### PR TITLE
refactor(entities): extract pure read-path helpers + unit-test them

### DIFF
--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -4,9 +4,14 @@ import { createHmac } from 'node:crypto';
 import { SurrealService, dbCreate } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { ForgetEntityDto } from './dto/forget.dto';
-import { policyFor, PREDICATE_POLICIES } from '../ingest/conflict-resolver';
 import { BrainScope } from '../auth/api-key.types';
 import { EmbedderService } from '../ai/embedder.service';
+import {
+  normalizeEntityId,
+  factVisibleToScopes,
+  blockedPredicates,
+  activeFactWhere,
+} from './entity-read.helpers';
 
 // Centralised SELECT-clause field lists. Adding a new field to a table
 // touches one place here, not every read site. The strings below are
@@ -83,7 +88,7 @@ export class EntitiesService {
     asOfRaw: string | undefined,
     scopes: BrainScope[],
   ): Promise<EntityProfile> {
-    const ref = this.normalizeEntityId(entityIdRaw);
+    const ref = normalizeEntityId(entityIdRaw);
     const asOf = asOfRaw ? new Date(asOfRaw) : null;
 
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
@@ -103,19 +108,12 @@ export class EntitiesService {
       // in JS. With a long-lived entity (~thousands of facts), this
       // collapses bytes-scanned by an order of magnitude for the
       // common case `asOf = now`.
-      const baseClauses = [`entityId = type::record('knowledge_entity', $rid)`];
-      const params: Record<string, unknown> = { rid: ref.id };
-      if (asOf) {
-        baseClauses.push(
-          `recordedAt <= $asOf`,
-          `(retractedAt IS NONE OR retractedAt > $asOf)`,
-          `validFrom <= $asOf`,
-          `(validUntil IS NONE OR validUntil > $asOf)`,
-        );
-        params.asOf = asOf;
-      } else {
-        baseClauses.push(`retractedAt IS NONE`);
-      }
+      const { clauses: asOfClauses, params: asOfParams } = activeFactWhere(asOf);
+      const baseClauses = [
+        `entityId = type::record('knowledge_entity', $rid)`,
+        ...asOfClauses,
+      ];
+      const params: Record<string, unknown> = { rid: ref.id, ...asOfParams };
       const [factRows] = await db.query<any[][]>(
         `SELECT ${FACT_PROFILE_FIELDS}
          FROM knowledge_fact
@@ -126,13 +124,9 @@ export class EntitiesService {
       );
       // PII scope gate — keep this in JS (per-row policy lookup).
       // Move to DB-side PERMISSIONS once we switch to JWT-per-conn.
-      const facts = ((factRows as any[]) ?? []).filter((f) => {
-        const policy = policyFor(f.predicate);
-        if (policy.requiresScope && !scopes.includes(policy.requiresScope)) {
-          return false;
-        }
-        return true;
-      });
+      const facts = ((factRows as any[]) ?? []).filter((f) =>
+        factVisibleToScopes(f.predicate, scopes),
+      );
 
       return {
         entityId: String(entity.id),
@@ -177,31 +171,20 @@ export class EntitiesService {
     asOfRaw: string | undefined,
     scopes: BrainScope[],
   ): Promise<{ maxRecordedAt: string | null; maxValidFrom: string | null }> {
-    const ref = this.normalizeEntityId(entityIdRaw);
+    const ref = normalizeEntityId(entityIdRaw);
     const asOf = asOfRaw ? new Date(asOfRaw) : null;
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
+      const { clauses: asOfClauses, params: asOfParams } = activeFactWhere(asOf);
       const baseClauses = [
         `entityId = type::record('knowledge_entity', $rid)`,
+        ...asOfClauses,
       ];
-      const params: Record<string, unknown> = { rid: ref.id };
-      if (asOf) {
-        baseClauses.push(
-          `recordedAt <= $asOf`,
-          `(retractedAt IS NONE OR retractedAt > $asOf)`,
-          `validFrom <= $asOf`,
-          `(validUntil IS NONE OR validUntil > $asOf)`,
-        );
-        params.asOf = asOf;
-      } else {
-        baseClauses.push(`retractedAt IS NONE`);
-      }
+      const params: Record<string, unknown> = { rid: ref.id, ...asOfParams };
       // Mirror getProfile's PII gate: a fact the caller can't see must
       // not move the watermark, else a low-scope caller's cache gets
       // invalidated exactly when a restricted fact lands (a timing oracle
       // + needless rebuilds). DB-side here since we don't fetch the rows.
-      const blocked = Object.entries(PREDICATE_POLICIES)
-        .filter(([, p]) => p.requiresScope && !scopes.includes(p.requiresScope))
-        .map(([predicate]) => predicate);
+      const blocked = blockedPredicates(scopes);
       if (blocked.length) {
         baseClauses.push(`predicate NOT IN $blocked`);
         params.blocked = blocked;
@@ -238,7 +221,7 @@ export class EntitiesService {
     untilRaw: string | undefined,
     scopes: BrainScope[],
   ): Promise<{ entityId: string; events: any[] }> {
-    const ref = this.normalizeEntityId(entityIdRaw);
+    const ref = normalizeEntityId(entityIdRaw);
     const since = sinceRaw ? new Date(sinceRaw) : null;
     const until = untilRaw ? new Date(untilRaw) : null;
 
@@ -258,13 +241,9 @@ export class EntitiesService {
          ORDER BY recordedAt ASC`,
         params,
       );
-      const rows = ((factRows as any[]) ?? []).filter((f) => {
-        const policy = policyFor(f.predicate);
-        if (policy.requiresScope && !scopes.includes(policy.requiresScope)) {
-          return false;
-        }
-        return true;
-      });
+      const rows = ((factRows as any[]) ?? []).filter((f) =>
+        factVisibleToScopes(f.predicate, scopes),
+      );
 
       const events: any[] = [];
       for (const f of rows) {
@@ -301,7 +280,7 @@ export class EntitiesService {
     scopes: BrainScope[] = [],
     asOf?: string,
   ): Promise<{ entityId: string; edges: any[] }> {
-    const ref = this.normalizeEntityId(entityIdRaw);
+    const ref = normalizeEntityId(entityIdRaw);
 
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       // Native graph traversal via SurrealDB's `->` / `<-` operators
@@ -376,17 +355,14 @@ export class EntitiesService {
             : undefined,
           direction: 'inbound' as const,
         })),
-      ].filter((edge) => {
+      ].filter((edge) =>
         // Defense-in-depth: the DB-level PERMISSIONS fence (migration 0005)
         // gates knowledge_fact.object, but knowledge_edge has no such fence,
         // so a scoped caller could otherwise read a PII-classed relation
-        // (edge.kind maps to a predicate). Mirror the timeline policyFor
-        // filter: drop edges whose kind requires a scope the caller lacks.
-        const policy = policyFor(edge.kind);
-        return (
-          !policy.requiresScope || scopes.includes(policy.requiresScope)
-        );
-      });
+        // (edge.kind maps to a predicate). Mirror the timeline scope gate:
+        // drop edges whose kind requires a scope the caller lacks.
+        factVisibleToScopes(edge.kind, scopes),
+      );
       return { entityId: ref.full, edges };
     });
   }
@@ -397,7 +373,7 @@ export class EntitiesService {
     dto: ForgetEntityDto,
     actorKeyHash?: string,
   ): Promise<ForgetResult> {
-    const ref = this.normalizeEntityId(entityIdRaw);
+    const ref = normalizeEntityId(entityIdRaw);
 
     const result = await this.surreal.withCompany(companyId, async (db) => {
       // Verify exists
@@ -569,15 +545,4 @@ export class EntitiesService {
 
     return result;
   }
-
-  private normalizeEntityId(raw: string): { id: string; full: string } {
-    const id = raw.startsWith('knowledge_entity:')
-      ? raw.slice('knowledge_entity:'.length)
-      : raw;
-    return { id, full: `knowledge_entity:${id}` };
-  }
 }
-
-// Keep import-side alive: re-export to avoid tree-shake stripping the policies
-// when search/forget paths are the only call sites.
-export { PREDICATE_POLICIES };

--- a/src/entities/entity-read.helpers.ts
+++ b/src/entities/entity-read.helpers.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure read-path helpers extracted from EntitiesService.
+ *
+ * These functions carry no DB handle and no I/O — they are the
+ * deterministic logic that used to live inline inside the
+ * `withScopedCompany` closures (entity-id normalisation, the PII scope
+ * gate, and the bitemporal "active fact" WHERE-clause builder). Pulling
+ * them out makes the rules unit-testable without a live SurrealDB, and
+ * removes the copy-paste of the bitemporal clause set between
+ * `getProfile` and `freshnessWatermark`.
+ */
+import { policyFor, PREDICATE_POLICIES } from '../ingest/conflict-resolver';
+import { BrainScope } from '../auth/api-key.types';
+
+/**
+ * Split a raw entity reference into the bare record id and the full
+ * `table:id` form. Accepts either `knowledge_entity:foo` or bare `foo`
+ * and is idempotent — passing an already-prefixed id does not double it.
+ */
+export function normalizeEntityId(raw: string): { id: string; full: string } {
+  const id = raw.startsWith('knowledge_entity:')
+    ? raw.slice('knowledge_entity:'.length)
+    : raw;
+  return { id, full: `knowledge_entity:${id}` };
+}
+
+/**
+ * PII scope gate for a single predicate. A fact/edge whose predicate is
+ * classed `requiresScope` is visible only to callers holding that scope.
+ * Mirrors the DB-level PERMISSIONS fence (migration 0005) for the JS read
+ * paths (profile/timeline rows, edge `kind`) where rows are materialised
+ * before filtering.
+ */
+export function factVisibleToScopes(
+  predicate: string,
+  scopes: BrainScope[],
+): boolean {
+  const policy = policyFor(predicate);
+  return !policy.requiresScope || scopes.includes(policy.requiresScope);
+}
+
+/**
+ * DB-side equivalent of {@link factVisibleToScopes} for the watermark
+ * probe, which never materialises rows: the set of known predicates the
+ * caller may NOT see, pushed into a `predicate NOT IN $blocked` clause.
+ * Derived from the same policy table so the two gates stay in lockstep —
+ * a predicate is blocked here iff it is invisible there.
+ */
+export function blockedPredicates(scopes: BrainScope[]): string[] {
+  return Object.entries(PREDICATE_POLICIES)
+    .filter(([, p]) => p.requiresScope && !scopes.includes(p.requiresScope))
+    .map(([predicate]) => predicate);
+}
+
+/**
+ * Bitemporal "active fact" predicates for a `knowledge_fact` read.
+ *
+ * Without `asOf`, "active" means believed-now: `retractedAt IS NONE`.
+ * With `asOf`, it is the four-axis cutoff — recorded by then, not yet
+ * retracted as of then, and valid across the event-time window — so the
+ * composite (entityId, status, recordedAt) index does the work instead of
+ * pulling rows just to drop them in JS.
+ *
+ * Returns only the bitemporal clauses + their params; callers prepend the
+ * `entityId = …` clause and its `$rid` param.
+ */
+export function activeFactWhere(asOf: Date | null): {
+  clauses: string[];
+  params: Record<string, unknown>;
+} {
+  if (asOf) {
+    return {
+      clauses: [
+        `recordedAt <= $asOf`,
+        `(retractedAt IS NONE OR retractedAt > $asOf)`,
+        `validFrom <= $asOf`,
+        `(validUntil IS NONE OR validUntil > $asOf)`,
+      ],
+      params: { asOf },
+    };
+  }
+  return { clauses: [`retractedAt IS NONE`], params: {} };
+}

--- a/test/entity-read-helpers.unit-spec.ts
+++ b/test/entity-read-helpers.unit-spec.ts
@@ -1,0 +1,108 @@
+import {
+  normalizeEntityId,
+  factVisibleToScopes,
+  blockedPredicates,
+  activeFactWhere,
+} from '../src/entities/entity-read.helpers';
+import { PREDICATE_POLICIES } from '../src/ingest/conflict-resolver';
+import { BrainScope } from '../src/auth/api-key.types';
+
+const PII: BrainScope = 'brain:read_pii';
+
+describe('normalizeEntityId', () => {
+  it('strips a knowledge_entity: prefix into bare id + full form', () => {
+    expect(normalizeEntityId('knowledge_entity:foo')).toEqual({
+      id: 'foo',
+      full: 'knowledge_entity:foo',
+    });
+  });
+
+  it('promotes a bare id to the full table:id form', () => {
+    expect(normalizeEntityId('foo')).toEqual({
+      id: 'foo',
+      full: 'knowledge_entity:foo',
+    });
+  });
+
+  it('is idempotent — re-normalising never double-prefixes', () => {
+    const once = normalizeEntityId('abc123');
+    const twice = normalizeEntityId(once.full);
+    expect(twice).toEqual(once);
+  });
+
+  it('only strips the leading prefix, not an embedded colon', () => {
+    expect(normalizeEntityId('knowledge_entity:a:b')).toEqual({
+      id: 'a:b',
+      full: 'knowledge_entity:a:b',
+    });
+  });
+});
+
+describe('factVisibleToScopes', () => {
+  // 'dob' / 'address' are seeded as requiresScope: 'brain:read_pii';
+  // 'name' / 'said' are non-PII; an unknown predicate falls to DEFAULT_POLICY.
+  it('hides a PII-classed predicate from a caller without the scope', () => {
+    expect(factVisibleToScopes('dob', [])).toBe(false);
+    expect(factVisibleToScopes('address', [])).toBe(false);
+  });
+
+  it('reveals a PII-classed predicate to a caller holding the scope', () => {
+    expect(factVisibleToScopes('dob', [PII])).toBe(true);
+    expect(factVisibleToScopes('address', [PII])).toBe(true);
+  });
+
+  it('always reveals a non-PII predicate regardless of scopes', () => {
+    expect(factVisibleToScopes('name', [])).toBe(true);
+    expect(factVisibleToScopes('said', [])).toBe(true);
+  });
+
+  it('reveals an unknown predicate (DEFAULT_POLICY has no required scope)', () => {
+    expect(factVisibleToScopes('zzz_not_a_real_predicate', [])).toBe(true);
+  });
+});
+
+describe('blockedPredicates', () => {
+  it('lists the PII predicates when the caller lacks the scope', () => {
+    const blocked = blockedPredicates([]);
+    expect(blocked).toContain('dob');
+    expect(blocked).toContain('address');
+  });
+
+  it('blocks nothing when the caller holds the PII scope', () => {
+    expect(blockedPredicates([PII])).toEqual([]);
+  });
+
+  it('stays in lockstep with factVisibleToScopes for every known predicate', () => {
+    // A predicate is in the DB-side blocklist iff the JS-side row filter
+    // would hide it — the two gates must never disagree, or a low-scope
+    // caller could move a watermark on a fact it cannot read.
+    for (const scopes of [[] as BrainScope[], [PII]]) {
+      const blocked = new Set(blockedPredicates(scopes));
+      for (const predicate of Object.keys(PREDICATE_POLICIES)) {
+        expect(blocked.has(predicate)).toBe(
+          !factVisibleToScopes(predicate, scopes),
+        );
+      }
+    }
+  });
+});
+
+describe('activeFactWhere', () => {
+  it('without asOf, gates on believed-now (retractedAt IS NONE) and binds no params', () => {
+    const { clauses, params } = activeFactWhere(null);
+    expect(clauses).toEqual(['retractedAt IS NONE']);
+    expect(params).toEqual({});
+  });
+
+  it('with asOf, emits the four-axis bitemporal cutoff and binds $asOf', () => {
+    const asOf = new Date('2026-01-02T03:04:05.000Z');
+    const { clauses, params } = activeFactWhere(asOf);
+    expect(clauses).toEqual([
+      'recordedAt <= $asOf',
+      '(retractedAt IS NONE OR retractedAt > $asOf)',
+      'validFrom <= $asOf',
+      '(validUntil IS NONE OR validUntil > $asOf)',
+    ]);
+    expect(params).toEqual({ asOf });
+  });
+});


### PR DESCRIPTION
## What

First of the god-service decomposition PRs from `docs/roadmap/audit-followup-2026-06.md` (item 1). `EntitiesService` had **no unit spec** — only slow live-DB e2e — and copy-pasted read logic across its closures.

Pulls the deterministic, DB-free logic into `src/entities/entity-read.helpers.ts`:

- **`normalizeEntityId`** — entity-ref splitting (was a private method)
- **`factVisibleToScopes`** — the PII scope gate (was inlined 3×: profile / timeline / edge filter)
- **`blockedPredicates`** — the watermark's DB-side equivalent of that same gate
- **`activeFactWhere`** — the bitemporal "active fact" `WHERE` builder (was copy-pasted between `getProfile` and `freshnessWatermark`)

The service now delegates to the helpers — pure refactor, no behaviour change. Also drops a dead `PREDICATE_POLICIES` re-export (no consumers; the tree-shake rationale is moot for a Nest backend).

## Tests

New `test/entity-read-helpers.unit-spec.ts` — 13 assertions, including a **lockstep invariant**: a predicate is in `blockedPredicates` iff `factVisibleToScopes` would hide it, for every known predicate under both scope sets. That guards the watermark timing-oracle the two gates exist to prevent.

## Acceptance

- `pnpm exec tsc --noEmit` clean · `pnpm lint` clean
- `pnpm test` green — **655** unit (was 642 + 13 new)
- `pnpm test:e2e` green — **128** e2e (behaviour-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)