### PR TITLE
refactor(lint): flip max-params gate 8→3, exempt decorated route handlers (3/3)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,8 +28,10 @@ import globals from 'globals';
  *   - `max-classes-per-file` (1)     — one class per module file.
  *     Helper types/interfaces ok; multiple @Injectable classes in one
  *     file is a Single Responsibility smell.
- *   - `max-params` (8)               — argument-list bloat. Past 8 the
- *     callee almost certainly wants a typed config object.
+ *   - `max-params` (3)               — argument-list bloat. Past 3 the
+ *     callee wants a typed options object; DI constructors past 3 want a
+ *     responsibility split. The only exemptions are decorated HTTP route
+ *     handlers (@Query/@Param/@Body bindings), marked per-line.
  *   - `complexity` (25)              — cyclomatic complexity per fn.
  *   - `sonarjs/cognitive-complexity` (30) — readability-weighted variant.
  *
@@ -48,7 +50,7 @@ const sizeGates = {
     { max: 200, skipBlankLines: true, skipComments: true, IIFEs: true },
   ],
   'max-classes-per-file': ['error', 1],
-  'max-params': ['error', 8],
+  'max-params': ['error', 3],
   complexity: ['error', 25],
   'sonarjs/cognitive-complexity': ['error', 30],
 };

--- a/src/admin/admin-jobs.controller.ts
+++ b/src/admin/admin-jobs.controller.ts
@@ -97,6 +97,7 @@ export class AdminJobsController {
     private readonly config: ConfigService,
   ) {}
 
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get('jobs')
   @RequireScopes('brain:admin')
   async listJobs(

--- a/src/admin/admin-ops.controller.ts
+++ b/src/admin/admin-ops.controller.ts
@@ -82,6 +82,7 @@ export class AdminOpsController {
 
   // ── Forgotten ─────────────────────────────────────────────
 
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get('forgotten')
   @RequireScopes('brain:admin')
   async forgotten(
@@ -156,6 +157,7 @@ export class AdminOpsController {
 
   // ── Operator action log ───────────────────────────────────
 
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get('operator-actions')
   @RequireScopes('brain:admin')
   async operatorActions(

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -85,6 +85,7 @@ export class AdminController {
    * (capped at 500). Returns aggregate totals and hourly buckets so
    * the UI can render charts without a second round-trip.
    */
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get('audit')
   @RequireScopes('brain:admin')
   async audit(

--- a/src/communities/communities.controller.ts
+++ b/src/communities/communities.controller.ts
@@ -25,6 +25,7 @@ export class CommunitiesController {
     return { communities };
   }
 
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get('search')
   @RequireScopes('brain:read')
   async search(

--- a/src/entities/entities.controller.ts
+++ b/src/entities/entities.controller.ts
@@ -33,6 +33,7 @@ export class EntitiesController {
     });
   }
 
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Param/@Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get(':id/timeline')
   @RequireScopes('brain:read')
   async getTimeline(
@@ -50,6 +51,7 @@ export class EntitiesController {
     });
   }
 
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Param/@Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get(':id/connections')
   @RequireScopes('brain:read')
   async getConnections(


### PR DESCRIPTION
## What

**Final step of the `max-params=3` program.** With all 18 god-classes split (≤3 DI deps each, PRs #51–#69) and all helper functions objectified (#49), the eslint gate flips from `['error', 8]` → `['error', 3]`.

The only methods that legitimately exceed 3 params are **7 decorated HTTP route handlers** whose params are `@Query` / `@Param` / `@Req` bindings — folding them into an options object would break Nest's parameter resolution. Each now carries a per-line `// eslint-disable-next-line max-params -- decorated HTTP route handler`:

- `admin-jobs.controller` → `@Get('jobs')`
- `admin-ops.controller` → `@Get('forgotten')`, `@Get('operator-actions')`
- `admin.controller` → `@Get('audit')`
- `communities.controller` → `@Get('search')`
- `entities.controller` → `@Get(':id/timeline')`, `@Get(':id/connections')`

`eslint.config.mjs` `sizeGates` doc-block updated to reflect the new ceiling + the route-handler exemption.

## Verification
- `pnpm lint` clean under **gate = 3** across all `src/**`
- `pnpm exec tsc --noEmit` · `pnpm typecheck` ✓
- 700 unit ✓ · 128 e2e ✓ · 9 jobs e2e ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)