### PR TITLE
fix(ops/ci/docs): shutdown ordering, snapshot dedup, strict lint:ci, docker-smoke 3.1.5, MCP doc counts (audit wave 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,10 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-workspace
 
       - name: Lint
-        run: pnpm lint
+        # lint:ci has no --fix and fails on any warning, so a fixable violation
+        # gates the build instead of being silently auto-fixed in CI (where the
+        # fix is thrown away — the working tree isn't committed back).
+        run: pnpm lint:ci
 
       # Typecheck the WHOLE project, tests included. `nest build` only
       # compiles src/ (tsconfig.json excludes test/), so before this step a
@@ -228,7 +231,7 @@ jobs:
         run: |
           docker network create brain-ci
           docker run -d --name surreal --network brain-ci \
-            surrealdb/surrealdb:v2.2.8 \
+            surrealdb/surrealdb:v3.1.5 \
             start --user=root --pass=root --bind=0.0.0.0:8000 memory
           sleep 5
           docker run -d --name brain --network brain-ci -p 3030:3000 \

--- a/brain-landing/content/docs/en/mcp/tools.mdx
+++ b/brain-landing/content/docs/en/mcp/tools.mdx
@@ -1,6 +1,6 @@
 # MCP tools reference
 
-Six tools registered against `McpServer({ name: 'inite-brain-service' })`. Four are always visible; two require `brain:write`. Sensitive PII values require an additional `brain:read_pii` scope.
+The server registers **25 tools + 2 resources** against `McpServer({ name: 'inite-brain-service' })`, gated by scope: 18 read (`brain:read`), 6 more with `brain:write`, and 1 with `brain:admin`. Sensitive PII values require an additional `brain:read_pii` scope. This page documents the most commonly used tools; the full surface (communities, procedural memory, source reputation, code memory) is enumerated in the repo's `docs/roadmap/mcp-and-memory.md`.
 
 ## search_knowledge
 

--- a/brain-landing/content/docs/ru/mcp/tools.mdx
+++ b/brain-landing/content/docs/ru/mcp/tools.mdx
@@ -1,6 +1,6 @@
 # Справочник MCP-инструментов
 
-Шесть инструментов, зарегистрированных на `McpServer({ name: 'inite-brain-service' })`. Четыре видны всегда; двум нужен `brain:write`. Чувствительным PII-значениям нужен дополнительный scope `brain:read_pii`.
+Сервер регистрирует **25 инструментов + 2 ресурса** на `McpServer({ name: 'inite-brain-service' })`, с гейтингом по scope: 18 на чтение (`brain:read`), ещё 6 с `brain:write` и 1 с `brain:admin`. Чувствительным PII-значениям нужен дополнительный scope `brain:read_pii`. На этой странице описаны самые используемые инструменты; полный список (communities, процедурная память, репутация источников, code memory) перечислен в `docs/roadmap/mcp-and-memory.md` репозитория.
 
 ## search_knowledge
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -126,7 +126,7 @@ Add inite-brain-service to Knowledge & Memory
 
 ```
 Adds inite-brain-service — open-source (AGPL-3.0) bitemporal memory layer
-for LLM agents. MCP server (Streamable HTTP) exposing 21 tools across
+for LLM agents. MCP server (Streamable HTTP) exposing 25 tools across
 read/write/admin scopes.
 
 Distinct from existing entries: bitemporal (valid-time + transaction-
@@ -202,7 +202,7 @@ URL: https://mcpservers.org/submit
 Section: **Claude Code & Model Context Protocol (MCP)**.
 
 ```
-- [inite-brain-service](https://github.com/inite-ai/inite-brain-service) — open-source memory layer for Claude (and any other MCP client). Bitemporal knowledge graph, 21 tools, three memory tiers (facts/episodes/procedural), conflict resolution, GDPR forget. AGPL-3.0.
+- [inite-brain-service](https://github.com/inite-ai/inite-brain-service) — open-source memory layer for Claude (and any other MCP client). Bitemporal knowledge graph, 25 tools, three memory tiers (facts/episodes/procedural), conflict resolution, GDPR forget. AGPL-3.0.
 ```
 
 Note: 165+ open PRs on this repo as of 2026-06 — maintainer is slow. File and forget.

--- a/docs/roadmap/mcp-and-memory.md
+++ b/docs/roadmap/mcp-and-memory.md
@@ -4,8 +4,8 @@
 > Phases 1–4 are all landed: `memory_diff`, `summarize_entity`,
 > `get_competing_facts`, `detect_contradiction`, procedural memory, MCP
 > resources (`brain://entity/...`), sampling, the new skills, and the
-> ClaudeMcpAgent. The live MCP surface is **21 tools** (15 read / 20 with
-> write / 21 with admin) + 2 resources. The only genuinely-open items are:
+> ClaudeMcpAgent. The live MCP surface is **25 tools** (18 read / 24 with
+> write / 25 with admin) + 2 resources. The only genuinely-open items are:
 > the full paid LoCoMo run + published numbers (Phase 5.2), optional
 > BERTScore (5.3), and MCP resource *subscribe* (4.2, deferred to v2). Read
 > the rest as a record of what was built, not work to redo.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,test}/**/*.ts\" --fix",
+    "lint:ci": "eslint \"{src,test}/**/*.ts\" --max-warnings 0",
     "test": "jest --config ./test/jest-unit.json",
     "test:unit": "jest --config ./test/jest-unit.json",
     "test:watch": "jest --config ./test/jest-unit.json --watch",
@@ -48,7 +49,6 @@
     "test:eval:json": "pnpm build && jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=json-directory",
     "directory:fetch:wikidata": "ts-node -r tsconfig-paths/register scripts/fetch-wikidata-directory.ts",
     "test:eval:dreams": "pnpm build && DREAMS_E2E_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=dreams.real",
-    "schema:apply": "ts-node -r tsconfig-paths/register scripts/apply-schema.ts",
     "skills:build": "ts-node -T scripts/build-skill-versions.ts",
     "skills:bump": "ts-node -T scripts/bump-skill-versions.ts --staged",
     "skills:pack": "pnpm skills:build && ts-node -T scripts/package-skills.ts"

--- a/src/ai/predicate-registry.service.ts
+++ b/src/ai/predicate-registry.service.ts
@@ -77,6 +77,13 @@ export class PredicateRegistryService {
   // two cold reads don't both run the seed (which would CREATE duplicate
   // knowledge_predicate rows; no unique constraint protects against it).
   private readonly bootstrapInFlight = new Map<string, Promise<void>>();
+  // In-flight snapshot load per tenant — on a cold/expired cache a burst of
+  // concurrent requests would each run loadFresh (a full predicate SELECT +
+  // batched embeds). Dedupe so the herd shares one load and the rest await it.
+  private readonly snapshotInFlight = new Map<
+    string,
+    Promise<PredicateSnapshot>
+  >();
 
   private readonly canonicalizeThreshold: number;
 
@@ -230,9 +237,18 @@ export class PredicateRegistryService {
     if (cached && Date.now() - cached.loadedAt < SNAPSHOT_TTL_MS) {
       return cached.snapshot;
     }
-    const snapshot = await this.loadFresh(companyId);
-    this.cache.set(companyId, { snapshot, loadedAt: Date.now() });
-    return snapshot;
+    // Dedupe a thundering herd on the cold path: the first caller starts the
+    // load and registers the promise; concurrent callers await the same one.
+    const inFlight = this.snapshotInFlight.get(companyId);
+    if (inFlight) return inFlight;
+    const load = this.loadFresh(companyId)
+      .then((snapshot) => {
+        this.cache.set(companyId, { snapshot, loadedAt: Date.now() });
+        return snapshot;
+      })
+      .finally(() => this.snapshotInFlight.delete(companyId));
+    this.snapshotInFlight.set(companyId, load);
+    return load;
   }
 
   /**

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnApplicationShutdown,
+  OnModuleInit,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Surreal } from 'surrealdb';
 import { join } from 'node:path';
@@ -30,7 +35,7 @@ export {
  * physically impossible from outside `withCompany`.
  */
 @Injectable()
-export class SurrealService implements OnModuleInit, OnModuleDestroy {
+export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   private readonly logger = new Logger(SurrealService.name);
   // Two pools — admin (root) and scoped (brain_caller user).
   // Caller-facing reads route through scopedPool so PERMISSIONS clauses
@@ -226,7 +231,12 @@ export class SurrealService implements OnModuleInit, OnModuleDestroy {
     );
   }
 
-  async onModuleDestroy() {
+  // Close the pool in onApplicationShutdown (the LAST lifecycle phase), not
+  // onModuleDestroy (the FIRST). Consumers that release DB-backed state on
+  // shutdown — the worker loop's lease release (beforeApplicationShutdown),
+  // any onModuleDestroy DB touch — must find the pool still open. Closing here
+  // guarantees the pool outlives every earlier-phase shutdown hook.
+  async onApplicationShutdown() {
     await Promise.all(
       this.all.map((c) =>
         c.close().catch((e: unknown) => {

--- a/src/jobs/worker-loop.service.ts
+++ b/src/jobs/worker-loop.service.ts
@@ -3,7 +3,7 @@ import {
   Logger,
   Optional,
   OnModuleInit,
-  OnApplicationShutdown,
+  BeforeApplicationShutdown,
 } from '@nestjs/common';
 import { LeaderLeaseService } from './leader-lease.service';
 import { MetricsService } from '../metrics/metrics.service';
@@ -26,7 +26,9 @@ export type { JobContext, JobHandler } from './worker-loop.types';
  * up. Cadence/enabled flags read from the environment.
  */
 @Injectable()
-export class WorkerLoopService implements OnModuleInit, OnApplicationShutdown {
+export class WorkerLoopService
+  implements OnModuleInit, BeforeApplicationShutdown
+{
   private readonly logger = new Logger(WorkerLoopService.name);
   private readonly handlers = new Map<JobType, RegisteredHandler>();
   private readonly enabled =
@@ -111,7 +113,12 @@ export class WorkerLoopService implements OnModuleInit, OnApplicationShutdown {
     this.poller.startDecay();
   }
 
-  async onApplicationShutdown(): Promise<void> {
+  // beforeApplicationShutdown (phase 2), NOT onApplicationShutdown (phase 3):
+  // the lease release below is a DB write, and SurrealService closes the pool
+  // in onApplicationShutdown. Running here guarantees the pool is still open
+  // when we release — otherwise the lease zombied for a full TTL on every
+  // deploy and in-flight jobs were orphaned.
+  async beforeApplicationShutdown(): Promise<void> {
     if (this.leaseTimer) clearTimeout(this.leaseTimer);
     this.poller.stopDecay();
     this.abortController.abort();

--- a/test/worker-loop.unit-spec.ts
+++ b/test/worker-loop.unit-spec.ts
@@ -102,6 +102,28 @@ describe('WorkerLoopService.register', () => {
   });
 });
 
+describe('WorkerLoopService shutdown ordering', () => {
+  // The lease release is a DB write; SurrealService closes the pool in
+  // onApplicationShutdown (phase 3). The worker MUST release in
+  // beforeApplicationShutdown (phase 2) so the pool is still open — a rename
+  // back to onApplicationShutdown reintroduces the zombie-lease-on-deploy bug.
+  it('releases in beforeApplicationShutdown, not onApplicationShutdown', () => {
+    const svc = new WorkerLoopService(undefined as never);
+    expect(typeof (svc as unknown as Record<string, unknown>)
+      .beforeApplicationShutdown).toBe('function');
+    expect((svc as unknown as Record<string, unknown>)
+      .onApplicationShutdown).toBeUndefined();
+  });
+
+  it('beforeApplicationShutdown stops the poller and resolves', async () => {
+    const stopDecay = jest.fn();
+    const poller = { stopDecay, startDecay: jest.fn(), hasClaim: false };
+    const svc = new WorkerLoopService(poller as never);
+    await expect(svc.beforeApplicationShutdown()).resolves.toBeUndefined();
+    expect(stopDecay).toHaveBeenCalled();
+  });
+});
+
 describe('JobDispatcherService.dispatch', () => {
   it('routes a successful handler result to complete()', async () => {
     const claim = makeJobClaim();


### PR DESCRIPTION
Audit wave 5 — the CI/ops/docs cluster from `audit_2026-07-07`.

## Ops / reliability
- **Shutdown ordering** — `SurrealService` closed the pool in `onModuleDestroy` (Nest phase 1) while `WorkerLoopService` released its lease in `onApplicationShutdown` (phase 3). The release is a DB write → hit a **closed pool** → the worker lease zombied for a full TTL on every deploy, orphaning in-flight jobs. Fix: pool close → `onApplicationShutdown` (last phase); worker release → `beforeApplicationShutdown` (phase 2), so the pool is still open. `job-worker-pool` (thread terminate, no DB) is unaffected.
- **Snapshot herd dedup** — `getSnapshot` now dedupes concurrent cold-cache loads via a per-tenant in-flight promise (mirrors the proven `bootstrapInFlight`); a burst no longer fires N parallel `loadFresh` (SELECT + batched embeds).

## CI / config
- **`lint:ci`** — new script, no `--fix`, `--max-warnings 0`, wired into CI. `pnpm lint` auto-fixed in CI and discarded the fix (tree isn't committed back), so a fixable violation never gated the build.
- **docker-smoke** — SurrealDB `v2.2.8` → `v3.1.5` to match prod.
- Removed **dead `schema:apply`** script (pointed at a non-existent `scripts/apply-schema.ts`).

## Docs
- MCP surface corrected to **25 tools + 2 resources** (18 read / 24 +write / 25 +admin) in `distribution.md` + `mcp-and-memory.md`; `tools.mdx` (en/ru) no longer claims "six tools" — states the real count and that it documents the common subset.

## Tests
+2 worker-loop shutdown-contract unit (release is `beforeApplicationShutdown`, not `onApplicationShutdown`). 912 unit / strict `lint:ci` / e2e green locally.

**Deferred:** the e2e parallel-worker-vs-migration-queue flake — needs a repro; not touched blind to avoid masking or slowing CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)