### PR TITLE
fix(domain-packs): reinstall reactivation + validate enums + reject downgrade (audit wave 2)

### DIFF
--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -13,8 +13,10 @@ import type { PredicateDefinition } from '../ai/predicate-registry-internals/typ
 import {
   assertPackTrust,
   BUILTIN_PACKS,
+  compareSemver,
   composePredicateId,
   DomainPackError,
+  PACK_NAMESPACE_SEP,
   packChecksum,
   validatePack,
   type DomainPackManifest,
@@ -152,16 +154,37 @@ export class DomainPackInstallService {
       };
     });
 
+    const prefix = `${manifest.id}${PACK_NAMESPACE_SEP}`;
     const seeded = await this.surreal.withCompany(companyId, async (db) => {
       const [existing] = await db.query<[any[]]>(
-        `SELECT id FROM domain_pack WHERE packId = $packId LIMIT 1`,
+        `SELECT id, version FROM domain_pack WHERE packId = $packId LIMIT 1`,
         { packId: manifest.id },
       );
       const row = ((existing as any[]) ?? [])[0];
       if (row) {
+        // Reject a silent version downgrade — an out-of-order replay or a
+        // stale artifact must not quietly roll a tenant's ontology back.
+        if (compareSemver(manifest.version, String(row.version)) < 0) {
+          throw new BadRequestException(
+            `pack "${manifest.id}" v${manifest.version} is older than the installed v${row.version}; refusing to downgrade`,
+          );
+        }
         await db.query(
           `UPDATE $id SET version = $version, manifest = $manifest, checksum = $checksum, status = 'active', updatedAt = time::now()`,
           { id: row.id, version: manifest.version, manifest, checksum },
+        );
+        // Reinstall after uninstall: uninstall DEPRECATED this pack's
+        // predicates; seedMissingPredicates skips them (they exist by id),
+        // so without this they'd stay out of the active snapshot forever —
+        // the pack would read as installed but extract nothing. Reactivate
+        // the pack-owned rows we deprecated (createdBy='admin' guards
+        // against reviving an operator's manual deprecation of a core id).
+        await db.query(
+          `UPDATE knowledge_predicate SET status = 'active'
+             WHERE string::starts_with(predicateId, $prefix)
+               AND status = 'deprecated'
+               AND createdBy = 'admin'`,
+          { prefix },
         );
       } else {
         await db.query(`CREATE domain_pack CONTENT $content`, {

--- a/src/ai/domain-packs/validate.ts
+++ b/src/ai/domain-packs/validate.ts
@@ -14,6 +14,26 @@ import {
 
 const SNAKE = /^[a-z][a-z0-9_]*$/;
 const SEMVER = /^\d+\.\d+\.\d+$/;
+// Mirror the DB-level ASSERTs (0011_predicate_registry). validatePack runs
+// BEFORE the domain_pack row is written and predicates are seeded, so an
+// invalid enum here would otherwise surface as a raw Surreal ASSERT error
+// (HTTP 500 + a half-installed pack) rather than a clean 400.
+const SEMANTICS = new Set(['append_only', 'single_active', 'bitemporal']);
+const PII_CLASSES = new Set([
+  'none',
+  'identifier',
+  'behavioral',
+  'text',
+  'sensitive',
+]);
+const DATATYPES = new Set([
+  'string',
+  'number',
+  'date',
+  'datetime',
+  'enum',
+  'json',
+]);
 
 export class DomainPackError extends Error {}
 
@@ -23,16 +43,29 @@ export function validatePack(pack: DomainPackManifest): void {
       `pack id "${pack.id}" must be snake_case and must not contain "${PACK_NAMESPACE_SEP}"`,
     );
   }
+  // A trailing underscore lets `foo_`'s composed prefix (`foo___`) collide
+  // with `foo`'s uninstall prefix (`foo__`) — reject it up front.
+  if (pack.id.endsWith('_')) {
+    throw new DomainPackError(
+      `pack id "${pack.id}" must not end with an underscore`,
+    );
+  }
   if (!SEMVER.test(pack.version)) {
     throw new DomainPackError(
       `pack "${pack.id}" version "${pack.version}" must be semver MAJOR.MINOR.PATCH`,
     );
+  }
+  if (!Array.isArray(pack.predicates)) {
+    throw new DomainPackError(`pack "${pack.id}" predicates must be an array`);
   }
   if (pack.predicates.length === 0) {
     throw new DomainPackError(`pack "${pack.id}" declares no predicates`);
   }
   const seen = new Set<string>();
   for (const p of pack.predicates) {
+    if (p === null || typeof p !== 'object') {
+      throw new DomainPackError(`pack "${pack.id}" predicate entries must be objects`);
+    }
     if (!SNAKE.test(p.localId) || p.localId.includes(PACK_NAMESPACE_SEP)) {
       throw new DomainPackError(
         `pack "${pack.id}" localId "${p.localId}" must be snake_case and must not contain "${PACK_NAMESPACE_SEP}"`,
@@ -44,6 +77,21 @@ export function validatePack(pack: DomainPackManifest): void {
       );
     }
     seen.add(p.localId);
+    if (!SEMANTICS.has(p.semantics as string)) {
+      throw new DomainPackError(
+        `pack "${pack.id}" predicate "${p.localId}" semantics "${p.semantics}" must be one of ${[...SEMANTICS].join('|')}`,
+      );
+    }
+    if (!PII_CLASSES.has(p.piiClass as string)) {
+      throw new DomainPackError(
+        `pack "${pack.id}" predicate "${p.localId}" piiClass "${p.piiClass}" must be one of ${[...PII_CLASSES].join('|')}`,
+      );
+    }
+    if (p.datatype !== undefined && !DATATYPES.has(p.datatype as string)) {
+      throw new DomainPackError(
+        `pack "${pack.id}" predicate "${p.localId}" datatype "${p.datatype}" must be one of ${[...DATATYPES].join('|')}`,
+      );
+    }
   }
   if (pack.extractionProfile !== undefined) {
     validateExtractionProfile(pack.id, pack.extractionProfile);

--- a/test/domain-pack-install.e2e-spec.ts
+++ b/test/domain-pack-install.e2e-spec.ts
@@ -121,4 +121,55 @@ describe('/v1/admin/packs — runtime Domain Pack install', () => {
     const r = await f.http.delete('/v1/admin/packs/code_memory').set(auth());
     expect(r.status).toBe(400);
   });
+
+  it('reinstall after uninstall REACTIVATES the deprecated predicate (not inert)', async () => {
+    // 'medical' was uninstalled above → its predicate is deprecated.
+    const before = await f.http.get('/v1/admin/predicates').set(auth());
+    const depd = (before.body.predicates ?? []).find(
+      (p: any) => p.predicateId === 'medical__diagnosis',
+    );
+    expect(depd?.status).toBe('deprecated');
+
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: MEDICAL_MANIFEST });
+    expect([200, 201]).toContain(r.status);
+
+    // The pack must be USABLE again — the predicate back in the active set,
+    // not lingering deprecated (which read as "installed but extracts
+    // nothing" pre-fix).
+    const after = await f.http.get('/v1/admin/predicates').set(auth());
+    const react = (after.body.predicates ?? []).find(
+      (p: any) => p.predicateId === 'medical__diagnosis',
+    );
+    expect(react?.status).toBe('active');
+  });
+
+  it('rejects a version downgrade', async () => {
+    // medical is at 1.0.0 (reinstalled above). A 0.9.0 install must 400.
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: { ...MEDICAL_MANIFEST, version: '0.9.0' } });
+    expect(r.status).toBe(400);
+    expect(JSON.stringify(r.body)).toMatch(/downgrade/i);
+  });
+
+  it('rejects a manifest with an invalid enum as a 400, not a 500', async () => {
+    const bad = {
+      ...MEDICAL_MANIFEST,
+      id: 'badenum',
+      version: '1.0.0',
+      predicates: [
+        { ...MEDICAL_MANIFEST.predicates[0], semantics: 'sometimes' },
+      ],
+    };
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: bad });
+    expect(r.status).toBe(400);
+    expect(JSON.stringify(r.body)).toMatch(/semantics/);
+  });
 });

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -83,6 +83,22 @@ describe('validatePack', () => {
       validatePack(pack({ predicates: [packPredicate('a__b')] })),
     ).toThrow(DomainPackError);
   });
+  it('rejects a pack id ending in underscore (uninstall-prefix collision)', () => {
+    expect(() => validatePack(pack({ id: 'foo_' }))).toThrow(/underscore/);
+  });
+  it('rejects a bad semantics enum (would be a DB ASSERT 500 mid-install)', () => {
+    const bad = { ...packPredicate('x'), semantics: 'sometimes' as never };
+    expect(() => validatePack(pack({ predicates: [bad] }))).toThrow(/semantics/);
+  });
+  it('rejects a bad piiClass enum', () => {
+    const bad = { ...packPredicate('x'), piiClass: 'secret' as never };
+    expect(() => validatePack(pack({ predicates: [bad] }))).toThrow(/piiClass/);
+  });
+  it('rejects a non-array predicates field', () => {
+    expect(() =>
+      validatePack(pack({ predicates: 42 as never })),
+    ).toThrow(/must be an array/);
+  });
   it('accepts a well-formed extractionProfile', () => {
     expect(() =>
       validatePack(


### PR DESCRIPTION
## Что это

Волна 2 аудита — correctness-фиксы pack-lifecycle (install path).

| # | Sev | Фикс |
|---|-----|------|
| H1 | HIGH | **reinstall-инертность**: uninstall депрекейтит предикаты пака, seedMissingPredicates их пропускает (существуют по id) → reinstall оставлял их deprecated навсегда (пак «установлен», но словарь вне active-снапшота — ничего не извлекает, факты через canonicalize мис-алиасятся). install теперь реактивирует pack-owned deprecated-строки (гард createdBy='admin'). |
| M4 | MED | **validatePack не проверял enum'ы** — невалидный манифест проходил валидацию, флипал domain_pack в active, ловил DB-ASSERT 0011 → **500 с полу-установленным паком**. Теперь зеркалит DB-enum'ы (semantics/piiClass/datatype) + predicates-is-array → чистый **400**, ничего не пишется. Плюс reject pack id с хвостовым `_` (коллизия uninstall-префикса). |
| M5 | MED | **downgrade молча принимался** (стейл-артефакт откатывал онтологию тенанта). compareSemver-гард → **400**. |

## Тесты

893 unit / 184 e2e. Новые e2e: reinstall→реактивация, downgrade→400, bad-enum→400 (не 500); unit — enum/underscore/array. Drift-guard 6 first-party паков цел.

## Осталось из волны 2 (отдельно)

M1/M2 (upgrade: применять изменённые определения / депрекейтить удалённые предикаты) + M3 (versionHash без extractionProfiles → стейл extraction-кэш) — сложнее, требуют diff-манифеста; следующим заходом.

🤖 Generated with [Claude Code](https://claude.com/claude-code)