### PR TITLE
feat(registry): pull-only cross-instance mirroring (REGISTRY_UPSTREAM_URL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -267,6 +267,22 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 # (POST /v1/admin/registry/packs). Same strict value set.
 #PACK_REGISTRY_REQUIRE_SIGNATURE=0
 
+# ── Registry mirroring (pull-only) ───────────────────────────────────────
+# Base URL of another Brain instance whose pack registry this one mirrors
+# (e.g. https://brain.example.com). Unset (default) = mirroring off — no job
+# is registered. When set, a background job periodically pulls the upstream
+# catalogue and republishes missing versions locally with an `origin` marker
+# (migration 0064). Pull-only: local publishes never push upstream; upstream
+# yanks mirror onto origin-matching rows only. Must parse as an http(s) URL
+# (fails boot otherwise). Restart required to turn the feature on/off.
+#REGISTRY_UPSTREAM_URL=
+# Bearer token sent on upstream /v1/registry reads (the upstream's JSON API
+# requires a brain:read key). Optional — omit for an open upstream.
+#REGISTRY_UPSTREAM_TOKEN=
+# How often the mirror syncs, in hours (default 24 — one run at 00:26 UTC,
+# clear of the 03:17–04:00 nightly maintenance window).
+#REGISTRY_MIRROR_INTERVAL_HOURS=24
+
 # ── Calibration ──────────────────────────────────────────────────────────
 # Nightly source-trust refit crons (03:42 enqueue / 03:51 inline). Enabled
 # ONLY on literal 'true' — any other value disables.

--- a/brain-landing/lib/contracts/admin-config.ts
+++ b/brain-landing/lib/contracts/admin-config.ts
@@ -22,6 +22,7 @@ const ConfigCategorySchema = z.enum([
   'throttle',
   'jobs',
   'auth',
+  'registry',
   'misc',
 ])
 

--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -259,6 +259,26 @@ pnpm pack:install  -- --brain-url $URL --registry real_estate[@0.2.0]  # brain:a
 pnpm registry:seed -- --brain-url $URL                   # publish all packs/*.json
 ```
 
+### Mirroring (pull-only)
+
+A deployment can mirror another instance's registry: set
+`REGISTRY_UPSTREAM_URL` (+ optional `REGISTRY_UPSTREAM_TOKEN`, a `brain:read`
+key on the upstream) and a background job pulls the upstream catalogue every
+`REGISTRY_MIRROR_INTERVAL_HOURS` (default 24; one run at 00:26 UTC) and
+republishes missing versions locally through the normal publish path — so
+validation, builtin-id squatting protection, version immutability and the
+local trust store's `verified` recomputation all apply. Mirrored rows carry
+an `origin` marker (the upstream base URL, migration 0064; surfaced in the
+API and as *mirrored from `<host>`* in `/registry/ui`).
+
+Rules: **pull-only** (local publishes never push upstream); **local rows
+always win** (an id/version that exists locally is skipped); **yanks mirror
+one-way** — an upstream yank is applied only to rows whose `origin` matches
+that upstream, never to local publishes; every pulled manifest's checksum is
+recomputed locally and a mismatch is rejected. Work is bounded (200 versions
+per run, 10s per request; per-pack failures don't abort the run). Unset
+`REGISTRY_UPSTREAM_URL` (the default) = feature off, no job registered.
+
 ## Eval fixtures (consumed)
 
 A pack may ship `evalFixtures` — small extraction test cases for its domain,

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -17,6 +17,7 @@ export type ConfigCategory =
   | 'throttle'
   | 'jobs'
   | 'auth'
+  | 'registry'
   | 'misc';
 
 export interface ConfigEntry {
@@ -852,6 +853,35 @@ export class ConfigInspectorService {
         isBooleanFlag: false,
         description:
           'Cap on in-flight dispatches across all jobTypes in this process; 0 = uncapped.',
+      },
+      // ── Registry mirroring (pull-only, migration 0064) ───────
+      {
+        key: 'REGISTRY_UPSTREAM_URL',
+        category: 'registry',
+        defaultValue: null,
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Base URL of the upstream Brain instance whose pack registry this one mirrors. Unset = mirroring off (no job registered); restart required to turn on/off.',
+      },
+      {
+        key: 'REGISTRY_UPSTREAM_TOKEN',
+        category: 'registry',
+        defaultValue: null,
+        runtimeMutable: true,
+        isBooleanFlag: false,
+        secret: true,
+        description:
+          'Bearer token sent on upstream /v1/registry reads (brain:read key on the upstream). Optional.',
+      },
+      {
+        key: 'REGISTRY_MIRROR_INTERVAL_HOURS',
+        category: 'registry',
+        defaultValue: '24',
+        runtimeMutable: true,
+        isBooleanFlag: false,
+        description:
+          'Mirror sync cadence in hours. The hourly :26 UTC cron collapses ticks inside one interval bucket via dedup key.',
       },
     ];
   }

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -103,6 +103,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // ── Pack supply-chain knobs ───────────────────────────────────────
   validatePackTrustEnv(env, errors);
 
+  // ── Registry mirroring (pull-only) ────────────────────────────────
+  validateRegistryMirrorEnv(env, errors);
+
   // ── fact_trust ranking knobs (source-reputation Phase 5) ──────────
   nonNegativeFloat(env, 'SEARCH_TRUST_BETA', errors);
   nonNegativeFloat(env, 'SEARCH_CORROBORATION_GAMMA', errors);
@@ -397,6 +400,35 @@ function validatePackTrustEnv(env: NodeJS.ProcessEnv, errors: string[]): void {
       );
     }
   }
+}
+
+/**
+ * Pull-only registry mirroring (RegistryMirrorService). A malformed
+ * REGISTRY_UPSTREAM_URL would make every sync run fail at fetch time —
+ * catch it at boot instead. REGISTRY_UPSTREAM_TOKEN is a free-form bearer
+ * (nothing to validate); the interval shares the positiveInt idiom.
+ */
+function validateRegistryMirrorEnv(
+  env: NodeJS.ProcessEnv,
+  errors: string[],
+): void {
+  const url = env.REGISTRY_UPSTREAM_URL;
+  if (url !== undefined && url.trim() !== '') {
+    let valid = false;
+    try {
+      const parsed = new URL(url.trim());
+      valid = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      valid = false;
+    }
+    if (!valid) {
+      errors.push(
+        'REGISTRY_UPSTREAM_URL must be a valid http(s) URL — the pull-only ' +
+          'registry mirror fetches the upstream catalogue from it.',
+      );
+    }
+  }
+  positiveInt(env, 'REGISTRY_MIRROR_INTERVAL_HOURS', errors);
 }
 
 function required({

--- a/src/contracts/admin/config.schema.ts
+++ b/src/contracts/admin/config.schema.ts
@@ -23,6 +23,7 @@ const ConfigCategorySchema = z.enum([
   'throttle',
   'jobs',
   'auth',
+  'registry',
   'misc',
 ]);
 

--- a/src/contracts/registry/registry.schema.ts
+++ b/src/contracts/registry/registry.schema.ts
@@ -24,6 +24,9 @@ export const RegistryVersionSchema = z.object({
   /** Installs served for THIS version (install path only — browsing and
    *  manifest inspection are not counted). */
   downloads: z.number().int().nonnegative().default(0),
+  /** Upstream registry base URL this version was mirrored from
+   *  (pull-only mirror, REGISTRY_UPSTREAM_URL). Absent = locally published. */
+  origin: z.string().optional(),
 });
 
 /** One pack in a catalogue listing — its latest installable version + counts. */
@@ -41,6 +44,8 @@ export const RegistryPackSummarySchema = z.object({
   /** publishedAt of the latest installable version (ISO 8601). */
   publishedAt: z.string().optional(),
   versionCount: z.number().int().nonnegative(),
+  /** origin of the latest installable version (see RegistryVersion). */
+  origin: z.string().optional(),
 });
 
 export const RegistryListResponseSchema = z.object({

--- a/src/db/migrations/0064_registry_pack_origin.surql
+++ b/src/db/migrations/0064_registry_pack_origin.surql
@@ -1,0 +1,12 @@
+-- 0064_registry_pack_origin — provenance marker for mirrored catalogue rows
+-- (registry_pack, migrations 0042 + 0063).
+--
+-- origin: the upstream registry base URL this version was pulled from by the
+--   pull-only mirror job (RegistryMirrorService, REGISTRY_UPSTREAM_URL).
+--   NONE = locally published. The mirror uses it as a one-way yank fence:
+--   an upstream yank is mirrored ONLY onto rows whose origin matches that
+--   upstream — locally published versions are never yanked by the mirror.
+--   No backfill needed: every pre-existing row is by definition a local
+--   publish, and option<string> already reads back NONE.
+
+DEFINE FIELD IF NOT EXISTS origin ON registry_pack TYPE option<string>;

--- a/src/jobs/job-run.service.ts
+++ b/src/jobs/job-run.service.ts
@@ -17,7 +17,8 @@ export type JobType =
   | 'commit_document'
   | 'candidate_sweeper'
   | 'reindex_documents'
-  | 'scenarios_batch';
+  | 'scenarios_batch'
+  | 'registry_mirror';
 
 export type JobStatus =
   | 'pending'

--- a/src/registry/pack-registry.service.ts
+++ b/src/registry/pack-registry.service.ts
@@ -41,6 +41,8 @@ interface RegistryRow {
   yankReason?: string | null;
   publishedAt: string;
   downloads?: number;
+  /** Upstream base URL the row was mirrored from; NONE = local publish. */
+  origin?: string | null;
 }
 
 /**
@@ -84,6 +86,10 @@ export class PackRegistryService {
     publishedBy?: string;
     keywords?: string[];
     expectedChecksum?: string;
+    /** Set by the pull-only mirror (RegistryMirrorService): the upstream
+     *  base URL the version was pulled from. Never set on operator
+     *  publishes — the field is what fences mirrored yanks off local rows. */
+    origin?: string;
   }): Promise<PublishPackResponse> {
     const { manifest } = input;
     if (!manifest || typeof manifest !== 'object') {
@@ -170,6 +176,7 @@ export class PackRegistryService {
         };
         if (manifest.publisher) content.publisher = manifest.publisher;
         if (input.publishedBy) content.publishedBy = input.publishedBy;
+        if (input.origin) content.origin = input.origin;
         await db.query(`CREATE registry_pack CONTENT $content`, { content });
         this.logger.log(
           `Published pack ${manifest.id} v${manifest.version} (checksum ${checksum.slice(0, 12)}…)`,
@@ -222,6 +229,7 @@ export class PackRegistryService {
         downloads: versions.reduce((n, v) => n + Number(v.downloads ?? 0), 0),
         publishedAt: new Date(row.publishedAt).toISOString(),
         versionCount: versions.length,
+        ...(row.origin ? { origin: row.origin } : {}),
       });
     }
     const q = filter.q?.trim().toLowerCase();
@@ -386,7 +394,7 @@ export class PackRegistryService {
   private projection(includeManifest: boolean): string {
     return `packId, version,${includeManifest ? ' manifest,' : ''} checksum,
             description, keywords, publisher, signed, verified, yanked,
-            yankReason, publishedAt, downloads`;
+            yankReason, publishedAt, downloads, origin`;
   }
 
   /** One pack's rows, packId-index scoped (no full-table scan). */
@@ -429,6 +437,7 @@ export class PackRegistryService {
       yankReason: r.yankReason ?? null,
       publishedAt: new Date(r.publishedAt).toISOString(),
       downloads: Number(r.downloads ?? 0),
+      ...(r.origin ? { origin: r.origin } : {}),
     };
   }
 

--- a/src/registry/registry-mirror-sync.ts
+++ b/src/registry/registry-mirror-sync.ts
@@ -1,0 +1,350 @@
+import { packChecksum, type DomainPackManifest } from '../ai/domain-packs';
+
+/**
+ * Pull-only registry mirroring — the pure sync core (docs/domain-packs.md).
+ *
+ * Consumes another Brain instance's public registry API
+ * (GET /v1/registry/packs → /:packId → /:packId/:version) and replays new
+ * versions into the LOCAL catalogue through the caller-supplied port — the
+ * same publish path operators use, so validation / builtin-id squatting
+ * protection / version immutability / local `verified` recomputation all
+ * apply unchanged. Framework-free and fetch-injectable so the merge logic
+ * is unit-testable without a network.
+ *
+ * Rules:
+ *   - Local rows always win: an (id, version) that exists locally is never
+ *     overwritten (skipped at debug).
+ *   - Yanks mirror ONE-WAY (upstream yank → local yank) and ONLY onto rows
+ *     whose `origin` matches this upstream — locally published versions are
+ *     never yanked by the mirror. Unyanks are NOT mirrored.
+ *   - A version that is already yanked upstream and absent locally is not
+ *     imported (no point pulling known-bad content).
+ *   - Every imported manifest's checksum is recomputed locally and compared
+ *     against the upstream's declared checksum — a mismatch is rejected.
+ *   - Work is bounded: at most `maxVersionsPerRun` manifests are fetched per
+ *     run (the rest waits for the next run); each request gets its own
+ *     timeout; one pack's failure never aborts the run.
+ *
+ * Known limitation (documented, accepted): the upstream catalogue listing
+ * omits packs whose every version is yanked, so a pack fully yanked upstream
+ * stops being visited and its yanks are not mirrored until/unless it lists
+ * again.
+ */
+
+export interface MirrorLocalVersion {
+  version: string;
+  yanked: boolean;
+  /** Upstream base URL the row was mirrored from; unset = local publish. */
+  origin?: string | null;
+}
+
+/** Port onto the local registry — implemented over PackRegistryService. */
+export interface MirrorLocalRegistry {
+  versionsOf(packId: string): Promise<MirrorLocalVersion[]>;
+  publish(input: {
+    manifest: DomainPackManifest;
+    origin: string;
+    expectedChecksum: string;
+  }): Promise<{ created: boolean }>;
+  yank(input: {
+    packId: string;
+    version: string;
+    reason?: string;
+  }): Promise<void>;
+}
+
+export interface MirrorLogger {
+  log(message: string): void;
+  warn(message: string): void;
+  debug(message: string): void;
+}
+
+export interface MirrorSyncOptions {
+  /** Upstream base URL (scheme + host [+ port]), no trailing slash. */
+  upstreamBase: string;
+  /** Optional bearer for the upstream's /v1/registry reads. */
+  token?: string;
+  local: MirrorLocalRegistry;
+  logger: MirrorLogger;
+  /** Injectable for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Per-request timeout (default 10s). */
+  timeoutMs?: number;
+  /** Manifest-fetch budget per run (default 200). */
+  maxVersionsPerRun?: number;
+  /** Outer cancellation (job lease loss / shutdown). */
+  signal?: AbortSignal;
+}
+
+export interface MirrorSyncSummary {
+  upstream: string;
+  packsSeen: number;
+  imported: number;
+  skippedExisting: number;
+  yanksMirrored: number;
+  checksumMismatches: number;
+  failures: number;
+  capped: boolean;
+}
+
+/** Canonical form of the upstream URL — used verbatim as the `origin`
+ *  marker, so normalization keeps the yank fence stable across config
+ *  edits like a trailing slash. */
+export function normalizeUpstreamBase(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_VERSIONS_PER_RUN = 200;
+/** Catalogue page size — the upstream caps limit at 500. */
+const PAGE_SIZE = 200;
+
+interface UpstreamVersionRow {
+  version: string;
+  checksum?: string;
+  yanked?: boolean;
+  yankReason?: string | null;
+}
+
+interface SyncCtx {
+  base: string;
+  token?: string;
+  local: MirrorLocalRegistry;
+  logger: MirrorLogger;
+  fetchImpl: typeof fetch;
+  timeoutMs: number;
+  signal?: AbortSignal;
+  /** Remaining manifest fetches this run. */
+  budget: number;
+  maxVersions: number;
+  capped: boolean;
+  summary: MirrorSyncSummary;
+}
+
+export async function syncRegistryMirror(
+  opts: MirrorSyncOptions,
+): Promise<MirrorSyncSummary> {
+  const base = normalizeUpstreamBase(opts.upstreamBase);
+  const ctx: SyncCtx = {
+    base,
+    token: opts.token,
+    local: opts.local,
+    logger: opts.logger,
+    fetchImpl: opts.fetchImpl ?? fetch,
+    timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    signal: opts.signal,
+    budget: opts.maxVersionsPerRun ?? DEFAULT_MAX_VERSIONS_PER_RUN,
+    maxVersions: opts.maxVersionsPerRun ?? DEFAULT_MAX_VERSIONS_PER_RUN,
+    capped: false,
+    summary: {
+      upstream: base,
+      packsSeen: 0,
+      imported: 0,
+      skippedExisting: 0,
+      yanksMirrored: 0,
+      checksumMismatches: 0,
+      failures: 0,
+      capped: false,
+    },
+  };
+  const packIds = await listUpstreamPackIds(ctx);
+  for (const packId of packIds) {
+    if (ctx.capped || ctx.signal?.aborted) break;
+    ctx.summary.packsSeen++;
+    try {
+      await syncPack(ctx, packId);
+    } catch (e) {
+      ctx.summary.failures++;
+      ctx.logger.warn(
+        `mirror: pack ${packId} failed — ${(e as Error).message}`,
+      );
+    }
+  }
+  ctx.summary.capped = ctx.capped;
+  const s = ctx.summary;
+  ctx.logger.log(
+    `registry mirror ${base}: packs=${s.packsSeen} imported=${s.imported} ` +
+      `skipped=${s.skippedExisting} yanksMirrored=${s.yanksMirrored} ` +
+      `checksumRejected=${s.checksumMismatches} failures=${s.failures}` +
+      (s.capped ? ' CAPPED' : ''),
+  );
+  return s;
+}
+
+/** Page through the upstream catalogue collecting pack ids. */
+async function listUpstreamPackIds(ctx: SyncCtx): Promise<string[]> {
+  const ids: string[] = [];
+  for (let offset = 0; ; offset += PAGE_SIZE) {
+    const page = (await fetchUpstreamJson(
+      ctx,
+      `/v1/registry/packs?limit=${PAGE_SIZE}&offset=${offset}`,
+    )) as { packs?: Array<{ packId?: unknown }> };
+    const packs = Array.isArray(page?.packs) ? page.packs : [];
+    ids.push(...packs.map((p) => String(p.packId ?? '')).filter(Boolean));
+    if (packs.length < PAGE_SIZE) return ids;
+  }
+}
+
+async function syncPack(ctx: SyncCtx, packId: string): Promise<void> {
+  const res = (await fetchUpstreamJson(
+    ctx,
+    `/v1/registry/packs/${encodeURIComponent(packId)}`,
+  )) as { versions?: UpstreamVersionRow[] };
+  const upstreamVersions = Array.isArray(res?.versions) ? res.versions : [];
+  const localByVersion = new Map(
+    (await ctx.local.versionsOf(packId)).map((v) => [v.version, v]),
+  );
+  for (const uv of upstreamVersions) {
+    if (ctx.capped || ctx.signal?.aborted) return;
+    const existing = localByVersion.get(uv.version);
+    if (existing) {
+      await reconcileExisting(ctx, { packId, upstream: uv, local: existing });
+      continue;
+    }
+    if (uv.yanked) {
+      // Born-yanked upstream and absent here: nothing installable to gain
+      // by pulling known-bad content.
+      ctx.logger.debug(
+        `mirror: skip ${packId}@${uv.version} — yanked upstream, not present locally`,
+      );
+      continue;
+    }
+    try {
+      await importVersion(ctx, { packId, row: uv });
+    } catch (e) {
+      ctx.summary.failures++;
+      ctx.logger.warn(
+        `mirror: import ${packId}@${uv.version} failed — ${(e as Error).message}`,
+      );
+    }
+  }
+}
+
+/** A version that exists locally: local rows always win — the only action
+ *  ever taken is mirroring an upstream yank onto an origin-matching row. */
+async function reconcileExisting(
+  ctx: SyncCtx,
+  args: {
+    packId: string;
+    upstream: UpstreamVersionRow;
+    local: MirrorLocalVersion;
+  },
+): Promise<void> {
+  const { packId, upstream, local } = args;
+  const at = `${packId}@${upstream.version}`;
+  if (!upstream.yanked || local.yanked) {
+    ctx.summary.skippedExisting++;
+    ctx.logger.debug(`mirror: skip ${at} — already present locally`);
+    return;
+  }
+  if ((local.origin ?? null) !== ctx.base) {
+    // The yank fence: never yank a locally published (or other-origin) row.
+    ctx.summary.skippedExisting++;
+    ctx.logger.debug(
+      `mirror: yank fence ${at} — local row does not originate from this upstream`,
+    );
+    return;
+  }
+  await ctx.local.yank({
+    packId,
+    version: upstream.version,
+    reason: upstream.yankReason
+      ? `mirrored yank from ${ctx.base}: ${upstream.yankReason}`
+      : `mirrored yank from ${ctx.base}`,
+  });
+  ctx.summary.yanksMirrored++;
+  ctx.logger.log(`mirror: yanked ${at} (mirrored from ${ctx.base})`);
+}
+
+async function importVersion(
+  ctx: SyncCtx,
+  args: { packId: string; row: UpstreamVersionRow },
+): Promise<void> {
+  const { packId, row } = args;
+  const at = `${packId}@${row.version}`;
+  if (ctx.budget <= 0) {
+    ctx.capped = true;
+    ctx.logger.log(
+      `mirror: version budget (${ctx.maxVersions}) exhausted — remaining versions deferred to the next run`,
+    );
+    return;
+  }
+  ctx.budget--;
+  const resolved = (await fetchUpstreamJson(
+    ctx,
+    `/v1/registry/packs/${encodeURIComponent(packId)}/${encodeURIComponent(row.version)}`,
+  )) as { checksum?: string; manifest?: Record<string, unknown> };
+  const manifest = resolved?.manifest as DomainPackManifest | undefined;
+  if (!manifest || typeof manifest !== 'object') {
+    ctx.summary.failures++;
+    ctx.logger.warn(`mirror: ${at} returned no manifest — skipped`);
+    return;
+  }
+  // A hostile/buggy upstream must not smuggle content for a DIFFERENT
+  // (id, version) under this pack's URL.
+  if (manifest.id !== packId || manifest.version !== row.version) {
+    ctx.summary.failures++;
+    ctx.logger.warn(
+      `mirror: ${at} manifest identifies as ${String(manifest.id)}@${String(manifest.version)} — skipped`,
+    );
+    return;
+  }
+  // Recompute with the LOCAL checksum util; the upstream's declared value
+  // (manifest response, cross-checked against its versions listing) must
+  // match the content we actually received.
+  const computed = packChecksum(manifest);
+  const declared = String(resolved?.checksum ?? '');
+  const listed = row.checksum ? String(row.checksum) : declared;
+  if (computed !== declared || computed !== listed) {
+    ctx.summary.checksumMismatches++;
+    ctx.logger.warn(
+      `mirror: rejected ${at} — checksum mismatch (declared ${declared.slice(0, 12)}…, computed ${computed.slice(0, 12)}…)`,
+    );
+    return;
+  }
+  // Same code path as an operator publish: validation, builtin-id squatting
+  // protection, immutability and local trust-store `verified` recomputation
+  // all apply. `origin` marks the row as mirrored.
+  const { created } = await ctx.local.publish({
+    manifest,
+    origin: ctx.base,
+    expectedChecksum: computed,
+  });
+  if (created) {
+    ctx.summary.imported++;
+    ctx.logger.log(`mirror: imported ${at} from ${ctx.base}`);
+  } else {
+    ctx.summary.skippedExisting++;
+    ctx.logger.debug(`mirror: ${at} already present (idempotent republish)`);
+  }
+}
+
+/** GET a JSON document from the upstream with a per-request timeout and
+ *  optional bearer, honouring the outer abort signal. */
+async function fetchUpstreamJson(
+  ctx: SyncCtx,
+  path: string,
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ctx.timeoutMs);
+  timer.unref?.();
+  const onOuterAbort = () => controller.abort();
+  ctx.signal?.addEventListener('abort', onOuterAbort, { once: true });
+  if (ctx.signal?.aborted) controller.abort();
+  try {
+    const res = await ctx.fetchImpl(`${ctx.base}${path}`, {
+      headers: {
+        accept: 'application/json',
+        ...(ctx.token ? { authorization: `Bearer ${ctx.token}` } : {}),
+      },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`upstream ${path} answered HTTP ${res.status}`);
+    }
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+    ctx.signal?.removeEventListener('abort', onOuterAbort);
+  }
+}

--- a/src/registry/registry-mirror.service.ts
+++ b/src/registry/registry-mirror.service.ts
@@ -1,0 +1,167 @@
+import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ApiKeyService } from '../auth/api-key.service';
+import { JobClaimService } from '../jobs/job-claim.service';
+import { WorkerLoopService, JobContext } from '../jobs/worker-loop.service';
+import { PackRegistryService } from './pack-registry.service';
+import {
+  normalizeUpstreamBase,
+  syncRegistryMirror,
+  type MirrorLocalRegistry,
+  type MirrorSyncSummary,
+} from './registry-mirror-sync';
+
+/**
+ * Pull-only cross-instance registry mirroring (docs/domain-packs.md).
+ *
+ * When REGISTRY_UPSTREAM_URL is set, a background job periodically pulls the
+ * upstream instance's pack catalogue and republishes versions missing locally
+ * with an `origin` marker (migration 0064). Pull-only: local publishes never
+ * push upstream; yanks mirror one-way (upstream yank → local yank, and only
+ * onto rows whose origin matches this upstream). The merge rules live in
+ * registry-mirror-sync.ts; this class owns config, scheduling and the
+ * jobs-framework plumbing (candidate-sweeper mold: onModuleInit register +
+ * cron-time enqueue + queue handler).
+ *
+ * Unset REGISTRY_UPSTREAM_URL (the default) = feature off: no handler is
+ * registered, the cron enqueues nothing — zero behavior change.
+ *
+ * Tenancy: the registry is INSTANCE-GLOBAL (PackRegistryService writes the
+ * shared `system` DB via withAdminDb), but the jobs framework is strictly
+ * per-tenant — every job_run row lives in one tenant DB. Same adaptation as
+ * the cross-tenant source-trust refit (CalibrationRefitQueueService): the
+ * cron enqueues a SINGLE row homed on the first known tenant, and the
+ * handler does instance-global work regardless of the row's tenant.
+ *
+ * Cadence: the cron ticks hourly at :26 UTC (a minute no other cron uses)
+ * and enqueues with a dedup key derived from the current
+ * REGISTRY_MIRROR_INTERVAL_HOURS bucket, so extra ticks inside one interval
+ * collapse against the bucket's run. With the default 24h interval the
+ * bucket flips at midnight UTC → one run at 00:26 UTC, clear of the
+ * 03:17–04:00 nightly maintenance window.
+ */
+@Injectable()
+export class RegistryMirrorService implements OnModuleInit {
+  private readonly logger = new Logger(RegistryMirrorService.name);
+
+  // Job-owner service in the candidate-sweeper mold: registration,
+  // cron-time enqueue, and the sync entrypoint.
+  // eslint-disable-next-line max-params
+  constructor(
+    private readonly registry: PackRegistryService,
+    private readonly apiKeys: ApiKeyService,
+    @Optional() private readonly workerLoop?: WorkerLoopService,
+    @Optional() private readonly claim?: JobClaimService,
+  ) {}
+
+  onModuleInit(): void {
+    // Feature off (no upstream configured) → nothing registered, the
+    // worker loop never polls for registry_mirror rows.
+    if (!this.upstreamUrl() || !this.workerLoop) return;
+    this.workerLoop.register(
+      'registry_mirror',
+      (ctx) => this.executeFromQueue(ctx),
+      { ttlSeconds: 600, maxAttempts: 2 },
+    );
+  }
+
+  /** Hourly at :26 UTC — the interval-bucketed dedup key collapses ticks
+   *  inside one REGISTRY_MIRROR_INTERVAL_HOURS window into a single run. */
+  @Cron('26 * * * *', { timeZone: 'UTC' })
+  async runScheduled(): Promise<{ enqueued: boolean }> {
+    const upstream = this.upstreamUrl();
+    if (!upstream || !this.claim) return { enqueued: false };
+    const hostTenant = this.apiKeys.knownCompanyIds()[0];
+    if (!hostTenant) {
+      this.logger.warn('registry_mirror enqueue skipped — no known tenants');
+      return { enqueued: false };
+    }
+    const intervalMs = this.intervalHours() * 3_600_000;
+    const bucketStart = new Date(Math.floor(Date.now() / intervalMs) * intervalMs);
+    // Date-keyed (bucket-start date + hour): registry_mirror_2026-07-15T00
+    const dedupKey = `registry_mirror_${bucketStart.toISOString().slice(0, 13)}`;
+    try {
+      const { created } = await this.claim.enqueue({
+        jobType: 'registry_mirror',
+        companyId: hostTenant,
+        triggeredBy: 'cron',
+        dedupKey,
+      });
+      if (created) {
+        this.logger.log(
+          `registry_mirror enqueued (${dedupKey}, upstream ${upstream})`,
+        );
+      }
+      return { enqueued: created };
+    } catch (e) {
+      this.logger.warn(
+        `enqueue registry_mirror failed: ${(e as Error).message}`,
+      );
+      return { enqueued: false };
+    }
+  }
+
+  /** Run one pull-sync against the configured upstream. */
+  async sync(signal?: AbortSignal): Promise<MirrorSyncSummary> {
+    const upstream = this.upstreamUrl();
+    if (!upstream) {
+      throw new Error('REGISTRY_UPSTREAM_URL is not set — mirroring is off');
+    }
+    return syncRegistryMirror({
+      upstreamBase: upstream,
+      token: process.env.REGISTRY_UPSTREAM_TOKEN,
+      local: this.localPort(upstream),
+      logger: {
+        log: (m) => this.logger.log(m),
+        warn: (m) => this.logger.warn(m),
+        debug: (m) => this.logger.debug(m),
+      },
+      signal,
+    });
+  }
+
+  private async executeFromQueue(
+    ctx: JobContext,
+  ): Promise<Record<string, unknown>> {
+    const summary = await this.sync(ctx.abortSignal);
+    return { ...summary };
+  }
+
+  /** The sync core's port onto the LOCAL registry — the same publish/yank
+   *  paths operators use, so every invariant (validation, builtin-id
+   *  squatting protection, immutability, local trust-store `verified`
+   *  recomputation, signed-packs policy) applies to mirrored rows too. */
+  private localPort(upstream: string): MirrorLocalRegistry {
+    return {
+      versionsOf: async (packId) => {
+        const { versions } = await this.registry.getVersions(packId);
+        return versions.map((v) => ({
+          version: v.version,
+          yanked: v.yanked,
+          origin: v.origin ?? null,
+        }));
+      },
+      publish: (input) =>
+        this.registry.publish({
+          manifest: input.manifest,
+          origin: input.origin,
+          expectedChecksum: input.expectedChecksum,
+          publishedBy: `mirror:${upstream}`,
+        }),
+      yank: async (input) => {
+        await this.registry.yank(input.packId, input.version, input.reason);
+      },
+    };
+  }
+
+  private upstreamUrl(): string | undefined {
+    const raw = process.env.REGISTRY_UPSTREAM_URL?.trim();
+    return raw ? normalizeUpstreamBase(raw) : undefined;
+  }
+
+  private intervalHours(): number {
+    const raw = process.env.REGISTRY_MIRROR_INTERVAL_HOURS;
+    const n = raw === undefined ? NaN : parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? n : 24;
+  }
+}

--- a/src/registry/registry-ui.ts
+++ b/src/registry/registry-ui.ts
@@ -18,6 +18,16 @@ function esc(s: unknown): string {
     .replace(/"/g, '&quot;');
 }
 
+/** Host part of a mirrored pack's origin URL — falls back to the raw value
+ *  when it isn't parseable (it still goes through esc()). */
+function originHost(origin: string): string {
+  try {
+    return new URL(origin).host;
+  } catch {
+    return origin;
+  }
+}
+
 function card(p: RegistryPackSummary): string {
   const tags = p.keywords
     .map((k) => `<span class="tag">${esc(k)}</span>`)
@@ -37,10 +47,15 @@ function card(p: RegistryPackSummary): string {
   const published = p.publishedAt
     ? `<span class="date">published ${esc(String(p.publishedAt).slice(0, 10))}</span>`
     : '';
+  // Pull-only mirror provenance (migration 0064): the latest installable
+  // version was pulled from another instance's registry.
+  const mirrored = p.origin
+    ? `<span class="origin">mirrored from ${esc(originHost(String(p.origin)))}</span>`
+    : '';
   return `<article class="pack">
   <h2>${esc(p.packId)} <span class="ver">v${esc(p.latestVersion)}</span> ${badge}</h2>
   <p class="desc">${esc(p.description || '(no description)')}</p>
-  <div class="meta">${tags}${publisher}<span class="dl">${esc(p.downloads ?? 0)} download(s)</span>${published}<span class="vc">${p.versionCount} version(s)</span></div>
+  <div class="meta">${tags}${publisher}${mirrored}<span class="dl">${esc(p.downloads ?? 0)} download(s)</span>${published}<span class="vc">${p.versionCount} version(s)</span></div>
   <code class="install">pnpm pack:install -- --registry ${esc(p.packId)}</code>
 </article>`;
 }
@@ -68,6 +83,7 @@ h1{font-size:1.6rem;margin:0 0 .25rem}
 .desc{margin:.25rem 0 .5rem}
 .meta{display:flex;flex-wrap:wrap;gap:.4rem;align-items:center;font-size:.8rem;color:#888;margin-bottom:.5rem}
 .tag{background:#8882;border-radius:4px;padding:.1rem .45rem}
+.origin{font-style:italic}
 .install{display:block;background:#8881;padding:.5rem .6rem;border-radius:6px;font-size:.8rem;overflow-x:auto}
 #q{width:100%;padding:.6rem .75rem;border:1px solid #8884;border-radius:8px;margin-bottom:1.25rem;font-size:1rem;box-sizing:border-box}
 .empty{color:#888}

--- a/src/registry/registry.module.ts
+++ b/src/registry/registry.module.ts
@@ -4,6 +4,7 @@ import { PackRegistryService } from './pack-registry.service';
 import { RegistryController } from './registry.controller';
 import { AdminRegistryController } from './admin-registry.controller';
 import { RegistryUiController } from './registry-ui.controller';
+import { RegistryMirrorService } from './registry-mirror.service';
 
 /**
  * The GLOBAL Domain Pack registry (docs/domain-packs.md): a shared catalogue of
@@ -11,12 +12,15 @@ import { RegistryUiController } from './registry-ui.controller';
  * (RegistryController, brain:read) + publish/yank (AdminRegistryController,
  * registry:publish). PackRegistryService is exported so the tenant-facing
  * install path (AdminPacksController) can resolve manifests from the registry.
- * SurrealService is @Global; AuthModule supplies the ApiKeyGuard.
+ * RegistryMirrorService pull-syncs an upstream instance's catalogue when
+ * REGISTRY_UPSTREAM_URL is set (inert otherwise). SurrealService is @Global;
+ * AuthModule supplies the ApiKeyGuard; JobsModule (@Global) supplies the
+ * worker-loop/claim services the mirror job uses.
  */
 @Module({
   imports: [AuthModule],
   controllers: [RegistryController, AdminRegistryController, RegistryUiController],
-  providers: [PackRegistryService],
+  providers: [PackRegistryService, RegistryMirrorService],
   exports: [PackRegistryService],
 })
 export class RegistryModule {}

--- a/test/env-validation.unit-spec.ts
+++ b/test/env-validation.unit-spec.ts
@@ -109,6 +109,40 @@ describe('validateEnv — pack supply-chain knobs', () => {
   });
 });
 
+describe('validateEnv — registry mirroring (pull-only)', () => {
+  it('accepts a valid http(s) REGISTRY_UPSTREAM_URL and a positive interval', () => {
+    for (const url of ['https://brain.example.com', 'http://10.0.0.2:3000/']) {
+      const env = baseProdEnv();
+      env.REGISTRY_UPSTREAM_URL = url;
+      env.REGISTRY_MIRROR_INTERVAL_HOURS = '6';
+      expect(() => validateEnv(env)).not.toThrow();
+    }
+  });
+
+  it('accepts the feature-off default (unset / blank URL)', () => {
+    const env = baseProdEnv();
+    expect(() => validateEnv(env)).not.toThrow();
+    env.REGISTRY_UPSTREAM_URL = '  ';
+    expect(() => validateEnv(env)).not.toThrow();
+  });
+
+  it('rejects a non-URL and a non-http(s) scheme', () => {
+    for (const bad of ['not a url', 'ftp://brain.example.com', 'brain.example.com']) {
+      const env = baseProdEnv();
+      env.REGISTRY_UPSTREAM_URL = bad;
+      expect(() => validateEnv(env)).toThrow(/REGISTRY_UPSTREAM_URL/);
+    }
+  });
+
+  it('rejects a non-positive-integer interval', () => {
+    for (const bad of ['0', '-1', 'daily', '1.5']) {
+      const env = baseProdEnv();
+      env.REGISTRY_MIRROR_INTERVAL_HOURS = bad;
+      expect(() => validateEnv(env)).toThrow(/REGISTRY_MIRROR_INTERVAL_HOURS/);
+    }
+  });
+});
+
 describe('validateEnv — ABAC boolean flags', () => {
   it('accepts 1/0/true/false for ABAC_DB_FENCE_ENABLED', () => {
     for (const v of ['1', '0', 'true', 'false']) {

--- a/test/pack-registry.e2e-spec.ts
+++ b/test/pack-registry.e2e-spec.ts
@@ -9,7 +9,10 @@
  * per-tenant domain_pack install record.
  */
 import { generateKeyPairSync } from 'node:crypto';
-import { REAL_ESTATE_PACK, signPack } from '../src/ai/domain-packs';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { packChecksum, REAL_ESTATE_PACK, signPack } from '../src/ai/domain-packs';
+import { RegistryMirrorService } from '../src/registry/registry-mirror.service';
 import type { AppFixture } from './app-fixture';
 import { createApp } from './app-fixture';
 
@@ -387,5 +390,181 @@ describe('/v1/registry — global pack registry (e2e)', () => {
     expect(page1.body.packs[0].packId).not.toBe(page2.body.packs[0].packId);
     const seen = [page1.body.packs[0].packId, page2.body.packs[0].packId].sort();
     expect(seen).toEqual(['pg_a_e2e', 'pg_b_e2e']);
+  });
+
+  describe('pull-only cross-instance mirroring (REGISTRY_UPSTREAM_URL)', () => {
+    // A fake UPSTREAM registry served by a plain node http server. State is
+    // mutable so tests can flip yanks between sync runs. JSON round-trip the
+    // manifests so checksums are computed over exactly what goes on the wire.
+    const wire = (m: Record<string, unknown>) =>
+      JSON.parse(JSON.stringify(m)) as Record<string, unknown> & {
+        id: string;
+        version: string;
+      };
+    const M_010 = wire({ ...PACK, id: 'mirror_e2e', version: '0.1.0' });
+    const M_020 = wire({
+      ...PACK,
+      id: 'mirror_e2e',
+      version: '0.2.0',
+      description: 'upstream 0.2.0 — must lose to the local publish',
+    });
+    const M_BUILTIN = wire({ ...PACK, id: 'code_memory', version: '9.0.0' });
+    const upstreamPacks: Record<
+      string,
+      Array<{ manifest: typeof M_010; yanked: boolean }>
+    > = {
+      mirror_e2e: [
+        { manifest: M_010, yanked: false },
+        { manifest: M_020, yanked: false },
+      ],
+      code_memory: [{ manifest: M_BUILTIN, yanked: false }],
+    };
+    const seenAuth: Array<string | undefined> = [];
+    let server: Server;
+    let upstreamBase: string;
+    let mirror: RegistryMirrorService;
+
+    beforeAll(async () => {
+      server = createServer((req, res) => {
+        seenAuth.push(req.headers.authorization);
+        const url = new URL(req.url ?? '/', 'http://localhost');
+        const parts = url.pathname.split('/').filter(Boolean); // v1 registry packs [id] [version]
+        const json = (body: unknown) => {
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify(body));
+        };
+        const versionRow = (packId: string, v: { manifest: typeof M_010; yanked: boolean }) => ({
+          packId,
+          version: v.manifest.version,
+          checksum: packChecksum(v.manifest as never),
+          description: '',
+          keywords: [],
+          publisher: null,
+          signed: false,
+          verified: false,
+          yanked: v.yanked,
+          yankReason: v.yanked ? 'upstream says no' : null,
+          publishedAt: new Date().toISOString(),
+          downloads: 0,
+        });
+        if (parts.length === 3) {
+          return json({
+            packs: Object.keys(upstreamPacks).map((packId) => ({
+              packId,
+              latestVersion: '0.1.0',
+              description: '',
+              keywords: [],
+              publisher: null,
+              signed: false,
+              verified: false,
+              downloads: 0,
+              versionCount: upstreamPacks[packId].length,
+            })),
+          });
+        }
+        const rows = upstreamPacks[parts[3]];
+        if (!rows) {
+          res.statusCode = 404;
+          return res.end('{}');
+        }
+        if (parts.length === 4) {
+          return json({
+            packId: parts[3],
+            latestVersion: rows[0].manifest.version,
+            versions: rows.map((v) => versionRow(parts[3], v)),
+          });
+        }
+        const row = rows.find((v) => v.manifest.version === parts[4]);
+        if (!row) {
+          res.statusCode = 404;
+          return res.end('{}');
+        }
+        return json({
+          packId: parts[3],
+          version: row.manifest.version,
+          checksum: packChecksum(row.manifest as never),
+          yanked: row.yanked,
+          manifest: row.manifest,
+        });
+      });
+      await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+      upstreamBase = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+      process.env.REGISTRY_UPSTREAM_URL = upstreamBase;
+      process.env.REGISTRY_UPSTREAM_TOKEN = 'upstream-e2e-token';
+      mirror = pub.app.get(RegistryMirrorService);
+    });
+
+    afterAll(async () => {
+      delete process.env.REGISTRY_UPSTREAM_URL;
+      delete process.env.REGISTRY_UPSTREAM_TOKEN;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+
+    it('imports upstream versions with origin, skips local rows, rejects builtin ids', async () => {
+      // A LOCAL publish of mirror_e2e@0.2.0 that must win over the upstream's.
+      const local020 = { ...PACK, id: 'mirror_e2e', version: '0.2.0' };
+      const published = await pub.http
+        .post('/v1/admin/registry/packs')
+        .set(auth(pub))
+        .send({ manifest: local020 });
+      expect([200, 201]).toContain(published.status);
+
+      const summary = await mirror.sync();
+      expect(summary.imported).toBe(1); // only 0.1.0 — 0.2.0 exists locally
+      expect(summary.skippedExisting).toBeGreaterThanOrEqual(1);
+      expect(summary.failures).toBeGreaterThanOrEqual(1); // builtin id rejected
+
+      const versions = await reader.http
+        .get('/v1/registry/packs/mirror_e2e')
+        .set(auth(reader));
+      const byVer = Object.fromEntries(
+        versions.body.versions.map((v: any) => [v.version, v]),
+      );
+      // Mirrored row carries the origin marker; the local row carries none —
+      // and its content is the LOCAL publish, not the upstream 0.2.0.
+      expect(byVer['0.1.0'].origin).toBe(upstreamBase);
+      expect(byVer['0.2.0'].origin).toBeUndefined();
+      const localManifest = await reader.http
+        .get('/v1/registry/packs/mirror_e2e/0.2.0')
+        .set(auth(reader));
+      expect(localManifest.body.manifest.description).not.toContain('upstream');
+      // Builtin-id squatting protection held on the mirror path.
+      const builtin = await reader.http
+        .get('/v1/registry/packs/code_memory')
+        .set(auth(reader));
+      expect(builtin.body.versions).toHaveLength(0);
+      // The upstream token was sent on every upstream request.
+      expect(seenAuth.length).toBeGreaterThan(0);
+      expect(seenAuth.every((a) => a === 'Bearer upstream-e2e-token')).toBe(
+        true,
+      );
+    });
+
+    it('re-sync is idempotent and mirrors upstream yanks only onto origin-matching rows', async () => {
+      // Upstream yanks BOTH versions; locally only the mirrored 0.1.0 may
+      // follow — 0.2.0 is a local publish and must stay installable.
+      upstreamPacks.mirror_e2e[0].yanked = true;
+      upstreamPacks.mirror_e2e[1].yanked = true;
+
+      const summary = await mirror.sync();
+      expect(summary.imported).toBe(0);
+      expect(summary.yanksMirrored).toBe(1);
+
+      const versions = await reader.http
+        .get('/v1/registry/packs/mirror_e2e')
+        .set(auth(reader));
+      const byVer = Object.fromEntries(
+        versions.body.versions.map((v: any) => [v.version, v]),
+      );
+      expect(byVer['0.1.0'].yanked).toBe(true);
+      expect(byVer['0.1.0'].yankReason).toContain('upstream says no');
+      expect(byVer['0.2.0'].yanked).toBe(false);
+      expect(versions.body.latestVersion).toBe('0.2.0');
+
+      // Third run: nothing left to do (yank already mirrored).
+      const again = await mirror.sync();
+      expect(again.imported).toBe(0);
+      expect(again.yanksMirrored).toBe(0);
+    });
   });
 });

--- a/test/registry-mirror.unit-spec.ts
+++ b/test/registry-mirror.unit-spec.ts
@@ -1,0 +1,358 @@
+/**
+ * Pull-only registry mirror — the pure sync core against a stubbed fetch.
+ *
+ * Covers the merge rules end-to-end without a network or DB: new versions
+ * imported with origin + locally recomputed checksum, local rows always win,
+ * one-way yank mirroring fenced to origin-matching rows, checksum-mismatch
+ * rejection, the per-run version budget, and per-pack failure isolation.
+ */
+import {
+  normalizeUpstreamBase,
+  syncRegistryMirror,
+  type MirrorLocalRegistry,
+  type MirrorLocalVersion,
+  type MirrorLogger,
+} from '../src/registry/registry-mirror-sync';
+import { packChecksum, type DomainPackManifest } from '../src/ai/domain-packs';
+
+const BASE = 'https://upstream.example.com';
+
+function manifest(id: string, version: string): DomainPackManifest {
+  return {
+    id,
+    version,
+    description: `${id} pack`,
+    predicates: [],
+  } as unknown as DomainPackManifest;
+}
+
+interface UpstreamVersionFixture {
+  version: string;
+  yanked?: boolean;
+  yankReason?: string | null;
+  /** Override the declared checksum (defaults to the true one). */
+  checksum?: string;
+  /** Override the manifest body served for this version. */
+  manifest?: DomainPackManifest;
+}
+
+/** Build a fetch stub serving a fake upstream registry API. */
+function fakeUpstream(packs: Record<string, UpstreamVersionFixture[]>) {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+  const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({
+      url,
+      headers: (init?.headers ?? {}) as Record<string, string>,
+    });
+    const path = url.replace(BASE, '');
+    const json = (body: unknown) =>
+      ({ ok: true, status: 200, json: async () => body }) as Response;
+
+    if (path.startsWith('/v1/registry/packs?')) {
+      const offset = Number(/offset=(\d+)/.exec(path)?.[1] ?? '0');
+      const ids = Object.keys(packs).slice(offset, offset + 200);
+      return json({ packs: ids.map((packId) => ({ packId })) });
+    }
+    const m = /^\/v1\/registry\/packs\/([^/?]+)(?:\/([^/?]+))?$/.exec(path);
+    const packId = m ? decodeURIComponent(m[1]) : '';
+    const version = m?.[2] ? decodeURIComponent(m[2]) : undefined;
+    const rows = packs[packId];
+    if (!rows) return { ok: false, status: 404 } as Response;
+    if (!version) {
+      return json({
+        packId,
+        latestVersion: rows[0]?.version ?? null,
+        versions: rows.map((r) => ({
+          packId,
+          version: r.version,
+          checksum: r.checksum ?? packChecksum(r.manifest ?? manifest(packId, r.version)),
+          yanked: Boolean(r.yanked),
+          yankReason: r.yankReason ?? null,
+        })),
+      });
+    }
+    const row = rows.find((r) => r.version === version);
+    if (!row) return { ok: false, status: 404 } as Response;
+    const body = row.manifest ?? manifest(packId, row.version);
+    return json({
+      packId,
+      version: row.version,
+      checksum: row.checksum ?? packChecksum(body),
+      yanked: Boolean(row.yanked),
+      manifest: body,
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+/** In-memory local registry port recording publishes and yanks. */
+function fakeLocal(existing: Record<string, MirrorLocalVersion[]> = {}) {
+  const published: Array<{
+    manifest: DomainPackManifest;
+    origin: string;
+    expectedChecksum: string;
+  }> = [];
+  const yanks: Array<{ packId: string; version: string; reason?: string }> =
+    [];
+  const port: MirrorLocalRegistry = {
+    versionsOf: async (packId) => existing[packId] ?? [],
+    publish: async (input) => {
+      published.push(input);
+      return { created: true };
+    },
+    yank: async (input) => {
+      yanks.push(input);
+    },
+  };
+  return { port, published, yanks };
+}
+
+function fakeLogger() {
+  const lines: string[] = [];
+  const logger: MirrorLogger = {
+    log: (m) => lines.push(`LOG ${m}`),
+    warn: (m) => lines.push(`WARN ${m}`),
+    debug: (m) => lines.push(`DEBUG ${m}`),
+  };
+  return { logger, lines };
+}
+
+function runSync(args: {
+  upstream: ReturnType<typeof fakeUpstream>;
+  local: ReturnType<typeof fakeLocal>;
+  logger: ReturnType<typeof fakeLogger>;
+  maxVersionsPerRun?: number;
+  token?: string;
+  upstreamBase?: string;
+}) {
+  return syncRegistryMirror({
+    upstreamBase: args.upstreamBase ?? BASE,
+    token: args.token,
+    local: args.local.port,
+    logger: args.logger.logger,
+    fetchImpl: args.upstream.fetchImpl,
+    maxVersionsPerRun: args.maxVersionsPerRun,
+  });
+}
+
+describe('registry mirror — sync core', () => {
+  it('imports a new upstream version with origin set and a locally recomputed checksum', async () => {
+    const upstream = fakeUpstream({ alpha: [{ version: '1.0.0' }] });
+    const local = fakeLocal();
+    const logger = fakeLogger();
+    const summary = await runSync({ upstream, local, logger });
+
+    expect(summary.imported).toBe(1);
+    expect(summary.checksumMismatches).toBe(0);
+    expect(local.published).toHaveLength(1);
+    expect(local.published[0].origin).toBe(BASE);
+    expect(local.published[0].manifest.id).toBe('alpha');
+    expect(local.published[0].expectedChecksum).toBe(
+      packChecksum(manifest('alpha', '1.0.0')),
+    );
+  });
+
+  it('skips a version that already exists locally (local rows always win)', async () => {
+    const upstream = fakeUpstream({ alpha: [{ version: '1.0.0' }] });
+    const local = fakeLocal({
+      alpha: [{ version: '1.0.0', yanked: false, origin: null }],
+    });
+    const logger = fakeLogger();
+    const summary = await runSync({ upstream, local, logger });
+
+    expect(summary.imported).toBe(0);
+    expect(summary.skippedExisting).toBe(1);
+    expect(local.published).toHaveLength(0);
+    expect(
+      logger.lines.some((l) => l.startsWith('DEBUG') && l.includes('skip')),
+    ).toBe(true);
+  });
+
+  it('mirrors an upstream yank ONLY onto rows whose origin matches this upstream', async () => {
+    const upstream = fakeUpstream({
+      mirrored_pack: [
+        { version: '1.0.0', yanked: true, yankReason: 'CVE-2026-1' },
+      ],
+      local_pack: [{ version: '1.0.0', yanked: true }],
+      other_origin: [{ version: '1.0.0', yanked: true }],
+    });
+    const local = fakeLocal({
+      mirrored_pack: [{ version: '1.0.0', yanked: false, origin: BASE }],
+      local_pack: [{ version: '1.0.0', yanked: false, origin: null }],
+      other_origin: [
+        { version: '1.0.0', yanked: false, origin: 'https://elsewhere.example' },
+      ],
+    });
+    const logger = fakeLogger();
+    const summary = await runSync({ upstream, local, logger });
+
+    expect(summary.yanksMirrored).toBe(1);
+    expect(local.yanks).toHaveLength(1);
+    expect(local.yanks[0]).toMatchObject({
+      packId: 'mirrored_pack',
+      version: '1.0.0',
+    });
+    expect(local.yanks[0].reason).toContain('CVE-2026-1');
+    // Neither the local publish nor the foreign-origin row was touched.
+    expect(local.yanks.some((y) => y.packId === 'local_pack')).toBe(false);
+    expect(local.yanks.some((y) => y.packId === 'other_origin')).toBe(false);
+  });
+
+  it('does not re-yank an already-yanked local row', async () => {
+    const upstream = fakeUpstream({
+      alpha: [{ version: '1.0.0', yanked: true }],
+    });
+    const local = fakeLocal({
+      alpha: [{ version: '1.0.0', yanked: true, origin: BASE }],
+    });
+    const logger = fakeLogger();
+    const summary = await runSync({ upstream, local, logger });
+    expect(summary.yanksMirrored).toBe(0);
+    expect(local.yanks).toHaveLength(0);
+  });
+
+  it('does not import a version that is born-yanked upstream', async () => {
+    const upstream = fakeUpstream({
+      alpha: [{ version: '1.0.0', yanked: true }],
+    });
+    const local = fakeLocal();
+    const logger = fakeLogger();
+    const summary = await runSync({ upstream, local, logger });
+    expect(summary.imported).toBe(0);
+    expect(local.published).toHaveLength(0);
+  });
+
+  it('rejects and logs a checksum mismatch (content differs from declaration)', async () => {
+    const upstream = fakeUpstream({
+      alpha: [{ version: '1.0.0', checksum: 'deadbeef'.repeat(8) }],
+    });
+    const local = fakeLocal();
+    const logger = fakeLogger();
+    const summary = await runSync({ upstream, local, logger });
+
+    expect(summary.checksumMismatches).toBe(1);
+    expect(summary.imported).toBe(0);
+    expect(local.published).toHaveLength(0);
+    expect(
+      logger.lines.some(
+        (l) => l.startsWith('WARN') && l.includes('checksum mismatch'),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects a manifest that identifies as a different (id, version)', async () => {
+    const smuggled = manifest('beta', '9.9.9');
+    const upstream = fakeUpstream({
+      alpha: [
+        {
+          version: '1.0.0',
+          manifest: smuggled,
+          checksum: packChecksum(smuggled),
+        },
+      ],
+    });
+    const local = fakeLocal();
+    const logger = fakeLogger();
+    const summary = await runSync({ upstream, local, logger });
+    expect(summary.imported).toBe(0);
+    expect(summary.failures).toBe(1);
+    expect(local.published).toHaveLength(0);
+  });
+
+  it('respects the per-run version budget and flags the run as capped', async () => {
+    const upstream = fakeUpstream({
+      alpha: [{ version: '1.0.0' }, { version: '1.1.0' }, { version: '1.2.0' }],
+    });
+    const local = fakeLocal();
+    const logger = fakeLogger();
+    const summary = await runSync({
+      upstream,
+      local,
+      logger,
+      maxVersionsPerRun: 2,
+    });
+
+    expect(summary.imported).toBe(2);
+    expect(summary.capped).toBe(true);
+    expect(local.published).toHaveLength(2);
+    expect(
+      logger.lines.some((l) => l.includes('budget') && l.includes('2')),
+    ).toBe(true);
+  });
+
+  it('one failing pack does not abort the rest of the run', async () => {
+    const upstream = fakeUpstream({ beta: [{ version: '2.0.0' }] });
+    // 'broken' is listed in the catalogue but 500s on its versions endpoint.
+    const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/v1/registry/packs?')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ packs: [{ packId: 'broken' }, { packId: 'beta' }] }),
+        } as Response;
+      }
+      if (url.includes('/broken')) return { ok: false, status: 500 } as Response;
+      return upstream.fetchImpl(input as string, init);
+    }) as unknown as typeof fetch;
+
+    const local = fakeLocal();
+    const logger = fakeLogger();
+    const summary = await syncRegistryMirror({
+      upstreamBase: BASE,
+      local: local.port,
+      logger: logger.logger,
+      fetchImpl,
+    });
+
+    expect(summary.failures).toBe(1);
+    expect(summary.imported).toBe(1);
+    expect(local.published[0].manifest.id).toBe('beta');
+  });
+
+  it('sends the bearer token when configured and omits it otherwise', async () => {
+    const withToken = fakeUpstream({ alpha: [{ version: '1.0.0' }] });
+    await runSync({
+      upstream: withToken,
+      local: fakeLocal(),
+      logger: fakeLogger(),
+      token: 'sekret',
+    });
+    expect(
+      withToken.calls.every(
+        (c) => c.headers.authorization === 'Bearer sekret',
+      ),
+    ).toBe(true);
+
+    const noToken = fakeUpstream({ alpha: [{ version: '1.0.0' }] });
+    await runSync({
+      upstream: noToken,
+      local: fakeLocal(),
+      logger: fakeLogger(),
+    });
+    expect(
+      noToken.calls.every((c) => c.headers.authorization === undefined),
+    ).toBe(true);
+  });
+
+  it('normalizes the upstream base so a trailing slash cannot split the yank fence', async () => {
+    expect(normalizeUpstreamBase(`${BASE}/`)).toBe(BASE);
+    expect(normalizeUpstreamBase(` ${BASE}// `)).toBe(BASE);
+
+    // A base configured WITH a slash still matches rows stored without one.
+    const upstream = fakeUpstream({
+      alpha: [{ version: '1.0.0', yanked: true }],
+    });
+    const local = fakeLocal({
+      alpha: [{ version: '1.0.0', yanked: false, origin: BASE }],
+    });
+    const summary = await runSync({
+      upstream,
+      local,
+      logger: fakeLogger(),
+      upstreamBase: `${BASE}/`,
+    });
+    expect(summary.yanksMirrored).toBe(1);
+  });
+});

--- a/test/registry-ui.unit-spec.ts
+++ b/test/registry-ui.unit-spec.ts
@@ -65,6 +65,24 @@ describe('renderRegistryPage', () => {
     expect(html).toContain('&quot;&gt;&lt;script&gt;');
   });
 
+  it('shows a "mirrored from <host>" note for mirrored packs only', () => {
+    const mirrored = renderRegistryPage([
+      pack({ origin: 'https://upstream.example.com:8443/' }),
+    ]);
+    expect(mirrored).toContain('mirrored from upstream.example.com:8443');
+    // Locally published packs carry no note.
+    const localOnly = renderRegistryPage([pack()]);
+    expect(localOnly).not.toContain('mirrored from');
+  });
+
+  it('HTML-escapes an unparseable origin instead of injecting it', () => {
+    const html = renderRegistryPage([
+      pack({ origin: '<img src=x onerror=alert(1)>' }),
+    ]);
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;img src=x');
+  });
+
   it('shows an empty state when there are no packs', () => {
     const html = renderRegistryPage([]);
     expect(html).toContain('No packs published yet');


### PR DESCRIPTION
Platform wave PL9 — stacked on #186 (merge that first; this PR's base retargets to main when #186 merges and its branch is deleted).

A Brain deployment can now mirror another instance's pack registry, pull-only:

- Migration 0064: `origin` on `registry_pack` (NONE = locally published).
- `REGISTRY_UPSTREAM_URL` (+ optional `REGISTRY_UPSTREAM_TOKEN`, `REGISTRY_MIRROR_INTERVAL_HOURS` default 24) — unset registers nothing, zero behavior change.
- Sync core is pure and fetch-injectable: paging, 10s per-request timeout, 200-version budget with a cap log, checksum + manifest-identity verification, per-pack failure isolation. Mirrored inserts go through the REAL publish path (validation, builtin-squat protection, immutability, `verified` recomputed against the LOCAL trust store); yanks mirror one-way and only onto rows whose `origin` matches this upstream — local publishes always win and are never yanked remotely.
- Scheduled via the existing jobs framework (new `registry_mirror` jobType, hourly cron whose dedupKey is the interval bucket, cross-tenant precedent of the source-trust refit); registry UI shows a "mirrored from <host>" note.

Verification: 10 sync-core unit tests; pack-registry e2e 19/19 against a real SurrealDB container **including a live fake-upstream HTTP stub** (origin import, local-rows-win, builtin rejection, bearer forwarding, one-way yank fencing, idempotent re-sync); registry-ui + domain-pack-install e2e green (no PL5 regression); tsc/lint/full unit suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd