### PR TITLE
fix(jobs): dispatchBody options object (max-params)

### DIFF
--- a/src/jobs/job-dispatcher.service.ts
+++ b/src/jobs/job-dispatcher.service.ts
@@ -67,19 +67,24 @@ export class JobDispatcherService {
     });
     try {
       await context.with(trace.setSpan(context.active(), span), () =>
-        this.dispatchBody(claim, reg, span, shutdownSignal),
+        this.dispatchBody({ claim, reg, consumerSpan: span, shutdownSignal }),
       );
     } finally {
       span.end();
     }
   }
 
-  private async dispatchBody(
-    claim: JobClaim,
-    reg: RegisteredHandler,
-    consumerSpan: ReturnType<ReturnType<typeof trace.getTracer>['startSpan']>,
-    shutdownSignal: AbortSignal,
-  ): Promise<void> {
+  private async dispatchBody({
+    claim,
+    reg,
+    consumerSpan,
+    shutdownSignal,
+  }: {
+    claim: JobClaim;
+    reg: RegisteredHandler;
+    consumerSpan: ReturnType<ReturnType<typeof trace.getTracer>['startSpan']>;
+    shutdownSignal: AbortSignal;
+  }): Promise<void> {
     const handlerAbort = new AbortController();
     const startedAt = Date.now();
     // Mirrors the span's `job.outcome`. Defaults to 'failed' so an


### PR DESCRIPTION
## What
The #65 worker-loop split left `JobDispatcherService.dispatchBody` with 4 positional params (claim, reg, consumerSpan, shutdownSignal) — it would trip the planned `max-params=3` gate at flip time. Collapse to a single destructured options object. No behaviour change.

## Verification
- `pnpm exec tsc --noEmit` ✓ · `pnpm lint` ✓ · worker-loop + jobs-otel unit 19/19 ✓ · jobs-e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)