### PR TITLE
fix(security): CodeQL findings + dependency alerts + workflow hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ on:
         required: false
         default: 'false'
 
+# Least-privilege default token: CI only reads the repo (build/test/lint).
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
 
+# Workflow-level least privilege; the analyze job below elevates to the
+# security-events: write it needs to upload results.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (javascript-typescript)

--- a/.github/workflows/deploy-brain-landing.yml
+++ b/.github/workflows/deploy-brain-landing.yml
@@ -31,6 +31,11 @@ env:
   DOMAIN: brain.inite.ai
   PORT: 3030
 
+# Least-privilege default token: checkout only. Registry auth uses Docker Hub
+# secrets, not GITHUB_TOKEN; deploy runs on a self-hosted runner via compose.
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     if: github.event_name == 'push' || (github.event.inputs.action != 'restart' && github.event.inputs.action != 'logs')

--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -33,6 +33,11 @@ env:
   DOMAIN: brain.inite.ai
   PORT: 3000
 
+# Least-privilege default token: checkout only. Registry auth uses Docker Hub
+# secrets, not GITHUB_TOKEN; deploy runs on a self-hosted runner via compose.
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     # Skip build for restart/logs ops. Push events have no inputs,

--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -25,6 +25,11 @@ concurrency:
 env:
   STACK_DIR: /opt/projects/inite-monitoring
 
+# Least-privilege default token: checkout only; deploy runs on a self-hosted
+# runner via rsync + compose.
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: [self-hosted, sfo]

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,13 +4,19 @@ on:
   push:
     branches: [main]
 
+# Least-privilege default token; only the release-please job below is
+# elevated to the write scopes it needs to open the release PR and cut the
+# release commit/tag. The `image` job calls a reusable workflow that does its
+# own Docker Hub auth and needs no more than the inherited contents: read.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}

--- a/brain-landing/Dockerfile
+++ b/brain-landing/Dockerfile
@@ -7,7 +7,7 @@
 # CI before the build-push step.
 # ────────────────────────────────────────────────────────────────
 
-FROM node:22-alpine AS builder
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS builder
 WORKDIR /app
 
 # pnpm via corepack — same channel the rest of the repo uses.
@@ -35,7 +35,7 @@ ENV NEXT_PUBLIC_BRAIN_API_URL=$NEXT_PUBLIC_BRAIN_API_URL
 RUN pnpm build
 
 # ── Runtime image ────────────────────────────────────────────────
-FROM node:22-alpine AS runtime
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS runtime
 WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@10 --activate

--- a/brain-landing/package.json
+++ b/brain-landing/package.json
@@ -53,5 +53,13 @@
     "tailwindcss": "^4.3.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
+  },
+  "pnpm": {
+    "overrides": {
+      "postcss@8": "^8.5.10",
+      "js-yaml@3": "^3.15.0",
+      "js-yaml@4": "^4.2.0",
+      "@babel/core": "^7.29.6"
+    }
   }
 }

--- a/brain-landing/pnpm-lock.yaml
+++ b/brain-landing/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss@8: ^8.5.10
+  js-yaml@3: ^3.15.0
+  js-yaml@4: ^4.2.0
+  '@babel/core': ^7.29.6
+
 importers:
 
   .:
@@ -52,7 +58,7 @@ importers:
         version: 1.24.0(react@19.2.7)
       next:
         specifier: ^16.2.10
-        version: 16.2.10(@babel/core@7.29.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.2.17)(react@19.2.7)
@@ -109,7 +115,7 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       postcss:
-        specifier: ^8.5.19
+        specifier: ^8.5.10
         version: 8.5.19
       tailwindcss:
         specifier: ^4.3.2
@@ -131,50 +137,62 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.3':
-    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.28.6':
-    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.29.6
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.3':
@@ -182,16 +200,25 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@dagrejs/dagre@3.0.0':
@@ -1428,7 +1455,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: ^8.5.10
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -1472,11 +1499,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   browserslist@4.28.5:
     resolution: {integrity: sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==}
@@ -1718,9 +1740,6 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
-
-  electron-to-chromium@1.5.361:
-    resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
 
   electron-to-chromium@1.5.389:
     resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
@@ -2301,12 +2320,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2684,10 +2703,6 @@ packages:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
 
-  node-releases@2.0.46:
-    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
-    engines: {node: '>=18'}
-
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
@@ -2786,10 +2801,6 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.19:
     resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
@@ -3448,19 +3459,25 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.3': {}
-
-  '@babel/core@7.29.0':
+  '@babel/code-frame@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.3
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -3470,69 +3487,77 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.29.1':
+  '@babel/generator@7.29.7':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.28.6':
+  '@babel/helper-compilation-targets@7.29.7':
     dependencies:
-      '@babel/compat-data': 7.29.3
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.2
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.5
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-globals@7.28.0': {}
+  '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.28.6':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/helper-validator-option@7.27.1': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helpers@7.29.2':
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/template@7.28.6':
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.0':
+  '@babel/template@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.3
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -3541,6 +3566,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@dagrejs/dagre@3.0.0':
     dependencies:
@@ -3595,7 +3625,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -4802,14 +4832,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.32
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.361
-      node-releases: 2.0.46
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
   browserslist@4.28.5:
     dependencies:
       baseline-browser-mapping: 2.10.42
@@ -5039,8 +5061,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-
-  electron-to-chromium@1.5.361: {}
 
   electron-to-chromium@1.5.389: {}
 
@@ -5280,7 +5300,7 @@ snapshots:
 
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.3
       eslint: 9.39.4(jiti@2.7.0)
       hermes-parser: 0.25.1
@@ -5556,7 +5576,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -5803,12 +5823,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -6401,16 +6421,16 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  next@16.2.10(@babel/core@7.29.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.32
       caniuse-lite: 1.0.30001793
-      postcss: 8.4.31
+      postcss: 8.5.19
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.10
       '@next/swc-darwin-x64': 16.2.10
@@ -6431,8 +6451,6 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
-
-  node-releases@2.0.46: {}
 
   node-releases@2.0.50: {}
 
@@ -6536,12 +6554,6 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.19:
     dependencies:
@@ -7001,12 +7013,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.7):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
     optionalDependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
   supports-color@7.2.0:
     dependencies:
@@ -7180,12 +7192,6 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.12.2
       '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
-
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
-    dependencies:
-      browserslist: 4.28.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.5):
     dependencies:

--- a/package.json
+++ b/package.json
@@ -134,6 +134,9 @@
       "tmp": "^0.2.6",
       "js-yaml": "^4.2.0",
       "@babel/core": "^7.29.6",
+      "undici": "^7.28.0",
+      "minimatch@10": "^10.2.3",
+      "uuid": "^11.1.1",
       "onnx-proto>protobufjs": "^7.6.3",
       "@grpc/proto-loader>protobufjs": "^8.6.0",
       "@opentelemetry/otlp-transformer>protobufjs": "^8.6.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ overrides:
   tmp: ^0.2.6
   js-yaml: ^4.2.0
   '@babel/core': ^7.29.6
+  undici: ^7.28.0
+  minimatch@10: ^10.2.3
+  uuid: ^11.1.1
   onnx-proto>protobufjs: ^7.6.3
   '@grpc/proto-loader>protobufjs': ^8.6.0
   '@opentelemetry/otlp-transformer>protobufjs': ^8.6.0
@@ -794,14 +797,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.1':
-    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
-    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3589,10 +3584,6 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  minimatch@10.1.2:
-    resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
-    engines: {node: 20 || >=22}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -4541,8 +4532,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   universalify@2.0.1:
@@ -4565,9 +4556,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uuidv7@1.2.1:
@@ -5319,12 +5309,6 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@22.19.17)':
     optionalDependencies:
       '@types/node': 22.19.17
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.1':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -7453,7 +7437,7 @@ snapshots:
       docker-modem: 5.0.7
       protobufjs: 7.5.6
       tar-fs: 2.1.4
-      uuid: 10.0.0
+      uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7677,7 +7661,7 @@ snapshots:
       functional-red-black-tree: 1.0.1
       jsx-ast-utils-x: 0.1.0
       lodash.merge: 4.6.2
-      minimatch: 10.1.2
+      minimatch: 10.2.5
       scslre: 0.3.0
       semver: 7.7.4
       typescript: 5.9.3
@@ -8863,10 +8847,6 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  minimatch@10.1.2:
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.1
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -9806,7 +9786,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
       tmp: 0.2.7
-      undici: 7.25.0
+      undici: 7.28.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -10007,7 +9987,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   universalify@2.0.1: {}
 
@@ -10025,7 +10005,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@10.0.0: {}
+  uuid@11.1.1: {}
 
   uuidv7@1.2.1: {}
 

