### PR TITLE
refactor(jobs): extract JobReaperService from LeaseManagerService (max-params 2/3)

### DIFF
--- a/src/jobs/job-reaper.service.ts
+++ b/src/jobs/job-reaper.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ApiKeyService } from '../auth/api-key.service';
+import { JobClaimService } from './job-claim.service';
+import { mapWithLimit } from '../common/parallel';
+
+export interface ReapResult {
+  requeued: number;
+  failed: number;
+  tenants: number;
+}
+
+/**
+ * JobReaperService — the zombie-reap engine.
+ *
+ * Sweeps job_run rows whose status='running' AND leaseUntil<now() across
+ * every known tenant: under maxAttempts → requeue with backoff;
+ * at-or-above → fail terminally. Owns only the reap mechanics + its
+ * tunables (maxAttempts, backoffBaseMs). The cron cadence, leader
+ * election, and re-entrancy guard live in LeaseManagerService, which
+ * calls reap() once it has confirmed it's the leader. Splitting this out
+ * keeps both classes' injected-dep lists ≤3 and makes the reap logic
+ * testable without the cron/lease scaffolding.
+ */
+@Injectable()
+export class JobReaperService {
+  private readonly logger = new Logger(JobReaperService.name);
+  private readonly maxAttempts: number;
+  private readonly backoffBaseMs: number;
+
+  constructor(
+    config: ConfigService,
+    @Optional() private readonly claim?: JobClaimService,
+    @Optional() private readonly apiKeys?: ApiKeyService,
+  ) {
+    this.maxAttempts = parseInt(
+      config.get<string>('JOB_RUN_MAX_ATTEMPTS', '3') ?? '3',
+      10,
+    );
+    this.backoffBaseMs = parseInt(
+      config.get<string>('JOB_RUN_BACKOFF_BASE_MS', '30000') ?? '30000',
+      10,
+    );
+  }
+
+  /**
+   * Reap expired claims across all known tenants. Returns null when the
+   * claim/apiKeys collaborators aren't wired (standalone contexts).
+   */
+  async reap(): Promise<ReapResult | null> {
+    if (!this.claim || !this.apiKeys) return null;
+    const tenants = this.apiKeys.knownCompanyIds();
+    let requeued = 0;
+    let failed = 0;
+    // Parallel fan-out bounded under the SURREALDB_POOL_SIZE budget
+    // — each reapZombies call holds one root pool conn for its
+    // SELECT+UPDATE pair. Cap at 4 so a saturated reap can't fully
+    // drain the pool from caller-facing requests.
+    await mapWithLimit({
+      items: tenants,
+      concurrency: 4,
+      fn: async (companyId) => {
+        const result = await this.claim!.reapZombies({
+          companyId,
+          maxAttempts: this.maxAttempts,
+          backoffBaseMs: this.backoffBaseMs,
+        });
+        requeued += result.requeued;
+        failed += result.failed;
+        return null;
+      },
+    });
+    if (requeued > 0 || failed > 0) {
+      this.logger.log(
+        `Zombie reap: requeued=${requeued}, failed=${failed} across ${tenants.length} tenant(s)`,
+      );
+    }
+    return { requeued, failed, tenants: tenants.length };
+  }
+}

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -5,6 +5,7 @@ import { JobClaimService } from './job-claim.service';
 import { LeaderLeaseService } from './leader-lease.service';
 import { WorkerLoopService } from './worker-loop.service';
 import { LeaseManagerService } from './lease-manager.service';
+import { JobReaperService } from './job-reaper.service';
 import { JobWorkerPool } from './job-worker-pool.service';
 import { DistributedLeaseGuard } from '../common/distributed-lease.guard';
 
@@ -35,6 +36,7 @@ import { DistributedLeaseGuard } from '../common/distributed-lease.guard';
     LeaderLeaseService,
     WorkerLoopService,
     LeaseManagerService,
+    JobReaperService,
     JobWorkerPool,
     DistributedLeaseGuard,
   ],

--- a/src/jobs/lease-manager.service.ts
+++ b/src/jobs/lease-manager.service.ts
@@ -1,10 +1,8 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
-import { ApiKeyService } from '../auth/api-key.service';
-import { JobClaimService } from './job-claim.service';
 import { LeaderLeaseService } from './leader-lease.service';
-import { mapWithLimit } from '../common/parallel';
+import { JobReaperService, ReapResult } from './job-reaper.service';
 
 /**
  * LeaseManagerService — cron-driven housekeeping for the queue.
@@ -34,27 +32,16 @@ import { mapWithLimit } from '../common/parallel';
 export class LeaseManagerService {
   private readonly logger = new Logger(LeaseManagerService.name);
   private readonly enabled: boolean;
-  private readonly maxAttempts: number;
-  private readonly backoffBaseMs: number;
   private reapInFlight = false;
   private janitorInFlight = false;
 
   constructor(
     config: ConfigService,
-    @Optional() private readonly claim?: JobClaimService,
+    private readonly reaper: JobReaperService,
     @Optional() private readonly lease?: LeaderLeaseService,
-    @Optional() private readonly apiKeys?: ApiKeyService,
   ) {
     this.enabled =
       (config.get<string>('LEASE_MANAGER_ENABLED', '1') ?? '1') !== '0';
-    this.maxAttempts = parseInt(
-      config.get<string>('JOB_RUN_MAX_ATTEMPTS', '3') ?? '3',
-      10,
-    );
-    this.backoffBaseMs = parseInt(
-      config.get<string>('JOB_RUN_BACKOFF_BASE_MS', '30000') ?? '30000',
-      10,
-    );
   }
 
   /**
@@ -67,49 +54,18 @@ export class LeaseManagerService {
    * catch + recycle a dead worker within the lease window.
    */
   @Cron('*/10 * * * * *')
-  async reapTick(): Promise<{
-    requeued: number;
-    failed: number;
-    tenants: number;
-  } | null> {
+  async reapTick(): Promise<ReapResult | null> {
     if (!this.enabled) return null;
     if (this.reapInFlight) {
       // Previous tick still draining a large backlog. Skip silently —
       // the next tick will pick up what we couldn't.
       return null;
     }
-    if (!this.claim || !this.apiKeys) return null;
     const isLeader = await this.acquireLease();
     if (!isLeader) return null;
     this.reapInFlight = true;
     try {
-      const tenants = this.apiKeys.knownCompanyIds();
-      let requeued = 0;
-      let failed = 0;
-      // Parallel fan-out bounded under the SURREALDB_POOL_SIZE budget
-      // — each reapZombies call holds one root pool conn for its
-      // SELECT+UPDATE pair. Cap at 4 so a saturated reap can't fully
-      // drain the pool from caller-facing requests.
-      await mapWithLimit({
-        items: tenants,
-        concurrency: 4,
-        fn: async (companyId) => {
-          const result = await this.claim!.reapZombies({
-            companyId,
-            maxAttempts: this.maxAttempts,
-            backoffBaseMs: this.backoffBaseMs,
-          });
-          requeued += result.requeued;
-          failed += result.failed;
-          return null;
-        },
-      });
-      if (requeued > 0 || failed > 0) {
-        this.logger.log(
-          `Zombie reap: requeued=${requeued}, failed=${failed} across ${tenants.length} tenant(s)`,
-        );
-      }
-      return { requeued, failed, tenants: tenants.length };
+      return await this.reaper.reap();
     } catch (e) {
       this.logger.warn(`reapTick failed: ${(e as Error).message}`);
       return null;


### PR DESCRIPTION
## What
`LeaseManagerService` injected 4 deps (config, claim, lease, apiKeys), tripping the planned `max-params=3` constructor gate. Move the zombie-reap engine — the per-tenant `reapZombies` fan-out plus its tunables (maxAttempts, backoffBaseMs) — into a new `JobReaperService` (config, claim, apiKeys). `LeaseManagerService` keeps cron scheduling, leader election, the re-entrancy guards, and the lease janitor (config, reaper, lease), 3 deps. `reapTick` delegates to `reaper.reap()` once it confirms leadership.

## Why
Part 2/3 of the `max-params=3` god-class split program. Real responsibility split — the reaper is now testable without the cron/lease scaffolding.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
- `pnpm test:unit` 700/700 ✓ · `pnpm test:e2e` 128/128 ✓ · `pnpm test:e2e:jobs` 9/9 ✓ (jobs DI boot exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)