### PR TITLE
fix(deploy): stop routing /metrics publicly + point OTLP at the monitoring collector

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -292,11 +292,13 @@ jobs:
                 # OpenTelemetry GenAI SemConv. When enabled, every
                 # gen_ai.chat.* and gen_ai.embed.* span carries the
                 # standard semconv attributes (gen_ai.system,
-                # gen_ai.request.model, gen_ai.usage.*). OTLP endpoint
-                # defaults to OTEL_EXPORTER_OTLP_ENDPOINT — set the
-                # standard env var alongside this flag when wiring up
-                # a backend (Langfuse, Phoenix, Tempo, …).
+                # gen_ai.request.model, gen_ai.usage.*).
                 - OTEL_ENABLED=1
+                # OTLP/HTTP receiver in the monitoring stack's Alloy
+                # (shared traefik-global network; deploy-monitoring.yml).
+                # BASE url only — the SDK exporter appends /v1/traces.
+                # Alloy forwards to Tempo; browse in Grafana Explore.
+                - OTEL_EXPORTER_OTLP_ENDPOINT=http://inite-monitoring-alloy:4318
                 # ── Multilingual embedder (Phase 4.D) ───────────────────
                 # BGE-M3 via @xenova/transformers, local CPU inference.
                 # 1024-dim multilingual cross-lingual recall vs OpenAI's
@@ -359,7 +361,7 @@ jobs:
                 # router naturally outranks the landing's Host-only catch-all.
                 - "traefik.enable=true"
                 - "traefik.docker.network=traefik-global"
-                - "traefik.http.routers.${{ env.PROJECT_NAME }}.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || PathPrefix(\`/metrics\`) || Path(\`/openapi.json\`))"
+                - "traefik.http.routers.${{ env.PROJECT_NAME }}.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || Path(\`/openapi.json\`))"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}.priority=200"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}.entrypoints=websecure"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}.tls=true"
@@ -367,7 +369,7 @@ jobs:
                 - "traefik.http.services.${{ env.PROJECT_NAME }}.loadbalancer.server.port=${{ env.PORT }}"
                 - "traefik.http.services.${{ env.PROJECT_NAME }}.loadbalancer.responseForwarding.flushInterval=-1"
                 # http→https redirect for the same backend paths (landing has its own).
-                - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || PathPrefix(\`/metrics\`) || Path(\`/openapi.json\`))"
+                - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || Path(\`/openapi.json\`))"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.priority=200"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.entrypoints=web"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.middlewares=redirect-to-https"

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -129,13 +129,31 @@ re-run the workflow on a previous commit.
 
 ## Observability
 
-OpenTelemetry traces emit per-leg search spans. Push to a collector by
-setting `OTEL_EXPORTER_OTLP_ENDPOINT` in the workflow env block (not set
-by default — wire when collector exists in inite infra).
+The self-hosted monitoring stack (VictoriaMetrics + Loki + Tempo +
+Alloy + Grafana) runs as its own compose project on the same droplet —
+see [`monitoring/README.md`](../monitoring/README.md) and
+`deploy-monitoring.yml`. Grafana lives at
+**https://brain.inite.ai/grafana** (admin password in the
+`GRAFANA_ADMIN_PASSWORD` repo secret).
 
-Prometheus metrics live at `/metrics` (in-process Prom-client). Traefik
-isn't routing this externally — scrape via `http://inite-brain-service:3000/metrics`
-from inside the docker network.
+- **Metrics**: Alloy scrapes `http://inite-brain-service:3000/metrics`
+  every 15s over the shared docker network and remote-writes into
+  VictoriaMetrics (30d). `/metrics` is intentionally NOT in the public
+  Traefik rule — requests to `brain.inite.ai/metrics` fall through to
+  the landing catch-all. Keep it that way: the endpoint is
+  unauthenticated by design and leaks volumes/token-spend if exposed.
+- **Traces**: `OTEL_ENABLED=1` + `OTEL_EXPORTER_OTLP_ENDPOINT=
+  http://inite-monitoring-alloy:4318` (base URL; the exporter appends
+  `/v1/traces`). Alloy forwards to Tempo (7d). Per-leg search spans,
+  gen_ai.* semconv spans and jobs.enqueue/process spans land there —
+  browse via Grafana Explore → Tempo.
+- **Logs**: Alloy tails the docker json logs of allowlisted containers
+  into Loki (14d) — query `{container="inite-brain-service"} | json`
+  in Grafana Explore.
+- **Alerts**: provisioned Grafana rules (scrape down, no worker
+  leader, policy resolution errors, job failure ratio, disk/mem low…);
+  Telegram notifications activate when the `TELEGRAM_BOT_TOKEN` +
+  `TELEGRAM_CHAT_ID` secrets are set.
 
 ## Surface-level invariants the deploy depends on
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -67,7 +67,12 @@ boot validation, graceful shutdown, test commands.
 | `DOMAIN_PACK_TRUSTED_KEYS` | unset | Pack-install trust store: JSON object mapping `publisher` → ed25519 PEM public key. Malformed JSON fails boot (env validation) — a typo would silently empty the store and every signed pack would fail as "unknown publisher". |
 | `DOMAIN_PACK_REQUIRE_SIGNATURE` | `0` | When `1`/`true`, `POST /v1/admin/packs` rejects unsigned manifests. Values outside `1/0/true/false` fail boot — an unrecognized value would silently disable enforcement. |
 | `PACK_REGISTRY_REQUIRE_SIGNATURE` | `0` | Same policy for `POST /v1/admin/registry/packs` (publish into the global catalogue). Same strict value set. |
-| `OTEL_ENABLED` | `0` | Enable OpenTelemetry tracing. When `1`, exports OTLP/HTTP traces with auto-instrumentation for `http` (so OpenAI + JWKS calls show up) + `express` (Nest). The pipeline emits explicit child spans under `search`: `vector_leg`, `lexical_leg`, `route`, `ppr`, `fetch_neighbours`, `rerank` — each annotated with candidate counts. Plus Phase K3 queue handoff spans: `jobs.enqueue` (PRODUCER) + `jobs.process <jobType>` (CONSUMER, linked via traceparent on the row). Bring-your-own backend via `OTEL_EXPORTER_OTLP_ENDPOINT`. Service name defaults to `inite-brain-service`; override via `OTEL_SERVICE_NAME`. No-op when off — zero cost. |
+| `OTEL_ENABLED` | `0` | Enable OpenTelemetry tracing. When `1`, exports OTLP/HTTP traces with auto-instrumentation for `http` (so OpenAI + JWKS calls show up) + `express` (Nest). The pipeline emits explicit child spans under `search`: `vector_leg`, `lexical_leg`, `route`, `ppr`, `fetch_neighbours`, `rerank` — each annotated with candidate counts. Plus Phase K3 queue handoff spans: `jobs.enqueue` (PRODUCER) + `jobs.process <jobType>` (CONSUMER, linked via traceparent on the row). Bring-your-own backend via `OTEL_EXPORTER_OTLP_ENDPOINT` (base URL, no path — the exporter appends `/v1/traces`; prod points it at the monitoring stack's Alloy, see `monitoring/README.md`). Service name defaults to `inite-brain-service`; override via `OTEL_SERVICE_NAME`. No-op when off — zero cost. |
+
+Prod observability (metrics scrape, log shipping, trace storage,
+Grafana dashboards + alert rules) is the `monitoring/` compose stack on
+the droplet — entry point [`monitoring/README.md`](../monitoring/README.md),
+Grafana at `https://brain.inite.ai/grafana`.
 
 ## Job queue (Phase J/K) — env vars
 


### PR DESCRIPTION
## Security: public unauthenticated /metrics

`https://brain.inite.ai/metrics` currently answers **200 to anonymous callers** with the full prom-client dump (uptime, ingest/search volumes, OpenAI token spend, node runtime internals). The Traefik router rule includes `PathPrefix(/metrics)` while `MetricsController` is deliberately unauthenticated — its own doc-comment says to firewall it instead — and `docs/DEPLOY.md` claimed Traefik wasn't routing it externally. Not found by the 07-08/07-11 audits; new finding from today's telemetry review.

## Changes

- **Remove `/metrics` from both Traefik router rules** (https + http-redirect). Requests to `brain.inite.ai/metrics` now fall through to the landing catch-all (priority 100). The monitoring stack's Alloy keeps scraping `inite-brain-service:3000/metrics` container-internally — no app change needed, matching the controller's intended pattern.
- **`OTEL_EXPORTER_OTLP_ENDPOINT=http://inite-monitoring-alloy:4318`** next to the existing `OTEL_ENABLED=1`. Until now spans exported to a nonexistent `localhost:4318` — instrumented but dropped. Base URL only; the OTLP/HTTP exporter appends `/v1/traces`. Alloy forwards to Tempo (7d retention), browsable in Grafana Explore.
- **Docs**: rewrite the stale `DEPLOY.md` Observability section (it described the pre-monitoring world and contradicted the actual routing); point `operations.md` at `monitoring/README.md`.

## Merge order

⚠️ **After #165 is merged and its deploy is green** — the OTLP endpoint references the Alloy container by name over `traefik-global`. (Mis-ordering is harmless — DNS-failure instead of connection-refused, both silently dropped — but the clean order gives an immediate 'traces appear' verification.)

## Verify after deploy

- `curl -s -o /dev/null -w '%{http_code}' https://brain.inite.ai/metrics` → landing 404/200 HTML, **not** metrics text
- `curl https://brain.inite.ai/health` → still 200 (backend routing intact)
- Grafana Explore → Tempo: traces for `inite-brain-service` appear on first traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)