### PR TITLE
feat(code-memory): trained Layer-1 decision gate — student model, train + serve (track C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ coverage/
 .idea/
 *.tsbuildinfo
 
-# Generated code-memory silver datasets (track C distillation)
+# Generated code-memory silver datasets + trained gate models (track C)
 data/code-memory/*.jsonl
+data/code-memory/*.model.json

--- a/docs/code-memory/distillation-dataset.md
+++ b/docs/code-memory/distillation-dataset.md
@@ -1,4 +1,4 @@
-# Track C — training the Layer-1 decision gate (distillation dataset)
+# Track C — the trained Layer-1 decision gate (dataset → train → serve)
 
 The capture pipeline's Layer-1 is a cheap binary gate: *does this commit's text
 (message + PR body, no diff) carry an engineering "why" — a decision / rationale
@@ -77,3 +77,59 @@ Generated datasets live under `data/code-memory/` and are git-ignored.
    `classify(commit): Layer1Verdict` (binary `likelyDecision` + `reason` =
    `model p=…` + `signals`). The capture pipeline is unchanged — swap the
    heuristic for the model at the same seam.
+
+## The trained gate (train → serve), in-process, zero-dep
+
+The shipped student is a **logistic regression** over hashed token n-grams of
+the commit text PLUS the deterministic commit signals — deliberately linear, not
+a BiLSTM/DistilBERT: the Layer-1 gate runs client-side (CI / git hook) with no ML
+runtime, the input is short commit text, and a linear model trains in seconds and
+serialises to a tiny JSON. A heavier student (DistilBERT via ONNX) can replace it
+behind the same `DecisionClassifier` seam if metrics ever demand — the pipeline
+never changes. Features live in one place (`gate-features.ts`) shared by trainer
+and server, so train-time and serve-time features always match.
+
+### Train
+
+```bash
+pnpm train:decision-gate -- \
+  --data data/code-memory/silver-decisions.jsonl \
+  --out  data/code-memory/decision-gate.model.json \
+  [--epochs 25] [--lr 0.1] [--l2 0.0001] [--threshold 0.5] [--holdout 0.2] [--seed 42]
+```
+
+Deterministic (seeded), fully offline. It holds out a slice (bucketed by commit
+sha) and prints **model-vs-heuristic** precision/recall/F1 against the teacher
+label — the payoff check: does the trained gate beat the heuristic? The model
+artifact is a portable sparse JSON (`{version, config, threshold, bias, weights}`),
+git-ignored under `data/code-memory/`.
+
+### Serve
+
+Point the capture CLI at the model — the trained gate replaces the heuristic at
+the same seam, so nothing else changes:
+
+```bash
+OPENAI_API_KEY=... BRAIN_API_KEY=... pnpm capture:decisions -- \
+  --range origin/main..HEAD --brain-url https://brain.inite.ai \
+  --gate-model data/code-memory/decision-gate.model.json
+```
+
+Without `--gate-model`, capture uses `HeuristicDecisionClassifier` as before.
+
+### Files
+- `gate-features.ts` — `featurize` (hashing trick + structured signal features),
+  shared by train + serve.
+- `gate-train.ts` — `trainGate` (SGD logistic regression, seeded, prunes
+  near-zero weights).
+- `gate-classifier.ts` — `GateModel`, `predictProba`, `evaluateGate`,
+  `TrainedDecisionClassifier` (the `DecisionClassifier` impl).
+- `scripts/train-decision-gate.ts` (`pnpm train:decision-gate`), and the
+  `--gate-model` flag on `scripts/capture-decisions.ts`.
+
+### Remaining
+Run `label:decisions` over real history to produce a real corpus, train, and
+compare F1 vs the heuristic on a hand-checked slice; tune `--threshold` for the
+precision/recall trade-off the gate wants (higher threshold = fewer wasted LLM
+calls, more missed "why"). Optionally add a multi-label (`kinds`) head or an
+ONNX BiLSTM/DistilBERT student behind the same seam.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bench:router": "ts-node -r tsconfig-paths/register scripts/bench-chat-router.ts",
     "capture:decisions": "ts-node -r tsconfig-paths/register scripts/capture-decisions.ts",
     "label:decisions": "ts-node -r tsconfig-paths/register scripts/label-decisions.ts",
+    "train:decision-gate": "ts-node -r tsconfig-paths/register scripts/train-decision-gate.ts",
     "pack:validate": "ts-node -r tsconfig-paths/register scripts/validate-pack.ts",
     "pack:install": "ts-node -r tsconfig-paths/register scripts/install-pack.ts",
     "pack:sign": "ts-node -r tsconfig-paths/register scripts/sign-pack.ts",

--- a/scripts/capture-decisions.ts
+++ b/scripts/capture-decisions.ts
@@ -23,10 +23,12 @@ import { join } from 'node:path';
 import { readCommits } from '../src/code-memory/capture/git-commits';
 import { makeSymbolAnchorRefiner } from '../src/code-memory/anchor/refine';
 import { HeuristicDecisionClassifier } from '../src/code-memory/capture/heuristic-classifier';
+import { TrainedDecisionClassifier } from '../src/code-memory/capture/gate-classifier';
 import {
   LlmDecisionExtractor,
   makeOpenAiCompleter,
 } from '../src/code-memory/capture/llm-extractor';
+import type { DecisionClassifier } from '../src/code-memory/capture/types';
 import { HttpDecisionSink } from '../src/code-memory/capture/http-sink';
 import { runCapturePipeline } from '../src/code-memory/capture/capture-pipeline';
 import type {
@@ -55,6 +57,18 @@ async function main(): Promise<void> {
   const commits = readCommits({ range });
   console.error(`[capture] ${commits.length} commit(s) in ${range}`);
 
+  // Layer-1 gate: the trained student (track C) when a model is supplied,
+  // else the deterministic heuristic. Same DecisionClassifier seam either way.
+  const gateModelPath = arg('gate-model');
+  const classifier: DecisionClassifier = gateModelPath
+    ? TrainedDecisionClassifier.fromJson(
+        JSON.parse(readFileSync(gateModelPath, 'utf8')),
+      )
+    : new HeuristicDecisionClassifier();
+  console.error(
+    `[capture] Layer-1 gate: ${gateModelPath ? `trained (${gateModelPath})` : 'heuristic'}`,
+  );
+
   const extractor = new LlmDecisionExtractor(
     makeOpenAiCompleter({ apiKey: openAiKey, model }),
   );
@@ -81,7 +95,7 @@ async function main(): Promise<void> {
 
   const summary = await runCapturePipeline({
     commits,
-    classifier: new HeuristicDecisionClassifier(),
+    classifier,
     extractor,
     sink,
     refineAnchor,

--- a/scripts/train-decision-gate.ts
+++ b/scripts/train-decision-gate.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env tsx
+/**
+ * Code-memory track C — train the Layer-1 decision gate.
+ * (docs/code-memory/distillation-dataset.md)
+ *
+ *   pnpm train:decision-gate -- \
+ *     --data data/code-memory/silver-decisions.jsonl \
+ *     --out  data/code-memory/decision-gate.model.json \
+ *     [--epochs 25] [--lr 0.1] [--l2 0.0001] [--threshold 0.5] \
+ *     [--holdout 0.2] [--seed 42]
+ *
+ * Reads the silver JSONL produced by `pnpm label:decisions`, trains a logistic-
+ * regression student, reports model-vs-heuristic metrics on a held-out split
+ * (the payoff — does the trained gate beat the heuristic against the teacher
+ * label?), and writes the portable model artifact for TrainedDecisionClassifier.
+ * Fully offline: no LLM, no network.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { featurize } from '../src/code-memory/capture/gate-features';
+import { evaluateGate } from '../src/code-memory/capture/gate-classifier';
+import { trainGate } from '../src/code-memory/capture/gate-train';
+import type { SilverExample } from '../src/code-memory/capture/silver-dataset';
+
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+/** Deterministic holdout: bucket by an FNV hash of the sha, no shuffle needed. */
+function inHoldout(sha: string, fraction: number, seed: number): boolean {
+  let h = (0x811c9dc5 ^ seed) >>> 0;
+  for (let i = 0; i < sha.length; i++) {
+    h ^= sha.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0) % 1000 < fraction * 1000;
+}
+
+function prf(preds: number[], labels: number[]): {
+  n: number;
+  accuracy: number;
+  precision: number;
+  recall: number;
+  f1: number;
+} {
+  let tp = 0;
+  let fp = 0;
+  let fn = 0;
+  let correct = 0;
+  for (let i = 0; i < labels.length; i++) {
+    if (preds[i] === labels[i]) correct += 1;
+    if (preds[i] === 1 && labels[i] === 1) tp += 1;
+    else if (preds[i] === 1 && labels[i] === 0) fp += 1;
+    else if (preds[i] === 0 && labels[i] === 1) fn += 1;
+  }
+  const precision = tp + fp > 0 ? tp / (tp + fp) : 0;
+  const recall = tp + fn > 0 ? tp / (tp + fn) : 0;
+  const f1 =
+    precision + recall > 0 ? (2 * precision * recall) / (precision + recall) : 0;
+  return {
+    n: labels.length,
+    accuracy: labels.length ? correct / labels.length : 0,
+    precision,
+    recall,
+    f1,
+  };
+}
+
+function fmt(m: { accuracy: number; precision: number; recall: number; f1: number }): string {
+  const p = (x: number) => (x * 100).toFixed(1);
+  return `acc ${p(m.accuracy)}  P ${p(m.precision)}  R ${p(m.recall)}  F1 ${p(m.f1)}`;
+}
+
+function main(): void {
+  const dataPath = arg('data', 'data/code-memory/silver-decisions.jsonl')!;
+  const outPath = arg('out', 'data/code-memory/decision-gate.model.json')!;
+  const epochs = parseInt(arg('epochs', '25')!, 10);
+  const learningRate = parseFloat(arg('lr', '0.1')!);
+  const l2 = parseFloat(arg('l2', '0.0001')!);
+  const threshold = parseFloat(arg('threshold', '0.5')!);
+  const holdout = parseFloat(arg('holdout', '0.2')!);
+  const seed = parseInt(arg('seed', '42')!, 10);
+
+  const rows: SilverExample[] = readFileSync(dataPath, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as SilverExample);
+  if (rows.length === 0) throw new Error(`no rows in ${dataPath}`);
+
+  const train = rows.filter((r) => !inHoldout(r.sha, holdout, seed));
+  const test = rows.filter((r) => inHoldout(r.sha, holdout, seed));
+  const pos = rows.filter((r) => r.label === 1).length;
+  console.error(
+    `[train] ${rows.length} rows (${pos} pos / ${rows.length - pos} neg) → train ${train.length} / holdout ${test.length}`,
+  );
+  if (train.length === 0 || test.length === 0) {
+    throw new Error('empty train or holdout split — need more data or a smaller --holdout');
+  }
+
+  const model = trainGate(
+    train.map((r) => ({ text: r.text, signals: r.signals, label: r.label })),
+    { epochs, learningRate, l2, threshold, seed },
+  );
+
+  const testFeats = test.map((r) => ({
+    feats: featurize(r.text, r.signals, model.config),
+    label: r.label,
+  }));
+  const modelMetrics = evaluateGate(model, testFeats);
+  const heurMetrics = prf(
+    test.map((r) => (r.heuristic.likelyDecision ? 1 : 0)),
+    test.map((r) => r.label),
+  );
+
+  console.error(`[train] holdout heuristic: ${fmt(heurMetrics)}`);
+  console.error(`[train] holdout model:     ${fmt(modelMetrics)}`);
+  console.error(
+    `[train] model F1 − heuristic F1 = ${((modelMetrics.f1 - heurMetrics.f1) * 100).toFixed(1)} pts`,
+  );
+
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, `${JSON.stringify(model)}\n`);
+  const size = Object.keys(model.weights).length;
+  console.error(`[train] wrote ${outPath} (${size} non-zero weights)`);
+}
+
+try {
+  main();
+} catch (e) {
+  console.error(`[train] fatal: ${(e as Error).message}`);
+  process.exit(1);
+}

--- a/src/code-memory/capture/gate-classifier.ts
+++ b/src/code-memory/capture/gate-classifier.ts
@@ -1,0 +1,129 @@
+import type { CommitInput, DecisionClassifier, Layer1Verdict } from './types';
+import { parseCommitSignals } from './commit-signals';
+import { commitText } from './silver-dataset';
+import {
+  DEFAULT_FEATURE_CONFIG,
+  featurize,
+  type FeatureConfig,
+} from './gate-features';
+
+/**
+ * Code-memory track C — the trained Layer-1 gate model + serving classifier.
+ * (docs/code-memory/distillation-dataset.md)
+ *
+ * A logistic-regression student distilled from the Layer-2 teacher's silver
+ * labels. Deliberately a lightweight LINEAR model, not a BiLSTM/DistilBERT: the
+ * gate runs client-side with zero ML runtime, the input is short commit text,
+ * and a linear model over hashed n-grams + the deterministic signals trains in
+ * seconds and serialises to a tiny JSON. A heavier student (DistilBERT via ONNX)
+ * can replace it behind this same {@link DecisionClassifier} seam if metrics
+ * ever demand — the pipeline never changes.
+ */
+
+/** Serialised trained gate. `weights` is sparse (bucket index → weight); only
+ *  buckets the trainer touched are stored. Portable JSON, no vocabulary. */
+export interface GateModel {
+  version: 1;
+  config: FeatureConfig;
+  /** Admit when P(decision) >= threshold. */
+  threshold: number;
+  bias: number;
+  weights: Record<string, number>;
+}
+
+function sigmoid(z: number): number {
+  return 1 / (1 + Math.exp(-z));
+}
+
+/** P(decision-bearing) for a feature map under a model. */
+export function predictProba(
+  model: GateModel,
+  feats: Map<number, number>,
+): number {
+  let z = model.bias;
+  for (const [idx, val] of feats) {
+    const w = model.weights[idx];
+    if (w) z += w * val;
+  }
+  return sigmoid(z);
+}
+
+export interface GateMetrics {
+  n: number;
+  accuracy: number;
+  precision: number;
+  recall: number;
+  f1: number;
+}
+
+/** Evaluate a model (or any predictor) against labeled, pre-featurized examples. */
+export function evaluateGate(
+  model: GateModel,
+  examples: Array<{ feats: Map<number, number>; label: 0 | 1 }>,
+): GateMetrics {
+  let tp = 0;
+  let fp = 0;
+  let fn = 0;
+  let correct = 0;
+  for (const ex of examples) {
+    const pred = predictProba(model, ex.feats) >= model.threshold ? 1 : 0;
+    if (pred === ex.label) correct += 1;
+    if (pred === 1 && ex.label === 1) tp += 1;
+    else if (pred === 1 && ex.label === 0) fp += 1;
+    else if (pred === 0 && ex.label === 1) fn += 1;
+  }
+  const precision = tp + fp > 0 ? tp / (tp + fp) : 0;
+  const recall = tp + fn > 0 ? tp / (tp + fn) : 0;
+  const f1 =
+    precision + recall > 0
+      ? (2 * precision * recall) / (precision + recall)
+      : 0;
+  return {
+    n: examples.length,
+    accuracy: examples.length > 0 ? correct / examples.length : 0,
+    precision,
+    recall,
+    f1,
+  };
+}
+
+/**
+ * Layer-1 classifier backed by a trained {@link GateModel}. Drop-in replacement
+ * for HeuristicDecisionClassifier — same interface, so the capture pipeline is
+ * unchanged. Featurizes a commit identically to training and admits when the
+ * predicted probability clears the model's threshold.
+ */
+export class TrainedDecisionClassifier implements DecisionClassifier {
+  constructor(private readonly model: GateModel) {}
+
+  /** Build from parsed JSON (a model artifact), validating the shape. */
+  static fromJson(raw: unknown): TrainedDecisionClassifier {
+    const m = raw as Partial<GateModel>;
+    if (
+      !m ||
+      m.version !== 1 ||
+      typeof m.bias !== 'number' ||
+      typeof m.threshold !== 'number' ||
+      typeof m.weights !== 'object' ||
+      m.weights === null ||
+      !m.config ||
+      typeof m.config.dim !== 'number'
+    ) {
+      throw new Error('invalid gate model JSON');
+    }
+    return new TrainedDecisionClassifier(m as GateModel);
+  }
+
+  classify(commit: CommitInput): Layer1Verdict {
+    const signals = parseCommitSignals(commit);
+    const p = predictProba(
+      this.model,
+      featurize(commitText(commit), signals, this.model.config ?? DEFAULT_FEATURE_CONFIG),
+    );
+    return {
+      likelyDecision: p >= this.model.threshold,
+      reason: `trained gate p=${p.toFixed(3)} (thr ${this.model.threshold})`,
+      signals,
+    };
+  }
+}

--- a/src/code-memory/capture/gate-features.ts
+++ b/src/code-memory/capture/gate-features.ts
@@ -1,0 +1,88 @@
+import type { CommitInput, Layer1Signals } from './types';
+import { parseCommitSignals } from './commit-signals';
+import { commitText } from './silver-dataset';
+
+/**
+ * Code-memory track C — feature extraction for the trained Layer-1 gate.
+ * (docs/code-memory/distillation-dataset.md)
+ *
+ * SINGLE SOURCE OF TRUTH for features, shared by the trainer and the serving
+ * classifier — train-time and serve-time features MUST match. Pure, zero-dep:
+ * the whole point of the Layer-1 gate is to run client-side (CI / git hook) with
+ * no ML runtime. We use the hashing trick (no stored vocabulary) over token
+ * n-grams of the commit text PLUS the deterministic commit signals the heuristic
+ * already parses, so the linear student subsumes the heuristic's knowledge.
+ */
+
+export interface FeatureConfig {
+  /** Hashing space size — MUST be a power of two (bucket = hash & (dim-1)). */
+  dim: number;
+  /** Max token n-gram length (1 = unigrams, 2 = uni+bigrams). */
+  ngram: number;
+}
+
+export const DEFAULT_FEATURE_CONFIG: FeatureConfig = { dim: 1 << 15, ngram: 2 };
+
+/** FNV-1a → bucket. Deterministic across runs/processes (no Math.random). */
+function hashToken(s: string, dim: number): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0) & (dim - 1);
+}
+
+function tokenize(text: string): string[] {
+  return text.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
+}
+
+/** Structured features from the deterministic signals, prefixed with `§` so they
+ *  live in the same hashed space as text tokens without colliding with prose. */
+function structuredFeatures(signals: Layer1Signals): string[] {
+  const f: string[] = [];
+  if (signals.conventionalType) f.push(`§type=${signals.conventionalType}`);
+  for (const k of Object.keys(signals.trailers)) f.push(`§trailer=${k}`);
+  for (const m of signals.rationaleMarkers) f.push(`§rat=${m}`);
+  f.push(`§bodybucket=${bodyBucket(signals.bodyLength)}`);
+  if (signals.issueRefs.length > 0) f.push('§hasissue');
+  return f;
+}
+
+function bodyBucket(len: number): string {
+  if (len === 0) return '0';
+  if (len < 80) return 's';
+  if (len < 400) return 'm';
+  return 'l';
+}
+
+/** Featurize raw text + signals into a sparse {bucket → count} map. */
+export function featurize(
+  text: string,
+  signals: Layer1Signals,
+  config: FeatureConfig = DEFAULT_FEATURE_CONFIG,
+): Map<number, number> {
+  const feats = new Map<number, number>();
+  const add = (tok: string) => {
+    const idx = hashToken(tok, config.dim);
+    feats.set(idx, (feats.get(idx) ?? 0) + 1);
+  };
+  const tokens = tokenize(text);
+  for (let i = 0; i < tokens.length; i++) {
+    add(tokens[i]);
+    if (config.ngram >= 2 && i + 1 < tokens.length) {
+      add(`${tokens[i]} ${tokens[i + 1]}`);
+    }
+  }
+  for (const s of structuredFeatures(signals)) add(s);
+  return feats;
+}
+
+/** Featurize a commit exactly as the serving gate sees it (message + PR body +
+ *  parsed signals) — the bridge used by TrainedDecisionClassifier. */
+export function featurizeCommit(
+  commit: CommitInput,
+  config?: FeatureConfig,
+): Map<number, number> {
+  return featurize(commitText(commit), parseCommitSignals(commit), config);
+}

--- a/src/code-memory/capture/gate-train.ts
+++ b/src/code-memory/capture/gate-train.ts
@@ -1,0 +1,94 @@
+import type { Layer1Signals } from './types';
+import {
+  DEFAULT_FEATURE_CONFIG,
+  featurize,
+  type FeatureConfig,
+} from './gate-features';
+import type { GateModel } from './gate-classifier';
+
+/**
+ * Code-memory track C — train the Layer-1 gate (logistic regression, SGD).
+ * (docs/code-memory/distillation-dataset.md)
+ *
+ * Pure + deterministic (seeded PRNG shuffle) so training is reproducible and
+ * unit-testable offline. Trains on the silver labels the harness distilled from
+ * the Layer-2 teacher; the resulting {@link GateModel} serves behind
+ * TrainedDecisionClassifier.
+ */
+
+export interface TrainExample {
+  text: string;
+  signals: Layer1Signals;
+  label: 0 | 1;
+}
+
+export interface TrainOptions {
+  config?: FeatureConfig;
+  epochs?: number;
+  learningRate?: number;
+  l2?: number;
+  threshold?: number;
+  seed?: number;
+  /** Drop weights with |w| below this after training to shrink the artifact. */
+  pruneBelow?: number;
+}
+
+/** Deterministic PRNG (mulberry32) — reproducible shuffles without Math.random. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffle<T>(arr: T[], rng: () => number): void {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+export function trainGate(
+  examples: TrainExample[],
+  opts: TrainOptions = {},
+): GateModel {
+  const config = opts.config ?? DEFAULT_FEATURE_CONFIG;
+  const epochs = opts.epochs ?? 25;
+  const lr = opts.learningRate ?? 0.1;
+  const l2 = opts.l2 ?? 1e-4;
+  const threshold = opts.threshold ?? 0.5;
+  const pruneBelow = opts.pruneBelow ?? 1e-5;
+  const rng = mulberry32(opts.seed ?? 42);
+
+  const feats = examples.map((e) => featurize(e.text, e.signals, config));
+  const weights = new Map<number, number>();
+  let bias = 0;
+  const order = examples.map((_, i) => i);
+
+  for (let epoch = 0; epoch < epochs; epoch++) {
+    shuffle(order, rng);
+    for (const i of order) {
+      const f = feats[i];
+      const y = examples[i].label;
+      let z = bias;
+      for (const [k, v] of f) z += (weights.get(k) ?? 0) * v;
+      const p = 1 / (1 + Math.exp(-z));
+      const g = p - y; // dLoss/dz for logistic loss
+      bias -= lr * g;
+      for (const [k, v] of f) {
+        const w = weights.get(k) ?? 0;
+        weights.set(k, w - lr * (g * v + l2 * w));
+      }
+    }
+  }
+
+  const sparse: Record<string, number> = {};
+  for (const [k, w] of weights) {
+    if (Math.abs(w) >= pruneBelow) sparse[k] = w;
+  }
+  return { version: 1, config, threshold, bias, weights: sparse };
+}

--- a/test/decision-gate.unit-spec.ts
+++ b/test/decision-gate.unit-spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Code-memory track C — train + serve the Layer-1 decision gate. Fully offline:
+ * synthetic separable data, deterministic training, and the serving classifier
+ * behind the same DecisionClassifier seam as the heuristic.
+ */
+import { trainGate } from '../src/code-memory/capture/gate-train';
+import {
+  TrainedDecisionClassifier,
+  evaluateGate,
+  predictProba,
+  type GateModel,
+} from '../src/code-memory/capture/gate-classifier';
+import { featurize } from '../src/code-memory/capture/gate-features';
+import { parseCommitSignals } from '../src/code-memory/capture/commit-signals';
+import type { CommitInput } from '../src/code-memory/capture/types';
+
+function commit(message: string): CommitInput {
+  return {
+    sha: message.slice(0, 6),
+    message,
+    changedFiles: ['src/x.ts'],
+    authorDate: '2026-07-07T00:00:00Z',
+  };
+}
+
+// Decision-bearing (rationale/decision/invariant/gotcha prose) vs noise.
+const POSITIVE = [
+  'refactor: split module because the 21 args drifted between call-sites',
+  'feat: gateway so that facts resolve through one path and stay consistent',
+  'fix: guard the loop to avoid a race that otherwise corrupts state',
+  'perf: cache the snapshot instead of recomputing to prevent cold-start tax',
+  'refactor: decided to invert control so tenants cannot leak across dbs',
+  'fix: invariant — always export from the global module otherwise DI fails',
+  'feat: chose ed25519 because it needs no dependency and proves authorship',
+  'refactor: gotcha — pnpm test double-dash does not work, use testPathPattern',
+];
+const NEGATIVE = [
+  'chore: bump deps',
+  'style: run prettier',
+  'docs: fix typo in readme',
+  'ci: update workflow file',
+  'build: bump version to 1.2.3',
+  'test: add missing semicolon',
+  'chore: update lockfile',
+  'style: reformat imports',
+];
+
+function dataset(): Array<{
+  text: string;
+  signals: ReturnType<typeof parseCommitSignals>;
+  label: 0 | 1;
+}> {
+  const rows: Array<{ text: string; signals: any; label: 0 | 1 }> = [];
+  for (const m of POSITIVE) {
+    const c = commit(m);
+    rows.push({ text: m, signals: parseCommitSignals(c), label: 1 });
+  }
+  for (const m of NEGATIVE) {
+    const c = commit(m);
+    rows.push({ text: m, signals: parseCommitSignals(c), label: 0 });
+  }
+  return rows;
+}
+
+describe('trainGate + evaluateGate', () => {
+  it('fits the separable training set', () => {
+    const rows = dataset();
+    const model = trainGate(rows, { epochs: 40, seed: 1 });
+    const feats = rows.map((r) => ({
+      feats: featurize(r.text, r.signals, model.config),
+      label: r.label,
+    }));
+    const m = evaluateGate(model, feats);
+    expect(m.accuracy).toBeGreaterThanOrEqual(0.9);
+    expect(m.f1).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('is reproducible for a fixed seed', () => {
+    const rows = dataset();
+    const a = trainGate(rows, { epochs: 20, seed: 7 });
+    const b = trainGate(rows, { epochs: 20, seed: 7 });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it('prunes near-zero weights from the artifact', () => {
+    const rows = dataset();
+    const model = trainGate(rows, { epochs: 20, seed: 1, pruneBelow: 1e-4 });
+    for (const w of Object.values(model.weights)) {
+      expect(Math.abs(w)).toBeGreaterThanOrEqual(1e-4);
+    }
+  });
+});
+
+describe('TrainedDecisionClassifier', () => {
+  it('admits a decision-bearing commit and rejects noise', () => {
+    const model = trainGate(dataset(), { epochs: 40, seed: 1 });
+    const gate = new TrainedDecisionClassifier(model);
+    const pos = gate.classify(
+      commit('refactor: split it because the args drifted between call-sites'),
+    );
+    const neg = gate.classify(commit('chore: bump deps'));
+    expect(pos.likelyDecision).toBe(true);
+    expect(neg.likelyDecision).toBe(false);
+    expect(pos.reason).toMatch(/trained gate p=/);
+    expect(pos.signals).toBeDefined();
+  });
+
+  it('round-trips through JSON (fromJson gives identical predictions)', () => {
+    const model = trainGate(dataset(), { epochs: 20, seed: 3 });
+    const restored = TrainedDecisionClassifier.fromJson(
+      JSON.parse(JSON.stringify(model)),
+    );
+    const c = commit('feat: gateway so that facts resolve through one path');
+    const before = predictProba(model, featurize(c.message, parseCommitSignals(c), model.config));
+    const after = restored.classify(c);
+    expect(after.likelyDecision).toBe(before >= model.threshold);
+  });
+
+  it('rejects an invalid model JSON', () => {
+    expect(() => TrainedDecisionClassifier.fromJson({ version: 2 })).toThrow(
+      /invalid gate model/,
+    );
+    expect(() =>
+      TrainedDecisionClassifier.fromJson({ version: 1, bias: 0 } as Partial<GateModel>),
+    ).toThrow(/invalid gate model/);
+  });
+});

--- a/test/gate-features.unit-spec.ts
+++ b/test/gate-features.unit-spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Code-memory track C — feature extraction for the trained gate. Deterministic,
+ * shared by trainer + serving classifier (train/serve features must match).
+ */
+import {
+  featurize,
+  featurizeCommit,
+  DEFAULT_FEATURE_CONFIG,
+} from '../src/code-memory/capture/gate-features';
+import { parseCommitSignals } from '../src/code-memory/capture/commit-signals';
+import type { CommitInput } from '../src/code-memory/capture/types';
+
+function commit(message: string): CommitInput {
+  return {
+    sha: 'x',
+    message,
+    changedFiles: ['src/x.ts'],
+    authorDate: '2026-07-07T00:00:00Z',
+  };
+}
+
+describe('featurize', () => {
+  it('is deterministic for the same input', () => {
+    const c = commit('feat: x\n\nwe did this because it avoids drift');
+    const a = featurizeCommit(c);
+    const b = featurizeCommit(c);
+    expect([...a.entries()].sort()).toEqual([...b.entries()].sort());
+  });
+
+  it('changes when a rationale signal appears (structured features count)', () => {
+    const plain = featurizeCommit(commit('refactor: rename the internal handler'));
+    const withWhy = featurizeCommit(
+      commit('refactor: rename the internal handler because it avoids drift'),
+    );
+    expect([...plain.entries()].sort()).not.toEqual([...withWhy.entries()].sort());
+  });
+
+  it('emits more features with bigrams than unigrams only', () => {
+    const text = 'split the module per phase';
+    const signals = parseCommitSignals(commit(text));
+    const uni = featurize(text, signals, { dim: 1 << 14, ngram: 1 });
+    const bi = featurize(text, signals, { dim: 1 << 14, ngram: 2 });
+    expect(bi.size).toBeGreaterThan(uni.size);
+  });
+
+  it('buckets into the configured power-of-two space', () => {
+    const feats = featurize('hello world', parseCommitSignals(commit('hello world')), {
+      dim: 1 << 10,
+      ngram: 2,
+    });
+    for (const idx of feats.keys()) {
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(1 << 10);
+    }
+    expect(DEFAULT_FEATURE_CONFIG.dim).toBe(1 << 15);
+  });
+});


### PR DESCRIPTION
## Track C — from silver labels to a served, trained gate

Completes track C's code path. The harness (#101) distils silver labels from the Layer-2 teacher; this PR **trains a cheap student** on them and **serves it** behind the same `DecisionClassifier` seam — the capture pipeline is unchanged.

### Why a linear student (not BiLSTM/DistilBERT)
Deliberate: the Layer-1 gate runs **client-side with zero ML runtime**, the input is short commit text, and a **logistic regression over hashed n-grams + the deterministic commit signals** trains in seconds and serialises to a tiny sparse JSON. A DistilBERT/BiLSTM via ONNX can replace it behind the *same seam* if metrics ever demand — nothing else changes. Named honestly in code + docs (no overclaim of "BiLSTM").

### What's here
- **`gate-features.ts`** — `featurize` (hashing trick, no stored vocabulary) over token n-grams + structured signal features. **Single source of truth** shared by trainer and server so train/serve features always match.
- **`gate-train.ts`** — `trainGate` (SGD logistic regression, seeded/deterministic, prunes near-zero weights).
- **`gate-classifier.ts`** — `GateModel`, `predictProba`, `evaluateGate`, and `TrainedDecisionClassifier` (the `DecisionClassifier` impl: `p ≥ threshold`, reason carries the probability, signals preserved).
- **`pnpm train:decision-gate`** — reads the silver JSONL, holds out a sha-bucketed slice, prints **model-vs-heuristic** P/R/F1 against the teacher label (the payoff check), writes the portable model artifact.
- **`capture:decisions --gate-model <path>`** — swaps the trained gate in for the heuristic (omit = heuristic as before).
- **`docs/code-memory/distillation-dataset.md`** — extended to the full **dataset → train → serve** flow (commands, artifact, metrics, linear-vs-BiLSTM rationale).

### Tests
featurize determinism/ngram/bucketing; `trainGate` fits separable data + reproducible + pruned; `TrainedDecisionClassifier` admit/reject + JSON round-trip + invalid-model guard. Train CLI **smoke-run end-to-end offline** (96-row synthetic corpus → model artifact, model F1 100 vs heuristic F1 0 — the heuristic only reads the body, the model reads all text, exactly the false-negative distillation recovers).

**805 unit** · tsc · lint (max-params=3, complexity=25). No server/module/migration change → e2e/jobs (158/9) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)