### PR TITLE
perf(jobs): bounded per-jobType poller concurrency with tenant and global caps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -439,6 +439,18 @@ EMBEDDER_PROVIDER=openai
 # Run the queue worker loop in this process. 1 (default) = on; set 0 on a
 # web-only pod that should not claim jobs.
 #WORKER_LOOP_ENABLED=1
+# Max in-flight dispatches per jobType. 1 (default) keeps the original
+# strictly-serial loop: claim → await dispatch → sleep. Raise to let one
+# slow tenant stop blocking the others on the same jobType.
+#WORKER_LOOP_MAX_CONCURRENT=1
+# Per-jobType override of the same knob (jobType uppercased), e.g.:
+#WORKER_LOOP_MAX_CONCURRENT_DREAMS=2
+# Max in-flight dispatches per (jobType, tenant). 1 (default) means extra
+# concurrency slots always go to OTHER tenants first.
+#WORKER_LOOP_TENANT_MAX_CONCURRENT=1
+# Cap on in-flight dispatches across ALL jobTypes in this process.
+# 0 (default) = uncapped.
+#WORKER_LOOP_GLOBAL_MAX_CONCURRENT=0
 # Synthesize guardrail mode when the caller doesn't pass one:
 # strict (default) | lenient | off.
 #SYNTHESIZE_DEFAULT_GUARDRAILS=strict

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -817,6 +817,33 @@ export class ConfigInspectorService {
         description:
           'Where background jobs run: enqueue (durable worker loop, default) vs inline (in-process).',
       },
+      {
+        key: 'WORKER_LOOP_MAX_CONCURRENT',
+        category: 'jobs',
+        defaultValue: '1',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Max in-flight dispatches per jobType in the queue poller; 1 = original serial loop. Per-type override: WORKER_LOOP_MAX_CONCURRENT_<JOBTYPE>.',
+      },
+      {
+        key: 'WORKER_LOOP_TENANT_MAX_CONCURRENT',
+        category: 'jobs',
+        defaultValue: '1',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Max in-flight dispatches per (jobType, tenant) — extra concurrency slots go to other tenants first.',
+      },
+      {
+        key: 'WORKER_LOOP_GLOBAL_MAX_CONCURRENT',
+        category: 'jobs',
+        defaultValue: '0',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Cap on in-flight dispatches across all jobTypes in this process; 0 = uncapped.',
+      },
     ];
   }
 }

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -145,6 +145,9 @@ validateAbacEnv(env, errors);
   // ── Chat-route NLI intent classifier ───────────────────────────────
   positiveInt(env, 'CHAT_ROUTE_NLI_TIMEOUT_MS', errors);
 
+  // ── Worker-loop concurrency (per-jobType poller) ────────────────────
+  validateWorkerConcurrencyEnv(env, errors);
+
   // ── All remaining boolean feature flags ────────────────────────────
   validateBooleanFlags(env, warnings);
 
@@ -264,6 +267,27 @@ function validateBooleanFlags(env: NodeJS.ProcessEnv, warnings: string[]): void 
         `${name} must be one of 1/0/true/false (got "${v}") — ` +
           'unrecognized values parse as OFF.',
       );
+    }
+  }
+}
+
+/**
+ * Worker-loop concurrency knobs. A typo'd value would silently parse as
+ * "unset" in the poller (falling back to serial) — validate at boot like
+ * the rest of the numeric knobs. The per-jobType overrides are dynamic
+ * (WORKER_LOOP_MAX_CONCURRENT_<JOBTYPE>), so sweep every env key with
+ * that prefix instead of hard-coding the jobType list.
+ */
+function validateWorkerConcurrencyEnv(
+  env: NodeJS.ProcessEnv,
+  errors: string[],
+): void {
+  positiveInt(env, 'WORKER_LOOP_MAX_CONCURRENT', errors);
+  positiveInt(env, 'WORKER_LOOP_TENANT_MAX_CONCURRENT', errors);
+  nonNegativeInt(env, 'WORKER_LOOP_GLOBAL_MAX_CONCURRENT', errors);
+  for (const name of Object.keys(env)) {
+    if (name.startsWith('WORKER_LOOP_MAX_CONCURRENT_')) {
+      positiveInt(env, name, errors);
     }
   }
 }
@@ -396,6 +420,18 @@ function positiveInt(env: NodeJS.ProcessEnv, name: string, errors: string[]): vo
   if (v === undefined) return;
   if (!/^\d+$/.test(v) || parseInt(v, 10) < 1) {
     errors.push(`${name} must be a positive integer`);
+  }
+}
+
+function nonNegativeInt(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  errors: string[],
+): void {
+  const v = env[name];
+  if (v === undefined) return;
+  if (!/^\d+$/.test(v)) {
+    errors.push(`${name} must be a non-negative integer`);
   }
 }
 

--- a/src/jobs/worker-loop.service.ts
+++ b/src/jobs/worker-loop.service.ts
@@ -166,6 +166,8 @@ export class WorkerLoopService
       const control: PollControl = {
         isLeader: () => this.isLeader,
         signal: this.abortController.signal,
+        onInFlight: (jobType, inFlight) =>
+          this.metrics?.setWorkerJobsInFlight(jobType, inFlight),
       };
       for (const reg of this.handlers.values()) {
         void this.poller.runLoop(reg, control);

--- a/src/jobs/worker-loop.types.ts
+++ b/src/jobs/worker-loop.types.ts
@@ -43,4 +43,11 @@ export interface RegisteredHandler {
 export interface PollControl {
   isLeader: () => boolean;
   signal: AbortSignal;
+  /**
+   * Observability hook: invoked with the number of in-flight dispatches
+   * for a jobType whenever it changes. Only fired by the bounded-
+   * concurrency loop (the default serial loop is untouched); wired to
+   * the brain_worker_jobs_in_flight gauge by WorkerLoopService.
+   */
+  onInFlight?: (jobType: JobType, inFlight: number) => void;
 }

--- a/src/jobs/worker-poller.service.ts
+++ b/src/jobs/worker-poller.service.ts
@@ -21,6 +21,23 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   });
 }
 
+/** Per-jobType concurrency limits resolved from the environment. */
+interface ConcurrencyLimits {
+  /** Max in-flight dispatches for this jobType (≥1). */
+  maxConcurrent: number;
+  /** Max in-flight dispatches per (jobType, tenant) (≥1). */
+  tenantMax: number;
+  /** Max in-flight dispatches across ALL jobTypes in this process; 0 = uncapped. */
+  globalMax: number;
+}
+
+/** Parse an integer env var; undefined when unset or not a valid integer. */
+function readIntEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || !/^\d+$/.test(raw.trim())) return undefined;
+  return parseInt(raw.trim(), 10);
+}
+
 /**
  * WorkerPollerService — the per-jobType polling loop with weighted-fair
  * tenant ordering. Claims the next job for a fair tenant and hands it to
@@ -28,6 +45,14 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
  * by WorkerLoopService via the PollControl handle. Owns the recent-claim
  * fairness counters (+ their decay). Splitting it out keeps every worker
  * class ≤3 deps. Poll cadences read from the environment.
+ *
+ * Concurrency: WORKER_LOOP_MAX_CONCURRENT_<JOBTYPE> (fallback
+ * WORKER_LOOP_MAX_CONCURRENT, default 1) bounds in-flight dispatches per
+ * jobType; WORKER_LOOP_TENANT_MAX_CONCURRENT (default 1) bounds them per
+ * (jobType, tenant) so extra slots go to OTHER tenants first;
+ * WORKER_LOOP_GLOBAL_MAX_CONCURRENT (default 0 = uncapped) bounds them
+ * across every loop in this process. With everything at the defaults the
+ * loop takes the original strictly-serial code path.
  */
 @Injectable()
 export class WorkerPollerService {
@@ -42,6 +67,10 @@ export class WorkerPollerService {
   );
   private readonly recentClaims = new Map<string, number>();
   private decayTimer: NodeJS.Timeout | null = null;
+  /** In-flight dispatch count per `${jobType}::${companyId}` (tenant cap). */
+  private readonly inFlightByTenant = new Map<string, number>();
+  /** In-flight dispatches across all runLoops in this process (global cap). */
+  private globalInFlight = 0;
 
   constructor(
     private readonly dispatcher: JobDispatcherService,
@@ -74,8 +103,24 @@ export class WorkerPollerService {
   /**
    * Per-jobType polling loop. Runs while the pod holds the lease (per
    * control.isLeader). On empty queue across all tenants, backs off.
+   *
+   * With the concurrency knobs at their defaults (per-type max 1, no
+   * global cap) this delegates to the original strictly-serial loop;
+   * otherwise to the bounded-concurrency variant.
    */
   async runLoop(reg: RegisteredHandler, control: PollControl): Promise<void> {
+    const limits = this.concurrencyLimits(reg.jobType);
+    if (limits.maxConcurrent <= 1 && limits.globalMax === 0) {
+      return this.runLoopSerial(reg, control);
+    }
+    return this.runLoopConcurrent(reg, control, limits);
+  }
+
+  /** The original one-at-a-time loop: claim → await dispatch → sleep. */
+  private async runLoopSerial(
+    reg: RegisteredHandler,
+    control: PollControl,
+  ): Promise<void> {
     this.logger.log(`Poll loop started for jobType=${reg.jobType}`);
     while (!control.signal.aborted) {
       if (!control.isLeader()) {
@@ -117,6 +162,167 @@ export class WorkerPollerService {
       await sleep(this.pollIntervalMs, control.signal);
     }
     this.logger.log(`Poll loop stopped for jobType=${reg.jobType}`);
+  }
+
+  /**
+   * Bounded-concurrency loop. Keeps up to limits.maxConcurrent dispatches
+   * in flight for this jobType, at most limits.tenantMax per tenant (so a
+   * slow tenant can't hog every slot — extra slots go to other tenants),
+   * and never exceeds limits.globalMax across all loops in this process.
+   * When saturated it waits for a slot or the next poll tick, whichever
+   * comes first. On abort it drains in-flight dispatches before returning.
+   */
+  private async runLoopConcurrent(
+    reg: RegisteredHandler,
+    control: PollControl,
+    limits: ConcurrencyLimits,
+  ): Promise<void> {
+    this.logger.log(
+      `Poll loop started for jobType=${reg.jobType} ` +
+        `(maxConcurrent=${limits.maxConcurrent}, tenantMax=${limits.tenantMax}, ` +
+        `globalMax=${limits.globalMax || 'uncapped'})`,
+    );
+    const inFlight = new Set<Promise<void>>();
+    while (!control.signal.aborted) {
+      if (!control.isLeader()) {
+        // Lost leadership mid-loop; sleep until renew tick reinstates us.
+        await sleep(this.pollIntervalMs, control.signal);
+        continue;
+      }
+      if (this.saturated(inFlight.size, limits)) {
+        // All slots busy — wake on the first finished dispatch or the
+        // poll tick (the tick matters for the global cap: a slot may
+        // free up in ANOTHER jobType's loop).
+        await Promise.race([
+          ...inFlight,
+          sleep(this.pollIntervalMs, control.signal),
+        ]);
+        continue;
+      }
+      // Reserve the global slot BEFORE the claim await: the saturation
+      // check above and this increment run in the same synchronous block,
+      // so two loops can't both pass the cap and then both claim.
+      this.globalInFlight += 1;
+      const claimed = await this.claimForEligibleTenant(reg, control, limits);
+      if (claimed) {
+        this.trackDispatch({ claimed, reg, control, inFlight });
+      } else {
+        this.globalInFlight -= 1;
+        // Empty queue (for eligible tenants) — back off, but wake early
+        // if a dispatch finishes: that can free a tenant-cap slot whose
+        // tenant still has pending jobs.
+        await Promise.race([
+          ...inFlight,
+          sleep(this.emptyPollBackoffMs, control.signal),
+        ]);
+      }
+      // Always yield a beat so a tight loop can't starve the event loop.
+      await sleep(this.pollIntervalMs, control.signal);
+    }
+    if (inFlight.size > 0) {
+      // Dispatcher propagates the shutdown abort into handlers and owns
+      // the terminal writes; we only wait for them to settle.
+      await Promise.allSettled([...inFlight]);
+    }
+    this.logger.log(`Poll loop stopped for jobType=${reg.jobType}`);
+  }
+
+  /** True when the per-type or global concurrency cap leaves no free slot. */
+  private saturated(inFlightSize: number, limits: ConcurrencyLimits): boolean {
+    return (
+      inFlightSize >= limits.maxConcurrent ||
+      (limits.globalMax > 0 && this.globalInFlight >= limits.globalMax)
+    );
+  }
+
+  /**
+   * One claim cycle over tenants that still have a free (jobType, tenant)
+   * slot. Tenants at their cap are filtered out BEFORE fairness sampling
+   * so the weighted ordering only ranks tenants we could actually serve.
+   */
+  private async claimForEligibleTenant(
+    reg: RegisteredHandler,
+    control: PollControl,
+    limits: ConcurrencyLimits,
+  ): Promise<JobClaim | null> {
+    try {
+      const eligible = (this.apiKeys?.knownCompanyIds() ?? []).filter(
+        (companyId) =>
+          (this.inFlightByTenant.get(`${reg.jobType}::${companyId}`) ?? 0) <
+          limits.tenantMax,
+      );
+      const tenants = this.sampleByFairness(reg.jobType, eligible);
+      for (const companyId of tenants) {
+        if (control.signal.aborted || !control.isLeader()) break;
+        const claimed = await this.claim!.claimNext({
+          companyId,
+          jobType: reg.jobType,
+          ttlSeconds: reg.ttlSeconds,
+        });
+        if (claimed) {
+          this.recordClaim(reg.jobType, companyId);
+          return claimed;
+        }
+      }
+    } catch (e) {
+      this.logger.warn(
+        `claim cycle (${reg.jobType}) failed: ${(e as Error).message}`,
+      );
+    }
+    return null;
+  }
+
+  /**
+   * Fire a dispatch without awaiting it inline. The dispatcher owns lease
+   * renewal and the terminal complete/fail/cancelled writes, so errors are
+   * swallowed here; bookkeeping (in-flight set + tenant/global counters)
+   * is released in finally. The GLOBAL counter was already incremented by
+   * the caller (slot reservation) — only the tenant counter is taken here.
+   */
+  private trackDispatch(args: {
+    claimed: JobClaim;
+    reg: RegisteredHandler;
+    control: PollControl;
+    inFlight: Set<Promise<void>>;
+  }): void {
+    const { claimed, reg, control, inFlight } = args;
+    const tenantKey = `${reg.jobType}::${claimed.companyId}`;
+    this.inFlightByTenant.set(
+      tenantKey,
+      (this.inFlightByTenant.get(tenantKey) ?? 0) + 1,
+    );
+    const p: Promise<void> = withSpan('jobs.dispatch', () =>
+      this.dispatcher.dispatch(claimed, reg, control.signal),
+    )
+      .catch(() => undefined)
+      .finally(() => {
+        inFlight.delete(p);
+        const n = (this.inFlightByTenant.get(tenantKey) ?? 1) - 1;
+        if (n <= 0) this.inFlightByTenant.delete(tenantKey);
+        else this.inFlightByTenant.set(tenantKey, n);
+        this.globalInFlight = Math.max(0, this.globalInFlight - 1);
+        control.onInFlight?.(reg.jobType, inFlight.size);
+      });
+    inFlight.add(p);
+    control.onInFlight?.(reg.jobType, inFlight.size);
+  }
+
+  /**
+   * Resolve the concurrency knobs for one jobType. Read at loop start
+   * (loops spin up once per leadership acquisition), not per cycle.
+   */
+  private concurrencyLimits(jobType: JobType): ConcurrencyLimits {
+    const suffix = jobType.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+    const perType = readIntEnv(`WORKER_LOOP_MAX_CONCURRENT_${suffix}`);
+    const fallback = readIntEnv('WORKER_LOOP_MAX_CONCURRENT');
+    return {
+      maxConcurrent: Math.max(1, perType ?? fallback ?? 1),
+      tenantMax: Math.max(
+        1,
+        readIntEnv('WORKER_LOOP_TENANT_MAX_CONCURRENT') ?? 1,
+      ),
+      globalMax: readIntEnv('WORKER_LOOP_GLOBAL_MAX_CONCURRENT') ?? 0,
+    };
   }
 
   /**

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -299,6 +299,17 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // In-flight job dispatches per jobType. Only reported by the bounded-
+  // concurrency poll loop (WORKER_LOOP_MAX_CONCURRENT[_<JOBTYPE>] > 1 or
+  // WORKER_LOOP_GLOBAL_MAX_CONCURRENT > 0); the default serial loop keeps
+  // its original code path and emits nothing here.
+  readonly workerJobsInFlight = new Gauge({
+    name: 'brain_worker_jobs_in_flight',
+    help: 'In-flight background job dispatches, by jobType',
+    labelNames: ['jobType'] as const,
+    registers: [this.registry],
+  });
+
   // Document ingest (Source → Indexer → Candidates → Brain). No packId
   // label anywhere here — tenant-installed pack ids are unbounded
   // cardinality; per-pack stats live on indexer_run.stats rows.
@@ -551,6 +562,13 @@ export class MetricsService implements OnModuleInit {
 
   setWorkerLeader(isLeader: boolean): void {
     this.workerIsLeader.set(isLeader ? 1 : 0);
+  }
+
+  setWorkerJobsInFlight(jobType: string, inFlight: number): void {
+    this.workerJobsInFlight.set(
+      { jobType } as LabelValues<'jobType'>,
+      inFlight,
+    );
   }
 
   countChangefeedConsumed(source: string, n = 1): void {

--- a/test/worker-poller-concurrency.unit-spec.ts
+++ b/test/worker-poller-concurrency.unit-spec.ts
@@ -1,0 +1,304 @@
+/**
+ * Bounded per-jobType poller concurrency (WorkerPollerService.runLoop):
+ *   1. default env → strictly serial: no second claim while a dispatch
+ *      is in flight (the original code path, byte-identical);
+ *   2. per-type max 2, two tenants → two dispatches in flight at once;
+ *   3. per-type max 2, ONE tenant at the default tenant cap 1 → the
+ *      second slot stays empty (no claim attempts for a capped tenant),
+ *      and frees up when the in-flight dispatch resolves;
+ *   4. global cap 1 across two jobTypes on the shared service instance
+ *      → one dispatch in flight process-wide;
+ *   5. abort mid-flight → the loop drains in-flight dispatches before
+ *      resolving, and handlers observe the shutdown abort.
+ */
+import { WorkerPollerService } from '../src/jobs/worker-poller.service';
+import { JobDispatcherService } from '../src/jobs/job-dispatcher.service';
+import type { JobClaim } from '../src/jobs/job-claim.service';
+import type { JobType } from '../src/jobs/job-run.service';
+import type {
+  PollControl,
+  RegisteredHandler,
+} from '../src/jobs/worker-loop.types';
+
+const ENV_KEYS = [
+  'WORKER_LOOP_POLL_MS',
+  'WORKER_LOOP_EMPTY_BACKOFF_MS',
+  'WORKER_LOOP_MAX_CONCURRENT',
+  'WORKER_LOOP_MAX_CONCURRENT_DREAMS',
+  'WORKER_LOOP_TENANT_MAX_CONCURRENT',
+  'WORKER_LOOP_GLOBAL_MAX_CONCURRENT',
+];
+
+let savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  // Tight cadences so the loops cycle fast under real timers.
+  process.env.WORKER_LOOP_POLL_MS = '5';
+  process.env.WORKER_LOOP_EMPTY_BACKOFF_MS = '5';
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+function settle(ms = 60): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeReg(jobType: JobType = 'dreams'): RegisteredHandler {
+  return {
+    jobType,
+    handler: async () => ({}),
+    ttlSeconds: 3,
+    maxAttempts: 3,
+  };
+}
+
+function makeControl(): { control: PollControl; abort: () => void } {
+  const ac = new AbortController();
+  return {
+    control: { isLeader: () => true, signal: ac.signal },
+    abort: () => ac.abort(),
+  };
+}
+
+/**
+ * Dispatcher stub that parks every dispatch on a deferred so the test
+ * controls exactly when each "job" finishes.
+ */
+function makeParkedDispatcher() {
+  const parked: Array<{ claim: JobClaim; release: () => void }> = [];
+  const dispatch = jest.fn(
+    (claim: JobClaim) =>
+      new Promise<void>((resolve) => {
+        parked.push({ claim, release: resolve });
+      }),
+  );
+  const releaseAll = () => {
+    for (const p of parked) p.release();
+  };
+  return { dispatcher: { dispatch } as never, dispatch, parked, releaseAll };
+}
+
+/**
+ * Claim-service stub backed by fixed per-(jobType, tenant) job counts.
+ * claimNext consumes one job per call; null once a bucket is empty.
+ */
+function makeQueue(jobs: Record<string, number>) {
+  const counts = { ...jobs };
+  let seq = 0;
+  const claimNext = jest.fn(
+    async (input: { companyId: string; jobType: JobType }) => {
+      const key = `${input.jobType}::${input.companyId}`;
+      if ((counts[key] ?? 0) <= 0) return null;
+      counts[key] -= 1;
+      seq += 1;
+      return {
+        recordId: `job_run:${seq}`,
+        runId: `run-${seq}`,
+        jobType: input.jobType,
+        companyId: input.companyId,
+        attempts: 1,
+        payload: null,
+        leaseUntil: '2030-01-01T00:05:00Z',
+      } as JobClaim;
+    },
+  );
+  return { claimNext };
+}
+
+function makeApiKeys(companyIds: string[]) {
+  return { knownCompanyIds: () => companyIds };
+}
+
+function makePoller(args: {
+  dispatcher: unknown;
+  claimSvc: unknown;
+  tenants: string[];
+}): WorkerPollerService {
+  return new WorkerPollerService(
+    args.dispatcher as never,
+    args.claimSvc as never,
+    makeApiKeys(args.tenants) as never,
+  );
+}
+
+describe('WorkerPollerService.runLoop — default env stays serial', () => {
+  it('does not attempt a second claim until the first dispatch resolves', async () => {
+    const { dispatcher, dispatch, parked, releaseAll } = makeParkedDispatcher();
+    const claimSvc = makeQueue({ 'dreams::co_a': 2 });
+    const poller = makePoller({ dispatcher, claimSvc, tenants: ['co_a'] });
+    const { control, abort } = makeControl();
+
+    const loop = poller.runLoop(makeReg(), control);
+    await settle();
+    // First job claimed and dispatched; the serial loop is parked on the
+    // awaited dispatch, so no further claim attempt happened.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(claimSvc.claimNext).toHaveBeenCalledTimes(1);
+
+    parked[0].release();
+    await settle();
+    // Dispatch resolved → the loop went around and claimed the second job.
+    expect(claimSvc.claimNext.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+
+    abort();
+    releaseAll();
+    await loop;
+  });
+});
+
+describe('WorkerPollerService.runLoop — per-jobType concurrency', () => {
+  it('max=2 with two tenants keeps two dispatches in flight concurrently', async () => {
+    process.env.WORKER_LOOP_MAX_CONCURRENT_DREAMS = '2';
+    const { dispatcher, dispatch, parked, releaseAll } = makeParkedDispatcher();
+    const claimSvc = makeQueue({ 'dreams::co_a': 1, 'dreams::co_b': 1 });
+    const poller = makePoller({
+      dispatcher,
+      claimSvc,
+      tenants: ['co_a', 'co_b'],
+    });
+    const { control, abort } = makeControl();
+
+    const loop = poller.runLoop(makeReg(), control);
+    await settle();
+    // Both tenants' jobs are in flight at the same time — neither has
+    // resolved yet (they're parked), so this is real concurrency.
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(parked.map((p) => p.claim.companyId).sort()).toEqual([
+      'co_a',
+      'co_b',
+    ]);
+
+    abort();
+    releaseAll();
+    await loop;
+  });
+
+  it('max=2 with one tenant at tenant cap 1 leaves the second slot empty', async () => {
+    process.env.WORKER_LOOP_MAX_CONCURRENT = '2';
+    // WORKER_LOOP_TENANT_MAX_CONCURRENT defaults to 1.
+    const { dispatcher, dispatch, parked, releaseAll } = makeParkedDispatcher();
+    const claimSvc = makeQueue({ 'dreams::co_a': 3 });
+    const poller = makePoller({ dispatcher, claimSvc, tenants: ['co_a'] });
+    const { control, abort } = makeControl();
+
+    const loop = poller.runLoop(makeReg(), control);
+    await settle();
+    // One in flight; the tenant is at its cap, so the poller must not
+    // even attempt further claims for it while the job runs.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(claimSvc.claimNext).toHaveBeenCalledTimes(1);
+
+    parked[0].release();
+    await settle();
+    // Slot freed → the tenant is eligible again and its next job runs.
+    expect(dispatch).toHaveBeenCalledTimes(2);
+
+    abort();
+    releaseAll();
+    await loop;
+  });
+
+  it('global cap 1 across two jobTypes keeps one dispatch in flight process-wide', async () => {
+    process.env.WORKER_LOOP_MAX_CONCURRENT = '2';
+    process.env.WORKER_LOOP_GLOBAL_MAX_CONCURRENT = '1';
+    const { dispatcher, dispatch, parked, releaseAll } = makeParkedDispatcher();
+    const claimSvc = makeQueue({
+      'dreams::co_a': 1,
+      'compaction::co_a': 1,
+    });
+    // One shared service instance — the global counter lives on it.
+    const poller = makePoller({ dispatcher, claimSvc, tenants: ['co_a'] });
+    const { control, abort } = makeControl();
+
+    const loopA = poller.runLoop(makeReg('dreams'), control);
+    const loopB = poller.runLoop(makeReg('compaction'), control);
+    await settle();
+    // Both loops have work available, but only one dispatch may fly.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    parked[0].release();
+    await settle();
+    // Global slot freed → the other jobType's job goes out.
+    expect(dispatch).toHaveBeenCalledTimes(2);
+
+    abort();
+    releaseAll();
+    await Promise.all([loopA, loopB]);
+  });
+});
+
+describe('WorkerPollerService.runLoop — abort drains in-flight dispatches', () => {
+  it('waits for in-flight jobs and propagates the shutdown abort to handlers', async () => {
+    process.env.WORKER_LOOP_MAX_CONCURRENT = '2';
+    const claimSvc = {
+      identity: () => 'host-test#42',
+      claimNext: jest.fn(),
+      renew: jest.fn(async () => ({
+        stillOwned: true,
+        cancelRequested: false,
+      })),
+      complete: jest.fn(async () => undefined),
+      fail: jest.fn(async () => ({ requeued: true })),
+      cancelled: jest.fn(async () => undefined),
+    };
+    claimSvc.claimNext
+      .mockResolvedValueOnce({
+        recordId: 'job_run:abc',
+        runId: 'run-uuid-1',
+        jobType: 'dreams',
+        companyId: 'co_a',
+        attempts: 1,
+        payload: null,
+        leaseUntil: '2030-01-01T00:05:00Z',
+      })
+      .mockResolvedValue(null);
+    // Real dispatcher: it owns the shutdown→handler abort propagation
+    // and the terminal write, which is exactly what drain relies on.
+    const dispatcher = new JobDispatcherService(claimSvc as never, undefined);
+    let sawAbort = false;
+    const reg: RegisteredHandler = {
+      jobType: 'dreams',
+      handler: async (ctx) => {
+        await new Promise<void>((resolve) => {
+          ctx.abortSignal.addEventListener('abort', () => {
+            sawAbort = true;
+            resolve();
+          });
+        });
+        return { ok: true };
+      },
+      ttlSeconds: 3,
+      maxAttempts: 3,
+    };
+    const poller = makePoller({ dispatcher, claimSvc, tenants: ['co_a'] });
+    const { control, abort } = makeControl();
+
+    const loop = poller.runLoop(reg, control);
+    await settle();
+    expect(claimSvc.claimNext).toHaveBeenCalled();
+
+    let loopResolved = false;
+    void loop.then(() => {
+      loopResolved = true;
+    });
+    // The handler is parked on its abortSignal — the loop must not have
+    // resolved yet.
+    expect(loopResolved).toBe(false);
+
+    abort();
+    await loop;
+    expect(sawAbort).toBe(true);
+    expect(claimSvc.complete).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Workers wave W2. Each jobType's poll loop dispatched strictly one job at a time — a slow dreams tenant blocked every other dreams tenant. The poller now supports bounded concurrency while keeping the default byte-identical:

- `WORKER_LOOP_MAX_CONCURRENT[_<JOBTYPE>]` (default 1), `WORKER_LOOP_TENANT_MAX_CONCURRENT` (default 1 — spare slots go to OTHER tenants first), `WORKER_LOOP_GLOBAL_MAX_CONCURRENT` (default 0 = uncapped, shared across jobTypes).
- At default settings the loop takes the untouched original serial path (verified byte-identical by diff).
- Global slot reserved synchronously before the claim await (no TOCTOU between loops); tenant fairness sampling unchanged, composed with a skip-at-cap filter; abort drains in-flight dispatches via `allSettled`.
- New gauge `brain_worker_jobs_in_flight{jobType}` wired through the existing PollControl handle (keeps the poller at 3 constructor deps).
- No SQL changes — claim CAS/leases are already concurrency-safe.

Suggested prod settings after W1/W3 land: `WORKER_LOOP_MAX_CONCURRENT_DREAMS=2`, `WORKER_LOOP_MAX_CONCURRENT_INDEX_DOCUMENT=2`, `WORKER_LOOP_GLOBAL_MAX_CONCURRENT=3`.

Verification: new `worker-poller-concurrency` spec (serial default, 2-in-flight, tenant cap, global cap, abort drain), tsc/lint clean, full unit suite 155 suites / 1092 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd