### PR TITLE
feat(mcp): pack-declared MCP tools — query tools over pack predicates + HMAC-proxied external tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -372,6 +372,27 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 #INDEXER_WEBHOOK_PUSH_ENABLED=1
 #INDEXER_WEBHOOK_RETRY_BASE_MS=250
 
+# ── MCP pack tools (migration 0068) ──────────────────────────────────────
+# Pack-declared MCP tools (docs/mcp-pack-tools.md): installed Domain Packs
+# whose manifest ships a consented mcpTools section contribute tools to the
+# tenant's MCP surface, named <packId>__<toolName>. Master switch — off
+# (default) keeps the surface exactly the static tool families.
+#MCP_PACK_TOOLS_ENABLED=0
+# Declarative query tools over the pack's OWN predicates (search /
+# facts_by_predicate). Default ON under the master flag.
+#MCP_PACK_QUERY_TOOLS_ENABLED=1
+# External proxy tools: Brain POSTs the call to the publisher's https
+# endpoint, HMAC-signed with the pack's install secret; the wire carries an
+# opaque installId, never companyId. No retries, 64 KB response cap,
+# per-endpoint circuit breaker.
+#MCP_PACK_EXTERNAL_TOOLS_ENABLED=0
+# Dev/test ONLY: permit plain-http + loopback/private endpoints (disables
+# the SSRF egress guard on pack tool calls). Never enable in production.
+#MCP_PACK_TOOLS_ALLOW_HTTP=0
+# TTL of the per-tenant pack-tool binding cache (install/uninstall
+# invalidate immediately).
+#MCP_PACK_TOOLS_CACHE_TTL_MS=30000
+
 # ── ABAC: per-key policy sets (migration 0056) ───────────────────────────
 # Master switch. Off (default) = the policy resolver never runs and every
 # surface behaves byte-identically to pre-ABAC. On, keys that reference

--- a/docs/api.md
+++ b/docs/api.md
@@ -109,7 +109,7 @@ a quiet stale field.
 
 | Endpoint | Notes |
 |---|---|
-| `ALL /mcp/:companyId` | Streamable HTTP MCP endpoint per tenant. |
+| `ALL /mcp/:companyId` | Streamable HTTP MCP endpoint per tenant. Besides the static tool families, installed Domain Packs with a consented `mcpTools` section contribute tools named `<packId>__<toolName>` (behind `MCP_PACK_TOOLS_ENABLED`, default off) — see [mcp-pack-tools.md](mcp-pack-tools.md). Installing such a pack requires `acceptMcpTools: true` in the `POST /v1/admin/packs` (or `/from-registry`) body; a changed section on upgrade re-requires it. The unauthenticated `/health` probe lists only the static read baseline. |
 
 ## Auth + scopes
 

--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -214,6 +214,25 @@ cover it with no extra machinery:
   no in-process extraction runs for it. The builtin `code_memory` pack is the
   reference external indexer — its capture pipeline runs where the code lives.
 
+## MCP tools (consumed)
+
+A pack MAY ship an `mcpTools` section — up to 8 tools contributed to the
+tenant's MCP surface, registered as `<packId>__<toolName>` once the
+operator installs the pack with explicit consent (`acceptMcpTools:
+true`; an upgrade that changes the section re-requires it). Two shapes,
+by hard design constraint (no third-party code runs in-process):
+
+- **`query`** — a declarative read over the pack's OWN namespaced
+  predicates (`search` or `facts_by_predicate` surface); input schemas
+  are fixed server-side.
+- **`external`** — an HMAC-signed HTTPS proxy to a publisher-operated
+  endpoint; the wire carries an opaque per-install `installId`, never
+  the tenant id.
+
+Both are flag-gated (`MCP_PACK_TOOLS_ENABLED` master, default off).
+Full reference — manifest fields, consent flow, endpoint protocol with
+signature verification, security model: [mcp-pack-tools.md](mcp-pack-tools.md).
+
 ## The registry (global catalogue)
 
 Packs are published to and installed from a **global registry** — a shared,

--- a/docs/mcp-pack-tools.md
+++ b/docs/mcp-pack-tools.md
@@ -1,0 +1,234 @@
+# Pack-declared MCP tools
+
+How a Domain Pack extends a tenant's MCP surface with its own tools —
+without running any third-party code inside Brain. A pack's manifest may
+ship an `mcpTools` section; once the operator installs the pack **and
+explicitly consents to that section**, the declared tools appear in the
+tenant's MCP `tools/list` next to the built-in families, named
+`<packId>__<toolName>`.
+
+Settled design constraint: **no in-process plugin code**. A pack tool is
+one of exactly two shapes:
+
+- **`query`** — a declarative read over the tenant's knowledge graph,
+  locked to the pack's own (namespaced) predicates;
+- **`external`** — an HTTPS proxy: Brain POSTs the call, HMAC-signed,
+  to an endpoint the pack publisher operates.
+
+Each shape is independently toggleable by the operator (see
+[Operator flags](#operator-flags)).
+
+## Manifest reference
+
+```jsonc
+{
+  "id": "compliance",
+  "version": "1.2.0",
+  "predicates": [ /* compliance__* vocabulary */ ],
+  "mcpTools": [                       // max 8 per pack
+    {
+      "kind": "query",
+      "name": "find_violations",      // ^[a-z][a-z0-9_]{1,40}$, no "__"
+      "title": "Find compliance violations",       // ≤ 80 chars
+      "description": "Search recorded compliance violations.", // ≤ 500
+      "query": {
+        "surface": "search",          // or "facts_by_predicate"
+        "predicates": ["violation"],  // localIds of THIS pack (optional for search)
+        "defaultLimit": 10,           // 1..20
+        "minConfidence": 0.5          // 0..1, search surface only
+      }
+    },
+    {
+      "kind": "external",
+      "name": "check_sanctions",
+      "description": "Screen a counterparty against the publisher's sanctions data.",
+      "endpoint": "https://tools.publisher.example/sanctions",  // https only
+      "timeoutMs": 10000,             // 1000..30000, default 10000
+      "params": [                     // ≤ 8 declared params
+        { "name": "counterparty", "type": "string", "required": true, "maxLength": 200 },
+        { "name": "mode", "type": "string", "enum": ["fast", "deep"] }
+      ]
+    }
+  ]
+}
+```
+
+Validation runs in `pnpm pack:validate`, at publish, at install, and
+defensively again before every registration (`validateMcpTools`):
+1–8 tools; unique snake_case names without the reserved `__` separator;
+description required (≤ 500); query predicates must be the pack's OWN
+localIds (`facts_by_predicate` requires them); external endpoints must
+parse as http(s) URLs; params are capped at 8 with `string | number |
+boolean` types, `enum`/`maxLength` for strings only.
+
+The section lives inside the signed, checksummed manifest — publisher
+signatures and version immutability cover it with no extra machinery.
+
+## Install consent (and re-consent)
+
+Installing a pack whose manifest declares `mcpTools` **fails with 400**
+unless the request carries the explicit flag:
+
+```
+POST /v1/admin/packs
+{ "manifest": { … }, "acceptMcpTools": true }
+```
+
+The refusal lists every tool's name, kind, and (for external tools) the
+endpoint, so the operator reviews exactly what they accept. The same
+flag exists on `POST /v1/admin/packs/from-registry`.
+
+Consent is stored with a sha256 checksum of the canonical-JSON
+`mcpTools` section:
+
+- an **upgrade that leaves the section unchanged** carries consent over
+  (no flag needed);
+- an **upgrade that changes it** (any tool added/removed/edited)
+  re-requires `acceptMcpTools: true`;
+- an upgrade that **drops** the section clears the stored consent.
+
+The MCP reader only ever registers tools whose stored consent checksum
+matches the stored section — a row edited out-of-band serves nothing.
+
+## Query tools
+
+Query tools are served entirely by Brain. The input schemas are fixed
+server-side (a pack chooses names and descriptions, never the query
+shape), and the predicate set is **server-computed from the pack's own
+manifest** — a pack cannot point a tool at core predicates or another
+pack's namespace.
+
+| surface | input | behaviour |
+|---|---|---|
+| `search` | `{query (≤500 chars), limit? (1..20)}` | The standard hybrid search pipeline, restricted to the spec's `predicates` (localIds → `<packId>__<localId>`) or ALL of the pack's predicates when unset; `minConfidence` from the spec; limit = `min(limit ?? defaultLimit ?? 10, 20)`. |
+| `facts_by_predicate` | `{predicate (enum of declared localIds), entity? (id), limit? (1..50)}` | Active-believed-now facts for ONE namespaced predicate, optionally scoped to an entity; ordered newest-first. |
+
+Both surfaces run under the caller's scopes and the full row fence:
+the predicate `requiresScope` gate (a `brain:read` key never sees
+`brain:read_pii`-fenced pack facts) plus the ABAC row filter
+(surface `pack_facts_by_predicate`; the search surface inherits
+SearchService's own row fence).
+
+**ABAC kind**: query tools are `read`-kind — they register under a
+readonly-allow policy (`@readonly` macro) and can be denied by their
+concrete namespaced name.
+
+## External tools
+
+An external tool call becomes a single signed POST to the declared
+endpoint (no retries — the calling agent should see the failure):
+
+```
+POST <endpoint>
+Content-Type: application/json
+X-Brain-Event: mcp_tool_call
+X-Brain-Signature: sha256=<hex HMAC-SHA256 over the raw request body>
+
+{
+  "event": "mcp_tool_call",
+  "tool": "check_sanctions",          // local name (unprefixed)
+  "packId": "compliance",
+  "installId": "3f2a…-…",             // opaque per-install identity
+  "requestId": "b41c…-…",             // unique per call
+  "ts": "2026-07-16T10:00:00.000Z",
+  "args": { "counterparty": "Acme GmbH" }
+}
+```
+
+**The wire never carries companyId.** `installId` (migration 0068) is
+minted at install time and stays stable across upgrades — the publisher
+keys its per-tenant state on it without learning Brain's tenant ids.
+
+The HMAC key is the pack's **install webhook secret** — the same secret
+external indexers use, returned ONCE in the install response
+(`webhookSecret`). Verify before trusting a request:
+
+```ts
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+function verify(rawBody: Buffer, header: string, secret: string): boolean {
+  const expected = `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`;
+  return (
+    header.length === expected.length &&
+    timingSafeEqual(Buffer.from(header), Buffer.from(expected))
+  );
+}
+```
+
+Respond `200` with JSON:
+
+```jsonc
+{ "content": "Acme GmbH: no sanctions hits" }        // string → text result
+{ "content": { "verdict": "clean", "score": 0.98 } } // object → text + structuredContent
+{ "error": "counterparty not found" }                // application-level error
+```
+
+Rules Brain enforces on the response path:
+
+- timeout `timeoutMs` (default 10 s, hard cap 30 s); redirects are
+  errors; **no retries**;
+- response body hard-capped at **64 KB** (oversize = error);
+- non-200 / malformed JSON / `{error}` → a sanitized error is shown to
+  the calling agent (control characters stripped, 500-char cap) — raw
+  endpoint output never reaches an exception;
+- **circuit breaker per endpoint**: 3 consecutive transport failures
+  latch the endpoint for 60 s (calls fail immediately, "circuit open").
+
+**ABAC kind**: external tools are `write`-kind — a readonly-allow
+policy strips them; grant them per-key by concrete name when needed.
+
+## Security model
+
+- **No third-party code in-process** — declarative queries + proxied
+  HTTPS calls only. No JSON-Schema passthrough either: input schemas
+  are built server-side from the validated param specs.
+- **Prompt-injection hardening**: every pack-authored string (title,
+  description, param descriptions) is Unicode-normalized, stripped of
+  control/bidi/zero-width characters, whitespace-collapsed and capped;
+  every tool description begins with a server-owned preamble naming the
+  pack and its effect (reads tenant knowledge / calls an external
+  endpoint) that a pack cannot spoof.
+- **Predicate fence**: query tools can only read the pack's own
+  namespaced predicates; `requiresScope` (PII) and ABAC row policies
+  apply per row.
+- **Egress guard (SSRF fence)**: external endpoints must be https, may
+  not embed credentials, and their DNS answers may not include
+  loopback/private/link-local/ULA/unspecified addresses (covers
+  169.254.169.254). Checked at install AND on every call.
+  `MCP_PACK_TOOLS_ALLOW_HTTP=1` disables this fence for local dev/test.
+- **Tenant privacy**: external endpoints see `installId`, never
+  companyId; calls are signed so the endpoint can reject forgeries.
+- **Consent**: nothing is served without a stored, checksum-matched
+  operator consent; changed sections re-require it.
+- **Key binding**: an API key with `packIds` (or a JWT `packs` claim)
+  sees only its bound packs' tools.
+- **Known limitation** — the egress guard resolves DNS separately from
+  the subsequent fetch, so a fast-flux DNS rebinding between check and
+  call is a residual risk (mitigated by re-checking per call).
+
+## Operator flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `MCP_PACK_TOOLS_ENABLED` | `0` | Master switch. Off = MCP surface is exactly the static tool families. |
+| `MCP_PACK_QUERY_TOOLS_ENABLED` | `1` | Query tools (only reachable under the master flag). |
+| `MCP_PACK_EXTERNAL_TOOLS_ENABLED` | `0` | External proxy tools. |
+| `MCP_PACK_TOOLS_ALLOW_HTTP` | `0` | Dev/test ONLY: allow http + loopback endpoints (disables the SSRF fence). |
+| `MCP_PACK_TOOLS_CACHE_TTL_MS` | `30000` | Per-tenant binding cache TTL (install/uninstall invalidate immediately). |
+
+## Health-probe limitation
+
+`GET /mcp/:companyId/health` returns a **static** read-baseline tool
+list — pack tools are per-tenant, consented, and flag-gated, so they are
+deliberately absent from the unauthenticated probe. Confirm them via an
+authenticated `tools/list`.
+
+## Not in v1
+
+Raw SurrealQL from packs; more query surfaces (entity_profile /
+timeline / multi-hop); JSON Schema passthrough for inputs; `asOf` /
+`userId` parameters on query tools; pack tools in the health probe;
+pack-provided MCP resources / prompts / sampling; streaming or progress
+on external calls; retries on external calls; DNS pinning between the
+egress check and the fetch; per-tool rate limits or metering;
+webhookSecret rotation.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -484,6 +484,16 @@
             },
             "type": "object"
           },
+          "mcpTools": {
+            "items": {
+              "additionalProperties": {},
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
           "predicates": {
             "items": {
               "additionalProperties": {},
@@ -960,6 +970,9 @@
       "InstallFromRegistryRequest": {
         "additionalProperties": false,
         "properties": {
+          "acceptMcpTools": {
+            "type": "boolean"
+          },
           "packId": {
             "type": "string"
           },
@@ -975,6 +988,9 @@
       "InstallPackRequest": {
         "additionalProperties": false,
         "properties": {
+          "acceptMcpTools": {
+            "type": "boolean"
+          },
           "expectedChecksum": {
             "type": "string"
           },
@@ -1028,6 +1044,9 @@
             "type": "object"
           },
           "version": {
+            "type": "string"
+          },
+          "webhookSecret": {
             "type": "string"
           }
         },

--- a/src/admin/admin-packs.controller.ts
+++ b/src/admin/admin-packs.controller.ts
@@ -53,10 +53,17 @@ export class AdminPacksController {
   @RequireScopes('brain:admin')
   async install(
     @Req() req: AuthenticatedRequest,
-    @Body() body: { manifest: DomainPackManifest; expectedChecksum?: string },
+    @Body()
+    body: {
+      manifest: DomainPackManifest;
+      expectedChecksum?: string;
+      /** Consent to the manifest's mcpTools section (docs/mcp-pack-tools.md). */
+      acceptMcpTools?: boolean;
+    },
   ): Promise<InstallPackResponse> {
     return this.packs.install(req.brainAuth.companyId, body?.manifest, {
       expectedChecksum: body?.expectedChecksum,
+      acceptMcpTools: body?.acceptMcpTools,
     });
   }
 
@@ -68,7 +75,8 @@ export class AdminPacksController {
   @RequireScopes('brain:admin')
   async installFromRegistry(
     @Req() req: AuthenticatedRequest,
-    @Body() body: { packId: string; version?: string },
+    @Body()
+    body: { packId: string; version?: string; acceptMcpTools?: boolean },
   ): Promise<InstallPackResponse> {
     const { manifest, checksum } = await this.registry.resolveForInstall({
       packId: body?.packId,
@@ -77,6 +85,7 @@ export class AdminPacksController {
     });
     return this.packs.install(req.brainAuth.companyId, manifest, {
       expectedChecksum: checksum,
+      acceptMcpTools: body?.acceptMcpTools,
     });
   }
 

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -37,6 +37,7 @@ import { HnswMaintenanceService } from './hnsw-maintenance.service';
 import { CodeMemoryModule } from '../code-memory/code-memory.module';
 import { RegistryModule } from '../registry/registry.module';
 import { IndexersModule } from '../indexers/indexers.module';
+import { McpModule } from '../mcp/mcp.module';
 import { DomainPackInstallService } from './domain-pack-install.service';
 import { PackEvalService } from './pack-eval.service';
 import { ScenarioRunnerService } from './scenario-runner.service';
@@ -74,6 +75,9 @@ import { ConfigInspectorService } from './config-inspector.service';
     // PackEvalService scores fixtures in 'dedicated' mode through the
     // pack-scoped extractor.
     IndexersModule,
+    // DomainPackInstallService invalidates the MCP pack-tools reader
+    // cache on install/uninstall (PackToolsReaderService export).
+    McpModule,
   ],
   controllers: [
     AdminController,

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -651,6 +651,52 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
         description:
           'Signed work_available webhook hints to external packs declaring indexer.external.callbackUrl. Best-effort (retries + per-URL breaker); polling stays the source of truth.',
       },
+      // ── MCP pack tools (migration 0068) ───────────────────────
+      {
+        key: 'MCP_PACK_TOOLS_ENABLED',
+        category: 'misc',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Master switch for pack-declared MCP tools (installed packs with a consented mcpTools section). Off = the MCP surface is exactly the static tool families.',
+      },
+      {
+        key: 'MCP_PACK_QUERY_TOOLS_ENABLED',
+        category: 'misc',
+        defaultValue: '1',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Declarative query tools (search / facts_by_predicate over the pack’s own predicates). Default ON under the master flag; only reachable when MCP_PACK_TOOLS_ENABLED=1.',
+      },
+      {
+        key: 'MCP_PACK_EXTERNAL_TOOLS_ENABLED',
+        category: 'misc',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'HMAC-signed HTTPS proxy tools to publisher endpoints (opaque installId on the wire, never companyId). Off = external tool specs are ignored even when consented.',
+      },
+      {
+        key: 'MCP_PACK_TOOLS_ALLOW_HTTP',
+        category: 'misc',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Dev/test ONLY: permit plain-http + loopback/private external tool endpoints (disables the SSRF egress guard). Never enable in production.',
+      },
+      {
+        key: 'MCP_PACK_TOOLS_CACHE_TTL_MS',
+        category: 'misc',
+        defaultValue: '30000',
+        runtimeMutable: true,
+        isBooleanFlag: false,
+        description:
+          'TTL of the per-tenant pack-tool binding cache on the MCP hot path. Install/uninstall invalidate immediately; the TTL covers out-of-band domain_pack edits.',
+      },
       // ── Search: retrieval-evolution stages (migrations 0052–0055) ──
       {
         key: 'SEARCH_HNSW_ENABLED',

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -31,6 +31,7 @@ import {
   type PackExternalToolSpec,
 } from '../ai/domain-packs';
 import { assertPublicHttpUrl, EgressDeniedError } from '../common/egress-guard';
+import { PackToolsReaderService } from '../mcp/pack-tools-reader.service';
 
 export interface InstalledPack {
   packId: string;
@@ -70,15 +71,17 @@ export class DomainPackInstallService {
   private readonly logger = new Logger(DomainPackInstallService.name);
   private readonly builtinIds = new Set(BUILTIN_PACKS.map((p) => p.id));
 
-  // The optional 4th dep serves the REINDEX_ON_PACK_INSTALL and seed-ingest
-  // queue hooks — fire-and-forget enqueues, not a responsibility worth a
-  // wrapper class.
+  // The optional 4th/5th deps are hooks — the REINDEX_ON_PACK_INSTALL /
+  // seed-ingest queue enqueues and the MCP pack-tools cache invalidation
+  // — fire-and-forget concerns, not responsibilities worth a wrapper
+  // class.
   // eslint-disable-next-line max-params
   constructor(
     private readonly surreal: SurrealService,
     private readonly embedder: EmbedderService,
     private readonly registry: PredicateRegistryService,
     @Optional() private readonly claim?: JobClaimService,
+    @Optional() private readonly packToolsReader?: PackToolsReaderService,
   ) {}
 
   /** Trust store: publisher → PEM public key, from DOMAIN_PACK_TRUSTED_KEYS
@@ -270,6 +273,7 @@ export class DomainPackInstallService {
     });
 
     this.registry.invalidate(companyId);
+    this.packToolsReader?.invalidate(companyId);
     this.logger.log(
       `Installed pack ${manifest.id} v${manifest.version} into ${companyId} (${seeded} predicate(s) seeded)`,
     );
@@ -537,6 +541,7 @@ export class DomainPackInstallService {
     });
 
     this.registry.invalidate(companyId);
+    this.packToolsReader?.invalidate(companyId);
     this.logger.log(
       `Uninstalled pack ${packId} from ${companyId} (${deprecated} predicate(s) deprecated)`,
     );

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import {
   BadRequestException,
   Injectable,
@@ -22,10 +22,15 @@ import {
   composePredicateId,
   diffPackUpgrade,
   DomainPackError,
+  externalMcpTools,
+  mcpConsentRequired,
+  mcpToolsChecksum,
   packChecksum,
   validatePack,
   type DomainPackManifest,
+  type PackExternalToolSpec,
 } from '../ai/domain-packs';
+import { assertPublicHttpUrl, EgressDeniedError } from '../common/egress-guard';
 
 export interface InstalledPack {
   packId: string;
@@ -124,17 +129,17 @@ export class DomainPackInstallService {
   async install(
     companyId: string,
     manifest: DomainPackManifest,
-    opts: { expectedChecksum?: string } = {},
+    opts: { expectedChecksum?: string; acceptMcpTools?: boolean } = {},
   ): Promise<{
     packId: string;
     version: string;
     predicatesSeeded: number;
     checksum: string;
     /**
-     * HMAC secret for indexer.external.callbackUrl pushes — present ONLY
-     * when freshly minted (first install of a callback-bearing pack).
-     * Shown once; relay it to the external indexer. Upgrades keep the
-     * existing secret and omit the field.
+     * HMAC secret for indexer.external.callbackUrl pushes AND external
+     * mcpTool calls — present ONLY when freshly minted (first install of
+     * a pack that needs one). Shown once; relay it to the external
+     * integration. Upgrades keep the existing secret and omit the field.
      */
     webhookSecret?: string;
     /** Present iff the manifest ships seedDocuments — whether their
@@ -184,78 +189,56 @@ export class DomainPackInstallService {
     });
 
     const newIds = predicates.map((p) => p.predicateId);
-    // A callback-bearing pack gets an HMAC secret for signed pushes
-    // (0065). Minted on first install; upgrades preserve the existing
-    // secret so the integration doesn't have to rotate on every bump.
-    const wantsWebhook = Boolean(manifest.indexer?.external?.callbackUrl);
+    // MCP tools (0068): egress-check every external endpoint up front,
+    // then require operator consent unless a prior install accepted the
+    // byte-identical section (see mcpConsentRequired).
+    const externalTools = externalMcpTools(manifest);
+    await this.assertToolEndpoints(externalTools);
+    const mcpChecksum = mcpToolsChecksum(manifest);
+    // A callback-bearing pack — or one declaring external MCP tools —
+    // gets an HMAC secret for signed pushes/calls (0065/0068). Minted on
+    // first install; upgrades preserve the existing secret so the
+    // integration doesn't have to rotate on every bump.
+    const wantsWebhook =
+      Boolean(manifest.indexer?.external?.callbackUrl) ||
+      externalTools.length > 0;
     let mintedSecret: string | undefined;
+    // Consent/upgrade SET fragment for the 0068 fields: stamped when the
+    // manifest declares tools (the consent gate has passed by then),
+    // cleared when an upgrade drops the section.
+    const mcpSet = mcpChecksum
+      ? `, acceptedMcpTools = true, acceptedMcpToolsChecksum = $mcpChecksum`
+      : `, acceptedMcpTools = NONE, acceptedMcpToolsChecksum = NONE`;
+    let mintedInstallId: string | undefined;
     const seeded = await this.surreal.withCompany(companyId, async (db) => {
       const [existing] = await db.query<[any[]]>(
-        `SELECT id, version, manifest, webhookSecret FROM domain_pack WHERE packId = $packId LIMIT 1`,
+        `SELECT id, version, manifest, webhookSecret, installId, acceptedMcpTools, acceptedMcpToolsChecksum FROM domain_pack WHERE packId = $packId LIMIT 1`,
         { packId: manifest.id },
       );
       const row = ((existing as any[]) ?? [])[0];
+      const consentMessage = mcpConsentRequired({
+        manifest,
+        acceptMcpTools: opts.acceptMcpTools,
+        priorAccepted: row?.acceptedMcpTools === true,
+        priorChecksum: row?.acceptedMcpToolsChecksum
+          ? String(row.acceptedMcpToolsChecksum)
+          : null,
+      });
+      if (consentMessage) throw new BadRequestException(consentMessage);
+      // installId (0068) — the opaque per-install identity external tool
+      // endpoints see instead of companyId. Minted once, kept forever.
+      if (externalTools.length > 0 && !row?.installId) {
+        mintedInstallId = randomUUID();
+      }
       if (row) {
-        // Reject a silent version downgrade — an out-of-order replay or a
-        // stale artifact must not quietly roll a tenant's ontology back.
-        if (compareSemver(manifest.version, String(row.version)) < 0) {
-          throw new BadRequestException(
-            `pack "${manifest.id}" v${manifest.version} is older than the installed v${row.version}; refusing to downgrade`,
-          );
-        }
-        const { changed, removedIds } = diffPackUpgrade(
-          manifest.id,
-          row.manifest as DomainPackManifest | undefined,
+        mintedSecret = await this.applyPackUpgrade({
+          db,
+          row,
           manifest,
-        );
-        if (wantsWebhook && !row.webhookSecret) {
-          mintedSecret = randomBytes(32).toString('hex');
-        }
-        await db.query(
-          `UPDATE $id SET version = $version, manifest = $manifest, checksum = $checksum, status = 'active', updatedAt = time::now()${
-            mintedSecret ? ', webhookSecret = $webhookSecret' : ''
-          }`,
-          {
-            id: row.id,
-            version: manifest.version,
-            manifest,
-            checksum,
-            ...(mintedSecret ? { webhookSecret: mintedSecret } : {}),
-          },
-        );
-        // Reinstall/upgrade: uninstall DEPRECATED this pack's predicates and
-        // seedMissingPredicates skips them (they exist by id), so without this
-        // they'd stay out of the active snapshot forever — the pack would read
-        // as installed but extract nothing. Reactivate the pack-owned rows the
-        // NEW manifest still declares (scoped to $newIds, so a predicate this
-        // upgrade dropped is NOT revived below; createdBy='admin' guards
-        // against reviving an operator's manual deprecation of a core id).
-        if (newIds.length) {
-          await db.query(
-            `UPDATE knowledge_predicate SET status = 'active', updatedAt = time::now()
-               WHERE predicateId IN $newIds
-                 AND status = 'deprecated'
-                 AND createdBy = 'admin'`,
-            { newIds },
-          );
-        }
-        // Apply redefined predicates. seedMissingPredicates only CREATEs absent
-        // ids, so an upgrade that edits a predicate (piiClass, semantics,
-        // description, …) would otherwise leave the tenant frozen at
-        // first-install values. MERGE preserves createdAt/version; re-embed the
-        // card since the description feeds the embedding.
-        await this.applyChangedPredicates(db, manifest.id, changed);
-        // Deprecate predicates the new manifest dropped (present before, gone
-        // now) — facts on them survive; they just leave the active vocab.
-        if (removedIds.length) {
-          await db.query(
-            `UPDATE knowledge_predicate SET status = 'deprecated', updatedAt = time::now()
-               WHERE predicateId IN $removedIds
-                 AND status != 'deprecated'
-                 AND createdBy = 'admin'`,
-            { removedIds },
-          );
-        }
+          checksum,
+          newIds,
+          mint: { wantsWebhook, mintedInstallId, mcpChecksum, mcpSet },
+        });
       } else {
         if (wantsWebhook) {
           mintedSecret = randomBytes(32).toString('hex');
@@ -268,6 +251,13 @@ export class DomainPackInstallService {
             checksum,
             status: 'active',
             ...(mintedSecret ? { webhookSecret: mintedSecret } : {}),
+            ...(mintedInstallId ? { installId: mintedInstallId } : {}),
+            ...(mcpChecksum
+              ? {
+                  acceptedMcpTools: true,
+                  acceptedMcpToolsChecksum: mcpChecksum,
+                }
+              : {}),
           },
         });
       }
@@ -293,6 +283,119 @@ export class DomainPackInstallService {
       ...(mintedSecret ? { webhookSecret: mintedSecret } : {}),
       ...(seedDocuments ? { seedDocuments } : {}),
     };
+  }
+
+  /**
+   * The existing-row branch of install(): downgrade fence, domain_pack
+   * row update (incl. the 0068 consent/identity fields), predicate
+   * reactivation, redefined-predicate apply, and dropped-predicate
+   * deprecation. Returns the freshly minted webhook secret, if any
+   * (upgrades preserve an existing one). Extracted from the install
+   * closure for the complexity gate.
+   */
+  private async applyPackUpgrade(opts: {
+    db: Surreal;
+    row: any;
+    manifest: DomainPackManifest;
+    checksum: string;
+    newIds: string[];
+    mint: {
+      wantsWebhook: boolean;
+      mintedInstallId?: string;
+      mcpChecksum: string | null;
+      mcpSet: string;
+    };
+  }): Promise<string | undefined> {
+    const { db, row, manifest, checksum, newIds, mint } = opts;
+    // Reject a silent version downgrade — an out-of-order replay or a
+    // stale artifact must not quietly roll a tenant's ontology back.
+    if (compareSemver(manifest.version, String(row.version)) < 0) {
+      throw new BadRequestException(
+        `pack "${manifest.id}" v${manifest.version} is older than the installed v${row.version}; refusing to downgrade`,
+      );
+    }
+    const { changed, removedIds } = diffPackUpgrade(
+      manifest.id,
+      row.manifest as DomainPackManifest | undefined,
+      manifest,
+    );
+    let mintedSecret: string | undefined;
+    if (mint.wantsWebhook && !row.webhookSecret) {
+      mintedSecret = randomBytes(32).toString('hex');
+    }
+    await db.query(
+      `UPDATE $id SET version = $version, manifest = $manifest, checksum = $checksum, status = 'active', updatedAt = time::now()${
+        mintedSecret ? ', webhookSecret = $webhookSecret' : ''
+      }${mint.mintedInstallId ? ', installId = $installId' : ''}${mint.mcpSet}`,
+      {
+        id: row.id,
+        version: manifest.version,
+        manifest,
+        checksum,
+        ...(mintedSecret ? { webhookSecret: mintedSecret } : {}),
+        ...(mint.mintedInstallId ? { installId: mint.mintedInstallId } : {}),
+        ...(mint.mcpChecksum ? { mcpChecksum: mint.mcpChecksum } : {}),
+      },
+    );
+    // Reinstall/upgrade: uninstall DEPRECATED this pack's predicates and
+    // seedMissingPredicates skips them (they exist by id), so without this
+    // they'd stay out of the active snapshot forever — the pack would read
+    // as installed but extract nothing. Reactivate the pack-owned rows the
+    // NEW manifest still declares (scoped to $newIds, so a predicate this
+    // upgrade dropped is NOT revived below; createdBy='admin' guards
+    // against reviving an operator's manual deprecation of a core id).
+    if (newIds.length) {
+      await db.query(
+        `UPDATE knowledge_predicate SET status = 'active', updatedAt = time::now()
+           WHERE predicateId IN $newIds
+             AND status = 'deprecated'
+             AND createdBy = 'admin'`,
+        { newIds },
+      );
+    }
+    // Apply redefined predicates. seedMissingPredicates only CREATEs absent
+    // ids, so an upgrade that edits a predicate (piiClass, semantics,
+    // description, …) would otherwise leave the tenant frozen at
+    // first-install values. MERGE preserves createdAt/version; re-embed the
+    // card since the description feeds the embedding.
+    await this.applyChangedPredicates(db, manifest.id, changed);
+    // Deprecate predicates the new manifest dropped (present before, gone
+    // now) — facts on them survive; they just leave the active vocab.
+    if (removedIds.length) {
+      await db.query(
+        `UPDATE knowledge_predicate SET status = 'deprecated', updatedAt = time::now()
+           WHERE predicateId IN $removedIds
+             AND status != 'deprecated'
+             AND createdBy = 'admin'`,
+        { removedIds },
+      );
+    }
+    return mintedSecret;
+  }
+
+  /**
+   * Install-time SSRF fence on external mcpTool endpoints: reject
+   * non-https (unless MCP_PACK_TOOLS_ALLOW_HTTP), embedded credentials,
+   * and hosts resolving to loopback/private/link-local/metadata ranges.
+   * The same guard re-runs on EVERY proxied call — this early check just
+   * turns a misdeclared pack into a clean 400 at review time.
+   */
+  private async assertToolEndpoints(
+    tools: PackExternalToolSpec[],
+  ): Promise<void> {
+    const allowHttp = envFlagEnabled(process.env.MCP_PACK_TOOLS_ALLOW_HTTP);
+    for (const tool of tools) {
+      try {
+        await assertPublicHttpUrl(tool.endpoint, { allowHttp });
+      } catch (e) {
+        if (e instanceof EgressDeniedError) {
+          throw new BadRequestException(
+            `mcpTool "${tool.name}": ${e.message}`,
+          );
+        }
+        throw e;
+      }
+    }
   }
 
   /**

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -28,6 +28,7 @@ export * from './manifest';
 export * from './validate';
 export * from './upgrade-diff';
 export * from './checksum';
+export * from './mcp-consent';
 export * from './signature';
 export * from './semver';
 export * from './eval-fixture';

--- a/src/ai/domain-packs/manifest.ts
+++ b/src/ai/domain-packs/manifest.ts
@@ -95,6 +95,15 @@ export interface DomainPackManifest {
    * Absent = 'virtual' — the pack rides the union extraction call.
    */
   indexer?: IndexerDescriptor;
+  /**
+   * MCP tools this pack contributes to the tenant's MCP surface (see
+   * PackToolSpec below and docs/mcp-pack-tools.md). Max 8. Deliberately
+   * NOT executable code: 'query' tools are declarative reads over the
+   * pack's own predicates; 'external' tools are HMAC-signed HTTPS
+   * proxies to the publisher's endpoint. Requires explicit operator
+   * consent at install time (`acceptMcpTools`).
+   */
+  mcpTools?: PackToolSpec[];
 }
 
 /** Compose the stored, namespaced predicate id for a pack-local predicate. */
@@ -147,3 +156,70 @@ export interface IndexerDescriptor {
     callbackUrl?: string;
   };
 }
+
+/**
+ * Pack-declared MCP tools (docs/mcp-pack-tools.md). The specs live INSIDE
+ * the signed/checksummed manifest, so signature and version-immutability
+ * cover them with zero new machinery. Registered tool names are
+ * namespaced `<packId>__<name>` — same separator discipline as
+ * predicates, so packs can't collide with core tools or each other.
+ *
+ * Settled product decision: NO in-process third-party code. A pack tool
+ * is either a declarative query over tenant knowledge ('query') or an
+ * HMAC-signed HTTPS proxy to the publisher's own endpoint ('external').
+ */
+
+/** One declared parameter of an external pack tool. */
+export interface PackToolParam {
+  /** snake_case name, `^[a-z][a-z0-9_]{0,30}$`, no `__`. */
+  name: string;
+  type: 'string' | 'number' | 'boolean';
+  /** Shown to the calling agent — sanitized + capped at 200 chars. */
+  description?: string;
+  required?: boolean;
+  /** string type only; ≤ 20 items, each ≤ 60 chars. */
+  enum?: string[];
+  /** string type only; 1..2000. */
+  maxLength?: number;
+}
+
+/** Declarative read over the tenant's knowledge, scoped to the pack's
+ *  own (namespaced) predicates. The server computes the predicate set —
+ *  a pack can never widen a tool onto core or another pack's vocabulary. */
+export interface PackQueryToolSpec {
+  kind: 'query';
+  /** `^[a-z][a-z0-9_]{1,40}$`, no `__`; registered as `<packId>__<name>`. */
+  name: string;
+  /** ≤ 80 chars (sanitized). */
+  title?: string;
+  /** ≤ 500 chars (sanitized, server preamble prepended). */
+  description: string;
+  query: {
+    surface: 'search' | 'facts_by_predicate';
+    /** localIds — MUST exist in pack.predicates. REQUIRED for
+     *  facts_by_predicate; absent on search = ALL pack predicates. */
+    predicates?: string[];
+    /** 1..20. */
+    defaultLimit?: number;
+    /** 0..1, search surface only. */
+    minConfidence?: number;
+  };
+}
+
+/** HTTPS-proxied tool: Brain POSTs the call (HMAC-signed with the pack's
+ *  install webhook secret) to the publisher-operated endpoint. The tenant
+ *  is identified by the opaque per-install `installId`, never companyId. */
+export interface PackExternalToolSpec {
+  kind: 'external';
+  name: string;
+  title?: string;
+  description: string;
+  /** ≤ 8 params. */
+  params?: PackToolParam[];
+  /** https URL (egress-guarded at install AND per call). */
+  endpoint: string;
+  /** default 10_000, range [1_000, 30_000]. */
+  timeoutMs?: number;
+}
+
+export type PackToolSpec = PackQueryToolSpec | PackExternalToolSpec;

--- a/src/ai/domain-packs/mcp-consent.ts
+++ b/src/ai/domain-packs/mcp-consent.ts
@@ -1,0 +1,72 @@
+import { createHash } from 'node:crypto';
+import { canonicalJson } from './checksum';
+import type {
+  DomainPackManifest,
+  PackExternalToolSpec,
+} from './manifest';
+
+/**
+ * Install-time consent for pack-declared MCP tools (docs/mcp-pack-tools.md).
+ *
+ * A pack that ships mcpTools changes the tenant's agent surface (new tool
+ * names/descriptions in every MCP client) and — for external tools —
+ * causes signed outbound calls to a publisher endpoint. That must be an
+ * explicit operator decision, not a side effect of installing an
+ * ontology. Consent is recorded WITH a checksum of the mcpTools section
+ * (canonical JSON, same primitive as packChecksum) so an upgrade that
+ * changes the section re-requires the flag, while an upgrade that leaves
+ * it untouched carries the prior consent over.
+ *
+ * Pure helpers — DomainPackInstallService owns the DB row and maps the
+ * returned message to a 400.
+ */
+
+/** sha256 hex of the canonical mcpTools section; null when absent/empty. */
+export function mcpToolsChecksum(manifest: DomainPackManifest): string | null {
+  if (!Array.isArray(manifest.mcpTools) || manifest.mcpTools.length === 0) {
+    return null;
+  }
+  return createHash('sha256')
+    .update(canonicalJson(manifest.mcpTools))
+    .digest('hex');
+}
+
+/** The manifest's external mcpTools (empty array when none declared). */
+export function externalMcpTools(
+  manifest: DomainPackManifest,
+): PackExternalToolSpec[] {
+  return (manifest.mcpTools ?? []).filter(
+    (t): t is PackExternalToolSpec => t.kind === 'external',
+  );
+}
+
+/**
+ * Decide whether this install/upgrade needs the `acceptMcpTools` flag.
+ * Returns the client-facing refusal message (listing every tool's
+ * name/kind/endpoint so the operator reviews exactly what they accept),
+ * or null when consent is granted or not required.
+ */
+export function mcpConsentRequired(opts: {
+  manifest: DomainPackManifest;
+  acceptMcpTools: boolean | undefined;
+  /** Prior row state — pass false/null on a fresh install. */
+  priorAccepted: boolean;
+  priorChecksum: string | null;
+}): string | null {
+  const checksum = mcpToolsChecksum(opts.manifest);
+  if (!checksum) return null; // no tools declared — nothing to consent to
+  if (opts.acceptMcpTools === true) return null;
+  if (opts.priorAccepted && opts.priorChecksum === checksum) return null;
+  const listing = (opts.manifest.mcpTools ?? [])
+    .map((t) =>
+      t.kind === 'external'
+        ? `external "${t.name}" → ${t.endpoint}`
+        : `query "${t.name}" (${t.query.surface})`,
+    )
+    .join('; ');
+  return (
+    `pack "${opts.manifest.id}" v${opts.manifest.version} declares ` +
+    `${opts.manifest.mcpTools?.length} MCP tool(s): ${listing}. ` +
+    `Review them and repeat the install with acceptMcpTools: true.`
+  );
+}

--- a/src/ai/domain-packs/validate.ts
+++ b/src/ai/domain-packs/validate.ts
@@ -6,6 +6,7 @@ import {
   SEED_MAX_DOCS,
   SEED_TOTAL_MAX_CHARS,
   type DomainPackManifest,
+  type PackToolParam,
 } from './manifest';
 
 /**
@@ -107,6 +108,9 @@ export function validatePack(pack: DomainPackManifest): void {
   }
   if (pack.indexer !== undefined) {
     validateIndexerDescriptor(pack.id, pack.indexer);
+  }
+  if (pack.mcpTools !== undefined) {
+    validateMcpTools(pack, pack.mcpTools);
   }
 }
 
@@ -451,6 +455,287 @@ function validateExtractionProfile(packId: string, profile: unknown): void {
           `pack "${packId}" extractionProfile.fewShot entries must be { text: string, note: string }`,
         );
       }
+    }
+  }
+}
+
+// ── MCP pack tools (docs/mcp-pack-tools.md) ──────────────────────────
+
+const TOOL_NAME = /^[a-z][a-z0-9_]{1,40}$/;
+const PARAM_NAME = /^[a-z][a-z0-9_]{0,30}$/;
+const TOOL_KINDS = new Set(['query', 'external']);
+const QUERY_SURFACES = new Set(['search', 'facts_by_predicate']);
+const MAX_TOOLS = 8;
+const MAX_TOOL_PARAMS = 8;
+
+/**
+ * Validate the pack's declared MCP tools (PackToolSpec[] in manifest.ts).
+ * Structural + referential only (predicates must be the pack's OWN
+ * localIds) and deliberately env-free: the https-only rule for external
+ * endpoints is enforced at install/call time by the egress guard, so a
+ * pure `pnpm pack:validate` run gives an author the same verdict a
+ * server would. Exported: the MCP reader re-runs it defensively against
+ * stored manifests before registering anything.
+ */
+export function validateMcpTools(pack: DomainPackManifest, tools: unknown): void {
+  if (!Array.isArray(tools) || tools.length === 0) {
+    throw new DomainPackError(
+      `pack "${pack.id}" mcpTools must be a non-empty array`,
+    );
+  }
+  if (tools.length > MAX_TOOLS) {
+    throw new DomainPackError(
+      `pack "${pack.id}" declares ${tools.length} mcpTools — max is ${MAX_TOOLS}`,
+    );
+  }
+  const localIds = new Set(pack.predicates.map((p) => p.localId));
+  const seen = new Set<string>();
+  for (const t of tools) {
+    if (t === null || typeof t !== 'object' || Array.isArray(t)) {
+      throw new DomainPackError(`pack "${pack.id}" mcpTools entries must be objects`);
+    }
+    const tool = t as {
+      kind?: unknown;
+      name?: unknown;
+      title?: unknown;
+      description?: unknown;
+    };
+    if (!TOOL_KINDS.has(tool.kind as string)) {
+      throw new DomainPackError(
+        `pack "${pack.id}" mcpTool kind "${tool.kind}" must be one of ${[...TOOL_KINDS].join('|')}`,
+      );
+    }
+    const name = tool.name as string;
+    if (
+      typeof name !== 'string' ||
+      !TOOL_NAME.test(name) ||
+      name.includes(PACK_NAMESPACE_SEP)
+    ) {
+      throw new DomainPackError(
+        `pack "${pack.id}" mcpTool name "${name}" must match ${TOOL_NAME} and must not contain "${PACK_NAMESPACE_SEP}"`,
+      );
+    }
+    if (seen.has(name)) {
+      throw new DomainPackError(
+        `pack "${pack.id}" declares duplicate mcpTool name "${name}"`,
+      );
+    }
+    seen.add(name);
+    if (tool.title !== undefined && (typeof tool.title !== 'string' || tool.title.length > 80)) {
+      throw new DomainPackError(
+        `pack "${pack.id}" mcpTool "${name}" title must be a string of at most 80 characters`,
+      );
+    }
+    if (
+      typeof tool.description !== 'string' ||
+      tool.description.length === 0 ||
+      tool.description.length > 500
+    ) {
+      throw new DomainPackError(
+        `pack "${pack.id}" mcpTool "${name}" description must be a non-empty string of at most 500 characters`,
+      );
+    }
+    if (tool.kind === 'query') {
+      validateQueryTool({ packId: pack.id, name, tool: t, localIds });
+    } else {
+      validateExternalTool(pack.id, name, t);
+    }
+  }
+}
+
+function validateQueryTool({
+  packId,
+  name,
+  tool,
+  localIds,
+}: {
+  packId: string;
+  name: string;
+  tool: unknown;
+  localIds: Set<string>;
+}): void {
+  const { query } = tool as { query?: unknown };
+  if (typeof query !== 'object' || query === null || Array.isArray(query)) {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" needs a query object`,
+    );
+  }
+  const q = query as {
+    surface?: unknown;
+    predicates?: unknown;
+    defaultLimit?: unknown;
+    minConfidence?: unknown;
+  };
+  if (!QUERY_SURFACES.has(q.surface as string)) {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" query.surface "${q.surface}" must be one of ${[...QUERY_SURFACES].join('|')}`,
+    );
+  }
+  if (q.predicates !== undefined) {
+    if (
+      !Array.isArray(q.predicates) ||
+      q.predicates.length === 0 ||
+      q.predicates.some((p) => typeof p !== 'string')
+    ) {
+      throw new DomainPackError(
+        `pack "${packId}" mcpTool "${name}" query.predicates must be a non-empty array of localIds`,
+      );
+    }
+    for (const p of q.predicates) {
+      if (!localIds.has(p as string)) {
+        throw new DomainPackError(
+          `pack "${packId}" mcpTool "${name}" query.predicates references "${p}", which is not a predicate of this pack`,
+        );
+      }
+    }
+  } else if (q.surface === 'facts_by_predicate') {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" surface facts_by_predicate requires query.predicates`,
+    );
+  }
+  if (
+    q.defaultLimit !== undefined &&
+    (typeof q.defaultLimit !== 'number' ||
+      !Number.isInteger(q.defaultLimit) ||
+      q.defaultLimit < 1 ||
+      q.defaultLimit > 20)
+  ) {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" query.defaultLimit must be an integer in [1, 20]`,
+    );
+  }
+  if (q.minConfidence !== undefined) {
+    if (q.surface !== 'search') {
+      throw new DomainPackError(
+        `pack "${packId}" mcpTool "${name}" query.minConfidence applies to the search surface only`,
+      );
+    }
+    if (
+      typeof q.minConfidence !== 'number' ||
+      q.minConfidence < 0 ||
+      q.minConfidence > 1
+    ) {
+      throw new DomainPackError(
+        `pack "${packId}" mcpTool "${name}" query.minConfidence must be a number in [0, 1]`,
+      );
+    }
+  }
+}
+
+function validateExternalTool(packId: string, name: string, tool: unknown): void {
+  const t = tool as { endpoint?: unknown; timeoutMs?: unknown; params?: unknown };
+  // Pure structural URL check — http accepted here so the validator stays
+  // env-free; https-only (and the private-address fence) is enforced by
+  // the egress guard at install time and again on every call.
+  let parsed: URL | null = null;
+  try {
+    parsed = new URL(t.endpoint as string);
+  } catch {
+    parsed = null;
+  }
+  if (!parsed || (parsed.protocol !== 'https:' && parsed.protocol !== 'http:')) {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" endpoint must be a valid http(s) URL`,
+    );
+  }
+  if (
+    t.timeoutMs !== undefined &&
+    (typeof t.timeoutMs !== 'number' ||
+      !Number.isInteger(t.timeoutMs) ||
+      t.timeoutMs < 1_000 ||
+      t.timeoutMs > 30_000)
+  ) {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" timeoutMs must be an integer in [1000, 30000]`,
+    );
+  }
+  if (t.params === undefined) return;
+  if (!Array.isArray(t.params) || t.params.length > MAX_TOOL_PARAMS) {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" params must be an array of at most ${MAX_TOOL_PARAMS}`,
+    );
+  }
+  const seen = new Set<string>();
+  for (const p of t.params) {
+    validateToolParam(packId, name, p);
+    const pname = (p as PackToolParam).name;
+    if (seen.has(pname)) {
+      throw new DomainPackError(
+        `pack "${packId}" mcpTool "${name}" declares duplicate param "${pname}"`,
+      );
+    }
+    seen.add(pname);
+  }
+}
+
+const TOOL_PARAM_TYPES = new Set(['string', 'number', 'boolean']);
+
+function validateToolParam(packId: string, name: string, param: unknown): void {
+  if (param === null || typeof param !== 'object' || Array.isArray(param)) {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" params entries must be objects`,
+    );
+  }
+  const p = param as Partial<PackToolParam>;
+  if (
+    typeof p.name !== 'string' ||
+    !PARAM_NAME.test(p.name) ||
+    p.name.includes(PACK_NAMESPACE_SEP)
+  ) {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" param name "${p.name}" must match ${PARAM_NAME} and must not contain "${PACK_NAMESPACE_SEP}"`,
+    );
+  }
+  if (!TOOL_PARAM_TYPES.has(p.type as string)) {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" param "${p.name}" type must be one of ${[...TOOL_PARAM_TYPES].join('|')}`,
+    );
+  }
+  if (
+    p.description !== undefined &&
+    (typeof p.description !== 'string' || p.description.length > 200)
+  ) {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" param "${p.name}" description must be a string of at most 200 characters`,
+    );
+  }
+  if (p.required !== undefined && typeof p.required !== 'boolean') {
+    throw new DomainPackError(
+      `pack "${packId}" mcpTool "${name}" param "${p.name}" required must be a boolean`,
+    );
+  }
+  if (p.enum !== undefined) {
+    if (p.type !== 'string') {
+      throw new DomainPackError(
+        `pack "${packId}" mcpTool "${name}" param "${p.name}" enum applies to string params only`,
+      );
+    }
+    if (
+      !Array.isArray(p.enum) ||
+      p.enum.length === 0 ||
+      p.enum.length > 20 ||
+      p.enum.some((v) => typeof v !== 'string' || v.length === 0 || v.length > 60)
+    ) {
+      throw new DomainPackError(
+        `pack "${packId}" mcpTool "${name}" param "${p.name}" enum must be 1..20 non-empty strings of at most 60 characters`,
+      );
+    }
+  }
+  if (p.maxLength !== undefined) {
+    if (p.type !== 'string') {
+      throw new DomainPackError(
+        `pack "${packId}" mcpTool "${name}" param "${p.name}" maxLength applies to string params only`,
+      );
+    }
+    if (
+      typeof p.maxLength !== 'number' ||
+      !Number.isInteger(p.maxLength) ||
+      p.maxLength < 1 ||
+      p.maxLength > 2_000
+    ) {
+      throw new DomainPackError(
+        `pack "${packId}" mcpTool "${name}" param "${p.name}" maxLength must be an integer in [1, 2000]`,
+      );
     }
   }
 }

--- a/src/common/egress-guard.ts
+++ b/src/common/egress-guard.ts
@@ -1,0 +1,96 @@
+import { promises as dns } from 'node:dns';
+
+/**
+ * SSRF fence for operator-supplied outbound URLs (pack-declared external
+ * MCP tool endpoints). Pure module — no Nest, no config; callers pass
+ * `allowHttp` from their own flag.
+ *
+ * The check resolves the host and rejects when ANY address is
+ * loopback / private / link-local / ULA / unspecified — which covers the
+ * cloud metadata endpoint (169.254.169.254). Known limitation (stated in
+ * docs/mcp-pack-tools.md): the address is not pinned between this check
+ * and the subsequent fetch, so a fast-flux DNS rebind is a residual
+ * risk; the check runs at install time AND per call to narrow the window.
+ */
+export class EgressDeniedError extends Error {}
+
+export async function assertPublicHttpUrl(
+  rawUrl: string,
+  opts: { allowHttp?: boolean } = {},
+): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new EgressDeniedError(`"${rawUrl}" is not a valid URL`);
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new EgressDeniedError(
+      `endpoint "${rawUrl}" must use http(s), got ${url.protocol}`,
+    );
+  }
+  if (url.username || url.password) {
+    throw new EgressDeniedError(
+      `endpoint must not embed credentials in the URL`,
+    );
+  }
+  if (opts.allowHttp) {
+    // Dev/test escape hatch (MCP_PACK_TOOLS_ALLOW_HTTP): permits plain
+    // http AND loopback/private targets so a local endpoint is testable.
+    // Never enable in production — it disables the SSRF fence entirely.
+    return;
+  }
+  if (url.protocol !== 'https:') {
+    throw new EgressDeniedError(`endpoint "${rawUrl}" must use https`);
+  }
+  // URL keeps IPv6 literals bracketed ("[::1]") — strip for lookup.
+  const host = url.hostname.replace(/^\[|\]$/g, '');
+  let addrs: Array<{ address: string; family: number }>;
+  try {
+    addrs = await dns.lookup(host, { all: true });
+  } catch {
+    throw new EgressDeniedError(`cannot resolve endpoint host "${host}"`);
+  }
+  for (const { address, family } of addrs) {
+    const blocked =
+      family === 6 ? isBlockedIPv6(address) : isBlockedIPv4(address);
+    if (blocked) {
+      throw new EgressDeniedError(
+        `endpoint host "${host}" resolves to a non-public address (${address})`,
+      );
+    }
+  }
+}
+
+/** 0/8 (unspecified), 127/8, 10/8, 172.16/12, 192.168/16, 169.254/16. */
+function isBlockedIPv4(ip: string): boolean {
+  const parts = ip.split('.').map(Number);
+  if (
+    parts.length !== 4 ||
+    parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)
+  ) {
+    return true; // unparseable → fail closed
+  }
+  const [a, b] = parts;
+  return (
+    a === 0 ||
+    a === 127 ||
+    a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254)
+  );
+}
+
+/** ::, ::1, fc00::/7 (ULA), fe80::/10 (link-local), IPv4-mapped. */
+function isBlockedIPv6(ip: string): boolean {
+  const bare = ip.toLowerCase().split('%')[0];
+  if (bare === '::' || bare === '::1') return true;
+  const mapped = bare.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isBlockedIPv4(mapped[1]);
+  const first = parseInt(bare.split(':')[0] || '0', 16);
+  if (!Number.isFinite(first)) return true;
+  if ((first & 0xfe00) === 0xfc00) return true;
+  if ((first & 0xffc0) === 0xfe80) return true;
+  return false;
+}

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -167,6 +167,9 @@ validateAbacEnv(env, errors);
   // ── Chat-route NLI intent classifier ───────────────────────────────
   positiveInt(env, 'CHAT_ROUTE_NLI_TIMEOUT_MS', errors);
 
+  // ── MCP pack tools (migration 0068) ────────────────────────────────
+  positiveInt(env, 'MCP_PACK_TOOLS_CACHE_TTL_MS', errors);
+
   // ── Worker-loop concurrency (per-jobType poller) ────────────────────
   validateWorkerConcurrencyEnv(env, errors);
 
@@ -407,6 +410,14 @@ const KNOWN_BOOLEAN_FLAGS = [
   // envFlagEnabled, so only an explicit 0/false skips pack seed ingest.
   'PACK_SEED_INGEST_ENABLED',
   'DOMAIN_PACK_BILLING_ENABLED',
+  'MCP_PACK_TOOLS_ENABLED',
+  // Default-ON under the master flag: read as
+  // `MCP_PACK_QUERY_TOOLS_ENABLED ?? '1'` before envFlagEnabled.
+  'MCP_PACK_QUERY_TOOLS_ENABLED',
+  'MCP_PACK_EXTERNAL_TOOLS_ENABLED',
+  // Dev/test only — permits http + loopback endpoints (disables the
+  // egress guard's SSRF fence for pack tool calls).
+  'MCP_PACK_TOOLS_ALLOW_HTTP',
 ];
 
 /**

--- a/src/contracts/admin/packs.schema.ts
+++ b/src/contracts/admin/packs.schema.ts
@@ -29,12 +29,19 @@ export const PacksListResponseSchema = z.object({
 export const InstallPackRequestSchema = z.object({
   manifest: DomainPackManifestSchema,
   expectedChecksum: z.string().optional(),
+  /** Explicit consent to the manifest's mcpTools section (docs/
+   *  mcp-pack-tools.md). Required (400 otherwise) whenever the section is
+   *  non-empty, unless a prior install already accepted the identical
+   *  section — an upgrade that CHANGES it re-requires the flag. */
+  acceptMcpTools: z.boolean().optional(),
 });
 
 export const InstallFromRegistryRequestSchema = z.object({
   packId: z.string(),
   /** Absent = latest non-yanked registry version. */
   version: z.string().optional(),
+  /** See InstallPackRequest.acceptMcpTools — same consent gate. */
+  acceptMcpTools: z.boolean().optional(),
 });
 
 export const InstallPackResponseSchema = z.object({
@@ -57,6 +64,10 @@ export const InstallPackResponseSchema = z.object({
     .describe(
       'Present iff the manifest ships seedDocuments — whether their document-pipeline ingest was enqueued. Install never fails because of seeds.',
     ),
+  /** HMAC secret for indexer webhook pushes AND external mcpTool calls —
+   *  present ONLY when freshly minted (first install of a pack that needs
+   *  one). Shown once; upgrades keep the existing secret and omit this. */
+  webhookSecret: z.string().optional(),
 });
 
 export const UninstallPackResponseSchema = z.object({

--- a/src/contracts/registry/registry.schema.ts
+++ b/src/contracts/registry/registry.schema.ts
@@ -100,6 +100,10 @@ export const DomainPackManifestSchema = z.looseObject({
   ),
   publisher: z.string().optional(),
   indexer: z.record(z.string(), z.unknown()).optional(),
+  /** Pack-declared MCP tools (PackToolSpec[] — docs/mcp-pack-tools.md).
+   *  NO raw JSON Schema passthrough by design; runtime validation is
+   *  validateMcpTools on the install/publish path. */
+  mcpTools: z.array(z.record(z.string(), z.unknown())).optional(),
 });
 
 export const PublishPackRequestSchema = z.object({

--- a/src/db/migrations/0068_domain_pack_mcp_tools.surql
+++ b/src/db/migrations/0068_domain_pack_mcp_tools.surql
@@ -1,0 +1,7 @@
+-- 0068_domain_pack_mcp_tools — per-install identity + consent for pack-declared
+-- MCP tools. installId is the opaque id sent to external tool endpoints
+-- (never companyId). Consent is stored with a checksum of the mcpTools
+-- section so an upgrade that changes the section requires re-consent.
+DEFINE FIELD IF NOT EXISTS installId ON domain_pack TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS acceptedMcpTools ON domain_pack TYPE option<bool>;
+DEFINE FIELD IF NOT EXISTS acceptedMcpToolsChecksum ON domain_pack TYPE option<string>;

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -9,6 +9,7 @@ import {
   makeRowPolicyFilter,
   type PolicyFilterableRow,
 } from '../policy/row-filter';
+import { activeFactWhere } from '../entities/entity-read.helpers';
 
 /**
  * Predicate-class allowlist that requires `brain:admin` for retract,
@@ -393,6 +394,90 @@ export class FactsService {
         asOf: asOf ? asOf.toISOString() : undefined,
         groups: Array.from(groupMap.values()),
       };
+    });
+  }
+
+  /**
+   * Active-believed-now facts for ONE predicate, optionally scoped to an
+   * entity — the `facts_by_predicate` surface of pack-declared MCP query
+   * tools (docs/mcp-pack-tools.md). The caller (registerPackTools) has
+   * already composed the namespaced predicate id from the pack manifest,
+   * so this read can never leave the pack's own vocabulary. Mold:
+   * EntitiesService.getTimeline — scoped pool, bitemporal closure pushed
+   * into WHERE, overfetch ×2 for the row fence, slice after filtering.
+   */
+  async listByPredicate(opts: {
+    companyId: string;
+    /** FULL namespaced predicate id (`<packId>__<localId>`). */
+    predicate: string;
+    /** Optional entity scope — short or `knowledge_entity:` form. */
+    entityIdRaw?: string;
+    limit: number;
+    scopes: readonly BrainScope[];
+  }): Promise<{
+    predicate: string;
+    found: number;
+    facts: Array<{
+      factId: string;
+      entityId: string;
+      predicate: string;
+      object: string;
+      confidence: number;
+      validFrom: string;
+      validUntil?: string;
+      recordedAt: string;
+      status: string;
+    }>;
+  }> {
+    const { companyId, predicate, entityIdRaw, limit, scopes } = opts;
+    return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
+      const { clauses: activeClauses, params: activeParams } =
+        activeFactWhere(null);
+      const clauses = [
+        `predicate = $predicate`,
+        // User scope (0055): pack tool reads are tenant-global v1.
+        `userId IS NONE`,
+        ...activeClauses,
+      ];
+      const params: Record<string, unknown> = { predicate, ...activeParams };
+      if (entityIdRaw) {
+        const ref = this.normalizeEntityId(entityIdRaw);
+        clauses.push(`entityId = type::record('knowledge_entity:' + $rid)`);
+        params.rid = ref.id;
+      }
+      // ×2 headroom so the scope/ABAC row fence doesn't starve the page.
+      const overfetch = Math.min(limit * 2, 100);
+      const [rows] = await db.query<any[][]>(
+        `SELECT id, entityId, predicate, object, confidence,
+                validFrom, validUntil, recordedAt, status,
+                source, trustSnapshot, corroboration, userId
+           FROM knowledge_fact
+           WHERE ${clauses.join(' AND ')}
+           ORDER BY recordedAt DESC
+           LIMIT ${overfetch}`,
+        params,
+      );
+      const rowPolicy = makeRowPolicyFilter({
+        callerScopes: scopes,
+        surface: 'pack_facts_by_predicate',
+        policyLookup: await this.predicateRegistry?.rowPolicyLookup(companyId),
+      });
+      const visible = (((rows as any[]) ?? []) as PolicyFilterableRow[]).filter(
+        (r) => rowPolicy.filter(r),
+      );
+      rowPolicy.finish();
+      const facts = (visible as any[]).slice(0, limit).map((r) => ({
+        factId: String(r.id),
+        entityId: String(r.entityId),
+        predicate: String(r.predicate),
+        object: String(r.object),
+        confidence: typeof r.confidence === 'number' ? r.confidence : 0,
+        validFrom: toIso(r.validFrom),
+        validUntil: r.validUntil ? toIso(r.validUntil) : undefined,
+        recordedAt: toIso(r.recordedAt),
+        status: String(r.status),
+      }));
+      return { predicate, found: facts.length, facts };
     });
   }
 

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -84,9 +84,10 @@ export class McpController {
       );
     }
 
-    const server = this.mcp.buildServer(auth.companyId, auth.scopes, {
+    const server = await this.mcp.buildServer(auth.companyId, auth.scopes, {
       actorKeyHash: auth.keyHash,
       policy: auth.policy,
+      packIds: auth.packIds,
     });
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined, // stateless

--- a/src/mcp/mcp.module.ts
+++ b/src/mcp/mcp.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { McpController } from './mcp.controller';
 import { McpService } from './mcp.service';
+import { PackToolsReaderService } from './pack-tools-reader.service';
 import { SearchModule } from '../search/search.module';
 import { EntitiesModule } from '../entities/entities.module';
 import { IngestModule } from '../ingest/ingest.module';
@@ -34,6 +35,9 @@ import { FeedbackModule } from '../feedback/feedback.module';
     FeedbackModule,
   ],
   controllers: [McpController],
-  providers: [McpService],
+  providers: [McpService, PackToolsReaderService],
+  // Exported for DomainPackInstallService's cache invalidation hook
+  // (AdminModule imports McpModule).
+  exports: [PackToolsReaderService],
 })
 export class McpModule {}

--- a/src/mcp/mcp.module.ts
+++ b/src/mcp/mcp.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { McpController } from './mcp.controller';
 import { McpService } from './mcp.service';
 import { PackToolsReaderService } from './pack-tools-reader.service';
+import { PackToolProxyService } from './pack-tool-proxy.service';
 import { SearchModule } from '../search/search.module';
 import { EntitiesModule } from '../entities/entities.module';
 import { IngestModule } from '../ingest/ingest.module';
@@ -35,7 +36,7 @@ import { FeedbackModule } from '../feedback/feedback.module';
     FeedbackModule,
   ],
   controllers: [McpController],
-  providers: [McpService, PackToolsReaderService],
+  providers: [McpService, PackToolsReaderService, PackToolProxyService],
   // Exported for DomainPackInstallService's cache invalidation hook
   // (AdminModule imports McpModule).
   exports: [PackToolsReaderService],

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -29,7 +29,14 @@ import { DocumentIngestService } from '../documents/document-ingest.service';
 import { FeedbackService } from '../feedback/feedback.service';
 import { PolicyGateService } from '../policy/policy-gate.service';
 import { evaluateAction } from '../policy/policy-engine';
-import { PolicyContext } from '../policy/policy.types';
+import { ActionKind, PolicyContext } from '../policy/policy.types';
+import { envFlagEnabled } from '../common/env-validation';
+import { PACK_NAMESPACE_SEP } from '../ai/domain-packs';
+import {
+  PackToolsReaderService,
+  type PackToolBinding,
+} from './pack-tools-reader.service';
+import { registerPackTools } from './pack-tools';
 
 const MCP_SERVER_VERSION = '0.3.0';
 
@@ -96,6 +103,7 @@ export class McpService {
     private readonly documents: DocumentIngestService,
     private readonly feedback: FeedbackService,
     private readonly policyGate: PolicyGateService,
+    private readonly packToolsReader: PackToolsReaderService,
   ) {}
 
   /**
@@ -151,16 +159,24 @@ export class McpService {
       }) as never);
   }
 
-  private applyPolicyToolGate(server: McpServer, policy: PolicyContext): void {
+  // `kinds` carries the explicit read/write classification for tool
+  // names OUTSIDE the static action registry (pack-declared tools:
+  // query=read, external=write); registry names resolve as before.
+  private applyPolicyToolGate(
+    server: McpServer,
+    policy: PolicyContext,
+    kinds?: ReadonlyMap<string, ActionKind>,
+  ): void {
     const raw = server.registerTool.bind(server);
     (server as McpServer & { registerTool: unknown }).registerTool = (
       name: string,
       config: unknown,
       handler: (...args: unknown[]) => unknown,
     ) => {
-      const denied = evaluateAction(policy, name).decision === 'deny';
+      const denied =
+        evaluateAction(policy, name, kinds?.get(name)).decision === 'deny';
       const tool = raw(name as never, config as never, ((...args: unknown[]) => {
-        this.policyGate.enforceAction(policy, name);
+        this.policyGate.enforceToolAction(policy, name, kinds?.get(name));
         return handler(...args);
       }) as never);
       // Enforce-denied tools unregister immediately: gone from
@@ -203,7 +219,7 @@ export class McpService {
     }
   }
 
-  buildServer(
+  async buildServer(
     companyId: string,
     scopes: BrainScope[],
     caller?: {
@@ -218,16 +234,33 @@ export class McpService {
        * policies attached, tool surface identical to pre-ABAC.
        */
       policy?: PolicyContext;
+      /**
+       * Per-pack key binding (ApiKeyRecord.packIds): a bound key sees
+       * only its packs' declared tools; absent = every consented pack.
+       */
+      packIds?: string[];
     },
-  ): McpServer {
+  ): Promise<McpServer> {
     const actorKeyHash = caller?.actorKeyHash;
     const policy = caller?.policy;
+    // Bindings are fetched BEFORE the wrappers so the ABAC gate knows
+    // each pack tool's read/write kind at registration time.
+    const packBindings = await this.packToolBindings(companyId, caller?.packIds);
+    const packToolKinds = new Map<string, ActionKind>();
+    for (const b of packBindings) {
+      for (const t of b.tools) {
+        packToolKinds.set(
+          `${b.packId}${PACK_NAMESPACE_SEP}${t.name}`,
+          t.kind === 'query' ? 'read' : 'write',
+        );
+      }
+    }
     const server = new McpServer({
       name: 'inite-brain-service',
       version: MCP_SERVER_VERSION,
     });
     this.wrapToolErrors(server);
-    if (policy) this.applyPolicyToolGate(server, policy);
+    if (policy) this.applyPolicyToolGate(server, policy, packToolKinds);
     registerReadTools({
       server,
       companyId,
@@ -289,6 +322,29 @@ export class McpService {
         actorKeyHash: actorKeyHash ?? `mcp:${companyId}`,
       });
     }
+    registerPackTools({
+      server,
+      companyId,
+      scopes,
+      bindings: packBindings,
+      deps: { search: this.search, facts: this.facts },
+    });
     return server;
+  }
+
+  /**
+   * Consented pack tool bindings for this request — [] when the master
+   * flag is off (no DB round-trip on the pre-existing surface), fenced
+   * to the key's packIds binding when one is present.
+   */
+  private async packToolBindings(
+    companyId: string,
+    packIds?: string[],
+  ): Promise<PackToolBinding[]> {
+    if (!envFlagEnabled(process.env.MCP_PACK_TOOLS_ENABLED)) return [];
+    const bindings = await this.packToolsReader.installedPackTools(companyId);
+    return packIds
+      ? bindings.filter((b) => packIds.includes(b.packId))
+      : bindings;
   }
 }

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -36,6 +36,7 @@ import {
   PackToolsReaderService,
   type PackToolBinding,
 } from './pack-tools-reader.service';
+import { PackToolProxyService } from './pack-tool-proxy.service';
 import { registerPackTools } from './pack-tools';
 
 const MCP_SERVER_VERSION = '0.3.0';
@@ -104,6 +105,7 @@ export class McpService {
     private readonly feedback: FeedbackService,
     private readonly policyGate: PolicyGateService,
     private readonly packToolsReader: PackToolsReaderService,
+    private readonly packToolProxy: PackToolProxyService,
   ) {}
 
   /**
@@ -327,7 +329,11 @@ export class McpService {
       companyId,
       scopes,
       bindings: packBindings,
-      deps: { search: this.search, facts: this.facts },
+      deps: {
+        search: this.search,
+        facts: this.facts,
+        proxy: this.packToolProxy,
+      },
     });
     return server;
   }

--- a/src/mcp/pack-tool-proxy.service.ts
+++ b/src/mcp/pack-tool-proxy.service.ts
@@ -1,0 +1,213 @@
+import { createHmac, randomUUID } from 'node:crypto';
+import { HttpException, Injectable, Logger } from '@nestjs/common';
+import { envFlagEnabled } from '../common/env-validation';
+import { assertPublicHttpUrl, EgressDeniedError } from '../common/egress-guard';
+import type { PackExternalToolSpec } from '../ai/domain-packs';
+import { sanitizePackText } from './pack-tool-render';
+import type { PackToolBinding } from './pack-tools-reader.service';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_TIMEOUT_MS = 30_000;
+const MAX_RESPONSE_BYTES = 64 * 1024;
+const BREAKER_THRESHOLD = 3;
+const BREAKER_MS = 60_000;
+
+/** Shape handed straight back as the MCP tool result. */
+export interface PackToolCallResult {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: Record<string, unknown>;
+}
+
+/**
+ * Outbound proxy for pack-declared EXTERNAL MCP tools
+ * (docs/mcp-pack-tools.md): Brain POSTs the call to the publisher's
+ * endpoint, HMAC-signed with the pack's per-install webhook secret
+ * (indexer-webhook mold), and relays a bounded response. Privacy
+ * invariant: the wire carries the opaque installId, never companyId.
+ *
+ * Failure posture is deliberate: NO retries (a tool call is not a
+ * best-effort hint — the agent should see the failure and decide), a
+ * per-endpoint circuit breaker (3 consecutive transport failures latch
+ * 60 s), and a 64 KB response cap so a misbehaving endpoint can't pin
+ * memory. Errors surface as HTTP 424 (< 500, so wrapToolErrors passes
+ * the sanitized message through instead of masking it).
+ */
+@Injectable()
+export class PackToolProxyService {
+  private readonly logger = new Logger(PackToolProxyService.name);
+  /** endpoint → consecutive transport failures + latch expiry. */
+  private readonly breaker = new Map<string, { fails: number; until: number }>();
+
+  async call(opts: {
+    binding: PackToolBinding;
+    tool: PackExternalToolSpec;
+    args: Record<string, unknown>;
+  }): Promise<PackToolCallResult> {
+    const { binding, tool } = opts;
+    const endpoint = tool.endpoint;
+    const latched = this.breaker.get(endpoint);
+    if (latched && Date.now() < latched.until) {
+      throw upstreamError(
+        'external tool endpoint is temporarily unavailable (circuit open)',
+      );
+    }
+    if (!binding.webhookSecret || !binding.installId) {
+      // Pre-0068 install rows lack the identity/secret pair; an
+      // unsigned call is worse than none. Reinstalling mints both.
+      throw upstreamError(
+        `pack "${binding.packId}" has no install identity for external tools — reinstall the pack`,
+      );
+    }
+    // Same SSRF fence as install time, re-run per call (the endpoint's
+    // DNS answer may have changed since install).
+    try {
+      await assertPublicHttpUrl(endpoint, {
+        allowHttp: envFlagEnabled(process.env.MCP_PACK_TOOLS_ALLOW_HTTP),
+      });
+    } catch (e) {
+      if (e instanceof EgressDeniedError) throw upstreamError(e.message);
+      throw e;
+    }
+    const payload = JSON.stringify({
+      event: 'mcp_tool_call',
+      tool: tool.name,
+      packId: binding.packId,
+      installId: binding.installId,
+      requestId: randomUUID(),
+      ts: new Date().toISOString(),
+      args: opts.args,
+    });
+    const signature = createHmac('sha256', binding.webhookSecret)
+      .update(payload)
+      .digest('hex');
+    const timeoutMs = Math.min(tool.timeoutMs ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
+    const text = await this.deliver({ endpoint, payload, signature, timeoutMs });
+    return this.shapeResponse(endpoint, text);
+  }
+
+  /** One POST, no retries. Throws a recorded upstreamError on timeout /
+   *  network error / non-200 / oversized body; returns the body text. */
+  private async deliver(opts: {
+    endpoint: string;
+    payload: string;
+    signature: string;
+    timeoutMs: number;
+  }): Promise<string> {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs);
+    try {
+      let res: Response;
+      try {
+        res = await fetch(opts.endpoint, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-brain-event': 'mcp_tool_call',
+            'x-brain-signature': `sha256=${opts.signature}`,
+          },
+          body: opts.payload,
+          redirect: 'error',
+          signal: ctrl.signal,
+        });
+      } catch {
+        this.recordFailure(opts.endpoint);
+        throw upstreamError(
+          ctrl.signal.aborted
+            ? `external tool timed out after ${opts.timeoutMs}ms`
+            : 'external tool endpoint unreachable',
+        );
+      }
+      if (res.status !== 200) {
+        this.recordFailure(opts.endpoint);
+        throw upstreamError(
+          `external tool endpoint answered HTTP ${res.status}`,
+        );
+      }
+      const text = await readCapped(res, MAX_RESPONSE_BYTES);
+      if (text === null) {
+        this.recordFailure(opts.endpoint);
+        throw upstreamError(
+          `external tool response exceeded ${MAX_RESPONSE_BYTES / 1024} KB`,
+        );
+      }
+      return text;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Contract: 200 + JSON `{content: string|object}`. An `{error}` body
+   * is an application-level failure — surfaced (sanitized, capped) but
+   * NOT counted against the breaker; the endpoint is clearly alive.
+   */
+  private shapeResponse(endpoint: string, text: string): PackToolCallResult {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      this.recordFailure(endpoint);
+      throw upstreamError('external tool returned malformed JSON');
+    }
+    this.breaker.delete(endpoint);
+    const body = (parsed ?? {}) as { content?: unknown; error?: unknown };
+    if (body.error !== undefined || body.content === undefined) {
+      const detail =
+        body.error === undefined
+          ? 'response carries no content field'
+          : sanitizePackText(
+              typeof body.error === 'string'
+                ? body.error
+                : JSON.stringify(body.error),
+              500,
+            );
+      throw upstreamError(`external tool returned an error: ${detail}`);
+    }
+    const content = body.content;
+    if (typeof content === 'string') {
+      return { content: [{ type: 'text', text: content }] };
+    }
+    return {
+      content: [{ type: 'text', text: JSON.stringify(content, null, 2) }],
+      structuredContent: content as Record<string, unknown>,
+    };
+  }
+
+  private recordFailure(endpoint: string): void {
+    const state = this.breaker.get(endpoint) ?? { fails: 0, until: 0 };
+    state.fails += 1;
+    if (state.fails >= BREAKER_THRESHOLD) {
+      state.until = Date.now() + BREAKER_MS;
+      state.fails = 0;
+      this.logger.warn(
+        `pack tool endpoint ${endpoint} latched for ${BREAKER_MS / 1000}s after ${BREAKER_THRESHOLD} consecutive failures`,
+      );
+    }
+    this.breaker.set(endpoint, state);
+  }
+}
+
+function upstreamError(message: string): HttpException {
+  // 424 Failed Dependency: < 500 so the MCP error wrapper passes this
+  // deliberate, sanitized message through to the calling agent.
+  return new HttpException({ error: 'pack_tool_upstream', message }, 424);
+}
+
+/** Read the response body up to `cap` bytes; null = oversize (aborted). */
+async function readCapped(res: Response, cap: number): Promise<string | null> {
+  const reader = res.body?.getReader();
+  if (!reader) return '';
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > cap) {
+      await reader.cancel().catch(() => undefined);
+      return null;
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/src/mcp/pack-tool-render.ts
+++ b/src/mcp/pack-tool-render.ts
@@ -1,0 +1,62 @@
+import type { PackToolSpec } from '../ai/domain-packs';
+
+/**
+ * Rendering of pack-authored tool text for the MCP surface
+ * (docs/mcp-pack-tools.md). Pack manifests are third-party input that
+ * ends up verbatim in an agent's context window, so every author string
+ * is sanitized (Unicode normalization, control/bidi/zero-width strip,
+ * whitespace collapse, hard cap) and every tool description gets a
+ * server-owned preamble stating its provenance and effect FIRST — the
+ * one part of the description a pack cannot spoof. Pure module.
+ */
+
+export const TITLE_CAP = 80;
+export const DESCRIPTION_CAP = 500;
+export const PARAM_DESCRIPTION_CAP = 200;
+
+// Control chars (C0/C1 minus \t\n\r, which the whitespace collapse
+// turns into single spaces), bidi overrides/isolates (U+202A-E,
+// U+2066-69, U+200E/F, U+061C), zero-width + word joiners (U+200B-D,
+// U+2060-64, U+FEFF) — the classes used to smuggle invisible or
+// re-ordered instructions into tool descriptions.
+const STRIP = new RegExp(
+  '[\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F\\u007F-\\u009F' +
+    '\\u061C\\u200B-\\u200F\\u202A-\\u202E\\u2060-\\u2064\\u2066-\\u2069\\uFEFF]',
+  'g',
+);
+
+/** NFC-normalize, strip control/bidi/zero-width, collapse whitespace,
+ *  trim, cap. Idempotent; returns '' for non-strings. */
+export function sanitizePackText(s: unknown, cap: number): string {
+  if (typeof s !== 'string') return '';
+  return s
+    .normalize('NFC')
+    .replace(STRIP, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, cap);
+}
+
+/**
+ * Full tool description: server preamble (always first, kind-specific)
+ * + the sanitized author description.
+ */
+export function renderPackToolDescription(opts: {
+  packId: string;
+  version: string;
+  tool: PackToolSpec;
+}): string {
+  const effect =
+    opts.tool.kind === 'external'
+      ? 'calls an external endpoint operated by the pack publisher'
+      : "reads this tenant's knowledge graph";
+  const preamble = `[third-party tool from domain pack "${opts.packId}" v${opts.version}; ${effect}] `;
+  return preamble + sanitizePackText(opts.tool.description, DESCRIPTION_CAP);
+}
+
+/** Sanitized author title, or undefined when the pack declared none. */
+export function renderPackToolTitle(tool: PackToolSpec): string | undefined {
+  if (tool.title === undefined) return undefined;
+  const title = sanitizePackText(tool.title, TITLE_CAP);
+  return title.length > 0 ? title : undefined;
+}

--- a/src/mcp/pack-tools-reader.service.ts
+++ b/src/mcp/pack-tools-reader.service.ts
@@ -1,0 +1,144 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { LRUCache } from '../common/lru-cache';
+import {
+  composePredicateId,
+  mcpToolsChecksum,
+  validateMcpTools,
+  DomainPackError,
+  type DomainPackManifest,
+  type PackToolSpec,
+} from '../ai/domain-packs';
+
+/** One installed, consented pack's MCP tool surface. */
+export interface PackToolBinding {
+  packId: string;
+  version: string;
+  /** Opaque per-install identity for external tool calls (0068). */
+  installId: string | null;
+  /** HMAC key for external tool calls (0065/0068). */
+  webhookSecret: string | null;
+  tools: PackToolSpec[];
+  /** ALL of the pack's namespaced predicate ids — the query-tool fence. */
+  namespacedPredicates: Set<string>;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+const CACHE_CAP = 200;
+
+/**
+ * Read side of pack-declared MCP tools: which packs are installed,
+ * consented, and structurally valid for this tenant. Sits on the MCP
+ * hot path (every buildServer under MCP_PACK_TOOLS_ENABLED), hence the
+ * LRU+TTL cache with in-flight dedupe (PredicateRegistryService.
+ * getSnapshot mold). Fail-open to [] on read errors — a domain_pack
+ * hiccup must not take down the whole MCP surface; the static tool
+ * families keep working and pack tools reappear on the next load.
+ */
+@Injectable()
+export class PackToolsReaderService {
+  private readonly logger = new Logger(PackToolsReaderService.name);
+  private readonly cache = new LRUCache<
+    string,
+    { bindings: PackToolBinding[]; loadedAt: number }
+  >(CACHE_CAP);
+  private readonly inFlight = new Map<string, Promise<PackToolBinding[]>>();
+
+  constructor(private readonly surreal: SurrealService) {}
+
+  async installedPackTools(companyId: string): Promise<PackToolBinding[]> {
+    const cached = this.cache.get(companyId);
+    if (cached && Date.now() - cached.loadedAt < ttlMs()) {
+      return cached.bindings;
+    }
+    const inFlight = this.inFlight.get(companyId);
+    if (inFlight) return inFlight;
+    const load = this.loadFresh(companyId)
+      .then((bindings) => {
+        this.cache.set(companyId, { bindings, loadedAt: Date.now() });
+        return bindings;
+      })
+      .catch((e) => {
+        this.logger.warn(
+          `pack tool load failed for ${companyId} (${(e as Error).message}) — serving no pack tools`,
+        );
+        return [] as PackToolBinding[];
+      })
+      .finally(() => this.inFlight.delete(companyId));
+    this.inFlight.set(companyId, load);
+    return load;
+  }
+
+  /** Called by DomainPackInstallService next to registry.invalidate. */
+  invalidate(companyId: string): void {
+    this.cache.delete(companyId);
+  }
+
+  private async loadFresh(companyId: string): Promise<PackToolBinding[]> {
+    const rows = await this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT packId, version, manifest, installId, webhookSecret,
+                acceptedMcpTools, acceptedMcpToolsChecksum
+           FROM domain_pack
+          WHERE status = 'active' AND manifest.mcpTools != NONE`,
+      );
+      return ((rows as any[]) ?? []) as Array<Record<string, unknown>>;
+    });
+    const bindings: PackToolBinding[] = [];
+    for (const row of rows) {
+      const binding = this.toBinding(row);
+      if (binding) bindings.push(binding);
+    }
+    return bindings;
+  }
+
+  /**
+   * Row → binding, defensively: consent must be on record for EXACTLY
+   * the stored section (checksum match), and the section must still
+   * pass validateMcpTools — a manifest written by an older/newer server
+   * version never reaches registration half-checked.
+   */
+  private toBinding(row: Record<string, unknown>): PackToolBinding | null {
+    const manifest = row.manifest as DomainPackManifest | undefined;
+    if (
+      !manifest ||
+      !Array.isArray(manifest.mcpTools) ||
+      manifest.mcpTools.length === 0
+    ) {
+      return null;
+    }
+    if (
+      row.acceptedMcpTools !== true ||
+      String(row.acceptedMcpToolsChecksum ?? '') !== mcpToolsChecksum(manifest)
+    ) {
+      return null;
+    }
+    try {
+      validateMcpTools(manifest, manifest.mcpTools);
+    } catch (e) {
+      if (e instanceof DomainPackError) {
+        this.logger.warn(
+          `pack ${row.packId}: stored mcpTools failed validation (${e.message}) — skipped`,
+        );
+        return null;
+      }
+      throw e;
+    }
+    const packId = String(row.packId);
+    return {
+      packId,
+      version: String(row.version),
+      installId: row.installId ? String(row.installId) : null,
+      webhookSecret: row.webhookSecret ? String(row.webhookSecret) : null,
+      tools: manifest.mcpTools,
+      namespacedPredicates: new Set(
+        manifest.predicates.map((p) => composePredicateId(packId, p.localId)),
+      ),
+    };
+  }
+}
+
+function ttlMs(): number {
+  const v = Number(process.env.MCP_PACK_TOOLS_CACHE_TTL_MS);
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_TTL_MS;
+}

--- a/src/mcp/pack-tools.ts
+++ b/src/mcp/pack-tools.ts
@@ -1,0 +1,164 @@
+import { Logger } from '@nestjs/common';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { envFlagEnabled } from '../common/env-validation';
+import {
+  composePredicateId,
+  PACK_NAMESPACE_SEP,
+  type PackQueryToolSpec,
+} from '../ai/domain-packs';
+import type { SearchService } from '../search/search.service';
+import type { FactsService } from '../facts/facts.service';
+import type { BrainScope } from '../auth/api-key.types';
+import type { PackToolBinding } from './pack-tools-reader.service';
+import {
+  renderPackToolDescription,
+  renderPackToolTitle,
+} from './pack-tool-render';
+
+/**
+ * Registration of pack-declared MCP tools (docs/mcp-pack-tools.md) on a
+ * per-request server — same free-function shape as read-tools.ts.
+ * Called AFTER the wrapToolErrors / applyPolicyToolGate patches, so
+ * every pack tool inherits error sanitization and the ABAC gate.
+ *
+ * The security-relevant invariant lives HERE, not in the manifest:
+ * query predicates are SERVER-COMPUTED from the pack's own vocabulary
+ * (spec localIds → composePredicateId, or all pack predicates), and the
+ * caller-facing input schemas are fixed — a pack chooses names and
+ * descriptions, never the query shape.
+ */
+export interface PackToolsDeps {
+  search: SearchService;
+  facts: FactsService;
+}
+
+const logger = new Logger('PackTools');
+
+export interface RegisterPackToolsOptions {
+  server: McpServer;
+  companyId: string;
+  scopes: BrainScope[];
+  bindings: PackToolBinding[];
+  deps: PackToolsDeps;
+}
+
+export function registerPackTools(opts: RegisterPackToolsOptions): void {
+  if (!envFlagEnabled(process.env.MCP_PACK_TOOLS_ENABLED)) return;
+  // Sub-flag: query tools default ON under the master flag
+  // (independently toggleable, like the external-tools flag).
+  const queryEnabled = envFlagEnabled(
+    process.env.MCP_PACK_QUERY_TOOLS_ENABLED ?? '1',
+  );
+  const seen = new Set<string>();
+  for (const binding of opts.bindings) {
+    for (const tool of binding.tools) {
+      const fullName = `${binding.packId}${PACK_NAMESPACE_SEP}${tool.name}`;
+      // Defensive — the validator already rejects in-pack duplicates and
+      // cross-pack names can't collide (distinct packId prefix).
+      if (seen.has(fullName)) {
+        logger.warn(`duplicate pack tool name ${fullName} — skipped`);
+        continue;
+      }
+      seen.add(fullName);
+      if (tool.kind === 'query' && queryEnabled) {
+        registerQueryTool({ ...opts, binding, tool, fullName });
+      }
+    }
+  }
+}
+
+interface QueryToolContext extends RegisterPackToolsOptions {
+  binding: PackToolBinding;
+  tool: PackQueryToolSpec;
+  fullName: string;
+}
+
+function registerQueryTool(ctx: QueryToolContext): void {
+  if (ctx.tool.query.surface === 'search') registerSearchQueryTool(ctx);
+  else registerFactsByPredicateTool(ctx);
+}
+
+function registerSearchQueryTool(ctx: QueryToolContext): void {
+  const { server, companyId, scopes, binding, tool, fullName, deps } = ctx;
+  // Locked server-side: spec localIds → namespaced ids, or the whole
+  // pack vocabulary when the spec names none. Never caller-supplied.
+  const predicates = tool.query.predicates?.length
+    ? tool.query.predicates.map((l) => composePredicateId(binding.packId, l))
+    : [...binding.namespacedPredicates];
+  server.registerTool(
+    fullName,
+    {
+      title: renderPackToolTitle(tool),
+      description: renderPackToolDescription({
+        packId: binding.packId,
+        version: binding.version,
+        tool,
+      }),
+      inputSchema: {
+        query: z.string().min(1).max(500).describe('Natural-language query'),
+        limit: z.number().int().min(1).max(20).optional(),
+      },
+    },
+    async (args: { query: string; limit?: number }) => {
+      const limit = Math.min(args.limit ?? tool.query.defaultLimit ?? 10, 20);
+      const out = await deps.search.search(
+        companyId,
+        {
+          query: args.query,
+          limit,
+          predicates,
+          minConfidence: tool.query.minConfidence,
+        },
+        scopes,
+      );
+      return {
+        content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
+        structuredContent: out as any,
+      };
+    },
+  );
+}
+
+function registerFactsByPredicateTool(ctx: QueryToolContext): void {
+  const { server, companyId, scopes, binding, tool, fullName, deps } = ctx;
+  // Validator guarantees predicates is a non-empty localId list here;
+  // the enum makes any predicate OUTSIDE the declared set a schema
+  // error before the handler runs.
+  const locals = tool.query.predicates as [string, ...string[]];
+  server.registerTool(
+    fullName,
+    {
+      title: renderPackToolTitle(tool),
+      description: renderPackToolDescription({
+        packId: binding.packId,
+        version: binding.version,
+        tool,
+      }),
+      inputSchema: {
+        predicate: z
+          .enum(locals)
+          .describe("One of the pack's own predicates"),
+        entity: z
+          .string()
+          .max(200)
+          .optional()
+          .describe('Scope to one entity (knowledge_entity:… or short id)'),
+        limit: z.number().int().min(1).max(50).optional(),
+      },
+    },
+    async (args: { predicate: string; entity?: string; limit?: number }) => {
+      const out = await deps.facts.listByPredicate({
+        companyId,
+        predicate: composePredicateId(binding.packId, args.predicate),
+        entityIdRaw: args.entity,
+        limit: Math.min(args.limit ?? tool.query.defaultLimit ?? 10, 50),
+        scopes,
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
+        structuredContent: out as any,
+      };
+    },
+  );
+}

--- a/src/mcp/pack-tools.ts
+++ b/src/mcp/pack-tools.ts
@@ -5,15 +5,20 @@ import { envFlagEnabled } from '../common/env-validation';
 import {
   composePredicateId,
   PACK_NAMESPACE_SEP,
+  type PackExternalToolSpec,
   type PackQueryToolSpec,
+  type PackToolParam,
 } from '../ai/domain-packs';
 import type { SearchService } from '../search/search.service';
 import type { FactsService } from '../facts/facts.service';
 import type { BrainScope } from '../auth/api-key.types';
 import type { PackToolBinding } from './pack-tools-reader.service';
+import type { PackToolProxyService } from './pack-tool-proxy.service';
 import {
+  PARAM_DESCRIPTION_CAP,
   renderPackToolDescription,
   renderPackToolTitle,
+  sanitizePackText,
 } from './pack-tool-render';
 
 /**
@@ -31,6 +36,8 @@ import {
 export interface PackToolsDeps {
   search: SearchService;
   facts: FactsService;
+  /** Absent = external tools cannot be served and are skipped. */
+  proxy?: PackToolProxyService;
 }
 
 const logger = new Logger('PackTools');
@@ -45,10 +52,14 @@ export interface RegisterPackToolsOptions {
 
 export function registerPackTools(opts: RegisterPackToolsOptions): void {
   if (!envFlagEnabled(process.env.MCP_PACK_TOOLS_ENABLED)) return;
-  // Sub-flag: query tools default ON under the master flag
-  // (independently toggleable, like the external-tools flag).
+  // Sub-flags, independently toggleable: query tools default ON under
+  // the master flag; external tools default OFF (outbound calls are a
+  // bigger operator decision than tenant-local reads).
   const queryEnabled = envFlagEnabled(
     process.env.MCP_PACK_QUERY_TOOLS_ENABLED ?? '1',
+  );
+  const externalEnabled = envFlagEnabled(
+    process.env.MCP_PACK_EXTERNAL_TOOLS_ENABLED,
   );
   const seen = new Set<string>();
   for (const binding of opts.bindings) {
@@ -63,6 +74,8 @@ export function registerPackTools(opts: RegisterPackToolsOptions): void {
       seen.add(fullName);
       if (tool.kind === 'query' && queryEnabled) {
         registerQueryTool({ ...opts, binding, tool, fullName });
+      } else if (tool.kind === 'external' && externalEnabled && opts.deps.proxy) {
+        registerExternalTool({ ...opts, binding, tool, fullName });
       }
     }
   }
@@ -161,4 +174,66 @@ function registerFactsByPredicateTool(ctx: QueryToolContext): void {
       };
     },
   );
+}
+
+interface ExternalToolContext extends RegisterPackToolsOptions {
+  binding: PackToolBinding;
+  tool: PackExternalToolSpec;
+  fullName: string;
+}
+
+function registerExternalTool(ctx: ExternalToolContext): void {
+  const { server, binding, tool, fullName, deps } = ctx;
+  const inputSchema: Record<string, z.ZodTypeAny> = {};
+  for (const p of tool.params ?? []) {
+    inputSchema[p.name] = paramSchema(p);
+  }
+  // Only declared params are forwarded — the SDK's schema parse strips
+  // extras, but the handler is also called directly in unit fixtures.
+  const declared = new Set((tool.params ?? []).map((p) => p.name));
+  server.registerTool(
+    fullName,
+    {
+      title: renderPackToolTitle(tool),
+      description: renderPackToolDescription({
+        packId: binding.packId,
+        version: binding.version,
+        tool,
+      }),
+      inputSchema,
+    },
+    async (args: Record<string, unknown>) => {
+      const forwarded = Object.fromEntries(
+        Object.entries(args ?? {}).filter(([k]) => declared.has(k)),
+      );
+      const out = await deps.proxy!.call({ binding, tool, args: forwarded });
+      return {
+        content: out.content,
+        ...(out.structuredContent
+          ? { structuredContent: out.structuredContent as any }
+          : {}),
+      };
+    },
+  );
+}
+
+/** Declared param → zod schema. Enum wins over maxLength for strings;
+ *  a plain string is capped (author's maxLength or the 2000 ceiling). */
+function paramSchema(p: PackToolParam): z.ZodTypeAny {
+  let schema: z.ZodTypeAny;
+  if (p.type === 'string') {
+    schema = p.enum?.length
+      ? z.enum(p.enum as [string, ...string[]])
+      : z.string().max(p.maxLength ?? 2_000);
+  } else if (p.type === 'number') {
+    schema = z.number();
+  } else {
+    schema = z.boolean();
+  }
+  if (p.description) {
+    schema = schema.describe(
+      sanitizePackText(p.description, PARAM_DESCRIPTION_CAP),
+    );
+  }
+  return p.required ? schema : schema.optional();
 }

--- a/src/policy/policy-engine.ts
+++ b/src/policy/policy-engine.ts
@@ -1,5 +1,6 @@
 import { actionKind, actionRuleMatches } from './action-registry';
 import {
+  ActionKind,
   CompiledPolicySet,
   CompiledSourceRule,
   PolicyContext,
@@ -31,8 +32,11 @@ export function sourceRuleMatches(
   return true;
 }
 
-function setVerdictForAction(set: CompiledPolicySet, action: string): SetVerdict {
-  const kind = actionKind(action);
+function setVerdictForAction(
+  set: CompiledPolicySet,
+  action: string,
+  kind: ActionKind,
+): SetVerdict {
   for (const rule of set.actionDeny) {
     if (actionRuleMatches(rule, action, kind)) {
       return { policySet: set.name, mode: set.mode, verdict: 'deny', ruleId: rule.id };
@@ -85,11 +89,21 @@ function combine(
   return { decision, verdicts };
 }
 
-/** Combined action decision across all sets in the context. */
-export function evaluateAction(ctx: PolicyContext, action: string): PolicyEvaluation {
+/**
+ * Combined action decision across all sets in the context. `kind`
+ * defaults to the static registry's classification; callers whose
+ * actions aren't in the registry (pack-declared MCP tools — query=read,
+ * external=write) pass it explicitly so the readonly/@write macros
+ * still apply correctly.
+ */
+export function evaluateAction(
+  ctx: PolicyContext,
+  action: string,
+  kind: ActionKind = actionKind(action),
+): PolicyEvaluation {
   return combine(
     ctx,
-    ctx.sets.map((s) => setVerdictForAction(s, action)),
+    ctx.sets.map((s) => setVerdictForAction(s, action, kind)),
   );
 }
 
@@ -164,8 +178,11 @@ export function explainRow(ctx: PolicyContext, view: PolicyRowView): SetTrace[] 
   });
 }
 
-export function explainAction(ctx: PolicyContext, action: string): SetTrace[] {
-  const kind = actionKind(action);
+export function explainAction(
+  ctx: PolicyContext,
+  action: string,
+  kind: ActionKind = actionKind(action),
+): SetTrace[] {
   return ctx.sets.map((set) => {
     const rules: RuleTrace[] = [...set.actionDeny, ...set.actionAllow].map(
       (r) => ({
@@ -174,7 +191,7 @@ export function explainAction(ctx: PolicyContext, action: string): SetTrace[] {
         matched: actionRuleMatches(r, action, kind),
       }),
     );
-    const verdict = setVerdictForAction(set, action);
+    const verdict = setVerdictForAction(set, action, kind);
     return {
       policySet: set.name,
       mode: set.mode,

--- a/src/policy/policy-gate.service.ts
+++ b/src/policy/policy-gate.service.ts
@@ -2,10 +2,11 @@ import { ForbiddenException, Injectable } from '@nestjs/common';
 import { MetricsService } from '../metrics/metrics.service';
 import { ApiKeyRecord } from '../auth/api-key.types';
 import { getCorrelationId } from '../common/request-context';
+import { actionKind } from './action-registry';
 import { evaluateAction } from './policy-engine';
 import { PolicyDecisionSink } from './policy-decision.sink';
 import { PolicyResolverService } from './policy-resolver.service';
-import { PolicyContext } from './policy.types';
+import { ActionKind, PolicyContext } from './policy.types';
 import { RowDecisionSummary } from './row-filter';
 
 /**
@@ -64,7 +65,31 @@ export class PolicyGateService {
    * Emits metrics + decision rows and throws on an enforced deny.
    */
   enforceAction(ctx: PolicyContext, action: string, requestId?: string): void {
-    const evaluation = evaluateAction(ctx, action);
+    this.enforce({ ctx, action, kind: actionKind(action), requestId });
+  }
+
+  /**
+   * enforceAction twin for tool names OUTSIDE the static action
+   * registry — pack-declared MCP tools carry their kind explicitly
+   * (query=read, external=write) so the @readonly/@write macros apply
+   * correctly instead of the unknown-name write default.
+   */
+  enforceToolAction(ctx: PolicyContext, action: string, kind?: ActionKind): void {
+    this.enforce({ ctx, action, kind: kind ?? actionKind(action) });
+  }
+
+  private enforce({
+    ctx,
+    action,
+    kind,
+    requestId,
+  }: {
+    ctx: PolicyContext;
+    action: string;
+    kind: ActionKind;
+    requestId?: string;
+  }): void {
+    const evaluation = evaluateAction(ctx, action, kind);
     const denies = evaluation.verdicts.filter((v) => v.verdict === 'deny');
     const decided = denies[0];
 

--- a/test/mcp-policy-gate.unit-spec.ts
+++ b/test/mcp-policy-gate.unit-spec.ts
@@ -67,6 +67,7 @@ function buildWithPolicy(policy?: PolicyContext): Promise<McpServer> {
     {} as never,
     stubPolicyGate as never,
     stubPackToolsReader as never,
+    {} as never, // packToolProxy
   );
   return svc.buildServer('co_test', ['brain:read', 'brain:write', 'brain:admin'], {
     actorKeyHash: 'sha256:test',
@@ -198,5 +199,43 @@ describe('MCP ABAC gate over pack-declared tools', () => {
     const names = toolNames(await buildWithPolicy(policy));
     expect(names).not.toContain('demo__find_things');
     expect(names).toContain('search_knowledge');
+  });
+
+  it('an EXTERNAL pack tool is write-kind: stripped by a readonly-allow policy', async () => {
+    process.env.MCP_PACK_EXTERNAL_TOOLS_ENABLED = '1';
+    try {
+      packBindings = [
+        {
+          ...demoBinding,
+          tools: [
+            {
+              kind: 'external',
+              name: 'call_home',
+              description: 'Calls the publisher.',
+              endpoint: 'https://tools.example.com/hook',
+            },
+          ],
+        },
+      ];
+      // Registers when no policy restricts the surface…
+      const open = toolNames(await buildWithPolicy(undefined));
+      expect(open).toContain('demo__call_home');
+      // …and is removed under readonly-allow, because its explicit kind
+      // is write (the whole point of the kind map: an external tool must
+      // never ride the read macro).
+      const policy = ctxFromDoc({
+        name: 'readonly-agent',
+        posture: { actions: 'deny', reads: 'allow' },
+        mode: 'enforce',
+        rules: [
+          { id: 'ro', effect: 'allow', kind: 'action', actions: ['@readonly'] },
+        ],
+      });
+      const names = toolNames(await buildWithPolicy(policy));
+      expect(names).not.toContain('demo__call_home');
+      expect(names).toContain('search_knowledge');
+    } finally {
+      delete process.env.MCP_PACK_EXTERNAL_TOOLS_ENABLED;
+    }
   });
 });

--- a/test/mcp-policy-gate.unit-spec.ts
+++ b/test/mcp-policy-gate.unit-spec.ts
@@ -23,6 +23,15 @@ const stubPolicyGate = {
   enforceAction: (_ctx: PolicyContext, action: string) => {
     enforceCalls.push(action);
   },
+  enforceToolAction: (_ctx: PolicyContext, action: string) => {
+    enforceCalls.push(action);
+  },
+};
+
+// Reader stub — individual tests override the resolved bindings.
+let packBindings: unknown[] = [];
+const stubPackToolsReader = {
+  installedPackTools: async () => packBindings,
 };
 
 function ctxFromDoc(doc: Record<string, unknown>): PolicyContext {
@@ -38,7 +47,7 @@ function ctxFromDoc(doc: Record<string, unknown>): PolicyContext {
   };
 }
 
-function buildWithPolicy(policy?: PolicyContext): McpServer {
+function buildWithPolicy(policy?: PolicyContext): Promise<McpServer> {
   const svc = new McpService(
     {} as never,
     {} as never,
@@ -57,6 +66,7 @@ function buildWithPolicy(policy?: PolicyContext): McpServer {
     {} as never,
     {} as never,
     stubPolicyGate as never,
+    stubPackToolsReader as never,
   );
   return svc.buildServer('co_test', ['brain:read', 'brain:write', 'brain:admin'], {
     actorKeyHash: 'sha256:test',
@@ -72,7 +82,7 @@ function toolNames(server: McpServer): string[] {
 }
 
 describe('MCP ABAC tool gate', () => {
-  it('readonly enforce policy strips every write tool from the surface', () => {
+  it('readonly enforce policy strips every write tool from the surface', async () => {
     const policy = ctxFromDoc({
       name: 'readonly-agent',
       posture: { actions: 'deny', reads: 'allow' },
@@ -81,7 +91,7 @@ describe('MCP ABAC tool gate', () => {
         { id: 'ro', effect: 'allow', kind: 'action', actions: ['@readonly'] },
       ],
     });
-    const names = toolNames(buildWithPolicy(policy));
+    const names = toolNames(await buildWithPolicy(policy));
     expect(names).toContain('search_knowledge');
     expect(names).toContain('graph_retrieve');
     expect(names).toContain('get_source_reputation');
@@ -92,7 +102,7 @@ describe('MCP ABAC tool gate', () => {
     expect(names).not.toContain('record_procedure');
   });
 
-  it('a targeted deny removes exactly that tool', () => {
+  it('a targeted deny removes exactly that tool', async () => {
     const policy = ctxFromDoc({
       name: 'no-forget',
       posture: { actions: 'allow', reads: 'allow' },
@@ -101,29 +111,92 @@ describe('MCP ABAC tool gate', () => {
         { id: 'nf', effect: 'deny', kind: 'action', actions: ['forget_entity'] },
       ],
     });
-    const names = toolNames(buildWithPolicy(policy));
+    const names = toolNames(await buildWithPolicy(policy));
     expect(names).not.toContain('forget_entity');
     expect(names).toContain('record_fact');
     expect(names).toContain('search_knowledge');
   });
 
-  it('report_only policy leaves the full surface registered', () => {
+  it('report_only policy leaves the full surface registered', async () => {
     const policy = ctxFromDoc({
       name: 'watcher',
       posture: { actions: 'deny', reads: 'allow' },
       mode: 'report_only',
       rules: [],
     });
-    const withPolicy = toolNames(buildWithPolicy(policy)).sort();
-    const without = toolNames(buildWithPolicy(undefined)).sort();
+    const withPolicy = toolNames(await buildWithPolicy(policy)).sort();
+    const without = toolNames(await buildWithPolicy(undefined)).sort();
     expect(withPolicy).toEqual(without);
   });
 
-  it('no policy context = pre-ABAC surface, gate service untouched', () => {
+  it('no policy context = pre-ABAC surface, gate service untouched', async () => {
     enforceCalls.length = 0;
-    const names = toolNames(buildWithPolicy(undefined));
+    const names = toolNames(await buildWithPolicy(undefined));
     expect(names).toContain('record_fact');
     expect(names).toContain('forget_entity');
     expect(enforceCalls).toHaveLength(0);
+  });
+});
+
+describe('MCP ABAC gate over pack-declared tools', () => {
+  // Pack tool names are OUTSIDE the static action registry, where
+  // unknown names default to write-kind. The explicit kind map built in
+  // buildServer (query=read, external=write) is what these tests pin.
+  const demoBinding = {
+    packId: 'demo',
+    version: '0.1.0',
+    installId: 'inst-1',
+    webhookSecret: 'sec',
+    tools: [
+      {
+        kind: 'query',
+        name: 'find_things',
+        description: 'Find things.',
+        query: { surface: 'search' },
+      },
+    ],
+    namespacedPredicates: new Set(['demo__thing']),
+  };
+
+  beforeEach(() => {
+    process.env.MCP_PACK_TOOLS_ENABLED = '1';
+    packBindings = [demoBinding];
+  });
+  afterEach(() => {
+    delete process.env.MCP_PACK_TOOLS_ENABLED;
+    packBindings = [];
+  });
+
+  it('a pack QUERY tool registers under a readonly-allow enforce policy', async () => {
+    const policy = ctxFromDoc({
+      name: 'readonly-agent',
+      posture: { actions: 'deny', reads: 'allow' },
+      mode: 'enforce',
+      rules: [
+        { id: 'ro', effect: 'allow', kind: 'action', actions: ['@readonly'] },
+      ],
+    });
+    const names = toolNames(await buildWithPolicy(policy));
+    expect(names).toContain('demo__find_things');
+    expect(names).not.toContain('record_fact');
+  });
+
+  it('an enforce-deny on the concrete namespaced name removes exactly that tool', async () => {
+    const policy = ctxFromDoc({
+      name: 'no-demo-tool',
+      posture: { actions: 'allow', reads: 'allow' },
+      mode: 'enforce',
+      rules: [
+        {
+          id: 'nd',
+          effect: 'deny',
+          kind: 'action',
+          actions: ['demo__find_things'],
+        },
+      ],
+    });
+    const names = toolNames(await buildWithPolicy(policy));
+    expect(names).not.toContain('demo__find_things');
+    expect(names).toContain('search_knowledge');
   });
 });

--- a/test/mcp-tools.unit-spec.ts
+++ b/test/mcp-tools.unit-spec.ts
@@ -53,6 +53,7 @@ function buildWithScopes(scopes: BrainScope[]): Promise<McpServer> {
     {} as never, // feedback
     {} as never, // policyGate — unused without a policy context
     stubPackToolsReader as never,
+    {} as never, // packToolProxy — no external tools in these fixtures
   );
   return svc.buildServer('co_test', scopes);
 }
@@ -184,6 +185,7 @@ describe('McpService.health — unauthenticated probe payload', () => {
       {} as never, // feedback
       {} as never, // policyGate — unused without a policy context
       stubPackToolsReader as never,
+      {} as never, // packToolProxy
     );
     const health = svc.health();
     expect(health.ok).toBe(true);

--- a/test/mcp-tools.unit-spec.ts
+++ b/test/mcp-tools.unit-spec.ts
@@ -29,7 +29,11 @@ const stubEmbedder = {
   getDimensions: () => 1536,
 };
 
-function buildWithScopes(scopes: BrainScope[]): McpServer {
+// Pack-tools reader — flag off in unit tests, but buildServer still
+// holds the dep; an empty read keeps the pre-pack surface identical.
+const stubPackToolsReader = { installedPackTools: async () => [] };
+
+function buildWithScopes(scopes: BrainScope[]): Promise<McpServer> {
   const svc = new McpService(
     {} as never,
     {} as never,
@@ -48,6 +52,7 @@ function buildWithScopes(scopes: BrainScope[]): McpServer {
     {} as never,
     {} as never, // feedback
     {} as never, // policyGate — unused without a policy context
+    stubPackToolsReader as never,
   );
   return svc.buildServer('co_test', scopes);
 }
@@ -93,13 +98,13 @@ const READ_BASELINE = [
 ];
 
 describe('McpService.buildServer — scope-gated tool surface', () => {
-  it('registers the read baseline with only brain:read', () => {
-    const names = toolNames(buildWithScopes(['brain:read']));
+  it('registers the read baseline with only brain:read', async () => {
+    const names = toolNames(await buildWithScopes(['brain:read']));
     for (const t of READ_BASELINE) expect(names).toContain(t);
   });
 
-  it('does NOT register mutation tools without brain:write', () => {
-    const names = toolNames(buildWithScopes(['brain:read']));
+  it('does NOT register mutation tools without brain:write', async () => {
+    const names = toolNames(await buildWithScopes(['brain:read']));
     expect(names).not.toContain('record_fact');
     expect(names).not.toContain('retract_fact');
     expect(names).not.toContain('link_entities');
@@ -109,8 +114,8 @@ describe('McpService.buildServer — scope-gated tool surface', () => {
     expect(names).not.toContain('record_decision');
   });
 
-  it('registers mutation tools when brain:write is present', () => {
-    const names = toolNames(buildWithScopes(['brain:read', 'brain:write']));
+  it('registers mutation tools when brain:write is present', async () => {
+    const names = toolNames(await buildWithScopes(['brain:read', 'brain:write']));
     expect(names).toContain('record_fact');
     expect(names).toContain('retract_fact');
     expect(names).toContain('link_entities');
@@ -120,29 +125,29 @@ describe('McpService.buildServer — scope-gated tool surface', () => {
     expect(names).toContain('record_decision');
   });
 
-  it('does NOT register forget_entity without brain:admin (even with write)', () => {
-    const names = toolNames(buildWithScopes(['brain:read', 'brain:write']));
+  it('does NOT register forget_entity without brain:admin (even with write)', async () => {
+    const names = toolNames(await buildWithScopes(['brain:read', 'brain:write']));
     expect(names).not.toContain('forget_entity');
   });
 
-  it('registers forget_entity only with brain:admin', () => {
+  it('registers forget_entity only with brain:admin', async () => {
     const names = toolNames(
-      buildWithScopes(['brain:read', 'brain:write', 'brain:admin']),
+      await buildWithScopes(['brain:read', 'brain:write', 'brain:admin']),
     );
     expect(names).toContain('forget_entity');
   });
 
-  it('registers brain://entity/ + /timeline resources at brain:read', () => {
-    const names = resourceNames(buildWithScopes(['brain:read']));
+  it('registers brain://entity/ + /timeline resources at brain:read', async () => {
+    const names = resourceNames(await buildWithScopes(['brain:read']));
     expect(names).toContain('entity-profile');
     expect(names).toContain('entity-timeline');
   });
 
-  it('ingest_document exposes the indexers param (REST parity: auto routes packs)', () => {
+  it('ingest_document exposes the indexers param (REST parity: auto routes packs)', async () => {
     const prev = process.env.DOCUMENT_INGEST_ENABLED;
     process.env.DOCUMENT_INGEST_ENABLED = '1';
     try {
-      const server = buildWithScopes(['brain:read', 'brain:write']);
+      const server = await buildWithScopes(['brain:read', 'brain:write']);
       const internals = server as unknown as {
         _registeredTools: Record<string, { inputSchema?: { shape?: object } }>;
       };
@@ -178,6 +183,7 @@ describe('McpService.health — unauthenticated probe payload', () => {
       {} as never,
       {} as never, // feedback
       {} as never, // policyGate — unused without a policy context
+      stubPackToolsReader as never,
     );
     const health = svc.health();
     expect(health.ok).toBe(true);

--- a/test/pack-mcp-tools.e2e-spec.ts
+++ b/test/pack-mcp-tools.e2e-spec.ts
@@ -1,0 +1,329 @@
+/**
+ * Pack-declared MCP tools — end-to-end on a real DB (docs/mcp-pack-tools.md).
+ *
+ * Full loop: install a pack whose manifest ships mcpTools (consent gate →
+ * 400 without acceptMcpTools), see the tools in tools/list as
+ * `<packId>__<name>`, call the facts_by_predicate query tool over
+ * ingested facts, verify the PII row fence against a plain brain:read
+ * key, call the external tool against a REAL local http server (HMAC
+ * verified with the install webhookSecret; installId — not companyId —
+ * on the wire), re-consent on a changed section, and uninstall.
+ *
+ * Flags are set BEFORE createApp; MCP_PACK_TOOLS_ALLOW_HTTP permits the
+ * loopback endpoint for the external-tool leg.
+ */
+import http from 'node:http';
+import { createHmac } from 'node:crypto';
+import type { AppFixture } from './app-fixture';
+
+process.env.MCP_PACK_TOOLS_ENABLED = '1';
+process.env.MCP_PACK_EXTERNAL_TOOLS_ENABLED = '1';
+process.env.MCP_PACK_TOOLS_ALLOW_HTTP = '1';
+
+// Import AFTER the env flags so nothing captures them un-set at load.
+import { createApp } from './app-fixture';
+
+describe('pack-declared MCP tools (e2e)', () => {
+  let f: AppFixture;
+  let endpointServer: http.Server;
+  let endpointPort = 0;
+  let webhookSecret = '';
+  const endpointHits: Array<{
+    signature: string;
+    body: string;
+    verified: boolean;
+  }> = [];
+
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const manifest = (over: Record<string, unknown> = {}) => ({
+    id: 'compliance',
+    version: '1.0.0',
+    description: 'Compliance test pack (MCP tools e2e).',
+    predicates: [
+      {
+        localId: 'violation',
+        displayLabel: 'violation',
+        description: 'TYPE subject is a company; value is a recorded violation',
+        datatype: 'string',
+        semantics: 'append_only',
+        decayHalfLifeDays: null,
+        piiClass: 'none',
+        status: 'active',
+      },
+      {
+        localId: 'sanction_status',
+        displayLabel: 'sanction status',
+        description: 'TYPE subject is a company; value is a sanction finding',
+        datatype: 'string',
+        semantics: 'append_only',
+        decayHalfLifeDays: null,
+        piiClass: 'sensitive',
+        requiresScope: 'brain:read_pii',
+        status: 'active',
+      },
+    ],
+    mcpTools: [
+      {
+        kind: 'query',
+        name: 'find_violations',
+        title: 'Find recorded violations',
+        description: 'List facts recorded by the compliance pack.',
+        query: {
+          surface: 'facts_by_predicate',
+          predicates: ['violation', 'sanction_status'],
+          defaultLimit: 10,
+        },
+      },
+      {
+        kind: 'external',
+        name: 'check_sanctions',
+        description: 'Screen a counterparty against the publisher backend.',
+        endpoint: `http://127.0.0.1:${endpointPort}/tool`,
+        timeoutMs: 5_000,
+        params: [
+          { name: 'counterparty', type: 'string', required: true, maxLength: 200 },
+        ],
+      },
+    ],
+    ...over,
+  });
+
+  // ── JSON-RPC over the stateless Streamable HTTP endpoint ──────────
+  function parseSse(text: string): any {
+    const events: any[] = [];
+    for (const line of text.split('\n')) {
+      if (line.startsWith('data: ')) events.push(JSON.parse(line.slice(6)));
+    }
+    return events[events.length - 1];
+  }
+
+  async function rpc(key: string, body: Record<string, unknown>): Promise<any> {
+    const res = await f.http
+      .post(`/mcp/${f.companyId}`)
+      .set({
+        Authorization: `Bearer ${key}`,
+        Accept: 'application/json, text/event-stream',
+      })
+      .send(body);
+    expect(res.status).toBe(200);
+    const ct = String(res.headers['content-type'] ?? '');
+    if (ct.includes('text/event-stream')) {
+      return parseSse(res.text ?? res.body.toString());
+    }
+    return res.body;
+  }
+
+  const toolsList = async (key: string): Promise<string[]> => {
+    const out = await rpc(key, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {},
+    });
+    return (out.result?.tools ?? []).map((t: { name: string }) => t.name);
+  };
+
+  const toolCall = async (
+    key: string,
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<any> => {
+    const out = await rpc(key, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    });
+    return out.result;
+  };
+
+  beforeAll(async () => {
+    endpointServer = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        const signature = String(req.headers['x-brain-signature'] ?? '');
+        const expected =
+          'sha256=' +
+          createHmac('sha256', webhookSecret).update(body).digest('hex');
+        endpointHits.push({ signature, body, verified: signature === expected });
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ content: { verdict: 'clean', hits: 0 } }));
+      });
+    });
+    await new Promise<void>((resolve) =>
+      endpointServer.listen(0, '127.0.0.1', resolve),
+    );
+    endpointPort = (endpointServer.address() as { port: number }).port;
+
+    f = await createApp({
+      companyId: 'co_pack_mcp_e2e',
+      scopes: ['brain:read', 'brain:write', 'brain:admin', 'brain:read_pii'],
+      // A plain reader key — the PII row-fence leg.
+      extraKeys: [{ scopes: ['brain:read'] }],
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    if (f) await f.close();
+    if (endpointServer) {
+      await new Promise((resolve) => endpointServer.close(resolve));
+    }
+  });
+
+  it('rejects installing a pack with mcpTools without acceptMcpTools (listing the tools)', async () => {
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: manifest() });
+    expect(r.status).toBe(400);
+    const msg = JSON.stringify(r.body);
+    expect(msg).toContain('acceptMcpTools');
+    expect(msg).toContain('find_violations');
+    expect(msg).toContain('check_sanctions');
+  });
+
+  it('installs with acceptMcpTools: true and mints a webhookSecret', async () => {
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: manifest(), acceptMcpTools: true });
+    expect([200, 201]).toContain(r.status);
+    expect(typeof r.body.webhookSecret).toBe('string');
+    webhookSecret = r.body.webhookSecret;
+  });
+
+  it('tools/list shows the namespaced pack tools with the server preamble', async () => {
+    const names = await toolsList(f.apiKey);
+    expect(names).toContain('compliance__find_violations');
+    expect(names).toContain('compliance__check_sanctions');
+
+    const out = await rpc(f.apiKey, {
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/list',
+      params: {},
+    });
+    const tool = out.result.tools.find(
+      (t: { name: string }) => t.name === 'compliance__find_violations',
+    );
+    expect(tool.description).toMatch(
+      /^\[third-party tool from domain pack "compliance" v1\.0\.0;/,
+    );
+  });
+
+  it('the query tool returns ingested facts', async () => {
+    const ingest = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'crm', id: 'acme' },
+        predicate: 'compliance__violation',
+        object: 'late filing 2026-Q1',
+        validFrom: '2026-07-01T00:00:00Z',
+        source: { vertical: 'crm' },
+      });
+    expect([200, 201]).toContain(ingest.status);
+
+    const result = await toolCall(f.apiKey, 'compliance__find_violations', {
+      predicate: 'violation',
+    });
+    expect(result.isError).toBeFalsy();
+    const out = result.structuredContent;
+    expect(out.predicate).toBe('compliance__violation');
+    expect(out.found).toBeGreaterThanOrEqual(1);
+    expect(
+      out.facts.some(
+        (x: { object: string }) => x.object === 'late filing 2026-Q1',
+      ),
+    ).toBe(true);
+  });
+
+  it('row-fences a requiresScope pack predicate from a plain brain:read key', async () => {
+    const ingest = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'crm', id: 'acme' },
+        predicate: 'compliance__sanction_status',
+        object: 'OFAC list hit',
+        validFrom: '2026-07-01T00:00:00Z',
+        source: { vertical: 'crm' },
+      });
+    expect([200, 201]).toContain(ingest.status);
+
+    // Privileged key (brain:read_pii) sees the fact…
+    const privileged = await toolCall(f.apiKey, 'compliance__find_violations', {
+      predicate: 'sanction_status',
+    });
+    expect(privileged.structuredContent.found).toBeGreaterThanOrEqual(1);
+
+    // …the plain brain:read key gets zero rows from the SAME tool.
+    const plain = await toolCall(
+      f.extraApiKeys[0],
+      'compliance__find_violations',
+      { predicate: 'sanction_status' },
+    );
+    expect(plain.structuredContent.found).toBe(0);
+  });
+
+  it('proxies the external tool: HMAC verifies, installId (not companyId) on the wire', async () => {
+    const result = await toolCall(f.apiKey, 'compliance__check_sanctions', {
+      counterparty: 'Acme GmbH',
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({ verdict: 'clean', hits: 0 });
+
+    expect(endpointHits).toHaveLength(1);
+    const hit = endpointHits[0];
+    expect(hit.verified).toBe(true);
+    const body = JSON.parse(hit.body);
+    expect(body).toMatchObject({
+      event: 'mcp_tool_call',
+      tool: 'check_sanctions',
+      packId: 'compliance',
+      args: { counterparty: 'Acme GmbH' },
+    });
+    expect(typeof body.installId).toBe('string');
+    expect(body.companyId).toBeUndefined();
+    expect(hit.body).not.toContain(f.companyId);
+  });
+
+  it('an upgrade with an UNCHANGED mcpTools section carries consent over', async () => {
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: manifest({ version: '1.0.1' }) });
+    expect([200, 201]).toContain(r.status);
+    // Secret survives the upgrade (no re-mint → not in the response).
+    expect(r.body.webhookSecret).toBeUndefined();
+  });
+
+  it('an upgrade with a CHANGED mcpTools section re-requires consent', async () => {
+    const changed = manifest({ version: '1.0.2' }) as any;
+    changed.mcpTools[0].description = 'Now with different behaviour.';
+    const denied = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: changed });
+    expect(denied.status).toBe(400);
+    expect(JSON.stringify(denied.body)).toContain('acceptMcpTools');
+
+    const accepted = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: changed, acceptMcpTools: true });
+    expect([200, 201]).toContain(accepted.status);
+  });
+
+  it('uninstall removes the pack tools from tools/list', async () => {
+    const del = await f.http.delete('/v1/admin/packs/compliance').set(auth());
+    expect(del.status).toBe(200);
+    const names = await toolsList(f.apiKey);
+    expect(names).not.toContain('compliance__find_violations');
+    expect(names).not.toContain('compliance__check_sanctions');
+    // The static families are untouched.
+    expect(names).toContain('search_knowledge');
+  });
+});

--- a/test/pack-tools.unit-spec.ts
+++ b/test/pack-tools.unit-spec.ts
@@ -14,6 +14,9 @@
  *     carry-over, changed-section re-consent).
  */
 import {
+  externalMcpTools,
+  mcpConsentRequired,
+  mcpToolsChecksum,
   validateMcpTools,
   validatePack,
   DomainPackError,
@@ -21,6 +24,10 @@ import {
   type PackPredicate,
   type PackToolSpec,
 } from '../src/ai/domain-packs';
+import {
+  assertPublicHttpUrl,
+  EgressDeniedError,
+} from '../src/common/egress-guard';
 
 function packPredicate(localId: string): PackPredicate {
   return {
@@ -224,5 +231,124 @@ describe('validateMcpTools', () => {
       [externalTool({ params: [{ name: 'p', type: 'number', maxLength: 10 }] })],
       /string params only/,
     );
+  });
+});
+
+describe('mcpTools install consent (mcpConsentRequired)', () => {
+  const withTools = (tools: PackToolSpec[]) => pack({ mcpTools: tools });
+
+  it('requires the flag on a fresh install declaring tools', () => {
+    const msg = mcpConsentRequired({
+      manifest: withTools([queryTool(), externalTool()]),
+      acceptMcpTools: undefined,
+      priorAccepted: false,
+      priorChecksum: null,
+    });
+    expect(msg).toMatch(/acceptMcpTools/);
+    // The refusal lists every tool's name/kind — and endpoints for
+    // external ones — so the operator reviews exactly what they accept.
+    expect(msg).toContain('query "find_things"');
+    expect(msg).toContain('external "check_thing" → https://tools.example.com/check');
+  });
+
+  it('passes with the flag, and without tools no consent is needed', () => {
+    expect(
+      mcpConsentRequired({
+        manifest: withTools([queryTool()]),
+        acceptMcpTools: true,
+        priorAccepted: false,
+        priorChecksum: null,
+      }),
+    ).toBeNull();
+    expect(
+      mcpConsentRequired({
+        manifest: pack(),
+        acceptMcpTools: undefined,
+        priorAccepted: false,
+        priorChecksum: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('carries consent over an upgrade with an UNCHANGED section', () => {
+    const manifest = withTools([queryTool()]);
+    const prior = mcpToolsChecksum(manifest);
+    expect(prior).toMatch(/^[0-9a-f]{64}$/);
+    expect(
+      mcpConsentRequired({
+        manifest: { ...manifest, version: '0.2.0' },
+        acceptMcpTools: undefined,
+        priorAccepted: true,
+        priorChecksum: prior,
+      }),
+    ).toBeNull();
+  });
+
+  it('re-requires the flag when the section CHANGED', () => {
+    const v1 = withTools([queryTool()]);
+    const v2 = withTools([queryTool({ description: 'now calls home' })]);
+    expect(
+      mcpConsentRequired({
+        manifest: v2,
+        acceptMcpTools: undefined,
+        priorAccepted: true,
+        priorChecksum: mcpToolsChecksum(v1),
+      }),
+    ).toMatch(/acceptMcpTools/);
+  });
+
+  it('checksum is canonical (key order irrelevant) and null without tools', () => {
+    const a = withTools([queryTool()]);
+    const reordered = {
+      ...a,
+      mcpTools: [
+        JSON.parse(
+          JSON.stringify({
+            query: { surface: 'search' },
+            description: 'Find things recorded by this pack.',
+            name: 'find_things',
+            kind: 'query',
+          }),
+        ),
+      ],
+    } as DomainPackManifest;
+    expect(mcpToolsChecksum(reordered)).toBe(mcpToolsChecksum(a));
+    expect(mcpToolsChecksum(pack())).toBeNull();
+  });
+
+  it('externalMcpTools picks only external specs', () => {
+    const m = withTools([queryTool(), externalTool()]);
+    expect(externalMcpTools(m).map((t) => t.name)).toEqual(['check_thing']);
+    expect(externalMcpTools(pack())).toEqual([]);
+  });
+});
+
+describe('egress guard (assertPublicHttpUrl)', () => {
+  const denied = (url: string, opts?: { allowHttp?: boolean }) =>
+    expect(assertPublicHttpUrl(url, opts)).rejects.toThrow(EgressDeniedError);
+
+  it('blocks loopback, metadata, and private ranges', async () => {
+    await denied('https://127.0.0.1/hook');
+    await denied('https://169.254.169.254/latest/meta-data');
+    await denied('https://10.1.2.3/hook');
+    await denied('https://172.16.0.9/hook');
+    await denied('https://192.168.1.1/hook');
+    await denied('https://[::1]/hook');
+    await denied('https://localhost/hook'); // resolves to loopback
+  });
+
+  it('blocks plain http, non-http schemes, and embedded credentials', async () => {
+    await denied('http://tools.example.com/hook');
+    await denied('ftp://tools.example.com/hook');
+    await denied('not a url');
+    await denied('https://user:pass@tools.example.com/hook');
+  });
+
+  it('allowHttp permits http + loopback (dev/test) but still rejects credentials', async () => {
+    await expect(
+      assertPublicHttpUrl('http://127.0.0.1:8080/tool', { allowHttp: true }),
+    ).resolves.toBeUndefined();
+    await denied('http://user:pass@127.0.0.1/tool', { allowHttp: true });
+    await denied('ftp://127.0.0.1/tool', { allowHttp: true });
   });
 });

--- a/test/pack-tools.unit-spec.ts
+++ b/test/pack-tools.unit-spec.ts
@@ -36,7 +36,11 @@ import {
 } from '../src/mcp/pack-tool-render';
 import { registerPackTools } from '../src/mcp/pack-tools';
 import type { PackToolBinding } from '../src/mcp/pack-tools-reader.service';
+import { PackToolProxyService } from '../src/mcp/pack-tool-proxy.service';
 import { McpService } from '../src/mcp/mcp.service';
+import http from 'node:http';
+import { createHmac } from 'node:crypto';
+import type { PackExternalToolSpec } from '../src/ai/domain-packs';
 
 function packPredicate(localId: string): PackPredicate {
   return {
@@ -594,6 +598,7 @@ describe('packIds fence (McpService.buildServer)', () => {
       {} as never,
       {} as never,
       reader as never,
+      {} as never, // packToolProxy
     );
   }
 
@@ -624,5 +629,246 @@ describe('packIds fence (McpService.buildServer)', () => {
     } finally {
       delete process.env.MCP_PACK_TOOLS_ENABLED;
     }
+  });
+});
+
+
+// ---- external tools: registration + proxy ------------------------------
+
+describe('registerPackTools — external tools', () => {
+  const FLAGS = ['MCP_PACK_TOOLS_ENABLED', 'MCP_PACK_EXTERNAL_TOOLS_ENABLED'];
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const f of FLAGS) saved[f] = process.env[f];
+    process.env.MCP_PACK_TOOLS_ENABLED = '1';
+    process.env.MCP_PACK_EXTERNAL_TOOLS_ENABLED = '1';
+  });
+  afterEach(() => {
+    for (const f of FLAGS) {
+      if (saved[f] === undefined) delete process.env[f];
+      else process.env[f] = saved[f];
+    }
+  });
+
+  function registerExternal(opts: {
+    tools?: PackToolSpec[];
+    proxy?: unknown;
+  } = {}) {
+    const { server, tools } = stubServer();
+    const proxyCalls: unknown[] = [];
+    const proxy =
+      opts.proxy === undefined
+        ? {
+            call: async (o: unknown) => {
+              proxyCalls.push(o);
+              return { content: [{ type: 'text', text: 'ok' }] };
+            },
+          }
+        : opts.proxy;
+    registerPackTools({
+      server,
+      companyId: 'co_test',
+      scopes: ['brain:read'],
+      bindings: [
+        binding({
+          tools: opts.tools ?? [
+            externalTool({
+              params: [
+                { name: 'thing_id', type: 'string', required: true, maxLength: 64 },
+                { name: 'mode', type: 'string', enum: ['fast', 'deep'] },
+                { name: 'depth', type: 'number' },
+              ],
+            }),
+          ],
+        }),
+      ],
+      deps: {
+        search: stubSearch([]),
+        facts: stubFacts([]),
+        ...(proxy ? { proxy: proxy as never } : {}),
+      },
+    });
+    return { tools, proxyCalls };
+  }
+
+  it('registers only under the external flag AND with a proxy dep', () => {
+    expect(registerExternal().tools.has('demo__check_thing')).toBe(true);
+    expect(registerExternal({ proxy: null }).tools.size).toBe(0);
+    process.env.MCP_PACK_EXTERNAL_TOOLS_ENABLED = '0';
+    expect(registerExternal().tools.size).toBe(0);
+  });
+
+  it('declared params map to the zod input schema (required/enum/maxLength/type)', () => {
+    const { tools } = registerExternal();
+    const shape = tools.get('demo__check_thing')!.config.inputSchema!;
+    expect(Object.keys(shape).sort()).toEqual(['depth', 'mode', 'thing_id']);
+    const schema = z.object(shape);
+    expect(schema.safeParse({ thing_id: 'x' }).success).toBe(true);
+    expect(schema.safeParse({}).success).toBe(false); // thing_id required
+    expect(schema.safeParse({ thing_id: 'x'.repeat(65) }).success).toBe(false);
+    expect(schema.safeParse({ thing_id: 'x', mode: 'slow' }).success).toBe(false);
+    expect(schema.safeParse({ thing_id: 'x', depth: 'nope' }).success).toBe(false);
+    expect(schema.safeParse({ thing_id: 'x', mode: 'deep', depth: 2 }).success).toBe(true);
+  });
+
+  it('handler forwards ONLY declared args to the proxy', async () => {
+    const { tools, proxyCalls } = registerExternal();
+    await tools.get('demo__check_thing')!.handler({
+      thing_id: 'x1',
+      smuggled: 'nope',
+    });
+    const call = proxyCalls[0] as { args: Record<string, unknown> };
+    expect(call.args).toEqual({ thing_id: 'x1' });
+  });
+
+  it('external description carries the endpoint-calling preamble', () => {
+    const { tools } = registerExternal();
+    expect(tools.get('demo__check_thing')!.config.description).toContain(
+      'calls an external endpoint operated by the pack publisher] ',
+    );
+  });
+});
+
+describe('PackToolProxyService — against a real local http server', () => {
+  let server: http.Server;
+  let port = 0;
+  let behavior: (res: http.ServerResponse) => void;
+  const received: Array<{ headers: http.IncomingHttpHeaders; body: string }> = [];
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        received.push({ headers: req.headers, body });
+        behavior(res);
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as { port: number }).port;
+    process.env.MCP_PACK_TOOLS_ALLOW_HTTP = '1';
+  });
+  afterAll(async () => {
+    delete process.env.MCP_PACK_TOOLS_ALLOW_HTTP;
+    await new Promise((resolve) => server.close(resolve));
+  });
+  beforeEach(() => {
+    received.length = 0;
+    behavior = (res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ content: 'ok' }));
+    };
+  });
+
+  const proxy = () => new PackToolProxyService();
+  const extTool = (over: Record<string, unknown> = {}) =>
+    ({
+      kind: 'external',
+      name: 'check_thing',
+      description: 'd',
+      endpoint: `http://127.0.0.1:${port}/tool`,
+      ...over,
+    }) as PackExternalToolSpec;
+  const callOnce = (
+    p: PackToolProxyService,
+    over: Record<string, unknown> = {},
+    b: Partial<PackToolBinding> = {},
+  ) => p.call({ binding: binding(b), tool: extTool(over), args: { thing_id: 'x1' } });
+
+  it('signs the raw body with the install secret; installId (not companyId) on the wire', async () => {
+    const out = await callOnce(proxy());
+    expect(out.content[0].text).toBe('ok');
+    const { headers, body } = received[0];
+    expect(headers['x-brain-event']).toBe('mcp_tool_call');
+    expect(headers['content-type']).toBe('application/json');
+    const expected =
+      'sha256=' + createHmac('sha256', 'sec-1').update(body).digest('hex');
+    expect(headers['x-brain-signature']).toBe(expected);
+    const parsed = JSON.parse(body);
+    expect(parsed).toMatchObject({
+      event: 'mcp_tool_call',
+      tool: 'check_thing',
+      packId: 'demo',
+      installId: 'inst-1',
+      args: { thing_id: 'x1' },
+    });
+    expect(parsed.companyId).toBeUndefined();
+    expect(typeof parsed.requestId).toBe('string');
+    expect(typeof parsed.ts).toBe('string');
+  });
+
+  it('object content is relayed as text + structuredContent', async () => {
+    behavior = (res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ content: { verdict: 'clean', score: 0.9 } }));
+    };
+    const out = await callOnce(proxy());
+    expect(out.structuredContent).toEqual({ verdict: 'clean', score: 0.9 });
+    expect(JSON.parse(out.content[0].text)).toEqual({ verdict: 'clean', score: 0.9 });
+  });
+
+  it('timeout yields a clean 424 error, never a raw stack', async () => {
+    behavior = () => undefined; // never respond
+    await expect(callOnce(proxy(), { timeoutMs: 150 } as never)).rejects.toThrow(
+      /timed out after 150ms/,
+    );
+  });
+
+  it('responses above 64 KB are rejected', async () => {
+    behavior = (res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ content: 'x'.repeat(70_000) }));
+    };
+    await expect(callOnce(proxy())).rejects.toThrow(/exceeded 64 KB/);
+  });
+
+  it('{error} bodies surface sanitized; non-200 surfaces the status', async () => {
+    behavior = (res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ error: 'boom‮ details' }));
+    };
+    await expect(callOnce(proxy())).rejects.toThrow(
+      /external tool returned an error: boom details/,
+    );
+    behavior = (res) => {
+      res.writeHead(503);
+      res.end('oops');
+    };
+    await expect(callOnce(proxy())).rejects.toThrow(/answered HTTP 503/);
+  });
+
+  it('circuit breaker: 3 consecutive failures latch the endpoint for 60s', async () => {
+    const p = proxy();
+    behavior = (res) => {
+      res.writeHead(500);
+      res.end();
+    };
+    for (let i = 0; i < 3; i++) {
+      await expect(callOnce(p)).rejects.toThrow(/answered HTTP 500/);
+    }
+    const hits = received.length;
+    await expect(callOnce(p)).rejects.toThrow(/circuit open/);
+    expect(received.length).toBe(hits); // latched call never left the process
+  });
+
+  it('egress guard applies per call: loopback blocked without ALLOW_HTTP', async () => {
+    delete process.env.MCP_PACK_TOOLS_ALLOW_HTTP;
+    try {
+      await expect(callOnce(proxy())).rejects.toThrow(/must use https/);
+      await expect(
+        callOnce(proxy(), { endpoint: `https://127.0.0.1:${port}/tool` }),
+      ).rejects.toThrow(/non-public address/);
+    } finally {
+      process.env.MCP_PACK_TOOLS_ALLOW_HTTP = '1';
+    }
+  });
+
+  it('a pre-0068 install (no installId/secret) gets a clean reinstall hint', async () => {
+    await expect(callOnce(proxy(), {}, { installId: null })).rejects.toThrow(
+      /reinstall the pack/,
+    );
+    await expect(callOnce(proxy(), {}, { webhookSecret: null })).rejects.toThrow(
+      /reinstall the pack/,
+    );
   });
 });

--- a/test/pack-tools.unit-spec.ts
+++ b/test/pack-tools.unit-spec.ts
@@ -28,6 +28,15 @@ import {
   assertPublicHttpUrl,
   EgressDeniedError,
 } from '../src/common/egress-guard';
+import { z } from 'zod';
+import {
+  renderPackToolDescription,
+  renderPackToolTitle,
+  sanitizePackText,
+} from '../src/mcp/pack-tool-render';
+import { registerPackTools } from '../src/mcp/pack-tools';
+import type { PackToolBinding } from '../src/mcp/pack-tools-reader.service';
+import { McpService } from '../src/mcp/mcp.service';
 
 function packPredicate(localId: string): PackPredicate {
   return {
@@ -350,5 +359,270 @@ describe('egress guard (assertPublicHttpUrl)', () => {
     ).resolves.toBeUndefined();
     await denied('http://user:pass@127.0.0.1/tool', { allowHttp: true });
     await denied('ftp://127.0.0.1/tool', { allowHttp: true });
+  });
+});
+
+
+describe('pack tool renderer', () => {
+  it('prepends the kind-specific server preamble', () => {
+    expect(
+      renderPackToolDescription({ packId: 'demo', version: '0.1.0', tool: queryTool() }),
+    ).toBe(
+      '[third-party tool from domain pack "demo" v0.1.0; reads this ' +
+        "tenant's knowledge graph] Find things recorded by this pack.",
+    );
+    expect(
+      renderPackToolDescription({ packId: 'demo', version: '0.1.0', tool: externalTool() }),
+    ).toContain('calls an external endpoint operated by the pack publisher] ');
+  });
+
+  it('strips control/bidi/zero-width characters and collapses whitespace', () => {
+    expect(sanitizePackText('a‮b​cd  e\n\tf', 100)).toBe('abcd e f');
+    expect(sanitizePackText('⁦hidden⁩ ﻿text', 100)).toBe('hidden text');
+  });
+
+  it('caps to the given length and tolerates non-strings', () => {
+    expect(sanitizePackText('x'.repeat(600), 500)).toHaveLength(500);
+    expect(sanitizePackText(42, 10)).toBe('');
+  });
+
+  it('title: sanitized, undefined when absent or empty after strip', () => {
+    expect(renderPackToolTitle(queryTool({ title: ' Nice‎ tool ' }))).toBe('Nice tool');
+    expect(renderPackToolTitle(queryTool())).toBeUndefined();
+    expect(renderPackToolTitle(queryTool({ title: '​​' }))).toBeUndefined();
+  });
+});
+
+// ---- registration through a stub McpServer ----------------------------
+
+interface RegisteredTool {
+  config: {
+    title?: string;
+    description?: string;
+    inputSchema?: Record<string, z.ZodTypeAny>;
+  };
+  handler: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+function stubServer(): {
+  server: never;
+  tools: Map<string, RegisteredTool>;
+} {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    registerTool: (
+      name: string,
+      config: RegisteredTool['config'],
+      handler: RegisteredTool['handler'],
+    ) => {
+      tools.set(name, { config, handler });
+    },
+  };
+  return { server: server as never, tools };
+}
+
+function binding(over: Partial<PackToolBinding> = {}): PackToolBinding {
+  return {
+    packId: 'demo',
+    version: '0.1.0',
+    installId: 'inst-1',
+    webhookSecret: 'sec-1',
+    tools: [
+      queryTool(),
+      queryTool({
+        name: 'things_by_status',
+        query: { surface: 'facts_by_predicate', predicates: ['status'], defaultLimit: 5 },
+      }),
+    ],
+    namespacedPredicates: new Set(['demo__thing', 'demo__status']),
+    ...over,
+  };
+}
+
+function stubSearch(calls: unknown[]) {
+  return {
+    search: async (companyId: string, dto: unknown, scopes: unknown) => {
+      calls.push({ companyId, dto, scopes });
+      return { results: [] };
+    },
+  } as never;
+}
+
+function stubFacts(calls: unknown[]) {
+  return {
+    listByPredicate: async (opts: unknown) => {
+      calls.push(opts);
+      return { predicate: 'x', found: 0, facts: [] };
+    },
+  } as never;
+}
+
+describe('registerPackTools', () => {
+  const FLAGS = [
+    'MCP_PACK_TOOLS_ENABLED',
+    'MCP_PACK_QUERY_TOOLS_ENABLED',
+    'MCP_PACK_EXTERNAL_TOOLS_ENABLED',
+  ];
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const f of FLAGS) saved[f] = process.env[f];
+    process.env.MCP_PACK_TOOLS_ENABLED = '1';
+  });
+  afterEach(() => {
+    for (const f of FLAGS) {
+      if (saved[f] === undefined) delete process.env[f];
+      else process.env[f] = saved[f];
+    }
+  });
+
+  function register(bindings: PackToolBinding[]) {
+    const { server, tools } = stubServer();
+    const searchCalls: unknown[] = [];
+    const factsCalls: unknown[] = [];
+    registerPackTools({
+      server,
+      companyId: 'co_test',
+      scopes: ['brain:read'],
+      bindings,
+      deps: { search: stubSearch(searchCalls), facts: stubFacts(factsCalls) },
+    });
+    return { tools, searchCalls, factsCalls };
+  }
+
+  it('registers nothing when the master flag is off', () => {
+    delete process.env.MCP_PACK_TOOLS_ENABLED;
+    expect(register([binding()]).tools.size).toBe(0);
+  });
+
+  it('registers nothing when the query sub-flag is explicitly off', () => {
+    process.env.MCP_PACK_QUERY_TOOLS_ENABLED = '0';
+    expect(register([binding()]).tools.size).toBe(0);
+  });
+
+  it('registers namespaced names with the server preamble + fixed search schema', () => {
+    const { tools } = register([binding()]);
+    expect([...tools.keys()].sort()).toEqual(['demo__find_things', 'demo__things_by_status']);
+    const search = tools.get('demo__find_things')!;
+    expect(search.config.description).toMatch(/^\[third-party tool from domain pack "demo" v0\.1\.0;/);
+    // Fixed input surface: a pack cannot add parameters to a query tool.
+    expect(Object.keys(search.config.inputSchema ?? {}).sort()).toEqual(['limit', 'query']);
+    const schema = z.object(search.config.inputSchema!);
+    expect(schema.safeParse({ query: 'x'.repeat(501) }).success).toBe(false);
+    expect(schema.safeParse({ query: 'ok', limit: 21 }).success).toBe(false);
+  });
+
+  it('search handler locks server-computed namespaced predicates + clamps limit', async () => {
+    const { tools, searchCalls } = register([binding()]);
+    await tools.get('demo__find_things')!.handler({ query: 'what things?', limit: 20 });
+    const call = searchCalls[0] as { companyId: string; dto: any; scopes: unknown };
+    expect(call.companyId).toBe('co_test');
+    expect(call.scopes).toEqual(['brain:read']);
+    // No spec predicates -> ALL pack predicates, namespaced. Never caller-supplied.
+    expect([...call.dto.predicates].sort()).toEqual(['demo__status', 'demo__thing']);
+    expect(call.dto.limit).toBe(20);
+  });
+
+  it('search handler applies spec defaultLimit/minConfidence and predicate subset', async () => {
+    const withSpec = binding({
+      tools: [
+        queryTool({
+          query: {
+            surface: 'search',
+            predicates: ['thing'],
+            defaultLimit: 3,
+            minConfidence: 0.7,
+          },
+        }),
+      ],
+    });
+    const { tools, searchCalls } = register([withSpec]);
+    await tools.get('demo__find_things')!.handler({ query: 'q' });
+    const dto = (searchCalls[0] as { dto: any }).dto;
+    expect(dto.predicates).toEqual(['demo__thing']);
+    expect(dto.limit).toBe(3);
+    expect(dto.minConfidence).toBe(0.7);
+  });
+
+  it('facts handler composes the namespaced predicate and clamps the limit', async () => {
+    const { tools, factsCalls } = register([binding()]);
+    await tools.get('demo__things_by_status')!.handler({ predicate: 'status', limit: 99 });
+    const call = factsCalls[0] as { predicate: string; limit: number; scopes: unknown };
+    expect(call.predicate).toBe('demo__status');
+    expect(call.limit).toBe(50);
+    expect(call.scopes).toEqual(['brain:read']);
+  });
+
+  it('facts input schema enum rejects a predicate outside the declared set', () => {
+    const { tools } = register([binding()]);
+    const shape = tools.get('demo__things_by_status')!.config.inputSchema!;
+    expect(z.object(shape).safeParse({ predicate: 'status' }).success).toBe(true);
+    expect(z.object(shape).safeParse({ predicate: 'thing' }).success).toBe(false);
+    expect(z.object(shape).safeParse({ predicate: 'other__salary' }).success).toBe(false);
+  });
+
+  it('skips a duplicate full name instead of overwriting', () => {
+    const dup = binding({ tools: [queryTool(), queryTool()] });
+    const { tools } = register([dup]);
+    expect(tools.size).toBe(1);
+  });
+});
+
+describe('packIds fence (McpService.buildServer)', () => {
+  const stubEmbedder = {
+    cacheStats: () => ({ provider: 'openai:text-embedding-3-small' }),
+    getDimensions: () => 1536,
+  };
+
+  function service(bindings: PackToolBinding[]): McpService {
+    const reader = { installedPackTools: async () => bindings };
+    return new McpService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      stubEmbedder as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      reader as never,
+    );
+  }
+
+  function toolNames(server: unknown): string[] {
+    return Object.keys(
+      (server as { _registeredTools: Record<string, unknown> })._registeredTools,
+    );
+  }
+
+  it('a packIds-bound key sees only its packs declared tools', async () => {
+    process.env.MCP_PACK_TOOLS_ENABLED = '1';
+    try {
+      const bindings = [
+        binding({ packId: 'packa', namespacedPredicates: new Set(['packa__thing']) }),
+        binding({ packId: 'packb', namespacedPredicates: new Set(['packb__thing']) }),
+      ];
+      const bound = await service(bindings).buildServer('co_test', ['brain:read'], {
+        packIds: ['packa'],
+      });
+      const names = toolNames(bound);
+      expect(names).toContain('packa__find_things');
+      expect(names).not.toContain('packb__find_things');
+
+      const unbound = await service(bindings).buildServer('co_test', ['brain:read']);
+      expect(toolNames(unbound)).toEqual(
+        expect.arrayContaining(['packa__find_things', 'packb__find_things']),
+      );
+    } finally {
+      delete process.env.MCP_PACK_TOOLS_ENABLED;
+    }
   });
 });

--- a/test/pack-tools.unit-spec.ts
+++ b/test/pack-tools.unit-spec.ts
@@ -1,0 +1,228 @@
+/**
+ * Pack-declared MCP tools (docs/mcp-pack-tools.md) — unit coverage:
+ *
+ *   - validateMcpTools matrix (names, duplicates, caps, surfaces,
+ *     foreign predicates, endpoints, params);
+ *   - renderer (server preamble per kind, control/bidi strip, caps);
+ *   - registration through a stub McpServer (flag gating, namespacing,
+ *     packIds fence, fixed query schemas);
+ *   - handlers (server-computed predicate lock + limit clamp, enum
+ *     fence on facts_by_predicate);
+ *   - external proxy against a REAL local http server (HMAC signature,
+ *     timeout, 64 KB cap, circuit breaker, egress guard);
+ *   - install consent helper (fresh install, unchanged re-consent
+ *     carry-over, changed-section re-consent).
+ */
+import {
+  validateMcpTools,
+  validatePack,
+  DomainPackError,
+  type DomainPackManifest,
+  type PackPredicate,
+  type PackToolSpec,
+} from '../src/ai/domain-packs';
+
+function packPredicate(localId: string): PackPredicate {
+  return {
+    localId,
+    displayLabel: localId,
+    description: 'x',
+    datatype: 'string',
+    semantics: 'append_only',
+    decayHalfLifeDays: null,
+    piiClass: 'none',
+    status: 'active',
+  };
+}
+
+function pack(over: Partial<DomainPackManifest> = {}): DomainPackManifest {
+  return {
+    id: 'demo',
+    version: '0.1.0',
+    description: 'demo',
+    predicates: [packPredicate('thing'), packPredicate('status')],
+    ...over,
+  };
+}
+
+function queryTool(over: Record<string, unknown> = {}): PackToolSpec {
+  return {
+    kind: 'query',
+    name: 'find_things',
+    description: 'Find things recorded by this pack.',
+    query: { surface: 'search' },
+    ...over,
+  } as PackToolSpec;
+}
+
+function externalTool(over: Record<string, unknown> = {}): PackToolSpec {
+  return {
+    kind: 'external',
+    name: 'check_thing',
+    description: 'Check a thing against the publisher backend.',
+    endpoint: 'https://tools.example.com/check',
+    ...over,
+  } as PackToolSpec;
+}
+
+describe('validateMcpTools', () => {
+  const ok = (tools: PackToolSpec[]) =>
+    expect(() => validateMcpTools(pack(), tools)).not.toThrow();
+  const bad = (tools: unknown, re: RegExp) =>
+    expect(() => validateMcpTools(pack(), tools)).toThrow(re);
+
+  it('accepts a well-formed query + external tool set', () => {
+    ok([
+      queryTool(),
+      queryTool({
+        name: 'things_by_status',
+        query: { surface: 'facts_by_predicate', predicates: ['status'] },
+      }),
+      externalTool({
+        params: [
+          { name: 'thing_id', type: 'string', required: true, maxLength: 64 },
+          { name: 'mode', type: 'string', enum: ['fast', 'deep'] },
+        ],
+        timeoutMs: 5_000,
+      }),
+    ]);
+  });
+
+  it('is wired into validatePack', () => {
+    expect(() =>
+      validatePack(pack({ mcpTools: [queryTool({ name: 'BAD' })] })),
+    ).toThrow(DomainPackError);
+  });
+
+  it('rejects an empty array', () => bad([], /non-empty array/));
+  it('rejects more than 8 tools', () => {
+    const tools = Array.from({ length: 9 }, (_, i) =>
+      queryTool({ name: `tool_${i}` }),
+    );
+    bad(tools, /max is 8/);
+  });
+
+  it('rejects bad tool names (uppercase, digit-lead, separator, too long)', () => {
+    bad([queryTool({ name: 'Find' })], /must match/);
+    bad([queryTool({ name: '9find' })], /must match/);
+    bad([queryTool({ name: 'a__b' })], /must match|__/);
+    bad([queryTool({ name: 'a'.repeat(42) })], /must match/);
+    bad([queryTool({ name: 'x' })], /must match/); // single char — below min
+  });
+
+  it('rejects duplicate tool names', () =>
+    bad([queryTool(), queryTool()], /duplicate mcpTool name/));
+
+  it('rejects an unknown kind', () =>
+    bad([{ ...queryTool(), kind: 'wasm' }], /kind/));
+
+  it('rejects a missing / oversized description and oversized title', () => {
+    bad([queryTool({ description: undefined })], /description/);
+    bad([queryTool({ description: 'x'.repeat(501) })], /description/);
+    bad([queryTool({ title: 'x'.repeat(81) })], /title/);
+  });
+
+  it('rejects an unknown query surface', () =>
+    bad([queryTool({ query: { surface: 'raw_surql' } })], /surface/));
+
+  it('rejects facts_by_predicate without predicates', () =>
+    bad(
+      [queryTool({ query: { surface: 'facts_by_predicate' } })],
+      /requires query.predicates/,
+    ));
+
+  it('rejects predicates that are not the pack own localIds', () =>
+    bad(
+      [queryTool({ query: { surface: 'search', predicates: ['other__salary'] } })],
+      /not a predicate of this pack/,
+    ));
+
+  it('rejects defaultLimit / minConfidence out of range', () => {
+    bad([queryTool({ query: { surface: 'search', defaultLimit: 0 } })], /defaultLimit/);
+    bad([queryTool({ query: { surface: 'search', defaultLimit: 21 } })], /defaultLimit/);
+    bad([queryTool({ query: { surface: 'search', minConfidence: 1.5 } })], /minConfidence/);
+  });
+
+  it('rejects minConfidence on facts_by_predicate (search only)', () =>
+    bad(
+      [
+        queryTool({
+          query: {
+            surface: 'facts_by_predicate',
+            predicates: ['thing'],
+            minConfidence: 0.5,
+          },
+        }),
+      ],
+      /search surface only/,
+    ));
+
+  it('rejects a malformed endpoint (and non-http schemes)', () => {
+    bad([externalTool({ endpoint: 'not a url' })], /endpoint/);
+    bad([externalTool({ endpoint: 'ftp://tools.example.com' })], /endpoint/);
+  });
+
+  it('accepts an http endpoint at validation time (egress guard owns https-only)', () =>
+    ok([externalTool({ endpoint: 'http://tools.example.com/hook' })]));
+
+  it('rejects timeoutMs out of [1000, 30000]', () => {
+    bad([externalTool({ timeoutMs: 500 })], /timeoutMs/);
+    bad([externalTool({ timeoutMs: 31_000 })], /timeoutMs/);
+  });
+
+  it('rejects more than 8 params and duplicate param names', () => {
+    const params = Array.from({ length: 9 }, (_, i) => ({
+      name: `p_${i}`,
+      type: 'string',
+    }));
+    bad([externalTool({ params })], /at most 8/);
+    bad(
+      [
+        externalTool({
+          params: [
+            { name: 'p', type: 'string' },
+            { name: 'p', type: 'number' },
+          ],
+        }),
+      ],
+      /duplicate param/,
+    );
+  });
+
+  it('rejects bad param names / types / caps', () => {
+    bad([externalTool({ params: [{ name: 'P', type: 'string' }] })], /param name/);
+    bad([externalTool({ params: [{ name: 'p', type: 'object' }] })], /type/);
+    bad(
+      [externalTool({ params: [{ name: 'p', type: 'string', description: 'x'.repeat(201) }] })],
+      /description/,
+    );
+    bad(
+      [externalTool({ params: [{ name: 'p', type: 'number', enum: ['1'] }] })],
+      /string params only/,
+    );
+    bad(
+      [
+        externalTool({
+          params: [{ name: 'p', type: 'string', enum: Array(21).fill('v') }],
+        }),
+      ],
+      /enum/,
+    );
+    bad(
+      [externalTool({ params: [{ name: 'p', type: 'string', enum: ['x'.repeat(61)] }] })],
+      /enum/,
+    );
+    bad(
+      [externalTool({ params: [{ name: 'p', type: 'string', maxLength: 0 }] })],
+      /maxLength/,
+    );
+    bad(
+      [externalTool({ params: [{ name: 'p', type: 'string', maxLength: 2_001 }] })],
+      /maxLength/,
+    );
+    bad(
+      [externalTool({ params: [{ name: 'p', type: 'number', maxLength: 10 }] })],
+      /string params only/,
+    );
+  });
+});


### PR DESCRIPTION
Domain Packs can now contribute tools to a tenant's MCP surface — without ever running third-party code inside Brain. A pack's manifest may ship an `mcpTools` section (max 8); after an explicit operator consent at install, the tools appear in `tools/list` as `<packId>__<toolName>` next to the static families.

Full reference: `docs/mcp-pack-tools.md`.

## What a pack tool is (hard design constraint: no in-process plugin code)

- **`query`** — declarative read over the tenant's knowledge graph, locked to the pack's OWN namespaced predicates. Two surfaces: `search` (hybrid pipeline; spec `predicates`/`defaultLimit`/`minConfidence`; limit clamped ≤ 20) and `facts_by_predicate` (active-believed-now facts for one predicate via new `FactsService.listByPredicate`; the input `predicate` is a `z.enum` over the declared localIds). Input schemas are fixed server-side; predicate sets are SERVER-COMPUTED from the manifest — a pack can never widen a tool onto core or another pack's vocabulary.
- **`external`** — HTTPS proxy: Brain POSTs the call to a publisher-operated endpoint, HMAC-SHA256-signed with the pack's install webhook secret (`x-brain-signature: sha256=<hex>` over the raw body). The wire carries an opaque per-install `installId` (migration 0068), **never companyId**. `timeoutMs` capped at 30 s, `redirect:'error'`, NO retries, response hard-capped at 64 KB, `{error}`/non-200 surfaced as sanitized 424 errors, per-endpoint circuit breaker (3 consecutive transport failures → 60 s latch).

## Phases (one commit each)

- **A — manifest + validation**: `PackQueryToolSpec` / `PackExternalToolSpec` / `PackToolParam` on `DomainPackManifest`; `validateMcpTools` wired into `validatePack` (names/dups/caps/surfaces/own-predicate references/endpoint/timeout/param rules); OpenAPI spec-mirror field.
- **B — install consent + migration 0068 + egress guard**: `installId` + `acceptedMcpTools`(+checksum) fields on `domain_pack`; installs with a non-empty section 400 (listing every tool) unless `acceptMcpTools: true`; consent stored with a canonical-JSON checksum — a changed section on upgrade re-requires the flag, an unchanged one carries it over; `webhookSecret` minting extended to packs with external tools; new pure `src/common/egress-guard.ts` (https-only, no URL credentials, DNS answers must be public — covers 169.254.169.254; re-run per call).
- **C — query tools live**: sanitized pack-authored text (NFC, control/bidi/zero-width strip, caps) with a server-owned provenance preamble first; `PackToolsReaderService` (consent-checked + re-validated bindings, LRU+TTL cache with in-flight dedupe, fail-open to `[]`, invalidated on install/uninstall); registration behind `MCP_PACK_TOOLS_ENABLED`; ABAC kind threading (`evaluateAction`/`explainAction` optional explicit kind, `PolicyGateService.enforceToolAction`, per-request kind map: query=read, external=write) so pack tools behave correctly under `@readonly`/`@write` macros and per-name denies; `buildServer` is now async; `packIds`-bound keys see only their packs' tools.
- **D — external proxy + flags + docs**: `PackToolProxyService`; env flags (`MCP_PACK_TOOLS_ENABLED` master off, `MCP_PACK_QUERY_TOOLS_ENABLED` on under master, `MCP_PACK_EXTERNAL_TOOLS_ENABLED` off, `MCP_PACK_TOOLS_ALLOW_HTTP` dev/test-only, `MCP_PACK_TOOLS_CACHE_TTL_MS`) registered in env-validation + config catalog + `.env.example`; `docs/mcp-pack-tools.md` + sections in `docs/domain-packs.md` / `docs/api.md`.

## Security model

Sanitized author text + unspoofable server preamble (prompt-injection hardening); server-computed predicate fence; predicate `requiresScope` (PII) + ABAC row filter apply per row (`pack_facts_by_predicate` surface); SSRF egress guard at install AND per call; consent with re-consent on change; tenant privacy via `installId`; per-key `packIds` fence. Known residual risk (documented): DNS is not pinned between the egress check and the fetch.

## Not in v1 (deliberate)

Raw SurrealQL from packs; more query surfaces (entity_profile/timeline/multi-hop); JSON Schema passthrough; `asOf`/`userId` params; pack tools in the unauthenticated health probe (kept static, documented); pack-provided MCP resources/prompts/sampling; streaming/progress; retries on external calls; DNS pinning; per-tool rate limits/metering; webhookSecret rotation.

## Testing

- `pnpm exec tsc --noEmit` — clean
- `pnpm lint:ci` — 0 warnings
- `pnpm test` — 172 suites / 1342 tests green (includes new `test/pack-tools.unit-spec.ts`: validator matrix, renderer, registration/flag gating/packIds fence, handler predicate-lock + limit clamps, proxy against a real local http server — HMAC verification, timeout, 64 KB cap, breaker, egress guard; consent helper matrix; extended `mcp-tools` / `mcp-policy-gate` suites)
- Targeted e2e on a SurrealDB testcontainer: new `test/pack-mcp-tools.e2e-spec.ts` (9 tests: consent 400 → install → `tools/list` shows namespaced tools → query tool returns ingested facts → PII row fence vs a plain `brain:read` key → external call against a live local server with HMAC verified and `installId` on the wire → unchanged-upgrade consent carry-over → changed-section re-consent → uninstall removes the tools) + `domain-pack-install`, `mcp-health`, `abac-action-gate`, `domain-pack-seed` all green.

Branch is rebased onto current `main` (post #200/#202); the shared-file overlaps (validate.ts, packs.schema.ts, env-validation.ts, config catalog) were resolved by appending after the seed-documents track's entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd
