### PR TITLE
test(eval): freeze golden baseline + diff against it (stop nightly ratchet)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,30 +172,17 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile --ignore-workspace
 
-      # Baseline cache. On every job we restore the most recent
-      # eval-report.json from a previous green main; the post-eval
-      # diff step compares current numbers against it. Cache key is
-      # uniquified by github.run_id so each successful main run
-      # writes a fresh entry (without overwriting the prior one),
-      # and the restoreKeys prefix matches any earlier entry for the
-      # delta-gate to find.
-      #
-      # Namespace bump: `v5-openai-` prefix invalidates the prior
-      # baseline epoch taken under openai SDK v4 (node-fetch keep-alive
-      # path). v5 (undici) shifts a few LLM-extraction recall numbers
-      # ±5-15pp run-to-run within absolute thresholds; comparing them
-      # to a v4 snapshot produced false-positive regressions in CI.
-      # Bumping the namespace forces the first green main run on v5
-      # to seed a fresh baseline. Bump again on the next SDK epoch.
-      - name: Restore eval baseline
-        id: baseline-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .eval-baseline/main.json
-          key: eval-baseline-main-v5-openai-${{ github.run_id }}
-          restore-keys: |
-            eval-baseline-main-v5-openai-
-
+      # Delta-gate baseline is now a FROZEN golden committed at
+      # test/eval/golden-baseline.json — not a cache-restored,
+      # self-promoted snapshot. The old cache flow promoted every green
+      # nightly's report into the next run's baseline, so a slow ~1pp/night
+      # drift within the diff tolerance ratcheted the comparison floor down
+      # over time. Anchoring to a committed golden removes that ratchet: the
+      # comparison reference only moves when a human re-measures and commits
+      # a new golden (regen: pnpm test:eval with BRAIN_EVAL_REPORT_OUT
+      # pointing at the golden path, on a clean main, under real OpenAI).
+      # The absolute overall floors in test/quality.real-e2e-spec.ts (PR #31)
+      # remain the hard anti-erosion anchor; this diff is the drift detector.
       - name: Quality eval (multi-vertical, real OpenAI)
         env:
           # Repo secret is `BRAIN_OPENAI_API_KEY` (org convention —
@@ -208,24 +195,12 @@ jobs:
           BRAIN_EVAL_REPORT_OUT: .eval-current/report.json
         run: pnpm test:eval
 
-      - name: Compare to baseline (delta-gate)
+      - name: Compare to frozen golden (delta-gate)
         run: |
-          if [ -f .eval-baseline/main.json ]; then
-            pnpm eval:diff .eval-baseline/main.json .eval-current/report.json
-          else
-            echo "[delta-gate] no baseline yet — first run, skipping diff"
-            pnpm eval:diff --no-baseline .eval-current/report.json
-          fi
-
-      # Promote current to baseline for next run, but ONLY on a green
-      # nightly schedule run. Workflow_dispatch runs (manual / branch)
-      # still diff against the cached baseline but don't pollute it,
-      # so an ad-hoc dispatch can't lock in a flaky number as truth.
-      - name: Promote current to baseline
-        if: github.event_name == 'schedule'
-        run: |
-          mkdir -p .eval-baseline
-          cp .eval-current/report.json .eval-baseline/main.json
+          # Diff against the committed golden, never a cache-promoted
+          # snapshot — no ratchet. eval:diff blocks on regressions beyond
+          # per-metric tolerances; improvements never block.
+          pnpm eval:diff test/eval/golden-baseline.json .eval-current/report.json
 
   docker:
     runs-on: ubuntu-latest

