### PR TITLE
refactor(dreams): drop dead embedder + metrics deps from DreamsDedupService (max-params 2/3)

### DIFF
--- a/src/dreams/dedup.service.ts
+++ b/src/dreams/dedup.service.ts
@@ -1,9 +1,7 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Surreal, StringRecordId } from 'surrealdb';
-import { EmbedderService } from '../ai/embedder.service';
 import { EntityJudgeService } from '../ai/entity-judge.service';
-import { MetricsService } from '../metrics/metrics.service';
 import { withSpan } from '../common/tracing';
 
 /**
@@ -59,9 +57,7 @@ export class DreamsDedupService {
 
   constructor(
     private readonly configService: ConfigService,
-    private readonly embedder: EmbedderService,
     private readonly judge: EntityJudgeService,
-    @Optional() private readonly metrics?: MetricsService,
   ) {
     this.enabled =
       this.configService.get<string>('DREAMS_DEDUP_ENABLED', '0') === '1';


### PR DESCRIPTION
## What
`DreamsDedupService` injected 4 deps but used only two of them. `embedder` is never referenced — candidate-finding runs a Surreal HNSW-cosine k-NN over precomputed `name`-fact embeddings, not the embedder. `metrics` has no call site. Remove both; the constructor is now `(configService, judge)`, 2 deps.

## Why
Part 2/3 of the `max-params=3` god-class split program. Pure dead-dependency cleanup — no behaviour change.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
- `pnpm test:unit` 700/700 ✓ · `pnpm test:e2e` 128/128 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)