### PR TITLE
feat(security): auth hardening, body limits, worker-pool self-heal & correctness fences

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -156,6 +156,10 @@ jobs:
                 - AUTH_SERVICE_URL=https://auth.inite.ai
                 - AUTH_SERVICE_JWKS_URL=https://auth.inite.ai/.well-known/jwks.json
                 - AUTH_SERVICE_AUDIENCE=brain
+                # Required: JwksService refuses to boot in production when JWKS
+                # is enabled without an issuer (else the `iss` claim is not
+                # validated). Must match the `iss` auth-service signs with.
+                - AUTH_SERVICE_ISSUER=https://auth.inite.ai
                 # GDPR forget HMAC — opaque tombstone marker.
                 - FORGET_HMAC_KEY=${{ secrets.BRAIN_FORGET_HMAC_KEY }}
                 # Search retrieval features — eval-validated ON config.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "skills:pack": "pnpm skills:build && ts-node -T scripts/package-skills.ts"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.80.0",
+    "@anthropic-ai/sdk": "^0.91.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@nestjs/common": "^11.1.9",
     "@nestjs/config": "^4.0.2",
@@ -107,7 +107,17 @@
       "onnxruntime-node"
     ],
     "overrides": {
-      "sharp": "^0.34.4"
+      "sharp": "^0.34.4",
+      "ws": "^8.21.0",
+      "multer": "^2.2.0",
+      "qs": "^6.15.2",
+      "hono": "^4.12.25",
+      "@grpc/grpc-js": "^1.14.4",
+      "ip-address": "^10.1.1",
+      "@opentelemetry/core": "^2.8.0",
+      "onnx-proto>protobufjs": "^7.6.3",
+      "@grpc/proto-loader>protobufjs": "^8.6.0",
+      "@opentelemetry/otlp-transformer>protobufjs": "^8.6.0"
     }
   },
   "jest": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,14 +6,24 @@ settings:
 
 overrides:
   sharp: ^0.34.4
+  ws: ^8.21.0
+  multer: ^2.2.0
+  qs: ^6.15.2
+  hono: ^4.12.25
+  '@grpc/grpc-js': ^1.14.4
+  ip-address: ^10.1.1
+  '@opentelemetry/core': ^2.8.0
+  onnx-proto>protobufjs: ^7.6.3
+  '@grpc/proto-loader>protobufjs': ^8.6.0
+  '@opentelemetry/otlp-transformer>protobufjs': ^8.6.0
 
 importers:
 
   .:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.80.0
-        version: 0.80.0(zod@4.4.3)
+        specifier: ^0.91.1
+        version: 0.91.1(zod@4.4.3)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -40,7 +50,7 @@ importers:
         version: 1.9.1
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.75.0
-        version: 0.75.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))
+        version: 0.75.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.217.0
         version: 0.217.0(@opentelemetry/api@1.9.1)
@@ -76,7 +86,7 @@ importers:
         version: 1.0.21
       openai:
         specifier: ^5.16.0
-        version: 5.23.2(ws@8.20.0)(zod@4.4.3)
+        version: 5.23.2(zod@4.4.3)
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -195,8 +205,8 @@ packages:
     resolution: {integrity: sha512-lnw+ZM1Io+cJAkReC0NPDjqObL8NtKzKIkdgEEKC8CUmkhurYhedbicN8Y8NYHgG1uLd2GozW3+/QqPRZaN+Lw==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
-  '@anthropic-ai/sdk@0.80.0':
-    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -428,8 +438,8 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@grpc/grpc-js@1.14.3':
-    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
   '@grpc/proto-loader@0.7.15':
@@ -446,7 +456,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: ^4.12.25
 
   '@huggingface/jinja@0.2.2':
     resolution: {integrity: sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==}
@@ -993,7 +1003,7 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.4.1
-      '@opentelemetry/core': ^2.0.0
+      '@opentelemetry/core': ^2.8.0
 
   '@opentelemetry/configuration@0.217.0':
     resolution: {integrity: sha512-xCtrYOhBqdy6ZOMfe0Oa73ZKF+2LMhoOv4L5vmwAHVvOXUg+V3fvKuEIr9ZyD0Ow+vxllEjWO6PV1wd0DOtyvw==}
@@ -1007,8 +1017,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.7.1':
-    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+  '@opentelemetry/core@2.8.0':
+    resolution: {integrity: sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -1458,8 +1468,14 @@ packages:
   '@protobufjs/eventemitter@1.1.0':
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
 
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
   '@protobufjs/fetch@1.1.0':
     resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
@@ -1582,9 +1598,6 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  '@types/long@4.0.2':
-    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
   '@types/luxon@3.7.1':
     resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
@@ -2958,8 +2971,8 @@ packages:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
 
-  hono@4.12.17:
-    resolution: {integrity: sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==}
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -3020,8 +3033,8 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -3590,8 +3603,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  multer@2.1.1:
-    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
+  multer@2.2.0:
+    resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
 
   mute-stream@2.0.0:
@@ -3704,7 +3717,7 @@ packages:
     resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
     hasBin: true
     peerDependencies:
-      ws: ^8.18.0
+      ws: ^8.21.0
       zod: ^3.23.8
     peerDependenciesMeta:
       ws:
@@ -3889,16 +3902,16 @@ packages:
     resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
     engines: {node: '>=18'}
 
-  protobufjs@6.11.6:
-    resolution: {integrity: sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==}
-    hasBin: true
-
   protobufjs@7.5.6:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
 
-  protobufjs@8.0.1:
-    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.6.5:
+    resolution: {integrity: sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -3915,8 +3928,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -4114,6 +4127,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
@@ -4628,18 +4645,6 @@ packages:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -4723,7 +4728,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@anthropic-ai/sdk@0.80.0(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -4982,7 +4987,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@grpc/grpc-js@1.14.3':
+  '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.0
       '@js-sdsl/ordered-map': 4.4.2
@@ -4991,19 +4996,19 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.6
+      protobufjs: 8.6.5
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.6
+      protobufjs: 8.6.5
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.14(hono@4.12.17)':
+  '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
-      hono: 4.12.17
+      hono: 4.12.27
 
   '@huggingface/jinja@0.2.2': {}
 
@@ -5487,7 +5492,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.17)
+      '@hono/node-server': 1.19.14(hono@4.12.27)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -5497,7 +5502,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.0(express@5.2.1)
-      hono: 4.12.17
+      hono: 4.12.27
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5577,7 +5582,7 @@ snapshots:
       '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cors: 2.8.6
       express: 5.2.1
-      multer: 2.1.1
+      multer: 2.2.0
       path-to-regexp: 8.4.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -5628,10 +5633,10 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/auto-instrumentations-node@0.75.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))':
+  '@opentelemetry/auto-instrumentations-node@0.75.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-amqplib': 0.64.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-aws-lambda': 0.69.0(@opentelemetry/api@1.9.1)
@@ -5686,23 +5691,23 @@ snapshots:
   '@opentelemetry/configuration@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       yaml: 2.8.4
 
   '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/exporter-logs-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
@@ -5712,7 +5717,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
@@ -5721,7 +5726,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
@@ -5730,9 +5735,9 @@ snapshots:
 
   '@opentelemetry/exporter-metrics-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
@@ -5743,7 +5748,7 @@ snapshots:
   '@opentelemetry/exporter-metrics-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
@@ -5752,7 +5757,7 @@ snapshots:
   '@opentelemetry/exporter-metrics-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
@@ -5762,16 +5767,16 @@ snapshots:
   '@opentelemetry/exporter-prometheus@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/exporter-trace-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
@@ -5781,7 +5786,7 @@ snapshots:
   '@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
@@ -5790,7 +5795,7 @@ snapshots:
   '@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
@@ -5799,7 +5804,7 @@ snapshots:
   '@opentelemetry/exporter-zipkin@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -5807,7 +5812,7 @@ snapshots:
   '@opentelemetry/instrumentation-amqplib@0.64.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -5825,7 +5830,7 @@ snapshots:
   '@opentelemetry/instrumentation-aws-sdk@0.72.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -5851,7 +5856,7 @@ snapshots:
   '@opentelemetry/instrumentation-connect@0.60.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/connect': 3.4.38
@@ -5883,7 +5888,7 @@ snapshots:
   '@opentelemetry/instrumentation-express@0.65.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -5892,7 +5897,7 @@ snapshots:
   '@opentelemetry/instrumentation-fs@0.36.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
@@ -5922,7 +5927,7 @@ snapshots:
   '@opentelemetry/instrumentation-hapi@0.63.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -5931,7 +5936,7 @@ snapshots:
   '@opentelemetry/instrumentation-http@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       forwarded-parse: 2.1.2
@@ -5966,7 +5971,7 @@ snapshots:
   '@opentelemetry/instrumentation-koa@0.65.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -5999,7 +6004,7 @@ snapshots:
   '@opentelemetry/instrumentation-mongoose@0.63.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -6060,7 +6065,7 @@ snapshots:
   '@opentelemetry/instrumentation-pg@0.69.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
@@ -6073,7 +6078,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
@@ -6090,7 +6095,7 @@ snapshots:
   '@opentelemetry/instrumentation-restify@0.62.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -6130,7 +6135,7 @@ snapshots:
   '@opentelemetry/instrumentation-undici@0.27.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
@@ -6156,14 +6161,14 @@ snapshots:
   '@opentelemetry/otlp-exporter-base@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/otlp-grpc-exporter-base@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
 
@@ -6171,55 +6176,55 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      protobufjs: 8.0.1
+      protobufjs: 8.6.5
 
   '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/propagator-jaeger@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/redis-common@0.38.3': {}
 
   '@opentelemetry/resource-detector-alibaba-cloud@0.33.7(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/resource-detector-aws@2.17.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/resource-detector-azure@0.25.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/resource-detector-container@0.8.8(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/resource-detector-gcp@0.52.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       gcp-metadata: 8.1.2
     transitivePeerDependencies:
@@ -6228,21 +6233,21 @@ snapshots:
   '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-logs@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-node@0.217.0(@opentelemetry/api@1.9.1)':
@@ -6251,7 +6256,7 @@ snapshots:
       '@opentelemetry/api-logs': 0.217.0
       '@opentelemetry/configuration': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-logs-otlp-grpc': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-logs-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-logs-otlp-proto': 0.217.0(@opentelemetry/api@1.9.1)
@@ -6279,7 +6284,7 @@ snapshots:
   '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
@@ -6287,7 +6292,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
@@ -6295,7 +6300,7 @@ snapshots:
   '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -6314,10 +6319,16 @@ snapshots:
 
   '@protobufjs/eventemitter@1.1.0': {}
 
+  '@protobufjs/eventemitter@1.1.1': {}
+
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/inquire': 1.1.1
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
 
   '@protobufjs/float@1.0.2': {}
 
@@ -6458,8 +6469,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
-
-  '@types/long@4.0.2': {}
 
   '@types/luxon@3.7.1': {}
 
@@ -7045,7 +7054,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.3
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -7387,7 +7396,7 @@ snapshots:
   dockerode@4.0.12:
     dependencies:
       '@balena/dockerignore': 1.0.2
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
       docker-modem: 5.0.7
       protobufjs: 7.5.6
@@ -7741,7 +7750,7 @@ snapshots:
   express-rate-limit@8.5.0(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -7765,7 +7774,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.3
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -8071,7 +8080,7 @@ snapshots:
 
   helmet@8.1.0: {}
 
-  hono@4.12.17: {}
+  hono@4.12.27: {}
 
   html-escaper@2.0.2: {}
 
@@ -8134,7 +8143,7 @@ snapshots:
       hasown: 2.0.3
       side-channel: 1.1.0
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -8839,7 +8848,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  multer@2.1.1:
+  multer@2.2.0:
     dependencies:
       append-field: 1.0.0
       busboy: 1.6.0
@@ -8944,7 +8953,7 @@ snapshots:
 
   onnx-proto@4.0.4:
     dependencies:
-      protobufjs: 6.11.6
+      protobufjs: 7.6.4
 
   onnxruntime-common@1.14.0: {}
 
@@ -8962,9 +8971,8 @@ snapshots:
       onnxruntime-common: 1.14.0
       platform: 1.3.6
 
-  openai@5.23.2(ws@8.20.0)(zod@4.4.3):
+  openai@5.23.2(zod@4.4.3):
     optionalDependencies:
-      ws: 8.20.0
       zod: 4.4.3
 
   optionator@0.9.4:
@@ -9132,22 +9140,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  protobufjs@6.11.6:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.1
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
-      '@types/long': 4.0.2
-      '@types/node': 22.19.17
-      long: 4.0.0
-
   protobufjs@7.5.6:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -9163,19 +9155,22 @@ snapshots:
       '@types/node': 22.19.17
       long: 5.3.2
 
-  protobufjs@8.0.1:
+  protobufjs@7.6.4:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
       '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.1
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
       '@types/node': 22.19.17
+      long: 5.3.2
+
+  protobufjs@8.6.5:
+    dependencies:
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -9192,9 +9187,10 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.15.1:
+  qs@6.15.3:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   range-parser@1.2.1: {}
 
@@ -9492,6 +9488,14 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -9634,7 +9638,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.15.1
+      qs: 6.15.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10116,9 +10120,6 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
-
-  ws@8.20.0:
-    optional: true
 
   xtend@4.0.2: {}
 

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -14,11 +14,11 @@ import { CalibrationService } from './calibration/calibration.service';
 import { CalibrationRefitService } from './calibration/calibration-refit.service';
 import { ReindexEmbeddingsService } from './embedder/reindex-embeddings.service';
 import { EntityJudgeService } from './entity-judge.service';
-import { ScheduleModule } from '@nestjs/schedule';
 
 @Global()
 @Module({
-  imports: [ScheduleModule.forRoot()],
+  // ScheduleModule.forRoot() lives in AppModule; @Cron providers here are
+  // discovered by the global scheduler without a local registration.
   providers: [
     EmbedderService,
     ExtractorService,

--- a/src/ai/embedder.service.ts
+++ b/src/ai/embedder.service.ts
@@ -196,9 +196,24 @@ export class EmbedderService implements OnModuleInit, OnModuleDestroy {
       const vecs = provider.embedMany
         ? await provider.embedMany(missTexts)
         : await Promise.all(missTexts.map((t) => provider.embed(t)));
+      // A provider that returns fewer vectors than inputs (or a hole) would
+      // otherwise cache `undefined` and write it as the row's embedding,
+      // silently corrupting the vector store. Fail loud instead.
+      if (vecs.length !== missTexts.length) {
+        throw new Error(
+          `embedMany(${provider.providerId}) returned ${vecs.length} vectors ` +
+            `for ${missTexts.length} inputs`,
+        );
+      }
       for (let j = 0; j < missTexts.length; j++) {
         const text = missTexts[j];
         const vec = vecs[j];
+        if (!Array.isArray(vec) || vec.length === 0) {
+          throw new Error(
+            `embedMany(${provider.providerId}) produced an empty/invalid ` +
+              `vector at index ${j}`,
+          );
+        }
         const k = this.cacheKey(provider.providerId, text);
         this.cache.set(k, vec);
         out[missIdx[j]] = vec;

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ThrottlerModule } from '@nestjs/throttler';
+import { ScheduleModule } from '@nestjs/schedule';
 import { APP_GUARD } from '@nestjs/core';
 import { CommonModule } from './common/common.module';
 import { HealthController } from './common/health.controller';
@@ -63,6 +64,11 @@ import { StatsModule } from './stats/stats.module';
         },
       ],
     }),
+
+    // Registered once at the root. `@Cron`/`@Interval` providers in any
+    // feature module are picked up by the global SchedulerOrchestrator —
+    // feature modules must NOT call forRoot() again (duplicate registration).
+    ScheduleModule.forRoot(),
 
     CommonModule,
     SurrealModule,

--- a/src/auth/jwks.service.ts
+++ b/src/auth/jwks.service.ts
@@ -15,6 +15,10 @@ const VALID_SCOPES: ReadonlySet<BrainScope> = new Set([
 // identifier charset (alnum / underscore / hyphen, bounded length).
 const VALID_COMPANY_ID = /^[A-Za-z0-9_-]{1,64}$/;
 
+// Defence-in-depth cap. A well-formed token carries a handful of scopes;
+// an absurdly long array is malformed/hostile and we refuse to parse it.
+const MAX_SCOPES = 64;
+
 /**
  * JWT verification against the @inite/auth-service JWKS endpoint.
  *
@@ -32,6 +36,7 @@ export class JwksService implements OnModuleInit {
   private jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
   private issuer?: string;
   private audience?: string;
+  private algorithms: string[] = ['RS256'];
 
   constructor(private readonly configService: ConfigService) {}
 
@@ -46,7 +51,33 @@ export class JwksService implements OnModuleInit {
     this.jwks = createRemoteJWKSet(new URL(url));
     this.issuer = this.configService.get<string>('AUTH_SERVICE_ISSUER');
     this.audience = this.configService.get<string>('AUTH_SERVICE_AUDIENCE', 'brain');
-    this.logger.log(`JWKS verifier enabled — url=${url}, audience=${this.audience}`);
+    // Pin the accepted signature algorithms. Without this, jwtVerify accepts
+    // ANY alg advertised in the JWKS, which is the classic algorithm-confusion
+    // surface (e.g. a symmetric key smuggled into the key set). Configurable
+    // for issuers that sign with ES256/EdDSA, but default to RS256.
+    this.algorithms = (
+      this.configService.get<string>('AUTH_SERVICE_JWT_ALGS', 'RS256') ?? 'RS256'
+    )
+      .split(',')
+      .map((a) => a.trim())
+      .filter(Boolean);
+    // In production an unvalidated issuer means a token minted by ANY trusted
+    // JWKS (e.g. another tenant's auth realm sharing the key infra) would pass.
+    // Refuse to boot rather than fail open.
+    if (
+      this.configService.get<string>('NODE_ENV') === 'production' &&
+      !this.issuer
+    ) {
+      throw new Error(
+        'AUTH_SERVICE_ISSUER must be set in production when JWKS verification ' +
+          'is enabled — without it the `iss` claim is not validated and any ' +
+          'token signed by the JWKS keys is accepted.',
+      );
+    }
+    this.logger.log(
+      `JWKS verifier enabled — url=${url}, audience=${this.audience}, ` +
+        `issuer=${this.issuer ?? '(unvalidated)'}, algs=[${this.algorithms.join(',')}]`,
+    );
   }
 
   enabled(): boolean {
@@ -65,6 +96,7 @@ export class JwksService implements OnModuleInit {
       ({ payload } = await jwtVerify(token, this.jwks, {
         issuer: this.issuer,
         audience: this.audience,
+        algorithms: this.algorithms,
       }));
     } catch (e) {
       // Don't log token contents — only the error class/message
@@ -98,10 +130,12 @@ export class JwksService implements OnModuleInit {
 
 function extractScopes(payload: JWTPayload): string[] {
   if (Array.isArray(payload.scopes)) {
-    return payload.scopes.filter((s): s is string => typeof s === 'string');
+    return payload.scopes
+      .filter((s): s is string => typeof s === 'string')
+      .slice(0, MAX_SCOPES);
   }
   if (typeof payload.scope === 'string') {
-    return payload.scope.split(' ').filter(Boolean);
+    return payload.scope.split(' ').filter(Boolean).slice(0, MAX_SCOPES);
   }
   return [];
 }

--- a/src/common/correlation-id.middleware.ts
+++ b/src/common/correlation-id.middleware.ts
@@ -40,17 +40,21 @@ export function correlationIdMiddleware() {
     // tokens. The listener self-removes on response 'finish' (normal
     // path) to avoid leaking when the response completes normally.
     const controller = new AbortController();
-    // Defensive: unit tests mock req/res as plain objects without
-    // EventEmitter wiring. Skip the listener install when on() is
-    // missing — production Express requests always have it.
-    if (typeof (req as { on?: unknown }).on === 'function') {
-      const onClose = () => {
-        if (!res.writableEnded) controller.abort();
-      };
-      req.on('close', onClose);
-      if (typeof (res as { on?: unknown }).on === 'function') {
-        res.on('finish', () => req.removeListener('close', onClose));
-      }
+    // Bind cancellation to the RESPONSE lifecycle, not the request stream.
+    // On Express 5 / modern Node the request's 'close' event fires once the
+    // request BODY has been fully read — which happens long before a slow
+    // async handler (OpenAI embed/extract) finishes — so keying the abort
+    // off `req 'close'` cancelled every in-flight request mid-flight
+    // (observed: ingest aborting its own embedding call ~25ms in → HTTP 500
+    // "Request was aborted"). The response 'close' event fires when the
+    // response stream closes; if it closed WITHOUT finishing, the client
+    // genuinely went away and we abort to stop burning tokens.
+    // Defensive: unit tests mock res as a plain object without EventEmitter
+    // wiring — skip the listener when on() is missing.
+    if (typeof (res as { on?: unknown }).on === 'function') {
+      res.on('close', () => {
+        if (!res.writableFinished) controller.abort();
+      });
     }
     runWithRequestContext(
       { correlationId, abortSignal: controller.signal },

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -2,6 +2,12 @@ import { Logger } from '@nestjs/common';
 
 const log = new Logger('EnvValidation');
 
+// The placeholder password baked into migration 0005's `DEFINE USER
+// brain_caller`. It is public (lives in the repo), so deploying with it
+// unchanged leaves the scoped account on a known credential.
+const SHIPPED_SCOPED_PASS_DEFAULT =
+  'brain-caller-password-must-be-overridden-via-env';
+
 /**
  * Validate required environment variables at boot. Fails fast with a
  * single multi-line error rather than dribbling out 500s once requests
@@ -91,6 +97,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   positiveInt(env, 'THROTTLE_EXPENSIVE_LIMIT', errors);
   positiveInt(env, 'COMPACTION_HOT_RETENTION_DAYS', errors);
 
+  // ── Body size cap (main.ts useBodyParser) ─────────────────────────
+  validateBodySize(env, errors);
+
   for (const w of warnings) log.warn(w);
 
   if (errors.length > 0) {
@@ -137,6 +146,16 @@ function validateProductionGuards(
           '(app-layer policy only). Set both before deploying.',
       );
     }
+  } else if (env.SURREALDB_SCOPED_PASS?.trim() === SHIPPED_SCOPED_PASS_DEFAULT) {
+    // The placeholder shipped in migration 0005 is public (it's in the repo).
+    // Setting it verbatim leaves the brain_caller account on a known password,
+    // which is no better than no fence at all.
+    const msg =
+      'SURREALDB_SCOPED_PASS is set to the public placeholder from migration ' +
+      '0005 — choose a real secret; the shipped default is known to anyone ' +
+      'with the source.';
+    if (isProd) errors.push(msg);
+    else warnings.push(msg);
   }
 
   // Test-only kill switch must never run in production.
@@ -145,6 +164,22 @@ function validateProductionGuards(
       'THROTTLE_DISABLED=1 is a test-only flag and must not be set in ' +
         'production — it disables all rate limiting, including the ' +
         'expensive OpenAI-budget caps.',
+    );
+  }
+}
+
+/**
+ * MAX_BODY_SIZE feeds body-parser's `limit`. A bad value silently defeats the
+ * memory-pinning cap: an unparseable string makes body-parser throw at boot,
+ * and a `gb`/`tb` unit lets one request pin gigabytes. Accept only a byte
+ * count or a b/kb/mb size.
+ */
+function validateBodySize(env: NodeJS.ProcessEnv, errors: string[]): void {
+  const maxBody = env.MAX_BODY_SIZE;
+  if (maxBody !== undefined && !/^\d+(\.\d+)?(b|kb|mb)?$/i.test(maxBody.trim())) {
+    errors.push(
+      'MAX_BODY_SIZE must be a byte count or a b/kb/mb size (e.g. "1mb", ' +
+        '"512kb", "1048576") — gb/tb and other units are rejected.',
     );
   }
 }

--- a/src/compaction/compaction.module.ts
+++ b/src/compaction/compaction.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-import { ScheduleModule } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { CompactionService, SUMMARY_GENERATOR } from './compaction.service';
 import {
@@ -20,7 +19,7 @@ import { MetricsModule } from '../metrics/metrics.module';
  * existing concat output, never a hard error inside compaction.
  */
 @Module({
-  imports: [ScheduleModule.forRoot(), MetricsModule],
+  imports: [MetricsModule],
   providers: [
     CompactionService,
     {

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -620,6 +620,12 @@ export async function dbCreate<T extends Record<string, unknown>>(
     d: data,
   });
   const arr = (rows as T[]) ?? [];
+  // A CREATE that returns no row means the write didn't land. Returning
+  // arr[0] would hand back `undefined` typed as T and corrupt every caller
+  // downstream — fail loud instead.
+  if (arr.length === 0) {
+    throw new Error(`dbCreate(${table}) returned no row`);
+  }
   return arr[0];
 }
 
@@ -633,6 +639,11 @@ export async function dbMerge<T extends Record<string, unknown>>(
     { t: tableOf(recordId), i: idOf(recordId), p: patch },
   );
   const arr = (rows as T[]) ?? [];
+  // An UPDATE...MERGE that matched no record returns []. Returning arr[0]
+  // would hand back `undefined` typed as T — surface the missing record.
+  if (arr.length === 0) {
+    throw new Error(`dbMerge(${recordId}) matched no record`);
+  }
   return arr[0];
 }
 

--- a/src/dreams/dedup.service.ts
+++ b/src/dreams/dedup.service.ts
@@ -150,7 +150,8 @@ export class DreamsDedupService {
        WHERE predicate = 'name'
          AND status = 'active'
          AND retractedAt IS NONE
-         AND embedding != NONE`,
+         AND embedding != NONE
+         AND entityId.mergedInto IS NONE`,
     );
     const seeds = (seedRows as NameRow[]) ?? [];
     if (seeds.length < 2) return [];
@@ -169,6 +170,7 @@ export class DreamsDedupService {
           AND status = 'active'
           AND retractedAt IS NONE
           AND embedding != NONE
+          AND entityId.mergedInto IS NONE
         ORDER BY sim DESC
         LIMIT 5
       `;

--- a/src/dreams/dreams.module.ts
+++ b/src/dreams/dreams.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-import { ScheduleModule } from '@nestjs/schedule';
 import { ConfigModule } from '@nestjs/config';
 import { CompactionModule } from '../compaction/compaction.module';
 import { CommunityModule } from '../communities/community.module';
@@ -19,13 +18,7 @@ import { DreamsResolverService } from './resolver.service';
  * via the SUMMARY_GENERATOR token (see compaction.module.ts).
  */
 @Module({
-  imports: [
-    ScheduleModule.forRoot(),
-    ConfigModule,
-    CompactionModule,
-    CommunityModule,
-    AuthModule,
-  ],
+  imports: [ConfigModule, CompactionModule, CommunityModule, AuthModule],
   controllers: [DreamsController],
   providers: [DreamsService, DreamsDedupService, DreamsResolverService],
   exports: [DreamsService],

--- a/src/dreams/resolver.service.ts
+++ b/src/dreams/resolver.service.ts
@@ -174,14 +174,17 @@ export class DreamsResolverService {
     const cutoff = new Date(
       Date.now() - this.minAgeDays * 24 * 60 * 60 * 1000,
     );
+    // Fetch ALL competing facts (no age filter in the query). The group-size
+    // check that follows decides what's a 2-way pair vs a 3+-way disagreement,
+    // so it must see every competing member. Filtering by age here would hide a
+    // recent member of a genuine 3-way group and make it look like a clean pair
+    // we could auto-resolve — exactly the multi-way case we must NOT touch.
     const [rows] = await db.query<[CompetingFactRow[]]>(
       `SELECT id, entityId, predicate, object, confidence, validFrom, recordedAt, source
        FROM knowledge_fact
        WHERE status = 'competing'
          AND retractedAt IS NONE
-         AND recordedAt <= $cutoff
        ORDER BY entityId, predicate, recordedAt ASC`,
-      { cutoff },
     );
     const all = (rows as CompetingFactRow[]) ?? [];
 
@@ -194,9 +197,19 @@ export class DreamsResolverService {
       else byKey.set(key, [r]);
     }
 
+    const cutoffMs = cutoff.getTime();
     const pairs: Array<{ a: CompetingFactRow; b: CompetingFactRow }> = [];
     for (const group of byKey.values()) {
+      // Exactly two competing facts = a resolvable pair. One = nothing to do;
+      // three or more = a multi-way disagreement that needs operator review,
+      // never auto-resolution.
       if (group.length !== 2) continue;
+      // Min-age gate is now an eligibility condition on the pair: both members
+      // must have settled past the cutoff before we let the LLM adjudicate.
+      const aged = group.every(
+        (r) => new Date(r.recordedAt as unknown as string).getTime() <= cutoffMs,
+      );
+      if (!aged) continue;
       pairs.push({ a: group[0], b: group[1] });
       if (pairs.length >= this.maxPairs) break;
     }

--- a/src/ingest/entity-resolver.service.ts
+++ b/src/ingest/entity-resolver.service.ts
@@ -126,6 +126,7 @@ export class EntityResolverService {
            AND status = 'active'
            AND retractedAt IS NONE
            AND embedding != NONE
+           AND entityId.mergedInto IS NONE
          ORDER BY sim DESC
          LIMIT $k`,
       { q, k: this.candidateK },

--- a/src/jobs/job-worker-pool.service.ts
+++ b/src/jobs/job-worker-pool.service.ts
@@ -14,6 +14,16 @@ interface PendingRequest {
   reject: (err: Error) => void;
 }
 
+/**
+ * A caller parked in `acquire()` because no worker was idle. Settled either
+ * by `release()` handing it a worker, or — so it can never hang forever — by
+ * its own acquire timeout / by `rejectAllWaiters` when the pool dies for good.
+ */
+interface Waiter {
+  resolve: (w: PooledWorker) => void;
+  reject: (err: Error) => void;
+}
+
 interface PooledWorker {
   worker: Worker;
   ready: boolean;
@@ -59,15 +69,28 @@ export class JobWorkerPool implements OnModuleInit, OnApplicationShutdown {
   private readonly poolSize: number;
   private readonly workers: PooledWorker[] = [];
   private readonly idle: PooledWorker[] = [];
-  private readonly waiters: Array<(w: PooledWorker) => void> = [];
+  private readonly waiters: Array<Waiter> = [];
   private nextReqId = 1;
   private shuttingDown = false;
+  /** Per-call ceiling: a worker stuck in a tight native loop emits no
+   * message/exit, so without this its slot is pinned forever. On timeout we
+   * terminate the worker (→ exit → respawn) and reject the caller. */
+  private readonly callTimeoutMs: number;
+  private readonly runnerPath: string;
+  // Crash-loop backstop for respawns.
+  private respawnAttempts = 0;
+  private lastRespawnAt = 0;
 
   constructor(config: ConfigService) {
     this.poolSize = parseInt(
       config.get<string>('JOB_WORKER_POOL_SIZE', '2') ?? '2',
       10,
     );
+    this.callTimeoutMs = parseInt(
+      config.get<string>('JOB_WORKER_CALL_TIMEOUT_MS', '120000') ?? '120000',
+      10,
+    );
+    this.runnerPath = this.resolveRunnerPath();
   }
 
   enabled(): boolean {
@@ -79,10 +102,9 @@ export class JobWorkerPool implements OnModuleInit, OnApplicationShutdown {
       this.logger.log('Job worker pool disabled (JOB_WORKER_POOL_SIZE=0)');
       return;
     }
-    const runnerPath = this.resolveRunnerPath();
     for (let i = 0; i < this.poolSize; i++) {
       try {
-        const w = await this.spawnWorker(runnerPath);
+        const w = await this.spawnWorker(this.runnerPath);
         this.workers.push(w);
         this.idle.push(w);
       } catch (e) {
@@ -98,14 +120,9 @@ export class JobWorkerPool implements OnModuleInit, OnApplicationShutdown {
 
   async onApplicationShutdown(): Promise<void> {
     this.shuttingDown = true;
-    // Reject any queued waiters cleanly.
-    for (const waiter of this.waiters.splice(0)) {
-      try {
-        waiter({} as PooledWorker);
-      } catch {
-        /* ignore */
-      }
-    }
+    // Reject any queued waiters cleanly so their `run()` rejects instead of
+    // hanging until shutdown tears the process down.
+    this.rejectAllWaiters(new Error('JobWorkerPool shutting down'));
     await Promise.all(
       this.workers.map(async (w) => {
         if (w.inFlight) {
@@ -134,24 +151,40 @@ export class JobWorkerPool implements OnModuleInit, OnApplicationShutdown {
     if (this.shuttingDown) {
       throw new Error('JobWorkerPool shutting down');
     }
+    // acquire() may park us as a waiter; it rejects on its own timeout, on
+    // shutdown, or when the pool dies for good — so we never hang here.
     const w = await this.acquire();
-    // acquire() may have parked us as a waiter; onApplicationShutdown
-    // resolves pending waiters with a placeholder worker to unblock them.
-    // Re-check after the await — dereferencing that placeholder's
-    // (undefined) `.worker.postMessage` would throw a raw TypeError.
-    if (this.shuttingDown || !w.worker) {
+    if (this.shuttingDown) {
+      this.release(w);
       throw new Error('JobWorkerPool shutting down');
     }
     const id = this.nextReqId++;
+    let timer: NodeJS.Timeout | undefined;
     try {
       return await new Promise<R>((resolve, reject) => {
         w.inFlight = {
           resolve: (v) => resolve(v as R),
           reject,
         };
+        timer = setTimeout(() => {
+          if (!w.inFlight) return;
+          w.inFlight = null;
+          // Mark dead BEFORE terminate() so the finally's release() can't
+          // re-idle this worker in the window before the async 'exit' fires.
+          w.dead = true;
+          this.logger.warn(
+            `Worker call id=${id} timed out after ${this.callTimeoutMs}ms — ` +
+              'terminating worker',
+          );
+          w.worker.terminate().catch(() => undefined);
+          reject(
+            new Error(`worker call timed out after ${this.callTimeoutMs}ms`),
+          );
+        }, this.callTimeoutMs);
         w.worker.postMessage({ id, kind: 'run', modulePath, input });
       });
     } finally {
+      if (timer) clearTimeout(timer);
       w.inFlight = null;
       this.release(w);
     }
@@ -170,9 +203,46 @@ export class JobWorkerPool implements OnModuleInit, OnApplicationShutdown {
   private acquire(): Promise<PooledWorker> {
     const free = this.idle.shift();
     if (free) return Promise.resolve(free);
-    return new Promise<PooledWorker>((resolve) => {
-      this.waiters.push(resolve);
+    return new Promise<PooledWorker>((resolve, reject) => {
+      const waiter: Waiter = { resolve, reject };
+      // Park timeout. Without it a caller waits forever when every worker is
+      // dead and the respawn budget is spent — no release() ever fires. The
+      // per-call timeout only arms after acquire() resolves, so it can't
+      // cover this phase; this is the backstop for it.
+      const timer = setTimeout(() => {
+        const i = this.waiters.indexOf(waiter);
+        if (i >= 0) this.waiters.splice(i, 1);
+        reject(
+          new Error(
+            `worker acquire timed out after ${this.callTimeoutMs}ms — ` +
+              'pool exhausted/degraded',
+          ),
+        );
+      }, this.callTimeoutMs);
+      timer.unref();
+      // Wrap both settle paths so the timer is cleared exactly once whichever
+      // fires first (release, shutdown, permanent-degradation, or timeout).
+      waiter.resolve = (w) => {
+        clearTimeout(timer);
+        resolve(w);
+      };
+      waiter.reject = (e) => {
+        clearTimeout(timer);
+        reject(e);
+      };
+      this.waiters.push(waiter);
     });
+  }
+
+  /** Settle every parked caller with an error (shutdown / permanent death). */
+  private rejectAllWaiters(err: Error): void {
+    for (const waiter of this.waiters.splice(0)) {
+      try {
+        waiter.reject(err);
+      } catch {
+        /* ignore */
+      }
+    }
   }
 
   private release(w: PooledWorker): void {
@@ -183,7 +253,7 @@ export class JobWorkerPool implements OnModuleInit, OnApplicationShutdown {
     // terminated worker whose postMessage no-ops and run() hangs forever.
     if (w.dead || !this.workers.includes(w)) return;
     const next = this.waiters.shift();
-    if (next) next(w);
+    if (next) next.resolve(w);
     else this.idle.push(w);
   }
 
@@ -244,13 +314,69 @@ export class JobWorkerPool implements OnModuleInit, OnApplicationShutdown {
           slot.inFlight.reject(new Error(`worker exited (code ${code})`));
           slot.inFlight = null;
         }
-        // Remove from pool tracking — onApplicationShutdown is best-
-        // effort, an unexpected exit just shrinks the pool.
+        // Remove from pool tracking.
         const i = this.workers.indexOf(slot);
         if (i >= 0) this.workers.splice(i, 1);
         const j = this.idle.indexOf(slot);
         if (j >= 0) this.idle.splice(j, 1);
+        // Self-heal: replace a worker that had successfully booted and then
+        // died unexpectedly. Slots that never readied (init/respawn failures)
+        // are handled by their spawn caller, not here, to avoid double-spawn.
+        if (!this.shuttingDown && slot.ready) {
+          this.scheduleRespawn();
+        }
       });
     });
+  }
+
+  /**
+   * Spawn a replacement worker after an unexpected exit, with exponential
+   * backoff and a crash-loop budget. Without the budget a worker that crashes
+   * on boot (bad native dep) would respawn in a tight loop forever.
+   */
+  private scheduleRespawn(): void {
+    if (this.shuttingDown) return;
+    const now = Date.now();
+    // Reset the budget after a calm minute — transient crashes shouldn't
+    // permanently consume it.
+    if (now - this.lastRespawnAt > 60_000) this.respawnAttempts = 0;
+    if (this.respawnAttempts >= this.poolSize * 5) {
+      this.logger.error(
+        `Worker respawn budget exhausted (${this.respawnAttempts}) — pool ` +
+          `degraded at ${this.workers.length}/${this.poolSize}`,
+      );
+      // If no worker survives, nothing will ever hand a slot to parked
+      // callers — fail them now instead of leaving them to the acquire
+      // timeout. If some workers are still alive, their release() can still
+      // serve waiters, so leave them parked.
+      if (this.workers.length === 0) {
+        this.rejectAllWaiters(
+          new Error('worker pool permanently degraded — all workers dead'),
+        );
+      }
+      return;
+    }
+    this.respawnAttempts++;
+    this.lastRespawnAt = now;
+    const delay = Math.min(100 * 2 ** this.respawnAttempts, 5_000);
+    setTimeout(() => {
+      if (this.shuttingDown) return;
+      this.spawnWorker(this.runnerPath)
+        .then((w) => {
+          if (this.shuttingDown) {
+            w.worker.terminate().catch(() => undefined);
+            return;
+          }
+          this.workers.push(w);
+          this.release(w); // hand to a waiter, else return to idle
+          this.logger.log(
+            `Respawned pool worker — size=${this.workers.length}/${this.poolSize}`,
+          );
+        })
+        .catch((e) => {
+          this.logger.warn(`Worker respawn failed: ${(e as Error).message}`);
+          this.scheduleRespawn();
+        });
+    }, delay).unref();
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ initTracing();
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import type { NestExpressApplication } from '@nestjs/platform-express';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
 import { validateEnv } from './common/env-validation';
@@ -46,10 +47,18 @@ async function bootstrap() {
     procLog.error(`uncaughtException: ${err?.message ?? err}`, err?.stack);
   });
 
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
   app.enableShutdownHooks();
   const configService = app.get(ConfigService);
   const logger = new Logger('Bootstrap');
+
+  // Bound the JSON body. Express defaults to 100kb, but the app installs its
+  // own parser; set an explicit cap so a hostile client can't post a huge
+  // payload that pins memory before any handler runs. Ingest text fits well
+  // under 1mb; override via MAX_BODY_SIZE for unusual workloads.
+  const maxBody = configService.get<string>('MAX_BODY_SIZE', '1mb');
+  app.useBodyParser('json', { limit: maxBody });
+  app.useBodyParser('urlencoded', { limit: maxBody, extended: true });
 
   app.use(helmet({
     contentSecurityPolicy: false,

--- a/test/auth-guard.unit-spec.ts
+++ b/test/auth-guard.unit-spec.ts
@@ -212,6 +212,9 @@ describe('ApiKeyGuard — production with JWKS rejects static keys', () => {
 
     const config = new StubConfig({
       AUTH_SERVICE_JWKS_URL: `http://127.0.0.1:${port}/.well-known/jwks.json`,
+      // Required in production now that JwksService refuses to boot with an
+      // unvalidated issuer (alg/issuer hardening).
+      AUTH_SERVICE_ISSUER: 'https://auth.test/',
       BRAIN_API_KEYS: JSON.stringify([
         {
           keyHash:

--- a/test/fixtures/echo-worker-job.ts
+++ b/test/fixtures/echo-worker-job.ts
@@ -11,6 +11,15 @@ export async function run(input: unknown): Promise<unknown> {
   if (i.mode === 'sleep') {
     await new Promise((r) => setTimeout(r, 50));
   }
+  if (i.mode === 'hang') {
+    // Never resolves — simulates a worker wedged in a tight loop. Only the
+    // pool's per-call timeout (which terminates the worker) frees the slot.
+    await new Promise(() => {});
+  }
+  if (i.mode === 'crash') {
+    // Abruptly kill the worker thread — simulates a native crash / OOM.
+    process.exit(1);
+  }
   return {
     echoed: i.payload ?? null,
     workerPid: process.pid,

--- a/test/job-worker-pool.unit-spec.ts
+++ b/test/job-worker-pool.unit-spec.ts
@@ -25,6 +25,15 @@ function makeConfig(env: Record<string, string> = {}): ConfigService {
 
 const FIXTURE_PATH = join(__dirname, 'fixtures', 'echo-worker-job.ts');
 
+async function waitFor(pred: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pred()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error('waitFor: condition not met within timeout');
+}
+
 describe('JobWorkerPool', () => {
   it('runs a worker module and returns its result', async () => {
     const pool = new JobWorkerPool(makeConfig({ JOB_WORKER_POOL_SIZE: '2' }));
@@ -80,6 +89,46 @@ describe('JobWorkerPool', () => {
     await expect(pool.run(FIXTURE_PATH, {})).rejects.toThrow(/disabled/);
     await pool.onApplicationShutdown();
   });
+
+  it('times out a wedged worker call and self-heals the slot', async () => {
+    const pool = new JobWorkerPool(
+      makeConfig({ JOB_WORKER_POOL_SIZE: '1', JOB_WORKER_CALL_TIMEOUT_MS: '200' }),
+    );
+    await pool.onModuleInit();
+    try {
+      await expect(pool.run(FIXTURE_PATH, { mode: 'hang' })).rejects.toThrow(
+        /timed out/,
+      );
+      // The timed-out worker was terminated; the pool should respawn a
+      // replacement and accept new work again. Wait for an *idle* worker, not
+      // just size===1 — the terminated slot lingers in `workers` until its
+      // async 'exit' fires, so size===1 can briefly count the dead worker.
+      await waitFor(() => pool.stats().idle === 1, 8_000);
+      const out = (await pool.run(FIXTURE_PATH, {
+        mode: 'echo',
+        payload: { ok: 1 },
+      })) as { echoed: { ok: number } };
+      expect(out.echoed).toEqual({ ok: 1 });
+    } finally {
+      await pool.onApplicationShutdown();
+    }
+  }, 20_000);
+
+  it('respawns a worker that crashes mid-job', async () => {
+    const pool = new JobWorkerPool(makeConfig({ JOB_WORKER_POOL_SIZE: '1' }));
+    await pool.onModuleInit();
+    try {
+      await expect(pool.run(FIXTURE_PATH, { mode: 'crash' })).rejects.toThrow();
+      await waitFor(() => pool.stats().idle === 1, 8_000);
+      const out = (await pool.run(FIXTURE_PATH, {
+        mode: 'echo',
+        payload: { back: true },
+      })) as { echoed: { back: boolean } };
+      expect(out.echoed).toEqual({ back: true });
+    } finally {
+      await pool.onApplicationShutdown();
+    }
+  }, 20_000);
 
   it('rejects in-flight requests on shutdown', async () => {
     const pool = new JobWorkerPool(makeConfig({ JOB_WORKER_POOL_SIZE: '1' }));


### PR DESCRIPTION
Branch-level security/correctness/reliability hardening surfaced by a deep audit. Two commits.

## `fix(http)` — request-cancellation regression (Express 5)
On Express 5 / modern Node the request's `'close'` fires once the request **body** is fully read — long before a slow async handler (OpenAI embed/extract) finishes. Keying the `AbortController` off `req 'close'` cancelled every in-flight request mid-flight (ingest aborting its own embedding ~25ms in → HTTP 500 *"Request was aborted"*). Now bound to `res 'close'` + `res.writableFinished` — abort only when the client genuinely went away.

## `hardening` — bundle
**Security**
- JWT alg-pinning (`AUTH_SERVICE_JWT_ALGS`, default RS256) closes algorithm-confusion; `AUTH_SERVICE_ISSUER` required in prod (refuse to boot vs. accept any JWKS-signed token); scope cap.
- Reject the public placeholder scoped-pool password from migration 0005; validate `MAX_BODY_SIZE`.
- Explicit JSON/urlencoded body-size cap (`MAX_BODY_SIZE`, default 1mb).

**Correctness**
- Filter tombstoned entities (`entityId.mergedInto IS NONE`) in dedup / resolver / entity-resolver candidate queries.
- Dreams resolver: min-age as a per-pair eligibility gate over *all* competing facts, so a real 3-way disagreement is never mistaken for an auto-resolvable pair.
- Embedder: fail loud on wrong vector count / empty vector instead of caching `undefined`.
- `dbCreate`/`dbMerge`: throw on no-row instead of returning `undefined` typed as `T`.

**Reliability**
- Worker-pool: per-call timeout terminates a wedged worker; self-heal respawn (backoff + crash-loop budget); parked `acquire()` callers get their own timeout and are rejected on permanent pool death instead of hanging forever.

**Wiring**
- `ScheduleModule.forRoot()` registered once in `AppModule` (was 3× across ai/compaction/dreams) — avoids duplicate scheduler registration.

## Tests
641 unit tests green; `tsc --noEmit` + eslint clean. Worker-pool gains hang/crash fixtures + self-heal coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)