### PR TITLE
fix(test): migrate runner-driven specs off the SDK to HttpBrainClient

### DIFF
--- a/test/directory.real-e2e-spec.ts
+++ b/test/directory.real-e2e-spec.ts
@@ -23,7 +23,7 @@
  *       pnpm exec jest --config ./test/jest-e2e-real.json \
  *         --runInBand --testPathPattern=directory
  */
-import { BrainClient } from '@inite/knowledge';
+import { HttpBrainClient } from './eval/http-brain-client';
 import { spawnService, SpawnedService } from './spawn';
 import { buildFatTenant } from './eval/fixtures/fat-tenant.generator';
 import {
@@ -98,13 +98,12 @@ describe('Directory eval (jumbo tenant + memory lifecycle)', () => {
           `forgotten=${fixture.stats.forgottenCustomers}`,
       );
 
-      const sdkOpts = { baseUrl: svc.baseUrl, timeoutMs: 60_000 };
-      const fullClient = new BrainClient({
-        ...sdkOpts,
+      const fullClient = new HttpBrainClient({
+        baseUrl: svc.baseUrl,
         apiKey: svc.primary.plaintext,
       });
-      const limitedClient = new BrainClient({
-        ...sdkOpts,
+      const limitedClient = new HttpBrainClient({
+        baseUrl: svc.baseUrl,
         apiKey: svc.extras[0].plaintext,
       });
 

--- a/test/fat-tenant.real-e2e-spec.ts
+++ b/test/fat-tenant.real-e2e-spec.ts
@@ -17,7 +17,7 @@
  * Tune scale via FAT_TENANT_CUSTOMERS / FAT_TENANT_STAFF /
  * FAT_TENANT_PROJECTS env vars (defaults 500 / 50 / 30).
  */
-import { BrainClient } from '@inite/knowledge';
+import { HttpBrainClient } from './eval/http-brain-client';
 import { spawnService, SpawnedService } from './spawn';
 import { buildFatTenant } from './eval/fixtures/fat-tenant.generator';
 import {
@@ -65,13 +65,12 @@ describe('Fat-tenant retrieval eval', () => {
           `${fixture.stats.totalFacts} facts`,
       );
 
-      const sdkOpts = { baseUrl: svc.baseUrl, timeoutMs: 60_000 };
-      const fullClient = new BrainClient({
-        ...sdkOpts,
+      const fullClient = new HttpBrainClient({
+        baseUrl: svc.baseUrl,
         apiKey: svc.primary.plaintext,
       });
-      const limitedClient = new BrainClient({
-        ...sdkOpts,
+      const limitedClient = new HttpBrainClient({
+        baseUrl: svc.baseUrl,
         apiKey: svc.extras[0].plaintext,
       });
 

--- a/test/json-directory.real-e2e-spec.ts
+++ b/test/json-directory.real-e2e-spec.ts
@@ -22,7 +22,7 @@
  * query lands the expected entity in top-3.
  */
 import { resolve } from 'node:path';
-import { BrainClient } from '@inite/knowledge';
+import { HttpBrainClient } from './eval/http-brain-client';
 import { spawnService, SpawnedService } from './spawn';
 import { loadDirectoryJson } from './eval/loaders/json-directory.loader';
 import {
@@ -73,13 +73,12 @@ describe('JSON-directory eval (load + retrieval + lifecycle)', () => {
           `${loaded.stats.forgets} forgets`,
       );
 
-      const sdkOpts = { baseUrl: svc.baseUrl, timeoutMs: 60_000 };
-      const fullClient = new BrainClient({
-        ...sdkOpts,
+      const fullClient = new HttpBrainClient({
+        baseUrl: svc.baseUrl,
         apiKey: svc.primary.plaintext,
       });
-      const limitedClient = new BrainClient({
-        ...sdkOpts,
+      const limitedClient = new HttpBrainClient({
+        baseUrl: svc.baseUrl,
         apiKey: svc.extras[0].plaintext,
       });
 

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -15,19 +15,19 @@
     "rootDir": null
   },
   "include": ["src/**/*", "test/**/*"],
-  // The five real-e2e specs below import the `@inite/knowledge` SDK from
-  // the sibling ../inite-shared repo, which is intentionally NOT checked
-  // out in the build-test gate (kept self-contained, no cross-repo PAT).
-  // They are typechecked by ts-jest when the real-e2e job runs them with
-  // the sibling present. Excluding them here keeps `pnpm typecheck` green
-  // and dependency-free; everything else under test/ is now gated.
+  // The two specs below genuinely exercise the `@inite/knowledge` SDK
+  // (brain = the SDK-over-HTTP smoke; dreams = the SDK's dreams.run
+  // surface), which lives in the sibling ../inite-shared repo that is
+  // intentionally NOT checked out in the build-test gate (kept
+  // self-contained, no cross-repo PAT). They stay typechecked by ts-jest
+  // when the real-e2e job runs them with the sibling present. Everything
+  // else under test/ — including the directory / fat-tenant / json-
+  // directory specs, which were migrated off the SDK to HttpBrainClient —
+  // is gated here.
   "exclude": [
     "node_modules",
     "dist",
     "test/brain.real-e2e-spec.ts",
-    "test/directory.real-e2e-spec.ts",
-    "test/dreams.real-e2e-spec.ts",
-    "test/fat-tenant.real-e2e-spec.ts",
-    "test/json-directory.real-e2e-spec.ts"
+    "test/dreams.real-e2e-spec.ts"
   ]
 }


### PR DESCRIPTION
## What (item A)

The typecheck gate (#44) surfaced real **SDK type drift**: `directory` / `fat-tenant` / `json-directory` real-e2e specs constructed the `@inite/knowledge` SDK `BrainClient` and fed it to the eval-runner components (`SetupApplier` / `QueryExecutor` / `MemoryAssertionsChecker` / `MiaChecker`), which are typed for **`HttpBrainClient`** — the runner's own client, carrying `call` / `multiHop` that the SDK client lacks. `quality.real-e2e` already uses `HttpBrainClient`; these three just hadn't been migrated, so they passed the wrong client type.

Switch all three to `HttpBrainClient` (drop the SDK import + the unused `timeoutMs` opt). This:
1. Fixes the type mismatch.
2. Removes their dependency on the sibling `../inite-shared` repo → they're now typechecked in the **self-contained build-test gate**.

`tsconfig.spec.json`'s exclusion list drops **5 → 2**: only `brain` (the SDK-over-HTTP smoke) and `dreams` (the SDK `dreams.run` surface) genuinely exercise the SDK and stay excluded (typechecked by ts-jest in the `real-e2e` job, which checks out the sibling).

## Acceptance

- `pnpm typecheck` clean (now covers the 3 migrated specs) · `pnpm lint` clean · `pnpm test` 700 unit green.
- These are dispatch-only real-e2e specs; the runner is the same one `quality.real-e2e` drives with `HttpBrainClient`, so the swap is behaviour-equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)