### PR TITLE
feat(db): move identity-merge, zombie-reap & locale tagging into SurrealDB functions

### DIFF
--- a/src/db/migrations/0037_merge_identity.surql
+++ b/src/db/migrations/0037_merge_identity.surql
@@ -1,0 +1,65 @@
+-- 0037_merge_identity — atomic identity_of merge with server-side cycle guard.
+--
+-- Before this, ingestLink() ran the cycle guard and the mergedInto write as
+-- separate round-trips: a bounded 32-hop TS walk of the survivor's chain,
+-- then (after the RELATE) a standalone `UPDATE ... SET mergedInto`. Two
+-- problems:
+--   1. TOCTOU window. The decision (walk) and the write (merge) were
+--      different network calls, so any interleaving mutation between them
+--      could invalidate the check. The classic failure is a mutual merge
+--      A→B and B→A: both walks observe an empty chain, both commit, and
+--      BOTH entities end up with mergedInto set — so both vanish from
+--      retrieval, since survivor resolution is single-hop
+--      (`WHERE mergedInto IS NONE`).
+--   2. Extra round-trips: up to 32 SELECTs for the walk + 1 UPDATE.
+--
+-- fn::merge_identity folds the whole read-decide-write into one statement
+-- (one transaction):
+--   * self-merge guard,
+--   * a sorted-pair lock row so concurrent reverse merges of the same pair
+--     collide on a single record write — SurrealDB aborts one with a
+--     retryable conflict; the caller's retryOnUniqueViolation re-runs it,
+--     and the second attempt observes the committed merge and trips the
+--     cycle guard. This is what actually serializes the mutual-merge race;
+--     single-transaction atomicity alone does not, because snapshot
+--     isolation would let two reverse merges each read an empty chain.
+--   * a multi-hop cycle guard via the recursive path operator
+--     `$survivor.{1..32+collect}.mergedInto` (bounded to 32 hops, so a
+--     pre-existing cycle can never spin), rejecting the merge when the
+--     survivor already resolves transitively to the loser.
+--
+-- The knowledge_edge `identity_of` record is still RELATEd by ingestLink;
+-- only the cycle check + mergedInto write move here. Calling the function
+-- BEFORE the RELATE preserves the "reject before any write" contract: a
+-- cycle returns merged=false having written nothing.
+
+-- Lock table. SCHEMALESS — the only consumer is fn::merge_identity, keyed by
+-- the sorted "loser|survivor" pair. One tiny row per distinct merged pair.
+DEFINE TABLE IF NOT EXISTS merge_lock SCHEMALESS;
+
+DEFINE FUNCTION OVERWRITE fn::merge_identity(
+    $loser: record<knowledge_entity>,
+    $survivor: record<knowledge_entity>
+) {
+    IF $loser = $survivor {
+        RETURN { merged: false, reason: 'self_merge' };
+    };
+
+    -- Serialize concurrent merges of the same (unordered) pair. A→B and
+    -- B→A both hash to the same lock record, so one of two racing
+    -- transactions aborts with a retryable write conflict.
+    LET $pair = array::sort([<string>$loser, <string>$survivor]);
+    UPSERT type::thing('merge_lock', array::join($pair, '|')) SET at = time::now();
+
+    -- Multi-hop cycle guard. `+collect` returns every mergedInto value along
+    -- the survivor's chain; if the loser is anywhere in it, merging the loser
+    -- into the survivor would close a cycle. `?? []` covers a survivor that
+    -- is itself a root (empty chain).
+    LET $chain = $survivor.{1..32+collect}.mergedInto;
+    IF $loser IN ($chain ?? []) {
+        RETURN { merged: false, reason: 'cycle' };
+    };
+
+    UPDATE $loser SET mergedInto = $survivor, mergedAt = time::now();
+    RETURN { merged: true, reason: NONE };
+};

--- a/src/db/migrations/0037_merge_identity.surql
+++ b/src/db/migrations/0037_merge_identity.surql
@@ -28,13 +28,29 @@
 --     pre-existing cycle can never spin), rejecting the merge when the
 --     survivor already resolves transitively to the loser.
 --
+-- Scope of the serialization guarantee: the pair lock only serializes the
+-- SAME unordered pair, so it fully closes the 2-node mutual race (A→B vs
+-- B→A). A 3+-node race across DISTINCT pairs committed simultaneously
+-- (A→B, B→C, C→A) uses three different lock rows and is NOT serialized — under
+-- snapshot isolation each walk can miss the others and a >2-node cycle can
+-- still form. This is strictly better than the old multi-RTT TS walk (which
+-- was vulnerable to both), not a full fix; multi-node concurrent identity
+-- merges are rare and a later hardening (e.g. a global merge lock or
+-- serializable txn) would close it.
+--
 -- The knowledge_edge `identity_of` record is still RELATEd by ingestLink;
 -- only the cycle check + mergedInto write move here. Calling the function
--- BEFORE the RELATE preserves the "reject before any write" contract: a
--- cycle returns merged=false having written nothing.
+-- BEFORE the RELATE preserves the "reject before any write" contract for
+-- entity/edge state: on a cycle/self-merge it returns merged=false having
+-- written NO entity or edge data. (It may have UPSERTed the internal
+-- merge_lock row — that is a concurrency artifact, not graph state.)
 
 -- Lock table. SCHEMALESS — the only consumer is fn::merge_identity, keyed by
--- the sorted "loser|survivor" pair. One tiny row per distinct merged pair.
+-- the sorted "loser|survivor" pair. One tiny row per distinct attempted pair;
+-- rows are never deleted (the lock has no post-merge value, but is cheap).
+-- If merge volume ever makes this table large, a periodic prune of rows older
+-- than the longest possible merge txn is safe — they only serialize the brief
+-- A→B/B→A window.
 DEFINE TABLE IF NOT EXISTS merge_lock SCHEMALESS;
 
 DEFINE FUNCTION OVERWRITE fn::merge_identity(

--- a/src/db/migrations/0038_reap_zombies.surql
+++ b/src/db/migrations/0038_reap_zombies.surql
@@ -1,0 +1,65 @@
+-- 0038_reap_zombies — atomic, set-based zombie-lease reclamation.
+--
+-- reapZombies() used to SELECT expired 'running' rows and then loop in TS,
+-- issuing one UPDATE per row. Two problems:
+--   1. Two LeaseManager crons (or two pods) could each SELECT the same
+--      expired row before either UPDATE landed, then both rewrite it — a
+--      requeue racing an abandon, or a stale worker's late completion
+--      racing the reaper. The per-row UPDATEs had no "still expired" guard.
+--   2. N round-trips per tick.
+--
+-- fn::reap_zombies does the whole reclamation in two set-based UPDATEs
+-- inside one statement. Each UPDATE re-checks `status = 'running' AND
+-- leaseUntil < now` via the pre-selected id set, so a row another reaper
+-- already flipped is simply not in this call's set (or matches zero rows) —
+-- no double-write. Per-row exponential backoff is computed from the row's
+-- own `attempts` field directly in SET, so no TS loop is needed; the count
+-- of affected rows is returned via array::len.
+--
+-- Behaviour parity with the old TS:
+--   * attempts < max_attempts  → requeue: status='pending', lease cleared,
+--     visibleAfter = now + min(base * 2^(attempts-1) * jitter, 1h),
+--     jitter = 0.5..1.0 (rand::float), error.name='ZombieReclaim'.
+--   * attempts >= max_attempts → abandon: status='failed', finishedAt set,
+--     error.name='ZombieAbandoned'.
+--   * LIMIT 200 per call preserved to bound work per cron tick.
+
+DEFINE FUNCTION OVERWRITE fn::reap_zombies($max_attempts: int, $backoff_base_ms: int) {
+    LET $now = time::now();
+
+    LET $rq_ids = (SELECT VALUE id FROM job_run
+        WHERE status = 'running' AND leaseUntil < $now AND (attempts ?? 1) < $max_attempts
+        LIMIT 200);
+    LET $fl_ids = (SELECT VALUE id FROM job_run
+        WHERE status = 'running' AND leaseUntil < $now AND (attempts ?? 1) >= $max_attempts
+        LIMIT 200);
+
+    LET $rq = UPDATE $rq_ids SET
+        status = 'pending',
+        claimedBy = NONE,
+        leaseUntil = NONE,
+        visibleAfter = time::now() + duration::from::millis(<int> math::floor(math::min([
+            $backoff_base_ms * math::pow(2, (attempts ?? 1) - 1) * (0.5 + rand::float() * 0.5),
+            3600000
+        ]))),
+        error = {
+            message: 'lease expired while held by ' + (claimedBy ?? 'unknown')
+                + '; requeued (attempt ' + <string>(attempts ?? 1) + '/' + <string>$max_attempts + ')',
+            name: 'ZombieReclaim'
+        }
+        RETURN id;
+
+    LET $fl = UPDATE $fl_ids SET
+        status = 'failed',
+        finishedAt = time::now(),
+        claimedBy = NONE,
+        leaseUntil = NONE,
+        error = {
+            message: 'lease expired while held by ' + (claimedBy ?? 'unknown')
+                + '; abandoned after ' + <string>(attempts ?? 1) + ' attempt(s)',
+            name: 'ZombieAbandoned'
+        }
+        RETURN id;
+
+    RETURN { requeued: array::len($rq), failed: array::len($fl) };
+};

--- a/src/db/migrations/0038_reap_zombies.surql
+++ b/src/db/migrations/0038_reap_zombies.surql
@@ -8,33 +8,39 @@
 --      racing the reaper. The per-row UPDATEs had no "still expired" guard.
 --   2. N round-trips per tick.
 --
--- fn::reap_zombies does the whole reclamation in two set-based UPDATEs
--- inside one statement. Each UPDATE re-checks `status = 'running' AND
--- leaseUntil < now` via the pre-selected id set, so a row another reaper
--- already flipped is simply not in this call's set (or matches zero rows) —
--- no double-write. Per-row exponential backoff is computed from the row's
--- own `attempts` field directly in SET, so no TS loop is needed; the count
--- of affected rows is returned via array::len.
+-- fn::reap_zombies does the whole reclamation as two set-based UPDATEs inside
+-- one statement. Both UPDATEs carry the SAME guard the pre-select used —
+-- `status = 'running' AND leaseUntil < $now` (plus the attempts split) — so a
+-- row another reaper already flipped between this call's SELECT and UPDATE
+-- matches zero rows and is neither rewritten nor counted. (A racing committer
+-- that flips the row first also wins the per-record write check; the guard is
+-- what makes the loser a clean no-op rather than relying on abort.) Per-row
+-- exponential backoff is computed from the row's own `attempts` field directly
+-- in SET, so no TS loop is needed; the count of affected rows is returned via
+-- array::len.
 --
 -- Behaviour parity with the old TS:
 --   * attempts < max_attempts  → requeue: status='pending', lease cleared,
 --     visibleAfter = now + min(base * 2^(attempts-1) * jitter, 1h),
---     jitter = 0.5..1.0 (rand::float), error.name='ZombieReclaim'.
+--     jitter = 0.5..1.0 (rand::float, evaluated per row in the SET),
+--     error.name='ZombieReclaim'.
 --   * attempts >= max_attempts → abandon: status='failed', finishedAt set,
 --     error.name='ZombieAbandoned'.
---   * LIMIT 200 per call preserved to bound work per cron tick.
+--   * A SINGLE LIMIT 200 budget per call (one pre-select, then split by
+--     attempts in the two UPDATE guards) — matches the old one-SELECT-then-
+--     split-in-TS bound of 200 total rows per tick, NOT 200-per-branch.
 
 DEFINE FUNCTION OVERWRITE fn::reap_zombies($max_attempts: int, $backoff_base_ms: int) {
     LET $now = time::now();
 
-    LET $rq_ids = (SELECT VALUE id FROM job_run
-        WHERE status = 'running' AND leaseUntil < $now AND (attempts ?? 1) < $max_attempts
-        LIMIT 200);
-    LET $fl_ids = (SELECT VALUE id FROM job_run
-        WHERE status = 'running' AND leaseUntil < $now AND (attempts ?? 1) >= $max_attempts
+    -- One 200-row budget across both branches, matching the old single
+    -- `SELECT ... LIMIT 200`. The requeue/abandon split happens in the UPDATE
+    -- guards below, not by widening the cap to 200-per-branch.
+    LET $ids = (SELECT VALUE id FROM job_run
+        WHERE status = 'running' AND leaseUntil < $now
         LIMIT 200);
 
-    LET $rq = UPDATE $rq_ids SET
+    LET $rq = UPDATE $ids SET
         status = 'pending',
         claimedBy = NONE,
         leaseUntil = NONE,
@@ -47,9 +53,10 @@ DEFINE FUNCTION OVERWRITE fn::reap_zombies($max_attempts: int, $backoff_base_ms:
                 + '; requeued (attempt ' + <string>(attempts ?? 1) + '/' + <string>$max_attempts + ')',
             name: 'ZombieReclaim'
         }
+        WHERE status = 'running' AND leaseUntil < $now AND (attempts ?? 1) < $max_attempts
         RETURN id;
 
-    LET $fl = UPDATE $fl_ids SET
+    LET $fl = UPDATE $ids SET
         status = 'failed',
         finishedAt = time::now(),
         claimedBy = NONE,
@@ -59,6 +66,7 @@ DEFINE FUNCTION OVERWRITE fn::reap_zombies($max_attempts: int, $backoff_base_ms:
                 + '; abandoned after ' + <string>(attempts ?? 1) + ' attempt(s)',
             name: 'ZombieAbandoned'
         }
+        WHERE status = 'running' AND leaseUntil < $now AND (attempts ?? 1) >= $max_attempts
         RETURN id;
 
     RETURN { requeued: array::len($rq), failed: array::len($fl) };

--- a/src/db/migrations/0039_resolve_fact_locale_fold.surql
+++ b/src/db/migrations/0039_resolve_fact_locale_fold.surql
@@ -1,0 +1,221 @@
+-- 0039_resolve_fact_locale_fold — fold locale + entropy tagging into
+-- fn::resolve_fact so the ingest hot path stops issuing follow-up UPDATEs.
+--
+-- ingestFact() and recordExtractedFact() used to call fn::resolve_fact and
+-- then, on outcome='INSERTED', fire 1-2 extra round-trips:
+--   * UPDATE ... SET lang, script   (locale tagging; detectLanguage is pure
+--     TS, computed BEFORE the call — it never needed the returned factId)
+--   * UPDATE ... SET extractionEntropy  (self-consistency, mention path)
+-- Both values are known before resolve_fact runs, so they can ride in as
+-- optional params and be written inside the function on the INSERTED branch.
+-- HyPE's altEmbedding stays a separate post-call UPDATE: it's an LLM call
+-- gated on isEnabled() AND INSERTED, and pre-computing it would burn the
+-- model on REJECTED/SUPERSEDED/COMPETING outcomes.
+--
+-- Behaviour parity: lang/script/entropy are still applied ONLY when the new
+-- fact is INSERTED (no competing rows) — identical to the old
+-- `outcome === 'INSERTED'` gate. SUPERSEDED/COMPETING winners are untouched,
+-- exactly as before. When a param is NONE the corresponding field is left
+-- unset (matches "language !== 'und'" / "entropy provided" guards in TS).
+--
+-- Body is migration 0034 VERBATIM (learned-trust wiring + no retractedAt on
+-- supersede) with three trailing optional params and the INSERTED-branch
+-- writes added. Nothing else changes.
+
+DEFINE FUNCTION OVERWRITE fn::resolve_fact(
+    $entity_id: record<knowledge_entity>,
+    $predicate: string,
+    $object: string,
+    $object_meta: option<object>,
+    $embedding: array<float>,
+    $confidence: float,
+    $valid_from: datetime,
+    $valid_until: option<datetime>,
+    $source: object,
+    $source_trust: float,
+    $semantics: string,
+    $similarity_threshold: float,
+    $w_confidence: float,
+    $w_source_trust: float,
+    $w_recency: float,
+    $w_authority: float,
+    $reject_threshold: float,
+    $margin_for_supersede: float,
+    $lang: option<string>,
+    $script: option<string>,
+    $entropy: option<float>
+) {
+    LET $new_score =
+        $w_confidence * $confidence
+        + $w_source_trust * $source_trust
+        + $w_recency * 1.0
+        + $w_authority * 0.0;
+
+    IF $semantics = 'bitemporal' AND $new_score < $reject_threshold {
+        CREATE ingest_dead_letter CONTENT {
+            payload: { entityId: $entity_id, predicate: $predicate, object: $object, source: $source },
+            reason: 'low_score: ' + <string>$new_score
+        };
+        RETURN { outcome: 'REJECTED', factId: NONE, reason: 'low_score' };
+    };
+
+    LET $candidates = SELECT
+        id, predicate, object, confidence, recordedAt, source, embedding,
+        validFrom, validUntil
+    FROM knowledge_fact
+    WHERE entityId = $entity_id
+      AND predicate = $predicate
+      AND status = 'active'
+      AND retractedAt IS NONE;
+
+    LET $competing = IF $semantics = 'append_only' THEN
+        []
+    ELSE IF $semantics = 'single_active' THEN
+        $candidates
+    ELSE
+        (SELECT * FROM $candidates
+            WHERE embedding != NONE
+              AND vector::similarity::cosine(embedding, $embedding) >= $similarity_threshold
+              AND fn::intervals_overlap(validFrom, validUntil, $valid_from, $valid_until))
+    END;
+
+    LET $new = CREATE ONLY knowledge_fact CONTENT {
+        entityId: $entity_id,
+        predicate: $predicate,
+        object: $object,
+        objectMeta: $object_meta,
+        confidence: $confidence,
+        validFrom: $valid_from,
+        validUntil: $valid_until,
+        source: $source,
+        embedding: $embedding,
+        status: 'active'
+    };
+
+    IF array::len($competing) = 0 {
+        -- Locale + entropy folded in from the caller (migration 0039). Applied
+        -- on INSERTED only, matching the old post-call UPDATE gate.
+        IF $lang != NONE {
+            UPDATE $new.id SET lang = $lang, script = $script;
+        };
+        IF $entropy != NONE {
+            UPDATE $new.id SET extractionEntropy = $entropy;
+        };
+        RETURN { outcome: 'INSERTED', factId: $new.id, reason: NONE };
+    };
+
+    LET $scored = SELECT
+        id,
+        confidence,
+        source,
+        validFrom,
+        object,
+        predicate,
+        $w_confidence * confidence AS sc_confidence,
+        $w_source_trust * fn::source_trust_for(fn::source_key_of(source)) AS sc_source_trust,
+        $w_recency * math::pow(math::E, - duration::secs(time::now() - recordedAt) / 31536000) AS sc_recency,
+        $w_authority * 0.0 AS sc_authority,
+        ($w_confidence * confidence
+         + $w_source_trust * fn::source_trust_for(fn::source_key_of(source))
+         + $w_recency * math::pow(math::E, - duration::secs(time::now() - recordedAt) / 31536000)
+         + $w_authority * 0.0
+        ) AS score
+    FROM $competing;
+
+    LET $best_opp_score = math::max($scored.score);
+    LET $best_opp = (SELECT * FROM $scored WHERE score = $best_opp_score LIMIT 1)[0];
+
+    LET $winner_components = {
+        confidence: $w_confidence * $confidence,
+        sourceTrust: $w_source_trust * $source_trust,
+        recency: $w_recency * 1.0,
+        authority: $w_authority * 0.0
+    };
+    LET $loser_components = {
+        confidence: $best_opp.sc_confidence,
+        sourceTrust: $best_opp.sc_source_trust,
+        recency: $best_opp.sc_recency,
+        authority: $best_opp.sc_authority
+    };
+
+    LET $abs_conf = math::abs($winner_components.confidence - $loser_components.confidence);
+    LET $abs_st   = math::abs($winner_components.sourceTrust - $loser_components.sourceTrust);
+    LET $abs_rec  = math::abs($winner_components.recency - $loser_components.recency);
+    LET $abs_auth = math::abs($winner_components.authority - $loser_components.authority);
+    LET $max_abs  = math::max([$abs_conf, $abs_st, $abs_rec, $abs_auth]);
+
+    LET $dominant_dim = IF $max_abs = $abs_conf THEN 'confidence'
+                       ELSE IF $max_abs = $abs_st THEN 'source_trust'
+                       ELSE IF $max_abs = $abs_rec THEN 'recency'
+                       ELSE 'authority'
+                       END;
+
+    LET $slot_delta = {
+        predicate: ($best_opp.predicate != $predicate),
+        object: ($best_opp.object != $object),
+        validFrom: ($best_opp.validFrom != $valid_from),
+        source: ($best_opp.source != $source)
+    };
+
+    LET $score_breakdown = {
+        winner: {
+            total: $new_score,
+            confidence: $winner_components.confidence,
+            sourceTrust: $winner_components.sourceTrust,
+            recency: $winner_components.recency,
+            authority: $winner_components.authority
+        },
+        loser: {
+            total: $best_opp_score,
+            confidence: $loser_components.confidence,
+            sourceTrust: $loser_components.sourceTrust,
+            recency: $loser_components.recency,
+            authority: $loser_components.authority
+        },
+        margin: $new_score - $best_opp_score
+    };
+
+    LET $supersede =
+        $semantics = 'single_active'
+        OR $new_score >= $best_opp_score + $margin_for_supersede;
+
+    LET $loser_ids = $competing.id;
+
+    IF $supersede {
+        -- NO `retractedAt = time::now()` — a natural supersede is not a
+        -- retraction (migration 0014). Keep the retractionReason +
+        -- retractedBy sentinel that revive + calibration depend on.
+        FOR $loser IN $competing {
+            UPDATE $loser.id SET
+                status = 'superseded',
+                retractionReason = 'superseded',
+                retractedBy = 'system',
+                supersededBy = $new.id,
+                priorValidUntil = $loser.validUntil,
+                validUntil = $valid_from;
+        };
+        RETURN {
+            outcome: 'SUPERSEDED',
+            factId: $new.id,
+            supersededFactIds: $loser_ids,
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            reason: NONE
+        };
+    };
+
+    UPDATE $new.id SET status = 'competing';
+    UPDATE knowledge_fact SET status = 'competing' WHERE id IN $loser_ids;
+    RETURN {
+        outcome: 'COMPETING',
+        factId: $new.id,
+        competingFactIds: $loser_ids,
+        scoreBreakdown: $score_breakdown,
+        dominantDimension: $dominant_dim,
+        slotDelta: $slot_delta,
+        bestOpponentId: $best_opp.id,
+        reason: NONE
+    };
+};

--- a/src/ingest/ingest.service.ts
+++ b/src/ingest/ingest.service.ts
@@ -157,44 +157,24 @@ export class IngestService {
       //    (multiple FANOUT inserts targeting the same entity+predicate);
       //    retry sees the racing committer's row and either supersedes
       //    or competes correctly on the second attempt.
-      const result = await retryOnUniqueViolation(async () => {
-        const [r] = await db.query<[any]>(
-          `RETURN fn::resolve_fact(
-              type::thing('knowledge_entity', $eid),
-              $predicate, $object, $object_meta, $embedding,
-              $confidence, $valid_from, $valid_until, $source,
-              $source_trust, $semantics, $similarity_threshold,
-              $w_confidence, $w_source_trust, $w_recency, $w_authority,
-              $reject_threshold, $margin_for_supersede,
-              $lang, $script, $entropy
-           )`,
-          {
-            eid: idTailOf(entityId),
-            predicate: dto.predicate,
-            object: objectStr,
-            object_meta: objectMeta,
-            embedding,
-            confidence: dto.confidence ?? 0.7,
-            valid_from: new Date(dto.validFrom),
-            valid_until: dto.validUntil ? new Date(dto.validUntil) : undefined,
-            source: dto.source,
-            source_trust: sourceTrust,
-            semantics: policy.semantics,
-            similarity_threshold: this.conflict.similarityThreshold,
-            w_confidence: this.conflict.weights.confidence,
-            w_source_trust: this.conflict.weights.sourceTrust,
-            w_recency: this.conflict.weights.recency,
-            w_authority: this.conflict.weights.authority,
-            reject_threshold: this.conflict.rejectThreshold,
-            margin_for_supersede: this.conflict.marginForSupersede,
-            // Phase 4.A locale tag folded into fn::resolve_fact (migration
-            // 0039) — set on INSERTED only, server-side, no follow-up RTT.
-            lang: detectedLang.lang,
-            script: detectedLang.script,
-            entropy: undefined,
-          },
-        );
-        return r;
+      // Phase 4.A locale tag (detectedLang) folded into fn::resolve_fact
+      // (migration 0039) — set on INSERTED only, server-side, no follow-up RTT.
+      // Direct ingest carries no extraction entropy.
+      const result = await this.resolveFactCall(db, {
+        entityId,
+        predicate: dto.predicate,
+        object: objectStr,
+        objectMeta,
+        embedding,
+        confidence: dto.confidence ?? 0.7,
+        validFrom: new Date(dto.validFrom),
+        validUntil: dto.validUntil ? new Date(dto.validUntil) : undefined,
+        source: dto.source,
+        sourceTrust,
+        semantics: policy.semantics,
+        lang: detectedLang.lang,
+        script: detectedLang.script,
+        entropy: undefined,
       });
 
       const factId = result?.factId ? String(result.factId) : null;
@@ -571,8 +551,19 @@ export class IngestService {
               'identity_of would create a merge cycle (survivor already resolves to the loser)',
             );
           }
-          throw new BadRequestException(
-            'identity_of cannot merge an entity into itself',
+          if (merge?.reason === 'self_merge') {
+            // Defensive: the fromId===toId fast-path above already covers
+            // this, so the function's own self-merge branch is normally dead.
+            throw new BadRequestException(
+              'identity_of cannot merge an entity into itself',
+            );
+          }
+          // merged=false with no recognised reason (or a null/unexpected
+          // result shape) is NOT a client input error — surface it as such
+          // instead of mislabelling it a self-merge 400, so a driver/infra
+          // failure is debuggable rather than masked.
+          throw new Error(
+            `identity_of merge failed unexpectedly (reason=${merge?.reason ?? 'none'})`,
           );
         }
         this.logger.log(
@@ -625,6 +616,76 @@ export class IngestService {
   }
 
   // ── helpers used by mention + link ───────────────────────────────────
+
+  /**
+   * Single entry point for fn::resolve_fact (migration 0039). Both ingest
+   * paths — typed ingestFact and mention-extracted recordExtractedFact — call
+   * this so the 21-positional-arg invocation lives in ONE place: a future
+   * signature change can't drift the two call sites out of sync (which would
+   * silently bind a value to the wrong slot, e.g. entropy into script). The
+   * caller supplies the per-fact values; the conflict weights/thresholds come
+   * from this.conflict. Wrapped in retryOnUniqueViolation because the CREATE
+   * inside the function can hit a write-set conflict under FANOUT against the
+   * same entity+predicate — retry sees the racing committer's row and
+   * supersedes/competes on the second attempt.
+   */
+  private resolveFactCall(
+    db: Surreal,
+    p: {
+      entityId: string;
+      predicate: string;
+      object: string;
+      objectMeta?: object;
+      embedding: number[];
+      confidence: number;
+      validFrom: Date;
+      validUntil?: Date;
+      source: unknown;
+      sourceTrust: number;
+      semantics: string;
+      lang?: string;
+      script?: string;
+      entropy?: number;
+    },
+  ): Promise<any> {
+    return retryOnUniqueViolation(async () => {
+      const [r] = await db.query<[any]>(
+        `RETURN fn::resolve_fact(
+            type::thing('knowledge_entity', $eid),
+            $predicate, $object, $object_meta, $embedding,
+            $confidence, $valid_from, $valid_until, $source,
+            $source_trust, $semantics, $similarity_threshold,
+            $w_confidence, $w_source_trust, $w_recency, $w_authority,
+            $reject_threshold, $margin_for_supersede,
+            $lang, $script, $entropy
+         )`,
+        {
+          eid: idTailOf(p.entityId),
+          predicate: p.predicate,
+          object: p.object,
+          object_meta: p.objectMeta,
+          embedding: p.embedding,
+          confidence: p.confidence,
+          valid_from: p.validFrom,
+          valid_until: p.validUntil,
+          source: p.source,
+          source_trust: p.sourceTrust,
+          semantics: p.semantics,
+          similarity_threshold: this.conflict.similarityThreshold,
+          w_confidence: this.conflict.weights.confidence,
+          w_source_trust: this.conflict.weights.sourceTrust,
+          w_recency: this.conflict.weights.recency,
+          w_authority: this.conflict.weights.authority,
+          reject_threshold: this.conflict.rejectThreshold,
+          margin_for_supersede: this.conflict.marginForSupersede,
+          lang: p.lang,
+          script: p.script,
+          entropy: p.entropy,
+        },
+      );
+      return r;
+    });
+  }
 
   private async resolveOrCreateNamedEntity(
     db: Surreal,
@@ -783,42 +844,21 @@ export class IngestService {
       typeof factPayload.extractionEntropy === 'number'
         ? factPayload.extractionEntropy
         : undefined;
-    const result = await retryOnUniqueViolation(async () => {
-      const [r] = await db.query<[any]>(
-        `RETURN fn::resolve_fact(
-            type::thing('knowledge_entity', $eid),
-            $predicate, $object, $object_meta, $embedding,
-            $confidence, $valid_from, $valid_until, $source,
-            $source_trust, $semantics, $similarity_threshold,
-            $w_confidence, $w_source_trust, $w_recency, $w_authority,
-            $reject_threshold, $margin_for_supersede,
-            $lang, $script, $entropy
-         )`,
-        {
-          eid: idTailOf(entityId),
-          predicate,
-          object,
-          object_meta: undefined,
-          embedding,
-          confidence,
-          valid_from: validFrom,
-          valid_until: undefined,
-          source,
-          source_trust: sourceTrust,
-          semantics: policy.semantics,
-          similarity_threshold: this.conflict.similarityThreshold,
-          w_confidence: this.conflict.weights.confidence,
-          w_source_trust: this.conflict.weights.sourceTrust,
-          w_recency: this.conflict.weights.recency,
-          w_authority: this.conflict.weights.authority,
-          reject_threshold: this.conflict.rejectThreshold,
-          margin_for_supersede: this.conflict.marginForSupersede,
-          lang: langTag,
-          script: scriptTag,
-          entropy: entropyTag,
-        },
-      );
-      return r;
+    const result = await this.resolveFactCall(db, {
+      entityId,
+      predicate,
+      object,
+      objectMeta: undefined,
+      embedding,
+      confidence,
+      validFrom,
+      validUntil: undefined,
+      source,
+      sourceTrust,
+      semantics: policy.semantics,
+      lang: langTag,
+      script: scriptTag,
+      entropy: entropyTag,
     });
 
     const factId = result?.factId ? String(result.factId) : null;

--- a/src/ingest/ingest.service.ts
+++ b/src/ingest/ingest.service.ts
@@ -10,7 +10,6 @@ import { Surreal, StringRecordId } from 'surrealdb';
 import {
   SurrealService,
   dbCreate,
-  dbMerge,
   isUniqueViolation,
   retryOnUniqueViolation,
   runTransaction,
@@ -136,6 +135,17 @@ export class IngestService {
       // is what we want for an optional field.
       const objectMeta = objectIsString ? undefined : (dto.object as unknown as object);
 
+      // Detect locale up front so it rides into fn::resolve_fact as a param
+      // (folded, INSERTED-only write — migration 0039) rather than a
+      // follow-up UPDATE. detectLanguage is pure TS and never needed the
+      // returned factId. 'und' → leave the fields unset (NONE), matching the
+      // old `language !== 'und'` guard.
+      const detLang = detectLanguage(objectStr);
+      const detectedLang =
+        detLang.language !== 'und'
+          ? { lang: detLang.language, script: detLang.script }
+          : { lang: undefined, script: undefined };
+
       // 5. One-RTT server-side resolve. `fn::resolve_fact` (migration
       //    0006) does: filter by cosine for bitemporal → score → decide
       //    INSERTED/SUPERSEDED/COMPETING/REJECTED → CREATE + cascade.
@@ -155,7 +165,8 @@ export class IngestService {
               $confidence, $valid_from, $valid_until, $source,
               $source_trust, $semantics, $similarity_threshold,
               $w_confidence, $w_source_trust, $w_recency, $w_authority,
-              $reject_threshold, $margin_for_supersede
+              $reject_threshold, $margin_for_supersede,
+              $lang, $script, $entropy
            )`,
           {
             eid: idTailOf(entityId),
@@ -176,6 +187,11 @@ export class IngestService {
             w_authority: this.conflict.weights.authority,
             reject_threshold: this.conflict.rejectThreshold,
             margin_for_supersede: this.conflict.marginForSupersede,
+            // Phase 4.A locale tag folded into fn::resolve_fact (migration
+            // 0039) — set on INSERTED only, server-side, no follow-up RTT.
+            lang: detectedLang.lang,
+            script: detectedLang.script,
+            entropy: undefined,
           },
         );
         return r;
@@ -184,25 +200,8 @@ export class IngestService {
       const factId = result?.factId ? String(result.factId) : null;
       const outcome = result?.outcome as IngestOutcome;
 
-      // Phase 4.A locale tagging. Detect language + script on the
-      // object span (the "what is true about the entity" text) and
-      // persist alongside the fact. We tag on INSERTED only — for
-      // SUPERSEDED/COMPETING the new fact is already in `factId`
-      // and the previous tag, if any, stays valid for the loser row.
-      if (factId && outcome === 'INSERTED') {
-        const detected = detectLanguage(objectStr);
-        if (detected.language !== 'und') {
-          await db.query(
-            `UPDATE type::thing('knowledge_fact', $tail)
-                SET lang = $lang, script = $script`,
-            {
-              tail: idTailOf(factId),
-              lang: detected.language,
-              script: detected.script,
-            },
-          );
-        }
-      }
+      // Phase 4.A locale tagging now happens inside fn::resolve_fact via the
+      // $lang/$script params above (migration 0039) — no follow-up UPDATE.
 
       // HyPE: generate a hypothetical-question embedding and write
       // it onto the new fact. We do this synchronously inside the
@@ -533,32 +532,52 @@ export class IngestService {
       const fromId = await this.resolveOrCreateBareRef(db, dto.from as any);
       const toId = await this.resolveOrCreateBareRef(db, dto.to as any);
 
-      // identity_of cycle-guard. The merge sets toId.mergedInto = fromId.
+      // identity_of merge. The merge sets toId.mergedInto = fromId.
       // If fromId already resolves (transitively) back to toId, both ends end
       // up mergedInto-set and BOTH vanish from retrieval (`WHERE mergedInto IS
-      // NONE`), since survivor resolution is single-hop. Reject before any
-      // write so nothing is created on a contradictory link.
+      // NONE`), since survivor resolution is single-hop.
+      //
+      // fn::merge_identity (migration 0037) runs the multi-hop cycle guard
+      // AND the mergedInto write as a single atomic statement, so the
+      // read-decide-write can't be interleaved the way the old separate
+      // TS-walk + standalone UPDATE could. A sorted-pair lock row inside the
+      // function makes concurrent reverse merges (A→B racing B→A) collide on
+      // one record write; retryOnUniqueViolation re-runs the loser, whose
+      // second attempt sees the committed merge and trips the cycle guard.
+      //
+      // Called BEFORE the RELATE so the "reject before any write" contract
+      // holds: a cycle / self-merge returns merged=false having written
+      // nothing, and we throw before creating the edge.
       if (dto.kind === 'identity_of') {
         if (fromId === toId) {
           throw new BadRequestException(
             'identity_of cannot merge an entity into itself',
           );
         }
-        let cursor: string | null = fromId;
-        for (let hops = 0; cursor && hops < 32; hops++) {
-          const [rows] = await db.query<[Array<{ mergedInto: unknown }>]>(
-            `SELECT mergedInto FROM $e`,
-            { e: new StringRecordId(cursor) },
+        const merge = await retryOnUniqueViolation(async () => {
+          const [r] = await db.query<
+            [{ merged: boolean; reason: string | null }]
+          >(
+            `RETURN fn::merge_identity(
+                type::thing('knowledge_entity', $loser),
+                type::thing('knowledge_entity', $survivor))`,
+            { loser: idTailOf(toId), survivor: idTailOf(fromId) },
           );
-          const next = (rows as Array<{ mergedInto: unknown }>)?.[0]
-            ?.mergedInto;
-          cursor = next ? String(next) : null;
-          if (cursor === toId) {
+          return r;
+        });
+        if (!merge?.merged) {
+          if (merge?.reason === 'cycle') {
             throw new BadRequestException(
               'identity_of would create a merge cycle (survivor already resolves to the loser)',
             );
           }
+          throw new BadRequestException(
+            'identity_of cannot merge an entity into itself',
+          );
         }
+        this.logger.log(
+          `[knowledge.entity.merged] companyId=${companyId} loser=${toId} survivor=${fromId}`,
+        );
       }
 
       // Idempotent edge insert. UNIQUE on (in, out, kind) means the second
@@ -598,16 +617,8 @@ export class IngestService {
         `[knowledge.edge.created] companyId=${companyId} kind=${dto.kind} ${fromId} → ${toId}`,
       );
 
-      // Optional: identity merge on kind='identity_of'
-      if (dto.kind === 'identity_of') {
-        await dbMerge(db, toId, {
-          mergedAt: new Date(),
-          mergedInto: new StringRecordId(fromId),
-        });
-        this.logger.log(
-          `[knowledge.entity.merged] companyId=${companyId} loser=${toId} survivor=${fromId}`,
-        );
-      }
+      // identity merge (mergedInto write) already happened atomically in
+      // fn::merge_identity above, before the RELATE.
 
       return { edgeId, fromEntityId: fromId, toEntityId: toId, kind: dto.kind };
     });
@@ -762,6 +773,16 @@ export class IngestService {
     }
     const policy = this.predicateRegistry.policyFor(companyId, predicate);
     const sourceTrust = this.sourceTrustFor(source);
+    // Locale + entropy ride into fn::resolve_fact as params (migration 0039),
+    // folded INSERTED-only writes instead of follow-up UPDATEs. detectLanguage
+    // is pure TS; 'und' → leave unset (NONE), matching the old guard.
+    const detLang = detectLanguage(object);
+    const langTag = detLang.language !== 'und' ? detLang.language : undefined;
+    const scriptTag = detLang.language !== 'und' ? detLang.script : undefined;
+    const entropyTag =
+      typeof factPayload.extractionEntropy === 'number'
+        ? factPayload.extractionEntropy
+        : undefined;
     const result = await retryOnUniqueViolation(async () => {
       const [r] = await db.query<[any]>(
         `RETURN fn::resolve_fact(
@@ -770,7 +791,8 @@ export class IngestService {
             $confidence, $valid_from, $valid_until, $source,
             $source_trust, $semantics, $similarity_threshold,
             $w_confidence, $w_source_trust, $w_recency, $w_authority,
-            $reject_threshold, $margin_for_supersede
+            $reject_threshold, $margin_for_supersede,
+            $lang, $script, $entropy
          )`,
         {
           eid: idTailOf(entityId),
@@ -791,6 +813,9 @@ export class IngestService {
           w_authority: this.conflict.weights.authority,
           reject_threshold: this.conflict.rejectThreshold,
           margin_for_supersede: this.conflict.marginForSupersede,
+          lang: langTag,
+          script: scriptTag,
+          entropy: entropyTag,
         },
       );
       return r;
@@ -799,36 +824,12 @@ export class IngestService {
     const factId = result?.factId ? String(result.factId) : null;
     const outcome = result?.outcome as IngestOutcome | undefined;
 
-    // Phase 4.A locale tagging + Phase 1 HyPE alt-embedding — must
-    // apply to mention-ingested facts too, not just direct-ingest.
-    // Pre-fix only ingestFact() ran these passes, so chat-router /
-    // conversational corpora bypassed BOTH:
-    //   - lang/script never set → the locale-pinned retrieval pass
-    //     (where-builder lang filter) treated mention-ingested facts
-    //     as language-agnostic and they only survived via the legacy
-    //     `OR lang IS NONE` back-compat branch.
-    //   - altEmbedding never written → the question-shaped HyPE max
-    //     pool in runVectorLeg saw zero alt vectors for the conversa-
-    //     tional half of the corpus.
-    // Both passes mirror what ingestFact() does after fn::resolve_fact
-    // (same `outcome === INSERTED` gate, same UPDATE shape), so the
-    // demo-chat / chat-router path now has parity with the direct
-    // ingestion path for both Phase 1 and Phase 4.A/B.
-    if (factId && outcome === 'INSERTED') {
-      const detected = detectLanguage(object);
-      if (detected.language !== 'und') {
-        await db.query(
-          `UPDATE type::thing('knowledge_fact', $tail)
-              SET lang = $lang, script = $script`,
-          {
-            tail: idTailOf(factId),
-            lang: detected.language,
-            script: detected.script,
-          },
-        );
-      }
-    }
-
+    // Phase 4.A locale tag + Phase 3.B entropy now ride into fn::resolve_fact
+    // via the $lang/$script/$entropy params (migration 0039) — set on
+    // INSERTED only, server-side, with no follow-up round-trips. HyPE stays a
+    // post-call UPDATE below: it's an LLM call, gated on isEnabled() AND
+    // INSERTED, so pre-computing it would burn the model on non-INSERTED
+    // outcomes.
     if (factId && this.hype.isEnabled() && outcome === 'INSERTED') {
       const altEmbedding = await this.hype.generateAltEmbedding(
         predicate,
@@ -842,19 +843,6 @@ export class IngestService {
       }
     }
 
-    // Phase 3.B — persist self-consistency entropy on INSERTED rows.
-    // Only fires when EXTRACTOR_SC_PASSES > 1 produced a value;
-    // single-pass extractions leave the column NONE.
-    if (
-      factId &&
-      outcome === 'INSERTED' &&
-      typeof factPayload.extractionEntropy === 'number'
-    ) {
-      await db.query(
-        `UPDATE type::thing('knowledge_fact', $tail) SET extractionEntropy = $h`,
-        { tail: idTailOf(factId), h: factPayload.extractionEntropy },
-      );
-    }
 
     // Surface supersede / compete outcomes in the trace so the demo can
     // show "Berlin fact closed at July 1, Dublin became current" —

--- a/src/jobs/job-claim.service.ts
+++ b/src/jobs/job-claim.service.ts
@@ -475,11 +475,12 @@ export class JobClaimService {
     const baseMs = input.backoffBaseMs ?? 30_000;
     try {
       return await this.surreal.withCompany(input.companyId, async (db) => {
-        // fn::reap_zombies (migration 0038) does the SELECT + split + per-row
-        // backoff as two set-based UPDATEs inside one statement. Each UPDATE
-        // re-checks status='running' AND leaseUntil<now, so a row another
-        // reaper already flipped matches zero rows — no read-then-write race
-        // between concurrent reapers, and no N round-trips.
+        // fn::reap_zombies (migration 0038) does the pre-select + split +
+        // per-row backoff as two set-based UPDATEs inside one statement. Both
+        // UPDATEs re-apply the status='running' AND leaseUntil<now guard in
+        // their WHERE, so a row another reaper already flipped matches zero
+        // rows — no read-then-write race between concurrent reapers, and no N
+        // round-trips. One shared LIMIT 200 budget per call (not per branch).
         const [res] = (await db.query<[{ requeued: number; failed: number }]>(
           `RETURN fn::reap_zombies($max_attempts, $backoff_base_ms)`,
           { max_attempts: maxAttempts, backoff_base_ms: baseMs },

--- a/src/jobs/job-claim.service.ts
+++ b/src/jobs/job-claim.service.ts
@@ -475,60 +475,19 @@ export class JobClaimService {
     const baseMs = input.backoffBaseMs ?? 30_000;
     try {
       return await this.surreal.withCompany(input.companyId, async (db) => {
-        // Find expired claims first so we can split into requeue vs fail.
-        const [rows] = (await db.query<any[]>(
-          `SELECT id, attempts, claimedBy FROM job_run
-             WHERE status = 'running' AND leaseUntil < time::now()
-             LIMIT 200`,
-        )) as any[];
-        const arr = (rows ?? []) as Array<{
-          id: string;
-          attempts?: number;
-          claimedBy?: string;
-        }>;
-        let requeued = 0;
-        let failed = 0;
-        for (const row of arr) {
-          const attempts = Number(row.attempts ?? 1);
-          const claimedBy = String(row.claimedBy ?? 'unknown');
-          if (attempts < maxAttempts) {
-            const jitter = 0.5 + Math.random() * 0.5;
-            const backoffMs = Math.min(
-              baseMs * Math.pow(2, attempts - 1) * jitter,
-              3_600_000,
-            );
-            const visibleAfter = new Date(
-              Date.now() + backoffMs,
-            ).toISOString();
-            await db.query(
-              `UPDATE type::thing($rid) SET
-                  status = 'pending',
-                  claimedBy = NONE, leaseUntil = NONE,
-                  visibleAfter = type::datetime($visibleAfter),
-                  error = { message: $msg, name: 'ZombieReclaim' }`,
-              {
-                rid: row.id,
-                visibleAfter,
-                msg: `lease expired while held by ${claimedBy}; requeued (attempt ${attempts}/${maxAttempts})`,
-              },
-            );
-            requeued++;
-          } else {
-            await db.query(
-              `UPDATE type::thing($rid) SET
-                  status = 'failed',
-                  finishedAt = time::now(),
-                  claimedBy = NONE, leaseUntil = NONE,
-                  error = { message: $msg, name: 'ZombieAbandoned' }`,
-              {
-                rid: row.id,
-                msg: `lease expired while held by ${claimedBy}; abandoned after ${attempts} attempt(s)`,
-              },
-            );
-            failed++;
-          }
-        }
-        return { requeued, failed };
+        // fn::reap_zombies (migration 0038) does the SELECT + split + per-row
+        // backoff as two set-based UPDATEs inside one statement. Each UPDATE
+        // re-checks status='running' AND leaseUntil<now, so a row another
+        // reaper already flipped matches zero rows — no read-then-write race
+        // between concurrent reapers, and no N round-trips.
+        const [res] = (await db.query<[{ requeued: number; failed: number }]>(
+          `RETURN fn::reap_zombies($max_attempts, $backoff_base_ms)`,
+          { max_attempts: maxAttempts, backoff_base_ms: baseMs },
+        )) as [{ requeued: number; failed: number }];
+        return {
+          requeued: Number(res?.requeued ?? 0),
+          failed: Number(res?.failed ?? 0),
+        };
       });
     } catch (e) {
       this.logger.warn(

--- a/test/job-claim.unit-spec.ts
+++ b/test/job-claim.unit-spec.ts
@@ -252,34 +252,32 @@ describe('JobClaimService', () => {
     warn.mockRestore();
   });
 
-  it('reapZombies routes below-maxAttempts rows to requeue and at-max to fail', async () => {
-    const updates: string[] = [];
+  it('reapZombies delegates to fn::reap_zombies and returns its counts', async () => {
+    // The requeue/abandon split + per-row backoff now live in
+    // fn::reap_zombies (migration 0038), run as two set-based UPDATEs in one
+    // atomic statement — so no concurrent reaper can read-then-write the same
+    // expired row. The service is now a thin caller: pass the knobs, return
+    // the counts. We assert the wiring (fn name + params + result mapping).
+    let captured: { sql: string; params?: Record<string, unknown> } | null =
+      null;
     const db = {
-      query: async (sql: string, _params?: Record<string, unknown>) => {
-        if (sql.startsWith('SELECT id, attempts')) {
-          return [
-            [
-              { id: 'job_run:a', attempts: 1, claimedBy: 'host#1' },
-              { id: 'job_run:b', attempts: 3, claimedBy: 'host#1' },
-            ],
-          ];
-        }
-        if (sql.includes('UPDATE')) {
-          updates.push(sql);
-          return [[]];
-        }
-        return [[]];
+      query: async (sql: string, params?: Record<string, unknown>) => {
+        captured = { sql, params };
+        return [{ requeued: 2, failed: 1 }];
       },
     };
     const svc = new JobClaimService(mkSurreal(db));
     const out = await svc.reapZombies({
       companyId: 'co_x',
       maxAttempts: 3,
+      backoffBaseMs: 30_000,
     });
-    expect(out.requeued).toBe(1);
-    expect(out.failed).toBe(1);
-    expect(updates.find((s) => s.includes("status = 'pending'"))).toBeDefined();
-    expect(updates.find((s) => s.includes("status = 'failed'"))).toBeDefined();
+    expect(out).toEqual({ requeued: 2, failed: 1 });
+    expect(captured!.sql).toContain('fn::reap_zombies');
+    expect(captured!.params).toMatchObject({
+      max_attempts: 3,
+      backoff_base_ms: 30_000,
+    });
   });
 
   it('identity is hostname#pid format', () => {

--- a/test/jobs.real-e2e-spec.ts
+++ b/test/jobs.real-e2e-spec.ts
@@ -243,6 +243,52 @@ describe('JobClaimService — real Surreal end-to-end', () => {
     expect(row.status).toBe('pending');
     expect(row.claimedBy).toBeFalsy();
   }, 60_000);
+
+  it('reapZombies abandons a stale row at/above maxAttempts (ZombieAbandoned)', async () => {
+    // Distinct dedupKey: a prior test already enqueued a no-dedupKey
+    // reindex_embeddings row, and the (jobType, dedupKey) unique index would
+    // collide on ['reindex_embeddings', NONE] for a second keyless enqueue.
+    const { runId } = await claim.enqueue({
+      jobType: 'reindex_embeddings',
+      companyId: TENANT,
+      triggeredBy: 'cron',
+      dedupKey: 'zombie_abandon_test',
+    });
+
+    // Drive THIS row (by runId) directly into a stale-running state at the
+    // attempts cap, rather than via claimNext — a prior reap test leaves a
+    // pending row of another jobType, so claimNext is nondeterministic here.
+    // This isolates the requeue/abandon split in fn::reap_zombies (0038).
+    await surreal.withCompany(TENANT, async (db) => {
+      await db.query(
+        `UPDATE job_run SET
+            status = 'running', claimedBy = 'dead-worker', attempts = 3,
+            leaseUntil = type::datetime($t)
+         WHERE runId = $r`,
+        { r: runId, t: new Date(Date.now() - 60_000).toISOString() },
+      );
+    });
+
+    const out = await claim.reapZombies({
+      companyId: TENANT,
+      maxAttempts: 3,
+      backoffBaseMs: 1000,
+    });
+    expect(out.failed).toBe(1);
+    expect(out.requeued).toBe(0);
+
+    const row = await surreal.withCompany(TENANT, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT status, claimedBy, error.name AS errName, finishedAt FROM job_run WHERE runId = $r`,
+        { r: runId },
+      );
+      return (rows as any[])[0];
+    });
+    expect(row.status).toBe('failed');
+    expect(row.claimedBy).toBeFalsy();
+    expect(row.errName).toBe('ZombieAbandoned');
+    expect(row.finishedAt).toBeTruthy();
+  }, 60_000);
 });
 
 describe('LeaderLeaseService — real Surreal end-to-end', () => {


### PR DESCRIPTION
Moves three read-modify-write flows out of TS and into atomic SurrealDB stored functions — fixing concurrency hazards and collapsing ingest hot-path round-trips. From the Tier 1 + Tier 2.1 of the stored-function audit.

## Changes
- **`0037` `fn::merge_identity`** (+ `merge_lock` table) — the `identity_of` cycle guard + `mergedInto` write were separate round-trips (32-hop TS walk, then a standalone `UPDATE` after the RELATE), so a mutual merge `A→B` / `B→A` could leave both ends `mergedInto`-set and vanish from single-hop resolution. Now the multi-hop cycle guard (recursive path `$survivor.{1..32+collect}.mergedInto`) and the write run in one statement; a sorted-pair `merge_lock` row serializes concurrent reverse merges so `retryOnUniqueViolation` re-runs the loser, which trips the cycle guard.
- **`0038` `fn::reap_zombies`** — `reapZombies` SELECTed expired rows then looped per-row `UPDATE`s with no "still expired" guard (two reapers could double-write). Now one 200-row pre-select + two set-based `UPDATE`s, each carrying the `status='running' AND leaseUntil<now` guard in its WHERE; per-row exponential backoff computed in SET; idempotent.
- **`0039` `fn::resolve_fact`** — `lang`/`script` + self-consistency `entropy` rode in as follow-up `UPDATE`s on every INSERTED fact; both values are known before the call, so they now pass as optional params and write inside the function on the INSERTED branch (INSERTED-only parity preserved). HyPE `altEmbedding` stays a post-call UPDATE (LLM, gated).
- `ingestLink` and `reapZombies` become thin callers; `resolveFactCall()` centralises the 21-arg `fn::resolve_fact` invocation so the two ingest paths can't drift.

## Verification
626→639 unit + `jobs.real` (9, incl. new `ZombieAbandoned` abandon-branch e2e) + ingest/merge/locale/supersede e2e cluster (12) green against SurrealDB v2.3.10. Includes a round of `/code-review high` fixes (reap WHERE-guard + single LIMIT budget, helper extraction, accurate concurrency-scope comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)