### PR TITLE
feat(observability): self-hosted monitoring stack (VM + Loki + Tempo + Alloy + Grafana)

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -11,6 +11,9 @@ on:
       - 'docs/**'
       - '*.md'
       - '.planning/**'
+      # The monitoring stack has its own deploy workflow
+      # (deploy-monitoring.yml) — don't redeploy brain for it.
+      - 'monitoring/**'
   workflow_dispatch:
     inputs:
       action:

--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -1,0 +1,120 @@
+name: Deploy monitoring
+
+# Self-hosted observability stack (VictoriaMetrics + Loki + Tempo +
+# Alloy + Grafana) — see monitoring/README.md. Runs on the droplet's
+# own runner, same pattern as deploy-brain.yml: no SSH, just rsync the
+# checked-out monitoring/ dir into the stack path and compose up.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'monitoring/**'
+      - '.github/workflows/deploy-monitoring.yml'
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'deploy | restart | logs'
+        required: false
+        default: 'deploy'
+
+concurrency:
+  group: deploy-monitoring
+  cancel-in-progress: true
+
+env:
+  STACK_DIR: /opt/projects/inite-monitoring
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, sfo]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Logs
+        if: github.event.inputs.action == 'logs'
+        run: |
+          cd "$STACK_DIR"
+          docker-compose logs --tail=200
+
+      - name: Restart
+        if: github.event.inputs.action == 'restart'
+        run: |
+          cd "$STACK_DIR"
+          docker-compose restart
+
+      - name: Preflight — host memory headroom
+        if: github.event.inputs.action != 'logs' && github.event.inputs.action != 'restart'
+        run: |
+          free -m
+          avail=$(free -m | awk '/^Mem:/{print $7}')
+          if [ "$avail" -lt 1200 ]; then
+            echo "::warning::Only ${avail}MB RAM available — the monitoring stack is capped at 1GB; watch for OOM pressure"
+          fi
+          docker stats --no-stream --format 'table {{.Name}}\t{{.MemUsage}}' | head -20 || true
+          docker ps --format 'table {{.Names}}\t{{.Image}}' || true
+
+      - name: Sync stack config
+        if: github.event.inputs.action != 'logs' && github.event.inputs.action != 'restart'
+        run: |
+          mkdir -p "$STACK_DIR"
+          rsync -a --delete --exclude '.env' monitoring/ "$STACK_DIR"/
+
+      - name: Write .env (secrets → compose)
+        if: github.event.inputs.action != 'logs' && github.event.inputs.action != 'restart'
+        env:
+          GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          if [ -z "$GRAFANA_ADMIN_PASSWORD" ]; then
+            echo "::error::GRAFANA_ADMIN_PASSWORD secret is not set"
+            exit 1
+          fi
+          umask 077
+          {
+            printf 'GRAFANA_ADMIN_PASSWORD=%s\n' "$GRAFANA_ADMIN_PASSWORD"
+            printf 'TELEGRAM_BOT_TOKEN=%s\n' "$TELEGRAM_BOT_TOKEN"
+            printf 'TELEGRAM_CHAT_ID=%s\n' "$TELEGRAM_CHAT_ID"
+          } > "$STACK_DIR/.env"
+          # Telegram contact point is provisioned only when both secrets
+          # exist — an empty $-expansion would brick the contact point.
+          if [ -n "$TELEGRAM_BOT_TOKEN" ] && [ -n "$TELEGRAM_CHAT_ID" ]; then
+            cp "$STACK_DIR/grafana/alerting-optional/telegram.yaml" \
+               "$STACK_DIR/grafana/provisioning/alerting/telegram.yaml"
+            echo "[ok] telegram alerting provisioned"
+          else
+            echo "[info] TELEGRAM_* secrets unset — alerts visible in Grafana UI only"
+          fi
+
+      - name: Deploy
+        if: github.event.inputs.action != 'logs' && github.event.inputs.action != 'restart'
+        run: |
+          cd "$STACK_DIR"
+          docker-compose pull
+          docker-compose up -d --remove-orphans
+
+      - name: Health probe
+        if: github.event.inputs.action != 'logs' && github.event.inputs.action != 'restart'
+        run: |
+          cd "$STACK_DIR"
+          # VM has no shell (scratch image) — probe it through grafana's
+          # busybox wget over the shared monitoring network. Grafana's
+          # public URL is probed from the host through Traefik.
+          for i in $(seq 1 12); do
+            ok=1
+            docker-compose exec -T grafana wget -qO- http://localhost:3000/api/health >/dev/null 2>&1 || ok=0
+            docker-compose exec -T grafana wget -qO- http://victoriametrics:8428/health >/dev/null 2>&1 || ok=0
+            curl -fsS https://brain.inite.ai/grafana/api/health >/dev/null 2>&1 || ok=0
+            if [ "$ok" = 1 ]; then
+              echo "[ok] grafana + victoriametrics healthy, public route live"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::monitoring stack failed health probe"
+          docker-compose ps
+          docker-compose logs --tail=50
+          exit 1

--- a/monitoring/.env.example
+++ b/monitoring/.env.example
@@ -1,0 +1,6 @@
+# Written on the droplet by deploy-monitoring.yml from repo secrets —
+# never commit real values. This file documents the expected keys.
+GRAFANA_ADMIN_PASSWORD=change-me
+# Optional — enables the Telegram alert contact point when BOTH are set:
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,55 @@
+# inite-monitoring — self-hosted observability stack
+
+Runs on the inite-temporal droplet next to the brain, deployed by
+[`deploy-monitoring.yml`](../.github/workflows/deploy-monitoring.yml)
+(self-hosted runner; rsync to `/opt/projects/inite-monitoring` +
+`docker-compose up -d`). Total memory ceiling ≈ 1 GB across five
+containers.
+
+| signal | store | retention | collector |
+|---|---|---|---|
+| metrics (brain `/metrics` + host) | VictoriaMetrics | 30d | Alloy scrape, 15s/30s |
+| logs (allowlisted containers) | Loki | 14d | Alloy ← docker socket |
+| traces (OTel) | Tempo | 7d | Alloy OTLP/HTTP :4318 → gRPC |
+
+## Access
+
+Grafana: **https://brain.inite.ai/grafana** — user `admin`, password in
+the `GRAFANA_ADMIN_PASSWORD` repo secret. The "Brain Overview" dashboard
+and all datasources (VictoriaMetrics / Loki / Tempo) are provisioned
+from this directory; edits made in the UI are not persisted — change the
+files here instead.
+
+VictoriaMetrics, Loki, Tempo and Alloy are **not** exposed publicly and
+never should be (Alloy holds the docker socket — root-equivalent).
+
+## Alerts
+
+Rules live in `grafana/provisioning/alerting/rules.yaml` and always
+evaluate (visible under Alerting in the UI). Notifications are wired to
+Telegram **only when** the `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`
+repo secrets are set — the workflow then copies
+`grafana/alerting-optional/telegram.yaml` into the provisioning dir.
+
+To enable Telegram: create a bot via @BotFather, get your chat id (e.g.
+message the bot, then `curl https://api.telegram.org/bot<token>/getUpdates`),
+set both secrets, re-run the deploy-monitoring workflow.
+
+Gotcha: provisioned contact points persist in Grafana's DB even after
+the provisioning file is removed — unsetting the secrets stops updates
+but doesn't delete the contact point (ship a `deleteContactPoints`
+reset entry if that ever matters).
+
+## Adding a container to log collection
+
+Logs are allowlisted by container-name substring in
+`alloy/config.alloy` (`discovery.docker` filter). Add the name there —
+temporal-stack chatter is deliberately excluded.
+
+## Local sanity check
+
+```bash
+cd monitoring
+GRAFANA_ADMIN_PASSWORD=dev docker-compose config -q   # validate compose
+docker run --rm -v $PWD/alloy:/cfg grafana/alloy:v1.9.2 fmt /cfg/config.alloy
+```

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -1,0 +1,120 @@
+// Grafana Alloy — single collector for the inite-monitoring stack.
+//
+// Four pipelines:
+//   1. scrape brain's prom-client /metrics  → VictoriaMetrics
+//   2. embedded node exporter (host CPU/mem/disk/net) → VictoriaMetrics
+//   3. docker logs (allowlisted containers) → Loki
+//   4. OTLP in from brain (HTTP :4318)      → Tempo (gRPC)
+
+// ── 1. Metrics: brain app ────────────────────────────────────────────
+// brain joins traefik-global, so its service name resolves from here.
+// /health and /metrics hits are already excluded from brain's request
+// logs, so a 15s scrape adds no log noise.
+prometheus.scrape "brain" {
+	targets = [{
+		__address__ = "inite-brain-service:3000",
+		job         = "brain",
+	}]
+	metrics_path    = "/metrics"
+	scrape_interval = "15s"
+	forward_to      = [prometheus.remote_write.vm.receiver]
+}
+
+// ── 2. Metrics: host (embedded node exporter) ────────────────────────
+prometheus.exporter.unix "host" {
+	rootfs_path = "/rootfs"
+	procfs_path = "/host/proc"
+	sysfs_path  = "/host/sys"
+
+	set_collectors = ["cpu", "meminfo", "filesystem", "diskstats", "netdev", "loadavg"]
+
+	filesystem {
+		fs_types_exclude = "^(tmpfs|overlay|squashfs|autofs|proc|sysfs)$"
+	}
+}
+
+prometheus.scrape "host" {
+	targets         = prometheus.exporter.unix.host.targets
+	job_name        = "node"
+	scrape_interval = "30s"
+	forward_to      = [prometheus.remote_write.vm.receiver]
+}
+
+prometheus.remote_write "vm" {
+	endpoint {
+		url = "http://victoriametrics:8428/api/v1/write"
+	}
+}
+
+// ── 3. Logs: docker, allowlist only ──────────────────────────────────
+// The name filter is a substring match at the Docker API, so
+// "inite-monitoring-" covers this whole stack. Temporal-stack chatter
+// (temporal server, elastic, postgres) deliberately never enters Loki.
+// Brain's JSON log lines are parsed at query time (`| json`), not at
+// ingest — mixed NestJS plain-text lines would otherwise generate
+// parse-error noise, and label-per-level would churn streams.
+discovery.docker "ours" {
+	host = "unix:///var/run/docker.sock"
+
+	filter {
+		name   = "name"
+		values = ["inite-brain-service", "inite-brain-landing", "inite-monitoring-"]
+	}
+}
+
+discovery.relabel "ours" {
+	targets = discovery.docker.ours.targets
+
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "container"
+	}
+}
+
+loki.source.docker "logs" {
+	host       = "unix:///var/run/docker.sock"
+	targets    = discovery.relabel.ours.output
+	labels     = {job = "docker"}
+	forward_to = [loki.write.loki.receiver]
+}
+
+loki.write "loki" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}
+
+// ── 4. Traces: OTLP in → Tempo ───────────────────────────────────────
+// brain's exporter is OTLP/HTTP (@opentelemetry/exporter-trace-otlp-http)
+// pointed at http://inite-monitoring-alloy:4318. Alloy forwards over
+// gRPC because otelcol.exporter.otlp is gRPC-only; Tempo listens on 4317.
+otelcol.receiver.otlp "brain" {
+	http {
+		endpoint = "0.0.0.0:4318"
+	}
+
+	grpc {
+		endpoint = "0.0.0.0:4317"
+	}
+
+	output {
+		traces = [otelcol.processor.batch.default.input]
+	}
+}
+
+otelcol.processor.batch "default" {
+	output {
+		traces = [otelcol.exporter.otlp.tempo.input]
+	}
+}
+
+otelcol.exporter.otlp "tempo" {
+	client {
+		endpoint = "tempo:4317"
+
+		tls {
+			insecure = true
+		}
+	}
+}

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,156 @@
+# Self-hosted observability stack for the inite-temporal droplet.
+# Deployed by .github/workflows/deploy-monitoring.yml (rsync to
+# /opt/projects/inite-monitoring + docker-compose up -d).
+#
+# Data flow:
+#   brain /metrics ── scrape ─────▶ alloy ── remote_write ─▶ victoriametrics ─┐
+#   host /proc /sys ─ unix exporter (inside alloy) ────────▶ victoriametrics ─┤
+#   docker logs (allowlisted containers) ─▶ alloy ─ push ──▶ loki ────────────┼─▶ grafana
+#   brain OTLP/HTTP :4318 ────────▶ alloy ── OTLP/gRPC ────▶ tempo ───────────┘
+#
+# Only alloy and grafana join the shared traefik-global network: alloy has
+# to reach inite-brain-service (scrape) and be reachable from it (OTLP);
+# grafana is routed by Traefik at brain.inite.ai/grafana. VictoriaMetrics,
+# Loki and Tempo stay on the private `monitoring` network — invisible to
+# other stacks and to the internet.
+#
+# All containers carry the inite-monitoring- prefix to avoid name
+# collisions with whatever the temporal stack runs.
+
+services:
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:v1.115.0
+    container_name: inite-monitoring-vm
+    restart: unless-stopped
+    command:
+      - -storageDataPath=/storage
+      - -retentionPeriod=30d
+      - -httpListenAddr=:8428
+    volumes:
+      - vm-data:/storage
+    expose:
+      - "8428"
+    mem_limit: 192m
+    networks:
+      - monitoring
+
+  loki:
+    image: grafana/loki:3.5.1
+    container_name: inite-monitoring-loki
+    restart: unless-stopped
+    command: ["-config.file=/etc/loki/loki.yaml"]
+    environment:
+      # Keep Go's GC inside the cgroup ceiling — without this the runtime
+      # sizes its heap off host RAM and the kernel OOM-kills the container
+      # at the compose mem_limit instead of GC backing off.
+      - GOMEMLIMIT=200MiB
+    volumes:
+      - ./loki/loki.yaml:/etc/loki/loki.yaml:ro
+      - loki-data:/loki
+    expose:
+      - "3100"
+    mem_limit: 256m
+    networks:
+      - monitoring
+
+  tempo:
+    image: grafana/tempo:2.7.2
+    container_name: inite-monitoring-tempo
+    restart: unless-stopped
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    environment:
+      - GOMEMLIMIT=120MiB
+    volumes:
+      - ./tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo-data:/var/tempo
+    expose:
+      - "4317" # OTLP gRPC in (from alloy)
+      - "3200" # query API (grafana datasource)
+    mem_limit: 160m
+    networks:
+      - monitoring
+
+  alloy:
+    image: grafana/alloy:v1.9.2
+    container_name: inite-monitoring-alloy
+    restart: unless-stopped
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - alloy-data:/var/lib/alloy/data
+      # Log discovery + tailing. Read-only, but still root-equivalent on
+      # the host — never expose alloy's HTTP port through Traefik.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Host filesystem views for the embedded node exporter.
+      - /:/rootfs:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+    expose:
+      - "4318" # OTLP HTTP in (from brain over traefik-global)
+    mem_limit: 200m
+    networks:
+      - monitoring
+      - traefik-global
+
+  grafana:
+    image: grafana/grafana:11.6.3
+    container_name: inite-monitoring-grafana
+    restart: unless-stopped
+    environment:
+      # Served under a sub-path behind Traefik. Both vars are required;
+      # Traefik must NOT StripPrefix or /grafana/login redirect-loops.
+      - GF_SERVER_ROOT_URL=https://brain.inite.ai/grafana
+      - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_AUTH_ANONYMOUS_ENABLED=false
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      # Consumed by $-expansion in provisioning/alerting/telegram.yaml —
+      # the file is only present when the deploy workflow found both
+      # secrets, so empty values never reach a provisioned contact point.
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
+      - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID:-}
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    expose:
+      - "3000"
+    mem_limit: 192m
+    networks:
+      - monitoring
+      - traefik-global
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik-global"
+      - "traefik.http.routers.inite-monitoring-grafana.rule=Host(`brain.inite.ai`) && PathPrefix(`/grafana`)"
+      - "traefik.http.routers.inite-monitoring-grafana.priority=200"
+      - "traefik.http.routers.inite-monitoring-grafana.entrypoints=websecure"
+      - "traefik.http.routers.inite-monitoring-grafana.tls=true"
+      - "traefik.http.routers.inite-monitoring-grafana.tls.certresolver=letsencrypt"
+      - "traefik.http.services.inite-monitoring-grafana.loadbalancer.server.port=3000"
+      # Own http→https middleware, not brain's redirect-to-https: a
+      # middleware defined on another container vanishes when that
+      # container is down, silently breaking this router with it.
+      - "traefik.http.routers.inite-monitoring-grafana-http.rule=Host(`brain.inite.ai`) && PathPrefix(`/grafana`)"
+      - "traefik.http.routers.inite-monitoring-grafana-http.priority=200"
+      - "traefik.http.routers.inite-monitoring-grafana-http.entrypoints=web"
+      - "traefik.http.routers.inite-monitoring-grafana-http.middlewares=mon-redirect-https"
+      - "traefik.http.middlewares.mon-redirect-https.redirectscheme.scheme=https"
+      - "traefik.http.middlewares.mon-redirect-https.redirectscheme.permanent=true"
+
+volumes:
+  vm-data:
+  loki-data:
+  tempo-data:
+  alloy-data:
+  grafana-data:
+
+networks:
+  monitoring:
+  traefik-global:
+    external: true

--- a/monitoring/grafana/alerting-optional/telegram.yaml
+++ b/monitoring/grafana/alerting-optional/telegram.yaml
@@ -1,0 +1,31 @@
+# Telegram contact point + root notification policy.
+#
+# NOT provisioned by default: the deploy workflow copies this file into
+# grafana/provisioning/alerting/ ONLY when both TELEGRAM_BOT_TOKEN and
+# TELEGRAM_CHAT_ID repo secrets are set (empty $-expansions would brick
+# the contact point). Without it, alert rules still evaluate — state is
+# visible in the Alerting UI, notifications go to the built-in
+# grafana-default-email no-op.
+#
+# Note: provisioned contact points persist in Grafana's DB even after
+# this file is removed; to truly delete one, ship a deleteContactPoints
+# reset entry.
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: telegram
+    receivers:
+      - uid: telegram-ops
+        type: telegram
+        settings:
+          bottoken: $TELEGRAM_BOT_TOKEN
+          chatid: "$TELEGRAM_CHAT_ID"
+
+policies:
+  - orgId: 1
+    receiver: telegram
+    group_by: [alertname]
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h

--- a/monitoring/grafana/dashboards/brain-overview.json
+++ b/monitoring/grafana/dashboards/brain-overview.json
@@ -1,0 +1,1800 @@
+{
+  "uid": "brain-overview",
+  "title": "Brain Overview",
+  "tags": [
+    "brain"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Traffic",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP requests by status (req/s)",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum by (status) (rate({container=\"inite-brain-service\"} | json | kind=`request` [5m]))",
+          "legendFormat": "{{status}}",
+          "queryType": "range"
+        }
+      ],
+      "id": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP latency p95 (ms)",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "quantile_over_time(0.95, {container=\"inite-brain-service\"} | json | kind=`request` | unwrap durationMs [5m])",
+          "legendFormat": "p95",
+          "queryType": "range"
+        }
+      ],
+      "id": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Search rate (req/s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "rate(brain_search_duration_seconds_count[5m])",
+          "legendFormat": "searches"
+        }
+      ],
+      "id": 4,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Search latency quantiles (s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(brain_search_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(brain_search_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(brain_search_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99"
+        }
+      ],
+      "id": 5,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Synthesize outcomes (/s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum by (outcome) (rate(brain_synthesize_total[5m]))",
+          "legendFormat": "{{outcome}}"
+        }
+      ],
+      "id": 6,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Ingest facts by outcome (/s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum by (outcome) (rate(brain_ingest_facts_total[5m]))",
+          "legendFormat": "{{outcome}}"
+        }
+      ],
+      "id": 7,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Ingest mentions by result (/s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum by (result) (rate(brain_ingest_mentions_total[5m]))",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "id": 8,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      }
+    },
+    {
+      "id": 9,
+      "type": "row",
+      "title": "LLM cost",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "OpenAI tokens/min by type",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum by (type) (rate(brain_openai_tokens_total[5m])) * 60",
+          "legendFormat": "{{type}}"
+        }
+      ],
+      "id": 10,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "OpenAI latency p95 by kind (s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, kind) (rate(brain_openai_call_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{kind}}"
+        }
+      ],
+      "id": 11,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Tokens last 24h",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(increase(brain_openai_tokens_total[24h]))",
+          "instant": true
+        }
+      ],
+      "id": 12,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 34
+      }
+    },
+    {
+      "type": "stat",
+      "title": "OpenAI error ratio (15m)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.15
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(rate(brain_openai_calls_total{outcome!=\"ok\"}[15m])) / clamp_min(sum(rate(brain_openai_calls_total[15m])), 1e-9)",
+          "instant": true
+        }
+      ],
+      "id": 13,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 34
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "OpenAI calls by kind/outcome (/s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum by (kind, outcome) (rate(brain_openai_calls_total[5m]))",
+          "legendFormat": "{{kind}}/{{outcome}}"
+        }
+      ],
+      "id": 14,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 34
+      }
+    },
+    {
+      "id": 15,
+      "type": "row",
+      "title": "Jobs",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Job throughput by type/outcome (/s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum by (jobType, outcome) (rate(brain_job_total[5m]))",
+          "legendFormat": "{{jobType}}/{{outcome}}"
+        }
+      ],
+      "id": 16,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Job duration p95 by type (s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, jobType) (rate(brain_job_duration_seconds_bucket[15m])))",
+          "legendFormat": "{{jobType}}"
+        }
+      ],
+      "id": 17,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Worker leader",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(brain_worker_is_leader) or vector(0)",
+          "instant": true
+        }
+      ],
+      "id": 18,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 51
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Changefeed lag (records)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "brain_changefeed_lag_records",
+          "legendFormat": "lag"
+        }
+      ],
+      "id": 19,
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 51
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Dreams artefacts emitted by kind (/h)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum by (kind) (increase(brain_dreams_emitted_total[1h]))",
+          "legendFormat": "{{kind}}"
+        }
+      ],
+      "id": 20,
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 51
+      }
+    },
+    {
+      "id": 21,
+      "type": "row",
+      "title": "Memory health",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Facts by status (nightly snapshot)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum by (status) (brain_memory_facts)",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "id": 22,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 60
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Stale active facts (nightly snapshot)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum by (older_than_days) (brain_memory_stale_active_facts)",
+          "legendFormat": ">{{older_than_days}}d"
+        }
+      ],
+      "id": 23,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 60
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Fact trust bands (nightly snapshot)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum by (band) (brain_memory_fact_trust)",
+          "legendFormat": "{{band}}"
+        }
+      ],
+      "id": 24,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 68
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Orphan entities",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 100
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "brain_memory_orphan_entities",
+          "instant": true
+        }
+      ],
+      "id": 25,
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 8,
+        "y": 68
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Policy sets active",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "brain_policy_sets_active",
+          "instant": true
+        }
+      ],
+      "id": 26,
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 12,
+        "y": 68
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Policy resolution errors (1h)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "increase(brain_policy_resolution_errors_total[1h])",
+          "instant": true
+        }
+      ],
+      "id": 27,
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 16,
+        "y": 68
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Facts compacted (24h)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "increase(brain_compaction_facts_total[24h])",
+          "instant": true
+        }
+      ],
+      "id": 28,
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 68
+      }
+    },
+    {
+      "id": 29,
+      "type": "row",
+      "title": "Host & process",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Host CPU / RAM used (%)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "max": 100,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])))",
+          "legendFormat": "cpu"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+          "legendFormat": "ram"
+        }
+      ],
+      "id": 30,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 77
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Disk free (/)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "green",
+                "value": 0.25
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "min(node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"})",
+          "instant": true
+        }
+      ],
+      "id": 31,
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 8,
+        "y": 77
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Brain RSS",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "brain_process_resident_memory_bytes",
+          "legendFormat": "rss"
+        }
+      ],
+      "id": 32,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 77
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Brain event-loop lag p99 (s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "brain_nodejs_eventloop_lag_p99_seconds",
+          "legendFormat": "p99"
+        }
+      ],
+      "id": 33,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 77
+      }
+    },
+    {
+      "type": "logs",
+      "title": "Brain warnings & errors",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "prettifyLogMessage": false,
+        "showLabels": false,
+        "showCommonLabels": false
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{container=\"inite-brain-service\"} |~ `(?i)(error|warn)`",
+          "queryType": "range"
+        }
+      ],
+      "id": 34,
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 85
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/alerting/rules.yaml
+++ b/monitoring/grafana/provisioning/alerting/rules.yaml
@@ -1,0 +1,240 @@
+# Grafana-managed alert rules. Always provisioned; where notifications
+# land depends on whether telegram.yaml was deployed alongside (see
+# grafana/alerting-optional/ and the deploy workflow) — without it the
+# rules still evaluate and show state in the Alerting UI.
+#
+# Pattern per rule: refId A = PromQL against VictoriaMetrics (uid vm),
+# refId C = threshold expression. Comparisons live in the threshold, not
+# in the PromQL — `expr == 0` returns an EMPTY set on healthy, which
+# Grafana reads as NoData, not OK.
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: brain
+    folder: Brain
+    interval: 1m
+    rules:
+      - uid: brain-scrape-down
+        title: BrainScrapeDown
+        condition: C
+        for: 3m
+        noDataState: Alerting # series gone = collector or brain gone
+        execErrState: Alerting
+        labels:
+          severity: critical
+        annotations:
+          summary: brain /metrics scrape is failing (target down or unreachable)
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              expr: up{job="brain"}
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+
+      - uid: brain-policy-resolution-errors
+        title: PolicyResolutionErrors
+        condition: C
+        for: 0s
+        noDataState: OK
+        execErrState: Alerting
+        labels:
+          severity: critical
+        annotations:
+          summary: a key referenced an unknown policy set (failed closed — some key is bricked)
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              expr: increase(brain_policy_resolution_errors_total[10m])
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
+      - uid: brain-no-worker-leader
+        title: NoWorkerLeader
+        condition: C
+        for: 10m
+        noDataState: OK # scrape-down alert covers series absence
+        execErrState: Alerting
+        labels:
+          severity: critical
+        annotations:
+          summary: no pod holds the worker_loop lease — background jobs (dreams/compaction/sweeper) are not running
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              expr: sum(brain_worker_is_leader) or vector(0)
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+
+      - uid: brain-job-failure-ratio
+        title: JobFailureRatioHigh
+        condition: C
+        for: 15m
+        noDataState: OK
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: '>20% of background jobs failed over the last 15m'
+        data:
+          - refId: A
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              expr: sum(increase(brain_job_total{outcome="failed"}[15m])) / clamp_min(sum(increase(brain_job_total[15m])), 1)
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0.2] }
+
+      - uid: brain-changefeed-lag
+        title: ChangefeedLagSustained
+        condition: C
+        for: 15m
+        noDataState: OK
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: CHANGEFEED consumer is falling behind (audit_event ingestion lag)
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              expr: max(brain_changefeed_lag_records)
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [500] }
+
+      - uid: brain-openai-error-ratio
+        title: OpenAIErrorRatioHigh
+        condition: C
+        for: 10m
+        noDataState: OK
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: '>15% of OpenAI calls errored over the last 15m (upstream flaky or key/quota trouble)'
+        data:
+          - refId: A
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              expr: sum(increase(brain_openai_calls_total{outcome!="ok"}[15m])) / clamp_min(sum(increase(brain_openai_calls_total[15m])), 1)
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0.15] }
+
+      - uid: host-disk-low
+        title: HostDiskLow
+        condition: C
+        for: 10m
+        noDataState: Alerting # losing disk visibility is itself a page
+        execErrState: Alerting
+        labels:
+          severity: critical
+        annotations:
+          summary: droplet root filesystem has <10% free space
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              expr: min(node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"})
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [0.10] }
+
+      - uid: host-mem-low
+        title: HostMemLow
+        condition: C
+        for: 10m
+        noDataState: OK
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: droplet has <8% RAM available
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [0.08] }

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yaml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: brain
+    orgId: 1
+    folder: Brain
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasources.yaml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,39 @@
+# Provisioned datasources. VictoriaMetrics is exposed as a plain
+# Prometheus datasource (PromQL-compatible; no VM plugin to install —
+# "Save & test" may warn about missing buildinfo, queries work fine).
+apiVersion: 1
+
+datasources:
+  - name: VictoriaMetrics
+    uid: vm
+    type: prometheus
+    url: http://victoriametrics:8428
+    access: proxy
+    isDefault: true
+    jsonData:
+      timeInterval: 15s
+
+  - name: Loki
+    uid: loki
+    type: loki
+    url: http://loki:3100
+    access: proxy
+
+  - name: Tempo
+    uid: tempo
+    type: tempo
+    url: http://tempo:3200
+    access: proxy
+    jsonData:
+      # Jump from a span to the container's logs in the span's time
+      # window. Brain log lines don't carry traceId yet, so this is
+      # time+container correlation only — flip filterByTraceID on once
+      # request-logger.ts starts emitting traceId.
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: "-5m"
+        spanEndTimeShift: "5m"
+        tags:
+          - key: container
+            value: container
+        filterByTraceID: false

--- a/monitoring/loki/loki.yaml
+++ b/monitoring/loki/loki.yaml
@@ -1,0 +1,46 @@
+# Loki 3.x single-binary, filesystem storage, 14d retention.
+#
+# 3.x gotchas encoded here:
+#   - schema must be tsdb + v13 (older stores refuse to boot on 3.x)
+#   - retention_enabled requires compactor.delete_request_store,
+#     otherwise Loki exits at startup
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+
+schema_config:
+  configs:
+    - from: "2026-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 336h # 14d
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  retention_delete_delay: 2h
+  delete_request_store: filesystem
+
+analytics:
+  reporting_enabled: false

--- a/monitoring/tempo/tempo.yaml
+++ b/monitoring/tempo/tempo.yaml
@@ -1,0 +1,32 @@
+# Tempo 2.x single-binary, local storage, 7d retention.
+# OTLP gRPC in from alloy on :4317; Grafana queries the HTTP API on :3200.
+# metrics_generator deliberately omitted (~100MB RSS saved; service
+# graphs not needed at this scale).
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+
+ingester:
+  max_block_duration: 10m
+
+compactor:
+  compaction:
+    block_retention: 168h # 7d
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/blocks
+    wal:
+      path: /var/tempo/wal
+
+usage_report:
+  reporting_enabled: false


### PR DESCRIPTION
## Why

Telemetry audit (2026-07-11) found the observability story operationally dead: nothing scrapes `/metrics`, `OTEL_ENABLED=1` exports traces to a nonexistent collector, logs have no retention/search, and no alert can reach an operator — including the documented "operator page" signals like `brain_policy_resolution_errors_total`.

## What

Self-hosted stack as a separate compose project (`/opt/projects/inite-monitoring`), deployed by the new **deploy-monitoring** workflow on the droplet's runner:

| container | role | retention | mem |
|---|---|---|---|
| `inite-monitoring-alloy` | scrape brain + node exporter + docker logs + OTLP in | — | 200m |
| `inite-monitoring-vm` | VictoriaMetrics (metrics) | 30d | 192m |
| `inite-monitoring-loki` | Loki 3.x (logs, tsdb/v13) | 14d | 256m |
| `inite-monitoring-tempo` | Tempo (traces, local) | 7d | 160m |
| `inite-monitoring-grafana` | UI + provisioned dashboard/alerts | — | 192m |

- Grafana served at **https://brain.inite.ai/grafana** (sub-path; own Traefik router at priority 200, own https-redirect middleware). VM/Loki/Tempo/Alloy stay on the private network.
- "Brain Overview" dashboard: traffic (incl. LogQL over the JSON request log), LLM cost, jobs (worker-leader stat), memory health, host.
- 8 provisioned alert rules (scrape down, policy resolution errors, no worker leader, job failure ratio, changefeed lag, OpenAI error ratio, disk/mem low). Telegram contact point is deployed **only** when `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` secrets exist.
- Log collection is an **allowlist** (`inite-brain-service`, `inite-brain-landing`, `inite-monitoring-*`) — temporal-stack chatter never enters Loki.
- `deploy-brain.yml` gets `monitoring/**` in paths-ignore (monitoring has its own workflow).

## Verified

Booted the full stack locally: all 5 containers healthy; datasources, dashboard and all 8 alert rules provision cleanly; node metrics flow Alloy→VM; docker logs flow into Loki via the allowlist; `alloy fmt` + `docker compose config` pass.

## Before merge

Requires the `GRAFANA_ADMIN_PASSWORD` repo secret (deploy fails fast without it). Follow-up PR closes public `/metrics` and points brain's OTLP at Alloy once this stack is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)