### PR TITLE
perf(ai): local NER pipeline to a worker thread

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -429,3 +429,16 @@ EMBEDDER_PROVIDER=openai
 # annotated with extractionEntropy + extractionAgreement (Phase 3.B,
 # Farquhar Nature 2024). Cost scales linearly with N.
 EXTRACTOR_SC_PASSES=1
+
+# ── Local NER (extractor pre-pass) ────────────────────────────────────────
+# Opt-in local @xenova/transformers token-classification pass before the
+# extractor LLM. The model (~135MB ONNX) downloads on first warmup.
+#EXTRACTOR_LOCAL_NER_ENABLED=false
+#EXTRACTOR_LOCAL_NER_MODEL=Xenova/bert-base-multilingual-cased-ner-hrl
+#EXTRACTOR_LOCAL_NER_MIN_SCORE=0.7
+# ONNX inference runs in a worker_thread by default so it never blocks the
+# main event loop during ingest; 0 = in-thread (benchmarks / constrained envs).
+#EXTRACTOR_LOCAL_NER_WORKER=1
+# Per-call budget for the NER worker RPC; a stalled call degrades to
+# "no local entities" and latches worker retries for 5 minutes.
+#EXTRACTOR_LOCAL_NER_TIMEOUT_MS=3000

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -129,16 +129,34 @@ export class ConfigInspectorService {
       {
         key: 'EXTRACTOR_LOCAL_NER_MIN_SCORE',
         category: 'extractor',
-        defaultValue: '0.6',
+        defaultValue: '0.7',
         runtimeMutable: false,
         isBooleanFlag: false,
       },
       {
         key: 'EXTRACTOR_LOCAL_NER_MODEL',
         category: 'extractor',
-        defaultValue: 'Xenova/bert-base-NER',
+        defaultValue: 'Xenova/bert-base-multilingual-cased-ner-hrl',
         runtimeMutable: false,
         isBooleanFlag: false,
+      },
+      {
+        key: 'EXTRACTOR_LOCAL_NER_WORKER',
+        category: 'extractor',
+        defaultValue: '1',
+        runtimeMutable: false,
+        isBooleanFlag: true,
+        description:
+          'Run the local NER ONNX pipeline in a dedicated worker_thread so inference never blocks the event loop. 0 = in-thread.',
+      },
+      {
+        key: 'EXTRACTOR_LOCAL_NER_TIMEOUT_MS',
+        category: 'extractor',
+        defaultValue: '3000',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Per-call budget for the NER worker RPC; a stalled call degrades to "no local entities" and latches worker retries for 5 minutes.',
       },
       {
         key: 'EXTRACTOR_LOCAL_PREDICATE_THRESHOLD',

--- a/src/ai/local-ner.service.ts
+++ b/src/ai/local-ner.service.ts
@@ -1,6 +1,15 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  type OnApplicationShutdown,
+  type OnModuleInit,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Worker } from 'node:worker_threads';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { LRUCache } from '../common/lru-cache';
+import { envFlagEnabled } from '../common/env-validation';
 
 /**
  * Local multilingual NER via @xenova/transformers token-classification.
@@ -17,6 +26,17 @@ import { LRUCache } from '../common/lru-cache';
  *     artifact today; subsequent sprints (E7 skip gate) will consume
  *     it as a fast-path local entity source.
  *
+ * Runtime: a dedicated `worker_thread` owns the model (default), so ONNX
+ * inference never blocks the main event loop during ingest — same pattern
+ * as the local cross-encoder (src/ai/cross-encoder) and the BGE-M3
+ * embedder. EXTRACTOR_LOCAL_NER_WORKER=0 keeps the original in-thread
+ * path (benchmarks / constrained envs); the test seam
+ * (setClassifierForTesting) always drives the in-thread path. Every
+ * worker failure — spawn error, RPC timeout, crash — degrades to the
+ * feature's existing unavailable behavior: extract() returns [] and the
+ * extractor stays LLM-only for NER. A failure latches for FAIL_RETRY_MS
+ * so a wedged host isn't asked to reload the model on every call.
+ *
  * Default model: Xenova/bert-base-multilingual-cased-ner-hrl
  * (~135MB ONNX). Multilingual (EN/RU/many more), CONLL-2003-style
  * tags (PER, ORG, LOC, MISC). Override with EXTRACTOR_LOCAL_NER_MODEL
@@ -29,16 +49,17 @@ import { LRUCache } from '../common/lru-cache';
 type TokenClassificationPipeline = (
   text: string,
   options?: { aggregation_strategy?: string },
-) => Promise<
-  Array<{
-    entity_group?: string;
-    entity?: string;
-    word: string;
-    start: number;
-    end: number;
-    score: number;
-  }>
->;
+) => Promise<RawSpan[]>;
+
+/** One aggregated span as the pipeline (in-thread or worker) returns it. */
+interface RawSpan {
+  entity_group?: string;
+  entity?: string;
+  word: string;
+  start: number;
+  end: number;
+  score: number;
+}
 
 export interface LocalEntity {
   text: string;
@@ -50,15 +71,31 @@ export interface LocalEntity {
 
 const CACHE_SIZE = 1000;
 const DEFAULT_MODEL = 'Xenova/bert-base-multilingual-cased-ner-hrl';
+const WORKER_WARMUP_TIMEOUT_MS = 120_000;
+const DEFAULT_EXTRACT_TIMEOUT_MS = 3_000;
+const FAIL_RETRY_MS = 5 * 60_000;
 
 @Injectable()
-export class LocalNerService implements OnModuleInit {
+export class LocalNerService implements OnModuleInit, OnApplicationShutdown {
   private readonly logger = new Logger(LocalNerService.name);
   private readonly modelId: string;
   private readonly enabled: boolean;
   private readonly minScore: number;
+  private readonly useWorker: boolean;
+  private readonly extractTimeoutMs: number;
   private classifier: TokenClassificationPipeline | null = null;
   private readonly cache = new LRUCache<string, LocalEntity[]>(CACHE_SIZE);
+
+  // Worker runtime (EXTRACTOR_LOCAL_NER_WORKER=1, the default)
+  private worker: Worker | null = null;
+  private workerReady = false;
+  private nextReqId = 1;
+  private readonly pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  private warmupPromise: Promise<void> | null = null;
+  private failedUntil = 0;
 
   constructor(private readonly config: ConfigService) {
     this.enabled =
@@ -70,6 +107,16 @@ export class LocalNerService implements OnModuleInit {
     );
     this.minScore = parseFloat(
       this.config.get<string>('EXTRACTOR_LOCAL_NER_MIN_SCORE', '0.7'),
+    );
+    this.useWorker = envFlagEnabled(
+      this.config.get<string>('EXTRACTOR_LOCAL_NER_WORKER', '1'),
+    );
+    this.extractTimeoutMs = parseInt(
+      this.config.get<string>(
+        'EXTRACTOR_LOCAL_NER_TIMEOUT_MS',
+        String(DEFAULT_EXTRACT_TIMEOUT_MS),
+      ),
+      10,
     );
   }
 
@@ -83,8 +130,22 @@ export class LocalNerService implements OnModuleInit {
     void this.warmup();
   }
 
+  /**
+   * Terminate the inference worker thread. A worker_threads.Worker keeps the
+   * event loop alive until terminated. Idempotent.
+   */
+  async onApplicationShutdown(): Promise<void> {
+    const w = this.worker;
+    this.worker = null;
+    this.workerReady = false;
+    if (w) {
+      this.failAllPending(new Error('worker terminated on shutdown'));
+      await w.terminate().catch(() => undefined);
+    }
+  }
+
   isReady(): boolean {
-    return this.classifier !== null;
+    return this.classifier !== null || this.workerReady;
   }
 
   /** Test seam — drive the NER code path without loading the real model. */
@@ -93,53 +154,186 @@ export class LocalNerService implements OnModuleInit {
     this.cache.clear();
   }
 
+  /** Load (or await the in-flight load of) the model. Idempotent; a failed
+   *  load latches for FAIL_RETRY_MS so we don't re-download every call. */
   private async warmup(): Promise<void> {
+    if (this.isReady()) return;
+    if (this.warmupPromise) return this.warmupPromise;
+    if (Date.now() < this.failedUntil) return;
     const start = Date.now();
-    try {
-      const transformers = await import('@xenova/transformers');
-      this.classifier = (await transformers.pipeline(
-        'token-classification',
-        this.modelId,
-      )) as unknown as TokenClassificationPipeline;
-      this.logger.log(
-        `Local NER ready (${this.modelId}) — warmup ${Date.now() - start}ms`,
-      );
-    } catch (e) {
-      this.logger.warn(
-        `Local NER warmup failed for ${this.modelId}: ${(e as Error).message}; extractor stays LLM-only for NER`,
-      );
-      this.classifier = null;
+    this.warmupPromise = (this.useWorker
+      ? this.warmupWorker()
+      : this.warmupInThread()
+    )
+      .then(() => {
+        this.logger.log(
+          `Local NER ready (${this.modelId}) — warmup ${Date.now() - start}ms`,
+        );
+      })
+      .catch((e) => {
+        this.failedUntil = Date.now() + FAIL_RETRY_MS;
+        this.logger.warn(
+          `Local NER warmup failed for ${this.modelId}: ${(e as Error).message}; extractor stays LLM-only for NER`,
+        );
+      })
+      .finally(() => {
+        this.warmupPromise = null;
+      });
+    return this.warmupPromise;
+  }
+
+  private async warmupInThread(): Promise<void> {
+    const transformers = await import('@xenova/transformers');
+    this.classifier = (await transformers.pipeline(
+      'token-classification',
+      this.modelId,
+    )) as unknown as TokenClassificationPipeline;
+  }
+
+  private async warmupWorker(): Promise<void> {
+    // Re-warmup after an extract-RPC timeout must not orphan the previous
+    // worker: an un-terminated worker_threads.Worker keeps its message
+    // listener (and the loaded model) alive for the process lifetime — one
+    // leaked worker per timeout incident. Tear the old one down before
+    // spawning its replacement.
+    const stale = this.worker;
+    if (stale) {
+      this.worker = null;
+      this.failAllPending(new Error('worker replaced after stall'));
+      await stale.terminate().catch(() => undefined);
     }
+    const workerPath = this.resolveWorkerPath();
+    this.worker = new Worker(workerPath);
+    this.worker.on('message', (m: unknown) => this.handleReply(m));
+    this.worker.on('error', (err) => {
+      this.logger.warn(`local NER worker error: ${err.message}`);
+      this.failAllPending(err);
+      this.workerReady = false;
+    });
+    this.worker.on('exit', (code) => {
+      if (code !== 0) this.logger.warn(`local NER worker exited (${code})`);
+      this.failAllPending(new Error('worker exited'));
+      this.workerReady = false;
+    });
+    await this.rpc<{ ready: boolean }>('warmup', { modelId: this.modelId });
+    this.workerReady = true;
+  }
+
+  private resolveWorkerPath(): string {
+    const distCandidate = join(__dirname, 'local-ner.worker.js');
+    if (existsSync(distCandidate)) return distCandidate;
+    return join(__dirname, 'local-ner.worker.ts');
+  }
+
+  private handleReply(msg: unknown): void {
+    const m = msg as { id: number; ok: boolean; result?: unknown; error?: string };
+    const entry = this.pending.get(m.id);
+    if (!entry) return;
+    this.pending.delete(m.id);
+    if (m.ok) entry.resolve(m.result);
+    else entry.reject(new Error(m.error ?? 'unknown worker error'));
+  }
+
+  private failAllPending(err: Error): void {
+    for (const [, entry] of this.pending) entry.reject(err);
+    this.pending.clear();
+  }
+
+  private rpc<R>(kind: 'warmup' | 'extract', payload: unknown): Promise<R> {
+    if (!this.worker) {
+      return Promise.reject(new Error('local NER worker not initialised'));
+    }
+    const id = this.nextReqId++;
+    // Warmup loads ~135MB from disk/network; an extract call is bounded by
+    // its own deadline so a wedged worker can't pend forever.
+    const timeoutMs =
+      kind === 'warmup' ? WORKER_WARMUP_TIMEOUT_MS : this.extractTimeoutMs;
+    return new Promise<R>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          this.workerReady = false;
+          // Latch like a warmup failure: without this, the next extract()
+          // immediately re-warms (spawning a replacement worker) while the
+          // wedged one may still be mid-inference — on a persistently slow
+          // host that would cycle a new worker per timeout. The latch gives
+          // the host FAIL_RETRY_MS to recover; the extractor stays LLM-only
+          // for NER meanwhile.
+          if (kind === 'extract') {
+            this.failedUntil = Date.now() + FAIL_RETRY_MS;
+          }
+          reject(
+            new Error(`local NER '${kind}' RPC timed out after ${timeoutMs}ms`),
+          );
+        }
+      }, timeoutMs);
+      if (typeof timer.unref === 'function') timer.unref();
+      this.pending.set(id, {
+        resolve: (v: unknown) => {
+          clearTimeout(timer);
+          (resolve as (value: unknown) => void)(v);
+        },
+        reject: (e: Error) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      });
+      this.worker!.postMessage({ id, kind, payload });
+    });
   }
 
   async extract(text: string): Promise<LocalEntity[]> {
-    if (!this.classifier) return [];
     const trimmed = text.trim();
     if (trimmed.length === 0) return [];
     const cached = this.cache.get(trimmed);
     if (cached) return cached;
-    try {
-      const raw = await this.classifier(trimmed, {
-        aggregation_strategy: 'simple',
+    const raw = await this.classify(trimmed);
+    if (raw === null) return [];
+    const entities: LocalEntity[] = [];
+    for (const r of raw) {
+      if (r.score < this.minScore) continue;
+      entities.push({
+        text: r.word,
+        type: (r.entity_group ?? r.entity ?? 'MISC').toUpperCase(),
+        start: r.start,
+        end: r.end,
+        score: r.score,
       });
-      const entities: LocalEntity[] = [];
-      for (const r of raw) {
-        if (r.score < this.minScore) continue;
-        entities.push({
-          text: r.word,
-          type: (r.entity_group ?? r.entity ?? 'MISC').toUpperCase(),
-          start: r.start,
-          end: r.end,
-          score: r.score,
+    }
+    this.cache.set(trimmed, entities);
+    return entities;
+  }
+
+  /** Run the pipeline on the active path; null means "unavailable" (the
+   *  caller returns [] uncached — the feature's existing disabled behavior). */
+  private async classify(trimmed: string): Promise<RawSpan[] | null> {
+    // In-thread pipeline (EXTRACTOR_LOCAL_NER_WORKER=0 or the test seam)
+    // takes precedence — in worker mode it is never loaded, so no conflict.
+    if (this.classifier) {
+      try {
+        return await this.classifier(trimmed, {
+          aggregation_strategy: 'simple',
         });
+      } catch (e) {
+        this.logger.warn(
+          `Local NER extract failed for "${trimmed.slice(0, 60)}": ${(e as Error).message}; returning []`,
+        );
+        return null;
       }
-      this.cache.set(trimmed, entities);
-      return entities;
+    }
+    if (!this.enabled || !this.useWorker) return null;
+    if (!this.workerReady) {
+      // Kick a (latched) re-warmup in the background; this call degrades to
+      // "no local entities" — same contract as the pre-worker lazy load.
+      void this.warmup();
+      return null;
+    }
+    try {
+      return await this.rpc<RawSpan[]>('extract', { text: trimmed });
     } catch (e) {
       this.logger.warn(
         `Local NER extract failed for "${trimmed.slice(0, 60)}": ${(e as Error).message}; returning []`,
       );
-      return [];
+      return null;
     }
   }
 
@@ -152,7 +346,7 @@ export class LocalNerService implements OnModuleInit {
   } {
     return {
       enabled: this.enabled,
-      ready: this.classifier !== null,
+      ready: this.isReady(),
       model: this.modelId,
       minScore: this.minScore,
       cacheSize: this.cache.size,

--- a/src/ai/local-ner.worker.ts
+++ b/src/ai/local-ner.worker.ts
@@ -1,0 +1,107 @@
+/**
+ * Worker thread that owns the local NER token-classification model.
+ *
+ * Why a dedicated worker: @xenova/transformers runs ONNX inference (WASM or
+ * native) on the main thread by default. The NER model
+ * (Xenova/bert-base-multilingual-cased-ner-hrl, ~135MB ONNX) takes tens of
+ * milliseconds per text; running it in-thread during ingest stalls the event
+ * loop — and every other tenant's request — for the whole pass. Hosting the
+ * model in a worker_thread confines the blocking to a dedicated loop, exactly
+ * as the cross-encoder (src/ai/cross-encoder/cross-encoder.worker.ts) and the
+ * BGE-M3 embedder (src/ai/embedder/bge-m3.worker.ts) do.
+ *
+ * Protocol: parent posts `{ id, kind, payload }`; worker replies with
+ * `{ id, ok, result | error }`. id demuxes concurrent requests.
+ */
+import { parentPort } from 'node:worker_threads';
+
+interface WorkerConfig {
+  modelId: string;
+}
+
+type TokenClassificationPipeline = (
+  text: string,
+  options?: { aggregation_strategy?: string },
+) => Promise<
+  Array<{
+    entity_group?: string;
+    entity?: string;
+    word: string;
+    start: number;
+    end: number;
+    score: number;
+  }>
+>;
+
+type Inbound =
+  | { id: number; kind: 'warmup'; payload: WorkerConfig }
+  | { id: number; kind: 'extract'; payload: { text: string } };
+
+type Outbound =
+  | { id: number; ok: true; result: unknown }
+  | { id: number; ok: false; error: string };
+
+if (!parentPort) {
+  throw new Error('local-ner.worker must be run as a worker_thread');
+}
+
+let classifier: TokenClassificationPipeline | null = null;
+let warmupPromise: Promise<void> | null = null;
+
+function reply(msg: Outbound): void {
+  parentPort!.postMessage(msg);
+}
+
+async function warmup(cfg: WorkerConfig): Promise<void> {
+  if (warmupPromise) return warmupPromise;
+  warmupPromise = (async () => {
+    const t = (await import('@xenova/transformers')) as unknown as {
+      env: { cacheDir?: string };
+      pipeline: (task: string, model: string) => Promise<unknown>;
+    };
+    // transformers.js v2 ignores the python-style TRANSFORMERS_CACHE / HF_HOME
+    // env vars — it resolves its own default under node_modules, which is
+    // root-owned (and re-downloaded on every restart) in the Docker image.
+    // Honour the env explicitly so the operator's cache mount actually works.
+    const cacheDir = process.env.TRANSFORMERS_CACHE ?? process.env.HF_HOME;
+    if (cacheDir) t.env.cacheDir = cacheDir;
+    classifier = (await t.pipeline(
+      'token-classification',
+      cfg.modelId,
+    )) as unknown as TokenClassificationPipeline;
+  })();
+  return warmupPromise;
+}
+
+async function extract(p: { text: string }): Promise<unknown[]> {
+  if (!classifier) throw new Error('local NER not ready');
+  const raw = await classifier(p.text, { aggregation_strategy: 'simple' });
+  // Copy into plain objects: keeps the reply structured-clone-safe even if
+  // the pipeline returns class instances or tensor-backed fields, and drops
+  // everything the parent doesn't consume.
+  return raw.map((r) => ({
+    entity_group: r.entity_group,
+    entity: r.entity,
+    word: r.word,
+    start: r.start,
+    end: r.end,
+    score: Number(r.score),
+  }));
+}
+
+parentPort.on('message', async (msg: Inbound) => {
+  try {
+    if (msg.kind === 'warmup') {
+      await warmup(msg.payload);
+      reply({ id: msg.id, ok: true, result: { ready: true } });
+      return;
+    }
+    if (warmupPromise) await warmupPromise;
+    if (msg.kind === 'extract') {
+      reply({ id: msg.id, ok: true, result: await extract(msg.payload) });
+      return;
+    }
+  } catch (e) {
+    reply({ id: msg.id, ok: false, error: (e as Error).message });
+  }
+});

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -88,6 +88,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   positiveInt(env, 'OPENAI_CONCURRENCY', errors);
   positiveInt(env, 'EMBEDDING_CACHE_SIZE', errors);
 
+  // ── Local NER worker (extractor pre-pass) ─────────────────────────
+  positiveInt(env, 'EXTRACTOR_LOCAL_NER_TIMEOUT_MS', errors);
+
   // ── Throttling ────────────────────────────────────────────────────
   positiveInt(env, 'THROTTLE_TTL_MS', errors);
   positiveInt(env, 'THROTTLE_LIMIT', errors);
@@ -296,6 +299,7 @@ const KNOWN_BOOLEAN_FLAGS = [
   'SEARCH_HYPE_ENABLED',
   'MULTI_HOP_EDGE_EXPANSION_ENABLED',
   'EXTRACTOR_SKIP_LLM_ENABLED',
+  'EXTRACTOR_LOCAL_NER_WORKER',
   'CALIBRATION_NIGHTLY_REFIT',
   'DREAMS_ENABLED',
   'DREAMS_RUN_SUMMARIZE',

--- a/test/local-ner-worker.unit-spec.ts
+++ b/test/local-ner-worker.unit-spec.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit-test for the LocalNerService worker runtime — the default
+ * EXTRACTOR_LOCAL_NER_WORKER=1 path with node:worker_threads mocked
+ * (no model download, no real thread).
+ *
+ * Proves the degradation contract: a worker that is not ready, times
+ * out, or crashes always degrades to the feature's existing
+ * unavailable behavior (extract() → []), a timeout latches re-warmup
+ * for FAIL_RETRY_MS, the test seam still drives the in-thread path,
+ * and shutdown terminates the thread.
+ */
+import type { ConfigService } from '@nestjs/config';
+import { LocalNerService } from '../src/ai/local-ner.service';
+
+// jest.mock is hoisted above the imports, so LocalNerService sees the fake.
+jest.mock('node:worker_threads', () => {
+  class FakeWorker {
+    static instances: FakeWorker[] = [];
+    readonly listeners = new Map<string, (arg: any) => void>();
+    readonly posted: Array<{ id: number; kind: string; payload: any }> = [];
+    terminated = false;
+    constructor(public readonly path: string) {
+      FakeWorker.instances.push(this);
+    }
+    on(event: string, fn: (arg: any) => void): this {
+      this.listeners.set(event, fn);
+      return this;
+    }
+    postMessage(msg: { id: number; kind: string; payload: any }): void {
+      this.posted.push(msg);
+    }
+    async terminate(): Promise<number> {
+      this.terminated = true;
+      return 0;
+    }
+  }
+  return { Worker: FakeWorker };
+});
+
+interface FakeWorkerT {
+  instances: FakeWorkerT[];
+  listeners: Map<string, (arg: any) => void>;
+  posted: Array<{ id: number; kind: string; payload: any }>;
+  terminated: boolean;
+  path: string;
+}
+
+const FakeWorker = (
+  jest.requireMock('node:worker_threads') as { Worker: { instances: FakeWorkerT[] } }
+).Worker;
+
+function mkConfig(over: Record<string, string> = {}): ConfigService {
+  const data: Record<string, string> = {
+    EXTRACTOR_LOCAL_NER_ENABLED: 'true',
+    EXTRACTOR_LOCAL_NER_MIN_SCORE: '0.7',
+    ...over,
+  };
+  return {
+    get: (k: string, def?: string) => data[k] ?? def,
+  } as unknown as ConfigService;
+}
+
+function replyToLast(w: FakeWorkerT, ok: boolean, body: unknown): void {
+  const last = w.posted[w.posted.length - 1];
+  const msg = ok
+    ? { id: last.id, ok: true, result: body }
+    : { id: last.id, ok: false, error: String(body) };
+  w.listeners.get('message')!(msg);
+}
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+beforeEach(() => {
+  FakeWorker.instances.length = 0;
+});
+
+describe('LocalNerService — worker runtime', () => {
+  it('extract before the worker is ready returns [] and kicks background warmup', async () => {
+    const svc = new LocalNerService(mkConfig());
+    expect(svc.isReady()).toBe(false);
+    await expect(svc.extract('Maria works at Acme')).resolves.toEqual([]);
+    // The not-ready call fired a background warmup: worker spawned, warmup RPC posted.
+    expect(FakeWorker.instances).toHaveLength(1);
+    const w = FakeWorker.instances[0];
+    expect(w.posted[0].kind).toBe('warmup');
+    // Complete warmup → ready; extract now round-trips through the worker.
+    replyToLast(w, true, { ready: true });
+    await flush();
+    expect(svc.isReady()).toBe(true);
+  });
+
+  it('scores flow through the worker RPC with min-score filtering intact', async () => {
+    const svc = new LocalNerService(mkConfig());
+    svc.onModuleInit();
+    const w = FakeWorker.instances[0];
+    replyToLast(w, true, { ready: true });
+    await flush();
+
+    const pending = svc.extract('Maria Petrov is CTO at Acme');
+    await flush();
+    expect(w.posted[1]).toMatchObject({
+      kind: 'extract',
+      payload: { text: 'Maria Petrov is CTO at Acme' },
+    });
+    replyToLast(w, true, [
+      { word: 'Maria Petrov', entity_group: 'PER', start: 0, end: 12, score: 0.95 },
+      { word: 'Acme', entity_group: 'org', start: 23, end: 27, score: 0.85 },
+      { word: 'low', entity_group: 'MISC', start: 0, end: 3, score: 0.5 },
+    ]);
+    const out = await pending;
+    expect(out).toEqual([
+      { text: 'Maria Petrov', type: 'PER', start: 0, end: 12, score: 0.95 },
+      { text: 'Acme', type: 'ORG', start: 23, end: 27, score: 0.85 },
+    ]);
+    // Cached: a repeat extract does not post a second RPC.
+    await expect(svc.extract('Maria Petrov is CTO at Acme')).resolves.toEqual(out);
+    expect(w.posted).toHaveLength(2);
+  });
+
+  it('a worker-side error degrades to [] (existing unavailable behavior)', async () => {
+    const svc = new LocalNerService(mkConfig());
+    svc.onModuleInit();
+    const w = FakeWorker.instances[0];
+    replyToLast(w, true, { ready: true });
+    await flush();
+
+    const pending = svc.extract('anything');
+    await flush();
+    replyToLast(w, false, 'boom');
+    await expect(pending).resolves.toEqual([]);
+  });
+
+  it('RPC timeout falls back to [] and latches re-warmup', async () => {
+    const svc = new LocalNerService(
+      mkConfig({ EXTRACTOR_LOCAL_NER_TIMEOUT_MS: '25' }),
+    );
+    svc.onModuleInit();
+    const w = FakeWorker.instances[0];
+    replyToLast(w, true, { ready: true });
+    await flush();
+
+    // Never reply → the per-call deadline fires and the call degrades to [].
+    await expect(svc.extract('wedged host')).resolves.toEqual([]);
+    expect(svc.isReady()).toBe(false);
+    // Latched: the next extract neither RPCs the wedged worker nor spawns a
+    // replacement within the retry window.
+    await expect(svc.extract('next call')).resolves.toEqual([]);
+    expect(w.posted).toHaveLength(2); // warmup + the timed-out extract only
+    expect(FakeWorker.instances).toHaveLength(1);
+  });
+
+  it('the test seam (in-thread classifier) takes precedence over the worker', async () => {
+    const svc = new LocalNerService(mkConfig());
+    const pipe = jest.fn(async () => [
+      { word: 'Berlin', entity_group: 'LOC', start: 0, end: 6, score: 0.9 },
+    ]);
+    svc.setClassifierForTesting(pipe as any);
+    const out = await svc.extract('Berlin');
+    expect(out).toHaveLength(1);
+    expect(pipe).toHaveBeenCalledTimes(1);
+    expect(FakeWorker.instances).toHaveLength(0);
+  });
+
+  it('never spawns a worker when the feature is disabled or the worker flag is off', async () => {
+    const disabled = new LocalNerService(
+      mkConfig({ EXTRACTOR_LOCAL_NER_ENABLED: 'false' }),
+    );
+    disabled.onModuleInit();
+    await expect(disabled.extract('text')).resolves.toEqual([]);
+
+    const inThread = new LocalNerService(
+      mkConfig({ EXTRACTOR_LOCAL_NER_WORKER: '0' }),
+    );
+    await expect(inThread.extract('text')).resolves.toEqual([]);
+    expect(FakeWorker.instances).toHaveLength(0);
+  });
+
+  it('onApplicationShutdown terminates the worker and rejects in-flight calls to []', async () => {
+    const svc = new LocalNerService(mkConfig());
+    svc.onModuleInit();
+    const w = FakeWorker.instances[0];
+    replyToLast(w, true, { ready: true });
+    await flush();
+
+    const inflight = svc.extract('in flight');
+    await flush();
+    await svc.onApplicationShutdown();
+    expect(w.terminated).toBe(true);
+    await expect(inflight).resolves.toEqual([]);
+    expect(svc.isReady()).toBe(false);
+  });
+});


### PR DESCRIPTION
Workers wave W6. The local NER pre-pass (@xenova token-classification, default-off feature) ran its ONNX inference on the main event loop when enabled. It now runs in a dedicated worker thread following the cross-encoder/NLI house pattern: `{id, kind}` RPC, 120s warmup timeout, per-call deadline `EXTRACTOR_LOCAL_NER_TIMEOUT_MS` (default 3000), 5-min `failedUntil` latch, stale-worker teardown, terminate on shutdown.

- `EXTRACTOR_LOCAL_NER_WORKER` default ON (relevant only when `EXTRACTOR_LOCAL_NER_ENABLED` is on); every worker failure returns `[]` — the feature's existing "no local entities" degraded behavior. Public surface and test seams unchanged.
- Also documents the whole `EXTRACTOR_LOCAL_NER_*` knob family in `.env.example` (previously absent) and fixes two stale config-catalog defaults in that section (min-score and model id drift).

Verification: 7 new unit tests with mocked worker_threads (no model download in CI), existing local-ner specs unmodified and green, tsc/lint clean, full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd