### PR TITLE
feat(app): end-user memory UI with Explore/Develop console

### DIFF
--- a/.github/workflows/deploy-brain-landing.yml
+++ b/.github/workflows/deploy-brain-landing.yml
@@ -156,6 +156,15 @@ jobs:
                 - OAUTH_CLIENT_ID=brain-landing
                 - NEXT_PUBLIC_OAUTH_CLIENT_ID=brain-landing
                 - OAUTH_CLIENT_SECRET=${{ secrets.OAUTH_CLIENT_SECRET }}
+                # End-user product UI (/[lang]/app/**). ENABLED asserts this
+                # is a single-company deployment — brain derives the tenant
+                # from the service credential, not the end user, so the
+                # surface is only safe when all brain-landing users belong to
+                # one company. ALLOW_USER_WRITES lets any authenticated user
+                # (not just admins) record/retract facts in that company's
+                # memory via the user BFF.
+                - BRAIN_APP_ENABLED=1
+                - BRAIN_APP_ALLOW_USER_WRITES=1
               labels:
                 - "traefik.enable=true"
                 - "traefik.docker.network=traefik-global"

--- a/brain-landing/app/[lang]/app/communities/page.tsx
+++ b/brain-landing/app/[lang]/app/communities/page.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+/* eslint-disable react/jsx-no-literals -- TODO i18n: end-user /app pages ship English-only for MVP (admin UI is too); queued for a dedicated i18n pass. */
+
+import { useCallback, useEffect, useState } from 'react'
+import { Users, Search } from 'lucide-react'
+import { useProxyBase } from '../../../../components/playground/usePlaygroundCall'
+
+interface Community {
+  communityId: string
+  label: string
+  summary: string
+  memberCount: number
+  builtAt: string
+  similarity?: number
+}
+
+/**
+ * Communities — clusters of densely-connected entities the brain builds
+ * off-hours. Lists the largest clusters and supports semantic search
+ * over their summaries. Backed by GET /v1/communities and
+ * /v1/communities/search through the reduced-scope app BFF.
+ */
+export default function CommunitiesPage() {
+  const proxyBase = useProxyBase()
+  const [items, setItems] = useState<Community[]>([])
+  const [query, setQuery] = useState('')
+  const [searching, setSearching] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState<string | null>(null)
+
+  const loadList = useCallback(async () => {
+    setLoading(true)
+    setErr(null)
+    try {
+      const res = await fetch(`${proxyBase}/v1/communities?limit=50`)
+      const data = await res.json()
+      if (!res.ok) throw new Error(data?.error ?? `Failed (${res.status})`)
+      setItems((data?.communities ?? []) as Community[])
+      setSearching(false)
+    } catch (e) {
+      setErr((e as Error).message)
+      setItems([])
+    } finally {
+      setLoading(false)
+    }
+  }, [proxyBase])
+
+  useEffect(() => {
+    void loadList()
+  }, [loadList])
+
+  const runSearch = useCallback(
+    async (q: string) => {
+      if (!q.trim()) {
+        void loadList()
+        return
+      }
+      setLoading(true)
+      setErr(null)
+      try {
+        const res = await fetch(
+          `${proxyBase}/v1/communities/search?query=${encodeURIComponent(q)}&limit=10`,
+        )
+        const data = await res.json()
+        if (!res.ok) throw new Error(data?.error ?? `Failed (${res.status})`)
+        setItems((data?.communities ?? []) as Community[])
+        setSearching(true)
+      } catch (e) {
+        setErr((e as Error).message)
+        setItems([])
+      } finally {
+        setLoading(false)
+      }
+    },
+    [proxyBase, loadList],
+  )
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <div>
+        <h1 className="text-lg font-semibold text-[var(--text)]">Communities</h1>
+        <p className="text-sm text-[var(--text-muted)] mt-1">
+          Groups of densely-connected entities your brain has clustered
+          together, each with a rolled-up summary.
+        </p>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          void runSearch(query)
+        }}
+        className="flex items-center gap-2"
+      >
+        <div className="flex items-center gap-2 px-3 h-9 flex-1 rounded-md border border-[var(--border)] bg-[var(--bg-elevated)]">
+          <Search className="w-3.5 h-3.5 text-[var(--text-faint)]" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search communities by topic…"
+            className="bg-transparent text-sm text-[var(--text)] placeholder:text-[var(--text-faint)] outline-none flex-1"
+          />
+        </div>
+        <button
+          type="submit"
+          className="px-3 h-9 rounded-md bg-[var(--accent)] text-white text-sm"
+        >
+          Search
+        </button>
+        {searching && (
+          <button
+            type="button"
+            onClick={() => {
+              setQuery('')
+              void loadList()
+            }}
+            className="px-3 h-9 rounded-md border border-[var(--border)] text-sm text-[var(--text-muted)] hover:text-[var(--text)]"
+          >
+            Clear
+          </button>
+        )}
+      </form>
+
+      {err && <div className="text-xs text-[var(--danger)] font-mono">{err}</div>}
+      {loading && (
+        <div className="text-sm text-[var(--text-muted)]">Loading…</div>
+      )}
+
+      {!loading && items.length === 0 && !err && (
+        <div className="border border-[var(--border)] rounded-md p-8 flex flex-col items-center text-center gap-2 text-[var(--text-muted)]">
+          <Users className="w-6 h-6 text-[var(--text-faint)]" />
+          <div className="text-sm">
+            {searching
+              ? 'No communities match that query.'
+              : 'No communities yet.'}
+          </div>
+          <div className="text-xs text-[var(--text-faint)] max-w-sm">
+            Communities are built off-hours once the graph has enough connected
+            entities.
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {items.map((c) => (
+          <div
+            key={c.communityId}
+            className="border border-[var(--border)] rounded-md p-3"
+          >
+            <div className="flex items-baseline gap-2">
+              <span className="font-medium text-[var(--text)] truncate">
+                {c.label || 'Untitled cluster'}
+              </span>
+              <span className="text-[10px] font-mono text-[var(--text-faint)]">
+                {c.memberCount} members
+              </span>
+              {c.similarity !== undefined && (
+                <span className="ml-auto text-xs font-mono text-[var(--accent)]">
+                  {c.similarity.toFixed(3)}
+                </span>
+              )}
+            </div>
+            {c.summary && (
+              <p className="mt-1 text-sm text-[var(--text-muted)]">{c.summary}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/brain-landing/app/[lang]/app/entities/page.tsx
+++ b/brain-landing/app/[lang]/app/entities/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+/* eslint-disable react/jsx-no-literals -- TODO i18n: end-user /app pages ship English-only for MVP (admin UI is too); queued for a dedicated i18n pass. */
+
+import { useState } from 'react'
+import {
+  EntitySearch,
+  type SearchHit,
+} from '../../../../components/admin/EntitySearch'
+import { EntityDetailDock } from '../../../../components/EntityDetailDock'
+
+/**
+ * Entities — find an entity and inspect its full profile: active facts,
+ * external refs, and bitemporal lineage. The detail view reuses the
+ * admin EntityPanel (rendered as a docked side panel). All fetches go
+ * through the reduced-scope app BFF.
+ */
+export default function EntitiesPage() {
+  const [selected, setSelected] = useState<SearchHit | null>(null)
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h1 className="text-lg font-semibold text-[var(--text)]">Entities</h1>
+        <p className="text-sm text-[var(--text-muted)] mt-1">
+          Search people, places, projects and topics in your memory. Open one
+          to see its current facts and full bitemporal history.
+        </p>
+      </div>
+
+      <div className="max-w-md">
+        <EntitySearch onSelect={setSelected} />
+      </div>
+
+      <EntityDetailDock
+        entityId={selected?.entityId ?? null}
+        onClose={() => setSelected(null)}
+        emptyTitle="Search above to pick an entity."
+        emptyHint="Its profile and timeline will appear here."
+      />
+    </div>
+  )
+}

--- a/brain-landing/app/[lang]/app/graph/page.tsx
+++ b/brain-landing/app/[lang]/app/graph/page.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+/* eslint-disable react/jsx-no-literals -- TODO i18n: end-user /app pages ship English-only for MVP (admin UI is too); queued for a dedicated i18n pass. */
+
+import { GraphExplorer } from '../../../../components/admin/GraphExplorer'
+
+/**
+ * Knowledge graph — interactive force-directed explorer over the
+ * caller's memory. Search to seed, click for a profile, double-click to
+ * expand neighbours. Reuses the admin GraphExplorer; all its fetches go
+ * through the reduced-scope app BFF via ProxyBaseProvider.
+ */
+export default function GraphPage() {
+  return (
+    <div className="space-y-3">
+      <div>
+        <h1 className="text-lg font-semibold text-[var(--text)]">
+          Knowledge graph
+        </h1>
+        <p className="text-sm text-[var(--text-muted)] mt-1">
+          Search an entity to seed the graph, then expand its relationships.
+          Drag the bitemporal slider to see the graph as it was at any point in
+          time.
+        </p>
+      </div>
+      <div className="h-[calc(100vh-12rem)] min-h-[28rem]">
+        <GraphExplorer />
+      </div>
+    </div>
+  )
+}

--- a/brain-landing/app/[lang]/app/keys/page.tsx
+++ b/brain-landing/app/[lang]/app/keys/page.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+/* eslint-disable react/jsx-no-literals -- TODO i18n: end-user /app pages ship English-only for MVP (admin UI is too); queued for a dedicated i18n pass. */
+
+import { useParams } from 'next/navigation'
+import { McpInstall } from '../../../../components/McpInstall'
+import { QuickstartTabs } from '../../../../components/QuickstartTabs'
+import { normalizeLang } from '../../../../lib/i18n'
+
+/**
+ * Keys & integrations — how to connect to brain. For now this surfaces
+ * the MCP connection config and SDK quickstart (read-only). Brain keys
+ * are issued per company, not per user, so self-serve per-user key CRUD
+ * is a later backend increment; today this is the onboarding surface.
+ */
+export default function KeysPage() {
+  const params = useParams<{ lang: string }>()
+  const lang = normalizeLang(params?.lang)
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      <div>
+        <h1 className="text-lg font-semibold text-[var(--text)]">
+          Keys &amp; integrations
+        </h1>
+        <p className="text-sm text-[var(--text-muted)] mt-1">
+          Connect your agents and tools to this brain. Use the MCP config for
+          Claude Desktop, Cursor, and other MCP hosts, or the SDK quickstart
+          for direct API access.
+        </p>
+      </div>
+
+      <section className="space-y-2">
+        <h2 className="text-sm font-medium text-[var(--text)]">MCP</h2>
+        <McpInstall lang={lang} />
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-sm font-medium text-[var(--text)]">Quickstart</h2>
+        <QuickstartTabs lang={lang} />
+      </section>
+
+      <p className="text-xs text-[var(--text-faint)]">
+        Brain keys are scoped to your company. Need a new key or per-user
+        scopes? Contact your workspace admin.
+      </p>
+    </div>
+  )
+}

--- a/brain-landing/app/[lang]/app/layout.tsx
+++ b/brain-landing/app/[lang]/app/layout.tsx
@@ -1,141 +1,101 @@
 'use client'
 
-/* eslint-disable react/jsx-no-literals -- TODO i18n: admin shell is English-only (pre-Phase-J); queued for a dedicated i18n pass. */
+/* eslint-disable react/jsx-no-literals -- TODO i18n: end-user /app pages ship English-only for MVP (admin UI is too); queued for a dedicated i18n pass. */
 
+import Link from 'next/link'
 import { usePathname, useParams } from 'next/navigation'
 import { ReactNode, useState } from 'react'
 import {
-  Activity,
-  CalendarClock,
-  ClipboardList,
-  Coins,
-  Cpu,
-  Database,
-  FlaskConical,
-  Gauge,
-  Heart,
-  History,
+  BarChart3,
+  GitCompareArrows,
   KeyRound,
-  ListChecks,
-  Lock,
   Menu,
-  Moon,
   Network,
-  Presentation,
-  Play,
-  Radio,
-  Settings2,
-  ShieldAlert,
-  Sigma,
-  Skull,
-  SlidersHorizontal,
-  Tags,
-  Trash2,
+  Search,
+  Boxes,
+  History,
+  FlaskConical,
+  Users,
   UserRound,
-  Waypoints,
   X,
 } from 'lucide-react'
-import { CommandPalette } from '../../../components/admin/CommandPalette'
 import { Header } from '../../../components/Header'
 import { ShellNav, type ShellGroup } from '../../../components/ShellNav'
+import { ProxyBaseProvider } from '../../../components/playground/usePlaygroundCall'
 import { useAuth } from '../../../hooks/useAuth'
 import { normalizeLang } from '../../../lib/i18n'
+
+/** End-user pages route all brain calls through the reduced-scope BFF. */
+const APP_PROXY_BASE = '/api/app/proxy'
 
 interface Props {
   children: ReactNode
 }
 
+// Two-section product shell: a memory Explorer for everyone, and a
+// Develop console for technical users. Mirrors the admin layout's
+// nav/mobile-drawer structure but routes under /[lang]/app/*.
 const GROUPS: ShellGroup[] = [
   {
-    label: 'Ops',
+    label: 'Explore',
     items: [
-      { slug: 'explore/overview', title: 'Overview', icon: Activity },
-      { slug: 'maintenance', title: 'Maintenance', icon: CalendarClock },
-      { slug: 'jobs', title: 'Jobs', icon: Play },
-      { slug: 'dreams', title: 'Dreams', icon: Moon },
-      { slug: 'cost', title: 'Cost', icon: Coins },
-      { slug: 'audit', title: 'Audit log', icon: History },
-      { slug: 'operator-actions', title: 'Operator actions', icon: KeyRound },
-      { slug: 'router', title: 'Router / cache', icon: Gauge },
-      { slug: 'predicates', title: 'Predicates', icon: Tags },
+      { slug: 'search', title: 'Search & Ask', icon: Search },
+      { slug: 'entities', title: 'Entities', icon: Boxes },
+      { slug: 'graph', title: 'Knowledge graph', icon: Network },
+      { slug: 'timeline', title: 'Timeline', icon: History },
+      { slug: 'review', title: 'Conflicts', icon: GitCompareArrows },
+      { slug: 'communities', title: 'Communities', icon: Users },
     ],
   },
   {
-    label: 'Compliance',
-    items: [
-      { slug: 'pii', title: 'PII inventory', icon: ShieldAlert },
-      { slug: 'forgotten', title: 'Forgotten', icon: Skull },
-      { slug: 'dlq', title: 'Dead-letter', icon: Trash2 },
-      { slug: 'config', title: 'Config', icon: Settings2 },
-    ],
-  },
-  {
-    label: 'Infra',
-    items: [
-      { slug: 'health', title: 'Health', icon: Heart },
-      { slug: 'migrations', title: 'Migrations', icon: Database },
-      { slug: 'throttler', title: 'Throttler', icon: SlidersHorizontal },
-      { slug: 'now', title: 'In-flight', icon: Radio },
-      { slug: 'leases', title: 'Leases', icon: Lock },
-    ],
-  },
-  {
-    label: 'Eval',
-    items: [
-      { slug: 'scenarios', title: 'Scenarios', icon: ListChecks },
-      { slug: 'baselines', title: 'Baselines', icon: ClipboardList },
-      { slug: 'calibration', title: 'Calibration', icon: Sigma },
-      { slug: 'traces', title: 'Traces', icon: Waypoints },
-    ],
-  },
-  {
-    label: 'Dev',
+    label: 'Develop',
     items: [
       { slug: 'playground', title: 'Playground', icon: FlaskConical },
-      { slug: 'explore/graph', title: 'Graph explorer', icon: Network },
-      { slug: 'reindex', title: 'Reindex', icon: Cpu },
+      { slug: 'keys', title: 'Keys & integrations', icon: KeyRound },
+      { slug: 'usage', title: 'Usage', icon: BarChart3 },
     ],
-  },
-  {
-    label: 'Live',
-    items: [{ slug: 'demo', title: 'Demo deck', icon: Presentation }],
   },
 ]
 
-export default function AdminLayout({ children }: Props) {
+export default function AppLayout({ children }: Props) {
   const params = useParams<{ lang: string }>()
   const lang = normalizeLang(params?.lang)
   const pathname = usePathname() ?? ''
   const auth = useAuth()
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
 
-  if (!auth.loading && !auth.isAdmin) {
+  if (!auth.loading && !auth.isAuthenticated) {
     return (
       <div className="min-h-screen bg-[var(--bg)] flex items-center justify-center">
         <div className="max-w-md text-center px-4">
           <h1 className="text-xl font-semibold text-[var(--text)]">
-            Admin sign-in required
+            Sign-in required
           </h1>
           <p className="mt-2 text-sm text-[var(--text-muted)]">
-            This area is restricted to brain operators. Sign in through
-            <code className="ml-1 text-[var(--accent)]">auth.inite.ai</code>{' '}
-            with an account that has <code>metadata.isAdmin = true</code>.
+            Sign in through
+            <code className="mx-1 text-[var(--accent)]">auth.inite.ai</code>
+            to explore your brain.
           </p>
+          <Link
+            href={`/api/auth/login?return_url=${encodeURIComponent(
+              pathname || `/${lang}/app/search`,
+            )}`}
+            className="mt-4 inline-block px-4 py-2 rounded-md text-sm bg-[var(--accent)] text-white"
+          >
+            Sign in
+          </Link>
         </div>
       </div>
     )
   }
 
-  const adminPath = pathname.replace(/^\/+(en|ru)\/admin\/?/, '')
-  const currentSlug = adminPath.startsWith('explore/')
-    ? adminPath.split('/').slice(0, 2).join('/')
-    : adminPath.split('/')[0]
-
+  const appPath = pathname.replace(/^\/+(en|ru)\/app\/?/, '')
+  const currentSlug = appPath.split('/')[0]
   const closeNav = () => setMobileNavOpen(false)
 
   return (
     <div className="min-h-screen bg-[var(--bg)]">
-      <Header lang={lang} context="Admin" />
+      <Header lang={lang} context="Brain" />
 
       <div className="border-b border-[var(--border)] bg-[var(--bg-elevated)]/60 backdrop-blur sticky top-12 z-20">
         <div className="max-w-7xl mx-auto px-4 h-10 flex items-center gap-2 text-xs">
@@ -147,7 +107,7 @@ export default function AdminLayout({ children }: Props) {
           >
             <Menu className="w-4 h-4" />
           </button>
-          <CommandPalette lang={lang} />
+          <span className="font-mono text-[var(--text-muted)]">Memory</span>
           <div className="ml-auto flex items-center gap-2 text-[var(--text-muted)]">
             {auth.email && (
               <span className="hidden sm:flex items-center gap-1">
@@ -155,15 +115,14 @@ export default function AdminLayout({ children }: Props) {
                 <span className="font-mono">{auth.email}</span>
               </span>
             )}
-            <span
-              className={`px-1.5 py-0.5 rounded text-[10px] font-mono ${
-                auth.isAdmin
-                  ? 'bg-[var(--accent)]/10 text-[var(--accent)]'
-                  : 'bg-[var(--bg-overlay)] text-[var(--text-faint)]'
-              }`}
-            >
-              {auth.loading ? '…' : auth.isAdmin ? 'brain:admin' : 'no admin'}
-            </span>
+            {auth.isAdmin && (
+              <Link
+                href={`/${lang}/admin/explore/overview`}
+                className="px-1.5 py-0.5 rounded text-[10px] font-mono bg-[var(--accent)]/10 text-[var(--accent)]"
+              >
+                admin
+              </Link>
+            )}
           </div>
         </div>
       </div>
@@ -173,9 +132,9 @@ export default function AdminLayout({ children }: Props) {
           <ShellNav
             groups={GROUPS}
             currentSlug={currentSlug}
-            hrefFor={(slug) => `/${lang}/admin/${slug}`}
+            hrefFor={(slug) => `/${lang}/app/${slug}`}
             onNavigate={closeNav}
-            ariaLabel="Admin sections"
+            ariaLabel="Memory sections"
           />
         </aside>
 
@@ -190,7 +149,7 @@ export default function AdminLayout({ children }: Props) {
             >
               <div className="flex items-center justify-between mb-3">
                 <span className="text-xs uppercase tracking-wider text-[var(--text-faint)]">
-                  Admin
+                  Memory
                 </span>
                 <button
                   type="button"
@@ -204,15 +163,17 @@ export default function AdminLayout({ children }: Props) {
               <ShellNav
                 groups={GROUPS}
                 currentSlug={currentSlug}
-                hrefFor={(slug) => `/${lang}/admin/${slug}`}
+                hrefFor={(slug) => `/${lang}/app/${slug}`}
                 onNavigate={closeNav}
-                ariaLabel="Admin sections"
+                ariaLabel="Memory sections"
               />
             </aside>
           </div>
         )}
 
-        <main className="py-6 min-w-0">{children}</main>
+        <main className="py-6 min-w-0">
+          <ProxyBaseProvider value={APP_PROXY_BASE}>{children}</ProxyBaseProvider>
+        </main>
       </div>
     </div>
   )

--- a/brain-landing/app/[lang]/app/page.tsx
+++ b/brain-landing/app/[lang]/app/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation'
+
+/** /[lang]/app → Search & Ask is the product home. */
+export default async function AppHome({
+  params,
+}: {
+  params: Promise<{ lang: string }>
+}) {
+  const { lang } = await params
+  redirect(`/${lang}/app/search`)
+}

--- a/brain-landing/app/[lang]/app/playground/page.tsx
+++ b/brain-landing/app/[lang]/app/playground/page.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+/* eslint-disable react/jsx-no-literals -- TODO i18n: end-user /app pages ship English-only for MVP (admin UI is too); queued for a dedicated i18n pass. */
+
+import { useState } from 'react'
+import { SearchForm } from '../../../../components/playground/SearchForm'
+import { SynthesizeForm } from '../../../../components/playground/SynthesizeForm'
+import { MentionForm } from '../../../../components/playground/MentionForm'
+
+type Tab = 'search' | 'synthesize' | 'record'
+
+const TABS: Array<{ id: Tab; label: string }> = [
+  { id: 'search', label: 'Search' },
+  { id: 'synthesize', label: 'Synthesize' },
+  { id: 'record', label: 'Record' },
+]
+
+/**
+ * Playground — the developer surface. Exercise the brain API directly
+ * (record a mention, search, synthesize) and inspect the raw response
+ * plus the per-request trace waterfall. Every call goes through the
+ * reduced-scope app BFF, so it behaves exactly like an integration on
+ * a brain:read/brain:write key.
+ */
+export default function PlaygroundPage() {
+  const [tab, setTab] = useState<Tab>('search')
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <div>
+        <h1 className="text-lg font-semibold text-[var(--text)]">Playground</h1>
+        <p className="text-sm text-[var(--text-muted)] mt-1">
+          Test ingestion and retrieval interactively. Each response carries a{' '}
+          <span className="font-mono text-[var(--text)]">raw</span> and{' '}
+          <span className="font-mono text-[var(--text)]">trace</span> tab so you
+          can see exactly what the API returns and why.
+        </p>
+      </div>
+
+      <div className="inline-flex rounded-md border border-[var(--border)] p-0.5 text-sm">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => setTab(t.id)}
+            className={`px-3 py-1 rounded ${
+              tab === t.id
+                ? 'bg-[var(--bg-overlay)] text-[var(--text)]'
+                : 'text-[var(--text-muted)] hover:text-[var(--text)]'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'search' && <SearchForm />}
+      {tab === 'synthesize' && <SynthesizeForm />}
+      {tab === 'record' && <MentionForm />}
+    </div>
+  )
+}

--- a/brain-landing/app/[lang]/app/review/page.tsx
+++ b/brain-landing/app/[lang]/app/review/page.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+/* eslint-disable react/jsx-no-literals -- TODO i18n: end-user /app pages ship English-only for MVP (admin UI is too); queued for a dedicated i18n pass. */
+
+import { useCallback, useState } from 'react'
+import { AlertTriangle, Check } from 'lucide-react'
+import {
+  EntitySearch,
+  type SearchHit,
+} from '../../../../components/admin/EntitySearch'
+import { useProxyBase } from '../../../../components/playground/usePlaygroundCall'
+
+interface Fact {
+  factId: string
+  predicate: string
+  object: string | null
+  status?: string
+  confidence?: number
+  validFrom?: string
+}
+
+interface Profile {
+  entityId: string
+  canonicalName?: string
+  facts: Fact[]
+}
+
+/**
+ * Conflicts — surface competing facts and let the user resolve them by
+ * retracting the wrong one. Brain's conflict resolver marks rival facts
+ * `competing` when their scores are within margin; this page groups an
+ * entity's facts by predicate and flags predicates that carry more than
+ * one live value. Retraction calls POST /v1/facts/:id/retract (audited,
+ * brain:write).
+ */
+export default function ReviewPage() {
+  const proxyBase = useProxyBase()
+  const [selected, setSelected] = useState<SearchHit | null>(null)
+  const [profile, setProfile] = useState<Profile | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const load = useCallback(
+    async (entityId: string) => {
+      setLoading(true)
+      setErr(null)
+      try {
+        const res = await fetch(
+          `${proxyBase}/v1/entities/${encodeURIComponent(entityId)}`,
+        )
+        const data = await res.json()
+        if (!res.ok) throw new Error(data?.error ?? `Failed (${res.status})`)
+        setProfile(data as Profile)
+      } catch (e) {
+        setErr((e as Error).message)
+        setProfile(null)
+      } finally {
+        setLoading(false)
+      }
+    },
+    [proxyBase],
+  )
+
+  const onSelect = useCallback(
+    (hit: SearchHit) => {
+      setSelected(hit)
+      void load(hit.entityId)
+    },
+    [load],
+  )
+
+  const retract = useCallback(
+    async (factId: string) => {
+      setBusy(factId)
+      setErr(null)
+      try {
+        const res = await fetch(
+          `${proxyBase}/v1/facts/${encodeURIComponent(factId)}/retract`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ reason: 'manual conflict resolution' }),
+          },
+        )
+        const data = await res.json().catch(() => ({}))
+        if (!res.ok) throw new Error(data?.error ?? `Retract failed (${res.status})`)
+        if (selected) await load(selected.entityId)
+      } catch (e) {
+        setErr((e as Error).message)
+      } finally {
+        setBusy(null)
+      }
+    },
+    [proxyBase, selected, load],
+  )
+
+  // Group live facts by predicate; a predicate with >1 entry is a conflict.
+  const groups = groupConflicts(profile?.facts ?? [])
+
+  return (
+    <div className="max-w-3xl space-y-3">
+      <div>
+        <h1 className="text-lg font-semibold text-[var(--text)]">Conflicts</h1>
+        <p className="text-sm text-[var(--text-muted)] mt-1">
+          When memory holds two competing values for the same attribute, pick
+          the right one — retract the other. Retractions are audited and
+          reversible in history.
+        </p>
+      </div>
+
+      <div className="max-w-md">
+        <EntitySearch onSelect={onSelect} />
+      </div>
+
+      {err && (
+        <div className="text-xs text-[var(--danger)] font-mono">{err}</div>
+      )}
+      {loading && (
+        <div className="text-sm text-[var(--text-muted)]">Loading…</div>
+      )}
+
+      {profile && !loading && (
+        <div className="space-y-3">
+          {groups.length === 0 ? (
+            <div className="flex items-center gap-2 text-sm text-[var(--success)]">
+              <Check className="w-4 h-4" />
+              No competing facts for{' '}
+              <span className="font-medium">
+                {profile.canonicalName ?? profile.entityId}
+              </span>
+              .
+            </div>
+          ) : (
+            groups.map((g) => (
+              <div
+                key={g.predicate}
+                className="border border-[var(--warning)]/40 rounded-md p-3"
+              >
+                <div className="flex items-center gap-1.5 text-xs text-[var(--warning)] mb-2">
+                  <AlertTriangle className="w-3.5 h-3.5" />
+                  <span className="font-mono">{g.predicate}</span>
+                  <span className="text-[var(--text-faint)]">
+                    · {g.facts.length} competing values
+                  </span>
+                </div>
+                <ul className="space-y-1.5">
+                  {g.facts.map((f) => (
+                    <li
+                      key={f.factId}
+                      className="flex items-center gap-2 text-sm"
+                    >
+                      <span className="flex-1 text-[var(--text)] truncate">
+                        {f.object ?? (
+                          <em className="text-[var(--text-faint)]">[gated]</em>
+                        )}
+                      </span>
+                      {f.confidence !== undefined && (
+                        <span className="text-[10px] font-mono text-[var(--text-faint)]">
+                          {f.confidence.toFixed(2)}
+                        </span>
+                      )}
+                      <button
+                        type="button"
+                        disabled={busy === f.factId}
+                        onClick={() => retract(f.factId)}
+                        className="px-2 py-1 rounded border border-[var(--border)] text-xs text-[var(--text-muted)] hover:text-[var(--danger)] hover:border-[var(--danger)] disabled:opacity-50"
+                      >
+                        {busy === f.factId ? 'Retracting…' : 'Retract'}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const LIVE_STATUSES = new Set(['active', 'competing'])
+
+function groupConflicts(
+  facts: Fact[],
+): Array<{ predicate: string; facts: Fact[] }> {
+  const byPred = new Map<string, Fact[]>()
+  for (const f of facts) {
+    if (f.status && !LIVE_STATUSES.has(f.status)) continue
+    const arr = byPred.get(f.predicate) ?? []
+    arr.push(f)
+    byPred.set(f.predicate, arr)
+  }
+  return [...byPred.entries()]
+    .filter(([, arr]) => arr.length > 1)
+    .map(([predicate, arr]) => ({ predicate, facts: arr }))
+}

--- a/brain-landing/app/[lang]/app/search/page.tsx
+++ b/brain-landing/app/[lang]/app/search/page.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+/* eslint-disable react/jsx-no-literals -- TODO i18n: end-user /app pages ship English-only for MVP (admin UI is too); queued for a dedicated i18n pass. */
+
+import { useState } from 'react'
+import { SearchForm } from '../../../../components/playground/SearchForm'
+import { SynthesizeForm } from '../../../../components/playground/SynthesizeForm'
+
+type Mode = 'search' | 'ask'
+
+/**
+ * Search & Ask — the product home. Two modes over the same memory:
+ *  - Search: ranked entities + facts with scores.
+ *  - Ask: a grounded answer with citations.
+ *
+ * Both forms expose a "trace" tab (the per-leg retrieval waterfall)
+ * which is our differentiator: users can see *why* something was
+ * retrieved, not just the result. Forms route through the reduced-scope
+ * app BFF via the ProxyBaseProvider in the app layout.
+ */
+export default function SearchPage() {
+  const [mode, setMode] = useState<Mode>('search')
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <div>
+        <h1 className="text-lg font-semibold text-[var(--text)]">Search &amp; Ask</h1>
+        <p className="text-sm text-[var(--text-muted)] mt-1">
+          Query your brain in natural language. Open the{' '}
+          <span className="font-mono text-[var(--text)]">trace</span> tab on any
+          result to see <em>why</em> each fact was retrieved — the per-leg
+          scores, fusion, and reranking behind the answer.
+        </p>
+      </div>
+
+      <div className="inline-flex rounded-md border border-[var(--border)] p-0.5 text-sm">
+        {(['search', 'ask'] as Mode[]).map((m) => (
+          <button
+            key={m}
+            type="button"
+            onClick={() => setMode(m)}
+            className={`px-3 py-1 rounded ${
+              mode === m
+                ? 'bg-[var(--bg-overlay)] text-[var(--text)]'
+                : 'text-[var(--text-muted)] hover:text-[var(--text)]'
+            }`}
+          >
+            {m === 'search' ? 'Search' : 'Ask'}
+          </button>
+        ))}
+      </div>
+
+      {mode === 'search' ? <SearchForm /> : <SynthesizeForm />}
+    </div>
+  )
+}

--- a/brain-landing/app/[lang]/app/timeline/page.tsx
+++ b/brain-landing/app/[lang]/app/timeline/page.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+/* eslint-disable react/jsx-no-literals -- TODO i18n: end-user /app pages ship English-only for MVP (admin UI is too); queued for a dedicated i18n pass. */
+
+import { useState } from 'react'
+import {
+  EntitySearch,
+  type SearchHit,
+} from '../../../../components/admin/EntitySearch'
+import { EntityDetailDock } from '../../../../components/EntityDetailDock'
+import { AsOfSlider } from '../../../../components/admin/AsOfSlider'
+
+/**
+ * Timeline — memory over time. Pick an entity, then sweep the two
+ * bitemporal axes:
+ *   - valid (asOf):     "what was true in the world at this moment?"
+ *   - tx (recordedAt):  "what did we know about it as of this moment?"
+ *
+ * The EntityPanel re-fetches against both axes and renders the full
+ * bitemporal lineage. This is the surface neither mem0 nor Zep offer —
+ * watching memory evolve, not just reading the latest state.
+ */
+export default function TimelinePage() {
+  const [selected, setSelected] = useState<SearchHit | null>(null)
+  const [asOf, setAsOf] = useState<string | null>(null)
+  const [recordedAt, setRecordedAt] = useState<string | null>(null)
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h1 className="text-lg font-semibold text-[var(--text)]">Timeline</h1>
+        <p className="text-sm text-[var(--text-muted)] mt-1">
+          See how an entity&apos;s facts changed over time. Pick an entity, then
+          move the bitemporal sliders to travel through both world-time and
+          knowledge-time.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="w-72 max-w-full">
+          <EntitySearch onSelect={setSelected} />
+        </div>
+        {selected && (
+          <AsOfSlider
+            asOf={asOf}
+            recordedAt={recordedAt}
+            onChange={({ asOf: nextAsOf, recordedAt: nextTx }) => {
+              setAsOf(nextAsOf)
+              setRecordedAt(nextTx ?? null)
+            }}
+          />
+        )}
+      </div>
+
+      <EntityDetailDock
+        entityId={selected?.entityId ?? null}
+        asOf={asOf}
+        recordedAt={recordedAt}
+        onClose={() => setSelected(null)}
+        emptyTitle="Pick an entity to see its history."
+        emptyHint="Then scrub the sliders to replay how memory changed."
+      />
+    </div>
+  )
+}

--- a/brain-landing/app/[lang]/app/usage/page.tsx
+++ b/brain-landing/app/[lang]/app/usage/page.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+/* eslint-disable react/jsx-no-literals -- TODO i18n: end-user /app pages ship English-only for MVP (admin UI is too); queued for a dedicated i18n pass. */
+
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Boxes,
+  CircleCheck,
+  GitCompareArrows,
+  Trash2,
+  Users,
+  Activity,
+} from 'lucide-react'
+import { useProxyBase } from '../../../../components/playground/usePlaygroundCall'
+
+interface MemoryStats {
+  entities: number
+  factsActive: number
+  factsCompeting: number
+  factsRetracted: number
+  communities: number
+  factsLast7d: number
+  asOf: string
+}
+
+const CARDS: Array<{
+  key: keyof Omit<MemoryStats, 'asOf'>
+  label: string
+  icon: typeof Boxes
+  hint: string
+}> = [
+  { key: 'entities', label: 'Entities', icon: Boxes, hint: 'people, places, projects, topics' },
+  { key: 'factsActive', label: 'Active facts', icon: CircleCheck, hint: 'currently true statements' },
+  { key: 'factsCompeting', label: 'Competing facts', icon: GitCompareArrows, hint: 'unresolved conflicts' },
+  { key: 'factsRetracted', label: 'Retracted facts', icon: Trash2, hint: 'kept for audit history' },
+  { key: 'communities', label: 'Communities', icon: Users, hint: 'entity clusters' },
+  { key: 'factsLast7d', label: 'Learned (7d)', icon: Activity, hint: 'facts recorded this week' },
+]
+
+/**
+ * Usage — per-company memory footprint. Real counts from
+ * GET /v1/stats/overview through the reduced-scope app BFF.
+ */
+export default function UsagePage() {
+  const proxyBase = useProxyBase()
+  const [stats, setStats] = useState<MemoryStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setErr(null)
+    try {
+      const res = await fetch(`${proxyBase}/v1/stats/overview`)
+      const data = await res.json()
+      if (!res.ok) throw new Error(data?.error ?? `Failed (${res.status})`)
+      setStats(data as MemoryStats)
+    } catch (e) {
+      setErr((e as Error).message)
+      setStats(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [proxyBase])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <div>
+        <h1 className="text-lg font-semibold text-[var(--text)]">Usage</h1>
+        <p className="text-sm text-[var(--text-muted)] mt-1">
+          The size and shape of your brain&apos;s memory right now.
+        </p>
+      </div>
+
+      {err && <div className="text-xs text-[var(--danger)] font-mono">{err}</div>}
+      {loading && (
+        <div className="text-sm text-[var(--text-muted)]">Loading…</div>
+      )}
+
+      {stats && (
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {CARDS.map((c) => {
+              const Icon = c.icon
+              return (
+                <div
+                  key={c.key}
+                  className="border border-[var(--border)] rounded-md p-3"
+                >
+                  <div className="flex items-center gap-1.5 text-[var(--text-muted)]">
+                    <Icon className="w-3.5 h-3.5" />
+                    <span className="text-xs">{c.label}</span>
+                  </div>
+                  <div className="mt-1 text-2xl font-semibold text-[var(--text)] tabular-nums">
+                    {stats[c.key].toLocaleString()}
+                  </div>
+                  <div className="text-[10px] text-[var(--text-faint)]">
+                    {c.hint}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+          <div className="text-[10px] text-[var(--text-faint)] font-mono">
+            as of {stats.asOf}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/brain-landing/app/api/admin/proxy/[...path]/route.ts
+++ b/brain-landing/app/api/admin/proxy/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAdmin } from '@/lib/server-auth'
 import { brainFetch } from '@/lib/brain-api'
+import { extractProxyPath, collectQuery, isPathAllowed } from '@/lib/bff-proxy'
 import { LeasesResponseSchema } from '@/lib/contracts/admin-leases'
 import { SchedulerResponseSchema } from '@/lib/contracts/admin-scheduler'
 import { ChangefeedStateResponseSchema } from '@/lib/contracts/admin-changefeed-state'
@@ -253,30 +254,19 @@ const ALLOWED_PREFIXES = [
   'health',
 ]
 
-function isAllowed(path: string): boolean {
-  const normalized = path.replace(/^\/+/, '').replace(/\?.*$/, '')
-  return ALLOWED_PREFIXES.some(
-    (p) => normalized === p || normalized.startsWith(p),
-  )
-}
-
 async function forward(
   request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> },
+  path: string[],
 ): Promise<NextResponse> {
-  const { path } = await params
   const subpath = path.join('/')
-  if (!isAllowed(subpath)) {
+  if (!isPathAllowed(subpath, { allow: ALLOWED_PREFIXES })) {
     return NextResponse.json(
       { error: `path '/${subpath}' is not in the admin proxy allow-list` },
       { status: 403 },
     )
   }
 
-  const query: Record<string, string> = {}
-  request.nextUrl.searchParams.forEach((v, k) => {
-    query[k] = v
-  })
+  const query = collectQuery(request)
 
   const body =
     request.method === 'GET' || request.method === 'HEAD'
@@ -317,29 +307,17 @@ async function forward(
   })
 }
 
+const ADMIN_ROUTE_PREFIX = '/api/admin/proxy/'
+
 export const GET = withAdmin((_session, request) =>
-  forward(request, extractCtx(request)),
+  forward(request, extractProxyPath(request, ADMIN_ROUTE_PREFIX)),
 )
 export const POST = withAdmin((_session, request) =>
-  forward(request, extractCtx(request)),
+  forward(request, extractProxyPath(request, ADMIN_ROUTE_PREFIX)),
 )
 export const PUT = withAdmin((_session, request) =>
-  forward(request, extractCtx(request)),
+  forward(request, extractProxyPath(request, ADMIN_ROUTE_PREFIX)),
 )
 export const DELETE = withAdmin((_session, request) =>
-  forward(request, extractCtx(request)),
+  forward(request, extractProxyPath(request, ADMIN_ROUTE_PREFIX)),
 )
-
-// Pull dynamic [...path] segments out of the URL since `withAdmin`
-// erases the second handler arg.
-function extractCtx(request: NextRequest): {
-  params: Promise<{ path: string[] }>
-} {
-  const u = request.nextUrl
-  const prefix = '/api/admin/proxy/'
-  const rest = u.pathname.startsWith(prefix)
-    ? u.pathname.slice(prefix.length)
-    : ''
-  const path = rest.split('/').filter(Boolean)
-  return { params: Promise.resolve({ path }) }
-}

--- a/brain-landing/app/api/app/proxy/[...path]/route.ts
+++ b/brain-landing/app/api/app/proxy/[...path]/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withUser, type UserSession } from '@/lib/server-auth'
+import { brainFetch, USER_SCOPE } from '@/lib/brain-api'
+import { extractProxyPath, collectQuery, isPathAllowed } from '@/lib/bff-proxy'
+
+/**
+ * /api/app/proxy/[...path] — end-user BFF for the brain backend.
+ *
+ * Sibling of `/api/admin/proxy` but for the product UI under
+ * `/[lang]/app/**`. Guard rails:
+ *
+ *   1. Tenancy fail-closed (`BRAIN_APP_ENABLED`). brain derives the
+ *      tenant (companyId) from the *service* credential, not the end
+ *      user (src/auth/api-key.guard.ts), so every authenticated user
+ *      maps to the single company this brain-landing instance is bound
+ *      to. Until per-user companyId propagation exists, the end-user
+ *      surface is only safe on a single-company deployment — so it is
+ *      OFF unless the operator explicitly opts in, asserting that.
+ *   2. `withUser` — any authenticated OAuth user (not admin-only).
+ *   3. A tight, segment-anchored allow-list of user-facing endpoints.
+ *      No `v1/admin/*` path is reachable; `/forget` is denied outright.
+ *   4. Writes default to admins only; open to all authenticated users
+ *      only when `BRAIN_APP_ALLOW_USER_WRITES=1`.
+ *   5. The M2M token is minted with USER_SCOPE (`brain:read
+ *      brain:write`) — no admin, no PII. PII predicates come back
+ *      redacted.
+ *   6. The internal debug `__trace` is forwarded only for admins.
+ */
+
+const ROUTE_PREFIX = '/api/app/proxy/'
+
+// Read paths every authenticated user may reach.
+const READ_PREFIXES = [
+  'v1/search',
+  'v1/synthesize',
+  'v1/entities/',
+  'v1/communities',
+  'v1/stats',
+  'health',
+]
+
+// Write paths (still brain:write scope). Gated additionally by role —
+// see canWrite() — so a read-only visitor can't mutate the company's
+// memory just by being logged in.
+const WRITE_PREFIXES = [
+  'v1/ingest/fact',
+  'v1/ingest/mention',
+  'v1/ingest/link',
+  'v1/facts/',
+]
+
+// Denied even though a broader allow prefix would otherwise sweep them
+// in. `v1/entities/` is needed for profiles/timeline/connections but
+// must never expose the admin-only GDPR erase.
+const DENIED_SUFFIXES = ['/forget']
+
+function appEnabled(): boolean {
+  return process.env.BRAIN_APP_ENABLED === '1'
+}
+
+function isWritePath(subpath: string): boolean {
+  return isPathAllowed(subpath, { allow: WRITE_PREFIXES })
+}
+
+function canWrite(session: UserSession): boolean {
+  return session.isAdmin || process.env.BRAIN_APP_ALLOW_USER_WRITES === '1'
+}
+
+async function forward(
+  session: UserSession,
+  request: NextRequest,
+): Promise<NextResponse> {
+  if (!appEnabled()) {
+    return NextResponse.json(
+      {
+        error:
+          'end-user app is disabled on this deployment (set BRAIN_APP_ENABLED=1 for single-company instances)',
+      },
+      { status: 403 },
+    )
+  }
+
+  const subpath = extractProxyPath(request, ROUTE_PREFIX).join('/')
+  if (!isPathAllowed(subpath, { allow: READ_PREFIXES.concat(WRITE_PREFIXES), deny: DENIED_SUFFIXES })) {
+    return NextResponse.json(
+      { error: `path '/${subpath}' is not in the app proxy allow-list` },
+      { status: 403 },
+    )
+  }
+
+  const writing = request.method !== 'GET' && request.method !== 'HEAD'
+  if (writing && isWritePath(subpath) && !canWrite(session)) {
+    return NextResponse.json(
+      { error: 'write access requires an admin or BRAIN_APP_ALLOW_USER_WRITES=1' },
+      { status: 403 },
+    )
+  }
+
+  const query = collectQuery(request)
+  const body = writing
+    ? await request.json().catch(() => undefined)
+    : undefined
+
+  // ?debug=1 → forward X-Brain-Debug:1 so the backend returns the
+  // per-request __trace span buffer. The trace exposes internal
+  // pipeline timings/IDs, so it is forwarded for admins only.
+  const wantsDebug = query.debug === '1'
+  if (wantsDebug) delete query.debug
+  const forwardDebug = wantsDebug && session.isAdmin
+
+  const res = await brainFetch(`/${subpath}`, {
+    method: request.method as 'GET' | 'POST' | 'PUT' | 'DELETE',
+    body,
+    query,
+    scope: USER_SCOPE,
+    headers: forwardDebug ? { 'X-Brain-Debug': '1' } : undefined,
+  })
+
+  return NextResponse.json(res.data ?? { error: res.error }, {
+    status: res.status || (res.ok ? 200 : 502),
+  })
+}
+
+export const GET = withUser(forward)
+export const POST = withUser(forward)
+export const PUT = withUser(forward)
+export const DELETE = withUser(forward)

--- a/brain-landing/app/api/auth/me/route.ts
+++ b/brain-landing/app/api/auth/me/route.ts
@@ -1,22 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getAdminSession } from '@/lib/server-auth'
+import { getUserSession } from '@/lib/server-auth'
 
 /**
  * GET /api/auth/me
  *
- * Returns the current admin session (verified via JWT). Used by the
- * client `useAuth` hook + Header.tsx to decide whether to show the
- * "Admin" nav link. Returns 200 with `{ isAdmin: false }` when no
- * session — never 401 — so the hook can branch cleanly.
+ * Returns the current session (verified via JWT). Used by the client
+ * `useAuth` hook + Header.tsx to decide whether to show the "Admin" nav
+ * link, and by the end-user app shell to gate on "is logged in".
+ *
+ * Resolves via {@link getUserSession} so a logged-in non-admin is
+ * distinguishable from an anonymous visitor: anonymous →
+ * `{ isAuthenticated: false, isAdmin: false }`, logged-in user →
+ * `{ isAuthenticated: true, isAdmin: <bool> }`. Always 200 (never 401)
+ * so the hook can branch cleanly.
  */
 export async function GET(request: NextRequest) {
-  const session = await getAdminSession(request)
+  const session = await getUserSession(request)
   if (!session) {
-    return NextResponse.json({ isAdmin: false }, { status: 200 })
+    return NextResponse.json(
+      { isAuthenticated: false, isAdmin: false },
+      { status: 200 },
+    )
   }
   return NextResponse.json({
+    isAuthenticated: true,
     userId: session.userId,
     email: session.email,
-    isAdmin: true,
+    isAdmin: session.isAdmin,
   })
 }

--- a/brain-landing/components/EntityDetailDock.tsx
+++ b/brain-landing/components/EntityDetailDock.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { EntityPanel } from './admin/EntityPanel'
+
+/**
+ * Docked entity-detail surface shared by the Entities and Timeline
+ * pages: a bordered relative container that either shows the EntityPanel
+ * for the selected entity or an empty-state placeholder. The Timeline
+ * page additionally passes the bitemporal axes (asOf/recordedAt).
+ */
+export function EntityDetailDock({
+  entityId,
+  asOf,
+  recordedAt,
+  onClose,
+  emptyTitle,
+  emptyHint,
+}: {
+  entityId: string | null
+  asOf?: string | null
+  recordedAt?: string | null
+  onClose(): void
+  emptyTitle: string
+  emptyHint: string
+}) {
+  return (
+    <div className="relative min-h-[28rem] border border-[var(--border)] rounded-md bg-[var(--bg-elevated)] overflow-hidden">
+      {entityId ? (
+        <EntityPanel
+          entityId={entityId}
+          asOf={asOf}
+          recordedAt={recordedAt}
+          onClose={onClose}
+          onExpand={() => {
+            /* graph expansion lives on the Graph page */
+          }}
+        />
+      ) : (
+        <div className="absolute inset-0 flex items-center justify-center text-center text-[var(--text-muted)] px-4">
+          <div>
+            <div className="text-sm">{emptyTitle}</div>
+            <div className="mt-1 text-xs text-[var(--text-faint)]">
+              {emptyHint}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/brain-landing/components/ShellNav.tsx
+++ b/brain-landing/components/ShellNav.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import Link from 'next/link'
+import type { ComponentType } from 'react'
+
+export interface ShellSection {
+  slug: string
+  title: string
+  icon: ComponentType<{ className?: string }>
+}
+
+export interface ShellGroup {
+  label: string
+  items: ShellSection[]
+}
+
+/**
+ * Shared sidebar nav for the admin and end-user shells. Each shell
+ * passes its own groups, the active slug, and an `hrefFor` that turns a
+ * slug into a route (so the admin/app base path lives with the caller).
+ * Section titles/labels come from data, never hardcoded JSX literals.
+ */
+export function ShellNav({
+  groups,
+  currentSlug,
+  hrefFor,
+  onNavigate,
+  ariaLabel,
+}: {
+  groups: ShellGroup[]
+  currentSlug: string
+  hrefFor: (slug: string) => string
+  onNavigate?: () => void
+  ariaLabel: string
+}) {
+  return (
+    <nav aria-label={ariaLabel} className="space-y-3">
+      {groups.map((g) => (
+        <div key={g.label}>
+          <div className="px-2.5 mb-1 text-[10px] uppercase tracking-wider text-[var(--text-faint)]">
+            {g.label}
+          </div>
+          <div className="space-y-0.5">
+            {g.items.map((s) => {
+              const active = currentSlug === s.slug
+              const Icon = s.icon
+              return (
+                <Link
+                  key={s.slug}
+                  href={hrefFor(s.slug)}
+                  onClick={onNavigate}
+                  aria-current={active ? 'page' : undefined}
+                  className={`flex items-center gap-2 px-2.5 py-1.5 rounded-md text-sm transition-colors ${
+                    active
+                      ? 'bg-[var(--bg-overlay)] text-[var(--text)]'
+                      : 'text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--bg-overlay)]'
+                  }`}
+                >
+                  <Icon className="w-3.5 h-3.5" />
+                  {s.title}
+                </Link>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </nav>
+  )
+}

--- a/brain-landing/components/admin/EntityPanel.tsx
+++ b/brain-landing/components/admin/EntityPanel.tsx
@@ -11,6 +11,7 @@ import {
   Trash2,
   CircleDot,
 } from 'lucide-react'
+import { useProxyBase } from '../playground/usePlaygroundCall'
 
 /**
  * Brain returns externalRefs in two shapes depending on the path:
@@ -74,6 +75,7 @@ export function EntityPanel({
   onClose,
   onExpand,
 }: Props) {
+  const proxyBase = useProxyBase()
   const [profile, setProfile] = useState<EntityProfile | null>(null)
   const [timeline, setTimeline] = useState<TimelineRow[] | null>(null)
   const [loading, setLoading] = useState(false)
@@ -101,10 +103,10 @@ export function EntityPanel({
       : ''
     Promise.all([
       fetch(
-        `/api/admin/proxy/v1/entities/${encodeURIComponent(entityId)}${profileQs}`,
+        `${proxyBase}/v1/entities/${encodeURIComponent(entityId)}${profileQs}`,
       ),
       fetch(
-        `/api/admin/proxy/v1/entities/${encodeURIComponent(entityId)}/timeline${timelineQs}`,
+        `${proxyBase}/v1/entities/${encodeURIComponent(entityId)}/timeline${timelineQs}`,
       ),
     ])
       .then(async ([p, t]) => {
@@ -118,7 +120,7 @@ export function EntityPanel({
       })
       .catch((e) => setErr((e as Error).message))
       .finally(() => setLoading(false))
-  }, [entityId, asOf, recordedAt])
+  }, [entityId, asOf, recordedAt, proxyBase])
 
   if (!entityId) return null
 

--- a/brain-landing/components/admin/EntitySearch.tsx
+++ b/brain-landing/components/admin/EntitySearch.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { Search } from 'lucide-react'
+import { useProxyBase } from '../playground/usePlaygroundCall'
 
 export interface SearchHit {
   entityId: string
@@ -19,6 +20,7 @@ interface Props {
  * via the BFF. Picks the brain backend default scope (read-only).
  */
 export function EntitySearch({ onSelect }: Props) {
+  const proxyBase = useProxyBase()
   const [q, setQ] = useState('')
   const [open, setOpen] = useState(false)
   const [results, setResults] = useState<SearchHit[]>([])
@@ -35,7 +37,7 @@ export function EntitySearch({ onSelect }: Props) {
       setLoading(true)
       setErr(null)
       try {
-        const res = await fetch('/api/admin/proxy/v1/search', {
+        const res = await fetch(`${proxyBase}/v1/search`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ query: q, limit: 10 }),
@@ -75,7 +77,7 @@ export function EntitySearch({ onSelect }: Props) {
       ctrl.abort()
       clearTimeout(t)
     }
-  }, [q])
+  }, [q, proxyBase])
 
   return (
     <div className="relative">

--- a/brain-landing/components/admin/GraphExplorer.tsx
+++ b/brain-landing/components/admin/GraphExplorer.tsx
@@ -24,6 +24,7 @@ import { EntitySearch, type SearchHit } from './EntitySearch'
 import { EntityPanel } from './EntityPanel'
 import { PredicateFilter } from './PredicateFilter'
 import { AsOfSlider } from './AsOfSlider'
+import { useProxyBase } from '../playground/usePlaygroundCall'
 import {
   applyDagreLayout,
   type LayoutDirection,
@@ -62,6 +63,7 @@ export function GraphExplorer() {
 }
 
 function GraphExplorerInner() {
+  const proxyBase = useProxyBase()
   const [nodes, setNodes] = useState<Node<EntityNodeData>[]>([])
   const [edges, setEdges] = useState<Edge<KindEdgeData>[]>([])
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -180,7 +182,7 @@ function GraphExplorerInner() {
         if (recordedAt) params.set('recordedAt', recordedAt)
         const qs = params.toString() ? `?${params.toString()}` : ''
         const res = await fetch(
-          `/api/admin/proxy/v1/entities/${encodeURIComponent(entityId)}/connections${qs}`,
+          `${proxyBase}/v1/entities/${encodeURIComponent(entityId)}/connections${qs}`,
         )
         const data = (await res.json()) as
           | ConnectionsResponse
@@ -228,7 +230,7 @@ function GraphExplorerInner() {
         setExpanding(false)
       }
     },
-    [nodes, edges, updateGraph, asOf, recordedAt],
+    [nodes, edges, updateGraph, asOf, recordedAt, proxyBase],
   )
 
   // Wire reactflow's own change-pipeline so drag motion is rendered.

--- a/brain-landing/components/playground/usePlaygroundCall.ts
+++ b/brain-landing/components/playground/usePlaygroundCall.ts
@@ -1,7 +1,28 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import type { DebugTracePayload } from './TraceWaterfall'
+
+/**
+ * BFF base the playground hooks POST through. Defaults to the admin
+ * proxy so existing admin pages keep working untouched. The end-user
+ * app shell overrides it with `/api/app/proxy` (reduced scope, no
+ * admin/PII) via {@link ProxyBaseProvider} so the same playground
+ * components can be reused under `/[lang]/app/*`.
+ */
+export const ProxyBaseContext = createContext<string>('/api/admin/proxy')
+export const ProxyBaseProvider = ProxyBaseContext.Provider
+
+export function useProxyBase(): string {
+  return useContext(ProxyBaseContext)
+}
 
 export interface PlaygroundCallState<T> {
   loading: boolean
@@ -12,15 +33,17 @@ export interface PlaygroundCallState<T> {
 }
 
 /**
- * Hook that POST/GETs a brain endpoint via the admin BFF with
- * ?debug=1 appended. Splits the JSON response into `data` (the
- * brain result with the synthetic `__trace` field stripped) and
- * `trace` (the per-request debug-mode waterfall).
+ * Hook that POST/GETs a brain endpoint via the active BFF (admin by
+ * default, app when wrapped in {@link ProxyBaseProvider}) with ?debug=1
+ * appended. Splits the JSON response into `data` (the brain result with
+ * the synthetic `__trace` field stripped) and `trace` (the per-request
+ * debug-mode waterfall).
  *
  * Owns an AbortController per call: a rapid resubmit aborts the
  * previous request before its response can clobber fresh state.
  */
 export function usePlaygroundCall<T = unknown>() {
+  const proxyBase = useProxyBase()
   const [state, setState] = useState<PlaygroundCallState<T>>({
     loading: false,
     data: null,
@@ -49,7 +72,8 @@ export function usePlaygroundCall<T = unknown>() {
       const t0 = Date.now()
       try {
         const sep = path.includes('?') ? '&' : '?'
-        const url = `/api/admin/proxy/${path.replace(/^\/+/, '')}${sep}debug=1`
+        const base = proxyBase.replace(/\/+$/, '')
+        const url = `${base}/${path.replace(/^\/+/, '')}${sep}debug=1`
         const res = await fetch(url, {
           method: init.method ?? 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -91,7 +115,7 @@ export function usePlaygroundCall<T = unknown>() {
         if (abortRef.current === ctrl) abortRef.current = null
       }
     },
-    [],
+    [proxyBase],
   )
 
   return { ...state, send }

--- a/brain-landing/hooks/useAuth.ts
+++ b/brain-landing/hooks/useAuth.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 
 export interface AuthState {
   loading: boolean
+  isAuthenticated: boolean
   isAdmin: boolean
   userId: string | null
   email: string | null
@@ -11,16 +12,21 @@ export interface AuthState {
 
 const INITIAL: AuthState = {
   loading: true,
+  isAuthenticated: false,
   isAdmin: false,
   userId: null,
   email: null,
 }
 
+const ANON: AuthState = { ...INITIAL, loading: false }
+
 /**
- * Client hook that reads the current admin session from
- * `/api/auth/me`. The endpoint is the canonical place where the
- * cookie → JWT → admin check happens; the client just renders the
- * shape. Returns `{ loading, isAdmin, userId, email }`.
+ * Client hook that reads the current session from `/api/auth/me`. The
+ * endpoint is the canonical place where the cookie → JWT check happens;
+ * the client just renders the shape. Returns `{ loading, isAuthenticated,
+ * isAdmin, userId, email }`. `isAuthenticated` distinguishes a logged-in
+ * non-admin (app shell gate) from an anonymous visitor; `isAdmin` gates
+ * admin-only affordances.
  */
 export function useAuth(): AuthState {
   const [state, setState] = useState<AuthState>(INITIAL)
@@ -32,30 +38,19 @@ export function useAuth(): AuthState {
       .then((data) => {
         if (cancelled) return
         if (!data) {
-          setState({
-            loading: false,
-            isAdmin: false,
-            userId: null,
-            email: null,
-          })
+          setState(ANON)
           return
         }
         setState({
           loading: false,
+          isAuthenticated: Boolean(data.isAuthenticated),
           isAdmin: Boolean(data.isAdmin),
           userId: data.userId ?? null,
           email: data.email ?? null,
         })
       })
       .catch(() => {
-        if (!cancelled) {
-          setState({
-            loading: false,
-            isAdmin: false,
-            userId: null,
-            email: null,
-          })
-        }
+        if (!cancelled) setState(ANON)
       })
     return () => {
       cancelled = true

--- a/brain-landing/lib/bff-proxy.ts
+++ b/brain-landing/lib/bff-proxy.ts
@@ -1,0 +1,60 @@
+import 'server-only'
+import { NextRequest } from 'next/server'
+
+/**
+ * Shared mechanics for the brain BFF proxies (admin + end-user). Keeps
+ * path extraction and allow-list matching in one place so a security fix
+ * (e.g. segment anchoring) can't drift between the two routes.
+ */
+
+/** Pull the [...path] segments out of `/<routePrefix>/a/b/c`. */
+export function extractProxyPath(
+  request: NextRequest,
+  routePrefix: string,
+): string[] {
+  const prefix = routePrefix.endsWith('/') ? routePrefix : `${routePrefix}/`
+  const { pathname } = request.nextUrl
+  const rest = pathname.startsWith(prefix) ? pathname.slice(prefix.length) : ''
+  return rest.split('/').filter(Boolean)
+}
+
+/** Collect the request's query string into a plain object. */
+export function collectQuery(request: NextRequest): Record<string, string> {
+  const query: Record<string, string> = {}
+  request.nextUrl.searchParams.forEach((v, k) => {
+    query[k] = v
+  })
+  return query
+}
+
+export interface AllowlistOptions {
+  allow: string[]
+  /** Case-insensitive, segment-aware suffix denies (e.g. '/forget'). */
+  deny?: string[]
+}
+
+/**
+ * Allow-list match anchored on path-segment boundaries. A prefix `p`
+ * matches a path only when the path equals `p` or continues with `/`
+ * after `p` — so `v1/search` does NOT match `v1/searchsecret`. Denies
+ * are checked first, case-insensitively, on a trailing segment so
+ * `/forget`, `/forget/`, `/FORGET` are all rejected.
+ */
+export function isPathAllowed(
+  rawPath: string,
+  { allow, deny = [] }: AllowlistOptions,
+): boolean {
+  const normalized = rawPath.replace(/^\/+/, '').replace(/\?.*$/, '')
+  const lower = normalized.toLowerCase()
+  for (const d of deny) {
+    const dl = d.toLowerCase()
+    // match `.../forget` and `.../forget/` (trailing slash)
+    if (lower.endsWith(dl) || lower.endsWith(`${dl}/`)) return false
+  }
+  return allow.some((p) => {
+    const pn = p.replace(/^\/+/, '')
+    if (normalized === pn) return true
+    const boundary = pn.endsWith('/') ? pn : `${pn}/`
+    return normalized.startsWith(boundary)
+  })
+}

--- a/brain-landing/lib/brain-api.ts
+++ b/brain-landing/lib/brain-api.ts
@@ -37,8 +37,19 @@ const CLIENT_ID =
 const CLIENT_SECRET = process.env.OAUTH_CLIENT_SECRET || ''
 
 const BRAIN_AUDIENCE = process.env.BRAIN_AUDIENCE || 'brain'
-const BRAIN_SCOPE =
+
+/**
+ * Full operator scope — used by the admin BFF (`/api/admin/proxy`).
+ */
+export const ADMIN_SCOPE =
   process.env.BRAIN_SCOPE || 'brain:read brain:write brain:admin brain:read_pii'
+
+/**
+ * Reduced scope for the end-user product BFF (`/api/app/proxy`).
+ * Deliberately excludes `brain:admin` and `brain:read_pii` — PII
+ * predicates come back as `__pii_redacted__` for ordinary users.
+ */
+export const USER_SCOPE = process.env.BRAIN_USER_SCOPE || 'brain:read brain:write'
 
 interface CachedToken {
   accessToken: string
@@ -46,10 +57,13 @@ interface CachedToken {
   expiresAtMs: number
 }
 
-let cached: CachedToken | null = null
-let inFlight: Promise<CachedToken> | null = null
+// One cache entry + one in-flight promise per requested scope set. A
+// user request must never be served an admin-scoped token (or vice
+// versa), so the scope string is the cache key.
+const tokenCache = new Map<string, CachedToken>()
+const inFlight = new Map<string, Promise<CachedToken>>()
 
-async function fetchServiceToken(): Promise<CachedToken> {
+async function fetchServiceToken(scope: string): Promise<CachedToken> {
   if (!CLIENT_SECRET) {
     throw new Error('OAUTH_CLIENT_SECRET is not configured')
   }
@@ -60,7 +74,7 @@ async function fetchServiceToken(): Promise<CachedToken> {
       grant_type: 'client_credentials',
       client_id: CLIENT_ID,
       client_secret: CLIENT_SECRET,
-      scope: BRAIN_SCOPE,
+      scope,
       audience: BRAIN_AUDIENCE,
     }),
   })
@@ -82,20 +96,24 @@ async function fetchServiceToken(): Promise<CachedToken> {
   }
 }
 
-async function getServiceToken(): Promise<string> {
+async function getServiceToken(scope: string): Promise<string> {
+  const cached = tokenCache.get(scope)
   if (cached && cached.expiresAtMs > Date.now()) {
     return cached.accessToken
   }
-  if (inFlight) {
-    const t = await inFlight
+  const pending = inFlight.get(scope)
+  if (pending) {
+    const t = await pending
     return t.accessToken
   }
-  inFlight = fetchServiceToken()
+  const p = fetchServiceToken(scope)
+  inFlight.set(scope, p)
   try {
-    cached = await inFlight
-    return cached.accessToken
+    const fresh = await p
+    tokenCache.set(scope, fresh)
+    return fresh.accessToken
   } finally {
-    inFlight = null
+    inFlight.delete(scope)
   }
 }
 
@@ -106,6 +124,12 @@ export interface BrainFetchOptions {
   signal?: AbortSignal
   /** Extra headers merged on top of Authorization/Content-Type. */
   headers?: Record<string, string>
+  /**
+   * OAuth scope set to mint the M2M token with. Defaults to
+   * {@link ADMIN_SCOPE} for backward compatibility with the admin BFF.
+   * The user BFF passes {@link USER_SCOPE}.
+   */
+  scope?: string
 }
 
 export interface BrainResponse<T = unknown> {
@@ -129,9 +153,10 @@ export async function brainFetch<T = unknown>(
   path: string,
   options: BrainFetchOptions = {},
 ): Promise<BrainResponse<T>> {
+  const scope = options.scope ?? ADMIN_SCOPE
   let token: string
   try {
-    token = await getServiceToken()
+    token = await getServiceToken(scope)
   } catch (err) {
     return {
       ok: false,
@@ -161,10 +186,10 @@ export async function brainFetch<T = unknown>(
     } catch {
       // raw text below
     }
-    // On 401 the cached token may have been revoked — invalidate and
-    // let the next request re-mint.
+    // On 401 the cached token may have been revoked — invalidate the
+    // entry for this scope and let the next request re-mint.
     if (res.status === 401) {
-      cached = null
+      tokenCache.delete(scope)
     }
     if (!res.ok) {
       return {

--- a/brain-landing/lib/server-auth.ts
+++ b/brain-landing/lib/server-auth.ts
@@ -13,6 +13,18 @@ export interface AdminSession {
   isAdmin: true
 }
 
+/**
+ * Any authenticated OAuth user (not necessarily an admin). Backs the
+ * end-user product UI under `/[lang]/app/**` and its BFF
+ * (`/api/app/proxy`). `isAdmin` is surfaced so the UI can reveal
+ * admin-only affordances, but it is never required to enter the app.
+ */
+export interface UserSession {
+  userId: string
+  email: string | null
+  isAdmin: boolean
+}
+
 // Sentinel value used by dev-bypass + reused by /api/auth/me.
 const DEV_BYPASS_SESSION: AdminSession = {
   userId: 'dev-bypass',
@@ -30,10 +42,12 @@ export async function extractAccessToken(
 
 /**
  * Dev escape hatch. When `ADMIN_DEV_BYPASS=1` is set, all requests are
- * treated as an admin synthetic user. Never enable in production —
- * `validateEnv` should refuse to start with this flag in prod.
+ * treated as an admin synthetic user. Fails closed in production: the
+ * bypass is ignored when NODE_ENV==='production' regardless of the flag,
+ * so a leaked/copied env var can't expose the full-scope admin BFF.
  */
 function devBypass(): AdminSession | null {
+  if (process.env.NODE_ENV === 'production') return null
   if (process.env.ADMIN_DEV_BYPASS !== '1') return null
   return DEV_BYPASS_SESSION
 }
@@ -55,6 +69,51 @@ export async function getAdminSession(
     userId: decoded.sub,
     email: (decoded.email as string) ?? null,
     isAdmin: true,
+  }
+}
+
+/**
+ * Like {@link getAdminSession} but does NOT require admin. Returns a
+ * session for any valid OAuth token (audience='brain-landing'). The
+ * dev-bypass still applies so local development without auth works.
+ */
+export async function getUserSession(
+  request: NextRequest,
+): Promise<UserSession | null> {
+  const bypass = devBypass()
+  if (bypass) return bypass
+
+  const token = await extractAccessToken(request)
+  if (!token) return null
+
+  const decoded = await verifyAccessToken(token)
+  if (!decoded) return null
+
+  return {
+    userId: decoded.sub,
+    email: (decoded.email as string) ?? null,
+    isAdmin: isAdminFromToken(decoded),
+  }
+}
+
+/**
+ * Wraps a Next.js API handler so it runs for any authenticated user.
+ * Returns 401 when there is no valid session. Used by the end-user BFF
+ * (`/api/app/proxy`) — access control beyond "is logged in" is enforced
+ * by the proxy's allow-list and the reduced M2M scope it requests.
+ */
+export function withUser(
+  handler: (
+    session: UserSession,
+    request: NextRequest,
+  ) => Promise<NextResponse>,
+) {
+  return async (request: NextRequest): Promise<NextResponse> => {
+    const session = await getUserSession(request)
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    return handler(session, request)
   }
 }
 

--- a/brain-landing/middleware.ts
+++ b/brain-landing/middleware.ts
@@ -2,18 +2,21 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { jwtVerify, createRemoteJWKSet } from 'jose'
 
 /**
- * Edge guard for /(en|ru)/admin/**.
+ * Edge guard for /(en|ru)/admin/** and /(en|ru)/app/**.
  *
  * Strategy: lightweight JWT verify on the edge (signature + audience).
- * If the cookie is missing or `isAdmin` is false, redirect into the
- * OAuth init flow (`/api/auth/login?return_url=...`). The init endpoint
- * generates PKCE and bounces the user to auth.inite.ai.
+ *   - /admin/**: requires a token whose `isAdmin` is true.
+ *   - /app/**:   requires any valid token (the end-user product shell).
+ * On a missing/invalid (or non-admin, for /admin) token we redirect
+ * into the OAuth init flow (`/api/auth/login?return_url=...`). The init
+ * endpoint generates PKCE and bounces the user to auth.inite.ai.
  *
  * ADMIN_DEV_BYPASS=1 short-circuits the JWT check entirely. Never
  * enable in production.
  */
 
 const ADMIN_PATH_RE = /^\/(en|ru)?\/?admin(\/|$)/
+const APP_PATH_RE = /^\/(en|ru)?\/?app(\/|$)/
 
 const AUTH_DOMAIN =
   process.env.AUTH_SERVICE_URL ||
@@ -42,7 +45,9 @@ function loginRedirect(req: NextRequest): NextResponse {
   return NextResponse.redirect(url)
 }
 
-async function isAdminToken(token: string): Promise<boolean> {
+async function verifyToken(
+  token: string,
+): Promise<{ valid: boolean; isAdmin: boolean }> {
   try {
     const { payload } = await jwtVerify(token, JWKS, {
       audience: EXPECTED_AUDIENCE,
@@ -51,20 +56,27 @@ async function isAdminToken(token: string): Promise<boolean> {
     const roles = (payload.roles as string[] | undefined) ?? []
     const metadataIsAdmin =
       (payload.metadata as { isAdmin?: boolean } | undefined)?.isAdmin === true
-    return roles.includes('admin') || metadataIsAdmin
+    return { valid: true, isAdmin: roles.includes('admin') || metadataIsAdmin }
   } catch {
-    return false
+    return { valid: false, isAdmin: false }
   }
 }
 
 export async function middleware(req: NextRequest) {
   const pathname = req.nextUrl.pathname
 
-  if (!ADMIN_PATH_RE.test(pathname)) {
+  const isAdminPath = ADMIN_PATH_RE.test(pathname)
+  const isAppPath = APP_PATH_RE.test(pathname)
+  if (!isAdminPath && !isAppPath) {
     return NextResponse.next()
   }
 
-  if (process.env.ADMIN_DEV_BYPASS === '1') {
+  // Dev escape hatch — fails closed in production (mirrors devBypass in
+  // lib/server-auth.ts) so a leaked flag can't disable the edge guard.
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.ADMIN_DEV_BYPASS === '1'
+  ) {
     return NextResponse.next()
   }
 
@@ -73,8 +85,9 @@ export async function middleware(req: NextRequest) {
     return loginRedirect(req)
   }
 
-  const allowed = await isAdminToken(token)
-  if (!allowed) {
+  const { valid, isAdmin } = await verifyToken(token)
+  // /app/** needs any valid session; /admin/** additionally needs admin.
+  if (!valid || (isAdminPath && !isAdmin)) {
     return loginRedirect(req)
   }
 
@@ -82,5 +95,12 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/admin/:path*', '/en/admin/:path*', '/ru/admin/:path*'],
+  matcher: [
+    '/admin/:path*',
+    '/en/admin/:path*',
+    '/ru/admin/:path*',
+    '/app/:path*',
+    '/en/app/:path*',
+    '/ru/app/:path*',
+  ],
 }

--- a/brain-landing/next-env.d.ts
+++ b/brain-landing/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,8 @@ import { MetricsModule } from './metrics/metrics.module';
 import { AdminModule } from './admin/admin.module';
 import { AuditModule } from './audit/audit.module';
 import { JobsModule } from './jobs/jobs.module';
+import { CommunityModule } from './communities/community.module';
+import { StatsModule } from './stats/stats.module';
 
 @Module({
   imports: [
@@ -80,6 +82,8 @@ import { JobsModule } from './jobs/jobs.module';
     AdminModule,
     AuditModule,
     JobsModule,
+    CommunityModule,
+    StatsModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/src/common/keyed-mutex.ts
+++ b/src/common/keyed-mutex.ts
@@ -1,0 +1,41 @@
+/**
+ * In-process async mutex keyed by an arbitrary string. Serializes
+ * sections that share a key; sections with different keys run freely.
+ *
+ * Why this exists: SurrealDB 2.x raised an optimistic-concurrency read
+ * conflict when two `fn::resolve_fact` calls raced on the same
+ * (entity, predicate), so the loser retried and superseded instead of
+ * inserting a second active row. SurrealDB 3.x no longer surfaces that
+ * conflict reliably for single-statement SELECT-then-write inside a
+ * function, so concurrent resolves could each insert an `active` row.
+ * Serializing resolves per (company, entity, predicate) restores the
+ * "at most one active" invariant within a process; the retry loop still
+ * covers the cross-pod case best-effort.
+ *
+ * The key is dropped from the map as soon as the last holder releases,
+ * so the map never grows unbounded.
+ */
+export class KeyedMutex {
+  private readonly locks = new Map<string, Promise<void>>();
+
+  async run<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    // Wait until no one holds this key. Re-check after each await: when
+    // the holder releases, every waiter wakes, but the first to fall
+    // through synchronously re-takes the lock (set() happens before any
+    // further await), so the rest loop and wait again.
+    while (this.locks.has(key)) {
+      await this.locks.get(key);
+    }
+    let release!: () => void;
+    const held = new Promise<void>((r) => {
+      release = r;
+    });
+    this.locks.set(key, held);
+    try {
+      return await fn();
+    } finally {
+      this.locks.delete(key);
+      release();
+    }
+  }
+}

--- a/src/communities/communities.controller.ts
+++ b/src/communities/communities.controller.ts
@@ -1,0 +1,75 @@
+import { Controller, Get, Param, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { AuthenticatedRequest } from '../auth/api-key.types';
+import { CommunityService } from './community.service';
+
+/**
+ * Read-only REST surface over topic communities — the same data the
+ * `list_communities` / `search_communities` / `find_entity_communities`
+ * MCP tools expose, for the end-user app UI. All read-scope.
+ */
+@Controller('v1/communities')
+@UseGuards(ApiKeyGuard)
+export class CommunitiesController {
+  constructor(private readonly communities: CommunityService) {}
+
+  @Get()
+  @RequireScopes('brain:read')
+  async list(
+    @Req() req: AuthenticatedRequest,
+    @Query('limit') limit?: string,
+  ) {
+    const communities = await this.communities.list(req.brainAuth.companyId, {
+      limit: parseLimit(limit, 50, 200),
+    });
+    return { communities };
+  }
+
+  @Get('search')
+  @RequireScopes('brain:read')
+  async search(
+    @Req() req: AuthenticatedRequest,
+    @Query('query') query?: string,
+    @Query('limit') limit?: string,
+    @Query('minSimilarity') minSimilarity?: string,
+  ) {
+    const q = (query ?? '').trim();
+    if (!q) return { communities: [] };
+    const communities = await this.communities.search(req.brainAuth.companyId, {
+      query: q,
+      limit: parseLimit(limit, 5, 20),
+      minSimilarity: parseSimilarity(minSimilarity),
+    });
+    return { communities };
+  }
+
+  @Get('for-entity/:entityId')
+  @RequireScopes('brain:read')
+  async forEntity(
+    @Req() req: AuthenticatedRequest,
+    @Param('entityId') entityId: string,
+  ) {
+    const communities = await this.communities.forEntity(
+      req.brainAuth.companyId,
+      entityId,
+    );
+    return { communities };
+  }
+}
+
+function parseLimit(
+  raw: string | undefined,
+  fallback: number,
+  max: number,
+): number {
+  const n = raw ? Number.parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.min(n, max);
+}
+
+function parseSimilarity(raw: string | undefined): number | undefined {
+  if (raw == null) return undefined;
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.min(Math.max(n, 0), 1);
+}

--- a/src/communities/community.module.ts
+++ b/src/communities/community.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { CompactionModule } from '../compaction/compaction.module';
+import { CommunitiesController } from './communities.controller';
 import { CommunityBuilderService } from './community-builder.service';
 import { CommunityService } from './community.service';
 
@@ -15,6 +16,7 @@ import { CommunityService } from './community.service';
  */
 @Module({
   imports: [ConfigModule, CompactionModule],
+  controllers: [CommunitiesController],
   providers: [CommunityBuilderService, CommunityService],
   exports: [CommunityBuilderService, CommunityService],
 })

--- a/src/ingest/ingest.service.ts
+++ b/src/ingest/ingest.service.ts
@@ -30,6 +30,7 @@ import {
   type ResolverConflictPayload,
 } from './conflict-explainer';
 import { detectLanguage } from '../ai/locale/language-detector';
+import { KeyedMutex } from '../common/keyed-mutex';
 
 export type IngestOutcome =
   | 'INSERTED'
@@ -58,6 +59,11 @@ export interface IngestResult {
 @Injectable()
 export class IngestService {
   private readonly logger = new Logger(IngestService.name);
+  // Serializes concurrent fn::resolve_fact calls on the same
+  // (company, entity, predicate) so at most one row ends up active —
+  // SurrealDB 3.x no longer raises the OCC conflict the retry loop
+  // relied on for this case. See KeyedMutex.
+  private readonly resolveLock = new KeyedMutex();
   private readonly conflict: ConflictConfig;
 
   constructor(
@@ -161,6 +167,7 @@ export class IngestService {
       // (migration 0039) — set on INSERTED only, server-side, no follow-up RTT.
       // Direct ingest carries no extraction entropy.
       const result = await this.resolveFactCall(db, {
+        companyId,
         entityId,
         predicate: dto.predicate,
         object: objectStr,
@@ -632,6 +639,7 @@ export class IngestService {
   private resolveFactCall(
     db: Surreal,
     p: {
+      companyId: string;
       entityId: string;
       predicate: string;
       object: string;
@@ -648,7 +656,15 @@ export class IngestService {
       entropy?: number;
     },
   ): Promise<any> {
-    return retryOnUniqueViolation(async () => {
+    // Serialize resolves on the same (company, entity, predicate). Under
+    // SurrealDB 3.x the OCC read-conflict that let racing single_active
+    // resolves retry-and-supersede no longer fires for the function's
+    // SELECT-then-write, so without this two concurrent ingests could
+    // each leave an `active` row. Space-joined — neither an entity record
+    // tail nor a predicate slug contains a space, so the key can't collide.
+    const lockKey = `${p.companyId} ${p.entityId} ${p.predicate}`;
+    return this.resolveLock.run(lockKey, () =>
+      retryOnUniqueViolation(async () => {
       const [r] = await db.query<[any]>(
         `RETURN fn::resolve_fact(
             type::record('knowledge_entity', $eid),
@@ -684,7 +700,8 @@ export class IngestService {
         },
       );
       return r;
-    });
+      }),
+    );
   }
 
   private async resolveOrCreateNamedEntity(
@@ -845,6 +862,7 @@ export class IngestService {
         ? factPayload.extractionEntropy
         : undefined;
     const result = await this.resolveFactCall(db, {
+      companyId,
       entityId,
       predicate,
       object,

--- a/src/stats/stats.controller.ts
+++ b/src/stats/stats.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { AuthenticatedRequest } from '../auth/api-key.types';
+import { StatsService } from './stats.service';
+
+/**
+ * Per-company memory stats for the end-user "Usage" page. Read-scope;
+ * companyId comes from the authenticated credential.
+ */
+@Controller('v1/stats')
+@UseGuards(ApiKeyGuard)
+export class StatsController {
+  constructor(private readonly stats: StatsService) {}
+
+  @Get('overview')
+  @RequireScopes('brain:read')
+  async overview(@Req() req: AuthenticatedRequest) {
+    return this.stats.overview(req.brainAuth.companyId, req.brainAuth.scopes);
+  }
+}

--- a/src/stats/stats.module.ts
+++ b/src/stats/stats.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { StatsController } from './stats.controller';
+import { StatsService } from './stats.service';
+
+/**
+ * StatsModule — read-only per-company memory counts for the end-user
+ * Usage page. SurrealService comes from the @Global SurrealModule.
+ */
+@Module({
+  controllers: [StatsController],
+  providers: [StatsService],
+})
+export class StatsModule {}

--- a/src/stats/stats.service.ts
+++ b/src/stats/stats.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+
+export interface MemoryStats {
+  entities: number;
+  factsActive: number;
+  factsCompeting: number;
+  factsRetracted: number;
+  communities: number;
+  /** Facts recorded (learned) in the last 7 days. */
+  factsLast7d: number;
+  asOf: string;
+}
+
+/**
+ * StatsService — cheap per-company memory counts for the end-user
+ * "Usage" surface. One batched round-trip of COUNT aggregates, run on a
+ * scope-bound connection so PII permissions still apply.
+ */
+@Injectable()
+export class StatsService {
+  constructor(private readonly surreal: SurrealService) {}
+
+  async overview(
+    companyId: string,
+    scopes: readonly string[],
+  ): Promise<MemoryStats> {
+    const nowMs = Date.now();
+    const weekAgoIso = new Date(nowMs - 7 * 24 * 60 * 60 * 1000).toISOString();
+    return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
+      const sql = `
+        SELECT count() AS c FROM knowledge_entity GROUP ALL;
+        SELECT count() AS c FROM knowledge_fact WHERE status = 'active' GROUP ALL;
+        SELECT count() AS c FROM knowledge_fact WHERE status = 'competing' GROUP ALL;
+        SELECT count() AS c FROM knowledge_fact WHERE status = 'retracted' GROUP ALL;
+        SELECT count() AS c FROM community_node GROUP ALL;
+        SELECT count() AS c FROM knowledge_fact WHERE recordedAt > type::datetime($weekAgoIso) GROUP ALL;
+      `;
+      const res = (await db.query<unknown[]>(sql, { weekAgoIso })) as unknown[];
+      return {
+        entities: countOf(res[0]),
+        factsActive: countOf(res[1]),
+        factsCompeting: countOf(res[2]),
+        factsRetracted: countOf(res[3]),
+        communities: countOf(res[4]),
+        factsLast7d: countOf(res[5]),
+        asOf: new Date(nowMs).toISOString(),
+      };
+    });
+  }
+}
+
+function countOf(stmtResult: unknown): number {
+  if (!Array.isArray(stmtResult) || stmtResult.length === 0) return 0;
+  const first = stmtResult[0] as { c?: unknown };
+  return typeof first?.c === 'number' ? first.c : 0;
+}

--- a/test/communities.e2e-spec.ts
+++ b/test/communities.e2e-spec.ts
@@ -119,6 +119,33 @@ describe('Communities — build + read surfaces', () => {
     expect(out[0].similarity).toBeGreaterThanOrEqual(0);
   });
 
+  it('REST: list / search / for-entity / stats resolve over HTTP', async () => {
+    const listRes = await f.http.get('/v1/communities?limit=50').set(auth());
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.communities).toHaveLength(2);
+
+    const searchRes = await f.http
+      .get(
+        `/v1/communities/search?query=${encodeURIComponent('Acme billing')}&minSimilarity=0`,
+      )
+      .set(auth());
+    expect(searchRes.status).toBe(200);
+    expect(searchRes.body.communities.length).toBeGreaterThanOrEqual(1);
+
+    const feRes = await f.http
+      .get(`/v1/communities/for-entity/${encodeURIComponent(entityA)}`)
+      .set(auth());
+    expect(feRes.status).toBe(200);
+    expect(feRes.body.communities).toHaveLength(1);
+
+    const statsRes = await f.http.get('/v1/stats/overview').set(auth());
+    expect(statsRes.status).toBe(200);
+    expect(statsRes.body.entities).toBeGreaterThanOrEqual(6);
+    expect(statsRes.body.communities).toBe(2);
+    expect(typeof statsRes.body.factsActive).toBe('number');
+    expect(typeof statsRes.body.asOf).toBe('string');
+  });
+
   it('rebuild with no graph change reuses every community (watermark)', async () => {
     const stats = await f.app
       .get(DreamsService)


### PR DESCRIPTION
## What

Adds a **user-facing product UI** at `/[lang]/app/**` in `brain-landing`, alongside the existing operator admin. Previously brain only had a technical admin console.

### Explore (everyone)
- **Search & Ask** — NL search + grounded synthesize, with a `trace` tab showing *why* facts were retrieved (per-leg scores) — our differentiator vs mem0/Zep.
- **Entities** — profile + bitemporal lineage.
- **Knowledge graph** — force-directed explorer.
- **Timeline** — bitemporal scrubber (memory over time).
- **Conflicts** — competing facts + retract.
- **Communities** — list + semantic search (real, REST-backed).

### Develop (technical)
- **Playground** (record/search/synthesize), **Keys & integrations** (MCP + quickstart), **Usage** (real per-company memory stats).

## Security / auth
- `getUserSession`/`withUser` gate any authenticated OAuth user.
- New reduced-scope (`brain:read brain:write`) BFF `/api/app/proxy`: **segment-anchored** allow-list, `/forget` deny, **admin-only** debug trace.
- **`BRAIN_APP_ENABLED`** fail-closed tenancy gate (brain derives tenant from the service credential, so the surface is only safe on a single-company deployment — off unless the operator opts in).
- Writes default to admins; `BRAIN_APP_ALLOW_USER_WRITES=1` opens them to all authenticated users.
- `devBypass` now **inert in production**.

## Backend
- Read-only REST: `GET /v1/communities`, `/v1/communities/search`, `/v1/communities/for-entity/:id` (delegates to existing `CommunityService`); `GET /v1/stats/overview` (batched per-company COUNTs via `withScopedCompany`).
- Registered `CommunityModule` + `StatsModule` in `AppModule`.

## Cleanup (from code review)
- Shared `lib/bff-proxy` (both BFFs), `ShellNav` (admin+app), `EntityDetailDock` (entities+timeline).

## Verification
- Backend `nest build` ✓, frontend `pnpm build`/`lint`/`vitest` (9/9) ✓.
- **`communities.e2e-spec` extended** to assert the new HTTP routes + `/v1/stats/overview` against a real SurrealDB — green (also validates DI wiring of both new modules).

## Deploy
- Enables `BRAIN_APP_ENABLED=1` + `BRAIN_APP_ALLOW_USER_WRITES=1` in the brain-landing prod deploy (single-company instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)