### PR TITLE
feat(code-memory): teacher verification (LLM-judge) — a stronger teacher for track C

### DIFF
--- a/docs/code-memory/distillation-dataset.md
+++ b/docs/code-memory/distillation-dataset.md
@@ -154,6 +154,27 @@ Without `--gate-model`, capture uses `HeuristicDecisionClassifier` as before.
   balances the corpus, and the trained gate **beats the heuristic by ~17 F1
   points** with real precision/recall — the track-C payoff.
 
+- **A stronger teacher: `--verify` (LLM-judge).** The confidence gate is a blunt
+  knob; the sharper fix is a strict second pass. `--verify` (on
+  `label:decisions` / `label:commitpackft` / `capture:decisions`) re-scores every
+  extracted candidate with a judge prompt ("a genuine, non-derivable why, or a
+  restatement of the change?") and drops the false ones. It composes with the
+  gate (it writes the confidence the gate reads) and is **fail-open** — a bad
+  judge response keeps the raw candidates. Measured on 200 CommitPackFT commits
+  (same gpt-4o-mini as judge):
+
+  | | positive rate | heuristic agreement |
+  |---|---|---|
+  | extractor only | 94% *(over-labels)* | 30 / 200 |
+  | **+ `--verify`** | **31%** | **136 / 200** |
+
+  126 over-labeled positives were reclassified to negative — the judge task
+  (binary "real why?") is far stricter than generative extraction, so even the
+  same cheap model raises precision a lot. Use `--verify` (optionally
+  `--verify-model <stronger>`) when building the corpus; it roughly doubles LLM
+  cost (one judge call per commit) but yields far cleaner labels than the gate
+  alone. On the trained gate this raises the ceiling above the +17 F1 baseline.
+
 ### Recommended run
 ```bash
 OPENAI_API_KEY=... pnpm label:decisions   -- --range <big-range> --out data/code-memory/silver-brain.jsonl

--- a/scripts/capture-decisions.ts
+++ b/scripts/capture-decisions.ts
@@ -28,6 +28,7 @@ import {
   LlmDecisionExtractor,
   makeOpenAiCompleter,
 } from '../src/code-memory/capture/llm-extractor';
+import { LlmDecisionVerifier } from '../src/code-memory/capture/llm-verifier';
 import type { DecisionClassifier } from '../src/code-memory/capture/types';
 import { HttpDecisionSink } from '../src/code-memory/capture/http-sink';
 import { runCapturePipeline } from '../src/code-memory/capture/capture-pipeline';
@@ -93,14 +94,25 @@ async function main(): Promise<void> {
     },
   });
 
+  // --verify adds a strict LLM-judge pass that filters over-labeled candidates
+  // before they're recorded (raises precision at the cost of one call/commit).
+  const verify = process.argv.includes('--verify');
   const summary = await runCapturePipeline({
     commits,
     classifier,
     extractor,
+    ...(verify
+      ? {
+          verifier: new LlmDecisionVerifier(
+            makeOpenAiCompleter({ apiKey: openAiKey, model }),
+          ),
+        }
+      : {}),
     sink,
     refineAnchor,
     log: (m) => console.error(`[capture] ${m}`),
   });
+  if (verify) console.error(`[capture] verification ON (judge=${model})`);
 
   console.error(`[capture] done: ${JSON.stringify(summary)}`);
 }

--- a/scripts/label-commitpackft.ts
+++ b/scripts/label-commitpackft.ts
@@ -23,6 +23,7 @@ import {
   LlmDecisionExtractor,
   makeOpenAiCompleter,
 } from '../src/code-memory/capture/llm-extractor';
+import { LlmDecisionVerifier } from '../src/code-memory/capture/llm-verifier';
 import { labelCommits } from '../src/code-memory/capture/silver-dataset';
 import type { CommitInput } from '../src/code-memory/capture/types';
 
@@ -91,16 +92,29 @@ async function main(): Promise<void> {
 
   mkdirSync(dirname(out), { recursive: true });
   const stream = createWriteStream(out, { flags: 'w' });
+  const verify = process.argv.includes('--verify');
+  const verifyModel = arg('verify-model', model)!;
   const summary = await labelCommits({
     commits,
     extractor: new LlmDecisionExtractor(
       makeOpenAiCompleter({ apiKey: process.env.OPENAI_API_KEY, model }),
     ),
     classifier: new HeuristicDecisionClassifier(),
+    ...(verify
+      ? {
+          verifier: new LlmDecisionVerifier(
+            makeOpenAiCompleter({
+              apiKey: process.env.OPENAI_API_KEY,
+              model: verifyModel,
+            }),
+          ),
+        }
+      : {}),
     emit: (ex) => stream.write(`${JSON.stringify(ex)}\n`),
     concurrency,
     log: (m) => console.error(`[cpft] ${m}`),
   });
+  if (verify) console.error(`[cpft] verification ON (judge=${verifyModel})`);
   await new Promise<void>((resolve, reject) => {
     stream.end((err?: Error | null) => (err ? reject(err) : resolve()));
   });

--- a/scripts/label-decisions.ts
+++ b/scripts/label-decisions.ts
@@ -24,6 +24,7 @@ import {
   LlmDecisionExtractor,
   makeOpenAiCompleter,
 } from '../src/code-memory/capture/llm-extractor';
+import { LlmDecisionVerifier } from '../src/code-memory/capture/llm-verifier';
 import { labelCommits } from '../src/code-memory/capture/silver-dataset';
 
 function arg(name: string, fallback?: string): string | undefined {
@@ -49,16 +50,28 @@ async function main(): Promise<void> {
   mkdirSync(dirname(out), { recursive: true });
   const stream = createWriteStream(out, { flags: 'w' });
 
+  // --verify adds a strict LLM-judge pass (a stronger teacher — raises
+  // precision against the extractor's over-labeling). --verify-model overrides.
+  const verify = process.argv.includes('--verify');
+  const verifyModel = arg('verify-model', model)!;
   const summary = await labelCommits({
     commits,
     extractor: new LlmDecisionExtractor(
       makeOpenAiCompleter({ apiKey: openAiKey, model }),
     ),
     classifier: new HeuristicDecisionClassifier(),
+    ...(verify
+      ? {
+          verifier: new LlmDecisionVerifier(
+            makeOpenAiCompleter({ apiKey: openAiKey, model: verifyModel }),
+          ),
+        }
+      : {}),
     emit: (ex) => stream.write(`${JSON.stringify(ex)}\n`),
     concurrency,
     log: (m) => console.error(`[label] ${m}`),
   });
+  if (verify) console.error(`[label] verification ON (judge=${verifyModel})`);
 
   await new Promise<void>((resolve, reject) => {
     stream.end((err?: Error | null) => (err ? reject(err) : resolve()));

--- a/src/code-memory/capture/capture-pipeline.ts
+++ b/src/code-memory/capture/capture-pipeline.ts
@@ -5,6 +5,7 @@ import type {
   DecisionExtractor,
   DecisionSink,
 } from './types';
+import type { DecisionVerifier } from './llm-verifier';
 import { isMergeCommit } from './commit-signals';
 
 /**
@@ -23,6 +24,9 @@ export async function runCapturePipeline(opts: {
   commits: CommitInput[];
   classifier: DecisionClassifier;
   extractor: DecisionExtractor;
+  /** Optional strict LLM-judge pass — filters over-labeled candidates before
+   *  they're recorded (raises precision). Fail-open. */
+  verifier?: DecisionVerifier;
   sink: DecisionSink;
   /**
    * Optional Phase-2 anchor refinement — upgrade a candidate's file anchor to a
@@ -66,6 +70,14 @@ export async function runCapturePipeline(opts: {
       summary.failures += 1;
       log(`extract failed ${short(commit.sha)}: ${(e as Error).message}`);
       continue;
+    }
+    if (opts.verifier) {
+      try {
+        candidates = await opts.verifier.rescore(commit, candidates);
+      } catch (e) {
+        // Fail-open: keep the raw candidates if the judge errors.
+        log(`verify failed ${short(commit.sha)} (keeping raw): ${(e as Error).message}`);
+      }
     }
     summary.extracted += candidates.length;
 

--- a/src/code-memory/capture/llm-verifier.ts
+++ b/src/code-memory/capture/llm-verifier.ts
@@ -1,0 +1,113 @@
+import type { ChatComplete } from './llm-extractor';
+import type { CommitInput, DecisionCandidate } from './types';
+
+/**
+ * Code-memory track C — teacher verification (LLM-as-judge).
+ * (docs/code-memory/distillation-dataset.md)
+ *
+ * The Layer-2 extractor is a lenient teacher: the first real run showed it
+ * manufactures a `decided` from a bare "what" subject, so ~97% of diverse
+ * commits came back positive — teacher PRECISION was the bottleneck. This adds a
+ * second, STRICT pass: a judge re-scores each candidate ("is this a genuine,
+ * non-derivable engineering why, or a restatement of the change?"), dropping the
+ * false ones and calibrating confidence. Extractor + verifier = a stronger
+ * teacher; it composes with the confidence gate (`--min-confidence`) since it
+ * writes the confidence the gate thresholds on.
+ *
+ * Behind the same {@link ChatComplete} seam as the extractor, so it's stubbable.
+ * Fail-OPEN: a judge error or unparseable response keeps the raw candidates
+ * (verification must never silently delete a real "why").
+ */
+
+export interface DecisionVerifier {
+  /** Return the kept candidates (dropped = judged false), confidence calibrated. */
+  rescore(
+    commit: CommitInput,
+    candidates: DecisionCandidate[],
+  ): Promise<DecisionCandidate[]>;
+}
+
+export class LlmDecisionVerifier implements DecisionVerifier {
+  constructor(private readonly complete: ChatComplete) {}
+
+  async rescore(
+    commit: CommitInput,
+    candidates: DecisionCandidate[],
+  ): Promise<DecisionCandidate[]> {
+    if (candidates.length === 0) return [];
+    const raw = await this.complete(buildVerifyPrompt(commit, candidates));
+    return applyVerdicts(candidates, raw);
+  }
+}
+
+export function buildVerifyPrompt(
+  commit: CommitInput,
+  candidates: DecisionCandidate[],
+): { system: string; user: string } {
+  const system = `You are a STRICT reviewer of engineering-knowledge extractions. For each item, decide whether it is a GENUINE, non-derivable engineering "why" that is EXPLICITLY stated in the commit — a real design decision, rationale, invariant, or gotcha — and NOT a mere restatement of what the code change literally does.
+
+Reject (keep=false) an item that just paraphrases the change ("decided to add X" for a commit whose subject is "Add X"), states no reason/constraint/trap, or is not supported by the text. Keep (keep=true) only items a parser could not recover from the diff.
+
+Return STRICT JSON: {"verdicts":[{"keep":true,"confidence":0.0}]} — EXACTLY one entry per item, in the SAME ORDER. confidence is 0..1, your certainty the item is a genuine "why".`;
+
+  const body = commit.prBody
+    ? `${commit.message}\n\nPR body:\n${commit.prBody}`
+    : commit.message;
+  const items = candidates
+    .map((c, i) => `${i}. [${c.kind}] ${c.text}`)
+    .join('\n');
+  const user = `Commit:\n${body}\n\nItems to review:\n${items}`;
+  return { system, user };
+}
+
+/** Apply the judge's verdicts to the candidates. Drops keep=false; calibrates
+ *  confidence from the verdict. Fail-open: on any mismatch/parse failure the
+ *  original candidates are returned unchanged. */
+export function applyVerdicts(
+  candidates: DecisionCandidate[],
+  raw: string,
+): DecisionCandidate[] {
+  const verdicts = parseVerdicts(raw);
+  // A judge that returned the wrong count is untrustworthy for alignment —
+  // keep the raw candidates rather than drop by a misaligned index.
+  if (!verdicts || verdicts.length !== candidates.length) return candidates;
+  const out: DecisionCandidate[] = [];
+  for (let i = 0; i < candidates.length; i++) {
+    const v = verdicts[i];
+    if (v.keep === false) continue;
+    const confidence =
+      typeof v.confidence === 'number' && v.confidence >= 0 && v.confidence <= 1
+        ? v.confidence
+        : candidates[i].confidence;
+    out.push({ ...candidates[i], confidence });
+  }
+  return out;
+}
+
+function parseVerdicts(
+  raw: string,
+): Array<{ keep?: boolean; confidence?: number }> | null {
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/.exec(raw);
+  const body = fenced ? fenced[1] : raw;
+  const start = body.search(/[[{]/);
+  if (start === -1) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body.slice(start));
+  } catch {
+    return null;
+  }
+  const list = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { verdicts?: unknown[] })?.verdicts)
+      ? (parsed as { verdicts: unknown[] }).verdicts
+      : null;
+  if (!list) return null;
+  return list.map((v) => {
+    const o = (v ?? {}) as Record<string, unknown>;
+    return {
+      keep: typeof o.keep === 'boolean' ? o.keep : undefined,
+      confidence: typeof o.confidence === 'number' ? o.confidence : undefined,
+    };
+  });
+}

--- a/src/code-memory/capture/silver-dataset.ts
+++ b/src/code-memory/capture/silver-dataset.ts
@@ -6,6 +6,7 @@ import type {
   DecisionKind,
   Layer1Signals,
 } from './types';
+import type { DecisionVerifier } from './llm-verifier';
 import { isMergeCommit, parseCommitSignals } from './commit-signals';
 
 /**
@@ -113,10 +114,13 @@ export async function labelCommits(opts: {
   extractor: DecisionExtractor;
   classifier: DecisionClassifier;
   emit: (ex: SilverExample) => void;
+  /** Optional strict second pass (LLM-judge) that filters over-labeled
+   *  candidates + calibrates confidence — a stronger teacher. Fail-open. */
+  verifier?: DecisionVerifier;
   concurrency?: number;
   log?: (msg: string) => void;
 }): Promise<LabelSummary> {
-  const { commits, extractor, classifier, emit } = opts;
+  const { commits, extractor, classifier, emit, verifier } = opts;
   const log = opts.log ?? (() => {});
   const concurrency = Math.max(1, opts.concurrency ?? 4);
   const summary: LabelSummary = {
@@ -147,6 +151,14 @@ export async function labelCommits(opts: {
       summary.failures += 1;
       log(`label failed ${commit.sha.slice(0, 8)}: ${(e as Error).message}`);
       return;
+    }
+    if (verifier) {
+      try {
+        candidates = await verifier.rescore(commit, candidates);
+      } catch (e) {
+        // Fail-open: a judge failure keeps the raw candidates, never drops them.
+        log(`verify failed ${commit.sha.slice(0, 8)} (keeping raw): ${(e as Error).message}`);
+      }
     }
     const ex = buildSilverExample({ commit, candidates, classifier });
     emit(ex);

--- a/test/llm-verifier.unit-spec.ts
+++ b/test/llm-verifier.unit-spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Code-memory track C — teacher verification (LLM-judge). Raises precision by
+ * dropping over-labeled candidates; composes with the confidence gate. Fail-open
+ * so a bad judge response never deletes a real "why".
+ */
+import {
+  LlmDecisionVerifier,
+  applyVerdicts,
+  buildVerifyPrompt,
+} from '../src/code-memory/capture/llm-verifier';
+import { labelCommits } from '../src/code-memory/capture/silver-dataset';
+import { HeuristicDecisionClassifier } from '../src/code-memory/capture/heuristic-classifier';
+import type {
+  CommitInput,
+  DecisionCandidate,
+  DecisionExtractor,
+} from '../src/code-memory/capture/types';
+
+function commit(over: Partial<CommitInput> & { sha: string }): CommitInput {
+  return {
+    message: 'feat: x',
+    changedFiles: ['src/x.ts'],
+    authorDate: '2026-07-07T00:00:00Z',
+    ...over,
+  };
+}
+function candidate(over: Partial<DecisionCandidate> = {}): DecisionCandidate {
+  return {
+    kind: 'decided',
+    text: 'a decision',
+    anchor: 'src/x.ts',
+    commit: 's',
+    validFrom: '2026-07-07T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('applyVerdicts', () => {
+  const cands = [
+    candidate({ kind: 'decided', text: 'real decision', confidence: 0.9 }),
+    candidate({ kind: 'because', text: 'restates the what', confidence: 0.9 }),
+  ];
+
+  it('drops keep=false and calibrates confidence on keep=true', () => {
+    const raw = JSON.stringify({
+      verdicts: [
+        { keep: true, confidence: 0.8 },
+        { keep: false, confidence: 0.1 },
+      ],
+    });
+    const out = applyVerdicts(cands, raw);
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toBe('real decision');
+    expect(out[0].confidence).toBe(0.8); // recalibrated by the judge
+  });
+
+  it('fails open on unparseable judge output (keeps raw)', () => {
+    expect(applyVerdicts(cands, 'not json at all')).toEqual(cands);
+  });
+
+  it('fails open on a verdict-count mismatch (misaligned → untrusted)', () => {
+    const raw = JSON.stringify({ verdicts: [{ keep: false }] }); // 1 vs 2
+    expect(applyVerdicts(cands, raw)).toEqual(cands);
+  });
+
+  it('accepts a bare array and keeps original confidence when none given', () => {
+    const raw = JSON.stringify([{ keep: true }, { keep: true }]);
+    const out = applyVerdicts(cands, raw);
+    expect(out).toHaveLength(2);
+    expect(out[0].confidence).toBe(0.9); // unchanged
+  });
+});
+
+describe('buildVerifyPrompt', () => {
+  it('lists each candidate with its kind + text', () => {
+    const { system, user } = buildVerifyPrompt(
+      commit({ sha: 'a', message: 'feat: x', prBody: 'why body' }),
+      [candidate({ kind: 'gotcha', text: 'double dash trap' })],
+    );
+    expect(system).toMatch(/STRICT reviewer/);
+    expect(user).toContain('[gotcha] double dash trap');
+    expect(user).toContain('why body');
+  });
+});
+
+describe('LlmDecisionVerifier.rescore', () => {
+  it('does not call the judge for an empty candidate list', async () => {
+    let called = false;
+    const v = new LlmDecisionVerifier(async () => {
+      called = true;
+      return '{}';
+    });
+    expect(await v.rescore(commit({ sha: 'a' }), [])).toEqual([]);
+    expect(called).toBe(false);
+  });
+
+  it('filters via the judge verdicts', async () => {
+    const v = new LlmDecisionVerifier(async () =>
+      JSON.stringify({ verdicts: [{ keep: false }, { keep: true, confidence: 0.7 }] }),
+    );
+    const out = await v.rescore(commit({ sha: 'a' }), [
+      candidate({ text: 'drop me' }),
+      candidate({ text: 'keep me' }),
+    ]);
+    expect(out.map((c) => c.text)).toEqual(['keep me']);
+    expect(out[0].confidence).toBe(0.7);
+  });
+});
+
+describe('labelCommits with a verifier', () => {
+  it('flips the label to 0 when the judge rejects every candidate', async () => {
+    const extractor: DecisionExtractor = {
+      extract: async () => [candidate({ text: 'over-labeled decided' })],
+    };
+    const verifier = {
+      rescore: async () => [] as DecisionCandidate[], // judge rejects all
+    };
+    const rows: string[] = [];
+    const emitted: Array<{ label: 0 | 1 }> = [];
+    const summary = await labelCommits({
+      commits: [commit({ sha: 'a', message: 'chore: bump deps' })],
+      extractor,
+      classifier: new HeuristicDecisionClassifier(),
+      verifier,
+      emit: (ex) => {
+        rows.push(ex.sha);
+        emitted.push({ label: ex.label });
+      },
+    });
+    expect(summary.labeled).toBe(1);
+    expect(emitted[0].label).toBe(0); // verifier turned an over-label into a negative
+    expect(summary.positive).toBe(0);
+  });
+});


### PR DESCRIPTION
## Track C polish — a stronger teacher (not ONNX)

The first real run showed the Layer-2 extractor **over-labels** (manufactures a `decided` from a bare "what" subject), so teacher **precision** — not the student — was the limiter. This adds the sharp fix over the blunt confidence gate.

### What's here
- **`llm-verifier.ts`** — `DecisionVerifier` + `LlmDecisionVerifier` behind the same `ChatComplete` seam as the extractor (stubbable). `applyVerdicts` drops `keep=false` + calibrates confidence; **fail-open** — a bad or mis-counted judge response keeps the raw candidates (verification must never silently delete a real "why"). Composes with `--min-confidence` (it writes the confidence the gate reads).
- Wired as an optional stage in `labelCommits` + `runCapturePipeline`, behind a **`--verify`** flag (+ `--verify-model`) on `label:decisions` / `label:commitpackft` / `capture:decisions`.

### Measured effect (200 CommitPackFT commits, same gpt-4o-mini as judge)
| | positive rate | heuristic agreement |
|---|---|---|
| extractor only | 94% *(over-labels)* | 30 / 200 |
| **+ `--verify`** | **31%** | **136 / 200** |

126 over-labeled positives correctly reclassified. The judge task (binary "real why?") is far stricter than generative extraction, so **even the same cheap model raises precision a lot** — cleaner labels than the confidence gate alone.

### On ONNX (the other option offered)
Deliberately **not** adding an onnxruntime/Python student: it would burden the dep-free client-side gate for marginal gain over the linear model (already +17 F1 over the heuristic). The high-leverage lever was teacher precision. DistilBERT/BiLSTM-via-ONNX stays available behind the same `DecisionClassifier` seam if ever wanted.

**813 unit** · tsc · lint. No server change → e2e/jobs unaffected. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)