### PR TITLE
refactor(ingest): extract pure utils, dedupe sourceTrustFor, DRY HyPE write

### DIFF
--- a/src/ingest/ingest-predictor.service.ts
+++ b/src/ingest/ingest-predictor.service.ts
@@ -9,6 +9,7 @@ import {
   SOURCE_TRUST,
   scoreFact,
 } from './conflict-resolver';
+import { sourceTrustFor } from './ingest-utils';
 
 export type IngestOutcome =
   | 'INSERTED'
@@ -351,20 +352,6 @@ export class IngestPredictionService {
     const n = typeof raw === 'number' ? raw : Number(raw);
     return Number.isFinite(n) ? n : fallback;
   }
-}
-
-function sourceTrustFor(source: {
-  vertical: string;
-  eventId?: string;
-  messageId?: string;
-  recorder?: string;
-}): number {
-  if (source.eventId?.startsWith('billing.')) return SOURCE_TRUST.billing_event;
-  if (source.eventId?.startsWith('incidents.'))
-    return SOURCE_TRUST.incidents_event;
-  if (source.eventId?.startsWith('auth.')) return SOURCE_TRUST.auth_event;
-  if (source.messageId) return SOURCE_TRUST.inbox_extraction;
-  return SOURCE_TRUST.default;
 }
 
 function rowToOpposingFact(row: PriorRow): OpposingFact {

--- a/src/ingest/ingest-utils.ts
+++ b/src/ingest/ingest-utils.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure helpers extracted from IngestService (and de-duplicated against
+ * IngestPredictorService, which carried its own copy of sourceTrustFor).
+ *
+ * Everything here is deterministic and I/O-free — record-id slicing, the
+ * dot-safe externalRef key, the naive PII redactor, the source-trust
+ * heuristic, and the HyPE write-gate predicate — so the rules are
+ * unit-testable without a live SurrealDB or an LLM.
+ */
+import { SOURCE_TRUST } from './conflict-resolver';
+
+/** Strip the `table:` prefix off a SurrealDB record id, leaving the tail. */
+export function idTailOf(rid: string): string {
+  const i = rid.indexOf(':');
+  return i === -1 ? rid : rid.slice(i + 1);
+}
+
+/**
+ * Build a SurrealDB-safe externalRefs key. SurrealQL CONTENT treats dots
+ * inside object keys as nested-path separators, so a key like
+ * "rent.cust_42" silently expands into nested fields and is then dropped
+ * by the schemafull `externalRefs: object` constraint. Replace dots with
+ * a double underscore — the original `vertical.entityId` form is
+ * recoverable but stored unambiguously as a single property.
+ */
+export function externalRefKey(vertical: string, id: string): string {
+  const safe = (s: string) => s.replace(/\./g, '__');
+  return `${safe(vertical)}__${safe(id)}`;
+}
+
+/**
+ * Naive PII redactor — masks emails, phone-like numbers, and 9+ digit runs.
+ * 0.2.0 will replace this with @inite/assistant.piiMask once the package
+ * exposes a server-side import path.
+ */
+export function redactPii(text: string): string {
+  return text
+    .replace(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, '[EMAIL]')
+    .replace(/\+?\d[\d\s().-]{7,}\d/g, '[PHONE]')
+    .replace(/\b\d{9,}\b/g, '[NUM]');
+}
+
+/**
+ * Heuristic source-trust label derived from the source's shape. Billing /
+ * incidents / auth events are most trusted, inbox extractions less so,
+ * everything else falls to the default. Shared by the ingest write path
+ * and the ingest predictor so the two never drift.
+ */
+export function sourceTrustFor(source: {
+  vertical: string;
+  eventId?: string;
+  messageId?: string;
+  recorder?: string;
+}): number {
+  if (source.eventId?.startsWith('billing.')) return SOURCE_TRUST.billing_event;
+  if (source.eventId?.startsWith('incidents.'))
+    return SOURCE_TRUST.incidents_event;
+  if (source.eventId?.startsWith('auth.')) return SOURCE_TRUST.auth_event;
+  if (source.messageId) return SOURCE_TRUST.inbox_extraction;
+  return SOURCE_TRUST.default;
+}
+
+/**
+ * Gate for the HyPE post-INSERT alt-embedding UPDATE. We only generate +
+ * write the hypothetical-question embedding when a fact was actually
+ * INSERTED (not superseded/competed/rejected), HyPE is enabled, and we
+ * have a concrete factId to UPDATE — otherwise we'd burn an LLM call on a
+ * row that won't keep the embedding.
+ */
+export function shouldWriteHypeAltEmbedding(
+  outcome: unknown,
+  hypeEnabled: boolean,
+  factId: string | null,
+): boolean {
+  return factId !== null && hypeEnabled && outcome === 'INSERTED';
+}

--- a/src/ingest/ingest.service.ts
+++ b/src/ingest/ingest.service.ts
@@ -660,9 +660,11 @@ export class IngestService {
     // SurrealDB 3.x the OCC read-conflict that let racing single_active
     // resolves retry-and-supersede no longer fires for the function's
     // SELECT-then-write, so without this two concurrent ingests could
-    // each leave an `active` row. Space-joined — neither an entity record
-    // tail nor a predicate slug contains a space, so the key can't collide.
-    const lockKey = `${p.companyId} ${p.entityId} ${p.predicate}`;
+    // each leave an `active` row. NUL-joined (\x00) — no entity record tail
+    // or predicate slug can contain a NUL, so the composite key can't
+    // collide. (The escape keeps the source clean ASCII while the runtime
+    // separator stays a NUL byte.)
+    const lockKey = `${p.companyId}\x00${p.entityId}\x00${p.predicate}`;
     return this.resolveLock.run(lockKey, () =>
       retryOnUniqueViolation(async () => {
       const [r] = await db.query<[any]>(

--- a/src/ingest/ingest.service.ts
+++ b/src/ingest/ingest.service.ts
@@ -22,7 +22,7 @@ import { EntityResolverService } from './entity-resolver.service';
 import { IngestFactDto } from './dto/ingest-fact.dto';
 import { IngestMentionDto } from './dto/ingest-mention.dto';
 import { IngestLinkDto } from './dto/ingest-link.dto';
-import { ConflictConfig, SOURCE_TRUST } from './conflict-resolver';
+import { ConflictConfig } from './conflict-resolver';
 import { traceSpan, traceArtifact } from '../common/debug-trace';
 import {
   buildConflictExplanation,
@@ -31,6 +31,13 @@ import {
 } from './conflict-explainer';
 import { detectLanguage } from '../ai/locale/language-detector';
 import { KeyedMutex } from '../common/keyed-mutex';
+import {
+  idTailOf,
+  externalRefKey,
+  redactPii,
+  sourceTrustFor,
+  shouldWriteHypeAltEmbedding,
+} from './ingest-utils';
 
 export type IngestOutcome =
   | 'INSERTED'
@@ -127,7 +134,7 @@ export class IngestService {
         );
       }
       const policy = this.predicateRegistry.policyFor(companyId, dto.predicate);
-      const sourceTrust = this.sourceTrustFor(dto.source);
+      const sourceTrust = sourceTrustFor(dto.source);
 
       // 4. Object preservation. Schema stores `object` as string for
       //    indexing; for non-string DTO objects we additionally keep
@@ -190,24 +197,15 @@ export class IngestService {
       // Phase 4.A locale tagging now happens inside fn::resolve_fact via the
       // $lang/$script params above (migration 0039) — no follow-up UPDATE.
 
-      // HyPE: generate a hypothetical-question embedding and write
-      // it onto the new fact. We do this synchronously inside the
-      // ingest flow so the post-condition "fact is searchable with
-      // alt-embedding" holds immediately. When SEARCH_HYPE_ENABLED
-      // is off, hype.generateAltEmbedding returns null and we skip
-      // the UPDATE entirely — no extra latency on ingest.
-      if (factId && this.hype.isEnabled() && outcome === 'INSERTED') {
-        const altEmbedding = await this.hype.generateAltEmbedding(
-          dto.predicate,
-          objectStr,
-        );
-        if (altEmbedding) {
-          await db.query(
-            `UPDATE type::record('knowledge_fact', $tail) SET altEmbedding = $emb`,
-            { tail: idTailOf(factId), emb: altEmbedding },
-          );
-        }
-      }
+      // HyPE: generate a hypothetical-question embedding and write it onto
+      // the new fact (shared with recordExtractedFact via this helper).
+      await this.writeAltEmbeddingIfHype(
+        db,
+        factId,
+        outcome,
+        dto.predicate,
+        objectStr,
+      );
 
       const out: IngestResult = { factId, outcome };
       if (result?.reason) out.reason = String(result.reason);
@@ -296,15 +294,6 @@ export class IngestService {
     if (outcome) this.metrics?.countIngestFact(String(outcome));
   }
 
-
-  private sourceTrustFor(source: { vertical: string; eventId?: string; messageId?: string }): number {
-    // Heuristic: derive a trust label from source shape.
-    if (source.eventId?.startsWith('billing.'))   return SOURCE_TRUST.billing_event;
-    if (source.eventId?.startsWith('incidents.')) return SOURCE_TRUST.incidents_event;
-    if (source.eventId?.startsWith('auth.'))      return SOURCE_TRUST.auth_event;
-    if (source.messageId)                         return SOURCE_TRUST.inbox_extraction;
-    return SOURCE_TRUST.default;
-  }
 
   // ── ingestMention: free-text → LLM extraction → fact records ─────────
   async ingestMention(companyId: string, dto: IngestMentionDto) {
@@ -852,7 +841,7 @@ export class IngestService {
       );
     }
     const policy = this.predicateRegistry.policyFor(companyId, predicate);
-    const sourceTrust = this.sourceTrustFor(source);
+    const sourceTrust = sourceTrustFor(source);
     // Locale + entropy ride into fn::resolve_fact as params (migration 0039),
     // folded INSERTED-only writes instead of follow-up UPDATEs. detectLanguage
     // is pure TS; 'und' → leave unset (NONE), matching the old guard.
@@ -887,22 +876,9 @@ export class IngestService {
     // Phase 4.A locale tag + Phase 3.B entropy now ride into fn::resolve_fact
     // via the $lang/$script/$entropy params (migration 0039) — set on
     // INSERTED only, server-side, with no follow-up round-trips. HyPE stays a
-    // post-call UPDATE below: it's an LLM call, gated on isEnabled() AND
-    // INSERTED, so pre-computing it would burn the model on non-INSERTED
-    // outcomes.
-    if (factId && this.hype.isEnabled() && outcome === 'INSERTED') {
-      const altEmbedding = await this.hype.generateAltEmbedding(
-        predicate,
-        object,
-      );
-      if (altEmbedding) {
-        await db.query(
-          `UPDATE type::record('knowledge_fact', $tail) SET altEmbedding = $emb`,
-          { tail: idTailOf(factId), emb: altEmbedding },
-        );
-      }
-    }
-
+    // post-call UPDATE: it's an LLM call, gated on isEnabled() AND INSERTED,
+    // so pre-computing it would burn the model on non-INSERTED outcomes.
+    await this.writeAltEmbeddingIfHype(db, factId, outcome, predicate, object);
 
     // Surface supersede / compete outcomes in the trace so the demo can
     // show "Berlin fact closed at July 1, Dublin became current" —
@@ -962,34 +938,31 @@ export class IngestService {
     const n = Number(v);
     return Number.isFinite(n) ? n : fallback;
   }
-}
 
-function idTailOf(rid: string): string {
-  const i = rid.indexOf(':');
-  return i === -1 ? rid : rid.slice(i + 1);
-}
-
-/**
- * Build a SurrealDB-safe externalRefs key. SurrealQL CONTENT treats dots
- * inside object keys as nested-path separators, so a key like
- * "rent.cust_42" silently expands into nested fields and is then dropped
- * by the schemafull `externalRefs: object` constraint. Replace dots with
- * a double underscore — the original `vertical.entityId` form is
- * recoverable but stored unambiguously as a single property.
- */
-function externalRefKey(vertical: string, id: string): string {
-  const safe = (s: string) => s.replace(/\./g, '__');
-  return `${safe(vertical)}__${safe(id)}`;
-}
-
-/**
- * Naive PII redactor — masks emails, phone-like numbers, and 9+ digit runs.
- * 0.2.0 will replace this with @inite/assistant.piiMask once the package
- * exposes a server-side import path.
- */
-function redactPii(text: string): string {
-  return text
-    .replace(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, '[EMAIL]')
-    .replace(/\+?\d[\d\s().-]{7,}\d/g, '[PHONE]')
-    .replace(/\b\d{9,}\b/g, '[NUM]');
+  /**
+   * HyPE post-INSERT alt-embedding write, shared by both ingest paths
+   * (typed ingestFact + mention-extracted recordExtractedFact). We do this
+   * synchronously inside the ingest flow so the post-condition "fact is
+   * searchable with alt-embedding" holds immediately. Gated on
+   * shouldWriteHypeAltEmbedding (INSERTED only, HyPE enabled, concrete
+   * factId); when HyPE is off generateAltEmbedding returns null and we skip
+   * the UPDATE — no extra ingest latency.
+   */
+  private async writeAltEmbeddingIfHype(
+    db: Surreal,
+    factId: string | null,
+    outcome: unknown,
+    predicate: string,
+    object: string,
+  ): Promise<void> {
+    if (!shouldWriteHypeAltEmbedding(outcome, this.hype.isEnabled(), factId)) {
+      return;
+    }
+    const altEmbedding = await this.hype.generateAltEmbedding(predicate, object);
+    if (!altEmbedding) return;
+    await db.query(
+      `UPDATE type::record('knowledge_fact', $tail) SET altEmbedding = $emb`,
+      { tail: idTailOf(factId as string), emb: altEmbedding },
+    );
+  }
 }

--- a/test/ingest-utils.unit-spec.ts
+++ b/test/ingest-utils.unit-spec.ts
@@ -1,0 +1,118 @@
+import {
+  idTailOf,
+  externalRefKey,
+  redactPii,
+  sourceTrustFor,
+  shouldWriteHypeAltEmbedding,
+} from '../src/ingest/ingest-utils';
+import { SOURCE_TRUST } from '../src/ingest/conflict-resolver';
+
+describe('idTailOf', () => {
+  it('strips the table prefix off a record id', () => {
+    expect(idTailOf('knowledge_fact:abc123')).toBe('abc123');
+  });
+
+  it('returns the input unchanged when there is no colon', () => {
+    expect(idTailOf('abc123')).toBe('abc123');
+  });
+
+  it('only splits on the first colon (id tails may contain colons)', () => {
+    expect(idTailOf('knowledge_entity:a:b')).toBe('a:b');
+  });
+});
+
+describe('externalRefKey', () => {
+  it('joins vertical and id with a double underscore', () => {
+    expect(externalRefKey('rent', 'cust42')).toBe('rent__cust42');
+  });
+
+  it('replaces dots in either component so SurrealQL CONTENT cannot nest them', () => {
+    expect(externalRefKey('rent.eu', 'cust.42')).toBe('rent__eu__cust__42');
+  });
+});
+
+describe('redactPii', () => {
+  it('masks email addresses', () => {
+    expect(redactPii('reach me at jane.doe@example.com please')).toBe(
+      'reach me at [EMAIL] please',
+    );
+  });
+
+  it('masks phone-like numbers', () => {
+    expect(redactPii('call +1 (415) 555-2671 now')).toContain('[PHONE]');
+  });
+
+  it('masks long digit runs (the phone pattern claims them first)', () => {
+    const out = redactPii('id 123456789012');
+    expect(out).not.toContain('123456789012');
+    expect(out).toMatch(/\[(PHONE|NUM)\]/);
+  });
+
+  it('leaves non-PII text untouched', () => {
+    expect(redactPii('moved to Berlin, tier gold')).toBe(
+      'moved to Berlin, tier gold',
+    );
+  });
+});
+
+describe('sourceTrustFor', () => {
+  it('maps billing events to the billing trust label', () => {
+    expect(sourceTrustFor({ vertical: 'x', eventId: 'billing.charge' })).toBe(
+      SOURCE_TRUST.billing_event,
+    );
+  });
+
+  it('maps incidents events', () => {
+    expect(sourceTrustFor({ vertical: 'x', eventId: 'incidents.opened' })).toBe(
+      SOURCE_TRUST.incidents_event,
+    );
+  });
+
+  it('maps auth events', () => {
+    expect(sourceTrustFor({ vertical: 'x', eventId: 'auth.login' })).toBe(
+      SOURCE_TRUST.auth_event,
+    );
+  });
+
+  it('maps a message id (no event) to inbox extraction', () => {
+    expect(sourceTrustFor({ vertical: 'x', messageId: 'm1' })).toBe(
+      SOURCE_TRUST.inbox_extraction,
+    );
+  });
+
+  it('falls back to the default trust for an unrecognised shape', () => {
+    expect(sourceTrustFor({ vertical: 'x' })).toBe(SOURCE_TRUST.default);
+  });
+
+  it('prefers the eventId branch over messageId', () => {
+    expect(
+      sourceTrustFor({ vertical: 'x', eventId: 'billing.x', messageId: 'm1' }),
+    ).toBe(SOURCE_TRUST.billing_event);
+  });
+});
+
+describe('shouldWriteHypeAltEmbedding', () => {
+  it('is true only for an INSERTED outcome with HyPE enabled and a factId', () => {
+    expect(shouldWriteHypeAltEmbedding('INSERTED', true, 'fact:1')).toBe(true);
+  });
+
+  it('is false when HyPE is disabled', () => {
+    expect(shouldWriteHypeAltEmbedding('INSERTED', false, 'fact:1')).toBe(false);
+  });
+
+  it('is false when there is no factId', () => {
+    expect(shouldWriteHypeAltEmbedding('INSERTED', true, null)).toBe(false);
+  });
+
+  it('is false for non-INSERTED outcomes (no embedding burned on supersede/compete/reject)', () => {
+    for (const outcome of [
+      'SUPERSEDED',
+      'COMPETING',
+      'REJECTED',
+      undefined,
+      null,
+    ]) {
+      expect(shouldWriteHypeAltEmbedding(outcome, true, 'fact:1')).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## What

Third god-service decomposition PR (item 1 of `docs/roadmap/audit-followup-2026-06.md`). `ingest.service.ts` (993 lines, **no unit spec**) carried pure helpers inline and a HyPE post-INSERT UPDATE block copy-pasted between `ingestFact` and `recordExtractedFact`.

**Two commits:**

1. **`fix(ingest)`: de-corrupt NUL-byte lock-key separators.** The file had two raw `U+0000` bytes committed into the `resolveLock` key template literal, which made git/grep/eslint treat the whole file as **binary**. Replaced with `\x00` escapes — the runtime lock key is byte-identical (still NUL-joined, still collision-free), the source is clean ASCII again, and the stale "Space-joined" comment is corrected.

2. **`refactor(ingest)`: extract pure logic into `ingest-utils.ts`:**
   - `idTailOf` / `externalRefKey` / `redactPii` — were file-local free functions
   - `sourceTrustFor` — was **also duplicated verbatim** in `ingest-predictor.service.ts`; both now import the one shared copy
   - `shouldWriteHypeAltEmbedding` — new pure gate predicate (INSERTED + HyPE enabled + concrete factId)

   The two identical HyPE blocks collapse into one private `writeAltEmbeddingIfHype(db, …)` backed by that predicate.

## Tests

New `test/ingest-utils.unit-spec.ts` — 19 assertions: every `sourceTrustFor` branch + precedence, the dot-safe key, the PII redactor, `idTailOf` colon handling, and the full `shouldWriteHypeAltEmbedding` truth table.

## Acceptance

- `pnpm exec tsc --noEmit` clean · `pnpm lint` clean
- `pnpm test` green — **697** unit (678 + 19 new)
- `pnpm test:e2e` green — **128** e2e (HyPE write paths exercised live; behaviour-preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)