### PR TITLE
feat(predicates): v1.1 content-domain vocabulary (BRUP-01..06)

### DIFF
--- a/src/ai/extractor.service.ts
+++ b/src/ai/extractor.service.ts
@@ -25,6 +25,7 @@ export interface ExtractionResult {
 }
 
 const PREDICATE_VOCABULARY = [
+  // CRM predicates (unchanged)
   'said',
   'name',
   'email',
@@ -37,6 +38,17 @@ const PREDICATE_VOCABULARY = [
   'interacted_with',
   'address',
   'dob',
+  // Content-domain predicates (v1.1)
+  'brand_voice',
+  'brand_archetype',
+  'tone_of_voice',
+  'product_description',
+  'target_audience_segment',
+  'content_guideline',
+  'tension_point',
+  'reference_example',
+  'narrative_pillar',
+  'forbidden_pattern',
 ] as const;
 
 const ENTITY_TYPE_VOCABULARY = [
@@ -77,7 +89,57 @@ Rules:
 - confidence is 0..1; reserve >0.8 for facts the text states explicitly,
   0.5–0.8 for inferred or implicit facts.
 - Skip entities you cannot characterize beyond a pronoun.
-- Set \`canonical\` to null unless the text explicitly states a canonical/legal form different from \`name\`.`;
+- Set \`canonical\` to null unless the text explicitly states a canonical/legal form different from \`name\`.
+
+Content-domain predicates (for marketing / brand / editorial mentions):
+   brand_voice          — how the brand SOUNDS (single description, ≤500 chars).
+                          SINGLETON: newer supersedes older. Extract the full
+                          style description as one fact, not word-by-word.
+   brand_archetype      — Jungian archetype. SINGLETON. One of: Hero, Sage,
+                          Outlaw, Explorer, Magician, Lover, Jester, Caregiver,
+                          Creator, Ruler, Innocent, Everyman.
+   tone_of_voice        — style attributes (e.g. "confident, conversational,
+                          no jargon"). SINGLETON.
+   product_description  — short product summary (≤1000 chars). SINGLETON.
+   target_audience_segment — one segment description. MULTI-VALUED: each
+                          distinct segment becomes its own fact. Example:
+                          "indie SaaS founders in EU/NA" → one fact;
+                          "content creators on LinkedIn" → a second fact.
+   content_guideline    — one editorial rule. MULTI-VALUED. Example:
+                          "Always lead with a customer result" → one fact.
+   tension_point        — one customer pain or contradiction the content
+                          addresses. MULTI-VALUED.
+   reference_example    — one URL or short quote of an exemplar piece.
+                          MULTI-VALUED.
+   narrative_pillar     — one theme the brand returns to. MULTI-VALUED.
+   forbidden_pattern    — one anti-pattern (e.g. "Never use the word
+                          'revolutionary'"). MULTI-VALUED.
+
+SINGLETON vs MULTI-VALUED rule: for singleton predicates (brand_voice,
+brand_archetype, tone_of_voice, product_description) emit EXACTLY ONE fact
+per entity even if the text mentions multiple drafts — pick the most recent
+or most specific. For multi-valued predicates, emit ONE fact per distinct
+item; do not concatenate multiple items into one object string. Always prefer
+a content-domain predicate when the brand itself is the subject — do NOT
+fall back to \`said\` or \`intent\` when a content-domain predicate fits better.
+
+Few-shot examples:
+  Input: "Our brand voice is confident, witty, and never apologetic.
+          We target indie SaaS founders in EU/NA and content creators
+          who build on LinkedIn. Never say 'revolutionary'."
+  Output facts (for entity: the brand):
+    { predicate: "brand_voice", object: "confident, witty, never apologetic", confidence: 0.92 }
+    { predicate: "target_audience_segment", object: "indie SaaS founders in EU/NA", confidence: 0.88 }
+    { predicate: "target_audience_segment", object: "content creators who build on LinkedIn", confidence: 0.88 }
+    { predicate: "forbidden_pattern", object: "Never say 'revolutionary'", confidence: 0.90 }
+
+  Input: "Acme's Outlaw archetype shows up in every headline. Their tone
+          is irreverent and warmly human, never corporate. Editorial rule:
+          always lead with a customer quote."
+  Output facts:
+    { predicate: "brand_archetype", object: "Outlaw", confidence: 0.90 }
+    { predicate: "tone_of_voice", object: "irreverent and warmly human, never corporate", confidence: 0.88 }
+    { predicate: "content_guideline", object: "always lead with a customer quote", confidence: 0.87 }`;
 
 @Injectable()
 export class ExtractorService {

--- a/src/ai/predicate-router.service.ts
+++ b/src/ai/predicate-router.service.ts
@@ -39,6 +39,7 @@ export interface RouterClassification {
 }
 
 const DEFAULT_VOCABULARY = [
+  // CRM (unchanged)
   'name',
   'email',
   'phone',
@@ -51,6 +52,17 @@ const DEFAULT_VOCABULARY = [
   'address',
   'dob',
   'said',
+  // Content-domain (v1.1)
+  'brand_voice',
+  'brand_archetype',
+  'tone_of_voice',
+  'product_description',
+  'target_audience_segment',
+  'content_guideline',
+  'tension_point',
+  'reference_example',
+  'narrative_pillar',
+  'forbidden_pattern',
 ] as const;
 
 const TYPE_VOCABULARY = [
@@ -150,6 +162,16 @@ Predicates in our knowledge graph:
 - complained_about: complaint / problem report / dissatisfaction
 - interacted_with: a transaction, attendance, viewing, booking, contact
 - said: a generic utterance (use as residual when nothing more specific fits)
+- brand_voice: the brand's overall sound / personality description
+- brand_archetype: Jungian archetype (Hero, Sage, Outlaw, Explorer, Magician, Lover, Jester, Caregiver, Creator, Ruler, Innocent, Everyman)
+- tone_of_voice: writing-style attributes (e.g. "conversational, punchy, no jargon")
+- product_description: short product or service summary
+- target_audience_segment: a specific audience group the brand targets
+- content_guideline: one editorial rule or content standard
+- tension_point: customer pain or contradiction the content addresses
+- reference_example: an example URL or quote of an exemplar content piece
+- narrative_pillar: a recurring brand theme or strategic narrative
+- forbidden_pattern: a writing anti-pattern or phrase the brand avoids
 
 Entity types in our knowledge graph:
 - customer: a customer / tenant / lead / patient / attendee

--- a/src/db/migrations/0010_content_predicates.surql
+++ b/src/db/migrations/0010_content_predicates.surql
@@ -1,0 +1,44 @@
+-- 0010_content_predicates — content-domain predicate vocabulary extension.
+--
+-- This migration has NO procedural SurrealQL to apply. Its purpose is:
+--   1. Record in schema_migrations that the content vocabulary was declared
+--      (migrationId = '0010') so per-tenant bootstrap knows this vocabulary
+--      was active when the tenant's schema was last advanced.
+--   2. Serve as the authoritative comment block listing the 10 predicates,
+--      their cardinality, decay values, and char-limits for ops / DBA
+--      inspection without reading TypeScript source.
+--
+-- All policy data lives in src/ingest/conflict-resolver.ts (JS source of
+-- truth). SurrealDB's fn::resolve_fact (0009) accepts $semantics as a
+-- parameter from the JS caller and already handles both single_active
+-- (brand_voice, brand_archetype, tone_of_voice, product_description) and
+-- append_only (target_audience_segment, content_guideline, tension_point,
+-- reference_example, narrative_pillar, forbidden_pattern) without changes.
+--
+-- New predicates (piiClass=none for all — no PII gate change needed):
+--
+--   Singletons (single_active — newer validFrom supersedes older):
+--     brand_voice            single_active  decayHalfLifeDays=180   ≤500 chars
+--     brand_archetype        single_active  decayHalfLifeDays=null  enum of 12 Jungian archetypes
+--     tone_of_voice          single_active  decayHalfLifeDays=180   ≤500 chars
+--     product_description    single_active  decayHalfLifeDays=180   ≤1000 chars
+--
+--   Multi-valued (append_only — every fact accumulates; no supersede):
+--     target_audience_segment  append_only  decayHalfLifeDays=90    ≤300 chars; dedupe by object hash
+--     content_guideline        append_only  decayHalfLifeDays=365   ≤500 chars
+--     tension_point            append_only  decayHalfLifeDays=90    ≤500 chars
+--     reference_example        append_only  decayHalfLifeDays=null  URL or quote ≤1000 chars; dedupe by (entityId, object) hash
+--     narrative_pillar         append_only  decayHalfLifeDays=365   ≤300 chars
+--     forbidden_pattern        append_only  decayHalfLifeDays=null  ≤300 chars; dedupe by (entityId, object) hash
+--
+-- Why no DDL:
+--   knowledge_fact.predicate is TYPE string (schema.surql) with no CHECK
+--   constraint — free-text predicates are already supported. Adding DEFINE
+--   statements here would duplicate the JS source-of-truth and create drift
+--   risk (RESEARCH § 4 / 0009 design rationale). Additive only; no existing
+--   DDL modified.
+--
+-- Backward compatibility:
+--   Existing CRM predicates (said, name, email, phone, status, tier, intent,
+--   preference, complained_about, interacted_with, address, dob) are
+--   unchanged. This vocabulary extension is purely additive.

--- a/src/ingest/conflict-resolver.ts
+++ b/src/ingest/conflict-resolver.ts
@@ -29,6 +29,20 @@ export const PREDICATE_POLICIES: Record<string, PredicatePolicy> = {
   interacted_with:  { semantics: 'append_only',  decayHalfLifeDays: 30,   piiClass: 'behavioral' },
   address:          { semantics: 'bitemporal',   decayHalfLifeDays: 90,   piiClass: 'sensitive', requiresScope: 'brain:read_pii' },
   dob:              { semantics: 'single_active', decayHalfLifeDays: null, piiClass: 'sensitive', requiresScope: 'brain:read_pii' },
+
+  // Content-domain predicates (v1.1)
+  // Singletons: only one canonical value per entity at a time; newer validFrom supersedes older.
+  brand_voice:             { semantics: 'single_active', decayHalfLifeDays: 180,  piiClass: 'none' },
+  brand_archetype:         { semantics: 'single_active', decayHalfLifeDays: null, piiClass: 'none' },
+  tone_of_voice:           { semantics: 'single_active', decayHalfLifeDays: 180,  piiClass: 'none' },
+  product_description:     { semantics: 'single_active', decayHalfLifeDays: 180,  piiClass: 'none' },
+  // Multi-valued: each fact accumulates; no supersede occurs.
+  target_audience_segment: { semantics: 'append_only',   decayHalfLifeDays: 90,   piiClass: 'none' },
+  content_guideline:       { semantics: 'append_only',   decayHalfLifeDays: 365,  piiClass: 'none' },
+  tension_point:           { semantics: 'append_only',   decayHalfLifeDays: 90,   piiClass: 'none' },
+  reference_example:       { semantics: 'append_only',   decayHalfLifeDays: null, piiClass: 'none' },
+  narrative_pillar:        { semantics: 'append_only',   decayHalfLifeDays: 365,  piiClass: 'none' },
+  forbidden_pattern:       { semantics: 'append_only',   decayHalfLifeDays: null, piiClass: 'none' },
 };
 
 export const DEFAULT_POLICY: PredicatePolicy = {

--- a/test/eval/fixtures/content-brand-acme.json
+++ b/test/eval/fixtures/content-brand-acme.json
@@ -1,0 +1,176 @@
+{
+  "directoryName": "content",
+  "description": "Acme Beverages brand briefing — full content-predicate lifecycle: ingest singletons + multi-valued facts, supersede singleton (brand_voice v1 → v2), accumulate multi-valued, retract one tension_point, verify search surface. Exercises all 10 v1.1 predicates across 15 facts.",
+  "entities": [
+    {
+      "id": "acme_beverages",
+      "vertical": "content",
+      "facts": [
+        {
+          "predicate": "brand_voice",
+          "object": "Confident, witty, never apologetic. Direct tone that respects the reader's intelligence.",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.95,
+          "tag": "bv-v1"
+        },
+        {
+          "predicate": "brand_voice",
+          "object": "Bold, irreverent, and warmly human. Never corporate.",
+          "validFrom": "2026-02-01T00:00:00Z",
+          "confidence": 0.95,
+          "tag": "bv-v2"
+        },
+        {
+          "predicate": "brand_archetype",
+          "object": "Outlaw",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.9
+        },
+        {
+          "predicate": "tone_of_voice",
+          "object": "Conversational, punchy, no jargon, avoids passive voice",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.9
+        },
+        {
+          "predicate": "product_description",
+          "object": "Acme Beverages makes small-batch functional drinks targeting indie creators and SaaS founders. No artificial sweeteners.",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.9
+        },
+        {
+          "predicate": "target_audience_segment",
+          "object": "Indie SaaS founders aged 25-40 in EU and North America",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.85
+        },
+        {
+          "predicate": "target_audience_segment",
+          "object": "Content creators building audiences on LinkedIn and YouTube",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.85
+        },
+        {
+          "predicate": "content_guideline",
+          "object": "Always lead with a customer result or data point, not a feature.",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.9
+        },
+        {
+          "predicate": "content_guideline",
+          "object": "Use second-person address. Speak directly to the reader.",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.9
+        },
+        {
+          "predicate": "tension_point",
+          "object": "Founders want sustained focus without the jitteriness of high-caffeine drinks",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.85,
+          "tag": "tp-focus"
+        },
+        {
+          "predicate": "tension_point",
+          "object": "Creators distrust brands that talk about community but feel corporate",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.85
+        },
+        {
+          "predicate": "narrative_pillar",
+          "object": "Built by builders, for builders",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.9,
+          "source": { "vertical": "content", "eventId": "kb.acme.briefing.2026-01" }
+        },
+        {
+          "predicate": "forbidden_pattern",
+          "object": "Never use the word 'revolutionary' or 'game-changing'",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.95
+        },
+        {
+          "predicate": "forbidden_pattern",
+          "object": "Do not claim health benefits without citing a study",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.9
+        },
+        {
+          "predicate": "reference_example",
+          "object": "https://acmebev.com/story/founder-fuel",
+          "validFrom": "2026-01-01T00:00:00Z",
+          "confidence": 0.8
+        }
+      ],
+      "retract": [
+        { "tag": "tp-focus", "reason": "messaging pivot: tension_point superseded by new positioning doc" }
+      ]
+    }
+  ],
+  "forgetEntities": [],
+  "queries": [
+    {
+      "query": "acme target audience",
+      "expectedTopEntityRef": "content.acme_beverages",
+      "expectedFactPredicate": "target_audience_segment"
+    },
+    {
+      "query": "acme brand voice",
+      "expectedTopEntityRef": "content.acme_beverages",
+      "expectedFactPredicate": "brand_voice"
+    },
+    {
+      "query": "acme tension points customer pain",
+      "expectedTopEntityRef": "content.acme_beverages",
+      "expectedFactPredicate": "tension_point"
+    },
+    {
+      "query": "acme forbidden words content rules",
+      "expectedTopEntityRef": "content.acme_beverages",
+      "expectedFactPredicate": "forbidden_pattern"
+    }
+  ],
+  "memoryAssertions": [
+    {
+      "description": "updated brand_voice (v2) surfaces; original v1 is superseded",
+      "kind": "search_object_present",
+      "query": "acme brand voice",
+      "expectedRefPresent": "content.acme_beverages",
+      "objectSubstring": "Bold, irreverent"
+    },
+    {
+      "description": "original brand_voice v1 no longer surfaces (superseded)",
+      "kind": "search_object_absent",
+      "query": "acme brand voice",
+      "expectedRefAbsent": "content.acme_beverages",
+      "objectSubstring": "Confident, witty, never apologetic"
+    },
+    {
+      "description": "retracted tension_point (focus/jitteriness) is gone from default search",
+      "kind": "search_object_absent",
+      "query": "acme tension points customer pain",
+      "expectedRefAbsent": "content.acme_beverages",
+      "objectSubstring": "jitteriness"
+    },
+    {
+      "description": "non-retracted tension_point (corporate distrust) still present",
+      "kind": "search_object_present",
+      "query": "acme tension points customer pain",
+      "expectedRefPresent": "content.acme_beverages",
+      "objectSubstring": "corporate"
+    },
+    {
+      "description": "narrative_pillar accumulates (not superseded)",
+      "kind": "search_object_present",
+      "query": "acme narrative pillar brand theme",
+      "expectedRefPresent": "content.acme_beverages",
+      "objectSubstring": "Built by builders"
+    },
+    {
+      "description": "forbidden_pattern: revolutionary rule present",
+      "kind": "search_object_present",
+      "query": "acme forbidden words content rules",
+      "expectedRefPresent": "content.acme_beverages",
+      "objectSubstring": "revolutionary"
+    }
+  ]
+}

--- a/test/eval/scenarios/content.scenarios.ts
+++ b/test/eval/scenarios/content.scenarios.ts
@@ -1,0 +1,80 @@
+import type { Scenario, SetupMentionStep } from '../types';
+
+/**
+ * Content-domain extraction-recall scenario.
+ *
+ * Tests that ExtractorService correctly surfaces v1.1 content-domain
+ * predicates from a brand-briefing paragraph (BRUP-03: recall@1 ≥ 0.90).
+ *
+ * Why TypeScript not JSON: SetupMentionStep (with expectedPredicates) is a
+ * TypeScript-only construct. The JSON directory loader only supports
+ * fact | retract | forgetEntities — mention steps are unsupported in the
+ * JSON shape (see test/eval/loaders/json-directory.loader.ts and
+ * RESEARCH.md § Pitfall 3).
+ *
+ * Entity narrative is consistent with test/eval/fixtures/content-brand-acme.json
+ * (same acme_beverages entity in content vertical) so a reviewer can read
+ * both side-by-side.
+ */
+
+const ISO = (d: string) => new Date(d).toISOString();
+
+/**
+ * Brand-briefing text. Contains unambiguous signals for exactly 7 distinct
+ * content-domain predicates. Calibrated per 10-EXTRACTION-SCENARIO-SPEC.md.
+ * Do NOT add product_description, narrative_pillar, or reference_example
+ * signals — those 3 predicates are intentionally absent from expectedPredicates
+ * because the text carries no unambiguous signal for them.
+ */
+const BRAND_BRIEFING_TEXT = `Acme Beverages is a small-batch functional-drinks brand built by indie founders for indie founders. Our brand voice is bold, irreverent, and warmly human — never corporate. We embody the Outlaw archetype: we challenge industry conventions and refuse to take ourselves too seriously. Our tone is conversational, punchy, and free of jargon; we avoid passive voice and we don't hedge. Our audience breaks into two segments: indie SaaS founders aged 25-40 in EU and North America, and content creators building audiences on LinkedIn and YouTube. Every piece of content we publish must lead with a customer result or data point, not a feature. Our customers feel a deep tension: they want sustained focus without the jitteriness of high-caffeine drinks. We never use the word 'revolutionary' in any content piece, and we don't claim health benefits without citing a study.`;
+
+/**
+ * Content brand extraction scenario.
+ *
+ * One SetupMentionStep with a 7-predicate expectedPredicates array.
+ * The harness computes predicateRecall = (predicates_observed ∩ expected) /
+ * expected.length — must be ≥ 0.90 per BRUP-03. With 7 expected predicates,
+ * all 7 must be surfaced (0.857 < 0.90 threshold; only 1.0 passes).
+ */
+export const contentScenarios: Scenario[] = [
+  {
+    id: 'content-brand-extraction',
+    vertical: 'cross',
+    description:
+      'Content-domain brand briefing extraction. Validates that ExtractorService surfaces 7 distinct content-domain predicate types from a prose brand-briefing paragraph. BRUP-03: predicateRecall ≥ 0.90.',
+    setup: [
+      {
+        kind: 'mention',
+        text: BRAND_BRIEFING_TEXT,
+        contextRef: {
+          vertical: 'content',
+          conversationId: 'kb:acme:briefing',
+          messageId: 'acme:briefing:001',
+        },
+        knownEntities: [
+          { vertical: 'content', id: 'acme_beverages', role: 'subject' },
+        ],
+        emittedAt: ISO('2026-05-18'),
+        /**
+         * 7 distinct predicate types the extractor must surface.
+         * Note: target_audience_segment appears twice in the text (two segments)
+         * but predicateRecall measures distinct predicate types, not fact counts —
+         * two target_audience_segment extractions count as one toward recall.
+         *
+         * Intentionally absent: product_description, narrative_pillar,
+         * reference_example — text carries no unambiguous signal for them.
+         */
+        expectedPredicates: [
+          'brand_voice',
+          'brand_archetype',
+          'tone_of_voice',
+          'target_audience_segment',
+          'content_guideline',
+          'tension_point',
+          'forbidden_pattern',
+        ],
+      } satisfies SetupMentionStep,
+    ],
+    queries: [],
+  },
+];

--- a/test/eval/scenarios/index.ts
+++ b/test/eval/scenarios/index.ts
@@ -11,6 +11,7 @@ import { bitemporalScenarios } from './bitemporal.scenarios';
 import { conflictResolutionScenarios } from './conflict-resolution.scenarios';
 import { graphTraversalScenarios } from './graph-traversal.scenarios';
 import { memoryLifecycleScenarios } from './memory-lifecycle.scenarios';
+import { contentScenarios } from './content.scenarios';
 
 export const allScenarios: Scenario[] = [
   ...rentScenarios,
@@ -25,6 +26,7 @@ export const allScenarios: Scenario[] = [
   ...conflictResolutionScenarios,
   ...graphTraversalScenarios,
   ...memoryLifecycleScenarios,
+  ...contentScenarios,
 ];
 
 export {
@@ -40,4 +42,5 @@ export {
   conflictResolutionScenarios,
   graphTraversalScenarios,
   memoryLifecycleScenarios,
+  contentScenarios,
 };


### PR DESCRIPTION
## v1.1 Content-Domain Predicates

Extends Brain's predicate vocabulary with 10 content-domain predicates to support figma's Brain Migration (figma milestone v1.1, Phase 10 / BRUP-01..06).

### What changes

- **`PREDICATE_POLICIES`** (`src/ingest/conflict-resolver.ts`): adds 10 entries — 4 `single_active` (brand_voice, brand_archetype, tone_of_voice, product_description), 6 `append_only` (target_audience_segment, content_guideline, tension_point, reference_example, narrative_pillar, forbidden_pattern).
- **`PREDICATE_VOCABULARY`** + extractor system prompt + JSON-schema enum (`src/ai/extractor.service.ts`): 10 new predicates with one-line descriptions + few-shot example.
- **`DEFAULT_VOCABULARY`** (`src/ai/predicate-router.service.ts`): same 10 predicates for the router LLM call.
- **`src/db/migrations/0010_content_predicates.surql`**: comment-only ledger entry (runtime policy is in JS, not SurrealQL — by design).
- **`test/eval/fixtures/content-brand-acme.json`**: lifecycle eval — ingest → search → singleton supersede → multi-valued accumulate → retract.
- **`test/eval/scenarios/content.scenarios.ts`**: extraction-recall scenario (target `predicateRecall ≥ 0.90`).

### Cardinality & policy decisions

| Predicate | Cardinality | Policy |
|---|---|---|
| brand_voice | singleton | single_active |
| brand_archetype | singleton | single_active |
| tone_of_voice | singleton | single_active |
| product_description | singleton | single_active |
| target_audience_segment | multi | append_only |
| content_guideline | multi | append_only |
| tension_point | multi | append_only |
| reference_example | multi | append_only |
| narrative_pillar | multi | append_only |
| forbidden_pattern | multi | append_only |

### Compatibility

**Additive only.** Existing CRM predicates (name/email/phone/dob/status/tier/intent/preference/complained_about/interacted_with/address/said) untouched. No DDL changes (Option A — JS-level policy, per figma planning doc `.planning/phases/10-brain-upstream/10-CONTEXT.md`).

### CI noise notice

`build-test` on `main` has 28 pre-existing failing e2e tests (`/v1/facts/:id/retract` returning 404 vs expected 201). Not caused by this PR — see prior CI runs on `main` HEAD `11488427c`. Our 4 commits do NOT touch retract/forget endpoints. Filed separately for the maintainer.

### Local pre-PR eval

Skipped per operator override (`feat/v1.1-content-predicates` rebased on `main` directly, fresh from upstream). Post-deploy smoke will run from figma's network against `brain.inite.ai` to verify the new vocabulary is live in production.

### Figma-side coordination artefacts

For full migration context: `/Users/mikefluff/Documents/figma/.planning/phases/10-brain-upstream/` contains:
- `10-CONTEXT.md` — locked decisions
- `10-RESEARCH.md` — file-anchored extension points
- `10-PR-DESCRIPTION.md` — this PR body's source
- `10-EVAL-FIXTURE-SPEC.md`, `10-EXTRACTION-SCENARIO-SPEC.md` — fixture/scenario specs
- `10-DEPLOY-RUNBOOK.md`, `10-SMOKE-VERIFICATION.md` — deploy + smoke specs
- `10-POST-DEPLOY-LOG.md` — to be filled by figma after smoke

Closes figma BRUP-01..06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)