### PR TITLE
fix(gdpr): audit wave E — env-flag coverage, ABAC fence validation, edge audit purge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -323,6 +323,51 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 # = most restrictive). One batched contentHash lookup per request behind
 # a process LRU; applied on search fusion + graph_retrieve.
 #POLICY_META_UNION_ENABLED=0
+# DB-level PERMISSIONS PII fence (migrations 0005/0057). NOTE: inert for the
+# system-user connection pool the service uses — the app-layer JS filter is
+# the actually-enforcing gate. Off (default). An unrecognized value would
+# silently disable it, so it's validated like the other ABAC flags.
+#ABAC_DB_FENCE_ENABLED=0
+
+# ── Memory quality & retrieval evolution (migrations 0052–0055) ──────────
+# All default OFF and byte-identical to pre-0052 when unset. See
+# docs/operations.md for the rollout order.
+# Usage feedback loop: record lastReadAt on retrieved facts, and let recency
+# decay count from it (not just recordedAt). Recording must be on for decay
+# to have data.
+#SEARCH_USAGE_RECORDING_ENABLED=0
+#SEARCH_USAGE_DECAY_ENABLED=0
+# Query expansion: an LLM rewrites the query into N variants before search.
+# Concurrency-capped, LRU-cached; fails open to the raw query on error.
+# MODEL defaults to OPENAI_CHAT_MODEL.
+#SEARCH_QUERY_EXPANSION_ENABLED=0
+#SEARCH_QUERY_EXPANSION_N=2
+#SEARCH_QUERY_EXPANSION_CONCURRENCY=4
+#SEARCH_QUERY_EXPANSION_CACHE=500
+#SEARCH_QUERY_EXPANSION_MODEL=gpt-4o-mini
+# Dreams: fuzzy corroboration (cosine-close facts confirm each other) and
+# community summaries. Both cost LLM calls; bounded by the knobs shown.
+# MODEL defaults to OPENAI_CHAT_MODEL.
+#DREAMS_CORROBORATE_ENABLED=0
+#DREAMS_CORROBORATE_MAX_PAIRS=20
+#DREAMS_CORROBORATE_COSINE_THRESHOLD=0.9
+#DREAMS_CORROBORATE_CONCURRENCY=4
+#DREAMS_CORROBORATE_MODEL=gpt-4o-mini
+#DREAMS_COMMUNITIES_ENABLED=0
+# Compaction promotion: old corroborated fact groups promote to a durable
+# summary. AGE_DAYS before eligible, MIN_GROUP members required, MAX_GROUPS
+# per run caps cost.
+#COMPACTION_PROMOTION_ENABLED=0
+#COMPACTION_PROMOTION_AGE_DAYS=180
+#COMPACTION_PROMOTION_MIN_GROUP=5
+#COMPACTION_PROMOTION_MAX_GROUPS=20
+# HNSW vector index (opt-in per tenant via POST /v1/admin/maintenance/hnsw).
+# The flag only switches the KNN leg on; tenants without an index fall back
+# to the full scan. OVERFETCH/EF trade recall for speed. Swapping the
+# embedder needs a drop → reindex → create; see docs/operations.md.
+#SEARCH_HNSW_ENABLED=0
+#SEARCH_HNSW_OVERFETCH=4
+#SEARCH_HNSW_EF=100
 
 # ── Observability ────────────────────────────────────────────────────────
 # Enable the OpenTelemetry SDK + GenAI SemConv attributes on every LLM

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,6 +76,7 @@ See [Document pipeline](document-pipeline.md) for the architecture.
 | `POST /v1/admin/maintenance/dreams/run` | Async kick of dreams (returns runId). |
 | `POST /v1/admin/maintenance/calibration-refit` | Async kick of calibration + source-trust refit. |
 | `POST /v1/admin/maintenance/reindex` | Async re-embed `knowledge_fact`, optionally per tenant. |
+| `POST /v1/admin/maintenance/hnsw` | Per-tenant HNSW vector-index lifecycle: `{action: 'create' \| 'drop', tenant?}`. Synchronous. `create` refuses (`400`) when an index already exists at a different dimension — recover in order: drop → reindex embeddings → create. |
 | `GET /v1/admin/changefeed/state` | Consumer lag + per-(tenant, source) cursor table. |
 | `POST /v1/admin/changefeed/drain` | Manual drain of pending change events. |
 

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -218,6 +218,7 @@ function validateAbacEnv(env: NodeJS.ProcessEnv, errors: string[]): void {
   for (const name of [
     'ABAC_ENABLED',
     'ABAC_FORCE_REPORT_ONLY',
+    'ABAC_DB_FENCE_ENABLED',
     'SOURCE_META_STRICT',
     'POLICY_META_UNION_ENABLED',
   ]) {

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -9,11 +9,20 @@ import { SurrealService } from '../db/surreal.service';
  * a database drop: every personal fact (including personal facts sitting
  * on SHARED entities), every personal entity with its edges and dedup
  * refs, the usage/feedback side tables keyed by those facts, and the
- * materialised audit_event mirror rows.
+ * materialised audit_event mirror rows for facts, entities AND edges.
  *
  * Ordering is load-bearing: side tables and refs traverse record links
  * into the rows being erased, so they go FIRST — the traversal dies with
  * the target.
+ *
+ * NOT covered (no per-user linkage to filter on — documented GDPR gap):
+ *   - debug_trace: a per-request ring buffer keyed by requestId, no
+ *     userId column; TraceBufferService TTL-prunes it (bounded window).
+ *   - ingest_dead_letter: rejected-ingest payloads carry no userId, so a
+ *     REJECTED personal fact can't be selectively purged. Operators
+ *     must sweep/redact dead-letter rows out of band. Adding a userId
+ *     stamp at reject time (fn::resolve_fact et al.) would close this —
+ *     tracked, not done here.
  */
 export interface UserForgetResult {
   companyId: string;
@@ -67,12 +76,18 @@ export class UserForgetService {
       });
       // Edges touching a personal entity (either endpoint) or stamped
       // with the scope directly — before the entities go.
-      const [edgesDeleted] = await db.query<[unknown[]]>(
+      const [edgesDeletedRows] = await db.query<[Array<{ id?: unknown }>]>(
         `DELETE knowledge_edge
           WHERE userId = $u OR in.userId = $u OR out.userId = $u
           RETURN BEFORE`,
         { u: userId },
       );
+      const edgeRows = (edgesDeletedRows as Array<{ id?: unknown }>) ?? [];
+      // Edges are mirrored to audit_event (changefeed-drain), so their
+      // mirror rows must be purged with the fact/entity ones below.
+      const edgeIds = edgeRows
+        .map((r) => String(r.id))
+        .filter((s) => s && s !== 'undefined');
       // Dedup refs traverse the entity link — before the entities go.
       await db.query(`DELETE entity_external_ref WHERE entity.userId = $u`, {
         u: userId,
@@ -101,7 +116,7 @@ export class UserForgetService {
       // Purge the materialised audit mirror (same contract as entity
       // forget): recordId is the full `table:id` string. The changefeed
       // consumer's PII redaction covers any still-unconsumed lag.
-      const recordIds = [...factIds, ...entityIds];
+      const recordIds = [...factIds, ...entityIds, ...edgeIds];
       let auditEventsDeleted = 0;
       if (recordIds.length > 0) {
         const [auditRows] = await db.query<[unknown[]]>(
@@ -116,7 +131,7 @@ export class UserForgetService {
         userId,
         factsDeleted: factIds.length,
         entitiesDeleted: entityIds.length,
-        edgesDeleted: ((edgesDeleted as unknown[]) ?? []).length,
+        edgesDeleted: edgeRows.length,
         auditEventsDeleted,
       };
       this.logger.log(

--- a/test/env-validation.unit-spec.ts
+++ b/test/env-validation.unit-spec.ts
@@ -108,3 +108,21 @@ describe('validateEnv — pack supply-chain knobs', () => {
     expect(() => validateEnv(env)).not.toThrow();
   });
 });
+
+describe('validateEnv — ABAC boolean flags', () => {
+  it('accepts 1/0/true/false for ABAC_DB_FENCE_ENABLED', () => {
+    for (const v of ['1', '0', 'true', 'false']) {
+      const env = baseProdEnv();
+      env.ABAC_DB_FENCE_ENABLED = v;
+      expect(() => validateEnv(env)).not.toThrow();
+    }
+  });
+
+  it('rejects an unrecognized ABAC_DB_FENCE_ENABLED value (silent fail-open)', () => {
+    const env = baseProdEnv();
+    // 'yes' parses as OFF under an envFlagEnabled check — the fence would
+    // be silently disabled. Boot error, not a silent downgrade.
+    env.ABAC_DB_FENCE_ENABLED = 'yes';
+    expect(() => validateEnv(env)).toThrow(/ABAC_DB_FENCE_ENABLED/);
+  });
+});

--- a/test/user-forget-edge-audit.e2e-spec.ts
+++ b/test/user-forget-edge-audit.e2e-spec.ts
@@ -1,0 +1,80 @@
+/**
+ * GDPR completeness (audit wave E): knowledge_edge is mirrored into
+ * audit_event by the changefeed drain, so user-forget must purge the
+ * edge's audit rows too — not just the fact/entity ones. This seeds a
+ * personal entity, an edge on it, and a matching audit_event mirror row,
+ * then asserts forget erases all three.
+ */
+import { StringRecordId } from 'surrealdb';
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+describe('user-forget purges edge audit_event rows', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_forget_edge_e2e' });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('erases the audit_event mirror of a forgotten user’s edge', async () => {
+    const surreal = f.app.get(SurrealService);
+    const edgeId = await surreal.withCompany(f.companyId, async (db) => {
+      // A personal entity for user_x and a global one to point at.
+      const [personal] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE knowledge_entity SET type='other', canonicalName='Personal X',
+           externalRefs={}, userId='user_x' RETURN id`,
+      );
+      const [global] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE knowledge_entity SET type='other', canonicalName='Global Y',
+           externalRefs={} RETURN id`,
+      );
+      const pid = String((personal as Array<{ id: unknown }>)[0].id);
+      const gid = String((global as Array<{ id: unknown }>)[0].id);
+
+      // An edge whose `in` endpoint is the personal entity — user-forget
+      // matches it via in.userId = $u. knowledge_edge is TYPE RELATION,
+      // so it must be created with RELATE (bound record ids, per
+      // edge-writer.ts).
+      const [edge] = await db.query<[Array<{ id: unknown }>]>(
+        `RELATE $from->knowledge_edge->$to
+           CONTENT { kind: 'related_to', weight: 1.0, source: {} } RETURN AFTER`,
+        { from: new StringRecordId(pid), to: new StringRecordId(gid) },
+      );
+      const eid = String((edge as Array<{ id: unknown }>)[0].id);
+
+      // The changefeed mirror row the drain would have written for it.
+      await db.query(
+        `CREATE audit_event SET source='changefeed', recordId=$rid,
+           op='create', versionstamp=1, consumedBy='test'`,
+        { rid: eid },
+      );
+      return eid;
+    });
+
+    const countAudit = () =>
+      surreal.withCompany(f.companyId, async (db) => {
+        const [rows] = await db.query<[Array<{ n: number }>]>(
+          `SELECT count() AS n FROM audit_event WHERE recordId = $rid GROUP ALL`,
+          { rid: edgeId },
+        );
+        return (rows as Array<{ n: number }>)[0]?.n ?? 0;
+      });
+
+    expect(await countAudit()).toBe(1);
+
+    const forget = await f.http
+      .post('/v1/users/user_x/forget')
+      .set(auth())
+      .send({});
+    expect([200, 201]).toContain(forget.status);
+    expect(forget.body.edgesDeleted).toBeGreaterThanOrEqual(1);
+
+    // The edge's audit mirror is gone with it.
+    expect(await countAudit()).toBe(0);
+  });
+});


### PR DESCRIPTION
Docs/hygiene wave of the v0.6.0 audit follow-up — the last one. Follows waves A (#154), B (#156), C (#157), D (#158).

## `env-validation` — ABAC_DB_FENCE_ENABLED validated
The flag is read (`surreal.service.ts` via `envFlagEnabled`) but wasn't in `validateAbacEnv`'s list. An unrecognized value (`yes`, `enabled`, a typo) parses as **OFF** with no boot error — silently disabling the fence, the exact fail-open shape this validator exists for. Now validated like the other ABAC flags.

## `user-forget` (GDPR) — edge audit rows purged + honest gaps documented
`knowledge_edge` is mirrored into `audit_event` by the changefeed drain, but the cascade only purged the **fact/entity** audit rows — a forgotten user's **edge** audit mirror survived. Now collects the deleted edge ids and purges their audit rows too.

The docstring also states what user-forget **cannot** purge and why:
- `debug_trace` — per-request ring buffer, no userId column, TTL-pruned.
- `ingest_dead_letter` — rejected payloads carry no userId, so a REJECTED personal fact can't be selectively purged.

An honest, documented GDPR gap (closing it needs a userId stamp at reject time) rather than a broken partial purge.

## `.env.example` — the #145 flags were missing
`SEARCH_USAGE_*`, `SEARCH_QUERY_EXPANSION_*`, `DREAMS_CORROBORATE_*`, `DREAMS_COMMUNITIES_*`, `COMPACTION_PROMOTION_*`, `SEARCH_HNSW_*`, and `ABAC_DB_FENCE_ENABLED` were absent (present in `operations.md` → drift). **Every name + default verified against the code that reads it** (e.g. `SEARCH_QUERY_EXPANSION_N=2`, `SEARCH_HNSW_EF=100`, `DREAMS_CORROBORATE_MAX_PAIRS=20`).

## `api.md`
Document `POST /v1/admin/maintenance/hnsw` (was missing), including the create dimension-mismatch `400`.

## Verification
env-validation unit (ABAC-flag accept/reject); a self-contained e2e seeds a personal entity + edge + `audit_event` mirror and asserts forget purges all three. `tsc` + `eslint` clean; affected unit + e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYm9x6dMncfHuRR9xseWHn