### PR TITLE
refactor(policy,ai): audit wave P5 — registry-aware row fence, one OpenAI client, parity

### DIFF
--- a/src/admin/admin-jobs.controller.ts
+++ b/src/admin/admin-jobs.controller.ts
@@ -404,7 +404,7 @@ export class AdminJobsController {
     const tenants = this.apiKeys.knownCompanyIds();
     const hostTenant = tenants[0];
     const row = await this.jobs.start({
-      jobType: 'reindex_embeddings', // reuses generic generic-job storage; future: 'scenarios_batch'
+      jobType: 'scenarios_batch',
       companyId: hostTenant,
       triggeredBy: 'manual',
       triggeredByActor: req.brainAuth.companyId,

--- a/src/admin/chat-router-llm.service.ts
+++ b/src/admin/chat-router-llm.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { createOpenAiClientOrThrow } from '../ai/openai-client';
 import { traceArtifact } from '../common/debug-trace';
 import { withGenAiCall } from '../common/gen-ai-observability';
 import { MetricsService } from '../metrics/metrics.service';
@@ -31,15 +32,7 @@ export class ChatRouterLlmService {
     private readonly config: ConfigService,
     @Optional() private readonly metrics?: MetricsService,
   ) {
-    this.openai = new OpenAI({
-      apiKey: this.config.getOrThrow<string>('OPENAI_API_KEY'),
-      // Honour the same OPENAI_TIMEOUT_MS / OPENAI_MAX_RETRIES knobs every
-      // other OpenAI-using service reads — this was the sole outlier
-      // hardcoding 15s/1, so an operator raising the timeout silently
-      // didn't apply to chat routing.
-      timeout: parseInt(this.config.get<string>('OPENAI_TIMEOUT_MS', '30000'), 10),
-      maxRetries: parseInt(this.config.get<string>('OPENAI_MAX_RETRIES', '3'), 10),
-    });
+    this.openai = createOpenAiClientOrThrow(this.config);
     this.model = this.config.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini');
   }
 

--- a/src/ai/embedder.service.ts
+++ b/src/ai/embedder.service.ts
@@ -11,6 +11,7 @@ import { LRUCache } from '../common/lru-cache';
 import { withGenAiCall } from '../common/gen-ai-observability';
 import { MetricsService } from '../metrics/metrics.service';
 import type { EmbedderProvider } from './embedder/embedder-provider.interface';
+import { createOpenAiClientOrThrow } from './openai-client';
 import { OpenAIEmbedderProvider } from './embedder/openai-embedder.provider';
 import { BgeM3EmbedderProvider } from './embedder/bge-m3-embedder.provider';
 import { envFlagEnabled } from '../common/env-validation';
@@ -266,21 +267,13 @@ export class EmbedderService implements OnModuleInit, OnModuleDestroy {
 
   private buildOpenAIProvider(): OpenAIEmbedderProvider {
     return new OpenAIEmbedderProvider({
-      apiKey: this.configService.getOrThrow<string>('OPENAI_API_KEY'),
+      client: createOpenAiClientOrThrow(this.configService),
       model: this.configService.get<string>(
         'OPENAI_EMBEDDING_MODEL',
         'text-embedding-3-small',
       ),
       dimensions: parseInt(
         this.configService.get<string>('OPENAI_EMBEDDING_DIMENSIONS', '1536'),
-        10,
-      ),
-      timeoutMs: parseInt(
-        this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-        10,
-      ),
-      maxRetries: parseInt(
-        this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
         10,
       ),
       concurrency: parseInt(

--- a/src/ai/embedder/openai-embedder.provider.ts
+++ b/src/ai/embedder/openai-embedder.provider.ts
@@ -5,11 +5,10 @@ import { getAbortSignal } from '../../common/request-context';
 import type { EmbedderProvider } from './embedder-provider.interface';
 
 export interface OpenAIEmbedderConfig {
-  apiKey: string;
+  /** Pre-built SDK client (see `createOpenAiClient` in src/ai/openai-client.ts). */
+  client: OpenAI;
   model: string;
   dimensions: number;
-  timeoutMs: number;
-  maxRetries: number;
   concurrency: number;
 }
 
@@ -31,11 +30,7 @@ export class OpenAIEmbedderProvider implements EmbedderProvider {
   private readonly limiter: Semaphore;
 
   constructor(cfg: OpenAIEmbedderConfig) {
-    this.openai = new OpenAI({
-      apiKey: cfg.apiKey,
-      timeout: cfg.timeoutMs,
-      maxRetries: cfg.maxRetries,
-    });
+    this.openai = cfg.client;
     this.model = cfg.model;
     this.dimensions = cfg.dimensions;
     this.providerId = `openai:${cfg.model}:${cfg.dimensions}`;

--- a/src/ai/entity-judge.service.ts
+++ b/src/ai/entity-judge.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Surreal, StringRecordId } from 'surrealdb';
 import OpenAI from 'openai';
+import { createOpenAiClient } from './openai-client';
 import { MetricsService } from '../metrics/metrics.service';
 import { Semaphore } from '../common/semaphore';
 import { withGenAiCall } from '../common/gen-ai-observability';
@@ -37,20 +38,8 @@ export class EntityJudgeService {
     private readonly config: ConfigService,
     @Optional() private readonly metrics?: MetricsService,
   ) {
-    const apiKey = this.config.get<string>('OPENAI_API_KEY');
-    this.openai = apiKey
-      ? new OpenAI({
-          apiKey,
-          timeout: parseInt(
-            this.config.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-            10,
-          ),
-          maxRetries: parseInt(
-            this.config.get<string>('OPENAI_MAX_RETRIES', '3'),
-            10,
-          ),
-        })
-      : (undefined as unknown as OpenAI);
+    this.openai =
+      createOpenAiClient(this.config) ?? (undefined as unknown as OpenAI);
     this.model = this.config.get<string>(
       'ENTITY_JUDGE_MODEL',
       this.config.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),

--- a/src/ai/extractor-llm.service.ts
+++ b/src/ai/extractor-llm.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { createOpenAiClientOrThrow } from './openai-client';
 import { Semaphore } from '../common/semaphore';
 import { withGenAiCall } from '../common/gen-ai-observability';
 import { getAbortSignal } from '../common/request-context';
@@ -36,19 +37,7 @@ export class ExtractorLlmService {
     private readonly configService: ConfigService,
     @Optional() private readonly metrics?: MetricsService,
   ) {
-    const timeoutMs = parseInt(
-      this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-      10,
-    );
-    const maxRetries = parseInt(
-      this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-      10,
-    );
-    this.openai = new OpenAI({
-      apiKey: this.configService.getOrThrow<string>('OPENAI_API_KEY'),
-      timeout: timeoutMs,
-      maxRetries,
-    });
+    this.openai = createOpenAiClientOrThrow(this.configService);
     this.model = this.configService.get<string>(
       'OPENAI_CHAT_MODEL',
       'gpt-4o-mini',

--- a/src/ai/extractor.service.ts
+++ b/src/ai/extractor.service.ts
@@ -31,8 +31,6 @@ export type {
  * One LLM call per ingest (json_schema strict, no hot-path retry);
  * server-side validation drops malformed facts and traces them.
  */
-export const PREDICATE_VOCABULARY = CORE_PREDICATES.map((p) => p.predicateId);
-
 @Injectable()
 export class ExtractorService {
   private readonly logger = new Logger(ExtractorService.name);

--- a/src/ai/hype.service.ts
+++ b/src/ai/hype.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { createOpenAiClient } from './openai-client';
 import { Semaphore } from '../common/semaphore';
 import { EmbedderService } from './embedder.service';
 import { withGenAiCall } from '../common/gen-ai-observability';
@@ -39,20 +40,8 @@ export class HypeService {
   ) {
     this.enabled =
       envFlagEnabled(this.configService.get<string>('SEARCH_HYPE_ENABLED'));
-    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
-    this.openai = apiKey
-      ? new OpenAI({
-          apiKey,
-          timeout: parseInt(
-            this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-            10,
-          ),
-          maxRetries: parseInt(
-            this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-            10,
-          ),
-        })
-      : (undefined as unknown as OpenAI);
+    this.openai =
+      createOpenAiClient(this.configService) ?? (undefined as unknown as OpenAI);
     this.model = this.configService.get<string>(
       'SEARCH_HYPE_MODEL',
       this.configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),

--- a/src/ai/openai-client.ts
+++ b/src/ai/openai-client.ts
@@ -1,0 +1,34 @@
+import { ConfigService } from '@nestjs/config';
+import OpenAI from 'openai';
+
+function buildClient(config: ConfigService, apiKey: string): OpenAI {
+  return new OpenAI({
+    apiKey,
+    timeout: parseInt(config.get<string>('OPENAI_TIMEOUT_MS', '30000'), 10),
+    maxRetries: parseInt(config.get<string>('OPENAI_MAX_RETRIES', '3'), 10),
+  });
+}
+
+/**
+ * The one way to construct an OpenAI SDK client. Every service used to
+ * hand-roll `new OpenAI({...})` with its own copy of the
+ * OPENAI_TIMEOUT_MS / OPENAI_MAX_RETRIES parsing — 13 copies meant an
+ * operator knob change had 13 chances to miss one. Returns null when
+ * OPENAI_API_KEY is unset so feature-gated callers can treat "no key"
+ * as feature-off; callers that REQUIRE the key use the orThrow variant.
+ */
+export function createOpenAiClient(config: ConfigService): OpenAI | null {
+  const apiKey = config.get<string>('OPENAI_API_KEY');
+  if (!apiKey) return null;
+  return buildClient(config, apiKey);
+}
+
+/**
+ * Required-key variant. Reads via `getOrThrow` so a missing key throws
+ * Nest's canonical configuration error at construction time — the exact
+ * behaviour the non-gated services (extractor, synthesize, embedder,
+ * chat router, multi-hop planner) had before the consolidation.
+ */
+export function createOpenAiClientOrThrow(config: ConfigService): OpenAI {
+  return buildClient(config, config.getOrThrow<string>('OPENAI_API_KEY'));
+}

--- a/src/ai/predicate-registry.service.ts
+++ b/src/ai/predicate-registry.service.ts
@@ -274,6 +274,29 @@ export class PredicateRegistryService {
     return seed ?? DEFAULT_FALLBACK;
   }
 
+  /**
+   * Registry-backed predicate-policy lookup for makeRowPolicyFilter.
+   * Warms the tenant snapshot first (TTL-cached, herd-deduped — cheap on
+   * the hot path) and returns a sync resolver that merges the tenant's
+   * registry over the CORE seed. This is what makes an operator-set
+   * requiresScope on a tenant-authored predicate actually fence reads:
+   * the static seed lookup the row filter falls back to only knows
+   * CORE_PREDICATES. Fail-open to the seed on snapshot errors — a
+   * registry outage must not take down every read surface.
+   */
+  async rowPolicyLookup(
+    companyId: string,
+  ): Promise<(predicate: string) => PredicateDefinition> {
+    try {
+      await this.getSnapshot(companyId);
+    } catch (e) {
+      this.logger.warn(
+        `rowPolicyLookup: snapshot load failed for ${companyId} (${(e as Error).message}); using seed policies`,
+      );
+    }
+    return (predicate) => this.policyFor(companyId, predicate);
+  }
+
   /** Invalidate cache for a tenant (called after admin edits). */
   invalidate(companyId: string): void {
     this.cache.delete(companyId);

--- a/src/ai/predicate-router.service.ts
+++ b/src/ai/predicate-router.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { createOpenAiClient } from './openai-client';
 import { Semaphore } from '../common/semaphore';
 import { createHash } from 'node:crypto';
 import { withGenAiCall } from '../common/gen-ai-observability';
@@ -95,20 +96,8 @@ export class PredicateRouterService {
     this.enabled =
       this.configService.get<string>('SEARCH_PREDICATE_ROUTER_ENABLED', '0') ===
       '1';
-    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
-    this.openai = apiKey
-      ? new OpenAI({
-          apiKey,
-          timeout: parseInt(
-            this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-            10,
-          ),
-          maxRetries: parseInt(
-            this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-            10,
-          ),
-        })
-      : (undefined as unknown as OpenAI);
+    this.openai =
+      createOpenAiClient(this.configService) ?? (undefined as unknown as OpenAI);
     this.model = this.configService.get<string>(
       'SEARCH_PREDICATE_ROUTER_MODEL',
       this.configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),

--- a/src/ai/query-expansion.service.ts
+++ b/src/ai/query-expansion.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { createOpenAiClient } from './openai-client';
 import { createHash } from 'node:crypto';
 import { Semaphore } from '../common/semaphore';
 import { withGenAiCall } from '../common/gen-ai-observability';
@@ -40,20 +41,8 @@ export class QueryExpansionService {
     this.enabled =
       this.configService.get<string>('SEARCH_QUERY_EXPANSION_ENABLED', '0') ===
       '1';
-    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
-    this.openai = apiKey
-      ? new OpenAI({
-          apiKey,
-          timeout: parseInt(
-            this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-            10,
-          ),
-          maxRetries: parseInt(
-            this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-            10,
-          ),
-        })
-      : (undefined as unknown as OpenAI);
+    this.openai =
+      createOpenAiClient(this.configService) ?? (undefined as unknown as OpenAI);
     this.model = this.configService.get<string>(
       'SEARCH_QUERY_EXPANSION_MODEL',
       this.configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),

--- a/src/ai/reranker.service.ts
+++ b/src/ai/reranker.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { createOpenAiClient } from './openai-client';
 import { Semaphore } from '../common/semaphore';
 import { withGenAiCall } from '../common/gen-ai-observability';
 import { getAbortSignal } from '../common/request-context';
@@ -49,20 +50,8 @@ export class RerankerService {
   ) {
     this.enabled =
       envFlagEnabled(this.configService.get<string>('SEARCH_RERANKER_ENABLED'));
-    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
-    this.openai = apiKey
-      ? new OpenAI({
-          apiKey,
-          timeout: parseInt(
-            this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-            10,
-          ),
-          maxRetries: parseInt(
-            this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-            10,
-          ),
-        })
-      : (undefined as unknown as OpenAI);
+    this.openai =
+      createOpenAiClient(this.configService) ?? (undefined as unknown as OpenAI);
     this.model = this.configService.get<string>(
       'SEARCH_RERANKER_MODEL',
       this.configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),

--- a/src/code-memory/code-memory-search.service.ts
+++ b/src/code-memory/code-memory-search.service.ts
@@ -1,6 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { SurrealService } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
+import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { BrainScope } from '../auth/api-key.types';
 import { CODE_MEMORY_PACK, codeMemoryKindOf } from '../ai/domain-packs';
 import { makeRowPolicyFilter } from '../policy/row-filter';
@@ -31,6 +32,8 @@ export class CodeMemorySearchService {
   constructor(
     private readonly surreal: SurrealService,
     private readonly embedder: EmbedderService,
+    @Optional()
+    private readonly predicateRegistry?: PredicateRegistryService,
   ) {}
 
   async recall(opts: {
@@ -89,6 +92,9 @@ export class CodeMemorySearchService {
         const rowPolicy = makeRowPolicyFilter({
           callerScopes: opts.scopes,
           surface: 'recall_decisions',
+          policyLookup: await this.predicateRegistry?.rowPolicyLookup(
+            opts.companyId,
+          ),
         });
         const visible = ((rows as any[]) ?? []).filter((r) =>
           rowPolicy.filter(r as { predicate: string }),

--- a/src/diff/memory-diff.service.ts
+++ b/src/diff/memory-diff.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
+import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { makeRowPolicyFilter } from '../policy/row-filter';
 
 /**
@@ -32,7 +33,11 @@ import { makeRowPolicyFilter } from '../policy/row-filter';
 export class MemoryDiffService {
   private readonly logger = new Logger(MemoryDiffService.name);
 
-  constructor(private readonly surreal: SurrealService) {}
+  constructor(
+    private readonly surreal: SurrealService,
+    @Optional()
+    private readonly predicateRegistry?: PredicateRegistryService,
+  ) {}
 
   async diff(
     companyId: string,
@@ -54,11 +59,15 @@ export class MemoryDiffService {
     // test/abac-db-fence.e2e-spec.ts), so the scoped pool alone leaks —
     // the JS filter (requiresScope PII gate + ABAC row rules) is the only
     // working gate. Rows the caller may not see never enter the result.
+    const policyLookup = await this.predicateRegistry?.rowPolicyLookup(
+      companyId,
+    );
     return this.surreal.withScopedCompany(companyId, callerScopes, async (db) => {
       const scoping = buildScoping(args);
       const rowFilter = makeRowPolicyFilter({
         callerScopes,
         surface: 'memory_diff',
+        policyLookup,
       });
 
       // Per-section row cap. The window is caller-controlled (MCP args)

--- a/src/documents/commit-writer.service.ts
+++ b/src/documents/commit-writer.service.ts
@@ -112,27 +112,41 @@ export class CommitWriterService {
         outcomes.push({ fact: mf, factId: null, outcome: null });
         continue;
       }
-      const { result } = await traceSpan(
-        'brain.commit.fact',
-        () =>
-          this.factResolver.resolve(db, {
-            companyId: p.companyId,
-            entityId,
-            predicate: mf.predicate,
-            object: mf.object,
-            confidence: mf.confidence,
-            validFrom: p.doc.occurredAt,
-            source: this.factSource(p.doc, mf),
-            entropy: mf.entropy,
-            precomputedEmbedding: p.embeddings[i],
-          }),
-        { predicate: mf.predicate, entityId },
-      );
-      outcomes.push({
-        fact: mf,
-        factId: result?.factId ? String(result.factId) : null,
-        outcome: result?.outcome ? String(result.outcome) : null,
-      });
+      // Per-fact isolation, mirroring writeRelations: one poison fact
+      // (a value fn::resolve_fact rejects non-retriably) must not fail
+      // the whole commit_document job terminally — that stranded the
+      // already-written half, left every candidate status pending, and
+      // had the sweeper re-arm the same failing commit forever. The
+      // pipeline's own motto: one broken pack must not hold a document's
+      // memory hostage.
+      try {
+        const { result } = await traceSpan(
+          'brain.commit.fact',
+          () =>
+            this.factResolver.resolve(db, {
+              companyId: p.companyId,
+              entityId,
+              predicate: mf.predicate,
+              object: mf.object,
+              confidence: mf.confidence,
+              validFrom: p.doc.occurredAt,
+              source: this.factSource(p.doc, mf),
+              entropy: mf.entropy,
+              precomputedEmbedding: p.embeddings[i],
+            }),
+          { predicate: mf.predicate, entityId },
+        );
+        outcomes.push({
+          fact: mf,
+          factId: result?.factId ? String(result.factId) : null,
+          outcome: result?.outcome ? String(result.outcome) : null,
+        });
+      } catch (err) {
+        this.logger.warn(
+          `[brain.commit.fact] predicate=${mf.predicate} entity=${entityId} failed: ${(err as Error).message}`,
+        );
+        outcomes.push({ fact: mf, factId: null, outcome: 'error' });
+      }
     }
     return outcomes;
   }

--- a/src/dreams/corroborate.service.ts
+++ b/src/dreams/corroborate.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Surreal, StringRecordId } from 'surrealdb';
 import OpenAI from 'openai';
+import { createOpenAiClient } from '../ai/openai-client';
 import { Semaphore } from '../common/semaphore';
 import { withGenAiCall } from '../common/gen-ai-observability';
 import { MetricsService } from '../metrics/metrics.service';
@@ -102,20 +103,8 @@ export class DreamsCorroborateService {
   ) {
     this.enabled =
       envFlagEnabled(this.configService.get<string>('DREAMS_CORROBORATE_ENABLED'));
-    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
-    this.openai = apiKey
-      ? new OpenAI({
-          apiKey,
-          timeout: parseInt(
-            this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-            10,
-          ),
-          maxRetries: parseInt(
-            this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-            10,
-          ),
-        })
-      : (undefined as unknown as OpenAI);
+    this.openai =
+      createOpenAiClient(this.configService) ?? (undefined as unknown as OpenAI);
     this.model = this.configService.get<string>(
       'DREAMS_CORROBORATE_MODEL',
       this.configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),

--- a/src/dreams/llm-summary.generator.ts
+++ b/src/dreams/llm-summary.generator.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { createOpenAiClient } from '../ai/openai-client';
 import { Semaphore } from '../common/semaphore';
 import { withGenAiCall } from '../common/gen-ai-observability';
 import { MetricsService } from '../metrics/metrics.service';
@@ -44,20 +45,8 @@ export class LlmSummaryGenerator implements SummaryGenerator {
   ) {
     this.enabled =
       envFlagEnabled(this.configService.get<string>('DREAMS_LLM_SUMMARY_ENABLED'));
-    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
-    this.openai = apiKey
-      ? new OpenAI({
-          apiKey,
-          timeout: parseInt(
-            this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-            10,
-          ),
-          maxRetries: parseInt(
-            this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-            10,
-          ),
-        })
-      : (undefined as unknown as OpenAI);
+    this.openai =
+      createOpenAiClient(this.configService) ?? (undefined as unknown as OpenAI);
     this.model = this.configService.get<string>(
       'DREAMS_SUMMARY_MODEL',
       this.configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),

--- a/src/dreams/resolver.service.ts
+++ b/src/dreams/resolver.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Surreal, StringRecordId } from 'surrealdb';
 import OpenAI from 'openai';
+import { createOpenAiClient } from '../ai/openai-client';
 import { Semaphore } from '../common/semaphore';
 import { withGenAiCall } from '../common/gen-ai-observability';
 import { MetricsService } from '../metrics/metrics.service';
@@ -75,20 +76,8 @@ export class DreamsResolverService {
   ) {
     this.enabled =
       envFlagEnabled(this.configService.get<string>('DREAMS_RESOLVE_ENABLED'));
-    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
-    this.openai = apiKey
-      ? new OpenAI({
-          apiKey,
-          timeout: parseInt(
-            this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-            10,
-          ),
-          maxRetries: parseInt(
-            this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-            10,
-          ),
-        })
-      : (undefined as unknown as OpenAI);
+    this.openai =
+      createOpenAiClient(this.configService) ?? (undefined as unknown as OpenAI);
     this.model = this.configService.get<string>(
       'DREAMS_RESOLVE_MODEL',
       this.configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException, Optional } from '@nestjs/common';
 import { SurrealService } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
+import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { ForgetEntityDto } from './dto/forget.dto';
 import { BrainScope } from '../auth/api-key.types';
 import { EntityForgetService } from './entity-forget.service';
@@ -104,10 +105,15 @@ export interface ForgetOptions {
 
 @Injectable()
 export class EntitiesService {
+  // Fourth dep is the tenant predicate registry — the row fence must see
+  // operator-authored requiresScope predicates, not only the code seed.
+  // eslint-disable-next-line max-params
   constructor(
     private readonly surreal: SurrealService,
     private readonly forgetService: EntityForgetService,
     @Optional() private readonly metrics?: MetricsService,
+    @Optional()
+    private readonly predicateRegistry?: PredicateRegistryService,
   ) {}
 
   async getProfile({
@@ -157,6 +163,7 @@ export class EntitiesService {
       const rowPolicy = makeRowPolicyFilter({
         callerScopes: scopes,
         surface: 'entity_profile',
+        policyLookup: await this.predicateRegistry?.rowPolicyLookup(companyId),
       });
       const facts = ((factRows as any[]) ?? []).filter((f) =>
         rowPolicy.filter(f),
@@ -328,6 +335,7 @@ export class EntitiesService {
       const rowPolicy = makeRowPolicyFilter({
         callerScopes: scopes,
         surface: 'entity_timeline',
+        policyLookup: await this.predicateRegistry?.rowPolicyLookup(companyId),
       });
       const rows = ((factRows as any[]) ?? []).filter((f) =>
         rowPolicy.filter(f),
@@ -454,6 +462,7 @@ export class EntitiesService {
       const rowPolicy = makeRowPolicyFilter({
         callerScopes: scopes,
         surface: 'entity_connections',
+        policyLookup: await this.predicateRegistry?.rowPolicyLookup(companyId),
       });
       const visibleEdges = edges.filter((edge) =>
         rowPolicy.filter({

--- a/src/entities/entity-read.helpers.ts
+++ b/src/entities/entity-read.helpers.ts
@@ -9,7 +9,7 @@
  * removes the copy-paste of the bitemporal clause set between
  * `getProfile` and `freshnessWatermark`.
  */
-import { policyFor, PREDICATE_POLICIES } from '../ingest/conflict-resolver';
+import { PREDICATE_POLICIES } from '../ingest/conflict-resolver';
 import { BrainScope } from '../auth/api-key.types';
 
 /**
@@ -25,26 +25,16 @@ export function normalizeEntityId(raw: string): { id: string; full: string } {
 }
 
 /**
- * PII scope gate for a single predicate. A fact/edge whose predicate is
- * classed `requiresScope` is visible only to callers holding that scope.
- * Mirrors the DB-level PERMISSIONS fence (migration 0005) for the JS read
- * paths (profile/timeline rows, edge `kind`) where rows are materialised
- * before filtering.
- */
-export function factVisibleToScopes(
-  predicate: string,
-  scopes: BrainScope[],
-): boolean {
-  const policy = policyFor(predicate);
-  return !policy.requiresScope || scopes.includes(policy.requiresScope);
-}
-
-/**
- * DB-side equivalent of {@link factVisibleToScopes} for the watermark
- * probe, which never materialises rows: the set of known predicates the
- * caller may NOT see, pushed into a `predicate NOT IN $blocked` clause.
- * Derived from the same policy table so the two gates stay in lockstep —
- * a predicate is blocked here iff it is invisible there.
+ * DB-side equivalent of the row filter's predicate scope gate
+ * (makeRowPolicyFilter) for the watermark probe, which never
+ * materialises rows: the set of known predicates the caller may NOT
+ * see, pushed into a `predicate NOT IN $blocked` clause. Derived from
+ * the same seed policy table so the two gates stay in lockstep for
+ * CORE predicates — a predicate is blocked here iff it is invisible
+ * there. Known limitation: tenant-authored registry predicates with
+ * requiresScope are not in this static list, so they influence the
+ * watermark timestamps (never row content — the row surfaces apply the
+ * registry-aware filter).
  */
 export function blockedPredicates(scopes: BrainScope[]): string[] {
   return Object.entries(PREDICATE_POLICIES)

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -2,6 +2,7 @@ import { ForbiddenException, Injectable, Logger, NotFoundException, Optional } f
 import { Surreal } from 'surrealdb';
 import { SurrealService, dbMerge } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
+import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { RetractFactDto } from './dto/retract.dto';
 import { BrainScope } from '../auth/api-key.types';
 import {
@@ -95,6 +96,8 @@ export class FactsService {
   constructor(
     private readonly surreal: SurrealService,
     @Optional() private readonly metrics?: MetricsService,
+    @Optional()
+    private readonly predicateRegistry?: PredicateRegistryService,
   ) {}
 
   async retract({
@@ -348,6 +351,7 @@ export class FactsService {
       const rowPolicy = makeRowPolicyFilter({
         callerScopes: opts.callerScopes ?? [],
         surface: 'competing_facts',
+        policyLookup: await this.predicateRegistry?.rowPolicyLookup(companyId),
       });
       const visible = (((rows as any[]) ?? []) as PolicyFilterableRow[]).filter(
         (r) => rowPolicy.filter(r),

--- a/src/ingest/ingest-predictor.service.ts
+++ b/src/ingest/ingest-predictor.service.ts
@@ -95,6 +95,7 @@ export class IngestPredictionService {
     const rowFilter = makeRowPolicyFilter({
       callerScopes,
       surface: 'detect_contradiction',
+      policyLookup: await this.predicateRegistry.rowPolicyLookup(companyId),
     });
     try {
       const entityId = await this.lookupEntity(db, args.entityRef);

--- a/src/jobs/job-run.service.ts
+++ b/src/jobs/job-run.service.ts
@@ -16,22 +16,8 @@ export type JobType =
   | 'index_document'
   | 'commit_document'
   | 'candidate_sweeper'
-  | 'reindex_documents';
-
-/** Stable list of registered job types — used for iteration without
- *  duplicating the union elsewhere. */
-export const JOB_TYPES: readonly JobType[] = [
-  'dreams',
-  'compaction',
-  'calibration_refit',
-  'source_trust_refit',
-  'reindex_embeddings',
-  'changefeed_drain',
-  'index_document',
-  'commit_document',
-  'candidate_sweeper',
-  'reindex_documents',
-];
+  | 'reindex_documents'
+  | 'scenarios_batch';
 
 export type JobStatus =
   | 'pending'

--- a/src/mcp/read-tools.ts
+++ b/src/mcp/read-tools.ts
@@ -120,7 +120,7 @@ function registerSearchTools({
         embedderHint,
       inputSchema: {
         query: z.string().describe('Natural-language query'),
-        limit: z.number().int().min(1).max(50).optional().describe('Max results (default 10)'),
+        limit: z.number().int().min(1).max(100).optional().describe('Max results (default 10)'),
         predicates: z.array(z.string()).optional().describe('Filter to these predicates only'),
         asOf: z.string().datetime().optional().describe('Knowledge as-of this ISO 8601 moment'),
         minConfidence: z.number().min(0).max(1).optional(),
@@ -182,7 +182,7 @@ function registerSearchTools({
           .array(z.string())
           .optional()
           .describe('Filter to these predicates only'),
-        limit: z.number().int().min(1).max(50).optional(),
+        limit: z.number().int().min(1).max(100).optional(),
         userId: z
           .string()
           .max(200)
@@ -228,7 +228,7 @@ function registerSearchTools({
         embedderHint,
       inputSchema: {
         query: z.string().describe('Natural-language question'),
-        limit: z.number().int().min(1).max(50).optional().describe(
+        limit: z.number().int().min(1).max(100).optional().describe(
           'Top-K facts fed to the generator (default 10)',
         ),
         predicates: z.array(z.string()).optional(),
@@ -520,6 +520,13 @@ function registerEntityReadTools({
       inputSchema: {
         entityId: z.string(),
         kind: z.string().optional().describe('Edge kind filter (e.g. "paid_for", "mentioned_in")'),
+        asOf: z
+          .string()
+          .datetime()
+          .optional()
+          .describe(
+            'Bitemporal edge cutoff — connections as they were believed at this ISO 8601 moment (mirrors GET /v1/entities/:id/connections?asOf=)',
+          ),
       },
     },
     async (args) => {
@@ -531,6 +538,7 @@ function registerEntityReadTools({
         entityIdRaw: args.entityId,
         kind: args.kind,
         scopes,
+        asOf: args.asOf,
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],

--- a/src/mcp/write-tools.ts
+++ b/src/mcp/write-tools.ts
@@ -152,6 +152,15 @@ export function registerWriteTools({
       inputSchema: {
         factId: z.string(),
         reason: z.string(),
+        retractedBy: z
+          .object({
+            userId: z.string().max(200).optional(),
+            source: z.enum(['human', 'system']),
+          })
+          .optional()
+          .describe(
+            "Who initiated the retraction — mirrors the REST RetractFactDto. Omit for the pre-existing default ({source: 'system'}); pass {source: 'human', userId} when relaying an operator/user decision so the audit trail records the real initiator",
+          ),
       },
     },
     async (args) => {
@@ -165,7 +174,7 @@ export function registerWriteTools({
         factId: args.factId,
         dto: {
           reason: args.reason,
-          retractedBy: { source: 'system' },
+          retractedBy: args.retractedBy ?? { source: 'system' },
         },
         callerScopes: scopes,
       });

--- a/src/multi-hop/multi-hop-planner.service.ts
+++ b/src/multi-hop/multi-hop-planner.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { createOpenAiClientOrThrow } from '../ai/openai-client';
 import { Semaphore } from '../common/semaphore';
 import { clampLlmInputText } from '../common/input-limits';
 import { withGenAiCall } from '../common/gen-ai-observability';
@@ -114,17 +115,7 @@ export class MultiHopPlannerService {
     private readonly configService: ConfigService,
     @Optional() private readonly metrics?: MetricsService,
   ) {
-    this.openai = new OpenAI({
-      apiKey: this.configService.getOrThrow<string>('OPENAI_API_KEY'),
-      timeout: parseInt(
-        this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-        10,
-      ),
-      maxRetries: parseInt(
-        this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-        10,
-      ),
-    });
+    this.openai = createOpenAiClientOrThrow(this.configService);
     this.model = this.configService.get<string>(
       'MULTI_HOP_PLANNER_MODEL',
       this.configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),

--- a/src/policy/row-filter.ts
+++ b/src/policy/row-filter.ts
@@ -65,6 +65,17 @@ export interface RowPolicyFilter {
   readonly active: boolean;
 }
 
+/**
+ * Predicate → policy resolution for the scope gate + PII classing.
+ * The registry-backed lookup (PredicateRegistryService.policyFor,
+ * partially applied with the tenant) sees operator-authored per-tenant
+ * predicates; the static seed fallback only knows CORE_PREDICATES.
+ */
+export type PredicatePolicyLookup = (predicate: string) => {
+  requiresScope?: string;
+  piiClass: string;
+};
+
 export function makeRowPolicyFilter(opts: {
   callerScopes: readonly string[];
   surface: string;
@@ -73,9 +84,18 @@ export function makeRowPolicyFilter(opts: {
    * context; pass null to force policy-off while keeping the scope gate.
    */
   policy?: PolicyContext | null;
+  /**
+   * Tenant-aware predicate policy source. Callers on request paths pass
+   * the registry-backed lookup so an operator-set requiresScope on a
+   * tenant predicate actually fences reads; without it the gate only
+   * sees the static code-side seed (the pre-registry behaviour, kept as
+   * the fallback for callers with no tenant in hand).
+   */
+  policyLookup?: PredicatePolicyLookup;
 }): RowPolicyFilter {
   const ctx = opts.policy !== undefined ? opts.policy : getPolicyContext();
   const scopes = opts.callerScopes;
+  const lookup: PredicatePolicyLookup = opts.policyLookup ?? policyFor;
 
   type SetStats = RowDecisionSummary['perSet'][number];
   const perSet = new Map<string, SetStats>();
@@ -83,7 +103,7 @@ export function makeRowPolicyFilter(opts: {
   let evalNs = 0n;
 
   const filter = (row: PolicyFilterableRow): boolean => {
-    const predicatePolicy = policyFor(row.predicate);
+    const predicatePolicy = lookup(row.predicate);
     if (
       predicatePolicy.requiresScope &&
       !scopes.includes(predicatePolicy.requiresScope)
@@ -93,7 +113,7 @@ export function makeRowPolicyFilter(opts: {
     if (!ctx) return true;
 
     const t0 = process.hrtime.bigint();
-    const view = toRowView(row, (p) => policyFor(p).piiClass);
+    const view = toRowView(row, (p) => lookup(p).piiClass);
     const evaluation = evaluateRow(ctx, view);
     evalNs += process.hrtime.bigint() - t0;
     total += 1;

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Surreal } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
+import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { detectLanguage } from '../ai/locale/language-detector';
 import { SearchDto, SearchMode } from './dto/search.dto';
 import { withSpan } from '../common/tracing';
@@ -16,7 +17,10 @@ import {
 } from './internals/stage-budget';
 import { buildBaseWhere } from './internals/where-builder';
 import { hydrateSurvivors, reattributeMerged } from './internals/identity-merge';
-import { makeRowPolicyFilter } from '../policy/row-filter';
+import {
+  makeRowPolicyFilter,
+  type PredicatePolicyLookup,
+} from '../policy/row-filter';
 import { applyMetaUnion } from '../policy/meta-union';
 import { getPolicyContext } from '../common/request-context';
 import { expandEntityIdsViaEdges as expandEntityIdsViaEdgesDb } from './internals/neighbours';
@@ -64,11 +68,28 @@ export class SearchService {
   private readonly logger = new Logger(SearchService.name);
   private readonly budgets: StageBudgets = resolveStageBudgets();
 
+  // Fourth dep is the tenant predicate registry — the row fence must see
+  // operator-authored requiresScope predicates, not only the code seed.
+  // eslint-disable-next-line max-params
   constructor(
     private readonly surreal: SurrealService,
     private readonly retrieval: SearchRetrievalService,
     private readonly rerank: SearchRerankService,
+    @Optional() private readonly predicateRegistry?: PredicateRegistryService,
   ) {}
+
+  /**
+   * Registry-backed predicate-policy lookup for the row fence; falls
+   * back to the static seed when the registry isn't wired (unit tests
+   * construct SearchService positionally).
+   */
+  private async policyLookupFor(
+    companyId: string,
+  ): Promise<PredicatePolicyLookup | undefined> {
+    return this.predicateRegistry
+      ? this.predicateRegistry.rowPolicyLookup(companyId)
+      : undefined;
+  }
 
   /** Pure helper — kept exposed for unit testing. Delegates to the
    *  rerank-skip module so the orchestrator owns no math. */
@@ -147,6 +168,7 @@ export class SearchService {
           const rowPolicy = makeRowPolicyFilter({
             callerScopes,
             surface: 'graph_retrieve',
+            policyLookup: await this.policyLookupFor(companyId),
           });
           for (const [entityId, facts] of factsByEntity) {
             factsByEntity.set(
@@ -366,6 +388,7 @@ export class SearchService {
     const rowPolicy = makeRowPolicyFilter({
       callerScopes: ctx.callerScopes,
       surface: 'search',
+      policyLookup: await this.policyLookupFor(ctx.companyId),
     });
     const rowFilterFn = (row: FactRow) => rowPolicy.filter(row);
     const survivorRecords = await hydrateSurvivors(db, fused);

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { createOpenAiClientOrThrow } from '../ai/openai-client';
 import { SearchService, SearchHit } from '../search/search.service';
 import { Semaphore } from '../common/semaphore';
 import { withSpan } from '../common/tracing';
@@ -123,17 +124,7 @@ export class SynthesizeService {
     private readonly configService: ConfigService,
     @Optional() private readonly metrics?: MetricsService,
   ) {
-    this.openai = new OpenAI({
-      apiKey: this.configService.getOrThrow<string>('OPENAI_API_KEY'),
-      timeout: parseInt(
-        this.configService.get<string>('OPENAI_TIMEOUT_MS', '30000'),
-        10,
-      ),
-      maxRetries: parseInt(
-        this.configService.get<string>('OPENAI_MAX_RETRIES', '3'),
-        10,
-      ),
-    });
+    this.openai = createOpenAiClientOrThrow(this.configService);
     this.defaultModel = this.configService.get<string>(
       'SYNTHESIZE_MODEL',
       this.configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),

--- a/test/entity-read-helpers.unit-spec.ts
+++ b/test/entity-read-helpers.unit-spec.ts
@@ -1,13 +1,26 @@
 import {
   normalizeEntityId,
-  factVisibleToScopes,
   blockedPredicates,
   activeFactWhere,
 } from '../src/entities/entity-read.helpers';
+import { makeRowPolicyFilter } from '../src/policy/row-filter';
 import { PREDICATE_POLICIES } from '../src/ingest/conflict-resolver';
 import { BrainScope } from '../src/auth/api-key.types';
 
 const PII: BrainScope = 'brain:read_pii';
+
+/** The JS row gate as every read surface applies it (seed lookup,
+ *  policy forced off so only the predicate scope gate runs). */
+function gateAllows(predicate: string, scopes: BrainScope[]): boolean {
+  const f = makeRowPolicyFilter({
+    callerScopes: scopes,
+    surface: 'entity-read-helpers-spec',
+    policy: null,
+  });
+  const ok = f.filter({ predicate });
+  f.finish();
+  return ok;
+}
 
 describe('normalizeEntityId', () => {
   it('strips a knowledge_entity: prefix into bare id + full form', () => {
@@ -38,26 +51,26 @@ describe('normalizeEntityId', () => {
   });
 });
 
-describe('factVisibleToScopes', () => {
+describe('row-filter predicate scope gate', () => {
   // 'dob' / 'address' are seeded as requiresScope: 'brain:read_pii';
   // 'name' / 'said' are non-PII; an unknown predicate falls to DEFAULT_POLICY.
   it('hides a PII-classed predicate from a caller without the scope', () => {
-    expect(factVisibleToScopes('dob', [])).toBe(false);
-    expect(factVisibleToScopes('address', [])).toBe(false);
+    expect(gateAllows('dob', [])).toBe(false);
+    expect(gateAllows('address', [])).toBe(false);
   });
 
   it('reveals a PII-classed predicate to a caller holding the scope', () => {
-    expect(factVisibleToScopes('dob', [PII])).toBe(true);
-    expect(factVisibleToScopes('address', [PII])).toBe(true);
+    expect(gateAllows('dob', [PII])).toBe(true);
+    expect(gateAllows('address', [PII])).toBe(true);
   });
 
   it('always reveals a non-PII predicate regardless of scopes', () => {
-    expect(factVisibleToScopes('name', [])).toBe(true);
-    expect(factVisibleToScopes('said', [])).toBe(true);
+    expect(gateAllows('name', [])).toBe(true);
+    expect(gateAllows('said', [])).toBe(true);
   });
 
   it('reveals an unknown predicate (DEFAULT_POLICY has no required scope)', () => {
-    expect(factVisibleToScopes('zzz_not_a_real_predicate', [])).toBe(true);
+    expect(gateAllows('zzz_not_a_real_predicate', [])).toBe(true);
   });
 });
 
@@ -72,16 +85,14 @@ describe('blockedPredicates', () => {
     expect(blockedPredicates([PII])).toEqual([]);
   });
 
-  it('stays in lockstep with factVisibleToScopes for every known predicate', () => {
+  it('stays in lockstep with the row-filter scope gate for every known predicate', () => {
     // A predicate is in the DB-side blocklist iff the JS-side row filter
     // would hide it — the two gates must never disagree, or a low-scope
     // caller could move a watermark on a fact it cannot read.
     for (const scopes of [[] as BrainScope[], [PII]]) {
       const blocked = new Set(blockedPredicates(scopes));
       for (const predicate of Object.keys(PREDICATE_POLICIES)) {
-        expect(blocked.has(predicate)).toBe(
-          !factVisibleToScopes(predicate, scopes),
-        );
+        expect(blocked.has(predicate)).toBe(!gateAllows(predicate, scopes));
       }
     }
   });


### PR DESCRIPTION
Wave P5 of the 2026-07 audit — the code-quality residuals. Builds on #176–#179. Closes the audit's remaining HIGH: the two-sources-of-predicate-policy hole.

## Registry-aware row fence (the audit's top remaining item)

`makeRowPolicyFilter` — the row-level enforcement seam shared by every read surface — resolved predicate policy through the **static code-side seed** (`CORE_PREDICATES`). The predicate registry's per-tenant policies, including an operator-set `requiresScope`, were invisible to it: a tenant-authored PII predicate fenced in the registry was **not fenced on any read**. Same latent class as the "phantom fence" from the 2026-07-11 functional audit.

- `makeRowPolicyFilter` gains an optional `policyLookup`; the default stays the seed (callers with no tenant in hand, unit fixtures).
- `PredicateRegistryService.rowPolicyLookup(companyId)` warms the TTL-cached, herd-deduped snapshot and returns a sync registry-over-seed resolver (fail-open to the seed on registry outage — a registry blip must not take down every read surface).
- Threaded through: search pipeline, `graph_retrieve`, `memory_diff`, `detect_contradiction`, `get_competing_facts`, entity profile / timeline / connections, code-memory `recall_decisions`.
- Deliberately NOT threaded: artifacts and community summaries — their predicates are fixed CORE template fields, and the builder has no tenant key in scope. The watermark probe's `blockedPredicates` pushdown also stays seed-based (documented limitation: registry predicates can influence watermark *timestamps*, never row content).

## One OpenAI client

`new OpenAI({...})` with its own copy of the `OPENAI_TIMEOUT_MS` / `OPENAI_MAX_RETRIES` parsing existed in **13 files** — an operator knob change had 13 chances to miss one (and had: chat-router hardcoded 15s/1 until recently). Now one `createOpenAiClient` / `createOpenAiClientOrThrow` pair in `src/ai/openai-client.ts`; the feature-gated services keep their exact `?? (undefined as unknown as OpenAI)` availability semantics, the throwing callers keep `getOrThrow` semantics, and the embedder provider takes a pre-built client. Timeout/retry defaults unchanged.

## Dead code

- `JOB_TYPES` (job-run.service) — its comment claimed "used for iteration"; nothing ever iterated it.
- `PREDICATE_VOCABULARY` (extractor.service) — zero consumers.
- `factVisibleToScopes` (entity-read.helpers) — production-dead: every read path goes through `makeRowPolicyFilter`, which re-implements the same gate. The `blockedPredicates` lockstep test now asserts against the row filter directly, so the "DB pushdown agrees with the JS gate" invariant is still pinned — against the gate that actually runs.

## MCP ↔ REST parity

- `search_knowledge` / `search_multi_hop` / `synthesize` limit caps 50 → 100, matching `SearchDto`'s `@Max(100)` (post-F1 the service honours it; the two transports returned different maxima).
- `find_related_entities` gains `asOf` — REST `GET /v1/entities/:id/connections?asOf=` had it, and every other MCP read tool exposes it.
- `retract_fact` accepts optional `retractedBy` mirroring REST's `RetractFactDto` (default keeps the pre-existing `{source: 'system'}`) — an operator-relayed retraction can now record the real initiator in the audit trail.
- `scenarios_batch` becomes a real `JobType` — batch scenario runs no longer masquerade as `reindex_embeddings` in `/admin/jobs` listings and filters.

## commit_document poison-fact isolation

`writeFacts` had no per-fact error isolation (the relations loop did): one fact `fn::resolve_fact` rejects non-retriably failed the whole `commit_document` job → 3 attempts → terminal, stranding the already-written half and leaving every candidate `pending` for the sweeper to re-arm against the same failure forever. Each fact now maps its own failure to candidate status `resolver_rejected`, matching the pipeline's stated design ("one broken pack must not hold a document's memory hostage").

## Tests

Full unit suite 1087 green; **full e2e 73/73 suites green** (including the usually-flaky registry suite); build and lint clean. The lockstep spec was retargeted rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fwi1BYfdDZL4kkvgtakWrC
