### PR TITLE
feat(auth): per-pack binding for indexer:write keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,9 @@ SEARCH_PPR_AUTO_THRESHOLD=0
 # Example: BRAIN_API_KEYS='[{"keyHash":"sha256:...","companyId":"co_123","scopes":["brain:read","brain:write"]}]'
 # Optional per-entry `"policies": ["set-name", ...]` attaches ABAC policy
 # sets (see the ABAC section below) to the key when ABAC_ENABLED=1.
+# Optional per-entry `"packIds": ["my_pack", ...]` binds an indexer:write
+# key to specific external packs — it can poll/claim/read/submit ONLY as
+# those pack identities (JWT equivalent: a `packs` claim).
 BRAIN_API_KEYS=[]
 
 # Service-to-service JWT verification.

--- a/docs/api.md
+++ b/docs/api.md
@@ -114,7 +114,7 @@ a quiet stale field.
 | `brain:read_pii` | Lifts the PII gate — `dob` / `email` / `phone` / `address` facts return real values. |
 | `brain:admin` | All `/v1/admin/*` endpoints, dreams trigger, retraction / forget. |
 | `registry:publish` | Publish/yank in the global pack registry (catalogue shared across tenants). |
-| `indexer:write` | Stage candidates as an external indexer (`POST /v1/documents/:id/candidates`) — can propose hypotheses, never write facts directly. |
+| `indexer:write` | Stage candidates as an external indexer (`POST /v1/documents/:id/candidates`) — can propose hypotheses, never write facts directly. Optionally pack-bound: a key with `packIds` (static entry) or a `packs` JWT claim acts ONLY as those pack identities (403 outside the binding). |
 
 Keys are stored as `sha256:<hex>` — see [Getting started](getting-started.md#seed-an-apikey)
 for the seeding flow.

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -95,6 +95,7 @@ export class ApiKeyGuard implements CanActivate {
       companyId: record.companyId,
       scopes: record.scopes,
       keyHash: record.keyHash,
+      ...(record.packIds ? { packIds: record.packIds } : {}),
       ...(policy ? { policy } : {}),
     };
     return true;

--- a/src/auth/api-key.service.ts
+++ b/src/auth/api-key.service.ts
@@ -59,6 +59,20 @@ export class ApiKeyService implements OnModuleInit {
         k.policyNames = names;
         delete (k as any).policies;
       }
+      // Optional per-pack indexer binding: `"packIds": ["my_pack", …]`.
+      // Same malformed-is-a-boot-error stance as policies — an operator
+      // who typed `"packIds": "my_pack"` believes the key is fenced.
+      if (k.packIds !== undefined) {
+        if (
+          !Array.isArray(k.packIds) ||
+          k.packIds.length === 0 ||
+          k.packIds.some((p: unknown) => typeof p !== 'string' || !p)
+        ) {
+          throw new Error(
+            `BRAIN_API_KEYS entry has malformed packIds (expected non-empty array of strings): companyId=${k.companyId}`,
+          );
+        }
+      }
       this.byHash.set(normalised, k);
     }
     this.logger.log(`Loaded ${this.byHash.size} ApiKey(s)`);

