### PR TITLE
feat(domain-packs): pluggable versioned ontology pack standard + namespacing (code-memory becomes pack #1)

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -1,0 +1,97 @@
+# Domain Packs — the ontology extension standard
+
+> A **Domain Pack** is a versioned, pluggable bundle of ontology that extends
+> the brain predicate registry **without forking core**. Packs let a domain
+> (code-memory, real-estate, fintech, …) — or the community — ship its own
+> typed predicates that brain merges into every tenant's registry. This file is
+> the standard third parties conform to.
+
+## Why packs
+
+Brain's predicate registry decides how facts are typed, conflict-resolved, and
+decayed (semantics: `single_active` / `append_only` / `bitemporal`). Core ships
+a general seed (`name`, `said`, `plan`, …). A domain needs its own vocabulary —
+but baking every domain's predicates into the core seed doesn't scale and can't
+be community-extended. Packs make the ontology a first-class, versioned plugin.
+
+## The manifest
+
+A pack is a `DomainPackManifest` (`src/ai/domain-packs/manifest.ts`):
+
+```ts
+interface DomainPackManifest {
+  id: string;            // snake_case, no "__" — the predicate namespace
+  version: string;       // semver MAJOR.MINOR.PATCH — bump to ship an update
+  description: string;
+  predicates: PackPredicate[];   // the ontology this pack contributes
+}
+
+type PackPredicate = {
+  localId: string;       // snake_case, no "__"
+  displayLabel: string;
+  description: string;   // the extractor "card" (TYPE / ADMIT / VALUE)
+  datatype: 'string' | 'number' | 'date' | 'datetime' | 'enum' | 'json';
+  semantics: 'append_only' | 'single_active' | 'bitemporal';
+  decayHalfLifeDays: number | null;
+  piiClass: 'none' | 'identifier' | 'behavioral' | 'text' | 'sensitive';
+  status: 'active' | 'proposed' | 'aliased' | 'deprecated';
+  requiresScope?: string; allowedValues?: string[]; /* …optional */
+};
+```
+
+## Namespacing (the one hard rule)
+
+Every pack predicate is stored as **`<packId>__<localId>`** — double underscore
+is the reserved separator. A pack declaring `id: 'code_memory'` with a predicate
+`localId: 'decided'` becomes the registry predicate **`code_memory__decided`**.
+
+Why `__` and not `/` or `:`:
+- predicate ids must match `^[a-z][a-z0-9_]*$` (admin CRUD validation) and flow
+  through REST path params — `/` breaks routing, `:` collides with record ids.
+- `__` stays inside the existing charset, so admin tooling and routing keep
+  working unchanged.
+
+**Core predicates are the reserved UNPREFIXED namespace** and are never renamed
+(that would orphan existing facts). Packs MUST namespace; the loader enforces it
+and **fails the boot on any id collision** (pack-vs-core or pack-vs-pack) rather
+than silently shadowing.
+
+## How merge + install works today
+
+- `src/ai/domain-packs/index.ts` lists `BUILTIN_PACKS` and exports
+  `SEED_PREDICATES = assembleSeed(CORE_PREDICATES, BUILTIN_PACKS)` — validated +
+  collision-checked at module load.
+- The predicate registry seeds **`SEED_PREDICATES`** (core + packs) into each
+  tenant's `knowledge_predicate` table on first access (idempotent — admin
+  overrides survive). `policyFor` falls back to the same merged set.
+- So installing a builtin pack = author a manifest module + add it to
+  `BUILTIN_PACKS`; its namespaced predicates are seeded into every tenant.
+
+## Authoring a pack
+
+1. Create `src/ai/domain-packs/<your-pack>.pack.ts` exporting a
+   `DomainPackManifest`. Use the reference: `code-memory.pack.ts`.
+2. Validate it: `pnpm pack:validate path/to/pack.json` (or rely on the unit
+   test — `assembleSeed` throws at load on a bad/colliding pack).
+3. Register it in `BUILTIN_PACKS` (`index.ts`).
+4. Expose ergonomic helpers for consumers (see `codeMemoryPredicateId` /
+   `codeMemoryKindOf`) so tools pass local kinds while the registry stores the
+   namespaced id.
+5. Bump `version` (semver) whenever you change the ontology. Renames/removals
+   should go through the registry's alias/deprecate lifecycle, not a hard delete.
+
+## Reference pack
+
+`code_memory` (`src/ai/domain-packs/code-memory.pack.ts`) — the non-derivable
+engineering "why" of a codebase: `decided`, `because`, `invariant`, `gotcha`,
+anchored to code anchors. See `docs/roadmap/code-memory-domain.md`.
+
+## Roadmap (not built yet)
+
+This phase delivers the **standard + namespacing + the merge loader**. Still
+ahead, to make packs fully community-distributable:
+- **Runtime per-tenant install/uninstall** — a `domain_pack` table recording
+  installed packs + pinned versions per tenant; install/upgrade/rollback API.
+- **Distribution** — load packs from JSON manifests / a registry, not only
+  compiled modules; signed/checksummed packs.
+- **Per-pack eval fixtures + extraction profiles** carried in the manifest.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eval:diff": "ts-node -r tsconfig-paths/register scripts/eval-baseline-diff.ts",
     "bench:router": "ts-node -r tsconfig-paths/register scripts/bench-chat-router.ts",
     "capture:decisions": "ts-node -r tsconfig-paths/register scripts/capture-decisions.ts",
+    "pack:validate": "ts-node -r tsconfig-paths/register scripts/validate-pack.ts",
     "test:eval:fat": "pnpm build && FAT_TENANT_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=fat-tenant",
     "test:eval:directory": "pnpm build && DIRECTORY_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=directory",
     "test:eval:json": "pnpm build && jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=json-directory",

--- a/scripts/validate-pack.ts
+++ b/scripts/validate-pack.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env ts-node
+/**
+ * Domain Pack validator CLI (docs/domain-packs.md).
+ *
+ *   pnpm pack:validate path/to/pack.json
+ *
+ * Validates a Domain Pack manifest (JSON) against the standard — snake_case +
+ * non-colliding namespaced ids, semver, non-empty predicate set. Community pack
+ * authors run this before publishing. Exit 0 = valid, 1 = invalid.
+ */
+import { readFileSync } from 'node:fs';
+import { assembleSeed, validatePack } from '../src/ai/domain-packs/validate';
+import { CORE_PREDICATES } from '../src/ai/predicate-registry-internals/core-seed';
+import type { DomainPackManifest } from '../src/ai/domain-packs/manifest';
+
+function main(): void {
+  const path = process.argv[2];
+  if (!path) throw new Error('usage: pack:validate <path/to/pack.json>');
+
+  const manifest = JSON.parse(readFileSync(path, 'utf8')) as DomainPackManifest;
+  validatePack(manifest);
+  // Also assemble against core to surface any id collision with core predicates.
+  assembleSeed(CORE_PREDICATES, [manifest]);
+
+  console.log(
+    `✓ pack "${manifest.id}" v${manifest.version} valid — ${manifest.predicates.length} predicate(s), namespaced ${manifest.id}__*`,
+  );
+}
+
+try {
+  main();
+} catch (e) {
+  console.error(`✗ invalid pack: ${(e as Error).message}`);
+  process.exit(1);
+}

--- a/src/ai/domain-packs/code-memory.pack.ts
+++ b/src/ai/domain-packs/code-memory.pack.ts
@@ -1,0 +1,96 @@
+import { composePredicateId, type DomainPackManifest } from './manifest';
+
+/**
+ * The first real Domain Pack: code-memory (docs/roadmap/code-memory-domain.md).
+ * The non-derivable engineering "why" of a codebase — decisions, rationale,
+ * invariants, gotchas — anchored to code anchors. Previously these predicates
+ * were hardcoded in CORE_PREDICATES (Phase 0 PoC shortcut); they now live here
+ * as a versioned, namespaced pack, proving the pack standard end-to-end.
+ *
+ * Bump `version` to ship an updated code-memory ontology.
+ */
+export const CODE_MEMORY_PACK: DomainPackManifest = {
+  id: 'code_memory',
+  version: '0.1.0',
+  description:
+    'Non-derivable engineering "why" of a codebase — decisions, rationale, invariants, gotchas anchored to code.',
+  predicates: [
+    {
+      localId: 'decided',
+      displayLabel: 'decided',
+      description: `TYPE   subject is a code anchor; value is a design decision
+ADMIT  text states a design/implementation decision made for this code
+       location ("resolve facts through one gateway", "split per phase")
+VALUE  the decision statement`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'because',
+      displayLabel: 'because',
+      description: `TYPE   subject is a code anchor; value is the rationale for a decision
+ADMIT  text gives the reason a decision was made ("21 positional args
+       drifted between call-sites")
+VALUE  one rationale per fact (multi-valued)`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'invariant',
+      displayLabel: 'invariant',
+      description: `TYPE   subject is a code anchor; value is a constraint that must hold
+ADMIT  text states a rule the code must satisfy ("always export a new
+       @Injectable from the @Global module or e2e DI-boot fails")
+VALUE  the invariant statement`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'gotcha',
+      displayLabel: 'gotcha',
+      description: `TYPE   subject is a code anchor; value is a non-obvious trap
+ADMIT  text warns of a counter-intuitive behaviour or pitfall
+       ("pnpm test -- --testPathPattern does NOT work — double dash")
+VALUE  one gotcha per fact (multi-valued)`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+  ],
+};
+
+/** The pack-local kinds, in author order. The ergonomic surface for the MCP
+ *  `record_decision` tool + the capture pipeline (callers pass `decided`, not
+ *  the namespaced id). */
+export const CODE_MEMORY_KINDS = ['decided', 'because', 'invariant', 'gotcha'] as const;
+export type CodeMemoryKind = (typeof CODE_MEMORY_KINDS)[number];
+
+/** Fully-qualified, namespaced predicate id for a code-memory kind, e.g.
+ *  `code_memory__decided`. Single source of truth for every consumer. */
+export function codeMemoryPredicateId(kind: CodeMemoryKind): string {
+  return composePredicateId(CODE_MEMORY_PACK.id, kind);
+}
+
+/** The set of namespaced code-memory predicate ids (for filtering reads). */
+export const CODE_MEMORY_PREDICATE_IDS: string[] = CODE_MEMORY_KINDS.map(
+  codeMemoryPredicateId,
+);
+
+/** Strip the pack prefix from a namespaced id → the local kind (for display). */
+export function codeMemoryKindOf(predicateId: string): string {
+  const prefix = `${CODE_MEMORY_PACK.id}__`;
+  return predicateId.startsWith(prefix)
+    ? predicateId.slice(prefix.length)
+    : predicateId;
+}

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -1,0 +1,29 @@
+import { CORE_PREDICATES } from '../predicate-registry-internals/core-seed';
+import type { PredicateDefinition } from '../predicate-registry-internals/types';
+import type { DomainPackManifest } from './manifest';
+import { assembleSeed } from './validate';
+import { CODE_MEMORY_PACK } from './code-memory.pack';
+
+/**
+ * The installed Domain Packs and the assembled bootstrap seed the predicate
+ * registry consumes. Adding a builtin pack = author a manifest module + list it
+ * here; its (namespaced) predicates are then seeded into every tenant on
+ * bootstrap. Runtime per-tenant install/uninstall + distribution is the next
+ * increment; this is the standard + the merge loader.
+ */
+export const BUILTIN_PACKS: DomainPackManifest[] = [CODE_MEMORY_PACK];
+
+/**
+ * Core predicates + every builtin pack's namespaced predicates. Validated and
+ * collision-checked at module load (assembleSeed throws on a bad/ colliding
+ * pack — a misconfigured pack fails the boot, not silently). The registry uses
+ * this everywhere it previously used CORE_PREDICATES.
+ */
+export const SEED_PREDICATES: PredicateDefinition[] = assembleSeed(
+  CORE_PREDICATES,
+  BUILTIN_PACKS,
+);
+
+export * from './manifest';
+export * from './validate';
+export * from './code-memory.pack';

--- a/src/ai/domain-packs/manifest.ts
+++ b/src/ai/domain-packs/manifest.ts
@@ -1,0 +1,46 @@
+import type { PredicateDefinition } from '../predicate-registry-internals/types';
+
+/**
+ * Domain Pack standard (docs/domain-packs.md).
+ *
+ * A DomainPack is a versioned, pluggable bundle of ontology that extends the
+ * brain predicate registry without forking core. The community authors packs;
+ * brain merges their predicates (namespaced) into every tenant's registry on
+ * bootstrap. This file is the manifest CONTRACT — the schema third parties
+ * conform to.
+ *
+ * Namespacing: every pack predicate is stored as `<packId>__<localId>` (double
+ * underscore = the reserved separator). This keeps ids inside the existing
+ * `^[a-z][a-z0-9_]*$` predicate-id charset (so admin CRUD + routing keep
+ * working) and guarantees community packs can't collide with core or each
+ * other. Core predicates are the reserved UNPREFIXED namespace and are never
+ * renamed (that would orphan existing facts).
+ */
+
+/** Reserved namespace separator between packId and a predicate's localId. */
+export const PACK_NAMESPACE_SEP = '__';
+
+/** A predicate as declared INSIDE a pack — a core PredicateDefinition minus the
+ *  fully-qualified id (the loader composes it) and the provenance tag (the
+ *  loader stamps it). The pack author supplies a `localId` instead. */
+export type PackPredicate = Omit<
+  PredicateDefinition,
+  'predicateId' | 'createdBy'
+> & { localId: string };
+
+/** The versioned, self-describing pack manifest — the community standard. */
+export interface DomainPackManifest {
+  /** snake_case pack id, no `__`. The predicate namespace. */
+  id: string;
+  /** semver MAJOR.MINOR.PATCH. Bump to ship an updated ontology. */
+  version: string;
+  /** One-line human description. */
+  description: string;
+  /** The ontology this pack contributes. */
+  predicates: PackPredicate[];
+}
+
+/** Compose the stored, namespaced predicate id for a pack-local predicate. */
+export function composePredicateId(packId: string, localId: string): string {
+  return `${packId}${PACK_NAMESPACE_SEP}${localId}`;
+}

--- a/src/ai/domain-packs/validate.ts
+++ b/src/ai/domain-packs/validate.ts
@@ -1,0 +1,80 @@
+import type { PredicateDefinition } from '../predicate-registry-internals/types';
+import {
+  composePredicateId,
+  PACK_NAMESPACE_SEP,
+  type DomainPackManifest,
+} from './manifest';
+
+/**
+ * Validation + assembly for the Domain Pack standard. `validatePack` is what a
+ * community author runs (also exposed via `pnpm pack:validate`); `assembleSeed`
+ * is what the predicate registry runs to merge packs into the bootstrap seed,
+ * failing loudly on any id collision rather than silently shadowing.
+ */
+
+const SNAKE = /^[a-z][a-z0-9_]*$/;
+const SEMVER = /^\d+\.\d+\.\d+$/;
+
+export class DomainPackError extends Error {}
+
+export function validatePack(pack: DomainPackManifest): void {
+  if (!SNAKE.test(pack.id) || pack.id.includes(PACK_NAMESPACE_SEP)) {
+    throw new DomainPackError(
+      `pack id "${pack.id}" must be snake_case and must not contain "${PACK_NAMESPACE_SEP}"`,
+    );
+  }
+  if (!SEMVER.test(pack.version)) {
+    throw new DomainPackError(
+      `pack "${pack.id}" version "${pack.version}" must be semver MAJOR.MINOR.PATCH`,
+    );
+  }
+  if (pack.predicates.length === 0) {
+    throw new DomainPackError(`pack "${pack.id}" declares no predicates`);
+  }
+  const seen = new Set<string>();
+  for (const p of pack.predicates) {
+    if (!SNAKE.test(p.localId) || p.localId.includes(PACK_NAMESPACE_SEP)) {
+      throw new DomainPackError(
+        `pack "${pack.id}" localId "${p.localId}" must be snake_case and must not contain "${PACK_NAMESPACE_SEP}"`,
+      );
+    }
+    if (seen.has(p.localId)) {
+      throw new DomainPackError(
+        `pack "${pack.id}" declares duplicate localId "${p.localId}"`,
+      );
+    }
+    seen.add(p.localId);
+  }
+}
+
+/**
+ * Merge the core seed with installed packs into one PredicateDefinition[] for
+ * the registry to bootstrap. Each pack is validated; pack predicates are
+ * namespaced (`<packId>__<localId>`) and stamped `createdBy:'system'`. Throws
+ * on ANY id collision (pack-vs-core or pack-vs-pack) — no silent shadowing.
+ */
+export function assembleSeed(
+  core: PredicateDefinition[],
+  packs: DomainPackManifest[],
+): PredicateDefinition[] {
+  const byId = new Map<string, string>(); // predicateId -> origin (for errors)
+  for (const c of core) byId.set(c.predicateId, 'core');
+
+  const composed: PredicateDefinition[] = [];
+  for (const pack of packs) {
+    validatePack(pack);
+    for (const p of pack.predicates) {
+      const predicateId = composePredicateId(pack.id, p.localId);
+      const prior = byId.get(predicateId);
+      if (prior) {
+        throw new DomainPackError(
+          `predicate id collision "${predicateId}": pack "${pack.id}" vs ${prior}`,
+        );
+      }
+      byId.set(predicateId, `pack "${pack.id}"`);
+      const { localId: _localId, ...rest } = p;
+      composed.push({ ...rest, predicateId, createdBy: 'system' });
+    }
+  }
+  return [...core, ...composed];
+}

--- a/src/ai/predicate-registry-internals/core-seed.ts
+++ b/src/ai/predicate-registry-internals/core-seed.ts
@@ -346,69 +346,9 @@ VALUE  one anti-pattern per fact (multi-valued)`,
     status: 'active',
     createdBy: 'system',
   },
-
-  // ── CODE-MEMORY DomainPack (docs/roadmap/code-memory-domain.md) ───────
-  // The non-derivable engineering "why" of a codebase, anchored to code
-  // anchors (knowledge_entity with externalRef "code__<scip-symbol>"). This
-  // is NOT a code index — it stores decisions / rationale / invariants /
-  // gotchas a parser cannot recover from source. decayHalfLifeDays:null —
-  // code knowledge doesn't decay on a wall clock; it's superseded by a newer
-  // decision (single_active) or accumulates (append_only).
-  {
-    predicateId: 'decided',
-    displayLabel: 'decided',
-    description: `TYPE   subject is a code anchor; value is a design decision
-ADMIT  text states a design/implementation decision made for this code
-       location ("resolve facts through one gateway", "split per phase")
-VALUE  the decision statement`,
-    datatype: 'string',
-    semantics: 'single_active',
-    decayHalfLifeDays: null,
-    piiClass: 'none',
-    status: 'active',
-    createdBy: 'system',
-  },
-  {
-    predicateId: 'because',
-    displayLabel: 'because',
-    description: `TYPE   subject is a code anchor; value is the rationale for a decision
-ADMIT  text gives the reason a decision was made ("21 positional args
-       drifted between call-sites")
-VALUE  one rationale per fact (multi-valued)`,
-    datatype: 'string',
-    semantics: 'append_only',
-    decayHalfLifeDays: null,
-    piiClass: 'none',
-    status: 'active',
-    createdBy: 'system',
-  },
-  {
-    predicateId: 'invariant',
-    displayLabel: 'invariant',
-    description: `TYPE   subject is a code anchor; value is a constraint that must hold
-ADMIT  text states a rule the code must satisfy ("always export a new
-       @Injectable from the @Global module or e2e DI-boot fails")
-VALUE  the invariant statement`,
-    datatype: 'string',
-    semantics: 'single_active',
-    decayHalfLifeDays: null,
-    piiClass: 'none',
-    status: 'active',
-    createdBy: 'system',
-  },
-  {
-    predicateId: 'gotcha',
-    displayLabel: 'gotcha',
-    description: `TYPE   subject is a code anchor; value is a non-obvious trap
-ADMIT  text warns of a counter-intuitive behaviour or pitfall
-       ("pnpm test -- --testPathPattern does NOT work — double dash")
-VALUE  one gotcha per fact (multi-valued)`,
-    datatype: 'string',
-    semantics: 'append_only',
-    decayHalfLifeDays: null,
-    piiClass: 'none',
-    status: 'active',
-    createdBy: 'system',
-  },
+  // NB: code-memory predicates (decided/because/invariant/gotcha) used to live
+  // here (Phase 0 PoC). They are now the `code_memory` Domain Pack
+  // (src/ai/domain-packs/code-memory.pack.ts), namespaced code_memory__*, and
+  // merged into the bootstrap seed via SEED_PREDICATES.
 ];
 

--- a/src/ai/predicate-registry.service.ts
+++ b/src/ai/predicate-registry.service.ts
@@ -16,7 +16,10 @@ import {
   type Semantics,
   SNAPSHOT_TTL_MS,
 } from './predicate-registry-internals/types';
-import { CORE_PREDICATES } from './predicate-registry-internals/core-seed';
+// Core + installed Domain Packs (namespaced predicates), assembled + collision-
+// checked at load. The registry seeds / falls back on the MERGED set so a pack's
+// predicates are bootstrapped into every tenant. See src/ai/domain-packs.
+import { SEED_PREDICATES } from './domain-packs';
 import {
   computeHash,
   deserializeFromRow,
@@ -129,7 +132,7 @@ export class PredicateRegistryService {
         embedding?: number[] | null;
       }>) ?? [];
       const existingIds = new Set(existing.map((r) => r.predicateId));
-      const missing = CORE_PREDICATES.filter(
+      const missing = SEED_PREDICATES.filter(
         (p) => !existingIds.has(p.predicateId),
       );
       if (missing.length > 0) {
@@ -176,7 +179,7 @@ export class PredicateRegistryService {
           `Backfilling embeddings for ${needBackfill.length} predicate(s) in ${companyId}`,
         );
         const texts = needBackfill.map((row) => {
-          const seed = CORE_PREDICATES.find(
+          const seed = SEED_PREDICATES.find(
             (p) => p.predicateId === row.predicateId,
           );
           return seed
@@ -250,7 +253,7 @@ export class PredicateRegistryService {
     // Fallback: CORE seed table by predicate id. Covers the case where the
     // tenant snapshot wasn't preloaded yet (early-boot search path) — the
     // policy reflects the code-side defaults until the cache populates.
-    const seed = CORE_PREDICATES.find((p) => p.predicateId === predicate);
+    const seed = SEED_PREDICATES.find((p) => p.predicateId === predicate);
     return seed ?? DEFAULT_FALLBACK;
   }
 

--- a/src/code-memory/capture/http-sink.ts
+++ b/src/code-memory/capture/http-sink.ts
@@ -1,3 +1,4 @@
+import { codeMemoryPredicateId } from '../../ai/domain-packs';
 import type { DecisionCandidate, DecisionSink } from './types';
 
 /**
@@ -38,7 +39,7 @@ export class HttpDecisionSink implements DecisionSink {
   async record(candidate: DecisionCandidate): Promise<{ outcome: string }> {
     const body = {
       entityRef: { vertical: CODE_VERTICAL, id: candidate.anchor },
-      predicate: candidate.kind,
+      predicate: codeMemoryPredicateId(candidate.kind),
       object: candidate.text,
       validFrom: candidate.validFrom,
       ...(candidate.confidence !== undefined

--- a/src/mcp/code-memory-tools.ts
+++ b/src/mcp/code-memory-tools.ts
@@ -3,6 +3,12 @@ import { z } from 'zod';
 import type { IngestService } from '../ingest/ingest.service';
 import type { EntitiesService } from '../entities/entities.service';
 import type { BrainScope } from '../auth/api-key.types';
+import {
+  CODE_MEMORY_KINDS,
+  CODE_MEMORY_PREDICATE_IDS,
+  codeMemoryKindOf,
+  codeMemoryPredicateId,
+} from '../ai/domain-packs';
 
 /**
  * Code-memory MCP surface (Phase 0 — docs/roadmap/code-memory-domain.md).
@@ -18,8 +24,6 @@ import type { BrainScope } from '../auth/api-key.types';
  * over the existing ingest + entity-read paths — no new retrieval engine.
  */
 
-/** The four code-memory predicates seeded in CORE_PREDICATES. */
-const CODE_MEMORY_KINDS = ['decided', 'because', 'invariant', 'gotcha'] as const;
 /** Vertical used for code-anchor external refs. */
 const CODE_VERTICAL = 'code';
 
@@ -63,15 +67,14 @@ export function registerCodeMemoryReadTools(opts: {
         asOfRaw: args.asOf,
         scopes,
       });
-      const memory = (profile?.facts ?? []).filter((f) =>
-        (CODE_MEMORY_KINDS as readonly string[]).includes(f.predicate),
-      );
+      const codeIds = new Set(CODE_MEMORY_PREDICATE_IDS);
+      const memory = (profile?.facts ?? []).filter((f) => codeIds.has(f.predicate));
       const out = {
         symbol: args.symbol,
         entityId: profile?.entityId ?? null,
         found: memory.length,
         memory: memory.map((f) => ({
-          kind: f.predicate,
+          kind: codeMemoryKindOf(f.predicate),
           text: f.object,
           validFrom: f.validFrom,
           validUntil: f.validUntil,
@@ -131,7 +134,7 @@ export function registerCodeMemoryWriteTools(opts: {
     async (args) => {
       const out = await deps.ingest.ingestFact(companyId, {
         entityRef: { vertical: CODE_VERTICAL, id: args.symbol },
-        predicate: args.kind,
+        predicate: codeMemoryPredicateId(args.kind),
         object: args.text,
         validFrom: args.validFrom ?? new Date().toISOString(),
         confidence: args.confidence,

--- a/test/code-memory-capture-io.unit-spec.ts
+++ b/test/code-memory-capture-io.unit-spec.ts
@@ -116,7 +116,7 @@ describe('HttpDecisionSink', () => {
       vertical: 'code',
       id: 'src/ingest/fact-resolver.service.ts',
     });
-    expect(body.predicate).toBe('decided');
+    expect(body.predicate).toBe('code_memory__decided');
     expect(body.source.eventId).toBe('f0e824b1');
     expect(body.source.recorder).toBe('code_memory_capture');
     expect(body.source.messageId).toBe('src/ingest/fact-resolver.service.ts:145');

--- a/test/code-memory.e2e-spec.ts
+++ b/test/code-memory.e2e-spec.ts
@@ -23,6 +23,10 @@ import { createApp } from './app-fixture';
 import { IngestService } from '../src/ingest/ingest.service';
 import { EntitiesService } from '../src/entities/entities.service';
 import type { BrainScope } from '../src/auth/api-key.types';
+import {
+  codeMemoryPredicateId,
+  type CodeMemoryKind,
+} from '../src/ai/domain-packs';
 
 describe('code-memory Phase 0 — record_decision → why round-trip', () => {
   let f: AppFixture;
@@ -42,9 +46,12 @@ describe('code-memory Phase 0 — record_decision → why round-trip', () => {
       scopes: READ,
     });
   };
-  const activeOf = (profile: Awaited<ReturnType<typeof recall>>, kind: string) =>
+  const activeOf = (
+    profile: Awaited<ReturnType<typeof recall>>,
+    kind: CodeMemoryKind,
+  ) =>
     (profile?.facts ?? []).filter(
-      (x) => x.predicate === kind && x.status === 'active',
+      (x) => x.predicate === codeMemoryPredicateId(kind) && x.status === 'active',
     );
 
   beforeAll(async () => {
@@ -59,7 +66,7 @@ describe('code-memory Phase 0 — record_decision → why round-trip', () => {
     const ingest = f.app.get(IngestService);
     const out = await ingest.ingestFact(f.companyId, {
       entityRef: { vertical: 'code', id: SYMBOL },
-      predicate: 'decided',
+      predicate: codeMemoryPredicateId('decided'),
       object: 'Route every fact write through one fn::resolve_fact gateway',
       validFrom: '2026-06-28T00:00:00Z',
       source: { vertical: 'code', recorder: 'code_memory', eventId: 'f0e824b' },
@@ -77,7 +84,7 @@ describe('code-memory Phase 0 — record_decision → why round-trip', () => {
     const ingest = f.app.get(IngestService);
     const out = await ingest.ingestFact(f.companyId, {
       entityRef: { vertical: 'code', id: SYMBOL },
-      predicate: 'decided',
+      predicate: codeMemoryPredicateId('decided'),
       object: 'Gateway also detects locale and writes the HyPE alt-embedding',
       validFrom: '2026-06-29T00:00:00Z',
       source: { vertical: 'code', recorder: 'code_memory', eventId: 'a002e1f' },
@@ -94,14 +101,14 @@ describe('code-memory Phase 0 — record_decision → why round-trip', () => {
     const ingest = f.app.get(IngestService);
     await ingest.ingestFact(f.companyId, {
       entityRef: { vertical: 'code', id: SYMBOL },
-      predicate: 'gotcha',
+      predicate: codeMemoryPredicateId('gotcha'),
       object: 'conflict weights are read from process.env, not ConfigService',
       validFrom: '2026-06-28T00:00:00Z',
       source: { vertical: 'code', recorder: 'code_memory' },
     });
     await ingest.ingestFact(f.companyId, {
       entityRef: { vertical: 'code', id: SYMBOL },
-      predicate: 'gotcha',
+      predicate: codeMemoryPredicateId('gotcha'),
       object: 'the resolve lock key is companyId + entityId + predicate (NUL-joined)',
       validFrom: '2026-06-28T00:00:00Z',
       source: { vertical: 'code', recorder: 'code_memory' },

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Domain Pack standard — manifest validation + seed assembly (namespacing,
+ * collision detection) + the code-memory pack wiring.
+ */
+import {
+  assembleSeed,
+  composePredicateId,
+  validatePack,
+  DomainPackError,
+  type DomainPackManifest,
+  type PackPredicate,
+} from '../src/ai/domain-packs';
+import {
+  CODE_MEMORY_PACK,
+  CODE_MEMORY_PREDICATE_IDS,
+  codeMemoryKindOf,
+  codeMemoryPredicateId,
+  SEED_PREDICATES,
+} from '../src/ai/domain-packs';
+import type { PredicateDefinition } from '../src/ai/predicate-registry-internals/types';
+
+function packPredicate(localId: string): PackPredicate {
+  return {
+    localId,
+    displayLabel: localId,
+    description: 'x',
+    datatype: 'string',
+    semantics: 'append_only',
+    decayHalfLifeDays: null,
+    piiClass: 'none',
+    status: 'active',
+  };
+}
+function pack(over: Partial<DomainPackManifest>): DomainPackManifest {
+  return {
+    id: 'demo',
+    version: '0.1.0',
+    description: 'demo',
+    predicates: [packPredicate('thing')],
+    ...over,
+  };
+}
+function corePredicate(predicateId: string): PredicateDefinition {
+  return {
+    predicateId,
+    displayLabel: predicateId,
+    description: 'x',
+    datatype: 'string',
+    semantics: 'append_only',
+    decayHalfLifeDays: null,
+    piiClass: 'none',
+    status: 'active',
+    createdBy: 'system',
+  };
+}
+
+describe('validatePack', () => {
+  it('accepts a well-formed pack', () => {
+    expect(() => validatePack(pack({}))).not.toThrow();
+  });
+  it('rejects a non-snake_case pack id', () => {
+    expect(() => validatePack(pack({ id: 'Demo-Pack' }))).toThrow(DomainPackError);
+  });
+  it('rejects a pack id containing the namespace separator', () => {
+    expect(() => validatePack(pack({ id: 'a__b' }))).toThrow(/__/);
+  });
+  it('rejects a non-semver version', () => {
+    expect(() => validatePack(pack({ version: '1.0' }))).toThrow(/semver/);
+  });
+  it('rejects an empty predicate set', () => {
+    expect(() => validatePack(pack({ predicates: [] }))).toThrow(/no predicates/);
+  });
+  it('rejects duplicate localIds', () => {
+    expect(() =>
+      validatePack(
+        pack({ predicates: [packPredicate('x'), packPredicate('x')] }),
+      ),
+    ).toThrow(/duplicate/);
+  });
+  it('rejects a localId containing the separator', () => {
+    expect(() =>
+      validatePack(pack({ predicates: [packPredicate('a__b')] })),
+    ).toThrow(DomainPackError);
+  });
+});
+
+describe('assembleSeed', () => {
+  it('namespaces pack predicates and keeps core unchanged', () => {
+    const core = [corePredicate('name')];
+    const merged = assembleSeed(core, [
+      pack({ id: 'demo', predicates: [packPredicate('thing')] }),
+    ]);
+    const ids = merged.map((p) => p.predicateId);
+    expect(ids).toContain('name');
+    expect(ids).toContain('demo__thing');
+    expect(merged.find((p) => p.predicateId === 'demo__thing')?.createdBy).toBe(
+      'system',
+    );
+  });
+
+  it('throws on a pack-vs-pack id collision', () => {
+    expect(() =>
+      assembleSeed(
+        [],
+        [
+          pack({ id: 'dup', predicates: [packPredicate('x')] }),
+          pack({ id: 'dup', predicates: [packPredicate('x')] }),
+        ],
+      ),
+    ).toThrow(/collision/);
+  });
+
+  it('throws on a pack-vs-core id collision', () => {
+    expect(() =>
+      assembleSeed(
+        [corePredicate('p__x')],
+        [pack({ id: 'p', predicates: [packPredicate('x')] })],
+      ),
+    ).toThrow(/collision/);
+  });
+});
+
+describe('composePredicateId', () => {
+  it('joins with the double-underscore separator', () => {
+    expect(composePredicateId('code_memory', 'decided')).toBe('code_memory__decided');
+  });
+});
+
+describe('code-memory pack', () => {
+  it('is a valid pack', () => {
+    expect(() => validatePack(CODE_MEMORY_PACK)).not.toThrow();
+  });
+  it('exposes namespaced predicate ids + round-trips kindOf', () => {
+    expect(codeMemoryPredicateId('decided')).toBe('code_memory__decided');
+    expect(codeMemoryKindOf('code_memory__gotcha')).toBe('gotcha');
+    expect(CODE_MEMORY_PREDICATE_IDS).toContain('code_memory__invariant');
+  });
+  it('is merged into SEED_PREDICATES (namespaced, not bare)', () => {
+    const ids = SEED_PREDICATES.map((p) => p.predicateId);
+    expect(ids).toContain('code_memory__decided');
+    expect(ids).not.toContain('decided');
+    // core predicates still present
+    expect(ids).toContain('name');
+  });
+});


### PR DESCRIPTION
## What

Turns the ontology from a **hardcoded core-seed** into a real **Domain Pack standard** — versioned, pluggable, namespaced, community-authorable. This directly answers the question "is our ontology pack a self-updatable, versioned module with a standard so the community can make their own?" — **before this PR: no** (the code-memory predicates were appended straight into `CORE_PREDICATES`). After: yes — manifest standard + namespacing + merge loader. (Runtime per-tenant install + distribution is the documented next increment.)

## The standard (`src/ai/domain-packs/`, `docs/domain-packs.md`)
- **`DomainPackManifest`** = `{ id (snake_case), version (semver), description, predicates: PackPredicate[] }` — the contract third parties conform to.
- **Namespacing**: every pack predicate is stored as **`<packId>__<localId>`** (double-underscore separator). Chosen over `/` or `:` because predicate ids must match `^[a-z][a-z0-9_]*$` and flow through REST path params — `/` breaks admin CRUD routing. Core predicates stay **unprefixed** (renaming would orphan existing facts); packs **must** namespace.
- **`validatePack` + `assembleSeed`**: validate semver / snake_case / non-empty, compose namespaced ids, and **fail the boot on any id collision** (pack-vs-core or pack-vs-pack) — no silent shadowing.
- **`SEED_PREDICATES = assembleSeed(CORE_PREDICATES, BUILTIN_PACKS)`**, validated at module load. The predicate registry seeds / falls back on the merged set, so a pack's predicates bootstrap into every tenant (idempotent; admin overrides survive).
- **`pnpm pack:validate <pack.json>`** — CLI for community pack authors.

## code-memory is now pack #1
Was hardcoded in `CORE_PREDICATES` (Phase 0). Now `code_memory` v0.1.0 → `code_memory__{decided,because,invariant,gotcha}`. MCP tools (`record_decision`/`why`) + the capture sink consume the pack's namespaced ids via `codeMemoryPredicateId`/`codeMemoryKindOf`; callers still pass ergonomic local kinds.

## Verification
- `pnpm exec tsc --noEmit` · `pnpm typecheck` · `pnpm lint` · max-params ≤3 ✓
- 735 unit (+14 domain-pack: validation, namespacing, collision detection, pack wiring) · 132 e2e (code-memory round-trip now uses namespaced predicates — confirms pack predicates bootstrap per-tenant) · 9 jobs ✓

## Next (documented in docs/domain-packs.md)
Runtime per-tenant install/uninstall (a `domain_pack` table + pin/upgrade/rollback), JSON-manifest distribution (not only compiled modules), per-pack eval fixtures + extraction profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)