### PR TITLE
feat(auth): inite-auth vertical tightening — per-user memory, agent grants, ABAC delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,14 +206,24 @@ BRAIN_API_KEYS=[]
 
 # Service-to-service JWT verification.
 # When AUTH_SERVICE_JWKS_URL is set, Bearer tokens shaped like JWTs are
-# verified against this URL's keys. The token's `sub` is the companyId,
-# `scopes` (or `scope`) carry brain scopes. Static BRAIN_API_KEYS still
-# works as a fallback unless NODE_ENV=production and JWKS is enabled
-# (in that case static keys are rejected — JWTs only).
+# verified against this URL's keys. Tenant/user mapping: `org` present →
+# tenant = org and end-user = sub (user-bound token, pinned per-user
+# memory scope); `org` absent → tenant = sub (M2M token). Static
+# BRAIN_API_KEYS still works as a fallback unless NODE_ENV=production
+# and a remote verifier (JWKS or introspection) is enabled.
 AUTH_SERVICE_URL=https://auth.inite.ai
 AUTH_SERVICE_JWKS_URL=
 AUTH_SERVICE_ISSUER=
 AUTH_SERVICE_AUDIENCE=brain
+
+# Opaque API-key introspection (RFC 7662). Long-lived ik_… keys issued in
+# the auth-service admin panel are resolved via POST /v1/oauth/introspect
+# using the brain-service M2M client credentials (register-brain-clients
+# in the auth repo). All three unset → introspection disabled.
+AUTH_SERVICE_INTROSPECTION_CLIENT_ID=
+AUTH_SERVICE_INTROSPECTION_CLIENT_SECRET=
+# Optional endpoint override; default = AUTH_SERVICE_URL + /v1/oauth/introspect
+AUTH_SERVICE_INTROSPECTION_URL=
 
 # ── Conflict resolution weights (overrides spec defaults) ────────────────
 # These mirror the values in inite-ecosystem/core/capabilities/knowledge.yaml

--- a/.env.example
+++ b/.env.example
@@ -225,6 +225,21 @@ AUTH_SERVICE_INTROSPECTION_CLIENT_SECRET=
 # Optional endpoint override; default = AUTH_SERVICE_URL + /v1/oauth/introspect
 AUTH_SERVICE_INTROSPECTION_URL=
 
+# CAEP revocation propagation (OpenID Shared Signals Framework, RFC 8936
+# poll delivery). When set, brain polls the auth-service stream and
+# deny-lists subjects from session-revoked / account-disabled /
+# token-claims-change events — closing the "revoked token stays valid
+# until exp" window of local JWKS verification. Create the stream in the
+# auth admin (Shared Signals → poll) and point this at its poll endpoint,
+# e.g. https://auth.inite.ai/v1/ssf/streams/<id>/poll. Credentials default
+# to the introspection client above; the poll endpoint requires an
+# admin-scoped M2M client (AUTH_SSF_POLL_SCOPE, default "admin").
+AUTH_SSF_POLL_URL=
+AUTH_SSF_POLL_INTERVAL_MS=30000
+AUTH_SSF_CLIENT_ID=
+AUTH_SSF_CLIENT_SECRET=
+AUTH_SSF_POLL_SCOPE=admin
+
 # ── Conflict resolution weights (overrides spec defaults) ────────────────
 # These mirror the values in inite-ecosystem/core/capabilities/knowledge.yaml
 # Override only if you really know what you're doing.

--- a/.env.example
+++ b/.env.example
@@ -240,6 +240,13 @@ AUTH_SSF_CLIENT_ID=
 AUTH_SSF_CLIENT_SECRET=
 AUTH_SSF_POLL_SCOPE=admin
 
+# Tier-aware throttling. JSON map of entitlement slug (from the token's
+# `entitlements` claim) to a rate-limit multiplier applied on top of the
+# THROTTLE_*_LIMIT defaults after the credential verifies. Unset = every
+# credential gets the default tier.
+# Example: THROTTLE_TIER_MULTIPLIERS={"plan:pro":2,"plan:enterprise":5}
+THROTTLE_TIER_MULTIPLIERS=
+
 # ── Conflict resolution weights (overrides spec defaults) ────────────────
 # These mirror the values in inite-ecosystem/core/capabilities/knowledge.yaml
 # Override only if you really know what you're doing.

--- a/brain-landing/app/api/admin/proxy/[...path]/route.ts
+++ b/brain-landing/app/api/admin/proxy/[...path]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { withAdmin } from '@/lib/server-auth'
+import { withAdmin, extractAccessToken } from '@/lib/server-auth'
 import { brainFetch } from '@/lib/brain-api'
 import { extractProxyPath, collectQuery, isPathAllowed } from '@/lib/bff-proxy'
 import { LeasesResponseSchema } from '@/lib/contracts/admin-leases'
@@ -415,10 +415,14 @@ async function forward(
       ? process.env.BRAIN_REGISTRY_API_KEY
       : undefined
 
+  // Preserve the operator's identity downstream via token exchange —
+  // brain's audit trail then names the real admin, not the anonymous
+  // service credential. Dev-bypass sessions keep the M2M path.
   const res = await brainFetch(`/${subpath}`, {
     method: request.method as 'GET' | 'POST' | 'PUT' | 'DELETE',
     body,
     query,
+    userToken: await extractAccessToken(request),
     headers: debug ? { 'X-Brain-Debug': '1' } : undefined,
     apiKey: registryKey,
   })

--- a/brain-landing/app/api/admin/sse/[...path]/route.ts
+++ b/brain-landing/app/api/admin/sse/[...path]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { withAdmin } from '@/lib/server-auth'
+import { withAdmin, extractAccessToken } from '@/lib/server-auth'
+import { getBrainToken } from '@/lib/brain-api'
 
 /**
  * /api/admin/sse/[...path] — admin-gated SSE pass-through.
@@ -27,32 +28,8 @@ function isAllowed(path: string): boolean {
   )
 }
 
-async function getToken(): Promise<string> {
-  const auth = process.env.AUTH_SERVICE_URL || 'https://auth.inite.ai'
-  const clientId = process.env.OAUTH_CLIENT_ID || 'brain-landing'
-  const clientSecret = process.env.OAUTH_CLIENT_SECRET || ''
-  const aud = process.env.BRAIN_AUDIENCE || 'brain'
-  const scope =
-    process.env.BRAIN_SCOPE || 'brain:read brain:write brain:admin brain:read_pii'
-  if (!clientSecret) throw new Error('OAUTH_CLIENT_SECRET is not configured')
-  const res = await fetch(`${auth}/oauth/token`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'client_credentials',
-      client_id: clientId,
-      client_secret: clientSecret,
-      audience: aud,
-      scope,
-    }).toString(),
-    cache: 'no-store',
-  })
-  if (!res.ok) {
-    throw new Error(`auth-service token mint failed (${res.status})`)
-  }
-  const body = (await res.json()) as { access_token: string }
-  return body.access_token
-}
+const SSE_SCOPE =
+  process.env.BRAIN_SCOPE || 'brain:read brain:write brain:admin brain:read_pii'
 
 export const GET = withAdmin(async (_session, request) => {
   const u = request.nextUrl
@@ -72,7 +49,12 @@ export const GET = withAdmin(async (_session, request) => {
 
   let token: string
   try {
-    token = await getToken()
+    // Same identity-preserving exchange as the JSON proxy (M2M fallback
+    // for dev-bypass sessions).
+    token = await getBrainToken({
+      scope: SSE_SCOPE,
+      userToken: await extractAccessToken(request),
+    })
   } catch (e) {
     return NextResponse.json(
       { error: (e as Error).message },

--- a/brain-landing/app/api/app/proxy/[...path]/route.ts
+++ b/brain-landing/app/api/app/proxy/[...path]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { withUser, type UserSession } from '@/lib/server-auth'
+import { withUser, extractAccessToken, type UserSession } from '@/lib/server-auth'
 import { brainFetch, USER_SCOPE } from '@/lib/brain-api'
 import { extractProxyPath, collectQuery, isPathAllowed } from '@/lib/bff-proxy'
 
@@ -108,11 +108,16 @@ async function forward(
   if (wantsDebug) delete query.debug
   const forwardDebug = wantsDebug && session.isAdmin
 
+  // Ride the user's identity downstream via token exchange: brain then
+  // scopes memory to org (tenant) + sub (this user) instead of the
+  // anonymous service identity. Dev-bypass sessions have no token and
+  // keep the M2M path.
   const res = await brainFetch(`/${subpath}`, {
     method: request.method as 'GET' | 'POST' | 'PUT' | 'DELETE',
     body,
     query,
     scope: USER_SCOPE,
+    userToken: await extractAccessToken(request),
     headers: forwardDebug ? { 'X-Brain-Debug': '1' } : undefined,
   })
 

--- a/brain-landing/app/api/auth/login/route.ts
+++ b/brain-landing/app/api/auth/login/route.ts
@@ -23,7 +23,14 @@ const CLIENT_ID =
   process.env.NEXT_PUBLIC_OAUTH_CLIENT_ID ||
   'brain-landing'
 
-const SCOPE = 'openid profile email'
+// brain:* scopes ride the session token so the BFF can RFC 8693-exchange
+// it for an aud=brain token that keeps the user's identity (org + sub).
+// Scope is authority ceiling, not role: admin routes still require the
+// admin role (middleware + withAdmin), and the exchange narrows per proxy
+// (USER_SCOPE vs ADMIN_SCOPE).
+const SCOPE =
+  process.env.OAUTH_SCOPE ||
+  'openid profile email brain:read brain:write brain:admin brain:read_pii'
 
 function appOrigin(request: NextRequest): string {
   if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL

--- a/brain-landing/lib/brain-api.ts
+++ b/brain-landing/lib/brain-api.ts
@@ -1,15 +1,22 @@
 /**
  * Server-side client to the brain backend.
  *
- * The admin BFF (`/api/admin/proxy/[...path]`) calls into here. We
- * intentionally do NOT forward the user's cookie JWT — that token has
- * audience='brain-landing' and brain backend validates audience='brain'.
+ * The BFFs (`/api/admin/proxy`, `/api/app/proxy`) call into here. The
+ * user's cookie JWT is never forwarded verbatim — it has
+ * audience='brain-landing' and the brain backend validates
+ * audience='brain'.
  *
- * Instead, brain-landing acts as an OAuth client and mints a
- * machine-to-machine token via the `client_credentials` grant against
- * auth.inite.ai. The token has aud='brain' and scopes=brain:admin
- * (subject to client allowlist on the auth-service side). Tokens are
- * cached in-process until ~30s before expiry.
+ * Preferred path: RFC 8693 token exchange. The BFF trades the user's
+ * session token for an aud='brain' token that KEEPS the user identity —
+ * `sub` (end-user), `org`/`org_id` (tenant) and an `act` claim naming
+ * brain-landing as the acting party. Brain maps org→companyId and
+ * sub→userId, which is what makes per-user memory scoping and
+ * multi-tenant end-user deployments possible.
+ *
+ * Fallback path: `client_credentials` M2M mint (no user identity) —
+ * used for calls with no user in scope and as a graceful degrade while
+ * the auth-service hasn't granted the token-exchange grant yet.
+ * Tokens of both kinds are cached in-process until ~30s before expiry.
  */
 
 // Hard server-only gate. The OAUTH_CLIENT_SECRET this module mints
@@ -18,6 +25,7 @@
 // 'use client' file accidentally pulling brain-api in fails the
 // Next.js build instead of silently leaking the secret.
 import 'server-only'
+import { createHash } from 'node:crypto'
 
 const BRAIN_API_URL =
   process.env.BRAIN_API_URL ||
@@ -117,6 +125,112 @@ async function getServiceToken(scope: string): Promise<string> {
   }
 }
 
+// ── RFC 8693 token exchange (user identity preserved) ───────────────
+
+const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange'
+const SUBJECT_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token'
+
+// Exchanged tokens are per (user session × scope). Bounded so a busy
+// multi-user deployment can't grow the map unboundedly — entries are
+// tiny and expire in ~5min anyway.
+const exchangeCache = new Map<string, CachedToken>()
+const exchangeInFlight = new Map<string, Promise<CachedToken>>()
+const MAX_EXCHANGE_ENTRIES = 500
+
+function exchangeKey(subjectToken: string, scope: string): string {
+  const digest = createHash('sha256').update(subjectToken).digest('hex').slice(0, 32)
+  return `${digest}:${scope}`
+}
+
+async function fetchExchangedToken(
+  subjectToken: string,
+  scope: string,
+): Promise<CachedToken> {
+  if (!CLIENT_SECRET) {
+    throw new Error('OAUTH_CLIENT_SECRET is not configured')
+  }
+  const res = await fetch(`${AUTH_SERVICE_URL}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: TOKEN_EXCHANGE_GRANT,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      subject_token: subjectToken,
+      subject_token_type: SUBJECT_TOKEN_TYPE,
+      scope,
+      audience: BRAIN_AUDIENCE,
+    }),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(
+      `token exchange failed: ${res.status} ${text.slice(0, 200)}`,
+    )
+  }
+  const body = (await res.json()) as {
+    access_token: string
+    expires_in?: number
+  }
+  const ttlSec = body.expires_in ?? 300
+  return {
+    accessToken: body.access_token,
+    expiresAtMs: Date.now() + (ttlSec - 30) * 1000,
+  }
+}
+
+async function getExchangedToken(
+  subjectToken: string,
+  scope: string,
+): Promise<string> {
+  const key = exchangeKey(subjectToken, scope)
+  const cached = exchangeCache.get(key)
+  if (cached && cached.expiresAtMs > Date.now()) {
+    return cached.accessToken
+  }
+  const pending = exchangeInFlight.get(key)
+  if (pending) {
+    const t = await pending
+    return t.accessToken
+  }
+  const p = fetchExchangedToken(subjectToken, scope)
+  exchangeInFlight.set(key, p)
+  try {
+    const fresh = await p
+    if (exchangeCache.size >= MAX_EXCHANGE_ENTRIES) {
+      const oldest = exchangeCache.keys().next().value
+      if (oldest !== undefined) exchangeCache.delete(oldest)
+    }
+    exchangeCache.set(key, fresh)
+    return fresh.accessToken
+  } finally {
+    exchangeInFlight.delete(key)
+  }
+}
+
+/**
+ * Resolve the bearer token for a brain call. With a user session token,
+ * prefer the identity-preserving exchange; degrade to the anonymous M2M
+ * mint when exchange is unavailable (grant not provisioned yet, subject
+ * token lacking brain scopes) so the dashboard keeps working during the
+ * auth-service rollout.
+ */
+export async function getBrainToken(opts: {
+  scope: string
+  userToken?: string | null
+}): Promise<string> {
+  if (opts.userToken) {
+    try {
+      return await getExchangedToken(opts.userToken, opts.scope)
+    } catch (err) {
+      console.warn(
+        `[brain-api] token exchange unavailable, falling back to client_credentials: ${(err as Error).message}`,
+      )
+    }
+  }
+  return getServiceToken(opts.scope)
+}
+
 export interface BrainFetchOptions {
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE'
   body?: unknown
@@ -135,9 +249,17 @@ export interface BrainFetchOptions {
    * M2M JWT. Needed for the registry catalogue scopes
    * (`registry:publish` / `registry:curate`), which are deliberately
    * absent from the JWT `VALID_SCOPES` allowlist on the backend and can
-   * only ride an env-provisioned `BRAIN_API_KEYS` key.
+   * only ride an env-provisioned `BRAIN_API_KEYS` key. Takes precedence
+   * over {@link userToken}.
    */
   apiKey?: string
+  /**
+   * The caller's session access token (cookie JWT). When present, the
+   * call rides an RFC 8693 exchange that preserves the user identity
+   * downstream (per-user memory, audit attribution) instead of the
+   * anonymous M2M mint.
+   */
+  userToken?: string | null
 }
 
 export interface BrainResponse<T = unknown> {
@@ -167,7 +289,7 @@ export async function brainFetch<T = unknown>(
     token = options.apiKey
   } else {
     try {
-      token = await getServiceToken(scope)
+      token = await getBrainToken({ scope, userToken: options.userToken })
     } catch (err) {
       return {
         ok: false,
@@ -199,10 +321,13 @@ export async function brainFetch<T = unknown>(
       // raw text below
     }
     // On 401 the cached token may have been revoked — invalidate the
-    // entry for this scope and let the next request re-mint. (Static
-    // apiKey calls never touched the cache.)
+    // entries for this scope and let the next request re-mint. (Static
+    // apiKey calls never touched the caches.)
     if (res.status === 401 && !options.apiKey) {
       tokenCache.delete(scope)
+      if (options.userToken) {
+        exchangeCache.delete(exchangeKey(options.userToken, scope))
+      }
     }
     if (!res.ok) {
       return {

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -59,7 +59,10 @@ deploy:
 
 Optional (off by default in workflow, opt in per-feature):
 - `BRAIN_COHERE_API_KEY` — cross-encoder reranker
-- `BRAIN_API_KEYS` — static `[{keyHash, companyId, scopes}]` JSON; only if you need a non-JWT fallback path. NODE_ENV=production + JWKS enabled rejects static keys, so leaving this empty is correct.
+- `BRAIN_API_KEYS` — static `[{keyHash, companyId, scopes}]` JSON; only if you need a non-JWT fallback path. NODE_ENV=production + a remote verifier (JWKS/introspection) rejects static keys, so leaving this empty is correct.
+- `BRAIN_AUTH_INTROSPECTION_CLIENT_ID/SECRET` → `AUTH_SERVICE_INTROSPECTION_CLIENT_ID/SECRET` — enables auth-service `ik_…` API-key resolution (RFC 7662). Provision the `brain-service` client with `register-brain-clients` in the auth repo first.
+- `BRAIN_AUTH_SSF_POLL_URL` → `AUTH_SSF_POLL_URL` — CAEP revocation stream (create a poll stream in the auth admin → Shared Signals); revoked IdP sessions then die here within the poll interval instead of at token expiry.
+- `BRAIN_THROTTLE_TIER_MULTIPLIERS` → `THROTTLE_TIER_MULTIPLIERS` — per-plan rate-limit multipliers, e.g. `{"plan:pro":2}`.
 
 ## DNS
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,7 +13,10 @@ auth-service JWT (verified via JWKS; `org`+`sub` = tenant+user,
 bare `sub` = M2M tenant), a long-lived `ik_…` API key (resolved via
 RFC 7662 introspection), or a static `BRAIN_API_KEYS` entry (dev
 fallback). Admin endpoints require `brain:admin` scope on top of base
-auth; PII surfaces require `brain:read_pii`. Unauthenticated requests
+auth; PII surfaces require `brain:read_pii`. Tokens may additionally
+carry RFC 9396 `inite_mcp_resource` grants (per-tool MCP permissions,
+enforced on tools/list) and a `policy` claim (ABAC set names — see
+operator-playbook, "Per-agent rights"). Unauthenticated requests
 get `WWW-Authenticate: Bearer resource_metadata=…` (RFC 9728) pointing
 at the discovery document below.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,10 +8,14 @@ response schemas — regenerate with `pnpm openapi:build`; this page
 stays an index, not a second spec.
 
 All v1 endpoints are live; MCP transport is mounted per tenant. Every
-v1 call requires `Authorization: Bearer <plaintext>` where the key's
-SHA-256 lives in `BRAIN_API_KEYS`. Admin endpoints require
-`brain:admin` scope on top of base auth; PII surfaces require
-`brain:read_pii`.
+v1 call requires `Authorization: Bearer <credential>` — an
+auth-service JWT (verified via JWKS; `org`+`sub` = tenant+user,
+bare `sub` = M2M tenant), a long-lived `ik_…` API key (resolved via
+RFC 7662 introspection), or a static `BRAIN_API_KEYS` entry (dev
+fallback). Admin endpoints require `brain:admin` scope on top of base
+auth; PII surfaces require `brain:read_pii`. Unauthenticated requests
+get `WWW-Authenticate: Bearer resource_metadata=…` (RFC 9728) pointing
+at the discovery document below.
 
 ## Health + observability
 
@@ -20,6 +24,7 @@ SHA-256 lives in `BRAIN_API_KEYS`. Admin endpoints require
 | `GET /health` | Container + SurrealDB readiness. No auth. |
 | `GET /ready` | Readiness probe (schema + connectivity). No auth. |
 | `GET /metrics` | Prometheus exposition (in-cluster scrape; keep off the public surface). |
+| `GET /.well-known/oauth-protected-resource` | RFC 9728 metadata: which authorization server protects this deployment + user-delegable scopes. No auth — MCP clients use it to self-onboard. |
 
 ## Ingest
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -38,6 +38,11 @@ the operator's reference for running Brain.
 | `CONFLICT_*` | per spec | Override the resolution weights at runtime; defaults match `core/capabilities/knowledge.yaml`. |
 | `MULTI_HOP_PLANNER_MODEL` | `OPENAI_CHAT_MODEL` | Override the chat model for the multi-hop planner LLM call. |
 | `MULTI_HOP_PLANNER_CONCURRENCY` | `4` | Max in-flight planner calls. |
+| `AUTH_SERVICE_INTROSPECTION_CLIENT_ID` / `_SECRET` | unset | Enables RFC 7662 resolution of auth-service `ik_…` API keys (brain-service M2M client credentials). |
+| `AUTH_SERVICE_INTROSPECTION_URL` | `AUTH_SERVICE_URL`+`/v1/oauth/introspect` | Endpoint override. |
+| `AUTH_SSF_POLL_URL` | unset | CAEP revocation stream poll endpoint (RFC 8936); enables the deny-list that rejects IdP-revoked tokens before `exp`. `AUTH_SSF_CLIENT_ID/SECRET` default to the introspection client; `AUTH_SSF_POLL_SCOPE` default `admin`; `AUTH_SSF_POLL_INTERVAL_MS` default `30000`. |
+| `THROTTLE_TIER_MULTIPLIERS` | unset | JSON map entitlement→rate-limit multiplier applied after credential verification, e.g. `{"plan:pro":2}`. |
+| `BRAIN_PUBLIC_URL` | derived from Host | Canonical resource URL advertised in RFC 9728 metadata + WWW-Authenticate challenges. |
 | `SYNTHESIZE_MODEL` | `OPENAI_CHAT_MODEL` | Override the chat model for `/v1/synthesize` generator + verifier calls. |
 | `SYNTHESIZE_DEFAULT_GUARDRAILS` | `strict` | `strict` / `lenient` / `off`. Caller can override per-request via `synthesisGuardrails`. |
 | `SYNTHESIZE_CONCURRENCY` | `4` | Max in-flight LLM calls across synthesize requests. Each request makes 2 calls (generator + verifier in strict/lenient). |

--- a/docs/operator-playbook.md
+++ b/docs/operator-playbook.md
@@ -47,6 +47,41 @@ In prod, the static map is disabled (NODE_ENV=production + any remote verifier c
 - **JWTs** (user or M2M tokens) — verified locally via JWKS.
 - **Long-lived `ik_…` API keys** — issued in the auth-service admin panel (API Keys tab, audience `brain`) and resolved by brain through RFC 7662 introspection (`AUTH_SERVICE_INTROSPECTION_CLIENT_ID/SECRET`). Revocation in the panel takes effect within the introspection cache TTL (≤60 s).
 
+## Per-agent rights and policies
+
+Three layers decide what an AI agent may do and see; they compose (most
+restrictive wins):
+
+1. **Scopes** — coarse (`brain:read` reads everything the tenant has).
+2. **RFC 9396 grants (consent-time)** — the token's
+   `authorization_details` entry of type `inite_mcp_resource` lists the
+   MCP actions the user approved for this agent, e.g.
+   `{"type":"inite_mcp_resource","locations":["https://brain.inite.ai"],"actions":["search_knowledge","record_fact"]}`.
+   Brain removes every tool outside the granted union (macro grants
+   `read`/`write` allow a whole kind). Fail-closed: a grant scoped to
+   another deployment yields an EMPTY tool surface. Requires
+   `RAR_ENABLED` in the auth-service; set `BRAIN_PUBLIC_URL` here when
+   grants carry `locations`.
+3. **ABAC policies (answer-time)** — row/action rules. Delivery
+   channels: `policy` claim (auth-service per-client customClaims or
+   ApiKey policyNames), `policy_binding` subjects `key:<hash>`,
+   `jwt:<sub>`, and `agent:<client_id>` — the last one pins sets to the
+   ACTING client regardless of credential.
+
+Every fact written through an agent carries the verified agent identity:
+`source.recorder = mcp_agent:<client_id>` (MCP write tools) and
+`source.meta.actor` (all ingest paths) — usable in ABAC `source.meta.*`
+rules, trust review, and audits.
+
+### Enable ABAC safely (report_only → enforce)
+
+1. Create a policy set in the admin UI (mode `report_only`).
+2. Attach it: auth-side (client customClaims / ApiKey policyNames) or
+   brain-side (`policy_binding`, incl. `agent:<client_id>`).
+3. Set `ABAC_ENABLED=1` and watch `v1/admin/policy/decisions` — report
+   rows show what WOULD be denied, nothing blocks yet.
+4. Flip the set to `enforce` once the decision stream looks right.
+
 ## Promote a tenant from dev to prod auth
 
 1. Make sure `AUTH_SERVICE_JWKS_URL` points to the prod auth-service (`https://auth.inite.ai/.well-known/jwks.json`).

--- a/docs/operator-playbook.md
+++ b/docs/operator-playbook.md
@@ -42,14 +42,17 @@ JSON
 
 Hand the **plaintext** to the vertical operator over a secure channel. Brain only stores the hash.
 
-In prod, the static map is disabled (NODE_ENV=production && AUTH_SERVICE_JWKS_URL set → JWT-only). Issue keys through `inite-auth-service` — the vertical receives a JWT signed by that service, and brain verifies it via JWKS.
+In prod, the static map is disabled (NODE_ENV=production + any remote verifier configured). Two auth-service credential kinds replace it:
+
+- **JWTs** (user or M2M tokens) — verified locally via JWKS.
+- **Long-lived `ik_…` API keys** — issued in the auth-service admin panel (API Keys tab, audience `brain`) and resolved by brain through RFC 7662 introspection (`AUTH_SERVICE_INTROSPECTION_CLIENT_ID/SECRET`). Revocation in the panel takes effect within the introspection cache TTL (≤60 s).
 
 ## Promote a tenant from dev to prod auth
 
 1. Make sure `AUTH_SERVICE_JWKS_URL` points to the prod auth-service (`https://auth.inite.ai/.well-known/jwks.json`).
 2. Set `AUTH_SERVICE_ISSUER` and `AUTH_SERVICE_AUDIENCE` to the values that auth-service signs with.
-3. Set `NODE_ENV=production`. The boot log should say `Static BRAIN_API_KEYS disabled in production with JWKS enabled — JWT only`.
-4. Have the vertical re-issue its credentials. The brain accepts JWTs whose `sub` is the company ID and whose `scopes` claim contains the brain scopes (`brain:read`, `brain:write`, optionally `brain:read_pii`, `brain:admin`).
+3. Set `NODE_ENV=production`. The boot log should say `Static BRAIN_API_KEYS disabled in production with a remote verifier enabled`.
+4. Have the vertical re-issue its credentials. Brain accepts JWTs whose `scopes` claim contains the brain scopes (`brain:read`, `brain:write`, optionally `brain:read_pii`, `brain:admin`). Tenant/user mapping: an `org` claim makes it a user-bound token (tenant = `org`, end-user = `sub`, per-user memory pinned to that user); without `org`, `sub` is the company ID (M2M).
 5. Verify with a single `curl` that uses the JWT — expect `200 OK` on `GET /v1/entities/<id>` for the company's data.
 
 ## Troubleshoot: ingest is failing

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -73,7 +73,13 @@ export class ApiKeyGuard implements CanActivate {
     // the pipeline (search fusion, graph_retrieve, competing facts,
     // entity reads) row-filter without signature threading. The
     // recorder closure gives the pure row-filter module a path to the
-    // decision sink + metrics without DI.
+    // decision sink + metrics without DI. authUserId rides the same
+    // store — per-user memory surfaces pin caller-asserted userId to
+    // the token's end-user via pinUserScope().
+    if (record.userId) {
+      const store = getRequestContext();
+      if (store) store.authUserId = record.userId;
+    }
     if (policy) {
       const store = getRequestContext();
       if (store) {
@@ -95,6 +101,7 @@ export class ApiKeyGuard implements CanActivate {
       companyId: record.companyId,
       scopes: record.scopes,
       keyHash: record.keyHash,
+      ...(record.userId ? { userId: record.userId } : {}),
       ...(record.packIds ? { packIds: record.packIds } : {}),
       ...(policy ? { policy } : {}),
     };

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -26,8 +26,10 @@ export const RequireScopes = (...scopes: BrainScope[]) =>
  * best-effort — unit fixtures without a response object just get the 401.
  */
 function unauthorized(context: ExecutionContext, message: string): UnauthorizedException {
-  const req = context.switchToHttp().getRequest();
-  const res = context.switchToHttp().getResponse();
+  const httpCtx = context.switchToHttp();
+  const req = httpCtx.getRequest();
+  // Unit fixtures mock only getRequest — degrade to a plain 401 there.
+  const res = typeof httpCtx.getResponse === 'function' ? httpCtx.getResponse() : undefined;
   const metadata = resourceMetadataUrl(req);
   if (metadata && typeof res?.setHeader === 'function') {
     res.setHeader('WWW-Authenticate', `Bearer resource_metadata="${metadata}"`);

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -12,11 +12,28 @@ import { CredentialResolverService } from './credential-resolver.service';
 import { PolicyGateService } from '../policy/policy-gate.service';
 import { POLICY_ACTION_KEY } from '../policy/action-registry';
 import { getRequestContext } from '../common/request-context';
+import { resourceMetadataUrl } from './resource-metadata';
 import { BrainScope, AuthenticatedRequest, ApiKeyRecord } from './api-key.types';
 
 const REQUIRED_SCOPES_KEY = 'requiredScopes';
 export const RequireScopes = (...scopes: BrainScope[]) =>
   SetMetadata(REQUIRED_SCOPES_KEY, scopes);
+
+/**
+ * 401 with RFC 9728 discovery: WWW-Authenticate names the protected-
+ * resource metadata document so an MCP client can find the authorization
+ * server and self-onboard instead of failing opaquely. Header is
+ * best-effort — unit fixtures without a response object just get the 401.
+ */
+function unauthorized(context: ExecutionContext, message: string): UnauthorizedException {
+  const req = context.switchToHttp().getRequest();
+  const res = context.switchToHttp().getResponse();
+  const metadata = resourceMetadataUrl(req);
+  if (metadata && typeof res?.setHeader === 'function') {
+    res.setHeader('WWW-Authenticate', `Bearer resource_metadata="${metadata}"`);
+  }
+  return new UnauthorizedException(message);
+}
 
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
@@ -33,13 +50,13 @@ export class ApiKeyGuard implements CanActivate {
     const header = request.headers['authorization'] as string | undefined;
 
     if (!header || !header.toLowerCase().startsWith('bearer ')) {
-      throw new UnauthorizedException('Missing or malformed Authorization header');
+      throw unauthorized(context, 'Missing or malformed Authorization header');
     }
 
     const token = header.slice(7).trim();
     const record: ApiKeyRecord | null = await this.credentials.resolve(token);
     if (!record) {
-      throw new UnauthorizedException('Invalid credentials');
+      throw unauthorized(context, 'Invalid credentials');
     }
 
     const required =

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -95,9 +95,12 @@ export class ApiKeyGuard implements CanActivate {
     // decision sink + metrics without DI. authUserId rides the same
     // store — per-user memory surfaces pin caller-asserted userId to
     // the token's end-user via pinUserScope().
-    if (record.userId) {
+    if (record.userId || record.actorId) {
       const store = getRequestContext();
-      if (store) store.authUserId = record.userId;
+      if (store) {
+        if (record.userId) store.authUserId = record.userId;
+        if (record.actorId) store.authActorId = record.actorId;
+      }
     }
     if (policy) {
       const store = getRequestContext();
@@ -121,6 +124,10 @@ export class ApiKeyGuard implements CanActivate {
       scopes: record.scopes,
       keyHash: record.keyHash,
       ...(record.userId ? { userId: record.userId } : {}),
+      ...(record.actorId ? { actorId: record.actorId } : {}),
+      ...(record.mcpGrantedActions !== undefined
+        ? { mcpGrantedActions: record.mcpGrantedActions }
+        : {}),
       ...(record.packIds ? { packIds: record.packIds } : {}),
       ...(policy ? { policy } : {}),
     };

--- a/src/auth/api-key.service.ts
+++ b/src/auth/api-key.service.ts
@@ -6,10 +6,11 @@ import { ApiKeyRecord } from './api-key.types';
 /**
  * In-memory ApiKey registry, sourced from BRAIN_API_KEYS env var (JSON).
  *
- * 0.1.0 walking-skeleton: keys are static, declared at boot.
- * 0.2.0+: replace with @inite/auth integration — verticals will issue
- * keys via inite.core.api-key, and this service will lookup via JWKS or
- * an auth-service introspection endpoint.
+ * Dev/bootstrap fallback only. Production credentials come from the
+ * auth-service: JWTs verified via JWKS (JwksService) and long-lived
+ * opaque ik_… keys resolved via RFC 7662 introspection
+ * (IntrospectionClient); CredentialResolverService disables this static
+ * table in production whenever a remote verifier is configured.
  */
 @Injectable()
 export class ApiKeyService implements OnModuleInit {

--- a/src/auth/api-key.types.ts
+++ b/src/auth/api-key.types.ts
@@ -24,6 +24,19 @@ export interface ApiKeyRecord {
   keyHash: string;
   companyId: string;
   scopes: BrainScope[];
+  /**
+   * End-user identity for user-bound tokens: the auth-service stamps
+   * `org` (tenant) + `sub` (user did) on user-flow and token-exchange
+   * tokens, and this field carries the sub. Absent for M2M credentials
+   * (client_credentials, static keys), where sub IS the tenant. Drives
+   * per-user memory scoping — see pinUserScope().
+   */
+  userId?: string;
+  /**
+   * Plan/tier entitlements from the token's `entitlements` claim —
+   * feeds tier-aware throttling. Absent = default tier.
+   */
+  entitlements?: string[];
   /** Optional human label. */
   name?: string;
   /**
@@ -48,6 +61,8 @@ export interface AuthenticatedRequest {
     companyId: string;
     scopes: BrainScope[];
     keyHash: string;
+    /** End-user of a user-bound token; absent for M2M credentials. */
+    userId?: string;
     /** Per-pack binding of an indexer key; absent = all external packs. */
     packIds?: string[];
     /**

--- a/src/auth/api-key.types.ts
+++ b/src/auth/api-key.types.ts
@@ -37,6 +37,20 @@ export interface ApiKeyRecord {
    * feeds tier-aware throttling. Absent = default tier.
    */
   entitlements?: string[];
+  /**
+   * Identity of the ACTING client (the agent): RFC 8693 `act`, falling
+   * back to the token's `client_id`. Drives provenance attribution
+   * (source.meta.actor / mcp_agent:<id> recorder) and `agent:<id>`
+   * policy bindings. Absent for static keys.
+   */
+  actorId?: string;
+  /**
+   * RFC 9396 inite_mcp_resource grant — the union of MCP actions the
+   * user consented to for this deployment. undefined = no grant claim,
+   * gate inactive (scopes/ABAC only); empty = granted nothing (every
+   * tool removed) — foreign-location grants fail closed this way.
+   */
+  mcpGrantedActions?: string[];
   /** Optional human label. */
   name?: string;
   /**
@@ -63,6 +77,10 @@ export interface AuthenticatedRequest {
     keyHash: string;
     /** End-user of a user-bound token; absent for M2M credentials. */
     userId?: string;
+    /** Acting client (agent) identity; see ApiKeyRecord.actorId. */
+    actorId?: string;
+    /** RFC 9396 MCP grant; see ApiKeyRecord.mcpGrantedActions. */
+    mcpGrantedActions?: string[];
     /** Per-pack binding of an indexer key; absent = all external packs. */
     packIds?: string[];
     /**

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -4,6 +4,8 @@ import { ApiKeyGuard } from './api-key.guard';
 import { CredentialResolverService } from './credential-resolver.service';
 import { JwksService } from './jwks.service';
 import { ProtectedResourceController } from './protected-resource.controller';
+import { RevocationCacheService } from './revocation-cache.service';
+import { SsfReceiverService } from './ssf-receiver.service';
 
 @Global()
 @Module({
@@ -13,12 +15,15 @@ import { ProtectedResourceController } from './protected-resource.controller';
     JwksService,
     CredentialResolverService,
     ApiKeyGuard,
+    RevocationCacheService,
+    SsfReceiverService,
   ],
   exports: [
     ApiKeyService,
     JwksService,
     CredentialResolverService,
     ApiKeyGuard,
+    RevocationCacheService,
   ],
 })
 export class AuthModule {}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,9 +3,11 @@ import { ApiKeyService } from './api-key.service';
 import { ApiKeyGuard } from './api-key.guard';
 import { CredentialResolverService } from './credential-resolver.service';
 import { JwksService } from './jwks.service';
+import { ProtectedResourceController } from './protected-resource.controller';
 
 @Global()
 @Module({
+  controllers: [ProtectedResourceController],
   providers: [
     ApiKeyService,
     JwksService,

--- a/src/auth/claim-parsers.ts
+++ b/src/auth/claim-parsers.ts
@@ -1,0 +1,175 @@
+/**
+ * Pure claim parsers shared by the JWKS verifier and the RFC 7662
+ * introspection client — one charset/cap policy per claim regardless of
+ * which remote verifier produced the payload. Every parser is
+ * drop-don't-throw: an out-of-charset entry is discarded rather than
+ * failing the whole credential on an encoding quirk.
+ */
+
+type Claims = Record<string, unknown>;
+
+// Tenant slug charset. The companyId becomes the `co_<id>` database name
+// and is interpolated into record ids, so it must stay within a safe
+// identifier charset (alnum / underscore / hyphen, bounded length).
+export const VALID_COMPANY_ID = /^[A-Za-z0-9_-]{1,64}$/;
+
+// Per-user memory rows store userId verbatim (option<string> column, always
+// a bound query param — never interpolated), so the charset can be wider
+// than companyId: did:key subjects contain ':'.
+const MAX_USER_ID_LENGTH = 200;
+
+// Defence-in-depth cap. A well-formed token carries a handful of scopes;
+// an absurdly long array is malformed/hostile and we refuse to parse it.
+const MAX_SCOPES = 64;
+
+/**
+ * Map token claims to the tenant (companyId) + optional end-user (userId).
+ *   `org` present → user-bound token: tenant = org, end-user = sub
+ *   `org` absent  → M2M token: tenant = sub, no end-user
+ * Returns null when no valid tenant identity can be derived.
+ */
+export function resolveTokenIdentity(
+  payload: Claims,
+): { companyId: string; userId?: string } | null {
+  const org = payload.org;
+  const sub = typeof payload.sub === 'string' ? payload.sub : null;
+  if (typeof org === 'string' && org.length > 0) {
+    if (!VALID_COMPANY_ID.test(org)) return null;
+    if (!sub || sub.length === 0 || sub.length > MAX_USER_ID_LENGTH) return null;
+    return { companyId: org, userId: sub };
+  }
+  if (!sub || !VALID_COMPANY_ID.test(sub)) return null;
+  return { companyId: sub };
+}
+
+export function extractScopes(payload: Claims): string[] {
+  if (Array.isArray(payload.scopes)) {
+    return payload.scopes
+      .filter((s): s is string => typeof s === 'string')
+      .slice(0, MAX_SCOPES);
+  }
+  if (typeof payload.scope === 'string') {
+    return payload.scope.split(/\s+/).filter(Boolean).slice(0, MAX_SCOPES);
+  }
+  return [];
+}
+
+/** Array-or-space-delimited string claim → string list (uncapped, unfiltered). */
+function stringList(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.filter((n): n is string => typeof n === 'string');
+  if (typeof raw === 'string') return raw.split(/\s+/).filter(Boolean);
+  return [];
+}
+
+// Policy set names live in the same identifier charset the CRUD layer
+// enforces (policy-store); cap mirrors the resolver's MAX_SETS_PER_KEY.
+const VALID_POLICY_NAME = /^[a-z][a-z0-9_-]{1,63}$/;
+const MAX_POLICY_NAMES = 8;
+
+/** `policy` claim → ABAC policy set names. */
+export function extractPolicyNames(payload: Claims): string[] {
+  return stringList(payload.policy)
+    .filter((n) => VALID_POLICY_NAME.test(n))
+    .slice(0, MAX_POLICY_NAMES);
+}
+
+// Pack ids share the manifest's snake_case charset (validate.ts).
+const VALID_PACK_ID = /^[a-z][a-z0-9_]{1,63}$/;
+const MAX_PACK_IDS = 16;
+
+/** `packs` claim → per-pack indexer binding (ApiKeyRecord.packIds). */
+export function extractPackIds(payload: Claims): string[] {
+  return stringList(payload.packs)
+    .filter((n) => VALID_PACK_ID.test(n))
+    .slice(0, MAX_PACK_IDS);
+}
+
+// Entitlement slugs are display/tier hints, not authority — still keep the
+// charset bounded so a hostile claim can't smuggle odd bytes into metrics.
+const VALID_ENTITLEMENT = /^[a-z][a-z0-9_:-]{1,63}$/;
+const MAX_ENTITLEMENTS = 16;
+
+/** `entitlements` claim → plan/tier hints (throttle tiers, feature gates). */
+export function extractEntitlements(payload: Claims): string[] {
+  if (!Array.isArray(payload.entitlements)) return [];
+  return payload.entitlements
+    .filter((e): e is string => typeof e === 'string')
+    .filter((e) => VALID_ENTITLEMENT.test(e))
+    .slice(0, MAX_ENTITLEMENTS);
+}
+
+// OAuth client ids (dcr_<hex>, brain-landing, …) — loose but bounded.
+const VALID_ACTOR_ID = /^[A-Za-z0-9:._-]{1,200}$/;
+
+/**
+ * Identity of the ACTING client (the agent), for provenance attribution
+ * and per-agent policy bindings. RFC 8693 `act` wins (the party acting
+ * on the subject's behalf), falling back to the RFC 9068 top-level
+ * `client_id` (the client the token was issued to).
+ */
+export function extractActorId(payload: Claims): string | undefined {
+  const act = payload.act;
+  if (typeof act === 'object' && act !== null) {
+    const a = act as Claims;
+    const fromAct =
+      (typeof a.client_id === 'string' && a.client_id) ||
+      (typeof a.sub === 'string' && a.sub) ||
+      undefined;
+    if (fromAct && VALID_ACTOR_ID.test(fromAct)) return fromAct;
+  }
+  if (typeof payload.client_id === 'string' && VALID_ACTOR_ID.test(payload.client_id)) {
+    return payload.client_id;
+  }
+  return undefined;
+}
+
+// MCP action names: brain action-registry style (snake_case, optional
+// namespace separators for pack tools / REST actions).
+const VALID_MCP_ACTION = /^[a-z][a-z0-9_:.-]{0,63}$/;
+const MAX_MCP_ACTIONS = 64;
+const MCP_DETAIL_TYPE = 'inite_mcp_resource';
+
+function normalizeUrl(value: string): string {
+  return value.replace(/\/$/, '');
+}
+
+/**
+ * RFC 9396 `authorization_details` → the union of granted MCP actions.
+ *
+ * Fail-closed by design: when the claim carries ANY inite_mcp_resource
+ * entries, the user consented to a restricted tool set — entries whose
+ * `locations` don't name this deployment contribute NOTHING, so a token
+ * granted for another brain yields an empty grant (all tools removed),
+ * never full access. No inite_mcp_resource entries at all → undefined
+ * (gate inactive, scopes/ABAC only).
+ */
+export function extractMcpGrantedActions(
+  payload: Claims,
+  deploymentUrl: string | undefined,
+): string[] | undefined {
+  const raw = payload.authorization_details;
+  if (!Array.isArray(raw)) return undefined;
+  const entries = raw.filter(
+    (d): d is Claims =>
+      typeof d === 'object' && d !== null && (d as Claims).type === MCP_DETAIL_TYPE,
+  );
+  if (entries.length === 0) return undefined;
+
+  const here = deploymentUrl ? normalizeUrl(deploymentUrl) : undefined;
+  const granted = new Set<string>();
+  for (const entry of entries) {
+    const locations = Array.isArray(entry.locations)
+      ? entry.locations.filter((l): l is string => typeof l === 'string')
+      : [];
+    const applies =
+      locations.length === 0 ||
+      (here !== undefined && locations.map(normalizeUrl).includes(here));
+    if (!applies) continue;
+    for (const action of stringList(entry.actions)) {
+      if (VALID_MCP_ACTION.test(action) && granted.size < MAX_MCP_ACTIONS) {
+        granted.add(action);
+      }
+    }
+  }
+  return [...granted];
+}

--- a/src/auth/credential-resolver.service.ts
+++ b/src/auth/credential-resolver.service.ts
@@ -2,50 +2,69 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ApiKeyService } from './api-key.service';
 import { JwksService } from './jwks.service';
+import { IntrospectionClient } from './introspection.client';
 import { ApiKeyRecord } from './api-key.types';
 
 const JWT_SHAPE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+/** Opaque auth-service API keys are ik_-prefixed — see auth admin panel. */
+const OPAQUE_KEY_PREFIX = 'ik_';
 
 /**
  * CredentialResolverService — turns a bearer token into an ApiKeyRecord.
  *
- * Owns the two-source credential policy (JWT via JWKS, falling back to
- * static BRAIN_API_KEYS) and the production hardening that disables the
- * static fallback when JWKS is configured. Extracted from ApiKeyGuard so
- * the guard is left with just HTTP plumbing (header parsing + scope
- * enforcement) and keeps its injected-dep list ≤3.
+ * Owns the three-source credential policy:
+ *   1. JWT-shaped tokens → JWKS verification (auth-service user/M2M tokens)
+ *   2. ik_-prefixed opaque keys → RFC 7662 introspection at the
+ *      auth-service (operator-issued long-lived API keys)
+ *   3. static BRAIN_API_KEYS — dev fallback only
+ * plus the production hardening that disables the static fallback when a
+ * remote verifier is configured. Extracted from ApiKeyGuard so the guard
+ * is left with just HTTP plumbing (header parsing + scope enforcement)
+ * and keeps its injected-dep list ≤3; the introspection client is a plain
+ * config-built helper, not a DI dependency, for the same reason.
  */
 @Injectable()
 export class CredentialResolverService {
   private readonly logger = new Logger(CredentialResolverService.name);
   private readonly staticAllowed: boolean;
+  private readonly introspection: IntrospectionClient | null;
 
   constructor(
     private readonly apiKeys: ApiKeyService,
     private readonly jwks: JwksService,
     config: ConfigService,
   ) {
+    this.introspection = IntrospectionClient.fromConfig(config);
     const env = config.get<string>('NODE_ENV', 'development');
-    // In production with JWKS configured, static keys are off — operators
-    // must issue tokens through the auth-service. Everywhere else (dev,
-    // test, JWKS not configured) static keys are accepted as a fallback.
-    this.staticAllowed = !(env === 'production' && this.jwks.enabled());
+    // In production with a remote verifier configured (JWKS and/or
+    // introspection), static keys are off — operators must issue
+    // credentials through the auth-service. Everywhere else (dev, test,
+    // nothing configured) static keys are accepted as a fallback.
+    const remoteConfigured = this.jwks.enabled() || this.introspection !== null;
+    this.staticAllowed = !(env === 'production' && remoteConfigured);
     if (!this.staticAllowed) {
       this.logger.log(
-        'Static BRAIN_API_KEYS disabled in production with JWKS enabled — JWT only',
+        'Static BRAIN_API_KEYS disabled in production with a remote verifier enabled',
       );
+    }
+    if (this.introspection) {
+      this.logger.log('Opaque API-key introspection enabled (RFC 7662)');
     }
   }
 
   /**
    * Resolve a bearer token to an authenticated record, or null when no
-   * source recognises it. Tries JWKS verification first (when the token
-   * has JWT shape), then the static-key table when still allowed.
+   * source recognises it. JWT-shaped tokens go to JWKS verification,
+   * ik_-prefixed keys to introspection, then the static-key table when
+   * still allowed.
    */
   async resolve(token: string): Promise<ApiKeyRecord | null> {
     let record: ApiKeyRecord | null = null;
     if (this.jwks.enabled() && JWT_SHAPE.test(token)) {
       record = await this.jwks.verify(token);
+    }
+    if (!record && this.introspection && token.startsWith(OPAQUE_KEY_PREFIX)) {
+      record = await this.introspection.resolve(token);
     }
     if (!record && this.staticAllowed) {
       record = this.apiKeys.resolve(token);

--- a/src/auth/credential-resolver.service.ts
+++ b/src/auth/credential-resolver.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { ApiKeyService } from './api-key.service';
 import { JwksService } from './jwks.service';
 import { IntrospectionClient } from './introspection.client';
+import { recordTier, tokenTrackerKey } from './tier-cache';
 import { ApiKeyRecord } from './api-key.types';
 
 const JWT_SHAPE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
@@ -69,6 +70,9 @@ export class CredentialResolverService {
     if (!record && this.staticAllowed) {
       record = this.apiKeys.resolve(token);
     }
+    // Feed the verified tier to the throttler (which runs before this
+    // guard and must not trust unverified claims).
+    if (record) recordTier(tokenTrackerKey(token), record.entitlements);
     return record;
   }
 }

--- a/src/auth/introspection.client.ts
+++ b/src/auth/introspection.client.ts
@@ -18,6 +18,7 @@ import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHash } from 'node:crypto';
 import { ApiKeyRecord, BrainScope } from './api-key.types';
+import { extractPolicyNames } from './claim-parsers';
 
 /**
  * Scopes an introspected (operator-issued) key may carry. Superset of the
@@ -159,10 +160,13 @@ export function mapIntrospectionRecord(
   if (scopes.length === 0) return null;
 
   const userId = sub && sub !== companyId ? sub : undefined;
+  // Same `policy` member the JWT path parses — auth ApiKey.policyNames.
+  const policyNames = extractPolicyNames(payload);
   return {
     keyHash: `introspect:${tokenHash}`,
     companyId,
     scopes,
     ...(userId ? { userId } : {}),
+    ...(policyNames.length > 0 ? { policyNames } : {}),
   };
 }

--- a/src/auth/introspection.client.ts
+++ b/src/auth/introspection.client.ts
@@ -1,0 +1,168 @@
+/**
+ * RFC 7662 introspection client — resolves opaque auth-service API keys
+ * ("ik_…", issued via the auth admin panel) into ApiKeyRecords.
+ *
+ * Fulfils the 0.2.0 plan from api-key.service.ts: verticals stop baking
+ * static key tables into env and look credentials up at the IdP instead.
+ * The introspection answer uses the same claim shape as JWTs
+ * (sub/org/org_id/scope/aud), so the tenant/user mapping matches the
+ * JWKS path: org → companyId, sub → userId (unless sub IS the org).
+ *
+ * Deliberately a plain class, not a Nest provider: CredentialResolver
+ * constructs it from config, keeping its DI constructor within the
+ * 3-param gate. Answers are cached briefly so an MCP burst doesn't turn
+ * into an introspection-endpoint burst (auth throttles at 60/min).
+ */
+
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'node:crypto';
+import { ApiKeyRecord, BrainScope } from './api-key.types';
+
+/**
+ * Scopes an introspected (operator-issued) key may carry. Superset of the
+ * JWT set: indexer:write / registry:publish are meaningful ONLY as
+ * long-lived integration keys — exactly what auth-service API keys are —
+ * while user JWTs must never smuggle them. registry:curate stays
+ * env-key-only (hosting-operator surface).
+ */
+const INTROSPECTED_SCOPES: ReadonlySet<BrainScope> = new Set([
+  'brain:read',
+  'brain:write',
+  'brain:admin',
+  'brain:read_pii',
+  'registry:publish',
+  'indexer:write',
+]);
+
+const VALID_COMPANY_ID = /^[A-Za-z0-9_-]{1,64}$/;
+const MAX_SCOPES = 64;
+/** Positive answers are safe to reuse briefly; revocation lag ≤ this. */
+const POSITIVE_TTL_MS = 60_000;
+/** Negative answers retry sooner — a just-issued key must not be bricked. */
+const NEGATIVE_TTL_MS = 15_000;
+const MAX_CACHE_ENTRIES = 1000;
+
+interface CacheEntry {
+  expiresAt: number;
+  record: ApiKeyRecord | null;
+}
+
+export class IntrospectionClient {
+  private readonly logger = new Logger(IntrospectionClient.name);
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(
+    private readonly opts: {
+      url: string;
+      clientId: string;
+      clientSecret: string;
+      audience: string;
+    },
+  ) {}
+
+  /**
+   * Build from env, or null when not configured (dev without auth-service).
+   * Requires AUTH_SERVICE_URL (or the explicit *_INTROSPECTION_URL
+   * override) plus the brain-service M2M client credentials.
+   */
+  static fromConfig(config: ConfigService): IntrospectionClient | null {
+    const base = config.get<string>('AUTH_SERVICE_URL');
+    const url =
+      config.get<string>('AUTH_SERVICE_INTROSPECTION_URL') ??
+      (base ? `${base.replace(/\/$/, '')}/v1/oauth/introspect` : undefined);
+    const clientId = config.get<string>('AUTH_SERVICE_INTROSPECTION_CLIENT_ID');
+    const clientSecret = config.get<string>(
+      'AUTH_SERVICE_INTROSPECTION_CLIENT_SECRET',
+    );
+    if (!url || !clientId || !clientSecret) return null;
+    const audience = config.get<string>('AUTH_SERVICE_AUDIENCE', 'brain') ?? 'brain';
+    return new IntrospectionClient({ url, clientId, clientSecret, audience });
+  }
+
+  /** Resolve an opaque key, or null when inactive/foreign/unreachable. */
+  async resolve(token: string): Promise<ApiKeyRecord | null> {
+    const cacheKey = createHash('sha256').update(token).digest('hex');
+    const hit = this.cache.get(cacheKey);
+    if (hit && hit.expiresAt > Date.now()) return hit.record;
+
+    const record = await this.introspect(token, cacheKey);
+    this.remember(cacheKey, record);
+    return record;
+  }
+
+  private async introspect(
+    token: string,
+    tokenHash: string,
+  ): Promise<ApiKeyRecord | null> {
+    let payload: Record<string, unknown>;
+    try {
+      const res = await fetch(this.opts.url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          token,
+          client_id: this.opts.clientId,
+          client_secret: this.opts.clientSecret,
+        }),
+      });
+      if (!res.ok) {
+        this.logger.warn(`Introspection endpoint answered ${res.status}`);
+        return null;
+      }
+      payload = (await res.json()) as Record<string, unknown>;
+    } catch (e) {
+      this.logger.warn(`Introspection request failed: ${(e as Error).message}`);
+      return null;
+    }
+    return mapIntrospectionRecord(payload, tokenHash, this.opts.audience);
+  }
+
+  private remember(cacheKey: string, record: ApiKeyRecord | null): void {
+    if (this.cache.size >= MAX_CACHE_ENTRIES) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) this.cache.delete(oldest);
+    }
+    this.cache.set(cacheKey, {
+      record,
+      expiresAt: Date.now() + (record ? POSITIVE_TTL_MS : NEGATIVE_TTL_MS),
+    });
+  }
+}
+
+/**
+ * Introspection payload → ApiKeyRecord. Enforces `active`, audience
+ * binding (a key minted for another vertical never passes), the tenant
+ * charset, and the introspected scope allow-list.
+ */
+export function mapIntrospectionRecord(
+  payload: Record<string, unknown>,
+  tokenHash: string,
+  audience: string,
+): ApiKeyRecord | null {
+  if (payload.active !== true) return null;
+  const aud = payload.aud;
+  const audOk = Array.isArray(aud) ? aud.includes(audience) : aud === audience;
+  if (!audOk) return null;
+
+  const org = typeof payload.org === 'string' ? payload.org : undefined;
+  const sub = typeof payload.sub === 'string' ? payload.sub : undefined;
+  const companyId = org ?? sub;
+  if (!companyId || !VALID_COMPANY_ID.test(companyId)) return null;
+
+  const scopeStr = typeof payload.scope === 'string' ? payload.scope : '';
+  const scopes = scopeStr
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, MAX_SCOPES)
+    .filter((s): s is BrainScope => INTROSPECTED_SCOPES.has(s as BrainScope));
+  if (scopes.length === 0) return null;
+
+  const userId = sub && sub !== companyId ? sub : undefined;
+  return {
+    keyHash: `introspect:${tokenHash}`,
+    companyId,
+    scopes,
+    ...(userId ? { userId } : {}),
+  };
+}

--- a/src/auth/jwks.service.ts
+++ b/src/auth/jwks.service.ts
@@ -3,6 +3,15 @@ import { ConfigService } from '@nestjs/config';
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
 import { ApiKeyRecord, BrainScope } from './api-key.types';
 import { RevocationCacheService } from './revocation-cache.service';
+import {
+  extractActorId,
+  extractEntitlements,
+  extractMcpGrantedActions,
+  extractPackIds,
+  extractPolicyNames,
+  extractScopes,
+  resolveTokenIdentity,
+} from './claim-parsers';
 
 const VALID_SCOPES: ReadonlySet<BrainScope> = new Set([
   'brain:read',
@@ -10,15 +19,6 @@ const VALID_SCOPES: ReadonlySet<BrainScope> = new Set([
   'brain:admin',
   'brain:read_pii',
 ]);
-
-// Tenant slug charset. The companyId becomes the `co_<id>` database name
-// and is interpolated into record ids, so it must stay within a safe
-// identifier charset (alnum / underscore / hyphen, bounded length).
-const VALID_COMPANY_ID = /^[A-Za-z0-9_-]{1,64}$/;
-
-// Defence-in-depth cap. A well-formed token carries a handful of scopes;
-// an absurdly long array is malformed/hostile and we refuse to parse it.
-const MAX_SCOPES = 64;
 
 /**
  * JWT verification against the @inite/auth-service JWKS endpoint.
@@ -38,6 +38,8 @@ export class JwksService implements OnModuleInit {
   private issuer?: string;
   private audience?: string;
   private algorithms: string[] = ['RS256'];
+  /** Canonical deployment URL — matches RFC 9396 grant `locations`. */
+  private publicUrl?: string;
 
   constructor(
     private readonly configService: ConfigService,
@@ -55,6 +57,7 @@ export class JwksService implements OnModuleInit {
     this.jwks = createRemoteJWKSet(new URL(url));
     this.issuer = this.configService.get<string>('AUTH_SERVICE_ISSUER');
     this.audience = this.configService.get<string>('AUTH_SERVICE_AUDIENCE', 'brain');
+    this.publicUrl = this.configService.get<string>('BRAIN_PUBLIC_URL');
     // Pin the accepted signature algorithms. Without this, jwtVerify accepts
     // ANY alg advertised in the JWKS, which is the classic algorithm-confusion
     // surface (e.g. a symmetric key smuggled into the key set). Configurable
@@ -133,112 +136,21 @@ export class JwksService implements OnModuleInit {
     const policyNames = extractPolicyNames(payload);
     const packIds = extractPackIds(payload);
     const entitlements = extractEntitlements(payload);
+    const actorId = extractActorId(payload);
+    // RFC 9396 per-tool grants; fail-closed for foreign-location entries
+    // (see claim-parsers.ts). undefined = gate inactive.
+    const mcpGrantedActions = extractMcpGrantedActions(payload, this.publicUrl);
 
     return {
       keyHash: `jwt:${payload.jti ?? payload.sub}`,
       companyId: identity.companyId,
       scopes,
       ...(identity.userId ? { userId: identity.userId } : {}),
+      ...(actorId ? { actorId } : {}),
+      ...(mcpGrantedActions !== undefined ? { mcpGrantedActions } : {}),
       ...(entitlements.length > 0 ? { entitlements } : {}),
       ...(policyNames.length > 0 ? { policyNames } : {}),
       ...(packIds.length > 0 ? { packIds } : {}),
     };
   }
-}
-
-// Per-user memory rows store userId verbatim (option<string> column, always
-// a bound query param — never interpolated), so the charset can be wider
-// than companyId: any printable token up to the column cap used across the
-// DTOs (200). did:key subjects contain ':' so VALID_COMPANY_ID can't apply.
-const MAX_USER_ID_LENGTH = 200;
-
-/**
- * Map token claims to the tenant (companyId) + optional end-user (userId).
- * companyId becomes the `co_<id>` database name and is interpolated into
- * record ids, so it must pass the strict tenant-slug charset — whether it
- * came from `org` (user token) or `sub` (M2M token). Returns null when no
- * valid tenant identity can be derived (guard then treats it as 401).
- */
-function resolveTokenIdentity(
-  payload: JWTPayload,
-): { companyId: string; userId?: string } | null {
-  const org = (payload as Record<string, unknown>).org;
-  const sub = typeof payload.sub === 'string' ? payload.sub : null;
-  if (typeof org === 'string' && org.length > 0) {
-    if (!VALID_COMPANY_ID.test(org)) return null;
-    if (!sub || sub.length === 0 || sub.length > MAX_USER_ID_LENGTH) return null;
-    return { companyId: org, userId: sub };
-  }
-  if (!sub || !VALID_COMPANY_ID.test(sub)) return null;
-  return { companyId: sub };
-}
-
-// Entitlement slugs are display/tier hints, not authority — still keep the
-// charset bounded so a hostile claim can't smuggle odd bytes into metrics.
-const VALID_ENTITLEMENT = /^[a-z][a-z0-9_:-]{1,63}$/;
-const MAX_ENTITLEMENTS = 16;
-
-/** `entitlements` claim → plan/tier hints (throttle tiers, feature gates). */
-function extractEntitlements(payload: JWTPayload): string[] {
-  const raw = (payload as Record<string, unknown>).entitlements;
-  if (!Array.isArray(raw)) return [];
-  return raw
-    .filter((e): e is string => typeof e === 'string')
-    .filter((e) => VALID_ENTITLEMENT.test(e))
-    .slice(0, MAX_ENTITLEMENTS);
-}
-
-// Policy set names live in the same identifier charset the CRUD layer
-// enforces; anything else in the claim is dropped here rather than
-// carried into resolution (where an out-of-charset name would fail
-// closed and brick the key on a claim-encoding quirk).
-const VALID_POLICY_NAME = /^[a-z][a-z0-9_-]{1,63}$/;
-const MAX_POLICY_NAMES = 8;
-
-/**
- * `policy` claim → ABAC policy set names. Array of strings or a single
- * space-delimited string, capped at MAX_POLICY_NAMES (mirrors the
- * resolver-side MAX_SETS_PER_KEY).
- */
-function extractPolicyNames(payload: JWTPayload): string[] {
-  const raw = (payload as Record<string, unknown>).policy;
-  let names: string[] = [];
-  if (Array.isArray(raw)) {
-    names = raw.filter((n): n is string => typeof n === 'string');
-  } else if (typeof raw === 'string') {
-    names = raw.split(' ').filter(Boolean);
-  }
-  return names.filter((n) => VALID_POLICY_NAME.test(n)).slice(0, MAX_POLICY_NAMES);
-}
-
-// Pack ids share the manifest's snake_case charset (validate.ts); an
-// out-of-charset claim entry is dropped, not carried into fencing.
-const VALID_PACK_ID = /^[a-z][a-z0-9_]{1,63}$/;
-const MAX_PACK_IDS = 16;
-
-/**
- * `packs` claim → per-pack indexer binding (ApiKeyRecord.packIds).
- * Array of strings or a single space-delimited string.
- */
-function extractPackIds(payload: JWTPayload): string[] {
-  const raw = (payload as Record<string, unknown>).packs;
-  let ids: string[] = [];
-  if (Array.isArray(raw)) {
-    ids = raw.filter((n): n is string => typeof n === 'string');
-  } else if (typeof raw === 'string') {
-    ids = raw.split(' ').filter(Boolean);
-  }
-  return ids.filter((n) => VALID_PACK_ID.test(n)).slice(0, MAX_PACK_IDS);
-}
-
-function extractScopes(payload: JWTPayload): string[] {
-  if (Array.isArray(payload.scopes)) {
-    return payload.scopes
-      .filter((s): s is string => typeof s === 'string')
-      .slice(0, MAX_SCOPES);
-  }
-  if (typeof payload.scope === 'string') {
-    return payload.scope.split(' ').filter(Boolean).slice(0, MAX_SCOPES);
-  }
-  return [];
 }

--- a/src/auth/jwks.service.ts
+++ b/src/auth/jwks.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
 import { ApiKeyRecord, BrainScope } from './api-key.types';
+import { RevocationCacheService } from './revocation-cache.service';
 
 const VALID_SCOPES: ReadonlySet<BrainScope> = new Set([
   'brain:read',
@@ -38,7 +39,10 @@ export class JwksService implements OnModuleInit {
   private audience?: string;
   private algorithms: string[] = ['RS256'];
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly revocations: RevocationCacheService,
+  ) {}
 
   onModuleInit() {
     const url = this.configService.get<string>('AUTH_SERVICE_JWKS_URL');
@@ -101,6 +105,14 @@ export class JwksService implements OnModuleInit {
     } catch (e) {
       // Don't log token contents — only the error class/message
       this.logger.debug(`JWT verification failed: ${(e as Error).message}`);
+      return null;
+    }
+
+    // CAEP deny-list (fed by the SSF receiver): a session/account the
+    // auth-service revoked is rejected here even though the signature
+    // is still cryptographically valid until exp.
+    if (typeof payload.sub === 'string' && this.revocations.isDenied(payload.sub)) {
+      this.logger.debug('JWT rejected: subject is deny-listed (CAEP revocation)');
       return null;
     }
 

--- a/src/auth/jwks.service.ts
+++ b/src/auth/jwks.service.ts
@@ -104,14 +104,12 @@ export class JwksService implements OnModuleInit {
       return null;
     }
 
-    const companyId = typeof payload.sub === 'string' ? payload.sub : null;
-    if (!companyId) return null;
-    // The sub becomes the tenant database name (`co_<companyId>`) and is
-    // interpolated into SurrealDB record ids. An out-of-charset value would
-    // surface as a DB-layer 500 deep in a query; reject it here so a malformed
-    // token is a clean 401 instead. Tenant slugs are alnum/underscore/hyphen.
-    if (!VALID_COMPANY_ID.test(companyId)) {
-      this.logger.debug('JWT rejected: sub is not a valid companyId');
+    // Tenant/user split (auth-service claim model):
+    //   `org` present → user-bound token: tenant = org, end-user = sub
+    //   `org` absent  → M2M token: tenant = sub, no end-user
+    const identity = resolveTokenIdentity(payload);
+    if (!identity) {
+      this.logger.debug('JWT rejected: no valid tenant identity in org/sub');
       return null;
     }
 
@@ -122,15 +120,60 @@ export class JwksService implements OnModuleInit {
 
     const policyNames = extractPolicyNames(payload);
     const packIds = extractPackIds(payload);
+    const entitlements = extractEntitlements(payload);
 
     return {
       keyHash: `jwt:${payload.jti ?? payload.sub}`,
-      companyId,
+      companyId: identity.companyId,
       scopes,
+      ...(identity.userId ? { userId: identity.userId } : {}),
+      ...(entitlements.length > 0 ? { entitlements } : {}),
       ...(policyNames.length > 0 ? { policyNames } : {}),
       ...(packIds.length > 0 ? { packIds } : {}),
     };
   }
+}
+
+// Per-user memory rows store userId verbatim (option<string> column, always
+// a bound query param — never interpolated), so the charset can be wider
+// than companyId: any printable token up to the column cap used across the
+// DTOs (200). did:key subjects contain ':' so VALID_COMPANY_ID can't apply.
+const MAX_USER_ID_LENGTH = 200;
+
+/**
+ * Map token claims to the tenant (companyId) + optional end-user (userId).
+ * companyId becomes the `co_<id>` database name and is interpolated into
+ * record ids, so it must pass the strict tenant-slug charset — whether it
+ * came from `org` (user token) or `sub` (M2M token). Returns null when no
+ * valid tenant identity can be derived (guard then treats it as 401).
+ */
+function resolveTokenIdentity(
+  payload: JWTPayload,
+): { companyId: string; userId?: string } | null {
+  const org = (payload as Record<string, unknown>).org;
+  const sub = typeof payload.sub === 'string' ? payload.sub : null;
+  if (typeof org === 'string' && org.length > 0) {
+    if (!VALID_COMPANY_ID.test(org)) return null;
+    if (!sub || sub.length === 0 || sub.length > MAX_USER_ID_LENGTH) return null;
+    return { companyId: org, userId: sub };
+  }
+  if (!sub || !VALID_COMPANY_ID.test(sub)) return null;
+  return { companyId: sub };
+}
+
+// Entitlement slugs are display/tier hints, not authority — still keep the
+// charset bounded so a hostile claim can't smuggle odd bytes into metrics.
+const VALID_ENTITLEMENT = /^[a-z][a-z0-9_:-]{1,63}$/;
+const MAX_ENTITLEMENTS = 16;
+
+/** `entitlements` claim → plan/tier hints (throttle tiers, feature gates). */
+function extractEntitlements(payload: JWTPayload): string[] {
+  const raw = (payload as Record<string, unknown>).entitlements;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((e): e is string => typeof e === 'string')
+    .filter((e) => VALID_ENTITLEMENT.test(e))
+    .slice(0, MAX_ENTITLEMENTS);
 }
 
 // Policy set names live in the same identifier charset the CRUD layer

--- a/src/auth/protected-resource.controller.ts
+++ b/src/auth/protected-resource.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Header, Req } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { Request } from 'express';
+import { requestBaseUrl } from './resource-metadata';
+
+/**
+ * RFC 9728 — OAuth 2.0 Protected Resource Metadata.
+ *
+ * Advertises which authorization server protects this brain deployment
+ * and which scopes it understands, so MCP clients auto-onboard: 401 →
+ * WWW-Authenticate resource_metadata → this document → auth.inite.ai
+ * (dynamic client registration + device/PKCE flow). Public by design,
+ * like the MCP health probe.
+ */
+@Controller('.well-known')
+export class ProtectedResourceController {
+  constructor(private readonly config: ConfigService) {}
+
+  @Get('oauth-protected-resource')
+  @Header('Content-Type', 'application/json')
+  metadata(@Req() req: Request) {
+    const issuer =
+      this.config.get<string>('AUTH_SERVICE_ISSUER') ??
+      this.config.get<string>('AUTH_SERVICE_URL', 'https://auth.inite.ai');
+    const resource = requestBaseUrl(req) ?? 'https://brain.inite.ai';
+    return {
+      resource,
+      authorization_servers: [issuer],
+      // The user-delegable surface. Integration scopes (indexer:write,
+      // registry:publish) are operator-provisioned keys, not something
+      // an MCP client should request on a user's behalf.
+      scopes_supported: ['brain:read', 'brain:write', 'brain:admin', 'brain:read_pii'],
+      bearer_methods_supported: ['header'],
+      resource_documentation: `${resource}/docs`,
+    };
+  }
+}

--- a/src/auth/resource-metadata.ts
+++ b/src/auth/resource-metadata.ts
@@ -1,0 +1,51 @@
+/**
+ * RFC 9728 (OAuth 2.0 Protected Resource Metadata) URL helpers.
+ *
+ * Brain advertises itself as an OAuth protected resource so MCP clients
+ * can discover the authorization server without out-of-band setup: a 401
+ * carries `WWW-Authenticate: Bearer resource_metadata="…"`, the client
+ * fetches that document, finds auth.inite.ai, self-registers (RFC 7591)
+ * and runs the device/PKCE flow. Pure module — used by the guard and the
+ * well-known controller alike.
+ */
+
+export const PROTECTED_RESOURCE_PATH = '/.well-known/oauth-protected-resource';
+
+interface RequestLike {
+  headers?: Record<string, string | string[] | undefined>;
+  protocol?: string;
+}
+
+function headerValue(
+  headers: Record<string, string | string[] | undefined> | undefined,
+  name: string,
+): string | undefined {
+  const raw = headers?.[name];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  // Proxies may fold multiple hops into a comma-separated list — the
+  // first entry is the client-facing edge.
+  return value?.split(',')[0]?.trim() || undefined;
+}
+
+/**
+ * Public base URL of this deployment as seen by the caller, honouring
+ * reverse-proxy forwarding headers. BRAIN_PUBLIC_URL (when set) wins so
+ * a multi-hostname deploy advertises one canonical resource identifier.
+ * Returns null when the host cannot be determined (bare socket probes).
+ */
+export function requestBaseUrl(req: RequestLike): string | null {
+  const configured = process.env.BRAIN_PUBLIC_URL;
+  if (configured) return configured.replace(/\/$/, '');
+  const host =
+    headerValue(req.headers, 'x-forwarded-host') ?? headerValue(req.headers, 'host');
+  if (!host) return null;
+  const proto =
+    headerValue(req.headers, 'x-forwarded-proto') ?? req.protocol ?? 'https';
+  return `${proto}://${host}`;
+}
+
+/** Absolute URL of the RFC 9728 metadata document, or null without a host. */
+export function resourceMetadataUrl(req: RequestLike): string | null {
+  const base = requestBaseUrl(req);
+  return base ? `${base}${PROTECTED_RESOURCE_PATH}` : null;
+}

--- a/src/auth/revocation-cache.service.ts
+++ b/src/auth/revocation-cache.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * In-memory deny-list of revoked subjects, fed by the SSF receiver
+ * (CAEP session-revoked / account-disabled / token-claims-change events
+ * from the auth-service).
+ *
+ * Why it exists: brain verifies JWTs locally against the JWKS, so a
+ * revoked-at-the-IdP token stays valid here until `exp`. The deny-list
+ * closes that window to the SSF poll interval. Entries expire after the
+ * max access-token lifetime — past that the token itself is dead and
+ * the entry is dead weight.
+ *
+ * Single-process cache by design (matches the tenant throttler): each
+ * replica polls the stream independently.
+ */
+@Injectable()
+export class RevocationCacheService {
+  private readonly logger = new Logger(RevocationCacheService.name);
+  private readonly denied = new Map<string, number>();
+
+  /** Covers the auth-service user access-token TTL (10m) with margin. */
+  static readonly DEFAULT_TTL_MS = 15 * 60_000;
+  private static readonly MAX_ENTRIES = 10_000;
+
+  deny(subject: string, ttlMs: number = RevocationCacheService.DEFAULT_TTL_MS): void {
+    if (!subject) return;
+    this.prune();
+    if (this.denied.size >= RevocationCacheService.MAX_ENTRIES) {
+      const oldest = this.denied.keys().next().value;
+      if (oldest !== undefined) this.denied.delete(oldest);
+    }
+    this.denied.set(subject, Date.now() + ttlMs);
+    this.logger.log(`Subject deny-listed for ${Math.round(ttlMs / 1000)}s`);
+  }
+
+  isDenied(subject: string): boolean {
+    const until = this.denied.get(subject);
+    if (until === undefined) return false;
+    if (until <= Date.now()) {
+      this.denied.delete(subject);
+      return false;
+    }
+    return true;
+  }
+
+  private prune(): void {
+    if (this.denied.size < RevocationCacheService.MAX_ENTRIES) return;
+    const now = Date.now();
+    for (const [sub, until] of this.denied) {
+      if (until <= now) this.denied.delete(sub);
+    }
+  }
+}

--- a/src/auth/ssf-receiver.service.ts
+++ b/src/auth/ssf-receiver.service.ts
@@ -1,0 +1,158 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { RevocationCacheService } from './revocation-cache.service';
+
+/**
+ * OpenID Shared Signals Framework receiver — poll delivery (RFC 8936).
+ *
+ * Polls the auth-service transmitter for CAEP security events and feeds
+ * the revocation deny-list, closing the "revoked token stays valid until
+ * exp" window inherent to local JWKS verification. Events acted on:
+ * session-revoked, account-disabled, token-claims-change (the
+ * auth-service emits the latter on refresh-token-family revocation).
+ *
+ * Enabled when AUTH_SSF_POLL_URL + the poll client credentials are set;
+ * silent no-op otherwise (dev). Each SET is itself a signed JWT and is
+ * verified against the same JWKS as access tokens before being trusted.
+ */
+
+/** CAEP/RISC event URIs that translate to "deny this subject now". */
+const REVOKING_EVENTS = [
+  'https://schemas.openid.net/secevent/caep/event-type/session-revoked',
+  'https://schemas.openid.net/secevent/risc/event-type/account-disabled',
+  'https://schemas.openid.net/secevent/caep/event-type/token-claims-change',
+];
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const MAX_EVENTS_PER_POLL = 50;
+
+interface SetClaims {
+  events?: Record<string, unknown>;
+  sub_id?: { sub?: string };
+}
+
+@Injectable()
+export class SsfReceiverService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(SsfReceiverService.name);
+  private timer: NodeJS.Timeout | null = null;
+  private pendingAcks: string[] = [];
+  private accessToken: { value: string; expiresAtMs: number } | null = null;
+  private jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+  private polling = false;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly revocations: RevocationCacheService,
+  ) {}
+
+  onModuleInit(): void {
+    const pollUrl = this.config.get<string>('AUTH_SSF_POLL_URL');
+    const jwksUrl = this.config.get<string>('AUTH_SERVICE_JWKS_URL');
+    if (!pollUrl || !jwksUrl || !this.pollCredentials()) {
+      this.logger.log('SSF receiver disabled (AUTH_SSF_POLL_URL / credentials unset)');
+      return;
+    }
+    this.jwks = createRemoteJWKSet(new URL(jwksUrl));
+    const interval = Number(
+      this.config.get<string>('AUTH_SSF_POLL_INTERVAL_MS') ?? DEFAULT_POLL_INTERVAL_MS,
+    );
+    this.timer = setInterval(() => void this.pollOnce(pollUrl), interval);
+    this.timer.unref();
+    this.logger.log(`SSF receiver polling ${pollUrl} every ${interval}ms`);
+  }
+
+  onModuleDestroy(): void {
+    if (this.timer) clearInterval(this.timer);
+  }
+
+  /** One poll turn: deliver acks, verify + apply new SETs, queue acks. */
+  async pollOnce(pollUrl: string): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      const token = await this.pollToken();
+      const res = await fetch(pollUrl, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ acks: this.pendingAcks, maxEvents: MAX_EVENTS_PER_POLL }),
+      });
+      if (!res.ok) {
+        this.logger.warn(`SSF poll answered ${res.status}`);
+        return;
+      }
+      this.pendingAcks = [];
+      const body = (await res.json()) as { sets?: Record<string, string> };
+      for (const [jti, setJwt] of Object.entries(body.sets ?? {})) {
+        await this.applySet(jti, setJwt);
+      }
+    } catch (e) {
+      this.logger.warn(`SSF poll failed: ${(e as Error).message}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  /** Verify one SET and deny-list its subject for revoking event types. */
+  async applySet(jti: string, setJwt: string): Promise<void> {
+    if (!this.jwks) return;
+    try {
+      const { payload } = await jwtVerify(setJwt, this.jwks, {
+        issuer: this.config.get<string>('AUTH_SERVICE_ISSUER'),
+      });
+      const claims = payload as SetClaims;
+      const subject = claims.sub_id?.sub;
+      const revokes = Object.keys(claims.events ?? {}).some((e) =>
+        REVOKING_EVENTS.includes(e),
+      );
+      if (subject && revokes) this.revocations.deny(subject);
+      this.pendingAcks.push(jti);
+    } catch (e) {
+      // A SET we can't verify is acked anyway — redelivering it forever
+      // would wedge the stream; the failure is logged for the operator.
+      this.logger.warn(`SET ${jti} rejected: ${(e as Error).message}`);
+      this.pendingAcks.push(jti);
+    }
+  }
+
+  private pollCredentials(): { clientId: string; clientSecret: string } | null {
+    const clientId =
+      this.config.get<string>('AUTH_SSF_CLIENT_ID') ??
+      this.config.get<string>('AUTH_SERVICE_INTROSPECTION_CLIENT_ID');
+    const clientSecret =
+      this.config.get<string>('AUTH_SSF_CLIENT_SECRET') ??
+      this.config.get<string>('AUTH_SERVICE_INTROSPECTION_CLIENT_SECRET');
+    return clientId && clientSecret ? { clientId, clientSecret } : null;
+  }
+
+  /** Mint (and cache) the M2M token the poll endpoint requires. */
+  private async pollToken(): Promise<string> {
+    if (this.accessToken && this.accessToken.expiresAtMs > Date.now()) {
+      return this.accessToken.value;
+    }
+    const creds = this.pollCredentials();
+    if (!creds) throw new Error('SSF poll credentials unset');
+    const base = (this.config.get<string>('AUTH_SERVICE_URL') ?? '').replace(/\/$/, '');
+    const scope = this.config.get<string>('AUTH_SSF_POLL_SCOPE', 'admin');
+    const res = await fetch(`${base}/v1/oauth/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: creds.clientId,
+        client_secret: creds.clientSecret,
+        scope,
+      }),
+    });
+    if (!res.ok) throw new Error(`poll token mint failed (${res.status})`);
+    const body = (await res.json()) as { access_token: string; expires_in?: number };
+    this.accessToken = {
+      value: body.access_token,
+      expiresAtMs: Date.now() + ((body.expires_in ?? 300) - 30) * 1000,
+    };
+    return this.accessToken.value;
+  }
+}

--- a/src/auth/tier-cache.ts
+++ b/src/auth/tier-cache.ts
@@ -1,0 +1,77 @@
+/**
+ * Verified-tier cache for tier-aware throttling.
+ *
+ * The throttler guard runs BEFORE the auth guard (global vs controller
+ * guard order), so it cannot trust claims off the raw token — a forged
+ * "enterprise" entitlement would widen the rate window for a credential
+ * that never authenticates. Instead, CredentialResolverService records
+ * the entitlement-derived multiplier here AFTER verification, keyed by
+ * the same token hash the throttler tracks by. The first request of a
+ * session runs at the default limit; every subsequent one gets the
+ * verified tier. Pure module (no DI) — mirrors request-context.
+ *
+ * Multipliers come from THROTTLE_TIER_MULTIPLIERS, a JSON object mapping
+ * entitlement slug → limit multiplier, e.g. {"plan:pro":2,"plan:team":5}.
+ * A credential with several matching entitlements gets the largest one.
+ */
+
+import { createHash } from 'node:crypto';
+
+const MAX_ENTRIES = 10_000;
+
+const tiers = new Map<string, number>();
+
+let parsedMultipliers: { src: string | undefined; map: Record<string, number> } | null =
+  null;
+
+function multiplierMap(): Record<string, number> {
+  const src = process.env.THROTTLE_TIER_MULTIPLIERS;
+  if (parsedMultipliers && parsedMultipliers.src === src) return parsedMultipliers.map;
+  let map: Record<string, number> = {};
+  if (src) {
+    try {
+      const raw = JSON.parse(src) as Record<string, unknown>;
+      for (const [k, v] of Object.entries(raw)) {
+        const n = Number(v);
+        if (Number.isFinite(n) && n >= 1 && n <= 100) map[k] = n;
+      }
+    } catch {
+      map = {};
+    }
+  }
+  parsedMultipliers = { src, map };
+  return map;
+}
+
+/**
+ * The throttle tracker key for a bearer token — single source of truth
+ * shared by TenantThrottlerGuard.getTracker and this cache, so the tier
+ * lookup can never drift from the bucket key.
+ */
+export function tokenTrackerKey(token: string): string {
+  const digest = createHash('sha256').update(token).digest('hex').slice(0, 32);
+  return `k:${digest}`;
+}
+
+/** Record the verified tier for a credential (post-authentication). */
+export function recordTier(trackerKey: string, entitlements?: string[]): void {
+  const map = multiplierMap();
+  const multiplier = Math.max(
+    1,
+    ...(entitlements ?? []).map((e) => map[e] ?? 1),
+  );
+  if (multiplier <= 1) {
+    tiers.delete(trackerKey);
+    return;
+  }
+  if (tiers.size >= MAX_ENTRIES) {
+    const oldest = tiers.keys().next().value;
+    if (oldest !== undefined) tiers.delete(oldest);
+  }
+  tiers.set(trackerKey, multiplier);
+}
+
+/** Verified limit multiplier for a tracker key; 1 = default tier. */
+export function tierMultiplier(trackerKey: string): number {
+  return tiers.get(trackerKey) ?? 1;
+}

--- a/src/auth/user-scope.ts
+++ b/src/auth/user-scope.ts
@@ -1,0 +1,38 @@
+/**
+ * Per-user memory scope pinning.
+ *
+ * userId on read/write DTOs is caller-asserted: an M2M credential holds
+ * tenant-wide authority and may scope requests to any end-user. A
+ * user-bound access token (auth-service token with `org` + `sub`) must
+ * NOT — its authority is one user's slice of the tenant. The guard stamps
+ * the token's end-user into the ALS request context (authUserId); this
+ * helper pins every caller-asserted userId to it at the service entry
+ * points, so the enforcement needs no signature threading (same pattern
+ * as ABAC row filtering).
+ *
+ * Pure module — importable from services and pure internals alike.
+ */
+
+import { ForbiddenException } from '@nestjs/common';
+import { getRequestContext } from '../common/request-context';
+
+/**
+ * Resolve the effective per-user scope for a request.
+ *
+ *  - M2M credential (no authUserId): the caller-asserted value passes
+ *    through unchanged — tenant-wide authority, pre-existing behavior.
+ *  - User-bound token: the token's user wins. An explicit mismatching
+ *    assertion is a 403 (attempt to read/write another user's scope);
+ *    an omitted one defaults to the token's user, so a user session
+ *    always operates on global + own memory, never global-only writes.
+ */
+export function pinUserScope(requested: string | undefined): string | undefined {
+  const authUserId = getRequestContext()?.authUserId;
+  if (!authUserId) return requested;
+  if (requested !== undefined && requested !== authUserId) {
+    throw new ForbiddenException(
+      'userId does not match the authenticated user scope of this token',
+    );
+  }
+  return authUserId;
+}

--- a/src/common/request-context.ts
+++ b/src/common/request-context.ts
@@ -56,6 +56,12 @@ export interface RequestContext {
    * credentials (tenant-wide authority, caller may assert any userId).
    */
   authUserId?: string;
+  /**
+   * Acting client (agent) identity from the token (`act`/`client_id`),
+   * stamped by ApiKeyGuard. Fact ingest attributes writes to it via
+   * source.meta.actor — provenance without signature threading.
+   */
+  authActorId?: string;
 }
 
 const storage = new AsyncLocalStorage<RequestContext>();

--- a/src/common/request-context.ts
+++ b/src/common/request-context.ts
@@ -48,6 +48,14 @@ export interface RequestContext {
   recordPolicyRows?: (
     summary: import('../policy/row-filter').RowDecisionSummary,
   ) => void;
+  /**
+   * End-user identity of a user-bound access token (auth-service `sub`
+   * when the token carries an `org` claim), stamped by ApiKeyGuard.
+   * Per-user memory surfaces pin caller-asserted userId to this value
+   * via pinUserScope() — no signature threading. Undefined for M2M
+   * credentials (tenant-wide authority, caller may assert any userId).
+   */
+  authUserId?: string;
 }
 
 const storage = new AsyncLocalStorage<RequestContext>();

--- a/src/common/tenant-throttler.guard.ts
+++ b/src/common/tenant-throttler.guard.ts
@@ -1,7 +1,7 @@
 import { ExecutionContext, Injectable } from '@nestjs/common';
-import { ThrottlerGuard } from '@nestjs/throttler';
-import { createHash } from 'node:crypto';
+import { ThrottlerGuard, ThrottlerRequest } from '@nestjs/throttler';
 import { envFlagEnabled } from '../common/env-validation';
+import { tierMultiplier, tokenTrackerKey } from '../auth/tier-cache';
 
 /**
  * Per-credential rate limiter.
@@ -16,10 +16,13 @@ import { envFlagEnabled } from '../common/env-validation';
  * the ApiKeyGuard anyway, but bucketing them by IP prevents an unauth
  * flood from spending one tenant's quota.
  *
- * Per-tier overrides: today every credential gets the same default
- * limit. When @inite/auth surfaces tier in the JWT (scopes or claim), the
- * matching path is `req.brainAuth.tier` → distinct ThrottlerOptions array
- * + per-tier @Throttle() decorators on the routes that need it.
+ * Per-tier limits: the auth-service stamps plan entitlements on issued
+ * tokens; after verification the resolver records the entitlement-derived
+ * multiplier in the tier cache (keyed by the same tracker key), and
+ * handleRequest scales the bucket limit by it. Claims are never read off
+ * the raw token here — this guard runs before authentication, and an
+ * unverified "enterprise" claim must not widen anyone's window.
+ * Configure via THROTTLE_TIER_MULTIPLIERS (see tier-cache.ts).
  */
 @Injectable()
 export class TenantThrottlerGuard extends ThrottlerGuard {
@@ -44,13 +47,24 @@ export class TenantThrottlerGuard extends ThrottlerGuard {
     return super.shouldSkip(context);
   }
 
+  protected async handleRequest(requestProps: ThrottlerRequest): Promise<boolean> {
+    const req = requestProps.context.switchToHttp().getRequest();
+    const tracker = await this.getTracker(req);
+    const multiplier = tierMultiplier(tracker);
+    if (multiplier > 1) {
+      return super.handleRequest({
+        ...requestProps,
+        limit: Math.ceil(requestProps.limit * multiplier),
+      });
+    }
+    return super.handleRequest(requestProps);
+  }
+
   protected async getTracker(req: Record<string, unknown>): Promise<string> {
     const headers = (req.headers as Record<string, string> | undefined) ?? {};
     const auth = headers.authorization;
     if (auth && auth.toLowerCase().startsWith('bearer ')) {
-      const token = auth.slice(7).trim();
-      const digest = createHash('sha256').update(token).digest('hex').slice(0, 32);
-      return `k:${digest}`;
+      return tokenTrackerKey(auth.slice(7).trim());
     }
     const ip = (req.ip as string | undefined) ?? 'unknown';
     return `ip:${ip}`;

--- a/src/entities/user-forget.controller.ts
+++ b/src/entities/user-forget.controller.ts
@@ -3,6 +3,7 @@ import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import { PolicyAction } from '../policy/action-registry';
 import { UserForgetService, UserForgetResult } from './user-forget.service';
 import { AuthenticatedRequest } from '../auth/api-key.types';
+import { pinUserScope } from '../auth/user-scope';
 import { Req } from '@nestjs/common';
 
 @Controller('v1/users')
@@ -21,6 +22,11 @@ export class UserForgetController {
     @Req() req: AuthenticatedRequest,
     @Param('userId') userId: string,
   ): Promise<UserForgetResult> {
-    return this.userForget.forgetUser(req.brainAuth.companyId, userId);
+    // A user-bound token may erase only its own scope; the pin throws
+    // 403 when the path names another user. M2M admin keys erase any.
+    return this.userForget.forgetUser(
+      req.brainAuth.companyId,
+      pinUserScope(userId) ?? userId,
+    );
   }
 }

--- a/src/ingest/fact-ingest.service.ts
+++ b/src/ingest/fact-ingest.service.ts
@@ -11,6 +11,7 @@ import {
 import { EntityUpsertService } from './entity-upsert.service';
 import { FactResolverService } from './fact-resolver.service';
 import { evidenceValidationError } from './ingest-utils';
+import { pinUserScope } from '../auth/user-scope';
 
 /**
  * The typed direct-ingest path (`ingestFact`): a single fully-specified fact
@@ -30,6 +31,10 @@ export class FactIngestService {
   ) {}
 
   async ingestFact(companyId: string, dto: IngestFactDto): Promise<IngestResult> {
+    // A user-bound token writes into its own user scope only — the
+    // caller-asserted userId is pinned to the token's end-user (403 on
+    // mismatch, default when omitted). M2M credentials pass through.
+    dto = { ...dto, userId: pinUserScope(dto.userId) };
     // Reject an inverted or zero-width validity interval up front. Both are
     // nonsensical bitemporally — a fact valid until before (or exactly at)
     // it became valid covers no instant — and would otherwise corrupt

--- a/src/ingest/fact-ingest.service.ts
+++ b/src/ingest/fact-ingest.service.ts
@@ -12,6 +12,7 @@ import { EntityUpsertService } from './entity-upsert.service';
 import { FactResolverService } from './fact-resolver.service';
 import { evidenceValidationError } from './ingest-utils';
 import { pinUserScope } from '../auth/user-scope';
+import { getRequestContext } from '../common/request-context';
 
 /**
  * The typed direct-ingest path (`ingestFact`): a single fully-specified fact
@@ -92,6 +93,14 @@ export class FactIngestService {
         );
       }
       if (meta) source.meta = meta;
+    }
+    // Agent attribution: the verified acting-client identity (token act/
+    // client_id, stamped into ALS by the guard) lands on source.meta.actor
+    // — auth-derived, so it OVERRIDES any caller-asserted `actor` meta.
+    // Gives ABAC source rules and audits a per-agent handle on every fact.
+    const actorId = getRequestContext()?.authActorId;
+    if (actorId) {
+      source.meta = { ...((source.meta as Record<string, unknown>) ?? {}), actor: actorId };
     }
     return this.surreal.withCompany(companyId, async (db) => {
       // 1. Resolve entity (own atomic step — own tx with unique-retry).

--- a/src/ingest/ingest-predictor.service.ts
+++ b/src/ingest/ingest-predictor.service.ts
@@ -14,6 +14,7 @@ import {
   rowToOpposingFact,
 } from './predictor-internals';
 import { makeRowPolicyFilter } from '../policy/row-filter';
+import { pinUserScope } from '../auth/user-scope';
 
 export type {
   IngestOutcome,
@@ -73,6 +74,10 @@ export class IngestPredictionService {
     args: PredictResolveArgs,
     callerScopes: readonly string[],
   ): Promise<PredictResolveResult> {
+    // Preflight sees the same per-user slice the eventual record_fact
+    // would touch — pin the asserted userId to a user-bound token's
+    // end-user (403 on mismatch). M2M credentials pass through.
+    args = { ...args, userId: pinUserScope(args.userId) };
     // opposingFacts carry raw `object` values, so the preflight must run
     // the same app-layer gate as every read surface. The DB-level PII
     // fence (migration 0005) is inert for the system-user pool (verified

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -88,6 +88,8 @@ export class McpController {
       actorKeyHash: auth.keyHash,
       policy: auth.policy,
       packIds: auth.packIds,
+      actorId: auth.actorId,
+      mcpGrantedActions: auth.mcpGrantedActions,
     });
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined, // stateless

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -29,6 +29,7 @@ import { DocumentIngestService } from '../documents/document-ingest.service';
 import { FeedbackService } from '../feedback/feedback.service';
 import { PolicyGateService } from '../policy/policy-gate.service';
 import { evaluateAction } from '../policy/policy-engine';
+import { ACTIONS } from '../policy/action-registry';
 import { ActionKind, PolicyContext } from '../policy/policy.types';
 import { envFlagEnabled } from '../common/env-validation';
 import { PACK_NAMESPACE_SEP } from '../ai/domain-packs';
@@ -191,6 +192,38 @@ export class McpService {
   }
 
   /**
+   * RFC 9396 grant gate — the consent-time counterpart of the ABAC gate
+   * above. Active only when the token carried inite_mcp_resource
+   * entries: a tool stays registered iff its name is in the granted
+   * union, or its kind is covered by a 'read'/'write' macro grant.
+   * Applied AFTER the policy gate, and removals are independent, so
+   * deny-overrides holds: a policy deny removes a tool the grant
+   * allows, and a grant omission removes a tool the policy allows.
+   */
+  private applyGrantToolGate(
+    server: McpServer,
+    granted: readonly string[],
+    kinds?: ReadonlyMap<string, ActionKind>,
+  ): void {
+    const grantSet = new Set(granted);
+    const allows = (name: string): boolean => {
+      if (grantSet.has(name)) return true;
+      const kind = kinds?.get(name) ?? ACTIONS[name]?.kind;
+      return kind !== undefined && grantSet.has(kind);
+    };
+    const raw = server.registerTool.bind(server);
+    (server as McpServer & { registerTool: unknown }).registerTool = (
+      name: string,
+      config: unknown,
+      handler: (...args: unknown[]) => unknown,
+    ) => {
+      const tool = raw(name as never, config as never, handler as never);
+      if (!allows(name)) tool.remove();
+      return tool;
+    };
+  }
+
+  /**
    * Unauthenticated health probe payload — surfaces version + the
    * read-baseline tool list so setup scripts can confirm the MCP
    * endpoint is reachable BEFORE the operator pastes the API key.
@@ -241,6 +274,13 @@ export class McpService {
        * only its packs' declared tools; absent = every consented pack.
        */
       packIds?: string[];
+      /** Acting client (agent) identity — provenance attribution. */
+      actorId?: string;
+      /**
+       * RFC 9396 inite_mcp_resource grant (ApiKeyRecord.mcpGrantedActions):
+       * undefined = gate inactive; [] = granted nothing (all tools removed).
+       */
+      mcpGrantedActions?: string[];
     },
   ): Promise<McpServer> {
     const actorKeyHash = caller?.actorKeyHash;
@@ -263,6 +303,9 @@ export class McpService {
     });
     this.wrapToolErrors(server);
     if (policy) this.applyPolicyToolGate(server, policy, packToolKinds);
+    if (caller?.mcpGrantedActions !== undefined) {
+      this.applyGrantToolGate(server, caller.mcpGrantedActions, packToolKinds);
+    }
     registerReadTools({
       server,
       companyId,
@@ -304,6 +347,7 @@ export class McpService {
         companyId,
         scopes,
         actorKeyHash: actorKeyHash ?? `mcp:${companyId}`,
+        actorId: caller?.actorId,
         deps: {
           ingest: this.ingest,
           facts: this.facts,

--- a/src/mcp/write-tools.ts
+++ b/src/mcp/write-tools.ts
@@ -42,6 +42,7 @@ export function registerWriteTools({
   deps,
   scopes,
   actorKeyHash,
+  actorId,
 }: {
   server: McpServer;
   companyId: string;
@@ -49,7 +50,12 @@ export function registerWriteTools({
   scopes: BrainScope[];
   /** Caller key hash — actor identity for record_feedback's one-vote fence. */
   actorKeyHash?: string;
+  /** Acting client (agent) identity — stamped into fact provenance. */
+  actorId?: string;
 }): void {
+  // The recorder names WHICH agent wrote the fact (token act/client_id),
+  // not just that "an MCP agent" did — feeds per-agent trust and audits.
+  const recorder = actorId ? `mcp_agent:${actorId}` : 'mcp_agent';
   // ── record_fact ────────────────────────────────────────────────
   server.registerTool(
     'record_fact',
@@ -86,7 +92,7 @@ export function registerWriteTools({
         validUntil: args.validUntil,
         confidence: args.confidence,
         userId: args.userId,
-        source: { vertical: args.sourceVertical, recorder: 'mcp_agent' },
+        source: { vertical: args.sourceVertical, recorder },
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
@@ -99,7 +105,7 @@ export function registerWriteTools({
   // Registered only when the documents pipeline is wired AND enabled —
   // agents shouldn't see a tool that answers 503.
   if (deps.documents && envFlagEnabled(process.env.DOCUMENT_INGEST_ENABLED)) {
-    registerIngestDocumentTool({ server, companyId, documents: deps.documents });
+    registerIngestDocumentTool({ server, companyId, documents: deps.documents, recorder });
   }
 
   // ── link_entities ──────────────────────────────────────────────
@@ -346,10 +352,13 @@ function registerIngestDocumentTool({
   server,
   companyId,
   documents,
+  recorder,
 }: {
   server: McpServer;
   companyId: string;
   documents: DocumentIngestService;
+  /** Agent-attributed recorder identity (mcp_agent[:<client_id>]). */
+  recorder: string;
 }): void {
   server.registerTool(
     'ingest_document',
@@ -407,7 +416,7 @@ function registerIngestDocumentTool({
         title: args.title,
         originUri: args.originUri,
         occurredAt: args.occurredAt,
-        contextRef: { vertical: args.vertical, recorder: 'mcp_agent' },
+        contextRef: { vertical: args.vertical, recorder },
         storeContent: args.storeContent,
         indexers: args.indexers ?? 'general',
         mode: 'sync',

--- a/src/policy/policy-gate.service.ts
+++ b/src/policy/policy-gate.service.ts
@@ -48,11 +48,11 @@ export class PolicyGateService {
     action: string,
     requestId?: string,
   ): Promise<PolicyContext | undefined> {
-    const ctx = await this.resolver.contextFor(
-      record.companyId,
-      record.keyHash,
-      record.policyNames,
-    );
+    const ctx = await this.resolver.contextFor(record.companyId, {
+      keyHash: record.keyHash,
+      claimNames: record.policyNames,
+      actorId: record.actorId,
+    });
     if (!ctx) return undefined;
     if (action !== POLICY_ACTION_EXEMPT) {
       this.enforceAction(ctx, action, requestId);

--- a/src/policy/policy-resolver.service.ts
+++ b/src/policy/policy-resolver.service.ts
@@ -12,6 +12,13 @@ import {
   PolicyDocument,
 } from './policy.types';
 
+/** Who is asking: credential hash + claim-carried set names + acting client. */
+export interface PolicySubject {
+  keyHash: string;
+  claimNames?: readonly string[];
+  actorId?: string;
+}
+
 interface TenantPolicySnapshot {
   /** Compiled sets by name — disabled/inactive sets are absent here… */
   sets: Map<string, CompiledPolicySet>;
@@ -78,10 +85,10 @@ export class PolicyResolverService {
    */
   async contextFor(
     companyId: string,
-    keyHash: string,
-    claimNames?: readonly string[],
+    subject: PolicySubject,
   ): Promise<PolicyContext | null> {
     if (!this.enabled) return null;
+    const { keyHash, claimNames, actorId } = subject;
     const snap = await this.snapshot(companyId);
 
     const names: string[] = [];
@@ -104,6 +111,11 @@ export class PolicyResolverService {
     // written against that stable subject too.
     if (keyHash.startsWith('jwt:')) {
       for (const n of snap.bindings.get(keyHash) ?? []) push(n);
+    }
+    // Per-agent bindings: a tenant can attach sets to the ACTING client
+    // (`agent:<client_id>`) regardless of which credential it presents.
+    if (actorId) {
+      for (const n of snap.bindings.get(`agent:${actorId}`) ?? []) push(n);
     }
     for (const n of claimNames ?? []) push(n);
     if (truncated) {

--- a/src/policy/policy-store.service.ts
+++ b/src/policy/policy-store.service.ts
@@ -46,7 +46,7 @@ export interface FactPolicyView {
   userId?: string | null;
 }
 
-const SUBJECT_SHAPE = /^(key|jwt):[A-Za-z0-9:_-]{1,128}$/;
+const SUBJECT_SHAPE = /^(key|jwt|agent):[A-Za-z0-9:._-]{1,200}$/;
 
 /**
  * CRUD over the per-tenant ABAC tables (migration 0056). Writes are

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -23,6 +23,7 @@ import {
 } from '../policy/row-filter';
 import { applyMetaUnion } from '../policy/meta-union';
 import { getPolicyContext } from '../common/request-context';
+import { pinUserScope } from '../auth/user-scope';
 import { expandEntityIdsViaEdges as expandEntityIdsViaEdgesDb } from './internals/neighbours';
 import { expandViaEdges } from './internals/edge-expansion';
 import { applyPprPrior } from './internals/ppr';
@@ -261,7 +262,10 @@ export class SearchService {
         `search: query truncated to ${clamped.value.length} chars (companyId=${companyId})`,
       );
     }
-    dto = { ...dto, query: clamped.value };
+    // A user-bound token operates on global + own memory only — the
+    // caller-asserted userId is pinned to the token's end-user (403 on
+    // mismatch). M2M credentials pass through unchanged.
+    dto = { ...dto, query: clamped.value, userId: pinUserScope(dto.userId) };
     // Empty/whitespace query → empty result, before any DB or embedding
     // work. Without this the full pipeline ran on '' — a zero-vector
     // cosine scan plus BM25 over an empty string, all guaranteed noise.

--- a/test/auth-guard.unit-spec.ts
+++ b/test/auth-guard.unit-spec.ts
@@ -26,6 +26,7 @@ import { ApiKeyGuard } from '../src/auth/api-key.guard';
 import { ApiKeyService } from '../src/auth/api-key.service';
 import { CredentialResolverService } from '../src/auth/credential-resolver.service';
 import { JwksService } from '../src/auth/jwks.service';
+import { RevocationCacheService } from '../src/auth/revocation-cache.service';
 
 const ISSUER = 'https://auth.test';
 const AUDIENCE = 'brain';
@@ -68,6 +69,7 @@ describe('ApiKeyGuard — JWKS verification', () => {
   let guard: ApiKeyGuard;
   let jwks: JwksService;
   let apiKeys: ApiKeyService;
+  let revocations: RevocationCacheService;
 
   function mintJwt(opts: {
     sub: string;
@@ -132,7 +134,8 @@ describe('ApiKeyGuard — JWKS verification', () => {
       NODE_ENV: 'test',
     });
 
-    jwks = new JwksService(config as unknown as ConfigService);
+    revocations = new RevocationCacheService();
+    jwks = new JwksService(config as unknown as ConfigService, revocations);
     jwks.onModuleInit();
 
     apiKeys = new ApiKeyService(config as unknown as ConfigService);
@@ -177,6 +180,13 @@ describe('ApiKeyGuard — JWKS verification', () => {
       sub: 'did:key:z6MkUser',
       extraClaims: { org: 'co:bad:chars' },
     });
+    const { ctx } = makeMockContext({ authorization: `Bearer ${token}` });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('rejects a valid JWT whose subject is CAEP deny-listed (401)', async () => {
+    const token = await mintJwt({ sub: 'jwt_co_revoked' });
+    revocations.deny('jwt_co_revoked', 60_000);
     const { ctx } = makeMockContext({ authorization: `Bearer ${token}` });
     await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
   });
@@ -294,7 +304,7 @@ describe('ApiKeyGuard — production with JWKS rejects static keys', () => {
       NODE_ENV: 'production',
     });
 
-    jwks = new JwksService(config as unknown as ConfigService);
+    jwks = new JwksService(config as unknown as ConfigService, new RevocationCacheService());
     jwks.onModuleInit();
     apiKeys = new ApiKeyService(config as unknown as ConfigService);
     apiKeys.onModuleInit();

--- a/test/auth-guard.unit-spec.ts
+++ b/test/auth-guard.unit-spec.ts
@@ -77,10 +77,12 @@ describe('ApiKeyGuard — JWKS verification', () => {
     audience?: string;
     expiresIn?: string | number;
     signWith?: KeyLike;
+    extraClaims?: Record<string, unknown>;
   }): Promise<string> {
     return new SignJWT({
       scopes: opts.scopes ?? ['brain:read', 'brain:write'],
       ...(opts.policy !== undefined ? { policy: opts.policy } : {}),
+      ...(opts.extraClaims ?? {}),
     })
       .setProtectedHeader({ alg: 'RS256', kid: 'test-key-1' })
       .setSubject(opts.sub)
@@ -156,6 +158,36 @@ describe('ApiKeyGuard — JWKS verification', () => {
     expect(await guard.canActivate(ctx)).toBe(true);
     expect((req.brainAuth as { companyId: string }).companyId).toBe('jwt_co_alpha');
     expect((req.brainAuth as { keyHash: string }).keyHash).toMatch(/^jwt:/);
+  });
+
+  it('user-bound token (org claim): tenant = org, end-user = sub', async () => {
+    const token = await mintJwt({
+      sub: 'did:key:z6MkUser',
+      extraClaims: { org: 'co_acme', org_id: 'org-uuid-1' },
+    });
+    const { ctx, req } = makeMockContext({ authorization: `Bearer ${token}` });
+    expect(await guard.canActivate(ctx)).toBe(true);
+    const auth = req.brainAuth as { companyId: string; userId?: string };
+    expect(auth.companyId).toBe('co_acme');
+    expect(auth.userId).toBe('did:key:z6MkUser');
+  });
+
+  it('rejects a user-bound token whose org fails the tenant charset (401)', async () => {
+    const token = await mintJwt({
+      sub: 'did:key:z6MkUser',
+      extraClaims: { org: 'co:bad:chars' },
+    });
+    const { ctx } = makeMockContext({ authorization: `Bearer ${token}` });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('extracts entitlements (charset-filtered, capped)', async () => {
+    const token = await mintJwt({
+      sub: 'jwt_co_e',
+      extraClaims: { entitlements: ['plan:pro', 'BAD ENTRY!', 'app:read'] },
+    });
+    const rec = await jwks.verify(token);
+    expect(rec?.entitlements).toEqual(['plan:pro', 'app:read']);
   });
 
   it('extracts ABAC policy names from the policy claim (array + string forms, charset filter, cap 8)', async () => {

--- a/test/auth-guard.unit-spec.ts
+++ b/test/auth-guard.unit-spec.ts
@@ -184,6 +184,55 @@ describe('ApiKeyGuard — JWKS verification', () => {
     await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
+  it('extracts the acting client: act wins over client_id, charset-bounded', async () => {
+    const viaAct = await mintJwt({
+      sub: 'did:key:z6MkUser',
+      extraClaims: { org: 'co_acme', act: { sub: 'brain-landing' }, client_id: 'other' },
+    });
+    expect((await jwks.verify(viaAct))?.actorId).toBe('brain-landing');
+
+    const viaClientId = await mintJwt({
+      sub: 'jwt_co_m2m',
+      extraClaims: { client_id: 'dcr_abc123' },
+    });
+    expect((await jwks.verify(viaClientId))?.actorId).toBe('dcr_abc123');
+
+    const none = await mintJwt({ sub: 'jwt_co_m2m' });
+    expect((await jwks.verify(none))?.actorId).toBeUndefined();
+  });
+
+  it('maps inite_mcp_resource grants to mcpGrantedActions (fail-closed on foreign location)', async () => {
+    const granted = await mintJwt({
+      sub: 'jwt_co_g',
+      extraClaims: {
+        authorization_details: [
+          { type: 'inite_mcp_resource', actions: ['search_knowledge', 'BAD ACTION!'] },
+          { type: 'payment_initiation', actions: ['initiate'] },
+        ],
+      },
+    });
+    expect((await jwks.verify(granted))?.mcpGrantedActions).toEqual(['search_knowledge']);
+
+    // Foreign-location grant → empty grant (all tools removed), never full access.
+    const foreign = await mintJwt({
+      sub: 'jwt_co_g',
+      extraClaims: {
+        authorization_details: [
+          {
+            type: 'inite_mcp_resource',
+            locations: ['https://other-brain.example'],
+            actions: ['search_knowledge'],
+          },
+        ],
+      },
+    });
+    expect((await jwks.verify(foreign))?.mcpGrantedActions).toEqual([]);
+
+    // No MCP entries at all → gate inactive.
+    const noGrant = await mintJwt({ sub: 'jwt_co_g' });
+    expect((await jwks.verify(noGrant))?.mcpGrantedActions).toBeUndefined();
+  });
+
   it('rejects a valid JWT whose subject is CAEP deny-listed (401)', async () => {
     const token = await mintJwt({ sub: 'jwt_co_revoked' });
     revocations.deny('jwt_co_revoked', 60_000);

--- a/test/introspection-client.unit-spec.ts
+++ b/test/introspection-client.unit-spec.ts
@@ -35,6 +35,22 @@ describe('mapIntrospectionRecord', () => {
     expect(rec?.userId).toBeUndefined();
   });
 
+  it('carries policy set names from the introspection answer', () => {
+    const rec = mapIntrospectionRecord(
+      {
+        active: true,
+        sub: 'co_acme',
+        org: 'co_acme',
+        aud: 'brain',
+        scope: 'brain:read',
+        policy: ['support-reader', 'BAD NAME!'],
+      },
+      hash,
+      'brain',
+    );
+    expect(rec?.policyNames).toEqual(['support-reader']);
+  });
+
   it('maps a user-bound key: tenant = org, userId = sub', () => {
     const rec = mapIntrospectionRecord(
       { active: true, sub: 'did:key:z6MkUser', org: 'co_acme', aud: 'brain', scope: 'brain:read' },

--- a/test/introspection-client.unit-spec.ts
+++ b/test/introspection-client.unit-spec.ts
@@ -1,0 +1,141 @@
+/**
+ * IntrospectionClient — opaque ik_… key resolution via a locally-served
+ * RFC 7662 endpoint. Covers the claim mapping (org/sub → tenant/user),
+ * audience binding, the introspected scope allow-list, and the answer
+ * cache. No real auth-service, no SurrealDB.
+ */
+import * as http from 'node:http';
+import { ConfigService } from '@nestjs/config';
+import {
+  IntrospectionClient,
+  mapIntrospectionRecord,
+} from '../src/auth/introspection.client';
+
+class StubConfig {
+  constructor(private readonly map: Record<string, string>) {}
+  get<T = string>(key: string, fallback?: T): T {
+    return (this.map[key] as unknown as T) ?? (fallback as T);
+  }
+}
+
+describe('mapIntrospectionRecord', () => {
+  const hash = 'deadbeef';
+
+  it('maps an org-bound key: tenant = org, no userId', () => {
+    const rec = mapIntrospectionRecord(
+      { active: true, sub: 'co_acme', org: 'co_acme', aud: 'brain', scope: 'brain:read brain:write' },
+      hash,
+      'brain',
+    );
+    expect(rec).toMatchObject({
+      companyId: 'co_acme',
+      scopes: ['brain:read', 'brain:write'],
+      keyHash: 'introspect:deadbeef',
+    });
+    expect(rec?.userId).toBeUndefined();
+  });
+
+  it('maps a user-bound key: tenant = org, userId = sub', () => {
+    const rec = mapIntrospectionRecord(
+      { active: true, sub: 'did:key:z6MkUser', org: 'co_acme', aud: 'brain', scope: 'brain:read' },
+      hash,
+      'brain',
+    );
+    expect(rec?.companyId).toBe('co_acme');
+    expect(rec?.userId).toBe('did:key:z6MkUser');
+  });
+
+  it('rejects inactive, foreign-audience, and scope-less answers', () => {
+    expect(
+      mapIntrospectionRecord({ active: false }, hash, 'brain'),
+    ).toBeNull();
+    expect(
+      mapIntrospectionRecord(
+        { active: true, sub: 'co_a', org: 'co_a', aud: 'inbox', scope: 'brain:read' },
+        hash,
+        'brain',
+      ),
+    ).toBeNull();
+    expect(
+      mapIntrospectionRecord(
+        { active: true, sub: 'co_a', org: 'co_a', aud: 'brain', scope: '' },
+        hash,
+        'brain',
+      ),
+    ).toBeNull();
+  });
+
+  it('allows integration scopes (indexer:write, registry:publish) but drops registry:curate', () => {
+    const rec = mapIntrospectionRecord(
+      {
+        active: true,
+        sub: 'co_a',
+        org: 'co_a',
+        aud: 'brain',
+        scope: 'indexer:write registry:publish registry:curate',
+      },
+      hash,
+      'brain',
+    );
+    expect(rec?.scopes).toEqual(['registry:publish', 'indexer:write'].sort());
+  });
+});
+
+describe('IntrospectionClient (HTTP + cache)', () => {
+  let server: http.Server;
+  let url: string;
+  let hits = 0;
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      hits += 1;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          active: true,
+          sub: 'co_acme',
+          org: 'co_acme',
+          aud: 'brain',
+          scope: 'brain:read',
+        }),
+      );
+    });
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()));
+    const port = (server.address() as { port: number }).port;
+    url = `http://127.0.0.1:${port}/introspect`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it('resolves via HTTP once and serves the repeat from cache', async () => {
+    const client = new IntrospectionClient({
+      url,
+      clientId: 'brain-service',
+      clientSecret: 's3cret',
+      audience: 'brain',
+    });
+    const first = await client.resolve('ik_test_key');
+    const second = await client.resolve('ik_test_key');
+    expect(first?.companyId).toBe('co_acme');
+    expect(second?.companyId).toBe('co_acme');
+    expect(hits).toBe(1);
+  });
+
+  it('fromConfig returns null when credentials are missing', () => {
+    const none = IntrospectionClient.fromConfig(
+      new StubConfig({}) as unknown as ConfigService,
+    );
+    expect(none).toBeNull();
+
+    const configured = IntrospectionClient.fromConfig(
+      new StubConfig({
+        AUTH_SERVICE_URL: 'https://auth.test',
+        AUTH_SERVICE_INTROSPECTION_CLIENT_ID: 'brain-service',
+        AUTH_SERVICE_INTROSPECTION_CLIENT_SECRET: 's3cret',
+      }) as unknown as ConfigService,
+    );
+    expect(configured).not.toBeNull();
+  });
+});

--- a/test/mcp-grant-gate.unit-spec.ts
+++ b/test/mcp-grant-gate.unit-spec.ts
@@ -1,0 +1,160 @@
+/**
+ * RFC 9396 grant gating on the MCP surface: with inite_mcp_resource
+ * grants present, only granted actions (or 'read'/'write' kind macros)
+ * stay registered; an empty grant strips everything; policy deny beats
+ * grant allow. Also covers agent-attributed provenance: record_fact's
+ * recorder carries the acting client id. Mirrors mcp-policy-gate spec.
+ */
+import { McpService } from '../src/mcp/mcp.service';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerWriteTools } from '../src/mcp/write-tools';
+import { compilePolicySet } from '../src/policy/policy-compile';
+import {
+  PolicyContext,
+  PolicyDocument,
+  PolicyDocumentSchema,
+} from '../src/policy/policy.types';
+
+const stubEmbedder = {
+  cacheStats: () => ({ provider: 'openai:text-embedding-3-small' }),
+  getDimensions: () => 1536,
+};
+const stubPolicyGate = {
+  enforceAction: () => undefined,
+  enforceToolAction: () => undefined,
+};
+const stubPackToolsReader = { installedPackTools: async () => [] };
+
+function service(): McpService {
+  return new McpService(
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    stubEmbedder as never,
+    {} as never,
+    {} as never,
+    stubPolicyGate as never,
+    stubPackToolsReader as never,
+    {} as never,
+  );
+}
+
+function build(opts: {
+  mcpGrantedActions?: string[];
+  policy?: PolicyContext;
+}): Promise<McpServer> {
+  return service().buildServer(
+    'co_test',
+    ['brain:read', 'brain:write', 'brain:admin'],
+    { actorKeyHash: 'sha256:test', ...opts },
+  );
+}
+
+function toolNames(server: McpServer): string[] {
+  const internals = server as unknown as {
+    _registeredTools: Record<string, unknown>;
+  };
+  return Object.keys(internals._registeredTools);
+}
+
+function ctxFromDoc(doc: Record<string, unknown>): PolicyContext {
+  const parsed: PolicyDocument = PolicyDocumentSchema.parse(doc);
+  const compiled = compilePolicySet(parsed);
+  if (!compiled) throw new Error('disabled set in test');
+  return {
+    companyId: 'co_test',
+    keyHash: 'sha256:test',
+    sets: [compiled],
+    forceReportOnly: false,
+    resolutionError: false,
+  };
+}
+
+describe('MCP RFC 9396 grant gate', () => {
+  it('a named-action grant keeps exactly those tools', async () => {
+    const names = toolNames(await build({ mcpGrantedActions: ['search_knowledge'] }));
+    expect(names).toEqual(['search_knowledge']);
+  });
+
+  it("the 'read' macro grants every read tool and no write tool", async () => {
+    const names = toolNames(await build({ mcpGrantedActions: ['read'] }));
+    expect(names).toContain('search_knowledge');
+    expect(names).toContain('graph_retrieve');
+    expect(names).not.toContain('record_fact');
+    expect(names).not.toContain('forget_entity');
+  });
+
+  it('an empty grant (foreign-location consent) strips every tool', async () => {
+    expect(toolNames(await build({ mcpGrantedActions: [] }))).toEqual([]);
+  });
+
+  it('no grant claim = full surface (gate inactive)', async () => {
+    const names = toolNames(await build({}));
+    expect(names).toContain('record_fact');
+    expect(names).toContain('search_knowledge');
+  });
+
+  it('policy deny overrides a grant allow', async () => {
+    const policy = ctxFromDoc({
+      name: 'no-forget',
+      posture: { actions: 'allow', reads: 'allow' },
+      mode: 'enforce',
+      rules: [
+        { id: 'nf', effect: 'deny', kind: 'action', actions: ['forget_entity'] },
+      ],
+    });
+    const names = toolNames(
+      await build({ policy, mcpGrantedActions: ['write', 'read'] }),
+    );
+    expect(names).not.toContain('forget_entity');
+    expect(names).toContain('record_fact');
+  });
+});
+
+describe('agent-attributed recorder', () => {
+  it('record_fact stamps mcp_agent:<actorId> as the source recorder', async () => {
+    const handlers: Record<string, (args: unknown) => Promise<unknown>> = {};
+    const fakeServer = {
+      registerTool: (name: string, _cfg: unknown, cb: (args: unknown) => Promise<unknown>) => {
+        handlers[name] = cb;
+        return { remove: () => undefined };
+      },
+    } as unknown as McpServer;
+    const seen: unknown[] = [];
+    registerWriteTools({
+      server: fakeServer,
+      companyId: 'co_test',
+      scopes: ['brain:read', 'brain:write'],
+      actorKeyHash: 'sha256:test',
+      actorId: 'dcr_agent1',
+      deps: {
+        ingest: { ingestFact: async (_c: string, dto: unknown) => (seen.push(dto), { outcome: 'INSERTED' }) },
+        facts: {},
+        procedural: {},
+        documents: undefined,
+        feedback: {},
+      } as never,
+    });
+
+    await handlers['record_fact']({
+      entityRef: { entityId: 'knowledge_entity:x' },
+      predicate: 'works_at',
+      object: 'acme',
+      validFrom: '2026-01-01T00:00:00Z',
+      sourceVertical: 'chat',
+    });
+    expect((seen[0] as { source: { recorder: string } }).source.recorder).toBe(
+      'mcp_agent:dcr_agent1',
+    );
+  });
+});

--- a/test/policy-resolver-cache.unit-spec.ts
+++ b/test/policy-resolver-cache.unit-spec.ts
@@ -56,15 +56,30 @@ function makeResolver(opts: {
 }
 
 describe('PolicyResolverService', () => {
+  it('resolves agent:<client_id> bindings for the acting client', async () => {
+    const { resolver } = makeResolver({
+      bindingRows: [{ subject: 'agent:dcr_agent1', policyNames: ['readonly-agent'] }],
+    });
+    const viaAgent = await resolver.contextFor('co_a', {
+      keyHash: 'sha256:k',
+      actorId: 'dcr_agent1',
+    });
+    expect(viaAgent?.sets.map((s) => s.name)).toEqual(['readonly-agent']);
+
+    // Same credential without the acting client -> binding doesn't apply.
+    const withoutActor = await resolver.contextFor('co_a', { keyHash: 'sha256:k' });
+    expect(withoutActor).toBeNull();
+  });
+
   it('returns null when ABAC_ENABLED is off — resolver never loads', async () => {
     const { resolver, loads } = makeResolver({ env: { ABAC_ENABLED: '0' } });
-    expect(await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent'])).toBeNull();
+    expect(await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['readonly-agent'] })).toBeNull();
     expect(loads()).toBe(0);
   });
 
   it('resolves claim names to compiled sets', async () => {
     const { resolver } = makeResolver();
-    const ctx = await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
+    const ctx = await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['readonly-agent'] });
     expect(ctx).not.toBeNull();
     expect(ctx!.sets).toHaveLength(1);
     expect(ctx!.sets[0].name).toBe('readonly-agent');
@@ -73,9 +88,9 @@ describe('PolicyResolverService', () => {
 
   it('returns null for keys with no bindings and no claims (tombstone, one load per TTL)', async () => {
     const { resolver, loads } = makeResolver();
-    expect(await resolver.contextFor('co_a', 'sha256:k1')).toBeNull();
-    expect(await resolver.contextFor('co_a', 'sha256:k2')).toBeNull();
-    expect(await resolver.contextFor('co_a', 'sha256:k3')).toBeNull();
+    expect(await resolver.contextFor('co_a', { keyHash: 'sha256:k1' })).toBeNull();
+    expect(await resolver.contextFor('co_a', { keyHash: 'sha256:k2' })).toBeNull();
+    expect(await resolver.contextFor('co_a', { keyHash: 'sha256:k3' })).toBeNull();
     expect(loads()).toBe(1);
   });
 
@@ -87,13 +102,13 @@ describe('PolicyResolverService', () => {
       ],
       bindingRows: [{ subject: 'key:sha256:k', policyNames: ['second', 'readonly-agent'] }],
     });
-    const ctx = await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
+    const ctx = await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['readonly-agent'] });
     expect(ctx!.sets.map((s) => s.name).sort()).toEqual(['readonly-agent', 'second']);
   });
 
   it('fails closed on an unknown referenced name (deny-all + metric)', async () => {
     const { resolver, resolutionErrors } = makeResolver();
-    const ctx = await resolver.contextFor('co_a', 'sha256:k', ['ghost-set']);
+    const ctx = await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['ghost-set'] });
     expect(ctx).not.toBeNull();
     expect(ctx!.resolutionError).toBe(true);
     expect(ctx!.sets[0].posture).toEqual({ actions: 'deny', reads: 'deny' });
@@ -107,34 +122,34 @@ describe('PolicyResolverService', () => {
         { name: DISABLED_DOC.name, mode: 'disabled', document: DISABLED_DOC },
       ],
     });
-    const ctx = await resolver.contextFor('co_a', 'sha256:k', ['switched-off']);
+    const ctx = await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['switched-off'] });
     expect(ctx).toBeNull();
     expect(resolutionErrors).toHaveLength(0);
   });
 
   it('serves from cache within TTL and reloads after invalidate()', async () => {
     const { resolver, loads } = makeResolver();
-    await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
-    await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
+    await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['readonly-agent'] });
+    await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['readonly-agent'] });
     expect(loads()).toBe(1);
     resolver.invalidate('co_a');
-    await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
+    await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['readonly-agent'] });
     expect(loads()).toBe(2);
   });
 
   it('dedupes concurrent cold loads (in-flight promise sharing)', async () => {
     const { resolver, loads } = makeResolver();
     await Promise.all([
-      resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']),
-      resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']),
-      resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']),
+      resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['readonly-agent'] }),
+      resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['readonly-agent'] }),
+      resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['readonly-agent'] }),
     ]);
     expect(loads()).toBe(1);
   });
 
   it('honours ABAC_FORCE_REPORT_ONLY on the context', async () => {
     const { resolver } = makeResolver({ env: { ABAC_FORCE_REPORT_ONLY: '1' } });
-    const ctx = await resolver.contextFor('co_a', 'sha256:k', ['readonly-agent']);
+    const ctx = await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['readonly-agent'] });
     expect(ctx!.forceReportOnly).toBe(true);
   });
 
@@ -147,7 +162,7 @@ describe('PolicyResolverService', () => {
         document: { ...DOC, name },
       })),
     });
-    const ctx = await resolver.contextFor('co_a', 'sha256:k', many);
+    const ctx = await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: many });
     expect(ctx!.sets.length).toBeLessThanOrEqual(8);
     // A dropped set may be a deny set — the overflow must not be silent.
     expect(truncations).toHaveLength(1);
@@ -162,7 +177,7 @@ describe('PolicyResolverService', () => {
         document: { ...DOC, name },
       })),
     });
-    const ctx = await resolver.contextFor('co_a', 'sha256:k', few);
+    const ctx = await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: few });
     expect(ctx!.sets).toHaveLength(8);
     expect(truncations).toHaveLength(0);
   });

--- a/test/protected-resource.unit-spec.ts
+++ b/test/protected-resource.unit-spec.ts
@@ -1,0 +1,97 @@
+/**
+ * RFC 9728 discovery surface: the well-known metadata document and the
+ * WWW-Authenticate resource_metadata challenge on 401s — the pair that
+ * lets an MCP client find auth.inite.ai and self-onboard.
+ */
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
+import { ApiKeyGuard } from '../src/auth/api-key.guard';
+import { ProtectedResourceController } from '../src/auth/protected-resource.controller';
+import {
+  requestBaseUrl,
+  resourceMetadataUrl,
+} from '../src/auth/resource-metadata';
+
+class StubConfig {
+  constructor(private readonly map: Record<string, string>) {}
+  get<T = string>(key: string, fallback?: T): T {
+    return (this.map[key] as unknown as T) ?? (fallback as T);
+  }
+}
+
+describe('resource-metadata helpers', () => {
+  afterEach(() => {
+    delete process.env.BRAIN_PUBLIC_URL;
+  });
+
+  it('derives the base URL from forwarding headers, then Host', () => {
+    expect(
+      requestBaseUrl({
+        headers: {
+          'x-forwarded-proto': 'https',
+          'x-forwarded-host': 'brain.inite.ai',
+          host: 'internal:3000',
+        },
+      }),
+    ).toBe('https://brain.inite.ai');
+    expect(requestBaseUrl({ headers: { host: 'localhost:3000' }, protocol: 'http' })).toBe(
+      'http://localhost:3000',
+    );
+    expect(requestBaseUrl({ headers: {} })).toBeNull();
+  });
+
+  it('BRAIN_PUBLIC_URL wins as the canonical resource identifier', () => {
+    process.env.BRAIN_PUBLIC_URL = 'https://brain.inite.ai/';
+    expect(resourceMetadataUrl({ headers: { host: 'other.host' } })).toBe(
+      'https://brain.inite.ai/.well-known/oauth-protected-resource',
+    );
+  });
+});
+
+describe('ProtectedResourceController', () => {
+  it('advertises the authorization server and the user-delegable scopes', () => {
+    const controller = new ProtectedResourceController(
+      new StubConfig({
+        AUTH_SERVICE_ISSUER: 'https://auth.inite.ai',
+      }) as unknown as ConfigService,
+    );
+    const doc = controller.metadata({
+      headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'brain.inite.ai' },
+    } as never);
+    expect(doc.resource).toBe('https://brain.inite.ai');
+    expect(doc.authorization_servers).toEqual(['https://auth.inite.ai']);
+    expect(doc.scopes_supported).toContain('brain:read');
+    expect(doc.scopes_supported).not.toContain('indexer:write');
+    expect(doc.bearer_methods_supported).toEqual(['header']);
+  });
+});
+
+describe('ApiKeyGuard — WWW-Authenticate challenge', () => {
+  it('401 carries resource_metadata so MCP clients can discover the AS', async () => {
+    const headersSet: Record<string, string> = {};
+    const req = { headers: { host: 'brain.inite.ai', authorization: undefined } };
+    const res = {
+      setHeader: (name: string, value: string) => {
+        headersSet[name] = value;
+      },
+    };
+    const ctx = {
+      switchToHttp: () => ({ getRequest: () => req, getResponse: () => res }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    // Credential resolver is never reached on the missing-header path.
+    const guard = new ApiKeyGuard(
+      { resolve: async () => null } as never,
+      new Reflector(),
+      { gate: async () => undefined } as never,
+    );
+
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(headersSet['WWW-Authenticate']).toBe(
+      'Bearer resource_metadata="https://brain.inite.ai/.well-known/oauth-protected-resource"',
+    );
+  });
+});

--- a/test/ssf-receiver.unit-spec.ts
+++ b/test/ssf-receiver.unit-spec.ts
@@ -1,0 +1,108 @@
+/**
+ * SSF receiver — CAEP SET handling against a locally-minted key pair.
+ * Covers: a signed session-revoked SET deny-lists its subject and is
+ * acked; a non-revoking event type is acked without denying; a SET with
+ * a bad signature is acked (never redelivered) but not trusted.
+ */
+import * as http from 'node:http';
+import { ConfigService } from '@nestjs/config';
+import { SignJWT, exportJWK, generateKeyPair, type JWK, type KeyLike } from 'jose';
+import { RevocationCacheService } from '../src/auth/revocation-cache.service';
+import { SsfReceiverService } from '../src/auth/ssf-receiver.service';
+
+const ISSUER = 'https://auth.test';
+const SESSION_REVOKED =
+  'https://schemas.openid.net/secevent/caep/event-type/session-revoked';
+const VERIFICATION =
+  'https://schemas.openid.net/secevent/ssf/event-type/verification';
+
+class StubConfig {
+  constructor(private readonly map: Record<string, string>) {}
+  get<T = string>(key: string, fallback?: T): T {
+    return (this.map[key] as unknown as T) ?? (fallback as T);
+  }
+}
+
+describe('SsfReceiverService.applySet', () => {
+  let server: http.Server;
+  let privateKey: KeyLike;
+  let receiver: SsfReceiverService;
+  let revocations: RevocationCacheService;
+
+  function mintSet(events: Record<string, unknown>, sub: string, key?: KeyLike) {
+    return new SignJWT({ events, sub_id: { format: 'iss_sub', iss: ISSUER, sub } })
+      .setProtectedHeader({ alg: 'RS256', kid: 'set-key' })
+      .setIssuer(ISSUER)
+      .setAudience('brain')
+      .setIssuedAt()
+      .setJti(`jti-${Math.floor(Math.random() * 1e9)}`)
+      .setExpirationTime('5m')
+      .sign(key ?? privateKey);
+  }
+
+  beforeAll(async () => {
+    const pair = await generateKeyPair('RS256', { extractable: true });
+    privateKey = pair.privateKey;
+    const jwk: JWK = await exportJWK(pair.publicKey);
+    jwk.alg = 'RS256';
+    jwk.use = 'sig';
+    jwk.kid = 'set-key';
+
+    server = http.createServer((req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ keys: [jwk] }));
+    });
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()));
+    const port = (server.address() as { port: number }).port;
+
+    revocations = new RevocationCacheService();
+    receiver = new SsfReceiverService(
+      new StubConfig({
+        AUTH_SSF_POLL_URL: `http://127.0.0.1:${port}/poll`,
+        AUTH_SERVICE_JWKS_URL: `http://127.0.0.1:${port}/.well-known/jwks.json`,
+        AUTH_SERVICE_ISSUER: ISSUER,
+        AUTH_SERVICE_URL: `http://127.0.0.1:${port}`,
+        AUTH_SSF_CLIENT_ID: 'brain-service',
+        AUTH_SSF_CLIENT_SECRET: 's3cret',
+      }) as unknown as ConfigService,
+      revocations,
+    );
+    receiver.onModuleInit();
+  });
+
+  afterAll(async () => {
+    receiver.onModuleDestroy();
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it('deny-lists the subject of a session-revoked SET', async () => {
+    const set = await mintSet({ [SESSION_REVOKED]: {} }, 'did:key:z6MkRevoked');
+    await receiver.applySet('jti-1', set);
+    expect(revocations.isDenied('did:key:z6MkRevoked')).toBe(true);
+  });
+
+  it('ignores (but acks) non-revoking event types', async () => {
+    const set = await mintSet({ [VERIFICATION]: {} }, 'did:key:z6MkFine');
+    await receiver.applySet('jti-2', set);
+    expect(revocations.isDenied('did:key:z6MkFine')).toBe(false);
+  });
+
+  it('never trusts a SET with a foreign signature', async () => {
+    const { privateKey: foreign } = await generateKeyPair('RS256', {
+      extractable: true,
+    });
+    const set = await mintSet({ [SESSION_REVOKED]: {} }, 'did:key:z6MkForged', foreign);
+    await receiver.applySet('jti-3', set);
+    expect(revocations.isDenied('did:key:z6MkForged')).toBe(false);
+  });
+});
+
+describe('RevocationCacheService', () => {
+  it('expires entries after their TTL', () => {
+    const cache = new RevocationCacheService();
+    cache.deny('sub-1', -1);
+    expect(cache.isDenied('sub-1')).toBe(false);
+    cache.deny('sub-2', 60_000);
+    expect(cache.isDenied('sub-2')).toBe(true);
+  });
+});

--- a/test/tier-cache.unit-spec.ts
+++ b/test/tier-cache.unit-spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Tier cache — verified entitlements → throttle-limit multipliers.
+ * Pure module; the security property under test is that only
+ * post-verification recordTier() calls widen a bucket, and unknown /
+ * malformed configuration degrades to the default tier.
+ */
+import {
+  recordTier,
+  tierMultiplier,
+  tokenTrackerKey,
+} from '../src/auth/tier-cache';
+
+describe('tier-cache', () => {
+  const key = tokenTrackerKey('some-bearer-token');
+
+  afterEach(() => {
+    delete process.env.THROTTLE_TIER_MULTIPLIERS;
+    recordTier(key, []); // clears the entry
+  });
+
+  it('tracker key matches the k:<sha256/32> throttler format', () => {
+    expect(key).toMatch(/^k:[0-9a-f]{32}$/);
+  });
+
+  it('records the largest matching multiplier', () => {
+    process.env.THROTTLE_TIER_MULTIPLIERS = '{"plan:pro":2,"plan:enterprise":5}';
+    recordTier(key, ['plan:pro', 'plan:enterprise', 'unrelated']);
+    expect(tierMultiplier(key)).toBe(5);
+  });
+
+  it('defaults to 1 without config, matching entitlements, or a record', () => {
+    expect(tierMultiplier('k:unknown')).toBe(1);
+
+    process.env.THROTTLE_TIER_MULTIPLIERS = '{"plan:pro":2}';
+    recordTier(key, ['plan:free']);
+    expect(tierMultiplier(key)).toBe(1);
+  });
+
+  it('ignores malformed config and out-of-range multipliers', () => {
+    process.env.THROTTLE_TIER_MULTIPLIERS = 'not-json';
+    recordTier(key, ['plan:pro']);
+    expect(tierMultiplier(key)).toBe(1);
+
+    process.env.THROTTLE_TIER_MULTIPLIERS = '{"plan:pro":0,"plan:mega":10000}';
+    recordTier(key, ['plan:pro', 'plan:mega']);
+    expect(tierMultiplier(key)).toBe(1);
+  });
+
+  it('re-recording without entitlements clears the tier (plan downgrade)', () => {
+    process.env.THROTTLE_TIER_MULTIPLIERS = '{"plan:pro":2}';
+    recordTier(key, ['plan:pro']);
+    expect(tierMultiplier(key)).toBe(2);
+    recordTier(key, []);
+    expect(tierMultiplier(key)).toBe(1);
+  });
+});

--- a/test/user-scope.unit-spec.ts
+++ b/test/user-scope.unit-spec.ts
@@ -1,0 +1,43 @@
+/**
+ * pinUserScope — per-user memory pinning against the ALS request context.
+ *
+ * The guard stamps a user-bound token's end-user into the request
+ * context; the pin then (a) defaults omitted userId to it, (b) 403s a
+ * mismatching assertion, (c) passes caller values through untouched for
+ * M2M credentials. Pure logic — no HTTP, no DB.
+ */
+import { ForbiddenException } from '@nestjs/common';
+import { pinUserScope } from '../src/auth/user-scope';
+import { runWithRequestContext } from '../src/common/request-context';
+
+describe('pinUserScope', () => {
+  it('passes the caller assertion through for M2M credentials (no authUserId)', () => {
+    runWithRequestContext({ correlationId: 't1' }, () => {
+      expect(pinUserScope('user-42')).toBe('user-42');
+      expect(pinUserScope(undefined)).toBeUndefined();
+    });
+  });
+
+  it('passes through outside any request context (cron, boot)', () => {
+    expect(pinUserScope('user-42')).toBe('user-42');
+  });
+
+  it('defaults an omitted userId to the token end-user', () => {
+    runWithRequestContext(
+      { correlationId: 't2', authUserId: 'did:key:z6MkUser' },
+      () => {
+        expect(pinUserScope(undefined)).toBe('did:key:z6MkUser');
+      },
+    );
+  });
+
+  it('accepts a matching assertion and rejects a mismatching one (403)', () => {
+    runWithRequestContext(
+      { correlationId: 't3', authUserId: 'did:key:z6MkUser' },
+      () => {
+        expect(pinUserScope('did:key:z6MkUser')).toBe('did:key:z6MkUser');
+        expect(() => pinUserScope('did:key:z6MkOther')).toThrow(ForbiddenException);
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Auth-vertical tightening (W1–W8) plus the agent-authorization pack: brain now consumes inite-auth tokens natively — per-user memory scoping, per-agent MCP tool grants, agent-attributed provenance, and per-agent ABAC bindings.

### Auth stack
- **JWKS verification + introspection fallback** (`ik_` keys) + static dev fallback via CredentialResolver; `org` → tenant, `sub` → user; caller-asserted userId is pinned to the token's user (`pinUserScope`, ALS request context).
- **Revocation deny-list** fed by SSF/CAEP poll (RFC 8936); optional `AUTH_SSF_POLL_URL`.
- **RFC 9728 protected-resource metadata** + `WWW-Authenticate: resource_metadata` on 401s.
- Tier-aware throttling via token entitlements (`THROTTLE_TIER_MULTIPLIERS`).

### Agent as principal
- **Claim parsers** (`src/auth/claim-parsers.ts`): actor identity `act.client_id ?? act.sub ?? client_id`; `inite_mcp_resource` grant extraction — fail-closed on foreign `locations` (grant for another deployment ⇒ empty tool surface, never full access); `policy` names from JWT or introspection.
- **RFC 9396 grant gate** on MCP: with grants present, tools outside the granted actions (`read`/`write` macros cover an ActionKind) are removed after the policy gate — policy deny beats grant allow. No grant claim ⇒ behavior unchanged.
- **Agent-attributed provenance**: `record_fact`/`ingest_document` recorder becomes `mcp_agent:<client_id>`; every ingest path stamps `source.meta.actor` from the token (overrides caller-asserted) — usable by ABAC source rules and "forget everything agent X wrote".
- **Per-agent policy bindings**: new binding subject `agent:<client_id>` — a tenant can constrain a specific acting client regardless of credential presented.

### Also
- brain-landing: token exchange preferred over M2M (bounded cache, warn on fallback); login scope includes `brain:*`.
- Docs: operator-playbook "Per-agent rights and policies" + ABAC report_only → enforce runbook; api.md, operations.md, DEPLOY.md, .env.example.

## Activation notes (nothing flips in this PR)
`ABAC_ENABLED` stays off. Required env for the integration: `AUTH_SERVICE_JWKS_URL`/`ISSUER`, `AUTH_SERVICE_INTROSPECTION_CLIENT_ID`/`SECRET`; `BRAIN_PUBLIC_URL` when RAR grants use `locations`. Users must re-login to carry `brain:*` scopes, else brain-landing falls back to M2M (warned in logs).

## Test plan
- 1382/1382 unit tests pass (`jest-unit.json`), `tsc -p tsconfig.spec.json --noEmit` clean.
- New specs: grant gate, claim parsers/guard, user-scope pinning, introspection client, protected-resource metadata, SSF receiver, tier cache, agent bindings resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
