### PR TITLE
feat(registry): download counters and verified-publisher badge

### DIFF
--- a/src/contracts/registry/registry.schema.ts
+++ b/src/contracts/registry/registry.schema.ts
@@ -14,9 +14,16 @@ export const RegistryVersionSchema = z.object({
   keywords: z.array(z.string()),
   publisher: z.string().nullable(),
   signed: z.boolean(),
+  /** Signature validated against the HOSTING instance's trust store at
+   *  publish time — a discovery badge. Install-time verification against the
+   *  installing tenant's own trust store stays the security boundary. */
+  verified: z.boolean().default(false),
   yanked: z.boolean(),
   yankReason: z.string().nullable(),
   publishedAt: z.string(),
+  /** Installs served for THIS version (install path only — browsing and
+   *  manifest inspection are not counted). */
+  downloads: z.number().int().nonnegative().default(0),
 });
 
 /** One pack in a catalogue listing — its latest installable version + counts. */
@@ -27,6 +34,12 @@ export const RegistryPackSummarySchema = z.object({
   keywords: z.array(z.string()),
   publisher: z.string().nullable(),
   signed: z.boolean(),
+  /** verified flag of the latest installable version (see RegistryVersion). */
+  verified: z.boolean().default(false),
+  /** Installs served, summed across ALL of the pack's versions. */
+  downloads: z.number().int().nonnegative().default(0),
+  /** publishedAt of the latest installable version (ISO 8601). */
+  publishedAt: z.string().optional(),
   versionCount: z.number().int().nonnegative(),
 });
 

--- a/src/db/migrations/0063_registry_pack_downloads.surql
+++ b/src/db/migrations/0063_registry_pack_downloads.surql
@@ -1,0 +1,23 @@
+-- 0063_registry_pack_downloads — download counters + verified-publisher flag
+-- for the GLOBAL pack registry catalogue (registry_pack, migration 0042).
+--
+-- downloads: per-version counter, incremented ONLY on the install path
+--   (PackRegistryService.resolveForInstall, serving POST
+--   /v1/admin/packs/from-registry). Catalogue browsing and manifest
+--   inspection deliberately do NOT count — the number means "installs
+--   served", not "page views". The catalogue summary reports the SUM
+--   across a pack's versions.
+--
+-- verified: set at PUBLISH time when the manifest carries an ed25519
+--   signature that validates against the HOSTING instance's trust store
+--   (DOMAIN_PACK_TRUSTED_KEYS). A discovery/UX signal only: install-time
+--   verification against the INSTALLING tenant's own trust store
+--   (assertPackTrust) remains the real security boundary.
+
+DEFINE FIELD IF NOT EXISTS downloads ON registry_pack TYPE int DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS verified  ON registry_pack TYPE bool DEFAULT false;
+
+-- Backfill versions published before this migration: DEFAULT applies on
+-- CREATE only, so pre-existing rows would read back NONE without this.
+UPDATE registry_pack SET downloads = 0 WHERE downloads IS NONE;
+UPDATE registry_pack SET verified = false WHERE verified IS NONE;

--- a/src/registry/pack-registry.service.ts
+++ b/src/registry/pack-registry.service.ts
@@ -15,6 +15,7 @@ import {
   pickLatestVersion,
   compareSemver,
   validatePack,
+  verifyPackSignature,
   type DomainPackManifest,
 } from '../ai/domain-packs';
 import type {
@@ -35,9 +36,11 @@ interface RegistryRow {
   keywords?: string[];
   publisher?: string | null;
   signed?: boolean;
+  verified?: boolean;
   yanked?: boolean;
   yankReason?: string | null;
   publishedAt: string;
+  downloads?: number;
 }
 
 /**
@@ -55,7 +58,9 @@ interface RegistryRow {
  *     reproducible.
  *   - Trust is end-to-end: the manifest's signature/publisher are stored as-is;
  *     cryptographic verification happens at INSTALL time against the installing
- *     tenant's trust store. The registry is a content store.
+ *     tenant's trust store. The registry is a content store. The `verified`
+ *     flag it stamps at publish time (hosting instance's trust store) is a
+ *     discovery badge, not a substitute for that boundary.
  */
 @Injectable()
 export class PackRegistryService {
@@ -114,6 +119,13 @@ export class PackRegistryService {
     const keywords = (Array.isArray(input.keywords) ? input.keywords : [])
       .map((k) => String(k).trim().toLowerCase())
       .filter(Boolean);
+    // NOTE: `verified` reflects the HOSTING instance's trust store AT PUBLISH
+    // TIME — a discovery/UX badge, not a security gate. Install-time
+    // verification against the INSTALLING tenant's own trust store
+    // (assertPackTrust) remains the real security boundary. Unsigned or
+    // failing verification is NOT an error here: publishing unsigned stays
+    // allowed unless PACK_REGISTRY_REQUIRE_SIGNATURE (above) says otherwise.
+    const verified = this.verifiedAtPublish(manifest);
 
     // Concurrent publishes of the same (packId, version) both pass the SELECT
     // (no prior) and race to CREATE; the UNIQUE index turns the loser's write
@@ -152,6 +164,8 @@ export class PackRegistryService {
           description: manifest.description ?? '',
           keywords,
           signed: Boolean(manifest.signature),
+          verified,
+          downloads: 0,
           yanked: false,
         };
         if (manifest.publisher) content.publisher = manifest.publisher;
@@ -202,6 +216,11 @@ export class PackRegistryService {
         keywords: row.keywords ?? [],
         publisher: row.publisher ?? null,
         signed: Boolean(row.signed),
+        verified: Boolean(row.verified),
+        // Adoption over the pack's whole history — SUM across all versions
+        // (yanked included: those installs happened), not just the latest.
+        downloads: versions.reduce((n, v) => n + Number(v.downloads ?? 0), 0),
+        publishedAt: new Date(row.publishedAt).toISOString(),
         versionCount: versions.length,
       });
     }
@@ -272,6 +291,24 @@ export class PackRegistryService {
     if (row.yanked) {
       throw new BadRequestException(
         `pack "${packId}" version ${row.version} is yanked and cannot be installed`,
+      );
+    }
+    // Download accounting lives HERE and only here: resolveForInstall serves
+    // the install path (POST /v1/admin/packs/from-registry). Catalogue
+    // browsing / manifest inspection (list/getVersions/getManifest) must not
+    // count. Best-effort: a failed counter write never fails the install.
+    // Keyed by the UNIQUE (packId, version) index — a single-row update.
+    try {
+      await this.surreal.withAdminDb((db) =>
+        db.query(
+          `UPDATE registry_pack SET downloads += 1
+             WHERE packId = $packId AND version = $version`,
+          { packId, version: row.version },
+        ),
+      );
+    } catch (e) {
+      this.logger.warn(
+        `Failed to count download for ${packId}@${row.version}: ${(e as Error).message}`,
       );
     }
     return { manifest: row.manifest, checksum: row.checksum };
@@ -348,8 +385,8 @@ export class PackRegistryService {
    *  inspection / install-resolution wants it dropped. */
   private projection(includeManifest: boolean): string {
     return `packId, version,${includeManifest ? ' manifest,' : ''} checksum,
-            description, keywords, publisher, signed, yanked, yankReason,
-            publishedAt`;
+            description, keywords, publisher, signed, verified, yanked,
+            yankReason, publishedAt, downloads`;
   }
 
   /** One pack's rows, packId-index scoped (no full-table scan). */
@@ -387,9 +424,37 @@ export class PackRegistryService {
       keywords: r.keywords ?? [],
       publisher: r.publisher ?? null,
       signed: Boolean(r.signed),
+      verified: Boolean(r.verified),
       yanked: Boolean(r.yanked),
       yankReason: r.yankReason ?? null,
       publishedAt: new Date(r.publishedAt).toISOString(),
+      downloads: Number(r.downloads ?? 0),
     };
+  }
+
+  /** Trust store: publisher → PEM public key, from DOMAIN_PACK_TRUSTED_KEYS
+   *  (JSON) — the SAME store the install path uses (DomainPackInstallService).
+   *  Empty when unset; a JSON typo is logged loudly and treated as empty
+   *  (validateEnv also rejects it at boot — this covers env drift after). */
+  private trustedKeys(): Record<string, string> {
+    try {
+      return JSON.parse(process.env.DOMAIN_PACK_TRUSTED_KEYS ?? '{}');
+    } catch (e) {
+      this.logger.error(
+        `DOMAIN_PACK_TRUSTED_KEYS is not valid JSON (${(e as Error).message}) — treating trust store as EMPTY`,
+      );
+      return {};
+    }
+  }
+
+  /** verified-at-publish: true only when the manifest names a publisher whose
+   *  key is in THIS hosting instance's trust store AND its ed25519 signature
+   *  validates against that key. Unsigned / unknown publisher / bad signature
+   *  → false, never an error (see the publish-time NOTE). */
+  private verifiedAtPublish(manifest: DomainPackManifest): boolean {
+    if (!manifest.signature || !manifest.publisher) return false;
+    const key = this.trustedKeys()[manifest.publisher];
+    if (!key) return false;
+    return verifyPackSignature(manifest, key);
   }
 }

--- a/src/registry/registry-ui.ts
+++ b/src/registry/registry-ui.ts
@@ -22,14 +22,25 @@ function card(p: RegistryPackSummary): string {
   const tags = p.keywords
     .map((k) => `<span class="tag">${esc(k)}</span>`)
     .join('');
-  const badge = p.signed ? '<span class="badge">signed</span>' : '';
+  // Green "verified" = signature validated against THIS instance's trust
+  // store at publish time; neutral "signed" = carries a signature nobody here
+  // vouches for. Deliberately distinct — a bare signature proves nothing to a
+  // visitor. Verified implies signed, so only the stronger badge is shown.
+  const badge = p.verified
+    ? '<span class="badge verified">verified</span>'
+    : p.signed
+      ? '<span class="badge signed">signed</span>'
+      : '';
   const publisher = p.publisher
     ? `<span class="pub">by ${esc(p.publisher)}</span>`
+    : '';
+  const published = p.publishedAt
+    ? `<span class="date">published ${esc(String(p.publishedAt).slice(0, 10))}</span>`
     : '';
   return `<article class="pack">
   <h2>${esc(p.packId)} <span class="ver">v${esc(p.latestVersion)}</span> ${badge}</h2>
   <p class="desc">${esc(p.description || '(no description)')}</p>
-  <div class="meta">${tags}${publisher}<span class="vc">${p.versionCount} version(s)</span></div>
+  <div class="meta">${tags}${publisher}<span class="dl">${esc(p.downloads ?? 0)} download(s)</span>${published}<span class="vc">${p.versionCount} version(s)</span></div>
   <code class="install">pnpm pack:install -- --registry ${esc(p.packId)}</code>
 </article>`;
 }
@@ -51,7 +62,9 @@ h1{font-size:1.6rem;margin:0 0 .25rem}
 .pack{border:1px solid #8883;border-radius:10px;padding:1rem 1.25rem;margin:0 0 1rem}
 .pack h2{font-size:1.15rem;margin:0 0 .25rem}
 .ver{color:#888;font-weight:400;font-size:.9rem}
-.badge{background:#2e7d32;color:#fff;font-size:.7rem;padding:.1rem .4rem;border-radius:4px;vertical-align:middle}
+.badge{font-size:.7rem;padding:.1rem .4rem;border-radius:4px;vertical-align:middle}
+.badge.signed{background:#8883}
+.badge.verified{background:#2e7d32;color:#fff}
 .desc{margin:.25rem 0 .5rem}
 .meta{display:flex;flex-wrap:wrap;gap:.4rem;align-items:center;font-size:.8rem;color:#888;margin-bottom:.5rem}
 .tag{background:#8882;border-radius:4px;padding:.1rem .45rem}

--- a/test/pack-registry.e2e-spec.ts
+++ b/test/pack-registry.e2e-spec.ts
@@ -8,7 +8,8 @@
  * catalogue lives in the shared `system` DB (withAdminDb), distinct from the
  * per-tenant domain_pack install record.
  */
-import { REAL_ESTATE_PACK } from '../src/ai/domain-packs';
+import { generateKeyPairSync } from 'node:crypto';
+import { REAL_ESTATE_PACK, signPack } from '../src/ai/domain-packs';
 import type { AppFixture } from './app-fixture';
 import { createApp } from './app-fixture';
 
@@ -21,12 +22,29 @@ const PACK = {
 };
 const bump = (version: string) => ({ ...PACK, version });
 
+// ed25519 keypairs for the verified-publisher tests: one whose public key the
+// hosting instance trusts (DOMAIN_PACK_TRUSTED_KEYS), one rogue.
+function keypair() {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  return {
+    pub: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    priv: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+  };
+}
+const trusted = keypair();
+const rogue = keypair();
+
 describe('/v1/registry — global pack registry (e2e)', () => {
   let pub: AppFixture; // has registry:publish + brain:admin + brain:read
   let reader: AppFixture; // brain:read only
   const auth = (f: AppFixture) => ({ Authorization: `Bearer ${f.apiKey}` });
 
   beforeAll(async () => {
+    // The hosting instance's trust store — read lazily at publish time; set
+    // before boot so env validation sees valid JSON too.
+    process.env.DOMAIN_PACK_TRUSTED_KEYS = JSON.stringify({
+      acme_e2e: trusted.pub,
+    });
     pub = await createApp({
       companyId: 'co_registry_pub_e2e',
       scopes: ['brain:read', 'brain:write', 'brain:admin', 'registry:publish'],
@@ -37,6 +55,7 @@ describe('/v1/registry — global pack registry (e2e)', () => {
     });
   });
   afterAll(async () => {
+    delete process.env.DOMAIN_PACK_TRUSTED_KEYS;
     if (pub) await pub.close();
     if (reader) await reader.close();
   });
@@ -188,6 +207,164 @@ describe('/v1/registry — global pack registry (e2e)', () => {
       .get('/v1/registry/packs/kw_guard_e2e')
       .set(auth(reader));
     expect(versions.body.versions[0].keywords).toEqual([]);
+  });
+
+  it('counts downloads on install only — browsing does not count', async () => {
+    const id = 'dl_count_e2e';
+    await pub.http
+      .post('/v1/admin/registry/packs')
+      .set(auth(pub))
+      .send({ manifest: { ...PACK, id, version: '0.1.0' } });
+
+    // Hit every read/browse surface: catalogue list, version list, manifest
+    // inspection. None of these are installs.
+    await reader.http.get('/v1/registry/packs?q=dl_count').set(auth(reader));
+    await reader.http.get(`/v1/registry/packs/${id}`).set(auth(reader));
+    await reader.http.get(`/v1/registry/packs/${id}/latest`).set(auth(reader));
+
+    let versions = await reader.http
+      .get(`/v1/registry/packs/${id}`)
+      .set(auth(reader));
+    expect(versions.body.versions[0].downloads).toBe(0);
+
+    // Install from the registry twice (same-version reinstall is an upsert) —
+    // each resolve-for-install counts.
+    for (let i = 0; i < 2; i++) {
+      const r = await pub.http
+        .post('/v1/admin/packs/from-registry')
+        .set(auth(pub))
+        .send({ packId: id });
+      expect([200, 201]).toContain(r.status);
+    }
+    versions = await reader.http
+      .get(`/v1/registry/packs/${id}`)
+      .set(auth(reader));
+    expect(versions.body.versions[0].downloads).toBe(2);
+  });
+
+  it('catalogue summary sums downloads across versions; publishedAt exposed', async () => {
+    const id = 'dl_count_e2e'; // 0.1.0 already has 2 downloads from above
+    await pub.http
+      .post('/v1/admin/registry/packs')
+      .set(auth(pub))
+      .send({ manifest: { ...PACK, id, version: '0.2.0' } });
+    const r = await pub.http
+      .post('/v1/admin/packs/from-registry')
+      .set(auth(pub))
+      .send({ packId: id, version: '0.2.0' });
+    expect([200, 201]).toContain(r.status);
+
+    const list = await reader.http
+      .get('/v1/registry/packs?q=dl_count')
+      .set(auth(reader));
+    const summary = list.body.packs.find((p: any) => p.packId === id);
+    expect(summary.downloads).toBe(3); // 2 (v0.1.0) + 1 (v0.2.0)
+    expect(typeof summary.publishedAt).toBe('string');
+    expect(new Date(summary.publishedAt).getTime()).not.toBeNaN();
+
+    // Per-version split stays visible on the versions endpoint.
+    const versions = await reader.http
+      .get(`/v1/registry/packs/${id}`)
+      .set(auth(reader));
+    const byVer = Object.fromEntries(
+      versions.body.versions.map((v: any) => [v.version, v.downloads]),
+    );
+    expect(byVer['0.1.0']).toBe(2);
+    expect(byVer['0.2.0']).toBe(1);
+  });
+
+  it('a refused install (yanked pin) does not count as a download', async () => {
+    const id = 'dl_count_e2e';
+    await pub.http
+      .post('/v1/admin/registry/packs')
+      .set(auth(pub))
+      .send({ manifest: { ...PACK, id, version: '0.3.0' } });
+    await pub.http
+      .post(`/v1/admin/registry/packs/${id}/0.3.0/yank`)
+      .set(auth(pub))
+      .send({ reason: 'bad' });
+    const refused = await pub.http
+      .post('/v1/admin/packs/from-registry')
+      .set(auth(pub))
+      .send({ packId: id, version: '0.3.0' });
+    expect(refused.status).toBe(400);
+
+    const versions = await reader.http
+      .get(`/v1/registry/packs/${id}`)
+      .set(auth(reader));
+    const v = versions.body.versions.find((x: any) => x.version === '0.3.0');
+    expect(v.downloads).toBe(0);
+  });
+
+  it('marks verified=true only when the signature validates against the trust store', async () => {
+    const manifest: any = {
+      ...PACK,
+      id: 'verified_e2e',
+      version: '0.1.0',
+      publisher: 'acme_e2e',
+    };
+    manifest.signature = signPack(manifest, trusted.priv);
+    const r = await pub.http
+      .post('/v1/admin/registry/packs')
+      .set(auth(pub))
+      .send({ manifest });
+    expect([200, 201]).toContain(r.status);
+
+    const versions = await reader.http
+      .get('/v1/registry/packs/verified_e2e')
+      .set(auth(reader));
+    expect(versions.body.versions[0].signed).toBe(true);
+    expect(versions.body.versions[0].verified).toBe(true);
+
+    const list = await reader.http
+      .get('/v1/registry/packs?q=verified_e2e')
+      .set(auth(reader));
+    expect(
+      list.body.packs.find((p: any) => p.packId === 'verified_e2e').verified,
+    ).toBe(true);
+  });
+
+  it('signed but NOT trust-store-verifiable → verified=false, publish still allowed', async () => {
+    // Unknown publisher: signature is valid for its key, but the hosting
+    // instance has no key for 'rogue_pub_e2e'.
+    const unknown: any = {
+      ...PACK,
+      id: 'unverified_pub_e2e',
+      version: '0.1.0',
+      publisher: 'rogue_pub_e2e',
+    };
+    unknown.signature = signPack(unknown, rogue.priv);
+    // Known publisher, WRONG key: the signature fails cryptographic verify.
+    const badSig: any = {
+      ...PACK,
+      id: 'badsig_e2e',
+      version: '0.1.0',
+      publisher: 'acme_e2e',
+    };
+    badSig.signature = signPack(badSig, rogue.priv);
+
+    for (const m of [unknown, badSig]) {
+      const r = await pub.http
+        .post('/v1/admin/registry/packs')
+        .set(auth(pub))
+        .send({ manifest: m });
+      expect([200, 201]).toContain(r.status); // not an error — just unverified
+      const versions = await reader.http
+        .get(`/v1/registry/packs/${m.id}`)
+        .set(auth(reader));
+      expect(versions.body.versions[0].signed).toBe(true);
+      expect(versions.body.versions[0].verified).toBe(false);
+    }
+  });
+
+  it('unsigned publish → verified=false', async () => {
+    // PACK 0.1.0 was published unsigned at the top of the suite.
+    const versions = await reader.http
+      .get(`/v1/registry/packs/${PACK.id}`)
+      .set(auth(reader));
+    const v = versions.body.versions.find((x: any) => x.version === '0.1.0');
+    expect(v.signed).toBe(false);
+    expect(v.verified).toBe(false);
   });
 
   it('paginates the catalogue with offset (packs beyond a page stay reachable)', async () => {

--- a/test/registry-ui.e2e-spec.ts
+++ b/test/registry-ui.e2e-spec.ts
@@ -1,8 +1,14 @@
 /**
  * Registry UI — end-to-end. A published pack shows up on the public,
- * unauthenticated HTML catalogue page.
+ * unauthenticated HTML catalogue page, with its download count and the
+ * verified-publisher badge.
  */
-import { REAL_ESTATE_PACK } from '../src/ai/domain-packs';
+import { generateKeyPairSync } from 'node:crypto';
+import {
+  REAL_ESTATE_PACK,
+  signPack,
+  type DomainPackManifest,
+} from '../src/ai/domain-packs';
 import type { AppFixture } from './app-fixture';
 import { createApp } from './app-fixture';
 
@@ -10,16 +16,34 @@ describe('GET /registry/ui — public catalogue (e2e)', () => {
   let f: AppFixture;
 
   beforeAll(async () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    process.env.DOMAIN_PACK_TRUSTED_KEYS = JSON.stringify({
+      ui_pub_e2e: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    });
     f = await createApp({
       companyId: 'co_registry_ui_e2e',
-      scopes: ['brain:read', 'registry:publish'],
+      scopes: ['brain:read', 'brain:admin', 'registry:publish'],
     });
+    const auth = { Authorization: `Bearer ${f.apiKey}` };
+    // A signed pack whose publisher this instance trusts → verified badge.
+    const manifest: DomainPackManifest = {
+      ...REAL_ESTATE_PACK,
+      id: 'realty_ui_e2e',
+      publisher: 'ui_pub_e2e',
+    };
+    manifest.signature = signPack(
+      manifest,
+      privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+    );
+    await f.http.post('/v1/admin/registry/packs').set(auth).send({ manifest });
+    // One install-from-registry → download counter at 1.
     await f.http
-      .post('/v1/admin/registry/packs')
-      .set({ Authorization: `Bearer ${f.apiKey}` })
-      .send({ manifest: { ...REAL_ESTATE_PACK, id: 'realty_ui_e2e' } });
+      .post('/v1/admin/packs/from-registry')
+      .set(auth)
+      .send({ packId: 'realty_ui_e2e' });
   });
   afterAll(async () => {
+    delete process.env.DOMAIN_PACK_TRUSTED_KEYS;
     if (f) await f.close();
   });
 
@@ -29,5 +53,13 @@ describe('GET /registry/ui — public catalogue (e2e)', () => {
     expect(r.headers['content-type']).toMatch(/text\/html/);
     expect(r.text).toContain('realty_ui_e2e');
     expect(r.text).toContain('Domain Pack registry');
+  });
+
+  it('renders the verified badge, download count, and published date', async () => {
+    const r = await f.http.get('/registry/ui');
+    expect(r.status).toBe(200);
+    expect(r.text).toContain('badge verified');
+    expect(r.text).toContain('1 download(s)');
+    expect(r.text).toMatch(/published \d{4}-\d{2}-\d{2}/);
   });
 });

--- a/test/registry-ui.unit-spec.ts
+++ b/test/registry-ui.unit-spec.ts
@@ -12,6 +12,9 @@ function pack(over: Partial<RegistryPackSummary> = {}): RegistryPackSummary {
     keywords: ['finance'],
     publisher: 'acme',
     signed: true,
+    verified: false,
+    downloads: 42,
+    publishedAt: '2026-07-01T12:00:00.000Z',
     versionCount: 2,
     ...over,
   };
@@ -34,6 +37,32 @@ describe('renderRegistryPage', () => {
     expect(html).not.toContain('<script>alert(1)</script>');
     expect(html).toContain('&lt;script&gt;');
     expect(html).toContain('&lt;b&gt;x');
+  });
+
+  it('shows the download count and published date', () => {
+    const html = renderRegistryPage([pack()]);
+    expect(html).toContain('42 download(s)');
+    expect(html).toContain('published 2026-07-01');
+  });
+
+  it('renders a green verified badge distinct from the neutral signed marker', () => {
+    // verified implies signed → only the stronger badge shows.
+    const verified = renderRegistryPage([pack({ verified: true })]);
+    expect(verified).toContain('badge verified');
+    expect(verified).not.toContain('badge signed');
+    // signed-but-unverified → neutral marker only.
+    const signedOnly = renderRegistryPage([pack({ signed: true })]);
+    expect(signedOnly).toContain('badge signed');
+    expect(signedOnly).not.toContain('badge verified');
+    // unsigned → no badge at all.
+    const unsigned = renderRegistryPage([pack({ signed: false })]);
+    expect(unsigned).not.toContain('class="badge');
+  });
+
+  it('HTML-escapes the new dynamic fields too (publishedAt injection)', () => {
+    const html = renderRegistryPage([pack({ publishedAt: '"><script>x' })]);
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&quot;&gt;&lt;script&gt;');
   });
 
   it('shows an empty state when there are no packs', () => {


### PR DESCRIPTION
Platform wave PL5 — adoption telemetry + supply-chain signal for the global pack registry.

- Migration 0063: `downloads int DEFAULT 0`, `verified bool DEFAULT false` on `registry_pack` (+ backfill for pre-existing rows).
- `downloads` increments ONLY on the install path (`resolveForInstall`, after not-found/yanked checks); browsing and manifest inspection never count. Counter failure never fails an install. `list` sums across versions; `getVersions` reports per-version.
- `verified` computed at publish time by verifying the manifest signature against the hosting instance's trust store (`DOMAIN_PACK_TRUSTED_KEYS`); unsigned/unknown-publisher/bad-signature publish fine with `verified=false` (`PACK_REGISTRY_REQUIRE_SIGNATURE` behavior untouched). Code comments pin the caveat: the badge reflects publish-time trust; install-time verification against the installing tenant's trust store remains the real security boundary.
- Registry UI: download count, published date, green `verified` badge distinct from the neutral `signed` marker, all escaped.

Verification: pack-registry e2e 17/17 against a real SurrealDB 3.1.5 container (increments, browse-doesn't-count, cross-version sum, verified matrix), registry-ui e2e/unit green, tsc/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd