### PR TITLE
perf(communities): offload label propagation to the job worker pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -400,6 +400,11 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 #DREAMS_CORROBORATE_CONCURRENCY=4
 #DREAMS_CORROBORATE_MODEL=gpt-4o-mini
 #DREAMS_COMMUNITIES_ENABLED=0
+# Offload community label propagation to the job worker pool once the
+# tenant graph has at least this many live edges (needs
+# JOB_WORKER_POOL_SIZE > 0; pool failures fall back in-thread).
+# 0 = never offload — always run in-thread.
+#COMMUNITIES_LP_OFFLOAD_MIN_EDGES=2000
 # Compaction promotion: old corroborated fact groups promote to a durable
 # summary. AGE_DAYS before eligible, MIN_GROUP members required, MAX_GROUPS
 # per run caps cost.

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -797,6 +797,15 @@ export class ConfigInspectorService {
         isBooleanFlag: true,
         description: 'Build + persist entity-community summaries during dreams.',
       },
+      {
+        key: 'COMMUNITIES_LP_OFFLOAD_MIN_EDGES',
+        category: 'dreams',
+        defaultValue: '2000',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Edge count from which community label propagation runs on the job worker pool instead of the main thread (needs JOB_WORKER_POOL_SIZE > 0; pool failures fall back in-thread). 0 = never offload.',
+      },
       // ── Compaction: promotion ────────────────────────────────
       {
         key: 'COMPACTION_PROMOTION_ENABLED',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -121,6 +121,11 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   positiveInt(env, 'SEARCH_HNSW_EF', errors);
   positiveInt(env, 'SEARCH_HNSW_OVERFETCH', errors);
 
+  // ── Communities (dreams sub-op) ────────────────────────────────────
+  // 0 is meaningful (= never offload label propagation to the worker
+  // pool), so this one is non-negative rather than positive.
+  nonNegativeInt(env, 'COMMUNITIES_LP_OFFLOAD_MIN_EDGES', errors);
+
   // ── Edge expansion (default-ON retrieval stage) ────────────────────
   // Bad values silently fell back to defaults; the numeric knobs are now
   // boot-validated like the rest of the search stack.
@@ -423,6 +428,7 @@ function positiveInt(env: NodeJS.ProcessEnv, name: string, errors: string[]): vo
   }
 }
 
+/** Like positiveInt, but 0 is a valid (usually "feature off") value. */
 function nonNegativeInt(
   env: NodeJS.ProcessEnv,
   name: string,

--- a/src/communities/community-builder.service.ts
+++ b/src/communities/community-builder.service.ts
@@ -1,7 +1,10 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { Surreal, StringRecordId } from 'surrealdb';
 import { EmbedderService } from '../ai/embedder.service';
+import { JobWorkerPool } from '../jobs/job-worker-pool.service';
 import { withSpan } from '../common/tracing';
 import {
   SUMMARY_GENERATOR,
@@ -41,12 +44,18 @@ export class CommunityBuilderService {
   private readonly minSize: number;
   private readonly maxIterations: number;
   private readonly summaryMaxMembers: number;
+  private readonly offloadMinEdges: number;
 
+  // eslint-disable-next-line max-params -- Nest DI constructor; each param is an injection token and cannot be folded into an options object without breaking DI
   constructor(
     private readonly config: ConfigService,
     private readonly embedder: EmbedderService,
     @Inject(SUMMARY_GENERATOR)
     private readonly summaryGenerator: SummaryGenerator,
+    // @Optional so the positional unit tests (no DI) can omit it. In
+    // production the @Global JobsModule provides it; when absent or
+    // disabled the propagation simply runs in-thread as before.
+    @Optional() private readonly workerPool?: JobWorkerPool,
   ) {
     this.enabled =
       envFlagEnabled(this.config.get<string>('DREAMS_COMMUNITIES_ENABLED'));
@@ -60,6 +69,10 @@ export class CommunityBuilderService {
     );
     this.summaryMaxMembers = parseInt(
       this.config.get<string>('COMMUNITIES_SUMMARY_MAX_MEMBERS', '10'),
+      10,
+    );
+    this.offloadMinEdges = parseInt(
+      this.config.get<string>('COMMUNITIES_LP_OFFLOAD_MIN_EDGES', '2000'),
       10,
     );
   }
@@ -104,10 +117,7 @@ export class CommunityBuilderService {
       return result;
     }
 
-    const adjacency = buildAdjacency(
-      edges.map((e) => ({ from: e.from, to: e.to, weight: e.weight })),
-    );
-    const clusters = labelPropagation(adjacency, this.maxIterations).filter(
+    const clusters = (await this.computeClusters(edges)).filter(
       (c) => c.length >= this.minSize,
     );
 
@@ -177,6 +187,43 @@ export class CommunityBuilderService {
         `removed=${result.communitiesRemoved} entitiesClustered=${result.entitiesClustered}`,
     );
     return result;
+  }
+
+  /**
+   * Cluster the edge list — off the main thread when the worker pool is
+   * available AND the graph is big enough to be worth the postMessage
+   * round-trip (COMMUNITIES_LP_OFFLOAD_MIN_EDGES; 0 = never offload).
+   * labelPropagation is pure and deterministic, so both paths produce
+   * identical clusters; a pool failure falls back in-thread and is
+   * invisible to the output (warn-logged only).
+   */
+  private async computeClusters(edges: EdgeRow[]): Promise<string[][]> {
+    const lpEdges = edges.map((e) => ({
+      from: e.from,
+      to: e.to,
+      weight: e.weight,
+    }));
+    if (
+      this.offloadMinEdges > 0 &&
+      lpEdges.length >= this.offloadMinEdges &&
+      this.workerPool?.enabled()
+    ) {
+      try {
+        const out = await this.workerPool.run<{ clusters: string[][] }>(
+          resolveWorkerJobPath(),
+          { edges: lpEdges, maxIterations: this.maxIterations },
+        );
+        if (Array.isArray(out?.clusters)) return out.clusters;
+        this.logger.warn(
+          '[communities] worker-pool label propagation returned a malformed result; falling back in-thread',
+        );
+      } catch (e) {
+        this.logger.warn(
+          `[communities] worker-pool label propagation failed (${(e as Error).message}); falling back in-thread`,
+        );
+      }
+    }
+    return labelPropagation(buildAdjacency(lpEdges), this.maxIterations);
   }
 
   /**
@@ -487,6 +534,19 @@ interface RawFact {
   confidence: number;
   validFrom: unknown;
   validUntil?: unknown;
+}
+
+/**
+ * Locate the label-propagation worker-job module for the pool — the
+ * same .js-exists-else-.ts resolution JobWorkerPool uses for its
+ * runner: after nest build the handler compiles to .js alongside this
+ * file; in dev / ts-jest only the .ts source exists and Node's native
+ * type stripping loads it directly inside the pool worker.
+ */
+function resolveWorkerJobPath(): string {
+  const distCandidate = join(__dirname, 'label-propagation.worker-job.js');
+  if (existsSync(distCandidate)) return distCandidate;
+  return join(__dirname, 'label-propagation.worker-job.ts');
 }
 
 /**

--- a/src/communities/label-propagation.worker-job.ts
+++ b/src/communities/label-propagation.worker-job.ts
@@ -1,0 +1,64 @@
+/**
+ * JobWorkerPool handler for community label propagation.
+ *
+ * The nightly community rebuild used to run the O(iterations × edges)
+ * propagation sweeps on the main thread inside the dreams job. This
+ * module lets CommunityBuilderService offload that CPU chunk to the
+ * generic worker pool (see job-worker-runner.ts for the envelope):
+ * the pool worker dynamic-imports this file and calls `run(input)`.
+ *
+ * Contract constraints:
+ *   - Input and result MUST be structured-clone-able — plain arrays and
+ *     objects only, which is why the adjacency Map is built here from
+ *     raw edges rather than passed across the postMessage boundary.
+ *   - The import chain MUST stay free of Nest/DI so the worker thread
+ *     never boots framework code: this file loads ONLY the pure helpers
+ *     in ./label-propagation.
+ *
+ * Determinism: labelPropagation is pure and deterministic, so this
+ * off-thread path produces identical clusters to the in-thread fallback
+ * in CommunityBuilderService.
+ */
+
+export interface LabelPropagationWorkerInput {
+  edges: Array<{ from: string; to: string; weight?: number }>;
+  /** Sweep cap; omitted → labelPropagation's own default (10). */
+  maxIterations?: number;
+}
+
+type LabelPropagationModule = typeof import('./label-propagation');
+
+let lpModule: LabelPropagationModule | null = null;
+
+/**
+ * Load ./label-propagation in whichever module format this file is
+ * running as. After nest build both files are CommonJS .js and the
+ * static-looking specifier resolves normally. Under dev / jest the pool
+ * worker runs this .ts source directly via Node's native type
+ * stripping, which treats it as ESM and does NO extension searching —
+ * the relative specifier must name the .ts file explicitly. That
+ * fallback specifier is assembled at runtime because tsc (correctly)
+ * rejects literal .ts specifiers in emitted code.
+ */
+async function loadLabelPropagation(): Promise<LabelPropagationModule> {
+  if (lpModule) return lpModule;
+  try {
+    lpModule = (await import('./label-propagation.js')) as LabelPropagationModule;
+  } catch {
+    const tsSpecifier = './label-propagation' + '.ts';
+    lpModule = (await import(tsSpecifier)) as LabelPropagationModule;
+  }
+  return lpModule;
+}
+
+export async function run(input: unknown): Promise<{ clusters: string[][] }> {
+  const { edges, maxIterations } = (input ??
+    {}) as LabelPropagationWorkerInput;
+  const { buildAdjacency, labelPropagation } = await loadLabelPropagation();
+  const adjacency = buildAdjacency(Array.isArray(edges) ? edges : []);
+  const clusters =
+    typeof maxIterations === 'number'
+      ? labelPropagation(adjacency, maxIterations)
+      : labelPropagation(adjacency);
+  return { clusters };
+}

--- a/test/label-propagation-worker.unit-spec.ts
+++ b/test/label-propagation-worker.unit-spec.ts
@@ -1,0 +1,254 @@
+/**
+ * Community label propagation on the JobWorkerPool.
+ *
+ * Two surfaces under test:
+ *
+ *   1. label-propagation.worker-job.ts through a REAL worker_thread pool
+ *      (size 1) — the pool worker dynamic-imports the .ts handler via
+ *      Node's native type stripping (same mechanism as the pool's own
+ *      runner resolution) and its clusters must deep-equal a direct
+ *      in-thread labelPropagation(buildAdjacency(edges)) call: the
+ *      algorithm is pure and deterministic, so offloading may never
+ *      change the output.
+ *
+ *   2. CommunityBuilderService offload wiring — a pool whose run()
+ *      rejects must be invisible to the build result (in-thread
+ *      fallback produces the identical communities), a pool that
+ *      resolves is actually consumed, and COMMUNITIES_LP_OFFLOAD_MIN_EDGES=0
+ *      never touches the pool.
+ */
+import { ConfigService } from '@nestjs/config';
+import { join } from 'node:path';
+import { JobWorkerPool } from '../src/jobs/job-worker-pool.service';
+import {
+  buildAdjacency,
+  labelPropagation,
+} from '../src/communities/label-propagation';
+import {
+  CommunityBuilderService,
+  type CommunityBuildResult,
+} from '../src/communities/community-builder.service';
+
+const WORKER_JOB_PATH = join(
+  __dirname,
+  '..',
+  'src',
+  'communities',
+  'label-propagation.worker-job.ts',
+);
+
+function makeConfig(env: Record<string, string> = {}): ConfigService {
+  return {
+    get: <T>(key: string, dflt?: T) => (env[key] ?? dflt) as T,
+    getOrThrow: <T>(key: string) => env[key] as unknown as T,
+  } as unknown as ConfigService;
+}
+
+/** Two weighted cliques bridged by a weak link, plus a stray pair. */
+const FIXTURE_EDGES = [
+  { from: 'a', to: 'b', weight: 5 },
+  { from: 'b', to: 'c', weight: 5 },
+  { from: 'a', to: 'c', weight: 5 },
+  { from: 'c', to: 'n', weight: 5 },
+  { from: 'n', to: 's', weight: 1 },
+  { from: 'x', to: 'y' },
+  { from: 'y', to: 'z' },
+  { from: 'x', to: 'z' },
+  { from: 'p', to: 'q', weight: 2 },
+];
+
+describe('label-propagation.worker-job on a real JobWorkerPool', () => {
+  it('returns clusters deep-equal to the in-thread computation', async () => {
+    const pool = new JobWorkerPool(makeConfig({ JOB_WORKER_POOL_SIZE: '1' }));
+    await pool.onModuleInit();
+    try {
+      const out = await pool.run<{ clusters: string[][] }>(WORKER_JOB_PATH, {
+        edges: FIXTURE_EDGES,
+        maxIterations: 10,
+      });
+      const expected = labelPropagation(buildAdjacency(FIXTURE_EDGES), 10);
+      expect(out.clusters).toEqual(expected);
+      expect(expected.length).toBeGreaterThanOrEqual(3);
+    } finally {
+      await pool.onApplicationShutdown();
+    }
+  }, 15_000);
+
+  it('serves repeat calls from the cached module with identical output', async () => {
+    const pool = new JobWorkerPool(makeConfig({ JOB_WORKER_POOL_SIZE: '1' }));
+    await pool.onModuleInit();
+    try {
+      const first = await pool.run<{ clusters: string[][] }>(WORKER_JOB_PATH, {
+        edges: FIXTURE_EDGES,
+      });
+      const second = await pool.run<{ clusters: string[][] }>(WORKER_JOB_PATH, {
+        edges: FIXTURE_EDGES.slice(0, 5),
+      });
+      expect(first.clusters).toEqual(
+        labelPropagation(buildAdjacency(FIXTURE_EDGES)),
+      );
+      expect(second.clusters).toEqual(
+        labelPropagation(buildAdjacency(FIXTURE_EDGES.slice(0, 5))),
+      );
+    } finally {
+      await pool.onApplicationShutdown();
+    }
+  }, 15_000);
+});
+
+// ── CommunityBuilderService offload wiring ──────────────────────────
+
+/** Two entity triangles — both clear the default minSize of 3. */
+const E = (s: string): string => `knowledge_entity:${s}`;
+const BUILDER_EDGES = [
+  { in: E('a'), out: E('b') },
+  { in: E('b'), out: E('c') },
+  { in: E('a'), out: E('c') },
+  { in: E('x'), out: E('y') },
+  { in: E('y'), out: E('z') },
+  { in: E('x'), out: E('z') },
+];
+
+interface CapturedBuild {
+  result: CommunityBuildResult;
+  /** Sorted member-id lists, one per CREATEd community, in build order. */
+  memberSets: string[][];
+}
+
+function mkDb(): { db: { query: jest.Mock }; memberSets: string[][] } {
+  const memberSets: string[][] = [];
+  let created = 0;
+  const query = jest.fn(async (sql: string, params?: Record<string, unknown>) => {
+    if (sql.includes('GROUP ALL')) {
+      return [[{ c: BUILDER_EDGES.length, maxAt: '2026-07-01T00:00:00Z' }]];
+    }
+    if (sql.includes('UPSERT community_build_state')) return [[]];
+    if (sql.includes('FROM community_build_state')) return [[]];
+    if (sql.includes('FROM knowledge_edge')) {
+      return [
+        BUILDER_EDGES.map((e) => ({
+          ...e,
+          weight: 1,
+          createdAt: '2026-07-01T00:00:00Z',
+        })),
+      ];
+    }
+    if (sql.includes('FROM community_node')) return [[]];
+    if (sql.includes('FROM knowledge_entity')) {
+      return [[{ id: E('a'), canonicalName: 'Alpha' }]];
+    }
+    if (sql.includes('FROM knowledge_fact')) return [[]];
+    if (sql.includes('CREATE community_node')) {
+      created++;
+      return [[{ id: `community_node:c${created}` }]];
+    }
+    if (sql.includes('RELATE')) {
+      // Param values are StringRecordId instances; read the underlying
+      // rid so the captured member sets carry real entity ids.
+      const members = Object.entries(params ?? {})
+        .filter(([k]) => k.startsWith('e'))
+        .map(([, v]) => (v as { rid?: unknown }).rid ?? v)
+        .map(String)
+        .sort();
+      memberSets.push(members);
+      return [[]];
+    }
+    throw new Error(`unexpected query: ${sql}`);
+  });
+  return { db: { query }, memberSets };
+}
+
+function mkBuilder(pool?: JobWorkerPool): CommunityBuilderService {
+  return new CommunityBuilderService(
+    makeConfig({
+      DREAMS_COMMUNITIES_ENABLED: '1',
+      // Tiny threshold so the 6-edge fixture graph qualifies for offload.
+      COMMUNITIES_LP_OFFLOAD_MIN_EDGES: '1',
+    }),
+    { embed: jest.fn(async () => [0.1, 0.2]) } as never,
+    { generate: jest.fn(async () => 'summary') } as never,
+    pool,
+  );
+}
+
+async function runBuild(pool?: JobWorkerPool): Promise<CapturedBuild> {
+  const { db, memberSets } = mkDb();
+  const svc = mkBuilder(pool);
+  const result = await svc.run(db as never);
+  return { result, memberSets };
+}
+
+describe('CommunityBuilderService worker-pool offload', () => {
+  it('falls back in-thread on pool failure with an identical result', async () => {
+    const rejectingPool = {
+      enabled: () => true,
+      run: jest.fn().mockRejectedValue(new Error('pool exploded')),
+    } as unknown as JobWorkerPool;
+
+    const withPool = await runBuild(rejectingPool);
+    const withoutPool = await runBuild(undefined);
+
+    // The offload was attempted once, failed, and the fallback produced
+    // exactly what a pool-less builder produces.
+    expect((rejectingPool.run as jest.Mock).mock.calls).toHaveLength(1);
+    expect(withPool.result).toEqual(withoutPool.result);
+    expect(withPool.memberSets).toEqual(withoutPool.memberSets);
+    expect(withPool.result.communitiesBuilt).toBe(2);
+    expect(withPool.result.entitiesClustered).toBe(6);
+  });
+
+  it('consumes clusters computed by the pool when it succeeds', async () => {
+    const pool = {
+      enabled: () => true,
+      run: jest.fn(async (modulePath: string, input: unknown) => {
+        expect(modulePath).toMatch(/label-propagation\.worker-job\.(js|ts)$/);
+        const { edges, maxIterations } = input as {
+          edges: Array<{ from: string; to: string; weight?: number }>;
+          maxIterations: number;
+        };
+        return { clusters: labelPropagation(buildAdjacency(edges), maxIterations) };
+      }),
+    } as unknown as JobWorkerPool;
+
+    const offloaded = await runBuild(pool);
+    const inThread = await runBuild(undefined);
+
+    expect((pool.run as jest.Mock).mock.calls).toHaveLength(1);
+    expect(offloaded.result).toEqual(inThread.result);
+    expect(offloaded.memberSets).toEqual(inThread.memberSets);
+  });
+
+  it('never touches the pool when COMMUNITIES_LP_OFFLOAD_MIN_EDGES=0', async () => {
+    const pool = {
+      enabled: () => true,
+      run: jest.fn(),
+    } as unknown as JobWorkerPool;
+    const { db } = mkDb();
+    const svc = new CommunityBuilderService(
+      makeConfig({
+        DREAMS_COMMUNITIES_ENABLED: '1',
+        COMMUNITIES_LP_OFFLOAD_MIN_EDGES: '0',
+      }),
+      { embed: jest.fn(async () => [0.1, 0.2]) } as never,
+      { generate: jest.fn(async () => 'summary') } as never,
+      pool,
+    );
+
+    const result = await svc.run(db as never);
+
+    expect(pool.run).not.toHaveBeenCalled();
+    expect(result.communitiesBuilt).toBe(2);
+  });
+
+  it('skips a disabled pool without calling run()', async () => {
+    const pool = {
+      enabled: () => false,
+      run: jest.fn(),
+    } as unknown as JobWorkerPool;
+
+    const { result } = await runBuild(pool);
+
+    expect(pool.run).not.toHaveBeenCalled();
+    expect(result.communitiesBuilt).toBe(2);
+  });
+});


### PR DESCRIPTION
Workers wave W3 — the first real consumer of the JobWorkerPool (built, warmed at boot with 2 threads, and unused until now).

- New `src/communities/label-propagation.worker-job.ts`: pure DI-free worker module; adjacency built in-worker so the O(E) materialisation also leaves the main thread.
- `CommunityBuilderService` offloads when the pool is enabled AND `edges >= COMMUNITIES_LP_OFFLOAD_MIN_EDGES` (default 2000; 0 = never); any pool failure falls back in-thread — the function is deterministic, output identical either way.
- Runtime gotcha solved: a plain relative import fails in the pool worker under Node 24 native type-stripping (ESM, no extension search) — the worker-job path resolves `.js` (dist) first, then a runtime-assembled `.ts` specifier; both environments verified end-to-end with a real worker thread.

Verification: real size-1 pool vs in-thread deep-equal, rejecting-pool fallback identity, threshold/disabled paths never touch the pool; tsc/lint clean; label-propagation + job-worker-pool + communities suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd