### PR TITLE
fix(observability): audit wave F4 — corroborate backlog, rerank metric, config catalogue, docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,6 +168,15 @@ SEARCH_PPR_ENABLED=0
 # mid-scale deploys: SEARCH_PPR_AUTO_THRESHOLD=100.
 SEARCH_PPR_AUTO_THRESHOLD=0
 
+# Edge expansion: graph-walk from the top seeds to pull in 1-hop neighbours.
+# This is the one optional retrieval stage that is default-ON. An expanded
+# neighbour inherits its seed's score × ALPHA (≤0.4 so it can never outrank
+# the seed). Set _ENABLED=0 to turn it off entirely.
+#SEARCH_EDGE_EXPANSION_ENABLED=1
+#SEARCH_EDGE_EXPANSION_TOP_SEEDS=3
+#SEARCH_EDGE_EXPANSION_MAX_NEIGHBOURS=5
+#SEARCH_EDGE_EXPANSION_ALPHA=0.4
+
 # ── Auth ─────────────────────────────────────────────────────────────────
 # For 0.1.0 walking-skeleton: ApiKey is a static map { keyHash → companyId,scope }
 # loaded from this env var as JSON. Will be replaced by inite-auth-service
@@ -256,6 +265,9 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 # Multiply by (1 + γ·min(corroborationCount, 3)) — independently confirmed
 # facts rank higher. 0 (default) = off.
 #SEARCH_CORROBORATION_GAMMA=0
+# Multiply by (1 + δ·authority) — write-time source authority enters ranking.
+# 0 (default) = off; completes the β/γ trust-ranking trio.
+#SEARCH_AUTHORITY_DELTA=0
 # Citation floor on write-time source reputation for synthesize (beside
 # SYNTHESIZE_MIN_CONFIDENCE). 0 (default) = off; unscored facts sit on the
 # neutral 0.5, so floors ≤ 0.5 only drop sources that EARNED distrust.
@@ -345,9 +357,16 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 #SEARCH_QUERY_EXPANSION_CONCURRENCY=4
 #SEARCH_QUERY_EXPANSION_CACHE=500
 #SEARCH_QUERY_EXPANSION_MODEL=gpt-4o-mini
+# Dreams — the nightly consolidation pass. DREAMS_ENABLED is the master
+# switch; the sub-ops below each gate one stage (all default off).
+#DREAMS_ENABLED=0
+#DREAMS_DEDUP_ENABLED=0
+#DREAMS_RESOLVE_ENABLED=0
+#DREAMS_LLM_SUMMARY_ENABLED=0
 # Dreams: fuzzy corroboration (cosine-close facts confirm each other) and
 # community summaries. Both cost LLM calls; bounded by the knobs shown.
-# MODEL defaults to OPENAI_CHAT_MODEL.
+# MODEL defaults to OPENAI_CHAT_MODEL. A run corroborates at most MAX_PAIRS
+# groups; a persistent backlog is warn-logged (groupBacklog > window).
 #DREAMS_CORROBORATE_ENABLED=0
 #DREAMS_CORROBORATE_MAX_PAIRS=20
 #DREAMS_CORROBORATE_COSINE_THRESHOLD=0.9
@@ -382,6 +401,20 @@ OTEL_ENABLED=0
 #             After flipping this, run POST /v1/admin/reindex/embeddings
 #             so historical rows move into the new vector space.
 EMBEDDER_PROVIDER=openai
+# Run bge-m3 inference on a worker thread (keeps the event loop responsive
+# under load). 0 (default) = in-thread.
+#BGE_M3_WORKER=0
+
+# ── Jobs / background workers ─────────────────────────────────────────────
+# Where background jobs run: 'enqueue' (default) drives a durable worker
+# loop with leases; 'inline' runs them in-process (single-pod / tests).
+#JOBS_QUEUE_MODE=enqueue
+# Run the queue worker loop in this process. 1 (default) = on; set 0 on a
+# web-only pod that should not claim jobs.
+#WORKER_LOOP_ENABLED=1
+# Synthesize guardrail mode when the caller doesn't pass one:
+# strict (default) | lenient | off.
+#SYNTHESIZE_DEFAULT_GUARDRAILS=strict
 
 # ── N-pass extraction (semantic entropy) ─────────────────────────────────
 # Number of stochastic re-rolls per extraction; 1 = legacy single-pass.

