### PR TITLE
refactor(audit): drop the two complexity-gate suppressions (job-run.list, dreams)

### DIFF
--- a/src/dreams/dreams.service.ts
+++ b/src/dreams/dreams.service.ts
@@ -338,11 +338,6 @@ export class DreamsService implements OnModuleInit {
     };
   }
 
-  // TODO: complexity 28 — opSet branching across dedup/resolve/
-  // summarize + jobRow lifecycle + abortSignal checks. Extract each
-  // sub-leg into a helper (runDedupLeg, runResolveLeg, etc.) and
-  // drop back under the gate. Tracked separately.
-  // eslint-disable-next-line complexity
   private async runForTenantInner({
     companyId,
     operations,
@@ -357,135 +352,28 @@ export class DreamsService implements OnModuleInit {
     };
     opts?: { skipJobRowLifecycle?: boolean; abortSignal?: AbortSignal };
   }): Promise<DreamsTenantStats> {
-    const checkAbort = () => {
-      if (opts?.abortSignal?.aborted) {
-        throw opts.abortSignal.reason ?? new Error('aborted');
-      }
-    };
     const t0 = Date.now();
-    const stats: DreamsTenantStats = {
-      companyId,
-      durationSeconds: 0,
-    };
+    const stats: DreamsTenantStats = { companyId, durationSeconds: 0 };
     const opSet = new Set(operations);
-    // Queue mode (skipJobRowLifecycle): WorkerLoopService owns the
-    // job_run row's lifecycle — already wrote claimedBy/leaseUntil on
-    // claim, will write status='succeeded'/'failed' on dispatch return.
-    // We skip start()/finish() to avoid double-row + double-terminal.
-    let jobRow: JobRunRow | null = null;
-    if (!opts?.skipJobRowLifecycle) {
-      try {
-        jobRow =
-          (await this.jobs?.start({
-            jobType: 'dreams',
-            companyId,
-            triggeredBy: triggered?.triggeredBy ?? 'cron',
-            triggeredByActor: triggered?.triggeredByActor,
-            initialProgress: { operations: [...opSet] },
-          })) ?? null;
-      } catch (e) {
-        this.logger.warn(
-          `dreams job_run start failed for ${companyId}: ${(e as Error).message}`,
-        );
-      }
-    }
+    const signal = opts?.abortSignal;
+    // Queue mode (skipJobRowLifecycle): WorkerLoopService owns the job_run
+    // row's lifecycle — already wrote claimedBy/leaseUntil on claim, will write
+    // status='succeeded'/'failed' on dispatch return. Skip start()/finish() to
+    // avoid double-row + double-terminal.
+    const jobRow = opts?.skipJobRowLifecycle
+      ? null
+      : await this.startDreamsJobRow(companyId, triggered, opSet);
 
     try {
-      await this.surreal.withCompany(companyId, async (db) => {
-        if (opSet.has('dedup')) {
-          checkAbort();
-          stats.dedup = await withSpan(
-            'dreams.dedup',
-            () => this.dedup.run(db),
-            { 'dreams.tenant': companyId },
-          );
-          if (jobRow) {
-            await this.jobs?.updateProgress(jobRow, {
-              currentTenant: companyId,
-              dedupLinksCreated: stats.dedup.identityLinksCreated,
-            });
-          }
-        }
-        if (opSet.has('resolve')) {
-          checkAbort();
-          stats.resolve = await withSpan(
-            'dreams.resolve',
-            () => this.resolver.run(db),
-            { 'dreams.tenant': companyId },
-          );
-          if (jobRow) {
-            await this.jobs?.updateProgress(jobRow, {
-              resolutionsApplied: stats.resolve.resolutionsApplied,
-            });
-          }
-        }
-        if (opSet.has('communities') && this.community) {
-          checkAbort();
-          stats.communities = await withSpan(
-            'dreams.communities',
-            () => this.community!.run(db),
-            { 'dreams.tenant': companyId },
-          );
-          if (jobRow) {
-            await this.jobs?.updateProgress(jobRow, {
-              communitiesBuilt: stats.communities.communitiesBuilt,
-              communitiesReused: stats.communities.communitiesReused,
-            });
-          }
-        }
-        if (jobRow) {
-          await this.writeEmits(db, jobRow.runId, stats);
-        }
-      });
-
+      await this.surreal.withCompany(companyId, (db) =>
+        this.runGraphLegs({ db, companyId, opSet, stats, jobRow, signal }),
+      );
       if (opSet.has('summarize')) {
-        checkAbort();
-        // Compaction owns its own connection lifecycle (it iterates
-        // over knowledge_fact in batches and updates statuses), so we
-        // delegate rather than threading the existing db handle in.
-        try {
-          await withSpan(
-            'dreams.summarize',
-            () => this.compaction.compactCompany(companyId),
-            { 'dreams.tenant': companyId },
-          );
-          stats.summarized = true;
-        } catch (err) {
-          this.logger.warn(
-            `Dreams summarize failed for ${companyId}: ${(err as Error).message}`,
-          );
-          stats.summarized = false;
-        }
+        await this.runSummarizeLeg(companyId, stats, signal);
       }
-
       stats.durationSeconds = (Date.now() - t0) / 1000;
-      this.metrics?.countDreams('ok');
-      if (stats.dedup) {
-        this.metrics?.countDreamsEmitted(
-          'identity_link',
-          stats.dedup.identityLinksCreated,
-        );
-      }
-      if (stats.resolve) {
-        this.metrics?.countDreamsEmitted(
-          'resolution',
-          stats.resolve.resolutionsApplied,
-        );
-      }
-      if (stats.summarized) {
-        this.metrics?.countDreamsEmitted('summary', 1);
-      }
-      if (jobRow) {
-        await this.jobs?.finish(jobRow, {
-          status: 'succeeded',
-          result: {
-            durationSeconds: stats.durationSeconds,
-            identityLinksCreated: stats.dedup?.identityLinksCreated ?? 0,
-            resolutionsApplied: stats.resolve?.resolutionsApplied ?? 0,
-            summarized: stats.summarized ?? false,
-          },
-        });
-      }
+      this.recordDreamsMetrics(stats);
+      await this.finishDreamsJobRow(jobRow, stats);
       return stats;
     } catch (err) {
       const e = err as Error;
@@ -497,6 +385,157 @@ export class DreamsService implements OnModuleInit {
       }
       throw err;
     }
+  }
+
+  /** Throw the abort reason if the run's signal has fired. Checked between legs
+   *  so a cancelled dreams run exits promptly. */
+  private assertNotAborted(signal?: AbortSignal): void {
+    if (signal?.aborted) throw signal.reason ?? new Error('aborted');
+  }
+
+  /** Open a job_run row for the dreams run (non-queue mode). Best-effort — a
+   *  start() failure logs and yields null; the run proceeds without a row. */
+  private async startDreamsJobRow(
+    companyId: string,
+    triggered:
+      | { triggeredBy?: 'cron' | 'manual' | 'startup'; triggeredByActor?: string }
+      | undefined,
+    opSet: Set<DreamsOperation>,
+  ): Promise<JobRunRow | null> {
+    try {
+      return (
+        (await this.jobs?.start({
+          jobType: 'dreams',
+          companyId,
+          triggeredBy: triggered?.triggeredBy ?? 'cron',
+          triggeredByActor: triggered?.triggeredByActor,
+          initialProgress: { operations: [...opSet] },
+        })) ?? null
+      );
+    } catch (e) {
+      this.logger.warn(
+        `dreams job_run start failed for ${companyId}: ${(e as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  /** The in-DB graph legs (dedup / resolve / communities) + emit rows, run
+   *  under one tenant connection. Each leg is gated on the requested op set and
+   *  writes progress to the job row. Extracted from runForTenantInner. */
+  private async runGraphLegs(args: {
+    db: any;
+    companyId: string;
+    opSet: Set<DreamsOperation>;
+    stats: DreamsTenantStats;
+    jobRow: JobRunRow | null;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const { db, companyId, opSet, stats, jobRow, signal } = args;
+    if (opSet.has('dedup')) {
+      this.assertNotAborted(signal);
+      stats.dedup = await withSpan('dreams.dedup', () => this.dedup.run(db), {
+        'dreams.tenant': companyId,
+      });
+      if (jobRow) {
+        await this.jobs?.updateProgress(jobRow, {
+          currentTenant: companyId,
+          dedupLinksCreated: stats.dedup.identityLinksCreated,
+        });
+      }
+    }
+    if (opSet.has('resolve')) {
+      this.assertNotAborted(signal);
+      stats.resolve = await withSpan(
+        'dreams.resolve',
+        () => this.resolver.run(db),
+        { 'dreams.tenant': companyId },
+      );
+      if (jobRow) {
+        await this.jobs?.updateProgress(jobRow, {
+          resolutionsApplied: stats.resolve.resolutionsApplied,
+        });
+      }
+    }
+    if (opSet.has('communities') && this.community) {
+      this.assertNotAborted(signal);
+      stats.communities = await withSpan(
+        'dreams.communities',
+        () => this.community!.run(db),
+        { 'dreams.tenant': companyId },
+      );
+      if (jobRow) {
+        await this.jobs?.updateProgress(jobRow, {
+          communitiesBuilt: stats.communities.communitiesBuilt,
+          communitiesReused: stats.communities.communitiesReused,
+        });
+      }
+    }
+    if (jobRow) {
+      await this.writeEmits(db, jobRow.runId, stats);
+    }
+  }
+
+  /** The summarize leg. Compaction owns its own connection lifecycle (it
+   *  batches over knowledge_fact), so we delegate rather than thread the db
+   *  handle in. A failure here is non-fatal — records summarized=false. */
+  private async runSummarizeLeg(
+    companyId: string,
+    stats: DreamsTenantStats,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    this.assertNotAborted(signal);
+    try {
+      await withSpan(
+        'dreams.summarize',
+        () => this.compaction.compactCompany(companyId),
+        { 'dreams.tenant': companyId },
+      );
+      stats.summarized = true;
+    } catch (err) {
+      this.logger.warn(
+        `Dreams summarize failed for ${companyId}: ${(err as Error).message}`,
+      );
+      stats.summarized = false;
+    }
+  }
+
+  /** Emit the per-run dreams counters. */
+  private recordDreamsMetrics(stats: DreamsTenantStats): void {
+    this.metrics?.countDreams('ok');
+    if (stats.dedup) {
+      this.metrics?.countDreamsEmitted(
+        'identity_link',
+        stats.dedup.identityLinksCreated,
+      );
+    }
+    if (stats.resolve) {
+      this.metrics?.countDreamsEmitted(
+        'resolution',
+        stats.resolve.resolutionsApplied,
+      );
+    }
+    if (stats.summarized) {
+      this.metrics?.countDreamsEmitted('summary', 1);
+    }
+  }
+
+  /** Commit the terminal 'succeeded' job row (non-queue mode). No-op when there
+   *  is no row (queue mode or a failed start). */
+  private async finishDreamsJobRow(
+    jobRow: JobRunRow | null,
+    stats: DreamsTenantStats,
+  ): Promise<void> {
+    if (!jobRow) return;
+    await this.jobs?.finish(jobRow, {
+      status: 'succeeded',
+      result: {
+        durationSeconds: stats.durationSeconds,
+        identityLinksCreated: stats.dedup?.identityLinksCreated ?? 0,
+        resolutionsApplied: stats.resolve?.resolutionsApplied ?? 0,
+        summarized: stats.summarized ?? false,
+      },
+    });
   }
 
   /**

--- a/src/jobs/job-run.service.ts
+++ b/src/jobs/job-run.service.ts
@@ -67,6 +67,60 @@ export interface JobRunRow {
   companyId: string;
 }
 
+/** The job_run columns the cross-tenant list projects. */
+const JOB_RUN_LIST_COLUMNS = `runId, jobType, status, triggeredBy, triggeredByActor,
+        startedAt, finishedAt, progress, payload, result, error,
+        cancelRequested, attempts, claimedBy, claimedAt,
+        leaseUntil, heartbeatAt, visibleAfter`;
+
+/** Build the optional WHERE clause + bound params for the cross-tenant list.
+ *  Pure — extracted from JobRunService.list so each stays under the complexity
+ *  gate and the filter logic is unit-testable in isolation. */
+function buildJobRunListWhere(filter: {
+  jobType?: JobType;
+  status?: JobStatus;
+  since?: string;
+}): { whereSql: string; params: Record<string, unknown> } {
+  const clauses: Array<[string, string, unknown]> = [];
+  if (filter.jobType) clauses.push(['jobType = $jobType', 'jobType', filter.jobType]);
+  if (filter.status) clauses.push(['status = $status', 'status', filter.status]);
+  if (filter.since)
+    clauses.push(['startedAt >= type::datetime($since)', 'since', filter.since]);
+  const params: Record<string, unknown> = {};
+  for (const [, key, value] of clauses) params[key] = value;
+  const whereSql = clauses.length
+    ? `WHERE ${clauses.map(([sql]) => sql).join(' AND ')}`
+    : '';
+  return { whereSql, params };
+}
+
+/** Project a raw job_run DB row onto the API shape (datetimes → ISO strings,
+ *  null-coalesced optionals). Pure — extracted from JobRunService.list. */
+function mapJobRunRow(r: any, companyId: string): JobRunRow {
+  const iso = (v: unknown): string | null => (v ? new Date(v as string).toISOString() : null);
+  return {
+    runId: r.runId,
+    jobType: r.jobType,
+    status: r.status,
+    triggeredBy: r.triggeredBy ?? 'cron',
+    triggeredByActor: r.triggeredByActor ?? null,
+    startedAt: new Date(r.startedAt).toISOString(),
+    finishedAt: iso(r.finishedAt),
+    progress: r.progress ?? null,
+    payload: r.payload ?? null,
+    result: r.result ?? null,
+    error: r.error ?? null,
+    cancelRequested: r.cancelRequested === true,
+    attempts: typeof r.attempts === 'number' ? r.attempts : undefined,
+    claimedBy: r.claimedBy ?? null,
+    claimedAt: iso(r.claimedAt),
+    leaseUntil: iso(r.leaseUntil),
+    heartbeatAt: iso(r.heartbeatAt),
+    visibleAfter: iso(r.visibleAfter),
+    companyId,
+  };
+}
+
 /**
  * JobRunService — generic projection of long-running operator jobs.
  *
@@ -315,10 +369,6 @@ export class JobRunService {
    * per tenant before merging so a single noisy tenant can't crowd
    * out the rest.
    */
-  // TODO: complexity 26 — three optional WHERE branches + per-tenant
-  // fan-out + row-shape projection. Extract buildWhere + rowToRow
-  // helpers to drop back under the gate. Tracked separately.
-  // eslint-disable-next-line complexity
   async list(filter: {
     jobType?: JobType;
     status?: JobStatus;
@@ -331,75 +381,39 @@ export class JobRunService {
     const tenants = filter.companyId
       ? [filter.companyId]
       : this.apiKeys.knownCompanyIds();
-    const where: string[] = [];
-    const params: Record<string, unknown> = {};
-    if (filter.jobType) {
-      where.push('jobType = $jobType');
-      params.jobType = filter.jobType;
-    }
-    if (filter.status) {
-      where.push('status = $status');
-      params.status = filter.status;
-    }
-    if (filter.since) {
-      where.push('startedAt >= type::datetime($since)');
-      params.since = filter.since;
-    }
-    const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+    const where = buildJobRunListWhere(filter);
     const out: JobRunRow[] = [];
     for (const companyId of tenants) {
-      try {
-        const rows = await this.surreal.withCompany(companyId, async (db) => {
-          const res = (await db.query<any[]>(
-            `SELECT runId, jobType, status, triggeredBy, triggeredByActor,
-                    startedAt, finishedAt, progress, payload, result, error,
-                    cancelRequested, attempts, claimedBy, claimedAt,
-                    leaseUntil, heartbeatAt, visibleAfter
-               FROM job_run ${whereSql}
-              ORDER BY startedAt DESC LIMIT ${limit}`,
-            params,
-          )) as any[];
-          return (res[0] ?? []) as any[];
-        });
-        for (const r of rows) {
-          out.push({
-            runId: r.runId,
-            jobType: r.jobType,
-            status: r.status,
-            triggeredBy: r.triggeredBy ?? 'cron',
-            triggeredByActor: r.triggeredByActor ?? null,
-            startedAt: new Date(r.startedAt).toISOString(),
-            finishedAt: r.finishedAt
-              ? new Date(r.finishedAt).toISOString()
-              : null,
-            progress: r.progress ?? null,
-            payload: r.payload ?? null,
-            result: r.result ?? null,
-            error: r.error ?? null,
-            cancelRequested: r.cancelRequested === true,
-            attempts: typeof r.attempts === 'number' ? r.attempts : undefined,
-            claimedBy: r.claimedBy ?? null,
-            claimedAt: r.claimedAt ? new Date(r.claimedAt).toISOString() : null,
-            leaseUntil: r.leaseUntil
-              ? new Date(r.leaseUntil).toISOString()
-              : null,
-            heartbeatAt: r.heartbeatAt
-              ? new Date(r.heartbeatAt).toISOString()
-              : null,
-            visibleAfter: r.visibleAfter
-              ? new Date(r.visibleAfter).toISOString()
-              : null,
-            companyId,
-          });
-        }
-      } catch (e) {
-        this.logger.warn(
-          `job_run list failed for ${companyId}: ${(e as Error).message}`,
-        );
-      }
+      const rows = await this.listTenantRows(companyId, where, limit);
+      for (const r of rows) out.push(mapJobRunRow(r, companyId));
     }
     out.sort((a, b) => b.startedAt.localeCompare(a.startedAt));
     return out.slice(0, limit);
+  }
+
+  /** Query one tenant's job_run rows for the cross-tenant list. A per-tenant
+   *  failure is logged and yields [] so one noisy tenant can't sink the rollup. */
+  private async listTenantRows(
+    companyId: string,
+    where: { whereSql: string; params: Record<string, unknown> },
+    limit: number,
+  ): Promise<any[]> {
+    try {
+      return await this.surreal!.withCompany(companyId, async (db) => {
+        const res = (await db.query<any[]>(
+          `SELECT ${JOB_RUN_LIST_COLUMNS}
+               FROM job_run ${where.whereSql}
+              ORDER BY startedAt DESC LIMIT ${limit}`,
+          where.params,
+        )) as any[];
+        return (res[0] ?? []) as any[];
+      });
+    } catch (e) {
+      this.logger.warn(
+        `job_run list failed for ${companyId}: ${(e as Error).message}`,
+      );
+      return [];
+    }
   }
 
   async get(runId: string, companyId: string): Promise<JobRunRow | null> {


### PR DESCRIPTION
## Track D — audit-remainder complexity cleanup

The refactor items from the audit backlog (`audit_next_session` / next-session brief, track D). Both methods carried an `// eslint-disable complexity` pragma over the `complexity=25` gate with a TODO naming the intended split. This does exactly that split — **pure, behaviour-preserving** — so the suppressions come off.

### `JobRunService.list` (cyclomatic 26 → under gate)
- `buildJobRunListWhere(filter)` — pure `{ whereSql, params }` builder (the 3 optional WHERE branches).
- `mapJobRunRow(r, companyId)` — pure raw-row → API-shape projection (ISO datetimes, null-coalesced optionals).
- `listTenantRows(...)` — the per-tenant fan-out query + its log-and-continue try/catch.
- `JOB_RUN_LIST_COLUMNS` const for the SELECT list.

### `DreamsService.runForTenantInner` (cyclomatic 28 → under gate)
Extracts the legs the TODO named: `runGraphLegs` (dedup/resolve/communities + emit rows on one connection), `runSummarizeLeg`, `startDreamsJobRow` / `finishDreamsJobRow` (job-row lifecycle), `recordDreamsMetrics`. The abort closure becomes `assertNotAborted(signal)`. The main body is now a ~30-line orchestrator.

### Deliberately NOT changed — the 2 `it.skip` in `concurrency.real-e2e`
Un-skipping is blocked on **infrastructure, not code**:
- cold-start isolation test → needs the namespace-level vs database-level **migration split** (namespace DEFINEs race under parallel cold-start; serialising them blows the 120s budget).
- pool-drain test → SurrealDB rocksdb **write-lock fairness** under 12+ contending CREATEs at testcontainer scale.

Both are documented in-place; the underlying behaviours (cross-tenant isolation, pool acquire/release) are already covered by passing FANOUT tests. Forcing them green would be migration surgery across the fleet or a DB-version bump — out of scope for a complexity cleanup.

Acceptance bar met: **786 unit · 150 e2e · 9 jobs** · tsc · lint (max-params=3, complexity=25, no new suppressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)