### PR TITLE
fix(code-memory): sweep guard, resolver ext-gate, reanchor threshold, gate ratchet, sink timeout (audit wave 4)

### DIFF
--- a/scripts/validate-anchors.ts
+++ b/scripts/validate-anchors.ts
@@ -44,6 +44,8 @@ async function main(): Promise<void> {
   };
   console.error(`[anchors] ${anchors.length} anchor(s) to check`);
 
+  // --force bypasses the blast-radius guard for a confirmed mass removal.
+  const force = process.argv.includes('--force');
   const verdicts = buildAnchorVerdicts({
     anchors: anchors.map((a) => a.anchor),
     readFile: (p) => {
@@ -54,6 +56,7 @@ async function main(): Promise<void> {
       }
     },
     choose: heuristicChoose,
+    ...(force ? { maxInvalidateRatio: 1 } : {}),
   });
   const actionable = verdicts.filter((v) => v.action !== 'ok');
   console.error(

--- a/src/code-memory/anchor/sweep.ts
+++ b/src/code-memory/anchor/sweep.ts
@@ -14,12 +14,27 @@ export type AnchorVerdict =
   | { anchor: string; action: 'reanchor'; newAnchor: string }
   | { anchor: string; action: 'invalidate'; reason: string };
 
+/** Thrown when a suspiciously large fraction of anchors would be invalidated —
+ *  the signature of a misconfigured run (CLI launched outside the repo root so
+ *  every readFile misses, or a mixed anchor-format set) rather than a real mass
+ *  deletion. Aborts before the CLI POSTs a tenant-wide retract. Override with
+ *  `maxInvalidateRatio: 1` for a genuine large removal. */
+export class SweepBlastRadiusError extends Error {}
+
 export function buildAnchorVerdicts(opts: {
   anchors: string[];
   readFile: ReadFile;
   choose: (candidates: string[], missing: string) => string | null;
+  /** Abort if > this fraction of anchors would invalidate (default 0.5). Set to
+   *  1 to disable the guard for a legitimate mass removal. */
+  maxInvalidateRatio?: number;
+  /** Only guard once there are at least this many anchors (default 10) — a tiny
+   *  set legitimately hits high ratios. */
+  minAnchorsForGuard?: number;
 }): AnchorVerdict[] {
   const { anchors, readFile, choose } = opts;
+  const maxInvalidateRatio = opts.maxInvalidateRatio ?? 0.5;
+  const minAnchorsForGuard = opts.minAnchorsForGuard ?? 10;
   const verdicts: AnchorVerdict[] = [];
   for (const anchor of anchors) {
     const health = validateAnchor({ anchor, readFile });
@@ -48,6 +63,25 @@ export function buildAnchorVerdicts(opts: {
           },
     );
   }
+  // Blast-radius guard: a run that would retract most of the tenant's anchors is
+  // almost always a misconfiguration, not reality. Refuse rather than emit the
+  // mass-invalidate; the operator re-runs from the right cwd or passes the
+  // override once they've confirmed the removal is real.
+  const invalidateCount = verdicts.filter(
+    (v) => v.action === 'invalidate',
+  ).length;
+  if (
+    anchors.length >= minAnchorsForGuard &&
+    invalidateCount / anchors.length > maxInvalidateRatio
+  ) {
+    throw new SweepBlastRadiusError(
+      `sweep would invalidate ${invalidateCount}/${anchors.length} anchors ` +
+        `(> ${Math.round(maxInvalidateRatio * 100)}%) — refusing. This usually ` +
+        `means the sweep ran outside the repo root or against mismatched ` +
+        `anchor formats. Re-run from the code root, or pass the override to ` +
+        `confirm a real mass removal.`,
+    );
+  }
   return verdicts;
 }
 
@@ -60,15 +94,26 @@ export function heuristicChoose(
 ): string | null {
   let best: string | null = null;
   let bestScore = 0;
+  let tied = false;
   for (const c of candidates) {
     const score = commonPrefixLen(c, missing);
     if (score > bestScore) {
       bestScore = score;
       best = c;
+      tied = false;
+    } else if (score === bestScore && score > 0 && c !== best) {
+      tied = true;
     }
   }
-  // Require a meaningful overlap so unrelated symbols aren't grabbed.
-  return bestScore >= Math.min(4, missing.length) ? best : null;
+  // Ambiguous: two current symbols share the top prefix (e.g. get_user vs
+  // get_post for a gone get_uuid) — don't guess, invalidate instead.
+  if (tied) return null;
+  // Require the overlap to cover a MAJORITY of the missing symbol (60%), with a
+  // 4-char floor. The old `>= min(4, len)` accepted any 4-char stem, so
+  // `handleFoo`→`handleBar` (prefix 6) or `get_user`→`get_post` (prefix 4)
+  // would silently re-anchor to an unrelated symbol.
+  const need = Math.max(4, Math.ceil(missing.length * 0.6));
+  return bestScore >= need ? best : null;
 }
 
 function commonPrefixLen(a: string, b: string): number {

--- a/src/code-memory/anchor/ts-symbol-resolver.ts
+++ b/src/code-memory/anchor/ts-symbol-resolver.ts
@@ -22,6 +22,18 @@ export interface SymbolSpan {
   endLine: number;
 }
 
+const TS_JS_EXT = /\.(mts|cts|tsx?|jsx?|mjs|cjs)$/i; // ts tsx mts cts js jsx mjs cjs
+
+/**
+ * Only TS/JS files get an AST symbol walk. Anything else (.py / .go / .rs / .md)
+ * must NOT be fed to the TS parser: it would "succeed" and emit garbage symbol
+ * spans from misparsed tokens, poisoning anchors. The docstring always promised
+ * "non-TS/JS files get no symbols" — this enforces it.
+ */
+export function isTsJsSource(fileName: string): boolean {
+  return TS_JS_EXT.test(fileName);
+}
+
 function scriptKindFor(fileName: string): ts.ScriptKind {
   if (fileName.endsWith('.tsx')) return ts.ScriptKind.TSX;
   if (fileName.endsWith('.jsx')) return ts.ScriptKind.JSX;
@@ -59,8 +71,10 @@ function declaredName(node: ts.Node): { name: string; kind: string } | null {
   return null;
 }
 
-/** All named symbol spans in a source file, outermost-first. */
+/** All named symbol spans in a source file, outermost-first. Non-TS/JS files
+ *  get no symbols — the caller falls back to a file-level anchor. */
 export function listSymbols(source: string, fileName = 'file.ts'): SymbolSpan[] {
+  if (!isTsJsSource(fileName)) return [];
   const sf = ts.createSourceFile(
     fileName,
     source,

--- a/src/code-memory/capture/http-sink.ts
+++ b/src/code-memory/capture/http-sink.ts
@@ -17,23 +17,30 @@ type FetchLike = (
     method: string;
     headers: Record<string, string>;
     body: string;
+    signal?: AbortSignal;
   },
 ) => Promise<{ ok: boolean; status: number; json: () => Promise<any> }>;
 
 const CODE_VERTICAL = 'code';
+const DEFAULT_TIMEOUT_MS = 15_000;
 
 export class HttpDecisionSink implements DecisionSink {
   private readonly fetchImpl: FetchLike;
+  private readonly timeoutMs: number;
 
   constructor(
     private readonly opts: {
       baseUrl: string;
       apiKey: string;
       fetchImpl?: FetchLike;
+      /** Per-request timeout; a hung server must not stall a CI capture hook
+       *  for hours. Default 15s. */
+      timeoutMs?: number;
     },
   ) {
     this.fetchImpl =
       opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 
   async record(candidate: DecisionCandidate): Promise<{ outcome: string }> {
@@ -52,14 +59,27 @@ export class HttpDecisionSink implements DecisionSink {
         ...(candidate.location ? { messageId: candidate.location } : {}),
       },
     };
-    const res = await this.fetchImpl(`${this.opts.baseUrl}/v1/ingest/fact`, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        authorization: `Bearer ${this.opts.apiKey}`,
-      },
-      body: JSON.stringify(body),
-    });
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), this.timeoutMs);
+    let res: { ok: boolean; status: number; json: () => Promise<any> };
+    try {
+      res = await this.fetchImpl(`${this.opts.baseUrl}/v1/ingest/fact`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${this.opts.apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: ac.signal,
+      });
+    } catch (e) {
+      if (ac.signal.aborted) {
+        throw new Error(`ingest POST timed out after ${this.timeoutMs}ms`);
+      }
+      throw e;
+    } finally {
+      clearTimeout(timer);
+    }
     if (!res.ok) {
       throw new Error(`ingest POST failed: ${res.status}`);
     }

--- a/test/code-memory-anchor.unit-spec.ts
+++ b/test/code-memory-anchor.unit-spec.ts
@@ -72,6 +72,20 @@ describe('ts-symbol-resolver', () => {
   it('non-TS content yields no symbols (caller falls back to file anchor)', () => {
     expect(listSymbols('plain text, not code', 'notes.md')).toEqual([]);
   });
+
+  it('gates by extension: a .py file is not parsed as TS (no garbage symbols)', () => {
+    // Python that the TS parser would happily misparse into junk spans.
+    const py = [
+      'class Foo:',
+      '    def bar(self):',
+      '        return 1',
+      'def baz():',
+      '    return 2',
+    ].join('\n');
+    expect(listSymbols(py, 'thing.py')).toEqual([]);
+    // But the SAME text under a .ts name still parses (gate is by extension).
+    expect(listSymbols(py, 'thing.ts').length).toBeGreaterThan(0);
+  });
 });
 
 describe('symbol-id', () => {

--- a/test/code-memory-capture-io.unit-spec.ts
+++ b/test/code-memory-capture-io.unit-spec.ts
@@ -139,6 +139,31 @@ describe('HttpDecisionSink', () => {
       }),
     ).rejects.toThrow(/503/);
   });
+
+  it('times out a hung request instead of hanging forever', async () => {
+    // A server that never responds; the sink must abort on its own timer so a
+    // CI capture hook can't stall for hours.
+    const sink = new HttpDecisionSink({
+      baseUrl: 'https://brain.test',
+      apiKey: 'k',
+      timeoutMs: 20,
+      fetchImpl: (_url: string, init: any) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () =>
+            reject(new Error('aborted')),
+          );
+        }) as any,
+    });
+    await expect(
+      sink.record({
+        kind: 'gotcha',
+        text: 'g',
+        anchor: 'a.ts',
+        commit: 'c',
+        validFrom: '2026-06-28T10:00:00Z',
+      }),
+    ).rejects.toThrow(/timed out/);
+  });
 });
 
 describe('parseGitLog', () => {

--- a/test/code-memory-sweep.unit-spec.ts
+++ b/test/code-memory-sweep.unit-spec.ts
@@ -4,6 +4,7 @@
 import {
   buildAnchorVerdicts,
   heuristicChoose,
+  SweepBlastRadiusError,
 } from '../src/code-memory/anchor/sweep';
 
 const SRC = `export class FactResolverService {
@@ -29,6 +30,15 @@ describe('heuristicChoose', () => {
   });
   it('declines when nothing meaningfully overlaps', () => {
     expect(heuristicChoose(['helper', 'other'], 'Zzz.Qqq')).toBeNull();
+  });
+  it('declines a weak stem match (get_user → get_post is not a rename)', () => {
+    expect(heuristicChoose(['get_post', 'other'], 'get_user')).toBeNull();
+  });
+  it('declines when two candidates tie on the top prefix (ambiguous)', () => {
+    // Both share "handle" (6) with the gone "handleThing" — don't guess.
+    expect(
+      heuristicChoose(['handleFoo', 'handleBar'], 'handleThing'),
+    ).toBeNull();
   });
 });
 
@@ -74,5 +84,36 @@ describe('buildAnchorVerdicts', () => {
       choose: heuristicChoose,
     });
     expect(v[0]).toMatchObject({ action: 'invalidate' });
+  });
+
+  it('refuses a mass-invalidate blast radius (misconfigured run)', () => {
+    // 12 anchors, none of whose files exist → 100% would invalidate. That's a
+    // wrong-cwd run, not a real deletion — abort instead of retracting all.
+    const anchors = Array.from({ length: 12 }, (_, i) => `gone_${i}.ts#Foo.bar`);
+    expect(() =>
+      buildAnchorVerdicts({ anchors, readFile: () => null, choose: heuristicChoose }),
+    ).toThrow(SweepBlastRadiusError);
+  });
+
+  it('does not guard a small anchor set (legitimately high ratio)', () => {
+    // Below minAnchorsForGuard — 2 gone files must not trip the guard.
+    const v = buildAnchorVerdicts({
+      anchors: ['gone_a.ts#Foo.bar', 'gone_b.ts#Baz.qux'],
+      readFile: () => null,
+      choose: heuristicChoose,
+    });
+    expect(v.every((x) => x.action === 'invalidate')).toBe(true);
+  });
+
+  it('honors the override for a confirmed mass removal', () => {
+    const anchors = Array.from({ length: 12 }, (_, i) => `gone_${i}.ts#Foo.bar`);
+    const v = buildAnchorVerdicts({
+      anchors,
+      readFile: () => null,
+      choose: heuristicChoose,
+      maxInvalidateRatio: 1,
+    });
+    expect(v).toHaveLength(12);
+    expect(v.every((x) => x.action === 'invalidate')).toBe(true);
   });
 });

