### PR TITLE
feat(synthesize): V4 carry tail — lane parallelism, one lane type system + leg results docs

### DIFF
--- a/docs/roadmap/validate-2026-08-results.md
+++ b/docs/roadmap/validate-2026-08-results.md
@@ -216,3 +216,49 @@ review.
 None of the new profile points (overlap_boost / fused /
 entityExpansion) are default-on: defaults are byte-identical to V3
 prod, and each is a measured-leg candidate for the next eval session.
+
+## V4 confirm legs (2026-08-05, same day, read-side re-QA)
+
+All four axes ran as paired A/B chains on the SURVIVING stand
+substrates (loco-321; no re-ingest, no re-derive — read-side only):
+control arm = merged-main defaults, treatment arm = one new profile
+point. Controls double as defaults-equivalence checks against the
+pre-merge reports. Judge gpt-4.1-mini throughout; McNemar pairing.
+
+| Axis (substrate) | Control | Treatment | Verdict |
+|---|---|---|---|
+| LME temporal 233-365 (n=127 judged) | **40.2%** vs ewave-era 30.7% (+9.4pp, p=0.004) | overlap_boost **41.7%** (+1.6pp, p=0.73) | see below |
+| LME SSA 444-499 (n=56) | 48.2% | fused **41.1%** (−7.1pp, p=0.50; prompt 4.9k→11.1k tok) | fused NOT viable vs shape_conditioned as tuned |
+| LME SSU first-50 (n=50) | 82.0% vs v2smoke 80.0 (p=1.0) | entityExpansion 80.0% (p=1.0) | no harm; wrong genre (MS worlds are gone — real target unmeasured) |
+| LoCoMo dev-5 (n=762 judged) | 'always' **76.8%** vs v2eq2 76.6 (p=1.0) | fused **78.2%** (+1.4pp, p=0.27; single-hop +2.6 p=0.08; prompt 5745→5550 tok) | fused ≥ always on diary, CHEAPER |
+
+Findings:
+
+1. **The V2/V3 read-path wave was worth +9.4pp on LME temporal**
+   (30.7 → 40.2, p=0.004, 14↑/2↓). The ewave-era baseline predates the
+   W4/W5 read-path fixes (local cross-encoder default-ON, fact-centric
+   layered over the rerank order, verifier bundle); this is the first
+   paired measurement of that stack on the weakest LME type. Not a V4
+   effect — V4 defaults are equivalence-clean on all three other axes
+   (p=1.0 twice, +0.1pp once).
+2. **overlap_boost is safe and mildly positive on its target type**
+   (+1.6pp temporal, n.s., no collapse from the relaxed closure — the
+   feared soft-recall poisoning did not materialize). Needs bigger n
+   for a claim; stays default-off.
+3. **'fused' is genre-split exactly as the capability-profile thesis
+   predicts**: on assistant chats vs shape_conditioned it is additive
+   cost (2.3× prompt) with noisy-negative drift (−7.1pp n.s.); on the
+   diary profile vs 'always' it is nominally better (+1.4pp, single-hop
+   +2.6 at p=0.08) AND cheaper (−200 avg prompt tokens), because
+   segments compete for the fact budget instead of riding as an
+   unconditional appendix. Candidate: make 'fused' the diary-profile
+   default after a held-out confirm; never a shape_conditioned
+   replacement without a segment token cap.
+4. **entityExpansion remains unmeasured on its target genre** — the
+   multi-session worlds no longer exist on the stand (0/133); the
+   SSU smoke shows no harm (p=1.0). A real MS leg needs a paid
+   re-ingest.
+
+Reports: var/lme-tr-v4{control,boost}.json,
+var/lme-ssa-v4{control,fused}.json, var/lme-ssu-v4{control,exp}.json,
+var/locomo-v4{always,fused}-dev5.json (checkpoints alongside).

--- a/src/synthesize/answer-router.ts
+++ b/src/synthesize/answer-router.ts
@@ -17,11 +17,14 @@ import type { LaneId, RetrievalProfile } from '../search/retrieval-profile';
  * fail open — an unrouted question just gets the generic path.
  */
 
-/** The four query-detectable lanes (the router's output space). */
-export type AnswerLane = 'temporal' | 'enumeration' | 'preference' | 'summary';
-
-/** Alias kept for older imports; the canonical id lives in the profile. */
-export type DispatchLane = LaneId;
+/**
+ * One lane type system (audit W5 #27 carried): the canonical LaneId
+ * union lives in the profile; the router's output is a LaneId whose
+ * registry entry carries `detect` — narrowed at runtime by routing,
+ * not by a parallel type union. Re-exported so synthesize-side
+ * consumers name the type without reaching into the search layer.
+ */
+export type { LaneId } from '../search/retrieval-profile';
 
 const UNIT = '(?:day|week|month|year)s?';
 /**
@@ -52,7 +55,7 @@ const TEMPORAL_PATTERNS: RegExp[] = [
  * 98.2% after). The fix is evidence-side, not framing-side: this shape
  * pulls role-tagged episode quotes into the prompt (see
  * SynthesizeService.collectTranscriptLines), so it is deliberately NOT
- * an AnswerLane — it composes with whatever lane frames the answer.
+ * a routed lane — it composes with whatever lane frames the answer.
  */
 const VERBATIM_PATTERNS: RegExp[] = [
   /what (?:did|do|have|had) you (?:say|tell|suggest|recommend|propose|advise|share|give|send|write|explain|walk)/i,
@@ -298,19 +301,19 @@ export function laneInstructionFor(lane: LaneId | null | undefined):
 export function routeLane(
   profile: RetrievalProfile,
   query: string,
-): AnswerLane | null {
+): LaneId | null {
   for (const lane of LANE_REGISTRY) {
     if (!lane.detect || !profile.lanes.has(lane.id)) continue;
-    if (lane.detect(query ?? '')) return lane.id as AnswerLane;
+    if (lane.detect(query ?? '')) return lane.id;
   }
   return null;
 }
 
 /** Detection over every registry lexicon, ignoring the profile — for
  *  tests and offline tooling that ask "what WOULD this route to". */
-export function detectLane(query: string): AnswerLane | null {
+export function detectLane(query: string): LaneId | null {
   for (const lane of LANE_REGISTRY) {
-    if (lane.detect?.(query ?? '')) return lane.id as AnswerLane;
+    if (lane.detect?.(query ?? '')) return lane.id;
   }
   return null;
 }
@@ -322,7 +325,7 @@ export function detectLane(query: string): AnswerLane | null {
  */
 export function laneProbeDto(
   profile: RetrievalProfile,
-  lane: AnswerLane | null,
+  lane: LaneId | null,
   probe: { query: string; baseHits: SearchHit[] },
 ): { query: string; limit: number } | null {
   if (!lane || !profile.lanes.has(lane)) return null;

--- a/src/synthesize/generator-prompt.ts
+++ b/src/synthesize/generator-prompt.ts
@@ -3,7 +3,7 @@ import {
   CONTRADICTION_NOTE_INSTRUCTION,
   STANDING_INSTRUCTIONS_INSTRUCTION,
   laneInstructionFor,
-  type AnswerLane,
+  type LaneId,
 } from './answer-router';
 
 /**
@@ -31,7 +31,7 @@ export function buildGeneratorUserMessage({
   answerLang: string | null;
   dateContext?: string;
   /** T1 typed dispatch: lane-specific answer instruction. */
-  lane?: AnswerLane | null;
+  lane?: LaneId | null;
   /** T7: standing user instructions rendered as their own section. */
   instructions?: string[];
   /** T3: write-side COMPETING conflict pairs present in the evidence. */

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -24,7 +24,7 @@ import {
   extractStandingInstructions,
   detectEvidenceConflicts,
   detectVerbatimShape,
-  type AnswerLane,
+  type LaneId,
 } from './answer-router';
 export { detectEvidenceConflicts } from './answer-router';
 import {
@@ -154,7 +154,7 @@ function salvageTruncatedAnswer(content: string): GeneratorOutput | null {
  *  profile's dateAnchoring. */
 function resolveLaneDateContext(
   profile: RetrievalProfile,
-  lane: AnswerLane | null,
+  lane: LaneId | null,
   asOf: string | undefined,
 ): string | undefined {
   if (lane === 'temporal' && asOf) return asOf.slice(0, 10);
@@ -283,7 +283,7 @@ export class SynthesizeService {
     // Typed dispatch: lane detection is lexical and free, so it runs
     // before retrieval — the preference lane adds a deterministic
     // second probe that similarity search would never surface.
-    const lane: AnswerLane | null = routeLane(profile, dto.query);
+    const lane: LaneId | null = routeLane(profile, dto.query);
 
     onProgress({ stage: 'search', message: 'hybrid retrieval' });
     const searchResult = await withSpan(
@@ -694,7 +694,7 @@ export class SynthesizeService {
     baseHits,
   }: {
     profile: RetrievalProfile;
-    lane: AnswerLane | null;
+    lane: LaneId | null;
     query: string;
     companyId: string;
     callerScopes: string[];
@@ -799,7 +799,7 @@ export class SynthesizeService {
     /** ISO date the answer should treat as "today" (SYNTHESIZE_DATE_CONTEXT). */
     dateContext?: string;
     /** T1 typed dispatch lane, when the router matched. */
-    lane?: AnswerLane | null;
+    lane?: LaneId | null;
     /** T7: standing user instructions for their own section. */
     instructions?: string[];
     /** T3: COMPETING conflict pairs detected in the evidence. */

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -322,7 +322,14 @@ export class SynthesizeService {
     );
 
     const answerMode = guardrails === 'answer';
-    const instructions = await this.collectStandingInstructions({
+    // Audit W4 carried (lane-collection parallelism): the standing-
+    // instruction probe is a full second search and used to be a
+    // sequential await in front of everything else. It only needs
+    // `evidence`, so it starts here and is joined with the transcript
+    // lanes below — one round-trip window instead of two. The method
+    // degrades internally (probe failures → evidence-only), so the
+    // started promise never rejects.
+    const instructionsPromise = this.collectStandingInstructions({
       profile,
       companyId,
       callerScopes,
@@ -339,18 +346,26 @@ export class SynthesizeService {
       // routed request, independent of lane.
       markRecency: profile.lanes.has('recency'),
     });
-    if ('empty' in prepared) return prepared.empty;
+    if ('empty' in prepared) {
+      // The in-flight probe is abandoned deliberately — the empty path
+      // returns without a prompt for the instructions to land in.
+      void instructionsPromise.catch(() => undefined);
+      return prepared.empty;
+    }
     const { results, factIndex, factLines } = prepared;
 
-    const transcriptLines = await this.collectTranscriptLines({
-      profile,
-      companyId,
-      query: dto.query,
-      callerScopes,
-      factIds: [...factIndex.keys()],
-      // Same fail-closed user scope the fact read path applies (0055).
-      userId: dto.userId,
-    });
+    const [instructions, transcriptLines] = await Promise.all([
+      instructionsPromise,
+      this.collectTranscriptLines({
+        profile,
+        companyId,
+        query: dto.query,
+        callerScopes,
+        factIds: [...factIndex.keys()],
+        // Same fail-closed user scope the fact read path applies (0055).
+        userId: dto.userId,
+      }),
+    ]);
 
     // Phase 4.C — resolve the answer language. Explicit DTO wins;
     // otherwise we detect from the query (so a Russian question gets
@@ -579,40 +594,49 @@ export class SynthesizeService {
     userId?: string;
   }): Promise<string[]> {
     const active = wantsVerbatimEvidence(profile, query);
-    const laneLines = active
-      ? ((await this.episodeLane?.transcriptLines({
-          companyId,
-          query,
-          callerScopes,
-          userId,
-          limit: profile.quotesPerPrompt,
-        })) ?? [])
-      : [];
-    const sourceLines = active
-      ? ((await this.episodeLane?.sourceExcerpts({
-          companyId,
-          factIds,
-          callerScopes,
-          userId,
-          cap: profile.sourceExcerptsCap,
-        })) ?? [])
-      : [];
+    // The three lanes are independent reads — run them concurrently
+    // (audit W4 carried: they used to be three sequential awaits).
     // Segments compete for the prompt on their own retrieval merit —
     // an 'always' verbatim profile runs them; the shape-conditioned
     // default does not (they measurably distract on assistant chats);
     // 'fused' retrieves them as scored SearchHits inside search, so
     // appending them here would duplicate the evidence.
-    const segmentLines =
+    const [laneLines, sourceLines, segmentLines] = await Promise.all([
+      active
+        ? this.episodeLane
+            ?.transcriptLines({
+              companyId,
+              query,
+              callerScopes,
+              userId,
+              limit: profile.quotesPerPrompt,
+            })
+            .then((v) => v ?? [])
+        : [],
+      active
+        ? this.episodeLane
+            ?.sourceExcerpts({
+              companyId,
+              factIds,
+              callerScopes,
+              userId,
+              cap: profile.sourceExcerptsCap,
+            })
+            .then((v) => v ?? [])
+        : [],
       profile.verbatimEvidence === 'always'
-        ? ((await this.segmentLane?.transcriptLines({
-            companyId,
-            query,
-            callerScopes,
-            userId,
-            topK: profile.segmentTopK,
-            rerank: profile.segmentRerank,
-          })) ?? [])
-        : [];
+        ? this.segmentLane
+            ?.transcriptLines({
+              companyId,
+              query,
+              callerScopes,
+              userId,
+              topK: profile.segmentTopK,
+              rerank: profile.segmentRerank,
+            })
+            .then((v) => v ?? [])
+        : [],
+    ]).then((lanes) => lanes.map((l) => l ?? []));
     return [...new Set([...segmentLines, ...sourceLines, ...laneLines])];
   }
 

--- a/test/engine-gates.unit-spec.ts
+++ b/test/engine-gates.unit-spec.ts
@@ -196,9 +196,9 @@ describe('S5.6 — lane registry completeness', () => {
   it('no second lane type union exists outside the profile', () => {
     // The LaneId union lives in retrieval-profile.ts; any other file
     // spelling a union containing the evidence-conditional lanes is a
-    // parallel lane type system growing back (audit #27). AnswerLane —
-    // the router's four-detectable-lane output space — is legitimate
-    // and does not contain them.
+    // parallel lane type system growing back (audit #27). The former
+    // AnswerLane union is gone (W5 carried) — the router returns LaneId
+    // narrowed at runtime by which registry entries carry `detect`.
     const UNION_RE = /'temporal'[^;]{0,200}\|\s*'(?:contradiction|recency|instruction)'/s;
     const offenders = [...SOURCES]
       .filter(([file]) => !file.endsWith('src/search/retrieval-profile.ts'))


### PR DESCRIPTION
Two carried engineering items plus the V4 confirm-leg results doc:

- **perf(synthesize)**: standing-instruction probe and the three verbatim lanes now run concurrently (they were four sequential awaits) — same values, one round-trip window.
- **refactor(synthesize)**: the second lane type union (AnswerLane) and the DispatchLane alias are gone — routeLane/detectLane/laneProbeDto and all consumers use the canonical LaneId, narrowed at runtime by which registry entries carry detect(). S5.6 gate comment updated.
- **docs(roadmap)**: V4 confirm-leg results — four read-side A/B axes. Headline: the V2/V3 read-path wave measures +9.4pp on LME temporal (p=0.004); 'fused' is genre-split (diary +1.4pp and cheaper / assistant-chat −7.1pp at 2.3× tokens) exactly as the capability-profile thesis predicts; defaults equivalence clean on all axes.

Tests: synthesize/answer-router/gates suites green, lint:ci 0 warnings, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yApwtdYhLPdB8C8jpkPQV