### PR TITLE
docs: SOTA refresh — README, docs hub, freshness sweep across all guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,10 @@ sequence: see the
 [Quickstart in docs/domain-packs.md](docs/domain-packs.md#quickstart-author--validate--sign--publish--install)
 (`pnpm pack:init my_pack` scaffolds a valid starter manifest; edit →
 `pack:validate` → `pack:sign` → `pack:publish` → `pack:install` → eval).
+Beyond predicates, a manifest can ship `seedDocuments` (knowledge ingested
+through the document pipeline on install) and `mcpTools` (consented MCP
+surface extensions) — both covered in
+[docs/domain-packs.md](docs/domain-packs.md).
 
 **First-party packs** (shipped in-repo, like the six industry packs:
 `real_estate`, `fintech`, `medical`, `legal`, `insurance`, `hr`) DO go
@@ -206,10 +210,11 @@ through a PR, and the recipe is fixed:
 ## Releasing
 
 Brain auto-deploys on push to `main` via `.github/workflows/deploy-brain.yml`
-(self-hosted SFO runner builds + ships the image, restarts the container).
-There's no semver release process for the service itself — every green main
-commit is "released" to prod. The version field in `package.json` (`0.1.0`)
-is decorative.
+(self-hosted SFO runner builds + ships the image, restarts the container) —
+every green main commit is live in prod. Versioned releases (the
+`package.json` version, `CHANGELOG.md`, GitHub Releases) are cut by
+release-please from conventional-commit titles; don't edit the changelog
+by hand.
 
 Rollback is via the workflow's `restart` action against a previous tag
 (see `docs/DEPLOY.md` § Rollback).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ sources that disagree, and can't truly delete a user on request. **Brain** is
 a per-tenant knowledge graph built for those jobs — a *system of insight, not
 a system of record*.
 
+```mermaid
+flowchart LR
+  subgraph ingest ["Ingest"]
+    facts["facts · mentions · links"]
+    docs["documents<br/>Source → Indexer → Candidates"]
+  end
+  ext["external indexers ✳<br/>pull work API"] --> docs
+  packs["Domain Packs ✳<br/>registry · marketplace"] -. "predicates · indexers<br/>seed documents" .-> ingest
+  facts --> resolver["conflict resolver<br/>+ trust snapshot"]
+  docs --> resolver
+  resolver --> graph[("bitemporal graph<br/>two clocks per fact")]
+  graph --> retrieval["retrieval pipeline<br/>vector + BM25 → router → PPR →<br/>cross-encoder → LLM rerank"]
+  retrieval --> rest["REST /v1"]
+  retrieval --> mcp["MCP per tenant<br/>+ pack tools ✳"]
+```
+
+✳ = extension points for third parties — see [Build on Brain](#build-on-brain).
+
 ## Why Brain
 
 - **Two clocks per fact.** Every fact carries *valid time* (when it was true)
@@ -61,10 +79,27 @@ a system of record*.
   thresholds, and corroboration. Deny-overrides, report-only rollout, per-rule
   explain, and a visual policy editor + Key Lens simulator in the admin UI.
   See [`docs/abac.md`](docs/abac.md).
-- **Pluggable ontology.** Domain Packs extend the predicate registry without
-  forking core: a signed, versioned manifest format, a six-pack industry library
-  (real-estate, fintech, medical, legal, insurance, HR), and a global pack
-  registry to publish and install them per tenant at runtime.
+- **Pluggable ontology — as a platform.** Domain Packs extend the predicate
+  registry without forking core: signed, versioned JSON manifests that carry
+  predicates, extraction tuning, eval fixtures, indexer descriptors, seed
+  documents, and MCP tools. A six-pack industry library ships in-repo
+  (real-estate, fintech, medical, legal, insurance, HR); a global registry
+  with immutable versions, verified-publisher badges, download counters, and
+  pull-only mirroring closes the publish → discover → install loop.
+- **An execution seam for third parties.** External indexers contribute
+  knowledge over a pull work API — poll → claim → read content → submit
+  candidates — without ever running inside Brain's process. Every submitted
+  span is re-grounded against the stored document text, and indexer trust is
+  earned through the nightly refit, not granted.
+- **Pack-declared MCP tools.** A pack can extend a tenant's MCP surface:
+  declarative query tools locked to its own predicates, or HMAC-signed proxies
+  to a publisher-operated endpoint. Registered only with explicit operator
+  consent, flag-gated, never in-process code.
+- **A marketplace with honest defaults.** Featured curation, publisher
+  profiles, and paid packs via a central billing service (per-pack
+  entitlements, self-describing 402 → checkout → retry, fail-closed when
+  billing is unreachable). With billing off — the default — every pack
+  installs free: the self-hosted posture.
 - **A document pipeline, not an upload button.** Ingestion is split into four
   layers — *Source* (a normalized document; Brain doesn't know what a PDF is) →
   *Indexer* (composable domain readers: one meeting can be read by the meetings,
@@ -144,6 +179,8 @@ pointing at the per-tenant URL with a Bearer key — no glue code.
   ```
 
 Full per-client guide: [MCP setup](https://brain.inite.ai/en/docs/mcp/setup).
+Installed Domain Packs can extend the tool surface with their own consented,
+flag-gated tools — see [MCP pack tools](docs/mcp-pack-tools.md).
 
 ## Feed it documents
 
@@ -184,6 +221,41 @@ What that buys:
 - **A privacy dial.** `storeContent: false` keeps only the content hash and
   metadata — extraction still runs, but nothing to re-index or leak later.
 
+## Build on Brain
+
+Brain is a platform, not just a service: third parties extend the ontology,
+the ingestion plane, and the tool surface without a PR to this repo.
+
+- **Author a Domain Pack.** `pnpm pack:init` scaffolds a valid manifest;
+  edit → `pack:validate` → `pack:sign` (ed25519) → `pack:publish` →
+  `pack:install`. A pack is JSON — no compiled module, no fork.
+  [Domain Packs](docs/domain-packs.md).
+- **Publish to the global registry.** Immutable versions, yank-not-delete,
+  verified-publisher badges, download counters, and pull-only cross-instance
+  mirroring (`REGISTRY_UPSTREAM_URL`). Public catalogue at `GET /registry/ui`.
+  [Registry](docs/domain-packs.md#the-registry-global-catalogue).
+- **Sell it on the marketplace.** Hosting instances can feature packs, render
+  publisher profiles, and price packs through the central billing service —
+  the entitlement `domain_pack:<packId>` gates the install, and a refused
+  install is a self-describing 402 with the checkout path. Billing off =
+  everything installs free. [Marketplace](docs/domain-packs.md#marketplace).
+- **Run an external indexer.** A plain HTTP client polls for routed documents,
+  claims a lease, reads stored text, and submits candidate facts that Brain
+  re-grounds and adjudicates. Protocol: [indexer-protocol.md](docs/indexer-protocol.md);
+  dependency-free reference client: [`examples/reference-indexer.ts`](examples/reference-indexer.ts)
+  (`pnpm indexer:reference`).
+- **Declare MCP tools.** Packs contribute query tools over their own
+  predicates or HMAC-proxied external tools, installed only with explicit
+  operator consent (`acceptMcpTools`). [MCP pack tools](docs/mcp-pack-tools.md).
+- **Ship knowledge with the pack.** `seedDocuments` in the manifest are
+  ingested through the normal document pipeline on install — same chunking,
+  staging, conflict resolution, and provenance as any connector's document.
+  [Seed documents](docs/domain-packs.md#seed-documents-consumed).
+
+The platform surface is machine-described in
+[`docs/openapi.json`](docs/openapi.json) (OpenAPI 3.1, regenerate with
+`pnpm openapi:build`).
+
 ## Quality (latest gate run)
 
 ```
@@ -209,16 +281,22 @@ Methodology: [`docs/eval.md`](docs/eval.md).
 NestJS 11 + TypeScript on Node 22 · SurrealDB 3.x (HNSW + BM25, one database
 per tenant) · BGE-M3 embeddings (ONNX, runs locally in a worker thread) ·
 OpenAI `gpt-4o-mini` for extraction / synthesize / verifier · optional Cohere
-Rerank · a SurrealDB-native job queue · OpenTelemetry. Ships as a Docker image;
-runs on any host.
+Rerank or a local ONNX cross-encoder · a SurrealDB-native job queue ·
+OpenTelemetry. CPU-heavy work (embeddings, cross-encoder, NLI intent routing,
+local NER, label propagation, token counting) runs in `worker_threads` so the
+event loop keeps serving HTTP, and `PROCESS_ROLE=api|worker` splits one image
+into an HTTP pod and a jobs pod when a deployment outgrows a single process.
+Ships as a Docker image; runs on any host.
 
 ## Documentation
+
+The hub with per-persona routing lives at [`docs/README.md`](docs/README.md).
 
 | | |
 |---|---|
 | **Get going** | [Getting started](docs/getting-started.md) · [Migration guide](docs/migration-guide.md) |
 | **Understand it** | [Architecture](docs/architecture.md) · [API reference](docs/api.md) · [OpenAPI 3.1 spec](docs/openapi.json) (platform surface, generated) · [Data model](docs/data-model.md) · [Bitemporal semantics](docs/bitemporal-semantics.md) · [Source reputation & trust](docs/source-reputation.md) · [ABAC access policies](docs/abac.md) · [Document pipeline](docs/document-pipeline.md) |
-| **Extend it** | [Domain Packs](docs/domain-packs.md) · [Pack distribution & registry](docs/distribution.md) · [Code memory](docs/roadmap/code-memory-domain.md) |
+| **Extend it** | [Domain Packs](docs/domain-packs.md) (registry + marketplace + seed documents) · [External indexer protocol](docs/indexer-protocol.md) · [MCP pack tools](docs/mcp-pack-tools.md) · [Listing playbook](docs/distribution.md) · [Code memory](docs/roadmap/code-memory-domain.md) |
 | **Run it** | [Operations](docs/operations.md) · [Operator playbook](docs/operator-playbook.md) · [Deploy runbook](docs/DEPLOY.md) |
 | **Measure it** | [Eval harness](docs/eval.md) · [LoCoMo benchmark](docs/locomo.md) |
 
@@ -249,14 +327,23 @@ public issue — see [`SECURITY.md`](SECURITY.md).
 ## Roadmap
 
 Shipped: bitemporal graph, hybrid retrieval pipeline, conflict resolution,
-domain-scoped source reputation + cross-source corroboration, identity merge,
-GDPR forget, native MCP, Domain Packs (industry library + signed global
-registry), code memory (record *why* a decision was made, drift-resistant symbol
-anchors), eval-gated CI, off-hours self-improvement (dreams).
+domain-scoped source reputation + cross-source corroboration + a read-only
+trust-inputs API, identity merge, GDPR forget, native MCP, per-key ABAC
+policy sets, the document pipeline with an external-indexer protocol
+(pull work API + signed webhook hints + reference client), Domain Packs
+(industry library, signed global registry with verified badges, download
+counters and pull-only mirroring, marketplace with paid packs, pack-declared
+MCP tools, seed documents), OpenAPI 3.1 platform spec, worker-thread offloads
++ `PROCESS_ROLE` api/worker split, code memory (record *why* a decision was
+made, drift-resistant symbol anchors), eval-gated CI, off-hours
+self-improvement (dreams).
 
-Exploring (issues + ideas welcome): HNSW on by default for large tenants,
-multi-hop edge-expansion by default, a local cross-encoder fallback, per-leg
-OpenTelemetry spans, and an embedding-upgrade path. Have a use case? Open an issue.
+Exploring (issues + ideas welcome): extractor span-grounding offload (profile
+first), worker-pool right-sizing as more handlers move to threads, and the
+full paid LoCoMo run with published numbers. Temporal was evaluated and
+deliberately not adopted — the re-evaluation triggers live in
+[docs/roadmap/platform-gap-2026-07.md](docs/roadmap/platform-gap-2026-07.md).
+Have a use case? Open an issue.
 
 ## License
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,5 +1,8 @@
 # brain.inite.ai — deployment runbook
 
+How the production instance is built, shipped, rolled back, and
+observed — for whoever operates the deploy pipeline.
+
 Production target: `brain.inite.ai`
 Docker host: `inite-temporal` droplet (SFO), self-hosted GitHub runner `[self-hosted, sfo]`
 Reverse proxy: Traefik global, automatic Let's Encrypt
@@ -26,9 +29,11 @@ Workflow: `.github/workflows/deploy-brain.yml` (manual dispatch)
 ```
 
 The shared `inite-surrealdb` is **the** decision point — chosen for ops
-simplicity over hard isolation. Brain's namespace `brain` is fully isolated
-data-wise from gateway's `inite`. CPU/IO is shared. Watch for hot-tenant
-contention if either side starts running heavy graph queries.
+simplicity over hard isolation. Brain shares the `inite` namespace with the
+gateway but owns its per-tenant `co_<companyId>` databases and the
+`knowledge_*` tables, so the two never collide data-wise. CPU/IO is shared.
+Watch for hot-tenant contention if either side starts running heavy graph
+queries.
 
 Brain holds an **internal SQL connection pool** (root + scoped). The DB-
 level PII fence (migration `0005_pii_permissions.surql`) creates the
@@ -76,9 +81,11 @@ retries for 2 minutes.
      pulls the new image, `docker-compose up -d`.
    - Waits 25s for the container, then probes `https://brain.inite.ai/health`
      with retries (cert provisioning).
-5. First request to any tenant triggers `ensureSchema` — migrations 0001-0009
-   apply on the per-tenant `co_<companyId>` DB, including 0005 (PII PERMISSIONS
-   + `brain_caller` user). No separate migration step needed.
+5. First request to any tenant triggers `ensureSchema` — every numbered
+   migration in `src/db/migrations/` (0001 through the current head) applies
+   on the per-tenant `co_<companyId>` DB, including 0005 (PII PERMISSIONS +
+   `brain_caller` user). No separate migration step needed; concurrent
+   appliers racing the ledger insert are tolerated.
 
 ## Subsequent deploys
 
@@ -173,3 +180,9 @@ see [`monitoring/README.md`](../monitoring/README.md) and
   in-depth becomes app-only — DB-level fence not enforced). On password
   rotation: re-deploy. Brain's `ensureSchema` re-syncs the password
   once per process boot for any tenant DB that already has 0005 applied.
+
+## See also
+
+- [Operations](operations.md) — every env var the compose file sets.
+- [Operator playbook](operator-playbook.md) — day-2 troubleshooting once deployed.
+- [`monitoring/README.md`](../monitoring/README.md) — the observability stack in depth.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,42 +1,78 @@
 # Documentation
 
-Brain documentation — grouped by what you're trying to do, not by
-which file the bits used to live in.
+The hub for everything in `docs/` — grouped by what you're trying to do,
+with one row per document.
 
-## For new users
+**Where do I start?**
+
+- **Using Brain from an app or agent** → [Getting started](getting-started.md),
+  then the [API reference](api.md).
+- **Understanding how it works** → [Architecture](architecture.md), then
+  [Data model](data-model.md) and [Bitemporal semantics](bitemporal-semantics.md).
+- **Building on the platform** (packs, indexers, tools) →
+  [Domain Packs](domain-packs.md) and the
+  [External indexer protocol](indexer-protocol.md).
+- **Running it in production** → [Operations](operations.md) and the
+  [Operator playbook](operator-playbook.md).
+
+## Use it
 
 | Doc | Purpose |
 |---|---|
-| [Getting started](getting-started.md) | Run brain locally in five commands. Seed an ApiKey. Smoke test. |
-| [Migration guide](migration-guide.md) | Wire a vertical into brain via the `@inite/knowledge` SDK. |
+| [Getting started](getting-started.md) | Run Brain locally in five commands, seed an ApiKey, smoke test. |
+| [Migration guide](migration-guide.md) | Wire a vertical into Brain via the `@inite/knowledge` SDK. |
+| [API reference](api.md) | Every v1 endpoint with notes + auth scopes, grouped by area. |
+| [OpenAPI 3.1 spec](openapi.json) | Machine-readable platform surface. Generated — regenerate with `pnpm openapi:build`, never edit by hand. |
 
-## For developers
+## Understand it
 
 | Doc | Purpose |
 |---|---|
-| [Architecture](architecture.md) | Retrieval pipeline, multi-hop planner, synthesize guardrail, dreams + job queue. |
-| [API reference](api.md) | Every v1 endpoint with notes + auth scopes. |
+| [Architecture](architecture.md) | Retrieval pipeline, multi-hop planner, synthesize guardrail, dreams + job queue, worker threads, MCP surface. |
 | [Data model](data-model.md) | Bitemporal facts, predicate vocabulary, conflict resolution, tenancy, PII / GDPR. |
-| [Bitemporal semantics — deep dive](bitemporal-semantics.md) | Default-now search, Allen's interval algebra, why not just post-filter. |
-| [Document pipeline](document-pipeline.md) | Source → Indexer → Candidates → Brain: composable indexers, staged candidates, origin-keyed corroboration, re-indexing, external indexers. |
+| [Bitemporal semantics](bitemporal-semantics.md) | Default-now search, Allen's interval algebra, why not just post-filter. |
+| [Source reputation & trust](source-reputation.md) | Domain-scoped trust, corroboration, feedback loop, trust in ranking. |
+| [ABAC access policies](abac.md) | Per-key policy sets: action gating + row-level read filtering, rollout runbook. |
+| [Document pipeline](document-pipeline.md) | Source → Indexer → Candidates → Brain: composable indexers, staged candidates, origin-keyed corroboration, re-indexing, external indexers, seed documents. |
 | [Eval harness](eval.md) | Production-gate retrieval + lifecycle eval. Load your CRM via JSON or Wikidata. |
 | [LoCoMo benchmark](locomo.md) | Long-term conversational memory eval — apples-to-apples vs Mem0 / Zep / MemGPT. |
 
-## For operators
+## Build on it
+
+Platform and community extension points — none require a PR to this repo.
 
 | Doc | Purpose |
 |---|---|
-| [Operations](operations.md) | All env vars, retrieval feature flags, queue tuning, boot validation, test commands. |
+| [Domain Packs](domain-packs.md) | The ontology extension standard: manifest reference, authoring quickstart, registry, marketplace, seed documents. |
+| [External indexer protocol](indexer-protocol.md) | Build a service that reads stored documents and submits candidate facts: poll → claim → content → submit. |
+| [MCP pack tools](mcp-pack-tools.md) | Packs extending the tenant MCP surface: query tools + HMAC-proxied external tools, consent flow, security model. |
+| [`examples/reference-indexer.ts`](../examples/reference-indexer.ts) | Dependency-free reference external indexer (`pnpm indexer:reference`). |
+| [Listing playbook](distribution.md) | Where to list Brain itself — MCP Registry, awesome-list PRs, ready-to-paste rows. |
+| [Code memory](roadmap/code-memory-domain.md) | The `code_memory` Domain Pack: remembering the *why* of a codebase. |
+| [Distillation dataset](code-memory/distillation-dataset.md) | Data plan + harness for the trained code-memory decision gate. |
+
+## Operate it
+
+| Doc | Purpose |
+|---|---|
+| [Operations](operations.md) | All env vars, feature flags, queue tuning, role split, enablement runbooks, test commands. |
 | [Operator playbook](operator-playbook.md) | Issue an ApiKey, troubleshoot ingest / search, run a GDPR forget, drain a stuck queue. |
-| [Deploy runbook](DEPLOY.md) | Production deploy — Traefik, GitHub Actions, rollback. |
-| [Distribution playbook](distribution.md) | Where to list brain — MCP Registry, awesome-* PRs, with ready-to-paste rows. |
+| [Deploy runbook](DEPLOY.md) | Production deploy — Traefik, GitHub Actions, rollback, observability. |
 
 ## Roadmap
 
-- [MCP + memory next steps](roadmap/mcp-and-memory.md) — planned work: memory_diff / procedural memory / MCP resources / ClaudeMcpAgent + full LoCoMo run
+- [Platform gap analysis — July 2026](roadmap/platform-gap-2026-07.md) — the
+  **current** roadmap document: where the platform stands, the Temporal
+  not-adopted decision (+ re-evaluation triggers), and the residual backlog.
+- Historical planning records (kept as a record of what was built, not TODOs):
+  [mcp-and-memory.md](roadmap/mcp-and-memory.md) (self-labelled ~95% shipped),
+  [next-session-2026-07.md](roadmap/next-session-2026-07.md),
+  [next-session-2026-07b.md](roadmap/next-session-2026-07b.md),
+  [audit-followup-2026-06.md](roadmap/audit-followup-2026-06.md),
+  [max-params-and-remainder-2026-06.md](roadmap/max-params-and-remainder-2026-06.md).
 
 ## Cross-cutting
 
 - [License](../LICENSE) — AGPL-3.0-or-later
 - [Security policy](../SECURITY.md) — private channel for vulnerabilities
-- [Contributing guide](../CONTRIBUTING.md) — PR bars, commit style, release model
+- [Contributing guide](../CONTRIBUTING.md) — PR bars, commit style, Domain Pack recipe

--- a/docs/abac.md
+++ b/docs/abac.md
@@ -1,12 +1,23 @@
 # ABAC — attribute-based access control for API keys
 
+Per-key policy sets that narrow what a scoped key may call and see —
+the policy model, enforcement points, and rollout runbook for tenant
+operators.
+
 Scopes answer "may this key search at all"; they cannot answer "may this key
 see facts that came from HR documents". ABAC adds named **policy sets** a
 tenant attaches to individual API keys. A set carries rules of two kinds:
 
 - **action rules** gate which REST endpoints and MCP tools the key can call,
   by name (`search_knowledge`, `record_fact`, `rest.documents.get`, …) or via
-  the macros `@readonly` / `@write` / `@all`;
+  the macros `@readonly` / `@write` / `@all`. The full gateable namespace —
+  MCP tool names verbatim, `rest.*` names for REST-only routes, and
+  auto-names for anything undecorated — is defined in
+  [`src/policy/action-registry.ts`](../src/policy/action-registry.ts) (the
+  source of truth; `GET /v1/admin/policy/registry` serves it to tooling).
+  Pack-declared MCP tools are gateable by their concrete
+  `<packId>__<toolName>` names — query tools are `read`-kind, external
+  tools `write`-kind ([mcp-pack-tools.md](mcp-pack-tools.md));
 - **source rules** gate which *rows* (facts, and edges via their `kind`) the
   key can read, by attribute match on the fact's provenance.
 
@@ -166,3 +177,10 @@ query() boundary. This applies equally to the pre-existing 0005 PII fence:
 every read surface (e2e-enforced). The canary test fails loudly the moment an
 upgrade or a move to record users makes PERMISSIONS fire — activate the fence
 then, deliberately.
+
+## See also
+
+- [API reference](api.md#abac-policy-sets) — every policy-set endpoint with wire notes.
+- [`src/policy/action-registry.ts`](../src/policy/action-registry.ts) — the gateable action namespace (source of truth).
+- [MCP pack tools](mcp-pack-tools.md) — how pack tools slot into the action model.
+- [Operations](operations.md) — `ABAC_*` flags and cache knobs.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,8 +1,11 @@
 # API reference
 
+An index of every HTTP endpoint Brain serves, grouped by area, with
+auth scopes — for anyone calling Brain over REST or wiring an admin UI.
 A generated [OpenAPI 3.1 document](openapi.json) covers the platform
-surface (registry, packs, documents, indexer work) — regenerate with
-`pnpm openapi:build`.
+surface (registry, packs, documents, indexer work) with full request /
+response schemas — regenerate with `pnpm openapi:build`; this page
+stays an index, not a second spec.
 
 All v1 endpoints are live; MCP transport is mounted per tenant. Every
 v1 call requires `Authorization: Bearer <plaintext>` where the key's
@@ -15,7 +18,8 @@ SHA-256 lives in `BRAIN_API_KEYS`. Admin endpoints require
 | Endpoint | Notes |
 |---|---|
 | `GET /health` | Container + SurrealDB readiness. No auth. |
-| `GET /metrics` | Prometheus exposition (in-cluster scrape). |
+| `GET /ready` | Readiness probe (schema + connectivity). No auth. |
+| `GET /metrics` | Prometheus exposition (in-cluster scrape; keep off the public surface). |
 
 ## Ingest
 
@@ -65,6 +69,10 @@ Protocol: [indexer-protocol.md](indexer-protocol.md).
 | `GET /v1/artifacts/:type/:entityId` | Derived artifacts (profile / digest / etc) with manual `recompile` POST. |
 | `GET /v1/sources` | Read-only trust inputs: declared `type`/`authLevel` ⋈ learned reputation, one row per source. Filters `domain` / `type` / `minSamples`, paginated (`limit` ≤ 200 / `offset`). Public projection — operator annotations (`owner`/`note`) stay on the admin surface. |
 | `GET /v1/sources/:sourceKey` | One source's declared identity, per-domain trust rows, and reputation history (newest first, ≤ 50). Same data as the `get_source_reputation` MCP tool. |
+| `GET /v1/communities` | Persisted graph communities (label propagation), paginated. |
+| `GET /v1/communities/search` | Vector search over community summaries. |
+| `GET /v1/communities/for-entity/:entityId` | Communities an entity belongs to. |
+| `GET /v1/stats/overview` | Tenant-level counts (entities / facts / edges) for dashboards. |
 
 ## Mutation (audited)
 
@@ -80,6 +88,50 @@ Protocol: [indexer-protocol.md](indexer-protocol.md).
 | Endpoint | Notes |
 |---|---|
 | `POST /v1/dreams/run` | Off-hours self-improvement: dedup / resolve / summarize (admin scope). |
+
+## Domain Packs (admin)
+
+Manifest format + install semantics: [domain-packs.md](domain-packs.md).
+All routes `brain:admin`.
+
+| Endpoint | Notes |
+|---|---|
+| `GET /v1/admin/packs` | Installed packs for the tenant. |
+| `POST /v1/admin/packs` | Install/upgrade from a manifest body (`{manifest, expectedChecksum?, acceptMcpTools?}`). A manifest with an `mcpTools` section **requires `acceptMcpTools: true`** (400 otherwise; re-required when an upgrade changes the section). Response includes `webhookSecret` (once, external packs) and `seedDocuments: {count, status}` when the manifest ships seeds. |
+| `POST /v1/admin/packs/from-registry` | Install from the global registry (`{packId, version?, acceptMcpTools?}`). Paid packs answer a self-describing `402` until the entitlement exists — see [Marketplace](domain-packs.md#marketplace). |
+| `POST /v1/admin/packs/:packId/eval` | Run the pack's own `evalFixtures` through the live extractor (`?mode=union\|dedicated`). |
+| `DELETE /v1/admin/packs/:packId` | Uninstall — deprecates the pack's predicates; facts survive. |
+
+## Registry + marketplace
+
+Global pack catalogue (shared `system` database) + instance-local
+marketplace state. Semantics: [domain-packs.md § Registry](domain-packs.md#the-registry-global-catalogue).
+
+| Endpoint | Scope | Notes |
+|---|---|---|
+| `GET /v1/registry/packs` | `brain:read` | Discovery: `?q=&tag=&publisher=`; carries `featured` / download counters / `verified` / `origin` (mirrored rows). |
+| `GET /v1/registry/packs/:packId` | `brain:read` | All versions + latest. |
+| `GET /v1/registry/packs/:packId/:version` | `brain:read` | One version (`latest` accepted). |
+| `GET /v1/registry/publishers/:publisher` | `brain:read` | Publisher page: profile (or null) + published packs. |
+| `POST /v1/admin/registry/packs` | `registry:publish` | Publish a manifest; `(packId, version)` immutable, identical republish idempotent. |
+| `POST /v1/admin/registry/packs/:packId/:version/yank` / `unyank` | `registry:publish` | Flag a bad version out of resolution; never deletes. |
+| `PUT /v1/admin/registry/packs/:packId/pricing` | `registry:publish` | Price the pack (`{amount, currency}`, minor units); mints a billing product + price. |
+| `DELETE /v1/admin/registry/packs/:packId/pricing` | `registry:publish` | Back to free. |
+| `POST /v1/admin/registry/packs/:packId/checkout` | `brain:admin` | Create a billing checkout session for a paid pack (`{successUrl?, errorUrl?}`, optional `idempotency-key` header). |
+| `POST /v1/admin/registry/packs/:packId/feature` / `unfeature` | `registry:curate` | Featured curation (hosting-operator scope). |
+| `PUT /v1/admin/registry/publishers/:publisher` | `registry:publish` | Upsert the public publisher profile (requires ≥1 verified pack under that publisher id). |
+| `GET /registry/ui` · `GET /registry/ui/publisher/:publisher` | none | Public server-rendered HTML catalogue / publisher page. |
+
+## Admin — sources
+
+Source registry + trust management (all `brain:admin`); the model lives
+in [source-reputation.md](source-reputation.md).
+
+| Endpoint | Notes |
+|---|---|
+| `GET /v1/admin/sources` | Registry ⋈ learned trust, one row per source (includes `owner` / `note`). |
+| `GET /v1/admin/sources/:sourceKey` | Detail: per-domain trust rows + history + recent facts. |
+| `PUT /v1/admin/sources/:sourceKey` | Declare `type` / `authLevel` / `owner` / `note`. |
 
 ## Admin — jobs + leases
 
@@ -105,6 +157,24 @@ has a zod wire contract. The browser-side BFF at
 response through the same schema — drift becomes a loud 502 instead of
 a quiet stale field.
 
+## Admin — governance + ops
+
+The rest of the `brain:admin` surface, compactly (one row per family —
+the admin UI at brain-landing is the primary consumer):
+
+| Family | Endpoints | Notes |
+|---|---|---|
+| Overview + audit | `GET /v1/admin/overview`, `GET /v1/admin/audit` | Tenant dashboard counts; filterable `audit_event` feed. |
+| Predicates | `GET/POST /v1/admin/predicates`, `PATCH/DELETE /v1/admin/predicates/:id`, `POST …/:id/promote`, `POST …/:id/alias` | Tenant predicate-registry CRUD + proposed→active promotion + alias lifecycle. |
+| Ops | `GET /v1/admin/config`, `GET /v1/admin/dlq`, `DELETE /v1/admin/dlq/:companyId/:id`, `GET /v1/admin/forgotten` (+`/export`), `GET /v1/admin/pii`, `GET /v1/admin/operator-actions` | Config catalogue (effective values + defaults), dead-letter queue, forget tombstones, PII-surface inventory, operator action log. |
+| Infra | `GET /v1/admin/health/components`, `GET /v1/admin/migrations`, `GET /v1/admin/throttler`, `GET /v1/admin/now` | Component health, per-tenant migration ledger, rate-limiter state, server clock. |
+| Retrieval ops | `GET /v1/admin/router/stats`, `GET /v1/admin/cost`, `GET /v1/admin/calibration`, `POST /v1/admin/reindex/embeddings` | Router cache stats, LLM cost rollups, calibration curves, re-embed kick. |
+| Eval | `GET /v1/admin/scenarios` (+`/:id`, `POST /:id/run`, `POST /run-batch`), `GET/POST /v1/admin/baselines…`, `GET /v1/admin/traces…` | Runtime scenario runner over `src/eval/`, baseline diffing, debug traces. |
+| Dreams detail | `GET /v1/admin/dreams/runs/:runId/emits`, `GET /v1/admin/dreams/summary`, `POST /v1/admin/dreams/run` | Per-run emit drill-down + rollups; synchronous dreams trigger. |
+| Code memory | `GET /v1/admin/code-memory/anchors`, `POST /v1/admin/code-memory/anchors/apply` | Drift-resistant anchor review + apply. |
+| Demo | `POST /v1/admin/demo/*`, `GET /v1/admin/demo/state` | Sandboxed demo-tenant flows for the public playground. |
+| Tenancy | `DELETE /v1/admin/tenants/:companyId` | Whole-tenant erasure (`REMOVE DATABASE`). |
+
 ## MCP
 
 | Endpoint | Notes |
@@ -119,7 +189,8 @@ a quiet stale field.
 | `brain:write` | All ingest endpoints. |
 | `brain:read_pii` | Lifts the PII gate — `dob` / `email` / `phone` / `address` facts return real values. |
 | `brain:admin` | All `/v1/admin/*` endpoints, dreams trigger, retraction / forget. |
-| `registry:publish` | Publish/yank in the global pack registry (catalogue shared across tenants). |
+| `registry:publish` | Publish/yank in the global pack registry (catalogue shared across tenants); also pricing + publisher-profile writes for the publisher's own packs. |
+| `registry:curate` | Feature/unfeature packs in the catalogue — a hosting-operator scope, distinct from `registry:publish` (publishers manage their own packs; curation ranks everyone's). Env-key-only, like `registry:publish`. |
 | `indexer:write` | Stage candidates as an external indexer (`POST /v1/documents/:id/candidates`) — can propose hypotheses, never write facts directly. Optionally pack-bound: a key with `packIds` (static entry) or a `packs` JWT claim acts ONLY as those pack identities (403 outside the binding). |
 
 Keys are stored as `sha256:<hex>` — see [Getting started](getting-started.md#seed-an-apikey)
@@ -158,3 +229,10 @@ gets a synthetic enforce/deny-all set and
 
 Denied REST calls answer `403 {error: 'policy_denied', action, policySet,
 ruleId}`. Enforce-denied MCP tools disappear from `tools/list` entirely.
+
+## See also
+
+- [OpenAPI 3.1 spec](openapi.json) — request/response schemas for the platform surface (generated).
+- [Operations](operations.md) — the env flags that gate whole endpoint families.
+- [Domain Packs](domain-packs.md) — pack manifest + registry + marketplace semantics.
+- [External indexer protocol](indexer-protocol.md) — the work API end to end.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,13 @@
 # Architecture
 
+How Brain's read path, background plane, and serving surfaces fit
+together — the developer's mental model of the service.
+
 Brain has four moving parts: a layered **retrieval pipeline**, an
 optional **multi-hop planner** that chains it, a **synthesize**
-guardrail on top, and a **dreams + jobs** background plane.
+guardrail on top, and a **dreams + jobs** background plane — served
+over REST and a per-tenant [MCP endpoint](#mcp-surface), with CPU-heavy
+work pushed to [worker threads](#worker-threads--process-roles).
 
 ## Retrieval pipeline
 
@@ -264,3 +269,46 @@ rows are currently in `running` state (with `claimedBy` / `attempts`
 `worker_loop` leader flag. The admin UI page at `/admin/leases` auto-
 refreshes every 5s and colour-codes stale heartbeats / expired
 leases. See [Operator playbook § Drain a stuck queue](operator-playbook.md).
+
+## Worker threads + process roles
+
+Everything CPU-shaped runs off the main event loop in
+`node:worker_threads`, so a burst of embeddings or a rerank never
+starves HTTP: the BGE-M3 embedder (`BGE_M3_WORKER=1`), the local
+ONNX cross-encoder, the NLI intent classifier behind chat routing,
+local NER, community label propagation, and tiktoken token counting.
+Models lazy-load where they're used, so a pod only pays for what its
+role touches.
+
+When one process stops being enough, `PROCESS_ROLE=api|worker|all`
+splits the same image into an HTTP-only pod and a jobs pod against the
+same SurrealDB — no new infrastructure, just a flag bundle over the
+existing worker-loop kill switch and leader leases. Semantics, compose
+recipe, and when to actually split:
+[Operations § Splitting API and worker roles](operations.md#splitting-api-and-worker-roles).
+(A dedicated workflow engine was evaluated and deliberately not
+adopted — see [platform-gap-2026-07.md](roadmap/platform-gap-2026-07.md).)
+
+## MCP surface
+
+Every tenant gets a Streamable HTTP MCP endpoint (`ALL /mcp/:companyId`)
+serving the same knowledge over agent-native tools: 28 static tools
+across read / write / community / procedural / source families
+(`ingest_document` registers only under `DOCUMENT_INGEST_ENABLED`),
+gated by the caller key's scopes (and, when enabled, per-key
+[ABAC policies](abac.md) — enforce-denied tools vanish from
+`tools/list`). Two MCP resources (`brain://entity/...`) and sampling
+round out the surface; REST and MCP share one action namespace, so a
+policy written once gates both.
+
+Installed Domain Packs can extend the surface with consented,
+flag-gated tools of their own — declarative query tools over the
+pack's predicates or HMAC-proxied external tools. Model + security
+posture: [mcp-pack-tools.md](mcp-pack-tools.md).
+
+## See also
+
+- [Data model](data-model.md) — the facts the pipeline retrieves.
+- [Bitemporal semantics](bitemporal-semantics.md) — the two clocks behind `asOf`.
+- [Document pipeline](document-pipeline.md) — the ingestion plane.
+- [Operations](operations.md) — every flag named above, with rollout guidance.

--- a/docs/bitemporal-semantics.md
+++ b/docs/bitemporal-semantics.md
@@ -106,3 +106,9 @@ The "actual now" default is the convention in:
 - **Graphiti / Zep** (Jan 2025) — bitemporal KG specifically for AI-agent memory; default search is "current truth", `as_of` for historical context. Cited in the research that informed this design.
 
 Brain follows the same family. The `includeStale` flag exists for exotic callers (admin tooling, batch jobs that build full-history exports), not as a mode toggle for normal application code.
+
+## See also
+
+- [Data model](data-model.md) — the fact shape these axes live on.
+- [Architecture](architecture.md) — how the cutoff pushes into the retrieval WHERE clause.
+- [API reference](api.md) — `asOf` / `includeStale` / timeline endpoints.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,9 +1,12 @@
 # Data model
 
+What Brain stores and why — facts, vocabulary, tenancy, and erasure —
+for anyone writing to or reasoning about the graph.
+
 Brain stores **bitemporal facts** about entities, governed by a
 declarative **predicate vocabulary**. Tenancy is physical-isolation;
-PII gating runs at the database layer. GDPR forgets cascade
-synchronously.
+PII gating runs at the JS read layer (every read surface, e2e-enforced).
+GDPR forgets cascade synchronously.
 
 ## Bitemporal facts
 
@@ -25,11 +28,14 @@ Full semantics: [bitemporal-semantics.md](bitemporal-semantics.md).
 ## Predicate vocabulary
 
 Brain governs how facts are merged via per-predicate policies
-(semantics, decay half-life, PII class). The vocabulary and the
-conflict-resolution algorithm are **declared in the spec** at
+(semantics, decay half-life, PII class). The live vocabulary is each
+tenant's **predicate registry** (`knowledge_predicate`, managed via
+`/v1/admin/predicates`), seeded from the core set plus any installed
+[Domain Packs](domain-packs.md); the core set and the
+conflict-resolution algorithm are declared in the spec at
 `inite-ecosystem/core/capabilities/knowledge.yaml`.
 
-Quick reference (full table in spec):
+Quick reference (core predicates):
 
 | Predicate | Semantics | Decay half-life | PII class |
 |---|---|---|---|
@@ -72,7 +78,10 @@ A separate `system` database holds global state — `leader_lease`,
   cascades through facts, edges, and embeddings, leaving only an
   HMAC-hash tombstone in `forgotten_entity`.
 - Sensitive predicates are gated by `brain:read_pii` scope — they
-  never appear in MCP results to AI agents without it.
+  never appear in MCP results to AI agents without it. The gate is
+  enforced in the app layer on every read surface (the DB-level
+  PERMISSIONS fence exists but is inert for the pooled system user —
+  see [ABAC § DB-level fence status](abac.md#db-level-fence-status-migration-0057)).
 
 ### `FORGET_HMAC_KEY`
 
@@ -88,3 +97,10 @@ flip status flags. The `audit_event` table records every
 `create`/`update`/`delete`/`define` operation per tenant (migration
 0023). Operators read it through `GET /v1/admin/audit`; admin UI has a
 filterable page with per-source / per-op rollups.
+
+## See also
+
+- [Bitemporal semantics](bitemporal-semantics.md) — the two clocks in depth.
+- [Source reputation & trust](source-reputation.md) — the trust snapshot stamped on every fact.
+- [Domain Packs](domain-packs.md) — extending the predicate vocabulary.
+- [ABAC access policies](abac.md) — narrowing what individual keys read.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -4,6 +4,15 @@ How to land `inite-brain-service` in the directories and awesome lists that MCP 
 
 This file is the source of truth — keep the row text and form fields here so the next push (new tool surface, new version) needs only a search-and-replace.
 
+> [!NOTE]
+> This playbook is about distributing **Brain itself**. Distributing
+> **Domain Packs** is a built-in product surface: the global registry with
+> verified-publisher badges, download counters, and pull-only
+> cross-instance mirroring, plus a marketplace layer (featured curation,
+> publisher profiles, paid packs) — see
+> [Domain Packs § Registry](domain-packs.md#the-registry-global-catalogue)
+> and [§ Marketplace](domain-packs.md#marketplace).
+
 ## Fast-path automation
 
 For the Tier 1-2 awesome-list PRs, `scripts/submit-awesome.sh` automates fork + clone + insert + commit + draft-PR for the 5 most-impactful targets:
@@ -259,3 +268,8 @@ Same row format as #9 unless a specific list uses a table. Each PR is ~5 minutes
 ## After landing
 
 Update the Status table at the top of this file with the live URL for each row. Add a Telegram / X teaser post per major hit (template lives in `docs/teasers.md` — create when first one ships). When you bump brain past a major version, re-publish `server.json`, re-check the top three (punkpeye / topoteretes / surrealdb) for stale descriptions, edit-PR if the row text doesn't reflect the new surface.
+
+## See also
+
+- [Domain Packs](domain-packs.md) — distributing packs through the built-in registry + marketplace.
+- [README](../README.md) — the positioning copy the list rows compress.

--- a/docs/document-pipeline.md
+++ b/docs/document-pipeline.md
@@ -6,13 +6,23 @@ exactly one decision engine DISPOSES. Everything here is dark behind
 `DOCUMENT_INGEST_ENABLED` (default off); with the flag off the legacy
 mention/fact paths behave byte-identically.
 
+```mermaid
+flowchart LR
+  conn["connectors<br/>(PDF · email · chat · git)"] --> src["Source<br/>normalized document<br/>hash-deduped · PII-redacted · chunked"]
+  seeds["pack seedDocuments<br/>(install-triggered)"] --> src
+  src --> router{"relevance router<br/>L0 vertical / L1 keywords / L2 cosine"}
+  router --> union["Indexer: union pass<br/>('_general' + virtual packs)"]
+  router --> ded["Indexer: dedicated pack runs<br/>(own model / prompt budget)"]
+  router --> work["external work items<br/>(pending indexer_run)"]
+  work <--> ext["external indexer ✳<br/>poll → claim → content → submit"]
+  union --> cand["Candidates<br/>staged hypotheses — not memory"]
+  ded --> cand
+  ext --> ground["span re-grounding"] --> cand
+  cand --> commit["Brain: CommitMemory<br/>unify entities · merge facts ·<br/>fn::resolve_fact"]
+  commit --> graph[("bitemporal graph")]
 ```
-Source          normalized document (brain doesn't know what a PDF is)
-  → Indexer     composable domain readers (one union pass + opt-in
-                dedicated pack runs, gated by a relevance router)
-  → Candidates  "this MIGHT be a fact" — staged hypotheses, not memory
-  → Brain       merge / dedupe / conflict-resolve → CommitMemory
-```
+
+✳ = the third-party seam — see [indexer-protocol.md](indexer-protocol.md).
 
 Schema: migrations `0048` (source_document + source_chunk), `0049`
 (indexer_run + candidate), `0050` (origin-keyed corroboration). Code:
@@ -136,6 +146,19 @@ skips whatever the pack version already processed; the extraction cache
 eats unchanged text. New candidates merge against existing memory through
 the same resolver — originKey keeps a document from corroborating itself.
 
+## Seed documents (pack-shipped knowledge)
+
+A Domain Pack may ship `seedDocuments` — pre-populated domain knowledge
+ingested through THIS pipeline when the pack is installed (flag
+`PACK_SEED_INGEST_ENABLED`, default on; requires `DOCUMENT_INGEST_ENABLED`
+since seeds ride the normal path). Each seed becomes an ordinary document
+with `kind: 'pack_seed'` and provenance meta on every derived fact's
+`source.meta` (`pack_seed`, `pack_id`, `pack_version`, `pack_seed_doc`) —
+same chunking, staging, conflict resolution, and contentHash dedupe as any
+connector's document, so a same-version reinstall or an unchanged seed on
+upgrade is a no-op. Caps, upgrade semantics, and the install-response
+status field: [Domain Packs § Seed documents](domain-packs.md#seed-documents-consumed).
+
 ## External indexers
 
 A remote service (CI job, SaaS integration, an agent) registers as a pack
@@ -221,6 +244,8 @@ only — polling remains the source of truth
 | `CANDIDATE_PENDING_TTL_DAYS` | `7` | Sweeper: expire stuck pending candidates after. |
 | `REINDEX_MAX_DOCS_PER_RUN` | `500` | Backfill batch budget per job. |
 | `INDEXER_EXTERNAL_PENDING_TTL_DAYS` | `7` | Sweeper: expire unclaimed external work items after. |
+| `PACK_SEED_INGEST_ENABLED` | `1` | Ingest pack `seedDocuments` on install (also needs `DOCUMENT_INGEST_ENABLED`). |
+| `INDEXER_WEBHOOK_PUSH_ENABLED` | `1` | `work_available` push hints to packs with a `callbackUrl` (polling stays the source of truth). |
 
 ## Observability
 
@@ -231,3 +256,10 @@ Prometheus: `brain_documents_total{result}`,
 `brain.commit` (+ a `brain.commit.merge` artifact with per-document merge
 stats). Per-pack stats live on `indexer_run.stats` rows — pack ids are
 unbounded, so they are deliberately not metric labels.
+
+## See also
+
+- [External indexer protocol](indexer-protocol.md) — the third-party side of the work API.
+- [Domain Packs](domain-packs.md) — indexer descriptors, relevance routing, seed documents.
+- [Operations](operations.md#enabling-the-document-pipeline--external-indexers) — the staged enablement runbook.
+- [API reference](api.md) — every document + indexer endpoint with scopes.

--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -1,10 +1,15 @@
 # Domain Packs — the ontology extension standard
 
+The manifest format, authoring loop, registry, and marketplace for pack
+authors and operators — the standard third parties conform to.
+
+> [!NOTE]
 > A **Domain Pack** is a versioned, pluggable bundle of ontology that extends
 > the brain predicate registry **without forking core**. Packs let a domain
 > (code-memory, real-estate, fintech, …) — or the community — ship its own
-> typed predicates that brain merges into every tenant's registry. This file is
-> the standard third parties conform to.
+> typed predicates that brain merges into every tenant's registry, plus
+> optional extraction tuning, eval fixtures, indexer execution, seed
+> documents, and MCP tools.
 
 ## Why packs
 
@@ -15,6 +20,16 @@ but baking every domain's predicates into the core seed doesn't scale and can't
 be community-extended. Packs make the ontology a first-class, versioned plugin.
 
 ## Quickstart: author → validate → sign → publish → install
+
+```mermaid
+flowchart LR
+  init["pnpm pack:init"] --> edit["edit manifest<br/>predicates · profile · fixtures ·<br/>indexer · seeds · tools"]
+  edit --> validate["pack:validate"] --> sign["pack:sign<br/>(ed25519)"] --> publish["pack:publish"]
+  publish --> registry[("global registry<br/>immutable versions · yank ·<br/>verified · downloads")]
+  registry --> install["pack:install / from-registry<br/>(consent · checksum pin)"] --> evalstep["POST /v1/admin/packs/:id/eval"]
+  upstream[("upstream registry")] -. "pull-only mirror" .-> registry
+  market["marketplace<br/>featured · profiles · paid"] -. "instance-local" .-> registry
+```
 
 The whole community-author loop, copy-paste ready (details for each step live
 in the sections below):
@@ -55,15 +70,22 @@ published to a registry instance and installed per-tenant.
 
 ## The manifest
 
-A pack is a `DomainPackManifest` (`src/ai/domain-packs/manifest.ts`):
+A pack is a `DomainPackManifest` (`src/ai/domain-packs/manifest.ts`).
+Every optional section is covered by the pack checksum + signature —
+there is no out-of-band pack content:
 
 ```ts
 interface DomainPackManifest {
   id: string;            // snake_case, no "__" — the predicate namespace
   version: string;       // semver MAJOR.MINOR.PATCH — bump to ship an update
   description: string;
-  predicates: PackPredicate[];   // the ontology this pack contributes
-  indexer?: IndexerDescriptor;   // document-pipeline execution (see below)
+  predicates: PackPredicate[];        // the ontology this pack contributes
+  extractionProfile?: {…};            // extractor tuning (see below)
+  evalFixtures?: EvalFixture[];       // per-pack extraction tests (see below)
+  indexer?: IndexerDescriptor;        // document-pipeline execution (see below)
+  seedDocuments?: SeedDocument[];     // knowledge shipped with the pack (see below)
+  mcpTools?: PackMcpTool[];           // MCP surface extension (see mcp-pack-tools.md)
+  publisher?: string; signature?: string;  // ed25519 authorship (pnpm pack:sign)
 }
 
 type PackPredicate = {
@@ -107,7 +129,12 @@ than silently shadowing.
 - So installing a builtin pack = author a manifest module + add it to
   `BUILTIN_PACKS`; its namespaced predicates are seeded into every tenant.
 
-## Authoring a pack
+## Authoring a builtin pack (in-repo)
+
+Community packs use the JSON quickstart above (`pnpm pack:init`) and need
+no PR; first-party distributable packs follow the recipe in
+[CONTRIBUTING.md](../CONTRIBUTING.md#building-a-domain-pack). A **builtin**
+pack (seeded into every tenant, like `code_memory`) is a code change:
 
 1. Create `src/ai/domain-packs/<your-pack>.pack.ts` exporting a
    `DomainPackManifest`. Use the reference: `code-memory.pack.ts`.
@@ -146,8 +173,7 @@ anchored to code anchors. See `docs/roadmap/code-memory-domain.md`.
 ## Extraction profiles (consumed)
 
 A pack MAY ship an `extractionProfile` — domain-specific tuning for the LLM
-extractor — and, unlike the still-forward-compat `evalFixtures`, it is now
-**consumed at extract time**:
+extractor, **consumed at extract time**:
 
 ```jsonc
 "extractionProfile": {
@@ -174,6 +200,40 @@ The first pack to use this is **real_estate** (`src/ai/domain-packs/
 real-estate.pack.ts`, distributable JSON at `packs/real-estate.pack.json`) — a
 DISTRIBUTABLE pack (installed per-tenant, deliberately NOT a builtin so its
 domain predicates don't seed into unrelated tenants).
+
+## Eval fixtures (consumed)
+
+A pack may ship `evalFixtures` — small extraction test cases for its domain,
+consumed at runtime (like `extractionProfile`):
+
+```jsonc
+"evalFixtures": [
+  {
+    "id": "zoning",
+    "text": "The parcel at 12 Elm St is zoned R-2.",
+    "expect": { "facts": [{ "predicate": "zoned_as", "objectIncludes": "R-2" }] }
+  }
+]
+```
+
+- `text` — the mention run through the LIVE extractor for the tenant (with the
+  pack's predicates + extractionProfile active).
+- `expect.facts[].predicate` — bare (`zoned_as`) resolves to the pack namespace
+  (`real_estate__zoned_as`); an already-namespaced id is used verbatim.
+  `objectIncludes` is an optional case-insensitive substring on the value.
+  `expect.minEntities` / `minFacts` are coarse thresholds.
+
+Flow: the manifest (already stored in `domain_pack` on install, or shipped for
+builtins) → `PackEvalService` runs each fixture through
+`ExtractorService.extract` → `scoreFixture` (pure) → a pass/fail report:
+
+```
+POST /v1/admin/packs/:packId/eval   (brain:admin)
+→ { packId, version, total, passed, results: [{ id, passed, failures[] }] }
+```
+
+`real_estate` ships three fixtures (zoning / valuation / tenure) as the
+demonstrator. Nothing forward-compat remains in the manifest.
 
 ## Indexer descriptor
 
@@ -389,40 +449,6 @@ signature validated against this instance's trust store is what ties a
 publisher's public page. Profile URLs render as links only when they parse
 as http(s).
 
-## Eval fixtures (consumed)
-
-A pack may ship `evalFixtures` — small extraction test cases for its domain,
-now **consumed at runtime** (like `extractionProfile`):
-
-```jsonc
-"evalFixtures": [
-  {
-    "id": "zoning",
-    "text": "The parcel at 12 Elm St is zoned R-2.",
-    "expect": { "facts": [{ "predicate": "zoned_as", "objectIncludes": "R-2" }] }
-  }
-]
-```
-
-- `text` — the mention run through the LIVE extractor for the tenant (with the
-  pack's predicates + extractionProfile active).
-- `expect.facts[].predicate` — bare (`zoned_as`) resolves to the pack namespace
-  (`real_estate__zoned_as`); an already-namespaced id is used verbatim.
-  `objectIncludes` is an optional case-insensitive substring on the value.
-  `expect.minEntities` / `minFacts` are coarse thresholds.
-
-Flow: the manifest (already stored in `domain_pack` on install, or shipped for
-builtins) → `PackEvalService` runs each fixture through
-`ExtractorService.extract` → `scoreFixture` (pure) → a pass/fail report:
-
-```
-POST /v1/admin/packs/:packId/eval   (brain:admin)
-→ { packId, version, total, passed, results: [{ id, passed, failures[] }] }
-```
-
-`real_estate` ships three fixtures (zoning / valuation / tenure) as the
-demonstrator. Nothing forward-compat remains in the manifest.
-
 ## Seed documents (consumed)
 
 A pack may ship `seedDocuments` — pre-populated domain knowledge that is
@@ -502,3 +528,10 @@ committed JSON in `packs/*.pack.json` (drift-guarded by
 `test/industry-packs.unit-spec.ts`). Install one with
 `pnpm pack:install -- --registry fintech` (after `registry:seed`) or
 `--file packs/fintech.pack.json`.
+
+## See also
+
+- [MCP pack tools](mcp-pack-tools.md) — the full `mcpTools` reference: consent, protocol, security model.
+- [External indexer protocol](indexer-protocol.md) — building the remote side of `indexer: { mode: 'external' }`.
+- [Document pipeline](document-pipeline.md) — where indexer descriptors and seed documents execute.
+- [API reference](api.md) — the pack, registry, and marketplace endpoints with scopes.

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -1,5 +1,8 @@
 # Eval harness
 
+The retrieval + memory-lifecycle quality gate and how to run it on your
+own data — for contributors and operators measuring Brain.
+
 `test/eval/` is the production gate, not a smoke folder. It runs
 against a spawned brain process with real OpenAI, against ~250
 retrieval queries plus 3 synthesize scenarios, and asserts hard
@@ -264,3 +267,9 @@ const score = await computeFaithfulness(new OpenAI(), {
 });
 // → { faithfulness: 0.83, totalClaims: 6, supportedClaims: 4, partialClaims: 1, unsupportedClaims: 1, claims: [...] }
 ```
+
+## See also
+
+- [LoCoMo benchmark](locomo.md) — the external long-term-memory benchmark run through the same surfaces.
+- [Operations § Tests](operations.md#tests) — the full test-command matrix.
+- [Domain Packs § Eval fixtures](domain-packs.md#eval-fixtures-consumed) — per-pack extraction evals.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,9 @@
 # Getting started
 
-Brain runs on Node 22 + SurrealDB 2.3.10 + OpenAI. The fast path is
-five commands; everything else is in the linked docs.
+Zero to a running Brain with one ingested fact — for anyone standing up
+the service for the first time. Brain runs on Node 22 + SurrealDB 3.1.5
++ OpenAI. The fast path is five commands; everything else is in the
+linked docs.
 
 ## Prerequisites
 
@@ -79,6 +81,15 @@ idempotent.
 
 ## Next steps
 
+- Connect an MCP agent: point any MCP-capable harness at
+  `http://localhost:3000/mcp/co_demo` with the same Bearer key
+  (per-client recipes in [README § Connect an agent](../README.md#connect-an-agent)).
+- Feed it documents: set `DOCUMENT_INGEST_ENABLED=1` and POST to
+  `/v1/ingest/document` — [Document pipeline](document-pipeline.md).
+- Install a Domain Pack (needs a `brain:admin`-scoped key):
+  `BRAIN_API_KEY=... pnpm pack:install -- --brain-url http://localhost:3000
+  --file packs/fintech.pack.json` extends the ontology at runtime —
+  [Domain Packs](domain-packs.md).
 - Wire your vertical: [Migration guide](migration-guide.md)
 - Understand the read path: [Architecture](architecture.md)
 - All knobs: [Operations](operations.md)

--- a/docs/indexer-protocol.md
+++ b/docs/indexer-protocol.md
@@ -329,3 +329,10 @@ routed to their pack (`/content`) — that text can carry anything the
 source carried (post-redaction). Mint per-integration keys, scope packs
 narrowly via relevance, and treat external indexers as processors in
 your data-protection terms.
+
+## See also
+
+- [Document pipeline](document-pipeline.md) — where work items come from and how candidates become memory.
+- [Domain Packs](domain-packs.md) — authoring the pack that registers your indexer.
+- [API reference](api.md) — the work API + candidates endpoints in the full surface index.
+- [Operations](operations.md#enabling-the-document-pipeline--external-indexers) — the operator enablement runbook.

--- a/docs/locomo.md
+++ b/docs/locomo.md
@@ -1,5 +1,8 @@
 # LoCoMo benchmark
 
+Running the LoCoMo long-term conversational-memory benchmark against
+Brain's production surfaces — methodology, procurement, and cost.
+
 Brain runs against [LoCoMo](https://github.com/snap-research/locomo)
 through its production ingest + retrieval surface — no harness-only
 adapters. Each conversation is ingested via `POST /v1/ingest/mention`
@@ -221,3 +224,9 @@ leaks back into the graph mid-run.
   downstream consumer that reads `scores[].prediction` + `scores[].gold`.
 - **CI gating** — once a baseline is established, the LoCoMo report
   joins the existing eval baseline diff in CI (`scripts/eval-baseline-diff.ts`).
+
+## See also
+
+- [Eval harness](eval.md) — the in-house production gate this complements.
+- [Architecture § Multi-hop](architecture.md#multi-hop-search) — the surface answering LoCoMo's QA.
+- [API reference](api.md#mcp) — the MCP endpoint the agent variant drives.

--- a/docs/mcp-pack-tools.md
+++ b/docs/mcp-pack-tools.md
@@ -18,6 +18,21 @@ one of exactly two shapes:
 Each shape is independently toggleable by the operator (see
 [Operator flags](#operator-flags)).
 
+```mermaid
+sequenceDiagram
+    participant A as MCP agent
+    participant B as Brain (tenant MCP endpoint)
+    participant E as Publisher endpoint
+    A->>B: tools/call compliance__find_violations
+    Note over B: query tool — served in-process:<br/>predicate fence + scopes + ABAC row filter
+    B-->>A: results
+    A->>B: tools/call compliance__check_sanctions
+    Note over B: external tool — egress guard (https,<br/>no private IPs), circuit breaker
+    B->>E: POST (HMAC-signed, installId — never companyId)
+    E-->>B: 200 {content} (≤64 KB, timeout-capped)
+    B-->>A: sanitized result
+```
+
 ## Manifest reference
 
 ```jsonc
@@ -232,3 +247,10 @@ pack-provided MCP resources / prompts / sampling; streaming or progress
 on external calls; retries on external calls; DNS pinning between the
 egress check and the fetch; per-tool rate limits or metering;
 webhookSecret rotation.
+
+## See also
+
+- [Domain Packs](domain-packs.md) — the manifest this section lives in; install + upgrade semantics.
+- [External indexer protocol](indexer-protocol.md) — the other publisher-side integration, sharing the same webhook secret.
+- [API reference](api.md#mcp) — the MCP endpoint + `acceptMcpTools` on the install routes.
+- [Operations](operations.md) — enabling the flags in production.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,6 +1,8 @@
-# Migration Guide — wiring a vertical into INITE Brain
+# Migration guide — wiring a vertical into INITE Brain
 
-This walks a vertical maintainer from "no brain integration" to "knowledge capability shipped" in their app. The runtime path is `inite.<vertical>` → `@inite/knowledge` SDK → brain HTTP/MCP.
+Walks a vertical maintainer from "no brain integration" to "knowledge
+capability shipped" in their app. The runtime path is `inite.<vertical>` →
+`@inite/knowledge` SDK → brain HTTP/MCP.
 
 ## What you get
 
@@ -160,3 +162,10 @@ Look for your vertical in the output. Recall@1 should be ≥ 0.6 across the scen
 - ADR: `docs/adr/0001-knowledge-system-of-insight.md`
 - SDK source: `packages/knowledge/` (in inite-shared)
 - Service source: `inite-brain-service/`
+
+## See also
+
+- [Getting started](getting-started.md) — running Brain itself.
+- [API reference](api.md) — the raw HTTP surface behind the SDK.
+- [Operator playbook](operator-playbook.md) — issuing keys, troubleshooting.
+- [Bitemporal semantics](bitemporal-semantics.md) — `validFrom` / `asOf` done right.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,7 +1,20 @@
 # Operations
 
-Required + optional env vars, retrieval feature flags, queue tuning,
-boot validation, graceful shutdown, test commands.
+Every env var and feature flag, queue tuning, the api/worker role
+split, staged enablement runbooks, boot validation, and test commands —
+the operator's reference for running Brain.
+
+**Contents:**
+[Required env vars](#required-env-vars) ·
+[Optional env vars](#optional-env-vars) ·
+[Job queue](#job-queue-phase-jk--env-vars) ·
+[Splitting API and worker roles](#splitting-api-and-worker-roles) ·
+[Retrieval feature flags](#retrieval-feature-flags) ·
+[Enabling the document pipeline + external indexers](#enabling-the-document-pipeline--external-indexers) ·
+[Enabling MCP pack tools](#enabling-mcp-pack-tools) ·
+[Enabling marketplace billing](#enabling-marketplace-billing-paid-packs) ·
+[Boot-time validation](#boot-time-validation) ·
+[Tests](#tests)
 
 ## Required env vars
 
@@ -68,6 +81,11 @@ boot validation, graceful shutdown, test commands.
 | `DOMAIN_PACK_TRUSTED_KEYS` | unset | Pack-install trust store: JSON object mapping `publisher` → ed25519 PEM public key. Malformed JSON fails boot (env validation) — a typo would silently empty the store and every signed pack would fail as "unknown publisher". |
 | `DOMAIN_PACK_REQUIRE_SIGNATURE` | `0` | When `1`/`true`, `POST /v1/admin/packs` rejects unsigned manifests. Values outside `1/0/true/false` fail boot — an unrecognized value would silently disable enforcement. |
 | `PACK_REGISTRY_REQUIRE_SIGNATURE` | `0` | Same policy for `POST /v1/admin/registry/packs` (publish into the global catalogue). Same strict value set. |
+| `PACK_SEED_INGEST_ENABLED` | `1` | Ingest a pack's `seedDocuments` through the document pipeline on install (`pack_seed_ingest` job). Requires `DOCUMENT_INGEST_ENABLED`; when either is off the install response reports a skip — install never fails because of seeds. |
+| `INDEXER_WEBHOOK_PUSH_ENABLED` | `1` | Signed `work_available` webhook hints to external packs declaring `indexer.external.callbackUrl`. Best-effort (retries + per-URL circuit breaker; `INDEXER_WEBHOOK_RETRY_BASE_MS` tunes backoff); polling stays the source of truth. |
+| `REGISTRY_UPSTREAM_URL` | unset | Pull-only registry mirroring: pull the upstream catalogue and republish missing versions locally through the normal publish path. Unset = off, no job registered. Optional `REGISTRY_UPSTREAM_TOKEN` (a `brain:read` key on the upstream); cadence via `REGISTRY_MIRROR_INTERVAL_HOURS` (default 24). |
+| `MCP_PACK_TOOLS_ENABLED` | `0` | Master switch for [pack-declared MCP tools](mcp-pack-tools.md). Off = the MCP surface is exactly the static tool families. Sub-flags: `MCP_PACK_QUERY_TOOLS_ENABLED` (default `1`), `MCP_PACK_EXTERNAL_TOOLS_ENABLED` (default `0`), `MCP_PACK_TOOLS_ALLOW_HTTP` (dev/test ONLY — disables the SSRF egress guard), `MCP_PACK_TOOLS_CACHE_TTL_MS` (default 30000). |
+| `DOMAIN_PACK_BILLING_ENABLED` | `0` | Paid packs via the central billing service — see [Enabling marketplace billing](#enabling-marketplace-billing-paid-packs). Off (the self-hosted posture) = pricing metadata is ignored, every pack installs free. Requires `BILLING_SERVICE_URL` + `BILLING_SERVICE_API_KEY` when on (boot-validated); `BILLING_TIMEOUT_MS` / `BILLING_ENTITLEMENT_CACHE_TTL_MS` tune the client. |
 | `OTEL_ENABLED` | `0` | Enable OpenTelemetry tracing. When `1`, exports OTLP/HTTP traces with auto-instrumentation for `http` (so OpenAI + JWKS calls show up) + `express` (Nest). The pipeline emits explicit child spans under `search`: `vector_leg`, `lexical_leg`, `route`, `ppr`, `fetch_neighbours`, `rerank` — each annotated with candidate counts. Plus Phase K3 queue handoff spans: `jobs.enqueue` (PRODUCER) + `jobs.process <jobType>` (CONSUMER, linked via traceparent on the row). Bring-your-own backend via `OTEL_EXPORTER_OTLP_ENDPOINT` (base URL, no path — the exporter appends `/v1/traces`; prod points it at the monitoring stack's Alloy, see `monitoring/README.md`). Service name defaults to `inite-brain-service`; override via `OTEL_SERVICE_NAME`. No-op when off — zero cost. |
 
 Prod observability (metrics scrape, log shipping, trace storage,
@@ -91,6 +109,7 @@ The queue is on by default. Every var has a safe default; tune below.
 | `JOB_RUN_BACKOFF_BASE_MS` | `30000` | Exponential-backoff base for failed/zombie-reaped jobs. Cap is 1h regardless of base × `2^(attempts-1)`. |
 | `JOB_WORKER_POOL_SIZE` | `2` (dev) / `0` (prod) | `node:worker_threads` pool size for `cpuBound: true` handlers. `0` disables the pool entirely (no current handler is cpuBound). |
 | `JOB_RUN_PERSIST` | `1` | Set `0` only in unit tests to disable job_run persistence entirely. Never in prod. |
+| `WORKER_LOOP_MAX_CONCURRENT` | `1` | In-flight dispatch bound per job type on this pod. Override per type with `WORKER_LOOP_MAX_CONCURRENT_<JOBTYPE>` (job type upper-cased, e.g. `WORKER_LOOP_MAX_CONCURRENT_DREAMS=2`, `WORKER_LOOP_MAX_CONCURRENT_INDEX_DOCUMENT=2`). `WORKER_LOOP_TENANT_MAX_CONCURRENT` (default 1) bounds per-tenant fan-out; `WORKER_LOOP_GLOBAL_MAX_CONCURRENT` (default 0 = unbounded) caps the pod total. |
 | `PROCESS_ROLE` | `all` | One-env role split: `all` / `api` / `worker`. Maps to the flag bundle described in [Splitting API and worker roles](#splitting-api-and-worker-roles). Explicitly-set flags always win over the role defaults. |
 
 ## Splitting API and worker roles
@@ -258,6 +277,30 @@ data loss. Staged candidates expire per `CANDIDATE_PENDING_TTL_DAYS`;
 stuck runs are reaped per the stale window; committed facts stay (they
 are ordinary memory — retract/forget applies as usual).
 
+## Enabling MCP pack tools
+
+Pack-declared MCP tools ([mcp-pack-tools.md](mcp-pack-tools.md)) ship
+dark behind `MCP_PACK_TOOLS_ENABLED` (default off). Two-stage rollout:
+
+1. **`MCP_PACK_TOOLS_ENABLED=1`** — query tools only (the
+   `MCP_PACK_QUERY_TOOLS_ENABLED=1` default). Query tools are served
+   entirely in-process, fenced to each pack's own predicates, and run
+   under the caller's scopes + ABAC row filter — the low-risk half.
+   Re-install (or install) packs with `acceptMcpTools: true`; without
+   stored consent nothing is served.
+2. **`MCP_PACK_EXTERNAL_TOOLS_ENABLED=1`** — only after reviewing each
+   consented pack's declared endpoints (the install refusal message
+   lists them). External calls are HMAC-signed, SSRF-fenced, budget- and
+   size-capped, and carry an opaque `installId` — never the tenant id.
+
+> [!WARNING]
+> `MCP_PACK_TOOLS_ALLOW_HTTP=1` disables the SSRF egress guard (plain
+> http + loopback endpoints allowed). Dev/test only — never in
+> production.
+
+Rollback: flip the master flag off — pack tools vanish from
+`tools/list` on the next binding-cache refresh (≤ `MCP_PACK_TOOLS_CACHE_TTL_MS`).
+
 ## Enabling marketplace billing (paid packs)
 
 The registry marketplace (docs/domain-packs.md "Marketplace") ships dark:
@@ -323,3 +366,10 @@ docker / fly / k8s don't `SIGKILL` you with no log line.
 | `pnpm test:eval:json` | Loads a directory from `BRAIN_DIRECTORY_JSON=…/file.json` and runs retrieval + lifecycle assertions; same runner, your data. | Bringing up brain on a real customer dataset; smoke-testing a CSV→JSON export against the eval harness. |
 | `pnpm test:e2e:jobs` | Real-Surreal e2e: enqueue → claim → renew → complete cycle, dedup collision, fail+requeue, zombie reap, leader_lease in `system` DB. | After touching anything in `src/jobs/` or migrations 0028-0031. |
 | `pnpm lint` | ESLint flat config. | Every commit. |
+
+## See also
+
+- [Operator playbook](operator-playbook.md) — day-2 troubleshooting runbooks.
+- [Deploy runbook](DEPLOY.md) — the production deployment + observability stack.
+- [API reference](api.md) — the endpoint families these flags gate.
+- [Document pipeline](document-pipeline.md) — the architecture behind the pipeline flags.

--- a/docs/operator-playbook.md
+++ b/docs/operator-playbook.md
@@ -1,6 +1,10 @@
-# Operator Playbook — INITE Brain Service
+# Operator playbook — INITE Brain Service
 
-This is the day-2 manual for the people who keep brain running. If you're trying to wire a vertical *into* brain, see `migration-guide.md` instead.
+The day-2 manual for the people who keep brain running — issue keys,
+troubleshoot, run maintenance, recover. If you're trying to wire a
+vertical *into* brain, see [migration-guide.md](migration-guide.md) instead;
+for enablement runbooks of dark-shipped features (document pipeline, MCP
+pack tools, billing), see [operations.md](operations.md).
 
 ## Contents
 
@@ -10,13 +14,14 @@ This is the day-2 manual for the people who keep brain running. If you're trying
 4. [Troubleshoot: search returns nothing](#troubleshoot-search-returns-nothing)
 5. [Run a forget (GDPR)](#run-a-forget-gdpr)
 6. [Monitor: metrics + logs](#monitor-metrics--logs)
-7. [Run dreams off-cycle](#run-dreams-off-cycle)
-8. [Enable dreams in production (staged checklist)](#enable-dreams-in-production-staged-checklist)
-9. [Run compaction off-cycle](#run-compaction-off-cycle)
-10. [Drain a stuck job queue](#drain-a-stuck-job-queue)
-11. [Rollback queue mode (kill switch)](#rollback-queue-mode-kill-switch)
-12. [Run the memory-lifecycle eval](#run-the-memory-lifecycle-eval)
-13. [Restore from event replay](#restore-from-event-replay)
+7. [Tune `SEARCH_RERANK_SKIP_MARGIN`](#tune-search_rerank_skip_margin)
+8. [Run dreams off-cycle](#run-dreams-off-cycle)
+9. [Enable dreams in production (staged checklist)](#enable-dreams-in-production-staged-checklist)
+10. [Run compaction off-cycle](#run-compaction-off-cycle)
+11. [Drain a stuck job queue](#drain-a-stuck-job-queue)
+12. [Rollback queue mode (kill switch)](#rollback-queue-mode-kill-switch)
+13. [Run the memory-lifecycle eval](#run-the-memory-lifecycle-eval)
+14. [Restore from event replay](#restore-from-event-replay)
 
 ---
 
@@ -92,7 +97,7 @@ For a whole-tenant forget, hit `dropCompanyDatabase` directly (admin tooling, no
 - `brain_search_rerank_total{outcome}` — invoked / skipped_disabled / skipped_singleton / skipped_margin. The `skipped_margin` line tracks how often the LLM rerank was bypassed because the post-fusion top-1 vs top-2 gap was already wide; ratio against `invoked` is the cost-saving you got from `SEARCH_RERANK_SKIP_MARGIN`.
 - `brain_search_cross_encoder_total{outcome}` — invoked / error / skipped_disabled / skipped_singleton. `error` rate above ~1% means Cohere is timing out or 4xx-ing — bump `SEARCH_CROSS_ENCODER_TIMEOUT_MS`, check the Cohere status page, or rotate `COHERE_API_KEY`.
 - `brain_multi_hop_total{outcome}` — ok / single_hop / chain_empty / no_results / planner_error / hop_error. `single_hop` dominating means most queries are one-step (planner correctly skipping decomposition); `chain_empty` is normal — chains often disprove themselves on hop 2. Spike in `planner_error` ⇒ OpenAI is flaky; spike in `hop_error` ⇒ the search backend (Surreal) is unhappy.
-- `brain_synthesize_total{outcome}` — ok / no_results / no_grounded_evidence / verifier_partial / verifier_failed / generator_error / verifier_error. The healthy mix is `ok` dominant + a few `no_grounded_evidence` (the model honestly refused). High `verifier_failed` rate means generator is hallucinating or context window is too narrow — investigate `SEARCH_*` knobs upstream. High `*_error` means OpenAI is flaky — check `brain_openai_calls_total{outcome="error"}` for confirmation. `error` rate above ~1% means Cohere is timing out or 4xx-ing — bump `SEARCH_CROSS_ENCODER_TIMEOUT_MS`, check the Cohere status page, or rotate `COHERE_API_KEY`.
+- `brain_synthesize_total{outcome}` — ok / no_results / no_grounded_evidence / verifier_partial / verifier_failed / generator_error / verifier_error. The healthy mix is `ok` dominant + a few `no_grounded_evidence` (the model honestly refused). High `verifier_failed` rate means generator is hallucinating or context window is too narrow — investigate `SEARCH_*` knobs upstream. High `*_error` means OpenAI is flaky — check `brain_openai_calls_total{outcome="error"}` for confirmation.
 - `brain_retract_total`, `brain_forget_total` — usage counters
 - `brain_compaction_facts_total` — sums across tenants
 - `brain_process_*`, `brain_nodejs_*` — node defaults (heap, event-loop lag)
@@ -260,3 +265,9 @@ Brain is a **system of insight**. If the storage layer is wiped, restore by repl
 3. Re-publish them into brain's normal ingest path. The conflict resolver will deduplicate against any survivors.
 
 Replay produces the same state modulo timestamps and CUIDs. If your downstream consumers depend on stable IDs, restore from a snapshot instead — the SurrealDB native backup CLI is the right tool for that.
+
+## See also
+
+- [Operations](operations.md) — every env var + the staged enablement runbooks.
+- [Deploy runbook](DEPLOY.md) — the production stack, rollback, observability wiring.
+- [API reference](api.md) — the admin endpoints used throughout this playbook.

--- a/docs/source-reputation.md
+++ b/docs/source-reputation.md
@@ -1,5 +1,8 @@
 # Source reputation & trust
 
+How Brain models who claimed a fact and how much that claim is trusted —
+for operators tuning trust and consumers reading it.
+
 > *A fact isn't true. It's claimed by a source, extracted from evidence, and
 > trusted under context.*
 
@@ -142,3 +145,10 @@ committing to a value.
   multiplicative trust composite is read-time only, behind the flags above.
 - Sources are **not** knowledge entities — no embeddings / merge / forget-cascade
   machinery is pointed at them.
+
+## See also
+
+- [Data model](data-model.md) — where the trust snapshot lives on a fact.
+- [Document pipeline](document-pipeline.md) — origin-keyed corroboration for multi-reader documents.
+- [External indexer protocol](indexer-protocol.md#trust-earned-not-granted) — how a new indexer earns weight.
+- [Operations](operations.md#retrieval-feature-flags) — the β/γ/δ ranking flags.


### PR DESCRIPTION
## Summary

State-of-the-art documentation refresh: brings every guide up to merged main after the platform waves (#181–#197: external-indexer work API, protocol spec, OpenAPI, `pack:init`, registry counters/verified/mirroring, `PROCESS_ROLE`, worker offloads) and the marketplace wave (#199–#204: marketplace + paid packs, trust-inputs API, seed documents, MCP pack tools). Docs-only — no source, migrations, or `docs/openapi.json` changes.

## Per-file changes

**README.md** — system-overview mermaid diagram (ingest → graph → retrieval → REST/MCP, extension points marked); "Why Brain" bullets updated for the full platform story (registry/marketplace, external-indexer seam, pack MCP tools, marketplace defaults); new **Build on Brain** section (pack authoring loop, registry, marketplace, external indexers, MCP tools, seed documents — one-liner + doc link each); "Connect an agent" links pack tools; stack paragraph now covers worker-thread offloads + `PROCESS_ROLE`; documentation table completed (indexer protocol, MCP pack tools); roadmap rewritten — "Shipped" includes waves 1+2, "Exploring" is the platform-gap residual backlog + Temporal re-eval triggers (link only; that file is intentionally untouched). Hero, badges, quality numbers, license untouched.

**docs/README.md** — rebuilt as the documentation hub: "Where do I start?" persona routing + four tables (Use it / Understand it / Build on it / Operate it) covering every file in `docs/`, incl. `openapi.json` (generated note), `examples/reference-indexer.ts`, and `code-memory/distillation-dataset.md`; roadmap section marks `platform-gap-2026-07.md` as current and the rest as historical planning records.

**docs/api.md** — now indexes the full surface: added Domain Packs admin (with `acceptMcpTools` consent flag + `seedDocuments` response field), Registry + marketplace (discovery, publish/yank, pricing PUT/DELETE, feature/unfeature, checkout, publisher profiles, `/registry/ui`) with per-route scopes, Admin — sources, Admin — governance + ops (one row per family), communities, `GET /v1/stats/overview`, `GET /ready`; scopes table gains `registry:curate`; See also footer.

**docs/domain-packs.md** — purpose line + lifecycle mermaid (init→validate→sign→publish→install→eval with registry/marketplace/mirror around it); manifest interface now lists ALL sections (extractionProfile, evalFixtures, indexer, seedDocuments, mcpTools, signature); eval-fixtures section moved into the manifest-reference cluster; builtin vs community authoring disambiguated; See also.

**docs/document-pipeline.md** — ASCII pipeline replaced with a mermaid diagram incl. the external-indexer seam; new Seed documents section (install-triggered, `kind='pack_seed'`, provenance meta) linking domain-packs; flags table gains `PACK_SEED_INGEST_ENABLED` + `INDEXER_WEBHOOK_PUSH_ENABLED`; See also.

**docs/mcp-pack-tools.md** — tool-call sequence diagram (query in-process vs external HMAC proxy); See also. Content verified complete (consent, flags, security model, Not-in-v1).

**docs/indexer-protocol.md** — verified accurate (lease semantics, webhook push, per-pack key binding); See also added.

**docs/operations.md** — purpose line + TOC; env table gains seed-ingest, webhook-push, registry-mirroring, MCP-pack-tools group, billing group; queue table gains `WORKER_LOOP_MAX_CONCURRENT[_<JOBTYPE>]` + tenant/global bounds; new **Enabling MCP pack tools** staged runbook (with an ALLOW_HTTP warning callout); See also.

**docs/architecture.md** — new "Worker threads + process roles" and "MCP surface" sections (28 static tools verified against `src/mcp/` + the action registry; pack tools pointer); retrieval-pipeline description unchanged; See also.

**docs/abac.md** — action-rules bullet now points at `src/policy/action-registry.ts` as the source of truth and documents pack-tool gating kinds; See also.

**docs/data-model.md, bitemporal-semantics.md, source-reputation.md, eval.md, locomo.md, distribution.md, getting-started.md, migration-guide.md, operator-playbook.md, DEPLOY.md** — purpose lines + See also footers; getting-started next-steps now route to MCP connect / document ingest / pack install; distribution gains the registry/marketplace note.

**CONTRIBUTING.md** — Domain Pack section mentions `seedDocuments` + `mcpTools`; release paragraph corrected (release-please owns versioning).

## Stale claims found and fixed

1. `getting-started.md`: "SurrealDB **2.3.10**" → 3.1.5 (compose pins `surrealdb/surrealdb:v3.1.5`).
2. `README.md` Roadmap "Exploring" listed features that have since shipped (opt-in HNSW, local cross-encoder fallback, per-leg OTel spans) — replaced with the real residual backlog.
3. `docs/DEPLOY.md`: "migrations **0001-0009** apply" (head is 0068) and "Brain's namespace `brain` is fully isolated from gateway's `inite`" (prod shares NS `inite`; isolation is per-tenant DBs + `knowledge_*` tables — contradicted its own diagram).
4. `docs/data-model.md`: "PII gating runs **at the database layer**" — the DB PERMISSIONS fence is inert for the pooled system user (verified 2026-07-09 finding, canary in `test/abac-db-fence.e2e-spec.ts`); the JS layer is the active gate. Also: vocabulary described as spec-file-only — now the tenant predicate registry + packs.
5. `docs/domain-packs.md`: "unlike the **still-forward-compat** `evalFixtures`" — evalFixtures have been consumed at runtime for a while (the doc said so itself two sections later).
6. `CONTRIBUTING.md`: "no semver release process… `package.json` version (**0.1.0**) is decorative" — release-please cuts releases (currently 0.7.0) and owns CHANGELOG.md.
7. `docs/operator-playbook.md`: duplicated Cohere troubleshooting sentence pasted into the `brain_synthesize_total` bullet; TOC missing the `SEARCH_RERANK_SKIP_MARGIN` section.
8. `docs/README.md` (old): missing 10+ docs (domain-packs, abac, source-reputation, api/openapi, indexer-protocol, mcp-pack-tools, …) and presented the ~95%-shipped `mcp-and-memory.md` as "planned work".

## Verification

- Link + anchor check: scripted (`grep` links → `test -e` + GitHub-anchor slugger over headings) — all green across every touched file.
- All flags named in docs verified against `src/common/env-validation.ts` / `src/admin/config-catalog.data.ts`; all endpoint paths + scopes verified against `src/**/*.controller.ts`; MCP tool count (28 static + 2 resources) verified against `src/mcp/` and `src/policy/action-registry.ts`.
- `pnpm lint:ci` ✅ (zero warnings) · `pnpm exec tsc --noEmit` ✅ · `pnpm test` ✅ (172 suites, 1343 tests) — untouched-green, no code changed.

## Notes

- `docs/roadmap/platform-gap-2026-07.md` deliberately not edited (may still change in #205) — only linked.
- 4 mermaid diagrams added (README overview, document-pipeline, domain-packs lifecycle, mcp-pack-tools flow), per the 3–4 target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd
