### PR TITLE
fix(synthesize): resolve inline + prefix-drifted citations (citation-rate)

### DIFF
--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -261,7 +261,11 @@ export class SynthesizeService {
       );
     }
 
-    const citations = resolveCitations(generated.citedFactIds, factIndex);
+    const citations = resolveCitations(
+      generated.citedFactIds,
+      generated.answer,
+      factIndex,
+    );
     const citedSet = new Set(citations.map((c) => c.factId));
     const decisionLog = explain
       ? buildDecisionLog(results, citedSet)
@@ -541,20 +545,60 @@ function buildFactIndex(results: SearchHit[]): FactIndexResult {
 }
 
 /**
- * Resolve a generator's `citedFactIds` against the retrieved index.
- * A factId not in the index is a hallucinated citation — drop it.
- * Preserves emission order; deduplicates.
+ * Strip a record-id prefix down to its bare tail so citations resolve
+ * across format drift. The generator is shown `[knowledge_fact:<tail>]`
+ * in the fact list but the prompt's own example uses `[fact_abc]`, so the
+ * model intermittently emits `fact_<tail>` / `fact:<tail>` instead of the
+ * canonical `knowledge_fact:<tail>`. Tails are 20-char random slugs, so
+ * matching on the tail is unambiguous.
+ */
+function citationTail(id: string): string {
+  return id.replace(/^knowledge_fact[:_]/i, '').replace(/^fact[:_]/i, '');
+}
+
+/**
+ * Pull `[<factId>]` citation markers out of the answer text. The generator
+ * RELIABLY inlines a bracketed citation after each claim (system prompt
+ * rule #2) but only INTERMITTENTLY mirrors them into the structured
+ * `citedFactIds` array — so the answer text is the more trustworthy
+ * citation source. Matches an optional table prefix + a ≥6-char slug to
+ * avoid catching ordinary bracketed prose.
+ */
+function extractInlineCitations(answer: string): string[] {
+  const ids: string[] = [];
+  const re = /\[((?:knowledge_fact[:_]|fact[:_])?[A-Za-z0-9]{6,})\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(answer)) !== null) ids.push(m[1]);
+  return ids;
+}
+
+/**
+ * Resolve the generator's citations against the retrieved index. Unions
+ * the structured `citedFactIds` array with the `[...]` markers parsed from
+ * the answer text (the model populates the array unreliably — see
+ * extractInlineCitations) and matches each candidate by exact id OR by
+ * bare tail (see citationTail) so prefix drift still resolves. A candidate
+ * that matches no retrieved fact is a hallucinated citation — dropped.
+ * Preserves emission order; deduplicates by resolved factId.
  */
 function resolveCitations(
   citedFactIds: string[] | undefined,
+  answer: string,
   factIndex: Map<string, Citation>,
 ): Citation[] {
+  const byTail = new Map<string, Citation>();
+  for (const [id, cite] of factIndex) byTail.set(citationTail(id), cite);
+
   const citations: Citation[] = [];
   const seen = new Set<string>();
-  for (const id of citedFactIds ?? []) {
-    const cite = factIndex.get(id);
-    if (cite && !seen.has(id)) {
-      seen.add(id);
+  const candidates = [
+    ...(citedFactIds ?? []),
+    ...extractInlineCitations(answer ?? ''),
+  ];
+  for (const raw of candidates) {
+    const cite = factIndex.get(raw) ?? byTail.get(citationTail(raw));
+    if (cite && !seen.has(cite.factId)) {
+      seen.add(cite.factId);
       citations.push(cite);
     }
   }

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -63,9 +63,9 @@ interface VerifierOutput {
 
 const GENERATOR_SYSTEM = `You are an answer synthesizer for a knowledge graph.
 
-Given a user query and a set of retrieved facts (each with a unique factId), generate a CONCISE answer that:
+Given a user query and a set of retrieved facts (each prefixed with its factId in square brackets, e.g. "[knowledge_fact:8a3fd2c1b9e4f7a6d5c0] ..."), generate a CONCISE answer that:
 1. Uses ONLY information present in the provided facts. Do NOT speculate, fill in missing details, or use outside knowledge.
-2. After each claim in the answer, inline a citation in square brackets with the factId(s) supporting it: e.g. "Maya complained about a broken washing machine [fact_abc]".
+2. After each claim in the answer, inline a citation in square brackets, copying the factId EXACTLY as it appears in the fact list — including its "knowledge_fact:" prefix. Do not abbreviate, renumber, or change the prefix. Example: "Maya complained about a broken washing machine [knowledge_fact:8a3fd2c1b9e4f7a6d5c0]". Mirror every factId you cite inline into the citedFactIds array.
 3. If the facts do not answer the question, output the exact answer string "I don't have grounded evidence for that." with citedFactIds set to [].
 
 Output strictly the JSON shape requested by the schema. Do not include preamble, follow-ups, or chain-of-thought.`;

--- a/test/synthesize.unit-spec.ts
+++ b/test/synthesize.unit-spec.ts
@@ -181,9 +181,10 @@ describe('SynthesizeService', () => {
   });
 
   it('resolves a citation whose prefix drifted to the example fact_ form', async () => {
-    // The prompt's own example uses "[fact_abc]"; the model sometimes
-    // echoes that prefix instead of the canonical knowledge_fact: one.
-    // Tail-matching must still resolve it against the retrieved fact.
+    // Even with the prompt instructing the canonical knowledge_fact:
+    // prefix, the model can still drift to a fact_ / fact: form. Tail-
+    // matching is the safety net that resolves it against the retrieved
+    // fact regardless of prefix.
     const search = makeSearch([
       makeHit('cust_a', [
         {

--- a/test/synthesize.unit-spec.ts
+++ b/test/synthesize.unit-spec.ts
@@ -147,6 +147,96 @@ describe('SynthesizeService', () => {
     expect(out.citations.map((c) => c.factId)).toEqual(['f1']);
   });
 
+  it('resolves an inline [factId] citation even when citedFactIds is empty', async () => {
+    // The generator reliably inlines a bracketed citation (system prompt
+    // rule #2) but only intermittently mirrors it into the structured
+    // citedFactIds array. The answer text must still produce a citation.
+    const search = makeSearch([
+      makeHit('cust_a', [
+        {
+          factId: 'knowledge_fact:abc123',
+          predicate: 'intent',
+          object: 'requested a refund',
+        },
+      ]),
+    ]);
+    const { svc } = makeSvc(
+      search,
+      {},
+      [
+        JSON.stringify({
+          answer: 'They requested a refund [knowledge_fact:abc123].',
+          citedFactIds: [],
+        }),
+      ],
+    );
+    const out = await svc.synthesize(
+      'co_x',
+      { ...baseDto, synthesisGuardrails: 'off' },
+      ['brain:read'],
+    );
+    expect(out.citations.map((c) => c.factId)).toEqual([
+      'knowledge_fact:abc123',
+    ]);
+  });
+
+  it('resolves a citation whose prefix drifted to the example fact_ form', async () => {
+    // The prompt's own example uses "[fact_abc]"; the model sometimes
+    // echoes that prefix instead of the canonical knowledge_fact: one.
+    // Tail-matching must still resolve it against the retrieved fact.
+    const search = makeSearch([
+      makeHit('cust_a', [
+        {
+          factId: 'knowledge_fact:abc123',
+          predicate: 'intent',
+          object: 'requested a refund',
+        },
+      ]),
+    ]);
+    const { svc } = makeSvc(
+      search,
+      {},
+      [
+        JSON.stringify({
+          answer: 'They requested a refund [fact_abc123].',
+          citedFactIds: ['fact_abc123'],
+        }),
+      ],
+    );
+    const out = await svc.synthesize(
+      'co_x',
+      { ...baseDto, synthesisGuardrails: 'off' },
+      ['brain:read'],
+    );
+    expect(out.citations.map((c) => c.factId)).toEqual([
+      'knowledge_fact:abc123',
+    ]);
+  });
+
+  it('drops a hallucinated citation that matches no retrieved fact', async () => {
+    const search = makeSearch([
+      makeHit('cust_a', [
+        { factId: 'knowledge_fact:real1', predicate: 'name', object: 'Maya' },
+      ]),
+    ]);
+    const { svc } = makeSvc(
+      search,
+      {},
+      [
+        JSON.stringify({
+          answer: 'Maya did something [knowledge_fact:notreal].',
+          citedFactIds: ['knowledge_fact:notreal'],
+        }),
+      ],
+    );
+    const out = await svc.synthesize(
+      'co_x',
+      { ...baseDto, synthesisGuardrails: 'off' },
+      ['brain:read'],
+    );
+    expect(out.citations).toEqual([]);
+  });
+
   it('strict mode + unsupported verdict fails closed (answer null)', async () => {
     const search = makeSearch([
       makeHit('cust_a', [


### PR DESCRIPTION
## What

Follow-up to #41. The golden run's `decision-log-citation-rate` cratered (`events` **0.00**, overall **0.667**) — but **not** because the generator failed to cite. Reproduced live against a spawned brain and found the citations were being **emitted but lost**. Two-part fix: the root cause (prompt) + a defence-in-depth net (resolver).

### Root cause — the generator prompt (`GENERATOR_SYSTEM`)

The fact list is rendered as `[knowledge_fact:<tail>] Name — predicate: object`, but the prompt's citation **example** said `[fact_abc]`. That inconsistency trained the model to (a) emit the wrong `fact_` prefix and (b) treat the bracket as decorative text rather than data to mirror into the structured `citedFactIds`. Fixed the example to the real `[knowledge_fact:<tail>]` form, and instruct the model to copy the id **exactly** (prefix included) and mirror every inline citation into `citedFactIds`.

### Defence-in-depth — `resolveCitations`

LLMs are non-deterministic, so even with a correct prompt the resolver shouldn't be brittle. It now treats the **answer text's inline `[…]` markers as the source of truth** (the channel the model is instructed to use — observed reliably populated even when `citedFactIds` was empty), unions them with the structured array, and matches each candidate by exact id **or bare tail** (`knowledge_fact:` / `fact_` / `fact:` prefix-tolerant). Hallucinated ids that match no retrieved fact are still dropped.

This is the answer to "isn't the resolver bit a crutch?" — the prompt fix removes the cause; the resolver tolerance is the safety net for residual drift.

## Evidence (live)

Reproduced against a spawned brain + real OpenAI. The exact golden query **"what did Noah Berggren request after the Veranda show"** went **0 → 1** citation (the answer always contained `[knowledge_fact:7y225…]` — the structured array was just empty). The query itself was fine; the abstention theory was wrong.

+3 unit tests: inline-only citation with empty `citedFactIds`, prefix-drift, hallucination-drop.

## Acceptance

- `pnpm exec tsc --noEmit` clean · `pnpm lint` clean
- `pnpm test` green — **700** unit (+3)
- `pnpm test:e2e` green — **128** e2e

## Golden

Raises citation-rate — not a threshold change (per your call: fix, don't lower). The #41 golden recorded the pre-fix number; I'll regenerate it on fresh `main` after this merges so the frozen baseline reflects the fixed system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)