### PR TITLE
feat(packs): pack:init scaffold and authoring quickstart docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,43 @@ expected — we keep the trail honest.
 - **Type-narrowing PRs.** If you find an `as any` or a `Record<string,
   unknown>` that shouldn't be there, tightening it is welcome.
 
+## Building a Domain Pack
+
+Domain Packs extend brain's ontology without forking core — the standard
+lives in [docs/domain-packs.md](docs/domain-packs.md).
+
+**Community packs need NO PR to this repo.** A pack is a JSON manifest you
+author, validate, optionally sign, and publish to a registry instance —
+then any tenant installs it at runtime. The full loop is one command
+sequence: see the
+[Quickstart in docs/domain-packs.md](docs/domain-packs.md#quickstart-author--validate--sign--publish--install)
+(`pnpm pack:init my_pack` scaffolds a valid starter manifest; edit →
+`pack:validate` → `pack:sign` → `pack:publish` → `pack:install` → eval).
+
+**First-party packs** (shipped in-repo, like the six industry packs:
+`real_estate`, `fintech`, `medical`, `legal`, `insurance`, `hr`) DO go
+through a PR, and the recipe is fixed:
+
+1. **TS source of truth** — `src/ai/domain-packs/<id>.pack.ts` exporting a
+   `DomainPackManifest` const (see `fintech.pack.ts` for the shape). A
+   first-party pack is a complete ontology, not a stub: ≥ 4 namespaced
+   predicates with TYPE/ADMIT/VALUE description cards, an
+   `extractionProfile` (guidance + few-shot), and `evalFixtures` with fact
+   expectations.
+2. **Registration** — add the export to `FIRST_PARTY_PACKS` in
+   `src/ai/domain-packs/index.ts` (NOT `BUILTIN_PACKS` — builtins seed
+   every tenant globally; distributable packs are installed per-tenant).
+3. **Committed JSON artifact** — `packs/<id-with-dashes>.pack.json`
+   (underscores in the id become dashes in the filename, e.g.
+   `real_estate` → `real-estate.pack.json`). Serialize the TS manifest
+   with 2-space indent + trailing newline; it must deep-equal the TS
+   source.
+4. **Tests** — `test/industry-packs.unit-spec.ts` covers every entry in
+   `FIRST_PARTY_PACKS` automatically (validity, profile, fixtures,
+   not-a-builtin, JSON/TS drift guard), but its `first-party pack
+   library` block hardcodes the expected sorted id list — add your id
+   there. Run `pnpm test -- industry-packs`.
+
 ## Releasing
 
 Brain auto-deploys on push to `main` via `.github/workflows/deploy-brain.yml`

--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -14,6 +14,45 @@ a general seed (`name`, `said`, `plan`, …). A domain needs its own vocabulary 
 but baking every domain's predicates into the core seed doesn't scale and can't
 be community-extended. Packs make the ontology a first-class, versioned plugin.
 
+## Quickstart: author → validate → sign → publish → install
+
+The whole community-author loop, copy-paste ready (details for each step live
+in the sections below):
+
+```bash
+# 1. Scaffold a valid starter manifest → ./my_pack.pack.json
+pnpm pack:init my_pack
+
+# 2. Edit my_pack.pack.json — predicates (TYPE/ADMIT/VALUE cards),
+#    extractionProfile, evalFixtures, optional indexer descriptor.
+
+# 3. Validate against the standard + core collision check
+pnpm pack:validate my_pack.pack.json
+
+# 4. (optional) Sign as your publisher id — required when the target brain
+#    sets DOMAIN_PACK_REQUIRE_SIGNATURE / PACK_REGISTRY_REQUIRE_SIGNATURE
+openssl genpkey -algorithm ed25519 -out priv.pem   # once, if you have no key
+pnpm pack:sign -- --file my_pack.pack.json --key priv.pem --publisher acme
+
+# 5. Publish into the global registry (key needs the registry:publish scope)
+BRAIN_API_KEY=... pnpm pack:publish -- --brain-url https://brain.inite.ai \
+  --file my_pack.pack.json --keywords my,keywords --verify
+
+# 6. Install into a tenant (key needs brain:admin) — from the registry…
+BRAIN_API_KEY=... pnpm pack:install -- --brain-url https://brain.inite.ai \
+  --registry my_pack
+#    …or straight from the reviewed local file, checksum-pinned
+BRAIN_API_KEY=... pnpm pack:install -- --brain-url https://brain.inite.ai \
+  --file my_pack.pack.json --verify
+
+# 7. Score the LIVE extractor against the pack's own evalFixtures
+curl -X POST -H "Authorization: Bearer $BRAIN_API_KEY" \
+  https://brain.inite.ai/v1/admin/packs/my_pack/eval
+```
+
+No PR to this repo is needed for any of it — a community pack is JSON,
+published to a registry instance and installed per-tenant.
+
 ## The manifest
 
 A pack is a `DomainPackManifest` (`src/ai/domain-packs/manifest.ts`):

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "label:decisions": "ts-node -r tsconfig-paths/register scripts/label-decisions.ts",
     "label:commitpackft": "ts-node -r tsconfig-paths/register scripts/label-commitpackft.ts",
     "train:decision-gate": "ts-node -r tsconfig-paths/register scripts/train-decision-gate.ts",
+    "pack:init": "ts-node -r tsconfig-paths/register scripts/init-pack.ts",
     "pack:validate": "ts-node -r tsconfig-paths/register scripts/validate-pack.ts",
     "pack:install": "ts-node -r tsconfig-paths/register scripts/install-pack.ts",
     "pack:sign": "ts-node -r tsconfig-paths/register scripts/sign-pack.ts",

--- a/scripts/init-pack.ts
+++ b/scripts/init-pack.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env ts-node
+/**
+ * Domain Pack scaffold CLI (docs/domain-packs.md § Quickstart).
+ *
+ *   pnpm pack:init <pack_id>
+ *
+ * Writes `./<pack_id>.pack.json` — a valid, installable skeleton manifest a
+ * community author edits into a real pack: one example predicate (the
+ * TYPE/ADMIT/VALUE card format the extractor consumes), an extractionProfile
+ * stub, one evalFixture, and a clearly-marked OPTIONAL `indexer` example
+ * showing the three document-pipeline modes (virtual / dedicated / external).
+ *
+ * The id must be snake_case, must not contain the reserved `__` separator or
+ * end with `_`, and must not shadow a builtin/first-party pack id. The fresh
+ * skeleton already passes `pnpm pack:validate` — edit, re-validate, then
+ * sign/publish/install (see the quickstart in docs/domain-packs.md).
+ *
+ * `makePackSkeleton` is exported pure so the unit suite
+ * (test/pack-init.unit-spec.ts) can assert the skeleton stays valid.
+ */
+import { existsSync, writeFileSync } from 'node:fs';
+import {
+  BUILTIN_PACKS,
+  FIRST_PARTY_PACKS,
+} from '../src/ai/domain-packs';
+import { DomainPackError, validatePack } from '../src/ai/domain-packs/validate';
+import type { DomainPackManifest } from '../src/ai/domain-packs/manifest';
+
+/** Ids already taken by builtin (globally seeded) or first-party
+ *  (distributable, shipped in packs/) manifests — a community pack must not
+ *  shadow them. */
+export const RESERVED_PACK_IDS: ReadonlySet<string> = new Set(
+  [...BUILTIN_PACKS, ...FIRST_PARTY_PACKS].map((p) => p.id),
+);
+
+/** The skeleton is a valid DomainPackManifest plus one advisory, non-standard
+ *  `// indexer` key (unknown keys are ignored by validatePack/assembleSeed)
+ *  that documents the OPTIONAL indexer descriptor. Authors delete it or
+ *  promote one of its shapes to a real top-level `indexer` field. */
+export type PackSkeleton = DomainPackManifest & {
+  '// indexer': Record<string, unknown>;
+};
+
+/**
+ * Build the starter manifest for a new community pack. Pure — no filesystem.
+ * Throws DomainPackError on an invalid id (charset / `__` / trailing `_`,
+ * enforced by validatePack) or a reserved builtin/first-party id.
+ */
+export function makePackSkeleton(id: string): PackSkeleton {
+  if (RESERVED_PACK_IDS.has(id)) {
+    throw new DomainPackError(
+      `pack id "${id}" is reserved by a builtin/first-party pack — pick another id`,
+    );
+  }
+  const skeleton: PackSkeleton = {
+    id,
+    version: '0.1.0',
+    description: `TODO: one-line human description of the ${id} pack.`,
+    predicates: [
+      {
+        localId: 'example_predicate',
+        displayLabel: 'example predicate',
+        description:
+          'TYPE   subject is a <what kind of entity>; value is <what the value means>\n' +
+          'ADMIT  text states <when the extractor should emit this fact>\n' +
+          'VALUE  the value, verbatim from the text',
+        datatype: 'string',
+        semantics: 'single_active',
+        decayHalfLifeDays: null,
+        piiClass: 'none',
+        status: 'active',
+      },
+    ],
+    extractionProfile: {
+      guidance: `TODO: domain framing appended to the extractor system prompt. Name the subject entity type and steer toward the ${id}__* predicates. Advisory — never overrides the VERBATIM RULE or the strict output schema.`,
+      fewShot: [
+        {
+          text: 'TODO: a short sample input snippet from your domain.',
+          note: `TODO: what a correct extraction captures, e.g. subject → ${id}__example_predicate='<value>'.`,
+        },
+      ],
+    },
+    evalFixtures: [
+      {
+        id: 'example',
+        description:
+          'TODO: what this fixture proves. Run via POST /v1/admin/packs/:packId/eval.',
+        text: 'TODO: input text the LIVE extractor is run against.',
+        expect: {
+          facts: [
+            {
+              // Bare localId resolves to the pack namespace (<id>__example_predicate).
+              predicate: 'example_predicate',
+              objectIncludes: 'TODO substring the extracted value must contain',
+            },
+          ],
+        },
+      },
+    ],
+    '// indexer': {
+      '//':
+        'OPTIONAL document-pipeline descriptor (docs/domain-packs.md § Indexer descriptor). ' +
+        "Absent = 'virtual': the pack rides the single union extraction call at zero extra " +
+        'LLM cost. To opt in, add a top-level "indexer" field shaped like ONE of the ' +
+        'examples below, then delete this whole "// indexer" block.',
+      virtual: { mode: 'virtual' },
+      dedicated: {
+        mode: 'dedicated',
+        relevance: {
+          keywords: ['example', 'keywords'],
+          description: 'Documents this pack should index (embedded for the cosine gate)',
+          threshold: 0.3,
+        },
+        dedicated: { includeCorePredicates: true, scPasses: 1 },
+      },
+      external: {
+        mode: 'external',
+        relevance: { keywords: ['example'] },
+        external: { publisher: 'your_publisher_id' },
+      },
+    },
+  };
+  // Same gate as `pnpm pack:validate` — enforces the id rules (snake_case,
+  // no "__", no trailing "_") and keeps the skeleton honest as the standard
+  // evolves. A skeleton that doesn't validate is a bug in this script.
+  validatePack(skeleton);
+  return skeleton;
+}
+
+function main(): void {
+  const id = process.argv[2];
+  if (!id) {
+    throw new Error('usage: pack:init <pack_id>   (snake_case, e.g. my_pack)');
+  }
+  const skeleton = makePackSkeleton(id);
+  const out = `${id}.pack.json`;
+  if (existsSync(out)) {
+    throw new Error(`refusing to overwrite existing ${out}`);
+  }
+  writeFileSync(out, `${JSON.stringify(skeleton, null, 2)}\n`);
+  console.log(`✓ wrote ${out} — a valid starter manifest for pack "${id}"`);
+  console.log('next steps (docs/domain-packs.md § Quickstart):');
+  console.log(`  1. edit ${out} — predicates, extractionProfile, evalFixtures`);
+  console.log(`  2. pnpm pack:validate ${out}`);
+  console.log(
+    `  3. pnpm pack:sign -- --file ${out} --key priv.pem --publisher <you>`,
+  );
+  console.log(
+    `  4. BRAIN_API_KEY=... pnpm pack:publish -- --brain-url <url> --file ${out} --verify`,
+  );
+  console.log(
+    `  5. BRAIN_API_KEY=... pnpm pack:install -- --brain-url <url> --registry ${id}`,
+  );
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (e) {
+    console.error(`✗ pack:init failed: ${(e as Error).message}`);
+    process.exit(1);
+  }
+}

--- a/test/pack-init.unit-spec.ts
+++ b/test/pack-init.unit-spec.ts
@@ -1,0 +1,88 @@
+/**
+ * pack:init scaffold (scripts/init-pack.ts) — the community-author on-ramp.
+ * The generated skeleton must ALWAYS be a valid, core-collision-free manifest
+ * (a fresh `pnpm pack:init` output passes `pnpm pack:validate` unedited), and
+ * the id gate must refuse malformed + reserved builtin/first-party ids.
+ */
+import {
+  makePackSkeleton,
+  RESERVED_PACK_IDS,
+} from '../scripts/init-pack';
+import {
+  assembleSeed,
+  validatePack,
+  DomainPackError,
+} from '../src/ai/domain-packs';
+import { CORE_PREDICATES } from '../src/ai/predicate-registry-internals/core-seed';
+
+describe('pack:init skeleton', () => {
+  it('passes validatePack unedited', () => {
+    const skeleton = makePackSkeleton('my_test_pack');
+    expect(() => validatePack(skeleton)).not.toThrow();
+    expect(skeleton.id).toBe('my_test_pack');
+    expect(skeleton.version).toBe('0.1.0');
+  });
+
+  it('assembles onto the core seed collision-free (namespaced)', () => {
+    const skeleton = makePackSkeleton('my_test_pack');
+    expect(() => assembleSeed(CORE_PREDICATES, [skeleton])).not.toThrow();
+    const merged = assembleSeed(CORE_PREDICATES, [skeleton]);
+    expect(
+      merged.some((p) => p.predicateId === 'my_test_pack__example_predicate'),
+    ).toBe(true);
+    // Pack predicates are stamped createdBy:'system' by the assembler.
+    const composed = merged.find(
+      (p) => p.predicateId === 'my_test_pack__example_predicate',
+    );
+    expect(composed?.createdBy).toBe('system');
+  });
+
+  it('ships an extractionProfile stub and one eval fixture', () => {
+    const skeleton = makePackSkeleton('my_test_pack');
+    expect(skeleton.extractionProfile?.guidance?.length ?? 0).toBeGreaterThan(0);
+    expect(skeleton.extractionProfile?.fewShot?.length ?? 0).toBeGreaterThan(0);
+    expect(skeleton.evalFixtures?.length ?? 0).toBeGreaterThan(0);
+    for (const f of skeleton.evalFixtures ?? []) {
+      expect(typeof f.id).toBe('string');
+      expect(typeof f.text).toBe('string');
+      expect((f.expect.facts ?? []).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('marks the indexer descriptor example as clearly optional (non-standard key)', () => {
+    const skeleton = makePackSkeleton('my_test_pack');
+    // The example rides a non-standard "// indexer" key so the skeleton stays
+    // a plain valid manifest; a real opt-in uses a top-level `indexer` field.
+    expect(skeleton['// indexer']).toBeDefined();
+    expect((skeleton as { indexer?: unknown }).indexer).toBeUndefined();
+    const modes = skeleton['// indexer'] as Record<
+      string,
+      { mode?: string } | string
+    >;
+    expect((modes.virtual as { mode?: string }).mode).toBe('virtual');
+    expect((modes.dedicated as { mode?: string }).mode).toBe('dedicated');
+    expect((modes.external as { mode?: string }).mode).toBe('external');
+  });
+
+  it('rejects malformed ids (charset / "__" separator / trailing underscore)', () => {
+    for (const bad of ['My-Pack', '1pack', 'foo__bar', 'foo_', '']) {
+      expect(() => makePackSkeleton(bad)).toThrow(DomainPackError);
+    }
+  });
+
+  it('refuses reserved builtin/first-party pack ids', () => {
+    const reserved = [
+      'code_memory',
+      'real_estate',
+      'fintech',
+      'medical',
+      'legal',
+      'insurance',
+      'hr',
+    ];
+    for (const id of reserved) {
+      expect(RESERVED_PACK_IDS.has(id)).toBe(true);
+      expect(() => makePackSkeleton(id)).toThrow(/reserved/);
+    }
+  });
+});


### PR DESCRIPTION
Platform wave PL4 — the pack-authoring on-ramp for community developers.

- New `pnpm pack:init <id>`: writes a `<id>.pack.json` skeleton (example predicate with real `PackPredicate` fields, extractionProfile stub, one evalFixture, and an optional indexer block showing all three modes). Ids are validated by the real `validatePack`; builtin/first-party ids are refused. Pure `makePackSkeleton` is unit-tested to pass `validatePack` + `assembleSeed`.
- `docs/domain-packs.md`: consolidated "Quickstart: author → validate → sign → publish → install" with the real CLI flags.
- `CONTRIBUTING.md`: "Building a Domain Pack" — community packs need no PR at all (author → publish); the first-party pack recipe is documented against how the 6 industry packs are actually wired.

Verification: 6 new unit tests + industry-packs suite green; live loop exercised (`pack:init demo_pack` → `pack:validate` OK); tsc/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd