### PR TITLE
feat(registry): global Domain Pack registry — publish, discover, install-from-registry

### DIFF
--- a/src/admin/admin-packs.controller.ts
+++ b/src/admin/admin-packs.controller.ts
@@ -11,6 +11,7 @@ import {
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import type { AuthenticatedRequest } from '../auth/api-key.types';
 import { DomainPackInstallService } from './domain-pack-install.service';
+import { PackRegistryService } from '../registry/pack-registry.service';
 import type { DomainPackManifest } from '../ai/domain-packs';
 import type {
   InstallPackResponse,
@@ -28,7 +29,10 @@ import type {
 @Controller('v1/admin/packs')
 @UseGuards(ApiKeyGuard)
 export class AdminPacksController {
-  constructor(private readonly packs: DomainPackInstallService) {}
+  constructor(
+    private readonly packs: DomainPackInstallService,
+    private readonly registry: PackRegistryService,
+  ) {}
 
   @Get()
   @RequireScopes('brain:admin')
@@ -48,6 +52,25 @@ export class AdminPacksController {
   ): Promise<InstallPackResponse> {
     return this.packs.install(req.brainAuth.companyId, body?.manifest, {
       expectedChecksum: body?.expectedChecksum,
+    });
+  }
+
+  /** Install a pack from the GLOBAL registry into this tenant. Resolves the
+   *  manifest (latest non-yanked, or a pinned version) and installs it through
+   *  the same path as a direct install, pinning the registry checksum so the
+   *  content that gets installed is exactly what the registry served. */
+  @Post('from-registry')
+  @RequireScopes('brain:admin')
+  async installFromRegistry(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { packId: string; version?: string },
+  ): Promise<InstallPackResponse> {
+    const { manifest, checksum } = await this.registry.resolveForInstall(
+      body?.packId,
+      body?.version,
+    );
+    return this.packs.install(req.brainAuth.companyId, manifest, {
+      expectedChecksum: checksum,
     });
   }
 

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -29,6 +29,7 @@ import { ThrottlerObservabilityInterceptor } from './throttler-observability.int
 import { AdminPacksController } from './admin-packs.controller';
 import { AdminCodeMemoryController } from './admin-code-memory.controller';
 import { CodeMemoryModule } from '../code-memory/code-memory.module';
+import { RegistryModule } from '../registry/registry.module';
 import { DomainPackInstallService } from './domain-pack-install.service';
 import { ScenarioRunnerService } from './scenario-runner.service';
 import { ScenarioWriteService } from './scenario-write.service';
@@ -59,6 +60,9 @@ import { ConfigInspectorService } from './config-inspector.service';
     // controller and the whole app refuses to boot.
     CompactionModule,
     CodeMemoryModule,
+    // AdminPacksController resolves manifests from the global registry for
+    // POST /v1/admin/packs/from-registry.
+    RegistryModule,
   ],
   controllers: [
     AdminController,

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -28,6 +28,7 @@ export * from './manifest';
 export * from './validate';
 export * from './checksum';
 export * from './signature';
+export * from './semver';
 export * from './code-memory.pack';
 // real-estate is a DISTRIBUTABLE pack (installed per-tenant at runtime), not a
 // builtin — exported for the JSON generator + tests, deliberately NOT added to

--- a/src/ai/domain-packs/semver.ts
+++ b/src/ai/domain-packs/semver.ts
@@ -1,0 +1,27 @@
+/**
+ * Minimal semver ordering for pack versions. Pack versions are validated as
+ * strict `MAJOR.MINOR.PATCH` (validate.ts SEMVER regex) — no pre-release /
+ * build metadata — so a numeric tuple compare is exact and dependency-free.
+ */
+
+function parts(v: string): [number, number, number] {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v);
+  if (!m) return [0, 0, 0];
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** Compare two semver strings. -1 if a<b, 0 if equal, 1 if a>b. */
+export function compareSemver(a: string, b: string): number {
+  const pa = parts(a);
+  const pb = parts(b);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+/** The highest version in the list, or null if empty. */
+export function pickLatestVersion(versions: string[]): string | null {
+  if (versions.length === 0) return null;
+  return versions.reduce((best, v) => (compareSemver(v, best) > 0 ? v : best));
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,7 @@ import { AuditModule } from './audit/audit.module';
 import { JobsModule } from './jobs/jobs.module';
 import { CommunityModule } from './communities/community.module';
 import { StatsModule } from './stats/stats.module';
+import { RegistryModule } from './registry/registry.module';
 
 @Module({
   imports: [
@@ -91,6 +92,7 @@ import { StatsModule } from './stats/stats.module';
     JobsModule,
     CommunityModule,
     StatsModule,
+    RegistryModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/src/auth/api-key.types.ts
+++ b/src/auth/api-key.types.ts
@@ -2,7 +2,12 @@ export type BrainScope =
   | 'brain:read'
   | 'brain:write'
   | 'brain:admin'
-  | 'brain:read_pii';
+  | 'brain:read_pii'
+  // Publish/yank in the GLOBAL pack registry — distinct from brain:admin
+  // ("operate my tenant") because it mutates the catalogue shared across all
+  // tenants. Discovery reads use brain:read; installing from the registry into
+  // a tenant uses brain:admin.
+  | 'registry:publish';
 
 export interface ApiKeyRecord {
   /** SHA-256 hex hash of the plaintext key (never store plaintext). */

--- a/src/contracts/registry/registry.schema.ts
+++ b/src/contracts/registry/registry.schema.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+
+/**
+ * Wire contracts for the GLOBAL Domain Pack registry — discovery reads
+ * (/v1/registry) + publish/yank (/v1/admin/registry). See docs/domain-packs.md.
+ */
+
+/** One published version's discovery metadata (no manifest body). */
+export const RegistryVersionSchema = z.object({
+  packId: z.string(),
+  version: z.string(),
+  checksum: z.string(),
+  description: z.string(),
+  keywords: z.array(z.string()),
+  publisher: z.string().nullable(),
+  signed: z.boolean(),
+  yanked: z.boolean(),
+  yankReason: z.string().nullable(),
+  publishedAt: z.string(),
+});
+
+/** One pack in a catalogue listing — its latest installable version + counts. */
+export const RegistryPackSummarySchema = z.object({
+  packId: z.string(),
+  latestVersion: z.string(),
+  description: z.string(),
+  keywords: z.array(z.string()),
+  publisher: z.string().nullable(),
+  signed: z.boolean(),
+  versionCount: z.number().int().nonnegative(),
+});
+
+export const RegistryListResponseSchema = z.object({
+  packs: z.array(RegistryPackSummarySchema),
+});
+
+export const RegistryVersionsResponseSchema = z.object({
+  packId: z.string(),
+  latestVersion: z.string().nullable(),
+  versions: z.array(RegistryVersionSchema),
+});
+
+/** A resolved manifest for install/inspection (carries the full body). */
+export const RegistryManifestResponseSchema = z.object({
+  packId: z.string(),
+  version: z.string(),
+  checksum: z.string(),
+  yanked: z.boolean(),
+  manifest: z.record(z.string(), z.unknown()),
+});
+
+export const PublishPackResponseSchema = z.object({
+  packId: z.string(),
+  version: z.string(),
+  checksum: z.string(),
+  /** false when the identical (packId, version, checksum) was already present
+   *  (idempotent republish); true when a new version row was created. */
+  created: z.boolean(),
+});
+
+export const YankPackResponseSchema = z.object({
+  packId: z.string(),
+  version: z.string(),
+  yanked: z.boolean(),
+});
+
+export type RegistryVersion = z.infer<typeof RegistryVersionSchema>;
+export type RegistryPackSummary = z.infer<typeof RegistryPackSummarySchema>;
+export type RegistryListResponse = z.infer<typeof RegistryListResponseSchema>;
+export type RegistryVersionsResponse = z.infer<
+  typeof RegistryVersionsResponseSchema
+>;
+export type RegistryManifestResponse = z.infer<
+  typeof RegistryManifestResponseSchema
+>;
+export type PublishPackResponse = z.infer<typeof PublishPackResponseSchema>;
+export type YankPackResponse = z.infer<typeof YankPackResponseSchema>;

--- a/src/db/migrations/0042_registry_pack.surql
+++ b/src/db/migrations/0042_registry_pack.surql
@@ -1,0 +1,41 @@
+-- 0042_registry_pack — the GLOBAL Domain Pack registry catalogue.
+--
+-- Unlike domain_pack (migration 0040, per-tenant record of what's INSTALLED),
+-- registry_pack is a GLOBAL, tenant-agnostic catalogue of what's PUBLISHED and
+-- installable. It lives in the `system` database (SurrealService.withAdminDb),
+-- alongside leader_lease / job_run — one shared store, not a per-tenant copy.
+--
+-- One row per (packId, version). A published version is IMMUTABLE: the row is
+-- content-addressed by `checksum`, and republishing the same (packId, version)
+-- with different content is rejected (see PackRegistryService.publish). A bad
+-- version is YANKED (yanked=true — excluded from latest-resolution + default
+-- listing) but never hard-deleted, so installs that pinned it stay reproducible.
+--
+-- Trust: the manifest's ed25519 signature + publisher are stored as-is. The
+-- registry is a content store; cryptographic trust is verified END-TO-END at
+-- install time against the installing tenant's trust store (same policy as a
+-- direct install). `signed` is a convenience flag for discovery/filtering.
+
+DEFINE TABLE IF NOT EXISTS registry_pack SCHEMAFULL;
+
+DEFINE FIELD IF NOT EXISTS packId      ON registry_pack TYPE string;
+DEFINE FIELD IF NOT EXISTS version     ON registry_pack TYPE string;
+DEFINE FIELD IF NOT EXISTS manifest    ON registry_pack TYPE object FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS checksum    ON registry_pack TYPE string;
+DEFINE FIELD IF NOT EXISTS description ON registry_pack TYPE string DEFAULT '';
+DEFINE FIELD IF NOT EXISTS keywords    ON registry_pack TYPE array DEFAULT [];
+DEFINE FIELD IF NOT EXISTS keywords[*] ON registry_pack TYPE string;
+DEFINE FIELD IF NOT EXISTS publisher   ON registry_pack TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS signed      ON registry_pack TYPE bool DEFAULT false;
+DEFINE FIELD IF NOT EXISTS yanked      ON registry_pack TYPE bool DEFAULT false;
+DEFINE FIELD IF NOT EXISTS yankReason  ON registry_pack TYPE option<string>;
+-- Provenance: the companyId whose admin key published this version.
+DEFINE FIELD IF NOT EXISTS publishedBy ON registry_pack TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS publishedAt ON registry_pack TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS updatedAt   ON registry_pack TYPE option<datetime>;
+
+-- A (packId, version) is unique — the immutability anchor.
+DEFINE INDEX IF NOT EXISTS registry_pack_id_version_idx
+  ON registry_pack FIELDS packId, version UNIQUE;
+DEFINE INDEX IF NOT EXISTS registry_pack_id_idx ON registry_pack FIELDS packId;
+DEFINE INDEX IF NOT EXISTS registry_pack_yanked_idx ON registry_pack FIELDS yanked;

--- a/src/registry/admin-registry.controller.ts
+++ b/src/registry/admin-registry.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Body,
+  Controller,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { PackRegistryService } from './pack-registry.service';
+import type { DomainPackManifest } from '../ai/domain-packs';
+import type {
+  PublishPackResponse,
+  YankPackResponse,
+} from '../contracts/registry/registry.schema';
+
+/**
+ * Publisher-facing writes to the GLOBAL Domain Pack registry
+ * (docs/domain-packs.md). Publish a version (immutable once published) and
+ * yank / unyank a bad version. Guarded by registry:publish — distinct from
+ * brain:admin because it mutates the catalogue shared across ALL tenants.
+ */
+@Controller('v1/admin/registry')
+@UseGuards(ApiKeyGuard)
+export class AdminRegistryController {
+  constructor(private readonly registry: PackRegistryService) {}
+
+  @Post('packs')
+  @RequireScopes('registry:publish')
+  async publish(
+    @Req() req: AuthenticatedRequest,
+    @Body()
+    body: {
+      manifest: DomainPackManifest;
+      keywords?: string[];
+      expectedChecksum?: string;
+    },
+  ): Promise<PublishPackResponse> {
+    return this.registry.publish({
+      manifest: body?.manifest,
+      keywords: body?.keywords,
+      expectedChecksum: body?.expectedChecksum,
+      publishedBy: req.brainAuth.companyId,
+    });
+  }
+
+  @Post('packs/:packId/:version/yank')
+  @RequireScopes('registry:publish')
+  async yank(
+    @Param('packId') packId: string,
+    @Param('version') version: string,
+    @Body() body?: { reason?: string },
+  ): Promise<YankPackResponse> {
+    return this.registry.yank(packId, version, body?.reason);
+  }
+
+  @Post('packs/:packId/:version/unyank')
+  @RequireScopes('registry:publish')
+  async unyank(
+    @Param('packId') packId: string,
+    @Param('version') version: string,
+  ): Promise<YankPackResponse> {
+    return this.registry.unyank(packId, version);
+  }
+}

--- a/src/registry/pack-registry.service.ts
+++ b/src/registry/pack-registry.service.ts
@@ -1,0 +1,338 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import {
+  DomainPackError,
+  packChecksum,
+  pickLatestVersion,
+  compareSemver,
+  validatePack,
+  type DomainPackManifest,
+} from '../ai/domain-packs';
+import type {
+  PublishPackResponse,
+  RegistryManifestResponse,
+  RegistryPackSummary,
+  RegistryVersion,
+  RegistryVersionsResponse,
+  YankPackResponse,
+} from '../contracts/registry/registry.schema';
+
+interface RegistryRow {
+  packId: string;
+  version: string;
+  manifest?: DomainPackManifest;
+  checksum: string;
+  description?: string;
+  keywords?: string[];
+  publisher?: string | null;
+  signed?: boolean;
+  yanked?: boolean;
+  yankReason?: string | null;
+  publishedAt: string;
+}
+
+/**
+ * The GLOBAL Domain Pack registry (docs/domain-packs.md). A shared, tenant-
+ * agnostic catalogue of published, installable packs — stored in the `system`
+ * database via SurrealService.withAdminDb, distinct from the per-tenant
+ * domain_pack table (which records what's INSTALLED).
+ *
+ * Invariants (supply-chain safety, npm/crates.io-style):
+ *   - Version immutability: a (packId, version) is content-addressed by
+ *     checksum. Republishing the same version with different content is a 409;
+ *     an identical republish is idempotent.
+ *   - Yank, not delete: a bad version is flagged yanked (excluded from latest-
+ *     resolution + default listing) but never removed, so pinned installs stay
+ *     reproducible.
+ *   - Trust is end-to-end: the manifest's signature/publisher are stored as-is;
+ *     cryptographic verification happens at INSTALL time against the installing
+ *     tenant's trust store. The registry is a content store.
+ */
+@Injectable()
+export class PackRegistryService {
+  private readonly logger = new Logger(PackRegistryService.name);
+
+  constructor(private readonly surreal: SurrealService) {}
+
+  private requireSignature(): boolean {
+    return process.env.PACK_REGISTRY_REQUIRE_SIGNATURE === 'true';
+  }
+
+  /** Publish a pack version into the global catalogue. Validates the manifest,
+   *  enforces the (optional) signed-packs policy + version immutability, and
+   *  stores it. Idempotent for an identical republish. */
+  async publish(input: {
+    manifest: DomainPackManifest;
+    publishedBy?: string;
+    keywords?: string[];
+    expectedChecksum?: string;
+  }): Promise<PublishPackResponse> {
+    const { manifest } = input;
+    if (!manifest || typeof manifest !== 'object') {
+      throw new BadRequestException('request body must include a pack manifest');
+    }
+    try {
+      validatePack(manifest);
+    } catch (e) {
+      if (e instanceof DomainPackError) throw new BadRequestException(e.message);
+      throw e;
+    }
+    if (this.requireSignature() && !manifest.signature) {
+      throw new BadRequestException(
+        `pack "${manifest.id}" is unsigned but this registry requires signed packs`,
+      );
+    }
+    const checksum = packChecksum(manifest);
+    if (input.expectedChecksum && input.expectedChecksum !== checksum) {
+      throw new BadRequestException(
+        `checksum mismatch: expected ${input.expectedChecksum}, computed ${checksum}`,
+      );
+    }
+    const keywords = (input.keywords ?? [])
+      .map((k) => String(k).trim().toLowerCase())
+      .filter(Boolean);
+
+    return this.surreal.withAdminDb(async (db) => {
+      const [existing] = await db.query<[RegistryRow[]]>(
+        `SELECT packId, version, checksum FROM registry_pack
+           WHERE packId = $packId AND version = $version LIMIT 1`,
+        { packId: manifest.id, version: manifest.version },
+      );
+      const prior = ((existing as RegistryRow[]) ?? [])[0];
+      if (prior) {
+        if (prior.checksum === checksum) {
+          // Idempotent republish of identical content.
+          return {
+            packId: manifest.id,
+            version: manifest.version,
+            checksum,
+            created: false,
+          };
+        }
+        throw new ConflictException(
+          `pack "${manifest.id}" version ${manifest.version} is already published with different content (immutable)`,
+        );
+      }
+      // option<string> fields reject a JS null under SCHEMAFULL ("Found NULL,
+      // expected option<...>") — omit them when absent so they store as NONE.
+      const content: Record<string, unknown> = {
+        packId: manifest.id,
+        version: manifest.version,
+        manifest,
+        checksum,
+        description: manifest.description ?? '',
+        keywords,
+        signed: Boolean(manifest.signature),
+        yanked: false,
+      };
+      if (manifest.publisher) content.publisher = manifest.publisher;
+      if (input.publishedBy) content.publishedBy = input.publishedBy;
+      await db.query(`CREATE registry_pack CONTENT $content`, { content });
+      this.logger.log(
+        `Published pack ${manifest.id} v${manifest.version} (checksum ${checksum.slice(0, 12)}…)`,
+      );
+      return {
+        packId: manifest.id,
+        version: manifest.version,
+        checksum,
+        created: true,
+      };
+    });
+  }
+
+  /** Catalogue listing — one entry per pack (its latest non-yanked version),
+   *  filtered by free-text q / publisher / tag. Packs with only yanked versions
+   *  are omitted (nothing installable). */
+  async list(filter: {
+    q?: string;
+    publisher?: string;
+    tag?: string;
+    limit?: number;
+  }): Promise<RegistryPackSummary[]> {
+    const rows = await this.allRows();
+    const byPack = new Map<string, RegistryRow[]>();
+    for (const r of rows) {
+      const arr = byPack.get(r.packId) ?? [];
+      arr.push(r);
+      byPack.set(r.packId, arr);
+    }
+    const summaries: RegistryPackSummary[] = [];
+    for (const [packId, versions] of byPack) {
+      const installable = versions.filter((v) => !v.yanked);
+      const latest = pickLatestVersion(installable.map((v) => v.version));
+      if (!latest) continue; // only-yanked pack → not installable
+      const row = installable.find((v) => v.version === latest)!;
+      summaries.push({
+        packId,
+        latestVersion: latest,
+        description: row.description ?? '',
+        keywords: row.keywords ?? [],
+        publisher: row.publisher ?? null,
+        signed: Boolean(row.signed),
+        versionCount: versions.length,
+      });
+    }
+    const q = filter.q?.trim().toLowerCase();
+    const tag = filter.tag?.trim().toLowerCase();
+    const publisher = filter.publisher?.trim();
+    const out = summaries.filter((s) => {
+      if (publisher && s.publisher !== publisher) return false;
+      if (tag && !s.keywords.includes(tag)) return false;
+      if (q) {
+        const hay = `${s.packId} ${s.description} ${s.keywords.join(' ')}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+    out.sort((a, b) => a.packId.localeCompare(b.packId));
+    const limit = Math.min(Math.max(filter.limit ?? 100, 1), 500);
+    return out.slice(0, limit);
+  }
+
+  /** All versions of one pack, newest-first, with the latest non-yanked flagged. */
+  async getVersions(packId: string): Promise<RegistryVersionsResponse> {
+    const rows = (await this.allRows()).filter((r) => r.packId === packId);
+    const versions = rows
+      .map((r) => this.toVersion(r))
+      .sort((a, b) => compareSemver(b.version, a.version));
+    const latestVersion = pickLatestVersion(
+      rows.filter((r) => !r.yanked).map((r) => r.version),
+    );
+    return { packId, latestVersion, versions };
+  }
+
+  /** Resolve a manifest for inspection. version omitted → latest non-yanked.
+   *  An exact version is returned even if yanked (carrying the flag). */
+  async getManifest(
+    packId: string,
+    version?: string,
+  ): Promise<RegistryManifestResponse | null> {
+    const row = await this.findRow(packId, version);
+    if (!row || !row.manifest) return null;
+    return {
+      packId,
+      version: row.version,
+      checksum: row.checksum,
+      yanked: Boolean(row.yanked),
+      manifest: row.manifest as unknown as Record<string, unknown>,
+    };
+  }
+
+  /** Resolve a manifest for INSTALL. Throws NotFound when nothing matches and
+   *  BadRequest when a pinned version is yanked / no non-yanked version exists. */
+  async resolveForInstall(
+    packId: string,
+    version?: string,
+  ): Promise<{ manifest: DomainPackManifest; checksum: string }> {
+    const row = await this.findRow(packId, version);
+    if (!row || !row.manifest) {
+      throw new NotFoundException(
+        `pack "${packId}"${version ? ` version ${version}` : ''} not found in the registry`,
+      );
+    }
+    if (row.yanked) {
+      throw new BadRequestException(
+        `pack "${packId}" version ${row.version} is yanked and cannot be installed`,
+      );
+    }
+    return { manifest: row.manifest, checksum: row.checksum };
+  }
+
+  async yank(
+    packId: string,
+    version: string,
+    reason?: string,
+  ): Promise<YankPackResponse> {
+    return this.setYanked({ packId, version, yanked: true, reason });
+  }
+
+  async unyank(packId: string, version: string): Promise<YankPackResponse> {
+    return this.setYanked({ packId, version, yanked: false });
+  }
+
+  // ── internals ─────────────────────────────────────────────────────────
+
+  private async setYanked(args: {
+    packId: string;
+    version: string;
+    yanked: boolean;
+    reason?: string;
+  }): Promise<YankPackResponse> {
+    const { packId, version, yanked, reason } = args;
+    return this.surreal.withAdminDb(async (db) => {
+      const [rows] = await db.query<[Array<{ id: unknown }>]>(
+        `SELECT id FROM registry_pack WHERE packId = $packId AND version = $version LIMIT 1`,
+        { packId, version },
+      );
+      const row = ((rows as Array<{ id: unknown }>) ?? [])[0];
+      if (!row) {
+        throw new NotFoundException(
+          `pack "${packId}" version ${version} not found in the registry`,
+        );
+      }
+      // yankReason is option<string> — clear it to NONE (not null) on unyank or
+      // a reasonless yank; bind it only when a reason is supplied.
+      const params: Record<string, unknown> = { id: row.id, yanked };
+      let reasonClause = 'yankReason = NONE';
+      if (yanked && reason) {
+        reasonClause = 'yankReason = $reason';
+        params.reason = reason;
+      }
+      await db.query(
+        `UPDATE $id SET yanked = $yanked, ${reasonClause}, updatedAt = time::now()`,
+        params,
+      );
+      this.logger.log(
+        `${yanked ? 'Yanked' : 'Unyanked'} pack ${packId} v${version}` +
+          (yanked && reason ? ` (${reason})` : ''),
+      );
+      return { packId, version, yanked };
+    });
+  }
+
+  /** Find one row: exact version, or the latest non-yanked when version omitted. */
+  private async findRow(
+    packId: string,
+    version?: string,
+  ): Promise<RegistryRow | null> {
+    const rows = (await this.allRows()).filter((r) => r.packId === packId);
+    if (rows.length === 0) return null;
+    if (version) return rows.find((r) => r.version === version) ?? null;
+    const latest = pickLatestVersion(
+      rows.filter((r) => !r.yanked).map((r) => r.version),
+    );
+    return latest ? (rows.find((r) => r.version === latest) ?? null) : null;
+  }
+
+  private async allRows(): Promise<RegistryRow[]> {
+    return this.surreal.withAdminDb(async (db) => {
+      const [rows] = await db.query<[RegistryRow[]]>(
+        `SELECT packId, version, manifest, checksum, description, keywords,
+                publisher, signed, yanked, yankReason, publishedAt
+           FROM registry_pack`,
+      );
+      return (rows as RegistryRow[]) ?? [];
+    });
+  }
+
+  private toVersion(r: RegistryRow): RegistryVersion {
+    return {
+      packId: r.packId,
+      version: r.version,
+      checksum: r.checksum,
+      description: r.description ?? '',
+      keywords: r.keywords ?? [],
+      publisher: r.publisher ?? null,
+      signed: Boolean(r.signed),
+      yanked: Boolean(r.yanked),
+      yankReason: r.yankReason ?? null,
+      publishedAt: new Date(r.publishedAt).toISOString(),
+    };
+  }
+}

--- a/src/registry/registry.controller.ts
+++ b/src/registry/registry.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PackRegistryService } from './pack-registry.service';
+import type {
+  RegistryListResponse,
+  RegistryManifestResponse,
+  RegistryVersionsResponse,
+} from '../contracts/registry/registry.schema';
+
+/**
+ * Discovery reads over the GLOBAL Domain Pack registry (docs/domain-packs.md).
+ * Any authenticated tenant may browse the catalogue (brain:read) — publishing +
+ * installing are separate, privileged surfaces. The catalogue is shared across
+ * all tenants (system DB), so these reads are tenant-agnostic.
+ */
+@Controller('v1/registry')
+@UseGuards(ApiKeyGuard)
+export class RegistryController {
+  constructor(private readonly registry: PackRegistryService) {}
+
+  @Get('packs')
+  @RequireScopes('brain:read')
+  async list(
+    @Query()
+    query: { q?: string; publisher?: string; tag?: string; limit?: string },
+  ): Promise<RegistryListResponse> {
+    const packs = await this.registry.list({
+      q: query.q,
+      publisher: query.publisher,
+      tag: query.tag,
+      limit: query.limit ? parseInt(query.limit, 10) : undefined,
+    });
+    return { packs };
+  }
+
+  @Get('packs/:packId')
+  @RequireScopes('brain:read')
+  async versions(
+    @Param('packId') packId: string,
+  ): Promise<RegistryVersionsResponse> {
+    return this.registry.getVersions(packId);
+  }
+
+  @Get('packs/:packId/:version')
+  @RequireScopes('brain:read')
+  async manifest(
+    @Param('packId') packId: string,
+    @Param('version') version: string,
+  ): Promise<RegistryManifestResponse> {
+    // `latest` is a convenience alias for "the latest non-yanked version".
+    const resolved = await this.registry.getManifest(
+      packId,
+      version === 'latest' ? undefined : version,
+    );
+    if (!resolved) {
+      throw new NotFoundException(
+        `pack "${packId}" ${version} not found in the registry`,
+      );
+    }
+    return resolved;
+  }
+}

--- a/src/registry/registry.module.ts
+++ b/src/registry/registry.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PackRegistryService } from './pack-registry.service';
+import { RegistryController } from './registry.controller';
+import { AdminRegistryController } from './admin-registry.controller';
+
+/**
+ * The GLOBAL Domain Pack registry (docs/domain-packs.md): a shared catalogue of
+ * publishable/installable packs stored in the system DB. Discovery reads
+ * (RegistryController, brain:read) + publish/yank (AdminRegistryController,
+ * registry:publish). PackRegistryService is exported so the tenant-facing
+ * install path (AdminPacksController) can resolve manifests from the registry.
+ * SurrealService is @Global; AuthModule supplies the ApiKeyGuard.
+ */
+@Module({
+  imports: [AuthModule],
+  controllers: [RegistryController, AdminRegistryController],
+  providers: [PackRegistryService],
+  exports: [PackRegistryService],
+})
+export class RegistryModule {}

--- a/test/contracts-admin-packs.unit-spec.ts
+++ b/test/contracts-admin-packs.unit-spec.ts
@@ -4,6 +4,7 @@
 import { PacksListResponseSchema } from '../src/contracts/admin/packs.schema';
 import { AdminPacksController } from '../src/admin/admin-packs.controller';
 import type { DomainPackInstallService } from '../src/admin/domain-pack-install.service';
+import type { PackRegistryService } from '../src/registry/pack-registry.service';
 import type { AuthenticatedRequest } from '../src/auth/api-key.types';
 
 function makeController(): AdminPacksController {
@@ -28,7 +29,8 @@ function makeController(): AdminPacksController {
         },
       ]),
   } as unknown as DomainPackInstallService;
-  return new AdminPacksController(svc);
+  const registry = {} as unknown as PackRegistryService;
+  return new AdminPacksController(svc, registry);
 }
 
 describe('AdminPacksController.list() — wire contract', () => {

--- a/test/pack-registry-semver.unit-spec.ts
+++ b/test/pack-registry-semver.unit-spec.ts
@@ -1,0 +1,28 @@
+/**
+ * Pack version ordering — the semver compare that drives the registry's
+ * latest-non-yanked resolution.
+ */
+import { compareSemver, pickLatestVersion } from '../src/ai/domain-packs';
+
+describe('compareSemver', () => {
+  it('orders by major, then minor, then patch', () => {
+    expect(compareSemver('1.0.0', '2.0.0')).toBe(-1);
+    expect(compareSemver('1.2.0', '1.10.0')).toBe(-1); // numeric, not lexical
+    expect(compareSemver('1.2.3', '1.2.4')).toBe(-1);
+    expect(compareSemver('2.0.0', '1.9.9')).toBe(1);
+    expect(compareSemver('1.2.3', '1.2.3')).toBe(0);
+  });
+});
+
+describe('pickLatestVersion', () => {
+  it('returns the highest semver', () => {
+    expect(pickLatestVersion(['0.1.0', '1.0.0', '0.9.9'])).toBe('1.0.0');
+    expect(pickLatestVersion(['1.2.0', '1.10.0', '1.9.0'])).toBe('1.10.0');
+  });
+  it('returns null for an empty list', () => {
+    expect(pickLatestVersion([])).toBeNull();
+  });
+  it('handles a single version', () => {
+    expect(pickLatestVersion(['3.1.4'])).toBe('3.1.4');
+  });
+});

--- a/test/pack-registry.e2e-spec.ts
+++ b/test/pack-registry.e2e-spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Global Domain Pack registry — end-to-end on a real DB.
+ *
+ * Proves the full product loop: publish → discover → install-from-registry, plus
+ * the supply-chain invariants (version immutability, idempotent republish, yank
+ * excludes from latest + blocks pinned install, unyank restores) and scope
+ * enforcement (registry:publish for writes, brain:read for discovery). The
+ * catalogue lives in the shared `system` DB (withAdminDb), distinct from the
+ * per-tenant domain_pack install record.
+ */
+import { REAL_ESTATE_PACK } from '../src/ai/domain-packs';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+
+// A distinct pack id per run guards against catalogue rows lingering in the
+// shared system DB across spec files in one jest process.
+const PACK = {
+  ...REAL_ESTATE_PACK,
+  id: 'realty_reg_e2e',
+  description: 'Registry e2e real-estate pack.',
+};
+const bump = (version: string) => ({ ...PACK, version });
+
+describe('/v1/registry — global pack registry (e2e)', () => {
+  let pub: AppFixture; // has registry:publish + brain:admin + brain:read
+  let reader: AppFixture; // brain:read only
+  const auth = (f: AppFixture) => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    pub = await createApp({
+      companyId: 'co_registry_pub_e2e',
+      scopes: ['brain:read', 'brain:write', 'brain:admin', 'registry:publish'],
+    });
+    reader = await createApp({
+      companyId: 'co_registry_reader_e2e',
+      scopes: ['brain:read'],
+    });
+  });
+  afterAll(async () => {
+    if (pub) await pub.close();
+    if (reader) await reader.close();
+  });
+
+  it('publishes a pack version', async () => {
+    const r = await pub.http
+      .post('/v1/admin/registry/packs')
+      .set(auth(pub))
+      .send({ manifest: bump('0.1.0'), keywords: ['Property', 'real-estate'] });
+    expect([200, 201]).toContain(r.status);
+    expect(r.body.packId).toBe(PACK.id);
+    expect(r.body.version).toBe('0.1.0');
+    expect(r.body.created).toBe(true);
+    expect(typeof r.body.checksum).toBe('string');
+  });
+
+  it('is idempotent for an identical republish', async () => {
+    const r = await pub.http
+      .post('/v1/admin/registry/packs')
+      .set(auth(pub))
+      .send({ manifest: bump('0.1.0') });
+    expect([200, 201]).toContain(r.status);
+    expect(r.body.created).toBe(false);
+  });
+
+  it('rejects republishing the same version with different content (409)', async () => {
+    const r = await pub.http
+      .post('/v1/admin/registry/packs')
+      .set(auth(pub))
+      .send({ manifest: { ...bump('0.1.0'), description: 'tampered' } });
+    expect(r.status).toBe(409);
+  });
+
+  it('lets any brain:read tenant discover the catalogue', async () => {
+    const list = await reader.http
+      .get('/v1/registry/packs?q=realty_reg')
+      .set(auth(reader));
+    expect(list.status).toBe(200);
+    const found = list.body.packs.find((p: any) => p.packId === PACK.id);
+    expect(found).toBeDefined();
+    expect(found.latestVersion).toBe('0.1.0');
+    expect(found.keywords).toContain('real-estate'); // normalized lowercase
+
+    const versions = await reader.http
+      .get(`/v1/registry/packs/${PACK.id}`)
+      .set(auth(reader));
+    expect(versions.body.latestVersion).toBe('0.1.0');
+    expect(versions.body.versions.map((v: any) => v.version)).toContain('0.1.0');
+
+    const manifest = await reader.http
+      .get(`/v1/registry/packs/${PACK.id}/latest`)
+      .set(auth(reader));
+    expect(manifest.body.manifest.id).toBe(PACK.id);
+    expect(manifest.body.version).toBe('0.1.0');
+  });
+
+  it('denies publish without registry:publish (403)', async () => {
+    const r = await reader.http
+      .post('/v1/admin/registry/packs')
+      .set(auth(reader))
+      .send({ manifest: bump('9.9.9') });
+    expect(r.status).toBe(403);
+  });
+
+  it('installs a pack from the registry into a tenant', async () => {
+    const r = await pub.http
+      .post('/v1/admin/packs/from-registry')
+      .set(auth(pub))
+      .send({ packId: PACK.id });
+    expect([200, 201]).toContain(r.status);
+    expect(r.body.packId).toBe(PACK.id);
+    expect(r.body.predicatesSeeded).toBe(PACK.predicates.length);
+
+    const installed = await pub.http.get('/v1/admin/packs').set(auth(pub));
+    expect(
+      installed.body.installed.some((p: any) => p.packId === PACK.id),
+    ).toBe(true);
+  });
+
+  it('resolves latest across versions and yank flips it back', async () => {
+    // Publish a newer version → latest advances.
+    await pub.http
+      .post('/v1/admin/registry/packs')
+      .set(auth(pub))
+      .send({ manifest: bump('0.2.0') });
+    let versions = await reader.http
+      .get(`/v1/registry/packs/${PACK.id}`)
+      .set(auth(reader));
+    expect(versions.body.latestVersion).toBe('0.2.0');
+
+    // Yank it → latest falls back to 0.1.0.
+    const yank = await pub.http
+      .post(`/v1/admin/registry/packs/${PACK.id}/0.2.0/yank`)
+      .set(auth(pub))
+      .send({ reason: 'bad release' });
+    expect([200, 201]).toContain(yank.status);
+    expect(yank.body.yanked).toBe(true);
+
+    versions = await reader.http
+      .get(`/v1/registry/packs/${PACK.id}`)
+      .set(auth(reader));
+    expect(versions.body.latestVersion).toBe('0.1.0');
+
+    // Installing the yanked version explicitly is refused.
+    const pinned = await pub.http
+      .post('/v1/admin/packs/from-registry')
+      .set(auth(pub))
+      .send({ packId: PACK.id, version: '0.2.0' });
+    expect(pinned.status).toBe(400);
+
+    // Unyank restores it as latest.
+    const unyank = await pub.http
+      .post(`/v1/admin/registry/packs/${PACK.id}/0.2.0/unyank`)
+      .set(auth(pub));
+    expect([200, 201]).toContain(unyank.status);
+    versions = await reader.http
+      .get(`/v1/registry/packs/${PACK.id}`)
+      .set(auth(reader));
+    expect(versions.body.latestVersion).toBe('0.2.0');
+  });
+
+  it('404s installing a pack that is not in the registry', async () => {
+    const r = await pub.http
+      .post('/v1/admin/packs/from-registry')
+      .set(auth(pub))
+      .send({ packId: 'no_such_pack_xyz' });
+    expect(r.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Track A — a real pack registry (SOTA), not a static JSON index

A first-class **in-brain Domain Pack registry**: a GLOBAL, tenant-agnostic catalogue of publishable/installable packs, stored in the shared `system` database (`SurrealService.withAdminDb`, alongside `leader_lease`/`job_run`) — distinct from the per-tenant `domain_pack` record of what's *installed*.

Closes the loop the pack machine was built for: **publish → discover → install-from-registry**.

### Supply-chain invariants (npm/crates.io-style)
- **Version immutability** — a `(packId, version)` is content-addressed by checksum. Republishing the same version with *different* content → `409`; an *identical* republish is idempotent (`created:false`).
- **Yank, not delete** — a bad version is flagged `yanked` (excluded from latest-resolution + default listing, refused for a pinned install) but never removed, so pinned installs stay reproducible. `unyank` restores it.
- **Trust end-to-end** — the manifest's `signature`/`publisher` are stored as-is; cryptographic verification stays at **install** time against the installing tenant's trust store (the registry is a content store). `PACK_REGISTRY_REQUIRE_SIGNATURE` optionally gates publishing to signed packs.

### Surface
- **migration 0042** `registry_pack` (system DB) — row per `(packId,version)`, UNIQUE index, `manifest` FLEXIBLE, keywords/publisher/signed/yanked.
- **`PackRegistryService`** — publish / list (`q`·`publisher`·`tag`) / getVersions / getManifest / resolveForInstall / yank / unyank. Latest = highest non-yanked semver (`domain-packs/semver.ts`).
- **`GET /v1/registry/packs[/:id[/:version|latest]]`** (`brain:read`) — any tenant browses the shared catalogue.
- **`POST /v1/admin/registry/packs`** + `/:id/:ver/{yank,unyank}` — new **`registry:publish`** scope (mutating the shared catalogue is deliberately distinct from `brain:admin`).
- **`POST /v1/admin/packs/from-registry {packId, version?}`** (`brain:admin`) — resolves latest-non-yanked (or a pin) and installs via the existing path, pinning the registry checksum.

### Tests
Semver ordering (unit) + a full **e2e loop on a real DB**: publish → discover → install-from-registry, immutability `409`, idempotent republish, yank flips `latest` + blocks pinned install, unyank restores, publish scope `403`, unknown-pack `404`.

Acceptance bar met: **790 unit · 158 e2e · 9 jobs** · tsc · lint (max-params=3, complexity=25).

Follow-up PR: CLI (`pack:publish` / `pack:search` / `pack:install --registry`), a first-party seed script, and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)