--- a/test/eval/golden-baseline.json
+++ b/test/eval/golden-baseline.json
@@ -1,0 +1,1035 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-06-26T13:49:45.836Z",
+  "perVertical": [
+    {
+      "vertical": "shop",
+      "scenarios": 8,
+      "metrics": [
+        {
+          "name": "recall@1",
+          "value": 0.8333333333333334,
+          "threshold": 0.6,
+          "ciLower": 0.5833333333333334,
+          "ciUpper": 1,
+          "n": 12
+        },
+        {
+          "name": "recall@3",
+          "value": 0.9166666666666666,
+          "threshold": 0.8,
+          "ciLower": 0.75,
+          "ciUpper": 1,
+          "n": 12
+        },
+        {
+          "name": "MRR",
+          "value": 0.8958333333333334,
+          "threshold": 0.5,
+          "ciLower": 0.7708333333333334,
+          "ciUpper": 1,
+          "n": 12
+        },
+        {
+          "name": "NDCG@10",
+          "value": 0.927815870126527,
+          "ciLower": 0.8272417212970122,
+          "ciUpper": 1,
+          "n": 13
+        },
+        {
+          "name": "recall@1:temporal",
+          "value": 1,
+          "ciLower": 1,
+          "ciUpper": 1,
+          "n": 2
+        },
+        {
+          "name": "recall@1:current",
+          "value": 0.8,
+          "ciLower": 0.5,
+          "ciUpper": 1,
+          "n": 10
+        },
+        {
+          "name": "MRR:temporal",
+          "value": 1,
+          "ciLower": 1,
+          "ciUpper": 1,
+          "n": 2
+        },
+        {
+          "name": "MRR:current",
+          "value": 0.875,
+          "ciLower": 0.725,
+          "ciUpper": 1,
+          "n": 10
+        },
+        {
+          "name": "extraction-predicate-recall",
+          "value": null,
+          "threshold": 0.5
+        },
+        {
+          "name": "entity-extraction-rate",
+          "value": null,
+          "threshold": 0.7
+        },
+        {
+          "name": "identity-resolution-f1",
+          "value": null,
+          "threshold": 0.8
+        },
+        {
+          "name": "identity-resolution-precision",
+          "value": null
+        },
+        {
+          "name": "identity-resolution-recall",
+          "value": null
+        },
+        {
+          "name": "pii-gating-correctness",
+          "value": 1,
+          "threshold": 1
+        },
+        {
+          "name": "memory-lifecycle-correctness",
+          "value": 1,
+          "threshold": 1
+        },
+        {
+          "name": "faithfulness:mean",
+          "value": 1,
+          "n": 1
+        },
+        {
+          "name": "faithfulness:pass-rate",
+          "value": 1,
+          "threshold": 0.8,
+          "n": 1
+        },
+        {
+          "name": "faithfulness:verifier-failures",
+          "value": 0,
+          "n": 1
+        },
+        {
+          "name": "conformal-active-rate",
+          "value": 1,
+          "threshold": 0.95,
+          "n": 1
+        },
+        {
+          "name": "synthesize-abstain-rate",
+          "value": 1,
+          "threshold": 0.7,
+          "n": 1
+        },
+        {
+          "name": "verifier-failure-rate",
+          "value": 1,
+          "threshold": 0.95,
+          "n": 1
+        },
+        {
+          "name": "answer-language-correctness",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "decision-log-citation-rate",
+          "value": 1,
+          "threshold": 0.8,
+          "n": 1
+        },
+        {
+          "name": "mean-extraction-entropy",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "privacy-leakage-mia-auc",
+          "value": null
+        }
+      ]
+    },
+    {
+      "vertical": "rent",
+      "scenarios": 15,
+      "metrics": [
+        {
+          "name": "recall@1",
+          "value": 0.8787878787878788,
+          "threshold": 0.6,
+          "ciLower": 0.7575757575757576,
+          "ciUpper": 0.9696969696969697,
+          "n": 33
+        },
+        {
+          "name": "recall@3",
+          "value": 1,
+          "threshold": 0.8,
+          "ciLower": 1,
+          "ciUpper": 1,
+          "n": 33
+        },
+        {
+          "name": "MRR",
+          "value": 0.9393939393939394,
+          "threshold": 0.5,
+          "ciLower": 0.8787878787878788,
+          "ciUpper": 0.9848484848484849,
+          "n": 33
+        },
+        {
+          "name": "NDCG@10",
+          "value": 0.9552642125541161,
+          "ciLower": 0.9105284251082322,
+          "ciUpper": 0.988816053138529,
+          "n": 33
+        },
+        {
+          "name": "recall@1:temporal",
+          "value": 0.8947368421052632,
+          "ciLower": 0.7368421052631579,
+          "ciUpper": 1,
+          "n": 19
+        },
+        {
+          "name": "recall@1:current",
+          "value": 0.8571428571428571,
+          "ciLower": 0.6428571428571429,
+          "ciUpper": 1,
+          "n": 14
+        },
+        {
+          "name": "MRR:temporal",
+          "value": 0.9473684210526315,
+          "ciLower": 0.868421052631579,
+          "ciUpper": 1,
+          "n": 19
+        },
+        {
+          "name": "MRR:current",
+          "value": 0.9285714285714286,
+          "ciLower": 0.8214285714285714,
+          "ciUpper": 1,
+          "n": 14
+        },
+        {
+          "name": "extraction-predicate-recall",
+          "value": 0.8333333333333334,
+          "threshold": 0.5
+        },
+        {
+          "name": "entity-extraction-rate",
+          "value": 1,
+          "threshold": 0.7
+        },
+        {
+          "name": "identity-resolution-f1",
+          "value": null,
+          "threshold": 0.8
+        },
+        {
+          "name": "identity-resolution-precision",
+          "value": null
+        },
+        {
+          "name": "identity-resolution-recall",
+          "value": null
+        },
+        {
+          "name": "pii-gating-correctness",
+          "value": 1,
+          "threshold": 1
+        },
+        {
+          "name": "memory-lifecycle-correctness",
+          "value": null,
+          "threshold": 1
+        },
+        {
+          "name": "faithfulness:mean",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "faithfulness:pass-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "faithfulness:verifier-failures",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "conformal-active-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "synthesize-abstain-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "verifier-failure-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "answer-language-correctness",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "decision-log-citation-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "mean-extraction-entropy",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "privacy-leakage-mia-auc",
+          "value": null
+        }
+      ]
+    },
+    {
+      "vertical": "estate",
+      "scenarios": 4,
+      "metrics": [
+        {
+          "name": "recall@1",
+          "value": 0.6,
+          "threshold": 0.6,
+          "ciLower": 0.3,
+          "ciUpper": 0.9,
+          "n": 10
+        },
+        {
+          "name": "recall@3",
+          "value": 0.9,
+          "threshold": 0.8,
+          "ciLower": 0.7,
+          "ciUpper": 1,
+          "n": 10
+        },
+        {
+          "name": "MRR",
+          "value": 0.775,
+          "threshold": 0.5,
+          "ciLower": 0.6,
+          "ciUpper": 0.95,
+          "n": 10
+        },
+        {
+          "name": "NDCG@10",
+          "value": 0.8323465818787767,
+          "ciLower": 0.7016001884004075,
+          "ciUpper": 0.9630929753571458,
+          "n": 10
+        },
+        {
+          "name": "recall@1:temporal",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "recall@1:current",
+          "value": 0.6,
+          "ciLower": 0.3,
+          "ciUpper": 0.9,
+          "n": 10
+        },
+        {
+          "name": "MRR:temporal",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "MRR:current",
+          "value": 0.775,
+          "ciLower": 0.6,
+          "ciUpper": 0.95,
+          "n": 10
+        },
+        {
+          "name": "extraction-predicate-recall",
+          "value": 0.5,
+          "threshold": 0.5
+        },
+        {
+          "name": "entity-extraction-rate",
+          "value": 1,
+          "threshold": 0.7
+        },
+        {
+          "name": "identity-resolution-f1",
+          "value": null,
+          "threshold": 0.8
+        },
+        {
+          "name": "identity-resolution-precision",
+          "value": null
+        },
+        {
+          "name": "identity-resolution-recall",
+          "value": null
+        },
+        {
+          "name": "pii-gating-correctness",
+          "value": 1,
+          "threshold": 1
+        },
+        {
+          "name": "memory-lifecycle-correctness",
+          "value": null,
+          "threshold": 1
+        },
+        {
+          "name": "faithfulness:mean",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "faithfulness:pass-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "faithfulness:verifier-failures",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "conformal-active-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "synthesize-abstain-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "verifier-failure-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "answer-language-correctness",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "decision-log-citation-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "mean-extraction-entropy",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "privacy-leakage-mia-auc",
+          "value": null
+        }
+      ]
+    },
+    {
+      "vertical": "events",
+      "scenarios": 3,
+      "metrics": [
+        {
+          "name": "recall@1",
+          "value": 0.6666666666666666,
+          "threshold": 0.6,
+          "ciLower": 0.3333333333333333,
+          "ciUpper": 1,
+          "n": 9
+        },
+        {
+          "name": "recall@3",
+          "value": 1,
+          "threshold": 0.8,
+          "ciLower": 1,
+          "ciUpper": 1,
+          "n": 9
+        },
+        {
+          "name": "MRR",
+          "value": 0.8333333333333334,
+          "threshold": 0.5,
+          "ciLower": 0.6666666666666666,
+          "ciUpper": 1,
+          "n": 9
+        },
+        {
+          "name": "NDCG@10",
+          "value": 0.8769765845238192,
+          "ciLower": 0.7539531690476384,
+          "ciUpper": 1,
+          "n": 9
+        },
+        {
+          "name": "recall@1:temporal",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "recall@1:current",
+          "value": 0.6666666666666666,
+          "ciLower": 0.3333333333333333,
+          "ciUpper": 1,
+          "n": 9
+        },
+        {
+          "name": "MRR:temporal",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "MRR:current",
+          "value": 0.8333333333333334,
+          "ciLower": 0.6666666666666666,
+          "ciUpper": 1,
+          "n": 9
+        },
+        {
+          "name": "extraction-predicate-recall",
+          "value": 0.5,
+          "threshold": 0.5
+        },
+        {
+          "name": "entity-extraction-rate",
+          "value": 1,
+          "threshold": 0.7
+        },
+        {
+          "name": "identity-resolution-f1",
+          "value": null,
+          "threshold": 0.8
+        },
+        {
+          "name": "identity-resolution-precision",
+          "value": null
+        },
+        {
+          "name": "identity-resolution-recall",
+          "value": null
+        },
+        {
+          "name": "pii-gating-correctness",
+          "value": 1,
+          "threshold": 1
+        },
+        {
+          "name": "memory-lifecycle-correctness",
+          "value": null,
+          "threshold": 1
+        },
+        {
+          "name": "faithfulness:mean",
+          "value": 1,
+          "n": 1
+        },
+        {
+          "name": "faithfulness:pass-rate",
+          "value": 1,
+          "threshold": 0.8,
+          "n": 1
+        },
+        {
+          "name": "faithfulness:verifier-failures",
+          "value": 0,
+          "n": 1
+        },
+        {
+          "name": "conformal-active-rate",
+          "value": 1,
+          "threshold": 0.95,
+          "n": 1
+        },
+        {
+          "name": "synthesize-abstain-rate",
+          "value": 1,
+          "threshold": 0.7,
+          "n": 1
+        },
+        {
+          "name": "verifier-failure-rate",
+          "value": 1,
+          "threshold": 0.95,
+          "n": 1
+        },
+        {
+          "name": "answer-language-correctness",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "decision-log-citation-rate",
+          "value": 0,
+          "threshold": 0.8,
+          "n": 1
+        },
+        {
+          "name": "mean-extraction-entropy",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "privacy-leakage-mia-auc",
+          "value": null
+        }
+      ]
+    },
+    {
+      "vertical": "health",
+      "scenarios": 3,
+      "metrics": [
+        {
+          "name": "recall@1",
+          "value": 1,
+          "threshold": 0.6,
+          "ciLower": 1,
+          "ciUpper": 1,
+          "n": 6
+        },
+        {
+          "name": "recall@3",
+          "value": 1,
+          "threshold": 0.8,
+          "ciLower": 1,
+          "ciUpper": 1,
+          "n": 6
+        },
+        {
+          "name": "MRR",
+          "value": 1,
+          "threshold": 0.5,
+          "ciLower": 1,
+          "ciUpper": 1,
+          "n": 6
+        },
+        {
+          "name": "NDCG@10",
+          "value": 0.7777777777777778,
+          "ciLower": 0.4444444444444444,
+          "ciUpper": 1,
+          "n": 9
+        },
+        {
+          "name": "recall@1:temporal",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "recall@1:current",
+          "value": 1,
+          "ciLower": 1,
+          "ciUpper": 1,
+          "n": 6
+        },
+        {
+          "name": "MRR:temporal",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "MRR:current",
+          "value": 1,
+          "ciLower": 1,
+          "ciUpper": 1,
+          "n": 6
+        },
+        {
+          "name": "extraction-predicate-recall",
+          "value": null,
+          "threshold": 0.5
+        },
+        {
+          "name": "entity-extraction-rate",
+          "value": null,
+          "threshold": 0.7
+        },
+        {
+          "name": "identity-resolution-f1",
+          "value": null,
+          "threshold": 0.8
+        },
+        {
+          "name": "identity-resolution-precision",
+          "value": null
+        },
+        {
+          "name": "identity-resolution-recall",
+          "value": null
+        },
+        {
+          "name": "pii-gating-correctness",
+          "value": 1,
+          "threshold": 1
+        },
+        {
+          "name": "memory-lifecycle-correctness",
+          "value": null,
+          "threshold": 1
+        },
+        {
+          "name": "faithfulness:mean",
+          "value": 1,
+          "n": 1
+        },
+        {
+          "name": "faithfulness:pass-rate",
+          "value": 1,
+          "threshold": 0.8,
+          "n": 1
+        },
+        {
+          "name": "faithfulness:verifier-failures",
+          "value": 0,
+          "n": 1
+        },
+        {
+          "name": "conformal-active-rate",
+          "value": 1,
+          "threshold": 0.95,
+          "n": 1
+        },
+        {
+          "name": "synthesize-abstain-rate",
+          "value": 1,
+          "threshold": 0.7,
+          "n": 1
+        },
+        {
+          "name": "verifier-failure-rate",
+          "value": 1,
+          "threshold": 0.95,
+          "n": 1
+        },
+        {
+          "name": "answer-language-correctness",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "decision-log-citation-rate",
+          "value": 1,
+          "threshold": 0.8,
+          "n": 1
+        },
+        {
+          "name": "mean-extraction-entropy",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "privacy-leakage-mia-auc",
+          "value": null
+        }
+      ]
+    },
+    {
+      "vertical": "cross",
+      "scenarios": 16,
+      "metrics": [
+        {
+          "name": "recall@1",
+          "value": 0.984375,
+          "threshold": 0.6,
+          "ciLower": 0.9635416666666666,
+          "ciUpper": 1,
+          "n": 192
+        },
+        {
+          "name": "recall@3",
+          "value": 0.9895833333333334,
+          "threshold": 0.8,
+          "ciLower": 0.9739583333333334,
+          "ciUpper": 1,
+          "n": 192
+        },
+        {
+          "name": "MRR",
+          "value": 0.9869791666666666,
+          "threshold": 0.5,
+          "ciLower": 0.96875,
+          "ciUpper": 1,
+          "n": 192
+        },
+        {
+          "name": "NDCG@10",
+          "value": 0.987661092466518,
+          "ciLower": 0.9701138515997026,
+          "ciUpper": 1,
+          "n": 192
+        },
+        {
+          "name": "recall@1:temporal",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "recall@1:current",
+          "value": 0.984375,
+          "ciLower": 0.9635416666666666,
+          "ciUpper": 1,
+          "n": 192
+        },
+        {
+          "name": "MRR:temporal",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "MRR:current",
+          "value": 0.9869791666666666,
+          "ciLower": 0.96875,
+          "ciUpper": 1,
+          "n": 192
+        },
+        {
+          "name": "extraction-predicate-recall",
+          "value": 0.5714285714285714,
+          "threshold": 0.5
+        },
+        {
+          "name": "entity-extraction-rate",
+          "value": 1,
+          "threshold": 0.7
+        },
+        {
+          "name": "identity-resolution-f1",
+          "value": 1,
+          "threshold": 0.8
+        },
+        {
+          "name": "identity-resolution-precision",
+          "value": 1
+        },
+        {
+          "name": "identity-resolution-recall",
+          "value": 1
+        },
+        {
+          "name": "pii-gating-correctness",
+          "value": 1,
+          "threshold": 1
+        },
+        {
+          "name": "memory-lifecycle-correctness",
+          "value": 1,
+          "threshold": 1
+        },
+        {
+          "name": "faithfulness:mean",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "faithfulness:pass-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "faithfulness:verifier-failures",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "conformal-active-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "synthesize-abstain-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "verifier-failure-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "answer-language-correctness",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "decision-log-citation-rate",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "mean-extraction-entropy",
+          "value": null,
+          "n": 0
+        },
+        {
+          "name": "privacy-leakage-mia-auc",
+          "value": null
+        }
+      ]
+    }
+  ],
+  "overall": [
+    {
+      "name": "recall@1",
+      "value": 0.9389312977099237,
+      "threshold": 0.85,
+      "ciLower": 0.9083969465648855,
+      "ciUpper": 0.9656488549618321,
+      "n": 262
+    },
+    {
+      "name": "recall@3",
+      "value": 0.9847328244274809,
+      "threshold": 0.93,
+      "ciLower": 0.9694656488549618,
+      "ciUpper": 0.9961832061068703,
+      "n": 262
+    },
+    {
+      "name": "MRR",
+      "value": 0.9637404580152672,
+      "threshold": 0.88,
+      "ciLower": 0.9446564885496184,
+      "ciUpper": 0.9799618320610687,
+      "n": 262
+    },
+    {
+      "name": "NDCG@10",
+      "value": 0.9640319930789634,
+      "ciLower": 0.9452951580564221,
+      "ciUpper": 0.9804570691933563,
+      "n": 266
+    },
+    {
+      "name": "recall@1:temporal",
+      "value": 0.9047619047619048,
+      "ciLower": 0.7619047619047619,
+      "ciUpper": 1,
+      "n": 21
+    },
+    {
+      "name": "recall@1:current",
+      "value": 0.941908713692946,
+      "ciLower": 0.9128630705394191,
+      "ciUpper": 0.966804979253112,
+      "n": 241
+    },
+    {
+      "name": "MRR:temporal",
+      "value": 0.9523809523809523,
+      "ciLower": 0.8809523809523809,
+      "ciUpper": 1,
+      "n": 21
+    },
+    {
+      "name": "MRR:current",
+      "value": 0.9647302904564315,
+      "ciLower": 0.9450207468879668,
+      "ciUpper": 0.9813278008298755,
+      "n": 241
+    },
+    {
+      "name": "extraction-predicate-recall",
+      "value": 0.6785714285714285,
+      "threshold": 0.5
+    },
+    {
+      "name": "entity-extraction-rate",
+      "value": 1,
+      "threshold": 0.7
+    },
+    {
+      "name": "identity-resolution-f1",
+      "value": 1,
+      "threshold": 0.8
+    },
+    {
+      "name": "identity-resolution-precision",
+      "value": 1
+    },
+    {
+      "name": "identity-resolution-recall",
+      "value": 1
+    },
+    {
+      "name": "pii-gating-correctness",
+      "value": 1,
+      "threshold": 1
+    },
+    {
+      "name": "memory-lifecycle-correctness",
+      "value": 1,
+      "threshold": 1
+    },
+    {
+      "name": "faithfulness:mean",
+      "value": 1,
+      "n": 3
+    },
+    {
+      "name": "faithfulness:pass-rate",
+      "value": 1,
+      "threshold": 0.8,
+      "n": 3
+    },
+    {
+      "name": "faithfulness:verifier-failures",
+      "value": 0,
+      "n": 3
+    },
+    {
+      "name": "conformal-active-rate",
+      "value": 1,
+      "threshold": 0.95,
+      "n": 3
+    },
+    {
+      "name": "synthesize-abstain-rate",
+      "value": 1,
+      "threshold": 0.7,
+      "n": 3
+    },
+    {
+      "name": "verifier-failure-rate",
+      "value": 1,
+      "threshold": 0.95,
+      "n": 3
+    },
+    {
+      "name": "answer-language-correctness",
+      "value": null,
+      "n": 0
+    },
+    {
+      "name": "decision-log-citation-rate",
+      "value": 0.6666666666666666,
+      "threshold": 0.8,
+      "n": 3
+    },
+    {
+      "name": "mean-extraction-entropy",
+      "value": null,
+      "n": 0
+    },
+    {
+      "name": "privacy-leakage-mia-auc",
+      "value": null
+    }
+  ]
+}


