### PR TITLE
docs(content): use typographic quotes in English docs and blog prose

### DIFF
--- a/brain-landing/content/blog/en/bitemporal-knowledge-graph.mdx
+++ b/brain-landing/content/blog/en/bitemporal-knowledge-graph.mdx
@@ -21,14 +21,14 @@ faqs:
 
 ## Two clocks, not one
 
-Most systems store one timestamp per record: when it was written. That answers "when did this change," but it can't answer "when did this *become* true" separately from "when did we *find out*." Those are two different questions, and conflating them is how audit trails quietly lie.
+Most systems store one timestamp per record: when it was written. That answers “when did this change,” but it can't answer “when did this *become* true” separately from “when did we *find out*.” Those are two different questions, and conflating them is how audit trails quietly lie.
 
 A bitemporal knowledge graph keeps both:
 
 - **Valid time** — the interval during which a fact holds in the real world.
 - **Transaction time** — the interval during which the system believed it.
 
-Every fact is a small claim with both stamps. "Acme is on the growth plan" is true *in the world* from March 10, but Brain only *recorded* it on March 12.
+Every fact is a small claim with both stamps. “Acme is on the growth plan” is true *in the world* from March 10, but Brain only *recorded* it on March 12.
 
 ## The correction problem
 
@@ -39,13 +39,13 @@ Here is the scenario that breaks single-clock systems. A customer switched plans
 | starter | Jan 1 → Mar 10 | Jan 1 → (capped Mar 12) |
 | growth | Mar 10 → now | Mar 12 → now |
 
-Now ask: *"On March 11, what plan did we think Acme was on?"*
+Now ask: *“On March 11, what plan did we think Acme was on?”*
 
 The honest answer is **starter** — because the switch wasn't recorded until the 12th. A single-clock store can't produce that answer. Once you write the correction, it looks like you always knew. Bitemporal keeps transaction time independent, so replaying March 11 returns what you actually knew on March 11.
 
 ## Why agents care
 
-An AI agent makes decisions on the memory it has at that instant. When a decision looks wrong in hindsight, "what did the agent know" is the first question — and the only useful answer is the state of memory *then*, before any later correction.
+An AI agent makes decisions on the memory it has at that instant. When a decision looks wrong in hindsight, “what did the agent know” is the first question — and the only useful answer is the state of memory *then*, before any later correction.
 
 - **Audit** — prove what the agent could have known at decision time.
 - **Replay** — reconstruct a past run exactly, bugs included.

--- a/brain-landing/content/blog/en/gdpr-forget-rag.mdx
+++ b/brain-landing/content/blog/en/gdpr-forget-rag.mdx
@@ -21,14 +21,14 @@ faqs:
 
 ## A row delete is not an erasure
 
-In a plain database, "delete the user" is one statement. In a RAG system, a user's data is scattered across representations:
+In a plain database, “delete the user” is one statement. In a RAG system, a user's data is scattered across representations:
 
 - the **facts** about them,
 - the **embeddings** of those facts (and of any chunk that mentions them),
 - the **graph edges** connecting them to other entities,
 - **derived artifacts** — summaries, profiles, digests built earlier.
 
-Delete the source row and the user is still findable by vector similarity, still reachable by walking an edge, still named in a cached summary. The regulator's question is "is the data gone?" — and "the main row is gone" is not a yes.
+Delete the source row and the user is still findable by vector similarity, still reachable by walking an edge, still named in a cached summary. The regulator's question is “is the data gone?” — and “the main row is gone” is not a yes.
 
 ## What a real forget removes
 

--- a/brain-landing/content/blog/en/memory-beyond-vector-search.mdx
+++ b/brain-landing/content/blog/en/memory-beyond-vector-search.mdx
@@ -21,17 +21,17 @@ faqs:
 
 ## The one job vector search does well
 
-Embed a query, embed your documents, return the nearest neighbours. For "find me passages about X," this is hard to beat. The failure isn't the technique — it's scope creep. Teams reach for a vector store as the agent's *memory*, and then ask it questions it was never built to answer.
+Embed a query, embed your documents, return the nearest neighbours. For “find me passages about X,” this is hard to beat. The failure isn't the technique — it's scope creep. Teams reach for a vector store as the agent's *memory*, and then ask it questions it was never built to answer.
 
 ## Four questions embeddings can't answer
 
-**"What is true *now*?"** A vector store returns whatever is most similar, even if it's stale. There's no notion of a fact being superseded — only of text being nearby.
+**“What is true *now*?”** A vector store returns whatever is most similar, even if it's stale. There's no notion of a fact being superseded — only of text being nearby.
 
-**"What was true in March?"** No time axis. A chunk written last year and a chunk written today are ranked the same way. Memory without time is just a pile.
+**“What was true in March?”** No time axis. A chunk written last year and a chunk written today are ranked the same way. Memory without time is just a pile.
 
-**"Two sources disagree — which wins?"** Re-embedding overwrites. The newest vector silently replaces the old one. No scoring, no "these conflict," no record that there was ever a disagreement.
+**“Two sources disagree — which wins?”** Re-embedding overwrites. The newest vector silently replaces the old one. No scoring, no “these conflict,” no record that there was ever a disagreement.
 
-**"Delete this user."** You can drop a row, but embeddings of their data may live in other chunks, and there's no cascade through relationships. "I think it's gone" is not a GDPR answer.
+**“Delete this user.”** You can drop a row, but embeddings of their data may live in other chunks, and there's no cascade through relationships. “I think it's gone” is not a GDPR answer.
 
 ## The fix is structure, not a bigger model
 

--- a/brain-landing/content/docs/en/api/entities.mdx
+++ b/brain-landing/content/docs/en/api/entities.mdx
@@ -84,7 +84,7 @@ Hard cascade. Synchronous. Deletes:
 - Every embedding row (vector + HyPE alt-embedding)
 - Every artifact (profile, digest)
 
-Leaves only an HMAC-hash tombstone in `forgotten_entity`. The tombstone proves "we honored the request" without keeping the entity id in plaintext.
+Leaves only an HMAC-hash tombstone in `forgotten_entity`. The tombstone proves “we honored the request” without keeping the entity id in plaintext.
 
 **Requires `brain:write` AND a separately-granted forget permission.** Audited per-call.
 

--- a/brain-landing/content/docs/en/api/multi-hop.mdx
+++ b/brain-landing/content/docs/en/api/multi-hop.mdx
@@ -4,8 +4,8 @@ A planner LLM decomposes a free-text query into ≤ `maxHops` sub-queries with e
 
 ## When to reach for multi-hop
 
-- "Tenants who complained in April **and** upgraded to platinum after."
-- "Companies founded by ex-Stripe engineers **and** headquartered in EU."
+- “Tenants who complained in April **and** upgraded to platinum after.”
+- “Companies founded by ex-Stripe engineers **and** headquartered in EU.”
 - Any question containing **and**, **then**, **who also**, **from those that**.
 
 If the question is single-shot, the planner reports `isMultiHop: false` and the executor falls back to `/v1/search`. Same shape, no extra cost.
@@ -52,7 +52,7 @@ If the question is single-shot, the planner reports `isMultiHop: false` and the 
 | `intersect` | Hop runs unconstrained, intersect after. Higher recall when prior set is small. |
 | `union` | Hop runs unconstrained, union after. Rare; included for completeness. |
 
-The planner picks the mode per hop based on phrasing — "from those that" → `subset_of_previous`, "who also" → `intersect`.
+The planner picks the mode per hop based on phrasing — “from those that” → `subset_of_previous`, “who also” → `intersect`.
 
 ## Joint-F1 scoring
 

--- a/brain-landing/content/docs/en/api/retract.mdx
+++ b/brain-landing/content/docs/en/api/retract.mdx
@@ -28,7 +28,7 @@ Content-Type: application/json
 }
 ```
 
-## What "retract" actually does
+## What “retract” actually does
 
 - Sets `retractedAt = now()` on the row.
 - Sets `status = 'retracted'`.
@@ -36,13 +36,13 @@ Content-Type: application/json
 - Walks `derivedFrom[]` chains and cascades unless `cascade: false`.
 - Removes the fact from active search results (`asOf <= retractedAt` queries still see it).
 
-The original row is NOT deleted. That's the audit invariant — "brain used to believe X" stays answerable forever.
+The original row is NOT deleted. That's the audit invariant — “brain used to believe X” stays answerable forever.
 
 ## When to retract vs forget
 
 | Action | Use when |
 | --- | --- |
-| **Retract** | The fact was wrong. You want the audit trail to show "we believed this, then we didn't". The entity remains. |
+| **Retract** | The fact was wrong. You want the audit trail to show “we believed this, then we didn't”. The entity remains. |
 | **Forget** | GDPR / right-to-erasure on the *entity*. Everything about the person is hard-deleted, only an HMAC tombstone remains. |
 
 If unsure, retract. Forget is one-way and reserved for genuine erasure requests.
@@ -60,7 +60,7 @@ The `cascade: true` (default) walks the dependency chain. For a single ingest th
 
 ## Reading retracted in timeline
 
-`GET /v1/entities/:id/timeline` returns retracted rows. Filter to them when investigating "what walked back":
+`GET /v1/entities/:id/timeline` returns retracted rows. Filter to them when investigating “what walked back”:
 
 ```ts
 const tl = await brain.entityTimeline(entityId)

--- a/brain-landing/content/docs/en/api/search.mdx
+++ b/brain-landing/content/docs/en/api/search.mdx
@@ -113,7 +113,7 @@ No JS post-filter, no double round-trip.
 
 ## PII gating
 
-If the caller's API key lacks `brain:read_pii`, sensitive predicates (`email`, `phone`, `dob`, `address`) return with `object: null`. The predicate is still visible — that's the "we have this data, you don't have rights" signal. Tighter than 403 because you can still rank entities by the *presence* of identifying facts.
+If the caller's API key lacks `brain:read_pii`, sensitive predicates (`email`, `phone`, `dob`, `address`) return with `object: null`. The predicate is still visible — that's the “we have this data, you don't have rights” signal. Tighter than 403 because you can still rank entities by the *presence* of identifying facts.
 
 ## Per-leg CI
 

--- a/brain-landing/content/docs/en/api/synthesize.mdx
+++ b/brain-landing/content/docs/en/api/synthesize.mdx
@@ -43,7 +43,7 @@ Verifier outage → fail-closed in `strict`, fail-open in the others.
 
 ## Hallucinated citations
 
-The generator sometimes invents `factId` values. Before the response leaves the server, brain filters out any citation that isn't in the retrieved set. Verifier sees the filtered set, so a "made up an ID" hallucination becomes "claim has no citation" → `partial`/`unsupported` in faithfulness.
+The generator sometimes invents `factId` values. Before the response leaves the server, brain filters out any citation that isn't in the retrieved set. Verifier sees the filtered set, so a “made up an ID” hallucination becomes “claim has no citation” → `partial`/`unsupported` in faithfulness.
 
 ## Faithfulness scoring
 

--- a/brain-landing/content/docs/en/concepts/bitemporal.mdx
+++ b/brain-landing/content/docs/en/concepts/bitemporal.mdx
@@ -4,12 +4,12 @@ Brain stores every fact along two independent time axes. Together they answer tw
 
 | Axis | Field pair | Answers |
 | --- | --- | --- |
-| Valid time | `validFrom` / `validUntil` | "When was this true in the real world?" |
-| Transaction time | `recordedAt` / `retractedAt` | "When did brain know about it / when did brain learn it was wrong?" |
+| Valid time | `validFrom` / `validUntil` | “When was this true in the real world?” |
+| Transaction time | `recordedAt` / `retractedAt` | “When did brain know about it / when did brain learn it was wrong?” |
 
-Both are first-class. You can ask "what was Alice's tier on March 15" (valid time) AND "what did brain believe on April 1" (transaction time). The default search treats now as both axes.
+Both are first-class. You can ask “what was Alice's tier on March 15” (valid time) AND “what did brain believe on April 1” (transaction time). The default search treats now as both axes.
 
-## Default = "actual now"
+## Default = “actual now”
 
 Without `asOf`, every read returns only facts whose valid window contains *now* AND that brain currently believes:
 
@@ -52,15 +52,15 @@ B:   [───]              → contains         → resolve by score
 
 ## Reading retracted rows
 
-`get_entity_timeline` and `GET /v1/entities/:id/timeline` return retracted facts too — `status: 'retracted'` with a `retractedAt` and `retractionReason`. By default search hides them; ask explicitly for "what changed" / "history" to expose them.
+`get_entity_timeline` and `GET /v1/entities/:id/timeline` return retracted facts too — `status: 'retracted'` with a `retractedAt` and `retractionReason`. By default search hides them; ask explicitly for “what changed” / “history” to expose them.
 
-Never delete-claim a retracted fact. Brain keeps the audit trail so the user can see "we used to believe X, then learned otherwise."
+Never delete-claim a retracted fact. Brain keeps the audit trail so the user can see “we used to believe X, then learned otherwise.”
 
 ## Pitfalls
 
-- **Sticky `asOf`** — drop it on follow-up turns unless the user says "still as of X".
+- **Sticky `asOf`** — drop it on follow-up turns unless the user says “still as of X”.
 - **Treating `validUntil` as expiry** — a fact with `validUntil = 2026-04-01` was true *up to* that moment. Bitemporally correct, not stale.
-- **Confusing the axes** — "what was true in March" (valid time) ≠ "what brain knew in March" (transaction time). For transaction-time-only queries, pull the full timeline and filter client-side.
+- **Confusing the axes** — “what was true in March” (valid time) ≠ “what brain knew in March” (transaction time). For transaction-time-only queries, pull the full timeline and filter client-side.
 
 ## Related
 

--- a/brain-landing/content/docs/en/concepts/predicates.mdx
+++ b/brain-landing/content/docs/en/concepts/predicates.mdx
@@ -10,7 +10,7 @@ A predicate is the verb of a fact — `name`, `email`, `tier`, `complained_about
 | `bitemporal` | Values carry explicit windows; overlap routes through conflict resolver. | `status`, `intent`, `address`, `tier` |
 | `append_only` | Never conflicts; every ingest is additive. | `said`, `mentioned_in`, `tag` |
 
-`single_active` is the simplest read model: take the row with the highest `validFrom`. `bitemporal` is the most expressive — the same predicate can be true over multiple disjoint windows. `append_only` is for utterance / tagging predicates where there is no notion of "the" value.
+`single_active` is the simplest read model: take the row with the highest `validFrom`. `bitemporal` is the most expressive — the same predicate can be true over multiple disjoint windows. `append_only` is for utterance / tagging predicates where there is no notion of “the” value.
 
 ## Decay half-life
 

--- a/brain-landing/content/docs/en/getting-started.mdx
+++ b/brain-landing/content/docs/en/getting-started.mdx
@@ -1,6 +1,6 @@
 # Getting started
 
-Five minutes from "I have an API key" to "I can search what I just ingested."
+Five minutes from “I have an API key” to “I can search what I just ingested.”
 
 ## Prerequisite — an API key
 

--- a/brain-landing/content/docs/en/mcp/tools.mdx
+++ b/brain-landing/content/docs/en/mcp/tools.mdx
@@ -4,7 +4,7 @@ Six tools registered against `McpServer({ name: 'inite-brain-service' })`. Four 
 
 ## search_knowledge
 
-> Semantic search over the company knowledge graph. Returns entities with their top facts and external references back to the originating verticals. Apply `asOf` for historical "what did we know on X" queries.
+> Semantic search over the company knowledge graph. Returns entities with their top facts and external references back to the originating verticals. Apply `asOf` for historical “what did we know on X” queries.
 
 **Required scope:** `brain:read`
 
@@ -35,7 +35,7 @@ Pairs with the `brain-search` skill at `~/.claude/skills/brain-search/`.
 
 ## get_entity_timeline
 
-> Chronological audit of all facts brain has learned about this entity, including retracted ones. Useful for "what did we know when" investigations.
+> Chronological audit of all facts brain has learned about this entity, including retracted ones. Useful for “what did we know when” investigations.
 
 **Required scope:** `brain:read`
 

--- a/brain-landing/content/docs/en/security.mdx
+++ b/brain-landing/content/docs/en/security.mdx
@@ -46,7 +46,7 @@ DEFINE FIELD object ON TABLE knowledge_fact
      OR $caller_scopes CONTAINS 'brain:read_pii';
 ```
 
-A scope-less caller still sees the row exists — `predicate`, `validFrom`, `factId` all visible. The `object` is `null`. This is the "we have this data, you don't have rights" surface.
+A scope-less caller still sees the row exists — `predicate`, `validFrom`, `factId` all visible. The `object` is `null`. This is the “we have this data, you don't have rights” surface.
 
 CI runs a PII-gating eval with threshold 1.0 — any leak blocks the release.
 

--- a/brain-landing/content/docs/en/skills.mdx
+++ b/brain-landing/content/docs/en/skills.mdx
@@ -11,7 +11,7 @@ curl -fsSL https://brain.inite.ai/install.sh | sh
 Optional flags:
 
 - `--target project` — install into `$PWD/.claude/skills/` instead of `$HOME`
-- `--key <api-key>` — ping a probe so the dashboard marks "skills installed" complete
+- `--key <api-key>` — ping a probe so the dashboard marks “skills installed” complete
 
 The installer downloads `skills.tar.gz`, unpacks each skill into `~/.claude/skills/<name>/SKILL.md`, and drops a `VERSION.brain` file alongside so the staleness check has a single number to compare against.
 
@@ -21,7 +21,7 @@ The installer downloads `skills.tar.gz`, unpacks each skill into `~/.claude/skil
 | --- | --- | --- |
 | `brain-search` | The user asks to find / look up / search knowledge | How to call `search_knowledge` with predicate hints and asOf semantics |
 | `brain-recall` | The user names an entity and asks for the full picture | How to combine `get_entity_profile` + `get_entity_timeline` + `find_related_entities` |
-| `brain-bitemporal` | The user has a temporal question ("on X date", "before Y") | asOf semantics, validFrom / validUntil, retracted-row handling |
+| `brain-bitemporal` | The user has a temporal question (“on X date”, “before Y”) | asOf semantics, validFrom / validUntil, retracted-row handling |
 | `brain-mcp-setup` | The user is wiring brain MCP into a new client | Step-by-step config for Claude Desktop, Cursor, Goose, n8n |
 
 ## Format


### PR DESCRIPTION
Replaced straight quotes with typographic quotes in English blog and documentation prose.
Code blocks, inline code, JSON values and frontmatter were left unchanged.

