### PR TITLE
refactor(admin): extract AdminInfraService — drop infra controller's db import

### DIFF
--- a/src/admin/admin-infra.controller.ts
+++ b/src/admin/admin-infra.controller.ts
@@ -1,9 +1,7 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
-// eslint-disable-next-line import/no-restricted-paths -- TODO: layer migration. Move the inline withCompany() / withAdminDb() queries below into a dedicated admin service, then drop this import. New controllers MUST NOT import db/* directly.
-import { SurrealService } from '../db/surreal.service';
-import { ApiKeyService } from '../auth/api-key.service';
+import { AdminInfraService } from './admin-infra.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { IntentClassifierService } from './intent-classifier.service';
 import { ChangefeedConsumerService } from '../audit/changefeed-consumer.service';
@@ -28,8 +26,7 @@ import type { NowResponse } from '../contracts/admin/now.schema';
 @UseGuards(ApiKeyGuard)
 export class AdminInfraController {
   constructor(
-    private readonly surreal: SurrealService,
-    private readonly apiKeys: ApiKeyService,
+    private readonly adminInfra: AdminInfraService,
     private readonly embedder: EmbedderService,
     private readonly intent: IntentClassifierService,
     private readonly changefeed: ChangefeedConsumerService,
@@ -56,12 +53,7 @@ export class AdminInfraController {
 
     // SurrealDB
     const dbStart = Date.now();
-    let dbOk = false;
-    try {
-      dbOk = await this.surreal.ping();
-    } catch {
-      dbOk = false;
-    }
+    const dbOk = await this.adminInfra.pingDb();
     components.push({
       name: 'surrealdb',
       status: dbOk ? 'ok' : 'unreachable',
@@ -143,46 +135,7 @@ export class AdminInfraController {
   @Get('migrations')
   @RequireScopes('brain:admin')
   async migrations(): Promise<MigrationsResponse> {
-    const manifest = await this.surreal.migrator.loadManifest();
-    const tenants = this.apiKeys.knownCompanyIds();
-    const perTenant: Array<{
-      companyId: string;
-      applied: string[];
-      pending: string[];
-    }> = [];
-    for (const companyId of tenants) {
-      try {
-        const applied = await this.surreal.withCompany(
-          companyId,
-          async (db) => {
-            const res = (await db.query<any[]>(
-              `SELECT migrationId FROM schema_migrations`,
-            )) as any[];
-            const rows = (res[0] ?? []) as Array<{ migrationId: string }>;
-            return rows.map((r) => r.migrationId).sort();
-          },
-        );
-        const appliedSet = new Set(applied);
-        const pending = manifest
-          .filter((m) => !appliedSet.has(m.id))
-          .map((m) => m.id);
-        perTenant.push({ companyId, applied, pending });
-      } catch (e) {
-        perTenant.push({
-          companyId,
-          applied: [],
-          pending: manifest.map((m) => m.id),
-        });
-        void e;
-      }
-    }
-    // Drift: any pending row across tenants?
-    const driftDetected = perTenant.some((t) => t.pending.length > 0);
-    return {
-      manifest: manifest.map((m) => ({ id: m.id, name: m.name })),
-      perTenant,
-      driftDetected,
-    } satisfies MigrationsResponse;
+    return this.adminInfra.migrationsAudit();
   }
 
   @Get('throttler')

--- a/src/admin/admin-infra.service.ts
+++ b/src/admin/admin-infra.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { ApiKeyService } from '../auth/api-key.service';
+import type { MigrationsResponse } from '../contracts/admin/migrations.schema';
+
+/**
+ * DB-touching logic for the infra cockpit, lifted out of
+ * AdminInfraController so the controller stays HTTP plumbing and does not
+ * import from src/db (layer-purity gate — import/no-restricted-paths).
+ * Holds the connection ping and the per-tenant migration audit.
+ */
+@Injectable()
+export class AdminInfraService {
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly apiKeys: ApiKeyService,
+  ) {}
+
+  /** Connection liveness ping; false on any error (never throws). */
+  async pingDb(): Promise<boolean> {
+    try {
+      return await this.surreal.ping();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Per-tenant migration audit: every migration in the manifest + which
+   * tenants applied each, with drift detection (a tenant missing a
+   * migration the others have). A tenant whose schema_migrations read
+   * throws is reported as fully pending rather than failing the audit.
+   */
+  async migrationsAudit(): Promise<MigrationsResponse> {
+    const manifest = await this.surreal.migrator.loadManifest();
+    const tenants = this.apiKeys.knownCompanyIds();
+    const perTenant: Array<{
+      companyId: string;
+      applied: string[];
+      pending: string[];
+    }> = [];
+    for (const companyId of tenants) {
+      try {
+        const applied = await this.surreal.withCompany(companyId, async (db) => {
+          const res = (await db.query<any[]>(
+            `SELECT migrationId FROM schema_migrations`,
+          )) as any[];
+          const rows = (res[0] ?? []) as Array<{ migrationId: string }>;
+          return rows.map((r) => r.migrationId).sort();
+        });
+        const appliedSet = new Set(applied);
+        const pending = manifest
+          .filter((m) => !appliedSet.has(m.id))
+          .map((m) => m.id);
+        perTenant.push({ companyId, applied, pending });
+      } catch (e) {
+        perTenant.push({
+          companyId,
+          applied: [],
+          pending: manifest.map((m) => m.id),
+        });
+        void e;
+      }
+    }
+    const driftDetected = perTenant.some((t) => t.pending.length > 0);
+    return {
+      manifest: manifest.map((m) => ({ id: m.id, name: m.name })),
+      perTenant,
+      driftDetected,
+    } satisfies MigrationsResponse;
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -15,6 +15,7 @@ import { AdminPredicatesController } from './admin-predicates.controller';
 import { AdminJobsController } from './admin-jobs.controller';
 import { AdminOpsController } from './admin-ops.controller';
 import { AdminInfraController } from './admin-infra.controller';
+import { AdminInfraService } from './admin-infra.service';
 import { AdminService } from './admin.service';
 import { OperatorActionService } from './operator-action.service';
 import { OperatorActionInterceptor } from './operator-action.interceptor';
@@ -54,6 +55,7 @@ import { ConfigInspectorService } from './config-inspector.service';
   ],
   providers: [
     AdminService,
+    AdminInfraService,
     ScenarioRunnerService,
     BaselineService,
     ChatRouterCacheService,

--- a/test/contracts-admin-health-components.unit-spec.ts
+++ b/test/contracts-admin-health-components.unit-spec.ts
@@ -3,6 +3,7 @@
  */
 import { HealthComponentsResponseSchema } from '../src/contracts/admin/health-components.schema';
 import { AdminInfraController } from '../src/admin/admin-infra.controller';
+import { AdminInfraService } from '../src/admin/admin-infra.service';
 import type { SurrealService } from '../src/db/surreal.service';
 import type { EmbedderService } from '../src/ai/embedder.service';
 import type { IntentClassifierService } from '../src/admin/intent-classifier.service';
@@ -37,9 +38,9 @@ function makeController(): AdminInfraController {
     get: <T>(_k: string, dflt?: T) => dflt,
   } as unknown as ConfigService;
   const undef = undefined as unknown as never;
+  const adminInfra = new AdminInfraService(surreal, undef);
   return new AdminInfraController(
-    surreal,
-    undef,
+    adminInfra,
     embedder,
     intent,
     changefeed,

--- a/test/contracts-admin-migrations.unit-spec.ts
+++ b/test/contracts-admin-migrations.unit-spec.ts
@@ -3,6 +3,7 @@
  */
 import { MigrationsResponseSchema } from '../src/contracts/admin/migrations.schema';
 import { AdminInfraController } from '../src/admin/admin-infra.controller';
+import { AdminInfraService } from '../src/admin/admin-infra.service';
 import type { SurrealService } from '../src/db/surreal.service';
 import type { ApiKeyService } from '../src/auth/api-key.service';
 
@@ -28,10 +29,10 @@ function makeController(): AdminInfraController {
   const apiKeys = {
     knownCompanyIds: () => ['tenant-a'],
   } as unknown as ApiKeyService;
+  const adminInfra = new AdminInfraService(surreal, apiKeys);
   const undef = undefined as unknown as never;
   return new AdminInfraController(
-    surreal,
-    apiKeys,
+    adminInfra,
     undef,
     undef,
     undef,

--- a/test/contracts-admin-now.unit-spec.ts
+++ b/test/contracts-admin-now.unit-spec.ts
@@ -29,7 +29,6 @@ function makeController(): AdminInfraController {
     undef,
     undef,
     undef,
-    undef,
     activity,
     undef,
     undef,

--- a/test/contracts-admin-throttler.unit-spec.ts
+++ b/test/contracts-admin-throttler.unit-spec.ts
@@ -37,7 +37,6 @@ function makeController(): AdminInfraController {
     undef,
     undef,
     undef,
-    undef,
     throttler,
     undef,
   );


### PR DESCRIPTION
## What (item C, 2/5)

`AdminInfraController` imported `SurrealService` from `src/db` (`import/no-restricted-paths` disable + TODO). Its two DB touchpoints move into a new **`AdminInfraService`**:
- `pingDb()` — the connection ping used by `healthComponents()`
- `migrationsAudit()` — the per-tenant migration/drift audit (was the whole `migrations()` body)

The controller injects the service (constructor **8→7 params**, also shedding the now-unused `ApiKeyService`) and delegates. `src/db` import + disable **removed**.

## Tests

Behaviour-identical. The **four** admin contract unit specs that construct the controller directly (`migrations` / `now` / `throttler` / `health-components`) are updated to build it through `AdminInfraService`. The #44 typecheck gate caught all four signature breaks at gate time — exactly what it's for.

## Acceptance

- `pnpm typecheck` clean · `pnpm lint` clean · `pnpm test` 700 unit · `pnpm test:e2e` 128 e2e — green.

Remaining C: `admin` / `admin-jobs` / `admin-demo` controllers (3 more PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)