### PR TITLE
feat(ops): PROCESS_ROLE api|worker|all split with compose recipe

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,12 @@ services:
       # (CI/prod) overrides it. ≥32 chars to also clear the length warning.
       # Mirrors the SURREALDB_SCOPED_PASS local-default pattern above.
       - FORGET_HMAC_KEY=${FORGET_HMAC_KEY:-local-dev-forget-hmac-key-change-in-prod}
+      # Uncomment when running the split-role recipe (docker compose
+      # --profile split up): this pod serves HTTP only, brain-worker below
+      # owns the job queue + nightly crons. Leave commented for the default
+      # single-process deployment. See docs/operations.md
+      # "Splitting API and worker roles".
+      # - PROCESS_ROLE=api
     ports:
       - "${BRAIN_HOST_PORT:-3030}:3000"
     # PID-1 init (tini): reaps zombie children — the app spawns
@@ -57,6 +63,46 @@ services:
     # it headroom so SIGTERM handling actually completes.
     stop_grace_period: 30s
     # Mirror the prod ceilings so local OOMs surface here, not in deploy.
+    mem_limit: 2g
+    mem_reservation: 768m
+    cpus: 2.0
+    pids_limit: 512
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # Split-role worker pod (opt-in): started only with
+  # `docker compose --profile split up`. Same image as `brain`;
+  # PROCESS_ROLE=worker keeps the HTTP server for the healthcheck but
+  # publishes NO ports — all external traffic goes to `brain` (set
+  # PROCESS_ROLE=api there). Requires JOBS_QUEUE_MODE=enqueue (the
+  # default; api/worker roles refuse to boot in inline mode).
+  # See docs/operations.md "Splitting API and worker roles".
+  brain-worker:
+    profiles: ["split"]
+    build: .
+    depends_on:
+      surrealdb:
+        condition: service_healthy
+    environment:
+      - PROCESS_ROLE=worker
+      - PORT=3000
+      - SURREALDB_URL=ws://surrealdb:8000
+      - SURREALDB_USERNAME=root
+      - SURREALDB_PASSWORD=root
+      - SURREALDB_NAMESPACE=brain
+      - SURREALDB_SCOPED_USER=brain_caller
+      - SURREALDB_SCOPED_PASS=${SURREALDB_SCOPED_PASS:-local-scoped-secret}
+      - BRAIN_BASELINES_DIR=/app/.cache/baselines
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - BRAIN_API_KEYS=${BRAIN_API_KEYS:-[]}
+      - FORGET_HMAC_KEY=${FORGET_HMAC_KEY:-local-dev-forget-hmac-key-change-in-prod}
+    # No `ports:` — internal healthcheck only; nothing routes here.
+    init: true
+    stop_grace_period: 30s
     mem_limit: 2g
     mem_reservation: 768m
     cpus: 2.0

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -91,6 +91,93 @@ The queue is on by default. Every var has a safe default; tune below.
 | `JOB_RUN_BACKOFF_BASE_MS` | `30000` | Exponential-backoff base for failed/zombie-reaped jobs. Cap is 1h regardless of base × `2^(attempts-1)`. |
 | `JOB_WORKER_POOL_SIZE` | `2` (dev) / `0` (prod) | `node:worker_threads` pool size for `cpuBound: true` handlers. `0` disables the pool entirely (no current handler is cpuBound). |
 | `JOB_RUN_PERSIST` | `1` | Set `0` only in unit tests to disable job_run persistence entirely. Never in prod. |