--- a/docs/abac.md
+++ b/docs/abac.md
@@ -83,7 +83,11 @@ by a policy — ABAC can only narrow further.
 2. **Row gate** — `makeRowPolicyFilter` (src/policy/row-filter.ts) applied on
    every read surface: search fusion + edge expansion + backfill,
    `graph_retrieve`, competing facts, entity profile/timeline/connections
-   (edges evaluate with `predicate = kind`), code-memory recall. The filter
+   (edges evaluate with `predicate = kind`), code-memory recall,
+   `memory_diff`, `detect_contradiction` (its opposing facts), and the
+   document candidates audit view. The persisted community summaries carry a
+   build-time PII/scope filter instead (one shared blob can't take per-caller
+   row rules). The filter
    reads the request's `PolicyContext` from AsyncLocalStorage (stamped by the
    guard) — no signature threading, MCP and REST share the path. Search legs
    already project `source`/`trustSnapshot`/`corroboration`, so evaluation
@@ -125,6 +129,7 @@ deleted-set races. Alert on the metric.
 | `brain_policy_eval_seconds` | per-request row-evaluation latency (histogram, buckets from 50 µs). |
 | `brain_policy_resolution_errors_total` | fail-closed events — non-zero pages an operator. |
 | `brain_policy_sets_active` | enabled sets across tenants (nightly gauge). |
+| `brain_policy_sets_truncated_total` | a key resolved to more than `MAX_SETS_PER_KEY` (8) sets and the overflow was dropped — **fails open** (a dropped set may be the deny set). Non-zero means a binding/claim needs pruning. |
 
 ## DB-level fence status (migration 0057)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,7 +53,7 @@ See [Document pipeline](document-pipeline.md) for the architecture.
 | Endpoint | Notes |
 |---|---|
 | `POST /v1/facts/:id/retract` | Mark a fact retracted with reason; survives in audit trail. |
-| `POST /v1/feedback` | Retrieval feedback: `helpful` / `not_helpful` / `incorrect` per fact. One standing vote per caller key (repeat replaces); `helpful`/`incorrect` feed the nightly source-trust refit. Also on MCP as `record_feedback`. |
+| `POST /v1/feedback` | Retrieval feedback: `helpful` / `not_helpful` / `incorrect` per fact. One standing vote per caller key (repeat replaces); `helpful`/`incorrect` feed the nightly source-trust refit. **Affects the SOURCE's trust for facts ingested AFTER the refit — it does not demote the flagged fact or the existing corpus** (ranking reads each fact's write-time trust snapshot). Also on MCP as `record_feedback`. |
 | `POST /v1/entities/:id/forget` | Hard GDPR cascade — facts + edges + embeddings deleted, HMAC tombstone retained. |
 | `POST /v1/users/:userId/forget` | GDPR erasure of one end-user's memory scope (migration 0055): personal facts (incl. those on shared entities), personal entities + edges + dedup refs, usage/feedback rows, audit mirror. |
 
@@ -76,6 +76,7 @@ See [Document pipeline](document-pipeline.md) for the architecture.
 | `POST /v1/admin/maintenance/dreams/run` | Async kick of dreams (returns runId). |
 | `POST /v1/admin/maintenance/calibration-refit` | Async kick of calibration + source-trust refit. |
 | `POST /v1/admin/maintenance/reindex` | Async re-embed `knowledge_fact`, optionally per tenant. |
+| `POST /v1/admin/maintenance/compaction` | Fire-and-forget kick of the compaction (+promotion) pass. |
 | `POST /v1/admin/maintenance/hnsw` | Per-tenant HNSW vector-index lifecycle: `{action: 'create' \| 'drop', tenant?}`. Synchronous. `create` refuses (`400`) when an index already exists at a different dimension — recover in order: drop → reindex embeddings → create. |
 | `GET /v1/admin/changefeed/state` | Consumer lag + per-(tenant, source) cursor table. |
 | `POST /v1/admin/changefeed/drain` | Manual drain of pending change events. |

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -576,6 +576,197 @@ export class ConfigInspectorService {
         runtimeMutable: false,
         isBooleanFlag: false,
       },
+      // ── ABAC (migrations 0056/0057) ──────────────────────────
+      {
+        key: 'ABAC_ENABLED',
+        category: 'auth',
+        defaultValue: '0',
+        runtimeMutable: false,
+        isBooleanFlag: true,
+        description:
+          'Master switch for attribute-based access control. Off = the policy resolver never runs; keys behave byte-identically to pre-ABAC.',
+      },
+      {
+        key: 'ABAC_FORCE_REPORT_ONLY',
+        category: 'auth',
+        defaultValue: '0',
+        runtimeMutable: false,
+        isBooleanFlag: true,
+        description:
+          'Emergency demote-all: every enforce set behaves report_only (logged, never blocks). Rollback lever for a bad policy.',
+      },
+      {
+        key: 'ABAC_DB_FENCE_ENABLED',
+        category: 'auth',
+        defaultValue: '0',
+        runtimeMutable: false,
+        isBooleanFlag: true,
+        description:
+          'DB-level PERMISSIONS PII fence (0057). Inert for the system-user pool — the app-layer JS filter is the enforcing gate.',
+      },
+      {
+        key: 'SOURCE_META_STRICT',
+        category: 'pipeline',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'On = ingest 400s on an invalid source.meta entry instead of dropping it (a silently-dropped data_class would widen access).',
+      },
+      {
+        key: 'POLICY_META_UNION_ENABLED',
+        category: 'auth',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Effective-meta union: a corroborated fact inherits its confirming documents’ meta for DENY evaluation (union = most restrictive).',
+      },
+      // ── Document pipeline (migrations 0048–0050) ─────────────
+      {
+        key: 'DOCUMENT_INGEST_ENABLED',
+        category: 'pipeline',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Master switch for POST /v1/ingest/document + the /v1/documents/* surface. Off = every route 503s.',
+      },
+      {
+        key: 'DOCUMENT_MULTI_INDEXER_ENABLED',
+        category: 'pipeline',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Dedicated per-pack indexer runs + relevance router + async fan-out. Off = only the generalist union pass runs.',
+      },
+      // ── Search: retrieval-evolution stages (migrations 0052–0055) ──
+      {
+        key: 'SEARCH_HNSW_ENABLED',
+        category: 'search',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Switch the KNN vector leg on. Tenants without a built index fall back to the full scan; build via POST /v1/admin/maintenance/hnsw.',
+      },
+      {
+        key: 'SEARCH_QUERY_EXPANSION_ENABLED',
+        category: 'search',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'LLM rewrites the query into N variants before search. Fails open to the raw query on error.',
+      },
+      {
+        key: 'SEARCH_USAGE_RECORDING_ENABLED',
+        category: 'search',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description: 'Record lastReadAt on retrieved facts (feeds recency decay).',
+      },
+      {
+        key: 'SEARCH_USAGE_DECAY_ENABLED',
+        category: 'search',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Count recency decay from lastReadAt, not only recordedAt (needs recording on for data).',
+      },
+      {
+        key: 'SEARCH_EDGE_EXPANSION_ENABLED',
+        category: 'search',
+        defaultValue: '1',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Graph-walk from top seeds to pull in 1-hop neighbours (default ON). Knobs: SEARCH_EDGE_EXPANSION_TOP_SEEDS/_MAX_NEIGHBOURS/_ALPHA.',
+      },
+      {
+        key: 'SEARCH_EDGE_EXPANSION_TOP_SEEDS',
+        category: 'search',
+        defaultValue: '3',
+        runtimeMutable: true,
+        isBooleanFlag: false,
+        description: 'How many top-ranked seeds edge-expansion walks from.',
+      },
+      {
+        key: 'SEARCH_EDGE_EXPANSION_MAX_NEIGHBOURS',
+        category: 'search',
+        defaultValue: '5',
+        runtimeMutable: true,
+        isBooleanFlag: false,
+        description: 'Max neighbours pulled per seed during edge-expansion.',
+      },
+      {
+        key: 'SEARCH_EDGE_EXPANSION_ALPHA',
+        category: 'search',
+        defaultValue: '0.4',
+        runtimeMutable: true,
+        isBooleanFlag: false,
+        description:
+          'Inherited-score multiplier for an expanded neighbour (≤0.4 so a neighbour can never outrank its seed).',
+      },
+      {
+        key: 'SEARCH_HYPE_ENABLED',
+        category: 'search',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Hypothetical-embedding (HyDE-style) alt-vector leg. Read side degrades cleanly when altEmbedding is absent.',
+      },
+      {
+        key: 'SEARCH_CROSS_ENCODER_LOCAL',
+        category: 'search',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Run the local cross-encoder reranker (no Cohere key). Note: opting in enables the stage even with SEARCH_CROSS_ENCODER_ENABLED=0.',
+      },
+      // ── Dreams: corroboration + communities ──────────────────
+      {
+        key: 'DREAMS_CORROBORATE_ENABLED',
+        category: 'dreams',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Fuzzy cross-source corroboration (cosine-close facts confirm each other). Bounded by DREAMS_CORROBORATE_MAX_PAIRS per run.',
+      },
+      {
+        key: 'DREAMS_COMMUNITIES_ENABLED',
+        category: 'dreams',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description: 'Build + persist entity-community summaries during dreams.',
+      },
+      // ── Compaction: promotion ────────────────────────────────
+      {
+        key: 'COMPACTION_PROMOTION_ENABLED',
+        category: 'compaction',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Promote old corroborated append_only fact groups into a durable summary. Bounded by COMPACTION_PROMOTION_MAX_GROUPS per run.',
+      },
+      // ── Jobs ─────────────────────────────────────────────────
+      {
+        key: 'JOBS_QUEUE_MODE',
+        category: 'jobs',
+        defaultValue: 'enqueue',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Where background jobs run: enqueue (durable worker loop, default) vs inline (in-process).',
+      },
     ];
   }
 }

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -121,6 +121,13 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   positiveInt(env, 'SEARCH_HNSW_EF', errors);
   positiveInt(env, 'SEARCH_HNSW_OVERFETCH', errors);
 
+  // ── Edge expansion (default-ON retrieval stage) ────────────────────
+  // Bad values silently fell back to defaults; the numeric knobs are now
+  // boot-validated like the rest of the search stack.
+  positiveInt(env, 'SEARCH_EDGE_EXPANSION_TOP_SEEDS', errors);
+  positiveInt(env, 'SEARCH_EDGE_EXPANSION_MAX_NEIGHBOURS', errors);
+  nonNegativeFloat(env, 'SEARCH_EDGE_EXPANSION_ALPHA', errors);
+
   // ── ABAC policy knobs ──────────────────────────────────────────────
 validateAbacEnv(env, errors);
 

--- a/src/db/schema.surql
+++ b/src/db/schema.surql
@@ -1,5 +1,15 @@
 -- INITE Brain Service — per-tenant database schema
 --
+-- ⚠️ REFERENCE ONLY — NOT the source of truth and NOT applied at runtime.
+-- The runtime schema is the ordered migrations in src/db/migrations/
+-- (0001…), tracked in `schema_migrations` (see src/db/migrator.service.ts).
+-- This file documents the CORE knowledge tables only; tables added by later
+-- migrations (procedural_memory, communities, domain/registry packs,
+-- source_trust/registry, source_document/indexer_run/candidate,
+-- retrieval_feedback, per-user scope, access_policy/policy_binding/
+-- policy_decision, the DB fence) are NOT reproduced here. Read the
+-- migrations for the authoritative shape.
+--
 -- Conformance: inite-ecosystem/core/services/brain.yaml + core/capabilities/knowledge.yaml
 -- Applied per tenant: NS=brain DB=co_<companyId>
 --

--- a/src/dreams/corroborate.service.ts
+++ b/src/dreams/corroborate.service.ts
@@ -54,7 +54,12 @@ export interface CorroborationApplied {
 }
 
 export interface CorroborateResult {
+  /** Candidate groups examined this run (≤ the window). */
   groupsConsidered: number;
+  /** Total eligible groups BEFORE the per-run window — the true backlog.
+   *  groupBacklog > groupsConsidered means the run left work on the table
+   *  (bounded by DREAMS_CORROBORATE_MAX_PAIRS); watch it trend down. */
+  groupBacklog: number;
   pairsConsidered: number;
   llmJudgements: number;
   corroborationsApplied: number;
@@ -138,6 +143,7 @@ export class DreamsCorroborateService {
   async run(db: Surreal): Promise<CorroborateResult> {
     const result: CorroborateResult = {
       groupsConsidered: 0,
+      groupBacklog: 0,
       pairsConsidered: 0,
       llmJudgements: 0,
       corroborationsApplied: 0,
@@ -146,10 +152,20 @@ export class DreamsCorroborateService {
     };
     if (!this.isEnabled()) return result;
 
-    const groups = await withSpan('dreams.corroborate.find_groups', () =>
-      this.findCandidateGroups(db),
+    const { groups, backlog } = await withSpan(
+      'dreams.corroborate.find_groups',
+      () => this.findCandidateGroups(db),
     );
     result.groupsConsidered = groups.length;
+    result.groupBacklog = backlog;
+    if (backlog > groups.length) {
+      // The window is bounded by maxPairs*2; anything past it waits for a
+      // later run. Surface the depth so a persistent backlog is visible
+      // instead of silently draining ~maxPairs/night.
+      this.logger.warn(
+        `[dreams.corroborate] ${backlog} eligible groups, only ${groups.length} in this run's window — backlog draining at ≤${this.maxPairs}/run`,
+      );
+    }
 
     for (const group of groups) {
       if (result.corroborationsApplied >= this.maxPairs) break;
@@ -192,10 +208,20 @@ export class DreamsCorroborateService {
     return result;
   }
 
-  /** (entityId, predicate) groups holding ≥2 active embedded facts. */
+  /**
+   * (entityId, predicate) groups holding ≥2 active embedded facts, in a
+   * DETERMINISTIC order (most-populated first, then a stable id tiebreak).
+   * Without an explicit order the window was arbitrary SurrealDB storage
+   * order, so which groups got corroborated each night was non-deterministic
+   * and a group could be starved indefinitely. Returns the windowed slice
+   * plus the true eligible backlog so the caller can surface the depth.
+   */
   private async findCandidateGroups(
     db: Surreal,
-  ): Promise<Array<{ entityId: unknown; predicate: string }>> {
+  ): Promise<{
+    groups: Array<{ entityId: unknown; predicate: string }>;
+    backlog: number;
+  }> {
     const [rows] = await db.query<
       [Array<{ entityId: unknown; predicate: string; n: number }>]
     >(
@@ -204,10 +230,18 @@ export class DreamsCorroborateService {
          AND userId IS NONE
        GROUP BY entityId, predicate`,
     );
-    return ((rows as Array<{ entityId: unknown; predicate: string; n: number }>) ?? [])
+    const eligible = (
+      (rows as Array<{ entityId: unknown; predicate: string; n: number }>) ?? []
+    )
       .filter((g) => g.n >= 2 && g.n <= MAX_GROUP_SIZE)
       .filter((g) => policyFor(g.predicate).semantics === 'bitemporal')
-      .slice(0, this.maxPairs * 2);
+      .sort((a, b) => {
+        if (b.n !== a.n) return b.n - a.n; // most-conflicted first
+        const ka = `${String(a.entityId)} ${a.predicate}`;
+        const kb = `${String(b.entityId)} ${b.predicate}`;
+        return ka < kb ? -1 : ka > kb ? 1 : 0; // stable tiebreak
+      });
+    return { groups: eligible.slice(0, this.maxPairs * 2), backlog: eligible.length };
   }
 
   private async fetchGroupMembers(

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -40,7 +40,7 @@ export interface MemoryQualitySnapshot {
  *   - ingest_facts_total{outcome}             — INSERTED|SUPERSEDED|COMPETING|REJECTED
  *   - ingest_mentions_total{result}           — extracted|skipped|failed
  *   - search_duration_seconds                 — histogram, buckets tuned for ~ms-to-1s
- *   - search_rerank_total{outcome}            — invoked|skipped_disabled|skipped_singleton|skipped_margin
+ *   - search_rerank_total{outcome}            — invoked|error|skipped_disabled|skipped_singleton|skipped_margin
  *   - search_cross_encoder_total{outcome}     — invoked|error|skipped_disabled|skipped_singleton
  *   - synthesize_total{outcome}               — ok|no_results|no_grounded_evidence|verifier_partial|verifier_failed|generator_error|verifier_error
  *   - multi_hop_total{outcome}                — ok|single_hop|chain_empty|no_results|planner_error|hop_error
@@ -399,6 +399,7 @@ export class MetricsService implements OnModuleInit {
   countRerank(
     outcome:
       | 'invoked'
+      | 'error'
       | 'skipped_disabled'
       | 'skipped_singleton'
       | 'skipped_margin',

--- a/src/search/search-rerank.service.ts
+++ b/src/search/search-rerank.service.ts
@@ -210,6 +210,12 @@ export class SearchRerankService {
       : undefined;
 
     const identityPerm = rerankInputs.map((_, i) => i);
+    // Distinguish a budget-timeout fallback (returns identityPerm) from the
+    // reranker genuinely returning an unchanged order — mirroring the
+    // cross-encoder path. The old code inferred the outcome from an
+    // identity permutation, mislabelling BOTH a legitimate no-op rerank AND
+    // a timeout as 'skipped_disabled', so rerank timeouts were invisible.
+    let timedOut = false;
     const permutation = await withSpan(
       'search.rerank',
       () =>
@@ -219,11 +225,13 @@ export class SearchRerankService {
           fn: () => this.reranker.rerank(ctx.dto.query, rerankInputs, hints),
           fallback: identityPerm,
           logger: this.logger,
+          onFallback: () => {
+            timedOut = true;
+          },
         }),
       { 'rerank.candidates': rerankInputs.length },
     );
-    const isIdentity = permutation.every((idx, i) => idx === i);
-    this.metrics?.countRerank(isIdentity ? 'skipped_disabled' : 'invoked');
+    this.metrics?.countRerank(timedOut ? 'error' : 'invoked');
     return permutation.map((i) => candidatesForRerank[i]);
   }
 }

--- a/test/dreams-corroborate.unit-spec.ts
+++ b/test/dreams-corroborate.unit-spec.ts
@@ -199,4 +199,19 @@ describe('DreamsCorroborateService', () => {
     } as never);
     expect(out.groupsConsidered).toBe(0);
   });
+
+  it('windows the group set and reports the true backlog', async () => {
+    const { svc, db } = makeService();
+    // 45 eligible groups > the 40-wide window (maxPairs*2). Members share an
+    // origin so nothing corroborates — we only assert the windowing counts.
+    const groups = Array.from({ length: 45 }, (_, i) => ({
+      entityId: `knowledge_entity:e${i}`,
+      predicate: 'claim_probe',
+    }));
+    const a = fact({ originKey: 'doc:same' });
+    const b = fact({ originKey: 'doc:same', recordedAt: '2026-06-02T00:00:00Z' });
+    const out = await svc.run(db(groups, [a, b]) as never);
+    expect(out.groupsConsidered).toBe(40); // window
+    expect(out.groupBacklog).toBe(45); // true eligible depth surfaced
+  });
 });


### PR DESCRIPTION
Batch 4 (final) of the functional-audit follow-up: observability + documentation tail.

## Code
- **Dreams corroboration** — `findCandidateGroups` had **no ORDER BY**, so the per-run 40-group window was arbitrary SurrealDB storage order (a group could be starved indefinitely), and the true backlog was invisible (`groupsConsidered` was set to the *post-slice* length). Now ordered deterministically (most-populated first, stable id tiebreak); the eligible-group backlog is surfaced (new `CorroborateResult.groupBacklog` + a warn when it exceeds the window).
- **Search rerank metric** — the LLM-rerank outcome was inferred from an identity permutation, so a budget-timeout **and** a legitimate no-op rerank both counted as `skipped_disabled` — timeouts were invisible. Now uses an explicit `onFallback` flag → `'error'` vs `'invoked'` (mirrors the cross-encoder path already fixed this way); adds the `'error'` label to `countRerank`.
- **Config inspector** — the `/admin/config` catalogue was missing ~20 shipped flags (ABAC_*, SOURCE_META_STRICT, POLICY_META_UNION, DOCUMENT_INGEST/MULTI_INDEXER, SEARCH_HNSW/QUERY_EXPANSION/USAGE_*/EDGE_EXPANSION/HYPE/CROSS_ENCODER_LOCAL, DREAMS_CORROBORATE/COMMUNITIES, COMPACTION_PROMOTION, JOBS_QUEUE_MODE). Added; defaults verified against the reading code.
- **Edge expansion** (the one default-ON optional retrieval stage) had no operator docs and no boot validation — added its knobs to `.env.example` + the catalogue, and boot-validated the numeric ones (were silent fallbacks on a bad value).

## Docs
- `.env.example`: pre-#145 tail — `DREAMS_ENABLED` family, `SEARCH_AUTHORITY_DELTA` (the broken β/γ/δ trio), `JOBS_QUEUE_MODE`, `WORKER_LOOP_ENABLED`, `BGE_M3_WORKER`, `SYNTHESIZE_DEFAULT_GUARDRAILS`.
- `abac.md`: `brain_policy_sets_truncated_total` metric + the `memory_diff`/`detect_contradiction`/candidates/communities row-gate surfaces.
- `api.md`: document `maintenance/compaction`; clarify feedback demotes only **future** facts (write-time snapshot, not the flagged fact).
- `schema.surql`: reference-only-not-runtime disclaimer.

## Verification
corroborate unit spec gains a window/backlog case. Full unit **1057** + corroborate e2e green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYm9x6dMncfHuRR9xseWHn