### PR TITLE
refactor(*): objectify functions with >3 params (max-params=3 prep, 1/3)

### DIFF
--- a/src/admin/admin-demo.controller.ts
+++ b/src/admin/admin-demo.controller.ts
@@ -198,7 +198,7 @@ export class AdminDemoController {
         if (route.intent === 'tell') {
           return this.runTellChat(route, tenant);
         }
-        return this.runAskChat(route, body, tenant, askScopes);
+        return this.runAskChat({ route, body, tenant, scopes: askScopes });
       });
       const result = captured.result as any;
       if (result.search) {
@@ -277,12 +277,17 @@ export class AdminDemoController {
     return { route, ingest, autoDedup };
   }
 
-  private async runAskChat(
-    route: ChatRoute,
-    body: { message: string; includePii?: boolean },
-    tenant: string,
-    scopes: readonly BrainScope[],
-  ) {
+  private async runAskChat({
+    route,
+    body,
+    tenant,
+    scopes,
+  }: {
+    route: ChatRoute;
+    body: { message: string; includePii?: boolean };
+    tenant: string;
+    scopes: readonly BrainScope[];
+  }) {
     const queryText = route.cleanedQuery ?? body.message;
     const entityRefs = route.mentions.map((m) => m.canonical);
     const predicateHints = route.predicateHints.map((h) => h.predicateId);
@@ -295,14 +300,14 @@ export class AdminDemoController {
     // fact even though Acme itself has no status fact — the answer
     // is one edge away.
     const graph = await traceSpan('demo.graph_first', () =>
-      this.search.graphRetrieve(
-        tenant,
+      this.search.graphRetrieve({
+        companyId: tenant,
         queryText,
         entityRefs,
         predicateHints,
         asOf,
-        scopes as string[],
-      ),
+        callerScopes: scopes as string[],
+      }),
     );
     const graphHasFacts = graph.results.some(
       (r) => Array.isArray(r.facts) && r.facts.length > 0,

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -144,17 +144,15 @@ export class AdminService {
     // Parallel fan-out — sequential was N × per-tenant-Surreal-RTT which
     // turned the overview into a 5s+ page under 20 tenants. Cap at
     // TENANT_FANOUT so we don't drain the Surreal pool either.
-    const tenantResults = await mapWithLimit(
-      tenants,
-      TENANT_FANOUT,
-      (companyId) => this.collectTenant(companyId, dayAgoIso),
-      {
-        onError: (err, companyId) =>
-          this.logger.warn(
-            `Failed to collect admin overview for ${companyId}: ${err.message}`,
-          ),
-      },
-    );
+    const tenantResults = await mapWithLimit({
+      items: tenants,
+      concurrency: TENANT_FANOUT,
+      fn: (companyId) => this.collectTenant(companyId, dayAgoIso),
+      onError: (err, companyId) =>
+        this.logger.warn(
+          `Failed to collect admin overview for ${companyId}: ${err.message}`,
+        ),
+    });
     tenants.forEach((companyId, i) => {
       const data = tenantResults[i];
       if (!data) {
@@ -401,10 +399,10 @@ export class AdminService {
       params.reason = filter.reason;
     }
     const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
-    const perTenant = await mapWithLimit(
-      tenants,
-      TENANT_FANOUT,
-      async (companyId) => {
+    const perTenant = await mapWithLimit({
+      items: tenants,
+      concurrency: TENANT_FANOUT,
+      fn: async (companyId) => {
         const rows = await this.surreal.withCompany(companyId, async (db) => {
           const res = (await db.query<any[]>(
             `SELECT id, reason, rejectedAt, payload
@@ -422,13 +420,11 @@ export class AdminService {
           payload: r.payload ?? {},
         }));
       },
-      {
-        onError: (err, companyId) =>
-          this.logger.warn(
-            `dead-letter list failed for ${companyId}: ${err.message}`,
-          ),
-      },
-    );
+      onError: (err, companyId) =>
+        this.logger.warn(
+          `dead-letter list failed for ${companyId}: ${err.message}`,
+        ),
+    });
     for (const batch of perTenant) {
       if (batch) out.push(...batch);
     }
@@ -484,10 +480,10 @@ export class AdminService {
     }
     const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
     const out: AdminForgottenRow[] = [];
-    const perTenant = await mapWithLimit(
-      tenants,
-      TENANT_FANOUT,
-      async (companyId) => {
+    const perTenant = await mapWithLimit({
+      items: tenants,
+      concurrency: TENANT_FANOUT,
+      fn: async (companyId) => {
         const rows = await this.surreal.withCompany(companyId, async (db) => {
           const res = (await db.query<any[]>(
             `SELECT entityIdHash, reason, forgottenAt, factsDeleted, edgesDeleted
@@ -506,13 +502,11 @@ export class AdminService {
           edgesDeleted: r.edgesDeleted ?? 0,
         }));
       },
-      {
-        onError: (err, companyId) =>
-          this.logger.warn(
-            `forgotten list failed for ${companyId}: ${err.message}`,
-          ),
-      },
-    );
+      onError: (err, companyId) =>
+        this.logger.warn(
+          `forgotten list failed for ${companyId}: ${err.message}`,
+        ),
+    });
     for (const batch of perTenant) {
       if (batch) out.push(...batch);
     }
@@ -627,10 +621,10 @@ export class AdminService {
       ? `WHERE ${whereClauses.join(' AND ')}`
       : '';
 
-    const perTenant = await mapWithLimit(
-      tenants,
-      TENANT_FANOUT,
-      async (companyId) => {
+    const perTenant = await mapWithLimit({
+      items: tenants,
+      concurrency: TENANT_FANOUT,
+      fn: async (companyId) => {
         const rows = await this.surreal.withCompany(companyId, async (db) => {
           const sql = `
             SELECT id, source, recordId, op, ts, versionstamp, before, after, consumedBy
@@ -655,13 +649,11 @@ export class AdminService {
           },
         }));
       },
-      {
-        onError: (err, companyId) =>
-          this.logger.warn(
-            `listAuditEvents failed for ${companyId}: ${err.message}`,
-          ),
-      },
-    );
+      onError: (err, companyId) =>
+        this.logger.warn(
+          `listAuditEvents failed for ${companyId}: ${err.message}`,
+        ),
+    });
     for (const batch of perTenant) {
       if (!batch) continue;
       for (const { row } of batch) {

--- a/src/admin/chat-router-internals/local-prepass.ts
+++ b/src/admin/chat-router-internals/local-prepass.ts
@@ -73,28 +73,40 @@ export function extractMentionsLocally(
   // so the full form wins when both substrings are present.
   const namesByLength = [...knownNames].sort((a, b) => b.length - a.length);
   for (const canonical of namesByLength) {
-    matchCanonicalForm(canonical, message, lowerMessage, occupied, accepted);
-    matchFirstTokenForm(
+    matchCanonicalForm({
+      canonical,
+      message,
+      lowerMessage,
+      occupied,
+      accepted,
+    });
+    matchFirstTokenForm({
       canonical,
       knownNames,
       message,
       lowerMessage,
       occupied,
       accepted,
-    );
+    });
   }
   return accepted;
 }
 
 /** Scan the message for the full canonical form. Honours `occupied`
  *  so longer matches recorded earlier in the pass win. */
-function matchCanonicalForm(
-  canonical: string,
-  message: string,
-  lowerMessage: string,
-  occupied: Array<[number, number]>,
-  accepted: MentionMatch[],
-): void {
+function matchCanonicalForm({
+  canonical,
+  message,
+  lowerMessage,
+  occupied,
+  accepted,
+}: {
+  canonical: string;
+  message: string;
+  lowerMessage: string;
+  occupied: Array<[number, number]>;
+  accepted: MentionMatch[];
+}): void {
   const needle = canonical.toLowerCase();
   if (needle.length < 2) return;
   let from = 0;
@@ -102,14 +114,7 @@ function matchCanonicalForm(
     const idx = lowerMessage.indexOf(needle, from);
     if (idx < 0) return;
     const end = idx + needle.length;
-    pushIfFree(
-      canonical,
-      message,
-      idx,
-      end,
-      occupied,
-      accepted,
-    );
+    pushIfFree({ canonical, message, start: idx, end, occupied, accepted });
     from = end;
   }
 }
@@ -119,14 +124,21 @@ function matchCanonicalForm(
  * "Maria Petrov"). Skipped when the first token clashes with another
  * knownName's first token (ambiguous case — leave it to the LLM).
  */
-function matchFirstTokenForm(
-  canonical: string,
-  knownNames: string[],
-  message: string,
-  lowerMessage: string,
-  occupied: Array<[number, number]>,
-  accepted: MentionMatch[],
-): void {
+function matchFirstTokenForm({
+  canonical,
+  knownNames,
+  message,
+  lowerMessage,
+  occupied,
+  accepted,
+}: {
+  canonical: string;
+  knownNames: string[];
+  message: string;
+  lowerMessage: string;
+  occupied: Array<[number, number]>;
+  accepted: MentionMatch[];
+}): void {
   const tokens = canonical.split(/\s+/).filter(Boolean);
   if (tokens.length <= 1) return;
   const firstToken = tokens[0];
@@ -139,7 +151,7 @@ function matchFirstTokenForm(
     if (idx < 0) return;
     const end = idx + needle.length;
     if (isWordBoundary(message, idx, end)) {
-      pushIfFree(canonical, message, idx, end, occupied, accepted);
+      pushIfFree({ canonical, message, start: idx, end, occupied, accepted });
     }
     from = end;
   }
@@ -168,14 +180,21 @@ function isWordChar(c: string): boolean {
   return /[\p{L}\p{N}]/u.test(c);
 }
 
-function pushIfFree(
-  canonical: string,
-  message: string,
-  start: number,
-  end: number,
-  occupied: Array<[number, number]>,
-  accepted: MentionMatch[],
-): void {
+function pushIfFree({
+  canonical,
+  message,
+  start,
+  end,
+  occupied,
+  accepted,
+}: {
+  canonical: string;
+  message: string;
+  start: number;
+  end: number;
+  occupied: Array<[number, number]>;
+  accepted: MentionMatch[];
+}): void {
   if (occupied.some(([s, e]) => !(end <= s || start >= e))) return;
   accepted.push({
     canonical,
@@ -202,13 +221,21 @@ function pushIfFree(
  * Failure modes degrade silently to empty hints — the LLM still
  * produces its own hints and validation handles missing slots.
  */
-export async function extractPredicateHintsLocally(
-  message: string,
-  snapshot: PredicateSnapshot | null,
-  embedder: EmbedderService,
-  threshold: number,
-  maxHints: number,
-): Promise<
+export interface ExtractPredicateHintsLocallyOptions {
+  message: string;
+  snapshot: PredicateSnapshot | null;
+  embedder: EmbedderService;
+  threshold: number;
+  maxHints: number;
+}
+
+export async function extractPredicateHintsLocally({
+  message,
+  snapshot,
+  embedder,
+  threshold,
+  maxHints,
+}: ExtractPredicateHintsLocallyOptions): Promise<
   Array<{ predicateId: string; similarity: number; triggerSpan: Span }>
 > {
   if (!snapshot || snapshot.embeddings.size === 0) return [];

--- a/src/admin/chat-router-internals/validator.ts
+++ b/src/admin/chat-router-internals/validator.ts
@@ -149,12 +149,19 @@ export function extractJsonObject(raw: string): string {
  *   5. Auto-derive strip_temporal from grounded anchors.
  *   6. Apply edits → normalizedMessage + cleanedQuery (ask only).
  */
-export function validateAndAssemble(
-  message: string,
-  parsed: RawRouteOutput,
-  vocab: Set<string>,
-  knownNames: Set<string>,
-): ChatRoute {
+export interface ValidateAndAssembleOptions {
+  message: string;
+  parsed: RawRouteOutput;
+  vocab: Set<string>;
+  knownNames: Set<string>;
+}
+
+export function validateAndAssemble({
+  message,
+  parsed,
+  vocab,
+  knownNames,
+}: ValidateAndAssembleOptions): ChatRoute {
   const normalizedInput = nfc(message);
   const report: ValidationReport = {
     acceptedEdits: 0,
@@ -167,33 +174,33 @@ export function validateAndAssemble(
     validFromStatus: 'absent',
   };
 
-  const mentions = collectMentions(
+  const mentions = collectMentions({
     parsed,
     message,
     normalizedInput,
     knownNames,
     report,
-  );
-  const predicateHints = collectPredicateHints(
+  });
+  const predicateHints = collectPredicateHints({
     parsed,
     message,
     normalizedInput,
     vocab,
     report,
-  );
-  const { asOf, validFrom } = collectTemporalAnchors(
+  });
+  const { asOf, validFrom } = collectTemporalAnchors({
     parsed,
     message,
     normalizedInput,
     report,
-  );
-  const acceptedEdits = collectEdits(
+  });
+  const acceptedEdits = collectEdits({
     parsed,
     message,
     normalizedInput,
     mentions,
     report,
-  );
+  });
   const autoStripEdits = deriveStripTemporalEdits(
     acceptedEdits.map((c) => c.span),
     asOf,
@@ -223,13 +230,19 @@ export function validateAndAssemble(
   };
 }
 
-function collectMentions(
-  parsed: RawRouteOutput,
-  message: string,
-  normalizedInput: string,
-  knownNames: Set<string>,
-  report: ValidationReport,
-): Array<{ canonical: string; span: Span }> {
+function collectMentions({
+  parsed,
+  message,
+  normalizedInput,
+  knownNames,
+  report,
+}: {
+  parsed: RawRouteOutput;
+  message: string;
+  normalizedInput: string;
+  knownNames: Set<string>;
+  report: ValidationReport;
+}): Array<{ canonical: string; span: Span }> {
   const mentions: Array<{ canonical: string; span: Span }> = [];
   for (const m of parsed.mentions ?? []) {
     const span = validateSpan(message, normalizedInput, m.nameSpan);
@@ -255,13 +268,19 @@ function collectMentions(
   return mentions;
 }
 
-function collectPredicateHints(
-  parsed: RawRouteOutput,
-  message: string,
-  normalizedInput: string,
-  vocab: Set<string>,
-  report: ValidationReport,
-): Array<{ predicateId: string; triggerSpan: Span }> {
+function collectPredicateHints({
+  parsed,
+  message,
+  normalizedInput,
+  vocab,
+  report,
+}: {
+  parsed: RawRouteOutput;
+  message: string;
+  normalizedInput: string;
+  vocab: Set<string>;
+  report: ValidationReport;
+}): Array<{ predicateId: string; triggerSpan: Span }> {
   const out: Array<{ predicateId: string; triggerSpan: Span }> = [];
   if (parsed.intent !== 'ask') return out;
   for (const h of parsed.predicateHints ?? []) {
@@ -288,12 +307,17 @@ function collectPredicateHints(
   return out;
 }
 
-function collectTemporalAnchors(
-  parsed: RawRouteOutput,
-  message: string,
-  normalizedInput: string,
-  report: ValidationReport,
-): { asOf?: TemporalAnchor; validFrom?: TemporalAnchor } {
+function collectTemporalAnchors({
+  parsed,
+  message,
+  normalizedInput,
+  report,
+}: {
+  parsed: RawRouteOutput;
+  message: string;
+  normalizedInput: string;
+  report: ValidationReport;
+}): { asOf?: TemporalAnchor; validFrom?: TemporalAnchor } {
   let asOf: TemporalAnchor | undefined;
   if (parsed.intent === 'ask' && parsed.asOf) {
     const span = validateSpan(message, normalizedInput, parsed.asOf.anchorSpan);
@@ -321,13 +345,19 @@ function collectTemporalAnchors(
   return { asOf, validFrom };
 }
 
-function collectEdits(
-  parsed: RawRouteOutput,
-  message: string,
-  normalizedInput: string,
-  mentions: Array<{ canonical: string; span: Span }>,
-  report: ValidationReport,
-): Array<{ edit: EditOp; span: Span }> {
+function collectEdits({
+  parsed,
+  message,
+  normalizedInput,
+  mentions,
+  report,
+}: {
+  parsed: RawRouteOutput;
+  message: string;
+  normalizedInput: string;
+  mentions: Array<{ canonical: string; span: Span }>;
+  report: ValidationReport;
+}): Array<{ edit: EditOp; span: Span }> {
   // Synthesise canonicalize_mention 1:1 from accepted mentions, then
   // validate LLM-emitted collapse_state_change edits. Edits whose
   // sourceSpan overlaps another accepted edit are dropped right-to-left

--- a/src/admin/chat-router.service.ts
+++ b/src/admin/chat-router.service.ts
@@ -177,13 +177,13 @@ export class ChatRouterService {
       now: refDate,
     });
 
-    const localHints = await extractPredicateHintsLocally(
+    const localHints = await extractPredicateHintsLocally({
       message,
       snapshot,
-      this.embedder,
-      this.hintSimilarityThreshold,
-      this.hintMaxCount,
-    );
+      embedder: this.embedder,
+      threshold: this.hintSimilarityThreshold,
+      maxHints: this.hintMaxCount,
+    });
     traceArtifact('demo.chat.local_hints', {
       hints: localHints,
       threshold: this.hintSimilarityThreshold,
@@ -281,12 +281,12 @@ export class ChatRouterService {
 
     if (skipDecision.skip) {
       const synthetic = this.buildSyntheticRoute(ctx, skipDecision.reason);
-      const route = validateAndAssemble(
+      const route = validateAndAssemble({
         message,
-        synthetic,
-        new Set(ctx.predicateVocab),
-        new Set(ctx.knownNames),
-      );
+        parsed: synthetic,
+        vocab: new Set(ctx.predicateVocab),
+        knownNames: new Set(ctx.knownNames),
+      });
       this.routeCache.set(ctx.cacheKey, route);
       return route;
     }
@@ -303,12 +303,12 @@ export class ChatRouterService {
     }
 
     const merged = this.mergeLlmWithLocals(llmOut.parsed, ctx);
-    const route = validateAndAssemble(
+    const route = validateAndAssemble({
       message,
-      merged,
-      new Set(ctx.predicateVocab),
-      new Set(ctx.knownNames),
-    );
+      parsed: merged,
+      vocab: new Set(ctx.predicateVocab),
+      knownNames: new Set(ctx.knownNames),
+    });
     this.routeCache.set(ctx.cacheKey, route);
 
     void this.teachCollapsePatterns(message, ctx, llmOut.parsed);

--- a/src/admin/operator-action.interceptor.ts
+++ b/src/admin/operator-action.interceptor.ts
@@ -39,21 +39,29 @@ export class OperatorActionInterceptor implements NestInterceptor {
     const startedAt = Date.now();
     return next.handle().pipe(
       tap({
-        next: () => this.maybeRecord(req, res, path, isAdminRoute, isSelf, startedAt),
+        next: () =>
+          this.maybeRecord({ req, res, path, isAdminRoute, isSelf, startedAt }),
         error: () =>
-          this.maybeRecord(req, res, path, isAdminRoute, isSelf, startedAt),
+          this.maybeRecord({ req, res, path, isAdminRoute, isSelf, startedAt }),
       }),
     );
   }
 
-  private maybeRecord(
-    req: Request & Partial<AuthenticatedRequest>,
-    res: Response,
-    path: string,
-    isAdminRoute: boolean,
-    isSelf: boolean,
-    startedAt: number,
-  ): void {
+  private maybeRecord({
+    req,
+    res,
+    path,
+    isAdminRoute,
+    isSelf,
+    startedAt,
+  }: {
+    req: Request & Partial<AuthenticatedRequest>;
+    res: Response;
+    path: string;
+    isAdminRoute: boolean;
+    isSelf: boolean;
+    startedAt: number;
+  }): void {
     if (!isAdminRoute || isSelf) return;
     const brainAuth = req.brainAuth;
     if (!brainAuth?.companyId) return;

--- a/src/admin/scenario-runner.service.ts
+++ b/src/admin/scenario-runner.service.ts
@@ -205,7 +205,12 @@ export class ScenarioRunnerService {
       for (let i = 0; i < scenario.setup.length; i++) {
         const step = scenario.setup[i];
         try {
-          await this.applyStep(companyId, step, setupSummary, factIdsByTag);
+          await this.applyStep({
+            companyId,
+            step,
+            summary: setupSummary,
+            factIdsByTag,
+          });
         } catch (e) {
           setupSummary.errors.push({
             step: i,
@@ -314,12 +319,17 @@ export class ScenarioRunnerService {
     return [];
   }
 
-  private async applyStep(
-    companyId: string,
-    step: SetupStep,
-    summary: ScenarioRunOutcome['setupSummary'],
-    factIdsByTag: Map<string, string>,
-  ): Promise<void> {
+  private async applyStep({
+    companyId,
+    step,
+    summary,
+    factIdsByTag,
+  }: {
+    companyId: string;
+    step: SetupStep;
+    summary: ScenarioRunOutcome['setupSummary'];
+    factIdsByTag: Map<string, string>;
+  }): Promise<void> {
     switch (step.kind) {
       case 'fact': {
         await this.applyFact(companyId, step, factIdsByTag);
@@ -392,9 +402,13 @@ export class ScenarioRunnerService {
     if (!factId) {
       throw new Error(`Retract references unknown tag '${step.tag}'`);
     }
-    await this.facts.retract(companyId, factId, {
-      reason: step.reason,
-      retractedBy: { source: 'system' },
+    await this.facts.retract({
+      companyId,
+      factId,
+      dto: {
+        reason: step.reason,
+        retractedBy: { source: 'system' },
+      },
     });
   }
 
@@ -410,9 +424,13 @@ export class ScenarioRunnerService {
     if (!hit) {
       throw new Error(`Forget could not resolve ${refKey}`);
     }
-    await this.entities.forget(companyId, hit, {
-      reason: step.reason,
-      requestId: step.requestId,
+    await this.entities.forget({
+      companyId,
+      entityIdRaw: hit,
+      dto: {
+        reason: step.reason,
+        requestId: step.requestId,
+      },
     });
   }
 

--- a/src/admin/throttler-observability.interceptor.ts
+++ b/src/admin/throttler-observability.interceptor.ts
@@ -38,21 +38,34 @@ export class ThrottlerObservabilityInterceptor implements NestInterceptor {
     }
     return next.handle().pipe(
       tap({
-        next: () => this.observability.record(this.buildInput(req, res, path, false)),
+        next: () =>
+          this.observability.record(
+            this.buildInput({ req, res, path, forceThrottled: false }),
+          ),
         error: (err) =>
           this.observability.record(
-            this.buildInput(req, res, path, err?.status === 429),
+            this.buildInput({
+              req,
+              res,
+              path,
+              forceThrottled: err?.status === 429,
+            }),
           ),
       }),
     );
   }
 
-  private buildInput(
-    req: Request & Partial<AuthenticatedRequest>,
-    res: Response,
-    path: string,
-    forceThrottled: boolean,
-  ): {
+  private buildInput({
+    req,
+    res,
+    path,
+    forceThrottled,
+  }: {
+    req: Request & Partial<AuthenticatedRequest>;
+    res: Response;
+    path: string;
+    forceThrottled: boolean;
+  }): {
     actor: string;
     method: string;
     path: string;

--- a/src/ai/extractor-internals/local-synth.ts
+++ b/src/ai/extractor-internals/local-synth.ts
@@ -51,19 +51,27 @@ function entityIndexForFact(
  *     and aren't a self-edge
  * Returns null if any check fails — caller falls back to the LLM.
  */
-export async function attemptLocalSynth(
-  patterns: ExtractionPatternService,
-  companyId: string,
-  inputText: string,
-  clauseTexts: string[],
+export interface AttemptLocalSynthOptions {
+  patterns: ExtractionPatternService;
+  companyId: string;
+  inputText: string;
+  clauseTexts: string[];
   localEntities: Array<{
     text: string;
     type: string;
     start: number;
     end: number;
     score: number;
-  }>,
-): Promise<ExtractionResult | null> {
+  }>;
+}
+
+export async function attemptLocalSynth({
+  patterns,
+  companyId,
+  inputText,
+  clauseTexts,
+  localEntities,
+}: AttemptLocalSynthOptions): Promise<ExtractionResult | null> {
   const facts: ExtractedFact[] = [];
   const edges: ExtractedEdge[] = [];
   const normalizedInput = normalizeForGrounding(inputText);

--- a/src/ai/extractor-internals/pattern-emitter.ts
+++ b/src/ai/extractor-internals/pattern-emitter.ts
@@ -18,15 +18,25 @@ import type {
  * Fire-and-forget: failure logs but doesn't fail the current
  * extraction. The cache will simply stay cold for those clauses.
  */
-export async function persistExtractionPatterns(
-  patterns: ExtractionPatternService,
-  logger: Logger,
-  companyId: string,
-  clauses: string[],
-  rawFacts: RawExtractedFact[],
-  facts: ExtractedFact[],
-  edges: ExtractedEdge[],
-): Promise<void> {
+export interface PersistExtractionPatternsOptions {
+  patterns: ExtractionPatternService;
+  logger: Logger;
+  companyId: string;
+  clauses: string[];
+  rawFacts: RawExtractedFact[];
+  facts: ExtractedFact[];
+  edges: ExtractedEdge[];
+}
+
+export async function persistExtractionPatterns({
+  patterns,
+  logger,
+  companyId,
+  clauses,
+  rawFacts,
+  facts,
+  edges,
+}: PersistExtractionPatternsOptions): Promise<void> {
   const entries: ExtractionPatternEntry[] = [];
   const factsByClause = new Map<number, RawExtractedFact[]>();
   for (const rf of rawFacts) {

--- a/src/ai/extractor-internals/predicate-canonicalize.ts
+++ b/src/ai/extractor-internals/predicate-canonicalize.ts
@@ -15,12 +15,19 @@ import type { ExtractedFact } from './types';
  * Mutates facts in place — predicate field is overwritten on hit.
  * Returns the override-decision list for trace emission.
  */
-export async function applyLocalPredicateOverrides(
-  facts: ExtractedFact[],
-  snapshot: PredicateSnapshot | null,
-  selector: LocalPredicateSelectorService,
-  threshold: number,
-): Promise<
+export interface ApplyLocalPredicateOverridesOptions {
+  facts: ExtractedFact[];
+  snapshot: PredicateSnapshot | null;
+  selector: LocalPredicateSelectorService;
+  threshold: number;
+}
+
+export async function applyLocalPredicateOverrides({
+  facts,
+  snapshot,
+  selector,
+  threshold,
+}: ApplyLocalPredicateOverridesOptions): Promise<
   Array<{ original: string; override: string; similarity: number }>
 > {
   const overrides: Array<{
@@ -54,12 +61,19 @@ export async function applyLocalPredicateOverrides(
  * Defensive: per-fact errors are logged but don't fail the pass.
  * Returns the non-trivial decisions for trace emission.
  */
-export async function applyCanonicalizePass(
-  facts: ExtractedFact[],
-  registry: PredicateRegistryService,
-  companyId: string,
-  logger: Logger,
-): Promise<
+export interface ApplyCanonicalizePassOptions {
+  facts: ExtractedFact[];
+  registry: PredicateRegistryService;
+  companyId: string;
+  logger: Logger;
+}
+
+export async function applyCanonicalizePass({
+  facts,
+  registry,
+  companyId,
+  logger,
+}: ApplyCanonicalizePassOptions): Promise<
   Array<{
     original: string;
     canonical: string;

--- a/src/ai/extractor.service.ts
+++ b/src/ai/extractor.service.ts
@@ -410,13 +410,13 @@ export class ExtractorService {
       });
       return null;
     }
-    const synthesised = await attemptLocalSynth(
-      this.extractionPatterns,
+    const synthesised = await attemptLocalSynth({
+      patterns: this.extractionPatterns,
       companyId,
-      trimmed,
-      localClauses.map((c) => c.text),
+      inputText: trimmed,
+      clauseTexts: localClauses.map((c) => c.text),
       localEntities,
-    );
+    });
     if (!synthesised) {
       traceArtifact('extractor.skip_decision', {
         skip: false,
@@ -567,15 +567,15 @@ export class ExtractorService {
     const result: ExtractionResult = { entities, facts, edges };
     this.extractionCache.set(cacheKey, result);
 
-    void persistExtractionPatterns(
-      this.extractionPatterns,
-      this.logger,
+    void persistExtractionPatterns({
+      patterns: this.extractionPatterns,
+      logger: this.logger,
       companyId,
       clauses,
       rawFacts,
       facts,
       edges,
-    );
+    });
 
     return result;
   }
@@ -591,12 +591,12 @@ export class ExtractorService {
         '0.45',
       ),
     );
-    const localOverrides = await applyLocalPredicateOverrides(
+    const localOverrides = await applyLocalPredicateOverrides({
       facts,
-      snapshot as PredicateSnapshot,
-      this.localPredicates,
-      localThreshold,
-    );
+      snapshot: snapshot as PredicateSnapshot,
+      selector: this.localPredicates,
+      threshold: localThreshold,
+    });
     if (localOverrides.length > 0) {
       traceArtifact('extractor.local_predicate_override', {
         threshold: localThreshold,
@@ -605,12 +605,12 @@ export class ExtractorService {
     }
     try {
       if (facts.length === 0) return;
-      const decisions = await applyCanonicalizePass(
+      const decisions = await applyCanonicalizePass({
         facts,
-        this.registry,
+        registry: this.registry,
         companyId,
-        this.logger,
-      );
+        logger: this.logger,
+      });
       if (decisions.length > 0) {
         traceArtifact('extractor.canonicalize', decisions);
       }

--- a/src/ai/reranker.service.ts
+++ b/src/ai/reranker.service.ts
@@ -114,7 +114,7 @@ export class RerankerService {
 
     if (this.scN === 1) {
       // Single-call path. Identity ordering — no shuffle.
-      return this.singleRerank(query, candidates, identity, hints);
+      return this.singleRerank({ query, candidates, presentationOrder: identity, hints });
     }
 
     // Permutation self-consistency: run scN calls in parallel with
@@ -126,7 +126,9 @@ export class RerankerService {
       shuffle(candidates.map((_, i) => i)),
     );
     const settled = await Promise.allSettled(
-      orderings.map((ord) => this.singleRerank(query, candidates, ord, hints)),
+      orderings.map((ord) =>
+        this.singleRerank({ query, candidates, presentationOrder: ord, hints }),
+      ),
     );
     const rankings: number[][] = [];
     for (const s of settled) {
@@ -147,12 +149,17 @@ export class RerankerService {
    * presentationOrder), so callers don't have to know about the
    * shuffle.
    */
-  private async singleRerank(
-    query: string,
-    candidates: RerankCandidate[],
-    presentationOrder: number[],
-    hints?: string,
-  ): Promise<number[]> {
+  private async singleRerank({
+    query,
+    candidates,
+    presentationOrder,
+    hints,
+  }: {
+    query: string;
+    candidates: RerankCandidate[];
+    presentationOrder: number[];
+    hints?: string;
+  }): Promise<number[]> {
     const identity = candidates.map((_, i) => i);
     const items = presentationOrder
       .map((parentIdx, presIdx) => {

--- a/src/artifacts/artifacts.controller.ts
+++ b/src/artifacts/artifacts.controller.ts
@@ -23,12 +23,12 @@ export class ArtifactsController {
     @Param('type') type: string,
     @Param('entityId') entityId: string,
   ) {
-    return this.artifacts.getArtifact(
-      req.brainAuth.companyId,
-      entityId,
-      type as ArtifactType,
-      req.brainAuth.scopes,
-    );
+    return this.artifacts.getArtifact({
+      companyId: req.brainAuth.companyId,
+      entityIdRaw: entityId,
+      artifactType: type as ArtifactType,
+      scopes: req.brainAuth.scopes,
+    });
   }
 
   @Post(':type/:entityId/recompile')
@@ -38,11 +38,11 @@ export class ArtifactsController {
     @Param('type') type: string,
     @Param('entityId') entityId: string,
   ) {
-    return this.artifacts.recompileArtifact(
-      req.brainAuth.companyId,
-      entityId,
-      type as ArtifactType,
-      req.brainAuth.scopes,
-    );
+    return this.artifacts.recompileArtifact({
+      companyId: req.brainAuth.companyId,
+      entityIdRaw: entityId,
+      artifactType: type as ArtifactType,
+      scopes: req.brainAuth.scopes,
+    });
   }
 }

--- a/src/artifacts/artifacts.service.ts
+++ b/src/artifacts/artifacts.service.ts
@@ -71,18 +71,32 @@ export interface KnowledgeArtifact {
 
 type FactRow = TemplateFactRow;
 
+export interface GetArtifactOptions {
+  companyId: string;
+  entityIdRaw: string;
+  artifactType: ArtifactType;
+  scopes: BrainScope[];
+}
+
+export interface RecompileArtifactOptions {
+  companyId: string;
+  entityIdRaw: string;
+  artifactType: ArtifactType;
+  scopes: BrainScope[];
+}
+
 @Injectable()
 export class ArtifactsService {
   private readonly logger = new Logger(ArtifactsService.name);
 
   constructor(private readonly surreal: SurrealService) {}
 
-  async getArtifact(
-    companyId: string,
-    entityIdRaw: string,
-    artifactType: ArtifactType,
-    scopes: BrainScope[],
-  ): Promise<KnowledgeArtifact> {
+  async getArtifact({
+    companyId,
+    entityIdRaw,
+    artifactType,
+    scopes,
+  }: GetArtifactOptions): Promise<KnowledgeArtifact> {
     const ref = this.normalizeEntityId(entityIdRaw);
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       // 1. Verify entity exists.
@@ -100,7 +114,13 @@ export class ArtifactsService {
       if (cached && !cached.dirty) {
         const ageMs = now - new Date(cached.builtAt).getTime();
         if (ageMs < cached.staleAfterMs) {
-          return this.shapeForReturn(cached, ref.full, scopes, ageMs, artifactType);
+          return this.shapeForReturn({
+            cached,
+            fullSelf: ref.full,
+            scopes,
+            ageMs,
+            artifactType,
+          });
         }
       }
 
@@ -112,29 +132,35 @@ export class ArtifactsService {
       // are unnecessary here because the unique index on (entityId,
       // artifactType) lets us either CREATE or UPDATE in one go.
       // We use UPDATE...UPSERT-style: update if exists, else create.
-      const stored = await this.upsertArtifact(
+      const stored = await this.upsertArtifact({
         db,
-        ref.id,
+        rid: ref.id,
         artifactType,
-        compiled.payload,
-        compiled.citations,
-        compiled.sourceFactIds,
+        payload: compiled.payload,
+        citations: compiled.citations,
+        sourceFactIds: compiled.sourceFactIds,
         // dirty as observed before we read facts; the CAS clears it only if
         // unchanged since (no fact-change event fired during compile).
-        cached?.dirty ?? false,
-      );
+        expectedDirty: cached?.dirty ?? false,
+      });
       const ageMs = now - new Date(stored.builtAt).getTime();
-      return this.shapeForReturn(stored, ref.full, scopes, ageMs, artifactType);
+      return this.shapeForReturn({
+        cached: stored,
+        fullSelf: ref.full,
+        scopes,
+        ageMs,
+        artifactType,
+      });
     });
   }
 
   /** Force-recompile and return — bypasses cache freshness check. */
-  async recompileArtifact(
-    companyId: string,
-    entityIdRaw: string,
-    artifactType: ArtifactType,
-    scopes: BrainScope[],
-  ): Promise<KnowledgeArtifact> {
+  async recompileArtifact({
+    companyId,
+    entityIdRaw,
+    artifactType,
+    scopes,
+  }: RecompileArtifactOptions): Promise<KnowledgeArtifact> {
     const ref = this.normalizeEntityId(entityIdRaw);
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       const [entRows] = await db.query<any[][]>(
@@ -149,16 +175,22 @@ export class ArtifactsService {
       const before = await this.fetchCached(db, ref.id, artifactType);
       const facts = await this.fetchActiveFacts(db, ref.id, scopes);
       const compiled = this.compile(artifactType, facts);
-      const stored = await this.upsertArtifact(
+      const stored = await this.upsertArtifact({
         db,
-        ref.id,
+        rid: ref.id,
         artifactType,
-        compiled.payload,
-        compiled.citations,
-        compiled.sourceFactIds,
-        before?.dirty ?? false,
-      );
-      return this.shapeForReturn(stored, ref.full, scopes, 0, artifactType);
+        payload: compiled.payload,
+        citations: compiled.citations,
+        sourceFactIds: compiled.sourceFactIds,
+        expectedDirty: before?.dirty ?? false,
+      });
+      return this.shapeForReturn({
+        cached: stored,
+        fullSelf: ref.full,
+        scopes,
+        ageMs: 0,
+        artifactType,
+      });
     });
   }
 
@@ -251,15 +283,23 @@ export class ArtifactsService {
       }));
   }
 
-  private async upsertArtifact(
-    db: Surreal,
-    rid: string,
-    artifactType: ArtifactType,
-    payload: Record<string, unknown>,
-    citations: KnowledgeArtifact['citations'],
-    sourceFactIds: string[],
-    expectedDirty: boolean,
-  ) {
+  private async upsertArtifact({
+    db,
+    rid,
+    artifactType,
+    payload,
+    citations,
+    sourceFactIds,
+    expectedDirty,
+  }: {
+    db: Surreal;
+    rid: string;
+    artifactType: ArtifactType;
+    payload: Record<string, unknown>;
+    citations: KnowledgeArtifact['citations'];
+    sourceFactIds: string[];
+    expectedDirty: boolean;
+  }) {
     // Wrap payload + citations together so they round-trip as a single
     // FLEXIBLE object — schema has one `payload` field, no need for
     // a separate citations column.
@@ -324,19 +364,25 @@ export class ArtifactsService {
     };
   }
 
-  private shapeForReturn(
+  private shapeForReturn({
+    cached,
+    fullSelf,
+    scopes,
+    ageMs,
+    artifactType,
+  }: {
     cached: {
       payload: Record<string, unknown>;
       citations: KnowledgeArtifact['citations'];
       sourceFactIds: string[];
       builtAt: string;
       staleAfterMs: number;
-    },
-    fullSelf: string,
-    scopes: BrainScope[],
-    ageMs: number,
-    artifactType: ArtifactType,
-  ): KnowledgeArtifact {
+    };
+    fullSelf: string;
+    scopes: BrainScope[];
+    ageMs: number;
+    artifactType: ArtifactType;
+  }): KnowledgeArtifact {
     // PII filter on the COMPILED payload — drop fields whose source
     // predicates require a scope the caller doesn't carry. The
     // citations array also gets pruned so we don't leak factIds for

--- a/src/artifacts/templates.ts
+++ b/src/artifacts/templates.ts
@@ -76,12 +76,17 @@ const empty = (): CompiledArtifact => ({
  * Add a single-active field (latest fact's object → payload[fieldName]).
  * Mutates compiled in place; returns the source fact id (or undefined).
  */
-const addSingle = (
-  compiled: CompiledArtifact,
-  facts: FactRow[],
-  fieldName: string,
-  predicate: string,
-): string | undefined => {
+const addSingle = ({
+  compiled,
+  facts,
+  fieldName,
+  predicate,
+}: {
+  compiled: CompiledArtifact;
+  facts: FactRow[];
+  fieldName: string;
+  predicate: string;
+}): string | undefined => {
   const f = latestSingle(facts, predicate);
   if (!f) return undefined;
   compiled.payload[fieldName] = f.object;
@@ -94,13 +99,19 @@ const addSingle = (
  * Add an append-only field — top-N facts as an array. Each fact gets
  * a citation entry parallel to the array entry.
  */
-const addList = (
-  compiled: CompiledArtifact,
-  facts: FactRow[],
-  fieldName: string,
-  predicate: string,
-  topN: number,
-) => {
+const addList = ({
+  compiled,
+  facts,
+  fieldName,
+  predicate,
+  topN,
+}: {
+  compiled: CompiledArtifact;
+  facts: FactRow[];
+  fieldName: string;
+  predicate: string;
+  topN: number;
+}) => {
   const subset = allOf(facts, predicate).slice(0, topN);
   if (subset.length === 0) return;
   compiled.payload[fieldName] = subset.map((f) => f.object);
@@ -112,12 +123,12 @@ const addList = (
 
 const customerProfile: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addSingle(c, facts, 'tier', 'tier');
-  addSingle(c, facts, 'status', 'status');
-  addSingle(c, facts, 'email', 'email');
-  addSingle(c, facts, 'phone', 'phone');
-  addList(c, facts, 'recentInteractions', 'interacted_with', 5);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'tier', predicate: 'tier' });
+  addSingle({ compiled: c, facts, fieldName: 'status', predicate: 'status' });
+  addSingle({ compiled: c, facts, fieldName: 'email', predicate: 'email' });
+  addSingle({ compiled: c, facts, fieldName: 'phone', predicate: 'phone' });
+  addList({ compiled: c, facts, fieldName: 'recentInteractions', predicate: 'interacted_with', topN: 5 });
   return c;
 };
 
@@ -194,157 +205,157 @@ const identityDossier: Template = (facts) => {
 /** inite.rent — tenant dossier for car-rental operators. */
 const tenantDossier: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addSingle(c, facts, 'tier', 'tier');
-  addSingle(c, facts, 'status', 'status');
-  addList(c, facts, 'rentalHistory', 'rented_vehicle', 10);
-  addList(c, facts, 'paymentEvents', 'paid_invoice', 10);
-  addList(c, facts, 'incidents', 'reported_incident', 5);
-  addList(c, facts, 'preferences', 'preference', 5);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'tier', predicate: 'tier' });
+  addSingle({ compiled: c, facts, fieldName: 'status', predicate: 'status' });
+  addList({ compiled: c, facts, fieldName: 'rentalHistory', predicate: 'rented_vehicle', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'paymentEvents', predicate: 'paid_invoice', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'incidents', predicate: 'reported_incident', topN: 5 });
+  addList({ compiled: c, facts, fieldName: 'preferences', predicate: 'preference', topN: 5 });
   return c;
 };
 
 /** inite.estate — listing card for property listings. */
 const listingCard: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'title', 'name');
-  addSingle(c, facts, 'price', 'listed_price');
-  addSingle(c, facts, 'status', 'status');
-  addSingle(c, facts, 'bedrooms', 'bedrooms');
-  addSingle(c, facts, 'bathrooms', 'bathrooms');
-  addSingle(c, facts, 'floorArea', 'floor_area');
-  addList(c, facts, 'amenities', 'amenity', 20);
-  addList(c, facts, 'recentViewings', 'viewed_by', 10);
+  addSingle({ compiled: c, facts, fieldName: 'title', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'price', predicate: 'listed_price' });
+  addSingle({ compiled: c, facts, fieldName: 'status', predicate: 'status' });
+  addSingle({ compiled: c, facts, fieldName: 'bedrooms', predicate: 'bedrooms' });
+  addSingle({ compiled: c, facts, fieldName: 'bathrooms', predicate: 'bathrooms' });
+  addSingle({ compiled: c, facts, fieldName: 'floorArea', predicate: 'floor_area' });
+  addList({ compiled: c, facts, fieldName: 'amenities', predicate: 'amenity', topN: 20 });
+  addList({ compiled: c, facts, fieldName: 'recentViewings', predicate: 'viewed_by', topN: 10 });
   return c;
 };
 
 /** inite.estate — prospect summary for buyers/renters interested in listings. */
 const prospectSummary: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addSingle(c, facts, 'budget', 'budget');
-  addSingle(c, facts, 'desiredArea', 'desired_area');
-  addList(c, facts, 'viewedListings', 'viewed_listing', 10);
-  addList(c, facts, 'preferences', 'preference', 10);
-  addList(c, facts, 'objections', 'complained_about', 5);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'budget', predicate: 'budget' });
+  addSingle({ compiled: c, facts, fieldName: 'desiredArea', predicate: 'desired_area' });
+  addList({ compiled: c, facts, fieldName: 'viewedListings', predicate: 'viewed_listing', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'preferences', predicate: 'preference', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'objections', predicate: 'complained_about', topN: 5 });
   return c;
 };
 
 /** inite.events — attendee history (concerts, classes, conferences). */
 const attendeeHistory: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addSingle(c, facts, 'tier', 'tier');
-  addList(c, facts, 'attendedEvents', 'attended_event', 20);
-  addList(c, facts, 'purchasedTickets', 'purchased_ticket', 10);
-  addList(c, facts, 'preferences', 'preference', 5);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'tier', predicate: 'tier' });
+  addList({ compiled: c, facts, fieldName: 'attendedEvents', predicate: 'attended_event', topN: 20 });
+  addList({ compiled: c, facts, fieldName: 'purchasedTickets', predicate: 'purchased_ticket', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'preferences', predicate: 'preference', topN: 5 });
   return c;
 };
 
 /** inite.health — patient summary (heavy PII; per-field gating active). */
 const patientSummary: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addSingle(c, facts, 'dob', 'dob');
-  addSingle(c, facts, 'status', 'status');
-  addList(c, facts, 'medications', 'prescribed_medication', 20);
-  addList(c, facts, 'allergies', 'has_allergy', 10);
-  addList(c, facts, 'recentAppointments', 'attended_appointment', 10);
-  addList(c, facts, 'recentTreatments', 'received_treatment', 10);
-  addList(c, facts, 'concerns', 'complained_about', 5);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'dob', predicate: 'dob' });
+  addSingle({ compiled: c, facts, fieldName: 'status', predicate: 'status' });
+  addList({ compiled: c, facts, fieldName: 'medications', predicate: 'prescribed_medication', topN: 20 });
+  addList({ compiled: c, facts, fieldName: 'allergies', predicate: 'has_allergy', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'recentAppointments', predicate: 'attended_appointment', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'recentTreatments', predicate: 'received_treatment', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'concerns', predicate: 'complained_about', topN: 5 });
   return c;
 };
 
 /** inite.shop — order history with LTV. */
 const orderHistory: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addSingle(c, facts, 'tier', 'tier');
-  addSingle(c, facts, 'status', 'status');
-  addList(c, facts, 'recentOrders', 'placed_order', 20);
-  addList(c, facts, 'returns', 'returned_item', 10);
-  addList(c, facts, 'reviews', 'reviewed_product', 10);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'tier', predicate: 'tier' });
+  addSingle({ compiled: c, facts, fieldName: 'status', predicate: 'status' });
+  addList({ compiled: c, facts, fieldName: 'recentOrders', predicate: 'placed_order', topN: 20 });
+  addList({ compiled: c, facts, fieldName: 'returns', predicate: 'returned_item', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'reviews', predicate: 'reviewed_product', topN: 10 });
   return c;
 };
 
 /** inite.club — community member profile. */
 const memberProfile: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addSingle(c, facts, 'tier', 'tier');
-  addSingle(c, facts, 'joinDate', 'joined_at');
-  addList(c, facts, 'attendedMeetups', 'attended_meetup', 10);
-  addList(c, facts, 'contributions', 'contributed_to', 10);
-  addList(c, facts, 'interests', 'interested_in', 10);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'tier', predicate: 'tier' });
+  addSingle({ compiled: c, facts, fieldName: 'joinDate', predicate: 'joined_at' });
+  addList({ compiled: c, facts, fieldName: 'attendedMeetups', predicate: 'attended_meetup', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'contributions', predicate: 'contributed_to', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'interests', predicate: 'interested_in', topN: 10 });
   return c;
 };
 
 /** inite.education — learner progress (courses, grades, AI tutor notes). */
 const learnerProgress: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addSingle(c, facts, 'currentLevel', 'level');
-  addList(c, facts, 'enrolledCourses', 'enrolled_in', 10);
-  addList(c, facts, 'completedCourses', 'completed_course', 20);
-  addList(c, facts, 'recentScores', 'scored', 10);
-  addList(c, facts, 'tutorNotes', 'said', 10);
-  addList(c, facts, 'strugglingTopics', 'complained_about', 5);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'currentLevel', predicate: 'level' });
+  addList({ compiled: c, facts, fieldName: 'enrolledCourses', predicate: 'enrolled_in', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'completedCourses', predicate: 'completed_course', topN: 20 });
+  addList({ compiled: c, facts, fieldName: 'recentScores', predicate: 'scored', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'tutorNotes', predicate: 'said', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'strugglingTopics', predicate: 'complained_about', topN: 5 });
   return c;
 };
 
 /** inite.sport — athlete card (training, performance, team). */
 const athleteCard: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addSingle(c, facts, 'team', 'plays_for');
-  addSingle(c, facts, 'position', 'plays_position');
-  addList(c, facts, 'recentMatches', 'played_match', 10);
-  addList(c, facts, 'trainingSessions', 'attended_training', 10);
-  addList(c, facts, 'achievements', 'achieved', 10);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'team', predicate: 'plays_for' });
+  addSingle({ compiled: c, facts, fieldName: 'position', predicate: 'plays_position' });
+  addList({ compiled: c, facts, fieldName: 'recentMatches', predicate: 'played_match', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'trainingSessions', predicate: 'attended_training', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'achievements', predicate: 'achieved', topN: 10 });
   return c;
 };
 
 /** inite.travel — traveler history (trips, preferences). */
 const travelerHistory: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addSingle(c, facts, 'tier', 'tier');
-  addList(c, facts, 'recentTrips', 'completed_trip', 10);
-  addList(c, facts, 'bookings', 'booked_trip', 10);
-  addList(c, facts, 'destinations', 'visited_destination', 20);
-  addList(c, facts, 'preferences', 'preference', 10);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'tier', predicate: 'tier' });
+  addList({ compiled: c, facts, fieldName: 'recentTrips', predicate: 'completed_trip', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'bookings', predicate: 'booked_trip', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'destinations', predicate: 'visited_destination', topN: 20 });
+  addList({ compiled: c, facts, fieldName: 'preferences', predicate: 'preference', topN: 10 });
   return c;
 };
 
 /** inite.food — diner preferences (cuisine, dietary, ordering history). */
 const dinerPreferences: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addList(c, facts, 'dietaryRestrictions', 'dietary_restriction', 10);
-  addList(c, facts, 'favouriteCuisines', 'preference', 10);
-  addList(c, facts, 'recentOrders', 'placed_order', 10);
-  addList(c, facts, 'visitedRestaurants', 'visited_restaurant', 10);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addList({ compiled: c, facts, fieldName: 'dietaryRestrictions', predicate: 'dietary_restriction', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'favouriteCuisines', predicate: 'preference', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'recentOrders', predicate: 'placed_order', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'visitedRestaurants', predicate: 'visited_restaurant', topN: 10 });
   return c;
 };
 
 /** inite.studio — booking history for studio rentals. */
 const studioBookings: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addList(c, facts, 'recentBookings', 'booked_session', 10);
-  addList(c, facts, 'instruments', 'requested_instrument', 5);
-  addList(c, facts, 'genres', 'preference', 5);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addList({ compiled: c, facts, fieldName: 'recentBookings', predicate: 'booked_session', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'instruments', predicate: 'requested_instrument', topN: 5 });
+  addList({ compiled: c, facts, fieldName: 'genres', predicate: 'preference', topN: 5 });
   return c;
 };
 
 /** inite.ai — usage and feedback for an AI agent end-user. */
 const aiUserContext: Template = (facts) => {
   const c = empty();
-  addSingle(c, facts, 'name', 'name');
-  addSingle(c, facts, 'plan', 'tier');
-  addList(c, facts, 'recentPrompts', 'said', 20);
-  addList(c, facts, 'feedback', 'rated', 10);
-  addList(c, facts, 'preferences', 'preference', 10);
+  addSingle({ compiled: c, facts, fieldName: 'name', predicate: 'name' });
+  addSingle({ compiled: c, facts, fieldName: 'plan', predicate: 'tier' });
+  addList({ compiled: c, facts, fieldName: 'recentPrompts', predicate: 'said', topN: 20 });
+  addList({ compiled: c, facts, fieldName: 'feedback', predicate: 'rated', topN: 10 });
+  addList({ compiled: c, facts, fieldName: 'preferences', predicate: 'preference', topN: 10 });
   return c;
 };
 

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -18,10 +18,10 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   const warnings: string[] = [];
 
   // ── Required ──────────────────────────────────────────────────────
-  required(env, 'SURREALDB_URL', errors, /^(ws|wss|http|https):\/\//);
-  required(env, 'SURREALDB_USERNAME', errors);
-  required(env, 'SURREALDB_PASSWORD', errors);
-  required(env, 'OPENAI_API_KEY', errors, /^sk-/);
+  required({ env, name: 'SURREALDB_URL', errors, pattern: /^(ws|wss|http|https):\/\// });
+  required({ env, name: 'SURREALDB_USERNAME', errors });
+  required({ env, name: 'SURREALDB_PASSWORD', errors });
+  required({ env, name: 'OPENAI_API_KEY', errors, pattern: /^sk-/ });
 
   // ── Auth ─────────────────────────────────────────────────────────
   // BRAIN_API_KEYS is required, but [] is acceptable in dev (no callers).
@@ -184,12 +184,17 @@ function validateBodySize(env: NodeJS.ProcessEnv, errors: string[]): void {
   }
 }
 
-function required(
-  env: NodeJS.ProcessEnv,
-  name: string,
-  errors: string[],
-  pattern?: RegExp,
-): void {
+function required({
+  env,
+  name,
+  errors,
+  pattern,
+}: {
+  env: NodeJS.ProcessEnv;
+  name: string;
+  errors: string[];
+  pattern?: RegExp;
+}): void {
   const v = env[name];
   if (!v || !v.trim()) {
     errors.push(`${name} is required`);

--- a/src/common/parallel.ts
+++ b/src/common/parallel.ts
@@ -8,12 +8,19 @@
  * removes the dep, which matters for our cold-start budget (BGE-M3
  * already imports onnxruntime + ~150MB model).
  */
-export async function mapWithLimit<T, R>(
-  items: readonly T[],
-  concurrency: number,
-  fn: (item: T, index: number) => Promise<R>,
-  opts?: { onError?: (err: Error, item: T, index: number) => void },
-): Promise<Array<R | null>> {
+export interface MapWithLimitOptions<T, R> {
+  items: readonly T[];
+  concurrency: number;
+  fn: (item: T, index: number) => Promise<R>;
+  onError?: (err: Error, item: T, index: number) => void;
+}
+
+export async function mapWithLimit<T, R>({
+  items,
+  concurrency,
+  fn,
+  onError,
+}: MapWithLimitOptions<T, R>): Promise<Array<R | null>> {
   const out: Array<R | null> = new Array(items.length).fill(null);
   let cursor = 0;
   const cap = Math.max(1, Math.min(concurrency, items.length || 1));
@@ -24,7 +31,7 @@ export async function mapWithLimit<T, R>(
       try {
         out[i] = await fn(items[i], i);
       } catch (e) {
-        opts?.onError?.(e as Error, items[i], i);
+        onError?.(e as Error, items[i], i);
         out[i] = null;
       }
     }

--- a/src/dreams/dreams.service.ts
+++ b/src/dreams/dreams.service.ts
@@ -241,12 +241,12 @@ export class DreamsService implements OnModuleInit {
     const opsRaw = ctx.payload?.operations as DreamsOperation[] | undefined;
     const ops = opsRaw && opsRaw.length ? opsRaw : [...this.defaultOps];
     this.throwIfAborted(ctx);
-    const stats = await this.runForTenantInner(
-      ctx.companyId,
-      ops,
-      { triggeredBy: 'cron', triggeredByActor: ctx.workerId },
-      { skipJobRowLifecycle: true, abortSignal: ctx.abortSignal },
-    );
+    const stats = await this.runForTenantInner({
+      companyId: ctx.companyId,
+      operations: ops,
+      triggered: { triggeredBy: 'cron', triggeredByActor: ctx.workerId },
+      opts: { skipJobRowLifecycle: true, abortSignal: ctx.abortSignal },
+    });
     this.throwIfAborted(ctx);
     return {
       durationSeconds: stats.durationSeconds,
@@ -324,9 +324,9 @@ export class DreamsService implements OnModuleInit {
   ): Promise<DreamsTenantStats> {
     const guarded = this.guard
       ? await this.guard.run(`dreams_tenant_${companyId}`, () =>
-          this.runForTenantInner(companyId, operations, triggered),
+          this.runForTenantInner({ companyId, operations, triggered }),
         )
-      : await this.runForTenantInner(companyId, operations, triggered);
+      : await this.runForTenantInner({ companyId, operations, triggered });
     if (guarded !== null) return guarded;
     this.logger.warn(
       `dreams skipped for ${companyId} — previous run still in flight`,
@@ -343,15 +343,20 @@ export class DreamsService implements OnModuleInit {
   // sub-leg into a helper (runDedupLeg, runResolveLeg, etc.) and
   // drop back under the gate. Tracked separately.
   // eslint-disable-next-line complexity
-  private async runForTenantInner(
-    companyId: string,
-    operations: DreamsOperation[],
+  private async runForTenantInner({
+    companyId,
+    operations,
+    triggered,
+    opts,
+  }: {
+    companyId: string;
+    operations: DreamsOperation[];
     triggered?: {
       triggeredBy?: 'cron' | 'manual' | 'startup';
       triggeredByActor?: string;
-    },
-    opts?: { skipJobRowLifecycle?: boolean; abortSignal?: AbortSignal },
-  ): Promise<DreamsTenantStats> {
+    };
+    opts?: { skipJobRowLifecycle?: boolean; abortSignal?: AbortSignal };
+  }): Promise<DreamsTenantStats> {
     const checkAbort = () => {
       if (opts?.abortSignal?.aborted) {
         throw opts.abortSignal.reason ?? new Error('aborted');

--- a/src/entities/entities.controller.ts
+++ b/src/entities/entities.controller.ts
@@ -25,12 +25,12 @@ export class EntitiesController {
     @Param('id') id: string,
     @Query('asOf') asOf?: string,
   ) {
-    return this.entities.getProfile(
-      req.brainAuth.companyId,
-      id,
-      asOf,
-      req.brainAuth.scopes,
-    );
+    return this.entities.getProfile({
+      companyId: req.brainAuth.companyId,
+      entityIdRaw: id,
+      asOfRaw: asOf,
+      scopes: req.brainAuth.scopes,
+    });
   }
 
   @Get(':id/timeline')
@@ -41,13 +41,13 @@ export class EntitiesController {
     @Query('since') since?: string,
     @Query('until') until?: string,
   ) {
-    return this.entities.getTimeline(
-      req.brainAuth.companyId,
-      id,
-      since,
-      until,
-      req.brainAuth.scopes,
-    );
+    return this.entities.getTimeline({
+      companyId: req.brainAuth.companyId,
+      entityIdRaw: id,
+      sinceRaw: since,
+      untilRaw: until,
+      scopes: req.brainAuth.scopes,
+    });
   }
 
   @Get(':id/connections')
@@ -58,13 +58,13 @@ export class EntitiesController {
     @Query('kind') kind?: string,
     @Query('asOf') asOf?: string,
   ) {
-    return this.entities.getConnections(
-      req.brainAuth.companyId,
-      id,
+    return this.entities.getConnections({
+      companyId: req.brainAuth.companyId,
+      entityIdRaw: id,
       kind,
-      req.brainAuth.scopes,
+      scopes: req.brainAuth.scopes,
       asOf,
-    );
+    });
   }
 
   @Post(':id/forget')
@@ -74,11 +74,11 @@ export class EntitiesController {
     @Param('id') id: string,
     @Body() body: ForgetEntityDto,
   ) {
-    return this.entities.forget(
-      req.brainAuth.companyId,
-      id,
-      body,
-      req.brainAuth.keyHash,
-    );
+    return this.entities.forget({
+      companyId: req.brainAuth.companyId,
+      entityIdRaw: id,
+      dto: body,
+      actorKeyHash: req.brainAuth.keyHash,
+    });
   }
 }

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -64,6 +64,43 @@ export interface ForgetResult {
   forgottenAt: string;
 }
 
+export interface GetProfileOptions {
+  companyId: string;
+  entityIdRaw: string;
+  asOfRaw: string | undefined;
+  scopes: BrainScope[];
+}
+
+export interface FreshnessWatermarkOptions {
+  companyId: string;
+  entityIdRaw: string;
+  asOfRaw: string | undefined;
+  scopes: BrainScope[];
+}
+
+export interface GetTimelineOptions {
+  companyId: string;
+  entityIdRaw: string;
+  sinceRaw: string | undefined;
+  untilRaw: string | undefined;
+  scopes: BrainScope[];
+}
+
+export interface GetConnectionsOptions {
+  companyId: string;
+  entityIdRaw: string;
+  kind: string | undefined;
+  scopes?: BrainScope[];
+  asOf?: string;
+}
+
+export interface ForgetOptions {
+  companyId: string;
+  entityIdRaw: string;
+  dto: ForgetEntityDto;
+  actorKeyHash?: string;
+}
+
 @Injectable()
 export class EntitiesService {
   private readonly logger = new Logger(EntitiesService.name);
@@ -82,12 +119,12 @@ export class EntitiesService {
       this.configService.get<string>('FORGET_HMAC_KEY') ?? 'inite-brain-default';
   }
 
-  async getProfile(
-    companyId: string,
-    entityIdRaw: string,
-    asOfRaw: string | undefined,
-    scopes: BrainScope[],
-  ): Promise<EntityProfile> {
+  async getProfile({
+    companyId,
+    entityIdRaw,
+    asOfRaw,
+    scopes,
+  }: GetProfileOptions): Promise<EntityProfile> {
     const ref = normalizeEntityId(entityIdRaw);
     const asOf = asOfRaw ? new Date(asOfRaw) : null;
 
@@ -165,12 +202,12 @@ export class EntitiesService {
    * every cache hit. Returns nulls when the entity has no qualifying
    * facts.
    */
-  async freshnessWatermark(
-    companyId: string,
-    entityIdRaw: string,
-    asOfRaw: string | undefined,
-    scopes: BrainScope[],
-  ): Promise<{ maxRecordedAt: string | null; maxValidFrom: string | null }> {
+  async freshnessWatermark({
+    companyId,
+    entityIdRaw,
+    asOfRaw,
+    scopes,
+  }: FreshnessWatermarkOptions): Promise<{ maxRecordedAt: string | null; maxValidFrom: string | null }> {
     const ref = normalizeEntityId(entityIdRaw);
     const asOf = asOfRaw ? new Date(asOfRaw) : null;
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
@@ -214,13 +251,13 @@ export class EntitiesService {
     });
   }
 
-  async getTimeline(
-    companyId: string,
-    entityIdRaw: string,
-    sinceRaw: string | undefined,
-    untilRaw: string | undefined,
-    scopes: BrainScope[],
-  ): Promise<{ entityId: string; events: any[] }> {
+  async getTimeline({
+    companyId,
+    entityIdRaw,
+    sinceRaw,
+    untilRaw,
+    scopes,
+  }: GetTimelineOptions): Promise<{ entityId: string; events: any[] }> {
     const ref = normalizeEntityId(entityIdRaw);
     const since = sinceRaw ? new Date(sinceRaw) : null;
     const until = untilRaw ? new Date(untilRaw) : null;
@@ -273,13 +310,13 @@ export class EntitiesService {
     });
   }
 
-  async getConnections(
-    companyId: string,
-    entityIdRaw: string,
-    kind: string | undefined,
-    scopes: BrainScope[] = [],
-    asOf?: string,
-  ): Promise<{ entityId: string; edges: any[] }> {
+  async getConnections({
+    companyId,
+    entityIdRaw,
+    kind,
+    scopes = [],
+    asOf,
+  }: GetConnectionsOptions): Promise<{ entityId: string; edges: any[] }> {
     const ref = normalizeEntityId(entityIdRaw);
 
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
@@ -367,12 +404,12 @@ export class EntitiesService {
     });
   }
 
-  async forget(
-    companyId: string,
-    entityIdRaw: string,
-    dto: ForgetEntityDto,
-    actorKeyHash?: string,
-  ): Promise<ForgetResult> {
+  async forget({
+    companyId,
+    entityIdRaw,
+    dto,
+    actorKeyHash,
+  }: ForgetOptions): Promise<ForgetResult> {
     const ref = normalizeEntityId(entityIdRaw);
 
     const result = await this.surreal.withCompany(companyId, async (db) => {

--- a/src/facts/facts.controller.ts
+++ b/src/facts/facts.controller.ts
@@ -22,11 +22,11 @@ export class FactsController {
     @Param('id') id: string,
     @Body() body: RetractFactDto,
   ) {
-    return this.facts.retract(
-      req.brainAuth.companyId,
-      id,
-      body,
-      req.brainAuth.scopes,
-    );
+    return this.facts.retract({
+      companyId: req.brainAuth.companyId,
+      factId: id,
+      dto: body,
+      callerScopes: req.brainAuth.scopes,
+    });
   }
 }

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -66,6 +66,13 @@ export interface CompetingFactGroup {
   facts: CompetingFactRecord[];
 }
 
+export interface RetractOptions {
+  companyId: string;
+  factId: string;
+  dto: RetractFactDto;
+  callerScopes?: ReadonlyArray<BrainScope>;
+}
+
 export interface ListCompetingResult {
   entityId: string;
   asOf?: string;
@@ -86,12 +93,12 @@ export class FactsService {
     @Optional() private readonly metrics?: MetricsService,
   ) {}
 
-  async retract(
-    companyId: string,
-    factId: string,
-    dto: RetractFactDto,
-    callerScopes?: ReadonlyArray<BrainScope>,
-  ): Promise<RetractResult> {
+  async retract({
+    companyId,
+    factId,
+    dto,
+    callerScopes,
+  }: RetractOptions): Promise<RetractResult> {
     return this.surreal.withCompany(companyId, async (db) => {
       const ref = this.normalizeFactId(factId);
       const now = new Date();
@@ -128,7 +135,12 @@ export class FactsService {
         };
       }
 
-      const cascaded = await this.cascadeRetract(db, String(existing.id), now, dto.reason);
+      const cascaded = await this.cascadeRetract({
+        db,
+        parentFactId: String(existing.id),
+        now,
+        reason: dto.reason,
+      });
 
       await dbMerge(db, `knowledge_fact:${ref.id}`, {
         status: 'retracted',
@@ -226,12 +238,17 @@ export class FactsService {
    * For 0.1.0 we apply a simpler rule: if any parent is retracted, the child
    * is retracted. Lazy re-validation on retrieval is a 0.2.0 enhancement.
    */
-  private async cascadeRetract(
-    db: Surreal,
-    parentFactId: string,
-    now: Date,
-    reason: string,
-  ): Promise<string[]> {
+  private async cascadeRetract({
+    db,
+    parentFactId,
+    now,
+    reason,
+  }: {
+    db: Surreal;
+    parentFactId: string;
+    now: Date;
+    reason: string;
+  }): Promise<string[]> {
     const cascaded: string[] = [];
     const stack = [parentFactId];
 

--- a/src/ingest/entity-resolver.service.ts
+++ b/src/ingest/entity-resolver.service.ts
@@ -33,6 +33,13 @@ import { EntityJudgeService } from '../ai/entity-judge.service';
  * flag is off by default (operators wanting reversible merges keep it off
  * and rely on dreams).
  */
+export interface ResolveByNameOptions {
+  db: Surreal;
+  name: string;
+  type: string;
+  incomingFacts: string[];
+}
+
 @Injectable()
 export class EntityResolverService {
   private readonly logger = new Logger(EntityResolverService.name);
@@ -69,12 +76,12 @@ export class EntityResolverService {
    * @param incomingFacts  the mention's freshly-extracted facts for THIS
    *   entity, as `"predicate: object"` lines — the judge's "new" side.
    */
-  async resolveByName(
-    db: Surreal,
-    name: string,
-    type: string,
-    incomingFacts: string[],
-  ): Promise<string | null> {
+  async resolveByName({
+    db,
+    name,
+    type,
+    incomingFacts,
+  }: ResolveByNameOptions): Promise<string | null> {
     if (!this.isEnabled()) return null;
     try {
       const candidate = await this.findBestNameCandidate(db, name, type);

--- a/src/ingest/ingest-predictor.service.ts
+++ b/src/ingest/ingest-predictor.service.ts
@@ -195,12 +195,12 @@ export class IngestPredictionService {
       }
 
       const overlapping = priors.filter((p) =>
-        intervalsOverlap(
-          new Date(p.validFrom),
-          p.validUntil ? new Date(p.validUntil) : null,
-          validFrom,
-          args.validUntil ? new Date(args.validUntil) : null,
-        ),
+        intervalsOverlap({
+          aFrom: new Date(p.validFrom),
+          aUntil: p.validUntil ? new Date(p.validUntil) : null,
+          bFrom: validFrom,
+          bUntil: args.validUntil ? new Date(args.validUntil) : null,
+        }),
       );
 
       if (overlapping.length === 0) {
@@ -372,12 +372,17 @@ function dateToIso(v: unknown): string {
   return new Date().toISOString();
 }
 
-function intervalsOverlap(
-  aFrom: Date,
-  aUntil: Date | null,
-  bFrom: Date,
-  bUntil: Date | null,
-): boolean {
+function intervalsOverlap({
+  aFrom,
+  aUntil,
+  bFrom,
+  bUntil,
+}: {
+  aFrom: Date;
+  aUntil: Date | null;
+  bFrom: Date;
+  bUntil: Date | null;
+}): boolean {
   const aEnd = aUntil ?? new Date(8.64e15);
   const bEnd = bUntil ?? new Date(8.64e15);
   return aFrom < bEnd && bFrom < aEnd;

--- a/src/ingest/ingest.service.ts
+++ b/src/ingest/ingest.service.ts
@@ -199,13 +199,13 @@ export class IngestService {
 
       // HyPE: generate a hypothetical-question embedding and write it onto
       // the new fact (shared with recordExtractedFact via this helper).
-      await this.writeAltEmbeddingIfHype(
+      await this.writeAltEmbeddingIfHype({
         db,
         factId,
         outcome,
-        dto.predicate,
-        objectStr,
-      );
+        predicate: dto.predicate,
+        object: objectStr,
+      });
 
       const out: IngestResult = { factId, outcome };
       if (result?.reason) out.reason = String(result.reason);
@@ -351,13 +351,13 @@ export class IngestService {
           const eid = await traceSpan(
             'ingest.entity.resolve',
             () =>
-              this.resolveOrCreateNamedEntity(
+              this.resolveOrCreateNamedEntity({
                 db,
                 e,
-                knownHint,
-                dto.contextRef,
+                hint: knownHint,
+                _contextRef: dto.contextRef,
                 incomingFacts,
-              ),
+              }),
             { name: e.name, type: e.type },
           );
           entityIds.push(eid);
@@ -404,14 +404,19 @@ export class IngestService {
           const result = await traceSpan(
             'ingest.fact.upsert',
             () =>
-              this.recordExtractedFact(db, companyId, eid, {
-                predicate: f.predicate,
-                object: f.object,
-                confidence: f.confidence,
-                validFrom: new Date(dto.emittedAt),
-                source: sourceFromContext,
-                extractionEntropy: f.extractionEntropy,
-                precomputedEmbedding: factEmbeddings[i],
+              this.recordExtractedFact({
+                db,
+                companyId,
+                entityId: eid,
+                factPayload: {
+                  predicate: f.predicate,
+                  object: f.object,
+                  confidence: f.confidence,
+                  validFrom: new Date(dto.emittedAt),
+                  source: sourceFromContext,
+                  extractionEntropy: f.extractionEntropy,
+                  precomputedEmbedding: factEmbeddings[i],
+                },
               }),
             { predicate: f.predicate, entityId: eid },
           );
@@ -431,12 +436,18 @@ export class IngestService {
             const edgeId = await traceSpan(
               'ingest.edge.upsert',
               () =>
-                this.createEdgeBetween(db, fromEid, toEid, e.kind, {
-                  vertical: dto.contextRef.vertical,
-                  eventId: dto.contextRef.eventId,
-                  conversationId: dto.contextRef.conversationId,
-                  messageId: dto.contextRef.messageId,
-                  confidence: e.confidence,
+                this.createEdgeBetween({
+                  db,
+                  fromEntityId: fromEid,
+                  toEntityId: toEid,
+                  kind: e.kind,
+                  source: {
+                    vertical: dto.contextRef.vertical,
+                    eventId: dto.contextRef.eventId,
+                    conversationId: dto.contextRef.conversationId,
+                    messageId: dto.contextRef.messageId,
+                    confidence: e.confidence,
+                  },
                 }),
               { kind: e.kind, from: fromEid, to: toEid },
             );
@@ -469,13 +480,19 @@ export class IngestService {
    * Idempotent: UNIQUE on (in, out, kind) — concurrent / duplicate
    * RELATEs return the existing edge id.
    */
-  private async createEdgeBetween(
-    db: Surreal,
-    fromEntityId: string,
-    toEntityId: string,
-    kind: string,
-    source: Record<string, unknown>,
-  ): Promise<string | null> {
+  private async createEdgeBetween({
+    db,
+    fromEntityId,
+    toEntityId,
+    kind,
+    source,
+  }: {
+    db: Surreal;
+    fromEntityId: string;
+    toEntityId: string;
+    kind: string;
+    source: Record<string, unknown>;
+  }): Promise<string | null> {
     const fromRid = new StringRecordId(fromEntityId);
     const toRid = new StringRecordId(toEntityId);
     try {
@@ -695,13 +712,19 @@ export class IngestService {
     );
   }
 
-  private async resolveOrCreateNamedEntity(
-    db: Surreal,
-    e: { name: string; type: string; canonical?: string },
-    hint: { vertical: string; id: string; role?: string } | undefined,
-    _contextRef: { vertical: string },
-    incomingFacts: string[] = [],
-  ): Promise<string> {
+  private async resolveOrCreateNamedEntity({
+    db,
+    e,
+    hint,
+    _contextRef,
+    incomingFacts = [],
+  }: {
+    db: Surreal;
+    e: { name: string; type: string; canonical?: string };
+    hint: { vertical: string; id: string; role?: string } | undefined;
+    _contextRef: { vertical: string };
+    incomingFacts?: string[];
+  }): Promise<string> {
     // 1. Caller hint wins — same atomic upsert as fact ingest.
     if (hint) {
       const hintKey = externalRefKey(hint.vertical, hint.id);
@@ -737,12 +760,12 @@ export class IngestService {
     // match reuses the existing entity, so the duplicate is never created.
     // Falls through to create-new when disabled, no match, or any error.
     if (this.entityResolver?.isEnabled()) {
-      const resolved = await this.entityResolver.resolveByName(
+      const resolved = await this.entityResolver.resolveByName({
         db,
-        e.name,
-        this.normalizeEntityType(e.type),
+        name: e.name,
+        type: this.normalizeEntityType(e.type),
         incomingFacts,
-      );
+      });
       if (resolved) return resolved;
     }
 
@@ -777,10 +800,15 @@ export class IngestService {
    * and noisy, so we let the conflict-resolution pass at search time handle
    * dedup via embeddings + decay rather than blocking ingest.
    */
-  private async recordExtractedFact(
-    db: Surreal,
-    companyId: string,
-    entityId: string,
+  private async recordExtractedFact({
+    db,
+    companyId,
+    entityId,
+    factPayload,
+  }: {
+    db: Surreal;
+    companyId: string;
+    entityId: string;
     factPayload: {
       predicate: string;
       object: string;
@@ -795,8 +823,8 @@ export class IngestService {
        * legacy path).
        */
       precomputedEmbedding?: number[];
-    },
-  ): Promise<{
+    };
+  }): Promise<{
     factId: string | null;
     outcome?: IngestOutcome;
     supersededFactIds?: string[];
@@ -878,7 +906,7 @@ export class IngestService {
     // INSERTED only, server-side, with no follow-up round-trips. HyPE stays a
     // post-call UPDATE: it's an LLM call, gated on isEnabled() AND INSERTED,
     // so pre-computing it would burn the model on non-INSERTED outcomes.
-    await this.writeAltEmbeddingIfHype(db, factId, outcome, predicate, object);
+    await this.writeAltEmbeddingIfHype({ db, factId, outcome, predicate, object });
 
     // Surface supersede / compete outcomes in the trace so the demo can
     // show "Berlin fact closed at July 1, Dublin became current" —
@@ -948,13 +976,19 @@ export class IngestService {
    * factId); when HyPE is off generateAltEmbedding returns null and we skip
    * the UPDATE — no extra ingest latency.
    */
-  private async writeAltEmbeddingIfHype(
-    db: Surreal,
-    factId: string | null,
-    outcome: unknown,
-    predicate: string,
-    object: string,
-  ): Promise<void> {
+  private async writeAltEmbeddingIfHype({
+    db,
+    factId,
+    outcome,
+    predicate,
+    object,
+  }: {
+    db: Surreal;
+    factId: string | null;
+    outcome: unknown;
+    predicate: string;
+    object: string;
+  }): Promise<void> {
     if (!shouldWriteHypeAltEmbedding(outcome, this.hype.isEnabled(), factId)) {
       return;
     }

--- a/src/jobs/lease-manager.service.ts
+++ b/src/jobs/lease-manager.service.ts
@@ -90,15 +90,19 @@ export class LeaseManagerService {
       // — each reapZombies call holds one root pool conn for its
       // SELECT+UPDATE pair. Cap at 4 so a saturated reap can't fully
       // drain the pool from caller-facing requests.
-      await mapWithLimit(tenants, 4, async (companyId) => {
-        const result = await this.claim!.reapZombies({
-          companyId,
-          maxAttempts: this.maxAttempts,
-          backoffBaseMs: this.backoffBaseMs,
-        });
-        requeued += result.requeued;
-        failed += result.failed;
-        return null;
+      await mapWithLimit({
+        items: tenants,
+        concurrency: 4,
+        fn: async (companyId) => {
+          const result = await this.claim!.reapZombies({
+            companyId,
+            maxAttempts: this.maxAttempts,
+            backoffBaseMs: this.backoffBaseMs,
+          });
+          requeued += result.requeued;
+          failed += result.failed;
+          return null;
+        },
       });
       if (requeued > 0 || failed > 0) {
         this.logger.log(

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -112,16 +112,21 @@ export class McpService {
       name: 'inite-brain-service',
       version: '0.1.0',
     });
-    registerReadTools(server, companyId, scopes, {
-      search: this.search,
-      entities: this.entities,
-      facts: this.facts,
-      multiHop: this.multiHop,
-      synth: this.synth,
-      memoryDiff: this.memoryDiff,
-      predictor: this.predictor,
-      summarizer: this.summarizer,
-      embedderDescription: () => this.embedderDescription(),
+    registerReadTools({
+      server,
+      companyId,
+      scopes,
+      deps: {
+        search: this.search,
+        entities: this.entities,
+        facts: this.facts,
+        multiHop: this.multiHop,
+        synth: this.synth,
+        memoryDiff: this.memoryDiff,
+        predictor: this.predictor,
+        summarizer: this.summarizer,
+        embedderDescription: () => this.embedderDescription(),
+      },
     });
     registerProceduralReadTools(server, companyId, {
       procedural: this.procedural,

--- a/src/mcp/read-tools.ts
+++ b/src/mcp/read-tools.ts
@@ -39,6 +39,18 @@ export interface ReadToolDeps {
 }
 
 /**
+ * Args for the brain:read registration entrypoint and its per-family
+ * helpers. One options object instead of the (server, companyId, scopes,
+ * deps) positional quad.
+ */
+export interface RegisterReadToolsOptions {
+  server: McpServer;
+  companyId: string;
+  scopes: BrainScope[];
+  deps: ReadToolDeps;
+}
+
+/**
  * Translate an MCP request's `extra` parameter into a ProgressReporter
  * that emits notifications/progress on every stage tick. The caller
  * opts in by including `_meta.progressToken` on the request — a
@@ -79,23 +91,23 @@ function buildProgressReporter(extra: {
  * `server.registerTool` pattern as community-tools.ts) to keep that file
  * under the max-lines gate and the tool families independently editable.
  */
-export function registerReadTools(
-  server: McpServer,
-  companyId: string,
-  scopes: BrainScope[],
-  deps: ReadToolDeps,
-): void {
-  registerSearchTools(server, companyId, scopes, deps);
-  registerEntityReadTools(server, companyId, scopes, deps);
-  registerReadResources(server, companyId, scopes, deps);
+export function registerReadTools({
+  server,
+  companyId,
+  scopes,
+  deps,
+}: RegisterReadToolsOptions): void {
+  registerSearchTools({ server, companyId, scopes, deps });
+  registerEntityReadTools({ server, companyId, scopes, deps });
+  registerReadResources({ server, companyId, scopes, deps });
 }
 
-function registerSearchTools(
-  server: McpServer,
-  companyId: string,
-  scopes: BrainScope[],
-  deps: ReadToolDeps,
-): void {
+function registerSearchTools({
+  server,
+  companyId,
+  scopes,
+  deps,
+}: RegisterReadToolsOptions): void {
   const embedderHint = ` Embedding model on this tenant: ${deps.embedderDescription()}.`;
 
   // ── search_knowledge ──────────────────────────────────────────────
@@ -169,9 +181,9 @@ function registerSearchTools(
     },
     async (args, extra) => {
       const reporter = buildProgressReporter(extra as never);
-      const out = await deps.multiHop.run(
+      const out = await deps.multiHop.run({
         companyId,
-        {
+        dto: {
           query: args.query,
           maxHops: args.maxHops,
           synthesize: args.synthesize,
@@ -180,9 +192,9 @@ function registerSearchTools(
           predicates: args.predicates,
           limit: args.limit,
         },
-        scopes,
-        reporter,
-      );
+        callerScopes: scopes,
+        onProgress: reporter,
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
         structuredContent: out as any,
@@ -214,9 +226,9 @@ function registerSearchTools(
     },
     async (args, extra) => {
       const reporter = buildProgressReporter(extra as never);
-      const out = await deps.synth.synthesize(
+      const out = await deps.synth.synthesize({
         companyId,
-        {
+        dto: {
           query: args.query,
           limit: args.limit,
           predicates: args.predicates,
@@ -224,9 +236,9 @@ function registerSearchTools(
           minConfidence: args.minConfidence,
           synthesisGuardrails: args.synthesisGuardrails,
         },
-        scopes,
-        reporter,
-      );
+        callerScopes: scopes,
+        onProgress: reporter,
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
         structuredContent: out as any,
@@ -269,12 +281,12 @@ function registerSearchTools(
   );
 }
 
-function registerEntityReadTools(
-  server: McpServer,
-  companyId: string,
-  scopes: BrainScope[],
-  deps: ReadToolDeps,
-): void {
+function registerEntityReadTools({
+  server,
+  companyId,
+  scopes,
+  deps,
+}: RegisterReadToolsOptions): void {
   // ── get_entity_profile ────────────────────────────────────────────
   server.registerTool(
     'get_entity_profile',
@@ -288,7 +300,12 @@ function registerEntityReadTools(
       },
     },
     async (args) => {
-      const out = await deps.entities.getProfile(companyId, args.entityId, args.asOf, scopes);
+      const out = await deps.entities.getProfile({
+        companyId,
+        entityIdRaw: args.entityId,
+        asOfRaw: args.asOf,
+        scopes,
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
         structuredContent: out as any,
@@ -310,13 +327,13 @@ function registerEntityReadTools(
       },
     },
     async (args) => {
-      const out = await deps.entities.getTimeline(
+      const out = await deps.entities.getTimeline({
         companyId,
-        args.entityId,
-        args.since,
-        args.until,
+        entityIdRaw: args.entityId,
+        sinceRaw: args.since,
+        untilRaw: args.until,
         scopes,
-      );
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
         structuredContent: out as any,
@@ -350,14 +367,14 @@ function registerEntityReadTools(
     },
     async (args) => {
       if (args.styleHint === 'client_llm') {
-        const out = await summarizeViaClientSampling(
-          { entities: deps.entities, summarizer: deps.summarizer },
+        const out = await summarizeViaClientSampling({
+          deps: { entities: deps.entities, summarizer: deps.summarizer },
           server,
           companyId,
-          args.entityId,
-          args.asOf,
+          entityId: args.entityId,
+          asOf: args.asOf,
           scopes,
-        );
+        });
         return {
           content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
           structuredContent: out as any,
@@ -365,17 +382,11 @@ function registerEntityReadTools(
       }
       const out = await deps.summarizer.summarize(
         companyId,
-        {
-          entityId: args.entityId,
-          asOf: args.asOf,
-          styleHint: args.styleHint,
-        },
+        { entityId: args.entityId, asOf: args.asOf, styleHint: args.styleHint },
         scopes,
       );
       return {
-        content: [
-          { type: 'text', text: JSON.stringify(out, null, 2) },
-        ],
+        content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
         structuredContent: { ...out, sampledBy: 'local_template' } as any,
       };
     },
@@ -469,12 +480,12 @@ function registerEntityReadTools(
       // Pass scopes — without them getConnections signs in with an
       // empty scope set, bypassing the DB-level PII fence (every other
       // MCP tool forwards scopes).
-      const out = await deps.entities.getConnections(
+      const out = await deps.entities.getConnections({
         companyId,
-        args.entityId,
-        args.kind,
+        entityIdRaw: args.entityId,
+        kind: args.kind,
         scopes,
-      );
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
         structuredContent: out as any,
@@ -496,12 +507,12 @@ function registerEntityReadTools(
  * Streamable HTTP mode, so subscribe is a no-op for v1. Streaming via a
  * server-pushed changefeed resource is the v2 lift.
  */
-function registerReadResources(
-  server: McpServer,
-  companyId: string,
-  scopes: BrainScope[],
-  deps: ReadToolDeps,
-): void {
+function registerReadResources({
+  server,
+  companyId,
+  scopes,
+  deps,
+}: RegisterReadToolsOptions): void {
   server.registerResource(
     'entity-profile',
     new ResourceTemplate('brain://entity/{entityId}', { list: undefined }),
@@ -513,12 +524,12 @@ function registerReadResources(
     },
     async (uri, params) => {
       const entityIdRaw = String(params.entityId);
-      const profile = await deps.entities.getProfile(
+      const profile = await deps.entities.getProfile({
         companyId,
         entityIdRaw,
-        undefined,
+        asOfRaw: undefined,
         scopes,
-      );
+      });
       return {
         contents: [
           {
@@ -544,13 +555,13 @@ function registerReadResources(
     },
     async (uri, params) => {
       const entityIdRaw = String(params.entityId);
-      const timeline = await deps.entities.getTimeline(
+      const timeline = await deps.entities.getTimeline({
         companyId,
         entityIdRaw,
-        undefined,
-        undefined,
+        sinceRaw: undefined,
+        untilRaw: undefined,
         scopes,
-      );
+      });
       return {
         contents: [
           {

--- a/src/mcp/sampling.ts
+++ b/src/mcp/sampling.ts
@@ -31,26 +31,35 @@ export interface SamplingSummarizeResult {
   asOf?: string;
 }
 
-export async function summarizeViaClientSampling(
+export interface SummarizeViaClientSamplingOptions {
   deps: {
     entities: EntitiesService;
     summarizer: SummarizeEntityService;
-  },
-  server: McpServer,
-  companyId: string,
-  entityId: string,
-  asOf: string | undefined,
-  scopes: BrainScope[],
-): Promise<SamplingSummarizeResult> {
-  const profile = await deps.entities.getProfile(
+  };
+  server: McpServer;
+  companyId: string;
+  entityId: string;
+  asOf: string | undefined;
+  scopes: BrainScope[];
+}
+
+export async function summarizeViaClientSampling({
+  deps,
+  server,
+  companyId,
+  entityId,
+  asOf,
+  scopes,
+}: SummarizeViaClientSamplingOptions): Promise<SamplingSummarizeResult> {
+  const profile = await deps.entities.getProfile({
     companyId,
-    entityId,
-    asOf,
+    entityIdRaw: entityId,
+    asOfRaw: asOf,
     scopes,
-  );
+  });
   const caps = server.server.getClientCapabilities();
   if (!caps?.sampling) {
-    return fallback(deps.summarizer, companyId, entityId, asOf, scopes);
+    return fallback({ summarizer: deps.summarizer, companyId, entityId, asOf, scopes });
   }
   const topFacts = profile.facts
     .filter((f) => f.status === 'active' || f.status === 'competing')
@@ -91,17 +100,23 @@ export async function summarizeViaClientSampling(
     log.warn(
       `summarize_entity sampling fell back to template: ${(err as Error).message}`,
     );
-    return fallback(deps.summarizer, companyId, entityId, asOf, scopes);
+    return fallback({ summarizer: deps.summarizer, companyId, entityId, asOf, scopes });
   }
 }
 
-async function fallback(
-  summarizer: SummarizeEntityService,
-  companyId: string,
-  entityId: string,
-  asOf: string | undefined,
-  scopes: BrainScope[],
-): Promise<SamplingSummarizeResult> {
+async function fallback({
+  summarizer,
+  companyId,
+  entityId,
+  asOf,
+  scopes,
+}: {
+  summarizer: SummarizeEntityService;
+  companyId: string;
+  entityId: string;
+  asOf: string | undefined;
+  scopes: BrainScope[];
+}): Promise<SamplingSummarizeResult> {
   const out = await summarizer.summarize(
     companyId,
     { entityId, asOf, styleHint: 'neutral' },

--- a/src/mcp/write-tools.ts
+++ b/src/mcp/write-tools.ts
@@ -116,9 +116,13 @@ export function registerWriteTools(
       },
     },
     async (args) => {
-      const out = await deps.facts.retract(companyId, args.factId, {
-        reason: args.reason,
-        retractedBy: { source: 'system' },
+      const out = await deps.facts.retract({
+        companyId,
+        factId: args.factId,
+        dto: {
+          reason: args.reason,
+          retractedBy: { source: 'system' },
+        },
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
@@ -218,9 +222,13 @@ export function registerAdminTools(
       },
     },
     async (args) => {
-      const out = await deps.entities.forget(companyId, args.entityId, {
-        reason: args.reason,
-        requestId: args.requestId,
+      const out = await deps.entities.forget({
+        companyId,
+        entityIdRaw: args.entityId,
+        dto: {
+          reason: args.reason,
+          requestId: args.requestId,
+        },
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],

--- a/src/multi-hop/multi-hop.controller.ts
+++ b/src/multi-hop/multi-hop.controller.ts
@@ -15,10 +15,10 @@ export class MultiHopController {
   // Planner + up to maxHops sub-searches + optional synthesize → expensive.
   @Throttle({ expensive: { limit: 10, ttl: 60_000 } })
   async run(@Req() req: AuthenticatedRequest, @Body() body: MultiHopDto) {
-    return this.multiHop.run(
-      req.brainAuth.companyId,
-      body,
-      req.brainAuth.scopes,
-    );
+    return this.multiHop.run({
+      companyId: req.brainAuth.companyId,
+      dto: body,
+      callerScopes: req.brainAuth.scopes,
+    });
   }
 }

--- a/src/multi-hop/multi-hop.service.ts
+++ b/src/multi-hop/multi-hop.service.ts
@@ -55,6 +55,13 @@ export interface MultiHopResult {
   };
 }
 
+export interface MultiHopRunOptions {
+  companyId: string;
+  dto: MultiHopDto;
+  callerScopes: string[];
+  onProgress?: ProgressReporter;
+}
+
 /**
  * MultiHopService — chained search across hop-decomposed sub-queries.
  *
@@ -113,12 +120,12 @@ export class MultiHopService {
   // termination; refactoring splits the chain semantics across
   // helpers without clarity gain.
   /* eslint-disable-next-line complexity */
-  async run(
-    companyId: string,
-    dto: MultiHopDto,
-    callerScopes: string[],
-    onProgress: ProgressReporter = NOOP_REPORTER,
-  ): Promise<MultiHopResult> {
+  async run({
+    companyId,
+    dto,
+    callerScopes,
+    onProgress = NOOP_REPORTER,
+  }: MultiHopRunOptions): Promise<MultiHopResult> {
     const maxHops = Math.min(dto.maxHops ?? 3, 5);
 
     onProgress({ stage: 'planning', message: 'planner-LLM decomposing query' });
@@ -153,7 +160,13 @@ export class MultiHopService {
         subQuery: dto.query,
         combination: 'seed' as const,
       };
-      const hopRes = await this.runHop(companyId, dto, callerScopes, hop, []);
+      const hopRes = await this.runHop({
+        companyId,
+        dto,
+        callerScopes,
+        hop,
+        priorEntityIds: [],
+      });
       this.metrics?.countMultiHop('single_hop');
       const factIds = collectFactIds(hopRes.hits);
       return {
@@ -190,24 +203,24 @@ export class MultiHopService {
         const hopRes = await withSpan(
           'multi_hop.hop',
           () =>
-            this.runHop(
+            this.runHop({
               companyId,
               dto,
               callerScopes,
               hop,
-              i === 0 ? [] : runningIds,
-            ),
+              priorEntityIds: i === 0 ? [] : runningIds,
+            }),
           { 'multi_hop.hop_index': i, 'multi_hop.combination': hop.combination },
         );
 
         const hopIds = hopRes.hits.map((h) => h.entityId);
-        const next = this.combine(
-          hop.combination,
-          runningIds,
+        const next = this.combine({
+          combination: hop.combination,
+          priorIds: runningIds,
           hopIds,
-          runningHitsByEntity,
-          hopRes.hits,
-        );
+          priorByEntity: runningHitsByEntity,
+          hopHits: hopRes.hits,
+        });
 
         outcomes.push({
           hop,
@@ -273,16 +286,16 @@ export class MultiHopService {
       const synth = await withSpan(
         'multi_hop.synthesize',
         () =>
-          this.synthesizer!.synthesize(
+          this.synthesizer!.synthesize({
             companyId,
-            {
+            dto: {
               ...dto,
               entityIds: runningIds,
               synthesize: undefined,
             } as never,
             callerScopes,
             onProgress,
-          ),
+          }),
         { 'multi_hop.final_set': finalHits.length },
       );
       result.synthesis = {
@@ -301,13 +314,19 @@ export class MultiHopService {
    * and, when combination=subset_of_previous, anchors to the running
    * entity set via SearchDto.entityIds (pushed into WHERE).
    */
-  private async runHop(
-    companyId: string,
-    dto: MultiHopDto,
-    callerScopes: string[],
-    hop: HopPlan,
-    priorEntityIds: string[],
-  ): Promise<{ hits: SearchHit[] }> {
+  private async runHop({
+    companyId,
+    dto,
+    callerScopes,
+    hop,
+    priorEntityIds,
+  }: {
+    companyId: string;
+    dto: MultiHopDto;
+    callerScopes: string[];
+    hop: HopPlan;
+    priorEntityIds: string[];
+  }): Promise<{ hits: SearchHit[] }> {
     // Build a per-hop SearchDto that inherits the caller's broad
     // intent (limit, mode, includeContested, ...) and overlays the
     // hop's local refinements.
@@ -378,13 +397,19 @@ export class MultiHopService {
    * Listing it explicitly so adding a new combination later doesn't
    * silently fall through to a default.
    */
-  private combine(
-    combination: HopPlan['combination'],
-    priorIds: string[],
-    hopIds: string[],
-    priorByEntity: Map<string, SearchHit>,
-    hopHits: SearchHit[],
-  ): { ids: string[]; byEntity: Map<string, SearchHit> } {
+  private combine({
+    combination,
+    priorIds,
+    hopIds,
+    priorByEntity,
+    hopHits,
+  }: {
+    combination: HopPlan['combination'];
+    priorIds: string[];
+    hopIds: string[];
+    priorByEntity: Map<string, SearchHit>;
+    hopHits: SearchHit[];
+  }): { ids: string[]; byEntity: Map<string, SearchHit> } {
     const hopByEntity = new Map<string, SearchHit>();
     for (const h of hopHits) hopByEntity.set(h.entityId, h);
 

--- a/src/search/internals/backfill.ts
+++ b/src/search/internals/backfill.ts
@@ -19,15 +19,25 @@ import type { FactRow } from './types';
  * Per-entity LIMIT pushed into DB — no JS-side dedup needed, no
  * over-fetch.
  */
-export async function backfillEntityFacts(
-  db: Surreal,
-  logger: { warn: (msg: string) => void },
-  entityIds: string[],
-  baseWhere: { sql: string; params: Record<string, unknown> },
-  dto: SearchDto,
-  callerScopes: string[],
-  passesPolicy: (row: FactRow, dto: SearchDto, scopes: string[]) => boolean,
-): Promise<Map<string, FactRow[]>> {
+export interface BackfillEntityFactsOptions {
+  db: Surreal;
+  logger: { warn: (msg: string) => void };
+  entityIds: string[];
+  baseWhere: { sql: string; params: Record<string, unknown> };
+  dto: SearchDto;
+  callerScopes: string[];
+  passesPolicy: (row: FactRow, dto: SearchDto, scopes: string[]) => boolean;
+}
+
+export async function backfillEntityFacts({
+  db,
+  logger,
+  entityIds,
+  baseWhere,
+  dto,
+  callerScopes,
+  passesPolicy,
+}: BackfillEntityFactsOptions): Promise<Map<string, FactRow[]>> {
   const out = new Map<string, FactRow[]>();
   if (entityIds.length === 0) return out;
   const ids = entityIds.map((raw) => {

--- a/src/search/internals/edge-expansion.ts
+++ b/src/search/internals/edge-expansion.ts
@@ -120,16 +120,27 @@ export function resolveExpansionConfig(env = process.env): ExpansionConfig {
  * Failure-soft: any query error logs and returns 0 — the pipeline
  * continues with the pre-expansion candidate set.
  */
-export async function expandViaEdges(
-  db: Surreal,
-  logger: { warn: (msg: string) => void },
-  byEntity: Map<string, EntityBucket>,
-  baseWhere: { sql: string; params: Record<string, unknown> },
-  dto: SearchDto,
-  callerScopes: string[],
-  passesPolicy: (row: FactRow, dto: SearchDto, scopes: string[]) => boolean,
-  config: ExpansionConfig = resolveExpansionConfig(),
-): Promise<number> {
+export interface ExpandViaEdgesOptions {
+  db: Surreal;
+  logger: { warn: (msg: string) => void };
+  byEntity: Map<string, EntityBucket>;
+  baseWhere: { sql: string; params: Record<string, unknown> };
+  dto: SearchDto;
+  callerScopes: string[];
+  passesPolicy: (row: FactRow, dto: SearchDto, scopes: string[]) => boolean;
+  config?: ExpansionConfig;
+}
+
+export async function expandViaEdges({
+  db,
+  logger,
+  byEntity,
+  baseWhere,
+  dto,
+  callerScopes,
+  passesPolicy,
+  config = resolveExpansionConfig(),
+}: ExpandViaEdgesOptions): Promise<number> {
   const seeds = selectEdgeExpansionSeeds(byEntity, config.topSeeds);
   if (seeds.length === 0) return 0;
 

--- a/src/search/internals/graph-retrieve-db.ts
+++ b/src/search/internals/graph-retrieve-db.ts
@@ -172,12 +172,19 @@ export async function fetchEntitiesByIds(
  * to still surface a couple of distinct facts on busy entities, small
  * enough that the demo response stays tight.
  */
-export async function fetchFactsForEntities(
-  db: Surreal,
-  entityIds: string[],
-  predicateHints: string[],
-  asOf: string | undefined,
-): Promise<Map<string, GraphFactRow[]>> {
+export interface FetchFactsForEntitiesOptions {
+  db: Surreal;
+  entityIds: string[];
+  predicateHints: string[];
+  asOf: string | undefined;
+}
+
+export async function fetchFactsForEntities({
+  db,
+  entityIds,
+  predicateHints,
+  asOf,
+}: FetchFactsForEntitiesOptions): Promise<Map<string, GraphFactRow[]>> {
   const out = new Map<string, GraphFactRow[]>();
   if (entityIds.length === 0) return out;
   const rids = entityIds.map((s) => new StringRecordId(s));

--- a/src/search/internals/graph-retrieve.ts
+++ b/src/search/internals/graph-retrieve.ts
@@ -82,12 +82,19 @@ const NON_HINT_FACT_SCORE = 0.5;
  *   - Neighbours: 0.7  (one edge away)
  *   - Fact-level score: 1.0 if predicate ∈ hints (or no hints), else 0.5
  */
-export function assembleGraphHits(
-  seedIds: string[],
-  entitiesById: Map<string, GraphEntity>,
-  factsByEntity: Map<string, GraphFactRow[]>,
-  predicateHints: string[],
-): GraphRetrieveHit[] {
+export interface AssembleGraphHitsOptions {
+  seedIds: string[];
+  entitiesById: Map<string, GraphEntity>;
+  factsByEntity: Map<string, GraphFactRow[]>;
+  predicateHints: string[];
+}
+
+export function assembleGraphHits({
+  seedIds,
+  entitiesById,
+  factsByEntity,
+  predicateHints,
+}: AssembleGraphHitsOptions): GraphRetrieveHit[] {
   const seedSet = new Set(seedIds);
   const hintSet = new Set(predicateHints);
 
@@ -96,7 +103,14 @@ export function assembleGraphHits(
   for (const seedId of seedIds) {
     const ent = entitiesById.get(seedId);
     if (!ent) continue;
-    results.push(renderHit(ent, factsByEntity.get(seedId) ?? [], hintSet, SEED_SCORE));
+    results.push(
+      renderHit({
+        ent,
+        rows: factsByEntity.get(seedId) ?? [],
+        hintSet,
+        entityScore: SEED_SCORE,
+      }),
+    );
   }
 
   for (const [eid, ent] of entitiesById) {
@@ -108,18 +122,25 @@ export function assembleGraphHits(
       // keeps the result focused on the asked predicate.
       continue;
     }
-    results.push(renderHit(ent, rows, hintSet, NEIGHBOUR_SCORE));
+    results.push(
+      renderHit({ ent, rows, hintSet, entityScore: NEIGHBOUR_SCORE }),
+    );
   }
 
   return results;
 }
 
-function renderHit(
-  ent: GraphEntity,
-  rows: GraphFactRow[],
-  hintSet: Set<string>,
-  entityScore: number,
-): GraphRetrieveHit {
+function renderHit({
+  ent,
+  rows,
+  hintSet,
+  entityScore,
+}: {
+  ent: GraphEntity;
+  rows: GraphFactRow[];
+  hintSet: Set<string>;
+  entityScore: number;
+}): GraphRetrieveHit {
   const deduped = dedupeAndSortFacts(rows);
   const stage = entityScore === SEED_SCORE ? 'graph_seed' : 'graph_neighbour';
   return {

--- a/src/search/internals/legs.ts
+++ b/src/search/internals/legs.ts
@@ -16,13 +16,21 @@ import type { FactRow } from './types';
  * on the read path. NONE alt (legacy facts or HyPE disabled)
  * contributes -1 so it never wins the max.
  */
-export async function runVectorLeg(
-  db: Surreal,
-  embedder: EmbedderService,
-  query: string,
-  k: number,
-  baseWhere: { sql: string; params: Record<string, unknown> },
-): Promise<FactRow[]> {
+export interface RunVectorLegOptions {
+  db: Surreal;
+  embedder: EmbedderService;
+  query: string;
+  k: number;
+  baseWhere: { sql: string; params: Record<string, unknown> };
+}
+
+export async function runVectorLeg({
+  db,
+  embedder,
+  query,
+  k,
+  baseWhere,
+}: RunVectorLegOptions): Promise<FactRow[]> {
   const queryEmbedding = await embedder.embed(query);
   const sql = `
       SELECT
@@ -61,13 +69,21 @@ export async function runVectorLeg(
  * / test fixtures pre-dating migration 0007) — the vector leg keeps
  * serving the request.
  */
-export async function runLexicalLeg(
-  db: Surreal,
-  logger: { warn: (msg: string) => void },
-  query: string,
-  k: number,
-  baseWhere: { sql: string; params: Record<string, unknown> },
-): Promise<FactRow[]> {
+export interface RunLexicalLegOptions {
+  db: Surreal;
+  logger: { warn: (msg: string) => void };
+  query: string;
+  k: number;
+  baseWhere: { sql: string; params: Record<string, unknown> };
+}
+
+export async function runLexicalLeg({
+  db,
+  logger,
+  query,
+  k,
+  baseWhere,
+}: RunLexicalLegOptions): Promise<FactRow[]> {
   // Parens around the OR clause are LOAD-BEARING. SurrealQL
   // evaluates AND with higher precedence than OR (same as SQL),
   // so without them the WHERE parses as

--- a/src/search/internals/ppr.ts
+++ b/src/search/internals/ppr.ts
@@ -66,12 +66,19 @@ export function buildPprSeed(
 
 /** PPR step 4 — power-iteration `r ← α·M·r + (1−α)·seed` with
  *  dangling-node mass returned to the seed slot. */
-export function runPprIterations(
-  ids: string[],
-  adj: Map<string, Array<{ to: string; w: number }>>,
-  outWeight: Map<string, number>,
-  seed: Map<string, number>,
-): Map<string, number> {
+export interface RunPprIterationsOptions {
+  ids: string[];
+  adj: Map<string, Array<{ to: string; w: number }>>;
+  outWeight: Map<string, number>;
+  seed: Map<string, number>;
+}
+
+export function runPprIterations({
+  ids,
+  adj,
+  outWeight,
+  seed,
+}: RunPprIterationsOptions): Map<string, number> {
   let r = new Map(seed);
   for (let i = 0; i < ITERATIONS; i++) {
     const next = new Map<string, number>();
@@ -136,6 +143,6 @@ export async function applyPprPrior(
   const seed = buildPprSeed(byEntity);
   if (!seed) return;
 
-  const r = runPprIterations(ids, adj, outWeight, seed);
+  const r = runPprIterations({ ids, adj, outWeight, seed });
   applyPprBoost(byEntity, r);
 }

--- a/src/search/internals/response-builder.ts
+++ b/src/search/internals/response-builder.ts
@@ -19,12 +19,19 @@ import type { EntityBucket, FactRow } from './types';
  * address, occupation, genre} instead of {name, occupation×4} and
  * the eval-side fact-predicate assertion passes.
  */
-export function assembleHits(
-  topEntities: EntityBucket[],
-  backfillByEntity: Map<string, FactRow[]>,
-  entityTypes: string[] | undefined,
+export interface AssembleHitsOptions {
+  topEntities: EntityBucket[];
+  backfillByEntity: Map<string, FactRow[]>;
+  entityTypes: string[] | undefined;
+  requireProvenance?: boolean;
+}
+
+export function assembleHits({
+  topEntities,
+  backfillByEntity,
+  entityTypes,
   requireProvenance = false,
-): SearchHit[] {
+}: AssembleHitsOptions): SearchHit[] {
   // requireProvenance — DTO compliance primitive: keep only facts whose
   // ingest path preserved a non-empty `source` trail (vertical/eventId/
   // messageId). `source` is on FactRow here but not projected onto the

--- a/src/search/internals/scoring.ts
+++ b/src/search/internals/scoring.ts
@@ -51,12 +51,19 @@ export interface ConfidenceCalibrator {
  * null → no decay (1.0). `calibrator` null → calibratedConfidence ===
  * rawConfidence.
  */
-export function scoreRows(
-  rows: FusedRow[],
-  predicateDist: PredicateDistribution | null,
-  now: number,
-  calibrator: ConfidenceCalibrator | null = null,
-): ScoredRow[] {
+export interface ScoreRowsOptions {
+  rows: FusedRow[];
+  predicateDist: PredicateDistribution | null;
+  now: number;
+  calibrator?: ConfidenceCalibrator | null;
+}
+
+export function scoreRows({
+  rows,
+  predicateDist,
+  now,
+  calibrator = null,
+}: ScoreRowsOptions): ScoredRow[] {
   return rows.map((row) => {
     const policy = policyFor(row.predicate);
     const ageDays = (now - new Date(row.recordedAt).getTime()) / 86_400_000;

--- a/src/search/internals/stage-budget.ts
+++ b/src/search/internals/stage-budget.ts
@@ -54,14 +54,23 @@ export function resolveStageBudgets(env = process.env): StageBudgets {
  * fine, the result is dropped on the floor. Memory pressure is bounded
  * by OPENAI_CONCURRENCY / per-stage limiters upstream.
  */
-export async function withStageBudget<T>(
-  stage: keyof typeof DEFAULT_STAGE_BUDGET_MS,
-  budgetMs: number,
-  fn: () => Promise<T>,
-  fallback: T,
-  logger?: { warn: (msg: string) => void },
-  onFallback?: () => void,
-): Promise<T> {
+export interface WithStageBudgetOptions<T> {
+  stage: keyof typeof DEFAULT_STAGE_BUDGET_MS;
+  budgetMs: number;
+  fn: () => Promise<T>;
+  fallback: T;
+  logger?: { warn: (msg: string) => void };
+  onFallback?: () => void;
+}
+
+export async function withStageBudget<T>({
+  stage,
+  budgetMs,
+  fn,
+  fallback,
+  logger,
+  onFallback,
+}: WithStageBudgetOptions<T>): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<{ __timedOut: true }>((resolve) => {
     timer = setTimeout(() => resolve({ __timedOut: true }), budgetMs);

--- a/src/search/internals/where-builder.ts
+++ b/src/search/internals/where-builder.ts
@@ -21,13 +21,21 @@ export interface BaseWhereOptions {
   langFilter?: string;
 }
 
-export function buildBaseWhere(
-  dto: SearchDto,
-  asOf: Date | null,
-  includeRetracted: boolean,
-  includeContested: boolean,
-  opts: BaseWhereOptions = {},
-): { sql: string; params: Record<string, unknown> } {
+export interface BuildBaseWhereOptions {
+  dto: SearchDto;
+  asOf: Date | null;
+  includeRetracted: boolean;
+  includeContested: boolean;
+  opts?: BaseWhereOptions;
+}
+
+export function buildBaseWhere({
+  dto,
+  asOf,
+  includeRetracted,
+  includeContested,
+  opts = {},
+}: BuildBaseWhereOptions): { sql: string; params: Record<string, unknown> } {
   const clauses: string[] = [];
   const params: Record<string, unknown> = {};
 

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -125,14 +125,14 @@ export class SearchService {
    * Soft-fail across the board: a query error logs and returns the
    * partial result so the caller can fall through to vector.
    */
-  async graphRetrieve(
-    companyId: string,
-    queryText: string,
-    entityRefs: string[],
-    predicateHints: string[],
-    asOf: string | undefined,
-    callerScopes: string[],
-  ): Promise<{ results: GraphRetrieveHit[] }> {
+  async graphRetrieve({
+    companyId,
+    queryText,
+    entityRefs,
+    predicateHints,
+    asOf,
+    callerScopes,
+  }: GraphRetrieveOptions): Promise<{ results: GraphRetrieveHit[] }> {
     return this.surreal.withScopedCompany(
       companyId,
       callerScopes,
@@ -152,12 +152,12 @@ export class SearchService {
           for (const e of seeds) entitiesById.set(e.entityId, e);
           for (const e of neighbours) entitiesById.set(e.entityId, e);
 
-          const factsByEntity = await fetchFactsForEntities(
+          const factsByEntity = await fetchFactsForEntities({
             db,
-            [...entitiesById.keys()],
+            entityIds: [...entitiesById.keys()],
             predicateHints,
             asOf,
-          );
+          });
 
           traceArtifact('graph_retrieve', {
             seeds: seedIds,
@@ -168,12 +168,12 @@ export class SearchService {
             predicateHints,
           });
 
-          const results = assembleGraphHits(
+          const results = assembleGraphHits({
             seedIds,
             entitiesById,
             factsByEntity,
             predicateHints,
-          );
+          });
           return { results };
         } catch (err) {
           this.logger.warn(
@@ -248,13 +248,13 @@ export class SearchService {
     // filter → cross-lingual backoff strategy. `und` or disabled →
     // single-pass exactly as before.
     const langFilter = this.resolveLangFilter(ctx.dto);
-    const baseWhere = buildBaseWhere(
-      ctx.dto,
-      ctx.asOf,
-      ctx.includeRetracted,
-      ctx.includeContested,
-      { langFilter },
-    );
+    const baseWhere = buildBaseWhere({
+      dto: ctx.dto,
+      asOf: ctx.asOf,
+      includeRetracted: ctx.includeRetracted,
+      includeContested: ctx.includeContested,
+      opts: { langFilter },
+    });
     traceArtifact('search.query', {
       query: ctx.dto.query,
       mode: ctx.mode,
@@ -274,12 +274,12 @@ export class SearchService {
       // which is wrong: only the non-duplicate fallback rows get pushed, so
       // the subtraction undercounts the true first pass.
       const firstPassCount = fused.length;
-      const fallbackWhere = buildBaseWhere(
-        ctx.dto,
-        ctx.asOf,
-        ctx.includeRetracted,
-        ctx.includeContested,
-      );
+      const fallbackWhere = buildBaseWhere({
+        dto: ctx.dto,
+        asOf: ctx.asOf,
+        includeRetracted: ctx.includeRetracted,
+        includeContested: ctx.includeContested,
+      });
       const fallback = await this.runRetrievalStage(db, ctx, fallbackWhere);
       const seen = new Set(fused.map((r) => String(r.id)));
       for (const r of fallback) {
@@ -311,44 +311,49 @@ export class SearchService {
     // 4. Scoring + per-entity bucketing with diversity-aware degree boost.
     //    `calibration` rewrites the raw confidence via the Phase 3
     //    isotonic map before it folds into the final score.
-    const scored = scoreRows(filtered, predicateDist, Date.now(), {
-      calibrate: (raw: number) => this.calibration.calibrate(raw),
+    const scored = scoreRows({
+      rows: filtered,
+      predicateDist,
+      now: Date.now(),
+      calibrator: {
+        calibrate: (raw: number) => this.calibration.calibrate(raw),
+      },
     });
     const byEntity = bucketByEntity(scored);
 
     // 5. Edge expansion (default ON) — graph-walk from top seeds.
-    await this.runEdgeExpansionStage(db, byEntity, baseWhere, ctx);
+    await this.runEdgeExpansionStage({ db, byEntity, baseWhere, ctx });
 
     // 6. PPR (opt-in) — HippoRAG-style cluster lift.
     await this.runPprStage(db, byEntity);
 
     // 7. Cross-encoder + LLM rerank.
-    let topEntities = await this.runRerankStage(db, byEntity, ctx, typeDist);
+    let topEntities = await this.runRerankStage({ db, byEntity, ctx, typeDist });
     topEntities = topEntities.slice(0, ctx.limit);
 
     // 8. Backfill missing facts for top-K, then assemble.
-    const backfillByEntity = await withStageBudget(
-      'backfill',
-      this.budgets.backfill,
-      () =>
-        backfillEntityFacts(
+    const backfillByEntity = await withStageBudget({
+      stage: 'backfill',
+      budgetMs: this.budgets.backfill,
+      fn: () =>
+        backfillEntityFacts({
           db,
-          this.logger,
-          topEntities.map((e) => e.entityId),
+          logger: this.logger,
+          entityIds: topEntities.map((e) => e.entityId),
           baseWhere,
-          ctx.dto,
-          ctx.callerScopes,
+          dto: ctx.dto,
+          callerScopes: ctx.callerScopes,
           passesPolicy,
-        ),
-      new Map<string, FactRow[]>(),
-      this.logger,
-    );
-    const hits = assembleHits(
+        }),
+      fallback: new Map<string, FactRow[]>(),
+      logger: this.logger,
+    });
+    const hits = assembleHits({
       topEntities,
       backfillByEntity,
-      ctx.dto.entityTypes,
-      ctx.dto.requireProvenance === true,
-    );
+      entityTypes: ctx.dto.entityTypes,
+      requireProvenance: ctx.dto.requireProvenance === true,
+    });
     return { results: applyOutputShaping(hits, ctx.dto) };
   }
 
@@ -363,13 +368,13 @@ export class SearchService {
         : withSpan(
             'search.vector_leg',
             async (span) => {
-              const rows = await runVectorLeg(
+              const rows = await runVectorLeg({
                 db,
-                this.embedder,
-                ctx.dto.query,
-                ctx.candidateK,
+                embedder: this.embedder,
+                query: ctx.dto.query,
+                k: ctx.candidateK,
                 baseWhere,
-              );
+              });
               span.setAttribute('candidates', rows.length);
               traceArtifact(
                 'search.vector_hits',
@@ -390,13 +395,13 @@ export class SearchService {
         : withSpan(
             'search.lexical_leg',
             async (span) => {
-              const rows = await runLexicalLeg(
+              const rows = await runLexicalLeg({
                 db,
-                this.logger,
-                ctx.dto.query,
-                ctx.candidateK,
+                logger: this.logger,
+                query: ctx.dto.query,
+                k: ctx.candidateK,
                 baseWhere,
-              );
+              });
               span.setAttribute('candidates', rows.length);
               traceArtifact(
                 'search.lexical_hits',
@@ -418,13 +423,13 @@ export class SearchService {
 
   private async runRouterStage(query: string) {
     const out = await withSpan('search.route', async (span) => {
-      const r = await withStageBudget(
-        'router',
-        this.budgets.router,
-        () => this.predicateRouter.route(query),
-        null,
-        this.logger,
-      );
+      const r = await withStageBudget({
+        stage: 'router',
+        budgetMs: this.budgets.router,
+        fn: () => this.predicateRouter.route(query),
+        fallback: null,
+        logger: this.logger,
+      });
       span.setAttribute('router.hit', r !== null);
       return r;
     });
@@ -432,26 +437,31 @@ export class SearchService {
     return out;
   }
 
-  private async runEdgeExpansionStage(
-    db: Surreal,
-    byEntity: Map<string, EntityBucket>,
-    baseWhere: { sql: string; params: Record<string, unknown> },
-    ctx: PipelineContext,
-  ): Promise<void> {
+  private async runEdgeExpansionStage({
+    db,
+    byEntity,
+    baseWhere,
+    ctx,
+  }: {
+    db: Surreal;
+    byEntity: Map<string, EntityBucket>;
+    baseWhere: { sql: string; params: Record<string, unknown> };
+    ctx: PipelineContext;
+  }): Promise<void> {
     if (process.env.SEARCH_EDGE_EXPANSION_ENABLED === '0') return;
     if (byEntity.size < 1) return;
     await withSpan(
       'search.edge_expansion',
       async (span) => {
-        const injected = await expandViaEdges(
+        const injected = await expandViaEdges({
           db,
-          this.logger,
+          logger: this.logger,
           byEntity,
           baseWhere,
-          ctx.dto,
-          ctx.callerScopes,
+          dto: ctx.dto,
+          callerScopes: ctx.callerScopes,
           passesPolicy,
-        );
+        });
         span.setAttribute('edge_expansion.injected', injected);
         if (injected > 0) {
           traceArtifact('search.edge_expansion', {
@@ -482,12 +492,17 @@ export class SearchService {
     );
   }
 
-  private async runRerankStage(
-    db: Surreal,
-    byEntity: Map<string, EntityBucket>,
-    ctx: PipelineContext,
-    typeDist: { weights: Record<string, number> } | null,
-  ): Promise<EntityBucket[]> {
+  private async runRerankStage({
+    db,
+    byEntity,
+    ctx,
+    typeDist,
+  }: {
+    db: Surreal;
+    byEntity: Map<string, EntityBucket>;
+    ctx: PipelineContext;
+    typeDist: { weights: Record<string, number> } | null;
+  }): Promise<EntityBucket[]> {
     const RERANK_WINDOW = Math.min(ctx.limit * 2, 20);
     const CROSS_ENCODER_WINDOW = this.crossEncoder.isEnabled()
       ? Math.min(
@@ -540,7 +555,7 @@ export class SearchService {
       return candidatesForRerank;
     }
 
-    return this.runLlmRerank(db, candidatesForRerank, ctx, typeDist);
+    return this.runLlmRerank({ db, candidatesForRerank, ctx, typeDist });
   }
 
   private async runCrossEncoder(
@@ -573,28 +588,33 @@ export class SearchService {
     const xPerm = await withSpan(
       'search.cross_encoder',
       () =>
-        withStageBudget(
-          'crossEncoder',
-          this.budgets.crossEncoder,
-          () => this.crossEncoder.rerank(query, xInputs),
-          identityPerm,
-          this.logger,
-          () => {
+        withStageBudget({
+          stage: 'crossEncoder',
+          budgetMs: this.budgets.crossEncoder,
+          fn: () => this.crossEncoder.rerank(query, xInputs),
+          fallback: identityPerm,
+          logger: this.logger,
+          onFallback: () => {
             timedOut = true;
           },
-        ),
+        }),
       { 'cross_encoder.candidates': xInputs.length },
     );
     this.metrics?.countCrossEncoder(timedOut ? 'error' : 'invoked');
     return xPerm.map((i) => wideCandidates[i]).slice(0, rerankWindow);
   }
 
-  private async runLlmRerank(
-    db: Surreal,
-    candidatesForRerank: EntityBucket[],
-    ctx: PipelineContext,
-    typeDist: { weights: Record<string, number> } | null,
-  ): Promise<EntityBucket[]> {
+  private async runLlmRerank({
+    db,
+    candidatesForRerank,
+    ctx,
+    typeDist,
+  }: {
+    db: Surreal;
+    candidatesForRerank: EntityBucket[];
+    ctx: PipelineContext;
+    typeDist: { weights: Record<string, number> } | null;
+  }): Promise<EntityBucket[]> {
     // SubgraphRAG-style 1-hop neighbourhood injection. Surfaces graph
     // context as "Connected to: …" lines in the candidate body — lets
     // the reranker disambiguate shared-firstname / same-topic peers by
@@ -648,19 +668,28 @@ export class SearchService {
     const permutation = await withSpan(
       'search.rerank',
       () =>
-        withStageBudget(
-          'rerank',
-          this.budgets.rerank,
-          () => this.reranker.rerank(ctx.dto.query, rerankInputs, hints),
-          identityPerm,
-          this.logger,
-        ),
+        withStageBudget({
+          stage: 'rerank',
+          budgetMs: this.budgets.rerank,
+          fn: () => this.reranker.rerank(ctx.dto.query, rerankInputs, hints),
+          fallback: identityPerm,
+          logger: this.logger,
+        }),
       { 'rerank.candidates': rerankInputs.length },
     );
     const isIdentity = permutation.every((idx, i) => idx === i);
     this.metrics?.countRerank(isIdentity ? 'skipped_disabled' : 'invoked');
     return permutation.map((i) => candidatesForRerank[i]);
   }
+}
+
+export interface GraphRetrieveOptions {
+  companyId: string;
+  queryText: string;
+  entityRefs: string[];
+  predicateHints: string[];
+  asOf: string | undefined;
+  callerScopes: string[];
 }
 
 interface PipelineContext {

--- a/src/summarize-entity/summarize-entity.service.ts
+++ b/src/summarize-entity/summarize-entity.service.ts
@@ -50,12 +50,12 @@ export class SummarizeEntityService {
     const cacheKey = buildCacheKey(companyId, args);
     // Freshness probe FIRST — one cheap indexed aggregate. Its wall-clock
     // watermark decides whether a cache hit is still valid.
-    const watermark = await this.entities.freshnessWatermark(
+    const watermark = await this.entities.freshnessWatermark({
       companyId,
-      args.entityId,
-      args.asOf,
+      entityIdRaw: args.entityId,
+      asOfRaw: args.asOf,
       scopes,
-    );
+    });
 
     const hit = this.cache.get(cacheKey);
     if (hit && !isStale(hit.watermark, watermark.maxRecordedAt)) {
@@ -66,12 +66,12 @@ export class SummarizeEntityService {
     }
     if (hit) this.cache.delete(cacheKey); // stale — drop and rebuild below.
 
-    const profile = await this.entities.getProfile(
+    const profile = await this.entities.getProfile({
       companyId,
-      args.entityId,
-      args.asOf,
+      entityIdRaw: args.entityId,
+      asOfRaw: args.asOf,
       scopes,
-    );
+    });
 
     const style = args.styleHint ?? 'neutral';
     const summary = renderSummary(profile, style);

--- a/src/synthesize/synthesize.controller.ts
+++ b/src/synthesize/synthesize.controller.ts
@@ -18,10 +18,10 @@ export class SynthesizeController {
     @Req() req: AuthenticatedRequest,
     @Body() body: SynthesizeDto,
   ) {
-    return this.synthesize.synthesize(
-      req.brainAuth.companyId,
-      body,
-      req.brainAuth.scopes,
-    );
+    return this.synthesize.synthesize({
+      companyId: req.brainAuth.companyId,
+      dto: body,
+      callerScopes: req.brainAuth.scopes,
+    });
   }
 }

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -21,6 +21,13 @@ import {
   type ProgressReporter,
 } from '../mcp/progress-reporter';
 
+export interface SynthesizeOptions {
+  companyId: string;
+  dto: SynthesizeDto;
+  callerScopes: string[];
+  onProgress?: ProgressReporter;
+}
+
 export interface Citation {
   factId: string;
   entityId: string;
@@ -151,12 +158,12 @@ export class SynthesizeService {
     );
   }
 
-  async synthesize(
-    companyId: string,
-    dto: SynthesizeDto,
-    callerScopes: string[],
-    onProgress: ProgressReporter = NOOP_REPORTER,
-  ): Promise<SynthesizeResult> {
+  async synthesize({
+    companyId,
+    dto,
+    callerScopes,
+    onProgress = NOOP_REPORTER,
+  }: SynthesizeOptions): Promise<SynthesizeResult> {
     // Defence-in-depth clamp. SynthesizeDto.@MaxLength('query', 8000)
     // covers HTTP callers, but multi-hop and admin-demo drive
     // synthesize() with bodies that bypass class-validator. Clamp here
@@ -241,7 +248,12 @@ export class SynthesizeService {
         'synthesize.generate',
         () =>
           this.limiter.run(() =>
-            this.callGenerator(dto.query, factLines, model, answerLang),
+            this.callGenerator({
+              query: dto.query,
+              factLines,
+              model,
+              answerLang,
+            }),
           ),
         { 'synthesize.facts': factIndex.size },
       );
@@ -307,35 +319,35 @@ export class SynthesizeService {
         'synthesize.verify',
         () =>
           this.limiter.run(() =>
-            this.callVerifier(
-              dto.query,
-              generated.answer,
+            this.callVerifier({
+              query: dto.query,
+              answer: generated.answer,
               factLines,
               model,
-            ),
+            }),
           ),
         { 'synthesize.facts': factIndex.size },
       );
     } catch (err) {
       this.logger.warn(`Synthesize verifier failed: ${(err as Error).message}`);
       this.metrics?.countSynthesize('verifier_error');
-      return verifierErrorResult(
+      return verifierErrorResult({
         guardrails,
-        generated.answer,
+        answer: generated.answer,
         citations,
         results,
         decisionLog,
-      );
+      });
     }
 
-    return this.finalizeVerdict(
-      verdict.verdict,
-      generated.answer,
+    return this.finalizeVerdict({
+      verdict: verdict.verdict,
+      answer: generated.answer,
       citations,
       results,
       guardrails,
       decisionLog,
-    );
+    });
   }
 
   /**
@@ -347,14 +359,21 @@ export class SynthesizeService {
    * Strict + non-supported → answer dropped (fail-closed). Lenient
    * surfaces the answer with a reason tag. Supported is the ok path.
    */
-  private finalizeVerdict(
-    verdict: VerifierOutput['verdict'],
-    answer: string,
-    citations: Citation[],
-    results: SynthesizeResult['results'],
-    guardrails: SynthesisGuardrails,
-    decisionLog?: DecisionLogEntry[],
-  ): SynthesizeResult {
+  private finalizeVerdict({
+    verdict,
+    answer,
+    citations,
+    results,
+    guardrails,
+    decisionLog,
+  }: {
+    verdict: VerifierOutput['verdict'];
+    answer: string;
+    citations: Citation[];
+    results: SynthesizeResult['results'];
+    guardrails: SynthesisGuardrails;
+    decisionLog?: DecisionLogEntry[];
+  }): SynthesizeResult {
     if (verdict === 'supported') {
       this.metrics?.countSynthesize('ok');
       return attachDecisionLog(
@@ -378,12 +397,17 @@ export class SynthesizeService {
     );
   }
 
-  private async callGenerator(
-    query: string,
-    factLines: string[],
-    model: string,
-    answerLang: string | null,
-  ): Promise<GeneratorOutput> {
+  private async callGenerator({
+    query,
+    factLines,
+    model,
+    answerLang,
+  }: {
+    query: string;
+    factLines: string[];
+    model: string;
+    answerLang: string | null;
+  }): Promise<GeneratorOutput> {
     const langInstruction = answerLang
       ? `\n\nLanguage policy: write your answer in ${answerLang} (ISO 639-1). Keep citation spans in their original language.`
       : '';
@@ -443,12 +467,17 @@ export class SynthesizeService {
     return parsed;
   }
 
-  private async callVerifier(
-    query: string,
-    answer: string,
-    factLines: string[],
-    model: string,
-  ): Promise<VerifierOutput> {
+  private async callVerifier({
+    query,
+    answer,
+    factLines,
+    model,
+  }: {
+    query: string;
+    answer: string;
+    factLines: string[];
+    model: string;
+  }): Promise<VerifierOutput> {
     const user = `Query: ${query}\n\nAnswer:\n${answer}\n\nSource facts:\n${factLines.join('\n')}`;
     traceArtifact('synthesize.verifier_prompt', {
       system: VERIFIER_SYSTEM,
@@ -634,13 +663,19 @@ function detectAnswerLang(query: string): string | null {
  * Extracted from `synthesize()` to keep the orchestrator under the
  * cognitive-complexity gate.
  */
-function verifierErrorResult(
-  guardrails: SynthesisGuardrails,
-  answer: string,
-  citations: Citation[],
-  results: SearchHit[],
-  decisionLog: DecisionLogEntry[] | undefined,
-): SynthesizeResult {
+function verifierErrorResult({
+  guardrails,
+  answer,
+  citations,
+  results,
+  decisionLog,
+}: {
+  guardrails: SynthesisGuardrails;
+  answer: string;
+  citations: Citation[];
+  results: SearchHit[];
+  decisionLog: DecisionLogEntry[] | undefined;
+}): SynthesizeResult {
   if (guardrails === 'strict') {
     return attachDecisionLog(
       { answer: null, reason: 'verifier_error', citations: [], results },

--- a/test/chat-router-hints.unit-spec.ts
+++ b/test/chat-router-hints.unit-spec.ts
@@ -54,35 +54,35 @@ function mkSnapshot(
 
 describe('extractPredicateHintsLocally', () => {
   it('returns [] when snapshot is null', async () => {
-    const hints = await extractPredicateHintsLocally(
-      'q',
-      null,
-      mkEmbedder(new Map([['q', vec([1, 0])]])),
-      0.4,
-      3,
-    );
+    const hints = await extractPredicateHintsLocally({
+      message: 'q',
+      snapshot: null,
+      embedder: mkEmbedder(new Map([['q', vec([1, 0])]])),
+      threshold: 0.4,
+      maxHints: 3,
+    });
     expect(hints).toEqual([]);
   });
 
   it('returns [] when snapshot has no embeddings', async () => {
-    const hints = await extractPredicateHintsLocally(
-      'q',
-      mkSnapshot({}),
-      mkEmbedder(new Map([['q', vec([1, 0])]])),
-      0.4,
-      3,
-    );
+    const hints = await extractPredicateHintsLocally({
+      message: 'q',
+      snapshot: mkSnapshot({}),
+      embedder: mkEmbedder(new Map([['q', vec([1, 0])]])),
+      threshold: 0.4,
+      maxHints: 3,
+    });
     expect(hints).toEqual([]);
   });
 
   it('returns [] when message is empty', async () => {
-    const hints = await extractPredicateHintsLocally(
-      '',
-      mkSnapshot({ address: vec([1, 0]) }),
-      mkEmbedder(new Map()),
-      0.4,
-      3,
-    );
+    const hints = await extractPredicateHintsLocally({
+      message: '',
+      snapshot: mkSnapshot({ address: vec([1, 0]) }),
+      embedder: mkEmbedder(new Map()),
+      threshold: 0.4,
+      maxHints: 3,
+    });
     expect(hints).toEqual([]);
   });
 
@@ -92,13 +92,13 @@ describe('extractPredicateHintsLocally', () => {
       email: vec([0, 1]),
     });
     const emb = mkEmbedder(new Map([['where lives', vec([1, 0])]]));
-    const hints = await extractPredicateHintsLocally(
-      'where lives',
-      snap,
-      emb,
-      0.4,
-      3,
-    );
+    const hints = await extractPredicateHintsLocally({
+      message: 'where lives',
+      snapshot: snap,
+      embedder: emb,
+      threshold: 0.4,
+      maxHints: 3,
+    });
     expect(hints).toHaveLength(1);
     expect(hints[0].predicateId).toBe('address');
     expect(hints[0].similarity).toBeCloseTo(1, 5);
@@ -112,7 +112,13 @@ describe('extractPredicateHintsLocally', () => {
       status: vec([0, 0, 1]),
     });
     const emb = mkEmbedder(new Map([['x', vec([1, 0, 0])]]));
-    const hints = await extractPredicateHintsLocally('x', snap, emb, 0.4, 2);
+    const hints = await extractPredicateHintsLocally({
+      message: 'x',
+      snapshot: snap,
+      embedder: emb,
+      threshold: 0.4,
+      maxHints: 2,
+    });
     expect(hints).toHaveLength(2);
     expect(hints[0].predicateId).toBe('address');
     expect(hints[1].predicateId).toBe('email');
@@ -127,15 +133,21 @@ describe('extractPredicateHintsLocally', () => {
     const emb = mkEmbedder(
       new Map([['x', vec([Math.SQRT1_2, Math.SQRT1_2])]]),
     );
-    const tightHints = await extractPredicateHintsLocally(
-      'x',
-      snap,
-      emb,
-      0.8,
-      3,
-    );
+    const tightHints = await extractPredicateHintsLocally({
+      message: 'x',
+      snapshot: snap,
+      embedder: emb,
+      threshold: 0.8,
+      maxHints: 3,
+    });
     expect(tightHints).toEqual([]);
-    const loose = await extractPredicateHintsLocally('x', snap, emb, 0.5, 3);
+    const loose = await extractPredicateHintsLocally({
+      message: 'x',
+      snapshot: snap,
+      embedder: emb,
+      threshold: 0.5,
+      maxHints: 3,
+    });
     expect(loose.map((h) => h.predicateId).sort()).toEqual([
       'address',
       'email',
@@ -145,13 +157,13 @@ describe('extractPredicateHintsLocally', () => {
   it('returns triggerSpan covering the whole message', async () => {
     const snap = mkSnapshot({ address: vec([1, 0]) });
     const emb = mkEmbedder(new Map([['where Maria lives', vec([1, 0])]]));
-    const hints = await extractPredicateHintsLocally(
-      'where Maria lives',
-      snap,
-      emb,
-      0.4,
-      3,
-    );
+    const hints = await extractPredicateHintsLocally({
+      message: 'where Maria lives',
+      snapshot: snap,
+      embedder: emb,
+      threshold: 0.4,
+      maxHints: 3,
+    });
     expect(hints[0].triggerSpan).toEqual({
       text: 'where Maria lives',
       start: 0,
@@ -161,13 +173,13 @@ describe('extractPredicateHintsLocally', () => {
 
   it('degrades silently when embedder throws', async () => {
     const snap = mkSnapshot({ address: vec([1, 0]) });
-    const hints = await extractPredicateHintsLocally(
-      'x',
-      snap,
-      mkEmbedder(new Map(), true),
-      0.4,
-      3,
-    );
+    const hints = await extractPredicateHintsLocally({
+      message: 'x',
+      snapshot: snap,
+      embedder: mkEmbedder(new Map(), true),
+      threshold: 0.4,
+      maxHints: 3,
+    });
     expect(hints).toEqual([]);
   });
 });

--- a/test/graph-retrieve.unit-spec.ts
+++ b/test/graph-retrieve.unit-spec.ts
@@ -53,12 +53,7 @@ describe('assembleGraphHits — regression for the Acme/Maria case', () => {
       ['e_maria', [fact('f1', 'e_maria', 'status', 'CTO at Acme')]],
     ]);
 
-    const out = assembleGraphHits(
-      ['e_acme'],
-      entitiesById,
-      factsByEntity,
-      ['status'],
-    );
+    const out = assembleGraphHits({ seedIds: ['e_acme'], entitiesById: entitiesById, factsByEntity: factsByEntity, predicateHints: ['status'] });
 
     // Seed comes first (anchor), Maria as the neighbour with the hit.
     expect(out.map((r) => r.entityId)).toEqual(['e_acme', 'e_maria']);
@@ -85,12 +80,7 @@ describe('assembleGraphHits — regression for the Acme/Maria case', () => {
       ['e_bob', [fact('f1', 'e_bob', 'address', '4B')]], // not 'status'
     ]);
 
-    const out = assembleGraphHits(
-      ['e_acme'],
-      entitiesById,
-      factsByEntity,
-      ['status'],
-    );
+    const out = assembleGraphHits({ seedIds: ['e_acme'], entitiesById: entitiesById, factsByEntity: factsByEntity, predicateHints: ['status'] });
 
     expect(out.map((r) => r.entityId)).toEqual(['e_acme']);
   });
@@ -107,7 +97,7 @@ describe('assembleGraphHits — regression for the Acme/Maria case', () => {
       ['e_bob', [fact('f1', 'e_bob', 'name', 'Bob Müller')]],
     ]);
 
-    const out = assembleGraphHits(['e_acme'], entitiesById, factsByEntity, []);
+    const out = assembleGraphHits({ seedIds: ['e_acme'], entitiesById: entitiesById, factsByEntity: factsByEntity, predicateHints: [] });
 
     expect(out.map((r) => r.entityId)).toEqual(['e_acme', 'e_bob']);
   });
@@ -119,9 +109,9 @@ describe('assembleGraphHits — regression for the Acme/Maria case', () => {
     const entitiesById = new Map([['e_acme', acme]]);
     const factsByEntity = new Map<string, GraphFactRow[]>([['e_acme', []]]);
 
-    const out = assembleGraphHits(['e_acme'], entitiesById, factsByEntity, [
+    const out = assembleGraphHits({ seedIds: ['e_acme'], entitiesById: entitiesById, factsByEntity: factsByEntity, predicateHints: [
       'status',
-    ]);
+    ] });
 
     expect(out).toHaveLength(1);
     expect(out[0].entityId).toBe('e_acme');
@@ -140,12 +130,7 @@ describe('assembleGraphHits — regression for the Acme/Maria case', () => {
       ['e_beta', [fact('f2', 'e_beta', 'name', 'BetaCorp')]],
     ]);
 
-    const out = assembleGraphHits(
-      ['e_beta', 'e_acme'],
-      entitiesById,
-      factsByEntity,
-      [],
-    );
+    const out = assembleGraphHits({ seedIds: ['e_beta', 'e_acme'], entitiesById: entitiesById, factsByEntity: factsByEntity, predicateHints: [] });
 
     expect(out.map((r) => r.entityId)).toEqual(['e_beta', 'e_acme']);
   });
@@ -159,12 +144,7 @@ describe('assembleGraphHits — regression for the Acme/Maria case', () => {
       ['e_maria', [older, newer]],
     ]);
 
-    const out = assembleGraphHits(
-      ['e_maria'],
-      entitiesById,
-      factsByEntity,
-      ['status'],
-    );
+    const out = assembleGraphHits({ seedIds: ['e_maria'], entitiesById: entitiesById, factsByEntity: factsByEntity, predicateHints: ['status'] });
 
     expect(out[0].facts).toHaveLength(1);
     expect(out[0].facts[0].factId).toBe('f_new');
@@ -183,24 +163,14 @@ describe('assembleGraphHits — regression for the Acme/Maria case', () => {
       ],
     ]);
 
-    const out = assembleGraphHits(
-      ['e_maria'],
-      entitiesById,
-      factsByEntity,
-      ['status'],
-    );
+    const out = assembleGraphHits({ seedIds: ['e_maria'], entitiesById: entitiesById, factsByEntity: factsByEntity, predicateHints: ['status'] });
 
     const byPredicate = new Map(out[0].facts.map((f) => [f.predicate, f.score]));
     expect(byPredicate.get('status')).toBeGreaterThan(byPredicate.get('name')!);
   });
 
   it('unknown seed id (not in entitiesById) is skipped without crashing', () => {
-    const out = assembleGraphHits(
-      ['e_missing'],
-      new Map(),
-      new Map(),
-      ['status'],
-    );
+    const out = assembleGraphHits({ seedIds: ['e_missing'], entitiesById: new Map(), factsByEntity: new Map(), predicateHints: ['status'] });
     expect(out).toEqual([]);
   });
 });

--- a/test/inline-entity-resolution.unit-spec.ts
+++ b/test/inline-entity-resolution.unit-spec.ts
@@ -53,28 +53,28 @@ describe('EntityResolverService.resolveByName', () => {
       ...ENABLED,
       INGEST_INLINE_RESOLUTION_ENABLED: '0',
     });
-    expect(await svc.resolveByName(db as any, 'Acme', 'customer', [])).toBeNull();
+    expect(await svc.resolveByName({ db: db as any, name: 'Acme', type: 'customer', incomingFacts: [] })).toBeNull();
     expect(db.query).not.toHaveBeenCalled();
     expect(judge.judge).not.toHaveBeenCalled();
   });
 
   it('returns null when the judge service is unavailable (no key)', async () => {
     const { svc, db } = makeService(ENABLED, { isAvailable: () => false });
-    expect(await svc.resolveByName(db as any, 'Acme', 'customer', [])).toBeNull();
+    expect(await svc.resolveByName({ db: db as any, name: 'Acme', type: 'customer', incomingFacts: [] })).toBeNull();
     expect(db.query).not.toHaveBeenCalled();
   });
 
   it('returns null when no candidate clears the cosine floor', async () => {
     const { svc, db, judge } = makeService(ENABLED);
     db.query.mockResolvedValueOnce(candidate(0.7));
-    expect(await svc.resolveByName(db as any, 'Acme', 'customer', [])).toBeNull();
+    expect(await svc.resolveByName({ db: db as any, name: 'Acme', type: 'customer', incomingFacts: [] })).toBeNull();
     expect(judge.judge).not.toHaveBeenCalled();
   });
 
   it('ignores a high-cosine candidate of a different type', async () => {
     const { svc, db, judge } = makeService(ENABLED);
     db.query.mockResolvedValueOnce(candidate(0.97, 'asset'));
-    expect(await svc.resolveByName(db as any, 'Acme', 'customer', [])).toBeNull();
+    expect(await svc.resolveByName({ db: db as any, name: 'Acme', type: 'customer', incomingFacts: [] })).toBeNull();
     expect(judge.judge).not.toHaveBeenCalled();
   });
 
@@ -82,9 +82,12 @@ describe('EntityResolverService.resolveByName', () => {
     const { svc, db, judge } = makeService(ENABLED);
     db.query.mockResolvedValueOnce(candidate(0.95));
     judge.judge.mockResolvedValue('same');
-    const out = await svc.resolveByName(db as any, 'Acme', 'customer', [
-      'dob: 1990-01-01',
-    ]);
+    const out = await svc.resolveByName({
+      db: db as any,
+      name: 'Acme',
+      type: 'customer',
+      incomingFacts: ['dob: 1990-01-01'],
+    });
     expect(out).toBe('knowledge_entity:x');
     expect(judge.judge).toHaveBeenCalledWith(
       '- dob: 1990-01-01',
@@ -100,7 +103,12 @@ describe('EntityResolverService.resolveByName', () => {
       db.query.mockResolvedValueOnce(candidate(0.95));
       judge.judge.mockResolvedValue(verdict);
       expect(
-        await svc.resolveByName(db as any, 'John Smith', 'customer', []),
+        await svc.resolveByName({
+          db: db as any,
+          name: 'John Smith',
+          type: 'customer',
+          incomingFacts: [],
+        }),
       ).toBeNull();
     },
   );
@@ -108,6 +116,6 @@ describe('EntityResolverService.resolveByName', () => {
   it('falls back to null when a DB read throws', async () => {
     const { svc, db } = makeService(ENABLED);
     db.query.mockRejectedValue(new Error('surreal down'));
-    expect(await svc.resolveByName(db as any, 'Acme', 'customer', [])).toBeNull();
+    expect(await svc.resolveByName({ db: db as any, name: 'Acme', type: 'customer', incomingFacts: [] })).toBeNull();
   });
 });

--- a/test/multi-hop.unit-spec.ts
+++ b/test/multi-hop.unit-spec.ts
@@ -87,7 +87,7 @@ describe('MultiHopService', () => {
       [hit('e1'), hit('e2')],
     ]);
     const svc = makeSvc(search, makePlanner(null));
-    const out = await svc.run('co_x', baseDto, scopes);
+    const out = await svc.run({ companyId: 'co_x', dto: baseDto, callerScopes: scopes });
     expect(out.isMultiHop).toBe(false);
     expect(out.hops).toEqual([]);
     expect(out.finalEntityIds).toEqual(['e1', 'e2']);
@@ -112,7 +112,7 @@ describe('MultiHopService', () => {
         ],
       }),
     );
-    const out = await svc.run('co_x', baseDto, scopes);
+    const out = await svc.run({ companyId: 'co_x', dto: baseDto, callerScopes: scopes });
     expect(out.isMultiHop).toBe(false);
     expect(out.hops.length).toBe(1);
     expect(out.finalEntityIds).toEqual(['e1']);
@@ -144,7 +144,7 @@ describe('MultiHopService', () => {
       ],
     };
     const svc = makeSvc(search, makePlanner(plan));
-    const out = await svc.run('co_x', baseDto, scopes);
+    const out = await svc.run({ companyId: 'co_x', dto: baseDto, callerScopes: scopes });
     expect(out.isMultiHop).toBe(true);
     expect(out.hops.length).toBe(2);
     expect(out.finalEntityIds).toEqual(['e2', 'e3']);
@@ -178,7 +178,7 @@ describe('MultiHopService', () => {
       ],
     };
     const svc = makeSvc(search, makePlanner(plan));
-    const out = await svc.run('co_x', baseDto, scopes);
+    const out = await svc.run({ companyId: 'co_x', dto: baseDto, callerScopes: scopes });
     expect(out.finalEntityIds).toEqual(['e2']);
     // Hop 2 must NOT be anchored — intersect runs unconstrained.
     const hop2Dto = calls[1] as { entityIds?: string[] };
@@ -210,7 +210,7 @@ describe('MultiHopService', () => {
       ],
     };
     const svc = makeSvc(search, makePlanner(plan));
-    const out = await svc.run('co_x', baseDto, scopes);
+    const out = await svc.run({ companyId: 'co_x', dto: baseDto, callerScopes: scopes });
     expect(out.finalEntityIds.sort()).toEqual(['e1', 'e2', 'e3', 'e4']);
   });
 
@@ -247,7 +247,7 @@ describe('MultiHopService', () => {
       ],
     };
     const svc = makeSvc(search, makePlanner(plan));
-    const out = await svc.run('co_x', baseDto, scopes);
+    const out = await svc.run({ companyId: 'co_x', dto: baseDto, callerScopes: scopes });
     // Hop 3 should NOT have been called.
     expect(calls.length).toBe(2);
     expect(out.finalEntityIds).toEqual([]);
@@ -287,7 +287,7 @@ describe('MultiHopService', () => {
       ],
     };
     const svc = makeSvc(search, makePlanner(plan));
-    const out = await svc.run('co_x', baseDto, scopes);
+    const out = await svc.run({ companyId: 'co_x', dto: baseDto, callerScopes: scopes });
     expect(out.hops.length).toBe(1);
     expect(out.finalEntityIds).toEqual(['e1', 'e2']);
   });
@@ -305,7 +305,7 @@ describe('MultiHopService', () => {
       search,
       makePlanner({ isMultiHop: false, hops: [hop] }),
     );
-    await svc.run('co_x', baseDto, scopes);
+    await svc.run({ companyId: 'co_x', dto: baseDto, callerScopes: scopes });
     const dto = calls[0] as { predicates?: string[]; asOf?: string };
     expect(dto.predicates).toEqual(['tier', 'status']);
     expect(dto.asOf).toBe('2026-04-01T00:00:00Z');
@@ -324,11 +324,11 @@ describe('MultiHopService', () => {
       search,
       makePlanner({ isMultiHop: false, hops: [hop] }),
     );
-    await svc.run(
-      'co_x',
-      { ...baseDto, predicates: ['inherited'] },
-      scopes,
-    );
+    await svc.run({
+      companyId: 'co_x',
+      dto: { ...baseDto, predicates: ['inherited'] },
+      callerScopes: scopes,
+    });
     // Hop omitted predicates ⇒ caller's inherited list survives.
     const dto = calls[0] as { predicates?: string[] };
     expect(dto.predicates).toEqual(['inherited']);
@@ -357,7 +357,11 @@ describe('MultiHopService', () => {
       search.svc,
       makePlanner({ isMultiHop: true, hops: seven }),
     );
-    const out = await svc.run('co_x', { ...baseDto, maxHops: 5 }, scopes);
+    const out = await svc.run({
+      companyId: 'co_x',
+      dto: { ...baseDto, maxHops: 5 },
+      callerScopes: scopes,
+    });
     // The planner can emit at most maxHops hops because the planner
     // caps internally; we don't enforce again in the service. Still,
     // the test is here to flag if the executor starts truncating
@@ -371,7 +375,7 @@ describe('MultiHopService', () => {
       [hit('e2')],
     ]);
     const synth = {
-      synthesize: async (_co: string, dto: { entityIds?: string[] }) => ({
+      synthesize: async ({ dto }: { dto: { entityIds?: string[] } }) => ({
         answer: 'final',
         citations: [],
         results: [],
@@ -399,11 +403,11 @@ describe('MultiHopService', () => {
       ],
     };
     const svc = makeSvc(search, makePlanner(plan), synth);
-    const out = await svc.run(
-      'co_x',
-      { ...baseDto, synthesize: true },
-      scopes,
-    );
+    const out = await svc.run({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesize: true },
+      callerScopes: scopes,
+    });
     expect(out.synthesis?.answer).toBe('final');
     expect(out.finalEntityIds).toEqual(['e2']);
   });
@@ -436,11 +440,11 @@ describe('MultiHopService', () => {
       ],
     };
     const svc = makeSvc(search, makePlanner(plan), synth);
-    const out: MultiHopResult = await svc.run(
-      'co_x',
-      { ...baseDto, synthesize: true },
-      scopes,
-    );
+    const out: MultiHopResult = await svc.run({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesize: true },
+      callerScopes: scopes,
+    });
     expect(out.finalEntityIds).toEqual([]);
     expect(out.synthesis).toBeUndefined();
     // synth.synthesize must NOT have been called on an empty set.
@@ -481,7 +485,7 @@ describe('MultiHopService', () => {
         ],
       };
       const svc = makeSvc(search, makePlanner(plan));
-      const out = await svc.run('co_x', baseDto, scopes);
+      const out = await svc.run({ companyId: 'co_x', dto: baseDto, callerScopes: scopes });
       // Expansion called once for hop 2's prior set.
       expect(expandCalls.length).toBe(1);
       expect(expandCalls[0]).toEqual(['e1']);
@@ -518,7 +522,7 @@ describe('MultiHopService', () => {
         ],
       };
       const svc = makeSvc(search, makePlanner(plan));
-      await svc.run('co_x', baseDto, scopes);
+      await svc.run({ companyId: 'co_x', dto: baseDto, callerScopes: scopes });
       expect(expandCalls.length).toBe(0);
       const hop2Dto = calls[1] as { entityIds?: string[] };
       expect(hop2Dto.entityIds).toEqual(['e1', 'e2']);
@@ -556,7 +560,7 @@ describe('MultiHopService', () => {
         ],
       };
       const svc = makeSvc(search, makePlanner(plan));
-      await svc.run('co_x', baseDto, scopes);
+      await svc.run({ companyId: 'co_x', dto: baseDto, callerScopes: scopes });
       const hop2Dto = calls[1] as { entityIds?: string[] };
       // Bare prior set — no expansion applied.
       expect(hop2Dto.entityIds).toEqual(['e1']);

--- a/test/sampling-fallback.unit-spec.ts
+++ b/test/sampling-fallback.unit-spec.ts
@@ -75,14 +75,14 @@ describe('summarizeViaClientSampling — capability gate + fallback', () => {
 
   it('client advertises sampling → returns client_llm summary', async () => {
     const server = fakeServer({ sampling: true, text: 'Platinum customer.' });
-    const out = await summarizeViaClientSampling(
+    const out = await summarizeViaClientSampling({
       deps,
-      server as never,
-      'co_test',
-      'test_entity',
-      undefined,
-      ['brain:read'],
-    );
+      server: server as never,
+      companyId: 'co_test',
+      entityId: 'test_entity',
+      asOf: undefined,
+      scopes: ['brain:read'],
+    });
     expect(out.sampledBy).toBe('client_llm');
     expect(out.summary).toBe('Platinum customer.');
     expect(out.modelUsed).toBe('fake-client-model-v1');
@@ -90,14 +90,14 @@ describe('summarizeViaClientSampling — capability gate + fallback', () => {
 
   it('client does NOT advertise sampling → falls back to template', async () => {
     const server = fakeServer({ sampling: false });
-    const out = await summarizeViaClientSampling(
+    const out = await summarizeViaClientSampling({
       deps,
-      server as never,
-      'co_test',
-      'test_entity',
-      undefined,
-      ['brain:read'],
-    );
+      server: server as never,
+      companyId: 'co_test',
+      entityId: 'test_entity',
+      asOf: undefined,
+      scopes: ['brain:read'],
+    });
     expect(out.sampledBy).toBe('local_template');
     expect(out.summary).toBe('Test Subject (customer): tier=platinum.');
     expect(out.modelUsed).toBeUndefined();
@@ -105,27 +105,27 @@ describe('summarizeViaClientSampling — capability gate + fallback', () => {
 
   it('createMessage throwing → falls back to template, no error to caller', async () => {
     const server = fakeServer({ sampling: true, shouldThrow: true });
-    const out = await summarizeViaClientSampling(
+    const out = await summarizeViaClientSampling({
       deps,
-      server as never,
-      'co_test',
-      'test_entity',
-      undefined,
-      ['brain:read'],
-    );
+      server: server as never,
+      companyId: 'co_test',
+      entityId: 'test_entity',
+      asOf: undefined,
+      scopes: ['brain:read'],
+    });
     expect(out.sampledBy).toBe('local_template');
   });
 
   it('empty client text → uses entity name + type as a safe default', async () => {
     const server = fakeServer({ sampling: true, text: '' });
-    const out = await summarizeViaClientSampling(
+    const out = await summarizeViaClientSampling({
       deps,
-      server as never,
-      'co_test',
-      'test_entity',
-      undefined,
-      ['brain:read'],
-    );
+      server: server as never,
+      companyId: 'co_test',
+      entityId: 'test_entity',
+      asOf: undefined,
+      scopes: ['brain:read'],
+    });
     expect(out.sampledBy).toBe('client_llm');
     expect(out.summary).toBe('Test Subject (customer)');
   });

--- a/test/search-scoring-shaping.unit-spec.ts
+++ b/test/search-scoring-shaping.unit-spec.ts
@@ -88,12 +88,12 @@ describe('assembleHits requireProvenance', () => {
       fact({ predicate: 'hobby', object: 'chess', source: null }),
       0.8,
     );
-    const hits = assembleHits(
-      [bucket([withSrc, noSrc])],
-      new Map(),
-      undefined,
-      true,
-    );
+    const hits = assembleHits({
+      topEntities: [bucket([withSrc, noSrc])],
+      backfillByEntity: new Map(),
+      entityTypes: undefined,
+      requireProvenance: true,
+    });
     expect(hits).toHaveLength(1);
     const preds = hits[0].facts.map((f) => f.predicate);
     expect(preds).toContain('role');
@@ -105,7 +105,12 @@ describe('assembleHits requireProvenance', () => {
       fact({ predicate: 'hobby', object: 'chess', source: {} }),
       0.8,
     );
-    const hits = assembleHits([bucket([noSrc])], new Map(), undefined, true);
+    const hits = assembleHits({
+      topEntities: [bucket([noSrc])],
+      backfillByEntity: new Map(),
+      entityTypes: undefined,
+      requireProvenance: true,
+    });
     expect(hits).toHaveLength(0);
   });
 
@@ -114,7 +119,12 @@ describe('assembleHits requireProvenance', () => {
       fact({ predicate: 'hobby', object: 'chess', source: null }),
       0.8,
     );
-    const hits = assembleHits([bucket([noSrc])], new Map(), undefined, false);
+    const hits = assembleHits({
+      topEntities: [bucket([noSrc])],
+      backfillByEntity: new Map(),
+      entityTypes: undefined,
+      requireProvenance: false,
+    });
     expect(hits).toHaveLength(1);
     expect(hits[0].facts).toHaveLength(1);
   });

--- a/test/synthesize.unit-spec.ts
+++ b/test/synthesize.unit-spec.ts
@@ -89,7 +89,7 @@ describe('SynthesizeService', () => {
 
   it('returns no_results when search comes back empty', async () => {
     const { svc } = makeSvc(makeSearch([]), {}, []);
-    const out = await svc.synthesize('co_x', baseDto, ['brain:read']);
+    const out = await svc.synthesize({ companyId: 'co_x', dto: baseDto, callerScopes: ['brain:read'] });
     expect(out).toMatchObject<Partial<SynthesizeResult>>({
       answer: null,
       reason: 'no_results',
@@ -114,7 +114,7 @@ describe('SynthesizeService', () => {
         }),
       ],
     );
-    const out = await svc.synthesize('co_x', baseDto, ['brain:read']);
+    const out = await svc.synthesize({ companyId: 'co_x', dto: baseDto, callerScopes: ['brain:read'] });
     expect(out.answer).toBe("I don't have grounded evidence for that.");
     expect(out.reason).toBe('no_grounded_evidence');
     expect(out.citations).toEqual([]);
@@ -141,7 +141,7 @@ describe('SynthesizeService', () => {
         JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
       ],
     );
-    const out = await svc.synthesize('co_x', baseDto, ['brain:read']);
+    const out = await svc.synthesize({ companyId: 'co_x', dto: baseDto, callerScopes: ['brain:read'] });
     expect(out.answer).toContain('broken washing machine');
     expect(out.reason).toBeUndefined();
     expect(out.citations.map((c) => c.factId)).toEqual(['f1']);
@@ -170,11 +170,7 @@ describe('SynthesizeService', () => {
         }),
       ],
     );
-    const out = await svc.synthesize(
-      'co_x',
-      { ...baseDto, synthesisGuardrails: 'off' },
-      ['brain:read'],
-    );
+    const out = await svc.synthesize({ companyId: 'co_x', dto: { ...baseDto, synthesisGuardrails: 'off' }, callerScopes: ['brain:read'] });
     expect(out.citations.map((c) => c.factId)).toEqual([
       'knowledge_fact:abc123',
     ]);
@@ -204,11 +200,7 @@ describe('SynthesizeService', () => {
         }),
       ],
     );
-    const out = await svc.synthesize(
-      'co_x',
-      { ...baseDto, synthesisGuardrails: 'off' },
-      ['brain:read'],
-    );
+    const out = await svc.synthesize({ companyId: 'co_x', dto: { ...baseDto, synthesisGuardrails: 'off' }, callerScopes: ['brain:read'] });
     expect(out.citations.map((c) => c.factId)).toEqual([
       'knowledge_fact:abc123',
     ]);
@@ -230,11 +222,7 @@ describe('SynthesizeService', () => {
         }),
       ],
     );
-    const out = await svc.synthesize(
-      'co_x',
-      { ...baseDto, synthesisGuardrails: 'off' },
-      ['brain:read'],
-    );
+    const out = await svc.synthesize({ companyId: 'co_x', dto: { ...baseDto, synthesisGuardrails: 'off' }, callerScopes: ['brain:read'] });
     expect(out.citations).toEqual([]);
   });
 
@@ -258,7 +246,7 @@ describe('SynthesizeService', () => {
         }),
       ],
     );
-    const out = await svc.synthesize('co_x', baseDto, ['brain:read']);
+    const out = await svc.synthesize({ companyId: 'co_x', dto: baseDto, callerScopes: ['brain:read'] });
     expect(out.answer).toBeNull();
     expect(out.reason).toBe('verifier_failed');
     expect(out.citations).toEqual([]);
@@ -284,11 +272,7 @@ describe('SynthesizeService', () => {
         }),
       ],
     );
-    const out = await svc.synthesize(
-      'co_x',
-      { ...baseDto, synthesisGuardrails: 'lenient' },
-      ['brain:read'],
-    );
+    const out = await svc.synthesize({ companyId: 'co_x', dto: { ...baseDto, synthesisGuardrails: 'lenient' }, callerScopes: ['brain:read'] });
     expect(out.answer).toContain('fridge');
     expect(out.reason).toBe('verifier_failed');
     expect(out.citations.map((c) => c.factId)).toEqual(['f1']);
@@ -314,11 +298,7 @@ describe('SynthesizeService', () => {
         }),
       ],
     );
-    const out = await svc.synthesize(
-      'co_x',
-      { ...baseDto, synthesisGuardrails: 'off' },
-      ['brain:read'],
-    );
+    const out = await svc.synthesize({ companyId: 'co_x', dto: { ...baseDto, synthesisGuardrails: 'off' }, callerScopes: ['brain:read'] });
     expect(out.answer).toContain('noisy neighbour');
     expect(out.reason).toBeUndefined();
     // Generator should be the only OpenAI call (no verifier).
@@ -349,7 +329,7 @@ describe('SynthesizeService', () => {
         JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
       ],
     );
-    const out = await svc.synthesize('co_x', baseDto, ['brain:read']);
+    const out = await svc.synthesize({ companyId: 'co_x', dto: baseDto, callerScopes: ['brain:read'] });
     expect(out.citations.map((c) => c.factId)).toEqual(['f1']);
   });
 
@@ -395,7 +375,7 @@ describe('SynthesizeService', () => {
         },
       },
     };
-    const out = await svc.synthesize('co_x', baseDto, ['brain:read']);
+    const out = await svc.synthesize({ companyId: 'co_x', dto: baseDto, callerScopes: ['brain:read'] });
     expect(out.answer).toBeNull();
     expect(out.reason).toBe('verifier_error');
   });
@@ -416,7 +396,7 @@ describe('SynthesizeService', () => {
         }),
       ],
     );
-    const out = await svc.synthesize('co_x', baseDto, ['brain:read']);
+    const out = await svc.synthesize({ companyId: 'co_x', dto: baseDto, callerScopes: ['brain:read'] });
     expect(out.answer).toContain('customer');
     expect(out.reason).toBeUndefined();
   });

--- a/test/where-builder.unit-spec.ts
+++ b/test/where-builder.unit-spec.ts
@@ -6,7 +6,12 @@ const dto = (extra: Partial<SearchDto> = {}): SearchDto =>
 
 describe('buildBaseWhere default-now bitemporal visibility', () => {
   it('admits a future-supersede prior whose interval still covers now', () => {
-    const { sql } = buildBaseWhere(dto(), null, false, false);
+    const { sql } = buildBaseWhere({
+      dto: dto(),
+      asOf: null,
+      includeRetracted: false,
+      includeContested: false,
+    });
     // The blanket superseded exclusion is gone…
     expect(sql).not.toContain("status NOT IN ['superseded', 'compacted']");
     // …replaced by a compacted exclusion plus a guarded superseded clause
@@ -18,14 +23,24 @@ describe('buildBaseWhere default-now bitemporal visibility', () => {
   });
 
   it('asOf path is unchanged (validity-axis only, no status gap clause)', () => {
-    const { sql } = buildBaseWhere(dto({ asOf: '2026-01-01' }), new Date(), false, false);
+    const { sql } = buildBaseWhere({
+      dto: dto({ asOf: '2026-01-01' }),
+      asOf: new Date(),
+      includeRetracted: false,
+      includeContested: false,
+    });
     expect(sql).toContain('validFrom <= $asOf');
     expect(sql).toContain("status != 'compacted'");
     expect(sql).not.toContain("status != 'superseded'");
   });
 
   it('includeStale drops the temporal closure entirely', () => {
-    const { sql } = buildBaseWhere(dto({ includeStale: true }), null, false, false);
+    const { sql } = buildBaseWhere({
+      dto: dto({ includeStale: true }),
+      asOf: null,
+      includeRetracted: false,
+      includeContested: false,
+    });
     expect(sql).not.toContain("validUntil > time::now()");
   });
 });


### PR DESCRIPTION
## What (max-params=3 program, part 1/3)

Toward the strict **`max-params: 3`** gate. Every **non-constructor** function/method in `src/` with more than 3 parameters now takes a single **typed options object**, destructured in the parameter list so the **body is byte-for-byte unchanged** (low-risk — only the signature shape + call sites move).

**69 functions** across `ai` / `artifacts` / `common` / `dreams` / `entities` / `facts` / `ingest` / `mcp` / `multi-hop` / `search` / `synthesize`, with call sites in controllers and specs updated to named-arg objects.

```ts
// before
scoreRows(rows, predicateDist, now, calibrator)
// after
scoreRows({ rows, predicateDist, now, calibrator })
```

### Genuinely exempt (left as-is, on purpose)
- **18 NestJS DI constructors** — objectifying injected providers is a Nest anti-pattern (loses per-provider injection / `@Optional`). Handled by the **god-class split series (part 2/3)**.
- **7 route handlers** with `@Query` / `@Param` / `@Body`-decorated params — objectifying breaks HTTP param binding.

## Gate flip is deferred

`max-params` stays at **8** in this PR. It flips to **3** in the final PR (part 3/3) once the constructors are split and the 7 decorated handlers are resolved (per-line exemption with justification, or an eslint override for decorated params) — otherwise flipping now would red-line CI on the not-yet-done items.

## Acceptance

- `pnpm typecheck` (src + tests) clean · `pnpm lint` clean · `pnpm test` **700** unit · `pnpm test:e2e` **128** e2e — all green. Behaviour-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)