### PR TITLE
fix(jobs): single-arg type::record in lease SQL — 2-arg form is a cast on SurrealDB 2.x

### DIFF
--- a/src/jobs/leader-lease.service.ts
+++ b/src/jobs/leader-lease.service.ts
@@ -55,12 +55,20 @@ export class LeaderLeaseService {
               // names (worker_loop every 30s vs lease_manager_cron every
               // 10s) — mutually abort with read-write conflicts. Prod sat
               // in a permanent conflict storm until this was narrowed.
+              //
+              // SINGLE-arg type::record('table:id') deliberately: the
+              // 2-arg form means "construct id" on SurrealDB 3.x but
+              // "cast arg1 into record<arg2>" on 2.x, where it fails at
+              // eval time ("cannot convert 'leader_lease' into a
+              // record<worker_loop>"). The string-compose form parses
+              // and constructs on both generations; lease names are
+              // code-controlled [a-z_]+ so no id-escaping concerns.
               .add(
-                `LET $row = (SELECT * FROM type::record('leader_lease', $name))[0]`,
+                `LET $row = (SELECT * FROM type::record('leader_lease:' + $name))[0]`,
               )
               .add(
                 `IF $row IS NONE OR $row.leaseUntil < time::now() OR $row.leaderId = $me {
-                   UPSERT type::record('leader_lease', $name) CONTENT {
+                   UPSERT type::record('leader_lease:' + $name) CONTENT {
                      name: $name,
                      leaderId: $me,
                      leaseUntil: type::datetime($until),
@@ -95,8 +103,9 @@ export class LeaderLeaseService {
         // Point-delete on the record id for the same reason tryAcquire
         // point-reads: a WHERE-name scan drags the whole table into the
         // transaction's read-set and aborts concurrent acquires.
+        // Single-arg type::record — see tryAcquire for why.
         await db.query(
-          `DELETE type::record('leader_lease', $name) WHERE leaderId = $me`,
+          `DELETE type::record('leader_lease:' + $name) WHERE leaderId = $me`,
           { name, me: this.leaderId },
         );
       });


### PR DESCRIPTION
Layer 3 of the dead-background-jobs prod bug (after #166 parse error → #169 conflict storm). Prod now fails with:

```
Expected a record<worker_loop> but cannot convert 'leader_lease' into a record<worker_loop>
```

## Cause

`type::record(a, b)` means **construct** record id `a:b` on SurrealDB **3.x**, but **cast `a` into `record<b>`** on **2.x** — and prod's shared `inite-surrealdb` is running **v2.3.10** (confirmed by the monitoring preflight's `docker ps`), not the 3.1.5 that dev/CI pin. The 2-arg call sat unreachable in the UPSERT until #166/#169 cleared the parse error and the conflict storm in front of it.

## Fix

Single-arg string-compose constructor: `type::record('leader_lease:' + $name)` — identical semantics on both server generations. Lease names are code-controlled `[a-z_]+`.

## Verified

- **Empirically on both versions**: ran the exact acquire/re-acquire/release transaction against local `surrealdb/surrealdb:v2.3.10` and `v3.1.5` containers — acquire returns `true`, same-holder re-acquire `true`, point-delete cleans up.
- Unit suites (19) + `jobs.real` e2e (3.1.5 testcontainers, 9/9) pass.

## ⚠️ Bigger picture (follow-up, not this PR)

The 2-arg `type::record(table, tail)` idiom is used widely across runtime code (documents, artifacts, ingest, candidates…) — all of it evaluates-and-fails on the 2.3.10 server prod currently runs. The strategic resolution is the prod SurrealDB version decision (upgrade back to 3.1.5), not a codebase-wide rewrite; this PR only unblocks the leader lease, which must work on whatever server is live today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)