### PR TITLE
refactor(jobs): split WorkerLoopService into dispatcher/poller/loop (max-params 2/3)

### DIFF
--- a/src/jobs/job-dispatcher.service.ts
+++ b/src/jobs/job-dispatcher.service.ts
@@ -1,0 +1,199 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { context, propagation, trace, SpanStatusCode } from '@opentelemetry/api';
+import { JobClaimService, type JobClaim } from './job-claim.service';
+import { JobWorkerPool } from './job-worker-pool.service';
+import { MetricsService } from '../metrics/metrics.service';
+import type { RegisteredHandler } from './worker-loop.types';
+
+/**
+ * JobDispatcherService — runs a single claimed job to completion. Owns
+ * the renew loop (which doubles as the cross-pod cancel poll), the
+ * handler/worker-pool invocation, OTel consumer span, and the terminal
+ * complete / fail / cancelled write. The poll loop + leader election live
+ * in WorkerPollerService / WorkerLoopService, which pass the pod-shutdown
+ * AbortSignal in. Splitting this out keeps every worker class ≤3 deps.
+ */
+@Injectable()
+export class JobDispatcherService {
+  private readonly logger = new Logger(JobDispatcherService.name);
+
+  constructor(
+    private readonly claim: JobClaimService,
+    @Optional() private readonly workerPool?: JobWorkerPool,
+    @Optional() private readonly metrics?: MetricsService,
+  ) {}
+
+  /**
+   * Run a single claim. `shutdownSignal` propagates a pod shutdown into
+   * the handler's own AbortController.
+   *
+   * OTel: extract the producer-side traceparent injected at enqueue
+   * (when present) and run the whole dispatch inside that context so the
+   * consumer span links back.
+   */
+  async dispatch(
+    claim: JobClaim,
+    reg: RegisteredHandler,
+    shutdownSignal: AbortSignal,
+  ): Promise<void> {
+    const parentCtx = claim.traceparent
+      ? propagation.extract(context.active(), {
+          traceparent: claim.traceparent,
+        })
+      : context.active();
+    return context.with(parentCtx, () =>
+      this.dispatchInner(claim, reg, shutdownSignal),
+    );
+  }
+
+  private async dispatchInner(
+    claim: JobClaim,
+    reg: RegisteredHandler,
+    shutdownSignal: AbortSignal,
+  ): Promise<void> {
+    const tracer = trace.getTracer('inite-brain-service');
+    const span = tracer.startSpan(`jobs.process ${claim.jobType}`, {
+      attributes: {
+        'messaging.system': 'surrealdb',
+        'messaging.operation': 'process',
+        'messaging.destination.name': claim.jobType,
+        'messaging.destination.kind': 'queue',
+        'messaging.message.id': claim.runId,
+        'job.companyId': claim.companyId,
+        'job.attempts': claim.attempts,
+        'job.workerId': this.claim.identity(),
+        'job.cpuBound': reg.cpuBound === true,
+      },
+    });
+    try {
+      await context.with(trace.setSpan(context.active(), span), () =>
+        this.dispatchBody(claim, reg, span, shutdownSignal),
+      );
+    } finally {
+      span.end();
+    }
+  }
+
+  private async dispatchBody(
+    claim: JobClaim,
+    reg: RegisteredHandler,
+    consumerSpan: ReturnType<ReturnType<typeof trace.getTracer>['startSpan']>,
+    shutdownSignal: AbortSignal,
+  ): Promise<void> {
+    const handlerAbort = new AbortController();
+    const startedAt = Date.now();
+    // Mirrors the span's `job.outcome`. Defaults to 'failed' so an
+    // unexpected throw before any branch is counted as a failure, not lost.
+    let outcome: 'succeeded' | 'failed' | 'cancelled' | 'lost_claim' = 'failed';
+    // Pod shutdown propagates into the handler.
+    const onShutdown = () => handlerAbort.abort(new Error('pod_shutdown'));
+    shutdownSignal.addEventListener('abort', onShutdown, { once: true });
+    // Renew every ttl/3. The renew result tells us if the row was
+    // reaped out from under us OR if an operator requested cancel.
+    let cancelRequested = false;
+    let lostClaim = false;
+    const renewIntervalMs = Math.max(
+      1000,
+      Math.floor((reg.ttlSeconds * 1000) / 3),
+    );
+    const renewTimer = setInterval(() => {
+      void (async () => {
+        const r = await this.claim.renew({
+          companyId: claim.companyId,
+          recordId: claim.recordId,
+          ttlSeconds: reg.ttlSeconds,
+        });
+        if (!r.stillOwned) {
+          lostClaim = true;
+          handlerAbort.abort(new Error('lost_claim'));
+        } else if (r.cancelRequested && !cancelRequested) {
+          cancelRequested = true;
+          handlerAbort.abort(new Error('cancel_requested'));
+        }
+      })();
+    }, renewIntervalMs);
+    try {
+      const ctx = {
+        runId: claim.runId,
+        jobType: claim.jobType,
+        companyId: claim.companyId,
+        payload: claim.payload,
+        attempts: claim.attempts,
+        abortSignal: handlerAbort.signal,
+        workerId: this.claim.identity(),
+      };
+      const result =
+        reg.cpuBound && reg.workerModule && this.workerPool?.enabled()
+          ? await this.workerPool.run(reg.workerModule, {
+              runId: ctx.runId,
+              jobType: ctx.jobType,
+              companyId: ctx.companyId,
+              payload: ctx.payload,
+              attempts: ctx.attempts,
+              workerId: ctx.workerId,
+            })
+          : await reg.handler(ctx);
+      clearInterval(renewTimer);
+      if (cancelRequested) {
+        consumerSpan.setAttribute('job.outcome', 'cancelled');
+        outcome = 'cancelled';
+        await this.claim.cancelled({
+          companyId: claim.companyId,
+          recordId: claim.recordId,
+          result: (result as Record<string, unknown>) ?? undefined,
+        });
+      } else if (lostClaim) {
+        // Don't write — another worker owns the row now. The
+        // duplicate-work cost was already paid; just bail.
+        consumerSpan.setAttribute('job.outcome', 'lost_claim');
+        outcome = 'lost_claim';
+        this.logger.warn(
+          `Claim ${claim.runId} lost mid-handler; skipping terminal write`,
+        );
+      } else {
+        consumerSpan.setAttribute('job.outcome', 'succeeded');
+        outcome = 'succeeded';
+        await this.claim.complete({
+          companyId: claim.companyId,
+          recordId: claim.recordId,
+          result: (result as Record<string, unknown>) ?? undefined,
+        });
+      }
+    } catch (err) {
+      clearInterval(renewTimer);
+      const e = err as Error;
+      consumerSpan.recordException(e);
+      if (cancelRequested) {
+        consumerSpan.setAttribute('job.outcome', 'cancelled');
+        outcome = 'cancelled';
+        await this.claim.cancelled({
+          companyId: claim.companyId,
+          recordId: claim.recordId,
+          result: { reason: 'cancel_requested', message: e.message },
+        });
+      } else if (lostClaim) {
+        consumerSpan.setAttribute('job.outcome', 'lost_claim');
+        outcome = 'lost_claim';
+        this.logger.warn(
+          `Claim ${claim.runId} lost mid-handler (handler threw): ${e.message}`,
+        );
+      } else {
+        consumerSpan.setAttribute('job.outcome', 'failed');
+        outcome = 'failed';
+        consumerSpan.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
+        await this.claim.fail({
+          companyId: claim.companyId,
+          recordId: claim.recordId,
+          attempts: claim.attempts,
+          error: { message: e.message, name: e.name },
+          requeue: true,
+          maxAttempts: reg.maxAttempts,
+        });
+      }
+    } finally {
+      shutdownSignal.removeEventListener('abort', onShutdown);
+      const elapsed = (Date.now() - startedAt) / 1000;
+      this.metrics?.recordJob(claim.jobType, outcome, elapsed);
+    }
+  }
+}

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -4,6 +4,8 @@ import { JobRunService } from './job-run.service';
 import { JobClaimService } from './job-claim.service';
 import { LeaderLeaseService } from './leader-lease.service';
 import { WorkerLoopService } from './worker-loop.service';
+import { WorkerPollerService } from './worker-poller.service';
+import { JobDispatcherService } from './job-dispatcher.service';
 import { LeaseManagerService } from './lease-manager.service';
 import { JobReaperService } from './job-reaper.service';
 import { JobWorkerPool } from './job-worker-pool.service';
@@ -34,6 +36,8 @@ import { DistributedLeaseGuard } from '../common/distributed-lease.guard';
     JobRunService,
     JobClaimService,
     LeaderLeaseService,
+    JobDispatcherService,
+    WorkerPollerService,
     WorkerLoopService,
     LeaseManagerService,
     JobReaperService,

--- a/src/jobs/worker-loop.service.ts
+++ b/src/jobs/worker-loop.service.ts
@@ -1,164 +1,62 @@
 import {
-  Inject,
   Injectable,
   Logger,
-  OnApplicationShutdown,
-  OnModuleInit,
   Optional,
+  OnModuleInit,
+  OnApplicationShutdown,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { context, propagation, trace, SpanStatusCode } from '@opentelemetry/api';
-import { ApiKeyService } from '../auth/api-key.service';
-import { JobClaimService, type JobClaim } from './job-claim.service';
 import { LeaderLeaseService } from './leader-lease.service';
-import { JobWorkerPool } from './job-worker-pool.service';
 import { MetricsService } from '../metrics/metrics.service';
+import { WorkerPollerService } from './worker-poller.service';
 import type { JobType } from './job-run.service';
+import type { PollControl, RegisteredHandler } from './worker-loop.types';
 
-export interface JobContext {
-  runId: string;
-  jobType: JobType;
-  companyId: string;
-  payload: Record<string, unknown> | null;
-  attempts: number;
-  /**
-   * Aborts on: (a) handler exceeded leaseUntil and lost the claim;
-   * (b) operator flipped cancelRequested via /admin/jobs/:id/cancel;
-   * (c) pod shutdown. Handlers MUST pass this into long-running
-   * primitives (fetch / OpenAI client / Surreal queries) so cancel
-   * actually terminates the work instead of just flagging the row.
-   */
-  abortSignal: AbortSignal;
-  /** For structured logs: pod identity that won the claim. */
-  workerId: string;
-}
-
-export type JobHandler = (
-  ctx: JobContext,
-) => Promise<Record<string, unknown> | void>;
-
-interface RegisteredHandler {
-  jobType: JobType;
-  handler: JobHandler;
-  /** Per-claim lease TTL — should be longer than typical handler runtime. */
-  ttlSeconds: number;
-  /** Max attempts before terminal-fail. */
-  maxAttempts: number;
-  /**
-   * Route to JobWorkerPool instead of running in-thread. Required
-   * companion: workerModule pointing at a CommonJS module that
-   * exports `run(input): Promise<output>`.
-   */
-  cpuBound?: boolean;
-  workerModule?: string;
-}
+export type { JobContext, JobHandler } from './worker-loop.types';
 
 /**
- * WorkerLoopService — drains the `job_run` queue across known tenants.
+ * WorkerLoopService — leader election + handler registry + lifecycle for
+ * the job_run queue worker. Holds the @Cron-less lease loop: it acquires
+ * the worker_loop lease, and while leader spins up one WorkerPollerService
+ * loop per registered jobType. The poll/claim mechanics live in
+ * WorkerPollerService and the per-job dispatch in JobDispatcherService —
+ * this class keeps ≤3 injected deps (poller, lease, metrics).
  *
- * Lifecycle:
- *   1. Modules register handlers in their onModuleInit:
- *        workerLoop.register('dreams', dreamsHandler, { ttlSeconds: 600 })
- *   2. After all handlers register, this service acquires the
- *      `worker_loop` leader_lease and starts one polling loop per
- *      registered jobType.
- *   3. Each poll iterates the known tenants in random order and tries
- *      claimNext(companyId, jobType). On a hit, dispatches with a
- *      renew interval that doubles as the cross-pod cancel poll.
- *   4. On shutdown: signal AbortController, release the leader_lease,
- *      let any in-flight handler observe the abort and exit.
- *
- * One pod runs the loop at a time. The other pods sit idle on a
- * try-acquire-every-N-seconds tick, ready to take over within ~ttl
- * when the leader dies. CAS on claimNext is still the ultimate
- * defence — even if two pods both thought they were leader for a
- * heartbeat-window, only one wins the CAS.
- *
- * Phase J ships ONE worker pod runs ALL job types. Phase K will lift
- * CPU-bound handlers (BGE-M3 reindex, multi-pass extractor) into a
- * worker_threads pool; the JobDispatcher will choose per-handler
- * based on a `cpuBound: true` flag in the registration.
- *
- * Tenant iteration is random per poll to give weak fairness — a
- * noisy tenant with a backlog can't monopolise claim attention.
- * Per-tenant weighted-shuffle (Inngest pattern) is Phase K.
+ * register() is the public surface module-owner services call from their
+ * onModuleInit; the registry must be complete before the lease loop spins
+ * up. Cadence/enabled flags read from the environment.
  */
 @Injectable()
-export class WorkerLoopService
-  implements OnModuleInit, OnApplicationShutdown
-{
+export class WorkerLoopService implements OnModuleInit, OnApplicationShutdown {
   private readonly logger = new Logger(WorkerLoopService.name);
   private readonly handlers = new Map<JobType, RegisteredHandler>();
-  private readonly enabled: boolean;
-  private readonly pollIntervalMs: number;
-  private readonly leaseRenewIntervalMs: number;
-  private readonly emptyPollBackoffMs: number;
+  private readonly enabled =
+    (process.env.WORKER_LOOP_ENABLED ?? '1') !== '0';
+  private readonly leaseRenewIntervalMs = parseInt(
+    process.env.WORKER_LOOP_LEASE_RENEW_MS ?? '30000',
+    10,
+  );
   private readonly abortController = new AbortController();
   private leaseTimer: NodeJS.Timeout | null = null;
   private isLeader = false;
   private loopsStarted = false;
-  /**
-   * Sliding-window per-tenant recent-claim counters keyed by
-   * `${jobType}::${companyId}`. The pollLoop bumps the counter on
-   * each successful claim AND naturally decays them via the
-   * scheduleClaimDecay loop. Used by sampleByFairness to give an
-   * underclaimed tenant a higher chance of being tried first in
-   * the next poll cycle — bounded, simple counter rather than a
-   * full priority queue.
-   */
-  private readonly recentClaims = new Map<string, number>();
-  private decayTimer: NodeJS.Timeout | null = null;
 
   constructor(
-    config: ConfigService,
-    @Optional() private readonly claim?: JobClaimService,
+    private readonly poller: WorkerPollerService,
     @Optional() private readonly lease?: LeaderLeaseService,
-    @Optional() private readonly apiKeys?: ApiKeyService,
-    @Optional() @Inject('WORKER_LOOP_NOW') private readonly now?: () => number,
-    @Optional() private readonly workerPool?: JobWorkerPool,
     @Optional() private readonly metrics?: MetricsService,
-  ) {
-    this.enabled =
-      (config.get<string>('WORKER_LOOP_ENABLED', '1') ?? '1') !== '0';
-    this.pollIntervalMs = parseInt(
-      config.get<string>('WORKER_LOOP_POLL_MS', '1000') ?? '1000',
-      10,
-    );
-    this.emptyPollBackoffMs = parseInt(
-      config.get<string>('WORKER_LOOP_EMPTY_BACKOFF_MS', '5000') ?? '5000',
-      10,
-    );
-    // Renew/acquire the leader_lease every 30s. ttl=90s gives a
-    // crashed leader's lease ~90s to expire — short enough for fast
-    // failover, long enough to survive GC pauses.
-    this.leaseRenewIntervalMs = parseInt(
-      config.get<string>('WORKER_LOOP_LEASE_RENEW_MS', '30000') ?? '30000',
-      10,
-    );
-  }
+  ) {}
 
   /**
    * Register a handler for a job type. Called from module-owner
-   * services' onModuleInit so we have a complete registry by the
-   * time the leader loop spins up.
+   * services' onModuleInit so the registry is complete by the time the
+   * leader loop spins up.
    */
   register(
     jobType: JobType,
-    handler: JobHandler,
+    handler: RegisteredHandler['handler'],
     opts?: {
       ttlSeconds?: number;
       maxAttempts?: number;
-      /**
-       * Set true to dispatch via JobWorkerPool. Required companion:
-       * workerModule — absolute path to a CommonJS file that
-       * `export run(input): Promise<output>`. The pool's worker
-       * thread dynamic-imports it once per pool slot and caches.
-       *
-       * The handler argument still runs as a fallback when the pool
-       * is disabled (JOB_WORKER_POOL_SIZE=0) or all workers crashed
-       * — keep it functionally equivalent so dev / test mode without
-       * the pool isn't a different code path.
-       */
       cpuBound?: boolean;
       workerModule?: string;
     },
@@ -199,35 +97,23 @@ export class WorkerLoopService
       this.logger.log('Worker loop disabled (WORKER_LOOP_ENABLED=0)');
       return;
     }
-    if (!this.claim) {
+    if (!this.poller.hasClaim) {
       this.logger.warn('JobClaimService not available — worker loop inert');
       return;
     }
-    // Defer the first lease acquisition by one tick so module-owners
-    // get a chance to register their handlers in their own onModuleInit
+    // Defer the first lease acquisition by one tick so module-owners get
+    // a chance to register their handlers in their own onModuleInit
     // before we start polling for jobs we can't dispatch.
     this.leaseTimer = setTimeout(
       () => void this.tryBecomeLeader(),
       this.leaseRenewIntervalMs / 6, // 5s by default
     );
-    // Decay recent-claim counters every 30s so a tenant that's been
-    // quiet for one window gets its weight back, but a tenant that's
-    // been hot needs ~2 windows of silence to fully reset. Multiplier
-    // 0.5 chosen so the exponential decay halves the count per tick.
-    this.decayTimer = setInterval(() => {
-      for (const [key, n] of this.recentClaims) {
-        const next = Math.floor(n * 0.5);
-        if (next <= 0) this.recentClaims.delete(key);
-        else this.recentClaims.set(key, next);
-      }
-    }, 30_000);
-    // Don't keep the event loop alive just for decay.
-    if (this.decayTimer.unref) this.decayTimer.unref();
+    this.poller.startDecay();
   }
 
   async onApplicationShutdown(): Promise<void> {
     if (this.leaseTimer) clearTimeout(this.leaseTimer);
-    if (this.decayTimer) clearInterval(this.decayTimer);
+    this.poller.stopDecay();
     this.abortController.abort();
     this.metrics?.setWorkerLeader(false);
     if (this.isLeader && this.lease) {
@@ -240,10 +126,6 @@ export class WorkerLoopService
     this.logger.log('Worker loop shut down');
   }
 
-  /**
-   * Acquire-or-renew the worker_loop lease, then spin up per-jobType
-   * polling loops once. Re-runs every leaseRenewIntervalMs.
-   */
   private async tryBecomeLeader(): Promise<void> {
     if (this.abortController.signal.aborted) return;
     if (!this.lease) {
@@ -274,11 +156,14 @@ export class WorkerLoopService
     this.metrics?.setWorkerLeader(this.isLeader);
     if (this.isLeader && !this.loopsStarted) {
       this.loopsStarted = true;
+      const control: PollControl = {
+        isLeader: () => this.isLeader,
+        signal: this.abortController.signal,
+      };
       for (const reg of this.handlers.values()) {
-        void this.pollLoop(reg);
+        void this.poller.runLoop(reg, control);
       }
     }
-    // Re-schedule the next lease check.
     if (!this.abortController.signal.aborted) {
       this.leaseTimer = setTimeout(
         () => void this.tryBecomeLeader(),
@@ -286,296 +171,4 @@ export class WorkerLoopService
       );
     }
   }
-
-  /**
-   * Per-jobType polling loop. Runs while this pod holds the lease.
-   *
-   * Tenant iteration: sampleByFairness() gives a weighted random
-   * order where weight = 1/(1+recentClaims[tenant]). A tenant that's
-   * just landed N successful claims gets weight 1/(N+1) for the next
-   * cycle, so a hot tenant can't monopolise the loop — quiet
-   * neighbours get tried first. Mirrors the "weighted-shuffle peek"
-   * pattern Inngest uses for queue fairness, scaled down to per-pod
-   * in-memory counters (we only need fairness within ONE leader
-   * pod's view; multi-pod scale is gated by leader_lease anyway).
-   *
-   * On empty queue across all tenants, back off to
-   * emptyPollBackoffMs so we don't hammer Surreal.
-   */
-  private async pollLoop(reg: RegisteredHandler): Promise<void> {
-    this.logger.log(`Poll loop started for jobType=${reg.jobType}`);
-    while (!this.abortController.signal.aborted) {
-      if (!this.isLeader) {
-        // Lost leadership mid-loop; sleep until renew tick reinstates us.
-        await sleep(this.leaseRenewIntervalMs, this.abortController.signal);
-        continue;
-      }
-      let claimed: JobClaim | null = null;
-      try {
-        const tenants = this.sampleByFairness(
-          reg.jobType,
-          this.apiKeys?.knownCompanyIds() ?? [],
-        );
-        for (const companyId of tenants) {
-          if (this.abortController.signal.aborted || !this.isLeader) break;
-          claimed = await this.claim!.claimNext({
-            companyId,
-            jobType: reg.jobType,
-            ttlSeconds: reg.ttlSeconds,
-          });
-          if (claimed) {
-            this.recordClaim(reg.jobType, companyId);
-            break;
-          }
-        }
-      } catch (e) {
-        this.logger.warn(
-          `claim cycle (${reg.jobType}) failed: ${(e as Error).message}`,
-        );
-      }
-      if (claimed) {
-        await this.dispatch(claimed, reg);
-      } else {
-        await sleep(this.emptyPollBackoffMs, this.abortController.signal);
-      }
-      // Always yield a beat so a tight loop can't starve the event loop.
-      await sleep(this.pollIntervalMs, this.abortController.signal);
-    }
-    this.logger.log(`Poll loop stopped for jobType=${reg.jobType}`);
-  }
-
-  /**
-   * Run a single claim. Owns the renew interval (which doubles as the
-   * cross-pod cancel poll), wraps the handler in an AbortController,
-   * and routes the outcome to complete / fail / cancelled.
-   *
-   * OTel: extract the producer-side traceparent injected at enqueue
-   * (when present) and run the whole dispatch inside that context so
-   * the consumer span links back. With OTEL_ENABLED=0 the API surface
-   * is a no-op tracer and the wrap costs essentially nothing.
-   */
-  private async dispatch(
-    claim: JobClaim,
-    reg: RegisteredHandler,
-  ): Promise<void> {
-    const parentCtx = claim.traceparent
-      ? propagation.extract(context.active(), {
-          traceparent: claim.traceparent,
-        })
-      : context.active();
-    return context.with(parentCtx, () => this.dispatchInner(claim, reg));
-  }
-
-  private async dispatchInner(
-    claim: JobClaim,
-    reg: RegisteredHandler,
-  ): Promise<void> {
-    const tracer = trace.getTracer('inite-brain-service');
-    const span = tracer.startSpan(`jobs.process ${claim.jobType}`, {
-      attributes: {
-        'messaging.system': 'surrealdb',
-        'messaging.operation': 'process',
-        'messaging.destination.name': claim.jobType,
-        'messaging.destination.kind': 'queue',
-        'messaging.message.id': claim.runId,
-        'job.companyId': claim.companyId,
-        'job.attempts': claim.attempts,
-        'job.workerId': this.claim!.identity(),
-        'job.cpuBound': reg.cpuBound === true,
-      },
-    });
-    try {
-      await context.with(trace.setSpan(context.active(), span), () =>
-        this.dispatchBody(claim, reg, span),
-      );
-    } finally {
-      span.end();
-    }
-  }
-
-  private async dispatchBody(
-    claim: JobClaim,
-    reg: RegisteredHandler,
-    consumerSpan: ReturnType<ReturnType<typeof trace.getTracer>['startSpan']>,
-  ): Promise<void> {
-    const handlerAbort = new AbortController();
-    const startedAt = this.now?.() ?? Date.now();
-    // Mirrors the span's `job.outcome`. Defaults to 'failed' so an
-    // unexpected throw before any branch is counted as a failure, not lost.
-    let outcome: 'succeeded' | 'failed' | 'cancelled' | 'lost_claim' = 'failed';
-    // Pod shutdown propagates into the handler.
-    const onShutdown = () => handlerAbort.abort(new Error('pod_shutdown'));
-    this.abortController.signal.addEventListener('abort', onShutdown, {
-      once: true,
-    });
-    // Renew every ttl/3. The renew result tells us if the row was
-    // reaped out from under us OR if an operator requested cancel.
-    let cancelRequested = false;
-    let lostClaim = false;
-    const renewIntervalMs = Math.max(
-      1000,
-      Math.floor((reg.ttlSeconds * 1000) / 3),
-    );
-    const renewTimer = setInterval(() => {
-      void (async () => {
-        const r = await this.claim!.renew({
-          companyId: claim.companyId,
-          recordId: claim.recordId,
-          ttlSeconds: reg.ttlSeconds,
-        });
-        if (!r.stillOwned) {
-          lostClaim = true;
-          handlerAbort.abort(new Error('lost_claim'));
-        } else if (r.cancelRequested && !cancelRequested) {
-          cancelRequested = true;
-          handlerAbort.abort(new Error('cancel_requested'));
-        }
-      })();
-    }, renewIntervalMs);
-    try {
-      const ctx = {
-        runId: claim.runId,
-        jobType: claim.jobType,
-        companyId: claim.companyId,
-        payload: claim.payload,
-        attempts: claim.attempts,
-        abortSignal: handlerAbort.signal,
-        workerId: this.claim!.identity(),
-      };
-      // CPU-bound path: hand off to JobWorkerPool. The worker thread
-      // receives only the serialisable subset of ctx — abortSignal /
-      // workerId stay in-process and surface to the handler as a
-      // cooperative cancel marker via an extra check after the
-      // postMessage completes.
-      const result =
-        reg.cpuBound && reg.workerModule && this.workerPool?.enabled()
-          ? await this.workerPool.run(reg.workerModule, {
-              runId: ctx.runId,
-              jobType: ctx.jobType,
-              companyId: ctx.companyId,
-              payload: ctx.payload,
-              attempts: ctx.attempts,
-              workerId: ctx.workerId,
-            })
-          : await reg.handler(ctx);
-      clearInterval(renewTimer);
-      if (cancelRequested) {
-        consumerSpan.setAttribute('job.outcome', 'cancelled');
-        outcome = 'cancelled';
-        await this.claim!.cancelled({
-          companyId: claim.companyId,
-          recordId: claim.recordId,
-          result: (result as Record<string, unknown>) ?? undefined,
-        });
-      } else if (lostClaim) {
-        // Don't write — another worker owns the row now. The
-        // duplicate-work cost was already paid; just bail.
-        consumerSpan.setAttribute('job.outcome', 'lost_claim');
-        outcome = 'lost_claim';
-        this.logger.warn(
-          `Claim ${claim.runId} lost mid-handler; skipping terminal write`,
-        );
-      } else {
-        consumerSpan.setAttribute('job.outcome', 'succeeded');
-        outcome = 'succeeded';
-        await this.claim!.complete({
-          companyId: claim.companyId,
-          recordId: claim.recordId,
-          result: (result as Record<string, unknown>) ?? undefined,
-        });
-      }
-    } catch (err) {
-      clearInterval(renewTimer);
-      const e = err as Error;
-      consumerSpan.recordException(e);
-      if (cancelRequested) {
-        consumerSpan.setAttribute('job.outcome', 'cancelled');
-        outcome = 'cancelled';
-        await this.claim!.cancelled({
-          companyId: claim.companyId,
-          recordId: claim.recordId,
-          result: { reason: 'cancel_requested', message: e.message },
-        });
-      } else if (lostClaim) {
-        consumerSpan.setAttribute('job.outcome', 'lost_claim');
-        outcome = 'lost_claim';
-        this.logger.warn(
-          `Claim ${claim.runId} lost mid-handler (handler threw): ${e.message}`,
-        );
-      } else {
-        consumerSpan.setAttribute('job.outcome', 'failed');
-        outcome = 'failed';
-        consumerSpan.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
-        await this.claim!.fail({
-          companyId: claim.companyId,
-          recordId: claim.recordId,
-          attempts: claim.attempts,
-          error: { message: e.message, name: e.name },
-          requeue: true,
-          maxAttempts: reg.maxAttempts,
-        });
-      }
-    } finally {
-      this.abortController.signal.removeEventListener('abort', onShutdown);
-      const elapsed = ((this.now?.() ?? Date.now()) - startedAt) / 1000;
-      this.metrics?.recordJob(claim.jobType, outcome, elapsed);
-    }
-  }
-
-  /**
-   * Weighted-random tenant ordering. Lower recentClaims → higher
-   * weight → more likely to be tried first this cycle. Uses Efraimidis-
-   * Spirakis weighted sampling: assign each tenant key = u^(1/weight),
-   * sort descending. Equivalent to weighted shuffle without
-   * replacement, O(n log n).
-   *
-   * Pure for test-time isolation: extracted to a method so the unit
-   * test can drive it with a seeded RNG and assert the ordering
-   * actually reflects the recent-claim counters.
-   */
-  sampleByFairness(jobType: JobType, tenants: readonly string[]): string[] {
-    if (tenants.length <= 1) return [...tenants];
-    const keyed = tenants.map((companyId) => {
-      const n = this.recentClaims.get(`${jobType}::${companyId}`) ?? 0;
-      const weight = 1 / (1 + n);
-      // u → (0,1); key = u^(1/weight). Higher weight pushes key
-      // toward 1 (more likely to win the sort).
-      const u = Math.random();
-      const key = Math.pow(u, 1 / weight);
-      return { companyId, key };
-    });
-    keyed.sort((a, b) => b.key - a.key);
-    return keyed.map((k) => k.companyId);
-  }
-
-  /** Bump the recent-claim counter — bounded to 64 so a runaway
-   *  tenant doesn't permanently zero its weight (decay still works
-   *  but starting from 64 means 7 decay ticks to fully reset, ~3.5
-   *  minutes at the default 30s decay cadence). */
-  private recordClaim(jobType: JobType, companyId: string): void {
-    const key = `${jobType}::${companyId}`;
-    const next = Math.min((this.recentClaims.get(key) ?? 0) + 1, 64);
-    this.recentClaims.set(key, next);
-  }
-
-  /** Read-only — test seam + observability. */
-  recentClaimsSnapshot(): Record<string, number> {
-    return Object.fromEntries(this.recentClaims);
-  }
 }
-
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    if (signal?.aborted) return resolve();
-    const t = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      clearTimeout(t);
-      resolve();
-    };
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
-}
-

--- a/src/jobs/worker-loop.types.ts
+++ b/src/jobs/worker-loop.types.ts
@@ -1,0 +1,46 @@
+import type { JobType } from './job-run.service';
+
+/** Execution context handed to a registered job handler. */
+export interface JobContext {
+  runId: string;
+  jobType: JobType;
+  companyId: string;
+  payload: Record<string, unknown> | null;
+  attempts: number;
+  /**
+   * Aborts on: (a) handler exceeded leaseUntil and lost the claim;
+   * (b) operator flipped cancelRequested via /admin/jobs/:id/cancel;
+   * (c) pod shutdown. Handlers MUST pass this into long-running
+   * primitives (fetch / OpenAI client / Surreal queries) so cancel
+   * actually terminates the work instead of just flagging the row.
+   */
+  abortSignal: AbortSignal;
+  /** For structured logs: pod identity that won the claim. */
+  workerId: string;
+}
+
+export type JobHandler = (
+  ctx: JobContext,
+) => Promise<Record<string, unknown> | void>;
+
+export interface RegisteredHandler {
+  jobType: JobType;
+  handler: JobHandler;
+  /** Per-claim lease TTL — should be longer than typical handler runtime. */
+  ttlSeconds: number;
+  /** Max attempts before terminal-fail. */
+  maxAttempts: number;
+  /**
+   * Route to JobWorkerPool instead of running in-thread. Required
+   * companion: workerModule pointing at a CommonJS module that
+   * exports `run(input): Promise<output>`.
+   */
+  cpuBound?: boolean;
+  workerModule?: string;
+}
+
+/** Leader/lifecycle control surface the poller reads on each cycle. */
+export interface PollControl {
+  isLeader: () => boolean;
+  signal: AbortSignal;
+}

--- a/src/jobs/worker-poller.service.ts
+++ b/src/jobs/worker-poller.service.ts
@@ -1,0 +1,151 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { withSpan } from '../common/tracing';
+import { ApiKeyService } from '../auth/api-key.service';
+import { JobClaimService, type JobClaim } from './job-claim.service';
+import { JobDispatcherService } from './job-dispatcher.service';
+import type { JobType } from './job-run.service';
+import type { PollControl, RegisteredHandler } from './worker-loop.types';
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) return resolve();
+    const t = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(t);
+      resolve();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * WorkerPollerService — the per-jobType polling loop with weighted-fair
+ * tenant ordering. Claims the next job for a fair tenant and hands it to
+ * JobDispatcherService. Leadership + the pod-shutdown signal are supplied
+ * by WorkerLoopService via the PollControl handle. Owns the recent-claim
+ * fairness counters (+ their decay). Splitting it out keeps every worker
+ * class ≤3 deps. Poll cadences read from the environment.
+ */
+@Injectable()
+export class WorkerPollerService {
+  private readonly logger = new Logger(WorkerPollerService.name);
+  private readonly pollIntervalMs = parseInt(
+    process.env.WORKER_LOOP_POLL_MS ?? '1000',
+    10,
+  );
+  private readonly emptyPollBackoffMs = parseInt(
+    process.env.WORKER_LOOP_EMPTY_BACKOFF_MS ?? '5000',
+    10,
+  );
+  private readonly recentClaims = new Map<string, number>();
+  private decayTimer: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly dispatcher: JobDispatcherService,
+    @Optional() private readonly claim?: JobClaimService,
+    @Optional() private readonly apiKeys?: ApiKeyService,
+  ) {}
+
+  get hasClaim(): boolean {
+    return !!this.claim;
+  }
+
+  /** Decay recent-claim counters so a quiet tenant regains weight. */
+  startDecay(): void {
+    if (this.decayTimer) return;
+    this.decayTimer = setInterval(() => {
+      for (const [key, n] of this.recentClaims) {
+        const next = Math.floor(n * 0.5);
+        if (next <= 0) this.recentClaims.delete(key);
+        else this.recentClaims.set(key, next);
+      }
+    }, 30_000);
+    if (this.decayTimer.unref) this.decayTimer.unref();
+  }
+
+  stopDecay(): void {
+    if (this.decayTimer) clearInterval(this.decayTimer);
+    this.decayTimer = null;
+  }
+
+  /**
+   * Per-jobType polling loop. Runs while the pod holds the lease (per
+   * control.isLeader). On empty queue across all tenants, backs off.
+   */
+  async runLoop(reg: RegisteredHandler, control: PollControl): Promise<void> {
+    this.logger.log(`Poll loop started for jobType=${reg.jobType}`);
+    while (!control.signal.aborted) {
+      if (!control.isLeader()) {
+        // Lost leadership mid-loop; sleep until renew tick reinstates us.
+        await sleep(this.pollIntervalMs, control.signal);
+        continue;
+      }
+      let claimed: JobClaim | null = null;
+      try {
+        const tenants = this.sampleByFairness(
+          reg.jobType,
+          this.apiKeys?.knownCompanyIds() ?? [],
+        );
+        for (const companyId of tenants) {
+          if (control.signal.aborted || !control.isLeader()) break;
+          claimed = await this.claim!.claimNext({
+            companyId,
+            jobType: reg.jobType,
+            ttlSeconds: reg.ttlSeconds,
+          });
+          if (claimed) {
+            this.recordClaim(reg.jobType, companyId);
+            break;
+          }
+        }
+      } catch (e) {
+        this.logger.warn(
+          `claim cycle (${reg.jobType}) failed: ${(e as Error).message}`,
+        );
+      }
+      if (claimed) {
+        await withSpan('jobs.dispatch', () =>
+          this.dispatcher.dispatch(claimed!, reg, control.signal),
+        );
+      } else {
+        await sleep(this.emptyPollBackoffMs, control.signal);
+      }
+      // Always yield a beat so a tight loop can't starve the event loop.
+      await sleep(this.pollIntervalMs, control.signal);
+    }
+    this.logger.log(`Poll loop stopped for jobType=${reg.jobType}`);
+  }
+
+  /**
+   * Weighted-random tenant ordering (Efraimidis-Spirakis). Lower
+   * recentClaims → higher weight → more likely tried first this cycle.
+   * Public for test-time isolation.
+   */
+  sampleByFairness(jobType: JobType, tenants: readonly string[]): string[] {
+    if (tenants.length <= 1) return [...tenants];
+    const keyed = tenants.map((companyId) => {
+      const n = this.recentClaims.get(`${jobType}::${companyId}`) ?? 0;
+      const weight = 1 / (1 + n);
+      const u = Math.random();
+      const key = Math.pow(u, 1 / weight);
+      return { companyId, key };
+    });
+    keyed.sort((a, b) => b.key - a.key);
+    return keyed.map((k) => k.companyId);
+  }
+
+  /** Bump the recent-claim counter — bounded to 64. */
+  private recordClaim(jobType: JobType, companyId: string): void {
+    const key = `${jobType}::${companyId}`;
+    const next = Math.min((this.recentClaims.get(key) ?? 0) + 1, 64);
+    this.recentClaims.set(key, next);
+  }
+
+  /** Read-only — test seam + observability. */
+  recentClaimsSnapshot(): Record<string, number> {
+    return Object.fromEntries(this.recentClaims);
+  }
+}

--- a/test/jobs-otel.unit-spec.ts
+++ b/test/jobs-otel.unit-spec.ts
@@ -12,15 +12,7 @@
  */
 import { context, propagation } from '@opentelemetry/api';
 import { JobClaimService } from '../src/jobs/job-claim.service';
-import { WorkerLoopService } from '../src/jobs/worker-loop.service';
-import { ConfigService } from '@nestjs/config';
-
-function makeConfig(env: Record<string, string> = {}): ConfigService {
-  return {
-    get: <T>(key: string, dflt?: T) => (env[key] ?? dflt) as T,
-    getOrThrow: <T>(key: string) => env[key] as unknown as T,
-  } as unknown as ConfigService;
-}
+import { JobDispatcherService } from '../src/jobs/job-dispatcher.service';
 
 describe('Jobs OTel handoff — wire contract', () => {
   it('enqueue includes traceparent: $traceparent in the CREATE statement when the propagator injects one', async () => {
@@ -77,7 +69,7 @@ describe('Jobs OTel handoff — wire contract', () => {
       fail: jest.fn(async () => ({ requeued: false })),
       cancelled: jest.fn(async () => undefined),
     };
-    const loop = new WorkerLoopService(makeConfig(), claimSvc as any);
+    const loop = new JobDispatcherService(claimSvc as any);
 
     let handlerRan = false;
     const reg = {
@@ -99,7 +91,7 @@ describe('Jobs OTel handoff — wire contract', () => {
       leaseUntil: '2030-01-01T00:05:00Z',
       traceparent: fakeTraceparent,
     };
-    await (loop as any).dispatch(claim, reg);
+    await (loop as any).dispatch(claim, reg, new AbortController().signal);
 
     // Without an SDK registered, trace.getActiveSpan() returns undefined
     // (no-op API surface). The contract verified here is that dispatch
@@ -123,7 +115,7 @@ describe('Jobs OTel handoff — wire contract', () => {
       fail: jest.fn(async () => ({ requeued: false })),
       cancelled: jest.fn(async () => undefined),
     };
-    const loop = new WorkerLoopService(makeConfig(), claimSvc as any);
+    const loop = new JobDispatcherService(claimSvc as any);
     const claim = {
       recordId: 'job_run:noparent',
       runId: 'run-2',
@@ -139,7 +131,7 @@ describe('Jobs OTel handoff — wire contract', () => {
       ttlSeconds: 3,
       maxAttempts: 3,
     };
-    await (loop as any).dispatch(claim, reg);
+    await (loop as any).dispatch(claim, reg, new AbortController().signal);
     expect(claimSvc.complete).toHaveBeenCalled();
   });
 

--- a/test/worker-loop.unit-spec.ts
+++ b/test/worker-loop.unit-spec.ts
@@ -1,29 +1,17 @@
 /**
- * Unit coverage for WorkerLoopService — the leader-elected polling
- * loop that drains the job_run queue. We assert:
- *
- *   - register() collects handlers
- *   - dispatch routes return-value to complete(), thrown to fail()
- *   - dispatch routes thrown-after-cancelRequest to cancelled()
- *   - dispatch routes thrown-after-lost-claim to neither (skip write)
+ * Unit coverage for the worker-loop trio after the max-params split:
+ *   - WorkerLoopService.register collects handlers
+ *   - JobDispatcherService routes return-value→complete, thrown→fail,
+ *     thrown-after-cancel→cancelled, thrown-after-lost-claim→neither
  *   - renew tick polls cancelRequested + propagates into AbortSignal
- *   - onApplicationShutdown aborts in-flight handlers
- *
- * The polling loop itself is exercised indirectly — we drive
- * dispatch() through the private path via a thin test harness that
- * doesn't require a real LeaderLease or the lease-acquire cron.
+ *   - the shutdown AbortSignal aborts in-flight handlers
+ *   - WorkerPollerService.sampleByFairness weighting
  */
-import { ConfigService } from '@nestjs/config';
 import { WorkerLoopService } from '../src/jobs/worker-loop.service';
+import { WorkerPollerService } from '../src/jobs/worker-poller.service';
+import { JobDispatcherService } from '../src/jobs/job-dispatcher.service';
 import type { JobClaim } from '../src/jobs/job-claim.service';
 import type { JobType } from '../src/jobs/job-run.service';
-
-function makeConfig(env: Record<string, string | undefined> = {}): ConfigService {
-  return {
-    get: <T>(key: string, dflt?: T) => (env[key] ?? dflt) as T,
-    getOrThrow: <T>(key: string) => env[key] as unknown as T,
-  } as unknown as ConfigService;
-}
 
 function makeClaimSvc(opts: {
   renewSequence?: Array<{ stillOwned: boolean; cancelRequested: boolean }>;
@@ -42,19 +30,13 @@ function makeClaimSvc(opts: {
     renew: jest.fn(async (input: { recordId: string }) => {
       calls.renewed.push({ recordId: input.recordId });
       const seq = opts.renewSequence ?? [];
-      return (
-        seq[renewIdx++] ?? { stillOwned: true, cancelRequested: false }
-      );
+      return seq[renewIdx++] ?? { stillOwned: true, cancelRequested: false };
     }),
     complete: jest.fn(async (input: { recordId: string; result?: unknown }) => {
       calls.completed.push({ recordId: input.recordId, result: input.result });
     }),
     fail: jest.fn(
-      async (input: {
-        recordId: string;
-        attempts: number;
-        error: unknown;
-      }) => {
+      async (input: { recordId: string; attempts: number; error: unknown }) => {
         calls.failed.push({
           recordId: input.recordId,
           attempts: input.attempts,
@@ -64,10 +46,7 @@ function makeClaimSvc(opts: {
       },
     ),
     cancelled: jest.fn(async (input: { recordId: string; result?: unknown }) => {
-      calls.cancelled.push({
-        recordId: input.recordId,
-        result: input.result,
-      });
+      calls.cancelled.push({ recordId: input.recordId, result: input.result });
     }),
     enqueue: jest.fn(),
     reapZombies: jest.fn(),
@@ -94,17 +73,26 @@ function makeJobClaim(opts: {
   };
 }
 
-// We need to reach the private dispatch() method from tests because
-// the full polling loop is hard to drive deterministically with real
-// timers. Cast to any to grant access — this is unit-level coverage
-// of the dispatch contract.
-function callDispatch(svc: WorkerLoopService, claim: JobClaim, reg: any) {
-  return (svc as any).dispatch(claim, reg);
+function mkDispatcher(claimSvc: unknown, metrics?: unknown): JobDispatcherService {
+  return new JobDispatcherService(
+    claimSvc as never,
+    undefined,
+    metrics as never,
+  );
+}
+
+function callDispatch(
+  dispatcher: JobDispatcherService,
+  claim: JobClaim,
+  reg: any,
+  signal: AbortSignal = new AbortController().signal,
+) {
+  return dispatcher.dispatch(claim, reg, signal);
 }
 
 describe('WorkerLoopService.register', () => {
   it('collects handlers by jobType and exposes registeredTypes()', () => {
-    const svc = new WorkerLoopService(makeConfig());
+    const svc = new WorkerLoopService(undefined as never);
     svc.register('dreams', async () => ({}));
     svc.register('compaction', async () => ({}));
     expect(svc.registeredTypes()).toEqual(
@@ -114,21 +102,17 @@ describe('WorkerLoopService.register', () => {
   });
 });
 
-describe('WorkerLoopService.dispatch', () => {
+describe('JobDispatcherService.dispatch', () => {
   it('routes a successful handler result to complete()', async () => {
     const claim = makeJobClaim();
     const claimSvc = makeClaimSvc();
-    const svc = new WorkerLoopService(
-      makeConfig(),
-      claimSvc as any,
-    );
     const reg = {
       jobType: 'dreams' as JobType,
       handler: async () => ({ ok: true }),
       ttlSeconds: 3,
       maxAttempts: 3,
     };
-    await callDispatch(svc, claim, reg);
+    await callDispatch(mkDispatcher(claimSvc), claim, reg);
     expect(claimSvc.calls.completed).toHaveLength(1);
     expect(claimSvc.calls.completed[0].recordId).toBe('job_run:abc');
     expect(claimSvc.calls.completed[0].result).toEqual({ ok: true });
@@ -139,18 +123,7 @@ describe('WorkerLoopService.dispatch', () => {
     const claim = makeJobClaim({ jobType: 'dreams' });
     const claimSvc = makeClaimSvc();
     const recordJob = jest.fn();
-    // metrics is the 7th constructor arg (config, claim, lease, apiKeys,
-    // now, workerPool, metrics).
-    const svc = new WorkerLoopService(
-      makeConfig(),
-      claimSvc as any,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      { recordJob, setWorkerLeader: jest.fn() } as any,
-    );
-    await callDispatch(svc, claim, {
+    await callDispatch(mkDispatcher(claimSvc, { recordJob }), claim, {
       jobType: 'dreams' as JobType,
       handler: async () => ({ ok: true }),
       ttlSeconds: 3,
@@ -167,7 +140,6 @@ describe('WorkerLoopService.dispatch', () => {
   it('routes a thrown handler error to fail()', async () => {
     const claim = makeJobClaim({ attempts: 2 });
     const claimSvc = makeClaimSvc();
-    const svc = new WorkerLoopService(makeConfig(), claimSvc as any);
     const reg = {
       jobType: 'dreams' as JobType,
       handler: async () => {
@@ -176,7 +148,7 @@ describe('WorkerLoopService.dispatch', () => {
       ttlSeconds: 3,
       maxAttempts: 3,
     };
-    await callDispatch(svc, claim, reg);
+    await callDispatch(mkDispatcher(claimSvc), claim, reg);
     expect(claimSvc.calls.failed).toHaveLength(1);
     expect(claimSvc.calls.failed[0].attempts).toBe(2);
     expect((claimSvc.calls.failed[0].error as Error).message).toBe(
@@ -186,13 +158,9 @@ describe('WorkerLoopService.dispatch', () => {
 
   it('routes cancel-requested → cancelled() not failed()', async () => {
     const claim = makeJobClaim();
-    // First renew tick reports cancelRequested=true; this should
-    // propagate into the handler's AbortSignal and route the throw
-    // to cancelled() instead of fail().
     const claimSvc = makeClaimSvc({
       renewSequence: [{ stillOwned: true, cancelRequested: true }],
     });
-    const svc = new WorkerLoopService(makeConfig(), claimSvc as any);
     let sawAbort = false;
     const reg = {
       jobType: 'dreams' as JobType,
@@ -202,14 +170,13 @@ describe('WorkerLoopService.dispatch', () => {
             sawAbort = true;
             resolve();
           });
-          // Allow the renew interval to fire.
         });
         throw new Error('aborted');
       },
       ttlSeconds: 1, // → renew tick every ttl/3 = 333ms
       maxAttempts: 3,
     };
-    await callDispatch(svc, claim, reg);
+    await callDispatch(mkDispatcher(claimSvc), claim, reg);
     expect(sawAbort).toBe(true);
     expect(claimSvc.calls.cancelled).toHaveLength(1);
     expect(claimSvc.calls.failed).toHaveLength(0);
@@ -218,11 +185,9 @@ describe('WorkerLoopService.dispatch', () => {
 
   it('skips terminal write when claim is lost mid-handler', async () => {
     const claim = makeJobClaim();
-    // Renew reports stillOwned=false — zombie reaper took the row.
     const claimSvc = makeClaimSvc({
       renewSequence: [{ stillOwned: false, cancelRequested: false }],
     });
-    const svc = new WorkerLoopService(makeConfig(), claimSvc as any);
     const reg = {
       jobType: 'dreams' as JobType,
       handler: async (ctx: any) => {
@@ -234,9 +199,7 @@ describe('WorkerLoopService.dispatch', () => {
       ttlSeconds: 1,
       maxAttempts: 3,
     };
-    await callDispatch(svc, claim, reg);
-    // We should not have written complete, fail, OR cancelled — the
-    // new owner does that.
+    await callDispatch(mkDispatcher(claimSvc), claim, reg);
     expect(claimSvc.calls.completed).toHaveLength(0);
     expect(claimSvc.calls.failed).toHaveLength(0);
     expect(claimSvc.calls.cancelled).toHaveLength(0);
@@ -245,7 +208,6 @@ describe('WorkerLoopService.dispatch', () => {
   it('completed handler receives a workerId in ctx', async () => {
     const claim = makeJobClaim();
     const claimSvc = makeClaimSvc();
-    const svc = new WorkerLoopService(makeConfig(), claimSvc as any);
     let observedWorkerId = '';
     const reg = {
       jobType: 'dreams' as JobType,
@@ -256,16 +218,14 @@ describe('WorkerLoopService.dispatch', () => {
       ttlSeconds: 3,
       maxAttempts: 3,
     };
-    await callDispatch(svc, claim, reg);
+    await callDispatch(mkDispatcher(claimSvc), claim, reg);
     expect(observedWorkerId).toBe('host-test#42');
   });
-});
 
-describe('WorkerLoopService.onApplicationShutdown', () => {
-  it('aborts in-flight handlers', async () => {
+  it('aborts in-flight handlers when the shutdown signal fires', async () => {
     const claim = makeJobClaim();
     const claimSvc = makeClaimSvc();
-    const svc = new WorkerLoopService(makeConfig(), claimSvc as any);
+    const ac = new AbortController();
     let sawAbort = false;
     const reg = {
       jobType: 'dreams' as JobType,
@@ -281,9 +241,8 @@ describe('WorkerLoopService.onApplicationShutdown', () => {
       ttlSeconds: 3,
       maxAttempts: 3,
     };
-    const dispatched = callDispatch(svc, claim, reg);
-    // Trigger shutdown — the dispatch's onShutdown listener aborts.
-    setTimeout(() => void svc.onApplicationShutdown(), 5);
+    const dispatched = callDispatch(mkDispatcher(claimSvc), claim, reg, ac.signal);
+    setTimeout(() => ac.abort(), 5);
     await dispatched;
     expect(sawAbort).toBe(true);
   });
@@ -291,37 +250,32 @@ describe('WorkerLoopService.onApplicationShutdown', () => {
 
 describe('WorkerLoopService.leader', () => {
   it('reports false until lease is acquired (default state)', () => {
-    const svc = new WorkerLoopService(makeConfig());
+    const svc = new WorkerLoopService(undefined as never);
     expect(svc.leader()).toBe(false);
   });
 });
 
-describe('WorkerLoopService.sampleByFairness', () => {
+describe('WorkerPollerService.sampleByFairness', () => {
   it('returns single-element list unchanged', () => {
-    const svc = new WorkerLoopService(makeConfig());
+    const svc = new WorkerPollerService(undefined as never);
     expect(svc.sampleByFairness('dreams', ['co_only'])).toEqual(['co_only']);
   });
 
   it('returns empty list unchanged', () => {
-    const svc = new WorkerLoopService(makeConfig());
+    const svc = new WorkerPollerService(undefined as never);
     expect(svc.sampleByFairness('dreams', [])).toEqual([]);
   });
 
   it('all tenants get sampled exactly once (permutation)', () => {
-    const svc = new WorkerLoopService(makeConfig());
+    const svc = new WorkerPollerService(undefined as never);
     const tenants = ['a', 'b', 'c', 'd'];
     const out = svc.sampleByFairness('dreams', tenants);
     expect([...out].sort()).toEqual([...tenants].sort());
   });
 
   it('heavily-claimed tenants are sampled later on average', () => {
-    const svc = new WorkerLoopService(makeConfig());
+    const svc = new WorkerPollerService(undefined as never);
     const tenants = ['busy', 'quiet'];
-    // Simulate busy tenant landing many recent claims.
-    // We can't poke recentClaims directly without exposing internals,
-    // but the test still inspects the statistical property via
-    // recordClaim through the dispatch path. Use the public
-    // recentClaimsSnapshot as a fixture point.
     for (let i = 0; i < 32; i++) {
       (svc as any).recordClaim('dreams', 'busy');
     }
@@ -331,14 +285,11 @@ describe('WorkerLoopService.sampleByFairness', () => {
       const out = svc.sampleByFairness('dreams', tenants);
       if (out[0] === 'busy') busyFirst++;
     }
-    // With weight(quiet)=1 vs weight(busy)=1/33, quiet should win
-    // first place ≫ 50% of the time. Allow a generous floor (60%)
-    // to keep the test stable across RNG flake.
     expect(busyFirst).toBeLessThan(trials * 0.4);
   });
 
   it('recentClaimsSnapshot reflects recordClaim writes', () => {
-    const svc = new WorkerLoopService(makeConfig());
+    const svc = new WorkerPollerService(undefined as never);
     (svc as any).recordClaim('dreams', 'co_a');
     (svc as any).recordClaim('dreams', 'co_a');
     (svc as any).recordClaim('compaction', 'co_b');
@@ -348,7 +299,7 @@ describe('WorkerLoopService.sampleByFairness', () => {
   });
 
   it('recordClaim is bounded at 64', () => {
-    const svc = new WorkerLoopService(makeConfig());
+    const svc = new WorkerPollerService(undefined as never);
     for (let i = 0; i < 100; i++) {
       (svc as any).recordClaim('dreams', 'co_a');
     }


### PR DESCRIPTION
## What
`WorkerLoopService` injected 7 deps (`now`/WORKER_LOOP_NOW was a never-provided dead seam). Three-way split:
- **JobDispatcherService** (claim, workerPool, metrics) — runs one claim to completion: renew/cancel poll, handler/worker-pool invoke, OTel span, terminal complete/fail/cancelled. Takes the shutdown `AbortSignal` in.
- **WorkerPollerService** (dispatcher, claim, apiKeys) — per-jobType poll loop with weighted-fair tenant ordering + recent-claim decay; cadences via env.
- **WorkerLoopService** (poller, lease, metrics) — leader election, handler registry, lifecycle; owns the abortController + passes its signal via `PollControl`.

Shared types moved to `worker-loop.types.ts` (re-exported). `register()`/`registeredTypes()`/`leader()` unchanged. Each class ≤3 deps.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
- `pnpm test:unit` 700/700 ✓ · `pnpm test:e2e` 128/128 ✓ · `pnpm test:e2e:jobs` 9/9 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)