### PR TITLE
feat(documents): signed webhook push hints for external indexers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -308,6 +308,12 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 # expires it — a remote indexer that never showed up. Claimed work rides
 # INDEXER_RUN_STALE_MINUTES via heartbeat instead.
 #INDEXER_EXTERNAL_PENDING_TTL_DAYS=7
+# Webhook push for external packs that declare indexer.external.callbackUrl:
+# ingest POSTs a signed work_available HINT there (HMAC secret minted at pack
+# install, returned once). Push is best-effort — polling stays the source of
+# truth. Kill switch + retry pacing (250ms base, x4 backoff, 3 attempts).
+#INDEXER_WEBHOOK_PUSH_ENABLED=1
+#INDEXER_WEBHOOK_RETRY_BASE_MS=250
 
 # ── ABAC: per-key policy sets (migration 0056) ───────────────────────────
 # Master switch. Off (default) = the policy resolver never runs and every

--- a/docs/document-pipeline.md
+++ b/docs/document-pipeline.md
@@ -198,6 +198,14 @@ items expire after `INDEXER_EXTERNAL_PENDING_TTL_DAYS`. Reindexing an
 external pack (`POST /v1/admin/documents/reindex`) backfills work items
 instead of running in-process extraction.
 
+Packs that declare `indexer.external.callbackUrl` additionally get a
+**push hint**: ingest fires a `work_available` POST (HMAC-signed with
+the per-install secret minted at pack install, returned once in the
+install response; header `X-Brain-Signature: sha256=<hex>`) with
+retries and a per-URL circuit breaker. Push is a latency optimization
+only — polling remains the source of truth
+(`INDEXER_WEBHOOK_PUSH_ENABLED` kill switch, default on).
+
 ## Flags and knobs
 
 | Env | Default | Meaning |

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -661,6 +661,15 @@ export class ConfigInspectorService {
         description:
           'How long an unclaimed external work item (pending external indexer_run, GET /v1/indexer/work) stays pollable before the nightly sweep expires it. Claimed work rides INDEXER_RUN_STALE_MINUTES via heartbeat.',
       },
+      {
+        key: 'INDEXER_WEBHOOK_PUSH_ENABLED',
+        category: 'pipeline',
+        defaultValue: '1',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Signed work_available webhook hints to external packs declaring indexer.external.callbackUrl. Best-effort (retries + per-URL breaker); polling stays the source of truth.',
+      },
       // ── Search: retrieval-evolution stages (migrations 0052–0055) ──
       {
         key: 'SEARCH_HNSW_ENABLED',

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import {
   BadRequestException,
   Injectable,
@@ -119,6 +120,13 @@ export class DomainPackInstallService {
     version: string;
     predicatesSeeded: number;
     checksum: string;
+    /**
+     * HMAC secret for indexer.external.callbackUrl pushes — present ONLY
+     * when freshly minted (first install of a callback-bearing pack).
+     * Shown once; relay it to the external indexer. Upgrades keep the
+     * existing secret and omit the field.
+     */
+    webhookSecret?: string;
   }> {
     if (!manifest || typeof manifest !== 'object') {
       throw new BadRequestException('request body must include a pack manifest');
@@ -163,9 +171,14 @@ export class DomainPackInstallService {
     });
 
     const newIds = predicates.map((p) => p.predicateId);
+    // A callback-bearing pack gets an HMAC secret for signed pushes
+    // (0065). Minted on first install; upgrades preserve the existing
+    // secret so the integration doesn't have to rotate on every bump.
+    const wantsWebhook = Boolean(manifest.indexer?.external?.callbackUrl);
+    let mintedSecret: string | undefined;
     const seeded = await this.surreal.withCompany(companyId, async (db) => {
       const [existing] = await db.query<[any[]]>(
-        `SELECT id, version, manifest FROM domain_pack WHERE packId = $packId LIMIT 1`,
+        `SELECT id, version, manifest, webhookSecret FROM domain_pack WHERE packId = $packId LIMIT 1`,
         { packId: manifest.id },
       );
       const row = ((existing as any[]) ?? [])[0];
@@ -182,9 +195,20 @@ export class DomainPackInstallService {
           row.manifest as DomainPackManifest | undefined,
           manifest,
         );
+        if (wantsWebhook && !row.webhookSecret) {
+          mintedSecret = randomBytes(32).toString('hex');
+        }
         await db.query(
-          `UPDATE $id SET version = $version, manifest = $manifest, checksum = $checksum, status = 'active', updatedAt = time::now()`,
-          { id: row.id, version: manifest.version, manifest, checksum },
+          `UPDATE $id SET version = $version, manifest = $manifest, checksum = $checksum, status = 'active', updatedAt = time::now()${
+            mintedSecret ? ', webhookSecret = $webhookSecret' : ''
+          }`,
+          {
+            id: row.id,
+            version: manifest.version,
+            manifest,
+            checksum,
+            ...(mintedSecret ? { webhookSecret: mintedSecret } : {}),
+          },
         );
         // Reinstall/upgrade: uninstall DEPRECATED this pack's predicates and
         // seedMissingPredicates skips them (they exist by id), so without this
@@ -220,6 +244,9 @@ export class DomainPackInstallService {
           );
         }
       } else {
+        if (wantsWebhook) {
+          mintedSecret = randomBytes(32).toString('hex');
+        }
         await db.query(`CREATE domain_pack CONTENT $content`, {
           content: {
             packId: manifest.id,
@@ -227,6 +254,7 @@ export class DomainPackInstallService {
             manifest,
             checksum,
             status: 'active',
+            ...(mintedSecret ? { webhookSecret: mintedSecret } : {}),
           },
         });
       }
@@ -248,6 +276,7 @@ export class DomainPackInstallService {
       version: manifest.version,
       predicatesSeeded: seeded,
       checksum,
+      ...(mintedSecret ? { webhookSecret: mintedSecret } : {}),
     };
   }
 

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -139,6 +139,7 @@ validateAbacEnv(env, errors);
   positiveInt(env, 'REINDEX_MAX_DOCS_PER_RUN', errors);
   positiveInt(env, 'INDEXER_RUN_STALE_MINUTES', errors);
   positiveInt(env, 'INDEXER_EXTERNAL_PENDING_TTL_DAYS', errors);
+  positiveInt(env, 'INDEXER_WEBHOOK_RETRY_BASE_MS', errors);
   positiveInt(env, 'MAX_DEDICATED_INDEXERS_PER_DOC', errors);
   nonNegativeFloat(env, 'CANDIDATE_MIN_CONFIDENCE', errors);
 
@@ -312,6 +313,7 @@ const KNOWN_BOOLEAN_FLAGS = [
   'DEBUG_TRACE_PERSIST',
   'BGE_M3_WORKER',
   'THROTTLE_DISABLED',
+  'INDEXER_WEBHOOK_PUSH_ENABLED',
 ];
 
 /**

--- a/src/db/migrations/0065_domain_pack_webhook.surql
+++ b/src/db/migrations/0065_domain_pack_webhook.surql
@@ -1,0 +1,11 @@
+-- 0065_domain_pack_webhook — per-install webhook secret for external
+-- indexer push notifications.
+--
+-- A pack whose manifest declares indexer.external.callbackUrl gets an
+-- HMAC secret generated at install time (returned ONCE in the install
+-- response). When ingest routes a document to that pack, Brain POSTs a
+-- signed work_available hint to the callbackUrl. Push is a HINT only —
+-- the pull API (GET /v1/indexer/work) stays the source of truth, so a
+-- missed webhook costs latency, never work.
+
+DEFINE FIELD IF NOT EXISTS webhookSecret ON domain_pack TYPE option<string>;

--- a/src/documents/documents.module.ts
+++ b/src/documents/documents.module.ts
@@ -8,6 +8,7 @@ import { ExternalCandidatesController } from './external-candidates.controller';
 import { ExternalCandidatesService } from './external-candidates.service';
 import { IndexerWorkController } from './indexer-work.controller';
 import { IndexerWorkService } from './indexer-work.service';
+import { IndexerWebhookService } from './indexer-webhook.service';
 import { DocumentStoreService } from './document-store.service';
 import { CandidateStoreService } from './candidate-store.service';
 import { IndexerRunService } from './indexer-run.service';
@@ -49,6 +50,7 @@ import { MentionViaDocumentService } from './mention-via-document.service';
     MentionViaDocumentService,
     ExternalCandidatesService,
     IndexerWorkService,
+    IndexerWebhookService,
   ],
   exports: [
     DocumentIngestService,

--- a/src/documents/indexer-dispatch.service.ts
+++ b/src/documents/indexer-dispatch.service.ts
@@ -5,6 +5,7 @@ import { DedicatedExtractorService } from '../indexers/dedicated-extractor.servi
 import type { IndexerBinding } from '../indexers/routing';
 import { GENERAL_INDEXER_ID } from '../indexers/candidate.types';
 import { IndexerRunService, IndexerRunResult } from './indexer-run.service';
+import { IndexerWebhookService } from './indexer-webhook.service';
 import type { DocumentChunk } from './chunker';
 import type { StoredDocument } from './document-store.service';
 
@@ -29,10 +30,14 @@ export type IndexerSelection = string[] | 'auto' | 'general';
 export class IndexerDispatchService {
   private readonly logger = new Logger(IndexerDispatchService.name);
 
+  // The 4th dep is the fire-and-forget webhook hint for external packs —
+  // a notification side-channel, not a pipeline stage.
+  // eslint-disable-next-line max-params
   constructor(
     private readonly router: IndexerRouterService,
     private readonly runs: IndexerRunService,
     private readonly dedicated: DedicatedExtractorService,
+    private readonly webhook: IndexerWebhookService,
   ) {}
 
   async dispatchSync(p: {
@@ -96,12 +101,14 @@ export class IndexerDispatchService {
       // with its vocabulary in-process — register the work item and let
       // the remote indexer pull it. Reindex is thereby the backfill
       // trigger for external indexers too.
-      return this.runs.planExternal({
+      const planned = await this.runs.planExternal({
         companyId: p.companyId,
         docId: p.doc.id,
         packId: binding.indexerId,
         packVersion: binding.packVersion,
       });
+      this.pushHint(p.companyId, p.doc.id, binding);
+      return planned;
     }
     return this.runBinding({ ...p, binding });
   }
@@ -154,8 +161,30 @@ export class IndexerDispatchService {
           packVersion: binding.packVersion,
         }),
       );
+      this.pushHint(p.companyId, p.doc.id, binding);
     }
     return results;
+  }
+
+  /**
+   * Fire-and-forget work_available hint for packs that declared a
+   * callbackUrl. Push is a latency optimization over polling — the
+   * webhook service owns retries/breaker and never throws.
+   */
+  private pushHint(
+    companyId: string,
+    documentId: string,
+    binding: IndexerBinding,
+  ): void {
+    const callbackUrl = binding.external?.callbackUrl;
+    if (!callbackUrl) return;
+    void this.webhook.notifyWorkAvailable({
+      companyId,
+      documentId,
+      packId: binding.indexerId,
+      packVersion: binding.packVersion,
+      callbackUrl,
+    });
   }
 
   private async selectRouted(

--- a/src/documents/indexer-webhook.service.ts
+++ b/src/documents/indexer-webhook.service.ts
@@ -1,0 +1,148 @@
+import { createHmac } from 'node:crypto';
+import { Injectable, Logger } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { envFlagEnabled } from '../common/env-validation';
+
+/** Payload of the work_available push (also the HMAC-signed bytes). */
+export interface WorkAvailableEvent {
+  event: 'work_available';
+  documentId: string;
+  packId: string;
+  packVersion: string;
+  ts: string;
+}
+
+const DELIVERY_TIMEOUT_MS = 5_000;
+const MAX_ATTEMPTS = 3;
+const BREAKER_MS = 5 * 60_000;
+
+/**
+ * Push side of external-indexer work discovery: when ingest routes a
+ * document to a pack that declared `indexer.external.callbackUrl`,
+ * Brain POSTs a signed work_available HINT there. Push is best-effort
+ * by design — the pull API stays the source of truth, so a missed
+ * webhook costs latency, never work. Consequently everything here is
+ * fire-and-forget: never throws into the ingest path, retries a couple
+ * of times, and latches a per-URL circuit breaker so a dead endpoint
+ * can't slow-burn outbound sockets on every ingest.
+ *
+ * Signature: `X-Brain-Signature: sha256=<hex hmac>` over the raw JSON
+ * body, keyed by the per-install webhook secret (0065, generated at
+ * pack install and returned once in the install response).
+ */
+@Injectable()
+export class IndexerWebhookService {
+  private readonly logger = new Logger(IndexerWebhookService.name);
+  /** callbackUrl → epoch-ms until which deliveries are skipped. */
+  private readonly failedUntil = new Map<string, number>();
+
+  constructor(private readonly surreal: SurrealService) {}
+
+  /** Fire the hint; resolves when delivery settled (callers use `void`). */
+  async notifyWorkAvailable(p: {
+    companyId: string;
+    documentId: string;
+    packId: string;
+    packVersion: string;
+    callbackUrl: string;
+  }): Promise<void> {
+    if (!envFlagEnabled(process.env.INDEXER_WEBHOOK_PUSH_ENABLED ?? '1')) {
+      return;
+    }
+    const until = this.failedUntil.get(p.callbackUrl) ?? 0;
+    if (Date.now() < until) return;
+
+    try {
+      const secret = await this.webhookSecret(p.companyId, p.packId);
+      if (!secret) {
+        // Builtin packs and pre-0065 installs have no secret; unsigned
+        // pushes are worse than none (the receiver can't authenticate
+        // them), so skip — reinstalling the pack mints a secret.
+        this.logger.debug(
+          `no webhook secret for pack ${p.packId} — push skipped (poll still works)`,
+        );
+        return;
+      }
+      const body: WorkAvailableEvent = {
+        event: 'work_available',
+        documentId: p.documentId,
+        packId: p.packId,
+        packVersion: p.packVersion,
+        ts: new Date().toISOString(),
+      };
+      const ok = await this.deliver(p.callbackUrl, body, secret);
+      if (!ok) {
+        this.failedUntil.set(p.callbackUrl, Date.now() + BREAKER_MS);
+        this.logger.warn(
+          `webhook delivery to ${p.callbackUrl} failed for pack ${p.packId} — breaker latched ${BREAKER_MS / 1000}s`,
+        );
+      }
+    } catch (e) {
+      // Absolute backstop — a push must never surface into ingest.
+      this.logger.warn(
+        `webhook push for pack ${p.packId} threw: ${(e as Error).message}`,
+      );
+    }
+  }
+
+  private async deliver(
+    url: string,
+    body: WorkAvailableEvent,
+    secret: string,
+  ): Promise<boolean> {
+    const payload = JSON.stringify(body);
+    const signature = createHmac('sha256', secret).update(payload).digest('hex');
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      if (attempt > 0) await sleep(retryBaseMs() * 4 ** (attempt - 1));
+      try {
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), DELIVERY_TIMEOUT_MS);
+        try {
+          const res = await fetch(url, {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              'x-brain-event': body.event,
+              'x-brain-signature': `sha256=${signature}`,
+            },
+            body: payload,
+            signal: ctrl.signal,
+          });
+          if (res.ok) return true;
+          // A 4xx is the endpoint REJECTING the event — retrying the same
+          // bytes can't help; latch the breaker via the false return.
+          if (res.status < 500) return false;
+        } finally {
+          clearTimeout(timer);
+        }
+      } catch {
+        // network error / timeout — retry
+      }
+    }
+    return false;
+  }
+
+  private async webhookSecret(
+    companyId: string,
+    packId: string,
+  ): Promise<string | null> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT webhookSecret FROM domain_pack
+           WHERE packId = $packId AND status = 'active' LIMIT 1`,
+        { packId },
+      );
+      const secret = ((rows as any[]) ?? [])[0]?.webhookSecret;
+      return secret ? String(secret) : null;
+    });
+  }
+}
+
+function retryBaseMs(): number {
+  const v = Number(process.env.INDEXER_WEBHOOK_RETRY_BASE_MS);
+  return Number.isFinite(v) && v > 0 ? v : 250;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/src/indexers/indexer-router.service.ts
+++ b/src/indexers/indexer-router.service.ts
@@ -52,6 +52,7 @@ export class IndexerRouterService {
         description: m.description,
         relevance: m.indexer?.relevance,
         dedicated: m.indexer?.dedicated,
+        external: m.indexer?.external,
       });
     }
     return bindings;

--- a/src/indexers/routing.ts
+++ b/src/indexers/routing.ts
@@ -16,6 +16,7 @@ export interface IndexerBinding {
   description: string;
   relevance?: IndexerRelevance;
   dedicated?: IndexerDescriptor['dedicated'];
+  external?: IndexerDescriptor['external'];
 }
 
 export interface RoutingInput {

--- a/test/indexer-webhook.unit-spec.ts
+++ b/test/indexer-webhook.unit-spec.ts
@@ -1,0 +1,119 @@
+import { createHmac } from 'node:crypto';
+import { IndexerWebhookService } from '../src/documents/indexer-webhook.service';
+
+/**
+ * Webhook push is a best-effort HINT: signed correctly, retried briefly,
+ * breaker-latched per URL, and NEVER observable as a failure by the
+ * ingest path. These specs pin exactly that contract with a stubbed
+ * fetch and a hand-rolled surreal (house style).
+ */
+describe('IndexerWebhookService', () => {
+  const realFetch = global.fetch;
+  let fetchMock: jest.Mock;
+  let secretRow: { webhookSecret?: string } | undefined;
+
+  const surreal = {
+    withCompany: async (_c: string, fn: (db: unknown) => unknown) =>
+      fn({ query: async () => [[secretRow]] }),
+  } as any;
+
+  const event = {
+    companyId: 'co_hook',
+    documentId: 'source_document:doc1',
+    packId: 'hook_pack',
+    packVersion: '1.0.0',
+    callbackUrl: 'https://indexer.example/hook',
+  };
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as any;
+    secretRow = { webhookSecret: 'shhh-secret' };
+    process.env.INDEXER_WEBHOOK_RETRY_BASE_MS = '1';
+    delete process.env.INDEXER_WEBHOOK_PUSH_ENABLED;
+  });
+
+  afterAll(() => {
+    global.fetch = realFetch;
+    delete process.env.INDEXER_WEBHOOK_RETRY_BASE_MS;
+    delete process.env.INDEXER_WEBHOOK_PUSH_ENABLED;
+  });
+
+  it('delivers a correctly signed work_available event', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    const svc = new IndexerWebhookService(surreal);
+    await svc.notifyWorkAvailable(event);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(event.callbackUrl);
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({
+      event: 'work_available',
+      documentId: event.documentId,
+      packId: event.packId,
+      packVersion: event.packVersion,
+    });
+    const expected = createHmac('sha256', 'shhh-secret')
+      .update(init.body)
+      .digest('hex');
+    expect(init.headers['x-brain-signature']).toBe(`sha256=${expected}`);
+    expect(init.headers['x-brain-event']).toBe('work_available');
+  });
+
+  it('retries a 5xx and succeeds on the second attempt', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    const svc = new IndexerWebhookService(surreal);
+    await svc.notifyWorkAvailable(event);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('latches the per-URL breaker after exhausted retries', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+    const svc = new IndexerWebhookService(surreal);
+    await svc.notifyWorkAvailable(event);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    fetchMock.mockClear();
+    await svc.notifyWorkAvailable(event);
+    expect(fetchMock).not.toHaveBeenCalled(); // breaker skips
+  });
+
+  it('treats a 4xx as a rejection: one attempt, breaker latched', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 410 });
+    const svc = new IndexerWebhookService(surreal);
+    await svc.notifyWorkAvailable(event);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockClear();
+    await svc.notifyWorkAvailable(event);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips silently when the install has no webhook secret', async () => {
+    secretRow = {};
+    const svc = new IndexerWebhookService(surreal);
+    await svc.notifyWorkAvailable(event);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('honors the kill switch', async () => {
+    process.env.INDEXER_WEBHOOK_PUSH_ENABLED = '0';
+    const svc = new IndexerWebhookService(surreal);
+    await svc.notifyWorkAvailable(event);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('never throws into the caller, even when the secret lookup dies', async () => {
+    const broken = {
+      withCompany: async () => {
+        throw new Error('db down');
+      },
+    } as any;
+    const svc = new IndexerWebhookService(broken);
+    await expect(svc.notifyWorkAvailable(event)).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Platform wave PL7 — activates the `callbackUrl` reserved in the external indexer descriptor.

- Pack install mints a per-install HMAC secret (migration 0065) when the manifest declares `indexer.external.callbackUrl`; returned ONCE in the install response, preserved across upgrades.
- When ingest/reindex plans a work item for such a pack, Brain POSTs a `work_available` hint: HMAC-SHA256 over the raw body in `X-Brain-Signature: sha256=<hex>`.
- Best-effort by contract: 3 attempts (250ms×4^n backoff), 5s timeout, 4xx = no retry, 5-min per-URL circuit breaker, absolute never-throws backstop — a dead endpoint can't slow ingest. Pull API stays the source of truth ("push is a hint"), kill switch `INDEXER_WEBHOOK_PUSH_ENABLED` (default on).
- No secret (builtin packs / pre-0065 installs) → push silently skipped, polling unaffected.

Verification: 7 new unit tests (signature correctness against an independent HMAC, 5xx retry, breaker latch, 4xx single-attempt, no-secret skip, kill switch, never-throws); indexer-work + external-candidates + domain-pack-install e2e green against a real SurrealDB container; tsc/lint/full unit suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd