### PR TITLE
test(eval): strict overall retrieval floors + fix eval throttle

### DIFF
--- a/test/eval/runner/aggregator.ts
+++ b/test/eval/runner/aggregator.ts
@@ -41,12 +41,25 @@ export class Aggregator {
 
     return {
       perVertical,
-      overall: this.computeMetrics(outcomes),
+      overall: this.computeMetrics(outcomes, true),
       outcomes,
     };
   }
 
-  private computeMetrics(group: ScenarioOutcome[]): AggregateMetric[] {
+  private computeMetrics(
+    group: ScenarioOutcome[],
+    isOverall = false,
+  ): AggregateMetric[] {
+    // Per-vertical groups are small (n≈8–30) with wide CIs, so their core
+    // retrieval floors stay lenient — a single miss on a 12-query vertical
+    // shouldn't red the suite. The OVERALL aggregate (n≈260) is tight, so it
+    // carries a much stricter floor that actually catches regression. The
+    // measured 2026-06-25 baseline is recall@1 0.95 / recall@3 0.99 / MRR
+    // 0.97; these floors sit ~10pp below with headroom for normal variance
+    // while still tripping on a real drop (the old 0.6/0.8/0.5 could not).
+    const recall1Floor = isOverall ? 0.85 : 0.6;
+    const recall3Floor = isOverall ? 0.93 : 0.8;
+    const mrrFloor = isOverall ? 0.88 : 0.5;
     const queries = group.flatMap((o) => o.queryResults);
     const extractions = group.flatMap((o) => o.extractionResults);
     const merges = group
@@ -103,9 +116,9 @@ export class Aggregator {
     };
 
     return [
-      bootstrap('recall@1', recallAtKVector(queries, 1), 0.6),
-      bootstrap('recall@3', recallAtKVector(queries, 3), 0.8),
-      bootstrap('MRR', reciprocalRankVector(queries), 0.5),
+      bootstrap('recall@1', recallAtKVector(queries, 1), recall1Floor),
+      bootstrap('recall@3', recallAtKVector(queries, 3), recall3Floor),
+      bootstrap('MRR', reciprocalRankVector(queries), mrrFloor),
       // NDCG@10 — canonical retrieval metric on BEIR/MTEB/MS MARCO.
       // Standard reporting unit for embedding-model papers; lets our
       // numbers be directly compared to published baselines.

--- a/test/spawn/spawn-service.ts
+++ b/test/spawn/spawn-service.ts
@@ -77,6 +77,12 @@ export async function spawnService(opts: SpawnOptions = {}): Promise<SpawnedServ
     // override via SpawnOptions.env.
     THROTTLE_LIMIT: '100000',
     THROTTLE_TTL_MS: '60000',
+    // search / synthesize / ingest sit in the *expensive* throttle tier,
+    // which has its own knobs — raising only the default limit above still
+    // let quality-eval's burst trip a 429 on /v1/search. Lift the expensive
+    // tier too so the harness isn't self-throttled.
+    THROTTLE_EXPENSIVE_LIMIT: '100000',
+    THROTTLE_EXPENSIVE_TTL_MS: '60000',
     BRAIN_API_KEYS: JSON.stringify(allKeys),
     FORGET_HMAC_KEY: 'test-hmac-key-must-be-at-least-32-chars',
     // Spec-supplied overrides land last so a spec can override anything


### PR DESCRIPTION
Third audit wave — eval governance. Test-harness only (test/eval, test/spawn); no production code, no deploy impact. 642 unit tests green, tsc + lint clean.

## Changes
1. **Split retrieval floors by scope.** `recall@1/recall@3/MRR` floors (0.6/0.8/0.5) were applied identically to tiny per-vertical groups (n≈8–30, wide CI) and the n≈260 overall aggregate — so they were tuned for small-n variance and could never catch a real overall regression. Per-vertical stays lenient; **overall now floors at 0.85/0.93/0.88**, ~10pp below the measured 2026-06-25 baseline (0.95/0.99/0.97) with headroom. This also gives a hard anchor against the self-promoting nightly baseline ratcheting quality down unnoticed.
2. **Lift the expensive throttle tier in spawn.** `spawn-service` raised only the default tier; search/synthesize/ingest sit in the *expensive* tier, so the quality eval's burst still 429'd on `/v1/search` — a silent eval-infra false negative. Lift `THROTTLE_EXPENSIVE_*` too.

Both surfaced while actually re-running the quality eval this session (baseline re-measured: recall@1 0.88→0.95, MRR 0.93→0.97).

## Still open (not in this PR)
- Frozen golden baseline + stop nightly cache-promotion in ci.yml (the new absolute overall floor mitigates the ratchet risk; the full fix touches shared CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)