### PR TITLE
feat(trust): cross-source corroboration — outcome CORROBORATED (source-reputation phase 4)

### DIFF
--- a/src/ai/calibration/calibration-refit-runner.service.ts
+++ b/src/ai/calibration/calibration-refit-runner.service.ts
@@ -188,7 +188,10 @@ export class CalibrationRefitRunnerService {
       const events = (rows ?? []).map((r) => ({
         sourceKey: `${r.vertical}:${r.recorder ?? '_'}`,
         domain: r.predicate,
-        win: r.status === 'active' ? 1 : 0,
+        // A corroborating row (migration 0047) is independent agreement
+        // with a standing fact — evidence of reliability, counted as a win
+        // for its source. (It used to count as neither.)
+        win: r.status === 'active' || r.status === 'corroborating' ? 1 : 0,
         loss: r.status === 'superseded' || r.status === 'retracted' ? 1 : 0,
         recordedAt: r.recordedAt,
       }));

--- a/src/db/migrations/0047_corroboration.surql
+++ b/src/db/migrations/0047_corroboration.surql
@@ -1,0 +1,334 @@
+-- 0047_corroboration — cross-source agreement strengthens instead of dueling.
+--
+-- Source-reputation track, Phase 4. Until now a same-object claim arriving
+-- from a DIFFERENT source either superseded the incumbent (single_active),
+-- competed with it (bitemporal), or coexisted (append_only) — independent
+-- confirmation was treated as a fight or ignored. Now it corroborates:
+--
+--   * the new row is kept as the audit trail of the second claim —
+--     status 'corroborating', `corroborates` → the incumbent (never
+--     deleted; bitemporal invariants hold);
+--   * the incumbent accumulates `corroboration = { count, sourceKeys[],
+--     lastAt }` — the signal Phase 5's read-time fact_trust multiplies on;
+--   * the caller sees outcome CORROBORATED { factId, corroboratedFactId }.
+--
+-- Scope decisions (v1, deliberate):
+--   * Match = EXACT `object` equality + DIFFERENT fn::source_key_of. Fuzzy
+--     agreement ("same meaning, different words") is a Phase-5+ concern.
+--   * Same-source duplicates keep today's semantics (supersede/compete) —
+--     a source repeating itself is refresh, not evidence.
+--   * append_only predicates never corroborate ($competing is [] by
+--     design) — every claim is its own event there.
+--   * The check runs BEFORE the backdated guard: claim identity beats
+--     date ordering — a matching claim corroborates regardless of its
+--     validFrom.
+--   * Retracting the incumbent leaves corroborating rows untouched (they
+--     are records of claims, not live values).
+--
+-- Read paths hide 'corroborating' rows wherever 'compacted' is hidden
+-- (search where-builder, graph-retrieve, entity reads) — the incumbent
+-- carries the surfaced fact; the audit shape (includeStale) still shows
+-- them. The nightly source-trust refit counts a corroborating row as a
+-- WIN for its source (independent agreement is evidence of reliability).
+--
+-- fn::resolve_fact body is 0046 VERBATIM plus the $corroborated branch.
+-- Signature stays 21 args — no TS call-site change.
+
+DEFINE FIELD OVERWRITE status ON knowledge_fact TYPE string DEFAULT 'active'
+  ASSERT $value INSIDE ['active','competing','retracted','superseded','compacted','corroborating'];
+
+DEFINE FIELD IF NOT EXISTS corroboration ON knowledge_fact TYPE option<object> FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS corroborates ON knowledge_fact TYPE option<record<knowledge_fact>>;
+
+DEFINE FUNCTION OVERWRITE fn::resolve_fact(
+    $entity_id: record<knowledge_entity>,
+    $predicate: string,
+    $object: string,
+    $object_meta: option<object>,
+    $embedding: array<float>,
+    $confidence: float,
+    $valid_from: datetime,
+    $valid_until: option<datetime>,
+    $source: object,
+    $source_trust: float,
+    $semantics: string,
+    $similarity_threshold: float,
+    $w_confidence: float,
+    $w_source_trust: float,
+    $w_recency: float,
+    $w_authority: float,
+    $reject_threshold: float,
+    $margin_for_supersede: float,
+    $lang: option<string>,
+    $script: option<string>,
+    $entropy: option<float>
+) {
+    -- Source key + declared authority (migration 0046): computed up front
+    -- because authority now participates in the winner's score, not just
+    -- the trust snapshot.
+    LET $src_key = fn::source_key_of($source);
+    LET $src_authority = fn::source_authority_of($src_key);
+
+    LET $new_score =
+        $w_confidence * $confidence
+        + $w_source_trust * $source_trust
+        + $w_recency * 1.0
+        + $w_authority * $src_authority;
+
+    IF $semantics = 'bitemporal' AND $new_score < $reject_threshold {
+        CREATE ingest_dead_letter CONTENT {
+            payload: { entityId: $entity_id, predicate: $predicate, object: $object, source: $source },
+            reason: 'low_score: ' + <string>$new_score
+        };
+        RETURN { outcome: 'REJECTED', factId: NONE, reason: 'low_score' };
+    };
+
+    LET $candidates = SELECT
+        id, predicate, object, confidence, recordedAt, source, embedding,
+        validFrom, validUntil
+    FROM knowledge_fact
+    WHERE entityId = $entity_id
+      AND predicate = $predicate
+      AND status = 'active'
+      AND retractedAt IS NONE;
+
+    LET $competing = IF $semantics = 'append_only' THEN
+        []
+    ELSE IF $semantics = 'single_active' THEN
+        $candidates
+    ELSE
+        (SELECT * FROM $candidates
+            WHERE embedding != NONE
+              AND vector::similarity::cosine(embedding, $embedding) >= $similarity_threshold
+              AND fn::intervals_overlap(validFrom, validUntil, $valid_from, $valid_until))
+    END;
+
+    -- Trust snapshot (migration 0044): what the resolver believes about this
+    -- source RIGHT NOW, frozen onto the fact. learnedTrust is read before
+    -- any nightly refit can overwrite the source_trust row. Scoped lookup
+    -- since migration 0045; declared authority since 0046.
+    LET $new = CREATE ONLY knowledge_fact CONTENT {
+        entityId: $entity_id,
+        predicate: $predicate,
+        object: $object,
+        objectMeta: $object_meta,
+        confidence: $confidence,
+        validFrom: $valid_from,
+        validUntil: $valid_until,
+        source: $source,
+        embedding: $embedding,
+        status: 'active',
+        trustSnapshot: {
+            sourceKey: $src_key,
+            domain: $predicate,
+            declaredTrust: $source_trust,
+            learnedTrust: fn::source_trust_scoped($src_key, $predicate),
+            authority: $src_authority,
+            calculatedAt: time::now()
+        }
+    };
+
+    IF array::len($competing) = 0 {
+        -- Locale + entropy folded in from the caller (migration 0039). Applied
+        -- on INSERTED only, matching the old post-call UPDATE gate.
+        IF $lang != NONE {
+            UPDATE $new.id SET lang = $lang, script = $script;
+        };
+        IF $entropy != NONE {
+            UPDATE $new.id SET extractionEntropy = $entropy;
+        };
+        RETURN { outcome: 'INSERTED', factId: $new.id, reason: NONE };
+    };
+
+    -- Corroboration (migration 0047): the SAME claim from a DIFFERENT
+    -- source is independent confirmation, not a duel. Keep the new row as
+    -- the audit record of the second claim; strengthen the incumbent.
+    -- Runs before the backdated guard — claim identity beats date order.
+    LET $corroborated = (SELECT id, recordedAt FROM $competing
+        WHERE object = $object
+          AND fn::source_key_of(source) != $src_key
+        ORDER BY recordedAt DESC LIMIT 1)[0];
+
+    IF $corroborated != NONE {
+        UPDATE $new.id SET
+            status = 'corroborating',
+            corroborates = $corroborated.id;
+        UPDATE $corroborated.id SET corroboration = {
+            count: IF corroboration IS NONE THEN 1 ELSE corroboration.count + 1 END,
+            sourceKeys: array::union(
+                IF corroboration IS NONE THEN [] ELSE corroboration.sourceKeys END,
+                [$src_key]
+            ),
+            lastAt: time::now()
+        };
+        RETURN {
+            outcome: 'CORROBORATED',
+            factId: $new.id,
+            corroboratedFactId: $corroborated.id,
+            reason: NONE
+        };
+    };
+
+    -- Backdated guard (migration 0043): for single_active, a candidate with
+    -- a STRICTLY NEWER validFrom means the incoming fact is history. Slot it
+    -- before the next-newer decision as an already-superseded row; the
+    -- active timeline stays exactly as if events had arrived in order.
+    LET $next_after = IF $semantics = 'single_active' THEN
+        (SELECT id, validFrom FROM $competing
+            WHERE validFrom > $valid_from
+            ORDER BY validFrom ASC LIMIT 1)[0]
+    ELSE
+        NONE
+    END;
+
+    IF $next_after != NONE {
+        -- Same sentinel shape as a natural supersede (no retractedAt —
+        -- migration 0014; retractionReason 'superseded' feeds revive +
+        -- calibration).
+        UPDATE $new.id SET
+            status = 'superseded',
+            retractionReason = 'superseded',
+            retractedBy = 'system',
+            supersededBy = $next_after.id,
+            priorValidUntil = $valid_until,
+            validUntil = $next_after.validFrom;
+        RETURN {
+            outcome: 'INSERTED_HISTORICAL',
+            factId: $new.id,
+            supersededByFactId: $next_after.id,
+            reason: 'backdated'
+        };
+    };
+
+    LET $scored = SELECT
+        id,
+        confidence,
+        source,
+        validFrom,
+        object,
+        predicate,
+        $w_confidence * confidence AS sc_confidence,
+        $w_source_trust * fn::source_trust_scoped(fn::source_key_of(source), $predicate) AS sc_source_trust,
+        $w_recency * math::pow(math::E, - duration::secs(time::now() - recordedAt) / 31536000) AS sc_recency,
+        $w_authority * fn::source_authority_of(fn::source_key_of(source)) AS sc_authority,
+        ($w_confidence * confidence
+         + $w_source_trust * fn::source_trust_scoped(fn::source_key_of(source), $predicate)
+         + $w_recency * math::pow(math::E, - duration::secs(time::now() - recordedAt) / 31536000)
+         + $w_authority * fn::source_authority_of(fn::source_key_of(source))
+        ) AS score
+    FROM $competing;
+
+    LET $best_opp_score = math::max($scored.score);
+    LET $best_opp = (SELECT * FROM $scored WHERE score = $best_opp_score LIMIT 1)[0];
+
+    LET $winner_components = {
+        confidence: $w_confidence * $confidence,
+        sourceTrust: $w_source_trust * $source_trust,
+        recency: $w_recency * 1.0,
+        authority: $w_authority * $src_authority
+    };
+    LET $loser_components = {
+        confidence: $best_opp.sc_confidence,
+        sourceTrust: $best_opp.sc_source_trust,
+        recency: $best_opp.sc_recency,
+        authority: $best_opp.sc_authority
+    };
+
+    LET $abs_conf = math::abs($winner_components.confidence - $loser_components.confidence);
+    LET $abs_st   = math::abs($winner_components.sourceTrust - $loser_components.sourceTrust);
+    LET $abs_rec  = math::abs($winner_components.recency - $loser_components.recency);
+    LET $abs_auth = math::abs($winner_components.authority - $loser_components.authority);
+    LET $max_abs  = math::max([$abs_conf, $abs_st, $abs_rec, $abs_auth]);
+
+    LET $dominant_dim = IF $max_abs = $abs_conf THEN 'confidence'
+                       ELSE IF $max_abs = $abs_st THEN 'source_trust'
+                       ELSE IF $max_abs = $abs_rec THEN 'recency'
+                       ELSE 'authority'
+                       END;
+
+    LET $slot_delta = {
+        predicate: ($best_opp.predicate != $predicate),
+        object: ($best_opp.object != $object),
+        validFrom: ($best_opp.validFrom != $valid_from),
+        source: ($best_opp.source != $source)
+    };
+
+    LET $score_breakdown = {
+        winner: {
+            total: $new_score,
+            confidence: $winner_components.confidence,
+            sourceTrust: $winner_components.sourceTrust,
+            recency: $winner_components.recency,
+            authority: $winner_components.authority
+        },
+        loser: {
+            total: $best_opp_score,
+            confidence: $loser_components.confidence,
+            sourceTrust: $loser_components.sourceTrust,
+            recency: $loser_components.recency,
+            authority: $loser_components.authority
+        },
+        margin: $new_score - $best_opp_score
+    };
+
+    LET $supersede =
+        $semantics = 'single_active'
+        OR $new_score >= $best_opp_score + $margin_for_supersede;
+
+    LET $loser_ids = $competing.id;
+
+    IF $supersede {
+        -- NO `retractedAt = time::now()` — a natural supersede is not a
+        -- retraction (migration 0014). Keep the retractionReason +
+        -- retractedBy sentinel that revive + calibration depend on.
+        FOR $loser IN $competing {
+            UPDATE $loser.id SET
+                status = 'superseded',
+                retractionReason = 'superseded',
+                retractedBy = 'system',
+                supersededBy = $new.id,
+                priorValidUntil = $loser.validUntil,
+                validUntil = $valid_from;
+        };
+        -- Conflict trace (migration 0044): persist the decision the fn just
+        -- computed — the fact remembers WHY it won.
+        UPDATE $new.id SET conflictTrace = {
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            decidedAt: time::now()
+        };
+        RETURN {
+            outcome: 'SUPERSEDED',
+            factId: $new.id,
+            supersededFactIds: $loser_ids,
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            reason: NONE
+        };
+    };
+
+    UPDATE $new.id SET
+        status = 'competing',
+        conflictTrace = {
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            decidedAt: time::now()
+        };
+    UPDATE knowledge_fact SET status = 'competing' WHERE id IN $loser_ids;
+    RETURN {
+        outcome: 'COMPETING',
+        factId: $new.id,
+        competingFactIds: $loser_ids,
+        scoreBreakdown: $score_breakdown,
+        dominantDimension: $dominant_dim,
+        slotDelta: $slot_delta,
+        bestOpponentId: $best_opp.id,
+        reason: NONE
+    };
+};

--- a/src/entities/entity-read.helpers.ts
+++ b/src/entities/entity-read.helpers.ts
@@ -68,6 +68,9 @@ export function activeFactWhere(asOf: Date | null): {
   clauses: string[];
   params: Record<string, unknown>;
 } {
+  // 'corroborating' rows (migration 0047) are audit records of a second
+  // claim — the incumbent (which carries the corroboration counter) is
+  // the fact to surface; both branches hide the duplicates.
   if (asOf) {
     return {
       clauses: [
@@ -75,9 +78,13 @@ export function activeFactWhere(asOf: Date | null): {
         `(retractedAt IS NONE OR retractedAt > $asOf)`,
         `validFrom <= $asOf`,
         `(validUntil IS NONE OR validUntil > $asOf)`,
+        `status != 'corroborating'`,
       ],
       params: { asOf },
     };
   }
-  return { clauses: [`retractedAt IS NONE`], params: {} };
+  return {
+    clauses: [`retractedAt IS NONE`, `status != 'corroborating'`],
+    params: {},
+  };
 }

--- a/src/ingest/fact-ingest.service.ts
+++ b/src/ingest/fact-ingest.service.ts
@@ -95,6 +95,9 @@ export class FactIngestService {
       if (result?.supersededByFactId) {
         out.supersededByFactId = String(result.supersededByFactId);
       }
+      if (result?.corroboratedFactId) {
+        out.corroboratedFactId = String(result.corroboratedFactId);
+      }
       if (dto.explain === true && factId && result?.bestOpponentId) {
         out.conflictExplanation = buildConflictExplanation({
           outcome: outcome as 'SUPERSEDED' | 'COMPETING',

--- a/src/ingest/ingest-result.ts
+++ b/src/ingest/ingest-result.ts
@@ -9,6 +9,13 @@ export type IngestOutcome =
    * decision) and displaced nothing. See migration 0043.
    */
   | 'INSERTED_HISTORICAL'
+  /**
+   * The same claim (exact object) already stands from a DIFFERENT source:
+   * the new row was kept as a `corroborating` audit record and the
+   * incumbent's `corroboration` counter grew — independent confirmation,
+   * not a conflict. See migration 0047.
+   */
+  | 'CORROBORATED'
   | 'SUPERSEDED'
   | 'COMPETING'
   | 'REJECTED';
@@ -24,6 +31,8 @@ export interface IngestResult {
    * row's interval).
    */
   supersededByFactId?: string;
+  /** CORROBORATED only: the incumbent fact this claim confirmed. */
+  corroboratedFactId?: string;
   reason?: string;
   /**
    * Populated only when the IngestFactDto carried `explain: true` AND

--- a/src/search/internals/graph-retrieve-db.ts
+++ b/src/search/internals/graph-retrieve-db.ts
@@ -195,12 +195,14 @@ export async function fetchFactsForEntities({
        AND (retractedAt IS NONE OR retractedAt > $asOf)
        AND validFrom <= $asOf
        AND (validUntil IS NONE OR validUntil > $asOf)
-       AND status != 'compacted'`
+       AND status != 'compacted'
+       AND status != 'corroborating'`
     : `entityId INSIDE $ids
        AND retractedAt IS NONE
        AND validFrom <= time::now()
        AND (validUntil IS NONE OR validUntil > time::now())
-       AND status != 'compacted'`;
+       AND status != 'compacted'
+       AND status != 'corroborating'`;
   const params: Record<string, unknown> = {
     ids: rids,
     ...(asOf ? { asOf: new Date(asOf) } : {}),

--- a/src/search/internals/where-builder.ts
+++ b/src/search/internals/where-builder.ts
@@ -90,7 +90,8 @@ export function buildBaseWhere({
       `AND (retractedAt IS NONE OR retractedAt > $asOf)
          AND validFrom <= $asOf
          AND (validUntil IS NONE OR validUntil > $asOf)
-         AND status != 'compacted'`,
+         AND status != 'compacted'
+         AND status != 'corroborating'`,
     );
     params.asOf = asOf;
   } else if (!dto.includeStale) {
@@ -106,10 +107,15 @@ export function buildBaseWhere({
     // fact whose interval still covers now: the `validUntil > now` guard
     // (already required above) means a normally-closed supersede, where
     // validUntil <= now, stays hidden; only the future-gap prior survives.
+    // 'corroborating' rows (migration 0047) are audit records of a second
+    // claim — the incumbent carries the surfaced fact; showing both would
+    // duplicate results. Hidden wherever 'compacted' is hidden; the audit
+    // shape (includeStale) still returns them.
     clauses.push(
       `AND validFrom <= time::now()
          AND (validUntil IS NONE OR validUntil > time::now())
          AND status != 'compacted'
+         AND status != 'corroborating'
          AND (status != 'superseded' OR validUntil > time::now())`,
     );
   }

--- a/test/corroboration.e2e-spec.ts
+++ b/test/corroboration.e2e-spec.ts
@@ -1,0 +1,197 @@
+/**
+ * e2e for the source-reputation track, Phase 4 (migration 0047):
+ * cross-source agreement strengthens instead of dueling.
+ *
+ *   1. The same claim (exact object) from a DIFFERENT source →
+ *      CORROBORATED: new row kept as a `corroborating` audit record,
+ *      incumbent accumulates {count, sourceKeys[], lastAt}.
+ *   2. Works for single_active too — a confirming source does NOT churn
+ *      the timeline (no supersede of an identical value).
+ *   3. Corroborating rows are hidden from search + entity reads (the
+ *      incumbent carries the fact); no duplicate results.
+ *   4. Retracting the incumbent leaves corroborating rows untouched
+ *      (accepted v1 semantics — they are records of claims).
+ *   5. The nightly refit counts a corroborating row as a WIN for its
+ *      source.
+ */
+import { Surreal } from 'surrealdb';
+import { SurrealService } from '../src/db/surreal.service';
+import { CalibrationRefitRunnerService } from '../src/ai/calibration/calibration-refit-runner.service';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+
+const ALPHA = { vertical: 'ops', recorder: 'scout_alpha' };
+const BRAVO = { vertical: 'ops', recorder: 'scout_bravo' };
+const CHARLIE = { vertical: 'ops', recorder: 'scout_charlie' };
+
+describe('cross-source corroboration (Phase 4)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const withDb = async <T>(fn: (db: Surreal) => Promise<T>) =>
+    f.app.get(SurrealService).withCompany(f.companyId, fn);
+
+  const factRow = async (factId: string) =>
+    withDb(async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT * FROM type::record('knowledge_fact', $rid)`,
+        { rid: factId.split(':')[1] },
+      );
+      return (rows as any[])?.[0];
+    });
+
+  const ingest = (opts: {
+    entityId: string;
+    predicate: string;
+    object: string;
+    source: object;
+  }) =>
+    f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: { vertical: 'ops', id: opts.entityId },
+      predicate: opts.predicate,
+      object: opts.object,
+      validFrom: '2026-06-01T00:00:00Z',
+      source: opts.source,
+      confidence: 0.9,
+    });
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_corroboration_e2e' });
+    await f.http.post('/v1/admin/predicates').set(auth()).send({
+      predicateId: 'sighting',
+      semantics: 'bitemporal',
+      piiClass: 'none',
+      description: 'e2e: bitemporal corroboration playground',
+    });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('a second and third source corroborate instead of dueling', async () => {
+    const OBJ = 'crane on the north lot';
+    const first = await ingest({
+      entityId: 'site_42',
+      predicate: 'sighting',
+      object: OBJ,
+      source: ALPHA,
+    });
+    expect(first.body.outcome).toBe('INSERTED');
+
+    const second = await ingest({
+      entityId: 'site_42',
+      predicate: 'sighting',
+      object: OBJ,
+      source: BRAVO,
+    });
+    expect(second.body.outcome).toBe('CORROBORATED');
+    expect(String(second.body.corroboratedFactId)).toBe(first.body.factId);
+
+    const third = await ingest({
+      entityId: 'site_42',
+      predicate: 'sighting',
+      object: OBJ,
+      source: CHARLIE,
+    });
+    expect(third.body.outcome).toBe('CORROBORATED');
+
+    // The corroborating row is a linked audit record...
+    const bravoRow = await factRow(second.body.factId);
+    expect(bravoRow.status).toBe('corroborating');
+    expect(String(bravoRow.corroborates)).toBe(first.body.factId);
+
+    // ...and the incumbent accumulated the independent confirmations.
+    const incumbent = await factRow(first.body.factId);
+    expect(incumbent.status).toBe('active');
+    expect(incumbent.corroboration.count).toBe(2);
+    expect(incumbent.corroboration.sourceKeys.sort()).toEqual([
+      'ops:scout_bravo',
+      'ops:scout_charlie',
+    ]);
+    expect(incumbent.corroboration.lastAt).toBeDefined();
+  });
+
+  it('confirming an identical single_active value does not churn the timeline', async () => {
+    const first = await ingest({
+      entityId: 'site_43',
+      predicate: 'status',
+      object: 'operational',
+      source: ALPHA,
+    });
+    expect(first.body.outcome).toBe('INSERTED');
+
+    // Pre-0047 this superseded the identical incumbent (pointless churn:
+    // new fact id, closed interval, same value). Now it confirms.
+    const second = await ingest({
+      entityId: 'site_43',
+      predicate: 'status',
+      object: 'operational',
+      source: BRAVO,
+    });
+    expect(second.body.outcome).toBe('CORROBORATED');
+
+    // A DIFFERENT value from another source still supersedes as before.
+    const change = await ingest({
+      entityId: 'site_43',
+      predicate: 'status',
+      object: 'shut down',
+      source: BRAVO,
+    });
+    expect(change.body.outcome).toBe('SUPERSEDED');
+  });
+
+  it('hides corroborating rows from search and entity reads (no duplicates)', async () => {
+    const search = await f.http
+      .post('/v1/search')
+      .set(auth())
+      .send({ query: 'crane on the north lot', limit: 10 });
+    expect(search.status).toBe(201);
+    const matches = search.body.results
+      .flatMap((r: any) => r.facts)
+      .filter((x: any) => x.object === 'crane on the north lot');
+    expect(matches).toHaveLength(1);
+  });
+
+  it('retracting the incumbent leaves corroborating rows untouched (v1 semantics)', async () => {
+    const OBJ = 'fence breached on east side';
+    const first = await ingest({
+      entityId: 'site_44',
+      predicate: 'sighting',
+      object: OBJ,
+      source: ALPHA,
+    });
+    const second = await ingest({
+      entityId: 'site_44',
+      predicate: 'sighting',
+      object: OBJ,
+      source: BRAVO,
+    });
+    expect(second.body.outcome).toBe('CORROBORATED');
+
+    const retract = await f.http
+      .post(`/v1/facts/${encodeURIComponent(first.body.factId)}/retract`)
+      .set(auth())
+      .send({ reason: 'false alarm', retractedBy: { source: 'human' } });
+    expect(retract.status).toBe(201);
+
+    const bravoRow = await factRow(second.body.factId);
+    expect(bravoRow.status).toBe('corroborating');
+    expect(bravoRow.retractedAt).toBeUndefined();
+  });
+
+  it('the refit counts corroborating rows as wins for their source', async () => {
+    await f.app.get(CalibrationRefitRunnerService).refitSourceTrust();
+    const rows = await withDb(async (db) => {
+      const [r] = await db.query<[any[]]>(
+        `SELECT domain, winCount, lossCount FROM source_trust
+           WHERE sourceKey = 'ops:scout_bravo' AND domain IS NONE`,
+      );
+      return r as any[];
+    });
+    expect(rows).toHaveLength(1);
+    // bravo produced only corroborating rows (+1 superseded 'shut down'
+    // supersede-winner is ALPHA's loss, not bravo's) — wins must be > 0.
+    expect(rows[0].winCount).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/test/entity-read-helpers.unit-spec.ts
+++ b/test/entity-read-helpers.unit-spec.ts
@@ -90,7 +90,12 @@ describe('blockedPredicates', () => {
 describe('activeFactWhere', () => {
   it('without asOf, gates on believed-now (retractedAt IS NONE) and binds no params', () => {
     const { clauses, params } = activeFactWhere(null);
-    expect(clauses).toEqual(['retractedAt IS NONE']);
+    expect(clauses).toEqual([
+      'retractedAt IS NONE',
+      // Corroborating rows (migration 0047) are audit records of a second
+      // claim — hidden from profile reads; the incumbent carries the fact.
+      "status != 'corroborating'",
+    ]);
     expect(params).toEqual({});
   });
 
@@ -102,6 +107,7 @@ describe('activeFactWhere', () => {
       '(retractedAt IS NONE OR retractedAt > $asOf)',
       'validFrom <= $asOf',
       '(validUntil IS NONE OR validUntil > $asOf)',
+      "status != 'corroborating'",
     ]);
     expect(params).toEqual({ asOf });
   });

--- a/test/source-registry.e2e-spec.ts
+++ b/test/source-registry.e2e-spec.ts
@@ -15,8 +15,11 @@
  * Confidence 1.0-vs-0.8 gives 0.30·0.2 = 0.06 (< 0.15 → COMPETING);
  * +0.10·1.0 declared authority = 0.16 (≥ 0.15 → SUPERSEDED).
  */
+import { Surreal } from 'surrealdb';
+import { SurrealService } from '../src/db/surreal.service';
 import type { AppFixture } from './app-fixture';
 import { createApp } from './app-fixture';
+import { StubEmbedder } from './test-doubles';
 
 describe('source registry + authority activation (Phase 3)', () => {
   let f: AppFixture;
@@ -25,6 +28,59 @@ describe('source registry + authority activation (Phase 3)', () => {
   const JUNIOR = { vertical: 'ops', recorder: 'junior_bot' };
   const SENIOR = { vertical: 'ops', recorder: 'senior_auditor' };
   const SENIOR_KEY = 'ops:senior_auditor';
+
+  const CHALLENGE_OBJECT = 'amsterdam office is over capacity';
+
+  /**
+   * Seed an incumbent bitemporal fact DIRECTLY, with its embedding set to
+   * the CHALLENGER's embedding text — cosine 1.0 despite a different
+   * object string. Needed because Phase 4 (migration 0047) turns an
+   * exact-object cross-source repeat into CORROBORATED before the
+   * conflict path is ever reached; the authority-margin math only applies
+   * to different-but-similar claims.
+   */
+  const seedIncumbent = async (entityId: string): Promise<string> => {
+    const embedding = await new StubEmbedder().embed(
+      `field_report: ${CHALLENGE_OBJECT}`,
+    );
+    return f.app
+      .get(SurrealService)
+      .withCompany(f.companyId, async (db: Surreal) => {
+        const [ent] = await db.query<[{ id: unknown }]>(
+          `CREATE ONLY knowledge_entity CONTENT {
+             type: 'location',
+             canonicalName: $name,
+             externalRefs: $refs
+           }`,
+          {
+            name: entityId,
+            refs: { [`ops__${entityId}`]: entityId },
+          },
+        );
+        const eid = String((ent as { id: unknown }).id).split(':')[1];
+        await db.query(
+          `CREATE entity_external_ref CONTENT {
+             key: $key,
+             entity: type::record('knowledge_entity', $eid)
+           }`,
+          { key: `ops__${entityId}`, eid },
+        );
+        const [fact] = await db.query<[{ id: unknown }]>(
+          `CREATE ONLY knowledge_fact CONTENT {
+             entityId: type::record('knowledge_entity', $eid),
+             predicate: 'field_report',
+             object: 'capacity problems reported at the amsterdam office',
+             confidence: 0.8,
+             validFrom: d'2026-05-01T00:00:00Z',
+             source: $src,
+             embedding: $embedding,
+             status: 'active'
+           }`,
+          { eid, src: JUNIOR, embedding },
+        );
+        return String((fact as { id: unknown }).id);
+      });
+  };
 
   beforeAll(async () => {
     f = await createApp({ companyId: 'co_source_registry_e2e' });
@@ -42,16 +98,18 @@ describe('source registry + authority activation (Phase 3)', () => {
     if (f) await f.close();
   });
 
-  const ingestReport = (entityId: string, source: object, confidence: number) =>
+  // A DIFFERENT object string than the seeded incumbent's — cosine is
+  // still 1.0 (the incumbent's embedding was planted, see seedIncumbent),
+  // so the pair enters the bitemporal competing set WITHOUT tripping the
+  // Phase-4 exact-object corroboration branch.
+  const challenge = (source: object, entityId: string) =>
     f.http.post('/v1/ingest/fact').set(auth()).send({
       entityRef: { vertical: 'ops', id: entityId },
       predicate: 'field_report',
-      // Identical object text → identical embeddings → cosine 1.0, so the
-      // pair always enters the competing set; only the scores differ.
-      object: 'amsterdam office is over capacity',
+      object: CHALLENGE_OBJECT,
       validFrom: '2026-06-01T00:00:00Z',
       source,
-      confidence,
+      confidence: 1.0,
     });
 
   it('declares a source and reads it back joined with reputation', async () => {
@@ -96,35 +154,33 @@ describe('source registry + authority activation (Phase 3)', () => {
   it('declared authority flips a COMPETING conflict to SUPERSEDED', async () => {
     // Control: challenger from an UNREGISTERED source. Margin 0.06 < 0.15
     // → the resolver refuses to auto-pick.
-    const controlIncumbent = await ingestReport('hq_control', JUNIOR, 0.8);
-    expect(controlIncumbent.body.outcome).toBe('INSERTED');
-    const controlChallenge = await ingestReport(
-      'hq_control',
+    const controlIncumbentId = await seedIncumbent('hq_control');
+    const controlChallenge = await challenge(
       { vertical: 'ops', recorder: 'unregistered_auditor' },
-      1.0,
+      'hq_control',
     );
     expect(controlChallenge.body.outcome).toBe('COMPETING');
+    expect(controlChallenge.body.competingFactIds).toContain(
+      controlIncumbentId,
+    );
 
     // Same conflict, but the challenger's source carries a declared
     // authLevel of 1.0 (registered in the previous test): margin 0.16.
-    const incumbent = await ingestReport('hq_live', JUNIOR, 0.8);
-    expect(incumbent.body.outcome).toBe('INSERTED');
-    const challenge = await f.http.post('/v1/ingest/fact').set(auth()).send({
+    const incumbentId = await seedIncumbent('hq_live');
+    const live = await f.http.post('/v1/ingest/fact').set(auth()).send({
       entityRef: { vertical: 'ops', id: 'hq_live' },
       predicate: 'field_report',
-      object: 'amsterdam office is over capacity',
+      object: CHALLENGE_OBJECT,
       validFrom: '2026-06-01T00:00:00Z',
       source: SENIOR,
       confidence: 1.0,
       explain: true,
     });
-    expect(challenge.body.outcome).toBe('SUPERSEDED');
-    expect(challenge.body.supersededFactIds).toContain(
-      incumbent.body.factId,
-    );
+    expect(live.body.outcome).toBe('SUPERSEDED');
+    expect(live.body.supersededFactIds).toContain(incumbentId);
     // The decomposition names authority as a live component now.
     expect(
-      challenge.body.conflictExplanation.scoreBreakdown.winner.authority,
+      live.body.conflictExplanation.scoreBreakdown.winner.authority,
     ).toBeCloseTo(0.1);
   });
 


### PR DESCRIPTION
## Что это

Фаза 4 трека Source Reputation: **согласие источников усиливает факт, а не устраивает дуэль**. Тот же object от ДРУГОГО источника теперь не вытесняет/не конкурирует, а корроборирует: новая строка остаётся audit-записью второго заявления (`status='corroborating'`, `corroborates` → инкумбент), инкумбент копит `corroboration {count, sourceKeys[], lastAt}`, вызывающий получает `CORROBORATED {factId, corroboratedFactId}`.

## Ключевые семантики (v1, осознанные)

- Матч = **точный** object + другой `fn::source_key_of`; same-source повтор = refresh (supersede, как раньше); append_only не корроборирует (там каждое заявление — событие).
- Ветка идёт **до** backdated-guard: идентичность заявления бьёт порядок дат.
- Retract инкумбента corroborating-строки не трогает (это записи заявлений, не живые значения).
- Read-пути прячут `corroborating` везде, где прячут `compacted` (search where-builder, graph-retrieve, entity reads) — факт показывает инкумбент со счётчиком; audit-shape (`includeStale`) их отдаёт.
- Nightly-рефит считает corroborating **WIN** для источника (раньше — ни то ни сё).

## Попутно

Ф3-флип-тест использовал идентичный object — под Ф4 он корректно даёт CORROBORATED до конфликтного пути. Переписан: инкумбент сидится напрямую с подсаженным эмбеддингом (cosine 1.0, объект другой) — margin-математика authority по-прежнему проверяется.

## Тесты

881 unit / 180 e2e / 9 jobs. Новый e2e: 2-й и 3-й источники копят счётчик; идентичное single_active-значение не чёрнит таймлайн (другое значение — supersede как раньше); в поиске нет дублей; retract-семантика; рефит-wins.

## Дальше

Ф5 (финал трека): fact_trust в ранжировании поиска за флагами + `SYNTHESIZE_MIN_FACT_TRUST`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)