### PR TITLE
docs(roadmap): §8 — ablation-run mining and ranked work items

### DIFF
--- a/docs/roadmap/v11-session-2026-08.md
+++ b/docs/roadmap/v11-session-2026-08.md
@@ -325,3 +325,54 @@ loco-321 have ZERO episode_segment rows — those worlds were never
 segmented. Any past or future mention-lane measurement on those
 worlds ran against an empty segment table (the scan lane degrades to
 [] there). Worth re-segmenting before the next ordering-lane leg.
+
+## §8 — Mining the ablation runs (2026-08-15, free analysis)
+
+The edge-expansion pair left two fresh fully-judged dev-5 runs (n=999
+each) on v1.0.0 code — mined offline against the wd-v2 substrate on
+the stand. Three standing calibrations and a failure decomposition:
+
+**Release guard:** the v1.0.0 answer path holds 75.3% headline judge
+(n=762) vs the 76.1 w8cp band — within noise; the release did not
+regress LoCoMo. Future dev-5 runs pair against the OFF-arm 74.8.
+
+**Noise floor (standing protocol):** the invalid first arm B ran
+byte-identical to baseline → a free same-config replication: headline
+reproduces to 0.0pp with ±17 flips at n=762. Decision rule: dev-5
+headline deltas under ~2.2pp (or per-category under ±4-7pp) are noise.
+
+**Miss decomposition (188 headline misses):** abstained 12; crisp
+off-by-1-3-days date answers 3 (+1 far-off) — the validFrom=emittedAt
+mention-collapse class, live examples: gold "7 May 2023" → answered
+"May 6, 2023"; gold-tokens-fully-present-but-judged-wrong 16 — almost
+all OVER-enumeration (the answer lists the gold items PLUS extras and
+the judge sinks it); answered-wrong 156.
+
+**The answered-wrong split vs the substrate (token-overlap match):**
+
+| bucket | n | share | by-cat concentration |
+|---|---|---|---|
+| gold IS in wd-v2 facts | 117 | 67% | single-hop 48, temporal 34, multi-hop 26 |
+| gold only in L0 segments | 21 | 12% | multi-hop 7, single-hop 11 |
+| gold absent from substrate | 38 | 22% | multi-hop 19, open-domain 17 |
+
+**Reading:** two thirds of all misses have the answer SITTING in the
+derived facts — the dominant lever on this axis is SELECTION/
+generation, not coverage (the July E3 profile, sharpened). The
+gold-absent tail is the known dataset-capped MH-enumeration/OD-
+inference class.
+
+**Work items this feeds (ranked):**
+1. Cross-encoder rerank over fused candidates (July program A3 —
+   already built, flag-gated, unmeasured on this world) targets the
+   117-row selection bucket directly.
+2. DERIVER_MENTION_STAMP measure on a re-derived LoCoMo world — the
+   off-by-days class is visibly live; the stamp is built (V12 write
+   side) and unmeasured on this axis.
+3. Over-enumeration answer contract (exact-N discipline for
+   enumeration-shaped questions) — cheap prompt leg, 16 rows ≈ +2.1pp
+   ceiling, right at the noise floor so measure paired.
+4. cat5 note: 'answer' guardrails structurally exempt the V11
+   abstention winner (verifier) on LoCoMo — a lenient+verifier
+   cat5-only arm (237 q) is the cheap missing row if the adversarial
+   number ever matters.


### PR DESCRIPTION
Free offline mining of the two judged dev-5 runs the edge-expansion ablation produced: release-guard statement (v1.0.0 holds 75.3, within noise), the standing noise-floor calibration (±2.2pp/±17 flips at n=762), and a fresh miss decomposition — 67% of headline misses have the gold sitting in wd-v2 facts (selection/generation lever, not coverage), with ranked follow-up legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB