### PR TITLE
feat(registry): public server-rendered registry UI (GET /registry/ui)

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -166,6 +166,8 @@ Surface:
 - **Install from registry** (`brain:admin`): `POST /v1/admin/packs/from-registry
   {packId, version?}` — resolves latest-non-yanked (or a pin) and installs via
   the normal path, pinning the registry checksum.
+- **Browse** (public, no auth): `GET /registry/ui` — a server-rendered HTML
+  catalogue of published packs (ids, versions, keywords, install hint).
 
 CLI:
 

--- a/src/registry/registry-ui.controller.ts
+++ b/src/registry/registry-ui.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { PackRegistryService } from './pack-registry.service';
+import { renderRegistryPage } from './registry-ui';
+
+/**
+ * Public, read-only HTML browser for the global pack registry — a discovery
+ * page (like a package index). NO auth guard: the catalogue is public metadata
+ * (pack ids / versions / descriptions), and a browser can't send a Bearer
+ * token. Renders server-side from PackRegistryService so no client token is
+ * needed. Machine clients use the JSON API at /v1/registry.
+ */
+@Controller('registry')
+export class RegistryUiController {
+  constructor(private readonly registry: PackRegistryService) {}
+
+  @Get('ui')
+  @Header('content-type', 'text/html; charset=utf-8')
+  @Header('cache-control', 'no-store')
+  async ui(): Promise<string> {
+    const packs = await this.registry.list({ limit: 500 });
+    return renderRegistryPage(packs);
+  }
+}

--- a/src/registry/registry-ui.ts
+++ b/src/registry/registry-ui.ts
@@ -1,0 +1,64 @@
+import type { RegistryPackSummary } from '../contracts/registry/registry.schema';
+
+/**
+ * Server-rendered HTML for the pack registry catalogue browser (a public,
+ * read-only discovery page over the global registry — like a package index).
+ * Pure + dependency-free so it's unit-testable; the controller supplies the
+ * summaries. All dynamic values are HTML-escaped.
+ */
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function card(p: RegistryPackSummary): string {
+  const tags = p.keywords
+    .map((k) => `<span class="tag">${esc(k)}</span>`)
+    .join('');
+  const badge = p.signed ? '<span class="badge">signed</span>' : '';
+  const publisher = p.publisher
+    ? `<span class="pub">by ${esc(p.publisher)}</span>`
+    : '';
+  return `<article class="pack">
+  <h2>${esc(p.packId)} <span class="ver">v${esc(p.latestVersion)}</span> ${badge}</h2>
+  <p class="desc">${esc(p.description || '(no description)')}</p>
+  <div class="meta">${tags}${publisher}<span class="vc">${p.versionCount} version(s)</span></div>
+  <code class="install">pnpm pack:install -- --registry ${esc(p.packId)}</code>
+</article>`;
+}
+
+export function renderRegistryPage(packs: RegistryPackSummary[]): string {
+  const body =
+    packs.length === 0
+      ? '<p class="empty">No packs published yet. Publish one with <code>pnpm pack:publish</code>.</p>'
+      : packs.map(card).join('\n');
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Brain — Domain Pack registry</title>
+<style>
+:root{color-scheme:light dark}
+body{font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;max-width:820px;margin:2rem auto;padding:0 1rem}
+h1{font-size:1.6rem;margin:0 0 .25rem}
+.sub{color:#888;margin:0 0 1.5rem}
+.pack{border:1px solid #8883;border-radius:10px;padding:1rem 1.25rem;margin:0 0 1rem}
+.pack h2{font-size:1.15rem;margin:0 0 .25rem}
+.ver{color:#888;font-weight:400;font-size:.9rem}
+.badge{background:#2e7d32;color:#fff;font-size:.7rem;padding:.1rem .4rem;border-radius:4px;vertical-align:middle}
+.desc{margin:.25rem 0 .5rem}
+.meta{display:flex;flex-wrap:wrap;gap:.4rem;align-items:center;font-size:.8rem;color:#888;margin-bottom:.5rem}
+.tag{background:#8882;border-radius:4px;padding:.1rem .45rem}
+.install{display:block;background:#8881;padding:.5rem .6rem;border-radius:6px;font-size:.8rem;overflow-x:auto}
+#q{width:100%;padding:.6rem .75rem;border:1px solid #8884;border-radius:8px;margin-bottom:1.25rem;font-size:1rem;box-sizing:border-box}
+.empty{color:#888}
+</style></head><body>
+<h1>Domain Pack registry</h1>
+<p class="sub">${packs.length} pack(s) · install with <code>pnpm pack:install -- --registry &lt;id&gt;</code></p>
+<input id="q" placeholder="Filter packs…" oninput="for(const a of document.querySelectorAll('.pack')){a.style.display=a.textContent.toLowerCase().includes(this.value.toLowerCase())?'':'none'}">
+<main>${body}</main>
+</body></html>`;
+}

--- a/src/registry/registry.module.ts
+++ b/src/registry/registry.module.ts
@@ -3,6 +3,7 @@ import { AuthModule } from '../auth/auth.module';
 import { PackRegistryService } from './pack-registry.service';
 import { RegistryController } from './registry.controller';
 import { AdminRegistryController } from './admin-registry.controller';
+import { RegistryUiController } from './registry-ui.controller';
 
 /**
  * The GLOBAL Domain Pack registry (docs/domain-packs.md): a shared catalogue of
@@ -14,7 +15,7 @@ import { AdminRegistryController } from './admin-registry.controller';
  */
 @Module({
   imports: [AuthModule],
-  controllers: [RegistryController, AdminRegistryController],
+  controllers: [RegistryController, AdminRegistryController, RegistryUiController],
   providers: [PackRegistryService],
   exports: [PackRegistryService],
 })

--- a/test/registry-ui.e2e-spec.ts
+++ b/test/registry-ui.e2e-spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Registry UI — end-to-end. A published pack shows up on the public,
+ * unauthenticated HTML catalogue page.
+ */
+import { REAL_ESTATE_PACK } from '../src/ai/domain-packs';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+
+describe('GET /registry/ui — public catalogue (e2e)', () => {
+  let f: AppFixture;
+
+  beforeAll(async () => {
+    f = await createApp({
+      companyId: 'co_registry_ui_e2e',
+      scopes: ['brain:read', 'registry:publish'],
+    });
+    await f.http
+      .post('/v1/admin/registry/packs')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({ manifest: { ...REAL_ESTATE_PACK, id: 'realty_ui_e2e' } });
+  });
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('serves an HTML page listing the published pack — no auth required', async () => {
+    const r = await f.http.get('/registry/ui'); // deliberately no Authorization
+    expect(r.status).toBe(200);
+    expect(r.headers['content-type']).toMatch(/text\/html/);
+    expect(r.text).toContain('realty_ui_e2e');
+    expect(r.text).toContain('Domain Pack registry');
+  });
+});

--- a/test/registry-ui.unit-spec.ts
+++ b/test/registry-ui.unit-spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Registry UI — pure server-rendered catalogue page.
+ */
+import { renderRegistryPage } from '../src/registry/registry-ui';
+import type { RegistryPackSummary } from '../src/contracts/registry/registry.schema';
+
+function pack(over: Partial<RegistryPackSummary> = {}): RegistryPackSummary {
+  return {
+    packId: 'fintech',
+    latestVersion: '0.1.0',
+    description: 'financial services',
+    keywords: ['finance'],
+    publisher: 'acme',
+    signed: true,
+    versionCount: 2,
+    ...over,
+  };
+}
+
+describe('renderRegistryPage', () => {
+  it('renders a pack card with id, version, install hint', () => {
+    const html = renderRegistryPage([pack()]);
+    expect(html).toContain('fintech');
+    expect(html).toContain('v0.1.0');
+    expect(html).toContain('pnpm pack:install -- --registry fintech');
+    expect(html).toContain('signed');
+    expect(html).toMatch(/^<!doctype html>/);
+  });
+
+  it('HTML-escapes dynamic fields (no injection)', () => {
+    const html = renderRegistryPage([
+      pack({ description: '<script>alert(1)</script>', keywords: ['<b>x'] }),
+    ]);
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&lt;b&gt;x');
+  });
+
+  it('shows an empty state when there are no packs', () => {
+    const html = renderRegistryPage([]);
+    expect(html).toContain('No packs published yet');
+  });
+});


### PR DESCRIPTION
A read-only HTML **catalogue browser** over the global pack registry — a discovery page like a package index. **Public** (no auth): the catalogue is public metadata and a browser can't send a Bearer token, so it renders server-side from `PackRegistryService`; machine clients still use the JSON API at `/v1/registry`.

- `renderRegistryPage` — pure, HTML-escaped, unit-tested: pack cards (id/version/keywords/publisher/signed) + install hint + a client-side filter box; empty state.
- `RegistryUiController` `GET /registry/ui` (no guard).
- Tests: pure render (escaping/empty/data) + e2e (publish → the public page lists it, no auth). **861 unit · 164 e2e · 9 jobs**.