### PR TITLE
fix(jobs): point-read the lease record — end the leader_lease conflict storm

### DIFF
--- a/src/jobs/leader-lease.service.ts
+++ b/src/jobs/leader-lease.service.ts
@@ -48,8 +48,15 @@ export class LeaderLeaseService {
             tx.bind('name', name)
               .bind('me', this.leaderId)
               .bind('until', until)
+              // Point-read on the record id (id IS the lease name — see
+              // migration 0029), NOT a `WHERE name = $name` table scan.
+              // Under SSI a scan puts the WHOLE table in the read-set, so
+              // any two concurrent acquires — even for different lease
+              // names (worker_loop every 30s vs lease_manager_cron every
+              // 10s) — mutually abort with read-write conflicts. Prod sat
+              // in a permanent conflict storm until this was narrowed.
               .add(
-                `LET $row = (SELECT * FROM leader_lease WHERE name = $name LIMIT 1)[0]`,
+                `LET $row = (SELECT * FROM type::record('leader_lease', $name))[0]`,
               )
               .add(
                 `IF $row IS NONE OR $row.leaseUntil < time::now() OR $row.leaderId = $me {
@@ -85,8 +92,11 @@ export class LeaderLeaseService {
     if (!this.surreal) return;
     try {
       await this.surreal.withAdminDb(async (db) => {
+        // Point-delete on the record id for the same reason tryAcquire
+        // point-reads: a WHERE-name scan drags the whole table into the
+        // transaction's read-set and aborts concurrent acquires.
         await db.query(
-          `DELETE FROM leader_lease WHERE name = $name AND leaderId = $me`,
+          `DELETE type::record('leader_lease', $name) WHERE leaderId = $me`,
           { name, me: this.leaderId },
         );
       });


### PR DESCRIPTION
Follow-up to #166 — second (and final) layer of the dead-background-jobs prod bug.

## What prod showed after #166 deployed

The parse error is gone; now every `tryAcquire` fails with:

```
The query was not executed due to a failed transaction: read or write conflict; this transaction can be retried
```

…through all 7 retry attempts, for both `worker_loop` and `lease_manager_cron`, indefinitely.

## Cause

The acquire transaction reads the lease with `SELECT * FROM leader_lease WHERE name = $name LIMIT 1` — a **table scan**. Under SSI the scan drags the whole table into the read-set, so two concurrent acquires **for different lease names** mutually abort. Prod runs two steady acquire loops (worker loop every 30s; the zombie-reaper cron every 10s), whose retry windows interleave into a permanent conflict storm.

## Fix

Point-read / point-delete on the record id — the id IS the lease name; migration 0029's header documents exactly this `leader_lease:[name]` pattern, the runtime code had drifted from it. Read-set = one key → cross-name conflicts vanish. Genuine same-name races (two pods after one lease) still conflict and resolve via the existing retry/backoff + the ELSE back-off path.

## Verified

- `jobs.real` e2e (testcontainers, SurrealDB 3.1.5): 9/9 incl. lease acquire + contention
- unit: worker-loop + admin-leases suites green
- post-merge: watch prod logs for `Acquired worker_loop lease — starting poll loops` and `brain_worker_is_leader` = 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)