### PR TITLE
feat: topic communities + watermark summarisation (ported from graphiti)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] — 2026-06-23
+## [Unreleased]
+
+### Added
+
+- **Topic communities** — the entity graph is now clustered into topic
+  communities (label propagation over `knowledge_edge`, borrowed from
+  graphiti). Each community carries a rolled-up summary + embedding and is
+  exposed as a coarse retrieval scope via the MCP tools `search_communities`,
+  `list_communities`, and `find_entity_communities`. Built off-hours by the
+  dreams loop (`communities` op, gated by `DREAMS_COMMUNITIES_ENABLED`).
+- **Watermark summarisation cache** — `summarize_entity` now invalidates its
+  cache by a dual wall-clock / event-time watermark (graphiti `summarize_saga`
+  pattern). A backfilled fact (newer `recordedAt`, past `validFrom`) correctly
+  busts the cache, and results carry `asOfValid` — the event-time the summary
+  reflects. Community summaries reuse the same watermark to skip rebuilding
+  unchanged clusters.
 
 First public open-source release.
 

--- a/src/communities/community-builder.service.ts
+++ b/src/communities/community-builder.service.ts
@@ -1,13 +1,7 @@
-import {
-  Inject,
-  Injectable,
-  Logger,
-  Optional,
-} from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Surreal, StringRecordId } from 'surrealdb';
 import { EmbedderService } from '../ai/embedder.service';
-import { MetricsService } from '../metrics/metrics.service';
 import { withSpan } from '../common/tracing';
 import {
   SUMMARY_GENERATOR,
@@ -51,7 +45,6 @@ export class CommunityBuilderService {
     private readonly embedder: EmbedderService,
     @Inject(SUMMARY_GENERATOR)
     private readonly summaryGenerator: SummaryGenerator,
-    @Optional() private readonly metrics?: MetricsService,
   ) {
     this.enabled =
       this.config.get<string>('DREAMS_COMMUNITIES_ENABLED', '0') === '1';
@@ -218,6 +211,23 @@ export class CommunityBuilderService {
       ? await this.embedder.embed(summary)
       : null;
 
+    // lastBuiltMaxEdgeAt is option<datetime>: OMIT it (leave NONE) when the
+    // cluster has no dated internal edge, rather than passing NULL — a JS
+    // null does not satisfy option<datetime> on a SCHEMAFULL field. The
+    // field is last in CONTENT so the conditional comma stays simple. A JS
+    // Date serialises as a native datetime (a `d$param` cast won't parse
+    // inside a CONTENT value).
+    const params: Record<string, unknown> = {
+      label,
+      summary,
+      embedding: summaryEmbedding,
+      count: members.length,
+    };
+    let edgeClause = '';
+    if (maxEdgeAt) {
+      edgeClause = ',\n         lastBuiltMaxEdgeAt: $maxEdgeAt';
+      params.maxEdgeAt = new Date(maxEdgeAt);
+    }
     const [created] = await db.query<[Array<{ id: unknown }>]>(
       `CREATE community_node CONTENT {
          label: $label,
@@ -226,18 +236,9 @@ export class CommunityBuilderService {
          memberCount: $count,
          algorithm: 'label_propagation',
          builtAt: time::now(),
-         lastBuiltAt: time::now(),
-         lastBuiltMaxEdgeAt: $maxEdgeAt
+         lastBuiltAt: time::now()${edgeClause}
        }`,
-      {
-        label,
-        summary,
-        embedding: summaryEmbedding,
-        count: members.length,
-        // Pass a JS Date so the driver serialises it as a native datetime
-        // (a `d$param` cast does not parse inside a CONTENT value).
-        maxEdgeAt: maxEdgeAt ? new Date(maxEdgeAt) : null,
-      },
+      params,
     );
     const cid = String(((created as Array<{ id: unknown }>) ?? [])[0]?.id ?? '');
     if (!cid) throw new Error('community_node CREATE returned no id');

--- a/src/communities/community-builder.service.ts
+++ b/src/communities/community-builder.service.ts
@@ -1,0 +1,357 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  Optional,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Surreal, StringRecordId } from 'surrealdb';
+import { EmbedderService } from '../ai/embedder.service';
+import { MetricsService } from '../metrics/metrics.service';
+import { withSpan } from '../common/tracing';
+import {
+  SUMMARY_GENERATOR,
+} from '../compaction/compaction.service';
+import type {
+  FactToSummarize,
+  SummaryGenerator,
+} from '../compaction/summary-generator';
+import {
+  buildAdjacency,
+  labelPropagation,
+} from './label-propagation';
+
+/**
+ * CommunityBuilderService — clusters the tenant's entity graph into
+ * topic communities (label propagation over `knowledge_edge`),
+ * summarises each, and persists `community_node` + `community_member`.
+ *
+ * Borrowed from graphiti's community layer. The off-hours dreams loop
+ * runs `run(db)` per tenant (gated by DREAMS_COMMUNITIES_ENABLED).
+ *
+ * WATERMARK (graphiti `summarize_saga`): each community records
+ * `lastBuiltMaxEdgeAt` — the newest `knowledge_edge.createdAt` that fed
+ * the cluster. On the next build, a community whose member set is
+ * unchanged AND whose freshest internal edge is no newer than the stored
+ * watermark is REUSED verbatim — no re-summarisation, no embedding spend.
+ * Only genuinely changed clusters re-pay the cost.
+ *
+ * Stateless: the caller (DreamsService) owns connection + tenant scoping.
+ */
+@Injectable()
+export class CommunityBuilderService {
+  private readonly logger = new Logger(CommunityBuilderService.name);
+  private readonly enabled: boolean;
+  private readonly minSize: number;
+  private readonly maxIterations: number;
+  private readonly summaryMaxMembers: number;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly embedder: EmbedderService,
+    @Inject(SUMMARY_GENERATOR)
+    private readonly summaryGenerator: SummaryGenerator,
+    @Optional() private readonly metrics?: MetricsService,
+  ) {
+    this.enabled =
+      this.config.get<string>('DREAMS_COMMUNITIES_ENABLED', '0') === '1';
+    this.minSize = parseInt(
+      this.config.get<string>('COMMUNITIES_MIN_SIZE', '3'),
+      10,
+    );
+    this.maxIterations = parseInt(
+      this.config.get<string>('COMMUNITIES_MAX_ITERATIONS', '10'),
+      10,
+    );
+    this.summaryMaxMembers = parseInt(
+      this.config.get<string>('COMMUNITIES_SUMMARY_MAX_MEMBERS', '10'),
+      10,
+    );
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /**
+   * Build (or incrementally refresh) communities for ONE tenant over the
+   * passed `db` handle. Idempotent: a second run with no graph change
+   * reuses every community via the watermark and creates/deletes nothing.
+   */
+  async run(db: Surreal): Promise<CommunityBuildResult> {
+    const result: CommunityBuildResult = {
+      communitiesBuilt: 0,
+      communitiesReused: 0,
+      communitiesRemoved: 0,
+      entitiesClustered: 0,
+    };
+    if (!this.enabled) return result;
+
+    const edges = await this.loadEdges(db);
+    if (edges.length === 0) {
+      // No edges → no communities. Still drop any stale ones left over
+      // from a prior denser graph so the scope doesn't serve ghosts.
+      result.communitiesRemoved = await this.removeAllCommunities(db);
+      return result;
+    }
+
+    const adjacency = buildAdjacency(
+      edges.map((e) => ({ from: e.from, to: e.to, weight: e.weight })),
+    );
+    const clusters = labelPropagation(adjacency, this.maxIterations).filter(
+      (c) => c.length >= this.minSize,
+    );
+
+    // Per-cluster newest internal edge (event-time watermark). An edge is
+    // "internal" when both endpoints sit in the same cluster.
+    const clusterOf = new Map<string, number>();
+    clusters.forEach((members, i) => members.forEach((m) => clusterOf.set(m, i)));
+    const maxEdgeAt: Array<string | null> = clusters.map(() => null);
+    for (const e of edges) {
+      const ci = clusterOf.get(e.from);
+      if (ci === undefined || clusterOf.get(e.to) !== ci) continue;
+      if (e.createdAt && (maxEdgeAt[ci] === null || e.createdAt > maxEdgeAt[ci]!)) {
+        maxEdgeAt[ci] = e.createdAt;
+      }
+    }
+
+    const existing = await this.loadExistingCommunities(db);
+    const matchedExistingIds = new Set<string>();
+
+    for (let i = 0; i < clusters.length; i++) {
+      const members = clusters[i];
+      result.entitiesClustered += members.length;
+      const signature = members.join('|');
+      const prior = existing.get(signature);
+
+      // WATERMARK skip: identical member set and no newer internal edge.
+      if (
+        prior &&
+        prior.lastBuiltMaxEdgeAt &&
+        maxEdgeAt[i] &&
+        prior.lastBuiltMaxEdgeAt >= maxEdgeAt[i]!
+      ) {
+        matchedExistingIds.add(prior.id);
+        result.communitiesReused++;
+        continue;
+      }
+
+      // (Re)build this cluster. If a community with the identical member
+      // set existed (but is now stale), delete it first so we don't leave
+      // a duplicate.
+      if (prior) {
+        await this.deleteCommunity(db, prior.id);
+        matchedExistingIds.add(prior.id);
+      }
+      await withSpan(
+        'communities.build_one',
+        () => this.buildCommunity(db, members, maxEdgeAt[i]),
+        { 'community.size': members.length },
+      );
+      result.communitiesBuilt++;
+    }
+
+    // Remove communities whose member set no longer corresponds to any
+    // current cluster (the graph drifted).
+    for (const [, prior] of existing) {
+      if (matchedExistingIds.has(prior.id)) continue;
+      await this.deleteCommunity(db, prior.id);
+      result.communitiesRemoved++;
+    }
+
+    this.logger.log(
+      `[communities] built=${result.communitiesBuilt} reused=${result.communitiesReused} ` +
+        `removed=${result.communitiesRemoved} entitiesClustered=${result.entitiesClustered}`,
+    );
+    return result;
+  }
+
+  /** Load every live entity-entity edge. Mirrors ppr.ts edge-load. */
+  private async loadEdges(db: Surreal): Promise<EdgeRow[]> {
+    type Raw = { in: unknown; out: unknown; weight?: number; createdAt?: unknown };
+    const [rows] = await db.query<[Raw[]]>(
+      `SELECT in, out, weight, createdAt FROM knowledge_edge
+         WHERE invalidatedAt IS NONE`,
+    );
+    return ((rows as Raw[]) ?? []).map((r) => ({
+      from: String(r.in),
+      to: String(r.out),
+      weight: typeof r.weight === 'number' ? r.weight : 1.0,
+      createdAt: toIso(r.createdAt),
+    }));
+  }
+
+  private async loadExistingCommunities(
+    db: Surreal,
+  ): Promise<Map<string, ExistingCommunity>> {
+    type Raw = { id: unknown; lastBuiltMaxEdgeAt?: unknown };
+    const [rows] = await db.query<[Raw[]]>(
+      `SELECT id, lastBuiltMaxEdgeAt FROM community_node`,
+    );
+    const out = new Map<string, ExistingCommunity>();
+    for (const r of (rows as Raw[]) ?? []) {
+      const cid = String(r.id);
+      const [memberRows] = await db.query<[Array<{ out: unknown }>]>(
+        `SELECT out FROM community_member WHERE in = $cid`,
+        { cid: new StringRecordId(cid) },
+      );
+      const members = ((memberRows as Array<{ out: unknown }>) ?? [])
+        .map((m) => String(m.out))
+        .sort();
+      out.set(members.join('|'), {
+        id: cid,
+        lastBuiltMaxEdgeAt: toIso(r.lastBuiltMaxEdgeAt) || null,
+      });
+    }
+    return out;
+  }
+
+  /** Summarise + embed + persist one community and its member edges. */
+  private async buildCommunity(
+    db: Surreal,
+    members: string[],
+    maxEdgeAt: string | null,
+  ): Promise<void> {
+    const { label, summaryInput } = await this.gatherMemberContext(db, members);
+    const summary = await this.summaryGenerator.generate(summaryInput);
+    const summaryEmbedding = summary
+      ? await this.embedder.embed(summary)
+      : null;
+
+    const [created] = await db.query<[Array<{ id: unknown }>]>(
+      `CREATE community_node CONTENT {
+         label: $label,
+         summary: $summary,
+         summaryEmbedding: $embedding,
+         memberCount: $count,
+         algorithm: 'label_propagation',
+         builtAt: time::now(),
+         lastBuiltAt: time::now(),
+         lastBuiltMaxEdgeAt: $maxEdgeAt
+       }`,
+      {
+        label,
+        summary,
+        embedding: summaryEmbedding,
+        count: members.length,
+        // Pass a JS Date so the driver serialises it as a native datetime
+        // (a `d$param` cast does not parse inside a CONTENT value).
+        maxEdgeAt: maxEdgeAt ? new Date(maxEdgeAt) : null,
+      },
+    );
+    const cid = String(((created as Array<{ id: unknown }>) ?? [])[0]?.id ?? '');
+    if (!cid) throw new Error('community_node CREATE returned no id');
+
+    for (const eid of members) {
+      await db.query(
+        `RELATE $cid->community_member->$eid SET addedAt = time::now()`,
+        { cid: new StringRecordId(cid), eid: new StringRecordId(eid) },
+      );
+    }
+  }
+
+  /**
+   * Build the summary input for a community: the highest-degree member's
+   * canonical name becomes the label; a bounded sample of members'
+   * top-confidence facts feeds the SummaryGenerator. Reusing the
+   * (entity-shaped) FactToSummarize contract keeps us on the existing
+   * SUMMARY_GENERATOR — concat by default, LLM behind the flag.
+   */
+  private async gatherMemberContext(
+    db: Surreal,
+    members: string[],
+  ): Promise<{ label: string; summaryInput: FactToSummarize[] }> {
+    const sample = members.slice(0, this.summaryMaxMembers);
+    const ridSample = sample.map((m) => new StringRecordId(m));
+
+    // Member display names — label off the first, summary lists the rest.
+    const [nameRows] = await db.query<[Array<{ id: unknown; canonicalName: string }>]>(
+      `SELECT id, canonicalName FROM knowledge_entity WHERE id INSIDE $ids`,
+      { ids: ridSample },
+    );
+    const names = (nameRows as Array<{ id: unknown; canonicalName: string }>) ?? [];
+    const label =
+      names[0]?.canonicalName ?? `community of ${members.length} entities`;
+
+    const [factRows] = await db.query<[Array<RawFact>]>(
+      `SELECT entityId, predicate, object, confidence, validFrom, validUntil
+         FROM knowledge_fact
+         WHERE entityId INSIDE $ids
+           AND status = 'active'
+           AND retractedAt IS NONE
+         ORDER BY confidence DESC
+         LIMIT 40`,
+      { ids: ridSample },
+    );
+    const summaryInput: FactToSummarize[] = (
+      (factRows as RawFact[]) ?? []
+    ).map((f) => ({
+      factId: String(f.entityId),
+      predicate: f.predicate,
+      object: f.object,
+      validFrom: toIso(f.validFrom),
+      validUntil: f.validUntil ? toIso(f.validUntil) : undefined,
+      confidence: typeof f.confidence === 'number' ? f.confidence : 0.5,
+    }));
+    return { label, summaryInput };
+  }
+
+  private async deleteCommunity(db: Surreal, cid: string): Promise<void> {
+    const rid = new StringRecordId(cid);
+    await db.query(`DELETE community_member WHERE in = $cid`, { cid: rid });
+    await db.query(`DELETE $cid`, { cid: rid });
+  }
+
+  private async removeAllCommunities(db: Surreal): Promise<number> {
+    const [rows] = await db.query<[Array<{ id: unknown }>]>(
+      `SELECT id FROM community_node`,
+    );
+    const ids = ((rows as Array<{ id: unknown }>) ?? []).map((r) => String(r.id));
+    for (const cid of ids) await this.deleteCommunity(db, cid);
+    return ids.length;
+  }
+}
+
+export interface CommunityBuildResult {
+  communitiesBuilt: number;
+  communitiesReused: number;
+  communitiesRemoved: number;
+  entitiesClustered: number;
+}
+
+interface EdgeRow {
+  from: string;
+  to: string;
+  weight: number;
+  createdAt: string;
+}
+
+interface ExistingCommunity {
+  id: string;
+  lastBuiltMaxEdgeAt: string | null;
+}
+
+interface RawFact {
+  entityId: unknown;
+  predicate: string;
+  object: string;
+  confidence: number;
+  validFrom: unknown;
+  validUntil?: unknown;
+}
+
+/**
+ * Normalise SurrealDB datetime / record values to a comparable ISO
+ * string. ISO-8601 sorts lexicographically, so we compare watermarks as
+ * plain strings. Empty string for nullish input.
+ */
+function toIso(v: unknown): string {
+  if (v == null) return '';
+  if (v instanceof Date) return v.toISOString();
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number') return new Date(v).toISOString();
+  if (typeof (v as { toDate?: () => Date }).toDate === 'function') {
+    return (v as { toDate: () => Date }).toDate().toISOString();
+  }
+  return String(v);
+}

--- a/src/communities/community-builder.service.ts
+++ b/src/communities/community-builder.service.ts
@@ -181,16 +181,26 @@ export class CommunityBuilderService {
     const [rows] = await db.query<[Raw[]]>(
       `SELECT id, lastBuiltMaxEdgeAt FROM community_node`,
     );
+    const comms = (rows as Raw[]) ?? [];
     const out = new Map<string, ExistingCommunity>();
-    for (const r of (rows as Raw[]) ?? []) {
+    if (comms.length === 0) return out;
+
+    // One batched member fetch instead of one query per community (N+1).
+    const cids = comms.map((r) => new StringRecordId(String(r.id)));
+    const [memberRows] = await db.query<[Array<{ in: unknown; out: unknown }>]>(
+      `SELECT in, out FROM community_member WHERE in INSIDE $cids`,
+      { cids },
+    );
+    const membersByComm = new Map<string, string[]>();
+    for (const m of (memberRows as Array<{ in: unknown; out: unknown }>) ?? []) {
+      const cid = String(m.in);
+      const arr = membersByComm.get(cid);
+      if (arr) arr.push(String(m.out));
+      else membersByComm.set(cid, [String(m.out)]);
+    }
+    for (const r of comms) {
       const cid = String(r.id);
-      const [memberRows] = await db.query<[Array<{ out: unknown }>]>(
-        `SELECT out FROM community_member WHERE in = $cid`,
-        { cid: new StringRecordId(cid) },
-      );
-      const members = ((memberRows as Array<{ out: unknown }>) ?? [])
-        .map((m) => String(m.out))
-        .sort();
+      const members = (membersByComm.get(cid) ?? []).sort();
       out.set(members.join('|'), {
         id: cid,
         lastBuiltMaxEdgeAt: toIso(r.lastBuiltMaxEdgeAt) || null,
@@ -243,11 +253,20 @@ export class CommunityBuilderService {
     const cid = String(((created as Array<{ id: unknown }>) ?? [])[0]?.id ?? '');
     if (!cid) throw new Error('community_node CREATE returned no id');
 
-    for (const eid of members) {
-      await db.query(
-        `RELATE $cid->community_member->$eid SET addedAt = time::now()`,
-        { cid: new StringRecordId(cid), eid: new StringRecordId(eid) },
-      );
+    // Batch all member edges into one round-trip: a multi-statement query
+    // with indexed params (avoids a per-member round-trip; a SurrealQL FOR
+    // loop has a known scoping gotcha we sidestep here).
+    if (members.length > 0) {
+      const relateParams: Record<string, unknown> = {
+        cid: new StringRecordId(cid),
+      };
+      const stmts = members
+        .map((eid, i) => {
+          relateParams[`e${i}`] = new StringRecordId(eid);
+          return `RELATE $cid->community_member->$e${i} SET addedAt = time::now();`;
+        })
+        .join('\n');
+      await db.query(stmts, relateParams);
     }
   }
 

--- a/src/communities/community.module.ts
+++ b/src/communities/community.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { CompactionModule } from '../compaction/compaction.module';
-import { MetricsModule } from '../metrics/metrics.module';
 import { CommunityBuilderService } from './community-builder.service';
 import { CommunityService } from './community.service';
 
@@ -15,7 +14,7 @@ import { CommunityService } from './community.service';
  * EmbedderService is auto-injected.
  */
 @Module({
-  imports: [ConfigModule, CompactionModule, MetricsModule],
+  imports: [ConfigModule, CompactionModule],
   providers: [CommunityBuilderService, CommunityService],
   exports: [CommunityBuilderService, CommunityService],
 })

--- a/src/communities/community.module.ts
+++ b/src/communities/community.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { CompactionModule } from '../compaction/compaction.module';
+import { MetricsModule } from '../metrics/metrics.module';
+import { CommunityBuilderService } from './community-builder.service';
+import { CommunityService } from './community.service';
+
+/**
+ * CommunityModule — topic clustering of the entity graph (graphiti-style
+ * communities). Built off-hours by DreamsModule, which imports this for
+ * CommunityBuilderService.
+ *
+ * CompactionModule is imported for the SUMMARY_GENERATOR token (shared
+ * with compaction's warm-tier rollups). AiModule is @Global, so
+ * EmbedderService is auto-injected.
+ */
+@Module({
+  imports: [ConfigModule, CompactionModule, MetricsModule],
+  providers: [CommunityBuilderService, CommunityService],
+  exports: [CommunityBuilderService, CommunityService],
+})
+export class CommunityModule {}

--- a/src/communities/community.service.ts
+++ b/src/communities/community.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
+import { cosineSimilarity } from '../common/vector-math';
 
 /**
  * CommunityService — read surface over the topic communities that
@@ -59,13 +60,12 @@ export class CommunityService {
       );
       const minSim = args.minSimilarity ?? 0.3;
       const limit = args.limit ?? 5;
-      const qNorm = norm(q);
 
       const scored: ScoredCommunity[] = [];
       for (const r of (rows as RawCommunity[]) ?? []) {
         const emb = Array.isArray(r.summaryEmbedding) ? r.summaryEmbedding : null;
         if (!emb) continue;
-        const sim = cosine(q, emb, qNorm);
+        const sim = cosineSimilarity(q, emb);
         if (sim < minSim) continue;
         scored.push({ ...mapCommunity(r), similarity: sim });
       }
@@ -130,25 +130,6 @@ function toIso(v: unknown): string {
     return (v as { toDate: () => Date }).toDate().toISOString();
   }
   return String(v);
-}
-
-function norm(v: number[]): number {
-  let s = 0;
-  for (const x of v) s += x * x;
-  return Math.sqrt(s);
-}
-
-function cosine(a: number[], b: number[], aNorm: number): number {
-  if (a.length !== b.length || aNorm === 0) return 0;
-  let dot = 0;
-  let bn = 0;
-  for (let i = 0; i < a.length; i++) {
-    dot += a[i] * b[i];
-    bn += b[i] * b[i];
-  }
-  bn = Math.sqrt(bn);
-  if (bn === 0) return 0;
-  return dot / (aNorm * bn);
 }
 
 interface RawCommunity {

--- a/src/communities/community.service.ts
+++ b/src/communities/community.service.ts
@@ -1,0 +1,174 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { StringRecordId } from 'surrealdb';
+import { SurrealService } from '../db/surreal.service';
+import { EmbedderService } from '../ai/embedder.service';
+
+/**
+ * CommunityService — read surface over the topic communities that
+ * CommunityBuilderService persists off-hours. This is the graphiti-style
+ * community retrieval SCOPE: coarse, summary-level answers to
+ * "what do we know about <domain>" without scanning the fact firehose.
+ *
+ * Kept separate from the builder so the MCP/read path doesn't drag in the
+ * SUMMARY_GENERATOR / build machinery. Cosine search mirrors
+ * ProceduralMemoryService.match — JS-side over a small N (communities are
+ * O(10²), not O(facts)); we revisit server-side vector::similarity only if
+ * a tenant's community count ever justifies an HNSW index.
+ */
+@Injectable()
+export class CommunityService {
+  private readonly logger = new Logger(CommunityService.name);
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly embedder: EmbedderService,
+  ) {}
+
+  /** Paginated listing for review UIs / agent enumeration. */
+  async list(
+    companyId: string,
+    args: { limit?: number } = {},
+  ): Promise<CommunityRecord[]> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<[RawCommunity[]]>(
+        `SELECT id, label, summary, memberCount, builtAt, lastBuiltMaxEdgeAt
+           FROM community_node
+           ORDER BY memberCount DESC, builtAt DESC
+           LIMIT $limit`,
+        { limit: args.limit ?? 50 },
+      );
+      return ((rows as RawCommunity[]) ?? []).map(mapCommunity);
+    });
+  }
+
+  /**
+   * Cosine-match communities by their summary embedding against a
+   * free-text query. The coarse retrieval scope: returns topic clusters
+   * relevant to the query, each with its LLM/concat summary.
+   */
+  async search(
+    companyId: string,
+    args: { query: string; limit?: number; minSimilarity?: number },
+  ): Promise<ScoredCommunity[]> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const q = await this.embedder.embed(args.query);
+      const [rows] = await db.query<[RawCommunity[]]>(
+        `SELECT id, label, summary, memberCount, builtAt, summaryEmbedding
+           FROM community_node
+           WHERE summaryEmbedding != NONE`,
+      );
+      const minSim = args.minSimilarity ?? 0.3;
+      const limit = args.limit ?? 5;
+      const qNorm = norm(q);
+
+      const scored: ScoredCommunity[] = [];
+      for (const r of (rows as RawCommunity[]) ?? []) {
+        const emb = Array.isArray(r.summaryEmbedding) ? r.summaryEmbedding : null;
+        if (!emb) continue;
+        const sim = cosine(q, emb, qNorm);
+        if (sim < minSim) continue;
+        scored.push({ ...mapCommunity(r), similarity: sim });
+      }
+      scored.sort((a, b) => b.similarity - a.similarity);
+      return scored.slice(0, limit);
+    });
+  }
+
+  /**
+   * Which communities an entity belongs to. Cheap entity→community lookup
+   * over the `member_out_idx`; also the type-hint feed for the listwise
+   * reranker ("this entity is part of the <label> cluster").
+   */
+  async forEntity(
+    companyId: string,
+    entityId: string,
+  ): Promise<CommunityRecord[]> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const eid = toRecordId(entityId);
+      const [rows] = await db.query<[Array<{ in: unknown }>]>(
+        `SELECT in FROM community_member WHERE out = $eid`,
+        { eid },
+      );
+      const cids = ((rows as Array<{ in: unknown }>) ?? []).map(
+        (r) => new StringRecordId(String(r.in)),
+      );
+      if (cids.length === 0) return [];
+      const [communities] = await db.query<[RawCommunity[]]>(
+        `SELECT id, label, summary, memberCount, builtAt
+           FROM community_node WHERE id INSIDE $cids
+           ORDER BY memberCount DESC`,
+        { cids },
+      );
+      return ((communities as RawCommunity[]) ?? []).map(mapCommunity);
+    });
+  }
+}
+
+function toRecordId(raw: string): StringRecordId {
+  return new StringRecordId(
+    raw.startsWith('knowledge_entity:')
+      ? raw
+      : `knowledge_entity:${raw}`,
+  );
+}
+
+function mapCommunity(r: RawCommunity): CommunityRecord {
+  return {
+    communityId: String(r.id),
+    label: String(r.label ?? ''),
+    summary: String(r.summary ?? ''),
+    memberCount: typeof r.memberCount === 'number' ? r.memberCount : 0,
+    builtAt: toIso(r.builtAt),
+  };
+}
+
+function toIso(v: unknown): string {
+  if (v == null) return '';
+  if (v instanceof Date) return v.toISOString();
+  if (typeof v === 'string') return v;
+  if (typeof (v as { toDate?: () => Date }).toDate === 'function') {
+    return (v as { toDate: () => Date }).toDate().toISOString();
+  }
+  return String(v);
+}
+
+function norm(v: number[]): number {
+  let s = 0;
+  for (const x of v) s += x * x;
+  return Math.sqrt(s);
+}
+
+function cosine(a: number[], b: number[], aNorm: number): number {
+  if (a.length !== b.length || aNorm === 0) return 0;
+  let dot = 0;
+  let bn = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    bn += b[i] * b[i];
+  }
+  bn = Math.sqrt(bn);
+  if (bn === 0) return 0;
+  return dot / (aNorm * bn);
+}
+
+interface RawCommunity {
+  id: unknown;
+  label?: string;
+  summary?: string;
+  memberCount?: number;
+  builtAt?: unknown;
+  lastBuiltMaxEdgeAt?: unknown;
+  summaryEmbedding?: number[];
+}
+
+export interface CommunityRecord {
+  communityId: string;
+  label: string;
+  summary: string;
+  memberCount: number;
+  builtAt: string;
+}
+
+export interface ScoredCommunity extends CommunityRecord {
+  similarity: number;
+}

--- a/src/communities/label-propagation.ts
+++ b/src/communities/label-propagation.ts
@@ -1,0 +1,118 @@
+/**
+ * Label Propagation Algorithm for community detection — a faithful,
+ * deterministic port of graphiti's
+ * `graphiti_core/utils/maintenance/community_operations.py:93-150`.
+ *
+ * Each node starts in its own community (label = its own id). On every
+ * sweep a node adopts the label carrying the greatest summed edge weight
+ * among its neighbours. Iterate until a sweep changes nothing or the cap
+ * is hit. Connected, densely-linked entities converge onto a shared
+ * label → one community.
+ *
+ * Determinism (we diverge from graphiti's random tie-break on purpose):
+ *   - nodes are swept in sorted id order,
+ *   - ties on summed weight break toward the lexicographically smallest
+ *     label.
+ * This makes the output reproducible, which the unit tests rely on and
+ * which keeps community ids stable across rebuilds when the graph is
+ * unchanged.
+ *
+ * Pure: no IO, no clock, no randomness. Mirrors the style of the PPR
+ * helpers in `src/search/internals/ppr.ts`.
+ */
+export interface WeightedNeighbor {
+  to: string;
+  w: number;
+}
+
+export function labelPropagation(
+  adjacency: Map<string, WeightedNeighbor[]>,
+  maxIterations = 10,
+): string[][] {
+  const nodes = [...adjacency.keys()].sort();
+  const labels = new Map<string, string>();
+  for (const n of nodes) labels.set(n, n);
+
+  for (let iter = 0; iter < maxIterations; iter++) {
+    let changed = false;
+    for (const node of nodes) {
+      const next = dominantNeighbourLabel(adjacency.get(node) ?? [], labels);
+      if (next !== null && next !== labels.get(node)) {
+        labels.set(node, next);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+
+  return groupByLabel(nodes, labels);
+}
+
+/**
+ * The neighbour label carrying the greatest summed incident weight; ties
+ * break toward the smallest label id (determinism). Null when the node has
+ * no labelled neighbours.
+ */
+function dominantNeighbourLabel(
+  neighbours: WeightedNeighbor[],
+  labels: Map<string, string>,
+): string | null {
+  const weightByLabel = new Map<string, number>();
+  for (const nb of neighbours) {
+    const lab = labels.get(nb.to);
+    if (lab === undefined) continue;
+    weightByLabel.set(lab, (weightByLabel.get(lab) ?? 0) + nb.w);
+  }
+  let best: string | null = null;
+  let bestW = -Infinity;
+  for (const [lab, w] of weightByLabel) {
+    if (w > bestW || (w === bestW && (best === null || lab < best))) {
+      best = lab;
+      bestW = w;
+    }
+  }
+  return best;
+}
+
+/** Bucket nodes by final label; sorted members, deterministic order. */
+function groupByLabel(
+  nodes: string[],
+  labels: Map<string, string>,
+): string[][] {
+  const groups = new Map<string, string[]>();
+  for (const node of nodes) {
+    const lab = labels.get(node)!;
+    const arr = groups.get(lab);
+    if (arr) arr.push(node);
+    else groups.set(lab, [node]);
+  }
+  return [...groups.values()]
+    .map((g) => g.sort())
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+}
+
+/**
+ * Build an undirected, weight-summed adjacency map from raw edges.
+ * Pure — same shape as `buildPprAdjacency` in the search internals.
+ * Edges whose endpoints are equal (self-loops) are dropped.
+ */
+export function buildAdjacency(
+  edges: Array<{ from: string; to: string; weight?: number }>,
+): Map<string, WeightedNeighbor[]> {
+  const adj = new Map<string, WeightedNeighbor[]>();
+  const ensure = (id: string): WeightedNeighbor[] => {
+    let arr = adj.get(id);
+    if (!arr) {
+      arr = [];
+      adj.set(id, arr);
+    }
+    return arr;
+  };
+  for (const e of edges) {
+    if (!e.from || !e.to || e.from === e.to) continue;
+    const w = typeof e.weight === 'number' && e.weight > 0 ? e.weight : 1.0;
+    ensure(e.from).push({ to: e.to, w });
+    ensure(e.to).push({ to: e.from, w });
+  }
+  return adj;
+}

--- a/src/db/migrations/0036_communities.surql
+++ b/src/db/migrations/0036_communities.surql
@@ -1,0 +1,60 @@
+-- 0036_communities — topic-level clustering of the entity graph.
+--
+-- Borrowed from graphiti (Zep) community detection: cluster the entity
+-- graph into topic communities via label propagation, summarise each,
+-- and expose a coarse retrieval scope alongside facts/entities. brain
+-- had no clustering layer before this (only PPR cluster-lift inside the
+-- fact search pipeline); a community is a first-class, persisted node.
+--
+-- Built off-hours by the dreams loop (CommunityBuilderService), gated
+-- behind DREAMS_COMMUNITIES_ENABLED. Idempotent: each build replaces
+-- the tenant's community set, reusing the summary when nothing changed.
+--
+-- Bi-temporal-flavoured WATERMARK (borrowed from graphiti summarize_saga):
+--   lastBuiltAt        — wall-clock: when we last (re)built this node.
+--   lastBuiltMaxEdgeAt — event-time: max knowledge_edge.createdAt that
+--                        fed this cluster. The next build re-summarises a
+--                        community ONLY when newer edges appeared, so a
+--                        stable cluster never re-pays the LLM cost.
+--
+-- community_member is a RELATION (community_node -> knowledge_entity),
+-- mirroring graphiti's HAS_MEMBER edge.
+
+DEFINE TABLE IF NOT EXISTS community_node SCHEMAFULL;
+
+DEFINE FIELD IF NOT EXISTS label              ON community_node TYPE string;
+DEFINE FIELD IF NOT EXISTS summary            ON community_node TYPE string DEFAULT '';
+DEFINE FIELD IF NOT EXISTS summaryEmbedding   ON community_node TYPE option<array<float>>;
+DEFINE FIELD IF NOT EXISTS memberCount        ON community_node TYPE int DEFAULT 0
+  ASSERT $value >= 0;
+DEFINE FIELD IF NOT EXISTS algorithm          ON community_node TYPE string DEFAULT 'label_propagation';
+DEFINE FIELD IF NOT EXISTS builtAt            ON community_node TYPE datetime DEFAULT time::now();
+-- Watermarks (see header). Wall-clock + event-time, as in graphiti.
+DEFINE FIELD IF NOT EXISTS lastBuiltAt        ON community_node TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS lastBuiltMaxEdgeAt ON community_node TYPE option<datetime>;
+
+DEFINE INDEX IF NOT EXISTS community_built_idx ON community_node FIELDS builtAt;
+-- Full-text over the summary so the community scope can answer
+-- "what do we know about <domain>" lexically. Same `content` analyzer
+-- the fact / entity BM25 indexes use (migration 0002).
+DEFINE INDEX IF NOT EXISTS community_summary_idx ON community_node
+  FIELDS summary SEARCH ANALYZER content BM25 HIGHLIGHTS;
+-- HNSW over the summary embedding is opt-in once a tenant grows many
+-- communities; full-scan cosine in CommunityBuilderService is fine at
+-- walking-skeleton scale (communities are O(10²), not O(facts)).
+-- DEFINE INDEX community_embedding_idx ON community_node FIELDS summaryEmbedding
+--   HNSW DIMENSION 1024 DIST COSINE EFC 200 M 16;
+
+-- ─── community_member (community_node -> knowledge_entity) ───────────────
+DEFINE TABLE IF NOT EXISTS community_member SCHEMAFULL TYPE RELATION
+  IN community_node OUT knowledge_entity;
+
+DEFINE FIELD IF NOT EXISTS addedAt ON community_member TYPE datetime DEFAULT time::now();
+
+-- Each (community, entity) pair at most once. An entity belongs to one
+-- community per build, but the UNIQUE guard keeps re-runs idempotent.
+DEFINE INDEX IF NOT EXISTS member_unique_idx ON community_member FIELDS in, out UNIQUE;
+DEFINE INDEX IF NOT EXISTS member_in_idx     ON community_member FIELDS in;
+-- Hot path for retrieval: entity -> its community (carry the label as a
+-- type hint into the listwise reranker).
+DEFINE INDEX IF NOT EXISTS member_out_idx    ON community_member FIELDS out;

--- a/src/dreams/dreams.module.ts
+++ b/src/dreams/dreams.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ConfigModule } from '@nestjs/config';
 import { CompactionModule } from '../compaction/compaction.module';
+import { CommunityModule } from '../communities/community.module';
 import { AuthModule } from '../auth/auth.module';
 import { DreamsService } from './dreams.service';
 import { DreamsController } from './dreams.controller';
@@ -22,6 +23,7 @@ import { DreamsResolverService } from './resolver.service';
     ScheduleModule.forRoot(),
     ConfigModule,
     CompactionModule,
+    CommunityModule,
     AuthModule,
   ],
   controllers: [DreamsController],

--- a/src/dreams/dreams.service.ts
+++ b/src/dreams/dreams.service.ts
@@ -8,6 +8,10 @@ import { withSpan } from '../common/tracing';
 import { DreamsDedupService, DedupResult } from './dedup.service';
 import { DreamsResolverService, ResolverResult } from './resolver.service';
 import { CompactionService } from '../compaction/compaction.service';
+import {
+  CommunityBuilderService,
+  type CommunityBuildResult,
+} from '../communities/community-builder.service';
 import { DreamsOperation } from './dto/run-dreams.dto';
 import { JobRunService, JobRunRow } from '../jobs/job-run.service';
 import { JobClaimService } from '../jobs/job-claim.service';
@@ -29,6 +33,8 @@ export interface DreamsTenantStats {
    * stay accessible via the existing /metrics surface.
    */
   summarized?: boolean;
+  /** Topic-community (re)build stats — present when the communities op ran. */
+  communities?: CommunityBuildResult;
   error?: string;
 }
 
@@ -92,6 +98,9 @@ export class DreamsService implements OnModuleInit {
     // @Optional so the positional unit tests (no DI) can omit it — they run
     // unguarded, which is correct for single-process tests.
     @Optional() private readonly guard?: DistributedLeaseGuard,
+    // @Optional so the positional unit tests (no DI) can omit it. In
+    // production CommunityModule (imported by DreamsModule) provides it.
+    @Optional() private readonly community?: CommunityBuilderService,
   ) {
     this.enabled =
       this.configService.get<string>('DREAMS_ENABLED', '0') === '1';
@@ -109,6 +118,9 @@ export class DreamsService implements OnModuleInit {
     ) {
       ops.push('summarize');
     }
+    // Communities auto-join the default set when enabled (same pattern as
+    // dedup/resolve — one flag, DREAMS_COMMUNITIES_ENABLED).
+    if (this.community?.isEnabled()) ops.push('communities');
     this.defaultOps = new Set(ops);
     this.logger.log(
       `Dreams config: enabled=${this.enabled}, default ops=${[...this.defaultOps].join(',') || '(none)'}`,
@@ -241,6 +253,7 @@ export class DreamsService implements OnModuleInit {
       identityLinksCreated: stats.dedup?.identityLinksCreated ?? 0,
       resolutionsApplied: stats.resolve?.resolutionsApplied ?? 0,
       summarized: stats.summarized ?? false,
+      communitiesBuilt: stats.communities?.communitiesBuilt ?? 0,
     };
   }
 
@@ -398,6 +411,20 @@ export class DreamsService implements OnModuleInit {
           if (jobRow) {
             await this.jobs?.updateProgress(jobRow, {
               resolutionsApplied: stats.resolve.resolutionsApplied,
+            });
+          }
+        }
+        if (opSet.has('communities') && this.community) {
+          checkAbort();
+          stats.communities = await withSpan(
+            'dreams.communities',
+            () => this.community!.run(db),
+            { 'dreams.tenant': companyId },
+          );
+          if (jobRow) {
+            await this.jobs?.updateProgress(jobRow, {
+              communitiesBuilt: stats.communities.communitiesBuilt,
+              communitiesReused: stats.communities.communitiesReused,
             });
           }
         }

--- a/src/dreams/dto/run-dreams.dto.ts
+++ b/src/dreams/dto/run-dreams.dto.ts
@@ -1,16 +1,21 @@
 import { IsArray, IsIn, IsOptional } from 'class-validator';
 
-export type DreamsOperation = 'dedup' | 'resolve' | 'summarize';
+export type DreamsOperation =
+  | 'dedup'
+  | 'resolve'
+  | 'summarize'
+  | 'communities';
 
 /**
  * Body of `POST /v1/dreams/run`. Caller picks which sub-operations
  * to run; default is all enabled ones. The summarize op is normally
  * triggered by compaction — exposed here for force-runs (e.g. after
- * a bulk import that needs immediate rollups).
+ * a bulk import that needs immediate rollups). The communities op
+ * rebuilds the topic-cluster graph (graphiti-style community detection).
  */
 export class RunDreamsDto {
   @IsOptional()
   @IsArray()
-  @IsIn(['dedup', 'resolve', 'summarize'], { each: true })
+  @IsIn(['dedup', 'resolve', 'summarize', 'communities'], { each: true })
   operations?: DreamsOperation[];
 }

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -156,6 +156,72 @@ export class EntitiesService {
     });
   }
 
