### PR TITLE
fix(release): bump docs/openapi.json info.version in release PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,14 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "docs/openapi.json",
+          "jsonpath": "$.info.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
`scripts/build-openapi.ts` stamps `info.version` from `package.json`, so a release PR's version bump makes the committed `docs/openapi.json` drift from a regeneration — the `openapi-doc` drift gate then fails `build-test` on every release PR (first hit: #201 / v0.8.0). release-please now bumps the spec's `info.version` in lockstep via `extra-files` (json + jsonpath).

🤖 Generated with [Claude Code](https://claude.com/claude-code)