### PR TITLE
fix(hnsw): refuse create on stale-dimension index + document drop-first recovery

### DIFF
--- a/src/admin/hnsw-maintenance.service.ts
+++ b/src/admin/hnsw-maintenance.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { Surreal } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 
@@ -12,13 +13,28 @@ import { EmbedderService } from '../ai/embedder.service';
  * embedder (openai 1536 vs bge-m3 1024), which is deploy-config, not
  * schema. So creation is an explicit admin action per tenant:
  *
- *   1. (if the embedder ever changed) run the embedding reindex first —
- *      the index build fails on rows whose vector length disagrees;
- *   2. POST /v1/admin/maintenance/hnsw {action:'create'} per tenant;
- *   3. flip SEARCH_HNSW_ENABLED=1 — the KNN leg kicks in, and tenants
- *      without indexes soft-fall back to the full scan;
- *   4. re-run the quality eval — filtered KNN is approximate; the
+ *   1. POST /v1/admin/maintenance/hnsw {action:'create'} per tenant;
+ *   2. flip SEARCH_HNSW_ENABLED=1 — the KNN leg kicks in, and tenants
+ *      without indexes fall back to the full scan;
+ *   3. re-run the quality eval — filtered KNN is approximate; the
  *      over-fetch knob (SEARCH_HNSW_OVERFETCH) trades recall for speed.
+ *
+ * Embedder swap (dimension change) — STRICT order, or the tenant's
+ * writes stall. The dimension is baked into the index DDL, and once an
+ * index exists every ingest/upsert of a differently-sized vector is
+ * rejected, which ALSO blocks the reindex that would fix it. Recover in
+ * this order (each step is a separate admin call):
+ *
+ *   a. {action:'drop'}        — remove the old-dimension indexes;
+ *   b. reindex embeddings     — rewrite every vector at the new size
+ *      (POST /v1/admin/maintenance/reindex-embeddings), now unblocked;
+ *   c. {action:'create'}      — build fresh indexes at the new size.
+ *
+ * `create` guards this: DEFINE INDEX IF NOT EXISTS SILENTLY NO-OPS when
+ * an index already exists at a different dimension (verified on 3.1.5),
+ * so a naive re-`create` after a swap would report success while leaving
+ * the stale index in place. We detect the mismatch and refuse, pointing
+ * the operator at the drop→reindex→create order above.
  *
  * DEFINE INDEX is synchronous — on a large tenant the call can take a
  * while; run it off-peak.
@@ -55,6 +71,9 @@ export class HnswMaintenanceService {
     }
     return this.surreal.withCompany(companyId, async (db) => {
       if (action === 'create') {
+        // Refuse a create that would SILENTLY leave a stale-dimension
+        // index in place (IF NOT EXISTS no-ops on a dimension change).
+        await this.assertNoDimensionMismatch(db, dimension);
         // DIMENSION can't be parameterised in DDL — `dimension` is a
         // validated integer, never caller input.
         await db.query(
@@ -82,5 +101,50 @@ export class HnswMaintenanceService {
         indexes: [FACT_MAIN, FACT_ALT, ENTITY_MAIN],
       };
     });
+  }
+
+  /**
+   * Throw if any target HNSW index already exists at a dimension other
+   * than `dimension`. Without this, DEFINE INDEX IF NOT EXISTS reports
+   * success but leaves the old-dimension index untouched (empirically
+   * confirmed on SurrealDB 3.1.5).
+   */
+  private async assertNoDimensionMismatch(
+    db: Surreal,
+    dimension: number,
+  ): Promise<void> {
+    const existing = await this.readIndexDimensions(db);
+    const mismatched = [FACT_MAIN, FACT_ALT, ENTITY_MAIN].filter(
+      (name) => existing.has(name) && existing.get(name) !== dimension,
+    );
+    if (mismatched.length > 0) {
+      const detail = mismatched
+        .map((n) => `${n}=${existing.get(n)}`)
+        .join(', ');
+      throw new BadRequestException(
+        `HNSW index(es) [${detail}] already exist at a different dimension; ` +
+          `the embedder now reports ${dimension}. DEFINE INDEX IF NOT EXISTS ` +
+          `silently no-ops on a dimension change, so this create would leave ` +
+          `the stale index in place. Recover in order: drop → reindex ` +
+          `embeddings → create.`,
+      );
+    }
+  }
+
+  /** Map of HNSW index name → its declared DIMENSION, parsed from INFO. */
+  private async readIndexDimensions(db: Surreal): Promise<Map<string, number>> {
+    const out = new Map<string, number>();
+    for (const table of ['knowledge_fact', 'knowledge_entity']) {
+      const [info] = await db.query<[{ indexes?: Record<string, string> }]>(
+        `INFO FOR TABLE ${table};`,
+      );
+      const indexes =
+        (info as { indexes?: Record<string, string> })?.indexes ?? {};
+      for (const [name, ddl] of Object.entries(indexes)) {
+        const m = /DIMENSION\s+(\d+)/i.exec(String(ddl));
+        if (m) out.set(name, parseInt(m[1], 10));
+      }
+    }
+    return out;
   }
 }

--- a/test/hnsw.e2e-spec.ts
+++ b/test/hnsw.e2e-spec.ts
@@ -6,6 +6,7 @@
  * flag is safe mid-rollout.
  */
 import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
 
 describe('HNSW vector leg (real SurrealDB)', () => {
   let f: AppFixture;
@@ -90,5 +91,45 @@ describe('HNSW vector leg (real SurrealDB)', () => {
     const results = await search('HNSW Probe Tenant');
     delete process.env.SEARCH_HNSW_ENABLED;
     expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('refuses create when an index exists at a stale dimension', async () => {
+    // Fresh, empty tenant so a mismatched index can be planted directly
+    // (DEFINE at a wrong dimension only fails once rows disagree).
+    const g = await createApp({ companyId: 'co_hnsw_dim_e2e' });
+    try {
+      const surreal = g.app.get(SurrealService);
+      await surreal.withCompany(g.companyId, async (db) => {
+        await db.query(
+          `DEFINE INDEX fact_embedding_hnsw ON knowledge_fact FIELDS embedding
+             HNSW DIMENSION 8 DIST COSINE EFC 200 M 16;`,
+        );
+      });
+
+      // The live StubEmbedder reports 1536 — a naive create would report
+      // success (IF NOT EXISTS no-ops) yet leave the dim-8 index in place.
+      const create = await g.http
+        .post('/v1/admin/maintenance/hnsw')
+        .set({ Authorization: `Bearer ${g.apiKey}` })
+        .send({});
+      expect(create.status).toBe(400);
+      expect(String(create.body.message)).toMatch(/different dimension/i);
+
+      // The documented recovery — drop first — then create succeeds.
+      const drop = await g.http
+        .post('/v1/admin/maintenance/hnsw')
+        .set({ Authorization: `Bearer ${g.apiKey}` })
+        .send({ action: 'drop' });
+      expect(drop.status).toBe(201);
+
+      const recreate = await g.http
+        .post('/v1/admin/maintenance/hnsw')
+        .set({ Authorization: `Bearer ${g.apiKey}` })
+        .send({});
+      expect(recreate.status).toBe(201);
+      expect(recreate.body.dimension).toBe(1536);
+    } finally {
+      await g.close();
+    }
   });
 });


### PR DESCRIPTION
Wave D of the v0.6.0 audit follow-up. Behind `SEARCH_HNSW_ENABLED` (default off) — **not live**; this hardens the embedder-swap recovery path before HNSW is ever enabled. Follows waves A (#154), B (#156), C (#157).

## The bug (empirically confirmed on SurrealDB 3.1.5)
`DEFINE INDEX IF NOT EXISTS … HNSW DIMENSION N` **silently no-ops** when the index already exists at a *different* dimension — the call returns success and `INFO FOR TABLE` still shows the old dimension.

So after an embedder swap (openai 1536 ↔ bge-m3 1024) a naive re-`create` reports `201` with the new dimension while leaving the **stale** index in place. And because the stale index then rejects every ingest of a new-sized vector, the reindex that would fix it is itself blocked — a tenant-wide write stall with a misleading "success".

## Fix
- `create` reads `INFO FOR TABLE`, parses each HNSW index's declared `DIMENSION`, and **refuses with 400** when any target index exists at a different dimension — pointing the operator at the only correct recovery order: **drop → reindex embeddings → create** (each a separate admin call).
- Service docstring now spells out that order (the old text implied a plain re-create sufficed).
- The un-indexed path is a plain full-scan fallback (correct results, ~2× cost), not the "soft fallback on a missing index" the docstring implied — wording corrected.

## Not changed (deliberate)
Cross-tenant DDL via `tenant` body param stays: the controller already restricts it to a **registered** tenant, matching the existing operator model (`withCompany` cross-tenant is an established admin pattern). Audit rated it low.

## Verification
`hnsw` e2e plants a dim-8 index on a fresh tenant, asserts `create` 400s with "different dimension", then `drop`→`create` at 1536 succeeds. 4/4 e2e green; `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYm9x6dMncfHuRR9xseWHn