### PR TITLE
fix(func): audit wave F1 — dead leases page, limit>20 cap, MCP pack parity, doc drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented here. The format is based on
 * **security:** audit wave A — dead nightly cron + phantom-fence PII leaks + artifact scope ([#154](https://github.com/inite-ai/inite-brain-service/issues/154)) ([c32c4c8](https://github.com/inite-ai/inite-brain-service/commit/c32c4c825408715c5b15068719811d8d78f1dce4))
 * **security:** audit wave B — feedback trust farming, source.meta bypass, entity scope collision ([#156](https://github.com/inite-ai/inite-brain-service/issues/156)) ([18fd8eb](https://github.com/inite-ai/inite-brain-service/commit/18fd8eb141a019d3f987fd0924254601de059f49))
 * **security:** audit wave C — ABAC behind-flag hardening (meta-union, resolver, windows, candidates) ([#157](https://github.com/inite-ai/inite-brain-service/issues/157)) ([7153a61](https://github.com/inite-ai/inite-brain-service/commit/7153a61f10440c7d0ac89ab9e1ac06ec676b7ff2))
+* **gdpr:** audit wave E — env-flag coverage, ABAC fence validation, edge audit purge ([#159](https://github.com/inite-ai/inite-brain-service/issues/159)) ([0ecddcf](https://github.com/inite-ai/inite-brain-service/commit/0ecddcf))
 
 ## [0.6.0](https://github.com/inite-ai/inite-brain-service/compare/v0.5.0...v0.6.0) (2026-07-10)
 

--- a/brain-landing/app/api/admin/proxy/[...path]/route.ts
+++ b/brain-landing/app/api/admin/proxy/[...path]/route.ts
@@ -264,6 +264,7 @@ const ALLOWED_PREFIXES = [
   'v1/admin/cost',
   'v1/admin/jobs',
   'v1/admin/scheduler',
+  'v1/admin/leases',
   'v1/admin/changefeed',
   'v1/admin/maintenance/',
   'v1/admin/dreams',

--- a/docs/abac.md
+++ b/docs/abac.md
@@ -43,6 +43,27 @@ Multiple sets on one key combine **most-restrictive**: the final verdict is
 allow only if every enforce-mode set allows. `report_only` sets are evaluated
 and logged (`would_deny`) but never block — that's the rollout mode.
 
+### Temporal windows (`activeFrom` / `activeUntil`)
+
+A set may carry an optional half-open activity window, both bounds ISO-8601
+UTC datetimes:
+
+```jsonc
+{ "name": "contractor-window", …,
+  "activeFrom": "2026-07-01T00:00:00Z",   // inclusive; omit = always-open start
+  "activeUntil": "2026-10-01T00:00:00Z" } // exclusive; omit = never-expiring
+```
+
+Outside the window the set compiles to **nothing** — it neither allows nor
+denies, exactly as if it weren't attached. Write-time validation rejects
+`activeFrom >= activeUntil` (a window that can never open would be a
+permanently-inert, fail-open set). **Operational caveat:** because an expired
+set simply drops out, a key whose *only* restriction was a windowed set reverts
+to its pre-ABAC (unpolicied) posture when the window closes — size the window to
+the grant, and keep a standing enforce set for the baseline. The window bounds
+round-trip through the policy editor unchanged; there is no dedicated UI for
+them yet, so edit them via the API or the raw document.
+
 ### Attributes source rules can match
 
 | Attribute | Ops | Notes |

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,7 +73,7 @@ See [Document pipeline](document-pipeline.md) for the architecture.
 | `GET /v1/admin/jobs/stream` | SSE stream of job_run transitions for live dashboard. |
 | `GET /v1/admin/leases` | leader_lease snapshot + active claims across tenants (Phase J cockpit). |
 | `GET /v1/admin/scheduler` | Registered cron entries with last/next fire timestamps. |
-| `POST /v1/admin/maintenance/dreams/run` | Async kick of dreams (returns runId). |
+| `POST /v1/admin/maintenance/dreams/run` | Fire-and-forget kick of dreams; returns `{accepted, jobType, companyId}` (no runId — poll `GET /v1/admin/maintenance/dreams/runs/:runId/emits` for a specific run). |
 | `POST /v1/admin/maintenance/calibration-refit` | Async kick of calibration + source-trust refit. |
 | `POST /v1/admin/maintenance/reindex` | Async re-embed `knowledge_fact`, optionally per tenant. |
 | `POST /v1/admin/maintenance/hnsw` | Per-tenant HNSW vector-index lifecycle: `{action: 'create' \| 'drop', tenant?}`. Synchronous. `create` refuses (`400`) when an index already exists at a different dimension — recover in order: drop → reindex embeddings → create. |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -133,5 +133,5 @@ docker / fly / k8s don't `SIGKILL` you with no log line.
 | `pnpm test:eval:fat` | Spawns a ~500-customer tenant via the generator and asserts retrieval thresholds at scale (`FAT_TENANT_RUN=1` implied). | When you've changed retrieval scoring and need to confirm the small-graph regression is gone. |
 | `pnpm test:eval:directory` | Jumbo eval — 1k customers with retracts, GDPR forgets, temporal tier trajectories, competing status; asserts memory-lifecycle correctness AND recall@3 at scale. | When you've touched ingest / lifecycle code; before signing off on a release. |
 | `pnpm test:eval:json` | Loads a directory from `BRAIN_DIRECTORY_JSON=…/file.json` and runs retrieval + lifecycle assertions; same runner, your data. | Bringing up brain on a real customer dataset; smoke-testing a CSV→JSON export against the eval harness. |
-| `pnpm test --testPathPattern=jobs.real` | Real-Surreal e2e: enqueue → claim → renew → complete cycle, dedup collision, fail+requeue, zombie reap, leader_lease in `system` DB. | After touching anything in `src/jobs/` or migrations 0028-0031. |
+| `pnpm test:e2e:jobs` | Real-Surreal e2e: enqueue → claim → renew → complete cycle, dedup collision, fail+requeue, zombie reap, leader_lease in `system` DB. | After touching anything in `src/jobs/` or migrations 0028-0031. |
 | `pnpm lint` | ESLint flat config. | Every commit. |

--- a/src/mcp/write-tools.ts
+++ b/src/mcp/write-tools.ts
@@ -339,7 +339,7 @@ function registerIngestDocumentTool({
     {
       title: 'Ingest a normalized document',
       description:
-        'Feed a normalized document (meeting transcript, email body, markdown…) through the Source → Indexer → Candidates → Brain pipeline: it is stored (content-hash deduped), read by the generalist indexer (plus relevant domain packs), staged as candidates, and committed through conflict resolution. Prefer this over record_fact for anything longer than one claim.',
+        "Feed a normalized document (meeting transcript, email body, markdown…) through the Source → Indexer → Candidates → Brain pipeline: it is stored (content-hash deduped), read by the generalist indexer, staged as candidates, and committed through conflict resolution. Pass indexers:'auto' to additionally route relevant installed domain packs (requires DOCUMENT_MULTI_INDEXER_ENABLED on the server; default 'general' runs only the generalist union pass). Prefer this over record_fact for anything longer than one claim.",
       inputSchema: {
         kind: z
           .string()
@@ -364,6 +364,12 @@ function registerIngestDocumentTool({
           .boolean()
           .optional()
           .describe('false keeps only the content hash (no re-indexing later)'),
+        indexers: z
+          .enum(['general', 'auto'])
+          .optional()
+          .describe(
+            "'general' (default) = generalist union pass only; 'auto' = also route relevant installed domain packs (server must have DOCUMENT_MULTI_INDEXER_ENABLED)",
+          ),
       },
     },
     async (args) => {
@@ -381,7 +387,7 @@ function registerIngestDocumentTool({
         occurredAt: args.occurredAt,
         contextRef: { vertical: args.vertical, recorder: 'mcp_agent' },
         storeContent: args.storeContent,
-        indexers: 'general',
+        indexers: args.indexers ?? 'general',
         mode: 'sync',
       });
       return {

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -373,6 +373,19 @@ export class SearchService {
       ctx,
       typeDist,
     });
+    // The rerank stage only ranks a bounded window (≤20 buckets). When the
+    // caller asked for more (limit up to the DTO's @Max(100)), the reranked
+    // head is correct but the tail beyond the window was dropped — a silent
+    // cap at 20. Refill from the remaining buckets in rankScore order so the
+    // response honors `limit`; the reranker legitimately only reorders its
+    // own window, so rankScore is the right ordering past it.
+    if (topEntities.length < ctx.limit && byEntity.size > topEntities.length) {
+      const present = new Set(topEntities.map((b) => b.entityId));
+      const tail = [...byEntity.values()]
+        .filter((b) => !present.has(b.entityId))
+        .sort((a, b) => b.rankScore - a.rankScore);
+      topEntities = topEntities.concat(tail);
+    }
     topEntities = topEntities.slice(0, ctx.limit);
 
     // 8. Backfill missing facts for top-K, then assemble.

--- a/test/mcp-tools.unit-spec.ts
+++ b/test/mcp-tools.unit-spec.ts
@@ -137,6 +137,25 @@ describe('McpService.buildServer — scope-gated tool surface', () => {
     expect(names).toContain('entity-profile');
     expect(names).toContain('entity-timeline');
   });
+
+  it('ingest_document exposes the indexers param (REST parity: auto routes packs)', () => {
+    const prev = process.env.DOCUMENT_INGEST_ENABLED;
+    process.env.DOCUMENT_INGEST_ENABLED = '1';
+    try {
+      const server = buildWithScopes(['brain:read', 'brain:write']);
+      const internals = server as unknown as {
+        _registeredTools: Record<string, { inputSchema?: { shape?: object } }>;
+      };
+      const tool = internals._registeredTools['ingest_document'];
+      expect(tool).toBeDefined();
+      // Before the fix the tool hardcoded indexers:'general' with no way to
+      // opt into domain-pack routing that the REST twin accepts.
+      expect(Object.keys(tool.inputSchema?.shape ?? {})).toContain('indexers');
+    } finally {
+      if (prev === undefined) delete process.env.DOCUMENT_INGEST_ENABLED;
+      else process.env.DOCUMENT_INGEST_ENABLED = prev;
+    }
+  });
 });
 
 describe('McpService.health — unauthenticated probe payload', () => {

--- a/test/search-limit-window.e2e-spec.ts
+++ b/test/search-limit-window.e2e-spec.ts
@@ -1,0 +1,47 @@
+/**
+ * The rerank stage only ranks a bounded window (≤20 buckets). Before the
+ * fix, `runRerankStage` returned at most that window and the tail was
+ * silently dropped, so a search with limit > 20 could never return more
+ * than 20 hits even though the DTO advertises @Max(100). This pins that a
+ * limit above the rerank window is honored (tail refilled by rankScore).
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+
+describe('search honors limit beyond the rerank window', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_limit_window_e2e' });
+    // 25 distinct entities, each with a name fact sharing a common token so
+    // one query retrieves them all into separate buckets.
+    for (let i = 0; i < 25; i++) {
+      await f.http
+        .post('/v1/ingest/fact')
+        .set(auth())
+        .send({
+          entityRef: { vertical: 'rent', id: `limitwin_${i}` },
+          predicate: 'name',
+          object: `Limit Window Probe ${i}`,
+          validFrom: '2026-01-01',
+          confidence: 0.9,
+          source: { vertical: 'rent', recorder: 'bot' },
+        });
+    }
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('returns more than the 20-wide rerank window when limit=25', async () => {
+    const res = await f.http
+      .post('/v1/search')
+      .set(auth())
+      .send({ query: 'Limit Window Probe', limit: 25 });
+    expect(res.status).toBe(201);
+    // Before the fix this capped at 20 regardless of limit.
+    expect(res.body.results.length).toBeGreaterThan(20);
+  });
+});


### PR DESCRIPTION
Batch 1 of the functional-audit follow-up (fast, high-value). From the 2026-07-11 functional pass (8 agents, focus: does each feature work as claimed; drift; gaps).

## LIVE fixes
- **Admin Leases page fully dead.** `v1/admin/leases` was missing from the BFF proxy allow-list → every load 403'd before forwarding. The endpoint (`admin-jobs.controller.ts`), wire contract, and even the boundary schema-map entry all existed — only the allow-list prefix was never added. One line. (Pre-existing, not a wave A–E regression.)
- **Search silently capped at 20 results.** The rerank stage only ranks a bounded ≤20 window; the pipeline returned only that window before `.slice(0, limit)`, so any `limit` in (20, 100] (the DTO's `@Max(100)`) could never return more than 20 hits. Refill the tail from the remaining buckets in rankScore order before the slice — the reranker legitimately only reorders its own window, so rankScore is the correct ordering past it.

## Parity
- **MCP `ingest_document` hardcoded `indexers:'general'`** → domain-pack routing permanently off via MCP while the REST twin accepts `'auto'`, and the tool description claimed packs run. Add an optional `indexers: 'general'|'auto'` param (default `'general'` — behavior unchanged, callers can now opt in) and correct the description.

## Doc drift
- `api.md`: dreams-run returns `{accepted, jobType, companyId}`, not a runId.
- `operations.md`: the jobs-e2e command `pnpm test --testPathPattern=jobs.real` matches **zero** tests under the unit config; it's `pnpm test:e2e:jobs`.
- `CHANGELOG`: restore the wave E (#159) entry release-please dropped (the `docs+fix` commit type isn't a conventional type).
- `abac.md`: document policy **temporal windows** (`activeFrom`/`activeUntil`) — half-open semantics, write-time validation, and the expiry-widens-access caveat. Previously entirely undocumented in the security doc.

## Verification
`search-limit-window` e2e (25 entities, limit=25 → >20 hits); `mcp-tools` asserts `ingest_document` exposes the `indexers` param. Full unit + affected e2e green; `tsc` + `eslint` clean (incl. brain-landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYm9x6dMncfHuRR9xseWHn