### PR TITLE
feat(trust): trust snapshot + conflict trace + evidence[] (source-reputation phase 1)

### DIFF
--- a/src/db/migrations/0044_trust_snapshot.surql
+++ b/src/db/migrations/0044_trust_snapshot.surql
@@ -1,0 +1,289 @@
+-- 0044_trust_snapshot — facts permanently remember what was believed about
+-- their source at write time; conflict decisions stop being ephemeral.
+--
+-- Source-reputation track, Phase 1 (docs/roadmap: "Fact is not true. Fact is
+-- claimed by source, extracted from evidence, trusted under context").
+--
+-- Two new FLEXIBLE fields on knowledge_fact:
+--   * trustSnapshot — written on EVERY created fact inside fn::resolve_fact:
+--     { sourceKey, domain, declaredTrust, learnedTrust, calculatedAt }.
+--     declaredTrust = the caller-supplied static heuristic ($source_trust);
+--     learnedTrust = the nightly-refit agreementRate AT THIS INSTANT
+--     (fn::source_trust_for). The nightly refit later overwrites the
+--     source_trust row in place — the snapshot is the untampered record of
+--     what the resolver actually believed, never recomputed retroactively.
+--     `domain` = the predicate for now; Phase 2 scopes reputation by the
+--     same generic string so a topic layer can land without migration.
+--   * conflictTrace — the already-computed scoreBreakdown/dominantDimension/
+--     slotDelta/bestOpponentId, UPDATE'd onto the new fact in the SUPERSEDED
+--     and COMPETING branches. Until now this was computed in-fn, returned
+--     once (explain:true), and thrown away — the fact never remembered WHY
+--     it won or tied.
+--
+-- Old facts simply have both fields NONE (no retroactive backfill — that
+-- would violate the snapshot principle itself).
+--
+-- Body is migration 0043 VERBATIM plus: $src_key LET, trustSnapshot in the
+-- CREATE CONTENT, and the two conflictTrace writes. Nothing else changes;
+-- signature stays 21 args (no TS call-site change).
+
+DEFINE FIELD IF NOT EXISTS trustSnapshot ON knowledge_fact TYPE option<object> FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS conflictTrace ON knowledge_fact TYPE option<object> FLEXIBLE;
+
+DEFINE FUNCTION OVERWRITE fn::resolve_fact(
+    $entity_id: record<knowledge_entity>,
+    $predicate: string,
+    $object: string,
+    $object_meta: option<object>,
+    $embedding: array<float>,
+    $confidence: float,
+    $valid_from: datetime,
+    $valid_until: option<datetime>,
+    $source: object,
+    $source_trust: float,
+    $semantics: string,
+    $similarity_threshold: float,
+    $w_confidence: float,
+    $w_source_trust: float,
+    $w_recency: float,
+    $w_authority: float,
+    $reject_threshold: float,
+    $margin_for_supersede: float,
+    $lang: option<string>,
+    $script: option<string>,
+    $entropy: option<float>
+) {
+    LET $new_score =
+        $w_confidence * $confidence
+        + $w_source_trust * $source_trust
+        + $w_recency * 1.0
+        + $w_authority * 0.0;
+
+    IF $semantics = 'bitemporal' AND $new_score < $reject_threshold {
+        CREATE ingest_dead_letter CONTENT {
+            payload: { entityId: $entity_id, predicate: $predicate, object: $object, source: $source },
+            reason: 'low_score: ' + <string>$new_score
+        };
+        RETURN { outcome: 'REJECTED', factId: NONE, reason: 'low_score' };
+    };
+
+    LET $candidates = SELECT
+        id, predicate, object, confidence, recordedAt, source, embedding,
+        validFrom, validUntil
+    FROM knowledge_fact
+    WHERE entityId = $entity_id
+      AND predicate = $predicate
+      AND status = 'active'
+      AND retractedAt IS NONE;
+
+    LET $competing = IF $semantics = 'append_only' THEN
+        []
+    ELSE IF $semantics = 'single_active' THEN
+        $candidates
+    ELSE
+        (SELECT * FROM $candidates
+            WHERE embedding != NONE
+              AND vector::similarity::cosine(embedding, $embedding) >= $similarity_threshold
+              AND fn::intervals_overlap(validFrom, validUntil, $valid_from, $valid_until))
+    END;
+
+    -- Trust snapshot (migration 0044): what the resolver believes about this
+    -- source RIGHT NOW, frozen onto the fact. learnedTrust is read before
+    -- any nightly refit can overwrite the source_trust row.
+    LET $src_key = fn::source_key_of($source);
+
+    LET $new = CREATE ONLY knowledge_fact CONTENT {
+        entityId: $entity_id,
+        predicate: $predicate,
+        object: $object,
+        objectMeta: $object_meta,
+        confidence: $confidence,
+        validFrom: $valid_from,
+        validUntil: $valid_until,
+        source: $source,
+        embedding: $embedding,
+        status: 'active',
+        trustSnapshot: {
+            sourceKey: $src_key,
+            domain: $predicate,
+            declaredTrust: $source_trust,
+            learnedTrust: fn::source_trust_for($src_key),
+            calculatedAt: time::now()
+        }
+    };
+
+    IF array::len($competing) = 0 {
+        -- Locale + entropy folded in from the caller (migration 0039). Applied
+        -- on INSERTED only, matching the old post-call UPDATE gate.
+        IF $lang != NONE {
+            UPDATE $new.id SET lang = $lang, script = $script;
+        };
+        IF $entropy != NONE {
+            UPDATE $new.id SET extractionEntropy = $entropy;
+        };
+        RETURN { outcome: 'INSERTED', factId: $new.id, reason: NONE };
+    };
+
+    -- Backdated guard (migration 0043): for single_active, a candidate with
+    -- a STRICTLY NEWER validFrom means the incoming fact is history. Slot it
+    -- before the next-newer decision as an already-superseded row; the
+    -- active timeline stays exactly as if events had arrived in order.
+    LET $next_after = IF $semantics = 'single_active' THEN
+        (SELECT id, validFrom FROM $competing
+            WHERE validFrom > $valid_from
+            ORDER BY validFrom ASC LIMIT 1)[0]
+    ELSE
+        NONE
+    END;
+
+    IF $next_after != NONE {
+        -- Same sentinel shape as a natural supersede (no retractedAt —
+        -- migration 0014; retractionReason 'superseded' feeds revive +
+        -- calibration).
+        UPDATE $new.id SET
+            status = 'superseded',
+            retractionReason = 'superseded',
+            retractedBy = 'system',
+            supersededBy = $next_after.id,
+            priorValidUntil = $valid_until,
+            validUntil = $next_after.validFrom;
+        RETURN {
+            outcome: 'INSERTED_HISTORICAL',
+            factId: $new.id,
+            supersededByFactId: $next_after.id,
+            reason: 'backdated'
+        };
+    };
+
+    LET $scored = SELECT
+        id,
+        confidence,
+        source,
+        validFrom,
+        object,
+        predicate,
+        $w_confidence * confidence AS sc_confidence,
+        $w_source_trust * fn::source_trust_for(fn::source_key_of(source)) AS sc_source_trust,
+        $w_recency * math::pow(math::E, - duration::secs(time::now() - recordedAt) / 31536000) AS sc_recency,
+        $w_authority * 0.0 AS sc_authority,
+        ($w_confidence * confidence
+         + $w_source_trust * fn::source_trust_for(fn::source_key_of(source))
+         + $w_recency * math::pow(math::E, - duration::secs(time::now() - recordedAt) / 31536000)
+         + $w_authority * 0.0
+        ) AS score
+    FROM $competing;
+
+    LET $best_opp_score = math::max($scored.score);
+    LET $best_opp = (SELECT * FROM $scored WHERE score = $best_opp_score LIMIT 1)[0];
+
+    LET $winner_components = {
+        confidence: $w_confidence * $confidence,
+        sourceTrust: $w_source_trust * $source_trust,
+        recency: $w_recency * 1.0,
+        authority: $w_authority * 0.0
+    };
+    LET $loser_components = {
+        confidence: $best_opp.sc_confidence,
+        sourceTrust: $best_opp.sc_source_trust,
+        recency: $best_opp.sc_recency,
+        authority: $best_opp.sc_authority
+    };
+
+    LET $abs_conf = math::abs($winner_components.confidence - $loser_components.confidence);
+    LET $abs_st   = math::abs($winner_components.sourceTrust - $loser_components.sourceTrust);
+    LET $abs_rec  = math::abs($winner_components.recency - $loser_components.recency);
+    LET $abs_auth = math::abs($winner_components.authority - $loser_components.authority);
+    LET $max_abs  = math::max([$abs_conf, $abs_st, $abs_rec, $abs_auth]);
+
+    LET $dominant_dim = IF $max_abs = $abs_conf THEN 'confidence'
+                       ELSE IF $max_abs = $abs_st THEN 'source_trust'
+                       ELSE IF $max_abs = $abs_rec THEN 'recency'
+                       ELSE 'authority'
+                       END;
+
+    LET $slot_delta = {
+        predicate: ($best_opp.predicate != $predicate),
+        object: ($best_opp.object != $object),
+        validFrom: ($best_opp.validFrom != $valid_from),
+        source: ($best_opp.source != $source)
+    };
+
+    LET $score_breakdown = {
+        winner: {
+            total: $new_score,
+            confidence: $winner_components.confidence,
+            sourceTrust: $winner_components.sourceTrust,
+            recency: $winner_components.recency,
+            authority: $winner_components.authority
+        },
+        loser: {
+            total: $best_opp_score,
+            confidence: $loser_components.confidence,
+            sourceTrust: $loser_components.sourceTrust,
+            recency: $loser_components.recency,
+            authority: $loser_components.authority
+        },
+        margin: $new_score - $best_opp_score
+    };
+
+    LET $supersede =
+        $semantics = 'single_active'
+        OR $new_score >= $best_opp_score + $margin_for_supersede;
+
+    LET $loser_ids = $competing.id;
+
+    IF $supersede {
+        -- NO `retractedAt = time::now()` — a natural supersede is not a
+        -- retraction (migration 0014). Keep the retractionReason +
+        -- retractedBy sentinel that revive + calibration depend on.
+        FOR $loser IN $competing {
+            UPDATE $loser.id SET
+                status = 'superseded',
+                retractionReason = 'superseded',
+                retractedBy = 'system',
+                supersededBy = $new.id,
+                priorValidUntil = $loser.validUntil,
+                validUntil = $valid_from;
+        };
+        -- Conflict trace (migration 0044): persist the decision the fn just
+        -- computed — the fact remembers WHY it won.
+        UPDATE $new.id SET conflictTrace = {
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            decidedAt: time::now()
+        };
+        RETURN {
+            outcome: 'SUPERSEDED',
+            factId: $new.id,
+            supersededFactIds: $loser_ids,
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            reason: NONE
+        };
+    };
+
+    UPDATE $new.id SET
+        status = 'competing',
+        conflictTrace = {
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            decidedAt: time::now()
+        };
+    UPDATE knowledge_fact SET status = 'competing' WHERE id IN $loser_ids;
+    RETURN {
+        outcome: 'COMPETING',
+        factId: $new.id,
+        competingFactIds: $loser_ids,
+        scoreBreakdown: $score_breakdown,
+        dominantDimension: $dominant_dim,
+        slotDelta: $slot_delta,
+        bestOpponentId: $best_opp.id,
+        reason: NONE
+    };
+};

--- a/src/ingest/dto/ingest-fact.dto.ts
+++ b/src/ingest/dto/ingest-fact.dto.ts
@@ -24,12 +24,36 @@ export interface EntityRef {
   entityId?: string;
 }
 
+/**
+ * One supporting observation behind a fact — a typed pointer to where the
+ * claim came from (an event row, a message, a URL, a document, a commit…).
+ * Stored verbatim inside `knowledge_fact.source` (FLEXIBLE), so it needs
+ * no migration and survives round-trips. Shape-checked in
+ * FactIngestService (see evidenceValidationError in ingest-utils.ts) —
+ * class-validator can't nest into the opaque source object.
+ */
+export interface SourceEvidence {
+  kind:
+    | 'event'
+    | 'message'
+    | 'conversation'
+    | 'url'
+    | 'document'
+    | 'commit'
+    | 'other';
+  /** The pointer itself — id, URL, path, sha… ≤512 chars. */
+  ref: string;
+  note?: string;
+}
+
 export interface FactSource {
   vertical: string;
   eventId?: string;
   conversationId?: string;
   messageId?: string;
   recorder?: string;
+  /** Supporting observations behind the claim — ≤10 entries. */
+  evidence?: SourceEvidence[];
 }
 
 export class IngestFactDto {

--- a/src/ingest/fact-ingest.service.ts
+++ b/src/ingest/fact-ingest.service.ts
@@ -8,6 +8,7 @@ import {
 } from './conflict-explainer';
 import { EntityUpsertService } from './entity-upsert.service';
 import { FactResolverService } from './fact-resolver.service';
+import { evidenceValidationError } from './ingest-utils';
 
 /**
  * The typed direct-ingest path (`ingestFact`): a single fully-specified fact
@@ -38,6 +39,12 @@ export class FactIngestService {
           'validUntil must be strictly after validFrom',
         );
       }
+    }
+    // source is an opaque @IsObject (union shape) — nested evidence[] must
+    // be shape-checked here, not by class-validator.
+    const evidenceError = evidenceValidationError(dto.source?.evidence);
+    if (evidenceError) {
+      throw new BadRequestException(evidenceError);
     }
     return this.surreal.withCompany(companyId, async (db) => {
       // 1. Resolve entity (own atomic step — own tx with unique-retry).

--- a/src/ingest/ingest-utils.ts
+++ b/src/ingest/ingest-utils.ts
@@ -60,6 +60,53 @@ export function sourceTrustFor(source: {
   return SOURCE_TRUST.default;
 }
 
+const EVIDENCE_KINDS = new Set([
+  'event',
+  'message',
+  'conversation',
+  'url',
+  'document',
+  'commit',
+  'other',
+]);
+const EVIDENCE_MAX_ITEMS = 10;
+const EVIDENCE_MAX_REF = 512;
+const EVIDENCE_MAX_NOTE = 512;
+
+/**
+ * Shape-check for `source.evidence` (SourceEvidence[]). Returns a
+ * human-readable error string, or null when valid/absent. Lives here (not
+ * class-validator) because `source` is an opaque @IsObject — the global
+ * whitelist pipe would strip a nested union. Caps keep the FLEXIBLE
+ * source object from becoming an unbounded blob on the hot write path.
+ */
+export function evidenceValidationError(evidence: unknown): string | null {
+  if (evidence === undefined) return null;
+  if (!Array.isArray(evidence)) return 'source.evidence must be an array';
+  if (evidence.length > EVIDENCE_MAX_ITEMS) {
+    return `source.evidence must have at most ${EVIDENCE_MAX_ITEMS} entries`;
+  }
+  for (const [i, e] of evidence.entries()) {
+    if (e === null || typeof e !== 'object' || Array.isArray(e)) {
+      return `source.evidence[${i}] must be an object`;
+    }
+    const { kind, ref, note } = e as Record<string, unknown>;
+    if (typeof kind !== 'string' || !EVIDENCE_KINDS.has(kind)) {
+      return `source.evidence[${i}].kind must be one of ${[...EVIDENCE_KINDS].join('|')}`;
+    }
+    if (typeof ref !== 'string' || ref.length === 0 || ref.length > EVIDENCE_MAX_REF) {
+      return `source.evidence[${i}].ref must be a non-empty string of at most ${EVIDENCE_MAX_REF} chars`;
+    }
+    if (
+      note !== undefined &&
+      (typeof note !== 'string' || note.length > EVIDENCE_MAX_NOTE)
+    ) {
+      return `source.evidence[${i}].note must be a string of at most ${EVIDENCE_MAX_NOTE} chars`;
+    }
+  }
+  return null;
+}
+
 /**
  * Gate for the HyPE post-INSERT alt-embedding UPDATE. We only generate +
  * write the hypothetical-question embedding when a fact was actually

--- a/test/ingest-utils.unit-spec.ts
+++ b/test/ingest-utils.unit-spec.ts
@@ -4,6 +4,7 @@ import {
   redactPii,
   sourceTrustFor,
   shouldWriteHypeAltEmbedding,
+  evidenceValidationError,
 } from '../src/ingest/ingest-utils';
 import { SOURCE_TRUST } from '../src/ingest/conflict-resolver';
 
@@ -114,5 +115,57 @@ describe('shouldWriteHypeAltEmbedding', () => {
     ]) {
       expect(shouldWriteHypeAltEmbedding(outcome, true, 'fact:1')).toBe(false);
     }
+  });
+});
+
+describe('evidenceValidationError', () => {
+  const good = { kind: 'url', ref: 'https://example.com/doc' };
+
+  it('accepts absent evidence', () => {
+    expect(evidenceValidationError(undefined)).toBeNull();
+  });
+
+  it('accepts a valid list with optional note', () => {
+    expect(
+      evidenceValidationError([
+        good,
+        { kind: 'commit', ref: 'a'.repeat(40), note: 'introduced the invariant' },
+      ]),
+    ).toBeNull();
+  });
+
+  it('rejects non-array evidence', () => {
+    expect(evidenceValidationError({})).toMatch(/must be an array/);
+  });
+
+  it('rejects more than 10 entries', () => {
+    expect(evidenceValidationError(Array(11).fill(good))).toMatch(/at most 10/);
+  });
+
+  it('rejects an unknown kind', () => {
+    expect(evidenceValidationError([{ kind: 'rumor', ref: 'x' }])).toMatch(
+      /kind must be one of/,
+    );
+  });
+
+  it('rejects a missing / empty / oversized ref', () => {
+    expect(evidenceValidationError([{ kind: 'url' }])).toMatch(/ref/);
+    expect(evidenceValidationError([{ kind: 'url', ref: '' }])).toMatch(/ref/);
+    expect(
+      evidenceValidationError([{ kind: 'url', ref: 'a'.repeat(513) }]),
+    ).toMatch(/ref/);
+  });
+
+  it('rejects a non-string or oversized note', () => {
+    expect(
+      evidenceValidationError([{ ...good, note: 42 as unknown as string }]),
+    ).toMatch(/note/);
+    expect(
+      evidenceValidationError([{ ...good, note: 'a'.repeat(513) }]),
+    ).toMatch(/note/);
+  });
+
+  it('rejects non-object entries', () => {
+    expect(evidenceValidationError(['x'])).toMatch(/must be an object/);
   });
 });

--- a/test/trust-snapshot.e2e-spec.ts
+++ b/test/trust-snapshot.e2e-spec.ts
@@ -1,0 +1,143 @@
+/**
+ * e2e for the source-reputation track, Phase 1 (migration 0044):
+ *
+ *   1. Every created fact carries `trustSnapshot` — what the resolver
+ *      believed about the source AT WRITE TIME ({sourceKey, domain,
+ *      declaredTrust, learnedTrust, calculatedAt}), frozen on the row so a
+ *      later nightly refit can never silently rewrite the history.
+ *   2. A conflict winner carries `conflictTrace` — the scoreBreakdown /
+ *      dominantDimension / slotDelta the fn computed, which until 0044 was
+ *      returned once (explain:true) and thrown away.
+ *   3. `source.evidence[]` round-trips verbatim through the FLEXIBLE
+ *      source object; malformed evidence is a 400 at the API boundary.
+ */
+import { SurrealService } from '../src/db/surreal.service';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+
+describe('trust snapshot + conflict trace + evidence (Phase 1)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const factRow = async (factId: string) => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<any[][]>(
+        `SELECT * FROM type::record('knowledge_fact', $rid)`,
+        { rid: factId.split(':')[1] },
+      );
+      return (rows as any[])?.[0];
+    });
+  };
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_trust_snapshot_e2e' });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('stamps trustSnapshot on an INSERTED fact', async () => {
+    const res = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: { vertical: 'rent', id: 'trust_snap_customer' },
+      predicate: 'status',
+      object: 'active',
+      validFrom: '2026-01-01T00:00:00Z',
+      // billing.* eventId → declared trust 0.95 in the static tier table.
+      source: { vertical: 'rent', eventId: 'billing.subscription_started' },
+      confidence: 0.9,
+    });
+    expect(res.body.outcome).toBe('INSERTED');
+
+    const row = await factRow(res.body.factId);
+    expect(row.trustSnapshot).toBeDefined();
+    // fn::source_key_of: `${vertical}:${recorder ?? '_'}`.
+    expect(row.trustSnapshot.sourceKey).toBe('rent:_');
+    // Phase 1: domain = the predicate (generic string — Phase 2 scopes
+    // reputation by it; a topic layer can reuse the field later).
+    expect(row.trustSnapshot.domain).toBe('status');
+    expect(row.trustSnapshot.declaredTrust).toBeCloseTo(0.95);
+    // No refit has run for this tenant → learned rate is the 0.5 neutral.
+    expect(row.trustSnapshot.learnedTrust).toBeCloseTo(0.5);
+    expect(row.trustSnapshot.calculatedAt).toBeDefined();
+  });
+
+  it('persists conflictTrace on a supersede winner, matching the explain payload', async () => {
+    const entityRef = { vertical: 'rent', id: 'trust_trace_customer' };
+    const first = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef,
+      predicate: 'status',
+      object: 'trial',
+      validFrom: '2026-01-01T00:00:00Z',
+      source: { vertical: 'rent', eventId: 'auth.signup' },
+      confidence: 0.8,
+    });
+    expect(first.body.outcome).toBe('INSERTED');
+
+    const second = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef,
+      predicate: 'status',
+      object: 'premium',
+      validFrom: '2026-03-01T00:00:00Z',
+      source: { vertical: 'rent', eventId: 'billing.tier_upgraded' },
+      confidence: 0.9,
+      explain: true,
+    });
+    expect(second.body.outcome).toBe('SUPERSEDED');
+    const explanation = second.body.conflictExplanation;
+    expect(explanation).toBeDefined();
+
+    const row = await factRow(second.body.factId);
+    expect(row.conflictTrace).toBeDefined();
+    // The stored trace is the same decision the explain path narrated.
+    expect(row.conflictTrace.scoreBreakdown).toEqual(
+      explanation.scoreBreakdown,
+    );
+    expect(row.conflictTrace.dominantDimension).toBe(
+      explanation.dominantDimension,
+    );
+    expect(row.conflictTrace.slotDelta).toEqual(explanation.slotDelta);
+    expect(String(row.conflictTrace.bestOpponentId)).toBe(first.body.factId);
+    expect(row.conflictTrace.decidedAt).toBeDefined();
+
+    // The loser keeps NO conflictTrace — the trace belongs to the decision
+    // that created the new fact.
+    const loser = await factRow(first.body.factId);
+    expect(loser.conflictTrace).toBeUndefined();
+    // But both rows carry their own write-time trustSnapshot.
+    expect(loser.trustSnapshot).toBeDefined();
+  });
+
+  it('round-trips source.evidence[] and rejects malformed evidence', async () => {
+    const evidence = [
+      { kind: 'url', ref: 'https://docs.example.com/policy#42' },
+      { kind: 'commit', ref: 'deadbeef', note: 'where the rule landed' },
+    ];
+    const ok = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: { vertical: 'rent', id: 'trust_evidence_customer' },
+      predicate: 'preference',
+      object: 'prefers email contact',
+      validFrom: '2026-01-01T00:00:00Z',
+      source: { vertical: 'rent', recorder: 'ops_bot', evidence },
+      confidence: 0.9,
+    });
+    expect(ok.status).toBe(201);
+    const row = await factRow(ok.body.factId);
+    expect(row.source.evidence).toEqual(evidence);
+    expect(row.trustSnapshot.sourceKey).toBe('rent:ops_bot');
+
+    const bad = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: { vertical: 'rent', id: 'trust_evidence_customer' },
+      predicate: 'preference',
+      object: 'prefers sms contact',
+      validFrom: '2026-01-01T00:00:00Z',
+      source: {
+        vertical: 'rent',
+        evidence: [{ kind: 'rumor', ref: 'heard it somewhere' }],
+      },
+    });
+    expect(bad.status).toBe(400);
+    expect(JSON.stringify(bad.body)).toMatch(/kind must be one of/);
+  });
+});


