### PR TITLE
refactor(admin): extract dropTenantDatabase + kill positional-undef test helpers

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -15,8 +15,6 @@ import type { AuthenticatedRequest } from '../auth/api-key.types';
 import { AdminService } from './admin.service';
 import { DreamsService } from '../dreams/dreams.service';
 import { RunDreamsDto } from '../dreams/dto/run-dreams.dto';
-// eslint-disable-next-line import/no-restricted-paths -- TODO: layer migration. Move the inline withCompany() / withAdminDb() queries below into a dedicated admin service, then drop this import. New controllers MUST NOT import db/* directly.
-import { SurrealService } from '../db/surreal.service';
 import { ChatRouterCacheService } from './chat-router-cache.service';
 import { CollapsePatternService } from './collapse-pattern.service';
 import { IntentClassifierService } from './intent-classifier.service';
@@ -57,13 +55,12 @@ import type {
 export class AdminController {
   // TODO: pre-existing god-controller. Split the surface into
   // AdminFactsController / AdminEntitiesController / AdminRouterController
-  // and the DI list shrinks naturally. Tracked separately so the new
-  // import/no-restricted-paths + max-params gates work for new code.
+  // and the DI list shrinks naturally; until then the constructor still
+  // injects 9 collaborators, over the max-params gate.
   // eslint-disable-next-line max-params
   constructor(
     private readonly admin: AdminService,
     private readonly dreams: DreamsService,
-    private readonly surreal: SurrealService,
     private readonly routeCache: ChatRouterCacheService,
     private readonly collapsePatterns: CollapsePatternService,
     private readonly intentClassifier: IntentClassifierService,
@@ -300,7 +297,7 @@ export class AdminController {
         `Only ephemeral eval_* tenants can be dropped via admin API`,
       );
     }
-    await this.surreal.dropCompanyDatabase(companyId);
+    await this.admin.dropTenantDatabase(companyId);
     return { dropped: companyId } satisfies DropTenantResponse;
   }
 }

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -748,6 +748,15 @@ export class AdminService {
       };
     });
   }
+
+  /**
+   * Drop a tenant's entire per-tenant database. The caller is responsible
+   * for authorising this (the admin API restricts it to ephemeral eval_*
+   * tenants) — this just performs the DB-level teardown.
+   */
+  async dropTenantDatabase(companyId: string): Promise<void> {
+    await this.surreal.dropCompanyDatabase(companyId);
+  }
 }
 
 function countOf(stmtResult: any): number {

--- a/test/contracts-admin-audit-page.unit-spec.ts
+++ b/test/contracts-admin-audit-page.unit-spec.ts
@@ -2,7 +2,8 @@
  * Wire-contract drift guard for GET /v1/admin/audit.
  */
 import { AuditPageResponseSchema } from '../src/contracts/admin/audit-page.schema';
-import { AdminController } from '../src/admin/admin.controller';
+import { makeAdminController } from './helpers/admin-controllers';
+import type { AdminController } from '../src/admin/admin.controller';
 import type { AdminService } from '../src/admin/admin.service';
 
 function makeController(): AdminController {
@@ -27,11 +28,7 @@ function makeController(): AdminController {
       hourly: [{ hour: '2026-06-22T15', count: 1 }],
     }),
   } as unknown as AdminService;
-  const undef = undefined as unknown as never;
-   
-  return new AdminController(
-    admin, undef, undef, undef, undef, undef, undef, undef, undef, undef,
-  );
+  return makeAdminController({ admin });
 }
 
 describe('AdminController.audit() — wire contract', () => {

--- a/test/contracts-admin-calibration.unit-spec.ts
+++ b/test/contracts-admin-calibration.unit-spec.ts
@@ -5,7 +5,8 @@
  * without (the disabled flow). Schema is flat, both must parse.
  */
 import { CalibrationResponseSchema } from '../src/contracts/admin/calibration.schema';
-import { AdminController } from '../src/admin/admin.controller';
+import { makeAdminController } from './helpers/admin-controllers';
+import type { AdminController } from '../src/admin/admin.controller';
 import type { CalibrationService } from '../src/ai/calibration/calibration.service';
 import type { CalibrationRefitService } from '../src/ai/calibration/calibration-refit.service';
 
@@ -13,11 +14,7 @@ function makeController(
   calibration: CalibrationService,
   refit: CalibrationRefitService,
 ): AdminController {
-  const undef = undefined as unknown as never;
-   
-  return new AdminController(
-    undef, undef, undef, undef, undef, undef, undef, undef, calibration, refit,
-  );
+  return makeAdminController({ calibration, calibrationRefit: refit });
 }
 
 describe('AdminController.calibrationStats() — wire contract', () => {

--- a/test/contracts-admin-cost.unit-spec.ts
+++ b/test/contracts-admin-cost.unit-spec.ts
@@ -2,7 +2,8 @@
  * Wire-contract drift guard for GET /v1/admin/cost.
  */
 import { CostResponseSchema } from '../src/contracts/admin/cost.schema';
-import { AdminController } from '../src/admin/admin.controller';
+import { makeAdminController } from './helpers/admin-controllers';
+import type { AdminController } from '../src/admin/admin.controller';
 import type { AdminService } from '../src/admin/admin.service';
 
 function makeController(): AdminController {
@@ -36,11 +37,7 @@ function makeController(): AdminController {
       source: 'metrics' as const,
     }),
   } as unknown as AdminService;
-  const undef = undefined as unknown as never;
-   
-  return new AdminController(
-    admin, undef, undef, undef, undef, undef, undef, undef, undef, undef,
-  );
+  return makeAdminController({ admin });
 }
 
 describe('AdminController.cost() — wire contract', () => {

--- a/test/contracts-admin-health-components.unit-spec.ts
+++ b/test/contracts-admin-health-components.unit-spec.ts
@@ -2,7 +2,8 @@
  * Wire-contract drift guard for GET /v1/admin/health/components.
  */
 import { HealthComponentsResponseSchema } from '../src/contracts/admin/health-components.schema';
-import { AdminInfraController } from '../src/admin/admin-infra.controller';
+import { makeAdminInfraController } from './helpers/admin-controllers';
+import type { AdminInfraController } from '../src/admin/admin-infra.controller';
 import { AdminInfraService } from '../src/admin/admin-infra.service';
 import type { SurrealService } from '../src/db/surreal.service';
 import type { EmbedderService } from '../src/ai/embedder.service';
@@ -37,17 +38,8 @@ function makeController(): AdminInfraController {
   const config = {
     get: <T>(_k: string, dflt?: T) => dflt,
   } as unknown as ConfigService;
-  const undef = undefined as unknown as never;
-  const adminInfra = new AdminInfraService(surreal, undef);
-  return new AdminInfraController(
-    adminInfra,
-    embedder,
-    intent,
-    changefeed,
-    undef,
-    undef,
-    config,
-  );
+  const adminInfra = new AdminInfraService(surreal, undefined as never);
+  return makeAdminInfraController({ adminInfra, embedder, intent, changefeed, config });
 }
 
 describe('AdminInfraController.healthComponents() — wire contract', () => {

--- a/test/contracts-admin-migrations.unit-spec.ts
+++ b/test/contracts-admin-migrations.unit-spec.ts
@@ -2,7 +2,8 @@
  * Wire-contract drift guard for GET /v1/admin/migrations.
  */
 import { MigrationsResponseSchema } from '../src/contracts/admin/migrations.schema';
-import { AdminInfraController } from '../src/admin/admin-infra.controller';
+import { makeAdminInfraController } from './helpers/admin-controllers';
+import type { AdminInfraController } from '../src/admin/admin-infra.controller';
 import { AdminInfraService } from '../src/admin/admin-infra.service';
 import type { SurrealService } from '../src/db/surreal.service';
 import type { ApiKeyService } from '../src/auth/api-key.service';
@@ -30,16 +31,7 @@ function makeController(): AdminInfraController {
     knownCompanyIds: () => ['tenant-a'],
   } as unknown as ApiKeyService;
   const adminInfra = new AdminInfraService(surreal, apiKeys);
-  const undef = undefined as unknown as never;
-  return new AdminInfraController(
-    adminInfra,
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
-  );
+  return makeAdminInfraController({ adminInfra });
 }
 
 describe('AdminInfraController.migrations() — wire contract', () => {

--- a/test/contracts-admin-now.unit-spec.ts
+++ b/test/contracts-admin-now.unit-spec.ts
@@ -2,7 +2,8 @@
  * Wire-contract drift guard for GET /v1/admin/now.
  */
 import { NowResponseSchema } from '../src/contracts/admin/now.schema';
-import { AdminInfraController } from '../src/admin/admin-infra.controller';
+import { makeAdminInfraController } from './helpers/admin-controllers';
+import type { AdminInfraController } from '../src/admin/admin-infra.controller';
 import type { ActivityTrackerService } from '../src/common/activity-tracker.service';
 
 function makeController(): AdminInfraController {
@@ -23,16 +24,7 @@ function makeController(): AdminInfraController {
       },
     ],
   } as unknown as ActivityTrackerService;
-  const undef = undefined as unknown as never;
-  return new AdminInfraController(
-    undef,
-    undef,
-    undef,
-    undef,
-    activity,
-    undef,
-    undef,
-  );
+  return makeAdminInfraController({ activity });
 }
 
 describe('AdminInfraController.now() — wire contract', () => {

--- a/test/contracts-admin-overview.unit-spec.ts
+++ b/test/contracts-admin-overview.unit-spec.ts
@@ -3,7 +3,8 @@
  * See contracts-admin-leases for the broader rationale.
  */
 import { OverviewResponseSchema } from '../src/contracts/admin/overview.schema';
-import { AdminController } from '../src/admin/admin.controller';
+import { makeAdminController } from './helpers/admin-controllers';
+import type { AdminController } from '../src/admin/admin.controller';
 import type { AdminService } from '../src/admin/admin.service';
 
 function makeController(): AdminController {
@@ -37,11 +38,7 @@ function makeController(): AdminController {
       recentForgotten: [],
     }),
   } as unknown as AdminService;
-  const undef = undefined as unknown as never;
-   
-  return new AdminController(
-    admin, undef, undef, undef, undef, undef, undef, undef, undef, undef,
-  );
+  return makeAdminController({ admin });
 }
 
 describe('AdminController.overview() — wire contract', () => {

--- a/test/contracts-admin-router-stats.unit-spec.ts
+++ b/test/contracts-admin-router-stats.unit-spec.ts
@@ -2,7 +2,8 @@
  * Wire-contract drift guard for GET /v1/admin/router/stats.
  */
 import { RouterStatsResponseSchema } from '../src/contracts/admin/router-stats.schema';
-import { AdminController } from '../src/admin/admin.controller';
+import { makeAdminController } from './helpers/admin-controllers';
+import type { AdminController } from '../src/admin/admin.controller';
 import type { ChatRouterCacheService } from '../src/admin/chat-router-cache.service';
 import type { CollapsePatternService } from '../src/admin/collapse-pattern.service';
 import type { IntentClassifierService } from '../src/admin/intent-classifier.service';
@@ -38,20 +39,12 @@ function makeController(): AdminController {
       provider: 'bge-m3',
     }),
   } as unknown as EmbedderService;
-  const undef = undefined as unknown as never;
-   
-  return new AdminController(
-    undef,
-    undef,
-    undef,
+  return makeAdminController({
     routeCache,
     collapsePatterns,
-    intent,
+    intentClassifier: intent,
     embedder,
-    undef,
-    undef,
-    undef,
-  );
+  });
 }
 
 describe('AdminController.routerStats() — wire contract', () => {

--- a/test/contracts-admin-throttler.unit-spec.ts
+++ b/test/contracts-admin-throttler.unit-spec.ts
@@ -2,7 +2,8 @@
  * Wire-contract drift guard for GET /v1/admin/throttler.
  */
 import { ThrottlerResponseSchema } from '../src/contracts/admin/throttler.schema';
-import { AdminInfraController } from '../src/admin/admin-infra.controller';
+import { makeAdminInfraController } from './helpers/admin-controllers';
+import type { AdminInfraController } from '../src/admin/admin-infra.controller';
 import type { ThrottlerObservabilityService } from '../src/admin/throttler-observability.service';
 
 function makeController(): AdminInfraController {
@@ -30,16 +31,7 @@ function makeController(): AdminInfraController {
       ],
     }),
   } as unknown as ThrottlerObservabilityService;
-  const undef = undefined as unknown as never;
-  return new AdminInfraController(
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
-    throttler,
-    undef,
-  );
+  return makeAdminInfraController({ throttler });
 }
 
 describe('AdminInfraController.throttlerView() — wire contract', () => {

--- a/test/contracts-admin-write-responses.unit-spec.ts
+++ b/test/contracts-admin-write-responses.unit-spec.ts
@@ -26,7 +26,7 @@ import {
   BaselineSaveResponseSchema,
   BaselineDiffResponseSchema,
 } from '../src/contracts/admin/write-responses.schema';
-import { AdminController } from '../src/admin/admin.controller';
+import { makeAdminController } from './helpers/admin-controllers';
 import { AdminOpsController } from '../src/admin/admin-ops.controller';
 import { AdminJobsController } from '../src/admin/admin-jobs.controller';
 import { AdminEvalController } from '../src/admin/admin-eval.controller';
@@ -46,13 +46,11 @@ function assertParses(schema: { safeParse: (x: unknown) => { success: boolean; e
 
 describe('write-side wire contracts', () => {
   it('AdminController.dropTenant() matches DropTenantResponseSchema', async () => {
-    const surreal = {
-      dropCompanyDatabase: async () => undefined,
-    } as never;
-     
-    const ctl = new AdminController(
-      undef, undef, surreal, undef, undef, undef, undef, undef, undef, undef,
-    );
+    const admin = {
+      dropTenantDatabase: async () => undefined,
+    };
+
+    const ctl = makeAdminController({ admin });
     const payload = await ctl.dropTenant('eval_test123');
     assertParses(DropTenantResponseSchema, payload, 'tenants drop');
   });
@@ -74,9 +72,7 @@ describe('write-side wire contracts', () => {
       }),
     } as never;
      
-    const ctl = new AdminController(
-      undef, dreams, undef, undef, undef, undef, undef, undef, undef, undef,
-    );
+    const ctl = makeAdminController({ dreams });
     const req = {
       brainAuth: { companyId: 'tenant-a' },
     } as unknown as AuthenticatedRequest;
@@ -96,9 +92,7 @@ describe('write-side wire contracts', () => {
       }),
     } as never;
      
-    const ctl = new AdminController(
-      undef, undef, undef, undef, undef, undef, undef, reindex, undef, undef,
-    );
+    const ctl = makeAdminController({ reindex });
     const payload = await ctl.reindexEmbeddings();
     assertParses(ReindexRunResponseSchema, payload, 'reindex/embeddings');
   });

--- a/test/helpers/admin-controllers.ts
+++ b/test/helpers/admin-controllers.ts
@@ -1,0 +1,67 @@
+/**
+ * Named-dependency builders for the admin controllers' wire-contract unit
+ * specs.
+ *
+ * The controllers are constructor-injected with many collaborators, but a
+ * given contract spec only stubs the one or two it actually calls. Passing
+ * a long run of positional `undefined`s was brittle (every constructor
+ * change shifted every spec's argument list) and unreadable. These helpers
+ * take the deps BY NAME and fill the rest with undefined, so a spec writes
+ * `makeAdminController({ reindex })` and constructor changes touch only
+ * this file.
+ */
+import { AdminController } from '../../src/admin/admin.controller';
+import { AdminInfraController } from '../../src/admin/admin-infra.controller';
+
+const u = undefined as never;
+const as = <T>(v: unknown): T => v as T;
+
+export interface AdminControllerDeps {
+  admin?: unknown;
+  dreams?: unknown;
+  routeCache?: unknown;
+  collapsePatterns?: unknown;
+  intentClassifier?: unknown;
+  embedder?: unknown;
+  reindex?: unknown;
+  calibration?: unknown;
+  calibrationRefit?: unknown;
+}
+
+export function makeAdminController(d: AdminControllerDeps = {}): AdminController {
+  return new AdminController(
+    as(d.admin ?? u),
+    as(d.dreams ?? u),
+    as(d.routeCache ?? u),
+    as(d.collapsePatterns ?? u),
+    as(d.intentClassifier ?? u),
+    as(d.embedder ?? u),
+    as(d.reindex ?? u),
+    as(d.calibration ?? u),
+    as(d.calibrationRefit ?? u),
+  );
+}
+
+export interface AdminInfraControllerDeps {
+  adminInfra?: unknown;
+  embedder?: unknown;
+  intent?: unknown;
+  changefeed?: unknown;
+  activity?: unknown;
+  throttler?: unknown;
+  config?: unknown;
+}
+
+export function makeAdminInfraController(
+  d: AdminInfraControllerDeps = {},
+): AdminInfraController {
+  return new AdminInfraController(
+    as(d.adminInfra ?? u),
+    as(d.embedder ?? u),
+    as(d.intent ?? u),
+    as(d.changefeed ?? u),
+    as(d.activity ?? u),
+    as(d.throttler ?? u),
+    as(d.config ?? u),
+  );
+}


### PR DESCRIPTION
## What (item C 3/5 + test-quality fix)

**Layer purity:** `AdminController` imported `SurrealService` from `src/db` for its one DB touchpoint (`dropCompanyDatabase` in `dropTenant()`). Moved to `AdminService.dropTenantDatabase()`; the controller delegates and the `src/db` import + `import/no-restricted-paths` disable are **removed**. (The constructor is still 9 deps — the `max-params` disable stays until the god-controller is split, which is its own tracked TODO.)

**Kills the positional-`undef` soup** in the admin controllers' contract specs (this was rightly called out — brittle + unreadable; every constructor change cascaded into ten specs). New **`test/helpers/admin-controllers.ts`** exposes `makeAdminController({...})` / `makeAdminInfraController({...})` taking deps **by name**:

```ts
// before
new AdminController(undef, undef, undef, undef, undef, undef, reindex, undef, undef)
// after
makeAdminController({ reindex })
```

A constructor change now touches **only the helper**, not ten specs. Converted all 10 admin / admin-infra contract specs.

## Acceptance

- `pnpm typecheck` clean · `pnpm lint` clean · `pnpm test` 700 unit · `pnpm test:e2e` 128 e2e — green.

Remaining C: `admin-jobs` / `admin-demo` controllers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)