### PR TITLE
fix(admin-ui): config/jobs panel drift + in-repo drift guards

### DIFF
--- a/brain-landing/__tests__/admin-drift.test.ts
+++ b/brain-landing/__tests__/admin-drift.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Drift guards — admin panels render filter/sort lists that mirror enums
+ * in lib/contracts (the landing-side wire-contract mirrors, which backend
+ * PRs are expected to keep in sync). The panels now derive those lists
+ * from the contracts; these tests fail if anyone re-hardcodes a copy and
+ * it drifts (that's exactly how 'registry'/'billing' went missing from
+ * ConfigPanel and 7 job types from JobsPanel).
+ */
+import { describe, it, expect } from 'vitest'
+import { CATEGORY_ORDER } from '@/components/admin/ConfigPanel'
+import { STATUSES } from '@/components/admin/JobsPanel'
+import { CONFIG_CATEGORIES } from '@/lib/contracts/admin-config'
+import { JOB_STATUSES } from '@/lib/contracts/admin-jobs'
+
+describe('ConfigPanel category order ↔ admin-config contract', () => {
+  it('covers exactly the contract enum values (no missing, no unknown)', () => {
+    expect([...CATEGORY_ORDER].sort()).toEqual([...CONFIG_CATEGORIES].sort())
+  })
+
+  it('has no duplicates', () => {
+    expect(new Set(CATEGORY_ORDER).size).toBe(CATEGORY_ORDER.length)
+  })
+})
+
+describe('JobsPanel status filter ↔ admin-jobs contract', () => {
+  it("covers exactly '' (= all) plus the contract status values", () => {
+    expect([...STATUSES]).toEqual(['', ...JOB_STATUSES])
+  })
+})

--- a/brain-landing/components/admin/ConfigPanel.tsx
+++ b/brain-landing/components/admin/ConfigPanel.tsx
@@ -4,26 +4,12 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { AlertTriangle, KeyRound, RefreshCw, Settings2 } from 'lucide-react'
+import { CONFIG_CATEGORIES } from '../../lib/contracts/admin-config'
 import type { ConfigEntry } from '../../lib/contracts/admin-config'
 
-const CATEGORY_ORDER = [
-  'pipeline',
-  'extractor',
-  'embedder',
-  'dreams',
-  'compaction',
-  'audit',
-  'router',
-  'search',
-  'multihop',
-  'calibration',
-  'conflict',
-  'cost',
-  'throttle',
-  'jobs',
-  'auth',
-  'misc',
-]
+// Display order = contract enum order. Derived (not copied) so a category
+// added to the wire contract can never miss the dropdown / sort again.
+export const CATEGORY_ORDER: readonly string[] = CONFIG_CATEGORIES
 
 export function ConfigPanel() {
   const [entries, setEntries] = useState<ConfigEntry[]>([])
@@ -75,8 +61,8 @@ export function ConfigPanel() {
   }, [entries, q, category, onlyOverridden])
 
   const categories = useMemo(() => {
-    const seen = new Set(entries.map((e) => e.category))
-    return CATEGORY_ORDER.filter((c) => seen.has(c as ConfigEntry['category']))
+    const seen = new Set<string>(entries.map((e) => e.category))
+    return CATEGORY_ORDER.filter((c) => seen.has(c))
   }, [entries])
 
   const grouped = useMemo(() => {

--- a/brain-landing/components/admin/JobsPanel.tsx
+++ b/brain-landing/components/admin/JobsPanel.tsx
@@ -12,23 +12,24 @@ import {
 } from 'lucide-react'
 import { JsonView } from './JsonView'
 import { getMessages, normalizeLang } from '../../lib/i18n'
+import { JOB_STATUSES } from '../../lib/contracts/admin-jobs'
 import type { JobRow } from '../../lib/contracts/admin-jobs'
 
 type AdminT = ReturnType<typeof getMessages>['admin']
 
-const JOB_TYPES = [
-  '',
-  'dreams',
-  'compaction',
-  'calibration_refit',
-  'source_trust_refit',
-  'reindex_embeddings',
-  'changefeed_drain',
-]
-// 'pending' MUST be in the list — Phase J/K queue mode creates pending
-// rows that the worker loop hasn't claimed yet. Pre-Phase-J this was
-// omitted because rows were born 'running'; that's no longer true.
-const STATUSES = ['', 'pending', 'running', 'succeeded', 'failed', 'cancelled']
+// Derived from the wire-contract mirror (not copied) so the status filter
+// can never drift; '' = all. 'pending' is in the contract — Phase J/K
+// queue mode creates rows the worker loop hasn't claimed yet.
+export const STATUSES: readonly string[] = ['', ...JOB_STATUSES]
+
+function mergeJobTypes(
+  prev: readonly string[],
+  rows: readonly JobRow[],
+): readonly string[] {
+  const next = new Set(prev)
+  for (const r of rows) next.add(r.jobType)
+  return next.size === prev.length ? prev : [...next].sort()
+}
 
 export function JobsPanel() {
   const params = useParams<{ lang: string }>()
@@ -47,6 +48,17 @@ export function JobsPanel() {
   })
   const [live, setLive] = useState(true)
   const [sseStatus, setSseStatus] = useState<'idle' | 'open' | 'closed'>('idle')
+  // Backend JobType union keeps growing — the dropdown derives from observed
+  // rows instead of a hardcoded list so it can never drift. Types accumulate
+  // across loads/SSE frames; otherwise an active type filter would shrink
+  // the options to itself.
+  const [seenTypes, setSeenTypes] = useState<readonly string[]>([])
+
+  const jobTypeOptions = useMemo(() => {
+    const types = new Set(seenTypes)
+    if (filter.jobType) types.add(filter.jobType)
+    return ['', ...[...types].sort()]
+  }, [seenTypes, filter.jobType])
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -62,7 +74,9 @@ export function JobsPanel() {
       )
       const data = await res.json()
       if (!res.ok) throw new Error(data.error ?? `Failed ${res.status}`)
-      setJobs(data.jobs ?? [])
+      const rows = (data.jobs ?? []) as JobRow[]
+      setJobs(rows)
+      setSeenTypes((prev) => mergeJobTypes(prev, rows))
       setError(null)
     } catch (e) {
       setError((e as Error).message)
@@ -93,6 +107,7 @@ export function JobsPanel() {
           next[idx] = j
           return next
         })
+        setSeenTypes((prev) => mergeJobTypes(prev, [j]))
       } catch {
         // ignore malformed frame
       }
@@ -164,7 +179,7 @@ export function JobsPanel() {
           onChange={(e) => setFilter((f) => ({ ...f, jobType: e.target.value }))}
           className="border border-[var(--border)] rounded-md bg-[var(--bg-elevated)] px-2 py-1 text-[var(--text)]"
         >
-          {JOB_TYPES.map((jt) => (
+          {jobTypeOptions.map((jt) => (
             <option key={jt} value={jt}>
               {jt || t.jobs.filters.allTypes}
             </option>

--- a/brain-landing/lib/contracts/admin-config.ts
+++ b/brain-landing/lib/contracts/admin-config.ts
@@ -27,6 +27,13 @@ const ConfigCategorySchema = z.enum([
   'misc',
 ])
 
+/**
+ * Canonical category list in display order. Panels must derive their
+ * ordering from this instead of hardcoding a copy (guarded by
+ * __tests__/admin-drift.test.ts).
+ */
+export const CONFIG_CATEGORIES = ConfigCategorySchema.options
+
 const ConfigEntrySchema = z.object({
   key: z.string(),
   category: ConfigCategorySchema,

--- a/brain-landing/lib/contracts/admin-jobs.ts
+++ b/brain-landing/lib/contracts/admin-jobs.ts
@@ -15,6 +15,13 @@ const JobStatusSchema = z.enum([
   'cancelled',
 ])
 
+/**
+ * Canonical status list. Panels must derive their filter options from
+ * this instead of hardcoding a copy (guarded by
+ * __tests__/admin-drift.test.ts).
+ */
+export const JOB_STATUSES = JobStatusSchema.options
+
 const TriggeredBySchema = z.enum(['cron', 'manual', 'startup'])
 
 const JobErrorSchema = z.object({

--- a/src/contracts/admin/policy-tools.schema.ts
+++ b/src/contracts/admin/policy-tools.schema.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
  *   GET  /v1/admin/policy/decisions (+ /stats)
  *   GET  /v1/admin/keys
  *
- * Duplicated in brain-landing/lib/contracts/admin-policy-tools.ts.
+ * Duplicated in brain-landing/lib/contracts/admin-policies.ts.
  */
 
 export const PolicyRegistryResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Admin UI drift fixes in `brain-landing`, plus tests that keep the panels honest against the wire-contract mirrors.

### ConfigPanel: 2 categories invisible in the filter
`CATEGORY_ORDER` hardcoded 16 categories while the contract enum (`lib/contracts/admin-config.ts`, mirror of `src/contracts/admin/config.schema.ts`) has 18 — `registry` and `billing` could not be selected in the category dropdown, and their groups sorted first via `indexOf → -1`. The panel now derives `CATEGORY_ORDER` from the contract's exported `CONFIG_CATEGORIES` (enum order = display order), killing the drift class rather than patching the list.

### JobsPanel: type filter knew 6 of 13 job types
`JOB_TYPES` hardcoded 6 types; the backend `JobType` union (`src/jobs/job-run.service.ts`) has 13 — `index_document`, `commit_document`, `candidate_sweeper`, `reindex_documents`, `pack_seed_ingest`, `scenarios_batch`, `registry_mirror` were unfilterable. The dropdown now derives its options dynamically from observed rows (distinct `jobType`, sorted, `''` = all stays the default). Types accumulate across loads and SSE frames so an active type filter doesn't shrink the options to itself.

While in there: the hardcoded `STATUSES` list got the same treatment — now derived from the contract mirror's status enum (`JOB_STATUSES`).

### Drift guards
New `brain-landing/__tests__/admin-drift.test.ts` (vitest) asserts:
- ConfigPanel's category order covers exactly the contract enum values (no missing, no unknown, no duplicates);
- JobsPanel's status filter covers exactly `''` + the contract status values.

Guards target the landing's own `lib/contracts` mirrors, which backend PRs already keep in sync. Other admin lists checked (`DreamsPanel` OPS, `AuditLog` sources/ops, `ActionMatrix` family order) mirror no contract enum — left as is.

### Stale comment
`src/contracts/admin/policy-tools.schema.ts` pointed at a non-existent mirror file `admin-policy-tools.ts`; the mirror lives in `brain-landing/lib/contracts/admin-policies.ts`. Comment fixed (backend change is this one line).

## Verification

- `pnpm -C brain-landing test` — 3 files / 12 tests passed (includes the new drift guards)
- `pnpm -C brain-landing lint` — 0 errors; warnings identical to main baseline (no new ones)
- `pnpm -C brain-landing build` — passes (CI does not build the landing)
- Repo root: `pnpm exec tsc --noEmit` and `pnpm lint:ci` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd