### PR TITLE
feat(packs): persona domain pack + mention-path user scoping

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -522,6 +522,17 @@ industry packs (installed per-tenant, published to the registry via
 | `legal` | contracts | governed_by, party_to, obligation, effective_from, terminates_on |
 | `insurance` | insurance policies | covers, coverage_limit, premium, deductible, excludes |
 | `hr` | HR / recruiting (roles, not PII) | requires_skill, seniority, compensation, employment_type, work_location |
+| `persona` | personal user memory (per-user) | education, health_condition, life_event, felt, dislike, relationship_role, closeness, occupation, employer, skill |
+
+`persona` is the personal-memory pack: it models an end user's biography,
+experiences, preferences, social circle, and work history for assistants
+that keep a long-running relationship with a specific person. Identity
+(name/dob/address/…) and positive likes route to CORE predicates; social
+links stay `knowledge_edge` kinds (family_of / friend_of / colleague_of).
+`health_condition` is `piiClass: sensitive` + `requiresScope:
+brain:read_pii`. Persona facts are per-user memory — ingest under a
+user-bound token (or pass `userId`) so migration 0055's read fence scopes
+them.
 
 Sources: `src/ai/domain-packs/*.pack.ts` (the `FIRST_PARTY_PACKS` list) →
 committed JSON in `packs/*.pack.json` (drift-guarded by

--- a/packs/persona.pack.json
+++ b/packs/persona.pack.json
@@ -1,0 +1,227 @@
+{
+  "id": "persona",
+  "version": "0.1.0",
+  "description": "Personal user memory ontology — education, health basics, life events, emotions, dislikes, social circle, and work history of an end user, with a domain extraction profile. Per-user scoped.",
+  "predicates": [
+    {
+      "localId": "education",
+      "displayLabel": "education",
+      "description": "TYPE   subject is a person; value is an educational credential/history\nADMIT  text states a degree, school, or field studied (\"PhD in\n       neuroscience at UCL\", \"studied law at Bologna\")\nNOT FOR generic learning intent (route to core intent)\nVALUE  one credential per fact, verbatim (\"PhD in neuroscience, UCL\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "health_condition",
+      "displayLabel": "health condition",
+      "description": "TYPE   subject is a person; value is a stated health condition/basic\nADMIT  text EXPLICITLY states a condition the person has (\"has type-2\n       diabetes\", \"allergic to penicillin\")\nNOT FOR inferred, hypothetical, or third-party health facts — extract\n       ONLY conditions the person states about themselves\nVALUE  the condition, verbatim (\"type-2 diabetes\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "sensitive",
+      "requiresScope": "brain:read_pii",
+      "status": "active"
+    },
+    {
+      "localId": "life_event",
+      "displayLabel": "life event",
+      "description": "TYPE   subject is a person; value is a significant life event\nADMIT  text reports a life episode (\"got married in 2019\", \"moved to\n       Berlin\", \"ran my first marathon last spring\")\nVALUE  one event per fact, verbatim, KEEPING any date words (\"ran my\n       first marathon last spring\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": 365,
+      "piiClass": "behavioral",
+      "status": "active"
+    },
+    {
+      "localId": "felt",
+      "displayLabel": "felt",
+      "description": "TYPE   subject is a person; value is an emotion about a thing/event\nADMIT  text reports how the person felt about something (\"was thrilled\n       about the new job\", \"nervous before the exam\")\nVALUE  the emotion + its object, EMOTION WORD VERBATIM (\"thrilled about\n       the new job\" — not \"happy\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": 180,
+      "piiClass": "behavioral",
+      "status": "active"
+    },
+    {
+      "localId": "dislike",
+      "displayLabel": "dislike",
+      "description": "TYPE   subject is a person; value is a thing/style/category disliked\nADMIT  text states a NEGATIVE preference (\"hates cilantro\", \"can't\n       stand open-plan offices\")\nNOT FOR positive preferences — route likes to core preference\nVALUE  the disliked thing, verbatim (\"cilantro\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": 90,
+      "piiClass": "behavioral",
+      "status": "active"
+    },
+    {
+      "localId": "relationship_role",
+      "displayLabel": "relationship role",
+      "description": "TYPE   subject is a CONTACT (a person in the user's circle); value is\n       their relationship role to the user\nADMIT  text names how a contact relates (\"my sister Maria\", \"Tom, my\n       college roommate\")\nVALUE  the role, verbatim (\"sister\", \"college roommate\"). Also emit a\n       knowledge_edge from the contact to the user (family_of /\n       friend_of / colleague_of).",
+      "datatype": "string",
+      "semantics": "single_active",
+      "decayHalfLifeDays": null,
+      "piiClass": "behavioral",
+      "status": "active"
+    },
+    {
+      "localId": "closeness",
+      "displayLabel": "closeness",
+      "description": "TYPE   subject is a CONTACT; value is how close they are to the user\nADMIT  text signals closeness (\"we're very close\", \"a distant cousin\")\nVALUE  one of: close, moderate, distant",
+      "datatype": "enum",
+      "semantics": "single_active",
+      "decayHalfLifeDays": 180,
+      "piiClass": "behavioral",
+      "allowedValues": [
+        "close",
+        "moderate",
+        "distant"
+      ],
+      "status": "active"
+    },
+    {
+      "localId": "occupation",
+      "displayLabel": "occupation",
+      "description": "TYPE   subject is a person; value is their current role/occupation\nADMIT  text states what they do (\"works as a data scientist\", \"I'm a\n       nurse\")\nVALUE  the role, verbatim (\"data scientist\")",
+      "datatype": "string",
+      "semantics": "bitemporal",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "employer",
+      "displayLabel": "employer",
+      "description": "TYPE   subject is a person; value is their employer/organization\nADMIT  text names where they work (\"at Acme\", \"joined Google in 2021\")\nVALUE  the organization, verbatim (\"Google\")",
+      "datatype": "string",
+      "semantics": "bitemporal",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    },
+    {
+      "localId": "skill",
+      "displayLabel": "skill",
+      "description": "TYPE   subject is a person; value is a skill/competency they have\nADMIT  text states a skill the person has (\"fluent in Japanese\", \"good\n       at woodworking\")\nVALUE  one skill per fact, verbatim (\"fluent in Japanese\")",
+      "datatype": "string",
+      "semantics": "append_only",
+      "decayHalfLifeDays": null,
+      "piiClass": "none",
+      "status": "active"
+    }
+  ],
+  "extractionProfile": {
+    "guidance": "Persona inputs describe ONE end user and the people in their circle.\nThe user is the SUBJECT for biography, episodes, and work facts. Contacts are\ntheir OWN entities carrying persona__relationship_role and persona__closeness,\nplus a knowledge_edge to the user (family_of / friend_of / colleague_of).\n\nRoute to CORE predicates, NOT pack predicates:\n- identity → core name / dob / address / email / phone\n- stable LIKES / positive preferences → core preference\n- plans / wants / goals → core intent\n\nUse persona__* for: education (persona__education), stated health conditions\n(persona__health_condition — extract ONLY what the person explicitly states,\nnever infer), life events (persona__life_event), emotions (persona__felt),\nNEGATIVE preferences (persona__dislike), a contact's role/closeness\n(persona__relationship_role / persona__closeness), and work\n(persona__occupation / persona__employer / persona__skill).\n\nCopy emotions and events VERBATIM — \"thrilled\" not \"happy\", \"ran my first\nmarathon last spring\" not \"did exercise\".",
+    "fewShot": [
+      {
+        "text": "I did my PhD in neuroscience at UCL, and I've worked as a data scientist at Acme since 2021.",
+        "note": "subject=the user → persona__education='PhD in neuroscience at UCL', persona__occupation='data scientist', persona__employer='Acme'."
+      },
+      {
+        "text": "I was absolutely thrilled when I finished my first marathon last spring.",
+        "note": "→ persona__life_event='finished my first marathon last spring', persona__felt='thrilled about finishing my first marathon'."
+      },
+      {
+        "text": "I love Italian food but I honestly cannot stand cilantro.",
+        "note": "positive like → core preference='Italian food'; negative → persona__dislike='cilantro'. Do NOT emit persona__preference (there is none)."
+      },
+      {
+        "text": "My sister Maria and I are very close — she's a nurse in Lisbon.",
+        "note": "contact 'Maria' → persona__relationship_role='sister', persona__closeness='close', persona__occupation='nurse'; emit a knowledge_edge Maria→user kind='family_of'."
+      }
+    ]
+  },
+  "evalFixtures": [
+    {
+      "id": "education",
+      "description": "an education credential is extracted",
+      "text": "I studied law at the University of Bologna.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "education",
+            "objectIncludes": "law"
+          }
+        ]
+      }
+    },
+    {
+      "id": "life-event",
+      "description": "a life event keeps its date words",
+      "text": "We got married in 2019.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "life_event",
+            "objectIncludes": "married"
+          }
+        ]
+      }
+    },
+    {
+      "id": "felt",
+      "description": "the emotion word is captured verbatim",
+      "text": "I was thrilled about starting the new job.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "felt",
+            "objectIncludes": "thrilled"
+          }
+        ]
+      }
+    },
+    {
+      "id": "dislike",
+      "description": "a negative preference routes to dislike",
+      "text": "I really can't stand cilantro.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "dislike",
+            "objectIncludes": "cilantro"
+          }
+        ]
+      }
+    },
+    {
+      "id": "occupation",
+      "description": "the current occupation is captured",
+      "text": "I work as a data scientist.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "occupation",
+            "objectIncludes": "data scientist"
+          }
+        ]
+      }
+    },
+    {
+      "id": "skill",
+      "description": "a skill is captured verbatim",
+      "text": "I am fluent in Japanese.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "skill",
+            "objectIncludes": "Japanese"
+          }
+        ]
+      }
+    },
+    {
+      "id": "health",
+      "description": "a stated health condition is captured (sensitive)",
+      "text": "I have type-2 diabetes.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "health_condition",
+            "objectIncludes": "diabetes"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -43,6 +43,7 @@ export * from './medical.pack';
 export * from './legal.pack';
 export * from './insurance.pack';
 export * from './hr.pack';
+export * from './persona.pack';
 
 import { REAL_ESTATE_PACK } from './real-estate.pack';
 import { FINTECH_PACK } from './fintech.pack';
@@ -50,6 +51,7 @@ import { MEDICAL_PACK } from './medical.pack';
 import { LEGAL_PACK } from './legal.pack';
 import { INSURANCE_PACK } from './insurance.pack';
 import { HR_PACK } from './hr.pack';
+import { PERSONA_PACK } from './persona.pack';
 
 /** First-party distributable packs shipped in-repo (packs/*.json). The industry
  *  ontology library — distinct from BUILTIN_PACKS (globally seeded). */
@@ -60,4 +62,5 @@ export const FIRST_PARTY_PACKS: DomainPackManifest[] = [
   LEGAL_PACK,
   INSURANCE_PACK,
   HR_PACK,
+  PERSONA_PACK,
 ];

--- a/src/ai/domain-packs/persona.pack.ts
+++ b/src/ai/domain-packs/persona.pack.ts
@@ -1,0 +1,265 @@
+import type { DomainPackManifest } from './manifest';
+
+/**
+ * Industry Domain Pack: persona / personal user memory. DISTRIBUTABLE
+ * (installed per-tenant from `packs/persona.pack.json`, NOT in
+ * BUILTIN_PACKS). Models the persistent memory of an END USER — who they
+ * are, what they've lived through, what they like/dislike, who matters to
+ * them, and what they do professionally — for assistants that maintain a
+ * long-running relationship with a specific person.
+ *
+ * Scope decisions (six Synthius-Mem cognitive domains → our model):
+ *  - Biography identity (name / dob / address / email / phone) stays in
+ *    CORE — those predicates already exist with the right piiClass +
+ *    requiresScope. The pack adds only `education` and `health_condition`.
+ *  - Stable likes route to CORE `preference` (append_only, behavioral) —
+ *    NOT duplicated here; declaring `persona__preference` would create an
+ *    extractor routing collision. The pack adds `dislike` for the
+ *    negative-polarity complement.
+ *  - Social relationships between people stay `knowledge_edge` (free-form
+ *    `kind`) — the extractionProfile names the recommended kinds
+ *    (family_of / friend_of / colleague_of). The pack's predicates
+ *    (`relationship_role`, `closeness`) attach to the CONTACT entity.
+ *  - Episodic experiences carry emotional valence + intensity LEXICALLY
+ *    in the verbatim value ("thrilled about finishing the marathon") —
+ *    numeric valence is out of the verbatim-string fact model.
+ *  - Psychometrics (Big Five etc. numeric framework scores with evidence
+ *    quotes) is DEFERRED to v2: numeric scores + confidence need a JSON
+ *    value convention and eval coverage this pack doesn't ship yet.
+ *
+ * Persona facts are per-user memory: ingest under a user-bound token (or
+ * pass `userId`) so migration 0055's fail-closed read fence scopes them.
+ * Bump `version` to update.
+ */
+export const PERSONA_PACK: DomainPackManifest = {
+  id: 'persona',
+  version: '0.1.0',
+  description:
+    'Personal user memory ontology — education, health basics, life events, emotions, dislikes, social circle, and work history of an end user, with a domain extraction profile. Per-user scoped.',
+  predicates: [
+    {
+      localId: 'education',
+      displayLabel: 'education',
+      description: `TYPE   subject is a person; value is an educational credential/history
+ADMIT  text states a degree, school, or field studied ("PhD in
+       neuroscience at UCL", "studied law at Bologna")
+NOT FOR generic learning intent (route to core intent)
+VALUE  one credential per fact, verbatim ("PhD in neuroscience, UCL")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'health_condition',
+      displayLabel: 'health condition',
+      description: `TYPE   subject is a person; value is a stated health condition/basic
+ADMIT  text EXPLICITLY states a condition the person has ("has type-2
+       diabetes", "allergic to penicillin")
+NOT FOR inferred, hypothetical, or third-party health facts — extract
+       ONLY conditions the person states about themselves
+VALUE  the condition, verbatim ("type-2 diabetes")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'sensitive',
+      requiresScope: 'brain:read_pii',
+      status: 'active',
+    },
+    {
+      localId: 'life_event',
+      displayLabel: 'life event',
+      description: `TYPE   subject is a person; value is a significant life event
+ADMIT  text reports a life episode ("got married in 2019", "moved to
+       Berlin", "ran my first marathon last spring")
+VALUE  one event per fact, verbatim, KEEPING any date words ("ran my
+       first marathon last spring")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: 365,
+      piiClass: 'behavioral',
+      status: 'active',
+    },
+    {
+      localId: 'felt',
+      displayLabel: 'felt',
+      description: `TYPE   subject is a person; value is an emotion about a thing/event
+ADMIT  text reports how the person felt about something ("was thrilled
+       about the new job", "nervous before the exam")
+VALUE  the emotion + its object, EMOTION WORD VERBATIM ("thrilled about
+       the new job" — not "happy")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: 180,
+      piiClass: 'behavioral',
+      status: 'active',
+    },
+    {
+      localId: 'dislike',
+      displayLabel: 'dislike',
+      description: `TYPE   subject is a person; value is a thing/style/category disliked
+ADMIT  text states a NEGATIVE preference ("hates cilantro", "can't
+       stand open-plan offices")
+NOT FOR positive preferences — route likes to core preference
+VALUE  the disliked thing, verbatim ("cilantro")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: 90,
+      piiClass: 'behavioral',
+      status: 'active',
+    },
+    {
+      localId: 'relationship_role',
+      displayLabel: 'relationship role',
+      description: `TYPE   subject is a CONTACT (a person in the user's circle); value is
+       their relationship role to the user
+ADMIT  text names how a contact relates ("my sister Maria", "Tom, my
+       college roommate")
+VALUE  the role, verbatim ("sister", "college roommate"). Also emit a
+       knowledge_edge from the contact to the user (family_of /
+       friend_of / colleague_of).`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'behavioral',
+      status: 'active',
+    },
+    {
+      localId: 'closeness',
+      displayLabel: 'closeness',
+      description: `TYPE   subject is a CONTACT; value is how close they are to the user
+ADMIT  text signals closeness ("we're very close", "a distant cousin")
+VALUE  one of: close, moderate, distant`,
+      datatype: 'enum',
+      semantics: 'single_active',
+      decayHalfLifeDays: 180,
+      piiClass: 'behavioral',
+      allowedValues: ['close', 'moderate', 'distant'],
+      status: 'active',
+    },
+    {
+      localId: 'occupation',
+      displayLabel: 'occupation',
+      description: `TYPE   subject is a person; value is their current role/occupation
+ADMIT  text states what they do ("works as a data scientist", "I'm a
+       nurse")
+VALUE  the role, verbatim ("data scientist")`,
+      datatype: 'string',
+      semantics: 'bitemporal',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'employer',
+      displayLabel: 'employer',
+      description: `TYPE   subject is a person; value is their employer/organization
+ADMIT  text names where they work ("at Acme", "joined Google in 2021")
+VALUE  the organization, verbatim ("Google")`,
+      datatype: 'string',
+      semantics: 'bitemporal',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'skill',
+      displayLabel: 'skill',
+      description: `TYPE   subject is a person; value is a skill/competency they have
+ADMIT  text states a skill the person has ("fluent in Japanese", "good
+       at woodworking")
+VALUE  one skill per fact, verbatim ("fluent in Japanese")`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+  ],
+  extractionProfile: {
+    guidance: `Persona inputs describe ONE end user and the people in their circle.
+The user is the SUBJECT for biography, episodes, and work facts. Contacts are
+their OWN entities carrying persona__relationship_role and persona__closeness,
+plus a knowledge_edge to the user (family_of / friend_of / colleague_of).
+
+Route to CORE predicates, NOT pack predicates:
+- identity → core name / dob / address / email / phone
+- stable LIKES / positive preferences → core preference
+- plans / wants / goals → core intent
+
+Use persona__* for: education (persona__education), stated health conditions
+(persona__health_condition — extract ONLY what the person explicitly states,
+never infer), life events (persona__life_event), emotions (persona__felt),
+NEGATIVE preferences (persona__dislike), a contact's role/closeness
+(persona__relationship_role / persona__closeness), and work
+(persona__occupation / persona__employer / persona__skill).
+
+Copy emotions and events VERBATIM — "thrilled" not "happy", "ran my first
+marathon last spring" not "did exercise".`,
+    fewShot: [
+      {
+        text: "I did my PhD in neuroscience at UCL, and I've worked as a data scientist at Acme since 2021.",
+        note: "subject=the user → persona__education='PhD in neuroscience at UCL', persona__occupation='data scientist', persona__employer='Acme'.",
+      },
+      {
+        text: 'I was absolutely thrilled when I finished my first marathon last spring.',
+        note: "→ persona__life_event='finished my first marathon last spring', persona__felt='thrilled about finishing my first marathon'.",
+      },
+      {
+        text: 'I love Italian food but I honestly cannot stand cilantro.',
+        note: "positive like → core preference='Italian food'; negative → persona__dislike='cilantro'. Do NOT emit persona__preference (there is none).",
+      },
+      {
+        text: "My sister Maria and I are very close — she's a nurse in Lisbon.",
+        note: "contact 'Maria' → persona__relationship_role='sister', persona__closeness='close', persona__occupation='nurse'; emit a knowledge_edge Maria→user kind='family_of'.",
+      },
+    ],
+  },
+  evalFixtures: [
+    {
+      id: 'education',
+      description: 'an education credential is extracted',
+      text: 'I studied law at the University of Bologna.',
+      expect: { facts: [{ predicate: 'education', objectIncludes: 'law' }] },
+    },
+    {
+      id: 'life-event',
+      description: 'a life event keeps its date words',
+      text: 'We got married in 2019.',
+      expect: { facts: [{ predicate: 'life_event', objectIncludes: 'married' }] },
+    },
+    {
+      id: 'felt',
+      description: 'the emotion word is captured verbatim',
+      text: 'I was thrilled about starting the new job.',
+      expect: { facts: [{ predicate: 'felt', objectIncludes: 'thrilled' }] },
+    },
+    {
+      id: 'dislike',
+      description: 'a negative preference routes to dislike',
+      text: "I really can't stand cilantro.",
+      expect: { facts: [{ predicate: 'dislike', objectIncludes: 'cilantro' }] },
+    },
+    {
+      id: 'occupation',
+      description: 'the current occupation is captured',
+      text: 'I work as a data scientist.',
+      expect: { facts: [{ predicate: 'occupation', objectIncludes: 'data scientist' }] },
+    },
+    {
+      id: 'skill',
+      description: 'a skill is captured verbatim',
+      text: 'I am fluent in Japanese.',
+      expect: { facts: [{ predicate: 'skill', objectIncludes: 'Japanese' }] },
+    },
+    {
+      id: 'health',
+      description: 'a stated health condition is captured (sensitive)',
+      text: 'I have type-2 diabetes.',
+      expect: {
+        facts: [{ predicate: 'health_condition', objectIncludes: 'diabetes' }],
+      },
+    },
+  ],
+};

--- a/src/ingest/dto/ingest-mention.dto.ts
+++ b/src/ingest/dto/ingest-mention.dto.ts
@@ -44,4 +44,15 @@ export class IngestMentionDto {
 
   @IsISO8601()
   emittedAt: string;
+
+  /**
+   * Per-user memory scope (migration 0055). When set (or pinned from a
+   * user-bound token), the entities and facts extracted from this mention
+   * are stamped with this userId, so the fail-closed read fence only
+   * surfaces them to the same user + tenant-global reads. Omitted →
+   * tenant-global, byte-identical to the historical behaviour. This is the
+   * ingestion axis persona / personal-memory packs rely on.
+   */
+  @IsOptional() @IsString()
+  userId?: string;
 }

--- a/src/ingest/edge-writer.ts
+++ b/src/ingest/edge-writer.ts
@@ -17,19 +17,29 @@ export async function createEdgeBetween(
     toEntityId: string;
     kind: string;
     source: Record<string, unknown>;
+    /** User scope (0055). Stamped onto the edge so a personal social link
+     *  (e.g. persona family_of) is fenced to the same user + tenant-global
+     *  reads. Omitted → tenant-global, unchanged. */
+    userId?: string;
   },
 ): Promise<string | null> {
   const fromRid = new StringRecordId(p.fromEntityId);
   const toRid = new StringRecordId(p.toEntityId);
+  // `option<string>` rejects NULL — the global path must OMIT userId (drops
+  // to NONE), never set it to null, so unscoped edges stay byte-identical.
+  const content: Record<string, unknown> = {
+    kind: p.kind,
+    weight: 1.0,
+    source: p.source,
+    ...(p.userId ? { userId: p.userId } : {}),
+  };
   try {
     const [edgeRows] = await db.query<[any[]]>(
-      `RELATE $from->knowledge_edge->$to CONTENT { kind: $kind, weight: $weight, source: $source } RETURN AFTER`,
+      `RELATE $from->knowledge_edge->$to CONTENT $content RETURN AFTER`,
       {
         from: fromRid,
         to: toRid,
-        kind: p.kind,
-        weight: 1.0,
-        source: p.source,
+        content,
       },
     );
     const edge = ((edgeRows as any[]) ?? [])[0];

--- a/src/ingest/entity-upsert.service.ts
+++ b/src/ingest/entity-upsert.service.ts
@@ -106,21 +106,29 @@ export class EntityUpsertService {
     hint,
     _contextRef,
     incomingFacts = [],
+    userId,
   }: {
     db: Surreal;
     e: { name: string; type: string; canonical?: string };
     hint: { vertical: string; id: string; role?: string } | undefined;
     _contextRef: { vertical: string };
     incomingFacts?: string[];
+    /** User scope (0055). When set, the entity is resolved/created within
+     *  the user's private scope; omitted → tenant-global (unchanged). */
+    userId?: string;
   }): Promise<string> {
-    // 1. Caller hint wins — same atomic upsert as fact ingest.
+    // 1. Caller hint wins — same atomic upsert as fact ingest. Fold the
+    // user scope into the ref key + stamp it so a hinted personal entity
+    // never collides with the tenant-global ref for the same (vertical, id).
     if (hint) {
-      const hintKey = externalRefKey(hint.vertical, hint.id);
+      const baseKey = externalRefKey(hint.vertical, hint.id);
+      const hintKey = userId ? `${baseKey}::u::${userId}` : baseKey;
       return this.upsertEntityByExternalRef(db, hintKey, () => ({
         type: this.normalizeEntityType(e.type),
         canonicalName: e.canonical ?? e.name,
         aliases: [e.name],
         externalRefs: { [hintKey]: hint.id },
+        ...(userId ? { userId } : {}),
       }));
     }
 
@@ -132,19 +140,20 @@ export class EntityUpsertService {
     // name canonicalisation is heuristic. Identity merge via
     // ingestLink consolidates downstream.
     const target = (e.canonical ?? e.name).toLowerCase();
-    // This is the tenant-GLOBAL naming path (mention/document ingest never
-    // stamps a userId). Pin `userId IS NONE` so a same-named PERSONAL
-    // entity never matches — otherwise global facts attach to a user's
-    // private entity and leak its identity (externalRefs, canonicalName)
-    // onto the global surface. Mirrors the scope fence on the embedding
-    // resolver (entity-resolver.service.ts).
+    // Scope the match to the SAME axis we'll create on: a user-scoped
+    // ingest matches only that user's entities (never a global or another
+    // user's same-named entity), a global ingest matches only global ones.
+    // The global path pins `userId IS NONE` so a same-named PERSONAL entity
+    // never matches — otherwise global facts attach to a user's private
+    // entity and leak its identity onto the global surface. Mirrors the
+    // scope fence on the embedding resolver (entity-resolver.service.ts).
     const [nRows] = await db.query<any[][]>(
       `SELECT id FROM knowledge_entity
        WHERE (canonicalNameLc = $name
           OR aliases CONTAINS $rawName)
-          AND userId IS NONE
+          AND ${userId ? 'userId = $scopeUserId' : 'userId IS NONE'}
        LIMIT 1`,
-      { name: target, rawName: e.name },
+      { name: target, rawName: e.name, ...(userId ? { scopeUserId: userId } : {}) },
     );
     const nRow = ((nRows as any[]) ?? [])[0];
     if (nRow) return String(nRow.id);
@@ -154,7 +163,10 @@ export class EntityUpsertService {
     // an LLM judge confirm same-as using the incoming facts. A confirmed
     // match reuses the existing entity, so the duplicate is never created.
     // Falls through to create-new when disabled, no match, or any error.
-    if (this.entityResolver?.isEnabled()) {
+    // Scoped-ingest skips it: the embedding resolver is a global surface,
+    // so consulting it would risk matching a user's mention onto a global
+    // (or another user's) entity — the exact leak the scope fence prevents.
+    if (!userId && this.entityResolver?.isEnabled()) {
       const resolved = await this.entityResolver.resolveByName({
         db,
         name: e.name,
@@ -169,6 +181,7 @@ export class EntityUpsertService {
       canonicalName: e.canonical ?? e.name,
       aliases: [e.name],
       externalRefs: {},
+      ...(userId ? { userId } : {}),
     });
     return String(created?.id);
   }

--- a/src/ingest/mention-ingest.service.ts
+++ b/src/ingest/mention-ingest.service.ts
@@ -4,6 +4,7 @@ import { IngestMentionDto } from './dto/ingest-mention.dto';
 import { traceSpan } from '../common/debug-trace';
 import { MentionExtractionService } from './mention-extraction.service';
 import { MentionPersistService } from './mention-persist.service';
+import { pinUserScope } from '../auth/user-scope';
 
 /**
  * The mention ingest path (`ingestMention`): free-text → LLM extraction → fact
@@ -20,6 +21,10 @@ export class MentionIngestService {
   ) {}
 
   async ingestMention(companyId: string, dto: IngestMentionDto) {
+    // A user-bound token pins the caller-asserted userId to the token's
+    // end-user (403 on mismatch); M2M credentials pass their asserted
+    // userId through unchanged. Mirrors FactIngestService.
+    dto = { ...dto, userId: pinUserScope(dto.userId) };
     try {
       return await this.run(companyId, dto);
     } catch (err) {

--- a/src/ingest/mention-persist.service.ts
+++ b/src/ingest/mention-persist.service.ts
@@ -84,6 +84,7 @@ export class MentionPersistService {
             hint: knownHint,
             _contextRef: dto.contextRef,
             incomingFacts,
+            userId: dto.userId,
           }),
         { name: e.name, type: e.type },
       );
@@ -119,6 +120,7 @@ export class MentionPersistService {
             source,
             validFrom: new Date(dto.emittedAt),
             precomputedEmbedding: factEmbeddings[i],
+            userId: dto.userId,
           }),
         { predicate: f.predicate, entityId: eid },
       );
@@ -149,6 +151,7 @@ export class MentionPersistService {
       source: MentionSource;
       validFrom: Date;
       precomputedEmbedding: number[] | undefined;
+      userId?: string;
     },
   ): Promise<string | null> {
     const { f } = p;
@@ -164,6 +167,7 @@ export class MentionPersistService {
       source: p.source,
       entropy,
       precomputedEmbedding: p.precomputedEmbedding,
+      userId: p.userId,
     });
 
     const factId = result?.factId ? String(result.factId) : null;
@@ -220,6 +224,7 @@ export class MentionPersistService {
                 messageId: dto.contextRef.messageId,
                 confidence: e.confidence,
               },
+              userId: dto.userId,
             }),
           { kind: e.kind, from: fromEid, to: toEid },
         );

--- a/test/industry-packs.unit-spec.ts
+++ b/test/industry-packs.unit-spec.ts
@@ -72,6 +72,7 @@ describe('first-party pack library', () => {
       'insurance',
       'legal',
       'medical',
+      'persona',
       'real_estate',
     ]);
   });

--- a/test/mention-user-scope.unit-spec.ts
+++ b/test/mention-user-scope.unit-spec.ts
@@ -1,0 +1,104 @@
+/**
+ * A0 — mention-path user scoping (migration 0055). Persona / personal
+ * memory ingested via the mention path must stamp userId onto the
+ * resolved entity and scope the canonical-name match to the user, so the
+ * fail-closed read fence only surfaces it to that user. Omitted userId
+ * stays tenant-global (byte-identical).
+ */
+import { dbCreate } from '../src/db/surreal.service';
+import { EntityUpsertService } from '../src/ingest/entity-upsert.service';
+
+jest.mock('../src/db/surreal.service', () => ({
+  __esModule: true,
+  dbCreate: jest.fn(),
+  retryOnUniqueViolation: (fn: () => unknown) => fn(),
+  runTransaction: jest.fn(),
+  isUniqueViolation: () => false,
+}));
+
+const mockDbCreate = dbCreate as jest.Mock;
+
+function fakeDb(queryImpl: (sql: string, params: any) => unknown) {
+  return { query: jest.fn(queryImpl) } as never;
+}
+
+describe('resolveOrCreateNamedEntity — user scope', () => {
+  beforeEach(() => mockDbCreate.mockReset());
+
+  const svc = new EntityUpsertService();
+  const e = { name: 'Maria', type: 'customer' };
+
+  it('scopes the canonical-name match to the user when userId is set', async () => {
+    let capturedSql = '';
+    let capturedParams: any = {};
+    const db = fakeDb((sql, params) => {
+      capturedSql = sql;
+      capturedParams = params;
+      return [[{ id: 'knowledge_entity:maria_u' }]]; // match found
+    });
+
+    const id = await svc.resolveOrCreateNamedEntity({
+      db,
+      e,
+      hint: undefined,
+      _contextRef: { vertical: 'persona' },
+      userId: 'user-7',
+    });
+
+    expect(id).toBe('knowledge_entity:maria_u');
+    expect(capturedSql).toContain('userId = $scopeUserId');
+    expect(capturedSql).not.toContain('userId IS NONE');
+    expect(capturedParams.scopeUserId).toBe('user-7');
+  });
+
+  it('pins the global path to userId IS NONE when userId is omitted', async () => {
+    let capturedSql = '';
+    const db = fakeDb((sql) => {
+      capturedSql = sql;
+      return [[{ id: 'knowledge_entity:maria_global' }]];
+    });
+
+    const id = await svc.resolveOrCreateNamedEntity({
+      db,
+      e,
+      hint: undefined,
+      _contextRef: { vertical: 'persona' },
+    });
+
+    expect(id).toBe('knowledge_entity:maria_global');
+    expect(capturedSql).toContain('userId IS NONE');
+    expect(capturedSql).not.toContain('$scopeUserId');
+  });
+
+  it('stamps userId on a freshly-created entity (canonical miss)', async () => {
+    const db = fakeDb(() => [[]]); // canonical miss
+    mockDbCreate.mockResolvedValue({ id: 'knowledge_entity:new' });
+
+    const id = await svc.resolveOrCreateNamedEntity({
+      db,
+      e,
+      hint: undefined,
+      _contextRef: { vertical: 'persona' },
+      userId: 'user-7',
+    });
+
+    expect(id).toBe('knowledge_entity:new');
+    const [, , content] = mockDbCreate.mock.calls[0];
+    expect(content.userId).toBe('user-7');
+  });
+
+  it('does NOT stamp userId on a global create', async () => {
+    const db = fakeDb(() => [[]]);
+    mockDbCreate.mockResolvedValue({ id: 'knowledge_entity:new_global' });
+
+    await svc.resolveOrCreateNamedEntity({
+      db,
+      e,
+      hint: undefined,
+      _contextRef: { vertical: 'persona' },
+    });
+
+    const [, , content] = mockDbCreate.mock.calls[0];
+    expect(content.userId).toBeUndefined();
+  });
+});

--- a/test/persona-pack.unit-spec.ts
+++ b/test/persona-pack.unit-spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Persona Domain Pack — personal user memory (Synthius-Mem-inspired).
+ * First first-party pack to carry a `sensitive` + requiresScope predicate
+ * and an enum predicate. Guards: manifest validity, JSON lockstep,
+ * extractionProfile shape, and the routing decisions that keep the pack
+ * from colliding with core `preference` / `intent`.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  BUILTIN_PACKS,
+  packChecksum,
+  PERSONA_PACK,
+  validatePack,
+  type DomainPackManifest,
+} from '../src/ai/domain-packs';
+
+describe('persona pack', () => {
+  it('is a valid pack', () => {
+    expect(() => validatePack(PERSONA_PACK)).not.toThrow();
+  });
+
+  it('declares the expected localIds', () => {
+    const localIds = PERSONA_PACK.predicates.map((p) => p.localId).sort();
+    expect(localIds).toEqual([
+      'closeness',
+      'dislike',
+      'education',
+      'employer',
+      'felt',
+      'health_condition',
+      'life_event',
+      'occupation',
+      'relationship_role',
+      'skill',
+    ]);
+  });
+
+  it('does NOT shadow core preference / intent (routing collision guard)', () => {
+    const localIds = PERSONA_PACK.predicates.map((p) => p.localId);
+    expect(localIds).not.toContain('preference');
+    expect(localIds).not.toContain('intent');
+    // Positive likes route to core preference — the extractionProfile must say so.
+    expect(PERSONA_PACK.extractionProfile?.guidance).toMatch(/core preference/i);
+  });
+
+  it('gates health_condition as sensitive + requiresScope', () => {
+    const health = PERSONA_PACK.predicates.find(
+      (p) => p.localId === 'health_condition',
+    );
+    expect(health?.piiClass).toBe('sensitive');
+    expect(health?.requiresScope).toBe('brain:read_pii');
+  });
+
+  it('closeness is an enum with the three closeness levels', () => {
+    const closeness = PERSONA_PACK.predicates.find(
+      (p) => p.localId === 'closeness',
+    );
+    expect(closeness?.datatype).toBe('enum');
+    expect(closeness?.allowedValues).toEqual(['close', 'moderate', 'distant']);
+  });
+
+  it('models work history with bitemporal occupation/employer', () => {
+    const occ = PERSONA_PACK.predicates.find((p) => p.localId === 'occupation');
+    const emp = PERSONA_PACK.predicates.find((p) => p.localId === 'employer');
+    expect(occ?.semantics).toBe('bitemporal');
+    expect(emp?.semantics).toBe('bitemporal');
+  });
+
+  it('ships an extractionProfile + eval fixtures', () => {
+    expect(PERSONA_PACK.extractionProfile?.guidance?.length ?? 0).toBeGreaterThan(0);
+    expect(PERSONA_PACK.extractionProfile?.fewShot?.length ?? 0).toBeGreaterThan(0);
+    expect(PERSONA_PACK.evalFixtures?.length ?? 0).toBeGreaterThan(0);
+    for (const f of PERSONA_PACK.evalFixtures ?? []) {
+      expect((f.expect.facts ?? []).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('is DISTRIBUTABLE — not a builtin', () => {
+    expect(BUILTIN_PACKS.some((p) => p.id === 'persona')).toBe(false);
+  });
+
+  it('the committed JSON artifact matches the TS source of truth', () => {
+    const jsonPath = join(__dirname, '..', 'packs', 'persona.pack.json');
+    const fromJson = JSON.parse(
+      readFileSync(jsonPath, 'utf8'),
+    ) as DomainPackManifest;
+    expect(fromJson).toEqual(PERSONA_PACK);
+    expect(packChecksum(fromJson)).toBe(packChecksum(PERSONA_PACK));
+  });
+});


### PR DESCRIPTION
## Motivation

From the [synthius.ai](https://synthius.ai) analysis (a persona-memory system with six cognitive domains): add a first-party `persona` pack modelling an end user's personal memory, and close a scoping gap it exposed in the mention ingest path.

## `persona` pack (7th first-party, distributable)

10 predicates covering biography (`education`, `health_condition`), episodic experiences (`life_event`, `felt`), negative preferences (`dislike`), social circle (`relationship_role`, `closeness`), and work (`occupation`, `employer`, `skill`).

Scope decisions baked into the extractionProfile:
- Identity (name/dob/address/…) and **positive** likes route to CORE predicates — `persona__preference` is deliberately **not** declared (it would be an extractor routing collision with core `preference`).
- Social links between people stay `knowledge_edge` kinds (`family_of` / `friend_of` / `colleague_of`); the pack predicates attach to the contact entity.
- `health_condition` is `piiClass: sensitive` + `requiresScope: brain:read_pii` (first pack predicate to carry a scope; mirrors core `dob`).
- Psychometrics (Big Five numeric scores) is deferred to v2 — numeric framework scores don't fit the verbatim-string fact model.

## Sub-task A0 — mention-path user scoping

Persona is per-user memory, but the mention/extraction ingest path never carried a `userId`, so extraction-derived facts landed **tenant-global even for user-bound tokens**. This threads `userId` through:

`IngestMentionDto.userId` → `pinUserScope` (403 on token mismatch, same as `FactIngestService`) → entity resolution (scoped canonical match + `userId` stamp + `::u::` refKey; the global embedding resolver is skipped for scoped ingests to avoid cross-scope entity leaks) → fact resolver → edge writer (`userId` stamped only when set; `option<string>` rejects NULL so the global path omits the field → byte-identical).

## Testing

`test/persona-pack` (validity, JSON lockstep, sensitive/requiresScope, enum, no core-shadow), `test/mention-user-scope` (scoped canonical match, userId stamp, global path unchanged), `test/industry-packs` (7-pack collision-free seed). Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBfnGNiT3f1S3bnnx1VQuB