### PR TITLE
feat(code-memory): Phase 3 — eval gate (recall + invariant surfacing) + metrics + golden

### DIFF
--- a/src/code-memory/eval/golden.ts
+++ b/src/code-memory/eval/golden.ts
@@ -1,0 +1,79 @@
+import type { CodeMemoryKind } from '../../ai/domain-packs';
+
+/**
+ * Frozen golden fixture for the code-memory eval. Small, hand-authored records
+ * (real decisions from this repo's history) + queries with expected recall. The
+ * eval ingests these into an ephemeral tenant and scores retrieval + invariant
+ * surfacing. Grow this set as the domain matures — it's the code-memory analog
+ * of test/eval/golden-baseline.json.
+ */
+
+export interface GoldenRecord {
+  anchor: string;
+  kind: CodeMemoryKind;
+  text: string;
+}
+
+export interface GoldenQuery {
+  id: string;
+  /** The code anchor an agent is touching (exact `why` lookup). */
+  anchor: string;
+  /** A natural-language query for the semantic-recall dimension. */
+  semanticQuery: string;
+  /** Kinds that MUST come back from `why(anchor)`. */
+  expectKinds: CodeMemoryKind[];
+}
+
+export const GOLDEN_RECORDS: GoldenRecord[] = [
+  {
+    anchor: 'src/ingest/fact-resolver.service.ts#FactResolverService.resolve',
+    kind: 'decided',
+    text: 'Route every fact write through one fn::resolve_fact gateway so the 21-positional-arg call lives in exactly one place.',
+  },
+  {
+    anchor: 'src/ingest/fact-resolver.service.ts#FactResolverService.resolve',
+    kind: 'because',
+    text: 'The two call-sites had drifted the positional arguments out of sync, binding values to the wrong slots.',
+  },
+  {
+    anchor: 'src/ingest/fact-resolver.service.ts#FactResolverService.resolve',
+    kind: 'invariant',
+    text: 'Conflict weights must be read from process.env, never added as a fourth ConfigService constructor dependency.',
+  },
+  {
+    anchor: 'src/ai/domain-packs/manifest.ts#composePredicateId',
+    kind: 'decided',
+    text: 'Namespace every pack predicate as packId__localId.',
+  },
+  {
+    anchor: 'src/ai/domain-packs/manifest.ts#composePredicateId',
+    kind: 'invariant',
+    text: 'Never use a slash as the namespace separator — it breaks admin route parameters and the predicate-id charset.',
+  },
+  {
+    anchor: 'src/jobs/worker-loop.service.ts#WorkerLoopService',
+    kind: 'gotcha',
+    text: 'Always export a new @Injectable from the @Global module or the full e2e DI-boot goes red.',
+  },
+];
+
+export const GOLDEN_QUERIES: GoldenQuery[] = [
+  {
+    id: 'resolver-gateway',
+    anchor: 'src/ingest/fact-resolver.service.ts#FactResolverService.resolve',
+    semanticQuery: 'why is there a single gateway for resolving facts',
+    expectKinds: ['decided', 'because', 'invariant'],
+  },
+  {
+    id: 'pack-namespacing',
+    anchor: 'src/ai/domain-packs/manifest.ts#composePredicateId',
+    semanticQuery: 'how are domain pack predicate names namespaced',
+    expectKinds: ['decided', 'invariant'],
+  },
+  {
+    id: 'global-injectable',
+    anchor: 'src/jobs/worker-loop.service.ts#WorkerLoopService',
+    semanticQuery: 'gotcha about exporting an injectable from the global module',
+    expectKinds: ['gotcha'],
+  },
+];

--- a/src/code-memory/eval/metrics.ts
+++ b/src/code-memory/eval/metrics.ts
@@ -1,0 +1,60 @@
+/**
+ * Code-memory Phase 3 — evaluation metrics (docs/roadmap/code-memory-domain.md).
+ *
+ * Pure set-based metrics over {expected, retrieved} id sets. Used by the
+ * code-memory eval to score two things the domain must guarantee:
+ *   - recall — does the stored "why" come back for a query (exact anchor read
+ *     AND semantic search)?
+ *   - invariant surfacing — when an agent touches an anchor, is the invariant it
+ *     must not violate handed to it? This is the actionable design-constraint-
+ *     compliance PRECONDITION code-memory can provide. (Full agent-in-the-loop
+ *     compliance à la SWE-Shield needs an agent harness — out of scope here.)
+ */
+
+/** |expected ∩ retrieved| / |expected|. Vacuously 1 when nothing is expected. */
+export function recall(expected: string[], retrieved: string[]): number {
+  if (expected.length === 0) return 1;
+  const got = new Set(retrieved);
+  const hit = expected.filter((e) => got.has(e)).length;
+  return hit / expected.length;
+}
+
+/** |expected ∩ retrieved| / |retrieved|. Vacuously 1 when nothing retrieved. */
+export function precision(expected: string[], retrieved: string[]): number {
+  if (retrieved.length === 0) return 1;
+  const want = new Set(expected);
+  const hit = retrieved.filter((r) => want.has(r)).length;
+  return hit / retrieved.length;
+}
+
+/** Recall considering only the top-k of a ranked retrieval. */
+export function recallAtK(
+  expected: string[],
+  rankedRetrieved: string[],
+  k: number,
+): number {
+  return recall(expected, rankedRetrieved.slice(0, k));
+}
+
+export function mean(xs: number[]): number {
+  return xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+export interface EvalCase {
+  expected: string[];
+  retrieved: string[];
+}
+
+export interface EvalSummary {
+  cases: number;
+  meanRecall: number;
+  meanPrecision: number;
+}
+
+export function summarize(cases: EvalCase[]): EvalSummary {
+  return {
+    cases: cases.length,
+    meanRecall: mean(cases.map((c) => recall(c.expected, c.retrieved))),
+    meanPrecision: mean(cases.map((c) => precision(c.expected, c.retrieved))),
+  };
+}

--- a/test/code-memory-eval.e2e-spec.ts
+++ b/test/code-memory-eval.e2e-spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Code-memory Phase 3 — eval gate on a real DB.
+ *
+ * Ingests the frozen golden fixture into an ephemeral tenant and scores the two
+ * guarantees the domain must hold:
+ *   1. exact `why(anchor)` recall = 1.0 — the stored "why" always comes back at
+ *      the anchor an agent is touching.
+ *   2. invariant surfacing = 1.0 — every recorded invariant is handed back at
+ *      its anchor (the design-constraint-compliance precondition).
+ *
+ * NL/semantic recall over code-memory (finding a decision by topic through the
+ * general entity-centric search) is deliberately NOT gated here: code anchors
+ * have path-string names, not NL names, so the general retriever doesn't surface
+ * them by topic out of the box. That's a real follow-up (Phase 3b — a
+ * code-memory-aware retrieval leg), not a domain guarantee, so it stays out of
+ * the gate rather than being faked. GOLDEN_QUERIES.semanticQuery is retained for
+ * that future eval.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { IngestService } from '../src/ingest/ingest.service';
+import { EntitiesService } from '../src/entities/entities.service';
+import {
+  codeMemoryKindOf,
+  codeMemoryPredicateId,
+} from '../src/ai/domain-packs';
+import { GOLDEN_QUERIES, GOLDEN_RECORDS } from '../src/code-memory/eval/golden';
+import { mean, recall } from '../src/code-memory/eval/metrics';
+
+describe('code-memory Phase 3 — eval (recall + invariant surfacing)', () => {
+  let f: AppFixture;
+  const READ = ['brain:read', 'brain:read_pii'] as any;
+
+  const recallProfile = (anchor: string) => {
+    const entities = f.app.get(EntitiesService);
+    return entities.getProfileByExternalRef({
+      companyId: f.companyId,
+      vertical: 'code',
+      id: anchor,
+      asOfRaw: undefined,
+      scopes: READ,
+    });
+  };
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_code_memory_eval' });
+    const ingest = f.app.get(IngestService);
+    for (const r of GOLDEN_RECORDS) {
+      await ingest.ingestFact(f.companyId, {
+        entityRef: { vertical: 'code', id: r.anchor },
+        predicate: codeMemoryPredicateId(r.kind),
+        object: r.text,
+        validFrom: '2026-07-07T00:00:00Z',
+        source: { vertical: 'code', recorder: 'code_memory' },
+      });
+    }
+  });
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('exact why() recall = 1.0 across golden queries', async () => {
+    const recalls: number[] = [];
+    for (const q of GOLDEN_QUERIES) {
+      const profile = await recallProfile(q.anchor);
+      const kinds = (profile?.facts ?? [])
+        .filter((x) => x.status === 'active')
+        .map((x) => codeMemoryKindOf(x.predicate));
+      recalls.push(recall(q.expectKinds, kinds));
+    }
+    expect(mean(recalls)).toBe(1);
+  });
+
+  it('every recorded invariant is surfaced at its anchor', async () => {
+    const invariants = GOLDEN_RECORDS.filter((r) => r.kind === 'invariant');
+    let surfaced = 0;
+    for (const inv of invariants) {
+      const profile = await recallProfile(inv.anchor);
+      const texts = (profile?.facts ?? [])
+        .filter((x) => x.status === 'active')
+        .map((x) => x.object);
+      if (texts.includes(inv.text)) surfaced += 1;
+    }
+    expect(surfaced).toBe(invariants.length);
+  });
+});

--- a/test/code-memory-eval.unit-spec.ts
+++ b/test/code-memory-eval.unit-spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Code-memory Phase 3 — eval metrics (pure).
+ */
+import {
+  mean,
+  precision,
+  recall,
+  recallAtK,
+  summarize,
+} from '../src/code-memory/eval/metrics';
+
+describe('code-memory eval metrics', () => {
+  it('recall = fraction of expected retrieved', () => {
+    expect(recall(['a', 'b'], ['a', 'b', 'c'])).toBe(1);
+    expect(recall(['a', 'b'], ['a'])).toBe(0.5);
+    expect(recall([], ['x'])).toBe(1); // vacuous
+  });
+
+  it('precision = fraction of retrieved that were expected', () => {
+    expect(precision(['a'], ['a', 'x'])).toBe(0.5);
+    expect(precision(['a'], [])).toBe(1); // vacuous
+  });
+
+  it('recallAtK only counts the top k', () => {
+    expect(recallAtK(['a', 'b'], ['x', 'a', 'b'], 1)).toBe(0);
+    expect(recallAtK(['a', 'b'], ['a', 'x', 'b'], 2)).toBe(0.5);
+    expect(recallAtK(['a', 'b'], ['a', 'b', 'x'], 2)).toBe(1);
+  });
+
+  it('mean + summarize aggregate correctly', () => {
+    expect(mean([1, 0])).toBe(0.5);
+    const s = summarize([
+      { expected: ['a'], retrieved: ['a'] },
+      { expected: ['a', 'b'], retrieved: ['a'] },
+    ]);
+    expect(s.cases).toBe(2);
+    expect(s.meanRecall).toBe(0.75);
+  });
+});


### PR DESCRIPTION
## What

**Track 3 (final of "делай все")** — a self-contained evaluation of the two guarantees the code-memory domain must hold, gated in CI on a real DB.

- **`eval/metrics`** — pure set-based `recall` / `precision` / `recallAtK` / `mean` / `summarize`.
- **`eval/golden`** — a frozen fixture of real decisions/invariants/gotchas on symbol anchors + queries with expected recall (the code-memory analog of `golden-baseline.json`).
- **e2e gate** — ingest the golden set → assert:
  1. **exact `why(anchor)` recall = 1.0** — the stored "why" always returns at the anchor an agent touches;
  2. **invariant surfacing = 1.0** — every recorded invariant is handed back at its anchor (the actionable design-constraint-compliance **precondition**).

## Honest scope
- **NL/semantic recall is NOT gated.** Code anchors have path-string names, so the general entity-centric retriever doesn't surface them by topic out of the box (verified: 0 results for NL queries). That's a real follow-up (**Phase 3b**: a code-memory-aware retrieval leg), kept out of the gate rather than faked. `GOLDEN_QUERIES.semanticQuery` is retained for it.
- **Full agent-in-the-loop SWE-Shield compliance** needs an agent harness — out of scope; this gates the precondition (the constraint reaches the edit point).

## Verification
- `pnpm exec tsc --noEmit` · `pnpm typecheck` · `pnpm lint` · max-params ≤3 ✓
- 755 unit (+4 metrics) · 141 e2e (+2 eval) · 9 jobs ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)