### PR TITLE
docs: reconcile MCP tool counts to the live 21-tool surface

### DIFF
--- a/clients/brain-mcp/README.md
+++ b/clients/brain-mcp/README.md
@@ -19,7 +19,7 @@ harness ──stdio──▶ brain-mcp ──HTTP + Bearer──▶ https://brai
 
 It is a **transparent passthrough** — it does not rename or curate tools.
 `tools/list` and `tools/call` are forwarded verbatim, so the harness sees
-exactly the surface the key unlocks (read → 10 tools, +write → 13, +admin → 14).
+exactly the surface the key unlocks (read → 15 tools, +write → 20, +admin → 21).
 
 ## Configuration
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -126,7 +126,7 @@ Add inite-brain-service to Knowledge & Memory
 
 ```
 Adds inite-brain-service — open-source (AGPL-3.0) bitemporal memory layer
-for LLM agents. MCP server (Streamable HTTP) exposing 18 tools across
+for LLM agents. MCP server (Streamable HTTP) exposing 21 tools across
 read/write/admin scopes.
 
 Distinct from existing entries: bitemporal (valid-time + transaction-
@@ -202,7 +202,7 @@ URL: https://mcpservers.org/submit
 Section: **Claude Code & Model Context Protocol (MCP)**.
 
 ```
-- [inite-brain-service](https://github.com/inite-ai/inite-brain-service) — open-source memory layer for Claude (and any other MCP client). Bitemporal knowledge graph, 18 tools, three memory tiers (facts/episodes/procedural), conflict resolution, GDPR forget. AGPL-3.0.
+- [inite-brain-service](https://github.com/inite-ai/inite-brain-service) — open-source memory layer for Claude (and any other MCP client). Bitemporal knowledge graph, 21 tools, three memory tiers (facts/episodes/procedural), conflict resolution, GDPR forget. AGPL-3.0.
 ```
 
 Note: 165+ open PRs on this repo as of 2026-06 — maintainer is slow. File and forget.

--- a/docs/locomo.md
+++ b/docs/locomo.md
@@ -209,7 +209,7 @@ OPENAI_API_KEY=… ANTHROPIC_API_KEY=… BRAIN_API_KEY=brain_… \
 
 The agent spawns one MCP transport for the lifetime of the run; the
 runner closes it at the end. Claude sees the full read-baseline tool
-surface (10 tools at brain:read; 13 with brain:write); pick a
+surface (15 tools at brain:read; 20 with brain:write); pick a
 read-only key for the QA leg if you want to be sure no fact write
 leaks back into the graph mid-run.
 

--- a/docs/roadmap/mcp-and-memory.md
+++ b/docs/roadmap/mcp-and-memory.md
@@ -1,5 +1,15 @@
 # MCP surface + memory — next session brief
 
+> **STATUS (2026-06-25): ~95% SHIPPED — historical brief, not a TODO.**
+> Phases 1–4 are all landed: `memory_diff`, `summarize_entity`,
+> `get_competing_facts`, `detect_contradiction`, procedural memory, MCP
+> resources (`brain://entity/...`), sampling, the new skills, and the
+> ClaudeMcpAgent. The live MCP surface is **21 tools** (15 read / 20 with
+> write / 21 with admin) + 2 resources. The only genuinely-open items are:
+> the full paid LoCoMo run + published numbers (Phase 5.2), optional
+> BERTScore (5.3), and MCP resource *subscribe* (4.2, deferred to v2). Read
+> the rest as a record of what was built, not work to redo.
+
 Self-contained brief для следующей сессии. Open this file first.
 
 ## Кто это читает

--- a/skills/brain-mcp-setup/SKILL.md
+++ b/skills/brain-mcp-setup/SKILL.md
@@ -159,12 +159,12 @@ Expected: a tool list whose count depends on the key's scopes (see matrix below)
 
 | Scope | Tools unlocked |
 | --- | --- |
-| `brain:read` (always) | `search_knowledge`, `search_multi_hop`, `synthesize`, `memory_diff`, `get_entity_profile`, `get_entity_timeline`, `summarize_entity`, `get_competing_facts`, `detect_contradiction`, `find_related_entities` (10 tools) |
-| `brain:write` | + `record_fact`, `link_entities`, `retract_fact` (3 more = 13 total) |
-| `brain:admin` | + `forget_entity` (1 more = 14 total) |
+| `brain:read` (always) | `search_knowledge`, `search_multi_hop`, `synthesize`, `memory_diff`, `get_entity_profile`, `get_entity_timeline`, `summarize_entity`, `get_competing_facts`, `detect_contradiction`, `find_related_entities`, `match_procedure`, `list_procedures`, `search_communities`, `list_communities`, `find_entity_communities` (15 tools) |
+| `brain:write` | + `record_fact`, `link_entities`, `retract_fact`, `record_procedure`, `retire_procedure` (5 more = 20 total) |
+| `brain:admin` | + `forget_entity` (1 more = 21 total) |
 | `brain:read_pii` | unlocks `email` / `phone` / `dob` / `address` object values in read results (predicate stays visible without it; no new tool surface) |
 
-A key with only `brain:read` will see 10 tools, not 14 — that's the security invariant, not a bug. Tell the user explicitly when their key is read-only so they don't waste time looking for `record_fact` / `forget_entity`.
+A key with only `brain:read` will see 15 tools, not 21 — that's the security invariant, not a bug. Tell the user explicitly when their key is read-only so they don't waste time looking for `record_fact` / `forget_entity`.
 
 The detailed taxonomy (which tool for which question) lives in the workflow skills — `brain-search`, `brain-recall`, `brain-bitemporal`, `brain-write`, `brain-conflict`.
 
@@ -188,4 +188,4 @@ Once connected, point the user at the workflow skills:
 - `brain-write` — recording, linking, and retracting (with `detect_contradiction` preflight)
 - `brain-conflict` — adjudicating COMPETING facts and 3+ multi-way disagreements
 
-These describe how to actually *use* the 14 tools brain exposes, not just how to wire them in.
+These describe how to actually *use* the 21 tools brain exposes, not just how to wire them in.


### PR DESCRIPTION
Tool count drifted across 5 docs (18/14/13/10) vs the actual **21** registered tools (15 read / 20 +write / 21 +admin, + 2 resources). Fixes distribution.md, locomo.md, connector README, and the brain-mcp-setup scope matrix (which omitted the procedural + community read tools — agents couldn't discover them). Adds a STATUS banner to the stale mcp-and-memory roadmap (~95% shipped, was read as a TODO). Docs/skills only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)