### PR TITLE
feat(trust): domain-scoped source reputation + history (source-reputation phase 2)

### DIFF
--- a/src/ai/calibration/calibration-refit-runner.service.ts
+++ b/src/ai/calibration/calibration-refit-runner.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { Surreal } from 'surrealdb';
 import { ApiKeyService } from '../../auth/api-key.service';
 import { SurrealService } from '../../db/surreal.service';
 import {
@@ -150,6 +151,16 @@ export class CalibrationRefitRunnerService {
     });
   }
 
+  /**
+   * Recompute learned source trust for one tenant at BOTH grains: the
+   * global per-source rate (domain NONE — what existed pre-0045) and the
+   * domain-scoped rate ((sourceKey, domain), domain = predicate for now).
+   * fn::source_trust_scoped resolves scoped → global → 0.5, so scoped rows
+   * simply sharpen the picture where a source has enough same-predicate
+   * history. Rate movements (or first sightings) append to
+   * source_trust_history — the reputation-over-time trail; the hot
+   * source_trust row stays an in-place UPSERT cache.
+   */
   private async refitSourceTrustForTenant(companyId: string): Promise<number> {
     return this.surreal.withCompany(companyId, async (db) => {
       const [rows] = await db.query<
@@ -157,13 +168,16 @@ export class CalibrationRefitRunnerService {
           Array<{
             vertical: string | null;
             recorder: string | null;
+            predicate: string;
             status: string;
+            recordedAt: string | Date;
           }>,
         ]
       >(
         `SELECT
             source.vertical AS vertical,
             source.recorder AS recorder,
+            predicate,
             status,
             recordedAt
           FROM knowledge_fact
@@ -173,38 +187,93 @@ export class CalibrationRefitRunnerService {
       );
       const events = (rows ?? []).map((r) => ({
         sourceKey: `${r.vertical}:${r.recorder ?? '_'}`,
+        domain: r.predicate,
         win: r.status === 'active' ? 1 : 0,
         loss: r.status === 'superseded' || r.status === 'retracted' ? 1 : 0,
+        recordedAt: r.recordedAt,
       }));
-      const summary = aggregateBySourceKey(events);
+      const summary = aggregateByScope(events);
+
+      // Prior rates in one read — the |Δ| > 0.01 history gate needs them,
+      // and per-scope SELECTs would be N extra round-trips.
+      const [existingRows] = await db.query<
+        [Array<{ sourceKey: string; domain: string | null; agreementRate: number }>]
+      >(`SELECT sourceKey, domain, agreementRate FROM source_trust;`);
+      const prior = new Map<string, number>();
+      for (const r of existingRows ?? []) {
+        prior.set(scopeKeyOf(r.sourceKey, r.domain ?? null), r.agreementRate);
+      }
 
       let upsertedHere = 0;
-      for (const { sourceKey, wins, losses } of summary) {
-        const sampleCount = wins + losses;
-        if (sampleCount === 0) continue;
-        const rate = wins / sampleCount;
-        await db.query(
-          `LET $existing = (SELECT id FROM source_trust
-              WHERE sourceKey = $k LIMIT 1)[0];
-           IF $existing IS NONE THEN
-             CREATE source_trust CONTENT {
-               sourceKey: $k,
-               agreementRate: $r,
-               sampleCount: $sc,
-               lastUpdated: time::now()
-             }
-           ELSE
-             UPDATE $existing.id SET
-               agreementRate = $r,
-               sampleCount = $sc,
-               lastUpdated = time::now()
-           END;`,
-          { k: sourceKey, r: rate, sc: sampleCount },
-        );
+      for (const scope of summary) {
+        if (scope.wins + scope.losses === 0) continue;
+        await this.upsertTrustScope(db, {
+          ...scope,
+          prevRate: prior.get(scopeKeyOf(scope.sourceKey, scope.domain)) ?? null,
+        });
         upsertedHere++;
       }
       return upsertedHere;
     });
+  }
+
+  /** UPSERT one (sourceKey, domain) trust row + append history when the
+   *  rate moved (or the scope is first seen). `domain: null` = the global
+   *  row; SurrealDB option<> rejects JS null, so the global variant omits
+   *  the field entirely and matches with `domain IS NONE`. */
+  private async upsertTrustScope(
+    db: Surreal,
+    scope: TrustScope & { prevRate: number | null },
+  ): Promise<void> {
+    const sampleCount = scope.wins + scope.losses;
+    const rate = scope.wins / sampleCount;
+    const isGlobal = scope.domain === null;
+    const params: Record<string, unknown> = {
+      k: scope.sourceKey,
+      r: rate,
+      sc: sampleCount,
+      w: scope.wins,
+      l: scope.losses,
+      ls: scope.lastSeenAt,
+      ...(isGlobal ? {} : { d: scope.domain }),
+    };
+    const domainWhere = isGlobal ? 'domain IS NONE' : 'domain = $d';
+    await db.query(
+      `LET $existing = (SELECT id FROM source_trust
+          WHERE sourceKey = $k AND ${domainWhere} LIMIT 1)[0];
+       IF $existing IS NONE THEN
+         CREATE source_trust CONTENT {
+           sourceKey: $k,
+           ${isGlobal ? '' : 'domain: $d,'}
+           agreementRate: $r,
+           sampleCount: $sc,
+           winCount: $w,
+           lossCount: $l,
+           lastSeenAt: $ls,
+           lastUpdated: time::now()
+         }
+       ELSE
+         UPDATE $existing.id SET
+           agreementRate = $r,
+           sampleCount = $sc,
+           winCount = $w,
+           lossCount = $l,
+           lastSeenAt = $ls,
+           lastUpdated = time::now()
+       END;`,
+      params,
+    );
+    if (scope.prevRate === null || Math.abs(scope.prevRate - rate) > 0.01) {
+      await db.query(
+        `CREATE source_trust_history CONTENT {
+            sourceKey: $k,
+            ${isGlobal ? '' : 'domain: $d,'}
+            agreementRate: $r,
+            sampleCount: $sc
+         };`,
+        params,
+      );
+    }
   }
 
   private async collectCalibrationPairsForTenant(
@@ -298,26 +367,58 @@ export function isCorrect(row: {
   return true;
 }
 
+export interface TrustScope {
+  sourceKey: string;
+  /** null = the global per-source rate (domain NONE in the DB). */
+  domain: string | null;
+  wins: number;
+  losses: number;
+  lastSeenAt: Date;
+}
+
+/** Map key for a (sourceKey, domain) scope — NUL can't appear in either. */
+export function scopeKeyOf(sourceKey: string, domain: string | null): string {
+  return `${sourceKey}\u0000${domain ?? ''}`;
+}
+
 /**
- * Roll up per-row {win, loss} tuples into {wins, losses} per
- * sourceKey. Exported so the unit test can exercise the math
- * without a SurrealDB round-trip.
+ * Roll up per-row {win, loss} tuples into {wins, losses, lastSeenAt} at
+ * BOTH reputation grains: (sourceKey, domain) and the global
+ * (sourceKey, null). Every row feeds both — the global rate stays exactly
+ * the pre-0045 blended number while scoped rows sharpen it per domain.
+ * Exported so the unit test can exercise the math without a SurrealDB
+ * round-trip.
  */
-export function aggregateBySourceKey(
-  rows: ReadonlyArray<{ sourceKey: string; win: number; loss: number }>,
-): Array<{ sourceKey: string; wins: number; losses: number }> {
-  const byKey = new Map<string, { wins: number; losses: number }>();
+export function aggregateByScope(
+  rows: ReadonlyArray<{
+    sourceKey: string;
+    domain: string;
+    win: number;
+    loss: number;
+    recordedAt: string | Date;
+  }>,
+): TrustScope[] {
+  const byScope = new Map<string, TrustScope>();
   for (const r of rows) {
-    const acc = byKey.get(r.sourceKey) ?? { wins: 0, losses: 0 };
-    acc.wins += r.win;
-    acc.losses += r.loss;
-    byKey.set(r.sourceKey, acc);
+    const seenAt = new Date(r.recordedAt);
+    for (const domain of [r.domain, null] as Array<string | null>) {
+      const key = scopeKeyOf(r.sourceKey, domain);
+      const acc =
+        byScope.get(key) ??
+        ({
+          sourceKey: r.sourceKey,
+          domain,
+          wins: 0,
+          losses: 0,
+          lastSeenAt: seenAt,
+        } satisfies TrustScope);
+      acc.wins += r.win;
+      acc.losses += r.loss;
+      if (seenAt.getTime() > acc.lastSeenAt.getTime()) acc.lastSeenAt = seenAt;
+      byScope.set(key, acc);
+    }
   }
-  return [...byKey.entries()].map(([sourceKey, v]) => ({
-    sourceKey,
-    wins: v.wins,
-    losses: v.losses,
-  }));
+  return [...byScope.values()];
 }
 
 function clamp01(x: number): number {

--- a/src/db/migrations/0045_source_trust_scoped.surql
+++ b/src/db/migrations/0045_source_trust_scoped.surql
@@ -1,0 +1,338 @@
+-- 0045_source_trust_scoped — DOMAIN-SCOPED source reputation.
+--
+-- Source-reputation track, Phase 2 (the core ask). A source is not equally
+-- trustworthy everywhere: a broker is authoritative on availability-today
+-- and guesswork on investment forecasts. Until now `source_trust` held ONE
+-- blended agreementRate per source; this migration scopes it by `domain`.
+--
+-- `domain` is a GENERIC string. v1 writes the predicate id into it — the
+-- axis conflicts actually happen on (the resolver only ever compares
+-- same-predicate facts, so the reputation that decides a conflict should
+-- be the same-predicate reputation). A later topic layer (grouping
+-- predicates via domain packs) reuses the same field with no migration.
+--
+-- Shape:
+--   * source_trust gains `domain option<string>` (+ winCount/lossCount/
+--     lastSeenAt observability). Rows with domain NONE are the GLOBAL
+--     per-source rate — exactly what pre-0045 rows already are, so the
+--     existing data degrades cleanly into the new model.
+--   * UNIQUE index moves from (sourceKey) to (sourceKey, domain).
+--   * `source_trust_history` — append-only trail written by the nightly
+--     refit when a rate moves: the "reputation over time" record. The hot
+--     `source_trust` row stays an UPSERT cache (same split as
+--     calibration_table's versioned rows vs the in-process hot copy).
+--   * fn::source_trust_scoped($key, $domain) — lookup ladder:
+--     scoped row (sampleCount>=8) → global row (>=8) → neutral 0.5.
+--     fn::source_trust_for stays untouched for compat.
+--   * fn::resolve_fact (body 0044 VERBATIM + delta): the loser-side learned
+--     trust and the trustSnapshot.learnedTrust go through the scoped
+--     lookup. Winner-side stays the caller-supplied static heuristic —
+--     the deliberate asymmetry from 0022 ("winner trust encodes what kind
+--     of source this is, loser trust encodes how well it has historically
+--     won conflicts") is preserved.
+--
+-- Behavior drift is monotone: only sources with >=8 scoped samples in a
+-- predicate shift away from their global rate (the refit must run before
+-- any scoped rows exist at all).
+
+DEFINE FIELD IF NOT EXISTS domain ON source_trust TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS winCount ON source_trust TYPE int DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS lossCount ON source_trust TYPE int DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS lastSeenAt ON source_trust TYPE option<datetime>;
+
+-- (sourceKey) UNIQUE → (sourceKey, domain) UNIQUE. Existing rows have
+-- domain NONE (the global row) — still unique per key under the composite.
+REMOVE INDEX IF EXISTS source_trust_key_idx ON TABLE source_trust;
+DEFINE INDEX IF NOT EXISTS source_trust_scope_idx
+    ON source_trust FIELDS sourceKey, domain UNIQUE;
+
+-- Append-only reputation trail. One row per (sourceKey, domain) per
+-- nightly refit that MOVED the rate (|Δ| > 0.01) or first observed the
+-- scope — "what was this source's reputation over time", queryable without
+-- forensics over fact rows.
+DEFINE TABLE IF NOT EXISTS source_trust_history SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS sourceKey ON source_trust_history TYPE string;
+DEFINE FIELD IF NOT EXISTS domain ON source_trust_history TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS agreementRate ON source_trust_history TYPE float
+    ASSERT $value >= 0 AND $value <= 1;
+DEFINE FIELD IF NOT EXISTS sampleCount ON source_trust_history TYPE int;
+DEFINE FIELD IF NOT EXISTS recordedAt ON source_trust_history TYPE datetime
+    DEFAULT time::now();
+DEFINE INDEX IF NOT EXISTS source_trust_history_scope_idx
+    ON source_trust_history FIELDS sourceKey, domain;
+
+-- Lookup ladder: scoped (>=8 samples) → global (>=8) → neutral 0.5. The
+-- 8-sample bootstrap matches fn::source_trust_for (FaithfulRAG, 0017).
+DEFINE FUNCTION OVERWRITE fn::source_trust_scoped($source_key: string, $domain: string) {
+    LET $scoped = (SELECT agreementRate, sampleCount FROM source_trust
+                   WHERE sourceKey = $source_key AND domain = $domain LIMIT 1)[0];
+    IF $scoped IS NOT NONE AND $scoped.sampleCount >= 8 {
+        RETURN $scoped.agreementRate;
+    };
+    LET $global = (SELECT agreementRate, sampleCount FROM source_trust
+                   WHERE sourceKey = $source_key AND domain IS NONE LIMIT 1)[0];
+    RETURN IF $global IS NONE OR $global.sampleCount < 8 THEN
+        0.5
+    ELSE
+        $global.agreementRate
+    END;
+};
+
+DEFINE FUNCTION OVERWRITE fn::resolve_fact(
+    $entity_id: record<knowledge_entity>,
+    $predicate: string,
+    $object: string,
+    $object_meta: option<object>,
+    $embedding: array<float>,
+    $confidence: float,
+    $valid_from: datetime,
+    $valid_until: option<datetime>,
+    $source: object,
+    $source_trust: float,
+    $semantics: string,
+    $similarity_threshold: float,
+    $w_confidence: float,
+    $w_source_trust: float,
+    $w_recency: float,
+    $w_authority: float,
+    $reject_threshold: float,
+    $margin_for_supersede: float,
+    $lang: option<string>,
+    $script: option<string>,
+    $entropy: option<float>
+) {
+    LET $new_score =
+        $w_confidence * $confidence
+        + $w_source_trust * $source_trust
+        + $w_recency * 1.0
+        + $w_authority * 0.0;
+
+    IF $semantics = 'bitemporal' AND $new_score < $reject_threshold {
+        CREATE ingest_dead_letter CONTENT {
+            payload: { entityId: $entity_id, predicate: $predicate, object: $object, source: $source },
+            reason: 'low_score: ' + <string>$new_score
+        };
+        RETURN { outcome: 'REJECTED', factId: NONE, reason: 'low_score' };
+    };
+
+    LET $candidates = SELECT
+        id, predicate, object, confidence, recordedAt, source, embedding,
+        validFrom, validUntil
+    FROM knowledge_fact
+    WHERE entityId = $entity_id
+      AND predicate = $predicate
+      AND status = 'active'
+      AND retractedAt IS NONE;
+
+    LET $competing = IF $semantics = 'append_only' THEN
+        []
+    ELSE IF $semantics = 'single_active' THEN
+        $candidates
+    ELSE
+        (SELECT * FROM $candidates
+            WHERE embedding != NONE
+              AND vector::similarity::cosine(embedding, $embedding) >= $similarity_threshold
+              AND fn::intervals_overlap(validFrom, validUntil, $valid_from, $valid_until))
+    END;
+
+    -- Trust snapshot (migration 0044): what the resolver believes about this
+    -- source RIGHT NOW, frozen onto the fact. learnedTrust is read before
+    -- any nightly refit can overwrite the source_trust row. Scoped lookup
+    -- since migration 0045.
+    LET $src_key = fn::source_key_of($source);
+
+    LET $new = CREATE ONLY knowledge_fact CONTENT {
+        entityId: $entity_id,
+        predicate: $predicate,
+        object: $object,
+        objectMeta: $object_meta,
+        confidence: $confidence,
+        validFrom: $valid_from,
+        validUntil: $valid_until,
+        source: $source,
+        embedding: $embedding,
+        status: 'active',
+        trustSnapshot: {
+            sourceKey: $src_key,
+            domain: $predicate,
+            declaredTrust: $source_trust,
+            learnedTrust: fn::source_trust_scoped($src_key, $predicate),
+            calculatedAt: time::now()
+        }
+    };
+
+    IF array::len($competing) = 0 {
+        -- Locale + entropy folded in from the caller (migration 0039). Applied
+        -- on INSERTED only, matching the old post-call UPDATE gate.
+        IF $lang != NONE {
+            UPDATE $new.id SET lang = $lang, script = $script;
+        };
+        IF $entropy != NONE {
+            UPDATE $new.id SET extractionEntropy = $entropy;
+        };
+        RETURN { outcome: 'INSERTED', factId: $new.id, reason: NONE };
+    };
+
+    -- Backdated guard (migration 0043): for single_active, a candidate with
+    -- a STRICTLY NEWER validFrom means the incoming fact is history. Slot it
+    -- before the next-newer decision as an already-superseded row; the
+    -- active timeline stays exactly as if events had arrived in order.
+    LET $next_after = IF $semantics = 'single_active' THEN
+        (SELECT id, validFrom FROM $competing
+            WHERE validFrom > $valid_from
+            ORDER BY validFrom ASC LIMIT 1)[0]
+    ELSE
+        NONE
+    END;
+
+    IF $next_after != NONE {
+        -- Same sentinel shape as a natural supersede (no retractedAt —
+        -- migration 0014; retractionReason 'superseded' feeds revive +
+        -- calibration).
+        UPDATE $new.id SET
+            status = 'superseded',
+            retractionReason = 'superseded',
+            retractedBy = 'system',
+            supersededBy = $next_after.id,
+            priorValidUntil = $valid_until,
+            validUntil = $next_after.validFrom;
+        RETURN {
+            outcome: 'INSERTED_HISTORICAL',
+            factId: $new.id,
+            supersededByFactId: $next_after.id,
+            reason: 'backdated'
+        };
+    };
+
+    LET $scored = SELECT
+        id,
+        confidence,
+        source,
+        validFrom,
+        object,
+        predicate,
+        $w_confidence * confidence AS sc_confidence,
+        $w_source_trust * fn::source_trust_scoped(fn::source_key_of(source), $predicate) AS sc_source_trust,
+        $w_recency * math::pow(math::E, - duration::secs(time::now() - recordedAt) / 31536000) AS sc_recency,
+        $w_authority * 0.0 AS sc_authority,
+        ($w_confidence * confidence
+         + $w_source_trust * fn::source_trust_scoped(fn::source_key_of(source), $predicate)
+         + $w_recency * math::pow(math::E, - duration::secs(time::now() - recordedAt) / 31536000)
+         + $w_authority * 0.0
+        ) AS score
+    FROM $competing;
+
+    LET $best_opp_score = math::max($scored.score);
+    LET $best_opp = (SELECT * FROM $scored WHERE score = $best_opp_score LIMIT 1)[0];
+
+    LET $winner_components = {
+        confidence: $w_confidence * $confidence,
+        sourceTrust: $w_source_trust * $source_trust,
+        recency: $w_recency * 1.0,
+        authority: $w_authority * 0.0
+    };
+    LET $loser_components = {
+        confidence: $best_opp.sc_confidence,
+        sourceTrust: $best_opp.sc_source_trust,
+        recency: $best_opp.sc_recency,
+        authority: $best_opp.sc_authority
+    };
+
+    LET $abs_conf = math::abs($winner_components.confidence - $loser_components.confidence);
+    LET $abs_st   = math::abs($winner_components.sourceTrust - $loser_components.sourceTrust);
+    LET $abs_rec  = math::abs($winner_components.recency - $loser_components.recency);
+    LET $abs_auth = math::abs($winner_components.authority - $loser_components.authority);
+    LET $max_abs  = math::max([$abs_conf, $abs_st, $abs_rec, $abs_auth]);
+
+    LET $dominant_dim = IF $max_abs = $abs_conf THEN 'confidence'
+                       ELSE IF $max_abs = $abs_st THEN 'source_trust'
+                       ELSE IF $max_abs = $abs_rec THEN 'recency'
+                       ELSE 'authority'
+                       END;
+
+    LET $slot_delta = {
+        predicate: ($best_opp.predicate != $predicate),
+        object: ($best_opp.object != $object),
+        validFrom: ($best_opp.validFrom != $valid_from),
+        source: ($best_opp.source != $source)
+    };
+
+    LET $score_breakdown = {
+        winner: {
+            total: $new_score,
+            confidence: $winner_components.confidence,
+            sourceTrust: $winner_components.sourceTrust,
+            recency: $winner_components.recency,
+            authority: $winner_components.authority
+        },
+        loser: {
+            total: $best_opp_score,
+            confidence: $loser_components.confidence,
+            sourceTrust: $loser_components.sourceTrust,
+            recency: $loser_components.recency,
+            authority: $loser_components.authority
+        },
+        margin: $new_score - $best_opp_score
+    };
+
+    LET $supersede =
+        $semantics = 'single_active'
+        OR $new_score >= $best_opp_score + $margin_for_supersede;
+
+    LET $loser_ids = $competing.id;
+
+    IF $supersede {
+        -- NO `retractedAt = time::now()` — a natural supersede is not a
+        -- retraction (migration 0014). Keep the retractionReason +
+        -- retractedBy sentinel that revive + calibration depend on.
+        FOR $loser IN $competing {
+            UPDATE $loser.id SET
+                status = 'superseded',
+                retractionReason = 'superseded',
+                retractedBy = 'system',
+                supersededBy = $new.id,
+                priorValidUntil = $loser.validUntil,
+                validUntil = $valid_from;
+        };
+        -- Conflict trace (migration 0044): persist the decision the fn just
+        -- computed — the fact remembers WHY it won.
+        UPDATE $new.id SET conflictTrace = {
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            decidedAt: time::now()
+        };
+        RETURN {
+            outcome: 'SUPERSEDED',
+            factId: $new.id,
+            supersededFactIds: $loser_ids,
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            reason: NONE
+        };
+    };
+
+    UPDATE $new.id SET
+        status = 'competing',
+        conflictTrace = {
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            decidedAt: time::now()
+        };
+    UPDATE knowledge_fact SET status = 'competing' WHERE id IN $loser_ids;
+    RETURN {
+        outcome: 'COMPETING',
+        factId: $new.id,
+        competingFactIds: $loser_ids,
+        scoreBreakdown: $score_breakdown,
+        dominantDimension: $dominant_dim,
+        slotDelta: $slot_delta,
+        bestOpponentId: $best_opp.id,
+        reason: NONE
+    };
+};

--- a/test/calibration-refit.unit-spec.ts
+++ b/test/calibration-refit.unit-spec.ts
@@ -1,34 +1,64 @@
 import {
-  aggregateBySourceKey,
+  aggregateByScope,
+  scopeKeyOf,
   isCorrect,
 } from '../src/ai/calibration/calibration-refit-runner.service';
 
 describe('calibration-refit pure helpers', () => {
-  describe('aggregateBySourceKey', () => {
-    it('rolls wins + losses per sourceKey', () => {
-      const out = aggregateBySourceKey([
-        { sourceKey: 'rent:bot', win: 1, loss: 0 },
-        { sourceKey: 'rent:bot', win: 1, loss: 0 },
-        { sourceKey: 'rent:bot', win: 0, loss: 1 },
-        { sourceKey: 'shop:cli', win: 0, loss: 1 },
+  describe('aggregateByScope', () => {
+    const T1 = '2026-01-01T00:00:00Z';
+    const T2 = '2026-02-01T00:00:00Z';
+
+    it('rolls wins + losses at BOTH grains: (sourceKey, domain) and global', () => {
+      const out = aggregateByScope([
+        { sourceKey: 'rent:bot', domain: 'status', win: 1, loss: 0, recordedAt: T1 },
+        { sourceKey: 'rent:bot', domain: 'status', win: 1, loss: 0, recordedAt: T2 },
+        { sourceKey: 'rent:bot', domain: 'address', win: 0, loss: 1, recordedAt: T1 },
+        { sourceKey: 'shop:cli', domain: 'status', win: 0, loss: 1, recordedAt: T1 },
       ]);
-      const rent = out.find((r) => r.sourceKey === 'rent:bot');
-      const shop = out.find((r) => r.sourceKey === 'shop:cli');
-      expect(rent).toEqual({ sourceKey: 'rent:bot', wins: 2, losses: 1 });
-      expect(shop).toEqual({ sourceKey: 'shop:cli', wins: 0, losses: 1 });
+      const byKey = new Map(out.map((s) => [scopeKeyOf(s.sourceKey, s.domain), s]));
+
+      // Scoped rows: the broker analogy — great on one predicate, weak on
+      // another, and the two never blend.
+      expect(byKey.get(scopeKeyOf('rent:bot', 'status'))).toMatchObject({
+        wins: 2,
+        losses: 0,
+      });
+      expect(byKey.get(scopeKeyOf('rent:bot', 'address'))).toMatchObject({
+        wins: 0,
+        losses: 1,
+      });
+      // Global row = the pre-0045 blended rate, untouched in meaning.
+      expect(byKey.get(scopeKeyOf('rent:bot', null))).toMatchObject({
+        wins: 2,
+        losses: 1,
+      });
+      expect(byKey.get(scopeKeyOf('shop:cli', null))).toMatchObject({
+        wins: 0,
+        losses: 1,
+      });
+    });
+
+    it('tracks lastSeenAt as the max recordedAt per scope', () => {
+      const out = aggregateByScope([
+        { sourceKey: 'k', domain: 'status', win: 1, loss: 0, recordedAt: T2 },
+        { sourceKey: 'k', domain: 'status', win: 1, loss: 0, recordedAt: T1 },
+      ]);
+      for (const scope of out) {
+        expect(scope.lastSeenAt.toISOString()).toBe(new Date(T2).toISOString());
+      }
     });
 
     it('returns empty array for empty input', () => {
-      expect(aggregateBySourceKey([])).toEqual([]);
+      expect(aggregateByScope([])).toEqual([]);
     });
 
-    it('keeps every sourceKey, including those with only losses', () => {
-      const out = aggregateBySourceKey([
-        { sourceKey: 'k1', win: 0, loss: 1 },
+    it('keeps loss-only scopes', () => {
+      const out = aggregateByScope([
+        { sourceKey: 'k1', domain: 'tier', win: 0, loss: 1, recordedAt: T1 },
       ]);
-      expect(out).toHaveLength(1);
-      expect(out[0].wins).toBe(0);
-      expect(out[0].losses).toBe(1);
+      expect(out).toHaveLength(2); // scoped + global
+      expect(out.every((s) => s.wins === 0 && s.losses === 1)).toBe(true);
     });
   });
 

--- a/test/migration-resolver-invariants.unit-spec.ts
+++ b/test/migration-resolver-invariants.unit-spec.ts
@@ -56,10 +56,13 @@ describe('GATE: live fn::resolve_fact invariants', () => {
   });
 
   it('scores opponent source-trust from the learned rate, NOT a hardcoded 0.5', () => {
-    // 0022's fix: fn::source_trust_for(fn::source_key_of(source)). A
-    // reverted baseline would reintroduce `$w_source_trust * 0.5`.
+    // 0022's fix scored the opponent from the learned rate
+    // (fn::source_trust_for); 0045 sharpened it to the DOMAIN-scoped
+    // ladder (fn::source_trust_scoped, falling back to the global rate
+    // then 0.5). A reverted baseline would reintroduce
+    // `$w_source_trust * 0.5`.
     expect(head.body).toContain(
-      'fn::source_trust_for(fn::source_key_of(source))',
+      'fn::source_trust_scoped(fn::source_key_of(source), $predicate)',
     );
     expect(head.body).not.toMatch(/\$w_source_trust \* 0\.5/);
   });

--- a/test/source-trust-scoped.e2e-spec.ts
+++ b/test/source-trust-scoped.e2e-spec.ts
@@ -1,0 +1,189 @@
+/**
+ * e2e for the source-reputation track, Phase 2 (migration 0045):
+ * domain-scoped source reputation.
+ *
+ *   1. fn::source_trust_scoped ladder: scoped row (>=8 samples) → global
+ *      row (>=8) → neutral 0.5.
+ *   2. The nightly refit aggregates at BOTH grains ((sourceKey, domain) +
+ *      global) and appends to source_trust_history when a rate moves —
+ *      and does NOT append when a re-run computes the same rate.
+ *   3. fn::resolve_fact stamps trustSnapshot.learnedTrust through the
+ *      SCOPED lookup — the same source gets different learned trust on a
+ *      predicate it wins vs one it loses (the broker analogy).
+ */
+import { Surreal } from 'surrealdb';
+import { SurrealService } from '../src/db/surreal.service';
+import { CalibrationRefitRunnerService } from '../src/ai/calibration/calibration-refit-runner.service';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+
+const SRC = { vertical: 'rent', recorder: 'flaky_bot' };
+const KEY = 'rent:flaky_bot';
+
+describe('domain-scoped source trust (Phase 2)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const withDb = async <T>(fn: (db: Surreal) => Promise<T>) =>
+    f.app.get(SurrealService).withCompany(f.companyId, fn);
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_scoped_trust_e2e' });
+
+    // Seed raw history for one source: 8 ACTIVE `status` facts (all wins)
+    // and 4 SUPERSEDED `address` facts (all losses). Directly via the DB —
+    // the refit reads fact rows, not the ingest path.
+    await withDb(async (db) => {
+      const [ent] = await db.query<[{ id: unknown }]>(
+        `CREATE ONLY knowledge_entity CONTENT {
+           type: 'customer',
+           canonicalName: 'Scoped Trust Seed'
+         }`,
+      );
+      const entityId = String((ent as { id: unknown }).id);
+      const tail = entityId.split(':')[1];
+      for (let i = 0; i < 8; i++) {
+        await db.query(
+          `CREATE knowledge_fact CONTENT {
+             entityId: type::record('knowledge_entity', $eid),
+             predicate: 'status',
+             object: 'ok_' + <string>$i,
+             confidence: 0.9,
+             validFrom: d'2026-01-01T00:00:00Z',
+             source: $src,
+             status: 'active'
+           }`,
+          { eid: tail, i, src: SRC },
+        );
+      }
+      for (let i = 0; i < 4; i++) {
+        await db.query(
+          `CREATE knowledge_fact CONTENT {
+             entityId: type::record('knowledge_entity', $eid),
+             predicate: 'address',
+             object: 'wrong_' + <string>$i,
+             confidence: 0.9,
+             validFrom: d'2026-01-01T00:00:00Z',
+             source: $src,
+             status: 'superseded',
+             retractionReason: 'superseded',
+             retractedBy: 'system'
+           }`,
+          { eid: tail, i, src: SRC },
+        );
+      }
+    });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('refit writes both grains + history; re-run stays quiet', async () => {
+    const runner = f.app.get(CalibrationRefitRunnerService);
+    await runner.refitSourceTrust();
+
+    const rows = await withDb(async (db) => {
+      const [r] = await db.query<[any[]]>(
+        `SELECT sourceKey, domain, agreementRate, sampleCount, winCount, lossCount, lastSeenAt
+           FROM source_trust WHERE sourceKey = $k`,
+        { k: KEY },
+      );
+      return r as any[];
+    });
+    const byDomain = new Map(rows.map((r) => [r.domain ?? null, r]));
+
+    // Scoped: perfect on `status`, hopeless on `address` — never blended.
+    expect(byDomain.get('status')).toMatchObject({
+      agreementRate: 1,
+      sampleCount: 8,
+      winCount: 8,
+      lossCount: 0,
+    });
+    expect(byDomain.get('address')).toMatchObject({
+      agreementRate: 0,
+      sampleCount: 4,
+    });
+    // Global row = the blended pre-0045 semantics (8 wins / 4 losses).
+    expect(byDomain.get(null).agreementRate).toBeCloseTo(8 / 12);
+    expect(byDomain.get(null).sampleCount).toBe(12);
+    expect(byDomain.get(null).lastSeenAt).toBeDefined();
+
+    // First sighting → history rows for every scope of this source.
+    const historyCount = async () =>
+      withDb(async (db) => {
+        const [h] = await db.query<[any[]]>(
+          `SELECT id FROM source_trust_history WHERE sourceKey = $k`,
+          { k: KEY },
+        );
+        return (h as any[]).length;
+      });
+    const afterFirst = await historyCount();
+    expect(afterFirst).toBeGreaterThanOrEqual(3);
+
+    // Re-run with identical data: rates unchanged → NO new history rows
+    // (the |Δ| > 0.01 gate).
+    await runner.refitSourceTrust();
+    expect(await historyCount()).toBe(afterFirst);
+  });
+
+  it('fn::source_trust_scoped resolves scoped → global → 0.5', async () => {
+    const lookup = (domain: string) =>
+      withDb(async (db) => {
+        const [v] = await db.query<[number]>(
+          `RETURN fn::source_trust_scoped($k, $d)`,
+          { k: KEY, d: domain },
+        );
+        return v as number;
+      });
+
+    // Scoped row with >=8 samples wins.
+    expect(await lookup('status')).toBeCloseTo(1.0);
+    // Scoped row exists but <8 samples → falls to the global rate.
+    expect(await lookup('address')).toBeCloseTo(8 / 12);
+    // No scoped row at all → global.
+    expect(await lookup('tier')).toBeCloseTo(8 / 12);
+
+    // Unknown source entirely → neutral.
+    const neutral = await withDb(async (db) => {
+      const [v] = await db.query<[number]>(
+        `RETURN fn::source_trust_scoped('nowhere:nobody', 'status')`,
+      );
+      return v as number;
+    });
+    expect(neutral).toBeCloseTo(0.5);
+  });
+
+  it('resolve_fact stamps learnedTrust through the scoped ladder', async () => {
+    const ingest = (predicate: string, object: string) =>
+      f.http.post('/v1/ingest/fact').set(auth()).send({
+        entityRef: { vertical: 'rent', id: 'scoped_trust_customer' },
+        predicate,
+        object,
+        validFrom: '2026-06-01T00:00:00Z',
+        source: SRC,
+        confidence: 0.9,
+      });
+
+    const factRow = async (factId: string) =>
+      withDb(async (db) => {
+        const [rows] = await db.query<[any[]]>(
+          `SELECT trustSnapshot FROM type::record('knowledge_fact', $rid)`,
+          { rid: factId.split(':')[1] },
+        );
+        return (rows as any[])?.[0];
+      });
+
+    // Same source, different domains: the snapshot records the scoped
+    // reputation — high where it wins, blended-global where it has no
+    // usable scoped history.
+    const onStatus = await ingest('status', 'premium');
+    const statusRow = await factRow(onStatus.body.factId);
+    expect(statusRow.trustSnapshot.learnedTrust).toBeCloseTo(1.0);
+    expect(statusRow.trustSnapshot.domain).toBe('status');
+
+    const onTier = await ingest('tier', 'gold');
+    const tierRow = await factRow(onTier.body.factId);
+    expect(tierRow.trustSnapshot.learnedTrust).toBeCloseTo(8 / 12);
+  });
+});


### PR DESCRIPTION
## Что это

Фаза 2 трека Source Reputation — **ядро**: репутация источника становится доменной. Один и тот же источник получает разный learned trust на предикате, где он исторически прав, и на предикате, где он гадает — вместо одного смешанного скаляра.

## Изменения

**Миграция 0045**:
- `source_trust` + `domain option<string>` (generic строка: v1 пишет predicate id — ось, на которой реально происходят конфликты; топик-слой позже реюзает поле без миграции) + `winCount`/`lossCount`/`lastSeenAt`. UNIQUE-индекс `(sourceKey)` → `(sourceKey, domain)`; строки до-0045 имеют `domain NONE` = глобальная ставка, чистая деградация.
- **`source_trust_history`** — append-only «репутация во времени»: строка при |Δrate| > 0.01 или первом появлении скоупа. Горячий `source_trust` остаётся UPSERT-кэшем (тот же сплит, что versioned `calibration_table` + hot copy).
- **`fn::source_trust_scoped(key, domain)`** — лестница: scoped (≥8 сэмплов) → global (≥8) → 0.5.
- **`fn::resolve_fact`** — тело 0044 verbatim, ровно 3 подстановки (дифф сверен): loser-side trust и `trustSnapshot.learnedTrust` через scoped-лестницу. Winner-side остаётся статик-эвристикой (осознанная асимметрия 0022). Дрейф монотонный: сдвигаются только источники с ≥8 scoped-сэмплами.

**Nightly refit**: агрегация в двух грануляциях (`aggregateByScope`, pure), запись обоих рядов (`upsertTrustScope`; option<>-гоча: global-вариант опускает `domain` и матчит `IS NONE`), history через Δ-гейт, prior-ставки одним чтением.

## Тесты

878 unit / 172 e2e / 9 jobs зелёные. Новый e2e `source-trust-scoped`: рефит пишет оба грейна + history молчит на идентичном повторе; лестница fn; `resolve_fact` штампует scoped learnedTrust — один источник, 1.0 на `status` и 8/12 на `tier`. Гейт resolver-инвариантов обновлён на scoped-вызов.

## Дальше

Ф3 source_registry + активация authority + read-API → Ф4 корроборация → Ф5 fact_trust в ранжировании.

🤖 Generated with [Claude Code](https://claude.com/claude-code)