### PR TITLE
refactor(admin): push AdminInfraController logic into focused services (max-params 2/3)

### DIFF
--- a/src/admin/admin-infra.controller.ts
+++ b/src/admin/admin-infra.controller.ts
@@ -1,12 +1,8 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import { AdminInfraService } from './admin-infra.service';
-import { EmbedderService } from '../ai/embedder.service';
-import { IntentClassifierService } from './intent-classifier.service';
-import { ChangefeedConsumerService } from '../audit/changefeed-consumer.service';
-import { ActivityTrackerService } from '../common/activity-tracker.service';
-import { ThrottlerObservabilityService } from './throttler-observability.service';
+import { HealthComponentsService } from './health-components.service';
+import { LiveSnapshotService } from './live-snapshot.service';
 import type { HealthComponentsResponse } from '../contracts/admin/health-components.schema';
 import type { MigrationsResponse } from '../contracts/admin/migrations.schema';
 import type { ThrottlerResponse } from '../contracts/admin/throttler.schema';
@@ -21,18 +17,18 @@ import type { NowResponse } from '../contracts/admin/now.schema';
  *   /v1/admin/migrations        — applied vs pending per tenant
  *   /v1/admin/throttler         — top routes / actors / recent 429s
  *   /v1/admin/now               — currently in-flight HTTP requests
+ *
+ * HTTP plumbing only — the per-component probing lives in
+ * HealthComponentsService, the live snapshots in LiveSnapshotService,
+ * and the DB/migration reads in AdminInfraService.
  */
 @Controller('v1/admin')
 @UseGuards(ApiKeyGuard)
 export class AdminInfraController {
   constructor(
     private readonly adminInfra: AdminInfraService,
-    private readonly embedder: EmbedderService,
-    private readonly intent: IntentClassifierService,
-    private readonly changefeed: ChangefeedConsumerService,
-    private readonly activity: ActivityTrackerService,
-    private readonly throttler: ThrottlerObservabilityService,
-    private readonly config: ConfigService,
+    private readonly healthComponents: HealthComponentsService,
+    private readonly liveSnapshot: LiveSnapshotService,
   ) {}
 
   /**
@@ -43,88 +39,10 @@ export class AdminInfraController {
    */
   @Get('health/components')
   @RequireScopes('brain:admin')
-  async healthComponents(): Promise<HealthComponentsResponse> {
-    const components: Array<{
-      name: string;
-      status: 'ok' | 'warming' | 'degraded' | 'disabled' | 'unreachable';
-      latencyMs?: number;
-      message?: string;
-    }> = [];
-
-    // SurrealDB
+  async healthComponentsView(): Promise<HealthComponentsResponse> {
     const dbStart = Date.now();
     const dbOk = await this.adminInfra.pingDb();
-    components.push({
-      name: 'surrealdb',
-      status: dbOk ? 'ok' : 'unreachable',
-      latencyMs: Date.now() - dbStart,
-    });
-
-    // Embedder (BGE-M3 or OpenAI proxy — service exposes isReady)
-    const embedderReady = this.embedder.isReady();
-    const embedderProvider = this.embedder.cacheStats().provider;
-    components.push({
-      name: `embedder (${embedderProvider})`,
-      status: embedderReady ? 'ok' : 'warming',
-      message: embedderReady
-        ? `cache size ${this.embedder.cacheStats().size}`
-        : 'downloading model weights',
-    });
-
-    // Intent classifier
-    const intentStats = this.intent.stats();
-    components.push({
-      name: 'intent classifier',
-      status: !intentStats.enabled
-        ? 'disabled'
-        : intentStats.ready
-          ? 'ok'
-          : 'warming',
-      message: intentStats.enabled
-        ? `model=${intentStats.model} cache=${intentStats.cacheSize}`
-        : 'CHAT_ROUTE_NLI_ENABLED=0',
-    });
-
-    // OpenAI key presence (we don't ping — that would burn tokens)
-    const hasOpenAI = !!this.config.get<string>('OPENAI_API_KEY');
-    components.push({
-      name: 'openai key',
-      status: hasOpenAI ? 'ok' : 'disabled',
-      message: hasOpenAI
-        ? 'present (not pinged)'
-        : 'OPENAI_API_KEY unset',
-    });
-
-    // Changefeed consumer
-    const cf = this.changefeed.stats();
-    components.push({
-      name: 'changefeed consumer',
-      status: !cf.enabled
-        ? 'disabled'
-        : cf.lastError
-          ? 'degraded'
-          : cf.lastPendingRemaining > 100
-            ? 'degraded'
-            : 'ok',
-      message: cf.enabled
-        ? `${cf.lastPendingRemaining} pending · ${cf.tickCount} ticks`
-        : 'AUDIT_CHANGEFEED_ENABLED=0',
-    });
-
-    // Calibration source
-    components.push({
-      name: 'calibration',
-      status:
-        this.config.get<string>('CALIBRATION_USE_GOLD_SET', '1') === '0'
-          ? 'disabled'
-          : 'ok',
-      message: 'see /admin/calibration for ECE + version history',
-    });
-
-    return {
-      generatedAt: new Date().toISOString(),
-      components,
-    } satisfies HealthComponentsResponse;
+    return this.healthComponents.build(dbOk, Date.now() - dbStart);
   }
 
   /**
@@ -141,15 +59,12 @@ export class AdminInfraController {
   @Get('throttler')
   @RequireScopes('brain:admin')
   throttlerView(): ThrottlerResponse {
-    return this.throttler.snapshot() satisfies ThrottlerResponse;
+    return this.liveSnapshot.throttlerSnapshot();
   }
 
   @Get('now')
   @RequireScopes('brain:admin')
   now(): NowResponse {
-    return {
-      generatedAt: new Date().toISOString(),
-      inFlight: this.activity.list(),
-    } satisfies NowResponse;
+    return this.liveSnapshot.now();
   }
 }

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -16,6 +16,8 @@ import { AdminJobsController } from './admin-jobs.controller';
 import { AdminOpsController } from './admin-ops.controller';
 import { AdminInfraController } from './admin-infra.controller';
 import { AdminInfraService } from './admin-infra.service';
+import { HealthComponentsService } from './health-components.service';
+import { LiveSnapshotService } from './live-snapshot.service';
 import { AdminService } from './admin.service';
 import { OperatorActionService } from './operator-action.service';
 import { OperatorActionInterceptor } from './operator-action.interceptor';
@@ -56,6 +58,8 @@ import { ConfigInspectorService } from './config-inspector.service';
   providers: [
     AdminService,
     AdminInfraService,
+    HealthComponentsService,
+    LiveSnapshotService,
     ScenarioRunnerService,
     BaselineService,
     ChatRouterCacheService,

--- a/src/admin/health-components.service.ts
+++ b/src/admin/health-components.service.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@nestjs/common';
+import { EmbedderService } from '../ai/embedder.service';
+import { IntentClassifierService } from './intent-classifier.service';
+import { ChangefeedConsumerService } from '../audit/changefeed-consumer.service';
+import type { HealthComponentsResponse } from '../contracts/admin/health-components.schema';
+
+type ComponentStatus =
+  | 'ok'
+  | 'warming'
+  | 'degraded'
+  | 'disabled'
+  | 'unreachable';
+
+/**
+ * HealthComponentsService — builds the per-component health grid for the
+ * admin cockpit (/v1/admin/health/components). Probes the embedder,
+ * intent classifier, and changefeed consumer; the DB-liveness result is
+ * passed in by the controller (which owns AdminInfraService.pingDb).
+ * Extracted from AdminInfraController so the controller keeps ≤3 deps and
+ * holds no business logic.
+ */
+@Injectable()
+export class HealthComponentsService {
+  constructor(
+    private readonly embedder: EmbedderService,
+    private readonly intent: IntentClassifierService,
+    private readonly changefeed: ChangefeedConsumerService,
+  ) {}
+
+  build(dbOk: boolean, dbLatencyMs: number): HealthComponentsResponse {
+    const components: Array<{
+      name: string;
+      status: ComponentStatus;
+      latencyMs?: number;
+      message?: string;
+    }> = [];
+
+    // SurrealDB (probed by the caller)
+    components.push({
+      name: 'surrealdb',
+      status: dbOk ? 'ok' : 'unreachable',
+      latencyMs: dbLatencyMs,
+    });
+
+    // Embedder (BGE-M3 or OpenAI proxy — service exposes isReady)
+    const embedderReady = this.embedder.isReady();
+    const embedderProvider = this.embedder.cacheStats().provider;
+    components.push({
+      name: `embedder (${embedderProvider})`,
+      status: embedderReady ? 'ok' : 'warming',
+      message: embedderReady
+        ? `cache size ${this.embedder.cacheStats().size}`
+        : 'downloading model weights',
+    });
+
+    // Intent classifier
+    const intentStats = this.intent.stats();
+    components.push({
+      name: 'intent classifier',
+      status: !intentStats.enabled
+        ? 'disabled'
+        : intentStats.ready
+          ? 'ok'
+          : 'warming',
+      message: intentStats.enabled
+        ? `model=${intentStats.model} cache=${intentStats.cacheSize}`
+        : 'CHAT_ROUTE_NLI_ENABLED=0',
+    });
+
+    // OpenAI key presence (we don't ping — that would burn tokens)
+    const hasOpenAI = !!process.env.OPENAI_API_KEY;
+    components.push({
+      name: 'openai key',
+      status: hasOpenAI ? 'ok' : 'disabled',
+      message: hasOpenAI ? 'present (not pinged)' : 'OPENAI_API_KEY unset',
+    });
+
+    // Changefeed consumer
+    const cf = this.changefeed.stats();
+    components.push({
+      name: 'changefeed consumer',
+      status: !cf.enabled
+        ? 'disabled'
+        : cf.lastError
+          ? 'degraded'
+          : cf.lastPendingRemaining > 100
+            ? 'degraded'
+            : 'ok',
+      message: cf.enabled
+        ? `${cf.lastPendingRemaining} pending · ${cf.tickCount} ticks`
+        : 'AUDIT_CHANGEFEED_ENABLED=0',
+    });
+
+    // Calibration source
+    components.push({
+      name: 'calibration',
+      status:
+        (process.env.CALIBRATION_USE_GOLD_SET ?? '1') === '0'
+          ? 'disabled'
+          : 'ok',
+      message: 'see /admin/calibration for ECE + version history',
+    });
+
+    return {
+      generatedAt: new Date().toISOString(),
+      components,
+    } satisfies HealthComponentsResponse;
+  }
+}

--- a/src/admin/live-snapshot.service.ts
+++ b/src/admin/live-snapshot.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { ActivityTrackerService } from '../common/activity-tracker.service';
+import { ThrottlerObservabilityService } from './throttler-observability.service';
+import type { ThrottlerResponse } from '../contracts/admin/throttler.schema';
+import type { NowResponse } from '../contracts/admin/now.schema';
+
+/**
+ * LiveSnapshotService — live operational snapshots for the admin cockpit:
+ * the throttler observability view (/v1/admin/throttler) and the
+ * in-flight HTTP request list (/v1/admin/now). Extracted from
+ * AdminInfraController so the controller keeps ≤3 deps.
+ */
+@Injectable()
+export class LiveSnapshotService {
+  constructor(
+    private readonly throttler: ThrottlerObservabilityService,
+    private readonly activity: ActivityTrackerService,
+  ) {}
+
+  throttlerSnapshot(): ThrottlerResponse {
+    return this.throttler.snapshot() satisfies ThrottlerResponse;
+  }
+
+  now(): NowResponse {
+    return {
+      generatedAt: new Date().toISOString(),
+      inFlight: this.activity.list(),
+    } satisfies NowResponse;
+  }
+}

--- a/test/contracts-admin-health-components.unit-spec.ts
+++ b/test/contracts-admin-health-components.unit-spec.ts
@@ -5,11 +5,11 @@ import { HealthComponentsResponseSchema } from '../src/contracts/admin/health-co
 import { makeAdminInfraController } from './helpers/admin-controllers';
 import type { AdminInfraController } from '../src/admin/admin-infra.controller';
 import { AdminInfraService } from '../src/admin/admin-infra.service';
+import { HealthComponentsService } from '../src/admin/health-components.service';
 import type { SurrealService } from '../src/db/surreal.service';
 import type { EmbedderService } from '../src/ai/embedder.service';
 import type { IntentClassifierService } from '../src/admin/intent-classifier.service';
 import type { ChangefeedConsumerService } from '../src/audit/changefeed-consumer.service';
-import type { ConfigService } from '@nestjs/config';
 
 function makeController(): AdminInfraController {
   const surreal = {
@@ -35,17 +35,15 @@ function makeController(): AdminInfraController {
       perBatchLimit: 100,
     }),
   } as unknown as ChangefeedConsumerService;
-  const config = {
-    get: <T>(_k: string, dflt?: T) => dflt,
-  } as unknown as ConfigService;
   const adminInfra = new AdminInfraService(surreal, undefined as never);
-  return makeAdminInfraController({ adminInfra, embedder, intent, changefeed, config });
+  const healthComponents = new HealthComponentsService(embedder, intent, changefeed);
+  return makeAdminInfraController({ adminInfra, healthComponents });
 }
 
 describe('AdminInfraController.healthComponents() — wire contract', () => {
   it('matches HealthComponentsResponseSchema', async () => {
     const parsed = HealthComponentsResponseSchema.safeParse(
-      await makeController().healthComponents(),
+      await makeController().healthComponentsView(),
     );
     if (!parsed.success) {
       throw new Error(

--- a/test/contracts-admin-now.unit-spec.ts
+++ b/test/contracts-admin-now.unit-spec.ts
@@ -4,7 +4,9 @@
 import { NowResponseSchema } from '../src/contracts/admin/now.schema';
 import { makeAdminInfraController } from './helpers/admin-controllers';
 import type { AdminInfraController } from '../src/admin/admin-infra.controller';
+import { LiveSnapshotService } from '../src/admin/live-snapshot.service';
 import type { ActivityTrackerService } from '../src/common/activity-tracker.service';
+import type { ThrottlerObservabilityService } from '../src/admin/throttler-observability.service';
 
 function makeController(): AdminInfraController {
   const activity = {
@@ -24,7 +26,11 @@ function makeController(): AdminInfraController {
       },
     ],
   } as unknown as ActivityTrackerService;
-  return makeAdminInfraController({ activity });
+  const liveSnapshot = new LiveSnapshotService(
+    undefined as unknown as ThrottlerObservabilityService,
+    activity,
+  );
+  return makeAdminInfraController({ liveSnapshot });
 }
 
 describe('AdminInfraController.now() — wire contract', () => {

--- a/test/contracts-admin-throttler.unit-spec.ts
+++ b/test/contracts-admin-throttler.unit-spec.ts
@@ -4,7 +4,9 @@
 import { ThrottlerResponseSchema } from '../src/contracts/admin/throttler.schema';
 import { makeAdminInfraController } from './helpers/admin-controllers';
 import type { AdminInfraController } from '../src/admin/admin-infra.controller';
+import { LiveSnapshotService } from '../src/admin/live-snapshot.service';
 import type { ThrottlerObservabilityService } from '../src/admin/throttler-observability.service';
+import type { ActivityTrackerService } from '../src/common/activity-tracker.service';
 
 function makeController(): AdminInfraController {
   const throttler = {
@@ -31,7 +33,11 @@ function makeController(): AdminInfraController {
       ],
     }),
   } as unknown as ThrottlerObservabilityService;
-  return makeAdminInfraController({ throttler });
+  const liveSnapshot = new LiveSnapshotService(
+    throttler,
+    undefined as unknown as ActivityTrackerService,
+  );
+  return makeAdminInfraController({ liveSnapshot });
 }
 
 describe('AdminInfraController.throttlerView() — wire contract', () => {

--- a/test/helpers/admin-controllers.ts
+++ b/test/helpers/admin-controllers.ts
@@ -44,12 +44,8 @@ export function makeAdminController(d: AdminControllerDeps = {}): AdminControlle
 
 export interface AdminInfraControllerDeps {
   adminInfra?: unknown;
-  embedder?: unknown;
-  intent?: unknown;
-  changefeed?: unknown;
-  activity?: unknown;
-  throttler?: unknown;
-  config?: unknown;
+  healthComponents?: unknown;
+  liveSnapshot?: unknown;
 }
 
 export function makeAdminInfraController(
@@ -57,11 +53,7 @@ export function makeAdminInfraController(
 ): AdminInfraController {
   return new AdminInfraController(
     as(d.adminInfra ?? u),
-    as(d.embedder ?? u),
-    as(d.intent ?? u),
-    as(d.changefeed ?? u),
-    as(d.activity ?? u),
-    as(d.throttler ?? u),
-    as(d.config ?? u),
+    as(d.healthComponents ?? u),
+    as(d.liveSnapshot ?? u),
   );
 }


### PR DESCRIPTION
## What
`AdminInfraController` injected 7 deps. Move the per-component health grid into `HealthComponentsService` (embedder, intent, changefeed — DB-liveness passed in, config flags via `process.env`) and the live operational snapshots (throttler / in-flight) into `LiveSnapshotService` (throttler, activity). The controller keeps HTTP plumbing only (adminInfra, healthComponents, liveSnapshot), 3 deps.

## Why
Part 2/3 of the `max-params=3` god-class split program. Controllers must hold no business logic (layer purity) AND ≤3 deps.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
- `pnpm test:unit` 700/700 ✓ · `pnpm test:e2e` 128/128 ✓ (named-dep helper + now/throttler/health-components contract specs updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)