### PR TITLE
chore(docker): pin node:22-slim base by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,15 @@
 # pre-pass speed-up. Switching to Debian slim is the simplest fix —
 # `apk add gcompat libc6-compat` is unreliable for native ABIs this
 # specific.
+#
+# Pinned by digest, not the floating `:22-slim` tag, so a base-image
+# republish can't silently change the build under us — reproducible
+# images + an auditable bump. Refresh both FROMs together with the new
+# manifest-list digest from:
+#   docker buildx imagetools inspect node:22-slim   # → Digest:
+# (use the top-level multi-arch manifest digest, which resolves per-arch).
 
-FROM node:22-slim AS builder
+FROM node:22-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4 AS builder
 
 WORKDIR /app
 
@@ -37,7 +44,8 @@ COPY src ./src
 RUN pnpm build
 
 # ── Runtime ──────────────────────────────────────────────────────────────
-FROM node:22-slim
+# Same digest pin as the builder stage above (keep them in lockstep).
+FROM node:22-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4
 
 # wget is preinstalled on node:22-alpine but NOT on -slim (Debian).
 # The deploy workflow's docker-compose healthcheck shells `wget -qO-


### PR DESCRIPTION
## What

Item 4 of `docs/roadmap/audit-followup-2026-06.md` (smaller items). The Docker base was the floating `node:22-slim` tag — a registry republish could change the build under us with no audit trail.

Pins **both** the builder and runtime `FROM`s to the current multi-arch manifest digest, fetched live (not guessed) from:

```
docker buildx imagetools inspect node:22-slim
→ Digest: sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4
```

The top-level manifest-list digest resolves per-arch, so the pin is platform-agnostic. Refresh instructions live in the Dockerfile header. Verified: `docker pull node:22-slim@sha256:813a7480…` resolves clean.

## Acceptance

- Only the two `FROM` refs change — no build-stage edits.
- The `docker` CI job builds the image from the pinned digest.

> Note: the `/ready` hard deploy gate (also listed under item 4) is intentionally **left as warning-only** — bge-m3 ONNX cold-warmup is unbounded and a hard gate risks flaking deploys (per the brief's own caveat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)