### PR TITLE
refactor(search): split SearchService into retrieval + rerank stages (max-params 2/3)

### DIFF
--- a/src/search/pipeline-context.ts
+++ b/src/search/pipeline-context.ts
@@ -1,0 +1,17 @@
+import { SearchDto, SearchMode } from './dto/search.dto';
+
+/**
+ * Per-request retrieval-pipeline context, shared by the search
+ * orchestrator and its stage services (retrieval / rerank). Built once
+ * by SearchService.search() from the public SearchDto.
+ */
+export interface PipelineContext {
+  dto: SearchDto;
+  callerScopes: string[];
+  limit: number;
+  asOf: Date | null;
+  includeRetracted: boolean;
+  includeContested: boolean;
+  mode: SearchMode;
+  candidateK: number;
+}

--- a/src/search/search-rerank.service.ts
+++ b/src/search/search-rerank.service.ts
@@ -1,0 +1,225 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Surreal } from 'surrealdb';
+import { RerankerService } from '../ai/reranker.service';
+import { CrossEncoderService } from '../ai/cross-encoder.service';
+import { MetricsService } from '../metrics/metrics.service';
+import { withSpan } from '../common/tracing';
+import type { EntityBucket } from './internals/types';
+import {
+  resolveStageBudgets,
+  withStageBudget,
+  type StageBudgets,
+} from './internals/stage-budget';
+import { fetchNeighbours } from './internals/neighbours';
+import { shouldSkipRerankByMargin } from './internals/rerank-skip';
+import { PipelineContext } from './pipeline-context';
+
+/**
+ * SearchRerankService — the rerank-side stages of the search pipeline:
+ * cross-encoder windowing, the margin-skip heuristic, and the LLM
+ * reranker with 1-hop neighbourhood injection. Owns the reranker,
+ * cross-encoder, and metrics deps (all rerank metrics live here).
+ * SearchService passes the bucketed candidates + scoped `db`; splitting
+ * this out keeps every search class ≤3 injected deps.
+ */
+@Injectable()
+export class SearchRerankService {
+  private readonly logger = new Logger(SearchRerankService.name);
+  private readonly budgets: StageBudgets = resolveStageBudgets();
+
+  constructor(
+    private readonly reranker: RerankerService,
+    private readonly crossEncoder: CrossEncoderService,
+    @Optional() private readonly metrics?: MetricsService,
+  ) {}
+
+  async runRerankStage({
+    db,
+    byEntity,
+    ctx,
+    typeDist,
+  }: {
+    db: Surreal;
+    byEntity: Map<string, EntityBucket>;
+    ctx: PipelineContext;
+    typeDist: { weights: Record<string, number> } | null;
+  }): Promise<EntityBucket[]> {
+    const RERANK_WINDOW = Math.min(ctx.limit * 2, 20);
+    const CROSS_ENCODER_WINDOW = this.crossEncoder.isEnabled()
+      ? Math.min(
+          parseInt(process.env.SEARCH_CROSS_ENCODER_WINDOW ?? '50', 10) || 50,
+          byEntity.size,
+        )
+      : RERANK_WINDOW;
+
+    const wideCandidates = [...byEntity.values()]
+      .sort((a, b) => b.rankScore - a.rankScore)
+      .slice(0, CROSS_ENCODER_WINDOW);
+
+    let candidatesForRerank = wideCandidates.slice(0, RERANK_WINDOW);
+
+    if (this.crossEncoder.isEnabled() && wideCandidates.length > 1) {
+      candidatesForRerank = await this.runCrossEncoder(
+        wideCandidates,
+        ctx.dto.query,
+        RERANK_WINDOW,
+      );
+    } else if (!this.crossEncoder.isEnabled()) {
+      this.metrics?.countCrossEncoder('skipped_disabled');
+    } else {
+      this.metrics?.countCrossEncoder('skipped_singleton');
+    }
+
+    const rerankSkipMargin = parseFloat(
+      process.env.SEARCH_RERANK_SKIP_MARGIN ?? '0',
+    );
+    // shouldSkipRerankByMargin compares fused rankScore of top-1 vs top-2.
+    // After runCrossEncoder, candidatesForRerank is ordered by cross-encoder
+    // relevance, NOT by rankScore — so candidatesForRerank[0/1] are no longer
+    // the highest-rankScore pair. Compute the margin on a rankScore-sorted
+    // copy so the heuristic reads the pair it actually claims to.
+    const skipByMargin = shouldSkipRerankByMargin(
+      [...candidatesForRerank].sort((a, b) => b.rankScore - a.rankScore),
+      rerankSkipMargin,
+    );
+
+    if (!this.reranker.isEnabled()) {
+      this.metrics?.countRerank('skipped_disabled');
+      return candidatesForRerank;
+    }
+    if (candidatesForRerank.length <= 1) {
+      this.metrics?.countRerank('skipped_singleton');
+      return candidatesForRerank;
+    }
+    if (skipByMargin) {
+      this.metrics?.countRerank('skipped_margin');
+      return candidatesForRerank;
+    }
+
+    return this.runLlmRerank({ db, candidatesForRerank, ctx, typeDist });
+  }
+
+  private async runCrossEncoder(
+    wideCandidates: EntityBucket[],
+    query: string,
+    rerankWindow: number,
+  ): Promise<EntityBucket[]> {
+    // Build inputs once — same shape feeds both cross-encoder and LLM
+    // rerank stages. The LLM stage adds neighbours later (per-candidate
+    // fetch happens inside its branch); the cross-encoder runs on the
+    // lighter "label + top-3 facts" body for speed and cost.
+    const xInputs = wideCandidates.map((e) => {
+      const ent = e.facts[0]?.row.entity ?? {
+        type: 'other',
+        canonicalName: e.entityId,
+      };
+      const topFacts = [...e.facts]
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 3)
+        .map((sf) => `- ${sf.row.predicate}: ${sf.row.object}`)
+        .join('\n');
+      return { label: `${ent.canonicalName} [${ent.type}]`, body: topFacts };
+    });
+    const identityPerm = xInputs.map((_, i) => i);
+    // Distinguish a budget-timeout fallback (which returns identityPerm)
+    // from the cross-encoder genuinely producing an unchanged order. The
+    // old code inferred 'error' from an identity permutation, which
+    // mislabelled every legitimate no-op rerank as a failure.
+    let timedOut = false;
+    const xPerm = await withSpan(
+      'search.cross_encoder',
+      () =>
+        withStageBudget({
+          stage: 'crossEncoder',
+          budgetMs: this.budgets.crossEncoder,
+          fn: () => this.crossEncoder.rerank(query, xInputs),
+          fallback: identityPerm,
+          logger: this.logger,
+          onFallback: () => {
+            timedOut = true;
+          },
+        }),
+      { 'cross_encoder.candidates': xInputs.length },
+    );
+    this.metrics?.countCrossEncoder(timedOut ? 'error' : 'invoked');
+    return xPerm.map((i) => wideCandidates[i]).slice(0, rerankWindow);
+  }
+
+  private async runLlmRerank({
+    db,
+    candidatesForRerank,
+    ctx,
+    typeDist,
+  }: {
+    db: Surreal;
+    candidatesForRerank: EntityBucket[];
+    ctx: PipelineContext;
+    typeDist: { weights: Record<string, number> } | null;
+  }): Promise<EntityBucket[]> {
+    // SubgraphRAG-style 1-hop neighbourhood injection. Surfaces graph
+    // context as "Connected to: …" lines in the candidate body — lets
+    // the reranker disambiguate shared-firstname / same-topic peers by
+    // whose neighbours match the query.
+    const neighboursByEntity = await withSpan(
+      'search.fetch_neighbours',
+      () =>
+        fetchNeighbours(
+          db,
+          this.logger,
+          candidatesForRerank.map((e) => e.entityId),
+        ),
+      { 'neighbours.candidates': candidatesForRerank.length },
+    );
+
+    const rerankInputs = candidatesForRerank.map((e) => {
+      const ent = e.facts[0]?.row.entity ?? {
+        type: 'other',
+        canonicalName: e.entityId,
+      };
+      const topFacts = [...e.facts]
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 3)
+        .map((sf) => `- ${sf.row.predicate}: ${sf.row.object}`)
+        .join('\n');
+      const nbrs = neighboursByEntity.get(e.entityId) ?? [];
+      const nbrLine = nbrs.length
+        ? `\nConnected to: ${nbrs
+            .slice(0, 5)
+            .map((n) => `${n.canonicalName} (${n.type}, ${n.kind})`)
+            .join('; ')}`
+        : '';
+      return {
+        label: `${ent.canonicalName} [${ent.type}]`,
+        body: `${topFacts}${nbrLine}`,
+      };
+    });
+
+    const hints = typeDist
+      ? `Likely target entity types: ${
+          Object.entries(typeDist.weights)
+            .filter(([, w]) => w >= 0.15)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 3)
+            .map(([t, w]) => `${t}=${w.toFixed(2)}`)
+            .join(', ') || 'unspecified'
+        }.`
+      : undefined;
+
+    const identityPerm = rerankInputs.map((_, i) => i);
+    const permutation = await withSpan(
+      'search.rerank',
+      () =>
+        withStageBudget({
+          stage: 'rerank',
+          budgetMs: this.budgets.rerank,
+          fn: () => this.reranker.rerank(ctx.dto.query, rerankInputs, hints),
+          fallback: identityPerm,
+          logger: this.logger,
+        }),
+      { 'rerank.candidates': rerankInputs.length },
+    );
+    const isIdentity = permutation.every((idx, i) => idx === i);
+    this.metrics?.countRerank(isIdentity ? 'skipped_disabled' : 'invoked');
+    return permutation.map((i) => candidatesForRerank[i]);
+  }
+}

