### PR TITLE
fix(ingest): audit wave F2 — detect_contradiction mirrors fn::resolve_fact (0055)

### DIFF
--- a/src/ingest/ingest-predictor.service.ts
+++ b/src/ingest/ingest-predictor.service.ts
@@ -8,7 +8,9 @@ import {
   PredictResolveArgs,
   PredictResolveResult,
   PriorRow,
+  dateToIso,
   intervalsOverlap,
+  originKeyOf,
   rowToOpposingFact,
 } from './predictor-internals';
 import { makeRowPolicyFilter } from '../policy/row-filter';
@@ -26,10 +28,15 @@ export type {
  * Answers "if I were to record this fact right now, what would the
  * resolver decide?" without writing to the database. The decision is
  * approximated in JS using the same scoring weights, recency decay,
- * and policy semantics the server-side function uses — the fidelity
- * gap vs. the live resolver is bounded by (a) source_trust learning
- * (we use the seed table, not the per-tenant learned rate from
- * migration 0022) and (b) embedding cache misses (we re-embed).
+ * and policy semantics (INSERTED / INSERTED_HISTORICAL / CORROBORATED /
+ * SUPERSEDED / COMPETING / REJECTED, in the resolver's order) the
+ * server-side function uses. The fidelity gap vs. the live resolver is
+ * bounded by: (a) source_trust learning (we use the seed table, not the
+ * per-tenant learned rate from migration 0022); (b) embedding cache
+ * misses (we re-embed); (c) declared source authority (we score it as
+ * the neutral 0, so a high-authority source's margin is understated);
+ * and (d) the prior scan cap below — the resolver scans every active
+ * competitor, the preflight the most recent PRIOR_SCAN_CAP.
  *
  * Use as preflight from agent loops: "is the entity already
  * conflicted on this predicate?" or "would this fact be rejected
@@ -42,6 +49,15 @@ export type {
  * registry inputs and delegates the conflict-scoring decisions to
  * PredictScoringService.
  */
+/**
+ * How many recent active competitors the preflight scans. The live
+ * resolver scans every active competitor; this caps the advisory path's
+ * cost. Newest-first, so the strongest recency-weighted opponents are
+ * always in-window — a miss only occurs past this many co-active facts
+ * on one (entity, predicate), rare outside bitemporal firehoses.
+ */
+const PRIOR_SCAN_CAP = 100;
+
 @Injectable()
 export class IngestPredictionService {
   private readonly logger = new Logger(IngestPredictionService.name);
@@ -127,7 +143,7 @@ export class IngestPredictionService {
              AND status = 'active'
              AND userId IS NONE
            ORDER BY recordedAt DESC
-           LIMIT 25`,
+           LIMIT ${PRIOR_SCAN_CAP}`,
         { eid: tail, predicate: args.predicate },
       );
       const priors = ((rows as any[]) ?? []) as PriorRow[];
@@ -145,16 +161,29 @@ export class IngestPredictionService {
 
       const candidateScore = this.scoring.scoreCandidate(args);
 
-      if (candidateScore < this.scoring.conflict.rejectThreshold) {
+      // The decision below mirrors fn::resolve_fact's ORDER (migration
+      // 0055): reject (bitemporal only) → empty-competing INSERTED →
+      // CORROBORATED → INSERTED_HISTORICAL (single_active) → supersede/
+      // compete. Getting the order OR the semantics wrong makes the
+      // preflight report an outcome the real resolver would never pick.
+
+      // 1. Reject is bitemporal-ONLY. single_active/append_only never
+      // reject on a low score — they insert/supersede/append (0055:69
+      // guards the reject with `$semantics = 'bitemporal'`).
+      if (
+        policy.semantics === 'bitemporal' &&
+        candidateScore < this.scoring.conflict.rejectThreshold
+      ) {
         return {
           wouldOutcome: 'REJECTED',
           reasoning:
-            `Candidate score ${candidateScore.toFixed(3)} is below the reject threshold ${this.scoring.conflict.rejectThreshold.toFixed(3)} — too unconfident or too low-trust to enter the graph.`,
+            `bitemporal predicate, candidate score ${candidateScore.toFixed(3)} is below the reject threshold ${this.scoring.conflict.rejectThreshold.toFixed(3)} — too unconfident or too low-trust to enter the graph.`,
           opposingFacts: gate(priors.map(rowToOpposingFact)),
           predicatePolicy: policy,
         };
       }
 
+      // 2. append_only never has competing facts — always INSERTED.
       if (policy.semantics === 'append_only') {
         return {
           wouldOutcome: 'INSERTED',
@@ -165,48 +194,88 @@ export class IngestPredictionService {
         };
       }
 
-      const overlapping = priors.filter((p) =>
-        intervalsOverlap({
-          aFrom: new Date(p.validFrom),
-          aUntil: p.validUntil ? new Date(p.validUntil) : null,
-          bFrom: validFrom,
-          bUntil: args.validUntil ? new Date(args.validUntil) : null,
-        }),
-      );
+      // 3. Build the competing set the way the stored fn does: for
+      // single_active it is ALL active priors; for bitemporal it is the
+      // interval-overlapping priors that also clear the cosine threshold.
+      let competing: PriorRow[];
+      let bitemporalAbove:
+        | ReturnType<PredictScoringService['scoreBitemporal']>
+        | undefined;
+      if (policy.semantics === 'single_active') {
+        competing = priors;
+      } else {
+        const overlapping = priors.filter((p) =>
+          intervalsOverlap({
+            aFrom: new Date(p.validFrom),
+            aUntil: p.validUntil ? new Date(p.validUntil) : null,
+            bFrom: validFrom,
+            bUntil: args.validUntil ? new Date(args.validUntil) : null,
+          }),
+        );
+        bitemporalAbove = this.scoring
+          .scoreBitemporal(candEmbedding, overlapping)
+          .filter((c) => c.cosine >= this.scoring.conflict.similarityThreshold);
+        competing = bitemporalAbove.map((c) => c.row);
+      }
 
-      if (overlapping.length === 0) {
+      // 4. No competitor → clean insert.
+      if (competing.length === 0) {
         return {
           wouldOutcome: 'INSERTED',
-          reasoning: 'No existing fact overlaps the candidate validity interval.',
+          reasoning:
+            policy.semantics === 'single_active'
+              ? 'No existing active fact on this predicate; fact would be inserted.'
+              : `Overlapping facts exist but none clear the cosine similarity threshold ${this.scoring.conflict.similarityThreshold.toFixed(2)}; semantically distinct, no contradiction.`,
           opposingFacts: [],
           predicatePolicy: policy,
         };
       }
 
+      // 5. Corroboration: the SAME object from a DIFFERENT origin is
+      // independent confirmation, not a conflict (0055:147, keyed on
+      // origin_key_of, and it runs BEFORE the backdated guard). The new
+      // row is kept as `corroborating`; nothing is superseded.
+      const incomingOrigin = originKeyOf(args.source);
+      const corroborator = competing.find(
+        (c) => c.object === args.object && originKeyOf(c.source) !== incomingOrigin,
+      );
+      if (corroborator) {
+        return {
+          wouldOutcome: 'CORROBORATED',
+          reasoning: `Same object already recorded from a different origin (${originKeyOf(corroborator.source)} ≠ ${incomingOrigin}); the fact would corroborate the incumbent, not conflict.`,
+          opposingFacts: gate([rowToOpposingFact(corroborator)]),
+          predicatePolicy: policy,
+        };
+      }
+
+      // 6. Backdated guard (single_active only): a competitor with a
+      // STRICTLY NEWER validFrom means the incoming fact is history — it
+      // slots in already-superseded, the active timeline is untouched
+      // (0055:190).
       if (policy.semantics === 'single_active') {
-        const r = this.scoring.predictSingleActive(candidateScore, overlapping);
+        const newer = competing
+          .filter((c) => new Date(c.validFrom) > validFrom)
+          .sort((a, b) => new Date(a.validFrom).getTime() - new Date(b.validFrom).getTime());
+        if (newer.length > 0) {
+          return {
+            wouldOutcome: 'INSERTED_HISTORICAL',
+            reasoning: `A newer fact (validFrom ${dateToIso(newer[0].validFrom)}) already exists; the backdated candidate would be inserted as already-superseded history, not supersede the active fact.`,
+            opposingFacts: gate(newer.map(rowToOpposingFact)),
+            predicatePolicy: policy,
+          };
+        }
+      }
+
+      // 7. Supersede vs compete on the conflict score.
+      if (policy.semantics === 'single_active') {
+        const r = this.scoring.predictSingleActive(candidateScore, competing);
         return {
           ...r,
           opposingFacts: gate(r.opposingFacts),
           predicatePolicy: policy,
         };
       }
-
-      // bitemporal
-      const scored = this.scoring.scoreBitemporal(candEmbedding, overlapping);
-      const above = scored.filter(
-        (c) => c.cosine >= this.scoring.conflict.similarityThreshold,
-      );
-      if (above.length === 0) {
-        return {
-          wouldOutcome: 'INSERTED',
-          reasoning:
-            `Overlapping facts exist but none clear the cosine similarity threshold ${this.scoring.conflict.similarityThreshold.toFixed(2)}; semantically distinct, no contradiction.`,
-          opposingFacts: gate(scored.map((c) => c.opposing)),
-          predicatePolicy: policy,
-        };
-      }
-      const r = this.scoring.predictBitemporal(candidateScore, above);
+      const r = this.scoring.predictBitemporal(candidateScore, bitemporalAbove!);
       return {
         ...r,
         opposingFacts: gate(r.opposingFacts),

--- a/src/ingest/predict-scoring.service.ts
+++ b/src/ingest/predict-scoring.service.ts
@@ -105,7 +105,7 @@ export class PredictScoringService {
   scoreBitemporal(
     candEmbedding: number[],
     overlapping: PriorRow[],
-  ): Array<{ opposing: OpposingFact; cosine: number; score: number }> {
+  ): Array<{ opposing: OpposingFact; cosine: number; score: number; row: PriorRow }> {
     const norm = vectorNorm(candEmbedding);
     return overlapping.map((p) => {
       const emb = Array.isArray(p.embedding) ? (p.embedding as number[]) : null;
@@ -122,13 +122,13 @@ export class PredictScoringService {
         },
         this.conflict,
       );
-      return { opposing: rowToOpposingFact(p), cosine, score };
+      return { opposing: rowToOpposingFact(p), cosine, score, row: p };
     });
   }
 
   predictBitemporal(
     candidateScore: number,
-    above: Array<{ opposing: OpposingFact; cosine: number; score: number }>,
+    above: Array<{ opposing: OpposingFact; cosine: number; score: number; row: PriorRow }>,
   ): Omit<PredictResolveResult, 'predicatePolicy'> {
     const top = above.reduce((acc, c) => (c.score > acc.score ? c : acc), above[0]);
     const gap = candidateScore - top.score;

--- a/src/ingest/predictor-internals.ts
+++ b/src/ingest/predictor-internals.ts
@@ -5,11 +5,39 @@
  * sides can import them without a circular dependency.
  */
 
+// Mirrors the outcomes fn::resolve_fact can return (migration 0055).
+// The preflight must be able to predict every one of them, not the
+// 0006-era subset — otherwise detect_contradiction reports the wrong
+// outcome for corroboration and backdated ingests.
 export type IngestOutcome =
   | 'INSERTED'
+  | 'INSERTED_HISTORICAL'
+  | 'CORROBORATED'
   | 'SUPERSEDED'
   | 'COMPETING'
   | 'REJECTED';
+
+/**
+ * JS mirror of `fn::origin_key_of` (migration 0050) composed with
+ * `fn::source_key_of` (0022): the origin key is `source.originKey` when
+ * the writer set one (the document path stamps `doc:<contentHash>`),
+ * else `vertical:recorder` (recorder → `_` when absent), else the
+ * `system_seed` sentinel. Corroboration keys off this — the SAME claim
+ * from a DIFFERENT origin is independent confirmation.
+ */
+export function originKeyOf(source: unknown): string {
+  if (!source || typeof source !== 'object') return 'system_seed';
+  const s = source as {
+    originKey?: unknown;
+    vertical?: unknown;
+    recorder?: unknown;
+  };
+  if (s.originKey != null && s.originKey !== '') return String(s.originKey);
+  if (s.vertical == null || s.vertical === '') return 'system_seed';
+  const recorder =
+    s.recorder == null || s.recorder === '' ? '_' : String(s.recorder);
+  return `${String(s.vertical)}:${recorder}`;
+}
 
 export interface PredictResolveArgs {
   entityRef:

--- a/test/predict-resolve.e2e-spec.ts
+++ b/test/predict-resolve.e2e-spec.ts
@@ -2,12 +2,13 @@
  * IngestPredictionService.predict — integration smoke
  *
  * The predictor is a JS-side dry-run of fn::resolve_fact. We exercise
- * each branch of the decision tree against a real DB:
+ * each branch of the decision tree against a real DB, in the resolver's
+ * order (migration 0055):
  *   - Unknown entity → INSERTED
- *   - Below reject threshold → REJECTED
- *   - append_only predicate → INSERTED (no conflict by policy)
+ *   - single_active low score → NEVER REJECTED (reject is bitemporal-only)
+ *   - same object, different origin → CORROBORATED
+ *   - backdated single_active candidate → INSERTED_HISTORICAL
  *   - single_active with overlapping prior → SUPERSEDED or COMPETING
- *   - bitemporal with non-overlapping valid-time → INSERTED
  *
  * No writes happen via predict — we assert the DB row count stays put.
  */
@@ -124,15 +125,65 @@ describe('IngestPredictionService.predict — read-only conflict preflight', () 
       confidence: 0,
       source: { vertical: 'rent' },
     }, ['brain:read', 'brain:read_pii']);
-    // We can't bank on REJECTED across all envs, but we can assert
-    // the predictor returned ONE of the four canonical outcomes and
-    // included a reasoning string. The dedicated REJECTED branch is
-    // unit-tested in the predictor's score-math (covered indirectly
-    // via the IngestService scoreFact tests).
-    expect(['INSERTED', 'SUPERSEDED', 'COMPETING', 'REJECTED']).toContain(
-      out.wouldOutcome,
-    );
+    // `name` is single_active — the reject gate is bitemporal-ONLY in
+    // fn::resolve_fact (0055), so a low score here must NEVER report
+    // REJECTED (the old predictor wrongly rejected every semantics). It
+    // resolves to a supersede/compete verdict instead.
+    expect(out.wouldOutcome).not.toBe('REJECTED');
+    expect(['SUPERSEDED', 'COMPETING', 'INSERTED']).toContain(out.wouldOutcome);
     expect(out.reasoning.length).toBeGreaterThan(0);
+  });
+
+  it('same object from a DIFFERENT origin → CORROBORATED', async () => {
+    await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'predict_corrob_subj' },
+        predicate: 'name',
+        object: 'Corroborated Name',
+        validFrom: '2026-01-01T00:00:00Z',
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'source_a' },
+      });
+
+    const predictor = f.app.get(IngestPredictionService);
+    const out = await predictor.predict(f.companyId, {
+      entityRef: { vertical: 'rent', id: 'predict_corrob_subj' },
+      predicate: 'name',
+      object: 'Corroborated Name', // SAME object
+      validFrom: '2026-02-01T00:00:00Z',
+      confidence: 0.9,
+      source: { vertical: 'rent', recorder: 'source_b' }, // DIFFERENT origin
+    }, ['brain:read', 'brain:read_pii']);
+    expect(out.wouldOutcome).toBe('CORROBORATED');
+    expect(out.opposingFacts[0]?.object).toBe('Corroborated Name');
+  });
+
+  it('backdated single_active candidate → INSERTED_HISTORICAL', async () => {
+    await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'predict_hist_subj' },
+        predicate: 'name',
+        object: 'Current Name',
+        validFrom: '2026-03-01T00:00:00Z',
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+      });
+
+    const predictor = f.app.get(IngestPredictionService);
+    const out = await predictor.predict(f.companyId, {
+      entityRef: { vertical: 'rent', id: 'predict_hist_subj' },
+      predicate: 'name',
+      object: 'Older Name', // different object → not corroboration
+      validFrom: '2026-01-01T00:00:00Z', // BEFORE the active fact
+      confidence: 0.9,
+      source: { vertical: 'rent', recorder: 'bot' },
+    }, ['brain:read', 'brain:read_pii']);
+    expect(out.wouldOutcome).toBe('INSERTED_HISTORICAL');
+    expect(out.opposingFacts.length).toBeGreaterThan(0);
   });
 
   it('predicate policy is surfaced in the result', async () => {

--- a/test/predictor-origin-key.unit-spec.ts
+++ b/test/predictor-origin-key.unit-spec.ts
@@ -1,0 +1,37 @@
+/**
+ * originKeyOf is the JS mirror of fn::origin_key_of (0050) ∘
+ * fn::source_key_of (0022). Corroboration keys off it, so its parity
+ * with the stored fns is load-bearing: a drift would make the preflight
+ * mis-detect "same claim, different origin".
+ */
+import { originKeyOf } from '../src/ingest/predictor-internals';
+
+describe('originKeyOf — parity with fn::origin_key_of', () => {
+  it('prefers an explicit originKey (document path stamps doc:<hash>)', () => {
+    expect(originKeyOf({ vertical: 'notes', recorder: 'sync', originKey: 'doc:abc' })).toBe(
+      'doc:abc',
+    );
+  });
+
+  it('falls back to vertical:recorder when no originKey', () => {
+    expect(originKeyOf({ vertical: 'rent', recorder: 'bot' })).toBe('rent:bot');
+  });
+
+  it('uses the _ recorder sentinel when recorder is absent/empty', () => {
+    expect(originKeyOf({ vertical: 'rent' })).toBe('rent:_');
+    expect(originKeyOf({ vertical: 'rent', recorder: '' })).toBe('rent:_');
+  });
+
+  it('returns system_seed for null / non-object / vertical-less source', () => {
+    expect(originKeyOf(undefined)).toBe('system_seed');
+    expect(originKeyOf(null)).toBe('system_seed');
+    expect(originKeyOf('nope')).toBe('system_seed');
+    expect(originKeyOf({ recorder: 'bot' })).toBe('system_seed');
+  });
+
+  it('distinguishes two recorders on the same vertical (corroboration axis)', () => {
+    expect(originKeyOf({ vertical: 'rent', recorder: 'a' })).not.toBe(
+      originKeyOf({ vertical: 'rent', recorder: 'b' }),
+    );
+  });
+});


### PR DESCRIPTION
Batch 2 of the functional-audit follow-up: the predictor cluster. The `predict` preflight (MCP `detect_contradiction`) is a JS dry-run of `fn::resolve_fact`, but it had drifted from the stored resolver so `wouldOutcome` was wrong for whole classes of ingest.

## Bugs
- **Rejected on low score for every semantics.** `fn::resolve_fact` rejects only for `bitemporal` (0055:69). A low-confidence `single_active` or `append_only` fact reported `REJECTED` but would actually be inserted/superseded/appended. → reject gate is now bitemporal-only.
- **Outcome enum frozen at the 0006-era four** (INSERTED/SUPERSEDED/COMPETING/REJECTED). The resolver has six, incl. `CORROBORATED` (0047) and `INSERTED_HISTORICAL` (0043) — the preflight could never predict either. → both added, detected in the resolver's **order**: empty-competing INSERTED → CORROBORATED → INSERTED_HISTORICAL → supersede/compete.
- **Corroboration keys off origin identity** → added `originKeyOf`, a JS mirror of `fn::origin_key_of` (0050) ∘ `fn::source_key_of` (0022). Same object from a *different* origin is confirmation, not a conflict.
- **single_active competing set** now = ALL active priors (matching `$competing` in the fn), not just interval-overlapping ones, so the backdated + corroboration checks see the right set.

## Now-disclosed approximations
The docstring previously named only source_trust-learning + embedding-cache as fidelity gaps. Two more are now documented rather than papered over: declared source **authority** is scored neutral (0), and the prior scan is capped (`PRIOR_SCAN_CAP=100`, up from a silent 25 — the resolver scans every competitor). Both understate margins only in rare high-authority / >100 co-active-fact cases; documented instead of adding a DB round-trip to the advisory path.

## Verification
`predict-resolve` e2e gains CORROBORATED + INSERTED_HISTORICAL cases and pins that single_active never REJECTs; `predictor-origin-key` unit spec pins `originKeyOf` parity with the stored fns. Full unit **1061 green**; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYm9x6dMncfHuRR9xseWHn