### PR TITLE
feat(domain-packs): more industry packs — insurance, hr

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -225,6 +225,8 @@ industry packs (installed per-tenant, published to the registry via
 | `fintech` | financial-services regulation | regulated_by, licensed_as, complies_with, capital_requirement, settlement_period |
 | `medical` | clinical pharmacology (drugs, not patients) | treats, dosed_at, administered_via, interacts_with, contraindicated_with |
 | `legal` | contracts | governed_by, party_to, obligation, effective_from, terminates_on |
+| `insurance` | insurance policies | covers, coverage_limit, premium, deductible, excludes |
+| `hr` | HR / recruiting (roles, not PII) | requires_skill, seniority, compensation, employment_type, work_location |
 
 Sources: `src/ai/domain-packs/*.pack.ts` (the `FIRST_PARTY_PACKS` list) →
 committed JSON in `packs/*.pack.json` (drift-guarded by

--- a/packs/hr.pack.json
+++ b/packs/hr.pack.json
@@ -1,0 +1,111 @@
+{
+  "id": "hr",
+  "version": "0.1.0",
+  "description": "HR / recruiting ontology — required skills, seniority, compensation, employment type, and work location of roles, with a domain extraction profile.",
+  "predicates": [
+    {
+      "localId": "requires_skill",
+      "displayLabel": "requires skill",
+      "description": "TYPE   subject is a role/requisition; value is a required skill\nADMIT  text states a skill/qualification the role requires (\"requires\n       Kubernetes\", \"must know Python\")\nVALUE  one skill per fact, verbatim (\"Kubernetes\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "seniority",
+      "displayLabel": "seniority",
+      "description": "TYPE   subject is a role; value is a seniority level\nADMIT  text states the seniority (\"Senior\", \"Staff\", \"5+ years\n       experience\")\nVALUE  the seniority term, verbatim (\"Senior\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "compensation",
+      "displayLabel": "compensation",
+      "description": "TYPE   subject is a role; value is a compensation range/amount\nADMIT  text states pay/salary/comp (\"$150k–$180k\", \"£90,000 base\")\nVALUE  the compensation, verbatim (\"$150k–$180k\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "employment_type",
+      "displayLabel": "employment type",
+      "description": "TYPE   subject is a role; value is an employment type\nADMIT  text states the type (\"full-time\", \"contract\", \"part-time\")\nVALUE  the type, verbatim (\"full-time\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "work_location",
+      "displayLabel": "work location",
+      "description": "TYPE   subject is a role; value is a work-location policy\nADMIT  text states remote/hybrid/onsite or a location (\"remote\",\n       \"hybrid, 2 days in Berlin\")\nVALUE  the location policy, verbatim (\"remote\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    }
+  ],
+  "extractionProfile": {
+    "guidance": "HR / recruiting inputs describe ROLES or job requisitions (not\nindividuals — do not extract personal candidate data). Treat the named role as\nthe SUBJECT entity. Prefer the hr__* predicates for required skills\n(hr__requires_skill), seniority (hr__seniority), compensation\n(hr__compensation), employment type (hr__employment_type), and work location\n(hr__work_location). Copy skills, levels, pay, and location policies VERBATIM —\n\"Kubernetes\" not \"container tech\", \"$150k–$180k\" not \"competitive\".",
+    "fewShot": [
+      {
+        "text": "Senior Backend Engineer, full-time, remote — requires Go and Kubernetes; $160k–$190k.",
+        "note": "role 'Senior Backend Engineer' → hr__seniority='Senior', hr__employment_type='full-time', hr__work_location='remote', hr__requires_skill='Go', hr__requires_skill='Kubernetes', hr__compensation='$160k–$190k'."
+      },
+      {
+        "text": "Contract role, hybrid 2 days in Berlin, must know Python.",
+        "note": "→ hr__employment_type='Contract', hr__work_location='hybrid 2 days in Berlin', hr__requires_skill='Python'."
+      }
+    ]
+  },
+  "evalFixtures": [
+    {
+      "id": "skill",
+      "description": "a required skill is extracted",
+      "text": "This role requires Kubernetes.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "requires_skill",
+            "objectIncludes": "Kubernetes"
+          }
+        ]
+      }
+    },
+    {
+      "id": "comp",
+      "description": "the compensation range is captured",
+      "text": "Compensation is $150k–$180k.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "compensation",
+            "objectIncludes": "$150k"
+          }
+        ]
+      }
+    },
+    {
+      "id": "location",
+      "description": "the work-location policy is captured",
+      "text": "This position is fully remote.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "work_location",
+            "objectIncludes": "remote"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packs/insurance.pack.json
+++ b/packs/insurance.pack.json
@@ -1,0 +1,111 @@
+{
+  "id": "insurance",
+  "version": "0.1.0",
+  "description": "Insurance ontology — coverage, limits, premiums, deductibles, and exclusions of policies, with a domain extraction profile.",
+  "predicates": [
+    {
+      "localId": "covers",
+      "displayLabel": "covers",
+      "description": "TYPE   subject is a policy; value is a covered peril/loss\nADMIT  text states what the policy covers (\"covers water damage\",\n       \"includes third-party liability\")\nVALUE  one covered item per fact, verbatim (\"water damage\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "coverage_limit",
+      "displayLabel": "coverage limit",
+      "description": "TYPE   subject is a policy; value is a coverage limit/sum insured\nADMIT  text states a limit or sum insured (\"limit of $1,000,000\",\n       \"sum insured £250k\")\nVALUE  the amount, verbatim including currency (\"$1,000,000\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "premium",
+      "displayLabel": "premium",
+      "description": "TYPE   subject is a policy; value is a premium\nADMIT  text states the premium (\"annual premium of $1,200\",\n       \"$100/month\")\nVALUE  the premium amount, verbatim (\"$1,200/year\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "deductible",
+      "displayLabel": "deductible",
+      "description": "TYPE   subject is a policy; value is a deductible/excess\nADMIT  text states the deductible or excess (\"$500 deductible\",\n       \"£250 excess\")\nVALUE  the amount, verbatim (\"$500\")",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "excludes",
+      "displayLabel": "excludes",
+      "description": "TYPE   subject is a policy; value is an exclusion\nADMIT  text states what is NOT covered (\"excludes flood\", \"war and\n       terrorism excluded\")\nVALUE  one exclusion per fact, verbatim (\"flood\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    }
+  ],
+  "extractionProfile": {
+    "guidance": "Insurance inputs describe POLICIES. Treat the named policy/product\nas the SUBJECT entity. Prefer the insurance__* predicates for covered perils\n(insurance__covers), limits (insurance__coverage_limit), premiums\n(insurance__premium), deductibles (insurance__deductible), and exclusions\n(insurance__excludes). Copy amounts and peril names VERBATIM — \"$1,000,000\" not\n\"a million\", \"flood\" not \"water event\". Distinguish what the policy COVERS from\nwhat it EXCLUDES.",
+    "fewShot": [
+      {
+        "text": "The Home Plus policy covers fire and theft with a $500 deductible; flood is excluded.",
+        "note": "policy 'Home Plus' → insurance__covers='fire', insurance__covers='theft', insurance__deductible='$500', insurance__excludes='flood'."
+      },
+      {
+        "text": "Annual premium of $1,200 with a coverage limit of $1,000,000.",
+        "note": "→ insurance__premium='$1,200', insurance__coverage_limit='$1,000,000'."
+      }
+    ]
+  },
+  "evalFixtures": [
+    {
+      "id": "coverage",
+      "description": "a covered peril is extracted",
+      "text": "The policy covers fire damage.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "covers",
+            "objectIncludes": "fire"
+          }
+        ]
+      }
+    },
+    {
+      "id": "deductible",
+      "description": "the deductible is captured verbatim",
+      "text": "This policy has a $500 deductible.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "deductible",
+            "objectIncludes": "$500"
+          }
+        ]
+      }
+    },
+    {
+      "id": "exclusion",
+      "description": "an exclusion is captured",
+      "text": "Flood is excluded from this policy.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "excludes",
+            "objectIncludes": "Flood"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/ai/domain-packs/hr.pack.ts
+++ b/src/ai/domain-packs/hr.pack.ts
@@ -1,0 +1,118 @@
+import type { DomainPackManifest } from './manifest';
+
+/**
+ * Industry Domain Pack: HR / recruiting. DISTRIBUTABLE (installed per-tenant from
+ * `packs/hr.pack.json`, NOT in BUILTIN_PACKS). Captures role/candidate ontology —
+ * required skills, seniority, compensation, employment type, location policy.
+ * Scoped to ROLES/REQUISITIONS, not individual PII. Bump `version` to update.
+ */
+export const HR_PACK: DomainPackManifest = {
+  id: 'hr',
+  version: '0.1.0',
+  description:
+    'HR / recruiting ontology — required skills, seniority, compensation, employment type, and work location of roles, with a domain extraction profile.',
+  predicates: [
+    {
+      localId: 'requires_skill',
+      displayLabel: 'requires skill',
+      description: `TYPE   subject is a role/requisition; value is a required skill
+ADMIT  text states a skill/qualification the role requires ("requires
+       Kubernetes", "must know Python")
+VALUE  one skill per fact, verbatim ("Kubernetes")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'seniority',
+      displayLabel: 'seniority',
+      description: `TYPE   subject is a role; value is a seniority level
+ADMIT  text states the seniority ("Senior", "Staff", "5+ years
+       experience")
+VALUE  the seniority term, verbatim ("Senior")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'compensation',
+      displayLabel: 'compensation',
+      description: `TYPE   subject is a role; value is a compensation range/amount
+ADMIT  text states pay/salary/comp ("$150k–$180k", "£90,000 base")
+VALUE  the compensation, verbatim ("$150k–$180k")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'employment_type',
+      displayLabel: 'employment type',
+      description: `TYPE   subject is a role; value is an employment type
+ADMIT  text states the type ("full-time", "contract", "part-time")
+VALUE  the type, verbatim ("full-time")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'work_location',
+      displayLabel: 'work location',
+      description: `TYPE   subject is a role; value is a work-location policy
+ADMIT  text states remote/hybrid/onsite or a location ("remote",
+       "hybrid, 2 days in Berlin")
+VALUE  the location policy, verbatim ("remote")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+  ],
+  extractionProfile: {
+    guidance: `HR / recruiting inputs describe ROLES or job requisitions (not
+individuals — do not extract personal candidate data). Treat the named role as
+the SUBJECT entity. Prefer the hr__* predicates for required skills
+(hr__requires_skill), seniority (hr__seniority), compensation
+(hr__compensation), employment type (hr__employment_type), and work location
+(hr__work_location). Copy skills, levels, pay, and location policies VERBATIM —
+"Kubernetes" not "container tech", "$150k–$180k" not "competitive".`,
+    fewShot: [
+      {
+        text: 'Senior Backend Engineer, full-time, remote — requires Go and Kubernetes; $160k–$190k.',
+        note: "role 'Senior Backend Engineer' → hr__seniority='Senior', hr__employment_type='full-time', hr__work_location='remote', hr__requires_skill='Go', hr__requires_skill='Kubernetes', hr__compensation='$160k–$190k'.",
+      },
+      {
+        text: 'Contract role, hybrid 2 days in Berlin, must know Python.',
+        note: "→ hr__employment_type='Contract', hr__work_location='hybrid 2 days in Berlin', hr__requires_skill='Python'.",
+      },
+    ],
+  },
+  evalFixtures: [
+    {
+      id: 'skill',
+      description: 'a required skill is extracted',
+      text: 'This role requires Kubernetes.',
+      expect: { facts: [{ predicate: 'requires_skill', objectIncludes: 'Kubernetes' }] },
+    },
+    {
+      id: 'comp',
+      description: 'the compensation range is captured',
+      text: 'Compensation is $150k–$180k.',
+      expect: { facts: [{ predicate: 'compensation', objectIncludes: '$150k' }] },
+    },
+    {
+      id: 'location',
+      description: 'the work-location policy is captured',
+      text: 'This position is fully remote.',
+      expect: { facts: [{ predicate: 'work_location', objectIncludes: 'remote' }] },
+    },
+  ],
+};

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -39,11 +39,15 @@ export * from './real-estate.pack';
 export * from './fintech.pack';
 export * from './medical.pack';
 export * from './legal.pack';
+export * from './insurance.pack';
+export * from './hr.pack';
 
 import { REAL_ESTATE_PACK } from './real-estate.pack';
 import { FINTECH_PACK } from './fintech.pack';
 import { MEDICAL_PACK } from './medical.pack';
 import { LEGAL_PACK } from './legal.pack';
+import { INSURANCE_PACK } from './insurance.pack';
+import { HR_PACK } from './hr.pack';
 
 /** First-party distributable packs shipped in-repo (packs/*.json). The industry
  *  ontology library — distinct from BUILTIN_PACKS (globally seeded). */
@@ -52,4 +56,6 @@ export const FIRST_PARTY_PACKS: DomainPackManifest[] = [
   FINTECH_PACK,
   MEDICAL_PACK,
   LEGAL_PACK,
+  INSURANCE_PACK,
+  HR_PACK,
 ];

--- a/src/ai/domain-packs/insurance.pack.ts
+++ b/src/ai/domain-packs/insurance.pack.ts
@@ -1,0 +1,120 @@
+import type { DomainPackManifest } from './manifest';
+
+/**
+ * Industry Domain Pack: insurance. DISTRIBUTABLE (installed per-tenant from
+ * `packs/insurance.pack.json`, NOT in BUILTIN_PACKS). Captures policy ontology —
+ * coverage, limits, premiums, deductibles, exclusions — with an extractionProfile
+ * + eval fixtures. Bump `version` to ship an update.
+ */
+export const INSURANCE_PACK: DomainPackManifest = {
+  id: 'insurance',
+  version: '0.1.0',
+  description:
+    'Insurance ontology — coverage, limits, premiums, deductibles, and exclusions of policies, with a domain extraction profile.',
+  predicates: [
+    {
+      localId: 'covers',
+      displayLabel: 'covers',
+      description: `TYPE   subject is a policy; value is a covered peril/loss
+ADMIT  text states what the policy covers ("covers water damage",
+       "includes third-party liability")
+VALUE  one covered item per fact, verbatim ("water damage")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'coverage_limit',
+      displayLabel: 'coverage limit',
+      description: `TYPE   subject is a policy; value is a coverage limit/sum insured
+ADMIT  text states a limit or sum insured ("limit of $1,000,000",
+       "sum insured £250k")
+VALUE  the amount, verbatim including currency ("$1,000,000")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'premium',
+      displayLabel: 'premium',
+      description: `TYPE   subject is a policy; value is a premium
+ADMIT  text states the premium ("annual premium of $1,200",
+       "$100/month")
+VALUE  the premium amount, verbatim ("$1,200/year")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'deductible',
+      displayLabel: 'deductible',
+      description: `TYPE   subject is a policy; value is a deductible/excess
+ADMIT  text states the deductible or excess ("$500 deductible",
+       "£250 excess")
+VALUE  the amount, verbatim ("$500")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'excludes',
+      displayLabel: 'excludes',
+      description: `TYPE   subject is a policy; value is an exclusion
+ADMIT  text states what is NOT covered ("excludes flood", "war and
+       terrorism excluded")
+VALUE  one exclusion per fact, verbatim ("flood")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+  ],
+  extractionProfile: {
+    guidance: `Insurance inputs describe POLICIES. Treat the named policy/product
+as the SUBJECT entity. Prefer the insurance__* predicates for covered perils
+(insurance__covers), limits (insurance__coverage_limit), premiums
+(insurance__premium), deductibles (insurance__deductible), and exclusions
+(insurance__excludes). Copy amounts and peril names VERBATIM — "$1,000,000" not
+"a million", "flood" not "water event". Distinguish what the policy COVERS from
+what it EXCLUDES.`,
+    fewShot: [
+      {
+        text: 'The Home Plus policy covers fire and theft with a $500 deductible; flood is excluded.',
+        note: "policy 'Home Plus' → insurance__covers='fire', insurance__covers='theft', insurance__deductible='$500', insurance__excludes='flood'.",
+      },
+      {
+        text: 'Annual premium of $1,200 with a coverage limit of $1,000,000.',
+        note: "→ insurance__premium='$1,200', insurance__coverage_limit='$1,000,000'.",
+      },
+    ],
+  },
+  evalFixtures: [
+    {
+      id: 'coverage',
+      description: 'a covered peril is extracted',
+      text: 'The policy covers fire damage.',
+      expect: { facts: [{ predicate: 'covers', objectIncludes: 'fire' }] },
+    },
+    {
+      id: 'deductible',
+      description: 'the deductible is captured verbatim',
+      text: 'This policy has a $500 deductible.',
+      expect: { facts: [{ predicate: 'deductible', objectIncludes: '$500' }] },
+    },
+    {
+      id: 'exclusion',
+      description: 'an exclusion is captured',
+      text: 'Flood is excluded from this policy.',
+      expect: { facts: [{ predicate: 'excludes', objectIncludes: 'Flood' }] },
+    },
+  ],
+};

--- a/test/industry-packs.unit-spec.ts
+++ b/test/industry-packs.unit-spec.ts
@@ -10,17 +10,17 @@ import { join } from 'node:path';
 import {
   assembleSeed,
   BUILTIN_PACKS,
-  FINTECH_PACK,
   FIRST_PARTY_PACKS,
-  LEGAL_PACK,
-  MEDICAL_PACK,
   packChecksum,
   validatePack,
   type DomainPackManifest,
 } from '../src/ai/domain-packs';
 import { CORE_PREDICATES } from '../src/ai/predicate-registry-internals/core-seed';
 
-const INDUSTRY: DomainPackManifest[] = [FINTECH_PACK, MEDICAL_PACK, LEGAL_PACK];
+// Every first-party pack except real_estate (which has its own spec).
+const INDUSTRY: DomainPackManifest[] = FIRST_PARTY_PACKS.filter(
+  (p) => p.id !== 'real_estate',
+);
 
 describe.each(INDUSTRY.map((p) => [p.id, p] as const))(
   'industry pack: %s',
@@ -66,7 +66,14 @@ describe.each(INDUSTRY.map((p) => [p.id, p] as const))(
 describe('first-party pack library', () => {
   it('lists the industry packs + real_estate', () => {
     const ids = FIRST_PARTY_PACKS.map((p) => p.id).sort();
-    expect(ids).toEqual(['fintech', 'legal', 'medical', 'real_estate']);
+    expect(ids).toEqual([
+      'fintech',
+      'hr',
+      'insurance',
+      'legal',
+      'medical',
+      'real_estate',
+    ]);
   });
 
   it('seeds together with core collision-free (namespaced)', () => {


### PR DESCRIPTION
Extends the first-party industry library with **insurance** (covers/coverage_limit/premium/deductible/excludes) and **hr** (requires_skill/seniority/compensation/employment_type/work_location) — each complete + distributable (predicates + extractionProfile + evalFixtures + committed JSON). The industry unit spec now iterates `FIRST_PARTY_PACKS`, so new packs are covered automatically. 858 unit · tsc · lint. Library is now 6 packs (real_estate + fintech + medical + legal + insurance + hr).