### PR TITLE
fix(deps): dedupe yaml@2.9.0 lockfile blocks left by textual dependabot merges

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4692,11 +4692,6 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yaml@2.9.0:
-    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -10177,8 +10172,6 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
-
-  yaml@2.9.0: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
Main's build-test and deploys have been red since the #237 merge: merging the rebased dependabot PRs in quick succession textually merged two lockfile diffs that both added yaml@2.9.0, duplicating its block in BOTH the packages and snapshots sections — pnpm rejects the file at parse time. Prod is unaffected (still on the v1.0.0 image; the broken deploys failed before replacing it).

This removes the duplicate blocks. Verified: `pnpm install --frozen-lockfile`, 242 suites / 2063 unit tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB