### PR TITLE
chore(db): upgrade SurrealDB 2.3.10 → 3.1.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   surrealdb:
-    image: surrealdb/surrealdb:v2.3.10
+    image: surrealdb/surrealdb:v3.1.5
     user: root                              # SurrealDB image needs root to write rocksdb files
     command:
       - start

--- a/src/artifacts/artifacts.service.ts
+++ b/src/artifacts/artifacts.service.ts
@@ -87,7 +87,7 @@ export class ArtifactsService {
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       // 1. Verify entity exists.
       const [entRows] = await db.query<any[][]>(
-        `SELECT id FROM type::thing('knowledge_entity', $rid) LIMIT 1`,
+        `SELECT id FROM type::record('knowledge_entity', $rid) LIMIT 1`,
         { rid: ref.id },
       );
       if (!(entRows as any[])?.[0]) {
@@ -138,7 +138,7 @@ export class ArtifactsService {
     const ref = this.normalizeEntityId(entityIdRaw);
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       const [entRows] = await db.query<any[][]>(
-        `SELECT id FROM type::thing('knowledge_entity', $rid) LIMIT 1`,
+        `SELECT id FROM type::record('knowledge_entity', $rid) LIMIT 1`,
         { rid: ref.id },
       );
       if (!(entRows as any[])?.[0]) {
@@ -202,7 +202,7 @@ export class ArtifactsService {
     const [rows] = await db.query<any[][]>(
       `SELECT payload, sourceFactIds, builtAt, staleAfterMs, dirty
        FROM knowledge_artifact
-       WHERE entityId = type::thing('knowledge_entity', $rid)
+       WHERE entityId = type::record('knowledge_entity', $rid)
          AND artifactType = $type
        LIMIT 1`,
       { rid, type: artifactType },
@@ -228,7 +228,7 @@ export class ArtifactsService {
   ): Promise<FactRow[]> {
     // Use the centralised server-side function from migration 0003.
     const [rows] = await db.query<[any[]]>(
-      `RETURN fn::active_facts_for(type::thing('knowledge_entity', $rid), NONE)`,
+      `RETURN fn::active_facts_for(type::record('knowledge_entity', $rid), NONE)`,
       { rid },
     );
     return ((rows as any[]) ?? [])
@@ -287,7 +287,7 @@ export class ArtifactsService {
              sourceFactIds = $facts,
              builtAt = time::now(),
              dirty = IF dirty = $expectedDirty THEN false ELSE dirty END
-         WHERE entityId = type::thing('knowledge_entity', $rid)
+         WHERE entityId = type::record('knowledge_entity', $rid)
            AND artifactType = $type
          RETURN AFTER`,
         {
@@ -302,7 +302,7 @@ export class ArtifactsService {
       if (updated) return updated;
       const [creRows] = await db.query<any[][]>(
         `CREATE knowledge_artifact CONTENT {
-            entityId: type::thing('knowledge_entity', $rid),
+            entityId: type::record('knowledge_entity', $rid),
             artifactType: $type,
             payload: $wrapped,
             sourceFactIds: $facts,

--- a/src/db/migrations/0001_baseline.surql
+++ b/src/db/migrations/0001_baseline.surql
@@ -18,7 +18,7 @@ DEFINE FIELD IF NOT EXISTS canonicalName   ON knowledge_entity TYPE string;
 DEFINE FIELD IF NOT EXISTS aliases         ON knowledge_entity TYPE option<array<string>>;
 -- FLEXIBLE keeps arbitrary dynamic keys (vertical.entityId pairs) on a
 -- SCHEMAFULL table. Without it, SurrealDB drops unknown sub-fields silently.
-DEFINE FIELD IF NOT EXISTS externalRefs    ON knowledge_entity FLEXIBLE TYPE object DEFAULT {};
+DEFINE FIELD IF NOT EXISTS externalRefs    ON knowledge_entity TYPE object FLEXIBLE DEFAULT {};
 DEFINE FIELD IF NOT EXISTS createdAt       ON knowledge_entity TYPE datetime DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS mergedAt        ON knowledge_entity TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS mergedInto      ON knowledge_entity TYPE option<record<knowledge_entity>>;
@@ -38,7 +38,7 @@ DEFINE TABLE IF NOT EXISTS knowledge_fact SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS entityId         ON knowledge_fact TYPE record<knowledge_entity>;
 DEFINE FIELD IF NOT EXISTS predicate        ON knowledge_fact TYPE string;
 DEFINE FIELD IF NOT EXISTS object           ON knowledge_fact TYPE string;
-DEFINE FIELD IF NOT EXISTS objectMeta       ON knowledge_fact FLEXIBLE TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS objectMeta       ON knowledge_fact TYPE option<object> FLEXIBLE;
 DEFINE FIELD IF NOT EXISTS confidence       ON knowledge_fact TYPE float ASSERT $value >= 0 AND $value <= 1;
 DEFINE FIELD IF NOT EXISTS validFrom        ON knowledge_fact TYPE datetime;
 DEFINE FIELD IF NOT EXISTS validUntil       ON knowledge_fact TYPE option<datetime>;
@@ -48,7 +48,7 @@ DEFINE FIELD IF NOT EXISTS retractionReason ON knowledge_fact TYPE option<string
 DEFINE FIELD IF NOT EXISTS retractedBy      ON knowledge_fact TYPE option<string>
   ASSERT $value = NONE OR $value INSIDE ['human','system','cascade'];
 DEFINE FIELD IF NOT EXISTS supersededBy     ON knowledge_fact TYPE option<record<knowledge_fact>>;
-DEFINE FIELD IF NOT EXISTS source           ON knowledge_fact FLEXIBLE TYPE object;
+DEFINE FIELD IF NOT EXISTS source           ON knowledge_fact TYPE object FLEXIBLE;
 DEFINE FIELD IF NOT EXISTS derivedFrom      ON knowledge_fact TYPE option<array<record<knowledge_fact>>>;
 DEFINE FIELD IF NOT EXISTS status           ON knowledge_fact TYPE string DEFAULT 'active'
   ASSERT $value INSIDE ['active','competing','retracted','superseded','compacted'];
@@ -72,7 +72,7 @@ DEFINE TABLE IF NOT EXISTS knowledge_edge SCHEMAFULL TYPE RELATION
 DEFINE FIELD IF NOT EXISTS kind            ON knowledge_edge TYPE string;
 DEFINE FIELD IF NOT EXISTS weight          ON knowledge_edge TYPE float DEFAULT 1.0
   ASSERT $value >= 0 AND $value <= 1;
-DEFINE FIELD IF NOT EXISTS source          ON knowledge_edge FLEXIBLE TYPE object;
+DEFINE FIELD IF NOT EXISTS source          ON knowledge_edge TYPE object FLEXIBLE;
 DEFINE FIELD IF NOT EXISTS createdAt       ON knowledge_edge TYPE datetime DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS invalidatedAt   ON knowledge_edge TYPE option<datetime>;
 
@@ -96,6 +96,6 @@ DEFINE INDEX IF NOT EXISTS forgotten_hash_idx ON forgotten_entity FIELDS entityI
 -- ─── DeadLetter (rejected ingests) ───────────────────────────────────────
 DEFINE TABLE IF NOT EXISTS ingest_dead_letter SCHEMAFULL;
 
-DEFINE FIELD IF NOT EXISTS payload     ON ingest_dead_letter FLEXIBLE TYPE object;
+DEFINE FIELD IF NOT EXISTS payload     ON ingest_dead_letter TYPE object FLEXIBLE;
 DEFINE FIELD IF NOT EXISTS reason      ON ingest_dead_letter TYPE string;
 DEFINE FIELD IF NOT EXISTS rejectedAt  ON ingest_dead_letter TYPE datetime DEFAULT time::now();

--- a/src/db/migrations/0002_sota.surql
+++ b/src/db/migrations/0002_sota.surql
@@ -46,9 +46,9 @@ DEFINE INDEX IF NOT EXISTS entity_canonical_lc_idx ON knowledge_entity FIELDS ca
 DEFINE INDEX IF NOT EXISTS entity_aliases_idx     ON knowledge_entity FIELDS aliases;
 
 DEFINE INDEX IF NOT EXISTS entity_name_search_idx ON knowledge_entity
-  FIELDS canonicalName SEARCH ANALYZER content BM25 HIGHLIGHTS;
+  FIELDS canonicalName FULLTEXT ANALYZER content BM25 HIGHLIGHTS;
 DEFINE INDEX IF NOT EXISTS entity_alias_search_idx ON knowledge_entity
-  FIELDS aliases SEARCH ANALYZER content BM25;
+  FIELDS aliases FULLTEXT ANALYZER content BM25;
 
 -- ─── EntityExternalRef (lookup table) ────────────────────────────────────
 DEFINE TABLE IF NOT EXISTS entity_external_ref SCHEMAFULL;
@@ -67,7 +67,7 @@ DEFINE INDEX IF NOT EXISTS fact_bitemporal_idx ON knowledge_fact
   FIELDS entityId, status, recordedAt;
 
 DEFINE INDEX IF NOT EXISTS fact_object_search_idx ON knowledge_fact
-  FIELDS object SEARCH ANALYZER content BM25 HIGHLIGHTS;
+  FIELDS object FULLTEXT ANALYZER content BM25 HIGHLIGHTS;
 
 -- ─── KnowledgeEdge additions ─────────────────────────────────────────────
 DEFINE TABLE IF NOT EXISTS knowledge_edge SCHEMAFULL TYPE RELATION

--- a/src/db/migrations/0004_knowledge_artifact.surql
+++ b/src/db/migrations/0004_knowledge_artifact.surql
@@ -30,7 +30,7 @@ DEFINE FIELD IF NOT EXISTS entityId       ON knowledge_artifact TYPE record<know
 -- templates (registry/verticals.yaml has 15+ verticals each with
 -- distinct artifact shapes).
 DEFINE FIELD IF NOT EXISTS artifactType   ON knowledge_artifact TYPE string;
-DEFINE FIELD IF NOT EXISTS payload        ON knowledge_artifact FLEXIBLE TYPE object;
+DEFINE FIELD IF NOT EXISTS payload        ON knowledge_artifact TYPE object FLEXIBLE;
 DEFINE FIELD IF NOT EXISTS sourceFactIds  ON knowledge_artifact TYPE array<record<knowledge_fact>>;
 DEFINE FIELD IF NOT EXISTS builtAt        ON knowledge_artifact TYPE datetime DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS staleAfterMs   ON knowledge_artifact TYPE int DEFAULT 300000;

--- a/src/db/migrations/0005_pii_permissions.surql
+++ b/src/db/migrations/0005_pii_permissions.surql
@@ -90,7 +90,7 @@ DEFINE FIELD OVERWRITE object ON knowledge_fact TYPE string PERMISSIONS
 
 -- objectMeta carries structured (non-string) PII for the same predicates
 -- when callers ingest non-string objects. Same gate.
-DEFINE FIELD OVERWRITE objectMeta ON knowledge_fact FLEXIBLE TYPE option<object> PERMISSIONS
+DEFINE FIELD OVERWRITE objectMeta ON knowledge_fact TYPE option<object> FLEXIBLE PERMISSIONS
     FOR select WHERE
         predicate NOT IN ['address', 'dob']
         OR ($caller_scopes ?? []) CONTAINS 'brain:read_pii';

--- a/src/db/migrations/0006_resolve_fact_fn.surql
+++ b/src/db/migrations/0006_resolve_fact_fn.surql
@@ -86,7 +86,7 @@ DEFINE FUNCTION IF NOT EXISTS fn::resolve_fact(
               AND vector::similarity::cosine(embedding, $embedding) >= $similarity_threshold)
     END;
 
-    -- CREATE the new fact. type::thing'd id is bound by the caller as
+    -- CREATE the new fact. type::record'd id is bound by the caller as
     -- a record<knowledge_entity>, so this is type-safe.
     LET $new = CREATE ONLY knowledge_fact CONTENT {
         entityId: $entity_id,

--- a/src/db/migrations/0007_search_haystack.surql
+++ b/src/db/migrations/0007_search_haystack.surql
@@ -36,4 +36,4 @@ DEFINE FIELD IF NOT EXISTS searchHaystack ON knowledge_fact
 UPDATE knowledge_fact SET searchHaystack = string::concat(string::replace(predicate, '_', ' '), ' ', object);
 
 DEFINE INDEX IF NOT EXISTS fact_haystack_search_idx ON knowledge_fact
-  FIELDS searchHaystack SEARCH ANALYZER content BM25 HIGHLIGHTS;
+  FIELDS searchHaystack FULLTEXT ANALYZER content BM25 HIGHLIGHTS;

--- a/src/db/migrations/0016_extraction_pattern.surql
+++ b/src/db/migrations/0016_extraction_pattern.surql
@@ -31,11 +31,15 @@ DEFINE FIELD IF NOT EXISTS clauseText   ON extraction_pattern TYPE string;
 -- input clause for the replay to be valid — the consumer (Sprint E7)
 -- runs the same span-grounding check before accepting the cached
 -- facts.
-DEFINE FIELD IF NOT EXISTS facts        ON extraction_pattern FLEXIBLE TYPE array;
+-- 3.x: flexible object-array needs the element typed via `facts.*` (parent
+-- must be plain `array`, not option<array>). See 0024 for the rationale.
+DEFINE FIELD IF NOT EXISTS facts        ON extraction_pattern TYPE array;
+DEFINE FIELD IF NOT EXISTS facts.*      ON extraction_pattern TYPE object FLEXIBLE;
 -- Captured edge templates as JSON. Each template carries the kind plus
 -- relative entity positions in the clause; the consumer maps them to
 -- the new clause's entities (Sprint E7).
-DEFINE FIELD IF NOT EXISTS edges        ON extraction_pattern FLEXIBLE TYPE array  DEFAULT [];
+DEFINE FIELD IF NOT EXISTS edges        ON extraction_pattern TYPE array DEFAULT [];
+DEFINE FIELD IF NOT EXISTS edges.*      ON extraction_pattern TYPE object FLEXIBLE;
 -- How many times this clause has been observed. Useful for operators
 -- triaging the learned set — high-count patterns are battle-tested;
 -- one-shot patterns may be brittle.

--- a/src/db/migrations/0023_changefeed_audit.surql
+++ b/src/db/migrations/0023_changefeed_audit.surql
@@ -42,8 +42,8 @@ DEFINE FIELD IF NOT EXISTS ts ON audit_event TYPE datetime
 DEFINE FIELD IF NOT EXISTS versionstamp ON audit_event TYPE int;
 -- Optional pre-image (state before the change) — populated for
 -- update/delete when CHANGEFEED was defined with INCLUDE ORIGINAL.
-DEFINE FIELD IF NOT EXISTS before ON audit_event FLEXIBLE TYPE option<object>;
-DEFINE FIELD IF NOT EXISTS after ON audit_event FLEXIBLE TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS before ON audit_event TYPE option<object> FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS after ON audit_event TYPE option<object> FLEXIBLE;
 -- Lightweight metadata for forensic queries.
 DEFINE FIELD IF NOT EXISTS consumedBy ON audit_event TYPE string
     DEFAULT 'changefeed-consumer';

--- a/src/db/migrations/0024_debug_trace.surql
+++ b/src/db/migrations/0024_debug_trace.surql
@@ -23,11 +23,15 @@ DEFINE FIELD IF NOT EXISTS path ON debug_trace TYPE string;
 DEFINE FIELD IF NOT EXISTS status ON debug_trace TYPE int;
 DEFINE FIELD IF NOT EXISTS durationMs ON debug_trace TYPE int;
 DEFINE FIELD IF NOT EXISTS companyId ON debug_trace TYPE option<string>;
-DEFINE FIELD IF NOT EXISTS spans ON debug_trace FLEXIBLE TYPE array
-    DEFAULT [];
-DEFINE FIELD IF NOT EXISTS artifacts ON debug_trace FLEXIBLE TYPE array
-    DEFAULT [];
-DEFINE FIELD IF NOT EXISTS errored ON debug_trace FLEXIBLE TYPE option<object>;
+-- SurrealDB 3.x validates object-element sub-fields even on FLEXIBLE arrays;
+-- arbitrary keys are only allowed by typing the element via `field.*` as a
+-- FLEXIBLE object. The parent must be plain `array` (NOT option<array>, which
+-- auto-defines `.*` and then collides). See migration audit for 2x→3x.
+DEFINE FIELD IF NOT EXISTS spans ON debug_trace TYPE array DEFAULT [];
+DEFINE FIELD IF NOT EXISTS spans.* ON debug_trace TYPE object FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS artifacts ON debug_trace TYPE array DEFAULT [];
+DEFINE FIELD IF NOT EXISTS artifacts.* ON debug_trace TYPE object FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS errored ON debug_trace TYPE option<object> FLEXIBLE;
 
 DEFINE INDEX IF NOT EXISTS debug_trace_request_idx
     ON debug_trace FIELDS requestId UNIQUE;

--- a/src/db/migrations/0025_job_run.surql
+++ b/src/db/migrations/0025_job_run.surql
@@ -37,15 +37,15 @@ DEFINE FIELD IF NOT EXISTS startedAt ON job_run TYPE datetime
     DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS finishedAt ON job_run TYPE option<datetime>;
 -- Set on transition to terminal status. Subtract startedAt for duration.
-DEFINE FIELD IF NOT EXISTS progress ON job_run FLEXIBLE TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS progress ON job_run TYPE option<object> FLEXIBLE;
 -- Free-form progress hash. Conventional keys:
 --   { processed: number, total?: number, currentTenant?: string,
 --     itemsEmitted?: number, partialStats?: any }
 -- The job is the source of truth for shape; UI renders whatever is here.
-DEFINE FIELD IF NOT EXISTS result ON job_run FLEXIBLE TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS result ON job_run TYPE option<object> FLEXIBLE;
 -- Terminal payload; mirrors what the legacy synchronous HTTP response
 -- returned (so callers waiting on the run can read it back from DB).
-DEFINE FIELD IF NOT EXISTS error ON job_run FLEXIBLE TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS error ON job_run TYPE option<object> FLEXIBLE;
 -- { message: string, name?: string, stack?: string } on failure.
 DEFINE FIELD IF NOT EXISTS cancelRequested ON job_run TYPE bool
     DEFAULT false;

--- a/src/db/migrations/0026_dream_emit.surql
+++ b/src/db/migrations/0026_dream_emit.surql
@@ -23,7 +23,7 @@ DEFINE FIELD IF NOT EXISTS subject ON dream_emit TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS object ON dream_emit TYPE option<string>;
 -- Sibling pointer: for identity_link the loser entityId; for
 -- resolution the loser factId.
-DEFINE FIELD IF NOT EXISTS detail ON dream_emit FLEXIBLE TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS detail ON dream_emit TYPE option<object> FLEXIBLE;
 -- Free-form judge output (similarity scores, judge reason, etc).
 
 DEFINE INDEX IF NOT EXISTS dream_emit_run_idx

--- a/src/db/migrations/0027_operator_action.surql
+++ b/src/db/migrations/0027_operator_action.surql
@@ -15,7 +15,7 @@ DEFINE FIELD IF NOT EXISTS ts ON operator_action TYPE datetime
     DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS actor ON operator_action TYPE string;
 -- companyId of the API key that made the call.
-DEFINE FIELD IF NOT EXISTS scopes ON operator_action FLEXIBLE TYPE array
+DEFINE FIELD IF NOT EXISTS scopes ON operator_action TYPE array
     DEFAULT [];
 -- Scopes granted to the key (e.g. ['brain:admin','brain:read_pii']).
 DEFINE FIELD IF NOT EXISTS method ON operator_action TYPE string;
@@ -24,8 +24,8 @@ DEFINE FIELD IF NOT EXISTS path ON operator_action TYPE string;
 DEFINE FIELD IF NOT EXISTS status ON operator_action TYPE int;
 DEFINE FIELD IF NOT EXISTS durationMs ON operator_action TYPE int
     DEFAULT 0;
-DEFINE FIELD IF NOT EXISTS query ON operator_action FLEXIBLE TYPE option<object>;
-DEFINE FIELD IF NOT EXISTS bodySummary ON operator_action FLEXIBLE TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS query ON operator_action TYPE option<object> FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS bodySummary ON operator_action TYPE option<object> FLEXIBLE;
 -- Truncated body — we cap each scalar at 200 chars and drop nested
 -- payloads past depth 2 so an oversized DTO can't blow up the table.
 

--- a/src/db/migrations/0029_leader_lease.surql
+++ b/src/db/migrations/0029_leader_lease.surql
@@ -14,7 +14,7 @@
 --
 --   IF leaseUntil IS NONE OR leaseUntil < time::now() THEN
 --     UPSERT leader_lease:[$name] CONTENT {
---       leaseUntil = time::now() + duration::from::secs($ttl),
+--       leaseUntil = time::now() + duration::from_secs($ttl),
 --       leaderId   = $me,
 --       heartbeatAt = time::now()
 --     };

--- a/src/db/migrations/0030_job_run_payload.surql
+++ b/src/db/migrations/0030_job_run_payload.surql
@@ -12,4 +12,4 @@
 -- shape (a dreams payload looks different from a reindex payload);
 -- the dispatcher reads it back into a typed handler-specific record.
 
-DEFINE FIELD IF NOT EXISTS payload ON job_run FLEXIBLE TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS payload ON job_run TYPE option<object> FLEXIBLE;

--- a/src/db/migrations/0035_procedural_memory.surql
+++ b/src/db/migrations/0035_procedural_memory.surql
@@ -36,7 +36,7 @@ DEFINE FIELD IF NOT EXISTS action           ON procedural_memory TYPE string;
 DEFINE FIELD IF NOT EXISTS priority         ON procedural_memory TYPE int     DEFAULT 100
     ASSERT $value >= 0;
 DEFINE FIELD IF NOT EXISTS decayHalfLifeDays ON procedural_memory TYPE option<int>;
-DEFINE FIELD IF NOT EXISTS source           ON procedural_memory FLEXIBLE TYPE object
+DEFINE FIELD IF NOT EXISTS source           ON procedural_memory TYPE object FLEXIBLE
     DEFAULT { kind: 'operator' };
 DEFINE FIELD IF NOT EXISTS createdAt        ON procedural_memory TYPE datetime DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS retiredAt        ON procedural_memory TYPE option<datetime>;

--- a/src/db/migrations/0036_communities.surql
+++ b/src/db/migrations/0036_communities.surql
@@ -38,7 +38,7 @@ DEFINE INDEX IF NOT EXISTS community_built_idx ON community_node FIELDS builtAt;
 -- "what do we know about <domain>" lexically. Same `content` analyzer
 -- the fact / entity BM25 indexes use (migration 0002).
 DEFINE INDEX IF NOT EXISTS community_summary_idx ON community_node
-  FIELDS summary SEARCH ANALYZER content BM25 HIGHLIGHTS;
+  FIELDS summary FULLTEXT ANALYZER content BM25 HIGHLIGHTS;
 -- HNSW over the summary embedding is opt-in once a tenant grows many
 -- communities; full-scan cosine in CommunityBuilderService is fine at
 -- walking-skeleton scale (communities are O(10²), not O(facts)).

--- a/src/db/migrations/0037_merge_identity.surql
+++ b/src/db/migrations/0037_merge_identity.surql
@@ -65,7 +65,7 @@ DEFINE FUNCTION OVERWRITE fn::merge_identity(
     -- B→A both hash to the same lock record, so one of two racing
     -- transactions aborts with a retryable write conflict.
     LET $pair = array::sort([<string>$loser, <string>$survivor]);
-    UPSERT type::thing('merge_lock', array::join($pair, '|')) SET at = time::now();
+    UPSERT type::record('merge_lock', array::join($pair, '|')) SET at = time::now();
 
     -- Multi-hop cycle guard. `+collect` returns every mergedInto value along
     -- the survivor's chain; if the loser is anywhere in it, merging the loser

--- a/src/db/migrations/0038_reap_zombies.surql
+++ b/src/db/migrations/0038_reap_zombies.surql
@@ -44,7 +44,7 @@ DEFINE FUNCTION OVERWRITE fn::reap_zombies($max_attempts: int, $backoff_base_ms:
         status = 'pending',
         claimedBy = NONE,
         leaseUntil = NONE,
-        visibleAfter = time::now() + duration::from::millis(<int> math::floor(math::min([
+        visibleAfter = time::now() + duration::from_millis(<int> math::floor(math::min([
             $backoff_base_ms * math::pow(2, (attempts ?? 1) - 1) * (0.5 + rand::float() * 0.5),
             3600000
         ]))),

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -472,6 +472,22 @@ export class SurrealService implements OnModuleInit, OnModuleDestroy {
       // finish. ensureRootSession may return a rebuilt conn — track
       // the swap so future migrations use the live reference.
       this.migratorConn = await this.ensureRootSession(this.migratorConn);
+      // SurrealDB 3.x no longer auto-creates a namespace/database on first
+      // DEFINE — `use()` + DDL against a non-existent NS/DB errors ("The
+      // namespace 'brain' does not exist"). 2.x created them implicitly.
+      // Provision both explicitly, idempotently, at root before selecting
+      // the tenant DB. DEFINE NAMESPACE is a root op (no NS selected);
+      // DEFINE DATABASE needs the NS selected. Identifiers can't be
+      // parameterized, so we backtick-quote — companyId is already
+      // validated `^[a-zA-Z0-9_-]+$` in withCompany, and `database` is
+      // `co_<companyId>` / `system`.
+      await this.migratorConn.query(
+        `DEFINE NAMESPACE IF NOT EXISTS \`${this.namespace}\``,
+      );
+      await this.migratorConn.use({ namespace: this.namespace });
+      await this.migratorConn.query(
+        `DEFINE DATABASE IF NOT EXISTS \`${database}\``,
+      );
       await this.migratorConn.use({ namespace: this.namespace, database });
       const result = await this.migrator.migrate(this.migratorConn);
       this.knownDatabases.add(database);
@@ -607,7 +623,7 @@ export async function dbMerge<T extends Record<string, unknown>>(
   patch: Record<string, unknown>,
 ): Promise<T> {
   const [rows] = await db.query<[T[]]>(
-    `UPDATE type::thing($t, $i) MERGE $p RETURN AFTER`,
+    `UPDATE type::record($t, $i) MERGE $p RETURN AFTER`,
     { t: tableOf(recordId), i: idOf(recordId), p: patch },
   );
   const arr = (rows as T[]) ?? [];
@@ -700,7 +716,16 @@ export async function runTransaction<T>(
     throw err;
   }
   const arr = result as unknown[];
-  return arr[arr.length - 1] as T;
+  // SurrealDB 3.x emits one result slot per top-level statement INCLUDING the
+  // trailing `COMMIT TRANSACTION` (always null). 2.x did not surface a COMMIT
+  // slot, so the old code took `arr[length-1]` (then the RETURN). On 3.x that
+  // index is the COMMIT null, which silently turned every transactional
+  // upsert's return into `undefined` (e.g. two distinct entity refs both
+  // resolving to "undefined" → a spurious self-merge 400). We always compose
+  // exactly one trailing COMMIT, and every caller's last statement is the
+  // RETURN it wants, so the meaningful value is the slot immediately before
+  // COMMIT.
+  return arr[arr.length - 2] as T;
 }
 
 /**
@@ -743,7 +768,13 @@ export function isReadConflict(err: unknown): boolean {
     m.includes('Transaction read conflict') ||
     m.includes('wrote at the same key') ||
     m.includes('read or write conflict') ||
-    m.includes('This transaction can be retried')
+    m.includes('This transaction can be retried') ||
+    // SurrealDB 3.x single-statement conflict wording:
+    // "Transaction conflict: Write conflict, retry the transaction. This
+    //  transaction can be retried" (already matched by the line above, but
+    //  match the distinctive prefix too in case the trailing sentence drops).
+    m.includes('Transaction conflict') ||
+    m.includes('Write conflict')
   );
 }
 

--- a/src/diff/memory-diff.service.ts
+++ b/src/diff/memory-diff.service.ts
@@ -137,7 +137,7 @@ export class MemoryDiffService {
       // Fetch the `after` snapshot for each changedFacts entry. The
       // id column is record<knowledge_fact>; an `IN` against plain
       // string ids doesn't match. We hydrate each replacement via
-      // type::thing in a per-row fetch — changedFacts counts are
+      // type::record in a per-row fetch — changedFacts counts are
       // bounded by retracts in-window, so the N+1 round trip is
       // cheap in practice and the SurrealQL stays portable.
       const replacementTails = Array.from(
@@ -153,7 +153,7 @@ export class MemoryDiffService {
       for (const tail of replacementTails) {
         const [afterRows] = await db.query<any[][]>(
           `SELECT ${FACT_FIELDS}
-             FROM type::thing('knowledge_fact', $tail) LIMIT 1`,
+             FROM type::record('knowledge_fact', $tail) LIMIT 1`,
           { tail },
         );
         const r = (afterRows as any[])?.[0];
@@ -232,11 +232,11 @@ function buildScoping(args: MemoryDiffArgs): ScopingClauses {
     );
     params.entityIds = normalized;
     // SurrealDB IN on a record<knowledge_entity> field accepts an
-    // array of record links (strings here cast through type::thing).
+    // array of record links (strings here cast through type::record).
     factParts.push(
-      `entityId IN (SELECT type::thing(id) FROM $entityIds AS id)`,
+      `entityId IN (SELECT type::record(id) FROM $entityIds AS id)`,
     );
-    entityParts.push(`id IN (SELECT type::thing(id) FROM $entityIds AS id)`);
+    entityParts.push(`id IN (SELECT type::record(id) FROM $entityIds AS id)`);
   }
 
   if (args.predicates && args.predicates.length > 0) {

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -89,7 +89,7 @@ export class EntitiesService {
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       const [entRows] = await db.query<any[][]>(
         `SELECT ${ENTITY_PROFILE_FIELDS}
-         FROM type::thing('knowledge_entity', $rid) LIMIT 1`,
+         FROM type::record('knowledge_entity', $rid) LIMIT 1`,
         { rid: ref.id },
       );
       const entity = (entRows as any[])?.[0];
@@ -103,7 +103,7 @@ export class EntitiesService {
       // in JS. With a long-lived entity (~thousands of facts), this
       // collapses bytes-scanned by an order of magnitude for the
       // common case `asOf = now`.
-      const baseClauses = [`entityId = type::thing('knowledge_entity', $rid)`];
+      const baseClauses = [`entityId = type::record('knowledge_entity', $rid)`];
       const params: Record<string, unknown> = { rid: ref.id };
       if (asOf) {
         baseClauses.push(
@@ -181,7 +181,7 @@ export class EntitiesService {
     const asOf = asOfRaw ? new Date(asOfRaw) : null;
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       const baseClauses = [
-        `entityId = type::thing('knowledge_entity', $rid)`,
+        `entityId = type::record('knowledge_entity', $rid)`,
       ];
       const params: Record<string, unknown> = { rid: ref.id };
       if (asOf) {
@@ -247,7 +247,7 @@ export class EntitiesService {
       // long-lived entities don't pay for full timeline materialisation
       // on every query. The composite (entityId, status, recordedAt)
       // index covers the entityId+range combination directly.
-      const clauses = [`entityId = type::thing('knowledge_entity', $rid)`];
+      const clauses = [`entityId = type::record('knowledge_entity', $rid)`];
       const params: Record<string, unknown> = { rid: ref.id };
       if (since) { clauses.push(`recordedAt >= $since`); params.since = since; }
       if (until) { clauses.push(`recordedAt <= $until`); params.until = until; }
@@ -305,7 +305,7 @@ export class EntitiesService {
 
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       // Native graph traversal via SurrealDB's `->` / `<-` operators
-      // applied to an inline `type::thing(...)` expression. The graph
+      // applied to an inline `type::record(...)` expression. The graph
       // operators walk the adjacency list directly — O(degree) — and
       // the inline `out.{...}` / `in.{...}` projections hydrate the
       // far entity in the same query. Two parallel reads (outbound +
@@ -326,13 +326,13 @@ export class EntitiesService {
       const outSql = `
         SELECT id, kind, weight, source, createdAt, invalidatedAt, in, out,
                out.{id, type, canonicalName} AS toEntity
-        FROM type::thing('knowledge_entity', $rid)->knowledge_edge
+        FROM type::record('knowledge_entity', $rid)->knowledge_edge
         WHERE 1=1${asOfParam}${kindParam}
       `;
       const inSql = `
         SELECT id, kind, weight, source, createdAt, invalidatedAt, in, out,
                in.{id, type, canonicalName} AS fromEntity
-        FROM type::thing('knowledge_entity', $rid)<-knowledge_edge
+        FROM type::record('knowledge_entity', $rid)<-knowledge_edge
         WHERE 1=1${asOfParam}${kindParam}
       `;
       const [outRowsResult, inRowsResult] = await Promise.all([
@@ -402,7 +402,7 @@ export class EntitiesService {
     const result = await this.surreal.withCompany(companyId, async (db) => {
       // Verify exists
       const [entRows] = await db.query<any[][]>(
-        `SELECT id FROM type::thing('knowledge_entity', $rid) LIMIT 1`,
+        `SELECT id FROM type::record('knowledge_entity', $rid) LIMIT 1`,
         { rid: ref.id },
       );
       const entity = (entRows as any[])?.[0];
@@ -423,12 +423,12 @@ export class EntitiesService {
       // reconstructable from audit_event indefinitely.
       const [factIdRows] = await db.query<any[][]>(
         `SELECT id FROM knowledge_fact
-         WHERE entityId = type::thing('knowledge_entity', $rid)`,
+         WHERE entityId = type::record('knowledge_entity', $rid)`,
         { rid: ref.id },
       );
       const [edgeIdRows] = await db.query<any[][]>(
         `SELECT id FROM knowledge_edge
-         WHERE in = type::thing('knowledge_entity', $rid) OR out = type::thing('knowledge_entity', $rid)`,
+         WHERE in = type::record('knowledge_entity', $rid) OR out = type::record('knowledge_entity', $rid)`,
         { rid: ref.id },
       );
       const factIds = ((factIdRows as any[]) ?? []).map((r) => String(r.id));
@@ -439,16 +439,16 @@ export class EntitiesService {
       // Cascade hard-delete. Embedding columns die with the rows.
       await db.query(
         `DELETE knowledge_fact
-         WHERE entityId = type::thing('knowledge_entity', $rid)`,
+         WHERE entityId = type::record('knowledge_entity', $rid)`,
         { rid: ref.id },
       );
       await db.query(
         `DELETE knowledge_edge
-         WHERE in = type::thing('knowledge_entity', $rid) OR out = type::thing('knowledge_entity', $rid)`,
+         WHERE in = type::record('knowledge_entity', $rid) OR out = type::record('knowledge_entity', $rid)`,
         { rid: ref.id },
       );
       await db.query(
-        `DELETE type::thing('knowledge_entity', $rid)`,
+        `DELETE type::record('knowledge_entity', $rid)`,
         { rid: ref.id },
       );
 
@@ -493,21 +493,21 @@ export class EntitiesService {
       // support_context) carry name/contact/complaints — entityId-keyed.
       await db.query(
         `DELETE knowledge_artifact
-           WHERE entityId = type::thing('knowledge_entity', $rid)`,
+           WHERE entityId = type::record('knowledge_entity', $rid)`,
         { rid: ref.id },
       );
 
       // ingest_dead_letter: rejected facts keep payload.{object,entityId}.
       await db.query(
         `DELETE ingest_dead_letter
-           WHERE payload.entityId = type::thing('knowledge_entity', $rid)`,
+           WHERE payload.entityId = type::record('knowledge_entity', $rid)`,
         { rid: ref.id },
       );
 
       // entity_external_ref: external subject identifier + pointer.
       await db.query(
         `DELETE entity_external_ref
-           WHERE entity = type::thing('knowledge_entity', $rid)`,
+           WHERE entity = type::record('knowledge_entity', $rid)`,
         { rid: ref.id },
       );
 

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -100,7 +100,7 @@ export class FactsService {
       // predicate + source so the admin-scope gate below can read them.
       const [existingRows] = await db.query<any[][]>(
         `SELECT id, status, retractedAt, validFrom, predicate, source
-           FROM type::thing('knowledge_fact', $rid) LIMIT 1`,
+           FROM type::record('knowledge_fact', $rid) LIMIT 1`,
         { rid: ref.id },
       );
       const existing = (existingRows as any[])?.[0];
@@ -188,7 +188,7 @@ export class FactsService {
     const rid = this.normalizeFactId(retractedFactId).id;
     const [rows] = await db.query<any[][]>(
       `SELECT id, priorValidUntil FROM knowledge_fact
-         WHERE supersededBy = type::thing('knowledge_fact', $rid)
+         WHERE supersededBy = type::record('knowledge_fact', $rid)
            AND status = 'superseded'
            AND retractionReason = 'superseded'`,
       { rid },
@@ -239,7 +239,7 @@ export class FactsService {
       const current = stack.pop()!;
       const [childRows] = await db.query<any[][]>(
         `SELECT id FROM knowledge_fact
-         WHERE derivedFrom CONTAINS type::thing('knowledge_fact', $cid)
+         WHERE derivedFrom CONTAINS type::record('knowledge_fact', $cid)
            AND retractedAt IS NONE`,
         { cid: this.normalizeFactId(current).id },
       );
@@ -289,7 +289,7 @@ export class FactsService {
       const asOf = opts.asOf ? new Date(opts.asOf) : null;
 
       const clauses = [
-        `entityId = type::thing('knowledge_entity', $rid)`,
+        `entityId = type::record('knowledge_entity', $rid)`,
         `status = 'competing'`,
       ];
       const params: Record<string, unknown> = { rid: ref.id };

--- a/src/ingest/ingest-predictor.service.ts
+++ b/src/ingest/ingest-predictor.service.ts
@@ -152,7 +152,7 @@ export class IngestPredictionService {
         `SELECT id, predicate, object, confidence, validFrom, validUntil,
                 recordedAt, embedding, source, status
            FROM knowledge_fact
-           WHERE entityId = type::thing('knowledge_entity', $eid)
+           WHERE entityId = type::record('knowledge_entity', $eid)
              AND predicate = $predicate
              AND retractedAt IS NONE
              AND status = 'active'
@@ -248,7 +248,7 @@ export class IngestPredictionService {
         ? ref.entityId.slice('knowledge_entity:'.length)
         : ref.entityId;
       const [rows] = await db.query<any[][]>(
-        `SELECT id FROM type::thing('knowledge_entity', $tail) LIMIT 1`,
+        `SELECT id FROM type::record('knowledge_entity', $tail) LIMIT 1`,
         { tail },
       );
       const row = (rows as any[])?.[0];

--- a/src/ingest/ingest.service.ts
+++ b/src/ingest/ingest.service.ts
@@ -196,7 +196,7 @@ export class IngestService {
         );
         if (altEmbedding) {
           await db.query(
-            `UPDATE type::thing('knowledge_fact', $tail) SET altEmbedding = $emb`,
+            `UPDATE type::record('knowledge_fact', $tail) SET altEmbedding = $emb`,
             { tail: idTailOf(factId), emb: altEmbedding },
           );
         }
@@ -539,8 +539,8 @@ export class IngestService {
             [{ merged: boolean; reason: string | null }]
           >(
             `RETURN fn::merge_identity(
-                type::thing('knowledge_entity', $loser),
-                type::thing('knowledge_entity', $survivor))`,
+                type::record('knowledge_entity', $loser),
+                type::record('knowledge_entity', $survivor))`,
             { loser: idTailOf(toId), survivor: idTailOf(fromId) },
           );
           return r;
@@ -651,7 +651,7 @@ export class IngestService {
     return retryOnUniqueViolation(async () => {
       const [r] = await db.query<[any]>(
         `RETURN fn::resolve_fact(
-            type::thing('knowledge_entity', $eid),
+            type::record('knowledge_entity', $eid),
             $predicate, $object, $object_meta, $embedding,
             $confidence, $valid_from, $valid_until, $source,
             $source_trust, $semantics, $similarity_threshold,
@@ -877,7 +877,7 @@ export class IngestService {
       );
       if (altEmbedding) {
         await db.query(
-          `UPDATE type::thing('knowledge_fact', $tail) SET altEmbedding = $emb`,
+          `UPDATE type::record('knowledge_fact', $tail) SET altEmbedding = $emb`,
           { tail: idTailOf(factId), emb: altEmbedding },
         );
       }

--- a/src/jobs/job-claim.service.ts
+++ b/src/jobs/job-claim.service.ts
@@ -209,7 +209,7 @@ export class JobClaimService {
                        SET status = 'running',
                            claimedBy = $me,
                            claimedAt = time::now(),
-                           leaseUntil = time::now() + duration::from::secs($ttl),
+                           leaseUntil = time::now() + duration::from_secs($ttl),
                            heartbeatAt = time::now(),
                            attempts = ($row.attempts OR 0) + 1
                      WHERE status = 'pending'
@@ -260,8 +260,8 @@ export class JobClaimService {
     try {
       return await this.surreal.withCompany(input.companyId, async (db) => {
         const [rows] = (await db.query<any[]>(
-          `UPDATE type::thing($rid) SET
-              leaseUntil = time::now() + duration::from::secs($ttl),
+          `UPDATE type::record($rid) SET
+              leaseUntil = time::now() + duration::from_secs($ttl),
               heartbeatAt = time::now()
             WHERE claimedBy = $me AND status = 'running'
             RETURN cancelRequested`,
@@ -312,7 +312,7 @@ export class JobClaimService {
           // corrupt status and double-count execution. 0 rows affected
           // ⇒ claim lost; skip silently (the dup-work cost is already
           // paid by the time we get here).
-          `UPDATE type::thing($rid) SET
+          `UPDATE type::record($rid) SET
               status = 'succeeded',
               finishedAt = time::now(),
               result = $result,
@@ -376,7 +376,7 @@ export class JobClaimService {
               Date.now() + backoffMs,
             ).toISOString();
             const [rows] = (await db.query<any[]>(
-              `UPDATE type::thing($rid) SET
+              `UPDATE type::record($rid) SET
                   status = 'pending',
                   error = $err,
                   claimedBy = NONE, leaseUntil = NONE,
@@ -393,7 +393,7 @@ export class JobClaimService {
             return ((rows ?? []) as unknown[]).length;
           }
           const [rows] = (await db.query<any[]>(
-            `UPDATE type::thing($rid) SET
+            `UPDATE type::record($rid) SET
                 status = 'failed',
                 finishedAt = time::now(),
                 error = $err,
@@ -435,7 +435,7 @@ export class JobClaimService {
       await this.surreal.withCompany(input.companyId, async (db) => {
         const [rows] = (await db.query<any[]>(
           // Ownership guard — same rationale as complete()/fail().
-          `UPDATE type::thing($rid) SET
+          `UPDATE type::record($rid) SET
               status = 'cancelled',
               finishedAt = time::now(),
               result = $result,

--- a/src/jobs/leader-lease.service.ts
+++ b/src/jobs/leader-lease.service.ts
@@ -48,10 +48,10 @@ export class LeaderLeaseService {
               )
               .add(
                 `IF $row IS NONE OR $row.leaseUntil < time::now() OR $row.leaderId = $me {
-                   UPSERT type::thing('leader_lease', $name) CONTENT {
+                   UPSERT type::record('leader_lease', $name) CONTENT {
                      name: $name,
                      leaderId: $me,
-                     leaseUntil: time::now() + duration::from::secs($ttl),
+                     leaseUntil: time::now() + duration::from_secs($ttl),
                      heartbeatAt: time::now(),
                      acquiredAt: $row.acquiredAt OR time::now()
                    };

--- a/src/procedural/procedural-memory.service.ts
+++ b/src/procedural/procedural-memory.service.ts
@@ -152,7 +152,7 @@ export class ProceduralMemoryService {
         ? procedureIdRaw.slice('procedural_memory:'.length)
         : procedureIdRaw;
       const [rows] = await db.query<any[][]>(
-        `UPDATE type::thing('procedural_memory', $tail)
+        `UPDATE type::record('procedural_memory', $tail)
            SET retiredAt = time::now()
            WHERE retiredAt IS NONE
            RETURN AFTER`,

--- a/src/search/internals/graph-retrieve-db.ts
+++ b/src/search/internals/graph-retrieve-db.ts
@@ -53,7 +53,7 @@ export async function resolveSeedEntities(
   // BM25 SEARCH fallback. Pre-fix this branch did a `SELECT … LIMIT
   // 200` full-table scan and a JS-side substring filter — linear in
   // tenant entity count per ask, hot-path. We have `entity_name_search_idx`
-  // (BM25 SEARCH ANALYZER content, migration 0002) defined for exactly
+  // (BM25 FULLTEXT ANALYZER content, migration 0002) defined for exactly
   // this purpose. Route through it and let SurrealDB score + rank;
   // returned `score` lets us prefer better matches without the
   // length-sort heuristic.

--- a/src/search/internals/where-builder.ts
+++ b/src/search/internals/where-builder.ts
@@ -44,7 +44,7 @@ export function buildBaseWhere(
   if (dto.entityIds && dto.entityIds.length > 0) {
     // Multi-hop anchoring. Accept both short and fully-qualified ids;
     // SurrealDB record-link parsing tolerates both via the
-    // `type::thing` cast at query time.
+    // `type::record` cast at query time.
     clauses.push(`AND entityId INSIDE $entityIds`);
     params.entityIds = dto.entityIds.map((raw) => {
       const id = raw.startsWith('knowledge_entity:')

--- a/test/communities.e2e-spec.ts
+++ b/test/communities.e2e-spec.ts
@@ -76,7 +76,7 @@ describe('Communities — build + read surfaces', () => {
     const surreal = f.app.get(SurrealService);
     entityA = await surreal.withCompany(f.companyId, async (db) => {
       const [rows] = await db.query<any[][]>(
-        `SELECT entityId FROM type::thing('knowledge_fact', $tail)`,
+        `SELECT entityId FROM type::record('knowledge_fact', $tail)`,
         { tail: factA.split(':')[1] },
       );
       return String((rows as any[])?.[0]?.entityId ?? '');

--- a/test/entities-forget.e2e-spec.ts
+++ b/test/entities-forget.e2e-spec.ts
@@ -61,7 +61,7 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
     const surreal = f.app.get(SurrealService);
     const entityId = await surreal.withCompany(f.companyId, async (db) => {
       const [rows] = await db.query<any[][]>(
-        `SELECT entityId FROM type::thing('knowledge_fact', $tail)`,
+        `SELECT entityId FROM type::record('knowledge_fact', $tail)`,
         {
           tail: String(subjFactId).split(':')[1],
         },
@@ -89,7 +89,7 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
       f.companyId,
       async (db) => {
         const [rows] = await db.query<any[][]>(
-          `SELECT entityId FROM type::thing('knowledge_fact', $tail)`,
+          `SELECT entityId FROM type::record('knowledge_fact', $tail)`,
           { tail: String(counterFactId).split(':')[1] },
         );
         return String((rows as any[])?.[0]?.entityId ?? '');
@@ -128,7 +128,7 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
       // Seed every other PII-bearing store the forget cascade must purge.
       await db.query(
         `CREATE knowledge_artifact CONTENT {
-            entityId: type::thing('knowledge_entity', $tail),
+            entityId: type::record('knowledge_entity', $tail),
             artifactType: 'customer_profile',
             payload: { name: 'secret-pii-value' },
             sourceFactIds: [], dirty: false }`,
@@ -136,7 +136,7 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
       );
       await db.query(
         `CREATE ingest_dead_letter CONTENT {
-            payload: { entityId: type::thing('knowledge_entity', $tail),
+            payload: { entityId: type::record('knowledge_entity', $tail),
                        object: 'secret-pii-value' },
             reason: 'low_score' }`,
         { tail },
@@ -144,7 +144,7 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
       await db.query(
         `CREATE entity_external_ref CONTENT {
             key: 'rent:secret-external-id',
-            entity: type::thing('knowledge_entity', $tail) }`,
+            entity: type::record('knowledge_entity', $tail) }`,
         { tail },
       );
       await db.query(
@@ -180,14 +180,14 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
     // tombstone written.
     await surreal.withCompany(f.companyId, async (db) => {
       const [entRows] = await db.query<any[][]>(
-        `SELECT id FROM type::thing('knowledge_entity', $tail)`,
+        `SELECT id FROM type::record('knowledge_entity', $tail)`,
         { tail: entityId.split(':')[1] },
       );
       expect((entRows as any[]).length).toBe(0);
 
       const [factRows] = await db.query<any[][]>(
         `SELECT id FROM knowledge_fact
-           WHERE entityId = type::thing('knowledge_entity', $tail)`,
+           WHERE entityId = type::record('knowledge_entity', $tail)`,
         { tail: entityId.split(':')[1] },
       );
       expect((factRows as any[]).length).toBe(0);
@@ -218,19 +218,19 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
       };
       expect(
         await countWhere(
-          `SELECT id FROM knowledge_artifact WHERE entityId = type::thing('knowledge_entity', $tail)`,
+          `SELECT id FROM knowledge_artifact WHERE entityId = type::record('knowledge_entity', $tail)`,
           { tail },
         ),
       ).toBe(0);
       expect(
         await countWhere(
-          `SELECT id FROM ingest_dead_letter WHERE payload.entityId = type::thing('knowledge_entity', $tail)`,
+          `SELECT id FROM ingest_dead_letter WHERE payload.entityId = type::record('knowledge_entity', $tail)`,
           { tail },
         ),
       ).toBe(0);
       expect(
         await countWhere(
-          `SELECT id FROM entity_external_ref WHERE entity = type::thing('knowledge_entity', $tail)`,
+          `SELECT id FROM entity_external_ref WHERE entity = type::record('knowledge_entity', $tail)`,
           { tail },
         ),
       ).toBe(0);

--- a/test/facts-list-competing.e2e-spec.ts
+++ b/test/facts-list-competing.e2e-spec.ts
@@ -32,7 +32,7 @@ describe('FactsService.listCompeting — groups competing pairs by predicate', (
     const surreal = f.app.get(SurrealService);
     await surreal.withCompany(f.companyId, async (db) => {
       await db.query(
-        `CREATE type::thing('knowledge_entity', $eid) CONTENT {
+        `CREATE type::record('knowledge_entity', $eid) CONTENT {
             type: 'customer',
             canonicalName: 'List Competing Subject',
             externalRefs: { rent: 'lc_subj' }
@@ -45,7 +45,7 @@ describe('FactsService.listCompeting — groups competing pairs by predicate', (
       const recordedB = new Date(now.getTime() - 1_000);
       await db.query(
         `CREATE knowledge_fact:lc_a CONTENT {
-            entityId: type::thing('knowledge_entity', $eid),
+            entityId: type::record('knowledge_entity', $eid),
             predicate: 'status',
             object: 'active',
             confidence: 0.7,
@@ -58,7 +58,7 @@ describe('FactsService.listCompeting — groups competing pairs by predicate', (
       );
       await db.query(
         `CREATE knowledge_fact:lc_b CONTENT {
-            entityId: type::thing('knowledge_entity', $eid),
+            entityId: type::record('knowledge_entity', $eid),
             predicate: 'status',
             object: 'churned',
             confidence: 0.72,
@@ -73,7 +73,7 @@ describe('FactsService.listCompeting — groups competing pairs by predicate', (
       // A non-competing fact on the same entity — must be excluded.
       await db.query(
         `CREATE knowledge_fact:lc_c CONTENT {
-            entityId: type::thing('knowledge_entity', $eid),
+            entityId: type::record('knowledge_entity', $eid),
             predicate: 'tier',
             object: 'gold',
             confidence: 0.95,

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -13,7 +13,7 @@ export default async function setup() {
   }
 
   console.log('[e2e] starting ephemeral SurrealDB container...');
-  const container = await new GenericContainer('surrealdb/surrealdb:v2.3.10')
+  const container = await new GenericContainer('surrealdb/surrealdb:v3.1.5')
     .withUser('root')
     .withCommand([
       'start',

--- a/test/inline-entity-resolution.e2e-spec.ts
+++ b/test/inline-entity-resolution.e2e-spec.ts
@@ -63,7 +63,7 @@ describe('Inline entity resolution — mention ingest wiring', () => {
     return surreal.withCompany(f.companyId, async (db) => {
       const [rows] = await db.query<any[][]>(
         `SELECT predicate FROM knowledge_fact
-           WHERE entityId = type::thing('knowledge_entity', $tail)`,
+           WHERE entityId = type::record('knowledge_entity', $tail)`,
         { tail: entityId.split(':')[1] },
       );
       return ((rows as any[]) ?? []).map((r) => String(r.predicate));

--- a/test/job-claim.unit-spec.ts
+++ b/test/job-claim.unit-spec.ts
@@ -37,10 +37,11 @@ function mkSurreal(db: { query: (s: string, p?: any) => Promise<any> }) {
 
 describe('JobClaimService', () => {
   it('claimNext returns null when the transaction yields no row', async () => {
-    // runTransaction returns the LAST statement's result. Our handler
-    // wraps "RETURN NONE" when the SELECT was empty.
+    // runTransaction reads the slot before the trailing COMMIT (SurrealDB 3.x
+    // emits a null COMMIT slot). RETURN NONE → the slot is null → claimNext
+    // returns null. [null, null] = (RETURN NONE, COMMIT).
     const { db } = mkDbScript([
-      () => [null], // BEGIN/COMMIT batch returns one slot: NONE
+      () => [null, null],
     ]);
     const svc = new JobClaimService(mkSurreal(db));
     const got = await svc.claimNext({
@@ -52,6 +53,7 @@ describe('JobClaimService', () => {
   });
 
   it('claimNext returns a typed JobClaim when the tx yields a row', async () => {
+    // 3.x: row is the RETURN slot, immediately before the COMMIT null slot.
     const { db } = mkDbScript([
       () => [
         {
@@ -62,6 +64,7 @@ describe('JobClaimService', () => {
           payload: { operations: ['dedup'] },
           leaseUntil: '2030-01-01T00:05:00Z',
         },
+        null,
       ],
     ]);
     const svc = new JobClaimService(mkSurreal(db));

--- a/test/jobs-otel.unit-spec.ts
+++ b/test/jobs-otel.unit-spec.ts
@@ -147,6 +147,8 @@ describe('Jobs OTel handoff — wire contract', () => {
     const traceparent =
       '00-cccccccccccccccccccccccccccccccc-3333333333333333-01';
     const db = {
+      // 3.x: RETURN slot precedes the trailing COMMIT null slot (runTransaction
+      // reads arr[length-2]).
       query: async () => [
         {
           id: 'job_run:withtp',
@@ -157,6 +159,7 @@ describe('Jobs OTel handoff — wire contract', () => {
           leaseUntil: '2030-01-01T00:05:00Z',
           traceparent,
         },
+        null,
       ],
     };
     const surreal = {

--- a/test/jobs.real-e2e-spec.ts
+++ b/test/jobs.real-e2e-spec.ts
@@ -221,7 +221,7 @@ describe('JobClaimService — real Surreal end-to-end', () => {
     // Force the lease into the past.
     await surreal.withCompany(TENANT, async (db) => {
       await db.query(
-        `UPDATE type::thing($rid) SET leaseUntil = type::datetime($t)`,
+        `UPDATE type::record($rid) SET leaseUntil = type::datetime($t)`,
         { rid: claimed!.recordId, t: new Date(Date.now() - 60_000).toISOString() },
       );
     });

--- a/test/memory-diff.e2e-spec.ts
+++ b/test/memory-diff.e2e-spec.ts
@@ -36,7 +36,7 @@ describe('MemoryDiffService.diff — window math', () => {
     await surreal.withCompany(f.companyId, async (db) => {
       // Two entities: target + bystander. Created at T0.
       await db.query(
-        `CREATE type::thing('knowledge_entity', $eid) CONTENT {
+        `CREATE type::record('knowledge_entity', $eid) CONTENT {
             type: 'customer',
             canonicalName: 'Diff Target',
             externalRefs: { rent: 'md_subj' },
@@ -46,7 +46,7 @@ describe('MemoryDiffService.diff — window math', () => {
       );
       // Bystander created INSIDE the window — should appear in newEntities.
       await db.query(
-        `CREATE type::thing('knowledge_entity', $eid) CONTENT {
+        `CREATE type::record('knowledge_entity', $eid) CONTENT {
             type: 'customer',
             canonicalName: 'Diff Bystander',
             externalRefs: { rent: 'md_bystander' },
@@ -58,8 +58,8 @@ describe('MemoryDiffService.diff — window math', () => {
       // 5 facts at T1 on the target.
       for (let i = 1; i <= 5; i++) {
         await db.query(
-          `CREATE type::thing('knowledge_fact', $rid) CONTENT {
-              entityId: type::thing('knowledge_entity', $eid),
+          `CREATE type::record('knowledge_fact', $rid) CONTENT {
+              entityId: type::record('knowledge_entity', $eid),
               predicate: 'tag',
               object: $obj,
               confidence: 0.9,
@@ -80,7 +80,7 @@ describe('MemoryDiffService.diff — window math', () => {
 
       // At T2: retract md_t1_1 (pure retract — no successor).
       await db.query(
-        `UPDATE type::thing('knowledge_fact', 'md_t1_1') SET
+        `UPDATE type::record('knowledge_fact', 'md_t1_1') SET
             status = 'retracted',
             retractedAt = $t2,
             retractionReason = 'operator',
@@ -89,8 +89,8 @@ describe('MemoryDiffService.diff — window math', () => {
       );
       // At T2: add md_t2_new — net-new active fact on target.
       await db.query(
-        `CREATE type::thing('knowledge_fact', $rid) CONTENT {
-            entityId: type::thing('knowledge_entity', $eid),
+        `CREATE type::record('knowledge_fact', $rid) CONTENT {
+            entityId: type::record('knowledge_entity', $eid),
             predicate: 'tag',
             object: 'tag_added_in_t2',
             confidence: 0.95,
@@ -108,8 +108,8 @@ describe('MemoryDiffService.diff — window math', () => {
       );
       // At T2: a superseded transition — md_t1_2 is replaced by md_t2_replacement.
       await db.query(
-        `CREATE type::thing('knowledge_fact', $rid) CONTENT {
-            entityId: type::thing('knowledge_entity', $eid),
+        `CREATE type::record('knowledge_fact', $rid) CONTENT {
+            entityId: type::record('knowledge_entity', $eid),
             predicate: 'tier',
             object: 'platinum',
             confidence: 0.95,
@@ -126,11 +126,11 @@ describe('MemoryDiffService.diff — window math', () => {
         },
       );
       await db.query(
-        `UPDATE type::thing('knowledge_fact', 'md_t1_2') SET
+        `UPDATE type::record('knowledge_fact', 'md_t1_2') SET
             status = 'superseded',
             retractedAt = $t2,
             retractionReason = 'superseded',
-            supersededBy = type::thing('knowledge_fact', 'md_t2_replacement')`,
+            supersededBy = type::record('knowledge_fact', 'md_t2_replacement')`,
         { t2: T2 },
       );
     });

--- a/test/mention-locale-hype.e2e-spec.ts
+++ b/test/mention-locale-hype.e2e-spec.ts
@@ -106,7 +106,7 @@ describe('mention-path locale + HyPE coverage', () => {
         ? String(factId).split(':')[1]
         : String(factId);
       const [rows] = await db.query<any[][]>(
-        `SELECT lang, script, altEmbedding FROM type::thing('knowledge_fact', $t)`,
+        `SELECT lang, script, altEmbedding FROM type::record('knowledge_fact', $t)`,
         { t: tail },
       );
       return (rows as any[])?.[0] ?? null;

--- a/test/phase4-db-persistence.e2e-spec.ts
+++ b/test/phase4-db-persistence.e2e-spec.ts
@@ -37,7 +37,7 @@ describe('P1 e2e — Phase 4 DB persistence', () => {
     const surreal = f.app.get(SurrealService);
     const row = await surreal.withCompany(f.companyId, async (db) => {
       const [rows] = await db.query<[Array<{ lang: string; script: string }>]>(
-        `SELECT lang, script FROM type::thing('knowledge_fact', $tail)`,
+        `SELECT lang, script FROM type::record('knowledge_fact', $tail)`,
         { tail: factId.replace(/^knowledge_fact:/, '') },
       );
       return Array.isArray(rows) ? rows[0] : null;
@@ -61,7 +61,7 @@ describe('P1 e2e — Phase 4 DB persistence', () => {
     const surreal = f.app.get(SurrealService);
     const row = await surreal.withCompany(f.companyId, async (db) => {
       const [rows] = await db.query<[Array<{ lang: string; script: string }>]>(
-        `SELECT lang, script FROM type::thing('knowledge_fact', $tail)`,
+        `SELECT lang, script FROM type::record('knowledge_fact', $tail)`,
         { tail: factId.replace(/^knowledge_fact:/, '') },
       );
       return Array.isArray(rows) ? rows[0] : null;
@@ -85,7 +85,7 @@ describe('P1 e2e — Phase 4 DB persistence', () => {
       f.companyId,
       async (db) => {
         const [rows] = await db.query<[Array<{ embedding: number[] }>]>(
-          `SELECT embedding FROM type::thing('knowledge_fact', $tail)`,
+          `SELECT embedding FROM type::record('knowledge_fact', $tail)`,
           { tail: factId.replace(/^knowledge_fact:/, '') },
         );
         return Array.isArray(rows) ? rows[0]?.embedding ?? null : null;
@@ -103,7 +103,7 @@ describe('P1 e2e — Phase 4 DB persistence', () => {
       f.companyId,
       async (db) => {
         const [rows] = await db.query<[Array<{ embedding: number[] }>]>(
-          `SELECT embedding FROM type::thing('knowledge_fact', $tail)`,
+          `SELECT embedding FROM type::record('knowledge_fact', $tail)`,
           { tail: factId.replace(/^knowledge_fact:/, '') },
         );
         return Array.isArray(rows) ? rows[0]?.embedding ?? null : null;

--- a/test/revive-after-retract.e2e-spec.ts
+++ b/test/revive-after-retract.e2e-spec.ts
@@ -202,7 +202,7 @@ describe('revive after retract — memlc.cycle scenario', () => {
       const tail = aFactId.split(':')[1];
       const [rows] = await db.query<any[][]>(
         `SELECT status, retractedAt, retractionReason, supersededBy
-           FROM type::thing('knowledge_fact', $tail) LIMIT 1`,
+           FROM type::record('knowledge_fact', $tail) LIMIT 1`,
         { tail },
       );
       const row = (rows as any[])[0];

--- a/test/summarize-entity.e2e-spec.ts
+++ b/test/summarize-entity.e2e-spec.ts
@@ -52,7 +52,7 @@ describe('SummarizeEntityService.summarize — briefings + LRU', () => {
     const surreal = f.app.get(SurrealService);
     entityId = await surreal.withCompany(f.companyId, async (db) => {
       const [rows] = await db.query<any[][]>(
-        `SELECT entityId FROM type::thing('knowledge_fact', $tail)`,
+        `SELECT entityId FROM type::record('knowledge_fact', $tail)`,
         { tail: factId.split(':')[1] },
       );
       return String((rows as any[])?.[0]?.entityId ?? '');

--- a/test/summarize-watermark.e2e-spec.ts
+++ b/test/summarize-watermark.e2e-spec.ts
@@ -47,7 +47,7 @@ describe('SummarizeEntityService — watermark freshness', () => {
     const surreal = f.app.get(SurrealService);
     entityId = await surreal.withCompany(f.companyId, async (db) => {
       const [rows] = await db.query<any[][]>(
-        `SELECT entityId FROM type::thing('knowledge_fact', $tail)`,
+        `SELECT entityId FROM type::record('knowledge_fact', $tail)`,
         { tail: factId.split(':')[1] },
       );
       return String((rows as any[])?.[0]?.entityId ?? '');


### PR DESCRIPTION
Migrates the engine and all SurrealQL to the 3.x dialect. The JS SDK (`surrealdb@2.x`) already speaks the 3.x protocol — no client bump. The query/DDL surface has breaking changes, fixed here and verified by the full suite against a **v3.1.5** testcontainer.

## SurrealQL dialect (mechanical)
- `type::thing` → `type::record` (87 sites, src + tests)
- `duration::from::secs/millis` → `duration::from_secs/from_millis`
- `DEFINE INDEX … SEARCH ANALYZER` → `FULLTEXT ANALYZER` (BM25 lexical legs)
- `DEFINE FIELD … FLEXIBLE TYPE x` → `TYPE x FLEXIBLE`

## 3.x semantics (behavioural)
- **NS/DB no longer auto-created** on `use()` — migrator now `DEFINE NAMESPACE/DATABASE IF NOT EXISTS` before selecting a tenant DB.
- **`runTransaction`**: 3.x emits a result slot for the trailing `COMMIT` (always null). Read `arr[length-2]` (the RETURN), not the last slot. The old code returned the COMMIT null → every transactional upsert's id collapsed to `"undefined"` → spurious self-merge **400** on `/ingest/link` and broken `claimNext`. Unit mocks updated to the 3.x layout.
- **`isReadConflict`**: match 3.x single-statement conflict wording so `retryOnUniqueViolation` still serializes concurrent `single_active` ingests.
- **SCHEMAFULL arbitrary-key object arrays**: 3.x validates element sub-fields even under FLEXIBLE. Type the element via `field.*` `TYPE object FLEXIBLE` with a plain `array` parent (`debug_trace.spans/artifacts`, `extraction_pattern.facts/edges`).

## Tooling
`docker-compose` + e2e testcontainer pinned to `v3.1.5`.

## Verification
**639 unit + 127 e2e + 9 jobs.real** green against v3.1.5.

## ⚠️ Ops (not code)
Persistent deployments must migrate data: `surreal v2 export --v3` → `surreal import`. An in-place tag swap on an existing rocksdb volume is **not** supported across the major. Fresh/e2e environments need only the tag bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)