### PR TITLE
refactor(compaction): split CompactionService into runner + queue (max-params 2/3)

### DIFF
--- a/src/compaction/compaction-queue.service.ts
+++ b/src/compaction/compaction-queue.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ApiKeyService } from '../auth/api-key.service';
+import { JobClaimService } from '../jobs/job-claim.service';
+import type { JobType } from '../jobs/job-run.service';
+import {
+  WorkerLoopService,
+  type JobContext,
+  type JobHandler,
+} from '../jobs/worker-loop.service';
+
+/**
+ * CompactionQueueService — the queue/dispatch plumbing for compaction.
+ *
+ * Owns the worker-loop handler registration and the per-tenant cron
+ * enqueue, plus the queue-mode flag and the known-tenant list. The
+ * actual compaction work lives in CompactionRunnerService; the cron
+ * cadence + metrics live in CompactionService. Splitting this out keeps
+ * each compaction class's injected-dep list ≤3.
+ *
+ * claim / workerLoop are optional — single-process test contexts run the
+ * legacy in-line path without a queue.
+ */
+@Injectable()
+export class CompactionQueueService {
+  private readonly logger = new Logger(CompactionQueueService.name);
+
+  constructor(
+    private readonly apiKeys: ApiKeyService,
+    @Optional() private readonly claim?: JobClaimService,
+    @Optional() private readonly workerLoop?: WorkerLoopService,
+  ) {}
+
+  /** True when the queue path is wired (claim available). */
+  get hasClaim(): boolean {
+    return !!this.claim;
+  }
+
+  knownTenants(): string[] {
+    return this.apiKeys.knownCompanyIds();
+  }
+
+  queueModeEnabled(): boolean {
+    return (process.env.JOBS_QUEUE_MODE ?? 'enqueue') === 'enqueue';
+  }
+
+  /**
+   * Register a job handler with the worker loop. No-op when the worker
+   * loop isn't wired (single-process tests).
+   */
+  register(
+    jobType: JobType,
+    handler: (ctx: JobContext) => Promise<Record<string, unknown>>,
+    opts: { ttlSeconds: number; maxAttempts: number },
+  ): void {
+    if (!this.workerLoop) return;
+    this.workerLoop.register(jobType, handler as JobHandler, opts);
+  }
+
+  /** Enqueue one compaction row per known tenant (idempotent per day). */
+  async enqueueAllTenants(jobType: JobType): Promise<{ enqueued: number }> {
+    const tenants = this.apiKeys.knownCompanyIds();
+    const today = new Date().toISOString().slice(0, 10);
+    let enqueued = 0;
+    for (const companyId of tenants) {
+      try {
+        const { created } = await this.claim!.enqueue({
+          jobType,
+          companyId,
+          triggeredBy: 'cron',
+          dedupKey: `${jobType}_${today}`,
+        });
+        if (created) enqueued++;
+      } catch (e) {
+        this.logger.warn(
+          `enqueue ${jobType} for ${companyId} failed: ${(e as Error).message}`,
+        );
+      }
+    }
+    this.logger.log(
+      `Compaction cron enqueued ${enqueued}/${tenants.length} tenant job(s) for ${today}`,
+    );
+    return { enqueued };
+  }
+}

--- a/src/compaction/compaction-runner.service.ts
+++ b/src/compaction/compaction-runner.service.ts
@@ -1,0 +1,197 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SurrealService, dbCreate } from '../db/surreal.service';
+import {
+  ConcatSummaryGenerator,
+  FactToSummarize,
+  SummaryGenerator,
+} from './summary-generator';
+import {
+  CandidateFactRow,
+  CompactionStats,
+  SUMMARY_GENERATOR,
+} from './compaction.types';
+
+/**
+ * CompactionRunnerService — the retention engine.
+ *
+ * Owns the actual compaction work for a tenant: SELECT old facts past
+ * the hot-retention window, optionally roll them up into summary facts
+ * via the SummaryGenerator, then mark + drop embeddings on the
+ * originals. Parameterised by tenant id / tenant list so it carries no
+ * apiKeys dependency — the cron cadence, queue dispatch, tenant fan-out
+ * source, and metrics live in CompactionService, which delegates here.
+ * Splitting the engine out keeps each compaction class's injected-dep
+ * list ≤3.
+ *
+ * compactCompany returns stats; the caller emits metrics. Idempotent: a
+ * compacted row stays compacted.
+ */
+@Injectable()
+export class CompactionRunnerService {
+  private readonly logger = new Logger(CompactionRunnerService.name);
+  private readonly hotRetentionDays: number;
+  private readonly summariesEnabled: boolean;
+  private readonly summaryGenerator: SummaryGenerator;
+
+  constructor(
+    private readonly surreal: SurrealService,
+    config: ConfigService,
+    @Optional() @Inject(SUMMARY_GENERATOR) injectedGenerator?: SummaryGenerator,
+  ) {
+    this.hotRetentionDays = parseInt(
+      config.get<string>('COMPACTION_HOT_RETENTION_DAYS', '90'),
+      10,
+    );
+    if (!Number.isFinite(this.hotRetentionDays) || this.hotRetentionDays < 1) {
+      throw new Error('COMPACTION_HOT_RETENTION_DAYS must be a positive integer');
+    }
+    this.summariesEnabled =
+      config.get<string>('COMPACTION_SUMMARIES', 'false').toLowerCase() === 'true';
+    this.summaryGenerator = injectedGenerator ?? new ConcatSummaryGenerator();
+    this.logger.log(
+      `Compaction config: retention=${this.hotRetentionDays}d, summaries=${this.summariesEnabled}, generator=${this.summaryGenerator.constructor.name}`,
+    );
+  }
+
+  /**
+   * Compact every tenant in the list. Errors per-tenant are logged; one
+   * bad tenant must not stop the rest from getting compacted.
+   */
+  async compactAll(tenants: string[]): Promise<CompactionStats[]> {
+    this.logger.log(`Compaction starting — ${tenants.length} tenant(s)`);
+    const results: CompactionStats[] = [];
+    for (const companyId of tenants) {
+      try {
+        const stats = await this.compactCompany(companyId);
+        results.push(stats);
+      } catch (e) {
+        this.logger.error(
+          `Compaction failed for ${companyId}: ${(e as Error).message}`,
+        );
+      }
+    }
+    const total = results.reduce((acc, r) => acc + r.factsCompacted, 0);
+    const summaries = results.reduce((acc, r) => acc + r.summariesCreated, 0);
+    this.logger.log(
+      `Compaction done — ${total} fact(s) compacted, ${summaries} summary fact(s) created across ${results.length} tenant(s)`,
+    );
+    return results;
+  }
+
+  /**
+   * Compact one tenant. Pipeline:
+   *   1. SELECT old facts (carrying embeddings) past the retention window.
+   *   2. (Optional) Group by (entityId, predicate) and create a summary
+   *      fact per group of ≥ 2.
+   *   3. UPDATE old facts: status = 'compacted', embedding = NONE.
+   */
+  async compactCompany(companyId: string): Promise<CompactionStats> {
+    const cutoff = new Date(
+      Date.now() - this.hotRetentionDays * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    return this.surreal.withCompany(companyId, async (db) => {
+      // Step 1: pull candidate facts with their bodies, so the summarizer
+      // has something to work with. We bound by 1000/run to avoid one
+      // tenant dominating the cron — anything past that gets compacted
+      // on the next cycle.
+      const [factRows] = await db.query<[CandidateFactRow[]]>(
+        `SELECT id, entityId, predicate, object, validFrom, validUntil, confidence
+           FROM knowledge_fact
+           WHERE status != 'compacted'
+             AND embedding != NONE
+             AND ((validUntil != NONE AND validUntil < d$cutoff)
+                  OR (retractedAt != NONE AND retractedAt < d$cutoff))
+           ORDER BY validFrom ASC
+           LIMIT 1000`,
+        { cutoff },
+      );
+      const candidates = (factRows ?? []) as CandidateFactRow[];
+      if (candidates.length === 0) {
+        return { companyId, factsCompacted: 0, summariesCreated: 0, bytesFreed: 0 };
+      }
+
+      // Step 2: optional summary rollup
+      let summariesCreated = 0;
+      if (this.summariesEnabled) {
+        summariesCreated = await this.createSummaries(db, candidates);
+      }
+
+      // Step 3: mark + drop embeddings on the originals
+      const ids = candidates.map((c) => String(c.id));
+      await db.query(
+        `UPDATE knowledge_fact
+           SET status = 'compacted', embedding = NONE
+           WHERE id INSIDE $ids`,
+        { ids },
+      );
+
+      const factsCompacted = candidates.length;
+      const bytesFreed = factsCompacted * 6 * 1024;
+      this.logger.log(
+        `Compacted ${factsCompacted} fact(s) in tenant ${companyId} ` +
+          `(~${(bytesFreed / 1024 / 1024).toFixed(1)} MiB freed, ${summariesCreated} summary fact(s))`,
+      );
+      return { companyId, factsCompacted, summariesCreated, bytesFreed };
+    });
+  }
+
+  /**
+   * Group candidate facts by (entityId, predicate), then for each group
+   * with ≥ 2 facts call the SummaryGenerator and CREATE a summary fact
+   * pointing at the originals via `derivedFrom`. Returns the count of
+   * summaries created.
+   */
+  private async createSummaries(
+
+    db: any,
+    candidates: CandidateFactRow[],
+  ): Promise<number> {
+    const groups = new Map<string, CandidateFactRow[]>();
+    for (const c of candidates) {
+      const key = `${c.entityId}::${c.predicate}`;
+      const arr = groups.get(key);
+      if (arr) arr.push(c);
+      else groups.set(key, [c]);
+    }
+
+    let created = 0;
+    for (const [, group] of groups) {
+      if (group.length < 2) continue;
+      const sorted = [...group].sort((a, b) =>
+        a.validFrom < b.validFrom ? -1 : 1,
+      );
+      const summaryText = await this.summaryGenerator.generate(
+        sorted.map((g) => ({
+          factId: String(g.id),
+          predicate: g.predicate,
+          object: g.object,
+          validFrom: g.validFrom,
+          validUntil: g.validUntil ?? undefined,
+          confidence: g.confidence,
+        }) satisfies FactToSummarize),
+      );
+      if (!summaryText) continue;
+
+      const earliest = sorted[0].validFrom;
+      const latest = sorted[sorted.length - 1].validUntil ?? sorted[sorted.length - 1].validFrom;
+      const meanConfidence =
+        sorted.reduce((acc, g) => acc + g.confidence, 0) / sorted.length;
+
+      await dbCreate(db, 'knowledge_fact', {
+        entityId: sorted[0].entityId,
+        predicate: `summary_${sorted[0].predicate}`,
+        object: summaryText,
+        confidence: meanConfidence,
+        validFrom: earliest,
+        validUntil: latest,
+        source: { kind: 'compaction-summary' },
+        derivedFrom: sorted.map((g) => g.id),
+        status: 'active',
+      });
+      created++;
+    }
+    return created;
+  }
+}

--- a/src/compaction/compaction.module.ts
+++ b/src/compaction/compaction.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { CompactionService, SUMMARY_GENERATOR } from './compaction.service';
+import { CompactionService } from './compaction.service';
+import { CompactionRunnerService } from './compaction-runner.service';
+import { CompactionQueueService } from './compaction-queue.service';
+import { SUMMARY_GENERATOR } from './compaction.types';
 import {
   ConcatSummaryGenerator,
   type SummaryGenerator,
@@ -22,6 +25,8 @@ import { MetricsModule } from '../metrics/metrics.module';
   imports: [MetricsModule],
   providers: [
     CompactionService,
+    CompactionRunnerService,
+    CompactionQueueService,
     {
       provide: SUMMARY_GENERATOR,
       inject: [ConfigService],

--- a/src/compaction/compaction.service.ts
+++ b/src/compaction/compaction.service.ts
@@ -1,93 +1,50 @@
-import { Inject, Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
-import { ApiKeyService } from '../auth/api-key.service';
-import { SurrealService, dbCreate } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
-import { JobClaimService } from '../jobs/job-claim.service';
-import {
-  WorkerLoopService,
-  type JobContext,
-} from '../jobs/worker-loop.service';
-import {
-  ConcatSummaryGenerator,
-  FactToSummarize,
-  SummaryGenerator,
-} from './summary-generator';
+import { type JobContext } from '../jobs/worker-loop.service';
+import { CompactionRunnerService } from './compaction-runner.service';
+import { CompactionQueueService } from './compaction-queue.service';
+import { CompactionStats } from './compaction.types';
 
-export const SUMMARY_GENERATOR = Symbol('SUMMARY_GENERATOR');
-
-export interface CompactionStats {
-  companyId: string;
-  factsCompacted: number;
-  summariesCreated: number;
-  bytesFreed: number;
-}
+export { SUMMARY_GENERATOR } from './compaction.types';
+export type { CompactionStats } from './compaction.types';
 
 /**
  * CompactionService — daily retention pass per spec.
  *
- * Two-stage retention model:
+ * Two-stage retention model (hot tier + warm summary tier) implemented
+ * by CompactionRunnerService. This class is the cron/dispatch
+ * orchestration shell:
  *
- *   1. **Hot tier (default 90d).** Raw facts are searchable, embeddings
- *      live in storage, full text is indexed. This is what most queries hit.
- *   2. **Warm summary tier.** Facts older than the hot window are marked
- *      `status = 'compacted'`, lose their embedding (storage saving), and
- *      — when there are ≥ 2 of them under the same (entityId, predicate) —
- *      get rolled up into one **summary** fact via `SummaryGenerator`.
- *      The summary carries `derivedFrom: [oldFactIds]` so the audit trail
- *      stays intact, and it's searchable on its own embedding.
+ *   Queue mode (JobClaimService wired): the cron enqueues one row per
+ *   known tenant; WorkerLoopService dispatches each to the handler
+ *   registered in onModuleInit. CAS handles multi-pod races.
  *
- * The summary leg is opt-in via `COMPACTION_SUMMARIES=true`. Without it,
- * compaction is a pure mark-and-drop pass (the original behaviour). With
- * it, the warm tier becomes genuinely searchable through one synthetic
- * fact per (entity, predicate) cluster.
+ *   Legacy fallback (no claim service — single-process tests): keep the
+ *   original in-flight bool guard and run the tenant fan-out inline.
  *
- * The default generator is `ConcatSummaryGenerator` (no LLM, just
- * chronological stitching). Verticals can inject their own
- * `SummaryGenerator` provider under the `SUMMARY_GENERATOR` token to
- * use an LLM-backed rollup.
- *
- * Idempotent: a compacted row stays compacted; re-running on the same
- * window finds zero new candidates.
+ * Metrics (countCompacted) are emitted here per tenant; the runner stays
+ * metrics-free so it's a pure engine. Splitting the runner (engine) and
+ * queue (dispatch) out keeps every compaction class's injected-dep list
+ * ≤3.
  */
 @Injectable()
 export class CompactionService implements OnModuleInit {
   private readonly logger = new Logger(CompactionService.name);
-  private readonly hotRetentionDays: number;
-  private readonly summariesEnabled: boolean;
-  private readonly summaryGenerator: SummaryGenerator;
+  private compactionInFlight = false;
 
   constructor(
-    private readonly surreal: SurrealService,
-    private readonly apiKeys: ApiKeyService,
-    private readonly config: ConfigService,
+    private readonly runner: CompactionRunnerService,
+    private readonly queue: CompactionQueueService,
     @Optional() private readonly metrics?: MetricsService,
-    @Optional() @Inject(SUMMARY_GENERATOR) injectedGenerator?: SummaryGenerator,
-    @Optional() private readonly claim?: JobClaimService,
-    @Optional() private readonly workerLoop?: WorkerLoopService,
-  ) {
-    this.hotRetentionDays = parseInt(
-      config.get<string>('COMPACTION_HOT_RETENTION_DAYS', '90'),
-      10,
-    );
-    if (!Number.isFinite(this.hotRetentionDays) || this.hotRetentionDays < 1) {
-      throw new Error('COMPACTION_HOT_RETENTION_DAYS must be a positive integer');
-    }
-    this.summariesEnabled =
-      config.get<string>('COMPACTION_SUMMARIES', 'false').toLowerCase() === 'true';
-    this.summaryGenerator = injectedGenerator ?? new ConcatSummaryGenerator();
-    this.logger.log(
-      `Compaction config: retention=${this.hotRetentionDays}d, summaries=${this.summariesEnabled}, generator=${this.summaryGenerator.constructor.name}`,
-    );
-  }
+  ) {}
 
   onModuleInit(): void {
-    if (!this.workerLoop) return;
-    this.workerLoop.register(
+    this.queue.register(
       'compaction',
       async (ctx: JobContext) => {
-        const stats = await this.compactCompany(ctx.companyId);
+        const stats = await this.runner.compactCompany(ctx.companyId);
+        this.metrics?.countCompacted(stats.factsCompacted);
         return {
           factsCompacted: stats.factsCompacted,
           summariesCreated: stats.summariesCreated,
@@ -105,22 +62,16 @@ export class CompactionService implements OnModuleInit {
   /**
    * Cron entry — daily at 03:17 UTC, off-peak for most regions.
    *
-   * Queue mode (JobClaimService wired): enqueue one row per known
-   * tenant. WorkerLoopService dispatches; CAS handles multi-pod races.
-   *
-   * Legacy fallback (no claim service — single-process tests): keep
-   * the original in-flight bool guard so callers don't regress.
-   *
-   * Reentrancy: compaction rewrites fact status in place; two
-   * concurrent passes would re-compact already-compacted rows and
-   * double-bill summary generation. The dedupKey + UNIQUE(jobType,
-   * dedupKey) index makes the cron-time enqueue idempotent across
-   * leader transitions on the same day.
+   * Reentrancy: compaction rewrites fact status in place; two concurrent
+   * passes would re-compact already-compacted rows and double-bill
+   * summary generation. The dedupKey + UNIQUE(jobType, dedupKey) index
+   * makes the cron-time enqueue idempotent across leader transitions on
+   * the same day.
    */
   @Cron('17 3 * * *', { timeZone: 'UTC' })
   async runDaily(): Promise<CompactionStats[] | { enqueued: number }> {
-    if (this.claim && this.queueModeEnabled()) {
-      return this.enqueueDailyForAllTenants();
+    if (this.queue.hasClaim && this.queue.queueModeEnabled()) {
+      return this.queue.enqueueAllTenants('compaction');
     }
     if (this.compactionInFlight) {
       this.logger.warn('compaction cron skipped — previous run still in flight');
@@ -134,190 +85,21 @@ export class CompactionService implements OnModuleInit {
     }
   }
 
-  private queueModeEnabled(): boolean {
-    return (
-      (this.config.get<string>('JOBS_QUEUE_MODE', 'enqueue') ?? 'enqueue') ===
-      'enqueue'
-    );
-  }
-
-  private async enqueueDailyForAllTenants(): Promise<{ enqueued: number }> {
-    const tenants = this.apiKeys.knownCompanyIds();
-    const today = new Date().toISOString().slice(0, 10);
-    let enqueued = 0;
-    for (const companyId of tenants) {
-      try {
-        const { created } = await this.claim!.enqueue({
-          jobType: 'compaction',
-          companyId,
-          triggeredBy: 'cron',
-          dedupKey: `compaction_${today}`,
-        });
-        if (created) enqueued++;
-      } catch (e) {
-        this.logger.warn(
-          `enqueue compaction for ${companyId} failed: ${(e as Error).message}`,
-        );
-      }
-    }
-    this.logger.log(
-      `Compaction cron enqueued ${enqueued}/${tenants.length} tenant job(s) for ${today}`,
-    );
-    return { enqueued };
-  }
-
-  private compactionInFlight = false;
-
   /**
-   * Compact every known tenant. Errors per-tenant are logged; one bad
-   * tenant must not stop the rest from getting compacted.
+   * Compact every known tenant inline, emitting per-tenant metrics.
+   * Delegates the work to the runner; kept here as the public entry the
+   * admin endpoints + dreams pipeline already call.
    */
   async compactAll(): Promise<CompactionStats[]> {
-    const tenants = this.apiKeys.knownCompanyIds();
-    this.logger.log(`Compaction starting — ${tenants.length} tenant(s)`);
-    const results: CompactionStats[] = [];
-    for (const companyId of tenants) {
-      try {
-        const stats = await this.compactCompany(companyId);
-        results.push(stats);
-      } catch (e) {
-        this.logger.error(
-          `Compaction failed for ${companyId}: ${(e as Error).message}`,
-        );
-      }
-    }
-    const total = results.reduce((acc, r) => acc + r.factsCompacted, 0);
-    const summaries = results.reduce((acc, r) => acc + r.summariesCreated, 0);
-    this.logger.log(
-      `Compaction done — ${total} fact(s) compacted, ${summaries} summary fact(s) created across ${results.length} tenant(s)`,
-    );
-    return results;
+    const stats = await this.runner.compactAll(this.queue.knownTenants());
+    for (const s of stats) this.metrics?.countCompacted(s.factsCompacted);
+    return stats;
   }
 
-  /**
-   * Compact one tenant. Pipeline:
-   *   1. SELECT old facts (carrying embeddings) past the retention window.
-   *   2. (Optional) Group by (entityId, predicate) and create a summary
-   *      fact per group of ≥ 2.
-   *   3. UPDATE old facts: status = 'compacted', embedding = NONE.
-   */
+  /** Compact one tenant inline (admin manual trigger / dreams pipeline). */
   async compactCompany(companyId: string): Promise<CompactionStats> {
-    const cutoff = new Date(
-      Date.now() - this.hotRetentionDays * 24 * 60 * 60 * 1000,
-    ).toISOString();
-
-    return this.surreal.withCompany(companyId, async (db) => {
-      // Step 1: pull candidate facts with their bodies, so the summarizer
-      // has something to work with. We bound by 1000/run to avoid one
-      // tenant dominating the cron — anything past that gets compacted
-      // on the next cycle.
-      const [factRows] = await db.query<[CandidateFactRow[]]>(
-        `SELECT id, entityId, predicate, object, validFrom, validUntil, confidence
-           FROM knowledge_fact
-           WHERE status != 'compacted'
-             AND embedding != NONE
-             AND ((validUntil != NONE AND validUntil < d$cutoff)
-                  OR (retractedAt != NONE AND retractedAt < d$cutoff))
-           ORDER BY validFrom ASC
-           LIMIT 1000`,
-        { cutoff },
-      );
-      const candidates = (factRows ?? []) as CandidateFactRow[];
-      if (candidates.length === 0) {
-        return { companyId, factsCompacted: 0, summariesCreated: 0, bytesFreed: 0 };
-      }
-
-      // Step 2: optional summary rollup
-      let summariesCreated = 0;
-      if (this.summariesEnabled) {
-        summariesCreated = await this.createSummaries(db, candidates);
-      }
-
-      // Step 3: mark + drop embeddings on the originals
-      const ids = candidates.map((c) => String(c.id));
-      await db.query(
-        `UPDATE knowledge_fact
-           SET status = 'compacted', embedding = NONE
-           WHERE id INSIDE $ids`,
-        { ids },
-      );
-
-      const factsCompacted = candidates.length;
-      const bytesFreed = factsCompacted * 6 * 1024;
-      this.logger.log(
-        `Compacted ${factsCompacted} fact(s) in tenant ${companyId} ` +
-          `(~${(bytesFreed / 1024 / 1024).toFixed(1)} MiB freed, ${summariesCreated} summary fact(s))`,
-      );
-      this.metrics?.countCompacted(factsCompacted);
-      return { companyId, factsCompacted, summariesCreated, bytesFreed };
-    });
+    const stats = await this.runner.compactCompany(companyId);
+    this.metrics?.countCompacted(stats.factsCompacted);
+    return stats;
   }
-
-  /**
-   * Group candidate facts by (entityId, predicate), then for each group
-   * with ≥ 2 facts call the SummaryGenerator and CREATE a summary fact
-   * pointing at the originals via `derivedFrom`. Returns the count of
-   * summaries created.
-   */
-  private async createSummaries(
-     
-    db: any,
-    candidates: CandidateFactRow[],
-  ): Promise<number> {
-    const groups = new Map<string, CandidateFactRow[]>();
-    for (const c of candidates) {
-      const key = `${c.entityId}::${c.predicate}`;
-      const arr = groups.get(key);
-      if (arr) arr.push(c);
-      else groups.set(key, [c]);
-    }
-
-    let created = 0;
-    for (const [, group] of groups) {
-      if (group.length < 2) continue;
-      const sorted = [...group].sort((a, b) =>
-        a.validFrom < b.validFrom ? -1 : 1,
-      );
-      const summaryText = await this.summaryGenerator.generate(
-        sorted.map((g) => ({
-          factId: String(g.id),
-          predicate: g.predicate,
-          object: g.object,
-          validFrom: g.validFrom,
-          validUntil: g.validUntil ?? undefined,
-          confidence: g.confidence,
-        }) satisfies FactToSummarize),
-      );
-      if (!summaryText) continue;
-
-      const earliest = sorted[0].validFrom;
-      const latest = sorted[sorted.length - 1].validUntil ?? sorted[sorted.length - 1].validFrom;
-      const meanConfidence =
-        sorted.reduce((acc, g) => acc + g.confidence, 0) / sorted.length;
-
-      await dbCreate(db, 'knowledge_fact', {
-        entityId: sorted[0].entityId,
-        predicate: `summary_${sorted[0].predicate}`,
-        object: summaryText,
-        confidence: meanConfidence,
-        validFrom: earliest,
-        validUntil: latest,
-        source: { kind: 'compaction-summary' },
-        derivedFrom: sorted.map((g) => g.id),
-        status: 'active',
-      });
-      created++;
-    }
-    return created;
-  }
-}
-
-interface CandidateFactRow {
-  id: unknown;
-  entityId: unknown;
-  predicate: string;
-  object: string;
-  validFrom: string;
-  validUntil?: string | null;
-  confidence: number;
 }

--- a/src/compaction/compaction.types.ts
+++ b/src/compaction/compaction.types.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared compaction types + DI token. Lives in its own module so the
+ * runner, queue, and orchestrator services can all import them without a
+ * circular dependency (compaction.service.ts re-exports the public ones
+ * for backward compatibility).
+ */
+
+export const SUMMARY_GENERATOR = Symbol('SUMMARY_GENERATOR');
+
+export interface CompactionStats {
+  companyId: string;
+  factsCompacted: number;
+  summariesCreated: number;
+  bytesFreed: number;
+}
+
+export interface CandidateFactRow {
+  id: unknown;
+  entityId: unknown;
+  predicate: string;
+  object: string;
+  validFrom: string;
+  validUntil?: string | null;
+  confidence: number;
+}

--- a/test/compaction.unit-spec.ts
+++ b/test/compaction.unit-spec.ts
@@ -4,12 +4,11 @@
  * error isolation, and the optional summary leg.
  */
 import { ConfigService } from '@nestjs/config';
-import { CompactionService } from '../src/compaction/compaction.service';
+import { CompactionRunnerService } from '../src/compaction/compaction-runner.service';
 import type {
   FactToSummarize,
   SummaryGenerator,
 } from '../src/compaction/summary-generator';
-import type { ApiKeyService } from '../src/auth/api-key.service';
 import type { SurrealService } from '../src/db/surreal.service';
 
 class StubConfig {
@@ -79,12 +78,6 @@ function makeFakeSurreal(byTenant: Record<string, TenantSeed>) {
   return { surreal, calls, created };
 }
 
-function makeApiKeys(companyIds: string[]): ApiKeyService {
-  return {
-    knownCompanyIds: () => companyIds,
-  } as unknown as ApiKeyService;
-}
-
 function rows(specs: Array<Partial<CandidateRow> & { id: string }>): CandidateRow[] {
   return specs.map((s, i) => ({
     entityId: 'knowledge_entity:e1',
@@ -103,13 +96,12 @@ describe('CompactionService — mark + drop (default mode)', () => {
       co_b: { rows: [] },
       co_c: { rows: rows(Array.from({ length: 5 }, (_, i) => ({ id: `g${i}` }))) },
     });
-    const service = new CompactionService(
+    const runner = new CompactionRunnerService(
       surreal,
-      makeApiKeys(['co_a', 'co_b', 'co_c']),
       new StubConfig() as unknown as ConfigService,
     );
 
-    const stats = await service.compactAll();
+    const stats = await runner.compactAll(['co_a', 'co_b', 'co_c']);
     expect(stats).toHaveLength(3);
     const byTenant = Object.fromEntries(stats.map((s) => [s.companyId, s]));
     expect(byTenant.co_a.factsCompacted).toBe(12);
@@ -134,26 +126,24 @@ describe('CompactionService — mark + drop (default mode)', () => {
       },
       co_c: { rows: rows([{ id: 'h1' }, { id: 'h2' }]) },
     });
-    const service = new CompactionService(
+    const runner = new CompactionRunnerService(
       surreal,
-      makeApiKeys(['co_a', 'co_b', 'co_c']),
       new StubConfig() as unknown as ConfigService,
     );
 
-    const stats = await service.compactAll();
+    const stats = await runner.compactAll(['co_a', 'co_b', 'co_c']);
     expect(stats.map((s) => s.companyId).sort()).toEqual(['co_a', 'co_c']);
   });
 
   it('honours COMPACTION_HOT_RETENTION_DAYS env override', async () => {
     const { surreal, calls } = makeFakeSurreal({ co_a: { rows: rows([{ id: 'f1' }]) } });
-    const service = new CompactionService(
+    const runner = new CompactionRunnerService(
       surreal,
-      makeApiKeys(['co_a']),
       new StubConfig({ COMPACTION_HOT_RETENTION_DAYS: '30' }) as unknown as ConfigService,
     );
 
     const before = Date.now();
-    await service.compactCompany('co_a');
+    await runner.compactCompany('co_a');
     const after = Date.now();
 
     const select = calls[0].calls.find((c) => c.sql.includes('SELECT id, entityId'))!;
@@ -165,20 +155,17 @@ describe('CompactionService — mark + drop (default mode)', () => {
 
   it('rejects invalid retention config at construction', () => {
     const surreal = {} as SurrealService;
-    const apiKeys = makeApiKeys([]);
     expect(
       () =>
-        new CompactionService(
+        new CompactionRunnerService(
           surreal,
-          apiKeys,
           new StubConfig({ COMPACTION_HOT_RETENTION_DAYS: '0' }) as unknown as ConfigService,
         ),
     ).toThrow(/positive integer/);
     expect(
       () =>
-        new CompactionService(
+        new CompactionRunnerService(
           surreal,
-          apiKeys,
           new StubConfig({ COMPACTION_HOT_RETENTION_DAYS: 'abc' }) as unknown as ConfigService,
         ),
     ).toThrow(/positive integer/);
@@ -210,15 +197,13 @@ describe('CompactionService — summary mode (COMPACTION_SUMMARIES=true)', () =>
     });
     const gen = new StubGenerator((g) => `SUMMARY(${g.length}:${g.map((f) => f.object).join(',')})`);
 
-    const service = new CompactionService(
+    const runner = new CompactionRunnerService(
       surreal,
-      makeApiKeys(['co_a']),
       new StubConfig({ COMPACTION_SUMMARIES: 'true' }) as unknown as ConfigService,
-      undefined,
       gen,
     );
 
-    const [stats] = await service.compactAll();
+    const [stats] = await runner.compactAll(['co_a']);
     expect(stats.factsCompacted).toBe(5);
     // Two summaries: tier (3 rows) + name (1 row) — name is singleton, skip
     expect(stats.summariesCreated).toBe(1);
@@ -248,14 +233,12 @@ describe('CompactionService — summary mode (COMPACTION_SUMMARIES=true)', () =>
       },
     });
     const emptyGen: SummaryGenerator = { generate: async () => '' };
-    const service = new CompactionService(
+    const runner = new CompactionRunnerService(
       surreal,
-      makeApiKeys(['co_a']),
       new StubConfig({ COMPACTION_SUMMARIES: 'true' }) as unknown as ConfigService,
-      undefined,
       emptyGen,
     );
-    const [stats] = await service.compactAll();
+    const [stats] = await runner.compactAll(['co_a']);
     expect(stats.factsCompacted).toBe(2);
     expect(stats.summariesCreated).toBe(0);
     expect(created).toHaveLength(0);
@@ -271,14 +254,12 @@ describe('CompactionService — summary mode (COMPACTION_SUMMARIES=true)', () =>
       },
     });
     const gen = new StubGenerator(() => 'should-not-run');
-    const service = new CompactionService(
+    const runner = new CompactionRunnerService(
       surreal,
-      makeApiKeys(['co_a']),
       new StubConfig() as unknown as ConfigService, // default = false
-      undefined,
       gen,
     );
-    const [stats] = await service.compactAll();
+    const [stats] = await runner.compactAll(['co_a']);
     expect(stats.factsCompacted).toBe(2);
     expect(stats.summariesCreated).toBe(0);
     expect(gen.calls).toHaveLength(0);


### PR DESCRIPTION
## What
`CompactionService` injected 7 deps (surreal, apiKeys, config, metrics, SUMMARY_GENERATOR, claim, workerLoop). Three-way responsibility split:
- **CompactionRunnerService** (surreal, config, generator) — the retention engine. `compactCompany(companyId)` / `compactAll(tenants[])` take the tenant list as a parameter (no apiKeys dep) and return stats metrics-free.
- **CompactionQueueService** (apiKeys, claim, workerLoop) — handler registration, per-tenant cron enqueue, queue-mode flag, tenant list.
- **CompactionService** (runner, queue, metrics) — the cron/dispatch shell; emits per-tenant metrics and keeps the public `compactAll`/`compactCompany` entry points the admin + dreams paths call.

`SUMMARY_GENERATOR` token + `CompactionStats` moved to `compaction.types.ts` (re-exported from `compaction.service` for backward compat). Each class ≤3 deps.

## Why
Part 2/3 of the `max-params=3` god-class split program.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
- `pnpm test:unit` 700/700 ✓ · `pnpm test:e2e` 128/128 ✓ · `pnpm test:e2e:jobs` 9/9 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)