### PR TITLE
chore(deps): js-yaml 4.3.1 / 3.15.1 — 3 fresh Dependabot highs

### DIFF
--- a/brain-landing/package.json
+++ b/brain-landing/package.json
@@ -57,8 +57,8 @@
   "pnpm": {
     "overrides": {
       "postcss@8": "^8.5.23",
-      "js-yaml@3": "^3.15.0",
-      "js-yaml@4": "^4.2.0",
+      "js-yaml@3": "^3.15.1",
+      "js-yaml@4": "^4.3.1",
       "@babel/core": "^7.29.6",
       "sharp": "^0.35.0",
       "brace-expansion@1": "^1.1.16"

--- a/brain-landing/pnpm-lock.yaml
+++ b/brain-landing/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 overrides:
   postcss@8: ^8.5.23
-  js-yaml@3: ^3.15.0
-  js-yaml@4: ^4.2.0
+  js-yaml@3: ^3.15.1
+  js-yaml@4: ^4.3.1
   '@babel/core': ^7.29.6
   sharp: ^0.35.0
   brace-expansion@1: ^1.1.16
@@ -2326,12 +2326,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3636,7 +3636,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5593,7 +5593,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -5840,12 +5840,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
       "body-parser": "^2.3.0",
       "form-data": "^4.0.6",
       "tmp": "^0.2.6",
-      "js-yaml": "^4.2.0",
+      "js-yaml": "^4.3.1",
       "@babel/core": "^7.29.6",
       "undici": "^7.29.0",
       "minimatch@10": "^10.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   body-parser: ^2.3.0
   form-data: ^4.0.6
   tmp: ^0.2.6
-  js-yaml: ^4.2.0
+  js-yaml: ^4.3.1
   '@babel/core': ^7.29.6
   undici: ^7.29.0
   minimatch@10: ^10.2.3
@@ -3396,8 +3396,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5039,7 +5039,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5355,7 +5355,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -7328,7 +7328,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -8719,7 +8719,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
Alerts 116-118 landed after the #255 sweep merged: js-yaml `>=4.0.0 <4.3.1` (root + brain-landing) and `>=3.0.0 <3.15.1` (brain-landing). Existing scoped overrides bumped (`js-yaml` ^4.3.1 root; `js-yaml@3` ^3.15.1 + `js-yaml@4` ^4.3.1 in brain-landing); both lockfiles regenerated `--lockfile-only --ignore-workspace`; grep-verified resolutions 4.3.1/3.15.1 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yApwtdYhLPdB8C8jpkPQV