--- a/scripts/bump-skill-versions.ts
+++ b/scripts/bump-skill-versions.ts
@@ -12,7 +12,7 @@
  * skills/VERSION, then `pnpm skills:build`.
  */
 
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 
 interface Args {
@@ -37,15 +37,18 @@ function parseArgs(argv: string[]): Args {
   return out;
 }
 
-function git(cmd: string): string {
-  return execSync(`git ${cmd}`, { encoding: 'utf8' }).trim();
+// argv array (not a shell string): `args.since` is a CLI value, so passing
+// it as a discrete argument to execFileSync keeps it out of a shell and
+// closes the command-injection vector.
+function git(argv: string[]): string {
+  return execFileSync('git', argv, { encoding: 'utf8' }).trim();
 }
 
 function changedFiles(args: Args): string[] {
-  const cmd = args.staged
-    ? 'diff --cached --name-only --diff-filter=ACMR'
-    : `diff --name-only --diff-filter=ACMR ${args.since}`;
-  return git(cmd).split('\n').filter(Boolean);
+  const argv = args.staged
+    ? ['diff', '--cached', '--name-only', '--diff-filter=ACMR']
+    : ['diff', '--name-only', '--diff-filter=ACMR', args.since!];
+  return git(argv).split('\n').filter(Boolean);
 }
 
 const SKIP_TOPLEVEL = new Set(['skills/VERSION', 'skills/CHANGELOG.md']);
@@ -111,7 +114,7 @@ function defaultNote(args: Args): string {
   if (args.note) return args.note;
   if (args.since && args.since !== 'HEAD' && args.since !== '--cached') {
     try {
-      return git('log -1 --pretty=%s');
+      return git(['log', '-1', '--pretty=%s']);
     } catch {
       /* ignore */
     }

--- a/scripts/init-pack.ts
+++ b/scripts/init-pack.ts
@@ -18,7 +18,7 @@
  * `makePackSkeleton` is exported pure so the unit suite
  * (test/pack-init.unit-spec.ts) can assert the skeleton stays valid.
  */
-import { existsSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import {
   BUILTIN_PACKS,
   FIRST_PARTY_PACKS,
@@ -134,10 +134,16 @@ function main(): void {
   }
   const skeleton = makePackSkeleton(id);
   const out = `${id}.pack.json`;
-  if (existsSync(out)) {
-    throw new Error(`refusing to overwrite existing ${out}`);
+  // Exclusive create ('wx') fails atomically if the file already exists —
+  // no check-then-write TOCTOU window.
+  try {
+    writeFileSync(out, `${JSON.stringify(skeleton, null, 2)}\n`, { flag: 'wx' });
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'EEXIST') {
+      throw new Error(`refusing to overwrite existing ${out}`);
+    }
+    throw e;
   }
-  writeFileSync(out, `${JSON.stringify(skeleton, null, 2)}\n`);
   console.log(`✓ wrote ${out} — a valid starter manifest for pack "${id}"`);
   console.log('next steps (docs/domain-packs.md § Quickstart):');
   console.log(`  1. edit ${out} — predicates, extractionProfile, evalFixtures`);

--- a/src/admin/admin-ops.controller.ts
+++ b/src/admin/admin-ops.controller.ts
@@ -134,12 +134,15 @@ export class AdminOpsController {
         'This manifest enumerates entities erased from the brain service. The original payloads have been deleted; only the hashed identifier, deletion reason, and counts of removed facts/edges remain. Issued in accordance with GDPR Art. 17 ("right to erasure") proof-of-deletion obligations.',
       entries: rows,
     };
-    res.setHeader('Content-Type', 'application/json');
     res.setHeader(
       'Content-Disposition',
       `attachment; filename="forgotten-${new Date().toISOString().slice(0, 10)}.json"`,
     );
-    res.send(JSON.stringify(manifest, null, 2));
+    // res.json() (not res.send): it fixes Content-Type to application/json and
+    // JSON-encodes, so the user-supplied filter values (companyId/since)
+    // echoed in the manifest can't be content-sniffed to text/html and
+    // reflected as markup.
+    res.json(manifest);
   }
 
   // ── PII inventory ──────────────────────────────────────────

--- a/src/admin/baseline.service.ts
+++ b/src/admin/baseline.service.ts
@@ -1,6 +1,11 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { promises as fs } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import type { ScenarioRunOutcome } from './scenario-runner.service';
 
 export interface BaselineEntry {
@@ -64,16 +69,33 @@ export class BaselineService {
     return out.sort((a, b) => (b.savedAt ?? '').localeCompare(a.savedAt ?? ''));
   }
 
+  /**
+   * Resolve a baseline name to an absolute path *inside* {@link dir}.
+   * `name` is caller-supplied (admin HTTP query), so besides the char
+   * sanitiser we assert the resolved path can't escape the baselines dir —
+   * a recognised path-traversal barrier and defence-in-depth if the
+   * sanitiser ever regresses.
+   */
+  private pathFor(name: string): string {
+    const safe = sanitize(name);
+    const full = resolve(this.dir, `${safe}.json`);
+    if (full !== join(this.dir, `${safe}.json`) || !full.startsWith(this.dir + sep)) {
+      throw new BadRequestException(`Invalid baseline name`);
+    }
+    return full;
+  }
+
   async save(name: string, outcomes: ScenarioRunOutcome[]): Promise<BaselineEntry> {
     await this.ensureDir();
     const safe = sanitize(name);
+    const target = this.pathFor(name);
     const payload: SavedBaseline = {
       name: safe,
       savedAt: new Date().toISOString(),
       outcomes,
     };
     await fs.writeFile(
-      join(this.dir, `${safe}.json`),
+      target,
       JSON.stringify(payload, null, 2),
       'utf-8',
     );
@@ -90,13 +112,12 @@ export class BaselineService {
 
   async load(name: string): Promise<SavedBaseline> {
     await this.ensureDir();
-    const safe = sanitize(name);
-    const path = join(this.dir, `${safe}.json`);
+    const path = this.pathFor(name);
     try {
       const raw = await fs.readFile(path, 'utf-8');
       return JSON.parse(raw) as SavedBaseline;
     } catch {
-      throw new NotFoundException(`Baseline ${safe} not found`);
+      throw new NotFoundException(`Baseline ${sanitize(name)} not found`);
     }
   }
 

--- a/src/admin/operator-action.interceptor.ts
+++ b/src/admin/operator-action.interceptor.ts
@@ -82,12 +82,21 @@ export class OperatorActionInterceptor implements NestInterceptor {
   }
 }
 
+// Prototype-pollution guard: request keys are attacker-controlled, so they
+// must never be allowed to address __proto__/constructor/prototype on the
+// plain summary object literals below.
+const PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+function isUnsafeKey(k: string): boolean {
+  return PROTO_KEYS.has(k);
+}
+
 function summariseQuery(
   q: Record<string, unknown> | undefined,
 ): Record<string, string> | null {
   if (!q || Object.keys(q).length === 0) return null;
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(q)) {
+    if (isUnsafeKey(k)) continue;
     out[k] = truncate(String(v));
   }
   return out;
@@ -99,6 +108,7 @@ function summariseBody(
   if (!body || typeof body !== 'object') return null;
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(body as Record<string, unknown>)) {
+    if (isUnsafeKey(k)) continue;
     if (v === null || v === undefined) {
       out[k] = v;
     } else if (typeof v === 'string') {

--- a/src/ai/predicate-registry-internals/seed-predicates.ts
+++ b/src/ai/predicate-registry-internals/seed-predicates.ts
@@ -41,10 +41,10 @@ export async function seedMissingPredicates(opts: {
   } catch {
     embeddings = missing.map(() => null);
   }
-  for (let i = 0; i < missing.length; i++) {
+  for (const [i, item] of missing.entries()) {
     await db.query(`CREATE knowledge_predicate CONTENT $content`, {
       content: {
-        ...serializeForInsert(missing[i]),
+        ...serializeForInsert(item),
         ...(embeddings[i] ? { embedding: embeddings[i] } : {}),
       },
     });

--- a/src/artifacts/artifacts.service.ts
+++ b/src/artifacts/artifacts.service.ts
@@ -204,12 +204,15 @@ export class ArtifactsService {
    * of returning an empty bundle.
    */
   private compile(type: ArtifactType, facts: FactRow[]): CompiledArtifact {
-    const template = TEMPLATES[type];
-    if (!template) {
+    // `type` is request-derived: guard with hasOwn so a value like
+    // 'constructor'/'toString' can't resolve to an inherited Object member
+    // and get invoked as a template.
+    if (!Object.prototype.hasOwnProperty.call(TEMPLATES, type)) {
       throw new BadRequestException(
         `Unknown artifactType '${type}'. Known: ${Object.keys(TEMPLATES).join(', ')}`,
       );
     }
+    const template = TEMPLATES[type];
     const out = template(facts);
     // De-duplicate sourceFactIds — multiple template fields commonly cite
     // the same fact (e.g. customer_profile.name + identity_dossier.name).

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,8 +68,22 @@ async function bootstrap() {
   app.useBodyParser('json', { limit: maxBody });
   app.useBodyParser('urlencoded', { limit: maxBody, extended: true });
 
+  // The only HTML this service serves is the server-rendered pack registry
+  // catalogue (src/registry/registry-ui.ts) — one inline <style> block, no
+  // inline scripts; everything else is JSON. Enforce a CSP that allows that
+  // one page's inline styles, pins scripts/objects to same-origin/none, and
+  // forbids framing. (Leaving CSP off entirely is what CodeQL flagged.)
   app.use(helmet({
-    contentSecurityPolicy: false,
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives: {
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        objectSrc: ["'none'"],
+        baseUri: ["'none'"],
+        frameAncestors: ["'none'"],
+      },
+    },
     hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
   }));
 

--- a/test/app-fixture.ts
+++ b/test/app-fixture.ts
@@ -42,7 +42,7 @@ export async function createApp(opts: {
     packIds?: string[];
   }>;
 } = {}): Promise<AppFixture> {
-  const companyId = opts.companyId ?? `co_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const companyId = opts.companyId ?? `co_test_${Date.now()}_${randomUUID().slice(0, 6)}`;
   const apiKey = `key_${randomUUID()}`;
   const keyHash = 'sha256:' + createHash('sha256').update(apiKey).digest('hex');
   const extraApiKeys = (opts.extraKeys ?? []).map(() => `key_${randomUUID()}`);

--- a/test/spawn/key-factory.ts
+++ b/test/spawn/key-factory.ts
@@ -19,5 +19,5 @@ export function newBrainKey(companyId: string, scopes: string[]): BrainKeySpec {
 }
 
 export function newCompanyId(): string {
-  return `co_real_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+  return `co_real_${Date.now()}_${randomUUID().slice(0, 4)}`;
 }


### PR DESCRIPTION
Sweeps the open GitHub security surface: **18 CodeQL findings fixed in code**, **12 Dependabot alerts** cleared via lockfile bumps, and **Scorecard** posture hardening. No behaviour change beyond the noted CSP enablement.

## CodeQL — production code
| Alert | File | Fix |
|---|---|---|
| remote-property-injection ×7 (#13–19) | `operator-action.interceptor.ts` | skip `__proto__`/`constructor`/`prototype` keys when summarising request query/body |
| path-injection ×2 (#8,#9) + http-to-file (#10) | `baseline.service.ts` | `pathFor()` asserts the resolved file stays inside the baselines dir |
| reflected-xss (#3) | `admin-ops.controller.ts` | emit GDPR export via `res.json()` (no content-sniff to text/html) |
| unvalidated-dynamic-method-call (#2) | `artifacts.service.ts` | `hasOwnProperty` guard on the template dispatch |
| insecure-helmet-configuration (#1) | `main.ts` | enable a locked CSP (was `false`); allows the registry page's inline styles only |
| loop-bound-injection (#75) | `seed-predicates.ts` | iterate with `.entries()` instead of a user-controlled `.length` bound |

## CodeQL — tests / scripts
| Alert | File | Fix |
|---|---|---|
| insecure-randomness (#4,#5) | `app-fixture.ts`, `key-factory.ts` | `randomUUID()` instead of `Math.random()` |
| file-system-race (#85) | `init-pack.ts` | exclusive `'wx'` write removes the check-then-write TOCTOU |
| indirect-command-injection (#12) | `bump-skill-versions.ts` | `execFileSync` argv array (no shell) closes the `--since` vector |

## Dependabot alerts (transitive → pnpm overrides + lockfile regen)
- **root:** undici `^7.28.0` (2×high + 3×med + low), minimatch@10 `^10.2.3` (high ReDoS), uuid `^11.1.1`
- **brain-landing:** postcss@8 `^8.5.10`, js-yaml@3 `^3.15.0` / js-yaml@4 `^4.2.0`, @babel/core `^7.29.6`

## Scorecard hardening
- least-privilege top-level `permissions: contents: read` on ci / codeql / deploy-brain / deploy-brain-landing / deploy-monitoring
- release-please: write scopes moved from workflow-level to the release-please job only
- pin `node:22-alpine` by digest in `brain-landing/Dockerfile` (matches the main Dockerfile)

## Verification
- `tsc -p tsconfig.spec.json` clean
- eslint clean on changed files
- 50 unit tests pass (admin-baselines, admin-operator-actions, registry-ui, domain-pack)

## Not code-fixable (recommend dismissing after review)
6 CodeQL alerts are false-positive / by-design and left open for a human call:
- `#7`, `#83` insufficient-password-hash — tests sha256-hash a **random** API key (mirrors prod key auth; not a password)
- `#11` file→http — eval test client
- `#77`, `#78`, `#79` file→http — `pack:install`/`pack:publish`/`seed-registry` CLIs whose function *is* read-file-then-upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)