### PR TITLE
perf(admin): move NLI intent classifier to a worker thread

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,21 @@ SEARCH_RERANKER_SC_N=1
 # SEARCH_CROSS_ENCODER_LOCAL_WINDOW=20   # documents the local path reranks (Cohere uses _WINDOW=50)
 # SEARCH_CROSS_ENCODER_LOCAL_WORKER=1    # 0 = in-thread (benchmarks/constrained envs)
 
+# ── Chat-route NLI intent classifier ─────────────────────────────────────
+# Zero-shot NLI model (~135MB ONNX via @xenova/transformers) that classifies
+# chat messages as ask/tell on the router's local pre-pass. On by default;
+# until the model warms up, the router uses the punctuation-only heuristic.
+# CHAT_ROUTE_NLI_ENABLED=true
+# CHAT_ROUTE_NLI_MODEL=Xenova/distilbert-base-multilingual-cased-finetuned-mnli
+# CHAT_ROUTE_NLI_ASK_THRESHOLD=0.6
+#
+# Inference runs in a dedicated worker_thread so the ~100-200ms ONNX pass never
+# blocks the event loop (set TRANSFORMERS_CACHE so the model caches across
+# restarts). If a classify RPC exceeds the deadline, the router keeps the
+# punctuation fallback and the classifier latches off for 5 minutes.
+# CHAT_ROUTE_NLI_WORKER=1        # 0 = in-thread (benchmarks/constrained envs)
+# CHAT_ROUTE_NLI_TIMEOUT_MS=3000 # per-call deadline for the worker RPC
+
 # ── Predicate-class + type-aware query router (optional) ─────────────────
 # Single LLM call classifies the query into TWO joint distributions:
 #   - predicate-class (`name`, `tier`, `complained_about`, `intent`, ...)

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -337,8 +337,11 @@ export class ConfigInspectorService {
       {
         key: 'CHAT_ROUTE_NLI_ENABLED',
         category: 'router',
-        defaultValue: '0',
-        runtimeMutable: true,
+        // Code default is ON (`get('CHAT_ROUTE_NLI_ENABLED', 'true') !==
+        // 'false'` in IntentClassifierService) and captured in the
+        // constructor — the previous '0'/runtime-mutable entry was drift.
+        defaultValue: '1',
+        runtimeMutable: false,
         isBooleanFlag: true,
       },
       {
@@ -347,6 +350,24 @@ export class ConfigInspectorService {
         defaultValue: '0.6',
         runtimeMutable: false,
         isBooleanFlag: false,
+      },
+      {
+        key: 'CHAT_ROUTE_NLI_WORKER',
+        category: 'router',
+        defaultValue: '1',
+        runtimeMutable: false,
+        isBooleanFlag: true,
+        description:
+          'Run NLI intent inference in a dedicated worker_thread so the ~100-200ms ONNX pass never blocks the event loop. 0 = in-thread (benchmarks/constrained envs).',
+      },
+      {
+        key: 'CHAT_ROUTE_NLI_TIMEOUT_MS',
+        category: 'router',
+        defaultValue: '3000',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Per-call deadline for the NLI worker RPC. On timeout the router keeps the punctuation fallback and the classifier latches off for 5 minutes.',
       },
       // ── Search ────────────────────────────────────────────
       {

--- a/src/admin/intent-classifier.service.ts
+++ b/src/admin/intent-classifier.service.ts
@@ -1,6 +1,15 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnApplicationShutdown,
+  OnModuleInit,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Worker } from 'node:worker_threads';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { LRUCache } from '../common/lru-cache';
+import { envFlagEnabled } from '../common/env-validation';
 
 /**
  * Zero-shot intent classifier — multilingual NLI without enumerated
@@ -17,6 +26,18 @@ import { LRUCache } from '../common/lru-cache';
  *     the confidence.
  *   • Results are LRU-cached on the trimmed message text — repeat
  *     queries are free.
+ *
+ * Runtime: a dedicated `worker_thread` owns the model (default), so ONNX
+ * inference never blocks the main event loop — an in-thread pass froze
+ * every other tenant's request for ~100-200ms per cache-missed message.
+ * `CHAT_ROUTE_NLI_WORKER=0` keeps the original in-thread path for unit
+ * tests and single-threaded benchmarks (same split as the cross-encoder
+ * reranker, src/ai/cross-encoder/local-cross-encoder.provider.ts). Every
+ * worker failure mode — spawn failure, warmup failure, RPC timeout,
+ * crash — degrades to the punctuation fallback, i.e. exactly the
+ * pre-warmup behavior, and latches for FAIL_RETRY_MS before re-warming.
+ * The LRU cache stays on the main thread, so repeat queries never pay
+ * the RPC hop.
  *
  * Model choice: `Xenova/distilbert-base-multilingual-cased-finetuned-mnli`
  * (~135MB ONNX). XNLI-finetuned distilbert, 100+ languages including
@@ -50,18 +71,38 @@ export interface IntentResult {
 const CACHE_SIZE = 2000;
 const DEFAULT_MODEL =
   'Xenova/distilbert-base-multilingual-cased-finetuned-mnli';
+const NLI_LABELS = ['question', 'statement'];
+const HYPOTHESIS_TEMPLATE = 'This text is a {}.';
+const WORKER_WARMUP_TIMEOUT_MS = 120_000;
+const DEFAULT_CLASSIFY_TIMEOUT_MS = 3_000;
+const FAIL_RETRY_MS = 5 * 60_000;
 
 @Injectable()
-export class IntentClassifierService implements OnModuleInit {
+export class IntentClassifierService
+  implements OnModuleInit, OnApplicationShutdown
+{
   private readonly logger = new Logger(IntentClassifierService.name);
   private readonly modelId: string;
   private readonly enabled: boolean;
   private readonly askThreshold: number;
+  private readonly useWorker: boolean;
+  private readonly classifyTimeoutMs: number;
   private classifier: ZeroShotPipeline | null = null;
   private readonly cache = new LRUCache<
     string,
     { intent: 'ask' | 'tell'; confidence: number }
   >(CACHE_SIZE);
+
+  // Worker runtime (mirrors LocalCrossEncoderProvider)
+  private worker: Worker | null = null;
+  private workerReady = false;
+  private nextReqId = 1;
+  private readonly pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  private warmupPromise: Promise<void> | null = null;
+  private failedUntil = 0;
 
   constructor(private readonly config: ConfigService) {
     this.enabled =
@@ -73,6 +114,17 @@ export class IntentClassifierService implements OnModuleInit {
     this.askThreshold = parseFloat(
       this.config.get<string>('CHAT_ROUTE_NLI_ASK_THRESHOLD', '0.6'),
     );
+    this.useWorker = envFlagEnabled(
+      this.config.get<string>('CHAT_ROUTE_NLI_WORKER', '1'),
+    );
+    this.classifyTimeoutMs =
+      parseInt(
+        this.config.get<string>(
+          'CHAT_ROUTE_NLI_TIMEOUT_MS',
+          String(DEFAULT_CLASSIFY_TIMEOUT_MS),
+        ),
+        10,
+      ) || DEFAULT_CLASSIFY_TIMEOUT_MS;
   }
 
   onModuleInit(): void {
@@ -87,8 +139,23 @@ export class IntentClassifierService implements OnModuleInit {
     void this.warmup();
   }
 
+  /**
+   * Terminate the inference worker thread. A worker_threads.Worker keeps
+   * the event loop alive until terminated, so app teardown must call this
+   * (same contract as LocalCrossEncoderProvider.terminate()). Idempotent.
+   */
+  async onApplicationShutdown(): Promise<void> {
+    const w = this.worker;
+    this.worker = null;
+    this.workerReady = false;
+    if (w) {
+      this.failAllPending(new Error('worker terminated on shutdown'));
+      await w.terminate().catch(() => undefined);
+    }
+  }
+
   isReady(): boolean {
-    return this.classifier !== null;
+    return this.classifier !== null || this.workerReady;
   }
 
   stats(): {
@@ -100,7 +167,7 @@ export class IntentClassifierService implements OnModuleInit {
   } {
     return {
       enabled: this.enabled,
-      ready: this.classifier !== null,
+      ready: this.isReady(),
       model: this.modelId,
       askThreshold: this.askThreshold,
       cacheSize: this.cache.size,
@@ -108,32 +175,11 @@ export class IntentClassifierService implements OnModuleInit {
   }
 
   /** Test-only seam — injects a mock pipeline so unit tests can drive
-   *  the NLI code path without loading the real model. */
+   *  the NLI code path without loading the real model. A seam pipeline
+   *  always runs in-thread (classify() prefers it over the worker). */
   setClassifierForTesting(pipeline: ZeroShotPipeline | null): void {
     this.classifier = pipeline;
     this.cache.clear();
-  }
-
-  private async warmup(): Promise<void> {
-    const start = Date.now();
-    try {
-      const transformers = await import('@xenova/transformers');
-      // Dynamic import so the transformers runtime is only paid for
-      // when the feature is enabled — keeps cold-boot fast in
-      // CHAT_ROUTE_NLI_ENABLED=false deployments.
-      this.classifier = (await transformers.pipeline(
-        'zero-shot-classification',
-        this.modelId,
-      )) as unknown as ZeroShotPipeline;
-      this.logger.log(
-        `NLI classifier ready (${this.modelId}) — warmup ${Date.now() - start}ms`,
-      );
-    } catch (e) {
-      this.logger.warn(
-        `NLI classifier warmup failed for ${this.modelId}: ${(e as Error).message}; falling back to punctuation-only`,
-      );
-      this.classifier = null;
-    }
   }
 
   async classify(message: string): Promise<IntentResult> {
@@ -146,7 +192,11 @@ export class IntentClassifierService implements OnModuleInit {
     if (/\?\s*$/.test(message)) {
       return { intent: 'ask', confidence: 0.95, source: 'punctuation' };
     }
-    if (!this.classifier) {
+    if (!this.hasNliRuntime()) {
+      // A crashed / timed-out worker re-warms in the background once the
+      // failure latch expires; this request keeps the punctuation
+      // fallback (a request never blocks on a model load).
+      if (this.useWorker && this.worker && this.enabled) void this.warmup();
       return { intent: 'tell', confidence: 0.7, source: 'punctuation' };
     }
     const cached = this.cache.get(trimmed);
@@ -154,23 +204,16 @@ export class IntentClassifierService implements OnModuleInit {
       return { ...cached, source: 'cache' };
     }
     try {
-      const result = await this.classifier(
-        trimmed,
-        ['question', 'statement'],
-        { hypothesis_template: 'This text is a {}.' },
-      );
-      const qIdx = result.labels.indexOf('question');
-      const qScore = qIdx >= 0 ? result.scores[qIdx] : 0;
-      let intent: 'ask' | 'tell';
-      let confidence: number;
-      if (qScore >= this.askThreshold) {
-        intent = 'ask';
-        confidence = qScore;
-      } else {
-        intent = 'tell';
-        confidence = 1 - qScore;
-      }
-      const value = { intent, confidence };
+      const result = this.classifier
+        ? await this.classifier(trimmed, NLI_LABELS, {
+            hypothesis_template: HYPOTHESIS_TEMPLATE,
+          })
+        : await this.rpc<{ labels: string[]; scores: number[] }>('classify', {
+            text: trimmed,
+            labels: NLI_LABELS,
+            hypothesisTemplate: HYPOTHESIS_TEMPLATE,
+          });
+      const value = this.toIntent(result);
       this.cache.set(trimmed, value);
       return { ...value, source: 'nli' };
     } catch (e) {
@@ -179,5 +222,176 @@ export class IntentClassifierService implements OnModuleInit {
       );
       return { intent: 'tell', confidence: 0.7, source: 'punctuation' };
     }
+  }
+
+  /** Whether an NLI backend can serve this request right now: the
+   *  in-thread pipeline (or test seam), or a warmed worker outside the
+   *  failure latch. */
+  private hasNliRuntime(): boolean {
+    if (this.classifier !== null) return true;
+    return this.workerReady && Date.now() >= this.failedUntil;
+  }
+
+  private toIntent(result: { labels: string[]; scores: number[] }): {
+    intent: 'ask' | 'tell';
+    confidence: number;
+  } {
+    const qIdx = result.labels.indexOf('question');
+    const qScore = qIdx >= 0 ? result.scores[qIdx] : 0;
+    if (qScore >= this.askThreshold) {
+      return { intent: 'ask', confidence: qScore };
+    }
+    return { intent: 'tell', confidence: 1 - qScore };
+  }
+
+  /** Load (or await the in-flight load of) the model. Idempotent; a
+   *  failed load latches for FAIL_RETRY_MS so we don't re-download on
+   *  every request. */
+  private async warmup(): Promise<void> {
+    if (this.isReady()) return;
+    if (this.warmupPromise) return this.warmupPromise;
+    if (Date.now() < this.failedUntil) return;
+    const start = Date.now();
+    this.warmupPromise = (this.useWorker
+      ? this.warmupWorker()
+      : this.warmupInThread()
+    )
+      .then(() => {
+        this.logger.log(
+          `NLI classifier ready (${this.modelId}${this.useWorker ? ', worker' : ''}) — warmup ${Date.now() - start}ms`,
+        );
+      })
+      .catch((e) => {
+        this.failedUntil = Date.now() + FAIL_RETRY_MS;
+        this.logger.warn(
+          `NLI classifier warmup failed for ${this.modelId}: ${(e as Error).message}; punctuation-only, retrying after ${Math.round(FAIL_RETRY_MS / 60000)}m`,
+        );
+      })
+      .finally(() => {
+        this.warmupPromise = null;
+      });
+    return this.warmupPromise;
+  }
+
+  private async warmupInThread(): Promise<void> {
+    // Dynamic import so the transformers runtime is only paid for
+    // when the feature is enabled — keeps cold-boot fast in
+    // CHAT_ROUTE_NLI_ENABLED=false deployments.
+    const t = (await import('@xenova/transformers')) as unknown as {
+      env: { cacheDir?: string };
+      pipeline: (task: string, modelId: string) => Promise<unknown>;
+    };
+    // transformers.js v2 ignores the python-style TRANSFORMERS_CACHE /
+    // HF_HOME env vars — honour them explicitly so the operator's cache
+    // mount actually works (same fix as cross-encoder.worker.ts).
+    const cacheDir = process.env.TRANSFORMERS_CACHE ?? process.env.HF_HOME;
+    if (cacheDir) t.env.cacheDir = cacheDir;
+    this.classifier = (await t.pipeline(
+      'zero-shot-classification',
+      this.modelId,
+    )) as ZeroShotPipeline;
+  }
+
+  private async warmupWorker(): Promise<void> {
+    // Re-warmup after a classify-RPC timeout must not orphan the previous
+    // worker: an un-terminated worker_threads.Worker keeps its message
+    // listener (and the ~135 MB loaded model) alive for the process
+    // lifetime — one leaked worker per timeout incident. Tear the old
+    // one down before spawning its replacement.
+    const stale = this.worker;
+    if (stale) {
+      this.worker = null;
+      this.failAllPending(new Error('worker replaced after stall'));
+      await stale.terminate().catch(() => undefined);
+    }
+    const workerPath = this.resolveWorkerPath();
+    this.worker = new Worker(workerPath);
+    this.worker.on('message', (m: unknown) => this.handleReply(m));
+    this.worker.on('error', (err) => {
+      this.logger.warn(`intent-classifier worker error: ${err.message}`);
+      this.failAllPending(err);
+      this.workerReady = false;
+    });
+    this.worker.on('exit', (code) => {
+      if (code !== 0) {
+        this.logger.warn(`intent-classifier worker exited (${code})`);
+      }
+      this.failAllPending(new Error('worker exited'));
+      this.workerReady = false;
+    });
+    await this.rpc<{ ready: boolean }>('warmup', { modelId: this.modelId });
+    this.workerReady = true;
+  }
+
+  private resolveWorkerPath(): string {
+    const distCandidate = join(__dirname, 'intent-classifier.worker.js');
+    if (existsSync(distCandidate)) return distCandidate;
+    return join(__dirname, 'intent-classifier.worker.ts');
+  }
+
+  private handleReply(msg: unknown): void {
+    const m = msg as {
+      id: number;
+      ok: boolean;
+      result?: unknown;
+      error?: string;
+    };
+    const entry = this.pending.get(m.id);
+    if (!entry) return;
+    this.pending.delete(m.id);
+    if (m.ok) entry.resolve(m.result);
+    else entry.reject(new Error(m.error ?? 'unknown worker error'));
+  }
+
+  private failAllPending(err: Error): void {
+    for (const [, entry] of this.pending) entry.reject(err);
+    this.pending.clear();
+  }
+
+  private rpc<R>(kind: 'warmup' | 'classify', payload: unknown): Promise<R> {
+    if (!this.worker) {
+      return Promise.reject(
+        new Error('intent-classifier worker not initialised'),
+      );
+    }
+    const id = this.nextReqId++;
+    // Warmup downloads/loads a ~135MB model; a classify call is a single
+    // inference bounded by CHAT_ROUTE_NLI_TIMEOUT_MS so a wedged worker
+    // can't pend forever.
+    const timeoutMs =
+      kind === 'warmup' ? WORKER_WARMUP_TIMEOUT_MS : this.classifyTimeoutMs;
+    return new Promise<R>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          this.workerReady = false;
+          // Latch like a warmup failure: without this, the next classify()
+          // immediately re-warms (spawning a replacement worker) while
+          // the wedged one may still be mid-inference — on a persistently
+          // slow host that would cycle a new ~135 MB worker per timeout.
+          // The latch gives the host FAIL_RETRY_MS to recover; intent
+          // degrades to the punctuation heuristic meanwhile.
+          if (kind === 'classify') {
+            this.failedUntil = Date.now() + FAIL_RETRY_MS;
+          }
+          reject(
+            new Error(
+              `intent-classifier '${kind}' RPC timed out after ${timeoutMs}ms`,
+            ),
+          );
+        }
+      }, timeoutMs);
+      if (typeof timer.unref === 'function') timer.unref();
+      this.pending.set(id, {
+        resolve: (v: unknown) => {
+          clearTimeout(timer);
+          (resolve as (value: unknown) => void)(v);
+        },
+        reject: (e: Error) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      });
+      this.worker!.postMessage({ id, kind, payload });
+    });
   }
 }

--- a/src/admin/intent-classifier.worker.ts
+++ b/src/admin/intent-classifier.worker.ts
@@ -1,0 +1,104 @@
+/**
+ * Worker thread that owns the zero-shot NLI intent model.
+ *
+ * Why a dedicated worker: @xenova/transformers runs ONNX inference (WASM or
+ * native) on the main thread by default. The intent model
+ * (Xenova/distilbert-base-multilingual-cased-finetuned-mnli, ~135MB ONNX)
+ * takes ~100-200ms per classification — every cache-missed chat-route
+ * request froze the event loop, and every other tenant's request, for the
+ * whole inference. Hosting the model in a worker_thread confines the
+ * blocking to a dedicated loop, exactly as the cross-encoder reranker
+ * (src/ai/cross-encoder/cross-encoder.worker.ts) and the BGE-M3 embedder
+ * (src/ai/embedder/bge-m3.worker.ts) do.
+ *
+ * Protocol: parent posts `{ id, kind, payload }`; worker replies with
+ * `{ id, ok, result | error }`. id demuxes concurrent requests.
+ */
+import { parentPort } from 'node:worker_threads';
+
+interface WorkerConfig {
+  modelId: string;
+}
+
+type ZeroShotPipeline = (
+  text: string,
+  labels: string[],
+  options: { hypothesis_template: string },
+) => Promise<{
+  sequence: string;
+  labels: string[];
+  scores: number[];
+}>;
+
+type Inbound =
+  | { id: number; kind: 'warmup'; payload: WorkerConfig }
+  | {
+      id: number;
+      kind: 'classify';
+      payload: { text: string; labels: string[]; hypothesisTemplate: string };
+    };
+
+type Outbound =
+  | { id: number; ok: true; result: unknown }
+  | { id: number; ok: false; error: string };
+
+if (!parentPort) {
+  throw new Error('intent-classifier.worker must be run as a worker_thread');
+}
+
+let classifier: ZeroShotPipeline | null = null;
+let warmupPromise: Promise<void> | null = null;
+
+function reply(msg: Outbound): void {
+  parentPort!.postMessage(msg);
+}
+
+async function warmup(cfg: WorkerConfig): Promise<void> {
+  if (warmupPromise) return warmupPromise;
+  warmupPromise = (async () => {
+    const t = (await import('@xenova/transformers')) as unknown as {
+      env: { cacheDir?: string };
+      pipeline: (task: string, modelId: string) => Promise<unknown>;
+    };
+    // transformers.js v2 ignores the python-style TRANSFORMERS_CACHE / HF_HOME
+    // env vars — it resolves its own default under node_modules, which is
+    // root-owned (and re-downloaded on every restart) in the Docker image.
+    // Honour the env explicitly so the operator's cache mount actually works.
+    const cacheDir = process.env.TRANSFORMERS_CACHE ?? process.env.HF_HOME;
+    if (cacheDir) t.env.cacheDir = cacheDir;
+    classifier = (await t.pipeline(
+      'zero-shot-classification',
+      cfg.modelId,
+    )) as ZeroShotPipeline;
+  })();
+  return warmupPromise;
+}
+
+async function classify(p: {
+  text: string;
+  labels: string[];
+  hypothesisTemplate: string;
+}): Promise<{ labels: string[]; scores: number[] }> {
+  if (!classifier) throw new Error('NLI classifier not ready');
+  const out = await classifier(p.text, p.labels, {
+    hypothesis_template: p.hypothesisTemplate,
+  });
+  return { labels: out.labels, scores: out.scores };
+}
+
+parentPort.on('message', async (msg: Inbound) => {
+  try {
+    if (msg.kind === 'warmup') {
+      await warmup(msg.payload);
+      reply({ id: msg.id, ok: true, result: { ready: true } });
+      return;
+    }
+    if (warmupPromise) await warmupPromise;
+    if (msg.kind === 'classify') {
+      reply({ id: msg.id, ok: true, result: await classify(msg.payload) });
+      return;
+    }
+  } catch (e) {
+    reply({ id: msg.id, ok: false, error: (e as Error).message });
+  }
+});

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -141,6 +141,9 @@ validateAbacEnv(env, errors);
   positiveInt(env, 'MAX_DEDICATED_INDEXERS_PER_DOC', errors);
   nonNegativeFloat(env, 'CANDIDATE_MIN_CONFIDENCE', errors);
 
+  // ── Chat-route NLI intent classifier ───────────────────────────────
+  positiveInt(env, 'CHAT_ROUTE_NLI_TIMEOUT_MS', errors);
+
   // ── All remaining boolean feature flags ────────────────────────────
   validateBooleanFlags(env, warnings);
 
@@ -310,6 +313,9 @@ const KNOWN_BOOLEAN_FLAGS = [
   'AUDIT_CHANGEFEED_ENABLED',
   'DEBUG_TRACE_PERSIST',
   'BGE_M3_WORKER',
+  // Default-ON (config default '1' feeds envFlagEnabled); a value outside
+  // FLAG_VALUES still parses as OFF, i.e. in-thread NLI inference.
+  'CHAT_ROUTE_NLI_WORKER',
   'THROTTLE_DISABLED',
 ];
 

--- a/test/intent-classifier-worker.unit-spec.ts
+++ b/test/intent-classifier-worker.unit-spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit coverage for the IntentClassifierService worker runtime
+ * (CHAT_ROUTE_NLI_WORKER, default ON):
+ *   - worker not warmed → punctuation fallback (marker intact)
+ *   - warmed worker → classify RPC flows through, result cached on main
+ *   - classify RPC timeout → punctuation fallback + 5-min failure latch
+ *     (no immediate replacement-worker churn)
+ *   - application shutdown terminates the worker thread
+ *
+ * worker_threads.Worker is hand-rolled-mocked (house style, see
+ * worker-loop.unit-spec.ts) — no model download, no real thread.
+ */
+import { ConfigService } from '@nestjs/config';
+
+interface RpcMessage {
+  id: number;
+  kind: string;
+  payload: unknown;
+}
+
+class MockWorker {
+  readonly handlers = new Map<string, Array<(arg: unknown) => void>>();
+  readonly posted: RpcMessage[] = [];
+  terminated = false;
+
+  on(event: string, fn: (arg: unknown) => void): this {
+    const list = this.handlers.get(event) ?? [];
+    list.push(fn);
+    this.handlers.set(event, list);
+    return this;
+  }
+
+  postMessage(msg: RpcMessage): void {
+    this.posted.push(msg);
+    mockOnPost?.(this, msg);
+  }
+
+  async terminate(): Promise<number> {
+    this.terminated = true;
+    return 0;
+  }
+
+  emit(event: string, arg?: unknown): void {
+    for (const fn of this.handlers.get(event) ?? []) fn(arg);
+  }
+}
+
+const mockWorkers: MockWorker[] = [];
+let mockOnPost: ((w: MockWorker, msg: RpcMessage) => void) | null = null;
+
+jest.mock('node:worker_threads', () => ({
+  Worker: jest.fn(() => {
+    const w = new MockWorker();
+    mockWorkers.push(w);
+    return w;
+  }),
+}));
+
+// Imported after the mock declaration for readability; jest hoists the
+// jest.mock() call above imports either way, so the service binds the
+// mocked Worker.
+import { IntentClassifierService } from '../src/admin/intent-classifier.service';
+
+function mkConfig(over: Record<string, string> = {}): ConfigService {
+  const data: Record<string, string> = {
+    CHAT_ROUTE_NLI_ENABLED: 'true',
+    CHAT_ROUTE_NLI_ASK_THRESHOLD: '0.6',
+    CHAT_ROUTE_NLI_WORKER: '1',
+    CHAT_ROUTE_NLI_TIMEOUT_MS: '40',
+    ...over,
+  };
+  return {
+    get: (k: string, def?: string) => data[k] ?? def,
+  } as unknown as ConfigService;
+}
+
+async function waitFor(cond: () => boolean, budgetMs = 2000): Promise<void> {
+  const deadline = Date.now() + budgetMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error('waitFor timed out');
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/** Boot the service and answer the warmup RPC so the worker goes ready. */
+async function warmService(svc: IntentClassifierService): Promise<MockWorker> {
+  const previous = mockOnPost;
+  mockOnPost = (w, msg) => {
+    if (msg.kind === 'warmup') {
+      queueMicrotask(() =>
+        w.emit('message', { id: msg.id, ok: true, result: { ready: true } }),
+      );
+      return;
+    }
+    previous?.(w, msg);
+  };
+  svc.onModuleInit();
+  await waitFor(() => svc.isReady());
+  mockOnPost = previous;
+  return mockWorkers[mockWorkers.length - 1];
+}
+
+beforeEach(() => {
+  mockWorkers.length = 0;
+  mockOnPost = null;
+});
+
+describe('IntentClassifierService — worker runtime', () => {
+  it('worker not warmed → punctuation fallback, no RPC', async () => {
+    const svc = new IntentClassifierService(mkConfig());
+    // onModuleInit fired, but the (mock) worker never answers warmup —
+    // the model is still "downloading".
+    svc.onModuleInit();
+    expect(svc.isReady()).toBe(false);
+    await expect(svc.classify('Maria moved to Berlin')).resolves.toEqual({
+      intent: 'tell',
+      confidence: 0.7,
+      source: 'punctuation',
+    });
+    expect(mockWorkers).toHaveLength(1);
+    expect(
+      mockWorkers[0].posted.filter((m) => m.kind === 'classify'),
+    ).toHaveLength(0);
+    await svc.onApplicationShutdown();
+  });
+
+  it('warmed worker → classify RPC carries {text, labels, hypothesisTemplate}; result cached on the main thread', async () => {
+    const svc = new IntentClassifierService(mkConfig());
+    mockOnPost = (w, msg) => {
+      if (msg.kind !== 'classify') return;
+      queueMicrotask(() =>
+        w.emit('message', {
+          id: msg.id,
+          ok: true,
+          result: { labels: ['question', 'statement'], scores: [0.82, 0.18] },
+        }),
+      );
+    };
+    const worker = await warmService(svc);
+
+    const first = await svc.classify('where Maria lives');
+    expect(first).toEqual({ intent: 'ask', confidence: 0.82, source: 'nli' });
+    const classifyCalls = worker.posted.filter((m) => m.kind === 'classify');
+    expect(classifyCalls).toHaveLength(1);
+    expect(classifyCalls[0].payload).toEqual({
+      text: 'where Maria lives',
+      labels: ['question', 'statement'],
+      hypothesisTemplate: 'This text is a {}.',
+    });
+
+    // Repeat query: served from the main-thread LRU, no second RPC.
+    const second = await svc.classify('where Maria lives');
+    expect(second).toEqual({
+      intent: 'ask',
+      confidence: 0.82,
+      source: 'cache',
+    });
+    expect(worker.posted.filter((m) => m.kind === 'classify')).toHaveLength(1);
+    await svc.onApplicationShutdown();
+  });
+
+  it('classify RPC timeout → punctuation fallback + failure latch (no worker churn)', async () => {
+    const svc = new IntentClassifierService(
+      mkConfig({ CHAT_ROUTE_NLI_TIMEOUT_MS: '30' }),
+    );
+    // Never answer classify RPCs — a wedged worker.
+    const worker = await warmService(svc);
+
+    const timedOut = await svc.classify('a statement that never scores');
+    expect(timedOut).toEqual({
+      intent: 'tell',
+      confidence: 0.7,
+      source: 'punctuation',
+    });
+    // The timeout dropped readiness…
+    expect(svc.isReady()).toBe(false);
+
+    // …and latched: the next miss short-circuits to punctuation without a
+    // new RPC and without spawning a replacement worker mid-latch.
+    const duringLatch = await svc.classify('another plain statement');
+    expect(duringLatch).toEqual({
+      intent: 'tell',
+      confidence: 0.7,
+      source: 'punctuation',
+    });
+    expect(worker.posted.filter((m) => m.kind === 'classify')).toHaveLength(1);
+    expect(mockWorkers).toHaveLength(1);
+    await svc.onApplicationShutdown();
+  });
+
+  it('onApplicationShutdown terminates the worker thread', async () => {
+    const svc = new IntentClassifierService(mkConfig());
+    const worker = await warmService(svc);
+    expect(svc.isReady()).toBe(true);
+
+    await svc.onApplicationShutdown();
+    expect(worker.terminated).toBe(true);
+    expect(svc.isReady()).toBe(false);
+
+    // Idempotent: a second shutdown is a no-op.
+    await expect(svc.onApplicationShutdown()).resolves.toBeUndefined();
+  });
+
+  it('worker crash (exit) → punctuation fallback for in-flight and later calls', async () => {
+    const svc = new IntentClassifierService(mkConfig());
+    const worker = await warmService(svc);
+
+    const inFlight = svc.classify('statement pending when the worker dies');
+    await waitFor(
+      () => worker.posted.filter((m) => m.kind === 'classify').length === 1,
+    );
+    worker.emit('exit', 1);
+    await expect(inFlight).resolves.toEqual({
+      intent: 'tell',
+      confidence: 0.7,
+      source: 'punctuation',
+    });
+    expect(svc.isReady()).toBe(false);
+    await expect(svc.classify('after the crash')).resolves.toMatchObject({
+      source: 'punctuation',
+    });
+    await svc.onApplicationShutdown();
+  });
+});


### PR DESCRIPTION
Workers wave W1. The zero-shot NLI model (~135MB distilbert via @xenova/transformers) ran in-thread on cache-missed chat-route requests, blocking the event loop ~100-200ms per inference. It now runs in a dedicated worker thread following the existing cross-encoder pattern (`{id, kind}` RPC, 120s warmup timeout, per-call deadline `CHAT_ROUTE_NLI_TIMEOUT_MS`=3000, 5-min `failedUntil` latch, terminate on shutdown).

- `CHAT_ROUTE_NLI_WORKER` default ON: every failure mode (crash/timeout/warmup failure) lands on the pre-existing punctuation fallback — degraded behavior equals today's pre-warmup behavior. Kill switch provided.
- Fixes a latent Docker cache bug for free: `TRANSFORMERS_CACHE`/`HF_HOME` → `env.cacheDir` was missing from the in-thread warmup.
- Also fixes pre-existing config-catalog drift: `CHAT_ROUTE_NLI_ENABLED` was catalogued as default-off/runtime-mutable; the code default is ON and constructor-captured.
- Public service surface unchanged — existing specs pass unmodified; new unit spec covers fallback, timeout latch, shutdown termination, and crash recovery with a mocked worker (no model download in CI).

Verification: tsc clean, lint clean, full unit suite 155 suites / 1092 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd