### PR TITLE
fix(landing): the footer links that pointed nowhere

### DIFF
--- a/.github/workflows/deploy-brain-landing.yml
+++ b/.github/workflows/deploy-brain-landing.yml
@@ -1,9 +1,9 @@
 name: Deploy brain.inite.ai landing
 
 # Builds + deploys the marketing/docs landing that serves /, /{en,ru}*,
-# /skills.tar.gz, /install.sh on the SAME host as the backend
+# /skills.tar.gz, /install.sh, /openapi.json on the SAME host as the backend
 # (brain.inite.ai). Backend's Traefik router is restricted to
-# /v1, /mcp, /health, /metrics, /openapi.json — see deploy-brain.yml.
+# /v1, /mcp, /health, /metrics — see deploy-brain.yml.
 
 on:
   push:
@@ -121,11 +121,11 @@ jobs:
           cd /opt/projects/${{ env.PROJECT_NAME }}
 
           # Landing handles Host(brain.inite.ai) as a catch-all. Backend
-          # owns the explicit /v1, /mcp, /health, /metrics, /openapi.json
-          # prefixes via priority=200 + PathPrefix rules. Traefik picks the
-          # longest matching rule, so backend wins on its paths and the
-          # landing serves everything else (/, /{en,ru}/*, /skills.tar.gz,
-          # /install.sh, /_next/*).
+          # owns the explicit /v1, /mcp, /health, /metrics prefixes via
+          # priority=200 + PathPrefix rules. Traefik picks the longest
+          # matching rule, so backend wins on its paths and the landing
+          # serves everything else (/, /{en,ru}/*, /skills.tar.gz,
+          # /install.sh, /openapi.json, /_next/*).
           tee docker-compose.yml > /dev/null << EOF
           services:
             ${{ env.PROJECT_NAME }}:
@@ -239,9 +239,15 @@ jobs:
           for i in $(seq 1 12); do
             if curl -fs "https://${{ env.DOMAIN }}/en" > /dev/null 2>&1; then
               echo "[ok] https://${{ env.DOMAIN }}/en responds"
-              echo "[ok] /skills.tar.gz: $(curl -fsI https://${{ env.DOMAIN }}/skills.tar.gz | head -1)"
-              echo "[ok] /install.sh:    $(curl -fsI https://${{ env.DOMAIN }}/install.sh | head -1)"
-              echo "[ok] /v1/health:     $(curl -fsI https://${{ env.DOMAIN }}/health | head -1)"
+              # Status codes, not decorated echoes. The lines below used to
+              # print "[ok]" whether or not the curl succeeded — `curl -fsI`
+              # writes nothing on a failure, so a 404 rendered as "[ok] " with
+              # an empty tail and read as a pass. /openapi.json was a 404 for
+              # months while this probe ran green on every deploy.
+              for path in /skills.tar.gz /install.sh /health /openapi.json; do
+                code=$(curl -s -o /dev/null -w '%{http_code}' "https://${{ env.DOMAIN }}$path")
+                [ "$code" = "200" ] && echo "[ok]   $path -> $code" || echo "[warn] $path -> $code"
+              done
               exit 0
             fi
             echo "[info] external probe retry ($i/12)..."

--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -381,12 +381,22 @@ jobs:
                 - /opt/projects/${{ env.PROJECT_NAME }}/baselines:/var/brain/baselines
               labels:
                 # ── Backend routes only — landing handles the rest of brain.inite.ai.
-                # Backend owns /v1/*, /mcp/*, /health, /metrics, /openapi.json.
+                # Backend owns /v1/*, /mcp/*, /health, /metrics.
                 # Traefik sorts by rule length so this PathPrefix-restricted
                 # router naturally outranks the landing's Host-only catch-all.
+                #
+                # /openapi.json used to be claimed here and was a 404 the whole
+                # time: this service has no route for it, no Swagger module, and
+                # the image does not even ship docs/openapi.json — the Dockerfile
+                # copies src, dist and package.json, nothing else. Claiming the
+                # path only guaranteed the request never reached anything that
+                # could answer it. The document is a committed static artifact,
+                # so it now falls through to the landing's catch-all and is
+                # served out of brain-landing/public alongside /install.sh and
+                # /skills.tar.gz, written there by scripts/build-openapi.ts.
                 - "traefik.enable=true"
                 - "traefik.docker.network=traefik-global"
-                - "traefik.http.routers.${{ env.PROJECT_NAME }}.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || Path(\`/openapi.json\`))"
+                - "traefik.http.routers.${{ env.PROJECT_NAME }}.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`))"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}.priority=200"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}.entrypoints=websecure"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}.tls=true"
@@ -394,7 +404,7 @@ jobs:
                 - "traefik.http.services.${{ env.PROJECT_NAME }}.loadbalancer.server.port=${{ env.PORT }}"
                 - "traefik.http.services.${{ env.PROJECT_NAME }}.loadbalancer.responseForwarding.flushInterval=-1"
                 # http→https redirect for the same backend paths (landing has its own).
-                - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || Path(\`/openapi.json\`))"
+                - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`))"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.priority=200"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.entrypoints=web"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.middlewares=redirect-to-https"

