### PR TITLE
fix(security): CodeQL backlog + tolerant AI summary

### DIFF
--- a/.github/workflows/ai-pr-summary.yml
+++ b/.github/workflows/ai-pr-summary.yml
@@ -53,6 +53,10 @@ jobs:
 
       - name: AI summary
         id: ai
+        # Best-effort: GitHub Models may be unavailable (e.g. 403 when Models
+        # isn't enabled for the org/repo). A failed summary must not red-X the
+        # PR — the summary is advisory only.
+        continue-on-error: true
         uses: actions/ai-inference@a7805884c80886efc241e94a5351df715968a0ad # v2.1.1
         with:
           model: openai/gpt-4o-mini
@@ -73,6 +77,8 @@ jobs:
           prompt-file: prompt.txt
 
       - name: Post/update summary comment
+        # Skip when the model produced nothing (unavailable/errored).
+        if: ${{ steps.ai.outputs.response != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/src/admin/operator-action.interceptor.ts
+++ b/src/admin/operator-action.interceptor.ts
@@ -94,7 +94,9 @@ function summariseQuery(
   q: Record<string, unknown> | undefined,
 ): Record<string, string> | null {
   if (!q || Object.keys(q).length === 0) return null;
-  const out: Record<string, string> = {};
+  // Null prototype: request-controlled keys can't collide with (or
+  // pollute) inherited Object members.
+  const out: Record<string, string> = Object.create(null);
   for (const [k, v] of Object.entries(q)) {
     if (isUnsafeKey(k)) continue;
     out[k] = truncate(String(v));
@@ -106,7 +108,7 @@ function summariseBody(
   body: unknown,
 ): Record<string, unknown> | null {
   if (!body || typeof body !== 'object') return null;
-  const out: Record<string, unknown> = {};
+  const out: Record<string, unknown> = Object.create(null);
   for (const [k, v] of Object.entries(body as Record<string, unknown>)) {
     if (isUnsafeKey(k)) continue;
     if (v === null || v === undefined) {

--- a/src/artifacts/artifacts.service.ts
+++ b/src/artifacts/artifacts.service.ts
@@ -14,6 +14,9 @@ import {
   type Citation,
 } from './templates';
 
+// Own-key Map view of the template registry for request-derived lookups.
+const TEMPLATE_MAP = new Map(Object.entries(TEMPLATES));
+
 /**
  * ArtifactsService — compilation-stage knowledge layer.
  *
@@ -204,15 +207,15 @@ export class ArtifactsService {
    * of returning an empty bundle.
    */
   private compile(type: ArtifactType, facts: FactRow[]): CompiledArtifact {
-    // `type` is request-derived: guard with hasOwn so a value like
-    // 'constructor'/'toString' can't resolve to an inherited Object member
-    // and get invoked as a template.
-    if (!Object.prototype.hasOwnProperty.call(TEMPLATES, type)) {
+    // `type` is request-derived: a Map lookup can't resolve inherited
+    // Object members ('constructor'/'toString') the way obj[type] can,
+    // so an unknown or hostile value dead-ends at undefined.
+    const template = TEMPLATE_MAP.get(type);
+    if (!template) {
       throw new BadRequestException(
-        `Unknown artifactType '${type}'. Known: ${Object.keys(TEMPLATES).join(', ')}`,
+        `Unknown artifactType '${type}'. Known: ${[...TEMPLATE_MAP.keys()].join(', ')}`,
       );
     }
-    const template = TEMPLATES[type];
     const out = template(facts);
     // De-duplicate sourceFactIds — multiple template fields commonly cite
     // the same fact (e.g. customer_profile.name + identity_dossier.name).

--- a/src/registry/publisher-profile.service.ts
+++ b/src/registry/publisher-profile.service.ts
@@ -22,7 +22,16 @@ interface ProfileRow {
 
 // Loose email shape — enough to catch a pasted URL or a bare word, not an
 // RFC 5321 validator (the address is display metadata, nothing is sent).
-const LOOSE_EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Index-based instead of a regex: the natural /x+@x+\.x+/ shape is
+// polynomially backtrackable on untrusted input of unbounded length.
+function looksLikeEmail(s: string): boolean {
+  if (s.length > 254 || /\s/.test(s)) return false;
+  const at = s.indexOf('@');
+  if (at <= 0 || at !== s.lastIndexOf('@') || at === s.length - 1) return false;
+  const domain = s.slice(at + 1);
+  const dot = domain.lastIndexOf('.');
+  return dot > 0 && dot < domain.length - 1;
+}
 
 /**
  * Public marketplace profiles per registry publisher id (migration 0067;
@@ -155,7 +164,7 @@ export class PublisherProfileService {
       throw new BadRequestException('url must be a valid http(s) URL');
     }
     const contactEmail = profile.contactEmail?.trim();
-    if (contactEmail && !LOOSE_EMAIL.test(contactEmail)) {
+    if (contactEmail && !looksLikeEmail(contactEmail)) {
       throw new BadRequestException('contactEmail must look like an email address');
     }
     return {


### PR DESCRIPTION
## Summary

Clears the actionable brain code-scanning backlog.

- **js/polynomial-redos (high)**: publisher-profile `contactEmail` now validated with an index-based check + 254-char cap — the old `/^[^\s@]+@[^\s@]+\.[^\s@]+$/` backtracks polynomially on unbounded untrusted input.
- **js/unvalidated-dynamic-method-call (high)**: artifact template dispatch goes through a `Map` built from the registry — a hostile `artifactType` dead-ends at `undefined` instead of reaching `TEMPLATES[type]` (behavior unchanged: unknown types still 400).
- **js/remote-property-injection x7 (high)**: operator-action audit summaries assign onto null-prototype objects; the existing `isUnsafeKey` filter stays as belt-and-braces.
- **ai-pr-summary**: `continue-on-error` + skip-comment-on-empty — the org-wide GitHub Models 403 stops red-X-ing every PR (ports the auth-repo fix).

Left open deliberately: `js/http-to-file-access` on `baseline.service.ts:99` — saving eval baselines to disk is the feature; the path is sanitized + containment-checked (`pathFor`), admin-scope only. Dismissal candidate, needs repo-admin action.
Scorecard "no file" findings (CITests/Fuzzing/CodeReview/CIIBestPractices/Vulnerabilities/SAST/Maintained) are repo-practice scores, not code fixes — triage separately.

## Test plan
- 1382/1382 unit tests, `tsc -p tsconfig.spec.json --noEmit` clean, eslint clean on touched files, workflow YAML parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)