### PR TITLE
fix(db): shape-aware transaction return slot — 2.x answers without BEGIN/COMMIT slots

### DIFF
--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -748,16 +748,28 @@ export async function runTransaction<T>(
     throw enrichTransactionError(err);
   }
   const arr = result as unknown[];
-  // SurrealDB 3.x emits one result slot per top-level statement INCLUDING the
-  // trailing `COMMIT TRANSACTION` (always null). 2.x did not surface a COMMIT
-  // slot, so the old code took `arr[length-1]` (then the RETURN). On 3.x that
-  // index is the COMMIT null, which silently turned every transactional
-  // upsert's return into `undefined` (e.g. two distinct entity refs both
-  // resolving to "undefined" → a spurious self-merge 400). We always compose
-  // exactly one trailing COMMIT, and every caller's last statement is the
-  // RETURN it wants, so the meaningful value is the slot immediately before
-  // COMMIT.
-  return arr[arr.length - 2] as T;
+  // The caller's last statement is the RETURN it wants, but WHERE that
+  // lands in the response depends on the server generation (verified
+  // empirically against v2.3.10 and v3.1.5):
+  //
+  //   3.x — one slot per top-level statement INCLUDING `BEGIN` and the
+  //   trailing `COMMIT` (both null): N user statements → N+2 slots, the
+  //   RETURN sits at length-2. Taking length-1 here reads the COMMIT
+  //   null and silently turns every transactional upsert into
+  //   `undefined` (historically: spurious self-merge 400s).
+  //
+  //   2.x — BEGIN/COMMIT emit no slots (and LETs may be collapsed too):
+  //   always ≤ N slots, the RETURN is simply the LAST one. Taking
+  //   length-2 there reads the statement BEFORE the RETURN — on prod
+  //   v2.3.10 this made every lease acquire and job claim silently
+  //   discard its committed result (gauge stuck at 0, queue never
+  //   dispatched) with zero errors logged.
+  //
+  // We compose exactly one BEGIN and one COMMIT, so the shapes are
+  // disjoint: only a 3.x server can answer with stmts+2 slots.
+  return (
+    arr.length === stmts.length + 2 ? arr[arr.length - 2] : arr[arr.length - 1]
+  ) as T;
 }
 
 /**

--- a/test/job-claim.unit-spec.ts
+++ b/test/job-claim.unit-spec.ts
@@ -37,11 +37,12 @@ function mkSurreal(db: { query: (s: string, p?: any) => Promise<any> }) {
 
 describe('JobClaimService', () => {
   it('claimNext returns null when the transaction yields no row', async () => {
-    // runTransaction reads the slot before the trailing COMMIT (SurrealDB 3.x
-    // emits a null COMMIT slot). RETURN NONE → the slot is null → claimNext
-    // returns null. [null, null] = (RETURN NONE, COMMIT).
+    // Real SurrealDB 3.x shape for the 2-statement claim tx: one slot
+    // per statement INCLUDING BEGIN and COMMIT → [BEGIN, LET,
+    // RETURN NONE, COMMIT]. runTransaction detects the stmts+2 shape
+    // and reads the slot before COMMIT.
     const { db } = mkDbScript([
-      () => [null, null],
+      () => [null, null, null, null],
     ]);
     const svc = new JobClaimService(mkSurreal(db));
     const got = await svc.claimNext({
@@ -53,9 +54,12 @@ describe('JobClaimService', () => {
   });
 
   it('claimNext returns a typed JobClaim when the tx yields a row', async () => {
-    // 3.x: row is the RETURN slot, immediately before the COMMIT null slot.
+    // 3.x shape: [BEGIN, LET, RETURN row, COMMIT] — row sits right
+    // before the trailing COMMIT null.
     const { db } = mkDbScript([
       () => [
+        null,
+        null,
         {
           id: 'job_run:abc',
           runId: 'run-uuid-1',
@@ -78,6 +82,32 @@ describe('JobClaimService', () => {
     expect(got?.recordId).toBe('job_run:abc');
     expect(got?.payload).toEqual({ operations: ['dedup'] });
     expect(got?.attempts).toBe(1);
+  });
+
+  it('claimNext reads the last slot on the 2.x response shape', async () => {
+    // 2.x shape: BEGIN/COMMIT emit no slots and LETs collapse — the
+    // RETURN row is simply the LAST (often only) slot. Regression for
+    // prod v2.3.10, where blind arr[length-2] silently discarded every
+    // committed claim.
+    const { db } = mkDbScript([
+      () => [
+        {
+          id: 'job_run:abc2',
+          runId: 'run-uuid-2',
+          jobType: 'dreams',
+          attempts: 1,
+          payload: null,
+          leaseUntil: '2030-01-01T00:05:00Z',
+        },
+      ],
+    ]);
+    const svc = new JobClaimService(mkSurreal(db));
+    const got = await svc.claimNext({
+      companyId: 'co_x',
+      jobType: 'dreams',
+      ttlSeconds: 300,
+    });
+    expect(got?.runId).toBe('run-uuid-2');
   });
 
   it('claimNext returns null and swallows transient driver errors', async () => {

--- a/test/jobs-otel.unit-spec.ts
+++ b/test/jobs-otel.unit-spec.ts
@@ -139,9 +139,12 @@ describe('Jobs OTel handoff — wire contract', () => {
     const traceparent =
       '00-cccccccccccccccccccccccccccccccc-3333333333333333-01';
     const db = {
-      // 3.x: RETURN slot precedes the trailing COMMIT null slot (runTransaction
-      // reads arr[length-2]).
+      // Real 3.x shape for the 2-statement claim tx: [BEGIN, LET,
+      // RETURN row, COMMIT] — runTransaction reads the slot before the
+      // trailing COMMIT when the response has stmts+2 slots.
       query: async () => [
+        null,
+        null,
         {
           id: 'job_run:withtp',
           runId: 'run-with-tp',


### PR DESCRIPTION
Layer 4 (and per three days of prod evidence, the last) of the dead-background-jobs bug: #166 parse error → #169 conflict storm → #170 record-constructor semantics → this.

## Prod evidence

Since #170 deployed (2026-07-11 14:19 UTC) the container has run for 3 days with **zero lease warnings** — the UPSERT commits (the janitor's stale-lease warning disappeared because the row is being refreshed) — yet `max_over_time(brain_worker_is_leader[3d]) == 0` and not a single `brain_job_total` sample. Silent wrongness, no errors.

## Cause

`runTransaction` returns `arr[length-2]` unconditionally — correct only for the 3.x response shape. Measured against both servers with the exact acquire transaction:

| server | response slots for `BEGIN; LET; IF…RETURN true; COMMIT` | RETURN lives at |
|---|---|---|
| v3.1.5 | `[null, null, true, null]` (slot per statement incl. BEGIN/COMMIT) | `length-2` |
| v2.3.10 | `[true]` (BEGIN/COMMIT emit no slots, LETs collapse) | `length-1` |

On 2.x that reads the statement **before** the RETURN: `tryAcquire` saw the LET's `null` → `out === true` false → not-leader forever, while its own UPSERT kept committing. `claimNext` had the identical silent failure — committed claims discarded.

## Fix

We compose exactly one `BEGIN` and one `COMMIT`, so the shapes are disjoint: only a 3.x server can answer with `stmts+2` slots. Take `length-2` on that shape, `length-1` otherwise.

## Verified

- Drove the **real `runTransaction` through the JS SDK** against local `v2.3.10` and `v3.1.5` containers: acquire → `true`, same-holder re-acquire → `true` on both (throwaway spec, not committed).
- Unit suite 1064/1064 — the two claimNext mocks encoded an unreal 2-slot shape and are updated to the real 4-slot 3.x shape; added a 2.x-shape regression case.
- `jobs.real` e2e (3.1.5 testcontainers): 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)