### PR TITLE
feat(domain-packs): consume evalFixtures — run a pack's eval cases against the live extractor

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -178,5 +178,36 @@ pnpm pack:install  -- --brain-url $URL --registry real_estate[@0.2.0]  # brain:a
 pnpm registry:seed -- --brain-url $URL                   # publish all packs/*.json
 ```
 
-Still ahead: consuming `evalFixtures` at runtime (the same wiring as
-`extractionProfile`).
+## Eval fixtures (consumed)
+
+A pack may ship `evalFixtures` — small extraction test cases for its domain,
+now **consumed at runtime** (like `extractionProfile`):
+
+```jsonc
+"evalFixtures": [
+  {
+    "id": "zoning",
+    "text": "The parcel at 12 Elm St is zoned R-2.",
+    "expect": { "facts": [{ "predicate": "zoned_as", "objectIncludes": "R-2" }] }
+  }
+]
+```
+
+- `text` — the mention run through the LIVE extractor for the tenant (with the
+  pack's predicates + extractionProfile active).
+- `expect.facts[].predicate` — bare (`zoned_as`) resolves to the pack namespace
+  (`real_estate__zoned_as`); an already-namespaced id is used verbatim.
+  `objectIncludes` is an optional case-insensitive substring on the value.
+  `expect.minEntities` / `minFacts` are coarse thresholds.
+
+Flow: the manifest (already stored in `domain_pack` on install, or shipped for
+builtins) → `PackEvalService` runs each fixture through
+`ExtractorService.extract` → `scoreFixture` (pure) → a pass/fail report:
+
+```
+POST /v1/admin/packs/:packId/eval   (brain:admin)
+→ { packId, version, total, passed, results: [{ id, passed, failures[] }] }
+```
+
+`real_estate` ships three fixtures (zoning / valuation / tenure) as the
+demonstrator. Nothing forward-compat remains in the manifest.

--- a/packs/real-estate.pack.json
+++ b/packs/real-estate.pack.json
@@ -80,5 +80,46 @@
         "note": "property 'The warehouse' → real_estate__built_in='1998', real_estate__listed_at='$1.5M', real_estate__encumbered_by='easement'."
       }
     ]
-  }
+  },
+  "evalFixtures": [
+    {
+      "id": "zoning",
+      "description": "zoning code is extracted from a parcel mention",
+      "text": "The parcel at 12 Elm St is zoned R-2.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "zoned_as",
+            "objectIncludes": "R-2"
+          }
+        ]
+      }
+    },
+    {
+      "id": "valuation",
+      "description": "appraised value is captured verbatim with currency",
+      "text": "The property at 8 Oak Ave was appraised at $840,000.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "valued_at",
+            "objectIncludes": "$840,000"
+          }
+        ]
+      }
+    },
+    {
+      "id": "tenure",
+      "description": "ownership tenure is captured",
+      "text": "Unit 4B is held on a leasehold basis.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "tenure_type",
+            "objectIncludes": "leasehold"
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/src/admin/admin-packs.controller.ts
+++ b/src/admin/admin-packs.controller.ts
@@ -12,7 +12,8 @@ import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import type { AuthenticatedRequest } from '../auth/api-key.types';
 import { DomainPackInstallService } from './domain-pack-install.service';
 import { PackRegistryService } from '../registry/pack-registry.service';
-import type { DomainPackManifest } from '../ai/domain-packs';
+import { PackEvalService } from './pack-eval.service';
+import type { DomainPackManifest, PackEvalReport } from '../ai/domain-packs';
 import type {
   InstallPackResponse,
   PacksListResponse,
@@ -32,6 +33,7 @@ export class AdminPacksController {
   constructor(
     private readonly packs: DomainPackInstallService,
     private readonly registry: PackRegistryService,
+    private readonly packEval: PackEvalService,
   ) {}
 
   @Get()
@@ -72,6 +74,18 @@ export class AdminPacksController {
     return this.packs.install(req.brainAuth.companyId, manifest, {
       expectedChecksum: checksum,
     });
+  }
+
+  /** Run a pack's eval fixtures against the live extractor for this tenant —
+   *  scores whether extraction (with the pack's predicates + extractionProfile
+   *  active) still meets the pack's own expectations. */
+  @Post(':packId/eval')
+  @RequireScopes('brain:admin')
+  async eval(
+    @Req() req: AuthenticatedRequest,
+    @Param('packId') packId: string,
+  ): Promise<PackEvalReport> {
+    return this.packEval.run(req.brainAuth.companyId, packId);
   }
 
   @Delete(':packId')

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -31,6 +31,7 @@ import { AdminCodeMemoryController } from './admin-code-memory.controller';
 import { CodeMemoryModule } from '../code-memory/code-memory.module';
 import { RegistryModule } from '../registry/registry.module';
 import { DomainPackInstallService } from './domain-pack-install.service';
+import { PackEvalService } from './pack-eval.service';
 import { ScenarioRunnerService } from './scenario-runner.service';
 import { ScenarioWriteService } from './scenario-write.service';
 import { ScenarioLifecycleService } from './scenario-lifecycle.service';
@@ -84,6 +85,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     DemoPipelineService,
     DemoChatService,
     DomainPackInstallService,
+    PackEvalService,
     ScenarioRunnerService,
     // Scenario-runner phase services (max-params split):
     ScenarioWriteService,

--- a/src/admin/pack-eval.service.ts
+++ b/src/admin/pack-eval.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { ExtractorService } from '../ai/extractor.service';
+import {
+  BUILTIN_PACKS,
+  scoreFixture,
+  type DomainPackManifest,
+  type PackEvalReport,
+} from '../ai/domain-packs';
+
+/**
+ * Runs a Domain Pack's eval fixtures against the LIVE extractor for a tenant
+ * (docs/domain-packs.md). Consumes the manifest's `evalFixtures` — the same
+ * manifest that's already stored per-tenant (installed packs) or shipped
+ * (builtins). Each fixture's input text is run through the extractor (with the
+ * pack's predicates + extractionProfile active for the tenant) and scored
+ * against its expectations. Mirrors the extractionProfile wiring.
+ */
+@Injectable()
+export class PackEvalService {
+  private readonly logger = new Logger(PackEvalService.name);
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly extractor: ExtractorService,
+  ) {}
+
+  async run(companyId: string, packId: string): Promise<PackEvalReport> {
+    const manifest = await this.resolveManifest(companyId, packId);
+    if (!manifest) {
+      throw new NotFoundException(
+        `pack "${packId}" is not a builtin and is not installed for this tenant`,
+      );
+    }
+    const fixtures = manifest.evalFixtures ?? [];
+    const results = [];
+    for (const fixture of fixtures) {
+      const extraction = await this.extractor.extract(fixture.text, companyId);
+      results.push(scoreFixture(manifest.id, fixture, extraction));
+    }
+    const passed = results.filter((r) => r.passed).length;
+    this.logger.log(
+      `pack eval ${manifest.id} v${manifest.version} for ${companyId}: ${passed}/${results.length} passed`,
+    );
+    return {
+      packId: manifest.id,
+      version: manifest.version,
+      total: results.length,
+      passed,
+      results,
+    };
+  }
+
+  /** Builtin packs ship their manifest in-process; installed packs store it in
+   *  domain_pack. Prefer the builtin (globally seeded) then the tenant's row. */
+  private async resolveManifest(
+    companyId: string,
+    packId: string,
+  ): Promise<DomainPackManifest | null> {
+    const builtin = BUILTIN_PACKS.find((p) => p.id === packId);
+    if (builtin) return builtin;
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ manifest?: DomainPackManifest }>]>(
+        `SELECT manifest FROM domain_pack WHERE packId = $packId AND status = 'active' LIMIT 1`,
+        { packId },
+      );
+      const row = ((rows as Array<{ manifest?: DomainPackManifest }>) ?? [])[0];
+      return row?.manifest ?? null;
+    });
+  }
+}

--- a/src/ai/domain-packs/eval-fixture.ts
+++ b/src/ai/domain-packs/eval-fixture.ts
@@ -1,0 +1,105 @@
+import { composePredicateId, PACK_NAMESPACE_SEP } from './manifest';
+
+/**
+ * Domain Pack eval fixtures (docs/domain-packs.md). A pack may ship small,
+ * self-describing extraction test cases — an input text + what the extractor
+ * should surface for this pack's domain. Consumed at runtime: an operator runs
+ * `POST /v1/admin/packs/:packId/eval` to check the LIVE extractor (with the
+ * pack's predicates + extractionProfile active) still meets the pack's own
+ * expectations for this tenant. Mirrors how `extractionProfile` was wired:
+ * manifest → install → domain_pack → run + score.
+ */
+
+/** One expected fact a fixture asserts must surface. */
+export interface EvalFixtureExpectFact {
+  /** Predicate id. Bare (`zoned_as`) is resolved against the pack namespace
+   *  (`<packId>__zoned_as`); an already-namespaced id (contains `__`) is used
+   *  verbatim — so a fixture can also assert a core predicate. */
+  predicate: string;
+  /** Optional case-insensitive substring the extracted object must contain. */
+  objectIncludes?: string;
+}
+
+export interface EvalFixture {
+  /** Unique within the pack. */
+  id: string;
+  description?: string;
+  /** Input mention text run through the extractor. */
+  text: string;
+  expect: {
+    /** Each listed fact must appear in the extraction. */
+    facts?: EvalFixtureExpectFact[];
+    minEntities?: number;
+    minFacts?: number;
+  };
+}
+
+export interface EvalFixtureResult {
+  id: string;
+  passed: boolean;
+  /** Human-readable reasons a fixture failed (empty when passed). */
+  failures: string[];
+}
+
+export interface PackEvalReport {
+  packId: string;
+  version: string;
+  total: number;
+  passed: number;
+  results: EvalFixtureResult[];
+}
+
+/** Minimal shape of an extraction result the scorer needs (decoupled from the
+ *  extractor module so this stays a pure, dependency-light domain-packs util). */
+export interface ScorableExtraction {
+  entities: unknown[];
+  facts: Array<{ predicate: string; object: string }>;
+}
+
+/** Resolve a fixture predicate to its stored id. */
+function resolvePredicate(packId: string, predicate: string): string {
+  return predicate.includes(PACK_NAMESPACE_SEP)
+    ? predicate
+    : composePredicateId(packId, predicate);
+}
+
+/** Score one fixture against an extraction. Pure — the runtime service supplies
+ *  the extraction; this is unit-testable without the extractor/DB. */
+export function scoreFixture(
+  packId: string,
+  fixture: EvalFixture,
+  extraction: ScorableExtraction,
+): EvalFixtureResult {
+  const failures: string[] = [];
+  for (const want of fixture.expect.facts ?? []) {
+    const predicateId = resolvePredicate(packId, want.predicate);
+    const needle = want.objectIncludes?.toLowerCase();
+    const hit = extraction.facts.some(
+      (f) =>
+        f.predicate === predicateId &&
+        (needle === undefined || f.object.toLowerCase().includes(needle)),
+    );
+    if (!hit) {
+      failures.push(
+        `missing fact ${predicateId}${want.objectIncludes ? ` ~ "${want.objectIncludes}"` : ''}`,
+      );
+    }
+  }
+  if (
+    fixture.expect.minEntities !== undefined &&
+    extraction.entities.length < fixture.expect.minEntities
+  ) {
+    failures.push(
+      `expected >= ${fixture.expect.minEntities} entities, got ${extraction.entities.length}`,
+    );
+  }
+  if (
+    fixture.expect.minFacts !== undefined &&
+    extraction.facts.length < fixture.expect.minFacts
+  ) {
+    failures.push(
+      `expected >= ${fixture.expect.minFacts} facts, got ${extraction.facts.length}`,
+    );
+  }
+  return { id: fixture.id, passed: failures.length === 0, failures };
+}

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -29,6 +29,7 @@ export * from './validate';
 export * from './checksum';
 export * from './signature';
 export * from './semver';
+export * from './eval-fixture';
 export * from './code-memory.pack';
 // real-estate is a DISTRIBUTABLE pack (installed per-tenant at runtime), not a
 // builtin — exported for the JSON generator + tests, deliberately NOT added to

--- a/src/ai/domain-packs/manifest.ts
+++ b/src/ai/domain-packs/manifest.ts
@@ -52,10 +52,11 @@ export interface DomainPackManifest {
    */
   extractionProfile?: ExtractionProfile;
   /**
-   * Forward-compatible eval fixtures (docs/domain-packs.md). Carried in the
-   * manifest + stored on install; not yet consumed by the runtime.
+   * Domain eval fixtures (docs/domain-packs.md). CONSUMED at runtime: an
+   * operator runs `POST /v1/admin/packs/:packId/eval` to score the live
+   * extractor against these cases for a tenant. Typed as EvalFixture[].
    */
-  evalFixtures?: unknown[];
+  evalFixtures?: import('./eval-fixture').EvalFixture[];
   /** ed25519 signature (base64) over the canonical manifest sans this field. */
   signature?: string;
   /** Publisher id — the key in the tenant's trust store used to verify. */

--- a/src/ai/domain-packs/real-estate.pack.ts
+++ b/src/ai/domain-packs/real-estate.pack.ts
@@ -127,4 +127,24 @@ encumbrance, ALSO emit an edge to that party (e.g. Property —held_by→ Bank).
       },
     ],
   },
+  evalFixtures: [
+    {
+      id: 'zoning',
+      description: 'zoning code is extracted from a parcel mention',
+      text: 'The parcel at 12 Elm St is zoned R-2.',
+      expect: { facts: [{ predicate: 'zoned_as', objectIncludes: 'R-2' }] },
+    },
+    {
+      id: 'valuation',
+      description: 'appraised value is captured verbatim with currency',
+      text: 'The property at 8 Oak Ave was appraised at $840,000.',
+      expect: { facts: [{ predicate: 'valued_at', objectIncludes: '$840,000' }] },
+    },
+    {
+      id: 'tenure',
+      description: 'ownership tenure is captured',
+      text: 'Unit 4B is held on a leasehold basis.',
+      expect: { facts: [{ predicate: 'tenure_type', objectIncludes: 'leasehold' }] },
+    },
+  ],
 };

--- a/src/ai/domain-packs/validate.ts
+++ b/src/ai/domain-packs/validate.ts
@@ -48,6 +48,63 @@ export function validatePack(pack: DomainPackManifest): void {
   if (pack.extractionProfile !== undefined) {
     validateExtractionProfile(pack.id, pack.extractionProfile);
   }
+  if (pack.evalFixtures !== undefined) {
+    validateEvalFixtures(pack.id, pack.evalFixtures);
+  }
+}
+
+/** Validate a pack's eval fixtures (consumed by the eval runner, so a malformed
+ *  one is a boot/install-time error). Structural only. */
+function validateEvalFixtures(packId: string, fixtures: unknown): void {
+  if (!Array.isArray(fixtures)) {
+    throw new DomainPackError(`pack "${packId}" evalFixtures must be an array`);
+  }
+  const ids = new Set<string>();
+  for (const f of fixtures) {
+    const fx = f as { id?: unknown; text?: unknown; expect?: unknown };
+    if (typeof fx.id !== 'string' || !fx.id) {
+      throw new DomainPackError(
+        `pack "${packId}" evalFixtures entries need a non-empty string id`,
+      );
+    }
+    if (ids.has(fx.id)) {
+      throw new DomainPackError(
+        `pack "${packId}" evalFixtures has duplicate id "${fx.id}"`,
+      );
+    }
+    ids.add(fx.id);
+    if (typeof fx.text !== 'string' || !fx.text) {
+      throw new DomainPackError(
+        `pack "${packId}" evalFixture "${fx.id}" needs a non-empty text`,
+      );
+    }
+    if (
+      typeof fx.expect !== 'object' ||
+      fx.expect === null ||
+      Array.isArray(fx.expect)
+    ) {
+      throw new DomainPackError(
+        `pack "${packId}" evalFixture "${fx.id}" needs an expect object`,
+      );
+    }
+    const facts = (fx.expect as { facts?: unknown }).facts;
+    if (facts !== undefined) {
+      if (!Array.isArray(facts)) {
+        throw new DomainPackError(
+          `pack "${packId}" evalFixture "${fx.id}" expect.facts must be an array`,
+        );
+      }
+      for (const want of facts) {
+        if (
+          typeof (want as { predicate?: unknown })?.predicate !== 'string'
+        ) {
+          throw new DomainPackError(
+            `pack "${packId}" evalFixture "${fx.id}" expect.facts entries need a string predicate`,
+          );
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/test/contracts-admin-packs.unit-spec.ts
+++ b/test/contracts-admin-packs.unit-spec.ts
@@ -30,7 +30,8 @@ function makeController(): AdminPacksController {
       ]),
   } as unknown as DomainPackInstallService;
   const registry = {} as unknown as PackRegistryService;
-  return new AdminPacksController(svc, registry);
+  const packEval = {} as unknown as import('../src/admin/pack-eval.service').PackEvalService;
+  return new AdminPacksController(svc, registry, packEval);
 }
 
 describe('AdminPacksController.list() — wire contract', () => {

--- a/test/pack-eval-fixture.unit-spec.ts
+++ b/test/pack-eval-fixture.unit-spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Domain Pack eval fixtures — the pure scorer + manifest validation.
+ */
+import {
+  scoreFixture,
+  validatePack,
+  type EvalFixture,
+  type ScorableExtraction,
+} from '../src/ai/domain-packs';
+
+function extraction(
+  facts: Array<{ predicate: string; object: string }>,
+  entityCount = 1,
+): ScorableExtraction {
+  return { entities: Array(entityCount).fill({}), facts };
+}
+
+describe('scoreFixture', () => {
+  const fixture: EvalFixture = {
+    id: 'zoning',
+    text: 'The parcel at 12 Elm St is zoned R-2.',
+    expect: { facts: [{ predicate: 'zoned_as', objectIncludes: 'R-2' }] },
+  };
+
+  it('passes when a bare predicate resolves to the pack namespace and matches', () => {
+    const r = scoreFixture(
+      'real_estate',
+      fixture,
+      extraction([{ predicate: 'real_estate__zoned_as', object: 'R-2' }]),
+    );
+    expect(r.passed).toBe(true);
+    expect(r.failures).toEqual([]);
+  });
+
+  it('fails with a reason when the expected fact is absent', () => {
+    const r = scoreFixture(
+      'real_estate',
+      fixture,
+      extraction([{ predicate: 'real_estate__valued_at', object: '$1' }]),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.failures[0]).toMatch(/missing fact real_estate__zoned_as ~ "R-2"/);
+  });
+
+  it('respects objectIncludes (case-insensitive substring)', () => {
+    const r = scoreFixture(
+      'real_estate',
+      fixture,
+      extraction([{ predicate: 'real_estate__zoned_as', object: 'zoned r-2 residential' }]),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('uses an already-namespaced predicate verbatim (can assert core predicates)', () => {
+    const f: EvalFixture = {
+      id: 'core',
+      text: 'x',
+      expect: { facts: [{ predicate: 'name' }] }, // no __ but core — resolves to real_estate__name
+    };
+    // A bare non-pack predicate composes to the pack namespace, so a core
+    // assertion must be written fully-qualified:
+    const qualified: EvalFixture = {
+      id: 'core2',
+      text: 'x',
+      expect: { facts: [{ predicate: 'address' }] },
+    };
+    expect(
+      scoreFixture('real_estate', f, extraction([{ predicate: 'name', object: 'Bob' }]))
+        .passed,
+    ).toBe(false); // resolved to real_estate__name, not core name
+    expect(
+      scoreFixture(
+        'real_estate',
+        { ...qualified, expect: { facts: [{ predicate: 'core__address' }] } },
+        extraction([{ predicate: 'core__address', object: 'Berlin' }]),
+      ).passed,
+    ).toBe(true);
+  });
+
+  it('enforces minEntities / minFacts thresholds', () => {
+    const f: EvalFixture = { id: 't', text: 'x', expect: { minEntities: 2, minFacts: 1 } };
+    const r = scoreFixture('p', f, extraction([{ predicate: 'p__a', object: 'v' }], 1));
+    expect(r.passed).toBe(false);
+    expect(r.failures.some((x) => /entities/.test(x))).toBe(true);
+  });
+});
+
+describe('validatePack — evalFixtures', () => {
+  const base = {
+    id: 'demo',
+    version: '0.1.0',
+    description: 'd',
+    predicates: [
+      {
+        localId: 'thing',
+        displayLabel: 'thing',
+        description: 'x',
+        datatype: 'string' as const,
+        semantics: 'append_only' as const,
+        decayHalfLifeDays: null,
+        piiClass: 'none' as const,
+        status: 'active' as const,
+      },
+    ],
+  };
+  it('accepts well-formed fixtures', () => {
+    expect(() =>
+      validatePack({
+        ...base,
+        evalFixtures: [{ id: 'a', text: 't', expect: { facts: [{ predicate: 'thing' }] } }],
+      }),
+    ).not.toThrow();
+  });
+  it('rejects a fixture without an id', () => {
+    expect(() =>
+      validatePack({ ...base, evalFixtures: [{ text: 't', expect: {} } as never] }),
+    ).toThrow(/non-empty string id/);
+  });
+  it('rejects duplicate fixture ids', () => {
+    expect(() =>
+      validatePack({
+        ...base,
+        evalFixtures: [
+          { id: 'a', text: 't', expect: {} },
+          { id: 'a', text: 't2', expect: {} },
+        ],
+      }),
+    ).toThrow(/duplicate id/);
+  });
+  it('rejects a fact expectation without a string predicate', () => {
+    expect(() =>
+      validatePack({
+        ...base,
+        evalFixtures: [{ id: 'a', text: 't', expect: { facts: [{} as never] } }],
+      }),
+    ).toThrow(/string predicate/);
+  });
+});

--- a/test/pack-eval.e2e-spec.ts
+++ b/test/pack-eval.e2e-spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Domain Pack eval fixtures — end-to-end. Install the real_estate pack (which
+ * ships evalFixtures), then run `POST /v1/admin/packs/:id/eval` and assert the
+ * report. The extractor is the StubExtractor (AppFixture override), scripted to
+ * satisfy one fixture — proving manifest → install → run + score wiring.
+ */
+import { REAL_ESTATE_PACK } from '../src/ai/domain-packs';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+
+describe('/v1/admin/packs/:id/eval — pack eval fixtures (e2e)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    f = await createApp({
+      companyId: 'co_pack_eval_e2e',
+      scopes: ['brain:read', 'brain:write', 'brain:admin'],
+    });
+    await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: REAL_ESTATE_PACK });
+  });
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('scores the pack fixtures against the live extractor', async () => {
+    // Script the (stub) extractor to satisfy the `zoning` fixture only.
+    f.extractor.setScript({
+      entities: [{ name: '12 Elm St', type: 'location' }],
+      facts: [
+        {
+          entityIndex: 0,
+          predicate: 'real_estate__zoned_as',
+          object: 'R-2',
+          confidence: 0.9,
+        },
+      ],
+      edges: [],
+    });
+
+    const r = await f.http
+      .post('/v1/admin/packs/real_estate/eval')
+      .set(auth());
+    expect(r.status).toBe(201);
+    expect(r.body.packId).toBe('real_estate');
+    expect(r.body.total).toBe(REAL_ESTATE_PACK.evalFixtures!.length);
+    const zoning = r.body.results.find((x: any) => x.id === 'zoning');
+    expect(zoning.passed).toBe(true);
+    // The other fixtures expect different predicates the script doesn't emit.
+    expect(r.body.passed).toBe(1);
+    const valuation = r.body.results.find((x: any) => x.id === 'valuation');
+    expect(valuation.passed).toBe(false);
+    expect(valuation.failures[0]).toMatch(/missing fact real_estate__valued_at/);
+  });
+
+  it('404s for a pack that is neither builtin nor installed', async () => {
+    f.extractor.setScript(null);
+    const r = await f.http.post('/v1/admin/packs/no_such_pack/eval').set(auth());
+    expect(r.status).toBe(404);
+  });
+});

--- a/test/real-estate-pack.unit-spec.ts
+++ b/test/real-estate-pack.unit-spec.ts
@@ -47,6 +47,17 @@ describe('real-estate pack', () => {
     }
   });
 
+  it('ships eval fixtures with pack-local predicate expectations', () => {
+    const fx = REAL_ESTATE_PACK.evalFixtures;
+    expect(fx).toBeDefined();
+    expect(fx!.length).toBeGreaterThan(0);
+    for (const f of fx!) {
+      expect(typeof f.id).toBe('string');
+      expect(typeof f.text).toBe('string');
+    }
+    expect(fx!.some((f) => f.id === 'zoning')).toBe(true);
+  });
+
   it('is DISTRIBUTABLE — deliberately NOT a builtin pack', () => {
     // Builtins seed into every tenant; real-estate must be installed per-tenant
     // so its domain predicates don't pollute unrelated tenants' extraction.


### PR DESCRIPTION
## The last forward-compat manifest field, consumed (analog of B)

`evalFixtures` was stored-not-consumed; this wires it end-to-end exactly like `extractionProfile`: **manifest → install → `domain_pack` → run + score**.

### What's here
- **Typed** `evalFixtures?: EvalFixture[]` (was `unknown[]`); `validatePack` checks the shape (id/text/expect, unique ids, string predicates). New `src/ai/domain-packs/eval-fixture.ts` with the types + a **pure `scoreFixture`**: a bare predicate (`zoned_as`) resolves to the pack namespace (`real_estate__zoned_as`), an already-namespaced id is verbatim; `objectIncludes` substring; `minEntities`/`minFacts` thresholds.
- **`PackEvalService`** resolves the manifest (builtin, or the tenant's active `domain_pack` row) and runs each fixture's text through `ExtractorService.extract`, scoring pass/fail. **`POST /v1/admin/packs/:packId/eval`** (`brain:admin`) → `{ packId, version, total, passed, results: [{ id, passed, failures[] }] }`.
- **`real_estate`** ships 3 fixtures (zoning / valuation / tenure) as the demonstrator; `packs/real-estate.pack.json` regenerated + drift-guarded.

### Tests
`scoreFixture` (namespacing / objectIncludes / thresholds) + `validatePack` rejection (unit); install `real_estate` → `POST eval` with a scripted `StubExtractor`, asserting per-fixture pass/fail + a 404 for an unknown pack (e2e).

**823 unit · 160 e2e · 9 jobs** · tsc · lint (max-params=3, complexity=25). Nothing forward-compat remains in the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)