### PR TITLE
feat(sources): read-only trust-inputs API under brain:read

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -63,6 +63,8 @@ Protocol: [indexer-protocol.md](indexer-protocol.md).
 | `GET /v1/entities/:id/timeline` | Bitemporal sweep — all facts ever known, with validFrom / validUntil / recordedAt / retractedAt. |
 | `GET /v1/entities/:id/connections` | Typed edges + direct neighbours. |
 | `GET /v1/artifacts/:type/:entityId` | Derived artifacts (profile / digest / etc) with manual `recompile` POST. |
+| `GET /v1/sources` | Read-only trust inputs: declared `type`/`authLevel` ⋈ learned reputation, one row per source. Filters `domain` / `type` / `minSamples`, paginated (`limit` ≤ 200 / `offset`). Public projection — operator annotations (`owner`/`note`) stay on the admin surface. |
+| `GET /v1/sources/:sourceKey` | One source's declared identity, per-domain trust rows, and reputation history (newest first, ≤ 50). Same data as the `get_source_reputation` MCP tool. |
 
 ## Mutation (audited)
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1035,6 +1035,153 @@
         ],
         "type": "object"
       },
+      "PublicDeclaredSource": {
+        "additionalProperties": false,
+        "properties": {
+          "authLevel": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "human",
+              "website",
+              "document",
+              "api",
+              "agent",
+              "sensor",
+              "system"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "authLevel"
+        ],
+        "type": "object"
+      },
+      "PublicSourceDetailResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "declared": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicDeclaredSource"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "history": {
+            "items": {
+              "$ref": "#/components/schemas/SourceHistoryRow"
+            },
+            "type": "array"
+          },
+          "sourceKey": {
+            "type": "string"
+          },
+          "trust": {
+            "items": {
+              "$ref": "#/components/schemas/TrustScopeRow"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "sourceKey",
+          "declared",
+          "trust",
+          "history"
+        ],
+        "type": "object"
+      },
+      "PublicSourceSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "declared": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicDeclaredSource"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "domainTrust": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TrustScopeRow"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "globalTrust": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TrustScopeRow"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "scopedDomains": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "sourceKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sourceKey",
+          "declared",
+          "globalTrust",
+          "scopedDomains"
+        ],
+        "type": "object"
+      },
+      "PublicSourcesListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "limit": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "offset": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "sources": {
+            "items": {
+              "$ref": "#/components/schemas/PublicSourceSummary"
+            },
+            "type": "array"
+          },
+          "total": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "sources",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "type": "object"
+      },
       "PublishPackRequest": {
         "additionalProperties": false,
         "properties": {
@@ -1303,6 +1450,39 @@
         ],
         "type": "object"
       },
+      "SourceHistoryRow": {
+        "additionalProperties": false,
+        "properties": {
+          "agreementRate": {
+            "type": "number"
+          },
+          "domain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "recordedAt": {
+            "type": "string"
+          },
+          "sampleCount": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "domain",
+          "agreementRate",
+          "sampleCount",
+          "recordedAt"
+        ],
+        "type": "object"
+      },
       "SubmitCandidatesRequest": {
         "additionalProperties": false,
         "properties": {
@@ -1513,6 +1693,58 @@
         ],
         "type": "object"
       },
+      "TrustScopeRow": {
+        "additionalProperties": false,
+        "properties": {
+          "agreementRate": {
+            "type": "number"
+          },
+          "domain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastSeenAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lossCount": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "sampleCount": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "winCount": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "domain",
+          "agreementRate",
+          "sampleCount",
+          "winCount",
+          "lossCount",
+          "lastSeenAt"
+        ],
+        "type": "object"
+      },
       "UninstallPackResponse": {
         "additionalProperties": false,
         "properties": {
@@ -1630,9 +1862,9 @@
       "identifier": "AGPL-3.0-or-later",
       "name": "AGPL-3.0-or-later"
     },
-    "summary": "The community-facing platform surface: Domain Pack registry, tenant pack admin, document ingest, and the external-indexer work protocol.",
+    "summary": "The community-facing platform surface: Domain Pack registry, tenant pack admin, document ingest, the external-indexer work protocol, and source reputation reads.",
     "title": "INITE Brain — Platform API",
-    "version": "0.6.2"
+    "version": "0.7.0"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -2651,6 +2883,135 @@
           "Registry"
         ]
       }
+    },
+    "/v1/sources": {
+      "get": {
+        "description": "Catalogue of everything brain knows ABOUT its fact sources: the operator-declared identity (type, authLevel) joined with the learned agreement rates, one row per sourceKey. Public projection — operator annotations (owner/note) are served only on the brain:admin surface. `domain` additionally captures that domain's learned rate into `domainTrust` and makes `minSamples` judge it (falling back to the global row). Source: src/sources/public-sources.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "listSources",
+        "parameters": [
+          {
+            "description": "Capture this domain’s learned rate per source (`domainTrust`).",
+            "in": "query",
+            "name": "domain",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only sources declared with this type.",
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "human",
+                "website",
+                "document",
+                "api",
+                "agent",
+                "sensor",
+                "system"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only sources whose learned rate rests on at least this many samples (domain-scoped row when `domain` is given, global row otherwise).",
+            "in": "query",
+            "name": "minSamples",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page size (default 50, max 200).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page offset.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSourcesListResponse"
+                }
+              }
+            },
+            "description": "The reputation catalogue page."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "List source reputations (trust inputs)",
+        "tags": [
+          "Sources"
+        ]
+      }
+    },
+    "/v1/sources/{sourceKey}": {
+      "get": {
+        "description": "Declared type/authLevel, every learned scope (global first, then domains alphabetically), and the reputation-over-time trail (newest first, capped at 50 rows). Public projection — owner/note are excluded. Same data the `get_source_reputation` MCP tool serves.\n\nRequired scope: `brain:read`.",
+        "operationId": "getSourceReputation",
+        "parameters": [
+          {
+            "description": "Source key, `vertical:recorder` (e.g. `rent:tenant_bot`).",
+            "in": "path",
+            "name": "sourceKey",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSourceDetailResponse"
+                }
+              }
+            },
+            "description": "The source reputation detail."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "One source’s declared identity, trust scopes, and history",
+        "tags": [
+          "Sources"
+        ]
+      }
     }
   },
   "security": [
@@ -2684,6 +3045,10 @@
     {
       "description": "The external-indexer protocol (scope `indexer:write`): poll → claim → read content → submit candidates / fail. See docs/indexer-protocol.md.",
       "name": "Indexer work"
+    },
+    {
+      "description": "Read-only trust inputs (scope `brain:read`): declared source identity ⋈ learned reputation. Public projection — operator annotations (owner/note) stay on the admin surface.",
+      "name": "Sources"
     }
   ]
 }

--- a/docs/source-reputation.md
+++ b/docs/source-reputation.md
@@ -70,7 +70,22 @@ Manage it over REST (all `brain:admin`):
 | `GET` | `/v1/admin/sources/:sourceKey` | detail: per-domain trust rows + history + recent facts |
 | `PUT` | `/v1/admin/sources/:sourceKey` | declare `type` / `authLevel` / `owner` |
 
