### PR TITLE
perf(dreams,documents): audit wave P3 — flag-gated pipeline fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -361,6 +361,9 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 # switch; the sub-ops below each gate one stage (all default off).
 #DREAMS_ENABLED=0
 #DREAMS_DEDUP_ENABLED=0
+# Cap on name-fact seeds per dedup run (newest first) — bounds the
+# per-seed neighbour queries on large tenants.
+#DREAMS_DEDUP_MAX_SEEDS=500
 #DREAMS_RESOLVE_ENABLED=0
 #DREAMS_LLM_SUMMARY_ENABLED=0
 # Dreams: fuzzy corroboration (cosine-close facts confirm each other) and
@@ -369,6 +372,10 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 # groups; a persistent backlog is warn-logged (groupBacklog > window).
 #DREAMS_CORROBORATE_ENABLED=0
 #DREAMS_CORROBORATE_MAX_PAIRS=20
+# Hard ceiling on judge LLM calls per run (default 2x MAX_PAIRS) —
+# different/unsure verdicts don't count toward MAX_PAIRS, so this is
+# what actually bounds nightly spend.
+#DREAMS_CORROBORATE_MAX_LLM_CALLS=40
 #DREAMS_CORROBORATE_COSINE_THRESHOLD=0.9
 #DREAMS_CORROBORATE_CONCURRENCY=4
 #DREAMS_CORROBORATE_MODEL=gpt-4o-mini

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -244,6 +244,15 @@ export class ConfigInspectorService {
         isBooleanFlag: false,
       },
       {
+        key: 'DREAMS_DEDUP_MAX_SEEDS',
+        category: 'dreams',
+        defaultValue: '500',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Cap on name-fact seeds per dedup run (newest first). Bounds the per-seed neighbour queries.',
+      },
+      {
         key: 'DREAMS_RESOLVE_MIN_AGE_DAYS',
         category: 'dreams',
         defaultValue: '7',
@@ -740,6 +749,15 @@ export class ConfigInspectorService {
         isBooleanFlag: true,
         description:
           'Fuzzy cross-source corroboration (cosine-close facts confirm each other). Bounded by DREAMS_CORROBORATE_MAX_PAIRS per run.',
+      },
+      {
+        key: 'DREAMS_CORROBORATE_MAX_LLM_CALLS',
+        category: 'dreams',
+        defaultValue: '40',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Hard ceiling on judge LLM calls per corroborate run (default 2× MAX_PAIRS). different/unsure verdicts never count toward MAX_PAIRS, so this is what actually bounds spend.',
       },
       {
         key: 'DREAMS_COMMUNITIES_ENABLED',

--- a/src/ai/cross-encoder/local-cross-encoder.provider.ts
+++ b/src/ai/cross-encoder/local-cross-encoder.provider.ts
@@ -168,6 +168,17 @@ export class LocalCrossEncoderProvider {
   }
 
   private async warmupWorker(): Promise<void> {
+    // Re-warmup after a score-RPC timeout must not orphan the previous
+    // worker: an un-terminated worker_threads.Worker keeps its message
+    // listener (and the ~300 MB loaded model) alive for the process
+    // lifetime — one leaked worker per timeout incident. Tear the old
+    // one down before spawning its replacement.
+    const stale = this.worker;
+    if (stale) {
+      this.worker = null;
+      this.failAllPending(new Error('worker replaced after stall'));
+      await stale.terminate().catch(() => undefined);
+    }
     const workerPath = this.resolveWorkerPath();
     this.worker = new Worker(workerPath);
     this.worker.on('message', (m: unknown) => this.handleReply(m));
@@ -220,6 +231,15 @@ export class LocalCrossEncoderProvider {
       const timer = setTimeout(() => {
         if (this.pending.delete(id)) {
           this.workerReady = false;
+          // Latch like a warmup failure: without this, the next score()
+          // immediately re-warms (spawning a replacement worker) while
+          // the wedged one may still be mid-inference — on a
+          // persistently slow host that cycled a new ~300 MB worker per
+          // timeout. The latch gives the host FAIL_RETRY_MS to recover;
+          // rerank degrades to fusion order meanwhile.
+          if (kind === 'score') {
+            this.failedUntil = Date.now() + FAIL_RETRY_MS;
+          }
           reject(new Error(`cross-encoder '${kind}' RPC timed out after ${timeoutMs}ms`));
         }
       }, timeoutMs);

--- a/src/ai/embedder/bge-m3-embedder.provider.ts
+++ b/src/ai/embedder/bge-m3-embedder.provider.ts
@@ -228,8 +228,13 @@ export class BgeM3EmbedderProvider implements EmbedderProvider {
         if (this.pending.delete(id)) {
           // A wedged worker won't recover on its own — mark it not-ready
           // so isReady() flips false and EmbedderService fails over to the
-          // fallback provider instead of stacking timed-out RPCs.
+          // fallback provider instead of stacking timed-out RPCs. And
+          // since nothing ever re-warms this provider (EmbedderService
+          // warms once at module init), the wedged worker would
+          // otherwise pin the ~600 MB model for the rest of the process
+          // lifetime while serving zero traffic — reclaim it now.
           this.workerReady = false;
+          void this.terminate();
           reject(
             new Error(
               `BGE-M3 worker '${kind}' RPC timed out after ${timeoutMs}ms`,

--- a/src/communities/community-builder.service.ts
+++ b/src/communities/community-builder.service.ts
@@ -82,6 +82,20 @@ export class CommunityBuilderService {
     };
     if (!this.enabled) return result;
 
+    // Tenant-level short-circuit (0061): probe the live-edge signature
+    // (count + newest createdAt) with one aggregate query; when nothing
+    // changed since the last full pass, skip the edge load + clustering
+    // entirely. The per-cluster watermark below only saves the
+    // summarize/embed step — the O(E) materialisation and O(V+E)
+    // propagation were paid every night regardless.
+    const signature = await this.probeGraphSignature(db);
+    if (signature && (await this.signatureUnchanged(db, signature))) {
+      this.logger.log(
+        `[communities] graph unchanged (edges=${signature.liveEdgeCount}, maxEdgeAt=${signature.maxEdgeAt ?? 'none'}) — skipping rebuild`,
+      );
+      return result;
+    }
+
     const edges = await this.loadEdges(db);
     if (edges.length === 0) {
       // No edges → no communities. Still drop any stale ones left over
@@ -154,11 +168,92 @@ export class CommunityBuilderService {
       result.communitiesRemoved++;
     }
 
+    // Persist the signature captured BEFORE the pass — edges landing
+    // mid-pass make next night's probe differ and re-trigger a build.
+    if (signature) await this.saveGraphSignature(db, signature);
+
     this.logger.log(
       `[communities] built=${result.communitiesBuilt} reused=${result.communitiesReused} ` +
         `removed=${result.communitiesRemoved} entitiesClustered=${result.entitiesClustered}`,
     );
     return result;
+  }
+
+  /**
+   * Live-edge signature in one aggregate round-trip. Returns null on
+   * any error — the caller then runs the full pass (fail-open: the
+   * short-circuit is a cost gate, never a correctness gate).
+   */
+  private async probeGraphSignature(
+    db: Surreal,
+  ): Promise<GraphSignature | null> {
+    try {
+      const [rows] = await db.query<
+        [Array<{ c: number; maxAt: unknown }>]
+      >(
+        `SELECT count() AS c, time::max(createdAt) AS maxAt
+           FROM knowledge_edge
+          WHERE invalidatedAt IS NONE
+          GROUP ALL`,
+      );
+      const row = ((rows as Array<{ c: number; maxAt: unknown }>) ?? [])[0];
+      return {
+        liveEdgeCount: row ? Number(row.c) : 0,
+        maxEdgeAt: row?.maxAt ? String(row.maxAt) : null,
+        minSize: this.minSize,
+      };
+    } catch (e) {
+      this.logger.warn(
+        `[communities] signature probe failed (${(e as Error).message}); running full pass`,
+      );
+      return null;
+    }
+  }
+
+  private async signatureUnchanged(
+    db: Surreal,
+    sig: GraphSignature,
+  ): Promise<boolean> {
+    try {
+      const [rows] = await db.query<
+        [Array<{ liveEdgeCount: number; maxEdgeAt: unknown; minSize: number }>]
+      >(`SELECT liveEdgeCount, maxEdgeAt, minSize FROM community_build_state`);
+      const prior = ((rows as Array<{
+        liveEdgeCount: number;
+        maxEdgeAt: unknown;
+        minSize: number;
+      }>) ?? [])[0];
+      if (!prior) return false;
+      return (
+        Number(prior.liveEdgeCount) === sig.liveEdgeCount &&
+        (prior.maxEdgeAt ? String(prior.maxEdgeAt) : null) === sig.maxEdgeAt &&
+        Number(prior.minSize) === sig.minSize
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private async saveGraphSignature(
+    db: Surreal,
+    sig: GraphSignature,
+  ): Promise<void> {
+    try {
+      await db.query(
+        `UPSERT community_build_state:singleton SET
+           liveEdgeCount = $c, maxEdgeAt = $maxAt,
+           minSize = $minSize, updatedAt = time::now()`,
+        {
+          c: sig.liveEdgeCount,
+          maxAt: sig.maxEdgeAt ? new Date(sig.maxEdgeAt) : undefined,
+          minSize: sig.minSize,
+        },
+      );
+    } catch (e) {
+      this.logger.warn(
+        `[communities] signature save failed: ${(e as Error).message}`,
+      );
+    }
   }
 
   /** Load every live entity-entity edge. Mirrors ppr.ts edge-load. */
@@ -371,6 +466,13 @@ interface EdgeRow {
   to: string;
   weight: number;
   createdAt: string;
+}
+
+/** Live-edge signature for the tenant-level rebuild short-circuit (0061). */
+interface GraphSignature {
+  liveEdgeCount: number;
+  maxEdgeAt: string | null;
+  minSize: number;
 }
 
 interface ExistingCommunity {

--- a/src/db/migrations/0060_corroborate_checked.surql
+++ b/src/db/migrations/0060_corroborate_checked.surql
@@ -1,0 +1,28 @@
+-- 0060_corroborate_checked — negative-result memo for the nightly
+-- corroboration pass.
+--
+-- DreamsCorroborateService selects its nightly window deterministically
+-- (most-populated groups first — wave F4). A group whose pairs are all
+-- judged 'different'/'unsure' applies nothing, so nothing about it
+-- changes — it re-qualifies every night and, being deterministically
+-- sorted to the top, permanently occupies a window slot. Once enough
+-- persistently-different groups exist, the window is 100% stuck groups:
+-- backlog drain rate goes to zero while the nightly LLM spend stays
+-- maximal.
+--
+-- The memo records (entityId, predicate, memberCount) after a group is
+-- processed. A group is skipped while its CURRENT active-member count
+-- equals the memo'd one; any membership change (new fact, retraction,
+-- a member turning 'corroborating') changes the count and re-qualifies
+-- the group. A same-count membership swap is a false skip — accepted:
+-- the memo is a cost gate, not a correctness gate, and the swap case
+-- self-heals on the next count change.
+
+DEFINE TABLE IF NOT EXISTS corroborate_checked SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS entityId    ON corroborate_checked TYPE record<knowledge_entity>;
+DEFINE FIELD IF NOT EXISTS predicate   ON corroborate_checked TYPE string;
+DEFINE FIELD IF NOT EXISTS memberCount ON corroborate_checked TYPE int;
+DEFINE FIELD IF NOT EXISTS checkedAt   ON corroborate_checked TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX IF NOT EXISTS corroborate_checked_group_idx
+  ON corroborate_checked FIELDS entityId, predicate UNIQUE;

--- a/src/db/migrations/0061_community_build_state.surql
+++ b/src/db/migrations/0061_community_build_state.surql
@@ -1,0 +1,21 @@
+-- 0061_community_build_state — tenant-level short-circuit for the
+-- nightly community builder.
+--
+-- CommunityBuilderService.run() loaded EVERY live edge into process
+-- memory and re-ran label propagation each night, even when the graph
+-- had not changed since the last pass — the per-cluster watermark only
+-- skipped the summarize/embed step. At 1M edges that is a ~200+ MB JS
+-- materialisation per tenant per night for a no-op.
+--
+-- One row per tenant DB (fixed id, UPSERTed after each full pass)
+-- records the live-edge signature (count + newest createdAt + the
+-- minSize knob). The next run probes the same signature with one
+-- aggregate query and skips the load+cluster when nothing moved.
+-- Invalidation is covered by the count; new edges by maxEdgeAt; a
+-- changed COMMUNITIES_MIN_SIZE by minSize.
+
+DEFINE TABLE IF NOT EXISTS community_build_state SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS liveEdgeCount ON community_build_state TYPE int;
+DEFINE FIELD IF NOT EXISTS maxEdgeAt     ON community_build_state TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS minSize       ON community_build_state TYPE int;
+DEFINE FIELD IF NOT EXISTS updatedAt     ON community_build_state TYPE datetime DEFAULT time::now();

--- a/src/documents/candidate-store.service.ts
+++ b/src/documents/candidate-store.service.ts
@@ -283,9 +283,21 @@ export class CandidateStoreService {
     const { batch } = p;
     const prov = batch.provenance;
     return this.surreal.withCompany(companyId, async (db) => {
-      for (const e of batch.entities) {
-        await this.insertRow(db, {
-          ...p,
+      // One INSERT for the whole chunk instead of one CREATE per
+      // candidate (same pattern-port as changefeed-drain's audit_event
+      // batch). A large document staged E+F+R serial round-trips per
+      // chunk — thousands per indexer run; this is one RTT per chunk,
+      // and single-statement staging makes the chunk atomic (a crash
+      // can no longer leave a partially staged chunk behind).
+      const shared = () => ({
+        docId: recordRef('source_document', p.docId),
+        runId: recordRef('indexer_run', p.runId),
+        chunkSeq: p.chunkSeq,
+        status: 'pending',
+      });
+      const rows: Record<string, unknown>[] = [
+        ...batch.entities.map((e) => ({
+          ...shared(),
           kind: 'entity',
           confidence: 0.5,
           payload: {
@@ -299,11 +311,9 @@ export class CandidateStoreService {
             executionMode: prov.executionMode,
             model: prov.model,
           },
-        });
-      }
-      for (const f of batch.facts) {
-        await this.insertRow(db, {
-          ...p,
+        })),
+        ...batch.facts.map((f) => ({
+          ...shared(),
           kind: 'fact',
           confidence: f.confidence,
           payload: {
@@ -322,11 +332,9 @@ export class CandidateStoreService {
             executionMode: prov.executionMode,
             model: prov.model,
           },
-        });
-      }
-      for (const r of batch.relations) {
-        await this.insertRow(db, {
-          ...p,
+        })),
+        ...batch.relations.map((r) => ({
+          ...shared(),
           kind: 'relation',
           confidence: r.confidence,
           payload: {
@@ -339,7 +347,10 @@ export class CandidateStoreService {
             executionMode: prov.executionMode,
             model: prov.model,
           },
-        });
+        })),
+      ];
+      if (rows.length > 0) {
+        await db.query(`INSERT INTO candidate $rows`, { rows });
       }
       this.metrics?.countCandidate('entity', 'created', batch.entities.length);
       this.metrics?.countCandidate('fact', 'created', batch.facts.length);
@@ -416,43 +427,32 @@ export class CandidateStoreService {
   ): Promise<void> {
     if (!updates.length) return;
     await this.surreal.withCompany(companyId, async (db) => {
-      for (const u of updates) {
-        await db.query(
-          `UPDATE type::record('candidate', $id) SET
-             status = $status, statusReason = $reason, commitRef = $ref,
-             decidedAt = time::now()`,
-          {
-            id: idTailOf(u.id),
+      // One FOR-loop statement instead of one UPDATE round-trip per
+      // candidate. These writes run while holding the per-doc commit
+      // lock, so the old per-row form stretched the window in which
+      // re-commits defer — by thousands of RTTs on a large document.
+      // (Side-effect-only FOR body — the "no cross-iteration variable
+      // accumulation" SurrealQL limitation doesn't apply.)
+      await db.query(
+        `FOR $u IN $updates {
+           UPDATE type::record($u.id) SET
+             status = $u.status,
+             statusReason = $u.reason ?? NONE,
+             commitRef = $u.ref ?? NONE,
+             decidedAt = time::now();
+         };`,
+        {
+          updates: updates.map((u) => ({
+            id: `candidate:${idTailOf(u.id)}`,
             status: u.status,
-            reason: u.statusReason,
-            ref: u.commitRef,
-          },
-        );
-      }
+            reason: u.statusReason ?? null,
+            ref: u.commitRef ?? null,
+          })),
+        },
+      );
     });
   }
 
-  private async insertRow(
-    db: Surreal,
-    p: {
-      docId: string;
-      runId: string;
-      chunkSeq: number;
-      kind: CandidateKind;
-      confidence: number;
-      payload: Record<string, unknown>;
-    },
-  ): Promise<void> {
-    await dbCreate(db, 'candidate', {
-      docId: recordRef('source_document', p.docId),
-      runId: recordRef('indexer_run', p.runId),
-      chunkSeq: p.chunkSeq,
-      kind: p.kind,
-      confidence: p.confidence,
-      payload: p.payload,
-      status: 'pending',
-    });
-  }
 
   private async loadByDoc(
     db: Surreal,

--- a/src/documents/document-store.service.ts
+++ b/src/documents/document-store.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
   Optional,
 } from '@nestjs/common';
-import { Surreal } from 'surrealdb';
+import { StringRecordId, Surreal } from 'surrealdb';
 import {
   SurrealService,
   dbCreate,
@@ -116,22 +116,19 @@ export class DocumentStoreService {
           status: 'received',
         });
         const docId = String(row.id);
-        if (storeContent) {
-          for (const c of chunks) {
-            await db.query(
-              `CREATE source_chunk CONTENT {
-                 docId: type::record('source_document', $doc),
-                 seq: $seq, text: $text, charStart: $start, charEnd: $end
-               }`,
-              {
-                doc: idTailOf(docId),
-                seq: c.seq,
-                text: c.text,
-                start: c.charStart,
-                end: c.charEnd,
-              },
-            );
-          }
+        if (storeContent && chunks.length > 0) {
+          // One INSERT for all chunks instead of one CREATE per chunk
+          // (up to ~43 serial round-trips per stored document at the
+          // DOC_MAX_CHARS cap).
+          await db.query(`INSERT INTO source_chunk $rows`, {
+            rows: chunks.map((c) => ({
+              docId: new StringRecordId(`source_document:${idTailOf(docId)}`),
+              seq: c.seq,
+              text: c.text,
+              charStart: c.charStart,
+              charEnd: c.charEnd,
+            })),
+          });
         }
         this.metrics?.countDocument('created');
         return { doc: mapDoc({ ...row, id: docId }), chunks, deduplicated: false };

--- a/src/dreams/corroborate.service.ts
+++ b/src/dreams/corroborate.service.ts
@@ -93,6 +93,7 @@ export class DreamsCorroborateService {
   private readonly model: string;
   private readonly maxPairs: number;
   private readonly cosineThreshold: number;
+  private readonly maxLlmCalls: number;
   private readonly limiter: Semaphore;
 
   constructor(
@@ -121,6 +122,18 @@ export class DreamsCorroborateService {
     );
     this.maxPairs = parseInt(
       this.configService.get<string>('DREAMS_CORROBORATE_MAX_PAIRS', '20'),
+      10,
+    );
+    // Hard ceiling on judge calls per run. maxPairs caps APPLIED
+    // corroborations only — 'different'/'unsure' verdicts don't count
+    // toward it, so a window full of non-matching pairs could burn
+    // (window × pairs-per-group) LLM calls (~280) against a nominal
+    // cap of 20. Default 2× the window.
+    this.maxLlmCalls = parseInt(
+      this.configService.get<string>(
+        'DREAMS_CORROBORATE_MAX_LLM_CALLS',
+        String(this.maxPairs * 2),
+      ),
       10,
     );
     this.cosineThreshold = parseFloat(
@@ -170,29 +183,48 @@ export class DreamsCorroborateService {
 
     for (const group of groups) {
       if (result.corroborationsApplied >= this.maxPairs) break;
+      // Hard judge-call ceiling: 'different'/'unsure' verdicts never
+      // count toward maxPairs, so without this a window of
+      // non-matching groups kept burning LLM calls all the way through.
+      if (result.llmJudgements >= this.maxLlmCalls) {
+        this.logger.warn(
+          `[dreams.corroborate] LLM call ceiling ${this.maxLlmCalls} reached — ${result.llmJudgements} judgements this run; remaining groups wait for the next run`,
+        );
+        break;
+      }
       const members = await this.fetchGroupMembers(db, group);
       const pairs = this.selectPairs(members);
-      for (const pair of pairs) {
-        if (result.corroborationsApplied >= this.maxPairs) break;
-        result.pairsConsidered++;
-        let method: 'exact' | 'llm';
-        if (pair.younger.object.trim() === pair.incumbent.object.trim()) {
-          method = 'exact';
-        } else {
-          const verdict = await withSpan('dreams.corroborate.judge', () =>
-            this.limiter.run(() => this.judge(pair)),
-          );
-          result.llmJudgements++;
-          if (verdict === 'unsure') {
-            result.unsurePairs++;
-            this.logger.warn(
-              `[dreams.corroborate] unsure: entity=${String(pair.incumbent.entityId)} predicate=${pair.incumbent.predicate} a='${pair.incumbent.object}' vs b='${pair.younger.object}'`,
-            );
-            continue;
+
+      // Judge in parallel under the semaphore, apply serially. The old
+      // per-iteration await never let the Semaphore hold more than one
+      // task, making DREAMS_CORROBORATE_CONCURRENCY a no-op — the
+      // nightly leg ran at 1× LLM latency. Exact-object matches skip
+      // the judge entirely. Within-group calls may overshoot the
+      // ceiling by at most the group's pair count (≤ MAX_GROUP_SIZE).
+      const judged = await Promise.all(
+        pairs.map((pair) => {
+          result.pairsConsidered++;
+          if (pair.younger.object.trim() === pair.incumbent.object.trim()) {
+            return Promise.resolve({ pair, verdict: 'exact' as const });
           }
-          if (verdict === 'different') continue;
-          method = 'llm';
+          result.llmJudgements++;
+          return withSpan('dreams.corroborate.judge', () =>
+            this.limiter.run(() => this.judge(pair)),
+          ).then((verdict) => ({ pair, verdict }));
+        }),
+      );
+
+      for (const { pair, verdict } of judged) {
+        if (result.corroborationsApplied >= this.maxPairs) break;
+        if (verdict === 'unsure') {
+          result.unsurePairs++;
+          this.logger.warn(
+            `[dreams.corroborate] unsure: entity=${String(pair.incumbent.entityId)} predicate=${pair.incumbent.predicate} a='${pair.incumbent.object}' vs b='${pair.younger.object}'`,
+          );
+          continue;
         }
+        if (verdict === 'different') continue;
+        const method: 'exact' | 'llm' = verdict === 'exact' ? 'exact' : 'llm';
         await this.applyCorroboration(db, pair);
         result.corroborationsApplied++;
         result.corroborations.push({
@@ -205,8 +237,40 @@ export class DreamsCorroborateService {
           method,
         });
       }
+
+      // Negative-result memo (migration 0060): remember the group's
+      // member count so a group whose membership hasn't changed is not
+      // re-fetched and re-judged every night. Groups that DID apply a
+      // corroboration change their active-member count (the younger row
+      // turns 'corroborating'), so the memo self-invalidates for them.
+      await this.markGroupChecked(db, group, members.length);
     }
     return result;
+  }
+
+  private async markGroupChecked(
+    db: Surreal,
+    group: { entityId: unknown; predicate: string },
+    memberCount: number,
+  ): Promise<void> {
+    try {
+      await db.query(
+        `UPSERT corroborate_checked SET
+           entityId = $entity, predicate = $predicate,
+           memberCount = $n, checkedAt = time::now()
+         WHERE entityId = $entity AND predicate = $predicate`,
+        {
+          entity: new StringRecordId(String(group.entityId)),
+          predicate: group.predicate,
+          n: memberCount,
+        },
+      );
+    } catch (e) {
+      // Best-effort: a missed memo only costs a re-judge next run.
+      this.logger.warn(
+        `[dreams.corroborate] checked-memo write failed: ${(e as Error).message}`,
+      );
+    }
   }
 
   /**
@@ -231,11 +295,20 @@ export class DreamsCorroborateService {
          AND userId IS NONE
        GROUP BY entityId, predicate`,
     );
+    // Negative-result memo (0060): a group already judged at the SAME
+    // member count is excluded before the window is cut. Without this,
+    // the deterministic most-populated-first order re-selected the same
+    // all-'different' groups every night — permanent starvation of the
+    // rest of the backlog at full LLM cost.
+    const checked = await this.loadCheckedMemo(db);
     const eligible = (
       (rows as Array<{ entityId: unknown; predicate: string; n: number }>) ?? []
     )
       .filter((g) => g.n >= 2 && g.n <= MAX_GROUP_SIZE)
       .filter((g) => policyFor(g.predicate).semantics === 'bitemporal')
+      .filter(
+        (g) => checked.get(`${String(g.entityId)}|${g.predicate}`) !== g.n,
+      )
       .sort((a, b) => {
         if (b.n !== a.n) return b.n - a.n; // most-conflicted first
         const ka = `${String(a.entityId)}\u0000${a.predicate}`;
@@ -243,6 +316,28 @@ export class DreamsCorroborateService {
         return ka < kb ? -1 : ka > kb ? 1 : 0; // stable tiebreak
       });
     return { groups: eligible.slice(0, this.maxPairs * 2), backlog: eligible.length };
+  }
+
+  /** (entityId|predicate) → memberCount at last check. Empty on error. */
+  private async loadCheckedMemo(db: Surreal): Promise<Map<string, number>> {
+    const memo = new Map<string, number>();
+    try {
+      const [rows] = await db.query<
+        [Array<{ entityId: unknown; predicate: string; memberCount: number }>]
+      >(`SELECT entityId, predicate, memberCount FROM corroborate_checked`);
+      for (const r of (rows as Array<{
+        entityId: unknown;
+        predicate: string;
+        memberCount: number;
+      }>) ?? []) {
+        memo.set(`${String(r.entityId)}|${r.predicate}`, r.memberCount);
+      }
+    } catch (e) {
+      this.logger.warn(
+        `[dreams.corroborate] checked-memo read failed (${(e as Error).message}); treating all groups as unchecked`,
+      );
+    }
+    return memo;
   }
 
   private async fetchGroupMembers(

--- a/src/dreams/dedup.service.ts
+++ b/src/dreams/dedup.service.ts
@@ -55,6 +55,7 @@ export class DreamsDedupService {
   private readonly enabled: boolean;
   private readonly cosineThreshold: number;
   private readonly maxPairs: number;
+  private readonly maxSeeds: number;
 
   constructor(
     private readonly configService: ConfigService,
@@ -67,6 +68,15 @@ export class DreamsDedupService {
     );
     this.maxPairs = parseInt(
       this.configService.get<string>('DREAMS_DEDUP_MAX_PAIRS', '50'),
+      10,
+    );
+    // Bounds the neighbour-query loop (one query per seed). maxPairs
+    // only capped EMITTED pairs — on a corpus where few pairs cleared
+    // the threshold, the loop still ran one full scan per entity:
+    // O(N²) vector ops per tenant per night. Newest name facts seed
+    // first, so recently-touched entities are always covered.
+    this.maxSeeds = parseInt(
+      this.configService.get<string>('DREAMS_DEDUP_MAX_SEEDS', '500'),
       10,
     );
   }
@@ -141,42 +151,35 @@ export class DreamsDedupService {
    *   - Cap at maxPairs to bound the LLM cost.
    */
   private async findCandidates(db: Surreal): Promise<DedupCandidate[]> {
-    type NameRow = { entityId: unknown; embedding: number[] };
-    const [seedRows] = await db.query<[NameRow[]]>(
-      `SELECT entityId, embedding FROM knowledge_fact
+    // Seed pass: fact id + entity id ONLY. The old shape selected every
+    // name embedding into process memory (1536 float64s × N entities —
+    // hundreds of MB at scale) and then looped over ALL of them. The
+    // embedding never leaves the DB now: each neighbour query resolves
+    // its seed vector by fact id, and the seed set is capped
+    // newest-first. recordedAt rides in the projection for the 3.x
+    // ORDER BY idiom.
+    type SeedRow = { id: unknown; entityId: unknown; recordedAt: unknown };
+    const [seedRows] = await db.query<[SeedRow[]]>(
+      `SELECT id, entityId, recordedAt FROM knowledge_fact
        WHERE predicate = 'name'
          AND status = 'active'
          AND retractedAt IS NONE
          AND embedding != NONE
          AND userId IS NONE
-         AND entityId.mergedInto IS NONE`,
+         AND entityId.mergedInto IS NONE
+       ORDER BY recordedAt DESC
+       LIMIT $maxSeeds`,
+      { maxSeeds: this.maxSeeds },
     );
-    const seeds = (seedRows as NameRow[]) ?? [];
+    const seeds = (seedRows as SeedRow[]) ?? [];
     if (seeds.length < 2) return [];
 
     const out: DedupCandidate[] = [];
     const seen = new Set<string>();
     for (const seed of seeds) {
       const aId = String(seed.entityId);
-      // K-NN over name facts. We ask for K=5 to surface the closest
-      // candidates without flooding the LLM stage; the threshold
-      // then filters most away.
-      const sql = `
-        SELECT entityId, vector::similarity::cosine(embedding, $q) AS sim
-        FROM knowledge_fact
-        WHERE predicate = 'name'
-          AND status = 'active'
-          AND retractedAt IS NONE
-          AND embedding != NONE
-          AND userId IS NONE
-          AND entityId.mergedInto IS NONE
-        ORDER BY sim DESC
-        LIMIT 5
-      `;
-      const [neighbourRows] = await db.query<
-        [Array<{ entityId: unknown; sim: number }>]
-      >(sql, { q: seed.embedding });
-      for (const n of (neighbourRows as Array<{ entityId: unknown; sim: number }>) ?? []) {
+      const neighbours = await this.nearestNames(db, String(seed.id));
+      for (const n of neighbours) {
         const bId = String(n.entityId);
         if (bId === aId) continue;
         if (n.sim < this.cosineThreshold) continue;
@@ -192,6 +195,59 @@ export class DreamsDedupService {
       }
     }
     return out;
+  }
+
+  /**
+   * K nearest name facts to a seed name fact, seed vector resolved
+   * DB-side by fact id. With SEARCH_HNSW_ENABLED the KNN operator rides
+   * the HNSW index (same literal-K idiom + overfetch as the search
+   * vector leg; the operator throws when the tenant has no index, and
+   * we fall back to the scan). Without it, a scan ordered by cosine —
+   * still zero vectors shipped to JS in both directions.
+   */
+  private async nearestNames(
+    db: Surreal,
+    seedFactId: string,
+  ): Promise<Array<{ entityId: unknown; sim: number }>> {
+    const filters = `predicate = 'name'
+          AND status = 'active'
+          AND retractedAt IS NONE
+          AND embedding != NONE
+          AND userId IS NONE
+          AND entityId.mergedInto IS NONE`;
+    type Row = { entityId: unknown; sim: number };
+    if (envFlagEnabled(process.env.SEARCH_HNSW_ENABLED)) {
+      const ef = parseInt(process.env.SEARCH_HNSW_EF ?? '100', 10);
+      const overfetch = parseInt(process.env.SEARCH_HNSW_OVERFETCH ?? '4', 10);
+      const kOver = Math.min(5 * overfetch, 1000);
+      try {
+        const res = await db.query<[unknown, Row[]]>(
+          `LET $q = (SELECT VALUE embedding FROM ONLY type::record($fid));
+           SELECT entityId, vector::similarity::cosine(embedding, $q) AS sim
+             FROM knowledge_fact
+            WHERE embedding <|${kOver},${ef}|> $q
+              AND ${filters}
+            ORDER BY sim DESC
+            LIMIT 5;`,
+          { fid: seedFactId },
+        );
+        return (res[1] as Row[]) ?? [];
+      } catch (e) {
+        this.logger.warn(
+          `[dreams.dedup] KNN leg failed (${(e as Error).message}); falling back to scan`,
+        );
+      }
+    }
+    const res = await db.query<[unknown, Row[]]>(
+      `LET $q = (SELECT VALUE embedding FROM ONLY type::record($fid));
+       SELECT entityId, vector::similarity::cosine(embedding, $q) AS sim
+         FROM knowledge_fact
+        WHERE ${filters}
+        ORDER BY sim DESC
+        LIMIT 5;`,
+      { fid: seedFactId },
+    );
+    return (res[1] as Row[]) ?? [];
   }
 
   private async identityEdgeExists(

--- a/src/dreams/dreams.service.ts
+++ b/src/dreams/dreams.service.ts
@@ -581,50 +581,34 @@ export class DreamsService implements OnModuleInit {
     stats: DreamsTenantStats,
   ): Promise<void> {
     try {
-      for (const link of stats.dedup?.identityLinks ?? []) {
-        await db.query(
-          `CREATE dream_emit CONTENT {
-             runId: $runId, kind: 'identity_link',
-             subject: $subject, object: $object,
-             detail: $detail
-           }`,
-          {
-            runId,
-            subject: link.survivorId ?? null,
-            object: link.loserId ?? null,
-            detail: link,
-          },
-        );
-      }
-      for (const res of stats.resolve?.resolutions ?? []) {
-        await db.query(
-          `CREATE dream_emit CONTENT {
-             runId: $runId, kind: 'resolution',
-             subject: $subject, object: $object,
-             detail: $detail
-           }`,
-          {
-            runId,
-            subject: res.winnerFactId ?? null,
-            object: res.loserFactId ?? null,
-            detail: res,
-          },
-        );
-      }
-      for (const cor of stats.corroborate?.corroborations ?? []) {
-        await db.query(
-          `CREATE dream_emit CONTENT {
-             runId: $runId, kind: 'corroboration',
-             subject: $subject, object: $object,
-             detail: $detail
-           }`,
-          {
-            runId,
-            subject: cor.incumbentFactId ?? null,
-            object: cor.corroboratingFactId ?? null,
-            detail: cor,
-          },
-        );
+      // One INSERT for the whole run's emits instead of one CREATE per
+      // row across three sequential loops (~90 round-trips on a busy
+      // night). Same batch idiom as changefeed-drain / candidate-store.
+      const rows = [
+        ...(stats.dedup?.identityLinks ?? []).map((link) => ({
+          runId,
+          kind: 'identity_link',
+          subject: link.survivorId ?? null,
+          object: link.loserId ?? null,
+          detail: link,
+        })),
+        ...(stats.resolve?.resolutions ?? []).map((res) => ({
+          runId,
+          kind: 'resolution',
+          subject: res.winnerFactId ?? null,
+          object: res.loserFactId ?? null,
+          detail: res,
+        })),
+        ...(stats.corroborate?.corroborations ?? []).map((cor) => ({
+          runId,
+          kind: 'corroboration',
+          subject: cor.incumbentFactId ?? null,
+          object: cor.corroboratingFactId ?? null,
+          detail: cor,
+        })),
+      ];
+      if (rows.length > 0) {
+        await db.query(`INSERT INTO dream_emit $rows`, { rows });
       }
     } catch (e) {
       this.logger.warn(

--- a/src/dreams/resolver.service.ts
+++ b/src/dreams/resolver.service.ts
@@ -131,11 +131,19 @@ export class DreamsResolverService {
     result.pairsConsidered = pairs.length;
     if (pairs.length === 0) return result;
 
-    for (const pair of pairs) {
-      const verdict = await withSpan(
-        'dreams.resolve.judge',
-        () => this.limiter.run(() => this.judge(db, pair)),
-      );
+    // Judge in parallel under the semaphore, apply serially. The old
+    // per-iteration await never let the Semaphore hold more than one
+    // task, so DREAMS_RESOLVE_CONCURRENCY was a no-op and the nightly
+    // leg ran at 1× LLM latency per pair.
+    const judged = await Promise.all(
+      pairs.map((pair) =>
+        withSpan('dreams.resolve.judge', () =>
+          this.limiter.run(() => this.judge(db, pair)),
+        ).then((verdict) => ({ pair, verdict })),
+      ),
+    );
+
+    for (const { pair, verdict } of judged) {
       result.llmJudgements++;
       if (verdict.kind === 'unsure') {
         result.unsurePairs++;

--- a/test/audit-p3-dreams.unit-spec.ts
+++ b/test/audit-p3-dreams.unit-spec.ts
@@ -1,0 +1,275 @@
+/**
+ * Wave P3 of the 2026-07 performance audit — flag-gated pipeline guards.
+ *
+ * 1. Migrations 0060/0061 define the negative-memo and build-state
+ *    tables the corroborate / community passes now rely on.
+ * 2. Corroborate skips groups whose member count matches the 0060 memo
+ *    (the deterministic window no longer restarves on stuck groups) and
+ *    stops judging at the hard LLM-call ceiling.
+ * 3. Community builder short-circuits a full rebuild when the live-edge
+ *    signature is unchanged.
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { ConfigService } from '@nestjs/config';
+import { DreamsCorroborateService } from '../src/dreams/corroborate.service';
+import { CommunityBuilderService } from '../src/communities/community-builder.service';
+
+const MIGRATIONS = join(__dirname, '..', 'src', 'db', 'migrations');
+
+describe('P3 migrations', () => {
+  it('0060 defines corroborate_checked with a unique group index', () => {
+    const sql = readFileSync(
+      join(MIGRATIONS, '0060_corroborate_checked.surql'),
+      'utf8',
+    );
+    expect(sql).toContain('DEFINE TABLE IF NOT EXISTS corroborate_checked');
+    for (const field of ['entityId', 'predicate', 'memberCount', 'checkedAt']) {
+      expect(sql).toContain(`DEFINE FIELD IF NOT EXISTS ${field}`);
+    }
+    expect(sql).toMatch(/corroborate_checked_group_idx[\s\S]*UNIQUE/);
+  });
+
+  it('0061 defines community_build_state signature fields', () => {
+    const sql = readFileSync(
+      join(MIGRATIONS, '0061_community_build_state.surql'),
+      'utf8',
+    );
+    expect(sql).toContain('DEFINE TABLE IF NOT EXISTS community_build_state');
+    for (const field of ['liveEdgeCount', 'maxEdgeAt', 'minSize']) {
+      expect(sql).toContain(`DEFINE FIELD IF NOT EXISTS ${field}`);
+    }
+  });
+});
+
+type Row = Record<string, unknown>;
+
+function fact(over: Partial<Row> = {}): Row {
+  return {
+    id: `knowledge_fact:${Math.random().toString(36).slice(2, 8)}`,
+    entityId: 'knowledge_entity:e1',
+    predicate: 'claim_probe',
+    object: 'gold tier customer',
+    validFrom: '2026-01-01T00:00:00Z',
+    validUntil: null,
+    recordedAt: '2026-06-01T00:00:00Z',
+    embedding: [1, 0],
+    originKey: 'doc:a',
+    corroborationCount: 0,
+    ...over,
+  };
+}
+
+function mkCorroborate(extraEnv: Record<string, string> = {}) {
+  const svc = new DreamsCorroborateService(
+    new ConfigService({
+      DREAMS_CORROBORATE_ENABLED: '1',
+      OPENAI_API_KEY: 'sk-test',
+      ...extraEnv,
+    }),
+  );
+  const judge = jest.fn();
+  (svc as unknown as { judge: unknown }).judge = judge;
+  return { svc, judge };
+}
+
+/**
+ * db mock: group listing, 0060 memo read/write, member fetch, and the
+ * corroboration apply — enough surface for run() end-to-end.
+ */
+function mkDb(opts: {
+  groups: Array<{ entityId: string; predicate: string; n: number }>;
+  membersByGroup: Record<string, Row[]>;
+  memo?: Array<{ entityId: string; predicate: string; memberCount: number }>;
+}) {
+  const memoWrites: Array<Record<string, unknown>> = [];
+  const memberFetches: string[] = [];
+  const query = jest.fn(async (sql: string, params?: Record<string, unknown>) => {
+    if (sql.includes('GROUP BY entityId, predicate')) {
+      return [opts.groups];
+    }
+    if (sql.includes('FROM corroborate_checked')) {
+      return [opts.memo ?? []];
+    }
+    if (sql.includes('UPSERT corroborate_checked')) {
+      memoWrites.push(params ?? {});
+      return [[]];
+    }
+    if (sql.includes('fn::origin_key_of(source) AS originKey')) {
+      const key = `${String(params?.entity)}|${String(params?.predicate)}`;
+      memberFetches.push(key);
+      return [opts.membersByGroup[key] ?? []];
+    }
+    if (sql.includes(`status = 'corroborating'`)) {
+      return [[]];
+    }
+    throw new Error(`unexpected query: ${sql}`);
+  });
+  return { db: { query }, memoWrites, memberFetches };
+}
+
+describe('DreamsCorroborateService 0060 memo + LLM ceiling', () => {
+  it('skips groups whose member count matches the memo and marks processed groups', async () => {
+    const { svc, judge } = mkCorroborate();
+    const a = fact({ id: 'knowledge_fact:a', originKey: 'doc:a' });
+    const b = fact({
+      id: 'knowledge_fact:b',
+      originKey: 'doc:b',
+      recordedAt: '2026-06-02T00:00:00Z',
+    });
+    const groups = [
+      { entityId: 'knowledge_entity:e1', predicate: 'claim_probe', n: 2 },
+      { entityId: 'knowledge_entity:e2', predicate: 'claim_probe', n: 2 },
+    ];
+    const { db, memoWrites, memberFetches } = mkDb({
+      groups,
+      membersByGroup: {
+        'knowledge_entity:e1|claim_probe': [a, b],
+        'knowledge_entity:e2|claim_probe': [],
+      },
+      // e2 already checked at the same member count → must be skipped.
+      memo: [
+        { entityId: 'knowledge_entity:e2', predicate: 'claim_probe', memberCount: 2 },
+      ],
+    });
+
+    const out = await svc.run(db as never);
+
+    expect(out.groupsConsidered).toBe(1);
+    expect(memberFetches).toEqual(['knowledge_entity:e1|claim_probe']);
+    expect(out.corroborationsApplied).toBe(1); // exact match, no LLM
+    expect(judge).not.toHaveBeenCalled();
+    // The processed group is memo'd with its member count.
+    expect(memoWrites).toHaveLength(1);
+    expect(memoWrites[0]).toMatchObject({ predicate: 'claim_probe', n: 2 });
+  });
+
+  it('re-qualifies a memo group whose member count changed', async () => {
+    const { svc } = mkCorroborate();
+    const a = fact({ id: 'knowledge_fact:a', originKey: 'doc:a' });
+    const b = fact({
+      id: 'knowledge_fact:b',
+      originKey: 'doc:b',
+      recordedAt: '2026-06-02T00:00:00Z',
+    });
+    const { db, memberFetches } = mkDb({
+      groups: [{ entityId: 'knowledge_entity:e1', predicate: 'claim_probe', n: 2 }],
+      membersByGroup: { 'knowledge_entity:e1|claim_probe': [a, b] },
+      memo: [
+        { entityId: 'knowledge_entity:e1', predicate: 'claim_probe', memberCount: 3 },
+      ],
+    });
+    const out = await svc.run(db as never);
+    expect(out.groupsConsidered).toBe(1);
+    expect(memberFetches).toHaveLength(1);
+  });
+
+  it('stops judging at the hard LLM-call ceiling', async () => {
+    const { svc, judge } = mkCorroborate({
+      DREAMS_CORROBORATE_MAX_LLM_CALLS: '2',
+    });
+    judge.mockResolvedValue('different'); // never applies → old code kept going
+    const mkGroupMembers = (suffix: string): Row[] => [
+      fact({
+        id: `knowledge_fact:a${suffix}`,
+        entityId: `knowledge_entity:${suffix}`,
+        originKey: 'doc:a',
+        object: `value one ${suffix}`,
+      }),
+      fact({
+        id: `knowledge_fact:b${suffix}`,
+        entityId: `knowledge_entity:${suffix}`,
+        originKey: 'doc:b',
+        object: `value two ${suffix}`,
+        recordedAt: '2026-06-02T00:00:00Z',
+      }),
+    ];
+    const groups = ['g1', 'g2', 'g3', 'g4'].map((s) => ({
+      entityId: `knowledge_entity:${s}`,
+      predicate: 'claim_probe',
+      n: 2,
+    }));
+    const membersByGroup = Object.fromEntries(
+      ['g1', 'g2', 'g3', 'g4'].map((s) => [
+        `knowledge_entity:${s}|claim_probe`,
+        mkGroupMembers(s),
+      ]),
+    );
+    const { db } = mkDb({ groups, membersByGroup });
+
+    const out = await svc.run(db as never);
+
+    // Ceiling 2: judges g1 (1 call) and g2 (1 call), then stops — g3/g4
+    // wait for the next run instead of burning the full window.
+    expect(out.llmJudgements).toBe(2);
+    expect(judge).toHaveBeenCalledTimes(2);
+    expect(out.corroborationsApplied).toBe(0);
+  });
+});
+
+describe('CommunityBuilderService signature short-circuit', () => {
+  function mkBuilder() {
+    return new CommunityBuilderService(
+      new ConfigService({ DREAMS_COMMUNITIES_ENABLED: '1' }),
+      { embed: jest.fn() } as never,
+      { generate: jest.fn() } as never,
+    );
+  }
+
+  it('skips the edge load when the live-edge signature is unchanged', async () => {
+    const svc = mkBuilder();
+    const query = jest.fn(async (sql: string) => {
+      if (sql.includes('GROUP ALL')) {
+        return [[{ c: 42, maxAt: '2026-07-01T00:00:00Z' }]];
+      }
+      if (sql.includes('FROM community_build_state')) {
+        return [
+          [
+            {
+              liveEdgeCount: 42,
+              maxEdgeAt: '2026-07-01T00:00:00Z',
+              minSize: 3,
+            },
+          ],
+        ];
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const out = await svc.run({ query } as never);
+
+    expect(out).toEqual({
+      communitiesBuilt: 0,
+      communitiesReused: 0,
+      communitiesRemoved: 0,
+      entitiesClustered: 0,
+    });
+    // Only the two signature queries ran — no edge load, no clustering.
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs the full pass when the stored signature differs', async () => {
+    const svc = mkBuilder();
+    const calls: string[] = [];
+    const query = jest.fn(async (sql: string) => {
+      calls.push(sql);
+      if (sql.includes('GROUP ALL')) {
+        return [[{ c: 42, maxAt: '2026-07-01T00:00:00Z' }]];
+      }
+      if (sql.includes('FROM community_build_state')) {
+        return [[{ liveEdgeCount: 41, maxEdgeAt: '2026-06-30T00:00:00Z', minSize: 3 }]];
+      }
+      if (sql.includes('FROM knowledge_edge')) {
+        return [[]]; // empty graph → removeAllCommunities path
+      }
+      if (sql.includes('community')) {
+        return [[]];
+      }
+      return [[]];
+    });
+
+    await svc.run({ query } as never);
+
+    expect(calls.some((s) => s.includes('FROM knowledge_edge'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Wave P3 of the 2026-07 performance audit — the flag-gated pipelines (dreams, doc-ingest, local inference), fixed **before** their flags are ever enabled. Builds on #176 (P1) and #177 (P2).

## Dreams dedup — O(N²) and a full embedding materialisation

The seed pass selected **every** name-fact embedding into process memory (1536 float64s × N entities — hundreds of MB at scale), then ran one full cosine scan per entity; `maxPairs` capped emitted pairs, not the loop. Now:

- seeds carry ids only — embeddings never leave the DB (each neighbour query resolves its seed vector by fact id with `FROM ONLY`);
- the seed loop is capped newest-first (`DREAMS_DEDUP_MAX_SEEDS`, default 500);
- with `SEARCH_HNSW_ENABLED` the neighbour query rides the KNN operator (same literal-K + overfetch idiom as the search vector leg, scan fallback when the tenant has no index).

## Dreams corroborate — the window that never converged

- **0060 negative-result memo**: the F4 deterministic ordering re-selected the same all-`different` groups every night — once ≥ window-size stuck groups existed, backlog drain hit zero at full LLM spend. Groups judged at an unchanged member count are now excluded before the window is cut; any membership change (including a member turning `corroborating`) re-qualifies the group.
- **Hard LLM ceiling** (`DREAMS_CORROBORATE_MAX_LLM_CALLS`, default 2× the window): `different`/`unsure` never counted toward `maxPairs`, so a non-matching window could burn ~280 judge calls against a nominal cap of 20.
- **Live semaphores** (also in the resolver): judgements now run in parallel under the existing `Semaphore`, applies stay serial — the per-iteration `await` made `DREAMS_*_CONCURRENCY` a no-op.
- `writeEmits`: one `INSERT` for the run's emit rows instead of ~90 serial `CREATE`s.

## Communities — nightly full rebuild for a no-op

**0061 tenant-level short-circuit**: one aggregate probe (live-edge count + newest `createdAt` + the `minSize` knob) skips the edge load and label propagation when the graph hasn't changed. The per-cluster watermark only ever saved the summarize/embed step — the O(E) materialisation (~200+ MB of JS objects at 1M edges) and clustering were paid every night regardless. Fail-open: any probe error runs the full pass.

## Candidate store / document store — batched writes

- chunk staging: one `INSERT INTO candidate $rows` per chunk instead of one `CREATE` per entity/fact/relation (up to ~15k serial round-trips per document across dedicated packs); single-statement staging also makes each chunk atomic;
- `markStatuses`: one `FOR $u IN $updates` statement instead of one `UPDATE` per candidate — these ran while holding the per-doc commit lock;
- `source_chunk`: one `INSERT` per document (was ~43 `CREATE`s at the `DOC_MAX_CHARS` cap).

## Local inference worker lifecycles

- **cross-encoder**: `warmupWorker` terminates the stale worker before spawning a replacement — a score-RPC timeout previously orphaned the old worker (~300 MB model pinned per incident, listener kept the thread alive for the process lifetime); score timeouts now latch `failedUntil` like warmup failures instead of immediately re-spawning against a still-slow host;
- **BGE-M3**: an embed-RPC timeout fails over to OpenAI but nothing ever re-warmed the provider — the wedged worker pinned ~600 MB serving zero traffic. It is now terminated on the failover path.

## memory_diff parse-error fix (carried from #177)

The `entityIds` scoping clause used `IN (SELECT type::record(id) FROM $param AS id)` — `FROM $param AS alias` is not SurrealQL and threw `ValidationError` whenever a caller passed `entityIds`. Both it and the replacement hydration bind `StringRecordId` arrays with `INSIDE` (where-builder idiom).

## Tests

New `test/audit-p3-dreams.unit-spec.ts`: 0060/0061 migration content, memo skip + re-qualify on count change, the hard LLM ceiling, and the community signature short-circuit (skip + full-pass paths). New knobs are catalogued in config-inspector and `.env.example` at introduction time. Full suite: 155 suites / 1087 tests green; full e2e (testcontainers) green on the affected suites; build and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fwi1BYfdDZL4kkvgtakWrC
