### PR TITLE
perf(live): audit wave P4 — nightly refit batching, bounded reads, gauge fixes

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -541,33 +541,43 @@ export class AdminService {
     }> = [];
     for (const companyId of tenants) {
       try {
-        const rows = await this.surreal.withCompany(companyId, async (db) => {
-          const res = (await db.query<any[]>(
-            `SELECT predicateId, piiClass, requiresScope FROM knowledge_predicate
-              WHERE piiClass != 'none'`,
-          )) as any[];
-          return (res[0] ?? []) as any[];
-        });
+        // One connection + two queries per tenant. The old shape opened
+        // a fresh withCompany and ran two GROUP ALL counts PER PII
+        // predicate — 50 tenants × 10 predicates ≈ 1000+ serial round
+        // trips inside one admin HTTP request.
+        const { rows, counts } = await this.surreal.withCompany(
+          companyId,
+          async (db) => {
+            const res = (await db.query<any[]>(
+              `SELECT predicateId, piiClass, requiresScope FROM knowledge_predicate
+                WHERE piiClass != 'none'`,
+            )) as any[];
+            const preds = ((res[0] ?? []) as any[]).map((p) => p.predicateId);
+            if (preds.length === 0) {
+              return { rows: [] as any[], counts: new Map<string, number>() };
+            }
+            const [countRows] = (await db.query<any[]>(
+              `SELECT predicate, status, count() AS c FROM knowledge_fact
+                WHERE predicate INSIDE $preds
+                  AND status INSIDE ['active', 'retracted']
+                GROUP BY predicate, status`,
+              { preds },
+            )) as any[];
+            const counts = new Map<string, number>();
+            for (const r of (countRows as any[]) ?? []) {
+              counts.set(`${r.predicate}|${r.status}`, Number(r.c) || 0);
+            }
+            return { rows: (res[0] ?? []) as any[], counts };
+          },
+        );
         for (const p of rows) {
-          const factCounts = await this.surreal
-            .withCompany(companyId, async (db) => {
-              const res = (await db.query<any[]>(
-                `SELECT count() AS c FROM knowledge_fact
-                  WHERE predicate = $p AND status = 'active' GROUP ALL;
-                 SELECT count() AS c FROM knowledge_fact
-                  WHERE predicate = $p AND status = 'retracted' GROUP ALL;`,
-                { p: p.predicateId },
-              )) as any[];
-              return [countOf(res[0]), countOf(res[1])];
-            })
-            .catch(() => [0, 0]);
           out.push({
             companyId,
             predicate: p.predicateId,
             piiClass: p.piiClass,
             requiresScope: p.requiresScope ?? '',
-            factCount: factCounts[0],
-            retractedCount: factCounts[1],
+            factCount: counts.get(`${p.predicateId}|active`) ?? 0,
+            retractedCount: counts.get(`${p.predicateId}|retracted`) ?? 0,
           });
         }
       } catch (e) {

--- a/src/ai/calibration/calibration-refit-runner.service.ts
+++ b/src/ai/calibration/calibration-refit-runner.service.ts
@@ -162,6 +162,20 @@ export class CalibrationRefitRunnerService {
    * source_trust row stays an in-place UPSERT cache.
    */
   private async refitSourceTrustForTenant(companyId: string): Promise<number> {
+    // Opt-in recency window (CALIBRATION_REFIT_WINDOW_DAYS): bounds both
+    // scans by createdAt/recordedAt instead of relying on the fixed
+    // LIMIT 50000 — on tenants past 50k rows the LIMIT already acts as a
+    // silent sliding window, so an explicit one changes nothing
+    // semantically while letting the (indexed) time predicates cut the
+    // scan. Unset = the pre-existing behaviour, unchanged.
+    const windowDays = parseInt(
+      process.env.CALIBRATION_REFIT_WINDOW_DAYS ?? '0',
+      10,
+    );
+    const since =
+      windowDays > 0
+        ? new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000)
+        : null;
     return this.surreal.withCompany(companyId, async (db) => {
       const [rows] = await db.query<
         [
@@ -186,8 +200,10 @@ export class CalibrationRefitRunnerService {
             recordedAt
           FROM knowledge_fact
           WHERE source.vertical IS NOT NONE
+            ${since ? 'AND recordedAt > $since' : ''}
           ORDER BY recordedAt DESC
           LIMIT 50000;`,
+        since ? { since } : undefined,
       );
       // Retrieval feedback (migration 0054) joins the same win/loss
       // currency: 'helpful' confirms the source, 'incorrect' counts
@@ -220,8 +236,10 @@ export class CalibrationRefitRunnerService {
           FROM retrieval_feedback
           WHERE verdict != 'not_helpful'
             AND factId.source.vertical IS NOT NONE
+            ${since ? 'AND createdAt > $since' : ''}
           ORDER BY createdAt DESC
           LIMIT 50000;`,
+        since ? { since } : undefined,
       );
       const summary = aggregateByScope([
         ...buildTrustEvents(rows ?? []),
@@ -238,74 +256,93 @@ export class CalibrationRefitRunnerService {
         prior.set(scopeKeyOf(r.sourceKey, r.domain ?? null), r.agreementRate);
       }
 
-      let upsertedHere = 0;
-      for (const scope of summary) {
-        if (scope.wins + scope.losses === 0) continue;
-        await this.upsertTrustScope(db, {
-          ...scope,
-          prevRate: prior.get(scopeKeyOf(scope.sourceKey, scope.domain)) ?? null,
+      const scopes = summary
+        .filter((s) => s.wins + s.losses > 0)
+        .map((scope) => {
+          const sampleCount = scope.wins + scope.losses;
+          const rate = scope.wins / sampleCount;
+          const prevRate =
+            prior.get(scopeKeyOf(scope.sourceKey, scope.domain)) ?? null;
+          return {
+            k: scope.sourceKey,
+            // JS null coalesces to NONE inside the FOR body (`?? NONE`),
+            // which option<string> accepts — the old per-scope form had
+            // to omit the field at the bind layer instead.
+            d: scope.domain,
+            r: rate,
+            sc: sampleCount,
+            w: scope.wins,
+            l: scope.losses,
+            ls: scope.lastSeenAt,
+            hist: prevRate === null || Math.abs(prevRate - rate) > 0.01,
+          };
         });
-        upsertedHere++;
-      }
-      return upsertedHere;
+      await this.upsertTrustScopes(db, scopes);
+      return scopes.length;
     });
   }
 
-  /** UPSERT one (sourceKey, domain) trust row + append history when the
-   *  rate moved (or the scope is first seen). `domain: null` = the global
-   *  row; SurrealDB option<> rejects JS null, so the global variant omits
-   *  the field entirely and matches with `domain IS NONE`. */
-  private async upsertTrustScope(
+  /**
+   * UPSERT the (sourceKey, domain) trust rows + append history where the
+   * rate moved (or the scope is first seen), batched into one FOR-loop
+   * statement per chunk. The per-scope form issued 1-2 serial round
+   * trips × (sources × predicates × 2 grains) — ~10k RTTs per tenant per
+   * night on a busy corpus. Side-effect-only FOR body (no cross-iteration
+   * accumulation — the SurrealQL limitation doesn't apply).
+   */
+  private async upsertTrustScopes(
     db: Surreal,
-    scope: TrustScope & { prevRate: number | null },
+    scopes: Array<{
+      k: string;
+      d: string | null;
+      r: number;
+      sc: number;
+      w: number;
+      l: number;
+      ls: unknown;
+      hist: boolean;
+    }>,
   ): Promise<void> {
-    const sampleCount = scope.wins + scope.losses;
-    const rate = scope.wins / sampleCount;
-    const isGlobal = scope.domain === null;
-    const params: Record<string, unknown> = {
-      k: scope.sourceKey,
-      r: rate,
-      sc: sampleCount,
-      w: scope.wins,
-      l: scope.losses,
-      ls: scope.lastSeenAt,
-      ...(isGlobal ? {} : { d: scope.domain }),
-    };
-    const domainWhere = isGlobal ? 'domain IS NONE' : 'domain = $d';
-    await db.query(
-      `LET $existing = (SELECT id FROM source_trust
-          WHERE sourceKey = $k AND ${domainWhere} LIMIT 1)[0];
-       IF $existing IS NONE THEN
-         CREATE source_trust CONTENT {
-           sourceKey: $k,
-           ${isGlobal ? '' : 'domain: $d,'}
-           agreementRate: $r,
-           sampleCount: $sc,
-           winCount: $w,
-           lossCount: $l,
-           lastSeenAt: $ls,
-           lastUpdated: time::now()
-         }
-       ELSE
-         UPDATE $existing.id SET
-           agreementRate = $r,
-           sampleCount = $sc,
-           winCount = $w,
-           lossCount = $l,
-           lastSeenAt = $ls,
-           lastUpdated = time::now()
-       END;`,
-      params,
-    );
-    if (scope.prevRate === null || Math.abs(scope.prevRate - rate) > 0.01) {
+    const CHUNK = 500;
+    for (let i = 0; i < scopes.length; i += CHUNK) {
+      const chunk = scopes.slice(i, i + CHUNK);
       await db.query(
-        `CREATE source_trust_history CONTENT {
-            sourceKey: $k,
-            ${isGlobal ? '' : 'domain: $d,'}
-            agreementRate: $r,
-            sampleCount: $sc
+        `FOR $s IN $scopes {
+           LET $d = $s.d ?? NONE;
+           LET $existing = (SELECT id FROM source_trust
+              WHERE sourceKey = $s.k
+                AND ((domain IS NONE AND $d IS NONE) OR domain = $d)
+              LIMIT 1)[0];
+           IF $existing IS NONE THEN
+             CREATE source_trust CONTENT {
+               sourceKey: $s.k,
+               domain: $d,
+               agreementRate: $s.r,
+               sampleCount: $s.sc,
+               winCount: $s.w,
+               lossCount: $s.l,
+               lastSeenAt: $s.ls,
+               lastUpdated: time::now()
+             }
+           ELSE
+             UPDATE $existing.id SET
+               agreementRate = $s.r,
+               sampleCount = $s.sc,
+               winCount = $s.w,
+               lossCount = $s.l,
+               lastSeenAt = $s.ls,
+               lastUpdated = time::now()
+           END;
+           IF $s.hist THEN
+             CREATE source_trust_history CONTENT {
+               sourceKey: $s.k,
+               domain: $d,
+               agreementRate: $s.r,
+               sampleCount: $s.sc
+             }
+           END;
          };`,
-        params,
+        { scopes: chunk },
       );
     }
   }

--- a/src/artifacts/artifacts.service.ts
+++ b/src/artifacts/artifacts.service.ts
@@ -264,6 +264,10 @@ export class ArtifactsService {
     // (userId != NONE, migration 0055) must never be compiled into a
     // dossier served to the whole tenant. The stored fn predates 0055 and
     // has no scope arg, so we query inline instead of extending it.
+    // LIMIT: compile() consumes a bounded slice of the newest facts, but
+    // this ran unbounded on the artifact read path — a long-lived entity
+    // shipped its entire fact history per cache miss. 500 newest is far
+    // beyond what any template renders.
     const [rows] = await db.query<[any[]]>(
       `SELECT id, predicate, object, confidence, validFrom, validUntil,
               recordedAt, source, status
@@ -271,7 +275,8 @@ export class ArtifactsService {
          WHERE entityId = type::record('knowledge_entity', $rid)
            AND retractedAt IS NONE
            AND userId IS NONE
-         ORDER BY recordedAt DESC`,
+         ORDER BY recordedAt DESC
+         LIMIT 500`,
       { rid },
     );
     return ((rows as any[]) ?? [])

--- a/src/audit/changefeed-consumer.service.ts
+++ b/src/audit/changefeed-consumer.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ApiKeyService } from '../auth/api-key.service';
 import { LeaderLeaseService } from '../jobs/leader-lease.service';
+import { MetricsService } from '../metrics/metrics.service';
 import { ChangefeedDrainService } from './changefeed-drain.service';
 
 /**
@@ -53,10 +54,15 @@ export class ChangefeedConsumerService {
   /** Rough number of completed ticks since process start. */
   private tickCount = 0;
 
+  // Fourth dep is the lag gauge sink — it must be set here (summed over
+  // ALL tenants after the loop), not in the per-tenant drain where it
+  // was last-tenant-wins.
+  // eslint-disable-next-line max-params
   constructor(
     private readonly apiKeys: ApiKeyService,
     private readonly drain: ChangefeedDrainService,
     @Optional() private readonly lease?: LeaderLeaseService,
+    @Optional() private readonly metrics?: MetricsService,
   ) {}
 
   // EVERY_MINUTE keeps lag bounded — see comment above. Operators
@@ -102,6 +108,9 @@ export class ChangefeedConsumerService {
       this.lastPendingRemaining = pendingThisTick;
       this.totalConsumed += consumedThisTick;
       this.tickCount += 1;
+      // Summed across ALL tenants — the drain no longer sets this per
+      // tenant (last-tenant-wins hid every backlog but the final one).
+      this.metrics?.setChangefeedLag(pendingThisTick);
     } finally {
       this.inFlight = false;
     }

--- a/src/audit/changefeed-drain.service.ts
+++ b/src/audit/changefeed-drain.service.ts
@@ -55,10 +55,6 @@ export class ChangefeedDrainService {
       config.get<string>('AUDIT_CHANGEFEED_BATCH', '500'),
       10,
     );
-    const fetchLimit = parseInt(
-      config.get<string>('AUDIT_CHANGEFEED_FETCH_LIMIT', '5000'),
-      10,
-    );
     // Never fetch fewer than we process in a tick, else we'd starve;
     // fall back to a sane default if the env value is garbage (the value
     // is interpolated into the SHOW CHANGES LIMIT clause, so NaN would
@@ -66,8 +62,22 @@ export class ChangefeedDrainService {
     const safeBatch = Number.isFinite(this.perBatchLimit)
       ? this.perBatchLimit
       : 500;
+    // Default fetch = batch + 1: SHOW CHANGES has no offset, so rows
+    // fetched past the batch are re-fetched every tick until the cursor
+    // catches up — the old 5000 default re-shipped up to 4500 rows
+    // (with INCLUDE ORIGINAL pre-images) per source per tick during a
+    // backlog, ~10x wasted transfer to compute a depth number. The +1
+    // keeps "backlog exists" (pendingRemaining > 0) observable;
+    // operators who want true depth raise AUDIT_CHANGEFEED_FETCH_LIMIT.
+    const fetchLimit = parseInt(
+      config.get<string>(
+        'AUDIT_CHANGEFEED_FETCH_LIMIT',
+        String(safeBatch + 1),
+      ),
+      10,
+    );
     this.fetchLimit = Math.max(
-      Number.isFinite(fetchLimit) ? fetchLimit : 5000,
+      Number.isFinite(fetchLimit) ? fetchLimit : safeBatch + 1,
       safeBatch,
     );
   }
@@ -126,7 +136,10 @@ export class ChangefeedDrainService {
       for (const [source, n] of Object.entries(consumed)) {
         this.metrics.countChangefeedConsumed(source, n);
       }
-      this.metrics.setChangefeedLag(pendingRemaining);
+      // NOTE: the lag gauge is set by the consumer AFTER the tenant loop
+      // with the summed value. Setting it here per tenant made the gauge
+      // last-tenant-wins — a backlog on any tenant but the last was
+      // invisible to "sustained non-zero" alerting.
     }
 
     return { consumed, pendingRemaining };

--- a/src/code-memory/code-memory-anchor.service.ts
+++ b/src/code-memory/code-memory-anchor.service.ts
@@ -37,12 +37,16 @@ export class CodeMemoryAnchorService {
     scopes: BrainScope[],
   ): Promise<AnchorRow[]> {
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
+      // Half-open predicate range rides fact_predicate_idx; the previous
+      // string::starts_with defeated the index (full scan + per-row
+      // entityId deref). LIMIT bounds the admin listing.
       const [rows] = await db.query<[any[]]>(
         `SELECT id, entityId, entityId.externalRefs AS refs
            FROM knowledge_fact
-           WHERE string::starts_with(predicate, $prefix)
-             AND retractedAt IS NONE`,
-        { prefix: this.prefix },
+           WHERE predicate >= $prefix AND predicate < $prefixEnd
+             AND retractedAt IS NONE
+           LIMIT 5000`,
+        { prefix: this.prefix, prefixEnd: `${this.prefix}￿` },
       );
       const byAnchor = new Map<string, AnchorRow>();
       for (const r of (rows as any[]) ?? []) {

--- a/src/code-memory/code-memory-search.service.ts
+++ b/src/code-memory/code-memory-search.service.ts
@@ -64,7 +64,7 @@ export class CodeMemorySearchService {
              entityId.externalRefs AS refs,
              vector::similarity::cosine(embedding, $embedding) AS score
            FROM knowledge_fact
-           WHERE string::starts_with(predicate, $prefix)
+           WHERE predicate >= $prefix AND predicate < $prefixEnd
              AND status = 'active'
              AND retractedAt IS NONE
              AND embedding != NONE
@@ -72,7 +72,16 @@ export class CodeMemorySearchService {
              AND (validUntil IS NONE OR validUntil > time::now())
            ORDER BY score DESC
            LIMIT $limit`,
-          { embedding, prefix: this.prefix, limit },
+          {
+            embedding,
+            // Half-open range instead of string::starts_with: a
+            // function-wrapped predicate can't use fact_predicate_idx,
+            // so every recall was a full scan computing cosine per row.
+            // U+FFFF upper-bounds the prefix range.
+            prefix: this.prefix,
+            prefixEnd: `${this.prefix}￿`,
+            limit,
+          },
         );
         // Scope + ABAC row gate — code_memory__* predicates are
         // piiClass none today, but per-key source rules (e.g. deny a

--- a/src/common/debug-trace-core.ts
+++ b/src/common/debug-trace-core.ts
@@ -26,6 +26,10 @@ export interface DebugArtifact {
   name: string;
   ts: number;
   value: unknown;
+  /** Serialized size of `value`, captured at trace time — the ring
+   *  buffer's byte budget sums this instead of re-guessing from shape
+   *  (a keys×64 guess undercounted a 32KB prompt object ~100×). */
+  sizeBytes: number;
 }
 
 export interface DebugContext {
@@ -100,31 +104,42 @@ export async function runWithDebugTrace<T>(fn: () => Promise<T>): Promise<{
 const MAX_ARTIFACT_SIZE = 32 * 1024;
 const MAX_ARTIFACTS_PER_REQUEST = 200;
 
-function safeArtifact(value: unknown): unknown {
-  if (value === undefined || value === null) return value;
+function safeArtifact(value: unknown): { value: unknown; sizeBytes: number } {
+  if (value === undefined || value === null) {
+    return { value, sizeBytes: 8 };
+  }
   try {
     if (typeof value === 'string') {
       return value.length <= MAX_ARTIFACT_SIZE
-        ? value
+        ? { value, sizeBytes: value.length }
         : {
-            __truncated: true,
-            preview: value.slice(0, MAX_ARTIFACT_SIZE),
-            originalSize: value.length,
+            value: {
+              __truncated: true,
+              preview: value.slice(0, MAX_ARTIFACT_SIZE),
+              originalSize: value.length,
+            },
+            sizeBytes: MAX_ARTIFACT_SIZE,
           };
     }
     const json = JSON.stringify(value);
     if (json.length <= MAX_ARTIFACT_SIZE) {
       // Deep-clone via JSON round-trip so later in-place mutations in
       // the producer code don't rewrite the captured artifact.
-      return JSON.parse(json);
+      return { value: JSON.parse(json), sizeBytes: json.length };
     }
     return {
-      __truncated: true,
-      preview: json.slice(0, MAX_ARTIFACT_SIZE),
-      originalSize: json.length,
+      value: {
+        __truncated: true,
+        preview: json.slice(0, MAX_ARTIFACT_SIZE),
+        originalSize: json.length,
+      },
+      sizeBytes: MAX_ARTIFACT_SIZE,
     };
   } catch {
-    return { __unserializable: true, type: typeof value };
+    return {
+      value: { __unserializable: true, type: typeof value },
+      sizeBytes: 64,
+    };
   }
 }
 
@@ -163,11 +178,13 @@ export function traceArtifact(name: string, value: unknown): void {
     ctx.artifactsDropped += 1;
     return;
   }
+  const captured = safeArtifact(value);
   ctx.artifacts.push({
     spanId: spanAls.getStore()?.spanId,
     name,
     ts: Date.now(),
-    value: safeArtifact(value),
+    value: captured.value,
+    sizeBytes: captured.sizeBytes,
   });
 }
 

--- a/src/common/trace-buffer.service.ts
+++ b/src/common/trace-buffer.service.ts
@@ -231,13 +231,20 @@ function estimateSnapshotBytes(s: DebugTraceSnapshot): number {
   const spans = (s.spans?.length ?? 0) * 256;
   let artifactBytes = 0;
   for (const a of s.artifacts ?? []) {
+    // Prefer the serialized size captured at trace time. The old
+    // shape-based guess charged an object artifact `topLevelKeys × 64`
+    // bytes — a 32KB prompt object with 3 keys counted as ~256B, so the
+    // 64MB byte budget effectively never triggered for object-valued
+    // artifacts (the exact scenario it was added to prevent: 100
+    // snapshots × 200 artifacts × 32KB ≈ 640MB).
+    if (typeof a.sizeBytes === 'number' && a.sizeBytes > 0) {
+      artifactBytes += a.sizeBytes;
+      continue;
+    }
     const v = a.value as unknown;
     if (typeof v === 'string') {
       artifactBytes += v.length;
     } else if (v && typeof v === 'object') {
-      // 2 bytes per key+value entry is a wild underestimate, but only
-      // by a constant factor. The 32KB artifact cap upstream is what
-      // really bounds the worst case.
       artifactBytes +=
         Object.keys(v as Record<string, unknown>).length * 64 + 64;
     } else {

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -313,11 +313,16 @@ export class EntitiesService {
       const params: Record<string, unknown> = { rid: ref.id };
       if (since) { clauses.push(`recordedAt >= $since`); params.since = since; }
       if (until) { clauses.push(`recordedAt <= $until`); params.until = until; }
+      // LIMIT 1000: the timeline is the audit surface, but without a cap
+      // a long-lived entity ships its entire history per request. Callers
+      // page with since/until (the window params above); 1000 rows is
+      // ~an order of magnitude beyond what any UI renders at once.
       const [factRows] = await db.query<any[][]>(
         `SELECT ${FACT_TIMELINE_FIELDS}
          FROM knowledge_fact
          WHERE ${clauses.join(' AND ')}
-         ORDER BY recordedAt ASC`,
+         ORDER BY recordedAt ASC
+         LIMIT 1000`,
         params,
       );
       const rowPolicy = makeRowPolicyFilter({

--- a/src/jobs/job-claim.service.ts
+++ b/src/jobs/job-claim.service.ts
@@ -290,10 +290,18 @@ export class JobClaimService {
         };
       });
     } catch (e) {
+      // A thrown query is NOT evidence the claim is lost — that's what
+      // the zero-rows branch above means. Treating a transient DB error
+      // (network blip, pool timeout) as `stillOwned: false` aborted a
+      // multi-minute job whose lease was still ≥2/3 valid; the work was
+      // thrown away, the row waited out the real lease, and the reaper
+      // requeued with attempts+1. Report still-owned: the lease clock
+      // keeps running, and there is at least one more renew tick before
+      // expiry to either succeed or genuinely lose ownership.
       this.logger.warn(
-        `renew(${input.recordId}) failed: ${(e as Error).message}`,
+        `renew(${input.recordId}) failed transiently — assuming still owned: ${(e as Error).message}`,
       );
-      return { stillOwned: false, cancelRequested: false };
+      return { stillOwned: true, cancelRequested: false };
     }
   }
 

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -120,21 +120,25 @@ export class SearchService {
           const seedIds = seeds.map((s) => s.entityId);
 
           const neighbourIds = await fetchOneHopNeighbourIds(db, seedIds);
-          const neighbours =
+          // Neighbour hydration and the facts fetch are independent once
+          // the neighbour ids are known — run them in one round-trip
+          // window instead of serially.
+          const allIds = [...new Set([...seedIds, ...neighbourIds])];
+          const [neighbours, factsByEntity] = await Promise.all([
             neighbourIds.length > 0
-              ? await fetchEntitiesByIds(db, neighbourIds)
-              : [];
+              ? fetchEntitiesByIds(db, neighbourIds)
+              : Promise.resolve([] as Awaited<ReturnType<typeof fetchEntitiesByIds>>),
+            fetchFactsForEntities({
+              db,
+              entityIds: allIds,
+              predicateHints,
+              asOf,
+            }),
+          ]);
 
           const entitiesById = new Map<string, (typeof seeds)[number]>();
           for (const e of seeds) entitiesById.set(e.entityId, e);
           for (const e of neighbours) entitiesById.set(e.entityId, e);
-
-          const factsByEntity = await fetchFactsForEntities({
-            db,
-            entityIds: [...entitiesById.keys()],
-            predicateHints,
-            asOf,
-          });
 
           // Scope + ABAC row filter. Also closes the pre-ABAC gap where
           // graph_retrieve skipped the requiresScope predicate gate that
@@ -153,15 +157,24 @@ export class SearchService {
           rowPolicy.finish();
           const policyCtx = getPolicyContext();
           if (policyCtx) {
+            // ONE applyMetaUnion over all facts instead of one per
+            // entity — the per-entity loop paid a cold-cache origin-meta
+            // fetch (its own withCompany round-trip) per entity, up to
+            // ×N for seeds ∪ neighbours. applyMetaUnion filters without
+            // cloning, so identity-based regrouping is safe.
+            const flatRows = [...factsByEntity.values()].flat();
+            const kept = new Set(
+              await applyMetaUnion({
+                surreal: this.surreal,
+                companyId,
+                ctx: policyCtx,
+                rows: flatRows,
+              }),
+            );
             for (const [entityId, facts] of factsByEntity) {
               factsByEntity.set(
                 entityId,
-                await applyMetaUnion({
-                  surreal: this.surreal,
-                  companyId,
-                  ctx: policyCtx,
-                  rows: facts,
-                }),
+                facts.filter((f) => kept.has(f)),
               );
             }
           }
@@ -305,6 +318,17 @@ export class SearchService {
       langFilter,
     });
 
+    // Router LLM (optional, budgeted) depends ONLY on the query text —
+    // kick it off alongside retrieval instead of awaiting it serially
+    // after merge/meta-union (a cache-miss added its full round-trip to
+    // the critical path). Awaited at stage 3 where its output is first
+    // consumed; .catch keeps a router failure from becoming an
+    // unhandled rejection while retrieval is still in flight (the
+    // router stage degrades to null on its own errors anyway).
+    const routerPromise = this.retrieval
+      .runRouterStage(ctx.dto.query)
+      .catch(() => null);
+
     // 1. Retrieval legs (parallel) + fusion, with cross-lingual backoff.
     const fused = await this.retrieval.runRetrievalStage(db, ctx, baseWhere);
     if (langFilter && fused.length < ctx.candidateK / 2) {
@@ -369,8 +393,9 @@ export class SearchService {
       await enrichWithUsage(db, this.logger, filtered);
     }
 
-    // 3. Predicate / type router (optional LLM call, under budget).
-    const routerOut = await this.retrieval.runRouterStage(ctx.dto.query);
+    // 3. Predicate / type router — launched in parallel with retrieval
+    // above; first consumed here.
+    const routerOut = await routerPromise;
     const predicateDist = routerOut?.predicates ?? null;
     const typeDist = routerOut?.types ?? null;
 

--- a/src/stats/stats.service.ts
+++ b/src/stats/stats.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { SurrealService } from '../db/surreal.service';
+import { LRUCache } from '../common/lru-cache';
 
 export interface MemoryStats {
   entities: number;
@@ -19,6 +20,17 @@ export interface MemoryStats {
  */
 @Injectable()
 export class StatsService {
+  /** 30s per-tenant cache: six COUNT aggregates over the largest tables
+   *  per dashboard page-load is pure waste — counts move slower than
+   *  users refresh. Keyed by tenant only (the counts are not
+   *  scope-dependent; the scoped connection matters for row reads, not
+   *  aggregates over statuses). */
+  private readonly cache = new LRUCache<
+    string,
+    { stats: MemoryStats; at: number }
+  >(500);
+  private static readonly CACHE_TTL_MS = 30_000;
+
   constructor(private readonly surreal: SurrealService) {}
 
   async overview(
@@ -26,6 +38,10 @@ export class StatsService {
     scopes: readonly string[],
   ): Promise<MemoryStats> {
     const nowMs = Date.now();
+    const cached = this.cache.get(companyId);
+    if (cached && nowMs - cached.at < StatsService.CACHE_TTL_MS) {
+      return cached.stats;
+    }
     const weekAgoIso = new Date(nowMs - 7 * 24 * 60 * 60 * 1000).toISOString();
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       const sql = `
@@ -37,7 +53,7 @@ export class StatsService {
         SELECT count() AS c FROM knowledge_fact WHERE recordedAt > type::datetime($weekAgoIso) GROUP ALL;
       `;
       const res = (await db.query<unknown[]>(sql, { weekAgoIso })) as unknown[];
-      return {
+      const stats: MemoryStats = {
         entities: countOf(res[0]),
         factsActive: countOf(res[1]),
         factsCompeting: countOf(res[2]),
@@ -46,6 +62,8 @@ export class StatsService {
         factsLast7d: countOf(res[5]),
         asOf: new Date(nowMs).toISOString(),
       };
+      this.cache.set(companyId, { stats, at: nowMs });
+      return stats;
     });
   }
 }


### PR DESCRIPTION
Wave P4 of the 2026-07 performance audit — the live-surface residuals. Builds on #176/#177/#178.

## Nightly source-trust refit (cron is on by default)

- **Batched scope upserts**: the per-scope form issued 1–2 serial round-trips per (sourceKey × domain × 2 grains) — ~10k RTTs per tenant per night on a busy corpus. Now one `FOR $s IN $scopes` statement per 500-scope chunk, with `null → NONE` normalisation inside the loop (`option<string>` rejects a bound JS null; the old code had to omit the field entirely). Verified against a real SurrealDB container (`nightly-refits`, `faithfulrag-loser-trust` e2e).
- **Opt-in recency window** (`CALIBRATION_REFIT_WINDOW_DAYS`): bounds both 50k scans with the time predicates 0059 indexed. Unset = pre-existing behaviour (on tenants past 50k rows the fixed LIMIT already acted as a silent sliding window).

## Bounded reads on live paths

- `artifacts.fetchActiveFacts`: `LIMIT 500` — previously every fact of the entity shipped per cache miss on the artifact read path.
- entity timeline: `LIMIT 1000` — the audit surface, but unbounded meant a long-lived entity shipped its full history per request; `since`/`until` remain the paging mechanism.
- code-memory `recall_decisions` + anchors listing: half-open predicate range (`>= $prefix AND < $prefix+U+FFFF`) instead of `string::starts_with`, which defeated `fact_predicate_idx` and made every MCP recall a full scan with per-row cosine.
- `/v1/stats/overview`: 30s per-tenant LRU in front of six COUNT aggregates.
- admin PII inventory: one connection + one grouped count per tenant — was 2 queries per PII predicate per tenant, 1000+ serial RTTs inside one admin HTTP request at 50 tenants.

## Changefeed (flag-gated)

- Default fetch = batch + 1: `SHOW CHANGES` has no offset, so rows fetched past the consumed batch were **re-fetched every tick** until the cursor caught up — the 5000 default re-shipped up to 4500 `INCLUDE ORIGINAL` pre-image rows per source per tick during a backlog, ~10× wasted transfer to compute a depth number. `pendingRemaining > 0` (backlog exists) stays observable; operators wanting true depth raise `AUDIT_CHANGEFEED_FETCH_LIMIT`.
- **Lag gauge fix**: `brain_changefeed_lag_records` was set per tenant inside the drain — last-tenant-wins, so a backlog on any tenant but the last was invisible to "sustained non-zero" alerting. The consumer now sets the summed value after the tenant loop.

## Search

- Router LLM (predicate/type distribution) launches alongside retrieval instead of serially after merge/meta-union — on a cache miss its full round-trip sat on the critical path despite depending only on the query text.
- `graph_retrieve`: neighbour hydration and the facts fetch run in parallel; meta-union is ONE call over all facts instead of one per entity (each per-entity call paid its own cold-cache origin-meta round-trip).

## Jobs

`renew()` treated a thrown query as `stillOwned: false` — one transient DB error (network blip, pool timeout) aborted a multi-minute job whose lease was still ≥2/3 valid; the work was discarded, the row waited out the real lease, and the reaper requeued with `attempts+1`. A throw now reports still-owned (the lease clock keeps running and there is at least one more renew tick before expiry); zero-rows remains the genuine lost-ownership signal.

## Trace buffer

Artifacts carry `sizeBytes` from capture time (`safeArtifact` already computed the JSON length and discarded it). The estimator charged object artifacts `topLevelKeys × 64` bytes — a 32KB prompt object with 3 keys counted as ~256B, so the 64MB ring-buffer byte budget effectively never fired for object-valued artifacts (the exact 640MB worst case it was added to prevent).

## Tests

Full unit suite 1087 green; full e2e (testcontainers) green except the pre-existing pack-registry full-run flake (passes 11/11 in isolation); refit e2e exercised the new batched upsert path against real SurrealDB. Build and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fwi1BYfdDZL4kkvgtakWrC
