### PR TITLE
fix(admin): bind operator_action ts as a Date on SurrealDB 3.x

### DIFF
--- a/src/admin/operator-action.service.ts
+++ b/src/admin/operator-action.service.ts
@@ -108,8 +108,10 @@ export class OperatorActionService {
     // (`Expected none | object but found NULL`; caught live by the V5
     // MS leg: every audited maintenance call 500'd). Absent means
     // absent: omit the fields instead of binding null.
+    // `ts` is a datetime field — 3.x refuses a bound ISO string (WARN
+    // per audited call, caught live by the W3 leg boot); bind a Date.
     const content: Record<string, unknown> = {
-      ts: row.ts,
+      ts: new Date(row.ts),
       actor: row.actor,
       scopes: row.scopes,
       method: row.method,

--- a/test/operator-action-ts.unit-spec.ts
+++ b/test/operator-action-ts.unit-spec.ts
@@ -1,0 +1,47 @@
+/**
+ * operator_action persist — SurrealDB 3.x datetime binding.
+ *
+ * `ts` is a `datetime` field (migration 0027). 3.x refuses to coerce a
+ * bound ISO STRING into datetime, so every audited admin call logged a
+ * persist WARN (caught live by the W3 leg boot). The write must bind a
+ * JS Date — the SDK serializes it as a Surreal datetime.
+ */
+import { OperatorActionService } from '../src/admin/operator-action.service';
+
+function surrealMock(capture: Record<string, any>[]) {
+  return {
+    withCompany: async (_c: string, fn: (db: any) => Promise<any>) =>
+      fn({
+        query: async (_sql: string, binds?: Record<string, any>) => {
+          if (binds) capture.push(binds);
+          return [[]];
+        },
+      }),
+  } as any;
+}
+
+describe('OperatorActionService.persist (3.x datetime coercion)', () => {
+  it('binds ts as a Date, not an ISO string', async () => {
+    const capture: Record<string, any>[] = [];
+    const svc = new OperatorActionService(surrealMock(capture));
+    await (svc as any).persist({
+      ts: '2026-08-07T12:00:00.000Z',
+      actor: 'evalops',
+      scopes: ['brain:admin'],
+      method: 'POST',
+      path: '/v1/admin/maintenance/derive',
+      status: 201,
+      durationMs: 42,
+      query: null,
+      bodySummary: null,
+      companyId: 'evalops',
+    });
+    expect(capture).toHaveLength(1);
+    const content = capture[0].content as Record<string, unknown>;
+    expect(content.ts).toBeInstanceOf(Date);
+    expect((content.ts as Date).toISOString()).toBe('2026-08-07T12:00:00.000Z');
+    // Null option fields stay omitted (the 0027 NULL-vs-none contract).
+    expect('query' in content).toBe(false);
+    expect('bodySummary' in content).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

One-liner + unit: `OperatorActionService.persist()` bound an ISO **string** into the `ts` `datetime` field (migration 0027). SurrealDB 3.x refuses the string→datetime coercion, so every audited admin call logged a persist WARN — found live by the W3 leg boot, carried in the V8 brief §5.

## Fix

- `ts: new Date(row.ts)` — the SDK serializes a JS Date as a Surreal datetime, same as every other datetime write in the codebase.
- New `test/operator-action-ts.unit-spec.ts`: asserts the bound content carries a `Date` (round-tripping the ISO instant) and that the 0027 null-omission contract for `query`/`bodySummary` holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yApwtdYhLPdB8C8jpkPQV