### PR TITLE
refactor: shared EntityJudgeService (dedup + inline resolution)

### DIFF
--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -13,6 +13,7 @@ import { ExtractionPatternService } from './extraction-pattern.service';
 import { CalibrationService } from './calibration/calibration.service';
 import { CalibrationRefitService } from './calibration/calibration-refit.service';
 import { ReindexEmbeddingsService } from './embedder/reindex-embeddings.service';
+import { EntityJudgeService } from './entity-judge.service';
 import { ScheduleModule } from '@nestjs/schedule';
 
 @Global()
@@ -33,6 +34,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     CalibrationService,
     CalibrationRefitService,
     ReindexEmbeddingsService,
+    EntityJudgeService,
   ],
   exports: [
     EmbedderService,
@@ -49,6 +51,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     CalibrationService,
     CalibrationRefitService,
     ReindexEmbeddingsService,
+    EntityJudgeService,
   ],
 })
 export class AiModule {}

--- a/src/ai/entity-judge.service.ts
+++ b/src/ai/entity-judge.service.ts
@@ -1,0 +1,188 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Surreal, StringRecordId } from 'surrealdb';
+import OpenAI from 'openai';
+import { MetricsService } from '../metrics/metrics.service';
+import { Semaphore } from '../common/semaphore';
+import { withGenAiCall } from '../common/gen-ai-observability';
+
+export type EntityVerdict = 'same' | 'different' | 'unsure';
+
+/**
+ * EntityJudgeService — the single LLM "are these two entities the same
+ * real-world thing?" decision, shared by:
+ *   - the off-hours dreams dedup (candidate name-pairs), and
+ *   - inline entity resolution at ingest (an extracted entity vs an
+ *     existing one).
+ *
+ * Both used to carry their own OpenAI client + Semaphore + judge prompt +
+ * fetchTopFacts; this consolidates them so the reasoning rules and tuning
+ * evolve in one place. Lives in the @Global AiModule, so any caller injects
+ * it directly.
+ *
+ * The verdict is fact-driven and conservative: when the facts don't
+ * disambiguate, it returns "unsure" and the prompt biases toward
+ * "different" — wrongly fusing two distinct entities is worse than a
+ * transient duplicate a later pass can still merge. Any LLM/parse failure
+ * degrades to "unsure" (never throws), so callers never block on it.
+ */
+@Injectable()
+export class EntityJudgeService {
+  private readonly logger = new Logger(EntityJudgeService.name);
+  private readonly openai: OpenAI;
+  private readonly model: string;
+  private readonly limiter: Semaphore;
+
+  constructor(
+    private readonly config: ConfigService,
+    @Optional() private readonly metrics?: MetricsService,
+  ) {
+    const apiKey = this.config.get<string>('OPENAI_API_KEY');
+    this.openai = apiKey
+      ? new OpenAI({
+          apiKey,
+          timeout: parseInt(
+            this.config.get<string>('OPENAI_TIMEOUT_MS', '30000'),
+            10,
+          ),
+          maxRetries: parseInt(
+            this.config.get<string>('OPENAI_MAX_RETRIES', '3'),
+            10,
+          ),
+        })
+      : (undefined as unknown as OpenAI);
+    this.model = this.config.get<string>(
+      'ENTITY_JUDGE_MODEL',
+      this.config.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),
+    );
+    // Shared judge concurrency. Falls back to the legacy DREAMS_DEDUP knob
+    // so existing operator tuning keeps working after the consolidation.
+    this.limiter = new Semaphore(
+      parseInt(
+        this.config.get<string>(
+          'ENTITY_JUDGE_CONCURRENCY',
+          this.config.get<string>('DREAMS_DEDUP_CONCURRENCY', '4'),
+        ),
+        10,
+      ),
+    );
+  }
+
+  /** True when an OpenAI key is configured (so a judge call is possible). */
+  isAvailable(): boolean {
+    return !!this.openai;
+  }
+
+  /**
+   * Top active facts for an entity, rendered as `- predicate: object`
+   * lines — the judge's evidence for one side. Shared by both call sites.
+   */
+  async fetchTopFacts(db: Surreal, entityId: string): Promise<string> {
+    type R = { predicate: string; object: string };
+    const [rows] = await db.query<[R[]]>(
+      `SELECT predicate, object FROM knowledge_fact
+         WHERE entityId = $eid
+           AND status = 'active'
+           AND retractedAt IS NONE
+         ORDER BY confidence DESC
+         LIMIT 5`,
+      { eid: new StringRecordId(entityId) },
+    );
+    const r = (rows as R[]) ?? [];
+    if (r.length === 0) return '(no facts)';
+    return r.map((f) => `- ${f.predicate}: ${f.object}`).join('\n');
+  }
+
+  /**
+   * Decide whether the two fact-blocks describe the same entity. Runs under
+   * the shared concurrency limiter. Returns "unsure" on any failure.
+   *
+   * @param left   rendered facts for side A (e.g. an existing entity)
+   * @param right  rendered facts for side B (e.g. the incoming mention)
+   * @param ctx.cosine optional name cosine-similarity hint for the prompt
+   */
+  async judge(
+    left: string,
+    right: string,
+    ctx: { cosine?: number } = {},
+  ): Promise<EntityVerdict> {
+    if (!this.openai) return 'unsure';
+    try {
+      return await this.limiter.run(() => this.callLLM(left, right, ctx));
+    } catch (err) {
+      this.logger.warn(`entity judge failed: ${(err as Error).message}`);
+      return 'unsure';
+    }
+  }
+
+  private async callLLM(
+    left: string,
+    right: string,
+    ctx: { cosine?: number },
+  ): Promise<EntityVerdict> {
+    const sys = `You decide whether two knowledge-graph entities are the SAME real-world thing or DIFFERENT things that happen to share a similar name.
+
+Use the facts as the only evidence:
+- "same" — facts directly identify them (matching dob / email / address / employer) OR facts are non-contradictory and the names are identical / clear aliases.
+- "different" — facts contradict (different dob / different email / different employer at the same time).
+- "unsure" — the facts don't disambiguate either way (just names + occupation, common name).
+
+When unsure, prefer "different" — wrongly fusing two distinct entities is worse than a transient duplicate a later pass can still merge.
+
+Output strictly the JSON shape requested. No preamble.`;
+    const cosineLine =
+      typeof ctx.cosine === 'number'
+        ? `\n\nCosine name-similarity: ${ctx.cosine.toFixed(3)}.`
+        : '';
+    const user = `Entity A:\n${left}\n\nEntity B:\n${right}${cosineLine}`;
+
+    const res = await withGenAiCall(
+      {
+        kind: 'chat',
+        spanName: 'gen_ai.chat.entity_judge',
+        system: 'openai',
+        model: this.model,
+      },
+      this.metrics,
+      () =>
+        this.openai.chat.completions.create({
+          model: this.model,
+          messages: [
+            { role: 'system', content: sys },
+            { role: 'user', content: user },
+          ],
+          response_format: {
+            type: 'json_schema',
+            json_schema: {
+              name: 'entity_judge_verdict',
+              strict: true,
+              schema: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  verdict: {
+                    type: 'string',
+                    enum: ['same', 'different', 'unsure'],
+                  },
+                },
+                required: ['verdict'],
+              },
+            },
+          },
+          max_completion_tokens: 64,
+          temperature: 0,
+        }),
+    );
+    const content = res.choices[0]?.message?.content;
+    if (!content) return 'unsure';
+    const parsed = JSON.parse(content) as { verdict: unknown };
+    if (
+      parsed.verdict === 'same' ||
+      parsed.verdict === 'different' ||
+      parsed.verdict === 'unsure'
+    ) {
+      return parsed.verdict;
+    }
+    return 'unsure';
+  }
+}

--- a/src/dreams/dedup.service.ts
+++ b/src/dreams/dedup.service.ts
@@ -1,11 +1,9 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Surreal, StringRecordId } from 'surrealdb';
-import OpenAI from 'openai';
 import { EmbedderService } from '../ai/embedder.service';
-import { withGenAiCall } from '../common/gen-ai-observability';
+import { EntityJudgeService } from '../ai/entity-judge.service';
 import { MetricsService } from '../metrics/metrics.service';
-import { Semaphore } from '../common/semaphore';
 import { withSpan } from '../common/tracing';
 
 /**
@@ -55,38 +53,18 @@ export interface DedupResult {
 @Injectable()
 export class DreamsDedupService {
   private readonly logger = new Logger(DreamsDedupService.name);
-  private readonly openai: OpenAI;
   private readonly enabled: boolean;
-  private readonly model: string;
   private readonly cosineThreshold: number;
   private readonly maxPairs: number;
-  private readonly limiter: Semaphore;
 
   constructor(
     private readonly configService: ConfigService,
     private readonly embedder: EmbedderService,
+    private readonly judge: EntityJudgeService,
     @Optional() private readonly metrics?: MetricsService,
   ) {
     this.enabled =
       this.configService.get<string>('DREAMS_DEDUP_ENABLED', '0') === '1';
-    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
-    this.openai = apiKey
-      ? new OpenAI({
-          apiKey,
-          timeout: parseInt(
-            this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-            10,
-          ),
-          maxRetries: parseInt(
-            this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-            10,
-          ),
-        })
-      : (undefined as unknown as OpenAI);
-    this.model = this.configService.get<string>(
-      'DREAMS_DEDUP_MODEL',
-      this.configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),
-    );
     this.cosineThreshold = parseFloat(
       this.configService.get<string>('DREAMS_DEDUP_COSINE_THRESHOLD', '0.92'),
     );
@@ -94,16 +72,10 @@ export class DreamsDedupService {
       this.configService.get<string>('DREAMS_DEDUP_MAX_PAIRS', '50'),
       10,
     );
-    this.limiter = new Semaphore(
-      parseInt(
-        this.configService.get<string>('DREAMS_DEDUP_CONCURRENCY', '4'),
-        10,
-      ),
-    );
   }
 
   isEnabled(): boolean {
-    return this.enabled && !!this.openai;
+    return this.enabled && this.judge.isAvailable();
   }
 
   /**
@@ -135,10 +107,11 @@ export class DreamsDedupService {
       const exists = await this.identityEdgeExists(db, cand.aId, cand.bId);
       if (exists) continue;
 
-      const verdict = await withSpan(
-        'dreams.dedup.judge',
-        () => this.limiter.run(() => this.judge(db, cand)),
-      );
+      const verdict = await withSpan('dreams.dedup.judge', async () => {
+        const factsA = await this.judge.fetchTopFacts(db, cand.aId);
+        const factsB = await this.judge.fetchTopFacts(db, cand.bId);
+        return this.judge.judge(factsA, factsB, { cosine: cand.cosine });
+      });
       result.llmJudgements++;
       if (verdict === 'same') {
         await this.linkIdentity(db, cand.aId, cand.bId);
@@ -236,101 +209,6 @@ export class DreamsDedupService {
       },
     );
     return ((rows as Array<{ id: unknown }>) ?? []).length > 0;
-  }
-
-  /**
-   * Ask the LLM whether two entities (with a few facts each) are
-   * likely the same real-world thing. Strict JSON schema, identity-
-   * fallback `unsure` on any parsing failure.
-   */
-  private async judge(
-    db: Surreal,
-    cand: DedupCandidate,
-  ): Promise<'same' | 'different' | 'unsure'> {
-    const factsA = await this.fetchTopFacts(db, cand.aId);
-    const factsB = await this.fetchTopFacts(db, cand.bId);
-
-    const sys = `You decide whether two knowledge-graph entities are the SAME real-world thing or DIFFERENT things that happen to share a similar name.
-
-Use the facts as the only evidence. Reasoning patterns:
-- "same" — facts directly identify them (matching dob / email / address) OR facts are non-contradictory and the names are identical / clear aliases.
-- "different" — facts contradict (different dob / different email / different employer at same time).
-- "unsure" — the facts don't disambiguate either way (just names + occupation, common name).
-
-Output strictly the JSON shape requested. No preamble.`;
-    const user =
-      `Entity A:\n${factsA}\n\n` +
-      `Entity B:\n${factsB}\n\n` +
-      `Cosine name-similarity: ${cand.cosine.toFixed(3)}.`;
-
-    try {
-      const res = await withGenAiCall(
-        {
-          kind: 'chat',
-          spanName: 'gen_ai.chat.dreams_dedup',
-          system: 'openai',
-          model: this.model,
-        },
-        this.metrics,
-        () => this.openai.chat.completions.create({
-        model: this.model,
-        messages: [
-          { role: 'system', content: sys },
-          { role: 'user', content: user },
-        ],
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            name: 'dedup_verdict',
-            strict: true,
-            schema: {
-              type: 'object',
-              additionalProperties: false,
-              properties: {
-                verdict: {
-                  type: 'string',
-                  enum: ['same', 'different', 'unsure'],
-                },
-              },
-              required: ['verdict'],
-            },
-          },
-        },
-        max_completion_tokens: 64,
-        temperature: 0,
-      }),
-      );
-      const content = res.choices[0]?.message?.content;
-      if (!content) return 'unsure';
-      const parsed = JSON.parse(content) as { verdict: unknown };
-      if (
-        parsed.verdict === 'same' ||
-        parsed.verdict === 'different' ||
-        parsed.verdict === 'unsure'
-      ) {
-        return parsed.verdict;
-      }
-      return 'unsure';
-    } catch (err) {
-      this.logger.warn(`Dedup judge failed: ${(err as Error).message}`);
-      return 'unsure';
-    }
-  }
-
-  private async fetchTopFacts(db: Surreal, entityId: string): Promise<string> {
-    type R = { predicate: string; object: string };
-    const [rows] = await db.query<[R[]]>(
-      `SELECT predicate, object, confidence FROM knowledge_fact
-       WHERE entityId = $eid
-         AND status = 'active'
-         AND retractedAt IS NONE
-       ORDER BY confidence DESC
-       LIMIT 5`,
-      { eid: new StringRecordId(entityId) },
-    );
-    const r = (rows as R[]) ?? [];
-    if (r.length === 0) return '(no facts)';
-    return r.map((f) => `- ${f.predicate}: ${f.object}`).join('\n');
   }
 
   private async linkIdentity(

--- a/src/ingest/entity-resolver.service.ts
+++ b/src/ingest/entity-resolver.service.ts
@@ -1,83 +1,52 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Surreal, StringRecordId } from 'surrealdb';
-import OpenAI from 'openai';
+import { Surreal } from 'surrealdb';
 import { EmbedderService } from '../ai/embedder.service';
-import { MetricsService } from '../metrics/metrics.service';
-import { Semaphore } from '../common/semaphore';
-import { withGenAiCall } from '../common/gen-ai-observability';
+import { EntityJudgeService } from '../ai/entity-judge.service';
 
 /**
  * EntityResolverService — inline entity resolution at ingest time
  * (graphiti-style). Before the mention pipeline mints a NEW entity for an
  * extracted name that missed the exact canonicalName match, we look for a
- * near-duplicate that already exists and, when an LLM judge confirms it's
- * the same real-world thing, reuse it — so the duplicate is never created.
+ * near-duplicate that already exists and, when the shared EntityJudge
+ * confirms it's the same real-world thing, reuse it — so the duplicate is
+ * never created.
  *
- * Why an LLM judge and not bare cosine: two different "John Smith"s have
+ * Why a judge and not bare cosine: two different "John Smith"s have
  * near-identical name embeddings and the same type; merging on cosine
  * alone would wrongly fuse them. The judge looks at the FACTS (dob /
  * email / employer) — the existing entity's stored facts vs the incoming
- * mention's freshly-extracted facts (already in memory, not yet written)
- * — exactly as the off-hours dreams dedup does, just for one pair, inline.
+ * mention's freshly-extracted facts (already in memory, not yet written).
  *
  * Scope: the free-text mention path only. Structured `POST /v1/ingest/fact`
  * with an explicit `vertical:id` stays authoritative (externalRef).
  *
- * Gated by INGEST_INLINE_RESOLUTION_ENABLED (default off). Any failure /
- * timeout falls back to "create new" — inline resolution must never block
- * or fail an ingest.
+ * Gated by INGEST_INLINE_RESOLUTION_ENABLED (default off). Any failure
+ * falls back to "create new" — inline resolution must never block ingest.
  *
  * Provenance (deliberate, graphiti-parity): a confirmed match REUSES the
  * existing entity rather than creating a duplicate + an `identity_of` edge
  * the way the off-hours dreams dedup does. So there is no reversible merge
  * edge to unlink — the trade-off for never materialising the duplicate.
  * Mitigations: the judge prefers "different" when unsure; each ingested
- * fact still carries its own `source` (messageId / vertical), so per-fact
- * origin is auditable; and the decision is logged. If a wrong fuse is ever
- * a concern for a tenant, leave the flag off and rely on dreams (reversible
- * edges) instead.
- *
- * DEDUP NOTE: the LLM judge + fetchTopFacts + OpenAI/Semaphore setup mirror
- * DreamsDedupService (one-pair vs candidate-scan framing). Extracting a
- * shared EntityJudge that serves both call sites is tracked as a follow-up;
- * kept duplicated here to keep this feature PR off the dreams hot path.
+ * fact still carries its own `source`; the decision is logged; and the
+ * flag is off by default (operators wanting reversible merges keep it off
+ * and rely on dreams).
  */
 @Injectable()
 export class EntityResolverService {
   private readonly logger = new Logger(EntityResolverService.name);
-  private readonly openai: OpenAI;
   private readonly enabled: boolean;
-  private readonly model: string;
   private readonly cosineFloor: number;
   private readonly candidateK: number;
-  private readonly limiter: Semaphore;
 
   constructor(
     private readonly config: ConfigService,
     private readonly embedder: EmbedderService,
-    @Optional() private readonly metrics?: MetricsService,
+    private readonly judge: EntityJudgeService,
   ) {
     this.enabled =
       this.config.get<string>('INGEST_INLINE_RESOLUTION_ENABLED', '0') === '1';
-    const apiKey = this.config.get<string>('OPENAI_API_KEY');
-    this.openai = apiKey
-      ? new OpenAI({
-          apiKey,
-          timeout: parseInt(
-            this.config.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-            10,
-          ),
-          maxRetries: parseInt(
-            this.config.get<string>('OPENAI_MAX_RETRIES', '3'),
-            10,
-          ),
-        })
-      : (undefined as unknown as OpenAI);
-    this.model = this.config.get<string>(
-      'INGEST_INLINE_RESOLUTION_MODEL',
-      this.config.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),
-    );
     this.cosineFloor = parseFloat(
       this.config.get<string>('INGEST_INLINE_RESOLUTION_COSINE_FLOOR', '0.85'),
     );
@@ -85,16 +54,10 @@ export class EntityResolverService {
       this.config.get<string>('INGEST_INLINE_RESOLUTION_CANDIDATES', '5'),
       10,
     );
-    this.limiter = new Semaphore(
-      parseInt(
-        this.config.get<string>('INGEST_INLINE_RESOLUTION_CONCURRENCY', '4'),
-        10,
-      ),
-    );
   }
 
   isEnabled(): boolean {
-    return this.enabled && !!this.openai;
+    return this.enabled && this.judge.isAvailable();
   }
 
   /**
@@ -117,10 +80,14 @@ export class EntityResolverService {
       const candidate = await this.findBestNameCandidate(db, name, type);
       if (!candidate) return null;
 
-      const existingFacts = await this.fetchTopFacts(db, candidate.entityId);
-      const verdict = await this.limiter.run(() =>
-        this.judge(name, existingFacts, incomingFacts),
-      );
+      const existingFacts = await this.judge.fetchTopFacts(db, candidate.entityId);
+      const incoming =
+        incomingFacts.length > 0
+          ? incomingFacts.map((f) => `- ${f}`).join('\n')
+          : '(no facts)';
+      const verdict = await this.judge.judge(existingFacts, incoming, {
+        cosine: candidate.cosine,
+      });
       if (verdict === 'same') {
         this.logger.log(
           `[ingest.inline_resolution] reused ${candidate.entityId} for "${name}" ` +
@@ -169,99 +136,5 @@ export class EntityResolverService {
       return { entityId: String(r.entityId), cosine: r.sim };
     }
     return null;
-  }
-
-  private async fetchTopFacts(db: Surreal, entityId: string): Promise<string> {
-    type R = { predicate: string; object: string };
-    const [rows] = await db.query<[R[]]>(
-      `SELECT predicate, object FROM knowledge_fact
-         WHERE entityId = $eid
-           AND status = 'active'
-           AND retractedAt IS NONE
-         ORDER BY confidence DESC
-         LIMIT 5`,
-      { eid: new StringRecordId(entityId) },
-    );
-    const r = (rows as R[]) ?? [];
-    if (r.length === 0) return '(no facts)';
-    return r.map((f) => `- ${f.predicate}: ${f.object}`).join('\n');
-  }
-
-  /**
-   * LLM same/different/unsure verdict — the dreams dedup judge, one pair.
-   * factsB is the incoming mention's extracted facts (the entity isn't in
-   * the graph yet, so its disambiguating evidence comes from extraction).
-   */
-  private async judge(
-    name: string,
-    existingFacts: string,
-    incomingFacts: string[],
-  ): Promise<'same' | 'different' | 'unsure'> {
-    const factsB =
-      incomingFacts.length > 0
-        ? incomingFacts.map((f) => `- ${f}`).join('\n')
-        : '(no facts)';
-    const sys = `You decide whether a newly-mentioned entity is the SAME real-world thing as an existing knowledge-graph entity, or a DIFFERENT thing that happens to share a similar name.
-
-Use the facts as the only evidence. Reasoning patterns:
-- "same" — facts directly identify them (matching dob / email / address / employer) OR facts are non-contradictory and the names are identical / clear aliases.
-- "different" — facts contradict (different dob / different email / different employer at the same time).
-- "unsure" — the facts don't disambiguate either way (just names + occupation, common name).
-
-When unsure, prefer "different" — wrongly fusing two distinct entities is worse than a transient duplicate the off-hours pass can still merge.
-
-Output strictly the JSON shape requested. No preamble.`;
-    const user =
-      `Existing entity facts:\n${existingFacts}\n\n` +
-      `Newly-mentioned entity "${name}" facts:\n${factsB}`;
-
-    const res = await withGenAiCall(
-      {
-        kind: 'chat',
-        spanName: 'gen_ai.chat.inline_resolution',
-        system: 'openai',
-        model: this.model,
-      },
-      this.metrics,
-      () =>
-        this.openai.chat.completions.create({
-          model: this.model,
-          messages: [
-            { role: 'system', content: sys },
-            { role: 'user', content: user },
-          ],
-          response_format: {
-            type: 'json_schema',
-            json_schema: {
-              name: 'resolution_verdict',
-              strict: true,
-              schema: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  verdict: {
-                    type: 'string',
-                    enum: ['same', 'different', 'unsure'],
-                  },
-                },
-                required: ['verdict'],
-              },
-            },
-          },
-          max_completion_tokens: 64,
-          temperature: 0,
-        }),
-    );
-    const content = res.choices[0]?.message?.content;
-    if (!content) return 'unsure';
-    const parsed = JSON.parse(content) as { verdict: unknown };
-    if (
-      parsed.verdict === 'same' ||
-      parsed.verdict === 'different' ||
-      parsed.verdict === 'unsure'
-    ) {
-      return parsed.verdict;
-    }
-    return 'unsure';
   }
 }

--- a/test/entity-judge.unit-spec.ts
+++ b/test/entity-judge.unit-spec.ts
@@ -1,0 +1,72 @@
+/**
+ * EntityJudgeService — the shared same/different/unsure verdict (unit).
+ *
+ * Pins the contract both dreams dedup and inline resolution rely on:
+ *   - no OpenAI key → unavailable, judge degrades to "unsure"
+ *   - valid verdict parsed through
+ *   - empty / malformed / thrown response → "unsure" (never throws)
+ *   - fetchTopFacts renders facts (or the empty sentinel)
+ */
+import { EntityJudgeService } from '../src/ai/entity-judge.service';
+
+function make(cfg: Record<string, string>) {
+  const config = {
+    get: (k: string, d?: string) => (k in cfg ? cfg[k] : d),
+  } as any;
+  const svc = new EntityJudgeService(config);
+  const openai = { chat: { completions: { create: jest.fn() } } };
+  (svc as any).openai = cfg.OPENAI_API_KEY ? openai : undefined;
+  return { svc, openai };
+}
+
+const verdict = (v: string) => ({
+  choices: [{ message: { content: JSON.stringify({ verdict: v }) } }],
+});
+
+describe('EntityJudgeService', () => {
+  it('is unavailable and returns "unsure" without an API key', async () => {
+    const { svc } = make({});
+    expect(svc.isAvailable()).toBe(false);
+    expect(await svc.judge('a', 'b')).toBe('unsure');
+  });
+
+  it('parses a valid verdict through', async () => {
+    const { svc, openai } = make({ OPENAI_API_KEY: 'sk-test' });
+    expect(svc.isAvailable()).toBe(true);
+    openai.chat.completions.create.mockResolvedValue(verdict('same'));
+    expect(await svc.judge('A facts', 'B facts', { cosine: 0.91 })).toBe('same');
+    // cosine hint reaches the prompt.
+    const arg = openai.chat.completions.create.mock.calls[0][0];
+    expect(JSON.stringify(arg.messages)).toContain('0.910');
+  });
+
+  it('returns "unsure" on empty content', async () => {
+    const { svc, openai } = make({ OPENAI_API_KEY: 'sk-test' });
+    openai.chat.completions.create.mockResolvedValue({
+      choices: [{ message: { content: '' } }],
+    });
+    expect(await svc.judge('a', 'b')).toBe('unsure');
+  });
+
+  it('returns "unsure" when the call throws (never propagates)', async () => {
+    const { svc, openai } = make({ OPENAI_API_KEY: 'sk-test' });
+    openai.chat.completions.create.mockRejectedValue(new Error('429'));
+    expect(await svc.judge('a', 'b')).toBe('unsure');
+  });
+
+  it('fetchTopFacts renders lines, with the empty sentinel', async () => {
+    const { svc } = make({ OPENAI_API_KEY: 'sk-test' });
+    const db = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([
+          [{ predicate: 'dob', object: '1990' }, { predicate: 'city', object: 'NYC' }],
+        ])
+        .mockResolvedValueOnce([[]]),
+    } as any;
+    expect(await svc.fetchTopFacts(db, 'knowledge_entity:x')).toBe(
+      '- dob: 1990\n- city: NYC',
+    );
+    expect(await svc.fetchTopFacts(db, 'knowledge_entity:y')).toBe('(no facts)');
+  });
+});

--- a/test/inline-entity-resolution.unit-spec.ts
+++ b/test/inline-entity-resolution.unit-spec.ts
@@ -1,14 +1,10 @@
 /**
- * EntityResolverService — inline entity resolution logic (unit).
+ * EntityResolverService — inline entity resolution orchestration (unit).
  *
- * Pins the two-zone routing + judge handling that decides whether an
- * extracted entity reuses an existing one (no duplicate) or creates new:
- *   - disabled → always null (create new), no DB / LLM touched
- *   - no candidate above the cosine floor → null
- *   - candidate of a DIFFERENT type → ignored
- *   - candidate ok + judge "same" → reuse existing id
- *   - judge "different" / "unsure" → null
- *   - any judge error → null (never blocks ingest)
+ * After the EntityJudge extraction, the resolver owns only the routing:
+ * cosine candidate search (same type, above floor) → delegate the verdict
+ * to the shared EntityJudgeService → reuse on "same", else create new.
+ * The judge itself is mocked here and unit-tested separately.
  */
 import { EntityResolverService } from '../src/ingest/entity-resolver.service';
 
@@ -16,117 +12,102 @@ type Cfg = Record<string, string>;
 
 function makeService(
   cfg: Cfg,
+  judgeOverrides: Partial<{
+    isAvailable: () => boolean;
+    fetchTopFacts: jest.Mock;
+    judge: jest.Mock;
+  }> = {},
 ): {
   svc: EntityResolverService;
   db: { query: jest.Mock };
-  openai: { chat: { completions: { create: jest.Mock } } };
+  judge: { isAvailable: jest.Mock; fetchTopFacts: jest.Mock; judge: jest.Mock };
 } {
   const config = {
     get: (k: string, d?: string) => (k in cfg ? cfg[k] : d),
   } as any;
   const embedder = { embed: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]) } as any;
-  const svc = new EntityResolverService(config, embedder);
-  const openai = {
-    chat: { completions: { create: jest.fn() } },
+  const judge = {
+    isAvailable: jest.fn(() => judgeOverrides.isAvailable?.() ?? true),
+    fetchTopFacts:
+      judgeOverrides.fetchTopFacts ??
+      jest.fn().mockResolvedValue('- dob: 1990-01-01'),
+    judge: judgeOverrides.judge ?? jest.fn().mockResolvedValue('same'),
   };
-  // Inject a fake OpenAI client (constructor built one from the api key).
-  (svc as any).openai = openai;
+  const svc = new EntityResolverService(config, embedder, judge as any);
   const db = { query: jest.fn() };
-  return { svc, db, openai };
+  return { svc, db, judge };
 }
 
 const ENABLED: Cfg = {
   INGEST_INLINE_RESOLUTION_ENABLED: '1',
   INGEST_INLINE_RESOLUTION_COSINE_FLOOR: '0.85',
-  OPENAI_API_KEY: 'sk-test',
 };
 
-function verdict(v: string) {
-  return { choices: [{ message: { content: JSON.stringify({ verdict: v }) } }] };
+function candidate(sim: number, etype = 'customer') {
+  return [[{ entityId: 'knowledge_entity:x', etype, sim }]];
 }
 
 describe('EntityResolverService.resolveByName', () => {
-  it('returns null and touches nothing when disabled', async () => {
-    const { svc, db } = makeService({
+  it('returns null and touches nothing when the flag is off', async () => {
+    const { svc, db, judge } = makeService({
       ...ENABLED,
       INGEST_INLINE_RESOLUTION_ENABLED: '0',
     });
-    const out = await svc.resolveByName(db as any, 'Acme', 'customer', []);
-    expect(out).toBeNull();
+    expect(await svc.resolveByName(db as any, 'Acme', 'customer', [])).toBeNull();
+    expect(db.query).not.toHaveBeenCalled();
+    expect(judge.judge).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the judge service is unavailable (no key)', async () => {
+    const { svc, db } = makeService(ENABLED, { isAvailable: () => false });
+    expect(await svc.resolveByName(db as any, 'Acme', 'customer', [])).toBeNull();
     expect(db.query).not.toHaveBeenCalled();
   });
 
   it('returns null when no candidate clears the cosine floor', async () => {
-    const { svc, db, openai } = makeService(ENABLED);
-    db.query.mockResolvedValueOnce([
-      [{ entityId: 'knowledge_entity:a', etype: 'customer', sim: 0.7 }],
-    ]);
-    const out = await svc.resolveByName(db as any, 'Acme', 'customer', []);
-    expect(out).toBeNull();
-    expect(openai.chat.completions.create).not.toHaveBeenCalled();
+    const { svc, db, judge } = makeService(ENABLED);
+    db.query.mockResolvedValueOnce(candidate(0.7));
+    expect(await svc.resolveByName(db as any, 'Acme', 'customer', [])).toBeNull();
+    expect(judge.judge).not.toHaveBeenCalled();
   });
 
   it('ignores a high-cosine candidate of a different type', async () => {
-    const { svc, db, openai } = makeService(ENABLED);
-    db.query.mockResolvedValueOnce([
-      [{ entityId: 'knowledge_entity:a', etype: 'asset', sim: 0.97 }],
-    ]);
-    const out = await svc.resolveByName(db as any, 'Acme', 'customer', []);
-    expect(out).toBeNull();
-    expect(openai.chat.completions.create).not.toHaveBeenCalled();
+    const { svc, db, judge } = makeService(ENABLED);
+    db.query.mockResolvedValueOnce(candidate(0.97, 'asset'));
+    expect(await svc.resolveByName(db as any, 'Acme', 'customer', [])).toBeNull();
+    expect(judge.judge).not.toHaveBeenCalled();
   });
 
   it('reuses the existing entity when the judge says "same"', async () => {
-    const { svc, db, openai } = makeService(ENABLED);
-    db.query
-      .mockResolvedValueOnce([
-        [{ entityId: 'knowledge_entity:x', etype: 'customer', sim: 0.95 }],
-      ])
-      .mockResolvedValueOnce([[{ predicate: 'dob', object: '1990-01-01' }]]);
-    openai.chat.completions.create.mockResolvedValue(verdict('same'));
+    const { svc, db, judge } = makeService(ENABLED);
+    db.query.mockResolvedValueOnce(candidate(0.95));
+    judge.judge.mockResolvedValue('same');
     const out = await svc.resolveByName(db as any, 'Acme', 'customer', [
       'dob: 1990-01-01',
     ]);
     expect(out).toBe('knowledge_entity:x');
+    expect(judge.judge).toHaveBeenCalledWith(
+      '- dob: 1990-01-01',
+      '- dob: 1990-01-01',
+      { cosine: 0.95 },
+    );
   });
 
-  it('creates new (null) when the judge says "unsure"', async () => {
-    const { svc, db, openai } = makeService(ENABLED);
-    db.query
-      .mockResolvedValueOnce([
-        [{ entityId: 'knowledge_entity:x', etype: 'customer', sim: 0.95 }],
-      ])
-      .mockResolvedValueOnce([[{ predicate: 'occupation', object: 'lawyer' }]]);
-    openai.chat.completions.create.mockResolvedValue(verdict('unsure'));
-    const out = await svc.resolveByName(db as any, 'John Smith', 'customer', [
-      'occupation: lawyer',
-    ]);
-    expect(out).toBeNull();
-  });
+  it.each(['different', 'unsure'])(
+    'creates new (null) when the judge says "%s"',
+    async (verdict) => {
+      const { svc, db, judge } = makeService(ENABLED);
+      db.query.mockResolvedValueOnce(candidate(0.95));
+      judge.judge.mockResolvedValue(verdict);
+      expect(
+        await svc.resolveByName(db as any, 'John Smith', 'customer', []),
+      ).toBeNull();
+    },
+  );
 
-  it('creates new (null) when the judge says "different"', async () => {
-    const { svc, db, openai } = makeService(ENABLED);
-    db.query
-      .mockResolvedValueOnce([
-        [{ entityId: 'knowledge_entity:x', etype: 'customer', sim: 0.95 }],
-      ])
-      .mockResolvedValueOnce([[{ predicate: 'dob', object: '1980-01-01' }]]);
-    openai.chat.completions.create.mockResolvedValue(verdict('different'));
-    const out = await svc.resolveByName(db as any, 'John Smith', 'customer', [
-      'dob: 1990-01-01',
-    ]);
-    expect(out).toBeNull();
-  });
-
-  it('falls back to null when the judge throws', async () => {
-    const { svc, db, openai } = makeService(ENABLED);
-    db.query
-      .mockResolvedValueOnce([
-        [{ entityId: 'knowledge_entity:x', etype: 'customer', sim: 0.95 }],
-      ])
-      .mockResolvedValueOnce([[{ predicate: 'dob', object: '1990' }]]);
-    openai.chat.completions.create.mockRejectedValue(new Error('LLM down'));
-    const out = await svc.resolveByName(db as any, 'Acme', 'customer', []);
-    expect(out).toBeNull();
+  it('falls back to null when a DB read throws', async () => {
+    const { svc, db } = makeService(ENABLED);
+    db.query.mockRejectedValue(new Error('surreal down'));
+    expect(await svc.resolveByName(db as any, 'Acme', 'customer', [])).toBeNull();
   });
 });


### PR DESCRIPTION
## Context

Follow-up to the inline-resolution review (#21): the LLM same/different/unsure **judge** + `fetchTopFacts` + OpenAI client/Semaphore setup were duplicated between `DreamsDedupService` (off-hours dedup) and `EntityResolverService` (inline ingest). This extracts them into one shared service so the reasoning rules and tuning live in one place.

## What changed

- **New `EntityJudgeService`** (`src/ai/entity-judge.service.ts`, in the `@Global` AiModule): one fact-driven prompt + JSON schema, conservative ("prefer different when unsure"), runs under a single shared concurrency limiter, and **degrades to "unsure" on any LLM/parse failure** (never throws) so callers never block. Exposes `judge(left, right, {cosine?})` + `fetchTopFacts(db, id)` + `isAvailable()`.
- **`DreamsDedupService`** keeps its candidate scan / `identityEdgeExists` / `linkIdentity`; drops its private judge/fetchTopFacts/OpenAI/Semaphore and delegates the verdict.
- **`EntityResolverService`** keeps cosine candidate routing; drops its private judge/OpenAI/Semaphore and delegates the verdict.
- Shared knobs `ENTITY_JUDGE_MODEL` / `ENTITY_JUDGE_CONCURRENCY`, the latter **falling back to `DREAMS_DEDUP_CONCURRENCY`** so existing operator tuning keeps working.

## Behaviour

Unchanged. The unified prompt keeps the same same/different/unsure semantics; dreams still treats unsure as "don't merge", inline still reuses only on "same". The shared judge now bounds total judge concurrency across both call sites (they rarely overlap — dreams runs at 04:00).

## Tests / gates

- New `entity-judge.unit-spec` (verdict parse / unavailable-without-key / empty / error → unsure / fetchTopFacts rendering).
- `inline-entity-resolution.unit-spec` reworked to mock the shared judge.
- `tsc`/`lint` clean, full unit suite **639 pass**, dedup/inline/communities/mention e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)