### PR TITLE
feat(ops): observability + deploy resilience

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -117,6 +117,14 @@ jobs:
               image: ${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service:latest
               container_name: ${{ env.PROJECT_NAME }}
               restart: unless-stopped
+              # PID-1 init (tini): reaps zombie children from the worker
+              # pool / native deps and forwards signals so SIGTERM reaches
+              # Node cleanly.
+              init: true
+              # The app's graceful shutdown drains in-flight work for up to
+              # 15s (main.ts); Docker's default 10s SIGKILLs mid-drain, so
+              # give it headroom past that budget.
+              stop_grace_period: 30s
               expose:
                 - "${{ env.PORT }}"
               environment:

--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -416,6 +416,28 @@ jobs:
           docker-compose logs --tail=120 ${{ env.PROJECT_NAME }}
           exit 1
 
+      - name: Internal readiness probe (warning-only)
+        if: github.event.inputs.action != 'logs'
+        continue-on-error: true
+        run: |
+          cd /opt/projects/${{ env.PROJECT_NAME }}
+          # /health (gate above) is liveness — green as soon as Nest boots,
+          # while the bge-m3 embedder is still warming and the app serves on
+          # the OpenAI fallback. /ready 503s until DB + embedder are warm.
+          # Surfaced as warning-only (NOT a gate) because a cold-image ONNX
+          # download can exceed this window without anything being wrong;
+          # failing the deploy on it would be a false alarm. Gives ops a
+          # clear "booted but not yet warm" signal in the deploy log.
+          for i in $(seq 1 24); do
+            if docker-compose exec -T ${{ env.PROJECT_NAME }} wget -qO- http://localhost:${{ env.PORT }}/ready > /dev/null 2>&1; then
+              echo "[ok] container is READY (db + embedder warm)"
+              exit 0
+            fi
+            echo "[info] booted, waiting for readiness (embedder warmup)... ($i/24)"
+            sleep 5
+          done
+          echo "[warn] /ready never went green within 120s — embedder may still be warming; serving on OpenAI fallback until then"
+
       - name: External health probe (warning-only)
         if: github.event.inputs.action != 'logs'
         continue-on-error: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,14 @@ services:
       - FORGET_HMAC_KEY=${FORGET_HMAC_KEY:-local-dev-forget-hmac-key-change-in-prod}
     ports:
       - "${BRAIN_HOST_PORT:-3030}:3000"
+    # PID-1 init (tini): reaps zombie children — the app spawns
+    # worker_threads / native processes, and without an init the Node
+    # PID-1 doesn't reap them. Also forwards signals correctly.
+    init: true
+    # The app's graceful shutdown gives in-flight work up to 15s before a
+    # forced exit (main.ts). Docker's default 10s SIGKILLs mid-drain; give
+    # it headroom so SIGTERM handling actually completes.
+    stop_grace_period: 30s
     # Mirror the prod ceilings so local OOMs surface here, not in deploy.
     mem_limit: 2g
     mem_reservation: 768m

--- a/src/ai/calibration/calibration-refit.service.ts
+++ b/src/ai/calibration/calibration-refit.service.ts
@@ -61,8 +61,6 @@ export class CalibrationRefitService implements OnModuleInit {
    * draining a huge tenant — and the manual trigger from
    * /admin/maintenance/calibration-refit can't overlap with either.
    */
-  private readonly guard = new DistributedLeaseGuard();
-
   constructor(
     private readonly surreal: SurrealService,
     private readonly apiKeys: ApiKeyService,
@@ -71,6 +69,12 @@ export class CalibrationRefitService implements OnModuleInit {
     @Optional() private readonly jobs?: JobRunService,
     @Optional() private readonly claim?: JobClaimService,
     @Optional() private readonly workerLoop?: WorkerLoopService,
+    // Inject the DI-wired guard (carries LeaderLeaseService from the global
+    // JobsModule) instead of `new DistributedLeaseGuard()`. A self-built
+    // guard has no lease, so in JOBS_QUEUE_MODE=inline the 03:42/03:51 cron
+    // fired on EVERY pod and double-wrote source_trust / calibration_table.
+    // @Optional so the positional unit tests (no DI) can omit it.
+    @Optional() private readonly guard?: DistributedLeaseGuard,
   ) {
     this.enabled =
       (config.get<string>('CALIBRATION_NIGHTLY_REFIT', 'true').toLowerCase()) ===
@@ -186,9 +190,11 @@ export class CalibrationRefitService implements OnModuleInit {
       triggeredByActor?: string;
     },
   ): Promise<number> {
-    const guarded = await this.guard.run('refit_source_trust', () =>
-      this.refitSourceTrustInner(trigger),
-    );
+    const guarded = this.guard
+      ? await this.guard.run('refit_source_trust', () =>
+          this.refitSourceTrustInner(trigger),
+        )
+      : await this.refitSourceTrustInner(trigger);
     if (guarded === null) {
       this.logger.warn('source-trust refit skipped — already in flight');
       return 0;
@@ -331,9 +337,11 @@ export class CalibrationRefitService implements OnModuleInit {
       triggeredByActor?: string;
     },
   ): Promise<number> {
-    const guarded = await this.guard.run('refit_calibration', () =>
-      this.refitCalibrationInner(trigger),
-    );
+    const guarded = this.guard
+      ? await this.guard.run('refit_calibration', () =>
+          this.refitCalibrationInner(trigger),
+        )
+      : await this.refitCalibrationInner(trigger);
     if (guarded === null) {
       this.logger.warn('calibration refit skipped — already in flight');
       return 0;

--- a/src/audit/changefeed-consumer.service.ts
+++ b/src/audit/changefeed-consumer.service.ts
@@ -51,6 +51,15 @@ export class ChangefeedConsumerService {
   // for minutes. Trailing batches drain on subsequent ticks; the
   // lag-records gauge surfaces the backlog.
   private readonly perBatchLimit: number;
+  /**
+   * Upper bound on rows pulled from SHOW CHANGES per source per tick.
+   * Without it, a cold start (cursor=0) materialises the ENTIRE 30-day
+   * CHANGEFEED retention into the node process before the TS-side batch
+   * slice runs. Kept a few multiples above perBatchLimit so the trailing
+   * count still reports a useful lag; the cursor drains the rest over
+   * subsequent ticks.
+   */
+  private readonly fetchLimit: number;
   // Hot in-flight flag — overlapping ticks waste DB connections and
   // could double-emit on a slow tenant. Each cron firing checks +
   // skips if a previous one is still running.
@@ -85,6 +94,21 @@ export class ChangefeedConsumerService {
     this.perBatchLimit = parseInt(
       config.get<string>('AUDIT_CHANGEFEED_BATCH', '500'),
       10,
+    );
+    const fetchLimit = parseInt(
+      config.get<string>('AUDIT_CHANGEFEED_FETCH_LIMIT', '5000'),
+      10,
+    );
+    // Never fetch fewer than we process in a tick, else we'd starve;
+    // fall back to a sane default if the env value is garbage (the value
+    // is interpolated into the SHOW CHANGES LIMIT clause, so NaN would
+    // produce invalid SurrealQL).
+    const safeBatch = Number.isFinite(this.perBatchLimit)
+      ? this.perBatchLimit
+      : 500;
+    this.fetchLimit = Math.max(
+      Number.isFinite(fetchLimit) ? fetchLimit : 5000,
+      safeBatch,
     );
   }
 
@@ -325,7 +349,7 @@ export class ChangefeedConsumerService {
       throw new Error(`refusing unknown changefeed source: ${source}`);
     }
     const [rows] = await db.query(
-      `SHOW CHANGES FOR TABLE ${source} SINCE ${since}`,
+      `SHOW CHANGES FOR TABLE ${source} SINCE ${since} LIMIT ${this.fetchLimit}`,
     );
     const changes = (rows as Array<Record<string, unknown>>) ?? [];
     // SurrealDB's SHOW CHANGES ... SINCE <vs> is inclusive of the boundary

--- a/src/jobs/worker-loop.service.ts
+++ b/src/jobs/worker-loop.service.ts
@@ -12,6 +12,7 @@ import { ApiKeyService } from '../auth/api-key.service';
 import { JobClaimService, type JobClaim } from './job-claim.service';
 import { LeaderLeaseService } from './leader-lease.service';
 import { JobWorkerPool } from './job-worker-pool.service';
+import { MetricsService } from '../metrics/metrics.service';
 import type { JobType } from './job-run.service';
 
 export interface JobContext {
@@ -115,6 +116,7 @@ export class WorkerLoopService
     @Optional() private readonly apiKeys?: ApiKeyService,
     @Optional() @Inject('WORKER_LOOP_NOW') private readonly now?: () => number,
     @Optional() private readonly workerPool?: JobWorkerPool,
+    @Optional() private readonly metrics?: MetricsService,
   ) {
     this.enabled =
       (config.get<string>('WORKER_LOOP_ENABLED', '1') ?? '1') !== '0';
@@ -227,6 +229,7 @@ export class WorkerLoopService
     if (this.leaseTimer) clearTimeout(this.leaseTimer);
     if (this.decayTimer) clearInterval(this.decayTimer);
     this.abortController.abort();
+    this.metrics?.setWorkerLeader(false);
     if (this.isLeader && this.lease) {
       try {
         await this.lease.release('worker_loop');
@@ -268,6 +271,7 @@ export class WorkerLoopService
         this.isLeader = false;
       }
     }
+    this.metrics?.setWorkerLeader(this.isLeader);
     if (this.isLeader && !this.loopsStarted) {
       this.loopsStarted = true;
       for (const reg of this.handlers.values()) {
@@ -395,6 +399,10 @@ export class WorkerLoopService
     consumerSpan: ReturnType<ReturnType<typeof trace.getTracer>['startSpan']>,
   ): Promise<void> {
     const handlerAbort = new AbortController();
+    const startedAt = this.now?.() ?? Date.now();
+    // Mirrors the span's `job.outcome`. Defaults to 'failed' so an
+    // unexpected throw before any branch is counted as a failure, not lost.
+    let outcome: 'succeeded' | 'failed' | 'cancelled' | 'lost_claim' = 'failed';
     // Pod shutdown propagates into the handler.
     const onShutdown = () => handlerAbort.abort(new Error('pod_shutdown'));
     this.abortController.signal.addEventListener('abort', onShutdown, {
@@ -453,6 +461,7 @@ export class WorkerLoopService
       clearInterval(renewTimer);
       if (cancelRequested) {
         consumerSpan.setAttribute('job.outcome', 'cancelled');
+        outcome = 'cancelled';
         await this.claim!.cancelled({
           companyId: claim.companyId,
           recordId: claim.recordId,
@@ -462,11 +471,13 @@ export class WorkerLoopService
         // Don't write — another worker owns the row now. The
         // duplicate-work cost was already paid; just bail.
         consumerSpan.setAttribute('job.outcome', 'lost_claim');
+        outcome = 'lost_claim';
         this.logger.warn(
           `Claim ${claim.runId} lost mid-handler; skipping terminal write`,
         );
       } else {
         consumerSpan.setAttribute('job.outcome', 'succeeded');
+        outcome = 'succeeded';
         await this.claim!.complete({
           companyId: claim.companyId,
           recordId: claim.recordId,
@@ -479,6 +490,7 @@ export class WorkerLoopService
       consumerSpan.recordException(e);
       if (cancelRequested) {
         consumerSpan.setAttribute('job.outcome', 'cancelled');
+        outcome = 'cancelled';
         await this.claim!.cancelled({
           companyId: claim.companyId,
           recordId: claim.recordId,
@@ -486,11 +498,13 @@ export class WorkerLoopService
         });
       } else if (lostClaim) {
         consumerSpan.setAttribute('job.outcome', 'lost_claim');
+        outcome = 'lost_claim';
         this.logger.warn(
           `Claim ${claim.runId} lost mid-handler (handler threw): ${e.message}`,
         );
       } else {
         consumerSpan.setAttribute('job.outcome', 'failed');
+        outcome = 'failed';
         consumerSpan.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
         await this.claim!.fail({
           companyId: claim.companyId,
@@ -503,6 +517,8 @@ export class WorkerLoopService
       }
     } finally {
       this.abortController.signal.removeEventListener('abort', onShutdown);
+      const elapsed = ((this.now?.() ?? Date.now()) - startedAt) / 1000;
+      this.metrics?.recordJob(claim.jobType, outcome, elapsed);
     }
   }
 

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -197,6 +197,35 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // Background job execution. Before this, job outcomes lived only on
+  // OTel spans + logs — there was no Prometheus signal to alert on a
+  // rising failure rate or a stalled queue. Outcomes mirror the span's
+  // `job.outcome`: succeeded | failed | cancelled | lost_claim.
+  readonly jobsTotal = new Counter({
+    name: 'brain_job_total',
+    help: 'Background job dispatches by type and terminal outcome',
+    labelNames: ['jobType', 'outcome'] as const,
+    registers: [this.registry],
+  });
+
+  readonly jobDuration = new Histogram({
+    name: 'brain_job_duration_seconds',
+    help: 'Background job handler latency in seconds, by type',
+    labelNames: ['jobType'] as const,
+    buckets: [0.05, 0.25, 1, 5, 15, 60, 300, 1200],
+    registers: [this.registry],
+  });
+
+  // 1 on the pod currently holding the worker_loop leader lease, 0
+  // elsewhere. Summed across pods it tells the operator whether the
+  // cluster has exactly one leader (sum=1), none (sum=0 → no jobs
+  // running), or a split-brain window (sum>1).
+  readonly workerIsLeader = new Gauge({
+    name: 'brain_worker_is_leader',
+    help: 'Whether this pod currently holds the worker_loop leader lease (1/0)',
+    registers: [this.registry],
+  });
+
   onModuleInit() {
     // Node defaults: GC, event-loop lag, memory, CPU. Cheap and useful.
     collectDefaultMetrics({ register: this.registry, prefix: 'brain_' });
@@ -315,6 +344,22 @@ export class MetricsService implements OnModuleInit {
         args.completionTokens,
       );
     }
+  }
+
+  recordJob(
+    jobType: string,
+    outcome: 'succeeded' | 'failed' | 'cancelled' | 'lost_claim',
+    durationSeconds: number,
+  ): void {
+    this.jobsTotal.inc({ jobType, outcome } as LabelValues<'jobType' | 'outcome'>);
+    this.jobDuration.observe(
+      { jobType } as LabelValues<'jobType'>,
+      durationSeconds,
+    );
+  }
+
+  setWorkerLeader(isLeader: boolean): void {
+    this.workerIsLeader.set(isLeader ? 1 : 0);
   }
 
   countChangefeedConsumed(source: string, n = 1): void {

--- a/test/changefeed-consumer.unit-spec.ts
+++ b/test/changefeed-consumer.unit-spec.ts
@@ -103,6 +103,11 @@ describe('ChangefeedConsumerService', () => {
     expect(
       ((inserts[0].params?.events ?? []) as unknown[]).length,
     ).toBe(2);
+    // SHOW CHANGES must carry a LIMIT so a cold cursor can't materialise
+    // the whole 30-day retention into the process.
+    const show = calls.find((c) => c.sql.startsWith('SHOW CHANGES'));
+    expect(show).toBeTruthy();
+    expect(show!.sql).toMatch(/LIMIT \d+/);
   });
 
   it('caps batch size and reports pendingRemaining for the trailing slice', async () => {

--- a/test/worker-loop.unit-spec.ts
+++ b/test/worker-loop.unit-spec.ts
@@ -135,6 +135,35 @@ describe('WorkerLoopService.dispatch', () => {
     expect(claimSvc.calls.failed).toHaveLength(0);
   });
 
+  it('records a job metric with the terminal outcome and a duration', async () => {
+    const claim = makeJobClaim({ jobType: 'dreams' });
+    const claimSvc = makeClaimSvc();
+    const recordJob = jest.fn();
+    // metrics is the 7th constructor arg (config, claim, lease, apiKeys,
+    // now, workerPool, metrics).
+    const svc = new WorkerLoopService(
+      makeConfig(),
+      claimSvc as any,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { recordJob, setWorkerLeader: jest.fn() } as any,
+    );
+    await callDispatch(svc, claim, {
+      jobType: 'dreams' as JobType,
+      handler: async () => ({ ok: true }),
+      ttlSeconds: 3,
+      maxAttempts: 3,
+    });
+    expect(recordJob).toHaveBeenCalledTimes(1);
+    const [jobType, outcome, seconds] = recordJob.mock.calls[0];
+    expect(jobType).toBe('dreams');
+    expect(outcome).toBe('succeeded');
+    expect(typeof seconds).toBe('number');
+    expect(seconds).toBeGreaterThanOrEqual(0);
+  });
+
   it('routes a thrown handler error to fail()', async () => {
     const claim = makeJobClaim({ attempts: 2 });
     const claimSvc = makeClaimSvc();


### PR DESCRIPTION
Second audit follow-up wave — operability hardening. All self-contained, additive, no behaviour change to request paths. 642 unit tests green, tsc + lint clean.

## Commits
1. **feat(metrics)** — Prometheus job metrics. Background jobs were unmetered (outcomes only on OTel spans/logs). Adds `brain_job_total{jobType,outcome}`, `brain_job_duration_seconds{jobType}`, `brain_worker_is_leader` wired into the dispatch terminal branches + leader-lease transition. +1 test.
2. **fix(changefeed)** — bound `SHOW CHANGES` with a `LIMIT`. A cold cursor (vs=0) materialised the entire 30-day CHANGEFEED retention into the process before the TS-side batch slice. Configurable `AUDIT_CHANGEFEED_FETCH_LIMIT` (default 5000, floored at batch size). +1 test.
3. **ci(deploy)** — `init: true` (tini PID-1, reaps worker-pool/native zombies + clean signals) and `stop_grace_period: 30s` (so the app's 15s graceful drain finishes before Docker SIGKILL). Both compose files.
4. **fix(calibration)** — inject the DI-wired `DistributedLeaseGuard` (carries `LeaderLeaseService`) instead of `new DistributedLeaseGuard()`. Under `JOBS_QUEUE_MODE=inline` the 03:42/03:51 cron fired on every pod and double-wrote `source_trust`/`calibration_table`. Mirrors the DreamsService pattern.
5. **ci(deploy)** — warning-only `/ready` probe after the `/health` gate, surfacing "booted but embedder still warming" without risking flaky deploys on a cold ONNX download.

## Out of scope (deliberately)
- Hard `/ready` deploy gate: bge-m3 warmup timing is uncertain; a hard gate could flake deploys. Left as warning-only.
- Eval governance (golden freeze + CI gate), code-quality (strictNullChecks, big-service unit specs), docs drift — separate waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)