### PR TITLE
feat(code-memory): Phase 0 — record_decision/why MCP tools + code-decision predicate pack

### DIFF
--- a/docs/roadmap/code-memory-domain.md
+++ b/docs/roadmap/code-memory-domain.md
@@ -1,0 +1,122 @@
+# Code-memory domain — design brief + phased plan
+
+> Self-contained brief. A **DomainPack** that makes brain remember the *why*
+> of a codebase — decisions, rationale, invariants/gotchas, evolution — as
+> typed bitemporal facts anchored to code, **without re-indexing the code
+> itself** (that is derived state and the job of a code-search indexer like
+> codeindexer.dev). Built on brain's existing primitives, not a new pipeline.
+
+## Thesis
+
+Brain is an invariant memory substrate (bitemporal typed facts + conflict
+resolution + graph edges + procedural memory, SurrealDB-backed, MCP-exposed).
+A codebase's *structure* (symbols, call graph, imports) is **derived state** —
+reconstructable from source at any commit, the domain of a local code indexer.
+What is **not** recoverable from the source is the engineering *why*:
+
+- decisions and their rationale ("resolve facts through one gateway because 21
+  positional args drifted between call-sites")
+- invariants and gotchas ("always export a new @Injectable from the @Global
+  module or e2e DI-boot goes red")
+- the evolution of contracts over time (when/why a signature changed)
+- rejected alternatives and agreements
+
+This is exactly what a human maintainer keeps in their head and what we already
+hand-curate in `MEMORY.md`. The code-memory domain captures it automatically,
+typed, with provenance and time.
+
+## SOTA grounding (deep-research, 2026-06; 25/25 claims verified 3-0)
+
+| Pattern | Source | What we take |
+|---|---|---|
+| Auto-capture, two tiers (repo facts vs user prefs), side-effect of activity, summary-first/full-on-demand | GitHub Copilot Memory; OpenHands skills/microagents | capture is automatic + tiered; load summaries, fetch full on demand |
+| Citation + just-in-time validation (re-check anchor vs current branch; invalidate, don't delete) | Copilot Memory eng blog | each fact carries a code anchor; stale anchor → `validUntil`, never delete |
+| Bitemporal invalidate-not-delete (t_valid/t_invalid + transaction time) | Graphiti / Zep (arXiv 2501.13956) | **already brain's model** — confirmed SOTA; reuse `fn::resolve_fact` |
+| Anchor OUTSIDE the file, hybrid edit-track + LLM semantic re-anchor, NOT offsets | Codetations (2504.18702), Magic Markup (2403.03481) | no in-code clutter; semantic re-anchor; avoid line/position anchors |
+| Capture from VCS artifacts (commits/PRs/issues/review) | IBM "Code Insights" (ASE 2025); CoMRAT (MSR 2025) | trigger on PR-merge; Decision/Rationale/Supporting-Facts taxonomy = predicate schema |
+| SCIP human-readable string symbol IDs, not LSIF numeric | Sourcegraph SCIP | anchor by `pkg/namespace/symbol`, survives moves, incremental re-validation |
+| Triple-level provenance (per-change agent/time/artifact) | PROV-STAR / Dibowski (FOIS 2024) | extend `source` to {agent, artifact, cause} at fact granularity |
+| Eval beyond pass-rate: design-constraint compliance | SWE-Shield (arXiv 2604.05955) | measure whether stored "why" raises agent design-compliance, not just recall |
+
+**Avoid:** positional/line-offset anchors; delete-on-invalid (Catseye's failure
+under `git pull`/Prettier); re-indexing the whole codebase; trusting LLM
+`valid_at` without guards (Graphiti issue #1489); LSIF numeric IDs.
+
+## Data model — on existing brain primitives
+
+Nothing new at the storage layer; this is an ontology + thin convenience tools.
+
+- **Entities**
+  - `code_anchor` — a knowledge_entity whose externalRef is a SCIP-style symbol
+    string `code:<pkg>/<namespace>/<symbol>` (NOT a line range). File-level
+    anchors use `code:<repo>/<path>`.
+  - `decision`, `component` — knowledge_entity of the respective type.
+- **Facts** (typed, via `fn::resolve_fact` — bitemporal + conflict for free)
+  Predicate pack seeded into `PredicateRegistry`, Decision/Rationale taxonomy:
+  - `decided` (single_active) — a decision on a component/anchor
+  - `because` (append_only) — rationale supporting a decision
+  - `invariant` / `gotcha` (single_active) — a constraint on an anchor
+  - `supersedes` (append_only) — decision-evolution edge
+  - `validFrom` = commit author-date · `knownFrom` = index date (reuse as-is)
+- **Procedural** — gotchas that should *fire* when an area is touched go into the
+  existing `procedural_memory` (migration 0035): trigger="touching X" → action.
+- **Provenance** — extend the fact `source` shape to triple-level:
+  `{ agent: extractor|commit-author, artifact: PR#|SHA|file:line, cause }`.
+
+## Capture triggers
+
+- **Manual (Phase 0):** MCP `record_decision` — explicit write from an agent or
+  human, mid-conversation (this is where "погнали"-style reasoning is captured).
+- **Automatic (Phase 1):** on PR-merge — filter trivial diffs (comment-only /
+  rename / format), LLM-extract Decision/Rationale, ingest via `fn::resolve_fact`
+  (dedup/supersede free). Optional cheap BiLSTM pre-filter → LLM enrich.
+
+## Retrieval (MCP, summary-first)
+
+- `recall_decisions(symbol | file | topic)` — decisions/invariants for an area
+- `why(symbol)` — rationale behind a code location
+- `record_decision(...)` — manual capture
+All wrap existing search / multi-hop / ingest; no new retrieval engine.
+
+## Drift-resistant anchoring
+
+- Anchor identity = SCIP symbol string (survives line shifts / file moves).
+- Just-in-time validation at retrieval: does the symbol still resolve in current
+  code? No → set `validUntil` on the anchored facts (invalidate, **not** delete);
+  LLM semantic re-anchor as fallback when the symbol path is gone.
+
+## Open forks (decide before Phase 1; Phase 0 independent of both)
+
+1. **Default capture trigger:** LLM extractor (richer, costlier, needs a
+   hallucination validator) vs cheap BiLSTM classifier vs layered
+   (BiLSTM filter → LLM enrich).
+2. **Local-vs-server:** parsing/SCIP locally, graph on server (hybrid) — the
+   code-privacy question. brain is server-side multi-tenant; a local parse +
+   server graph keeps source off the wire.
+
+## Phases
+
+### Phase 0 — PoC (this brief)
+One repo, manual capture, prove the model lands on existing primitives.
+- Seed the code-decision predicate pack into `PredicateRegistry`.
+- `code_anchor` entity convention (SCIP-string externalRef).
+- MCP tools `record_decision` + `why` (thin wrappers over ingest + search).
+- **Acceptance:** record a decision on a symbol with commit provenance →
+  `why(symbol)` returns it; a superseding decision marks the prior SUPERSEDED
+  (existing conflict path); golden fixture + unit/e2e. No new heavy infra.
+
+### Phase 1 — VCS auto-capture
+PR-merge trigger, trivial-diff filter, LLM Decision/Rationale extraction, dedup
+against existing decisions.
+
+### Phase 2 — drift-resistant anchors
+SCIP symbol-path resolution + JIT anchor validation + LLM re-anchor fallback.
+
+### Phase 3 — eval
+Per-domain golden + design-constraint-compliance dimension (agent with memory
+vs without → share of design-compliant patches) + LoCoMo-style recall.
+
+## Acceptance bar (every phase)
+`pnpm exec tsc --noEmit` · `pnpm typecheck` · `pnpm lint` · `pnpm test` ·
+`pnpm test:e2e` — all green. Each new MCP tool → unit test in the mcp-tools
+spec. Each DB-touching feature → real-e2e. max-params ≤3 holds.

--- a/src/ai/predicate-registry-internals/core-seed.ts
+++ b/src/ai/predicate-registry-internals/core-seed.ts
@@ -346,5 +346,69 @@ VALUE  one anti-pattern per fact (multi-valued)`,
     status: 'active',
     createdBy: 'system',
   },
+
+  // ── CODE-MEMORY DomainPack (docs/roadmap/code-memory-domain.md) ───────
+  // The non-derivable engineering "why" of a codebase, anchored to code
+  // anchors (knowledge_entity with externalRef "code__<scip-symbol>"). This
+  // is NOT a code index — it stores decisions / rationale / invariants /
+  // gotchas a parser cannot recover from source. decayHalfLifeDays:null —
+  // code knowledge doesn't decay on a wall clock; it's superseded by a newer
+  // decision (single_active) or accumulates (append_only).
+  {
+    predicateId: 'decided',
+    displayLabel: 'decided',
+    description: `TYPE   subject is a code anchor; value is a design decision
+ADMIT  text states a design/implementation decision made for this code
+       location ("resolve facts through one gateway", "split per phase")
+VALUE  the decision statement`,
+    datatype: 'string',
+    semantics: 'single_active',
+    decayHalfLifeDays: null,
+    piiClass: 'none',
+    status: 'active',
+    createdBy: 'system',
+  },
+  {
+    predicateId: 'because',
+    displayLabel: 'because',
+    description: `TYPE   subject is a code anchor; value is the rationale for a decision
+ADMIT  text gives the reason a decision was made ("21 positional args
+       drifted between call-sites")
+VALUE  one rationale per fact (multi-valued)`,
+    datatype: 'string',
+    semantics: 'append_only',
+    decayHalfLifeDays: null,
+    piiClass: 'none',
+    status: 'active',
+    createdBy: 'system',
+  },
+  {
+    predicateId: 'invariant',
+    displayLabel: 'invariant',
+    description: `TYPE   subject is a code anchor; value is a constraint that must hold
+ADMIT  text states a rule the code must satisfy ("always export a new
+       @Injectable from the @Global module or e2e DI-boot fails")
+VALUE  the invariant statement`,
+    datatype: 'string',
+    semantics: 'single_active',
+    decayHalfLifeDays: null,
+    piiClass: 'none',
+    status: 'active',
+    createdBy: 'system',
+  },
+  {
+    predicateId: 'gotcha',
+    displayLabel: 'gotcha',
+    description: `TYPE   subject is a code anchor; value is a non-obvious trap
+ADMIT  text warns of a counter-intuitive behaviour or pitfall
+       ("pnpm test -- --testPathPattern does NOT work — double dash")
+VALUE  one gotcha per fact (multi-valued)`,
+    datatype: 'string',
+    semantics: 'append_only',
+    decayHalfLifeDays: null,
+    piiClass: 'none',
+    status: 'active',
+    createdBy: 'system',
+  },
 ];
 

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -176,6 +176,47 @@ export class EntitiesService {
   }
 
   /**
+   * Resolve an entity by its external reference (vertical + id) and return
+   * its full profile, or null when no entity carries that ref. Used by the
+   * code-memory `why` tool, which addresses a code anchor by its SCIP-style
+   * symbol string rather than the internal knowledge_entity id.
+   */
+  async getProfileByExternalRef({
+    companyId,
+    vertical,
+    id,
+    asOfRaw,
+    scopes,
+  }: {
+    companyId: string;
+    vertical: string;
+    id: string;
+    asOfRaw: string | undefined;
+    scopes: BrainScope[];
+  }): Promise<EntityProfile | null> {
+    // externalRef key format mirrors externalRefKey() in
+    // src/ingest/ingest-utils.ts (the write side) — dots become "__". Kept
+    // inline to avoid an entities→ingest module dependency; the format is a
+    // stable storage contract.
+    const safe = (s: string) => s.replace(/\./g, '__');
+    const key = `${safe(vertical)}__${safe(id)}`;
+    const entityId = await this.surreal.withScopedCompany(
+      companyId,
+      scopes,
+      async (db) => {
+        const [rows] = await db.query<[any[]]>(
+          `SELECT VALUE entity FROM entity_external_ref WHERE key = $key LIMIT 1`,
+          { key },
+        );
+        const arr = (rows as any[]) ?? [];
+        return arr[0] ? String(arr[0]) : null;
+      },
+    );
+    if (!entityId) return null;
+    return this.getProfile({ companyId, entityIdRaw: entityId, asOfRaw, scopes });
+  }
+
+  /**
    * Cheap freshness probe for an entity's active fact set, used by the
    * summarize_entity watermark cache (graphiti-style dual watermark):
    *   - maxRecordedAt — wall-clock: the newest moment brain learned

--- a/src/mcp/code-memory-tools.ts
+++ b/src/mcp/code-memory-tools.ts
@@ -1,0 +1,153 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { IngestService } from '../ingest/ingest.service';
+import type { EntitiesService } from '../entities/entities.service';
+import type { BrainScope } from '../auth/api-key.types';
+
+/**
+ * Code-memory MCP surface (Phase 0 — docs/roadmap/code-memory-domain.md).
+ *
+ * Remembers the non-derivable engineering "why" of a codebase — design
+ * decisions, rationale, invariants, gotchas — as bitemporal typed facts
+ * anchored to a CODE ANCHOR: a knowledge_entity addressed by a SCIP-style
+ * symbol string (`code__<symbol>`), NOT line numbers, so the memory survives
+ * edits. This is NOT a code index; structure (symbols / call graph) is derived
+ * state recoverable from source and belongs to a code-search indexer.
+ *
+ * `why` is brain:read; `record_decision` is brain:write. Both are thin wrappers
+ * over the existing ingest + entity-read paths — no new retrieval engine.
+ */
+
+/** The four code-memory predicates seeded in CORE_PREDICATES. */
+const CODE_MEMORY_KINDS = ['decided', 'because', 'invariant', 'gotcha'] as const;
+/** Vertical used for code-anchor external refs. */
+const CODE_VERTICAL = 'code';
+
+export interface CodeMemoryReadDeps {
+  entities: EntitiesService;
+}
+
+export interface CodeMemoryWriteDeps {
+  ingest: IngestService;
+}
+
+export function registerCodeMemoryReadTools(opts: {
+  server: McpServer;
+  companyId: string;
+  scopes: BrainScope[];
+  deps: CodeMemoryReadDeps;
+}): void {
+  const { server, companyId, scopes, deps } = opts;
+  server.registerTool(
+    'why',
+    {
+      title: 'Recall the recorded "why" behind a code symbol',
+      description:
+        'Return the design decisions, rationale, invariants and gotchas recorded against a code anchor — the non-derivable engineering "why" a parser cannot recover from source. The anchor is a SCIP-style symbol string ("pkg/namespace/symbol") or a file path ("repo/path/file.ts"). Pass asOf to recall what was known at a past instant (bitemporal). Returns found:0 with empty memory when nothing is recorded.',
+      inputSchema: {
+        symbol: z
+          .string()
+          .describe('Code anchor — SCIP-style symbol or file path'),
+        asOf: z
+          .string()
+          .datetime()
+          .optional()
+          .describe('Bitemporal cursor — recall what was known as of this instant'),
+      },
+    },
+    async (args) => {
+      const profile = await deps.entities.getProfileByExternalRef({
+        companyId,
+        vertical: CODE_VERTICAL,
+        id: args.symbol,
+        asOfRaw: args.asOf,
+        scopes,
+      });
+      const memory = (profile?.facts ?? []).filter((f) =>
+        (CODE_MEMORY_KINDS as readonly string[]).includes(f.predicate),
+      );
+      const out = {
+        symbol: args.symbol,
+        entityId: profile?.entityId ?? null,
+        found: memory.length,
+        memory: memory.map((f) => ({
+          kind: f.predicate,
+          text: f.object,
+          validFrom: f.validFrom,
+          validUntil: f.validUntil,
+          status: f.status,
+        })),
+      };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
+        structuredContent: out as any,
+      };
+    },
+  );
+}
+
+export function registerCodeMemoryWriteTools(opts: {
+  server: McpServer;
+  companyId: string;
+  deps: CodeMemoryWriteDeps;
+}): void {
+  const { server, companyId, deps } = opts;
+  server.registerTool(
+    'record_decision',
+    {
+      title: 'Record a code-memory decision / rationale / invariant / gotcha',
+      description:
+        'Capture the non-derivable engineering "why" about a code location: a design decision, its rationale, an invariant that must hold, or a gotcha. Anchored to a SCIP-style symbol or file path (NOT line numbers — survives edits). Stored as a bitemporal typed fact: re-recording a `decided` / `invariant` for the same anchor SUPERSEDES the prior one (decision evolution over time), while `because` / `gotcha` accumulate. Attach commit / location for provenance.',
+      inputSchema: {
+        symbol: z
+          .string()
+          .describe('Code anchor — SCIP-style symbol or file path'),
+        kind: z
+          .enum(CODE_MEMORY_KINDS)
+          .describe(
+            'decided = a design decision (supersedes prior); because = rationale; invariant = a constraint that must hold (supersedes prior); gotcha = a non-obvious trap (accumulates)',
+          ),
+        text: z
+          .string()
+          .min(1)
+          .max(2000)
+          .describe('The decision / rationale / invariant / gotcha text'),
+        commit: z
+          .string()
+          .optional()
+          .describe('Commit SHA this was decided in (provenance)'),
+        location: z
+          .string()
+          .optional()
+          .describe('file:line provenance, e.g. src/x.ts:42'),
+        validFrom: z
+          .string()
+          .datetime()
+          .optional()
+          .describe('When the decision took effect — defaults to now'),
+        confidence: z.number().min(0).max(1).optional(),
+      },
+    },
+    async (args) => {
+      const out = await deps.ingest.ingestFact(companyId, {
+        entityRef: { vertical: CODE_VERTICAL, id: args.symbol },
+        predicate: args.kind,
+        object: args.text,
+        validFrom: args.validFrom ?? new Date().toISOString(),
+        confidence: args.confidence,
+        source: {
+          vertical: CODE_VERTICAL,
+          recorder: 'code_memory',
+          // Provenance rides existing FactSource fields (persisted + returned
+          // by the timeline). Phase 1 promotes this to triple-level PROV.
+          ...(args.commit ? { eventId: args.commit } : {}),
+          ...(args.location ? { messageId: args.location } : {}),
+        },
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
+        structuredContent: out as any,
+      };
+    },
+  );
+}

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -17,6 +17,10 @@ import { registerCommunityTools } from './community-tools';
 import { registerReadTools } from './read-tools';
 import { registerProceduralReadTools } from './procedural-tools';
 import { registerWriteTools, registerAdminTools } from './write-tools';
+import {
+  registerCodeMemoryReadTools,
+  registerCodeMemoryWriteTools,
+} from './code-memory-tools';
 
 const MCP_SERVER_VERSION = '0.3.0';
 
@@ -36,6 +40,7 @@ const HEALTH_TOOLS = [
   'search_communities',
   'list_communities',
   'find_entity_communities',
+  'why',
 ];
 
 /**
@@ -132,11 +137,22 @@ export class McpService {
       procedural: this.procedural,
     });
     registerCommunityTools(server, companyId, this.communities);
+    registerCodeMemoryReadTools({
+      server,
+      companyId,
+      scopes,
+      deps: { entities: this.entities },
+    });
     if (scopes.includes('brain:write')) {
       registerWriteTools(server, companyId, {
         ingest: this.ingest,
         facts: this.facts,
         procedural: this.procedural,
+      });
+      registerCodeMemoryWriteTools({
+        server,
+        companyId,
+        deps: { ingest: this.ingest },
       });
     }
     if (scopes.includes('brain:admin')) {

--- a/test/code-memory.e2e-spec.ts
+++ b/test/code-memory.e2e-spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Code-memory Phase 0 — end-to-end round-trip on a real DB.
+ *
+ * Proves the code-memory DomainPack lands on brain's existing primitives with
+ * no new storage: a decision is recorded against a CODE ANCHOR (a
+ * knowledge_entity addressed by a SCIP-style symbol string, not line numbers)
+ * as a typed fact, recalled by external ref, and the bitemporal conflict path
+ * gives decision evolution for free.
+ *
+ * What the MCP tools `record_decision` / `why` wrap is exercised directly:
+ *   - record_decision  → IngestService.ingestFact (code predicate + anchor ref)
+ *   - why              → EntitiesService.getProfileByExternalRef
+ *
+ * Asserts:
+ *   1. record `decided` on a fresh anchor → INSERTED; recall returns it.
+ *   2. re-`decided` the same anchor → SUPERSEDED; exactly one active decision,
+ *      the new one (single_active evolution).
+ *   3. `gotcha` is append_only → accumulates, no supersede.
+ *   4. unknown anchor → null.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { IngestService } from '../src/ingest/ingest.service';
+import { EntitiesService } from '../src/entities/entities.service';
+import type { BrainScope } from '../src/auth/api-key.types';
+
+describe('code-memory Phase 0 — record_decision → why round-trip', () => {
+  let f: AppFixture;
+  const READ: BrainScope[] = ['brain:read'];
+  // SCIP-style anchor: dots in the path are escaped to "__" by externalRefKey
+  // on both the write (ingest) and read (getProfileByExternalRef) sides.
+  const SYMBOL =
+    'inite-brain-service/src/ingest/fact-resolver.service.ts/FactResolverService#resolve';
+
+  const recall = () => {
+    const entities = f.app.get(EntitiesService);
+    return entities.getProfileByExternalRef({
+      companyId: f.companyId,
+      vertical: 'code',
+      id: SYMBOL,
+      asOfRaw: undefined,
+      scopes: READ,
+    });
+  };
+  const activeOf = (profile: Awaited<ReturnType<typeof recall>>, kind: string) =>
+    (profile?.facts ?? []).filter(
+      (x) => x.predicate === kind && x.status === 'active',
+    );
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_code_memory_e2e' });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('records a decision on a code anchor and recalls it by external ref', async () => {
+    const ingest = f.app.get(IngestService);
+    const out = await ingest.ingestFact(f.companyId, {
+      entityRef: { vertical: 'code', id: SYMBOL },
+      predicate: 'decided',
+      object: 'Route every fact write through one fn::resolve_fact gateway',
+      validFrom: '2026-06-28T00:00:00Z',
+      source: { vertical: 'code', recorder: 'code_memory', eventId: 'f0e824b' },
+    });
+    expect(out.outcome).toBe('INSERTED');
+
+    const profile = await recall();
+    expect(profile).not.toBeNull();
+    const decided = activeOf(profile, 'decided');
+    expect(decided).toHaveLength(1);
+    expect(decided[0].object).toMatch(/one fn::resolve_fact gateway/);
+  });
+
+  it('re-deciding the same anchor supersedes the prior decision (single_active)', async () => {
+    const ingest = f.app.get(IngestService);
+    const out = await ingest.ingestFact(f.companyId, {
+      entityRef: { vertical: 'code', id: SYMBOL },
+      predicate: 'decided',
+      object: 'Gateway also detects locale and writes the HyPE alt-embedding',
+      validFrom: '2026-06-29T00:00:00Z',
+      source: { vertical: 'code', recorder: 'code_memory', eventId: 'a002e1f' },
+    });
+    expect(out.outcome).toBe('SUPERSEDED');
+
+    const profile = await recall();
+    const activeDecided = activeOf(profile, 'decided');
+    expect(activeDecided).toHaveLength(1);
+    expect(activeDecided[0].object).toMatch(/HyPE alt-embedding/);
+  });
+
+  it('gotcha is append_only — accumulates instead of superseding', async () => {
+    const ingest = f.app.get(IngestService);
+    await ingest.ingestFact(f.companyId, {
+      entityRef: { vertical: 'code', id: SYMBOL },
+      predicate: 'gotcha',
+      object: 'conflict weights are read from process.env, not ConfigService',
+      validFrom: '2026-06-28T00:00:00Z',
+      source: { vertical: 'code', recorder: 'code_memory' },
+    });
+    await ingest.ingestFact(f.companyId, {
+      entityRef: { vertical: 'code', id: SYMBOL },
+      predicate: 'gotcha',
+      object: 'the resolve lock key is companyId + entityId + predicate (NUL-joined)',
+      validFrom: '2026-06-28T00:00:00Z',
+      source: { vertical: 'code', recorder: 'code_memory' },
+    });
+
+    const profile = await recall();
+    expect(activeOf(profile, 'gotcha')).toHaveLength(2);
+    // The superseded decision from the prior test is still on the anchor but
+    // not active — recall surfaces the full picture, active-filtered by kind.
+    expect(activeOf(profile, 'decided')).toHaveLength(1);
+  });
+
+  it('returns null for an unknown anchor', async () => {
+    const entities = f.app.get(EntitiesService);
+    const profile = await entities.getProfileByExternalRef({
+      companyId: f.companyId,
+      vertical: 'code',
+      id: 'inite-brain-service/src/does/not/exist.ts/Nope#missing',
+      asOfRaw: undefined,
+      scopes: READ,
+    });
+    expect(profile).toBeNull();
+  });
+});

--- a/test/mcp-tools.unit-spec.ts
+++ b/test/mcp-tools.unit-spec.ts
@@ -81,6 +81,7 @@ const READ_BASELINE = [
   'list_communities',
   'find_entity_communities',
   'find_related_entities',
+  'why',
 ];
 
 describe('McpService.buildServer — scope-gated tool surface', () => {
@@ -96,6 +97,7 @@ describe('McpService.buildServer — scope-gated tool surface', () => {
     expect(names).not.toContain('link_entities');
     expect(names).not.toContain('record_procedure');
     expect(names).not.toContain('retire_procedure');
+    expect(names).not.toContain('record_decision');
   });
 
   it('registers mutation tools when brain:write is present', () => {
@@ -105,6 +107,7 @@ describe('McpService.buildServer — scope-gated tool surface', () => {
     expect(names).toContain('link_entities');
     expect(names).toContain('record_procedure');
     expect(names).toContain('retire_procedure');
+    expect(names).toContain('record_decision');
   });
 
   it('does NOT register forget_entity without brain:admin (even with write)', () => {


### PR DESCRIPTION
## What

First slice of the **code-memory DomainPack** (`docs/roadmap/code-memory-domain.md`): make brain remember the non-derivable engineering **"why"** of a codebase — decisions, rationale, invariants, gotchas — as **bitemporal typed facts anchored to a code anchor** (a `knowledge_entity` addressed by a SCIP-style symbol string, **not line numbers**, so it survives edits).

This is **not** a code index — structure (symbols / call graph) is derived state recoverable from source and belongs to a code-search indexer. Phase 0 is built entirely on existing brain primitives: **no new storage layer**.

### Changes
- **Predicate pack** (`core-seed.ts`): 4 code-memory predicates — `decided` / `invariant` (single_active → decision evolution via supersede), `because` / `gotcha` (append_only → accumulate); `decayHalfLifeDays: null` (code knowledge doesn't decay on a clock).
- **`EntitiesService.getProfileByExternalRef`** — resolve an entity by its external ref (the `why` tool addresses anchors by symbol string, not internal id).
- **MCP tools** (`src/mcp/code-memory-tools.ts`): `record_decision` (brain:write) + `why` (brain:read), thin wrappers over `ingestFact` + entity-read. Provenance (commit / location) rides existing `FactSource` fields; Phase 1 promotes to triple-level PROV.
- Wired into `McpService`; `why` added to the health tool list.

### SOTA grounding (deep-research, 2026 — 25/25 claims verified)
Bitemporal invalidate-not-delete (Graphiti/Zep) — already brain's model; Decision/Rationale taxonomy as the predicate schema (CoMRAT, IBM Code Insights); SCIP string symbol anchors over line offsets; VCS-triggered capture (Phase 1). Full comparison + phased plan in the roadmap doc.

## Verification
e2e proves the round-trip on a real DB: record `decided` → recall by ref → re-decide **SUPERSEDES** (single_active evolution) → `gotcha` accumulates (append_only) → unknown anchor returns null.
- `pnpm exec tsc --noEmit` · `pnpm typecheck` · `pnpm lint` ✓
- 700 unit ✓ · 132 e2e (+4 new) ✓ · 9 jobs e2e ✓ · max-params ≤3 holds

## Not in this PR (next phases)
VCS auto-capture from PR-merge (Phase 1), drift-resistant SCIP anchor validation + LLM re-anchor (Phase 2), design-constraint-compliance eval (Phase 3). Two open forks documented: default capture trigger (LLM vs BiLSTM vs layered) and local-vs-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)