### PR TITLE
fix(auth): allow registry:curate on introspected operator keys

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -330,9 +330,11 @@ BILLING_SERVICE_API_KEY=<service key>          # required while the flag is on
 
 Fail-closed: when billing is unreachable and the entitlement cache is
 cold, PAID installs answer 503 (free packs are unaffected — they never
-touch billing). Curation keys: mint a `registry:curate` env key for the
-hosting operator (env-key-only, like `registry:publish` — JWT tokens
-cannot carry it).
+touch billing). Curation keys: `registry:curate` / `registry:publish`
+never ride user JWTs (absent from the JWT `VALID_SCOPES`); carry them on
+an operator-issued credential — an auth-service `ik_…` key (resolved via
+RFC 7662 introspection) in production, or a static `BRAIN_API_KEYS` env
+entry in dev (the static table is disabled in production).
 
 **Admin UI (brain-landing)**
 
@@ -347,18 +349,23 @@ plus all Marketplace *reads*; Marketplace *writes* need more:
 
 Missing scopes degrade gracefully — the Marketplace panel stays usable
 read-only and shows an amber note naming the missing scope instead of a
-generic error. The registry scopes are env-key-only by design
-(deliberately absent from the JWT `VALID_SCOPES` set in
-`src/auth/jwks.service.ts`), so a JWT-based BFF token can never carry
-them. To enable Marketplace writes from the admin UI:
+generic error. The registry scopes never ride JWTs (absent from the JWT
+`VALID_SCOPES` set in `src/auth/jwks.service.ts`), so the BFF's M2M
+token can never carry them. To enable Marketplace writes from the admin
+UI:
 
-1. Add a key to the backend's `BRAIN_API_KEYS` with scopes
-   `brain:admin registry:publish registry:curate` (see
-   docs/domain-packs.md for key minting).
+1. Issue an operator credential carrying
+   `brain:admin registry:publish registry:curate`:
+   - **production** — an auth-service API key (`ik_…`); brain resolves
+     it via RFC 7662 introspection, which allows exactly these
+     integration scopes;
+   - **dev / self-hosted without auth-service** — a static
+     `BRAIN_API_KEYS` env entry (the static table is disabled in
+     production whenever a remote verifier is configured).
 2. Set the plaintext key as `BRAIN_REGISTRY_API_KEY` in the
    brain-landing environment. The BFF proxy then sends it as the Bearer
    token on `v1/admin/registry/*` calls only; everything else stays on
-   the M2M JWT path. Without the env var, marketplace writes keep the
+   the JWT paths. Without the env var, marketplace writes keep the
    read-only degradation.
 
 **Deliberately NOT in v1**

--- a/src/auth/introspection.client.ts
+++ b/src/auth/introspection.client.ts
@@ -22,10 +22,12 @@ import { extractPolicyNames } from './claim-parsers';
 
 /**
  * Scopes an introspected (operator-issued) key may carry. Superset of the
- * JWT set: indexer:write / registry:publish are meaningful ONLY as
- * long-lived integration keys — exactly what auth-service API keys are —
- * while user JWTs must never smuggle them. registry:curate stays
- * env-key-only (hosting-operator surface).
+ * JWT set: indexer:write / registry:publish / registry:curate are
+ * meaningful ONLY as long-lived integration keys — exactly what
+ * auth-service API keys are — while user JWTs must never smuggle them.
+ * (registry:curate was briefly "env-key-only", but production disables
+ * the static key table entirely, which made curation unreachable —
+ * introspected keys ARE the operator-issued surface now.)
  */
 const INTROSPECTED_SCOPES: ReadonlySet<BrainScope> = new Set([
   'brain:read',
@@ -33,6 +35,7 @@ const INTROSPECTED_SCOPES: ReadonlySet<BrainScope> = new Set([
   'brain:admin',
   'brain:read_pii',
   'registry:publish',
+  'registry:curate',
   'indexer:write',
 ]);
 

--- a/test/introspection-client.unit-spec.ts
+++ b/test/introspection-client.unit-spec.ts
@@ -81,19 +81,23 @@ describe('mapIntrospectionRecord', () => {
     ).toBeNull();
   });
 
-  it('allows integration scopes (indexer:write, registry:publish) but drops registry:curate', () => {
+  it('allows integration scopes (indexer:write, registry:publish, registry:curate) and drops unknown ones', () => {
     const rec = mapIntrospectionRecord(
       {
         active: true,
         sub: 'co_a',
         org: 'co_a',
         aud: 'brain',
-        scope: 'indexer:write registry:publish registry:curate',
+        scope: 'indexer:write registry:publish registry:curate made:up',
       },
       hash,
       'brain',
     );
-    expect(rec?.scopes).toEqual(['registry:publish', 'indexer:write'].sort());
+    expect(rec?.scopes).toEqual([
+      'indexer:write',
+      'registry:publish',
+      'registry:curate',
+    ]);
   });
 });
 


### PR DESCRIPTION
`registry:curate` was deliberately env-key-only, but production disables the static `BRAIN_API_KEYS` table whenever a remote verifier is configured (#214's own hardening) — the combination made featured-curation unreachable with ANY credential in production. An introspected auth-service `ik_…` key is precisely the operator-issued long-lived surface, so `INTROSPECTED_SCOPES` now includes `registry:curate` alongside `registry:publish`/`indexer:write`. User JWTs still cannot carry any of them (`VALID_SCOPES` unchanged).

Also updates the operations.md marketplace runbook: production path = auth-service `ik_` key with `brain:admin registry:publish registry:curate` → `BRAIN_REGISTRY_API_KEY` in the landing env.

cc: this reverses one line of the #214 posture — flagged in chat; happy to revert if the auth track prefers a different curation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)