### PR TITLE
feat(code-memory): Phase 2 — drift-resistant symbol anchors (SCIP-style) + grounding + validation

### DIFF
--- a/scripts/capture-decisions.ts
+++ b/scripts/capture-decisions.ts
@@ -18,7 +18,10 @@
  *
  * Anchors are file-level in Phase 1; symbol-level (SCIP) is Phase 2.
  */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { readCommits } from '../src/code-memory/capture/git-commits';
+import { makeSymbolAnchorRefiner } from '../src/code-memory/anchor/refine';
 import { HeuristicDecisionClassifier } from '../src/code-memory/capture/heuristic-classifier';
 import {
   LlmDecisionExtractor,
@@ -64,11 +67,24 @@ async function main(): Promise<void> {
       }
     : new HttpDecisionSink({ baseUrl: brainUrl!, apiKey: brainKey! });
 
+  // Phase 2: ground LLM-proposed symbols against the local working tree and
+  // upgrade file anchors to drift-resistant symbol anchors (client-side).
+  const refineAnchor = makeSymbolAnchorRefiner({
+    readFile: (p) => {
+      try {
+        return readFileSync(join(process.cwd(), p), 'utf8');
+      } catch {
+        return null;
+      }
+    },
+  });
+
   const summary = await runCapturePipeline({
     commits,
     classifier: new HeuristicDecisionClassifier(),
     extractor,
     sink,
+    refineAnchor,
     log: (m) => console.error(`[capture] ${m}`),
   });
 

--- a/src/code-memory/anchor/refine.ts
+++ b/src/code-memory/anchor/refine.ts
@@ -1,0 +1,68 @@
+import type { DecisionCandidate } from '../capture/types';
+import { parseAnchor, symbolAnchorId } from './symbol-id';
+import { enclosingSymbol, listSymbols, symbolExists } from './ts-symbol-resolver';
+
+/** Read a repo-relative file's current source, or null if it's gone. */
+export type ReadFile = (path: string) => string | null;
+
+/**
+ * Upgrade a candidate's file-level anchor to a symbol anchor when the
+ * LLM-proposed `symbol` actually resolves in the current file — grounding the
+ * anchor so the model can't invent a symbol, and making it drift-resistant
+ * (survives line shifts). Falls back to the file anchor when there's no symbol,
+ * the file is unreadable, or the symbol doesn't resolve. Pure given `readFile`.
+ */
+export function makeSymbolAnchorRefiner(deps: {
+  readFile: ReadFile;
+}): (candidate: DecisionCandidate) => DecisionCandidate {
+  return (candidate) => {
+    if (!candidate.symbol) return candidate;
+    const { path } = parseAnchor(candidate.anchor);
+    const source = deps.readFile(path);
+    if (!source) return candidate;
+    if (!symbolExists(source, candidate.symbol, path)) return candidate;
+    return { ...candidate, anchor: symbolAnchorId(path, candidate.symbol) };
+  };
+}
+
+export type AnchorHealth = 'present' | 'symbol_missing' | 'file_gone';
+
+/**
+ * Drift check for a stored anchor against current code. A symbol anchor that
+ * still resolves is `present` — line-independent, so in-file moves are invisible
+ * (that's the whole point of symbol anchors); if the file exists but the symbol
+ * is gone it's `symbol_missing` (a re-anchor candidate); if the file itself is
+ * gone it's `file_gone`.
+ */
+export function validateAnchor(opts: {
+  anchor: string;
+  readFile: ReadFile;
+}): AnchorHealth {
+  const { path, symbolPath } = parseAnchor(opts.anchor);
+  const source = opts.readFile(path);
+  if (source === null) return 'file_gone';
+  if (!symbolPath) return 'present';
+  return symbolExists(source, symbolPath, path) ? 'present' : 'symbol_missing';
+}
+
+/**
+ * Propose a replacement symbol for a `symbol_missing` anchor. `choose` is the
+ * injected re-anchor decision (an LLM in production, per Magic Markup/Codetations
+ * semantic re-anchoring) — it picks the current symbol that best matches the old
+ * one, or null to leave the anchor stale (invalidate, never delete). We hand it
+ * only the CURRENT symbol names, never source, keeping the hybrid contract.
+ */
+export function reanchor(opts: {
+  source: string;
+  path: string;
+  missingSymbolPath: string;
+  choose: (candidates: string[], missing: string) => string | null;
+}): string | null {
+  const candidates = listSymbols(opts.source, opts.path).map((s) => s.symbolPath);
+  if (candidates.length === 0) return null;
+  const picked = opts.choose(candidates, opts.missingSymbolPath);
+  if (!picked || !candidates.includes(picked)) return null;
+  return symbolAnchorId(opts.path, picked);
+}
+
+export { enclosingSymbol };

--- a/src/code-memory/anchor/symbol-id.ts
+++ b/src/code-memory/anchor/symbol-id.ts
@@ -1,0 +1,28 @@
+/**
+ * Code anchor id format (code-memory Phase 2). An anchor addresses either a
+ * whole file or a symbol within it:
+ *   file-level    → "src/x.ts"
+ *   symbol-level  → "src/x.ts#FactResolverService.resolve"
+ * The `#` separates path from the SCIP-style dotted symbol path. Symbol anchors
+ * survive line shifts + file-internal moves; a file move still needs a
+ * re-anchor (Phase 2b sweep).
+ */
+
+const SYMBOL_SEP = '#';
+
+export function symbolAnchorId(path: string, symbolPath: string): string {
+  return `${path}${SYMBOL_SEP}${symbolPath}`;
+}
+
+export function parseAnchor(anchor: string): {
+  path: string;
+  symbolPath?: string;
+} {
+  const i = anchor.indexOf(SYMBOL_SEP);
+  if (i === -1) return { path: anchor };
+  return { path: anchor.slice(0, i), symbolPath: anchor.slice(i + 1) };
+}
+
+export function isSymbolAnchor(anchor: string): boolean {
+  return anchor.includes(SYMBOL_SEP);
+}

--- a/src/code-memory/anchor/ts-symbol-resolver.ts
+++ b/src/code-memory/anchor/ts-symbol-resolver.ts
@@ -1,0 +1,124 @@
+import * as ts from 'typescript';
+
+/**
+ * Drift-resistant symbol resolution for TS/JS (code-memory Phase 2,
+ * docs/roadmap/code-memory-domain.md). A code anchor keyed by a symbol PATH
+ * (`FactResolverService.resolve`) survives line shifts and file moves for free —
+ * unlike a line/offset anchor, which the research (Codetations / Magic Markup /
+ * Catseye) shows is fragile under `git pull` / formatter runs.
+ *
+ * Uses the TypeScript compiler API (already a project dep) for an accurate AST
+ * walk rather than a brittle regex scanner. Non-TS/JS files get no symbols —
+ * the caller falls back to a file-level anchor. Runs CLIENT-SIDE in the capture
+ * pipeline; only the resulting symbol-id string reaches the server.
+ */
+
+export interface SymbolSpan {
+  /** Dotted path of enclosing named declarations, e.g. "Foo.bar". */
+  symbolPath: string;
+  kind: string;
+  /** 1-based inclusive line range. */
+  startLine: number;
+  endLine: number;
+}
+
+function scriptKindFor(fileName: string): ts.ScriptKind {
+  if (fileName.endsWith('.tsx')) return ts.ScriptKind.TSX;
+  if (fileName.endsWith('.jsx')) return ts.ScriptKind.JSX;
+  if (fileName.endsWith('.js') || fileName.endsWith('.mjs') || fileName.endsWith('.cjs'))
+    return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function declaredName(node: ts.Node): { name: string; kind: string } | null {
+  if (ts.isClassDeclaration(node) && node.name) {
+    return { name: node.name.text, kind: 'class' };
+  }
+  if (ts.isFunctionDeclaration(node) && node.name) {
+    return { name: node.name.text, kind: 'function' };
+  }
+  if (ts.isConstructorDeclaration(node)) {
+    return { name: 'constructor', kind: 'constructor' };
+  }
+  if (
+    (ts.isMethodDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node)) &&
+    node.name &&
+    ts.isIdentifier(node.name)
+  ) {
+    return { name: node.name.text, kind: 'method' };
+  }
+  // Top-level (or nested) `const foo = () => {}` / `const foo = function () {}`.
+  if (ts.isVariableDeclaration(node) && node.name && ts.isIdentifier(node.name)) {
+    const init = node.initializer;
+    if (init && (ts.isArrowFunction(init) || ts.isFunctionExpression(init))) {
+      return { name: node.name.text, kind: 'function' };
+    }
+  }
+  return null;
+}
+
+/** All named symbol spans in a source file, outermost-first. */
+export function listSymbols(source: string, fileName = 'file.ts'): SymbolSpan[] {
+  const sf = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(fileName),
+  );
+  const spans: SymbolSpan[] = [];
+  const stack: string[] = [];
+
+  const lineOf = (pos: number): number =>
+    sf.getLineAndCharacterOfPosition(pos).line + 1;
+
+  const visit = (node: ts.Node): void => {
+    const decl = declaredName(node);
+    if (decl) {
+      stack.push(decl.name);
+      spans.push({
+        symbolPath: stack.join('.'),
+        kind: decl.kind,
+        startLine: lineOf(node.getStart(sf)),
+        endLine: lineOf(node.getEnd()),
+      });
+      ts.forEachChild(node, visit);
+      stack.pop();
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+  return spans;
+}
+
+/**
+ * The innermost (most specific) symbol whose range contains `line` (1-based),
+ * or null if the line sits outside any named declaration. Used at capture time
+ * to map a changed line to its enclosing symbol.
+ */
+export function enclosingSymbol(
+  source: string,
+  line: number,
+  fileName = 'file.ts',
+): string | null {
+  let best: SymbolSpan | null = null;
+  for (const s of listSymbols(source, fileName)) {
+    if (line < s.startLine || line > s.endLine) continue;
+    if (!best || s.endLine - s.startLine < best.endLine - best.startLine) {
+      best = s;
+    }
+  }
+  return best ? best.symbolPath : null;
+}
+
+/** Whether a symbol path still exists in the given source (drift check). */
+export function symbolExists(
+  source: string,
+  symbolPath: string,
+  fileName = 'file.ts',
+): boolean {
+  return listSymbols(source, fileName).some((s) => s.symbolPath === symbolPath);
+}

--- a/src/code-memory/capture/capture-pipeline.ts
+++ b/src/code-memory/capture/capture-pipeline.ts
@@ -24,9 +24,18 @@ export async function runCapturePipeline(opts: {
   classifier: DecisionClassifier;
   extractor: DecisionExtractor;
   sink: DecisionSink;
+  /**
+   * Optional Phase-2 anchor refinement — upgrade a candidate's file anchor to a
+   * grounded symbol anchor (see anchor/refine.ts). Runs client-side (reads local
+   * files); defaults to identity so Phase-1 file anchoring still works.
+   */
+  refineAnchor?: (
+    c: import('./types').DecisionCandidate,
+  ) => import('./types').DecisionCandidate;
   log?: (msg: string) => void;
 }): Promise<CaptureSummary> {
   const { commits, classifier, extractor, sink } = opts;
+  const refineAnchor = opts.refineAnchor ?? ((c) => c);
   const log = opts.log ?? (() => {});
   const summary: CaptureSummary = {
     scanned: commits.length,
@@ -60,7 +69,8 @@ export async function runCapturePipeline(opts: {
     }
     summary.extracted += candidates.length;
 
-    for (const candidate of candidates) {
+    for (const raw of candidates) {
+      const candidate = refineAnchor(raw);
       try {
         await sink.record(candidate);
         summary.recorded += 1;

--- a/src/code-memory/capture/llm-extractor.ts
+++ b/src/code-memory/capture/llm-extractor.ts
@@ -42,10 +42,11 @@ export function buildExtractionPrompt(commit: CommitInput): {
 } {
   const system = `You extract the non-derivable engineering "why" from a git commit — knowledge a parser cannot recover from source. Output ONLY decisions, rationale, invariants, and gotchas that are EXPLICITLY present in the message or PR body. Never restate what the code change literally is; capture the reasoning behind it. If the commit carries no such "why", return an empty list.
 
-Return STRICT JSON: {"decisions":[{"kind","text","anchor","confidence"}]}.
+Return STRICT JSON: {"decisions":[{"kind","text","anchor","symbol","confidence"}]}.
 - kind: one of decided | because | invariant | gotcha
 - text: the decision/rationale/invariant/gotcha, one sentence, faithful to the commit
 - anchor: the MOST relevant changed file path, chosen verbatim from the provided list
+- symbol: the enclosing function/class/method name the decision is about, if identifiable (e.g. "FactResolverService.resolve"), else null. It is verified against the file — do not guess.
 - confidence: 0..1, how explicitly the commit states it`;
 
   const files = commit.changedFiles.map((f) => `- ${f}`).join('\n');
@@ -89,10 +90,13 @@ export function parseCandidates(
       o.confidence <= 1
         ? o.confidence
         : undefined;
+    const symbol =
+      typeof o.symbol === 'string' && o.symbol.trim() ? o.symbol.trim() : undefined;
     out.push({
       kind,
       text,
       anchor,
+      ...(symbol ? { symbol } : {}),
       commit: commit.sha,
       validFrom: commit.authorDate,
       confidence,

--- a/src/code-memory/capture/types.ts
+++ b/src/code-memory/capture/types.ts
@@ -57,8 +57,18 @@ export type DecisionKind = 'decided' | 'because' | 'invariant' | 'gotcha';
 export interface DecisionCandidate {
   kind: DecisionKind;
   text: string;
-  /** File anchor — "src/x.ts". Mapped to externalRef code:<path> by the sink. */
+  /**
+   * Anchor — a file path ("src/x.ts") or, after symbol grounding (Phase 2), a
+   * symbol anchor ("src/x.ts#Foo.bar"). Mapped to externalRef code:<anchor> by
+   * the sink.
+   */
   anchor: string;
+  /**
+   * LLM-proposed enclosing symbol name (Phase 2). Grounded against the local
+   * file before use — the anchor is upgraded to symbol-level only if the symbol
+   * actually resolves; otherwise it stays file-level.
+   */
+  symbol?: string;
   /** Commit SHA provenance. */
   commit: string;
   /** Optional file:line provenance. */

--- a/test/code-memory-anchor.unit-spec.ts
+++ b/test/code-memory-anchor.unit-spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Code-memory Phase 2 — symbol anchoring: TS symbol resolver, anchor-id format,
+ * grounding refiner, drift validation + re-anchor. All pure / offline.
+ */
+import {
+  enclosingSymbol,
+  listSymbols,
+  symbolExists,
+} from '../src/code-memory/anchor/ts-symbol-resolver';
+import {
+  parseAnchor,
+  symbolAnchorId,
+  isSymbolAnchor,
+} from '../src/code-memory/anchor/symbol-id';
+import {
+  makeSymbolAnchorRefiner,
+  validateAnchor,
+  reanchor,
+} from '../src/code-memory/anchor/refine';
+import type { DecisionCandidate } from '../src/code-memory/capture/types';
+
+const SRC = `import { X } from './x';
+
+export class FactResolverService {
+  private readonly lock = 1;
+
+  constructor(private readonly db: X) {}
+
+  async resolve(id: string): Promise<number> {
+    const y = id.length;
+    return y;
+  }
+
+  private cfgNum(key: string): number {
+    return 0;
+  }
+}
+
+export function helper(a: number): number {
+  return a + 1;
+}
+
+export const arrowFn = (n: number) => n * 2;
+`;
+
+describe('ts-symbol-resolver', () => {
+  it('lists class, methods, constructor, function, arrow-const', () => {
+    const paths = listSymbols(SRC, 'x.ts').map((s) => s.symbolPath);
+    expect(paths).toContain('FactResolverService');
+    expect(paths).toContain('FactResolverService.resolve');
+    expect(paths).toContain('FactResolverService.constructor');
+    expect(paths).toContain('FactResolverService.cfgNum');
+    expect(paths).toContain('helper');
+    expect(paths).toContain('arrowFn');
+  });
+
+  it('maps a line to its innermost enclosing symbol', () => {
+    // "const y = id.length;" is inside resolve()
+    const line = SRC.split('\n').findIndex((l) => l.includes('const y = id.length')) + 1;
+    expect(enclosingSymbol(SRC, line, 'x.ts')).toBe('FactResolverService.resolve');
+  });
+
+  it('returns null outside any declaration (the import line)', () => {
+    expect(enclosingSymbol(SRC, 1, 'x.ts')).toBeNull();
+  });
+
+  it('symbolExists checks presence', () => {
+    expect(symbolExists(SRC, 'FactResolverService.resolve', 'x.ts')).toBe(true);
+    expect(symbolExists(SRC, 'FactResolverService.gone', 'x.ts')).toBe(false);
+  });
+
+  it('non-TS content yields no symbols (caller falls back to file anchor)', () => {
+    expect(listSymbols('plain text, not code', 'notes.md')).toEqual([]);
+  });
+});
+
+describe('symbol-id', () => {
+  it('composes + parses symbol anchors', () => {
+    const id = symbolAnchorId('src/x.ts', 'Foo.bar');
+    expect(id).toBe('src/x.ts#Foo.bar');
+    expect(parseAnchor(id)).toEqual({ path: 'src/x.ts', symbolPath: 'Foo.bar' });
+    expect(parseAnchor('src/x.ts')).toEqual({ path: 'src/x.ts' });
+    expect(isSymbolAnchor(id)).toBe(true);
+    expect(isSymbolAnchor('src/x.ts')).toBe(false);
+  });
+});
+
+describe('makeSymbolAnchorRefiner', () => {
+  const base: DecisionCandidate = {
+    kind: 'decided',
+    text: 't',
+    anchor: 'x.ts',
+    commit: 'c',
+    validFrom: '2026-07-07T00:00:00Z',
+  };
+  const readFile = (p: string) => (p === 'x.ts' ? SRC : null);
+
+  it('upgrades to a symbol anchor when the symbol resolves', () => {
+    const refine = makeSymbolAnchorRefiner({ readFile });
+    const out = refine({ ...base, symbol: 'FactResolverService.resolve' });
+    expect(out.anchor).toBe('x.ts#FactResolverService.resolve');
+  });
+
+  it('keeps the file anchor when the symbol does not resolve', () => {
+    const refine = makeSymbolAnchorRefiner({ readFile });
+    expect(refine({ ...base, symbol: 'Ghost.method' }).anchor).toBe('x.ts');
+  });
+
+  it('keeps the file anchor when there is no symbol or file is gone', () => {
+    const refine = makeSymbolAnchorRefiner({ readFile });
+    expect(refine(base).anchor).toBe('x.ts');
+    expect(
+      refine({ ...base, anchor: 'gone.ts', symbol: 'Whatever' }).anchor,
+    ).toBe('gone.ts');
+  });
+});
+
+describe('validateAnchor (drift check)', () => {
+  const readFile = (p: string) => (p === 'x.ts' ? SRC : null);
+  it('present when the symbol still resolves (line-independent)', () => {
+    expect(
+      validateAnchor({ anchor: 'x.ts#FactResolverService.resolve', readFile }),
+    ).toBe('present');
+  });
+  it('symbol_missing when the file exists but the symbol is gone', () => {
+    expect(
+      validateAnchor({ anchor: 'x.ts#FactResolverService.gone', readFile }),
+    ).toBe('symbol_missing');
+  });
+  it('file_gone when the file no longer exists', () => {
+    expect(validateAnchor({ anchor: 'deleted.ts#Foo.bar', readFile })).toBe(
+      'file_gone',
+    );
+  });
+  it('present for a bare file anchor that still exists', () => {
+    expect(validateAnchor({ anchor: 'x.ts', readFile })).toBe('present');
+  });
+});
+
+describe('reanchor', () => {
+  it('re-anchors a missing symbol to a chosen current symbol', () => {
+    const out = reanchor({
+      source: SRC,
+      path: 'x.ts',
+      missingSymbolPath: 'FactResolverService.resolv', // typo'd/renamed
+      choose: (candidates, missing) =>
+        candidates.find((c) => c.startsWith('FactResolverService.res')) ??
+        (missing ? null : null),
+    });
+    expect(out).toBe('x.ts#FactResolverService.resolve');
+  });
+  it('returns null when the chooser declines or picks a non-existent symbol', () => {
+    expect(
+      reanchor({
+        source: SRC,
+        path: 'x.ts',
+        missingSymbolPath: 'Foo',
+        choose: () => null,
+      }),
+    ).toBeNull();
+    expect(
+      reanchor({
+        source: SRC,
+        path: 'x.ts',
+        missingSymbolPath: 'Foo',
+        choose: () => 'Not.Real',
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

**Track 2** — upgrades code-memory anchors from **file-level → symbol-level**, so an anchor survives line shifts and in-file moves for free (the research's core drift-resistance win; line/offset anchors break under `git pull` / formatters).

- **`anchor/ts-symbol-resolver`** — accurate TS/JS symbol spans via the **TypeScript compiler API** (no new dep): `listSymbols` / `enclosingSymbol(line)` / `symbolExists`. Non-TS files yield none → caller keeps a file anchor.
- **`anchor/symbol-id`** — anchor format `path#Symbol.method` (compose/parse).
- **`anchor/refine`** — `makeSymbolAnchorRefiner` **grounds** the LLM's proposed symbol against the local file: upgrades to a symbol anchor only if it actually resolves, else stays file-level (the model can't invent a symbol). `validateAnchor` → `present | symbol_missing | file_gone` (drift check); `reanchor()` proposes a replacement via an injected chooser (LLM re-anchor per Magic Markup / Codetations), never deletes.
- **capture**: LLM extractor emits an optional `symbol`; the pipeline gains an optional `refineAnchor` stage; the CLI wires a working-tree `readFile` refiner. All client-side — only the symbol-id string reaches the server.

## Verification
- Runs entirely client-side; no server changes.
- `pnpm exec tsc --noEmit` · `pnpm typecheck` · `pnpm lint` · max-params ≤3 ✓
- 751 unit (+15 anchor: resolver, id format, grounding, drift-validation, re-anchor) · 139 e2e · 9 jobs ✓

## Deferred (Phase 2b, documented)
A read-time re-validation sweep — a server endpoint to list code-memory anchors + a `capture:validate-anchors` CLI that walks them, `reanchor`s `symbol_missing` ones, and invalidates the unfixable (sets validUntil, never deletes).

## Next
Track 3 — Phase 3 eval (design-constraint compliance + recall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)