### PR TITLE
fix(db): SurrealDB 3.x runtime gaps surfaced by full-Docker boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,13 @@ SURREALDB_SCOPED_POOL_SIZE=8
 # SURREALDB_SCOPED_USER=brain_caller
 # SURREALDB_SCOPED_PASS=brain-caller-password-must-be-overridden-via-env
 
+# ── Forget tombstones (GDPR erase) ───────────────────────────────────────
+# HMAC key that signs forget tombstones. REQUIRED when NODE_ENV=production
+# (boot refuses to start without it — the default would let anyone forge
+# tombstone hashes). Use ≥ 32 chars. docker-compose ships a clearly-local
+# default so `docker compose up` works out of the box; override in real envs.
+FORGET_HMAC_KEY=change-me-to-a-long-random-secret-≥32-chars
+
 # ── OpenAI (embeddings + extraction) ─────────────────────────────────────
 OPENAI_API_KEY=sk-...
 OPENAI_EMBEDDING_MODEL=text-embedding-3-small

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,12 @@ services:
       - BRAIN_BASELINES_DIR=/app/.cache/baselines
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - BRAIN_API_KEYS=${BRAIN_API_KEYS:-[]}
-      - FORGET_HMAC_KEY=${FORGET_HMAC_KEY:-}
+      # The image runs NODE_ENV=production, where validateEnv REQUIRES a
+      # FORGET_HMAC_KEY (the tombstone-signing secret). Ship a clearly-local
+      # default so `docker compose up` works out of the box; a real env value
+      # (CI/prod) overrides it. ≥32 chars to also clear the length warning.
+      # Mirrors the SURREALDB_SCOPED_PASS local-default pattern above.
+      - FORGET_HMAC_KEY=${FORGET_HMAC_KEY:-local-dev-forget-hmac-key-change-in-prod}
     ports:
       - "${BRAIN_HOST_PORT:-3030}:3000"
     # Mirror the prod ceilings so local OOMs surface here, not in deploy.

--- a/src/ai/calibration/calibration-refit.service.ts
+++ b/src/ai/calibration/calibration-refit.service.ts
@@ -489,7 +489,7 @@ export class CalibrationRefitService implements OnModuleInit {
           }>,
         ]
       >(
-        `SELECT confidence, status, retractedAt, retractionReason
+        `SELECT confidence, status, retractedAt, retractionReason, recordedAt
             FROM knowledge_fact
             WHERE confidence IS NOT NONE
               AND time::now() - recordedAt > 30d

--- a/src/ai/calibration/calibration.service.ts
+++ b/src/ai/calibration/calibration.service.ts
@@ -110,7 +110,7 @@ export class CalibrationService implements OnModuleInit {
           }>,
         ]
       >(
-        `SELECT thresholds, values, sampleCount
+        `SELECT version, thresholds, values, sampleCount
            FROM calibration_table
            WHERE extractorModel = $m AND promptHash = $p
            ORDER BY version DESC LIMIT 1`,

--- a/src/ai/entity-judge.service.ts
+++ b/src/ai/entity-judge.service.ts
@@ -80,7 +80,9 @@ export class EntityJudgeService {
   async fetchTopFacts(db: Surreal, entityId: string): Promise<string> {
     type R = { predicate: string; object: string };
     const [rows] = await db.query<[R[]]>(
-      `SELECT predicate, object FROM knowledge_fact
+      // confidence must be in the projection — SurrealDB 3.x requires the
+      // ORDER BY idiom to appear in the SELECT (else "Missing order idiom").
+      `SELECT predicate, object, confidence FROM knowledge_fact
          WHERE entityId = $eid
            AND status = 'active'
            AND retractedAt IS NONE

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -551,10 +551,16 @@ export class SurrealService implements OnModuleInit, OnModuleDestroy {
       );
       return;
     }
+    // SurrealDB 3.x requires DEFINE USER … PASSWORD to be a string LITERAL
+    // (a "strand"), not a bound parameter — `PASSWORD $pass` raises
+    // "Unexpected token `a parameter`, expected a strand". Splice the secret
+    // as an escaped single-quoted literal. scopedPass is an operator-supplied
+    // env secret; escape backslashes then single quotes so it can't break out
+    // of the literal or malform the DDL.
+    const escapedPass = scopedPass.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
     try {
       await this.migratorConn.query(
-        `DEFINE USER OVERWRITE ${scopedUser} ON NAMESPACE PASSWORD $pass ROLES EDITOR`,
-        { pass: scopedPass },
+        `DEFINE USER OVERWRITE ${scopedUser} ON NAMESPACE PASSWORD '${escapedPass}' ROLES EDITOR`,
       );
       this.logger.log(`Reset password for scoped user '${scopedUser}'`);
     } catch (err) {


### PR DESCRIPTION
Follow-up to #24. The 3.1.5 upgrade passed CI, but bringing up the **whole stack** with `docker compose up` (prod image, `NODE_ENV=production`) surfaced runtime paths the e2e didn't exercise. These fixes make the full stack boot clean with the scoped DB-security layer active.

- **`FORGET_HMAC_KEY`** had an empty compose default → the production image refused to boot (`must be set in production`). Ship a clearly-local default (mirrors `SURREALDB_SCOPED_PASS`); real envs override. Documented in `.env.example`.
- **`DEFINE USER … PASSWORD`**: 3.x requires a string literal, not a bound param (`PASSWORD $pass` → *"Unexpected token `a parameter`, expected a strand"*). Splice the scoped-user secret as an escaped single-quoted literal. Without this the scoped pool fell back to root every boot — app worked but the DB-level PERMISSIONS fence was off.
- **`ORDER BY` must reference a projected field** in 3.x (`SELECT a,b … ORDER BY c` → parse error *"Missing order idiom"*). Add the sort column to the projection in three e2e-uncovered queries: calibration bootstrap probe, calibration refit retraction scan, `EntityJudge.fetchTopFacts`.

## Verified end-to-end
`docker compose up` → brain **healthy**, **0 parse errors**, `Reset password for scoped user 'brain_caller'`, migrations through 0039, `/health` 200. **639 unit + e2e** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)