+| `PROCESS_ROLE` | `all` | One-env role split: `all` / `api` / `worker`. Maps to the flag bundle described in [Splitting API and worker roles](#splitting-api-and-worker-roles). Explicitly-set flags always win over the role defaults. |
+
+## Splitting API and worker roles
+
+By default one Node process does everything: HTTP API, crons, the
+job_run queue loop, and the `worker_threads` pool. `PROCESS_ROLE`
+bundles the existing split machinery (worker-loop kill switch, leader
+leases, dedupKey-idempotent cron enqueues) behind a single env so you
+can run one HTTP-only pod and one jobs pod against the same SurrealDB.
+
+### Role semantics
+
+Applied at boot, **before** Nest module init, and only for flags you
+did NOT set explicitly — an explicit env always wins over the role
+default. Each applied (or skipped-because-explicit) default is logged
+under the `ProcessRole` context.
+
+| Role | Flag defaults applied | Meaning |
+|---|---|---|
+| `all` (default) | none | Byte-identical single-process behavior. |
+| `api` | `WORKER_LOOP_ENABLED=0`, `JOB_WORKER_POOL_SIZE=0` | Serves HTTP; never claims/dispatches queued jobs; skips the `worker_threads` job pool (it serves cpuBound *job* handlers only — nothing on the request path uses it). |
+| `worker` | `CHAT_ROUTE_NLI_ENABLED=false` | Runs the queue loop + crons. Keeps the HTTP server up (healthcheck + `/v1/admin/*` need it) but the compose recipe publishes no ports. Skips the ~135MB NLI intent-classifier ONNX model — a worker pod doesn't chat-route. |
+
+**`JOBS_QUEUE_MODE=enqueue` is required** (it is the default):
+`PROCESS_ROLE=api|worker` combined with `JOBS_QUEUE_MODE=inline` fails
+boot-time validation — inline mode executes compaction/dreams/refit
+inside whatever process fired the cron, which defeats the split.
+
+### What still runs on an api-role pod
+
+`@Cron` registrations are not gated by `WORKER_LOOP_ENABLED`, so the
+api pod still fires them — by design, all of them are either
+enqueue-only or lease-arbitrated:
+
+- **Enqueue-only nightly crons** (compaction 03:17, calibration/source-
+  trust refit 03:42/03:51, candidate sweeper 03:45, dreams 04:00): in queue
+  mode they only insert `job_run` rows with date-keyed dedupKeys; the
+  rows sit pending until the worker pod's loop claims them. Double
+  firing across pods collapses on the UNIQUE(jobType, dedupKey) index.
+- **Memory-quality gauge cron (03:35)**: computes per-pod Prometheus
+  gauges locally on every pod — intentionally lease-less.
+- **Changefeed consumer (every minute, off by default)** and the
+  **lease-manager janitor (10s/60s)**: gated by leader leases, so ONE
+  pod runs them — and that can be the api pod if it wins the lease.
+  Both are light (IO-bound drain / zombie-reap writes). To pin them to
+  the worker, set `AUDIT_CHANGEFEED_ENABLED=0` /
+  `LEASE_MANAGER_ENABLED=0` explicitly on the api pod.
+
+The worker pod runs everything: queue loop (it should win the
+`worker_loop` lease since the api pod no longer competes), all crons,
+and the cpuBound `worker_threads` pool.
+
+### Compose recipe
+
+`docker-compose.yml` ships an opt-in `brain-worker` service under the
+`split` profile. Uncomment `PROCESS_ROLE=api` on the `brain` service,
+then:
+
+```bash
+docker compose --profile split up -d
+```
+
+Default `docker compose up` is unchanged — the profile keeps the
+worker service out of the single-process deployment.
+
+### Memory notes
+
+- A second pod is a second full Node + Nest RSS (~200-300MB baseline
+  before models) plus its own SurrealDB connection pool
+  (`SURREALDB_POOL_SIZE` per pod). Budget both against the host.
+- ONNX models lazy-load where used: the NLI intent classifier (~135MB)
+  loads only where chat routing runs (api pod; disabled on worker by
+  the role default), the local cross-encoder (~279MB, opt-in) only
+  where search runs. The BGE-M3 embedder (~150MB, when
+  `EMBEDDER_PROVIDER=bge-m3`) loads on BOTH pods — the api pod embeds
+  queries, the worker embeds ingested facts.
+
+### When to actually split
+
+Stay single-process until at least one of these holds:
+
+- **≥4 CPUs** available — below that the two pods just contend.
+- **p95 event-loop lag** on the API during the nightly cron window
+  (03:00-05:00 UTC) — the queue work is starving request latency.
+- **HA / ≥2 pods**: you are scaling the API horizontally anyway; give
+  every API pod `PROCESS_ROLE=api` and run exactly one (or a few —
+  leases arbitrate) `PROCESS_ROLE=worker` pod.
 
 ## Retrieval feature flags
 

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -901,6 +901,15 @@ export class ConfigInspectorService {
         description:
           'Mirror sync cadence in hours. The hourly :26 UTC cron collapses ticks inside one interval bucket via dedup key.',
       },
+      {
+        key: 'PROCESS_ROLE',
+        category: 'jobs',
+        defaultValue: 'all',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Boot-only role split: all (default, single do-everything process), api (applies WORKER_LOOP_ENABLED=0 + JOB_WORKER_POOL_SIZE=0 unless set explicitly), worker (applies CHAT_ROUTE_NLI_ENABLED=false unless set). api/worker require JOBS_QUEUE_MODE=enqueue — validated at boot. See docs/operations.md "Splitting API and worker roles".',
+      },
     ];
   }
 }

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@nestjs/common';
+import { isProcessRole, normalizeProcessRole } from './process-role';
 
 const log = new Logger('EnvValidation');
 
@@ -69,6 +70,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
 
   // ── Production-only guards (scoped pool + test-only kill switches) ─
   validateProductionGuards(env, errors, warnings);
+
+  // ── Process role (api / worker split) ─────────────────────────────
+  validateProcessRole(env, errors);
 
   // ── Embedding dimensions ──────────────────────────────────────────
   const dims = env.OPENAI_EMBEDDING_DIMENSIONS;
@@ -226,6 +230,38 @@ function validateProductionGuards(
       'THROTTLE_DISABLED=1 is a test-only flag and must not be set in ' +
         'production — it disables all rate limiting, including the ' +
         'expensive OpenAI-budget caps.',
+    );
+  }
+}
+
+/**
+ * PROCESS_ROLE maps one env to the api/worker flag bundle (see
+ * common/process-role.ts). Two failure shapes are caught here:
+ *   - a typo'd role (PROCESS_ROLE=apy) would silently apply NO bundle
+ *     and the pod would run everything — the exact misconfiguration the
+ *     convenience exists to prevent;
+ *   - api/worker with JOBS_QUEUE_MODE != enqueue: inline mode executes
+ *     jobs inside whatever process fired the cron, so the "api-only"
+ *     pod would still run compaction/dreams in-process. The queue modes
+ *     parse as `=== 'enqueue'`, so ANY other value (including a typo)
+ *     means inline behavior and is rejected alongside it.
+ */
+function validateProcessRole(env: NodeJS.ProcessEnv, errors: string[]): void {
+  if (env.PROCESS_ROLE === undefined) return;
+  const role = normalizeProcessRole(env.PROCESS_ROLE);
+  if (!isProcessRole(role)) {
+    errors.push(
+      `PROCESS_ROLE must be one of api/worker/all (got "${env.PROCESS_ROLE}")`,
+    );
+    return;
+  }
+  if (role === 'all') return;
+  const mode = (env.JOBS_QUEUE_MODE ?? 'enqueue').trim();
+  if (mode !== 'enqueue') {
+    errors.push(
+      `PROCESS_ROLE=${role} requires JOBS_QUEUE_MODE=enqueue (got "${mode}") — ` +
+        'inline mode executes background jobs inside the API process, ' +
+        'defeating the role split.',
     );
   }
 }

--- a/src/common/process-role.ts
+++ b/src/common/process-role.ts
@@ -1,0 +1,115 @@
+/**
+ * PROCESS_ROLE — one-env convenience mapping for splitting the single
+ * do-everything deployment into an HTTP-only pod and a jobs/crons pod.
+ *
+ * The split machinery already exists piecewise:
+ *   - WORKER_LOOP_ENABLED=0 disables the job_run claim/dispatch loop,
+ *   - leader leases arbitrate singleton crons across pods,
+ *   - cron enqueues are dedupKey-idempotent (double-fire collapses).
+ *
+ * PROCESS_ROLE bundles the right flags per role so an operator sets ONE
+ * env instead of remembering the combination:
+ *
+ *   all    (default) — no changes; byte-identical single-process behavior.
+ *   api             — WORKER_LOOP_ENABLED=0 (no job claiming) and
+ *                     JOB_WORKER_POOL_SIZE=0 (the worker_threads pool is
+ *                     consumed only by the job dispatcher in this tree —
+ *                     verified: no request-path offload uses JobWorkerPool;
+ *                     the admin stats endpoint reads it but tolerates an
+ *                     empty pool). Crons still fire but are enqueue-only /
+ *                     leader-lease-gated — see docs/operations.md.
+ *   worker          — keeps the HTTP server (healthcheck + admin need it;
+ *                     the compose recipe publishes no ports) and sets
+ *                     CHAT_ROUTE_NLI_ENABLED=false so the ~135MB NLI ONNX
+ *                     model never loads on a pod that doesn't chat-route.
+ *
+ * Precedence: a flag the operator set explicitly ALWAYS wins — the role
+ * only fills in unset flags. Applied (and skipped-because-explicit)
+ * decisions are returned as log lines for the bootstrap logger.
+ *
+ * Guard rail: PROCESS_ROLE=api|worker with JOBS_QUEUE_MODE != enqueue is
+ * a misconfiguration (inline mode executes jobs inside the API process,
+ * defeating the split) — validateEnv() fails boot on that combination.
+ *
+ * MUST run before NestFactory.create: WORKER_LOOP_ENABLED,
+ * JOB_WORKER_POOL_SIZE and CHAT_ROUTE_NLI_ENABLED are all captured from
+ * the environment during module init.
+ */
+
+export const PROCESS_ROLES = ['api', 'worker', 'all'] as const;
+export type ProcessRole = (typeof PROCESS_ROLES)[number];
+
+/** Trim + lowercase; unset means 'all'. */
+export function normalizeProcessRole(value: string | undefined): string {
+  return (value ?? 'all').trim().toLowerCase();
+}
+
+export function isProcessRole(value: string): value is ProcessRole {
+  return (PROCESS_ROLES as readonly string[]).includes(value);
+}
+
+interface RoleDefault {
+  name: string;
+  value: string;
+  reason: string;
+}
+
+// Values below MUST match how each reader parses its flag:
+//   - WorkerLoopService: `(env.WORKER_LOOP_ENABLED ?? '1') !== '0'`
+//     → the only disabling value is the literal '0'.
+//   - JobWorkerPool: `parseInt(config.get('JOB_WORKER_POOL_SIZE', '2'))`
+//     → '0' disables the pool.
+//   - IntentClassifierService:
+//     `config.get('CHAT_ROUTE_NLI_ENABLED', 'true') !== 'false'`
+//     → the only disabling value is the literal 'false' (NOT '0').
+const ROLE_DEFAULTS: Record<ProcessRole, RoleDefault[]> = {
+  all: [],
+  api: [
+    {
+      name: 'WORKER_LOOP_ENABLED',
+      value: '0',
+      reason: 'api role does not claim/dispatch queued jobs',
+    },
+    {
+      name: 'JOB_WORKER_POOL_SIZE',
+      value: '0',
+      reason:
+        'worker_threads pool serves cpuBound job handlers only — unused without the worker loop',
+    },
+  ],
+  worker: [
+    {
+      name: 'CHAT_ROUTE_NLI_ENABLED',
+      value: 'false',
+      reason: 'worker pod does not chat-route; skips the NLI ONNX model load',
+    },
+  ],
+};
+
+/**
+ * Apply the PROCESS_ROLE flag bundle to `env`, mutating ONLY flags the
+ * operator left unset. Returns human-readable log lines describing what
+ * was applied (and what was skipped because explicit env wins).
+ *
+ * Unknown roles apply nothing — validateEnv() rejects them at boot, so
+ * this function never has to guess.
+ */
+export function applyProcessRole(env: NodeJS.ProcessEnv): string[] {
+  const role = normalizeProcessRole(env.PROCESS_ROLE);
+  if (!isProcessRole(role)) return [];
+  const lines: string[] = [];
+  for (const def of ROLE_DEFAULTS[role]) {
+    const explicit = env[def.name];
+    if (explicit !== undefined) {
+      lines.push(
+        `PROCESS_ROLE=${role}: ${def.name} explicitly set to "${explicit}" — role default (${def.value}) not applied`,
+      );
+      continue;
+    }
+    env[def.name] = def.value;
+    lines.push(
+      `PROCESS_ROLE=${role}: applied ${def.name}=${def.value} (${def.reason})`,
+    );
+  }
+  return lines;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import type { NestExpressApplication } from '@nestjs/platform-express';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
 import { validateEnv } from './common/env-validation';
+import { applyProcessRole } from './common/process-role';
 import { requestLogger } from './common/request-logger';
 import { debugTraceMiddleware } from './common/debug-trace';
 import { correlationIdMiddleware } from './common/correlation-id.middleware';
@@ -23,6 +24,13 @@ import { AllExceptionsFilter } from './common/all-exceptions.filter';
 async function bootstrap() {
   // Fail fast on missing/invalid env before NestJS or Surreal even start.
   validateEnv();
+
+  // PROCESS_ROLE=api|worker|all → per-role flag defaults. MUST run before
+  // NestFactory.create: WORKER_LOOP_ENABLED / JOB_WORKER_POOL_SIZE /
+  // CHAT_ROUTE_NLI_ENABLED are captured from the environment during module
+  // init. Explicitly-set flags always win; the role fills in unset ones.
+  const roleLog = new Logger('ProcessRole');
+  for (const line of applyProcessRole(process.env)) roleLog.log(line);
 
   // Process-level crash safety. This is a long-lived worker pod with many
   // un-awaited background promises (worker poll loop, cron ticks, lease

--- a/test/env-validation.unit-spec.ts
+++ b/test/env-validation.unit-spec.ts
@@ -160,3 +160,31 @@ describe('validateEnv — ABAC boolean flags', () => {
     expect(() => validateEnv(env)).toThrow(/ABAC_DB_FENCE_ENABLED/);
   });
 });
+
+describe('validateEnv — PROCESS_ROLE', () => {
+  // Full mapping coverage lives in test/process-role.unit-spec.ts;
+  // this block keeps the validation walk itself covered alongside
+  // its sibling guards (production shape: baseProdEnv).
+  it('accepts api/worker/all and unset', () => {
+    for (const role of ['api', 'worker', 'all', undefined]) {
+      const env = baseProdEnv();
+      if (role !== undefined) env.PROCESS_ROLE = role;
+      expect(() => validateEnv(env)).not.toThrow();
+    }
+  });
+
+  it('rejects an unknown role', () => {
+    const env = baseProdEnv();
+    env.PROCESS_ROLE = 'front';
+    expect(() => validateEnv(env)).toThrow(/PROCESS_ROLE/);
+  });
+
+  it('rejects api/worker combined with JOBS_QUEUE_MODE=inline', () => {
+    for (const role of ['api', 'worker']) {
+      const env = baseProdEnv();
+      env.PROCESS_ROLE = role;
+      env.JOBS_QUEUE_MODE = 'inline';
+      expect(() => validateEnv(env)).toThrow(/JOBS_QUEUE_MODE=enqueue/);
+    }
+  });
+});

--- a/test/process-role.unit-spec.ts
+++ b/test/process-role.unit-spec.ts
@@ -1,0 +1,159 @@
+/**
+ * PROCESS_ROLE — role → flag-bundle mapping (common/process-role.ts) and
+ * its boot-time validation (common/env-validation.ts).
+ *
+ * The mapping is applied in main.ts BEFORE NestFactory.create, mutating
+ * process.env only for flags the operator left unset. These tests run the
+ * pure function against plain objects — no Nest app, no DB.
+ *
+ * Load-bearing literals (each matches how the reader parses the flag):
+ *   - WORKER_LOOP_ENABLED: WorkerLoopService disables ONLY on '0'.
+ *   - JOB_WORKER_POOL_SIZE: JobWorkerPool disables on parseInt(...) === 0.
+ *   - CHAT_ROUTE_NLI_ENABLED: IntentClassifierService disables ONLY on the
+ *     literal 'false' (NOT '0') — the mapping must emit exactly that.
+ */
+import { applyProcessRole } from '../src/common/process-role';
+import { validateEnv } from '../src/common/env-validation';
+
+function baseDevEnv(): NodeJS.ProcessEnv {
+  return {
+    NODE_ENV: 'development',
+    SURREALDB_URL: 'ws://db:8000',
+    SURREALDB_USERNAME: 'root',
+    SURREALDB_PASSWORD: 'root',
+    OPENAI_API_KEY: 'sk-test',
+    BRAIN_API_KEYS: '[]',
+  };
+}
+
+describe('applyProcessRole — role → flag mapping', () => {
+  it('all (explicit) applies nothing and touches no flags', () => {
+    const env: NodeJS.ProcessEnv = { PROCESS_ROLE: 'all' };
+    const lines = applyProcessRole(env);
+    expect(lines).toEqual([]);
+    expect(env).toEqual({ PROCESS_ROLE: 'all' });
+  });
+
+  it('unset PROCESS_ROLE behaves as all — byte-identical env', () => {
+    const env: NodeJS.ProcessEnv = { WORKER_LOOP_ENABLED: '1' };
+    const before = { ...env };
+    expect(applyProcessRole(env)).toEqual([]);
+    expect(env).toEqual(before);
+  });
+
+  it('api disables the worker loop and the job worker pool', () => {
+    const env: NodeJS.ProcessEnv = { PROCESS_ROLE: 'api' };
+    const lines = applyProcessRole(env);
+    expect(env.WORKER_LOOP_ENABLED).toBe('0');
+    expect(env.JOB_WORKER_POOL_SIZE).toBe('0');
+    // Does NOT touch the chat-route flag — that is a worker-role default.
+    expect(env.CHAT_ROUTE_NLI_ENABLED).toBeUndefined();
+    expect(lines).toHaveLength(2);
+    expect(lines.join('\n')).toContain('WORKER_LOOP_ENABLED=0');
+    expect(lines.join('\n')).toContain('JOB_WORKER_POOL_SIZE=0');
+  });
+
+  it('worker disables chat-route NLI with the literal "false"', () => {
+    const env: NodeJS.ProcessEnv = { PROCESS_ROLE: 'worker' };
+    const lines = applyProcessRole(env);
+    // IntentClassifierService parses `... !== 'false'` — '0' would NOT
+    // disable it. The exact literal matters.
+    expect(env.CHAT_ROUTE_NLI_ENABLED).toBe('false');
+    // Worker keeps the queue loop + pool on their normal defaults.
+    expect(env.WORKER_LOOP_ENABLED).toBeUndefined();
+    expect(env.JOB_WORKER_POOL_SIZE).toBeUndefined();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('CHAT_ROUTE_NLI_ENABLED=false');
+  });
+
+  it('explicit env always wins over the role default', () => {
+    const env: NodeJS.ProcessEnv = {
+      PROCESS_ROLE: 'api',
+      WORKER_LOOP_ENABLED: '1',
+      JOB_WORKER_POOL_SIZE: '4',
+    };
+    const lines = applyProcessRole(env);
+    expect(env.WORKER_LOOP_ENABLED).toBe('1');
+    expect(env.JOB_WORKER_POOL_SIZE).toBe('4');
+    // Skips are still reported so the operator sees the decision.
+    expect(lines).toHaveLength(2);
+    for (const line of lines) expect(line).toContain('not applied');
+  });
+
+  it('explicit CHAT_ROUTE_NLI_ENABLED wins in worker role', () => {
+    const env: NodeJS.ProcessEnv = {
+      PROCESS_ROLE: 'worker',
+      CHAT_ROUTE_NLI_ENABLED: 'true',
+    };
+    applyProcessRole(env);
+    expect(env.CHAT_ROUTE_NLI_ENABLED).toBe('true');
+  });
+
+  it('normalizes case and surrounding whitespace', () => {
+    const env: NodeJS.ProcessEnv = { PROCESS_ROLE: '  API ' };
+    applyProcessRole(env);
+    expect(env.WORKER_LOOP_ENABLED).toBe('0');
+    expect(env.JOB_WORKER_POOL_SIZE).toBe('0');
+  });
+
+  it('unknown role applies nothing (validation rejects it at boot)', () => {
+    const env: NodeJS.ProcessEnv = { PROCESS_ROLE: 'apy' };
+    expect(applyProcessRole(env)).toEqual([]);
+    expect(env).toEqual({ PROCESS_ROLE: 'apy' });
+  });
+});
+
+describe('validateEnv — PROCESS_ROLE', () => {
+  it('accepts api/worker/all', () => {
+    for (const role of ['api', 'worker', 'all']) {
+      const env = baseDevEnv();
+      env.PROCESS_ROLE = role;
+      expect(() => validateEnv(env)).not.toThrow();
+    }
+  });
+
+  it('accepts unset PROCESS_ROLE', () => {
+    expect(() => validateEnv(baseDevEnv())).not.toThrow();
+  });
+
+  it('rejects an unknown role', () => {
+    const env = baseDevEnv();
+    env.PROCESS_ROLE = 'apy';
+    expect(() => validateEnv(env)).toThrow(/PROCESS_ROLE must be one of/);
+  });
+
+  it('rejects api role with JOBS_QUEUE_MODE=inline', () => {
+    const env = baseDevEnv();
+    env.PROCESS_ROLE = 'api';
+    env.JOBS_QUEUE_MODE = 'inline';
+    expect(() => validateEnv(env)).toThrow(/JOBS_QUEUE_MODE=enqueue/);
+  });
+
+  it('rejects worker role with JOBS_QUEUE_MODE=inline', () => {
+    const env = baseDevEnv();
+    env.PROCESS_ROLE = 'worker';
+    env.JOBS_QUEUE_MODE = 'inline';
+    expect(() => validateEnv(env)).toThrow(/inline mode executes/);
+  });
+
+  it('rejects api role with a typo queue mode (parses as inline)', () => {
+    const env = baseDevEnv();
+    env.PROCESS_ROLE = 'api';
+    env.JOBS_QUEUE_MODE = 'enqueu';
+    expect(() => validateEnv(env)).toThrow(/JOBS_QUEUE_MODE=enqueue/);
+  });
+
+  it('allows role=all with JOBS_QUEUE_MODE=inline (single-process kill switch)', () => {
+    const env = baseDevEnv();
+    env.PROCESS_ROLE = 'all';
+    env.JOBS_QUEUE_MODE = 'inline';
+    expect(() => validateEnv(env)).not.toThrow();
+  });
+
+  it('allows api role with explicit JOBS_QUEUE_MODE=enqueue', () => {
+    const env = baseDevEnv();
+    env.PROCESS_ROLE = 'api';
+    env.JOBS_QUEUE_MODE = 'enqueue';
+    expect(() => validateEnv(env)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Workers wave W5. One env now splits the deployment into API and worker roles — the machinery (leader leases, dedupKey-idempotent cron enqueues, `WORKER_LOOP_ENABLED`) already existed; `PROCESS_ROLE` maps to the right flag bundle at bootstrap, touching only flags the operator did NOT set explicitly.

- `all` (default): byte-identical behavior.
- `api`: `WORKER_LOOP_ENABLED=0`, `JOB_WORKER_POOL_SIZE=0` (verified no request-path pool consumer in this tree; note — if #189/W4 merges, api-role pods simply use its sync fallback).
- `worker`: full queue loop + pool; `CHAT_ROUTE_NLI_ENABLED=false` (literal, matching that flag's parser); HTTP stays up for the healthcheck.
- Guard: `api`/`worker` with `JOBS_QUEUE_MODE != enqueue` fails boot (inline mode would execute jobs in the API process).
- `docker-compose.yml`: `brain-worker` service under `profiles: ["split"]` (no published ports); default compose unchanged.
- `docs/operations.md`: role semantics, what still runs where (enqueue-only crons on api pods are harmless; lease-arbitrated consumers can be pinned), trigger criteria for splitting.

Verification: new process-role unit spec + env-validation additions (32 tests targeted), tsc/lint clean, full unit suite 155 suites / 1106 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd