### PR TITLE
chore(deploy): enable the document pipeline in prod

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -231,6 +231,26 @@ jobs:
                 # refit accumulates domain-scoped reputation.
                 - SEARCH_TRUST_BETA=0.15
                 - SEARCH_CORROBORATION_GAMMA=0.1
+                # ── Document pipeline (Source → Indexer → Candidates → Brain,
+                # docs/document-pipeline.md) ─────────────────────────────
+                # Master switch: POST /v1/ingest/document + the /v1/documents/*
+                # surface + the MCP ingest_document tool. Additive endpoints.
+                - DOCUMENT_INGEST_ENABLED=1
+                # Dedicated per-pack indexer runs + relevance router + the
+                # async (queue-driven) fan-out. LLM fan-out is capped by
+                # MAX_DEDICATED_INDEXERS_PER_DOC (default 8).
+                - DOCUMENT_MULTI_INDEXER_ENABLED=1
+                # Route live mention ingestion through the pipeline (response
+                # contract preserved). Safe to enable now that the indexer_run
+                # reopen/reaper (#142) makes a crashed run recoverable.
+                - INGEST_MENTION_VIA_DOCUMENT=1
+                # Backfill stored documents with a pack's vocabulary on
+                # install/upgrade (bounded by REINDEX_MAX_DOCS_PER_RUN=500).
+                - REINDEX_ON_PACK_INSTALL=1
+                # Deliberately NOT set (default off): DOCUMENT_ALLOW_UNGROUNDED_
+                # EXTERNAL (security opt-in — lets external indexers stage
+                # unverifiable spans) and SEARCH_CROSS_ENCODER_LOCAL (prod uses
+                # the LLM reranker; no Cohere/cross-encoder configured).
                 # ── Hybrid pipeline knobs ────────────────────────────────
                 # Chat router (Sprints 1-4.5): cache, embedding hints,
                 # collapse cache, intent classification, skip gate.


### PR DESCRIPTION
Follow-up to #142. Enables the Source → Indexer → Candidates → Brain pipeline in the prod deploy env now that its safety blockers shipped:

- `DOCUMENT_INGEST_ENABLED=1` — new write endpoints + MCP `ingest_document`
- `DOCUMENT_MULTI_INDEXER_ENABLED=1` — dedicated packs + async fan-out (LLM fan-out capped at `MAX_DEDICATED_INDEXERS_PER_DOC=8`)
- `INGEST_MENTION_VIA_DOCUMENT=1` — routes live mention traffic through the pipeline; safe now that a crashed `indexer_run` is recoverable (reopen on retry + nightly reaper) instead of wedging a document
- `REINDEX_ON_PACK_INSTALL=1` — backfill stored docs on pack install/upgrade (bounded by `REINDEX_MAX_DOCS_PER_RUN=500`)

Left off by design: `DOCUMENT_ALLOW_UNGROUNDED_EXTERNAL` (security opt-in) and `SEARCH_CROSS_ENCODER_LOCAL` (prod uses the LLM reranker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)