### PR TITLE
refactor(audit): split ChangefeedConsumerService into drain + redaction (max-params 2/3)

### DIFF
--- a/src/audit/audit.module.ts
+++ b/src/audit/audit.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { SurrealModule } from '../db/surreal.module';
 import { ChangefeedConsumerService } from './changefeed-consumer.service';
+import { ChangefeedDrainService } from './changefeed-drain.service';
 
 /**
  * Audit module — owns the CHANGEFEED consumer (migration 0023). Kept
@@ -10,7 +11,7 @@ import { ChangefeedConsumerService } from './changefeed-consumer.service';
  */
 @Module({
   imports: [AuthModule, SurrealModule],
-  providers: [ChangefeedConsumerService],
+  providers: [ChangefeedConsumerService, ChangefeedDrainService],
   exports: [ChangefeedConsumerService],
 })
 export class AuditModule {}

--- a/src/audit/changefeed-consumer.service.ts
+++ b/src/audit/changefeed-consumer.service.ts
@@ -1,10 +1,8 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ApiKeyService } from '../auth/api-key.service';
-import { SurrealService } from '../db/surreal.service';
-import { MetricsService } from '../metrics/metrics.service';
 import { LeaderLeaseService } from '../jobs/leader-lease.service';
+import { ChangefeedDrainService } from './changefeed-drain.service';
 
 /**
  * Periodic SurrealDB CHANGEFEED reader.
@@ -15,18 +13,11 @@ import { LeaderLeaseService } from '../jobs/leader-lease.service';
  * NOTHING ever read them, so the 30-day pre-image stream sat as
  * unbounded rocksdb storage growth + compaction load.
  *
- * This service is the consumer. On each tick, for every known tenant
- * it:
- *
- *   1. Reads the last-consumed versionstamp per source table from
- *      `changefeed_state` (migration 0023).
- *   2. Calls `SHOW CHANGES FOR TABLE <t> SINCE <versionstamp>` —
- *      SurrealDB returns the slice of pending pre/post-images.
- *   3. Translates each change into an `audit_event` row with
- *      `source`, `recordId`, `op`, `ts`, `versionstamp`, `before`,
- *      and `after` populated. Per-tenant; no cross-pollination.
- *   4. UPSERTs the new high-watermark into `changefeed_state` so a
- *      crashed tick doesn't double-emit on the next run.
+ * This service is the consumer's cron/orchestration shell: every tick
+ * it fans out across known tenants and asks ChangefeedDrainService to
+ * drain each one, gated by a leader lease so multi-pod deploys don't
+ * double-emit. The actual SHOW CHANGES → audit_event drain (with PII
+ * redaction) lives in ChangefeedDrainService.
  *
  * Metrics:
  *   - brain_changefeed_consumed_total{source}
@@ -46,30 +37,10 @@ import { LeaderLeaseService } from '../jobs/leader-lease.service';
 @Injectable()
 export class ChangefeedConsumerService {
   private readonly logger = new Logger(ChangefeedConsumerService.name);
-  private readonly enabled: boolean;
-  // Cap per-tick batch size so a backlog doesn't pin the cron tick
-  // for minutes. Trailing batches drain on subsequent ticks; the
-  // lag-records gauge surfaces the backlog.
-  private readonly perBatchLimit: number;
-  /**
-   * Upper bound on rows pulled from SHOW CHANGES per source per tick.
-   * Without it, a cold start (cursor=0) materialises the ENTIRE 30-day
-   * CHANGEFEED retention into the node process before the TS-side batch
-   * slice runs. Kept a few multiples above perBatchLimit so the trailing
-   * count still reports a useful lag; the cursor drains the rest over
-   * subsequent ticks.
-   */
-  private readonly fetchLimit: number;
   // Hot in-flight flag — overlapping ticks waste DB connections and
   // could double-emit on a slow tenant. Each cron firing checks +
   // skips if a previous one is still running.
   private inFlight = false;
