### PR TITLE
fix(entities,app): real transaction-time axis for profile/timeline + timeline event rendering

### DIFF
--- a/brain-landing/app/[lang]/app/usage/page.tsx
+++ b/brain-landing/app/[lang]/app/usage/page.tsx
@@ -96,7 +96,7 @@ export default function UsagePage() {
                     <span className="text-xs">{c.label}</span>
                   </div>
                   <div className="mt-1 text-2xl font-semibold text-[var(--text)] tabular-nums">
-                    {stats[c.key].toLocaleString()}
+                    {(stats[c.key] ?? 0).toLocaleString()}
                   </div>
                   <div className="text-[10px] text-[var(--text-faint)]">
                     {c.hint}

--- a/brain-landing/components/admin/EntityPanel.tsx
+++ b/brain-landing/components/admin/EntityPanel.tsx
@@ -8,7 +8,6 @@ import {
   ExternalLink,
   Clock,
   ShieldOff,
-  Trash2,
   CircleDot,
 } from 'lucide-react'
 import { useProxyBase } from '../playground/usePlaygroundCall'
@@ -57,15 +56,23 @@ interface EntityProfile {
   }>
 }
 
-interface TimelineRow {
-  factId?: string
+/**
+ * Backend GET /v1/entities/:id/timeline returns EVENTS, not fact rows:
+ *   { type: 'fact.recorded',  at, factId, predicate, object, source, confidence }
+ *   { type: 'fact.retracted', at, factId, retractedBy, reason, supersededBy }
+ * `at` is the transaction-time instant of the event.
+ */
+interface TimelineEvent {
+  type: 'fact.recorded' | 'fact.retracted'
+  at: string
+  factId: string
   predicate?: string
   object?: string | null
-  validFrom?: string
-  validUntil?: string | null
-  recordedAt?: string
-  retractedAt?: string | null
-  status?: string
+  source?: { vertical?: string; recorder?: string } | null
+  confidence?: number
+  retractedBy?: string
+  reason?: string
+  supersededBy?: string
 }
 
 export function EntityPanel({
@@ -77,7 +84,7 @@ export function EntityPanel({
 }: Props) {
   const proxyBase = useProxyBase()
   const [profile, setProfile] = useState<EntityProfile | null>(null)
-  const [timeline, setTimeline] = useState<TimelineRow[] | null>(null)
+  const [timeline, setTimeline] = useState<TimelineEvent[] | null>(null)
   const [loading, setLoading] = useState(false)
   const [err, setErr] = useState<string | null>(null)
 
@@ -89,6 +96,11 @@ export function EntityPanel({
     }
     setLoading(true)
     setErr(null)
+    // Axis wiring: asOf (world-time) shapes the PROFILE's active-fact
+    // set only; timeline events live on the transaction-time axis, so
+    // the tx slider (recordedAt) is the one that cuts both surfaces.
+    // (Previously asOf was mis-mapped to the timeline's `until`, which
+    // filters recordedAt — the wrong axis.)
     const profileParams = new URLSearchParams()
     if (asOf) profileParams.set('asOf', asOf)
     if (recordedAt) profileParams.set('recordedAt', recordedAt)
@@ -96,7 +108,6 @@ export function EntityPanel({
       ? `?${profileParams.toString()}`
       : ''
     const timelineParams = new URLSearchParams()
-    if (asOf) timelineParams.set('until', asOf)
     if (recordedAt) timelineParams.set('recordedAt', recordedAt)
     const timelineQs = timelineParams.toString()
       ? `?${timelineParams.toString()}`
@@ -114,9 +125,7 @@ export function EntityPanel({
         const timelineData = await t.json()
         if (!p.ok) throw new Error(profileData?.error ?? `Profile ${p.status}`)
         setProfile(profileData as EntityProfile)
-        setTimeline(
-          (timelineData?.events ?? timelineData?.facts ?? []) as TimelineRow[],
-        )
+        setTimeline((timelineData?.events ?? []) as TimelineEvent[])
       })
       .catch((e) => setErr((e as Error).message))
       .finally(() => setLoading(false))
@@ -215,7 +224,7 @@ export function EntityPanel({
             </section>
 
             {timeline && timeline.length > 0 && (
-              <LineageTimeline rows={timeline} />
+              <LineageTimeline events={timeline} />
             )}
           </>
         )}
@@ -233,23 +242,21 @@ export function EntityPanel({
   )
 }
 
-function LineageTimeline({ rows }: { rows: TimelineRow[] }) {
-  // Sort newest first by max(validFrom, recordedAt) so the most recent
-  // event is at the top — operator's eye lands on "what's true now".
-  const sorted = [...rows].sort((a, b) => {
-    const aKey = (a.retractedAt ?? a.recordedAt ?? a.validFrom ?? '') as string
-    const bKey = (b.retractedAt ?? b.recordedAt ?? b.validFrom ?? '') as string
-    return bKey.localeCompare(aKey)
-  })
+function LineageTimeline({ events }: { events: TimelineEvent[] }) {
+  // Newest first by the event's tx instant — operator's eye lands on
+  // the most recent thing the graph learned (or unlearned).
+  const sorted = [...events].sort((a, b) =>
+    (b.at ?? '').localeCompare(a.at ?? ''),
+  )
   return (
     <section>
       <div className="text-[10px] uppercase tracking-wider text-[var(--text-faint)] mb-1 flex items-center gap-1">
-        <Clock className="w-3 h-3" /> bitemporal lineage ({rows.length})
+        <Clock className="w-3 h-3" /> bitemporal lineage ({events.length})
       </div>
       <ul className="space-y-1 relative">
         <div className="absolute left-2 top-2 bottom-2 w-px bg-[var(--border)]" />
-        {sorted.slice(0, 24).map((t, i) => (
-          <LineageRow key={t.factId ?? i} t={t} />
+        {sorted.slice(0, 24).map((e) => (
+          <LineageRow key={`${e.type}:${e.factId}`} e={e} />
         ))}
         {sorted.length > 24 && (
           <li className="pl-6 text-[10px] text-[var(--text-faint)]">
@@ -261,41 +268,55 @@ function LineageTimeline({ rows }: { rows: TimelineRow[] }) {
   )
 }
 
-function LineageRow({ t }: { t: TimelineRow }) {
-  const retracted = !!t.retractedAt || t.status === 'retracted'
-  const closed = !!t.validUntil
-  const validFromShort = (t.validFrom ?? '').slice(0, 10) || '—'
-  const recordedShort = (t.recordedAt ?? '').slice(0, 10)
-  const retractedShort = (t.retractedAt ?? '').slice(0, 10)
-  const Icon = retracted ? ShieldOff : closed ? Trash2 : CircleDot
-  const accent = retracted
-    ? 'text-[var(--danger)]'
-    : closed
-      ? 'text-[var(--warning)]'
-      : 'text-[var(--success)]'
+const shortId = (id: string) => id.replace(/^knowledge_fact:/, '')
+
+function LineageRow({ e }: { e: TimelineEvent }) {
+  const retracted = e.type === 'fact.retracted'
+  const atShort = (e.at ?? '').slice(0, 16).replace('T', ' ') || '—'
+  const Icon = retracted ? ShieldOff : CircleDot
+  const accent = retracted ? 'text-[var(--danger)]' : 'text-[var(--success)]'
   return (
     <li className="pl-6 relative">
-      <Icon
-        className={`w-3 h-3 absolute left-1 top-0.5 ${accent}`}
-      />
-      <div className="text-xs flex items-baseline gap-1.5">
-        <span className="font-mono text-[10px] text-[var(--text-muted)]">
-          {t.predicate ?? 'fact'}
-        </span>
-        <span
-          className={`flex-1 truncate ${retracted ? 'line-through text-[var(--text-faint)]' : 'text-[var(--text)]'}`}
-        >
-          {t.object ?? <em className="text-[var(--text-faint)]">[gated]</em>}
-        </span>
-      </div>
-      <div className="text-[10px] font-mono text-[var(--text-faint)] flex flex-wrap gap-x-2">
-        <span>valid: {validFromShort}</span>
-        {t.validUntil && <span>→ {t.validUntil.slice(0, 10)}</span>}
-        {recordedShort && <span>tx: {recordedShort}</span>}
-        {retractedShort && (
-          <span className="text-[var(--danger)]">retracted: {retractedShort}</span>
-        )}
-      </div>
+      <Icon className={`w-3 h-3 absolute left-1 top-0.5 ${accent}`} />
+      {retracted ? (
+        <>
+          <div className="text-xs flex items-baseline gap-1.5">
+            <span className="font-mono text-[10px] text-[var(--danger)]">
+              retracted
+            </span>
+            <span className="flex-1 truncate line-through text-[var(--text-faint)]">
+              {e.reason ?? shortId(e.factId)}
+            </span>
+          </div>
+          <div className="text-[10px] font-mono text-[var(--text-faint)] flex flex-wrap gap-x-2">
+            <span className="text-[var(--danger)]">tx: {atShort}</span>
+            {e.retractedBy && <span>by: {e.retractedBy}</span>}
+            {e.supersededBy && (
+              <span>superseded by: {shortId(e.supersededBy)}</span>
+            )}
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="text-xs flex items-baseline gap-1.5">
+            <span className="font-mono text-[10px] text-[var(--text-muted)]">
+              {e.predicate ?? 'fact'}
+            </span>
+            <span className="flex-1 truncate text-[var(--text)]">
+              {e.object ?? <em className="text-[var(--text-faint)]">[gated]</em>}
+            </span>
+            {e.confidence !== undefined && (
+              <span className="text-[10px] text-[var(--text-faint)] font-mono">
+                {e.confidence.toFixed(2)}
+              </span>
+            )}
+          </div>
+          <div className="text-[10px] font-mono text-[var(--text-faint)] flex flex-wrap gap-x-2">
+            <span>tx: {atShort}</span>
+            {e.source?.vertical && <span>src: {e.source.vertical}</span>}
+          </div>
+        </>
+      )}
     </li>
   )
 }

--- a/brain-landing/components/playground/SearchForm.tsx
+++ b/brain-landing/components/playground/SearchForm.tsx
@@ -65,8 +65,16 @@ export function SearchForm() {
             <label className="block text-xs text-[var(--text-muted)]">Limit</label>
             <input
               type="number"
+              min={1}
+              max={100}
               value={limit}
-              onChange={(e) => setLimit(parseInt(e.target.value) || 10)}
+              // Backend caps limit at 100 (search.dto) — clamp here so a
+              // free-typed value doesn't turn into an avoidable 400.
+              onChange={(e) =>
+                setLimit(
+                  Math.min(100, Math.max(1, parseInt(e.target.value) || 10)),
+                )
+              }
               className="w-full border border-[var(--border)] rounded-md bg-[var(--bg-elevated)] px-2 py-1 text-sm font-mono text-[var(--text)]"
             />
           </div>

--- a/docs/api.md
+++ b/docs/api.md
@@ -63,8 +63,8 @@ Protocol: [indexer-protocol.md](indexer-protocol.md).
 | `POST /v1/search` | Hybrid (vector + BM25), router-boosted, listwise rerank w/ self-consistency, per-leg CI, entity-fact backfill. `userId` scopes results to tenant-global + that user's personal memory (fail-closed: omitted → global only); also on `/synthesize` and `/search/multi-hop`. See [Architecture § Retrieval pipeline](architecture.md#retrieval-pipeline). |
 | `POST /v1/synthesize` | Corrective-RAG with strict / lenient / off guardrails + claim-level faithfulness scorer. See [Architecture § Synthesize](architecture.md#synthesize-corrective-rag). |
 | `POST /v1/search/multi-hop` | Planner-LLM decomposes the query into ≤N anchored sub-queries; carries supportingFactIds for HotpotQA-style joint-F1 eval. See [Architecture § Multi-hop](architecture.md#multi-hop-search). |
-| `GET /v1/entities/:id` | Entity profile + active facts (PII-gated by scope). |
-| `GET /v1/entities/:id/timeline` | Bitemporal sweep — all facts ever known, with validFrom / validUntil / recordedAt / retractedAt. |
+| `GET /v1/entities/:id` | Entity profile + active facts (PII-gated by scope). `?asOf=` slices world-time; `?recordedAt=` slices transaction-time (what the graph believed at T — a later retract/supersede is ignored). |
+| `GET /v1/entities/:id/timeline` | Bitemporal sweep — `fact.recorded` / `fact.retracted` events on the transaction-time axis. `?since=`/`?until=` page the window; `?recordedAt=` cuts to events known by T. |
 | `GET /v1/entities/:id/connections` | Typed edges + direct neighbours. |
 | `GET /v1/artifacts/:type/:entityId` | Derived artifacts (profile / digest / etc) with manual `recompile` POST. |
 | `GET /v1/sources` | Read-only trust inputs: declared `type`/`authLevel` ⋈ learned reputation, one row per source. Filters `domain` / `type` / `minSamples`, paginated (`limit` ≤ 200 / `offset`). Public projection — operator annotations (`owner`/`note`) stay on the admin surface. |

--- a/src/entities/entities.controller.ts
+++ b/src/entities/entities.controller.ts
@@ -19,6 +19,7 @@ import { AuthenticatedRequest } from '../auth/api-key.types';
 export class EntitiesController {
   constructor(private readonly entities: EntitiesService) {}
 
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Param/@Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get(':id')
   @RequireScopes('brain:read')
   @PolicyAction('get_entity_profile')
@@ -26,11 +27,13 @@ export class EntitiesController {
     @Req() req: AuthenticatedRequest,
     @Param('id') id: string,
     @Query('asOf') asOf?: string,
+    @Query('recordedAt') recordedAt?: string,
   ) {
     return this.entities.getProfile({
       companyId: req.brainAuth.companyId,
       entityIdRaw: id,
       asOfRaw: asOf,
+      recordedAtRaw: recordedAt,
       scopes: req.brainAuth.scopes,
     });
   }
@@ -44,12 +47,14 @@ export class EntitiesController {
     @Param('id') id: string,
     @Query('since') since?: string,
     @Query('until') until?: string,
+    @Query('recordedAt') recordedAt?: string,
   ) {
     return this.entities.getTimeline({
       companyId: req.brainAuth.companyId,
       entityIdRaw: id,
       sinceRaw: since,
       untilRaw: until,
+      recordedAtRaw: recordedAt,
       scopes: req.brainAuth.scopes,
     });
   }

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -70,6 +70,8 @@ export interface GetProfileOptions {
   companyId: string;
   entityIdRaw: string;
   asOfRaw: string | undefined;
+  /** Transaction-time cutoff — replay what the graph believed at T. */
+  recordedAtRaw?: string;
   scopes: BrainScope[];
 }
 
@@ -85,6 +87,12 @@ export interface GetTimelineOptions {
   entityIdRaw: string;
   sinceRaw: string | undefined;
   untilRaw: string | undefined;
+  /**
+   * Transaction-time cutoff — only events the graph knew by T: recorded
+   * events with recordedAt <= T, retraction events with retractedAt <= T.
+   * Distinct from `until`, which is an audit paging window over rows.
+   */
+  recordedAtRaw?: string;
   scopes: BrainScope[];
 }
 
@@ -120,10 +128,12 @@ export class EntitiesService {
     companyId,
     entityIdRaw,
     asOfRaw,
+    recordedAtRaw,
     scopes,
   }: GetProfileOptions): Promise<EntityProfile> {
     const ref = normalizeEntityId(entityIdRaw);
     const asOf = asOfRaw ? new Date(asOfRaw) : null;
+    const txAt = recordedAtRaw ? new Date(recordedAtRaw) : null;
 
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       const [entRows] = await db.query<any[][]>(
@@ -142,7 +152,10 @@ export class EntitiesService {
       // in JS. With a long-lived entity (~thousands of facts), this
       // collapses bytes-scanned by an order of magnitude for the
       // common case `asOf = now`.
-      const { clauses: asOfClauses, params: asOfParams } = activeFactWhere(asOf);
+      const { clauses: asOfClauses, params: asOfParams } = activeFactWhere(
+        asOf,
+        txAt,
+      );
       const baseClauses = [
         `entityId = type::record('knowledge_entity', $rid)`,
         // User scope (0055): entity reads are tenant-global v1 — a
@@ -305,11 +318,13 @@ export class EntitiesService {
     entityIdRaw,
     sinceRaw,
     untilRaw,
+    recordedAtRaw,
     scopes,
   }: GetTimelineOptions): Promise<{ entityId: string; events: any[] }> {
     const ref = normalizeEntityId(entityIdRaw);
     const since = sinceRaw ? new Date(sinceRaw) : null;
     const until = untilRaw ? new Date(untilRaw) : null;
+    const txAt = recordedAtRaw ? new Date(recordedAtRaw) : null;
 
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       // Range pushdown — recordedAt window is part of the WHERE so
@@ -320,6 +335,11 @@ export class EntitiesService {
       const params: Record<string, unknown> = { rid: ref.id };
       if (since) { clauses.push(`recordedAt >= $since`); params.since = since; }
       if (until) { clauses.push(`recordedAt <= $until`); params.until = until; }
+      // Transaction-time cutoff: events the graph knew by T. Row-level
+      // recordedAt <= T here; the retraction-event cut is applied in the
+      // event builder below (a retraction after T must not surface, while
+      // the fact's recorded event still shows as it was believed then).
+      if (txAt) { clauses.push(`recordedAt <= $txAt`); params.txAt = txAt; }
       // LIMIT 1000: the timeline is the audit surface, but without a cap
       // a long-lived entity ships its entire history per request. Callers
       // page with since/until (the window params above); 1000 rows is
@@ -353,7 +373,10 @@ export class EntitiesService {
           source: f.source,
           confidence: f.confidence,
         });
-        if (f.retractedAt) {
+        if (
+          f.retractedAt &&
+          (!txAt || new Date(f.retractedAt).getTime() <= txAt.getTime())
+        ) {
           events.push({
             type: 'fact.retracted',
             at: new Date(f.retractedAt).toISOString(),

--- a/src/entities/entity-read.helpers.ts
+++ b/src/entities/entity-read.helpers.ts
@@ -61,18 +61,56 @@ export function blockedPredicates(scopes: BrainScope[]): string[] {
  * composite (entityId, status, recordedAt) index does the work instead of
  * pulling rows just to drop them in JS.
  *
+ * With `recordedAt` (transaction-time travel), the closure replays what
+ * the graph BELIEVED at tx-time T: recorded by T, not yet retracted as
+ * of T, and — since a supersede has no timestamp of its own — a fact
+ * whose successor was recorded after T counts as still believed active,
+ * with its validity window read from the pre-supersede snapshot
+ * (`priorValidUntil`, written by fn::resolve_fact since migration 0021).
+ * The validity window is evaluated at `asOf` when given, else at T
+ * itself (belief at T about the world at T). Known approximation: an
+ * explicit retract mutates `validUntil` in place with no snapshot, so a
+ * fact retracted after T keeps the retract-written window rather than
+ * the exact one believed at T.
+ *
  * 'corroborating' rows (migration 0047) are audit records of a second
  * claim — the incumbent (which carries the corroboration counter) is
- * the fact to surface; both branches hide the duplicates. 'compacted'
- * skeletons are hidden in both branches, matching where-builder.
+ * the fact to surface; all branches hide the duplicates. 'compacted'
+ * skeletons are hidden in all branches, matching where-builder.
  *
  * Returns only the bitemporal clauses + their params; callers prepend the
  * `entityId = …` clause and its `$rid` param.
  */
-export function activeFactWhere(asOf: Date | null): {
+export function activeFactWhere(
+  asOf: Date | null,
+  recordedAt?: Date | null,
+): {
   clauses: string[];
   params: Record<string, unknown>;
 } {
+  if (recordedAt) {
+    const evalAt = asOf ?? recordedAt;
+    return {
+      clauses: [
+        `recordedAt <= $txAt`,
+        `(retractedAt IS NONE OR retractedAt > $txAt)`,
+        `validFrom <= $evalAt`,
+        // Supersede-aware window: a successor recorded after T had not
+        // happened yet at T — the fact was believed active with its
+        // priorValidUntil window. Once the successor is recorded (<= T),
+        // the supersede-written validUntil applies; this doubles as the
+        // future-gap rule (a superseded fact whose window still covers
+        // the evaluation moment IS the value believed then).
+        `((supersededBy IS NOT NONE AND supersededBy.recordedAt > $txAt` +
+          ` AND (priorValidUntil IS NONE OR priorValidUntil > $evalAt))` +
+          ` OR ((supersededBy IS NONE OR supersededBy.recordedAt <= $txAt)` +
+          ` AND (validUntil IS NONE OR validUntil > $evalAt)))`,
+        `status != 'compacted'`,
+        `status != 'corroborating'`,
+      ],
+      params: { txAt: recordedAt, evalAt },
+    };
+  }
   if (asOf) {
     return {
       clauses: [

--- a/test/entity-read-helpers.unit-spec.ts
+++ b/test/entity-read-helpers.unit-spec.ts
@@ -137,4 +137,49 @@ describe('activeFactWhere', () => {
     ]);
     expect(params).toEqual({ asOf });
   });
+
+  const TX_SUPERSEDE_CLAUSE =
+    `((supersededBy IS NOT NONE AND supersededBy.recordedAt > $txAt` +
+    ` AND (priorValidUntil IS NONE OR priorValidUntil > $evalAt))` +
+    ` OR ((supersededBy IS NONE OR supersededBy.recordedAt <= $txAt)` +
+    ` AND (validUntil IS NONE OR validUntil > $evalAt)))`;
+
+  it('with recordedAt, replays belief at tx-time T (window evaluated at T)', () => {
+    const txAt = new Date('2026-03-01T00:00:00.000Z');
+    const { clauses, params } = activeFactWhere(null, txAt);
+    expect(clauses).toEqual([
+      'recordedAt <= $txAt',
+      // A retraction after T had not happened yet — the fact is believed.
+      '(retractedAt IS NONE OR retractedAt > $txAt)',
+      'validFrom <= $evalAt',
+      // A supersede carries no timestamp of its own; its tx-time is the
+      // successor's recordedAt. Recorded after T → the fact was still
+      // believed active, with the pre-supersede priorValidUntil window.
+      TX_SUPERSEDE_CLAUSE,
+      "status != 'compacted'",
+      "status != 'corroborating'",
+    ]);
+    // Without asOf, the world moment defaults to T itself — the honest
+    // replay of what the no-param closure returned at wall-clock T.
+    expect(params).toEqual({ txAt, evalAt: txAt });
+  });
+
+  it('with recordedAt AND asOf, cuts the tx axis at T and evaluates validity at asOf', () => {
+    const txAt = new Date('2026-03-01T00:00:00.000Z');
+    const asOf = new Date('2026-02-01T00:00:00.000Z');
+    const { clauses, params } = activeFactWhere(asOf, txAt);
+    // asOf must NOT leak into the tx clauses — the axes stay separate.
+    expect(clauses.filter((c) => c.includes('$txAt'))).toEqual([
+      'recordedAt <= $txAt',
+      '(retractedAt IS NONE OR retractedAt > $txAt)',
+      TX_SUPERSEDE_CLAUSE,
+    ]);
+    expect(params).toEqual({ txAt, evalAt: asOf });
+  });
+
+  it('ignores an absent recordedAt — existing branches unchanged', () => {
+    expect(activeFactWhere(null, null)).toEqual(activeFactWhere(null));
+    const asOf = new Date('2026-01-02T03:04:05.000Z');
+    expect(activeFactWhere(asOf, undefined)).toEqual(activeFactWhere(asOf));
+  });
 });

--- a/test/entity-recorded-at.e2e-spec.ts
+++ b/test/entity-recorded-at.e2e-spec.ts
@@ -1,0 +1,200 @@
+/**
+ * e2e for the transaction-time (recordedAt) axis on entity profile and
+ * timeline — the backend half of the Timeline page's bitemporal travel.
+ *
+ * Matrix (fact recorded at tx T1, retracted at tx T2):
+ *   recordedAt ∈ (T1, T2) → profile shows the fact as believed active;
+ *                           timeline has the recorded event and NO
+ *                           retraction event (it hadn't happened yet).
+ *   recordedAt > T2       → profile hides it; timeline shows both events.
+ *   recordedAt < T1       → the graph knew nothing: no fact, no events.
+ * Plus supersede replay: a predecessor is believed active at any tx
+ * moment before its successor was recorded (a supersede carries no
+ * timestamp of its own — its tx-time is the successor's recordedAt).
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+describe('transaction-time axis — profile/timeline recordedAt', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  beforeAll(async () => {
+    f = await createApp();
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  // /v1/ingest/fact doesn't surface the entity id — read it off the
+  // created fact row (entity record ids are generated, not the ref id).
+  const entityIdOfFact = async (factId: string): Promise<string> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const tail = factId.split(':')[1];
+      const [rows] = await db.query<any[][]>(
+        `SELECT entityId FROM type::record('knowledge_fact', $tail) LIMIT 1`,
+        { tail },
+      );
+      return String((rows as any[])[0].entityId);
+    });
+  };
+
+  it('replays record→retract belief states across the tx axis', async () => {
+    const ingest = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: { vertical: 'rent', id: 'tx_axis_customer' },
+      predicate: 'tier',
+      object: 'platinum',
+      validFrom: '2026-01-15',
+      source: { vertical: 'rent', eventId: 'billing.tier_set' },
+      confidence: 0.9,
+    });
+    expect(ingest.body.outcome).toBe('INSERTED');
+    const factId = ingest.body.factId as string;
+    const entity = await entityIdOfFact(factId);
+
+    // Ensure the retraction lands on a strictly later tx millisecond.
+    await sleep(150);
+
+    const retract = await f.http
+      .post(`/v1/facts/${encodeURIComponent(factId)}/retract`)
+      .set(auth())
+      .send({
+        reason: 'operator correction',
+        retractedBy: { source: 'human' },
+      });
+    expect(retract.status).toBe(201);
+
+    // Learn the exact tx timestamps from the uncut timeline itself —
+    // no clock-skew games between the test host and the DB.
+    const full = await f.http
+      .get(`/v1/entities/${encodeURIComponent(entity)}/timeline`)
+      .set(auth());
+    expect(full.status).toBe(200);
+    const recordedEvt = full.body.events.find(
+      (e: any) => e.type === 'fact.recorded' && e.factId === factId,
+    );
+    const retractedEvt = full.body.events.find(
+      (e: any) => e.type === 'fact.retracted' && e.factId === factId,
+    );
+    expect(recordedEvt).toBeTruthy();
+    expect(retractedEvt).toBeTruthy();
+    const t1 = new Date(recordedEvt.at).getTime();
+    const t2 = new Date(retractedEvt.at).getTime();
+    expect(t2).toBeGreaterThan(t1);
+    const mid = new Date((t1 + t2) / 2).toISOString();
+    const before = new Date(t1 - 1000).toISOString();
+    const after = new Date(t2 + 1000).toISOString();
+
+    const profileAt = async (tx: string) => {
+      const res = await f.http
+        .get(
+          `/v1/entities/${encodeURIComponent(entity)}?recordedAt=${encodeURIComponent(tx)}`,
+        )
+        .set(auth());
+      expect(res.status).toBe(200);
+      return res.body.facts.some((x: any) => x.factId === factId);
+    };
+    const timelineTypesAt = async (tx: string) => {
+      const res = await f.http
+        .get(
+          `/v1/entities/${encodeURIComponent(entity)}/timeline?recordedAt=${encodeURIComponent(tx)}`,
+        )
+        .set(auth());
+      expect(res.status).toBe(200);
+      return res.body.events
+        .filter((e: any) => e.factId === factId)
+        .map((e: any) => e.type);
+    };
+
+    // Between record and retract: believed active, retraction unknown.
+    expect(await profileAt(mid)).toBe(true);
+    expect(await timelineTypesAt(mid)).toEqual(['fact.recorded']);
+
+    // After the retraction: no longer believed; both events on record.
+    expect(await profileAt(after)).toBe(false);
+    expect(await timelineTypesAt(after)).toEqual([
+      'fact.recorded',
+      'fact.retracted',
+    ]);
+
+    // Before the fact was recorded: the graph knew nothing.
+    expect(await profileAt(before)).toBe(false);
+    expect(await timelineTypesAt(before)).toEqual([]);
+  });
+
+  it('replays supersede belief: predecessor active until its successor is recorded', async () => {
+    const a = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: { vertical: 'rent', id: 'tx_axis_supersede' },
+      predicate: 'status',
+      object: 'active',
+      validFrom: '2026-01-15',
+      source: { vertical: 'rent', eventId: 'auth.profile_active' },
+      confidence: 0.9,
+    });
+    expect(a.body.outcome).toBe('INSERTED');
+    const aFactId = a.body.factId as string;
+    const entity = await entityIdOfFact(aFactId);
+
+    await sleep(150);
+
+    const b = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: { vertical: 'rent', id: 'tx_axis_supersede' },
+      predicate: 'status',
+      object: 'churned',
+      validFrom: '2026-04-10',
+      source: { vertical: 'rent', eventId: 'billing.churn' },
+      confidence: 0.9,
+    });
+    expect(b.body.outcome).toBe('SUPERSEDED');
+    expect(b.body.supersededFactIds).toContain(aFactId);
+    const bFactId = b.body.factId as string;
+
+    const full = await f.http
+      .get(`/v1/entities/${encodeURIComponent(entity)}/timeline`)
+      .set(auth());
+    const recordedAtOf = (id: string) =>
+      new Date(
+        full.body.events.find(
+          (e: any) => e.type === 'fact.recorded' && e.factId === id,
+        ).at,
+      ).getTime();
+    const tA = recordedAtOf(aFactId);
+    const tB = recordedAtOf(bFactId);
+    expect(tB).toBeGreaterThan(tA);
+    const mid = new Date((tA + tB) / 2).toISOString();
+
+    const factIdsAt = async (qs: string) => {
+      const res = await f.http
+        .get(`/v1/entities/${encodeURIComponent(entity)}${qs}`)
+        .set(auth());
+      expect(res.status).toBe(200);
+      return res.body.facts.map((x: any) => x.factId);
+    };
+
+    // Before the supersede was recorded, A was the believed truth —
+    // even though its row now carries supersededBy + a closed window.
+    const atMid = await factIdsAt(`?recordedAt=${encodeURIComponent(mid)}`);
+    expect(atMid).toContain(aFactId);
+    expect(atMid).not.toContain(bFactId);
+
+    // At the present tx moment the successor is the believed truth.
+    const now = new Date().toISOString();
+    const atNow = await factIdsAt(`?recordedAt=${encodeURIComponent(now)}`);
+    expect(atNow).toContain(bFactId);
+    expect(atNow).not.toContain(aFactId);
+
+    // Axes stay separate: tx cutoff at mid + world moment asOf — the
+    // belief at mid about 2026-02-01 is still A.
+    const atMidAsOf = await factIdsAt(
+      `?recordedAt=${encodeURIComponent(mid)}&asOf=${encodeURIComponent(
+        '2026-02-01T00:00:00Z',
+      )}`,
+    );
+    expect(atMidAsOf).toContain(aFactId);
+    expect(atMidAsOf).not.toContain(bFactId);
+  });
+});


### PR DESCRIPTION
## Problem

The end-user Timeline page advertises travel over BOTH bitemporal axes, but:

1. **`recordedAt` silently dropped** — the tx-time slider sends `recordedAt` on both fetches (`EntityPanel.tsx`), but `GET /v1/entities/:id` accepted only `asOf` and `/:id/timeline` only `since`/`until`. The knowledge-time axis did nothing.
2. **Wrong axis mapping** — the page mapped world-time `asOf` → timeline `until`, and `until` filters `recordedAt` (transaction time), so the world slider scrubbed the wrong axis.
3. **Event shape mismatch** — `EntityPanel` rendered timeline entries as fact rows (`validFrom/validUntil/recordedAt/retractedAt/status`) while the backend returns events (`{type: 'fact.recorded'|'fact.retracted', at, ...}`): blank dates, junk retraction rows, dead sort keys, no retracted styling.
4. Minor: playground search allowed any numeric limit (backend caps at 100 → avoidable 400s); usage page called `stats[key].toLocaleString()` unguarded.

## Fix

### Backend — transaction-time axis
- `activeFactWhere` (the unified bitemporal closure from the P2 wave — extended, not forked) grows a `recordedAt` branch replaying what the graph **believed at tx-time T**:
  - `recordedAt <= T`, retraction after T ignored (`retractedAt IS NONE OR retractedAt > T`);
  - a supersede has no timestamp of its own — its tx-time is the successor's `recordedAt` via the `supersededBy` link. A fact whose successor was recorded after T counts as still believed active, with its validity window read from the pre-supersede snapshot `priorValidUntil` (written by `fn::resolve_fact` since migration 0021);
  - the validity window is evaluated at `asOf` when given, else at T itself — the axes stay separate.
- `GET /v1/entities/:id` and `GET /v1/entities/:id/timeline` accept optional `?recordedAt=` (ISO datetime, parsed like `asOf`). The timeline cuts rows to `recordedAt <= T` and suppresses retraction events after T while keeping the fact's recorded event as it was believed then.
- No wire-contract/OpenAPI change: entities endpoints are not part of the generated platform surface. `docs/api.md` rows updated.

### App UI (brain-landing)
- `EntityPanel` rewritten to the real event shape: timestamp = `at`, newest-first sort by `at`, retracted styling + `retractedBy`/`reason`/`supersededBy` on `fact.retracted`, recorded events render predicate/object/confidence/source.
- Axis wiring: world-time `asOf` shapes the **profile** only; the tx slider `recordedAt` cuts **both** calls (the `asOf` → `until` mis-mapping is gone).
- `SearchForm` clamps limit to 1..100; usage page guards missing stat keys with `?? 0`.

## Tests
- Unit: tx-branch clauses + axis-separation + no-op-without-`recordedAt` equality (`test/entity-read-helpers.unit-spec.ts`).
- e2e (`test/entity-recorded-at.e2e-spec.ts`): fact recorded at T1, retracted at T2 → `recordedAt` between shows the fact active and no retraction event; after T2 shows the retraction; before T1 shows nothing. Supersede replay: predecessor believed active until its successor's tx moment, including a combined `recordedAt`+`asOf` probe.

## Verification
- `pnpm exec tsc --noEmit` — clean
- `pnpm lint:ci` — 0 warnings
- `pnpm test` — 172 suites / 1346 tests pass
- e2e (SurrealDB 3.1.5 testcontainer): full suite serial — 78/79 suites, 333/334 tests; the one failure (`brain.e2e-spec.ts`, 1 test) re-run in isolation passes 15/15 — cross-suite flake of the shared-container mega-run, not this change. Targeted `entit` matrix 5/5 suites green.
- brain-landing: `pnpm lint` 0 errors (50 pre-existing warnings, count identical before/after), `pnpm test` 9/9, `pnpm build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6QRex9uXdcTgGiVRq3RBd