### PR TITLE
refactor(ingest): extract PredictScoringService from IngestPredictionService (max-params 2/3)

### DIFF
--- a/src/ingest/ingest-predictor.service.ts
+++ b/src/ingest/ingest-predictor.service.ts
@@ -1,72 +1,22 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { Surreal } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
-import { EmbedderService } from '../ai/embedder.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
+import { PredictScoringService } from './predict-scoring.service';
 import {
-  ConflictConfig,
-  SOURCE_TRUST,
-  scoreFact,
-} from './conflict-resolver';
-import { sourceTrustFor } from './ingest-utils';
+  PredictResolveArgs,
+  PredictResolveResult,
+  PriorRow,
+  intervalsOverlap,
+  rowToOpposingFact,
+} from './predictor-internals';
 
-export type IngestOutcome =
-  | 'INSERTED'
-  | 'SUPERSEDED'
-  | 'COMPETING'
-  | 'REJECTED';
-
-export interface PredictResolveArgs {
-  entityRef:
-    | { vertical: string; id: string }
-    | { entityId: string };
-  predicate: string;
-  object: string;
-  validFrom: string;
-  validUntil?: string;
-  confidence?: number;
-  source: {
-    vertical: string;
-    eventId?: string;
-    messageId?: string;
-    recorder?: string;
-  };
-}
-
-export interface OpposingFact {
-  factId: string;
-  predicate: string;
-  object: string;
-  confidence: number;
-  validFrom: string;
-  validUntil?: string;
-  recordedAt: string;
-}
-
-export interface PredictResolveResult {
-  wouldOutcome: IngestOutcome;
-  reasoning: string;
-  opposingFacts: OpposingFact[];
-  predicatePolicy: {
-    semantics: string;
-    decayHalfLifeDays: number | null;
-    piiClass: string;
-  };
-}
-
-interface PriorRow {
-  id: unknown;
-  predicate: string;
-  object: string;
-  confidence?: number;
-  validFrom: string | Date;
-  validUntil?: string | Date | null;
-  recordedAt: string | Date;
-  embedding?: number[];
-  source?: unknown;
-  status?: string;
-}
+export type {
+  IngestOutcome,
+  PredictResolveArgs,
+  PredictResolveResult,
+  OpposingFact,
+} from './predictor-internals';
 
 /**
  * IngestPredictionService — read-only dry-run of fn::resolve_fact.
@@ -85,30 +35,20 @@ interface PriorRow {
  *
  * No side effects: does NOT create the entity, does NOT bump
  * predicate-registry stats, does NOT touch source_trust.
+ *
+ * This class is the orchestration half — it gathers the DB/embedder/
+ * registry inputs and delegates the conflict-scoring decisions to
+ * PredictScoringService.
  */
 @Injectable()
 export class IngestPredictionService {
   private readonly logger = new Logger(IngestPredictionService.name);
-  private readonly conflict: ConflictConfig;
 
   constructor(
     private readonly surreal: SurrealService,
-    private readonly embedder: EmbedderService,
     private readonly predicateRegistry: PredicateRegistryService,
-    private readonly configService: ConfigService,
-  ) {
-    this.conflict = {
-      similarityThreshold: this.cfgNum('CONFLICT_SIMILARITY_THRESHOLD', 0.85),
-      weights: {
-        confidence: this.cfgNum('CONFLICT_WEIGHT_CONFIDENCE', 0.3),
-        sourceTrust: this.cfgNum('CONFLICT_WEIGHT_SOURCE_TRUST', 0.4),
-        recency: this.cfgNum('CONFLICT_WEIGHT_RECENCY', 0.2),
-        authority: this.cfgNum('CONFLICT_WEIGHT_AUTHORITY', 0.1),
-      },
-      marginForSupersede: this.cfgNum('CONFLICT_MARGIN_SUPERSEDE', 0.15),
-      rejectThreshold: this.cfgNum('CONFLICT_REJECT_THRESHOLD', 0.3),
-    };
-  }
+    private readonly scoring: PredictScoringService,
+  ) {}
 
   async predict(
     companyId: string,
@@ -129,8 +69,9 @@ export class IngestPredictionService {
         };
       }
 
-      const candEmbedding = await this.embedder.embed(
-        `${args.predicate}: ${args.object}`,
+      const candEmbedding = await this.scoring.embedCandidate(
+        args.predicate,
+        args.object,
       );
 
       try {
@@ -163,22 +104,13 @@ export class IngestPredictionService {
       );
       const priors = ((rows as any[]) ?? []) as PriorRow[];
 
-      const sourceTrust = sourceTrustFor(args.source);
-      const candidateScore = scoreFact(
-        {
-          confidence: args.confidence ?? 0.7,
-          sourceTrust,
-          recordedAt: new Date(),
-          authority: 0,
-        },
-        this.conflict,
-      );
+      const candidateScore = this.scoring.scoreCandidate(args);
 
-      if (candidateScore < this.conflict.rejectThreshold) {
+      if (candidateScore < this.scoring.conflict.rejectThreshold) {
         return {
           wouldOutcome: 'REJECTED',
           reasoning:
-            `Candidate score ${candidateScore.toFixed(3)} is below the reject threshold ${this.conflict.rejectThreshold.toFixed(3)} — too unconfident or too low-trust to enter the graph.`,
+            `Candidate score ${candidateScore.toFixed(3)} is below the reject threshold ${this.scoring.conflict.rejectThreshold.toFixed(3)} — too unconfident or too low-trust to enter the graph.`,
           opposingFacts: priors.map(rowToOpposingFact),
           predicatePolicy: policy,
         };
@@ -214,27 +146,27 @@ export class IngestPredictionService {
 
       if (policy.semantics === 'single_active') {
         return {
-          ...this.predictSingleActive(candidateScore, overlapping),
+          ...this.scoring.predictSingleActive(candidateScore, overlapping),
           predicatePolicy: policy,
         };
       }
 
       // bitemporal
-      const scored = this.scoreBitemporal(candEmbedding, overlapping);
+      const scored = this.scoring.scoreBitemporal(candEmbedding, overlapping);
       const above = scored.filter(
-        (c) => c.cosine >= this.conflict.similarityThreshold,
+        (c) => c.cosine >= this.scoring.conflict.similarityThreshold,
       );
       if (above.length === 0) {
         return {
           wouldOutcome: 'INSERTED',
           reasoning:
-            `Overlapping facts exist but none clear the cosine similarity threshold ${this.conflict.similarityThreshold.toFixed(2)}; semantically distinct, no contradiction.`,
+            `Overlapping facts exist but none clear the cosine similarity threshold ${this.scoring.conflict.similarityThreshold.toFixed(2)}; semantically distinct, no contradiction.`,
           opposingFacts: scored.map((c) => c.opposing),
           predicatePolicy: policy,
         };
       }
       return {
-        ...this.predictBitemporal(candidateScore, above),
+        ...this.scoring.predictBitemporal(candidateScore, above),
         predicatePolicy: policy,
       };
     });
@@ -264,145 +196,4 @@ export class IngestPredictionService {
     const arr = (rows as any[]) ?? [];
     return arr[0] ? String(arr[0]) : null;
   }
-
-  private predictSingleActive(
-    candidateScore: number,
-    overlapping: PriorRow[],
-  ): Omit<PredictResolveResult, 'predicatePolicy'> {
-    const scored = overlapping
-      .map((p) => ({
-        opposing: rowToOpposingFact(p),
-        score: scoreFact(
-          {
-            confidence: p.confidence ?? 0.7,
-            sourceTrust:
-              typeof p.source === 'object' && p.source !== null
-                ? sourceTrustFor(p.source as any)
-                : SOURCE_TRUST.default,
-            recordedAt: new Date(p.recordedAt),
-            authority: 0,
-          },
-          this.conflict,
-        ),
-      }))
-      .sort((a, b) => b.score - a.score);
-    const top = scored[0];
-    const gap = candidateScore - top.score;
-    if (gap > this.conflict.marginForSupersede) {
-      return {
-        wouldOutcome: 'SUPERSEDED',
-        reasoning: `single_active predicate, candidate score ${candidateScore.toFixed(3)} beats strongest prior ${top.score.toFixed(3)} by ${gap.toFixed(3)} > margin ${this.conflict.marginForSupersede.toFixed(3)}; prior would be closed.`,
-        opposingFacts: scored.map((s) => s.opposing),
-      };
-    }
-    return {
-      wouldOutcome: 'COMPETING',
-      reasoning: `single_active predicate, candidate score ${candidateScore.toFixed(3)} vs strongest prior ${top.score.toFixed(3)} (gap ${gap.toFixed(3)}) within margin; both would remain active in COMPETING status.`,
-      opposingFacts: scored.map((s) => s.opposing),
-    };
-  }
-
-  private scoreBitemporal(
-    candEmbedding: number[],
-    overlapping: PriorRow[],
-  ): Array<{ opposing: OpposingFact; cosine: number; score: number }> {
-    const norm = vectorNorm(candEmbedding);
-    return overlapping.map((p) => {
-      const emb = Array.isArray(p.embedding) ? (p.embedding as number[]) : null;
-      const cosine = emb ? cosineSimilarity(candEmbedding, emb, norm) : 0;
-      const score = scoreFact(
-        {
-          confidence: p.confidence ?? 0.7,
-          sourceTrust:
-            typeof p.source === 'object' && p.source !== null
-              ? sourceTrustFor(p.source as any)
-              : SOURCE_TRUST.default,
-          recordedAt: new Date(p.recordedAt),
-          authority: 0,
-        },
-        this.conflict,
-      );
-      return { opposing: rowToOpposingFact(p), cosine, score };
-    });
-  }
-
-  private predictBitemporal(
-    candidateScore: number,
-    above: Array<{ opposing: OpposingFact; cosine: number; score: number }>,
-  ): Omit<PredictResolveResult, 'predicatePolicy'> {
-    const top = above.reduce((acc, c) => (c.score > acc.score ? c : acc), above[0]);
-    const gap = candidateScore - top.score;
-    if (gap > this.conflict.marginForSupersede) {
-      return {
-        wouldOutcome: 'SUPERSEDED',
-        reasoning: `bitemporal predicate, strongest semantically-similar prior (cosine ${top.cosine.toFixed(2)}) score ${top.score.toFixed(3)}; candidate ${candidateScore.toFixed(3)} wins by ${gap.toFixed(3)} > margin ${this.conflict.marginForSupersede.toFixed(3)}.`,
-        opposingFacts: above.map((c) => c.opposing),
-      };
-    }
-    return {
-      wouldOutcome: 'COMPETING',
-      reasoning: `bitemporal predicate, strongest similar prior (cosine ${top.cosine.toFixed(2)}) score ${top.score.toFixed(3)} too close to candidate ${candidateScore.toFixed(3)} (gap ${gap.toFixed(3)}) within margin; both would remain active in COMPETING status.`,
-      opposingFacts: above.map((c) => c.opposing),
-    };
-  }
-
-  private cfgNum(key: string, fallback: number): number {
-    const raw = this.configService.get<string | number | undefined>(key);
-    if (raw === undefined || raw === null) return fallback;
-    const n = typeof raw === 'number' ? raw : Number(raw);
-    return Number.isFinite(n) ? n : fallback;
-  }
-}
-
-function rowToOpposingFact(row: PriorRow): OpposingFact {
-  return {
-    factId: String(row.id),
-    predicate: row.predicate,
-    object: row.object,
-    confidence: row.confidence ?? 0,
-    validFrom: dateToIso(row.validFrom),
-    validUntil: row.validUntil ? dateToIso(row.validUntil) : undefined,
-    recordedAt: dateToIso(row.recordedAt),
-  };
-}
-
-function dateToIso(v: unknown): string {
-  if (v instanceof Date) return v.toISOString();
-  if (typeof v === 'string') return v;
-  return new Date().toISOString();
-}
-
-function intervalsOverlap({
-  aFrom,
-  aUntil,
-  bFrom,
-  bUntil,
-}: {
-  aFrom: Date;
-  aUntil: Date | null;
-  bFrom: Date;
-  bUntil: Date | null;
-}): boolean {
-  const aEnd = aUntil ?? new Date(8.64e15);
-  const bEnd = bUntil ?? new Date(8.64e15);
-  return aFrom < bEnd && bFrom < aEnd;
-}
-
-function vectorNorm(v: number[]): number {
-  let s = 0;
-  for (const x of v) s += x * x;
-  return Math.sqrt(s);
-}
-
-function cosineSimilarity(a: number[], b: number[], aNorm: number): number {
-  if (a.length !== b.length || aNorm === 0) return 0;
-  let dot = 0;
-  let bNorm = 0;
-  for (let i = 0; i < a.length; i++) {
-    dot += a[i] * b[i];
-    bNorm += b[i] * b[i];
-  }
-  bNorm = Math.sqrt(bNorm);
-  if (bNorm === 0) return 0;
-  return dot / (aNorm * bNorm);
 }

--- a/src/ingest/ingest.module.ts
+++ b/src/ingest/ingest.module.ts
@@ -2,11 +2,17 @@ import { Module } from '@nestjs/common';
 import { IngestController } from './ingest.controller';
 import { IngestService } from './ingest.service';
 import { IngestPredictionService } from './ingest-predictor.service';
+import { PredictScoringService } from './predict-scoring.service';
 import { EntityResolverService } from './entity-resolver.service';
 
 @Module({
   controllers: [IngestController],
-  providers: [IngestService, IngestPredictionService, EntityResolverService],
+  providers: [
+    IngestService,
+    IngestPredictionService,
+    PredictScoringService,
+    EntityResolverService,
+  ],
   exports: [IngestService, IngestPredictionService],
 })
 export class IngestModule {}

--- a/src/ingest/predict-scoring.service.ts
+++ b/src/ingest/predict-scoring.service.ts
@@ -1,0 +1,155 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EmbedderService } from '../ai/embedder.service';
+import {
+  ConflictConfig,
+  SOURCE_TRUST,
+  scoreFact,
+} from './conflict-resolver';
+import { sourceTrustFor } from './ingest-utils';
+import {
+  OpposingFact,
+  PredictResolveArgs,
+  PredictResolveResult,
+  PriorRow,
+  cosineSimilarity,
+  rowToOpposingFact,
+  vectorNorm,
+} from './predictor-internals';
+
+/**
+ * PredictScoringService — the conflict-scoring engine behind the ingest
+ * preflight (predict). Owns the conflict weights/thresholds (built from
+ * config), the candidate embedding, and the per-semantics scoring math
+ * (single_active / bitemporal). IngestPredictionService gathers the DB
+ * inputs and calls into here, reading `conflict` for the threshold
+ * decisions. Splitting this out keeps both classes ≤3 injected deps.
+ */
+@Injectable()
+export class PredictScoringService {
+  /** Exposed read-only so the orchestrator can apply threshold gates. */
+  readonly conflict: ConflictConfig;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly embedder: EmbedderService,
+  ) {
+    this.conflict = {
+      similarityThreshold: this.cfgNum('CONFLICT_SIMILARITY_THRESHOLD', 0.85),
+      weights: {
+        confidence: this.cfgNum('CONFLICT_WEIGHT_CONFIDENCE', 0.3),
+        sourceTrust: this.cfgNum('CONFLICT_WEIGHT_SOURCE_TRUST', 0.4),
+        recency: this.cfgNum('CONFLICT_WEIGHT_RECENCY', 0.2),
+        authority: this.cfgNum('CONFLICT_WEIGHT_AUTHORITY', 0.1),
+      },
+      marginForSupersede: this.cfgNum('CONFLICT_MARGIN_SUPERSEDE', 0.15),
+      rejectThreshold: this.cfgNum('CONFLICT_REJECT_THRESHOLD', 0.3),
+    };
+  }
+
+  /** Embed the candidate `predicate: object` for similarity scoring. */
+  async embedCandidate(predicate: string, object: string): Promise<number[]> {
+    return this.embedder.embed(`${predicate}: ${object}`);
+  }
+
+  /** Score the candidate fact under the conflict weights. */
+  scoreCandidate(args: PredictResolveArgs): number {
+    return scoreFact(
+      {
+        confidence: args.confidence ?? 0.7,
+        sourceTrust: sourceTrustFor(args.source),
+        recordedAt: new Date(),
+        authority: 0,
+      },
+      this.conflict,
+    );
+  }
+
+  predictSingleActive(
+    candidateScore: number,
+    overlapping: PriorRow[],
+  ): Omit<PredictResolveResult, 'predicatePolicy'> {
+    const scored = overlapping
+      .map((p) => ({
+        opposing: rowToOpposingFact(p),
+        score: scoreFact(
+          {
+            confidence: p.confidence ?? 0.7,
+            sourceTrust:
+              typeof p.source === 'object' && p.source !== null
+                ? sourceTrustFor(p.source as any)
+                : SOURCE_TRUST.default,
+            recordedAt: new Date(p.recordedAt),
+            authority: 0,
+          },
+          this.conflict,
+        ),
+      }))
+      .sort((a, b) => b.score - a.score);
+    const top = scored[0];
+    const gap = candidateScore - top.score;
+    if (gap > this.conflict.marginForSupersede) {
+      return {
+        wouldOutcome: 'SUPERSEDED',
+        reasoning: `single_active predicate, candidate score ${candidateScore.toFixed(3)} beats strongest prior ${top.score.toFixed(3)} by ${gap.toFixed(3)} > margin ${this.conflict.marginForSupersede.toFixed(3)}; prior would be closed.`,
+        opposingFacts: scored.map((s) => s.opposing),
+      };
+    }
+    return {
+      wouldOutcome: 'COMPETING',
+      reasoning: `single_active predicate, candidate score ${candidateScore.toFixed(3)} vs strongest prior ${top.score.toFixed(3)} (gap ${gap.toFixed(3)}) within margin; both would remain active in COMPETING status.`,
+      opposingFacts: scored.map((s) => s.opposing),
+    };
+  }
+
+  scoreBitemporal(
+    candEmbedding: number[],
+    overlapping: PriorRow[],
+  ): Array<{ opposing: OpposingFact; cosine: number; score: number }> {
+    const norm = vectorNorm(candEmbedding);
+    return overlapping.map((p) => {
+      const emb = Array.isArray(p.embedding) ? (p.embedding as number[]) : null;
+      const cosine = emb ? cosineSimilarity(candEmbedding, emb, norm) : 0;
+      const score = scoreFact(
+        {
+          confidence: p.confidence ?? 0.7,
+          sourceTrust:
+            typeof p.source === 'object' && p.source !== null
+              ? sourceTrustFor(p.source as any)
+              : SOURCE_TRUST.default,
+          recordedAt: new Date(p.recordedAt),
+          authority: 0,
+        },
+        this.conflict,
+      );
+      return { opposing: rowToOpposingFact(p), cosine, score };
+    });
+  }
+
+  predictBitemporal(
+    candidateScore: number,
+    above: Array<{ opposing: OpposingFact; cosine: number; score: number }>,
+  ): Omit<PredictResolveResult, 'predicatePolicy'> {
+    const top = above.reduce((acc, c) => (c.score > acc.score ? c : acc), above[0]);
+    const gap = candidateScore - top.score;
+    if (gap > this.conflict.marginForSupersede) {
+      return {
+        wouldOutcome: 'SUPERSEDED',
+        reasoning: `bitemporal predicate, strongest semantically-similar prior (cosine ${top.cosine.toFixed(2)}) score ${top.score.toFixed(3)}; candidate ${candidateScore.toFixed(3)} wins by ${gap.toFixed(3)} > margin ${this.conflict.marginForSupersede.toFixed(3)}.`,
+        opposingFacts: above.map((c) => c.opposing),
+      };
+    }
+    return {
+      wouldOutcome: 'COMPETING',
+      reasoning: `bitemporal predicate, strongest similar prior (cosine ${top.cosine.toFixed(2)}) score ${top.score.toFixed(3)} too close to candidate ${candidateScore.toFixed(3)} (gap ${gap.toFixed(3)}) within margin; both would remain active in COMPETING status.`,
+      opposingFacts: above.map((c) => c.opposing),
+    };
+  }
+
+  private cfgNum(key: string, fallback: number): number {
+    const raw = this.configService.get<string | number | undefined>(key);
+    if (raw === undefined || raw === null) return fallback;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    return Number.isFinite(n) ? n : fallback;
+  }
+}

--- a/src/ingest/predictor-internals.ts
+++ b/src/ingest/predictor-internals.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared types and pure helpers for the ingest conflict-preflight
+ * (predict) path. Lives in its own module so both the orchestration
+ * (IngestPredictionService) and the scoring (PredictScoringService)
+ * sides can import them without a circular dependency.
+ */
+
+export type IngestOutcome =
+  | 'INSERTED'
+  | 'SUPERSEDED'
+  | 'COMPETING'
+  | 'REJECTED';
+
+export interface PredictResolveArgs {
+  entityRef:
+    | { vertical: string; id: string }
+    | { entityId: string };
+  predicate: string;
+  object: string;
+  validFrom: string;
+  validUntil?: string;
+  confidence?: number;
+  source: {
+    vertical: string;
+    eventId?: string;
+    messageId?: string;
+    recorder?: string;
+  };
+}
+
+export interface OpposingFact {
+  factId: string;
+  predicate: string;
+  object: string;
+  confidence: number;
+  validFrom: string;
+  validUntil?: string;
+  recordedAt: string;
+}
+
+export interface PredictResolveResult {
+  wouldOutcome: IngestOutcome;
+  reasoning: string;
+  opposingFacts: OpposingFact[];
+  predicatePolicy: {
+    semantics: string;
+    decayHalfLifeDays: number | null;
+    piiClass: string;
+  };
+}
+
+export interface PriorRow {
+  id: unknown;
+  predicate: string;
+  object: string;
+  confidence?: number;
+  validFrom: string | Date;
+  validUntil?: string | Date | null;
+  recordedAt: string | Date;
+  embedding?: number[];
+  source?: unknown;
+  status?: string;
+}
+
+export function rowToOpposingFact(row: PriorRow): OpposingFact {
+  return {
+    factId: String(row.id),
+    predicate: row.predicate,
+    object: row.object,
+    confidence: row.confidence ?? 0,
+    validFrom: dateToIso(row.validFrom),
+    validUntil: row.validUntil ? dateToIso(row.validUntil) : undefined,
+    recordedAt: dateToIso(row.recordedAt),
+  };
+}
+
+export function dateToIso(v: unknown): string {
+  if (v instanceof Date) return v.toISOString();
+  if (typeof v === 'string') return v;
+  return new Date().toISOString();
+}
+
+export function intervalsOverlap({
+  aFrom,
+  aUntil,
+  bFrom,
+  bUntil,
+}: {
+  aFrom: Date;
+  aUntil: Date | null;
+  bFrom: Date;
+  bUntil: Date | null;
+}): boolean {
+  const aEnd = aUntil ?? new Date(8.64e15);
+  const bEnd = bUntil ?? new Date(8.64e15);
+  return aFrom < bEnd && bFrom < aEnd;
+}
+
+export function vectorNorm(v: number[]): number {
+  let s = 0;
+  for (const x of v) s += x * x;
+  return Math.sqrt(s);
+}
+
+export function cosineSimilarity(a: number[], b: number[], aNorm: number): number {
+  if (a.length !== b.length || aNorm === 0) return 0;
+  let dot = 0;
+  let bNorm = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    bNorm += b[i] * b[i];
+  }
+  bNorm = Math.sqrt(bNorm);
+  if (bNorm === 0) return 0;
+  return dot / (aNorm * bNorm);
+}


### PR DESCRIPTION
## What
`IngestPredictionService` injected 4 deps (surreal, embedder, predicateRegistry, config). Split the conflict-scoring engine — conflict weights/thresholds (built from config), candidate embedding, and per-semantics scoring math (single_active / bitemporal) — into a new `PredictScoringService` (config, embedder). `IngestPredictionService` keeps the DB/registry orchestration (surreal, predicateRegistry, scoring), 3 deps, reading `scoring.conflict` for the threshold gates.

Shared types + pure helpers moved to `predictor-internals.ts` so both halves import them without a cycle.

## Why
Part 2/3 of the `max-params=3` god-class split program. Real scoring-vs-orchestration responsibility split. Public `predict()` contract unchanged.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
- `pnpm test:unit` 700/700 ✓ · predict-resolve + mention e2e green (full app DI boot exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)