### PR TITLE
feat(code-memory): Phase 3b — semantic recall leg + recall_decisions MCP tool

### DIFF
--- a/src/code-memory/code-memory-search.service.ts
+++ b/src/code-memory/code-memory-search.service.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { EmbedderService } from '../ai/embedder.service';
+import { BrainScope } from '../auth/api-key.types';
+import { CODE_MEMORY_PACK, codeMemoryKindOf } from '../ai/domain-packs';
+
+export interface RecalledDecision {
+  anchor: string;
+  kind: string;
+  text: string;
+  score: number;
+  validFrom: string;
+}
+
+/**
+ * Code-memory-aware semantic retrieval (Phase 3b, docs/roadmap/code-memory-domain.md).
+ *
+ * The general entity-centric search does NOT surface code anchors by NL topic —
+ * their canonicalName is a path string, not natural language, so a topic query
+ * returns nothing (verified in the Phase 3 eval). This service is the dedicated
+ * retrieval leg: a direct cosine search over the `code_memory__*` facts' own
+ * embeddings, returning the matching decisions/rationale/invariants/gotchas with
+ * their code anchors. Answers "why do we do X?" across the codebase, vs `why`
+ * which reads one known anchor.
+ */
+@Injectable()
+export class CodeMemorySearchService {
+  private readonly prefix = `${CODE_MEMORY_PACK.id}__`;
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly embedder: EmbedderService,
+  ) {}
+
+  async recall(opts: {
+    companyId: string;
+    query: string;
+    limit?: number;
+    scopes: BrainScope[];
+  }): Promise<RecalledDecision[]> {
+    const q = (opts.query ?? '').trim();
+    if (!q) return [];
+    const limit = Math.min(Math.max(opts.limit ?? 10, 1), 50);
+    const embedding = await this.embedder.embed(q);
+
+    return this.surreal.withScopedCompany(
+      opts.companyId,
+      opts.scopes,
+      async (db) => {
+        const [rows] = await db.query<[any[]]>(
+          `SELECT
+             predicate,
+             object,
+             validFrom,
+             entityId.externalRefs AS refs,
+             vector::similarity::cosine(embedding, $embedding) AS score
+           FROM knowledge_fact
+           WHERE string::starts_with(predicate, $prefix)
+             AND status = 'active'
+             AND embedding != NONE
+           ORDER BY score DESC
+           LIMIT $limit`,
+          { embedding, prefix: this.prefix, limit },
+        );
+        return ((rows as any[]) ?? []).map((r) => ({
+          anchor: anchorOf(r.refs),
+          kind: codeMemoryKindOf(String(r.predicate)),
+          text: String(r.object),
+          score: typeof r.score === 'number' ? r.score : 0,
+          validFrom: r.validFrom ? new Date(r.validFrom).toISOString() : '',
+        }));
+      },
+    );
+  }
+}
+
+/** Pull the original code-anchor string out of an entity's externalRefs map
+ *  (the value under the `code__…` key the ingest side wrote). */
+function anchorOf(refs: Record<string, string> | undefined | null): string {
+  if (!refs) return '';
+  for (const [k, v] of Object.entries(refs)) {
+    if (k.startsWith('code__')) return String(v);
+  }
+  return '';
+}

--- a/src/code-memory/code-memory.module.ts
+++ b/src/code-memory/code-memory.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CodeMemorySearchService } from './code-memory-search.service';
+
+/**
+ * Server-side code-memory retrieval (Phase 3b). SurrealService + EmbedderService
+ * are provided by their @Global modules, so this module only declares the
+ * code-memory-specific service and exports it for the MCP surface.
+ */
+@Module({
+  providers: [CodeMemorySearchService],
+  exports: [CodeMemorySearchService],
+})
+export class CodeMemoryModule {}

--- a/src/mcp/code-memory-tools.ts
+++ b/src/mcp/code-memory-tools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { IngestService } from '../ingest/ingest.service';
 import type { EntitiesService } from '../entities/entities.service';
+import type { CodeMemorySearchService } from '../code-memory/code-memory-search.service';
 import type { BrainScope } from '../auth/api-key.types';
 import {
   CODE_MEMORY_KINDS,
@@ -29,6 +30,7 @@ const CODE_VERTICAL = 'code';
 
 export interface CodeMemoryReadDeps {
   entities: EntitiesService;
+  codeSearch: CodeMemorySearchService;
 }
 
 export interface CodeMemoryWriteDeps {
@@ -81,6 +83,32 @@ export function registerCodeMemoryReadTools(opts: {
           status: f.status,
         })),
       };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
+        structuredContent: out as any,
+      };
+    },
+  );
+
+  server.registerTool(
+    'recall_decisions',
+    {
+      title: 'Semantically recall code-memory across the codebase',
+      description:
+        'Find recorded design decisions / rationale / invariants / gotchas by NL topic ("why do we resolve facts through one gateway?"), across ALL code anchors — a semantic search over code-memory, vs `why` which reads one known anchor. Returns matches with their code anchor + kind, ranked by relevance.',
+      inputSchema: {
+        query: z.string().describe('Natural-language topic to recall the "why" for'),
+        limit: z.number().int().min(1).max(50).optional(),
+      },
+    },
+    async (args) => {
+      const decisions = await deps.codeSearch.recall({
+        companyId,
+        query: args.query,
+        limit: args.limit,
+        scopes,
+      });
+      const out = { query: args.query, found: decisions.length, decisions };
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
         structuredContent: out as any,

--- a/src/mcp/mcp.module.ts
+++ b/src/mcp/mcp.module.ts
@@ -11,6 +11,7 @@ import { DiffModule } from '../diff/diff.module';
 import { SummarizeEntityModule } from '../summarize-entity/summarize-entity.module';
 import { ProceduralModule } from '../procedural/procedural.module';
 import { CommunityModule } from '../communities/community.module';
+import { CodeMemoryModule } from '../code-memory/code-memory.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { CommunityModule } from '../communities/community.module';
     SummarizeEntityModule,
     ProceduralModule,
     CommunityModule,
+    CodeMemoryModule,
   ],
   controllers: [McpController],
   providers: [McpService],

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -11,6 +11,7 @@ import { IngestPredictionService } from '../ingest/ingest-predictor.service';
 import { SummarizeEntityService } from '../summarize-entity/summarize-entity.service';
 import { ProceduralMemoryService } from '../procedural/procedural-memory.service';
 import { CommunityService } from '../communities/community.service';
+import { CodeMemorySearchService } from '../code-memory/code-memory-search.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { BrainScope } from '../auth/api-key.types';
 import { registerCommunityTools } from './community-tools';
@@ -41,6 +42,7 @@ const HEALTH_TOOLS = [
   'list_communities',
   'find_entity_communities',
   'why',
+  'recall_decisions',
 ];
 
 /**
@@ -78,6 +80,7 @@ export class McpService {
     private readonly summarizer: SummarizeEntityService,
     private readonly procedural: ProceduralMemoryService,
     private readonly communities: CommunityService,
+    private readonly codeSearch: CodeMemorySearchService,
     private readonly embedder: EmbedderService,
   ) {}
 
@@ -141,7 +144,7 @@ export class McpService {
       server,
       companyId,
       scopes,
-      deps: { entities: this.entities },
+      deps: { entities: this.entities, codeSearch: this.codeSearch },
     });
     if (scopes.includes('brain:write')) {
       registerWriteTools(server, companyId, {

--- a/test/code-memory-eval.e2e-spec.ts
+++ b/test/code-memory-eval.e2e-spec.ts
@@ -20,6 +20,7 @@ import type { AppFixture } from './app-fixture';
 import { createApp } from './app-fixture';
 import { IngestService } from '../src/ingest/ingest.service';
 import { EntitiesService } from '../src/entities/entities.service';
+import { CodeMemorySearchService } from '../src/code-memory/code-memory-search.service';
 import {
   codeMemoryKindOf,
   codeMemoryPredicateId,
@@ -82,5 +83,23 @@ describe('code-memory Phase 3 — eval (recall + invariant surfacing)', () => {
       if (texts.includes(inv.text)) surfaced += 1;
     }
     expect(surfaced).toBe(invariants.length);
+  });
+
+  it('recall_decisions surfaces code-memory by NL topic (0 via the general search)', async () => {
+    const cm = f.app.get(CodeMemorySearchService);
+    const recalls: number[] = [];
+    for (const q of GOLDEN_QUERIES) {
+      const decisions = await cm.recall({
+        companyId: f.companyId,
+        query: q.semanticQuery,
+        limit: 20,
+        scopes: READ,
+      });
+      const anchors = new Set(decisions.map((d) => d.anchor));
+      recalls.push(anchors.has(q.anchor) ? 1 : 0);
+    }
+    // Dedicated code-memory retrieval leg: every query's anchor is recalled,
+    // where the general entity-centric search returned nothing.
+    expect(mean(recalls)).toBe(1);
   });
 });

--- a/test/mcp-tools.unit-spec.ts
+++ b/test/mcp-tools.unit-spec.ts
@@ -42,6 +42,7 @@ function buildWithScopes(scopes: BrainScope[]): McpServer {
     {} as never,
     {} as never,
     {} as never,
+    {} as never,
     stubEmbedder as never,
   );
   return svc.buildServer('co_test', scopes);
@@ -82,6 +83,7 @@ const READ_BASELINE = [
   'find_entity_communities',
   'find_related_entities',
   'why',
+  'recall_decisions',
 ];
 
 describe('McpService.buildServer — scope-gated tool surface', () => {
@@ -132,6 +134,7 @@ describe('McpService.buildServer — scope-gated tool surface', () => {
 describe('McpService.health — unauthenticated probe payload', () => {
   it('returns ok, version, the read-baseline tools, and embedder hint', () => {
     const svc = new McpService(
+      {} as never,
       {} as never,
       {} as never,
       {} as never,


### PR DESCRIPTION
## What

Closes the gap Phase 3 surfaced: the general entity-centric search returns **0** for NL topic queries over code-memory (code anchors have path-string names, not NL). This adds a dedicated retrieval leg.

- **`CodeMemorySearchService`** — a direct cosine search over the `code_memory__*` facts' own embeddings (status active), resolving each hit's code anchor from the entity `externalRefs`. Answers "why do we do X?" across the whole codebase, vs `why` which reads one known anchor. Scoped read (PII fence honoured).
- **MCP tool `recall_decisions(query, limit?)`** (brain:read) + `CodeMemoryModule` wired into `McpModule`; added to the health tool list.
- **eval e2e gate**: `recall_decisions` recalls every golden query's anchor by NL topic (recall = 1.0), where the general search returned nothing.

## Verification
- `pnpm exec tsc --noEmit` · `pnpm typecheck` · `pnpm lint` · max-params ≤3 ✓
- 755 unit · 142 e2e (+1) · 9 jobs ✓ (full-app DI boot confirms the new module wires)

## Next
Phase 2b (anchor re-validation sweep), pack distribution (JSON/signed manifests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)