### PR TITLE
feat(code-memory): Phase 1 — hybrid client-side decision capture (layered gate + LLM extract)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:eval": "pnpm build && jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=quality",
     "eval:diff": "ts-node -r tsconfig-paths/register scripts/eval-baseline-diff.ts",
     "bench:router": "ts-node -r tsconfig-paths/register scripts/bench-chat-router.ts",
+    "capture:decisions": "ts-node -r tsconfig-paths/register scripts/capture-decisions.ts",
     "test:eval:fat": "pnpm build && FAT_TENANT_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=fat-tenant",
     "test:eval:directory": "pnpm build && DIRECTORY_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=directory",
     "test:eval:json": "pnpm build && jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=json-directory",

--- a/scripts/capture-decisions.ts
+++ b/scripts/capture-decisions.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env tsx
+/**
+ * Code-memory Phase 1 — hybrid client-side decision capture CLI.
+ * (docs/roadmap/code-memory-domain.md)
+ *
+ *   OPENAI_API_KEY=... BRAIN_API_KEY=... \
+ *     pnpm capture:decisions -- \
+ *       --range origin/main..HEAD \
+ *       --brain-url https://brain.inite.ai \
+ *       [--dry-run]            # extract + print, do not POST
+ *       [--model gpt-4o-mini]
+ *
+ * Runs WHERE THE CODE LIVES (CI step / git hook / locally). It reads commit
+ * messages + changed file paths from the local git range, gates them through
+ * the deterministic Layer-1 classifier, extracts the "why" with your own LLM
+ * key (Layer 2), and POSTs ONLY the resulting decision facts (+ file anchors +
+ * commit provenance) to brain. Raw source never leaves the machine.
+ *
+ * Anchors are file-level in Phase 1; symbol-level (SCIP) is Phase 2.
+ */
+import { readCommits } from '../src/code-memory/capture/git-commits';
+import { HeuristicDecisionClassifier } from '../src/code-memory/capture/heuristic-classifier';
+import {
+  LlmDecisionExtractor,
+  makeOpenAiCompleter,
+} from '../src/code-memory/capture/llm-extractor';
+import { HttpDecisionSink } from '../src/code-memory/capture/http-sink';
+import { runCapturePipeline } from '../src/code-memory/capture/capture-pipeline';
+import type {
+  DecisionCandidate,
+  DecisionSink,
+} from '../src/code-memory/capture/types';
+
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+async function main(): Promise<void> {
+  const range = arg('range', 'origin/main..HEAD')!;
+  const brainUrl = arg('brain-url', process.env.BRAIN_URL);
+  const model = arg('model', process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o-mini')!;
+  const dryRun = process.argv.includes('--dry-run');
+  const openAiKey = process.env.OPENAI_API_KEY;
+  const brainKey = process.env.BRAIN_API_KEY;
+
+  if (!openAiKey) throw new Error('OPENAI_API_KEY is required');
+  if (!dryRun && (!brainUrl || !brainKey)) {
+    throw new Error('--brain-url and BRAIN_API_KEY required (or pass --dry-run)');
+  }
+
+  const commits = readCommits({ range });
+  console.error(`[capture] ${commits.length} commit(s) in ${range}`);
+
+  const extractor = new LlmDecisionExtractor(
+    makeOpenAiCompleter({ apiKey: openAiKey, model }),
+  );
+  const sink: DecisionSink = dryRun
+    ? {
+        record: (c: DecisionCandidate) => {
+          console.log(JSON.stringify(c));
+          return Promise.resolve({ outcome: 'DRY_RUN' });
+        },
+      }
+    : new HttpDecisionSink({ baseUrl: brainUrl!, apiKey: brainKey! });
+
+  const summary = await runCapturePipeline({
+    commits,
+    classifier: new HeuristicDecisionClassifier(),
+    extractor,
+    sink,
+    log: (m) => console.error(`[capture] ${m}`),
+  });
+
+  console.error(`[capture] done: ${JSON.stringify(summary)}`);
+}
+
+main().catch((e) => {
+  console.error(`[capture] fatal: ${(e as Error).message}`);
+  process.exit(1);
+});

--- a/src/code-memory/capture/capture-pipeline.ts
+++ b/src/code-memory/capture/capture-pipeline.ts
@@ -1,0 +1,81 @@
+import type {
+  CaptureSummary,
+  CommitInput,
+  DecisionClassifier,
+  DecisionExtractor,
+  DecisionSink,
+} from './types';
+import { isMergeCommit } from './commit-signals';
+
+/**
+ * The hybrid client-side capture pipeline. For each commit:
+ *   1. trivial filter (merge commits) — cheapest reject
+ *   2. Layer 1 classifier — deterministic admit/reject gate
+ *   3. Layer 2 extractor — LLM extraction of decision candidates (admitted only)
+ *   4. sink — record each candidate into brain (facts only, no source)
+ *
+ * Collaborators are injected (classifier / extractor / sink) so the orchestration
+ * is pure and unit-testable with stubs, and so the LLM + network live behind
+ * swappable seams. A per-commit extractor/sink failure is counted and logged via
+ * `log`, never aborts the run (one bad commit must not lose the rest).
+ */
+export async function runCapturePipeline(opts: {
+  commits: CommitInput[];
+  classifier: DecisionClassifier;
+  extractor: DecisionExtractor;
+  sink: DecisionSink;
+  log?: (msg: string) => void;
+}): Promise<CaptureSummary> {
+  const { commits, classifier, extractor, sink } = opts;
+  const log = opts.log ?? (() => {});
+  const summary: CaptureSummary = {
+    scanned: commits.length,
+    trivialSkipped: 0,
+    classifierRejected: 0,
+    extracted: 0,
+    recorded: 0,
+    failures: 0,
+  };
+
+  for (const commit of commits) {
+    if (isMergeCommit(commit)) {
+      summary.trivialSkipped += 1;
+      continue;
+    }
+
+    const verdict = classifier.classify(commit);
+    if (!verdict.likelyDecision) {
+      summary.classifierRejected += 1;
+      log(`skip ${short(commit.sha)}: ${verdict.reason}`);
+      continue;
+    }
+
+    let candidates;
+    try {
+      candidates = await extractor.extract(commit);
+    } catch (e) {
+      summary.failures += 1;
+      log(`extract failed ${short(commit.sha)}: ${(e as Error).message}`);
+      continue;
+    }
+    summary.extracted += candidates.length;
+
+    for (const candidate of candidates) {
+      try {
+        await sink.record(candidate);
+        summary.recorded += 1;
+      } catch (e) {
+        summary.failures += 1;
+        log(
+          `record failed ${short(commit.sha)} (${candidate.kind} @ ${candidate.anchor}): ${(e as Error).message}`,
+        );
+      }
+    }
+  }
+
+  return summary;
+}
+
+function short(sha: string): string {
+  return sha.slice(0, 8);
+}

--- a/src/code-memory/capture/commit-signals.ts
+++ b/src/code-memory/capture/commit-signals.ts
@@ -1,0 +1,73 @@
+import type { CommitInput, Layer1Signals } from './types';
+
+/**
+ * Pure parsers over a commit message — the deterministic substrate Layer 1
+ * classifies on. No LLM, no IO.
+ */
+
+const CONVENTIONAL_RE = /^([a-z]+)(?:\([^)]*\))?!?:/;
+const ISSUE_RE = /#(\d+)/g;
+// Rationale connectives that signal a "why" is present in prose.
+const RATIONALE_MARKERS = [
+  'because',
+  'so that',
+  'in order to',
+  'instead of',
+  'rather than',
+  'to avoid',
+  'to prevent',
+  'otherwise',
+  'the reason',
+];
+// Trailer keys that explicitly carry decision/rationale content.
+export const DECISION_TRAILER_KEYS = [
+  'decision',
+  'why',
+  'rationale',
+  'breaking change',
+  'breaking-change',
+  'gotcha',
+  'invariant',
+];
+
+function subjectAndBody(message: string): { subject: string; body: string } {
+  const nl = message.indexOf('\n');
+  if (nl === -1) return { subject: message.trim(), body: '' };
+  return {
+    subject: message.slice(0, nl).trim(),
+    body: message.slice(nl + 1).trim(),
+  };
+}
+
+function parseTrailers(body: string): Record<string, string> {
+  const trailers: Record<string, string> = {};
+  for (const line of body.split('\n')) {
+    const m = /^([A-Za-z][A-Za-z -]*):\s+(.+)$/.exec(line.trim());
+    if (m) trailers[m[1].toLowerCase()] = m[2].trim();
+  }
+  return trailers;
+}
+
+export function parseCommitSignals(commit: CommitInput): Layer1Signals {
+  const { subject, body } = subjectAndBody(commit.message);
+  const ctMatch = CONVENTIONAL_RE.exec(subject);
+  const haystack = `${body}\n${commit.prBody ?? ''}`.toLowerCase();
+  const rationaleMarkers = RATIONALE_MARKERS.filter((m) => haystack.includes(m));
+  const issueRefs = Array.from(
+    `${subject}\n${haystack}`.matchAll(ISSUE_RE),
+    (m) => m[1],
+  );
+  return {
+    conventionalType: ctMatch ? ctMatch[1] : null,
+    trailers: parseTrailers(body),
+    issueRefs: Array.from(new Set(issueRefs)),
+    bodyLength: body.length,
+    rationaleMarkers,
+  };
+}
+
+export function isMergeCommit(commit: CommitInput): boolean {
+  return /^Merge (branch|pull request|remote-tracking) /.test(
+    commit.message.trimStart(),
+  );
+}

--- a/src/code-memory/capture/git-commits.ts
+++ b/src/code-memory/capture/git-commits.ts
@@ -1,0 +1,54 @@
+import { execFileSync } from 'node:child_process';
+import type { CommitInput } from './types';
+
+/**
+ * Read commits from a local git range into CommitInput[]. Squash-merge repos
+ * (brain itself) fold the PR description into the commit body, so the message
+ * alone carries the PR rationale — no GitHub API round-trip needed in Phase 1.
+ *
+ * `parseGitLog` is pure (unit-tested); `readCommits` is the thin git shell.
+ */
+
+// Field sep \x1f, record sep \x1e — neither appears in commit text. Format:
+//   <RS><sha><FS><authorISO><FS><body><FS>\n<file>\n<file>...
+const FS = '\x1f';
+const RS = '\x1e';
+const GIT_FORMAT = `${RS}%H${FS}%aI${FS}%B${FS}`;
+
+export function parseGitLog(raw: string): CommitInput[] {
+  const commits: CommitInput[] = [];
+  for (const record of raw.split(RS)) {
+    if (!record.trim()) continue;
+    const [sha, authorDate, message, filesBlob = ''] = record.split(FS);
+    if (!sha || !authorDate) continue;
+    const changedFiles = filesBlob
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+    commits.push({
+      sha: sha.trim(),
+      authorDate: authorDate.trim(),
+      message: (message ?? '').trim(),
+      changedFiles,
+    });
+  }
+  return commits;
+}
+
+export function readCommits(opts: {
+  range: string;
+  cwd?: string;
+}): CommitInput[] {
+  const raw = execFileSync(
+    'git',
+    [
+      'log',
+      opts.range,
+      '--no-merges',
+      '--name-only',
+      `--format=${GIT_FORMAT}`,
+    ],
+    { cwd: opts.cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  );
+  return parseGitLog(raw);
+}

--- a/src/code-memory/capture/heuristic-classifier.ts
+++ b/src/code-memory/capture/heuristic-classifier.ts
@@ -1,0 +1,89 @@
+import type { CommitInput, DecisionClassifier, Layer1Verdict } from './types';
+import {
+  DECISION_TRAILER_KEYS,
+  isMergeCommit,
+  parseCommitSignals,
+} from './commit-signals';
+
+/**
+ * Layer 1, deterministic. Admits commits whose message carries a plausible
+ * engineering "why" and rejects pure noise — the cheap gate before the LLM
+ * extractor runs. This is a stand-in for a trained classifier (CoMRAT-style
+ * BiLSTM): it implements the exact {@link DecisionClassifier} seam, so a model
+ * can replace it later without touching the pipeline, once a labeled commit
+ * corpus exists. No LLM, no IO — safe to run over every commit.
+ *
+ * AVOIDs silent over-filtering: the verdict carries `reason` so a dropped
+ * commit is auditable, never silently swallowed.
+ */
+
+// Types that are noise for DECISION capture when they carry no explanatory body.
+const LOW_SIGNAL_TYPES = new Set(['chore', 'style', 'ci', 'build', 'test', 'docs']);
+// Types that usually accompany a design change worth a "why".
+const DECISION_TYPES = new Set(['feat', 'fix', 'refactor', 'perf', 'revert']);
+// A body shorter than this with no other signal is treated as not worth an LLM call.
+const MIN_EXPLANATORY_BODY = 80;
+
+export class HeuristicDecisionClassifier implements DecisionClassifier {
+  classify(commit: CommitInput): Layer1Verdict {
+    const signals = parseCommitSignals(commit);
+
+    if (isMergeCommit(commit)) {
+      return { likelyDecision: false, reason: 'merge commit', signals };
+    }
+
+    const hasDecisionTrailer = DECISION_TRAILER_KEYS.some(
+      (k) => k in signals.trailers,
+    );
+    if (hasDecisionTrailer) {
+      return {
+        likelyDecision: true,
+        reason: 'explicit decision/rationale trailer',
+        signals,
+      };
+    }
+
+    const type = signals.conventionalType;
+    const hasBody = signals.bodyLength >= MIN_EXPLANATORY_BODY;
+    const hasRationale = signals.rationaleMarkers.length > 0;
+
+    // Low-signal type with no explanatory body and no rationale prose → noise.
+    if (type && LOW_SIGNAL_TYPES.has(type) && !hasBody && !hasRationale) {
+      return {
+        likelyDecision: false,
+        reason: `low-signal type "${type}" with no explanatory body`,
+        signals,
+      };
+    }
+
+    if (hasRationale) {
+      return {
+        likelyDecision: true,
+        reason: `rationale markers: ${signals.rationaleMarkers.join(', ')}`,
+        signals,
+      };
+    }
+
+    if (type && DECISION_TYPES.has(type) && hasBody) {
+      return {
+        likelyDecision: true,
+        reason: `decision-type "${type}" with explanatory body`,
+        signals,
+      };
+    }
+
+    if (hasBody) {
+      return {
+        likelyDecision: true,
+        reason: 'substantial explanatory body',
+        signals,
+      };
+    }
+
+    return {
+      likelyDecision: false,
+      reason: 'no decision trailer, rationale, or explanatory body',
+      signals,
+    };
+  }
+}

--- a/src/code-memory/capture/http-sink.ts
+++ b/src/code-memory/capture/http-sink.ts
@@ -1,0 +1,68 @@
+import type { DecisionCandidate, DecisionSink } from './types';
+
+/**
+ * Terminal sink — POSTs each decision candidate to brain's existing
+ * /v1/ingest/fact HTTP endpoint (the same IngestService.ingestFact the
+ * `record_decision` MCP tool wraps). Only the extracted fact + file anchor +
+ * provenance travel to the server; raw source never does.
+ *
+ * `fetchImpl` is injected so the request shape + anchor mapping are unit-tested
+ * without a live server; it defaults to the global fetch.
+ */
+
+type FetchLike = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+  },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<any> }>;
+
+const CODE_VERTICAL = 'code';
+
+export class HttpDecisionSink implements DecisionSink {
+  private readonly fetchImpl: FetchLike;
+
+  constructor(
+    private readonly opts: {
+      baseUrl: string;
+      apiKey: string;
+      fetchImpl?: FetchLike;
+    },
+  ) {
+    this.fetchImpl =
+      opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+  }
+
+  async record(candidate: DecisionCandidate): Promise<{ outcome: string }> {
+    const body = {
+      entityRef: { vertical: CODE_VERTICAL, id: candidate.anchor },
+      predicate: candidate.kind,
+      object: candidate.text,
+      validFrom: candidate.validFrom,
+      ...(candidate.confidence !== undefined
+        ? { confidence: candidate.confidence }
+        : {}),
+      source: {
+        vertical: CODE_VERTICAL,
+        recorder: 'code_memory_capture',
+        eventId: candidate.commit,
+        ...(candidate.location ? { messageId: candidate.location } : {}),
+      },
+    };
+    const res = await this.fetchImpl(`${this.opts.baseUrl}/v1/ingest/fact`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${this.opts.apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      throw new Error(`ingest POST failed: ${res.status}`);
+    }
+    const json = await res.json();
+    return { outcome: String(json?.outcome ?? 'UNKNOWN') };
+  }
+}

--- a/src/code-memory/capture/llm-extractor.ts
+++ b/src/code-memory/capture/llm-extractor.ts
@@ -1,0 +1,140 @@
+import OpenAI from 'openai';
+import type {
+  CommitInput,
+  DecisionCandidate,
+  DecisionExtractor,
+  DecisionKind,
+} from './types';
+
+/**
+ * Layer 2 — LLM extraction of the Decision/Rationale taxonomy from a commit's
+ * NON-CODE signal (message + PR body + changed file PATHS). File contents are
+ * never sent — Phase 1 anchors at file granularity, which also keeps the hybrid
+ * client-side privacy contract tight (only paths + prose leave the machine, and
+ * only to the caller's own LLM).
+ *
+ * The LLM call sits behind {@link ChatComplete} so prompt-building and parsing
+ * are unit-tested with a stub; `makeOpenAiCompleter` is the default impl.
+ * Extraction is GROUNDED: a candidate whose anchor is not one of the commit's
+ * changed files is re-anchored to the sole changed file or dropped — the model
+ * cannot invent a path.
+ */
+
+export type ChatComplete = (prompt: {
+  system: string;
+  user: string;
+}) => Promise<string>;
+
+const KINDS: DecisionKind[] = ['decided', 'because', 'invariant', 'gotcha'];
+
+export class LlmDecisionExtractor implements DecisionExtractor {
+  constructor(private readonly complete: ChatComplete) {}
+
+  async extract(commit: CommitInput): Promise<DecisionCandidate[]> {
+    const raw = await this.complete(buildExtractionPrompt(commit));
+    return parseCandidates(raw, commit);
+  }
+}
+
+export function buildExtractionPrompt(commit: CommitInput): {
+  system: string;
+  user: string;
+} {
+  const system = `You extract the non-derivable engineering "why" from a git commit — knowledge a parser cannot recover from source. Output ONLY decisions, rationale, invariants, and gotchas that are EXPLICITLY present in the message or PR body. Never restate what the code change literally is; capture the reasoning behind it. If the commit carries no such "why", return an empty list.
+
+Return STRICT JSON: {"decisions":[{"kind","text","anchor","confidence"}]}.
+- kind: one of decided | because | invariant | gotcha
+- text: the decision/rationale/invariant/gotcha, one sentence, faithful to the commit
+- anchor: the MOST relevant changed file path, chosen verbatim from the provided list
+- confidence: 0..1, how explicitly the commit states it`;
+
+  const files = commit.changedFiles.map((f) => `- ${f}`).join('\n');
+  const user = `Commit ${commit.sha}
+Message:
+${commit.message}
+${commit.prBody ? `\nPR body:\n${commit.prBody}\n` : ''}
+Changed files (choose anchors only from these):
+${files}`;
+
+  return { system, user };
+}
+
+export function parseCandidates(
+  raw: string,
+  commit: CommitInput,
+): DecisionCandidate[] {
+  const parsed = safeParse(raw);
+  const list: unknown[] = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { decisions?: unknown[] })?.decisions)
+      ? (parsed as { decisions: unknown[] }).decisions
+      : [];
+  const changed = new Set(commit.changedFiles);
+  const out: DecisionCandidate[] = [];
+  for (const item of list) {
+    const o = item as Record<string, unknown>;
+    const kind = o.kind as DecisionKind;
+    const text = typeof o.text === 'string' ? o.text.trim() : '';
+    if (!KINDS.includes(kind) || !text) continue;
+    // Ground the anchor: must be one of the commit's changed files. If the
+    // model picked something else, fall back to the sole changed file, else drop.
+    let anchor = typeof o.anchor === 'string' ? o.anchor : '';
+    if (!changed.has(anchor)) {
+      if (commit.changedFiles.length === 1) anchor = commit.changedFiles[0];
+      else continue;
+    }
+    const confidence =
+      typeof o.confidence === 'number' &&
+      o.confidence >= 0 &&
+      o.confidence <= 1
+        ? o.confidence
+        : undefined;
+    out.push({
+      kind,
+      text,
+      anchor,
+      commit: commit.sha,
+      validFrom: commit.authorDate,
+      confidence,
+    });
+  }
+  return out;
+}
+
+function safeParse(raw: string): unknown {
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/.exec(raw);
+  const body = fenced ? fenced[1] : raw;
+  const start = body.search(/[[{]/);
+  if (start === -1) return null;
+  try {
+    return JSON.parse(body.slice(start));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Default {@link ChatComplete} backed by OpenAI. Runs client-side (the caller's
+ * own key), so the brain server never sees the commit text. JSON-object response
+ * format; temperature 0 for stable extraction.
+ */
+export function makeOpenAiCompleter(opts: {
+  apiKey: string;
+  model?: string;
+}): ChatComplete {
+  const client = new OpenAI({ apiKey: opts.apiKey });
+  const model = opts.model ?? 'gpt-4o-mini';
+  return async ({ system, user }) => {
+    const res = await client.chat.completions.create({
+      model,
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: user },
+      ],
+      response_format: { type: 'json_object' },
+      temperature: 0,
+      max_completion_tokens: 800,
+    });
+    return res.choices[0]?.message?.content ?? '';
+  };
+}

--- a/src/code-memory/capture/types.ts
+++ b/src/code-memory/capture/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Code-memory Phase 1 — VCS capture pipeline types.
+ * (docs/roadmap/code-memory-domain.md)
+ *
+ * Hybrid client-side capture: this pipeline runs where the code lives (CI /
+ * git hook / agent), extracting the engineering "why" from commit + PR text and
+ * sending ONLY the resulting decision facts (+ file anchors + provenance) to the
+ * brain server — raw source never leaves the machine. The sink is the existing
+ * /v1/ingest/fact HTTP path (same IngestService.ingestFact as `record_decision`).
+ *
+ * Layered extraction:
+ *   Layer 1 — cheap deterministic gate ({@link DecisionClassifier}). The
+ *     interface a trained BiLSTM (CoMRAT-style) would implement; shipped now as
+ *     a heuristic so there's no dependency on a labeled commit corpus.
+ *   Layer 2 — LLM extraction ({@link DecisionExtractor}) of the
+ *     Decision/Rationale taxonomy, only for commits Layer 1 admits.
+ */
+
+/** One commit's non-code signal — message, PR body, paths. NO file contents:
+ *  Phase 1 anchors at file granularity; symbol-level is Phase 2 (SCIP). */
+export interface CommitInput {
+  sha: string;
+  /** Full commit message (subject + body). */
+  message: string;
+  /** Linked PR / MR body, when resolvable. */
+  prBody?: string;
+  /** Paths touched by the commit (anchors), e.g. ["src/x.ts"]. */
+  changedFiles: string[];
+  /** Commit author date (ISO) — becomes the fact validFrom (event time). */
+  authorDate: string;
+}
+
+/** Deterministic signals parsed from a commit message. */
+export interface Layer1Signals {
+  /** Conventional-commit type (feat/fix/refactor/chore/…) or null. */
+  conventionalType: string | null;
+  /** Git trailers (Key: value lines in the body), keyed lowercase. */
+  trailers: Record<string, string>;
+  /** Issue / PR references (#123). */
+  issueRefs: string[];
+  /** Body length in chars (subject excluded). */
+  bodyLength: number;
+  /** Rationale connective phrases found ("because", "instead of", …). */
+  rationaleMarkers: string[];
+}
+
+/** Layer-1 gate verdict. */
+export interface Layer1Verdict {
+  likelyDecision: boolean;
+  reason: string;
+  signals: Layer1Signals;
+}
+
+export type DecisionKind = 'decided' | 'because' | 'invariant' | 'gotcha';
+
+/** A single extracted decision, ready to become a code-memory fact. */
+export interface DecisionCandidate {
+  kind: DecisionKind;
+  text: string;
+  /** File anchor — "src/x.ts". Mapped to externalRef code:<path> by the sink. */
+  anchor: string;
+  /** Commit SHA provenance. */
+  commit: string;
+  /** Optional file:line provenance. */
+  location?: string;
+  validFrom: string;
+  confidence?: number;
+}
+
+/** Layer 1 — cheap admit/reject gate. Swap the heuristic impl for a trained
+ *  classifier without touching the pipeline. */
+export interface DecisionClassifier {
+  classify(commit: CommitInput): Layer1Verdict;
+}
+
+/** Layer 2 — LLM extraction of decision candidates from an admitted commit. */
+export interface DecisionExtractor {
+  extract(commit: CommitInput): Promise<DecisionCandidate[]>;
+}
+
+/** Terminal sink — records one candidate into brain (HTTP /v1/ingest/fact). */
+export interface DecisionSink {
+  record(candidate: DecisionCandidate): Promise<{ outcome: string }>;
+}
+
+export interface CaptureSummary {
+  scanned: number;
+  trivialSkipped: number;
+  classifierRejected: number;
+  extracted: number;
+  recorded: number;
+  failures: number;
+}

--- a/test/code-memory-capture-io.unit-spec.ts
+++ b/test/code-memory-capture-io.unit-spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Code-memory Phase 1 — IO-layer unit coverage: LLM-extraction parsing +
+ * grounding, the HTTP sink request shape, and the git-log parser. The OpenAI
+ * call and the network are behind injected seams, so these run offline.
+ */
+import {
+  buildExtractionPrompt,
+  parseCandidates,
+} from '../src/code-memory/capture/llm-extractor';
+import { HttpDecisionSink } from '../src/code-memory/capture/http-sink';
+import { parseGitLog } from '../src/code-memory/capture/git-commits';
+import type { CommitInput } from '../src/code-memory/capture/types';
+
+const COMMIT: CommitInput = {
+  sha: 'f0e824b1',
+  message: 'refactor: split IngestService\n\nWhy: 21 positional args drifted.',
+  changedFiles: ['src/ingest/fact-resolver.service.ts', 'src/ingest/ingest.service.ts'],
+  authorDate: '2026-06-28T10:00:00Z',
+};
+
+describe('buildExtractionPrompt', () => {
+  it('includes the message and constrains anchors to changed files', () => {
+    const { system, user } = buildExtractionPrompt(COMMIT);
+    expect(system).toMatch(/STRICT JSON/);
+    expect(user).toContain('21 positional args drifted');
+    expect(user).toContain('- src/ingest/fact-resolver.service.ts');
+  });
+});
+
+describe('parseCandidates — grounding', () => {
+  it('parses {decisions:[...]} and stamps commit + validFrom', () => {
+    const raw = JSON.stringify({
+      decisions: [
+        {
+          kind: 'decided',
+          text: 'Route every write through one gateway',
+          anchor: 'src/ingest/fact-resolver.service.ts',
+          confidence: 0.9,
+        },
+      ],
+    });
+    const out = parseCandidates(raw, COMMIT);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      kind: 'decided',
+      anchor: 'src/ingest/fact-resolver.service.ts',
+      commit: 'f0e824b1',
+      validFrom: '2026-06-28T10:00:00Z',
+      confidence: 0.9,
+    });
+  });
+
+  it('drops a candidate whose anchor is not a changed file (multi-file commit)', () => {
+    const raw = JSON.stringify({
+      decisions: [
+        { kind: 'gotcha', text: 'g', anchor: 'src/not/touched.ts' },
+      ],
+    });
+    expect(parseCandidates(raw, COMMIT)).toHaveLength(0);
+  });
+
+  it('re-anchors to the sole changed file when the model picked a wrong path', () => {
+    const single: CommitInput = { ...COMMIT, changedFiles: ['src/only.ts'] };
+    const raw = JSON.stringify({
+      decisions: [{ kind: 'invariant', text: 'must hold', anchor: 'whatever.ts' }],
+    });
+    const out = parseCandidates(raw, single);
+    expect(out).toHaveLength(1);
+    expect(out[0].anchor).toBe('src/only.ts');
+  });
+
+  it('parses fenced ```json``` and skips invalid kinds', () => {
+    const raw =
+      '```json\n{"decisions":[{"kind":"nonsense","text":"x","anchor":"src/ingest/ingest.service.ts"},{"kind":"because","text":"real","anchor":"src/ingest/ingest.service.ts"}]}\n```';
+    const out = parseCandidates(raw, COMMIT);
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe('because');
+  });
+
+  it('returns [] on unparseable output', () => {
+    expect(parseCandidates('the model refused', COMMIT)).toEqual([]);
+  });
+});
+
+describe('HttpDecisionSink', () => {
+  it('POSTs /v1/ingest/fact with code anchor + provenance', async () => {
+    const calls: any[] = [];
+    const fetchImpl = (url: string, init: any) => {
+      calls.push({ url, init });
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ outcome: 'INSERTED' }),
+      });
+    };
+    const sink = new HttpDecisionSink({
+      baseUrl: 'https://brain.test',
+      apiKey: 'k',
+      fetchImpl,
+    });
+    const out = await sink.record({
+      kind: 'decided',
+      text: 'one gateway',
+      anchor: 'src/ingest/fact-resolver.service.ts',
+      commit: 'f0e824b1',
+      location: 'src/ingest/fact-resolver.service.ts:145',
+      validFrom: '2026-06-28T10:00:00Z',
+      confidence: 0.9,
+    });
+    expect(out.outcome).toBe('INSERTED');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://brain.test/v1/ingest/fact');
+    expect(calls[0].init.headers.authorization).toBe('Bearer k');
+    const body = JSON.parse(calls[0].init.body);
+    expect(body.entityRef).toEqual({
+      vertical: 'code',
+      id: 'src/ingest/fact-resolver.service.ts',
+    });
+    expect(body.predicate).toBe('decided');
+    expect(body.source.eventId).toBe('f0e824b1');
+    expect(body.source.recorder).toBe('code_memory_capture');
+    expect(body.source.messageId).toBe('src/ingest/fact-resolver.service.ts:145');
+  });
+
+  it('throws on a non-ok response', async () => {
+    const sink = new HttpDecisionSink({
+      baseUrl: 'https://brain.test',
+      apiKey: 'k',
+      fetchImpl: () =>
+        Promise.resolve({ ok: false, status: 503, json: () => Promise.resolve({}) }),
+    });
+    await expect(
+      sink.record({
+        kind: 'gotcha',
+        text: 'g',
+        anchor: 'a.ts',
+        commit: 'c',
+        validFrom: '2026-06-28T10:00:00Z',
+      }),
+    ).rejects.toThrow(/503/);
+  });
+});
+
+describe('parseGitLog', () => {
+  it('parses sha / authorDate / message / changed files', () => {
+    const FS = '\x1f';
+    const RS = '\x1e';
+    const raw =
+      `${RS}f0e824b${FS}2026-06-28T10:00:00Z${FS}refactor: split service\n\nWhy: drift.${FS}\n` +
+      `src/ingest/fact-resolver.service.ts\nsrc/ingest/ingest.service.ts\n` +
+      `${RS}a1211e8${FS}2026-06-27T09:00:00Z${FS}chore: bump${FS}\npackage.json\n`;
+    const commits = parseGitLog(raw);
+    expect(commits).toHaveLength(2);
+    expect(commits[0].sha).toBe('f0e824b');
+    expect(commits[0].authorDate).toBe('2026-06-28T10:00:00Z');
+    expect(commits[0].message).toMatch(/split service/);
+    expect(commits[0].changedFiles).toEqual([
+      'src/ingest/fact-resolver.service.ts',
+      'src/ingest/ingest.service.ts',
+    ]);
+    expect(commits[1].changedFiles).toEqual(['package.json']);
+  });
+
+  it('returns [] on empty input', () => {
+    expect(parseGitLog('')).toEqual([]);
+  });
+});

--- a/test/code-memory-capture.unit-spec.ts
+++ b/test/code-memory-capture.unit-spec.ts
@@ -1,0 +1,214 @@
+/**
+ * Code-memory Phase 1 — capture pipeline unit coverage.
+ *
+ * Pins the deterministic Layer-1 gate (HeuristicDecisionClassifier) and the
+ * pipeline orchestration (filter → classify → extract → sink) with stubbed
+ * Layer-2 + sink. The LLM extractor and HTTP sink are exercised only behind
+ * their interfaces here — their concrete impls are integration concerns.
+ */
+import { parseCommitSignals } from '../src/code-memory/capture/commit-signals';
+import { HeuristicDecisionClassifier } from '../src/code-memory/capture/heuristic-classifier';
+import { runCapturePipeline } from '../src/code-memory/capture/capture-pipeline';
+import type {
+  CommitInput,
+  DecisionCandidate,
+  DecisionExtractor,
+  DecisionSink,
+} from '../src/code-memory/capture/types';
+
+function commit(over: Partial<CommitInput>): CommitInput {
+  return {
+    sha: 'a1211e8d',
+    message: 'chore: bump deps',
+    changedFiles: ['package.json'],
+    authorDate: '2026-06-28T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('parseCommitSignals', () => {
+  it('extracts conventional type, trailers, issue refs, rationale markers', () => {
+    const s = parseCommitSignals(
+      commit({
+        message: `refactor(ingest): split IngestService (#67)
+
+Split the god-class because 21 positional args drifted between call-sites.
+Why: max-params=3 gate.
+Decision: route every write through one gateway.`,
+      }),
+    );
+    expect(s.conventionalType).toBe('refactor');
+    expect(s.issueRefs).toContain('67');
+    expect(s.trailers.why).toMatch(/max-params/);
+    expect(s.trailers.decision).toMatch(/one gateway/);
+    expect(s.rationaleMarkers).toContain('because');
+  });
+
+  it('handles a subject-only message (no body)', () => {
+    const s = parseCommitSignals(commit({ message: 'fix: typo' }));
+    expect(s.conventionalType).toBe('fix');
+    expect(s.bodyLength).toBe(0);
+    expect(s.rationaleMarkers).toHaveLength(0);
+  });
+});
+
+describe('HeuristicDecisionClassifier', () => {
+  const c = new HeuristicDecisionClassifier();
+
+  it('rejects merge commits', () => {
+    const v = c.classify(commit({ message: 'Merge pull request #5 from x/y' }));
+    expect(v.likelyDecision).toBe(false);
+    expect(v.reason).toMatch(/merge/);
+  });
+
+  it('admits on an explicit decision/rationale trailer', () => {
+    const v = c.classify(
+      commit({ message: 'fix: x\n\nWhy: prevents a race under FANOUT' }),
+    );
+    expect(v.likelyDecision).toBe(true);
+    expect(v.reason).toMatch(/trailer/);
+  });
+
+  it('rejects a low-signal type with no body', () => {
+    const v = c.classify(commit({ message: 'chore: bump deps' }));
+    expect(v.likelyDecision).toBe(false);
+    expect(v.reason).toMatch(/low-signal/);
+  });
+
+  it('admits when rationale markers appear in prose', () => {
+    const v = c.classify(
+      commit({
+        message: 'style: reformat\n\nReordered so that the hot path stays inlined instead of a call.',
+      }),
+    );
+    expect(v.likelyDecision).toBe(true);
+    expect(v.reason).toMatch(/rationale/);
+  });
+
+  it('admits a decision-type with an explanatory body', () => {
+    const v = c.classify(
+      commit({
+        message: `refactor: extract FactResolverService
+
+The single fn::resolve_fact gateway centralises the 21-arg call so a
+signature change cannot drift the two call-sites out of sync.`,
+      }),
+    );
+    expect(v.likelyDecision).toBe(true);
+    expect(v.reason).toMatch(/decision-type|explanatory body/);
+  });
+
+  it('rejects a bare decision-type subject with no body', () => {
+    const v = c.classify(commit({ message: 'feat: add endpoint' }));
+    expect(v.likelyDecision).toBe(false);
+  });
+});
+
+describe('runCapturePipeline', () => {
+  const classifier = new HeuristicDecisionClassifier();
+
+  function stubExtractor(bySha: Record<string, DecisionCandidate[]>): DecisionExtractor {
+    return {
+      extract: (cmt) => Promise.resolve(bySha[cmt.sha] ?? []),
+    };
+  }
+  function collectingSink(): DecisionSink & { recorded: DecisionCandidate[] } {
+    const recorded: DecisionCandidate[] = [];
+    return {
+      recorded,
+      record: (cand) => {
+        recorded.push(cand);
+        return Promise.resolve({ outcome: 'INSERTED' });
+      },
+    };
+  }
+
+  it('skips merge + classifier-rejected, extracts + records the rest', async () => {
+    const sink = collectingSink();
+    const candidate: DecisionCandidate = {
+      kind: 'decided',
+      text: 'route writes through one gateway',
+      anchor: 'src/ingest/fact-resolver.service.ts',
+      commit: 'dec1',
+      validFrom: '2026-06-28T00:00:00Z',
+    };
+    const summary = await runCapturePipeline({
+      commits: [
+        commit({ sha: 'merge1', message: 'Merge pull request #1 from a/b' }),
+        commit({ sha: 'chore1', message: 'chore: bump deps' }),
+        commit({
+          sha: 'dec1',
+          message: 'refactor: split service\n\nbecause the god-class drifted between call-sites and we wanted ≤3 deps.',
+        }),
+      ],
+      classifier,
+      extractor: stubExtractor({ dec1: [candidate] }),
+      sink,
+    });
+
+    expect(summary.scanned).toBe(3);
+    expect(summary.trivialSkipped).toBe(1);
+    expect(summary.classifierRejected).toBe(1);
+    expect(summary.extracted).toBe(1);
+    expect(summary.recorded).toBe(1);
+    expect(summary.failures).toBe(0);
+    expect(sink.recorded).toHaveLength(1);
+    expect(sink.recorded[0].anchor).toMatch(/fact-resolver/);
+  });
+
+  it('counts an extractor failure without aborting the run', async () => {
+    const sink = collectingSink();
+    const extractor: DecisionExtractor = {
+      extract: (cmt) =>
+        cmt.sha === 'boom'
+          ? Promise.reject(new Error('LLM down'))
+          : Promise.resolve([
+              {
+                kind: 'gotcha',
+                text: 'g',
+                anchor: 'a.ts',
+                commit: cmt.sha,
+                validFrom: '2026-06-28T00:00:00Z',
+              },
+            ]),
+    };
+    const admit = (sha: string) =>
+      commit({ sha, message: `fix: x\n\nWhy: rationale body for ${sha}` });
+
+    const summary = await runCapturePipeline({
+      commits: [admit('boom'), admit('ok')],
+      classifier,
+      extractor,
+      sink,
+    });
+
+    expect(summary.failures).toBe(1);
+    expect(summary.recorded).toBe(1);
+    expect(sink.recorded).toHaveLength(1);
+  });
+
+  it('counts a sink failure per candidate and continues', async () => {
+    const failingSink: DecisionSink = {
+      record: () => Promise.reject(new Error('503 from brain')),
+    };
+    const summary = await runCapturePipeline({
+      commits: [commit({ sha: 'd', message: 'fix: x\n\nWhy: because reasons here for body' })],
+      classifier,
+      extractor: stubExtractor({
+        d: [
+          {
+            kind: 'decided',
+            text: 't',
+            anchor: 'a.ts',
+            commit: 'd',
+            validFrom: '2026-06-28T00:00:00Z',
+          },
+        ],
+      }),
+      sink: failingSink,
+    });
+    expect(summary.extracted).toBe(1);
+    expect(summary.recorded).toBe(0);
+    expect(summary.failures).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Phase 1 of the code-memory DomainPack: **auto-capture the engineering "why" from version-control artifacts**, per the two chosen forks — **hybrid client-side** + **layered (BiLSTM→LLM)**.

Runs where the code lives (CI / git hook / locally): reads commit messages + changed file **paths**, gates them, extracts decisions with the caller's **own LLM key**, and POSTs **only the resulting facts** (+ file anchors + commit provenance) to brain's existing `/v1/ingest/fact`. **Raw source never leaves the machine.**

### Layered extraction (`src/code-memory/capture/`)
- **Layer 1 — deterministic** (`HeuristicDecisionClassifier`, no IO): admits commits with a decision/rationale trailer, rationale prose, or a decision-type + explanatory body; rejects merges and low-signal/no-body commits. It implements the **exact `DecisionClassifier` interface a trained BiLSTM would** — a drop-in once a labeled commit corpus exists. brain has no training pipeline/data today, so the heuristic ships now; **every reject carries a `reason`** (no silent over-filtering).
- **Layer 2 — LLM** (`LlmDecisionExtractor`): extracts the Decision/Rationale taxonomy (`decided`/`because`/`invariant`/`gotcha`). **Grounded** — a candidate's anchor must be a changed file or it's re-anchored/dropped; the model can't invent a path. OpenAI call behind an injectable `ChatComplete` seam.
- `capture-pipeline`: filter → classify → extract → sink; per-commit failures counted + logged, never abort the run.
- `HttpDecisionSink` → `/v1/ingest/fact` (facts only). `git-commits` reads the range (squash-merge bodies carry the PR rationale — no GitHub API needed).
- CLI `scripts/capture-decisions.ts` (`pnpm capture:decisions`), `--dry-run` supported.

### Honest scope note
The "BiLSTM" fork is realised as a **heuristic behind the model's interface**, not a trained model — building/training one needs a labeled corpus + serving brain doesn't have. Swap-in seam is ready; say the word to scope the training track. Anchors are **file-level** in Phase 1; symbol-level (SCIP) + drift-resistant re-anchoring is Phase 2.

## Verification
- No server changes — capture is a pure client over the Phase 0 ingest path.
- `pnpm exec tsc --noEmit` · `pnpm typecheck` · `pnpm lint` · max-params ≤3 ✓
- 721 unit (+21 capture: classifier, pipeline, grounding, HTTP sink, git parser) · 132 e2e · 9 jobs ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)