### PR TITLE
refactor(auth): extract CredentialResolverService from ApiKeyGuard (max-params 2/3)

### DIFF
--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -2,45 +2,24 @@ import {
   CanActivate,
   ExecutionContext,
   Injectable,
-  Logger,
   SetMetadata,
   UnauthorizedException,
   ForbiddenException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { Reflector } from '@nestjs/core';
-import { ApiKeyService } from './api-key.service';
-import { JwksService } from './jwks.service';
+import { CredentialResolverService } from './credential-resolver.service';
 import { BrainScope, AuthenticatedRequest, ApiKeyRecord } from './api-key.types';
 
 const REQUIRED_SCOPES_KEY = 'requiredScopes';
 export const RequireScopes = (...scopes: BrainScope[]) =>
   SetMetadata(REQUIRED_SCOPES_KEY, scopes);
 
-const JWT_SHAPE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
-
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
-  private readonly logger = new Logger(ApiKeyGuard.name);
-  private readonly staticAllowed: boolean;
-
   constructor(
-    private readonly apiKeys: ApiKeyService,
-    private readonly jwks: JwksService,
+    private readonly credentials: CredentialResolverService,
     private readonly reflector: Reflector,
-    config: ConfigService,
-  ) {
-    const env = config.get<string>('NODE_ENV', 'development');
-    // In production with JWKS configured, static keys are off — operators
-    // must issue tokens through the auth-service. Everywhere else (dev,
-    // test, JWKS not configured) static keys are accepted as a fallback.
-    this.staticAllowed = !(env === 'production' && this.jwks.enabled());
-    if (!this.staticAllowed) {
-      this.logger.log(
-        'Static BRAIN_API_KEYS disabled in production with JWKS enabled — JWT only',
-      );
-    }
-  }
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
@@ -51,14 +30,7 @@ export class ApiKeyGuard implements CanActivate {
     }
 
     const token = header.slice(7).trim();
-    let record: ApiKeyRecord | null = null;
-
-    if (this.jwks.enabled() && JWT_SHAPE.test(token)) {
-      record = await this.jwks.verify(token);
-    }
-    if (!record && this.staticAllowed) {
-      record = this.apiKeys.resolve(token);
-    }
+    const record: ApiKeyRecord | null = await this.credentials.resolve(token);
     if (!record) {
       throw new UnauthorizedException('Invalid credentials');
     }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,11 +1,22 @@
 import { Global, Module } from '@nestjs/common';
 import { ApiKeyService } from './api-key.service';
 import { ApiKeyGuard } from './api-key.guard';
+import { CredentialResolverService } from './credential-resolver.service';
 import { JwksService } from './jwks.service';
 
 @Global()
 @Module({
-  providers: [ApiKeyService, JwksService, ApiKeyGuard],
-  exports: [ApiKeyService, JwksService, ApiKeyGuard],
+  providers: [
+    ApiKeyService,
+    JwksService,
+    CredentialResolverService,
+    ApiKeyGuard,
+  ],
+  exports: [
+    ApiKeyService,
+    JwksService,
+    CredentialResolverService,
+    ApiKeyGuard,
+  ],
 })
 export class AuthModule {}

--- a/src/auth/credential-resolver.service.ts
+++ b/src/auth/credential-resolver.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ApiKeyService } from './api-key.service';
+import { JwksService } from './jwks.service';
+import { ApiKeyRecord } from './api-key.types';
+
+const JWT_SHAPE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+/**
+ * CredentialResolverService — turns a bearer token into an ApiKeyRecord.
+ *
+ * Owns the two-source credential policy (JWT via JWKS, falling back to
+ * static BRAIN_API_KEYS) and the production hardening that disables the
+ * static fallback when JWKS is configured. Extracted from ApiKeyGuard so
+ * the guard is left with just HTTP plumbing (header parsing + scope
+ * enforcement) and keeps its injected-dep list ≤3.
+ */
+@Injectable()
+export class CredentialResolverService {
+  private readonly logger = new Logger(CredentialResolverService.name);
+  private readonly staticAllowed: boolean;
+
+  constructor(
+    private readonly apiKeys: ApiKeyService,
+    private readonly jwks: JwksService,
+    config: ConfigService,
+  ) {
+    const env = config.get<string>('NODE_ENV', 'development');
+    // In production with JWKS configured, static keys are off — operators
+    // must issue tokens through the auth-service. Everywhere else (dev,
+    // test, JWKS not configured) static keys are accepted as a fallback.
+    this.staticAllowed = !(env === 'production' && this.jwks.enabled());
+    if (!this.staticAllowed) {
+      this.logger.log(
+        'Static BRAIN_API_KEYS disabled in production with JWKS enabled — JWT only',
+      );
+    }
+  }
+
+  /**
+   * Resolve a bearer token to an authenticated record, or null when no
+   * source recognises it. Tries JWKS verification first (when the token
+   * has JWT shape), then the static-key table when still allowed.
+   */
+  async resolve(token: string): Promise<ApiKeyRecord | null> {
+    let record: ApiKeyRecord | null = null;
+    if (this.jwks.enabled() && JWT_SHAPE.test(token)) {
+      record = await this.jwks.verify(token);
+    }
+    if (!record && this.staticAllowed) {
+      record = this.apiKeys.resolve(token);
+    }
+    return record;
+  }
+}

--- a/test/auth-guard.unit-spec.ts
+++ b/test/auth-guard.unit-spec.ts
@@ -24,6 +24,7 @@ import {
 } from 'jose';
 import { ApiKeyGuard } from '../src/auth/api-key.guard';
 import { ApiKeyService } from '../src/auth/api-key.service';
+import { CredentialResolverService } from '../src/auth/credential-resolver.service';
 import { JwksService } from '../src/auth/jwks.service';
 
 const ISSUER = 'https://auth.test';
@@ -125,12 +126,12 @@ describe('ApiKeyGuard — JWKS verification', () => {
     apiKeys = new ApiKeyService(config as unknown as ConfigService);
     apiKeys.onModuleInit();
 
-    guard = new ApiKeyGuard(
+    const credentials = new CredentialResolverService(
       apiKeys,
       jwks,
-      new Reflector(),
       config as unknown as ConfigService,
     );
+    guard = new ApiKeyGuard(credentials, new Reflector());
   });
 
   afterAll(async () => {
@@ -231,12 +232,12 @@ describe('ApiKeyGuard — production with JWKS rejects static keys', () => {
     jwks.onModuleInit();
     apiKeys = new ApiKeyService(config as unknown as ConfigService);
     apiKeys.onModuleInit();
-    guard = new ApiKeyGuard(
+    const credentials = new CredentialResolverService(
       apiKeys,
       jwks,
-      new Reflector(),
       config as unknown as ConfigService,
     );
+    guard = new ApiKeyGuard(credentials, new Reflector());
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## What
`ApiKeyGuard` injected 4 deps (apiKeys, jwks, reflector, config), tripping the planned `max-params=3` constructor gate. Move the two-source credential policy (JWKS verify → static-key fallback) plus the production hardening that disables static keys when JWKS is configured into a new `CredentialResolverService` (apiKeys, jwks, config→staticAllowed). `ApiKeyGuard` keeps just HTTP plumbing — header parse + scope enforcement — at 2 deps (credentials, reflector).

`CredentialResolverService` is exported from the `@Global` `AuthModule` so the globally-applied guard resolves it from every consuming module.

## Why
Part 2/3 of the `max-params=3` god-class split program. Real responsibility split, not an exemption or deps-object.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
- `pnpm test:unit` 700/700 ✓ · `pnpm test:e2e` 128/128 ✓ (auth wiring exercised by the full e2e boot)
- auth-guard unit spec updated to build the guard via the resolver; all 8 cases green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)