### PR TITLE
feat(domain-packs): publisher signatures — ed25519 sign/verify + install trust policy

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -99,6 +99,12 @@ anchored to code anchors. See `docs/roadmap/code-memory-domain.md`.
 - **Forward-compat manifest fields** — `extractionProfile` (prompt/few-shot for
   the extractor) and `evalFixtures` are carried + stored, not yet consumed.
 
-Still ahead: publisher **signatures** (verify authorship, not just integrity)
-and a discovery **registry**; consuming `extractionProfile` / `evalFixtures` at
-runtime.
+- **Publisher signatures** (shipped) — an ed25519 `signature` (+ `publisher`)
+  over the canonical manifest proves authorship, not just integrity. Sign with
+  `pnpm pack:sign --key priv.pem --publisher acme`; the server verifies against
+  a trust store (`DOMAIN_PACK_TRUSTED_KEYS` = publisher→PEM) and can require
+  signing (`DOMAIN_PACK_REQUIRE_SIGNATURE=true`). Unknown publisher / bad
+  signature → install rejected.
+
+Still ahead: a discovery **registry**; consuming `extractionProfile` /
+`evalFixtures` at runtime.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "capture:decisions": "ts-node -r tsconfig-paths/register scripts/capture-decisions.ts",
     "pack:validate": "ts-node -r tsconfig-paths/register scripts/validate-pack.ts",
     "pack:install": "ts-node -r tsconfig-paths/register scripts/install-pack.ts",
+    "pack:sign": "ts-node -r tsconfig-paths/register scripts/sign-pack.ts",
     "code-memory:validate-anchors": "ts-node -r tsconfig-paths/register scripts/validate-anchors.ts",
     "test:eval:fat": "pnpm build && FAT_TENANT_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=fat-tenant",
     "test:eval:directory": "pnpm build && DIRECTORY_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=directory",

--- a/scripts/sign-pack.ts
+++ b/scripts/sign-pack.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env ts-node
+/**
+ * Domain Pack signing CLI (docs/domain-packs.md).
+ *
+ *   pnpm pack:sign -- --file pack.json --key priv.pem --publisher acme [--out signed.json]
+ *
+ * Writes an ed25519 `signature` (+ `publisher`) into the manifest so a tenant
+ * whose trust store holds acme's public key can verify authorship on install.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { signPack } from '../src/ai/domain-packs/signature';
+import type { DomainPackManifest } from '../src/ai/domain-packs/manifest';
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+}
+
+function main(): void {
+  const file = arg('file');
+  const keyFile = arg('key');
+  const publisher = arg('publisher');
+  if (!file || !keyFile || !publisher) {
+    throw new Error('--file, --key and --publisher are required');
+  }
+  const manifest = JSON.parse(readFileSync(file, 'utf8')) as DomainPackManifest;
+  manifest.publisher = publisher;
+  delete manifest.signature;
+  manifest.signature = signPack(manifest, readFileSync(keyFile, 'utf8'));
+  const out = arg('out') ?? file;
+  writeFileSync(out, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.error(`[pack] signed ${manifest.id} as "${publisher}" → ${out}`);
+}
+
+try {
+  main();
+} catch (e) {
+  console.error(`[pack] sign failed: ${(e as Error).message}`);
+  process.exit(1);
+}

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -10,6 +10,7 @@ import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { seedMissingPredicates } from '../ai/predicate-registry-internals/seed-predicates';
 import type { PredicateDefinition } from '../ai/predicate-registry-internals/types';
 import {
+  assertPackTrust,
   BUILTIN_PACKS,
   composePredicateId,
   DomainPackError,
@@ -52,6 +53,17 @@ export class DomainPackInstallService {
     private readonly embedder: EmbedderService,
     private readonly registry: PredicateRegistryService,
   ) {}
+
+  /** Trust store: publisher → PEM public key, from DOMAIN_PACK_TRUSTED_KEYS
+   *  (JSON). Empty when unset — then only unsigned packs install (unless
+   *  DOMAIN_PACK_REQUIRE_SIGNATURE forces signing). */
+  private trustedKeys(): Record<string, string> {
+    try {
+      return JSON.parse(process.env.DOMAIN_PACK_TRUSTED_KEYS ?? '{}');
+    } catch {
+      return {};
+    }
+  }
 
   listAvailable(): AvailablePack[] {
     return BUILTIN_PACKS.map((p) => ({
@@ -103,6 +115,16 @@ export class DomainPackInstallService {
       throw new BadRequestException(
         `pack id "${manifest.id}" is reserved by a builtin pack and is already globally available`,
       );
+    }
+    try {
+      assertPackTrust({
+        manifest,
+        trustedKeys: this.trustedKeys(),
+        requireSignature: process.env.DOMAIN_PACK_REQUIRE_SIGNATURE === 'true',
+      });
+    } catch (e) {
+      if (e instanceof DomainPackError) throw new BadRequestException(e.message);
+      throw e;
     }
     const checksum = packChecksum(manifest);
     if (opts.expectedChecksum && opts.expectedChecksum !== checksum) {

--- a/src/ai/domain-packs/checksum.ts
+++ b/src/ai/domain-packs/checksum.ts
@@ -13,6 +13,12 @@ export function packChecksum(manifest: DomainPackManifest): string {
   return createHash('sha256').update(canonicalize(manifest)).digest('hex');
 }
 
+/** Canonical (recursively key-sorted) JSON string of any value. Shared by the
+ *  checksum and the signature (which signs the manifest minus its own sig). */
+export function canonicalJson(value: unknown): string {
+  return canonicalize(value);
+}
+
 function canonicalize(value: unknown): string {
   if (value === null || typeof value !== 'object') {
     return JSON.stringify(value) ?? 'null';

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -27,4 +27,5 @@ export const SEED_PREDICATES: PredicateDefinition[] = assembleSeed(
 export * from './manifest';
 export * from './validate';
 export * from './checksum';
+export * from './signature';
 export * from './code-memory.pack';

--- a/src/ai/domain-packs/manifest.ts
+++ b/src/ai/domain-packs/manifest.ts
@@ -46,6 +46,10 @@ export interface DomainPackManifest {
    */
   extractionProfile?: Record<string, unknown>;
   evalFixtures?: unknown[];
+  /** ed25519 signature (base64) over the canonical manifest sans this field. */
+  signature?: string;
+  /** Publisher id — the key in the tenant's trust store used to verify. */
+  publisher?: string;
 }
 
 /** Compose the stored, namespaced predicate id for a pack-local predicate. */

--- a/src/ai/domain-packs/signature.ts
+++ b/src/ai/domain-packs/signature.ts
@@ -1,0 +1,87 @@
+import {
+  sign as cryptoSign,
+  verify as cryptoVerify,
+  createPrivateKey,
+  createPublicKey,
+} from 'node:crypto';
+import { canonicalJson } from './checksum';
+import { DomainPackError } from './validate';
+import type { DomainPackManifest } from './manifest';
+
+/**
+ * Publisher authenticity for distributed packs (docs/domain-packs.md). Checksum
+ * proves integrity (unchanged); a signature proves AUTHORSHIP. An ed25519
+ * signature is computed over the canonical manifest EXCLUDING its own
+ * `signature` field (so signing is not circular). Verification is against a
+ * configured trust store (publisher → public key), so a tenant only installs
+ * packs from publishers it trusts. Uses node:crypto — no dependency.
+ */
+
+/** Canonical bytes signed/verified: the manifest without its signature field. */
+function signedBytes(manifest: DomainPackManifest): Buffer {
+  const { signature: _sig, ...rest } = manifest;
+  return Buffer.from(canonicalJson(rest), 'utf8');
+}
+
+export function signPack(
+  manifest: DomainPackManifest,
+  privateKeyPem: string,
+): string {
+  return cryptoSign(
+    null,
+    signedBytes(manifest),
+    createPrivateKey(privateKeyPem),
+  ).toString('base64');
+}
+
+export function verifyPackSignature(
+  manifest: DomainPackManifest,
+  publicKeyPem: string,
+): boolean {
+  if (!manifest.signature) return false;
+  try {
+    return cryptoVerify(
+      null,
+      signedBytes(manifest),
+      createPublicKey(publicKeyPem),
+      Buffer.from(manifest.signature, 'base64'),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Enforce the install-time trust policy. Throws DomainPackError when a signed
+ * pack fails to verify or names an unknown publisher, or when a signature is
+ * REQUIRED but absent. An unsigned pack is allowed only when signatures aren't
+ * required (integrity-only mode). Pure — the install service supplies the trust
+ * store + policy from config, so this is unit-testable without env/DB.
+ */
+export function assertPackTrust(opts: {
+  manifest: DomainPackManifest;
+  trustedKeys: Record<string, string>;
+  requireSignature: boolean;
+}): void {
+  const { manifest, trustedKeys, requireSignature } = opts;
+  if (!manifest.signature) {
+    if (requireSignature) {
+      throw new DomainPackError(
+        `pack "${manifest.id}" is unsigned but this tenant requires signed packs`,
+      );
+    }
+    return;
+  }
+  const publisher = manifest.publisher;
+  const key = publisher ? trustedKeys[publisher] : undefined;
+  if (!key) {
+    throw new DomainPackError(
+      `pack "${manifest.id}" is signed by an untrusted/unknown publisher "${publisher ?? ''}"`,
+    );
+  }
+  if (!verifyPackSignature(manifest, key)) {
+    throw new DomainPackError(
+      `pack "${manifest.id}" signature failed verification for publisher "${publisher}"`,
+    );
+  }
+}

--- a/test/domain-pack-signature.unit-spec.ts
+++ b/test/domain-pack-signature.unit-spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Domain Pack signatures — ed25519 sign/verify + install trust policy.
+ */
+import { generateKeyPairSync } from 'node:crypto';
+import {
+  assertPackTrust,
+  signPack,
+  verifyPackSignature,
+  DomainPackError,
+  type DomainPackManifest,
+} from '../src/ai/domain-packs';
+
+function keypair() {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  return {
+    pub: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    priv: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+  };
+}
+
+function manifest(over: Partial<DomainPackManifest> = {}): DomainPackManifest {
+  return {
+    id: 'medical',
+    version: '1.0.0',
+    description: 'medical',
+    predicates: [
+      {
+        localId: 'diagnosis',
+        displayLabel: 'diagnosis',
+        description: 'x',
+        datatype: 'string',
+        semantics: 'append_only',
+        decayHalfLifeDays: null,
+        piiClass: 'sensitive',
+        status: 'active',
+      },
+    ],
+    ...over,
+  };
+}
+
+describe('signPack / verifyPackSignature', () => {
+  it('round-trips a valid signature', () => {
+    const { pub, priv } = keypair();
+    const m = manifest();
+    m.signature = signPack(m, priv);
+    expect(verifyPackSignature(m, pub)).toBe(true);
+  });
+
+  it('fails when the manifest is tampered after signing', () => {
+    const { pub, priv } = keypair();
+    const m = manifest();
+    m.signature = signPack(m, priv);
+    m.version = '9.9.9';
+    expect(verifyPackSignature(m, pub)).toBe(false);
+  });
+
+  it('fails against a different public key', () => {
+    const a = keypair();
+    const b = keypair();
+    const m = manifest();
+    m.signature = signPack(m, a.priv);
+    expect(verifyPackSignature(m, b.pub)).toBe(false);
+  });
+});
+
+describe('assertPackTrust', () => {
+  it('allows an unsigned pack when signatures are not required', () => {
+    expect(() =>
+      assertPackTrust({ manifest: manifest(), trustedKeys: {}, requireSignature: false }),
+    ).not.toThrow();
+  });
+
+  it('rejects an unsigned pack when signatures are required', () => {
+    expect(() =>
+      assertPackTrust({ manifest: manifest(), trustedKeys: {}, requireSignature: true }),
+    ).toThrow(DomainPackError);
+  });
+
+  it('accepts a valid signature from a trusted publisher', () => {
+    const { pub, priv } = keypair();
+    const m = manifest({ publisher: 'acme' });
+    m.signature = signPack(m, priv);
+    expect(() =>
+      assertPackTrust({
+        manifest: m,
+        trustedKeys: { acme: pub },
+        requireSignature: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects an unknown publisher', () => {
+    const { priv } = keypair();
+    const m = manifest({ publisher: 'stranger' });
+    m.signature = signPack(m, priv);
+    expect(() =>
+      assertPackTrust({ manifest: m, trustedKeys: {}, requireSignature: false }),
+    ).toThrow(/untrusted\/unknown publisher/);
+  });
+
+  it('rejects a tampered signature from a trusted publisher', () => {
+    const { pub, priv } = keypair();
+    const m = manifest({ publisher: 'acme' });
+    m.signature = signPack(m, priv);
+    m.description = 'tampered';
+    expect(() =>
+      assertPackTrust({
+        manifest: m,
+        trustedKeys: { acme: pub },
+        requireSignature: false,
+      }),
+    ).toThrow(/failed verification/);
+  });
+});


### PR DESCRIPTION
## What

Integrity (checksum) proves a pack is unchanged; a **signature** proves **authorship**.

- **`signature.ts`** — `signPack` / `verifyPackSignature` (ed25519 via `node:crypto`, no dep) over the canonical manifest **excluding its own signature field**; `assertPackTrust` enforces the install policy (pure, unit-tested).
- manifest gains optional `signature` + `publisher`.
- install verifies against a trust store (`DOMAIN_PACK_TRUSTED_KEYS` = publisher→PEM) and can require signing (`DOMAIN_PACK_REQUIRE_SIGNATURE=true`): unsigned-when-required, unknown publisher, or bad signature → **400**. Unsigned allowed in integrity-only mode.
- CLI `pnpm pack:sign --key priv.pem --publisher acme`.

## Verification
- `pnpm exec tsc --noEmit` · `pnpm typecheck` · `pnpm lint` · max-params ≤3 ✓
- 772 unit (+8 signature: round-trip, tamper, wrong-key, trust policy) · 146 e2e · 9 jobs ✓

## Remaining (needs product/data decisions, not code)
A discovery **registry** for packs; consuming `extractionProfile`/`evalFixtures` at runtime; a trained BiLSTM for capture Layer-1 (needs a labeled corpus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)