### PR TITLE
fix(communities): deterministic fact order (fixes CI-flaky search e2e)

### DIFF
--- a/src/communities/community-builder.service.ts
+++ b/src/communities/community-builder.service.ts
@@ -294,12 +294,20 @@ export class CommunityBuilderService {
       names[0]?.canonicalName ?? `community of ${members.length} entities`;
 
     const [factRows] = await db.query<[Array<RawFact>]>(
+      // Deterministic tiebreakers after confidence: a cluster's facts often
+      // share one confidence (e.g. a batch of name facts all at 0.95), so
+      // ORDER BY confidence alone left the row order DB-dependent. That made
+      // the concat summary — and thus its embedding — vary run-to-run, so the
+      // cosine of an unrelated query against it flipped sign across
+      // environments and intermittently fell below minSimilarity:0 (a CI-only
+      // flake in the communities search e2e). A fully-ordered projection makes
+      // the summary, and every downstream similarity, reproducible.
       `SELECT entityId, predicate, object, confidence, validFrom, validUntil
          FROM knowledge_fact
          WHERE entityId INSIDE $ids
            AND status = 'active'
            AND retractedAt IS NONE
-         ORDER BY confidence DESC
+         ORDER BY confidence DESC, validFrom ASC, predicate ASC, object ASC
          LIMIT 40`,
       { ids: ridSample },
     );


### PR DESCRIPTION
Fixes the recurring `communities.e2e` flake that has been blocking unrelated PRs (#27, #31 both needed admin-merge / reruns past it).

## Root cause
`gatherMemberContext` ordered the member-facts projection by `confidence DESC` only. A cluster's facts often share a single confidence (the e2e ingests three name facts all at 0.95), so tie order fell back to DB row order — which varies across environments. The concat summary (and its embedding) therefore varied run-to-run; with the non-semantic hash stub, the cosine of an unrelated query against it flipped sign and intermittently dropped below `minSimilarity: 0`, filtering the result. sha256 is deterministic across machines, so the **only** local/CI divergence was this fact ordering.

## Fix
Add full deterministic tiebreakers: `ORDER BY confidence DESC, validFrom ASC, predicate ASC, object ASC`. Reproducible summaries → reproducible embeddings → stable similarity. Also a genuine correctness win (same graph → same community summary).

Verified: communities e2e green 3×; full StubEmbedder-dependent e2e set (communities, procedural-memory, sota, mention-locale-hype, phase4-db-persistence) 31/31 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)