### PR TITLE
feat(admin-ui): static registry API key path for marketplace writes

### DIFF
--- a/brain-landing/app/api/admin/proxy/[...path]/route.ts
+++ b/brain-landing/app/api/admin/proxy/[...path]/route.ts
@@ -403,11 +403,24 @@ async function forward(
   const debug = query.debug === '1'
   if (debug) delete query.debug
 
+  // The registry catalogue scopes (registry:publish / registry:curate)
+  // are env-key-only on the backend — JWT tokens get them stripped at
+  // verification. When the operator provisions BRAIN_REGISTRY_API_KEY
+  // (a BRAIN_API_KEYS entry with e.g. `brain:admin registry:publish
+  // registry:curate`), marketplace admin calls ride it instead of the
+  // M2M token; without it they degrade to the M2M path and the panel
+  // shows its missing-scope note.
+  const registryKey =
+    subpath.startsWith('v1/admin/registry') && process.env.BRAIN_REGISTRY_API_KEY
+      ? process.env.BRAIN_REGISTRY_API_KEY
+      : undefined
+
   const res = await brainFetch(`/${subpath}`, {
     method: request.method as 'GET' | 'POST' | 'PUT' | 'DELETE',
     body,
     query,
     headers: debug ? { 'X-Brain-Debug': '1' } : undefined,
+    apiKey: registryKey,
   })
 
   const schema = res.ok ? findSchema(request.method, subpath) : undefined

--- a/brain-landing/lib/brain-api.ts
+++ b/brain-landing/lib/brain-api.ts
@@ -130,6 +130,14 @@ export interface BrainFetchOptions {
    * The user BFF passes {@link USER_SCOPE}.
    */
   scope?: string
+  /**
+   * Static brain API key sent as the Bearer token INSTEAD of minting an
+   * M2M JWT. Needed for the registry catalogue scopes
+   * (`registry:publish` / `registry:curate`), which are deliberately
+   * absent from the JWT `VALID_SCOPES` allowlist on the backend and can
+   * only ride an env-provisioned `BRAIN_API_KEYS` key.
+   */
+  apiKey?: string
 }
 
 export interface BrainResponse<T = unknown> {
@@ -155,14 +163,18 @@ export async function brainFetch<T = unknown>(
 ): Promise<BrainResponse<T>> {
   const scope = options.scope ?? ADMIN_SCOPE
   let token: string
-  try {
-    token = await getServiceToken(scope)
-  } catch (err) {
-    return {
-      ok: false,
-      status: 500,
-      data: null,
-      error: (err as Error).message,
+  if (options.apiKey) {
+    token = options.apiKey
+  } else {
+    try {
+      token = await getServiceToken(scope)
+    } catch (err) {
+      return {
+        ok: false,
+        status: 500,
+        data: null,
+        error: (err as Error).message,
+      }
     }
   }
 
@@ -187,8 +199,9 @@ export async function brainFetch<T = unknown>(
       // raw text below
     }
     // On 401 the cached token may have been revoked — invalidate the
-    // entry for this scope and let the next request re-mint.
-    if (res.status === 401) {
+    // entry for this scope and let the next request re-mint. (Static
+    // apiKey calls never touched the cache.)
+    if (res.status === 401 && !options.apiKey) {
       tokenCache.delete(scope)
     }
     if (!res.ok) {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -342,13 +342,19 @@ plus all Marketplace *reads*; Marketplace *writes* need more:
 
 Missing scopes degrade gracefully — the Marketplace panel stays usable
 read-only and shows an amber note naming the missing scope instead of a
-generic error. To actually enable those writes, widening `BRAIN_SCOPE`
-is necessary but not sufficient today: the registry scopes are
-env-key-only (deliberately absent from the JWT `VALID_SCOPES` set in
-`src/auth/jwks.service.ts`), so a JWT-based BFF token gets them
-stripped at verification. Until that allowlist decision changes,
-perform registry curation/publishing with a `BRAIN_API_KEYS` env key
-(see docs/domain-packs.md) rather than through the admin UI.
+generic error. The registry scopes are env-key-only by design
+(deliberately absent from the JWT `VALID_SCOPES` set in
+`src/auth/jwks.service.ts`), so a JWT-based BFF token can never carry
+them. To enable Marketplace writes from the admin UI:
+
+1. Add a key to the backend's `BRAIN_API_KEYS` with scopes
+   `brain:admin registry:publish registry:curate` (see
+   docs/domain-packs.md for key minting).
+2. Set the plaintext key as `BRAIN_REGISTRY_API_KEY` in the
+   brain-landing environment. The BFF proxy then sends it as the Bearer
+   token on `v1/admin/registry/*` calls only; everything else stays on
+   the M2M JWT path. Without the env var, marketplace writes keep the
+   read-only degradation.
 
 **Deliberately NOT in v1**
 


### PR DESCRIPTION
The registry catalogue scopes (`registry:publish` / `registry:curate`) are env-key-only by design — the JWT `VALID_SCOPES` allowlist strips them at verification, so the admin BFF's M2M token can never carry them and Marketplace writes from the admin UI would 403 forever (found during #210).

- `brainFetch` gains an `apiKey` option that sends a static Bearer instead of minting an M2M JWT (server-only module, key never reaches the client bundle).
- The admin proxy uses `BRAIN_REGISTRY_API_KEY` (when provisioned) on `v1/admin/registry/*` calls only; all other paths stay on the M2M JWT.
- Without the env var, the Marketplace panel keeps its graceful read-only degradation.
- docs/operations.md: two-step enablement runbook (mint a `BRAIN_API_KEYS` entry with `brain:admin registry:publish registry:curate`, set it as `BRAIN_REGISTRY_API_KEY` in the landing env).

Verified: landing lint 0 errors, tests 27/27, next build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)