--- a/test/gate-default-model.unit-spec.ts
+++ b/test/gate-default-model.unit-spec.ts
@@ -17,6 +17,13 @@ import {
 
 const MODEL_PATH = join(__dirname, '..', 'models', 'decision-gate.model.json');
 
+// Ratchet: the shipped hybrid currently scores golden F1 0.6667 (prec 1.0, rec
+// 0.5). "Beats the heuristic" (0.621) alone is too loose a guard — a retrain
+// could silently regress to e.g. 0.638 and still pass. Pin an absolute floor so
+// a real regression fails CI. Raise this (never lower) when a better model
+// ships.
+const SHIPPED_GOLDEN_F1_FLOOR = 0.66;
+
 describe('shipped default gate model', () => {
   const model = TrainedDecisionClassifier.fromJson(
     JSON.parse(readFileSync(MODEL_PATH, 'utf8')),
@@ -45,5 +52,14 @@ describe('shipped default gate model', () => {
     expect(hy.precision).toBeGreaterThanOrEqual(h.precision);
     // The hybrid recall covers everything the heuristic caught, plus more.
     expect(hy.recall).toBeGreaterThan(h.recall);
+  });
+
+  it('holds the absolute golden F1 ratchet (catches a silent regression)', () => {
+    const hybrid = new HybridDecisionClassifier(
+      new HeuristicDecisionClassifier(),
+      model,
+    );
+    const hy = evaluateClassifierOnGolden(hybrid);
+    expect(hy.f1).toBeGreaterThanOrEqual(SHIPPED_GOLDEN_F1_FLOOR);
   });
 });


### PR DESCRIPTION
Code-memory robustness — audit wave 4 (MEDIUM cluster from `audit_2026-07-07`).

| Fix | Risk before | After |
|---|---|---|
| **Sweep blast-radius guard** | CLI run outside repo root / mixed anchor formats → every `readFile` misses → **tenant-wide mass retract** | `buildAnchorVerdicts` throws `SweepBlastRadiusError` when > 50% of ≥10 anchors would invalidate; `validate-anchors --force` overrides for a real removal |
| **Resolver extension gate** | a `.py`/`.go` file parsed as TS → garbage symbol spans poison anchors | `listSymbols` returns `[]` for non-TS/JS (`isTsJsSource`); docstring's promise now enforced |
| **Reanchor threshold** | any 4-char stem match re-anchored (`get_user`→`get_post`) | require 60% majority overlap (4-char floor) **and** decline ties (ambiguous) |
| **Golden model ratchet** | "beats heuristic" (0.621) let a retrain silently regress to ~0.638 and pass CI | absolute F1 floor 0.66 pinned on the shipped hybrid (current 0.6667) |
| **Sink timeout** | hung server stalls a CI capture hook for hours | per-request `AbortController`, default 15s → `timed out` error |

## Tests
+8 unit: guard trips / small-set exempt / override honored, weak-prefix + tie decline, `.py` gate (same text under `.ts` still parses), sink timeout, golden ratchet. 910 unit / code-memory anchor e2e green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)