### PR TITLE
fix(domain-packs): cap pack-eval fixtures + throttle eval route (audit H7)

### DIFF
--- a/src/admin/admin-packs.controller.ts
+++ b/src/admin/admin-packs.controller.ts
@@ -8,6 +8,7 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import type { AuthenticatedRequest } from '../auth/api-key.types';
 import { DomainPackInstallService } from './domain-pack-install.service';
@@ -80,6 +81,10 @@ export class AdminPacksController {
    *  scores whether extraction (with the pack's predicates + extractionProfile
    *  active) still meets the pack's own expectations. */
   @Post(':packId/eval')
+  // Heaviest admin route: up to MAX_EVAL_FIXTURES live extractor (LLM) calls
+  // per request. Tightest expensive bucket so it can't be looped into a cost
+  // spike even by an authorized admin.
+  @Throttle({ expensive: { limit: 3, ttl: 60_000 } })
   @RequireScopes('brain:admin')
   async eval(
     @Req() req: AuthenticatedRequest,

--- a/src/admin/pack-eval.service.ts
+++ b/src/admin/pack-eval.service.ts
@@ -16,6 +16,12 @@ import {
  * pack's predicates + extractionProfile active for the tenant) and scored
  * against its expectations. Mirrors the extractionProfile wiring.
  */
+/** Hard ceiling on fixtures run per eval request. Each fixture is one live
+ *  extractor (LLM) call, so an installed pack shipping thousands of fixtures
+ *  would turn a single request into thousands of paid calls. Cap + log the
+ *  overflow (no silent truncation) — the route is also @Throttle({expensive}). */
+const MAX_EVAL_FIXTURES = 50;
+
 @Injectable()
 export class PackEvalService {
   private readonly logger = new Logger(PackEvalService.name);
@@ -32,7 +38,13 @@ export class PackEvalService {
         `pack "${packId}" is not a builtin and is not installed for this tenant`,
       );
     }
-    const fixtures = manifest.evalFixtures ?? [];
+    const declared = manifest.evalFixtures ?? [];
+    const fixtures = declared.slice(0, MAX_EVAL_FIXTURES);
+    if (declared.length > fixtures.length) {
+      this.logger.warn(
+        `pack eval ${manifest.id}: ${declared.length} fixtures declared, running first ${fixtures.length} (MAX_EVAL_FIXTURES cap)`,
+      );
+    }
     const results = [];
     for (const fixture of fixtures) {
       const extraction = await this.extractor.extract(fixture.text, companyId);

--- a/test/pack-eval.e2e-spec.ts
+++ b/test/pack-eval.e2e-spec.ts
@@ -61,4 +61,40 @@ describe('/v1/admin/packs/:id/eval — pack eval fixtures (e2e)', () => {
     const r = await f.http.post('/v1/admin/packs/no_such_pack/eval').set(auth());
     expect(r.status).toBe(404);
   });
+
+  it('caps the fixtures run per request (cost bomb guard)', async () => {
+    // A pack shipping more than MAX_EVAL_FIXTURES fixtures must run only the
+    // cap's worth — each fixture is one live extractor call.
+    const fixtures = Array.from({ length: 60 }, (_, i) => ({
+      id: `fx_${i}`,
+      text: `sample input ${i}`,
+      expect: { facts: [{ predicate: 'capcheck__thing' }] },
+    }));
+    const manifest = {
+      id: 'capcheck',
+      version: '1.0.0',
+      description: 'Cap-guard test pack.',
+      predicates: [
+        {
+          localId: 'thing',
+          displayLabel: 'thing',
+          description: 'x',
+          datatype: 'string',
+          semantics: 'append_only',
+          decayHalfLifeDays: null,
+          piiClass: 'none',
+          status: 'active',
+        },
+      ],
+      evalFixtures: fixtures,
+    };
+    await f.http.post('/v1/admin/packs').set(auth()).send({ manifest });
+    f.extractor.setScript(null);
+
+    const r = await f.http.post('/v1/admin/packs/capcheck/eval').set(auth());
+    expect(r.status).toBe(201);
+    // 60 declared, capped at MAX_EVAL_FIXTURES (50).
+    expect(r.body.total).toBe(50);
+    expect(r.body.results).toHaveLength(50);
+  });
 });


### PR DESCRIPTION
Closes the last HIGH from `audit_2026-07-07` (H7 — pack eval cost bomb).

`POST /v1/admin/packs/:id/eval` runs **one live extractor (LLM) call per fixture**, with no cap and no expensive-bucket throttle. An installed pack shipping thousands of fixtures — or the route looped — turned a single request into thousands of paid calls.

- **Cap**: `PackEvalService` runs at most `MAX_EVAL_FIXTURES` (50), logging the overflow (no silent truncation). `total` reflects what actually ran.
- **Throttle**: the route now carries `@Throttle({ expensive: { limit: 3, ttl: 60_000 } })` — the tightest expensive bucket, since it's the heaviest admin route.

## Tests
- +1 e2e: a 60-fixture pack → report `total` 50, 50 results
- 902 unit / pack-eval e2e green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)