### PR TITLE
feat(domain-packs): industry pack library — fintech, medical, legal

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -211,3 +211,23 @@ POST /v1/admin/packs/:packId/eval   (brain:admin)
 
 `real_estate` ships three fixtures (zoning / valuation / tenure) as the
 demonstrator. Nothing forward-compat remains in the manifest.
+
+## First-party pack library (industries)
+
+Beyond the builtin `code_memory`, brain ships a library of DISTRIBUTABLE
+industry packs (installed per-tenant, published to the registry via
+`pnpm registry:seed`) — each a complete ontology with predicates +
+`extractionProfile` + `evalFixtures`, not a stub:
+
+| pack | domain | predicates (namespaced `<id>__*`) |
+|---|---|---|
+| `real_estate` | property | zoned_as, valued_at, listed_at, encumbered_by, tenure_type, built_in |
+| `fintech` | financial-services regulation | regulated_by, licensed_as, complies_with, capital_requirement, settlement_period |
+| `medical` | clinical pharmacology (drugs, not patients) | treats, dosed_at, administered_via, interacts_with, contraindicated_with |
+| `legal` | contracts | governed_by, party_to, obligation, effective_from, terminates_on |
+
+Sources: `src/ai/domain-packs/*.pack.ts` (the `FIRST_PARTY_PACKS` list) →
+committed JSON in `packs/*.pack.json` (drift-guarded by
+`test/industry-packs.unit-spec.ts`). Install one with
+`pnpm pack:install -- --registry fintech` (after `registry:seed`) or
+`--file packs/fintech.pack.json`.

--- a/packs/fintech.pack.json
+++ b/packs/fintech.pack.json
@@ -1,0 +1,115 @@
+{
+  "id": "fintech",
+  "version": "0.1.0",
+  "description": "Financial-services regulation ontology — regulators, licenses, compliance standards, capital, and settlement of institutions/products, with a domain extraction profile.",
+  "predicates": [
+    {
+      "localId": "regulated_by",
+      "displayLabel": "regulated by",
+      "description": "TYPE   subject is an institution/product; value is a regulator\nADMIT  text names the authority that regulates the subject (\"regulated\n       by the FCA\", \"under SEC oversight\")\nVALUE  the regulator, verbatim (\"FCA\", \"SEC\", \"MAS\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "licensed_as",
+      "displayLabel": "licensed as",
+      "description": "TYPE   subject is an institution; value is a license/registration type\nADMIT  text states the license or registration the subject holds\n       (\"licensed as an EMI\", \"registered broker-dealer\")\nVALUE  the license/registration term, verbatim (\"EMI\", \"broker-dealer\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "complies_with",
+      "displayLabel": "complies with",
+      "description": "TYPE   subject is an institution/product; value is a standard/regulation\nADMIT  text states a named standard or regulation the subject meets\n       (\"PCI-DSS compliant\", \"meets KYC/AML\", \"SOC 2 Type II\")\nVALUE  one standard per fact, verbatim (\"PCI-DSS\", \"KYC\", \"SOC 2\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "capital_requirement",
+      "displayLabel": "capital requirement",
+      "description": "TYPE   subject is an institution; value is a required capital/reserve\nADMIT  text states a regulatory capital or reserve requirement\n       (\"must hold €5M in own funds\", \"20% reserve requirement\")\nVALUE  the amount, verbatim including currency/percent (\"€5M\", \"20%\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "settlement_period",
+      "displayLabel": "settlement period",
+      "description": "TYPE   subject is an instrument/transaction; value is a settlement window\nADMIT  text states the settlement period (\"settles T+2\", \"same-day\n       settlement\")\nVALUE  the settlement term, verbatim (\"T+2\", \"same-day\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    }
+  ],
+  "extractionProfile": {
+    "guidance": "Financial-services inputs describe institutions, products, or\ntransactions. Treat the named institution / product / instrument as the SUBJECT\nentity. Prefer the fintech__* predicates for\nregulators (fintech__regulated_by), licenses (fintech__licensed_as), compliance\nstandards (fintech__complies_with), capital/reserve requirements\n(fintech__capital_requirement), and settlement windows\n(fintech__settlement_period). Copy regulator acronyms, license terms, standards,\namounts, and settlement terms VERBATIM — \"FCA\" not \"the regulator\", \"PCI-DSS\"\nnot \"card standard\", \"T+2\" not \"two days\". When a regulator or auditor is a\nnamed entity, ALSO emit an edge (Institution —regulated_by→ Authority).",
+    "fewShot": [
+      {
+        "text": "Acme Pay is an EMI regulated by the FCA and is PCI-DSS compliant.",
+        "note": "org 'Acme Pay' → fintech__licensed_as='EMI', fintech__regulated_by='FCA', fintech__complies_with='PCI-DSS'; edge (Acme Pay, regulated_by, FCA)."
+      },
+      {
+        "text": "The fund must hold €5M in own funds; trades settle T+2.",
+        "note": "→ fintech__capital_requirement='€5M', fintech__settlement_period='T+2'."
+      },
+      {
+        "text": "Nova Securities is a registered broker-dealer under SEC oversight.",
+        "note": "org 'Nova Securities' → fintech__licensed_as='broker-dealer', fintech__regulated_by='SEC'."
+      }
+    ]
+  },
+  "evalFixtures": [
+    {
+      "id": "regulator",
+      "description": "the regulating authority is extracted",
+      "text": "Acme Pay is regulated by the FCA.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "regulated_by",
+            "objectIncludes": "FCA"
+          }
+        ]
+      }
+    },
+    {
+      "id": "compliance",
+      "description": "a named compliance standard is captured",
+      "text": "The gateway is PCI-DSS compliant.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "complies_with",
+            "objectIncludes": "PCI-DSS"
+          }
+        ]
+      }
+    },
+    {
+      "id": "settlement",
+      "description": "the settlement window is captured verbatim",
+      "text": "Equity trades settle T+2.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "settlement_period",
+            "objectIncludes": "T+2"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packs/legal.pack.json
+++ b/packs/legal.pack.json
@@ -1,0 +1,115 @@
+{
+  "id": "legal",
+  "version": "0.1.0",
+  "description": "Legal / contracts ontology — governing law, parties, obligations, and term of agreements, with a domain extraction profile.",
+  "predicates": [
+    {
+      "localId": "governed_by",
+      "displayLabel": "governed by",
+      "description": "TYPE   subject is an agreement/case; value is the governing law/jurisdiction\nADMIT  text states the governing law or jurisdiction (\"governed by the\n       laws of England and Wales\", \"subject to Delaware law\")\nVALUE  the jurisdiction/law, verbatim (\"England and Wales\", \"Delaware\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "party_to",
+      "displayLabel": "party to",
+      "description": "TYPE   subject is an agreement; value is a named party\nADMIT  text names a party to the agreement (\"between Acme Corp and Beta\n       LLC\", \"the Supplier\")\nVALUE  one party per fact, verbatim (\"Acme Corp\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "obligation",
+      "displayLabel": "obligation",
+      "description": "TYPE   subject is a party/agreement; value is a duty/obligation\nADMIT  text states an obligation or covenant (\"shall deliver within 30\n       days\", \"must maintain insurance\")\nVALUE  the obligation, verbatim (\"deliver within 30 days\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "effective_from",
+      "displayLabel": "effective from",
+      "description": "TYPE   subject is an agreement; value is the effective date\nADMIT  text states when the agreement takes effect (\"effective 1 January\n       2026\", \"commences on signing\")\nVALUE  the effective date/term, verbatim (\"1 January 2026\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "terminates_on",
+      "displayLabel": "terminates on",
+      "description": "TYPE   subject is an agreement; value is a termination date/condition\nADMIT  text states when/how the agreement terminates (\"terminates 31\n       December 2027\", \"on 90 days notice\")\nVALUE  the termination date/condition, verbatim (\"90 days notice\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    }
+  ],
+  "extractionProfile": {
+    "guidance": "Legal inputs describe AGREEMENTS or contractual relationships.\nTreat the named agreement (or the parties) as the SUBJECT entity. Prefer the\nlegal__* predicates for governing law (legal__governed_by), parties\n(legal__party_to), obligations/covenants (legal__obligation), effective date\n(legal__effective_from), and termination (legal__terminates_on). Copy\njurisdictions, party names, dates, and obligation clauses VERBATIM — \"England\nand Wales\" not \"UK law\", \"30 days\" not \"a month\". When two named parties are in\nan agreement, emit an edge between them in addition to the party facts.",
+    "fewShot": [
+      {
+        "text": "This Agreement between Acme Corp and Beta LLC is governed by the laws of Delaware and effective 1 January 2026.",
+        "note": "→ legal__party_to='Acme Corp', legal__party_to='Beta LLC', legal__governed_by='Delaware', legal__effective_from='1 January 2026'; edge (Acme Corp, party_with, Beta LLC)."
+      },
+      {
+        "text": "The Supplier shall deliver within 30 days and must maintain insurance.",
+        "note": "→ legal__obligation='deliver within 30 days', legal__obligation='maintain insurance'."
+      },
+      {
+        "text": "The contract terminates on 90 days written notice.",
+        "note": "→ legal__terminates_on='90 days written notice'."
+      }
+    ]
+  },
+  "evalFixtures": [
+    {
+      "id": "governing-law",
+      "description": "the governing law is extracted",
+      "text": "This Agreement is governed by the laws of Delaware.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "governed_by",
+            "objectIncludes": "Delaware"
+          }
+        ]
+      }
+    },
+    {
+      "id": "obligation",
+      "description": "a contractual obligation is captured",
+      "text": "The Supplier shall deliver within 30 days.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "obligation",
+            "objectIncludes": "30 days"
+          }
+        ]
+      }
+    },
+    {
+      "id": "term",
+      "description": "the effective date is captured",
+      "text": "This Agreement is effective 1 January 2026.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "effective_from",
+            "objectIncludes": "1 January 2026"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packs/medical.pack.json
+++ b/packs/medical.pack.json
@@ -1,0 +1,115 @@
+{
+  "id": "medical",
+  "version": "0.1.0",
+  "description": "Clinical pharmacology ontology — indications, dosing, routes, interactions, and contraindications of drugs/treatments, with a domain extraction profile.",
+  "predicates": [
+    {
+      "localId": "treats",
+      "displayLabel": "treats",
+      "description": "TYPE   subject is a drug/treatment; value is a condition it is indicated for\nADMIT  text states what the drug is indicated for / treats (\"indicated\n       for hypertension\", \"treats type 2 diabetes\")\nVALUE  one condition per fact, verbatim (\"hypertension\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "dosed_at",
+      "displayLabel": "dosed at",
+      "description": "TYPE   subject is a drug; value is a dosage\nADMIT  text states the dose/strength/frequency (\"500 mg twice daily\",\n       \"10 mg once daily\")\nVALUE  the dosage, verbatim (\"500 mg twice daily\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "administered_via",
+      "displayLabel": "administered via",
+      "description": "TYPE   subject is a drug; value is a route of administration\nADMIT  text states how the drug is given (\"oral\", \"intravenous\",\n       \"subcutaneous injection\")\nVALUE  the route, verbatim (\"oral\", \"IV\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "interacts_with",
+      "displayLabel": "interacts with",
+      "description": "TYPE   subject is a drug; value is another drug/substance it interacts with\nADMIT  text states a drug-drug/drug-food interaction (\"interacts with\n       warfarin\", \"avoid with grapefruit\")\nVALUE  one interacting agent per fact, verbatim (\"warfarin\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "contraindicated_with",
+      "displayLabel": "contraindicated with",
+      "description": "TYPE   subject is a drug; value is a condition/population it must not be used in\nADMIT  text states a contraindication (\"contraindicated in pregnancy\",\n       \"not for patients with renal impairment\")\nVALUE  one contraindication per fact, verbatim (\"pregnancy\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    }
+  ],
+  "extractionProfile": {
+    "guidance": "Clinical inputs describe DRUGS or TREATMENTS (not patients). Treat\nthe named drug/treatment as the SUBJECT entity. Prefer the medical__* predicates\nfor indications (medical__treats), dosing (medical__dosed_at), route\n(medical__administered_via), interactions (medical__interacts_with), and\ncontraindications (medical__contraindicated_with). Copy conditions, doses,\nroutes, and interacting agents VERBATIM — \"500 mg twice daily\" not \"twice a\nday\", \"warfarin\" not \"blood thinner\". Do NOT infer patient-specific facts; this\npack captures drug ontology, not clinical records.",
+    "fewShot": [
+      {
+        "text": "Metformin is indicated for type 2 diabetes, dosed at 500 mg twice daily, taken orally.",
+        "note": "drug 'Metformin' → medical__treats='type 2 diabetes', medical__dosed_at='500 mg twice daily', medical__administered_via='orally'."
+      },
+      {
+        "text": "Warfarin interacts with aspirin and is contraindicated in pregnancy.",
+        "note": "drug 'Warfarin' → medical__interacts_with='aspirin', medical__contraindicated_with='pregnancy'."
+      },
+      {
+        "text": "Ceftriaxone is administered via intravenous infusion.",
+        "note": "drug 'Ceftriaxone' → medical__administered_via='intravenous infusion'."
+      }
+    ]
+  },
+  "evalFixtures": [
+    {
+      "id": "indication",
+      "description": "the treated condition is extracted",
+      "text": "Metformin is indicated for type 2 diabetes.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "treats",
+            "objectIncludes": "type 2 diabetes"
+          }
+        ]
+      }
+    },
+    {
+      "id": "dose",
+      "description": "the dosage is captured verbatim",
+      "text": "Amoxicillin is dosed at 500 mg three times daily.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "dosed_at",
+            "objectIncludes": "500 mg"
+          }
+        ]
+      }
+    },
+    {
+      "id": "contraindication",
+      "description": "a contraindication is captured",
+      "text": "Isotretinoin is contraindicated in pregnancy.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "contraindicated_with",
+            "objectIncludes": "pregnancy"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/ai/domain-packs/fintech.pack.ts
+++ b/src/ai/domain-packs/fintech.pack.ts
@@ -1,0 +1,129 @@
+import type { DomainPackManifest } from './manifest';
+
+/**
+ * Industry Domain Pack: fintech / financial-services regulation. Like
+ * real-estate (and unlike the builtin code-memory), a DISTRIBUTABLE pack —
+ * installed per-tenant from `packs/fintech.pack.json` via `pnpm pack:install`,
+ * NOT in BUILTIN_PACKS, so its domain predicates don't seed into unrelated
+ * tenants. Ships an extractionProfile + eval fixtures so it's a complete,
+ * self-verifying ontology, not a stub. Bump `version` to ship an update.
+ */
+export const FINTECH_PACK: DomainPackManifest = {
+  id: 'fintech',
+  version: '0.1.0',
+  description:
+    'Financial-services regulation ontology — regulators, licenses, compliance standards, capital, and settlement of institutions/products, with a domain extraction profile.',
+  predicates: [
+    {
+      localId: 'regulated_by',
+      displayLabel: 'regulated by',
+      description: `TYPE   subject is an institution/product; value is a regulator
+ADMIT  text names the authority that regulates the subject ("regulated
+       by the FCA", "under SEC oversight")
+VALUE  the regulator, verbatim ("FCA", "SEC", "MAS")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'licensed_as',
+      displayLabel: 'licensed as',
+      description: `TYPE   subject is an institution; value is a license/registration type
+ADMIT  text states the license or registration the subject holds
+       ("licensed as an EMI", "registered broker-dealer")
+VALUE  the license/registration term, verbatim ("EMI", "broker-dealer")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'complies_with',
+      displayLabel: 'complies with',
+      description: `TYPE   subject is an institution/product; value is a standard/regulation
+ADMIT  text states a named standard or regulation the subject meets
+       ("PCI-DSS compliant", "meets KYC/AML", "SOC 2 Type II")
+VALUE  one standard per fact, verbatim ("PCI-DSS", "KYC", "SOC 2")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'capital_requirement',
+      displayLabel: 'capital requirement',
+      description: `TYPE   subject is an institution; value is a required capital/reserve
+ADMIT  text states a regulatory capital or reserve requirement
+       ("must hold €5M in own funds", "20% reserve requirement")
+VALUE  the amount, verbatim including currency/percent ("€5M", "20%")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'settlement_period',
+      displayLabel: 'settlement period',
+      description: `TYPE   subject is an instrument/transaction; value is a settlement window
+ADMIT  text states the settlement period ("settles T+2", "same-day
+       settlement")
+VALUE  the settlement term, verbatim ("T+2", "same-day")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+  ],
+  extractionProfile: {
+    guidance: `Financial-services inputs describe institutions, products, or
+transactions. Treat the named institution / product / instrument as the SUBJECT
+entity. Prefer the fintech__* predicates for
+regulators (fintech__regulated_by), licenses (fintech__licensed_as), compliance
+standards (fintech__complies_with), capital/reserve requirements
+(fintech__capital_requirement), and settlement windows
+(fintech__settlement_period). Copy regulator acronyms, license terms, standards,
+amounts, and settlement terms VERBATIM — "FCA" not "the regulator", "PCI-DSS"
+not "card standard", "T+2" not "two days". When a regulator or auditor is a
+named entity, ALSO emit an edge (Institution —regulated_by→ Authority).`,
+    fewShot: [
+      {
+        text: 'Acme Pay is an EMI regulated by the FCA and is PCI-DSS compliant.',
+        note: "org 'Acme Pay' → fintech__licensed_as='EMI', fintech__regulated_by='FCA', fintech__complies_with='PCI-DSS'; edge (Acme Pay, regulated_by, FCA).",
+      },
+      {
+        text: 'The fund must hold €5M in own funds; trades settle T+2.',
+        note: "→ fintech__capital_requirement='€5M', fintech__settlement_period='T+2'.",
+      },
+      {
+        text: 'Nova Securities is a registered broker-dealer under SEC oversight.',
+        note: "org 'Nova Securities' → fintech__licensed_as='broker-dealer', fintech__regulated_by='SEC'.",
+      },
+    ],
+  },
+  evalFixtures: [
+    {
+      id: 'regulator',
+      description: 'the regulating authority is extracted',
+      text: 'Acme Pay is regulated by the FCA.',
+      expect: { facts: [{ predicate: 'regulated_by', objectIncludes: 'FCA' }] },
+    },
+    {
+      id: 'compliance',
+      description: 'a named compliance standard is captured',
+      text: 'The gateway is PCI-DSS compliant.',
+      expect: { facts: [{ predicate: 'complies_with', objectIncludes: 'PCI-DSS' }] },
+    },
+    {
+      id: 'settlement',
+      description: 'the settlement window is captured verbatim',
+      text: 'Equity trades settle T+2.',
+      expect: { facts: [{ predicate: 'settlement_period', objectIncludes: 'T+2' }] },
+    },
+  ],
+};

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -31,7 +31,25 @@ export * from './signature';
 export * from './semver';
 export * from './eval-fixture';
 export * from './code-memory.pack';
-// real-estate is a DISTRIBUTABLE pack (installed per-tenant at runtime), not a
-// builtin — exported for the JSON generator + tests, deliberately NOT added to
-// BUILTIN_PACKS so its domain predicates don't seed into every tenant.
+// DISTRIBUTABLE industry packs (installed per-tenant at runtime), NOT builtins —
+// exported for the JSON generator + tests, deliberately kept out of BUILTIN_PACKS
+// so their domain predicates don't seed into every tenant. Shipped as JSON in
+// packs/ and published to the registry via `pnpm registry:seed`.
 export * from './real-estate.pack';
+export * from './fintech.pack';
+export * from './medical.pack';
+export * from './legal.pack';
+
+import { REAL_ESTATE_PACK } from './real-estate.pack';
+import { FINTECH_PACK } from './fintech.pack';
+import { MEDICAL_PACK } from './medical.pack';
+import { LEGAL_PACK } from './legal.pack';
+
+/** First-party distributable packs shipped in-repo (packs/*.json). The industry
+ *  ontology library — distinct from BUILTIN_PACKS (globally seeded). */
+export const FIRST_PARTY_PACKS: DomainPackManifest[] = [
+  REAL_ESTATE_PACK,
+  FINTECH_PACK,
+  MEDICAL_PACK,
+  LEGAL_PACK,
+];

--- a/src/ai/domain-packs/legal.pack.ts
+++ b/src/ai/domain-packs/legal.pack.ts
@@ -1,0 +1,125 @@
+import type { DomainPackManifest } from './manifest';
+
+/**
+ * Industry Domain Pack: legal / contracts. A DISTRIBUTABLE pack (installed
+ * per-tenant from `packs/legal.pack.json`, NOT in BUILTIN_PACKS). Captures the
+ * ontology of agreements — governing law, parties, obligations, and term — with
+ * an extractionProfile + eval fixtures. Bump `version` to ship an update.
+ */
+export const LEGAL_PACK: DomainPackManifest = {
+  id: 'legal',
+  version: '0.1.0',
+  description:
+    'Legal / contracts ontology — governing law, parties, obligations, and term of agreements, with a domain extraction profile.',
+  predicates: [
+    {
+      localId: 'governed_by',
+      displayLabel: 'governed by',
+      description: `TYPE   subject is an agreement/case; value is the governing law/jurisdiction
+ADMIT  text states the governing law or jurisdiction ("governed by the
+       laws of England and Wales", "subject to Delaware law")
+VALUE  the jurisdiction/law, verbatim ("England and Wales", "Delaware")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'party_to',
+      displayLabel: 'party to',
+      description: `TYPE   subject is an agreement; value is a named party
+ADMIT  text names a party to the agreement ("between Acme Corp and Beta
+       LLC", "the Supplier")
+VALUE  one party per fact, verbatim ("Acme Corp")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'obligation',
+      displayLabel: 'obligation',
+      description: `TYPE   subject is a party/agreement; value is a duty/obligation
+ADMIT  text states an obligation or covenant ("shall deliver within 30
+       days", "must maintain insurance")
+VALUE  the obligation, verbatim ("deliver within 30 days")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'effective_from',
+      displayLabel: 'effective from',
+      description: `TYPE   subject is an agreement; value is the effective date
+ADMIT  text states when the agreement takes effect ("effective 1 January
+       2026", "commences on signing")
+VALUE  the effective date/term, verbatim ("1 January 2026")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'terminates_on',
+      displayLabel: 'terminates on',
+      description: `TYPE   subject is an agreement; value is a termination date/condition
+ADMIT  text states when/how the agreement terminates ("terminates 31
+       December 2027", "on 90 days notice")
+VALUE  the termination date/condition, verbatim ("90 days notice")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+  ],
+  extractionProfile: {
+    guidance: `Legal inputs describe AGREEMENTS or contractual relationships.
+Treat the named agreement (or the parties) as the SUBJECT entity. Prefer the
+legal__* predicates for governing law (legal__governed_by), parties
+(legal__party_to), obligations/covenants (legal__obligation), effective date
+(legal__effective_from), and termination (legal__terminates_on). Copy
+jurisdictions, party names, dates, and obligation clauses VERBATIM — "England
+and Wales" not "UK law", "30 days" not "a month". When two named parties are in
+an agreement, emit an edge between them in addition to the party facts.`,
+    fewShot: [
+      {
+        text: 'This Agreement between Acme Corp and Beta LLC is governed by the laws of Delaware and effective 1 January 2026.',
+        note: "→ legal__party_to='Acme Corp', legal__party_to='Beta LLC', legal__governed_by='Delaware', legal__effective_from='1 January 2026'; edge (Acme Corp, party_with, Beta LLC).",
+      },
+      {
+        text: 'The Supplier shall deliver within 30 days and must maintain insurance.',
+        note: "→ legal__obligation='deliver within 30 days', legal__obligation='maintain insurance'.",
+      },
+      {
+        text: 'The contract terminates on 90 days written notice.',
+        note: "→ legal__terminates_on='90 days written notice'.",
+      },
+    ],
+  },
+  evalFixtures: [
+    {
+      id: 'governing-law',
+      description: 'the governing law is extracted',
+      text: 'This Agreement is governed by the laws of Delaware.',
+      expect: { facts: [{ predicate: 'governed_by', objectIncludes: 'Delaware' }] },
+    },
+    {
+      id: 'obligation',
+      description: 'a contractual obligation is captured',
+      text: 'The Supplier shall deliver within 30 days.',
+      expect: { facts: [{ predicate: 'obligation', objectIncludes: '30 days' }] },
+    },
+    {
+      id: 'term',
+      description: 'the effective date is captured',
+      text: 'This Agreement is effective 1 January 2026.',
+      expect: { facts: [{ predicate: 'effective_from', objectIncludes: '1 January 2026' }] },
+    },
+  ],
+};

--- a/src/ai/domain-packs/medical.pack.ts
+++ b/src/ai/domain-packs/medical.pack.ts
@@ -1,0 +1,128 @@
+import type { DomainPackManifest } from './manifest';
+
+/**
+ * Industry Domain Pack: medical / clinical pharmacology. A DISTRIBUTABLE pack
+ * (installed per-tenant from `packs/medical.pack.json`, NOT in BUILTIN_PACKS).
+ * Scoped to DRUG / TREATMENT ontology (indications, dosing, interactions,
+ * contraindications) — not patient records — so its predicates are piiClass
+ * 'none'. Ships an extractionProfile + eval fixtures. Bump `version` to update.
+ */
+export const MEDICAL_PACK: DomainPackManifest = {
+  id: 'medical',
+  version: '0.1.0',
+  description:
+    'Clinical pharmacology ontology — indications, dosing, routes, interactions, and contraindications of drugs/treatments, with a domain extraction profile.',
+  predicates: [
+    {
+      localId: 'treats',
+      displayLabel: 'treats',
+      description: `TYPE   subject is a drug/treatment; value is a condition it is indicated for
+ADMIT  text states what the drug is indicated for / treats ("indicated
+       for hypertension", "treats type 2 diabetes")
+VALUE  one condition per fact, verbatim ("hypertension")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'dosed_at',
+      displayLabel: 'dosed at',
+      description: `TYPE   subject is a drug; value is a dosage
+ADMIT  text states the dose/strength/frequency ("500 mg twice daily",
+       "10 mg once daily")
+VALUE  the dosage, verbatim ("500 mg twice daily")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'administered_via',
+      displayLabel: 'administered via',
+      description: `TYPE   subject is a drug; value is a route of administration
+ADMIT  text states how the drug is given ("oral", "intravenous",
+       "subcutaneous injection")
+VALUE  the route, verbatim ("oral", "IV")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'interacts_with',
+      displayLabel: 'interacts with',
+      description: `TYPE   subject is a drug; value is another drug/substance it interacts with
+ADMIT  text states a drug-drug/drug-food interaction ("interacts with
+       warfarin", "avoid with grapefruit")
+VALUE  one interacting agent per fact, verbatim ("warfarin")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'contraindicated_with',
+      displayLabel: 'contraindicated with',
+      description: `TYPE   subject is a drug; value is a condition/population it must not be used in
+ADMIT  text states a contraindication ("contraindicated in pregnancy",
+       "not for patients with renal impairment")
+VALUE  one contraindication per fact, verbatim ("pregnancy")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+  ],
+  extractionProfile: {
+    guidance: `Clinical inputs describe DRUGS or TREATMENTS (not patients). Treat
+the named drug/treatment as the SUBJECT entity. Prefer the medical__* predicates
+for indications (medical__treats), dosing (medical__dosed_at), route
+(medical__administered_via), interactions (medical__interacts_with), and
+contraindications (medical__contraindicated_with). Copy conditions, doses,
+routes, and interacting agents VERBATIM — "500 mg twice daily" not "twice a
+day", "warfarin" not "blood thinner". Do NOT infer patient-specific facts; this
+pack captures drug ontology, not clinical records.`,
+    fewShot: [
+      {
+        text: 'Metformin is indicated for type 2 diabetes, dosed at 500 mg twice daily, taken orally.',
+        note: "drug 'Metformin' → medical__treats='type 2 diabetes', medical__dosed_at='500 mg twice daily', medical__administered_via='orally'.",
+      },
+      {
+        text: 'Warfarin interacts with aspirin and is contraindicated in pregnancy.',
+        note: "drug 'Warfarin' → medical__interacts_with='aspirin', medical__contraindicated_with='pregnancy'.",
+      },
+      {
+        text: 'Ceftriaxone is administered via intravenous infusion.',
+        note: "drug 'Ceftriaxone' → medical__administered_via='intravenous infusion'.",
+      },
+    ],
+  },
+  evalFixtures: [
+    {
+      id: 'indication',
+      description: 'the treated condition is extracted',
+      text: 'Metformin is indicated for type 2 diabetes.',
+      expect: { facts: [{ predicate: 'treats', objectIncludes: 'type 2 diabetes' }] },
+    },
+    {
+      id: 'dose',
+      description: 'the dosage is captured verbatim',
+      text: 'Amoxicillin is dosed at 500 mg three times daily.',
+      expect: { facts: [{ predicate: 'dosed_at', objectIncludes: '500 mg' }] },
+    },
+    {
+      id: 'contraindication',
+      description: 'a contraindication is captured',
+      text: 'Isotretinoin is contraindicated in pregnancy.',
+      expect: {
+        facts: [{ predicate: 'contraindicated_with', objectIncludes: 'pregnancy' }],
+      },
+    },
+  ],
+};

--- a/test/industry-packs.e2e-spec.ts
+++ b/test/industry-packs.e2e-spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Industry Domain Pack library — end-to-end. Install fintech / medical / legal
+ * into a tenant, confirm their namespaced predicates seed, and run one pack's
+ * eval fixtures through the live extractor endpoint. Proves the library is a
+ * real, installable, self-verifying set — not just TS constants.
+ */
+import {
+  FINTECH_PACK,
+  LEGAL_PACK,
+  MEDICAL_PACK,
+} from '../src/ai/domain-packs';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+
+describe('industry domain packs (e2e)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    f = await createApp({
+      companyId: 'co_industry_packs_e2e',
+      scopes: ['brain:read', 'brain:write', 'brain:admin'],
+    });
+    for (const pack of [FINTECH_PACK, MEDICAL_PACK, LEGAL_PACK]) {
+      await f.http.post('/v1/admin/packs').set(auth()).send({ manifest: pack });
+    }
+  });
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('seeds every industry pack namespaced predicate', async () => {
+    const preds = await f.http.get('/v1/admin/predicates').set(auth());
+    const ids = (preds.body.predicates ?? []).map((p: any) => p.predicateId);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'fintech__regulated_by',
+        'fintech__complies_with',
+        'medical__treats',
+        'medical__contraindicated_with',
+        'legal__governed_by',
+        'legal__obligation',
+      ]),
+    );
+  });
+
+  it('lists them installed alongside the builtin', async () => {
+    const r = await f.http.get('/v1/admin/packs').set(auth());
+    const installed = (r.body.installed ?? []).map((p: any) => p.packId);
+    expect(installed).toEqual(
+      expect.arrayContaining(['fintech', 'medical', 'legal']),
+    );
+  });
+
+  it('runs an industry pack eval fixture through the live extractor', async () => {
+    f.extractor.setScript({
+      entities: [{ name: 'Acme Pay', type: 'other' }],
+      facts: [
+        {
+          entityIndex: 0,
+          predicate: 'fintech__regulated_by',
+          object: 'FCA',
+          confidence: 0.9,
+        },
+      ],
+      edges: [],
+    });
+    const r = await f.http.post('/v1/admin/packs/fintech/eval').set(auth());
+    expect([200, 201]).toContain(r.status);
+    expect(r.body.packId).toBe('fintech');
+    expect(r.body.total).toBe(FINTECH_PACK.evalFixtures!.length);
+    const regulator = r.body.results.find((x: any) => x.id === 'regulator');
+    expect(regulator.passed).toBe(true);
+  });
+});

--- a/test/industry-packs.unit-spec.ts
+++ b/test/industry-packs.unit-spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Industry Domain Pack library — fintech / medical / legal (+ real_estate).
+ * Each is a complete, self-verifying, DISTRIBUTABLE pack: valid manifest, an
+ * extractionProfile, eval fixtures, a committed JSON artifact kept in sync with
+ * the TS source, and deliberately NOT a builtin. Together they seed the registry
+ * collision-free.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  assembleSeed,
+  BUILTIN_PACKS,
+  FINTECH_PACK,
+  FIRST_PARTY_PACKS,
+  LEGAL_PACK,
+  MEDICAL_PACK,
+  packChecksum,
+  validatePack,
+  type DomainPackManifest,
+} from '../src/ai/domain-packs';
+import { CORE_PREDICATES } from '../src/ai/predicate-registry-internals/core-seed';
+
+const INDUSTRY: DomainPackManifest[] = [FINTECH_PACK, MEDICAL_PACK, LEGAL_PACK];
+
+describe.each(INDUSTRY.map((p) => [p.id, p] as const))(
+  'industry pack: %s',
+  (id, pack) => {
+    it('is a valid pack with >= 4 namespaced predicates', () => {
+      expect(() => validatePack(pack)).not.toThrow();
+      expect(pack.predicates.length).toBeGreaterThanOrEqual(4);
+      expect(pack.id).toMatch(/^[a-z][a-z0-9_]*$/);
+    });
+
+    it('ships an extractionProfile (guidance + few-shot)', () => {
+      expect(pack.extractionProfile?.guidance?.length ?? 0).toBeGreaterThan(0);
+      expect(pack.extractionProfile?.fewShot?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it('ships eval fixtures with fact expectations', () => {
+      expect(pack.evalFixtures?.length ?? 0).toBeGreaterThan(0);
+      for (const f of pack.evalFixtures ?? []) {
+        expect(typeof f.id).toBe('string');
+        expect(typeof f.text).toBe('string');
+        expect((f.expect.facts ?? []).length).toBeGreaterThan(0);
+      }
+    });
+
+    it('is DISTRIBUTABLE — not a builtin', () => {
+      expect(BUILTIN_PACKS.some((p) => p.id === id)).toBe(false);
+    });
+
+    it('has a committed JSON artifact matching the TS source', () => {
+      const file = join(
+        __dirname,
+        '..',
+        'packs',
+        `${id.replace(/_/g, '-')}.pack.json`,
+      );
+      const fromJson = JSON.parse(readFileSync(file, 'utf8')) as DomainPackManifest;
+      expect(fromJson).toEqual(pack);
+      expect(packChecksum(fromJson)).toBe(packChecksum(pack));
+    });
+  },
+);
+
+describe('first-party pack library', () => {
+  it('lists the industry packs + real_estate', () => {
+    const ids = FIRST_PARTY_PACKS.map((p) => p.id).sort();
+    expect(ids).toEqual(['fintech', 'legal', 'medical', 'real_estate']);
+  });
+
+  it('seeds together with core collision-free (namespaced)', () => {
+    expect(() => assembleSeed(CORE_PREDICATES, FIRST_PARTY_PACKS)).not.toThrow();
+    const merged = assembleSeed(CORE_PREDICATES, FIRST_PARTY_PACKS);
+    expect(merged.some((p) => p.predicateId === 'fintech__regulated_by')).toBe(true);
+    expect(merged.some((p) => p.predicateId === 'medical__treats')).toBe(true);
+    expect(merged.some((p) => p.predicateId === 'legal__governed_by')).toBe(true);
+  });
+});


### PR DESCRIPTION
## The industry ontology library (по отраслям)

Turns the pack system from one demo (`real_estate`) into a real, multi-industry library. Each new pack is **complete + self-verifying, not a stub**: predicates + `extractionProfile` + `evalFixtures`, distributable (NOT a builtin), with a committed JSON artifact.

| pack | domain | predicates |
|---|---|---|
| `fintech` | financial-services regulation | regulated_by · licensed_as · complies_with · capital_requirement · settlement_period |
| `medical` | clinical pharmacology (drugs, not patients; piiClass none) | treats · dosed_at · administered_via · interacts_with · contraindicated_with |
| `legal` | contracts | governed_by · party_to · obligation · effective_from · terminates_on |

- `FIRST_PARTY_PACKS` list + `packs/{fintech,medical,legal}.pack.json` (published by `pnpm registry:seed`; installed via `pack:install --file` / `--registry`).
- **Tests**: parametrized unit (validity, profile + fixtures present, not builtin, JSON↔TS drift guard, collision-free `assembleSeed`) + an **e2e** installing all three and running fintech's eval fixtures through the live extractor.

**848 unit · 163 e2e · 9 jobs** · tsc · lint. Pure domain content — no server change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)