+Read-only trust inputs are also served to any `brain:read` key:
+
+| Method | Route | Purpose |
+|---|---|---|
+| `GET` | `/v1/sources` | catalogue: declared ⋈ learned; filters `domain` / `type` / `minSamples`; paginated (`limit` ≤ 200 / `offset`) |
+| `GET` | `/v1/sources/:sourceKey` | detail: declared identity + trust scopes + history (newest first, ≤ 50) |
+
+The public projection excludes the operator annotations (`owner`, `note`) and
+the registry row timestamps — those stay on the `brain:admin` surface. With
+`?domain=` the list additionally carries that domain's learned rate per source
+(`domainTrust`), and `minSamples` judges the domain-scoped row (global
+fallback).
+
 Agents can read reputation through the MCP tool **`get_source_reputation`**.
+(The MCP tool currently returns the full admin shape including `owner`/`note`;
+aligning it with the public projection is a tracked follow-up.)
 
 ## Corroboration
 

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -2,9 +2,9 @@
 /**
  * build-openapi — assemble the OpenAPI 3.1 document for the PLATFORM
  * surface (the community-facing API: pack registry, pack admin, document
- * ingest/read, external-indexer candidates + work discovery). The
- * admin/ops surface (jobs, leases, policy, stats, maintenance) is out of
- * scope on purpose.
+ * ingest/read, external-indexer candidates + work discovery, source
+ * reputation reads). The admin/ops surface (jobs, leases, policy, stats,
+ * maintenance) is out of scope on purpose.
  *
  * components.schemas are GENERATED from the zod wire contracts under
  * src/contracts/ (zod v4 z.toJSONSchema over a registry, so nested
@@ -47,6 +47,15 @@ import {
   PacksListResponseSchema,
   UninstallPackResponseSchema,
 } from '../src/contracts/admin/packs.schema';
+import {
+  PublicDeclaredSourceSchema,
+  PublicSourceDetailResponseSchema,
+  PublicSourceSummarySchema,
+  PublicSourcesListResponseSchema,
+  SOURCE_TYPES,
+  SourceHistoryRowSchema,
+  TrustScopeRowSchema,
+} from '../src/contracts/sources/sources.schema';
 import {
   ClaimWorkResponseSchema,
   FailWorkResponseSchema,
@@ -122,6 +131,13 @@ const ZOD_COMPONENTS: Record<string, z.ZodType> = {
   SubmittedEntity: SubmittedEntitySchema,
   SubmittedFact: SubmittedFactSchema,
   SubmittedRelation: SubmittedRelationSchema,
+  // --- source reputation reads (src/contracts/sources/sources.schema.ts)
+  PublicDeclaredSource: PublicDeclaredSourceSchema,
+  PublicSourceDetailResponse: PublicSourceDetailResponseSchema,
+  PublicSourceSummary: PublicSourceSummarySchema,
+  PublicSourcesListResponse: PublicSourcesListResponseSchema,
+  SourceHistoryRow: SourceHistoryRowSchema,
+  TrustScopeRow: TrustScopeRowSchema,
   // --- external-indexer work discovery (src/contracts/indexer/…)
   ClaimWorkResponse: ClaimWorkResponseSchema,
   FailWorkRequest: FailWorkRequestSchema,
@@ -592,6 +608,85 @@ function documentsPaths(): Json {
   };
 }
 
+function sourcesPaths(): Json {
+  return {
+    '/v1/sources': {
+      get: operation({
+        operationId: 'listSources',
+        tag: 'Sources',
+        summary: 'List source reputations (trust inputs)',
+        description:
+          'Catalogue of everything brain knows ABOUT its fact sources: the ' +
+          'operator-declared identity (type, authLevel) joined with the ' +
+          'learned agreement rates, one row per sourceKey. Public ' +
+          'projection — operator annotations (owner/note) are served only ' +
+          'on the brain:admin surface. `domain` additionally captures that ' +
+          "domain's learned rate into `domainTrust` and makes `minSamples` " +
+          'judge it (falling back to the global row). ' +
+          'Source: src/sources/public-sources.controller.ts.',
+        scope: 'brain:read',
+        parameters: [
+          queryParam(
+            'domain',
+            'Capture this domain’s learned rate per source (`domainTrust`).',
+          ),
+          queryParam('type', 'Only sources declared with this type.', {
+            type: 'string',
+            enum: [...SOURCE_TYPES],
+          }),
+          queryParam(
+            'minSamples',
+            'Only sources whose learned rate rests on at least this many ' +
+              'samples (domain-scoped row when `domain` is given, global ' +
+              'row otherwise).',
+            { type: 'integer' },
+          ),
+          queryParam('limit', 'Page size (default 50, max 200).', {
+            type: 'integer',
+          }),
+          queryParam('offset', 'Page offset.', { type: 'integer' }),
+        ],
+        responses: {
+          '200': jsonResponse(
+            'The reputation catalogue page.',
+            ref('PublicSourcesListResponse'),
+          ),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+        },
+      }),
+    },
+    '/v1/sources/{sourceKey}': {
+      get: operation({
+        operationId: 'getSourceReputation',
+        tag: 'Sources',
+        summary: 'One source’s declared identity, trust scopes, and history',
+        description:
+          'Declared type/authLevel, every learned scope (global first, ' +
+          'then domains alphabetically), and the reputation-over-time ' +
+          'trail (newest first, capped at 50 rows). Public projection — ' +
+          'owner/note are excluded. Same data the `get_source_reputation` ' +
+          'MCP tool serves.',
+        scope: 'brain:read',
+        parameters: [
+          pathParam(
+            'sourceKey',
+            'Source key, `vertical:recorder` (e.g. `rent:tenant_bot`).',
+          ),
+        ],
+        responses: {
+          '200': jsonResponse(
+            'The source reputation detail.',
+            ref('PublicSourceDetailResponse'),
+          ),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+  };
+}
+
 function indexerWorkPaths(): Json {
   return {
     '/v1/indexer/work': {
@@ -741,8 +836,8 @@ export function buildOpenApiDocument(): Json {
       version: pkg.version,
       summary:
         'The community-facing platform surface: Domain Pack registry, ' +
-        'tenant pack admin, document ingest, and the external-indexer ' +
-        'work protocol.',
+        'tenant pack admin, document ingest, the external-indexer ' +
+        'work protocol, and source reputation reads.',
       description:
         'Generated from the zod wire contracts (`pnpm openapi:build` — ' +
         'scripts/build-openapi.ts); do not edit by hand. The admin/ops ' +
@@ -795,12 +890,20 @@ export function buildOpenApiDocument(): Json {
           'claim → read content → submit candidates / fail. ' +
           'See docs/indexer-protocol.md.',
       },
+      {
+        name: 'Sources',
+        description:
+          'Read-only trust inputs (scope `brain:read`): declared source ' +
+          'identity ⋈ learned reputation. Public projection — operator ' +
+          'annotations (owner/note) stay on the admin surface.',
+      },
     ],
     paths: {
       ...registryPaths(),
       ...packsAdminPaths(),
       ...documentsPaths(),
       ...indexerWorkPaths(),
+      ...sourcesPaths(),
     },
     components: {
       securitySchemes: {

--- a/src/contracts/sources/sources.schema.ts
+++ b/src/contracts/sources/sources.schema.ts
@@ -50,6 +50,9 @@ export const SourceSummarySchema = z.object({
   globalTrust: TrustScopeRowSchema.nullable(),
   /** Number of domain-scoped reputation rows behind this source. */
   scopedDomains: z.number().int(),
+  /** The requested domain's learned rate — set only when list() was asked
+   *  to capture one domain (public /v1/sources?domain=). */
+  domainTrust: TrustScopeRowSchema.nullable().optional(),
 });
 export type SourceSummary = z.infer<typeof SourceSummarySchema>;
 
@@ -88,3 +91,47 @@ export const DeclareSourceResponseSchema = z.object({
   declared: DeclaredSourceSchema,
 });
 export type DeclareSourceResponse = z.infer<typeof DeclareSourceResponseSchema>;
+
+/**
+ * Public projection (/v1/sources, brain:read): the trust INPUTS a consumer
+ * needs to weigh a fact's trustSnapshot — declared type/authLevel and the
+ * learned rates. Operator annotations (owner/note) and the registry row
+ * timestamps stay on the brain:admin surface.
+ */
+export const PublicDeclaredSourceSchema = z.object({
+  type: z.enum(SOURCE_TYPES),
+  authLevel: z.number().min(0).max(1),
+});
+export type PublicDeclaredSource = z.infer<typeof PublicDeclaredSourceSchema>;
+
+export const PublicSourceSummarySchema = z.object({
+  sourceKey: z.string(),
+  declared: PublicDeclaredSourceSchema.nullable(),
+  globalTrust: TrustScopeRowSchema.nullable(),
+  scopedDomains: z.number().int(),
+  /** The requested domain's learned rate — present iff ?domain= given. */
+  domainTrust: TrustScopeRowSchema.nullable().optional(),
+});
+export type PublicSourceSummary = z.infer<typeof PublicSourceSummarySchema>;
+
+export const PublicSourcesListResponseSchema = z.object({
+  sources: z.array(PublicSourceSummarySchema),
+  total: z.number().int(),
+  limit: z.number().int(),
+  offset: z.number().int(),
+});
+export type PublicSourcesListResponse = z.infer<
+  typeof PublicSourcesListResponseSchema
+>;
+
+export const PublicSourceDetailResponseSchema = z.object({
+  sourceKey: z.string(),
+  declared: PublicDeclaredSourceSchema.nullable(),
+  /** All learned scopes, global first then domains alphabetically. */
+  trust: z.array(TrustScopeRowSchema),
+  /** Reputation-over-time trail, newest first, capped at 50 rows. */
+  history: z.array(SourceHistoryRowSchema),
+});
+export type PublicSourceDetailResponse = z.infer<
+  typeof PublicSourceDetailResponseSchema
+>;

--- a/src/policy/action-registry.ts
+++ b/src/policy/action-registry.ts
@@ -82,6 +82,7 @@ export const ACTIONS: Record<string, ActionSpec> = {
   'rest.artifacts.recompile': { kind: 'write', family: 'rest', title: 'Recompile artifact' },
   'rest.stats.overview': { kind: 'read', family: 'rest', title: 'Stats overview' },
   'rest.dreams.run': { kind: 'write', family: 'rest', title: 'Run dreams pass' },
+  'rest.sources.list': { kind: 'read', family: 'rest', title: 'List source reputations' },
 };
 
 /**

--- a/src/sources/public-projection.ts
+++ b/src/sources/public-projection.ts
@@ -1,0 +1,95 @@
+import type {
+  DeclaredSource,
+  PublicDeclaredSource,
+  PublicSourceDetailResponse,
+  PublicSourceSummary,
+  SourceDetailResponse,
+  SourceSummary,
+  SourceType,
+} from '../contracts/sources/sources.schema';
+
+/**
+ * Pure projection from the admin source shapes to the public /v1/sources
+ * wire (trust-inputs track). The public surface exposes what a consumer
+ * needs to weigh a fact's trustSnapshot — declared type/authLevel and the
+ * learned rates — and drops the operator annotations (owner/note) plus
+ * the registry row timestamps, which stay brain:admin-only.
+ */
+
+/** Detail history cap — the admin surface serves up to 100 rows. */
+export const PUBLIC_HISTORY_LIMIT = 50;
+export const PUBLIC_LIST_MAX_LIMIT = 200;
+
+export function toPublicDeclared(
+  declared: DeclaredSource | null,
+): PublicDeclaredSource | null {
+  if (!declared) return null;
+  return { type: declared.type, authLevel: declared.authLevel };
+}
+
+/** domainRequested mirrors the ?domain= query: the domainTrust slot is
+ *  present (possibly null) iff the caller asked for a domain. */
+export function toPublicSummary(
+  summary: SourceSummary,
+  domainRequested: boolean,
+): PublicSourceSummary {
+  return {
+    sourceKey: summary.sourceKey,
+    declared: toPublicDeclared(summary.declared),
+    globalTrust: summary.globalTrust,
+    scopedDomains: summary.scopedDomains,
+    ...(domainRequested ? { domainTrust: summary.domainTrust ?? null } : {}),
+  };
+}
+
+/** History arrives newest-first from the service — the slice keeps the
+ *  50 most recent rows. */
+export function toPublicDetail(
+  detail: SourceDetailResponse,
+): PublicSourceDetailResponse {
+  return {
+    sourceKey: detail.sourceKey,
+    declared: toPublicDeclared(detail.declared),
+    trust: detail.trust,
+    history: detail.history.slice(0, PUBLIC_HISTORY_LIMIT),
+  };
+}
+
+export interface PublicListFilter {
+  type?: SourceType;
+  minSamples?: number;
+  domain?: string;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Filter → sort (by sourceKey) → page → project. `total` counts the
+ * filtered set before paging so callers can walk pages. With an active
+ * domain filter, minSamples judges the domain-scoped row when the source
+ * has one and falls back to the global row otherwise.
+ */
+export function filterAndPage(
+  summaries: SourceSummary[],
+  filter: PublicListFilter,
+): { items: PublicSourceSummary[]; total: number } {
+  const domainRequested = filter.domain !== undefined;
+  const filtered = summaries.filter((s) => {
+    if (filter.type !== undefined && s.declared?.type !== filter.type) {
+      return false;
+    }
+    if (filter.minSamples !== undefined) {
+      const basis = domainRequested
+        ? (s.domainTrust ?? s.globalTrust)
+        : s.globalTrust;
+      if ((basis?.sampleCount ?? 0) < filter.minSamples) return false;
+    }
+    return true;
+  });
+  filtered.sort((a, b) => a.sourceKey.localeCompare(b.sourceKey));
+  const limit = Math.min(filter.limit, PUBLIC_LIST_MAX_LIMIT);
+  const items = filtered
+    .slice(filter.offset, filter.offset + limit)
+    .map((s) => toPublicSummary(s, domainRequested));
+  return { items, total: filtered.length };
+}

--- a/src/sources/public-sources.controller.ts
+++ b/src/sources/public-sources.controller.ts
@@ -1,0 +1,129 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { SourcesService } from './sources.service';
+import {
+  SOURCE_TYPES,
+  type PublicSourceDetailResponse,
+  type PublicSourcesListResponse,
+  type SourceType,
+} from '../contracts/sources/sources.schema';
+import {
+  filterAndPage,
+  PUBLIC_LIST_MAX_LIMIT,
+  toPublicDetail,
+  type PublicListFilter,
+} from './public-projection';
+
+/**
+ * Read-only trust-inputs surface for ordinary brain:read callers
+ * (trust-inputs track). Same data the brain:admin /v1/admin/sources
+ * routes serve, through the public projection: declared type/authLevel
+ * ⋈ learned reputation, WITHOUT the operator annotations (owner/note)
+ * and with the history trail capped at PUBLIC_HISTORY_LIMIT. Detail
+ * reuses the `get_source_reputation` ABAC action (house rule: REST
+ * reuses the equivalent MCP tool name); list is REST-only.
+ */
+@Controller('v1/sources')
+@UseGuards(ApiKeyGuard)
+export class PublicSourcesController {
+  constructor(private readonly sources: SourcesService) {}
+
+  @Get()
+  @RequireScopes('brain:read')
+  @PolicyAction('rest.sources.list')
+  async list(
+    @Req() req: AuthenticatedRequest,
+    @Query()
+    query: {
+      domain?: string;
+      type?: string;
+      minSamples?: string;
+      limit?: string;
+      offset?: string;
+    },
+  ): Promise<PublicSourcesListResponse> {
+    const filter = parseListQuery(query);
+    const summaries = await this.sources.list(req.brainAuth.companyId, {
+      domain: filter.domain,
+    });
+    const { items, total } = filterAndPage(summaries, filter);
+    return {
+      sources: items,
+      total,
+      limit: filter.limit,
+      offset: filter.offset,
+    } satisfies PublicSourcesListResponse;
+  }
+
+  @Get(':sourceKey')
+  @RequireScopes('brain:read')
+  @PolicyAction('get_source_reputation')
+  async detail(
+    @Req() req: AuthenticatedRequest,
+    @Param('sourceKey') sourceKey: string,
+  ): Promise<PublicSourceDetailResponse> {
+    const detail = await this.sources.detail(
+      req.brainAuth.companyId,
+      sourceKey,
+    );
+    // The admin detail never 404s (it answers empty shells); the public
+    // surface should not leak "known vs unknown" ambiguity — a source
+    // with neither a declared row nor learned trust does not exist.
+    if (!detail.declared && detail.trust.length === 0) {
+      throw new NotFoundException(`unknown source '${sourceKey}'`);
+    }
+    return toPublicDetail(detail);
+  }
+}
+
+function parseListQuery(query: {
+  domain?: string;
+  type?: string;
+  minSamples?: string;
+  limit?: string;
+  offset?: string;
+}): PublicListFilter {
+  if (
+    query.type !== undefined &&
+    !SOURCE_TYPES.includes(query.type as SourceType)
+  ) {
+    throw new BadRequestException(
+      `type must be one of ${SOURCE_TYPES.join('|')}`,
+    );
+  }
+  return {
+    ...(query.domain !== undefined ? { domain: query.domain } : {}),
+    ...(query.type !== undefined ? { type: query.type as SourceType } : {}),
+    ...(query.minSamples !== undefined
+      ? { minSamples: parseIntStrict('minSamples', query.minSamples, 0) }
+      : {}),
+    limit: Math.min(
+      query.limit !== undefined ? parseIntStrict('limit', query.limit, 1) : 50,
+      PUBLIC_LIST_MAX_LIMIT,
+    ),
+    offset:
+      query.offset !== undefined
+        ? parseIntStrict('offset', query.offset, 0)
+        : 0,
+  };
+}
+
+/** Strict base-10 parse — garbage is a 400, not a silent default. */
+function parseIntStrict(name: string, raw: string, min: number): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < min) {
+    throw new BadRequestException(`${name} must be an integer >= ${min}`);
+  }
+  return n;
+}

--- a/src/sources/sources.module.ts
+++ b/src/sources/sources.module.ts
@@ -2,17 +2,19 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { SourcesService } from './sources.service';
 import { AdminSourcesController } from './admin-sources.controller';
+import { PublicSourcesController } from './public-sources.controller';
 
 /**
  * Per-tenant source identity + reputation (source-reputation track,
  * Phase 3): the operator-declared source_registry joined with the
  * refit-computed source_trust under one sourceKey. SourcesService is
  * exported for the MCP get_source_reputation tool. SurrealService is
- * @Global; AuthModule supplies the ApiKeyGuard.
+ * @Global; AuthModule supplies the ApiKeyGuard. PublicSourcesController
+ * (trust-inputs track) serves the brain:read projection of the same data.
  */
 @Module({
   imports: [AuthModule],
-  controllers: [AdminSourcesController],
+  controllers: [AdminSourcesController, PublicSourcesController],
   providers: [SourcesService],
   exports: [SourcesService],
 })

--- a/src/sources/sources.service.ts
+++ b/src/sources/sources.service.ts
@@ -25,8 +25,13 @@ import {
 export class SourcesService {
   constructor(private readonly surreal: SurrealService) {}
 
-  /** Catalogue: union of declared and learned sources, one line each. */
-  async list(companyId: string): Promise<SourceSummary[]> {
+  /** Catalogue: union of declared and learned sources, one line each.
+   *  opts.domain additionally captures that domain's learned rate onto
+   *  each summary (public /v1/sources?domain= projection). */
+  async list(
+    companyId: string,
+    opts?: { domain?: string },
+  ): Promise<SourceSummary[]> {
     return this.surreal.withCompany(companyId, async (db) => {
       const [declaredRows] = await db.query<[any[]]>(
         `SELECT * FROM source_registry ORDER BY sourceKey`,
@@ -60,6 +65,7 @@ export class SourcesService {
           summary.globalTrust = mapTrustScope(r);
         } else {
           summary.scopedDomains += 1;
+          if (opts?.domain === r.domain) summary.domainTrust = mapTrustScope(r);
         }
       }
       return [...summaries.values()];

--- a/test/contracts-public-sources.unit-spec.ts
+++ b/test/contracts-public-sources.unit-spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Wire-contract drift guard for the public /v1/sources surface
+ * (trust-inputs track) — zod round-trips plus a regression fence
+ * asserting the public declared shape can never regrow the operator
+ * annotations (owner/note).
+ */
+import {
+  PublicDeclaredSourceSchema,
+  PublicSourceDetailResponseSchema,
+  PublicSourcesListResponseSchema,
+  PublicSourceSummarySchema,
+} from '../src/contracts/sources/sources.schema';
+
+const trustScope = {
+  domain: null,
+  agreementRate: 0.9,
+  sampleCount: 12,
+  winCount: 11,
+  lossCount: 1,
+  lastSeenAt: '2026-07-08T00:00:00.000Z',
+};
+
+const summary = {
+  sourceKey: 'rent:senior_auditor',
+  declared: { type: 'human', authLevel: 0.8 },
+  globalTrust: trustScope,
+  scopedDomains: 2,
+};
+
+describe('public sources — wire contracts', () => {
+  it('PublicDeclaredSource has NO owner/note keys (regression fence)', () => {
+    expect(Object.keys(PublicDeclaredSourceSchema.shape).sort()).toEqual([
+      'authLevel',
+      'type',
+    ]);
+  });
+
+  it('PublicSourceSummary round-trips with and without domainTrust', () => {
+    expect(PublicSourceSummarySchema.safeParse(summary).success).toBe(true);
+    expect(
+      PublicSourceSummarySchema.safeParse({
+        ...summary,
+        domainTrust: { ...trustScope, domain: 'status' },
+      }).success,
+    ).toBe(true);
+    expect(
+      PublicSourceSummarySchema.safeParse({ ...summary, domainTrust: null })
+        .success,
+    ).toBe(true);
+    // Either side of the join may be absent.
+    expect(
+      PublicSourceSummarySchema.safeParse({
+        sourceKey: 'rent:_',
+        declared: null,
+        globalTrust: null,
+        scopedDomains: 0,
+      }).success,
+    ).toBe(true);
+  });
+
+  it('PublicSourcesListResponse round-trips with paging metadata', () => {
+    const parsed = PublicSourcesListResponseSchema.safeParse({
+      sources: [summary],
+      total: 41,
+      limit: 50,
+      offset: 0,
+    });
+    expect(parsed.success).toBe(true);
+    expect(
+      PublicSourcesListResponseSchema.safeParse({ sources: [summary] })
+        .success,
+    ).toBe(false);
+  });
+
+  it('PublicSourceDetailResponse round-trips and rejects a declared row with authLevel out of range', () => {
+    expect(
+      PublicSourceDetailResponseSchema.safeParse({
+        sourceKey: 'rent:senior_auditor',
+        declared: { type: 'human', authLevel: 0.8 },
+        trust: [trustScope, { ...trustScope, domain: 'status' }],
+        history: [
+          {
+            domain: null,
+            agreementRate: 0.85,
+            sampleCount: 10,
+            recordedAt: '2026-07-01T03:42:00.000Z',
+          },
+        ],
+      }).success,
+    ).toBe(true);
+    expect(
+      PublicDeclaredSourceSchema.safeParse({ type: 'human', authLevel: 1.5 })
+        .success,
+    ).toBe(false);
+    expect(
+      PublicDeclaredSourceSchema.safeParse({ type: 'rumor_mill', authLevel: 1 })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -38,6 +38,8 @@ const PLATFORM_OPERATIONS: Array<[string, string]> = [
   ['/v1/indexer/work/{runId}/heartbeat', 'post'],
   ['/v1/indexer/work/{runId}/content', 'get'],
   ['/v1/indexer/work/{runId}/fail', 'post'],
+  ['/v1/sources', 'get'],
+  ['/v1/sources/{sourceKey}', 'get'],
 ];
 
 describe('docs/openapi.json', () => {

--- a/test/public-source-projection.unit-spec.ts
+++ b/test/public-source-projection.unit-spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Pure-projection tests for the public /v1/sources surface (trust-inputs
+ * track): the owner/note redaction, the 50-row history cap, the filter
+ * matrix (type / minSamples / domain capture), and pagination.
+ */
+import {
+  filterAndPage,
+  PUBLIC_HISTORY_LIMIT,
+  PUBLIC_LIST_MAX_LIMIT,
+  toPublicDeclared,
+  toPublicDetail,
+  toPublicSummary,
+} from '../src/sources/public-projection';
+import type {
+  DeclaredSource,
+  SourceSummary,
+  TrustScopeRow,
+} from '../src/contracts/sources/sources.schema';
+
+const declared = (over: Partial<DeclaredSource> = {}): DeclaredSource => ({
+  sourceKey: 'rent:senior_auditor',
+  type: 'human',
+  authLevel: 0.8,
+  owner: 'ops@inite.ai',
+  note: 'internal-only annotation',
+  createdAt: '2026-07-09T00:00:00.000Z',
+  updatedAt: '2026-07-10T00:00:00.000Z',
+  ...over,
+});
+
+const trust = (over: Partial<TrustScopeRow> = {}): TrustScopeRow => ({
+  domain: null,
+  agreementRate: 0.9,
+  sampleCount: 12,
+  winCount: 11,
+  lossCount: 1,
+  lastSeenAt: '2026-07-08T00:00:00.000Z',
+  ...over,
+});
+
+const summary = (over: Partial<SourceSummary> = {}): SourceSummary => ({
+  sourceKey: 'rent:a',
+  declared: null,
+  globalTrust: null,
+  scopedDomains: 0,
+  ...over,
+});
+
+describe('toPublicDeclared', () => {
+  it('keeps ONLY type + authLevel — owner/note/timestamps are dropped', () => {
+    const out = toPublicDeclared(declared());
+    expect(out).toEqual({ type: 'human', authLevel: 0.8 });
+    expect(Object.keys(out as object).sort()).toEqual(['authLevel', 'type']);
+  });
+
+  it('passes null through', () => {
+    expect(toPublicDeclared(null)).toBeNull();
+  });
+});
+
+describe('toPublicSummary', () => {
+  it('projects declared and omits domainTrust when no domain was asked', () => {
+    const out = toPublicSummary(
+      summary({ declared: declared(), globalTrust: trust(), scopedDomains: 2 }),
+      false,
+    );
+    expect(out).toEqual({
+      sourceKey: 'rent:a',
+      declared: { type: 'human', authLevel: 0.8 },
+      globalTrust: trust(),
+      scopedDomains: 2,
+    });
+    expect('domainTrust' in out).toBe(false);
+  });
+
+  it('materializes domainTrust (null when the source lacks the domain row)', () => {
+    const withRow = toPublicSummary(
+      summary({ domainTrust: trust({ domain: 'status' }) }),
+      true,
+    );
+    expect(withRow.domainTrust).toEqual(trust({ domain: 'status' }));
+    const withoutRow = toPublicSummary(summary(), true);
+    expect(withoutRow.domainTrust).toBeNull();
+  });
+});
+
+describe('toPublicDetail', () => {
+  it('drops owner/note and slices history to the 50 newest rows', () => {
+    const history = Array.from({ length: 80 }, (_, i) => ({
+      domain: null,
+      agreementRate: 0.5,
+      sampleCount: 80 - i,
+      // Newest-first, as the service serves it.
+      recordedAt: new Date(Date.UTC(2026, 0, 80 - i)).toISOString(),
+    }));
+    const out = toPublicDetail({
+      sourceKey: 'rent:a',
+      declared: declared(),
+      trust: [trust(), trust({ domain: 'status' })],
+      history,
+    });
+    expect(out.declared).toEqual({ type: 'human', authLevel: 0.8 });
+    expect(out.history).toHaveLength(PUBLIC_HISTORY_LIMIT);
+    // The kept rows are the FIRST 50 — i.e. the newest.
+    expect(out.history[0]).toEqual(history[0]);
+    expect(out.history[49]).toEqual(history[49]);
+    expect(JSON.stringify(out)).not.toContain('ops@inite.ai');
+    expect(JSON.stringify(out)).not.toContain('internal-only annotation');
+  });
+});
+
+describe('filterAndPage', () => {
+  const page = { limit: 50, offset: 0 };
+  const corpus: SourceSummary[] = [
+    summary({
+      sourceKey: 'rent:human_big',
+      declared: declared({ type: 'human' }),
+      globalTrust: trust({ sampleCount: 40 }),
+      scopedDomains: 1,
+      domainTrust: trust({ domain: 'status', sampleCount: 3 }),
+    }),
+    summary({
+      sourceKey: 'rent:api_small',
+      declared: declared({ type: 'api' }),
+      globalTrust: trust({ sampleCount: 5 }),
+    }),
+    summary({ sourceKey: 'rent:undeclared', globalTrust: null }),
+  ];
+
+  it('sorts by sourceKey and reports total', () => {
+    const { items, total } = filterAndPage(corpus, page);
+    expect(total).toBe(3);
+    expect(items.map((s) => s.sourceKey)).toEqual([
+      'rent:api_small',
+      'rent:human_big',
+      'rent:undeclared',
+    ]);
+  });
+
+  it('type filter matches the DECLARED type (undeclared never matches)', () => {
+    const { items, total } = filterAndPage(corpus, { ...page, type: 'human' });
+    expect(total).toBe(1);
+    expect(items[0].sourceKey).toBe('rent:human_big');
+  });
+
+  it('minSamples judges the global row when no domain is active', () => {
+    const { items } = filterAndPage(corpus, { ...page, minSamples: 10 });
+    expect(items.map((s) => s.sourceKey)).toEqual(['rent:human_big']);
+    // Missing globalTrust counts as 0 samples.
+    const all = filterAndPage(corpus, { ...page, minSamples: 0 });
+    expect(all.total).toBe(3);
+  });
+
+  it('minSamples judges domainTrust ?? globalTrust when domain is active', () => {
+    // human_big has 40 global samples but only 3 in `status` — the scoped
+    // row wins the comparison and knocks it out.
+    const scoped = filterAndPage(corpus, {
+      ...page,
+      domain: 'status',
+      minSamples: 10,
+    });
+    expect(scoped.items.map((s) => s.sourceKey)).toEqual([]);
+    // api_small has NO status row — falls back to its 5 global samples.
+    const fallback = filterAndPage(corpus, {
+      ...page,
+      domain: 'status',
+      minSamples: 4,
+    });
+    expect(fallback.items.map((s) => s.sourceKey)).toEqual(['rent:api_small']);
+  });
+
+  it('captures domainTrust on every item iff domain is active', () => {
+    const { items } = filterAndPage(corpus, { ...page, domain: 'status' });
+    const byKey = new Map(items.map((s) => [s.sourceKey, s]));
+    expect(byKey.get('rent:human_big')?.domainTrust).toEqual(
+      trust({ domain: 'status', sampleCount: 3 }),
+    );
+    expect(byKey.get('rent:api_small')?.domainTrust).toBeNull();
+    const plain = filterAndPage(corpus, page);
+    expect(plain.items.every((s) => !('domainTrust' in s))).toBe(true);
+  });
+
+  it('pages: limit above the cap is clamped; offset beyond the end is empty with correct total', () => {
+    const many = Array.from({ length: 250 }, (_, i) =>
+      summary({ sourceKey: `rent:s${String(i).padStart(3, '0')}` }),
+    );
+    const capped = filterAndPage(many, { limit: 10_000, offset: 0 });
+    expect(capped.items).toHaveLength(PUBLIC_LIST_MAX_LIMIT);
+    expect(capped.total).toBe(250);
+
+    const beyond = filterAndPage(many, { limit: 50, offset: 9_999 });
+    expect(beyond.items).toEqual([]);
+    expect(beyond.total).toBe(250);
+
+    const window = filterAndPage(many, { limit: 2, offset: 1 });
+    expect(window.items.map((s) => s.sourceKey)).toEqual([
+      'rent:s001',
+      'rent:s002',
+    ]);
+  });
+});

--- a/test/public-sources.e2e-spec.ts
+++ b/test/public-sources.e2e-spec.ts
@@ -1,0 +1,311 @@
+/**
+ * e2e for the public read-only trust-inputs surface (/v1/sources,
+ * brain:read):
+ *
+ *   1. list serves the declared ⋈ learned catalogue WITHOUT the operator
+ *      annotations (owner/note); filters (type / minSamples / domain
+ *      capture) and pagination work; garbage query params are 400s.
+ *   2. detail serves declared + trust scopes + history capped at 50
+ *      (newest first); an unknown source is a 404.
+ *   3. scope fences: a key without brain:read gets 403 on both routes;
+ *      a plain brain:read key still gets 403 on /v1/admin/sources.
+ *   4. ABAC: a policy denying `get_source_reputation` blocks the REST
+ *      detail route (house rule — REST reuses the MCP action name) while
+ *      the list route stays readable via @readonly.
+ */
+import { Surreal } from 'surrealdb';
+import { SurrealService } from '../src/db/surreal.service';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+
+const SENIOR = 'rent:senior_auditor';
+const API_BOT = 'rent:api_bot';
+const LEARNED_ONLY = 'rent:learned_only';
+const HISTORY_ROWS = 60;
+
+describe('public sources API (trust inputs)', () => {
+  let f: AppFixture;
+  let readKey: string;
+  let writeOnlyKey: string;
+  const admin = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const read = () => ({ Authorization: `Bearer ${readKey}` });
+
+  const seedTrust = async (db: Surreal, over: Record<string, unknown>) => {
+    // `domain` is option<string> — omit the key entirely for global rows.
+    await db.query(
+      `CREATE source_trust CONTENT {
+         sourceKey: $k,
+         ${over.domain !== undefined ? 'domain: $d,' : ''}
+         agreementRate: $rate,
+         sampleCount: $samples,
+         winCount: $wins,
+         lossCount: $losses,
+         lastSeenAt: time::now()
+       }`,
+      {
+        k: over.sourceKey,
+        ...(over.domain !== undefined ? { d: over.domain } : {}),
+        rate: over.rate ?? 0.9,
+        samples: over.samples ?? 0,
+        wins: over.wins ?? 0,
+        losses: over.losses ?? 0,
+      },
+    );
+  };
+
+  beforeAll(async () => {
+    f = await createApp({
+      companyId: 'co_public_sources_e2e',
+      extraKeys: [{ scopes: ['brain:read'] }, { scopes: ['brain:write'] }],
+    });
+    [readKey, writeOnlyKey] = f.extraApiKeys;
+
+    // Declared identities — SENIOR carries the operator annotations the
+    // public projection must never leak.
+    const put = await f.http
+      .put(`/v1/admin/sources/${encodeURIComponent(SENIOR)}`)
+      .set(admin())
+      .send({
+        type: 'human',
+        authLevel: 0.9,
+        owner: 'ops-team',
+        note: 'call before trusting',
+      });
+    expect(put.status).toBe(200);
+    await f.http
+      .put(`/v1/admin/sources/${encodeURIComponent(API_BOT)}`)
+      .set(admin())
+      .send({ type: 'api', authLevel: 0.2 });
+
+    // Learned reputation + history, seeded directly (the refit writes
+    // these tables; the read surface under test only reads them).
+    await f.app.get(SurrealService).withCompany(f.companyId, async (db) => {
+      await seedTrust(db, { sourceKey: SENIOR, samples: 40, wins: 36, losses: 4 });
+      await seedTrust(db, { sourceKey: SENIOR, domain: 'status', samples: 3 });
+      await seedTrust(db, { sourceKey: SENIOR, domain: 'address', samples: 12 });
+      await seedTrust(db, { sourceKey: LEARNED_ONLY, rate: 0.6, samples: 9 });
+      for (let i = 0; i < HISTORY_ROWS; i++) {
+        await db.query(
+          `CREATE source_trust_history CONTENT {
+             sourceKey: $k,
+             agreementRate: 0.5,
+             sampleCount: $i,
+             recordedAt: type::datetime($iso)
+           }`,
+          {
+            k: SENIOR,
+            i,
+            iso: new Date(Date.UTC(2026, 0, 1) + i * 86_400_000).toISOString(),
+          },
+        );
+      }
+    });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('lists the catalogue under brain:read without owner/note', async () => {
+    const res = await f.http.get('/v1/sources').set(read());
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(3);
+    expect(res.body.limit).toBe(50);
+    expect(res.body.offset).toBe(0);
+    // Sorted by sourceKey.
+    expect(res.body.sources.map((s: any) => s.sourceKey)).toEqual([
+      API_BOT,
+      LEARNED_ONLY,
+      SENIOR,
+    ]);
+    const senior = res.body.sources.find((s: any) => s.sourceKey === SENIOR);
+    expect(senior.declared).toEqual({ type: 'human', authLevel: 0.9 });
+    expect(senior.globalTrust.sampleCount).toBe(40);
+    expect(senior.scopedDomains).toBe(2);
+    expect('domainTrust' in senior).toBe(false);
+    const learned = res.body.sources.find(
+      (s: any) => s.sourceKey === LEARNED_ONLY,
+    );
+    expect(learned.declared).toBeNull();
+    const raw = JSON.stringify(res.body);
+    expect(raw).not.toContain('ops-team');
+    expect(raw).not.toContain('call before trusting');
+    expect(raw).not.toContain('"owner"');
+    expect(raw).not.toContain('"note"');
+  });
+
+  it('filters by type, minSamples, and captures domainTrust', async () => {
+    const byType = await f.http.get('/v1/sources?type=api').set(read());
+    expect(byType.body.sources.map((s: any) => s.sourceKey)).toEqual([API_BOT]);
+    expect(byType.body.total).toBe(1);
+
+    // Global basis: senior 40 ≥ 10; learned_only 9 and api_bot 0 drop.
+    const bySamples = await f.http.get('/v1/sources?minSamples=10').set(read());
+    expect(bySamples.body.sources.map((s: any) => s.sourceKey)).toEqual([
+      SENIOR,
+    ]);
+
+    // Domain capture: every row gains a domainTrust slot (null without a
+    // row for that domain).
+    const byDomain = await f.http.get('/v1/sources?domain=address').set(read());
+    const senior = byDomain.body.sources.find(
+      (s: any) => s.sourceKey === SENIOR,
+    );
+    expect(senior.domainTrust.domain).toBe('address');
+    expect(senior.domainTrust.sampleCount).toBe(12);
+    const learned = byDomain.body.sources.find(
+      (s: any) => s.sourceKey === LEARNED_ONLY,
+    );
+    expect(learned.domainTrust).toBeNull();
+
+    // With a domain active, minSamples judges the scoped row when present
+    // (senior's 3 `status` samples lose against its 40 global ones) and
+    // falls back to the global row otherwise.
+    const scoped = await f.http
+      .get('/v1/sources?domain=status&minSamples=10')
+      .set(read());
+    expect(scoped.body.sources).toEqual([]);
+    expect(scoped.body.total).toBe(0);
+    const fallback = await f.http
+      .get('/v1/sources?domain=status&minSamples=5')
+      .set(read());
+    expect(fallback.body.sources.map((s: any) => s.sourceKey)).toEqual([
+      LEARNED_ONLY,
+    ]);
+  });
+
+  it('paginates with a clamped limit and stable totals', async () => {
+    const first = await f.http.get('/v1/sources?limit=1').set(read());
+    expect(first.body.sources.map((s: any) => s.sourceKey)).toEqual([API_BOT]);
+    expect(first.body.total).toBe(3);
+    expect(first.body.limit).toBe(1);
+
+    const second = await f.http
+      .get('/v1/sources?limit=1&offset=1')
+      .set(read());
+    expect(second.body.sources.map((s: any) => s.sourceKey)).toEqual([
+      LEARNED_ONLY,
+    ]);
+
+    const beyond = await f.http.get('/v1/sources?offset=999').set(read());
+    expect(beyond.body.sources).toEqual([]);
+    expect(beyond.body.total).toBe(3);
+
+    const clamped = await f.http.get('/v1/sources?limit=9999').set(read());
+    expect(clamped.body.limit).toBe(200);
+  });
+
+  it('400s on garbage query params', async () => {
+    for (const q of [
+      'limit=abc',
+      'limit=0',
+      'limit=1.5',
+      'offset=-1',
+      'offset=x',
+      'minSamples=-2',
+      'type=rumor_mill',
+    ]) {
+      const res = await f.http.get(`/v1/sources?${q}`).set(read());
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it('serves detail with history capped at 50, newest first', async () => {
+    const res = await f.http
+      .get(`/v1/sources/${encodeURIComponent(SENIOR)}`)
+      .set(read());
+    expect(res.status).toBe(200);
+    expect(res.body.sourceKey).toBe(SENIOR);
+    expect(res.body.declared).toEqual({ type: 'human', authLevel: 0.9 });
+    // Global scope first, then domains alphabetically.
+    expect(res.body.trust.map((t: any) => t.domain)).toEqual([
+      null,
+      'address',
+      'status',
+    ]);
+    expect(res.body.history).toHaveLength(50);
+    expect(res.body.history[0].sampleCount).toBe(HISTORY_ROWS - 1);
+    expect(res.body.history[49].sampleCount).toBe(HISTORY_ROWS - 50);
+    const raw = JSON.stringify(res.body);
+    expect(raw).not.toContain('ops-team');
+    expect(raw).not.toContain('call before trusting');
+  });
+
+  it('404s on an unknown source instead of an empty shell', async () => {
+    const res = await f.http
+      .get(`/v1/sources/${encodeURIComponent('nowhere:nobody')}`)
+      .set(read());
+    expect(res.status).toBe(404);
+  });
+
+  it('403s without brain:read on both routes', async () => {
+    const writeAuth = { Authorization: `Bearer ${writeOnlyKey}` };
+    const list = await f.http.get('/v1/sources').set(writeAuth);
+    expect(list.status).toBe(403);
+    const detail = await f.http
+      .get(`/v1/sources/${encodeURIComponent(SENIOR)}`)
+      .set(writeAuth);
+    expect(detail.status).toBe(403);
+  });
+
+  it('brain:read does NOT unlock the admin surface', async () => {
+    const res = await f.http.get('/v1/admin/sources').set(read());
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('public sources API — ABAC action gate', () => {
+  let f: AppFixture;
+  let restrictedKey: string;
+
+  beforeAll(async () => {
+    process.env.ABAC_ENABLED = '1';
+    f = await createApp({
+      extraKeys: [
+        {
+          scopes: ['brain:read', 'brain:write'],
+          policies: ['no-source-reputation'],
+        },
+      ],
+    });
+    [restrictedKey] = f.extraApiKeys;
+    const created = await f.http
+      .post('/v1/admin/policy-sets')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({
+        name: 'no-source-reputation',
+        description: 'reads allowed, source reputation denied',
+        posture: { actions: 'deny', reads: 'allow' },
+        mode: 'enforce',
+        rules: [
+          { id: 'ro', effect: 'allow', kind: 'action', actions: ['@readonly'] },
+          {
+            id: 'no-src',
+            effect: 'deny',
+            kind: 'action',
+            actions: ['get_source_reputation'],
+          },
+        ],
+      });
+    expect(created.status).toBe(201);
+  });
+
+  afterAll(async () => {
+    delete process.env.ABAC_ENABLED;
+    if (f) await f.close();
+  });
+
+  it('denying get_source_reputation blocks REST detail; list stays readable', async () => {
+    const auth = { Authorization: `Bearer ${restrictedKey}` };
+    const list = await f.http.get('/v1/sources').set(auth);
+    expect(list.status).toBe(200);
+
+    const detail = await f.http.get('/v1/sources/rent:whatever').set(auth);
+    expect(detail.status).toBe(403);
+    expect(detail.body).toMatchObject({
+      error: 'policy_denied',
+      action: 'get_source_reputation',
+      policySet: 'no-source-reputation',
+    });
+  });
+});


### PR DESCRIPTION
## What

Public read-only trust-inputs surface: `GET /v1/sources` and `GET /v1/sources/:sourceKey` under `brain:read`, serving the same declared-identity + learned-reputation data as the `brain:admin` `/v1/admin/sources` routes — through a projection that **excludes operator annotations (`owner`/`note`)** and the registry row timestamps, with the reputation history capped at 50 rows (newest first).

## How

- **Contracts** (`src/contracts/sources/sources.schema.ts`): `PublicDeclaredSourceSchema` (type + authLevel only), `PublicSourceSummarySchema`, `PublicSourcesListResponseSchema` (with `total`/`limit`/`offset` paging metadata), `PublicSourceDetailResponseSchema`. Additive: internal `SourceSummarySchema` gains an optional `domainTrust` slot so the internal type stays single-sourced.
- **Service** (`src/sources/sources.service.ts`): `list(companyId, opts?: {domain?})` — the existing trust-row loop additionally captures the requested domain's learned rate per source. `detail()` unchanged.
- **New pure projection** (`src/sources/public-projection.ts`): `toPublicDeclared` / `toPublicSummary` / `toPublicDetail` (history slice 50) / `filterAndPage` (type, minSamples — judged against `domainTrust ?? globalTrust` when a domain filter is active — sort by sourceKey, clamp at 200/page).
- **New controller** (`src/sources/public-sources.controller.ts`): `GET /` under the new `rest.sources.list` action; `GET /:sourceKey` reuses the registered `get_source_reputation` action per the house rule (REST reuses the equivalent MCP tool action name, action-registry.ts:5-11). Garbage query params are 400s; a source with neither a declared row nor learned trust is a 404.
- **Policy** (`src/policy/action-registry.ts`): one new action `rest.sources.list` (kind read, family rest).
- **OpenAPI**: the new public routes are platform surface — registered in `scripts/build-openapi.ts` (2 paths, 6 schemas, new `Sources` tag), `docs/openapi.json` regenerated. `/v1/admin/sources` stays deliberately undocumented there (admin surface out of scope).
- **Docs**: `docs/api.md` (two rows in the Read section), `docs/source-reputation.md` (public endpoints table + projection note).

## Tests

- `test/public-source-projection.unit-spec.ts` — owner/note/timestamp redaction, 50-row history cap, filter matrix (type / minSamples vs global vs domain row / domain capture), pagination (limit clamp, offset beyond end).
- `test/contracts-public-sources.unit-spec.ts` — zod round-trips + regression fence asserting `PublicDeclaredSourceSchema` has NO owner/note keys.
- `test/public-sources.e2e-spec.ts` (SurrealDB testcontainer) — list/detail without owner/note, filters + pagination, 400s on garbage, 404 on unknown source, 403 without `brain:read` on both routes, `brain:read` still 403 on `/v1/admin/sources`, and an ABAC check: a policy denying `get_source_reputation` blocks the REST detail route while list stays readable via `@readonly`.
- `test/openapi-doc.unit-spec.ts` — the two new operations added to the platform-surface enumeration (drift gate).

Verification: `tsc --noEmit` clean, `lint:ci` zero warnings, `pnpm test` 166 suites / 1214 tests green, targeted e2e (`public-sources` + neighboring `source-registry` / `source-trust-scoped`) green.

## Follow-up (flagged, not changed here)

The MCP tool `get_source_reputation` (src/mcp/source-tools.ts) already exposes the FULL admin detail shape — **including `owner`/`note`** — to every `brain:read` MCP caller. This PR deliberately does not touch the MCP tool (breaking change for existing consumers); aligning it with the public projection should be a separate decision. Noted in docs/source-reputation.md.

## Not in v1 (by design)

No plug point / consumer seam; no owner/note on REST; no MCP tool change (follow-up above); no history on the list route; no new tables/migrations/env vars; no trust webhooks; no cross-tenant aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd