### PR TITLE
feat(write): coined-predicate alias column + append_only default (W3)

### DIFF
--- a/docs/bitemporal-semantics.md
+++ b/docs/bitemporal-semantics.md
@@ -57,7 +57,14 @@ Open-ended intervals (`validUntil IS NONE`) are treated as extending to +∞:
 | `[Mar15, ∞)` | `[Jan1, Apr1)` | Yes — overlap on `[Mar15, Apr1)`, conflict |
 | `[Apr1, May1)` | `[Apr15, ∞)` | Yes — overlap on `[Apr15, May1)`, conflict |
 
-Single-active predicates (`name`, `email`, `phone`, `dob`) bypass the overlap check — by definition only one row at a time, every prior active conflicts with the new one. Append-only (`said`, `complained_about`, `interacted_with`) never conflict.
+Single-active predicates (`name`, `email`, `phone`, `dob`) bypass the overlap check — by definition only one row at a time, every prior active conflicts with the new one. Append-only (`said`, `complained_about`, `interacted_with`) never conflict — but since migration 0082 they DO corroborate: an exact-object claim from a different origin strengthens the incumbent (`status='corroborating'`) instead of piling up as a duplicate active row.
+
+### Coined predicates: canonical alias + append_only (migration 0082)
+
+The dialogue extraction profile (open vocabulary) keeps the SPECIFIC predicate the extractor coined — `painted_seascape`, not `hobby`. Two consequences, both engine-wide invariants:
+
+1. **Resolution keys on the canonical form.** The EDC canonicalization the extraction prompt promises runs as an *alias pass*: the coinage stays in `predicate`, the registry's canonical id lands in `knowledge_fact.predicateAlias`, and the resolver (plus dedup, the diversity cap, chatter demotion, and the dreams sweeps) key on `predicateAlias ?? predicate`. Closed-vocabulary tenants never populate the alias, so their keys are byte-identical to pre-0082.
+2. **Unknown predicates default to `append_only`, not `bitemporal`.** A predicate absent from the registry is an open-vocabulary observation; supersede/compete semantics were designed for closed CRM predicates and made every coined fact take the serialized per-fact mutex path. Seed and operator-declared predicates keep their per-predicate policies. Two seed-keyed carve-outs deliberately do NOT follow the fallback: dreams-corroborate sweeps coined groups (fuzzy same-assertion is what collapses re-worded coinages) while still skipping seed append_only event history, and episodic promotion folds ONLY seed append_only predicates (a `summary_<coinage>` row would trade recall drivers for a paraphrase).
 
 ## What changes for callers
 

--- a/src/ai/extractor-internals/predicate-canonicalize.ts
+++ b/src/ai/extractor-internals/predicate-canonicalize.ts
@@ -53,6 +53,72 @@ export async function applyLocalPredicateOverrides({
 }
 
 /**
+ * EDC alias pass — the OPEN-vocabulary variant of canonicalization
+ * (0082, audit 2026-08 finding #2). The dialogue profile's point is to
+ * KEEP the specific coined predicate, so this pass never touches
+ * `f.predicate`; it runs the same registry.canonicalize and stamps the
+ * canonical id into `f.predicateAlias` instead. Downstream, resolution
+ * and the read-side predicate consumers key on
+ * `predicateAlias ?? predicate` — coinages of one canon meet, the raw
+ * coinage survives for display and embedding.
+ *
+ * A predicate that is its own canon (registry hit on itself, or a
+ * novel coinage inserted as proposed) gets NO alias — the ?? fallback
+ * already lands on the right key.
+ *
+ * Defensive: per-fact errors are logged but don't fail the pass.
+ * Returns the non-trivial decisions for trace emission.
+ */
+export async function applyAliasPass({
+  facts,
+  registry,
+  companyId,
+  logger,
+}: ApplyCanonicalizePassOptions): Promise<
+  Array<{
+    original: string;
+    canonical: string;
+    kind: 'matched' | 'aliased' | 'proposed';
+    similarity?: number;
+  }>
+> {
+  const decisions: Array<{
+    original: string;
+    canonical: string;
+    kind: 'matched' | 'aliased' | 'proposed';
+    similarity?: number;
+  }> = [];
+  for (const f of facts) {
+    const contextText = `${f.predicate}: ${f.object}${
+      f.clause ? ` (clause: ${f.clause})` : ''
+    }`;
+    try {
+      const decision = await registry.canonicalize(
+        companyId,
+        f.predicate,
+        contextText,
+      );
+      if (decision.canonicalId !== f.predicate) {
+        f.predicateAlias = decision.canonicalId;
+        decisions.push({
+          original: f.predicate,
+          canonical: decision.canonicalId,
+          kind: decision.kind,
+          ...(decision.kind === 'aliased'
+            ? { similarity: decision.similarity }
+            : {}),
+        });
+      }
+    } catch (e) {
+      logger.warn(
+        `alias pass failed for predicate '${f.predicate}': ${(e as Error).message}`,
+      );
+    }
+  }
+  return decisions;
+}
+
+/**
  * EDC canonicalization pass. For each fact, ask the registry to
  * resolve the (possibly-novel) predicate to its canonical id —
  * matching an existing predicate, auto-aliasing a similar novel one,

--- a/src/ai/extractor-internals/types.ts
+++ b/src/ai/extractor-internals/types.ts
@@ -20,6 +20,15 @@ export interface ExtractedEntity {
 export interface ExtractedFact {
   entityIndex: number;
   predicate: string;
+  /**
+   * EDC-canonical id for a coined predicate (0082, open vocabulary
+   * only). The raw coinage stays in `predicate` — specificity is the
+   * dialogue profile's whole point — while resolution, dedup and the
+   * read-side predicate consumers key on `predicateAlias ?? predicate`.
+   * Absent when the predicate is already canonical (registry hit or a
+   * novel coinage that became its own canon).
+   */
+  predicateAlias?: string;
   object: string;
   confidence: number;
   /** The clause this fact was anchored to (verbatim sub-span). */

--- a/src/ai/extractor-refine.service.ts
+++ b/src/ai/extractor-refine.service.ts
@@ -8,6 +8,7 @@ import {
 import { LocalPredicateSelectorService } from './local-predicate-selector.service';
 import type { ExtractedFact } from './extractor-internals/types';
 import {
+  applyAliasPass,
   applyCanonicalizePass,
   applyLocalPredicateOverrides,
 } from './extractor-internals/predicate-canonicalize';
@@ -34,11 +35,32 @@ export class ExtractorRefineService {
   ): Promise<void> {
     // Dialogue profile (Phase 4): the point is to KEEP the specific predicate
     // the extractor coined (painted, researched, relationship_status) rather
-    // than snap it back to a generic catch-all. Both refinement passes
-    // (local-override 0.45, canonicalize 0.85) collapse specificity, so skip
-    // them entirely. Off → unchanged.
+    // than snap it back to a generic catch-all. Both OVERWRITING refinement
+    // passes (local-override 0.45, canonicalize 0.85) collapse specificity,
+    // so they stay off — but the prompt's promised EDC canonicalization now
+    // runs as the ALIAS pass (0082, audit finding #2): the coinage survives
+    // in `predicate`, the canonical id lands in `predicateAlias`, and
+    // dedup/corroboration/read-side consumers key on `alias ?? predicate`.
     const profile = resolveExtractionProfile();
-    if (profile.vocabulary === 'open') return;
+    if (profile.vocabulary === 'open') {
+      if (facts.length === 0) return;
+      try {
+        const aliasDecisions = await applyAliasPass({
+          facts,
+          registry: this.registry,
+          companyId,
+          logger: this.logger,
+        });
+        if (aliasDecisions.length > 0) {
+          traceArtifact('extractor.predicate_alias', aliasDecisions);
+        }
+      } catch (e) {
+        this.logger.warn(
+          `extractor: alias pass failed: ${(e as Error).message}; facts keep raw coined predicates`,
+        );
+      }
+      return;
+    }
     const localThreshold = profile.refinePredicateThreshold;
     const localOverrides = await applyLocalPredicateOverrides({
       facts,

--- a/src/ai/predicate-registry-internals/types.ts
+++ b/src/ai/predicate-registry-internals/types.ts
@@ -123,7 +123,13 @@ export const DEFAULT_FALLBACK: PredicateDefinition = {
   description:
     'Synthesised fallback when a predicate is not in the registry.',
   datatype: 'string',
-  semantics: 'bitemporal',
+  // W3 (audit 2026-08 #2): a predicate NOT in the registry is a coined,
+  // open-vocabulary observation — history matters, and `bitemporal`
+  // supersede/compete semantics were invented for closed CRM predicates.
+  // Closed-vocabulary seeds keep their per-predicate policies; only the
+  // unknown-predicate fallback (and the 'proposed' rows canonicalize
+  // creates from it) defaults to append_only.
+  semantics: 'append_only',
   decayHalfLifeDays: 60,
   piiClass: 'none',
   status: 'active',

--- a/src/ai/predicate-registry-internals/types.ts
+++ b/src/ai/predicate-registry-internals/types.ts
@@ -92,6 +92,16 @@ export interface PredicateSnapshot {
    *  runtime-installed). Injected into the extractor system prompt so a pack
    *  can tune extraction for its domain. Empty when no active pack ships one. */
   extractionProfiles: PackExtractionProfile[];
+  /**
+   * Every non-deprecated predicateId (active + aliased + proposed).
+   * canonicalize()'s short-circuit checks it so a REPEAT coinage of a
+   * 'proposed' predicate resolves in-cache — before 0082's alias pass
+   * the repeat path embedded the context and hit a UNIQUE violation on
+   * re-insert EVERY time (bounded nuisance under closed vocabulary, an
+   * O(n²) registry storm under open). Optional: legacy snapshot
+   * literals in tests omit it; consumers treat absent as empty.
+   */
+  knownIds?: Set<string>;
 }
 
 export type CanonicalizeDecision =

--- a/src/ai/predicate-registry.service.ts
+++ b/src/ai/predicate-registry.service.ts
@@ -302,6 +302,28 @@ export class PredicateRegistryService {
     this.cache.delete(companyId);
   }
 
+  /**
+   * 0082: canonicalize's auto-inserts (aliased / proposed) update the
+   * cached snapshot IN PLACE instead of invalidating it. Invalidation
+   * made the NEXT canonicalize reload the whole registry — one full
+   * SELECT (embeddings included) per novel coinage, O(n²) under an open
+   * vocabulary; the eval stand's SurrealDB OOM'd exactly there. The
+   * active row-set is untouched, so versionHash stays valid; other pods
+   * converge via the snapshot TTL.
+   */
+  private noteAutoInsert(
+    companyId: string,
+    novelId: string,
+    canonicalId: string,
+  ): void {
+    const cached = this.cache.get(companyId);
+    if (!cached) return;
+    const s = cached.snapshot;
+    s.aliasMap.set(novelId, canonicalId);
+    if (!s.knownIds) s.knownIds = new Set();
+    s.knownIds.add(novelId);
+  }
+
   // ── Admin CRUD ────────────────────────────────────────────────────────
 
   /**
@@ -494,11 +516,19 @@ export class PredicateRegistryService {
     return this.surreal.withCompany(companyId, async (db) => {
       // We need ALL rows (not just active) so we can chain through
       // 'aliased' rows to their canonical id when a fact's predicate
-      // points at an alias.
-      const [rows] = await db.query<[Array<Record<string, unknown>>]>(
-        `SELECT * FROM knowledge_predicate`,
-      );
-      const all = ((rows as Array<Record<string, unknown>>) ?? []).map(
+      // points at an alias. Embeddings ride ONLY for active rows —
+      // similarity search never consults the rest, and under an open
+      // vocabulary the proposed set dominates the table (0082: pulling
+      // their vectors made every snapshot reload O(registry) MB and
+      // OOM'd the eval stand's SurrealDB).
+      const [activeRows, restRows] = (await db.query<
+        [Array<Record<string, unknown>>, Array<Record<string, unknown>>]
+      >(
+        `SELECT * FROM knowledge_predicate WHERE status = 'active';
+         SELECT * OMIT embedding FROM knowledge_predicate WHERE status != 'active'`,
+      )) as [Array<Record<string, unknown>>, Array<Record<string, unknown>>];
+      const rows = [...(activeRows ?? []), ...(restRows ?? [])];
+      const all = (rows ?? []).map(
         (r) => ({
           row: r,
           def: deserializeFromRow(r),
@@ -511,7 +541,10 @@ export class PredicateRegistryService {
 
       // Build aliasMap: for each row, follow aliasedTo chains until we
       // land on an active predicate (or give up). Length-capped to defend
-      // against accidental loops in the registry data.
+      // against accidental loops in the registry data. 0082: a chain may
+      // also end on a 'proposed' row — a proposed predicate is its own
+      // canon (self-map), so a repeat coinage short-circuits in
+      // canonicalize() instead of re-embedding and re-inserting.
       const aliasMap = new Map<string, string>();
       const allById = new Map(all.map(({ def }) => [def.predicateId, def]));
       const MAX_CHAIN = 8;
@@ -527,10 +560,18 @@ export class PredicateRegistryService {
           cursor = allById.get(cursor.aliasedTo);
           hops++;
         }
-        if (cursor && cursor.status === 'active') {
+        if (
+          cursor &&
+          (cursor.status === 'active' || cursor.status === 'proposed')
+        ) {
           aliasMap.set(def.predicateId, cursor.predicateId);
         }
       }
+      const knownIds = new Set(
+        all
+          .filter(({ def }) => def.status !== 'deprecated')
+          .map(({ def }) => def.predicateId),
+      );
 
       // Embedding lookup for active predicates only (no point matching
       // against deprecated rows). Skip any active row whose embedding
@@ -577,7 +618,15 @@ export class PredicateRegistryService {
       // Fold extraction profiles into the hash: a profile-only pack upgrade
       // must bust the extractor cache even though no predicate row changed.
       const versionHash = computeHash(active, extractionProfiles);
-      return { versionHash, active, byId, aliasMap, embeddings, extractionProfiles };
+      return {
+        versionHash,
+        active,
+        byId,
+        aliasMap,
+        embeddings,
+        extractionProfiles,
+        knownIds,
+      };
     });
   }
 
@@ -611,12 +660,18 @@ export class PredicateRegistryService {
   ): Promise<CanonicalizeDecision> {
     const snapshot = await this.getSnapshot(companyId);
 
-    // Direct hit on an active predicate or a known alias chain.
+    // Direct hit on an active predicate, a known alias chain, or (0082)
+    // a proposed predicate that is its own canon — repeat coinages must
+    // resolve here, not fall through to embed + re-insert.
     const aliasResolved = snapshot.aliasMap.get(predicate);
-    if (aliasResolved && snapshot.byId.has(aliasResolved)) {
+    if (
+      aliasResolved &&
+      (snapshot.byId.has(aliasResolved) ||
+        snapshot.knownIds?.has(aliasResolved))
+    ) {
       return { kind: 'matched', canonicalId: aliasResolved };
     }
-    if (snapshot.byId.has(predicate)) {
+    if (snapshot.byId.has(predicate) || snapshot.knownIds?.has(predicate)) {
       return { kind: 'matched', canonicalId: predicate };
     }
 
@@ -668,7 +723,7 @@ export class PredicateRegistryService {
             },
           });
         });
-        this.invalidate(companyId);
+        this.noteAutoInsert(companyId, predicate, best!.predicateId);
       } catch (e) {
         this.logger.warn(
           `canonicalize: auto-alias insert failed for '${predicate}' → '${best!.predicateId}': ${(e as Error).message}`,
@@ -708,7 +763,7 @@ export class PredicateRegistryService {
           },
         });
       });
-      this.invalidate(companyId);
+      this.noteAutoInsert(companyId, predicate, predicate);
     } catch (e) {
       this.logger.warn(
         `canonicalize: proposed insert failed for '${predicate}': ${(e as Error).message}`,

--- a/src/compaction/promotion-runner.service.ts
+++ b/src/compaction/promotion-runner.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { StringRecordId, Surreal } from 'surrealdb';
 import { SurrealService, dbCreate } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
-import { policyFor } from '../ingest/conflict-resolver';
+import { PREDICATE_POLICIES } from '../ingest/conflict-resolver';
 import {
   ConcatSummaryGenerator,
   FactToSummarize,
@@ -166,7 +166,16 @@ export class PromotionRunnerService {
     ];
     return (rows ?? [])
       .filter((g) => g.n >= this.minGroup)
-      .filter((g) => policyFor(g.predicate).semantics === 'append_only');
+      .filter((g) => {
+        // 0082: SEED lookup, not policyFor — the unknown-predicate
+        // fallback is append_only now, but a coined (open-vocabulary)
+        // predicate is a specific observation; folding those into a
+        // `summary_<coinage>` row would trade recall drivers for a
+        // paraphrase. Promotion keeps folding exactly the predicates it
+        // always folded: seed-declared append_only event history.
+        const seed = PREDICATE_POLICIES[g.predicate];
+        return seed !== undefined && seed.semantics === 'append_only';
+      });
   }
 
   /** Fold one group's aged tail into a summary fact. Returns count folded. */

--- a/src/db/migrations/0082_predicate_alias.surql
+++ b/src/db/migrations/0082_predicate_alias.surql
@@ -1,0 +1,388 @@
+-- 0082_predicate_alias — canonical alias for coined predicates (W3,
+-- engine-architecture-audit-2026-08 finding #2).
+--
+-- The dialogue tract (EXTRACTOR_DIALOGUE_PROFILE) deliberately keeps
+-- the SPECIFIC predicate the extractor coined ("painted", not
+-- "hobby") — but that left dedup/corroboration keyed on the raw
+-- coinage, so the same claim under two coinages never met. The fix
+-- keeps the raw predicate AND stamps the EDC-canonical id into a new
+-- `predicateAlias` column at write time (ExtractorRefineService alias
+-- pass); resolution keys on the CANONICAL form.
+--
+--   * knowledge_fact.predicateAlias — option<string>; NONE = the
+--     predicate is already canonical (closed vocabulary, registry hit,
+--     or a novel coinage that became its own canon). Every existing
+--     row reads as NONE, so `predicateAlias ?? predicate` is
+--     byte-identical to `predicate` on all pre-0082 data.
+--   * fn::resolve_fact gains a 24th arg ($predicate_alias) and keys
+--     its candidate set on (predicateAlias ?? predicate) — two
+--     coinages of one canon now dedup/corroborate; closed-vocabulary
+--     tenants (alias always NONE) keep the exact old key.
+--   * Corroboration now also runs for `append_only` semantics, pooled
+--     over $candidates (same canonical predicate, scope- and
+--     namespace-local) with the EXACT-object + different-origin gate
+--     unchanged. append_only used to early-return before the
+--     corroboration block ($competing = [] by definition), which is
+--     why re-observed open-vocabulary claims piled up as duplicate
+--     active rows instead of strengthening the incumbent.
+--
+-- fn body is 0079 VERBATIM except: the $predicate_alias arg, the
+-- canonical-key clause in $candidates, the predicateAlias stamp on the
+-- CREATE, and the corroboration pool ($corr_pool, marked `-- 0082:`).
+-- Signature grows 23 → 24 args — the TS call site
+-- (fact-resolver.service.ts) moves in the same commit.
+
+DEFINE FIELD IF NOT EXISTS predicateAlias ON knowledge_fact TYPE option<string>;
+
+DEFINE FUNCTION OVERWRITE fn::resolve_fact(
+    $entity_id: record<knowledge_entity>,
+    $predicate: string,
+    $object: string,
+    $object_meta: option<object>,
+    $embedding: array<float>,
+    $confidence: float,
+    $valid_from: datetime,
+    $valid_until: option<datetime>,
+    $source: object,
+    $source_trust: float,
+    $semantics: string,
+    $similarity_threshold: float,
+    $w_confidence: float,
+    $w_source_trust: float,
+    $w_recency: float,
+    $w_authority: float,
+    $reject_threshold: float,
+    $margin_for_supersede: float,
+    $lang: option<string>,
+    $script: option<string>,
+    $entropy: option<float>,
+    $user_id: option<string>,
+    $derived_version: option<string>,
+    $predicate_alias: option<string>
+) {
+    -- Source key + declared authority (migration 0046): computed up front
+    -- because authority now participates in the winner's score, not just
+    -- the trust snapshot.
+    LET $src_key = fn::source_key_of($source);
+    LET $src_authority = fn::source_authority_of($src_key);
+    -- 0050: origin identity — the document (or, absent one, the source key).
+    LET $origin_key = fn::origin_key_of($source);
+
+    LET $new_score =
+        $w_confidence * $confidence
+        + $w_source_trust * $source_trust
+        + $w_recency * 1.0
+        + $w_authority * $src_authority;
+
+    IF $semantics = 'bitemporal' AND $new_score < $reject_threshold {
+        CREATE ingest_dead_letter CONTENT {
+            payload: { entityId: $entity_id, predicate: $predicate, object: $object, source: $source },
+            reason: 'low_score: ' + <string>$new_score
+        };
+        RETURN { outcome: 'REJECTED', factId: NONE, reason: 'low_score' };
+    };
+
+    LET $candidates = SELECT
+        id, predicate, predicateAlias, object, confidence, recordedAt, source,
+        embedding, validFrom, validUntil
+    FROM knowledge_fact
+    WHERE entityId = $entity_id
+      -- 0082: resolution keys on the CANONICAL predicate — a coined
+      -- predicate meets every other coinage of the same canon. Rows and
+      -- calls without an alias reduce to the old `predicate = $predicate`.
+      AND (predicateAlias ?? predicate) = ($predicate_alias ?? $predicate)
+      AND status = 'active'
+      AND retractedAt IS NONE
+      -- 0055: conflict resolution is scope-local. A personal fact only
+      -- ever meets facts of the SAME user; a tenant-global fact only
+      -- meets tenant-global ones.
+      AND (IF $user_id IS NONE THEN userId IS NONE ELSE userId = $user_id END)
+      -- 0079: conflict resolution is namespace-local. A derived fact only
+      -- ever meets facts of the SAME derivedVersion; a live-world fact
+      -- only meets live-world ones — a re-derivation cannot supersede,
+      -- compete with, or corroborate the incumbent world.
+      AND (IF $derived_version IS NONE THEN derivedVersion IS NONE ELSE derivedVersion = $derived_version END);
+
+    LET $competing = IF $semantics = 'append_only' THEN
+        []
+    ELSE IF $semantics = 'single_active' THEN
+        $candidates
+    ELSE
+        (SELECT * FROM $candidates
+            WHERE embedding != NONE
+              AND vector::similarity::cosine(embedding, $embedding) >= $similarity_threshold
+              AND fn::intervals_overlap(validFrom, validUntil, $valid_from, $valid_until))
+    END;
+
+    -- Trust snapshot (migration 0044): what the resolver believes about this
+    -- source RIGHT NOW, frozen onto the fact. learnedTrust is read before
+    -- any nightly refit can overwrite the source_trust row. Scoped lookup
+    -- since migration 0045; declared authority since 0046; originKey since
+    -- 0050.
+    LET $new = CREATE ONLY knowledge_fact CONTENT {
+        entityId: $entity_id,
+        predicate: $predicate,
+        predicateAlias: $predicate_alias,
+        object: $object,
+        objectMeta: $object_meta,
+        confidence: $confidence,
+        validFrom: $valid_from,
+        validUntil: $valid_until,
+        source: $source,
+        embedding: $embedding,
+        status: 'active',
+        userId: $user_id,
+        derivedVersion: $derived_version,
+        trustSnapshot: {
+            sourceKey: $src_key,
+            originKey: $origin_key,
+            domain: $predicate,
+            declaredTrust: $source_trust,
+            learnedTrust: fn::source_trust_scoped($src_key, $predicate),
+            authority: $src_authority,
+            calculatedAt: time::now()
+        }
+    };
+
+    -- Corroboration (migration 0047): the SAME claim from a DIFFERENT
+    -- source is independent confirmation, not a duel. Keep the new row as
+    -- the audit record of the second claim; strengthen the incumbent.
+    -- Runs before the backdated guard — claim identity beats date order.
+    -- 0050: independence is decided by ORIGIN, not recorder — two indexers
+    -- reading one document are the same origin and must not corroborate.
+    -- 0082: append_only pools over $candidates ($competing is [] by
+    -- definition, which used to make corroboration unreachable for the
+    -- open-vocabulary bulk); other semantics keep the $competing pool.
+    -- The block moved above the empty-$competing INSERTED return to be
+    -- reachable for append_only — when the pool is empty, $corroborated
+    -- is NONE and the flow is byte-identical to 0079.
+    LET $corr_pool = IF $semantics = 'append_only' THEN $candidates ELSE $competing END;
+    LET $corroborated = (SELECT id, recordedAt FROM $corr_pool
+        WHERE object = $object
+          AND fn::origin_key_of(source) != $origin_key
+        ORDER BY recordedAt DESC LIMIT 1)[0];
+
+    IF $corroborated != NONE {
+        UPDATE $new.id SET
+            status = 'corroborating',
+            corroborates = $corroborated.id;
+        UPDATE $corroborated.id SET corroboration = {
+            -- 0051: count is the number of DISTINCT corroborating origins,
+            -- derived from the deduped set — a repeated origin leaves both
+            -- the union and the count unchanged. (0050 incremented count
+            -- unconditionally, so one source repeating itself could inflate
+            -- the read-time γ boost to its cap.)
+            count: array::len(array::union(
+                IF corroboration IS NONE OR corroboration.originKeys IS NONE THEN [] ELSE corroboration.originKeys END,
+                [$origin_key]
+            )),
+            sourceKeys: array::union(
+                IF corroboration IS NONE THEN [] ELSE corroboration.sourceKeys END,
+                [$src_key]
+            ),
+            -- 0050: origin trail alongside the recorder trail. `?? []` shape
+            -- kept explicit for pre-0050 accumulators that lack the field.
+            originKeys: array::union(
+                IF corroboration IS NONE OR corroboration.originKeys IS NONE THEN [] ELSE corroboration.originKeys END,
+                [$origin_key]
+            ),
+            lastAt: time::now()
+        };
+        RETURN {
+            outcome: 'CORROBORATED',
+            factId: $new.id,
+            corroboratedFactId: $corroborated.id,
+            reason: NONE
+        };
+    };
+
+    IF array::len($competing) = 0 {
+        -- Locale + entropy folded in from the caller (migration 0039). Applied
+        -- on INSERTED only, matching the old post-call UPDATE gate.
+        IF $lang != NONE {
+            UPDATE $new.id SET lang = $lang, script = $script;
+        };
+        IF $entropy != NONE {
+            UPDATE $new.id SET extractionEntropy = $entropy;
+        };
+        RETURN { outcome: 'INSERTED', factId: $new.id, reason: NONE };
+    };
+
+    -- Backdated guard (migration 0043): for single_active, a candidate with
+    -- a STRICTLY NEWER validFrom means the incoming fact is history. Slot it
+    -- before the next-newer decision as an already-superseded row; the
+    -- active timeline stays exactly as if events had arrived in order.
+    LET $next_after = IF $semantics = 'single_active' THEN
+        (SELECT id, validFrom FROM $competing
+            WHERE validFrom > $valid_from
+            ORDER BY validFrom ASC LIMIT 1)[0]
+    ELSE
+        NONE
+    END;
+
+    IF $next_after != NONE {
+        -- Same sentinel shape as a natural supersede (no retractedAt —
+        -- migration 0014; retractionReason 'superseded' feeds revive +
+        -- calibration).
+        UPDATE $new.id SET
+            status = 'superseded',
+            retractionReason = 'superseded',
+            retractedBy = 'system',
+            supersededBy = $next_after.id,
+            priorValidUntil = $valid_until,
+            validUntil = $next_after.validFrom;
+        RETURN {
+            outcome: 'INSERTED_HISTORICAL',
+            factId: $new.id,
+            supersededByFactId: $next_after.id,
+            reason: 'backdated'
+        };
+    };
+
+    LET $scored = SELECT
+        id,
+        confidence,
+        source,
+        validFrom,
+        object,
+        predicate,
+        $w_confidence * confidence AS sc_confidence,
+        $w_source_trust * fn::source_trust_scoped(fn::source_key_of(source), $predicate) AS sc_source_trust,
+        $w_recency * math::pow(math::E, - duration::secs(time::now() - recordedAt) / 31536000) AS sc_recency,
+        $w_authority * fn::source_authority_of(fn::source_key_of(source)) AS sc_authority,
+        ($w_confidence * confidence
+         + $w_source_trust * fn::source_trust_scoped(fn::source_key_of(source), $predicate)
+         + $w_recency * math::pow(math::E, - duration::secs(time::now() - recordedAt) / 31536000)
+         + $w_authority * fn::source_authority_of(fn::source_key_of(source))
+        ) AS score
+    FROM $competing;
+
+    LET $best_opp_score = math::max($scored.score);
+    LET $best_opp = (SELECT * FROM $scored WHERE score = $best_opp_score LIMIT 1)[0];
+
+    LET $winner_components = {
+        confidence: $w_confidence * $confidence,
+        sourceTrust: $w_source_trust * $source_trust,
+        recency: $w_recency * 1.0,
+        authority: $w_authority * $src_authority
+    };
+    LET $loser_components = {
+        confidence: $best_opp.sc_confidence,
+        sourceTrust: $best_opp.sc_source_trust,
+        recency: $best_opp.sc_recency,
+        authority: $best_opp.sc_authority
+    };
+
+    LET $abs_conf = math::abs($winner_components.confidence - $loser_components.confidence);
+    LET $abs_st   = math::abs($winner_components.sourceTrust - $loser_components.sourceTrust);
+    LET $abs_rec  = math::abs($winner_components.recency - $loser_components.recency);
+    LET $abs_auth = math::abs($winner_components.authority - $loser_components.authority);
+    LET $max_abs  = math::max([$abs_conf, $abs_st, $abs_rec, $abs_auth]);
+
+    LET $dominant_dim = IF $max_abs = $abs_conf THEN 'confidence'
+                       ELSE IF $max_abs = $abs_st THEN 'source_trust'
+                       ELSE IF $max_abs = $abs_rec THEN 'recency'
+                       ELSE 'authority'
+                       END;
+
+    LET $slot_delta = {
+        predicate: ($best_opp.predicate != $predicate),
+        object: ($best_opp.object != $object),
+        validFrom: ($best_opp.validFrom != $valid_from),
+        source: ($best_opp.source != $source)
+    };
+
+    LET $score_breakdown = {
+        winner: {
+            total: $new_score,
+            confidence: $winner_components.confidence,
+            sourceTrust: $winner_components.sourceTrust,
+            recency: $winner_components.recency,
+            authority: $winner_components.authority
+        },
+        loser: {
+            total: $best_opp_score,
+            confidence: $loser_components.confidence,
+            sourceTrust: $loser_components.sourceTrust,
+            recency: $loser_components.recency,
+            authority: $loser_components.authority
+        },
+        margin: $new_score - $best_opp_score
+    };
+
+    LET $supersede =
+        $semantics = 'single_active'
+        OR $new_score >= $best_opp_score + $margin_for_supersede;
+
+    LET $loser_ids = $competing.id;
+
+    IF $supersede {
+        -- NO `retractedAt = time::now()` — a natural supersede is not a
+        -- retraction (migration 0014). Keep the retractionReason +
+        -- retractedBy sentinel that revive + calibration depend on.
+        FOR $loser IN $competing {
+            UPDATE $loser.id SET
+                status = 'superseded',
+                retractionReason = 'superseded',
+                retractedBy = 'system',
+                supersededBy = $new.id,
+                priorValidUntil = $loser.validUntil,
+                validUntil = $valid_from;
+        };
+        -- Conflict trace (migration 0044): persist the decision the fn just
+        -- computed — the fact remembers WHY it won.
+        UPDATE $new.id SET conflictTrace = {
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            decidedAt: time::now()
+        };
+        RETURN {
+            outcome: 'SUPERSEDED',
+            factId: $new.id,
+            supersededFactIds: $loser_ids,
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            reason: NONE
+        };
+    };
+
+    UPDATE $new.id SET
+        status = 'competing',
+        conflictTrace = {
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            decidedAt: time::now()
+        };
+    UPDATE knowledge_fact SET status = 'competing' WHERE id IN $loser_ids;
+    RETURN {
+        outcome: 'COMPETING',
+        factId: $new.id,
+        competingFactIds: $loser_ids,
+        scoreBreakdown: $score_breakdown,
+        dominantDimension: $dominant_dim,
+        slotDelta: $slot_delta,
+        bestOpponentId: $best_opp.id,
+        reason: NONE
+    };
+};
+
+-- Batch mapper stays in lockstep with the 24-arg signature (positional
+-- contract lives HERE, beside the function it calls — see 0071).
+DEFINE FUNCTION OVERWRITE fn::resolve_facts($facts: array, $cfg: object) {
+    RETURN $facts.map(|$f| fn::resolve_fact(
+        type::record('knowledge_entity', $f.eid),
+        $f.predicate, $f.object, $f.object_meta, $f.embedding,
+        $f.confidence, $f.valid_from, $f.valid_until, $f.source,
+        $f.source_trust, $f.semantics, $cfg.similarity_threshold,
+        $cfg.w_confidence, $cfg.w_source_trust, $cfg.w_recency, $cfg.w_authority,
+        $cfg.reject_threshold, $cfg.margin_for_supersede,
+        $f.lang, $f.script, $f.entropy, $f.user_id, $f.derived_version,
+        $f.predicate_alias
+    ));
+};

--- a/src/dreams/corroborate.service.ts
+++ b/src/dreams/corroborate.service.ts
@@ -7,7 +7,7 @@ import { Semaphore } from '../common/semaphore';
 import { withGenAiCall } from '../common/gen-ai-observability';
 import { MetricsService } from '../metrics/metrics.service';
 import { withSpan } from '../common/tracing';
-import { policyFor } from '../ingest/conflict-resolver';
+import { PREDICATE_POLICIES } from '../ingest/conflict-resolver';
 import { envFlagEnabled } from '../common/env-validation';
 import { derivedVersionFence } from '../episodes/read-pin.service';
 
@@ -33,11 +33,13 @@ import { derivedVersionFence } from '../episodes/read-pin.service';
  *   - different origin (one document re-worded is NOT confirmation);
  *   - validity intervals overlap (sequential states are history, not
  *     the same claim);
- *   - predicate semantics 'bitemporal' (append_only predicates are
- *     event history — two similar events are two events; single_active
- *     never has two active rows). JS policyFor is the legacy lookup, so
- *     tenant-pack predicates unknown to it default to bitemporal — the
- *     LLM judge is the backstop for those;
+ *   - predicate semantics: seed 'bitemporal' claims sweep; seed
+ *     'append_only' stays out (event history — two similar events are
+ *     two events; single_active never has two active rows). Predicates
+ *     UNKNOWN to the JS seed are open-vocabulary coinages (0082): they
+ *     write as append_only, but fuzzy same-assertion corroboration is
+ *     exactly what collapses re-worded coinages, so they sweep like
+ *     claims — the LLM judge is the backstop;
  *   - exactly-equal objects skip the LLM (deterministic corroboration —
  *     these only exist for pairs that never conflicted at ingest);
  *   - LLM verdict 'same_assertion' required for everything else;
@@ -282,27 +284,42 @@ export class DreamsCorroborateService {
     backlog: number;
   }> {
     const fence = derivedVersionFence(derivedVersion);
-    const [rows] = await db.query<
-      [Array<{ entityId: unknown; predicate: string; n: number }>]
+    const [rawRows] = await db.query<
+      [Array<{ entityId: unknown; canonPredicate: string; n: number }>]
     >(
-      `SELECT entityId, predicate, count() AS n FROM knowledge_fact
+      // 0082: groups key on the CANONICAL predicate so coinages of one
+      // canon land in the same group; fetchGroupMembers mirrors the key.
+      `SELECT entityId, predicateAlias ?? predicate AS canonPredicate,
+              count() AS n FROM knowledge_fact
        WHERE status = 'active' AND retractedAt IS NONE AND embedding != NONE
          AND userId IS NONE
          ${fence.clause}
-       GROUP BY entityId, predicate`,
+       GROUP BY entityId, canonPredicate`,
       fence.params,
     );
+    const rows = (
+      (rawRows as Array<{
+        entityId: unknown;
+        canonPredicate: string;
+        n: number;
+      }>) ?? []
+    ).map((r) => ({ entityId: r.entityId, predicate: r.canonPredicate, n: r.n }));
     // Negative-result memo (0060): a group already judged at the SAME
     // member count is excluded before the window is cut. Without this,
     // the deterministic most-populated-first order re-selected the same
     // all-'different' groups every night — permanent starvation of the
     // rest of the backlog at full LLM cost.
     const checked = await this.loadCheckedMemo(db);
-    const eligible = (
-      (rows as Array<{ entityId: unknown; predicate: string; n: number }>) ?? []
-    )
+    const eligible = rows
       .filter((g) => g.n >= 2 && g.n <= MAX_GROUP_SIZE)
-      .filter((g) => policyFor(g.predicate).semantics === 'bitemporal')
+      .filter((g) => {
+        // 0082: seed lookup, not policyFor — the fallback for unknown
+        // predicates is append_only now, but an unknown (coined)
+        // predicate is an observation whose re-worded duplicates only
+        // this sweep can collapse. Known seeds keep the old rule.
+        const seed = PREDICATE_POLICIES[g.predicate];
+        return seed ? seed.semantics === 'bitemporal' : true;
+      })
       .filter(
         (g) => checked.get(`${String(g.entityId)}|${g.predicate}`) !== g.n,
       )
@@ -344,12 +361,15 @@ export class DreamsCorroborateService {
   ): Promise<ActiveFactRow[]> {
     const fence = derivedVersionFence(derivedVersion);
     const [rows] = await db.query<[ActiveFactRow[]]>(
+      // 0082: the group key is the CANONICAL predicate — membership
+      // matches on `predicateAlias ?? predicate` so coinages join their
+      // canon's group.
       `SELECT id, entityId, predicate, object, validFrom, validUntil,
               recordedAt, embedding,
               fn::origin_key_of(source) AS originKey,
               corroboration.count ?? 0 AS corroborationCount
        FROM knowledge_fact
-       WHERE entityId = $entity AND predicate = $predicate
+       WHERE entityId = $entity AND (predicateAlias ?? predicate) = $predicate
          AND status = 'active' AND retractedAt IS NONE AND embedding != NONE
          AND userId IS NONE
          ${fence.clause}

--- a/src/ingest/conflict-resolver.ts
+++ b/src/ingest/conflict-resolver.ts
@@ -56,7 +56,11 @@ export interface PredicatePolicy {
 }
 
 export const DEFAULT_POLICY: PredicatePolicy = {
-  semantics: 'bitemporal',
+  // W3 (audit 2026-08 #2): unknown predicate = open-vocabulary coinage →
+  // append_only, mirroring DEFAULT_FALLBACK in the tenant registry
+  // (predicate-registry-internals/types.ts) so display-only consumers
+  // report the same semantics the write path applies.
+  semantics: 'append_only',
   decayHalfLifeDays: 60,
   piiClass: 'none',
 };

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -60,6 +60,13 @@ export class FactResolverService {
       companyId: string;
       entityId: string;
       predicate: string;
+      /**
+       * EDC-canonical id when `predicate` is a coined (open-vocabulary)
+       * form (0082). Resolution keys on `predicateAlias ?? predicate`,
+       * so coinages of one canon dedup/corroborate. Omit when the
+       * predicate is already canonical.
+       */
+      predicateAlias?: string;
       /** The string form stored in `object` and used for locale detection. */
       object: string;
       objectMeta?: object;
@@ -187,6 +194,7 @@ export class FactResolverService {
       companyId: p.companyId,
       entityId: p.entityId,
       predicate: p.predicate,
+      predicateAlias: p.predicateAlias,
       object: p.object,
       objectMeta: p.objectMeta,
       embedding,
@@ -249,6 +257,7 @@ export class FactResolverService {
       // (fn::resolve_fact's contract), whereas an explicit null would store
       // NULL — e.g. a NULL validUntil would break the `validUntil IS NONE`
       // active-fact read filter.
+      if (c.predicateAlias !== undefined) f.predicate_alias = c.predicateAlias;
       if (c.objectMeta !== undefined) f.object_meta = c.objectMeta;
       if (c.validUntil !== undefined) f.valid_until = c.validUntil;
       if (c.lang !== undefined) f.lang = c.lang;
@@ -339,6 +348,7 @@ export class FactResolverService {
       companyId: string;
       entityId: string;
       predicate: string;
+      predicateAlias?: string;
       object: string;
       objectMeta?: object;
       embedding: number[];
@@ -362,7 +372,10 @@ export class FactResolverService {
     // each leave an `active` row. NUL-joined (\x00) — no entity record tail
     // or predicate slug can contain a NUL, so the composite key can't
     // collide.
-    const lockKey = `${p.companyId}\x00${p.entityId}\x00${p.predicate}`;
+    // Keyed on the CANONICAL predicate (0082) so two coinages of one
+    // canon serialize onto the same slot — their candidate sets are the
+    // same rows now that resolution keys on `predicateAlias ?? predicate`.
+    const lockKey = `${p.companyId}\x00${p.entityId}\x00${p.predicateAlias ?? p.predicate}`;
     return this.resolveLock.run(lockKey, () =>
       retryOnUniqueViolation(async () => {
         const [r] = await db.query<[any]>(
@@ -373,11 +386,13 @@ export class FactResolverService {
             $source_trust, $semantics, $similarity_threshold,
             $w_confidence, $w_source_trust, $w_recency, $w_authority,
             $reject_threshold, $margin_for_supersede,
-            $lang, $script, $entropy, $user_id, $derived_version
+            $lang, $script, $entropy, $user_id, $derived_version,
+            $predicate_alias
          )`,
           {
             eid: idTailOf(p.entityId),
             predicate: p.predicate,
+            predicate_alias: p.predicateAlias,
             object: p.object,
             object_meta: p.objectMeta,
             embedding: p.embedding,

--- a/src/ingest/ingest-predictor.service.ts
+++ b/src/ingest/ingest-predictor.service.ts
@@ -149,7 +149,7 @@ export class IngestPredictionService {
                 userId, trustSnapshot, corroboration
            FROM knowledge_fact
            WHERE entityId = type::record('knowledge_entity', $eid)
-             AND predicate = $predicate
+             AND (predicateAlias ?? predicate) = $predicate
              AND retractedAt IS NONE
              AND status = 'active'
              AND ${args.userId ? '(userId IS NONE OR userId = $userId)' : 'userId IS NONE'}
@@ -174,9 +174,10 @@ export class IngestPredictionService {
 
       const candidateScore = this.scoring.scoreCandidate(args);
 
-      // The decision below mirrors fn::resolve_fact's ORDER (migration
-      // 0055): reject (bitemporal only) → empty-competing INSERTED →
-      // CORROBORATED → INSERTED_HISTORICAL (single_active) → supersede/
+      // The decision below mirrors fn::resolve_fact's ORDER (0055, 0082):
+      // reject (bitemporal only) → CORROBORATED (pooled over candidates
+      // for append_only, over competing otherwise) → empty-competing
+      // INSERTED → INSERTED_HISTORICAL (single_active) → supersede/
       // compete. Getting the order OR the semantics wrong makes the
       // preflight report an outcome the real resolver would never pick.
 
@@ -196,8 +197,24 @@ export class IngestPredictionService {
         };
       }
 
-      // 2. append_only never has competing facts — always INSERTED.
+      // 2. append_only never competes/supersedes — but since 0082 it CAN
+      // corroborate: the resolver pools corroboration over ALL candidates
+      // (same canonical predicate, exact object, different origin), so the
+      // preflight mirrors that before declaring a clean insert.
       if (policy.semantics === 'append_only') {
+        const appendOrigin = originKeyOf(args.source);
+        const appendCorroborator = priors.find(
+          (c) =>
+            c.object === args.object && originKeyOf(c.source) !== appendOrigin,
+        );
+        if (appendCorroborator) {
+          return {
+            wouldOutcome: 'CORROBORATED',
+            reasoning: `Same object already recorded from a different origin (${originKeyOf(appendCorroborator.source)} ≠ ${appendOrigin}); the fact would corroborate the incumbent, not duplicate it (0082: corroboration runs for append_only).`,
+            opposingFacts: gate([rowToOpposingFact(appendCorroborator)]),
+            predicatePolicy: policy,
+          };
+        }
         return {
           wouldOutcome: 'INSERTED',
           reasoning:

--- a/src/ingest/mention-persist.service.ts
+++ b/src/ingest/mention-persist.service.ts
@@ -247,6 +247,7 @@ export class MentionPersistService {
           companyId,
           entityId: eid,
           predicate: f.predicate,
+          predicateAlias: f.predicateAlias,
           object: f.object,
           confidence: f.confidence,
           validFrom: this.factValidFrom(f, dto, eventTimeOn),
@@ -289,6 +290,7 @@ export class MentionPersistService {
       entityId: string;
       f: {
         predicate: string;
+        predicateAlias?: string;
         object: string;
         confidence: number;
         extractionEntropy?: number;
@@ -305,6 +307,7 @@ export class MentionPersistService {
       companyId: p.companyId,
       entityId: p.entityId,
       predicate: f.predicate,
+      predicateAlias: f.predicateAlias,
       object: f.object,
       confidence: f.confidence,
       validFrom: p.validFrom,

--- a/src/search/internals/graph-retrieve-db.ts
+++ b/src/search/internals/graph-retrieve-db.ts
@@ -224,6 +224,7 @@ export async function fetchFactsForEntities({
     id: unknown;
     entityId: unknown;
     predicate: string;
+    predicateAlias?: string;
     object: string;
     confidence: number;
     validFrom: string;
@@ -242,7 +243,7 @@ export async function fetchFactsForEntities({
   // filter (policy/row-filter.ts) — internal only, assembleGraphHits
   // never surfaces them in the response.
   const [rows] = await db.query<[FactSelect[]]>(
-    `SELECT id, entityId, predicate, object, confidence,
+    `SELECT id, entityId, predicate, predicateAlias, object, confidence,
             validFrom, validUntil, status, recordedAt,
             source, trustSnapshot, corroboration
        FROM knowledge_fact
@@ -259,6 +260,7 @@ export async function fetchFactsForEntities({
       factId: String(r.id),
       entityId: eid,
       predicate: r.predicate,
+      ...(r.predicateAlias ? { predicateAlias: r.predicateAlias } : {}),
       object: r.object,
       confidence: r.confidence,
       validFrom: r.validFrom,

--- a/src/search/internals/graph-retrieve.ts
+++ b/src/search/internals/graph-retrieve.ts
@@ -31,6 +31,9 @@ export interface GraphFactRow {
   factId: string;
   entityId: string;
   predicate: string;
+  /** EDC-canonical id for a coined predicate (0082); dedup keys on
+   *  `predicateAlias ?? predicate`. */
+  predicateAlias?: string;
   object: string;
   confidence: number;
   validFrom: string;
@@ -196,7 +199,8 @@ function renderHit({
 function dedupeAndSortFacts(rows: GraphFactRow[]): GraphFactRow[] {
   const byKey = new Map<string, GraphFactRow>();
   for (const f of rows) {
-    const key = `${f.predicate}::${f.object}`;
+    // 0082: coinages of one canonical predicate collapse together.
+    const key = `${f.predicateAlias ?? f.predicate}::${f.object}`;
     const prev = byKey.get(key);
     const ts = (r: GraphFactRow) => new Date(r.recordedAt ?? 0).getTime();
     if (!prev || ts(f) > ts(prev)) {

--- a/src/search/internals/legs.ts
+++ b/src/search/internals/legs.ts
@@ -81,7 +81,7 @@ export async function runVectorLeg({
   }
   const sql = `
       SELECT
-        id, entityId, predicate, object, confidence,
+        id, entityId, predicate, predicateAlias, object, confidence,
         validFrom, validUntil, recordedAt, retractedAt, status, source,
         trustSnapshot, corroboration, userId,
         entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity,
@@ -124,7 +124,7 @@ async function runVectorLegKnn({
   const ef = tuning.hnswEf;
   const kOver = Math.min(k * tuning.hnswOverfetch, 1000);
   const projection = `
-        id, entityId, predicate, object, confidence,
+        id, entityId, predicate, predicateAlias, object, confidence,
         validFrom, validUntil, recordedAt, retractedAt, status, source,
         trustSnapshot, corroboration, userId,
         entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity`;
@@ -194,7 +194,7 @@ export async function runLexicalLeg({
   // with status='retracted' on a query that hit searchHaystack.
   const sql = `
       SELECT
-        id, entityId, predicate, object, confidence,
+        id, entityId, predicate, predicateAlias, object, confidence,
         validFrom, validUntil, recordedAt, retractedAt, status, source,
         trustSnapshot, corroboration, userId,
         entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity,

--- a/src/search/internals/scoring.ts
+++ b/src/search/internals/scoring.ts
@@ -126,7 +126,11 @@ export function scoreRows({
       ? chatterPenalty
       : 1;
   return rows.map((row) => {
-    const policy = policyFor(row.predicate);
+    // 0082: predicate-keyed lookups (policy, chatter) go through the
+    // EDC-canonical alias — a coined predicate inherits its canon's
+    // decay/chatter treatment. Alias-less rows are byte-identical.
+    const canonPredicate = row.predicateAlias ?? row.predicate;
+    const policy = policyFor(canonPredicate);
     // Usage reinforcement: when the pipeline attached a lastReadAt
     // (SEARCH_USAGE_DECAY_ENABLED → enrichWithUsage), the decay clock
     // restarts at the most recent retrieval — memory that keeps getting
@@ -181,7 +185,7 @@ export function scoreRows({
       authorityFactor,
     };
 
-    const chatterFactor = chatterFactorFor(row.predicate);
+    const chatterFactor = chatterFactorFor(canonPredicate);
     const temporalOverlap = temporalAnchor
       ? temporalOverlapFactor(row, temporalAnchor.getTime())
       : 1;
@@ -245,7 +249,12 @@ export function bucketByEntity(scored: ScoredRow[]): Map<string, EntityBucket> {
     // skipped and never contributed to the degree boost.
     let skippedBest = false;
     for (const f of sortedFacts) {
-      const key = diversityKey(f.row.predicate, f.row.object);
+      // 0082: cap on the canonical predicate — coinages of one canon
+      // share a diversity bucket instead of each getting their own.
+      const key = diversityKey(
+        f.row.predicateAlias ?? f.row.predicate,
+        f.row.object,
+      );
       if (seenKeys.has(key)) continue;
       seenKeys.add(key);
       if (f.score === bucket.bestScore && !skippedBest) {

--- a/src/search/internals/types.ts
+++ b/src/search/internals/types.ts
@@ -30,6 +30,9 @@ export interface FactRow {
   id: unknown;
   entityId: unknown;
   predicate: string;
+  /** EDC-canonical id for a coined predicate (0082); predicate-keyed
+   *  consumers (policy, chatter, diversity) use `predicateAlias ?? predicate`. */
+  predicateAlias?: string;
   object: string;
   confidence: number;
   validFrom: string;

--- a/test/audit-p3-dreams.unit-spec.ts
+++ b/test/audit-p3-dreams.unit-spec.ts
@@ -85,8 +85,16 @@ function mkDb(opts: {
   const memoWrites: Array<Record<string, unknown>> = [];
   const memberFetches: string[] = [];
   const query = jest.fn(async (sql: string, params?: Record<string, unknown>) => {
-    if (sql.includes('GROUP BY entityId, predicate')) {
-      return [opts.groups];
+    if (sql.includes('GROUP BY entityId, canonPredicate')) {
+      // Service projects the canonical key as `canonPredicate` (0082)
+      // and maps it back to `predicate`; harness groups carry `predicate`.
+      return [
+        opts.groups.map((g) => ({
+          entityId: g.entityId,
+          canonPredicate: g.predicate,
+          n: g.n,
+        })),
+      ];
     }
     if (sql.includes('FROM corroborate_checked')) {
       return [opts.memo ?? []];

--- a/test/dreams-corroborate.unit-spec.ts
+++ b/test/dreams-corroborate.unit-spec.ts
@@ -14,7 +14,7 @@ function fact(over: Partial<Row> = {}): Row {
   return {
     id: `knowledge_fact:${Math.random().toString(36).slice(2, 8)}`,
     entityId: 'knowledge_entity:e1',
-    predicate: 'claim_probe', // not in CORE_PREDICATES → default bitemporal
+    predicate: 'claim_probe', // not in CORE_PREDICATES → coined observation, sweeps (0082)
     object: 'gold tier customer',
     validFrom: '2026-01-01T00:00:00Z',
     validUntil: null,
@@ -43,8 +43,17 @@ function makeService(): {
   const applied: Array<Record<string, unknown>> = [];
   const db = (groups: Row[], members: Row[]) => ({
     query: jest.fn(async (sql: string, params?: Record<string, unknown>) => {
-      if (sql.includes('GROUP BY entityId, predicate')) {
-        return [groups.map((g) => ({ ...g, n: members.length }))];
+      if (sql.includes('GROUP BY entityId, canonPredicate')) {
+        // The service projects the canonical key as `canonPredicate`
+        // and maps it back to `predicate` — the harness groups carry
+        // `predicate`, so mirror the projection here.
+        return [
+          groups.map((g) => ({
+            entityId: g.entityId,
+            canonPredicate: g.predicate,
+            n: members.length,
+          })),
+        ];
       }
       if (sql.includes('fn::origin_key_of(source) AS originKey')) {
         return [members];

--- a/test/dreams-version-fence.unit-spec.ts
+++ b/test/dreams-version-fence.unit-spec.ts
@@ -94,7 +94,7 @@ describe('dreams legs stay inside the tenant live world (W2)', () => {
     );
     await svc.run(db, 'wd-v3');
     const groups = queries.find((q) =>
-      q.sql.includes('GROUP BY entityId, predicate'),
+      q.sql.includes('GROUP BY entityId, canonPredicate'),
     );
     expect(groups?.sql).toContain('AND derivedVersion = $derivedVersion');
     expect(groups?.params?.derivedVersion).toBe('wd-v3');

--- a/test/predicate-alias.unit-spec.ts
+++ b/test/predicate-alias.unit-spec.ts
@@ -193,3 +193,58 @@ describe('predicate alias (W3 0082)', () => {
     });
   });
 });
+
+describe('canonicalize repeat-coinage short-circuit (registry storm fix)', () => {
+  it('second occurrence of a proposed coinage matches in-cache: one embed, one insert, no reload', async () => {
+    const { PredicateRegistryService } = await import(
+      '../src/ai/predicate-registry.service'
+    );
+    const { ConfigService } = await import('@nestjs/config');
+    const queries: string[] = [];
+    const db = {
+      query: jest.fn(async (sql: string) => {
+        queries.push(sql);
+        if (sql.includes("WHERE status = 'active'")) return [[], []];
+        if (sql.startsWith('SELECT predicateId')) return [[]];
+        return [[]];
+      }),
+    };
+    const surreal = {
+      withCompany: async (_c: string, fn: (d: unknown) => Promise<unknown>) =>
+        fn(db),
+    };
+    const embedder = {
+      embed: jest.fn(async () => [1, 0]),
+      embedMany: jest.fn(async (t: string[]) => t.map(() => [1, 0])),
+    };
+    const svc = new PredicateRegistryService(
+      surreal as never,
+      embedder as never,
+      new ConfigService({ PREDICATE_REGISTRY_CACHE_CAP: '10' }),
+    );
+    // Bypass seed bootstrap — empty registry is the point.
+    (svc as unknown as { bootstrapped: { set(k: string, v: true): void } })
+      .bootstrapped.set('co_x', true);
+
+    const first = await svc.canonicalize('co_x', 'painted_seascape', 'ctx');
+    expect(first.kind).toBe('proposed');
+    const inserts = () =>
+      db.query.mock.calls.filter(([sql]) =>
+        String(sql).includes('CREATE knowledge_predicate'),
+      ).length;
+    expect(inserts()).toBe(1);
+    const embedsAfterFirst = embedder.embed.mock.calls.length;
+
+    const second = await svc.canonicalize('co_x', 'painted_seascape', 'ctx');
+    expect(second).toEqual({ kind: 'matched', canonicalId: 'painted_seascape' });
+    expect(inserts()).toBe(1); // no re-insert
+    expect(embedder.embed.mock.calls.length).toBe(embedsAfterFirst); // no re-embed
+    // No snapshot reload between the calls (cache updated in place).
+    const fullLoads = queries.filter(
+      (q) =>
+        q.includes('FROM knowledge_predicate') &&
+        q.includes("WHERE status = 'active'"),
+    ).length;
+    expect(fullLoads).toBe(1);
+  });
+});

--- a/test/predicate-alias.unit-spec.ts
+++ b/test/predicate-alias.unit-spec.ts
@@ -1,0 +1,195 @@
+import { ExtractorRefineService } from '../src/ai/extractor-refine.service';
+import { applyAliasPass } from '../src/ai/extractor-internals/predicate-canonicalize';
+import type { ExtractedFact } from '../src/ai/extractor-internals/types';
+import { DEFAULT_FALLBACK } from '../src/ai/predicate-registry-internals/types';
+import { DEFAULT_POLICY } from '../src/ingest/conflict-resolver';
+import { FactResolverService } from '../src/ingest/fact-resolver.service';
+
+/**
+ * W3 (0082): coined-predicate canonicalization into predicateAlias +
+ * append_only default for open (unknown) predicates. The raw coinage
+ * must SURVIVE in `predicate`; the EDC-canonical id rides in
+ * `predicateAlias`; the resolver threads it into fn::resolve_fact as
+ * the 24th positional arg.
+ */
+describe('predicate alias (W3 0082)', () => {
+  const fact = (predicate: string, over: Partial<ExtractedFact> = {}): ExtractedFact => ({
+    entityIndex: 0,
+    predicate,
+    object: 'painted a sunset over the bay',
+    confidence: 0.9,
+    clause: 'She painted a sunset over the bay',
+    ...over,
+  });
+  const logger = { warn: jest.fn() } as never;
+
+  describe('applyAliasPass', () => {
+    it('stamps the canonical id into predicateAlias and keeps the coinage', async () => {
+      const facts = [fact('painted_seascape')];
+      const registry = {
+        canonicalize: jest.fn(async () => ({
+          kind: 'aliased' as const,
+          canonicalId: 'painted',
+          similarity: 0.91,
+          novelPredicateId: 'painted_seascape',
+        })),
+      };
+      const decisions = await applyAliasPass({
+        facts,
+        registry: registry as never,
+        companyId: 'co_x',
+        logger,
+      });
+      expect(facts[0].predicate).toBe('painted_seascape');
+      expect(facts[0].predicateAlias).toBe('painted');
+      expect(decisions).toEqual([
+        {
+          original: 'painted_seascape',
+          canonical: 'painted',
+          kind: 'aliased',
+          similarity: 0.91,
+        },
+      ]);
+    });
+
+    it('a predicate that is its own canon gets NO alias', async () => {
+      const facts = [fact('painted')];
+      const registry = {
+        canonicalize: jest.fn(async () => ({
+          kind: 'proposed' as const,
+          canonicalId: 'painted',
+          novelPredicateId: 'painted',
+        })),
+      };
+      const decisions = await applyAliasPass({
+        facts,
+        registry: registry as never,
+        companyId: 'co_x',
+        logger,
+      });
+      expect(facts[0].predicateAlias).toBeUndefined();
+      expect(decisions).toEqual([]);
+    });
+
+    it('a registry error leaves the fact aliasless and does not throw', async () => {
+      const facts = [fact('painted_seascape')];
+      const registry = {
+        canonicalize: jest.fn(async () => {
+          throw new Error('registry down');
+        }),
+      };
+      await applyAliasPass({
+        facts,
+        registry: registry as never,
+        companyId: 'co_x',
+        logger,
+      });
+      expect(facts[0].predicateAlias).toBeUndefined();
+      expect(facts[0].predicate).toBe('painted_seascape');
+    });
+  });
+
+  describe('ExtractorRefineService (open vocabulary)', () => {
+    const OLD = process.env.EXTRACTOR_DIALOGUE_PROFILE;
+    afterEach(() => {
+      if (OLD === undefined) delete process.env.EXTRACTOR_DIALOGUE_PROFILE;
+      else process.env.EXTRACTOR_DIALOGUE_PROFILE = OLD;
+    });
+
+    it('runs the alias pass and skips both overwrite passes', async () => {
+      process.env.EXTRACTOR_DIALOGUE_PROFILE = '1';
+      const registry = {
+        canonicalize: jest.fn(async () => ({
+          kind: 'aliased' as const,
+          canonicalId: 'painted',
+          similarity: 0.9,
+          novelPredicateId: 'painted_seascape',
+        })),
+      };
+      const localPredicates = { rank: jest.fn() };
+      const svc = new ExtractorRefineService(
+        registry as never,
+        localPredicates as never,
+      );
+      const facts = [fact('painted_seascape')];
+      await svc.applyPredicateRefinements(facts, null as never, 'co_x');
+      // Coinage kept, alias stamped, no local-override ranking ran.
+      expect(facts[0].predicate).toBe('painted_seascape');
+      expect(facts[0].predicateAlias).toBe('painted');
+      expect(localPredicates.rank).not.toHaveBeenCalled();
+      expect(registry.canonicalize).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('append_only default for open predicates', () => {
+    it('the unknown-predicate fallback is append_only on both lookups', () => {
+      expect(DEFAULT_FALLBACK.semantics).toBe('append_only');
+      expect(DEFAULT_POLICY.semantics).toBe('append_only');
+    });
+  });
+
+  describe('FactResolverService threading', () => {
+    function make() {
+      const queries: Array<{ sql: string; params: any }> = [];
+      const db = {
+        query: jest.fn(async (sql: string, params: any) => {
+          queries.push({ sql, params });
+          if (sql.includes('fn::resolve_facts')) {
+            return [
+              params.facts.map(() => ({
+                factId: 'knowledge_fact:b',
+                outcome: 'INSERTED',
+              })),
+            ];
+          }
+          return [{ factId: 'knowledge_fact:s', outcome: 'INSERTED' }];
+        }),
+      };
+      const svc = new FactResolverService(
+        {
+          embed: jest.fn(async () => [0.1]),
+          writeAltEmbeddingIfHype: jest.fn(async () => {}),
+        } as never,
+        {
+          getSnapshot: jest.fn(async () => ({})),
+          policyFor: jest.fn((_c: string, p: string) => ({
+            semantics: p === 'status' ? 'single_active' : 'append_only',
+          })),
+        } as never,
+      );
+      return { svc, db, queries };
+    }
+    const input = (predicate: string, predicateAlias?: string) => ({
+      companyId: 'co_x',
+      entityId: 'knowledge_entity:e1',
+      predicate,
+      predicateAlias,
+      object: 'gold',
+      confidence: 0.9,
+      validFrom: new Date('2023-01-01T00:00:00Z'),
+      source: {},
+      precomputedEmbedding: [0.1],
+    });
+
+    it('per-fact path binds $predicate_alias as the 24th arg', async () => {
+      const { svc, db, queries } = make();
+      await svc.resolve(db as never, input('status', 'state'));
+      const q = queries.find((x) => x.sql.includes('fn::resolve_fact('));
+      expect(q!.sql).toContain('$predicate_alias');
+      expect(q!.params.predicate_alias).toBe('state');
+      expect(q!.params.predicate).toBe('status');
+    });
+
+    it('batched append_only path carries predicate_alias per fact, omitted when absent', async () => {
+      const { svc, db, queries } = make();
+      await svc.resolveMany(db as never, [
+        input('painted_seascape', 'painted'),
+        input('researched'),
+      ]);
+      const batch = queries.find((x) => x.sql.includes('fn::resolve_facts'));
+      expect(batch!.params.facts[0].predicate_alias).toBe('painted');
+      expect(batch!.params.facts[0].predicate).toBe('painted_seascape');
+      expect('predicate_alias' in batch!.params.facts[1]).toBe(false);
+    });
+  });
+});

--- a/test/promotion.e2e-spec.ts
+++ b/test/promotion.e2e-spec.ts
@@ -58,8 +58,10 @@ describe('episodic→semantic promotion (real SurrealDB)', () => {
     const fresh = await ingest('said', 'fresh remark that must stay active');
     await backdate(aged, 365);
 
-    // Control group: 5 aged facts on a bitemporal (default-semantics)
-    // predicate — never promoted no matter the age.
+    // Control group: 5 aged facts on a COINED (not-in-seed) predicate —
+    // never promoted no matter the age. Coined predicates write as
+    // append_only since 0082, but promotion folds only seed-declared
+    // append_only event history; specific observations stay verbatim.
     const control: string[] = [];
     for (let i = 1; i <= 5; i++) {
       control.push(await ingest('claim_probe', `unrelated claim ${i}`));


### PR DESCRIPTION
## What

Closes the two remaining structural write items from the 2026-08 engine architecture audit (finding #2, "Still open / W3"):

### 1. `predicateAlias` column (migration 0082)

The dialogue tract deliberately keeps the SPECIFIC predicate the extractor coined (`painted_seascape`, not `hobby`) — but that left dedup/corroboration keyed on the raw coinage, so the same claim under two coinages never met. The prompt's promised EDC canonicalization now runs as an **alias pass**:

- the coinage survives in `predicate`; the registry's canonical id lands in `knowledge_fact.predicateAlias`;
- `fn::resolve_fact` grows a 24th positional arg and keys its candidate set on `predicateAlias ?? predicate`;
- read-side predicate consumers switch to the same canonical key: policy + chatter lookups in scoring, the diversity key, graph-retrieve demo dedup, dreams-corroborate grouping, and the ingest preflight mirror.

Alias-less rows (every closed-vocabulary tenant, all pre-0082 data) are byte-identical to before.

### 2. `append_only` default for open predicates

Unknown (coined) predicates inherited `bitemporal` supersede/compete — semantics invented for closed CRM vocabularies — and every coined fact took the serialized per-fact mutex path (`INGEST_BATCH_FACTS` was a no-op on the shipping tract). The registry fallback (and the `proposed` rows canonicalize creates from it) now defaults to `append_only`; seed and operator-declared predicates keep their per-predicate policies. Corroboration becomes reachable for `append_only` inside `fn::resolve_fact` (pooled over candidates; exact-object + different-origin gate unchanged).

Two seed-keyed carve-outs keep prior behavior where the fallback flip would have been wrong:
- **dreams-corroborate** sweeps coined groups (fuzzy same-assertion is exactly what collapses re-worded coinages) while still skipping seed `append_only` event history;
- **episodic promotion** folds ONLY seed `append_only` predicates — a `summary_<coinage>` row would trade recall drivers for a paraphrase.

## Verification

- 1828 unit tests green (7 new in `test/predicate-alias.unit-spec.ts`); mock-e2e green except `fact-trust-ranking`, which fails identically on clean main (pre-existing).
- No new env keys, no eval forks — engine-wide invariants only.
- **Merge gate:** per the ewave rule this is a write-path change — the fresh-derivedVersion LoCoMo dev-5 confirm leg (fresh tenant, diary write profile, paired vs `var/locomo-v4always-dev5.json`) runs before merge; result lands in `docs/roadmap/validate-2026-08-results.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yApwtdYhLPdB8C8jpkPQV