--- a/src/search/search-retrieval.service.ts
+++ b/src/search/search-retrieval.service.ts
@@ -1,0 +1,144 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Surreal } from 'surrealdb';
+import { EmbedderService } from '../ai/embedder.service';
+import { PredicateRouterService } from '../ai/predicate-router.service';
+import { CalibrationService } from '../ai/calibration/calibration.service';
+import { withSpan } from '../common/tracing';
+import { traceArtifact } from '../common/debug-trace';
+import type { EntityBucket, FactRow } from './internals/types';
+import {
+  resolveStageBudgets,
+  withStageBudget,
+  type StageBudgets,
+} from './internals/stage-budget';
+import { runVectorLeg, runLexicalLeg } from './internals/legs';
+import { fuse } from './internals/fusion';
+import {
+  scoreRows,
+  bucketByEntity,
+  type PredicateDistribution,
+} from './internals/scoring';
+import { PipelineContext } from './pipeline-context';
+
+/**
+ * SearchRetrievalService — the retrieval-side stages of the search
+ * pipeline: parallel vector + lexical legs with fusion, the optional
+ * predicate/type router LLM call, and confidence-calibrated scoring +
+ * per-entity bucketing. Owns the embedder (vector leg), predicate
+ * router, and calibration deps. SearchService threads the scoped `db`
+ * handle through these methods and sequences them with the rerank
+ * stage; splitting them out keeps every search class ≤3 injected deps.
+ */
+@Injectable()
+export class SearchRetrievalService {
+  private readonly logger = new Logger(SearchRetrievalService.name);
+  private readonly budgets: StageBudgets = resolveStageBudgets();
+
+  constructor(
+    private readonly embedder: EmbedderService,
+    private readonly predicateRouter: PredicateRouterService,
+    private readonly calibration: CalibrationService,
+  ) {}
+
+  /** Retrieval legs (parallel) + fusion. */
+  async runRetrievalStage(
+    db: Surreal,
+    ctx: PipelineContext,
+    baseWhere: { sql: string; params: Record<string, unknown> },
+  ) {
+    const [vectorRows, lexicalRows] = await Promise.all([
+      ctx.mode === 'lexical'
+        ? Promise.resolve([] as FactRow[])
+        : withSpan(
+            'search.vector_leg',
+            async (span) => {
+              const rows = await runVectorLeg({
+                db,
+                embedder: this.embedder,
+                query: ctx.dto.query,
+                k: ctx.candidateK,
+                baseWhere,
+              });
+              span.setAttribute('candidates', rows.length);
+              traceArtifact(
+                'search.vector_hits',
+                rows.slice(0, 20).map((r) => ({
+                  factId: String(r.id),
+                  entityId: String(r.entityId),
+                  predicate: r.predicate,
+                  object: r.object,
+                  simScore: r.simScore,
+                })),
+              );
+              return rows;
+            },
+            { 'search.k': ctx.candidateK },
+          ),
+      ctx.mode === 'vector'
+        ? Promise.resolve([] as FactRow[])
+        : withSpan(
+            'search.lexical_leg',
+            async (span) => {
+              const rows = await runLexicalLeg({
+                db,
+                logger: this.logger,
+                query: ctx.dto.query,
+                k: ctx.candidateK,
+                baseWhere,
+              });
+              span.setAttribute('candidates', rows.length);
+              traceArtifact(
+                'search.lexical_hits',
+                rows.slice(0, 20).map((r) => ({
+                  factId: String(r.id),
+                  entityId: String(r.entityId),
+                  predicate: r.predicate,
+                  object: r.object,
+                  bm25Score: r.bm25Score,
+                })),
+              );
+              return rows;
+            },
+            { 'search.k': ctx.candidateK },
+          ),
+    ]);
+    return fuse(vectorRows, lexicalRows, ctx.mode);
+  }
+
+  /** Predicate / type router (optional LLM call, under budget). */
+  async runRouterStage(query: string) {
+    const out = await withSpan('search.route', async (span) => {
+      const r = await withStageBudget({
+        stage: 'router',
+        budgetMs: this.budgets.router,
+        fn: () => this.predicateRouter.route(query),
+        fallback: null,
+        logger: this.logger,
+      });
+      span.setAttribute('router.hit', r !== null);
+      return r;
+    });
+    if (out) traceArtifact('search.router_classification', out);
+    return out;
+  }
+
+  /**
+   * Score + per-entity bucket with diversity-aware degree boost. The
+   * calibrator rewrites raw confidence via the Phase 3 isotonic map
+   * before it folds into the final score.
+   */
+  scoreAndBucket(
+    rows: Parameters<typeof scoreRows>[0]['rows'],
+    predicateDist: PredicateDistribution | null,
+  ): Map<string, EntityBucket> {
+    const scored = scoreRows({
+      rows,
+      predicateDist,
+      now: Date.now(),
+      calibrator: {
+        calibrate: (raw: number) => this.calibration.calibrate(raw),
+      },
+    });
+    return bucketByEntity(scored);
+  }
+}

