### PR TITLE
feat(code-memory): silver-dataset harness for the trained Layer-1 gate (track C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ coverage/
 .vscode/
 .idea/
 *.tsbuildinfo
+
+# Generated code-memory silver datasets (track C distillation)
+data/code-memory/*.jsonl

--- a/docs/code-memory/distillation-dataset.md
+++ b/docs/code-memory/distillation-dataset.md
@@ -1,0 +1,79 @@
+# Track C — training the Layer-1 decision gate (distillation dataset)
+
+The capture pipeline's Layer-1 is a cheap binary gate: *does this commit's text
+(message + PR body, no diff) carry an engineering "why" — a decision / rationale
+/ invariant / gotcha — worth an LLM extraction call?* It ships today as
+`HeuristicDecisionClassifier`, a stand-in behind the `DecisionClassifier` seam.
+A trained model would drop into that exact seam. This doc is the data plan +
+the harness that produces the training corpus.
+
+## Why we distill instead of using a public corpus
+
+No public dataset labels the `decided / because / invariant / gotcha` taxonomy
+on the commit-message + PR modality. The nearest public sets (verified where
+noted) are useful for **external calibration / eval**, not as drop-in labels:
+
+- **CoMRAT / OOM-Killer** — `arxiv.org/pdf/2506.10986`, dataset +
+  classifiers at `zenodo.org/records/10063089`. Sentence-level `Decision /
+  Rationale / Supporting Facts` on Linux-kernel commit messages; the authors
+  train cheap **BiLSTM binary detectors** for Decision and Rationale — a direct
+  precedent for our gate. Maps to `decided` / `because`; aggregate sentence →
+  commit. *(primary-source; not re-verified in the last research run.)*
+- **SATD "different sources"** — `github.com/yikun-li/satd-different-sources-data`
+  (Springer `10.1007/s10664-023-10297-9`). **5,000 commit messages + 5,000 PR
+  sections**, 103 Apache projects, labeled non-SATD vs 4 SATD types — exactly our
+  modality; usable as an external binary/typed gold set. *(verified 3-0.)*
+- **Maldonado SATD** — `github.com/maldonado/tse.satd.data`. Manually labeled
+  SATD, but modality is **code comments** → needs re-mapping. *(verified 3-0.)*
+- **Levin & Yehudai (1,151 commits, corrective/perfective/adaptive)**,
+  **Ghadhab (1,793 balanced)** — commit *intent*, not "why"; use as negatives /
+  features only. *(1151 & 1793 verified 3-0; the Zenodo license claim for Levin
+  was refuted — check it before reuse.)*
+- **CommitPack / CommitPackFT / CommitBench** (HF `bigcode/*`, `Maxscha/commitbench`)
+  — large but **unlabeled** for our taxonomy; base corpus for silver-labeling.
+
+Conclusion: **distill**. The existing Layer-2 LLM extractor is the *teacher*; a
+commit is decision-bearing iff the teacher extracts ≥1 candidate. Its verdicts
+are silver labels for a cheap student (BiLSTM / DistilBERT), validated against
+CoMRAT + SATD as external gold. This is self-consistent: the gate's job is
+precisely to admit what Layer-2 will extract.
+
+## The harness
+
+`pnpm label:decisions` (`scripts/label-decisions.ts` → `src/code-memory/capture/
+silver-dataset.ts`) runs the teacher over a git range and writes one JSONL row
+per non-merge commit:
+
+```bash
+OPENAI_API_KEY=... pnpm label:decisions -- \
+  --range origin/main~2000..HEAD \
+  --out data/code-memory/silver-decisions.jsonl \
+  [--model gpt-4o-mini] [--limit 500] [--concurrency 6]
+```
+
+Each row: `{ sha, text, label, kinds, candidateCount, signals, heuristic,
+authorDate }` — `text` is the exact classifier input (message + PR body);
+`label` is the teacher's binary verdict; `kinds` seeds a future multi-label head.
+
+**Key difference from the production capture pipeline:** the harness runs the
+teacher over EVERY commit, *not* behind the heuristic gate. Gating first would
+hide the heuristic's false negatives — the very examples a trained student must
+learn. Every row also records the current `heuristic` verdict, and the summary
+reports `heuristicFalseNeg` (missed "why") + `heuristicFalsePos` (wasted LLM
+calls) — the payoff signal that justifies training a model at all.
+
+Generated datasets live under `data/code-memory/` and are git-ignored.
+
+## Recommended path + sizes
+
+1. Label the project's own history + optionally a CommitPackFT slice with the
+   harness → tens of thousands of silver rows, cheaply.
+2. Train a binary student (DistilBERT or BiLSTM) on `text → label`. Rough sizes:
+   **~2–5k examples/class** for a decent baseline, **10k+/class** for a strong
+   one — well within reach of silver-labeling.
+3. Calibrate/validate on CoMRAT + SATD-"different-sources" as external gold
+   (hundreds–1k hand/strong-LLM-checked items suffice).
+4. Wrap the student as a `DecisionClassifier` implementing
+   `classify(commit): Layer1Verdict` (binary `likelyDecision` + `reason` =
+   `model p=…` + `signals`). The capture pipeline is unchanged — swap the
+   heuristic for the model at the same seam.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eval:diff": "ts-node -r tsconfig-paths/register scripts/eval-baseline-diff.ts",
     "bench:router": "ts-node -r tsconfig-paths/register scripts/bench-chat-router.ts",
     "capture:decisions": "ts-node -r tsconfig-paths/register scripts/capture-decisions.ts",
+    "label:decisions": "ts-node -r tsconfig-paths/register scripts/label-decisions.ts",
     "pack:validate": "ts-node -r tsconfig-paths/register scripts/validate-pack.ts",
     "pack:install": "ts-node -r tsconfig-paths/register scripts/install-pack.ts",
     "pack:sign": "ts-node -r tsconfig-paths/register scripts/sign-pack.ts",

--- a/scripts/label-decisions.ts
+++ b/scripts/label-decisions.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env tsx
+/**
+ * Code-memory track C — SILVER dataset builder CLI.
+ * (docs/code-memory/distillation-dataset.md)
+ *
+ *   OPENAI_API_KEY=... pnpm label:decisions -- \
+ *     --range origin/main~2000..HEAD \
+ *     --out data/code-memory/silver-decisions.jsonl \
+ *     [--model gpt-4o-mini] [--limit 500] [--concurrency 6]
+ *
+ * Runs the Layer-2 LLM extractor (the TEACHER) over a git range and writes one
+ * JSONL silver-labeled row per non-merge commit: the classifier input text
+ * (message + PR body), the teacher's binary label + kinds, the deterministic
+ * signals, and the current heuristic verdict (for heuristic-vs-teacher analysis).
+ * Feed the JSONL to a cheap student (BiLSTM / DistilBERT) that then drops into
+ * the DecisionClassifier seam. Client-side: only your own LLM key is used; no
+ * data leaves for anywhere but your LLM provider.
+ */
+import { createWriteStream, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { readCommits } from '../src/code-memory/capture/git-commits';
+import { HeuristicDecisionClassifier } from '../src/code-memory/capture/heuristic-classifier';
+import {
+  LlmDecisionExtractor,
+  makeOpenAiCompleter,
+} from '../src/code-memory/capture/llm-extractor';
+import { labelCommits } from '../src/code-memory/capture/silver-dataset';
+
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+async function main(): Promise<void> {
+  const range = arg('range', 'origin/main..HEAD')!;
+  const out = arg('out', 'data/code-memory/silver-decisions.jsonl')!;
+  const model = arg('model', process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o-mini')!;
+  const limit = arg('limit') ? parseInt(arg('limit')!, 10) : undefined;
+  const concurrency = parseInt(arg('concurrency', '4')!, 10);
+  const openAiKey = process.env.OPENAI_API_KEY;
+  if (!openAiKey) throw new Error('OPENAI_API_KEY is required');
+
+  let commits = readCommits({ range });
+  if (limit && limit > 0) commits = commits.slice(0, limit);
+  console.error(
+    `[label] ${commits.length} commit(s) in ${range} → ${out} (teacher=${model}, concurrency=${concurrency})`,
+  );
+
+  mkdirSync(dirname(out), { recursive: true });
+  const stream = createWriteStream(out, { flags: 'w' });
+
+  const summary = await labelCommits({
+    commits,
+    extractor: new LlmDecisionExtractor(
+      makeOpenAiCompleter({ apiKey: openAiKey, model }),
+    ),
+    classifier: new HeuristicDecisionClassifier(),
+    emit: (ex) => stream.write(`${JSON.stringify(ex)}\n`),
+    concurrency,
+    log: (m) => console.error(`[label] ${m}`),
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    stream.end((err?: Error | null) => (err ? reject(err) : resolve()));
+  });
+  console.error(`[label] done: ${JSON.stringify(summary)}`);
+  // Surface the payoff up front: how much a trained gate could beat the heuristic.
+  const { heuristicFalseNeg, heuristicFalsePos, labeled } = summary;
+  if (labeled > 0) {
+    console.error(
+      `[label] heuristic vs teacher: ${heuristicFalseNeg} false-neg (missed "why"), ` +
+        `${heuristicFalsePos} false-pos (wasted LLM calls) of ${labeled} labeled`,
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error(`[label] fatal: ${(e as Error).message}`);
+  process.exit(1);
+});

--- a/src/code-memory/capture/silver-dataset.ts
+++ b/src/code-memory/capture/silver-dataset.ts
@@ -1,0 +1,175 @@
+import type {
+  CommitInput,
+  DecisionCandidate,
+  DecisionClassifier,
+  DecisionExtractor,
+  DecisionKind,
+  Layer1Signals,
+} from './types';
+import { isMergeCommit, parseCommitSignals } from './commit-signals';
+
+/**
+ * Code-memory track C — SILVER dataset builder for the trained Layer-1 gate.
+ * (docs/code-memory/distillation-dataset.md)
+ *
+ * The Layer-1 classifier is a cheap binary gate: "does this commit's text carry
+ * an engineering 'why' worth an LLM extraction?". No public corpus labels the
+ * decided/because/invariant/gotcha taxonomy, so we DISTILL: the existing Layer-2
+ * LLM extractor is the TEACHER — a commit is decision-bearing iff the teacher
+ * extracts ≥1 candidate — and its verdicts become silver labels to train a cheap
+ * student (BiLSTM / DistilBERT) behind the same {@link DecisionClassifier} seam.
+ *
+ * CRUCIAL DIFFERENCE from the production capture pipeline: here we run the
+ * teacher over EVERY commit, NOT behind the heuristic gate. Gating first would
+ * hide the heuristic's false negatives — commits it rejected that DO carry a
+ * "why" — which are exactly the examples a trained student must learn. Each row
+ * also records the current heuristic verdict so we can measure how much the
+ * heuristic over/under-filters (the payoff signal for training a model at all).
+ */
+
+/** One silver-labeled training row. `text` is the EXACT input the Layer-1
+ *  classifier sees (message + PR body, no diff) — same at train + serve time. */
+export interface SilverExample {
+  sha: string;
+  text: string;
+  /** Teacher label: 1 iff Layer-2 extracted ≥1 decision candidate. */
+  label: 0 | 1;
+  /** Distinct kinds the teacher found — fodder for a future multi-label head. */
+  kinds: DecisionKind[];
+  candidateCount: number;
+  /** Deterministic cheap features (also the heuristic's substrate). */
+  signals: Layer1Signals;
+  /** Current heuristic verdict — for heuristic-vs-teacher agreement analysis. */
+  heuristic: { likelyDecision: boolean; reason: string };
+  authorDate: string;
+}
+
+/** The classifier input text: commit message + PR body (no diff, no file
+ *  contents). Single source of truth so the trained student is fed the same
+ *  text the production gate will see. */
+export function commitText(commit: CommitInput): string {
+  return commit.prBody
+    ? `${commit.message}\n\n${commit.prBody}`
+    : commit.message;
+}
+
+/** Build one silver example from a commit + the teacher's extraction. Pure. */
+export function buildSilverExample(args: {
+  commit: CommitInput;
+  candidates: DecisionCandidate[];
+  classifier: DecisionClassifier;
+}): SilverExample {
+  const { commit, candidates, classifier } = args;
+  const kinds = [...new Set(candidates.map((c) => c.kind))];
+  const verdict = classifier.classify(commit);
+  return {
+    sha: commit.sha,
+    text: commitText(commit),
+    label: candidates.length > 0 ? 1 : 0,
+    kinds,
+    candidateCount: candidates.length,
+    signals: parseCommitSignals(commit),
+    heuristic: {
+      likelyDecision: verdict.likelyDecision,
+      reason: verdict.reason,
+    },
+    authorDate: commit.authorDate,
+  };
+}
+
+export interface LabelSummary {
+  scanned: number;
+  merges: number;
+  labeled: number;
+  positive: number;
+  negative: number;
+  failures: number;
+  /** heuristic verdict == teacher label — how often the cheap gate already agrees. */
+  heuristicAgree: number;
+  /** heuristic REJECTED but teacher POSITIVE — the false negatives a model recovers. */
+  heuristicFalseNeg: number;
+  /** heuristic ADMITTED but teacher NEGATIVE — the wasted LLM calls a model saves. */
+  heuristicFalsePos: number;
+}
+
+/**
+ * Label a set of commits with the teacher extractor, emitting one SilverExample
+ * per non-merge commit. Merges are trivially non-decision (skipped, not
+ * labeled). A per-commit teacher failure is counted and skipped — one bad
+ * commit must not sink the run. Bounded-concurrency; emit order is not
+ * guaranteed (a JSONL dataset is order-insensitive).
+ */
+export async function labelCommits(opts: {
+  commits: CommitInput[];
+  extractor: DecisionExtractor;
+  classifier: DecisionClassifier;
+  emit: (ex: SilverExample) => void;
+  concurrency?: number;
+  log?: (msg: string) => void;
+}): Promise<LabelSummary> {
+  const { commits, extractor, classifier, emit } = opts;
+  const log = opts.log ?? (() => {});
+  const concurrency = Math.max(1, opts.concurrency ?? 4);
+  const summary: LabelSummary = {
+    scanned: commits.length,
+    merges: 0,
+    labeled: 0,
+    positive: 0,
+    negative: 0,
+    failures: 0,
+    heuristicAgree: 0,
+    heuristicFalseNeg: 0,
+    heuristicFalsePos: 0,
+  };
+
+  const targets = commits.filter((c) => {
+    if (isMergeCommit(c)) {
+      summary.merges += 1;
+      return false;
+    }
+    return true;
+  });
+
+  await runPool(targets, concurrency, async (commit) => {
+    let candidates: DecisionCandidate[];
+    try {
+      candidates = await extractor.extract(commit);
+    } catch (e) {
+      summary.failures += 1;
+      log(`label failed ${commit.sha.slice(0, 8)}: ${(e as Error).message}`);
+      return;
+    }
+    const ex = buildSilverExample({ commit, candidates, classifier });
+    emit(ex);
+    summary.labeled += 1;
+    if (ex.label === 1) summary.positive += 1;
+    else summary.negative += 1;
+    const heur = ex.heuristic.likelyDecision ? 1 : 0;
+    if (heur === ex.label) summary.heuristicAgree += 1;
+    else if (ex.label === 1) summary.heuristicFalseNeg += 1;
+    else summary.heuristicFalsePos += 1;
+  });
+
+  return summary;
+}
+
+/** Minimal bounded-concurrency map — no external dep, keeps the capture module
+ *  free of the NestJS/DI surface (it runs client-side). */
+async function runPool<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<void>,
+): Promise<void> {
+  let next = 0;
+  const lanes = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      for (;;) {
+        const i = next++;
+        if (i >= items.length) break;
+        await worker(items[i], i);
+      }
+    },
+  );
+  await Promise.all(lanes);
+}

--- a/test/silver-dataset.unit-spec.ts
+++ b/test/silver-dataset.unit-spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Code-memory track C — silver dataset builder. Verifies the teacher→label
+ * distillation logic and, crucially, the heuristic-vs-teacher confusion counts
+ * (the payoff signal: where a trained gate would beat the heuristic).
+ */
+import { HeuristicDecisionClassifier } from '../src/code-memory/capture/heuristic-classifier';
+import {
+  buildSilverExample,
+  commitText,
+  labelCommits,
+} from '../src/code-memory/capture/silver-dataset';
+import type {
+  CommitInput,
+  DecisionCandidate,
+  DecisionExtractor,
+} from '../src/code-memory/capture/types';
+
+function commit(over: Partial<CommitInput> & { sha: string }): CommitInput {
+  return {
+    message: '',
+    changedFiles: ['src/x.ts'],
+    authorDate: '2026-07-07T00:00:00Z',
+    ...over,
+  };
+}
+function candidate(over: Partial<DecisionCandidate> = {}): DecisionCandidate {
+  return {
+    kind: 'decided',
+    text: 'a decision',
+    anchor: 'src/x.ts',
+    commit: 'sha',
+    validFrom: '2026-07-07T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('commitText', () => {
+  it('joins message + PR body (no diff)', () => {
+    expect(commitText(commit({ sha: 'a', message: 'msg', prBody: 'body' }))).toBe(
+      'msg\n\nbody',
+    );
+  });
+  it('is just the message when there is no PR body', () => {
+    expect(commitText(commit({ sha: 'a', message: 'msg' }))).toBe('msg');
+  });
+});
+
+describe('buildSilverExample', () => {
+  const classifier = new HeuristicDecisionClassifier();
+  it('labels 1 with deduped kinds when the teacher extracts candidates', () => {
+    const ex = buildSilverExample({
+      commit: commit({ sha: 'a', message: 'feat: x\n\nbecause it avoids drift' }),
+      candidates: [
+        candidate({ kind: 'decided' }),
+        candidate({ kind: 'because' }),
+        candidate({ kind: 'because' }),
+      ],
+      classifier,
+    });
+    expect(ex.label).toBe(1);
+    expect(ex.candidateCount).toBe(3);
+    expect([...ex.kinds].sort()).toEqual(['because', 'decided']);
+    expect(ex.heuristic.likelyDecision).toBe(true);
+  });
+  it('labels 0 when the teacher extracts nothing', () => {
+    const ex = buildSilverExample({
+      commit: commit({ sha: 'b', message: 'chore: bump deps' }),
+      candidates: [],
+      classifier,
+    });
+    expect(ex.label).toBe(0);
+    expect(ex.kinds).toEqual([]);
+    expect(ex.heuristic.likelyDecision).toBe(false); // heuristic also rejects
+  });
+});
+
+describe('labelCommits', () => {
+  it('skips merges, counts failures, and scores heuristic vs teacher', async () => {
+    const commits: CommitInput[] = [
+      // agree: heuristic admits (rationale marker) + teacher positive
+      commit({ sha: 'a1', message: 'feat: x\n\nWe did this because it avoids drift.' }),
+      // false-neg: heuristic rejects (chore, no body) but teacher positive
+      commit({ sha: 'b2', message: 'chore: bump deps' }),
+      // false-pos: heuristic admits (refactor + long body) but teacher empty
+      commit({
+        sha: 'c3',
+        message:
+          'refactor: layout\n\nThis restructures the module layout and renames the internal handlers across the whole package.',
+      }),
+      // merge: skipped, not labeled
+      commit({ sha: 'd4', message: "Merge branch 'topic' into main" }),
+      // failure: teacher throws
+      commit({ sha: 'e5', message: 'feat: y\n\nbecause reasons enough to admit here' }),
+    ];
+    const scripted: Record<string, DecisionCandidate[]> = {
+      a1: [candidate({ kind: 'decided' })],
+      b2: [candidate({ kind: 'because' })],
+      c3: [],
+    };
+    const extractor: DecisionExtractor = {
+      extract: async (c) => {
+        if (c.sha === 'e5') throw new Error('boom');
+        return scripted[c.sha] ?? [];
+      },
+    };
+    const emitted: string[] = [];
+    const summary = await labelCommits({
+      commits,
+      extractor,
+      classifier: new HeuristicDecisionClassifier(),
+      emit: (ex) => emitted.push(ex.sha),
+      concurrency: 2,
+    });
+
+    expect(summary.scanned).toBe(5);
+    expect(summary.merges).toBe(1);
+    expect(summary.labeled).toBe(3); // a1, b2, c3 (e5 failed, d4 merge)
+    expect(summary.positive).toBe(2); // a1, b2
+    expect(summary.negative).toBe(1); // c3
+    expect(summary.failures).toBe(1); // e5
+    expect(summary.heuristicAgree).toBe(1); // a1
+    expect(summary.heuristicFalseNeg).toBe(1); // b2 — the "why" the heuristic missed
+    expect(summary.heuristicFalsePos).toBe(1); // c3 — the wasted LLM call
+    expect(emitted.sort()).toEqual(['a1', 'b2', 'c3']);
+  });
+});


### PR DESCRIPTION
## Track C, first brick — the training corpus, by distillation

Track C is the trained decision classifier that replaces `HeuristicDecisionClassifier` behind the `DecisionClassifier` seam. The blocker was always *"no labeled commit corpus."* Research (deep-research run) confirmed **no public dataset labels the `decided/because/invariant/gotcha` taxonomy on the commit-message + PR modality** — the nearest sets are useful only as external calibration. So the corpus is built by **distillation**: the existing Layer-2 LLM extractor is the *teacher* (a commit is decision-bearing iff it extracts ≥1 candidate), and its verdicts become silver labels for a cheap student (BiLSTM/DistilBERT) that later drops into the same seam.

### What's here
- **`src/code-memory/capture/silver-dataset.ts`** — `commitText` / `buildSilverExample` (pure) + `labelCommits` orchestrator (injected teacher, bounded concurrency, per-commit failures counted not fatal). One JSONL row per non-merge commit: `{sha, text, label, kinds, candidateCount, signals, heuristic, authorDate}`.
- **Crucial design choice** — the harness runs the teacher over **every** commit, *not* behind the heuristic gate. Gating first would hide the heuristic's false negatives — the exact examples a trained student must learn. The summary reports `heuristicFalseNeg` (missed "why") + `heuristicFalsePos` (wasted LLM calls): the payoff signal that justifies training a model at all.
- **`scripts/label-decisions.ts` + `pnpm label:decisions`** — run the teacher over a git range → JSONL, client-side with your own LLM key. Generated `data/code-memory/*.jsonl` is git-ignored.
- **`docs/code-memory/distillation-dataset.md`** — the data plan + external gold datasets for calibration (CoMRAT/OOM-Killer, which trains BiLSTM Decision/Rationale detectors — a direct precedent; SATD "different-sources" 5k commit + 5k PR; Levin/Ghadhab intent; CommitPack base), each with a verification note.

### Tests
`commitText` / `buildSilverExample` / `labelCommits` including the heuristic-vs-teacher confusion counts, fully offline (stub teacher). Real git read smoke-tested against this repo. **795 unit** · tsc · lint (max-params=3, complexity=25). No server/module/migration change, so e2e/jobs (158/9) are unaffected.

Next bricks (not this PR): run the harness to produce the corpus, train the student, wrap it as a `DecisionClassifier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)