### PR TITLE
feat(engine): V4 carried fixes — derive failure propagation, W2/W4 read-path work, S5.2 shrink

### DIFF
--- a/docs/architecture-manifest.md
+++ b/docs/architecture-manifest.md
@@ -1,0 +1,124 @@
+# Memory is a profile of capabilities, not a speed
+
+Status: draft thesis (2026-08). Evidence citations refer to the eval
+program documented in [eval-protocol.md](eval-protocol.md) and the
+roadmap results docs; numbers are paired-McNemar unless noted.
+
+## The claim
+
+Memory systems get compared the way engines get compared on a dyno:
+one number per system, bigger is better. Every vendor leaderboard and
+most papers work this way. The claim of this document is that the
+scalar does not exist. A memory engine has no single quality; it has a
+**capability profile** — a vector of abilities (verbatim recall,
+cross-session aggregation, temporal reasoning, contradiction handling,
+abstention, …) whose values are set by *mechanism choices*, and every
+mechanism that raises one ability lowers another. A benchmark is not a
+grade; it is a **genre** — a weighting over that vector. Optimizing
+"the number" without naming the genre silently trades capabilities you
+are not measuring.
+
+This is not a philosophical position. We measured it, from both
+directions, on one engine.
+
+## The evidence
+
+**Same engine, two profiles, 14.5pp apart — both correct.** On LoCoMo
+dev-5 (diary-genre dialogues) the engine's shipping defaults — the
+assistant-chat profile — score 62.1%. The same engine, same commit,
+with the dialogue profile (open-vocabulary extraction, event-time
+anchoring, episode substrate, derived windows, verbatim evidence
+always on) scores 76.6% (p=1.2e-11 between them). Neither number is a
+bug. Each profile is the right answer for its genre; the −14.5pp is
+what it costs to read a diary with CRM glasses.
+([validate-2026-08-results](roadmap/validate-2026-08-results.md))
+
+**One mechanism, opposite signs by genre.** The segment lane
+(retrieving composed conversational windows) was the single biggest
+win in the LoCoMo lineage — and on LongMemEval assistant chats it
+*costs* 28pp (80.0 lane-off vs 52 lane-on, p=5e-04), and on BEAM-100K
+it more than halves the score (31.1 vs 12.5). The same code is the
+best and the worst component we own, depending on corpus genre.
+([locomo-sota-architecture](roadmap/locomo-sota-architecture-2026-07.md))
+
+**The field measured the same law and named it.** Extraction
+pipelines destroy single-session-assistant recall — old Mem0 scored
+26.8 on SSA in the same harness where full-context scores 98.2, and
+Mem0's 2026 rewrite (verbatim storage) took it to 98.2. Meanwhile
+extraction is precisely what wins multi-hop and temporal reasoning
+over raw context. Extraction vs verbatim is not better-vs-worse; it is
+a capability trade the leaderboard scalar hides.
+([lme-sota-research](roadmap/lme-sota-research-2026-08.md))
+
+**Even "the same memory" has no number.** With retrieval frozen,
+swapping the reader model moves per-type accuracy by 7–31pp (Memoria:
+knowledge-update 58.4 → 89.6 across readers; abstention 56.7 → 93.3).
+A memory score that does not name the reader and the token budget is
+not a measurement.
+
+**Mechanism choices are profile choices all the way down.** Temporal
+handled as a hard filter gives clean compliance and a recall cliff on
+a bad asOf; interval-overlap scoring with distance decay (Hindsight,
+91.0 TR) gives soft recall and fuzzier compliance. Neither is "the
+fix"; they are two points on the strict↔soft axis, and different
+tenants legitimately want different points.
+
+## What this forces architecturally
+
+**1. One engine; genres are configuration.** If capability profiles
+are real, the engine must not fork per benchmark — a fork per genre is
+how you end up with "measured-good components wired by flag history"
+(the verdict of our own architecture audit). Capabilities live in
+engine code, once. Genre selection lives in the per-tenant
+**RetrievalProfile** — canonical keys, resolved per request, printed
+into every eval report's provenance header. Forks are git branches
+that die; profiles are the product surface. (This is the
+no-eval-forks rule, now enforced by gates.)
+
+**2. A benchmark score without a profile is noise.** Every eval
+report carries the git SHA and the resolved profile of the run. "We
+score X on Y" is meaningless until it reads "profile P scores X on
+genre Y with reader R at T tokens/question." This is also how we
+caught our own brief lying about a record config.
+
+**3. Prefer question shape over deployment state.** Where a genre law
+can be detected per-question (verbatim-shape questions pull episode
+quotes regardless of lane flags), encode it in the router — one
+tenant's mixed corpus then gets per-question behavior instead of a
+tenant-wide compromise. Deployment-level genre pins are the fallback,
+not the mechanism.
+
+**4. Defaults are a genre pick and must say so.** There is no neutral
+default. Our defaults are the assistant-chat profile; the deployment
+env says `RETRIEVAL_GENRE=assistant_chat` as intent documentation, and
+diary-genre evals MUST pin the dialogue profile. A default that does
+not name its genre will eventually be mistaken for the engine itself —
+that mistake cost us a 12pp phantom regression in V2.
+
+**5. "SOTA" is a per-genre claim.** Parity with a leader means
+matching them on their genre, their reader class, their token budget —
+all three stated. Chasing a scalar across genres produces exactly the
+flag archaeology this codebase spent a refactor digging out of.
+
+## What it predicts
+
+Falsifiable consequences we are willing to bet the roadmap on:
+
+- A new mechanism that wins on one axis and is not measured on the
+  other two will regress at least one of them. (History: every
+  segment-lane, date-context, and ordering-frame leg.)
+- Cross-genre "universal" gains exist but are rare and live in the
+  engine's shared substrate (extraction fidelity, date normalization,
+  reranking) — not in genre mechanisms. Those are the only changes
+  that should ever touch defaults.
+- A tenant-facing profile switch (diary vs assistant-chat) will
+  outperform any single tuned default on a mixed customer base.
+- Any eval leg whose report lacks a resolved-profile header will
+  eventually be misread and cost a session of forensics. (History:
+  twice.)
+
+## The one-line version
+
+We do not ship a memory speed. We ship a memory *engine* with a
+measured capability surface, and tenants pick a point on it. The
+benchmark table is a map of genres, not a podium.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1863,6 +1863,11 @@
             "minimum": -9007199254740991,
             "type": "integer"
           },
+          "failed": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
           "previousVersion": {
             "anyOf": [
               {
@@ -1902,6 +1907,14 @@
             },
             "type": "array"
           },
+          "status": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed"
+            ],
+            "type": "string"
+          },
           "unresolvedSubjects": {
             "maximum": 9007199254740991,
             "minimum": -9007199254740991,
@@ -1913,7 +1926,9 @@
           "sessions",
           "propositions",
           "unresolvedSubjects",
-          "skipped"
+          "skipped",
+          "status",
+          "failed"
         ],
         "type": "object"
       },

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -220,8 +220,10 @@ default; `RETRIEVAL_PROFILE_OVERRIDES` overlays per tenant.
 | Key | Default | What it does |
 |---|---|---|
 | `RETRIEVAL_GENRE` | `assistant_chat` | Names the corpus shape (`dialogue` \| `assistant_chat` \| `documents`) so per-tenant overrides read as intent. The dimensions the engine actually branches on are the two below. |
-| `RETRIEVAL_VERBATIM_EVIDENCE` | `shape_conditioned` | How verbatim L0 evidence reaches synthesis: `off` (facts only), `shape_conditioned` (episode quotes + provenance excerpts only when the question asks for conversational content — the engine default), `always` (all verbatim lanes unconditionally; the diary-genre profile). |
+| `RETRIEVAL_VERBATIM_EVIDENCE` | `shape_conditioned` | How verbatim L0 evidence reaches answers: `off` (facts only), `shape_conditioned` (episode quotes + provenance excerpts only when the question asks for conversational content — the engine default), `always` (all verbatim lanes unconditionally as a prompt appendix; the diary-genre profile), `fused` (segments become scored, reranked, citable SearchHits inside the search pipeline instead of an appendix). |
 | `RETRIEVAL_DATE_ANCHORING` | `absolute` | How the generator's "today" anchors: `none` (session-date-convention golds, e.g. the LoCoMo eval profile), `session_date` (only when the caller sends `asOf`), `absolute` (asOf, else wall clock). |
+| `RETRIEVAL_TEMPORAL_MODE` | `filter` | How an explicit `asOf` shapes retrieval: `filter` (strict bitemporal point-in-time closure), `overlap_boost` (the validity gate is relaxed; facts outside the interval survive with an exponential distance decay on their score — a slightly-wrong asOf degrades results instead of emptying them). |
+| `RETRIEVAL_ENTITY_EXPANSION` | off | Second retrieval pass anchored on the top entities the first pass discovered and the query never named. Costs one extra embedding + two leg queries when it fires; enable per genre after measuring. |
 | `RETRIEVAL_PROFILE_OVERRIDES` | — | JSON object mapping companyId → partial profile (`lanes` as an array of lane ids). Malformed per-tenant entries are ignored; the JSON shape is boot-validated. |
 
 Introspection: `GET /v1/admin/retrieval-profile` (brain:admin) returns

--- a/docs/roadmap/validate-2026-08-results.md
+++ b/docs/roadmap/validate-2026-08-results.md
@@ -174,16 +174,45 @@ OpenAI spend in Grafana. Expected quiet: prod already ran the reranker
 ON, so the capability fold changes nothing there; the real deltas are
 HyPE and the predicate router turning off with their deleted code.
 
-## Carried into V4
+## Carried into V4 — EXECUTED (2026-08-05, feat/engine-v4-carried)
 
-- `maintenance/derive` must propagate derive failures instead of
-  WARN+201 — a silent 201 on a failed derive is how a poisoned eval
-  row is born (bit us live this session).
-- The audit carry-list unchanged: temporal overlap boost; verbatim as
-  a fusion leg in SearchHit; entity-expansion rewrite; releasing the
-  scoped connection across LLM awaits; segment/aggregate version
-  columns + staging-swap; dreams version-awareness; shrink the S5.2
-  env allowlist to one search bootstrap module.
-- Candidate: an architecture thesis doc ("memory is a profile of
-  capabilities, not a speed") — the genre-law now has measured
-  evidence from both directions.
+All eight carried items landed as one PR-sized branch, each with unit
+coverage and the six gates green:
+
+- `maintenance/derive` propagates failures: DeriveRunResult grows
+  `status`/`failed`, total failure → registry `failed` + HTTP 502,
+  activation requires a clean run, and the eval driver refuses to QA
+  any non-ok derive (rows error instead of checkpointing).
+- Temporal overlap boost: profile key `RETRIEVAL_TEMPORAL_MODE`
+  (`filter` default | `overlap_boost` — validity closure relaxed,
+  Hindsight-style interval-overlap decay in scoring).
+- Verbatim as a fusion leg: `RETRIEVAL_VERBATIM_EVIDENCE=fused` —
+  segments retrieved inside the pipeline through the same convex
+  fusion, scored, reranked, citable as SearchHits; the appendix lane
+  stays byte-identical under `always`.
+- Entity-expansion second retrieval: profile key
+  `RETRIEVAL_ENTITY_EXPANSION` (default off) — top discovered entity
+  names anchor one more legs+fusion pass before scoring.
+- Scoped connection released across LLM awaits: the pipeline is now
+  runDbStages (inside the pool slot, ends by prefetching rerank
+  neighbourhoods) + rankAndAssemble (cross-encoder + LLM rerank +
+  assembly, connectionless).
+- Segments/aggregates: atomic staging-swap (paid calls before any
+  delete; delete+insert in one transaction), migration 0081 adds the
+  per-run `generation` stamp on episode_segment.
+- Dreams version-aware: every leg (dedup, resolve, corroborate,
+  communities) fenced to the tenant's live derived world via
+  ReadPinService + the new shared `derivedVersionFence()`.
+- S5.2 env allowlist = exactly one module: `retrieval-profile.ts`
+  (new `resolveSearchTuning()` snapshot in the PipelineContext; legs'
+  import-time SQL constants became per-call; derived-version fallbacks
+  route through `ReadPinService.bootstrapDefault()`).
+
+The architecture thesis doc shipped as
+[docs/architecture-manifest.md](../architecture-manifest.md) ("memory
+is a profile of capabilities, not a speed") — draft, pending owner
+review.
+
+None of the new profile points (overlap_boost / fused /
+entityExpansion) are default-on: defaults are byte-identical to V3
+prod, and each is a measured-leg candidate for the next eval session.

--- a/src/admin/admin-derive.controller.ts
+++ b/src/admin/admin-derive.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadGatewayException,
   BadRequestException,
   Body,
   Controller,
@@ -14,6 +15,27 @@ import {
   DeriveRunResult,
   WINDOW_DERIVER_VERSION,
 } from './window-deriver.service';
+
+/**
+ * A derive where every attempted conversation failed produced nothing:
+ * answering 201 would hand the caller a hollow world (the V2 incident —
+ * an OpenAI 429 became 18 poisoned eval rows). 502 says "upstream broke,
+ * nothing was derived, retry when it recovers". Partial failures still
+ * return the result — callers must check `status`/`failed`.
+ */
+export function throwIfDeriveFailed(result: DeriveRunResult): DeriveRunResult {
+  if (result.status === 'failed') {
+    throw new BadGatewayException({
+      message:
+        `derive failed: 0 of ${result.failed} conversation(s) derived — ` +
+        `first reason: ${result.skipped[0]?.reason}`,
+      status: result.status,
+      failed: result.failed,
+      skipped: result.skipped.slice(0, 10),
+    });
+  }
+  return result;
+}
 
 /**
  * Explicit trigger for the session-window batch deriver (P3 v1). One LLM
@@ -65,12 +87,14 @@ export class AdminDeriveController {
       throw new BadRequestException('conversation id too long');
     }
     try {
-      return await this.deriver.run(tenant, {
-        version,
-        conversationId,
-        activate: body.activate === true,
-        force: body.force === true,
-      });
+      return throwIfDeriveFailed(
+        await this.deriver.run(tenant, {
+          version,
+          conversationId,
+          activate: body.activate === true,
+          force: body.force === true,
+        }),
+      );
     } catch (e) {
       // The live-pin guard is a caller mistake, not a server fault.
       if ((e as Error).message.includes('live read pin')) {

--- a/src/admin/aggregate-composer.service.ts
+++ b/src/admin/aggregate-composer.service.ts
@@ -1,9 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
-import { StringRecordId } from 'surrealdb';
+import { StringRecordId, type Surreal } from 'surrealdb';
 import { createOpenAiClientOrThrow } from '../ai/openai-client';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, runTransaction } from '../db/surreal.service';
 import { FactEmbeddingService } from '../ingest/fact-embedding.service';
 
 /**
@@ -25,7 +25,8 @@ import { FactEmbeddingService } from '../ingest/fact-embedding.service';
  * Deliberately NOT routed through fn::resolve_fact: these are synthetic
  * derived rows — the bitemporal resolver's supersede/corroborate
  * semantics are for observations, and a re-run replaces aggregates
- * wholesale (delete-by-recorder, then create).
+ * wholesale (delete-by-recorder + insert, one atomic transaction; all
+ * paid calls happen before the swap).
  */
 export const AGGREGATE_RECORDER = 'aggregate-composer-v1';
 
@@ -156,53 +157,51 @@ export class AggregateComposerService {
         a.members.every((m) => m >= 0 && m < facts.length) &&
         a.proposition.trim().length > 0,
     );
-    // Wholesale replace: aggregates are derived state, a re-run owns them.
-    await db.query(
-      `DELETE knowledge_fact
-        WHERE entityId = $eid AND source.recorder = $recorder
-          ${versionClause}`,
-      {
-        eid: new StringRecordId(entityId),
-        recorder: AGGREGATE_RECORDER,
-        version,
-      },
-    );
-    if (valid.length === 0) return 0;
-
-    const vectors = await this.embedding.embedMany(
-      valid.map((a) => a.proposition),
-    );
-    for (const [i, agg] of valid.entries()) {
+    // Every paid step (LLM above, embeddings here) runs BEFORE the delete
+    // — a failure leaves the previous aggregates intact.
+    const vectors =
+      valid.length > 0
+        ? await this.embedding.embedMany(valid.map((a) => a.proposition))
+        : [];
+    const rows = valid.map((agg, i) => {
       const slug = agg.aspect
         .toLowerCase()
         .replace(/[^a-z0-9_]+/g, '_')
         .slice(0, 40);
-      await db.query(
-        `CREATE knowledge_fact CONTENT {
-           entityId: $eid,
-           predicate: $predicate,
-           object: $object,
-           confidence: 0.9,
-           validFrom: time::now(),
-           source: { vertical: 'aggregate', recorder: $recorder },
-           status: 'active',
-           embedding: $embedding,
-           derivedFrom: $derivedFrom,
-           derivedVersion: $version
-         }`,
-        {
-          eid: new StringRecordId(entityId),
-          predicate: `aggregate_${slug}`,
-          object: agg.proposition,
-          recorder: AGGREGATE_RECORDER,
-          embedding: vectors[i],
-          derivedFrom: agg.members.map(
-            (m) => new StringRecordId(String(facts[m].id)),
-          ),
-          version,
-        },
+      return {
+        entityId: new StringRecordId(entityId),
+        predicate: `aggregate_${slug}`,
+        object: agg.proposition,
+        confidence: 0.9,
+        validFrom: new Date(),
+        source: { vertical: 'aggregate', recorder: AGGREGATE_RECORDER },
+        status: 'active',
+        embedding: vectors[i],
+        derivedFrom: agg.members.map(
+          (m) => new StringRecordId(String(facts[m].id)),
+        ),
+        ...(version ? { derivedVersion: version } : {}),
+      };
+    });
+    // Wholesale replace: aggregates are derived state, a re-run owns
+    // them. Atomic swap (audit W2 #10/#11): the delete and the insert
+    // share one transaction, so a retrieval that lands mid-rerun sees
+    // the previous aggregate set or the new one — never an entity with
+    // its enumerations missing. (Under a pinned world the composer
+    // deliberately writes INTO the pin — that is the R4 flow — which is
+    // exactly why the swap must be atomic rather than fork-guarded.)
+    await runTransaction(db as unknown as Surreal, (tx) => {
+      tx.add(
+        `DELETE knowledge_fact
+          WHERE entityId = $eid AND source.recorder = $recorder
+            ${versionClause}`,
       );
-    }
+      if (rows.length > 0) tx.add(`INSERT INTO knowledge_fact $rows`);
+      tx.bind('eid', new StringRecordId(entityId))
+        .bind('recorder', AGGREGATE_RECORDER)
+        .bind('version', version)
+        .bind('rows', rows);
+    });
     return valid.length;
   }
 

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -775,6 +775,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
           "How the generator's \"today\" anchors: none (session-date-convention golds) | session_date (only when the caller sends asOf) | absolute (asOf, else wall clock — the engine default). Unset → derived from SYNTHESIZE_DATE_CONTEXT.",
       },
       {
+        key: 'RETRIEVAL_ENTITY_EXPANSION',
+        category: 'pipeline',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Entity-expansion second retrieval (profile field entityExpansion): after the first legs+fusion pass, the top discovered entity names the query never mentioned anchor one more legs+fusion pass before scoring — the SmartSearch multi-session lever. Costs one extra embedding + two leg queries per search. Default off; enable per genre after measuring.',
+      },
+      {
         key: 'RETRIEVAL_TEMPORAL_MODE',
         category: 'pipeline',
         defaultValue: 'filter',

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -775,13 +775,22 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
           "How the generator's \"today\" anchors: none (session-date-convention golds) | session_date (only when the caller sends asOf) | absolute (asOf, else wall clock — the engine default). Unset → derived from SYNTHESIZE_DATE_CONTEXT.",
       },
       {
+        key: 'RETRIEVAL_TEMPORAL_MODE',
+        category: 'pipeline',
+        defaultValue: 'filter',
+        runtimeMutable: true,
+        isBooleanFlag: false,
+        description:
+          'How an explicit asOf shapes retrieval: filter (bitemporal closure excludes facts not valid at asOf — strict point-in-time, the default) | overlap_boost (validity closure relaxed; facts outside the interval survive with an exponential distance decay on their score — soft recall, a slightly-wrong asOf degrades instead of emptying results).',
+      },
+      {
         key: 'RETRIEVAL_PROFILE_OVERRIDES',
         category: 'pipeline',
         defaultValue: null,
         runtimeMutable: true,
         isBooleanFlag: false,
         description:
-          'Per-tenant retrieval-profile overrides: JSON object mapping companyId → partial profile ({genre, verbatimEvidence, dateAnchoring, factBudget, quotesPerPrompt, sourceExcerptsCap, segmentTopK, segmentRerank, extraEvidenceCap, wideProbe, wideProbeLimit, lanes:[…]}). Resolved once per request in the auth guard.',
+          'Per-tenant retrieval-profile overrides: JSON object mapping companyId → partial profile ({genre, verbatimEvidence, dateAnchoring, temporalMode, factBudget, quotesPerPrompt, sourceExcerptsCap, segmentTopK, segmentRerank, extraEvidenceCap, wideProbe, wideProbeLimit, lanes:[…]}). Resolved once per request in the auth guard.',
       },
       {
         key: 'SYNTHESIZE_EXTRA_EVIDENCE_CAP',

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -763,7 +763,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
         runtimeMutable: true,
         isBooleanFlag: false,
         description:
-          'How verbatim L0 evidence reaches synthesis: off | shape_conditioned (engine default — quotes only when the question asks for conversational content) | always (all three verbatim lanes unconditional; diary-genre profile). Unset → derived from the legacy lane flags.',
+          'How verbatim L0 evidence reaches answers: off | shape_conditioned (engine default — quotes only when the question asks for conversational content) | always (all three verbatim lanes unconditional as a prompt appendix; diary-genre profile) | fused (segments become scored, reranked, citable SearchHits inside the search pipeline instead of an appendix). Unset → derived from the legacy lane flags.',
       },
       {
         key: 'RETRIEVAL_DATE_ANCHORING',

--- a/src/admin/projections.controller.ts
+++ b/src/admin/projections.controller.ts
@@ -23,6 +23,7 @@ import {
   WINDOW_DERIVER_VERSION,
   type DeriveRunResult,
 } from './window-deriver.service';
+import { throwIfDeriveFailed } from './admin-derive.controller';
 
 /**
  * Public projections API (raw-substrate driver v1, surface 3 —
@@ -104,12 +105,14 @@ export class ProjectionsController {
       throw new BadRequestException('conversation id too long');
     }
     try {
-      return await this.deriver.run(req.brainAuth.companyId, {
-        version,
-        conversationId,
-        activate: body.activate === true,
-        force: body.force === true,
-      });
+      return throwIfDeriveFailed(
+        await this.deriver.run(req.brainAuth.companyId, {
+          version,
+          conversationId,
+          activate: body.activate === true,
+          force: body.force === true,
+        }),
+      );
     } catch (e) {
       // The live-pin guard is a caller mistake, not a server fault.
       if ((e as Error).message.includes('live read pin')) {

--- a/src/admin/segment-composer.service.ts
+++ b/src/admin/segment-composer.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { StringRecordId } from 'surrealdb';
-import { SurrealService } from '../db/surreal.service';
+import { StringRecordId, type Surreal } from 'surrealdb';
+import { SurrealService, runTransaction } from '../db/surreal.service';
 import { FactEmbeddingService } from '../ingest/fact-embedding.service';
 import { EpisodeReadStoreService } from '../episodes/episode-read-store.service';
 import {
@@ -17,7 +17,12 @@ import {
  * episode substrate. LLM-free: segmentation is positional (SeCom-style
  * topical segmentation is the v2 upgrade if the positional baseline
  * measures well), the only paid step is one embedding batch per
- * conversation. Idempotent: delete-by-conversation, then insert.
+ * conversation. Idempotent per conversation, and atomic (audit W2 #10):
+ * the paid embedding batch runs BEFORE any delete, then the old window
+ * set is swapped for the new one in a single transaction — the segment
+ * lane never reads a conversation mid-rebuild (the old delete-then-
+ * embed-then-insert left it empty for the whole embedding call, and a
+ * crashed run left it empty until the next rebuild).
  */
 export const SEGMENT_RECORDER = 'segment-composer-v1';
 const WINDOW = 4;
@@ -79,12 +84,21 @@ export class SegmentComposerService {
       segments: 0,
       skipped: [],
     };
+    // One generation stamp per run: every row written by this rebuild
+    // carries it, so a partially-failed run is observable (conversations
+    // on the old generation = the ones whose swap never landed).
+    const generation = new Date().toISOString();
     await this.surreal.withCompany(companyId, async (db) => {
       const convs = await this.episodes.conversationCounts(db);
       for (const conv of convs) {
         const conversationId = conv.conversationId;
         try {
-          await this.composeConversation({ db, conversationId, result });
+          await this.composeConversation({
+            db,
+            conversationId,
+            result,
+            generation,
+          });
           result.conversations += 1;
         } catch (e) {
           result.skipped.push({ conversationId, reason: (e as Error).message });
@@ -101,21 +115,18 @@ export class SegmentComposerService {
     db,
     conversationId,
     result,
+    generation,
   }: {
     db: {
       query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T>;
     };
     conversationId: string;
     result: SegmentRunResult;
+    generation: string;
   }): Promise<void> {
     const episodes: SegmentEpisodeRow[] =
       await this.episodes.conversationTurns(db, conversationId);
     if (episodes.length === 0) return;
-
-    await db.query(
-      `DELETE episode_segment WHERE conversationId = $conv`,
-      { conv: conversationId },
-    );
 
     // Session boundaries first (same 60-min gap rule as the deriver), then
     // positional windows within each session — a segment never spans the
@@ -130,6 +141,8 @@ export class SegmentComposerService {
     }
     if (windows.length === 0) return;
 
+    // Paid step BEFORE any delete: an embedding failure now leaves the
+    // old window set intact instead of an emptied conversation.
     const texts = windows.map((w) => renderSegmentText(w.turns));
     const vectors = await this.embedding.embedMany(texts);
     // One multi-row INSERT per conversation — per-segment CREATEs cost a
@@ -151,9 +164,20 @@ export class SegmentComposerService {
         userId: userIds.length === 1 ? userIds[0] : undefined,
         embedding: vectors[i],
         recorder: SEGMENT_RECORDER,
+        generation,
       };
     });
-    await db.query(`INSERT INTO episode_segment $rows`, { rows });
+    // Atomic swap: old windows out, new windows in, one transaction —
+    // readers see the previous set or the new set, never neither. The
+    // delete must precede the insert INSIDE the transaction: (conv, seq)
+    // is UNIQUE and the new generation reuses the same seq values.
+    await runTransaction(db as unknown as Surreal, (tx) =>
+      tx
+        .add(`DELETE episode_segment WHERE conversationId = $conv`)
+        .add(`INSERT INTO episode_segment $rows`)
+        .bind('conv', conversationId)
+        .bind('rows', rows),
+    );
     result.segments += rows.length;
   }
 }

--- a/src/admin/window-deriver.service.ts
+++ b/src/admin/window-deriver.service.ts
@@ -73,12 +73,23 @@ export function buildDeriverSystem(opts?: {
   );
 }
 
+export type DeriveRunStatus = 'ok' | 'degraded' | 'failed';
+
 export interface DeriveRunResult {
   conversations: number;
   sessions: number;
   propositions: number;
   unresolvedSubjects: number;
   skipped: Array<{ conversationId: string; reason: string }>;
+  /**
+   * 'ok' — every targeted conversation derived; 'degraded' — some failed
+   * (skipped carries the reasons); 'failed' — at least one conversation
+   * was attempted and none succeeded. A silent success on a failed derive
+   * is how a poisoned eval row is born — callers must check this field.
+   */
+  status: DeriveRunStatus;
+  /** Mirror of skipped.length, for callers that only read counters. */
+  failed: number;
   /** Set when opts.activate flipped the live read pin to this version. */
   activated?: boolean;
   previousVersion?: string | null;
@@ -182,6 +193,8 @@ export class WindowDeriverService {
       propositions: 0,
       unresolvedSubjects: 0,
       skipped: [],
+      status: 'ok',
+      failed: 0,
     };
     // Registry (driver surface 3): observes the lifecycle, never fails it —
     // every registry write degrades to a warning inside the service.
@@ -216,19 +229,46 @@ export class WindowDeriverService {
       await this.registry?.fail({ companyId, name: 'facts', version });
       throw e;
     }
+    result.failed = result.skipped.length;
+    result.status =
+      result.failed === 0
+        ? 'ok'
+        : result.conversations > 0
+          ? 'degraded'
+          : 'failed';
+    // A run where every attempted conversation failed produced NOTHING —
+    // marking it built/live would let gc protect a hollow world and let
+    // eval drivers QA an empty substrate as if it were legitimate.
+    if (result.status === 'failed') {
+      await this.registry?.fail({ companyId, name: 'facts', version });
+      this.logger.error(
+        `derive '${version}' failed for ${companyId}: all ` +
+          `${result.failed} conversation(s) failed — first reason: ` +
+          `${result.skipped[0]?.reason}`,
+      );
+      return result;
+    }
     // Atomic world flip: readers switch from the old fork to the new one
     // between requests, never mid-build. The flip is a REGISTRY write
     // (complete({live:true}) below marks this version live and demotes
     // the previous one) — audit W2 #9 removed the process.env mutation
     // that made a per-tenant activation repoint every tenant on the pod
     // and stay invisible to every other pod.
-    if (opts.activate && result.conversations > 0) {
+    // Activation additionally requires a CLEAN run: flipping every reader
+    // onto a world with known holes is never what the operator meant.
+    if (opts.activate && result.conversations > 0 && result.failed === 0) {
       result.previousVersion =
         (await this.readPin?.resolve(companyId)) ?? activePin ?? null;
       result.activated = true;
       this.logger.log(
         `derived world '${version}' activated for ${companyId} ` +
           `(was: ${result.previousVersion ?? 'legacy'})`,
+      );
+    } else if (opts.activate && result.failed > 0) {
+      this.logger.warn(
+        `activation of '${version}' refused for ${companyId}: ` +
+          `${result.failed} of ${result.conversations + result.failed} ` +
+          `conversation(s) failed — re-derive the failures, then activate`,
       );
     }
     await this.registry?.complete({

--- a/src/admin/window-deriver.service.ts
+++ b/src/admin/window-deriver.service.ts
@@ -178,7 +178,7 @@ export class WindowDeriverService {
     // the guard and delete-by-version the world another pod served.
     const activePin =
       (await this.readPin?.resolve(companyId)) ??
-      process.env.RETRIEVAL_DERIVED_VERSION?.trim() ??
+      ReadPinService.bootstrapDefault() ??
       undefined;
     if (version === activePin && !opts.force) {
       throw new Error(
@@ -269,7 +269,7 @@ export class WindowDeriverService {
    * Atomic world flip: readers switch from the old fork to the new one
    * between requests, never mid-build. The flip is a REGISTRY write
    * (run()'s complete({live:true}) marks this version live and demotes
-   * the previous one) — audit W2 #9 removed the process.env mutation
+   * the previous one) — audit W2 #9 removed the env-var mutation
    * that made a per-tenant activation repoint every tenant on the pod
    * and stay invisible to every other pod. Activation additionally
    * requires a CLEAN run: flipping every reader onto a world with known
@@ -327,7 +327,8 @@ export class WindowDeriverService {
   ): Promise<{ deleted: Record<string, number>; kept: string[] }> {
     const activePin =
       (await this.readPin?.resolve(companyId)) ??
-      process.env.RETRIEVAL_DERIVED_VERSION?.trim();
+      ReadPinService.bootstrapDefault() ??
+      undefined;
     // Audit W0 (engine-architecture-audit-2026-08.md #8): the registry is
     // part of the keep-set — the env pin is process-local and may be unset
     // on this pod while another pod serves a live world. live/building/

--- a/src/admin/window-deriver.service.ts
+++ b/src/admin/window-deriver.service.ts
@@ -229,17 +229,10 @@ export class WindowDeriverService {
       await this.registry?.fail({ companyId, name: 'facts', version });
       throw e;
     }
-    result.failed = result.skipped.length;
-    result.status =
-      result.failed === 0
-        ? 'ok'
-        : result.conversations > 0
-          ? 'degraded'
-          : 'failed';
     // A run where every attempted conversation failed produced NOTHING —
     // marking it built/live would let gc protect a hollow world and let
     // eval drivers QA an empty substrate as if it were legitimate.
-    if (result.status === 'failed') {
+    if (this.finalizeRunStatus(result) === 'failed') {
       await this.registry?.fail({ companyId, name: 'facts', version });
       this.logger.error(
         `derive '${version}' failed for ${companyId}: all ` +
@@ -248,29 +241,13 @@ export class WindowDeriverService {
       );
       return result;
     }
-    // Atomic world flip: readers switch from the old fork to the new one
-    // between requests, never mid-build. The flip is a REGISTRY write
-    // (complete({live:true}) below marks this version live and demotes
-    // the previous one) — audit W2 #9 removed the process.env mutation
-    // that made a per-tenant activation repoint every tenant on the pod
-    // and stay invisible to every other pod.
-    // Activation additionally requires a CLEAN run: flipping every reader
-    // onto a world with known holes is never what the operator meant.
-    if (opts.activate && result.conversations > 0 && result.failed === 0) {
-      result.previousVersion =
-        (await this.readPin?.resolve(companyId)) ?? activePin ?? null;
-      result.activated = true;
-      this.logger.log(
-        `derived world '${version}' activated for ${companyId} ` +
-          `(was: ${result.previousVersion ?? 'legacy'})`,
-      );
-    } else if (opts.activate && result.failed > 0) {
-      this.logger.warn(
-        `activation of '${version}' refused for ${companyId}: ` +
-          `${result.failed} of ${result.conversations + result.failed} ` +
-          `conversation(s) failed — re-derive the failures, then activate`,
-      );
-    }
+    await this.maybeActivate({
+      companyId,
+      version,
+      activate: opts.activate === true,
+      activePin,
+      result,
+    });
     await this.registry?.complete({
       companyId,
       name: 'facts',
@@ -286,6 +263,57 @@ export class WindowDeriverService {
     // Readers cache the pin briefly; an activation must land at once.
     if (result.activated) this.readPin?.invalidate(companyId);
     return result;
+  }
+
+  /**
+   * Atomic world flip: readers switch from the old fork to the new one
+   * between requests, never mid-build. The flip is a REGISTRY write
+   * (run()'s complete({live:true}) marks this version live and demotes
+   * the previous one) — audit W2 #9 removed the process.env mutation
+   * that made a per-tenant activation repoint every tenant on the pod
+   * and stay invisible to every other pod. Activation additionally
+   * requires a CLEAN run: flipping every reader onto a world with known
+   * holes is never what the operator meant.
+   */
+  private async maybeActivate(args: {
+    companyId: string;
+    version: string;
+    activate: boolean;
+    activePin: string | undefined;
+    result: DeriveRunResult;
+  }): Promise<void> {
+    const { companyId, version, activate, activePin, result } = args;
+    if (activate && result.conversations > 0 && result.failed === 0) {
+      result.previousVersion =
+        (await this.readPin?.resolve(companyId)) ?? activePin ?? null;
+      result.activated = true;
+      this.logger.log(
+        `derived world '${version}' activated for ${companyId} ` +
+          `(was: ${result.previousVersion ?? 'legacy'})`,
+      );
+    } else if (activate && result.failed > 0) {
+      this.logger.warn(
+        `activation of '${version}' refused for ${companyId}: ` +
+          `${result.failed} of ${result.conversations + result.failed} ` +
+          `conversation(s) failed — re-derive the failures, then activate`,
+      );
+    }
+  }
+
+  /**
+   * Stamp status/failed from the skipped ledger: 'ok' — clean; 'degraded'
+   * — partial; 'failed' — attempted and nothing succeeded (the V2
+   * quota-poison shape).
+   */
+  private finalizeRunStatus(result: DeriveRunResult): DeriveRunStatus {
+    result.failed = result.skipped.length;
+    result.status =
+      result.failed === 0
+        ? 'ok'
+        : result.conversations > 0
+          ? 'degraded'
+          : 'failed';
+    return result.status;
   }
 
   /**

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -390,6 +390,7 @@ function validateRetrievalProfileEnv(
       ['off', 'shape_conditioned', 'always'],
     ],
     ['RETRIEVAL_DATE_ANCHORING', ['none', 'session_date', 'absolute']],
+    ['RETRIEVAL_TEMPORAL_MODE', ['filter', 'overlap_boost']],
   ];
   for (const [name, allowed] of enums) {
     const v = env[name];

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -387,7 +387,7 @@ function validateRetrievalProfileEnv(
     ['RETRIEVAL_GENRE', ['dialogue', 'assistant_chat', 'documents']],
     [
       'RETRIEVAL_VERBATIM_EVIDENCE',
-      ['off', 'shape_conditioned', 'always'],
+      ['off', 'shape_conditioned', 'always', 'fused'],
     ],
     ['RETRIEVAL_DATE_ANCHORING', ['none', 'session_date', 'absolute']],
     ['RETRIEVAL_TEMPORAL_MODE', ['filter', 'overlap_boost']],

--- a/src/communities/community-builder.service.ts
+++ b/src/communities/community-builder.service.ts
@@ -19,6 +19,7 @@ import {
 } from './label-propagation';
 import { policyFor } from '../ingest/conflict-resolver';
 import { envFlagEnabled } from '../common/env-validation';
+import { derivedVersionFence } from '../episodes/read-pin.service';
 
 /**
  * CommunityBuilderService — clusters the tenant's entity graph into
@@ -86,7 +87,10 @@ export class CommunityBuilderService {
    * passed `db` handle. Idempotent: a second run with no graph change
    * reuses every community via the watermark and creates/deletes nothing.
    */
-  async run(db: Surreal): Promise<CommunityBuildResult> {
+  async run(
+    db: Surreal,
+    derivedVersion: string | null = null,
+  ): Promise<CommunityBuildResult> {
     const result: CommunityBuildResult = {
       communitiesBuilt: 0,
       communitiesReused: 0,
@@ -164,7 +168,7 @@ export class CommunityBuilderService {
       }
       await withSpan(
         'communities.build_one',
-        () => this.buildCommunity(db, members, maxEdgeAt[i]),
+        () => this.buildCommunity(db, members, maxEdgeAt[i], derivedVersion),
         { 'community.size': members.length },
       );
       result.communitiesBuilt++;
@@ -354,12 +358,18 @@ export class CommunityBuilderService {
   }
 
   /** Summarise + embed + persist one community and its member edges. */
+  // eslint-disable-next-line max-params
   private async buildCommunity(
     db: Surreal,
     members: string[],
     maxEdgeAt: string | null,
+    derivedVersion: string | null,
   ): Promise<void> {
-    const { label, summaryInput } = await this.gatherMemberContext(db, members);
+    const { label, summaryInput } = await this.gatherMemberContext(
+      db,
+      members,
+      derivedVersion,
+    );
     const summary = await this.summaryGenerator.generate(summaryInput);
     const summaryEmbedding = summary
       ? await this.embedder.embed(summary)
@@ -424,7 +434,9 @@ export class CommunityBuilderService {
   private async gatherMemberContext(
     db: Surreal,
     members: string[],
+    derivedVersion: string | null,
   ): Promise<{ label: string; summaryInput: FactToSummarize[] }> {
+    const fence = derivedVersionFence(derivedVersion);
     const sample = members.slice(0, this.summaryMaxMembers);
     const ridSample = sample.map((m) => new StringRecordId(m));
 
@@ -453,9 +465,10 @@ export class CommunityBuilderService {
            AND status = 'active'
            AND retractedAt IS NONE
            AND userId IS NONE
+           ${fence.clause}
          ORDER BY confidence DESC, validFrom ASC, predicate ASC, object ASC
          LIMIT 60`,
-      { ids: ridSample },
+      { ids: ridSample, ...fence.params },
     );
     // The community summary is persisted and read tenant-wide with only
     // brain:read — it can carry no per-caller redaction. So a PII-classed

--- a/src/contracts/admin/retrieval-profile.schema.ts
+++ b/src/contracts/admin/retrieval-profile.schema.ts
@@ -17,6 +17,7 @@ export const RetrievalProfileWireSchema = z.object({
   genre: z.enum(['dialogue', 'assistant_chat', 'documents']),
   verbatimEvidence: z.enum(['off', 'shape_conditioned', 'always']),
   dateAnchoring: z.enum(['none', 'session_date', 'absolute']),
+  temporalMode: z.enum(['filter', 'overlap_boost']),
   factBudget: z.number().int(),
   quotesPerPrompt: z.number().int(),
   sourceExcerptsCap: z.number().int(),

--- a/src/contracts/admin/retrieval-profile.schema.ts
+++ b/src/contracts/admin/retrieval-profile.schema.ts
@@ -26,6 +26,7 @@ export const RetrievalProfileWireSchema = z.object({
   extraEvidenceCap: z.number().int(),
   wideProbe: z.boolean(),
   wideProbeLimit: z.number().int(),
+  entityExpansion: z.boolean(),
   lanes: z.array(z.string()),
 });
 

--- a/src/contracts/admin/retrieval-profile.schema.ts
+++ b/src/contracts/admin/retrieval-profile.schema.ts
@@ -15,7 +15,7 @@ import { z } from 'zod';
 
 export const RetrievalProfileWireSchema = z.object({
   genre: z.enum(['dialogue', 'assistant_chat', 'documents']),
-  verbatimEvidence: z.enum(['off', 'shape_conditioned', 'always']),
+  verbatimEvidence: z.enum(['off', 'shape_conditioned', 'always', 'fused']),
   dateAnchoring: z.enum(['none', 'session_date', 'absolute']),
   temporalMode: z.enum(['filter', 'overlap_boost']),
   factBudget: z.number().int(),

--- a/src/contracts/episodes/driver.schema.ts
+++ b/src/contracts/episodes/driver.schema.ts
@@ -86,6 +86,13 @@ export const RebuildProjectionResponseSchema = z.object({
   skipped: z.array(
     z.object({ conversationId: z.string(), reason: z.string() }),
   ),
+  /**
+   * 'ok' — clean run; 'degraded' — some conversations failed (reasons in
+   * skipped). A run where every attempted conversation failed never
+   * reaches the caller as a 2xx — the endpoint answers 502 instead.
+   */
+  status: z.enum(['ok', 'degraded', 'failed']),
+  failed: z.number().int(),
   activated: z.boolean().optional(),
   previousVersion: z.string().nullable().optional(),
 });

--- a/src/db/migrations/0081_segment_generation.surql
+++ b/src/db/migrations/0081_segment_generation.surql
@@ -1,0 +1,16 @@
+-- 0081: episode_segment.generation — rebuild provenance for the atomic
+-- staging-swap (audit W2 #10/#11 carried work).
+--
+-- The composer used to delete-by-conversation, then spend the embedding
+-- call, then insert — the segment lane read an EMPTY conversation for
+-- the whole paid window, and a crashed run left it empty until the next
+-- rebuild. The swap is now a single transaction (delete + insert), and
+-- every row carries the run's generation stamp so a partially-failed
+-- rebuild is observable: conversations still on the previous generation
+-- are exactly the ones whose swap never landed.
+--
+-- generation is provenance, NOT a read filter — the atomic swap
+-- guarantees at most one generation per conversation at any time, so
+-- the segment lane stays version-blind by design.
+
+DEFINE FIELD IF NOT EXISTS generation ON episode_segment TYPE option<string>;

--- a/src/dreams/corroborate.service.ts
+++ b/src/dreams/corroborate.service.ts
@@ -9,6 +9,7 @@ import { MetricsService } from '../metrics/metrics.service';
 import { withSpan } from '../common/tracing';
 import { policyFor } from '../ingest/conflict-resolver';
 import { envFlagEnabled } from '../common/env-validation';
+import { derivedVersionFence } from '../episodes/read-pin.service';
 
 /**
  * DreamsCorroborateService — fuzzy cross-source corroboration.
@@ -143,7 +144,10 @@ export class DreamsCorroborateService {
     return this.enabled && !!this.openai;
   }
 
-  async run(db: Surreal): Promise<CorroborateResult> {
+  async run(
+    db: Surreal,
+    derivedVersion: string | null = null,
+  ): Promise<CorroborateResult> {
     const result: CorroborateResult = {
       groupsConsidered: 0,
       groupBacklog: 0,
@@ -157,7 +161,7 @@ export class DreamsCorroborateService {
 
     const { groups, backlog } = await withSpan(
       'dreams.corroborate.find_groups',
-      () => this.findCandidateGroups(db),
+      () => this.findCandidateGroups(db, derivedVersion),
     );
     result.groupsConsidered = groups.length;
     result.groupBacklog = backlog;
@@ -181,7 +185,7 @@ export class DreamsCorroborateService {
         );
         break;
       }
-      const members = await this.fetchGroupMembers(db, group);
+      const members = await this.fetchGroupMembers(db, group, derivedVersion);
       const pairs = this.selectPairs(members);
 
       // Judge in parallel under the semaphore, apply serially. The old
@@ -272,17 +276,21 @@ export class DreamsCorroborateService {
    */
   private async findCandidateGroups(
     db: Surreal,
+    derivedVersion: string | null,
   ): Promise<{
     groups: Array<{ entityId: unknown; predicate: string }>;
     backlog: number;
   }> {
+    const fence = derivedVersionFence(derivedVersion);
     const [rows] = await db.query<
       [Array<{ entityId: unknown; predicate: string; n: number }>]
     >(
       `SELECT entityId, predicate, count() AS n FROM knowledge_fact
        WHERE status = 'active' AND retractedAt IS NONE AND embedding != NONE
          AND userId IS NONE
+         ${fence.clause}
        GROUP BY entityId, predicate`,
+      fence.params,
     );
     // Negative-result memo (0060): a group already judged at the SAME
     // member count is excluded before the window is cut. Without this,
@@ -332,7 +340,9 @@ export class DreamsCorroborateService {
   private async fetchGroupMembers(
     db: Surreal,
     group: { entityId: unknown; predicate: string },
+    derivedVersion: string | null,
   ): Promise<ActiveFactRow[]> {
+    const fence = derivedVersionFence(derivedVersion);
     const [rows] = await db.query<[ActiveFactRow[]]>(
       `SELECT id, entityId, predicate, object, validFrom, validUntil,
               recordedAt, embedding,
@@ -342,10 +352,12 @@ export class DreamsCorroborateService {
        WHERE entityId = $entity AND predicate = $predicate
          AND status = 'active' AND retractedAt IS NONE AND embedding != NONE
          AND userId IS NONE
+         ${fence.clause}
        ORDER BY recordedAt ASC`,
       {
         entity: new StringRecordId(String(group.entityId)),
         predicate: group.predicate,
+        ...fence.params,
       },
     );
     return (rows as ActiveFactRow[]) ?? [];

--- a/src/dreams/dedup.service.ts
+++ b/src/dreams/dedup.service.ts
@@ -4,6 +4,7 @@ import { Surreal, StringRecordId } from 'surrealdb';
 import { EntityJudgeService } from '../ai/entity-judge.service';
 import { withSpan } from '../common/tracing';
 import { envFlagEnabled } from '../common/env-validation';
+import { derivedVersionFence } from '../episodes/read-pin.service';
 
 /**
  * DreamsDedupService — find near-duplicate ENTITIES inside a tenant
@@ -91,7 +92,10 @@ export class DreamsDedupService {
    * passed `db` handle. This keeps the service stateless and
    * compatible with the controller's per-request manual trigger.
    */
-  async run(db: Surreal): Promise<DedupResult> {
+  async run(
+    db: Surreal,
+    derivedVersion: string | null = null,
+  ): Promise<DedupResult> {
     const result: DedupResult = {
       suspectsEvaluated: 0,
       llmJudgements: 0,
@@ -103,7 +107,7 @@ export class DreamsDedupService {
 
     const candidates = await withSpan(
       'dreams.dedup.find_candidates',
-      () => this.findCandidates(db),
+      () => this.findCandidates(db, derivedVersion),
       { 'dedup.cosine_threshold': this.cosineThreshold },
     );
     result.suspectsEvaluated = candidates.length;
@@ -150,7 +154,10 @@ export class DreamsDedupService {
    *     ordering so each pair is counted once).
    *   - Cap at maxPairs to bound the LLM cost.
    */
-  private async findCandidates(db: Surreal): Promise<DedupCandidate[]> {
+  private async findCandidates(
+    db: Surreal,
+    derivedVersion: string | null,
+  ): Promise<DedupCandidate[]> {
     // Seed pass: fact id + entity id ONLY. The old shape selected every
     // name embedding into process memory (1536 float64s × N entities —
     // hundreds of MB at scale) and then looped over ALL of them. The
@@ -158,6 +165,7 @@ export class DreamsDedupService {
     // its seed vector by fact id, and the seed set is capped
     // newest-first. recordedAt rides in the projection for the 3.x
     // ORDER BY idiom.
+    const fence = derivedVersionFence(derivedVersion);
     type SeedRow = { id: unknown; entityId: unknown; recordedAt: unknown };
     const [seedRows] = await db.query<[SeedRow[]]>(
       `SELECT id, entityId, recordedAt FROM knowledge_fact
@@ -167,9 +175,10 @@ export class DreamsDedupService {
          AND embedding != NONE
          AND userId IS NONE
          AND entityId.mergedInto IS NONE
+         ${fence.clause}
        ORDER BY recordedAt DESC
        LIMIT $maxSeeds`,
-      { maxSeeds: this.maxSeeds },
+      { maxSeeds: this.maxSeeds, ...fence.params },
     );
     const seeds = (seedRows as SeedRow[]) ?? [];
     if (seeds.length < 2) return [];
@@ -178,7 +187,11 @@ export class DreamsDedupService {
     const seen = new Set<string>();
     for (const seed of seeds) {
       const aId = String(seed.entityId);
-      const neighbours = await this.nearestNames(db, String(seed.id));
+      const neighbours = await this.nearestNames(
+        db,
+        String(seed.id),
+        derivedVersion,
+      );
       for (const n of neighbours) {
         const bId = String(n.entityId);
         if (bId === aId) continue;
@@ -208,13 +221,16 @@ export class DreamsDedupService {
   private async nearestNames(
     db: Surreal,
     seedFactId: string,
+    derivedVersion: string | null,
   ): Promise<Array<{ entityId: unknown; sim: number }>> {
+    const fence = derivedVersionFence(derivedVersion);
     const filters = `predicate = 'name'
           AND status = 'active'
           AND retractedAt IS NONE
           AND embedding != NONE
           AND userId IS NONE
-          AND entityId.mergedInto IS NONE`;
+          AND entityId.mergedInto IS NONE
+          ${fence.clause}`;
     type Row = { entityId: unknown; sim: number };
     if (envFlagEnabled(process.env.SEARCH_HNSW_ENABLED)) {
       const ef = parseInt(process.env.SEARCH_HNSW_EF ?? '100', 10);
@@ -229,7 +245,7 @@ export class DreamsDedupService {
               AND ${filters}
             ORDER BY sim DESC
             LIMIT 5;`,
-          { fid: seedFactId },
+          { fid: seedFactId, ...fence.params },
         );
         return (res[1] as Row[]) ?? [];
       } catch (e) {
@@ -245,7 +261,7 @@ export class DreamsDedupService {
         WHERE ${filters}
         ORDER BY sim DESC
         LIMIT 5;`,
-      { fid: seedFactId },
+      { fid: seedFactId, ...fence.params },
     );
     return (res[1] as Row[]) ?? [];
   }

--- a/src/dreams/dreams.module.ts
+++ b/src/dreams/dreams.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { CompactionModule } from '../compaction/compaction.module';
 import { CommunityModule } from '../communities/community.module';
 import { AuthModule } from '../auth/auth.module';
+import { EpisodesModule } from '../episodes/episodes.module';
 import { DreamsService } from './dreams.service';
 import { DreamsController } from './dreams.controller';
 import { DreamsDedupService } from './dedup.service';
@@ -17,9 +18,19 @@ import { DreamsCorroborateService } from './corroborate.service';
  * is imported so the summarize op can reuse compactCompany() — and so
  * the LlmSummaryGenerator can replace the default ConcatSummaryGenerator
  * via the SUMMARY_GENERATOR token (see compaction.module.ts).
+ * EpisodesModule provides ReadPinService: dreams legs are fenced to the
+ * tenant's live derived world (audit W2 #10 — a version-blind dreams run
+ * mutated fact status across residual worlds while the pinned reader saw
+ * none of the justification).
  */
 @Module({
-  imports: [ConfigModule, CompactionModule, CommunityModule, AuthModule],
+  imports: [
+    ConfigModule,
+    CompactionModule,
+    CommunityModule,
+    AuthModule,
+    EpisodesModule,
+  ],
   controllers: [DreamsController],
   providers: [
     DreamsService,

--- a/src/dreams/dreams.service.ts
+++ b/src/dreams/dreams.service.ts
@@ -25,6 +25,7 @@ import {
 } from '../jobs/worker-loop.service';
 import { DistributedLeaseGuard } from '../common/distributed-lease.guard';
 import { envFlagEnabled } from '../common/env-validation';
+import { ReadPinService } from '../episodes/read-pin.service';
 
 export interface DreamsTenantStats {
   companyId: string;
@@ -110,6 +111,9 @@ export class DreamsService implements OnModuleInit {
     @Optional() private readonly community?: CommunityBuilderService,
     // @Optional for the same positional-test reason; provided by DreamsModule.
     @Optional() private readonly corroborate?: DreamsCorroborateService,
+    // @Optional for the same positional-test reason; provided by
+    // EpisodesModule. Legs fenced to the live derived world (audit W2 #10).
+    @Optional() private readonly readPin?: ReadPinService,
   ) {
     this.enabled =
       envFlagEnabled(this.configService.get<string>('DREAMS_ENABLED'));
@@ -443,11 +447,22 @@ export class DreamsService implements OnModuleInit {
     signal?: AbortSignal;
   }): Promise<void> {
     const { db, companyId, opSet, stats, jobRow, signal } = args;
+    // Audit W2 #10: dreams used to be version-BLIND — dedup drew identity
+    // edges off residual worlds' name facts, resolve/corroborate mutated
+    // fact status in worlds the pinned reader never queries. Every leg is
+    // now fenced to this tenant's live world (or the legacy namespace).
+    const derivedVersion =
+      (await this.readPin?.resolve(companyId)) ??
+      ReadPinService.bootstrapDefault();
     if (opSet.has('dedup')) {
       this.assertNotAborted(signal);
-      stats.dedup = await withSpan('dreams.dedup', () => this.dedup.run(db), {
-        'dreams.tenant': companyId,
-      });
+      stats.dedup = await withSpan(
+        'dreams.dedup',
+        () => this.dedup.run(db, derivedVersion),
+        {
+          'dreams.tenant': companyId,
+        },
+      );
       if (jobRow) {
         await this.jobs?.updateProgress(jobRow, {
           currentTenant: companyId,
@@ -459,7 +474,7 @@ export class DreamsService implements OnModuleInit {
       this.assertNotAborted(signal);
       stats.resolve = await withSpan(
         'dreams.resolve',
-        () => this.resolver.run(db),
+        () => this.resolver.run(db, derivedVersion),
         { 'dreams.tenant': companyId },
       );
       if (jobRow) {
@@ -472,7 +487,7 @@ export class DreamsService implements OnModuleInit {
       this.assertNotAborted(signal);
       stats.corroborate = await withSpan(
         'dreams.corroborate',
-        () => this.corroborate!.run(db),
+        () => this.corroborate!.run(db, derivedVersion),
         { 'dreams.tenant': companyId },
       );
       if (jobRow) {
@@ -485,7 +500,7 @@ export class DreamsService implements OnModuleInit {
       this.assertNotAborted(signal);
       stats.communities = await withSpan(
         'dreams.communities',
-        () => this.community!.run(db),
+        () => this.community!.run(db, derivedVersion),
         { 'dreams.tenant': companyId },
       );
       if (jobRow) {

--- a/src/dreams/resolver.service.ts
+++ b/src/dreams/resolver.service.ts
@@ -8,6 +8,7 @@ import { withGenAiCall } from '../common/gen-ai-observability';
 import { MetricsService } from '../metrics/metrics.service';
 import { withSpan } from '../common/tracing';
 import { envFlagEnabled } from '../common/env-validation';
+import { derivedVersionFence } from '../episodes/read-pin.service';
 
 /**
  * DreamsResolverService — auto-resolve competing fact pairs that
@@ -102,7 +103,10 @@ export class DreamsResolverService {
     return this.enabled && !!this.openai;
   }
 
-  async run(db: Surreal): Promise<ResolverResult> {
+  async run(
+    db: Surreal,
+    derivedVersion: string | null = null,
+  ): Promise<ResolverResult> {
     const result: ResolverResult = {
       pairsConsidered: 0,
       llmJudgements: 0,
@@ -114,7 +118,7 @@ export class DreamsResolverService {
 
     const pairs = await withSpan(
       'dreams.resolve.find_pairs',
-      () => this.findCompetingPairs(db),
+      () => this.findCompetingPairs(db, derivedVersion),
       { 'resolve.min_age_days': this.minAgeDays },
     );
     result.pairsConsidered = pairs.length;
@@ -127,7 +131,7 @@ export class DreamsResolverService {
     const judged = await Promise.all(
       pairs.map((pair) =>
         withSpan('dreams.resolve.judge', () =>
-          this.limiter.run(() => this.judge(db, pair)),
+          this.limiter.run(() => this.judge(db, pair, derivedVersion)),
         ).then((verdict) => ({ pair, verdict })),
       ),
     );
@@ -168,22 +172,30 @@ export class DreamsResolverService {
    */
   private async findCompetingPairs(
     db: Surreal,
+    derivedVersion: string | null,
   ): Promise<Array<{ a: CompetingFactRow; b: CompetingFactRow }>> {
     const cutoff = new Date(
       Date.now() - this.minAgeDays * 24 * 60 * 60 * 1000,
     );
+    const fence = derivedVersionFence(derivedVersion);
     // Fetch ALL competing facts (no age filter in the query). The group-size
     // check that follows decides what's a 2-way pair vs a 3+-way disagreement,
     // so it must see every competing member. Filtering by age here would hide a
     // recent member of a genuine 3-way group and make it look like a clean pair
     // we could auto-resolve — exactly the multi-way case we must NOT touch.
+    // The version fence is NOT an age-style filter hazard: worlds are
+    // disjoint namespaces, so scoping to one world never hides a member
+    // of that world's group — it hides the SAME fact re-derived into
+    // other worlds, which used to masquerade as a 3-way disagreement.
     const [rows] = await db.query<[CompetingFactRow[]]>(
       `SELECT id, entityId, predicate, object, confidence, validFrom, recordedAt, source
        FROM knowledge_fact
        WHERE status = 'competing'
          AND retractedAt IS NONE
          AND userId IS NONE
+         ${fence.clause}
        ORDER BY entityId, predicate, recordedAt ASC`,
+      fence.params,
     );
     const all = (rows as CompetingFactRow[]) ?? [];
 
@@ -224,6 +236,7 @@ export class DreamsResolverService {
   private async judge(
     db: Surreal,
     pair: { a: CompetingFactRow; b: CompetingFactRow },
+    derivedVersion: string | null,
   ): Promise<{ kind: 'a_wins' | 'b_wins' | 'unsure' }> {
     // Pull a few neighbouring active facts on the same entity to give
     // the LLM context — sometimes the resolution depends on what's
@@ -232,6 +245,7 @@ export class DreamsResolverService {
     const ctxFacts = await this.fetchEntityContext(
       db,
       String(pair.a.entityId),
+      derivedVersion,
     );
     const sys = `You resolve a CONTRADICTION between two facts in a knowledge graph.
 
@@ -311,7 +325,9 @@ Output strictly the JSON shape requested.`;
   private async fetchEntityContext(
     db: Surreal,
     entityId: string,
+    derivedVersion: string | null,
   ): Promise<string> {
+    const fence = derivedVersionFence(derivedVersion);
     type R = { predicate: string; object: string; recordedAt: string };
     const [rows] = await db.query<[R[]]>(
       `SELECT predicate, object, recordedAt FROM knowledge_fact
@@ -319,9 +335,10 @@ Output strictly the JSON shape requested.`;
          AND status = 'active'
          AND retractedAt IS NONE
          AND userId IS NONE
+         ${fence.clause}
        ORDER BY recordedAt DESC
        LIMIT 6`,
-      { eid: new StringRecordId(entityId) },
+      { eid: new StringRecordId(entityId), ...fence.params },
     );
     const r = (rows as R[]) ?? [];
     if (r.length === 0) return '(no other active facts)';

--- a/src/episodes/read-pin.service.ts
+++ b/src/episodes/read-pin.service.ts
@@ -73,3 +73,22 @@ export class ReadPinService {
     this.cache.delete(companyId);
   }
 }
+
+/**
+ * The one WHERE-fragment every version-fenced consumer shares (audit W2
+ * #10 — compaction was the first port, dreams the second): a resolved
+ * pin scopes to that world, no pin scopes to the legacy namespace.
+ * Interpolate `clause` into the query and spread `params` into the
+ * bindings.
+ */
+export function derivedVersionFence(derivedVersion: string | null): {
+  clause: string;
+  params: Record<string, unknown>;
+} {
+  return derivedVersion
+    ? {
+        clause: 'AND derivedVersion = $derivedVersion',
+        params: { derivedVersion },
+      }
+    : { clause: 'AND derivedVersion IS NONE', params: {} };
+}

--- a/src/search/internals/edge-expansion.ts
+++ b/src/search/internals/edge-expansion.ts
@@ -87,7 +87,19 @@ export interface ExpansionConfig {
   alpha: number;
 }
 
-function resolveExpansionConfig(env = process.env): ExpansionConfig {
+/** Pure fallback for callers that resolve no env (unit fixtures). */
+const DEFAULT_EXPANSION_CONFIG: ExpansionConfig = {
+  topSeeds: 3,
+  maxNeighboursPerSeed: 5,
+  alpha: 0.4,
+};
+
+/**
+ * Env resolution lives with the caller-supplied env — the S5.2 boundary
+ * allows raw environment reads only in the retrieval-profile bootstrap,
+ * which calls this from resolveSearchTuning().
+ */
+export function resolveExpansionConfig(env: NodeJS.ProcessEnv): ExpansionConfig {
   const topSeeds = Math.max(
     1,
     parseInt(env.SEARCH_EDGE_EXPANSION_TOP_SEEDS ?? '3', 10) || 3,
@@ -177,7 +189,7 @@ export async function expandViaEdges({
   dto,
   callerScopes,
   passesPolicy,
-  config = resolveExpansionConfig(),
+  config = DEFAULT_EXPANSION_CONFIG,
   prefetchedNeighbours,
 }: ExpandViaEdgesOptions): Promise<number> {
   const seeds = selectEdgeExpansionSeeds(byEntity, config.topSeeds);

--- a/src/search/internals/legs.ts
+++ b/src/search/internals/legs.ts
@@ -1,7 +1,25 @@
 import type { Surreal } from 'surrealdb';
 import type { EmbedderService } from '../../ai/embedder.service';
 import type { FactRow } from './types';
-import { envFlagEnabled } from '../../common/env-validation';
+import type { SearchTuning } from '../retrieval-profile';
+
+/** The slice of SearchTuning the legs consume (kept narrow for tests). */
+export type LegTuning = Pick<
+  SearchTuning,
+  | 'combinedVectorGraph'
+  | 'hnswEnabled'
+  | 'hnswEf'
+  | 'hnswOverfetch'
+  | 'highlightEnabled'
+>;
+
+const DEFAULT_LEG_TUNING: LegTuning = {
+  combinedVectorGraph: false,
+  hnswEnabled: false,
+  hnswEf: 100,
+  hnswOverfetch: 4,
+  highlightEnabled: false,
+};
 
 /**
  * Vector leg — cosine similarity over `embedding`. The inline
@@ -19,12 +37,11 @@ import { envFlagEnabled } from '../../common/env-validation';
  * Off (default) → empty string → the query is byte-identical to before; the
  * legacy separate edge-expansion query runs instead. Verified on 3.2.0.
  */
-const COMBINED_GRAPH_PROJECTION = envFlagEnabled(
-  process.env.SEARCH_COMBINED_VECTOR_GRAPH,
-)
-  ? `entityId->knowledge_edge.{ kind, weight, peer: out.{id} } AS outNeighbours,
+const combinedGraphProjection = (on: boolean): string =>
+  on
+    ? `entityId->knowledge_edge.{ kind, weight, peer: out.{id} } AS outNeighbours,
      entityId<-knowledge_edge.{ kind, weight, peer: in.{id} } AS inNeighbours,`
-  : '';
+    : '';
 
 export interface RunVectorLegOptions {
   db: Surreal;
@@ -34,6 +51,8 @@ export interface RunVectorLegOptions {
   baseWhere: { sql: string; params: Record<string, unknown> };
   /** For the HNSW-fallback warning; the leg stays silent without it. */
   logger?: { warn: (msg: string) => void };
+  /** Resolved by the retrieval-profile bootstrap (S5.2). */
+  tuning?: LegTuning;
 }
 
 export async function runVectorLeg({
@@ -43,6 +62,7 @@ export async function runVectorLeg({
   k,
   baseWhere,
   logger,
+  tuning = DEFAULT_LEG_TUNING,
 }: RunVectorLegOptions): Promise<FactRow[]> {
   const queryEmbedding = await embedder.embed(query);
   // HNSW path (opt-in): approximate KNN over the per-tenant indexes
@@ -50,9 +70,9 @@ export async function runVectorLeg({
   // commonly "no index on this tenant yet" — falls back to the exact
   // full scan below, so the flag can be flipped globally while tenants
   // are indexed one by one.
-  if (envFlagEnabled(process.env.SEARCH_HNSW_ENABLED)) {
+  if (tuning.hnswEnabled) {
     try {
-      return await runVectorLegKnn({ db, queryEmbedding, k, baseWhere });
+      return await runVectorLegKnn({ db, queryEmbedding, k, baseWhere, tuning });
     } catch (e) {
       logger?.warn(
         `hnsw vector leg fell back to full scan: ${(e as Error).message}`,
@@ -65,7 +85,7 @@ export async function runVectorLeg({
         validFrom, validUntil, recordedAt, retractedAt, status, source,
         trustSnapshot, corroboration, userId,
         entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity,
-        ${COMBINED_GRAPH_PROJECTION}
+        ${combinedGraphProjection(tuning.combinedVectorGraph)}
         vector::similarity::cosine(embedding, $q) AS simScore
       FROM knowledge_fact
       WHERE embedding != NONE
@@ -93,15 +113,16 @@ async function runVectorLegKnn({
   queryEmbedding,
   k,
   baseWhere,
+  tuning,
 }: {
   db: Surreal;
   queryEmbedding: number[];
   k: number;
   baseWhere: { sql: string; params: Record<string, unknown> };
+  tuning: LegTuning;
 }): Promise<FactRow[]> {
-  const ef = positiveIntEnv('SEARCH_HNSW_EF', 100);
-  const overfetch = positiveIntEnv('SEARCH_HNSW_OVERFETCH', 4);
-  const kOver = Math.min(k * overfetch, 1000);
+  const ef = tuning.hnswEf;
+  const kOver = Math.min(k * tuning.hnswOverfetch, 1000);
   const projection = `
         id, entityId, predicate, object, confidence,
         validFrom, validUntil, recordedAt, retractedAt, status, source,
@@ -119,11 +140,6 @@ async function runVectorLegKnn({
     { ...baseWhere.params, q: queryEmbedding, k },
   );
   return (rows as FactRow[]) ?? [];
-}
-
-function positiveIntEnv(name: string, fallback: number): number {
-  const v = parseInt(process.env[name] ?? '', 10);
-  return Number.isFinite(v) && v > 0 ? v : fallback;
 }
 
 /**
@@ -146,9 +162,8 @@ function positiveIntEnv(name: string, fallback: number): number {
  * Highlights the searchHaystack match (ref 1 — the field the lexical WHERE
  * matches on for most rows). Off (default) → empty string → byte-identical.
  */
-const HIGHLIGHT_PROJECTION = envFlagEnabled(process.env.SEARCH_HIGHLIGHT_ENABLED)
-  ? `search::highlight('<em>', '</em>', 1) AS highlight,`
-  : '';
+const highlightProjection = (on: boolean): string =>
+  on ? `search::highlight('<em>', '</em>', 1) AS highlight,` : '';
 
 export interface RunLexicalLegOptions {
   db: Surreal;
@@ -156,6 +171,8 @@ export interface RunLexicalLegOptions {
   query: string;
   k: number;
   baseWhere: { sql: string; params: Record<string, unknown> };
+  /** Resolved by the retrieval-profile bootstrap (S5.2). */
+  tuning?: LegTuning;
 }
 
 export async function runLexicalLeg({
@@ -164,6 +181,7 @@ export async function runLexicalLeg({
   query,
   k,
   baseWhere,
+  tuning = DEFAULT_LEG_TUNING,
 }: RunLexicalLegOptions): Promise<FactRow[]> {
   // Parens around the OR clause are LOAD-BEARING. SurrealQL
   // evaluates AND with higher precedence than OR (same as SQL),
@@ -180,7 +198,7 @@ export async function runLexicalLeg({
         validFrom, validUntil, recordedAt, retractedAt, status, source,
         trustSnapshot, corroboration, userId,
         entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity,
-        ${HIGHLIGHT_PROJECTION}
+        ${highlightProjection(tuning.highlightEnabled)}
         math::max([search::score(1), search::score(2)]) AS bm25Score
       FROM knowledge_fact
       WHERE (searchHaystack @1@ $query OR object @2@ $query)

--- a/src/search/internals/query-expansion.ts
+++ b/src/search/internals/query-expansion.ts
@@ -1,0 +1,41 @@
+import type { FusedRow } from './types';
+
+/**
+ * Entity-expansion query rewrite (audit W4 #19, profile
+ * entityExpansion): the first retrieval pass DISCOVERS entities the
+ * query never named — the top discovered canonical names become extra
+ * anchors for a second pass. This is SmartSearch's multi-session lever
+ * (rule-based entity discovery on retrieved passages, 84.2 MS) done on
+ * our graph rows: no NER model needed, the rows already carry their
+ * entity.
+ *
+ * Returns null when there is nothing to expand with — every discovered
+ * name already appears in the query verbatim, or the first pass came
+ * back empty.
+ */
+const MAX_EXPANSION_NAMES = 3;
+
+export function buildEntityExpansionQuery(
+  query: string,
+  rows: FusedRow[],
+): string | null {
+  const lower = query.toLowerCase();
+  const bestByName = new Map<string, number>();
+  for (const r of rows) {
+    const name = r.entity?.canonicalName?.trim();
+    if (!name || name.length < 3) continue;
+    // Only NOVEL anchors: a name the caller already typed adds nothing
+    // to either the embedding or the BM25 term set.
+    if (lower.includes(name.toLowerCase())) continue;
+    const prev = bestByName.get(name);
+    if (prev === undefined || r.fusedScore > prev) {
+      bestByName.set(name, r.fusedScore);
+    }
+  }
+  const names = [...bestByName.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, MAX_EXPANSION_NAMES)
+    .map(([n]) => n);
+  if (names.length === 0) return null;
+  return `${query} ${names.join(' ')}`;
+}

--- a/src/search/internals/response-builder.ts
+++ b/src/search/internals/response-builder.ts
@@ -1,10 +1,16 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { countJsonTokens } from '../../common/token-counter';
-import { envFlagEnabled } from '../../common/env-validation';
 import type { SearchDto } from '../dto/search.dto';
 import type { SearchHit } from '../search.types';
+import type { SearchTuning } from '../retrieval-profile';
 import type { EntityBucket } from './types';
+
+/** The shaping slice of SearchTuning; defaults mirror the env defaults. */
+export type ShapingTuning = Pick<
+  SearchTuning,
+  'tokenCountOffload' | 'tokenOffloadMinHits'
+>;
 
 /**
  * Assemble final SearchHit rows from the fact-centric top-K bucket
@@ -120,12 +126,6 @@ export function tokenCountWorkerModulePath(): string {
   return cachedWorkerModulePath;
 }
 
-function offloadMinHits(): number {
-  const raw = process.env.SEARCH_TOKEN_OFFLOAD_MIN_HITS;
-  const n = raw === undefined ? Number.NaN : parseInt(raw, 10);
-  return Number.isFinite(n) && n >= 1 ? n : OFFLOAD_MIN_HITS_DEFAULT;
-}
-
 /**
  * Per-hit token counts (+1 per hit for the array comma). Serialisation
  * happens on the main thread either way; for large hit lists the
@@ -138,17 +138,12 @@ function offloadMinHits(): number {
 async function countHitTokens(
   results: SearchHit[],
   pool?: TokenCountPool,
+  tuning?: ShapingTuning,
 ): Promise<number[]> {
   const syncCounts = () => results.map((hit) => countJsonTokens(hit) + 1);
-  const offloadEnabled = envFlagEnabled(
-    process.env.SEARCH_TOKEN_COUNT_OFFLOAD ?? '1',
-  );
-  if (
-    !pool ||
-    !offloadEnabled ||
-    results.length < offloadMinHits() ||
-    !pool.enabled()
-  ) {
+  const offloadEnabled = tuning?.tokenCountOffload ?? true;
+  const minHits = tuning?.tokenOffloadMinHits ?? OFFLOAD_MIN_HITS_DEFAULT;
+  if (!pool || !offloadEnabled || results.length < minHits || !pool.enabled()) {
     return syncCounts();
   }
   const texts = results.map((hit) => JSON.stringify(hit));
@@ -187,10 +182,12 @@ async function countHitTokens(
  * per-hit counting may batch out to the worker pool (see
  * countHitTokens); semantics are identical on both paths.
  */
+// eslint-disable-next-line max-params
 export async function applyOutputShaping(
   hits: SearchHit[],
   dto: SearchDto,
   pool?: TokenCountPool,
+  tuning?: ShapingTuning,
 ): Promise<SearchHit[]> {
   let results = hits;
   if (dto.confidenceFloor !== undefined) {
@@ -232,7 +229,7 @@ export async function applyOutputShaping(
     // the budget stays a hard ceiling. The per-hit encodes batch out
     // to the worker pool for large lists (sync fallback inside).
     const envelopeTokens = countJsonTokens({ results: [] });
-    const perHit = await countHitTokens(results, pool);
+    const perHit = await countHitTokens(results, pool, tuning);
     let used = envelopeTokens;
     let keep = 0;
     for (const hitTokens of perHit) {

--- a/src/search/internals/scoring.ts
+++ b/src/search/internals/scoring.ts
@@ -64,9 +64,50 @@ export interface ScoreRowsOptions {
    * Only values in (0,1] make sense; ≥1 (or unset) leaves chatter unpenalized.
    */
   chatterPenalty?: number;
+  /**
+   * Temporal overlap boost (audit W4 #17, profile temporalMode =
+   * 'overlap_boost'): with an `asOf` anchor set, facts whose validity
+   * interval contains the anchor keep factor 1.0 and facts outside it
+   * decay exponentially with the gap (half-life
+   * TEMPORAL_OVERLAP_HALF_LIFE_DAYS, floor TEMPORAL_OVERLAP_FLOOR).
+   * Unset → factor exactly 1.0 → byte-identical ranking. Under the
+   * strict 'filter' mode every surviving row contains the anchor, so
+   * enabling this there is also a no-op by construction.
+   */
+  temporalAnchor?: Date | null;
 }
 
 const CORROBORATION_CAP = 3;
+
+/** Hindsight-style distance decay for out-of-interval facts. */
+const TEMPORAL_OVERLAP_HALF_LIFE_DAYS = 90;
+/** Score floor for facts arbitrarily far from the anchor — decayed, never dropped. */
+const TEMPORAL_OVERLAP_FLOOR = 0.25;
+
+/**
+ * 1.0 when the fact's validity interval contains the anchor; otherwise
+ * floor + (1 − floor) · exp(−ln2 · gapDays / halfLife). Rows without a
+ * parseable validFrom are neutral (1.0). Observable through
+ * breakdown.temporalOverlap — deliberately not exported (S5.5).
+ */
+function temporalOverlapFactor(
+  row: { validFrom?: unknown; validUntil?: unknown },
+  anchorMs: number,
+): number {
+  const vf = row.validFrom ? new Date(String(row.validFrom)).getTime() : NaN;
+  if (!Number.isFinite(vf)) return 1;
+  const vuMs = row.validUntil
+    ? new Date(String(row.validUntil)).getTime()
+    : Infinity;
+  const vu = Number.isFinite(vuMs) ? vuMs : Infinity;
+  if (vf <= anchorMs && anchorMs < vu) return 1;
+  const gapDays =
+    (vf > anchorMs ? vf - anchorMs : anchorMs - vu) / 86_400_000;
+  const decay = Math.exp(
+    (-Math.LN2 * gapDays) / TEMPORAL_OVERLAP_HALF_LIFE_DAYS,
+  );
+  return TEMPORAL_OVERLAP_FLOOR + (1 - TEMPORAL_OVERLAP_FLOOR) * decay;
+}
 
 export function scoreRows({
   rows,
@@ -76,6 +117,7 @@ export function scoreRows({
   corroborationGamma = 0,
   authorityDelta = 0,
   chatterPenalty = 1,
+  temporalAnchor = null,
 }: ScoreRowsOptions): ScoredRow[] {
   // A penalty is only meaningful in (0,1]; anything else (unset, ≥1, invalid)
   // means "no penalty" so ranking is byte-identical to before.
@@ -140,6 +182,9 @@ export function scoreRows({
     };
 
     const chatterFactor = chatterFactorFor(row.predicate);
+    const temporalOverlap = temporalAnchor
+      ? temporalOverlapFactor(row, temporalAnchor.getTime())
+      : 1;
     const finalScore =
       row.fusedScore *
       decay *
@@ -147,7 +192,8 @@ export function scoreRows({
       chatterFactor *
       trustFactor *
       corroborationFactor *
-      authorityFactor;
+      authorityFactor *
+      temporalOverlap;
     return {
       row,
       score: finalScore,
@@ -157,6 +203,7 @@ export function scoreRows({
         calibratedConfidence,
         decay,
         ...(chatterFactor !== 1 ? { chatterPenalty: chatterFactor } : {}),
+        ...(temporalOverlap !== 1 ? { temporalOverlap } : {}),
         factTrust,
         finalScore,
         stages: row.stages ?? [],

--- a/src/search/internals/segment-leg.ts
+++ b/src/search/internals/segment-leg.ts
@@ -1,0 +1,138 @@
+import type { Surreal } from 'surrealdb';
+import type { FactRow } from './types';
+
+/**
+ * Verbatim fusion leg (audit W4 #18): episode_segment rows retrieved as
+ * first-class retrieval candidates when the profile says
+ * verbatimEvidence='fused'. Until this leg, L0 reached answers only as
+ * a prompt appendix — quotes never entered SearchHit, never got scored
+ * or reranked against facts, and were structurally uncitable ("cite
+ * factIds only").
+ *
+ * Each segment becomes a pseudo-FactRow whose bucket is itself:
+ *  - id/entityId    — the segment record id (so a citation
+ *                     [episode_segment:…] resolves through the same
+ *                     fact-index machinery as [knowledge_fact:…]);
+ *  - predicate      — 'verbatim';
+ *  - object         — the rendered multi-turn window text;
+ *  - validFrom      — the window's occurredAt (temporal semantics —
+ *                     the overlap boost and asOf reasoning see it);
+ *  - recordedAt     — the query instant, deliberately: verbatim
+ *                     substrate must not rot under the generic 60-day
+ *                     read-decay the way derived facts do (the appendix
+ *                     lane it replaces had no decay at all);
+ *  - confidence 1   — a verbatim record is not an extraction guess.
+ *
+ * Both queries reuse the appendix lane's exact idioms (cosine scan +
+ * BM25 `@1@`, PII fence, fail-closed user scope) so the leg retrieves
+ * the same pool the measured segment lane did — the difference is what
+ * happens downstream: convex fusion + scoring + rerank + fact-centric
+ * arbitration instead of a blind prompt append.
+ */
+export interface SegmentLegOptions {
+  db: Pick<Surreal, 'query'>;
+  queryText: string;
+  queryVector: number[] | null;
+  /** Candidates per leg (the lane idiom: max(topK*3, 12)). */
+  fetchK: number;
+  callerScopes: string[];
+  userId?: string;
+  mode: 'hybrid' | 'vector' | 'lexical';
+}
+
+interface SegmentRow {
+  id: unknown;
+  conversationId?: string;
+  text: string;
+  occurredAt: unknown;
+  score?: number;
+}
+
+function toFactRow(r: SegmentRow, kind: 'vector' | 'lexical'): FactRow {
+  const occurred = String(r.occurredAt ?? '');
+  const day = occurred.slice(0, 10);
+  return {
+    id: r.id,
+    entityId: r.id,
+    predicate: 'verbatim',
+    object: r.text,
+    confidence: 1,
+    validFrom: occurred,
+    recordedAt: new Date().toISOString(),
+    status: 'active',
+    source: {
+      vertical: 'segment',
+      ...(r.conversationId ? { conversationId: r.conversationId } : {}),
+    },
+    entity: {
+      id: r.id,
+      type: 'segment',
+      canonicalName: r.conversationId
+        ? `conversation ${r.conversationId}${day ? ` (${day})` : ''}`
+        : `transcript segment${day ? ` (${day})` : ''}`,
+      externalRefs: {},
+    },
+    ...(kind === 'vector'
+      ? { simScore: r.score ?? 0 }
+      : { bm25Score: r.score ?? 0 }),
+  };
+}
+
+/**
+ * Run the two segment queries per the search mode. Returns
+ * (vectorRows, lexicalRows) shaped as pseudo-FactRows, ready for the
+ * SAME convex fuse() the fact legs use — one fusion doctrine, not two
+ * (audit #21: the appendix lane ran its own RRF).
+ */
+export async function runSegmentLegs({
+  db,
+  queryText,
+  queryVector,
+  fetchK,
+  callerScopes,
+  userId,
+  mode,
+}: SegmentLegOptions): Promise<{
+  vectorRows: FactRow[];
+  lexicalRows: FactRow[];
+}> {
+  const piiGate = callerScopes.includes('brain:read_pii')
+    ? ''
+    : 'AND piiClass IS NONE';
+  // Fail-closed user scope (0055, audit W1 #14): segments inherit the
+  // window's userId only when unanimous; an unscoped read stays
+  // tenant-global rather than serving another user's window.
+  const userGate = userId
+    ? 'AND (userId IS NONE OR userId = $scopeUserId)'
+    : 'AND userId IS NONE';
+  const userParams = userId ? { scopeUserId: userId } : {};
+
+  const [denseRes, bm25Res] = await Promise.all([
+    mode !== 'lexical' && queryVector
+      ? db.query<[SegmentRow[]]>(
+          `SELECT id, conversationId, text, occurredAt,
+                  vector::similarity::cosine(embedding, $q) AS score
+             FROM episode_segment
+            WHERE embedding != NONE ${piiGate} ${userGate}
+            ORDER BY score DESC
+            LIMIT $k`,
+          { q: queryVector, k: fetchK, ...userParams },
+        )
+      : Promise.resolve([[] as SegmentRow[]]),
+    mode !== 'vector'
+      ? db.query<[SegmentRow[]]>(
+          `SELECT id, conversationId, text, occurredAt,
+                  search::score(1) AS score
+             FROM episode_segment
+            WHERE text @1@ $q ${piiGate} ${userGate}
+            ORDER BY score DESC
+            LIMIT $k`,
+          { q: queryText, k: fetchK, ...userParams },
+        )
+      : Promise.resolve([[] as SegmentRow[]]),
+  ]);
+  return {
+    vectorRows: (denseRes[0] ?? []).map((r) => toFactRow(r, 'vector')),
+    lexicalRows: (bm25Res[0] ?? []).map((r) => toFactRow(r, 'lexical')),
+  };
+}

--- a/src/search/internals/stage-budget.ts
+++ b/src/search/internals/stage-budget.ts
@@ -18,7 +18,12 @@ const DEFAULT_STAGE_BUDGET_MS = {
 
 export type StageBudgets = Record<keyof typeof DEFAULT_STAGE_BUDGET_MS, number>;
 
-export function resolveStageBudgets(env = process.env): StageBudgets {
+/**
+ * Env resolution takes a caller-supplied env — the S5.2 boundary allows
+ * raw environment reads only in the retrieval-profile bootstrap
+ * (resolveSearchTuning), which owns the call.
+ */
+export function resolveStageBudgets(env: NodeJS.ProcessEnv): StageBudgets {
   const fromEnv = (key: string, fallback: number): number => {
     const raw = env[key];
     if (!raw) return fallback;

--- a/src/search/internals/types.ts
+++ b/src/search/internals/types.ts
@@ -132,6 +132,12 @@ export interface ScoreBreakdown {
    */
   chatterPenalty?: number;
   /**
+   * Interval-overlap decay vs the asOf anchor (profile temporalMode =
+   * 'overlap_boost', audit W4 #17). Omitted when 1.0 — i.e. the fact's
+   * validity interval contains the anchor, or no anchor was set.
+   */
+  temporalOverlap?: number;
+  /**
    * Source-reputation track, Phase 5: the "because" decomposition of the
    * fact's trust as it entered ranking. sourceReputation is the
    * write-time snapshot ladder (learnedTrust ?? declaredTrust ?? 0.5 —

--- a/src/search/internals/types.ts
+++ b/src/search/internals/types.ts
@@ -15,7 +15,8 @@ export type RetrievalStage =
   | 'graph_seed'
   | 'graph_neighbour'
   | 'edge_expansion'
-  | 'ppr';
+  | 'ppr'
+  | 'segment';
 
 /** One graph edge to a neighbour entity, as projected by both the edge-
  *  expansion query and (under SEARCH_COMBINED_VECTOR_GRAPH) the vector leg. */

--- a/src/search/internals/where-builder.ts
+++ b/src/search/internals/where-builder.ts
@@ -34,6 +34,13 @@ export interface BuildBaseWhereOptions {
    * working; production callers always pass it.
    */
   derivedVersion?: string | null;
+  /**
+   * Profile temporalMode (audit W4 #17). 'overlap_boost' relaxes the
+   * asOf validity closure — near-miss facts survive to scoring, where
+   * the interval-overlap factor decays them by distance instead of a
+   * hard cut. Default 'filter' keeps strict point-in-time semantics.
+   */
+  temporalMode?: 'filter' | 'overlap_boost';
   opts?: BaseWhereOptions;
 }
 
@@ -43,6 +50,7 @@ export function buildBaseWhere({
   includeRetracted,
   includeContested,
   derivedVersion,
+  temporalMode = 'filter',
   opts = {},
 }: BuildBaseWhereOptions): { sql: string; params: Record<string, unknown> } {
   const clauses: string[] = [];
@@ -120,7 +128,21 @@ export function buildBaseWhere({
   //   Bitemporal access ("what was true on date X") is the
   //   exception, served by the `asOf` parameter or the entity
   //   timeline endpoint.
-  if (asOf) {
+  if (asOf && temporalMode === 'overlap_boost') {
+    // Overlap-boost mode (audit W4 #17): the validity interval is NOT a
+    // gate here — facts outside it survive retrieval and the scoring
+    // stage decays them by their distance to asOf (Hindsight-style
+    // overlap + distance decay). A slightly-wrong asOf degrades scores
+    // instead of emptying the result set. Retraction and lifecycle
+    // gates still apply — soft recall never resurrects retracted or
+    // compacted rows.
+    clauses.push(
+      `AND (retractedAt IS NONE OR retractedAt > $asOf)
+         AND status != 'compacted'
+         AND status != 'corroborating'`,
+    );
+    params.asOf = asOf;
+  } else if (asOf) {
     // Explicit historical asOf — point-in-time view.
     // Filter on the VALIDITY axis (validFrom/validUntil); do NOT
     // gate on recordedAt — search shouldn't disappear a fact just

--- a/src/search/internals/where-builder.ts
+++ b/src/search/internals/where-builder.ts
@@ -1,5 +1,6 @@
 import { StringRecordId } from 'surrealdb';
 import type { SearchDto } from '../dto/search.dto';
+import { ReadPinService } from '../../episodes/read-pin.service';
 
 /**
  * Compose the WHERE-clause fragment that every leg query shares.
@@ -80,7 +81,7 @@ export function buildBaseWhere({
   // falls back to the process bootstrap default.
   const pin =
     derivedVersion === undefined
-      ? process.env.RETRIEVAL_DERIVED_VERSION?.trim() || null
+      ? ReadPinService.bootstrapDefault()
       : derivedVersion;
   if (pin) {
     clauses.push(`AND derivedVersion = $derivedVersion`);

--- a/src/search/pipeline-context.ts
+++ b/src/search/pipeline-context.ts
@@ -1,5 +1,5 @@
 import { SearchDto, SearchMode } from './dto/search.dto';
-import type { RetrievalProfile } from './retrieval-profile';
+import type { RetrievalProfile, SearchTuning } from './retrieval-profile';
 
 /**
  * Per-request retrieval-pipeline context, shared by the search
@@ -24,4 +24,10 @@ export interface PipelineContext {
   derivedVersion: string | null;
   /** Per-tenant retrieval profile, resolved once by the guard. */
   profile: RetrievalProfile;
+  /**
+   * Deployment-wide tuning knobs, resolved once per request by the
+   * retrieval-profile bootstrap (S5.2 — the one module allowed to read
+   * the environment under the boundary).
+   */
+  tuning: SearchTuning;
 }

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -110,6 +110,14 @@ export interface RetrievalProfile {
   /** PRF second retrieval for summary/enumeration-routed questions. */
   wideProbe: boolean;
   wideProbeLimit: number;
+  /**
+   * Entity-expansion second retrieval inside the search pipeline
+   * (audit W4 #19): the top entities the first pass discovered — and
+   * the query never named — anchor a second legs+fusion pass before
+   * scoring. SmartSearch's multi-session lever; off by default until
+   * measured per genre.
+   */
+  entityExpansion: boolean;
   /** Active dispatch lanes; empty set = no typed dispatch. */
   lanes: ReadonlySet<LaneId>;
 }
@@ -191,6 +199,7 @@ export function resolveRetrievalProfile(
     extraEvidenceCap: positiveIntEnv(env, 'SYNTHESIZE_EXTRA_EVIDENCE_CAP', 40),
     wideProbe: envFlagEnabled(env.SYNTHESIZE_LANE_WIDE_PROBE),
     wideProbeLimit: positiveIntEnv(env, 'SYNTHESIZE_WIDE_PROBE_LIMIT', 12),
+    entityExpansion: envFlagEnabled(env.RETRIEVAL_ENTITY_EXPANSION),
     lanes,
   };
 }
@@ -257,7 +266,11 @@ export function resolveRetrievalProfileFor(
       merged[key] = Math.floor(v);
     }
   }
-  for (const key of ['segmentRerank', 'wideProbe'] as const) {
+  for (const key of [
+    'segmentRerank',
+    'wideProbe',
+    'entityExpansion',
+  ] as const) {
     if (typeof o[key] === 'boolean') merged[key] = o[key] as boolean;
   }
   if (Array.isArray(o.lanes)) {

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -3,6 +3,14 @@ import {
   envFlagEnabled,
   envFlagNotDisabled,
 } from '../common/env-validation';
+import {
+  resolveStageBudgets,
+  type StageBudgets,
+} from './internals/stage-budget';
+import {
+  resolveExpansionConfig,
+  type ExpansionConfig,
+} from './internals/edge-expansion';
 
 /**
  * RetrievalProfile — the per-tenant configuration object that replaced
@@ -290,4 +298,102 @@ export function resolveRetrievalProfileFor(
  */
 export function getActiveRetrievalProfile(): RetrievalProfile {
   return getRequestContext()?.retrievalProfile ?? resolveRetrievalProfile();
+}
+
+/**
+ * SearchTuning — every numeric/infra knob the search pipeline reads,
+ * resolved HERE and only here (S5.2: this module is the one place under
+ * the profile boundary allowed to touch process.env). Unlike the
+ * RetrievalProfile — genre semantics, per-tenant — these are
+ * deployment-wide tuning values. Resolved per request (search() stamps
+ * one snapshot into the PipelineContext), so a live env flip lands on
+ * the next request: no constructor capture, no false runtimeMutable
+ * claims (audit W6 #28).
+ */
+export interface SearchTuning {
+  /** SEARCH_USAGE_RECORDING_ENABLED — stamp surfaced facts (0053). */
+  usageRecording: boolean;
+  /** SEARCH_USAGE_DECAY_ENABLED — decay from lastReadAt. */
+  usageDecay: boolean;
+  /** SEARCH_PPR_ENABLED / SEARCH_PPR_AUTO_THRESHOLD. */
+  pprEnabled: boolean;
+  pprAutoThreshold: number;
+  /** Source-reputation ranking knobs (Phase 5); 0 = factor 1.0. */
+  trustBeta: number;
+  corroborationGamma: number;
+  authorityDelta: number;
+  /** Chatter demotion in (0,1); 1 = off. */
+  chatterPenalty: number;
+  /** Cross-encoder windows + margin-skip. */
+  crossEncoderLocalWindow: number;
+  crossEncoderWindow: number;
+  rerankSkipMargin: number;
+  stageBudgets: StageBudgets;
+  /** Token-count worker offload (response shaping). */
+  tokenCountOffload: boolean;
+  tokenOffloadMinHits: number;
+  /** Leg construction knobs. */
+  combinedVectorGraph: boolean;
+  hnswEnabled: boolean;
+  hnswEf: number;
+  hnswOverfetch: number;
+  highlightEnabled: boolean;
+  edgeExpansion: ExpansionConfig;
+}
+
+function tuningInt(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  fallback: number,
+): number {
+  const v = parseInt(env[name] ?? '', 10);
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+}
+
+/** Optional non-negative float knob; unset/invalid → 0 (feature off). */
+function nonNegativeFloat(env: NodeJS.ProcessEnv, name: string): number {
+  const v = Number(env[name] ?? 0);
+  return Number.isFinite(v) && v > 0 ? v : 0;
+}
+
+/**
+ * Penalty multiplier; OFF is 1.0. Returns the value only when it's a
+ * real demotion in (0,1); unset / invalid / ≥1 → 1.0 (no penalty).
+ */
+function unitPenalty(env: NodeJS.ProcessEnv, name: string): number {
+  const raw = env[name];
+  if (raw === undefined) return 1;
+  const v = Number(raw);
+  return Number.isFinite(v) && v > 0 && v < 1 ? v : 1;
+}
+
+export function resolveSearchTuning(
+  env: NodeJS.ProcessEnv = process.env,
+): SearchTuning {
+  return {
+    usageRecording: envFlagEnabled(env.SEARCH_USAGE_RECORDING_ENABLED),
+    usageDecay: envFlagEnabled(env.SEARCH_USAGE_DECAY_ENABLED),
+    pprEnabled: envFlagEnabled(env.SEARCH_PPR_ENABLED),
+    pprAutoThreshold: tuningInt(env, 'SEARCH_PPR_AUTO_THRESHOLD', 0),
+    trustBeta: nonNegativeFloat(env, 'SEARCH_TRUST_BETA'),
+    corroborationGamma: nonNegativeFloat(env, 'SEARCH_CORROBORATION_GAMMA'),
+    authorityDelta: nonNegativeFloat(env, 'SEARCH_AUTHORITY_DELTA'),
+    chatterPenalty: unitPenalty(env, 'SEARCH_CHATTER_PENALTY'),
+    crossEncoderLocalWindow: tuningInt(
+      env,
+      'SEARCH_CROSS_ENCODER_LOCAL_WINDOW',
+      20,
+    ),
+    crossEncoderWindow: tuningInt(env, 'SEARCH_CROSS_ENCODER_WINDOW', 50),
+    rerankSkipMargin: nonNegativeFloat(env, 'SEARCH_RERANK_SKIP_MARGIN'),
+    stageBudgets: resolveStageBudgets(env),
+    tokenCountOffload: envFlagEnabled(env.SEARCH_TOKEN_COUNT_OFFLOAD ?? '1'),
+    tokenOffloadMinHits: tuningInt(env, 'SEARCH_TOKEN_OFFLOAD_MIN_HITS', 24),
+    combinedVectorGraph: envFlagEnabled(env.SEARCH_COMBINED_VECTOR_GRAPH),
+    hnswEnabled: envFlagEnabled(env.SEARCH_HNSW_ENABLED),
+    hnswEf: tuningInt(env, 'SEARCH_HNSW_EF', 100),
+    hnswOverfetch: tuningInt(env, 'SEARCH_HNSW_OVERFETCH', 4),
+    highlightEnabled: envFlagEnabled(env.SEARCH_HIGHLIGHT_ENABLED),
+    edgeExpansion: resolveExpansionConfig(env),
+  };
 }

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -23,15 +23,28 @@ export type RetrievalGenre = 'dialogue' | 'assistant_chat' | 'documents';
 
 /**
  * How verbatim L0 evidence (episode quotes / provenance excerpts /
- * segments) reaches the synthesis prompt:
+ * segments) reaches answers:
  *  - 'off'               — never; facts only.
  *  - 'shape_conditioned' — episode quotes + provenance excerpts only
  *                          when the question asks for conversational
  *                          content (verbatim shape). The engine default.
  *  - 'always'            — all three verbatim lanes run unconditionally
- *                          (diary-genre profile; the old lane flags ON).
+ *                          as a prompt appendix (diary-genre profile;
+ *                          the old lane flags ON).
+ *  - 'fused'             — audit W4 #18: segments become first-class
+ *                          SearchHits — retrieved inside the search
+ *                          pipeline (dense+BM25 through the same convex
+ *                          fusion), scored, reranked, and CITABLE next
+ *                          to facts, instead of an unscored prompt
+ *                          appendix. The two episode quote lanes stay
+ *                          shape-conditioned; the appendix segment lane
+ *                          is off (segments arrive as hits).
  */
-export type VerbatimEvidenceMode = 'off' | 'shape_conditioned' | 'always';
+export type VerbatimEvidenceMode =
+  | 'off'
+  | 'shape_conditioned'
+  | 'always'
+  | 'fused';
 
 /**
  * How the generator's "today" is anchored:
@@ -156,6 +169,7 @@ export function resolveRetrievalProfile(
         'off',
         'shape_conditioned',
         'always',
+        'fused',
       ] as const) ?? (legacyVerbatimAlways ? 'always' : 'shape_conditioned'),
     dateAnchoring:
       enumEnv(env, 'RETRIEVAL_DATE_ANCHORING', [
@@ -214,7 +228,7 @@ export function resolveRetrievalProfileFor(
   }
   if (
     typeof o.verbatimEvidence === 'string' &&
-    ['off', 'shape_conditioned', 'always'].includes(o.verbatimEvidence)
+    ['off', 'shape_conditioned', 'always', 'fused'].includes(o.verbatimEvidence)
   ) {
     merged.verbatimEvidence = o.verbatimEvidence as VerbatimEvidenceMode;
   }

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -42,6 +42,21 @@ export type VerbatimEvidenceMode = 'off' | 'shape_conditioned' | 'always';
  */
 export type DateAnchoring = 'none' | 'session_date' | 'absolute';
 
+/**
+ * How an explicit `asOf` shapes retrieval (audit W4 #17 — temporal used
+ * to be a hard filter ONLY, so a bad asOf was a recall cliff):
+ *  - 'filter'        — bitemporal closure excludes facts not valid at
+ *                      asOf. Strict point-in-time semantics; the engine
+ *                      default.
+ *  - 'overlap_boost' — the validity closure is relaxed for asOf reads;
+ *                      instead, facts whose validity interval contains
+ *                      asOf keep full score and facts outside it decay
+ *                      exponentially with distance (Hindsight-style
+ *                      overlap + distance decay). Soft recall, fuzzier
+ *                      point-in-time compliance.
+ */
+export type TemporalMode = 'filter' | 'overlap_boost';
+
 /** One id per dispatch lane; the Lane registry must cover all of them. */
 export type LaneId =
   | 'temporal'
@@ -66,6 +81,7 @@ export interface RetrievalProfile {
   genre: RetrievalGenre;
   verbatimEvidence: VerbatimEvidenceMode;
   dateAnchoring: DateAnchoring;
+  temporalMode: TemporalMode;
   /** Global fact budget for fact-centric selection. */
   factBudget: number;
   /** Episode quotes per prompt (episodic lane BM25 top-k). */
@@ -148,6 +164,11 @@ export function resolveRetrievalProfile(
         'absolute',
       ] as const) ??
       (envFlagNotDisabled(env.SYNTHESIZE_DATE_CONTEXT) ? 'absolute' : 'none'),
+    temporalMode:
+      enumEnv(env, 'RETRIEVAL_TEMPORAL_MODE', [
+        'filter',
+        'overlap_boost',
+      ] as const) ?? 'filter',
     factBudget: positiveIntEnv(env, 'SEARCH_FACT_CENTRIC_BUDGET', 48),
     quotesPerPrompt: positiveIntEnv(env, 'SEARCH_EPISODIC_LANE_TOPK', 8),
     sourceExcerptsCap: positiveIntEnv(env, 'SYNTHESIZE_SOURCE_EXCERPTS_CAP', 16),
@@ -202,6 +223,12 @@ export function resolveRetrievalProfileFor(
     ['none', 'session_date', 'absolute'].includes(o.dateAnchoring)
   ) {
     merged.dateAnchoring = o.dateAnchoring as DateAnchoring;
+  }
+  if (
+    typeof o.temporalMode === 'string' &&
+    ['filter', 'overlap_boost'].includes(o.temporalMode)
+  ) {
+    merged.temporalMode = o.temporalMode as TemporalMode;
   }
   for (const key of [
     'factBudget',

--- a/src/search/search-rerank.service.ts
+++ b/src/search/search-rerank.service.ts
@@ -5,14 +5,19 @@ import { CrossEncoderService } from '../ai/cross-encoder.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { withSpan } from '../common/tracing';
 import type { EntityBucket } from './internals/types';
-import {
-  resolveStageBudgets,
-  withStageBudget,
-  type StageBudgets,
-} from './internals/stage-budget';
+import { withStageBudget, type StageBudgets } from './internals/stage-budget';
+import { resolveSearchTuning } from './retrieval-profile';
 import { fetchNeighbours, type Neighbour } from './internals/neighbours';
 import { shouldSkipRerankByMargin } from './internals/rerank-skip';
 import { PipelineContext } from './pipeline-context';
+
+/**
+ * Stage budgets from the request's tuning snapshot; partial-cast test
+ * contexts fall back to a fresh bootstrap resolution.
+ */
+function budgetsOf(ctx: PipelineContext): StageBudgets {
+  return ctx.tuning?.stageBudgets ?? resolveSearchTuning().stageBudgets;
+}
 
 /**
  * SearchRerankService — the rerank-side stages of the search pipeline:
@@ -29,7 +34,6 @@ import { PipelineContext } from './pipeline-context';
 @Injectable()
 export class SearchRerankService {
   private readonly logger = new Logger(SearchRerankService.name);
-  private readonly budgets: StageBudgets = resolveStageBudgets();
 
   constructor(
     private readonly reranker: RerankerService,
@@ -52,8 +56,8 @@ export class SearchRerankService {
     // tighter window (SEARCH_CROSS_ENCODER_LOCAL_WINDOW, default 20). Cohere
     // batches server-side and keeps the wider SEARCH_CROSS_ENCODER_WINDOW.
     const configuredWindow = this.crossEncoder.isLocalOnly()
-      ? parseInt(process.env.SEARCH_CROSS_ENCODER_LOCAL_WINDOW ?? '20', 10) || 20
-      : parseInt(process.env.SEARCH_CROSS_ENCODER_WINDOW ?? '50', 10) || 50;
+      ? (ctx.tuning?.crossEncoderLocalWindow ?? 20)
+      : (ctx.tuning?.crossEncoderWindow ?? 50);
     const crossEncoderWindow = this.crossEncoder.isEnabled()
       ? Math.min(configuredWindow, byEntity.size)
       : rerankWindow;
@@ -113,6 +117,7 @@ export class SearchRerankService {
         wideCandidates,
         ctx.dto.query,
         RERANK_WINDOW,
+        budgetsOf(ctx),
       );
     } else if (!this.crossEncoder.isEnabled()) {
       this.metrics?.countCrossEncoder('skipped_disabled');
@@ -120,9 +125,7 @@ export class SearchRerankService {
       this.metrics?.countCrossEncoder('skipped_singleton');
     }
 
-    const rerankSkipMargin = parseFloat(
-      process.env.SEARCH_RERANK_SKIP_MARGIN ?? '0',
-    );
+    const rerankSkipMargin = ctx.tuning?.rerankSkipMargin ?? 0;
     // shouldSkipRerankByMargin compares fused rankScore of top-1 vs top-2.
     // After runCrossEncoder, candidatesForRerank is ordered by cross-encoder
     // relevance, NOT by rankScore — so candidatesForRerank[0/1] are no longer
@@ -153,10 +156,12 @@ export class SearchRerankService {
     });
   }
 
+  // eslint-disable-next-line max-params
   private async runCrossEncoder(
     wideCandidates: EntityBucket[],
     query: string,
     rerankWindow: number,
+    budgets: StageBudgets,
   ): Promise<EntityBucket[]> {
     // Build inputs once — same shape feeds both cross-encoder and LLM
     // rerank stages. The LLM stage adds neighbours later (per-candidate
@@ -185,7 +190,7 @@ export class SearchRerankService {
       () =>
         withStageBudget({
           stage: 'crossEncoder',
-          budgetMs: this.budgets.crossEncoder,
+          budgetMs: budgets.crossEncoder,
           fn: () => this.crossEncoder.rerank(query, xInputs),
           fallback: identityPerm,
           logger: this.logger,
@@ -248,7 +253,7 @@ export class SearchRerankService {
       () =>
         withStageBudget({
           stage: 'rerank',
-          budgetMs: this.budgets.rerank,
+          budgetMs: budgetsOf(ctx).rerank,
           fn: () => this.reranker.rerank(ctx.dto.query, rerankInputs),
           fallback: identityPerm,
           logger: this.logger,

--- a/src/search/search-rerank.service.ts
+++ b/src/search/search-rerank.service.ts
@@ -10,7 +10,7 @@ import {
   withStageBudget,
   type StageBudgets,
 } from './internals/stage-budget';
-import { fetchNeighbours } from './internals/neighbours';
+import { fetchNeighbours, type Neighbour } from './internals/neighbours';
 import { shouldSkipRerankByMargin } from './internals/rerank-skip';
 import { PipelineContext } from './pipeline-context';
 
@@ -19,8 +19,12 @@ import { PipelineContext } from './pipeline-context';
  * cross-encoder windowing, the margin-skip heuristic, and the LLM
  * reranker with 1-hop neighbourhood injection. Owns the reranker,
  * cross-encoder, and metrics deps (all rerank metrics live here).
- * SearchService passes the bucketed candidates + scoped `db`; splitting
- * this out keeps every search class ≤3 injected deps.
+ *
+ * Audit W4 #20: the stage runs WITHOUT a DB handle — its only DB need
+ * (1-hop neighbours for the LLM rerank body) is prefetched by
+ * SearchService via prefetchNeighbours() while it still holds the
+ * scoped connection, so the 8-slot scoped pool is never parked behind a
+ * cross-encoder pass or an external LLM round-trip.
  */
 @Injectable()
 export class SearchRerankService {
@@ -33,16 +37,16 @@ export class SearchRerankService {
     @Optional() private readonly metrics?: MetricsService,
   ) {}
 
-  async runRerankStage({
-    db,
-    byEntity,
-    ctx,
-  }: {
-    db: Surreal;
-    byEntity: Map<string, EntityBucket>;
-    ctx: PipelineContext;
-  }): Promise<EntityBucket[]> {
-    const RERANK_WINDOW = Math.min(ctx.limit * 2, 20);
+  /**
+   * The cross-encoder-window candidate slice, sorted by rankScore —
+   * shared by the rerank stage and the neighbour prefetch so the
+   * prefetch covers a superset of whatever the LLM rerank will see.
+   */
+  private wideCandidates(
+    byEntity: Map<string, EntityBucket>,
+    ctx: PipelineContext,
+  ): { wideCandidates: EntityBucket[]; rerankWindow: number } {
+    const rerankWindow = Math.min(ctx.limit * 2, 20);
     // The local cross-encoder scores pairs sequentially on a worker thread —
     // a 50-wide window can't clear the stage budget, so the local path gets a
     // tighter window (SEARCH_CROSS_ENCODER_LOCAL_WINDOW, default 20). Cohere
@@ -50,13 +54,57 @@ export class SearchRerankService {
     const configuredWindow = this.crossEncoder.isLocalOnly()
       ? parseInt(process.env.SEARCH_CROSS_ENCODER_LOCAL_WINDOW ?? '20', 10) || 20
       : parseInt(process.env.SEARCH_CROSS_ENCODER_WINDOW ?? '50', 10) || 50;
-    const CROSS_ENCODER_WINDOW = this.crossEncoder.isEnabled()
+    const crossEncoderWindow = this.crossEncoder.isEnabled()
       ? Math.min(configuredWindow, byEntity.size)
-      : RERANK_WINDOW;
+      : rerankWindow;
+    return {
+      wideCandidates: [...byEntity.values()]
+        .sort((a, b) => b.rankScore - a.rankScore)
+        .slice(0, crossEncoderWindow),
+      rerankWindow,
+    };
+  }
 
-    const wideCandidates = [...byEntity.values()]
-      .sort((a, b) => b.rankScore - a.rankScore)
-      .slice(0, CROSS_ENCODER_WINDOW);
+  /**
+   * Prefetch the 1-hop neighbourhoods the LLM rerank body will want,
+   * over the cross-encoder window (a superset of the final rerank
+   * window). Called by SearchService INSIDE the scoped connection;
+   * returns an empty map when the LLM reranker cannot run at all, so a
+   * disabled reranker costs no query.
+   */
+  async prefetchNeighbours(
+    db: Surreal,
+    byEntity: Map<string, EntityBucket>,
+    ctx: PipelineContext,
+  ): Promise<Map<string, Neighbour[]>> {
+    if (!this.reranker.isEnabled() || byEntity.size <= 1) return new Map();
+    const { wideCandidates } = this.wideCandidates(byEntity, ctx);
+    return withSpan(
+      'search.fetch_neighbours',
+      () =>
+        fetchNeighbours(
+          db,
+          this.logger,
+          wideCandidates.map((e) => e.entityId),
+        ),
+      { 'neighbours.candidates': wideCandidates.length },
+    );
+  }
+
+  async runRerankStage({
+    byEntity,
+    ctx,
+    neighboursByEntity,
+  }: {
+    byEntity: Map<string, EntityBucket>;
+    ctx: PipelineContext;
+    /** Prefetched by prefetchNeighbours(); missing entries → no graph line. */
+    neighboursByEntity?: Map<string, Neighbour[]>;
+  }): Promise<EntityBucket[]> {
+    const { wideCandidates, rerankWindow: RERANK_WINDOW } = this.wideCandidates(
+      byEntity,
+      ctx,
+    );
 
     let candidatesForRerank = wideCandidates.slice(0, RERANK_WINDOW);
 
@@ -98,7 +146,11 @@ export class SearchRerankService {
       return candidatesForRerank;
     }
 
-    return this.runLlmRerank({ db, candidatesForRerank, ctx });
+    return this.runLlmRerank({
+      candidatesForRerank,
+      ctx,
+      neighboursByEntity: neighboursByEntity ?? new Map(),
+    });
   }
 
   private async runCrossEncoder(
@@ -148,29 +200,19 @@ export class SearchRerankService {
   }
 
   private async runLlmRerank({
-    db,
     candidatesForRerank,
     ctx,
+    neighboursByEntity,
   }: {
-    db: Surreal;
     candidatesForRerank: EntityBucket[];
     ctx: PipelineContext;
+    neighboursByEntity: Map<string, Neighbour[]>;
   }): Promise<EntityBucket[]> {
     // SubgraphRAG-style 1-hop neighbourhood injection. Surfaces graph
     // context as "Connected to: …" lines in the candidate body — lets
     // the reranker disambiguate shared-firstname / same-topic peers by
-    // whose neighbours match the query.
-    const neighboursByEntity = await withSpan(
-      'search.fetch_neighbours',
-      () =>
-        fetchNeighbours(
-          db,
-          this.logger,
-          candidatesForRerank.map((e) => e.entityId),
-        ),
-      { 'neighbours.candidates': candidatesForRerank.length },
-    );
-
+    // whose neighbours match the query. The map arrives prefetched
+    // (audit W4 #20) — no DB work happens on this side of the seam.
     const rerankInputs = candidatesForRerank.map((e) => {
       const ent = e.facts[0]?.row.entity ?? {
         type: 'other',

--- a/src/search/search-retrieval.service.ts
+++ b/src/search/search-retrieval.service.ts
@@ -8,6 +8,7 @@ import type { EntityBucket, FactRow } from './internals/types';
 import { runVectorLeg, runLexicalLeg } from './internals/legs';
 import { fuse } from './internals/fusion';
 import { scoreRows, bucketByEntity } from './internals/scoring';
+import { runSegmentLegs } from './internals/segment-leg';
 import { PipelineContext } from './pipeline-context';
 
 /**
@@ -122,6 +123,62 @@ export class SearchRetrievalService {
           ),
     ]);
     return fuse(vectorRows, lexicalRows, ctx.mode);
+  }
+
+  /**
+   * Verbatim fusion leg (audit W4 #18, profile verbatimEvidence =
+   * 'fused'): episode segments retrieved as first-class candidates —
+   * dense + BM25 through the SAME convex fuse() as the fact legs, then
+   * the same scoring — returned as their own entity buckets for the
+   * rerank / fact-centric stages to arbitrate against facts. Failures
+   * degrade to an empty map: verbatim is additive evidence, never a
+   * reason to fail the search.
+   */
+  async runSegmentLegStage(
+    db: Surreal,
+    ctx: PipelineContext,
+  ): Promise<Map<string, EntityBucket>> {
+    try {
+      return await withSpan('search.segment_leg', async (span) => {
+        const queryVector =
+          ctx.mode !== 'lexical'
+            ? await this.embedder.embed(ctx.dto.query)
+            : null;
+        const { vectorRows, lexicalRows } = await runSegmentLegs({
+          db,
+          queryText: ctx.dto.query,
+          queryVector,
+          fetchK: Math.max(ctx.profile.segmentTopK * 3, 12),
+          callerScopes: ctx.callerScopes,
+          userId: ctx.dto.userId,
+          mode: ctx.mode,
+        });
+        const fused = fuse(vectorRows, lexicalRows, ctx.mode);
+        for (const r of fused) {
+          if (!r.stages?.includes('segment')) {
+            r.stages = [...(r.stages ?? []), 'segment'];
+          }
+        }
+        span.setAttribute('candidates', fused.length);
+        traceArtifact(
+          'search.segment_hits',
+          fused.slice(0, 10).map((r) => ({
+            segmentId: String(r.id),
+            fusedScore: r.fusedScore,
+            object: r.object.slice(0, 120),
+          })),
+        );
+        return this.scoreAndBucket(fused, {
+          temporalAnchor:
+            ctx.profile.temporalMode === 'overlap_boost' ? ctx.asOf : null,
+        });
+      });
+    } catch (e) {
+      this.logger.warn(
+        `segment fusion leg failed (companyId=${ctx.companyId}): ${(e as Error).message}`,
+      );
+      return new Map();
+    }
   }
 
   /**

--- a/src/search/search-retrieval.service.ts
+++ b/src/search/search-retrieval.service.ts
@@ -131,6 +131,13 @@ export class SearchRetrievalService {
    */
   scoreAndBucket(
     rows: Parameters<typeof scoreRows>[0]['rows'],
+    opts?: {
+      /**
+       * asOf anchor for the interval-overlap decay (profile
+       * temporalMode = 'overlap_boost'). Null/omitted → factor 1.0.
+       */
+      temporalAnchor?: Date | null;
+    },
   ): Map<string, EntityBucket> {
     const scored = scoreRows({
       rows,
@@ -142,6 +149,7 @@ export class SearchRetrievalService {
       corroborationGamma: this.corroborationGamma,
       authorityDelta: this.authorityDelta,
       chatterPenalty: this.chatterPenalty,
+      temporalAnchor: opts?.temporalAnchor ?? null,
     });
     return bucketByEntity(scored);
   }

--- a/src/search/search-retrieval.service.ts
+++ b/src/search/search-retrieval.service.ts
@@ -10,6 +10,7 @@ import { fuse } from './internals/fusion';
 import { scoreRows, bucketByEntity } from './internals/scoring';
 import { runSegmentLegs } from './internals/segment-leg';
 import { PipelineContext } from './pipeline-context';
+import { resolveSearchTuning, type SearchTuning } from './retrieval-profile';
 
 /**
  * SearchRetrievalService — the retrieval-side stages of the search
@@ -23,20 +24,6 @@ import { PipelineContext } from './pipeline-context';
 @Injectable()
 export class SearchRetrievalService {
   private readonly logger = new Logger(SearchRetrievalService.name);
-  // Source-reputation Phase 5 — all default 0 so ranking stays
-  // byte-identical until an operator opts in. Validated at boot
-  // (env-validation); the local guard covers post-boot env drift.
-  private readonly trustBeta = nonNegativeFloatEnv('SEARCH_TRUST_BETA');
-  private readonly corroborationGamma = nonNegativeFloatEnv(
-    'SEARCH_CORROBORATION_GAMMA',
-  );
-  private readonly authorityDelta = nonNegativeFloatEnv(
-    'SEARCH_AUTHORITY_DELTA',
-  );
-  // Chatter demotion — a sub-1.0 multiplier on `said` facts. Unlike the
-  // trust knobs, the OFF value is 1.0 (not 0), so a dedicated reader with a
-  // (0,1] clamp; unset/invalid/≥1 → 1.0 → byte-identical ranking.
-  private readonly chatterPenalty = unitPenaltyEnv('SEARCH_CHATTER_PENALTY');
 
   constructor(
     private readonly embedder: EmbedderService,
@@ -78,6 +65,7 @@ export class SearchRetrievalService {
                 k: ctx.candidateK,
                 baseWhere,
                 logger: this.logger,
+                tuning: ctx.tuning,
               });
               span.setAttribute('candidates', rows.length);
               traceArtifact(
@@ -105,6 +93,7 @@ export class SearchRetrievalService {
                 query: ctx.dto.query,
                 k: ctx.candidateK,
                 baseWhere,
+                tuning: ctx.tuning,
               });
               span.setAttribute('candidates', rows.length);
               traceArtifact(
@@ -171,6 +160,7 @@ export class SearchRetrievalService {
         return this.scoreAndBucket(fused, {
           temporalAnchor:
             ctx.profile.temporalMode === 'overlap_boost' ? ctx.asOf : null,
+          tuning: ctx.tuning,
         });
       });
     } catch (e) {
@@ -194,37 +184,29 @@ export class SearchRetrievalService {
        * temporalMode = 'overlap_boost'). Null/omitted → factor 1.0.
        */
       temporalAnchor?: Date | null;
+      /**
+       * Deployment tuning (trust/corroboration/authority/chatter
+       * knobs). Omitted → resolved fresh from the bootstrap, so a live
+       * env flip lands on the next call (no constructor capture —
+       * audit W6 #28).
+       */
+      tuning?: SearchTuning;
     },
   ): Map<string, EntityBucket> {
+    const tuning = opts?.tuning ?? resolveSearchTuning();
     const scored = scoreRows({
       rows,
       now: Date.now(),
       calibrator: {
         calibrate: (raw: number) => this.calibration.calibrate(raw),
       },
-      trustBeta: this.trustBeta,
-      corroborationGamma: this.corroborationGamma,
-      authorityDelta: this.authorityDelta,
-      chatterPenalty: this.chatterPenalty,
+      trustBeta: tuning.trustBeta,
+      corroborationGamma: tuning.corroborationGamma,
+      authorityDelta: tuning.authorityDelta,
+      chatterPenalty: tuning.chatterPenalty,
       temporalAnchor: opts?.temporalAnchor ?? null,
     });
     return bucketByEntity(scored);
   }
 }
 
-/** Optional non-negative float env knob; unset/invalid → 0 (feature off). */
-function nonNegativeFloatEnv(name: string): number {
-  const v = Number(process.env[name] ?? 0);
-  return Number.isFinite(v) && v > 0 ? v : 0;
-}
-
-/**
- * Penalty multiplier env knob; OFF is 1.0. Returns the value only when it's
- * a real demotion in (0,1); unset / invalid / ≥1 → 1.0 (no penalty).
- */
-function unitPenaltyEnv(name: string): number {
-  const raw = process.env[name];
-  if (raw === undefined) return 1;
-  const v = Number(raw);
-  return Number.isFinite(v) && v > 0 && v < 1 ? v : 1;
-}

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -358,6 +358,7 @@ export class SearchService {
       includeRetracted: ctx.includeRetracted,
       includeContested: ctx.includeContested,
       derivedVersion: ctx.derivedVersion,
+      temporalMode: ctx.profile.temporalMode,
       opts: { langFilter },
     });
     traceArtifact('search.query', {
@@ -379,6 +380,7 @@ export class SearchService {
         includeRetracted: ctx.includeRetracted,
         includeContested: ctx.includeContested,
         derivedVersion: ctx.derivedVersion,
+        temporalMode: ctx.profile.temporalMode,
       });
       const fallback = await this.retrieval.runRetrievalStage(
         db,
@@ -435,7 +437,13 @@ export class SearchService {
     }
 
     // 4. Scoring + per-entity bucketing with diversity-aware degree boost.
-    const byEntity = this.retrieval.scoreAndBucket(filtered);
+    // Under temporalMode='overlap_boost' the asOf anchor feeds the
+    // interval-overlap decay; in 'filter' mode every surviving row
+    // already contains the anchor, so passing it is a no-op there.
+    const byEntity = this.retrieval.scoreAndBucket(filtered, {
+      temporalAnchor:
+        ctx.profile.temporalMode === 'overlap_boost' ? ctx.asOf : null,
+    });
 
     // 5. Edge expansion (default ON) — graph-walk from top seeds. When the
     // combined vector+graph leg ran, the vector-matched facts already carry

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -22,7 +22,10 @@ import {
 import { applyMetaUnion } from '../policy/meta-union';
 import { getPolicyContext } from '../common/request-context';
 import { pinUserScope } from '../auth/user-scope';
-import { expandEntityIdsViaEdges as expandEntityIdsViaEdgesDb } from './internals/neighbours';
+import {
+  expandEntityIdsViaEdges as expandEntityIdsViaEdgesDb,
+  type Neighbour,
+} from './internals/neighbours';
 import { expandViaEdges, buildNeighbourMap } from './internals/edge-expansion';
 import { buildEntityExpansionQuery } from './internals/query-expansion';
 import { applyPprPrior } from './internals/ppr';
@@ -67,6 +70,17 @@ export type { GraphRetrieveHit } from './internals/graph-retrieve';
  * Anything heavier than that belongs in a stage module or stage service.
  */
 
+/**
+ * Hand-off between the DB-scoped stages and the connectionless rank
+ * tail (audit W4 #20): everything the rerank/assembly stages need,
+ * prefetched so the scoped pool slot is released before the pipeline's
+ * slowest awaits (cross-encoder pass, external LLM rerank).
+ */
+interface StagedPipeline {
+  byEntity: Map<string, import('./internals/types').EntityBucket>;
+  rowPolicy: ReturnType<typeof makeRowPolicyFilter>;
+  neighboursByEntity: Map<string, Neighbour[]>;
+}
 
 @Injectable()
 export class SearchService {
@@ -309,24 +323,30 @@ export class SearchService {
       ReadPinService.bootstrapDefault();
 
     const profile = getActiveRetrievalProfile();
-    const out = await this.surreal.withScopedCompany(
+    const ctx: PipelineContext = {
+      dto,
+      callerScopes,
+      companyId,
+      limit,
+      asOf,
+      includeRetracted,
+      includeContested,
+      mode,
+      candidateK,
+      derivedVersion,
+      profile,
+    };
+    // Audit W4 #20: only the DB-touching stages run inside the scoped
+    // connection; the cross-encoder pass and the external LLM rerank —
+    // the pipeline's slowest awaits — run AFTER the 8-slot pool
+    // connection is released (their one DB need, the 1-hop rerank
+    // neighbourhoods, is prefetched inside the scope).
+    const staged = await this.surreal.withScopedCompany(
       companyId,
       callerScopes,
-      (db) =>
-        this.runPipeline(db, {
-          dto,
-          callerScopes,
-          companyId,
-          limit,
-          asOf,
-          includeRetracted,
-          includeContested,
-          mode,
-          candidateK,
-          derivedVersion,
-          profile,
-        }),
+      (db) => this.runDbStages(db, ctx),
     );
+    const out = await this.rankAndAssemble(staged, ctx);
     // Usage reinforcement, write side (opt-in): stamp the facts this
     // search actually surfaced. Fire-and-forget on the root pool — the
     // response never waits on it, and multi-hop / synthesize get it for
@@ -344,10 +364,10 @@ export class SearchService {
     return out;
   }
 
-  private async runPipeline(
+  private async runDbStages(
     db: Surreal,
     ctx: PipelineContext,
-  ): Promise<{ results: SearchHit[] }> {
+  ): Promise<StagedPipeline> {
     // Phase 4.B locale-aware retrieval. Detect the query language
     // (or honour the explicit dto.queryLang) and apply a two-pass
     // filter → cross-lingual backoff strategy. `und` or disabled →
@@ -504,11 +524,31 @@ export class SearchService {
       }
     }
 
-    // 7. Cross-encoder + LLM rerank.
-    let topEntities = await this.rerank.runRerankStage({
+    // Last DB touch: prefetch the 1-hop neighbourhoods the LLM rerank
+    // body wants, so the rerank stage needs no connection at all.
+    const neighboursByEntity = await this.rerank.prefetchNeighbours(
       db,
       byEntity,
       ctx,
+    );
+    return { byEntity, rowPolicy, neighboursByEntity };
+  }
+
+  /**
+   * Post-connection stages (audit W4 #20): cross-encoder + LLM rerank,
+   * tail refill, fact-centric selection, assembly, output shaping. No
+   * DB handle in scope — everything here runs on prefetched state.
+   */
+  private async rankAndAssemble(
+    staged: StagedPipeline,
+    ctx: PipelineContext,
+  ): Promise<{ results: SearchHit[] }> {
+    const { byEntity, rowPolicy, neighboursByEntity } = staged;
+    // 7. Cross-encoder + LLM rerank.
+    let topEntities = await this.rerank.runRerankStage({
+      byEntity,
+      ctx,
+      neighboursByEntity,
     });
     // The rerank stage only ranks a bounded window (≤20 buckets). When the
     // caller asked for more (limit up to the DTO's @Max(100)), the reranked

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -47,8 +47,10 @@ import { SearchRetrievalService } from './search-retrieval.service';
 import { SearchRerankService } from './search-rerank.service';
 import { PipelineContext } from './pipeline-context';
 import { ReadPinService } from '../episodes/read-pin.service';
-import { envFlagEnabled } from '../common/env-validation';
-import { getActiveRetrievalProfile } from './retrieval-profile';
+import {
+  getActiveRetrievalProfile,
+  resolveSearchTuning,
+} from './retrieval-profile';
 import { JobWorkerPool } from '../jobs/job-worker-pool.service';
 
 export type { SearchHit } from './search.types';
@@ -323,6 +325,7 @@ export class SearchService {
       ReadPinService.bootstrapDefault();
 
     const profile = getActiveRetrievalProfile();
+    const tuning = resolveSearchTuning();
     const ctx: PipelineContext = {
       dto,
       callerScopes,
@@ -335,6 +338,7 @@ export class SearchService {
       candidateK,
       derivedVersion,
       profile,
+      tuning,
     };
     // Audit W4 #20: only the DB-touching stages run inside the scoped
     // connection; the cross-encoder pass and the external LLM rerank —
@@ -351,7 +355,7 @@ export class SearchService {
     // search actually surfaced. Fire-and-forget on the root pool — the
     // response never waits on it, and multi-hop / synthesize get it for
     // free since they route through this method.
-    if (envFlagEnabled(process.env.SEARCH_USAGE_RECORDING_ENABLED)) {
+    if (tuning.usageRecording) {
       recordFactUsage({
         surreal: this.surreal,
         logger: this.logger,
@@ -483,7 +487,7 @@ export class SearchService {
     // from the most recent retrieval instead of only recordedAt. Soft-
     // fails inside; rows injected later (edge expansion) stay
     // unenriched — supplementary context, not primary relevance.
-    if (envFlagEnabled(process.env.SEARCH_USAGE_DECAY_ENABLED)) {
+    if (ctx.tuning.usageDecay) {
       await enrichWithUsage(db, this.logger, filtered);
     }
 
@@ -494,6 +498,7 @@ export class SearchService {
     const byEntity = this.retrieval.scoreAndBucket(filtered, {
       temporalAnchor:
         ctx.profile.temporalMode === 'overlap_boost' ? ctx.asOf : null,
+      tuning: ctx.tuning,
     });
 
     // 5. Edge expansion (default ON) — graph-walk from top seeds. When the
@@ -511,7 +516,7 @@ export class SearchService {
     });
 
     // 6. PPR (opt-in) — HippoRAG-style cluster lift.
-    await this.runPprStage(db, byEntity);
+    await this.runPprStage(db, byEntity, ctx);
 
     // 6b. Verbatim fusion leg (audit W4 #18): under the 'fused' profile,
     // segments arrive as their own scored buckets and compete with fact
@@ -592,7 +597,12 @@ export class SearchService {
     });
     rowPolicy.finish();
     return {
-      results: await applyOutputShaping(hits, ctx.dto, this.workerPool),
+      results: await applyOutputShaping(
+        hits,
+        ctx.dto,
+        this.workerPool,
+        ctx.tuning,
+      ),
     };
   }
 
@@ -623,6 +633,7 @@ export class SearchService {
           logger: this.logger,
           byEntity,
           baseWhere,
+          config: ctx.tuning.edgeExpansion,
           dto: ctx.dto,
           callerScopes: ctx.callerScopes,
           passesPolicy: (row) => rowFilterFn(row),
@@ -643,12 +654,10 @@ export class SearchService {
   private async runPprStage(
     db: Surreal,
     byEntity: Map<string, EntityBucket>,
+    ctx: PipelineContext,
   ): Promise<void> {
-    const pprForced = envFlagEnabled(process.env.SEARCH_PPR_ENABLED);
-    const pprAutoThreshold = parseInt(
-      process.env.SEARCH_PPR_AUTO_THRESHOLD ?? '0',
-      10,
-    );
+    const pprForced = ctx.tuning.pprEnabled;
+    const pprAutoThreshold = ctx.tuning.pprAutoThreshold;
     const pprAuto = pprAutoThreshold > 0 && byEntity.size >= pprAutoThreshold;
     if (!(pprForced || pprAuto) || byEntity.size <= 1) return;
     await withSpan(

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -24,6 +24,7 @@ import { getPolicyContext } from '../common/request-context';
 import { pinUserScope } from '../auth/user-scope';
 import { expandEntityIdsViaEdges as expandEntityIdsViaEdgesDb } from './internals/neighbours';
 import { expandViaEdges, buildNeighbourMap } from './internals/edge-expansion';
+import { buildEntityExpansionQuery } from './internals/query-expansion';
 import { applyPprPrior } from './internals/ppr';
 import { shouldSkipRerankByMargin } from './internals/rerank-skip';
 import { selectFactCentric } from './internals/fact-centric';
@@ -400,6 +401,36 @@ export class SearchService {
         merged: fused.length - firstPassCount,
         langFilter,
       });
+    }
+
+    // 1c. Entity-expansion second retrieval (audit W4 #19, profile
+    // entityExpansion): the first pass DISCOVERED entities the query
+    // never named; a second legs+fusion pass anchored on the top
+    // discovered names pulls the facts a single-shot query misses.
+    // Runs BEFORE scoring so expansion rows go through identity-merge,
+    // ABAC, scoring, and rerank exactly like first-pass rows.
+    if (ctx.profile.entityExpansion && fused.length > 0) {
+      const expansionQuery = buildEntityExpansionQuery(ctx.dto.query, fused);
+      if (expansionQuery) {
+        const extra = await this.retrieval.runRetrievalStage(
+          db,
+          { ...ctx, dto: { ...ctx.dto, query: expansionQuery } },
+          baseWhere,
+        );
+        const seen = new Set(fused.map((r) => String(r.id)));
+        let added = 0;
+        for (const r of extra) {
+          if (!seen.has(String(r.id))) {
+            fused.push(r);
+            seen.add(String(r.id));
+            added += 1;
+          }
+        }
+        traceArtifact('search.entity_expansion', {
+          expansionQuery,
+          added,
+        });
+      }
     }
 
     // 2. Identity-merge re-attribution + scope/ABAC row filter. One

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -462,6 +462,17 @@ export class SearchService {
     // 6. PPR (opt-in) — HippoRAG-style cluster lift.
     await this.runPprStage(db, byEntity);
 
+    // 6b. Verbatim fusion leg (audit W4 #18): under the 'fused' profile,
+    // segments arrive as their own scored buckets and compete with fact
+    // buckets in the rerank + fact-centric stages — citable next to
+    // facts instead of an unscored prompt appendix.
+    if (ctx.profile.verbatimEvidence === 'fused') {
+      const segBuckets = await this.retrieval.runSegmentLegStage(db, ctx);
+      for (const [k, v] of segBuckets) {
+        if (!byEntity.has(k)) byEntity.set(k, v);
+      }
+    }
+
     // 7. Cross-encoder + LLM rerank.
     let topEntities = await this.rerank.runRerankStage({
       db,

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -115,8 +115,11 @@ interface GeneratorOutput {
  * engine default) only when the question asks for ASSISTANT-side
  * content — extraction is user-fact-shaped and the measured SSA
  * failure is "facts do not specify…" while the verbatim turn sits
- * unused in L0; 'off' never. Module-level to keep synthesize()
- * complexity flat.
+ * unused in L0; 'off' never. 'fused' behaves like shape_conditioned
+ * for the two episode quote lanes — segments arrive as first-class
+ * SearchHits from the retrieval-side fusion leg (audit W4 #18), so the
+ * appendix segment lane below deliberately does NOT run. Module-level
+ * to keep synthesize() complexity flat.
  */
 function wantsVerbatimEvidence(
   profile: RetrievalProfile,
@@ -596,7 +599,9 @@ export class SynthesizeService {
       : [];
     // Segments compete for the prompt on their own retrieval merit —
     // an 'always' verbatim profile runs them; the shape-conditioned
-    // default does not (they measurably distract on assistant chats).
+    // default does not (they measurably distract on assistant chats);
+    // 'fused' retrieves them as scored SearchHits inside search, so
+    // appending them here would duplicate the evidence.
     const segmentLines =
       profile.verbatimEvidence === 'always'
         ? ((await this.segmentLane?.transcriptLines({

--- a/test/aggregate-composer.unit-spec.ts
+++ b/test/aggregate-composer.unit-spec.ts
@@ -79,12 +79,16 @@ describe('AggregateComposerService (Lane C v1)', () => {
     const deletes = queries.filter((q) => q.sql.includes('DELETE knowledge_fact'));
     expect(deletes).toHaveLength(1);
     expect(deletes[0].params?.recorder).toBe(AGGREGATE_RECORDER);
-    const creates = queries.filter((q) => q.sql.includes('CREATE knowledge_fact'));
-    expect(creates).toHaveLength(2);
-    expect(creates[0].params?.predicate).toBe('aggregate_pets_');
-    expect(creates[1].params?.predicate).toBe('aggregate_activities');
-    expect((creates[0].params?.derivedFrom as unknown[]).length).toBe(2);
-    expect(creates[0].params?.embedding).toEqual([1, 0]);
+    // Atomic swap (audit W2): delete + insert share ONE transaction —
+    // a reader never sees the entity stripped of its aggregates.
+    expect(deletes[0].sql).toContain('BEGIN TRANSACTION');
+    expect(deletes[0].sql).toContain('INSERT INTO knowledge_fact');
+    const rows = deletes[0].params?.rows as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0].predicate).toBe('aggregate_pets_');
+    expect(rows[1].predicate).toBe('aggregate_activities');
+    expect((rows[0].derivedFrom as unknown[]).length).toBe(2);
+    expect(rows[0].embedding).toEqual([1, 0]);
   });
 
   it('filters aggregates with <2 members or out-of-range indexes', async () => {
@@ -100,7 +104,9 @@ describe('AggregateComposerService (Lane C v1)', () => {
     });
     const res = await svc.run('co_x');
     expect(res.aggregatesWritten).toBe(0);
-    expect(queries.some((q) => q.sql.includes('CREATE knowledge_fact'))).toBe(false);
+    expect(
+      queries.some((q) => q.sql.includes('INSERT INTO knowledge_fact')),
+    ).toBe(false);
   });
 
   it('skips entities with too few facts without calling the LLM', async () => {
@@ -133,8 +139,11 @@ describe('AggregateComposerService (Lane C v1)', () => {
     const tops = queries.find((q) => q.sql.includes('GROUP BY entityId'));
     expect(tops?.sql).toContain('derivedVersion = $version');
     expect(tops?.params?.version).toBe('wd-v2');
-    const create = queries.find((q) => q.sql.includes('CREATE knowledge_fact'));
-    expect(create?.params?.version).toBe('wd-v2');
+    const swap = queries.find((q) =>
+      q.sql.includes('INSERT INTO knowledge_fact'),
+    );
+    const rows = swap?.params?.rows as Array<Record<string, unknown>>;
+    expect(rows[0].derivedVersion).toBe('wd-v2');
     const del = queries.find((q) => q.sql.includes('DELETE knowledge_fact'));
     expect(del?.sql).toContain('derivedVersion = $version');
   });

--- a/test/audit-p2-hotpath.unit-spec.ts
+++ b/test/audit-p2-hotpath.unit-spec.ts
@@ -82,16 +82,26 @@ describe('SearchService empty-query short-circuit + embed prewarm', () => {
     withScopedCompany?: jest.Mock;
     prewarm?: jest.Mock;
   }) {
+    // The scoped-connection phase now returns the staged hand-off
+    // (audit W4 #20) — the rank tail runs after the pool slot is
+    // released, so the mock must hand back a minimal StagedPipeline.
     const withScopedCompany =
       overrides.withScopedCompany ??
-      jest.fn(async () => ({ results: [] as SearchHit[] }));
+      jest.fn(async () => ({
+        byEntity: new Map(),
+        rowPolicy: { finish: () => undefined },
+        neighboursByEntity: new Map(),
+      }));
     const prewarm = overrides.prewarm ?? jest.fn(async () => undefined);
     const surreal = { withScopedCompany } as never;
     const retrieval = {
       prewarmQueryEmbedding: prewarm,
       runRetrievalStage: jest.fn(async () => []),
     } as never;
-    const rerank = {} as never;
+    const rerank = {
+      runRerankStage: jest.fn(async () => []),
+      prefetchNeighbours: jest.fn(async () => new Map()),
+    } as never;
     return { svc: new SearchService(surreal, retrieval, rerank), withScopedCompany, prewarm };
   }
 
@@ -112,7 +122,11 @@ describe('SearchService empty-query short-circuit + embed prewarm', () => {
     });
     const withScopedCompany = jest.fn(async () => {
       order.push('scoped');
-      return { results: [] as SearchHit[] };
+      return {
+        byEntity: new Map(),
+        rowPolicy: { finish: () => undefined },
+        neighboursByEntity: new Map(),
+      };
     });
     const { svc } = mkService({ withScopedCompany, prewarm });
     await svc.search('co_x', { query: 'hello' } as SearchDto, ['brain:read']);

--- a/test/dreams-version-fence.unit-spec.ts
+++ b/test/dreams-version-fence.unit-spec.ts
@@ -1,0 +1,102 @@
+import type { ConfigService } from '@nestjs/config';
+import type { Surreal } from 'surrealdb';
+import { DreamsDedupService } from '../src/dreams/dedup.service';
+import { DreamsResolverService } from '../src/dreams/resolver.service';
+import { DreamsCorroborateService } from '../src/dreams/corroborate.service';
+import { derivedVersionFence } from '../src/episodes/read-pin.service';
+import type { EntityJudgeService } from '../src/ai/entity-judge.service';
+
+/**
+ * Audit W2 #10 (dreams port of the compaction fence): dreams legs were
+ * version-BLIND — dedup drew identity edges off residual worlds' name
+ * facts, resolve treated the same fact re-derived into three worlds as
+ * a 3-way disagreement, corroborate mutated fact status in worlds the
+ * pinned reader never queries. Every candidate SELECT now carries the
+ * derived-world fence.
+ */
+function recordingDb(): {
+  db: Surreal;
+  queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+} {
+  const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      queries.push({ sql, params });
+      return [[]];
+    },
+  } as unknown as Surreal;
+  return { db, queries };
+}
+
+function config(flags: Record<string, string>): ConfigService {
+  return {
+    get: (k: string, d?: string) => flags[k] ?? d,
+    getOrThrow: (k: string) => flags[k] ?? 'x',
+  } as unknown as ConfigService;
+}
+
+describe('derivedVersionFence', () => {
+  it('pins the versioned world', () => {
+    expect(derivedVersionFence('wd-v3')).toEqual({
+      clause: 'AND derivedVersion = $derivedVersion',
+      params: { derivedVersion: 'wd-v3' },
+    });
+  });
+
+  it('pins the legacy namespace when no world is live', () => {
+    expect(derivedVersionFence(null)).toEqual({
+      clause: 'AND derivedVersion IS NONE',
+      params: {},
+    });
+  });
+});
+
+describe('dreams legs stay inside the tenant live world (W2)', () => {
+  it('dedup seed query is fenced to the pin', async () => {
+    const { db, queries } = recordingDb();
+    const svc = new DreamsDedupService(
+      config({ DREAMS_DEDUP_ENABLED: '1', OPENAI_API_KEY: 'sk' }),
+      { isAvailable: () => true } as unknown as EntityJudgeService,
+    );
+    await svc.run(db, 'wd-v3');
+    const seed = queries.find((q) => q.sql.includes("predicate = 'name'"));
+    expect(seed?.sql).toContain('AND derivedVersion = $derivedVersion');
+    expect(seed?.params?.derivedVersion).toBe('wd-v3');
+  });
+
+  it('dedup legacy tenant is fenced to the NONE namespace', async () => {
+    const { db, queries } = recordingDb();
+    const svc = new DreamsDedupService(
+      config({ DREAMS_DEDUP_ENABLED: '1', OPENAI_API_KEY: 'sk' }),
+      { isAvailable: () => true } as unknown as EntityJudgeService,
+    );
+    await svc.run(db, null);
+    const seed = queries.find((q) => q.sql.includes("predicate = 'name'"));
+    expect(seed?.sql).toContain('AND derivedVersion IS NONE');
+    expect(seed?.params?.derivedVersion).toBeUndefined();
+  });
+
+  it('resolver competing-pair query is fenced to the pin', async () => {
+    const { db, queries } = recordingDb();
+    const svc = new DreamsResolverService(
+      config({ DREAMS_RESOLVE_ENABLED: '1', OPENAI_API_KEY: 'sk' }),
+    );
+    await svc.run(db, 'wd-v3');
+    const find = queries.find((q) => q.sql.includes("status = 'competing'"));
+    expect(find?.sql).toContain('AND derivedVersion = $derivedVersion');
+    expect(find?.params?.derivedVersion).toBe('wd-v3');
+  });
+
+  it('corroborate group query is fenced to the pin', async () => {
+    const { db, queries } = recordingDb();
+    const svc = new DreamsCorroborateService(
+      config({ DREAMS_CORROBORATE_ENABLED: '1', OPENAI_API_KEY: 'sk' }),
+    );
+    await svc.run(db, 'wd-v3');
+    const groups = queries.find((q) =>
+      q.sql.includes('GROUP BY entityId, predicate'),
+    );
+    expect(groups?.sql).toContain('AND derivedVersion = $derivedVersion');
+    expect(groups?.params?.derivedVersion).toBe('wd-v3');
+  });
+});

--- a/test/engine-gates.unit-spec.ts
+++ b/test/engine-gates.unit-spec.ts
@@ -48,23 +48,15 @@ const SOURCES = new Map(ALL_SRC.map((f) => [rel(f), readFileSync(f, 'utf8')]));
 const ENV_READ_RE = /process\.env/;
 
 describe('S5.2 — no process.env below the profile boundary', () => {
-  // The ONLY files inside the engine boundary allowed to read env.
-  // retrieval-profile.ts is the profile bootstrap; the rest are the
-  // pre-existing infra-knob readers, locked here so the set can only
-  // shrink (S4 removes the extractor entries; further search cleanups
-  // remove theirs). Adding a file — or re-adding a removed one — fails.
-  const ALLOWLIST = new Set([
-    'src/search/retrieval-profile.ts',
-    'src/search/search.service.ts',
-    'src/search/search-retrieval.service.ts',
-    'src/search/search-rerank.service.ts',
-    'src/search/internals/stage-budget.ts',
-    'src/search/internals/where-builder.ts',
-    'src/search/internals/response-builder.ts',
-    'src/search/internals/legs.ts',
-    'src/search/internals/edge-expansion.ts',
-    'src/admin/window-deriver.service.ts',
-  ]);
+  // The ONE file inside the engine boundary allowed to read env: the
+  // retrieval-profile bootstrap (RetrievalProfile for genre semantics +
+  // resolveSearchTuning for deployment knobs). Every other boundary
+  // module takes typed config as an argument. The V4 carried shrink
+  // (2026-08) folded the nine infra-knob readers here; the derived-
+  // version fallbacks route through ReadPinService.bootstrapDefault()
+  // in the episodes layer. Adding a file — or re-adding a removed one —
+  // fails.
+  const ALLOWLIST = new Set(['src/search/retrieval-profile.ts']);
   const BOUNDARY_PREFIXES = [
     'src/search/',
     'src/synthesize/',

--- a/test/eval-harness.unit-spec.ts
+++ b/test/eval-harness.unit-spec.ts
@@ -153,6 +153,8 @@ describe('runWorlds', () => {
   const calls: RecordedCall[] = [];
   let server: import('node:http').Server;
   let brainUrl = '';
+  // Overridden by the degraded-derive test; null = the healthy default.
+  let deriveOverride: Record<string, unknown> | null = null;
 
   beforeAll(async () => {
     const { createServer } = await import('node:http');
@@ -168,14 +170,17 @@ describe('runWorlds', () => {
           tenant: req.headers['x-brain-tenant'] as string | undefined,
           body,
         });
-        const payload = (req.url ?? '').includes('multi-hop')
+        const url = req.url ?? '';
+        const payload = url.includes('multi-hop')
           ? {
               synthesis: {
                 answer: 'no information about that',
                 tokenUsage: { promptTokens: 42 },
               },
             }
-          : { propositions: 1, segments: 1 };
+          : url.includes('/maintenance/derive') && deriveOverride
+            ? deriveOverride
+            : { propositions: 1, segments: 1, status: 'ok', failed: 0 };
         res.setHeader('Content-Type', 'application/json');
         res.end(JSON.stringify(payload));
       });
@@ -191,6 +196,33 @@ describe('runWorlds', () => {
 
   beforeEach(() => {
     calls.length = 0;
+    deriveOverride = null;
+  });
+
+  it('degraded derive fails the world instead of QAing a hollow substrate', async () => {
+    deriveOverride = {
+      propositions: 3,
+      status: 'degraded',
+      failed: 2,
+      skipped: [
+        { conversationId: 'c1', reason: '429 insufficient_quota' },
+        { conversationId: 'c2', reason: '429 insufficient_quota' },
+      ],
+    };
+    const { scores } = await runWorlds('lme', [world], {
+      brainUrl,
+      apiKey: 'k',
+      derivedVersion: 'wd-v2',
+      concurrency: 1,
+      skipIngest: false,
+      log: () => undefined,
+    });
+    // The V2 incident inverted: the poison is now a world-level error,
+    // the row is NOT checkpointed, and a resume re-derives it.
+    expect(scores).toHaveLength(1);
+    expect(String(scores[0].errored)).toContain('derive degraded');
+    expect(String(scores[0].errored)).toContain('insufficient_quota');
+    expect(calls.some((c) => c.url.includes('multi-hop'))).toBe(false);
   });
 
   it('ingests with protocol invariants and scores abstention', async () => {

--- a/test/eval/harness/driver.ts
+++ b/test/eval/harness/driver.ts
@@ -120,11 +120,29 @@ async function ingestWorld(
     }
   }
   log(`ingested ${turnTotal} turns`);
-  const derived = await client.call<{ propositions: number }>(
-    'POST',
-    '/v1/admin/maintenance/derive',
-    { version: opts.derivedVersion, force: true },
-  );
+  const derived = await client.call<{
+    propositions: number;
+    status?: 'ok' | 'degraded' | 'failed';
+    failed?: number;
+    skipped?: Array<{ conversationId: string; reason: string }>;
+  }>('POST', '/v1/admin/maintenance/derive', {
+    version: opts.derivedVersion,
+    force: true,
+  });
+  // The V2 incident: a quota 429 inside derive used to come back as a
+  // silent 201 and 18 worlds were QA'd against an empty substrate. Any
+  // non-clean derive fails the world — errored rows are not
+  // checkpointed, so a resume re-derives instead of poisoning the run.
+  if (derived.status && derived.status !== 'ok') {
+    const reasons = (derived.skipped ?? [])
+      .slice(0, 3)
+      .map((s) => s.reason)
+      .join('; ');
+    throw new Error(
+      `derive ${derived.status}: ${derived.failed ?? '?'} conversation(s) ` +
+        `failed (${reasons}) — refusing to QA a hollow world`,
+    );
+  }
   const segs = await client.call<{ segments: number }>(
     'POST',
     '/v1/admin/maintenance/segments',

--- a/test/query-expansion.unit-spec.ts
+++ b/test/query-expansion.unit-spec.ts
@@ -1,0 +1,89 @@
+import { buildEntityExpansionQuery } from '../src/search/internals/query-expansion';
+import { resolveRetrievalProfileFor } from '../src/search/retrieval-profile';
+import type { FusedRow } from '../src/search/internals/types';
+
+/**
+ * Audit W4 #19: no entity-expansion rewrite existed — retrieval
+ * discovered entities the query never named and did nothing with them.
+ */
+function row(name: string | undefined, fusedScore: number): FusedRow {
+  return {
+    id: `knowledge_fact:${name ?? 'x'}-${fusedScore}`,
+    entityId: `knowledge_entity:${name ?? 'x'}`,
+    predicate: 'hobby',
+    object: 'pottery',
+    confidence: 0.9,
+    validFrom: '2023-01-01T00:00:00Z',
+    recordedAt: '2023-01-01T00:00:00Z',
+    status: 'active',
+    source: {},
+    ...(name
+      ? {
+          entity: {
+            id: `knowledge_entity:${name}`,
+            type: 'person',
+            canonicalName: name,
+          },
+        }
+      : {}),
+    fusedScore,
+  } as FusedRow;
+}
+
+describe('buildEntityExpansionQuery', () => {
+  it('appends top discovered names the query never mentioned', () => {
+    const q = buildEntityExpansionQuery('who has cats?', [
+      row('Caroline', 0.9),
+      row('Melanie', 0.7),
+    ]);
+    expect(q).toBe('who has cats? Caroline Melanie');
+  });
+
+  it('orders by best fused score and caps at three names', () => {
+    const q = buildEntityExpansionQuery('who has cats?', [
+      row('Dana', 0.2),
+      row('Alice', 0.9),
+      row('Bob', 0.5),
+      row('Carol', 0.7),
+      row('Alice', 0.1), // duplicate keeps its best score
+    ]);
+    expect(q).toBe('who has cats? Alice Carol Bob');
+  });
+
+  it('names already present in the query are not anchors', () => {
+    expect(
+      buildEntityExpansionQuery('what does Caroline like?', [
+        row('Caroline', 0.9),
+      ]),
+    ).toBeNull();
+  });
+
+  it('empty pass, missing entities, or too-short names → null', () => {
+    expect(buildEntityExpansionQuery('q', [])).toBeNull();
+    expect(buildEntityExpansionQuery('q', [row(undefined, 0.9)])).toBeNull();
+    expect(buildEntityExpansionQuery('q', [row('ab', 0.9)])).toBeNull();
+  });
+});
+
+describe('profile entityExpansion resolution', () => {
+  const saved = process.env.RETRIEVAL_ENTITY_EXPANSION;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.RETRIEVAL_ENTITY_EXPANSION;
+    else process.env.RETRIEVAL_ENTITY_EXPANSION = saved;
+  });
+
+  it('defaults off; env and per-tenant overrides win', () => {
+    delete process.env.RETRIEVAL_ENTITY_EXPANSION;
+    expect(resolveRetrievalProfileFor('co_x').entityExpansion).toBe(false);
+    process.env.RETRIEVAL_ENTITY_EXPANSION = '1';
+    expect(resolveRetrievalProfileFor('co_x').entityExpansion).toBe(true);
+    const profile = resolveRetrievalProfileFor('co_y', {
+      ...process.env,
+      RETRIEVAL_ENTITY_EXPANSION: '0',
+      RETRIEVAL_PROFILE_OVERRIDES: JSON.stringify({
+        co_y: { entityExpansion: true },
+      }),
+    });
+    expect(profile.entityExpansion).toBe(true);
+  });
+});

--- a/test/segment-fusion-leg.unit-spec.ts
+++ b/test/segment-fusion-leg.unit-spec.ts
@@ -1,0 +1,173 @@
+import type { Surreal } from 'surrealdb';
+import { runSegmentLegs } from '../src/search/internals/segment-leg';
+import { SearchRetrievalService } from '../src/search/search-retrieval.service';
+import { resolveRetrievalProfileFor } from '../src/search/retrieval-profile';
+import type { EmbedderService } from '../src/ai/embedder.service';
+import type { CalibrationService } from '../src/ai/calibration/calibration.service';
+import type { PipelineContext } from '../src/search/pipeline-context';
+
+/**
+ * Audit W4 #18: verbatim had no read-path expression — quotes never
+ * entered SearchHit, never got scored/reranked against facts, and were
+ * structurally uncitable. Under verbatimEvidence='fused', segments run
+ * as a retrieval leg through the same convex fusion and scoring.
+ */
+function recordingDb(perQuery: Record<string, unknown[]>): {
+  db: Pick<Surreal, 'query'>;
+  queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+} {
+  const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      queries.push({ sql, params });
+      for (const [marker, rows] of Object.entries(perQuery)) {
+        if (sql.includes(marker)) return [rows];
+      }
+      return [[]];
+    },
+  } as Pick<Surreal, 'query'>;
+  return { db, queries };
+}
+
+const SEG = {
+  id: 'episode_segment:s1',
+  conversationId: 'conv-1',
+  text: '[2023-05-01] Caroline: my cats are Luna and Oliver',
+  occurredAt: '2023-05-01T10:00:00Z',
+  score: 0.9,
+};
+
+describe('runSegmentLegs', () => {
+  it('shapes segments as citable pseudo-FactRows with both leg scores', async () => {
+    const { db, queries } = recordingDb({
+      'vector::similarity::cosine': [SEG],
+      'search::score(1)': [{ ...SEG, score: 3.2 }],
+    });
+    const { vectorRows, lexicalRows } = await runSegmentLegs({
+      db,
+      queryText: 'cats',
+      queryVector: [1, 0],
+      fetchK: 12,
+      callerScopes: ['brain:read'],
+      mode: 'hybrid',
+    });
+    expect(vectorRows).toHaveLength(1);
+    expect(lexicalRows).toHaveLength(1);
+    const row = vectorRows[0];
+    expect(row.predicate).toBe('verbatim');
+    expect(String(row.entityId)).toBe('episode_segment:s1');
+    expect(row.entity?.type).toBe('segment');
+    expect(row.entity?.canonicalName).toContain('conv-1');
+    expect(row.confidence).toBe(1);
+    expect(row.validFrom).toBe('2023-05-01T10:00:00Z');
+    expect(row.simScore).toBe(0.9);
+    expect(lexicalRows[0].bm25Score).toBe(3.2);
+    // PII fence + fail-closed user scope on BOTH queries (0055 / W1 #14).
+    for (const q of queries) {
+      expect(q.sql).toContain('AND piiClass IS NONE');
+      expect(q.sql).toContain('AND userId IS NONE');
+    }
+  });
+
+  it('brain:read_pii lifts the PII fence; userId opens the user scope', async () => {
+    const { db, queries } = recordingDb({});
+    await runSegmentLegs({
+      db,
+      queryText: 'cats',
+      queryVector: [1, 0],
+      fetchK: 12,
+      callerScopes: ['brain:read', 'brain:read_pii'],
+      userId: 'u1',
+      mode: 'hybrid',
+    });
+    for (const q of queries) {
+      expect(q.sql).not.toContain('piiClass IS NONE');
+      expect(q.sql).toContain('userId IS NONE OR userId = $scopeUserId');
+      expect(q.params?.scopeUserId).toBe('u1');
+    }
+  });
+
+  it('lexical mode skips the dense query, vector mode skips BM25', async () => {
+    const { db, queries } = recordingDb({});
+    await runSegmentLegs({
+      db,
+      queryText: 'cats',
+      queryVector: null,
+      fetchK: 12,
+      callerScopes: [],
+      mode: 'lexical',
+    });
+    expect(queries).toHaveLength(1);
+    expect(queries[0].sql).toContain('search::score(1)');
+  });
+});
+
+describe('SearchRetrievalService.runSegmentLegStage', () => {
+  it('returns segment buckets scored through the shared pipeline', async () => {
+    const { db } = recordingDb({
+      'vector::similarity::cosine': [SEG],
+      'search::score(1)': [SEG],
+    });
+    const svc = new SearchRetrievalService(
+      { embed: async () => [1, 0] } as unknown as EmbedderService,
+      { calibrate: (x: number) => x } as unknown as CalibrationService,
+    );
+    const ctx = {
+      dto: { query: 'cats' },
+      mode: 'hybrid',
+      companyId: 'co_x',
+      callerScopes: ['brain:read'],
+      asOf: null,
+      profile: resolveRetrievalProfileFor('co_x'),
+    } as unknown as PipelineContext;
+    const buckets = await svc.runSegmentLegStage(db as Surreal, ctx);
+    expect(buckets.size).toBe(1);
+    const bucket = buckets.get('episode_segment:s1')!;
+    expect(bucket.facts[0].row.predicate).toBe('verbatim');
+    expect(bucket.facts[0].row.stages).toContain('segment');
+    expect(bucket.bestScore).toBeGreaterThan(0);
+  });
+
+  it('degrades to an empty map on a failing db', async () => {
+    const svc = new SearchRetrievalService(
+      { embed: async () => [1, 0] } as unknown as EmbedderService,
+      { calibrate: (x: number) => x } as unknown as CalibrationService,
+    );
+    const db = {
+      query: async () => {
+        throw new Error('db down');
+      },
+    } as unknown as Surreal;
+    const ctx = {
+      dto: { query: 'cats' },
+      mode: 'hybrid',
+      companyId: 'co_x',
+      callerScopes: [],
+      asOf: null,
+      profile: resolveRetrievalProfileFor('co_x'),
+    } as unknown as PipelineContext;
+    const buckets = await svc.runSegmentLegStage(db, ctx);
+    expect(buckets.size).toBe(0);
+  });
+});
+
+describe("profile verbatimEvidence 'fused'", () => {
+  const saved = process.env.RETRIEVAL_VERBATIM_EVIDENCE;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.RETRIEVAL_VERBATIM_EVIDENCE;
+    else process.env.RETRIEVAL_VERBATIM_EVIDENCE = saved;
+  });
+
+  it('resolves from env and per-tenant overrides', () => {
+    process.env.RETRIEVAL_VERBATIM_EVIDENCE = 'fused';
+    expect(resolveRetrievalProfileFor('co_x').verbatimEvidence).toBe('fused');
+    const profile = resolveRetrievalProfileFor('co_y', {
+      ...process.env,
+      RETRIEVAL_VERBATIM_EVIDENCE: 'shape_conditioned',
+      RETRIEVAL_PROFILE_OVERRIDES: JSON.stringify({
+        co_y: { verbatimEvidence: 'fused' },
+      }),
+    });
+    expect(profile.verbatimEvidence).toBe('fused');
+  });
+});

--- a/test/segment-lane.unit-spec.ts
+++ b/test/segment-lane.unit-spec.ts
@@ -92,16 +92,18 @@ describe('SegmentComposerService', () => {
     const svc = new SegmentComposerService(surreal, embedding, new EpisodeReadStoreService(surreal));
     const res = await svc.run('co_x');
     expect(res).toMatchObject({ conversations: 1, segments: 1 });
-    expect(
-      queries.some((q) => q.sql.includes('DELETE episode_segment')),
-    ).toBe(true);
-    const insert = queries.find((q) =>
+    const swap = queries.find((q) =>
       q.sql.includes('INSERT INTO episode_segment'),
     );
-    const rows = insert?.params?.rows as Array<Record<string, unknown>>;
+    // Atomic swap (audit W2 #10): delete + insert share ONE transaction —
+    // the lane sees the previous window set or the new one, never neither.
+    expect(swap?.sql).toContain('BEGIN TRANSACTION');
+    expect(swap?.sql).toContain('DELETE episode_segment');
+    const rows = swap?.params?.rows as Array<Record<string, unknown>>;
     expect(rows).toHaveLength(1);
     expect(rows[0].recorder).toBe(SEGMENT_RECORDER);
     expect(rows[0].piiClass).toEqual(['phone']);
+    expect(typeof rows[0].generation).toBe('string');
     expect(String(rows[0].text)).toContain('[2023-05-01] A: q1');
   });
 });

--- a/test/temporal-overlap.unit-spec.ts
+++ b/test/temporal-overlap.unit-spec.ts
@@ -1,0 +1,141 @@
+import { buildBaseWhere } from '../src/search/internals/where-builder';
+import { scoreRows } from '../src/search/internals/scoring';
+import { resolveRetrievalProfileFor } from '../src/search/retrieval-profile';
+import type { FusedRow } from '../src/search/internals/types';
+
+/**
+ * Audit W4 #17: temporal used to be a hard filter, never a boost — a bad
+ * asOf was a recall cliff. Profile temporalMode='overlap_boost' relaxes
+ * the asOf validity closure and decays out-of-interval facts by distance
+ * (Hindsight: overlap + distance decay = 91.0 TR).
+ */
+describe('where-builder temporalMode', () => {
+  const base = {
+    dto: {} as never,
+    asOf: new Date('2023-06-01T00:00:00Z'),
+    includeRetracted: false,
+    includeContested: false,
+    derivedVersion: null,
+  };
+
+  it("default 'filter' keeps the strict validity closure", () => {
+    const { sql } = buildBaseWhere(base);
+    expect(sql).toContain('validFrom <= $asOf');
+    expect(sql).toContain('validUntil IS NONE OR validUntil > $asOf');
+  });
+
+  it("'overlap_boost' drops the validity gate, keeps lifecycle gates", () => {
+    const { sql, params } = buildBaseWhere({
+      ...base,
+      temporalMode: 'overlap_boost',
+    });
+    expect(sql).not.toContain('validFrom <= $asOf');
+    expect(sql).not.toContain('validUntil > $asOf');
+    expect(sql).toContain('retractedAt IS NONE OR retractedAt > $asOf');
+    expect(sql).toContain("status != 'compacted'");
+    expect(params.asOf).toEqual(base.asOf);
+  });
+
+  it("without asOf, 'overlap_boost' changes nothing (actual-now closure)", () => {
+    const strict = buildBaseWhere({ ...base, asOf: null });
+    const soft = buildBaseWhere({
+      ...base,
+      asOf: null,
+      temporalMode: 'overlap_boost',
+    });
+    expect(soft.sql).toBe(strict.sql);
+  });
+});
+
+describe('scoreRows temporal anchor (overlap factor via breakdown)', () => {
+  const anchor = new Date('2023-06-01T00:00:00Z');
+  const row = (validFrom?: string, validUntil?: string): FusedRow =>
+    ({
+      id: `knowledge_fact:${validFrom ?? 'none'}`,
+      entityId: 'knowledge_entity:e1',
+      predicate: 'status',
+      object: 'x',
+      confidence: 0.9,
+      validFrom,
+      validUntil,
+      recordedAt: '2023-06-01T00:00:00Z',
+      fusedScore: 1,
+      stages: [],
+    }) as unknown as FusedRow;
+  const factorOf = (r: FusedRow): number | undefined =>
+    scoreRows({
+      rows: [r],
+      now: anchor.getTime(),
+      temporalAnchor: anchor,
+    })[0].breakdown.temporalOverlap;
+
+  it('interval containing the anchor → factor 1 (omitted)', () => {
+    expect(
+      factorOf(row('2023-01-01T00:00:00Z', '2024-01-01T00:00:00Z')),
+    ).toBeUndefined();
+    expect(factorOf(row('2023-01-01T00:00:00Z'))).toBeUndefined();
+  });
+
+  it('decays with distance, never below the floor', () => {
+    const near = factorOf(row('2023-06-15T00:00:00Z'))!; // 14 days after
+    const far = factorOf(row('2025-06-01T00:00:00Z'))!; // two years after
+    expect(near).toBeLessThan(1);
+    expect(near).toBeGreaterThan(far);
+    expect(far).toBeGreaterThanOrEqual(0.25);
+    expect(far).toBeLessThan(0.3);
+  });
+
+  it('expired interval decays from validUntil', () => {
+    const recentlyExpired = factorOf(
+      row('2022-01-01T00:00:00Z', '2023-05-01T00:00:00Z'), // ended 1 month before
+    )!;
+    expect(recentlyExpired).toBeLessThan(1);
+    expect(recentlyExpired).toBeGreaterThan(0.7);
+  });
+
+  it('no validFrom → neutral (omitted)', () => {
+    expect(factorOf(row(undefined))).toBeUndefined();
+  });
+
+  it('in-interval facts outrank distant ones under an anchor', () => {
+    const scored = scoreRows({
+      rows: [row('2023-05-01T00:00:00Z'), row('2025-06-01T00:00:00Z')],
+      now: anchor.getTime(),
+      temporalAnchor: anchor,
+    });
+    expect(scored[0].score).toBeGreaterThan(scored[1].score);
+  });
+
+  it('no anchor → factor absent regardless of interval', () => {
+    const scored = scoreRows({
+      rows: [row('2025-06-01T00:00:00Z')],
+      now: anchor.getTime(),
+    });
+    expect(scored[0].breakdown.temporalOverlap).toBeUndefined();
+  });
+});
+
+describe('profile temporalMode resolution', () => {
+  const saved = process.env.RETRIEVAL_TEMPORAL_MODE;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.RETRIEVAL_TEMPORAL_MODE;
+    else process.env.RETRIEVAL_TEMPORAL_MODE = saved;
+  });
+
+  it("defaults to 'filter'; env and per-tenant overrides win", () => {
+    delete process.env.RETRIEVAL_TEMPORAL_MODE;
+    expect(resolveRetrievalProfileFor('co_x').temporalMode).toBe('filter');
+    process.env.RETRIEVAL_TEMPORAL_MODE = 'overlap_boost';
+    expect(resolveRetrievalProfileFor('co_x').temporalMode).toBe(
+      'overlap_boost',
+    );
+    const profile = resolveRetrievalProfileFor('co_y', {
+      ...process.env,
+      RETRIEVAL_TEMPORAL_MODE: 'filter',
+      RETRIEVAL_PROFILE_OVERRIDES: JSON.stringify({
+        co_y: { temporalMode: 'overlap_boost' },
+      }),
+    });
+    expect(profile.temporalMode).toBe('overlap_boost');
+  });
+});

--- a/test/token-count-offload.unit-spec.ts
+++ b/test/token-count-offload.unit-spec.ts
@@ -14,6 +14,7 @@
 import { ConfigService } from '@nestjs/config';
 import { join } from 'node:path';
 import { JobWorkerPool } from '../src/jobs/job-worker-pool.service';
+import { resolveSearchTuning } from '../src/search/retrieval-profile';
 import {
   applyOutputShaping,
   tokenCountWorkerModulePath,
@@ -180,7 +181,14 @@ describe('applyOutputShaping offload vs sync parity', () => {
     process.env.SEARCH_TOKEN_OFFLOAD_MIN_HITS = '5';
     const few = hits.slice(0, 5);
     const { pool, runMock } = stubPool();
-    await applyOutputShaping(few, { query: 'q', tokenBudget: 100_000 } as SearchDto, pool);
+    // Env knobs now flow through the retrieval-profile bootstrap
+    // (S5.2) — resolve the tuning snapshot the pipeline would pass.
+    await applyOutputShaping(
+      few,
+      { query: 'q', tokenBudget: 100_000 } as SearchDto,
+      pool,
+      resolveSearchTuning(),
+    );
     expect(runMock).toHaveBeenCalledTimes(1);
   });
 
@@ -188,7 +196,7 @@ describe('applyOutputShaping offload vs sync parity', () => {
     process.env.SEARCH_TOKEN_COUNT_OFFLOAD = '0';
     const syncOut = await applyOutputShaping(hits, dto);
     const { pool, runMock } = stubPool();
-    const out = await applyOutputShaping(hits, dto, pool);
+    const out = await applyOutputShaping(hits, dto, pool, resolveSearchTuning());
     expect(out).toEqual(syncOut);
     expect(runMock).not.toHaveBeenCalled();
   });

--- a/test/window-deriver.unit-spec.ts
+++ b/test/window-deriver.unit-spec.ts
@@ -1,5 +1,7 @@
+import { BadGatewayException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { EpisodeReadStoreService } from '../src/episodes/episode-read-store.service';
+import { throwIfDeriveFailed } from '../src/admin/admin-derive.controller';
 import {
   WindowDeriverService,
   segmentSessions,
@@ -81,7 +83,10 @@ describe('buildBaseWhere derived-version namespace', () => {
 });
 
 describe('WindowDeriverService (P3 v1 batch)', () => {
-  function makeSvc(llm: unknown): {
+  function makeSvc(
+    llm: unknown,
+    opts?: { conversations?: Array<{ conversationId: string; n: number }> },
+  ): {
     svc: WindowDeriverService;
     queries: Array<{ sql: string; params?: Record<string, unknown> }>;
     derived: Array<Record<string, unknown>>;
@@ -91,7 +96,7 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
       query: async (sql: string, params?: Record<string, unknown>) => {
         queries.push({ sql, params });
         if (sql.includes('GROUP BY conversationId'))
-          return [[{ conversationId: 'conv-1', n: 3 }]];
+          return [opts?.conversations ?? [{ conversationId: 'conv-1', n: 3 }]];
         if (sql.includes('FROM episode'))
           return [
             [
@@ -419,9 +424,8 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
     });
   });
 
-  it('records conversation failures without failing the run', async () => {
-    const { svc } = makeSvc({ propositions: [] });
-    (svc as unknown as { openai: unknown }).openai = {
+  describe('failure propagation (the V2 quota-poison fix)', () => {
+    const failingLlm = {
       chat: {
         completions: {
           create: async () => {
@@ -430,11 +434,129 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
         },
       },
     };
-    const res = await svc.run('co_x');
-    expect(res.conversations).toBe(0);
-    expect(res.skipped).toEqual([
-      { conversationId: 'conv-1', reason: 'llm down' },
-    ]);
+
+    it('total failure: run resolves with status=failed and the reasons', async () => {
+      const { svc } = makeSvc({ propositions: [] });
+      (svc as unknown as { openai: unknown }).openai = failingLlm;
+      const res = await svc.run('co_x');
+      expect(res.conversations).toBe(0);
+      expect(res.skipped).toEqual([
+        { conversationId: 'conv-1', reason: 'llm down' },
+      ]);
+      expect(res.status).toBe('failed');
+      expect(res.failed).toBe(1);
+    });
+
+    it('total failure marks the registry failed, never built/live', async () => {
+      const { svc } = makeSvc({ propositions: [] });
+      (svc as unknown as { openai: unknown }).openai = failingLlm;
+      const events: string[] = [];
+      (svc as unknown as { registry: unknown }).registry = {
+        begin: async () => void events.push('begin'),
+        complete: async () => void events.push('complete'),
+        fail: async () => void events.push('fail'),
+      };
+      const res = await svc.run('co_x');
+      expect(res.status).toBe('failed');
+      expect(events).toEqual(['begin', 'fail']);
+    });
+
+    it('partial failure: degraded status, activation refused', async () => {
+      const { svc } = makeSvc(
+        {
+          propositions: [
+            {
+              subject: 'Caroline',
+              aspect: 'pets',
+              proposition: 'p',
+              occurred_on: null,
+              turns: [1],
+            },
+          ],
+        },
+        {
+          conversations: [
+            { conversationId: 'conv-1', n: 3 },
+            { conversationId: 'conv-2', n: 3 },
+          ],
+        },
+      );
+      let calls = 0;
+      const healthy = (svc as unknown as { openai: unknown }).openai;
+      (svc as unknown as { openai: unknown }).openai = {
+        chat: {
+          completions: {
+            create: async (...args: unknown[]) => {
+              calls += 1;
+              if (calls === 1) throw new Error('llm down');
+              return (
+                healthy as {
+                  chat: {
+                    completions: {
+                      create: (...a: unknown[]) => Promise<unknown>;
+                    };
+                  };
+                }
+              ).chat.completions.create(...args);
+            },
+          },
+        },
+      };
+      const res = await svc.run('co_x', { activate: true });
+      expect(res.status).toBe('degraded');
+      expect(res.failed).toBe(1);
+      expect(res.conversations).toBe(1);
+      expect(res.skipped).toEqual([
+        { conversationId: 'conv-1', reason: 'llm down' },
+      ]);
+      // Flipping every reader onto a world with known holes is never
+      // what the operator meant — activation demands a clean run.
+      expect(res.activated).toBeUndefined();
+    });
+
+    it('throwIfDeriveFailed: 502 on total failure, passthrough otherwise', () => {
+      const base = {
+        conversations: 0,
+        sessions: 0,
+        propositions: 0,
+        unresolvedSubjects: 0,
+      };
+      const failed = {
+        ...base,
+        status: 'failed' as const,
+        failed: 2,
+        skipped: [
+          { conversationId: 'c1', reason: '429 insufficient_quota' },
+          { conversationId: 'c2', reason: '429 insufficient_quota' },
+        ],
+      };
+      expect(() => throwIfDeriveFailed(failed)).toThrow(BadGatewayException);
+      const degraded = {
+        ...base,
+        conversations: 1,
+        status: 'degraded' as const,
+        failed: 1,
+        skipped: [{ conversationId: 'c1', reason: 'x' }],
+      };
+      expect(throwIfDeriveFailed(degraded)).toBe(degraded);
+    });
+
+    it('clean run reports status=ok with zero failed', async () => {
+      const { svc } = makeSvc({
+        propositions: [
+          {
+            subject: 'Caroline',
+            aspect: 'pets',
+            proposition: 'p',
+            occurred_on: null,
+            turns: [1],
+          },
+        ],
+      });
+      const res = await svc.run('co_x');
+      expect(res.status).toBe('ok');
+      expect(res.failed).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

The eight carried items from the V1-V3 validation session (docs/roadmap/validate-2026-08-results.md § Carried into V4), plus the architecture manifest draft. Defaults are byte-identical to current prod — every new behavior is a per-tenant RetrievalProfile point, default off.

### Failure propagation (the V2 quota-poison fix)
- `maintenance/derive` (and `projections/:name/rebuild`) no longer swallow per-conversation LLM failures: `DeriveRunResult` grows `status: ok|degraded|failed` + `failed`; total failure marks the projection registry `failed` and answers **502**; activation requires a clean run; the eval driver refuses to QA any non-ok derive (rows error and are not checkpointed, so a resume re-derives).

### Derived-world lifecycle (audit W2 carried)
- **Composers**: paid calls (LLM/embeddings) now run BEFORE any delete, and the wholesale replace is one atomic transaction — the segment lane never reads a conversation mid-rebuild, an entity never loses its aggregates mid-rerun. Migration **0081** adds a per-run `generation` stamp on `episode_segment`.
- **Dreams**: all four legs (dedup, resolve, corroborate, communities) are fenced to the tenant's live derived world via `ReadPinService` + the new shared `derivedVersionFence()` — a version-blind dreams run used to mutate fact status across residual worlds and treat the same fact re-derived into N worlds as an N-way disagreement.

### Read path (audit W4 carried)
- **Temporal overlap boost** — new profile key `RETRIEVAL_TEMPORAL_MODE`: `filter` (default, strict point-in-time closure) | `overlap_boost` (validity gate relaxed for asOf reads; scoring multiplies in an interval-overlap factor with exponential distance decay — Hindsight's 91.0 TR mechanism).
- **Verbatim fusion leg** — new `RETRIEVAL_VERBATIM_EVIDENCE=fused`: segments retrieved inside the search pipeline (same PII/user fences, same convex `fuse()`), scored, cross-encoder-reranked, and citable as first-class SearchHits; the `always` appendix profile stays byte-identical.
- **Entity expansion** — new profile key `RETRIEVAL_ENTITY_EXPANSION` (default off): top discovered entity names absent from the query anchor one extra legs+fusion pass before scoring (SmartSearch's multi-session lever).
- **Connection hold** — the pipeline splits into `runDbStages` (inside the scoped pool slot; ends by prefetching rerank neighbourhoods) and `rankAndAssemble` (cross-encoder + LLM rerank + assembly, connectionless) — the 8-slot pool is never parked behind model latency.

### Config as a system
- **S5.2 allowlist = one module**: every deployment knob the pipeline reads now resolves through `resolveSearchTuning()` in `retrieval-profile.ts`, stamped per request into the PipelineContext. `legs.ts` import-time SQL constants became per-call functions (live flips land without restart); the four constructor-captured trust knobs move to per-call resolution; derived-version fallbacks route through `ReadPinService.bootstrapDefault()`.

### Docs
- `docs/architecture-manifest.md` — the capability-profile thesis draft ("memory is a profile of capabilities, not a speed").
- `operations.md` profile table + validate-results V4 section updated.

## Testing
- 1820 unit tests green (36 new across 5 new spec files + updated suites), all six engine gates pass, `lint:ci` at max-warnings 0, typecheck clean, OpenAPI regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yApwtdYhLPdB8C8jpkPQV