### PR DESCRIPTION
## Что это

Фаза 1 трека **Source Identity + Reputation + Evidence** («Fact is not true. Fact is claimed by source, extracted from evidence, trusted under context»). Факты начинают навсегда помнить, что резолвер думал об источнике **на момент записи**, а конфликтные решения перестают быть эфемерными.

## Изменения

**Миграция 0044** — `fn::resolve_fact` тело 0043 verbatim + 3 дельты (сигнатура 21 арг не меняется, TS call-site не тронут):
- `knowledge_fact.trustSnapshot` (FLEXIBLE) на **каждом** созданном факте: `{sourceKey, domain, declaredTrust, learnedTrust, calculatedAt}`. `learnedTrust` читается в момент записи — nightly-рефит потом перезаписывает `source_trust` in-place, а снапшот остаётся нетронутой записью того, во что резолвер реально верил. `domain` = предикат (v1); Ф2 скоупит репутацию по этой же generic-строке, топик-слой ляжет позже без миграции.
- `knowledge_fact.conflictTrace` (FLEXIBLE) на победителе SUPERSEDED/COMPETING: уже посчитанный `scoreBreakdown/dominantDimension/slotDelta/bestOpponentId` — раньше считался, возвращался разово (`explain:true`) и выбрасывался.

**Evidence**: `FactSource.evidence?: {kind: event|message|conversation|url|document|commit|other, ref, note?}[]` — едет внутри FLEXIBLE `source` (без миграции), shape-check на границе API (`evidenceValidationError`, ≤10 шт, ref/note ≤512) — class-validator в opaque-union не залезает.

Старые факты: оба поля `NONE`, ретро-бэкфилла нет (он нарушал бы сам принцип снапшота).

## Тесты

877 unit / 169 e2e зелёные. Новые: `trust-snapshot.e2e-spec` (снапшот на INSERTED c проверкой sourceKey/declared/learned; `conflictTrace` == explain-payload на SUPERSEDED; evidence round-trip + 400 на мусор), unit-кейсы валидатора.

## Дальше по треку

Ф2 доменная репутация `(sourceKey, domain)` + history → Ф3 source_registry + активация мёртвого authority-слота + read-API → Ф4 корроборация → Ф5 fact_trust в ранжировании (за флагами).

🤖 Generated with [Claude Code](https://claude.com/claude-code)