### PR TITLE
refactor(ai): split ReindexEngineService out of ReindexEmbeddingsService (max-params 2/3)

### DIFF
--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -13,6 +13,7 @@ import { ExtractionPatternService } from './extraction-pattern.service';
 import { CalibrationService } from './calibration/calibration.service';
 import { CalibrationRefitService } from './calibration/calibration-refit.service';
 import { ReindexEmbeddingsService } from './embedder/reindex-embeddings.service';
+import { ReindexEngineService } from './embedder/reindex-engine.service';
 import { EntityJudgeService } from './entity-judge.service';
 
 @Global()
@@ -33,6 +34,7 @@ import { EntityJudgeService } from './entity-judge.service';
     ExtractionPatternService,
     CalibrationService,
     CalibrationRefitService,
+    ReindexEngineService,
     ReindexEmbeddingsService,
     EntityJudgeService,
   ],

--- a/src/ai/embedder/reindex-embeddings.service.ts
+++ b/src/ai/embedder/reindex-embeddings.service.ts
@@ -1,8 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { ApiKeyService } from '../../auth/api-key.service';
-import { SurrealService } from '../../db/surreal.service';
-import { EmbedderService } from '../embedder.service';
+import { ReindexEngineService } from './reindex-engine.service';
 
 export interface ReindexResult {
   tenantsScanned: number;
@@ -20,12 +18,6 @@ export interface ReindexOptions {
   dryRun?: boolean;
   /** Cap on facts processed per tenant; protects against runaway batches. */
   maxFacts?: number;
-}
-
-interface FactRowForReindex {
-  id: { tb: string; id: { String: string } } | string;
-  predicate: string;
-  object: string;
 }
 
 /**
@@ -49,19 +41,11 @@ interface FactRowForReindex {
 @Injectable()
 export class ReindexEmbeddingsService {
   private readonly logger = new Logger(ReindexEmbeddingsService.name);
-  private readonly batchSize: number;
 
   constructor(
-    private readonly surreal: SurrealService,
     private readonly apiKeys: ApiKeyService,
-    private readonly embedder: EmbedderService,
-    config: ConfigService,
-  ) {
-    this.batchSize = parseInt(
-      config.get<string>('REINDEX_BATCH_SIZE', '200'),
-      10,
-    );
-  }
+    private readonly engine: ReindexEngineService,
+  ) {}
 
   async run(opts: ReindexOptions = {}): Promise<ReindexResult> {
     const started = Date.now();
@@ -75,7 +59,7 @@ export class ReindexEmbeddingsService {
     let factsUpdated = 0;
     for (const companyId of tenants) {
       try {
-        const tenantResult = await this.reindexTenant(companyId, {
+        const tenantResult = await this.engine.reindexTenant(companyId, {
           dryRun,
           remaining: maxFacts - factsScanned,
         });
@@ -89,87 +73,17 @@ export class ReindexEmbeddingsService {
       }
     }
 
-    // Provider id surfaces in the response for operator audit. The
-    // stub embedder used in tests doesn't implement cacheStats, so
-    // we fall back to 'unknown' instead of crashing the endpoint.
-    const provider =
-      typeof this.embedder.cacheStats === 'function'
-        ? this.embedder.cacheStats().provider
-        : 'unknown';
     const result: ReindexResult = {
       tenantsScanned: tenants.length,
       factsScanned,
       factsUpdated,
       durationMs: Date.now() - started,
       dryRun,
-      provider,
+      provider: this.engine.providerId(),
     };
     this.logger.log(
       `reindex done — provider=${result.provider} tenants=${result.tenantsScanned} scanned=${result.factsScanned} updated=${result.factsUpdated} dryRun=${dryRun}`,
     );
     return result;
-  }
-
-  private async reindexTenant(
-    companyId: string,
-    opts: { dryRun: boolean; remaining: number },
-  ): Promise<{ factsScanned: number; factsUpdated: number }> {
-    return this.surreal.withCompany(companyId, async (db) => {
-      let offset = 0;
-      let factsScanned = 0;
-      let factsUpdated = 0;
-      const batch = Math.min(this.batchSize, opts.remaining);
-      // Paginate until either the tenant is empty or we hit the cap.
-      while (factsScanned < opts.remaining) {
-        const [rows] = await db.query<[FactRowForReindex[]]>(
-          `SELECT id, predicate, object
-              FROM knowledge_fact
-              ORDER BY id
-              LIMIT $batch START $offset`,
-          { batch, offset },
-        );
-        const page = (rows as FactRowForReindex[]) ?? [];
-        if (page.length === 0) break;
-
-        factsScanned += page.length;
-        if (!opts.dryRun) {
-          // Batch the whole page through one embedMany — the previous
-          // per-row embed() loop paid one HTTP round-trip per fact,
-          // which made reindex unworkable on large tenants (a 100k-row
-          // tenant = 100k sequential calls). embedMany chunks 512 at
-          // a time inside the OpenAI provider.
-          const texts = page.map((row) => `${row.predicate}: ${row.object}`);
-          let embeddings: number[][];
-          try {
-            embeddings = await this.embedder.embedMany(texts);
-          } catch (e) {
-            this.logger.warn(
-              `reindex batch embed failed (${companyId}, page=${page.length}): ${(e as Error).message}`,
-            );
-            // Skip this page entirely; the next outer-loop iteration
-            // advances `offset` by `page.length` so we don't retry-loop.
-            offset += page.length;
-            if (page.length < batch) break;
-            continue;
-          }
-          for (let i = 0; i < page.length; i++) {
-            try {
-              await db.query(`UPDATE $id SET embedding = $embedding`, {
-                id: page[i].id,
-                embedding: embeddings[i],
-              });
-              factsUpdated += 1;
-            } catch (e) {
-              this.logger.warn(
-                `reindex row update failed (${companyId}): ${(e as Error).message}`,
-              );
-            }
-          }
-        }
-        offset += page.length;
-        if (page.length < batch) break;
-      }
-      return { factsScanned, factsUpdated };
-    });
   }
 }

--- a/src/ai/embedder/reindex-engine.service.ts
+++ b/src/ai/embedder/reindex-engine.service.ts
@@ -1,0 +1,111 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SurrealService } from '../../db/surreal.service';
+import { EmbedderService } from '../embedder.service';
+
+interface FactRowForReindex {
+  id: { tb: string; id: { String: string } } | string;
+  predicate: string;
+  object: string;
+}
+
+/**
+ * ReindexEngineService — the per-tenant re-embed engine.
+ *
+ * Owns the "how to reindex ONE tenant" mechanics (pagination, batched
+ * embedMany, row updates) plus the active embedder provider id. The
+ * tenant-iteration / orchestration lives in ReindexEmbeddingsService,
+ * which delegates here. Splitting the engine out keeps each class's
+ * injected-dep list ≤3 and isolates the DB/embedder machinery from the
+ * "which tenants" policy.
+ */
+@Injectable()
+export class ReindexEngineService {
+  private readonly logger = new Logger(ReindexEngineService.name);
+  private readonly batchSize: number;
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly embedder: EmbedderService,
+    config: ConfigService,
+  ) {
+    this.batchSize = parseInt(
+      config.get<string>('REINDEX_BATCH_SIZE', '200'),
+      10,
+    );
+  }
+
+  /**
+   * The active embedder provider id, surfaced in the response for
+   * operator audit. The stub embedder used in tests doesn't implement
+   * cacheStats, so we fall back to 'unknown' instead of crashing.
+   */
+  providerId(): string {
+    return typeof this.embedder.cacheStats === 'function'
+      ? this.embedder.cacheStats().provider
+      : 'unknown';
+  }
+
+  async reindexTenant(
+    companyId: string,
+    opts: { dryRun: boolean; remaining: number },
+  ): Promise<{ factsScanned: number; factsUpdated: number }> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      let offset = 0;
+      let factsScanned = 0;
+      let factsUpdated = 0;
+      const batch = Math.min(this.batchSize, opts.remaining);
+      // Paginate until either the tenant is empty or we hit the cap.
+      while (factsScanned < opts.remaining) {
+        const [rows] = await db.query<[FactRowForReindex[]]>(
+          `SELECT id, predicate, object
+              FROM knowledge_fact
+              ORDER BY id
+              LIMIT $batch START $offset`,
+          { batch, offset },
+        );
+        const page = (rows as FactRowForReindex[]) ?? [];
+        if (page.length === 0) break;
+
+        factsScanned += page.length;
+        if (!opts.dryRun) {
+          // Batch the whole page through one embedMany — the previous
+          // per-row embed() loop paid one HTTP round-trip per fact,
+          // which made reindex unworkable on large tenants (a 100k-row
+          // tenant = 100k sequential calls). embedMany chunks 512 at
+          // a time inside the OpenAI provider.
+          const texts = page.map((row) => `${row.predicate}: ${row.object}`);
+          let embeddings: number[][];
+          try {
+            embeddings = await this.embedder.embedMany(texts);
+          } catch (e) {
+            this.logger.warn(
+              `reindex batch embed failed (${companyId}, page=${page.length}): ${(e as Error).message}`,
+            );
+            // Skip this page entirely; the next outer-loop iteration
+            // advances `offset` by `page.length` so we don't retry-loop.
+            offset += page.length;
+            if (page.length < batch) break;
+            continue;
+          }
+          for (let i = 0; i < page.length; i++) {
+            try {
+              await db.query(`UPDATE $id SET embedding = $embedding`, {
+                id: page[i].id,
+                embedding: embeddings[i],
+              });
+              factsUpdated += 1;
+            } catch (e) {
+              this.logger.warn(
+                `reindex row update failed (${companyId}): ${(e as Error).message}`,
+              );
+            }
+          }
+        }
+        offset += page.length;
+        if (page.length < batch) break;
+      }
+      return { factsScanned, factsUpdated };
+    });
+  }
+}


### PR DESCRIPTION
## What
`ReindexEmbeddingsService` injected 4 deps (surreal, apiKeys, embedder, config), tripping the planned `max-params=3` constructor gate. Split the per-tenant re-embed engine — pagination, batched `embedMany`, row updates, provider id — into a new `ReindexEngineService` (surreal, embedder, config→batchSize). `ReindexEmbeddingsService` is now the tenant orchestrator (apiKeys, engine), 2 deps.

## Why
Part 2/3 of the `max-params=3` god-class split program (see `docs/roadmap/max-params-and-remainder-2026-06.md`). Real responsibility split, not an exemption or deps-object.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
- `pnpm test:unit` 700/700 ✓ · `pnpm test:e2e` 128/128 ✓
- Public `run()` contract and behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)