### PR TITLE
fix(registry): publish-race, squatting, projection, pagination, esc coerce (audit wave 3)

### DIFF
--- a/src/registry/pack-registry.service.ts
+++ b/src/registry/pack-registry.service.ts
@@ -6,8 +6,10 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { SurrealService } from '../db/surreal.service';
+import { retryOnUniqueViolation } from '../db/surreal-retry';
 import { envFlagEnabled } from '../common/env-validation';
 import {
+  BUILTIN_PACKS,
   DomainPackError,
   packChecksum,
   pickLatestVersion,
@@ -58,6 +60,7 @@ interface RegistryRow {
 @Injectable()
 export class PackRegistryService {
   private readonly logger = new Logger(PackRegistryService.name);
+  private readonly builtinIds = new Set(BUILTIN_PACKS.map((p) => p.id));
 
   constructor(private readonly surreal: SurrealService) {}
 
@@ -87,6 +90,14 @@ export class PackRegistryService {
       if (e instanceof DomainPackError) throw new BadRequestException(e.message);
       throw e;
     }
+    // A builtin pack id is globally seeded, not installable from the registry —
+    // publishing one would let anyone squat the reserved namespace and shadow
+    // core ontology at the discovery layer.
+    if (this.builtinIds.has(manifest.id)) {
+      throw new BadRequestException(
+        `pack id "${manifest.id}" is reserved by a builtin pack and cannot be published`,
+      );
+    }
     if (this.requireSignature() && !manifest.signature) {
       throw new BadRequestException(
         `pack "${manifest.id}" is unsigned but this registry requires signed packs`,
@@ -98,56 +109,65 @@ export class PackRegistryService {
         `checksum mismatch: expected ${input.expectedChecksum}, computed ${checksum}`,
       );
     }
-    const keywords = (input.keywords ?? [])
+    // Guard against a non-array keywords body ({} / string): .map would throw a
+    // raw 500. Coerce to [] and normalize.
+    const keywords = (Array.isArray(input.keywords) ? input.keywords : [])
       .map((k) => String(k).trim().toLowerCase())
       .filter(Boolean);
 
-    return this.surreal.withAdminDb(async (db) => {
-      const [existing] = await db.query<[RegistryRow[]]>(
-        `SELECT packId, version, checksum FROM registry_pack
-           WHERE packId = $packId AND version = $version LIMIT 1`,
-        { packId: manifest.id, version: manifest.version },
-      );
-      const prior = ((existing as RegistryRow[]) ?? [])[0];
-      if (prior) {
-        if (prior.checksum === checksum) {
-          // Idempotent republish of identical content.
-          return {
-            packId: manifest.id,
-            version: manifest.version,
-            checksum,
-            created: false,
-          };
-        }
-        throw new ConflictException(
-          `pack "${manifest.id}" version ${manifest.version} is already published with different content (immutable)`,
+    // Concurrent publishes of the same (packId, version) both pass the SELECT
+    // (no prior) and race to CREATE; the UNIQUE index turns the loser's write
+    // into a violation. retryOnUniqueViolation re-runs the closure — the retry's
+    // SELECT now sees the winner's row and resolves to idempotent-or-409 instead
+    // of surfacing a raw 500.
+    return this.surreal.withAdminDb((db) =>
+      retryOnUniqueViolation(async () => {
+        const [existing] = await db.query<[RegistryRow[]]>(
+          `SELECT packId, version, checksum FROM registry_pack
+             WHERE packId = $packId AND version = $version LIMIT 1`,
+          { packId: manifest.id, version: manifest.version },
         );
-      }
-      // option<string> fields reject a JS null under SCHEMAFULL ("Found NULL,
-      // expected option<...>") — omit them when absent so they store as NONE.
-      const content: Record<string, unknown> = {
-        packId: manifest.id,
-        version: manifest.version,
-        manifest,
-        checksum,
-        description: manifest.description ?? '',
-        keywords,
-        signed: Boolean(manifest.signature),
-        yanked: false,
-      };
-      if (manifest.publisher) content.publisher = manifest.publisher;
-      if (input.publishedBy) content.publishedBy = input.publishedBy;
-      await db.query(`CREATE registry_pack CONTENT $content`, { content });
-      this.logger.log(
-        `Published pack ${manifest.id} v${manifest.version} (checksum ${checksum.slice(0, 12)}…)`,
-      );
-      return {
-        packId: manifest.id,
-        version: manifest.version,
-        checksum,
-        created: true,
-      };
-    });
+        const prior = ((existing as RegistryRow[]) ?? [])[0];
+        if (prior) {
+          if (prior.checksum === checksum) {
+            // Idempotent republish of identical content.
+            return {
+              packId: manifest.id,
+              version: manifest.version,
+              checksum,
+              created: false,
+            };
+          }
+          throw new ConflictException(
+            `pack "${manifest.id}" version ${manifest.version} is already published with different content (immutable)`,
+          );
+        }
+        // option<string> fields reject a JS null under SCHEMAFULL ("Found NULL,
+        // expected option<...>") — omit them when absent so they store as NONE.
+        const content: Record<string, unknown> = {
+          packId: manifest.id,
+          version: manifest.version,
+          manifest,
+          checksum,
+          description: manifest.description ?? '',
+          keywords,
+          signed: Boolean(manifest.signature),
+          yanked: false,
+        };
+        if (manifest.publisher) content.publisher = manifest.publisher;
+        if (input.publishedBy) content.publishedBy = input.publishedBy;
+        await db.query(`CREATE registry_pack CONTENT $content`, { content });
+        this.logger.log(
+          `Published pack ${manifest.id} v${manifest.version} (checksum ${checksum.slice(0, 12)}…)`,
+        );
+        return {
+          packId: manifest.id,
+          version: manifest.version,
+          checksum,
+          created: true,
+        };
+      }),
+    );
   }
 
   /** Catalogue listing — one entry per pack (its latest non-yanked version),
@@ -158,8 +178,11 @@ export class PackRegistryService {
     publisher?: string;
     tag?: string;
     limit?: number;
+    offset?: number;
   }): Promise<RegistryPackSummary[]> {
-    const rows = await this.allRows();
+    // Manifest-less projection: the summary needs none of the (potentially
+    // large) manifest JSON, and this path serves the public UI on every hit.
+    const rows = await this.allRows({ includeManifest: false });
     const byPack = new Map<string, RegistryRow[]>();
     for (const r of rows) {
       const arr = byPack.get(r.packId) ?? [];
@@ -195,13 +218,19 @@ export class PackRegistryService {
       return true;
     });
     out.sort((a, b) => a.packId.localeCompare(b.packId));
+    // Offset + capped limit: a catalogue larger than one page was previously
+    // truncated at the 500th pack with no way to reach the rest. Clients page by
+    // advancing offset until an empty page comes back.
+    const offset = Math.max(filter.offset ?? 0, 0);
     const limit = Math.min(Math.max(filter.limit ?? 100, 1), 500);
-    return out.slice(0, limit);
+    return out.slice(offset, offset + limit);
   }
 
   /** All versions of one pack, newest-first, with the latest non-yanked flagged. */
   async getVersions(packId: string): Promise<RegistryVersionsResponse> {
-    const rows = (await this.allRows()).filter((r) => r.packId === packId);
+    // packId-scoped + manifest-less: version metadata carries no manifest, and
+    // the packId index avoids a full-table scan.
+    const rows = await this.rowsForPack(packId, { includeManifest: false });
     const versions = rows
       .map((r) => this.toVersion(r))
       .sort((a, b) => compareSemver(b.version, a.version));
@@ -300,12 +329,13 @@ export class PackRegistryService {
     });
   }
 
-  /** Find one row: exact version, or the latest non-yanked when version omitted. */
+  /** Find one row (WITH manifest — this feeds getManifest/resolveForInstall):
+   *  exact version, or the latest non-yanked when version omitted. */
   private async findRow(
     packId: string,
     version?: string,
   ): Promise<RegistryRow | null> {
-    const rows = (await this.allRows()).filter((r) => r.packId === packId);
+    const rows = await this.rowsForPack(packId, { includeManifest: true });
     if (rows.length === 0) return null;
     if (version) return rows.find((r) => r.version === version) ?? null;
     const latest = pickLatestVersion(
@@ -314,12 +344,35 @@ export class PackRegistryService {
     return latest ? (rows.find((r) => r.version === latest) ?? null) : null;
   }
 
-  private async allRows(): Promise<RegistryRow[]> {
+  /** Manifest is the one heavy column; every read path except manifest
+   *  inspection / install-resolution wants it dropped. */
+  private projection(includeManifest: boolean): string {
+    return `packId, version,${includeManifest ? ' manifest,' : ''} checksum,
+            description, keywords, publisher, signed, yanked, yankReason,
+            publishedAt`;
+  }
+
+  /** One pack's rows, packId-index scoped (no full-table scan). */
+  private async rowsForPack(
+    packId: string,
+    opts: { includeManifest: boolean },
+  ): Promise<RegistryRow[]> {
     return this.surreal.withAdminDb(async (db) => {
       const [rows] = await db.query<[RegistryRow[]]>(
-        `SELECT packId, version, manifest, checksum, description, keywords,
-                publisher, signed, yanked, yankReason, publishedAt
-           FROM registry_pack`,
+        `SELECT ${this.projection(opts.includeManifest)} FROM registry_pack
+           WHERE packId = $packId`,
+        { packId },
+      );
+      return (rows as RegistryRow[]) ?? [];
+    });
+  }
+
+  private async allRows(
+    opts: { includeManifest: boolean } = { includeManifest: true },
+  ): Promise<RegistryRow[]> {
+    return this.surreal.withAdminDb(async (db) => {
+      const [rows] = await db.query<[RegistryRow[]]>(
+        `SELECT ${this.projection(opts.includeManifest)} FROM registry_pack`,
       );
       return (rows as RegistryRow[]) ?? [];
     });

--- a/src/registry/registry-ui.ts
+++ b/src/registry/registry-ui.ts
@@ -7,8 +7,11 @@ import type { RegistryPackSummary } from '../contracts/registry/registry.schema'
  * summaries. All dynamic values are HTML-escaped.
  */
 
-function esc(s: string): string {
-  return s
+function esc(s: unknown): string {
+  // Coerce first: a non-string value (e.g. a numeric description that slipped
+  // past the DB projection) would otherwise throw `.replace is not a function`
+  // and 500 the public page.
+  return String(s ?? '')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')

--- a/src/registry/registry.controller.ts
+++ b/src/registry/registry.controller.ts
@@ -29,13 +29,20 @@ export class RegistryController {
   @RequireScopes('brain:read')
   async list(
     @Query()
-    query: { q?: string; publisher?: string; tag?: string; limit?: string },
+    query: {
+      q?: string;
+      publisher?: string;
+      tag?: string;
+      limit?: string;
+      offset?: string;
+    },
   ): Promise<RegistryListResponse> {
     const packs = await this.registry.list({
       q: query.q,
       publisher: query.publisher,
       tag: query.tag,
       limit: query.limit ? parseInt(query.limit, 10) : undefined,
+      offset: query.offset ? parseInt(query.offset, 10) : undefined,
     });
     return { packs };
   }

--- a/test/pack-registry.e2e-spec.ts
+++ b/test/pack-registry.e2e-spec.ts
@@ -165,4 +165,50 @@ describe('/v1/registry — global pack registry (e2e)', () => {
       .send({ packId: 'no_such_pack_xyz' });
     expect(r.status).toBe(404);
   });
+
+  it('rejects publishing a builtin pack id (namespace squatting)', async () => {
+    const r = await pub.http
+      .post('/v1/admin/registry/packs')
+      .set(auth(pub))
+      .send({ manifest: { ...bump('1.0.0'), id: 'code_memory' } });
+    expect(r.status).toBe(400);
+    expect(JSON.stringify(r.body)).toMatch(/reserved|builtin/i);
+  });
+
+  it('does not 500 on a non-array keywords body (coerces to empty)', async () => {
+    const r = await pub.http
+      .post('/v1/admin/registry/packs')
+      .set(auth(pub))
+      .send({
+        manifest: { ...PACK, id: 'kw_guard_e2e', version: '0.1.0' },
+        keywords: 'not-an-array',
+      });
+    expect([200, 201]).toContain(r.status);
+    const versions = await reader.http
+      .get('/v1/registry/packs/kw_guard_e2e')
+      .set(auth(reader));
+    expect(versions.body.versions[0].keywords).toEqual([]);
+  });
+
+  it('paginates the catalogue with offset (packs beyond a page stay reachable)', async () => {
+    // Two distinct packs → page size 1 must surface each via offset.
+    for (const id of ['pg_a_e2e', 'pg_b_e2e']) {
+      await pub.http
+        .post('/v1/admin/registry/packs')
+        .set(auth(pub))
+        .send({ manifest: { ...PACK, id, version: '0.1.0' } });
+    }
+    const page1 = await reader.http
+      .get('/v1/registry/packs?q=pg_&limit=1&offset=0')
+      .set(auth(reader));
+    const page2 = await reader.http
+      .get('/v1/registry/packs?q=pg_&limit=1&offset=1')
+      .set(auth(reader));
+    expect(page1.body.packs).toHaveLength(1);
+    expect(page2.body.packs).toHaveLength(1);
+    // Sorted by packId → distinct, non-overlapping pages.
+    expect(page1.body.packs[0].packId).not.toBe(page2.body.packs[0].packId);
+    const seen = [page1.body.packs[0].packId, page2.body.packs[0].packId].sort();
+    expect(seen).toEqual(['pg_a_e2e', 'pg_b_e2e']);
+  });
 });

--- a/test/registry-ui.unit-spec.ts
+++ b/test/registry-ui.unit-spec.ts
@@ -40,4 +40,16 @@ describe('renderRegistryPage', () => {
     const html = renderRegistryPage([]);
     expect(html).toContain('No packs published yet');
   });
+
+  it('does not throw on a non-string field slipping through (coerces, no 500)', () => {
+    // A numeric description / null publisher from a hand-written DB row must
+    // render, not crash the public page with ".replace is not a function".
+    const rogue = pack({
+      description: 42 as unknown as string,
+      publisher: null,
+      latestVersion: 1.0 as unknown as string,
+    });
+    expect(() => renderRegistryPage([rogue])).not.toThrow();
+    expect(renderRegistryPage([rogue])).toContain('42');
+  });
 });


### PR DESCRIPTION
Registry hardening — audit wave 3 (MEDIUM cluster from \`audit_2026-07-07\`).

| Fix | Before | After |
|---|---|---|
| **Publish race** | SELECT-then-CREATE → two concurrent publishes of the same (packId, version) both pass, race the UNIQUE index → raw **500** | wrapped in `retryOnUniqueViolation` (house pattern); retry's SELECT sees the winner → idempotent-or-409 |
| **Builtin squatting** | anyone could publish id `code_memory` and shadow core at discovery | publish rejects builtin ids (matches install) |
| **keywords guard** | non-array `keywords` body → `.map` on a string → **500** | coerce to `[]` before normalizing |
| **allRows projection** | `list()`/`getVersions()` pulled the heavy `manifest` column (list serves the public UI every hit) | manifest dropped from summary paths; `getVersions()`/`findRow()` packId-index scoped, not full-table scan |
| **Pagination** | catalogue past the 500-cap unreachable | `list()` gained `offset`; clients page by advancing it |
| **esc() coerce** | UI escaper took `string`, threw `.replace is not a function` on a non-string field → **500** the public page | `String()`-coerce first |

## Tests
- +1 esc-coerce unit (non-string field renders, no throw)
- +3 e2e: builtin squat → 400, non-array keywords → no 500 (empty), offset pagination (packs beyond a page reachable)
- 894 unit / 11 pack-registry e2e / registry-ui e2e green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)