### PR DESCRIPTION
## What

Item 3 of `docs/roadmap/audit-followup-2026-06.md`. The nightly eval delta-gate restored its baseline from cache and **self-promoted** every green run's report into the next run's baseline, so a slow ~1pp/night drift within the diff tolerance ratcheted the comparison floor down over time.

Anchor the delta-gate to a **committed frozen golden** instead:

- **`test/eval/golden-baseline.json`** — a real measured run (`pnpm test:eval`, n=262 + 180 directory queries, OpenAI `text-embedding-3-small`, `gpt-4o-mini-2024-07-18`, `THROTTLE_DISABLED=1`).
- **`ci.yml`** — drop the baseline cache-restore + self-promotion steps; the diff now runs `pnpm eval:diff test/eval/golden-baseline.json .eval-current/report.json`. The reference only moves when a human re-measures and commits a new golden.

The PR #31 absolute floors in `quality.real-e2e-spec.ts` stay the hard anti-erosion anchor; this diff is the drift detector.

## Measured golden (all retrieval/correctness at or above floors)

| metric | value | floor |
|---|---|---|
| recall@1 | 0.939 | 0.85 |
| recall@3 | 0.985 | 0.93 |
| MRR | 0.964 | 0.88 |
| NDCG@10 | 0.964 | — |
| entity-extraction-rate | 1.0 | 0.7 |
| identity-resolution-f1 | 1.0 | 0.8 |
| pii-gating-correctness | 1.0 | 1.0 |
| memory-lifecycle-correctness | 1.0 | 1.0 |
| faithfulness:pass-rate | 1.0 | 0.8 |

