### PR TITLE
fix(jobs): version-agnostic lease/claim deadlines — unblock background jobs in prod

### DIFF
--- a/src/jobs/job-claim.service.ts
+++ b/src/jobs/job-claim.service.ts
@@ -188,12 +188,18 @@ export class JobClaimService {
   }): Promise<JobClaim | null> {
     if (!this.surreal) return null;
     try {
+      // JS-computed deadline + type::datetime: parses on SurrealDB 2.x
+      // and 3.x alike, unlike the duration::from_* function path (see
+      // LeaderLeaseService.tryAcquire).
+      const until = new Date(
+        Date.now() + input.ttlSeconds * 1000,
+      ).toISOString();
       return await retryOnUniqueViolation(() =>
         this.surreal!.withCompany(input.companyId, async (db) => {
           const claimed = await runTransaction<unknown>(db, (tx) => {
             tx.bind('jobType', input.jobType)
               .bind('me', this.workerId)
-              .bind('ttl', input.ttlSeconds)
+              .bind('until', until)
               .add(
                 `LET $row = (SELECT * FROM job_run
                               WHERE jobType = $jobType
@@ -209,7 +215,7 @@ export class JobClaimService {
                        SET status = 'running',
                            claimedBy = $me,
                            claimedAt = time::now(),
-                           leaseUntil = time::now() + duration::from_secs($ttl),
+                           leaseUntil = type::datetime($until),
                            heartbeatAt = time::now(),
                            attempts = ($row.attempts OR 0) + 1
                      WHERE status = 'pending'
@@ -261,14 +267,16 @@ export class JobClaimService {
       return await this.surreal.withCompany(input.companyId, async (db) => {
         const [rows] = (await db.query<any[]>(
           `UPDATE type::record($rid) SET
-              leaseUntil = time::now() + duration::from_secs($ttl),
+              leaseUntil = type::datetime($until),
               heartbeatAt = time::now()
             WHERE claimedBy = $me AND status = 'running'
             RETURN cancelRequested`,
           {
             rid: input.recordId,
             me: this.workerId,
-            ttl: input.ttlSeconds,
+            until: new Date(
+              Date.now() + input.ttlSeconds * 1000,
+            ).toISOString(),
           },
         )) as any[];
         const arr = (rows ?? []) as Array<{ cancelRequested?: boolean }>;

--- a/src/jobs/leader-lease.service.ts
+++ b/src/jobs/leader-lease.service.ts
@@ -37,12 +37,17 @@ export class LeaderLeaseService {
   async tryAcquire(name: string, ttlSeconds = 90): Promise<boolean> {
     if (!this.surreal) return true; // dev / unit tests — single process
     try {
+      // Deadline computed in JS and bound as an ISO string: the
+      // duration::from_* / duration::from::* function paths differ
+      // between SurrealDB 2.x and 3.x (prod hit a parse error on the
+      // 3.x spelling), while type::datetime($iso) parses on both.
+      const until = new Date(Date.now() + ttlSeconds * 1000).toISOString();
       return await retryOnUniqueViolation(() =>
         this.surreal!.withAdminDb(async (db) => {
           const out = await runTransaction<unknown>(db, (tx) => {
             tx.bind('name', name)
               .bind('me', this.leaderId)
-              .bind('ttl', ttlSeconds)
+              .bind('until', until)
               .add(
                 `LET $row = (SELECT * FROM leader_lease WHERE name = $name LIMIT 1)[0]`,
               )
@@ -51,7 +56,7 @@ export class LeaderLeaseService {
                    UPSERT type::record('leader_lease', $name) CONTENT {
                      name: $name,
                      leaderId: $me,
-                     leaseUntil: time::now() + duration::from_secs($ttl),
+                     leaseUntil: type::datetime($until),
                      heartbeatAt: time::now(),
                      acquiredAt: $row.acquiredAt OR time::now()
                    };

--- a/src/metrics/memory-quality.service.ts
+++ b/src/metrics/memory-quality.service.ts
@@ -95,10 +95,13 @@ export class MemoryQualityService {
 
       const staleActiveFacts: Record<number, number> = {};
       for (const days of STALE_BUCKETS_DAYS) {
+        // Cutoff computed in JS + type::datetime — parses on SurrealDB
+        // 2.x and 3.x alike; both duration::from spellings are
+        // version-specific parse errors on the other line.
         staleActiveFacts[days] = await this.countWhere(
           db,
-          `status = 'active' AND recordedAt < time::now() - duration::from_days($days)`,
-          { days },
+          `status = 'active' AND recordedAt < type::datetime($cutoff)`,
+          { cutoff: new Date(Date.now() - days * 86_400_000).toISOString() },
         );
       }
 

--- a/test/memory-quality.unit-spec.ts
+++ b/test/memory-quality.unit-spec.ts
@@ -20,8 +20,10 @@ const tenantDb = {
         ],
       ];
     }
-    if (sql.includes('duration::from_days')) {
-      const days = params?.days as number;
+    if (sql.includes('recordedAt < type::datetime($cutoff)')) {
+      const days = Math.round(
+        (Date.now() - Date.parse(params?.cutoff as string)) / 86_400_000,
+      );
       return [[{ n: days === 30 ? 6 : days === 90 ? 4 : 1 }]];
     }
     if (sql.includes('< 0.4')) return [[{ n: 2 }]];


### PR DESCRIPTION
## Live prod bug

Every `LeaderLeaseService.tryAcquire` in prod fails (seen in today's container logs, repeating every 10s for `worker_loop` and `lease_manager_cron`):

```
Parse error: Invalid function/constant path, did you maybe mean `duration::from::secs`
 7 | leaseUntil: time::now() + duration::from_secs($ttl),
```

The prod SurrealDB rejects the **3.x** `duration::from_secs` spelling and suggests the **2.x** `duration::from::secs` one — the exact mirror of wave A (#154), where 3.1.5 rejected the 2.x spelling. Whichever server generation you run, one of the two spellings is a parse error.

**Consequence: background jobs have never run in prod** — `worker_loop` never acquires its lease (`brain_worker_is_leader` = 0), so dreams / compaction / candidate-sweeper / calibration-refit never execute. `claimNext`/`renew` carry the same idiom and would fail immediately after.

⚠️ It also means the prod server does not look like 3.1.5 (local dev + CI pin `surrealdb/surrealdb:v3.1.5`). The monitoring PR's preflight (`docker ps`) will show the actual prod image — the version question needs an explicit follow-up either way.

## Fix

Compute deadlines/cutoffs in JS, bind ISO strings, cast with `type::datetime($iso)` — parses on both generations and is already the codebase's prod-proven idiom (job enqueue `visibleAfter`, admin `since`/`before` filters):

- `leader-lease.service.ts` — `tryAcquire` UPSERT
- `job-claim.service.ts` — `claimNext` + `renew`
- `memory-quality.service.ts` — stale-bucket cutoffs (wave A's `duration::from_days` would hit the same parse error tonight at 03:35 UTC on the prod server)

Deliberately **not** here: `candidate-sweeper`/`candidate-store` `duration::from_*` sites (same class of bug, but those files are under active work on another branch — same two-line `type::datetime` treatment applies) and `fn::reap_zombies` (migration 0038 stored fn — blocked on the server-version question).

## Verified

- unit: 34/34 across job-claim / worker-loop / memory-quality / admin-leases suites
- real e2e (testcontainers, SurrealDB **3.1.5**): 9/9 `jobs.real` incl. lease acquire, lease contention, zombie reap
- 2.x side: `type::datetime($iso)` is the same construct already executing in prod today (enqueue path writes `visibleAfter` with it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)