--- a/brain-landing/__tests__/footer-links.test.ts
+++ b/brain-landing/__tests__/footer-links.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Every internal link in the footer must point at a page that exists.
+ *
+ * The footer renders on every page of the site, so a wrong href there is not
+ * one broken link — it is one broken link times the whole corpus, and nothing
+ * fails when it happens. `/[lang]/docs/search` shipped that way: the page has
+ * always been `/[lang]/docs/api/search`, and the only thing that ever noticed
+ * was Google's 2026-08 crawl, filing it under not-found weeks later.
+ *
+ * Scope is internal links, checked against the same DOCS_PAGES registry the
+ * router and the sitemap read. The absolute ones (github.com, /openapi.json,
+ * /health) are not reachable from a unit test; /openapi.json is covered
+ * instead by the deploy's external probe and by the drift gate in
+ * test/openapi-doc.unit-spec.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import { footerColumns } from '@/components/Footer'
+import { LANGS } from '@/lib/i18n'
+import { DOCS_PAGES } from '@/lib/docs-nav'
+
+/** Locale-prefixed routes that exist without being a doc page. */
+const STATIC_ROUTES = new Set(['', '/docs', '/blog'])
+
+function internalHrefs(lang: (typeof LANGS)[number]): string[] {
+  return footerColumns(lang)
+    .flatMap((c) => c.links)
+    .filter((l) => !('ext' in l && l.ext))
+    .map((l) => l.href)
+    .filter((h) => h.startsWith('/'))
+}
+
+describe('footer links', () => {
+  const docSlugs = new Set(DOCS_PAGES.map((p) => p.slug))
+
+  it.each(LANGS)('resolves every internal link for %s', (lang) => {
+    const dead = internalHrefs(lang).filter((href) => {
+      const rest = href.replace(new RegExp(`^/${lang}`), '')
+      if (STATIC_ROUTES.has(rest)) return false
+      const slug = rest.replace(/^\/docs\//, '')
+      return rest.startsWith('/docs/') ? !docSlugs.has(slug) : true
+    })
+    expect(dead, `footer links with no page behind them: ${dead.join(', ')}`).toEqual([])
+  })
+
+  it('prefixes every internal link with its locale', () => {
+    for (const lang of LANGS) {
+      for (const href of internalHrefs(lang)) {
+        expect(href.startsWith(`/${lang}`), `${href} is not under /${lang}`).toBe(true)
+      }
+    }
+  })
+})

--- a/brain-landing/app/robots.ts
+++ b/brain-landing/app/robots.ts
@@ -16,7 +16,23 @@ import { SITE_URL } from '../lib/seo'
  * app surfaces (api / admin / auth).
  */
 
-const APP_PATHS = ['/api/', '/en/admin/', '/ru/admin/', '/admin/', '/auth/']
+/**
+ * Not-for-crawling surfaces.
+ *
+ * /v1/ and /mcp belong to the backend, and they are POST-only and key-gated. A
+ * crawler only ever issues GET, so every one of those URLs is a permanent 404
+ * to anything that walks it — while .well-known/agent-actions publishes the
+ * full list of them by design, as the machine-readable manifest agents are
+ * meant to read. Google read it too and walked the URLs: /v1/search,
+ * /v1/dreams/run, /v1/facts/:id/retract and /v1/entities/:id/forget all landed
+ * in the 2026-08 not-found report, the last two with the literal `:id`
+ * placeholder still in the path.
+ *
+ * The manifest itself stays crawlable — that is the point of publishing it,
+ * and an agent calling an endpoint it names is making an API call, not a
+ * crawl. What stops here is a search crawler treating an API as pages.
+ */
+const APP_PATHS = ['/api/', '/v1/', '/mcp', '/en/admin/', '/ru/admin/', '/admin/', '/auth/']
 
 const CITATION_GRADE = [
   'OAI-SearchBot',

--- a/brain-landing/components/Footer.tsx
+++ b/brain-landing/components/Footer.tsx
@@ -6,11 +6,22 @@ interface Props {
   lang: Lang
 }
 
-export function Footer({ lang }: Props) {
+/**
+ * The footer's link table, exported so a test can walk it.
+ *
+ * It used to be built inline in the component, which is why two dead links sat
+ * in the Resources column unnoticed — on every page of the site, since this
+ * footer renders on all of them. /docs/search has never existed (the page is
+ * /docs/api/search), and /openapi.json was claimed by the backend's Traefik
+ * router while the backend had no route for it. /health, the third link, is
+ * fine and always was. The 2026-08 Search Console crawl is where the other two
+ * surfaced, as not-founds, months after the fact.
+ */
+export function footerColumns(lang: Lang) {
   const t = getMessages(lang)
   const f = t.footer
 
-  const cols = [
+  return [
     {
       title: f.columns.product.title,
       links: [
@@ -35,10 +46,20 @@ export function Footer({ lang }: Props) {
       links: [
         { label: f.columns.resources.openapi, href: 'https://brain.inite.ai/openapi.json', ext: true },
         { label: f.columns.resources.status, href: 'https://brain.inite.ai/health', ext: true },
-        { label: f.columns.resources.api, href: `/${lang}/docs/search`, ext: false },
+        // /docs/search has never existed — the page is /docs/api/search, and
+        // this link 404'd from every page on the site. Google logged it as a
+        // not-found in the 2026-08 crawl alongside the other two entries in
+        // this column.
+        { label: f.columns.resources.api, href: `/${lang}/docs/api/search`, ext: false },
       ],
     },
   ]
+}
+
+export function Footer({ lang }: Props) {
+  const t = getMessages(lang)
+  const f = t.footer
+  const cols = footerColumns(lang)
 
   return (
     <footer className="mt-12 border-t border-[var(--border)] pt-12 pb-10">

--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -1,0 +1,4573 @@
+{
+  "components": {
+    "responses": {
+      "BadGateway": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "The billing service rejected the request."
+      },
+      "BadRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "Validation failed."
+      },
+      "BillingUnavailable": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "The billing service is unreachable — paid-pack entitlements cannot be verified (fail-closed). Retry shortly."
+      },
+      "Conflict": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "State conflict — e.g. a lost/mismatched claim token, an already claimed work item, or an immutable-version republish."
+      },
+      "FeatureDisabled": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FeatureDisabledResponse"
+            }
+          }
+        },
+        "description": "The document pipeline is dark (DOCUMENT_INGEST_ENABLED off)."
+      },
+      "Forbidden": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "The key lacks the required scope."
+      },
+      "NotFound": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "No such resource in this tenant."
+      },
+      "TooManyRequests": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "Per-credential throttle exceeded."
+      },
+      "Unauthorized": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "Missing or unknown bearer key."
+      }
+    },
+    "schemas": {
+      "AvailablePack": {
+        "additionalProperties": false,
+        "properties": {
+          "builtin": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "predicateCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "version",
+          "description",
+          "predicateCount",
+          "builtin"
+        ],
+        "type": "object"
+      },
+      "Candidate": {
+        "additionalProperties": false,
+        "properties": {
+          "chunkSeq": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "commitRef": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "entity",
+              "fact",
+              "relation"
+            ],
+            "type": "string"
+          },
+          "payload": {
+            "additionalProperties": {},
+            "description": "Extraction payload. `object`/`clause` of scope-gated fact candidates are redacted for callers without the required predicate scope.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "runId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusReason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "runId",
+          "chunkSeq",
+          "kind",
+          "confidence",
+          "status",
+          "payload"
+        ],
+        "type": "object"
+      },
+      "CheckoutRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "errorUrl": {
+            "type": "string"
+          },
+          "successUrl": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CheckoutResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "checkoutUrl": {
+            "description": "Hosted billing checkout URL to open.",
+            "type": "string"
+          },
+          "sessionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionId",
+          "checkoutUrl"
+        ],
+        "type": "object"
+      },
+      "ClaimWorkResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "claimToken": {
+            "type": "string"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "leaseSeconds": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "packVersion": {
+            "type": "string"
+          },
+          "runId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "documentId",
+          "packId",
+          "packVersion",
+          "claimToken",
+          "leaseSeconds"
+        ],
+        "type": "object"
+      },
+      "CommitCounts": {
+        "additionalProperties": false,
+        "properties": {
+          "committed": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "merged": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pending": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "rejected": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "pending",
+          "committed",
+          "merged",
+          "rejected"
+        ],
+        "type": "object"
+      },
+      "CreateEpisodeSubscriptionRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
+      },
+      "CreateEpisodeSubscriptionResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "secret": {
+            "type": "string"
+          },
+          "watermark": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "secret",
+          "watermark"
+        ],
+        "type": "object"
+      },
+      "DeleteEpisodeSubscriptionResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "deleted": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "deleted"
+        ],
+        "type": "object"
+      },
+      "DisplayPrice": {
+        "additionalProperties": false,
+        "properties": {
+          "amount": {
+            "description": "Minor units (e.g. cents).",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "currency": {
+            "description": "3-letter ISO 4217 currency code.",
+            "pattern": "^[A-Za-z]{3}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount",
+          "currency"
+        ],
+        "type": "object"
+      },
+      "DocumentCandidatesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/Candidate"
+            },
+            "type": "array"
+          },
+          "documentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "documentId",
+          "candidates"
+        ],
+        "type": "object"
+      },
+      "DocumentChunk": {
+        "additionalProperties": false,
+        "properties": {
+          "charEnd": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "charStart": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "seq": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "seq",
+          "text",
+          "charStart",
+          "charEnd"
+        ],
+        "type": "object"
+      },
+      "DocumentContextRef": {
+        "additionalProperties": false,
+        "properties": {
+          "recorder": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "vertical"
+        ],
+        "type": "object"
+      },
+      "DocumentResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "charLen": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "chunkCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "chunks": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentChunk"
+            },
+            "type": "array"
+          },
+          "contentHash": {
+            "type": "string"
+          },
+          "hasContent": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "meta": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "occurredAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "recorder": {
+            "type": "string"
+          },
+          "runs": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "packId": {
+                  "type": "string"
+                },
+                "packVersion": {
+                  "type": "string"
+                },
+                "runId": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "runId",
+                "packId",
+                "packVersion",
+                "status"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "contentHash",
+          "charLen",
+          "chunkCount",
+          "hasContent",
+          "vertical",
+          "occurredAt",
+          "status",
+          "runs"
+        ],
+        "type": "object"
+      },
+      "DomainPackManifest": {
+        "additionalProperties": {},
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "evalFixtures": {
+            "items": {
+              "additionalProperties": {},
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "extractionProfile": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "id": {
+            "description": "snake_case pack id, no `__`.",
+            "type": "string"
+          },
+          "indexer": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "mcpTools": {
+            "items": {
+              "additionalProperties": {},
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "predicates": {
+            "items": {
+              "additionalProperties": {},
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "publisher": {
+            "type": "string"
+          },
+          "seedDocuments": {
+            "items": {
+              "additionalProperties": {},
+              "propertyNames": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "signature": {
+            "description": "ed25519 signature (base64) over the canonical manifest sans this field.",
+            "type": "string"
+          },
+          "version": {
+            "description": "semver MAJOR.MINOR.PATCH.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "version",
+          "description",
+          "predicates"
+        ],
+        "type": "object"
+      },
+      "EpisodeSubscriptionRow": {
+        "additionalProperties": false,
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "failureCount": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "watermark": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "url",
+          "active",
+          "watermark",
+          "failureCount",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "EpisodeSubscriptionsListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "subscriptions": {
+            "items": {
+              "$ref": "#/components/schemas/EpisodeSubscriptionRow"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "subscriptions"
+        ],
+        "type": "object"
+      },
+      "EpisodeWire": {
+        "additionalProperties": false,
+        "properties": {
+          "addressee": {
+            "type": "string"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "lang": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "occurredAt": {
+            "type": "string"
+          },
+          "piiClass": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "recordedAt": {
+            "type": "string"
+          },
+          "source": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "speaker": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "messageId",
+          "text",
+          "occurredAt",
+          "recordedAt",
+          "source"
+        ],
+        "type": "object"
+      },
+      "EpisodesAvailableEvent": {
+        "additionalProperties": false,
+        "properties": {
+          "delivery": {
+            "const": "at-least-once",
+            "type": "string"
+          },
+          "episodes": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "conversationId": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "messageId": {
+                  "type": "string"
+                },
+                "occurredAt": {
+                  "type": "string"
+                },
+                "recordedAt": {
+                  "type": "string"
+                },
+                "speaker": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "messageId",
+                "occurredAt",
+                "recordedAt"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "event": {
+            "const": "episodes_available",
+            "type": "string"
+          },
+          "ts": {
+            "type": "string"
+          },
+          "watermark": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "event",
+          "delivery",
+          "episodes",
+          "watermark",
+          "ts"
+        ],
+        "type": "object"
+      },
+      "EpisodesListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "episodes": {
+            "items": {
+              "$ref": "#/components/schemas/EpisodeWire"
+            },
+            "type": "array"
+          },
+          "nextCursor": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "episodes"
+        ],
+        "type": "object"
+      },
+      "ErrorResponse": {
+        "description": "Standard NestJS error envelope.",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "statusCode": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "statusCode",
+          "message"
+        ],
+        "type": "object"
+      },
+      "FailWorkRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "claimToken": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "error": {
+            "description": "Optional diagnostic recorded on the run row (truncated server-side).",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "permanent": {
+            "description": "Default (false/absent) RELEASES the item back to 'pending'; true marks the run 'failed' — no longer offered, still claimable by runId.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "claimToken"
+        ],
+        "type": "object"
+      },
+      "FailWorkResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "runId": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "released",
+              "failed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "status"
+        ],
+        "type": "object"
+      },
+      "FeatureDisabledResponse": {
+        "description": "Answered by every document-pipeline route while DOCUMENT_INGEST_ENABLED is off.",
+        "properties": {
+          "error": {
+            "const": "feature_disabled",
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "message"
+        ],
+        "type": "object"
+      },
+      "FeatureResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "featured": {
+            "type": "boolean"
+          },
+          "packId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId",
+          "featured"
+        ],
+        "type": "object"
+      },
+      "GroundingDrop": {
+        "additionalProperties": false,
+        "properties": {
+          "detail": {
+            "type": "string"
+          },
+          "index": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "kind": {
+            "enum": [
+              "entity",
+              "fact",
+              "relation"
+            ],
+            "type": "string"
+          },
+          "reason": {
+            "enum": [
+              "ungrounded_entity",
+              "ungrounded_value",
+              "orphan_reference"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "index",
+          "reason",
+          "detail"
+        ],
+        "type": "object"
+      },
+      "HeartbeatWorkRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "claimToken": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "claimToken"
+        ],
+        "type": "object"
+      },
+      "HeartbeatWorkResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "leaseSeconds": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "runId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "leaseSeconds"
+        ],
+        "type": "object"
+      },
+      "IndexerWorkItem": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          },
+          "docHasContent": {
+            "type": "boolean"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "packVersion": {
+            "type": "string"
+          },
+          "runId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "documentId",
+          "packId",
+          "packVersion",
+          "createdAt",
+          "docHasContent"
+        ],
+        "type": "object"
+      },
+      "IndexerWorkListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "work": {
+            "items": {
+              "$ref": "#/components/schemas/IndexerWorkItem"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "work"
+        ],
+        "type": "object"
+      },
+      "IngestDocumentAsyncResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "chunkCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "deduplicated": {
+            "type": "boolean"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "mode": {
+            "const": "async",
+            "type": "string"
+          },
+          "runs": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "packId": {
+                  "type": "string"
+                },
+                "status": {
+                  "enum": [
+                    "enqueued",
+                    "already_processed",
+                    "planned"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "packId",
+                "status"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "documentId",
+          "deduplicated",
+          "chunkCount",
+          "mode",
+          "runs"
+        ],
+        "type": "object"
+      },
+      "IngestDocumentRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "contextRef": {
+            "$ref": "#/components/schemas/DocumentContextRef"
+          },
+          "indexers": {
+            "anyOf": [
+              {
+                "const": "general",
+                "type": "string"
+              },
+              {
+                "const": "auto",
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "'general' (union pass), 'auto' (router-selected), or explicit pack ids."
+          },
+          "kind": {
+            "description": "Container kind the connector normalized from (pdf/markdown/email/…). Open string — provenance metadata only.",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "meta": {
+            "additionalProperties": {},
+            "description": "Operator-supplied metadata, projected onto derived facts' source.meta.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "mode": {
+            "description": "'async' requires DOCUMENT_MULTI_INDEXER_ENABLED and storeContent.",
+            "enum": [
+              "sync",
+              "async"
+            ],
+            "type": "string"
+          },
+          "occurredAt": {
+            "description": "ISO 8601 — becomes the derived facts' validFrom.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "originUri": {
+            "description": "Pointer back to the raw container (URL, path, message id…).",
+            "maxLength": 512,
+            "type": "string"
+          },
+          "storeContent": {
+            "description": "Store the normalized chunks server-side. false keeps only contentHash + metadata (no re-index, no span re-validation).",
+            "type": "boolean"
+          },
+          "text": {
+            "description": "Normalized document text (DOC_MAX_CHARS may lower the cap).",
+            "maxLength": 512000,
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 512,
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "text",
+          "occurredAt",
+          "contextRef"
+        ],
+        "type": "object"
+      },
+      "IngestDocumentSyncResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "chunkCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "committed": {
+            "additionalProperties": false,
+            "properties": {
+              "edgeIds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "entityIds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "factIds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "entityIds",
+              "factIds",
+              "edgeIds"
+            ],
+            "type": "object"
+          },
+          "counts": {
+            "$ref": "#/components/schemas/CommitCounts"
+          },
+          "deduplicated": {
+            "type": "boolean"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "mode": {
+            "const": "sync",
+            "type": "string"
+          },
+          "runs": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "packId": {
+                  "type": "string"
+                },
+                "runId": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "runId",
+                "packId",
+                "status"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "documentId",
+          "deduplicated",
+          "chunkCount",
+          "mode",
+          "runs",
+          "committed",
+          "counts"
+        ],
+        "type": "object"
+      },
+      "InstallFromRegistryRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "acceptMcpTools": {
+            "type": "boolean"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId"
+        ],
+        "type": "object"
+      },
+      "InstallPackRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "acceptMcpTools": {
+            "type": "boolean"
+          },
+          "expectedChecksum": {
+            "type": "string"
+          },
+          "manifest": {
+            "$ref": "#/components/schemas/DomainPackManifest"
+          }
+        },
+        "required": [
+          "manifest"
+        ],
+        "type": "object"
+      },
+      "InstallPackResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "checksum": {
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "predicatesSeeded": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "seedDocuments": {
+            "additionalProperties": false,
+            "description": "Present iff the manifest ships seedDocuments — whether their document-pipeline ingest was enqueued. Install never fails because of seeds.",
+            "properties": {
+              "count": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "status": {
+                "enum": [
+                  "enqueued",
+                  "enqueue_failed",
+                  "skipped_flag_disabled",
+                  "skipped_ingest_disabled",
+                  "skipped_no_queue"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "count",
+              "status"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "type": "string"
+          },
+          "webhookSecret": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "predicatesSeeded",
+          "checksum"
+        ],
+        "type": "object"
+      },
+      "InstalledPack": {
+        "additionalProperties": false,
+        "properties": {
+          "checksum": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "installedAt": {
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "predicateCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "installedAt",
+          "predicateCount",
+          "checksum"
+        ],
+        "type": "object"
+      },
+      "PackEvalFixtureResult": {
+        "additionalProperties": false,
+        "properties": {
+          "failures": {
+            "description": "Human-readable reasons the fixture failed (empty when passed).",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "passed": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "passed",
+          "failures"
+        ],
+        "type": "object"
+      },
+      "PackEvalReport": {
+        "additionalProperties": false,
+        "properties": {
+          "packId": {
+            "type": "string"
+          },
+          "passed": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/PackEvalFixtureResult"
+            },
+            "type": "array"
+          },
+          "total": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "total",
+          "passed",
+          "results"
+        ],
+        "type": "object"
+      },
+      "PackPricingResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "displayPrice": {
+            "$ref": "#/components/schemas/DisplayPrice"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "paid": {
+            "type": "boolean"
+          },
+          "priceCode": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId",
+          "paid"
+        ],
+        "type": "object"
+      },
+      "PacksListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "available": {
+            "items": {
+              "$ref": "#/components/schemas/AvailablePack"
+            },
+            "type": "array"
+          },
+          "installed": {
+            "items": {
+              "$ref": "#/components/schemas/InstalledPack"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "available",
+          "installed"
+        ],
+        "type": "object"
+      },
+      "PaymentRequiredHint": {
+        "additionalProperties": false,
+        "properties": {
+          "checkout": {
+            "additionalProperties": false,
+            "properties": {
+              "method": {
+                "const": "POST",
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "method",
+              "path"
+            ],
+            "type": "object"
+          },
+          "displayPrice": {
+            "$ref": "#/components/schemas/DisplayPrice"
+          },
+          "error": {
+            "const": "Payment Required",
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "priceCode": {
+            "type": "string"
+          },
+          "statusCode": {
+            "const": 402,
+            "type": "number"
+          }
+        },
+        "required": [
+          "statusCode",
+          "error",
+          "message",
+          "packId",
+          "checkout"
+        ],
+        "type": "object"
+      },
+      "ProjectionRow": {
+        "additionalProperties": false,
+        "properties": {
+          "builder": {
+            "type": "string"
+          },
+          "finishedAt": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": "string"
+          },
+          "stats": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "status": {
+            "enum": [
+              "building",
+              "built",
+              "live",
+              "residual",
+              "failed"
+            ],
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "watermark": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "version",
+          "status",
+          "builder",
+          "startedAt"
+        ],
+        "type": "object"
+      },
+      "ProjectionsListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "projections": {
+            "items": {
+              "$ref": "#/components/schemas/ProjectionRow"
+            },
+            "type": "array"
+          },
+          "readPin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "projections",
+          "readPin"
+        ],
+        "type": "object"
+      },
+      "PublicDeclaredSource": {
+        "additionalProperties": false,
+        "properties": {
+          "authLevel": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "human",
+              "website",
+              "document",
+              "api",
+              "agent",
+              "sensor",
+              "system"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "authLevel"
+        ],
+        "type": "object"
+      },
+      "PublicSourceDetailResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "declared": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicDeclaredSource"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "history": {
+            "items": {
+              "$ref": "#/components/schemas/SourceHistoryRow"
+            },
+            "type": "array"
+          },
+          "sourceKey": {
+            "type": "string"
+          },
+          "trust": {
+            "items": {
+              "$ref": "#/components/schemas/TrustScopeRow"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "sourceKey",
+          "declared",
+          "trust",
+          "history"
+        ],
+        "type": "object"
+      },
+      "PublicSourceSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "declared": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicDeclaredSource"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "domainTrust": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TrustScopeRow"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "globalTrust": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TrustScopeRow"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "scopedDomains": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "sourceKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sourceKey",
+          "declared",
+          "globalTrust",
+          "scopedDomains"
+        ],
+        "type": "object"
+      },
+      "PublicSourcesListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "limit": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "offset": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "sources": {
+            "items": {
+              "$ref": "#/components/schemas/PublicSourceSummary"
+            },
+            "type": "array"
+          },
+          "total": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "sources",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "type": "object"
+      },
+      "PublishPackRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "expectedChecksum": {
+            "type": "string"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "manifest": {
+            "$ref": "#/components/schemas/DomainPackManifest"
+          }
+        },
+        "required": [
+          "manifest"
+        ],
+        "type": "object"
+      },
+      "PublishPackResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "checksum": {
+            "type": "string"
+          },
+          "created": {
+            "type": "boolean"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "checksum",
+          "created"
+        ],
+        "type": "object"
+      },
+      "PublisherProfile": {
+        "additionalProperties": false,
+        "properties": {
+          "bio": {
+            "type": "string"
+          },
+          "contactEmail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "publisher": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "publisher",
+          "displayName",
+          "url",
+          "bio",
+          "contactEmail",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "PublisherResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "packs": {
+            "items": {
+              "$ref": "#/components/schemas/RegistryPackSummary"
+            },
+            "type": "array"
+          },
+          "profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublisherProfile"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "publisher": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "publisher",
+          "profile",
+          "packs"
+        ],
+        "type": "object"
+      },
+      "RebuildProjectionRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "activate": {
+            "type": "boolean"
+          },
+          "conversation": {
+            "type": "string"
+          },
+          "force": {
+            "type": "boolean"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "RebuildProjectionResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "activated": {
+            "type": "boolean"
+          },
+          "conversations": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "failed": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "previousVersion": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "propositions": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "sessions": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "skipped": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "conversationId": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "conversationId",
+                "reason"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed"
+            ],
+            "type": "string"
+          },
+          "unresolvedSubjects": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "conversations",
+          "sessions",
+          "propositions",
+          "unresolvedSubjects",
+          "skipped",
+          "status",
+          "failed"
+        ],
+        "type": "object"
+      },
+      "RegistryListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "packs": {
+            "items": {
+              "$ref": "#/components/schemas/RegistryPackSummary"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "packs"
+        ],
+        "type": "object"
+      },
+      "RegistryManifestResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "checksum": {
+            "type": "string"
+          },
+          "manifest": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "yanked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "checksum",
+          "yanked",
+          "manifest"
+        ],
+        "type": "object"
+      },
+      "RegistryPackSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "displayPrice": {
+            "$ref": "#/components/schemas/DisplayPrice"
+          },
+          "downloads": {
+            "default": 0,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "featured": {
+            "type": "boolean"
+          },
+          "featuredAt": {
+            "type": "string"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "latestVersion": {
+            "type": "string"
+          },
+          "origin": {
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "paid": {
+            "type": "boolean"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "publisher": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "signed": {
+            "type": "boolean"
+          },
+          "verified": {
+            "default": false,
+            "type": "boolean"
+          },
+          "versionCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "packId",
+          "latestVersion",
+          "description",
+          "keywords",
+          "publisher",
+          "signed",
+          "verified",
+          "downloads",
+          "versionCount"
+        ],
+        "type": "object"
+      },
+      "RegistryVersion": {
+        "additionalProperties": false,
+        "properties": {
+          "checksum": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "downloads": {
+            "default": 0,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "origin": {
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "type": "string"
+          },
+          "publisher": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "signed": {
+            "type": "boolean"
+          },
+          "verified": {
+            "default": false,
+            "type": "boolean"
+          },
+          "version": {
+            "type": "string"
+          },
+          "yankReason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "yanked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "checksum",
+          "description",
+          "keywords",
+          "publisher",
+          "signed",
+          "verified",
+          "yanked",
+          "yankReason",
+          "publishedAt",
+          "downloads"
+        ],
+        "type": "object"
+      },
+      "RegistryVersionsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "latestVersion": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "packId": {
+            "type": "string"
+          },
+          "versions": {
+            "items": {
+              "$ref": "#/components/schemas/RegistryVersion"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "packId",
+          "latestVersion",
+          "versions"
+        ],
+        "type": "object"
+      },
+      "SetPricingRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "amount": {
+            "description": "Minor units (e.g. cents).",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "currency": {
+            "pattern": "^[A-Za-z]{3}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount",
+          "currency"
+        ],
+        "type": "object"
+      },
+      "SourceHistoryRow": {
+        "additionalProperties": false,
+        "properties": {
+          "agreementRate": {
+            "type": "number"
+          },
+          "domain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "recordedAt": {
+            "type": "string"
+          },
+          "sampleCount": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "domain",
+          "agreementRate",
+          "sampleCount",
+          "recordedAt"
+        ],
+        "type": "object"
+      },
+      "SubmitCandidatesRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "claimToken": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "entities": {
+            "items": {
+              "$ref": "#/components/schemas/SubmittedEntity"
+            },
+            "type": "array"
+          },
+          "facts": {
+            "items": {
+              "$ref": "#/components/schemas/SubmittedFact"
+            },
+            "type": "array"
+          },
+          "indexerId": {
+            "description": "The pack id this indexer is registered as (mode 'external').",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "packVersion": {
+            "description": "Optional claim of the pack version; must match the installed one.",
+            "maxLength": 32,
+            "type": "string"
+          },
+          "relations": {
+            "items": {
+              "$ref": "#/components/schemas/SubmittedRelation"
+            },
+            "type": "array"
+          },
+          "runId": {
+            "description": "A claimed work item this submission fulfils. Provided together with claimToken or not at all (claimless flow opens its own run).",
+            "maxLength": 128,
+            "type": "string"
+          }
+        },
+        "required": [
+          "indexerId",
+          "entities",
+          "facts"
+        ],
+        "type": "object"
+      },
+      "SubmitCandidatesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "commit": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "committed": {
+                    "type": "boolean"
+                  },
+                  "counts": {
+                    "$ref": "#/components/schemas/CommitCounts"
+                  },
+                  "deferred": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "deferred",
+                  "committed",
+                  "counts"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "null when the document vanished between staging and commit."
+          },
+          "dropped": {
+            "items": {
+              "$ref": "#/components/schemas/GroundingDrop"
+            },
+            "type": "array"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "packVersion": {
+            "type": "string"
+          },
+          "runId": {
+            "type": "string"
+          },
+          "staged": {
+            "additionalProperties": false,
+            "properties": {
+              "entities": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "facts": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "relations": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "entities",
+              "facts",
+              "relations"
+            ],
+            "type": "object"
+          },
+          "ungrounded": {
+            "description": "true when the document has no stored content — spans unverifiable.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "runId",
+          "packId",
+          "packVersion",
+          "staged",
+          "dropped",
+          "ungrounded",
+          "commit"
+        ],
+        "type": "object"
+      },
+      "SubmittedEntity": {
+        "additionalProperties": false,
+        "properties": {
+          "canonical": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SubmittedFact": {
+        "additionalProperties": false,
+        "properties": {
+          "clause": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "entityIndex": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "object": {
+            "type": "string"
+          },
+          "predicate": {
+            "description": "Must be namespaced `<indexerId>__*` or a core predicate.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "entityIndex",
+          "predicate",
+          "object"
+        ],
+        "type": "object"
+      },
+      "SubmittedRelation": {
+        "additionalProperties": false,
+        "properties": {
+          "confidence": {
+            "type": "number"
+          },
+          "fromEntityIndex": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "toEntityIndex": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "fromEntityIndex",
+          "toEntityIndex",
+          "kind"
+        ],
+        "type": "object"
+      },
+      "TrustScopeRow": {
+        "additionalProperties": false,
+        "properties": {
+          "agreementRate": {
+            "type": "number"
+          },
+          "domain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastSeenAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lossCount": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "sampleCount": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "winCount": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "domain",
+          "agreementRate",
+          "sampleCount",
+          "winCount",
+          "lossCount",
+          "lastSeenAt"
+        ],
+        "type": "object"
+      },
+      "UninstallPackResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "packId": {
+            "type": "string"
+          },
+          "predicatesDeprecated": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "packId",
+          "predicatesDeprecated"
+        ],
+        "type": "object"
+      },
+      "UpsertPublisherProfileRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "bio": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "contactEmail": {
+            "type": "string"
+          },
+          "displayName": {
+            "maxLength": 120,
+            "minLength": 1,
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "WorkContentChunk": {
+        "additionalProperties": false,
+        "properties": {
+          "seq": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "seq",
+          "text"
+        ],
+        "type": "object"
+      },
+      "WorkContentResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "chunkCount": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "chunks": {
+            "items": {
+              "$ref": "#/components/schemas/WorkContentChunk"
+            },
+            "type": "array"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "occurredAt": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "documentId",
+          "kind",
+          "vertical",
+          "occurredAt",
+          "chunkCount",
+          "chunks"
+        ],
+        "type": "object"
+      },
+      "YankPackRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "reason": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "YankPackResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "packId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "yanked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "packId",
+          "version",
+          "yanked"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "description": "API key (`Authorization: Bearer <key>`); its SHA-256 must be registered in BRAIN_API_KEYS. Keys carry scopes (`brain:read`, `brain:write`, `brain:admin`, `brain:read_pii`, `registry:publish`, `registry:curate`, `indexer:write`) — each operation states the scope it requires. Not an OAuth flow.",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "description": "Generated from the zod wire contracts (`pnpm openapi:build` — scripts/build-openapi.ts); do not edit by hand. The admin/ops surface (jobs, leases, policy, stats, maintenance) is documented in docs/api.md instead. Scopes are plain bearer-key grants, not OAuth flows — each operation states its required scope.",
+    "license": {
+      "identifier": "AGPL-3.0-or-later",
+      "name": "AGPL-3.0-or-later"
+    },
+    "summary": "The community-facing platform surface: Domain Pack registry, tenant pack admin, document ingest, the external-indexer work protocol, and source reputation reads.",
+    "title": "INITE Brain — Platform API",
+    "version": "1.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/v1/admin/packs": {
+      "get": {
+        "description": "Builtin packs are globally available and cannot be installed or uninstalled here. Source: src/admin/admin-packs.controller.ts.\n\nRequired scope: `brain:admin`.",
+        "operationId": "listDomainPacks",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PacksListResponse"
+                }
+              }
+            },
+            "description": "Available and installed packs."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "List available + installed packs for this tenant",
+        "tags": [
+          "Domain Packs"
+        ]
+      },
+      "post": {
+        "description": "Validates and installs a community / custom manifest, seeding its predicates. `expectedChecksum` pins the exact content.\n\nRequired scope: `brain:admin`.",
+        "operationId": "installDomainPack",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstallPackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallPackResponse"
+                }
+              }
+            },
+            "description": "Installed."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "Install a pack manifest into this tenant",
+        "tags": [
+          "Domain Packs"
+        ]
+      }
+    },
+    "/v1/admin/packs/from-registry": {
+      "post": {
+        "description": "Resolves the manifest (latest non-yanked, or a pinned version) and installs it with the registry checksum pinned — the installed content is exactly what the registry served. A PAID pack without an active `domain_pack:<packId>` entitlement answers 402 with a self-describing hint (the checkout route to call, then retry); while the billing service is unreachable, paid installs fail CLOSED with 503.\n\nRequired scope: `brain:admin`.",
+        "operationId": "installDomainPackFromRegistry",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstallFromRegistryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallPackResponse"
+                }
+              }
+            },
+            "description": "Installed."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredHint"
+                }
+              }
+            },
+            "description": "Paid pack, no entitlement — purchase via the checkout route in the hint, then retry."
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "502": {
+            "$ref": "#/components/responses/BadGateway"
+          },
+          "503": {
+            "$ref": "#/components/responses/BillingUnavailable"
+          }
+        },
+        "summary": "Install a pack from the global registry",
+        "tags": [
+          "Domain Packs"
+        ]
+      }
+    },
+    "/v1/admin/packs/{packId}": {
+      "delete": {
+        "description": "Deprecates the pack's predicates; facts extracted with them survive.\n\nRequired scope: `brain:admin`.",
+        "operationId": "uninstallDomainPack",
+        "parameters": [
+          {
+            "description": "The installed pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UninstallPackResponse"
+                }
+              }
+            },
+            "description": "Uninstalled."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Uninstall a pack from this tenant",
+        "tags": [
+          "Domain Packs"
+        ]
+      }
+    },
+    "/v1/admin/packs/{packId}/eval": {
+      "post": {
+        "description": "Scores whether extraction (with the pack's predicates + extractionProfile active) still meets the pack’s own expectations. Runs up to MAX_EVAL_FIXTURES live LLM calls — throttled to 3 requests/min per credential.\n\nRequired scope: `brain:admin`.",
+        "operationId": "evalDomainPack",
+        "parameters": [
+          {
+            "description": "The installed pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "'union' (default) scores the shared union prompt; 'dedicated' runs the pack-scoped dedicated prompt instead.",
+            "in": "query",
+            "name": "mode",
+            "required": false,
+            "schema": {
+              "enum": [
+                "union",
+                "dedicated"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PackEvalReport"
+                }
+              }
+            },
+            "description": "The eval report."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        },
+        "summary": "Run a pack's eval fixtures against the live extractor",
+        "tags": [
+          "Domain Packs"
+        ]
+      }
+    },
+    "/v1/admin/registry/packs": {
+      "post": {
+        "description": "Versions are immutable once published. Republishing an identical (packId, version, checksum) is idempotent (`created: false`); a different body for an existing version is rejected. Source: src/registry/admin-registry.controller.ts.\n\nRequired scope: `registry:publish`.",
+        "operationId": "publishRegistryPack",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublishPackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublishPackResponse"
+                }
+              }
+            },
+            "description": "Published (or already present)."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        },
+        "summary": "Publish a pack version to the global registry",
+        "tags": [
+          "Registry publishing"
+        ]
+      }
+    },
+    "/v1/admin/registry/packs/{packId}/checkout": {
+      "post": {
+        "description": "Creates a billing checkout session for the BUYING tenant (the caller's company is the billing userId). Open `checkoutUrl`, pay, then retry POST /v1/admin/packs/from-registry — the 402 hint on that route points here. Answers 400 for a free pack or while the billing integration is disabled. An `idempotency-key` header is forwarded to billing so client retries collapse into one order. Throttled to 10 requests/min per credential.\n\nRequired scope: `brain:admin`.",
+        "operationId": "createRegistryPackCheckout",
+        "parameters": [
+          {
+            "description": "The paid pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CheckoutRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckoutResponse"
+                }
+              }
+            },
+            "description": "The checkout session."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "502": {
+            "$ref": "#/components/responses/BadGateway"
+          },
+          "503": {
+            "$ref": "#/components/responses/BillingUnavailable"
+          }
+        },
+        "summary": "Start a hosted checkout for a paid pack",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/v1/admin/registry/packs/{packId}/feature": {
+      "post": {
+        "description": "Surfaces the pack in the featured section on top of the catalogue listing and /registry/ui. Instance-local; never mirrored.\n\nRequired scope: `registry:curate`.",
+        "operationId": "featureRegistryPack",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureResponse"
+                }
+              }
+            },
+            "description": "The curation state."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Feature a pack (hosting-operator curation)",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/v1/admin/registry/packs/{packId}/pricing": {
+      "delete": {
+        "description": "Clears the paid flag — installs stop requiring an entitlement. Billing products/prices are immutable and stay.\n\nRequired scope: `registry:publish`.",
+        "operationId": "clearRegistryPackPricing",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PackPricingResponse"
+                }
+              }
+            },
+            "description": "The pricing state."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Make a pack free again (publisher-owned)",
+        "tags": [
+          "Marketplace"
+        ]
+      },
+      "put": {
+        "description": "Marks the pack paid: ensures the billing product exists (entitlement key `domain_pack:<packId>`), mints a fresh immutable price, and stores the priceCode + display price in the instance-local registry meta. Only the company that published the pack may price it. Answers 400 while the billing integration is disabled. Source: src/registry/marketplace-admin.controller.ts.\n\nRequired scope: `registry:publish`.",
+        "operationId": "setRegistryPackPricing",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetPricingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PackPricingResponse"
+                }
+              }
+            },
+            "description": "The pricing state."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Price a pack (publisher-owned)",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/v1/admin/registry/packs/{packId}/unfeature": {
+      "post": {
+        "description": "Reverses a feature.\n\nRequired scope: `registry:curate`.",
+        "operationId": "unfeatureRegistryPack",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureResponse"
+                }
+              }
+            },
+            "description": "The curation state."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Remove a pack from the featured section",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/v1/admin/registry/packs/{packId}/{version}/unyank": {
+      "post": {
+        "description": "Reverses a yank — the version becomes installable again.\n\nRequired scope: `registry:publish`.",
+        "operationId": "unyankRegistryPack",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The yanked version to restore.",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/YankPackResponse"
+                }
+              }
+            },
+            "description": "Yank state after the call."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Restore a yanked version",
+        "tags": [
+          "Registry publishing"
+        ]
+      }
+    },
+    "/v1/admin/registry/packs/{packId}/{version}/yank": {
+      "post": {
+        "description": "Marks a version as not-installable (existing installs keep working). The version stays visible in the history, flagged.\n\nRequired scope: `registry:publish`.",
+        "operationId": "yankRegistryPack",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The published version to yank.",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/YankPackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/YankPackResponse"
+                }
+              }
+            },
+            "description": "Yank state after the call."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Yank a published version",
+        "tags": [
+          "Registry publishing"
+        ]
+      }
+    },
+    "/v1/admin/registry/publishers/{publisher}": {
+      "put": {
+        "description": "Full-replace upsert. Writable ONLY by a company that has published at least one VERIFIED pack under the publisher id — the ed25519 signature validated against the hosting instance's trust store is what ties a company to the publisher name (403 otherwise).\n\nRequired scope: `registry:publish`.",
+        "operationId": "upsertRegistryPublisherProfile",
+        "parameters": [
+          {
+            "description": "The publisher id (trust-store key id).",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpsertPublisherProfileRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublisherProfile"
+                }
+              }
+            },
+            "description": "The stored profile."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "Write a publisher's public profile",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/v1/documents/{id}": {
+      "get": {
+        "description": "Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/documents.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "getDocument",
+        "parameters": [
+          {
+            "description": "The document id.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Pass `1` to include the stored chunks. The raw text can carry any PII, so this additionally requires the `brain:read_pii` scope (403 otherwise).",
+            "in": "query",
+            "name": "includeText",
+            "required": false,
+            "schema": {
+              "enum": [
+                "1"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponse"
+                }
+              }
+            },
+            "description": "The document."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Read a document header and its indexer runs",
+        "tags": [
+          "Documents"
+        ]
+      }
+    },
+    "/v1/documents/{id}/candidates": {
+      "get": {
+        "description": "Every extraction candidate staged against the document, over all runs. `object`/`clause` of fact candidates whose predicate requires a scope the caller lacks are redacted; the row stays visible for the audit trail. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`.\n\nRequired scope: `brain:read`.",
+        "operationId": "listDocumentCandidates",
+        "parameters": [
+          {
+            "description": "The document id.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentCandidatesResponse"
+                }
+              }
+            },
+            "description": "The candidates."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "The document's staged candidates (audit view)",
+        "tags": [
+          "Documents"
+        ]
+      },
+      "post": {
+        "description": "A remote indexer that read a stored document submits its reading here. With `runId` + `claimToken` the submission fulfils a claimed work item; without them it opens its own run (claimless flow). Candidates are grounded against the stored text; the Brain commits once every run for the document is settled. Max 200 items per kind. Throttled to 10 requests/min per credential. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/external-candidates.controller.ts.\n\nRequired scope: `indexer:write`.",
+        "operationId": "submitDocumentCandidates",
+        "parameters": [
+          {
+            "description": "The document id.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitCandidatesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubmitCandidatesResponse"
+                }
+              }
+            },
+            "description": "Staged (and possibly committed)."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Stage an external indexer's candidate batch",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/episodes": {
+      "get": {
+        "description": "Verbatim pre-extraction dialogue turns in stable (occurredAt, id) order — the raw layer any consumer can build its own projection from. Callers without `brain:read_pii` see only episodes whose piiClass is empty. 404 until EPISODES_API_ENABLED=1. Source: src/episodes/episodes.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "listEpisodes",
+        "parameters": [
+          {
+            "description": "Only turns of this conversation.",
+            "in": "query",
+            "name": "conversationId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only turns by this speaker.",
+            "in": "query",
+            "name": "speaker",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO lower bound on occurredAt (inclusive).",
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO upper bound on occurredAt (exclusive).",
+            "in": "query",
+            "name": "until",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size (max 200, default 50).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque keyset cursor from the previous page (`nextCursor`).",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodesListResponse"
+                }
+              }
+            },
+            "description": "One page of episodes."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Read the L0 episode substrate (keyset-paged)",
+        "tags": [
+          "Episodes"
+        ]
+      }
+    },
+    "/v1/episodes/export": {
+      "get": {
+        "description": "The same filtered stream as GET /v1/episodes, one episode per line, paged internally — bounded memory however large the tenant. 404 until EPISODES_API_ENABLED=1.\n\nRequired scope: `brain:read`.",
+        "operationId": "exportEpisodes",
+        "parameters": [
+          {
+            "description": "Only turns of this conversation.",
+            "in": "query",
+            "name": "conversationId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only turns by this speaker.",
+            "in": "query",
+            "name": "speaker",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO lower bound on occurredAt (inclusive).",
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO upper bound on occurredAt (exclusive).",
+            "in": "query",
+            "name": "until",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/x-ndjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeWire"
+                }
+              }
+            },
+            "description": "NDJSON stream; each line is an Episode."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Stream the substrate as NDJSON (replay/export)",
+        "tags": [
+          "Episodes"
+        ]
+      }
+    },
+    "/v1/episodes/subscriptions": {
+      "get": {
+        "description": "Secrets are never included. 404 until EPISODE_SUBSCRIPTIONS_ENABLED=1.\n\nRequired scope: `brain:read`.",
+        "operationId": "listEpisodeSubscriptions",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeSubscriptionsListResponse"
+                }
+              }
+            },
+            "description": "Registered endpoints."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "List registered webhook endpoints",
+        "tags": [
+          "Episodes"
+        ]
+      },
+      "post": {
+        "description": "Registers an http(s) endpoint for `episodes_available` pushes (see the EpisodesAvailableEvent schema and the top-level webhooks section). The HMAC signing secret is returned exactly once. Pushes carry METADATA ONLY — bodies are pulled through GET /v1/episodes under the subscriber’s own scopes. Delivery is at-least-once. 404 until EPISODE_SUBSCRIPTIONS_ENABLED=1.\n\nRequired scope: `brain:admin`.",
+        "operationId": "createEpisodeSubscription",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEpisodeSubscriptionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateEpisodeSubscriptionResponse"
+                }
+              }
+            },
+            "description": "Registered; store the secret now."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Register a new-episode webhook endpoint",
+        "tags": [
+          "Episodes"
+        ]
+      }
+    },
+    "/v1/episodes/subscriptions/{id}": {
+      "delete": {
+        "description": "404 until EPISODE_SUBSCRIPTIONS_ENABLED=1.\n\nRequired scope: `brain:admin`.",
+        "operationId": "deleteEpisodeSubscription",
+        "parameters": [
+          {
+            "description": "The episode_subscription record id.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteEpisodeSubscriptionResponse"
+                }
+              }
+            },
+            "description": "Whether a subscription was deleted."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Delete a webhook endpoint",
+        "tags": [
+          "Episodes"
+        ]
+      }
+    },
+    "/v1/indexer/work": {
+      "get": {
+        "description": "Pending indexer runs routed to this tenant’s installed external packs. Protocol: docs/indexer-protocol.md. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/indexer-work.controller.ts.\n\nRequired scope: `indexer:write`.",
+        "operationId": "listIndexerWork",
+        "parameters": [
+          {
+            "description": "Only work for this external pack.",
+            "in": "query",
+            "name": "packId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max items to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerWorkListResponse"
+                }
+              }
+            },
+            "description": "Claimable work items."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Poll for pending external work items",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/indexer/work/{runId}/claim": {
+      "post": {
+        "description": "Atomically transitions the run to claimed and returns the claimToken that fences all subsequent calls. Heartbeat within leaseSeconds or the claim is reaped as abandoned. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`.\n\nRequired scope: `indexer:write`.",
+        "operationId": "claimIndexerWork",
+        "parameters": [
+          {
+            "description": "The work item (indexer run) id.",
+            "in": "path",
+            "name": "runId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClaimWorkResponse"
+                }
+              }
+            },
+            "description": "The claim."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Claim a pending work item",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/indexer/work/{runId}/content": {
+      "get": {
+        "description": "Serves the verbatim stored chunks of the claimed document — only for documents whose ingest routed to this tenant’s installed external packs. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`.\n\nRequired scope: `indexer:write`.",
+        "operationId": "getIndexerWorkContent",
+        "parameters": [
+          {
+            "description": "The claimed work item id.",
+            "in": "path",
+            "name": "runId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkContentResponse"
+                }
+              }
+            },
+            "description": "The document content."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Read the claimed document's stored content",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/indexer/work/{runId}/fail": {
+      "post": {
+        "description": "Default RELEASES the item back to 'pending' (transient trouble, shutdown mid-work); `permanent: true` marks the run 'failed' — no longer offered. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`.\n\nRequired scope: `indexer:write`.",
+        "operationId": "failIndexerWork",
+        "parameters": [
+          {
+            "description": "The claimed work item id.",
+            "in": "path",
+            "name": "runId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FailWorkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FailWorkResponse"
+                }
+              }
+            },
+            "description": "The outcome."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Release or permanently fail a claim",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/indexer/work/{runId}/heartbeat": {
+      "post": {
+        "description": "Extends the lease of a claimed work item. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`.\n\nRequired scope: `indexer:write`.",
+        "operationId": "heartbeatIndexerWork",
+        "parameters": [
+          {
+            "description": "The claimed work item id.",
+            "in": "path",
+            "name": "runId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HeartbeatWorkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HeartbeatWorkResponse"
+                }
+              }
+            },
+            "description": "The renewed lease."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Renew a claim lease",
+        "tags": [
+          "Indexer work"
+        ]
+      }
+    },
+    "/v1/ingest/document": {
+      "post": {
+        "description": "Source → Indexer → Candidates → Brain: stores + chunks the text, runs the selected indexers, commits grounded candidates as facts. `mode: \"async\"` fans out per-indexer queue jobs instead (requires DOCUMENT_MULTI_INDEXER_ENABLED). Throttled to 10 requests/min per credential. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/documents-ingest.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "ingestDocument",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngestDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/IngestDocumentSyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/IngestDocumentAsyncResponse"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Ingest outcome — shape follows the requested `mode`."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Ingest a normalized document",
+        "tags": [
+          "Documents"
+        ]
+      }
+    },
+    "/v1/projections": {
+      "get": {
+        "description": "Every derived world (facts@version, …) with its lifecycle status (building/built/live/residual/failed), watermark, builder identity and stats, plus the process-local read pin (RETRIEVAL_DERIVED_VERSION). A registry row promises a queryable world. 404 until PROJECTIONS_API_ENABLED=1. Source: src/admin/projections.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "listProjections",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectionsListResponse"
+                }
+              }
+            },
+            "description": "Derived worlds + read pin."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "List derived surfaces and the live read pin",
+        "tags": [
+          "Projections"
+        ]
+      }
+    },
+    "/v1/projections/{name}/rebuild": {
+      "post": {
+        "description": "The public verb over the maintenance batch engine. v1 rebuilds `facts` (the session-window deriver): derives into the given version (a paid, operator-invoked batch), optionally flips the live read pin (`activate`). Rewriting the pinned world needs `force`. 404 until PROJECTIONS_API_ENABLED=1.\n\nRequired scope: `brain:admin`.",
+        "operationId": "rebuildProjection",
+        "parameters": [
+          {
+            "description": "The projection name (v1: `facts`).",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RebuildProjectionRequest"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RebuildProjectionResponse"
+                }
+              }
+            },
+            "description": "The batch result."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Rebuild a derived surface (public verb)",
+        "tags": [
+          "Projections"
+        ]
+      }
+    },
+    "/v1/registry/packs": {
+      "get": {
+        "description": "Lists published packs (latest installable version each). The catalogue is shared across all tenants; any authenticated key may browse. Source: src/registry/registry.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "listRegistryPacks",
+        "parameters": [
+          {
+            "description": "Substring match on pack id / description.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by publisher id.",
+            "in": "query",
+            "name": "publisher",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by keyword tag.",
+            "in": "query",
+            "name": "tag",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page offset.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryListResponse"
+                }
+              }
+            },
+            "description": "The catalogue page."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "Browse the global Domain Pack catalogue",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/v1/registry/packs/{packId}": {
+      "get": {
+        "description": "All published versions of a pack, newest first, including yanked ones (flagged).\n\nRequired scope: `brain:read`.",
+        "operationId": "getRegistryPackVersions",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryVersionsResponse"
+                }
+              }
+            },
+            "description": "Version history (empty list when the pack is unknown)."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "One pack's published version history",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/v1/registry/packs/{packId}/{version}": {
+      "get": {
+        "description": "Returns the full manifest body for install/inspection. `latest` is an alias for the latest non-yanked version.\n\nRequired scope: `brain:read`.",
+        "operationId": "getRegistryPackManifest",
+        "parameters": [
+          {
+            "description": "The pack id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A published version, or `latest`.",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryManifestResponse"
+                }
+              }
+            },
+            "description": "The resolved manifest."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Resolve one version to its full manifest",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/v1/registry/publishers/{publisher}": {
+      "get": {
+        "description": "The publisher profile (when one was written — see PUT /v1/admin/registry/publishers/{publisher}) plus the publisher's catalogue entries. 404 only when the publisher is entirely unknown (no profile AND no packs). Source: src/registry/registry.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "getRegistryPublisher",
+        "parameters": [
+          {
+            "description": "The publisher id (trust-store key id).",
+            "in": "path",
+            "name": "publisher",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublisherResponse"
+                }
+              }
+            },
+            "description": "The publisher page."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "A publisher's public page as JSON",
+        "tags": [
+          "Registry"
+        ]
+      }
+    },
+    "/v1/sources": {
+      "get": {
+        "description": "Catalogue of everything brain knows ABOUT its fact sources: the operator-declared identity (type, authLevel) joined with the learned agreement rates, one row per sourceKey. Public projection — operator annotations (owner/note) are served only on the brain:admin surface. `domain` additionally captures that domain's learned rate into `domainTrust` and makes `minSamples` judge it (falling back to the global row). Source: src/sources/public-sources.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "listSources",
+        "parameters": [
+          {
+            "description": "Capture this domain’s learned rate per source (`domainTrust`).",
+            "in": "query",
+            "name": "domain",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only sources declared with this type.",
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "human",
+                "website",
+                "document",
+                "api",
+                "agent",
+                "sensor",
+                "system"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only sources whose learned rate rests on at least this many samples (domain-scoped row when `domain` is given, global row otherwise).",
+            "in": "query",
+            "name": "minSamples",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page size (default 50, max 200).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page offset.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSourcesListResponse"
+                }
+              }
+            },
+            "description": "The reputation catalogue page."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "List source reputations (trust inputs)",
+        "tags": [
+          "Sources"
+        ]
+      }
+    },
+    "/v1/sources/{sourceKey}": {
+      "get": {
+        "description": "Declared type/authLevel, every learned scope (global first, then domains alphabetically), and the reputation-over-time trail (newest first, capped at 50 rows). Public projection — owner/note are excluded. Same data the `get_source_reputation` MCP tool serves.\n\nRequired scope: `brain:read`.",
+        "operationId": "getSourceReputation",
+        "parameters": [
+          {
+            "description": "Source key, `vertical:recorder` (e.g. `rent:tenant_bot`).",
+            "in": "path",
+            "name": "sourceKey",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSourceDetailResponse"
+                }
+              }
+            },
+            "description": "The source reputation detail."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "One source’s declared identity, trust scopes, and history",
+        "tags": [
+          "Sources"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "servers": [
+    {
+      "description": "Hosted instance (placeholder — self-hosted deployments serve the same paths on their own origin).",
+      "url": "https://brain.inite.ai"
+    }
+  ],
+  "tags": [
+    {
+      "description": "Discovery reads over the global Domain Pack registry (shared across all tenants).",
+      "name": "Registry"
+    },
+    {
+      "description": "Publisher-facing writes to the global registry (scope `registry:publish`).",
+      "name": "Registry publishing"
+    },
+    {
+      "description": "Featured curation (scope `registry:curate`), pack pricing + publisher profiles (scope `registry:publish`) and the paid-pack checkout (scope `brain:admin`). State is instance-local — never part of the signed manifest, never mirrored.",
+      "name": "Marketplace"
+    },
+    {
+      "description": "Tenant-level pack management: install, list, eval, uninstall (scope `brain:admin`).",
+      "name": "Domain Packs"
+    },
+    {
+      "description": "The document pipeline: Source → Indexer → Candidates → Brain. Dark behind DOCUMENT_INGEST_ENABLED (default off).",
+      "name": "Documents"
+    },
+    {
+      "description": "The external-indexer protocol (scope `indexer:write`): poll → claim → read content → submit candidates / fail. See docs/indexer-protocol.md.",
+      "name": "Indexer work"
+    },
+    {
+      "description": "Read-only trust inputs (scope `brain:read`): declared source identity ⋈ learned reputation. Public projection — operator annotations (owner/note) stay on the admin surface.",
+      "name": "Sources"
+    },
+    {
+      "description": "The raw-substrate driver: verbatim pre-extraction dialogue turns (L0) as a contract — keyset reads, NDJSON export, and signed new-episode webhooks — so any consumer can build its own projection without touching our database. Flags: EPISODES_API_ENABLED / EPISODE_SUBSCRIPTIONS_ENABLED (off → 404).",
+      "name": "Episodes"
+    },
+    {
+      "description": "Derived surfaces as first-class records: lifecycle status, watermark, builder identity, and rebuild as the public verb. Flag: PROJECTIONS_API_ENABLED (off → 404).",
+      "name": "Projections"
+    }
+  ],
+  "webhooks": {
+    "episodesAvailable": {
+      "post": {
+        "description": "Brain POSTs this to every registered subscription endpoint when fresh episodes land. Metadata only — never episode text. Signed `X-Brain-Signature: sha256=<hex hmac>` over the raw JSON body with the per-subscription secret. Delivery is at-least-once (dedupe on episode ids); the watermark advances only after a 2xx.",
+        "operationId": "episodesAvailableWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EpisodesAvailableEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Acknowledged; the watermark advances."
+          }
+        },
+        "summary": "New-episode push (outbound webhook)",
+        "tags": [
+          "Episodes"
+        ]
+      }
+    }
+  }
+}

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -1390,16 +1390,43 @@ export function buildOpenApiDocument(): Json {
   return sortKeysDeep(document) as Json;
 }
 
+/**
+ * Where the document is written.
+ *
+ * Two copies, because brain.inite.ai/openapi.json is a URL three things
+ * already promise — the landing's footer on every page, its llms.txt, and
+ * .well-known/agent-actions as the API description — and none of them ever
+ * resolved. The reason was routing, not authorship: deploy-brain.yml claimed
+ * `Path(/openapi.json)` for the backend at priority 200, and the backend has
+ * no route for it, no Swagger module, and no copy of this file in its image
+ * (its Dockerfile ships src, dist and package.json). The request reached the
+ * one container that could not answer it.
+ *
+ * The document is a committed static artifact, so the path now falls through
+ * to the landing's catch-all and is served from its public/ next to
+ * /install.sh and /skills.tar.gz. It has to be a second write rather than a
+ * reference: the landing's Docker build copies only from inside
+ * brain-landing/, so a route reaching up to ../../docs would work locally and
+ * 404 in production.
+ *
+ * The copies cannot drift: one run of this script produces both, and
+ * test/openapi-doc.unit-spec.ts asserts both against a fresh build.
+ */
+const OUT_PATHS = [
+  join(__dirname, '..', 'docs', 'openapi.json'),
+  join(__dirname, '..', 'brain-landing', 'public', 'openapi.json'),
+];
+
 function main(): void {
-  const outPath = join(__dirname, '..', 'docs', 'openapi.json');
   const document = buildOpenApiDocument();
-  writeFileSync(outPath, JSON.stringify(document, null, 2) + '\n', 'utf8');
+  const body = JSON.stringify(document, null, 2) + '\n';
+  for (const outPath of OUT_PATHS) writeFileSync(outPath, body, 'utf8');
   const paths = Object.keys(document.paths as Json).length;
   const schemas = Object.keys(
     (document.components as Json).schemas as Json,
   ).length;
   process.stdout.write(
-    `wrote docs/openapi.json (${paths} paths, ${schemas} schemas)\n`,
+    `wrote ${OUT_PATHS.length} copies (${paths} paths, ${schemas} schemas)\n`,
   );
 }
 

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -70,6 +70,24 @@ describe('docs/openapi.json', () => {
     expect(committed).toEqual(built);
   });
 
+  // The landing serves a second copy at brain.inite.ai/openapi.json — the URL
+  // its own footer, llms.txt and .well-known/agent-actions have always pointed
+  // at, and which 404'd because deploy-brain.yml routed the path to this
+  // service, which has no route for it. It has to be a copy rather than a
+  // reference: brain-landing's Docker build copies only from inside
+  // brain-landing/, so a route reaching up to ../../docs would work locally
+  // and fail in production. Something then has to notice when the two stop
+  // agreeing, and this is that something.
+  it('is published byte-identically to brain-landing/public', () => {
+    const published = readFileSync(
+      join(__dirname, '..', 'brain-landing', 'public', 'openapi.json'),
+      'utf8',
+    );
+    expect(published).toBe(
+      readFileSync(join(__dirname, '..', 'docs', 'openapi.json'), 'utf8'),
+    );
+  });
+
   it.each(PLATFORM_OPERATIONS)(
     'documents %s %s with operationId and responses',
     (path, method) => {


### PR DESCRIPTION
Search Console's 2026-08 crawl reported six not-founds on brain.inite.ai. Four came from `.well-known/agent-actions`, one from a Traefik rule, one from a footer href — all shipping for months.

### `/openapi.json` was routed to a container that cannot serve it

`deploy-brain.yml` claimed `Path(/openapi.json)` for the backend at `priority=200`. The backend has no route for it, no Swagger module, and its image does not carry `docs/openapi.json` — the Dockerfile ships `src`, `dist` and `package.json`. Meanwhile the landing's footer, its `llms.txt` and `.well-known/agent-actions` all advertise the URL.

Dropped from the backend rule so it falls through to the landing's catch-all. `build-openapi.ts` now writes a second copy into `brain-landing/public` beside `/install.sh` and `/skills.tar.gz`, and the drift gate asserts the two copies byte-for-byte.

### `/v1` and `/mcp` were crawlable

`agent-actions` publishes the full endpoint list by design. Those endpoints are POST-only and key-gated; a crawler only issues GET, so each URL is a permanent 404 to anything that walks it. Google walked them — `/v1/search`, `/v1/dreams/run`, `/v1/facts/:id/retract`, `/v1/entities/:id/forget`, the last two with the literal `:id` still in the path. Disallowed now; the manifest itself stays crawlable.

### `/docs/search` has never existed

The page is `/docs/api/search`. The footer's link table moves out of the component so a test can walk it against the same `DOCS_PAGES` registry the router and the sitemap read.

### The probe that should have caught this could not

```bash
echo "[ok] $(curl -fsI .../openapi.json | head -1)"
```

`curl -fsI` writes nothing on failure, so a 404 rendered as `[ok] ` with an empty tail. Green on every deploy. Now prints real status codes.

## Verification

- openapi drift gate: 42 tests, including the new byte-identical assertion
- brain-landing: `tsc` clean, 30 tests, build clean
- New footer-links test verified against the bug: reverting the href fails it with `/en/docs/search: no page behind`
- Both workflow YAMLs parse

## Rollout order

**Backend must deploy before the landing copy is reachable** — until its Traefik label is replaced it still holds the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByHjKcPgwCBVhF6DQXcS7Y