### PR TITLE
perf(search): offload tokenBudget counting to the worker pool with sync fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -435,6 +435,13 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 #SEARCH_HNSW_ENABLED=0
 #SEARCH_HNSW_OVERFETCH=4
 #SEARCH_HNSW_EF=100
+# tokenBudget shaping: batch the per-hit tiktoken counts out to the job
+# worker pool (default ON). The request path never parks behind a busy
+# pool — a 25ms acquire timeout falls back to the in-thread count, with
+# identical results. MIN_HITS is the list size below which the offload
+# isn't worth the postMessage round-trip.
+#SEARCH_TOKEN_COUNT_OFFLOAD=1
+#SEARCH_TOKEN_OFFLOAD_MIN_HITS=24
 
 # ── Observability ────────────────────────────────────────────────────────
 # Enable the OpenTelemetry SDK + GenAI SemConv attributes on every LLM

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -414,6 +414,24 @@ export class ConfigInspectorService {
         isBooleanFlag: true,
       },
       {
+        key: 'SEARCH_TOKEN_COUNT_OFFLOAD',
+        category: 'search',
+        defaultValue: '1',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Batch tokenBudget tiktoken counting out to the job worker pool (25ms acquire timeout; any failure falls back to the in-thread count).',
+      },
+      {
+        key: 'SEARCH_TOKEN_OFFLOAD_MIN_HITS',
+        category: 'search',
+        defaultValue: '24',
+        runtimeMutable: true,
+        isBooleanFlag: false,
+        description:
+          'Hit-count threshold below which tokenBudget counting stays in-thread — the postMessage round-trip only pays off on large lists.',
+      },
+      {
         key: 'MULTI_HOP_EDGE_EXPANSION_ENABLED',
         category: 'multihop',
         defaultValue: '1',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -129,6 +129,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // pool), so this one is non-negative rather than positive.
   nonNegativeInt(env, 'COMMUNITIES_LP_OFFLOAD_MIN_EDGES', errors);
 
+  // ── tokenBudget shaping offload (default ON) ───────────────────────
+  positiveInt(env, 'SEARCH_TOKEN_OFFLOAD_MIN_HITS', errors);
+
   // ── Edge expansion (default-ON retrieval stage) ────────────────────
   // Bad values silently fell back to defaults; the numeric knobs are now
   // boot-validated like the rest of the search stack.
@@ -330,6 +333,9 @@ const KNOWN_BOOLEAN_FLAGS = [
   'SEARCH_HNSW_ENABLED',
   'SEARCH_RERANKER_ENABLED',
   'SEARCH_HYPE_ENABLED',
+  // Default-ON: read as `SEARCH_TOKEN_COUNT_OFFLOAD ?? '1'` before
+  // envFlagEnabled, so only an explicit 0/false disables the offload.
+  'SEARCH_TOKEN_COUNT_OFFLOAD',
   'MULTI_HOP_EDGE_EXPANSION_ENABLED',
   'EXTRACTOR_SKIP_LLM_ENABLED',
   'CALIBRATION_NIGHTLY_REFIT',

--- a/src/common/token-count.worker-job.ts
+++ b/src/common/token-count.worker-job.ts
@@ -1,0 +1,48 @@
+/**
+ * JobWorkerPool handler — batch tiktoken counting for search
+ * `tokenBudget` shaping.
+ *
+ * Contract: `run({ texts: string[] })` → `{ counts: number[] }` where
+ * `counts[i]` is the exact cl100k_base token count of `texts[i]`. The
+ * caller (response-builder) serialises each hit with JSON.stringify on
+ * the main thread and ships the strings here, so `countTokens(text)`
+ * is bit-identical to the in-thread `countJsonTokens(hit)` fallback —
+ * same string, same cached encoder.
+ *
+ * The first call in a fresh worker pays the one-time encoder build;
+ * the runner's module cache (and token-counter's own encoder cache)
+ * keeps it resident for every call after that.
+ *
+ * Module resolution: a plain relative import fails at runtime here —
+ * under Node 24 native type-stripping this file executes as ESM inside
+ * the pool worker (no extension search, and `__dirname` is undefined),
+ * while after `nest build` it runs as compiled CJS. So resolve the
+ * sibling module dynamically: try the built `.js` first (dist), then
+ * fall back to the runtime-assembled `.ts` (dev / ts-jest); the
+ * template-literal specifiers keep tsc from trying to statically
+ * resolve either candidate.
+ */
+interface TokenCounterModule {
+  countTokens: (text: string) => number;
+}
+
+let counterModule: Promise<TokenCounterModule> | null = null;
+
+function loadCounter(): Promise<TokenCounterModule> {
+  if (!counterModule) {
+    const base = './token-counter';
+    counterModule = (import(`${base}.js`) as Promise<TokenCounterModule>).catch(
+      () => import(`${base}.ts`) as Promise<TokenCounterModule>,
+    );
+  }
+  return counterModule;
+}
+
+export async function run(input: unknown): Promise<{ counts: number[] }> {
+  const texts = (input as { texts?: unknown }).texts;
+  if (!Array.isArray(texts) || texts.some((t) => typeof t !== 'string')) {
+    throw new Error('token-count worker expects { texts: string[] }');
+  }
+  const { countTokens } = await loadCounter();
+  return { counts: (texts as string[]).map((t) => countTokens(t)) };
+}

--- a/src/jobs/job-worker-pool.service.ts
+++ b/src/jobs/job-worker-pool.service.ts
@@ -143,8 +143,18 @@ export class JobWorkerPool implements OnModuleInit, OnApplicationShutdown {
    * (cached thereafter) and calls its exported `run(input)`. Throws
    * if the pool is disabled, no workers are healthy, OR the handler
    * threw inside the worker (re-thrown with original message + name).
+   *
+   * `opts.acquireTimeoutMs` bounds ONLY the park phase (waiting for an
+   * idle worker) — latency-sensitive callers (search tokenBudget
+   * shaping) pass a short value so they fall back to their in-thread
+   * path instead of queueing behind long CPU-bound jobs. The per-call
+   * execution timeout is unchanged (JOB_WORKER_CALL_TIMEOUT_MS).
    */
-  async run<R = unknown>(modulePath: string, input: unknown): Promise<R> {
+  async run<R = unknown>(
+    modulePath: string,
+    input: unknown,
+    opts?: { acquireTimeoutMs?: number },
+  ): Promise<R> {
     if (!this.enabled()) {
       throw new Error('JobWorkerPool disabled');
     }
@@ -153,7 +163,7 @@ export class JobWorkerPool implements OnModuleInit, OnApplicationShutdown {
     }
     // acquire() may park us as a waiter; it rejects on its own timeout, on
     // shutdown, or when the pool dies for good — so we never hang here.
-    const w = await this.acquire();
+    const w = await this.acquire(opts?.acquireTimeoutMs);
     if (this.shuttingDown) {
       this.release(w);
       throw new Error('JobWorkerPool shutting down');
@@ -200,25 +210,27 @@ export class JobWorkerPool implements OnModuleInit, OnApplicationShutdown {
     };
   }
 
-  private acquire(): Promise<PooledWorker> {
+  private acquire(timeoutMs?: number): Promise<PooledWorker> {
     const free = this.idle.shift();
     if (free) return Promise.resolve(free);
+    const parkTimeoutMs = timeoutMs ?? this.callTimeoutMs;
     return new Promise<PooledWorker>((resolve, reject) => {
       const waiter: Waiter = { resolve, reject };
       // Park timeout. Without it a caller waits forever when every worker is
       // dead and the respawn budget is spent — no release() ever fires. The
       // per-call timeout only arms after acquire() resolves, so it can't
-      // cover this phase; this is the backstop for it.
+      // cover this phase; this is the backstop for it. Callers may shorten
+      // it per-run via opts.acquireTimeoutMs (never-park request paths).
       const timer = setTimeout(() => {
         const i = this.waiters.indexOf(waiter);
         if (i >= 0) this.waiters.splice(i, 1);
         reject(
           new Error(
-            `worker acquire timed out after ${this.callTimeoutMs}ms — ` +
+            `worker acquire timed out after ${parkTimeoutMs}ms — ` +
               'pool exhausted/degraded',
           ),
         );
-      }, this.callTimeoutMs);
+      }, parkTimeoutMs);
       timer.unref();
       // Wrap both settle paths so the timer is cleared exactly once whichever
       // fires first (release, shutdown, permanent-degradation, or timeout).

--- a/src/search/internals/response-builder.ts
+++ b/src/search/internals/response-builder.ts
@@ -1,4 +1,7 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { countJsonTokens } from '../../common/token-counter';
+import { envFlagEnabled } from '../../common/env-validation';
 import type { SearchDto } from '../dto/search.dto';
 import type { SearchHit } from '../search.types';
 import type { EntityBucket, FactRow } from './types';
@@ -125,6 +128,89 @@ export function assembleHits({
 }
 
 /**
+ * Minimal structural slice of JobWorkerPool that the shaping path needs.
+ * Kept as an interface so response-builder (a pure function module)
+ * doesn't import the jobs service and unit tests can stub it.
+ */
+export interface TokenCountPool {
+  enabled(): boolean;
+  run<R = unknown>(
+    modulePath: string,
+    input: unknown,
+    opts?: { acquireTimeoutMs?: number },
+  ): Promise<R>;
+}
+
+/** Never park the request path behind a busy pool longer than this. */
+const OFFLOAD_ACQUIRE_TIMEOUT_MS = 25;
+/** Below this many hits the postMessage round-trip costs more than it saves. */
+const OFFLOAD_MIN_HITS_DEFAULT = 24;
+
+let cachedWorkerModulePath: string | null = null;
+
+/**
+ * Absolute path of the token-count worker-job handed to pool.run().
+ * Same `.js`-after-build / `.ts`-in-dev idiom as the pool's own
+ * runner resolution. Exported for the offload unit tests.
+ */
+export function tokenCountWorkerModulePath(): string {
+  if (cachedWorkerModulePath) return cachedWorkerModulePath;
+  const dist = join(__dirname, '..', '..', 'common', 'token-count.worker-job.js');
+  cachedWorkerModulePath = existsSync(dist)
+    ? dist
+    : join(__dirname, '..', '..', 'common', 'token-count.worker-job.ts');
+  return cachedWorkerModulePath;
+}
+
+function offloadMinHits(): number {
+  const raw = process.env.SEARCH_TOKEN_OFFLOAD_MIN_HITS;
+  const n = raw === undefined ? Number.NaN : parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 1 ? n : OFFLOAD_MIN_HITS_DEFAULT;
+}
+
+/**
+ * Per-hit token counts (+1 per hit for the array comma). Serialisation
+ * happens on the main thread either way; for large hit lists the
+ * tiktoken encoding — the actual CPU hog — batches out to the worker
+ * pool with a short acquire timeout. ANY offload failure (pool busy,
+ * disabled, shutting down, worker error, malformed reply) falls back
+ * to the existing synchronous loop, so shaping never degrades and the
+ * request path never parks behind long CPU-bound jobs.
+ */
+async function countHitTokens(
+  results: SearchHit[],
+  pool?: TokenCountPool,
+): Promise<number[]> {
+  const syncCounts = () => results.map((hit) => countJsonTokens(hit) + 1);
+  const offloadEnabled = envFlagEnabled(
+    process.env.SEARCH_TOKEN_COUNT_OFFLOAD ?? '1',
+  );
+  if (
+    !pool ||
+    !offloadEnabled ||
+    results.length < offloadMinHits() ||
+    !pool.enabled()
+  ) {
+    return syncCounts();
+  }
+  const texts = results.map((hit) => JSON.stringify(hit));
+  try {
+    const out = await pool.run<{ counts: number[] }>(
+      tokenCountWorkerModulePath(),
+      { texts },
+      { acquireTimeoutMs: OFFLOAD_ACQUIRE_TIMEOUT_MS },
+    );
+    const counts = out?.counts;
+    if (!Array.isArray(counts) || counts.length !== results.length) {
+      return syncCounts();
+    }
+    return counts.map((c) => c + 1);
+  } catch {
+    return syncCounts();
+  }
+}
+
+/**
  * Apply post-hits KnowQL-lite shaping: confidenceFloor, outputShape,
  * tokenBudget. Pure transforms — input list is not mutated.
  *
@@ -139,12 +225,15 @@ export function assembleHits({
  * serialised payload fits. Tokens counted exactly via tiktoken
  * (cl100k_base) on the JSON-serialised body — same encoding the
  * downstream OpenAI/Anthropic billing uses, so the budget the caller
- * specifies is the budget they'll actually consume.
+ * specifies is the budget they'll actually consume. Async because the
+ * per-hit counting may batch out to the worker pool (see
+ * countHitTokens); semantics are identical on both paths.
  */
-export function applyOutputShaping(
+export async function applyOutputShaping(
   hits: SearchHit[],
   dto: SearchDto,
-): SearchHit[] {
+  pool?: TokenCountPool,
+): Promise<SearchHit[]> {
   let results = hits;
   if (dto.confidenceFloor !== undefined) {
     const floor = dto.confidenceFloor;
@@ -182,12 +271,13 @@ export function applyOutputShaping(
     // JSON body, synchronous on the main thread. Per-hit sums
     // over-estimate the joined encoding only slightly (BPE merges
     // across boundaries reduce tokens; +1 covers the array comma), so
-    // the budget stays a hard ceiling.
+    // the budget stays a hard ceiling. The per-hit encodes batch out
+    // to the worker pool for large lists (sync fallback inside).
     const envelopeTokens = countJsonTokens({ results: [] });
+    const perHit = await countHitTokens(results, pool);
     let used = envelopeTokens;
     let keep = 0;
-    for (const hit of results) {
-      const hitTokens = countJsonTokens(hit) + 1;
+    for (const hitTokens of perHit) {
       if (used + hitTokens > budget) break;
       used += hitTokens;
       keep += 1;

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -44,6 +44,7 @@ import { SearchRetrievalService } from './search-retrieval.service';
 import { SearchRerankService } from './search-rerank.service';
 import { PipelineContext } from './pipeline-context';
 import { envFlagEnabled } from '../common/env-validation';
+import { JobWorkerPool } from '../jobs/job-worker-pool.service';
 
 export type { SearchHit } from './search.types';
 export type { GraphRetrieveHit } from './internals/graph-retrieve';
@@ -70,12 +71,16 @@ export class SearchService {
 
   // Fourth dep is the tenant predicate registry — the row fence must see
   // operator-authored requiresScope predicates, not only the code seed.
+  // Fifth is the shared job worker pool: tokenBudget shaping batches its
+  // tiktoken counting there (short acquire timeout, sync fallback), so
+  // both stay optional for positionally-constructed unit tests.
   // eslint-disable-next-line max-params
   constructor(
     private readonly surreal: SurrealService,
     private readonly retrieval: SearchRetrievalService,
     private readonly rerank: SearchRerankService,
     @Optional() private readonly predicateRegistry?: PredicateRegistryService,
+    @Optional() private readonly workerPool?: JobWorkerPool,
   ) {}
 
   /**
@@ -477,7 +482,9 @@ export class SearchService {
       requireProvenance: ctx.dto.requireProvenance === true,
     });
     rowPolicy.finish();
-    return { results: applyOutputShaping(hits, ctx.dto) };
+    return {
+      results: await applyOutputShaping(hits, ctx.dto, this.workerPool),
+    };
   }
 
   private async runEdgeExpansionStage({

--- a/test/audit-p2-hotpath.unit-spec.ts
+++ b/test/audit-p2-hotpath.unit-spec.ts
@@ -40,8 +40,8 @@ function mkHit(i: number, pad = 40): SearchHit {
 describe('applyOutputShaping tokenBudget (one-pass)', () => {
   const hits = Array.from({ length: 40 }, (_, i) => mkHit(i));
 
-  it('keeps the result under the budget', () => {
-    const out = applyOutputShaping(hits, {
+  it('keeps the result under the budget', async () => {
+    const out = await applyOutputShaping(hits, {
       query: 'q',
       tokenBudget: 500,
     } as SearchDto);
@@ -50,8 +50,8 @@ describe('applyOutputShaping tokenBudget (one-pass)', () => {
     expect(countJsonTokens({ results: out })).toBeLessThanOrEqual(500);
   });
 
-  it('keeps a prefix (never reorders or samples)', () => {
-    const out = applyOutputShaping(hits, {
+  it('keeps a prefix (never reorders or samples)', async () => {
+    const out = await applyOutputShaping(hits, {
       query: 'q',
       tokenBudget: 800,
     } as SearchDto);
@@ -60,16 +60,16 @@ describe('applyOutputShaping tokenBudget (one-pass)', () => {
     });
   });
 
-  it('returns everything when the budget is ample', () => {
-    const out = applyOutputShaping(hits.slice(0, 3), {
+  it('returns everything when the budget is ample', async () => {
+    const out = await applyOutputShaping(hits.slice(0, 3), {
       query: 'q',
       tokenBudget: 100_000,
     } as SearchDto);
     expect(out).toHaveLength(3);
   });
 
-  it('returns nothing when even one hit cannot fit', () => {
-    const out = applyOutputShaping(hits, {
+  it('returns nothing when even one hit cannot fit', async () => {
+    const out = await applyOutputShaping(hits, {
       query: 'q',
       tokenBudget: 3,
     } as SearchDto);

--- a/test/token-count-offload.unit-spec.ts
+++ b/test/token-count-offload.unit-spec.ts
@@ -1,0 +1,203 @@
+/**
+ * Wave W4 of the 2026-07 performance audit — search-path tiktoken
+ * counting offloaded to the JobWorkerPool.
+ *
+ * 1. The token-count worker-job returns exactly the counts the
+ *    in-thread token-counter produces (real pool, size 1, first call
+ *    pays the encoder build inside the worker).
+ * 2. A short acquireTimeoutMs rejects instead of parking behind a busy
+ *    pool — the never-park guarantee the request path relies on.
+ * 3. applyOutputShaping trims IDENTICALLY on the offload and sync
+ *    paths, and falls back to the sync loop on pool-throws /
+ *    pool-disabled / below-threshold / flag-off.
+ */
+import { ConfigService } from '@nestjs/config';
+import { join } from 'node:path';
+import { JobWorkerPool } from '../src/jobs/job-worker-pool.service';
+import {
+  applyOutputShaping,
+  tokenCountWorkerModulePath,
+  type TokenCountPool,
+} from '../src/search/internals/response-builder';
+import { countJsonTokens, countTokens } from '../src/common/token-counter';
+import type { SearchHit } from '../src/search/search.types';
+import type { SearchDto } from '../src/search/dto/search.dto';
+
+function makeConfig(env: Record<string, string> = {}): ConfigService {
+  return {
+    get: <T>(key: string, dflt?: T) => (env[key] ?? dflt) as T,
+    getOrThrow: <T>(key: string) => env[key] as unknown as T,
+  } as unknown as ConfigService;
+}
+
+const ECHO_FIXTURE = join(__dirname, 'fixtures', 'echo-worker-job.ts');
+
+function mkHit(i: number, pad = 40): SearchHit {
+  return {
+    entityId: `knowledge_entity:e${i}`,
+    entityType: 'person',
+    canonicalName: `Entity ${i} ${'x'.repeat(pad)}`,
+    externalRefs: {},
+    facts: [
+      {
+        factId: `knowledge_fact:f${i}`,
+        predicate: 'title',
+        object: `value ${i} ${'y'.repeat(pad)}`,
+        confidence: 0.9,
+        validFrom: '2026-01-01T00:00:00.000Z',
+        recordedAt: '2026-01-01T00:00:00.000Z',
+        score: 0.5,
+      },
+    ],
+    score: 1 - i / 100,
+  } as unknown as SearchHit;
+}
+
+const ENV_KEYS = ['SEARCH_TOKEN_COUNT_OFFLOAD', 'SEARCH_TOKEN_OFFLOAD_MIN_HITS'];
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe('token-count.worker-job via a real JobWorkerPool', () => {
+  it('returns counts identical to the in-thread token-counter', async () => {
+    const pool = new JobWorkerPool(makeConfig({ JOB_WORKER_POOL_SIZE: '1' }));
+    await pool.onModuleInit();
+    try {
+      const hits = Array.from({ length: 30 }, (_, i) => mkHit(i));
+      const texts = hits.map((h) => JSON.stringify(h));
+      const out = (await pool.run(tokenCountWorkerModulePath(), {
+        texts,
+      })) as { counts: number[] };
+      expect(out.counts).toEqual(texts.map((t) => countTokens(t)));
+      // Same numbers the sync shaping loop would use (minus its +1).
+      expect(out.counts).toEqual(hits.map((h) => countJsonTokens(h)));
+    } finally {
+      await pool.onApplicationShutdown();
+    }
+  }, 20_000);
+
+  it('rejects the input when texts is malformed', async () => {
+    const pool = new JobWorkerPool(makeConfig({ JOB_WORKER_POOL_SIZE: '1' }));
+    await pool.onModuleInit();
+    try {
+      await expect(
+        pool.run(tokenCountWorkerModulePath(), { texts: [1, 2] }),
+      ).rejects.toThrow(/expects \{ texts: string\[\] \}/);
+    } finally {
+      await pool.onApplicationShutdown();
+    }
+  }, 20_000);
+
+  it('acquireTimeoutMs rejects fast instead of parking behind a busy pool', async () => {
+    const pool = new JobWorkerPool(makeConfig({ JOB_WORKER_POOL_SIZE: '1' }));
+    await pool.onModuleInit();
+    try {
+      const busy = pool.run(ECHO_FIXTURE, { mode: 'sleep' });
+      // Let the first call claim the only worker.
+      await new Promise((r) => setTimeout(r, 10));
+      const started = Date.now();
+      await expect(
+        pool.run(ECHO_FIXTURE, { mode: 'echo' }, { acquireTimeoutMs: 25 }),
+      ).rejects.toThrow(/acquire timed out after 25ms/);
+      expect(Date.now() - started).toBeLessThan(1_000);
+      await busy;
+    } finally {
+      await pool.onApplicationShutdown();
+    }
+  }, 20_000);
+});
+
+describe('applyOutputShaping offload vs sync parity', () => {
+  const hits = Array.from({ length: 40 }, (_, i) => mkHit(i));
+  const dto = { query: 'q', tokenBudget: 500 } as SearchDto;
+
+  function stubPool(overrides: Partial<TokenCountPool> = {}): {
+    pool: TokenCountPool;
+    runMock: jest.Mock;
+  } {
+    const runMock = jest.fn(
+      async (_module: string, input: unknown): Promise<unknown> => {
+        const texts = (input as { texts: string[] }).texts;
+        return { counts: texts.map((t) => countTokens(t)) };
+      },
+    );
+    const pool: TokenCountPool = {
+      enabled: () => true,
+      run: runMock as TokenCountPool['run'],
+      ...overrides,
+    };
+    return { pool, runMock };
+  }
+
+  it('trims identically to the sync path and passes the short acquire timeout', async () => {
+    const syncOut = await applyOutputShaping(hits, dto);
+    const { pool, runMock } = stubPool();
+    const offloadOut = await applyOutputShaping(hits, dto, pool);
+    expect(offloadOut).toEqual(syncOut);
+    expect(runMock).toHaveBeenCalledTimes(1);
+    expect(runMock.mock.calls[0][2]).toEqual({ acquireTimeoutMs: 25 });
+    expect(countJsonTokens({ results: offloadOut })).toBeLessThanOrEqual(500);
+  });
+
+  it('falls back to the sync loop when the pool throws (busy/timeout)', async () => {
+    const syncOut = await applyOutputShaping(hits, dto);
+    const { pool, runMock } = stubPool();
+    runMock.mockRejectedValue(
+      new Error('worker acquire timed out after 25ms — pool exhausted/degraded'),
+    );
+    const out = await applyOutputShaping(hits, dto, pool);
+    expect(out).toEqual(syncOut);
+  });
+
+  it('falls back when the pool reports disabled — run() never called', async () => {
+    const syncOut = await applyOutputShaping(hits, dto);
+    const { pool, runMock } = stubPool({ enabled: () => false });
+    const out = await applyOutputShaping(hits, dto, pool);
+    expect(out).toEqual(syncOut);
+    expect(runMock).not.toHaveBeenCalled();
+  });
+
+  it('stays in-thread below the min-hits threshold', async () => {
+    const few = hits.slice(0, 5);
+    const fewDto = { query: 'q', tokenBudget: 100_000 } as SearchDto;
+    const syncOut = await applyOutputShaping(few, fewDto);
+    const { pool, runMock } = stubPool();
+    const out = await applyOutputShaping(few, fewDto, pool);
+    expect(out).toEqual(syncOut);
+    expect(runMock).not.toHaveBeenCalled();
+  });
+
+  it('honours SEARCH_TOKEN_OFFLOAD_MIN_HITS overrides', async () => {
+    process.env.SEARCH_TOKEN_OFFLOAD_MIN_HITS = '5';
+    const few = hits.slice(0, 5);
+    const { pool, runMock } = stubPool();
+    await applyOutputShaping(few, { query: 'q', tokenBudget: 100_000 } as SearchDto, pool);
+    expect(runMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects SEARCH_TOKEN_COUNT_OFFLOAD=0 (kill switch)', async () => {
+    process.env.SEARCH_TOKEN_COUNT_OFFLOAD = '0';
+    const syncOut = await applyOutputShaping(hits, dto);
+    const { pool, runMock } = stubPool();
+    const out = await applyOutputShaping(hits, dto, pool);
+    expect(out).toEqual(syncOut);
+    expect(runMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back on a malformed worker reply (count length mismatch)', async () => {
+    const syncOut = await applyOutputShaping(hits, dto);
+    const { pool, runMock } = stubPool();
+    runMock.mockResolvedValue({ counts: [1, 2, 3] });
+    const out = await applyOutputShaping(hits, dto, pool);
+    expect(out).toEqual(syncOut);
+  });
+});


### PR DESCRIPTION
Workers wave W4. `applyOutputShaping` synchronously tiktoken-encodes every hit when `tokenBudget` is set — ~20-100ms of main-thread CPU at 100 hits. The per-hit counts now batch to the JobWorkerPool with a hard 25ms acquire timeout and a sync fallback, so the request path can never park behind a busy pool.

- `JobWorkerPool.run()` gains `opts.acquireTimeoutMs` (park timeout only; execution timeout and defaults unchanged) — the only pool API change.
- New `src/common/token-count.worker-job.ts`; counts are bit-identical to the sync path (same cached encoder, hits pre-serialized on the main thread either way).
- Gate: `hits >= SEARCH_TOKEN_OFFLOAD_MIN_HITS` (default 24) AND `SEARCH_TOKEN_COUNT_OFFLOAD` (default ON, kill switch) AND pool enabled; any rejection falls back to the sync loop; the final budget safety-recheck stays synchronous (budget remains a hard ceiling).
- Runtime finding: pool worker modules execute as ESM under Node 24 syntax detection (`__dirname` undefined, no extension search) — module path resolved via runtime-assembled `.js`-else-`.ts` dynamic import, verified through a real pool worker in both dev-ts and compiled shapes.

Verification: 10 new unit tests incl. a real-pool never-park proof (acquire rejects <1s behind a busy worker) and offload-vs-sync identity; existing search/hot-path suites updated only for the now-async signature; tsc/lint clean; full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd