### PR TITLE
fix(db): tolerate concurrent migration appliers racing the ledger insert

### DIFF
--- a/src/db/migrator.service.ts
+++ b/src/db/migrator.service.ts
@@ -3,6 +3,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { Surreal } from 'surrealdb';
 import { isReadConflict } from './surreal.service';
+import { isUniqueViolation } from './surreal-retry';
 
 /**
  * Schema migrator — versioned, append-only DDL applied per tenant DB.
@@ -103,10 +104,21 @@ export class SchemaMigrator {
           await new Promise((r) => setTimeout(r, baseMs + Math.random() * baseMs));
         }
       }
-      await conn.query(
-        `CREATE schema_migrations CONTENT { migrationId: $id, name: $name }`,
-        { id: m.id, name: m.name },
-      );
+      // The ledger insert is the only non-idempotent step. Two appliers
+      // racing on a SHARED DB (the system DB under parallel e2e boots;
+      // multi-pod boots in general) both compute the same pending set —
+      // the DDL is IF-NOT-EXISTS-idempotent, so the loser of this CREATE
+      // has already applied identical schema and must treat the unique
+      // violation as "someone else recorded it first", not a failure.
+      try {
+        await conn.query(
+          `CREATE schema_migrations CONTENT { migrationId: $id, name: $name }`,
+          { id: m.id, name: m.name },
+        );
+      } catch (err) {
+        if (!isUniqueViolation(err)) throw err;
+        this.logger.log(`Ledger row for ${m.name} already written by a concurrent applier`);
+      }
     }
 
     return {

--- a/test/migrator.unit-spec.ts
+++ b/test/migrator.unit-spec.ts
@@ -138,6 +138,28 @@ describe('SchemaMigrator', () => {
     ).toBe(false);
   });
 
+  it('tolerates a concurrent applier winning the ledger insert', async () => {
+    // Two processes booting against a SHARED DB (system DB under parallel
+    // e2e, multi-pod boots) both compute the same pending set; the loser's
+    // ledger CREATE hits the UNIQUE index and must be treated as applied.
+    dir = await makeMigrationsDir({
+      '0001_baseline.surql': 'DEFINE TABLE a;',
+    });
+    const migrator = new SchemaMigrator(dir);
+    const { conn } = makeFakeConn();
+    const rawQuery = conn.query.bind(conn);
+    conn.query = async <T>(sql: string, params?: Record<string, unknown>): Promise<T> => {
+      if (sql.startsWith('CREATE schema_migrations')) {
+        throw new Error(
+          "Database index `schema_migrations_id_idx` already contains '0001', with record `schema_migrations:x`",
+        );
+      }
+      return rawQuery<T>(sql, params);
+    };
+    const result = await migrator.migrate(conn as never);
+    expect(result.applied).toEqual(['0001']);
+  });
+
   it('rejects duplicate migration IDs', async () => {
     dir = await makeMigrationsDir({
       '0001_baseline.surql': 'DEFINE TABLE a;',


### PR DESCRIPTION
Two processes booting against a shared DB (the system DB under parallel e2e suites; multi-pod boots in general) both compute the same pending migration set. The DDL is IF-NOT-EXISTS-idempotent, but the `schema_migrations` ledger `CREATE` was not fenced: the loser hit the UNIQUE index (`Database index schema_migrations_id_idx already contains '0066'`) and `migrate()` threw, failing the boot. Surfaced by CI on #202 when system-DB migrations 0066/0067 landed and three registry e2e suites booted concurrently.

Fix: a unique violation on the ledger insert now means "a concurrent applier already recorded it" — log and continue. Regression test included (concurrent winner steals the ledger insert; migrate() still reports the migration as applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)