### PR TITLE
fix(docs): rename reserved mermaid node id 'graph' in README and pipeline diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ flowchart LR
   packs["Domain Packs ✳<br/>registry · marketplace"] -. "predicates · indexers<br/>seed documents" .-> ingest
   facts --> resolver["conflict resolver<br/>+ trust snapshot"]
   docs --> resolver
-  resolver --> graph[("bitemporal graph<br/>two clocks per fact")]
-  graph --> retrieval["retrieval pipeline<br/>vector + BM25 → router → PPR →<br/>cross-encoder → LLM rerank"]
+  resolver --> kg[("bitemporal graph<br/>two clocks per fact")]
+  kg --> retrieval["retrieval pipeline<br/>vector + BM25 → router → PPR →<br/>cross-encoder → LLM rerank"]
   retrieval --> rest["REST /v1"]
   retrieval --> mcp["MCP per tenant<br/>+ pack tools ✳"]
 ```

--- a/docs/document-pipeline.md
+++ b/docs/document-pipeline.md
@@ -19,7 +19,7 @@ flowchart LR
   ded --> cand
   ext --> ground["span re-grounding"] --> cand
   cand --> commit["Brain: CommitMemory<br/>unify entities · merge facts ·<br/>fn::resolve_fact"]
-  commit --> graph[("bitemporal graph")]
+  commit --> kg[("bitemporal graph")]
 ```
 
 ✳ = the third-party seam — see [indexer-protocol.md](indexer-protocol.md).


### PR DESCRIPTION
`graph` is a mermaid keyword — using it as a flowchart node id breaks the parser, so the README hero diagram (and the document-pipeline one) showed GitHub's "Unable to render rich display" error instead of rendering. Renamed the node to `kg` in both. The other two diagrams (domain-packs lifecycle, mcp-pack-tools sequence) scanned clean for reserved ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)