### PR TITLE
feat(api): generated OpenAPI 3.1 spec for the platform surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ runs on any host.
 | | |
 |---|---|
 | **Get going** | [Getting started](docs/getting-started.md) · [Migration guide](docs/migration-guide.md) |
-| **Understand it** | [Architecture](docs/architecture.md) · [API reference](docs/api.md) · [Data model](docs/data-model.md) · [Bitemporal semantics](docs/bitemporal-semantics.md) · [Source reputation & trust](docs/source-reputation.md) · [ABAC access policies](docs/abac.md) · [Document pipeline](docs/document-pipeline.md) |
+| **Understand it** | [Architecture](docs/architecture.md) · [API reference](docs/api.md) · [OpenAPI 3.1 spec](docs/openapi.json) (platform surface, generated) · [Data model](docs/data-model.md) · [Bitemporal semantics](docs/bitemporal-semantics.md) · [Source reputation & trust](docs/source-reputation.md) · [ABAC access policies](docs/abac.md) · [Document pipeline](docs/document-pipeline.md) |
 | **Extend it** | [Domain Packs](docs/domain-packs.md) · [Pack distribution & registry](docs/distribution.md) · [Code memory](docs/roadmap/code-memory-domain.md) |
 | **Run it** | [Operations](docs/operations.md) · [Operator playbook](docs/operator-playbook.md) · [Deploy runbook](docs/DEPLOY.md) |
 | **Measure it** | [Eval harness](docs/eval.md) · [LoCoMo benchmark](docs/locomo.md) |

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,9 @@
 # API reference
 
+A generated [OpenAPI 3.1 document](openapi.json) covers the platform
+surface (registry, packs, documents, indexer work) — regenerate with
+`pnpm openapi:build`.
+
 All v1 endpoints are live; MCP transport is mounted per tenant. Every
 v1 call requires `Authorization: Bearer <plaintext>` where the key's
 SHA-256 lives in `BRAIN_API_KEYS`. Admin endpoints require

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,2656 @@
+{
+  "components": {
+    "responses": {
+      "BadRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "Validation failed."
+      },
+      "Conflict": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "State conflict — e.g. a lost/mismatched claim token, an already claimed work item, or an immutable-version republish."
+      },
+      "FeatureDisabled": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FeatureDisabledResponse"
+            }
+          }
+        },
+        "description": "The document pipeline is dark (DOCUMENT_INGEST_ENABLED off)."
+      },
+      "Forbidden": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "The key lacks the required scope."
+      },
+      "NotFound": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "No such resource in this tenant."
+      },
+      "TooManyRequests": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "Per-credential throttle exceeded."
+      },
+      "Unauthorized": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "Missing or unknown bearer key."
+      }
+    },
+    "schemas": {
+      "AvailablePack": {
+        "additionalProperties": false,
+        "properties": {
+          "builtin": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "predicateCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "version",
+          "description",
+          "predicateCount",
+          "builtin"
+        ],
+        "type": "object"
+      },
+      "Candidate": {
+        "additionalProperties": false,
+        "properties": {
+          "chunkSeq": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "commitRef": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "entity",
+              "fact",
+              "relation"
+            ],
+            "type": "string"
+          },
+          "payload": {
+            "additionalProperties": {},
+            "description": "Extraction payload. `object`/`clause` of scope-gated fact candidates are redacted for callers without the required predicate scope.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "runId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusReason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "runId",
+          "chunkSeq",
+          "kind",
+          "confidence",
+          "status",
+          "payload"
+        ],
+        "type": "object"
+      },
+      "ClaimWorkResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "claimToken": {
+            "type": "string"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "leaseSeconds": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "packVersion": {
+            "type": "string"
+          },
+          "runId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "documentId",
+          "packId",
+          "packVersion",
+          "claimToken",
+          "leaseSeconds"
+        ],
+        "type": "object"
+      },
+      "CommitCounts": {
+        "additionalProperties": false,
+        "properties": {
+          "committed": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "merged": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pending": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "rejected": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "pending",
+          "committed",
+          "merged",
+          "rejected"
+        ],
+        "type": "object"
+      },
+      "DocumentCandidatesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/Candidate"
+            },
+            "type": "array"
+          },
+          "documentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "documentId",
+          "candidates"
+        ],
+        "type": "object"
+      },
+      "DocumentChunk": {
+        "additionalProperties": false,
+        "properties": {
+          "charEnd": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "charStart": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "seq": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "seq",
+          "text",
+          "charStart",
+          "charEnd"
+        ],
+        "type": "object"
+      },
+      "DocumentContextRef": {
+        "additionalProperties": false,
+        "properties": {
+          "recorder": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "vertical"
+        ],
+        "type": "object"
+      },
+      "DocumentResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "charLen": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "chunkCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "chunks": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentChunk"
+            },
+            "type": "array"
+          },
+          "contentHash": {
+            "type": "string"
+          },
+          "hasContent": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "meta": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "occurredAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "recorder": {
+            "type": "string"
+          },
+          "runs": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "packId": {
+                  "type": "string"
+                },
+                "packVersion": {
+                  "type": "string"
+                },
+                "runId": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "runId",
+                "packId",
+                "packVersion",
+                "status"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "contentHash",
+          "charLen",
+          "chunkCount",
+          "hasContent",
+          "vertical",
+          "occurredAt",
+          "status",
+          "runs"
+        ],
+        "type": "object"
+      },
+      "DomainPackManifest": {
+        "additionalProperties": {},
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "evalFixtures": {
+            "items": {
+              "additionalProperties": {},
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "extractionProfile": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "id": {
+            "description": "snake_case pack id, no `__`.",
+            "type": "string"
+          },
+          "indexer": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "predicates": {
+            "items": {
+              "additionalProperties": {},
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "publisher": {
+            "type": "string"
+          },
+          "signature": {
+            "description": "ed25519 signature (base64) over the canonical manifest sans this field.",
+            "type": "string"
+          },
+          "version": {
+            "description": "semver MAJOR.MINOR.PATCH.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "version",
+          "description",
+          "predicates"
+        ],
+        "type": "object"
+      },
+      "ErrorResponse": {
+        "description": "Standard NestJS error envelope.",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "statusCode": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "statusCode",
+          "message"
+        ],
+        "type": "object"
+      },
+      "FailWorkRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "claimToken": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "error": {
+            "description": "Optional diagnostic recorded on the run row (truncated server-side).",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "permanent": {
+            "description": "Default (false/absent) RELEASES the item back to 'pending'; true marks the run 'failed' — no longer offered, still claimable by runId.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "claimToken"
+        ],
+        "type": "object"
+      },
+      "FailWorkResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "runId": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "released",
+              "failed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "status"
+        ],
+        "type": "object"
+      },
+      "FeatureDisabledResponse": {
+        "description": "Answered by every document-pipeline route while DOCUMENT_INGEST_ENABLED is off.",
+        "properties": {
+          "error": {
+            "const": "feature_disabled",
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "message"
+        ],
+        "type": "object"
+      },
+      "GroundingDrop": {
+        "additionalProperties": false,
+        "properties": {
+          "detail": {
+            "type": "string"
+          },
+          "index": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "kind": {
+            "enum": [
+              "entity",
+              "fact",
+              "relation"
+            ],
+            "type": "string"
+          },
+          "reason": {
+            "enum": [
+              "ungrounded_entity",
+              "ungrounded_value",
+              "orphan_reference"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "index",
+          "reason",
+          "detail"
+        ],
+        "type": "object"
+      },
+      "HeartbeatWorkRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "claimToken": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "claimToken"
+        ],
+        "type": "object"
+      },
+      "HeartbeatWorkResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "leaseSeconds": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "runId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "leaseSeconds"
+        ],
+        "type": "object"
+      },
+      "IndexerWorkItem": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          },
+          "docHasContent": {
+            "type": "boolean"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "packVersion": {
+            "type": "string"
+          },
+          "runId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "documentId",
+          "packId",
+          "packVersion",
+          "createdAt",
+          "docHasContent"
+        ],
+        "type": "object"
+      },
+      "IndexerWorkListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "work": {
+            "items": {
+              "$ref": "#/components/schemas/IndexerWorkItem"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "work"
+        ],
+        "type": "object"
+      },
+      "IngestDocumentAsyncResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "chunkCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "deduplicated": {
+            "type": "boolean"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "mode": {
+            "const": "async",
+            "type": "string"
+          },
+          "runs": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "packId": {
+                  "type": "string"
+                },
+                "status": {
+                  "enum": [
+                    "enqueued",
+                    "already_processed",
+                    "planned"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "packId",
+                "status"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "documentId",
+          "deduplicated",
+          "chunkCount",
+          "mode",
+          "runs"
+        ],
+        "type": "object"
+      },
+      "IngestDocumentRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "contextRef": {
+            "$ref": "#/components/schemas/DocumentContextRef"
+          },
+          "indexers": {
+            "anyOf": [
+              {
+                "const": "general",
+                "type": "string"
+              },
+              {
+                "const": "auto",
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "'general' (union pass), 'auto' (router-selected), or explicit pack ids."
+          },
+          "kind": {
+            "description": "Container kind the connector normalized from (pdf/markdown/email/…). Open string — provenance metadata only.",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "meta": {
+            "additionalProperties": {},
+            "description": "Operator-supplied metadata, projected onto derived facts' source.meta.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "mode": {
+            "description": "'async' requires DOCUMENT_MULTI_INDEXER_ENABLED and storeContent.",
+            "enum": [
+              "sync",
+              "async"
+            ],
+            "type": "string"
+          },
+          "occurredAt": {
+            "description": "ISO 8601 — becomes the derived facts' validFrom.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "originUri": {
+            "description": "Pointer back to the raw container (URL, path, message id…).",
+            "maxLength": 512,
+            "type": "string"
+          },
+          "storeContent": {
+            "description": "Store the normalized chunks server-side. false keeps only contentHash + metadata (no re-index, no span re-validation).",
+            "type": "boolean"
+          },
+          "text": {
+            "description": "Normalized document text (DOC_MAX_CHARS may lower the cap).",
+            "maxLength": 512000,
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 512,
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "text",
+          "occurredAt",
+          "contextRef"
+        ],
+        "type": "object"
+      },
+      "IngestDocumentSyncResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "chunkCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "committed": {
+            "additionalProperties": false,
+            "properties": {
+              "edgeIds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "entityIds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "factIds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "entityIds",
+              "factIds",
+              "edgeIds"
+            ],
+            "type": "object"
+          },
+          "counts": {
+            "$ref": "#/components/schemas/CommitCounts"
+          },
+          "deduplicated": {
+            "type": "boolean"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "mode": {
+            "const": "sync",
+            "type": "string"
+          },
+          "runs": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "packId": {
+                  "type": "string"
+                },
+                "runId": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "runId",
+                "packId",
+                "status"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "documentId",
+          "deduplicated",
+          "chunkCount",
+          "mode",
+          "runs",
+          "committed",
+          "counts"
+        ],
+        "type": "object"
+      },
+      "InstallFromRegistryRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "packId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId"
+        ],
+        "type": "object"
+      },
+      "InstallPackRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "expectedChecksum": {
+            "type": "string"
+          },
+          "manifest": {
+            "$ref": "#/components/schemas/DomainPackManifest"
+          }
+        },
+        "required": [
+          "manifest"
+        ],
+        "type": "object"
+      },
+      "InstallPackResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "checksum": {
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "predicatesSeeded": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "predicatesSeeded",
+          "checksum"
+        ],
+        "type": "object"
+      },
+      "InstalledPack": {
+        "additionalProperties": false,
+        "properties": {
+          "checksum": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "installedAt": {
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "predicateCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "installedAt",
+          "predicateCount",
+          "checksum"
+        ],
+        "type": "object"
+      },
+      "PackEvalFixtureResult": {
+        "additionalProperties": false,
+        "properties": {
+          "failures": {
+            "description": "Human-readable reasons the fixture failed (empty when passed).",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "passed": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "passed",
+          "failures"
+        ],
+        "type": "object"
+      },
+      "PackEvalReport": {
+        "additionalProperties": false,
+        "properties": {
+          "packId": {
+            "type": "string"
+          },
+          "passed": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/PackEvalFixtureResult"
+            },
+            "type": "array"
+          },
+          "total": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "total",
+          "passed",
+          "results"
+        ],
+        "type": "object"
+      },
+      "PacksListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "available": {
+            "items": {
+              "$ref": "#/components/schemas/AvailablePack"
+            },
+            "type": "array"
+          },
+          "installed": {
+            "items": {
+              "$ref": "#/components/schemas/InstalledPack"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "available",
+          "installed"
+        ],
+        "type": "object"
+      },
+      "PublishPackRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "expectedChecksum": {
+            "type": "string"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "manifest": {
+            "$ref": "#/components/schemas/DomainPackManifest"
+          }
+        },
+        "required": [
+          "manifest"
+        ],
+        "type": "object"
+      },
+      "PublishPackResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "checksum": {
+            "type": "string"
+          },
+          "created": {
+            "type": "boolean"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "checksum",
+          "created"
+        ],
+        "type": "object"
+      },
+      "RegistryListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "packs": {
+            "items": {
+              "$ref": "#/components/schemas/RegistryPackSummary"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "packs"
+        ],
+        "type": "object"
+      },
+      "RegistryManifestResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "checksum": {
+            "type": "string"
+          },
+          "manifest": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "yanked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "checksum",
+          "yanked",
+          "manifest"
+        ],
+        "type": "object"
+      },
+      "RegistryPackSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "latestVersion": {
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "publisher": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "signed": {
+            "type": "boolean"
+          },
+          "versionCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "packId",
+          "latestVersion",
+          "description",
+          "keywords",
+          "publisher",
+          "signed",
+          "versionCount"
+        ],
+        "type": "object"
+      },
+      "RegistryVersion": {
+        "additionalProperties": false,
+        "properties": {
+          "checksum": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "publisher": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "signed": {
+            "type": "boolean"
+          },
+          "version": {
+            "type": "string"
+          },
+          "yankReason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "yanked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "checksum",
+          "description",
+          "keywords",
+          "publisher",
+          "signed",
+          "yanked",
+          "yankReason",
+          "publishedAt"
+        ],
+        "type": "object"
+      },
+      "RegistryVersionsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "latestVersion": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "packId": {
+            "type": "string"
+          },
+          "versions": {
+            "items": {
+              "$ref": "#/components/schemas/RegistryVersion"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "packId",
+          "latestVersion",
+          "versions"
+        ],
+        "type": "object"
+      },
+      "SubmitCandidatesRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "claimToken": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "entities": {
+            "items": {
+              "$ref": "#/components/schemas/SubmittedEntity"
+            },
+            "type": "array"
+          },
+          "facts": {
+            "items": {
+              "$ref": "#/components/schemas/SubmittedFact"
+            },
+            "type": "array"
+          },
+          "indexerId": {
+            "description": "The pack id this indexer is registered as (mode 'external').",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "packVersion": {
+            "description": "Optional claim of the pack version; must match the installed one.",
+            "maxLength": 32,
+            "type": "string"
+          },
+          "relations": {
+            "items": {
+              "$ref": "#/components/schemas/SubmittedRelation"
+            },
+            "type": "array"
+          },
+          "runId": {
+            "description": "A claimed work item this submission fulfils. Provided together with claimToken or not at all (claimless flow opens its own run).",
+            "maxLength": 128,
+            "type": "string"
+          }
+        },
+        "required": [
+          "indexerId",
+          "entities",
+          "facts"
+        ],
+        "type": "object"
+      },
+      "SubmitCandidatesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "commit": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "committed": {
+                    "type": "boolean"
+                  },
+                  "counts": {
+                    "$ref": "#/components/schemas/CommitCounts"
+                  },
+                  "deferred": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "deferred",
+                  "committed",
+                  "counts"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "null when the document vanished between staging and commit."
+          },
+          "dropped": {
+            "items": {
+              "$ref": "#/components/schemas/GroundingDrop"
+            },
+            "type": "array"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "packVersion": {
+            "type": "string"
+          },
+          "runId": {
+            "type": "string"
+          },
+          "staged": {
+            "additionalProperties": false,
+            "properties": {
+              "entities": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "facts": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "relations": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "entities",
+              "facts",
+              "relations"
+            ],
+            "type": "object"
+          },
+          "ungrounded": {
+            "description": "true when the document has no stored content — spans unverifiable.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "runId",
+          "packId",
+          "packVersion",
+          "staged",
+          "dropped",
+          "ungrounded",
+          "commit"
+        ],
+        "type": "object"
+      },
+      "SubmittedEntity": {
+        "additionalProperties": false,
+        "properties": {
+          "canonical": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SubmittedFact": {
+        "additionalProperties": false,
+        "properties": {
+          "clause": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "entityIndex": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "object": {
+            "type": "string"
+          },
+          "predicate": {
+            "description": "Must be namespaced `<indexerId>__*` or a core predicate.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "entityIndex",
+          "predicate",
+          "object"
+        ],
+        "type": "object"
+      },
+      "SubmittedRelation": {
+        "additionalProperties": false,
+        "properties": {
+          "confidence": {
+            "type": "number"
+          },
+          "fromEntityIndex": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "toEntityIndex": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "fromEntityIndex",
+          "toEntityIndex",
+          "kind"
+        ],
+        "type": "object"
+      },
+      "UninstallPackResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "packId": {
+            "type": "string"
+          },
+          "predicatesDeprecated": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "packId",
+          "predicatesDeprecated"
+        ],
+        "type": "object"
+      },
+      "WorkContentChunk": {
+        "additionalProperties": false,
+        "properties": {
+          "seq": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "seq",
+          "text"
+        ],
+        "type": "object"
+      },
+      "WorkContentResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "chunkCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "chunks": {
+            "items": {
+              "$ref": "#/components/schemas/WorkContentChunk"
+            },
+            "type": "array"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "occurredAt": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "documentId",
+          "kind",
+          "vertical",
+          "occurredAt",
+          "chunkCount",
+          "chunks"
+        ],
+        "type": "object"
+      },
+      "YankPackRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "reason": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "YankPackResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "packId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "yanked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "yanked"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "description": "API key (`Authorization: Bearer <key>`); its SHA-256 must be registered in BRAIN_API_KEYS. Keys carry scopes (`brain:read`, `brain:write`, `brain:admin`, `brain:read_pii`, `registry:publish`, `indexer:write`) — each operation states the scope it requires. Not an OAuth flow.",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "description": "Generated from the zod wire contracts (`pnpm openapi:build` — scripts/build-openapi.ts); do not edit by hand. The admin/ops surface (jobs, leases, policy, stats, maintenance) is documented in docs/api.md instead. Scopes are plain bearer-key grants, not OAuth flows — each operation states its required scope.",
+    "license": {
+      "identifier": "AGPL-3.0-or-later",
+      "name": "AGPL-3.0-or-later"
+    },
+    "summary": "The community-facing platform surface: Domain Pack registry, tenant pack admin, document ingest, and the external-indexer work protocol.",
+    "title": "INITE Brain — Platform API",
+    "version": "0.6.2"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/v1/admin/packs": {
+      "get": {
+        "description": "Builtin packs are globally available and cannot be installed or uninstalled here. Source: src/admin/admin-packs.controller.ts.\n\nRequired scope: `brain:admin`.",
+        "operationId": "listDomainPacks",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PacksListResponse"
+                }
+              }
+            },
+            "description": "Available and installed packs."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "List available + installed packs for this tenant",
+        "tags": [
+          "Domain Packs"
+        ]
+      },
+      "post": {
+        "description": "Validates and installs a community / custom manifest, seeding its predicates. `expectedChecksum` pins the exact content.\n\nRequired scope: `brain:admin`.",
+        "operationId": "installDomainPack",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstallPackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallPackResponse"
+                }
+              }
+            },
+            "description": "Installed."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "Install a pack manifest into this tenant",
+        "tags": [
+          "Domain Packs"
+        ]
+      }
+    },
+    "/v1/admin/packs/from-registry": {
+      "post": {
+        "description": "Resolves the manifest (latest non-yanked, or a pinned version) and installs it with the registry checksum pinned — the installed content is exactly what the registry served.\n\nRequired scope: `brain:admin`.",
+        "operationId": "installDomainPackFromRegistry",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstallFromRegistryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallPackResponse"
+                }
+              }
+            },
+            "description": "Installed."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Install a pack from the global registry",
+        "tags": [
+          "Domain Packs"
+        ]
+      }
+    },
+    "/v1/admin/packs/{packId}": {
+      "delete": {
+        "description": "Deprecates the pack's predicates; facts extracted with them survive.\n\nRequired scope: `brain:admin`.",
+        "operationId": "uninstallDomainPack",
+        "parameters": [
+          {
+            "description": "The installed pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UninstallPackResponse"
+                }
+              }
+            },
+            "description": "Uninstalled."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Uninstall a pack from this tenant",
+        "tags": [
+          "Domain Packs"
+        ]
+      }
+    },
+    "/v1/admin/packs/{packId}/eval": {
+      "post": {
+        "description": "Scores whether extraction (with the pack's predicates + extractionProfile active) still meets the pack’s own expectations. Runs up to MAX_EVAL_FIXTURES live LLM calls — throttled to 3 requests/min per credential.\n\nRequired scope: `brain:admin`.",
+        "operationId": "evalDomainPack",
+        "parameters": [
+          {
+            "description": "The installed pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "'union' (default) scores the shared union prompt; 'dedicated' runs the pack-scoped dedicated prompt instead.",
+            "in": "query",
+            "name": "mode",
+            "required": false,
+            "schema": {
+              "enum": [
+                "union",
+                "dedicated"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PackEvalReport"
+                }
+              }
+            },
+            "description": "The eval report."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        },
+        "summary": "Run a pack's eval fixtures against the live extractor",
+        "tags": [
+          "Domain Packs"
+        ]
+      }
+    },
+    "/v1/admin/registry/packs": {
+      "post": {
+        "description": "Versions are immutable once published. Republishing an identical (packId, version, checksum) is idempotent (`created: false`); a different body for an existing version is rejected. Source: src/registry/admin-registry.controller.ts.\n\nRequired scope: `registry:publish`.",
+        "operationId": "publishRegistryPack",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublishPackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublishPackResponse"
+                }
+              }
+            },
+            "description": "Published (or already present)."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        },
+        "summary": "Publish a pack version to the global registry",
+        "tags": [
+          "Registry publishing"
+        ]
+      }
+    },
+    "/v1/admin/registry/packs/{packId}/{version}/unyank": {
+      "post": {
+        "description": "Reverses a yank — the version becomes installable again.\n\nRequired scope: `registry:publish`.",
+        "operationId": "unyankRegistryPack",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The yanked version to restore.",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/YankPackResponse"
+                }
+              }
+            },
+            "description": "Yank state after the call."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Restore a yanked version",
+        "tags": [
+          "Registry publishing"
+        ]
+      }
+    },
+    "/v1/admin/registry/packs/{packId}/{version}/yank": {
+      "post": {
+        "description": "Marks a version as not-installable (existing installs keep working). The version stays visible in the history, flagged.\n\nRequired scope: `registry:publish`.",
+        "operationId": "yankRegistryPack",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The published version to yank.",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/YankPackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/YankPackResponse"
+                }
+              }
+            },
+            "description": "Yank state after the call."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Yank a published version",
+        "tags": [
+          "Registry publishing"
+        ]
+      }
+    },
+    "/v1/documents/{id}": {
+      "get": {
+        "description": "Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/documents.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "getDocument",
+        "parameters": [
+          {
+            "description": "The document id.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Pass `1` to include the stored chunks. The raw text can carry any PII, so this additionally requires the `brain:read_pii` scope (403 otherwise).",
+            "in": "query",
+            "name": "includeText",
+            "required": false,
+            "schema": {
+              "enum": [
+                "1"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponse"
+                }
+              }
+            },
+            "description": "The document."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Read a document header and its indexer runs",
+        "tags": [
+          "Documents"
+        ]
+      }
+    },
+    "/v1/documents/{id}/candidates": {
+      "get": {
+        "description": "Every extraction candidate staged against the document, over all runs. `object`/`clause` of fact candidates whose predicate requires a scope the caller lacks are redacted; the row stays visible for the audit trail. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`.\n\nRequired scope: `brain:read`.",
+        "operationId": "listDocumentCandidates",
+        "parameters": [
+          {
+            "description": "The document id.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentCandidatesResponse"
+                }
+              }
+            },
+            "description": "The candidates."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "The document's staged candidates (audit view)",
+        "tags": [
+          "Documents"
+        ]
+      },
+      "post": {
+        "description": "A remote indexer that read a stored document submits its reading here. With `runId` + `claimToken` the submission fulfils a claimed work item; without them it opens its own run (claimless flow). Candidates are grounded against the stored text; the Brain commits once every run for the document is settled. Max 200 items per kind. Throttled to 10 requests/min per credential. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/external-candidates.controller.ts.\n\nRequired scope: `indexer:write`.",
+        "operationId": "submitDocumentCandidates",
+        "parameters": [
+          {
+            "description": "The document id.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitCandidatesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubmitCandidatesResponse"
+                }
+              }
+            },
+            "description": "Staged (and possibly committed)."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Stage an external indexer's candidate batch",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/indexer/work": {
+      "get": {
+        "description": "Pending indexer runs routed to this tenant’s installed external packs. Protocol: docs/indexer-protocol.md. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/indexer-work.controller.ts.\n\nRequired scope: `indexer:write`.",
+        "operationId": "listIndexerWork",
+        "parameters": [
+          {
+            "description": "Only work for this external pack.",
+            "in": "query",
+            "name": "packId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max items to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerWorkListResponse"
+                }
+              }
+            },
+            "description": "Claimable work items."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Poll for pending external work items",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/indexer/work/{runId}/claim": {
+      "post": {
+        "description": "Atomically transitions the run to claimed and returns the claimToken that fences all subsequent calls. Heartbeat within leaseSeconds or the claim is reaped as abandoned. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`.\n\nRequired scope: `indexer:write`.",
+        "operationId": "claimIndexerWork",
+        "parameters": [
+          {
+            "description": "The work item (indexer run) id.",
+            "in": "path",
+            "name": "runId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClaimWorkResponse"
+                }
+              }
+            },
+            "description": "The claim."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Claim a pending work item",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/indexer/work/{runId}/content": {
+      "get": {
+        "description": "Serves the verbatim stored chunks of the claimed document — only for documents whose ingest routed to this tenant’s installed external packs. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`.\n\nRequired scope: `indexer:write`.",
+        "operationId": "getIndexerWorkContent",
+        "parameters": [
+          {
+            "description": "The claimed work item id.",
+            "in": "path",
+            "name": "runId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkContentResponse"
+                }
+              }
+            },
+            "description": "The document content."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Read the claimed document's stored content",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/indexer/work/{runId}/fail": {
+      "post": {
+        "description": "Default RELEASES the item back to 'pending' (transient trouble, shutdown mid-work); `permanent: true` marks the run 'failed' — no longer offered. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`.\n\nRequired scope: `indexer:write`.",
+        "operationId": "failIndexerWork",
+        "parameters": [
+          {
+            "description": "The claimed work item id.",
+            "in": "path",
+            "name": "runId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FailWorkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FailWorkResponse"
+                }
+              }
+            },
+            "description": "The outcome."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Release or permanently fail a claim",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/indexer/work/{runId}/heartbeat": {
+      "post": {
+        "description": "Extends the lease of a claimed work item. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`.\n\nRequired scope: `indexer:write`.",
+        "operationId": "heartbeatIndexerWork",
+        "parameters": [
+          {
+            "description": "The claimed work item id.",
+            "in": "path",
+            "name": "runId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HeartbeatWorkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HeartbeatWorkResponse"
+                }
+              }
+            },
+            "description": "The renewed lease."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Renew a claim lease",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/ingest/document": {
+      "post": {
+        "description": "Source → Indexer → Candidates → Brain: stores + chunks the text, runs the selected indexers, commits grounded candidates as facts. `mode: \"async\"` fans out per-indexer queue jobs instead (requires DOCUMENT_MULTI_INDEXER_ENABLED). Throttled to 10 requests/min per credential. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/documents-ingest.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "ingestDocument",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngestDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/IngestDocumentSyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/IngestDocumentAsyncResponse"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Ingest outcome — shape follows the requested `mode`."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Ingest a normalized document",
+        "tags": [
+          "Documents"
+        ]
+      }
+    },
+    "/v1/registry/packs": {
+      "get": {
+        "description": "Lists published packs (latest installable version each). The catalogue is shared across all tenants; any authenticated key may browse. Source: src/registry/registry.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "listRegistryPacks",
+        "parameters": [
+          {
+            "description": "Substring match on pack id / description.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by publisher id.",
+            "in": "query",
+            "name": "publisher",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by keyword tag.",
+            "in": "query",
+            "name": "tag",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page offset.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryListResponse"
+                }
+              }
+            },
+            "description": "The catalogue page."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "Browse the global Domain Pack catalogue",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/v1/registry/packs/{packId}": {
+      "get": {
+        "description": "All published versions of a pack, newest first, including yanked ones (flagged).\n\nRequired scope: `brain:read`.",
+        "operationId": "getRegistryPackVersions",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryVersionsResponse"
+                }
+              }
+            },
+            "description": "Version history (empty list when the pack is unknown)."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "One pack's published version history",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/v1/registry/packs/{packId}/{version}": {
+      "get": {
+        "description": "Returns the full manifest body for install/inspection. `latest` is an alias for the latest non-yanked version.\n\nRequired scope: `brain:read`.",
+        "operationId": "getRegistryPackManifest",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A published version, or `latest`.",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryManifestResponse"
+                }
+              }
+            },
+            "description": "The resolved manifest."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Resolve one version to its full manifest",
+        "tags": [
+          "Registry"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "servers": [
+    {
+      "description": "Hosted instance (placeholder — self-hosted deployments serve the same paths on their own origin).",
+      "url": "https://brain.inite.ai"
+    }
+  ],
+  "tags": [
+    {
+      "description": "Discovery reads over the global Domain Pack registry (shared across all tenants).",
+      "name": "Registry"
+    },
+    {
+      "description": "Publisher-facing writes to the global registry (scope `registry:publish`).",
+      "name": "Registry publishing"
+    },
+    {
+      "description": "Tenant-level pack management: install, list, eval, uninstall (scope `brain:admin`).",
+      "name": "Domain Packs"
+    },
+    {
+      "description": "The document pipeline: Source → Indexer → Candidates → Brain. Dark behind DOCUMENT_INGEST_ENABLED (default off).",
+      "name": "Documents"
+    },
+    {
+      "description": "The external-indexer protocol (scope `indexer:write`): poll → claim → read content → submit candidates / fail. See docs/indexer-protocol.md.",
+      "name": "Indexer work"
+    }
+  ]
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1133,6 +1133,12 @@
           "description": {
             "type": "string"
           },
+          "downloads": {
+            "default": 0,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "keywords": {
             "items": {
               "type": "string"
@@ -1142,53 +1148,8 @@
           "latestVersion": {
             "type": "string"
           },
-          "packId": {
+          "origin": {
             "type": "string"
-          },
-          "publisher": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "signed": {
-            "type": "boolean"
-          },
-          "versionCount": {
-            "maximum": 9007199254740991,
-            "minimum": 0,
-            "type": "integer"
-          }
-        },
-        "required": [
-          "packId",
-          "latestVersion",
-          "description",
-          "keywords",
-          "publisher",
-          "signed",
-          "versionCount"
-        ],
-        "type": "object"
-      },
-      "RegistryVersion": {
-        "additionalProperties": false,
-        "properties": {
-          "checksum": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "keywords": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           },
           "packId": {
             "type": "string"
@@ -1207,6 +1168,76 @@
             ]
           },
           "signed": {
+            "type": "boolean"
+          },
+          "verified": {
+            "default": false,
+            "type": "boolean"
+          },
+          "versionCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "packId",
+          "latestVersion",
+          "description",
+          "keywords",
+          "publisher",
+          "signed",
+          "verified",
+          "downloads",
+          "versionCount"
+        ],
+        "type": "object"
+      },
+      "RegistryVersion": {
+        "additionalProperties": false,
+        "properties": {
+          "checksum": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "downloads": {
+            "default": 0,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "origin": {
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "publisher": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "signed": {
+            "type": "boolean"
+          },
+          "verified": {
+            "default": false,
             "type": "boolean"
           },
           "version": {
@@ -1234,9 +1265,11 @@
           "keywords",
           "publisher",
           "signed",
+          "verified",
           "yanked",
           "yankReason",
-          "publishedAt"
+          "publishedAt",
+          "downloads"
         ],
         "type": "object"
       },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:e2e:jobs": "jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=jobs.real",
     "test:eval": "pnpm build && jest --config ./test/jest-e2e-real.json --runInBand --testPathPattern=quality",
     "eval:diff": "ts-node -r tsconfig-paths/register scripts/eval-baseline-diff.ts",
+    "openapi:build": "ts-node -T scripts/build-openapi.ts",
     "bench:router": "ts-node -r tsconfig-paths/register scripts/bench-chat-router.ts",
     "capture:decisions": "ts-node -r tsconfig-paths/register scripts/capture-decisions.ts",
     "label:decisions": "ts-node -r tsconfig-paths/register scripts/label-decisions.ts",

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -1,0 +1,839 @@
+#!/usr/bin/env -S npx ts-node -T
+/**
+ * build-openapi — assemble the OpenAPI 3.1 document for the PLATFORM
+ * surface (the community-facing API: pack registry, pack admin, document
+ * ingest/read, external-indexer candidates + work discovery). The
+ * admin/ops surface (jobs, leases, policy, stats, maintenance) is out of
+ * scope on purpose.
+ *
+ * components.schemas are GENERATED from the zod wire contracts under
+ * src/contracts/ (zod v4 z.toJSONSchema over a registry, so nested
+ * contracts become $refs). zod's default output is JSON Schema 2020-12,
+ * which OpenAPI 3.1 accepts natively — no down-conversion. paths are
+ * hand-written below against the controllers they document.
+ *
+ * Output: docs/openapi.json (committed artifact, keys sorted so
+ * regenerate-and-diff is deterministic).
+ *
+ * Run:
+ *   pnpm openapi:build
+ *
+ * Drift gate: test/openapi-doc.unit-spec.ts re-builds the document and
+ * asserts deep-equality with the committed file.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod';
+import {
+  DomainPackManifestSchema,
+  PublishPackRequestSchema,
+  PublishPackResponseSchema,
+  RegistryListResponseSchema,
+  RegistryManifestResponseSchema,
+  RegistryPackSummarySchema,
+  RegistryVersionSchema,
+  RegistryVersionsResponseSchema,
+  YankPackRequestSchema,
+  YankPackResponseSchema,
+} from '../src/contracts/registry/registry.schema';
+import {
+  AvailablePackSchema,
+  InstalledPackSchema,
+  InstallFromRegistryRequestSchema,
+  InstallPackRequestSchema,
+  InstallPackResponseSchema,
+  PackEvalFixtureResultSchema,
+  PackEvalReportSchema,
+  PacksListResponseSchema,
+  UninstallPackResponseSchema,
+} from '../src/contracts/admin/packs.schema';
+import {
+  ClaimWorkResponseSchema,
+  FailWorkResponseSchema,
+  HeartbeatWorkResponseSchema,
+  IndexerWorkItemSchema,
+  IndexerWorkListResponseSchema,
+  WorkContentChunkSchema,
+  WorkContentResponseSchema,
+} from '../src/contracts/indexer/indexer-work.schema';
+import {
+  CandidateSchema,
+  CommitCountsSchema,
+  DocumentCandidatesResponseSchema,
+  DocumentChunkSchema,
+  DocumentContextRefSchema,
+  DocumentResponseSchema,
+  FailWorkRequestSchema,
+  GroundingDropSchema,
+  HeartbeatWorkRequestSchema,
+  IngestDocumentAsyncResponseSchema,
+  IngestDocumentRequestSchema,
+  IngestDocumentSyncResponseSchema,
+  SubmitCandidatesRequestSchema,
+  SubmitCandidatesResponseSchema,
+  SubmittedEntitySchema,
+  SubmittedFactSchema,
+  SubmittedRelationSchema,
+} from '../src/contracts/documents/documents.schema';
+
+type Json = Record<string, unknown>;
+
+/* ------------------------------------------------------------------ *
+ * components.schemas — generated from the zod contracts.
+ * ------------------------------------------------------------------ */
+
+/** Every zod contract exposed as a named component. Nested contracts
+ *  listed here become `$ref`s inside their parents. */
+const ZOD_COMPONENTS: Record<string, z.ZodType> = {
+  // --- global pack registry (src/contracts/registry/registry.schema.ts)
+  DomainPackManifest: DomainPackManifestSchema,
+  PublishPackRequest: PublishPackRequestSchema,
+  PublishPackResponse: PublishPackResponseSchema,
+  RegistryListResponse: RegistryListResponseSchema,
+  RegistryManifestResponse: RegistryManifestResponseSchema,
+  RegistryPackSummary: RegistryPackSummarySchema,
+  RegistryVersion: RegistryVersionSchema,
+  RegistryVersionsResponse: RegistryVersionsResponseSchema,
+  YankPackRequest: YankPackRequestSchema,
+  YankPackResponse: YankPackResponseSchema,
+  // --- tenant pack admin (src/contracts/admin/packs.schema.ts)
+  AvailablePack: AvailablePackSchema,
+  InstalledPack: InstalledPackSchema,
+  InstallFromRegistryRequest: InstallFromRegistryRequestSchema,
+  InstallPackRequest: InstallPackRequestSchema,
+  InstallPackResponse: InstallPackResponseSchema,
+  PackEvalFixtureResult: PackEvalFixtureResultSchema,
+  PackEvalReport: PackEvalReportSchema,
+  PacksListResponse: PacksListResponseSchema,
+  UninstallPackResponse: UninstallPackResponseSchema,
+  // --- document pipeline (src/contracts/documents/documents.schema.ts)
+  Candidate: CandidateSchema,
+  CommitCounts: CommitCountsSchema,
+  DocumentCandidatesResponse: DocumentCandidatesResponseSchema,
+  DocumentChunk: DocumentChunkSchema,
+  DocumentContextRef: DocumentContextRefSchema,
+  DocumentResponse: DocumentResponseSchema,
+  GroundingDrop: GroundingDropSchema,
+  IngestDocumentAsyncResponse: IngestDocumentAsyncResponseSchema,
+  IngestDocumentRequest: IngestDocumentRequestSchema,
+  IngestDocumentSyncResponse: IngestDocumentSyncResponseSchema,
+  SubmitCandidatesRequest: SubmitCandidatesRequestSchema,
+  SubmitCandidatesResponse: SubmitCandidatesResponseSchema,
+  SubmittedEntity: SubmittedEntitySchema,
+  SubmittedFact: SubmittedFactSchema,
+  SubmittedRelation: SubmittedRelationSchema,
+  // --- external-indexer work discovery (src/contracts/indexer/…)
+  ClaimWorkResponse: ClaimWorkResponseSchema,
+  FailWorkRequest: FailWorkRequestSchema,
+  FailWorkResponse: FailWorkResponseSchema,
+  HeartbeatWorkRequest: HeartbeatWorkRequestSchema,
+  HeartbeatWorkResponse: HeartbeatWorkResponseSchema,
+  IndexerWorkItem: IndexerWorkItemSchema,
+  IndexerWorkListResponse: IndexerWorkListResponseSchema,
+  WorkContentChunk: WorkContentChunkSchema,
+  WorkContentResponse: WorkContentResponseSchema,
+};
+
+function generateComponentSchemas(): Json {
+  const registry = z.registry<{ id: string }>();
+  for (const [id, schema] of Object.entries(ZOD_COMPONENTS)) {
+    registry.add(schema, { id });
+  }
+  const { schemas } = z.toJSONSchema(registry, {
+    uri: (id) => `#/components/schemas/${id}`,
+  });
+  const out: Json = {};
+  for (const [id, schema] of Object.entries(schemas)) {
+    // $schema/$id are legal but redundant inside components (3.1 defaults
+    // to the 2020-12 dialect; the component key is the identity).
+    const { $schema, $id, ...clean } = schema as Json;
+    void $schema;
+    void $id;
+    out[id] = clean;
+  }
+  // The Nest HttpException wire shape — hand-written (no zod contract:
+  // it is framework-owned, not one of ours).
+  out.ErrorResponse = {
+    type: 'object',
+    description: 'Standard NestJS error envelope.',
+    properties: {
+      statusCode: { type: 'integer' },
+      message: {
+        anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+      },
+      error: { type: 'string' },
+    },
+    required: ['statusCode', 'message'],
+  };
+  out.FeatureDisabledResponse = {
+    type: 'object',
+    description:
+      'Answered by every document-pipeline route while ' +
+      'DOCUMENT_INGEST_ENABLED is off.',
+    properties: {
+      error: { type: 'string', const: 'feature_disabled' },
+      message: { type: 'string' },
+    },
+    required: ['error', 'message'],
+  };
+  return out;
+}
+
+/* ------------------------------------------------------------------ *
+ * Small path-building helpers.
+ * ------------------------------------------------------------------ */
+
+const ref = (name: string): Json => ({
+  $ref: `#/components/schemas/${name}`,
+});
+const errorRef = (name: string): Json => ({
+  $ref: `#/components/responses/${name}`,
+});
+
+function jsonBody(schema: Json, description?: string): Json {
+  return {
+    required: true,
+    ...(description ? { description } : {}),
+    content: { 'application/json': { schema } },
+  };
+}
+
+function jsonResponse(description: string, schema: Json): Json {
+  return { description, content: { 'application/json': { schema } } };
+}
+
+function pathParam(name: string, description: string): Json {
+  return {
+    name,
+    in: 'path',
+    required: true,
+    description,
+    schema: { type: 'string' },
+  };
+}
+
+function queryParam(name: string, description: string, schema?: Json): Json {
+  return {
+    name,
+    in: 'query',
+    required: false,
+    description,
+    schema: schema ?? { type: 'string' },
+  };
+}
+
+interface OperationSpec {
+  operationId: string;
+  tag: string;
+  summary: string;
+  description: string;
+  /** Bearer-key scope the route's @RequireScopes guard demands. */
+  scope: string;
+  parameters?: Json[];
+  requestBody?: Json;
+  responses: Json;
+}
+
+function operation(spec: OperationSpec): Json {
+  return {
+    operationId: spec.operationId,
+    tags: [spec.tag],
+    summary: spec.summary,
+    description: `${spec.description}\n\nRequired scope: \`${spec.scope}\`.`,
+    ...(spec.parameters ? { parameters: spec.parameters } : {}),
+    ...(spec.requestBody ? { requestBody: spec.requestBody } : {}),
+    responses: spec.responses,
+  };
+}
+
+const AUTH_ERRORS: Json = {
+  '401': errorRef('Unauthorized'),
+  '403': errorRef('Forbidden'),
+};
+/** Everything behind the DOCUMENT_INGEST_ENABLED dark-launch flag. */
+const FLAG_GATED: Json = { ...AUTH_ERRORS, '503': errorRef('FeatureDisabled') };
+
+const FLAG_NOTE =
+  'Part of the document pipeline — answers `503 feature_disabled` until ' +
+  '`DOCUMENT_INGEST_ENABLED=1`.';
+
+/* ------------------------------------------------------------------ *
+ * paths — hand-written for the platform surface only.
+ * ------------------------------------------------------------------ */
+
+function registryPaths(): Json {
+  return {
+    '/v1/registry/packs': {
+      get: operation({
+        operationId: 'listRegistryPacks',
+        tag: 'Registry',
+        summary: 'Browse the global Domain Pack catalogue',
+        description:
+          'Lists published packs (latest installable version each). The ' +
+          'catalogue is shared across all tenants; any authenticated key ' +
+          'may browse. Source: src/registry/registry.controller.ts.',
+        scope: 'brain:read',
+        parameters: [
+          queryParam('q', 'Substring match on pack id / description.'),
+          queryParam('publisher', 'Filter by publisher id.'),
+          queryParam('tag', 'Filter by keyword tag.'),
+          queryParam('limit', 'Page size.', { type: 'integer' }),
+          queryParam('offset', 'Page offset.', { type: 'integer' }),
+        ],
+        responses: {
+          '200': jsonResponse('The catalogue page.', ref('RegistryListResponse')),
+          ...AUTH_ERRORS,
+        },
+      }),
+    },
+    '/v1/registry/packs/{packId}': {
+      get: operation({
+        operationId: 'getRegistryPackVersions',
+        tag: 'Registry',
+        summary: "One pack's published version history",
+        description:
+          'All published versions of a pack, newest first, including ' +
+          'yanked ones (flagged).',
+        scope: 'brain:read',
+        parameters: [pathParam('packId', 'The pack id.')],
+        responses: {
+          '200': jsonResponse(
+            'Version history (empty list when the pack is unknown).',
+            ref('RegistryVersionsResponse'),
+          ),
+          ...AUTH_ERRORS,
+        },
+      }),
+    },
+    '/v1/registry/packs/{packId}/{version}': {
+      get: operation({
+        operationId: 'getRegistryPackManifest',
+        tag: 'Registry',
+        summary: 'Resolve one version to its full manifest',
+        description:
+          'Returns the full manifest body for install/inspection. ' +
+          '`latest` is an alias for the latest non-yanked version.',
+        scope: 'brain:read',
+        parameters: [
+          pathParam('packId', 'The pack id.'),
+          pathParam('version', 'A published version, or `latest`.'),
+        ],
+        responses: {
+          '200': jsonResponse(
+            'The resolved manifest.',
+            ref('RegistryManifestResponse'),
+          ),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+    '/v1/admin/registry/packs': {
+      post: operation({
+        operationId: 'publishRegistryPack',
+        tag: 'Registry publishing',
+        summary: 'Publish a pack version to the global registry',
+        description:
+          'Versions are immutable once published. Republishing an ' +
+          'identical (packId, version, checksum) is idempotent ' +
+          '(`created: false`); a different body for an existing version ' +
+          'is rejected. Source: src/registry/admin-registry.controller.ts.',
+        scope: 'registry:publish',
+        requestBody: jsonBody(ref('PublishPackRequest')),
+        responses: {
+          '201': jsonResponse('Published (or already present).', ref('PublishPackResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '409': errorRef('Conflict'),
+        },
+      }),
+    },
+    '/v1/admin/registry/packs/{packId}/{version}/yank': {
+      post: operation({
+        operationId: 'yankRegistryPack',
+        tag: 'Registry publishing',
+        summary: 'Yank a published version',
+        description:
+          'Marks a version as not-installable (existing installs keep ' +
+          'working). The version stays visible in the history, flagged.',
+        scope: 'registry:publish',
+        parameters: [
+          pathParam('packId', 'The pack id.'),
+          pathParam('version', 'The published version to yank.'),
+        ],
+        requestBody: jsonBody(ref('YankPackRequest')),
+        responses: {
+          '201': jsonResponse('Yank state after the call.', ref('YankPackResponse')),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+    '/v1/admin/registry/packs/{packId}/{version}/unyank': {
+      post: operation({
+        operationId: 'unyankRegistryPack',
+        tag: 'Registry publishing',
+        summary: 'Restore a yanked version',
+        description: 'Reverses a yank — the version becomes installable again.',
+        scope: 'registry:publish',
+        parameters: [
+          pathParam('packId', 'The pack id.'),
+          pathParam('version', 'The yanked version to restore.'),
+        ],
+        responses: {
+          '201': jsonResponse('Yank state after the call.', ref('YankPackResponse')),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+  };
+}
+
+function packsAdminPaths(): Json {
+  return {
+    '/v1/admin/packs': {
+      get: operation({
+        operationId: 'listDomainPacks',
+        tag: 'Domain Packs',
+        summary: 'List available + installed packs for this tenant',
+        description:
+          'Builtin packs are globally available and cannot be installed ' +
+          'or uninstalled here. Source: src/admin/admin-packs.controller.ts.',
+        scope: 'brain:admin',
+        responses: {
+          '200': jsonResponse('Available and installed packs.', ref('PacksListResponse')),
+          ...AUTH_ERRORS,
+        },
+      }),
+      post: operation({
+        operationId: 'installDomainPack',
+        tag: 'Domain Packs',
+        summary: 'Install a pack manifest into this tenant',
+        description:
+          'Validates and installs a community / custom manifest, seeding ' +
+          'its predicates. `expectedChecksum` pins the exact content.',
+        scope: 'brain:admin',
+        requestBody: jsonBody(ref('InstallPackRequest')),
+        responses: {
+          '201': jsonResponse('Installed.', ref('InstallPackResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+        },
+      }),
+    },
+    '/v1/admin/packs/from-registry': {
+      post: operation({
+        operationId: 'installDomainPackFromRegistry',
+        tag: 'Domain Packs',
+        summary: 'Install a pack from the global registry',
+        description:
+          'Resolves the manifest (latest non-yanked, or a pinned version) ' +
+          'and installs it with the registry checksum pinned — the ' +
+          'installed content is exactly what the registry served.',
+        scope: 'brain:admin',
+        requestBody: jsonBody(ref('InstallFromRegistryRequest')),
+        responses: {
+          '201': jsonResponse('Installed.', ref('InstallPackResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+    '/v1/admin/packs/{packId}': {
+      delete: operation({
+        operationId: 'uninstallDomainPack',
+        tag: 'Domain Packs',
+        summary: 'Uninstall a pack from this tenant',
+        description:
+          "Deprecates the pack's predicates; facts extracted with them " +
+          'survive.',
+        scope: 'brain:admin',
+        parameters: [pathParam('packId', 'The installed pack id.')],
+        responses: {
+          '200': jsonResponse('Uninstalled.', ref('UninstallPackResponse')),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+    '/v1/admin/packs/{packId}/eval': {
+      post: operation({
+        operationId: 'evalDomainPack',
+        tag: 'Domain Packs',
+        summary: "Run a pack's eval fixtures against the live extractor",
+        description:
+          "Scores whether extraction (with the pack's predicates + " +
+          'extractionProfile active) still meets the pack’s own ' +
+          'expectations. Runs up to MAX_EVAL_FIXTURES live LLM calls — ' +
+          'throttled to 3 requests/min per credential.',
+        scope: 'brain:admin',
+        parameters: [
+          pathParam('packId', 'The installed pack id.'),
+          queryParam(
+            'mode',
+            "'union' (default) scores the shared union prompt; 'dedicated' " +
+              'runs the pack-scoped dedicated prompt instead.',
+            { type: 'string', enum: ['union', 'dedicated'] },
+          ),
+        ],
+        responses: {
+          '201': jsonResponse('The eval report.', ref('PackEvalReport')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+          '429': errorRef('TooManyRequests'),
+        },
+      }),
+    },
+  };
+}
+
+function documentsPaths(): Json {
+  return {
+    '/v1/ingest/document': {
+      post: operation({
+        operationId: 'ingestDocument',
+        tag: 'Documents',
+        summary: 'Ingest a normalized document',
+        description:
+          'Source → Indexer → Candidates → Brain: stores + chunks the ' +
+          'text, runs the selected indexers, commits grounded candidates ' +
+          'as facts. `mode: "async"` fans out per-indexer queue jobs ' +
+          'instead (requires DOCUMENT_MULTI_INDEXER_ENABLED). Throttled ' +
+          `to 10 requests/min per credential. ${FLAG_NOTE} ` +
+          'Source: src/documents/documents-ingest.controller.ts.',
+        scope: 'brain:write',
+        requestBody: jsonBody(ref('IngestDocumentRequest')),
+        responses: {
+          '201': jsonResponse('Ingest outcome — shape follows the requested `mode`.', {
+            oneOf: [
+              ref('IngestDocumentSyncResponse'),
+              ref('IngestDocumentAsyncResponse'),
+            ],
+          }),
+          '400': errorRef('BadRequest'),
+          '429': errorRef('TooManyRequests'),
+          ...FLAG_GATED,
+        },
+      }),
+    },
+    '/v1/documents/{id}': {
+      get: operation({
+        operationId: 'getDocument',
+        tag: 'Documents',
+        summary: 'Read a document header and its indexer runs',
+        description:
+          `${FLAG_NOTE} ` +
+          'Source: src/documents/documents.controller.ts.',
+        scope: 'brain:read',
+        parameters: [
+          pathParam('id', 'The document id.'),
+          queryParam(
+            'includeText',
+            'Pass `1` to include the stored chunks. The raw text can carry ' +
+              'any PII, so this additionally requires the `brain:read_pii` ' +
+              'scope (403 otherwise).',
+            { type: 'string', enum: ['1'] },
+          ),
+        ],
+        responses: {
+          '200': jsonResponse('The document.', ref('DocumentResponse')),
+          ...FLAG_GATED,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+    '/v1/documents/{id}/candidates': {
+      get: operation({
+        operationId: 'listDocumentCandidates',
+        tag: 'Documents',
+        summary: "The document's staged candidates (audit view)",
+        description:
+          'Every extraction candidate staged against the document, over ' +
+          'all runs. `object`/`clause` of fact candidates whose predicate ' +
+          'requires a scope the caller lacks are redacted; the row stays ' +
+          `visible for the audit trail. ${FLAG_NOTE}`,
+        scope: 'brain:read',
+        parameters: [pathParam('id', 'The document id.')],
+        responses: {
+          '200': jsonResponse('The candidates.', ref('DocumentCandidatesResponse')),
+          ...FLAG_GATED,
+          '404': errorRef('NotFound'),
+        },
+      }),
+      post: operation({
+        operationId: 'submitDocumentCandidates',
+        tag: 'Indexer work',
+        summary: "Stage an external indexer's candidate batch",
+        description:
+          'A remote indexer that read a stored document submits its ' +
+          'reading here. With `runId` + `claimToken` the submission ' +
+          'fulfils a claimed work item; without them it opens its own run ' +
+          '(claimless flow). Candidates are grounded against the stored ' +
+          'text; the Brain commits once every run for the document is ' +
+          'settled. Max 200 items per kind. Throttled to 10 requests/min ' +
+          `per credential. ${FLAG_NOTE} ` +
+          'Source: src/documents/external-candidates.controller.ts.',
+        scope: 'indexer:write',
+        parameters: [pathParam('id', 'The document id.')],
+        requestBody: jsonBody(ref('SubmitCandidatesRequest')),
+        responses: {
+          '201': jsonResponse('Staged (and possibly committed).', ref('SubmitCandidatesResponse')),
+          '400': errorRef('BadRequest'),
+          ...FLAG_GATED,
+          '404': errorRef('NotFound'),
+          '409': errorRef('Conflict'),
+          '429': errorRef('TooManyRequests'),
+        },
+      }),
+    },
+  };
+}
+
+function indexerWorkPaths(): Json {
+  return {
+    '/v1/indexer/work': {
+      get: operation({
+        operationId: 'listIndexerWork',
+        tag: 'Indexer work',
+        summary: 'Poll for pending external work items',
+        description:
+          'Pending indexer runs routed to this tenant’s installed ' +
+          'external packs. Protocol: docs/indexer-protocol.md. ' +
+          `${FLAG_NOTE} Source: src/documents/indexer-work.controller.ts.`,
+        scope: 'indexer:write',
+        parameters: [
+          queryParam('packId', 'Only work for this external pack.'),
+          queryParam('limit', 'Max items to return.', { type: 'integer' }),
+        ],
+        responses: {
+          '200': jsonResponse('Claimable work items.', ref('IndexerWorkListResponse')),
+          ...FLAG_GATED,
+        },
+      }),
+    },
+    '/v1/indexer/work/{runId}/claim': {
+      post: operation({
+        operationId: 'claimIndexerWork',
+        tag: 'Indexer work',
+        summary: 'Claim a pending work item',
+        description:
+          'Atomically transitions the run to claimed and returns the ' +
+          'claimToken that fences all subsequent calls. Heartbeat within ' +
+          `leaseSeconds or the claim is reaped as abandoned. ${FLAG_NOTE}`,
+        scope: 'indexer:write',
+        parameters: [pathParam('runId', 'The work item (indexer run) id.')],
+        responses: {
+          '201': jsonResponse('The claim.', ref('ClaimWorkResponse')),
+          ...FLAG_GATED,
+          '404': errorRef('NotFound'),
+          '409': errorRef('Conflict'),
+        },
+      }),
+    },
+    '/v1/indexer/work/{runId}/heartbeat': {
+      post: operation({
+        operationId: 'heartbeatIndexerWork',
+        tag: 'Indexer work',
+        summary: 'Renew a claim lease',
+        description: `Extends the lease of a claimed work item. ${FLAG_NOTE}`,
+        scope: 'indexer:write',
+        parameters: [pathParam('runId', 'The claimed work item id.')],
+        requestBody: jsonBody(ref('HeartbeatWorkRequest')),
+        responses: {
+          '201': jsonResponse('The renewed lease.', ref('HeartbeatWorkResponse')),
+          ...FLAG_GATED,
+          '404': errorRef('NotFound'),
+          '409': errorRef('Conflict'),
+        },
+      }),
+    },
+    '/v1/indexer/work/{runId}/content': {
+      get: operation({
+        operationId: 'getIndexerWorkContent',
+        tag: 'Indexer work',
+        summary: "Read the claimed document's stored content",
+        description:
+          'Serves the verbatim stored chunks of the claimed document — ' +
+          'only for documents whose ingest routed to this tenant’s ' +
+          `installed external packs. ${FLAG_NOTE}`,
+        scope: 'indexer:write',
+        parameters: [pathParam('runId', 'The claimed work item id.')],
+        responses: {
+          '200': jsonResponse('The document content.', ref('WorkContentResponse')),
+          ...FLAG_GATED,
+          '404': errorRef('NotFound'),
+          '409': errorRef('Conflict'),
+        },
+      }),
+    },
+    '/v1/indexer/work/{runId}/fail': {
+      post: operation({
+        operationId: 'failIndexerWork',
+        tag: 'Indexer work',
+        summary: 'Release or permanently fail a claim',
+        description:
+          "Default RELEASES the item back to 'pending' (transient trouble, " +
+          "shutdown mid-work); `permanent: true` marks the run 'failed' — " +
+          `no longer offered. ${FLAG_NOTE}`,
+        scope: 'indexer:write',
+        parameters: [pathParam('runId', 'The claimed work item id.')],
+        requestBody: jsonBody(ref('FailWorkRequest')),
+        responses: {
+          '201': jsonResponse('The outcome.', ref('FailWorkResponse')),
+          ...FLAG_GATED,
+          '404': errorRef('NotFound'),
+          '409': errorRef('Conflict'),
+        },
+      }),
+    },
+  };
+}
+
+/* ------------------------------------------------------------------ *
+ * Document assembly.
+ * ------------------------------------------------------------------ */
+
+/** Recursively sort object keys so the emitted JSON is byte-deterministic. */
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Json).sort()) {
+      out[key] = sortKeysDeep((value as Json)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function errorResponses(): Json {
+  const err = (description: string): Json =>
+    jsonResponse(description, ref('ErrorResponse'));
+  return {
+    BadRequest: err('Validation failed.'),
+    Unauthorized: err('Missing or unknown bearer key.'),
+    Forbidden: err('The key lacks the required scope.'),
+    NotFound: err('No such resource in this tenant.'),
+    Conflict: err(
+      'State conflict — e.g. a lost/mismatched claim token, an already ' +
+        'claimed work item, or an immutable-version republish.',
+    ),
+    TooManyRequests: err('Per-credential throttle exceeded.'),
+    FeatureDisabled: jsonResponse(
+      'The document pipeline is dark (DOCUMENT_INGEST_ENABLED off).',
+      ref('FeatureDisabledResponse'),
+    ),
+  };
+}
+
+export function buildOpenApiDocument(): Json {
+  const pkg = JSON.parse(
+    readFileSync(join(__dirname, '..', 'package.json'), 'utf8'),
+  ) as { version: string };
+
+  const document: Json = {
+    openapi: '3.1.0',
+    info: {
+      title: 'INITE Brain — Platform API',
+      version: pkg.version,
+      summary:
+        'The community-facing platform surface: Domain Pack registry, ' +
+        'tenant pack admin, document ingest, and the external-indexer ' +
+        'work protocol.',
+      description:
+        'Generated from the zod wire contracts (`pnpm openapi:build` — ' +
+        'scripts/build-openapi.ts); do not edit by hand. The admin/ops ' +
+        'surface (jobs, leases, policy, stats, maintenance) is documented ' +
+        'in docs/api.md instead. Scopes are plain bearer-key grants, not ' +
+        'OAuth flows — each operation states its required scope.',
+      license: {
+        name: 'AGPL-3.0-or-later',
+        identifier: 'AGPL-3.0-or-later',
+      },
+    },
+    servers: [
+      {
+        url: 'https://brain.inite.ai',
+        description:
+          'Hosted instance (placeholder — self-hosted deployments serve ' +
+          'the same paths on their own origin).',
+      },
+    ],
+    security: [{ bearerAuth: [] }],
+    tags: [
+      {
+        name: 'Registry',
+        description:
+          'Discovery reads over the global Domain Pack registry ' +
+          '(shared across all tenants).',
+      },
+      {
+        name: 'Registry publishing',
+        description:
+          'Publisher-facing writes to the global registry ' +
+          '(scope `registry:publish`).',
+      },
+      {
+        name: 'Domain Packs',
+        description:
+          'Tenant-level pack management: install, list, eval, uninstall ' +
+          '(scope `brain:admin`).',
+      },
+      {
+        name: 'Documents',
+        description:
+          'The document pipeline: Source → Indexer → Candidates → Brain. ' +
+          'Dark behind DOCUMENT_INGEST_ENABLED (default off).',
+      },
+      {
+        name: 'Indexer work',
+        description:
+          'The external-indexer protocol (scope `indexer:write`): poll → ' +
+          'claim → read content → submit candidates / fail. ' +
+          'See docs/indexer-protocol.md.',
+      },
+    ],
+    paths: {
+      ...registryPaths(),
+      ...packsAdminPaths(),
+      ...documentsPaths(),
+      ...indexerWorkPaths(),
+    },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          description:
+            'API key (`Authorization: Bearer <key>`); its SHA-256 must be ' +
+            'registered in BRAIN_API_KEYS. Keys carry scopes ' +
+            '(`brain:read`, `brain:write`, `brain:admin`, `brain:read_pii`, ' +
+            '`registry:publish`, `indexer:write`) — each operation states ' +
+            'the scope it requires. Not an OAuth flow.',
+        },
+      },
+      schemas: generateComponentSchemas(),
+      responses: errorResponses(),
+    },
+  };
+
+  return sortKeysDeep(document) as Json;
+}
+
+function main(): void {
+  const outPath = join(__dirname, '..', 'docs', 'openapi.json');
+  const document = buildOpenApiDocument();
+  writeFileSync(outPath, JSON.stringify(document, null, 2) + '\n', 'utf8');
+  const paths = Object.keys(document.paths as Json).length;
+  const schemas = Object.keys(
+    (document.components as Json).schemas as Json,
+  ).length;
+  process.stdout.write(
+    `wrote docs/openapi.json (${paths} paths, ${schemas} schemas)\n`,
+  );
+}
+
+if (require.main === module) main();

--- a/src/ai/domain-packs/eval-fixture.ts
+++ b/src/ai/domain-packs/eval-fixture.ts
@@ -34,6 +34,8 @@ export interface EvalFixture {
   };
 }
 
+/** OpenAPI mirror: src/contracts/admin/packs.schema.ts
+ *  (PackEvalFixtureResultSchema / PackEvalReportSchema) — keep in lockstep. */
 export interface EvalFixtureResult {
   id: string;
   passed: boolean;

--- a/src/ai/domain-packs/manifest.ts
+++ b/src/ai/domain-packs/manifest.ts
@@ -33,7 +33,9 @@ export type PackPredicate = Omit<
   'predicateId' | 'createdBy'
 > & { localId: string };
 
-/** The versioned, self-describing pack manifest — the community standard. */
+/** The versioned, self-describing pack manifest — the community standard.
+ *  OpenAPI mirror: src/contracts/registry/registry.schema.ts
+ *  (DomainPackManifestSchema) — keep in lockstep. */
 export interface DomainPackManifest {
   /** snake_case pack id, no `__`. The predicate namespace. */
   id: string;

--- a/src/contracts/admin/packs.schema.ts
+++ b/src/contracts/admin/packs.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { DomainPackManifestSchema } from '../registry/registry.schema';
 
 /**
  * Wire contracts for the Domain Pack admin surface (/v1/admin/packs).
@@ -25,6 +26,17 @@ export const PacksListResponseSchema = z.object({
   installed: z.array(InstalledPackSchema),
 });
 
+export const InstallPackRequestSchema = z.object({
+  manifest: DomainPackManifestSchema,
+  expectedChecksum: z.string().optional(),
+});
+
+export const InstallFromRegistryRequestSchema = z.object({
+  packId: z.string(),
+  /** Absent = latest non-yanked registry version. */
+  version: z.string().optional(),
+});
+
 export const InstallPackResponseSchema = z.object({
   packId: z.string(),
   version: z.string(),
@@ -37,6 +49,29 @@ export const UninstallPackResponseSchema = z.object({
   predicatesDeprecated: z.number().int().nonnegative(),
 });
 
+/** SPEC MIRROR of PackEvalReport / EvalFixtureResult
+ *  (src/ai/domain-packs/eval-fixture.ts) for docs/openapi.json. */
+export const PackEvalFixtureResultSchema = z.object({
+  id: z.string(),
+  passed: z.boolean(),
+  failures: z.array(z.string()).describe(
+    'Human-readable reasons the fixture failed (empty when passed).',
+  ),
+});
+
+export const PackEvalReportSchema = z.object({
+  packId: z.string(),
+  version: z.string(),
+  total: z.number().int().nonnegative(),
+  passed: z.number().int().nonnegative(),
+  results: z.array(PackEvalFixtureResultSchema),
+});
+
+export type InstallPackRequest = z.infer<typeof InstallPackRequestSchema>;
+export type InstallFromRegistryRequest = z.infer<
+  typeof InstallFromRegistryRequestSchema
+>;
+export type PackEvalReportWire = z.infer<typeof PackEvalReportSchema>;
 export type PacksListResponse = z.infer<typeof PacksListResponseSchema>;
 export type InstallPackResponse = z.infer<typeof InstallPackResponseSchema>;
 export type UninstallPackResponse = z.infer<typeof UninstallPackResponseSchema>;

--- a/src/contracts/documents/documents.schema.ts
+++ b/src/contracts/documents/documents.schema.ts
@@ -1,0 +1,276 @@
+import { z } from 'zod';
+
+/**
+ * Wire contracts for the document pipeline's PLATFORM surface
+ * (/v1/ingest/document, /v1/documents/:id, /v1/documents/:id/candidates).
+ *
+ * SPEC MIRRORS, not runtime validators. The request schemas mirror the
+ * class-validator DTOs that actually validate these bodies at runtime —
+ * src/documents/dto/ingest-document.dto.ts and submit-candidates.dto.ts —
+ * field-for-field (names, optionality, length caps). The response schemas
+ * mirror the service interfaces (DocumentIngestResponse,
+ * DocumentAsyncResponse, StoredDocument, CandidateRow,
+ * ExternalSubmissionResult). When a DTO or response interface changes,
+ * change the mirror here and regenerate docs/openapi.json
+ * (`pnpm openapi:build`); test/openapi-doc.unit-spec.ts gates the drift.
+ */
+
+/** Mirror of DocumentContextRef (src/documents/dto/ingest-document.dto.ts). */
+export const DocumentContextRefSchema = z.object({
+  vertical: z.string(),
+  /** CONNECTOR identity; committed facts carry the INDEXER as recorder. */
+  recorder: z.string().optional(),
+});
+
+/** Mirror of IngestDocumentDto — runtime cap DOC_TEXT_HARD_CAP = 512_000. */
+export const IngestDocumentRequestSchema = z.object({
+  kind: z.string().max(64).describe(
+    'Container kind the connector normalized from (pdf/markdown/email/…). ' +
+      'Open string — provenance metadata only.',
+  ),
+  text: z
+    .string()
+    .max(512_000)
+    .describe('Normalized document text (DOC_MAX_CHARS may lower the cap).'),
+  originUri: z.string().max(512).optional().describe(
+    'Pointer back to the raw container (URL, path, message id…).',
+  ),
+  title: z.string().max(512).optional(),
+  meta: z.record(z.string(), z.unknown()).optional().describe(
+    "Operator-supplied metadata, projected onto derived facts' source.meta.",
+  ),
+  occurredAt: z.string().meta({
+    format: 'date-time',
+    description: "ISO 8601 — becomes the derived facts' validFrom.",
+  }),
+  contextRef: DocumentContextRefSchema,
+  storeContent: z.boolean().optional().describe(
+    'Store the normalized chunks server-side. false keeps only ' +
+      'contentHash + metadata (no re-index, no span re-validation).',
+  ),
+  indexers: z
+    .union([z.literal('general'), z.literal('auto'), z.array(z.string())])
+    .optional()
+    .describe(
+      "'general' (union pass), 'auto' (router-selected), or explicit pack ids.",
+    ),
+  mode: z.enum(['sync', 'async']).optional().describe(
+    "'async' requires DOCUMENT_MULTI_INDEXER_ENABLED and storeContent.",
+  ),
+});
+
+/** Shared commit tally (CommitResult['counts']). */
+export const CommitCountsSchema = z.object({
+  pending: z.number().int().nonnegative(),
+  committed: z.number().int().nonnegative(),
+  merged: z.number().int().nonnegative(),
+  rejected: z.number().int().nonnegative(),
+});
+
+/** Mirror of DocumentIngestResponse (document-ingest.service.ts). */
+export const IngestDocumentSyncResponseSchema = z.object({
+  documentId: z.string(),
+  deduplicated: z.boolean(),
+  chunkCount: z.number().int().nonnegative(),
+  mode: z.literal('sync'),
+  runs: z.array(
+    z.object({ runId: z.string(), packId: z.string(), status: z.string() }),
+  ),
+  committed: z.object({
+    entityIds: z.array(z.string()),
+    factIds: z.array(z.string()),
+    edgeIds: z.array(z.string()),
+  }),
+  counts: CommitCountsSchema,
+});
+
+/** Mirror of DocumentAsyncResponse (document-async.service.ts). */
+export const IngestDocumentAsyncResponseSchema = z.object({
+  documentId: z.string(),
+  deduplicated: z.boolean(),
+  chunkCount: z.number().int().nonnegative(),
+  mode: z.literal('async'),
+  runs: z.array(
+    z.object({
+      packId: z.string(),
+      /** 'planned' = an external pack's pull-API work item was registered. */
+      status: z.enum(['enqueued', 'already_processed', 'planned']),
+    }),
+  ),
+});
+
+/** Mirror of DocumentChunk (src/documents/chunker.ts). */
+export const DocumentChunkSchema = z.object({
+  seq: z.number().int().nonnegative(),
+  text: z.string(),
+  charStart: z.number().int().nonnegative(),
+  charEnd: z.number().int().nonnegative(),
+});
+
+/**
+ * Mirror of the GET /v1/documents/:id response — StoredDocument
+ * (document-store.service.ts) + its indexer runs; `chunks` only with
+ * ?includeText=1 (scope brain:read_pii).
+ */
+export const DocumentResponseSchema = z.object({
+  id: z.string(),
+  kind: z.string(),
+  contentHash: z.string(),
+  charLen: z.number().int().nonnegative(),
+  chunkCount: z.number().int().nonnegative(),
+  hasContent: z.boolean(),
+  vertical: z.string(),
+  recorder: z.string().optional(),
+  occurredAt: z.string().meta({ format: 'date-time' }),
+  status: z.string(),
+  meta: z.record(z.string(), z.unknown()).optional(),
+  runs: z.array(
+    z.object({
+      runId: z.string(),
+      packId: z.string(),
+      packVersion: z.string(),
+      status: z.string(),
+    }),
+  ),
+  chunks: z.array(DocumentChunkSchema).optional(),
+});
+
+/** Mirror of CandidateRow (candidate-store.service.ts). */
+export const CandidateSchema = z.object({
+  id: z.string(),
+  runId: z.string(),
+  chunkSeq: z.number().int(),
+  kind: z.enum(['entity', 'fact', 'relation']),
+  confidence: z.number(),
+  status: z.string(),
+  statusReason: z.string().optional(),
+  commitRef: z.string().optional(),
+  payload: z.record(z.string(), z.unknown()).describe(
+    'Extraction payload. `object`/`clause` of scope-gated fact candidates ' +
+      'are redacted for callers without the required predicate scope.',
+  ),
+});
+
+export const DocumentCandidatesResponseSchema = z.object({
+  documentId: z.string(),
+  candidates: z.array(CandidateSchema),
+});
+
+/** Mirror of SubmittedEntity (src/documents/dto/submit-candidates.dto.ts). */
+export const SubmittedEntitySchema = z.object({
+  name: z.string(),
+  type: z.string().optional(),
+  canonical: z.string().optional(),
+});
+
+/** Mirror of SubmittedFact — entityIndex is LOCAL to this batch. */
+export const SubmittedFactSchema = z.object({
+  entityIndex: z.number().int().nonnegative(),
+  predicate: z
+    .string()
+    .describe('Must be namespaced `<indexerId>__*` or a core predicate.'),
+  object: z.string(),
+  confidence: z.number().optional(),
+  clause: z.string().optional(),
+});
+
+/** Mirror of SubmittedRelation. */
+export const SubmittedRelationSchema = z.object({
+  fromEntityIndex: z.number().int().nonnegative(),
+  toEntityIndex: z.number().int().nonnegative(),
+  kind: z.string(),
+  confidence: z.number().optional(),
+});
+
+/** Mirror of SubmitCandidatesDto (top-level class-validated; item shapes
+ *  service-validated — ≤200 items per kind). */
+export const SubmitCandidatesRequestSchema = z.object({
+  indexerId: z
+    .string()
+    .max(64)
+    .describe("The pack id this indexer is registered as (mode 'external')."),
+  packVersion: z.string().max(32).optional().describe(
+    'Optional claim of the pack version; must match the installed one.',
+  ),
+  runId: z.string().max(128).optional().describe(
+    'A claimed work item this submission fulfils. Provided together with ' +
+      'claimToken or not at all (claimless flow opens its own run).',
+  ),
+  claimToken: z.string().max(64).optional(),
+  entities: z.array(SubmittedEntitySchema),
+  facts: z.array(SubmittedFactSchema),
+  relations: z.array(SubmittedRelationSchema).optional(),
+});
+
+/** Mirror of GroundingDrop (candidate-grounding.ts). */
+export const GroundingDropSchema = z.object({
+  kind: z.enum(['entity', 'fact', 'relation']),
+  index: z.number().int().nonnegative(),
+  reason: z.enum(['ungrounded_entity', 'ungrounded_value', 'orphan_reference']),
+  detail: z.string(),
+});
+
+/**
+ * Mirror of the POST /v1/documents/:id/candidates response —
+ * ExternalSubmissionResult (external-candidates.service.ts) + the
+ * commit-if-settled outcome the controller appends.
+ */
+export const SubmitCandidatesResponseSchema = z.object({
+  runId: z.string(),
+  packId: z.string(),
+  packVersion: z.string(),
+  staged: z.object({
+    entities: z.number().int().nonnegative(),
+    facts: z.number().int().nonnegative(),
+    relations: z.number().int().nonnegative(),
+  }),
+  dropped: z.array(GroundingDropSchema),
+  ungrounded: z.boolean().describe(
+    'true when the document has no stored content — spans unverifiable.',
+  ),
+  commit: z
+    .object({
+      deferred: z.boolean(),
+      committed: z.boolean(),
+      counts: CommitCountsSchema,
+    })
+    .nullable()
+    .describe('null when the document vanished between staging and commit.'),
+});
+
+/** Mirror of HeartbeatWorkDto (src/documents/dto/heartbeat-work.dto.ts). */
+export const HeartbeatWorkRequestSchema = z.object({
+  claimToken: z.string().max(64),
+});
+
+/** Mirror of FailWorkDto (src/documents/dto/fail-work.dto.ts). */
+export const FailWorkRequestSchema = z.object({
+  claimToken: z.string().max(64),
+  error: z.string().max(2_000).optional().describe(
+    'Optional diagnostic recorded on the run row (truncated server-side).',
+  ),
+  permanent: z.boolean().optional().describe(
+    "Default (false/absent) RELEASES the item back to 'pending'; true " +
+      "marks the run 'failed' — no longer offered, still claimable by runId.",
+  ),
+});
+
+export type HeartbeatWorkRequest = z.infer<typeof HeartbeatWorkRequestSchema>;
+export type FailWorkRequest = z.infer<typeof FailWorkRequestSchema>;
+export type IngestDocumentRequest = z.infer<typeof IngestDocumentRequestSchema>;
+export type IngestDocumentSyncResponse = z.infer<
+  typeof IngestDocumentSyncResponseSchema
+>;
+export type IngestDocumentAsyncResponse = z.infer<
+  typeof IngestDocumentAsyncResponseSchema
+>;
+export type DocumentResponse = z.infer<typeof DocumentResponseSchema>;
+export type DocumentCandidatesResponse = z.infer<
+  typeof DocumentCandidatesResponseSchema
+>;
+export type SubmitCandidatesRequest = z.infer<
+  typeof SubmitCandidatesRequestSchema
+>;
+export type SubmitCandidatesResponse = z.infer<
+  typeof SubmitCandidatesResponseSchema
+>;

--- a/src/contracts/registry/registry.schema.ts
+++ b/src/contracts/registry/registry.schema.ts
@@ -67,6 +67,36 @@ export const RegistryManifestResponseSchema = z.object({
   manifest: z.record(z.string(), z.unknown()),
 });
 
+/**
+ * SPEC MIRROR of the DomainPackManifest TS interface
+ * (src/ai/domain-packs/manifest.ts) for docs/openapi.json. Deliberately
+ * loose (open object, opaque nested shapes) — runtime validation is the
+ * manifest validator on the install/publish path, never this schema.
+ */
+export const DomainPackManifestSchema = z.looseObject({
+  id: z.string().describe('snake_case pack id, no `__`.'),
+  version: z.string().describe('semver MAJOR.MINOR.PATCH.'),
+  description: z.string(),
+  predicates: z.array(z.record(z.string(), z.unknown())),
+  extractionProfile: z.record(z.string(), z.unknown()).optional(),
+  evalFixtures: z.array(z.record(z.string(), z.unknown())).optional(),
+  signature: z.string().optional().describe(
+    'ed25519 signature (base64) over the canonical manifest sans this field.',
+  ),
+  publisher: z.string().optional(),
+  indexer: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const PublishPackRequestSchema = z.object({
+  manifest: DomainPackManifestSchema,
+  keywords: z.array(z.string()).optional(),
+  expectedChecksum: z.string().optional(),
+});
+
+export const YankPackRequestSchema = z.object({
+  reason: z.string().optional(),
+});
+
 export const PublishPackResponseSchema = z.object({
   packId: z.string(),
   version: z.string(),
@@ -91,5 +121,8 @@ export type RegistryVersionsResponse = z.infer<
 export type RegistryManifestResponse = z.infer<
   typeof RegistryManifestResponseSchema
 >;
+export type DomainPackManifestWire = z.infer<typeof DomainPackManifestSchema>;
+export type PublishPackRequest = z.infer<typeof PublishPackRequestSchema>;
+export type YankPackRequest = z.infer<typeof YankPackRequestSchema>;
 export type PublishPackResponse = z.infer<typeof PublishPackResponseSchema>;
 export type YankPackResponse = z.infer<typeof YankPackResponseSchema>;

--- a/src/documents/dto/fail-work.dto.ts
+++ b/src/documents/dto/fail-work.dto.ts
@@ -6,6 +6,9 @@ import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
  * it (transient trouble, shutting down mid-work). `permanent: true`
  * marks the run 'failed' instead — "this indexer cannot process this
  * document", still reclaimable by runId but no longer offered.
+ *
+ * OpenAPI mirror: src/contracts/documents/documents.schema.ts
+ * (FailWorkRequestSchema) — keep in lockstep.
  */
 export class FailWorkDto {
   @IsString()

--- a/src/documents/dto/heartbeat-work.dto.ts
+++ b/src/documents/dto/heartbeat-work.dto.ts
@@ -1,6 +1,10 @@
 import { IsString, MaxLength } from 'class-validator';
 
-/** POST /v1/indexer/work/:runId/heartbeat — renew a claim lease. */
+/**
+ * POST /v1/indexer/work/:runId/heartbeat — renew a claim lease.
+ * OpenAPI mirror: src/contracts/documents/documents.schema.ts
+ * (HeartbeatWorkRequestSchema) — keep in lockstep.
+ */
 export class HeartbeatWorkDto {
   @IsString()
   @MaxLength(64)

--- a/src/documents/dto/ingest-document.dto.ts
+++ b/src/documents/dto/ingest-document.dto.ts
@@ -23,6 +23,11 @@ export interface DocumentContextRef {
 /** Static hard cap on document text; DOC_MAX_CHARS (env) may lower it. */
 export const DOC_TEXT_HARD_CAP = 512_000;
 
+/**
+ * OpenAPI mirror: src/contracts/documents/documents.schema.ts
+ * (IngestDocumentRequestSchema) — keep field names/optionality/caps in
+ * lockstep and regenerate docs/openapi.json on change.
+ */
 export class IngestDocumentDto {
   /**
    * Container kind the connector normalized from (pdf/markdown/email/

--- a/src/documents/dto/submit-candidates.dto.ts
+++ b/src/documents/dto/submit-candidates.dto.ts
@@ -31,6 +31,11 @@ export interface SubmittedRelation {
   confidence?: number;
 }
 
+/**
+ * OpenAPI mirror: src/contracts/documents/documents.schema.ts
+ * (SubmitCandidatesRequestSchema) — keep field names/optionality/caps in
+ * lockstep and regenerate docs/openapi.json on change.
+ */
 export class SubmitCandidatesDto {
   /** The pack id this indexer is registered as (indexer.mode 'external'). */
   @IsString()

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Drift gate for docs/openapi.json — the committed OpenAPI 3.1 document
+ * for the platform surface. Re-builds the document from the zod
+ * contracts (scripts/build-openapi.ts) and asserts it deep-equals the
+ * committed artifact: any contract or path change without a
+ * `pnpm openapi:build` fails here. Pure — no Nest app boots.
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { buildOpenApiDocument } from '../scripts/build-openapi';
+
+type Json = Record<string, unknown>;
+
+const built = buildOpenApiDocument();
+const committed = JSON.parse(
+  readFileSync(join(__dirname, '..', 'docs', 'openapi.json'), 'utf8'),
+) as Json;
+
+/** Every platform path+method the spec promises to document. */
+const PLATFORM_OPERATIONS: Array<[string, string]> = [
+  ['/v1/registry/packs', 'get'],
+  ['/v1/registry/packs/{packId}', 'get'],
+  ['/v1/registry/packs/{packId}/{version}', 'get'],
+  ['/v1/admin/registry/packs', 'post'],
+  ['/v1/admin/registry/packs/{packId}/{version}/yank', 'post'],
+  ['/v1/admin/registry/packs/{packId}/{version}/unyank', 'post'],
+  ['/v1/admin/packs', 'get'],
+  ['/v1/admin/packs', 'post'],
+  ['/v1/admin/packs/from-registry', 'post'],
+  ['/v1/admin/packs/{packId}', 'delete'],
+  ['/v1/admin/packs/{packId}/eval', 'post'],
+  ['/v1/ingest/document', 'post'],
+  ['/v1/documents/{id}', 'get'],
+  ['/v1/documents/{id}/candidates', 'get'],
+  ['/v1/documents/{id}/candidates', 'post'],
+  ['/v1/indexer/work', 'get'],
+  ['/v1/indexer/work/{runId}/claim', 'post'],
+  ['/v1/indexer/work/{runId}/heartbeat', 'post'],
+  ['/v1/indexer/work/{runId}/content', 'get'],
+  ['/v1/indexer/work/{runId}/fail', 'post'],
+];
+
+describe('docs/openapi.json', () => {
+  it('is an OpenAPI 3.1 document with the package version', () => {
+    expect(built.openapi).toBe('3.1.0');
+    const pkg = JSON.parse(
+      readFileSync(join(__dirname, '..', 'package.json'), 'utf8'),
+    ) as { version: string };
+    expect((built.info as Json).version).toBe(pkg.version);
+  });
+
+  it('matches the committed artifact (regenerate: pnpm openapi:build)', () => {
+    expect(committed).toEqual(built);
+  });
+
+  it.each(PLATFORM_OPERATIONS)(
+    'documents %s %s with operationId and responses',
+    (path, method) => {
+      const pathItem = (built.paths as Json)[path] as Json | undefined;
+      expect(pathItem).toBeDefined();
+      const op = pathItem?.[method] as Json | undefined;
+      expect(op).toBeDefined();
+      expect(typeof op?.operationId).toBe('string');
+      expect((op?.operationId as string).length).toBeGreaterThan(0);
+      const responses = op?.responses as Json;
+      expect(Object.keys(responses).length).toBeGreaterThanOrEqual(1);
+    },
+  );
+
+  it('documents no paths beyond the platform surface', () => {
+    const documented = Object.keys(built.paths as Json).sort();
+    const expected = [...new Set(PLATFORM_OPERATIONS.map(([p]) => p))].sort();
+    expect(documented).toEqual(expected);
+  });
+
+  it('every operation states its required scope and is bearer-secured', () => {
+    expect(built.security).toEqual([{ bearerAuth: [] }]);
+    for (const [path, method] of PLATFORM_OPERATIONS) {
+      const op = ((built.paths as Json)[path] as Json)[method] as Json;
+      expect(op.description).toMatch(/Required scope: `[a-z_]+:[a-z_]+`/);
+    }
+  });
+
+  it('every $ref in the document resolves', () => {
+    const refs = new Set<string>();
+    const collect = (value: unknown): void => {
+      if (Array.isArray(value)) return value.forEach(collect);
+      if (value !== null && typeof value === 'object') {
+        for (const [k, v] of Object.entries(value as Json)) {
+          if (k === '$ref' && typeof v === 'string') refs.add(v);
+          else collect(v);
+        }
+      }
+    };
+    collect(built);
+    expect(refs.size).toBeGreaterThan(0);
+    for (const r of refs) {
+      expect(r).toMatch(/^#\//);
+      let cursor: unknown = built;
+      for (const part of r.slice(2).split('/')) {
+        cursor = (cursor as Json | undefined)?.[part];
+      }
+      expect(cursor).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
Platform wave PL3. The community-facing surface (registry, packs, document pipeline, indexer work discovery) is now machine-described — `docs/openapi.json` (OpenAPI 3.1.0, 18 paths / 20 operations / 45 schemas), generated with **zero new dependencies** from the existing zod v4 contracts (`z.toJSONSchema` over a registry with `$ref` wiring; JSON Schema 2020-12 output is natively valid in 3.1).

- `pnpm openapi:build` regenerates deterministically (recursively sorted keys); `test/openapi-doc.unit-spec.ts` (25 tests, no Nest boot) enforces regenerate-and-diff equality, operationId/response presence, platform-surface-only paths, per-operation scope statements, and `$ref` resolution.
- Request bodies whose runtime validators are class-validator DTOs got zod spec mirrors in `src/contracts/documents/documents.schema.ts` with cross-pointer comments both ways (DTOs remain the runtime validators).
- Admin/ops surface (jobs, leases, policy, stats) deliberately excluded.

Verification: typecheck/lint/lint:ci clean, 25/25 spec tests, full unit suite 155 suites / 1112 tests green, rebuild-after-commit zero diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd