### PR TITLE
fix(security): audit wave C — ABAC behind-flag hardening

### DIFF
--- a/brain-landing/components/admin/policies/PolicySetEditor.tsx
+++ b/brain-landing/components/admin/policies/PolicySetEditor.tsx
@@ -21,6 +21,12 @@ interface Draft {
   description: string
   posture: { actions: 'allow' | 'deny'; reads: 'allow' | 'deny' }
   mode: PolicySet['mode']
+  // Round-tripped verbatim: the editor has no UI for temporal windows yet,
+  // but the save is a whole-document PUT replace — omitting these would
+  // silently ERASE an operator's activeFrom/activeUntil on every edit
+  // (and an erased activeUntil fails OPEN by reverting to the full scope).
+  activeFrom: string | null
+  activeUntil: string | null
   rules: PolicyRule[]
 }
 
@@ -30,6 +36,8 @@ function toDraft(s: PolicySet): Draft {
     description: s.description,
     posture: { ...s.posture },
     mode: s.mode,
+    activeFrom: s.activeFrom ?? null,
+    activeUntil: s.activeUntil ?? null,
     rules: s.rules.map((r) => ({ ...r, match: r.match?.map((c) => ({ ...c })) })),
   }
 }

--- a/src/communities/community-builder.service.ts
+++ b/src/communities/community-builder.service.ts
@@ -320,6 +320,12 @@ export class CommunityBuilderService {
     // every reader without brain:read_pii. Drop requiresScope predicates
     // at build time (over-fetch to 60 so the visible 40 stay full), and
     // pin to the tenant-global scope (personal facts never fold in).
+    //
+    // Per-caller ABAC row-rules can't apply here either: the summary is one
+    // pre-built blob shared across callers, not a set of rows evaluated at
+    // read time. The build-time PII/scope filter above is the enforceable
+    // approximation; a per-caller source-deny can't retro-scrub a baked
+    // summary. Documented limitation while DREAMS_COMMUNITIES matures.
     const summaryInput: FactToSummarize[] = (
       (factRows as RawFact[]) ?? []
     )

--- a/src/documents/documents.controller.ts
+++ b/src/documents/documents.controller.ts
@@ -13,6 +13,9 @@ import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import { PolicyAction } from '../policy/action-registry';
 import type { AuthenticatedRequest } from '../auth/api-key.types';
 import { policyFor } from '../ingest/conflict-resolver';
+import { getPolicyContext } from '../common/request-context';
+import { evaluateRow, toRowView } from '../policy/policy-engine';
+import type { PolicyContext } from '../policy/policy.types';
 import { DocumentStoreService } from './document-store.service';
 import {
   CandidateStoreService,
@@ -78,7 +81,11 @@ export class DocumentsController {
     );
     return {
       documentId: doc.id,
-      candidates: redactGatedCandidates(candidates, req.brainAuth.scopes),
+      candidates: redactGatedCandidates(
+        candidates,
+        req.brainAuth.scopes,
+        getPolicyContext() ?? null,
+      ),
     };
   }
 
@@ -99,15 +106,29 @@ export class DocumentsController {
  * that passesPolicy applies on the search path. Redact the `object` of any
  * fact candidate whose predicate requires a scope the caller doesn't hold;
  * the row (predicate, provenance) stays visible for the audit trail.
+ *
+ * Two gates, mirroring the committed-fact read seam (row-filter.ts): the
+ * always-on predicate scope gate, then the ABAC row verdict when the
+ * request carries a PolicyContext. A candidate is a PENDING extraction and
+ * carries no committed `source`, so only predicate/piiClass/posture rules
+ * can fire here — source.* deny conditions stay absent (no-match), which is
+ * correct: the fact's real source is only fixed at commit time.
  */
-function redactGatedCandidates(
+export function redactGatedCandidates(
   candidates: CandidateRow[],
   scopes: string[],
+  ctx: PolicyContext | null,
 ): CandidateRow[] {
   return candidates.map((c) => {
     if (c.kind !== 'fact') return c;
-    const requiresScope = policyFor(String(c.payload?.predicate ?? '')).requiresScope;
-    if (!requiresScope || scopes.includes(requiresScope)) return c;
+    const predicate = String(c.payload?.predicate ?? '');
+    const requiresScope = policyFor(predicate).requiresScope;
+    const scopeGated = !!requiresScope && !scopes.includes(requiresScope);
+    const abacDenied =
+      !!ctx &&
+      evaluateRow(ctx, toRowView({ predicate }, (p) => policyFor(p).piiClass))
+        .decision === 'deny';
+    if (!scopeGated && !abacDenied) return c;
     // Redact BOTH the extracted value and the verbatim grounding
     // sentence: `clause` is a quote from the source document and carries
     // the same PII the `object` does, so redacting object alone still

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -370,6 +370,15 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // A key resolved to MORE than MAX_SETS_PER_KEY distinct sets, so the
+  // overflow was dropped. Fail-OPEN: a dropped deny set weakens the
+  // key's posture. Non-zero means a binding needs pruning.
+  readonly policySetsTruncated = new Counter({
+    name: 'brain_policy_sets_truncated_total',
+    help: 'Keys whose resolved set list overflowed MAX_SETS_PER_KEY (sets dropped)',
+    registers: [this.registry],
+  });
+
   onModuleInit() {
     // Node defaults: GC, event-loop lag, memory, CPU. Cheap and useful.
     collectDefaultMetrics({ register: this.registry, prefix: 'brain_' });
@@ -591,6 +600,10 @@ export class MetricsService implements OnModuleInit {
 
   countPolicyResolutionError(): void {
     this.policyResolutionErrors.inc();
+  }
+
+  countPolicySetsTruncated(): void {
+    this.policySetsTruncated.inc();
   }
 
   async serialize(): Promise<{ contentType: string; body: string }> {

--- a/src/policy/meta-union.ts
+++ b/src/policy/meta-union.ts
@@ -4,7 +4,7 @@ import { envFlagEnabled } from '../common/env-validation';
 import { policyFor } from '../ingest/conflict-resolver';
 import { SurrealService } from '../db/surreal.service';
 import { evaluateRow, toRowView } from './policy-engine';
-import { PolicyContext } from './policy.types';
+import { PolicyContext, PolicyRowView } from './policy.types';
 
 /**
  * Effective-metadata union across corroborating origins
@@ -41,7 +41,21 @@ const metaCache = new LRUCache<
 export interface MetaUnionRow {
   predicate: string;
   source?: unknown;
-  corroboration?: { originKeys?: string[] } | null;
+  trustSnapshot?: PolicyRowView['trustSnapshot'];
+  corroboration?: ({ originKeys?: string[] } & { count?: number }) | null;
+  userId?: string | null;
+}
+
+/**
+ * Cache key MUST be tenant-scoped: `contentHash` is unique only within a
+ * tenant DB (the UNIQUE index is per-tenant), so two tenants can share a
+ * hash. Keying the process-wide LRU by the bare `doc:<hash>` origin key
+ * would serve tenant A's document meta to tenant B — a cross-tenant leak
+ * on the exact deny surface this module enforces. NUL separates the
+ * companyId from the origin key (neither ever emits it).
+ */
+function cacheKey(companyId: string, originKey: string): string {
+  return `${companyId}\u0000${originKey}`;
 }
 
 export function metaUnionEnabled(): boolean {
@@ -74,7 +88,7 @@ export async function applyMetaUnion<T extends MetaUnionRow>(opts: {
   const wanted = new Set<string>();
   for (const row of rows) {
     for (const key of row.corroboration?.originKeys ?? []) {
-      if (key.startsWith('doc:') && !isFresh(metaCache.get(key))) {
+      if (key.startsWith('doc:') && !isFresh(metaCache.get(cacheKey(companyId, key)))) {
         wanted.add(key);
       }
     }
@@ -93,7 +107,7 @@ export async function applyMetaUnion<T extends MetaUnionRow>(opts: {
       });
       const at = Date.now();
       for (const doc of found) {
-        metaCache.set(`doc:${String(doc.contentHash)}`, {
+        metaCache.set(cacheKey(companyId, `doc:${String(doc.contentHash)}`), {
           meta:
             doc.meta && typeof doc.meta === 'object'
               ? (doc.meta as Record<string, unknown>)
@@ -103,7 +117,8 @@ export async function applyMetaUnion<T extends MetaUnionRow>(opts: {
       }
       // Negative-cache misses so unknown origins don't refetch per request.
       for (const key of wanted) {
-        if (!metaCache.has(key)) metaCache.set(key, { meta: null, at });
+        const ck = cacheKey(companyId, key);
+        if (!metaCache.has(ck)) metaCache.set(ck, { meta: null, at });
       }
     } catch (e) {
       logger.warn(
@@ -116,12 +131,24 @@ export async function applyMetaUnion<T extends MetaUnionRow>(opts: {
   return rows.filter((row) => {
     const origins = row.corroboration?.originKeys ?? [];
     for (const key of origins) {
-      const cached = key.startsWith('doc:') ? metaCache.get(key) : undefined;
+      const cached = key.startsWith('doc:')
+        ? metaCache.get(cacheKey(companyId, key))
+        : undefined;
       const meta = cached?.meta;
       if (!meta) continue;
       const src = (row.source ?? {}) as Record<string, unknown>;
+      // Carry the row's own trust/corroboration/userId into the view so a
+      // COMPOUND deny rule (source.meta.* AND trustSnapshot.* / userId) still
+      // fires on the unioned meta — evaluating meta in isolation would let
+      // such a rule silently pass.
       const view = toRowView(
-        { predicate: row.predicate, source: { ...src, meta } },
+        {
+          predicate: row.predicate,
+          source: { ...src, meta },
+          trustSnapshot: row.trustSnapshot,
+          corroboration: row.corroboration,
+          userId: row.userId,
+        },
         (p) => policyFor(p).piiClass,
       );
       if (evaluateRow(ctx, view).decision === 'deny') return false;

--- a/src/policy/policy-resolver.service.ts
+++ b/src/policy/policy-resolver.service.ts
@@ -86,11 +86,18 @@ export class PolicyResolverService {
 
     const names: string[] = [];
     const seen = new Set<string>();
+    let truncated = false;
     const push = (n: string) => {
-      if (!seen.has(n) && names.length < MAX_SETS_PER_KEY) {
-        seen.add(n);
-        names.push(n);
+      if (seen.has(n)) return;
+      // At the cap a NEW set is silently dropped — and a dropped set may
+      // be the deny set, so the overflow FAILS OPEN. Flag it so the
+      // operator gets a warn + metric instead of a silent weakening.
+      if (names.length >= MAX_SETS_PER_KEY) {
+        truncated = true;
+        return;
       }
+      seen.add(n);
+      names.push(n);
     };
     for (const n of snap.bindings.get(`key:${keyHash}`) ?? []) push(n);
     // JWT keys without a jti hash to `jwt:<sub>` — honour bindings
@@ -99,6 +106,12 @@ export class PolicyResolverService {
       for (const n of snap.bindings.get(keyHash) ?? []) push(n);
     }
     for (const n of claimNames ?? []) push(n);
+    if (truncated) {
+      this.metrics.countPolicySetsTruncated();
+      this.logger.warn(
+        `Key ${keyHash.slice(0, 16)}… resolves to more than ${MAX_SETS_PER_KEY} policy sets — overflow dropped (fail-open; prune the binding/claims)`,
+      );
+    }
     if (names.length === 0) return null;
 
     const sets: CompiledPolicySet[] = [];

--- a/src/policy/policy.types.ts
+++ b/src/policy/policy.types.ts
@@ -313,6 +313,18 @@ export const PolicyDocumentSchema = z
         message: `Policy document exceeds ${MAX_DOCUMENT_BYTES} bytes`,
       });
     }
+    // A window with activeFrom >= activeUntil never opens — the set would
+    // be permanently inert (compile-time drop), which fails OPEN. Reject
+    // it at write time rather than silently accept a dead policy.
+    if (doc.activeFrom && doc.activeUntil) {
+      if (new Date(doc.activeFrom).getTime() >= new Date(doc.activeUntil).getTime()) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'activeFrom must be strictly before activeUntil',
+          path: ['activeFrom'],
+        });
+      }
+    }
   });
 
 export type MatchCondition = z.infer<typeof MatchConditionSchema>;

--- a/src/procedural/procedural-memory.service.ts
+++ b/src/procedural/procedural-memory.service.ts
@@ -82,6 +82,12 @@ export class ProceduralMemoryService {
   ): Promise<MatchedProcedure[]> {
     // Caller-facing reads ride the scoped pool when the caller
     // identifies itself (MCP path) so DB-level PERMISSIONS apply.
+    //
+    // No ABAC row-filter here by design: procedures are a curated
+    // OPERATOR layer (trigger→action how-tos), not user facts — they
+    // carry no predicate/piiClass and no per-user PII, so the fact-shaped
+    // row engine doesn't map. Access is gated at the tool/action level
+    // (@PolicyAction on the MCP procedural tools) instead.
     return this.run(companyId, args.callerScopes, async (db) => {
       const queryEmbedding = await this.embedder.embed(args.query);
 

--- a/test/candidate-redaction.unit-spec.ts
+++ b/test/candidate-redaction.unit-spec.ts
@@ -1,0 +1,120 @@
+/**
+ * The document candidates audit view (GET /v1/documents/:id/candidates)
+ * must honor the SAME two gates the committed-fact read seam applies:
+ *   1. the predicate scope gate (a `dob`/`address` candidate needs
+ *      brain:read_pii) — redact object AND the verbatim `clause`.
+ *   2. the ABAC row verdict when a PolicyContext is active — a source
+ *      deny rule on the predicate redacts the fact candidate too.
+ * Non-fact candidates (entity/relation) are never touched.
+ */
+import { redactGatedCandidates } from '../src/documents/documents.controller';
+import type { CandidateRow } from '../src/documents/candidate-store.service';
+import { compilePolicySet } from '../src/policy/policy-compile';
+import {
+  CompiledPolicySet,
+  PolicyContext,
+  PolicyDocument,
+  PolicyDocumentSchema,
+} from '../src/policy/policy.types';
+
+function factCandidate(predicate: string): CandidateRow {
+  return {
+    id: `candidate:${predicate}`,
+    runId: 'run:1',
+    chunkSeq: 0,
+    kind: 'fact',
+    confidence: 0.9,
+    status: 'pending',
+    payload: { predicate, object: 'secret value', clause: 'the source sentence' },
+  };
+}
+
+function ctxWith(rules: PolicyDocument['rules']): PolicyContext {
+  const parsed = PolicyDocumentSchema.parse({
+    name: 'cand-test',
+    description: '',
+    posture: { actions: 'allow', reads: 'allow' },
+    mode: 'enforce',
+    rules,
+  });
+  const compiled = compilePolicySet(parsed) as CompiledPolicySet;
+  return {
+    companyId: 'co_test',
+    keyHash: 'sha256:test',
+    sets: [compiled],
+    forceReportOnly: false,
+    resolutionError: false,
+  };
+}
+
+const isRedacted = (c: CandidateRow) =>
+  c.payload.object === '[redacted]' &&
+  c.payload.clause === '[redacted]' &&
+  c.payload.redacted === true;
+
+describe('redactGatedCandidates', () => {
+  it('leaves a non-PII candidate visible when no scope/policy gates it', () => {
+    const [c] = redactGatedCandidates([factCandidate('tier')], ['brain:read'], null);
+    expect(c.payload.object).toBe('secret value');
+    expect(c.payload.clause).toBe('the source sentence');
+  });
+
+  it('redacts object AND clause of a PII candidate without brain:read_pii', () => {
+    const [c] = redactGatedCandidates([factCandidate('dob')], ['brain:read'], null);
+    expect(isRedacted(c)).toBe(true);
+  });
+
+  it('shows the PII candidate to a caller holding brain:read_pii', () => {
+    const [c] = redactGatedCandidates(
+      [factCandidate('dob')],
+      ['brain:read', 'brain:read_pii'],
+      null,
+    );
+    expect(c.payload.object).toBe('secret value');
+  });
+
+  it('redacts a candidate an enforced ABAC rule denies (by predicate)', () => {
+    const ctx = ctxWith([
+      {
+        id: 'no-tier',
+        enabled: true,
+        effect: 'deny',
+        kind: 'source',
+        match: [{ attr: 'predicate', op: 'eq', value: 'tier' }],
+      },
+    ]);
+    const [denied] = redactGatedCandidates([factCandidate('tier')], ['brain:read'], ctx);
+    expect(isRedacted(denied)).toBe(true);
+    // A different predicate the rule doesn't target stays visible.
+    const [kept] = redactGatedCandidates(
+      [factCandidate('preference')],
+      ['brain:read'],
+      ctx,
+    );
+    expect(kept.payload.object).toBe('secret value');
+  });
+
+  it('never touches non-fact candidates', () => {
+    const entity: CandidateRow = {
+      id: 'candidate:e',
+      runId: 'run:1',
+      chunkSeq: 0,
+      kind: 'entity',
+      confidence: 0.9,
+      status: 'pending',
+      payload: { name: 'Acme Corp' },
+    };
+    const denyAll = ctxWith([
+      {
+        id: 'block-all',
+        enabled: true,
+        effect: 'deny',
+        kind: 'source',
+        match: [{ attr: 'predicate', op: 'prefix', value: '' }],
+      },
+    ]);
+    const [c] = redactGatedCandidates([entity], ['brain:read'], denyAll);
+    expect(c.payload.name).toBe('Acme Corp');
+    expect(c.payload.redacted).toBeUndefined();
+  });
+});

--- a/test/meta-union.unit-spec.ts
+++ b/test/meta-union.unit-spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Effective-meta union hardening (audit wave C):
+ *   1. the origin-meta LRU is keyed per TENANT — a contentHash shared by
+ *      two tenants must never serve tenant A's document meta to tenant B
+ *      (the cache is process-global; contentHash is unique only per-DB).
+ *   2. the union re-evaluation carries the row's OWN trust/corroboration/
+ *      userId, so a COMPOUND deny rule (source.meta.* AND corroboration.*)
+ *      still fires on the unioned meta instead of silently passing.
+ */
+import { applyMetaUnion } from '../src/policy/meta-union';
+import { compilePolicySet } from '../src/policy/policy-compile';
+import {
+  CompiledPolicySet,
+  PolicyContext,
+  PolicyDocument,
+  PolicyDocumentSchema,
+} from '../src/policy/policy.types';
+import { SurrealService } from '../src/db/surreal.service';
+
+function compile(rules: PolicyDocument['rules']): CompiledPolicySet {
+  const parsed = PolicyDocumentSchema.parse({
+    name: 'meta-union-test',
+    description: '',
+    posture: { actions: 'allow', reads: 'allow' },
+    mode: 'enforce',
+    rules,
+  });
+  const compiled = compilePolicySet(parsed);
+  if (!compiled) throw new Error('unexpected disabled set');
+  return compiled;
+}
+
+function ctxOf(set: CompiledPolicySet): PolicyContext {
+  return {
+    companyId: 'co_test',
+    keyHash: 'sha256:test',
+    sets: [set],
+    forceReportOnly: false,
+    resolutionError: false,
+  };
+}
+
+/** Stub Surreal that returns per-tenant documents by contentHash. */
+function stubSurreal(
+  docsByTenant: Record<string, Array<{ contentHash: string; meta: unknown }>>,
+): SurrealService {
+  return {
+    withCompany: async <R>(
+      companyId: string,
+      fn: (db: unknown) => Promise<R>,
+    ): Promise<R> => {
+      const db = {
+        query: async (_sql: string, params: { hashes: string[] }) => {
+          const docs = (docsByTenant[companyId] ?? []).filter((d) =>
+            params.hashes.includes(d.contentHash),
+          );
+          return [docs];
+        },
+      };
+      return fn(db);
+    },
+  } as unknown as SurrealService;
+}
+
+const publicRow = (hash: string, count = 1) => ({
+  predicate: 'tier',
+  source: { vertical: 'notes', recorder: 'sync', meta: { data_class: 'public' } },
+  corroboration: { originKeys: [`doc:${hash}`], count },
+  userId: null,
+});
+
+describe('applyMetaUnion tenant isolation + compound rules', () => {
+  beforeAll(() => {
+    process.env.POLICY_META_UNION_ENABLED = '1';
+  });
+  afterAll(() => {
+    delete process.env.POLICY_META_UNION_ENABLED;
+  });
+
+  const piiDeny = compile([
+    {
+      id: 'meta-pii',
+      enabled: true,
+      effect: 'deny',
+      kind: 'source',
+      match: [{ attr: 'source.meta.data_class', op: 'eq', value: 'pii' }],
+    },
+  ]);
+
+  it('keys the origin-meta cache by tenant — no cross-tenant leak', async () => {
+    const ctx = ctxOf(piiDeny);
+    const HASH = 'crosstenanthash01';
+    // Tenant A owns a PII-classed document with this hash → the corroborated
+    // (own-meta clean) row is denied via the union.
+    const surreal = stubSurreal({
+      co_a: [{ contentHash: HASH, meta: { data_class: 'pii' } }],
+      co_b: [], // Tenant B has NO document with this hash.
+    });
+
+    const a = await applyMetaUnion({
+      surreal,
+      companyId: 'co_a',
+      ctx,
+      rows: [publicRow(HASH)],
+    });
+    expect(a).toHaveLength(0); // denied through the union
+
+    // Same hash, different tenant: must NOT reuse tenant A's cached pii meta.
+    const b = await applyMetaUnion({
+      surreal,
+      companyId: 'co_b',
+      ctx,
+      rows: [publicRow(HASH)],
+    });
+    expect(b).toHaveLength(1); // survives — the cache did not leak across tenants
+  });
+
+  it('carries corroboration.count into the union view for compound deny rules', async () => {
+    const ctx = ctxOf(
+      compile([
+        {
+          id: 'meta-and-corrob',
+          enabled: true,
+          effect: 'deny',
+          kind: 'source',
+          match: [
+            { attr: 'source.meta.data_class', op: 'eq', value: 'pii' },
+            { attr: 'corroboration.count', op: 'gte', value: 2 },
+          ],
+        },
+      ]),
+    );
+
+    // count 2 → BOTH conditions match → denied. Before the fix the union
+    // view dropped corroboration, so this rule silently passed (survived).
+    const HASH = 'compoundhash01';
+    const denied = await applyMetaUnion({
+      surreal: stubSurreal({ co_c: [{ contentHash: HASH, meta: { data_class: 'pii' } }] }),
+      companyId: 'co_c',
+      ctx,
+      rows: [publicRow(HASH, 2)],
+    });
+    expect(denied).toHaveLength(0);
+
+    // count 1 → second condition fails → survives (control).
+    const HASH2 = 'compoundhash02';
+    const kept = await applyMetaUnion({
+      surreal: stubSurreal({ co_c: [{ contentHash: HASH2, meta: { data_class: 'pii' } }] }),
+      companyId: 'co_c',
+      ctx,
+      rows: [publicRow(HASH2, 1)],
+    });
+    expect(kept).toHaveLength(1);
+  });
+});

--- a/test/policy-compile-window.unit-spec.ts
+++ b/test/policy-compile-window.unit-spec.ts
@@ -47,3 +47,42 @@ describe('compilePolicySet temporal windows', () => {
     ).not.toBeNull();
   });
 });
+
+describe('PolicyDocumentSchema window validation', () => {
+  const parse = (over: Record<string, unknown>) =>
+    PolicyDocumentSchema.parse({
+      name: 'windowed-set',
+      posture: { actions: 'deny', reads: 'deny' },
+      mode: 'enforce',
+      rules: [],
+      ...over,
+    });
+
+  it('rejects a window that can never open (activeFrom >= activeUntil)', () => {
+    // Inverted — the set would be permanently inert (fail-open), a mistake.
+    expect(() =>
+      parse({
+        activeFrom: '2026-08-01T00:00:00Z',
+        activeUntil: '2026-07-01T00:00:00Z',
+      }),
+    ).toThrow(/activeFrom must be strictly before activeUntil/);
+    // Equal bounds are also a dead window.
+    expect(() =>
+      parse({
+        activeFrom: '2026-07-01T00:00:00Z',
+        activeUntil: '2026-07-01T00:00:00Z',
+      }),
+    ).toThrow(/activeFrom must be strictly before activeUntil/);
+  });
+
+  it('accepts a valid window and open-ended bounds', () => {
+    expect(() =>
+      parse({
+        activeFrom: '2026-07-01T00:00:00Z',
+        activeUntil: '2026-08-01T00:00:00Z',
+      }),
+    ).not.toThrow();
+    expect(() => parse({ activeFrom: '2026-07-01T00:00:00Z' })).not.toThrow();
+    expect(() => parse({ activeUntil: '2026-08-01T00:00:00Z' })).not.toThrow();
+  });
+});

--- a/test/policy-resolver-cache.unit-spec.ts
+++ b/test/policy-resolver-cache.unit-spec.ts
@@ -41,8 +41,10 @@ function makeResolver(opts: {
     },
   } as unknown as SurrealService;
   const resolutionErrors: number[] = [];
+  const truncations: number[] = [];
   const metrics = {
     countPolicyResolutionError: () => resolutionErrors.push(1),
+    countPolicySetsTruncated: () => truncations.push(1),
   } as unknown as MetricsService;
   const config = new ConfigService({
     ABAC_ENABLED: '1',
@@ -50,7 +52,7 @@ function makeResolver(opts: {
     ...(opts.env ?? {}),
   });
   const resolver = new PolicyResolverService(surreal, metrics, config);
-  return { resolver, resolutionErrors, loads: () => queryCalls };
+  return { resolver, resolutionErrors, truncations, loads: () => queryCalls };
 }
 
 describe('PolicyResolverService', () => {
@@ -136,9 +138,9 @@ describe('PolicyResolverService', () => {
     expect(ctx!.forceReportOnly).toBe(true);
   });
 
-  it('caps referenced sets at 8', async () => {
+  it('caps referenced sets at 8 and records the fail-open truncation', async () => {
     const many = Array.from({ length: 12 }, (_, i) => `set-${i}`);
-    const { resolver } = makeResolver({
+    const { resolver, truncations } = makeResolver({
       policyRows: many.map((name) => ({
         name,
         mode: 'enforce',
@@ -147,5 +149,21 @@ describe('PolicyResolverService', () => {
     });
     const ctx = await resolver.contextFor('co_a', 'sha256:k', many);
     expect(ctx!.sets.length).toBeLessThanOrEqual(8);
+    // A dropped set may be a deny set — the overflow must not be silent.
+    expect(truncations).toHaveLength(1);
+  });
+
+  it('does not flag truncation when the set count is within the cap', async () => {
+    const few = Array.from({ length: 8 }, (_, i) => `set-${i}`);
+    const { resolver, truncations } = makeResolver({
+      policyRows: few.map((name) => ({
+        name,
+        mode: 'enforce',
+        document: { ...DOC, name },
+      })),
+    });
+    const ctx = await resolver.contextFor('co_a', 'sha256:k', few);
+    expect(ctx!.sets).toHaveLength(8);
+    expect(truncations).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Wave C of the v0.6.0 audit follow-up. **Every item is behind a default-off flag** (`ABAC_ENABLED` / `POLICY_META_UNION_ENABLED`), so nothing here is live in prod — this closes the gaps *before* those flags are enabled. Follows wave A (#154) and wave B (#156).

## C3 — meta-union (`src/policy/meta-union.ts`)
- **Cross-tenant cache leak.** The process-global origin-meta LRU was keyed by the bare `doc:<contentHash>`. `contentHash` is unique only within a tenant DB, so two tenants sharing a hash would serve tenant A's document meta to tenant B — on the exact `source.meta.*` deny surface this module enforces. Now keyed by `companyId` + NUL + originKey.
- **Compound rules silently passed.** The union re-evaluation built its rowview from `predicate`+`source` only, dropping `trustSnapshot`/`corroboration`/`userId`. A compound deny rule (`source.meta.* AND corroboration.count …`) never fired. The row's own fields are now carried into the view.

## C4 — resolver fail-open (`policy-resolver.service.ts`, `metrics.service.ts`)
A key resolving to more than `MAX_SETS_PER_KEY` (8) sets silently dropped the overflow. A dropped set may be *the deny set*, so the truncation **fails open**. Now emits a warn log + `brain_policy_sets_truncated_total` counter.

## C2 — temporal windows (`policy.types.ts`, `PolicySetEditor.tsx`)
- **UI erased windows.** `PolicySetEditor`'s whole-document PUT omitted `activeFrom`/`activeUntil` from its `Draft`, so every save wiped an operator's window. An erased `activeUntil` fails open (reverts to full scope). Both are now round-tripped verbatim.
- **Dead-window write.** Reject `activeFrom >= activeUntil` at write time — a window that never opens is a permanently-inert (fail-open) set.

## C1 — candidates audit view (`documents.controller.ts`)
`redactGatedCandidates` applied only the PII scope gate; it now also honors the ABAC row verdict (predicate/posture rules — a pending candidate has no committed `source`, so `source.*` conditions stay absent by design). Documented why **procedural memory** (operator content, action-gated) and **community summaries** (persisted shared blob) don't take per-caller row rules.

## Verification
- Full unit suite **1054 green** (+ new: meta-union tenant-isolation & compound-rule, resolver truncation metric, window write-validation, candidate redaction scope+ABAC).
- `tsc` + `eslint` clean; brain-landing `tsc` clean.
- `abac-meta-union` + `documents-pipeline` e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYm9x6dMncfHuRR9xseWHn