-
-  static readonly SOURCES = [
-    'knowledge_entity',
-    'knowledge_fact',
-    'knowledge_edge',
-  ] as const;
 
   /** Last successful tick timestamp (ISO). Exposed for admin status. */
   private lastTickAt: string | null = null;
@@ -83,34 +54,10 @@ export class ChangefeedConsumerService {
   private tickCount = 0;
 
   constructor(
-    private readonly surreal: SurrealService,
     private readonly apiKeys: ApiKeyService,
-    config: ConfigService,
-    @Optional() private readonly metrics?: MetricsService,
+    private readonly drain: ChangefeedDrainService,
     @Optional() private readonly lease?: LeaderLeaseService,
-  ) {
-    this.enabled =
-      config.get<string>('AUDIT_CHANGEFEED_ENABLED', '0') === '1';
-    this.perBatchLimit = parseInt(
-      config.get<string>('AUDIT_CHANGEFEED_BATCH', '500'),
-      10,
-    );
-    const fetchLimit = parseInt(
-      config.get<string>('AUDIT_CHANGEFEED_FETCH_LIMIT', '5000'),
-      10,
-    );
-    // Never fetch fewer than we process in a tick, else we'd starve;
-    // fall back to a sane default if the env value is garbage (the value
-    // is interpolated into the SHOW CHANGES LIMIT clause, so NaN would
-    // produce invalid SurrealQL).
-    const safeBatch = Number.isFinite(this.perBatchLimit)
-      ? this.perBatchLimit
-      : 500;
-    this.fetchLimit = Math.max(
-      Number.isFinite(fetchLimit) ? fetchLimit : 5000,
-      safeBatch,
-    );
-  }
+  ) {}
 
   // EVERY_MINUTE keeps lag bounded — see comment above. Operators
   // who want lower-latency audit replication can drop to every-30s
@@ -122,7 +69,7 @@ export class ChangefeedConsumerService {
   // rows AND clobber each other's UPSERT of changefeed_state.
   @Cron(CronExpression.EVERY_MINUTE)
   async tick(): Promise<void> {
-    if (!this.enabled || this.inFlight) return;
+    if (!this.drain.enabled || this.inFlight) return;
     if (this.lease) {
       // ttl=180s leaves 3x the 60s cron cadence as headroom — a GC pause
       // can't strand the lease past the next tick attempt.
@@ -135,7 +82,7 @@ export class ChangefeedConsumerService {
     try {
       for (const companyId of this.apiKeys.knownCompanyIds()) {
         try {
-          const r = await this.consumeForTenant(companyId);
+          const r = await this.drain.consumeForTenant(companyId);
           pendingThisTick += r.pendingRemaining;
           consumedThisTick += Object.values(r.consumed).reduce(
             (a, b) => a + b,
@@ -176,15 +123,15 @@ export class ChangefeedConsumerService {
     perBatchLimit: number;
   } {
     return {
-      enabled: this.enabled,
+      enabled: this.drain.enabled,
       inFlight: this.inFlight,
       lastTickAt: this.lastTickAt,
       lastPendingRemaining: this.lastPendingRemaining,
       totalConsumed: this.totalConsumed,
       tickCount: this.tickCount,
       lastError: this.lastError,
-      sources: ChangefeedConsumerService.SOURCES,
-      perBatchLimit: this.perBatchLimit,
+      sources: this.drain.sources,
+      perBatchLimit: this.drain.perBatchLimit,
     };
   }
 
@@ -208,7 +155,7 @@ export class ChangefeedConsumerService {
     try {
       for (const companyId of tenants) {
         try {
-          const r = await this.consumeForTenant(companyId);
+          const r = await this.drain.consumeForTenant(companyId);
           for (const [k, v] of Object.entries(r.consumed)) {
             consumed[k] = (consumed[k] ?? 0) + v;
           }
@@ -231,31 +178,22 @@ export class ChangefeedConsumerService {
   }
 
   /**
-   * Per-source cursor table — joins the in-memory tick state with the
-   * persisted `changefeed_state` cursor per tenant + source. Cheap
-   * read; admin operators use it to spot tenants stuck behind a slow
-   * batch.
+   * Per-source cursor table — joins the tick state with the persisted
+   * `changefeed_state` cursor per tenant + source. Cheap read; admin
+   * operators use it to spot tenants stuck behind a slow batch.
    */
   async cursorState(): Promise<
     Array<{ companyId: string; source: string; cursor: number }>
   > {
-    if (!this.enabled) return [];
+    if (!this.drain.enabled) return [];
     const out: Array<{ companyId: string; source: string; cursor: number }> =
       [];
     for (const companyId of this.apiKeys.knownCompanyIds()) {
       try {
-        await this.surreal.withCompany(companyId, async (db) => {
-          for (const source of ChangefeedConsumerService.SOURCES) {
-            try {
-              const cursor = await this.loadCursor(db, source);
-              out.push({ companyId, source, cursor });
-            } catch (e) {
-              this.logger.warn(
-                `[changefeed] cursor read failed (${companyId}/${source}): ${(e as Error).message}`,
-              );
-            }
-          }
-        });
+        const rows = await this.drain.cursorStateForTenant(companyId);
+        for (const r of rows) {
+          out.push({ companyId, source: r.source, cursor: r.cursor });
+        }
       } catch (e) {
         this.logger.warn(
           `[changefeed] cursorState failed for ${companyId}: ${(e as Error).message}`,
@@ -264,216 +202,4 @@ export class ChangefeedConsumerService {
     }
     return out;
   }
-
-  // Exposed so a unit test (or the admin debug endpoint) can drain
-  // synchronously without waiting for the cron tick.
-  async consumeForTenant(companyId: string): Promise<{
-    consumed: Record<string, number>;
-    pendingRemaining: number;
-  }> {
-    const consumed: Record<string, number> = {};
-    let pendingRemaining = 0;
-
-    await this.surreal.withCompany(companyId, async (db) => {
-      for (const source of ChangefeedConsumerService.SOURCES) {
-        const since = await this.loadCursor(db, source);
-        const changes = await this.fetchChanges(db, source, since);
-        if (changes.length === 0) continue;
-
-        // The slice may be larger than perBatchLimit — emit the first
-        // N and leave the remainder for the next tick so a backlog
-        // can't lock the cron up. Sort by versionstamp ascending to
-        // guarantee we never advance the cursor past unconsumed rows.
-        const sorted = changes
-          .slice()
-          .sort(
-            (a, b) =>
-              (a.versionstamp as number) - (b.versionstamp as number),
-          );
-        const batch = sorted.slice(0, this.perBatchLimit);
-        const trailing = sorted.length - batch.length;
-        pendingRemaining += trailing;
-
-        // Bulk-insert the whole batch in one round-trip. Sequential
-        // CREATE was the bottleneck under load: 500 changes × 3 sources
-        // × 50 tenants = 75K serial round-trips per tick, easily
-        // overflowing the EVERY_MINUTE budget. INSERT INTO ... [..]
-        // takes one RTT per source instead.
-        const events = this.buildAuditEventBatch(source, batch);
-        if (events.length > 0) {
-          await db.query(
-            `INSERT INTO audit_event $events`,
-            { events },
-          );
-        }
-        await this.advanceCursor(
-          db,
-          source,
-          batch[batch.length - 1].versionstamp as number,
-        );
-        consumed[source] = batch.length;
-      }
-    });
-
-    if (this.metrics) {
-      for (const [source, n] of Object.entries(consumed)) {
-        this.metrics.countChangefeedConsumed(source, n);
-      }
-      this.metrics.setChangefeedLag(pendingRemaining);
-    }
-
-    return { consumed, pendingRemaining };
-  }
-
-  // ── Wire-format helpers ──────────────────────────────────────────
-
-  private async loadCursor(db: any, source: string): Promise<number> {
-    const [rows] = await db.query(
-      `SELECT lastVersionstamp FROM changefeed_state
-        WHERE source = $s LIMIT 1`,
-      { s: source },
-    );
-    const arr = (rows as Array<{ lastVersionstamp: number }>) ?? [];
-    return arr[0]?.lastVersionstamp ?? 0;
-  }
-
-  private async fetchChanges(
-    db: any,
-    source: string,
-    since: number,
-  ): Promise<Array<Record<string, unknown>>> {
-    // SHOW CHANGES is parameter-friendly for the SINCE clause but the
-    // table name is a syntactic identifier — we whitelist it via the
-    // static SOURCES tuple to keep it injection-safe.
-    if (!(ChangefeedConsumerService.SOURCES as readonly string[]).includes(source)) {
-      throw new Error(`refusing unknown changefeed source: ${source}`);
-    }
-    const [rows] = await db.query(
-      `SHOW CHANGES FOR TABLE ${source} SINCE ${since} LIMIT ${this.fetchLimit}`,
-    );
-    const changes = (rows as Array<Record<string, unknown>>) ?? [];
-    // SurrealDB's SHOW CHANGES ... SINCE <vs> is inclusive of the boundary
-    // versionstamp: a cursor parked at the last consumed vs would re-surface
-    // that same row on the next tick → duplicate audit_event. Drop anything
-    // at or below the cursor. Idempotent regardless of the DB's exact
-    // boundary semantics; cold start (since=0) keeps all real changes since
-    // versionstamps are strictly positive.
-    if (since > 0) {
-      return changes.filter((c) => (c.versionstamp as number) > since);
-    }
-    return changes;
-  }
-
-  /**
-   * Flatten a batch of SHOW CHANGES rows into the audit_event shape.
-   *
-   * Each `change` row carries one or more items (`update` / `delete` /
-   * `define_table`); each item becomes one audit_event. We compute
-   * the array once so the consumer can submit them in a single
-   * `INSERT INTO audit_event [..]` round-trip instead of N serial
-   * CREATEs. Returning the array (not awaiting per-row) is what makes
-   * the operation bulk-able.
-   */
-  private buildAuditEventBatch(
-    source: string,
-    changes: Array<Record<string, unknown>>,
-  ): Array<Record<string, unknown>> {
-    const out: Array<Record<string, unknown>> = [];
-    for (const change of changes) {
-      const versionstamp = change.versionstamp as number;
-      const items =
-        (change.changes as Array<Record<string, unknown>> | undefined) ?? [];
-      for (const item of items) {
-        const op = Object.keys(item)[0] ?? 'unknown';
-        const payload = (item as Record<string, unknown>)[op] as
-          | Record<string, unknown>
-          | string
-          | undefined;
-        const recordId =
-          op === 'delete'
-            ? String(payload)
-            : (payload as { id?: unknown } | undefined)?.id?.toString() ?? '';
-        const after =
-          typeof payload === 'object'
-            ? redactAfterImage(payload as Record<string, unknown>)
-            : undefined;
-        out.push({
-          source,
-          recordId,
-          op,
-          versionstamp,
-          after,
-        });
-      }
-    }
-    return out;
-  }
-
-  private async advanceCursor(
-    db: any,
-    source: string,
-    versionstamp: number,
-  ): Promise<void> {
-    await db.query(
-      `UPSERT changefeed_state:[$source] CONTENT {
-          source: $source,
-          lastVersionstamp: $vs,
-          updatedAt: time::now()
-       }`,
-      { source, vs: versionstamp },
-    );
-  }
-}
-
-/**
- * Redact PII *value* fields from a changefeed post-image before it is
- * mirrored into audit_event. The mirror is a structural change-log: it
- * records WHICH predicate changed on WHICH entity (id, predicate,
- * status, validity, op) — it must NOT carry the raw sensitive VALUE
- * (a fact `object` like an email/address, or an entity name/aliases).
- *
- * This is also the structural defence for the GDPR forget race: a
- * record whose CREATE/UPDATE is still unconsumed when the subject is
- * forgotten gets re-materialised here AFTER the forget purge — but with
- * the value already redacted, so no raw PII re-appears in audit_event.
- * `embedding` is dropped as bloat (huge float array, not human PII).
- */
-export const REDACTED = '[redacted]';
-// Allowlist of STRUCTURAL fields kept verbatim in the audit mirror. Any
-// other field — present or future — is redacted, so a new PII-bearing
-// column can't silently leak (denylist regressed once: canonicalNameLc /
-// externalRefs were missed). `embedding` is dropped as bloat.
-const STRUCTURAL_FIELDS = new Set([
-  'id',
-  'entityId',
-  'predicate',
-  'op',
-  'status',
-  'validFrom',
-  'validUntil',
-  'recordedAt',
-  'retractedAt',
-  'retractionReason',
-  'supersededBy',
-  'priorValidUntil',
-  'confidence',
-  'kind',
-  'in',
-  'out',
-  'weight',
-  'artifactType',
-  'dirty',
-  'mergedInto',
-  'mergedAt',
-  'type',
-]);
-export function redactAfterImage(
-  row: Record<string, unknown>,
-): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(row)) {
-    if (k === 'embedding') continue; // drop float-array bloat
-    out[k] = STRUCTURAL_FIELDS.has(k) || v == null ? v : REDACTED;
-  }
-  return out;
 }

--- a/src/audit/changefeed-drain.service.ts
+++ b/src/audit/changefeed-drain.service.ts
@@ -1,0 +1,252 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SurrealService } from '../db/surreal.service';
+import { MetricsService } from '../metrics/metrics.service';
+import { redactAfterImage } from './changefeed-redaction';
+
+/**
+ * ChangefeedDrainService — the per-tenant CHANGEFEED drain engine.
+ *
+ * Owns the actual work: read the per-source cursor, `SHOW CHANGES FOR
+ * TABLE … SINCE`, translate each change into an `audit_event` row
+ * (PII-redacted post-image), bulk-insert, and advance the cursor. Also
+ * owns the batch/fetch limits and the AUDIT_CHANGEFEED_ENABLED gate.
+ * The cron cadence, leader election, tenant fan-out, and operator
+ * status live in ChangefeedConsumerService, which delegates here.
+ * Splitting the drain out keeps both classes' injected-dep lists ≤3.
+ */
+@Injectable()
+export class ChangefeedDrainService {
+  private readonly logger = new Logger(ChangefeedDrainService.name);
+  readonly enabled: boolean;
+  // Cap per-tick batch size so a backlog doesn't pin the cron tick
+  // for minutes. Trailing batches drain on subsequent ticks; the
+  // lag-records gauge surfaces the backlog.
+  readonly perBatchLimit: number;
+  /**
+   * Upper bound on rows pulled from SHOW CHANGES per source per tick.
+   * Without it, a cold start (cursor=0) materialises the ENTIRE 30-day
+   * CHANGEFEED retention into the node process before the TS-side batch
+   * slice runs. Kept a few multiples above perBatchLimit so the trailing
+   * count still reports a useful lag; the cursor drains the rest over
+   * subsequent ticks.
+   */
+  private readonly fetchLimit: number;
+
+  static readonly SOURCES = [
+    'knowledge_entity',
+    'knowledge_fact',
+    'knowledge_edge',
+  ] as const;
+
+  get sources(): readonly string[] {
+    return ChangefeedDrainService.SOURCES;
+  }
+
+  constructor(
+    private readonly surreal: SurrealService,
+    config: ConfigService,
+    @Optional() private readonly metrics?: MetricsService,
+  ) {
+    this.enabled =
+      config.get<string>('AUDIT_CHANGEFEED_ENABLED', '0') === '1';
+    this.perBatchLimit = parseInt(
+      config.get<string>('AUDIT_CHANGEFEED_BATCH', '500'),
+      10,
+    );
+    const fetchLimit = parseInt(
+      config.get<string>('AUDIT_CHANGEFEED_FETCH_LIMIT', '5000'),
+      10,
+    );
+    // Never fetch fewer than we process in a tick, else we'd starve;
+    // fall back to a sane default if the env value is garbage (the value
+    // is interpolated into the SHOW CHANGES LIMIT clause, so NaN would
+    // produce invalid SurrealQL).
+    const safeBatch = Number.isFinite(this.perBatchLimit)
+      ? this.perBatchLimit
+      : 500;
+    this.fetchLimit = Math.max(
+      Number.isFinite(fetchLimit) ? fetchLimit : 5000,
+      safeBatch,
+    );
+  }
+
+  // Exposed so a unit test (or the admin debug endpoint) can drain
+  // synchronously without waiting for the cron tick.
+  async consumeForTenant(companyId: string): Promise<{
+    consumed: Record<string, number>;
+    pendingRemaining: number;
+  }> {
+    const consumed: Record<string, number> = {};
+    let pendingRemaining = 0;
+
+    await this.surreal.withCompany(companyId, async (db) => {
+      for (const source of ChangefeedDrainService.SOURCES) {
+        const since = await this.loadCursor(db, source);
+        const changes = await this.fetchChanges(db, source, since);
+        if (changes.length === 0) continue;
+
+        // The slice may be larger than perBatchLimit — emit the first
+        // N and leave the remainder for the next tick so a backlog
+        // can't lock the cron up. Sort by versionstamp ascending to
+        // guarantee we never advance the cursor past unconsumed rows.
+        const sorted = changes
+          .slice()
+          .sort(
+            (a, b) =>
+              (a.versionstamp as number) - (b.versionstamp as number),
+          );
+        const batch = sorted.slice(0, this.perBatchLimit);
+        const trailing = sorted.length - batch.length;
+        pendingRemaining += trailing;
+
+        // Bulk-insert the whole batch in one round-trip. Sequential
+        // CREATE was the bottleneck under load: 500 changes × 3 sources
+        // × 50 tenants = 75K serial round-trips per tick, easily
+        // overflowing the EVERY_MINUTE budget. INSERT INTO ... [..]
+        // takes one RTT per source instead.
+        const events = this.buildAuditEventBatch(source, batch);
+        if (events.length > 0) {
+          await db.query(
+            `INSERT INTO audit_event $events`,
+            { events },
+          );
+        }
+        await this.advanceCursor(
+          db,
+          source,
+          batch[batch.length - 1].versionstamp as number,
+        );
+        consumed[source] = batch.length;
+      }
+    });
+
+    if (this.metrics) {
+      for (const [source, n] of Object.entries(consumed)) {
+        this.metrics.countChangefeedConsumed(source, n);
+      }
+      this.metrics.setChangefeedLag(pendingRemaining);
+    }
+
+    return { consumed, pendingRemaining };
+  }
+
+  /** Per-source cursor snapshot for ONE tenant. */
+  async cursorStateForTenant(
+    companyId: string,
+  ): Promise<Array<{ source: string; cursor: number }>> {
+    const out: Array<{ source: string; cursor: number }> = [];
+    await this.surreal.withCompany(companyId, async (db) => {
+      for (const source of ChangefeedDrainService.SOURCES) {
+        try {
+          const cursor = await this.loadCursor(db, source);
+          out.push({ source, cursor });
+        } catch (e) {
+          this.logger.warn(
+            `[changefeed] cursor read failed (${companyId}/${source}): ${(e as Error).message}`,
+          );
+        }
+      }
+    });
+    return out;
+  }
+
+  // ── Wire-format helpers ──────────────────────────────────────────
+
+  private async loadCursor(db: any, source: string): Promise<number> {
+    const [rows] = await db.query(
+      `SELECT lastVersionstamp FROM changefeed_state
+        WHERE source = $s LIMIT 1`,
+      { s: source },
+    );
+    const arr = (rows as Array<{ lastVersionstamp: number }>) ?? [];
+    return arr[0]?.lastVersionstamp ?? 0;
+  }
+
+  private async fetchChanges(
+    db: any,
+    source: string,
+    since: number,
+  ): Promise<Array<Record<string, unknown>>> {
+    // SHOW CHANGES is parameter-friendly for the SINCE clause but the
+    // table name is a syntactic identifier — we whitelist it via the
+    // static SOURCES tuple to keep it injection-safe.
+    if (!(ChangefeedDrainService.SOURCES as readonly string[]).includes(source)) {
+      throw new Error(`refusing unknown changefeed source: ${source}`);
+    }
+    const [rows] = await db.query(
+      `SHOW CHANGES FOR TABLE ${source} SINCE ${since} LIMIT ${this.fetchLimit}`,
+    );
+    const changes = (rows as Array<Record<string, unknown>>) ?? [];
+    // SurrealDB's SHOW CHANGES ... SINCE <vs> is inclusive of the boundary
+    // versionstamp: a cursor parked at the last consumed vs would re-surface
+    // that same row on the next tick → duplicate audit_event. Drop anything
+    // at or below the cursor. Idempotent regardless of the DB's exact
+    // boundary semantics; cold start (since=0) keeps all real changes since
+    // versionstamps are strictly positive.
+    if (since > 0) {
+      return changes.filter((c) => (c.versionstamp as number) > since);
+    }
+    return changes;
+  }
+
+  /**
+   * Flatten a batch of SHOW CHANGES rows into the audit_event shape.
+   *
+   * Each `change` row carries one or more items (`update` / `delete` /
+   * `define_table`); each item becomes one audit_event. We compute
+   * the array once so the consumer can submit them in a single
+   * `INSERT INTO audit_event [..]` round-trip instead of N serial
+   * CREATEs. Returning the array (not awaiting per-row) is what makes
+   * the operation bulk-able.
+   */
+  private buildAuditEventBatch(
+    source: string,
+    changes: Array<Record<string, unknown>>,
+  ): Array<Record<string, unknown>> {
+    const out: Array<Record<string, unknown>> = [];
+    for (const change of changes) {
+      const versionstamp = change.versionstamp as number;
+      const items =
+        (change.changes as Array<Record<string, unknown>> | undefined) ?? [];
+      for (const item of items) {
+        const op = Object.keys(item)[0] ?? 'unknown';
+        const payload = (item as Record<string, unknown>)[op] as
+          | Record<string, unknown>
+          | string
+          | undefined;
+        const recordId =
+          op === 'delete'
+            ? String(payload)
+            : (payload as { id?: unknown } | undefined)?.id?.toString() ?? '';
+        const after =
+          typeof payload === 'object'
+            ? redactAfterImage(payload as Record<string, unknown>)
+            : undefined;
+        out.push({
+          source,
+          recordId,
+          op,
+          versionstamp,
+          after,
+        });
+      }
+    }
+    return out;
+  }
+
+  private async advanceCursor(
+    db: any,
+    source: string,
+    versionstamp: number,
+  ): Promise<void> {
+    await db.query(
+      `UPSERT changefeed_state:[$source] CONTENT {
+          source: $source,
+          lastVersionstamp: $vs,
+          updatedAt: time::now()
+       }`,
+      { source, vs: versionstamp },
+    );
+  }
+}

--- a/src/audit/changefeed-redaction.ts
+++ b/src/audit/changefeed-redaction.ts
@@ -1,0 +1,54 @@
+/**
+ * Redact PII *value* fields from a changefeed post-image before it is
+ * mirrored into audit_event. The mirror is a structural change-log: it
+ * records WHICH predicate changed on WHICH entity (id, predicate,
+ * status, validity, op) — it must NOT carry the raw sensitive VALUE
+ * (a fact `object` like an email/address, or an entity name/aliases).
+ *
+ * This is also the structural defence for the GDPR forget race: a
+ * record whose CREATE/UPDATE is still unconsumed when the subject is
+ * forgotten gets re-materialised here AFTER the forget purge — but with
+ * the value already redacted, so no raw PII re-appears in audit_event.
+ * `embedding` is dropped as bloat (huge float array, not human PII).
+ */
+export const REDACTED = '[redacted]';
+
+// Allowlist of STRUCTURAL fields kept verbatim in the audit mirror. Any
+// other field — present or future — is redacted, so a new PII-bearing
+// column can't silently leak (denylist regressed once: canonicalNameLc /
+// externalRefs were missed). `embedding` is dropped as bloat.
+const STRUCTURAL_FIELDS = new Set([
+  'id',
+  'entityId',
+  'predicate',
+  'op',
+  'status',
+  'validFrom',
+  'validUntil',
+  'recordedAt',
+  'retractedAt',
+  'retractionReason',
+  'supersededBy',
+  'priorValidUntil',
+  'confidence',
+  'kind',
+  'in',
+  'out',
+  'weight',
+  'artifactType',
+  'dirty',
+  'mergedInto',
+  'mergedAt',
+  'type',
+]);
+
+export function redactAfterImage(
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(row)) {
+    if (k === 'embedding') continue; // drop float-array bloat
+    out[k] = STRUCTURAL_FIELDS.has(k) || v == null ? v : REDACTED;
+  }
+  return out;
+}

--- a/test/changefeed-consumer.unit-spec.ts
+++ b/test/changefeed-consumer.unit-spec.ts
@@ -1,5 +1,5 @@
 /**
- * Unit-test for ChangefeedConsumerService.consumeForTenant — exercises
+ * Unit-test for ChangefeedDrainService.consumeForTenant — exercises
  * the cursor-advance + batch-cap + audit-event-emit paths without
  * standing up a real SurrealDB testcontainer.
  *
@@ -10,7 +10,7 @@
  *   3. Cursor is advanced to the highest consumed versionstamp.
  *   4. The unknown-source guard rejects an out-of-allowlist table.
  */
-import { ChangefeedConsumerService } from '../src/audit/changefeed-consumer.service';
+import { ChangefeedDrainService } from '../src/audit/changefeed-drain.service';
 
 type Captured = { sql: string; params?: Record<string, unknown> };
 
@@ -57,8 +57,7 @@ function mkSurreal(opts: {
 function mkSvc(
   surreal: any,
   cfgOverrides: Record<string, string> = {},
-): ChangefeedConsumerService {
-  const apiKeys = { knownCompanyIds: () => ['co_a'] } as any;
+): ChangefeedDrainService {
   const config = {
     get: (k: string, def?: string) => {
       if (k === 'AUDIT_CHANGEFEED_ENABLED') return cfgOverrides[k] ?? '1';
@@ -66,10 +65,10 @@ function mkSvc(
       return def;
     },
   } as any;
-  return new ChangefeedConsumerService(surreal, apiKeys, config);
+  return new ChangefeedDrainService(surreal, config);
 }
 
-describe('ChangefeedConsumerService', () => {
+describe('ChangefeedDrainService', () => {
   it('consumes every change from a cold cursor and advances to the high-water mark', async () => {
     const { surreal, calls } = mkSurreal({
       cursors: {},

--- a/test/changefeed-redaction.unit-spec.ts
+++ b/test/changefeed-redaction.unit-spec.ts
@@ -7,7 +7,7 @@
 import {
   redactAfterImage,
   REDACTED,
-} from '../src/audit/changefeed-consumer.service';
+} from '../src/audit/changefeed-redaction';
 
 describe('redactAfterImage', () => {
   it('redacts fact PII value fields but keeps structural fields', () => {


### PR DESCRIPTION
## What
`ChangefeedConsumerService` injected 5 deps (surreal, apiKeys, config, metrics, lease). Split the per-tenant drain engine — `SHOW CHANGES` → `audit_event` translation, batch caps, cursor management — into `ChangefeedDrainService` (surreal, config, metrics), and move the PII-redaction allowlist into its own pure `changefeed-redaction.ts`. The consumer keeps the cron tick, leader election, tenant fan-out, and operator status (apiKeys, drain, lease), 3 deps.

## Why
Part 2/3 of the `max-params=3` god-class split program — "split consume-loop vs redaction vs metrics" per the roadmap. Public surface (tick/stats/drainNow/cursorState) unchanged; the drain unit-spec now targets `ChangefeedDrainService.consumeForTenant` and the redaction spec imports from `changefeed-redaction`.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
- `pnpm test:unit` 700/700 ✓ · `pnpm test:e2e` 128/128 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)