### PR TITLE
fix(documents): audit wave F3 — async run-ledger reliability + external provenance

### DIFF
--- a/src/documents/candidate-store.service.ts
+++ b/src/documents/candidate-store.service.ts
@@ -46,13 +46,20 @@ export class CandidateStoreService {
    * index makes "already processed" a unique violation, not a race.
    *
    * On that violation we inspect the existing run and REOPEN it when it is
-   * recoverable — a terminal 'failed' run, or one stuck 'running' past the
-   * stale window (a crashed worker whose job lease has long expired). Left
-   * un-reopened, a transient LLM error would make the (doc, pack, version)
-   * slot permanently skip: retries and re-POSTs would hit the ledger and
-   * return 'skipped', so the document's extraction is lost forever. A
-   * freshly 'running' run is another worker actively extracting — never
-   * reopen it (would double-stage candidates). 'succeeded' is a real skip.
+   * recoverable: a 'pending' run this document's ingest pre-created (async
+   * path — its job is now claiming it), a terminal 'failed' run, or one
+   * stuck 'running' past the stale window (a crashed worker whose job
+   * lease has long expired). Left un-reopened, a transient LLM error would
+   * make the (doc, pack, version) slot permanently skip: retries and
+   * re-POSTs would hit the ledger and return 'skipped', so the document's
+   * extraction is lost forever. A freshly 'running' run is another worker
+   * actively extracting — never reopen it (would double-stage candidates).
+   * 'succeeded' is a real skip.
+   *
+   * The reopen is a COMPARE-AND-SWAP on the observed status: two jobs that
+   * both see the same reopenable row (e.g. an async index job and a
+   * reindex job that don't collide on the job-claim dedupKey) must not both
+   * re-extract. Only the CAS winner gets `created:true`; the loser skips.
    */
   async createRun(
     companyId: string,
@@ -92,17 +99,29 @@ export class CandidateStoreService {
           : 0;
         const isStaleRunning =
           status === 'running' && Date.now() - createdMs > staleRunMs();
-        if (status === 'failed' || isStaleRunning) {
-          // Reopen: drop the prior attempt's staged candidates (re-extraction
-          // re-inserts) and reset the ledger row to 'running'. option<> fields
-          // clear with NONE (never NULL — 0049 is SCHEMAFULL).
-          await db.query(
+        if (status === 'pending' || status === 'failed' || isStaleRunning) {
+          // Reopen under a CAS: only proceed if the row is STILL in the
+          // status we observed (`RETURN AFTER` gives us the updated rows;
+          // an empty result = a concurrent reopener already flipped it, so
+          // we defer to it). Drop any prior attempt's staged candidates
+          // (re-extraction re-inserts; a 'pending' run has none). option<>
+          // fields clear with NONE (never NULL — 0049 is SCHEMAFULL).
+          // Two statements → two result slots; the CAS verdict is the
+          // UPDATE's (slot 1), not the DELETE's (slot 0).
+          const res = await db.query<[any[], any[]]>(
             `DELETE candidate WHERE runId = type::record('indexer_run', $run);
              UPDATE type::record('indexer_run', $run) SET
                status = 'running', createdAt = time::now(),
-               finishedAt = NONE, error = NONE, stats = NONE`,
-            { run: idTailOf(runId) },
+               finishedAt = NONE, error = NONE, stats = NONE
+             WHERE status = $observed
+             RETURN AFTER`,
+            { run: idTailOf(runId), observed: status },
           );
+          const swapped = (res[1] as any[]) ?? [];
+          if (swapped.length === 0) {
+            // Lost the race — another job reopened it and is extracting.
+            return { runId, created: false };
+          }
           this.metrics?.countIndexerRun('reopened');
           return { runId, created: true };
         }
@@ -112,18 +131,59 @@ export class CandidateStoreService {
   }
 
   /**
-   * Reap indexer_run rows stuck 'running' past the stale window — a worker
-   * that crashed between createRun and finalizeRun leaves the row open
-   * forever, and countNonTerminalRuns then defers the document's commit
-   * indefinitely (its pending candidates eventually expire = silent memory
-   * loss). Mark them 'failed' so commit can settle over the runs that
-   * succeeded. Returns the reaped run count.
+   * Pre-create the ledger row for an async indexer run as 'pending', so
+   * `countNonTerminalRuns` sees every planned run from the instant the
+   * document is enqueued — NOT only once each job has started and called
+   * createRun. Without this, the general pass could finish and commit
+   * before a dedicated run's row exists (open-count 0), committing a
+   * partial candidate set and losing the cross-indexer merge. Idempotent:
+   * a row already present (any state) is left untouched — the job's
+   * createRun handles the 'pending' → 'running' transition, and a re-POST
+   * must not resurrect a terminal run.
+   */
+  async ensureRunPending(
+    companyId: string,
+    p: { docId: string; packId: string; packVersion: string },
+  ): Promise<void> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      try {
+        await dbCreate<Record<string, unknown>>(db, 'indexer_run', {
+          docId: recordRef('source_document', p.docId),
+          packId: p.packId,
+          packVersion: p.packVersion,
+          status: 'pending',
+        });
+      } catch (err) {
+        if (!isUniqueViolation(err)) throw err;
+        // Row already exists — leave whatever state it's in.
+      }
+    });
+  }
+
+  /**
+   * Reap non-terminal indexer_run rows past the stale window:
+   *   - 'running' — a worker that crashed between createRun and finalizeRun
+   *     leaves the row open forever (its job lease expired at ttlSeconds,
+   *     well below the stale window, so this is the only recovery for a
+   *     hard crash — SIGKILL/OOM never fires the graceful abort path);
+   *   - 'pending' — an async run pre-created by ingest whose job was never
+   *     claimed (worker fleet down at enqueue time).
+   * Either state left un-reaped makes countNonTerminalRuns defer the
+   * document's commit indefinitely, and its pending candidates eventually
+   * expire = silent memory loss. Mark them 'failed' so commit settles over
+   * the runs that succeeded. Returns the reaped run count.
+   *
+   * Latency note: between a hard crash and this reap the run sits orphaned
+   * for up to the stale window (kept above the job lease so a legitimately
+   * slow extraction is never falsely reopened). Candidates persist across
+   * that gap — no data loss, only commit latency bounded by the reap
+   * cadence and CANDIDATE_PENDING_TTL_DAYS.
    */
   async reapStaleRuns(companyId: string): Promise<number> {
     return this.surreal.withCompany(companyId, async (db) => {
       const [rows] = await db.query<[any[]]>(
         `SELECT count() AS c FROM indexer_run
-           WHERE status = 'running'
+           WHERE status IN ['running', 'pending']
              AND createdAt < time::now() - duration::from_millis($ms)
            GROUP ALL`,
         { ms: staleRunMs() },
@@ -134,7 +194,7 @@ export class CandidateStoreService {
           `UPDATE indexer_run SET
              status = 'failed', finishedAt = time::now(),
              error = { message: 'stale_reaped' }
-           WHERE status = 'running'
+           WHERE status IN ['running', 'pending']
              AND createdAt < time::now() - duration::from_millis($ms)
            RETURN NONE`,
           { ms: staleRunMs() },
@@ -146,12 +206,16 @@ export class CandidateStoreService {
   }
 
   /**
-   * Documents that still have staged (pending) candidates while sitting in
-   * a pre-commit state — a commit that was lost (the last run's enqueue
-   * failed, or its run was stuck 'running' and just got reaped). The
-   * reconciler re-drives their commit; commitIfRunsSettled itself defers if
-   * any run is still genuinely open, so enqueuing is always safe. Bounded so
-   * one nightly pass can't run unbounded work.
+   * Documents that still have staged (pending) candidates and a lost
+   * commit. Two sources: (1) a run-driven commit that never landed (the
+   * last run's enqueue failed, or its run was stuck 'running' and just got
+   * reaped); (2) an EXTERNAL submission (`POST …/candidates`, no job/retry)
+   * whose inline commit deferred/threw/died — these commonly target a doc
+   * already in status 'committed'. So reconcile any doc with pending
+   * candidates EXCEPT 'purged' (content erased — nothing to re-ground or
+   * commit). commitIfRunsSettled itself defers if any run is still open, so
+   * enqueuing is always safe. Bounded so one nightly pass can't run
+   * unbounded work.
    */
   async findDocsNeedingCommit(
     companyId: string,
@@ -168,7 +232,10 @@ export class CandidateStoreService {
       const out: string[] = [];
       for (const r of ((rows as any[]) ?? []) as any[]) {
         const docStatus = String(r.docStatus ?? '');
-        if (docStatus !== 'indexing' && docStatus !== 'indexed') continue;
+        // 'purged' facts have no source text left to commit against;
+        // everything else with pending candidates is a lost commit —
+        // including 'committed' docs an external submission re-staged.
+        if (docStatus === 'purged' || docStatus === '') continue;
         const docId = String(r.docId);
         if (seen.has(docId)) continue;
         seen.add(docId);

--- a/src/documents/document-async.service.ts
+++ b/src/documents/document-async.service.ts
@@ -5,6 +5,7 @@ import { GENERAL_INDEXER_ID } from '../indexers/candidate.types';
 import { DocumentStoreService, StoredDocument } from './document-store.service';
 import { IndexerDispatchService } from './indexer-dispatch.service';
 import { CandidateCommitService } from './candidate-commit.service';
+import { CandidateStoreService } from './candidate-store.service';
 import { IngestDocumentDto } from './dto/ingest-document.dto';
 
 export interface DocumentAsyncResponse {
@@ -41,6 +42,7 @@ export class DocumentAsyncService implements OnModuleInit {
     private readonly store: DocumentStoreService,
     private readonly dispatch: IndexerDispatchService,
     private readonly commit: CandidateCommitService,
+    private readonly candidates: CandidateStoreService,
     @Optional() private readonly workerLoop?: WorkerLoopService,
     @Optional() private readonly claim?: JobClaimService,
   ) {}
@@ -87,6 +89,17 @@ export class DocumentAsyncService implements OnModuleInit {
     await this.store.setStatus({ companyId, docId: doc.id, status: 'indexing' });
     const runs: DocumentAsyncResponse['runs'] = [];
     for (const spec of specs) {
+      // Pre-create the run ledger row as 'pending' BEFORE enqueuing, so
+      // countNonTerminalRuns sees this run from the outset. Otherwise the
+      // fastest pass (usually general) could finish and commit before a
+      // dedicated run's job has started and created its row — committing a
+      // partial set and losing the cross-indexer merge. The job's createRun
+      // transitions pending → running; a stuck pending row is reaped.
+      await this.candidates.ensureRunPending(companyId, {
+        docId: doc.id,
+        packId: spec.packId,
+        packVersion: spec.packVersion,
+      });
       // Version-aware dedupKey mirrors the indexer_run UNIQUE triple: a
       // re-POST of the same content collapses; a pack upgrade re-opens
       // the slot.

--- a/src/documents/external-candidates.service.ts
+++ b/src/documents/external-candidates.service.ts
@@ -83,6 +83,11 @@ export class ExternalCandidatesService {
       companyId,
       doc,
       dto,
+      // The RESOLVED installed version — not dto.packVersion, which the
+      // caller may omit. Keeps candidate/fact provenance in lockstep with
+      // the run ledger (which already uses binding.packVersion) instead of
+      // stamping the '0' fallback.
+      packVersion: binding.packVersion,
     });
 
     const run = await this.candidates.createRun(companyId, {
@@ -146,6 +151,7 @@ export class ExternalCandidatesService {
     companyId: string;
     doc: StoredDocument;
     dto: SubmitCandidatesDto;
+    packVersion: string;
   }): Promise<{
     batch: CandidateBatch;
     dropped: GroundingDrop[];
@@ -163,7 +169,7 @@ export class ExternalCandidatesService {
 
     const provenance = {
       indexerId: dto.indexerId,
-      packVersion: dto.packVersion ?? '0',
+      packVersion: p.packVersion,
       executionMode: 'external' as const,
       model: null,
     };

--- a/test/candidate-store-reliability.e2e-spec.ts
+++ b/test/candidate-store-reliability.e2e-spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Reliability of the async run ledger (audit wave F3), against a real
+ * SurrealDB:
+ *   BUG1 — a run pre-created 'pending' is counted by countNonTerminalRuns
+ *          from the outset (so a fast pass can't commit before a slower
+ *          run's row exists), and createRun transitions pending → running.
+ *   BUG4 — the pending/failed reopen is a compare-and-swap: the second
+ *          concurrent createRun on an already-running row does NOT re-open.
+ *   BUG2 — findDocsNeedingCommit re-drives a 'committed' document that
+ *          still has pending candidates (a lost external commit), not only
+ *          'indexing'/'indexed' ones.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { DocumentStoreService } from '../src/documents/document-store.service';
+import { CandidateStoreService } from '../src/documents/candidate-store.service';
+
+describe('candidate-store run-ledger reliability', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  let store: CandidateStoreService;
+
+  beforeAll(async () => {
+    process.env.DOCUMENT_INGEST_ENABLED = '1';
+    f = await createApp({ companyId: 'co_run_ledger_e2e' });
+    store = f.app.get(CandidateStoreService);
+  });
+
+  afterAll(async () => {
+    delete process.env.DOCUMENT_INGEST_ENABLED;
+    if (f) await f.close();
+  });
+
+  async function makeDoc(text: string): Promise<string> {
+    f.extractor.setScript({ entities: [], facts: [], edges: [] });
+    const r = await f.http.post('/v1/ingest/document').set(auth()).send({
+      kind: 'markdown',
+      text,
+      occurredAt: '2026-07-01T10:00:00.000Z',
+      contextRef: { vertical: 'ledger_e2e' },
+    });
+    expect(r.status).toBe(201);
+    return r.body.documentId as string;
+  }
+
+  it('pending pre-created run is counted, then createRun transitions it (BUG1)', async () => {
+    const docId = await makeDoc('Ledger doc for pending pre-creation.');
+
+    await store.ensureRunPending(f.companyId, {
+      docId,
+      packId: 'pack_a',
+      packVersion: 'v1',
+    });
+    // Counted before any job has started — the whole point of BUG1's fix.
+    expect(await store.countNonTerminalRuns(f.companyId, docId)).toBeGreaterThanOrEqual(1);
+
+    const first = await store.createRun(f.companyId, {
+      docId,
+      packId: 'pack_a',
+      packVersion: 'v1',
+    });
+    expect(first.created).toBe(true); // pending → running (CAS winner)
+    // Still non-terminal (now 'running'), so commit still defers.
+    expect(await store.countNonTerminalRuns(f.companyId, docId)).toBeGreaterThanOrEqual(1);
+
+    // A second createRun on the now-'running' row must NOT reopen it (BUG4).
+    const second = await store.createRun(f.companyId, {
+      docId,
+      packId: 'pack_a',
+      packVersion: 'v1',
+    });
+    expect(second.created).toBe(false);
+    expect(second.runId).toBe(first.runId);
+
+    await store.finalizeRun(f.companyId, { runId: first.runId, status: 'succeeded' });
+    expect(await store.countNonTerminalRuns(f.companyId, docId)).toBe(0);
+  });
+
+  it('findDocsNeedingCommit re-drives a committed doc with pending candidates (BUG2)', async () => {
+    const docId = await makeDoc('Ledger doc for external orphaned commit.');
+    const run = await store.createRun(f.companyId, {
+      docId,
+      packId: 'pack_ext',
+      packVersion: 'v1',
+    });
+    await store.finalizeRun(f.companyId, { runId: run.runId, status: 'succeeded' });
+
+    const surreal = f.app.get(SurrealService);
+    const docStore = f.app.get(DocumentStoreService);
+    // Seed a leftover pending candidate, then mark the doc 'committed' — the
+    // shape an external submission whose inline commit was lost leaves behind.
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `CREATE candidate SET
+           docId = type::record('source_document', $doc),
+           runId = type::record('indexer_run', $run),
+           chunkSeq = 0, kind = 'fact', status = 'pending',
+           payload = { predicate: 'name', object: 'Orphan' }`,
+        { doc: docId.split(':')[1], run: run.runId.split(':')[1] },
+      );
+    });
+    await docStore.setStatus({ companyId: f.companyId, docId, status: 'committed' });
+
+    const needing = await store.findDocsNeedingCommit(f.companyId);
+    // Before the fix this filtered to indexing/indexed only, so a committed
+    // doc's orphaned candidates were never re-driven → expired = memory loss.
+    expect(needing).toContain(docId);
+  });
+});

--- a/test/external-candidates.e2e-spec.ts
+++ b/test/external-candidates.e2e-spec.ts
@@ -126,6 +126,32 @@ describe('external candidates (e2e)', () => {
     expect(second.status).toBe(409);
   });
 
+  it('stamps the INSTALLED pack version on provenance when packVersion is omitted', async () => {
+    const docId = await createDoc(`${DOC_TEXT} Provenance variant.`);
+    const r = await f.http
+      .post(`/v1/documents/${encodeURIComponent(docId)}/candidates`)
+      .set(auth())
+      .send(submission()); // no packVersion in the body
+    expect(r.status).toBe(201);
+    // The response echoes the resolved installed version…
+    expect(r.body.packVersion).toBe('0.2.0');
+
+    // …and the PERSISTED candidate provenance must match it, not the '0'
+    // fallback the omitted-packVersion path used to stamp.
+    const { SurrealService } = await import('../src/db/surreal.service');
+    const surreal = f.app.get(SurrealService);
+    const versions = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ v: unknown }>]>(
+        `SELECT payload.packVersion AS v FROM candidate
+           WHERE docId = type::record('source_document', $doc) AND kind = 'fact'`,
+        { doc: docId.split(':')[1] },
+      );
+      return ((rows as Array<{ v: unknown }>) ?? []).map((x) => String(x.v));
+    });
+    expect(versions.length).toBeGreaterThan(0);
+    for (const v of versions) expect(v).toBe('0.2.0');
+  });
+
   it('rejects predicates outside the indexer namespace', async () => {
     const docId = await createDoc(`${DOC_TEXT} Namespace variant.`);
     const r = await f.http


### PR DESCRIPTION
Batch 3 of the functional-audit follow-up: async document-pipeline reliability (behind `DOCUMENT_MULTI_INDEXER_ENABLED`) + the external-indexer seam.

## BUG1 — premature commit lost the cross-indexer merge
`indexer_run` rows were created lazily inside each job's `createRun`; `ingestAsync` only enqueued. So the fastest pass (usually general) could finish and commit while a dedicated run's row **did not yet exist** — `countNonTerminalRuns` saw 0, didn't defer — committing a partial set. The second commit's duplicate facts share the same `originKey`, so they don't corroborate (0050): MAX-confidence + unified `source.indexers[]` lost. The tell: the count filter already referenced a `'pending'` status **nothing ever wrote**.
**Fix:** `ingestAsync` now pre-creates each run as `'pending'` (new `store.ensureRunPending`) before enqueuing, so the run is counted from the outset; the job's `createRun` transitions pending → running. This finally uses the vestigial status.

## BUG4 — non-atomic reopen
Two jobs for the same `(doc, pack, ver)` that don't collide on the job-claim dedupKey (e.g. `index_document` + `reindex_documents`) could both observe the reopenable row and both re-extract. The reopen is now a **compare-and-swap** on the observed status (`UPDATE … WHERE status = $observed RETURN AFTER`); only the winner gets `created:true`. (Review caught a self-inflicted bug: the multi-statement result's CAS verdict is slot 1, not slot 0 — the reliability test failed until fixed.)

## BUG2 — external candidates orphaned on a lost commit
`findDocsNeedingCommit` only reconciled `'indexing'`/`'indexed'` docs, but external submissions (`POST …/candidates`, no job/retry) commonly target an already-`'committed'` doc; a deferred/crashed inline commit left pending candidates nightly reconcile never re-drove → they expired = **silent memory loss**. Now reconciles any doc with pending candidates except `'purged'`.

## BUG3 — stale-pending reaping
`reapStaleRuns` now also reaps stale `'pending'` rows (a pre-created run whose job was never claimed). The hard-crash orphan window (job lease < stale window) is documented as a bounded-latency tradeoff — candidates persist, no data loss — rather than risking a false reopen of a legitimately slow run.

## BUG5 — external provenance drift
When the caller omitted `packVersion`, candidate/fact provenance stamped the `'0'` fallback while the run ledger used the resolved `binding.packVersion`. Now both use the installed version.

## Verification
`candidate-store-reliability` e2e (pending-counted + CAS + committed-doc reconcile); `external-candidates` e2e gains an omitted-packVersion provenance assertion. Full unit **1056** + doc-pipeline e2e (17) green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYm9x6dMncfHuRR9xseWHn