--- a/src/auth/api-key.types.ts
+++ b/src/auth/api-key.types.ts
@@ -27,6 +27,15 @@ export interface ApiKeyRecord {
    * a JWT. Unioned with policy_binding rows by PolicyResolverService.
    */
   policyNames?: string[];
+  /**
+   * Optional per-pack binding for `indexer:write` keys — from the
+   * `packIds` field of a BRAIN_API_KEYS entry or the `packs` claim of a
+   * JWT. A bound key can poll/claim/read/submit ONLY for these packs;
+   * absent = every external pack installed for the tenant (pre-binding
+   * behavior). Hardening: one integration's leaked key can't stage
+   * candidates as another integration's identity.
+   */
+  packIds?: string[];
 }
 
 export interface AuthenticatedRequest {
@@ -34,6 +43,8 @@ export interface AuthenticatedRequest {
     companyId: string;
     scopes: BrainScope[];
     keyHash: string;
+    /** Per-pack binding of an indexer key; absent = all external packs. */
+    packIds?: string[];
     /**
      * Resolved+compiled ABAC context; undefined when ABAC is disabled
      * or the key references no policy sets (= pre-ABAC behavior).

--- a/src/auth/jwks.service.ts
+++ b/src/auth/jwks.service.ts
@@ -121,12 +121,14 @@ export class JwksService implements OnModuleInit {
     if (scopes.length === 0) return null;
 
     const policyNames = extractPolicyNames(payload);
+    const packIds = extractPackIds(payload);
 
     return {
       keyHash: `jwt:${payload.jti ?? payload.sub}`,
       companyId,
       scopes,
       ...(policyNames.length > 0 ? { policyNames } : {}),
+      ...(packIds.length > 0 ? { packIds } : {}),
     };
   }
 }
@@ -152,6 +154,26 @@ function extractPolicyNames(payload: JWTPayload): string[] {
     names = raw.split(' ').filter(Boolean);
   }
   return names.filter((n) => VALID_POLICY_NAME.test(n)).slice(0, MAX_POLICY_NAMES);
+}
+
+// Pack ids share the manifest's snake_case charset (validate.ts); an
+// out-of-charset claim entry is dropped, not carried into fencing.
+const VALID_PACK_ID = /^[a-z][a-z0-9_]{1,63}$/;
+const MAX_PACK_IDS = 16;
+
+/**
+ * `packs` claim → per-pack indexer binding (ApiKeyRecord.packIds).
+ * Array of strings or a single space-delimited string.
+ */
+function extractPackIds(payload: JWTPayload): string[] {
+  const raw = (payload as Record<string, unknown>).packs;
+  let ids: string[] = [];
+  if (Array.isArray(raw)) {
+    ids = raw.filter((n): n is string => typeof n === 'string');
+  } else if (typeof raw === 'string') {
+    ids = raw.split(' ').filter(Boolean);
+  }
+  return ids.filter((n) => VALID_PACK_ID.test(n)).slice(0, MAX_PACK_IDS);
 }
 
 function extractScopes(payload: JWTPayload): string[] {

--- a/src/documents/external-candidates.controller.ts
+++ b/src/documents/external-candidates.controller.ts
@@ -48,6 +48,7 @@ export class ExternalCandidatesController {
       companyId,
       docId: id,
       dto: body,
+      keyPackIds: req.brainAuth.packIds,
     });
     const commit = await this.ingest.commitIfSettled(companyId, id);
     return {

--- a/src/documents/external-candidates.service.ts
+++ b/src/documents/external-candidates.service.ts
@@ -18,7 +18,10 @@ import type {
 } from '../indexers/candidate.types';
 import { DocumentStoreService, StoredDocument } from './document-store.service';
 import { CandidateStoreService } from './candidate-store.service';
-import { IndexerWorkService } from './indexer-work.service';
+import {
+  assertKeyBoundToPack,
+  IndexerWorkService,
+} from './indexer-work.service';
 import { groundExternalBatch, GroundingDrop } from './candidate-grounding';
 import {
   SubmitCandidatesDto,
@@ -76,11 +79,14 @@ export class ExternalCandidatesService {
     companyId: string;
     docId: string;
     dto: SubmitCandidatesDto;
+    /** Per-pack binding of the calling key; absent = unrestricted. */
+    keyPackIds?: string[];
   }): Promise<ExternalSubmissionResult> {
     const { companyId, docId, dto } = p;
     const doc = await this.store.getById(companyId, docId);
     if (!doc) throw new NotFoundException('document not found');
 
+    assertKeyBoundToPack(p.keyPackIds, dto.indexerId);
     const binding = await this.resolveExternalBinding(companyId, dto);
     validateShapes(dto, binding.indexerId);
     const claim = resolveClaimFields(dto);

--- a/src/documents/indexer-work.controller.ts
+++ b/src/documents/indexer-work.controller.ts
@@ -45,6 +45,7 @@ export class IndexerWorkController {
       companyId: req.brainAuth.companyId,
       packId: packId || undefined,
       limit: limit ? parseInt(limit, 10) : undefined,
+      keyPackIds: req.brainAuth.packIds,
     });
   }
 
@@ -56,6 +57,7 @@ export class IndexerWorkController {
     return this.work.claim({
       companyId: req.brainAuth.companyId,
       runId,
+      keyPackIds: req.brainAuth.packIds,
     });
   }
 
@@ -86,6 +88,7 @@ export class IndexerWorkController {
     return this.work.content({
       companyId: req.brainAuth.companyId,
       runId,
+      keyPackIds: req.brainAuth.packIds,
     });
   }
 

--- a/src/documents/indexer-work.service.ts
+++ b/src/documents/indexer-work.service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import {
   ConflictException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -56,9 +57,15 @@ export class IndexerWorkService {
     companyId: string;
     packId?: string;
     limit?: number;
+    /** Per-pack binding of the calling key; absent = unrestricted. */
+    keyPackIds?: string[];
   }): Promise<IndexerWorkListResponse> {
-    const externalPacks = await this.externalPackIds(p.companyId);
+    const externalPacks = boundPacks(
+      await this.externalPackIds(p.companyId),
+      p.keyPackIds,
+    );
     if (p.packId !== undefined) {
+      assertKeyBoundToPack(p.keyPackIds, p.packId);
       this.assertExternalPack(externalPacks, p.packId);
     }
     const limit = clampLimit(p.limit);
@@ -93,8 +100,10 @@ export class IndexerWorkService {
   async claim(p: {
     companyId: string;
     runId: string;
+    keyPackIds?: string[];
   }): Promise<ClaimWorkResponse> {
     const run = await this.getExternalRun(p.companyId, p.runId);
+    assertKeyBoundToPack(p.keyPackIds, run.packId);
     this.assertExternalPack(
       await this.externalPackIds(p.companyId),
       run.packId,
@@ -158,6 +167,7 @@ export class IndexerWorkService {
   async content(p: {
     companyId: string;
     runId: string;
+    keyPackIds?: string[];
   }): Promise<WorkContentResponse> {
     const run = await this.getExternalRun(p.companyId, p.runId);
     if (run.status !== 'pending' && run.status !== 'running') {
@@ -165,6 +175,7 @@ export class IndexerWorkService {
         `work item is ${run.status} — content is served for pending/claimed work only`,
       );
     }
+    assertKeyBoundToPack(p.keyPackIds, run.packId);
     this.assertExternalPack(
       await this.externalPackIds(p.companyId),
       run.packId,
@@ -272,6 +283,31 @@ export class IndexerWorkService {
         `indexer pack "${packId}" is not installed for this tenant`,
       );
     }
+  }
+}
+
+/** Intersect the tenant's external packs with a key's binding (0 = all). */
+function boundPacks(
+  externalPacks: Set<string>,
+  keyPackIds?: string[],
+): Set<string> {
+  if (!keyPackIds || keyPackIds.length === 0) return externalPacks;
+  return new Set([...externalPacks].filter((id) => keyPackIds.includes(id)));
+}
+
+/**
+ * A pack-bound key acting outside its binding is a permission error, not
+ * invisibility — the packs of one's own tenant are not a secret, and a
+ * clear 403 beats operators chasing phantom 404s.
+ */
+export function assertKeyBoundToPack(
+  keyPackIds: string[] | undefined,
+  packId: string,
+): void {
+  if (keyPackIds && keyPackIds.length > 0 && !keyPackIds.includes(packId)) {
+    throw new ForbiddenException(
+      `this key is not bound to indexer pack "${packId}"`,
+    );
   }
 }
 

--- a/test/app-fixture.ts
+++ b/test/app-fixture.ts
@@ -36,7 +36,11 @@ export async function createApp(opts: {
    * boot (BRAIN_API_KEYS is parsed once at module init). `policies`
    * maps to the entry's ABAC attachment field.
    */
-  extraKeys?: Array<{ scopes: string[]; policies?: string[] }>;
+  extraKeys?: Array<{
+    scopes: string[];
+    policies?: string[];
+    packIds?: string[];
+  }>;
 } = {}): Promise<AppFixture> {
   const companyId = opts.companyId ?? `co_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
   const apiKey = `key_${randomUUID()}`;
@@ -54,6 +58,7 @@ export async function createApp(opts: {
       companyId,
       scopes: k.scopes,
       ...(k.policies ? { policies: k.policies } : {}),
+      ...(k.packIds ? { packIds: k.packIds } : {}),
     })),
   ]);
   // Bypass real OpenAI calls.

--- a/test/indexer-work.e2e-spec.ts
+++ b/test/indexer-work.e2e-spec.ts
@@ -28,6 +28,11 @@ describe('indexer work discovery (e2e)', () => {
         'brain:read_pii',
         'indexer:write',
       ],
+      // A pack-bound indexer key in the SAME tenant — the binding-fence
+      // suite uses it (fixture keys are static at boot).
+      extraKeys: [
+        { scopes: ['indexer:write'], packIds: ['some_other_pack'] },
+      ],
     });
     process.env.DOCUMENT_INGEST_ENABLED = '1';
     // External work items are produced by the multi-indexer router.
@@ -314,6 +319,53 @@ describe('indexer work discovery (e2e)', () => {
       .set(auth())
       .send(submission({ runId: item.runId, claimToken: 'wrong' }));
     expect(wrongToken.status).toBe(409);
+  });
+
+  it('pack-bound keys are fenced to their packs (403 outside the binding)', async () => {
+    const { documentId } = await createDoc(`${DOC_TEXT} Binding variant.`);
+    const [item] = workFor(await pollWork(), documentId);
+    const boundAuth = { Authorization: `Bearer ${f.extraApiKeys[0]}` };
+
+    // Explicit packId outside the binding fences before any lookup.
+    const list = await f.http
+      .get('/v1/indexer/work?packId=code_memory')
+      .set(boundAuth);
+    expect(list.status).toBe(403);
+    expect(list.body.message).toMatch(/not bound to indexer pack/);
+
+    // Unfiltered poll intersects the binding to nothing — same tenant,
+    // real work items exist, none are offered to this key.
+    const all = await f.http.get('/v1/indexer/work').set(boundAuth);
+    expect(all.status).toBe(200);
+    expect(all.body.work).toHaveLength(0);
+
+    // Claim, content, and submission as a foreign pack identity: 403.
+    const claim = await f.http
+      .post(`/v1/indexer/work/${encodeURIComponent(item.runId)}/claim`)
+      .set(boundAuth)
+      .send({});
+    expect(claim.status).toBe(403);
+    const content = await f.http
+      .get(`/v1/indexer/work/${encodeURIComponent(item.runId)}/content`)
+      .set(boundAuth);
+    expect(content.status).toBe(403);
+    const submit = await f.http
+      .post(`/v1/documents/${encodeURIComponent(documentId)}/candidates`)
+      .set(boundAuth)
+      .send(submission());
+    expect(submit.status).toBe(403);
+
+    // The unbound key is unaffected (regression guard).
+    const okClaim = await f.http
+      .post(`/v1/indexer/work/${encodeURIComponent(item.runId)}/claim`)
+      .set(auth())
+      .send({});
+    expect(okClaim.status).toBe(201);
+    const release = await f.http
+      .post(`/v1/indexer/work/${encodeURIComponent(item.runId)}/fail`)
+      .set(auth())
+      .send({ claimToken: okClaim.body.claimToken });
+    expect(release.status).toBe(201);
   });
 
   it('plans no work for content-less documents unless ungrounded is allowed', async () => {


### PR DESCRIPTION
Platform wave PL8 — hardening follow-up to #181. An `indexer:write` key can now be bound to specific external packs: `"packIds": [...]` on a static `BRAIN_API_KEYS` entry (malformed value fails boot, same stance as `policies`) or a `packs` JWT claim (charset-filtered, capped at 16). A bound key polls/claims/reads/submits ONLY as those pack identities — acting outside the binding is an explicit 403 — so one leaked integration key can't stage candidates under another integration's identity. Unbound keys keep the pre-binding behavior.

Verification: indexer-work e2e grew a binding-fence case (same-tenant bound key: filtered poll intersects to empty, explicit packId/claim/content/submit all 403, unbound key regression-guarded) — 9/9 green against a real SurrealDB container; full unit suite green; tsc/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd