### PR TITLE
fix(security): audit wave A — dead nightly cron + phantom-fence PII leaks + artifact scope

### DIFF
--- a/src/artifacts/artifacts.service.ts
+++ b/src/artifacts/artifacts.service.ts
@@ -258,9 +258,20 @@ export class ArtifactsService {
     rid: string,
     scopes: BrainScope[],
   ): Promise<FactRow[]> {
-    // Use the centralised server-side function from migration 0003.
+    // Mirrors fn::active_facts_for (migration 0003) but pins the
+    // tenant-GLOBAL scope: artifacts are a tenant-wide surface with no
+    // per-user concept (like graph_retrieve), so a per-user fact
+    // (userId != NONE, migration 0055) must never be compiled into a
+    // dossier served to the whole tenant. The stored fn predates 0055 and
+    // has no scope arg, so we query inline instead of extending it.
     const [rows] = await db.query<[any[]]>(
-      `RETURN fn::active_facts_for(type::record('knowledge_entity', $rid), NONE)`,
+      `SELECT id, predicate, object, confidence, validFrom, validUntil,
+              recordedAt, source, status
+         FROM knowledge_fact
+         WHERE entityId = type::record('knowledge_entity', $rid)
+           AND retractedAt IS NONE
+           AND userId IS NONE
+         ORDER BY recordedAt DESC`,
       { rid },
     );
     return ((rows as any[]) ?? [])

--- a/src/communities/community-builder.service.ts
+++ b/src/communities/community-builder.service.ts
@@ -14,6 +14,7 @@ import {
   buildAdjacency,
   labelPropagation,
 } from './label-propagation';
+import { policyFor } from '../ingest/conflict-resolver';
 
 /**
  * CommunityBuilderService — clusters the tenant's entity graph into
@@ -286,7 +287,8 @@ export class CommunityBuilderService {
 
     // Member display names — label off the first, summary lists the rest.
     const [nameRows] = await db.query<[Array<{ id: unknown; canonicalName: string }>]>(
-      `SELECT id, canonicalName FROM knowledge_entity WHERE id INSIDE $ids`,
+      `SELECT id, canonicalName FROM knowledge_entity
+         WHERE id INSIDE $ids AND userId IS NONE`,
       { ids: ridSample },
     );
     const names = (nameRows as Array<{ id: unknown; canonicalName: string }>) ?? [];
@@ -307,20 +309,30 @@ export class CommunityBuilderService {
          WHERE entityId INSIDE $ids
            AND status = 'active'
            AND retractedAt IS NONE
+           AND userId IS NONE
          ORDER BY confidence DESC, validFrom ASC, predicate ASC, object ASC
-         LIMIT 40`,
+         LIMIT 60`,
       { ids: ridSample },
     );
+    // The community summary is persisted and read tenant-wide with only
+    // brain:read — it can carry no per-caller redaction. So a PII-classed
+    // fact's `object` (address/dob) baked into the summary would leak to
+    // every reader without brain:read_pii. Drop requiresScope predicates
+    // at build time (over-fetch to 60 so the visible 40 stay full), and
+    // pin to the tenant-global scope (personal facts never fold in).
     const summaryInput: FactToSummarize[] = (
       (factRows as RawFact[]) ?? []
-    ).map((f) => ({
-      factId: String(f.entityId),
-      predicate: f.predicate,
-      object: f.object,
-      validFrom: toIso(f.validFrom),
-      validUntil: f.validUntil ? toIso(f.validUntil) : undefined,
-      confidence: typeof f.confidence === 'number' ? f.confidence : 0.5,
-    }));
+    )
+      .filter((f) => !policyFor(f.predicate).requiresScope)
+      .slice(0, 40)
+      .map((f) => ({
+        factId: String(f.entityId),
+        predicate: f.predicate,
+        object: f.object,
+        validFrom: toIso(f.validFrom),
+        validUntil: f.validUntil ? toIso(f.validUntil) : undefined,
+        confidence: typeof f.confidence === 'number' ? f.confidence : 0.5,
+      }));
     return { label, summaryInput };
   }
 

--- a/src/diff/memory-diff.service.ts
+++ b/src/diff/memory-diff.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { SurrealService } from '../db/surreal.service';
+import { makeRowPolicyFilter } from '../policy/row-filter';
 
 /**
  * memory_diff — return everything brain learned (and unlearned) between
@@ -46,12 +47,18 @@ export class MemoryDiffService {
       throw new Error('memory_diff: from must be strictly before to');
     }
 
-    // Scoped pool, not root: the diff SELECTs fact `object` values, so it
-    // must sit behind the same DB-level PII fence ($caller_scopes,
-    // migration 0005) as every other read surface — memory_diff is
-    // MCP-only and used to be the one read that bypassed it.
+    // The diff SELECTs fact `object` values, so it must run the same
+    // app-layer gate as every other read surface: the DB-level PII fence
+    // (migration 0005) is inert for the system-user pool (verified in
+    // test/abac-db-fence.e2e-spec.ts), so the scoped pool alone leaks —
+    // the JS filter (requiresScope PII gate + ABAC row rules) is the only
+    // working gate. Rows the caller may not see never enter the result.
     return this.surreal.withScopedCompany(companyId, callerScopes, async (db) => {
       const scoping = buildScoping(args);
+      const rowFilter = makeRowPolicyFilter({
+        callerScopes,
+        surface: 'memory_diff',
+      });
 
       // CREATED: facts whose recordedAt landed in [from, to). We don't
       // care whether they were later retracted — at the moment of
@@ -100,15 +107,17 @@ export class MemoryDiffService {
         { from, to },
       );
 
-      const createdFacts: FactRef[] = ((createdRows as any[]) ?? []).map(
-        rowToFactRef,
-      );
+      const createdFacts: FactRef[] = ((createdRows as any[]) ?? [])
+        .filter((r) => rowFilter.filter(r))
+        .map(rowToFactRef);
       const retracted: Array<FactRef & { supersededBy?: string }> = (
         (retractedRows as any[]) ?? []
-      ).map((r) => ({
-        ...rowToFactRef(r),
-        supersededBy: r.supersededBy ? String(r.supersededBy) : undefined,
-      }));
+      )
+        .filter((r) => rowFilter.filter(r))
+        .map((r) => ({
+          ...rowToFactRef(r),
+          supersededBy: r.supersededBy ? String(r.supersededBy) : undefined,
+        }));
 
       // Partition the retract bucket: rows with supersededBy are
       // "changed" — replacement story; rows without supersededBy are
@@ -162,7 +171,7 @@ export class MemoryDiffService {
           { tail },
         );
         const r = (afterRows as any[])?.[0];
-        if (r) {
+        if (r && rowFilter.filter(r)) {
           const ref = rowToFactRef(r);
           replacementMap.set(ref.factId, ref);
         }
@@ -196,6 +205,8 @@ export class MemoryDiffService {
         forgottenAt: toIso(r.forgottenAt),
       }));
 
+      rowFilter.finish();
+
       this.logger.log(
         `[memory.diff] companyId=${companyId} window=${from.toISOString()}..${to.toISOString()} ` +
           `created=${netCreated.length} retracted=${retractedFacts.length} ` +
@@ -218,7 +229,7 @@ export class MemoryDiffService {
 
 const FACT_FIELDS =
   'id, entityId, predicate, object, confidence, validFrom, validUntil, ' +
-  'recordedAt, retractedAt';
+  'recordedAt, retractedAt, userId, source, trustSnapshot, corroboration';
 
 interface ScopingClauses {
   factClause: string;

--- a/src/documents/candidate-store.service.ts
+++ b/src/documents/candidate-store.service.ts
@@ -124,7 +124,7 @@ export class CandidateStoreService {
       const [rows] = await db.query<[any[]]>(
         `SELECT count() AS c FROM indexer_run
            WHERE status = 'running'
-             AND createdAt < time::now() - duration::from::millis($ms)
+             AND createdAt < time::now() - duration::from_millis($ms)
            GROUP ALL`,
         { ms: staleRunMs() },
       );
@@ -135,7 +135,7 @@ export class CandidateStoreService {
              status = 'failed', finishedAt = time::now(),
              error = { message: 'stale_reaped' }
            WHERE status = 'running'
-             AND createdAt < time::now() - duration::from::millis($ms)
+             AND createdAt < time::now() - duration::from_millis($ms)
            RETURN NONE`,
           { ms: staleRunMs() },
         );

--- a/src/documents/candidate-sweeper.service.ts
+++ b/src/documents/candidate-sweeper.service.ts
@@ -83,20 +83,20 @@ export class CandidateSweeperService implements OnModuleInit {
     const pendingTtlDays = envInt('CANDIDATE_PENDING_TTL_DAYS', 7);
     return this.surreal.withCompany(companyId, async (db) => {
       const expired = await this.countThen(db, {
-        countWhere: `status = 'pending' AND createdAt < time::now() - duration::from::days($days)`,
+        countWhere: `status = 'pending' AND createdAt < time::now() - duration::from_days($days)`,
         mutation: `UPDATE candidate SET status = 'expired',
              statusReason = 'sweeper_ttl', decidedAt = time::now()
            WHERE status = 'pending'
-             AND createdAt < time::now() - duration::from::days($days)
+             AND createdAt < time::now() - duration::from_days($days)
            RETURN NONE`,
         params: { days: pendingTtlDays },
       });
       const deleted = await this.countThen(db, {
-        countWhere: `status != 'pending' AND decidedAt != NONE AND decidedAt < time::now() - duration::from::days($days)`,
+        countWhere: `status != 'pending' AND decidedAt != NONE AND decidedAt < time::now() - duration::from_days($days)`,
         mutation: `DELETE candidate
            WHERE status != 'pending'
              AND decidedAt != NONE
-             AND decidedAt < time::now() - duration::from::days($days)`,
+             AND decidedAt < time::now() - duration::from_days($days)`,
         params: { days: retentionDays },
       });
       // Document retention leg: expired retainUntil → chunks go, header +

--- a/src/documents/documents.controller.ts
+++ b/src/documents/documents.controller.ts
@@ -108,9 +108,16 @@ function redactGatedCandidates(
     if (c.kind !== 'fact') return c;
     const requiresScope = policyFor(String(c.payload?.predicate ?? '')).requiresScope;
     if (!requiresScope || scopes.includes(requiresScope)) return c;
-    return {
-      ...c,
-      payload: { ...c.payload, object: '[redacted]', redacted: true },
+    // Redact BOTH the extracted value and the verbatim grounding
+    // sentence: `clause` is a quote from the source document and carries
+    // the same PII the `object` does, so redacting object alone still
+    // leaked the value through the citation.
+    const redactedPayload: Record<string, unknown> = {
+      ...c.payload,
+      object: '[redacted]',
+      redacted: true,
     };
+    if ('clause' in redactedPayload) redactedPayload.clause = '[redacted]';
+    return { ...c, payload: redactedPayload };
   });
 }

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -47,6 +47,17 @@ export class UserForgetService {
       const factIds = ((factIdRows as unknown[]) ?? []).map(String);
       const entityIds = ((entityIdRows as unknown[]) ?? []).map(String);
 
+      // Every entity this user had a fact on — personal AND shared. Their
+      // compiled dossiers (knowledge_artifact) may have baked in the
+      // user's personal fact text, so they must go before the facts do.
+      const [factEntityRows] = await db.query<[unknown[]]>(
+        `SELECT VALUE entityId FROM knowledge_fact WHERE userId = $u`,
+        { u: userId },
+      );
+      const touchedEntityIds = [
+        ...new Set(((factEntityRows as unknown[]) ?? []).map(String)),
+      ];
+
       // Side tables keyed by fact records — traversal needs live facts.
       await db.query(`DELETE fact_usage WHERE factId.userId = $u`, {
         u: userId,
@@ -66,6 +77,21 @@ export class UserForgetService {
       await db.query(`DELETE entity_external_ref WHERE entity.userId = $u`, {
         u: userId,
       });
+      // Compiled dossiers for every touched entity — personal ones die
+      // with the entity, shared ones recompile clean (fenced to global
+      // facts) on next read. Must precede the fact delete: entityId is a
+      // record link the artifact carries independently, but doing it here
+      // keeps the erasure atomic with the rest of the cascade.
+      for (const eid of touchedEntityIds) {
+        const tail = eid.startsWith('knowledge_entity:')
+          ? eid.slice('knowledge_entity:'.length)
+          : eid;
+        await db.query(
+          `DELETE knowledge_artifact
+             WHERE entityId = type::record('knowledge_entity', $tail)`,
+          { tail },
+        );
+      }
 
       await db.query(`DELETE knowledge_fact WHERE userId = $u`, { u: userId });
       await db.query(`DELETE knowledge_entity WHERE userId = $u`, {

--- a/src/ingest/ingest-predictor.service.ts
+++ b/src/ingest/ingest-predictor.service.ts
@@ -4,12 +4,14 @@ import { SurrealService } from '../db/surreal.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { PredictScoringService } from './predict-scoring.service';
 import {
+  OpposingFact,
   PredictResolveArgs,
   PredictResolveResult,
   PriorRow,
   intervalsOverlap,
   rowToOpposingFact,
 } from './predictor-internals';
+import { makeRowPolicyFilter } from '../policy/row-filter';
 
 export type {
   IngestOutcome,
@@ -55,11 +57,30 @@ export class IngestPredictionService {
     args: PredictResolveArgs,
     callerScopes: readonly string[],
   ): Promise<PredictResolveResult> {
-    // Scoped pool, not root: opposingFacts carry raw `object` values, so
-    // the preflight must sit behind the same DB-level PII fence
-    // ($caller_scopes, migration 0005) as the read surface — this path
-    // is MCP-only (detect_contradiction) and used to bypass it.
-    return this.surreal.withScopedCompany(companyId, callerScopes, async (db) => {
+    // opposingFacts carry raw `object` values, so the preflight must run
+    // the same app-layer gate as every read surface. The DB-level PII
+    // fence (migration 0005) is inert for the system-user pool (verified
+    // in test/abac-db-fence.e2e-spec.ts), so the JS filter (requiresScope
+    // PII gate + ABAC row rules) is the only working gate. It gates the
+    // returned opposingFacts only — the priors still drive the decision,
+    // so wouldOutcome is unchanged by what the caller may or may not see.
+    return this.surreal.withScopedCompany(companyId, callerScopes, (db) =>
+      this.predictScoped({ db, companyId, args, callerScopes }),
+    );
+  }
+
+  private async predictScoped(opts: {
+    db: Surreal;
+    companyId: string;
+    args: PredictResolveArgs;
+    callerScopes: readonly string[];
+  }): Promise<PredictResolveResult> {
+    const { db, companyId, args, callerScopes } = opts;
+    const rowFilter = makeRowPolicyFilter({
+      callerScopes,
+      surface: 'detect_contradiction',
+    });
+    try {
       const entityId = await this.lookupEntity(db, args.entityRef);
       if (!entityId) {
         return {
@@ -97,7 +118,8 @@ export class IngestPredictionService {
         : entityId;
       const [rows] = await db.query<any[][]>(
         `SELECT id, predicate, object, confidence, validFrom, validUntil,
-                recordedAt, embedding, source, status
+                recordedAt, embedding, source, status,
+                userId, trustSnapshot, corroboration
            FROM knowledge_fact
            WHERE entityId = type::record('knowledge_entity', $eid)
              AND predicate = $predicate
@@ -110,6 +132,17 @@ export class IngestPredictionService {
       );
       const priors = ((rows as any[]) ?? []) as PriorRow[];
 
+      // The caller only sees an opposing fact it is allowed to read. The
+      // priors themselves are untouched — the decision below runs on the
+      // full set — so gating never changes wouldOutcome, only the list.
+      const priorById = new Map(priors.map((p) => [String(p.id), p]));
+      const gate = (list: OpposingFact[]): OpposingFact[] =>
+        list.filter((o) =>
+          rowFilter.filter(
+            (priorById.get(o.factId) as never) ?? { predicate: o.predicate },
+          ),
+        );
+
       const candidateScore = this.scoring.scoreCandidate(args);
 
       if (candidateScore < this.scoring.conflict.rejectThreshold) {
@@ -117,7 +150,7 @@ export class IngestPredictionService {
           wouldOutcome: 'REJECTED',
           reasoning:
             `Candidate score ${candidateScore.toFixed(3)} is below the reject threshold ${this.scoring.conflict.rejectThreshold.toFixed(3)} — too unconfident or too low-trust to enter the graph.`,
-          opposingFacts: priors.map(rowToOpposingFact),
+          opposingFacts: gate(priors.map(rowToOpposingFact)),
           predicatePolicy: policy,
         };
       }
@@ -151,8 +184,10 @@ export class IngestPredictionService {
       }
 
       if (policy.semantics === 'single_active') {
+        const r = this.scoring.predictSingleActive(candidateScore, overlapping);
         return {
-          ...this.scoring.predictSingleActive(candidateScore, overlapping),
+          ...r,
+          opposingFacts: gate(r.opposingFacts),
           predicatePolicy: policy,
         };
       }
@@ -167,15 +202,19 @@ export class IngestPredictionService {
           wouldOutcome: 'INSERTED',
           reasoning:
             `Overlapping facts exist but none clear the cosine similarity threshold ${this.scoring.conflict.similarityThreshold.toFixed(2)}; semantically distinct, no contradiction.`,
-          opposingFacts: scored.map((c) => c.opposing),
+          opposingFacts: gate(scored.map((c) => c.opposing)),
           predicatePolicy: policy,
         };
       }
+      const r = this.scoring.predictBitemporal(candidateScore, above);
       return {
-        ...this.scoring.predictBitemporal(candidateScore, above),
+        ...r,
+        opposingFacts: gate(r.opposingFacts),
         predicatePolicy: policy,
       };
-    });
+    } finally {
+      rowFilter.finish();
+    }
   }
 
   private async lookupEntity(

--- a/src/metrics/memory-quality.service.ts
+++ b/src/metrics/memory-quality.service.ts
@@ -97,7 +97,7 @@ export class MemoryQualityService {
       for (const days of STALE_BUCKETS_DAYS) {
         staleActiveFacts[days] = await this.countWhere(
           db,
-          `status = 'active' AND recordedAt < time::now() - duration::from::days($days)`,
+          `status = 'active' AND recordedAt < time::now() - duration::from_days($days)`,
           { days },
         );
       }

--- a/src/summarize-entity/summarize-entity.service.ts
+++ b/src/summarize-entity/summarize-entity.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { createHash } from 'node:crypto';
 import { EntitiesService } from '../entities/entities.service';
 import { BrainScope } from '../auth/api-key.types';
+import { getPolicyContext } from '../common/request-context';
 
 /**
  * summarize_entity — one-liner-per-entity surface for LLM context.
@@ -47,7 +48,7 @@ export class SummarizeEntityService {
     args: SummarizeArgs,
     scopes: BrainScope[],
   ): Promise<SummarizeResult> {
-    const cacheKey = buildCacheKey(companyId, args);
+    const cacheKey = buildCacheKey(companyId, args, scopes);
     // Freshness probe FIRST — one cheap indexed aggregate. Its wall-clock
     // watermark decides whether a cache hit is still valid.
     const watermark = await this.entities.freshnessWatermark({
@@ -138,10 +139,24 @@ function isStale(
   return (builtWatermark ?? '') !== (currentWatermark ?? '');
 }
 
-function buildCacheKey(companyId: string, args: SummarizeArgs): string {
+function buildCacheKey(
+  companyId: string,
+  args: SummarizeArgs,
+  scopes: readonly BrainScope[],
+): string {
   const asOf = args.asOf ?? 'now';
   const style = args.styleHint ?? 'neutral';
-  const raw = `${companyId}::${args.entityId}::${asOf}::${style}`;
+  // The rendered summary bakes in the exact facts getProfile returned,
+  // which depend on the caller's VISIBILITY: the scope set (the PII gate)
+  // and, when ABAC is on, the key's policy (its keyHash identity). Two
+  // callers with different visibility must never share a cache entry —
+  // otherwise a read_pii summary is served to a brain:read key. Fold both
+  // axes into the key. Absent policy context (ABAC off) → scopes decide.
+  const visibility =
+    [...scopes].sort().join(',') +
+    '::' +
+    (getPolicyContext()?.keyHash ?? 'no-policy');
+  const raw = `${companyId}::${args.entityId}::${asOf}::${style}::${visibility}`;
   return createHash('sha256').update(raw).digest('hex').slice(0, 32);
 }
 

--- a/test/artifacts-user-scope.e2e-spec.ts
+++ b/test/artifacts-user-scope.e2e-spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Artifacts × per-user scope (migration 0055) against a REAL SurrealDB.
+ *
+ * fn::active_facts_for (migration 0003) had no userId filter, so a
+ * personal fact attached to a SHARED entity (bare-entityId + userId)
+ * used to compile into the tenant-wide knowledge_artifact and serve to
+ * any brain:read caller — and user-forget never purged the dossier.
+ * This pins both: the personal fact stays out of the compiled artifact,
+ * and forget takes the artifact with it.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { ArtifactsService } from '../src/artifacts/artifacts.service';
+
+describe('artifacts respect per-user scope', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const scopes = ['brain:read', 'brain:read_pii'] as never;
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_artifact_scope_e2e' });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  const ingest = async (body: Record<string, unknown>) => {
+    const r = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      validFrom: '2026-01-01',
+      confidence: 0.9,
+      source: { vertical: 'rent', recorder: 'bot' },
+      ...body,
+    });
+    expect([200, 201]).toContain(r.status);
+    return r.body;
+  };
+
+  it('excludes personal facts from the compiled dossier, and forget purges it', async () => {
+    // Global name on a shared entity.
+    const anchor = await ingest({
+      entityRef: { vertical: 'rent', id: 'artifact_shared_subject' },
+      predicate: 'name',
+      object: 'Public Shared Name',
+    });
+    const surreal = f.app.get(SurrealService);
+    const entityId = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ entityId: unknown }>]>(
+        `SELECT entityId FROM type::record('knowledge_fact', $tail)`,
+        { tail: (anchor.factId as string).split(':')[1] },
+      );
+      return String((rows as Array<{ entityId: unknown }>)[0].entityId);
+    });
+
+    // Personal name on the SAME shared entity (bare-entityId + userId).
+    await ingest({
+      entityRef: { entityId },
+      predicate: 'name',
+      object: 'Personal Secret Name',
+      userId: 'user_art',
+    });
+
+    const artifacts = f.app.get(ArtifactsService);
+    const built = await artifacts.getArtifact({
+      companyId: f.companyId,
+      entityIdRaw: entityId,
+      artifactType: 'customer_profile',
+      scopes,
+    });
+    const serialized = JSON.stringify(built);
+    expect(serialized).toContain('Public Shared Name');
+    expect(serialized).not.toContain('Personal Secret Name');
+
+    // The dossier row now exists; user-forget must take it.
+    const beforeCount = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM knowledge_artifact
+           WHERE entityId = type::record('knowledge_entity', $tail) GROUP ALL`,
+        { tail: entityId.split(':')[1] },
+      );
+      return (rows as Array<{ n: number }>)[0]?.n ?? 0;
+    });
+    expect(beforeCount).toBeGreaterThanOrEqual(1);
+
+    const forget = await f.http
+      .post('/v1/users/user_art/forget')
+      .set(auth())
+      .send({});
+    expect([200, 201]).toContain(forget.status);
+
+    const afterCount = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM knowledge_artifact
+           WHERE entityId = type::record('knowledge_entity', $tail) GROUP ALL`,
+        { tail: entityId.split(':')[1] },
+      );
+      return (rows as Array<{ n: number }>)[0]?.n ?? 0;
+    });
+    expect(afterCount).toBe(0);
+  });
+});

--- a/test/memory-diff.e2e-spec.ts
+++ b/test/memory-diff.e2e-spec.ts
@@ -226,4 +226,50 @@ describe('MemoryDiffService.diff — window math', () => {
     expect(out.retractedFacts).toHaveLength(0);
     expect(out.changedFacts).toHaveLength(0);
   });
+
+  it('gates PII-predicate facts for a caller without brain:read_pii', async () => {
+    const surreal = f.app.get(SurrealService);
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `CREATE type::record('knowledge_fact', $rid) CONTENT {
+            entityId: type::record('knowledge_entity', $eid),
+            predicate: 'address',
+            object: $obj,
+            confidence: 0.95,
+            validFrom: $vf,
+            recordedAt: $ra,
+            status: 'active',
+            source: { vertical: 'rent' }
+         }`,
+        {
+          rid: 'md_pii_1',
+          eid: ENT,
+          obj: '42 Secret Lane',
+          vf: T1,
+          ra: T1,
+        },
+      );
+    });
+
+    const diff = f.app.get(MemoryDiffService);
+    const window = { from: T0.toISOString(), to: T3.toISOString() };
+
+    // With read_pii the address is visible.
+    const privileged = await diff.diff(f.companyId, window, [
+      'brain:read',
+      'brain:read_pii',
+    ]);
+    expect(
+      privileged.createdFacts.some((fa) => fa.object === '42 Secret Lane'),
+    ).toBe(true);
+
+    // Without read_pii the PII-predicate fact never enters the result —
+    // the DB-level fence is inert for the system user, so the JS gate is
+    // the only thing standing between brain:read and the raw address.
+    const restricted = await diff.diff(f.companyId, window, ['brain:read']);
+    expect(
+      restricted.createdFacts.some((fa) => fa.predicate === 'address'),
+    ).toBe(false);
+    expect(JSON.stringify(restricted)).not.toContain('42 Secret Lane');
+  });
 });

--- a/test/memory-quality.e2e-spec.ts
+++ b/test/memory-quality.e2e-spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Memory-quality nightly pass against a REAL SurrealDB — regression for
+ * the `duration::from::days` 2.x idiom that SurrealDB 3.x fails to parse
+ * ("did you maybe mean `duration::from_days`"). Every tenant threw on the
+ * stale-bucket loop, so the nightly cron published all-zero gauges (and
+ * the collateral brain_policy_sets_active never ran). The unit spec mocks
+ * the DB, so only a real-DB pass catches the parse error.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { MemoryQualityService } from '../src/metrics/memory-quality.service';
+
+describe('memory-quality nightly pass (real SurrealDB)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_memquality_e2e' });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('collects gauges without throwing on the stale-bucket duration query', async () => {
+    const ingest = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: { vertical: 'rent', id: 'memquality_subject' },
+      predicate: 'name',
+      object: 'Memory Quality Probe',
+      validFrom: '2026-01-01',
+      confidence: 0.9,
+      source: { vertical: 'rent', recorder: 'bot' },
+    });
+    expect([200, 201]).toContain(ingest.status);
+
+    const svc = f.app.get(MemoryQualityService);
+    // Pre-fix this threw a parse error inside collectTenant → the tenant
+    // was skipped and every gauge fell to 0. Post-fix the query parses and
+    // the active fact we just ingested is counted.
+    const snapshot = await svc.collectNow();
+
+    expect(snapshot.factsByStatus['active']).toBeGreaterThanOrEqual(1);
+    // Stale buckets must be present (all three keys populated, not skipped).
+    expect(Object.keys(snapshot.staleActiveFacts).sort()).toEqual([
+      '30',
+      '365',
+      '90',
+    ]);
+    // A freshly ingested fact is not stale at any horizon.
+    expect(snapshot.staleActiveFacts[30]).toBe(0);
+  });
+});

--- a/test/memory-quality.unit-spec.ts
+++ b/test/memory-quality.unit-spec.ts
@@ -20,7 +20,7 @@ const tenantDb = {
         ],
       ];
     }
-    if (sql.includes('duration::from::days')) {
+    if (sql.includes('duration::from_days')) {
       const days = params?.days as number;
       return [[{ n: days === 30 ? 6 : days === 90 ? 4 : 1 }]];
     }


### PR DESCRIPTION
Wave A of the v0.6.0 audit (2026-07-11) — the LIVE-in-prod critical set on the #145 memory/user-scope + ABAC surface. All fixes verified against a real SurrealDB 3.1.5; full suite green (unit 1041, e2e 264, +3 new regression tests).

## Dead nightly cron (SurrealDB 3.x parse error)
`memory-quality.service.ts` used the 2.x `duration::from::days` idiom, which **fails to parse** on 3.1.5 (`did you maybe mean duration::from_days`). Every tenant threw on the stale-bucket loop → the nightly pass published all-zero gauges (`brain_memory_*` + the collateral `brain_policy_sets_active`). The same idiom in the doc-pipeline sweeper/store (`from::days` / `from::millis`) has been live since the pipeline was enabled — candidate retention never swept. Fixed to `duration::from_days` / `duration::from_millis`; added a **real-DB e2e** (the unit spec mocks the DB, so only a real pass catches the parse error).

## Phantom-fence PII leaks
The DB-level PII fence (migration 0005) is inert for the system-user pool — verified by the ABAC track's own canary (`test/abac-db-fence.e2e-spec.ts`) — so the app-layer JS filter is the only working gate. These surfaces lacked it:
- **memory_diff** and **detect_contradiction** returned raw fact `object` to a `brain:read` caller without `brain:read_pii`. Both now run `makeRowPolicyFilter` (requiresScope PII gate + ABAC row rules); detect_contradiction gates only the returned `opposingFacts`, so the decision is unchanged. New e2e proves a no-`read_pii` caller never sees an `address` fact.
- **summarize_entity** cached by `(companyId, entityId, asOf, style)` — scope-blind, so a `read_pii` summary was served to a `brain:read` key. The cache key now folds in the caller's scope set and (when ABAC is on) the key's policy identity.
- **community summaries** baked PII-predicate `object` values into a tenant-wide blob read with `brain:read`. Build now drops `requiresScope` predicates and pins the tenant-global scope.
- **GET /documents/:id/candidates** redacted `payload.object` but not the verbatim grounding `clause` — same PII through the citation. Now redacts both.

## Per-user scope leak + GDPR (artifacts)
Artifact compilation read facts via `fn::active_facts_for` (migration 0003), which has **no userId filter**, so a personal fact on a shared entity compiled into a tenant-wide dossier served to any `brain:read` caller — and `user-forget` never purged it. Now queried inline with `userId IS NONE` (artifacts are a tenant-global surface, like graph_retrieve); `user-forget` purges `knowledge_artifact` for every entity the user touched (personal dies with the entity, shared recompiles clean). New e2e covers both.

## Not in this PR (later waves, per the audit)
- **B (live-medium):** feedback→source-trust anti-farming, raw `dto.source.meta` sanitizer bypass, entity `__u__` / canonical-name mixing.
- **C (before enabling ABAC):** ABAC row rules on the same surfaces + candidates, temporal-window UI strip, meta-union cross-tenant cache.
- **D (before HNSW):** drop-first reindex ordering.
- **E (docs):** `.env.example`, `api.md`, flag validator, GDPR cascade for the new side-tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYm9x6dMncfHuRR9xseWHn