+  /**
+   * Cheap freshness probe for an entity's active fact set, used by the
+   * summarize_entity watermark cache (graphiti-style dual watermark):
+   *   - maxRecordedAt — wall-clock: the newest moment brain learned
+   *     anything about this entity. A cached summary is stale the instant
+   *     a fact with a newer recordedAt lands (even a BACKFILLED one whose
+   *     validFrom is in the past — the bug an asOf-keyed cache misses).
+   *   - maxValidFrom  — event-time: the newest real-world moment the
+   *     summary reflects ("as of"), surfaced to the caller.
+   *
+   * One indexed aggregate over (entityId, status, recordedAt) — far
+   * cheaper than rebuilding the full profile, so it's safe to run on
+   * every cache hit. Returns nulls when the entity has no qualifying
+   * facts.
+   */
+  async freshnessWatermark(
+    companyId: string,
+    entityIdRaw: string,
+    asOfRaw: string | undefined,
+    scopes: BrainScope[],
+  ): Promise<{ maxRecordedAt: string | null; maxValidFrom: string | null }> {
+    const ref = this.normalizeEntityId(entityIdRaw);
+    const asOf = asOfRaw ? new Date(asOfRaw) : null;
+    return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
+      const baseClauses = [
+        `entityId = type::thing('knowledge_entity', $rid)`,
+      ];
+      const params: Record<string, unknown> = { rid: ref.id };
+      if (asOf) {
+        baseClauses.push(
+          `recordedAt <= $asOf`,
+          `(retractedAt IS NONE OR retractedAt > $asOf)`,
+          `validFrom <= $asOf`,
+          `(validUntil IS NONE OR validUntil > $asOf)`,
+        );
+        params.asOf = asOf;
+      } else {
+        baseClauses.push(`retractedAt IS NONE`);
+      }
+      // Two cheap ORDER BY … LIMIT 1 probes (recordedAt is indexed).
+      // Avoids math::max aggregation, which returns NONE over datetimes on
+      // this SurrealDB build.
+      const where = baseClauses.join(' AND ');
+      const [recRows] = await db.query<any[][]>(
+        `SELECT recordedAt FROM knowledge_fact WHERE ${where}
+         ORDER BY recordedAt DESC LIMIT 1`,
+        params,
+      );
+      const [valRows] = await db.query<any[][]>(
+        `SELECT validFrom FROM knowledge_fact WHERE ${where}
+         ORDER BY validFrom DESC LIMIT 1`,
+        params,
+      );
+      const toIso = (v: unknown): string | null =>
+        v == null
+          ? null
+          : v instanceof Date
+            ? v.toISOString()
+            : new Date(String(v)).toISOString();
+      return {
+        maxRecordedAt: toIso((recRows as any[])?.[0]?.recordedAt),
+        maxValidFrom: toIso((valRows as any[])?.[0]?.validFrom),
+      };
+    });
+  }
+
   async getTimeline(
     companyId: string,
     entityIdRaw: string,

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -206,18 +206,16 @@ export class EntitiesService {
         baseClauses.push(`predicate NOT IN $blocked`);
         params.blocked = blocked;
       }
-      // Two cheap ORDER BY … LIMIT 1 probes (recordedAt is indexed).
-      // Avoids math::max aggregation, which returns NONE over datetimes on
-      // this SurrealDB build.
+      // Two cheap ORDER BY … LIMIT 1 probes (recordedAt is indexed),
+      // sent as ONE round-trip (two statements) so a cache-hit freshness
+      // check stays a single network hop. Avoids math::max aggregation,
+      // which returns NONE over datetimes on this SurrealDB build.
       const where = baseClauses.join(' AND ');
-      const [recRows] = await db.query<any[][]>(
+      const [recRows, valRows] = await db.query<[any[], any[]]>(
         `SELECT recordedAt FROM knowledge_fact WHERE ${where}
-         ORDER BY recordedAt DESC LIMIT 1`,
-        params,
-      );
-      const [valRows] = await db.query<any[][]>(
-        `SELECT validFrom FROM knowledge_fact WHERE ${where}
-         ORDER BY validFrom DESC LIMIT 1`,
+           ORDER BY recordedAt DESC LIMIT 1;
+         SELECT validFrom FROM knowledge_fact WHERE ${where}
+           ORDER BY validFrom DESC LIMIT 1`,
         params,
       );
       const toIso = (v: unknown): string | null =>

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -195,6 +195,17 @@ export class EntitiesService {
       } else {
         baseClauses.push(`retractedAt IS NONE`);
       }
+      // Mirror getProfile's PII gate: a fact the caller can't see must
+      // not move the watermark, else a low-scope caller's cache gets
+      // invalidated exactly when a restricted fact lands (a timing oracle
+      // + needless rebuilds). DB-side here since we don't fetch the rows.
+      const blocked = Object.entries(PREDICATE_POLICIES)
+        .filter(([, p]) => p.requiresScope && !scopes.includes(p.requiresScope))
+        .map(([predicate]) => predicate);
+      if (blocked.length) {
+        baseClauses.push(`predicate NOT IN $blocked`);
+        params.blocked = blocked;
+      }
       // Two cheap ORDER BY … LIMIT 1 probes (recordedAt is indexed).
       // Avoids math::max aggregation, which returns NONE over datetimes on
       // this SurrealDB build.

--- a/src/mcp/community-tools.ts
+++ b/src/mcp/community-tools.ts
@@ -1,0 +1,86 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { CommunityService } from '../communities/community.service';
+
+/**
+ * Registers the topic-community read scope (graphiti-style communities)
+ * on an MCP server bound to one tenant. Split out of mcp.service.ts purely
+ * to keep that file under the max-lines gate — same `server.registerTool`
+ * pattern as the read tools there.
+ */
+export function registerCommunityTools(
+  server: McpServer,
+  companyId: string,
+  communities: CommunityService,
+): void {
+  // ── search_communities ──────────────────────────────────────────────
+  server.registerTool(
+    'search_communities',
+    {
+      title: 'Search topic communities (coarse retrieval scope)',
+      description:
+        'Cosine-matches the query against topic-community summaries — the coarse retrieval scope. A community is a cluster of related entities (label propagation over the entity graph) with one rolled-up summary. Use BEFORE search_knowledge when the question is broad ("what do we know about X domain") to get an overview instead of a fact firehose, then drill into specific entities. Communities are (re)built off-hours by the dreams loop; an empty result means clustering has not run or the graph is too sparse.',
+      inputSchema: {
+        query: z.string().describe('Natural-language topic / domain'),
+        limit: z.number().int().min(1).max(20).optional(),
+        minSimilarity: z
+          .number()
+          .min(0)
+          .max(1)
+          .optional()
+          .describe('Floor (default 0.3); rows below are dropped'),
+      },
+    },
+    async (args) => {
+      const out = await communities.search(companyId, {
+        query: args.query,
+        limit: args.limit,
+        minSimilarity: args.minSimilarity,
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
+        structuredContent: { communities: out } as any,
+      };
+    },
+  );
+
+  // ── list_communities ────────────────────────────────────────────────
+  server.registerTool(
+    'list_communities',
+    {
+      title: 'List topic communities',
+      description:
+        'Paginated listing of topic communities, largest first. Each row carries a label, a rolled-up summary, and the member count. Use to enumerate the knowledge map at a glance.',
+      inputSchema: {
+        limit: z.number().int().min(1).max(200).optional(),
+      },
+    },
+    async (args) => {
+      const out = await communities.list(companyId, { limit: args.limit });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
+        structuredContent: { communities: out } as any,
+      };
+    },
+  );
+
+  // ── find_entity_communities ─────────────────────────────────────────
+  server.registerTool(
+    'find_entity_communities',
+    {
+      title: 'Find the communities an entity belongs to',
+      description:
+        'Returns the topic communities a given entity is a member of. Use to place an entity in its broader context — which clusters / themes it participates in — or to pivot from one entity to the wider neighbourhood the cluster summarises.',
+      inputSchema: {
+        entityId: z.string().describe('knowledge_entity id'),
+      },
+    },
+    async (args) => {
+      const out = await communities.forEntity(companyId, args.entityId);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
+        structuredContent: { communities: out } as any,
+      };
+    },
+  );
+}

--- a/src/mcp/mcp.module.ts
+++ b/src/mcp/mcp.module.ts
@@ -10,6 +10,7 @@ import { SynthesizeModule } from '../synthesize/synthesize.module';
 import { DiffModule } from '../diff/diff.module';
 import { SummarizeEntityModule } from '../summarize-entity/summarize-entity.module';
 import { ProceduralModule } from '../procedural/procedural.module';
+import { CommunityModule } from '../communities/community.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { ProceduralModule } from '../procedural/procedural.module';
     DiffModule,
     SummarizeEntityModule,
     ProceduralModule,
+    CommunityModule,
   ],
   controllers: [McpController],
   providers: [McpService],

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -14,6 +14,7 @@ import { MemoryDiffService } from '../diff/memory-diff.service';
 import { IngestPredictionService } from '../ingest/ingest-predictor.service';
 import { SummarizeEntityService } from '../summarize-entity/summarize-entity.service';
 import { ProceduralMemoryService } from '../procedural/procedural-memory.service';
+import { CommunityService } from '../communities/community.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { BrainScope } from '../auth/api-key.types';
 import {
@@ -22,6 +23,7 @@ import {
   type ProgressReporter,
 } from './progress-reporter';
 import { summarizeViaClientSampling } from './sampling';
+import { registerCommunityTools } from './community-tools';
 
 /**
  * Translate an MCP request's `extra` parameter into a ProgressReporter
@@ -72,6 +74,9 @@ const HEALTH_TOOLS = [
   'find_related_entities',
   'match_procedure',
   'list_procedures',
+  'search_communities',
+  'list_communities',
+  'find_entity_communities',
 ];
 
 /**
@@ -103,6 +108,7 @@ export class McpService {
     private readonly predictor: IngestPredictionService,
     private readonly summarizer: SummarizeEntityService,
     private readonly procedural: ProceduralMemoryService,
+    private readonly communities: CommunityService,
     private readonly embedder: EmbedderService,
   ) {}
 
@@ -691,6 +697,10 @@ export class McpService {
         };
       },
     );
+
+    // Community scope (search/list/find_entity) lives in its own module
+    // to keep this file under the max-lines gate.
+    registerCommunityTools(server, companyId, this.communities);
   }
 
 

--- a/src/summarize-entity/summarize-entity.service.ts
+++ b/src/summarize-entity/summarize-entity.service.ts
@@ -21,11 +21,18 @@ import { BrainScope } from '../auth/api-key.types';
  *     `compacted_entity` table is a v2 lift — note `Gotcha` in the
  *     roadmap brief: an LLM-backed generator pushes us toward
  *     persistent cache, but until that lands the LRU is enough.
- *   - Invalidation: cache key embeds the asOf timestamp (or 'now' for
- *     unspecified) so future calls at different cursors miss; the LRU
- *     tail evicts when entries pile up. Fact ingest does NOT
- *     proactively invalidate — risk is bounded by short LRU tail and
- *     mostly-stable summaries.
+ *   - Invalidation: WATERMARK-based (borrowed from graphiti
+ *     `summarize_saga`). Each cache entry stores the entity's wall-clock
+ *     watermark (max recordedAt) at build time. Every lookup runs a cheap
+ *     indexed aggregate (EntitiesService.freshnessWatermark); if a fact
+ *     with a newer recordedAt has landed since — including a BACKFILLED
+ *     one whose validFrom is in the past — the entry is treated as stale
+ *     and rebuilt. The cache key still embeds asOf, so historical cursors
+ *     stay isolated; the watermark adds the missing freshness axis the
+ *     prior LRU-only design could not see.
+ *   - The result also carries `asOfValid` — the event-time (max validFrom)
+ *     the summary reflects, so the caller knows "as of when", not just
+ *     "computed when".
  */
 @Injectable()
 export class SummarizeEntityService {
@@ -41,13 +48,23 @@ export class SummarizeEntityService {
     scopes: BrainScope[],
   ): Promise<SummarizeResult> {
     const cacheKey = buildCacheKey(companyId, args);
+    // Freshness probe FIRST — one cheap indexed aggregate. Its wall-clock
+    // watermark decides whether a cache hit is still valid.
+    const watermark = await this.entities.freshnessWatermark(
+      companyId,
+      args.entityId,
+      args.asOf,
+      scopes,
+    );
+
     const hit = this.cache.get(cacheKey);
-    if (hit) {
+    if (hit && !isStale(hit.watermark, watermark.maxRecordedAt)) {
       // LRU touch — re-insert moves the key to end-of-iteration.
       this.cache.delete(cacheKey);
       this.cache.set(cacheKey, hit);
       return { ...hit.result, cached: true };
     }
+    if (hit) this.cache.delete(cacheKey); // stale — drop and rebuild below.
 
     const profile = await this.entities.getProfile(
       companyId,
@@ -64,6 +81,7 @@ export class SummarizeEntityService {
       factsConsidered: profile.facts.length,
       style,
       asOf: args.asOf,
+      asOfValid: watermark.maxValidFrom ?? undefined,
       cached: false,
     };
     const cacheable: CachedSummary = {
@@ -74,7 +92,9 @@ export class SummarizeEntityService {
         factsConsidered: result.factsConsidered,
         style: result.style,
         asOf: result.asOf,
+        asOfValid: result.asOfValid,
       },
+      watermark: watermark.maxRecordedAt,
       insertedAt: Date.now(),
     };
     this.cache.set(cacheKey, cacheable);
@@ -102,6 +122,20 @@ export class SummarizeEntityService {
       this.cache.delete(oldest.value);
     }
   }
+}
+
+/**
+ * A cached summary is stale when the entity's current wall-clock
+ * watermark differs from the one captured at build time. recordedAt only
+ * advances as facts land, so "differs" means "newer fact arrived" — the
+ * proactive invalidation the old LRU-only cache lacked. Both-null (entity
+ * with no facts) is fresh.
+ */
+function isStale(
+  builtWatermark: string | null,
+  currentWatermark: string | null,
+): boolean {
+  return (builtWatermark ?? '') !== (currentWatermark ?? '');
 }
 
 function buildCacheKey(companyId: string, args: SummarizeArgs): string {
@@ -172,6 +206,12 @@ export interface SummarizeResult {
   factsConsidered: number;
   style: SummarizeStyle;
   asOf?: string;
+  /**
+   * Event-time the summary reflects — the max validFrom across the facts
+   * considered (graphiti-style event-time watermark). Lets the caller
+   * reason about "as of when", independent of when it was computed.
+   */
+  asOfValid?: string;
   /** True when this exact (entityId, asOf, style) was served from the LRU. */
   cached: boolean;
 }
@@ -179,5 +219,7 @@ export interface SummarizeResult {
 interface CachedSummary {
   key: string;
   result: Omit<SummarizeResult, 'cached'>;
+  /** Wall-clock watermark (max recordedAt) captured at build time. */
+  watermark: string | null;
   insertedAt: number;
 }

--- a/test/communities-label-propagation.unit-spec.ts
+++ b/test/communities-label-propagation.unit-spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Label-propagation community detection — pure-function unit coverage.
+ *
+ * The algorithm is a deterministic port of graphiti's
+ * community_operations.py. These tests pin the properties the builder
+ * relies on: dense clusters collapse onto one label, disconnected
+ * components stay separate, isolated nodes are singletons, and the output
+ * is reproducible (so community ids stay stable across rebuilds on an
+ * unchanged graph).
+ */
+import {
+  buildAdjacency,
+  labelPropagation,
+  type WeightedNeighbor,
+} from '../src/communities/label-propagation';
+
+function clusterOf(groups: string[][], node: string): string[] {
+  return groups.find((g) => g.includes(node)) ?? [];
+}
+
+describe('labelPropagation — community detection', () => {
+  it('collapses two disjoint cliques into two communities', () => {
+    const adj = buildAdjacency([
+      // clique 1: a-b-c
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'a', to: 'c' },
+      // clique 2: x-y-z
+      { from: 'x', to: 'y' },
+      { from: 'y', to: 'z' },
+      { from: 'x', to: 'z' },
+    ]);
+    const groups = labelPropagation(adj);
+    expect(groups).toHaveLength(2);
+    expect(clusterOf(groups, 'a').sort()).toEqual(['a', 'b', 'c']);
+    expect(clusterOf(groups, 'x').sort()).toEqual(['x', 'y', 'z']);
+  });
+
+  it('keeps disconnected components in separate communities', () => {
+    const adj = buildAdjacency([
+      { from: 'a', to: 'b' },
+      { from: 'c', to: 'd' },
+    ]);
+    const groups = labelPropagation(adj);
+    expect(groups).toHaveLength(2);
+    expect(clusterOf(groups, 'a').sort()).toEqual(['a', 'b']);
+    expect(clusterOf(groups, 'c').sort()).toEqual(['c', 'd']);
+  });
+
+  it('pulls a weakly-linked node toward its heavier neighbourhood', () => {
+    // n sits between the cluster (heavy, weight 5 to c) and a stray (light,
+    // weight 1 to s). It should land with the heavy cluster.
+    const adj = buildAdjacency([
+      { from: 'a', to: 'b', weight: 5 },
+      { from: 'b', to: 'c', weight: 5 },
+      { from: 'a', to: 'c', weight: 5 },
+      { from: 'c', to: 'n', weight: 5 },
+      { from: 'n', to: 's', weight: 1 },
+    ]);
+    const groups = labelPropagation(adj);
+    expect(clusterOf(groups, 'n')).toContain('a');
+    expect(clusterOf(groups, 'n')).toContain('c');
+  });
+
+  it('returns an empty list for an empty graph', () => {
+    expect(labelPropagation(new Map())).toEqual([]);
+  });
+
+  it('is deterministic — identical input yields identical output', () => {
+    const edges = [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'd', to: 'e' },
+    ];
+    const first = labelPropagation(buildAdjacency(edges));
+    const second = labelPropagation(buildAdjacency(edges));
+    expect(second).toEqual(first);
+  });
+});
+
+describe('buildAdjacency — undirected weight-summed graph', () => {
+  it('mirrors every edge in both directions', () => {
+    const adj = buildAdjacency([{ from: 'a', to: 'b', weight: 2 }]);
+    expect(adj.get('a')).toEqual([{ to: 'b', w: 2 }] as WeightedNeighbor[]);
+    expect(adj.get('b')).toEqual([{ to: 'a', w: 2 }] as WeightedNeighbor[]);
+  });
+
+  it('drops self-loops and defaults non-positive weights to 1', () => {
+    const adj = buildAdjacency([
+      { from: 'a', to: 'a', weight: 9 }, // self-loop dropped
+      { from: 'a', to: 'b', weight: 0 }, // 0 → default 1
+    ]);
+    expect(adj.has('a')).toBe(true);
+    expect(adj.get('a')).toEqual([{ to: 'b', w: 1 }]);
+  });
+});

--- a/test/communities.e2e-spec.ts
+++ b/test/communities.e2e-spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Communities — end-to-end smoke.
+ *
+ * Seeds two disjoint triangles of linked entities, runs the dreams
+ * `communities` op, and asserts:
+ *   - two communities materialise, each with 3 members + a summary,
+ *   - search / list / find-for-entity read surfaces resolve them,
+ *   - a second build with no graph change REUSES every community via the
+ *     watermark (graphiti summarize_saga port) — zero rebuilds.
+ *
+ * Embeddings are stubbed by the fixture, so the summary embedding +
+ * cosine search are deterministic and need no live model.
+ */
+process.env.DREAMS_COMMUNITIES_ENABLED = '1';
+process.env.COMMUNITIES_MIN_SIZE = '3';
+
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { DreamsService } from '../src/dreams/dreams.service';
+import { CommunityService } from '../src/communities/community.service';
+
+describe('Communities — build + read surfaces', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  let entityA = '';
+
+  const ingestName = async (id: string, name: string) => {
+    const res = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id },
+        predicate: 'name',
+        object: name,
+        validFrom: '2026-01-01T00:00:00Z',
+        confidence: 0.95,
+        source: { vertical: 'rent' },
+      });
+    expect([200, 201]).toContain(res.status);
+    return res.body.factId as string;
+  };
+
+  const link = async (a: string, b: string) => {
+    const res = await f.http
+      .post('/v1/ingest/link')
+      .set(auth())
+      .send({
+        from: { vertical: 'rent', id: a },
+        to: { vertical: 'rent', id: b },
+        kind: 'related_to',
+        source: { vertical: 'rent' },
+      });
+    expect([200, 201]).toContain(res.status);
+  };
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_communities_e2e' });
+
+    // Cluster 1 — billing topic triangle.
+    const factA = await ingestName('comm_a', 'Acme Invoicing');
+    await ingestName('comm_b', 'Acme Billing Run');
+    await ingestName('comm_c', 'Acme Dunning');
+    await link('comm_a', 'comm_b');
+    await link('comm_b', 'comm_c');
+    await link('comm_a', 'comm_c');
+
+    // Cluster 2 — logistics topic triangle.
+    await ingestName('comm_x', 'Warehouse North');
+    await ingestName('comm_y', 'Warehouse South');
+    await ingestName('comm_z', 'Fleet Dispatch');
+    await link('comm_x', 'comm_y');
+    await link('comm_y', 'comm_z');
+    await link('comm_x', 'comm_z');
+
+    const surreal = f.app.get(SurrealService);
+    entityA = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<any[][]>(
+        `SELECT entityId FROM type::thing('knowledge_fact', $tail)`,
+        { tail: factA.split(':')[1] },
+      );
+      return String((rows as any[])?.[0]?.entityId ?? '');
+    });
+    expect(entityA).toMatch(/^knowledge_entity:/);
+
+    // Build communities through the dreams leg.
+    const stats = await f.app
+      .get(DreamsService)
+      .runForTenant(f.companyId, ['communities']);
+    expect(stats.communities?.communitiesBuilt).toBe(2);
+    expect(stats.communities?.entitiesClustered).toBe(6);
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('materialises two communities of three members each', async () => {
+    const list = await f.app.get(CommunityService).list(f.companyId, {});
+    expect(list).toHaveLength(2);
+    for (const c of list) {
+      expect(c.memberCount).toBe(3);
+      expect(c.summary.length).toBeGreaterThan(0);
+      expect(c.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('find_entity_communities resolves an entity to its cluster', async () => {
+    const out = await f.app.get(CommunityService).forEntity(f.companyId, entityA);
+    expect(out).toHaveLength(1);
+    expect(out[0].memberCount).toBe(3);
+  });
+
+  it('search returns a community for a topical query', async () => {
+    const out = await f.app
+      .get(CommunityService)
+      .search(f.companyId, { query: 'Acme billing', minSimilarity: 0 });
+    expect(out.length).toBeGreaterThanOrEqual(1);
+    expect(out[0].similarity).toBeGreaterThanOrEqual(0);
+  });
+
+  it('rebuild with no graph change reuses every community (watermark)', async () => {
+    const stats = await f.app
+      .get(DreamsService)
+      .runForTenant(f.companyId, ['communities']);
+    expect(stats.communities?.communitiesBuilt).toBe(0);
+    expect(stats.communities?.communitiesReused).toBe(2);
+    expect(stats.communities?.communitiesRemoved).toBe(0);
+    // Still exactly two communities — no duplication on re-run.
+    const list = await f.app.get(CommunityService).list(f.companyId, {});
+    expect(list).toHaveLength(2);
+  });
+});

--- a/test/mcp-tools.unit-spec.ts
+++ b/test/mcp-tools.unit-spec.ts
@@ -41,6 +41,7 @@ function buildWithScopes(scopes: BrainScope[]): McpServer {
     {} as never,
     {} as never,
     {} as never,
+    {} as never,
     stubEmbedder as never,
   );
   return svc.buildServer('co_test', scopes);
@@ -76,6 +77,9 @@ const READ_BASELINE = [
   'detect_contradiction',
   'match_procedure',
   'list_procedures',
+  'search_communities',
+  'list_communities',
+  'find_entity_communities',
   'find_related_entities',
 ];
 
@@ -125,6 +129,7 @@ describe('McpService.buildServer — scope-gated tool surface', () => {
 describe('McpService.health — unauthenticated probe payload', () => {
   it('returns ok, version, the read-baseline tools, and embedder hint', () => {
     const svc = new McpService(
+      {} as never,
       {} as never,
       {} as never,
       {} as never,

--- a/test/summarize-watermark.e2e-spec.ts
+++ b/test/summarize-watermark.e2e-spec.ts
@@ -1,0 +1,88 @@
+/**
+ * summarize_entity watermark invalidation — end-to-end.
+ *
+ * Pins the graphiti-borrowed dual-watermark behaviour the prior LRU-only
+ * cache could not deliver:
+ *
+ *   - A repeated call with no new facts is served from cache.
+ *   - A BACKFILLED fact (validFrom in the PAST, recordedAt = now) lands a
+ *     newer wall-clock watermark, so the next "now" call is rebuilt
+ *     (cached: false) even though the new fact is historical. This is the
+ *     exact case an asOf-keyed cache misses.
+ *   - The result exposes `asOfValid` (event-time the summary reflects).
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { SummarizeEntityService } from '../src/summarize-entity/summarize-entity.service';
+
+describe('SummarizeEntityService — watermark freshness', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  let entityId = '';
+
+  const ingest = async (
+    predicate: string,
+    object: string,
+    validFrom: string,
+  ) => {
+    const res = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'wm_subj' },
+        predicate,
+        object,
+        validFrom,
+        confidence: 0.95,
+        source: { vertical: 'rent' },
+      });
+    expect([200, 201]).toContain(res.status);
+    return res.body.factId as string;
+  };
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_summarize_wm_e2e' });
+    const factId = await ingest('name', 'Watermark Subject', '2026-01-01T00:00:00Z');
+    const surreal = f.app.get(SurrealService);
+    entityId = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<any[][]>(
+        `SELECT entityId FROM type::thing('knowledge_fact', $tail)`,
+        { tail: factId.split(':')[1] },
+      );
+      return String((rows as any[])?.[0]?.entityId ?? '');
+    });
+    expect(entityId).toMatch(/^knowledge_entity:/);
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('serves a repeated call from cache and exposes asOfValid', async () => {
+    const svc = f.app.get(SummarizeEntityService);
+    svc.clearCacheForTest();
+    const first = await svc.summarize(f.companyId, { entityId }, ['brain:read']);
+    expect(first.cached).toBe(false);
+    expect(first.asOfValid).toBeDefined();
+    const second = await svc.summarize(f.companyId, { entityId }, ['brain:read']);
+    expect(second.cached).toBe(true);
+  });
+
+  it('rebuilds after a backfilled fact (newer recordedAt, past validFrom)', async () => {
+    const svc = f.app.get(SummarizeEntityService);
+    const before = await svc.summarize(f.companyId, { entityId }, ['brain:read']);
+    expect(before.cached).toBe(true); // warm from the previous test's build
+    const factsBefore = before.factsConsidered;
+
+    // Backfill: validFrom a YEAR in the past, but recordedAt is now. An
+    // asOf-keyed cache would happily keep serving the stale summary; the
+    // wall-clock watermark must catch it.
+    await ingest('tier', 'gold', '2025-01-01T00:00:00Z');
+
+    const after = await svc.summarize(f.companyId, { entityId }, ['brain:read']);
+    expect(after.cached).toBe(false);
+    expect(after.factsConsidered).toBe(factsBefore + 1);
+    expect(after.asOfValid).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Context

Deep audit of [graphiti](https://github.com/getzep/graphiti) (Zep, temporal KG) to see what's worth borrowing. Conclusion: brain already leads graphiti on bitemporality (+Allen's algebra), conflict resolution (COMPETING + scored ladder), hybrid retrieval (convex fusion, predicate router, PPR, listwise LLM rerank) and extraction (semantic-entropy/CISC, HyPE). Only two things were genuinely missing and worth taking.

## What's in this PR

### 1. Topic communities (new capability)
brain had no graph clustering at all. This adds it:
- `0036_communities.surql` — `community_node` + `community_member` (RELATION), watermark fields, BM25 index on summary.
- `label-propagation.ts` — faithful, deterministic port of graphiti `community_operations.py`.
- `CommunityBuilderService` — label propagation over `knowledge_edge` → summary via existing `SUMMARY_GENERATOR` → embedding → persist. Per-cluster incremental skip via an event-time edge watermark.
- `CommunityService` + MCP tools `search_communities` / `list_communities` / `find_entity_communities` (coarse retrieval scope).
- New dreams op `communities` (gated by `DREAMS_COMMUNITIES_ENABLED`), reusing fanout / leader_lease / job_run.

### 2. Watermark summarisation (graphiti `summarize_saga`)
Fixes the documented "ingest does not invalidate the cache" gotcha in the existing `SummarizeEntityService` (no new table) with a dual wall-clock / event-time watermark:
- A backfilled fact (newer `recordedAt`, past `validFrom`) now correctly busts the cache.
- Results carry `asOfValid` — the event-time the summary reflects.
- Community summaries reuse the same watermark to skip unchanged clusters.
- Adds the cheap `EntitiesService.freshnessWatermark` probe.

## Deviation from plan
Dropped the planned `0037_entity_summary` table — `SummarizeEntityService` already exists (roadmap was stale; `summarize_entity` / `memory_diff` / `get_competing_facts` already shipped). Enhanced it in place instead.

## Tests / gates
- Unit: label-propagation (7), mcp-tools surface updated.
- e2e: communities build + reuse + read surfaces (4), watermark backfill invalidation (2).
- Regression e2e (dreams / mcp / entities): 11/11.
- `tsc --noEmit` clean, `lint` clean, unit suite 620/620 (pre-existing OpenTelemetry transform failure in `hybrid-router-perf-gate` is environmental, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)