### PR TITLE
refactor(db): extract surreal error-classification + retry into a pure module

### DIFF
--- a/src/db/surreal-retry.ts
+++ b/src/db/surreal-retry.ts
@@ -1,0 +1,141 @@
+/**
+ * SurrealDB error-classification + retry helpers.
+ *
+ * Pure, driver-message-matching logic pulled out of the SurrealService
+ * god-file so it can be unit-tested without a live datastore. The runtime
+ * source of truth for "is this error retriable" lives here; the service
+ * and its transaction runner delegate to these functions.
+ */
+
+/**
+ * Detect SurrealDB unique-index violation. The driver surfaces these
+ * as plain Errors with the index name embedded in the message; we
+ * match on the marker text rather than coupling to a specific class.
+ */
+export function isUniqueViolation(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const m = err.message;
+  return (
+    m.includes('already contains') || // "already contains a record with id ..."
+    m.includes('Database index') || // "Database index `xxx` already contains ..."
+    m.includes('IndexExists') ||
+    m.includes('already exists') || // "Database record `xxx:yyy` already exists" — explicit-id CREATE collision
+    m.includes('Found a record') // SurrealDB v2 wording variant for the same condition
+  );
+}
+
+/**
+ * Detect SurrealDB optimistic-concurrency read conflict — narrow match.
+ * Only the specific datastore-level abort messages are retriable; the
+ * broader "failed transaction" envelope wraps non-retriable failures
+ * too (parse errors, type assertions, permission denials), and looping
+ * those burns the retry budget for nothing.
+ *
+ * v2.2.x rocksdb backend surfaces commit-time OCC aborts with a new,
+ * more explicit wording: "Failed to commit transaction due to a read
+ * or write conflict. This transaction can be retried". Under
+ * concurrent CREATEs against a UNIQUE-indexed key, the FIRST few
+ * attempts in a fanout often abort here at commit time before the
+ * uniqueness check fires (so they never present as
+ * `isUniqueViolation`). Both patterns must be caught for the
+ * retry loop to converge.
+ */
+export function isReadConflict(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const m = err.message;
+  return (
+    m.includes('Transaction read conflict') ||
+    m.includes('wrote at the same key') ||
+    m.includes('read or write conflict') ||
+    m.includes('This transaction can be retried') ||
+    // SurrealDB 3.x single-statement conflict wording:
+    // "Transaction conflict: Write conflict, retry the transaction. This
+    //  transaction can be retried" (already matched by the line above, but
+    //  match the distinctive prefix too in case the trailing sentence drops).
+    m.includes('Transaction conflict') ||
+    m.includes('Write conflict')
+  );
+}
+
+/**
+ * Enrich a multi-statement BEGIN/COMMIT batch rejection so the retry
+ * detector can see it.
+ *
+ * SurrealDB v2.2.8 surfaces aborted BEGIN/COMMIT batches as a single
+ * top-level rejection with the bare wrapper "The query was not executed
+ * due to a failed transaction" — the per-statement cause (e.g. "Failed to
+ * commit transaction due to a read or write conflict. This transaction can
+ * be retried") is dropped by the time the JS driver builds the error.
+ * Without enrichment, `isReadConflict(err)` sees only the wrapper and the
+ * surrounding retry loop won't fire.
+ *
+ * Mitigation: any `failed transaction` wrapper emerging from a
+ * multi-statement BEGIN/COMMIT batch IS, by construction, a commit-level
+ * abort — for our usage (atomic upsert), commit aborts under contention
+ * are exactly the retriable case. Re-throw with the canonical
+ * read-or-write-conflict suffix so the retry detector picks it up. Parse
+ * errors and permission denials don't surface via this wrapper (they fail
+ * at parse/auth before the tx is even entered), so the false-positive risk
+ * is bounded.
+ *
+ * Non-wrapper errors are returned unchanged so callers can `throw
+ * enrichTransactionError(err)` unconditionally.
+ */
+export function enrichTransactionError(err: unknown): unknown {
+  if (err instanceof Error && err.message.includes('failed transaction')) {
+    const cause = (err as { cause?: { message?: string } }).cause;
+    const suffix =
+      cause?.message ?? 'read or write conflict; this transaction can be retried';
+    const enriched = new Error(`${err.message}: ${suffix}`);
+    (enriched as Error & { cause?: unknown }).cause = err;
+    return enriched;
+  }
+  return err;
+}
+
+/** Real wall-clock backoff used in production. Swappable in tests. */
+const defaultBackoffSleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Retry a body on transient concurrency failures: unique-index
+ * violations OR optimistic-concurrency read conflicts. Both arise
+ * from the same SELECT-then-CREATE race window — under contention,
+ * one tx commits and others either (a) see a duplicate index entry
+ * (unique violation) or (b) have their read-set invalidated (read
+ * conflict). Both are retriable: re-run the closure, which on its
+ * second SELECT will see the racing caller's commit and either
+ * short-circuit (read path) or write fresh state (rare).
+ *
+ * We use exponential backoff with jitter so a herd of FANOUT
+ * retries doesn't synchronise into a second collision wave. The
+ * `sleep` injection point keeps the schedule real in production while
+ * letting unit tests run the loop without wall-clock delay.
+ */
+export async function retryOnUniqueViolation<T>(
+  fn: () => Promise<T>,
+  attempts = 7,
+  sleep: (ms: number) => Promise<void> = defaultBackoffSleep,
+): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (!isUniqueViolation(err) && !isReadConflict(err)) throw err;
+      lastErr = err;
+      if (i < attempts - 1) {
+        // Exponential backoff with full jitter: 10..20, 20..40, 40..80,
+        // 80..160, 160..320, 320..640 ms — total worst case ~1.3s.
+        // Sized for FANOUT-up-to-pool-size contention on the rocksdb
+        // backend: that's the regime where retries actually help (the
+        // racing committer's row appears within hundreds of ms).
+        // Beyond that the test path needs to back off load itself.
+        const baseMs = 10 * Math.pow(2, i);
+        const jitter = Math.random() * baseMs;
+        await sleep(baseMs + jitter);
+      }
+    }
+  }
+  throw lastErr;
+}

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -3,6 +3,16 @@ import { ConfigService } from '@nestjs/config';
 import { Surreal } from 'surrealdb';
 import { join } from 'node:path';
 import { SchemaMigrator } from './migrator.service';
+import { enrichTransactionError } from './surreal-retry';
+
+// Re-export the error-classification + retry helpers from their dedicated
+// module so existing `from './surreal.service'` import sites keep working.
+export {
+  isUniqueViolation,
+  isReadConflict,
+  enrichTransactionError,
+  retryOnUniqueViolation,
+} from './surreal-retry';
 
 /**
  * SurrealService — pooled connections with per-tenant database routing.
@@ -702,35 +712,15 @@ export async function runTransaction<T>(
     .map((s) => s.replace(/;\s*$/, ''))
     .join(';\n') + ';';
 
-  // SurrealDB v2.2.8 surfaces aborted BEGIN/COMMIT batches as a
-  // single top-level rejection with the bare wrapper "The query was
-  // not executed due to a failed transaction" — the per-statement
-  // cause (e.g. "Failed to commit transaction due to a read or
-  // write conflict. This transaction can be retried") is dropped
-  // by the time the JS driver builds the error. Without enrichment,
-  // `isReadConflict(err)` sees only the wrapper and the surrounding
-  // retry loop won't fire.
-  //
-  // Mitigation: any `failed transaction` wrapper emerging from a
-  // multi-statement BEGIN/COMMIT batch IS, by construction, a
-  // commit-level abort — for our usage (atomic upsert), commit
-  // aborts under contention are exactly the retriable case. Re-throw
-  // with the canonical read-or-write-conflict suffix so the retry
-  // detector picks it up. Parse errors and permission denials don't
-  // surface via this wrapper (they fail at parse/auth before the
-  // tx is even entered), so the false-positive risk is bounded.
+  // Aborted BEGIN/COMMIT batches surface as a bare "failed transaction"
+  // wrapper that hides the retriable per-statement cause; enrich it so the
+  // surrounding retry loop can classify it (see enrichTransactionError).
+  // Non-wrapper errors pass through unchanged.
   let result: unknown[];
   try {
     result = await db.query<unknown[]>(sql, vars);
   } catch (err) {
-    if (err instanceof Error && err.message.includes('failed transaction')) {
-      const cause = (err as { cause?: { message?: string } }).cause;
-      const suffix = cause?.message ?? 'read or write conflict; this transaction can be retried';
-      const enriched = new Error(`${err.message}: ${suffix}`);
-      (enriched as Error & { cause?: unknown }).cause = err;
-      throw enriched;
-    }
-    throw err;
+    throw enrichTransactionError(err);
   }
   const arr = result as unknown[];
   // SurrealDB 3.x emits one result slot per top-level statement INCLUDING the
@@ -743,96 +733,6 @@ export async function runTransaction<T>(
   // RETURN it wants, so the meaningful value is the slot immediately before
   // COMMIT.
   return arr[arr.length - 2] as T;
-}
-
-/**
- * Detect SurrealDB unique-index violation. The driver surfaces these
- * as plain Errors with the index name embedded in the message; we
- * match on the marker text rather than coupling to a specific class.
- */
-export function isUniqueViolation(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  const m = err.message;
-  return (
-    m.includes('already contains') ||  // "already contains a record with id ..."
-    m.includes('Database index') ||    // "Database index `xxx` already contains ..."
-    m.includes('IndexExists') ||
-    m.includes('already exists') ||    // "Database record `xxx:yyy` already exists" — explicit-id CREATE collision
-    m.includes('Found a record')       // SurrealDB v2 wording variant for the same condition
-  );
-}
-
-/**
- * Detect SurrealDB optimistic-concurrency read conflict — narrow match.
- * Only the specific datastore-level abort messages are retriable; the
- * broader "failed transaction" envelope wraps non-retriable failures
- * too (parse errors, type assertions, permission denials), and looping
- * those burns the retry budget for nothing.
- *
- * v2.2.x rocksdb backend surfaces commit-time OCC aborts with a new,
- * more explicit wording: "Failed to commit transaction due to a read
- * or write conflict. This transaction can be retried". Under
- * concurrent CREATEs against a UNIQUE-indexed key, the FIRST few
- * attempts in a fanout often abort here at commit time before the
- * uniqueness check fires (so they never present as
- * `isUniqueViolation`). Both patterns must be caught for the
- * retry loop to converge.
- */
-export function isReadConflict(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  const m = err.message;
-  return (
-    m.includes('Transaction read conflict') ||
-    m.includes('wrote at the same key') ||
-    m.includes('read or write conflict') ||
-    m.includes('This transaction can be retried') ||
-    // SurrealDB 3.x single-statement conflict wording:
-    // "Transaction conflict: Write conflict, retry the transaction. This
-    //  transaction can be retried" (already matched by the line above, but
-    //  match the distinctive prefix too in case the trailing sentence drops).
-    m.includes('Transaction conflict') ||
-    m.includes('Write conflict')
-  );
-}
-
-/**
- * Retry a body on transient concurrency failures: unique-index
- * violations OR optimistic-concurrency read conflicts. Both arise
- * from the same SELECT-then-CREATE race window — under contention,
- * one tx commits and others either (a) see a duplicate index entry
- * (unique violation) or (b) have their read-set invalidated (read
- * conflict). Both are retriable: re-run the closure, which on its
- * second SELECT will see the racing caller's commit and either
- * short-circuit (read path) or write fresh state (rare).
- *
- * We use exponential backoff with jitter so a herd of FANOUT
- * retries doesn't synchronise into a second collision wave.
- */
-export async function retryOnUniqueViolation<T>(
-  fn: () => Promise<T>,
-  attempts = 7,
-): Promise<T> {
-  let lastErr: unknown;
-  for (let i = 0; i < attempts; i++) {
-    try {
-      return await fn();
-    } catch (err) {
-      if (!isUniqueViolation(err) && !isReadConflict(err)) throw err;
-      lastErr = err;
-      if (i < attempts - 1) {
-        // Exponential backoff with full jitter: 10..20, 20..40, 40..80,
-        // 80..160, 160..320, 320..640 ms — total worst case ~1.3s.
-        // Sized for FANOUT-up-to-pool-size contention on the rocksdb
-        // backend: that's the regime where retries actually help (the
-        // racing committer's row appears within hundreds of ms).
-        // Beyond that the test path needs to back off load itself.
-        const baseMs = 10 * Math.pow(2, i);
-        const jitter = Math.random() * baseMs;
-        await new Promise((r) => setTimeout(r, baseMs + jitter));
-      }
-    }
-  }
-  throw lastErr;
 }
 
 /**

--- a/test/surreal-retry.unit-spec.ts
+++ b/test/surreal-retry.unit-spec.ts
@@ -1,0 +1,165 @@
+import {
+  isUniqueViolation,
+  isReadConflict,
+  enrichTransactionError,
+  retryOnUniqueViolation,
+} from '../src/db/surreal-retry';
+
+const noSleep = (): Promise<void> => Promise.resolve();
+
+describe('isUniqueViolation', () => {
+  it.each([
+    'Database index `idx` already contains a record with id foo',
+    'Database index `x` already contains 1',
+    'IndexExists: boom',
+    'Database record `entity:1` already exists',
+    'Found a record with the same value',
+  ])('matches the unique-violation wording: %s', (msg) => {
+    expect(isUniqueViolation(new Error(msg))).toBe(true);
+  });
+
+  it('does not match an unrelated error', () => {
+    expect(isUniqueViolation(new Error('parse error: unexpected token'))).toBe(
+      false,
+    );
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(isUniqueViolation('already exists')).toBe(false);
+    expect(isUniqueViolation(null)).toBe(false);
+    expect(isUniqueViolation(undefined)).toBe(false);
+  });
+});
+
+describe('isReadConflict', () => {
+  it.each([
+    'Transaction read conflict on key',
+    'two writers wrote at the same key',
+    'Failed to commit transaction due to a read or write conflict',
+    'This transaction can be retried',
+    'Transaction conflict: Write conflict, retry the transaction',
+    'Write conflict',
+  ])('matches the read/write-conflict wording: %s', (msg) => {
+    expect(isReadConflict(new Error(msg))).toBe(true);
+  });
+
+  it('does not match a permission denial or parse error', () => {
+    expect(isReadConflict(new Error('IAM error: permission denied'))).toBe(
+      false,
+    );
+    expect(isReadConflict(new Error('parse error near COMMIT'))).toBe(false);
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(isReadConflict({ message: 'Write conflict' })).toBe(false);
+  });
+});
+
+describe('enrichTransactionError', () => {
+  it('appends the cause message to a "failed transaction" wrapper so it becomes retriable', () => {
+    const wrapper = new Error(
+      'The query was not executed due to a failed transaction',
+    );
+    (wrapper as Error & { cause?: unknown }).cause = new Error(
+      'Failed to commit transaction due to a read or write conflict',
+    );
+    const enriched = enrichTransactionError(wrapper) as Error;
+    expect(enriched).not.toBe(wrapper);
+    expect(isReadConflict(enriched)).toBe(true);
+    // original wrapper alone is NOT classifiable — enrichment is what unlocks retry
+    expect(isReadConflict(wrapper)).toBe(false);
+    expect((enriched as Error & { cause?: unknown }).cause).toBe(wrapper);
+  });
+
+  it('falls back to the canonical suffix when no cause is attached', () => {
+    const wrapper = new Error('failed transaction envelope');
+    const enriched = enrichTransactionError(wrapper) as Error;
+    expect(enriched.message).toContain(
+      'read or write conflict; this transaction can be retried',
+    );
+    expect(isReadConflict(enriched)).toBe(true);
+  });
+
+  it('returns non-wrapper errors unchanged (so callers can throw it unconditionally)', () => {
+    const other = new Error('parse error');
+    expect(enrichTransactionError(other)).toBe(other);
+    const notError = { message: 'failed transaction' };
+    expect(enrichTransactionError(notError)).toBe(notError);
+  });
+});
+
+describe('retryOnUniqueViolation', () => {
+  it('returns immediately on success without retrying', async () => {
+    let calls = 0;
+    const out = await retryOnUniqueViolation(
+      async () => {
+        calls++;
+        return 'ok';
+      },
+      7,
+      noSleep,
+    );
+    expect(out).toBe('ok');
+    expect(calls).toBe(1);
+  });
+
+  it('retries on a unique violation, then succeeds', async () => {
+    let calls = 0;
+    const out = await retryOnUniqueViolation(
+      async () => {
+        calls++;
+        if (calls < 3) throw new Error('Database index `x` already contains 1');
+        return calls;
+      },
+      7,
+      noSleep,
+    );
+    expect(out).toBe(3);
+    expect(calls).toBe(3);
+  });
+
+  it('retries on a read conflict, then succeeds', async () => {
+    let calls = 0;
+    const out = await retryOnUniqueViolation(
+      async () => {
+        calls++;
+        if (calls < 2) throw new Error('Write conflict');
+        return 'done';
+      },
+      7,
+      noSleep,
+    );
+    expect(out).toBe('done');
+    expect(calls).toBe(2);
+  });
+
+  it('does NOT retry a non-retriable error — rethrows immediately', async () => {
+    let calls = 0;
+    await expect(
+      retryOnUniqueViolation(
+        async () => {
+          calls++;
+          throw new Error('permission denied');
+        },
+        7,
+        noSleep,
+      ),
+    ).rejects.toThrow('permission denied');
+    expect(calls).toBe(1);
+  });
+
+  it('gives up after exhausting attempts and throws the last error', async () => {
+    let calls = 0;
+    await expect(
+      retryOnUniqueViolation(
+        async () => {
+          calls++;
+          throw new Error(`Write conflict #${calls}`);
+        },
+        3,
+        noSleep,
+      ),
+    ).rejects.toThrow('Write conflict #3');
+    expect(calls).toBe(3);
+  });
+});


### PR DESCRIPTION
## What

Second god-service decomposition PR (item 1 of `docs/roadmap/audit-followup-2026-06.md`). `retryOnUniqueViolation` and the SurrealDB error classifiers had **no unit spec** and sat buried in the 867-line `SurrealService` file.

Pulls the deterministic, datastore-free logic into `src/db/surreal-retry.ts`:

- **`isUniqueViolation` / `isReadConflict`** — driver-message classifiers
- **`enrichTransactionError`** — the "failed transaction" wrapper → canonical read-conflict-suffix logic that was inlined in `runTransaction`'s catch (so `isReadConflict` can classify a commit-level abort). Non-wrapper errors pass through unchanged, so the call site is now just `throw enrichTransactionError(err)`.
- **`retryOnUniqueViolation`** — now takes an injectable `sleep` (3rd optional param, defaults to the real jittered backoff) so the loop is unit-testable without wall-clock delay.

`surreal.service.ts` re-exports all four (`export … from './surreal-retry'`) so every `from './surreal.service'` import site — `migrator.service`, `leader-lease.service`, e2e specs — keeps working unchanged.

## Tests

New `test/surreal-retry.unit-spec.ts` — 23 assertions: every classifier wording (positive + negative + non-Error), the enrichment round-trip (wrapper alone is *not* classifiable; enriched *is*), and the retry contract (success-no-retry / retry-then-succeed / no-retry-on-non-retriable / give-up-after-N).

## Acceptance

- `pnpm exec tsc --noEmit` clean · `pnpm lint` clean
- `pnpm test` green — **665** unit (642 + 23 new)
- `pnpm test:e2e` green — **128** e2e (concurrency + single-active paths exercise the retry loop live; behaviour-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)