### PR TITLE
fix(security): audit wave B — feedback trust farming, source.meta bypass, entity scope collision

### DIFF
--- a/src/ai/calibration/calibration-refit-runner.service.ts
+++ b/src/ai/calibration/calibration-refit-runner.service.ts
@@ -191,13 +191,17 @@ export class CalibrationRefitRunnerService {
       );
       // Retrieval feedback (migration 0054) joins the same win/loss
       // currency: 'helpful' confirms the source, 'incorrect' counts
-      // against it. One standing vote per (fact, caller key) is enforced
-      // at write time (UNIQUE index), so a single consumer can't farm
-      // its own source's rate. 'not_helpful' is a relevance signal, not
-      // a reliability one — excluded here by the WHERE.
+      // against it. The UNIQUE (factId, actor) write index stops stacking
+      // votes on ONE fact, but a single actor can still vote across every
+      // fact of a source (factIds are enumerable from search) and farm N
+      // losses/wins into one (source, predicate) rate. buildFeedbackTrust-
+      // Events dedups per (actor, scope, verdict) to cap that at one, so
+      // only DISTINCT callers move a source's rate — `actor` is projected
+      // for that. 'not_helpful' is a relevance signal, excluded by WHERE.
       const [feedbackRows] = await db.query<
         [
           Array<{
+            actor: string | null;
             vertical: string | null;
             recorder: string | null;
             predicate: string;
@@ -207,6 +211,7 @@ export class CalibrationRefitRunnerService {
         ]
       >(
         `SELECT
+            actor,
             factId.source.vertical AS vertical,
             factId.source.recorder AS recorder,
             factId.predicate AS predicate,
@@ -454,6 +459,7 @@ export function buildTrustEvents(
 }
 
 export interface FeedbackEventRow {
+  actor: string | null;
   vertical: string | null;
   recorder: string | null;
   predicate: string;
@@ -466,16 +472,27 @@ export interface FeedbackEventRow {
  * the fact-status events use: 'helpful' = win, 'incorrect' = loss.
  * 'not_helpful' rows never reach here (filtered in the query) — an
  * irrelevant retrieval says nothing about the source's reliability.
- * Exported for unit tests, same as buildTrustEvents.
+ *
+ * Anti-farming dedup (mirrors buildTrustEvents' corroboration dedup): a
+ * single actor's verdict counts at most ONCE per (sourceKey, domain,
+ * verdict). Without it, one write key voting 'incorrect' across all N of
+ * a source's facts would inject N losses and drag its learned rate down
+ * (or 'helpful' to inflate). Distinct actors still each count — that is
+ * genuine crowd signal. Exported for unit tests, same as buildTrustEvents.
  */
 export function buildFeedbackTrustEvents(
   rows: ReadonlyArray<FeedbackEventRow>,
 ): TrustEvent[] {
+  const seen = new Set<string>();
   const events: TrustEvent[] = [];
   for (const r of rows) {
     if (r.verdict !== 'helpful' && r.verdict !== 'incorrect') continue;
+    const sourceKey = `${r.vertical}:${r.recorder ?? '_'}`;
+    const dedupKey = `${r.actor ?? '_'} ${sourceKey} ${r.predicate} ${r.verdict}`;
+    if (seen.has(dedupKey)) continue;
+    seen.add(dedupKey);
     events.push({
-      sourceKey: `${r.vertical}:${r.recorder ?? '_'}`,
+      sourceKey,
       domain: r.predicate,
       win: r.verdict === 'helpful' ? 1 : 0,
       loss: r.verdict === 'incorrect' ? 1 : 0,

--- a/src/ingest/entity-upsert.service.ts
+++ b/src/ingest/entity-upsert.service.ts
@@ -51,7 +51,13 @@ export class EntityUpsertService {
     // another user's) for the same (vertical, id). Fold the scope into the
     // key and stamp it on the minted entity.
     const baseKey = externalRefKey(ref.vertical, ref.id);
-    const refKey = userId ? `${baseKey}__u__${userId}` : baseKey;
+    // Scope separator MUST be a byte externalRefKey never emits, or a
+    // dotted id folds into the marker and a tenant-global ref collides
+    // with a user-scoped one (e.g. global "x.u.bob" → "x__u__bob" ==
+    // scoped ("x", user "bob") under the old "__u__" marker — no crafted
+    // input needed). externalRefKey only ever produces [word]/`__`, never
+    // a colon, so "::u::" cannot be forged from the (vertical, id) side.
+    const refKey = userId ? `${baseKey}::u::${userId}` : baseKey;
     return this.upsertEntityByExternalRef(db, refKey, () => ({
       type: 'other',
       canonicalName: ref.id,
@@ -126,10 +132,17 @@ export class EntityUpsertService {
     // name canonicalisation is heuristic. Identity merge via
     // ingestLink consolidates downstream.
     const target = (e.canonical ?? e.name).toLowerCase();
+    // This is the tenant-GLOBAL naming path (mention/document ingest never
+    // stamps a userId). Pin `userId IS NONE` so a same-named PERSONAL
+    // entity never matches — otherwise global facts attach to a user's
+    // private entity and leak its identity (externalRefs, canonicalName)
+    // onto the global surface. Mirrors the scope fence on the embedding
+    // resolver (entity-resolver.service.ts).
     const [nRows] = await db.query<any[][]>(
       `SELECT id FROM knowledge_entity
-       WHERE canonicalNameLc = $name
-          OR aliases CONTAINS $rawName
+       WHERE (canonicalNameLc = $name
+          OR aliases CONTAINS $rawName)
+          AND userId IS NONE
        LIMIT 1`,
       { name: target, rawName: e.name },
     );

--- a/src/ingest/fact-ingest.service.ts
+++ b/src/ingest/fact-ingest.service.ts
@@ -64,8 +64,17 @@ export class FactIngestService {
     // `source.meta.*` rules match direct facts like document-derived
     // ones. Sanitized to operator vocabulary; SOURCE_META_STRICT=1
     // turns drops into a 400 instead of a warn.
-    if (dto.metadata !== undefined) {
-      const { meta, dropped } = sanitizeSourceMeta(dto.metadata);
+    //
+    // A caller can also put meta directly on `dto.source.meta` — that copy
+    // above carries it verbatim, so it MUST go through the same sanitizer,
+    // else it is an unfiltered write to the ABAC match surface (and to the
+    // read responses that echo `source`). dto.metadata is the documented
+    // channel and wins; a raw source.meta is sanitized as a fallback.
+    const rawSourceMeta = source.meta;
+    delete source.meta;
+    const metaInput = dto.metadata ?? rawSourceMeta;
+    if (metaInput !== undefined) {
+      const { meta, dropped } = sanitizeSourceMeta(metaInput);
       if (dropped.length > 0) {
         if (envFlagEnabled(process.env.SOURCE_META_STRICT)) {
           throw new BadRequestException({

--- a/test/feedback-trust-events.unit-spec.ts
+++ b/test/feedback-trust-events.unit-spec.ts
@@ -1,12 +1,14 @@
 /**
  * Retrieval feedback → source-trust events: 'helpful' is a win,
  * 'incorrect' is a loss, anything else (including a smuggled
- * 'not_helpful' row) contributes nothing.
+ * 'not_helpful' row) contributes nothing. One actor's verdict counts at
+ * most once per (source, predicate, verdict) — anti-farming dedup.
  */
 import { buildFeedbackTrustEvents } from '../src/ai/calibration/calibration-refit-runner.service';
 
 describe('buildFeedbackTrustEvents', () => {
-  const row = (verdict: string) => ({
+  const row = (verdict: string, actor = 'key_a') => ({
+    actor,
     vertical: 'rent',
     recorder: 'bot',
     predicate: 'tier',
@@ -43,5 +45,33 @@ describe('buildFeedbackTrustEvents', () => {
   it('falls back to the _ recorder like the fact-status events', () => {
     const [e] = buildFeedbackTrustEvents([{ ...row('helpful'), recorder: null }]);
     expect(e.sourceKey).toBe('rent:_');
+  });
+
+  it('caps one actor at a single vote per (source, predicate, verdict)', () => {
+    // key_a votes incorrect on THREE different facts of the same source —
+    // the farming vector. Only one loss should land.
+    const farmed = buildFeedbackTrustEvents([
+      row('incorrect'),
+      row('incorrect'),
+      row('incorrect'),
+    ]);
+    expect(farmed).toHaveLength(1);
+    expect(farmed[0]).toEqual(
+      expect.objectContaining({ sourceKey: 'rent:bot', loss: 1 }),
+    );
+  });
+
+  it('counts distinct actors separately (genuine crowd signal)', () => {
+    const crowd = buildFeedbackTrustEvents([
+      row('incorrect', 'key_a'),
+      row('incorrect', 'key_b'),
+      row('incorrect', 'key_c'),
+    ]);
+    expect(crowd).toHaveLength(3);
+  });
+
+  it('a helpful and an incorrect from one actor are distinct verdicts', () => {
+    const mixed = buildFeedbackTrustEvents([row('helpful'), row('incorrect')]);
+    expect(mixed).toHaveLength(2);
   });
 });

--- a/test/source-meta-ingest.e2e-spec.ts
+++ b/test/source-meta-ingest.e2e-spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Direct fact-ingest must sanitize meta on BOTH channels. dto.metadata
+ * was already sanitized, but a raw `dto.source.meta` used to be copied
+ * onto knowledge_fact.source.meta verbatim — an unfiltered write to the
+ * ABAC match surface (and to the entity reads that echo `source`). This
+ * pins that the source.meta channel goes through sanitizeSourceMeta too.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+describe('fact-ingest sanitizes raw source.meta', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_source_meta_e2e' });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('drops invalid keys/values from a raw source.meta blob', async () => {
+    const r = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'source_meta_subject' },
+        predicate: 'name',
+        object: 'Source Meta Probe',
+        validFrom: '2026-01-01',
+        confidence: 0.9,
+        source: {
+          vertical: 'rent',
+          recorder: 'bot',
+          // No dto.metadata — the meta rides directly on source.
+          meta: {
+            'Bad Key!': 'should not persist', // invalid key → dropped
+            data_class: 'pii', // valid → kept
+            huge: 'x'.repeat(500), // >256 chars → dropped
+          },
+        },
+      });
+    expect([200, 201]).toContain(r.status);
+    const factId = r.body.factId as string;
+
+    const surreal = f.app.get(SurrealService);
+    const meta = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ meta: unknown }>]>(
+        `SELECT source.meta AS meta FROM type::record('knowledge_fact', $tail)`,
+        { tail: factId.split(':')[1] },
+      );
+      return (rows as Array<{ meta: Record<string, unknown> | null }>)[0]?.meta;
+    });
+
+    // The valid key survived; the invalid ones never touched the graph.
+    expect(meta).toBeTruthy();
+    expect((meta as Record<string, unknown>).data_class).toBe('pii');
+    expect(meta).not.toHaveProperty('Bad Key!');
+    expect(meta).not.toHaveProperty('huge');
+  });
+});


### PR DESCRIPTION
Wave B of the v0.6.0 audit (2026-07-11) — the LIVE-medium set (reachable in prod today, no ABAC flag needed). Full suite green (unit 1044, e2e 265).

## feedback → source-trust farming
The feedback loop is live end-to-end (β=0.15 in prod). The UNIQUE `(factId, actor)` write index stops stacking votes on one fact, but a single write key could vote `incorrect` across *every* fact of a source (factIds are enumerable from search) and inject N losses into one `(source, predicate)` rate — dragging its learned trust down (or `helpful` to inflate). `buildFeedbackTrustEvents` now dedups per `(actor, sourceKey, domain, verdict)`, mirroring the corroboration anti-echo dedup: one actor moves a rate at most once, distinct actors still each count as genuine crowd signal. `actor` is now projected in the refit query. Unit tests cover the farming and crowd cases.

## source.meta sanitizer bypass
Direct fact-ingest sanitized `dto.metadata`, but `source = { ...dto.source }` copied a raw `dto.source.meta` verbatim onto `knowledge_fact.source.meta` — an unfiltered write to the ABAC match surface (and to the entity reads that echo `source`). Whatever lands on `source.meta` now goes through `sanitizeSourceMeta` / `SOURCE_META_STRICT`; `dto.metadata` stays the documented channel and wins. New e2e proves an invalid/oversized raw `source.meta` is sanitized.

## entity scope collision + canonical-name leak
- The user-scope dedup key used a `__u__<userId>` marker, but `externalRefKey` folds `.` → `__`, so a tenant-global ref `"x.u.bob"` produced `"x__u__bob"` == the scoped `("x", user "bob")` key — a collision with **no crafted input**, merging a personal entity with a global one. The separator is now `::u::` (`externalRefKey` never emits a colon, so it can't be forged from the vertical/id side).
- `resolveOrCreateNamedEntity` (the tenant-global mention/document naming path) matched canonical names without a scope filter, so a global mention could attach to a same-named **personal** entity and leak its identity onto the global surface. Pinned `userId IS NONE`, mirroring the embedding resolver's fence.

## Remaining audit waves
- **C (before enabling ABAC):** ABAC row rules on the phantom-fence surfaces + candidates, temporal-window UI strip, meta-union cross-tenant cache + dropped trust fields, MAX_SETS_PER_KEY warn.
- **D (before HNSW):** drop-first reindex ordering, un-indexed fallback premise.
- **E (docs):** `.env.example` (#145 flags), `api.md` (hnsw endpoint), `ABAC_DB_FENCE_ENABLED` flag validator, GDPR cascade for the new side-tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYm9x6dMncfHuRR9xseWHn