### PR TITLE
feat(code-memory): multi-label kinds heads + frozen golden eval for the gate (track C)

### DIFF
--- a/scripts/train-decision-gate.ts
+++ b/scripts/train-decision-gate.ts
@@ -20,6 +20,10 @@ import { dirname } from 'node:path';
 import { featurize } from '../src/code-memory/capture/gate-features';
 import { evaluateGate } from '../src/code-memory/capture/gate-classifier';
 import { trainGate } from '../src/code-memory/capture/gate-train';
+import {
+  evaluateHeuristicOnGolden,
+  evaluateModelOnGolden,
+} from '../src/code-memory/capture/gate-golden';
 import type { SilverExample } from '../src/code-memory/capture/silver-dataset';
 
 function arg(name: string, fallback?: string): string | undefined {
@@ -116,9 +120,19 @@ function main(): void {
   }
 
   const model = trainGate(
-    train.map((r) => ({ text: r.text, signals: r.signals, label: r.label })),
+    train.map((r) => ({
+      text: r.text,
+      signals: r.signals,
+      label: r.label,
+      kinds: r.kinds,
+    })),
     { epochs, learningRate, l2, threshold, seed },
   );
+  if (model.kinds) {
+    console.error(
+      `[train] multi-label heads: ${Object.keys(model.kinds).join(', ')}`,
+    );
+  }
 
   const testFeats = test.map((r) => ({
     feats: featurize(r.text, r.signals, model.config),
@@ -135,6 +149,13 @@ function main(): void {
   console.error(
     `[train] model F1 − heuristic F1 = ${((modelMetrics.f1 - heurMetrics.f1) * 100).toFixed(1)} pts`,
   );
+
+  // Independent check against the frozen, hand-labeled golden (human truth) —
+  // the shipping quality bar, unaffected by teacher-label noise in the corpus.
+  const goldenModel = evaluateModelOnGolden(model);
+  const goldenHeur = evaluateHeuristicOnGolden();
+  console.error(`[train] golden heuristic:  ${fmt(goldenHeur)}`);
+  console.error(`[train] golden model:      ${fmt(goldenModel)}`);
 
   mkdirSync(dirname(outPath), { recursive: true });
   writeFileSync(outPath, `${JSON.stringify(model)}\n`);

--- a/src/code-memory/capture/gate-classifier.ts
+++ b/src/code-memory/capture/gate-classifier.ts
@@ -1,4 +1,9 @@
-import type { CommitInput, DecisionClassifier, Layer1Verdict } from './types';
+import type {
+  CommitInput,
+  DecisionClassifier,
+  DecisionKind,
+  Layer1Verdict,
+} from './types';
 import { parseCommitSignals } from './commit-signals';
 import { commitText } from './silver-dataset';
 import {
@@ -6,6 +11,14 @@ import {
   featurize,
   type FeatureConfig,
 } from './gate-features';
+
+/** The decision kinds the multi-label heads predict, in a stable order. */
+export const GATE_KINDS: DecisionKind[] = [
+  'decided',
+  'because',
+  'invariant',
+  'gotcha',
+];
 
 /**
  * Code-memory track C — the trained Layer-1 gate model + serving classifier.
@@ -20,32 +33,61 @@ import {
  * ever demand — the pipeline never changes.
  */
 
+/** One logistic-regression head: bias + sparse bucket→weight map. */
+export interface LinearHead {
+  bias: number;
+  weights: Record<string, number>;
+}
+
 /** Serialised trained gate. `weights` is sparse (bucket index → weight); only
- *  buckets the trainer touched are stored. Portable JSON, no vocabulary. */
+ *  buckets the trainer touched are stored. Portable JSON, no vocabulary.
+ *  v2 adds optional per-kind one-vs-rest heads (multi-label). */
 export interface GateModel {
-  version: 1;
+  version: 1 | 2;
   config: FeatureConfig;
   /** Admit when P(decision) >= threshold. */
   threshold: number;
   bias: number;
   weights: Record<string, number>;
+  /** Per-kind heads (v2). Absent on v1 models. */
+  kinds?: Partial<Record<DecisionKind, LinearHead>>;
+  /** Threshold for the per-kind heads (default 0.5). */
+  kindThreshold?: number;
 }
 
 function sigmoid(z: number): number {
   return 1 / (1 + Math.exp(-z));
 }
 
-/** P(decision-bearing) for a feature map under a model. */
+/** Score a single linear head over a feature map. */
+function scoreHead(head: LinearHead, feats: Map<number, number>): number {
+  let z = head.bias;
+  for (const [idx, val] of feats) {
+    const w = head.weights[idx];
+    if (w) z += w * val;
+  }
+  return sigmoid(z);
+}
+
+/** P(decision-bearing) for a feature map under a model (the binary gate head). */
 export function predictProba(
   model: GateModel,
   feats: Map<number, number>,
 ): number {
-  let z = model.bias;
-  for (const [idx, val] of feats) {
-    const w = model.weights[idx];
-    if (w) z += w * val;
+  return scoreHead({ bias: model.bias, weights: model.weights }, feats);
+}
+
+/** P(kind) for each per-kind head the model carries. Empty for a v1 model. */
+export function predictKindProbas(
+  model: GateModel,
+  feats: Map<number, number>,
+): Partial<Record<DecisionKind, number>> {
+  const out: Partial<Record<DecisionKind, number>> = {};
+  for (const kind of GATE_KINDS) {
+    const head = model.kinds?.[kind];
+    if (head) out[kind] = scoreHead(head, feats);
   }
-  return sigmoid(z);
+  return out;
 }
 
 export interface GateMetrics {
@@ -101,7 +143,7 @@ export class TrainedDecisionClassifier implements DecisionClassifier {
     const m = raw as Partial<GateModel>;
     if (
       !m ||
-      m.version !== 1 ||
+      (m.version !== 1 && m.version !== 2) ||
       typeof m.bias !== 'number' ||
       typeof m.threshold !== 'number' ||
       typeof m.weights !== 'object' ||
@@ -112,6 +154,14 @@ export class TrainedDecisionClassifier implements DecisionClassifier {
       throw new Error('invalid gate model JSON');
     }
     return new TrainedDecisionClassifier(m as GateModel);
+  }
+
+  private features(commit: CommitInput): Map<number, number> {
+    return featurize(
+      commitText(commit),
+      parseCommitSignals(commit),
+      this.model.config ?? DEFAULT_FEATURE_CONFIG,
+    );
   }
 
   classify(commit: CommitInput): Layer1Verdict {
@@ -125,5 +175,17 @@ export class TrainedDecisionClassifier implements DecisionClassifier {
       reason: `trained gate p=${p.toFixed(3)} (thr ${this.model.threshold})`,
       signals,
     };
+  }
+
+  /** Per-kind probabilities (empty for a v1 model). */
+  predictKinds(commit: CommitInput): Partial<Record<DecisionKind, number>> {
+    return predictKindProbas(this.model, this.features(commit));
+  }
+
+  /** The decision kinds whose head clears the model's kind threshold. */
+  classifyKinds(commit: CommitInput): DecisionKind[] {
+    const thr = this.model.kindThreshold ?? 0.5;
+    const probas = this.predictKinds(commit);
+    return GATE_KINDS.filter((k) => (probas[k] ?? 0) >= thr);
   }
 }

--- a/src/code-memory/capture/gate-golden.ts
+++ b/src/code-memory/capture/gate-golden.ts
@@ -1,0 +1,239 @@
+import type { CommitInput, DecisionKind } from './types';
+import { parseCommitSignals } from './commit-signals';
+import { commitText } from './silver-dataset';
+import { HeuristicDecisionClassifier } from './heuristic-classifier';
+import { featurize } from './gate-features';
+import { predictProba, type GateModel } from './gate-classifier';
+
+/**
+ * Code-memory track C — a FROZEN, hand-labeled golden eval set for the Layer-1
+ * gate. (docs/code-memory/distillation-dataset.md)
+ *
+ * The silver labels are teacher-derived (noisy); this is human truth, so it's a
+ * stable regression guard: a shipped/trained gate model is asserted to beat the
+ * heuristic here. Deliberately mixes genuine "why" commits (decision / rationale
+ * / invariant / gotcha, several with the reason in the SUBJECT only — which the
+ * body-scanning heuristic misses) with what-only noise (`label:0`). Edit with
+ * care: this is the contract the gate is measured against.
+ */
+
+export interface GoldenCase {
+  message: string;
+  label: 0 | 1;
+  kinds: DecisionKind[];
+}
+
+export const GATE_GOLDEN: GoldenCase[] = [
+  // ── decision-bearing (label 1) ─────────────────────────────────────────
+  {
+    message:
+      'refactor(auth): funnel token checks through one guard\n\nThe checks had drifted between three middlewares and disagreed on expiry; one gateway keeps them consistent.',
+    label: 1,
+    kinds: ['decided', 'because'],
+  },
+  {
+    message:
+      'fix(di): export the new @Injectable from the @Global module\n\nInvariant: anything constructed by a @Global provider must be listed in exports or e2e DI boot fails.',
+    label: 1,
+    kinds: ['invariant'],
+  },
+  {
+    message:
+      'test: filter with --testPathPattern= (equals form)\n\nGotcha: `pnpm test -- --testPathPattern x` swallows the flag via the double dash; only the = form filters.',
+    label: 1,
+    kinds: ['gotcha'],
+  },
+  {
+    message:
+      'perf: cache the predicate snapshot for 60s\n\nReloading per request added a cold-start round-trip; a short TTL cuts it without real staleness risk.',
+    label: 1,
+    kinds: ['decided', 'because'],
+  },
+  {
+    message:
+      'feat(packs): sign manifests with ed25519\n\nChose ed25519 over RSA: no extra dependency and far smaller signatures.',
+    label: 1,
+    kinds: ['decided', 'because'],
+  },
+  {
+    message:
+      'revert: back out the async write cache\n\nIt introduced a race that dropped writes under load; reverting until we add a lock.',
+    label: 1,
+    kinds: ['because'],
+  },
+  {
+    message:
+      'fix(surreal): omit null on option<> fields\n\nGotcha: SCHEMAFULL rejects a JS null for option<string> with "Found NULL"; emit NONE or omit the field.',
+    label: 1,
+    kinds: ['gotcha'],
+  },
+  {
+    message:
+      'feat: resolve facts through a single gateway\n\nDecided to centralize conflict resolution so the bitemporal rules live in exactly one place.',
+    label: 1,
+    kinds: ['decided'],
+  },
+  {
+    message:
+      'docs: note that migrations must be idempotent\n\nInvariant: every migration uses IF NOT EXISTS so a re-run is a no-op.',
+    label: 1,
+    kinds: ['invariant'],
+  },
+  {
+    message:
+      'refactor: make the registry snapshot TTL-cached\n\nChose a 60s TTL to bound staleness while amortizing the load across requests.',
+    label: 1,
+    kinds: ['decided', 'because'],
+  },
+  {
+    message:
+      'feat: keep the distributable pack out of the builtin seed\n\nDecided to install real-estate per tenant so its predicates do not seed into unrelated tenants.',
+    label: 1,
+    kinds: ['decided', 'because'],
+  },
+  // reason in the SUBJECT only — the body-scanning heuristic tends to miss these
+  {
+    message:
+      'fix: acquire the pool lock before migrating because concurrent boots race the schema',
+    label: 1,
+    kinds: ['because', 'invariant'],
+  },
+  {
+    message:
+      'chore: pin the docker digest — a floating tag silently changed the base image',
+    label: 1,
+    kinds: ['gotcha', 'because'],
+  },
+  {
+    message:
+      'refactor: split the god-class into phase services because 21 positional args drifted between call-sites',
+    label: 1,
+    kinds: ['decided', 'because'],
+  },
+  {
+    message:
+      'fix: always redact PII before the extractor call — raw bodies must never reach the LLM log',
+    label: 1,
+    kinds: ['invariant'],
+  },
+  {
+    message:
+      'perf: memoize the embedder to avoid N sequential round-trips on cold tenants',
+    label: 1,
+    kinds: ['decided', 'because'],
+  },
+  {
+    message:
+      'perf: batch predicate embeds into one call instead of per-row to kill the fresh-tenant tax',
+    label: 1,
+    kinds: ['decided', 'because'],
+  },
+  {
+    message:
+      'ci: disable throttling in e2e — the FANOUT suites trip the 10/min expensive cap and 429',
+    label: 1,
+    kinds: ['gotcha', 'because'],
+  },
+  {
+    message:
+      'fix: dedupe in-flight bootstrap per tenant to prevent duplicate predicate rows under concurrent cold reads',
+    label: 1,
+    kinds: ['because'],
+  },
+  {
+    message:
+      'fix: clamp LLM input so a huge mention cannot blow the token budget or stall the queue',
+    label: 1,
+    kinds: ['because'],
+  },
+  // ── what-only noise (label 0) ──────────────────────────────────────────
+  { message: 'chore: bump deps', label: 0, kinds: [] },
+  { message: 'style: run prettier', label: 0, kinds: [] },
+  { message: 'docs: fix typo in README', label: 0, kinds: [] },
+  { message: 'ci: update workflow file', label: 0, kinds: [] },
+  { message: 'build: bump version to 1.2.3', label: 0, kinds: [] },
+  { message: 'test: add a missing semicolon', label: 0, kinds: [] },
+  { message: 'chore: update lockfile', label: 0, kinds: [] },
+  { message: 'refactor: rename variable foo to bar', label: 0, kinds: [] },
+  { message: 'feat: add a user settings endpoint', label: 0, kinds: [] },
+  { message: 'fix: correct spelling in a comment', label: 0, kinds: [] },
+  { message: 'chore(release): 2.0.0', label: 0, kinds: [] },
+  { message: 'docs: update the changelog', label: 0, kinds: [] },
+  { message: 'style: reformat imports', label: 0, kinds: [] },
+  { message: 'feat: add a GET /health route', label: 0, kinds: [] },
+  { message: 'test: increase coverage for utils', label: 0, kinds: [] },
+  { message: 'chore: remove an unused import', label: 0, kinds: [] },
+  { message: 'refactor: extract a helper function', label: 0, kinds: [] },
+  { message: 'fix: update snapshot tests', label: 0, kinds: [] },
+  { message: 'build: add a tsconfig path alias', label: 0, kinds: [] },
+  { message: 'feat: wire up the new button', label: 0, kinds: [] },
+];
+
+export interface GateEvalMetrics {
+  n: number;
+  accuracy: number;
+  precision: number;
+  recall: number;
+  f1: number;
+}
+
+/** Golden case → a synthetic CommitInput (the gate only reads message text). */
+export function goldenCommit(c: GoldenCase): CommitInput {
+  return {
+    sha: 'golden',
+    message: c.message,
+    changedFiles: ['src/x.ts'],
+    authorDate: '2026-07-07T00:00:00Z',
+  };
+}
+
+function prf(preds: number[], labels: number[]): GateEvalMetrics {
+  let tp = 0;
+  let fp = 0;
+  let fn = 0;
+  let correct = 0;
+  for (let i = 0; i < labels.length; i++) {
+    if (preds[i] === labels[i]) correct += 1;
+    if (preds[i] === 1 && labels[i] === 1) tp += 1;
+    else if (preds[i] === 1 && labels[i] === 0) fp += 1;
+    else if (preds[i] === 0 && labels[i] === 1) fn += 1;
+  }
+  const precision = tp + fp > 0 ? tp / (tp + fp) : 0;
+  const recall = tp + fn > 0 ? tp / (tp + fn) : 0;
+  const f1 =
+    precision + recall > 0 ? (2 * precision * recall) / (precision + recall) : 0;
+  return {
+    n: labels.length,
+    accuracy: labels.length ? correct / labels.length : 0,
+    precision,
+    recall,
+    f1,
+  };
+}
+
+/** Score a trained model against the golden set. */
+export function evaluateModelOnGolden(
+  model: GateModel,
+  golden: GoldenCase[] = GATE_GOLDEN,
+): GateEvalMetrics {
+  const preds = golden.map((c) =>
+    predictProba(
+      model,
+      featurize(commitText(goldenCommit(c)), parseCommitSignals(goldenCommit(c)), model.config),
+    ) >= model.threshold
+      ? 1
+      : 0,
+  );
+  return prf(preds, golden.map((c) => c.label));
+}
+
+/** Score the deterministic heuristic against the golden set (the baseline). */
+export function evaluateHeuristicOnGolden(
+  golden: GoldenCase[] = GATE_GOLDEN,
+): GateEvalMetrics {
+  const h = new HeuristicDecisionClassifier();
+  const preds = golden.map((c) =>
+    h.classify(goldenCommit(c)).likelyDecision ? 1 : 0,
+  );
+  return prf(preds, golden.map((c) => c.label));
+}

--- a/src/code-memory/capture/gate-train.ts
+++ b/src/code-memory/capture/gate-train.ts
@@ -1,25 +1,27 @@
-import type { Layer1Signals } from './types';
+import type { DecisionKind, Layer1Signals } from './types';
 import {
   DEFAULT_FEATURE_CONFIG,
   featurize,
   type FeatureConfig,
 } from './gate-features';
-import type { GateModel } from './gate-classifier';
+import { GATE_KINDS, type GateModel, type LinearHead } from './gate-classifier';
 
 /**
  * Code-memory track C — train the Layer-1 gate (logistic regression, SGD).
  * (docs/code-memory/distillation-dataset.md)
  *
  * Pure + deterministic (seeded PRNG shuffle) so training is reproducible and
- * unit-testable offline. Trains on the silver labels the harness distilled from
- * the Layer-2 teacher; the resulting {@link GateModel} serves behind
- * TrainedDecisionClassifier.
+ * unit-testable offline. Trains the binary decision-bearing head plus, when the
+ * silver examples carry `kinds`, one-vs-rest heads for each decision kind
+ * (decided/because/invariant/gotcha) — a multi-label view for routing/analytics.
  */
 
 export interface TrainExample {
   text: string;
   signals: Layer1Signals;
   label: 0 | 1;
+  /** Decision kinds the teacher found (for the multi-label heads). */
+  kinds?: DecisionKind[];
 }
 
 export interface TrainOptions {
@@ -28,9 +30,12 @@ export interface TrainOptions {
   learningRate?: number;
   l2?: number;
   threshold?: number;
+  /** Threshold for the per-kind heads (default 0.5). */
+  kindThreshold?: number;
   seed?: number;
-  /** Drop weights with |w| below this after training to shrink the artifact. */
   pruneBelow?: number;
+  /** Set false to skip the per-kind heads even when examples carry kinds. */
+  trainKinds?: boolean;
 }
 
 /** Deterministic PRNG (mulberry32) — reproducible shuffles without Math.random. */
@@ -52,32 +57,28 @@ function shuffle<T>(arr: T[], rng: () => number): void {
   }
 }
 
-export function trainGate(
-  examples: TrainExample[],
-  opts: TrainOptions = {},
-): GateModel {
-  const config = opts.config ?? DEFAULT_FEATURE_CONFIG;
-  const epochs = opts.epochs ?? 25;
-  const lr = opts.learningRate ?? 0.1;
-  const l2 = opts.l2 ?? 1e-4;
-  const threshold = opts.threshold ?? 0.5;
-  const pruneBelow = opts.pruneBelow ?? 1e-5;
-  const rng = mulberry32(opts.seed ?? 42);
-
-  const feats = examples.map((e) => featurize(e.text, e.signals, config));
+/** Train one logistic-regression head over pre-featurized examples. */
+function trainLogistic(
+  feats: Array<Map<number, number>>,
+  targets: number[],
+  opts: Required<
+    Pick<TrainOptions, 'epochs' | 'learningRate' | 'l2' | 'seed' | 'pruneBelow'>
+  >,
+): LinearHead {
+  const { epochs, learningRate: lr, l2, seed, pruneBelow } = opts;
+  const rng = mulberry32(seed);
   const weights = new Map<number, number>();
   let bias = 0;
-  const order = examples.map((_, i) => i);
-
+  const order = feats.map((_, i) => i);
   for (let epoch = 0; epoch < epochs; epoch++) {
     shuffle(order, rng);
     for (const i of order) {
       const f = feats[i];
-      const y = examples[i].label;
+      const y = targets[i];
       let z = bias;
       for (const [k, v] of f) z += (weights.get(k) ?? 0) * v;
       const p = 1 / (1 + Math.exp(-z));
-      const g = p - y; // dLoss/dz for logistic loss
+      const g = p - y;
       bias -= lr * g;
       for (const [k, v] of f) {
         const w = weights.get(k) ?? 0;
@@ -85,10 +86,60 @@ export function trainGate(
       }
     }
   }
-
   const sparse: Record<string, number> = {};
   for (const [k, w] of weights) {
     if (Math.abs(w) >= pruneBelow) sparse[k] = w;
   }
-  return { version: 1, config, threshold, bias, weights: sparse };
+  return { bias, weights: sparse };
+}
+
+export function trainGate(
+  examples: TrainExample[],
+  opts: TrainOptions = {},
+): GateModel {
+  const config = opts.config ?? DEFAULT_FEATURE_CONFIG;
+  const seed = opts.seed ?? 42;
+  const base = {
+    epochs: opts.epochs ?? 25,
+    learningRate: opts.learningRate ?? 0.1,
+    l2: opts.l2 ?? 1e-4,
+    pruneBelow: opts.pruneBelow ?? 1e-5,
+  };
+  const feats = examples.map((e) => featurize(e.text, e.signals, config));
+
+  // Binary decision-bearing head (seed unchanged → same weights as a v1 train).
+  const binary = trainLogistic(feats, examples.map((e) => e.label), {
+    ...base,
+    seed,
+  });
+
+  const model: GateModel = {
+    version: 1,
+    config,
+    threshold: opts.threshold ?? 0.5,
+    bias: binary.bias,
+    weights: binary.weights,
+  };
+
+  // Per-kind one-vs-rest heads when the corpus carries kinds.
+  const trainKinds =
+    opts.trainKinds !== false &&
+    examples.some((e) => e.kinds && e.kinds.length > 0);
+  if (trainKinds) {
+    const kinds: Partial<Record<DecisionKind, LinearHead>> = {};
+    GATE_KINDS.forEach((kind, i) => {
+      const targets = examples.map((e) => (e.kinds?.includes(kind) ? 1 : 0));
+      if (targets.some((t) => t === 1)) {
+        // Distinct seed per head so they don't share a shuffle sequence.
+        kinds[kind] = trainLogistic(feats, targets, { ...base, seed: seed + i + 1 });
+      }
+    });
+    if (Object.keys(kinds).length > 0) {
+      model.version = 2;
+      model.kinds = kinds;
+      model.kindThreshold = opts.kindThreshold ?? 0.5;
+    }
+  }
+
+  return model;
 }

--- a/test/gate-kinds-golden.unit-spec.ts
+++ b/test/gate-kinds-golden.unit-spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Code-memory track C — the multi-label kinds heads + the frozen golden eval.
+ * Deterministic + offline: trains on the hand-labeled golden and checks the
+ * gate beats the heuristic on human truth, and that the per-kind heads work.
+ */
+import { trainGate } from '../src/code-memory/capture/gate-train';
+import { TrainedDecisionClassifier } from '../src/code-memory/capture/gate-classifier';
+import {
+  GATE_GOLDEN,
+  evaluateHeuristicOnGolden,
+  evaluateModelOnGolden,
+  goldenCommit,
+  type GoldenCase,
+} from '../src/code-memory/capture/gate-golden';
+import { parseCommitSignals } from '../src/code-memory/capture/commit-signals';
+import { commitText } from '../src/code-memory/capture/silver-dataset';
+
+function trainExamples(cases: GoldenCase[]) {
+  return cases.map((c) => {
+    const commit = goldenCommit(c);
+    return {
+      text: commitText(commit),
+      signals: parseCommitSignals(commit),
+      label: c.label,
+      kinds: c.kinds,
+    };
+  });
+}
+
+describe('gate golden set', () => {
+  it('is balanced and challenges the heuristic (subject-only "why" it misses)', () => {
+    const pos = GATE_GOLDEN.filter((c) => c.label === 1).length;
+    const neg = GATE_GOLDEN.length - pos;
+    expect(pos).toBeGreaterThanOrEqual(15);
+    expect(neg).toBeGreaterThanOrEqual(15);
+    const heur = evaluateHeuristicOnGolden();
+    // The heuristic can't recall the reason-in-subject positives → recall < 1.
+    expect(heur.recall).toBeLessThan(1);
+    expect(heur.f1).toBeLessThan(1);
+  });
+});
+
+describe('trained gate vs heuristic on the golden', () => {
+  it('the trained model beats the heuristic on human truth', () => {
+    const model = trainGate(trainExamples(GATE_GOLDEN), { epochs: 60, seed: 7 });
+    const m = evaluateModelOnGolden(model);
+    const h = evaluateHeuristicOnGolden();
+    expect(m.accuracy).toBeGreaterThanOrEqual(0.9);
+    expect(m.f1).toBeGreaterThan(h.f1);
+  });
+
+  it('generalizes on a held-out split (model >= heuristic F1)', () => {
+    const train = GATE_GOLDEN.filter((_, i) => i % 2 === 0);
+    const test = GATE_GOLDEN.filter((_, i) => i % 2 === 1);
+    const model = trainGate(trainExamples(train), { epochs: 60, seed: 7 });
+    const m = evaluateModelOnGolden(model, test);
+    const h = evaluateHeuristicOnGolden(test);
+    expect(m.f1).toBeGreaterThanOrEqual(h.f1);
+  });
+});
+
+describe('multi-label kinds heads', () => {
+  const model = trainGate(trainExamples(GATE_GOLDEN), { epochs: 60, seed: 7 });
+
+  it('trains a v2 model with a head per kind present in the corpus', () => {
+    expect(model.version).toBe(2);
+    expect(Object.keys(model.kinds ?? {}).sort()).toEqual([
+      'because',
+      'decided',
+      'gotcha',
+      'invariant',
+    ]);
+  });
+
+  it('classifies the kinds of a clear commit', () => {
+    const gate = new TrainedDecisionClassifier(model);
+    const gotcha = gate.classifyKinds(
+      goldenCommit({
+        message:
+          'test: filter with --testPathPattern= (equals form)\n\nGotcha: the double dash swallows the flag.',
+        label: 1,
+        kinds: ['gotcha'],
+      }),
+    );
+    expect(gotcha).toContain('gotcha');
+
+    const probas = gate.predictKinds(
+      goldenCommit({
+        message:
+          'fix(di): export the new @Injectable from the @Global module\n\nInvariant: it must be listed in exports or DI boot fails.',
+        label: 1,
+        kinds: ['invariant'],
+      }),
+    );
+    expect(probas.invariant).toBeGreaterThan(probas.gotcha ?? 0);
+  });
+
+  it('a v1 model (no kinds) yields no kind predictions', () => {
+    const v1 = trainGate(
+      trainExamples(GATE_GOLDEN).map((e) => ({ ...e, kinds: undefined })),
+      { epochs: 20, seed: 7 },
+    );
+    expect(v1.version).toBe(1);
+    expect(new TrainedDecisionClassifier(v1).classifyKinds(goldenCommit(GATE_GOLDEN[0]))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Productionizing track C (1/2) — kinds-aware + quality-guarded

Turns the gate from a binary demo into a kinds-aware, regression-guarded classifier. Pure code, offline.

### Multi-label kinds heads
`GateModel` v2 adds optional per-kind one-vs-rest logistic heads (`decided`/`because`/`invariant`/`gotcha`), trained from the silver `kinds` alongside the binary gate. `gate-train` refactors the SGD into a reusable `trainLogistic`; the binary head is seeded identically so **v1 training is byte-unchanged**. `TrainedDecisionClassifier` gains `predictKinds` / `classifyKinds`; **v1 models still load** and yield no kinds (backward compatible).

### Frozen golden eval
`gate-golden.ts` — a **40-case hand-labeled** eval set (human truth, not teacher-noisy), mixing genuine why-commits (several with the reason in the **subject only**, which the body-scanning heuristic misses) with what-only noise. `evaluateModelOnGolden` / `evaluateHeuristicOnGolden` score against it, and `train:decision-gate` now prints **golden model-vs-heuristic F1** as the shipping quality bar (independent of teacher-label noise in the training corpus).

### Tests
The golden challenges the heuristic (recall < 1); a trained model beats it **in-sample and generalizes on a held-out split**; the kinds heads classify a clear gotcha/invariant; a v1 model yields no kinds.

**829 unit** · tsc · lint. No server change → e2e/jobs unaffected.

Next (2/2): ship a default trained model + make the gate the default in capture, with a golden regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)