### PR TITLE
feat(ingest): inline entity resolution at write time (graphiti audit #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] — 2026-06-23
+## [Unreleased]
+
+### Added
+
+- **Inline entity resolution at ingest** (opt-in, graphiti-style) — on the
+  free-text mention path, before minting a new entity for an extracted name
+  that missed the exact-name match, brain now cosine-searches existing
+  entities and lets an LLM judge confirm same-as using the incoming mention's
+  freshly-extracted facts. A confirmed match reuses the existing entity, so
+  the near-duplicate is never created (narrows the dedup window that
+  previously waited for the off-hours dreams pass). The judge prefers
+  "different" when unsure — wrongly fusing two distinct entities (e.g. two
+  "John Smith"s) is worse than a transient duplicate dreams can still merge.
+  Gated by `INGEST_INLINE_RESOLUTION_ENABLED` (default off); any error or
+  timeout falls back to create-new and never blocks ingest. Structured
+  `POST /v1/ingest/fact` with an explicit `vertical:id` is untouched.
 
 First public open-source release.
 

--- a/src/ingest/entity-resolver.service.ts
+++ b/src/ingest/entity-resolver.service.ts
@@ -27,6 +27,21 @@ import { withGenAiCall } from '../common/gen-ai-observability';
  * Gated by INGEST_INLINE_RESOLUTION_ENABLED (default off). Any failure /
  * timeout falls back to "create new" — inline resolution must never block
  * or fail an ingest.
+ *
+ * Provenance (deliberate, graphiti-parity): a confirmed match REUSES the
+ * existing entity rather than creating a duplicate + an `identity_of` edge
+ * the way the off-hours dreams dedup does. So there is no reversible merge
+ * edge to unlink — the trade-off for never materialising the duplicate.
+ * Mitigations: the judge prefers "different" when unsure; each ingested
+ * fact still carries its own `source` (messageId / vertical), so per-fact
+ * origin is auditable; and the decision is logged. If a wrong fuse is ever
+ * a concern for a tenant, leave the flag off and rely on dreams (reversible
+ * edges) instead.
+ *
+ * DEDUP NOTE: the LLM judge + fetchTopFacts + OpenAI/Semaphore setup mirror
+ * DreamsDedupService (one-pair vs candidate-scan framing). Extracting a
+ * shared EntityJudge that serves both call sites is tracked as a follow-up;
+ * kept duplicated here to keep this feature PR off the dreams hot path.
  */
 @Injectable()
 export class EntityResolverService {

--- a/src/ingest/entity-resolver.service.ts
+++ b/src/ingest/entity-resolver.service.ts
@@ -1,0 +1,252 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Surreal, StringRecordId } from 'surrealdb';
+import OpenAI from 'openai';
+import { EmbedderService } from '../ai/embedder.service';
+import { MetricsService } from '../metrics/metrics.service';
+import { Semaphore } from '../common/semaphore';
+import { withGenAiCall } from '../common/gen-ai-observability';
+
+/**
+ * EntityResolverService — inline entity resolution at ingest time
+ * (graphiti-style). Before the mention pipeline mints a NEW entity for an
+ * extracted name that missed the exact canonicalName match, we look for a
+ * near-duplicate that already exists and, when an LLM judge confirms it's
+ * the same real-world thing, reuse it — so the duplicate is never created.
+ *
+ * Why an LLM judge and not bare cosine: two different "John Smith"s have
+ * near-identical name embeddings and the same type; merging on cosine
+ * alone would wrongly fuse them. The judge looks at the FACTS (dob /
+ * email / employer) — the existing entity's stored facts vs the incoming
+ * mention's freshly-extracted facts (already in memory, not yet written)
+ * — exactly as the off-hours dreams dedup does, just for one pair, inline.
+ *
+ * Scope: the free-text mention path only. Structured `POST /v1/ingest/fact`
+ * with an explicit `vertical:id` stays authoritative (externalRef).
+ *
+ * Gated by INGEST_INLINE_RESOLUTION_ENABLED (default off). Any failure /
+ * timeout falls back to "create new" — inline resolution must never block
+ * or fail an ingest.
+ */
+@Injectable()
+export class EntityResolverService {
+  private readonly logger = new Logger(EntityResolverService.name);
+  private readonly openai: OpenAI;
+  private readonly enabled: boolean;
+  private readonly model: string;
+  private readonly cosineFloor: number;
+  private readonly candidateK: number;
+  private readonly limiter: Semaphore;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly embedder: EmbedderService,
+    @Optional() private readonly metrics?: MetricsService,
+  ) {
+    this.enabled =
+      this.config.get<string>('INGEST_INLINE_RESOLUTION_ENABLED', '0') === '1';
+    const apiKey = this.config.get<string>('OPENAI_API_KEY');
+    this.openai = apiKey
+      ? new OpenAI({
+          apiKey,
+          timeout: parseInt(
+            this.config.get<string>('OPENAI_TIMEOUT_MS', '30000'),
+            10,
+          ),
+          maxRetries: parseInt(
+            this.config.get<string>('OPENAI_MAX_RETRIES', '3'),
+            10,
+          ),
+        })
+      : (undefined as unknown as OpenAI);
+    this.model = this.config.get<string>(
+      'INGEST_INLINE_RESOLUTION_MODEL',
+      this.config.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),
+    );
+    this.cosineFloor = parseFloat(
+      this.config.get<string>('INGEST_INLINE_RESOLUTION_COSINE_FLOOR', '0.85'),
+    );
+    this.candidateK = parseInt(
+      this.config.get<string>('INGEST_INLINE_RESOLUTION_CANDIDATES', '5'),
+      10,
+    );
+    this.limiter = new Semaphore(
+      parseInt(
+        this.config.get<string>('INGEST_INLINE_RESOLUTION_CONCURRENCY', '4'),
+        10,
+      ),
+    );
+  }
+
+  isEnabled(): boolean {
+    return this.enabled && !!this.openai;
+  }
+
+  /**
+   * Resolve an extracted entity to an EXISTING entity id when a confident
+   * same-as match is found, otherwise null (caller creates a new entity).
+   *
+   * @param name   the extracted entity name (also its `name` fact object)
+   * @param type   the normalized entity type (must match the candidate's)
+   * @param incomingFacts  the mention's freshly-extracted facts for THIS
+   *   entity, as `"predicate: object"` lines — the judge's "new" side.
+   */
+  async resolveByName(
+    db: Surreal,
+    name: string,
+    type: string,
+    incomingFacts: string[],
+  ): Promise<string | null> {
+    if (!this.isEnabled()) return null;
+    try {
+      const candidate = await this.findBestNameCandidate(db, name, type);
+      if (!candidate) return null;
+
+      const existingFacts = await this.fetchTopFacts(db, candidate.entityId);
+      const verdict = await this.limiter.run(() =>
+        this.judge(name, existingFacts, incomingFacts),
+      );
+      if (verdict === 'same') {
+        this.logger.log(
+          `[ingest.inline_resolution] reused ${candidate.entityId} for "${name}" ` +
+            `(cos=${candidate.cosine.toFixed(3)})`,
+        );
+        return candidate.entityId;
+      }
+      return null;
+    } catch (err) {
+      // Never block ingest — fall back to "create new".
+      this.logger.warn(
+        `[ingest.inline_resolution] failed for "${name}": ${(err as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Cosine k-NN over existing `name` fact embeddings; returns the closest
+   * candidate of the SAME type at or above the floor, else null. Mirrors
+   * the dreams dedup candidate scan, scoped to one query.
+   */
+  private async findBestNameCandidate(
+    db: Surreal,
+    name: string,
+    type: string,
+  ): Promise<{ entityId: string; cosine: number } | null> {
+    const q = await this.embedder.embed(`name: ${name}`);
+    const [rows] = await db.query<
+      [Array<{ entityId: unknown; etype: string; sim: number }>]
+    >(
+      `SELECT entityId, entityId.type AS etype,
+              vector::similarity::cosine(embedding, $q) AS sim
+         FROM knowledge_fact
+         WHERE predicate = 'name'
+           AND status = 'active'
+           AND retractedAt IS NONE
+           AND embedding != NONE
+         ORDER BY sim DESC
+         LIMIT $k`,
+      { q, k: this.candidateK },
+    );
+    for (const r of (rows as Array<{ entityId: unknown; etype: string; sim: number }>) ?? []) {
+      if (r.sim < this.cosineFloor) break; // rows are sorted DESC
+      if (r.etype !== type) continue;
+      return { entityId: String(r.entityId), cosine: r.sim };
+    }
+    return null;
+  }
+
+  private async fetchTopFacts(db: Surreal, entityId: string): Promise<string> {
+    type R = { predicate: string; object: string };
+    const [rows] = await db.query<[R[]]>(
+      `SELECT predicate, object FROM knowledge_fact
+         WHERE entityId = $eid
+           AND status = 'active'
+           AND retractedAt IS NONE
+         ORDER BY confidence DESC
+         LIMIT 5`,
+      { eid: new StringRecordId(entityId) },
+    );
+    const r = (rows as R[]) ?? [];
+    if (r.length === 0) return '(no facts)';
+    return r.map((f) => `- ${f.predicate}: ${f.object}`).join('\n');
+  }
+
+  /**
+   * LLM same/different/unsure verdict — the dreams dedup judge, one pair.
+   * factsB is the incoming mention's extracted facts (the entity isn't in
+   * the graph yet, so its disambiguating evidence comes from extraction).
+   */
+  private async judge(
+    name: string,
+    existingFacts: string,
+    incomingFacts: string[],
+  ): Promise<'same' | 'different' | 'unsure'> {
+    const factsB =
+      incomingFacts.length > 0
+        ? incomingFacts.map((f) => `- ${f}`).join('\n')
+        : '(no facts)';
+    const sys = `You decide whether a newly-mentioned entity is the SAME real-world thing as an existing knowledge-graph entity, or a DIFFERENT thing that happens to share a similar name.
+
+Use the facts as the only evidence. Reasoning patterns:
+- "same" — facts directly identify them (matching dob / email / address / employer) OR facts are non-contradictory and the names are identical / clear aliases.
+- "different" — facts contradict (different dob / different email / different employer at the same time).
+- "unsure" — the facts don't disambiguate either way (just names + occupation, common name).
+
+When unsure, prefer "different" — wrongly fusing two distinct entities is worse than a transient duplicate the off-hours pass can still merge.
+
+Output strictly the JSON shape requested. No preamble.`;
+    const user =
+      `Existing entity facts:\n${existingFacts}\n\n` +
+      `Newly-mentioned entity "${name}" facts:\n${factsB}`;
+
+    const res = await withGenAiCall(
+      {
+        kind: 'chat',
+        spanName: 'gen_ai.chat.inline_resolution',
+        system: 'openai',
+        model: this.model,
+      },
+      this.metrics,
+      () =>
+        this.openai.chat.completions.create({
+          model: this.model,
+          messages: [
+            { role: 'system', content: sys },
+            { role: 'user', content: user },
+          ],
+          response_format: {
+            type: 'json_schema',
+            json_schema: {
+              name: 'resolution_verdict',
+              strict: true,
+              schema: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  verdict: {
+                    type: 'string',
+                    enum: ['same', 'different', 'unsure'],
+                  },
+                },
+                required: ['verdict'],
+              },
+            },
+          },
+          max_completion_tokens: 64,
+          temperature: 0,
+        }),
+    );
+    const content = res.choices[0]?.message?.content;
+    if (!content) return 'unsure';
+    const parsed = JSON.parse(content) as { verdict: unknown };
+    if (
+      parsed.verdict === 'same' ||
+      parsed.verdict === 'different' ||
+      parsed.verdict === 'unsure'
+    ) {
+      return parsed.verdict;
+    }
+    return 'unsure';
+  }
+}

--- a/src/ingest/ingest.module.ts
+++ b/src/ingest/ingest.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { IngestController } from './ingest.controller';
 import { IngestService } from './ingest.service';
 import { IngestPredictionService } from './ingest-predictor.service';
+import { EntityResolverService } from './entity-resolver.service';
 
 @Module({
   controllers: [IngestController],
-  providers: [IngestService, IngestPredictionService],
+  providers: [IngestService, IngestPredictionService, EntityResolverService],
   exports: [IngestService, IngestPredictionService],
 })
 export class IngestModule {}

--- a/src/ingest/ingest.service.ts
+++ b/src/ingest/ingest.service.ts
@@ -69,8 +69,8 @@ export class IngestService {
     private readonly configService: ConfigService,
     private readonly predicateRegistry: PredicateRegistryService,
     @Optional() private readonly metrics?: MetricsService,
-    // @Optional so the positional unit tests (no DI) can omit it; the
-    // mention path simply skips inline resolution when it's absent.
+    // @Optional: when the resolver isn't wired (or its flag is off), the
+    // mention path simply skips inline resolution and creates new as before.
     @Optional() private readonly entityResolver?: EntityResolverService,
   ) {
     this.conflict = {

--- a/src/ingest/ingest.service.ts
+++ b/src/ingest/ingest.service.ts
@@ -19,6 +19,7 @@ import { EmbedderService } from '../ai/embedder.service';
 import { ExtractorService } from '../ai/extractor.service';
 import { HypeService } from '../ai/hype.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
+import { EntityResolverService } from './entity-resolver.service';
 import { IngestFactDto } from './dto/ingest-fact.dto';
 import { IngestMentionDto } from './dto/ingest-mention.dto';
 import { IngestLinkDto } from './dto/ingest-link.dto';
@@ -68,6 +69,9 @@ export class IngestService {
     private readonly configService: ConfigService,
     private readonly predicateRegistry: PredicateRegistryService,
     @Optional() private readonly metrics?: MetricsService,
+    // @Optional so the positional unit tests (no DI) can omit it; the
+    // mention path simply skips inline resolution when it's absent.
+    @Optional() private readonly entityResolver?: EntityResolverService,
   ) {
     this.conflict = {
       similarityThreshold: this.cfgNum('CONFLICT_SIMILARITY_THRESHOLD', 0.85),
@@ -364,6 +368,11 @@ export class IngestService {
         for (let i = 0; i < extraction.entities.length; i++) {
           const e = extraction.entities[i];
           const knownHint = dto.knownEntities?.[i];
+          // The entity's freshly-extracted facts feed the inline-resolution
+          // judge (the "new" side — these aren't written yet).
+          const incomingFacts = extraction.facts
+            .filter((f) => f.entityIndex === i)
+            .map((f) => `${f.predicate}: ${f.object}`);
           const eid = await traceSpan(
             'ingest.entity.resolve',
             () =>
@@ -372,6 +381,7 @@ export class IngestService {
                 e,
                 knownHint,
                 dto.contextRef,
+                incomingFacts,
               ),
             { name: e.name, type: e.type },
           );
@@ -610,6 +620,7 @@ export class IngestService {
     e: { name: string; type: string; canonical?: string },
     hint: { vertical: string; id: string; role?: string } | undefined,
     _contextRef: { vertical: string },
+    incomingFacts: string[] = [],
   ): Promise<string> {
     // 1. Caller hint wins — same atomic upsert as fact ingest.
     if (hint) {
@@ -639,6 +650,21 @@ export class IngestService {
     );
     const nRow = ((nRows as any[]) ?? [])[0];
     if (nRow) return String(nRow.id);
+
+    // 3. Inline entity resolution (graphiti-style, opt-in). Before minting
+    // a new entity, look for a near-duplicate that already exists and let
+    // an LLM judge confirm same-as using the incoming facts. A confirmed
+    // match reuses the existing entity, so the duplicate is never created.
+    // Falls through to create-new when disabled, no match, or any error.
+    if (this.entityResolver?.isEnabled()) {
+      const resolved = await this.entityResolver.resolveByName(
+        db,
+        e.name,
+        this.normalizeEntityType(e.type),
+        incomingFacts,
+      );
+      if (resolved) return resolved;
+    }
 
     const created = await dbCreate<any>(db, 'knowledge_entity', {
       type: this.normalizeEntityType(e.type),

--- a/test/inline-entity-resolution.e2e-spec.ts
+++ b/test/inline-entity-resolution.e2e-spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Inline entity resolution — ingest wiring (end-to-end).
+ *
+ * Verifies the mention path honours EntityResolverService's verdict:
+ *   - resolver says "reuse <id>" → the second mention's facts land on the
+ *     EXISTING entity; no near-duplicate entity is created.
+ *   - resolver says "create new" (null) → a distinct entity is minted, as
+ *     before the feature.
+ *
+ * The resolver's own cosine+LLM logic is unit-tested; here we stub
+ * resolveByName (the embedder stub gives ~0 cosine for differing text, and
+ * we don't want a live LLM) and assert the INGEST side reacts correctly.
+ */
+process.env.INGEST_INLINE_RESOLUTION_ENABLED = '1';
+
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { EntityResolverService } from '../src/ingest/entity-resolver.service';
+
+describe('Inline entity resolution — mention ingest wiring', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const ingestMention = async (text: string) => {
+    const res = await f.http
+      .post('/v1/ingest/mention')
+      .set(auth())
+      .send({
+        text,
+        contextRef: { vertical: 'rent', conversationId: 'conv_inline' },
+        emittedAt: new Date().toISOString(),
+      });
+    expect(res.status).toBe(201);
+    return res.body;
+  };
+
+  const entityIdByName = async (name: string): Promise<string | null> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<any[][]>(
+        `SELECT id FROM knowledge_entity WHERE canonicalName = $name`,
+        { name },
+      );
+      const arr = (rows as any[]) ?? [];
+      return arr.length ? String(arr[0].id) : null;
+    });
+  };
+
+  const countByName = async (name: string): Promise<number> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<any[][]>(
+        `SELECT id FROM knowledge_entity WHERE canonicalName = $name`,
+        { name },
+      );
+      return ((rows as any[]) ?? []).length;
+    });
+  };
+
+  const predicatesOf = async (entityId: string): Promise<string[]> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<any[][]>(
+        `SELECT predicate FROM knowledge_fact
+           WHERE entityId = type::thing('knowledge_entity', $tail)`,
+        { tail: entityId.split(':')[1] },
+      );
+      return ((rows as any[]) ?? []).map((r) => String(r.predicate));
+    });
+  };
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_inline_resolution_e2e' });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+    jest.restoreAllMocks();
+  });
+
+  it('reuses the existing entity when the resolver confirms a match', async () => {
+    // Mention 1 → mints "Acme Inc" with an `industry` fact.
+    f.extractor.setScript({
+      entities: [{ name: 'Acme Inc', type: 'customer' }],
+      facts: [
+        { entityIndex: 0, predicate: 'industry', object: 'software', confidence: 0.9 },
+      ],
+      edges: [],
+    });
+    await ingestMention('first mention about acme');
+    const acmeId = await entityIdByName('Acme Inc');
+    expect(acmeId).toBeTruthy();
+
+    // Resolver confirms the near-duplicate is the same entity.
+    const resolver = f.app.get(EntityResolverService);
+    jest.spyOn(resolver, 'resolveByName').mockResolvedValue(acmeId);
+
+    // Mention 2 → different surface name + a `tier` fact.
+    f.extractor.setScript({
+      entities: [{ name: 'Acme Incorporated', type: 'customer' }],
+      facts: [
+        { entityIndex: 0, predicate: 'tier', object: 'gold', confidence: 0.9 },
+      ],
+      edges: [],
+    });
+    await ingestMention('second mention about acme incorporated');
+
+    // No duplicate entity, and the tier fact landed on the original.
+    expect(await countByName('Acme Incorporated')).toBe(0);
+    const preds = await predicatesOf(acmeId!);
+    expect(preds).toContain('industry');
+    expect(preds).toContain('tier');
+  });
+
+  it('mints a distinct entity when the resolver declines', async () => {
+    const resolver = f.app.get(EntityResolverService);
+    jest.spyOn(resolver, 'resolveByName').mockResolvedValue(null);
+
+    f.extractor.setScript({
+      entities: [{ name: 'Globex Ltd', type: 'customer' }],
+      facts: [
+        { entityIndex: 0, predicate: 'tier', object: 'silver', confidence: 0.9 },
+      ],
+      edges: [],
+    });
+    await ingestMention('globex first');
+
+    f.extractor.setScript({
+      entities: [{ name: 'Globex Limited', type: 'customer' }],
+      facts: [
+        { entityIndex: 0, predicate: 'tier', object: 'gold', confidence: 0.9 },
+      ],
+      edges: [],
+    });
+    await ingestMention('globex second');
+
+    // Resolver said "new" → a separate entity exists.
+    expect(await countByName('Globex Ltd')).toBe(1);
+    expect(await countByName('Globex Limited')).toBe(1);
+  });
+});

--- a/test/inline-entity-resolution.unit-spec.ts
+++ b/test/inline-entity-resolution.unit-spec.ts
@@ -1,0 +1,118 @@
+/**
+ * EntityResolverService — inline entity resolution logic (unit).
+ *
+ * Pins the two-zone routing + judge handling that decides whether an
+ * extracted entity reuses an existing one (no duplicate) or creates new:
+ *   - disabled → always null (create new), no DB / LLM touched
+ *   - no candidate above the cosine floor → null
+ *   - candidate of a DIFFERENT type → ignored
+ *   - candidate ok + judge "same" → reuse existing id
+ *   - judge "different" / "unsure" → null
+ *   - any judge error → null (never blocks ingest)
+ */
+import { EntityResolverService } from '../src/ingest/entity-resolver.service';
+
+type Cfg = Record<string, string>;
+
+function makeService(
+  cfg: Cfg,
+): {
+  svc: EntityResolverService;
+  db: { query: jest.Mock };
+  openai: { chat: { completions: { create: jest.Mock } } };
+} {
+  const config = {
+    get: (k: string, d?: string) => (k in cfg ? cfg[k] : d),
+  } as any;
+  const embedder = { embed: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]) } as any;
+  const svc = new EntityResolverService(config, embedder);
+  const openai = {
+    chat: { completions: { create: jest.fn() } },
+  };
+  // Inject a fake OpenAI client (constructor built one from the api key).
+  (svc as any).openai = openai;
+  const db = { query: jest.fn() };
+  return { svc, db, openai };
+}
+
+const ENABLED: Cfg = {
+  INGEST_INLINE_RESOLUTION_ENABLED: '1',
+  INGEST_INLINE_RESOLUTION_COSINE_FLOOR: '0.85',
+  OPENAI_API_KEY: 'sk-test',
+};
+
+function verdict(v: string) {
+  return { choices: [{ message: { content: JSON.stringify({ verdict: v }) } }] };
+}
+
+describe('EntityResolverService.resolveByName', () => {
+  it('returns null and touches nothing when disabled', async () => {
+    const { svc, db } = makeService({
+      ...ENABLED,
+      INGEST_INLINE_RESOLUTION_ENABLED: '0',
+    });
+    const out = await svc.resolveByName(db as any, 'Acme', 'customer', []);
+    expect(out).toBeNull();
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no candidate clears the cosine floor', async () => {
+    const { svc, db, openai } = makeService(ENABLED);
+    db.query.mockResolvedValueOnce([
+      [{ entityId: 'knowledge_entity:a', etype: 'customer', sim: 0.7 }],
+    ]);
+    const out = await svc.resolveByName(db as any, 'Acme', 'customer', []);
+    expect(out).toBeNull();
+    expect(openai.chat.completions.create).not.toHaveBeenCalled();
+  });
+
+  it('ignores a high-cosine candidate of a different type', async () => {
+    const { svc, db, openai } = makeService(ENABLED);
+    db.query.mockResolvedValueOnce([
+      [{ entityId: 'knowledge_entity:a', etype: 'asset', sim: 0.97 }],
+    ]);
+    const out = await svc.resolveByName(db as any, 'Acme', 'customer', []);
+    expect(out).toBeNull();
+    expect(openai.chat.completions.create).not.toHaveBeenCalled();
+  });
+
+  it('reuses the existing entity when the judge says "same"', async () => {
+    const { svc, db, openai } = makeService(ENABLED);
+    db.query
+      .mockResolvedValueOnce([
+        [{ entityId: 'knowledge_entity:x', etype: 'customer', sim: 0.95 }],
+      ])
+      .mockResolvedValueOnce([[{ predicate: 'dob', object: '1990-01-01' }]]);
+    openai.chat.completions.create.mockResolvedValue(verdict('same'));
+    const out = await svc.resolveByName(db as any, 'Acme', 'customer', [
+      'dob: 1990-01-01',
+    ]);
+    expect(out).toBe('knowledge_entity:x');
+  });
+
+  it('creates new (null) when the judge says "different"', async () => {
+    const { svc, db, openai } = makeService(ENABLED);
+    db.query
+      .mockResolvedValueOnce([
+        [{ entityId: 'knowledge_entity:x', etype: 'customer', sim: 0.95 }],
+      ])
+      .mockResolvedValueOnce([[{ predicate: 'dob', object: '1980-01-01' }]]);
+    openai.chat.completions.create.mockResolvedValue(verdict('different'));
+    const out = await svc.resolveByName(db as any, 'John Smith', 'customer', [
+      'dob: 1990-01-01',
+    ]);
+    expect(out).toBeNull();
+  });
+
+  it('falls back to null when the judge throws', async () => {
+    const { svc, db, openai } = makeService(ENABLED);
+    db.query
+      .mockResolvedValueOnce([
+        [{ entityId: 'knowledge_entity:x', etype: 'customer', sim: 0.95 }],
+      ])
+      .mockResolvedValueOnce([[{ predicate: 'dob', object: '1990' }]]);
+    openai.chat.completions.create.mockRejectedValue(new Error('LLM down'));
+    const out = await svc.resolveByName(db as any, 'Acme', 'customer', []);
+    expect(out).toBeNull();
+  });
+});

--- a/test/inline-entity-resolution.unit-spec.ts
+++ b/test/inline-entity-resolution.unit-spec.ts
@@ -90,6 +90,20 @@ describe('EntityResolverService.resolveByName', () => {
     expect(out).toBe('knowledge_entity:x');
   });
 
+  it('creates new (null) when the judge says "unsure"', async () => {
+    const { svc, db, openai } = makeService(ENABLED);
+    db.query
+      .mockResolvedValueOnce([
+        [{ entityId: 'knowledge_entity:x', etype: 'customer', sim: 0.95 }],
+      ])
+      .mockResolvedValueOnce([[{ predicate: 'occupation', object: 'lawyer' }]]);
+    openai.chat.completions.create.mockResolvedValue(verdict('unsure'));
+    const out = await svc.resolveByName(db as any, 'John Smith', 'customer', [
+      'occupation: lawyer',
+    ]);
+    expect(out).toBeNull();
+  });
+
   it('creates new (null) when the judge says "different"', async () => {
     const { svc, db, openai } = makeService(ENABLED);
     db.query


### PR DESCRIPTION
## Context

Third and final item from the graphiti audit. Today brain resolves entities at write time only by hard keys: `externalRef (vertical:id)` → exact `canonicalNameLc` → otherwise **create new**. Near-duplicates ("Acme Inc" vs "Acme Incorporated", typos) are only reconciled by the nightly `dreams` dedup → a duplicate window of up to a day.

graphiti resolves at extraction time so the duplicate is never created. This ports that, as a thin layer over the existing dedup judge.

## What's in this PR

- **`EntityResolverService`** (`src/ingest/entity-resolver.service.ts`): on the free-text mention path, before minting a new entity for an extracted name that missed the exact match — cosine k-NN over existing `name`-fact embeddings (same type, ≥ floor) → LLM judge confirms same-as. Crucially the judge compares the **existing entity's stored facts** vs the **incoming mention's freshly-extracted facts** (the new entity isn't written yet — its evidence comes from extraction). A confirmed match reuses the existing entity; the near-duplicate is never created.
- **Why a judge, not bare cosine:** two different "John Smith"s have near-identical name embeddings and the same type — merging on cosine alone would wrongly fuse them. The judge looks at facts (dob/email/employer) and **prefers "different" when unsure**.
- **Hook**: `resolveOrCreateNamedEntity` between exact-name miss and create-new; `runIngestMention` threads each entity's extracted facts in.
- **Safety**: gated by `INGEST_INLINE_RESOLUTION_ENABLED` (default **off**). Any error/timeout → create-new; never blocks ingest. Structured `POST /v1/ingest/fact` (explicit `vertical:id`) is untouched.
- **Known residual** (documented): two truly-concurrent first creations still race — the same window as today's exact-name match, not a new class; dreams still backstops. Cross-request pending-cache (graphiti's race-guard) deferred.

## Scope
Mention path only (already LLM-heavy). The off-hours `dreams` dedup is unchanged and continues to catch anything inline resolution leaves behind.

## Tests / gates
- Unit (`inline-entity-resolution.unit-spec`): two-zone routing + judge verdicts (disabled / no-candidate / wrong-type / same / different / judge-error) — 6.
- e2e (`inline-entity-resolution.e2e-spec`): resolver-confirms-match → facts land on the existing entity, no duplicate; resolver-declines → distinct entity minted — 2.
- `tsc --noEmit` clean, `lint` clean, full unit suite **625 pass**, ingest/mention/sota e2e regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)