--- a/src/search/search.module.ts
+++ b/src/search/search.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { SearchController } from './search.controller';
 import { SearchService } from './search.service';
+import { SearchRetrievalService } from './search-retrieval.service';
+import { SearchRerankService } from './search-rerank.service';
 
 @Module({
   controllers: [SearchController],
-  providers: [SearchService],
+  providers: [SearchService, SearchRetrievalService, SearchRerankService],
   exports: [SearchService],
 })
 export class SearchModule {}

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -1,14 +1,8 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Surreal } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
-import { EmbedderService } from '../ai/embedder.service';
-import { RerankerService } from '../ai/reranker.service';
-import { PredicateRouterService } from '../ai/predicate-router.service';
-import { CrossEncoderService } from '../ai/cross-encoder.service';
-import { CalibrationService } from '../ai/calibration/calibration.service';
 import { detectLanguage } from '../ai/locale/language-detector';
 import { SearchDto, SearchMode } from './dto/search.dto';
-import { MetricsService } from '../metrics/metrics.service';
 import { withSpan } from '../common/tracing';
 import { clampLlmInputText } from '../common/input-limits';
 import { traceArtifact } from '../common/debug-trace';
@@ -21,15 +15,9 @@ import {
   type StageBudgets,
 } from './internals/stage-budget';
 import { buildBaseWhere } from './internals/where-builder';
-import { runVectorLeg, runLexicalLeg } from './internals/legs';
-import { fuse } from './internals/fusion';
 import { hydrateSurvivors, reattributeMerged } from './internals/identity-merge';
 import { passesPolicy } from './internals/policy';
-import { scoreRows, bucketByEntity } from './internals/scoring';
-import {
-  fetchNeighbours,
-  expandEntityIdsViaEdges as expandEntityIdsViaEdgesDb,
-} from './internals/neighbours';
+import { expandEntityIdsViaEdges as expandEntityIdsViaEdgesDb } from './internals/neighbours';
 import { expandViaEdges } from './internals/edge-expansion';
 import { applyPprPrior } from './internals/ppr';
 import { shouldSkipRerankByMargin } from './internals/rerank-skip';
@@ -45,40 +33,38 @@ import {
   fetchOneHopNeighbourIds,
   resolveSeedEntities,
 } from './internals/graph-retrieve-db';
+import { SearchRetrievalService } from './search-retrieval.service';
+import { SearchRerankService } from './search-rerank.service';
+import { PipelineContext } from './pipeline-context';
 
 export type { SearchHit } from './search.types';
 export type { GraphRetrieveHit } from './internals/graph-retrieve';
 
 /**
  * Search orchestrator. The retrieval pipeline lives in stage modules
- * under `./internals/` — this file's only job is to:
+ * under `./internals/` (pure functions) and the two stage services
+ * SearchRetrievalService (retrieval legs / router / scoring) +
+ * SearchRerankService (cross-encoder / LLM rerank). This file's only job
+ * is to:
  *   1. Translate the public `SearchDto` into a per-request context.
- *   2. Sequence the stages (retrieval → fusion → identity merge →
- *      scoring → bucketing → edge expansion → PPR → cross-encoder →
- *      LLM rerank → backfill → assemble).
- *   3. Wire each stage to its withSpan / withStageBudget / metrics
- *      callsite.
+ *   2. Open the scoped DB connection and sequence the stages (retrieval
+ *      → fusion → identity merge → scoring → bucketing → edge expansion
+ *      → PPR → rerank → backfill → assemble).
+ *   3. Own the db-threading stages that need no AI service (identity
+ *      merge, edge expansion, PPR, backfill, graph retrieval).
  *
- * Anything heavier than that belongs in a stage module. Adding a new
- * stage means adding a new file under internals/ + one extra line
- * here — not growing this method.
+ * Anything heavier than that belongs in a stage module or stage service.
  */
 @Injectable()
 export class SearchService {
   private readonly logger = new Logger(SearchService.name);
-  private readonly budgets: StageBudgets;
+  private readonly budgets: StageBudgets = resolveStageBudgets();
 
   constructor(
     private readonly surreal: SurrealService,
-    private readonly embedder: EmbedderService,
-    private readonly reranker: RerankerService,
-    private readonly predicateRouter: PredicateRouterService,
-    private readonly crossEncoder: CrossEncoderService,
-    private readonly calibration: CalibrationService,
-    @Optional() private readonly metrics?: MetricsService,
-  ) {
-    this.budgets = resolveStageBudgets();
-  }
+    private readonly retrieval: SearchRetrievalService,
+    private readonly rerank: SearchRerankService,
+  ) {}
 
   /** Pure helper — kept exposed for unit testing. Delegates to the
    *  rerank-skip module so the orchestrator owns no math. */
@@ -107,20 +93,7 @@ export class SearchService {
    * Graph-first retrieval. Resolves named entities by canonical name,
    * walks their 1-hop neighbourhood over knowledge_edge, and returns
    * facts across (seeds ∪ neighbours) optionally filtered by predicate
-   * hints. Replaces the demo controller's inline graphSearch which
-   * filtered only the seed's own facts and missed multi-hop answers
-   * (asking "who runs engineering at Acme" → the status fact lives on
-   * Maria, not Acme).
-   *
-   *   queryText       — used for substring fallback when entityRefs
-   *                     are absent (e.g. chat router didn't lift a
-   *                     clean mention).
-   *   entityRefs      — canonical names the chat router identified.
-   *   predicateHints  — predicates the question targets; controls the
-   *                     SQL filter and the assembly-pass score policy.
-   *   asOf            — ISO date for bitemporal cut; undefined = "now".
-   *   callerScopes    — scope gate (PII fields stripped by surreal
-   *                     PERMISSIONS on the scoped connection).
+   * hints.
    *
    * Soft-fail across the board: a query error logs and returns the
    * partial result so the caller can fall through to vector.
@@ -263,16 +236,10 @@ export class SearchService {
       langFilter,
     });
 
-    // 1. Retrieval legs (parallel) + fusion. With a langFilter on,
-    //    a thin first pass may yield too few hits — fall back to a
-    //    second pass without the filter so cross-lingual paraphrases
-    //    surface (BGE-M3-style backoff path).
-    const fused = await this.runRetrievalStage(db, ctx, baseWhere);
+    // 1. Retrieval legs (parallel) + fusion, with cross-lingual backoff.
+    const fused = await this.retrieval.runRetrievalStage(db, ctx, baseWhere);
     if (langFilter && fused.length < ctx.candidateK / 2) {
       // Capture the first-pass size BEFORE the merge loop mutates `fused`.
-      // The old trace computed `fused.length - fallback.length` post-merge,
-      // which is wrong: only the non-duplicate fallback rows get pushed, so
-      // the subtraction undercounts the true first pass.
       const firstPassCount = fused.length;
       const fallbackWhere = buildBaseWhere({
         dto: ctx.dto,
@@ -280,7 +247,11 @@ export class SearchService {
         includeRetracted: ctx.includeRetracted,
         includeContested: ctx.includeContested,
       });
-      const fallback = await this.runRetrievalStage(db, ctx, fallbackWhere);
+      const fallback = await this.retrieval.runRetrievalStage(
+        db,
+        ctx,
+        fallbackWhere,
+      );
       const seen = new Set(fused.map((r) => String(r.id)));
       for (const r of fallback) {
         if (!seen.has(String(r.id))) {
@@ -304,22 +275,12 @@ export class SearchService {
     );
 
     // 3. Predicate / type router (optional LLM call, under budget).
-    const routerOut = await this.runRouterStage(ctx.dto.query);
+    const routerOut = await this.retrieval.runRouterStage(ctx.dto.query);
     const predicateDist = routerOut?.predicates ?? null;
     const typeDist = routerOut?.types ?? null;
 
     // 4. Scoring + per-entity bucketing with diversity-aware degree boost.
-    //    `calibration` rewrites the raw confidence via the Phase 3
-    //    isotonic map before it folds into the final score.
-    const scored = scoreRows({
-      rows: filtered,
-      predicateDist,
-      now: Date.now(),
-      calibrator: {
-        calibrate: (raw: number) => this.calibration.calibrate(raw),
-      },
-    });
-    const byEntity = bucketByEntity(scored);
+    const byEntity = this.retrieval.scoreAndBucket(filtered, predicateDist);
 
     // 5. Edge expansion (default ON) — graph-walk from top seeds.
     await this.runEdgeExpansionStage({ db, byEntity, baseWhere, ctx });
@@ -328,7 +289,12 @@ export class SearchService {
     await this.runPprStage(db, byEntity);
 
     // 7. Cross-encoder + LLM rerank.
-    let topEntities = await this.runRerankStage({ db, byEntity, ctx, typeDist });
+    let topEntities = await this.rerank.runRerankStage({
+      db,
+      byEntity,
+      ctx,
+      typeDist,
+    });
     topEntities = topEntities.slice(0, ctx.limit);
 
     // 8. Backfill missing facts for top-K, then assemble.
@@ -355,86 +321,6 @@ export class SearchService {
       requireProvenance: ctx.dto.requireProvenance === true,
     });
     return { results: applyOutputShaping(hits, ctx.dto) };
-  }
-
-  private async runRetrievalStage(
-    db: Surreal,
-    ctx: PipelineContext,
-    baseWhere: { sql: string; params: Record<string, unknown> },
-  ) {
-    const [vectorRows, lexicalRows] = await Promise.all([
-      ctx.mode === 'lexical'
-        ? Promise.resolve([] as FactRow[])
-        : withSpan(
-            'search.vector_leg',
-            async (span) => {
-              const rows = await runVectorLeg({
-                db,
-                embedder: this.embedder,
-                query: ctx.dto.query,
-                k: ctx.candidateK,
-                baseWhere,
-              });
-              span.setAttribute('candidates', rows.length);
-              traceArtifact(
-                'search.vector_hits',
-                rows.slice(0, 20).map((r) => ({
-                  factId: String(r.id),
-                  entityId: String(r.entityId),
-                  predicate: r.predicate,
-                  object: r.object,
-                  simScore: r.simScore,
-                })),
-              );
-              return rows;
-            },
-            { 'search.k': ctx.candidateK },
-          ),
-      ctx.mode === 'vector'
-        ? Promise.resolve([] as FactRow[])
-        : withSpan(
-            'search.lexical_leg',
-            async (span) => {
-              const rows = await runLexicalLeg({
-                db,
-                logger: this.logger,
-                query: ctx.dto.query,
-                k: ctx.candidateK,
-                baseWhere,
-              });
-              span.setAttribute('candidates', rows.length);
-              traceArtifact(
-                'search.lexical_hits',
-                rows.slice(0, 20).map((r) => ({
-                  factId: String(r.id),
-                  entityId: String(r.entityId),
-                  predicate: r.predicate,
-                  object: r.object,
-                  bm25Score: r.bm25Score,
-                })),
-              );
-              return rows;
-            },
-            { 'search.k': ctx.candidateK },
-          ),
-    ]);
-    return fuse(vectorRows, lexicalRows, ctx.mode);
-  }
-
-  private async runRouterStage(query: string) {
-    const out = await withSpan('search.route', async (span) => {
-      const r = await withStageBudget({
-        stage: 'router',
-        budgetMs: this.budgets.router,
-        fn: () => this.predicateRouter.route(query),
-        fallback: null,
-        logger: this.logger,
-      });
-      span.setAttribute('router.hit', r !== null);
-      return r;
-    });
-    if (out) traceArtifact('search.router_classification', out);
-    return out;
   }
 
   private async runEdgeExpansionStage({
@@ -491,196 +377,6 @@ export class SearchService {
       { 'ppr.entities': byEntity.size },
     );
   }
-
-  private async runRerankStage({
-    db,
-    byEntity,
-    ctx,
-    typeDist,
-  }: {
-    db: Surreal;
-    byEntity: Map<string, EntityBucket>;
-    ctx: PipelineContext;
-    typeDist: { weights: Record<string, number> } | null;
-  }): Promise<EntityBucket[]> {
-    const RERANK_WINDOW = Math.min(ctx.limit * 2, 20);
-    const CROSS_ENCODER_WINDOW = this.crossEncoder.isEnabled()
-      ? Math.min(
-          parseInt(process.env.SEARCH_CROSS_ENCODER_WINDOW ?? '50', 10) || 50,
-          byEntity.size,
-        )
-      : RERANK_WINDOW;
-
-    const wideCandidates = [...byEntity.values()]
-      .sort((a, b) => b.rankScore - a.rankScore)
-      .slice(0, CROSS_ENCODER_WINDOW);
-
-    let candidatesForRerank = wideCandidates.slice(0, RERANK_WINDOW);
-
-    if (this.crossEncoder.isEnabled() && wideCandidates.length > 1) {
-      candidatesForRerank = await this.runCrossEncoder(
-        wideCandidates,
-        ctx.dto.query,
-        RERANK_WINDOW,
-      );
-    } else if (!this.crossEncoder.isEnabled()) {
-      this.metrics?.countCrossEncoder('skipped_disabled');
-    } else {
-      this.metrics?.countCrossEncoder('skipped_singleton');
-    }
-
-    const rerankSkipMargin = parseFloat(
-      process.env.SEARCH_RERANK_SKIP_MARGIN ?? '0',
-    );
-    // shouldSkipRerankByMargin compares fused rankScore of top-1 vs top-2.
-    // After runCrossEncoder, candidatesForRerank is ordered by cross-encoder
-    // relevance, NOT by rankScore — so candidatesForRerank[0/1] are no longer
-    // the highest-rankScore pair. Compute the margin on a rankScore-sorted
-    // copy so the heuristic reads the pair it actually claims to.
-    const skipByMargin = shouldSkipRerankByMargin(
-      [...candidatesForRerank].sort((a, b) => b.rankScore - a.rankScore),
-      rerankSkipMargin,
-    );
-
-    if (!this.reranker.isEnabled()) {
-      this.metrics?.countRerank('skipped_disabled');
-      return candidatesForRerank;
-    }
-    if (candidatesForRerank.length <= 1) {
-      this.metrics?.countRerank('skipped_singleton');
-      return candidatesForRerank;
-    }
-    if (skipByMargin) {
-      this.metrics?.countRerank('skipped_margin');
-      return candidatesForRerank;
-    }
-
-    return this.runLlmRerank({ db, candidatesForRerank, ctx, typeDist });
-  }
-
-  private async runCrossEncoder(
-    wideCandidates: EntityBucket[],
-    query: string,
-    rerankWindow: number,
-  ): Promise<EntityBucket[]> {
-    // Build inputs once — same shape feeds both cross-encoder and LLM
-    // rerank stages. The LLM stage adds neighbours later (per-candidate
-    // fetch happens inside its branch); the cross-encoder runs on the
-    // lighter "label + top-3 facts" body for speed and cost.
-    const xInputs = wideCandidates.map((e) => {
-      const ent = e.facts[0]?.row.entity ?? {
-        type: 'other',
-        canonicalName: e.entityId,
-      };
-      const topFacts = [...e.facts]
-        .sort((a, b) => b.score - a.score)
-        .slice(0, 3)
-        .map((sf) => `- ${sf.row.predicate}: ${sf.row.object}`)
-        .join('\n');
-      return { label: `${ent.canonicalName} [${ent.type}]`, body: topFacts };
-    });
-    const identityPerm = xInputs.map((_, i) => i);
-    // Distinguish a budget-timeout fallback (which returns identityPerm)
-    // from the cross-encoder genuinely producing an unchanged order. The
-    // old code inferred 'error' from an identity permutation, which
-    // mislabelled every legitimate no-op rerank as a failure.
-    let timedOut = false;
-    const xPerm = await withSpan(
-      'search.cross_encoder',
-      () =>
-        withStageBudget({
-          stage: 'crossEncoder',
-          budgetMs: this.budgets.crossEncoder,
-          fn: () => this.crossEncoder.rerank(query, xInputs),
-          fallback: identityPerm,
-          logger: this.logger,
-          onFallback: () => {
-            timedOut = true;
-          },
-        }),
-      { 'cross_encoder.candidates': xInputs.length },
-    );
-    this.metrics?.countCrossEncoder(timedOut ? 'error' : 'invoked');
-    return xPerm.map((i) => wideCandidates[i]).slice(0, rerankWindow);
-  }
-
-  private async runLlmRerank({
-    db,
-    candidatesForRerank,
-    ctx,
-    typeDist,
-  }: {
-    db: Surreal;
-    candidatesForRerank: EntityBucket[];
-    ctx: PipelineContext;
-    typeDist: { weights: Record<string, number> } | null;
-  }): Promise<EntityBucket[]> {
-    // SubgraphRAG-style 1-hop neighbourhood injection. Surfaces graph
-    // context as "Connected to: …" lines in the candidate body — lets
-    // the reranker disambiguate shared-firstname / same-topic peers by
-    // whose neighbours match the query.
-    const neighboursByEntity = await withSpan(
-      'search.fetch_neighbours',
-      () =>
-        fetchNeighbours(
-          db,
-          this.logger,
-          candidatesForRerank.map((e) => e.entityId),
-        ),
-      { 'neighbours.candidates': candidatesForRerank.length },
-    );
-
-    const rerankInputs = candidatesForRerank.map((e) => {
-      const ent = e.facts[0]?.row.entity ?? {
-        type: 'other',
-        canonicalName: e.entityId,
-      };
-      const topFacts = [...e.facts]
-        .sort((a, b) => b.score - a.score)
-        .slice(0, 3)
-        .map((sf) => `- ${sf.row.predicate}: ${sf.row.object}`)
-        .join('\n');
-      const nbrs = neighboursByEntity.get(e.entityId) ?? [];
-      const nbrLine = nbrs.length
-        ? `\nConnected to: ${nbrs
-            .slice(0, 5)
-            .map((n) => `${n.canonicalName} (${n.type}, ${n.kind})`)
-            .join('; ')}`
-        : '';
-      return {
-        label: `${ent.canonicalName} [${ent.type}]`,
-        body: `${topFacts}${nbrLine}`,
-      };
-    });
-
-    const hints = typeDist
-      ? `Likely target entity types: ${
-          Object.entries(typeDist.weights)
-            .filter(([, w]) => w >= 0.15)
-            .sort((a, b) => b[1] - a[1])
-            .slice(0, 3)
-            .map(([t, w]) => `${t}=${w.toFixed(2)}`)
-            .join(', ') || 'unspecified'
-        }.`
-      : undefined;
-
-    const identityPerm = rerankInputs.map((_, i) => i);
-    const permutation = await withSpan(
-      'search.rerank',
-      () =>
-        withStageBudget({
-          stage: 'rerank',
-          budgetMs: this.budgets.rerank,
-          fn: () => this.reranker.rerank(ctx.dto.query, rerankInputs, hints),
-          fallback: identityPerm,
-          logger: this.logger,
-        }),
-      { 'rerank.candidates': rerankInputs.length },
-    );
-    const isIdentity = permutation.every((idx, i) => idx === i);
-    this.metrics?.countRerank(isIdentity ? 'skipped_disabled' : 'invoked');
-    return permutation.map((i) => candidatesForRerank[i]);
-  }
 }
 
 export interface GraphRetrieveOptions {
@@ -690,15 +386,4 @@ export interface GraphRetrieveOptions {
   predicateHints: string[];
   asOf: string | undefined;
   callerScopes: string[];
-}
-
-interface PipelineContext {
-  dto: SearchDto;
-  callerScopes: string[];
-  limit: number;
-  asOf: Date | null;
-  includeRetracted: boolean;
-  includeContested: boolean;
-  mode: SearchMode;
-  candidateK: number;
 }


### PR DESCRIPTION
## What
`SearchService` injected 7 deps (surreal, embedder, reranker, predicateRouter, crossEncoder, calibration, metrics). The pipeline stages were already pre-extracted as private methods; group them behind two stage services:
- **SearchRetrievalService** (embedder, predicateRouter, calibration) — vector + lexical legs with fusion, the predicate/type router, and calibrated scoring + per-entity bucketing.
- **SearchRerankService** (reranker, crossEncoder, metrics) — cross-encoder windowing, margin-skip, and the LLM reranker with neighbour injection (all rerank metrics live here).

`SearchService` (surreal, retrieval, rerank) keeps the orchestration: db lifecycle, identity-merge, edge expansion, PPR, backfill, graph retrieval — the db-threading stages that need no AI service. `PipelineContext` moved to its own module.

## Why
Part 2/3 of the `max-params=3` god-class split program. Public `search()` / `graphRetrieve()` / `expandEntityIdsViaEdges()` contracts unchanged.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
- `pnpm test:unit` 700/700 ✓ · `pnpm test:e2e` 128/128 ✓ (incl. sota / lang-filtered-retrieve / brain retrieval suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)