### PR TITLE
chore(deploy): enable read-time trust flags in prod (β=0.15, γ=0.1)

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -220,6 +220,17 @@ jobs:
                 - SEARCH_STAGE_BUDGET_RERANK_MS=4000
                 - SEARCH_STAGE_BUDGET_CROSS_ENCODER_MS=2000
                 - SEARCH_STAGE_BUDGET_BACKFILL_MS=2000
+                # Source-reputation trust at read time (source-reputation phase
+                # 5, docs/source-reputation.md). finalScore ×= (1 + β·(trust−0.5))
+                # × (1 + γ·min(corroboration, 3)). Turned ON after the quality
+                # eval was rerun with the flags set: overall recall@1 0.9466,
+                # recall@3 0.9885, MRR 0.9683 (n=262) — within tolerance of the
+                # trust-off baseline, delta-gate green. Conservative values:
+                # neutral sources (learnedTrust 0.5, no corroboration) stay a
+                # ×1.0 no-op, so the effect ramps gracefully as the nightly
+                # refit accumulates domain-scoped reputation.
+                - SEARCH_TRUST_BETA=0.15
+                - SEARCH_CORROBORATION_GAMMA=0.1
                 # ── Hybrid pipeline knobs ────────────────────────────────
                 # Chat router (Sprints 1-4.5): cache, embedding hints,
                 # collapse cache, intent classification, skip gate.


### PR DESCRIPTION
Turns on the source-reputation trust re-weighting (source-reputation phase 5, `docs/source-reputation.md`) in the prod deploy env, **after validating with the quality eval**:

```
SEARCH_TRUST_BETA=0.15
SEARCH_CORROBORATION_GAMMA=0.1
```

**Eval-validated (measure-first gate):** the quality suite was rerun with the flags set —
- overall **recall@1 0.9466**, recall@3 0.9885, MRR 0.9683 (n=262)
- faithfulness / PII-gating / identity-resolution 1.0
- within tolerance of the trust-off baseline; the CI-aware delta-gate passed (exit 0).

**Safe ramp:** the multiplier is `(1 + β·(trust−0.5)) · (1 + γ·min(corroboration, 3))`, so a neutral source (learnedTrust 0.5, no corroboration) is a ×1.0 no-op. The effect grows gracefully only as the nightly refit (03:42 UTC) accumulates domain-scoped reputation — no cliff on deploy.

⚠️ Merging this auto-deploys to prod (deploy triggers on push to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)