### PR TITLE
ci(typecheck): gate the whole project incl. tests, not just src

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      # Typecheck the WHOLE project, tests included. `nest build` only
+      # compiles src/ (tsconfig.json excludes test/), so before this step a
+      # type error in a spec only surfaced if/when ts-jest happened to run
+      # that spec — a skipped or never-run spec shipped its type error
+      # green. tsconfig.spec.json re-includes test/ and gates it here.
+      - name: Typecheck (src + tests)
+        run: pnpm typecheck
+
       - name: Build
         run: pnpm build
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "packageManager": "pnpm@10.15.0",
   "scripts": {
     "build": "nest build",
+    "typecheck": "tsc -p tsconfig.spec.json",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,33 @@
+{
+  // Typecheck-only config that COVERS test files. The base tsconfig.json
+  // excludes test/ (nest build only compiles src/), so a plain `tsc` left
+  // every spec untyped at gate time — ts-jest only catches a type error
+  // when that spec actually runs. This config re-includes test/ and must
+  // therefore override the inherited exclude (extends does NOT merge
+  // exclude — without this line the base's "test" entry silently drops
+  // every spec again).
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // noEmit ⇒ no rootDir needed; dropping it lets the @inite/knowledge
+    // sibling source (../inite-shared, outside this repo) join the program
+    // without a TS6059 "not under rootDir" error for the real-e2e specs.
+    "noEmit": true,
+    "rootDir": null
+  },
+  "include": ["src/**/*", "test/**/*"],
+  // The five real-e2e specs below import the `@inite/knowledge` SDK from
+  // the sibling ../inite-shared repo, which is intentionally NOT checked
+  // out in the build-test gate (kept self-contained, no cross-repo PAT).
+  // They are typechecked by ts-jest when the real-e2e job runs them with
+  // the sibling present. Excluding them here keeps `pnpm typecheck` green
+  // and dependency-free; everything else under test/ is now gated.
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test/brain.real-e2e-spec.ts",
+    "test/directory.real-e2e-spec.ts",
+    "test/dreams.real-e2e-spec.ts",
+    "test/fat-tenant.real-e2e-spec.ts",
+    "test/json-directory.real-e2e-spec.ts"
+  ]
+}


### PR DESCRIPTION
## What

Closes the most-flagged ignored gate: **the build-test gate never typechecked test files.** `nest build` compiles only `src/` (tsconfig.json `exclude`s `test/`), and ts-jest only typechecks a spec when it *runs* — so a type error in any spec build-test doesn't execute (the `real-e2e` / `quality` / `concurrency` specs) shipped green. The brief's standing warning *"a green tsc does not mean the suites compile"* held literally.

- **`tsconfig.spec.json`** — typecheck-only (`noEmit`) config re-including `test/`. It **overrides the inherited `exclude`** (`extends` does *not* merge `exclude` — without that, the base's `"test"` entry silently drops every spec, which I verified by planting a probe). Drops `rootDir` so the sibling `@inite/knowledge` source can join the program under `noEmit` without TS6059.
- **`pnpm typecheck`** script + a **"Typecheck (src + tests)"** step in `build-test`.

## Verified

- Planted a `const x: number = "s"` in a spec → the step **fails** (TS2322). Removed → green.
- `pnpm typecheck` clean · `pnpm lint` clean · `pnpm test` 700 unit green.

## Self-contained

The five real-e2e specs that import the `@inite/knowledge` SDK from the sibling `../inite-shared` repo are excluded here — that repo is **deliberately not checked out in build-test** (no cross-repo PAT on the hot gate). They stay typechecked by ts-jest in the `real-e2e` job, which does check it out.

## ⚠️ Surfaced by this gate (separate follow-up)

Enabling the full check revealed **pre-existing SDK type drift** in those five specs: they construct the SDK `BrainClient` and pass it to eval-runner components typed for `HttpBrainClient` (missing `call` / `multiHop`). Real debt the old gate was hiding — flagged, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)