### PR TITLE
feat(abac): per-key policy sets — action gating + row-level read filtering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,8 @@ SEARCH_PPR_AUTO_THRESHOLD=0
 # loaded from this env var as JSON. Will be replaced by inite-auth-service
 # integration in 0.2.0.
 # Example: BRAIN_API_KEYS='[{"keyHash":"sha256:...","companyId":"co_123","scopes":["brain:read","brain:write"]}]'
+# Optional per-entry `"policies": ["set-name", ...]` attaches ABAC policy
+# sets (see the ABAC section below) to the key when ABAC_ENABLED=1.
 BRAIN_API_KEYS=[]
 
 # Service-to-service JWT verification.
@@ -289,6 +291,28 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 #REINDEX_MAX_DOCS_PER_RUN=500
 #MAX_DEDICATED_INDEXERS_PER_DOC=8
 #INDEXER_RUN_STALE_MINUTES=30
+
+# ── ABAC: per-key policy sets (migration 0056) ───────────────────────────
+# Master switch. Off (default) = the policy resolver never runs and every
+# surface behaves byte-identically to pre-ABAC. On, keys that reference
+# policy sets (BRAIN_API_KEYS entry `"policies": [...]`, JWT `policy`
+# claim, or POST /v1/admin/policy-sets/:name/attachments) get action-level
+# gating (REST routes + MCP tools) and row-level read filtering. Keys with
+# no policies attached stay unchanged even when this is on.
+#ABAC_ENABLED=0
+# Emergency demote-all: treat every enforce-mode set as report_only
+# (decisions logged, nothing blocked). Rollback lever for a bad policy —
+# flip on, restart pods, fix the set, flip off.
+#ABAC_FORCE_REPORT_ONLY=0
+# Per-tenant policy snapshot cache. CRUD invalidates in-process; other
+# instances converge within the TTL. Cap = max tenants held in the LRU.
+#POLICY_CACHE_TTL_MS=60000
+#POLICY_CACHE_CAP=500
+# policy_decision stream: enforce-mode allow rows are sampled at this rate
+# (denies + report_only divergences are always written); rows are pruned
+# after the retention window.
+#POLICY_DECISION_SAMPLE_RATE=0.01
+#POLICY_DECISION_RETENTION_DAYS=30
 
 # ── Observability ────────────────────────────────────────────────────────
 # Enable the OpenTelemetry SDK + GenAI SemConv attributes on every LLM

--- a/docs/abac.md
+++ b/docs/abac.md
@@ -1,0 +1,127 @@
+# ABAC — attribute-based access control for API keys
+
+Scopes answer "may this key search at all"; they cannot answer "may this key
+see facts that came from HR documents". ABAC adds named **policy sets** a
+tenant attaches to individual API keys. A set carries rules of two kinds:
+
+- **action rules** gate which REST endpoints and MCP tools the key can call,
+  by name (`search_knowledge`, `record_fact`, `rest.documents.get`, …) or via
+  the macros `@readonly` / `@write` / `@all`;
+- **source rules** gate which *rows* (facts, and edges via their `kind`) the
+  key can read, by attribute match on the fact's provenance.
+
+Everything is inert unless `ABAC_ENABLED=1` **and** the key references at
+least one set — a tenant that never creates a policy runs byte-identical to
+pre-ABAC, enforced by a golden e2e.
+
+## The policy document
+
+```jsonc
+{
+  "name": "support-reader",
+  "description": "support agents: read-only, support vertical only, no PII",
+  "posture": { "actions": "deny", "reads": "deny" },   // verdict when nothing matches
+  "mode": "report_only",                                // report_only | enforce | disabled
+  "rules": [
+    { "id": "ro",          "effect": "allow", "kind": "action", "actions": ["@readonly"] },
+    { "id": "support-only","effect": "allow", "kind": "source",
+      "match": [ { "attr": "source.vertical", "op": "eq", "value": "support" } ] },
+    { "id": "no-pii",      "effect": "deny",  "kind": "source",
+      "match": [ { "attr": "piiClass", "op": "in", "value": ["identifier", "sensitive"] } ] }
+  ]
+}
+```
+
+Evaluation is **deny-overrides** and order-independent:
+`explicit deny > explicit allow > default posture`, separately for the action
+and read domains. Conditions inside one rule AND together; list values OR. An
+absent attribute never matches a value-comparing condition (a rule on
+`source.meta.data_class` says nothing about facts without meta); only
+`not_exists` matches absence.
+
+Multiple sets on one key combine **most-restrictive**: the final verdict is
+allow only if every enforce-mode set allows. `report_only` sets are evaluated
+and logged (`would_deny`) but never block — that's the rollout mode.
+
+### Attributes source rules can match
+
+| Attribute | Ops | Notes |
+|---|---|---|
+| `predicate` | eq, in, prefix | tenant predicate registry ids |
+| `piiClass` | eq, in | from the predicate registry (`none/identifier/behavioral/text/sensitive`) |
+| `source.vertical`, `source.recorder` | eq, in | who wrote the fact |
+| `source.documentId`, `source.originKey` | eq, in (+prefix on originKey) | document lineage |
+| `source.meta.<key>` | eq, in, exists, not_exists | operator metadata projected from documents (wave 2) |
+| `trust.authority`, `trust.declaredTrust`, `trust.learnedTrust` | gte, gt, lte, lt | write-time trust snapshot (0..1) — **numeric thresholds, not just equality** |
+| `corroboration.count` | gte, gt, lte, lt | distinct confirming origins |
+| `provenance.purged` | eq | document text has been erased |
+| `userId` | eq, in, exists, not_exists | per-user memory scope (migration 0055) |
+
+The existing `requiresScope` PII gate always runs first and is never weakened
+by a policy — ABAC can only narrow further.
+
+### vs. Zep's ABAC (July 2026)
+
+| Capability | Zep | brain |
+|---|---|---|
+| Action-level allow/deny per key | ✓ | ✓ (REST + MCP, one namespace) |
+| Metadata read filtering | equality on projected episode metadata | equality + prefix + **numeric trust thresholds** + corroboration + provenance-purged + piiClass |
+| Default-deny / default-allow | per key | per set, per domain (actions/reads) |
+| report_only + explain | ✓ (zepctl CLI) | ✓ (API + admin UI) |
+| Simulation against real tenant data | ✗ | ✓ (wave 2: run a search as-if holding key X, per-row verdicts) |
+| Management surface | CLI + YAML (Enterprise) | REST API + policy editor UI |
+
+## Enforcement points
+
+1. **Action gate** — `ApiKeyGuard` (after the scope check): the handler's
+   `@PolicyAction('name')` (fallback: auto-name `"<METHOD> <path>"`, so
+   default-deny has no unnamed holes) is evaluated against the key's sets;
+   an enforced deny is `403 policy_denied`. The MCP transport route is
+   exempt — instead `McpService.buildServer` drops enforce-denied tools from
+   registration (they vanish from `tools/list`) and wraps the rest with
+   per-call decision telemetry.
+2. **Row gate** — `makeRowPolicyFilter` (src/policy/row-filter.ts) applied on
+   every read surface: search fusion + edge expansion + backfill,
+   `graph_retrieve`, competing facts, entity profile/timeline/connections
+   (edges evaluate with `predicate = kind`), code-memory recall. The filter
+   reads the request's `PolicyContext` from AsyncLocalStorage (stamped by the
+   guard) — no signature threading, MCP and REST share the path. Search legs
+   already project `source`/`trustSnapshot`/`corroboration`, so evaluation
+   adds no queries; compiled matchers keep the whole-request cost well under
+   a millisecond (see `brain_policy_eval_seconds`).
+
+Storage is per-tenant (migration 0056): `access_policy` (documents, zod-caps
+64 rules / 32 KB), `policy_binding` (subject → names), `policy_decision`
+(observability stream; action decisions per call, row decisions as
+per-request aggregates; allows sampled at `POLICY_DECISION_SAMPLE_RATE`).
+Resolution is cached per tenant (`POLICY_CACHE_TTL_MS`, default 60 s) — one
+query per tenant per TTL, zero per request.
+
+## Rollout runbook
+
+1. Migrate (0056 applies lazily like every migration) and set
+   `ABAC_ENABLED=1`. Nothing changes yet — no key references a set.
+2. Create a set from a template with `"mode": "report_only"` and attach it to
+   one key (`POST /v1/admin/policy-sets/:name/attachments`).
+3. Watch `brain_policy_decisions_total{decision="would_deny"}` and the
+   `policy_decision` rows. Investigate every divergence with
+   `POST /v1/admin/policy-sets/explain`.
+4. Clean for a comfortable window → flip the set's `mode` to `enforce` (PUT).
+5. Rollback levers, safest first: set `mode` back to `report_only` (PUT, ≤60 s
+   to converge) → detach the key → `ABAC_FORCE_REPORT_ONLY=1` + restart
+   (demotes every set fleet-wide) → `ABAC_ENABLED=0` + restart.
+
+**Fail-closed:** a key referencing a set name that doesn't resolve gets a
+synthetic enforce/deny-all set, a warn log, and
+`brain_policy_resolution_errors_total`. Attach-time validation makes this
+unreachable through the API — it exists for hand-written JWT claims and
+deleted-set races. Alert on the metric.
+
+## Metrics
+
+| Metric | Meaning |
+|---|---|
+| `brain_policy_decisions_total{decision,kind,mode}` | allow / deny / would_deny, by action-vs-row and set mode. Row decisions count requests, not facts. |
+| `brain_policy_eval_seconds` | per-request row-evaluation latency (histogram, buckets from 50 µs). |
+| `brain_policy_resolution_errors_total` | fail-closed events — non-zero pages an operator. |
+| `brain_policy_sets_active` | enabled sets across tenants (nightly gauge). |

--- a/docs/api.md
+++ b/docs/api.md
@@ -104,3 +104,31 @@ a quiet stale field.
 
 Keys are stored as `sha256:<hex>` — see [Getting started](getting-started.md#seed-an-apikey)
 for the seeding flow.
+
+## ABAC policy sets
+
+Scopes are coarse (any `brain:read` key reads the whole tenant graph); [ABAC
+policy sets](abac.md) narrow individual keys. Behind `ABAC_ENABLED` (default
+off). All endpoints require `brain:admin`; wire contracts live in
+`src/contracts/admin/policies.schema.ts`.
+
+| Method + path | Purpose |
+|---|---|
+| `GET /v1/admin/policy-sets` | List sets with attachments. |
+| `POST /v1/admin/policy-sets` | Create from a policy document (zod-validated: ≤64 rules, ≤32 KB). |
+| `GET /v1/admin/policy-sets/:name` | Fetch one. |
+| `PUT /v1/admin/policy-sets/:name` | Whole-document replace; body carries the loaded `version`, stale → `409 {error: 'version_conflict', current}`. Names are immutable. |
+| `DELETE /v1/admin/policy-sets/:name` | Delete; `409 policy_attached` while any key references it. |
+| `GET /v1/admin/policy-sets/bindings/all` | Every subject → set-names binding. |
+| `POST /v1/admin/policy-sets/:name/attachments` | `{attach: [subject], detach: [subject]}`; subjects are `key:<keyHash>` (static keys) or `jwt:<sub>`. Validates the set exists — this is what keeps the resolver's fail-closed branch unreachable. |
+| `POST /v1/admin/policy-sets/explain` | `{policyNames, action?, factId?}` → per-rule decision traces (which condition matched, expected vs actual). |
+
+A key acquires policies three ways, unioned and capped at 8: a
+`policy_binding` row (attachments above), a `"policies": [...]` field on its
+`BRAIN_API_KEYS` entry, or a `policy` claim (array or space-delimited string)
+in its JWT. A referenced name that doesn't resolve **fails closed** — the key
+gets a synthetic enforce/deny-all set and
+`brain_policy_resolution_errors_total` increments.
+
+Denied REST calls answer `403 {error: 'policy_denied', action, policySet,
+ruleId}`. Enforce-denied MCP tools disappear from `tools/list` entirely.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -56,6 +56,11 @@ boot validation, graceful shutdown, test commands.
 | `REINDEX_MAX_DOCS_PER_RUN` | `500` | Backfill batch budget per `reindex_documents` job (batches self-chain). |
 | `MAX_DEDICATED_INDEXERS_PER_DOC` | `8` | Upper bound on dedicated indexers a single document routes to (LLM fan-out = chunks × packs × sc-passes). Router keeps the most relevant; the drop is logged. |
 | `INDEXER_RUN_STALE_MINUTES` | `30` | How long an `indexer_run` may sit `running` before the nightly sweep reaps it as crashed (unblocking a wedged commit). Must exceed the job lease (600s) + longest extraction. |
+| `ABAC_ENABLED` | `0` | Master switch for [per-key ABAC policies](abac.md) (migration 0056). Off = the resolver never runs, byte-identical behavior. On = keys referencing policy sets get action-level gating (REST + MCP tools) and row-level read filtering; keys without policies stay unchanged. Values outside `1/0/true/false` fail boot. |
+| `ABAC_FORCE_REPORT_ONLY` | `0` | Emergency demote-all: every enforce-mode policy set behaves as report_only (decisions logged, nothing blocked). The rollback lever for a bad policy. Same strict value set. |
+| `POLICY_CACHE_TTL_MS` / `POLICY_CACHE_CAP` | `60000` / `500` | Per-tenant compiled-policy snapshot cache. CRUD invalidates in-process; other instances converge within the TTL (document the staleness bound to tenants). Cap = tenants held in the LRU. |
+| `POLICY_DECISION_SAMPLE_RATE` | `0.01` | `policy_decision` stream sampling for enforce-mode *allows*. Denies and report_only divergences are always written. |
+| `POLICY_DECISION_RETENTION_DAYS` | `30` | Decision rows older than this are pruned lazily on flush (at most once per 6 h per tenant). |
 | `DOMAIN_PACK_TRUSTED_KEYS` | unset | Pack-install trust store: JSON object mapping `publisher` → ed25519 PEM public key. Malformed JSON fails boot (env validation) — a typo would silently empty the store and every signed pack would fail as "unknown publisher". |
 | `DOMAIN_PACK_REQUIRE_SIGNATURE` | `0` | When `1`/`true`, `POST /v1/admin/packs` rejects unsigned manifests. Values outside `1/0/true/false` fail boot — an unrecognized value would silently disable enforcement. |
 | `PACK_REGISTRY_REQUIRE_SIGNATURE` | `0` | Same policy for `POST /v1/admin/registry/packs` (publish into the global catalogue). Same strict value set. |

--- a/src/admin/admin-policies.controller.ts
+++ b/src/admin/admin-policies.controller.ts
@@ -1,0 +1,254 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  Put,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import {
+  PolicyStoreService,
+  StoredPolicySet,
+} from '../policy/policy-store.service';
+import { compilePolicySet } from '../policy/policy-compile';
+import {
+  evaluateAction,
+  evaluateRow,
+  explainAction,
+  explainRow,
+  toRowView,
+} from '../policy/policy-engine';
+import { policyFor } from '../ingest/conflict-resolver';
+import { CompiledPolicySet, PolicyContext } from '../policy/policy.types';
+import type {
+  PolicyBindingsResponse,
+  PolicyExplainResponse,
+  PolicySetDeleteResponse,
+  PolicySetResponse,
+  PolicySetsListResponse,
+  PolicySetWire,
+} from '../contracts/admin/policies.schema';
+
+/**
+ * ABAC policy-set CRUD + attachments + decision explain. The rule
+ * documents themselves are validated by PolicyDocumentSchema inside
+ * PolicyStoreService (zod, strict caps) — this controller owns HTTP
+ * shape only. Tenancy comes from the token (`req.brainAuth.companyId`),
+ * never a param, per house convention.
+ */
+@Controller('v1/admin/policy-sets')
+@UseGuards(ApiKeyGuard)
+export class AdminPoliciesController {
+  constructor(private readonly store: PolicyStoreService) {}
+
+  @Get()
+  @RequireScopes('brain:admin')
+  async list(@Req() req: AuthenticatedRequest): Promise<PolicySetsListResponse> {
+    const sets = await this.store.list(req.brainAuth.companyId);
+    return { policySets: sets.map(toWire) } satisfies PolicySetsListResponse;
+  }
+
+  @Post()
+  @RequireScopes('brain:admin')
+  async create(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: unknown,
+  ): Promise<PolicySetResponse> {
+    const created = await this.store.create(
+      req.brainAuth.companyId,
+      body,
+      actorOf(req),
+    );
+    return { policySet: toWire(created) } satisfies PolicySetResponse;
+  }
+
+  @Get(':name')
+  @RequireScopes('brain:admin')
+  async get(
+    @Req() req: AuthenticatedRequest,
+    @Param('name') name: string,
+  ): Promise<PolicySetResponse> {
+    const found = await this.store.get(req.brainAuth.companyId, name);
+    return { policySet: toWire(found) } satisfies PolicySetResponse;
+  }
+
+  /**
+   * Whole-document replace with optimistic concurrency: the body is the
+   * policy document plus the `version` the client loaded. A stale
+   * version 409s with the current copy so the UI can offer a reload.
+   */
+  @Put(':name')
+  @RequireScopes('brain:admin')
+  async update(
+    @Req() req: AuthenticatedRequest,
+    @Param('name') name: string,
+    @Body() body: { version?: unknown } & Record<string, unknown>,
+  ): Promise<PolicySetResponse> {
+    const version = Number(body?.version);
+    if (!Number.isInteger(version) || version < 1) {
+      throw new BadRequestException('version (int ≥ 1) is required');
+    }
+    const { version: _v, ...document } = body;
+    const updated = await this.store.update(req.brainAuth.companyId, name, {
+      body: document,
+      expectedVersion: version,
+      updatedBy: actorOf(req),
+    });
+    return { policySet: toWire(updated) } satisfies PolicySetResponse;
+  }
+
+  @Delete(':name')
+  @RequireScopes('brain:admin')
+  async remove(
+    @Req() req: AuthenticatedRequest,
+    @Param('name') name: string,
+  ): Promise<PolicySetDeleteResponse> {
+    await this.store.remove(req.brainAuth.companyId, name);
+    return { deleted: name } satisfies PolicySetDeleteResponse;
+  }
+
+  @Get('bindings/all')
+  @RequireScopes('brain:admin')
+  async bindings(
+    @Req() req: AuthenticatedRequest,
+  ): Promise<PolicyBindingsResponse> {
+    const bindings = await this.store.listBindings(req.brainAuth.companyId);
+    return { bindings } satisfies PolicyBindingsResponse;
+  }
+
+  @Post(':name/attachments')
+  @RequireScopes('brain:admin')
+  async attachments(
+    @Req() req: AuthenticatedRequest,
+    @Param('name') name: string,
+    @Body() body: { attach?: string[]; detach?: string[] },
+  ): Promise<PolicySetResponse> {
+    const attach = body?.attach ?? [];
+    const detach = body?.detach ?? [];
+    if (!Array.isArray(attach) || !Array.isArray(detach)) {
+      throw new BadRequestException('attach/detach must be arrays of subjects');
+    }
+    if (attach.length === 0 && detach.length === 0) {
+      throw new BadRequestException('Nothing to do: attach and detach are empty');
+    }
+    const updated = await this.store.updateAttachments(
+      req.brainAuth.companyId,
+      name,
+      { attach, detach },
+    );
+    return { policySet: toWire(updated) } satisfies PolicySetResponse;
+  }
+
+  /**
+   * Single-decision explain (Zep's `zepctl api-key explain`, but with
+   * per-rule field traces). Evaluates the named sets as one context —
+   * `action` explains an action verdict, `factId` explains a row
+   * verdict against a real stored fact. Either or both.
+   */
+  @Post('explain')
+  @RequireScopes('brain:admin')
+  async explain(
+    @Req() req: AuthenticatedRequest,
+    @Body()
+    body: { policyNames?: string[]; action?: string; factId?: string },
+  ): Promise<PolicyExplainResponse> {
+    const companyId = req.brainAuth.companyId;
+    const names = body?.policyNames ?? [];
+    if (!Array.isArray(names) || names.length === 0) {
+      throw new BadRequestException('policyNames (non-empty array) is required');
+    }
+    if (!body.action && !body.factId) {
+      throw new BadRequestException('Provide action and/or factId to explain');
+    }
+
+    const stored = await this.store.list(companyId);
+    const byName = new Map(stored.map((s) => [s.name, s]));
+    const sets: CompiledPolicySet[] = [];
+    for (const name of names) {
+      const s = byName.get(String(name));
+      if (!s) throw new NotFoundException(`Policy set '${name}' not found`);
+      const compiled = compilePolicySet(s.document);
+      if (compiled) sets.push(compiled);
+    }
+    if (sets.length === 0) {
+      throw new BadRequestException('All referenced policy sets are disabled');
+    }
+    const ctx: PolicyContext = {
+      companyId,
+      keyHash: 'explain',
+      sets,
+      forceReportOnly: false,
+      resolutionError: false,
+    };
+
+    const out: PolicyExplainResponse = {};
+    if (body.action) {
+      const action = String(body.action);
+      out.action = {
+        name: action,
+        decision: evaluateAction(ctx, action).decision,
+        traces: explainAction(ctx, action),
+      };
+    }
+    if (body.factId) {
+      const row = await this.store.loadFactForExplain(
+        companyId,
+        String(body.factId),
+      );
+      const view = toRowView(row, (p) => policyFor(p).piiClass);
+      out.row = {
+        factId: String(body.factId),
+        decision: evaluateRow(ctx, view).decision,
+        traces: explainRow(ctx, view),
+        view: {
+          predicate: view.predicate,
+          piiClass: view.piiClass,
+          source: (view.source as Record<string, unknown>) ?? null,
+          trustSnapshot:
+            (view.trustSnapshot as Record<string, unknown>) ?? null,
+          corroboration:
+            (view.corroboration as Record<string, unknown>) ?? null,
+          userId: view.userId ?? null,
+        },
+      };
+    }
+    return out;
+  }
+
+}
+
+function actorOf(req: AuthenticatedRequest): string {
+  return req.brainAuth.keyHash.slice(0, 20);
+}
+
+function toWire(s: StoredPolicySet): PolicySetWire {
+  return {
+    name: s.name,
+    description: s.document.description ?? '',
+    posture: s.document.posture,
+    mode: s.mode,
+    activeFrom: s.document.activeFrom ?? null,
+    activeUntil: s.document.activeUntil ?? null,
+    rules: s.document.rules.map((r) => ({
+      id: r.id,
+      effect: r.effect,
+      kind: r.kind,
+      enabled: r.enabled,
+      ...(r.description !== undefined ? { description: r.description } : {}),
+      ...(r.actions !== undefined ? { actions: r.actions } : {}),
+      ...(r.match !== undefined ? { match: r.match } : {}),
+    })),
+    version: s.version,
+    createdAt: s.createdAt,
+    updatedAt: s.updatedAt,
+    updatedBy: s.updatedBy,
+    attachedSubjects: s.attachedSubjects,
+  };
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -27,6 +27,7 @@ import { OperatorActionInterceptor } from './operator-action.interceptor';
 import { ThrottlerObservabilityService } from './throttler-observability.service';
 import { ThrottlerObservabilityInterceptor } from './throttler-observability.interceptor';
 import { AdminPacksController } from './admin-packs.controller';
+import { AdminPoliciesController } from './admin-policies.controller';
 import { AdminCodeMemoryController } from './admin-code-memory.controller';
 import { AdminHnswController } from './admin-hnsw.controller';
 import { HnswMaintenanceService } from './hnsw-maintenance.service';
@@ -80,6 +81,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     AdminOpsController,
     AdminInfraController,
     AdminPacksController,
+    AdminPoliciesController,
     AdminCodeMemoryController,
     AdminHnswController,
   ],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { HealthService } from './common/health.service';
 import { TenantThrottlerGuard } from './common/tenant-throttler.guard';
 import { SurrealModule } from './db/surreal.module';
 import { AuthModule } from './auth/auth.module';
+import { PolicyModule } from './policy/policy.module';
 import { AiModule } from './ai/ai.module';
 import { IngestModule } from './ingest/ingest.module';
 import { SearchModule } from './search/search.module';
@@ -78,6 +79,7 @@ import { FeedbackModule } from './feedback/feedback.module';
     CommonModule,
     SurrealModule,
     AuthModule,
+    PolicyModule,
     AiModule,
     IngestModule,
     SearchModule,

--- a/src/artifacts/artifacts.controller.ts
+++ b/src/artifacts/artifacts.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Param, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import { ArtifactsService, ArtifactType } from './artifacts.service';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 
@@ -18,6 +19,7 @@ export class ArtifactsController {
 
   @Get(':type/:entityId')
   @RequireScopes('brain:read')
+  @PolicyAction('rest.artifacts.get')
   async get(
     @Req() req: AuthenticatedRequest,
     @Param('type') type: string,
@@ -33,6 +35,7 @@ export class ArtifactsController {
 
   @Post(':type/:entityId/recompile')
   @RequireScopes('brain:write')
+  @PolicyAction('rest.artifacts.recompile')
   async recompile(
     @Req() req: AuthenticatedRequest,
     @Param('type') type: string,

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -2,12 +2,16 @@ import {
   CanActivate,
   ExecutionContext,
   Injectable,
+  Logger,
   SetMetadata,
   UnauthorizedException,
   ForbiddenException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { CredentialResolverService } from './credential-resolver.service';
+import { PolicyGateService } from '../policy/policy-gate.service';
+import { POLICY_ACTION_KEY } from '../policy/action-registry';
+import { getRequestContext } from '../common/request-context';
 import { BrainScope, AuthenticatedRequest, ApiKeyRecord } from './api-key.types';
 
 const REQUIRED_SCOPES_KEY = 'requiredScopes';
@@ -16,9 +20,12 @@ export const RequireScopes = (...scopes: BrainScope[]) =>
 
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
+  private readonly logger = new Logger(ApiKeyGuard.name);
+
   constructor(
     private readonly credentials: CredentialResolverService,
     private readonly reflector: Reflector,
+    private readonly policyGate: PolicyGateService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -46,10 +53,49 @@ export class ApiKeyGuard implements CanActivate {
       }
     }
 
+    // ABAC action gate, after the scope gate. Decorated handlers carry
+    // an action name; undecorated ones fall back to "<METHOD> <path>"
+    // so a default-deny policy has no unnamed holes. Throws 403
+    // policy_denied on an enforced deny; resolves to undefined when the
+    // key carries no policies (pre-ABAC behavior).
+    const action =
+      this.reflector.getAllAndOverride<string>(POLICY_ACTION_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]) ?? `${request.method} ${request.route?.path ?? request.url}`;
+    const policy = await this.policyGate.gate(
+      record,
+      action,
+      request.id ?? request.headers['x-request-id'],
+    );
+
+    // Stamp the context into AsyncLocalStorage so read surfaces deep in
+    // the pipeline (search fusion, graph_retrieve, competing facts,
+    // entity reads) row-filter without signature threading. The
+    // recorder closure gives the pure row-filter module a path to the
+    // decision sink + metrics without DI.
+    if (policy) {
+      const store = getRequestContext();
+      if (store) {
+        store.policy = policy;
+        store.recordPolicyRows = (summary) =>
+          this.policyGate.recordRowSummary(policy, summary);
+      } else {
+        // Deliberately loud: without the correlation middleware's ALS
+        // store the row-level gate is inactive (action gate above still
+        // enforced). This only happens on a mis-wired bootstrap — every
+        // real entrypoint mounts correlationIdMiddleware before routing.
+        this.logger.warn(
+          'Request context missing — ABAC row-level filtering inactive for this request',
+        );
+      }
+    }
+
     (request as AuthenticatedRequest).brainAuth = {
       companyId: record.companyId,
       scopes: record.scopes,
       keyHash: record.keyHash,
+      ...(policy ? { policy } : {}),
     };
     return true;
   }

--- a/src/auth/api-key.service.ts
+++ b/src/auth/api-key.service.ts
@@ -42,6 +42,23 @@ export class ApiKeyService implements OnModuleInit {
           `BRAIN_API_KEYS entry has malformed keyHash (expected 'sha256:' + 64 hex chars): companyId=${k.companyId}`,
         );
       }
+      // Optional ABAC attachment: `"policies": ["set-name", …]`. A
+      // malformed value is a boot error, not a silently ignored field —
+      // an operator who typed `"policies": "readonly"` believes the key
+      // is restricted.
+      if (k.policyNames !== undefined || (k as any).policies !== undefined) {
+        const names = (k as any).policies ?? k.policyNames;
+        if (
+          !Array.isArray(names) ||
+          names.some((n: unknown) => typeof n !== 'string')
+        ) {
+          throw new Error(
+            `BRAIN_API_KEYS entry has malformed policies (expected array of strings): companyId=${k.companyId}`,
+          );
+        }
+        k.policyNames = names;
+        delete (k as any).policies;
+      }
       this.byHash.set(normalised, k);
     }
     this.logger.log(`Loaded ${this.byHash.size} ApiKey(s)`);

--- a/src/auth/api-key.types.ts
+++ b/src/auth/api-key.types.ts
@@ -21,6 +21,12 @@ export interface ApiKeyRecord {
   scopes: BrainScope[];
   /** Optional human label. */
   name?: string;
+  /**
+   * ABAC policy set names this key carries directly — from the optional
+   * `policies` field of a BRAIN_API_KEYS entry or the `policy` claim of
+   * a JWT. Unioned with policy_binding rows by PolicyResolverService.
+   */
+  policyNames?: string[];
 }
 
 export interface AuthenticatedRequest {
@@ -28,5 +34,10 @@ export interface AuthenticatedRequest {
     companyId: string;
     scopes: BrainScope[];
     keyHash: string;
+    /**
+     * Resolved+compiled ABAC context; undefined when ABAC is disabled
+     * or the key references no policy sets (= pre-ABAC behavior).
+     */
+    policy?: import('../policy/policy.types').PolicyContext;
   };
 }

--- a/src/auth/jwks.service.ts
+++ b/src/auth/jwks.service.ts
@@ -120,12 +120,38 @@ export class JwksService implements OnModuleInit {
     );
     if (scopes.length === 0) return null;
 
+    const policyNames = extractPolicyNames(payload);
+
     return {
       keyHash: `jwt:${payload.jti ?? payload.sub}`,
       companyId,
       scopes,
+      ...(policyNames.length > 0 ? { policyNames } : {}),
     };
   }
+}
+
+// Policy set names live in the same identifier charset the CRUD layer
+// enforces; anything else in the claim is dropped here rather than
+// carried into resolution (where an out-of-charset name would fail
+// closed and brick the key on a claim-encoding quirk).
+const VALID_POLICY_NAME = /^[a-z][a-z0-9_-]{1,63}$/;
+const MAX_POLICY_NAMES = 8;
+
+/**
+ * `policy` claim → ABAC policy set names. Array of strings or a single
+ * space-delimited string, capped at MAX_POLICY_NAMES (mirrors the
+ * resolver-side MAX_SETS_PER_KEY).
+ */
+function extractPolicyNames(payload: JWTPayload): string[] {
+  const raw = (payload as Record<string, unknown>).policy;
+  let names: string[] = [];
+  if (Array.isArray(raw)) {
+    names = raw.filter((n): n is string => typeof n === 'string');
+  } else if (typeof raw === 'string') {
+    names = raw.split(' ').filter(Boolean);
+  }
+  return names.filter((n) => VALID_POLICY_NAME.test(n)).slice(0, MAX_POLICY_NAMES);
 }
 
 function extractScopes(payload: JWTPayload): string[] {

--- a/src/code-memory/code-memory-search.service.ts
+++ b/src/code-memory/code-memory-search.service.ts
@@ -3,6 +3,7 @@ import { SurrealService } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { BrainScope } from '../auth/api-key.types';
 import { CODE_MEMORY_PACK, codeMemoryKindOf } from '../ai/domain-packs';
+import { makeRowPolicyFilter } from '../policy/row-filter';
 
 export interface RecalledDecision {
   anchor: string;
@@ -57,6 +58,9 @@ export class CodeMemorySearchService {
              predicate,
              object,
              validFrom,
+             source,
+             trustSnapshot,
+             corroboration,
              entityId.externalRefs AS refs,
              vector::similarity::cosine(embedding, $embedding) AS score
            FROM knowledge_fact
@@ -70,7 +74,18 @@ export class CodeMemorySearchService {
            LIMIT $limit`,
           { embedding, prefix: this.prefix, limit },
         );
-        return ((rows as any[]) ?? []).map((r) => ({
+        // Scope + ABAC row gate — code_memory__* predicates are
+        // piiClass none today, but per-key source rules (e.g. deny a
+        // recorder) must still apply here like on every read surface.
+        const rowPolicy = makeRowPolicyFilter({
+          callerScopes: opts.scopes,
+          surface: 'recall_decisions',
+        });
+        const visible = ((rows as any[]) ?? []).filter((r) =>
+          rowPolicy.filter(r as { predicate: string }),
+        );
+        rowPolicy.finish();
+        return visible.map((r) => ({
           anchor: anchorOf(r.refs),
           kind: codeMemoryKindOf(String(r.predicate)),
           text: String(r.object),

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -121,6 +121,24 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   positiveInt(env, 'SEARCH_HNSW_EF', errors);
   positiveInt(env, 'SEARCH_HNSW_OVERFETCH', errors);
 
+  // ── ABAC policy knobs ──────────────────────────────────────────────
+  // The two booleans are security-relevant: an unrecognized value
+  // (ABAC_ENABLED=yes) silently parsing as OFF is the fail-open shape
+  // this validator exists for — same rationale as the pack-trust flags.
+  for (const name of ['ABAC_ENABLED', 'ABAC_FORCE_REPORT_ONLY']) {
+    const v = env[name];
+    if (v !== undefined && !FLAG_VALUES.has(v.trim().toLowerCase())) {
+      errors.push(
+        `${name} must be one of 1/0/true/false (got "${v}") — an ` +
+          'unrecognized value would silently disable policy enforcement.',
+      );
+    }
+  }
+  positiveInt(env, 'POLICY_CACHE_TTL_MS', errors);
+  positiveInt(env, 'POLICY_CACHE_CAP', errors);
+  positiveInt(env, 'POLICY_DECISION_RETENTION_DAYS', errors);
+  nonNegativeFloat(env, 'POLICY_DECISION_SAMPLE_RATE', errors);
+
   // ── Document ingest knobs (Source → Indexer → Candidates → Brain) ──
   positiveInt(env, 'DOC_MAX_CHARS', errors);
   positiveInt(env, 'DOC_CHUNK_TARGET_CHARS', errors);

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -122,22 +122,7 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   positiveInt(env, 'SEARCH_HNSW_OVERFETCH', errors);
 
   // ── ABAC policy knobs ──────────────────────────────────────────────
-  // The two booleans are security-relevant: an unrecognized value
-  // (ABAC_ENABLED=yes) silently parsing as OFF is the fail-open shape
-  // this validator exists for — same rationale as the pack-trust flags.
-  for (const name of ['ABAC_ENABLED', 'ABAC_FORCE_REPORT_ONLY']) {
-    const v = env[name];
-    if (v !== undefined && !FLAG_VALUES.has(v.trim().toLowerCase())) {
-      errors.push(
-        `${name} must be one of 1/0/true/false (got "${v}") — an ` +
-          'unrecognized value would silently disable policy enforcement.',
-      );
-    }
-  }
-  positiveInt(env, 'POLICY_CACHE_TTL_MS', errors);
-  positiveInt(env, 'POLICY_CACHE_CAP', errors);
-  positiveInt(env, 'POLICY_DECISION_RETENTION_DAYS', errors);
-  nonNegativeFloat(env, 'POLICY_DECISION_SAMPLE_RATE', errors);
+  validateAbacEnv(env, errors);
 
   // ── Document ingest knobs (Source → Indexer → Candidates → Brain) ──
   positiveInt(env, 'DOC_MAX_CHARS', errors);
@@ -223,6 +208,28 @@ function validateProductionGuards(
  * and a `gb`/`tb` unit lets one request pin gigabytes. Accept only a byte
  * count or a b/kb/mb size.
  */
+/**
+ * ABAC env knobs (split from validateEnv for the complexity gate).
+ * The boolean flags are security-relevant: an unrecognized value
+ * (ABAC_ENABLED=yes) silently parsing as OFF is the fail-open shape
+ * this validator exists for — same rationale as the pack-trust flags.
+ */
+function validateAbacEnv(env: NodeJS.ProcessEnv, errors: string[]): void {
+  for (const name of ['ABAC_ENABLED', 'ABAC_FORCE_REPORT_ONLY']) {
+    const v = env[name];
+    if (v !== undefined && !FLAG_VALUES.has(v.trim().toLowerCase())) {
+      errors.push(
+        `${name} must be one of 1/0/true/false (got "${v}") — an ` +
+          'unrecognized value would silently disable policy enforcement.',
+      );
+    }
+  }
+  positiveInt(env, 'POLICY_CACHE_TTL_MS', errors);
+  positiveInt(env, 'POLICY_CACHE_CAP', errors);
+  positiveInt(env, 'POLICY_DECISION_RETENTION_DAYS', errors);
+  nonNegativeFloat(env, 'POLICY_DECISION_SAMPLE_RATE', errors);
+}
+
 function validateBodySize(env: NodeJS.ProcessEnv, errors: string[]): void {
   const maxBody = env.MAX_BODY_SIZE;
   if (maxBody !== undefined && !/^\d+(\.\d+)?(b|kb|mb)?$/i.test(maxBody.trim())) {

--- a/src/common/request-context.ts
+++ b/src/common/request-context.ts
@@ -31,6 +31,23 @@ export interface RequestContext {
    * tokens. Undefined for background contexts (cron, startup).
    */
   abortSignal?: AbortSignal;
+  /**
+   * ABAC policy context for the authenticated key, stamped by
+   * ApiKeyGuard after credential + action gating. Read surfaces pick
+   * it up via getPolicyContext() so row-level filtering needs no
+   * signature threading. Undefined = no policies attached (or the
+   * request never passed the guard) → pre-ABAC behavior.
+   */
+  policy?: import('../policy/policy.types').PolicyContext;
+  /**
+   * Recorder for aggregated row-decision summaries, bound by the guard
+   * to PolicyGateService (which owns the decision sink + metrics).
+   * Kept as a closure so pure modules (policy/row-filter) never touch
+   * DI. Set iff `policy` is set.
+   */
+  recordPolicyRows?: (
+    summary: import('../policy/row-filter').RowDecisionSummary,
+  ) => void;
 }
 
 const storage = new AsyncLocalStorage<RequestContext>();
@@ -66,4 +83,18 @@ export function getRequestContext(): RequestContext | undefined {
  */
 export function getAbortSignal(): AbortSignal | undefined {
   return storage.getStore()?.abortSignal;
+}
+
+/** Active ABAC policy context, or undefined outside a policied request. */
+export function getPolicyContext():
+  | import('../policy/policy.types').PolicyContext
+  | undefined {
+  return storage.getStore()?.policy;
+}
+
+/** Row-decision recorder bound by the guard; undefined without a policy. */
+export function getPolicyRowRecorder():
+  | ((summary: import('../policy/row-filter').RowDecisionSummary) => void)
+  | undefined {
+  return storage.getStore()?.recordPolicyRows;
 }

--- a/src/communities/communities.controller.ts
+++ b/src/communities/communities.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Param, Query, Req, UseGuards } from '@nestjs/common';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 import { CommunityService } from './community.service';
 
@@ -15,6 +16,7 @@ export class CommunitiesController {
 
   @Get()
   @RequireScopes('brain:read')
+  @PolicyAction('list_communities')
   async list(
     @Req() req: AuthenticatedRequest,
     @Query('limit') limit?: string,
@@ -28,6 +30,7 @@ export class CommunitiesController {
   // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get('search')
   @RequireScopes('brain:read')
+  @PolicyAction('search_communities')
   async search(
     @Req() req: AuthenticatedRequest,
     @Query('query') query?: string,
@@ -46,6 +49,7 @@ export class CommunitiesController {
 
   @Get('for-entity/:entityId')
   @RequireScopes('brain:read')
+  @PolicyAction('find_entity_communities')
   async forEntity(
     @Req() req: AuthenticatedRequest,
     @Param('entityId') entityId: string,

--- a/src/contracts/admin/policies.schema.ts
+++ b/src/contracts/admin/policies.schema.ts
@@ -1,0 +1,138 @@
+import { z } from 'zod';
+
+/**
+ * Wire contracts for the ABAC admin surface:
+ *   /v1/admin/policy-sets (CRUD + attachments)
+ *   /v1/admin/policy/explain
+ *
+ * Mirrors PolicyDocument from src/policy/policy.types.ts, flattened —
+ * the wire PolicySet spreads the document fields next to the row
+ * metadata (version, timestamps, attachments) so the UI never nests
+ * into `.document`. Duplicated in brain-landing/lib/contracts/
+ * admin-policies.ts.
+ */
+
+export const PolicyMatchConditionSchema = z.object({
+  attr: z.string(),
+  op: z.enum([
+    'eq',
+    'in',
+    'prefix',
+    'gte',
+    'gt',
+    'lte',
+    'lt',
+    'exists',
+    'not_exists',
+  ]),
+  value: z
+    .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+    .optional(),
+});
+
+export const PolicyRuleWireSchema = z.object({
+  id: z.string(),
+  effect: z.enum(['allow', 'deny']),
+  kind: z.enum(['action', 'source']),
+  enabled: z.boolean(),
+  description: z.string().optional(),
+  actions: z.array(z.string()).optional(),
+  match: z.array(PolicyMatchConditionSchema).optional(),
+});
+
+export const PolicySetWireSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  posture: z.object({
+    actions: z.enum(['allow', 'deny']),
+    reads: z.enum(['allow', 'deny']),
+  }),
+  mode: z.enum(['report_only', 'enforce', 'disabled']),
+  activeFrom: z.string().nullish(),
+  activeUntil: z.string().nullish(),
+  rules: z.array(PolicyRuleWireSchema),
+  version: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  updatedBy: z.string(),
+  attachedSubjects: z.array(z.string()),
+});
+
+export const PolicySetsListResponseSchema = z.object({
+  policySets: z.array(PolicySetWireSchema),
+});
+
+export const PolicySetResponseSchema = z.object({
+  policySet: PolicySetWireSchema,
+});
+
+export const PolicySetDeleteResponseSchema = z.object({
+  deleted: z.string(),
+});
+
+export const PolicyBindingsResponseSchema = z.object({
+  bindings: z.array(
+    z.object({
+      subject: z.string(),
+      policyNames: z.array(z.string()),
+      updatedAt: z.string(),
+    }),
+  ),
+});
+
+const RuleTraceSchema = z.object({
+  ruleId: z.string(),
+  effect: z.enum(['allow', 'deny']),
+  matched: z.boolean(),
+  fields: z
+    .array(
+      z.object({
+        attr: z.string(),
+        op: z.string(),
+        expected: z.unknown(),
+        actual: z.unknown(),
+        matched: z.boolean(),
+      }),
+    )
+    .optional(),
+});
+
+const SetTraceSchema = z.object({
+  policySet: z.string(),
+  mode: z.enum(['report_only', 'enforce']),
+  verdict: z.enum(['allow', 'deny']),
+  decidedBy: z.string(),
+  rules: z.array(RuleTraceSchema),
+});
+
+export const PolicyExplainResponseSchema = z.object({
+  action: z
+    .object({
+      name: z.string(),
+      decision: z.enum(['allow', 'deny', 'would_deny']),
+      traces: z.array(SetTraceSchema),
+    })
+    .optional(),
+  row: z
+    .object({
+      factId: z.string(),
+      decision: z.enum(['allow', 'deny', 'would_deny']),
+      traces: z.array(SetTraceSchema),
+      view: z.object({
+        predicate: z.string(),
+        piiClass: z.string(),
+        source: z.record(z.string(), z.unknown()).nullable(),
+        trustSnapshot: z.record(z.string(), z.unknown()).nullable(),
+        corroboration: z.record(z.string(), z.unknown()).nullable(),
+        userId: z.string().nullable(),
+      }),
+    })
+    .optional(),
+});
+
+export type PolicySetWire = z.infer<typeof PolicySetWireSchema>;
+export type PolicySetsListResponse = z.infer<typeof PolicySetsListResponseSchema>;
+export type PolicySetResponse = z.infer<typeof PolicySetResponseSchema>;
+export type PolicySetDeleteResponse = z.infer<typeof PolicySetDeleteResponseSchema>;
+export type PolicyBindingsResponse = z.infer<typeof PolicyBindingsResponseSchema>;
+export type PolicyExplainResponse = z.infer<typeof PolicyExplainResponseSchema>;

--- a/src/db/migrations/0056_abac_policy.surql
+++ b/src/db/migrations/0056_abac_policy.surql
@@ -1,0 +1,71 @@
+-- 0056_abac_policy — attribute-based access control, storage side.
+--
+-- Scopes (brain:read/write/admin/read_pii) are coarse: any key holding
+-- brain:read can read the tenant's entire graph. ABAC adds named policy
+-- sets a tenant attaches to individual API keys: action rules gate which
+-- endpoints/MCP tools the key can call, source rules gate which facts it
+-- can read by attribute match (predicate, piiClass, source.*, trust
+-- thresholds, corroboration, provenance). Evaluation is deny-overrides
+-- (explicit deny > explicit allow > per-domain default posture), multiple
+-- sets on a key combine most-restrictive, report_only sets log but never
+-- block. Everything is inert unless ABAC_ENABLED=1 AND a key references
+-- at least one set.
+--
+-- Three tables, all per-tenant (the co_<companyId> database):
+--   * access_policy   — one row per policy set; the rule document is a
+--                       FLEXIBLE object validated by zod at CRUD time
+--                       (PolicyDocumentSchema), not by the schema here.
+--   * policy_binding  — subject ('key:<keyHash>') → set names. JWT-minted
+--                       keys carry names in a `policy` claim instead;
+--                       bindings cover static keys.
+--   * policy_decision — append-only decision stream for report_only
+--                       observability and the admin decisions feed.
+--                       Row-kind rows are per-request aggregates
+--                       (rowCounts), never per fact — bounded volume.
+--                       Pruned app-side after 30 days.
+
+DEFINE TABLE IF NOT EXISTS access_policy SCHEMAFULL;
+
+DEFINE FIELD IF NOT EXISTS name      ON access_policy TYPE string;
+DEFINE FIELD IF NOT EXISTS mode      ON access_policy TYPE string
+    ASSERT $value IN ['report_only', 'enforce', 'disabled'] DEFAULT 'report_only';
+DEFINE FIELD IF NOT EXISTS document  ON access_policy TYPE object FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS version   ON access_policy TYPE int DEFAULT 1;
+DEFINE FIELD IF NOT EXISTS createdAt ON access_policy TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS updatedAt ON access_policy TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS updatedBy ON access_policy TYPE string;
+
+DEFINE INDEX IF NOT EXISTS access_policy_name_idx ON access_policy FIELDS name UNIQUE;
+
+DEFINE TABLE IF NOT EXISTS policy_binding SCHEMAFULL;
+
+DEFINE FIELD IF NOT EXISTS subject     ON policy_binding TYPE string;
+DEFINE FIELD IF NOT EXISTS policyNames ON policy_binding TYPE array<string> DEFAULT [];
+DEFINE FIELD IF NOT EXISTS updatedAt   ON policy_binding TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX IF NOT EXISTS policy_binding_subject_idx ON policy_binding FIELDS subject UNIQUE;
+
+DEFINE TABLE IF NOT EXISTS policy_decision SCHEMAFULL;
+
+DEFINE FIELD IF NOT EXISTS ts        ON policy_decision TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS keyHash   ON policy_decision TYPE string;
+DEFINE FIELD IF NOT EXISTS kind      ON policy_decision TYPE string
+    ASSERT $value IN ['action', 'row'];
+DEFINE FIELD IF NOT EXISTS decision  ON policy_decision TYPE string
+    ASSERT $value IN ['allow', 'deny', 'would_deny'];
+DEFINE FIELD IF NOT EXISTS mode      ON policy_decision TYPE string
+    ASSERT $value IN ['report_only', 'enforce'];
+DEFINE FIELD IF NOT EXISTS action    ON policy_decision TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS policySet ON policy_decision TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS ruleId    ON policy_decision TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS requestId ON policy_decision TYPE option<string>;
+-- Row-kind aggregates: how many rows the request surfaced vs how many
+-- this policy denied (or would deny) — {total, denied}. Sampled
+-- per-fact detail rides in sampleFactIds/samplePredicates, capped by
+-- the sink.
+DEFINE FIELD IF NOT EXISTS rowCounts ON policy_decision TYPE option<object> FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS sampleFactIds ON policy_decision TYPE option<array<string>>;
+DEFINE FIELD IF NOT EXISTS samplePredicates ON policy_decision TYPE option<array<string>>;
+DEFINE FIELD IF NOT EXISTS sampled   ON policy_decision TYPE bool DEFAULT false;
+
+DEFINE INDEX IF NOT EXISTS policy_decision_ts_idx ON policy_decision FIELDS ts;

--- a/src/documents/documents-ingest.controller.ts
+++ b/src/documents/documents-ingest.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import type { AuthenticatedRequest } from '../auth/api-key.types';
 import { envFlagEnabled } from '../common/env-validation';
 import { DocumentIngestService } from './document-ingest.service';
@@ -34,6 +35,7 @@ export class DocumentsIngestController {
 
   @Post('ingest/document')
   @RequireScopes('brain:write')
+  @PolicyAction('ingest_document')
   // Document ingest runs the LLM extractor per chunk; cap per-credential.
   @Throttle({ expensive: { limit: 10, ttl: 60_000 } })
   async ingestDocument(
@@ -50,6 +52,7 @@ export class DocumentsIngestController {
 
   @Post('documents/:id/commit')
   @RequireScopes('brain:admin')
+  @PolicyAction('rest.documents.commit')
   async commit(@Req() req: AuthenticatedRequest, @Param('id') id: string) {
     assertDocumentIngestEnabled();
     const result = await this.ingest.commitPending(req.brainAuth.companyId, id);

--- a/src/documents/documents.controller.ts
+++ b/src/documents/documents.controller.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import type { AuthenticatedRequest } from '../auth/api-key.types';
 import { policyFor } from '../ingest/conflict-resolver';
 import { DocumentStoreService } from './document-store.service';
@@ -35,6 +36,7 @@ export class DocumentsController {
 
   @Get(':id')
   @RequireScopes('brain:read')
+  @PolicyAction('rest.documents.get')
   async getDocument(
     @Req() req: AuthenticatedRequest,
     @Param('id') id: string,
@@ -62,6 +64,7 @@ export class DocumentsController {
 
   @Get(':id/candidates')
   @RequireScopes('brain:read')
+  @PolicyAction('rest.documents.candidates')
   async listCandidates(
     @Req() req: AuthenticatedRequest,
     @Param('id') id: string,
@@ -81,6 +84,7 @@ export class DocumentsController {
 
   @Delete(':id/content')
   @RequireScopes('brain:admin')
+  @PolicyAction('rest.documents.purge_content')
   async purge(@Req() req: AuthenticatedRequest, @Param('id') id: string) {
     assertDocumentIngestEnabled();
     const purged = await this.store.purgeContent(req.brainAuth.companyId, id);

--- a/src/documents/external-candidates.controller.ts
+++ b/src/documents/external-candidates.controller.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import type { AuthenticatedRequest } from '../auth/api-key.types';
 import { ExternalCandidatesService } from './external-candidates.service';
 import { DocumentIngestService } from './document-ingest.service';
@@ -31,6 +32,7 @@ export class ExternalCandidatesController {
 
   @Post(':id/candidates')
   @RequireScopes('indexer:write')
+  @PolicyAction('rest.documents.stage_candidates')
   // Staging is DB-only, but each submission fans into entity resolution +
   // fact resolves at commit — keep the same per-credential ceiling as
   // document ingest.

--- a/src/dreams/dreams.controller.ts
+++ b/src/dreams/dreams.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 import { DreamsService } from './dreams.service';
 import { RunDreamsDto } from './dto/run-dreams.dto';
@@ -21,6 +22,7 @@ export class DreamsController {
 
   @Post('run')
   @RequireScopes('brain:admin')
+  @PolicyAction('rest.dreams.run')
   // Dreams fan out to dedup (cosine k-NN per entity) + verdict LLM calls
   // + summary LLM calls. Single tenant kicking this on a loop drains
   // the shared OpenAI budget; hard-cap manual triggers to 3/min.

--- a/src/entities/entities.controller.ts
+++ b/src/entities/entities.controller.ts
@@ -9,6 +9,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import { EntitiesService } from './entities.service';
 import { ForgetEntityDto } from './dto/forget.dto';
 import { AuthenticatedRequest } from '../auth/api-key.types';
@@ -20,6 +21,7 @@ export class EntitiesController {
 
   @Get(':id')
   @RequireScopes('brain:read')
+  @PolicyAction('get_entity_profile')
   async getProfile(
     @Req() req: AuthenticatedRequest,
     @Param('id') id: string,
@@ -36,6 +38,7 @@ export class EntitiesController {
   // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Param/@Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get(':id/timeline')
   @RequireScopes('brain:read')
+  @PolicyAction('get_entity_timeline')
   async getTimeline(
     @Req() req: AuthenticatedRequest,
     @Param('id') id: string,
@@ -54,6 +57,7 @@ export class EntitiesController {
   // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Param/@Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get(':id/connections')
   @RequireScopes('brain:read')
+  @PolicyAction('find_related_entities')
   async getConnections(
     @Req() req: AuthenticatedRequest,
     @Param('id') id: string,
@@ -71,6 +75,7 @@ export class EntitiesController {
 
   @Post(':id/forget')
   @RequireScopes('brain:admin')
+  @PolicyAction('forget_entity')
   async forget(
     @Req() req: AuthenticatedRequest,
     @Param('id') id: string,

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -6,10 +6,10 @@ import { BrainScope } from '../auth/api-key.types';
 import { EntityForgetService } from './entity-forget.service';
 import {
   normalizeEntityId,
-  factVisibleToScopes,
   blockedPredicates,
   activeFactWhere,
 } from './entity-read.helpers';
+import { makeRowPolicyFilter } from '../policy/row-filter';
 
 // Centralised SELECT-clause field lists. Adding a new field to a table
 // touches one place here, not every read site. The strings below are
@@ -18,14 +18,17 @@ import {
 const ENTITY_PROFILE_FIELDS =
   'id, type, canonicalName, externalRefs, mergedAt, mergedInto';
 
+// source/trustSnapshot/corroboration ride along for the ABAC row filter
+// (policy/row-filter.ts); the response mappers never surface them unless
+// the field was already part of the wire shape (timeline's `source`).
 const FACT_PROFILE_FIELDS =
   'id, predicate, object, confidence, validFrom, validUntil, ' +
-  'recordedAt, retractedAt, status';
+  'recordedAt, retractedAt, status, source, trustSnapshot, corroboration';
 
 const FACT_TIMELINE_FIELDS =
   'id, predicate, object, confidence, validFrom, validUntil, ' +
   'recordedAt, retractedAt, retractedBy, retractionReason, ' +
-  'supersededBy, source, status';
+  'supersededBy, source, status, trustSnapshot, corroboration';
 
 export interface EntityProfile {
   entityId: string;
@@ -150,11 +153,15 @@ export class EntitiesService {
          LIMIT 100`,
         params,
       );
-      // PII scope gate — keep this in JS (per-row policy lookup).
-      // Move to DB-side PERMISSIONS once we switch to JWT-per-conn.
+      // PII scope gate + ABAC row filter — per-row policy lookup in JS.
+      const rowPolicy = makeRowPolicyFilter({
+        callerScopes: scopes,
+        surface: 'entity_profile',
+      });
       const facts = ((factRows as any[]) ?? []).filter((f) =>
-        factVisibleToScopes(f.predicate, scopes),
+        rowPolicy.filter(f),
       );
+      rowPolicy.finish();
 
       return {
         entityId: String(entity.id),
@@ -313,9 +320,14 @@ export class EntitiesService {
          ORDER BY recordedAt ASC`,
         params,
       );
+      const rowPolicy = makeRowPolicyFilter({
+        callerScopes: scopes,
+        surface: 'entity_timeline',
+      });
       const rows = ((factRows as any[]) ?? []).filter((f) =>
-        factVisibleToScopes(f.predicate, scopes),
+        rowPolicy.filter(f),
       );
+      rowPolicy.finish();
 
       const events: any[] = [];
       for (const f of rows) {
@@ -427,15 +439,26 @@ export class EntitiesService {
             : undefined,
           direction: 'inbound' as const,
         })),
-      ].filter((edge) =>
-        // Defense-in-depth: the DB-level PERMISSIONS fence (migration 0005)
-        // gates knowledge_fact.object, but knowledge_edge has no such fence,
-        // so a scoped caller could otherwise read a PII-classed relation
-        // (edge.kind maps to a predicate). Mirror the timeline scope gate:
-        // drop edges whose kind requires a scope the caller lacks.
-        factVisibleToScopes(edge.kind, scopes),
+      ];
+      // Defense-in-depth: the DB-level PERMISSIONS fence (migration 0005)
+      // gates knowledge_fact.object, but knowledge_edge has no such fence,
+      // so a scoped caller could otherwise read a PII-classed relation
+      // (edge.kind maps to a predicate). Mirror the timeline scope gate,
+      // then the ABAC row verdict — edges evaluate with predicate = kind,
+      // so predicate/source rules apply to relations too.
+      const rowPolicy = makeRowPolicyFilter({
+        callerScopes: scopes,
+        surface: 'entity_connections',
+      });
+      const visibleEdges = edges.filter((edge) =>
+        rowPolicy.filter({
+          id: edge.edgeId,
+          predicate: edge.kind,
+          source: edge.source,
+        }),
       );
-      return { entityId: ref.full, edges };
+      rowPolicy.finish();
+      return { entityId: ref.full, edges: visibleEdges };
     });
   }
 

--- a/src/entities/user-forget.controller.ts
+++ b/src/entities/user-forget.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Param, Post, UseGuards } from '@nestjs/common';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import { UserForgetService, UserForgetResult } from './user-forget.service';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 import { Req } from '@nestjs/common';
@@ -15,6 +16,7 @@ export class UserForgetController {
    */
   @Post(':userId/forget')
   @RequireScopes('brain:admin')
+  @PolicyAction('rest.users.forget')
   async forget(
     @Req() req: AuthenticatedRequest,
     @Param('userId') userId: string,

--- a/src/facts/facts.controller.ts
+++ b/src/facts/facts.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Param, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import { FactsService } from './facts.service';
 import { RetractFactDto } from './dto/retract.dto';
 import { AuthenticatedRequest } from '../auth/api-key.types';
@@ -17,6 +18,7 @@ export class FactsController {
   // we read the row.
   @Post(':id/retract')
   @RequireScopes('brain:write')
+  @PolicyAction('retract_fact')
   async retract(
     @Req() req: AuthenticatedRequest,
     @Param('id') id: string,

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -4,6 +4,10 @@ import { SurrealService, dbMerge } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { RetractFactDto } from './dto/retract.dto';
 import { BrainScope } from '../auth/api-key.types';
+import {
+  makeRowPolicyFilter,
+  type PolicyFilterableRow,
+} from '../policy/row-filter';
 
 /**
  * Predicate-class allowlist that requires `brain:admin` for retract,
@@ -337,14 +341,28 @@ export class FactsService {
 
       const [rows] = await db.query<any[][]>(
         `SELECT id, entityId, predicate, object, confidence,
-                validFrom, validUntil, recordedAt, source
+                validFrom, validUntil, recordedAt, source,
+                trustSnapshot, corroboration
            FROM knowledge_fact
            WHERE ${clauses.join(' AND ')}
            ORDER BY predicate ASC, recordedAt ASC`,
         params,
       );
 
-      const records: CompetingFactRecord[] = ((rows as any[]) ?? []).map(
+      // Scope + ABAC row gate. Pre-ABAC this path leaned on the DB-level
+      // PII fence alone (scoped pool, object-null on address/dob); the
+      // JS filter now applies the same requiresScope drop as search plus
+      // any per-key source rules.
+      const rowPolicy = makeRowPolicyFilter({
+        callerScopes: opts.callerScopes ?? [],
+        surface: 'competing_facts',
+      });
+      const visible = (((rows as any[]) ?? []) as PolicyFilterableRow[]).filter(
+        (r) => rowPolicy.filter(r),
+      );
+      rowPolicy.finish();
+
+      const records: CompetingFactRecord[] = (visible as any[]).map(
         (r): CompetingFactRecord => ({
           factId: String(r.id),
           entityId: String(r.entityId),

--- a/src/ingest/ingest.controller.ts
+++ b/src/ingest/ingest.controller.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import { envFlagEnabled } from '../common/env-validation';
 import { MentionViaDocumentService } from '../documents/mention-via-document.service';
 import { IngestService } from './ingest.service';
@@ -25,6 +26,7 @@ export class IngestController {
 
   @Post('fact')
   @RequireScopes('brain:write')
+  @PolicyAction('record_fact')
   async ingestFact(
     @Req() req: AuthenticatedRequest,
     @Body() body: IngestFactDto,
@@ -34,6 +36,7 @@ export class IngestController {
 
   @Post('mention')
   @RequireScopes('brain:write')
+  @PolicyAction('rest.ingest.mention')
   // Mention ingest runs the LLM extractor; cap per-credential rate.
   @Throttle({ expensive: { limit: 10, ttl: 60_000 } })
   async ingestMention(
@@ -51,6 +54,7 @@ export class IngestController {
 
   @Post('link')
   @RequireScopes('brain:write')
+  @PolicyAction('link_entities')
   async ingestLink(
     @Req() req: AuthenticatedRequest,
     @Body() body: IngestLinkDto,

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -12,6 +12,8 @@ import { Request, Response } from 'express';
 import { Throttle } from '@nestjs/throttler';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
+import { POLICY_ACTION_EXEMPT } from '../policy/policy-gate.service';
 import { McpService } from './mcp.service';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 
@@ -61,10 +63,15 @@ export class McpController {
   // several JSON-RPC POSTs (initialize / tools/list / tools/call), and
   // the handshake messages don't fan out to OpenAI — 30 leaves headroom
   // for them while still capping the OpenAI-bound calls well below 120.
+  // Exempt from the ABAC action gate: gating the transport would deny
+  // the whole JSON-RPC surface (initialize, tools/list) on any
+  // default-deny key. Individual tools are gated inside buildServer —
+  // denied tools vanish from tools/list and their handlers never bind.
   @Throttle({ expensive: { limit: 30, ttl: 60_000 } })
   @All(':companyId')
   @UseGuards(ApiKeyGuard)
   @RequireScopes('brain:read')
+  @PolicyAction(POLICY_ACTION_EXEMPT)
   async handle(
     @Req() req: AuthenticatedRequest & Request,
     @Res() res: Response,
@@ -77,11 +84,10 @@ export class McpController {
       );
     }
 
-    const server = this.mcp.buildServer(
-      auth.companyId,
-      auth.scopes,
-      auth.keyHash,
-    );
+    const server = this.mcp.buildServer(auth.companyId, auth.scopes, {
+      actorKeyHash: auth.keyHash,
+      policy: auth.policy,
+    });
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined, // stateless
     });

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -26,6 +26,9 @@ import { registerSourceReadTools } from './source-tools';
 import { SourcesService } from '../sources/sources.service';
 import { DocumentIngestService } from '../documents/document-ingest.service';
 import { FeedbackService } from '../feedback/feedback.service';
+import { PolicyGateService } from '../policy/policy-gate.service';
+import { evaluateAction } from '../policy/policy-engine';
+import { PolicyContext } from '../policy/policy.types';
 
 const MCP_SERVER_VERSION = '0.3.0';
 
@@ -91,7 +94,38 @@ export class McpService {
     private readonly embedder: EmbedderService,
     private readonly documents: DocumentIngestService,
     private readonly feedback: FeedbackService,
+    private readonly policyGate: PolicyGateService,
   ) {}
+
+  /**
+   * ABAC tool gate: wraps server.registerTool so every subsequent
+   * registration (all six tool families) is policy-checked without
+   * touching the tool files. An enforce-denied tool is not registered
+   * at all — it disappears from tools/list and a tools/call gets the
+   * SDK's standard unknown-tool error. Allowed tools get a per-call
+   * wrapper that emits allow/would_deny decisions (report_only
+   * observability).
+   */
+  private applyPolicyToolGate(server: McpServer, policy: PolicyContext): void {
+    const raw = server.registerTool.bind(server);
+    (server as McpServer & { registerTool: unknown }).registerTool = (
+      name: string,
+      config: unknown,
+      handler: (...args: unknown[]) => unknown,
+    ) => {
+      const denied = evaluateAction(policy, name).decision === 'deny';
+      const tool = raw(name as never, config as never, ((...args: unknown[]) => {
+        this.policyGate.enforceAction(policy, name);
+        return handler(...args);
+      }) as never);
+      // Enforce-denied tools unregister immediately: gone from
+      // tools/list, and a blind tools/call gets the SDK's standard
+      // unknown-tool error. Registered-then-removed (vs never
+      // registered) only to keep the SDK's return type intact.
+      if (denied) tool.remove();
+      return tool;
+    };
+  }
 
   /**
    * Unauthenticated health probe payload — surfaces version + the
@@ -127,15 +161,27 @@ export class McpService {
   buildServer(
     companyId: string,
     scopes: BrainScope[],
-    // Caller key hash — the feedback tool's one-vote-per-(fact, actor)
-    // fence. Falls back to a per-tenant sentinel for callers that don't
-    // thread it (unit fixtures).
-    actorKeyHash?: string,
+    caller?: {
+      /**
+       * Caller key hash — the feedback tool's one-vote-per-(fact,
+       * actor) fence. Falls back to a per-tenant sentinel for callers
+       * that don't thread it (unit fixtures).
+       */
+      actorKeyHash?: string;
+      /**
+       * Resolved ABAC context from ApiKeyGuard; undefined = no
+       * policies attached, tool surface identical to pre-ABAC.
+       */
+      policy?: PolicyContext;
+    },
   ): McpServer {
+    const actorKeyHash = caller?.actorKeyHash;
+    const policy = caller?.policy;
     const server = new McpServer({
       name: 'inite-brain-service',
       version: '0.1.0',
     });
+    if (policy) this.applyPolicyToolGate(server, policy);
     registerReadTools({
       server,
       companyId,

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -335,6 +335,40 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // ABAC (policy module). decision: allow | deny | would_deny;
+  // kind: action | row; mode: report_only | enforce. Row decisions are
+  // per-request aggregates, so this counts requests, not facts.
+  readonly policyDecisions = new Counter({
+    name: 'brain_policy_decisions_total',
+    help: 'ABAC policy decisions by decision, kind, and mode',
+    labelNames: ['decision', 'kind', 'mode'] as const,
+    registers: [this.registry],
+  });
+
+  // Whole-request row-evaluation cost inside the search/read pipelines.
+  // Budget is sub-millisecond at typical K; buckets bottom out at 50 µs
+  // so a regression is visible long before it hurts.
+  readonly policyEvalDuration = new Histogram({
+    name: 'brain_policy_eval_seconds',
+    help: 'Per-request ABAC row-evaluation latency in seconds',
+    buckets: [0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.01, 0.05],
+    registers: [this.registry],
+  });
+
+  readonly policySetsActive = new Gauge({
+    name: 'brain_policy_sets_active',
+    help: 'Enabled (enforce or report_only) policy sets, summed across tenants',
+    registers: [this.registry],
+  });
+
+  // Fail-closed events: a key referenced a policy set that doesn't
+  // exist. Non-zero is an operator page — some key is bricked.
+  readonly policyResolutionErrors = new Counter({
+    name: 'brain_policy_resolution_errors_total',
+    help: 'Keys that referenced an unknown policy set (failed closed)',
+    registers: [this.registry],
+  });
+
   onModuleInit() {
     // Node defaults: GC, event-loop lag, memory, CPU. Cheap and useful.
     collectDefaultMetrics({ register: this.registry, prefix: 'brain_' });
@@ -537,6 +571,28 @@ export class MetricsService implements OnModuleInit {
       );
     }
     this.memoryOrphanEntities.set(snapshot.orphanEntities);
+  }
+
+  countPolicyDecision(
+    decision: 'allow' | 'deny' | 'would_deny',
+    kind: 'action' | 'row',
+    mode: 'report_only' | 'enforce',
+  ): void {
+    this.policyDecisions.inc({ decision, kind, mode } as LabelValues<
+      'decision' | 'kind' | 'mode'
+    >);
+  }
+
+  observePolicyEval(seconds: number): void {
+    this.policyEvalDuration.observe(seconds);
+  }
+
+  setPolicySetsActive(n: number): void {
+    this.policySetsActive.set(n);
+  }
+
+  countPolicyResolutionError(): void {
+    this.policyResolutionErrors.inc();
   }
 
   async serialize(): Promise<{ contentType: string; body: string }> {

--- a/src/multi-hop/multi-hop.controller.ts
+++ b/src/multi-hop/multi-hop.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import { MultiHopService } from './multi-hop.service';
 import { MultiHopDto } from './dto/multi-hop.dto';
 import { AuthenticatedRequest } from '../auth/api-key.types';
@@ -12,6 +13,7 @@ export class MultiHopController {
 
   @Post()
   @RequireScopes('brain:read')
+  @PolicyAction('search_multi_hop')
   // Planner + up to maxHops sub-searches + optional synthesize → expensive.
   @Throttle({ expensive: { limit: 10, ttl: 60_000 } })
   async run(@Req() req: AuthenticatedRequest, @Body() body: MultiHopDto) {

--- a/src/policy/action-registry.ts
+++ b/src/policy/action-registry.ts
@@ -1,0 +1,115 @@
+import { SetMetadata } from '@nestjs/common';
+import { ActionKind, CompiledActionRule } from './policy.types';
+
+/**
+ * The flat action namespace ABAC policies gate. MCP tool names are used
+ * verbatim; REST endpoints reuse the equivalent MCP tool name where one
+ * exists (POST /v1/search and the search_knowledge tool are the same
+ * action) and get `rest.*` names otherwise. Controllers opt in via
+ * @PolicyAction('name'); undecorated guarded routes fall back to the
+ * auto-name `"<METHOD> <path>"` with kind inferred from the HTTP verb
+ * (GET → read, else write) so a default-deny posture has no holes.
+ *
+ * family is UI grouping only — the engine reads kind (readonly macro).
+ */
+export type ActionFamily =
+  | 'mcp_read'
+  | 'mcp_write'
+  | 'mcp_community'
+  | 'mcp_procedural'
+  | 'mcp_source'
+  | 'rest';
+
+export interface ActionSpec {
+  kind: ActionKind;
+  family: ActionFamily;
+  title?: string;
+}
+
+export const ACTIONS: Record<string, ActionSpec> = {
+  // MCP read tools (also the REST search/entity surface)
+  search_knowledge: { kind: 'read', family: 'mcp_read', title: 'Search knowledge' },
+  search_multi_hop: { kind: 'read', family: 'mcp_read', title: 'Multi-hop search' },
+  graph_retrieve: { kind: 'read', family: 'mcp_read', title: 'Graph-first retrieval' },
+  synthesize: { kind: 'read', family: 'mcp_read', title: 'Synthesize answer' },
+  memory_diff: { kind: 'read', family: 'mcp_read', title: 'Memory diff' },
+  get_entity_profile: { kind: 'read', family: 'mcp_read', title: 'Entity profile' },
+  get_entity_timeline: { kind: 'read', family: 'mcp_read', title: 'Entity timeline' },
+  get_competing_facts: { kind: 'read', family: 'mcp_read', title: 'Competing facts' },
+  summarize_entity: { kind: 'read', family: 'mcp_read', title: 'Summarize entity' },
+  detect_contradiction: { kind: 'read', family: 'mcp_read', title: 'Detect contradiction' },
+  why: { kind: 'read', family: 'mcp_read', title: 'Code-memory why' },
+  recall_decisions: { kind: 'read', family: 'mcp_read', title: 'Recall decisions' },
+
+  // MCP write tools
+  record_fact: { kind: 'write', family: 'mcp_write', title: 'Record fact' },
+  retract_fact: { kind: 'write', family: 'mcp_write', title: 'Retract fact' },
+  link_entities: { kind: 'write', family: 'mcp_write', title: 'Link entities' },
+  forget_entity: { kind: 'write', family: 'mcp_write', title: 'Forget entity' },
+  ingest_document: { kind: 'write', family: 'mcp_write', title: 'Ingest document' },
+  record_decision: { kind: 'write', family: 'mcp_write', title: 'Record decision' },
+  record_feedback: { kind: 'write', family: 'mcp_write', title: 'Record retrieval feedback' },
+
+  // Communities / graph neighbourhood
+  list_communities: { kind: 'read', family: 'mcp_community', title: 'List communities' },
+  search_communities: { kind: 'read', family: 'mcp_community', title: 'Search communities' },
+  find_entity_communities: { kind: 'read', family: 'mcp_community', title: 'Entity communities' },
+  find_related_entities: { kind: 'read', family: 'mcp_community', title: 'Related entities' },
+
+  // Procedural memory
+  list_procedures: { kind: 'read', family: 'mcp_procedural', title: 'List procedures' },
+  match_procedure: { kind: 'read', family: 'mcp_procedural', title: 'Match procedure' },
+  record_procedure: { kind: 'write', family: 'mcp_procedural', title: 'Record procedure' },
+  retire_procedure: { kind: 'write', family: 'mcp_procedural', title: 'Retire procedure' },
+
+  // Sources
+  get_source_reputation: { kind: 'read', family: 'mcp_source', title: 'Source reputation' },
+
+  // REST-only actions
+  'rest.users.forget': { kind: 'write', family: 'rest', title: 'GDPR user forget' },
+  'rest.ingest.mention': { kind: 'write', family: 'rest', title: 'Ingest mention' },
+  'rest.documents.get': { kind: 'read', family: 'rest', title: 'Get document' },
+  'rest.documents.candidates': { kind: 'read', family: 'rest', title: 'List candidates' },
+  'rest.documents.commit': { kind: 'write', family: 'rest', title: 'Commit candidates' },
+  'rest.documents.stage_candidates': { kind: 'write', family: 'rest', title: 'Stage external candidates' },
+  'rest.documents.purge_content': { kind: 'write', family: 'rest', title: 'Purge document content' },
+  'rest.artifacts.get': { kind: 'read', family: 'rest', title: 'Get artifact' },
+  'rest.artifacts.recompile': { kind: 'write', family: 'rest', title: 'Recompile artifact' },
+  'rest.stats.overview': { kind: 'read', family: 'rest', title: 'Stats overview' },
+  'rest.dreams.run': { kind: 'write', family: 'rest', title: 'Run dreams pass' },
+};
+
+/**
+ * Kind of an action name. Registered names use their spec; auto-named
+ * fallbacks ("GET /v1/...") infer from the verb. Unknown non-fallback
+ * names are treated as write — the conservative bucket for the
+ * readonly macro.
+ */
+export function actionKind(action: string): ActionKind {
+  const spec = ACTIONS[action];
+  if (spec) return spec.kind;
+  if (action.startsWith('GET ')) return 'read';
+  return 'write';
+}
+
+/** Does one compiled action rule cover this action? */
+export function actionRuleMatches(
+  rule: CompiledActionRule,
+  action: string,
+  kind: ActionKind,
+): boolean {
+  if (rule.names.has(action)) return true;
+  if (rule.macros.has('@all')) return true;
+  if (rule.macros.has('@readonly') && kind === 'read') return true;
+  if (rule.macros.has('@write') && kind === 'write') return true;
+  return false;
+}
+
+export const POLICY_ACTION_KEY = 'policyAction';
+
+/**
+ * Names a controller handler in the ABAC action namespace. Mirrors
+ * RequireScopes (SetMetadata + reflector read in ApiKeyGuard).
+ */
+export const PolicyAction = (action: string) =>
+  SetMetadata(POLICY_ACTION_KEY, action);

--- a/src/policy/policy-compile.ts
+++ b/src/policy/policy-compile.ts
@@ -1,0 +1,202 @@
+import {
+  CompiledActionRule,
+  CompiledCondition,
+  CompiledPolicySet,
+  CompiledSourceRule,
+  MatchCondition,
+  PolicyDocument,
+  PolicyMacro,
+  PolicyRowView,
+} from './policy.types';
+
+/**
+ * Compiles a validated PolicyDocument into matcher closures so the hot
+ * read path pays hash lookups and comparators, never JSON walking.
+ * Compilation happens once per resolver cache load (per tenant per TTL),
+ * evaluation happens per row — keep everything allocated here.
+ */
+
+/** Dotted-path getter over the row view. Precomputed per condition. */
+function accessor(attr: string): (view: PolicyRowView) => unknown {
+  if (attr === 'predicate') return (v) => v.predicate;
+  if (attr === 'piiClass') return (v) => v.piiClass;
+  if (attr === 'provenance.purged') return (v) => v.source?.provenancePurged;
+  if (attr === 'userId') return (v) => v.userId;
+  if (attr === 'corroboration.count') return (v) => v.corroboration?.count;
+  if (attr.startsWith('trust.')) {
+    const key = attr.slice('trust.'.length) as
+      | 'authority'
+      | 'declaredTrust'
+      | 'learnedTrust';
+    return (v) => v.trustSnapshot?.[key];
+  }
+  if (attr.startsWith('source.meta.')) {
+    const key = attr.slice('source.meta.'.length);
+    return (v) => {
+      const meta = v.source?.meta;
+      if (meta === null || typeof meta !== 'object') return undefined;
+      return (meta as Record<string, unknown>)[key];
+    };
+  }
+  if (attr.startsWith('source.')) {
+    const key = attr.slice('source.'.length);
+    return (v) => v.source?.[key];
+  }
+  return () => undefined;
+}
+
+function compileCondition(cond: MatchCondition): CompiledCondition {
+  const get = accessor(cond.attr);
+  const { attr, op } = cond;
+
+  // Absent attribute never matches a value-comparing rule; only
+  // not_exists matches absence. Null and undefined are both "absent".
+  const present = (x: unknown) => x !== undefined && x !== null;
+
+  let expected: CompiledCondition['expected'] = null;
+  let matches: (view: PolicyRowView) => boolean;
+
+  switch (op) {
+    case 'exists':
+      matches = (v) => present(get(v));
+      break;
+    case 'not_exists':
+      matches = (v) => !present(get(v));
+      break;
+    case 'eq': {
+      const want = cond.value as string | number | boolean;
+      expected = want;
+      matches = (v) => {
+        const x = get(v);
+        return present(x) && x === want;
+      };
+      break;
+    }
+    case 'in': {
+      const set = new Set(cond.value as string[]);
+      expected = set;
+      matches = (v) => {
+        const x = get(v);
+        return typeof x === 'string' && set.has(x);
+      };
+      break;
+    }
+    case 'prefix': {
+      const want = cond.value as string;
+      expected = want;
+      matches = (v) => {
+        const x = get(v);
+        return typeof x === 'string' && x.startsWith(want);
+      };
+      break;
+    }
+    case 'gte':
+    case 'gt':
+    case 'lte':
+    case 'lt': {
+      const want = cond.value as number;
+      expected = want;
+      matches = (v) => {
+        const x = get(v);
+        if (typeof x !== 'number' || !Number.isFinite(x)) return false;
+        if (op === 'gte') return x >= want;
+        if (op === 'gt') return x > want;
+        if (op === 'lte') return x <= want;
+        return x < want;
+      };
+      break;
+    }
+  }
+
+  return { attr, op, expected, matches, actual: get };
+}
+
+function compileSourceRule(rule: {
+  id: string;
+  effect: 'allow' | 'deny';
+  match?: MatchCondition[];
+}): CompiledSourceRule {
+  return {
+    id: rule.id,
+    effect: rule.effect,
+    conditions: (rule.match ?? []).map(compileCondition),
+  };
+}
+
+function compileActionRule(rule: {
+  id: string;
+  effect: 'allow' | 'deny';
+  actions?: string[];
+}): CompiledActionRule {
+  const names = new Set<string>();
+  const macros = new Set<PolicyMacro>();
+  for (const a of rule.actions ?? []) {
+    if (a.startsWith('@')) macros.add(a as PolicyMacro);
+    else names.add(a);
+  }
+  return { id: rule.id, effect: rule.effect, names, macros };
+}
+
+/**
+ * Compile one document. Disabled sets and (extras wave) sets outside
+ * their activeFrom/activeUntil window return null — the resolver drops
+ * them from the context entirely.
+ */
+export function compilePolicySet(doc: PolicyDocument): CompiledPolicySet | null {
+  if (doc.mode === 'disabled') return null;
+
+  const actionDeny: CompiledActionRule[] = [];
+  const actionAllow: CompiledActionRule[] = [];
+  const sourceDeny: CompiledSourceRule[] = [];
+  const sourceAllow: CompiledSourceRule[] = [];
+
+  for (const rule of doc.rules) {
+    if (!rule.enabled) continue;
+    if (rule.kind === 'action') {
+      (rule.effect === 'deny' ? actionDeny : actionAllow).push(
+        compileActionRule(rule),
+      );
+    } else {
+      (rule.effect === 'deny' ? sourceDeny : sourceAllow).push(
+        compileSourceRule(rule),
+      );
+    }
+  }
+
+  return {
+    name: doc.name,
+    mode: doc.mode,
+    posture: doc.posture,
+    actionDeny,
+    actionAllow,
+    sourceDeny,
+    sourceAllow,
+    document: doc,
+  };
+}
+
+/**
+ * Fail-closed sentinel set: injected by the resolver when a key
+ * references a policy name that doesn't resolve. Denies everything in
+ * enforce mode so a deleted/mistyped set can never silently widen
+ * access.
+ */
+export function denyAllSet(name: string): CompiledPolicySet {
+  const doc: PolicyDocument = {
+    name,
+    description: 'fail-closed: referenced policy set not found',
+    posture: { actions: 'deny', reads: 'deny' },
+    mode: 'enforce',
+    rules: [],
+  };
+  return {
+    name,
+    mode: 'enforce',
+    posture: doc.posture,
+    actionDeny: [],
+    actionAllow: [],
+    sourceDeny: [],
+    sourceAllow: [],
+    document: doc,
+  };
+}

--- a/src/policy/policy-decision.sink.ts
+++ b/src/policy/policy-decision.sink.ts
@@ -1,0 +1,117 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SurrealService } from '../db/surreal.service';
+import { PolicyDecision } from './policy.types';
+
+export interface PolicyDecisionRow {
+  keyHash: string;
+  kind: 'action' | 'row';
+  decision: PolicyDecision;
+  mode: 'report_only' | 'enforce';
+  action?: string;
+  policySet?: string;
+  ruleId?: string;
+  requestId?: string;
+  rowCounts?: { total: number; denied: number };
+  sampleFactIds?: string[];
+  samplePredicates?: string[];
+  sampled?: boolean;
+}
+
+const FLUSH_INTERVAL_MS = 5_000;
+const FLUSH_THRESHOLD = 500;
+const MAX_BUFFER = 5_000;
+const RETENTION_DAYS = 30;
+const PRUNE_MIN_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Buffered writer for the policy_decision stream (bulk-INSERT pattern,
+ * see changefeed-drain). Decisions are observability, not enforcement:
+ * a lost buffer on hard crash costs a few seconds of decision rows,
+ * never an access-control outcome. Hence fire-and-forget writes with a
+ * bounded buffer (oldest dropped past MAX_BUFFER) and best-effort flush
+ * on shutdown.
+ *
+ * Retention is pruned lazily on flush, at most once per 6 h per tenant
+ * — no leader election needed, a concurrent double-DELETE across pods
+ * is idempotent.
+ */
+@Injectable()
+export class PolicyDecisionSink implements OnModuleDestroy {
+  private readonly logger = new Logger(PolicyDecisionSink.name);
+  private readonly buffers = new Map<string, PolicyDecisionRow[]>();
+  private readonly lastPruneAt = new Map<string, number>();
+  private timer: NodeJS.Timeout | null = null;
+  private flushing = false;
+  private readonly retentionDays: number;
+
+  constructor(
+    private readonly surreal: SurrealService,
+    config: ConfigService,
+  ) {
+    const days = parseInt(
+      config.get<string>('POLICY_DECISION_RETENTION_DAYS', String(RETENTION_DAYS)),
+      10,
+    );
+    this.retentionDays = Number.isFinite(days) && days > 0 ? days : RETENTION_DAYS;
+  }
+
+  record(companyId: string, row: PolicyDecisionRow): void {
+    let buf = this.buffers.get(companyId);
+    if (!buf) {
+      buf = [];
+      this.buffers.set(companyId, buf);
+    }
+    buf.push(row);
+    if (buf.length > MAX_BUFFER) buf.splice(0, buf.length - MAX_BUFFER);
+    if (buf.length >= FLUSH_THRESHOLD) {
+      void this.flushAll();
+      return;
+    }
+    if (!this.timer) {
+      this.timer = setTimeout(() => {
+        this.timer = null;
+        void this.flushAll();
+      }, FLUSH_INTERVAL_MS);
+      // Never keep the process alive just to flush decision telemetry.
+      this.timer.unref?.();
+    }
+  }
+
+  async flushAll(): Promise<void> {
+    if (this.flushing) return;
+    this.flushing = true;
+    try {
+      const entries = [...this.buffers.entries()].filter(([, b]) => b.length > 0);
+      for (const [companyId, buf] of entries) {
+        const rows = buf.splice(0, buf.length);
+        try {
+          await this.surreal.withCompany(companyId, async (db) => {
+            await db.query(`INSERT INTO policy_decision $rows`, { rows });
+            const last = this.lastPruneAt.get(companyId) ?? 0;
+            if (Date.now() - last > PRUNE_MIN_INTERVAL_MS) {
+              this.lastPruneAt.set(companyId, Date.now());
+              await db.query(
+                `DELETE policy_decision WHERE ts < time::now() - ${this.retentionDays}d`,
+              );
+            }
+          });
+        } catch (e) {
+          this.logger.warn(
+            `policy_decision flush failed for ${companyId} (${rows.length} rows dropped): ${(e as Error).message}`,
+          );
+        }
+      }
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    await this.flushAll();
+  }
+}

--- a/src/policy/policy-engine.ts
+++ b/src/policy/policy-engine.ts
@@ -1,0 +1,182 @@
+import { actionKind, actionRuleMatches } from './action-registry';
+import {
+  CompiledPolicySet,
+  CompiledSourceRule,
+  PolicyContext,
+  PolicyEffect,
+  PolicyEvaluation,
+  PolicyRowView,
+  RuleTrace,
+  SetTrace,
+  SetVerdict,
+} from './policy.types';
+
+/**
+ * Pure evaluation core. Deny-overrides within a set (explicit deny >
+ * explicit allow > default posture), most-restrictive across sets:
+ * the combined decision is ALLOW only when every effective enforce-mode
+ * set allows. report_only sets (and all sets under forceReportOnly)
+ * contribute would_deny verdicts to the decision stream but never
+ * block. No I/O, no clock, no logging — callers own side effects.
+ */
+
+function sourceRuleMatches(rule: CompiledSourceRule, view: PolicyRowView): boolean {
+  for (const cond of rule.conditions) {
+    if (!cond.matches(view)) return false;
+  }
+  return true;
+}
+
+function setVerdictForAction(set: CompiledPolicySet, action: string): SetVerdict {
+  const kind = actionKind(action);
+  for (const rule of set.actionDeny) {
+    if (actionRuleMatches(rule, action, kind)) {
+      return { policySet: set.name, mode: set.mode, verdict: 'deny', ruleId: rule.id };
+    }
+  }
+  for (const rule of set.actionAllow) {
+    if (actionRuleMatches(rule, action, kind)) {
+      return { policySet: set.name, mode: set.mode, verdict: 'allow', ruleId: rule.id };
+    }
+  }
+  return {
+    policySet: set.name,
+    mode: set.mode,
+    verdict: set.posture.actions,
+    ruleId: null,
+  };
+}
+
+function setVerdictForRow(set: CompiledPolicySet, view: PolicyRowView): SetVerdict {
+  for (const rule of set.sourceDeny) {
+    if (sourceRuleMatches(rule, view)) {
+      return { policySet: set.name, mode: set.mode, verdict: 'deny', ruleId: rule.id };
+    }
+  }
+  for (const rule of set.sourceAllow) {
+    if (sourceRuleMatches(rule, view)) {
+      return { policySet: set.name, mode: set.mode, verdict: 'allow', ruleId: rule.id };
+    }
+  }
+  return {
+    policySet: set.name,
+    mode: set.mode,
+    verdict: set.posture.reads,
+    ruleId: null,
+  };
+}
+
+function combine(
+  ctx: PolicyContext,
+  verdicts: SetVerdict[],
+): PolicyEvaluation {
+  let enforcedDeny = false;
+  let wouldDeny = false;
+  for (const v of verdicts) {
+    if (v.verdict !== 'deny') continue;
+    if (v.mode === 'enforce' && !ctx.forceReportOnly) enforcedDeny = true;
+    else wouldDeny = true;
+  }
+  const decision = enforcedDeny ? 'deny' : wouldDeny ? 'would_deny' : 'allow';
+  return { decision, verdicts };
+}
+
+/** Combined action decision across all sets in the context. */
+export function evaluateAction(ctx: PolicyContext, action: string): PolicyEvaluation {
+  return combine(
+    ctx,
+    ctx.sets.map((s) => setVerdictForAction(s, action)),
+  );
+}
+
+/** Combined row decision across all sets in the context. */
+export function evaluateRow(ctx: PolicyContext, view: PolicyRowView): PolicyEvaluation {
+  return combine(
+    ctx,
+    ctx.sets.map((s) => setVerdictForRow(s, view)),
+  );
+}
+
+/**
+ * Normalize a retrieved fact row (FactRow or any fact-shaped record)
+ * into the attribute view the engine matches on. piiClass comes from
+ * the caller's predicate-policy lookup so tenant-registry overrides are
+ * honored where available.
+ */
+export function toRowView(
+  row: {
+    predicate: string;
+    source?: unknown;
+    trustSnapshot?: PolicyRowView['trustSnapshot'];
+    corroboration?: PolicyRowView['corroboration'];
+    userId?: string | null;
+  },
+  piiClassOf: (predicate: string) => string,
+): PolicyRowView {
+  return {
+    predicate: row.predicate,
+    piiClass: piiClassOf(row.predicate),
+    source:
+      row.source && typeof row.source === 'object'
+        ? (row.source as Record<string, unknown>)
+        : null,
+    trustSnapshot: row.trustSnapshot ?? null,
+    corroboration: row.corroboration ?? null,
+    userId: row.userId ?? null,
+  };
+}
+
+// ── Explain (DecisionLog-style traces) ──────────────────────────────────
+
+function traceSourceRule(rule: CompiledSourceRule, view: PolicyRowView): RuleTrace {
+  const fields = rule.conditions.map((c) => ({
+    attr: c.attr,
+    op: c.op,
+    expected: c.expected instanceof Set ? [...c.expected] : c.expected,
+    actual: c.actual(view),
+    matched: c.matches(view),
+  }));
+  return {
+    ruleId: rule.id,
+    effect: rule.effect,
+    matched: fields.every((f) => f.matched),
+    fields,
+  };
+}
+
+export function explainRow(ctx: PolicyContext, view: PolicyRowView): SetTrace[] {
+  return ctx.sets.map((set) => {
+    const rules = [...set.sourceDeny, ...set.sourceAllow].map((r) =>
+      traceSourceRule(r, view),
+    );
+    const verdict = setVerdictForRow(set, view);
+    return {
+      policySet: set.name,
+      mode: set.mode,
+      verdict: verdict.verdict,
+      decidedBy: verdict.ruleId ?? 'posture',
+      rules,
+    };
+  });
+}
+
+export function explainAction(ctx: PolicyContext, action: string): SetTrace[] {
+  const kind = actionKind(action);
+  return ctx.sets.map((set) => {
+    const rules: RuleTrace[] = [...set.actionDeny, ...set.actionAllow].map(
+      (r) => ({
+        ruleId: r.id,
+        effect: r.effect as PolicyEffect,
+        matched: actionRuleMatches(r, action, kind),
+      }),
+    );
+    const verdict = setVerdictForAction(set, action);
+    return {
+      policySet: set.name,
+      mode: set.mode,
+      verdict: verdict.verdict,
+      decidedBy: verdict.ruleId ?? 'posture',
+      rules,
+    };
+  });
+}

--- a/src/policy/policy-gate.service.ts
+++ b/src/policy/policy-gate.service.ts
@@ -1,0 +1,165 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { MetricsService } from '../metrics/metrics.service';
+import { ApiKeyRecord } from '../auth/api-key.types';
+import { getCorrelationId } from '../common/request-context';
+import { evaluateAction } from './policy-engine';
+import { PolicyDecisionSink } from './policy-decision.sink';
+import { PolicyResolverService } from './policy-resolver.service';
+import { PolicyContext } from './policy.types';
+import { RowDecisionSummary } from './row-filter';
+
+/**
+ * Action-level ABAC gate, bundled behind one injectable so ApiKeyGuard
+ * keeps its ≤3-dependency shape (same extraction rationale as
+ * CredentialResolverService). Resolves the key's PolicyContext, applies
+ * the action verdict, and owns decision telemetry (metrics always;
+ * decision rows for every deny/would_deny, sampled for allows).
+ *
+ * Routes that must not be action-gated (the MCP transport — its tools
+ * are gated individually inside McpService) mark themselves
+ * @PolicyAction(POLICY_ACTION_EXEMPT): the context still resolves and
+ * flows downstream, only the action verdict is skipped.
+ */
+export const POLICY_ACTION_EXEMPT = '@exempt';
+
+@Injectable()
+export class PolicyGateService {
+  private readonly sampleRate: number;
+
+  constructor(
+    private readonly resolver: PolicyResolverService,
+    private readonly sink: PolicyDecisionSink,
+    private readonly metrics: MetricsService,
+  ) {
+    // ConfigService is deliberately not injected (4th dep) — the rate
+    // is process-static anyway.
+    const raw = parseFloat(process.env.POLICY_DECISION_SAMPLE_RATE ?? '0.01');
+    this.sampleRate = Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : 0.01;
+  }
+
+  /**
+   * Resolve the key's policy context and enforce the action verdict.
+   * Returns undefined when ABAC is off / no sets attached. Throws 403
+   * policy_denied when an enforce-mode set denies the action.
+   */
+  async gate(
+    record: ApiKeyRecord,
+    action: string,
+    requestId?: string,
+  ): Promise<PolicyContext | undefined> {
+    const ctx = await this.resolver.contextFor(
+      record.companyId,
+      record.keyHash,
+      record.policyNames,
+    );
+    if (!ctx) return undefined;
+    if (action !== POLICY_ACTION_EXEMPT) {
+      this.enforceAction(ctx, action, requestId);
+    }
+    return ctx;
+  }
+
+  /**
+   * Shared by the REST gate above and McpService's per-tool wrappers.
+   * Emits metrics + decision rows and throws on an enforced deny.
+   */
+  enforceAction(ctx: PolicyContext, action: string, requestId?: string): void {
+    const evaluation = evaluateAction(ctx, action);
+    const denies = evaluation.verdicts.filter((v) => v.verdict === 'deny');
+    const decided = denies[0];
+
+    for (const v of denies) {
+      const enforced =
+        v.mode === 'enforce' && !ctx.forceReportOnly && evaluation.decision === 'deny';
+      const decision = enforced ? 'deny' : 'would_deny';
+      this.metrics.countPolicyDecision(decision, 'action', v.mode);
+      this.sink.record(ctx.companyId, {
+        keyHash: ctx.keyHash,
+        kind: 'action',
+        decision,
+        mode: v.mode,
+        action,
+        policySet: v.policySet,
+        ruleId: v.ruleId ?? undefined,
+        requestId,
+      });
+    }
+
+    if (denies.length === 0) {
+      this.metrics.countPolicyDecision('allow', 'action', 'enforce');
+      if (Math.random() < this.sampleRate) {
+        this.sink.record(ctx.companyId, {
+          keyHash: ctx.keyHash,
+          kind: 'action',
+          decision: 'allow',
+          mode: 'enforce',
+          action,
+          requestId,
+          sampled: true,
+        });
+      }
+    }
+
+    if (evaluation.decision === 'deny') {
+      throw new ForbiddenException({
+        error: 'policy_denied',
+        action,
+        policySet: decided?.policySet,
+        ruleId: decided?.ruleId ?? null,
+      });
+    }
+  }
+
+  /**
+   * Sink + metrics for one read surface's aggregated row decisions
+   * (bound into the request context by ApiKeyGuard, consumed by
+   * makeRowPolicyFilter.finish()). Row decisions are per-request
+   * aggregates — one sink row per (surface × policy set × outcome),
+   * never one per fact.
+   */
+  recordRowSummary(ctx: PolicyContext, summary: RowDecisionSummary): void {
+    this.metrics.observePolicyEval(summary.evalSeconds);
+    const requestId = getCorrelationId();
+    let anyDeny = false;
+
+    for (const s of summary.perSet) {
+      for (const [decision, count] of [
+        ['deny', s.denied],
+        ['would_deny', s.wouldDeny],
+      ] as const) {
+        if (count === 0) continue;
+        anyDeny = true;
+        this.metrics.countPolicyDecision(decision, 'row', s.mode);
+        this.sink.record(ctx.companyId, {
+          keyHash: ctx.keyHash,
+          kind: 'row',
+          decision,
+          mode: s.mode,
+          action: summary.surface,
+          policySet: s.policySet,
+          ruleId: s.ruleIds[0],
+          requestId,
+          rowCounts: { total: summary.total, denied: count },
+          sampleFactIds: s.sampleFactIds,
+          samplePredicates: s.samplePredicates,
+        });
+      }
+    }
+
+    if (!anyDeny) {
+      this.metrics.countPolicyDecision('allow', 'row', 'enforce');
+      if (Math.random() < this.sampleRate) {
+        this.sink.record(ctx.companyId, {
+          keyHash: ctx.keyHash,
+          kind: 'row',
+          decision: 'allow',
+          mode: 'enforce',
+          action: summary.surface,
+          requestId,
+          rowCounts: { total: summary.total, denied: 0 },
+          sampled: true,
+        });
+      }
+    }
+  }
+}

--- a/src/policy/policy-resolver.service.ts
+++ b/src/policy/policy-resolver.service.ts
@@ -1,0 +1,187 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { LRUCache } from '../common/lru-cache';
+import { envFlagEnabled } from '../common/env-validation';
+import { MetricsService } from '../metrics/metrics.service';
+import { SurrealService } from '../db/surreal.service';
+import { compilePolicySet, denyAllSet } from './policy-compile';
+import {
+  CompiledPolicySet,
+  MAX_SETS_PER_KEY,
+  PolicyContext,
+  PolicyDocument,
+} from './policy.types';
+
+interface TenantPolicySnapshot {
+  /** Compiled sets by name — disabled/inactive sets are absent here… */
+  sets: Map<string, CompiledPolicySet>;
+  /** …but present here, so "disabled" can be told apart from "missing". */
+  knownNames: Set<string>;
+  /** subject ('key:<hash>' / 'jwt:<sub>') → attached set names. */
+  bindings: Map<string, string[]>;
+  loadedAt: number;
+}
+
+/**
+ * Turns (companyId, keyHash, JWT claim names) into a per-request
+ * PolicyContext without adding a DB round-trip: one query per tenant per
+ * TTL loads and compiles every set + binding, then every request is a
+ * couple of Map lookups. A tenant with zero policy sets caches an empty
+ * snapshot (the tombstone) and contextFor returns null immediately —
+ * ABAC-free tenants pay one lookup per TTL, nothing per request.
+ *
+ * Cross-instance invalidation is TTL-bounded: CRUD invalidates
+ * in-process; other pods converge within POLICY_CACHE_TTL_MS.
+ *
+ * Fail-closed: a referenced name that isn't in the tenant's table
+ * resolves to a synthetic enforce deny-all set (metric + warn log).
+ * A DISABLED set, by contrast, is skipped silently — turning a set off
+ * is an operator action, not a dangling reference.
+ */
+@Injectable()
+export class PolicyResolverService {
+  private readonly logger = new Logger(PolicyResolverService.name);
+  private readonly cache: LRUCache<string, TenantPolicySnapshot>;
+  private readonly inFlight = new Map<string, Promise<TenantPolicySnapshot>>();
+  private readonly ttlMs: number;
+  private readonly enabled: boolean;
+  private readonly forceReportOnly: boolean;
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly metrics: MetricsService,
+    config: ConfigService,
+  ) {
+    this.enabled = envFlagEnabled(config.get<string>('ABAC_ENABLED'));
+    this.forceReportOnly = envFlagEnabled(
+      config.get<string>('ABAC_FORCE_REPORT_ONLY'),
+    );
+    const ttl = parseInt(config.get<string>('POLICY_CACHE_TTL_MS', '60000'), 10);
+    this.ttlMs = Number.isFinite(ttl) && ttl >= 0 ? ttl : 60_000;
+    const cap = parseInt(config.get<string>('POLICY_CACHE_CAP', '500'), 10);
+    this.cache = new LRUCache(Number.isFinite(cap) && cap > 0 ? cap : 500);
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /** Drop the tenant snapshot after a policy/binding mutation. */
+  invalidate(companyId: string): void {
+    this.cache.delete(companyId);
+  }
+
+  /**
+   * Resolve the request's policy context. Returns null when ABAC is off
+   * or the key references no policy sets — the null short-circuits every
+   * enforcement point to pre-ABAC behavior.
+   */
+  async contextFor(
+    companyId: string,
+    keyHash: string,
+    claimNames?: readonly string[],
+  ): Promise<PolicyContext | null> {
+    if (!this.enabled) return null;
+    const snap = await this.snapshot(companyId);
+
+    const names: string[] = [];
+    const seen = new Set<string>();
+    const push = (n: string) => {
+      if (!seen.has(n) && names.length < MAX_SETS_PER_KEY) {
+        seen.add(n);
+        names.push(n);
+      }
+    };
+    for (const n of snap.bindings.get(`key:${keyHash}`) ?? []) push(n);
+    // JWT keys without a jti hash to `jwt:<sub>` — honour bindings
+    // written against that stable subject too.
+    if (keyHash.startsWith('jwt:')) {
+      for (const n of snap.bindings.get(keyHash) ?? []) push(n);
+    }
+    for (const n of claimNames ?? []) push(n);
+    if (names.length === 0) return null;
+
+    const sets: CompiledPolicySet[] = [];
+    let resolutionError = false;
+    for (const name of names) {
+      const compiled = snap.sets.get(name);
+      if (compiled) {
+        sets.push(compiled);
+      } else if (!snap.knownNames.has(name)) {
+        resolutionError = true;
+        sets.push(denyAllSet(name));
+        this.metrics.countPolicyResolutionError();
+        this.logger.warn(
+          `Key ${keyHash.slice(0, 16)}… references unknown policy set '${name}' — failing closed`,
+        );
+      }
+      // known but disabled → skipped
+    }
+    if (sets.length === 0) return null;
+
+    return {
+      companyId,
+      keyHash,
+      sets,
+      forceReportOnly: this.forceReportOnly,
+      resolutionError,
+    };
+  }
+
+  private async snapshot(companyId: string): Promise<TenantPolicySnapshot> {
+    const cached = this.cache.get(companyId);
+    if (cached && Date.now() - cached.loadedAt < this.ttlMs) return cached;
+
+    let p = this.inFlight.get(companyId);
+    if (!p) {
+      p = this.loadFresh(companyId)
+        .then((snap) => {
+          this.cache.set(companyId, snap);
+          return snap;
+        })
+        .finally(() => this.inFlight.delete(companyId));
+      this.inFlight.set(companyId, p);
+    }
+    // A stale-but-present snapshot is served while a refresh is in
+    // flight only if the load fails — otherwise wait for the fresh one
+    // (policy changes should apply promptly after TTL).
+    try {
+      return await p;
+    } catch (e) {
+      if (cached) {
+        this.logger.warn(
+          `Policy snapshot refresh failed for ${companyId}, serving stale: ${(e as Error).message}`,
+        );
+        return cached;
+      }
+      throw e;
+    }
+  }
+
+  private async loadFresh(companyId: string): Promise<TenantPolicySnapshot> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [policyRows] = await db.query<[any[]]>(
+        `SELECT name, mode, document FROM access_policy`,
+      );
+      const [bindingRows] = await db.query<[any[]]>(
+        `SELECT subject, policyNames FROM policy_binding`,
+      );
+      const sets = new Map<string, CompiledPolicySet>();
+      const knownNames = new Set<string>();
+      for (const r of (policyRows as any[]) ?? []) {
+        const name = String(r.name);
+        knownNames.add(name);
+        const compiled = compilePolicySet(r.document as PolicyDocument);
+        if (compiled) sets.set(name, compiled);
+      }
+      const bindings = new Map<string, string[]>();
+      for (const r of (bindingRows as any[]) ?? []) {
+        bindings.set(
+          String(r.subject),
+          ((r.policyNames as string[]) ?? []).map(String),
+        );
+      }
+      return { sets, knownNames, bindings, loadedAt: Date.now() };
+    });
+  }
+}

--- a/src/policy/policy-store.service.ts
+++ b/src/policy/policy-store.service.ts
@@ -1,0 +1,306 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { PolicyResolverService } from './policy-resolver.service';
+import {
+  MAX_SETS_PER_KEY,
+  PolicyDocument,
+  PolicyDocumentSchema,
+  PolicyMode,
+} from './policy.types';
+
+export interface StoredPolicySet {
+  name: string;
+  mode: PolicyMode;
+  document: PolicyDocument;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  updatedBy: string;
+  attachedSubjects: string[];
+}
+
+export interface StoredBinding {
+  subject: string;
+  policyNames: string[];
+  updatedAt: string;
+}
+
+const SUBJECT_SHAPE = /^(key|jwt):[A-Za-z0-9:_-]{1,128}$/;
+
+/**
+ * CRUD over the per-tenant ABAC tables (migration 0056). Writes are
+ * admin-only and run on the root pool; every mutation invalidates the
+ * tenant's resolver snapshot in-process (other instances converge
+ * within POLICY_CACHE_TTL_MS).
+ *
+ * The `mode` column mirrors document.mode so list queries never parse
+ * documents; the document itself is the source of truth and the two
+ * are written together.
+ */
+@Injectable()
+export class PolicyStoreService {
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly resolver: PolicyResolverService,
+  ) {}
+
+  /** Validate an untrusted document body. Throws 400 with zod issues. */
+  parseDocument(body: unknown): PolicyDocument {
+    const parsed = PolicyDocumentSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new BadRequestException({
+        error: 'invalid_policy_document',
+        issues: parsed.error.issues.map((i) => ({
+          path: i.path.join('.'),
+          message: i.message,
+        })),
+      });
+    }
+    return parsed.data;
+  }
+
+  async list(companyId: string): Promise<StoredPolicySet[]> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT * FROM access_policy ORDER BY name`,
+      );
+      const [bindings] = await db.query<[any[]]>(
+        `SELECT subject, policyNames FROM policy_binding`,
+      );
+      const attachedBy = new Map<string, string[]>();
+      for (const b of (bindings as any[]) ?? []) {
+        for (const name of (b.policyNames as string[]) ?? []) {
+          const list = attachedBy.get(name) ?? [];
+          list.push(String(b.subject));
+          attachedBy.set(name, list);
+        }
+      }
+      return ((rows as any[]) ?? []).map((r) => mapRow(r, attachedBy));
+    });
+  }
+
+  async get(companyId: string, name: string): Promise<StoredPolicySet> {
+    const found = (await this.list(companyId)).find((s) => s.name === name);
+    if (!found) {
+      throw new NotFoundException(`Policy set '${name}' not found`);
+    }
+    return found;
+  }
+
+  async create(
+    companyId: string,
+    body: unknown,
+    updatedBy: string,
+  ): Promise<StoredPolicySet> {
+    const doc = this.parseDocument(body);
+    await this.surreal.withCompany(companyId, async (db) => {
+      try {
+        await db.query(
+          `CREATE access_policy CONTENT {
+             name: $name, mode: $mode, document: $document,
+             version: 1, updatedBy: $updatedBy
+           }`,
+          { name: doc.name, mode: doc.mode, document: doc, updatedBy },
+        );
+      } catch (e) {
+        if (/index|unique|exists/i.test((e as Error).message)) {
+          throw new ConflictException(`Policy set '${doc.name}' already exists`);
+        }
+        throw e;
+      }
+    });
+    this.resolver.invalidate(companyId);
+    return this.get(companyId, doc.name);
+  }
+
+  /**
+   * Whole-document replace with optimistic concurrency. The document's
+   * name must match the path name — renames are deliberately not
+   * supported (bindings and JWT claims reference sets by name).
+   */
+  async update(
+    companyId: string,
+    name: string,
+    change: { body: unknown; expectedVersion: number; updatedBy: string },
+  ): Promise<StoredPolicySet> {
+    const { body, expectedVersion, updatedBy } = change;
+    const doc = this.parseDocument(body);
+    if (doc.name !== name) {
+      throw new BadRequestException(
+        `Policy set name is immutable ('${name}' → '${doc.name}' not allowed)`,
+      );
+    }
+    const current = await this.get(companyId, name);
+    if (current.version !== expectedVersion) {
+      throw new ConflictException({
+        error: 'version_conflict',
+        current,
+      });
+    }
+    await this.surreal.withCompany(companyId, async (db) => {
+      const [updated] = await db.query<[any[]]>(
+        `UPDATE access_policy SET
+           mode = $mode, document = $document, version = version + 1,
+           updatedAt = time::now(), updatedBy = $updatedBy
+         WHERE name = $name AND version = $version RETURN AFTER`,
+        {
+          name,
+          mode: doc.mode,
+          document: doc,
+          version: expectedVersion,
+          updatedBy,
+        },
+      );
+      if (((updated as any[]) ?? []).length === 0) {
+        // Raced with a concurrent writer between our read and write.
+        throw new ConflictException({ error: 'version_conflict', current });
+      }
+    });
+    this.resolver.invalidate(companyId);
+    return this.get(companyId, name);
+  }
+
+  async remove(companyId: string, name: string): Promise<void> {
+    const current = await this.get(companyId, name);
+    if (current.attachedSubjects.length > 0) {
+      throw new ConflictException({
+        error: 'policy_attached',
+        message: `Policy set '${name}' is attached to ${current.attachedSubjects.length} key(s) — detach first`,
+        attachedSubjects: current.attachedSubjects,
+      });
+    }
+    await this.surreal.withCompany(companyId, async (db) => {
+      await db.query(`DELETE access_policy WHERE name = $name`, { name });
+    });
+    this.resolver.invalidate(companyId);
+  }
+
+  async listBindings(companyId: string): Promise<StoredBinding[]> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT * FROM policy_binding ORDER BY subject`,
+      );
+      return ((rows as any[]) ?? []).map((r) => ({
+        subject: String(r.subject),
+        policyNames: ((r.policyNames as string[]) ?? []).map(String),
+        updatedAt: String(r.updatedAt ?? ''),
+      }));
+    });
+  }
+
+  /**
+   * Attach/detach one policy set for a batch of subjects. Subjects are
+   * `key:<keyHash>` (static keys) or `jwt:<sub>` (JWT keys without a
+   * jti). Attaching validates the set exists — this is what makes the
+   * resolver's fail-closed branch unreachable through our own CRUD.
+   */
+  async updateAttachments(
+    companyId: string,
+    name: string,
+    changes: { attach: string[]; detach: string[] },
+  ): Promise<StoredPolicySet> {
+    const { attach, detach } = changes;
+    await this.get(companyId, name); // 404 when the set doesn't exist
+    for (const s of [...attach, ...detach]) {
+      if (!SUBJECT_SHAPE.test(s)) {
+        throw new BadRequestException(`Invalid subject '${s}'`);
+      }
+    }
+    await this.surreal.withCompany(companyId, async (db) => {
+      for (const subject of attach) {
+        const [rows] = await db.query<[any[]]>(
+          `SELECT policyNames FROM policy_binding WHERE subject = $subject`,
+          { subject },
+        );
+        const existing: string[] =
+          ((rows as any[])?.[0]?.policyNames as string[]) ?? [];
+        if (existing.includes(name)) continue;
+        if (existing.length >= MAX_SETS_PER_KEY) {
+          throw new BadRequestException(
+            `Subject '${subject}' already carries ${existing.length} policy sets (max ${MAX_SETS_PER_KEY})`,
+          );
+        }
+        if (rows && (rows as any[]).length > 0) {
+          await db.query(
+            `UPDATE policy_binding SET policyNames += $name,
+               updatedAt = time::now() WHERE subject = $subject`,
+            { subject, name },
+          );
+        } else {
+          await db.query(
+            `CREATE policy_binding CONTENT {
+               subject: $subject, policyNames: [$name]
+             }`,
+            { subject, name },
+          );
+        }
+      }
+      for (const subject of detach) {
+        await db.query(
+          `UPDATE policy_binding SET policyNames -= $name,
+             updatedAt = time::now() WHERE subject = $subject`,
+          { subject, name },
+        );
+        // Drop empty bindings so listBindings stays tidy.
+        await db.query(
+          `DELETE policy_binding WHERE subject = $subject AND array::len(policyNames) = 0`,
+          { subject },
+        );
+      }
+    });
+    this.resolver.invalidate(companyId);
+    return this.get(companyId, name);
+  }
+
+  /**
+   * Load the policy-relevant view of one fact for the explain endpoint
+   * (controllers must not touch src/db directly — layer purity).
+   */
+  async loadFactForExplain(
+    companyId: string,
+    factIdRaw: string,
+  ): Promise<{
+    predicate: string;
+    source?: unknown;
+    trustSnapshot?: { authority?: number } | null;
+    corroboration?: { count?: number } | null;
+    userId?: string | null;
+  }> {
+    const id = factIdRaw.startsWith('knowledge_fact:')
+      ? factIdRaw.slice('knowledge_fact:'.length)
+      : factIdRaw;
+    if (!FACT_ID_SHAPE.test(id)) {
+      throw new BadRequestException(`Malformed factId '${factIdRaw}'`);
+    }
+    const row = await this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT predicate, source, trustSnapshot, corroboration, userId
+           FROM type::record('knowledge_fact', $id) LIMIT 1`,
+        { id },
+      );
+      return ((rows as any[]) ?? [])[0];
+    });
+    if (!row) throw new NotFoundException(`Fact ${factIdRaw} not found`);
+    return row;
+  }
+}
+
+const FACT_ID_SHAPE = /^[A-Za-z0-9_]+$/;
+
+function mapRow(r: any, attachedBy: Map<string, string[]>): StoredPolicySet {
+  return {
+    name: String(r.name),
+    mode: String(r.mode) as PolicyMode,
+    document: r.document as PolicyDocument,
+    version: Number(r.version ?? 1),
+    createdAt: String(r.createdAt ?? ''),
+    updatedAt: String(r.updatedAt ?? ''),
+    updatedBy: String(r.updatedBy ?? ''),
+    attachedSubjects: attachedBy.get(String(r.name)) ?? [],
+  };
+}

--- a/src/policy/policy.module.ts
+++ b/src/policy/policy.module.ts
@@ -1,0 +1,27 @@
+import { Global, Module } from '@nestjs/common';
+import { PolicyDecisionSink } from './policy-decision.sink';
+import { PolicyGateService } from './policy-gate.service';
+import { PolicyResolverService } from './policy-resolver.service';
+import { PolicyStoreService } from './policy-store.service';
+
+/**
+ * ABAC wiring. Global because the resolver is consumed by ApiKeyGuard
+ * (every guarded request) and the sink/store by admin + read surfaces
+ * across modules — mirroring AuthModule/MetricsModule.
+ */
+@Global()
+@Module({
+  providers: [
+    PolicyResolverService,
+    PolicyStoreService,
+    PolicyDecisionSink,
+    PolicyGateService,
+  ],
+  exports: [
+    PolicyResolverService,
+    PolicyStoreService,
+    PolicyDecisionSink,
+    PolicyGateService,
+  ],
+})
+export class PolicyModule {}

--- a/src/policy/policy.types.ts
+++ b/src/policy/policy.types.ts
@@ -1,0 +1,432 @@
+import { z } from 'zod';
+
+/**
+ * ABAC policy model — the tenant-authored policy document, its zod
+ * validation, and the attribute vocabulary rules can match on.
+ *
+ * A policy set carries ordered-independent rules evaluated
+ * deny-overrides: explicit deny > explicit allow > the set's default
+ * posture (separately for actions and reads). Multiple sets attached to
+ * one key combine most-restrictive: the final verdict is ALLOW only if
+ * every enforce-mode set allows. report_only sets are evaluated for the
+ * decision stream but never block.
+ *
+ * The document is stored verbatim in `access_policy.document` (FLEXIBLE)
+ * — SurrealDB does not validate it; PolicyDocumentSchema at CRUD time is
+ * the sole gate, so keep it strict.
+ */
+
+export type PolicyEffect = 'allow' | 'deny';
+export type PolicyRuleKind = 'action' | 'source';
+export type PolicyMode = 'report_only' | 'enforce' | 'disabled';
+export type PolicyPosture = 'allow' | 'deny';
+/** would_deny = a report_only (or force-demoted) set would have blocked. */
+export type PolicyDecision = 'allow' | 'deny' | 'would_deny';
+export type ActionKind = 'read' | 'write' | 'admin';
+
+export type MatchOp =
+  | 'eq'
+  | 'in'
+  | 'prefix'
+  | 'gte'
+  | 'gt'
+  | 'lte'
+  | 'lt'
+  | 'exists'
+  | 'not_exists';
+
+/**
+ * Static attribute vocabulary. `source.meta.<key>` is the one dynamic
+ * family (operator-supplied document metadata projected onto facts).
+ * Everything here is readable straight off a retrieved FactRow — the
+ * search legs already SELECT source/trustSnapshot/corroboration, so
+ * row evaluation costs no extra queries.
+ */
+export const POLICY_ATTRIBUTES: Record<
+  string,
+  { type: 'string' | 'number' | 'boolean'; ops: MatchOp[]; description: string }
+> = {
+  predicate: {
+    type: 'string',
+    ops: ['eq', 'in', 'prefix'],
+    description: 'Fact predicate id (tenant predicate registry)',
+  },
+  piiClass: {
+    type: 'string',
+    ops: ['eq', 'in'],
+    description: 'PII class of the predicate (none/identifier/behavioral/text/sensitive)',
+  },
+  'source.vertical': {
+    type: 'string',
+    ops: ['eq', 'in'],
+    description: 'Ingest vertical the fact arrived through',
+  },
+  'source.recorder': {
+    type: 'string',
+    ops: ['eq', 'in'],
+    description: 'Recorder / connector that wrote the fact',
+  },
+  'source.documentId': {
+    type: 'string',
+    ops: ['eq', 'in'],
+    description: 'Originating source_document id (doc-pipeline facts)',
+  },
+  'source.originKey': {
+    type: 'string',
+    ops: ['eq', 'in', 'prefix'],
+    description: 'Origin identity key (doc:<hash> or vertical:recorder)',
+  },
+  'trust.authority': {
+    type: 'number',
+    ops: ['gte', 'gt', 'lte', 'lt'],
+    description: 'Write-time source authority (0..1, trustSnapshot)',
+  },
+  'trust.declaredTrust': {
+    type: 'number',
+    ops: ['gte', 'gt', 'lte', 'lt'],
+    description: 'Declared source trust at write time (0..1)',
+  },
+  'trust.learnedTrust': {
+    type: 'number',
+    ops: ['gte', 'gt', 'lte', 'lt'],
+    description: 'Learned source trust at write time (0..1)',
+  },
+  'corroboration.count': {
+    type: 'number',
+    ops: ['gte', 'gt', 'lte', 'lt'],
+    description: 'Distinct corroborating origins',
+  },
+  'provenance.purged': {
+    type: 'boolean',
+    ops: ['eq'],
+    description: 'Originating document text has been erased',
+  },
+  userId: {
+    type: 'string',
+    ops: ['eq', 'in', 'exists', 'not_exists'],
+    description: 'Per-user memory scope owner (0055); absent = tenant-global',
+  },
+};
+
+const SOURCE_META_ATTR = /^source\.meta\.[a-z][a-z0-9_]{0,63}$/;
+const META_ATTR_OPS: MatchOp[] = ['eq', 'in', 'exists', 'not_exists'];
+
+export function attributeSpec(
+  attr: string,
+): { type: 'string' | 'number' | 'boolean'; ops: MatchOp[] } | null {
+  const fixed = POLICY_ATTRIBUTES[attr];
+  if (fixed) return fixed;
+  if (SOURCE_META_ATTR.test(attr)) return { type: 'string', ops: META_ATTR_OPS };
+  return null;
+}
+
+export const POLICY_MACROS = ['@readonly', '@write', '@all'] as const;
+export type PolicyMacro = (typeof POLICY_MACROS)[number];
+
+// ── zod document schema ─────────────────────────────────────────────────
+
+const RULE_ID = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+const SET_NAME = /^[a-z][a-z0-9_-]{1,63}$/;
+const ACTION_NAME = /^(@[a-z]+|[a-z][a-z0-9_.-]{0,127})$/;
+
+export const MAX_RULES_PER_SET = 64;
+export const MAX_VALUES_PER_LIST = 128;
+export const MAX_DOCUMENT_BYTES = 32 * 1024;
+export const MAX_SETS_PER_KEY = 8;
+
+const MatchConditionSchema = z
+  .object({
+    attr: z.string().max(96),
+    op: z.enum([
+      'eq',
+      'in',
+      'prefix',
+      'gte',
+      'gt',
+      'lte',
+      'lt',
+      'exists',
+      'not_exists',
+    ]),
+    value: z
+      .union([
+        z.string().max(256),
+        z.number().finite(),
+        z.boolean(),
+        z.array(z.string().max(256)).min(1).max(MAX_VALUES_PER_LIST),
+      ])
+      .optional(),
+  })
+  .superRefine((cond, ctx) => {
+    const spec = attributeSpec(cond.attr);
+    if (!spec) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Unknown attribute '${cond.attr}'`,
+        path: ['attr'],
+      });
+      return;
+    }
+    if (!spec.ops.includes(cond.op)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Operator '${cond.op}' not valid for '${cond.attr}' (allowed: ${spec.ops.join(', ')})`,
+        path: ['op'],
+      });
+      return;
+    }
+    if (cond.op === 'exists' || cond.op === 'not_exists') {
+      if (cond.value !== undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Operator '${cond.op}' takes no value`,
+          path: ['value'],
+        });
+      }
+      return;
+    }
+    if (cond.value === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Operator '${cond.op}' requires a value`,
+        path: ['value'],
+      });
+      return;
+    }
+    const v = cond.value;
+    const scalarOk =
+      spec.type === 'number'
+        ? typeof v === 'number'
+        : spec.type === 'boolean'
+          ? typeof v === 'boolean'
+          : typeof v === 'string';
+    if (cond.op === 'in') {
+      if (!Array.isArray(v)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Operator 'in' requires an array of strings`,
+          path: ['value'],
+        });
+      } else if (spec.type !== 'string') {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Operator 'in' only applies to string attributes`,
+          path: ['value'],
+        });
+      }
+      return;
+    }
+    if (Array.isArray(v) || !scalarOk) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Value type does not match attribute type '${spec.type}'`,
+        path: ['value'],
+      });
+    }
+  });
+
+const PolicyRuleSchema = z
+  .object({
+    id: z.string().regex(RULE_ID),
+    effect: z.enum(['allow', 'deny']),
+    kind: z.enum(['action', 'source']),
+    enabled: z.boolean().default(true),
+    description: z.string().max(300).optional(),
+    actions: z
+      .array(z.string().regex(ACTION_NAME))
+      .min(1)
+      .max(MAX_VALUES_PER_LIST)
+      .optional(),
+    match: z.array(MatchConditionSchema).min(1).max(16).optional(),
+  })
+  .superRefine((rule, ctx) => {
+    if (rule.kind === 'action') {
+      if (!rule.actions) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `kind=action rule requires 'actions'`,
+          path: ['actions'],
+        });
+      }
+      if (rule.match) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `kind=action rule cannot carry 'match'`,
+          path: ['match'],
+        });
+      }
+      for (const a of rule.actions ?? []) {
+        if (a.startsWith('@') && !POLICY_MACROS.includes(a as PolicyMacro)) {
+          ctx.addIssue({
+            code: 'custom',
+            message: `Unknown macro '${a}' (known: ${POLICY_MACROS.join(', ')})`,
+            path: ['actions'],
+          });
+        }
+      }
+    } else {
+      if (!rule.match) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `kind=source rule requires 'match'`,
+          path: ['match'],
+        });
+      }
+      if (rule.actions) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `kind=source rule cannot carry 'actions'`,
+          path: ['actions'],
+        });
+      }
+    }
+  });
+
+export const PolicyDocumentSchema = z
+  .object({
+    name: z.string().regex(SET_NAME),
+    description: z.string().max(500).default(''),
+    posture: z.object({
+      actions: z.enum(['allow', 'deny']),
+      reads: z.enum(['allow', 'deny']),
+    }),
+    mode: z.enum(['report_only', 'enforce', 'disabled']),
+    activeFrom: z.iso.datetime().nullish(),
+    activeUntil: z.iso.datetime().nullish(),
+    rules: z.array(PolicyRuleSchema).max(MAX_RULES_PER_SET).default([]),
+  })
+  .superRefine((doc, ctx) => {
+    const ids = new Set<string>();
+    for (const r of doc.rules) {
+      if (ids.has(r.id)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Duplicate rule id '${r.id}'`,
+          path: ['rules'],
+        });
+      }
+      ids.add(r.id);
+    }
+    if (JSON.stringify(doc).length > MAX_DOCUMENT_BYTES) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Policy document exceeds ${MAX_DOCUMENT_BYTES} bytes`,
+      });
+    }
+  });
+
+export type MatchCondition = z.infer<typeof MatchConditionSchema>;
+export type PolicyRule = z.infer<typeof PolicyRuleSchema>;
+export type PolicyDocument = z.infer<typeof PolicyDocumentSchema>;
+
+// ── Evaluation shapes ───────────────────────────────────────────────────
+
+/**
+ * Normalized per-row attribute view. Built once per row from a FactRow
+ * (or any fact-shaped record) — the engine never touches raw rows.
+ */
+export interface PolicyRowView {
+  predicate: string;
+  piiClass: string;
+  source?: Record<string, unknown> | null;
+  trustSnapshot?: {
+    authority?: number;
+    declaredTrust?: number;
+    learnedTrust?: number;
+  } | null;
+  corroboration?: { count?: number } | null;
+  userId?: string | null;
+}
+
+export interface CompiledActionRule {
+  id: string;
+  effect: PolicyEffect;
+  /** Exact action names, macros pre-split. */
+  names: Set<string>;
+  macros: Set<PolicyMacro>;
+}
+
+export interface CompiledSourceRule {
+  id: string;
+  effect: PolicyEffect;
+  conditions: CompiledCondition[];
+}
+
+export interface CompiledCondition {
+  attr: string;
+  op: MatchOp;
+  /** Pre-normalized: Set for eq/in on strings, scalar otherwise. */
+  expected: Set<string> | string | number | boolean | null;
+  matches(view: PolicyRowView): boolean;
+  /** Actual value read from the view — for explain traces. */
+  actual(view: PolicyRowView): unknown;
+}
+
+export interface CompiledPolicySet {
+  name: string;
+  mode: Exclude<PolicyMode, 'disabled'>;
+  posture: { actions: PolicyPosture; reads: PolicyPosture };
+  /** Deny rules first — evaluation order is fixed by effect, not array order. */
+  actionDeny: CompiledActionRule[];
+  actionAllow: CompiledActionRule[];
+  sourceDeny: CompiledSourceRule[];
+  sourceAllow: CompiledSourceRule[];
+  document: PolicyDocument;
+}
+
+/**
+ * Per-request policy context attached to req.brainAuth. null context
+ * (no ABAC / no sets referenced) short-circuits every enforcement
+ * point to today's exact behavior.
+ */
+export interface PolicyContext {
+  companyId: string;
+  keyHash: string;
+  sets: CompiledPolicySet[];
+  /** ABAC_FORCE_REPORT_ONLY — treat every enforce set as report_only. */
+  forceReportOnly: boolean;
+  /**
+   * Fail-closed sentinel: a referenced set name did not resolve. The
+   * resolver injects a synthetic enforce deny-all set; this flag marks
+   * the condition for logs/metrics.
+   */
+  resolutionError: boolean;
+}
+
+/** Verdict of one set for one action/row, before cross-set combination. */
+export interface SetVerdict {
+  policySet: string;
+  mode: Exclude<PolicyMode, 'disabled'>;
+  verdict: PolicyEffect;
+  /** Rule that decided it; null = default posture. */
+  ruleId: string | null;
+}
+
+export interface PolicyEvaluation {
+  /** Final combined decision across enforce-mode sets. */
+  decision: PolicyDecision;
+  /** Per-set verdicts (enforce and report_only alike). */
+  verdicts: SetVerdict[];
+}
+
+/** Explain trace, DecisionLog-style: additive, per-rule field detail. */
+export interface RuleTrace {
+  ruleId: string;
+  effect: PolicyEffect;
+  matched: boolean;
+  fields?: Array<{
+    attr: string;
+    op: MatchOp;
+    expected: unknown;
+    actual: unknown;
+    matched: boolean;
+  }>;
+}
+
+export interface SetTrace {
+  policySet: string;
+  mode: Exclude<PolicyMode, 'disabled'>;
+  verdict: PolicyEffect;
+  decidedBy: string | 'posture';
+  rules: RuleTrace[];
+}

--- a/src/policy/row-filter.ts
+++ b/src/policy/row-filter.ts
@@ -1,0 +1,144 @@
+import { policyFor } from '../ingest/conflict-resolver';
+import {
+  getPolicyContext,
+  getPolicyRowRecorder,
+} from '../common/request-context';
+import { evaluateRow, toRowView } from './policy-engine';
+import { PolicyContext } from './policy.types';
+
+/**
+ * Row-level enforcement seam shared by every read surface (search
+ * fusion/backfill/edge-expansion, graph_retrieve, competing facts,
+ * entity profile/timeline, code-memory recall).
+ *
+ * Two gates, in order:
+ *   1. The predicate scope gate (requiresScope, e.g. brain:read_pii) —
+ *      pre-ABAC behavior, always on, never weakened by a policy.
+ *   2. The ABAC row verdict — only when the request carries a
+ *      PolicyContext (from ApiKeyGuard via AsyncLocalStorage; an
+ *      explicit `policy` option overrides for simulation).
+ *
+ * Decision telemetry is aggregated per filter instance (= per pipeline
+ * invocation) and handed to the request's recorder on finish() — the
+ * pure module stays DI-free, PolicyGateService owns sink + metrics.
+ */
+
+/** Minimal fact shape the filter needs — FactRow and friends satisfy it. */
+export interface PolicyFilterableRow {
+  id?: unknown;
+  predicate: string;
+  source?: unknown;
+  trustSnapshot?: {
+    authority?: number;
+    declaredTrust?: number;
+    learnedTrust?: number;
+  } | null;
+  corroboration?: { count?: number } | null;
+  userId?: string | null;
+}
+
+export interface RowDecisionSummary {
+  /** Which read surface produced this batch (search, graph_retrieve, …). */
+  surface: string;
+  /** Rows that reached the policy gate (after the scope gate). */
+  total: number;
+  evalSeconds: number;
+  perSet: Array<{
+    policySet: string;
+    mode: 'report_only' | 'enforce';
+    denied: number;
+    wouldDeny: number;
+    ruleIds: string[];
+    sampleFactIds: string[];
+    samplePredicates: string[];
+  }>;
+}
+
+const SAMPLE_CAP = 3;
+
+export interface RowPolicyFilter {
+  /** True = row stays. False only on an enforced deny. */
+  filter(row: PolicyFilterableRow): boolean;
+  /** Emit the aggregated decision summary (no-op with no policy/rows). */
+  finish(): void;
+  /** Whether a policy context is active (callers can skip work). */
+  readonly active: boolean;
+}
+
+export function makeRowPolicyFilter(opts: {
+  callerScopes: readonly string[];
+  surface: string;
+  /**
+   * Explicit context override (simulation). Omit to read the request's
+   * context; pass null to force policy-off while keeping the scope gate.
+   */
+  policy?: PolicyContext | null;
+}): RowPolicyFilter {
+  const ctx = opts.policy !== undefined ? opts.policy : getPolicyContext();
+  const scopes = opts.callerScopes;
+
+  type SetStats = RowDecisionSummary['perSet'][number];
+  const perSet = new Map<string, SetStats>();
+  let total = 0;
+  let evalNs = 0n;
+
+  const filter = (row: PolicyFilterableRow): boolean => {
+    const predicatePolicy = policyFor(row.predicate);
+    if (
+      predicatePolicy.requiresScope &&
+      !scopes.includes(predicatePolicy.requiresScope)
+    ) {
+      return false;
+    }
+    if (!ctx) return true;
+
+    const t0 = process.hrtime.bigint();
+    const view = toRowView(row, (p) => policyFor(p).piiClass);
+    const evaluation = evaluateRow(ctx, view);
+    evalNs += process.hrtime.bigint() - t0;
+    total += 1;
+
+    for (const v of evaluation.verdicts) {
+      if (v.verdict !== 'deny') continue;
+      let stats = perSet.get(v.policySet);
+      if (!stats) {
+        stats = {
+          policySet: v.policySet,
+          mode: v.mode,
+          denied: 0,
+          wouldDeny: 0,
+          ruleIds: [],
+          sampleFactIds: [],
+          samplePredicates: [],
+        };
+        perSet.set(v.policySet, stats);
+      }
+      const enforced = v.mode === 'enforce' && !ctx.forceReportOnly;
+      if (enforced) stats.denied += 1;
+      else stats.wouldDeny += 1;
+      const ruleId = v.ruleId ?? 'posture';
+      if (!stats.ruleIds.includes(ruleId) && stats.ruleIds.length < SAMPLE_CAP) {
+        stats.ruleIds.push(ruleId);
+      }
+      if (stats.sampleFactIds.length < SAMPLE_CAP && row.id !== undefined) {
+        stats.sampleFactIds.push(String(row.id));
+        stats.samplePredicates.push(row.predicate);
+      }
+    }
+
+    return evaluation.decision !== 'deny';
+  };
+
+  const finish = (): void => {
+    if (!ctx || total === 0) return;
+    const summary: RowDecisionSummary = {
+      surface: opts.surface,
+      total,
+      evalSeconds: Number(evalNs) / 1e9,
+      perSet: [...perSet.values()],
+    };
+    getPolicyRowRecorder()?.(summary);
+  };
+
+  return { filter, finish, active: ctx !== null && ctx !== undefined };
+}

--- a/src/search/internals/backfill.ts
+++ b/src/search/internals/backfill.ts
@@ -59,7 +59,7 @@ export async function backfillEntityFacts({
           SELECT
             id, entityId, predicate, object, confidence,
             validFrom, validUntil, recordedAt, retractedAt, status, source,
-            trustSnapshot, corroboration
+            trustSnapshot, corroboration, userId
           FROM knowledge_fact
           WHERE entityId = $parent.id
             ${baseWhere.sql}

--- a/src/search/internals/edge-expansion.ts
+++ b/src/search/internals/edge-expansion.ts
@@ -223,7 +223,7 @@ export async function expandViaEdges({
         SELECT
           id, entityId, predicate, object, confidence,
           validFrom, validUntil, recordedAt, retractedAt, status, source,
-        trustSnapshot, corroboration,
+        trustSnapshot, corroboration, userId,
           entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity
         FROM knowledge_fact
         WHERE entityId INSIDE $entityIds

--- a/src/search/internals/graph-retrieve-db.ts
+++ b/src/search/internals/graph-retrieve-db.ts
@@ -223,10 +223,21 @@ export async function fetchFactsForEntities({
     validUntil?: string;
     status: string;
     recordedAt: string;
+    source?: unknown;
+    trustSnapshot?: {
+      authority?: number;
+      declaredTrust?: number;
+      learnedTrust?: number;
+    } | null;
+    corroboration?: { count?: number } | null;
   };
+  // source/trustSnapshot/corroboration ride along for the ABAC row
+  // filter (policy/row-filter.ts) — internal only, assembleGraphHits
+  // never surfaces them in the response.
   const [rows] = await db.query<[FactSelect[]]>(
     `SELECT id, entityId, predicate, object, confidence,
-            validFrom, validUntil, status, recordedAt
+            validFrom, validUntil, status, recordedAt,
+            source, trustSnapshot, corroboration
        FROM knowledge_fact
       WHERE ${where}${predicateClause}
       ORDER BY recordedAt DESC
@@ -247,6 +258,13 @@ export async function fetchFactsForEntities({
       ...(r.validUntil ? { validUntil: r.validUntil } : {}),
       status: r.status,
       recordedAt: r.recordedAt,
+      ...(r.source !== undefined ? { source: r.source } : {}),
+      ...(r.trustSnapshot !== undefined && r.trustSnapshot !== null
+        ? { trustSnapshot: r.trustSnapshot }
+        : {}),
+      ...(r.corroboration !== undefined && r.corroboration !== null
+        ? { corroboration: r.corroboration }
+        : {}),
     });
     out.set(eid, list);
   }

--- a/src/search/internals/graph-retrieve.ts
+++ b/src/search/internals/graph-retrieve.ts
@@ -37,6 +37,18 @@ export interface GraphFactRow {
   validUntil?: string;
   status: string;
   recordedAt?: string;
+  /**
+   * Provenance payload for the ABAC row filter (policy/row-filter.ts).
+   * Internal to retrieval — assembleGraphHits never copies these into
+   * the response surface.
+   */
+  source?: unknown;
+  trustSnapshot?: {
+    authority?: number;
+    declaredTrust?: number;
+    learnedTrust?: number;
+  } | null;
+  corroboration?: { count?: number } | null;
 }
 
 import type { ScoreBreakdown } from './types';

--- a/src/search/internals/legs.ts
+++ b/src/search/internals/legs.ts
@@ -53,7 +53,7 @@ export async function runVectorLeg({
       SELECT
         id, entityId, predicate, object, confidence,
         validFrom, validUntil, recordedAt, retractedAt, status, source,
-        trustSnapshot, corroboration,
+        trustSnapshot, corroboration, userId,
         entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity,
         math::max([
           vector::similarity::cosine(embedding, $q),
@@ -99,7 +99,7 @@ async function runVectorLegKnn({
   const projection = `
         id, entityId, predicate, object, confidence,
         validFrom, validUntil, recordedAt, retractedAt, status, source,
-        trustSnapshot, corroboration,
+        trustSnapshot, corroboration, userId,
         entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity`;
   // `<|K,EF|>` takes literals, not params — kOver/ef are validated ints.
   const [mainRows, altRows] = await Promise.all([
@@ -219,7 +219,7 @@ export async function runLexicalLeg({
       SELECT
         id, entityId, predicate, object, confidence,
         validFrom, validUntil, recordedAt, retractedAt, status, source,
-        trustSnapshot, corroboration,
+        trustSnapshot, corroboration, userId,
         entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity,
         math::max([search::score(1), search::score(2)]) AS bm25Score
       FROM knowledge_fact

--- a/src/search/internals/policy.ts
+++ b/src/search/internals/policy.ts
@@ -10,6 +10,11 @@ import type { FactRow } from './types';
  *
  * `dto` is accepted to keep the signature stable for future per-DTO
  * gates, even though the current logic only reads predicate policy.
+ *
+ * NOTE: the pipeline now filters through makeRowPolicyFilter
+ * (src/policy/row-filter.ts), which applies this same scope gate FIRST
+ * and then the per-key ABAC row verdict. This function stays as the
+ * scope-gate reference implementation and for unit tests.
  */
 export function passesPolicy(
   row: FactRow,

--- a/src/search/internals/types.ts
+++ b/src/search/internals/types.ts
@@ -65,6 +65,11 @@ export interface FactRow {
     sourceKeys?: string[];
   } | null;
   /**
+   * Per-user memory scope owner (migration 0055); NONE = tenant-global.
+   * Projected so the ABAC row filter can match userId policies.
+   */
+  userId?: string | null;
+  /**
    * Usage reinforcement (migration 0053): most recent time search
    * surfaced this fact, attached by enrichWithUsage when
    * SEARCH_USAGE_DECAY_ENABLED is on. Absent → decay from recordedAt

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import { SearchService } from './search.service';
 import { SearchDto } from './dto/search.dto';
 import { AuthenticatedRequest } from '../auth/api-key.types';
@@ -18,6 +19,7 @@ export class SearchController {
   @Throttle({ expensive: { limit: 10, ttl: 60_000 } })
   @Post()
   @RequireScopes('brain:read')
+  @PolicyAction('search_knowledge')
   async run(@Req() req: AuthenticatedRequest, @Body() body: SearchDto) {
     return this.search.search(
       req.brainAuth.companyId,

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -16,7 +16,7 @@ import {
 } from './internals/stage-budget';
 import { buildBaseWhere } from './internals/where-builder';
 import { hydrateSurvivors, reattributeMerged } from './internals/identity-merge';
-import { passesPolicy } from './internals/policy';
+import { makeRowPolicyFilter } from '../policy/row-filter';
 import { expandEntityIdsViaEdges as expandEntityIdsViaEdgesDb } from './internals/neighbours';
 import { expandViaEdges } from './internals/edge-expansion';
 import { applyPprPrior } from './internals/ppr';
@@ -132,6 +132,22 @@ export class SearchService {
             predicateHints,
             asOf,
           });
+
+          // Scope + ABAC row filter. Also closes the pre-ABAC gap where
+          // graph_retrieve skipped the requiresScope predicate gate that
+          // search applied — PII-scoped facts no longer surface here
+          // without brain:read_pii.
+          const rowPolicy = makeRowPolicyFilter({
+            callerScopes,
+            surface: 'graph_retrieve',
+          });
+          for (const [entityId, facts] of factsByEntity) {
+            factsByEntity.set(
+              entityId,
+              facts.filter((f) => rowPolicy.filter(f)),
+            );
+          }
+          rowPolicy.finish();
 
           traceArtifact('graph_retrieve', {
             seeds: seedIds,
@@ -286,12 +302,17 @@ export class SearchService {
       });
     }
 
-    // 2. Identity-merge re-attribution + scope-policy filter.
+    // 2. Identity-merge re-attribution + scope/ABAC row filter. One
+    // filter instance covers the whole pipeline (fusion + edge
+    // expansion + backfill) so the decision summary aggregates once.
+    const rowPolicy = makeRowPolicyFilter({
+      callerScopes: ctx.callerScopes,
+      surface: 'search',
+    });
+    const rowFilterFn = (row: FactRow) => rowPolicy.filter(row);
     const survivorRecords = await hydrateSurvivors(db, fused);
     const reattributed = reattributeMerged(fused, survivorRecords);
-    const filtered = reattributed.filter((row) =>
-      passesPolicy(row, ctx.dto, ctx.callerScopes),
-    );
+    const filtered = reattributed.filter(rowFilterFn);
 
     // 2b. Usage enrichment (opt-in) — attach lastReadAt so decay counts
     // from the most recent retrieval instead of only recordedAt. Soft-
@@ -310,7 +331,7 @@ export class SearchService {
     const byEntity = this.retrieval.scoreAndBucket(filtered, predicateDist);
 
     // 5. Edge expansion (default ON) — graph-walk from top seeds.
-    await this.runEdgeExpansionStage({ db, byEntity, baseWhere, ctx });
+    await this.runEdgeExpansionStage({ db, byEntity, baseWhere, ctx, rowFilterFn });
 
     // 6. PPR (opt-in) — HippoRAG-style cluster lift.
     await this.runPprStage(db, byEntity);
@@ -336,7 +357,7 @@ export class SearchService {
           baseWhere,
           dto: ctx.dto,
           callerScopes: ctx.callerScopes,
-          passesPolicy,
+          passesPolicy: (row) => rowFilterFn(row),
         }),
       fallback: new Map<string, FactRow[]>(),
       logger: this.logger,
@@ -347,6 +368,7 @@ export class SearchService {
       entityTypes: ctx.dto.entityTypes,
       requireProvenance: ctx.dto.requireProvenance === true,
     });
+    rowPolicy.finish();
     return { results: applyOutputShaping(hits, ctx.dto) };
   }
 
@@ -355,11 +377,13 @@ export class SearchService {
     byEntity,
     baseWhere,
     ctx,
+    rowFilterFn,
   }: {
     db: Surreal;
     byEntity: Map<string, EntityBucket>;
     baseWhere: { sql: string; params: Record<string, unknown> };
     ctx: PipelineContext;
+    rowFilterFn: (row: FactRow) => boolean;
   }): Promise<void> {
     if (process.env.SEARCH_EDGE_EXPANSION_ENABLED === '0') return;
     if (byEntity.size < 1) return;
@@ -373,7 +397,7 @@ export class SearchService {
           baseWhere,
           dto: ctx.dto,
           callerScopes: ctx.callerScopes,
-          passesPolicy,
+          passesPolicy: (row) => rowFilterFn(row),
         });
         span.setAttribute('edge_expansion.injected', injected);
         if (injected > 0) {

--- a/src/stats/stats.controller.ts
+++ b/src/stats/stats.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Req, UseGuards } from '@nestjs/common';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 import { StatsService } from './stats.service';
 
@@ -14,6 +15,7 @@ export class StatsController {
 
   @Get('overview')
   @RequireScopes('brain:read')
+  @PolicyAction('rest.stats.overview')
   async overview(@Req() req: AuthenticatedRequest) {
     return this.stats.overview(req.brainAuth.companyId, req.brainAuth.scopes);
   }

--- a/src/synthesize/synthesize.controller.ts
+++ b/src/synthesize/synthesize.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
 import { SynthesizeService } from './synthesize.service';
 import { SynthesizeDto } from './dto/synthesize.dto';
 import { AuthenticatedRequest } from '../auth/api-key.types';
@@ -12,6 +13,7 @@ export class SynthesizeController {
 
   @Post()
   @RequireScopes('brain:read')
+  @PolicyAction('synthesize')
   // Generator + verifier each cost one chat completion; treat as expensive.
   @Throttle({ expensive: { limit: 10, ttl: 60_000 } })
   async run(

--- a/test/abac-action-gate.e2e-spec.ts
+++ b/test/abac-action-gate.e2e-spec.ts
@@ -1,0 +1,235 @@
+/**
+ * ABAC action-level enforcement end-to-end:
+ *   - enforce policy: 403 policy_denied on gated writes, reads pass
+ *   - report_only policy: nothing blocked, would_deny decisions land
+ *     in policy_decision
+ *   - ABAC_ENABLED=0: policies attached to keys are inert
+ *
+ * Policy sets are seeded through the real admin CRUD; the restricted
+ * keys reference them via the BRAIN_API_KEYS `policies` field (the
+ * static-key attachment path).
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { PolicyDecisionSink } from '../src/policy/policy-decision.sink';
+import { SurrealService } from '../src/db/surreal.service';
+
+jest.setTimeout(120_000);
+
+const READONLY_DOC = {
+  name: 'readonly-agent',
+  description: 'default-deny, reads only',
+  posture: { actions: 'deny', reads: 'allow' },
+  mode: 'enforce',
+  rules: [
+    { id: 'ro', effect: 'allow', kind: 'action', actions: ['@readonly'] },
+  ],
+};
+
+const WATCHER_DOC = {
+  name: 'watcher',
+  description: 'report_only shadow of readonly-agent',
+  posture: { actions: 'deny', reads: 'allow' },
+  mode: 'report_only',
+  rules: [
+    { id: 'ro', effect: 'allow', kind: 'action', actions: ['@readonly'] },
+  ],
+};
+
+describe('ABAC action gate (enforce + report_only)', () => {
+  let f: AppFixture;
+  let readonlyKey: string;
+  let watcherKey: string;
+
+  beforeAll(async () => {
+    process.env.ABAC_ENABLED = '1';
+    f = await createApp({
+      extraKeys: [
+        { scopes: ['brain:read', 'brain:write'], policies: ['readonly-agent'] },
+        { scopes: ['brain:read', 'brain:write'], policies: ['watcher'] },
+      ],
+    });
+    [readonlyKey, watcherKey] = f.extraApiKeys;
+    for (const doc of [READONLY_DOC, WATCHER_DOC]) {
+      const r = await f.http
+        .post('/v1/admin/policy-sets')
+        .set({ Authorization: `Bearer ${f.apiKey}` })
+        .send(doc);
+      expect(r.status).toBe(201);
+    }
+  });
+
+  afterAll(async () => {
+    delete process.env.ABAC_ENABLED;
+    await f.close();
+  });
+
+  const ingestBody = () => ({
+    entityRef: { vertical: 'rent', id: 'subj_abac_gate' },
+    predicate: 'preference',
+    object: 'quiet street',
+    validFrom: '2026-01-01',
+    confidence: 0.9,
+    source: { vertical: 'rent', recorder: 'bot' },
+  });
+
+  it('unrestricted admin key is untouched by ABAC', async () => {
+    const r = await f.http
+      .post('/v1/ingest/fact')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send(ingestBody());
+    expect([200, 201]).toContain(r.status);
+  });
+
+  it('enforce readonly key: search allowed, ingest 403 policy_denied', async () => {
+    const search = await f.http
+      .post('/v1/search')
+      .set({ Authorization: `Bearer ${readonlyKey}` })
+      .send({ query: 'quiet street' });
+    expect(search.status).toBe(201);
+
+    const write = await f.http
+      .post('/v1/ingest/fact')
+      .set({ Authorization: `Bearer ${readonlyKey}` })
+      .send(ingestBody());
+    expect(write.status).toBe(403);
+    expect(write.body).toMatchObject({
+      error: 'policy_denied',
+      action: 'record_fact',
+      policySet: 'readonly-agent',
+    });
+  });
+
+  it('enforce readonly key: undecorated write routes fall to the posture too', async () => {
+    // retract is @PolicyAction('retract_fact') — registered write action.
+    const r = await f.http
+      .post('/v1/facts/whatever/retract')
+      .set({ Authorization: `Bearer ${readonlyKey}` })
+      .send({ reason: 'test' });
+    expect(r.status).toBe(403);
+    expect(r.body.error).toBe('policy_denied');
+  });
+
+  it('report_only key: writes pass and a would_deny decision row lands', async () => {
+    const write = await f.http
+      .post('/v1/ingest/fact')
+      .set({ Authorization: `Bearer ${watcherKey}` })
+      .send({ ...ingestBody(), object: 'watched write' });
+    expect([200, 201]).toContain(write.status);
+
+    const sink = f.app.get(PolicyDecisionSink);
+    await sink.flushAll();
+    const surreal = f.app.get(SurrealService);
+    const rows = await surreal.withCompany(f.companyId, async (db) => {
+      const [r] = await db.query<[any[]]>(
+        `SELECT * FROM policy_decision
+          WHERE decision = 'would_deny' AND action = 'record_fact'`,
+      );
+      return (r as any[]) ?? [];
+    });
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[0]).toMatchObject({
+      kind: 'action',
+      mode: 'report_only',
+      policySet: 'watcher',
+    });
+  });
+
+  it('attachments endpoint validates the set exists (fail-closed stays unreachable)', async () => {
+    const r = await f.http
+      .post('/v1/admin/policy-sets/no-such-set/attachments')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({ attach: ['key:sha256:deadbeef'] });
+    expect(r.status).toBe(404);
+  });
+
+  it('CRUD lifecycle: version conflict 409s with current copy; attached delete 409s', async () => {
+    const created = await f.http
+      .post('/v1/admin/policy-sets')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({ ...READONLY_DOC, name: 'lifecycle-set' });
+    expect(created.status).toBe(201);
+    expect(created.body.policySet.version).toBe(1);
+
+    const stale = await f.http
+      .put('/v1/admin/policy-sets/lifecycle-set')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({ ...READONLY_DOC, name: 'lifecycle-set', version: 99 });
+    expect(stale.status).toBe(409);
+    expect(stale.body.current.policySet ?? stale.body.current).toBeDefined();
+
+    const attach = await f.http
+      .post('/v1/admin/policy-sets/lifecycle-set/attachments')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({ attach: ['key:sha256:deadbeef'] });
+    expect(attach.status).toBe(201);
+
+    const del = await f.http
+      .delete('/v1/admin/policy-sets/lifecycle-set')
+      .set({ Authorization: `Bearer ${f.apiKey}` });
+    expect(del.status).toBe(409);
+    expect(del.body.error).toBe('policy_attached');
+
+    const detach = await f.http
+      .post('/v1/admin/policy-sets/lifecycle-set/attachments')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({ detach: ['key:sha256:deadbeef'] });
+    expect(detach.status).toBe(201);
+
+    const del2 = await f.http
+      .delete('/v1/admin/policy-sets/lifecycle-set')
+      .set({ Authorization: `Bearer ${f.apiKey}` });
+    expect(del2.status).toBe(200);
+  });
+
+  it('rejects an invalid policy document with zod issues', async () => {
+    const r = await f.http
+      .post('/v1/admin/policy-sets')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({
+        name: 'bad-set',
+        posture: { actions: 'deny', reads: 'deny' },
+        mode: 'enforce',
+        rules: [
+          { id: 'r', effect: 'deny', kind: 'source', match: [{ attr: 'no.such.attr', op: 'eq', value: 'x' }] },
+        ],
+      });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toBe('invalid_policy_document');
+    expect(r.body.issues?.length).toBeGreaterThan(0);
+  });
+});
+
+describe('ABAC master switch off — attached policies are inert', () => {
+  let f: AppFixture;
+  let restrictedKey: string;
+
+  beforeAll(async () => {
+    process.env.ABAC_ENABLED = '0';
+    f = await createApp({
+      extraKeys: [
+        { scopes: ['brain:read', 'brain:write'], policies: ['readonly-agent'] },
+      ],
+    });
+    [restrictedKey] = f.extraApiKeys;
+  });
+
+  afterAll(async () => {
+    delete process.env.ABAC_ENABLED;
+    await f.close();
+  });
+
+  it('a key referencing policy sets writes freely when ABAC_ENABLED=0', async () => {
+    const r = await f.http
+      .post('/v1/ingest/fact')
+      .set({ Authorization: `Bearer ${restrictedKey}` })
+      .send({
+        entityRef: { vertical: 'rent', id: 'subj_abac_off' },
+        predicate: 'preference',
+        object: 'anything goes',
+        validFrom: '2026-01-01',
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+      });
+    expect([200, 201]).toContain(r.status);
+  });
+});

--- a/test/abac-explain.e2e-spec.ts
+++ b/test/abac-explain.e2e-spec.ts
@@ -1,0 +1,123 @@
+/**
+ * POST /v1/admin/policy-sets/explain — single-decision traces for an
+ * action and for a real stored fact (row), the API twin of Zep's
+ * `zepctl api-key explain` with per-condition expected/actual detail.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { PolicyExplainResponseSchema } from '../src/contracts/admin/policies.schema';
+
+jest.setTimeout(120_000);
+
+const DOC = {
+  name: 'support-reader',
+  description: 'readonly + support vertical only',
+  posture: { actions: 'deny', reads: 'deny' },
+  mode: 'enforce',
+  rules: [
+    { id: 'ro', effect: 'allow', kind: 'action', actions: ['@readonly'] },
+    {
+      id: 'support-open',
+      effect: 'allow',
+      kind: 'source',
+      match: [{ attr: 'source.vertical', op: 'eq', value: 'support' }],
+    },
+  ],
+};
+
+describe('ABAC explain endpoint', () => {
+  let f: AppFixture;
+  let hrFactId: string;
+  let supportFactId: string;
+
+  beforeAll(async () => {
+    process.env.ABAC_ENABLED = '1';
+    f = await createApp();
+    const created = await f.http
+      .post('/v1/admin/policy-sets')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send(DOC);
+    expect(created.status).toBe(201);
+
+    const ingest = async (vertical: string, object: string) => {
+      const r = await f.http
+        .post('/v1/ingest/fact')
+        .set({ Authorization: `Bearer ${f.apiKey}` })
+        .send({
+          entityRef: { vertical: 'rent', id: 'subj_explain' },
+          predicate: 'preference',
+          object,
+          validFrom: '2026-01-01',
+          confidence: 0.9,
+          source: { vertical, recorder: 'crm' },
+        });
+      expect([200, 201]).toContain(r.status);
+      return r.body.factId as string;
+    };
+    supportFactId = await ingest('support', 'likes fast replies');
+    hrFactId = await ingest('hr', 'salary negotiation notes');
+  });
+
+  afterAll(async () => {
+    delete process.env.ABAC_ENABLED;
+    await f.close();
+  });
+
+  const explain = (body: Record<string, unknown>) =>
+    f.http
+      .post('/v1/admin/policy-sets/explain')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({ policyNames: ['support-reader'], ...body });
+
+  it('explains an allowed action via the readonly macro', async () => {
+    const r = await explain({ action: 'search_knowledge' });
+    expect(r.status).toBe(201);
+    expect(r.body.action).toMatchObject({
+      name: 'search_knowledge',
+      decision: 'allow',
+    });
+    expect(r.body.action.traces[0].decidedBy).toBe('ro');
+  });
+
+  it('explains a posture-denied action', async () => {
+    const r = await explain({ action: 'record_fact' });
+    expect(r.status).toBe(201);
+    expect(r.body.action.decision).toBe('deny');
+    expect(r.body.action.traces[0].decidedBy).toBe('posture');
+  });
+
+  it('explains row verdicts with per-condition expected/actual fields', async () => {
+    const denied = await explain({ factId: hrFactId });
+    expect(denied.status).toBe(201);
+    expect(denied.body.row.decision).toBe('deny');
+    const trace = denied.body.row.traces[0];
+    expect(trace.decidedBy).toBe('posture');
+    expect(trace.rules[0]).toMatchObject({ ruleId: 'support-open', matched: false });
+    expect(trace.rules[0].fields[0]).toMatchObject({
+      attr: 'source.vertical',
+      expected: 'support',
+      actual: 'hr',
+      matched: false,
+    });
+
+    const allowed = await explain({ factId: supportFactId });
+    expect(allowed.body.row.decision).toBe('allow');
+    expect(allowed.body.row.traces[0].decidedBy).toBe('support-open');
+    expect(allowed.body.row.view.predicate).toBe('preference');
+  });
+
+  it('both at once, and the response matches the wire contract', async () => {
+    const r = await explain({ action: 'graph_retrieve', factId: supportFactId });
+    expect(r.status).toBe(201);
+    const parsed = PolicyExplainResponseSchema.safeParse(r.body);
+    if (!parsed.success) {
+      throw new Error(`explain drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+  });
+
+  it('404s on unknown policy names and 400s without a target', async () => {
+    const unknown = await explain({ policyNames: ['ghost'], action: 'synthesize' });
+    expect(unknown.status).toBe(404);
+    const empty = await explain({});
+    expect(empty.status).toBe(400);
+  });
+});

--- a/test/abac-row-filter.e2e-spec.ts
+++ b/test/abac-row-filter.e2e-spec.ts
@@ -1,0 +1,246 @@
+/**
+ * ABAC row-level enforcement end-to-end across read surfaces:
+ *   - enforce deny on source.vertical hides matching facts from
+ *     search and entity profile while other facts stay visible
+ *   - default-deny reads posture with one allow rule
+ *   - report_only source rules hide nothing but land row decisions
+ *   - GOLDEN: with ABAC_ENABLED=1, a key with no policies gets the
+ *     byte-identical search response captured with ABAC_ENABLED=0
+ *     (same tenant, same data — the app is rebooted between passes).
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { PolicyDecisionSink } from '../src/policy/policy-decision.sink';
+import { SurrealService } from '../src/db/surreal.service';
+
+jest.setTimeout(180_000);
+
+const NO_HR_DOC = {
+  name: 'no-hr',
+  description: 'hide facts recorded through the hr vertical',
+  posture: { actions: 'allow', reads: 'allow' },
+  mode: 'enforce',
+  rules: [
+    {
+      id: 'hr-off',
+      effect: 'deny',
+      kind: 'source',
+      match: [{ attr: 'source.vertical', op: 'eq', value: 'hr' }],
+    },
+  ],
+};
+
+const SUPPORT_ONLY_DOC = {
+  name: 'support-only',
+  description: 'default-deny reads, support vertical opened',
+  posture: { actions: 'allow', reads: 'deny' },
+  mode: 'enforce',
+  rules: [
+    {
+      id: 'support-open',
+      effect: 'allow',
+      kind: 'source',
+      match: [{ attr: 'source.vertical', op: 'eq', value: 'support' }],
+    },
+  ],
+};
+
+const SHADOW_DOC = {
+  name: 'shadow-no-hr',
+  description: 'report_only twin of no-hr',
+  posture: { actions: 'allow', reads: 'allow' },
+  mode: 'report_only',
+  rules: [
+    {
+      id: 'hr-off',
+      effect: 'deny',
+      kind: 'source',
+      match: [{ attr: 'source.vertical', op: 'eq', value: 'hr' }],
+    },
+  ],
+};
+
+const ENTITY_REF = { vertical: 'rent', id: 'subj_abac_rows' };
+
+async function seedFacts(f: AppFixture): Promise<void> {
+  const facts = [
+    { predicate: 'preference', object: 'ground floor apartments', source: { vertical: 'support', recorder: 'crm' } },
+    { predicate: 'complaint', object: 'noisy ground floor neighbours', source: { vertical: 'hr', recorder: 'hr-sync' } },
+  ];
+  for (const fact of facts) {
+    const r = await f.http
+      .post('/v1/ingest/fact')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({ entityRef: ENTITY_REF, validFrom: '2026-01-01', confidence: 0.9, ...fact });
+    expect([200, 201]).toContain(r.status);
+  }
+}
+
+function objectsOf(searchBody: any): string[] {
+  return (searchBody.results ?? [])
+    .flatMap((hit: any) => hit.facts ?? [])
+    .map((fct: any) => String(fct.object));
+}
+
+/**
+ * Scores carry a recency-decay factor computed at query time, so two
+ * identical searches seconds apart differ in the ~9th decimal. Round
+ * every number to 6 dp — far below any behavioral difference the
+ * golden test exists to catch (a dropped row, a changed field).
+ */
+function normalizeNumbers(value: any): any {
+  if (typeof value === 'number') return Math.round(value * 1e6) / 1e6;
+  if (Array.isArray(value)) return value.map(normalizeNumbers);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, normalizeNumbers(v)]),
+    );
+  }
+  return value;
+}
+
+describe('ABAC row filter across read surfaces', () => {
+  const companyId = `co_abac_rows_${Date.now()}`;
+  let baseline: any;
+
+  it('pass 1 (ABAC off): seed facts and capture the golden search response', async () => {
+    process.env.ABAC_ENABLED = '0';
+    const f = await createApp({ companyId });
+    try {
+      await seedFacts(f);
+      const r = await f.http
+        .post('/v1/search')
+        .set({ Authorization: `Bearer ${f.apiKey}` })
+        .send({ query: 'ground floor' });
+      expect(r.status).toBe(201);
+      baseline = r.body;
+      expect(objectsOf(baseline).length).toBeGreaterThanOrEqual(2);
+    } finally {
+      await f.close();
+    }
+  });
+
+  describe('pass 2 (ABAC on): same tenant, policied keys', () => {
+    let f: AppFixture;
+    let noHrKey: string;
+    let supportOnlyKey: string;
+    let shadowKey: string;
+    let entityId: string;
+
+    beforeAll(async () => {
+      process.env.ABAC_ENABLED = '1';
+      f = await createApp({
+        companyId,
+        extraKeys: [
+          { scopes: ['brain:read', 'brain:write'], policies: ['no-hr'] },
+          { scopes: ['brain:read', 'brain:write'], policies: ['support-only'] },
+          { scopes: ['brain:read', 'brain:write'], policies: ['shadow-no-hr'] },
+        ],
+      });
+      [noHrKey, supportOnlyKey, shadowKey] = f.extraApiKeys;
+      for (const doc of [NO_HR_DOC, SUPPORT_ONLY_DOC, SHADOW_DOC]) {
+        const r = await f.http
+          .post('/v1/admin/policy-sets')
+          .set({ Authorization: `Bearer ${f.apiKey}` })
+          .send(doc);
+        expect(r.status).toBe(201);
+      }
+      const profile = await f.http
+        .post('/v1/search')
+        .set({ Authorization: `Bearer ${f.apiKey}` })
+        .send({ query: 'ground floor' });
+      entityId = profile.body.results[0].entityId;
+    });
+
+    afterAll(async () => {
+      delete process.env.ABAC_ENABLED;
+      await f.close();
+    });
+
+    it('GOLDEN: a policy-free key gets the exact pre-ABAC response', async () => {
+      const r = await f.http
+        .post('/v1/search')
+        .set({ Authorization: `Bearer ${f.apiKey}` })
+        .send({ query: 'ground floor' });
+      expect(r.status).toBe(201);
+      expect(normalizeNumbers(r.body)).toEqual(normalizeNumbers(baseline));
+    });
+
+    it('enforce deny rule hides hr facts from search, keeps support facts', async () => {
+      const r = await f.http
+        .post('/v1/search')
+        .set({ Authorization: `Bearer ${noHrKey}` })
+        .send({ query: 'ground floor' });
+      expect(r.status).toBe(201);
+      const objects = objectsOf(r.body);
+      expect(objects).toContain('ground floor apartments');
+      expect(objects).not.toContain('noisy ground floor neighbours');
+    });
+
+    it('default-deny reads posture: only the allowed vertical survives', async () => {
+      const r = await f.http
+        .post('/v1/search')
+        .set({ Authorization: `Bearer ${supportOnlyKey}` })
+        .send({ query: 'ground floor' });
+      expect(r.status).toBe(201);
+      const objects = objectsOf(r.body);
+      expect(objects).toContain('ground floor apartments');
+      expect(objects).not.toContain('noisy ground floor neighbours');
+    });
+
+    it('entity profile applies the same row gate', async () => {
+      const full = await f.http
+        .get(`/v1/entities/${encodeURIComponent(entityId)}`)
+        .set({ Authorization: `Bearer ${f.apiKey}` });
+      expect(full.status).toBe(200);
+      const fullObjects = full.body.facts.map((x: any) => x.object);
+      expect(fullObjects).toEqual(
+        expect.arrayContaining(['ground floor apartments', 'noisy ground floor neighbours']),
+      );
+
+      const restricted = await f.http
+        .get(`/v1/entities/${encodeURIComponent(entityId)}`)
+        .set({ Authorization: `Bearer ${noHrKey}` });
+      expect(restricted.status).toBe(200);
+      const restrictedObjects = restricted.body.facts.map((x: any) => x.object);
+      expect(restrictedObjects).toContain('ground floor apartments');
+      expect(restrictedObjects).not.toContain('noisy ground floor neighbours');
+    });
+
+    it('entity timeline applies the same row gate', async () => {
+      const restricted = await f.http
+        .get(`/v1/entities/${encodeURIComponent(entityId)}/timeline`)
+        .set({ Authorization: `Bearer ${noHrKey}` });
+      expect(restricted.status).toBe(200);
+      const objects = restricted.body.events
+        .filter((e: any) => e.type === 'fact.recorded')
+        .map((e: any) => e.object);
+      expect(objects).toContain('ground floor apartments');
+      expect(objects).not.toContain('noisy ground floor neighbours');
+    });
+
+    it('report_only source rule hides nothing but records a row would_deny aggregate', async () => {
+      const r = await f.http
+        .post('/v1/search')
+        .set({ Authorization: `Bearer ${shadowKey}` })
+        .send({ query: 'ground floor' });
+      expect(r.status).toBe(201);
+      const objects = objectsOf(r.body);
+      expect(objects).toContain('noisy ground floor neighbours');
+
+      const sink = f.app.get(PolicyDecisionSink);
+      await sink.flushAll();
+      const surreal = f.app.get(SurrealService);
+      const rows = await surreal.withCompany(f.companyId, async (db) => {
+        const [rowsOut] = await db.query<[any[]]>(
+          `SELECT * FROM policy_decision
+            WHERE kind = 'row' AND decision = 'would_deny'
+              AND policySet = 'shadow-no-hr'`,
+        );
+        return (rowsOut as any[]) ?? [];
+      });
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      expect(rows[0].rowCounts.denied).toBeGreaterThanOrEqual(1);
+      expect(rows[0].ruleId).toBe('hr-off');
+    });
+  });
+});

--- a/test/app-fixture.ts
+++ b/test/app-fixture.ts
@@ -5,12 +5,15 @@ import { createHash, randomUUID } from 'node:crypto';
 import { AppModule } from '../src/app.module';
 import { EmbedderService } from '../src/ai/embedder.service';
 import { ExtractorService } from '../src/ai/extractor.service';
+import { correlationIdMiddleware } from '../src/common/correlation-id.middleware';
 import { StubEmbedder, StubExtractor } from './test-doubles';
 
 export interface AppFixture {
   app: INestApplication;
   http: ReturnType<typeof request>;
   apiKey: string;
+  /** Plaintext keys for opts.extraKeys, in order. */
+  extraApiKeys: string[];
   companyId: string;
   extractor: StubExtractor;
   close: () => Promise<void>;
@@ -27,16 +30,31 @@ export async function createApp(opts: {
    * connections and DB-level PERMISSIONS apply.
    */
   enableScopedPool?: boolean;
+  /**
+   * Additional static keys for the SAME tenant — the ABAC suites need a
+   * privileged admin key plus a policy-restricted caller key in one
+   * boot (BRAIN_API_KEYS is parsed once at module init). `policies`
+   * maps to the entry's ABAC attachment field.
+   */
+  extraKeys?: Array<{ scopes: string[]; policies?: string[] }>;
 } = {}): Promise<AppFixture> {
   const companyId = opts.companyId ?? `co_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
   const apiKey = `key_${randomUUID()}`;
   const keyHash = 'sha256:' + createHash('sha256').update(apiKey).digest('hex');
+  const extraApiKeys = (opts.extraKeys ?? []).map(() => `key_${randomUUID()}`);
   process.env.BRAIN_API_KEYS = JSON.stringify([
     {
       keyHash,
       companyId,
       scopes: opts.scopes ?? ['brain:read', 'brain:write', 'brain:admin', 'brain:read_pii'],
     },
+    ...(opts.extraKeys ?? []).map((k, i) => ({
+      keyHash:
+        'sha256:' + createHash('sha256').update(extraApiKeys[i]).digest('hex'),
+      companyId,
+      scopes: k.scopes,
+      ...(k.policies ? { policies: k.policies } : {}),
+    })),
   ]);
   // Bypass real OpenAI calls.
   process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || 'sk-test-stub';
@@ -70,6 +88,11 @@ export async function createApp(opts: {
     .compile();
 
   const app = moduleRef.createNestApplication();
+  // Mirror main.ts: the correlation middleware also carries the
+  // AsyncLocalStorage request context that ABAC row filtering reads
+  // (getPolicyContext) — without it the row gate is silently inactive
+  // and the abac e2e suites would pass vacuously.
+  app.use(correlationIdMiddleware());
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -84,6 +107,7 @@ export async function createApp(opts: {
     app,
     http,
     apiKey,
+    extraApiKeys,
     companyId,
     extractor: stubExtractor,
     close: () => app.close(),

--- a/test/auth-guard.unit-spec.ts
+++ b/test/auth-guard.unit-spec.ts
@@ -54,6 +54,12 @@ class StubConfig {
   }
 }
 
+// ABAC gate stub: no policies resolve in these suites, so gate() is a
+// pass-through returning "no context".
+const stubPolicyGate = {
+  gate: async () => undefined,
+} as unknown as import('../src/policy/policy-gate.service').PolicyGateService;
+
 describe('ApiKeyGuard — JWKS verification', () => {
   let jwksServer: http.Server;
   let jwksUrl: string;
@@ -66,12 +72,16 @@ describe('ApiKeyGuard — JWKS verification', () => {
   function mintJwt(opts: {
     sub: string;
     scopes?: string[];
+    policy?: unknown;
     issuer?: string;
     audience?: string;
     expiresIn?: string | number;
     signWith?: KeyLike;
   }): Promise<string> {
-    return new SignJWT({ scopes: opts.scopes ?? ['brain:read', 'brain:write'] })
+    return new SignJWT({
+      scopes: opts.scopes ?? ['brain:read', 'brain:write'],
+      ...(opts.policy !== undefined ? { policy: opts.policy } : {}),
+    })
       .setProtectedHeader({ alg: 'RS256', kid: 'test-key-1' })
       .setSubject(opts.sub)
       .setIssuer(opts.issuer ?? ISSUER)
@@ -131,7 +141,7 @@ describe('ApiKeyGuard — JWKS verification', () => {
       jwks,
       config as unknown as ConfigService,
     );
-    guard = new ApiKeyGuard(credentials, new Reflector());
+    guard = new ApiKeyGuard(credentials, new Reflector(), stubPolicyGate);
   });
 
   afterAll(async () => {
@@ -146,6 +156,30 @@ describe('ApiKeyGuard — JWKS verification', () => {
     expect(await guard.canActivate(ctx)).toBe(true);
     expect((req.brainAuth as { companyId: string }).companyId).toBe('jwt_co_alpha');
     expect((req.brainAuth as { keyHash: string }).keyHash).toMatch(/^jwt:/);
+  });
+
+  it('extracts ABAC policy names from the policy claim (array + string forms, charset filter, cap 8)', async () => {
+    const arr = await mintJwt({
+      sub: 'jwt_co_p',
+      policy: ['support-reader', 'BAD NAME!', 'no-pii'],
+    });
+    const rec1 = await jwks.verify(arr);
+    expect(rec1?.policyNames).toEqual(['support-reader', 'no-pii']);
+
+    const str = await mintJwt({ sub: 'jwt_co_p', policy: 'support-reader no-pii' });
+    const rec2 = await jwks.verify(str);
+    expect(rec2?.policyNames).toEqual(['support-reader', 'no-pii']);
+
+    const many = await mintJwt({
+      sub: 'jwt_co_p',
+      policy: Array.from({ length: 12 }, (_, i) => `set-${i}`),
+    });
+    const rec3 = await jwks.verify(many);
+    expect(rec3?.policyNames).toHaveLength(8);
+
+    const none = await mintJwt({ sub: 'jwt_co_p' });
+    const rec4 = await jwks.verify(none);
+    expect(rec4?.policyNames).toBeUndefined();
   });
 
   it('rejects expired JWT (401)', async () => {
@@ -237,7 +271,7 @@ describe('ApiKeyGuard — production with JWKS rejects static keys', () => {
       jwks,
       config as unknown as ConfigService,
     );
-    guard = new ApiKeyGuard(credentials, new Reflector());
+    guard = new ApiKeyGuard(credentials, new Reflector(), stubPolicyGate);
   });
 
   afterAll(async () => {

--- a/test/contracts-admin-policies.unit-spec.ts
+++ b/test/contracts-admin-policies.unit-spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Wire-contract drift guard for the /v1/admin/policy-sets surface.
+ */
+import {
+  PolicySetsListResponseSchema,
+  PolicySetResponseSchema,
+  PolicyBindingsResponseSchema,
+} from '../src/contracts/admin/policies.schema';
+import { AdminPoliciesController } from '../src/admin/admin-policies.controller';
+import type { PolicyStoreService, StoredPolicySet } from '../src/policy/policy-store.service';
+import type { AuthenticatedRequest } from '../src/auth/api-key.types';
+
+const STORED: StoredPolicySet = {
+  name: 'support-reader',
+  mode: 'report_only',
+  document: {
+    name: 'support-reader',
+    description: 'support agents',
+    posture: { actions: 'deny', reads: 'deny' },
+    mode: 'report_only',
+    rules: [
+      { id: 'ro', effect: 'allow', kind: 'action', enabled: true, actions: ['@readonly'] },
+      {
+        id: 'support-only',
+        effect: 'allow',
+        kind: 'source',
+        enabled: true,
+        match: [{ attr: 'source.vertical', op: 'eq', value: 'support' }],
+      },
+    ],
+  },
+  version: 3,
+  createdAt: '2026-07-09T00:00:00Z',
+  updatedAt: '2026-07-09T01:00:00Z',
+  updatedBy: 'sha256:abcdef',
+  attachedSubjects: ['key:sha256:1234'],
+};
+
+function makeController(): AdminPoliciesController {
+  const store = {
+    list: async () => [STORED],
+    get: async () => STORED,
+    listBindings: async () => [
+      { subject: 'key:sha256:1234', policyNames: ['support-reader'], updatedAt: '2026-07-09T01:00:00Z' },
+    ],
+  } as unknown as PolicyStoreService;
+  return new AdminPoliciesController(store);
+}
+
+const req = { brainAuth: { companyId: 'tenant-a', keyHash: 'sha256:admin' } } as AuthenticatedRequest;
+
+describe('AdminPoliciesController — wire contracts', () => {
+  it('list() matches PolicySetsListResponseSchema', async () => {
+    const parsed = PolicySetsListResponseSchema.safeParse(
+      await makeController().list(req),
+    );
+    if (!parsed.success) {
+      throw new Error(`policy-sets list drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+  });
+
+  it('get() matches PolicySetResponseSchema', async () => {
+    const parsed = PolicySetResponseSchema.safeParse(
+      await makeController().get(req, 'support-reader'),
+    );
+    if (!parsed.success) {
+      throw new Error(`policy-set get drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+  });
+
+  it('bindings() matches PolicyBindingsResponseSchema', async () => {
+    const parsed = PolicyBindingsResponseSchema.safeParse(
+      await makeController().bindings(req),
+    );
+    if (!parsed.success) {
+      throw new Error(`policy bindings drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+  });
+});

--- a/test/mcp-policy-gate.unit-spec.ts
+++ b/test/mcp-policy-gate.unit-spec.ts
@@ -1,0 +1,129 @@
+/**
+ * ABAC tool gating on the MCP surface: enforce-denied tools never
+ * appear in the registration table (⇒ absent from tools/list), while
+ * report_only policies leave the surface intact. Uses the same
+ * `_registeredTools` inspection as mcp-tools.unit-spec.ts.
+ */
+import { McpService } from '../src/mcp/mcp.service';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { compilePolicySet } from '../src/policy/policy-compile';
+import {
+  PolicyContext,
+  PolicyDocument,
+  PolicyDocumentSchema,
+} from '../src/policy/policy.types';
+
+const stubEmbedder = {
+  cacheStats: () => ({ provider: 'openai:text-embedding-3-small' }),
+  getDimensions: () => 1536,
+};
+
+const enforceCalls: string[] = [];
+const stubPolicyGate = {
+  enforceAction: (_ctx: PolicyContext, action: string) => {
+    enforceCalls.push(action);
+  },
+};
+
+function ctxFromDoc(doc: Record<string, unknown>): PolicyContext {
+  const parsed: PolicyDocument = PolicyDocumentSchema.parse(doc);
+  const compiled = compilePolicySet(parsed);
+  if (!compiled) throw new Error('disabled set in test');
+  return {
+    companyId: 'co_test',
+    keyHash: 'sha256:test',
+    sets: [compiled],
+    forceReportOnly: false,
+    resolutionError: false,
+  };
+}
+
+function buildWithPolicy(policy?: PolicyContext): McpServer {
+  const svc = new McpService(
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    stubEmbedder as never,
+    {} as never,
+    {} as never,
+    stubPolicyGate as never,
+  );
+  return svc.buildServer('co_test', ['brain:read', 'brain:write', 'brain:admin'], {
+    actorKeyHash: 'sha256:test',
+    policy,
+  });
+}
+
+function toolNames(server: McpServer): string[] {
+  const internals = server as unknown as {
+    _registeredTools: Record<string, unknown>;
+  };
+  return Object.keys(internals._registeredTools);
+}
+
+describe('MCP ABAC tool gate', () => {
+  it('readonly enforce policy strips every write tool from the surface', () => {
+    const policy = ctxFromDoc({
+      name: 'readonly-agent',
+      posture: { actions: 'deny', reads: 'allow' },
+      mode: 'enforce',
+      rules: [
+        { id: 'ro', effect: 'allow', kind: 'action', actions: ['@readonly'] },
+      ],
+    });
+    const names = toolNames(buildWithPolicy(policy));
+    expect(names).toContain('search_knowledge');
+    expect(names).toContain('graph_retrieve');
+    expect(names).toContain('get_source_reputation');
+    expect(names).not.toContain('record_fact');
+    expect(names).not.toContain('retract_fact');
+    expect(names).not.toContain('forget_entity');
+    expect(names).not.toContain('ingest_document');
+    expect(names).not.toContain('record_procedure');
+  });
+
+  it('a targeted deny removes exactly that tool', () => {
+    const policy = ctxFromDoc({
+      name: 'no-forget',
+      posture: { actions: 'allow', reads: 'allow' },
+      mode: 'enforce',
+      rules: [
+        { id: 'nf', effect: 'deny', kind: 'action', actions: ['forget_entity'] },
+      ],
+    });
+    const names = toolNames(buildWithPolicy(policy));
+    expect(names).not.toContain('forget_entity');
+    expect(names).toContain('record_fact');
+    expect(names).toContain('search_knowledge');
+  });
+
+  it('report_only policy leaves the full surface registered', () => {
+    const policy = ctxFromDoc({
+      name: 'watcher',
+      posture: { actions: 'deny', reads: 'allow' },
+      mode: 'report_only',
+      rules: [],
+    });
+    const withPolicy = toolNames(buildWithPolicy(policy)).sort();
+    const without = toolNames(buildWithPolicy(undefined)).sort();
+    expect(withPolicy).toEqual(without);
+  });
+
+  it('no policy context = pre-ABAC surface, gate service untouched', () => {
+    enforceCalls.length = 0;
+    const names = toolNames(buildWithPolicy(undefined));
+    expect(names).toContain('record_fact');
+    expect(names).toContain('forget_entity');
+    expect(enforceCalls).toHaveLength(0);
+  });
+});

--- a/test/mcp-tools.unit-spec.ts
+++ b/test/mcp-tools.unit-spec.ts
@@ -47,6 +47,7 @@ function buildWithScopes(scopes: BrainScope[]): McpServer {
     stubEmbedder as never,
     {} as never,
     {} as never, // feedback
+    {} as never, // policyGate — unused without a policy context
   );
   return svc.buildServer('co_test', scopes);
 }
@@ -157,6 +158,7 @@ describe('McpService.health — unauthenticated probe payload', () => {
       stubEmbedder as never,
       {} as never,
       {} as never, // feedback
+      {} as never, // policyGate — unused without a policy context
     );
     const health = svc.health();
     expect(health.ok).toBe(true);

--- a/test/policy-engine.unit-spec.ts
+++ b/test/policy-engine.unit-spec.ts
@@ -1,0 +1,364 @@
+import { compilePolicySet, denyAllSet } from '../src/policy/policy-compile';
+import {
+  evaluateAction,
+  evaluateRow,
+  explainRow,
+  toRowView,
+} from '../src/policy/policy-engine';
+import {
+  CompiledPolicySet,
+  PolicyContext,
+  PolicyDocument,
+  PolicyDocumentSchema,
+  PolicyRowView,
+} from '../src/policy/policy.types';
+
+function compile(doc: Partial<PolicyDocument> & { name?: string }): CompiledPolicySet {
+  const parsed = PolicyDocumentSchema.parse({
+    name: doc.name ?? 'test-set',
+    description: '',
+    posture: { actions: 'allow', reads: 'allow' },
+    mode: 'enforce',
+    rules: [],
+    ...doc,
+  });
+  const compiled = compilePolicySet(parsed);
+  if (!compiled) throw new Error('unexpected disabled set');
+  return compiled;
+}
+
+function ctxOf(...sets: CompiledPolicySet[]): PolicyContext {
+  return {
+    companyId: 'co_test',
+    keyHash: 'sha256:test',
+    sets,
+    forceReportOnly: false,
+    resolutionError: false,
+  };
+}
+
+const view = (over: Partial<PolicyRowView> = {}): PolicyRowView => ({
+  predicate: 'preference',
+  piiClass: 'none',
+  source: { vertical: 'support', recorder: 'crm' },
+  trustSnapshot: { authority: 0.8, learnedTrust: 0.6 },
+  corroboration: { count: 2 },
+  userId: null,
+  ...over,
+});
+
+describe('policy-engine action evaluation', () => {
+  it('deny overrides allow regardless of rule order', () => {
+    const set = compile({
+      rules: [
+        { id: 'a', effect: 'allow', kind: 'action', enabled: true, actions: ['record_fact'] },
+        { id: 'd', effect: 'deny', kind: 'action', enabled: true, actions: ['record_fact'] },
+      ],
+    });
+    expect(evaluateAction(ctxOf(set), 'record_fact').decision).toBe('deny');
+  });
+
+  it('default-deny posture blocks unmatched actions; allow rule opens exactly its names', () => {
+    const set = compile({
+      posture: { actions: 'deny', reads: 'allow' },
+      rules: [
+        { id: 'ro', effect: 'allow', kind: 'action', enabled: true, actions: ['search_knowledge'] },
+      ],
+    });
+    expect(evaluateAction(ctxOf(set), 'search_knowledge').decision).toBe('allow');
+    expect(evaluateAction(ctxOf(set), 'record_fact').decision).toBe('deny');
+    expect(evaluateAction(ctxOf(set), 'GET /v1/whatever').decision).toBe('deny');
+  });
+
+  it('@readonly macro matches read-kind actions only (registered and auto-named)', () => {
+    const set = compile({
+      posture: { actions: 'deny', reads: 'allow' },
+      rules: [
+        { id: 'ro', effect: 'allow', kind: 'action', enabled: true, actions: ['@readonly'] },
+      ],
+    });
+    const ctx = ctxOf(set);
+    expect(evaluateAction(ctx, 'search_knowledge').decision).toBe('allow');
+    expect(evaluateAction(ctx, 'graph_retrieve').decision).toBe('allow');
+    expect(evaluateAction(ctx, 'GET /v1/stats/overview').decision).toBe('allow');
+    expect(evaluateAction(ctx, 'record_fact').decision).toBe('deny');
+    expect(evaluateAction(ctx, 'forget_entity').decision).toBe('deny');
+    // Unknown non-GET auto-names are conservatively write-kind.
+    expect(evaluateAction(ctx, 'POST /v1/unknown').decision).toBe('deny');
+  });
+
+  it('@write macro denies every write in one rule', () => {
+    const set = compile({
+      rules: [
+        { id: 'nw', effect: 'deny', kind: 'action', enabled: true, actions: ['@write'] },
+      ],
+    });
+    expect(evaluateAction(ctxOf(set), 'record_fact').decision).toBe('deny');
+    expect(evaluateAction(ctxOf(set), 'search_knowledge').decision).toBe('allow');
+  });
+
+  it('multiple sets combine most-restrictive: any enforce deny wins', () => {
+    const open = compile({ name: 'open-set' });
+    const strict = compile({
+      name: 'strict-set',
+      rules: [
+        { id: 'd', effect: 'deny', kind: 'action', enabled: true, actions: ['synthesize'] },
+      ],
+    });
+    expect(evaluateAction(ctxOf(open, strict), 'synthesize').decision).toBe('deny');
+    expect(evaluateAction(ctxOf(open, strict), 'search_knowledge').decision).toBe('allow');
+  });
+
+  it('report_only set records would_deny but never blocks', () => {
+    const doc = compile({
+      mode: 'report_only',
+      posture: { actions: 'deny', reads: 'allow' },
+    });
+    const out = evaluateAction(ctxOf(doc), 'record_fact');
+    expect(out.decision).toBe('would_deny');
+    expect(out.verdicts[0]).toMatchObject({ verdict: 'deny', mode: 'report_only' });
+  });
+
+  it('forceReportOnly demotes enforce sets to would_deny', () => {
+    const set = compile({ posture: { actions: 'deny', reads: 'allow' } });
+    const ctx = { ...ctxOf(set), forceReportOnly: true };
+    expect(evaluateAction(ctx, 'record_fact').decision).toBe('would_deny');
+  });
+
+  it('disabled rules are ignored at compile time', () => {
+    const set = compile({
+      rules: [
+        { id: 'd', effect: 'deny', kind: 'action', enabled: false, actions: ['@all'] },
+      ],
+    });
+    expect(evaluateAction(ctxOf(set), 'search_knowledge').decision).toBe('allow');
+  });
+
+  it('fail-closed denyAllSet blocks everything', () => {
+    const ctx = ctxOf(denyAllSet('ghost'));
+    expect(evaluateAction(ctx, 'search_knowledge').decision).toBe('deny');
+    expect(evaluateRow(ctx, view()).decision).toBe('deny');
+  });
+});
+
+describe('policy-engine row evaluation', () => {
+  it('source equality and in-list rules deny matching rows', () => {
+    const set = compile({
+      rules: [
+        {
+          id: 'no-hr', effect: 'deny', kind: 'source', enabled: true,
+          match: [{ attr: 'source.vertical', op: 'in', value: ['hr', 'finance'] }],
+        },
+      ],
+    });
+    const ctx = ctxOf(set);
+    expect(evaluateRow(ctx, view({ source: { vertical: 'hr' } })).decision).toBe('deny');
+    expect(evaluateRow(ctx, view({ source: { vertical: 'support' } })).decision).toBe('allow');
+  });
+
+  it('numeric threshold rules on trustSnapshot work (the beat-Zep case)', () => {
+    const set = compile({
+      rules: [
+        {
+          id: 'low-trust', effect: 'deny', kind: 'source', enabled: true,
+          match: [{ attr: 'trust.authority', op: 'lt', value: 0.5 }],
+        },
+      ],
+    });
+    const ctx = ctxOf(set);
+    expect(evaluateRow(ctx, view({ trustSnapshot: { authority: 0.3 } })).decision).toBe('deny');
+    expect(evaluateRow(ctx, view({ trustSnapshot: { authority: 0.9 } })).decision).toBe('allow');
+    // Absent attribute never matches a comparator — snapshot-less rows pass.
+    expect(evaluateRow(ctx, view({ trustSnapshot: null })).decision).toBe('allow');
+  });
+
+  it('conditions inside one rule AND together', () => {
+    const set = compile({
+      rules: [
+        {
+          id: 'combo', effect: 'deny', kind: 'source', enabled: true,
+          match: [
+            { attr: 'source.vertical', op: 'eq', value: 'support' },
+            { attr: 'corroboration.count', op: 'lt', value: 2 },
+          ],
+        },
+      ],
+    });
+    const ctx = ctxOf(set);
+    expect(evaluateRow(ctx, view({ corroboration: { count: 1 } })).decision).toBe('deny');
+    expect(evaluateRow(ctx, view({ corroboration: { count: 3 } })).decision).toBe('allow');
+  });
+
+  it('default-deny reads posture with a single allow rule', () => {
+    const set = compile({
+      posture: { actions: 'allow', reads: 'deny' },
+      rules: [
+        {
+          id: 'support-only', effect: 'allow', kind: 'source', enabled: true,
+          match: [{ attr: 'source.vertical', op: 'eq', value: 'support' }],
+        },
+      ],
+    });
+    const ctx = ctxOf(set);
+    expect(evaluateRow(ctx, view()).decision).toBe('allow');
+    expect(evaluateRow(ctx, view({ source: { vertical: 'sales' } })).decision).toBe('deny');
+    // No source at all → allow rule can't match → posture denies.
+    expect(evaluateRow(ctx, view({ source: null })).decision).toBe('deny');
+  });
+
+  it('prefix, exists/not_exists, provenance.purged and userId attributes', () => {
+    const set = compile({
+      rules: [
+        {
+          id: 'purged', effect: 'deny', kind: 'source', enabled: true,
+          match: [{ attr: 'provenance.purged', op: 'eq', value: true }],
+        },
+        {
+          id: 'doc-origin', effect: 'deny', kind: 'source', enabled: true,
+          match: [{ attr: 'source.originKey', op: 'prefix', value: 'doc:bad' }],
+        },
+        {
+          id: 'personal', effect: 'deny', kind: 'source', enabled: true,
+          match: [{ attr: 'userId', op: 'exists' }],
+        },
+      ],
+    });
+    const ctx = ctxOf(set);
+    expect(
+      evaluateRow(ctx, view({ source: { provenancePurged: true } })).decision,
+    ).toBe('deny');
+    expect(
+      evaluateRow(ctx, view({ source: { originKey: 'doc:bad123' } })).decision,
+    ).toBe('deny');
+    expect(evaluateRow(ctx, view({ userId: 'u42' })).decision).toBe('deny');
+    expect(evaluateRow(ctx, view()).decision).toBe('allow');
+  });
+
+  it('source.meta dotted paths match projected document metadata', () => {
+    const set = compile({
+      rules: [
+        {
+          id: 'no-pii-class', effect: 'deny', kind: 'source', enabled: true,
+          match: [{ attr: 'source.meta.data_class', op: 'in', value: ['pii'] }],
+        },
+      ],
+    });
+    const ctx = ctxOf(set);
+    expect(
+      evaluateRow(ctx, view({ source: { meta: { data_class: 'pii' } } })).decision,
+    ).toBe('deny');
+    expect(
+      evaluateRow(ctx, view({ source: { meta: { data_class: 'public' } } })).decision,
+    ).toBe('allow');
+    expect(evaluateRow(ctx, view({ source: {} })).decision).toBe('allow');
+  });
+
+  it('piiClass comes from the lookup passed to toRowView', () => {
+    const set = compile({
+      rules: [
+        {
+          id: 'no-pii', effect: 'deny', kind: 'source', enabled: true,
+          match: [{ attr: 'piiClass', op: 'in', value: ['identifier', 'sensitive'] }],
+        },
+      ],
+    });
+    const rowView = toRowView(
+      { predicate: 'dob', source: { vertical: 'crm' } },
+      (p) => (p === 'dob' ? 'identifier' : 'none'),
+    );
+    expect(evaluateRow(ctxOf(set), rowView).decision).toBe('deny');
+  });
+
+  it('explainRow traces expected vs actual per condition', () => {
+    const set = compile({
+      rules: [
+        {
+          id: 'no-hr', effect: 'deny', kind: 'source', enabled: true,
+          match: [{ attr: 'source.vertical', op: 'eq', value: 'hr' }],
+        },
+      ],
+    });
+    const traces = explainRow(ctxOf(set), view({ source: { vertical: 'hr' } }));
+    expect(traces).toHaveLength(1);
+    expect(traces[0].verdict).toBe('deny');
+    expect(traces[0].decidedBy).toBe('no-hr');
+    expect(traces[0].rules[0].fields?.[0]).toMatchObject({
+      attr: 'source.vertical',
+      expected: 'hr',
+      actual: 'hr',
+      matched: true,
+    });
+  });
+});
+
+describe('PolicyDocumentSchema validation', () => {
+  const base = {
+    name: 'valid-set',
+    posture: { actions: 'allow', reads: 'allow' },
+    mode: 'enforce',
+  };
+
+  it('rejects unknown attributes, bad operators, and missing values', () => {
+    expect(
+      PolicyDocumentSchema.safeParse({
+        ...base,
+        rules: [{ id: 'r', effect: 'deny', kind: 'source', match: [{ attr: 'object', op: 'eq', value: 'x' }] }],
+      }).success,
+    ).toBe(false);
+    expect(
+      PolicyDocumentSchema.safeParse({
+        ...base,
+        rules: [{ id: 'r', effect: 'deny', kind: 'source', match: [{ attr: 'trust.authority', op: 'prefix', value: '0.' }] }],
+      }).success,
+    ).toBe(false);
+    expect(
+      PolicyDocumentSchema.safeParse({
+        ...base,
+        rules: [{ id: 'r', effect: 'deny', kind: 'source', match: [{ attr: 'predicate', op: 'eq' }] }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects duplicate rule ids, kind/field mismatches, unknown macros, bad names', () => {
+    expect(
+      PolicyDocumentSchema.safeParse({
+        ...base,
+        rules: [
+          { id: 'dup', effect: 'allow', kind: 'action', actions: ['@readonly'] },
+          { id: 'dup', effect: 'deny', kind: 'action', actions: ['record_fact'] },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      PolicyDocumentSchema.safeParse({
+        ...base,
+        rules: [{ id: 'r', effect: 'deny', kind: 'action', match: [{ attr: 'predicate', op: 'eq', value: 'x' }] }],
+      }).success,
+    ).toBe(false);
+    expect(
+      PolicyDocumentSchema.safeParse({
+        ...base,
+        rules: [{ id: 'r', effect: 'allow', kind: 'action', actions: ['@readwrite'] }],
+      }).success,
+    ).toBe(false);
+    expect(PolicyDocumentSchema.safeParse({ ...base, name: 'Bad Name!' }).success).toBe(false);
+  });
+
+  it('accepts a full valid document and defaults enabled=true', () => {
+    const parsed = PolicyDocumentSchema.parse({
+      ...base,
+      rules: [
+        { id: 'ro', effect: 'allow', kind: 'action', actions: ['@readonly', 'rest.stats.overview'] },
+        {
+          id: 's', effect: 'deny', kind: 'source',
+          match: [
+            { attr: 'source.meta.data_class', op: 'exists' },
+            { attr: 'trust.learnedTrust', op: 'lte', value: 0.2 },
+          ],
+        },
+      ],
+    });
+    expect(parsed.rules[0].enabled).toBe(true);
+    expect(parsed.description).toBe('');
+  });
+});

--- a/test/policy-resolver-cache.unit-spec.ts
+++ b/test/policy-resolver-cache.unit-spec.ts
@@ -1,0 +1,151 @@
+import { ConfigService } from '@nestjs/config';
+import { PolicyResolverService } from '../src/policy/policy-resolver.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { MetricsService } from '../src/metrics/metrics.service';
+import type { PolicyDocument } from '../src/policy/policy.types';
+
+const DOC: PolicyDocument = {
+  name: 'readonly-agent',
+  description: '',
+  posture: { actions: 'deny', reads: 'allow' },
+  mode: 'enforce',
+  rules: [
+    { id: 'ro', effect: 'allow', kind: 'action', enabled: true, actions: ['@readonly'] },
+  ],
+};
+
+const DISABLED_DOC: PolicyDocument = {
+  ...DOC,
+  name: 'switched-off',
+  mode: 'disabled',
+};
+
+function makeResolver(opts: {
+  env?: Record<string, string>;
+  policyRows?: Array<{ name: string; mode: string; document: PolicyDocument }>;
+  bindingRows?: Array<{ subject: string; policyNames: string[] }>;
+} = {}) {
+  let queryCalls = 0;
+  const surreal = {
+    withCompany: async (_companyId: string, fn: (db: unknown) => Promise<unknown>) => {
+      queryCalls += 1;
+      const db = {
+        query: async (sql: string) => {
+          if (sql.includes('access_policy')) {
+            return [opts.policyRows ?? [{ name: DOC.name, mode: DOC.mode, document: DOC }]];
+          }
+          return [opts.bindingRows ?? []];
+        },
+      };
+      return fn(db);
+    },
+  } as unknown as SurrealService;
+  const resolutionErrors: number[] = [];
+  const metrics = {
+    countPolicyResolutionError: () => resolutionErrors.push(1),
+  } as unknown as MetricsService;
+  const config = new ConfigService({
+    ABAC_ENABLED: '1',
+    POLICY_CACHE_TTL_MS: '60000',
+    ...(opts.env ?? {}),
+  });
+  const resolver = new PolicyResolverService(surreal, metrics, config);
+  return { resolver, resolutionErrors, loads: () => queryCalls };
+}
+
+describe('PolicyResolverService', () => {
+  it('returns null when ABAC_ENABLED is off — resolver never loads', async () => {
+    const { resolver, loads } = makeResolver({ env: { ABAC_ENABLED: '0' } });
+    expect(await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent'])).toBeNull();
+    expect(loads()).toBe(0);
+  });
+
+  it('resolves claim names to compiled sets', async () => {
+    const { resolver } = makeResolver();
+    const ctx = await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.sets).toHaveLength(1);
+    expect(ctx!.sets[0].name).toBe('readonly-agent');
+    expect(ctx!.resolutionError).toBe(false);
+  });
+
+  it('returns null for keys with no bindings and no claims (tombstone, one load per TTL)', async () => {
+    const { resolver, loads } = makeResolver();
+    expect(await resolver.contextFor('co_a', 'sha256:k1')).toBeNull();
+    expect(await resolver.contextFor('co_a', 'sha256:k2')).toBeNull();
+    expect(await resolver.contextFor('co_a', 'sha256:k3')).toBeNull();
+    expect(loads()).toBe(1);
+  });
+
+  it('unions binding-table names with claim names and dedupes', async () => {
+    const { resolver } = makeResolver({
+      policyRows: [
+        { name: DOC.name, mode: DOC.mode, document: DOC },
+        { name: 'second', mode: 'enforce', document: { ...DOC, name: 'second' } },
+      ],
+      bindingRows: [{ subject: 'key:sha256:k', policyNames: ['second', 'readonly-agent'] }],
+    });
+    const ctx = await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
+    expect(ctx!.sets.map((s) => s.name).sort()).toEqual(['readonly-agent', 'second']);
+  });
+
+  it('fails closed on an unknown referenced name (deny-all + metric)', async () => {
+    const { resolver, resolutionErrors } = makeResolver();
+    const ctx = await resolver.contextFor('co_a', 'sha256:k', ['ghost-set']);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.resolutionError).toBe(true);
+    expect(ctx!.sets[0].posture).toEqual({ actions: 'deny', reads: 'deny' });
+    expect(ctx!.sets[0].mode).toBe('enforce');
+    expect(resolutionErrors).toHaveLength(1);
+  });
+
+  it('skips DISABLED sets silently (known name ≠ dangling reference)', async () => {
+    const { resolver, resolutionErrors } = makeResolver({
+      policyRows: [
+        { name: DISABLED_DOC.name, mode: 'disabled', document: DISABLED_DOC },
+      ],
+    });
+    const ctx = await resolver.contextFor('co_a', 'sha256:k', ['switched-off']);
+    expect(ctx).toBeNull();
+    expect(resolutionErrors).toHaveLength(0);
+  });
+
+  it('serves from cache within TTL and reloads after invalidate()', async () => {
+    const { resolver, loads } = makeResolver();
+    await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
+    await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
+    expect(loads()).toBe(1);
+    resolver.invalidate('co_a');
+    await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
+    expect(loads()).toBe(2);
+  });
+
+  it('dedupes concurrent cold loads (in-flight promise sharing)', async () => {
+    const { resolver, loads } = makeResolver();
+    await Promise.all([
+      resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']),
+      resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']),
+      resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']),
+    ]);
+    expect(loads()).toBe(1);
+  });
+
+  it('honours ABAC_FORCE_REPORT_ONLY on the context', async () => {
+    const { resolver } = makeResolver({ env: { ABAC_FORCE_REPORT_ONLY: '1' } });
+    const ctx = await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
+    expect(ctx!.forceReportOnly).toBe(true);
+  });
+
+  it('caps referenced sets at 8', async () => {
+    const many = Array.from({ length: 12 }, (_, i) => `set-${i}`);
+    const { resolver } = makeResolver({
+      policyRows: many.map((name) => ({
+        name,
+        mode: 'enforce',
+        document: { ...DOC, name },
+      })),
+    });
+    const ctx = await resolver.contextFor('co_a', 'sha256:k', many);
+    expect(ctx!.sets.length).toBeLessThanOrEqual(8);
+  });
+});


### PR DESCRIPTION
## What

Attribute-based access control for API keys — the answer to "scopes are coarse: any `brain:read` key reads the whole tenant graph". Tenants create named **policy sets** and attach them to individual keys; a set carries deny-overrides rules of two kinds:

- **action rules** — gate REST endpoints + MCP tools by name (`search_knowledge`, `record_fact`, `rest.documents.get`, …) or via `@readonly` / `@write` / `@all` macros;
- **source rules** — gate which *rows* a key can read, matching `predicate`, `piiClass`, `source.vertical/recorder/documentId/originKey`, `source.meta.*`, **numeric `trustSnapshot` thresholds**, `corroboration.count`, `provenance.purged`, and `userId`.

Everything sits behind `ABAC_ENABLED` (default off). A key with no policies attached — or a deployment that never flips the flag — behaves **byte-identically** to today, pinned by a golden e2e.

## Design

- **Evaluation**: explicit deny > explicit allow > per-domain default posture; conditions in a rule AND, list values OR; multiple sets per key (max 8) combine most-restrictive; `report_only` sets log `would_deny` and never block; unknown referenced set names **fail closed** (synthetic deny-all + `brain_policy_resolution_errors_total`).
- **Action gate** in `ApiKeyGuard` after the scope check — `@PolicyAction` names with a `"<METHOD> <path>"` fallback so default-deny has no unnamed holes; enforce-deny → `403 policy_denied`. MCP: enforce-denied tools are unregistered in `buildServer` and vanish from `tools/list`.
- **Row gate** rides AsyncLocalStorage (no signature threading): applied at search fusion / edge expansion / backfill, `graph_retrieve`, competing facts, entity profile / timeline / connections (edges via `kind`), code-memory recall. The existing `requiresScope` PII gate always runs first and is never weakened.
- **Resolution cost**: one query per tenant per `POLICY_CACHE_TTL_MS` (60 s), zero per request; compiled matcher closures keep per-request row evaluation well under 1 ms (`brain_policy_eval_seconds`).
- **Decisions**: buffered `policy_decision` stream — action decisions per call, row decisions as per-request aggregates; allows sampled at `POLICY_DECISION_SAMPLE_RATE`; lazy 30-day prune.
- **Admin surface**: `/v1/admin/policy-sets` CRUD (PUT + optimistic `version`, 409 with current copy), attachments (validated — keeps fail-closed unreachable via the API), bindings, and `explain` with per-rule expected-vs-actual traces for an action or a stored fact.

## Behavior fix

`graph_retrieve` previously skipped the JS `requiresScope` predicate filter that `/v1/search` applies — PII-scoped facts could surface there for callers without `brain:read_pii` (the DB fence only nulls `object` for the two hardcoded predicates). The shared row filter now closes that gap.

## Rollout

`docs/abac.md` carries the runbook: create a set in `report_only` → attach to one key → watch `would_deny` decisions + explain → flip to `enforce`. Kill switches: per-set mode (≤60 s), detach, `ABAC_FORCE_REPORT_ONLY`, `ABAC_ENABLED=0`.

## Tests

- unit: engine semantics matrix (20), resolver cache (10), MCP tool gate (4), contract drift (3), JWT `policy` claim extraction
- e2e: action gate (enforce 403 / report_only decision rows / master switch off), row filter across search + entity surfaces with the **golden invariant** (policy-free key response deep-equals the ABAC-off baseline), explain traces
- full suites green: 1030 unit / 244 e2e

Part 1/6 of the ABAC track (next: metadata projection + simulation endpoints, then the policy editor + Key Lens UI in brain-landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cKmGsUBwi3kcFp2nE5dxm