### PR TITLE
refactor(health): extract HealthService — drop controller's db import

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { APP_GUARD } from '@nestjs/core';
 import { CommonModule } from './common/common.module';
 import { HealthController } from './common/health.controller';
+import { HealthService } from './common/health.service';
 import { TenantThrottlerGuard } from './common/tenant-throttler.guard';
 import { SurrealModule } from './db/surreal.module';
 import { AuthModule } from './auth/auth.module';
@@ -93,6 +94,7 @@ import { StatsModule } from './stats/stats.module';
   ],
   controllers: [HealthController],
   providers: [
+    HealthService,
     {
       provide: APP_GUARD,
       useClass: TenantThrottlerGuard,

--- a/src/common/health.controller.ts
+++ b/src/common/health.controller.ts
@@ -5,16 +5,11 @@ import {
   HttpStatus,
   ServiceUnavailableException,
 } from '@nestjs/common';
-// eslint-disable-next-line import/no-restricted-paths -- TODO: layer migration. Move the inline withCompany() / withAdminDb() queries below into a dedicated admin service, then drop this import. New controllers MUST NOT import db/* directly.
-import { SurrealService } from '../db/surreal.service';
-import { EmbedderService } from '../ai/embedder.service';
+import { HealthService } from './health.service';
 
 @Controller()
 export class HealthController {
-  constructor(
-    private readonly surreal: SurrealService,
-    private readonly embedder: EmbedderService,
-  ) {}
+  constructor(private readonly healthService: HealthService) {}
 
   // Liveness — answers true as soon as Nest is up, so the container
   // is considered alive while warmups (BGE-M3, local NER, intent
@@ -22,7 +17,7 @@ export class HealthController {
   // healthcheck uses this.
   @Get('health')
   async health() {
-    const dbOk = await this.surreal.ping().catch(() => false);
+    const { dbOk } = await this.healthService.liveness();
     return {
       status: dbOk ? 'ok' : 'degraded',
       service: 'inite-brain-service',
@@ -43,9 +38,8 @@ export class HealthController {
   @Get('ready')
   @HttpCode(HttpStatus.OK)
   async ready() {
-    const dbOk = await this.surreal.ping().catch(() => false);
-    const embedderReady = this.embedder.isReady();
-    if (!dbOk || !embedderReady) {
+    const { dbOk, embedderReady, ready } = await this.healthService.readiness();
+    if (!ready) {
       throw new ServiceUnavailableException({
         ready: false,
         checks: {

--- a/src/common/health.service.ts
+++ b/src/common/health.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { EmbedderService } from '../ai/embedder.service';
+
+export interface LivenessReport {
+  dbOk: boolean;
+}
+
+export interface ReadinessReport {
+  dbOk: boolean;
+  embedderReady: boolean;
+  ready: boolean;
+}
+
+/**
+ * Health probe logic, lifted out of HealthController so the controller
+ * stays pure HTTP plumbing and does not import from src/db (layer-purity
+ * gate — import/no-restricted-paths). The DB connection ping and embedder
+ * warmup check live here; the controller just shapes the HTTP response.
+ */
+@Injectable()
+export class HealthService {
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly embedder: EmbedderService,
+  ) {}
+
+  /** Liveness — is the DB connection reachable right now. */
+  async liveness(): Promise<LivenessReport> {
+    const dbOk = await this.surreal.ping().catch(() => false);
+    return { dbOk };
+  }
+
+  /**
+   * Readiness — request-path dependencies warm enough for production
+   * traffic: DB reachable AND the embedder finished its (ONNX) warmup.
+   */
+  async readiness(): Promise<ReadinessReport> {
+    const dbOk = await this.surreal.ping().catch(() => false);
+    const embedderReady = this.embedder.isReady();
+    return { dbOk, embedderReady, ready: dbOk && embedderReady };
+  }
+}

--- a/test/health-ready.unit-spec.ts
+++ b/test/health-ready.unit-spec.ts
@@ -12,6 +12,7 @@
  * and-forget; /ready waits on isReady() instead.
  */
 import { HealthController } from '../src/common/health.controller';
+import { HealthService } from '../src/common/health.service';
 import { ServiceUnavailableException } from '@nestjs/common';
 
 describe('HealthController', () => {
@@ -24,7 +25,7 @@ describe('HealthController', () => {
   }) {
     const surreal = { ping: async () => db } as any;
     const embedder = { isReady: () => embedderReady } as any;
-    return new HealthController(surreal, embedder);
+    return new HealthController(new HealthService(surreal, embedder));
   }
 
   describe('/health', () => {


### PR DESCRIPTION
## What (item C, 1/5)

First of the layer-purity cleanups. `HealthController` imported `SurrealService` from `src/db` directly — a violation of the `import/no-restricted-paths` gate, suppressed with an inline disable + TODO ("move into a dedicated service").

Move the DB ping + embedder warmup checks into a new **`HealthService`** (`src/common/health.service.ts`). The controller now injects `HealthService` and only shapes the HTTP response — **no `src/db` import, disable removed**.

## Behaviour

Identical: `/health` liveness (DB-ping, embedder-independent) and `/ready` 503-gating (DB ping AND embedder ready) unchanged. The `health-ready` unit spec now drives the controller through a real `HealthService` built from the same stubs.

## Acceptance

- `pnpm typecheck` clean · `pnpm build` clean · `pnpm lint` clean
- `pnpm test` 700 unit · `pnpm test:e2e` 128 e2e — green

> Remaining import/no-restricted-paths disables: 4 admin controllers (admin / admin-demo / admin-jobs / admin-infra) — each a follow-up PR (they carry real inline `withCompany`/`withAdminDb` queries to extract into admin services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)