### PR TITLE
feat(domain-packs): distribution — JSON-manifest install CLI + content-integrity checksum

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -86,12 +86,19 @@ than silently shadowing.
 engineering "why" of a codebase: `decided`, `because`, `invariant`, `gotcha`,
 anchored to code anchors. See `docs/roadmap/code-memory-domain.md`.
 
-## Roadmap (not built yet)
+## Distribution + integrity
 
-This phase delivers the **standard + namespacing + the merge loader**. Still
-ahead, to make packs fully community-distributable:
-- **Runtime per-tenant install/uninstall** — a `domain_pack` table recording
-  installed packs + pinned versions per tenant; install/upgrade/rollback API.
-- **Distribution** — load packs from JSON manifests / a registry, not only
-  compiled modules; signed/checksummed packs.
-- **Per-pack eval fixtures + extraction profiles** carried in the manifest.
+- **Runtime per-tenant install/uninstall** (shipped) — `domain_pack` table +
+  `/v1/admin/packs` (install upserts = upgrade; uninstall deprecates predicates).
+- **JSON-manifest install** (shipped) — `pnpm pack:install --file pack.json`
+  POSTs a manifest; no compiled module needed. Community packs ship as JSON.
+- **Content integrity** (shipped) — every install computes + stores a
+  `packChecksum` (sha256 of the canonical, key-sorted manifest). Pass
+  `expectedChecksum` (or `pnpm pack:install --verify`) and the server rejects a
+  mismatch: "the manifest I install is the one I reviewed".
+- **Forward-compat manifest fields** — `extractionProfile` (prompt/few-shot for
+  the extractor) and `evalFixtures` are carried + stored, not yet consumed.
+
+Still ahead: publisher **signatures** (verify authorship, not just integrity)
+and a discovery **registry**; consuming `extractionProfile` / `evalFixtures` at
+runtime.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bench:router": "ts-node -r tsconfig-paths/register scripts/bench-chat-router.ts",
     "capture:decisions": "ts-node -r tsconfig-paths/register scripts/capture-decisions.ts",
     "pack:validate": "ts-node -r tsconfig-paths/register scripts/validate-pack.ts",
+    "pack:install": "ts-node -r tsconfig-paths/register scripts/install-pack.ts",
     "code-memory:validate-anchors": "ts-node -r tsconfig-paths/register scripts/validate-anchors.ts",
     "test:eval:fat": "pnpm build && FAT_TENANT_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=fat-tenant",
     "test:eval:directory": "pnpm build && DIRECTORY_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=directory",

--- a/scripts/install-pack.ts
+++ b/scripts/install-pack.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env ts-node
+/**
+ * Domain Pack install CLI (docs/domain-packs.md) — install a distributed pack
+ * from a JSON manifest file into a tenant.
+ *
+ *   BRAIN_API_KEY=... pnpm pack:install -- \
+ *     --brain-url https://brain.inite.ai --file ./my-pack.json [--verify]
+ *
+ * --verify recomputes the manifest checksum locally and pins it in the request,
+ * so the server rejects if what it receives differs from what you reviewed.
+ */
+import { readFileSync } from 'node:fs';
+import { packChecksum } from '../src/ai/domain-packs/checksum';
+import type { DomainPackManifest } from '../src/ai/domain-packs/manifest';
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+}
+
+async function main(): Promise<void> {
+  const brainUrl = arg('brain-url') ?? process.env.BRAIN_URL;
+  const file = arg('file');
+  const key = process.env.BRAIN_API_KEY;
+  if (!brainUrl || !file || !key) {
+    throw new Error('--brain-url, --file and BRAIN_API_KEY are required');
+  }
+  const manifest = JSON.parse(readFileSync(file, 'utf8')) as DomainPackManifest;
+  const checksum = packChecksum(manifest);
+  console.error(`[pack] ${manifest.id} v${manifest.version} checksum=${checksum}`);
+
+  const res = await fetch(`${brainUrl}/v1/admin/packs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({
+      manifest,
+      ...(process.argv.includes('--verify') ? { expectedChecksum: checksum } : {}),
+    }),
+  });
+  if (!res.ok) throw new Error(`install failed: ${res.status} ${await res.text()}`);
+  console.error(`[pack] installed: ${JSON.stringify(await res.json())}`);
+}
+
+main().catch((e) => {
+  console.error(`[pack] fatal: ${(e as Error).message}`);
+  process.exit(1);
+});

--- a/src/admin/admin-packs.controller.ts
+++ b/src/admin/admin-packs.controller.ts
@@ -44,9 +44,11 @@ export class AdminPacksController {
   @RequireScopes('brain:admin')
   async install(
     @Req() req: AuthenticatedRequest,
-    @Body() body: { manifest: DomainPackManifest },
+    @Body() body: { manifest: DomainPackManifest; expectedChecksum?: string },
   ): Promise<InstallPackResponse> {
-    return this.packs.install(req.brainAuth.companyId, body?.manifest);
+    return this.packs.install(req.brainAuth.companyId, body?.manifest, {
+      expectedChecksum: body?.expectedChecksum,
+    });
   }
 
   @Delete(':packId')

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -13,6 +13,7 @@ import {
   BUILTIN_PACKS,
   composePredicateId,
   DomainPackError,
+  packChecksum,
   validatePack,
   type DomainPackManifest,
 } from '../ai/domain-packs';
@@ -22,6 +23,7 @@ export interface InstalledPack {
   version: string;
   installedAt: string;
   predicateCount: number;
+  checksum: string | null;
 }
 
 export interface AvailablePack {
@@ -64,7 +66,7 @@ export class DomainPackInstallService {
   async listInstalled(companyId: string): Promise<InstalledPack[]> {
     return this.surreal.withCompany(companyId, async (db) => {
       const [rows] = await db.query<[any[]]>(
-        `SELECT packId, version, installedAt, manifest FROM domain_pack WHERE status = 'active'`,
+        `SELECT packId, version, installedAt, manifest, checksum FROM domain_pack WHERE status = 'active'`,
       );
       return ((rows as any[]) ?? []).map((r) => ({
         packId: String(r.packId),
@@ -73,6 +75,7 @@ export class DomainPackInstallService {
         predicateCount: Array.isArray(r.manifest?.predicates)
           ? r.manifest.predicates.length
           : 0,
+        checksum: r.checksum ? String(r.checksum) : null,
       }));
     });
   }
@@ -80,7 +83,13 @@ export class DomainPackInstallService {
   async install(
     companyId: string,
     manifest: DomainPackManifest,
-  ): Promise<{ packId: string; version: string; predicatesSeeded: number }> {
+    opts: { expectedChecksum?: string } = {},
+  ): Promise<{
+    packId: string;
+    version: string;
+    predicatesSeeded: number;
+    checksum: string;
+  }> {
     if (!manifest || typeof manifest !== 'object') {
       throw new BadRequestException('request body must include a pack manifest');
     }
@@ -93,6 +102,12 @@ export class DomainPackInstallService {
     if (this.builtinIds.has(manifest.id)) {
       throw new BadRequestException(
         `pack id "${manifest.id}" is reserved by a builtin pack and is already globally available`,
+      );
+    }
+    const checksum = packChecksum(manifest);
+    if (opts.expectedChecksum && opts.expectedChecksum !== checksum) {
+      throw new BadRequestException(
+        `checksum mismatch: expected ${opts.expectedChecksum}, computed ${checksum}`,
       );
     }
 
@@ -113,8 +128,8 @@ export class DomainPackInstallService {
       const row = ((existing as any[]) ?? [])[0];
       if (row) {
         await db.query(
-          `UPDATE $id SET version = $version, manifest = $manifest, status = 'active', updatedAt = time::now()`,
-          { id: row.id, version: manifest.version, manifest },
+          `UPDATE $id SET version = $version, manifest = $manifest, checksum = $checksum, status = 'active', updatedAt = time::now()`,
+          { id: row.id, version: manifest.version, manifest, checksum },
         );
       } else {
         await db.query(`CREATE domain_pack CONTENT $content`, {
@@ -122,6 +137,7 @@ export class DomainPackInstallService {
             packId: manifest.id,
             version: manifest.version,
             manifest,
+            checksum,
             status: 'active',
           },
         });
@@ -138,7 +154,12 @@ export class DomainPackInstallService {
     this.logger.log(
       `Installed pack ${manifest.id} v${manifest.version} into ${companyId} (${seeded} predicate(s) seeded)`,
     );
-    return { packId: manifest.id, version: manifest.version, predicatesSeeded: seeded };
+    return {
+      packId: manifest.id,
+      version: manifest.version,
+      predicatesSeeded: seeded,
+      checksum,
+    };
   }
 
   async uninstall(

--- a/src/ai/domain-packs/checksum.ts
+++ b/src/ai/domain-packs/checksum.ts
@@ -1,0 +1,28 @@
+import { createHash } from 'node:crypto';
+import type { DomainPackManifest } from './manifest';
+
+/**
+ * Content integrity for distributed packs (docs/domain-packs.md). A pack's
+ * checksum is the sha256 of its manifest in CANONICAL form (recursively
+ * key-sorted JSON), so two byte-different-but-equivalent manifests hash the
+ * same. On install a caller may pass an expectedChecksum; the server rejects a
+ * mismatch — "the manifest I install is the one I reviewed". (Publisher
+ * signatures are a further step; this is the integrity primitive.)
+ */
+export function packChecksum(manifest: DomainPackManifest): string {
+  return createHash('sha256').update(canonicalize(manifest)).digest('hex');
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(',')}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${canonicalize(obj[k])}`)
+    .join(',')}}`;
+}

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -26,4 +26,5 @@ export const SEED_PREDICATES: PredicateDefinition[] = assembleSeed(
 
 export * from './manifest';
 export * from './validate';
+export * from './checksum';
 export * from './code-memory.pack';

--- a/src/ai/domain-packs/manifest.ts
+++ b/src/ai/domain-packs/manifest.ts
@@ -38,6 +38,14 @@ export interface DomainPackManifest {
   description: string;
   /** The ontology this pack contributes. */
   predicates: PackPredicate[];
+  /**
+   * Forward-compatible distribution fields (docs/domain-packs.md). Carried in
+   * the manifest + stored on install; not yet consumed by the runtime. A pack
+   * may ship its extraction profile (prompt/few-shot for the LLM extractor) and
+   * eval fixtures alongside its predicates, per the full DomainPack vision.
+   */
+  extractionProfile?: Record<string, unknown>;
+  evalFixtures?: unknown[];
 }
 
 /** Compose the stored, namespaced predicate id for a pack-local predicate. */

--- a/src/contracts/admin/packs.schema.ts
+++ b/src/contracts/admin/packs.schema.ts
@@ -17,6 +17,7 @@ export const InstalledPackSchema = z.object({
   version: z.string(),
   installedAt: z.string(),
   predicateCount: z.number().int().nonnegative(),
+  checksum: z.string().nullable(),
 });
 
 export const PacksListResponseSchema = z.object({
@@ -28,6 +29,7 @@ export const InstallPackResponseSchema = z.object({
   packId: z.string(),
   version: z.string(),
   predicatesSeeded: z.number().int().nonnegative(),
+  checksum: z.string(),
 });
 
 export const UninstallPackResponseSchema = z.object({

--- a/src/db/migrations/0041_domain_pack_checksum.surql
+++ b/src/db/migrations/0041_domain_pack_checksum.surql
@@ -1,0 +1,6 @@
+-- 0041_domain_pack_checksum — content-integrity checksum for installed packs.
+-- sha256 of the canonical (key-sorted) manifest, computed on install. Lets an
+-- operator verify a distributed pack is the one they reviewed (see
+-- src/ai/domain-packs/checksum.ts). Optional — pre-existing rows have none.
+
+DEFINE FIELD IF NOT EXISTS checksum ON domain_pack TYPE option<string>;

--- a/test/contracts-admin-packs.unit-spec.ts
+++ b/test/contracts-admin-packs.unit-spec.ts
@@ -24,6 +24,7 @@ function makeController(): AdminPacksController {
           version: '1.0.0',
           installedAt: '2026-07-07T00:00:00.000Z',
           predicateCount: 1,
+          checksum: 'abc123',
         },
       ]),
   } as unknown as DomainPackInstallService;

--- a/test/domain-pack-install.e2e-spec.ts
+++ b/test/domain-pack-install.e2e-spec.ts
@@ -49,6 +49,8 @@ describe('/v1/admin/packs — runtime Domain Pack install', () => {
     expect([200, 201]).toContain(r.status);
     expect(r.body.packId).toBe('medical');
     expect(r.body.predicatesSeeded).toBe(1);
+    expect(typeof r.body.checksum).toBe('string');
+    expect(r.body.checksum.length).toBeGreaterThan(0);
 
     const preds = await f.http.get('/v1/admin/predicates').set(auth());
     const ids = (preds.body.predicates ?? []).map((p: any) => p.predicateId);
@@ -84,6 +86,17 @@ describe('/v1/admin/packs — runtime Domain Pack install', () => {
       .post('/v1/admin/packs')
       .set(auth())
       .send({ manifest: { ...MEDICAL_MANIFEST, id: 'code_memory' } });
+    expect(r.status).toBe(400);
+  });
+
+  it('rejects install when expectedChecksum does not match', async () => {
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({
+        manifest: { ...MEDICAL_MANIFEST, id: 'legal', version: '2.0.0' },
+        expectedChecksum: 'deadbeef',
+      });
     expect(r.status).toBe(400);
   });
 

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -5,6 +5,7 @@
 import {
   assembleSeed,
   composePredicateId,
+  packChecksum,
   validatePack,
   DomainPackError,
   type DomainPackManifest,
@@ -117,6 +118,19 @@ describe('assembleSeed', () => {
         [pack({ id: 'p', predicates: [packPredicate('x')] })],
       ),
     ).toThrow(/collision/);
+  });
+});
+
+describe('packChecksum', () => {
+  it('is deterministic and independent of key order', () => {
+    const a = pack({ id: 'demo', version: '1.2.3' });
+    const b = { version: '1.2.3', predicates: a.predicates, description: 'demo', id: 'demo' };
+    expect(packChecksum(a)).toBe(packChecksum(b as DomainPackManifest));
+  });
+  it('changes when content changes', () => {
+    const a = pack({ version: '1.0.0' });
+    const c = pack({ version: '1.0.1' });
+    expect(packChecksum(a)).not.toBe(packChecksum(c));
   });
 });
 


### PR DESCRIPTION
## What

Completes the pack-distribution backlog: community packs ship as **JSON** and install with an **integrity check**, no compiled module or redeploy.

- **`packChecksum`** — sha256 of the canonical (key-sorted) manifest; deterministic + key-order independent. Install computes + stores it (**migration 0041** `domain_pack.checksum`) and returns it; an optional `expectedChecksum` (or `pnpm pack:install --verify`) is **rejected on mismatch** — "the manifest I install is the one I reviewed".
- **CLI `pnpm pack:install --file pack.json [--verify]`** — reads a JSON manifest and POSTs it. `listInstalled` + install response now carry the checksum.
- **Forward-compat manifest fields** `extractionProfile` / `evalFixtures` — carried + stored, not yet consumed (the full DomainPack vision).
- docs updated; publisher signatures + a discovery registry noted as still ahead.

## Verification
- `pnpm exec tsc --noEmit` · `pnpm typecheck` · `pnpm lint` · max-params ≤3 ✓
- 764 unit (+2 checksum) · 146 e2e (+1 checksum mismatch → 400) · 9 jobs ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)