### PR TITLE
feat(packs): seed documents — packs ship knowledge through the document pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -318,6 +318,10 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 # Enqueue a pack-scoped backfill over stored documents at the end of every
 # pack install/upgrade.
 #REINDEX_ON_PACK_INSTALL=0
+# Ingest a pack's seedDocuments through the document pipeline on install
+# (default ON — needs DOCUMENT_INGEST_ENABLED too; a skip never fails the
+# install, the response's seedDocuments.status says what happened).
+#PACK_SEED_INGEST_ENABLED=1
 # Route POST /v1/ingest/mention through the document pipeline (response
 # contract preserved). Off = the legacy mention path, untouched.
 #INGEST_MENTION_VIA_DOCUMENT=0

--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -313,6 +313,64 @@ POST /v1/admin/packs/:packId/eval   (brain:admin)
 `real_estate` ships three fixtures (zoning / valuation / tenure) as the
 demonstrator. Nothing forward-compat remains in the manifest.
 
+## Seed documents (consumed)
+
+A pack may ship `seedDocuments` — pre-populated domain knowledge that is
+**ingested through the normal document pipeline on install** (no bespoke
+fact-writing path: seeds get the same chunking, extraction, candidate staging,
+conflict resolution and provenance as any connector's document):
+
+```jsonc
+"seedDocuments": [
+  {
+    "localId": "zoning_primer",          // snake_case, unique in the pack
+    "title": "Zoning classifications primer",
+    "text": "R-1 districts allow …",     // ≤ 65,536 chars each
+    "vertical": "real_estate",           // contextRef.vertical at ingest
+    "originUri": "https://example.com/zoning",  // optional; default pack://<packId>/<localId>
+    "occurredAt": "2026-01-01T00:00:00Z",       // optional; → derived facts' validFrom
+    "meta": { "audience": "agents" }     // optional; FLAT scalars only
+  }
+]
+```
+
+Caps (validated by `pnpm pack:validate` and again at install): at most **32**
+documents, **65,536** chars per document, **262,144** chars combined. `meta`
+keys are snake_case, values scalar ≤256 chars — the bag must survive
+`sanitizeSourceMeta` verbatim.
+
+Flow: install stores the manifest → the install hook enqueues a
+`pack_seed_ingest` job (flag `PACK_SEED_INGEST_ENABLED`, default ON; also
+requires `DOCUMENT_INGEST_ENABLED` since seeds ride that pipeline) → the job
+feeds each seed to `POST /v1/ingest/document` semantics with
+`kind: 'pack_seed'` and provenance meta stamped on every derived fact's
+`source.meta`:
+
+| key | value |
+|---|---|
+| `pack_seed` | `true` |
+| `pack_id` | the pack id |
+| `pack_version` | the installed version |
+| `pack_seed_doc` | the seed's `localId` |
+
+The install response reports what happened without ever failing the install:
+`seedDocuments: { count, status }` with status one of `enqueued`,
+`enqueue_failed`, `skipped_flag_disabled`, `skipped_ingest_disabled`,
+`skipped_no_queue`.
+
+Idempotency is two-layered: the job's dedupKey is `pack_seed_<id>_<version>`
+(a same-version reinstall doesn't re-run a completed ingest), and the document
+contentHash UNIQUE index dedups at the text level (a re-run — or an upgrade
+whose seed text didn't change — is a per-document no-op). Upgrade semantics
+follow: **changed seed texts become new documents**, unchanged ones dedup
+silently. Like everything in the manifest, `seedDocuments` is covered by the
+pack checksum and signature.
+
+Uninstall leaves seed documents and their facts in place — the same
+facts-survive philosophy as predicate deprecation. The provenance meta keys
+above make them queryable (`source.meta.pack_id`) for manual cleanup or an
+ABAC deny rule.
+
 ## First-party pack library (industries)
 
 Beyond the builtin `code_memory`, brain ships a library of DISTRIBUTABLE

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -427,6 +427,16 @@
           "publisher": {
             "type": "string"
           },
+          "seedDocuments": {
+            "items": {
+              "additionalProperties": {},
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
           "signature": {
             "description": "ed25519 signature (base64) over the canonical manifest sans this field.",
             "type": "string"
@@ -904,6 +914,32 @@
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
+          },
+          "seedDocuments": {
+            "additionalProperties": false,
+            "description": "Present iff the manifest ships seedDocuments — whether their document-pipeline ingest was enqueued. Install never fails because of seeds.",
+            "properties": {
+              "count": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "status": {
+                "enum": [
+                  "enqueued",
+                  "enqueue_failed",
+                  "skipped_flag_disabled",
+                  "skipped_ingest_disabled",
+                  "skipped_no_queue"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "count",
+              "status"
+            ],
+            "type": "object"
           },
           "version": {
             "type": "string"

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -625,6 +625,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
           'Dedicated per-pack indexer runs + relevance router + async fan-out + external work items. Off = only the generalist union pass runs.',
       },
       {
+        key: 'PACK_SEED_INGEST_ENABLED',
+        category: 'pipeline',
+        defaultValue: '1',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Ingest a pack’s seedDocuments through the document pipeline on install (pack_seed_ingest job). Requires DOCUMENT_INGEST_ENABLED; when either is off the install response reports a skip — install never fails because of seeds.',
+      },
+      {
         key: 'INDEXER_EXTERNAL_PENDING_TTL_DAYS',
         category: 'pipeline',
         defaultValue: '7',

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -43,6 +43,15 @@ export interface AvailablePack {
   builtin: boolean;
 }
 
+/** Outcome of the seed-documents install hook. Contract mirror:
+ *  src/contracts/admin/packs.schema.ts (InstallPackResponseSchema). */
+export type SeedIngestEnqueueStatus =
+  | 'enqueued'
+  | 'enqueue_failed'
+  | 'skipped_flag_disabled'
+  | 'skipped_ingest_disabled'
+  | 'skipped_no_queue';
+
 /**
  * Runtime per-tenant Domain Pack install (docs/domain-packs.md). Additive to
  * the builtin packs, which stay globally seeded via SEED_PREDICATES: this lets
@@ -56,8 +65,9 @@ export class DomainPackInstallService {
   private readonly logger = new Logger(DomainPackInstallService.name);
   private readonly builtinIds = new Set(BUILTIN_PACKS.map((p) => p.id));
 
-  // The optional 4th dep is the REINDEX_ON_PACK_INSTALL queue hook — a
-  // fire-and-forget enqueue, not a responsibility worth a wrapper class.
+  // The optional 4th dep serves the REINDEX_ON_PACK_INSTALL and seed-ingest
+  // queue hooks — fire-and-forget enqueues, not a responsibility worth a
+  // wrapper class.
   // eslint-disable-next-line max-params
   constructor(
     private readonly surreal: SurrealService,
@@ -127,6 +137,9 @@ export class DomainPackInstallService {
      * existing secret and omit the field.
      */
     webhookSecret?: string;
+    /** Present iff the manifest ships seedDocuments — whether their
+     *  pipeline ingest was enqueued (install itself never fails on it). */
+    seedDocuments?: { count: number; status: SeedIngestEnqueueStatus };
   }> {
     if (!manifest || typeof manifest !== 'object') {
       throw new BadRequestException('request body must include a pack manifest');
@@ -271,12 +284,14 @@ export class DomainPackInstallService {
       `Installed pack ${manifest.id} v${manifest.version} into ${companyId} (${seeded} predicate(s) seeded)`,
     );
     await this.maybeEnqueueReindex(companyId, manifest);
+    const seedDocuments = await this.maybeEnqueueSeedIngest(companyId, manifest);
     return {
       packId: manifest.id,
       version: manifest.version,
       predicatesSeeded: seeded,
       checksum,
       ...(mintedSecret ? { webhookSecret: mintedSecret } : {}),
+      ...(seedDocuments ? { seedDocuments } : {}),
     };
   }
 
@@ -305,6 +320,47 @@ export class DomainPackInstallService {
       this.logger.warn(
         `reindex enqueue after install of ${manifest.id} failed: ${(e as Error).message}`,
       );
+    }
+  }
+
+  /**
+   * PACK_SEED_INGEST_ENABLED hook (default ON): a manifest shipping
+   * seedDocuments gets a pack_seed_ingest job (PackSeedIngestService owns
+   * the handler) that feeds each seed through the normal document
+   * pipeline. Enqueue-only via the global queue — like the reindex hook —
+   * and best-effort: install NEVER fails because of seeds. The dedupKey is
+   * version-stable, so a same-version reinstall doesn't re-run a completed
+   * seed ingest.
+   */
+  private async maybeEnqueueSeedIngest(
+    companyId: string,
+    manifest: DomainPackManifest,
+  ): Promise<{ count: number; status: SeedIngestEnqueueStatus } | undefined> {
+    const count = manifest.seedDocuments?.length ?? 0;
+    if (count === 0) return undefined;
+    if (!envFlagEnabled(process.env.PACK_SEED_INGEST_ENABLED ?? '1')) {
+      return { count, status: 'skipped_flag_disabled' };
+    }
+    // Seeds ride the document pipeline; with its master switch off the
+    // ingest entry would 503-shape anyway — skip loudly in the response.
+    if (!envFlagEnabled(process.env.DOCUMENT_INGEST_ENABLED)) {
+      return { count, status: 'skipped_ingest_disabled' };
+    }
+    if (!this.claim) return { count, status: 'skipped_no_queue' };
+    try {
+      await this.claim.enqueue({
+        jobType: 'pack_seed_ingest',
+        companyId,
+        triggeredBy: 'manual',
+        dedupKey: `pack_seed_${manifest.id}_${manifest.version}`,
+        payload: { packId: manifest.id, packVersion: manifest.version },
+      });
+      return { count, status: 'enqueued' };
+    } catch (e) {
+      this.logger.warn(
+        `seed ingest enqueue after install of ${manifest.id} failed: ${(e as Error).message}`,
+      );
+      return { count, status: 'enqueue_failed' };
     }
   }
 

--- a/src/ai/domain-packs/manifest.ts
+++ b/src/ai/domain-packs/manifest.ts
@@ -25,6 +25,26 @@ export type { ExtractionProfile, ExtractionExample } from '../predicate-registry
 /** Reserved namespace separator between packId and a predicate's localId. */
 export const PACK_NAMESPACE_SEP = '__';
 
+/** Per-document cap on a seed document's text. */
+export const SEED_DOC_MAX_CHARS = 65_536;
+/** Cap on all of a pack's seed documents' text combined. */
+export const SEED_TOTAL_MAX_CHARS = 262_144;
+/** Cap on how many seed documents a pack may ship. */
+export const SEED_MAX_DOCS = 32;
+
+/** Pre-populated knowledge shipped with a pack — ingested through the
+ *  NORMAL document pipeline on install (kind='pack_seed'). Covered by
+ *  checksum + signature like every other manifest section. */
+export interface PackSeedDocument {
+  localId: string;      // snake_case, unique within the pack
+  title: string;
+  text: string;         // <= SEED_DOC_MAX_CHARS; all docs together <= SEED_TOTAL_MAX_CHARS
+  vertical: string;     // contextRef.vertical at ingest — author-declared, required
+  originUri?: string;
+  occurredAt?: string;  // ISO datetime -> derived facts' validFrom; default: ingest time
+  meta?: Record<string, string | number | boolean>; // flat scalars only
+}
+
 /** A predicate as declared INSIDE a pack — a core PredicateDefinition minus the
  *  fully-qualified id (the loader composes it) and the provenance tag (the
  *  loader stamps it). The pack author supplies a `localId` instead. */
@@ -59,6 +79,13 @@ export interface DomainPackManifest {
    * extractor against these cases for a tenant. Typed as EvalFixture[].
    */
   evalFixtures?: import('./eval-fixture').EvalFixture[];
+  /**
+   * Pre-populated domain knowledge (see PackSeedDocument above). CONSUMED
+   * on install: each document is fed through the normal document pipeline
+   * (PACK_SEED_INGEST_ENABLED, via the pack_seed_ingest job), so seed
+   * facts get the same provenance/dedup/conflict machinery as any ingest.
+   */
+  seedDocuments?: PackSeedDocument[];
   /** ed25519 signature (base64) over the canonical manifest sans this field. */
   signature?: string;
   /** Publisher id — the key in the tenant's trust store used to verify. */

--- a/src/ai/domain-packs/validate.ts
+++ b/src/ai/domain-packs/validate.ts
@@ -2,6 +2,9 @@ import type { PredicateDefinition } from '../predicate-registry-internals/types'
 import {
   composePredicateId,
   PACK_NAMESPACE_SEP,
+  SEED_DOC_MAX_CHARS,
+  SEED_MAX_DOCS,
+  SEED_TOTAL_MAX_CHARS,
   type DomainPackManifest,
 } from './manifest';
 
@@ -98,6 +101,9 @@ export function validatePack(pack: DomainPackManifest): void {
   }
   if (pack.evalFixtures !== undefined) {
     validateEvalFixtures(pack.id, pack.evalFixtures);
+  }
+  if (pack.seedDocuments !== undefined) {
+    validateSeedDocuments(pack.id, pack.seedDocuments);
   }
   if (pack.indexer !== undefined) {
     validateIndexerDescriptor(pack.id, pack.indexer);
@@ -263,6 +269,147 @@ function validateEvalFixtures(packId: string, fixtures: unknown): void {
           );
         }
       }
+    }
+  }
+}
+
+// Local mirror of the source-meta constraints (src/policy/source-meta.ts:
+// META_KEY + SOURCE_META_MAX_VALUE_CHARS). Duplicated on purpose — this pure
+// validator is what `pnpm pack:validate` runs and must stay dependency-free.
+const SEED_META_KEY = /^[a-z][a-z0-9_]{0,63}$/;
+const SEED_META_MAX_VALUE_CHARS = 256;
+
+/**
+ * Validate a pack's seed documents (consumed by the pack_seed_ingest job —
+ * each entry becomes a normal document-pipeline ingest on install, so a
+ * malformed one must be a clean 400 at author/install time). The text caps
+ * bound the install-time LLM fan-out a single manifest can trigger.
+ */
+interface SeedShape {
+  localId?: unknown;
+  title?: unknown;
+  text?: unknown;
+  vertical?: unknown;
+  originUri?: unknown;
+  occurredAt?: unknown;
+  meta?: unknown;
+}
+
+function validateSeedDocuments(packId: string, seeds: unknown): void {
+  if (!Array.isArray(seeds)) {
+    throw new DomainPackError(`pack "${packId}" seedDocuments must be an array`);
+  }
+  if (seeds.length > SEED_MAX_DOCS) {
+    throw new DomainPackError(
+      `pack "${packId}" ships ${seeds.length} seed documents — the cap is ${SEED_MAX_DOCS}`,
+    );
+  }
+  const ids = new Set<string>();
+  let totalChars = 0;
+  for (const s of seeds) {
+    if (typeof s !== 'object' || s === null || Array.isArray(s)) {
+      throw new DomainPackError(
+        `pack "${packId}" seedDocuments entries must be objects`,
+      );
+    }
+    const seed = s as SeedShape;
+    if (
+      typeof seed.localId !== 'string' ||
+      !SNAKE.test(seed.localId) ||
+      seed.localId.includes(PACK_NAMESPACE_SEP)
+    ) {
+      throw new DomainPackError(
+        `pack "${packId}" seed document localId "${String(seed.localId)}" must be snake_case and must not contain "${PACK_NAMESPACE_SEP}"`,
+      );
+    }
+    if (ids.has(seed.localId)) {
+      throw new DomainPackError(
+        `pack "${packId}" declares duplicate seed document localId "${seed.localId}"`,
+      );
+    }
+    ids.add(seed.localId);
+    validateSeedFields(packId, seed.localId, seed);
+    totalChars += (seed.text as string).length;
+    if (totalChars > SEED_TOTAL_MAX_CHARS) {
+      throw new DomainPackError(
+        `pack "${packId}" seed documents exceed ${SEED_TOTAL_MAX_CHARS} chars of text combined`,
+      );
+    }
+  }
+}
+
+/** Per-document field checks (localId already vetted by the caller). */
+function validateSeedFields(
+  packId: string,
+  localId: string,
+  seed: SeedShape,
+): void {
+  if (typeof seed.title !== 'string' || !seed.title || seed.title.length > 512) {
+    throw new DomainPackError(
+      `pack "${packId}" seed document "${localId}" needs a non-empty title of at most 512 chars`,
+    );
+  }
+  if (typeof seed.text !== 'string' || !seed.text) {
+    throw new DomainPackError(
+      `pack "${packId}" seed document "${localId}" needs a non-empty text`,
+    );
+  }
+  if (seed.text.length > SEED_DOC_MAX_CHARS) {
+    throw new DomainPackError(
+      `pack "${packId}" seed document "${localId}" text is ${seed.text.length} chars — the per-document cap is ${SEED_DOC_MAX_CHARS}`,
+    );
+  }
+  if (
+    typeof seed.vertical !== 'string' ||
+    !seed.vertical ||
+    seed.vertical.length > 64
+  ) {
+    throw new DomainPackError(
+      `pack "${packId}" seed document "${localId}" needs a non-empty vertical of at most 64 chars`,
+    );
+  }
+  if (
+    seed.originUri !== undefined &&
+    (typeof seed.originUri !== 'string' || seed.originUri.length > 512)
+  ) {
+    throw new DomainPackError(
+      `pack "${packId}" seed document "${localId}" originUri must be a string of at most 512 chars`,
+    );
+  }
+  if (
+    seed.occurredAt !== undefined &&
+    (typeof seed.occurredAt !== 'string' ||
+      !Number.isFinite(Date.parse(seed.occurredAt)))
+  ) {
+    throw new DomainPackError(
+      `pack "${packId}" seed document "${localId}" occurredAt must be an ISO datetime`,
+    );
+  }
+  if (seed.meta !== undefined) validateSeedMeta(packId, localId, seed.meta);
+}
+
+/** Seed meta must survive sanitizeSourceMeta verbatim (flat scalar bag) —
+ *  a key the sanitizer would drop is an authoring error, not a runtime one. */
+function validateSeedMeta(packId: string, localId: string, meta: unknown): void {
+  if (typeof meta !== 'object' || meta === null || Array.isArray(meta)) {
+    throw new DomainPackError(
+      `pack "${packId}" seed document "${localId}" meta must be an object of scalar values`,
+    );
+  }
+  for (const [key, value] of Object.entries(meta as Record<string, unknown>)) {
+    if (!SEED_META_KEY.test(key)) {
+      throw new DomainPackError(
+        `pack "${packId}" seed document "${localId}" meta key "${key}" is not snake_case (${SEED_META_KEY})`,
+      );
+    }
+    const ok =
+      typeof value === 'boolean' ||
+      (typeof value === 'number' && Number.isFinite(value)) ||
+      (typeof value === 'string' && value.length <= SEED_META_MAX_VALUE_CHARS);
+    if (!ok) {
+      throw new DomainPackError(
+        `pack "${packId}" seed document "${localId}" meta value of "${key}" must be a boolean, finite number, or string of at most ${SEED_META_MAX_VALUE_CHARS} chars`,
+      );
     }
   }
 }

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -398,6 +398,11 @@ const KNOWN_BOOLEAN_FLAGS = [
   'CHAT_ROUTE_NLI_WORKER',
   'THROTTLE_DISABLED',
   'INDEXER_WEBHOOK_PUSH_ENABLED',
+  'REINDEX_ON_PACK_INSTALL',
+  'DOCUMENT_ALLOW_UNGROUNDED_EXTERNAL',
+  // Default-ON: read as `PACK_SEED_INGEST_ENABLED ?? '1'` before
+  // envFlagEnabled, so only an explicit 0/false skips pack seed ingest.
+  'PACK_SEED_INGEST_ENABLED',
 ];
 
 /**

--- a/src/contracts/admin/packs.schema.ts
+++ b/src/contracts/admin/packs.schema.ts
@@ -42,6 +42,21 @@ export const InstallPackResponseSchema = z.object({
   version: z.string(),
   predicatesSeeded: z.number().int().nonnegative(),
   checksum: z.string(),
+  seedDocuments: z
+    .object({
+      count: z.number().int().nonnegative(),
+      status: z.enum([
+        'enqueued',
+        'enqueue_failed',
+        'skipped_flag_disabled',
+        'skipped_ingest_disabled',
+        'skipped_no_queue',
+      ]),
+    })
+    .optional()
+    .describe(
+      'Present iff the manifest ships seedDocuments — whether their document-pipeline ingest was enqueued. Install never fails because of seeds.',
+    ),
 });
 
 export const UninstallPackResponseSchema = z.object({

--- a/src/contracts/registry/registry.schema.ts
+++ b/src/contracts/registry/registry.schema.ts
@@ -80,6 +80,7 @@ export const DomainPackManifestSchema = z.looseObject({
   predicates: z.array(z.record(z.string(), z.unknown())),
   extractionProfile: z.record(z.string(), z.unknown()).optional(),
   evalFixtures: z.array(z.record(z.string(), z.unknown())).optional(),
+  seedDocuments: z.array(z.record(z.string(), z.unknown())).optional(),
   signature: z.string().optional().describe(
     'ed25519 signature (base64) over the canonical manifest sans this field.',
   ),

--- a/src/documents/documents.module.ts
+++ b/src/documents/documents.module.ts
@@ -18,6 +18,7 @@ import { CandidateCommitService } from './candidate-commit.service';
 import { DocumentIngestService } from './document-ingest.service';
 import { DocumentAsyncService } from './document-async.service';
 import { DocumentReindexService } from './document-reindex.service';
+import { PackSeedIngestService } from './pack-seed-ingest.service';
 import { CandidateSweeperService } from './candidate-sweeper.service';
 import { MentionViaDocumentService } from './mention-via-document.service';
 
@@ -46,6 +47,7 @@ import { MentionViaDocumentService } from './mention-via-document.service';
     DocumentIngestService,
     DocumentAsyncService,
     DocumentReindexService,
+    PackSeedIngestService,
     CandidateSweeperService,
     MentionViaDocumentService,
     ExternalCandidatesService,
@@ -57,6 +59,7 @@ import { MentionViaDocumentService } from './mention-via-document.service';
     DocumentStoreService,
     CandidateStoreService,
     MentionViaDocumentService,
+    PackSeedIngestService,
   ],
 })
 export class DocumentsModule {}

--- a/src/documents/pack-seed-ingest.service.ts
+++ b/src/documents/pack-seed-ingest.service.ts
@@ -1,0 +1,197 @@
+import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { JobClaimService } from '../jobs/job-claim.service';
+import { WorkerLoopService, JobContext } from '../jobs/worker-loop.service';
+import type { DomainPackManifest, PackSeedDocument } from '../ai/domain-packs';
+import { DocumentIngestService } from './document-ingest.service';
+import type { IngestDocumentDto } from './dto/ingest-document.dto';
+
+export interface PackSeedIngestResult {
+  total: number;
+  ingested: number;
+  deduplicated: number;
+  failed: number;
+}
+
+/**
+ * Pack seed documents: knowledge a pack SHIPS, fed through the NORMAL
+ * document pipeline on install (kind='pack_seed', PACK_SEED_INGEST_ENABLED).
+ * The install hook enqueues a pack_seed_ingest job; this service owns the
+ * handler. Each seed becomes a regular document ingest, so seed facts get
+ * the same dedup/provenance/conflict machinery as any connector's — and the
+ * contentHash UNIQUE index (0048) makes re-runs idempotent for free: an
+ * unchanged seed dedups into the existing document, a changed one is simply
+ * a new document.
+ */
+@Injectable()
+export class PackSeedIngestService implements OnModuleInit {
+  private readonly logger = new Logger(PackSeedIngestService.name);
+
+  // Seed-ingest job owner in the reindex mold: registration, enqueue, and
+  // the pipeline entry it drives per seed document.
+  // eslint-disable-next-line max-params
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly ingest: DocumentIngestService,
+    @Optional() private readonly workerLoop?: WorkerLoopService,
+    @Optional() private readonly claim?: JobClaimService,
+  ) {}
+
+  onModuleInit(): void {
+    if (!this.workerLoop) return;
+    this.workerLoop.register(
+      'pack_seed_ingest',
+      (ctx) => this.executeFromQueue(ctx),
+      // At most SEED_MAX_DOCS synchronous ingests (LLM extraction per
+      // chunk) — bounded well under the reindex batch. 10-minute lease.
+      { ttlSeconds: 600, maxAttempts: 3 },
+    );
+  }
+
+  /** Enqueue the seed ingest for one installed pack version. The dedupKey
+   *  is version-stable, so reinstalling the same version is a no-op once
+   *  the job has succeeded — upgrades (new version) enqueue fresh. */
+  async enqueueForInstall(
+    companyId: string,
+    p: { packId: string; packVersion: string },
+  ): Promise<{ enqueued: boolean }> {
+    if (!this.claim) return { enqueued: false };
+    const { created } = await this.claim.enqueue({
+      jobType: 'pack_seed_ingest',
+      companyId,
+      triggeredBy: 'manual',
+      dedupKey: `pack_seed_${p.packId}_${p.packVersion}`,
+      payload: { packId: p.packId, packVersion: p.packVersion },
+    });
+    return { enqueued: created };
+  }
+
+  /**
+   * Ingest every seed document of the pack's INSTALLED manifest. Skips
+   * cleanly (all-zero result) when the pack is gone, a newer install
+   * superseded the queued version, or the manifest ships no seeds. One
+   * poison document must not sink the batch: per-document failures are
+   * counted and the rest proceed.
+   */
+  async runForPack(
+    companyId: string,
+    p: { packId: string; packVersion: string },
+    abortSignal?: AbortSignal,
+  ): Promise<PackSeedIngestResult> {
+    const result: PackSeedIngestResult = {
+      total: 0,
+      ingested: 0,
+      deduplicated: 0,
+      failed: 0,
+    };
+    const seeds = await this.loadSeeds(companyId, p);
+    if (!seeds) return result;
+    result.total = seeds.length;
+
+    for (const seed of seeds) {
+      if (abortSignal?.aborted) {
+        // A deploy mid-batch must not read as "done". Throw so the job
+        // requeues; already-ingested seeds dedup on the re-run.
+        throw new Error('aborted');
+      }
+      try {
+        const r = await this.ingest.ingestDocument(
+          companyId,
+          this.seedDto(seed, p),
+        );
+        if (r.deduplicated) result.deduplicated++;
+        else result.ingested++;
+      } catch (err) {
+        result.failed++;
+        this.logger.warn(
+          `seed document ${p.packId}/${seed.localId} failed for ${companyId}: ${(err as Error).message}`,
+        );
+      }
+    }
+    this.logger.log(
+      `pack seeds ${p.packId}@${p.packVersion} for ${companyId}: ingested=${result.ingested} deduplicated=${result.deduplicated} failed=${result.failed}`,
+    );
+    return result;
+  }
+
+  /** The installed manifest's seed documents, or null on any clean skip. */
+  private async loadSeeds(
+    companyId: string,
+    p: { packId: string; packVersion: string },
+  ): Promise<PackSeedDocument[] | null> {
+    const row = await this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT version, manifest FROM domain_pack WHERE packId = $packId AND status = 'active' LIMIT 1`,
+        { packId: p.packId },
+      );
+      return ((rows as any[]) ?? [])[0] as
+        | { version: unknown; manifest?: DomainPackManifest }
+        | undefined;
+    });
+    if (!row) {
+      this.logger.log(
+        `pack_seed_ingest skipped — pack ${p.packId} is not installed for ${companyId}`,
+      );
+      return null;
+    }
+    if (String(row.version) !== p.packVersion) {
+      // A newer install superseded the queued version; its own job (fresh
+      // dedupKey) owns the current manifest's seeds.
+      this.logger.log(
+        `pack_seed_ingest skipped — ${p.packId} is at v${row.version}, job was for v${p.packVersion}`,
+      );
+      return null;
+    }
+    const seeds = row.manifest?.seedDocuments;
+    if (!Array.isArray(seeds) || seeds.length === 0) return null;
+    return seeds;
+  }
+
+  /** Shape one seed as a normal document-pipeline ingest. */
+  private seedDto(
+    seed: PackSeedDocument,
+    p: { packId: string; packVersion: string },
+  ): IngestDocumentDto {
+    return {
+      kind: 'pack_seed',
+      text: seed.text,
+      title: seed.title,
+      originUri: seed.originUri ?? `pack://${p.packId}/${seed.localId}`,
+      occurredAt: seed.occurredAt ?? new Date().toISOString(),
+      // recorder = connector provenance on the source_document row; the
+      // commit writer stamps the INDEXER id on facts' source.recorder.
+      contextRef: { vertical: seed.vertical, recorder: `pack:${p.packId}` },
+      // Flat scalar keys only (sanitizeSourceMeta drops nested objects) —
+      // the provenance quad makes seed-derived rows queryable for manual
+      // cleanup after an uninstall.
+      meta: {
+        ...seed.meta,
+        pack_seed: true,
+        pack_id: p.packId,
+        pack_version: p.packVersion,
+        pack_seed_doc: seed.localId,
+      },
+      // Stored content keeps seeds reindexable when the NEXT pack lands.
+      storeContent: true,
+      mode: 'sync',
+      // With DOCUMENT_MULTI_INDEXER_ENABLED off the routed selection is
+      // empty and seeds ride the union generalist pass; on, the pack's
+      // own indexer reads its seeds as a dedicated run.
+      indexers: [p.packId],
+    };
+  }
+
+  private async executeFromQueue(
+    ctx: JobContext,
+  ): Promise<Record<string, unknown>> {
+    const packId = String(ctx.payload?.packId ?? '');
+    const packVersion = String(ctx.payload?.packVersion ?? '');
+    if (!packId) return { skipped: 'missing_packId' };
+    const result = await this.runForPack(
+      ctx.companyId,
+      { packId, packVersion },
+      ctx.abortSignal,
+    );
+    return { ...result };
+  }
+}

--- a/src/jobs/job-run.service.ts
+++ b/src/jobs/job-run.service.ts
@@ -17,6 +17,7 @@ export type JobType =
   | 'commit_document'
   | 'candidate_sweeper'
   | 'reindex_documents'
+  | 'pack_seed_ingest'
   | 'scenarios_batch'
   | 'registry_mirror';
 

--- a/test/domain-pack-seed.e2e-spec.ts
+++ b/test/domain-pack-seed.e2e-spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Pack seed documents — end-to-end on a real DB.
+ *
+ * Proves a pack shipping seedDocuments gets them ingested through the NORMAL
+ * document pipeline on install: the install response reports the enqueue, the
+ * pack_seed_ingest handler (driven directly here for determinism) creates
+ * source_document rows with kind='pack_seed' + provenance meta, a re-run
+ * dedups on contentHash, and with DOCUMENT_INGEST_ENABLED off the install
+ * still succeeds while the seeds are skipped loudly.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { PackSeedIngestService } from '../src/documents/pack-seed-ingest.service';
+import { SurrealService } from '../src/db/surreal.service';
+
+const GARDENING_MANIFEST = {
+  id: 'gardening',
+  version: '1.0.0',
+  description: 'Gardening domain ontology (test pack).',
+  predicates: [
+    {
+      localId: 'grows_in',
+      displayLabel: 'grows in',
+      description: 'TYPE subject is a plant; value is a growing condition',
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+  ],
+  seedDocuments: [
+    {
+      localId: 'primer',
+      title: 'Gardening primer',
+      text: 'Tomatoes grow best in full sun with regular watering.',
+      vertical: 'garden',
+      meta: { audience: 'agents' },
+    },
+    {
+      localId: 'glossary',
+      title: 'Gardening glossary',
+      text: 'Perennial: a plant that lives more than two years.',
+      vertical: 'garden',
+      occurredAt: '2026-01-01T00:00:00Z',
+    },
+  ],
+};
+
+describe('/v1/admin/packs — seed documents through the pipeline (e2e)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    // The direct runForPack calls below are the deterministic driver — park
+    // the worker loop so the enqueued job can't race them.
+    process.env.WORKER_LOOP_ENABLED = '0';
+    process.env.DOCUMENT_INGEST_ENABLED = '1';
+    f = await createApp({ companyId: 'co_pack_seed_e2e' });
+  });
+  afterAll(async () => {
+    delete process.env.DOCUMENT_INGEST_ENABLED;
+    delete process.env.WORKER_LOOP_ENABLED;
+    if (f) await f.close();
+  });
+
+  const seedRows = async (packId: string) => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT kind, title, meta, vertical FROM source_document WHERE kind = 'pack_seed' AND meta.pack_id = $packId`,
+        { packId },
+      );
+      return (rows as any[]) ?? [];
+    });
+  };
+
+  it('install reports the seed ingest as enqueued', async () => {
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: GARDENING_MANIFEST });
+    expect([200, 201]).toContain(r.status);
+    expect(r.body.packId).toBe('gardening');
+    expect(r.body.seedDocuments).toEqual({ count: 2, status: 'enqueued' });
+  });
+
+  it('runForPack ingests the seeds as pack_seed documents with provenance meta', async () => {
+    const svc = f.app.get(PackSeedIngestService);
+    const result = await svc.runForPack(f.companyId, {
+      packId: 'gardening',
+      packVersion: '1.0.0',
+    });
+    expect(result).toEqual({
+      total: 2,
+      ingested: 2,
+      deduplicated: 0,
+      failed: 0,
+    });
+
+    const rows = await seedRows('gardening');
+    expect(rows).toHaveLength(2);
+    const byDoc = new Map(rows.map((r: any) => [r.meta.pack_seed_doc, r]));
+    const primer = byDoc.get('primer');
+    expect(primer.title).toBe('Gardening primer');
+    expect(primer.vertical).toBe('garden');
+    expect(primer.meta.pack_seed).toBe(true);
+    expect(primer.meta.pack_id).toBe('gardening');
+    expect(primer.meta.pack_version).toBe('1.0.0');
+    expect(primer.meta.audience).toBe('agents');
+    expect(byDoc.get('glossary')).toBeDefined();
+  });
+
+  it('re-running the seed ingest dedups every document (idempotent)', async () => {
+    const svc = f.app.get(PackSeedIngestService);
+    const again = await svc.runForPack(f.companyId, {
+      packId: 'gardening',
+      packVersion: '1.0.0',
+    });
+    expect(again).toEqual({
+      total: 2,
+      ingested: 0,
+      deduplicated: 2,
+      failed: 0,
+    });
+    expect(await seedRows('gardening')).toHaveLength(2);
+  });
+
+  it('with DOCUMENT_INGEST_ENABLED off the install succeeds and skips the seeds', async () => {
+    process.env.DOCUMENT_INGEST_ENABLED = '0';
+    try {
+      const r = await f.http
+        .post('/v1/admin/packs')
+        .set(auth())
+        .send({
+          manifest: {
+            ...GARDENING_MANIFEST,
+            id: 'beekeeping',
+            description: 'Beekeeping domain ontology (test pack).',
+            seedDocuments: [
+              {
+                localId: 'hive_basics',
+                title: 'Hive basics',
+                text: 'A healthy hive has one queen.',
+                vertical: 'apiary',
+              },
+            ],
+          },
+        });
+      expect([200, 201]).toContain(r.status);
+      expect(r.body.seedDocuments).toEqual({
+        count: 1,
+        status: 'skipped_ingest_disabled',
+      });
+      expect(await seedRows('beekeeping')).toHaveLength(0);
+    } finally {
+      process.env.DOCUMENT_INGEST_ENABLED = '1';
+    }
+  });
+});

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -9,8 +9,12 @@ import {
   packChecksum,
   validatePack,
   DomainPackError,
+  SEED_DOC_MAX_CHARS,
+  SEED_MAX_DOCS,
+  SEED_TOTAL_MAX_CHARS,
   type DomainPackManifest,
   type PackPredicate,
+  type PackSeedDocument,
 } from '../src/ai/domain-packs';
 import { computeHash } from '../src/ai/predicate-registry-internals/db-mapping';
 import {
@@ -130,6 +134,116 @@ describe('validatePack', () => {
         }),
       ),
     ).toThrow(/fewShot entries must be/);
+  });
+});
+
+describe('validateSeedDocuments (via validatePack)', () => {
+  function seed(over: Partial<PackSeedDocument> = {}): PackSeedDocument {
+    return {
+      localId: 'primer',
+      title: 'Domain primer',
+      text: 'Some seed knowledge.',
+      vertical: 'demo',
+      ...over,
+    };
+  }
+
+  it('accepts a well-formed seed document set', () => {
+    expect(() =>
+      validatePack(
+        pack({
+          seedDocuments: [
+            seed({
+              originUri: 'https://example.com/primer',
+              occurredAt: '2026-01-01T00:00:00Z',
+              meta: { audience: 'agents', priority: 2, curated: true },
+            }),
+            seed({ localId: 'glossary' }),
+          ],
+        }),
+      ),
+    ).not.toThrow();
+  });
+  it('rejects duplicate seed localIds', () => {
+    expect(() =>
+      validatePack(pack({ seedDocuments: [seed(), seed()] })),
+    ).toThrow(/duplicate seed document localId/);
+  });
+  it('rejects a non-snake_case seed localId', () => {
+    expect(() =>
+      validatePack(pack({ seedDocuments: [seed({ localId: 'Primer-1' })] })),
+    ).toThrow(DomainPackError);
+  });
+  it('rejects a seed localId containing the namespace separator', () => {
+    expect(() =>
+      validatePack(pack({ seedDocuments: [seed({ localId: 'a__b' })] })),
+    ).toThrow(/__/);
+  });
+  it('rejects a seed text over the per-document cap', () => {
+    expect(() =>
+      validatePack(
+        pack({
+          seedDocuments: [seed({ text: 'x'.repeat(SEED_DOC_MAX_CHARS + 1) })],
+        }),
+      ),
+    ).toThrow(/per-document cap/);
+  });
+  it('rejects seed texts over the combined cap', () => {
+    const chunk = 'x'.repeat(SEED_DOC_MAX_CHARS);
+    const docs = Array.from(
+      { length: Math.ceil(SEED_TOTAL_MAX_CHARS / SEED_DOC_MAX_CHARS) + 1 },
+      (_, i) => seed({ localId: `doc_${i}`, text: chunk }),
+    );
+    expect(() => validatePack(pack({ seedDocuments: docs }))).toThrow(
+      /chars of text combined/,
+    );
+  });
+  it('rejects a seed without a vertical', () => {
+    expect(() =>
+      validatePack(
+        pack({
+          seedDocuments: [seed({ vertical: undefined as unknown as string })],
+        }),
+      ),
+    ).toThrow(/vertical/);
+  });
+  it('rejects an unparseable occurredAt', () => {
+    expect(() =>
+      validatePack(pack({ seedDocuments: [seed({ occurredAt: 'yesterday' })] })),
+    ).toThrow(/occurredAt/);
+  });
+  it('rejects non-scalar meta values', () => {
+    expect(() =>
+      validatePack(
+        pack({
+          seedDocuments: [
+            seed({
+              meta: { nested: { deep: true } } as unknown as PackSeedDocument['meta'],
+            }),
+          ],
+        }),
+      ),
+    ).toThrow(/meta value/);
+  });
+  it('rejects a non-snake_case meta key', () => {
+    expect(() =>
+      validatePack(
+        pack({ seedDocuments: [seed({ meta: { 'Bad-Key': 'x' } })] }),
+      ),
+    ).toThrow(/meta key/);
+  });
+  it(`rejects more than ${SEED_MAX_DOCS} seed documents`, () => {
+    const docs = Array.from({ length: SEED_MAX_DOCS + 1 }, (_, i) =>
+      seed({ localId: `doc_${i}` }),
+    );
+    expect(() => validatePack(pack({ seedDocuments: docs }))).toThrow(
+      /the cap is/,
+    );
+  });
+  it('changes the pack checksum when a seed text changes', () => {
+    const a = pack({ seedDocuments: [seed({ text: 'version one' })] });
+    const b = pack({ seedDocuments: [seed({ text: 'version two' })] });
+    expect(packChecksum(a)).not.toBe(packChecksum(b));
   });
 });
 

--- a/test/pack-seed-ingest.unit-spec.ts
+++ b/test/pack-seed-ingest.unit-spec.ts
@@ -1,0 +1,204 @@
+/**
+ * PackSeedIngestService.runForPack — DTO shaping, count bookkeeping,
+ * poison-document isolation, and the clean skips (pack missing / version
+ * superseded / no seeds). The DocumentIngestService is stubbed; what's
+ * under test is the seam between an installed manifest's seedDocuments
+ * and the normal document-pipeline entry.
+ */
+import { PackSeedIngestService } from '../src/documents/pack-seed-ingest.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { DocumentIngestService } from '../src/documents/document-ingest.service';
+import type { IngestDocumentDto } from '../src/documents/dto/ingest-document.dto';
+import type { PackSeedDocument } from '../src/ai/domain-packs';
+
+function surrealWithRow(row: unknown): SurrealService {
+  return {
+    withCompany: (_companyId: string, fn: (db: unknown) => Promise<unknown>) =>
+      fn({ query: async () => [row === undefined ? [] : [row]] }),
+  } as unknown as SurrealService;
+}
+
+function packRow(seeds: PackSeedDocument[] | undefined, version = '1.0.0') {
+  return {
+    version,
+    manifest: {
+      id: 'gardening',
+      version,
+      description: 'x',
+      predicates: [],
+      ...(seeds ? { seedDocuments: seeds } : {}),
+    },
+  };
+}
+
+function seed(over: Partial<PackSeedDocument> = {}): PackSeedDocument {
+  return {
+    localId: 'primer',
+    title: 'Gardening primer',
+    text: 'Tomatoes want sun.',
+    vertical: 'garden',
+    ...over,
+  };
+}
+
+interface IngestStub {
+  svc: DocumentIngestService;
+  calls: IngestDocumentDto[];
+}
+
+function ingestStub(
+  behavior?: (dto: IngestDocumentDto, call: number) => { deduplicated: boolean },
+): IngestStub {
+  const calls: IngestDocumentDto[] = [];
+  const svc = {
+    ingestDocument: async (_companyId: string, dto: IngestDocumentDto) => {
+      calls.push(dto);
+      return {
+        documentId: `source_document:d${calls.length}`,
+        ...(behavior
+          ? behavior(dto, calls.length)
+          : { deduplicated: false }),
+      };
+    },
+  } as unknown as DocumentIngestService;
+  return { svc, calls };
+}
+
+const REF = { packId: 'gardening', packVersion: '1.0.0' };
+
+describe('PackSeedIngestService.runForPack', () => {
+  it('ingests every seed and reports counts (dedup split out)', async () => {
+    const ingest = ingestStub((_dto, call) => ({ deduplicated: call === 2 }));
+    const svc = new PackSeedIngestService(
+      surrealWithRow(
+        packRow([
+          seed(),
+          seed({ localId: 'glossary' }),
+          seed({ localId: 'faq' }),
+        ]),
+      ),
+      ingest.svc,
+    );
+    const r = await svc.runForPack('co_1', REF);
+    expect(r).toEqual({ total: 3, ingested: 2, deduplicated: 1, failed: 0 });
+    expect(ingest.calls).toHaveLength(3);
+  });
+
+  it('isolates a poison document — counts it failed and continues', async () => {
+    const ingest = ingestStub((_dto, call) => {
+      if (call === 2) throw new Error('boom');
+      return { deduplicated: false };
+    });
+    const svc = new PackSeedIngestService(
+      surrealWithRow(
+        packRow([
+          seed(),
+          seed({ localId: 'poison' }),
+          seed({ localId: 'faq' }),
+        ]),
+      ),
+      ingest.svc,
+    );
+    const r = await svc.runForPack('co_1', REF);
+    expect(r).toEqual({ total: 3, ingested: 2, deduplicated: 0, failed: 1 });
+  });
+
+  it('skips cleanly when the pack is not installed', async () => {
+    const ingest = ingestStub();
+    const svc = new PackSeedIngestService(surrealWithRow(undefined), ingest.svc);
+    const r = await svc.runForPack('co_1', REF);
+    expect(r).toEqual({ total: 0, ingested: 0, deduplicated: 0, failed: 0 });
+    expect(ingest.calls).toHaveLength(0);
+  });
+
+  it('skips cleanly when a newer install superseded the queued version', async () => {
+    const ingest = ingestStub();
+    const svc = new PackSeedIngestService(
+      surrealWithRow(packRow([seed()], '2.0.0')),
+      ingest.svc,
+    );
+    const r = await svc.runForPack('co_1', REF);
+    expect(r.total).toBe(0);
+    expect(ingest.calls).toHaveLength(0);
+  });
+
+  it('skips cleanly when the manifest ships no seedDocuments', async () => {
+    const ingest = ingestStub();
+    const svc = new PackSeedIngestService(
+      surrealWithRow(packRow(undefined)),
+      ingest.svc,
+    );
+    const r = await svc.runForPack('co_1', REF);
+    expect(r.total).toBe(0);
+    expect(ingest.calls).toHaveLength(0);
+  });
+
+  it('shapes the DTO for the normal pipeline (defaults applied)', async () => {
+    const before = Date.now();
+    const ingest = ingestStub();
+    const svc = new PackSeedIngestService(
+      surrealWithRow(packRow([seed({ meta: { audience: 'agents' } })])),
+      ingest.svc,
+    );
+    await svc.runForPack('co_1', REF);
+    const dto = ingest.calls[0];
+    expect(dto.kind).toBe('pack_seed');
+    expect(dto.title).toBe('Gardening primer');
+    expect(dto.text).toBe('Tomatoes want sun.');
+    expect(dto.originUri).toBe('pack://gardening/primer');
+    expect(dto.contextRef).toEqual({
+      vertical: 'garden',
+      recorder: 'pack:gardening',
+    });
+    // Flat scalar provenance keys, author meta preserved.
+    expect(dto.meta).toEqual({
+      audience: 'agents',
+      pack_seed: true,
+      pack_id: 'gardening',
+      pack_version: '1.0.0',
+      pack_seed_doc: 'primer',
+    });
+    expect(dto.storeContent).toBe(true);
+    expect(dto.mode).toBe('sync');
+    expect(dto.indexers).toEqual(['gardening']);
+    // occurredAt defaults to ingest time (valid ISO, roughly now).
+    const at = Date.parse(dto.occurredAt);
+    expect(Number.isFinite(at)).toBe(true);
+    expect(at).toBeGreaterThanOrEqual(before - 1000);
+    expect(at).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+
+  it('passes explicit originUri and occurredAt through verbatim', async () => {
+    const ingest = ingestStub();
+    const svc = new PackSeedIngestService(
+      surrealWithRow(
+        packRow([
+          seed({
+            originUri: 'https://example.com/primer',
+            occurredAt: '2026-01-01T00:00:00.000Z',
+          }),
+        ]),
+      ),
+      ingest.svc,
+    );
+    await svc.runForPack('co_1', REF);
+    expect(ingest.calls[0].originUri).toBe('https://example.com/primer');
+    expect(ingest.calls[0].occurredAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('throws "aborted" between documents so the job requeues', async () => {
+    const controller = new AbortController();
+    const ingest = ingestStub(() => {
+      controller.abort();
+      return { deduplicated: false };
+    });
+    const svc = new PackSeedIngestService(
+      surrealWithRow(packRow([seed(), seed({ localId: 'glossary' })])),
+      ingest.svc,
+    );
+    await expect(
+      svc.runForPack('co_1', REF, controller.signal),
+    ).rejects.toThrow('aborted');
+    expect(ingest.calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

A Domain Pack may now ship **`seedDocuments`** — pre-populated domain knowledge that is ingested through the **normal document pipeline** on install (`kind='pack_seed'`). No bespoke fact-writing path: seeds get the same chunking, extraction, candidate staging, conflict resolution, contentHash dedup and provenance as any connector's document. **No new migrations.**

## Manifest + validation

- `PackSeedDocument` (`localId`, `title`, `text`, `vertical`, optional `originUri` / `occurredAt` / flat-scalar `meta`) + `DomainPackManifest.seedDocuments?`, covered by pack checksum + signature like every other section.
- Caps as exported consts: `SEED_MAX_DOCS = 32`, `SEED_DOC_MAX_CHARS = 65,536`, `SEED_TOTAL_MAX_CHARS = 262,144` — bounds the install-time LLM fan-out a single manifest can trigger.
- `validateSeedDocuments` wired into `validatePack`: snake_case unique `localId`, non-empty title/text/vertical, per-doc + running-total text caps, ISO `occurredAt`, meta that survives `sanitizeSourceMeta` verbatim (constraints mirrored locally so the pure validator behind `pnpm pack:validate` stays dependency-free). Failures are `DomainPackError` → clean 400 at install.

## Job + service

- New `pack_seed_ingest` job type; `PackSeedIngestService` (mold: `DocumentReindexService`) registers the handler (`ttlSeconds: 600`, `maxAttempts: 3`).
- `runForPack` loads the **installed** manifest and skips cleanly when the pack is missing, a newer install superseded the queued version, or no seeds are declared. Each seed becomes a sync `DocumentIngestService.ingestDocument` call with:
  - `originUri` defaulting to `pack://<packId>/<localId>`, `occurredAt` defaulting to ingest time,
  - `contextRef: { vertical, recorder: 'pack:<packId>' }`,
  - provenance meta `pack_seed` / `pack_id` / `pack_version` / `pack_seed_doc` (flat scalars → project onto derived facts' `source.meta`),
  - `storeContent: true` (seeds stay reindexable), `indexers: [packId]` (degrades to the generalist union pass with `DOCUMENT_MULTI_INDEXER_ENABLED` off).
- Poison-document isolation (per-doc try/catch, `failed` counted) and abort-aware requeue between documents.

## Install hook

- `maybeEnqueueSeedIngest` beside `maybeEnqueueReindex` (enqueue-only via the global queue, best-effort): install **never** fails because of seeds. Response gains `seedDocuments: { count, status }`, status ∈ `enqueued | enqueue_failed | skipped_flag_disabled | skipped_ingest_disabled | skipped_no_queue`.
- Idempotency is two-layered: version-stable dedupKey `pack_seed_<id>_<version>` (same-version reinstall doesn't re-run a completed ingest) + document contentHash dedup (unchanged seed text is a per-document no-op; changed text = a new document).

## Env / contracts / docs

- `PACK_SEED_INGEST_ENABLED` (default ON via the `?? '1'` idiom) in `KNOWN_BOOLEAN_FLAGS`, config catalog (`pipeline`, runtime-mutable) and `.env.example`. Piggyback: registered the pre-existing `REINDEX_ON_PACK_INSTALL` and `DOCUMENT_ALLOW_UNGROUNDED_EXTERNAL` flags that were never in `KNOWN_BOOLEAN_FLAGS`.
- `DomainPackManifestSchema` += `seedDocuments` (loose mirror, consistent with `evalFixtures`); `InstallPackResponseSchema` += `seedDocuments`; `docs/openapi.json` regenerated.
- New "Seed documents" section in `docs/domain-packs.md` (shape, caps, provenance keys, idempotency, upgrade + uninstall semantics — uninstall leaves seed docs/facts, queryable via `source.meta.pack_id`).

## Tests

- `test/domain-pack.unit-spec.ts`: 12 new validator cases (valid set, dup/bad localId, per-doc + combined oversize, missing vertical, bad occurredAt, non-scalar meta, bad meta key, >32 docs, checksum changes with seed text).
- `test/pack-seed-ingest.unit-spec.ts` (new): counts + dedup split, poison isolation, all three clean skips, full DTO shaping (defaults + verbatim pass-through), abort requeue.
- `test/domain-pack-seed.e2e-spec.ts` (new, real SurrealDB testcontainer): install reports `{count: 2, status: 'enqueued'}` → `runForPack` creates `source_document` rows with `kind='pack_seed'` + provenance meta → re-run dedups everything → with `DOCUMENT_INGEST_ENABLED` off the install succeeds with `skipped_ingest_disabled` and zero documents.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm lint:ci` — 0 errors / 0 warnings
- `pnpm test` — 165 suites, 1217 tests passed
- targeted e2e (`domain-pack-seed`, `domain-pack-install`, `documents-pipeline`) — 3 suites, 24 tests passed against the SurrealDB testcontainer
- `pnpm pack:validate` on a seed-bearing manifest — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd