### PR TITLE
refactor(ai): split ExtractorService into llm/local/refine/runner (max-params 2/3)

### DIFF
--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -1,6 +1,10 @@
 import { Global, Module } from '@nestjs/common';
 import { EmbedderService } from './embedder.service';
 import { ExtractorService } from './extractor.service';
+import { ExtractorRunnerService } from './extractor-runner.service';
+import { ExtractorLlmService } from './extractor-llm.service';
+import { ExtractorLocalService } from './extractor-local.service';
+import { ExtractorRefineService } from './extractor-refine.service';
 import { RerankerService } from './reranker.service';
 import { HypeService } from './hype.service';
 import { PredicateRouterService } from './predicate-router.service';
@@ -25,6 +29,10 @@ import { EntityJudgeService } from './entity-judge.service';
   // discovered by the global scheduler without a local registration.
   providers: [
     EmbedderService,
+    ExtractorLlmService,
+    ExtractorLocalService,
+    ExtractorRefineService,
+    ExtractorRunnerService,
     ExtractorService,
     RerankerService,
     HypeService,

--- a/src/ai/extractor-llm.service.ts
+++ b/src/ai/extractor-llm.service.ts
@@ -1,0 +1,130 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import OpenAI from 'openai';
+import { Semaphore } from '../common/semaphore';
+import { withGenAiCall } from '../common/gen-ai-observability';
+import { getAbortSignal } from '../common/request-context';
+import { MetricsService } from '../metrics/metrics.service';
+import { PredicateDefinition } from './predicate-registry.service';
+import {
+  EXTRACTION_PROMPT_HEADER,
+  buildExtractionSchema,
+  buildSystemPrompt,
+  renderPredicateCard,
+} from './extractor-internals/prompts';
+
+/**
+ * ExtractorLlmService — the OpenAI I/O slice of the extractor: the chat
+ * client, the system-prompt assembly from the predicate snapshot, and
+ * the self-consistency pass count. Owns config (client + tuning) and
+ * metrics; the orchestration/assembly live in ExtractorRunnerService.
+ * Splitting it out keeps each extractor class ≤3 injected deps.
+ */
+@Injectable()
+export class ExtractorLlmService {
+  private readonly logger = new Logger(ExtractorLlmService.name);
+  private readonly openai: OpenAI;
+  private readonly model: string;
+  private readonly systemPromptHeader: string;
+  private readonly limiter: Semaphore;
+  /** Self-consistency / N-pass driver count (1 = single-pass). */
+  readonly scPasses: number;
+
+  constructor(
+    private readonly configService: ConfigService,
+    @Optional() private readonly metrics?: MetricsService,
+  ) {
+    const timeoutMs = parseInt(
+      this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
+      10,
+    );
+    const maxRetries = parseInt(
+      this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
+      10,
+    );
+    this.openai = new OpenAI({
+      apiKey: this.configService.getOrThrow<string>('OPENAI_API_KEY'),
+      timeout: timeoutMs,
+      maxRetries,
+    });
+    this.model = this.configService.get<string>(
+      'OPENAI_CHAT_MODEL',
+      'gpt-4o-mini',
+    );
+    // The static EXTRACTION_SYSTEM_PROMPT override is no longer the
+    // source of truth for vocabulary — that's the registry. The env
+    // var stays as an escape hatch for operators who want to fully
+    // replace the prompt header (everything before the dynamically-
+    // rendered predicate cards).
+    this.systemPromptHeader =
+      this.configService.get<string>('EXTRACTION_SYSTEM_PROMPT') ??
+      EXTRACTION_PROMPT_HEADER;
+    this.limiter = new Semaphore(
+      parseInt(this.configService.get<string>('OPENAI_CONCURRENCY', '8'), 10),
+    );
+    this.scPasses = Math.max(
+      1,
+      parseInt(this.configService.get<string>('EXTRACTOR_SC_PASSES', '1'), 10),
+    );
+  }
+
+  /** Identity of the extraction model — used as the default source.recorder. */
+  modelId(): string {
+    return this.model;
+  }
+
+  composeSystemPrompt(snapshot: { active: PredicateDefinition[] }): string {
+    return this.systemPromptHeader === EXTRACTION_PROMPT_HEADER
+      ? buildSystemPrompt(snapshot.active)
+      : this.systemPromptHeader +
+          snapshot.active.map(renderPredicateCard).join('\n');
+  }
+
+  async callLlm(
+    trimmed: string,
+    systemPrompt: string,
+    temperature = 0.1,
+  ): Promise<any> {
+    const res = await this.limiter.run(() =>
+      withGenAiCall(
+        {
+          kind: 'chat',
+          spanName: 'gen_ai.chat.extractor',
+          system: 'openai',
+          model: this.model,
+          attrs: { 'gen_ai.request.temperature': temperature },
+        },
+        this.metrics,
+        () =>
+          this.openai.chat.completions.create(
+            {
+              model: this.model,
+              messages: [
+                { role: 'system', content: systemPrompt },
+                { role: 'user', content: trimmed },
+              ],
+              response_format: {
+                type: 'json_schema',
+                json_schema: {
+                  name: 'extraction',
+                  strict: true,
+                  schema: buildExtractionSchema(),
+                },
+              },
+              max_completion_tokens: 1500,
+              temperature,
+            },
+            { signal: getAbortSignal() },
+          ),
+      ),
+    );
+    const content = res.choices[0]?.message?.content;
+    if (!content) return null;
+    try {
+      return JSON.parse(content);
+    } catch (err) {
+      this.logger.warn(`Extractor returned non-JSON: ${(err as Error).message}`);
+      return null;
+    }
+  }
+}

--- a/src/ai/extractor-local.service.ts
+++ b/src/ai/extractor-local.service.ts
@@ -1,0 +1,108 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { traceArtifact } from '../common/debug-trace';
+import { LocalNerService } from './local-ner.service';
+import { ExtractionPatternService } from './extraction-pattern.service';
+import { splitClauses } from './clause-splitter';
+import { attemptLocalSynth } from './extractor-internals/local-synth';
+import { persistExtractionPatterns } from './extractor-internals/pattern-emitter';
+import type {
+  ExtractedEdge,
+  ExtractedFact,
+  ExtractionResult,
+} from './extractor-internals/types';
+
+/**
+ * ExtractorLocalService — the no-LLM slice of the extractor: the
+ * skip-LLM local fast path (clause split + local NER + cached-pattern
+ * synthesis) and the post-assembly pattern emission. Owns localNer +
+ * extractionPatterns. The skip gate is read from the environment so this
+ * stays at ≤2 deps. trySkip returns the result (or null); caching is the
+ * orchestrator's job.
+ */
+@Injectable()
+export class ExtractorLocalService {
+  private readonly logger = new Logger(ExtractorLocalService.name);
+
+  constructor(
+    private readonly localNer: LocalNerService,
+    private readonly extractionPatterns: ExtractionPatternService,
+  ) {}
+
+  /**
+   * Attempt a fully-local extraction (no LLM). Returns the synthesised
+   * result when every clause is covered by cached patterns + local NER,
+   * else null so the caller falls through to the LLM path.
+   */
+  async trySkip(
+    companyId: string,
+    trimmed: string,
+  ): Promise<ExtractionResult | null> {
+    const localClauses = splitClauses(trimmed);
+    traceArtifact('extractor.local_clauses', {
+      count: localClauses.length,
+      clauses: localClauses,
+    });
+    let localEntities: Awaited<ReturnType<LocalNerService['extract']>> = [];
+    if (this.localNer.isReady()) {
+      localEntities = await this.localNer.extract(trimmed);
+      if (localEntities.length > 0) {
+        traceArtifact('extractor.local_entities', {
+          count: localEntities.length,
+          entities: localEntities,
+        });
+      }
+    }
+    const skipEnabled =
+      (process.env.EXTRACTOR_SKIP_LLM_ENABLED ?? 'false') === 'true';
+    if (!skipEnabled) return null;
+    if (localClauses.length === 0) {
+      traceArtifact('extractor.skip_decision', {
+        skip: false,
+        reason: 'no_local_clauses',
+      });
+      return null;
+    }
+    if (localEntities.length === 0) {
+      traceArtifact('extractor.skip_decision', {
+        skip: false,
+        reason: 'no_local_entities',
+      });
+      return null;
+    }
+    const synthesised = await attemptLocalSynth({
+      patterns: this.extractionPatterns,
+      companyId,
+      inputText: trimmed,
+      clauseTexts: localClauses.map((c) => c.text),
+      localEntities,
+    });
+    if (!synthesised) {
+      traceArtifact('extractor.skip_decision', {
+        skip: false,
+        reason: 'partial_coverage',
+      });
+      return null;
+    }
+    traceArtifact('extractor.skip_decision', { skip: true, reason: 'all_local' });
+    return synthesised;
+  }
+
+  /** Best-effort pattern emission after an LLM assembly. Fire-and-forget. */
+  persistPatterns(args: {
+    companyId: string;
+    clauses: unknown[];
+    rawFacts: unknown[];
+    facts: ExtractedFact[];
+    edges: ExtractedEdge[];
+  }): void {
+    void persistExtractionPatterns({
+      patterns: this.extractionPatterns,
+      logger: this.logger,
+      companyId: args.companyId,
+      clauses: args.clauses as never,
+      rawFacts: args.rawFacts as never,
+      facts: args.facts,
+      edges: args.edges,
+    });
+  }
+}

--- a/src/ai/extractor-refine.service.ts
+++ b/src/ai/extractor-refine.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { traceArtifact } from '../common/debug-trace';
+import {
+  PredicateRegistryService,
+  PredicateSnapshot,
+} from './predicate-registry.service';
+import { LocalPredicateSelectorService } from './local-predicate-selector.service';
+import type { ExtractedFact } from './extractor-internals/types';
+import {
+  applyCanonicalizePass,
+  applyLocalPredicateOverrides,
+} from './extractor-internals/predicate-canonicalize';
+
+/**
+ * ExtractorRefineService — post-extraction predicate refinement: the
+ * local-predicate-selector overrides and the EDC canonicalize pass
+ * against the registry. Owns registry + localPredicates; the threshold
+ * is read from the environment so this stays at ≤2 deps.
+ */
+@Injectable()
+export class ExtractorRefineService {
+  private readonly logger = new Logger(ExtractorRefineService.name);
+
+  constructor(
+    private readonly registry: PredicateRegistryService,
+    private readonly localPredicates: LocalPredicateSelectorService,
+  ) {}
+
+  async applyPredicateRefinements(
+    facts: ExtractedFact[],
+    snapshot: PredicateSnapshot,
+    companyId: string,
+  ): Promise<void> {
+    const localThreshold = parseFloat(
+      process.env.EXTRACTOR_LOCAL_PREDICATE_THRESHOLD ?? '0.45',
+    );
+    const localOverrides = await applyLocalPredicateOverrides({
+      facts,
+      snapshot,
+      selector: this.localPredicates,
+      threshold: localThreshold,
+    });
+    if (localOverrides.length > 0) {
+      traceArtifact('extractor.local_predicate_override', {
+        threshold: localThreshold,
+        decisions: localOverrides,
+      });
+    }
+    try {
+      if (facts.length === 0) return;
+      const decisions = await applyCanonicalizePass({
+        facts,
+        registry: this.registry,
+        companyId,
+        logger: this.logger,
+      });
+      if (decisions.length > 0) {
+        traceArtifact('extractor.canonicalize', decisions);
+      }
+    } catch (e) {
+      this.logger.warn(
+        `extractor: canonicalize pass failed: ${(e as Error).message}; keeping model-emitted predicates`,
+      );
+    }
+  }
+}

--- a/src/ai/extractor-runner.service.ts
+++ b/src/ai/extractor-runner.service.ts
@@ -1,0 +1,254 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { traceArtifact } from '../common/debug-trace';
+import { PredicateDefinition } from './predicate-registry.service';
+import { ExtractorLlmService } from './extractor-llm.service';
+import { ExtractorLocalService } from './extractor-local.service';
+import { ExtractorRefineService } from './extractor-refine.service';
+import {
+  clusterKey,
+  selfConsistencyByFact,
+} from './extractor-internals/semantic-entropy';
+import type {
+  ExtractedEntity,
+  ExtractionResult,
+} from './extractor-internals/types';
+import {
+  applyGroundingGate,
+  groundEntities,
+  parseClauses,
+  parseEntities,
+  parseRawFacts,
+} from './extractor-internals/grounding';
+import { validateEdges } from './extractor-internals/edge-validator';
+
+type Snapshot = { versionHash: string; active: PredicateDefinition[] };
+
+/**
+ * ExtractorRunnerService — the extraction engine. Sequences the local
+ * skip → LLM call (single or N-pass self-consistency) → response parsing
+ * + span grounding + edge validation → predicate refinement → pattern
+ * emission. Delegates each concern to ExtractorLlmService /
+ * ExtractorLocalService / ExtractorRefineService. The predicate snapshot
+ * is supplied by the caller (ExtractorService, which owns the cache);
+ * this class holds no cache/registry dep, keeping it at ≤3.
+ */
+@Injectable()
+export class ExtractorRunnerService {
+  private readonly logger = new Logger(ExtractorRunnerService.name);
+
+  constructor(
+    private readonly llm: ExtractorLlmService,
+    private readonly local: ExtractorLocalService,
+    private readonly refine: ExtractorRefineService,
+  ) {}
+
+  modelId(): string {
+    return this.llm.modelId();
+  }
+
+  get scPasses(): number {
+    return this.llm.scPasses;
+  }
+
+  /** Run the extraction for an already-clamped input + loaded snapshot. */
+  async run(
+    trimmed: string,
+    companyId: string,
+    snapshot: Snapshot,
+  ): Promise<ExtractionResult> {
+    const systemPrompt = this.llm.composeSystemPrompt(snapshot);
+
+    const skip = await this.local.trySkip(companyId, trimmed);
+    if (skip) return skip;
+
+    traceArtifact('extractor.vocab', {
+      versionHash: snapshot.versionHash,
+      predicateCount: snapshot.active.length,
+      predicateIds: snapshot.active.map((p) => p.predicateId),
+    });
+
+    if (this.llm.scPasses > 1) {
+      return this.runMultiPassExtract({ companyId, trimmed, snapshot, systemPrompt });
+    }
+
+    const rawJson = await this.llm.callLlm(trimmed, systemPrompt, 0.1);
+    if (!rawJson) return { entities: [], facts: [], edges: [] };
+    return this.assembleResult({ companyId, trimmed, snapshot, rawJson });
+  }
+
+  private async runMultiPassExtract(args: {
+    companyId: string;
+    trimmed: string;
+    snapshot: Snapshot;
+    systemPrompt: string;
+  }): Promise<ExtractionResult> {
+    const N = this.llm.scPasses;
+    // Even temperature spread across [0.1, 0.7].
+    const temperatures = Array.from(
+      { length: N },
+      (_, i) => 0.1 + (i * 0.6) / Math.max(N - 1, 1),
+    );
+
+    const rawJsons = await Promise.all(
+      temperatures.map((t) =>
+        this.llm.callLlm(args.trimmed, args.systemPrompt, t).catch((e) => {
+          this.logger.warn(
+            `sc-pass T=${t.toFixed(2)} failed: ${(e as Error).message}`,
+          );
+          return null;
+        }),
+      ),
+    );
+    const results = await Promise.all(
+      rawJsons.map((rj) =>
+        rj
+          ? this.assembleResult({
+              companyId: args.companyId,
+              trimmed: args.trimmed,
+              snapshot: args.snapshot,
+              rawJson: rj,
+            })
+          : null,
+      ),
+    );
+    const surviving = results.filter((r): r is ExtractionResult => !!r);
+    if (surviving.length === 0) return { entities: [], facts: [], edges: [] };
+
+    const passFacts = surviving.map((r) =>
+      r.facts.map((f) => ({ predicate: f.predicate, object: f.object })),
+    );
+    const sc = selfConsistencyByFact(passFacts);
+
+    const entityKey = (e: { name: string; type: string }) =>
+      `${e.type}:${e.name.toLowerCase().trim()}`;
+    const entityMap = new Map<string, ExtractionResult['entities'][number]>();
+    for (const r of surviving) {
+      for (const e of r.entities) {
+        const k = entityKey(e);
+        if (!entityMap.has(k)) entityMap.set(k, e);
+      }
+    }
+    const entities = [...entityMap.values()];
+
+    const edgeMap = new Map<string, ExtractionResult['edges'][number]>();
+    for (const r of surviving) {
+      for (const ed of r.edges) {
+        const k = `${ed.fromEntityIndex}-${ed.kind}-${ed.toEntityIndex}`;
+        if (!edgeMap.has(k)) edgeMap.set(k, ed);
+      }
+    }
+    const edges = [...edgeMap.values()];
+
+    const seenClusters = new Set<string>();
+    const facts: ExtractionResult['facts'] = [];
+    for (const r of surviving) {
+      for (const f of r.facts) {
+        const k = clusterKey({ predicate: f.predicate, object: f.object });
+        if (seenClusters.has(k)) continue;
+        seenClusters.add(k);
+        const stats = sc.get(k);
+        facts.push({
+          ...f,
+          ...(stats
+            ? {
+                extractionEntropy: stats.entropy,
+                extractionAgreement: stats.agreement,
+              }
+            : {}),
+        });
+      }
+    }
+
+    traceArtifact('extractor.sc_passes', {
+      passes: surviving.length,
+      temperatures,
+      clusterCount: sc.size,
+      clusterEntropy: facts[0]?.extractionEntropy ?? 0,
+    });
+
+    return { entities, facts, edges };
+  }
+
+  private async assembleResult(args: {
+    companyId: string;
+    trimmed: string;
+    snapshot: Snapshot;
+    rawJson: any;
+  }): Promise<ExtractionResult> {
+    const { companyId, trimmed, snapshot, rawJson } = args;
+
+    const parsedEntities: ExtractedEntity[] = parseEntities(rawJson);
+    const clauses = parseClauses(rawJson);
+    const rawFacts = parseRawFacts(rawJson, parsedEntities.length);
+    const { facts: valueGroundedFacts, dropped } = applyGroundingGate(
+      trimmed,
+      rawFacts,
+      clauses,
+    );
+
+    if (dropped.length > 0) {
+      this.logger.warn(
+        `extractor dropped ${dropped.length} fact(s) that failed span-grounding: ${dropped
+          .map((d) => `${d.predicate}="${d.claimedValueSpan}" (${d.reason})`)
+          .join('; ')}`,
+      );
+      traceArtifact('extractor.invalid_value_span', {
+        droppedCount: dropped.length,
+        dropped,
+        normalizedInputPreview: trimmed.slice(0, 200),
+      });
+    }
+    if (clauses.length > 0) traceArtifact('extractor.clauses', clauses);
+
+    const { edges: parsedEdges, dropped: droppedEdges } = validateEdges(
+      rawJson,
+      parsedEntities.length,
+      clauses,
+    );
+    if (droppedEdges.length > 0) {
+      traceArtifact('extractor.invalid_edges', { dropped: droppedEdges });
+    }
+
+    // Entity span-grounding: drop entities whose name never appears in the
+    // source, then re-index the surviving facts/edges onto the compacted
+    // entity array.
+    const groundedMask = groundEntities(trimmed, parsedEntities);
+    const remap = new Map<number, number>();
+    const entities: ExtractedEntity[] = [];
+    parsedEntities.forEach((e, i) => {
+      if (groundedMask[i]) {
+        remap.set(i, entities.length);
+        entities.push(e);
+      }
+    });
+    const facts = valueGroundedFacts
+      .filter((f) => remap.has(f.entityIndex))
+      .map((f) => ({ ...f, entityIndex: remap.get(f.entityIndex) as number }));
+    const edges = parsedEdges
+      .filter((e) => remap.has(e.fromEntityIndex) && remap.has(e.toEntityIndex))
+      .map((e) => ({
+        ...e,
+        fromEntityIndex: remap.get(e.fromEntityIndex) as number,
+        toEntityIndex: remap.get(e.toEntityIndex) as number,
+      }));
+    if (entities.length < parsedEntities.length) {
+      const droppedNames = parsedEntities
+        .filter((_, i) => !groundedMask[i])
+        .map((e) => e.name);
+      this.logger.warn(
+        `extractor dropped ${droppedNames.length} entity(ies) that failed span-grounding: ${droppedNames.join('; ')}`,
+      );
+      traceArtifact('extractor.ungrounded_entities', {
+        droppedCount: droppedNames.length,
+        names: droppedNames,
+      });
+    }
+    if (edges.length > 0) traceArtifact('extractor.edges', edges);
+
+    await this.refine.applyPredicateRefinements(facts, snapshot as never, companyId);
+
+    const result: ExtractionResult = { entities, facts, edges };
+    this.local.persistPatterns({ companyId, clauses, rawFacts, facts, edges });
+    return result;
+  }
+}

--- a/src/ai/extractor.service.ts
+++ b/src/ai/extractor.service.ts
@@ -1,53 +1,14 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import OpenAI from 'openai';
-import { Semaphore } from '../common/semaphore';
+import { Injectable, Logger } from '@nestjs/common';
 import { clampLlmInputText } from '../common/input-limits';
 import { traceArtifact } from '../common/debug-trace';
-import { withGenAiCall } from '../common/gen-ai-observability';
-import { getAbortSignal } from '../common/request-context';
-import { MetricsService } from '../metrics/metrics.service';
-import {
-  clusterKey,
-  selfConsistencyByFact,
-} from './extractor-internals/semantic-entropy';
 import {
   PredicateRegistryService,
   CORE_PREDICATES,
   PredicateDefinition,
-  PredicateSnapshot,
 } from './predicate-registry.service';
-import { LocalPredicateSelectorService } from './local-predicate-selector.service';
 import { ExtractorCacheService } from './extractor-cache.service';
-import { splitClauses } from './clause-splitter';
-import { LocalNerService } from './local-ner.service';
-import { ExtractionPatternService } from './extraction-pattern.service';
-
-import type {
-  ExtractedEntity,
-  ExtractedFact,
-  ExtractionResult,
-} from './extractor-internals/types';
-import {
-  EXTRACTION_PROMPT_HEADER,
-  buildExtractionSchema,
-  buildSystemPrompt,
-  renderPredicateCard,
-} from './extractor-internals/prompts';
-import {
-  applyGroundingGate,
-  groundEntities,
-  parseClauses,
-  parseEntities,
-  parseRawFacts,
-} from './extractor-internals/grounding';
-import { validateEdges } from './extractor-internals/edge-validator';
-import { attemptLocalSynth } from './extractor-internals/local-synth';
-import {
-  applyCanonicalizePass,
-  applyLocalPredicateOverrides,
-} from './extractor-internals/predicate-canonicalize';
-import { persistExtractionPatterns } from './extractor-internals/pattern-emitter';
+import { ExtractorRunnerService } from './extractor-runner.service';
+import type { ExtractionResult } from './extractor-internals/types';
 
 export type {
   ExtractedEntity,
@@ -59,121 +20,51 @@ export type {
 /**
  * Closed-vocabulary, span-grounded entity-and-fact extractor.
  *
- * Pipeline stages — each lives in its own module under
- * `./extractor-internals/`:
- *   1. Predicate registry snapshot + system-prompt assembly (`prompts.ts`)
- *   2. Cache lookup (existing ExtractorCacheService)
- *   3. Local pre-pass: clause split (`clause-splitter`), local NER
- *      (`local-ner.service`), skip-LLM gate via cached patterns
- *      (`local-synth.ts`)
- *   4. LLM call — this file (one OpenAI round-trip, json_schema strict)
- *   5. Response parsing + span grounding (`grounding.ts`)
- *   6. Edge validation (`edge-validator.ts`)
- *   7. Local predicate-override + EDC canonicalize
- *      (`predicate-canonicalize.ts`)
- *   8. Cache write + pattern emission (`pattern-emitter.ts`)
+ * This class is the thin entry point: input clamp, predicate-registry
+ * snapshot, extraction-cache memoisation, and delegation to
+ * ExtractorRunnerService (which sequences the local-skip / LLM /
+ * grounding / refinement / pattern-emission stages across
+ * ExtractorLlmService, ExtractorLocalService, ExtractorRefineService).
+ * Each extractor class keeps ≤3 injected deps.
  *
- * One LLM call per ingest, json_schema strict, no retry loop in the
- * hot path — server-side validation drops malformed facts and traces
- * them for offline schema iteration (PARSE recommendation).
+ * One LLM call per ingest (json_schema strict, no hot-path retry);
+ * server-side validation drops malformed facts and traces them.
  */
 export const PREDICATE_VOCABULARY = CORE_PREDICATES.map((p) => p.predicateId);
 
 @Injectable()
 export class ExtractorService {
   private readonly logger = new Logger(ExtractorService.name);
-  private readonly openai: OpenAI;
-  private readonly model: string;
-  private readonly systemPromptHeader: string;
-  private readonly limiter: Semaphore;
-  private readonly scPasses: number;
 
   constructor(
-    private readonly configService: ConfigService,
-    private readonly registry: PredicateRegistryService,
-    private readonly localPredicates: LocalPredicateSelectorService,
     private readonly extractionCache: ExtractorCacheService,
-    private readonly localNer: LocalNerService,
-    private readonly extractionPatterns: ExtractionPatternService,
-    @Optional() private readonly metrics?: MetricsService,
-  ) {
-    const timeoutMs = parseInt(
-      this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-      10,
-    );
-    const maxRetries = parseInt(
-      this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-      10,
-    );
-    this.openai = new OpenAI({
-      apiKey: this.configService.getOrThrow<string>('OPENAI_API_KEY'),
-      timeout: timeoutMs,
-      maxRetries,
-    });
-    this.model = this.configService.get<string>(
-      'OPENAI_CHAT_MODEL',
-      'gpt-4o-mini',
-    );
-    // The static EXTRACTION_SYSTEM_PROMPT override is no longer the
-    // source of truth for vocabulary — that's the registry. The env
-    // var stays as an escape hatch for operators who want to fully
-    // replace the prompt header (everything before the dynamically-
-    // rendered predicate cards).
-    this.systemPromptHeader =
-      this.configService.get<string>('EXTRACTION_SYSTEM_PROMPT') ??
-      EXTRACTION_PROMPT_HEADER;
-    this.limiter = new Semaphore(
-      parseInt(this.configService.get<string>('OPENAI_CONCURRENCY', '8'), 10),
-    );
-    // Self-consistency / N-pass driver. Default 1 = single-pass (the
-    // historical single LLM call). When EXTRACTOR_SC_PASSES > 1 the
-    // extractor fans N stochastic re-rolls in parallel and emits the
-    // dominant-cluster facts annotated with semantic entropy + cluster
-    // agreement (Farquhar Nature 2024, Nikitin NeurIPS 2024). Cost
-    // scales linearly with N — kept opt-in for that reason.
-    this.scPasses = Math.max(
-      1,
-      parseInt(this.configService.get<string>('EXTRACTOR_SC_PASSES', '1'), 10),
-    );
-  }
+    private readonly registry: PredicateRegistryService,
+    private readonly runner: ExtractorRunnerService,
+  ) {}
 
-  /**
-   * Identity of the extraction model — used as the default `source.recorder`
-   * for mention-extracted facts so source-trust can score them per model.
-   */
+  /** Identity of the extraction model — default source.recorder. */
   modelId(): string {
-    return this.model;
+    return this.runner.modelId();
   }
 
-  async extract(
-    text: string,
-    companyId: string,
-  ): Promise<ExtractionResult> {
+  async extract(text: string, companyId: string): Promise<ExtractionResult> {
     // Defence in depth — DTOs already cap at 16K, but MCP and the
     // admin-demo inline body shapes don't pass through class-validator.
-    // The cap MUST hold here too, otherwise a single rogue ingest can
-    // burn the shared OpenAI budget. See common/input-limits.ts.
-    const { value: trimmed, truncated } = clampLlmInputText(
-      text,
-      'mentionText',
-    );
+    const { value: trimmed, truncated } = clampLlmInputText(text, 'mentionText');
     if (!trimmed) return { entities: [], facts: [], edges: [] };
     if (truncated) {
       this.logger.warn(
         `extractor: input truncated to ${trimmed.length} chars (companyId=${companyId})`,
       );
-      traceArtifact('extractor.input_truncated', {
-        finalLength: trimmed.length,
-      });
+      traceArtifact('extractor.input_truncated', { finalLength: trimmed.length });
     }
 
     const snapshot = await this.loadSnapshot(companyId);
-    const systemPrompt = this.composeSystemPrompt(snapshot);
     const cacheKey = this.extractionCache.computeKey({
       text: trimmed,
       companyId,
       predicateVocabHash: snapshot.versionHash,
-      scPasses: this.scPasses,
+      scPasses: this.runner.scPasses,
     });
     const cached = this.extractionCache.get(cacheKey);
     if (cached) {
@@ -190,162 +81,10 @@ export class ExtractorService {
       registryVersionHash: snapshot.versionHash,
     });
 
-    const skipResult = await this.tryLocalSkip(companyId, trimmed, cacheKey);
-    if (skipResult) return skipResult;
-
-    traceArtifact('extractor.vocab', {
-      versionHash: snapshot.versionHash,
-      predicateCount: snapshot.active.length,
-      predicateIds: snapshot.active.map((p) => p.predicateId),
-    });
-
-    // N-pass self-consistency driver. When EXTRACTOR_SC_PASSES > 1 we
-    // run the same prompt N times with varied temperature (stochastic
-    // re-rolls), assemble per-pass extractions, then cluster facts
-    // across passes by canonical predicate + normalised object span
-    // (semantic-entropy.ts). The returned facts come from the dominant
-    // cluster of each canonical (predicate, object) tuple and carry
-    // per-fact `extractionEntropy` + `extractionAgreement` — a hallu-
-    // cinated low-agreement fact lands in a singleton cluster and
-    // gets a high-entropy tag so downstream confidence calibration
-    // can discount it.
-    if (this.scPasses > 1) {
-      return this.runMultiPassExtract({
-        companyId,
-        trimmed,
-        cacheKey,
-        snapshot,
-        systemPrompt,
-      });
-    }
-
-    const rawJson = await this.callLlm(trimmed, systemPrompt, 0.1);
-    if (!rawJson) return { entities: [], facts: [], edges: [] };
-
-    return this.assembleResult({
-      companyId,
-      trimmed,
-      cacheKey,
-      snapshot,
-      rawJson,
-    });
+    const result = await this.runner.run(trimmed, companyId, snapshot);
+    this.extractionCache.set(cacheKey, result);
+    return result;
   }
-
-  /**
-   * Run the extraction prompt N times in parallel with stepped
-   * temperatures (more variance at higher T to seed cluster spread),
-   * cluster the resulting facts, and emit a merged ExtractionResult
-   * with each surviving fact tagged by its cluster's semantic entropy
-   * + agreement rate.
-   *
-   * Entities and edges: merged across passes by dedupe-on-content (no
-   * cluster math — they're far less prone to LLM variance than the
-   * predicate/value pair, and the ingest side resolves entity
-   * identity downstream anyway via externalRefs + identity links).
-   */
-  private async runMultiPassExtract(args: {
-    companyId: string;
-    trimmed: string;
-    cacheKey: string;
-    snapshot: { versionHash: string; active: PredicateDefinition[] };
-    systemPrompt: string;
-  }): Promise<ExtractionResult> {
-    const N = this.scPasses;
-    // Even temperature spread across [0.1, 0.7]. T=0.1 is the existing
-    // single-pass setting (reproducibility anchor); the spread above it
-    // produces the variance that surfaces a hallucination as a singleton
-    // cluster. Bounded above at 0.7 — past that the LLM emits genuine
-    // schema violations the grounding gate then has to drop anyway.
-    const temperatures = Array.from(
-      { length: N },
-      (_, i) => 0.1 + (i * 0.6) / Math.max(N - 1, 1),
-    );
-
-    const rawJsons = await Promise.all(
-      temperatures.map((t) =>
-        this.callLlm(args.trimmed, args.systemPrompt, t).catch((e) => {
-          this.logger.warn(`sc-pass T=${t.toFixed(2)} failed: ${(e as Error).message}`);
-          return null;
-        }),
-      ),
-    );
-    const results = await Promise.all(
-      rawJsons.map((rj) =>
-        rj
-          ? this.assembleResult({
-              companyId: args.companyId,
-              trimmed: args.trimmed,
-              cacheKey: args.cacheKey,
-              snapshot: args.snapshot,
-              rawJson: rj,
-            })
-          : null,
-      ),
-    );
-    const surviving = results.filter((r): r is ExtractionResult => !!r);
-    if (surviving.length === 0) return { entities: [], facts: [], edges: [] };
-
-    // Cluster facts across passes.
-    const passFacts = surviving.map((r) =>
-      r.facts.map((f) => ({ predicate: f.predicate, object: f.object })),
-    );
-    const sc = selfConsistencyByFact(passFacts);
-
-    // Dedupe entities by canonical-or-name; merge edges by triple.
-    const entityKey = (e: { name: string; type: string }) =>
-      `${e.type}:${e.name.toLowerCase().trim()}`;
-    const entityMap = new Map<string, ExtractionResult['entities'][number]>();
-    for (const r of surviving) {
-      for (const e of r.entities) {
-        const k = entityKey(e);
-        if (!entityMap.has(k)) entityMap.set(k, e);
-      }
-    }
-    const entities = [...entityMap.values()];
-
-    const edgeMap = new Map<string, ExtractionResult['edges'][number]>();
-    for (const r of surviving) {
-      for (const ed of r.edges) {
-        const k = `${ed.fromEntityIndex}-${ed.kind}-${ed.toEntityIndex}`;
-        if (!edgeMap.has(k)) edgeMap.set(k, ed);
-      }
-    }
-    const edges = [...edgeMap.values()];
-
-    // Dedupe facts: one entry per (predicate, normalisedObject) cluster.
-    // Pick the first pass's variant as the exemplar so the verbatim
-    // span survives. Attach entropy + agreement.
-    const seenClusters = new Set<string>();
-    const facts: ExtractionResult['facts'] = [];
-    for (const r of surviving) {
-      for (const f of r.facts) {
-        const k = clusterKey({ predicate: f.predicate, object: f.object });
-        if (seenClusters.has(k)) continue;
-        seenClusters.add(k);
-        const stats = sc.get(k);
-        facts.push({
-          ...f,
-          ...(stats
-            ? {
-                extractionEntropy: stats.entropy,
-                extractionAgreement: stats.agreement,
-              }
-            : {}),
-        });
-      }
-    }
-
-    traceArtifact('extractor.sc_passes', {
-      passes: surviving.length,
-      temperatures,
-      clusterCount: sc.size,
-      clusterEntropy: facts[0]?.extractionEntropy ?? 0,
-    });
-
-    return { entities, facts, edges };
-  }
-
-  // ── Pre-LLM stages ────────────────────────────────────────────────
 
   private async loadSnapshot(
     companyId: string,
@@ -360,264 +99,6 @@ export class ExtractorService {
         versionHash: 'fallback-seed',
         active: CORE_PREDICATES.filter((p) => p.status === 'active'),
       };
-    }
-  }
-
-  private composeSystemPrompt(snapshot: {
-    active: PredicateDefinition[];
-  }): string {
-    return this.systemPromptHeader === EXTRACTION_PROMPT_HEADER
-      ? buildSystemPrompt(snapshot.active)
-      : this.systemPromptHeader +
-          snapshot.active.map(renderPredicateCard).join('\n');
-  }
-
-  private async tryLocalSkip(
-    companyId: string,
-    trimmed: string,
-    cacheKey: string,
-  ): Promise<ExtractionResult | null> {
-    const localClauses = splitClauses(trimmed);
-    traceArtifact('extractor.local_clauses', {
-      count: localClauses.length,
-      clauses: localClauses,
-    });
-    let localEntities: Awaited<ReturnType<LocalNerService['extract']>> = [];
-    if (this.localNer.isReady()) {
-      localEntities = await this.localNer.extract(trimmed);
-      if (localEntities.length > 0) {
-        traceArtifact('extractor.local_entities', {
-          count: localEntities.length,
-          entities: localEntities,
-        });
-      }
-    }
-    const skipEnabled =
-      this.configService.get<string>('EXTRACTOR_SKIP_LLM_ENABLED', 'false') ===
-      'true';
-    if (!skipEnabled) return null;
-    if (localClauses.length === 0) {
-      traceArtifact('extractor.skip_decision', {
-        skip: false,
-        reason: 'no_local_clauses',
-      });
-      return null;
-    }
-    if (localEntities.length === 0) {
-      traceArtifact('extractor.skip_decision', {
-        skip: false,
-        reason: 'no_local_entities',
-      });
-      return null;
-    }
-    const synthesised = await attemptLocalSynth({
-      patterns: this.extractionPatterns,
-      companyId,
-      inputText: trimmed,
-      clauseTexts: localClauses.map((c) => c.text),
-      localEntities,
-    });
-    if (!synthesised) {
-      traceArtifact('extractor.skip_decision', {
-        skip: false,
-        reason: 'partial_coverage',
-      });
-      return null;
-    }
-    traceArtifact('extractor.skip_decision', { skip: true, reason: 'all_local' });
-    this.extractionCache.set(cacheKey, synthesised);
-    return synthesised;
-  }
-
-  // ── LLM call + response assembly ──────────────────────────────────
-
-  private async callLlm(
-    trimmed: string,
-    systemPrompt: string,
-    temperature = 0.1,
-  ): Promise<any> {
-    const res = await this.limiter.run(() =>
-      withGenAiCall(
-        {
-          kind: 'chat',
-          spanName: 'gen_ai.chat.extractor',
-          system: 'openai',
-          model: this.model,
-          attrs: { 'gen_ai.request.temperature': temperature },
-        },
-        this.metrics,
-        () =>
-          this.openai.chat.completions.create(
-            {
-              model: this.model,
-              messages: [
-                { role: 'system', content: systemPrompt },
-                { role: 'user', content: trimmed },
-              ],
-              response_format: {
-                type: 'json_schema',
-                json_schema: {
-                  name: 'extraction',
-                  strict: true,
-                  schema: buildExtractionSchema(),
-                },
-              },
-              max_completion_tokens: 1500,
-              temperature,
-            },
-            { signal: getAbortSignal() },
-          ),
-      ),
-    );
-    const content = res.choices[0]?.message?.content;
-    if (!content) return null;
-    try {
-      return JSON.parse(content);
-    } catch (err) {
-      this.logger.warn(
-        `Extractor returned non-JSON: ${(err as Error).message}`,
-      );
-      return null;
-    }
-  }
-
-  private async assembleResult(args: {
-    companyId: string;
-    trimmed: string;
-    cacheKey: string;
-    snapshot: { versionHash: string; active: PredicateDefinition[] };
-    rawJson: any;
-  }): Promise<ExtractionResult> {
-    const { companyId, trimmed, cacheKey, snapshot, rawJson } = args;
-
-    const parsedEntities: ExtractedEntity[] = parseEntities(rawJson);
-    const clauses = parseClauses(rawJson);
-    const rawFacts = parseRawFacts(rawJson, parsedEntities.length);
-    const { facts: valueGroundedFacts, dropped } = applyGroundingGate(
-      trimmed,
-      rawFacts,
-      clauses,
-    );
-
-    if (dropped.length > 0) {
-      this.logger.warn(
-        `extractor dropped ${dropped.length} fact(s) that failed span-grounding: ${dropped
-          .map((d) => `${d.predicate}="${d.claimedValueSpan}" (${d.reason})`)
-          .join('; ')}`,
-      );
-      traceArtifact('extractor.invalid_value_span', {
-        droppedCount: dropped.length,
-        dropped,
-        normalizedInputPreview: trimmed.slice(0, 200),
-      });
-    }
-    if (clauses.length > 0) traceArtifact('extractor.clauses', clauses);
-
-    const { edges: parsedEdges, dropped: droppedEdges } = validateEdges(
-      rawJson,
-      parsedEntities.length,
-      clauses,
-    );
-    if (droppedEdges.length > 0) {
-      traceArtifact('extractor.invalid_edges', { dropped: droppedEdges });
-    }
-
-    // Entity span-grounding: drop entities whose name never appears in the
-    // source, then re-index the surviving facts/edges onto the compacted
-    // entity array. Ingest creates EVERY returned entity (not only those a
-    // fact references), so an ungrounded name would otherwise materialise a
-    // hallucinated entity record.
-    const groundedMask = groundEntities(trimmed, parsedEntities);
-    const remap = new Map<number, number>();
-    const entities: ExtractedEntity[] = [];
-    parsedEntities.forEach((e, i) => {
-      if (groundedMask[i]) {
-        remap.set(i, entities.length);
-        entities.push(e);
-      }
-    });
-    const facts = valueGroundedFacts
-      .filter((f) => remap.has(f.entityIndex))
-      .map((f) => ({ ...f, entityIndex: remap.get(f.entityIndex) as number }));
-    const edges = parsedEdges
-      .filter(
-        (e) => remap.has(e.fromEntityIndex) && remap.has(e.toEntityIndex),
-      )
-      .map((e) => ({
-        ...e,
-        fromEntityIndex: remap.get(e.fromEntityIndex) as number,
-        toEntityIndex: remap.get(e.toEntityIndex) as number,
-      }));
-    if (entities.length < parsedEntities.length) {
-      const droppedNames = parsedEntities
-        .filter((_, i) => !groundedMask[i])
-        .map((e) => e.name);
-      this.logger.warn(
-        `extractor dropped ${droppedNames.length} entity(ies) that failed span-grounding: ${droppedNames.join('; ')}`,
-      );
-      traceArtifact('extractor.ungrounded_entities', {
-        droppedCount: droppedNames.length,
-        names: droppedNames,
-      });
-    }
-    if (edges.length > 0) traceArtifact('extractor.edges', edges);
-
-    await this.applyPredicateRefinements(facts, snapshot, companyId);
-
-    const result: ExtractionResult = { entities, facts, edges };
-    this.extractionCache.set(cacheKey, result);
-
-    void persistExtractionPatterns({
-      patterns: this.extractionPatterns,
-      logger: this.logger,
-      companyId,
-      clauses,
-      rawFacts,
-      facts,
-      edges,
-    });
-
-    return result;
-  }
-
-  private async applyPredicateRefinements(
-    facts: ExtractedFact[],
-    snapshot: { versionHash: string; active: PredicateDefinition[] },
-    companyId: string,
-  ): Promise<void> {
-    const localThreshold = parseFloat(
-      this.configService.get<string>(
-        'EXTRACTOR_LOCAL_PREDICATE_THRESHOLD',
-        '0.45',
-      ),
-    );
-    const localOverrides = await applyLocalPredicateOverrides({
-      facts,
-      snapshot: snapshot as PredicateSnapshot,
-      selector: this.localPredicates,
-      threshold: localThreshold,
-    });
-    if (localOverrides.length > 0) {
-      traceArtifact('extractor.local_predicate_override', {
-        threshold: localThreshold,
-        decisions: localOverrides,
-      });
-    }
-    try {
-      if (facts.length === 0) return;
-      const decisions = await applyCanonicalizePass({
-        facts,
-        registry: this.registry,
-        companyId,
-        logger: this.logger,
-      });
-      if (decisions.length > 0) {
-        traceArtifact('extractor.canonicalize', decisions);
-      }
-    } catch (e) {
-      this.logger.warn(
-        `extractor: canonicalize pass failed: ${(e as Error).message}; keeping model-emitted predicates`,
-      );
     }
   }
 }

--- a/test/extractor-prompt-injection.unit-spec.ts
+++ b/test/extractor-prompt-injection.unit-spec.ts
@@ -16,6 +16,10 @@
  * the extractor output is sanitised.
  */
 import { ExtractorService } from '../src/ai/extractor.service';
+import { ExtractorRunnerService } from '../src/ai/extractor-runner.service';
+import { ExtractorLlmService } from '../src/ai/extractor-llm.service';
+import { ExtractorLocalService } from '../src/ai/extractor-local.service';
+import { ExtractorRefineService } from '../src/ai/extractor-refine.service';
 
 function mkExtractor(scriptedLlmResponse: any): ExtractorService {
   const config = {
@@ -50,17 +54,13 @@ function mkExtractor(scriptedLlmResponse: any): ExtractorService {
     lookup: async () => undefined,
     record: async () => {},
   } as any;
-  const svc = new ExtractorService(
-    config,
-    registry,
-    localPredicates,
-    extractionCache,
-    localNer,
-    extractionPatterns,
-  );
-  (svc as any).callLlm = async () => scriptedLlmResponse;
-  (svc as any).tryLocalSkip = async () => null;
-  return svc;
+  const llm = new ExtractorLlmService(config);
+  (llm as any).callLlm = async () => scriptedLlmResponse;
+  const local = new ExtractorLocalService(localNer, extractionPatterns);
+  (local as any).trySkip = async () => null;
+  const refine = new ExtractorRefineService(registry, localPredicates);
+  const runner = new ExtractorRunnerService(llm, local, refine);
+  return new ExtractorService(extractionCache, registry, runner);
 }
 
 describe('ExtractorService — prompt injection resistance', () => {

--- a/test/extractor-sc-passes.unit-spec.ts
+++ b/test/extractor-sc-passes.unit-spec.ts
@@ -9,6 +9,10 @@
  * produced the entropy because the extractor only ran N=1.
  */
 import { ExtractorService } from '../src/ai/extractor.service';
+import { ExtractorRunnerService } from '../src/ai/extractor-runner.service';
+import { ExtractorLlmService } from '../src/ai/extractor-llm.service';
+import { ExtractorLocalService } from '../src/ai/extractor-local.service';
+import { ExtractorRefineService } from '../src/ai/extractor-refine.service';
 
 function mkExtractor(scPasses: number, scripted: any[]): ExtractorService {
   const config = {
@@ -47,22 +51,18 @@ function mkExtractor(scPasses: number, scripted: any[]): ExtractorService {
     record: async () => {},
   } as any;
 
-  const svc = new ExtractorService(
-    config,
-    registry,
-    localPredicates,
-    extractionCache,
-    localNer,
-    extractionPatterns,
-  );
+  const llm = new ExtractorLlmService(config);
   // Replace the private callLlm with a scripted stub. The driver
   // calls callLlm once per pass; scripted[i] is returned on pass i.
   let call = 0;
-  (svc as any).callLlm = async () => scripted[call++ % scripted.length];
-  // Also short-circuit tryLocalSkip so the test exercises the LLM
-  // / multi-pass branch directly.
-  (svc as any).tryLocalSkip = async () => null;
-  return svc;
+  (llm as any).callLlm = async () => scripted[call++ % scripted.length];
+  const local = new ExtractorLocalService(localNer, extractionPatterns);
+  // Short-circuit trySkip so the test exercises the LLM / multi-pass
+  // branch directly.
+  (local as any).trySkip = async () => null;
+  const refine = new ExtractorRefineService(registry, localPredicates);
+  const runner = new ExtractorRunnerService(llm, local, refine);
+  return new ExtractorService(extractionCache, registry, runner);
 }
 
 describe('ExtractorService N-pass driver', () => {


### PR DESCRIPTION
## What
`ExtractorService` injected 7 deps (config, registry, localPredicates, extractionCache, localNer, extractionPatterns, metrics). The pipeline's collaborators are a web (cache/registry/local/llm reused across the skip + assembly paths), so strict ≤3 needs a nested split:
- **ExtractorLlmService** (config, metrics) — OpenAI client, system-prompt assembly, scPasses, callLlm.
- **ExtractorLocalService** (localNer, extractionPatterns) — skip-LLM local fast path + post-assembly pattern emission (skip flag via env).
- **ExtractorRefineService** (registry, localPredicates) — predicate override + EDC canonicalize (threshold via env).
- **ExtractorRunnerService** (llm, local, refine) — the engine: skip → LLM (single / N-pass SC) → grounding/validation → refine → persist.
- **ExtractorService** (extractionCache, registry, runner) — input clamp, snapshot load, cache memoisation; delegates.

Each class ≤3 deps. Public `extract()`/`modelId()` unchanged.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
- `pnpm test:unit` 700/700 ✓ · `pnpm test:e2e` 128/128 ✓ (sc-passes + prompt-injection specs build the chain + patch sub-services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)