### PR TITLE
feat(code-memory): Phase 2b — anchor re-validation sweep (list/reanchor/invalidate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bench:router": "ts-node -r tsconfig-paths/register scripts/bench-chat-router.ts",
     "capture:decisions": "ts-node -r tsconfig-paths/register scripts/capture-decisions.ts",
     "pack:validate": "ts-node -r tsconfig-paths/register scripts/validate-pack.ts",
+    "code-memory:validate-anchors": "ts-node -r tsconfig-paths/register scripts/validate-anchors.ts",
     "test:eval:fat": "pnpm build && FAT_TENANT_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=fat-tenant",
     "test:eval:directory": "pnpm build && DIRECTORY_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=directory",
     "test:eval:json": "pnpm build && jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=json-directory",

--- a/scripts/validate-anchors.ts
+++ b/scripts/validate-anchors.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env ts-node
+/**
+ * Code-memory Phase 2b — anchor re-validation sweep CLI.
+ * (docs/roadmap/code-memory-domain.md)
+ *
+ *   BRAIN_API_KEY=... pnpm code-memory:validate-anchors -- \
+ *     --brain-url https://brain.inite.ai [--dry-run]
+ *
+ * Runs where the code lives. Lists the tenant's code anchors from brain, checks
+ * each against the current working tree (symbol still present? file still
+ * there?), re-anchors moved/renamed symbols and invalidates gone ones, then
+ * POSTs the verdicts. Only anchor strings cross the wire — never source.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  buildAnchorVerdicts,
+  heuristicChoose,
+} from '../src/code-memory/anchor/sweep';
+
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+async function main(): Promise<void> {
+  const brainUrl = arg('brain-url', process.env.BRAIN_URL);
+  const brainKey = process.env.BRAIN_API_KEY;
+  const dryRun = process.argv.includes('--dry-run');
+  if (!brainUrl || !brainKey) {
+    throw new Error('--brain-url and BRAIN_API_KEY are required');
+  }
+  const headers = {
+    'content-type': 'application/json',
+    authorization: `Bearer ${brainKey}`,
+  };
+
+  const listed = await fetch(`${brainUrl}/v1/admin/code-memory/anchors`, {
+    headers,
+  });
+  if (!listed.ok) throw new Error(`list anchors failed: ${listed.status}`);
+  const { anchors } = (await listed.json()) as {
+    anchors: Array<{ anchor: string }>;
+  };
+  console.error(`[anchors] ${anchors.length} anchor(s) to check`);
+
+  const verdicts = buildAnchorVerdicts({
+    anchors: anchors.map((a) => a.anchor),
+    readFile: (p) => {
+      try {
+        return readFileSync(join(process.cwd(), p), 'utf8');
+      } catch {
+        return null;
+      }
+    },
+    choose: heuristicChoose,
+  });
+  const actionable = verdicts.filter((v) => v.action !== 'ok');
+  console.error(
+    `[anchors] ${actionable.length} actionable: ` +
+      JSON.stringify(actionable),
+  );
+
+  if (dryRun || actionable.length === 0) {
+    console.error('[anchors] dry-run / nothing to apply');
+    return;
+  }
+  const applied = await fetch(
+    `${brainUrl}/v1/admin/code-memory/anchors/apply`,
+    { method: 'POST', headers, body: JSON.stringify({ verdicts: actionable }) },
+  );
+  if (!applied.ok) throw new Error(`apply failed: ${applied.status}`);
+  console.error(`[anchors] applied: ${JSON.stringify(await applied.json())}`);
+}
+
+main().catch((e) => {
+  console.error(`[anchors] fatal: ${(e as Error).message}`);
+  process.exit(1);
+});

--- a/src/admin/admin-code-memory.controller.ts
+++ b/src/admin/admin-code-memory.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { CodeMemoryAnchorService } from '../code-memory/code-memory-anchor.service';
+import type {
+  AnchorsListResponse,
+  AnchorVerdict,
+  ApplyVerdictsResponse,
+} from '../contracts/admin/code-memory.schema';
+
+/**
+ * Server side of the code-memory anchor re-validation sweep (Phase 2b). The
+ * client lists anchors, checks each against the working tree, and POSTs
+ * verdicts; the server applies reanchor / invalidate. brain:admin.
+ */
+@Controller('v1/admin/code-memory')
+@UseGuards(ApiKeyGuard)
+export class AdminCodeMemoryController {
+  constructor(private readonly anchors: CodeMemoryAnchorService) {}
+
+  @Get('anchors')
+  @RequireScopes('brain:admin')
+  async list(@Req() req: AuthenticatedRequest): Promise<AnchorsListResponse> {
+    const anchors = await this.anchors.listAnchors(
+      req.brainAuth.companyId,
+      req.brainAuth.scopes,
+    );
+    return { anchors } satisfies AnchorsListResponse;
+  }
+
+  @Post('anchors/apply')
+  @RequireScopes('brain:admin')
+  async apply(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { verdicts: AnchorVerdict[] },
+  ): Promise<ApplyVerdictsResponse> {
+    const companyId = req.brainAuth.companyId;
+    const out: ApplyVerdictsResponse = {
+      reanchored: 0,
+      invalidated: 0,
+      factsRetracted: 0,
+      skipped: 0,
+    };
+    for (const v of body?.verdicts ?? []) {
+      if (v.action === 'reanchor') {
+        const r = await this.anchors.reanchor(companyId, v.anchor, v.newAnchor);
+        if (r.reanchored) out.reanchored += 1;
+        else out.skipped += 1;
+      } else if (v.action === 'invalidate') {
+        const n = await this.anchors.invalidateAnchor(
+          companyId,
+          v.anchor,
+          v.reason ?? 'anchor stale',
+        );
+        out.invalidated += 1;
+        out.factsRetracted += n;
+      } else {
+        out.skipped += 1;
+      }
+    }
+    return out;
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -27,6 +27,8 @@ import { OperatorActionInterceptor } from './operator-action.interceptor';
 import { ThrottlerObservabilityService } from './throttler-observability.service';
 import { ThrottlerObservabilityInterceptor } from './throttler-observability.interceptor';
 import { AdminPacksController } from './admin-packs.controller';
+import { AdminCodeMemoryController } from './admin-code-memory.controller';
+import { CodeMemoryModule } from '../code-memory/code-memory.module';
 import { DomainPackInstallService } from './domain-pack-install.service';
 import { ScenarioRunnerService } from './scenario-runner.service';
 import { ScenarioWriteService } from './scenario-write.service';
@@ -56,6 +58,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     // @Global, so without this import Nest fails to resolve the
     // controller and the whole app refuses to boot.
     CompactionModule,
+    CodeMemoryModule,
   ],
   controllers: [
     AdminController,
@@ -66,6 +69,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     AdminOpsController,
     AdminInfraController,
     AdminPacksController,
+    AdminCodeMemoryController,
   ],
   providers: [
     AdminService,

--- a/src/code-memory/anchor/sweep.ts
+++ b/src/code-memory/anchor/sweep.ts
@@ -1,0 +1,79 @@
+import { reanchor, validateAnchor, type ReadFile } from './refine';
+import { parseAnchor } from './symbol-id';
+
+/**
+ * Client-side anchor sweep (Phase 2b): turn a list of stored anchors into
+ * verdicts by checking each against the current working tree. Pure given
+ * `readFile` + a re-anchor `choose` (heuristic or LLM). The CLI sends the
+ * verdicts to the server, which applies reanchor / invalidate. `ok` anchors
+ * (including symbol anchors that merely moved lines) need no action.
+ */
+
+export type AnchorVerdict =
+  | { anchor: string; action: 'ok' }
+  | { anchor: string; action: 'reanchor'; newAnchor: string }
+  | { anchor: string; action: 'invalidate'; reason: string };
+
+export function buildAnchorVerdicts(opts: {
+  anchors: string[];
+  readFile: ReadFile;
+  choose: (candidates: string[], missing: string) => string | null;
+}): AnchorVerdict[] {
+  const { anchors, readFile, choose } = opts;
+  const verdicts: AnchorVerdict[] = [];
+  for (const anchor of anchors) {
+    const health = validateAnchor({ anchor, readFile });
+    if (health === 'present') {
+      verdicts.push({ anchor, action: 'ok' });
+      continue;
+    }
+    if (health === 'file_gone') {
+      verdicts.push({ anchor, action: 'invalidate', reason: 'file removed' });
+      continue;
+    }
+    // symbol_missing — try an LLM/heuristic re-anchor before giving up.
+    const { path, symbolPath } = parseAnchor(anchor);
+    const source = readFile(path);
+    const newAnchor =
+      source && symbolPath
+        ? reanchor({ source, path, missingSymbolPath: symbolPath, choose })
+        : null;
+    verdicts.push(
+      newAnchor
+        ? { anchor, action: 'reanchor', newAnchor }
+        : {
+            anchor,
+            action: 'invalidate',
+            reason: `symbol ${symbolPath ?? ''} not found`,
+          },
+    );
+  }
+  return verdicts;
+}
+
+/** Cheap default re-anchor chooser: pick the current symbol sharing the longest
+ *  common prefix with the missing one (covers renames like resolv→resolve and
+ *  moves that keep the class). An LLM chooser can replace this. */
+export function heuristicChoose(
+  candidates: string[],
+  missing: string,
+): string | null {
+  let best: string | null = null;
+  let bestScore = 0;
+  for (const c of candidates) {
+    const score = commonPrefixLen(c, missing);
+    if (score > bestScore) {
+      bestScore = score;
+      best = c;
+    }
+  }
+  // Require a meaningful overlap so unrelated symbols aren't grabbed.
+  return bestScore >= Math.min(4, missing.length) ? best : null;
+}
+
+function commonPrefixLen(a: string, b: string): number {
+  const n = Math.min(a.length, b.length);
+  let i = 0;
+  while (i < n && a[i] === b[i]) i += 1;
+  return i;
+}

--- a/src/code-memory/code-memory-anchor.service.ts
+++ b/src/code-memory/code-memory-anchor.service.ts
@@ -1,0 +1,161 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  SurrealService,
+  retryOnUniqueViolation,
+  isUniqueViolation,
+} from '../db/surreal.service';
+import { BrainScope } from '../auth/api-key.types';
+import { CODE_MEMORY_PACK } from '../ai/domain-packs';
+
+export interface AnchorRow {
+  anchor: string;
+  entityId: string;
+  factIds: string[];
+}
+
+/**
+ * Server side of the code-memory anchor re-validation sweep (Phase 2b). The
+ * client (which has the code) lists anchors, checks each against the current
+ * source, and applies verdicts:
+ *   - reanchor  — a symbol moved/renamed: point the old anchor's entity at the
+ *     new symbol id too (facts preserved, `why(newAnchor)` starts resolving).
+ *   - invalidate — the symbol/file is gone: retract the anchor's active facts
+ *     (retractedAt set — dropped from `why`; row kept for audit, never deleted).
+ * Symbol anchors survive line shifts on their own; this handles the harder
+ * rename/delete drift.
+ */
+@Injectable()
+export class CodeMemoryAnchorService {
+  private readonly logger = new Logger(CodeMemoryAnchorService.name);
+  private readonly prefix = `${CODE_MEMORY_PACK.id}__`;
+
+  constructor(private readonly surreal: SurrealService) {}
+
+  /** All code anchors currently carrying active code-memory facts. */
+  async listAnchors(
+    companyId: string,
+    scopes: BrainScope[],
+  ): Promise<AnchorRow[]> {
+    return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT id, entityId, entityId.externalRefs AS refs
+           FROM knowledge_fact
+           WHERE string::starts_with(predicate, $prefix)
+             AND retractedAt IS NONE`,
+        { prefix: this.prefix },
+      );
+      const byAnchor = new Map<string, AnchorRow>();
+      for (const r of (rows as any[]) ?? []) {
+        const anchor = anchorOf(r.refs);
+        if (!anchor) continue;
+        const existing = byAnchor.get(anchor);
+        if (existing) {
+          existing.factIds.push(String(r.id));
+        } else {
+          byAnchor.set(anchor, {
+            anchor,
+            entityId: String(r.entityId),
+            factIds: [String(r.id)],
+          });
+        }
+      }
+      return [...byAnchor.values()];
+    });
+  }
+
+  /** Retract the active code-memory facts on an anchor (drift: symbol/file gone). */
+  async invalidateAnchor(
+    companyId: string,
+    anchor: string,
+    reason: string,
+  ): Promise<number> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const entityId = await this.resolveEntity(db, anchor);
+      if (!entityId) return 0;
+      const [updated] = await db.query<[any[]]>(
+        `UPDATE knowledge_fact
+           SET retractedAt = time::now(), retractionReason = $reason
+           WHERE entityId = type::record('knowledge_entity', $eid)
+             AND string::starts_with(predicate, $prefix)
+             AND retractedAt IS NONE
+           RETURN AFTER`,
+        { eid: idTail(entityId), prefix: this.prefix, reason },
+      );
+      const n = ((updated as any[]) ?? []).length;
+      this.logger.log(
+        `Invalidated ${n} code-memory fact(s) at anchor ${anchor} (${companyId}): ${reason}`,
+      );
+      return n;
+    });
+  }
+
+  /** Add `newAnchor` as an alias external-ref of `oldAnchor`'s entity, so the
+   *  preserved facts resolve under the moved/renamed symbol too. */
+  async reanchor(
+    companyId: string,
+    oldAnchor: string,
+    newAnchor: string,
+  ): Promise<{ reanchored: boolean; reason?: string }> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const entityId = await this.resolveEntity(db, oldAnchor);
+      if (!entityId) return { reanchored: false, reason: 'old anchor not found' };
+      const newKey = externalRefKey('code', newAnchor);
+      try {
+        await retryOnUniqueViolation(async () => {
+          await db.query(
+            `CREATE entity_external_ref CONTENT { key: $key, entity: type::record('knowledge_entity', $eid) }`,
+            { key: newKey, eid: idTail(entityId) },
+          );
+        });
+      } catch (e) {
+        if (isUniqueViolation(e)) {
+          return { reanchored: false, reason: 'new anchor already exists' };
+        }
+        throw e;
+      }
+      // Mirror into the entity's externalRefs map (read-merge-write).
+      const [ent] = await db.query<[any[]]>(
+        `SELECT externalRefs FROM type::record('knowledge_entity', $eid) LIMIT 1`,
+        { eid: idTail(entityId) },
+      );
+      const refs = ((ent as any[]) ?? [])[0]?.externalRefs ?? {};
+      await db.query(
+        `UPDATE type::record('knowledge_entity', $eid) SET externalRefs = $refs`,
+        { eid: idTail(entityId), refs: { ...refs, [newKey]: newAnchor } },
+      );
+      this.logger.log(
+        `Re-anchored ${oldAnchor} → ${newAnchor} (${companyId})`,
+      );
+      return { reanchored: true };
+    });
+  }
+
+  private async resolveEntity(db: any, anchor: string): Promise<string | null> {
+    const key = externalRefKey('code', anchor);
+    const [rows] = await db.query(
+      `SELECT VALUE entity FROM entity_external_ref WHERE key = $key LIMIT 1`,
+      { key },
+    );
+    const arr = (rows as any[]) ?? [];
+    return arr[0] ? String(arr[0]) : null;
+  }
+}
+
+function anchorOf(refs: Record<string, string> | undefined | null): string {
+  if (!refs) return '';
+  for (const [k, v] of Object.entries(refs)) {
+    if (k.startsWith('code__')) return String(v);
+  }
+  return '';
+}
+
+// Mirrors externalRefKey() in src/ingest/ingest-utils.ts (write side): dots → __.
+function externalRefKey(vertical: string, id: string): string {
+  const safe = (s: string) => s.replace(/\./g, '__');
+  return `${safe(vertical)}__${safe(id)}`;
+}
+
+function idTail(entityId: string): string {
+  const i = entityId.indexOf(':');
+  return i === -1 ? entityId : entityId.slice(i + 1);
+}

--- a/src/code-memory/code-memory.module.ts
+++ b/src/code-memory/code-memory.module.ts
@@ -1,13 +1,15 @@
 import { Module } from '@nestjs/common';
 import { CodeMemorySearchService } from './code-memory-search.service';
+import { CodeMemoryAnchorService } from './code-memory-anchor.service';
 
 /**
- * Server-side code-memory retrieval (Phase 3b). SurrealService + EmbedderService
- * are provided by their @Global modules, so this module only declares the
- * code-memory-specific service and exports it for the MCP surface.
+ * Server-side code-memory services: semantic retrieval (Phase 3b) + anchor
+ * re-validation (Phase 2b). SurrealService + EmbedderService come from their
+ * @Global modules; this module declares + exports the code-memory-specific
+ * services for the MCP + admin surfaces.
  */
 @Module({
-  providers: [CodeMemorySearchService],
-  exports: [CodeMemorySearchService],
+  providers: [CodeMemorySearchService, CodeMemoryAnchorService],
+  exports: [CodeMemorySearchService, CodeMemoryAnchorService],
 })
 export class CodeMemoryModule {}

--- a/src/contracts/admin/code-memory.schema.ts
+++ b/src/contracts/admin/code-memory.schema.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+/** Wire contracts for the code-memory anchor sweep (/v1/admin/code-memory). */
+
+export const AnchorRowSchema = z.object({
+  anchor: z.string(),
+  entityId: z.string(),
+  factIds: z.array(z.string()),
+});
+
+export const AnchorsListResponseSchema = z.object({
+  anchors: z.array(AnchorRowSchema),
+});
+
+export const AnchorVerdictSchema = z.discriminatedUnion('action', [
+  z.object({ anchor: z.string(), action: z.literal('ok') }),
+  z.object({
+    anchor: z.string(),
+    action: z.literal('reanchor'),
+    newAnchor: z.string(),
+  }),
+  z.object({
+    anchor: z.string(),
+    action: z.literal('invalidate'),
+    reason: z.string().optional(),
+  }),
+]);
+
+export const ApplyVerdictsResponseSchema = z.object({
+  reanchored: z.number().int().nonnegative(),
+  invalidated: z.number().int().nonnegative(),
+  factsRetracted: z.number().int().nonnegative(),
+  skipped: z.number().int().nonnegative(),
+});
+
+export type AnchorsListResponse = z.infer<typeof AnchorsListResponseSchema>;
+export type AnchorVerdict = z.infer<typeof AnchorVerdictSchema>;
+export type ApplyVerdictsResponse = z.infer<typeof ApplyVerdictsResponseSchema>;

--- a/test/code-memory-anchor.e2e-spec.ts
+++ b/test/code-memory-anchor.e2e-spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Code-memory Phase 2b — anchor re-validation service, end-to-end on a real DB.
+ *
+ * Proves list → invalidate → reanchor against the actual store:
+ *   - listAnchors surfaces anchors carrying active code-memory facts;
+ *   - invalidateAnchor retracts an anchor's facts (dropped from `why`, kept for
+ *     audit);
+ *   - reanchor makes the preserved facts resolve under a new (renamed) symbol.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { IngestService } from '../src/ingest/ingest.service';
+import { EntitiesService } from '../src/entities/entities.service';
+import { CodeMemoryAnchorService } from '../src/code-memory/code-memory-anchor.service';
+import { codeMemoryPredicateId } from '../src/ai/domain-packs';
+
+describe('code-memory Phase 2b — anchor re-validation service', () => {
+  let f: AppFixture;
+  const SCOPES = ['brain:read', 'brain:read_pii', 'brain:admin'] as any;
+  const ANCHOR_A = 'src/x.ts#Foo.bar';
+  const ANCHOR_B = 'src/y.ts#Baz.qux';
+  const ANCHOR_B_NEW = 'src/y.ts#Baz.renamed';
+
+  const activeCodeFacts = async (anchor: string) => {
+    const entities = f.app.get(EntitiesService);
+    const profile = await entities.getProfileByExternalRef({
+      companyId: f.companyId,
+      vertical: 'code',
+      id: anchor,
+      asOfRaw: undefined,
+      scopes: SCOPES,
+    });
+    return (profile?.facts ?? []).filter((x) =>
+      x.predicate.startsWith('code_memory__'),
+    );
+  };
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_code_anchor_e2e' });
+    const ingest = f.app.get(IngestService);
+    await ingest.ingestFact(f.companyId, {
+      entityRef: { vertical: 'code', id: ANCHOR_A },
+      predicate: codeMemoryPredicateId('decided'),
+      object: 'Foo.bar owns the decision',
+      validFrom: '2026-07-07T00:00:00Z',
+      source: { vertical: 'code', recorder: 'code_memory' },
+    });
+    await ingest.ingestFact(f.companyId, {
+      entityRef: { vertical: 'code', id: ANCHOR_B },
+      predicate: codeMemoryPredicateId('gotcha'),
+      object: 'Baz.qux has a subtle trap',
+      validFrom: '2026-07-07T00:00:00Z',
+      source: { vertical: 'code', recorder: 'code_memory' },
+    });
+  });
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('listAnchors surfaces anchors with active code-memory facts', async () => {
+    const svc = f.app.get(CodeMemoryAnchorService);
+    const anchors = await svc.listAnchors(f.companyId, SCOPES);
+    const map = new Map(anchors.map((a) => [a.anchor, a]));
+    expect(map.has(ANCHOR_A)).toBe(true);
+    expect(map.has(ANCHOR_B)).toBe(true);
+    expect(map.get(ANCHOR_A)!.factIds.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('invalidateAnchor retracts an anchor and drops it from why', async () => {
+    const svc = f.app.get(CodeMemoryAnchorService);
+    expect((await activeCodeFacts(ANCHOR_A)).length).toBe(1);
+
+    const n = await svc.invalidateAnchor(f.companyId, ANCHOR_A, 'symbol removed');
+    expect(n).toBe(1);
+    expect((await activeCodeFacts(ANCHOR_A)).length).toBe(0);
+  });
+
+  it('reanchor makes preserved facts resolve under the renamed symbol', async () => {
+    const svc = f.app.get(CodeMemoryAnchorService);
+    const r = await svc.reanchor(f.companyId, ANCHOR_B, ANCHOR_B_NEW);
+    expect(r.reanchored).toBe(true);
+
+    const viaNew = await activeCodeFacts(ANCHOR_B_NEW);
+    expect(viaNew.length).toBe(1);
+    expect(viaNew[0].object).toMatch(/subtle trap/);
+  });
+});

--- a/test/code-memory-sweep.unit-spec.ts
+++ b/test/code-memory-sweep.unit-spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Code-memory Phase 2b — client-side anchor sweep verdict builder (pure).
+ */
+import {
+  buildAnchorVerdicts,
+  heuristicChoose,
+} from '../src/code-memory/anchor/sweep';
+
+const SRC = `export class FactResolverService {
+  async resolve(id: string): Promise<number> {
+    return id.length;
+  }
+}
+export function helper(a: number): number {
+  return a + 1;
+}
+`;
+
+const readFile = (p: string) => (p === 'x.ts' ? SRC : null);
+
+describe('heuristicChoose', () => {
+  it('picks the current symbol sharing the longest prefix (rename)', () => {
+    expect(
+      heuristicChoose(
+        ['FactResolverService.resolve', 'helper'],
+        'FactResolverService.resolv',
+      ),
+    ).toBe('FactResolverService.resolve');
+  });
+  it('declines when nothing meaningfully overlaps', () => {
+    expect(heuristicChoose(['helper', 'other'], 'Zzz.Qqq')).toBeNull();
+  });
+});
+
+describe('buildAnchorVerdicts', () => {
+  it('ok for a resolving symbol anchor and a bare file anchor', () => {
+    const v = buildAnchorVerdicts({
+      anchors: ['x.ts#FactResolverService.resolve', 'x.ts'],
+      readFile,
+      choose: heuristicChoose,
+    });
+    expect(v).toEqual([
+      { anchor: 'x.ts#FactResolverService.resolve', action: 'ok' },
+      { anchor: 'x.ts', action: 'ok' },
+    ]);
+  });
+
+  it('invalidates when the file is gone', () => {
+    const v = buildAnchorVerdicts({
+      anchors: ['deleted.ts#Foo.bar'],
+      readFile,
+      choose: heuristicChoose,
+    });
+    expect(v[0]).toMatchObject({ action: 'invalidate' });
+  });
+
+  it('re-anchors a renamed symbol to its closest current match', () => {
+    const v = buildAnchorVerdicts({
+      anchors: ['x.ts#FactResolverService.resolv'],
+      readFile,
+      choose: heuristicChoose,
+    });
+    expect(v[0]).toEqual({
+      anchor: 'x.ts#FactResolverService.resolv',
+      action: 'reanchor',
+      newAnchor: 'x.ts#FactResolverService.resolve',
+    });
+  });
+
+  it('invalidates when the symbol is gone with no plausible match', () => {
+    const v = buildAnchorVerdicts({
+      anchors: ['x.ts#Totally.Different'],
+      readFile,
+      choose: heuristicChoose,
+    });
+    expect(v[0]).toMatchObject({ action: 'invalidate' });
+  });
+});

--- a/test/contracts-admin-code-memory.unit-spec.ts
+++ b/test/contracts-admin-code-memory.unit-spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Wire-contract drift guard for GET /v1/admin/code-memory/anchors.
+ */
+import { AnchorsListResponseSchema } from '../src/contracts/admin/code-memory.schema';
+import { AdminCodeMemoryController } from '../src/admin/admin-code-memory.controller';
+import type { CodeMemoryAnchorService } from '../src/code-memory/code-memory-anchor.service';
+import type { AuthenticatedRequest } from '../src/auth/api-key.types';
+
+function makeController(): AdminCodeMemoryController {
+  const svc = {
+    listAnchors: () =>
+      Promise.resolve([
+        {
+          anchor: 'src/x.ts#Foo.bar',
+          entityId: 'knowledge_entity:abc',
+          factIds: ['knowledge_fact:1', 'knowledge_fact:2'],
+        },
+      ]),
+  } as unknown as CodeMemoryAnchorService;
+  return new AdminCodeMemoryController(svc);
+}
+
+describe('AdminCodeMemoryController.list() — wire contract', () => {
+  it('matches AnchorsListResponseSchema', async () => {
+    const req = {
+      brainAuth: { companyId: 'co_test', scopes: ['brain:admin'] },
+    } as AuthenticatedRequest;
+    const parsed = AnchorsListResponseSchema.safeParse(
+      await makeController().list(req),
+    );
+    if (!parsed.success) {
+      throw new Error(
+        `anchors list drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## What

Keeps code-memory from rotting as code changes. Symbol anchors already survive line shifts (Phase 2); this handles the harder **rename/delete** drift via a client-driven sweep (client has the code; only anchor strings cross the wire).

- **`CodeMemoryAnchorService`** (server): `listAnchors` (anchors carrying active facts), `reanchor` (alias an old anchor's entity to a new symbol id — facts preserved, `why(newAnchor)` resolves), `invalidateAnchor` (retract an anchor's facts — dropped from `why`, kept for audit, **never deleted**).
- **`AdminCodeMemoryController`** (brain:admin): `GET /v1/admin/code-memory/anchors`, `POST anchors/apply {verdicts}` — in `CodeMemoryModule`, imported by admin.
- **`anchor/sweep`** (client, pure): `buildAnchorVerdicts` checks each anchor against the working tree via the Phase-2 resolver → `ok | reanchor(newAnchor) | invalidate`; `heuristicChoose` re-anchors renames by longest-common-prefix (an LLM chooser can replace it). CLI `pnpm code-memory:validate-anchors` (`--dry-run`).

## Verification
e2e round-trip on a real DB: list → invalidate (facts drop from `why`) → reanchor (preserved facts resolve under the renamed symbol).
- `pnpm exec tsc --noEmit` · `pnpm typecheck` · `pnpm lint` · max-params ≤3 ✓
- 762 unit (+7) · 145 e2e (+3) · 9 jobs ✓

## Next
Final backlog item: pack distribution (JSON/signed manifests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)