### PR TITLE
fix(search): fused honours segmentTopK; abort checkpoints in synthesize lanes

### DIFF
--- a/src/search/search-retrieval.service.ts
+++ b/src/search/search-retrieval.service.ts
@@ -157,11 +157,24 @@ export class SearchRetrievalService {
             object: r.object.slice(0, 120),
           })),
         );
-        return this.scoreAndBucket(fused, {
+        const buckets = this.scoreAndBucket(fused, {
           temporalAnchor:
             ctx.profile.temporalMode === 'overlap_boost' ? ctx.asOf : null,
           tuning: ctx.tuning,
         });
+        // profile.segmentTopK means "segments per prompt" — the appendix
+        // lane honoured it, the first fused cut did not (every fetchK
+        // candidate became a bucket; measured 2.3× prompt bloat on LME
+        // SSA). Keep only the top-K segment buckets by score; the fetch
+        // overshoot still feeds the fusion/scoring stages their pool.
+        if (buckets.size > ctx.profile.segmentTopK) {
+          const keep = [...buckets.values()]
+            .sort((a, b) => b.bestScore - a.bestScore)
+            .slice(0, ctx.profile.segmentTopK);
+          buckets.clear();
+          for (const b of keep) buckets.set(b.entityId, b);
+        }
+        return buckets;
       });
     } catch (e) {
       this.logger.warn(

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -594,6 +594,7 @@ export class SynthesizeService {
     userId?: string;
   }): Promise<string[]> {
     const active = wantsVerbatimEvidence(profile, query);
+    if (getAbortSignal()?.aborted) return [];
     // The three lanes are independent reads — run them concurrently
     // (audit W4 carried: they used to be three sequential awaits).
     // Segments compete for the prompt on their own retrieval merit —
@@ -659,6 +660,11 @@ export class SynthesizeService {
     evidence: SearchHit[];
   }): Promise<string[] | undefined> {
     if (!profile.lanes.has('instruction')) return undefined;
+    // Structured cancellation: the probe is a full second search — if
+    // the request already died, don't spend it. (Per-query aborts are
+    // not supported by the DB SDK; stage-boundary checks are the
+    // honest granularity.)
+    if (getAbortSignal()?.aborted) return undefined;
     let probeHits: SearchHit[] = [];
     try {
       const probe = await withSpan('synthesize.instruction_probe', () =>
@@ -702,6 +708,7 @@ export class SynthesizeService {
   }): Promise<SearchHit[]> {
     const probeDto = laneProbeDto(profile, lane, { query, baseHits });
     if (!probeDto) return [];
+    if (getAbortSignal()?.aborted) return [];
     try {
       const probe = await withSpan('synthesize.lane_probe', () =>
         this.search.search(companyId, probeDto as SearchDto, callerScopes),

--- a/test/segment-fusion-leg.unit-spec.ts
+++ b/test/segment-fusion-leg.unit-spec.ts
@@ -151,6 +151,40 @@ describe('SearchRetrievalService.runSegmentLegStage', () => {
   });
 });
 
+describe('SearchRetrievalService.runSegmentLegStage segmentTopK cap', () => {
+  it('keeps only the top-K segment buckets by score', async () => {
+    const rows = Array.from({ length: 9 }, (_, i) => ({
+      id: `episode_segment:s${i}`,
+      conversationId: 'conv-1',
+      text: `window ${i}`,
+      occurredAt: '2023-05-01T10:00:00Z',
+      score: 0.9 - i * 0.05,
+    }));
+    const db = {
+      query: async (sql: string) =>
+        sql.includes('vector::similarity::cosine') ? [rows] : [[]],
+    } as unknown as Surreal;
+    const svc = new SearchRetrievalService(
+      { embed: async () => [1, 0] } as unknown as EmbedderService,
+      { calibrate: (x: number) => x } as unknown as CalibrationService,
+    );
+    const profile = resolveRetrievalProfileFor('co_x');
+    const ctx = {
+      dto: { query: 'cats' },
+      mode: 'vector',
+      companyId: 'co_x',
+      callerScopes: [],
+      asOf: null,
+      profile,
+    } as unknown as PipelineContext;
+    const buckets = await svc.runSegmentLegStage(db, ctx);
+    expect(profile.segmentTopK).toBe(5);
+    expect(buckets.size).toBe(5);
+    expect(buckets.has('episode_segment:s0')).toBe(true);
+    expect(buckets.has('episode_segment:s8')).toBe(false);
+  });
+});
+
 describe("profile verbatimEvidence 'fused'", () => {
   const saved = process.env.RETRIEVAL_VERBATIM_EVIDENCE;
   afterEach(() => {


### PR DESCRIPTION
V5 brief §3/§4: the fused verbatim leg now keeps only the top profile.segmentTopK segment buckets (measured 2.3× prompt bloat on LME SSA came from every fetchK candidate becoming a bucket), and synthesize I/O stages check the request AbortSignal before firing. SSA re-measure queued behind the running held-out leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yApwtdYhLPdB8C8jpkPQV