(Close to the 2026-06-25 numbers 0.95 / 0.99 / 0.97 — within run-to-run LLM variance; the v5/undici SDK epoch shifts extraction recall ±5-15pp.)

## ⚠️ One known-flake red

This golden run **red-failed exactly one** absolute-threshold assertion: `decision-log-citation-rate` (overall **0.667**, `events` **0.00** at n=3; `shop` & `health` = 1.0, floor 0.8). It measures whether the generator LLM (`gpt-4o-mini`) emits inline `[factId]` citations — a **small-n LLM-variance** metric (the metric's own comment notes trivial yes/no answers may not ground), the known nightly-watchdog flake class. **Not a code regression** (my decomposition PRs were behaviour-preserving and don't touch synthesis) and **not something the frozen baseline can false-positive on** — the delta-gate only blocks on *drops*, and 0.667/0.00 can only be matched or beaten.

Worth a follow-up decision (separate from this PR): lower that metric's absolute floor to reflect its small-n variance, or mark it advisory. I did **not** touch the threshold or fudge the number.

## Acceptance

- `pnpm exec tsc --noEmit` clean · `pnpm lint` clean
- `pnpm eval:diff test/eval/golden-baseline.json <golden>` → "No regressions ✓" (script parses the golden; gate wired correctly)
- `ci.yml` validates as YAML; `quality-eval` is schedule/dispatch-only (not a PR gate), so the golden change doesn't affect `build-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)