### PR TITLE
feat(facts): fact read + provenance API behind FACTS_API_ENABLED

### DIFF
--- a/docs/fact-provenance-api.md
+++ b/docs/fact-provenance-api.md
@@ -1,0 +1,111 @@
+# Fact read + provenance API
+
+"Show me why I remember this." Two read endpoints over `knowledge_fact`:
+the fact as stored, and the verbatim conversation turns it was derived
+from. Both are gated by `FACTS_API_ENABLED` (default off → the routes
+answer 404, indistinguishable from absent routes). The existing
+`POST /v1/facts/:id/retract` is deliberately **not** gated by this flag —
+it is a write/GDPR path and must always work.
+
+## Positioning
+
+The market has learned to distrust silent fact-mining: memories extracted
+behind the user's back, served with no way to ask "where did this come
+from?" (Cursor removed auto-extracted memories over exactly this).
+This platform keeps episode-level provenance for every derived fact —
+`source.episodeIds` points at the verbatim L0 turns the extraction was
+grounded in — and this API turns that stamp into a contract. Every
+remembered statement can be traced to the exact dated, attributed
+utterances behind it, and every retraction stays visible as a retraction.
+Provenance-first memory is the trust counter-position to silent
+fact-mining: not "trust the model", but "check the transcript".
+
+## Endpoints
+
+### `GET /v1/facts/:id`
+
+Scope: `brain:read`. Policy action: `get_fact`.
+
+`:id` accepts both the short id (`f1`) and the full record id
+(`knowledge_fact:f1`).
+
+```json
+{
+  "factId": "knowledge_fact:f1",
+  "aspect": "preference",
+  "statement": "likes hiking in the mountains",
+  "confidence": 0.92,
+  "validFrom": "2026-08-01T00:00:00.000Z",
+  "userId": "u2",
+  "kind": "fact",
+  "vertical": "dialogue",
+  "recorder": "session-deriver-v1",
+  "conversationId": "conv-1",
+  "retracted": false,
+  "derivedVersion": "wd-v3s"
+}
+```
+
+- `aspect` / `statement` are the stored `predicate` / `object`.
+- `kind`, `vertical`, `recorder`, `conversationId` come from the fact's
+  `source` stamp and are present only when stamped.
+- `userId` is the per-user memory scope (migration 0055); absent =
+  tenant-global.
+- Retracted facts still resolve, with `retracted: true` — what was
+  un-remembered and why it disappeared is part of the trust story.
+
+### `GET /v1/facts/:id/provenance`
+
+Scope: `brain:read`. Policy action: `get_fact_provenance`.
+
+Serves the grounding turns listed in the fact's `source.episodeIds`,
+fetched through the shared episode read port (one PII fence + user gate
+implementation), chronological, with each turn's text capped at 600
+characters:
+
+```json
+{
+  "factId": "knowledge_fact:f1",
+  "episodes": [
+    {
+      "episodeId": "episode:e1",
+      "conversationId": "conv-1",
+      "speaker": "Caroline",
+      "occurredAt": "2026-07-01T10:00:00.000Z",
+      "text": "I love hiking, we should plan a trip!"
+    }
+  ]
+}
+```
+
+A fact with no grounding stamp (e.g. directly recorded via the write
+API) serves an empty `episodes` list.
+
+## Auth semantics
+
+Every visibility miss is a **404, never a 403** — a 403 would confirm
+the row exists.
+
+| Fence | Behavior |
+| --- | --- |
+| Flag | `FACTS_API_ENABLED` off (default) → 404 on both GET routes. Runtime-mutable. |
+| Tenant | The read runs inside the caller's per-tenant database (same fence as retract); a foreign tenant's fact id is simply not found. |
+| User scope (0055) | A user-bound access token reads tenant-global facts and its **own** user-scoped facts; another user's fact → 404. M2M credentials read all. |
+| Row policy | The registry-backed row-policy seam shared with the fact retrieval lanes: an operator scope-fenced predicate (`requiresScope`, e.g. `brain:read_pii`) is absent to callers without the scope; ABAC row verdicts apply when a policy context is attached. |
+| PII (episodes) | Episode text is served through the L0 read port's PII fence: without `brain:read_pii`, PII-classed turns are omitted from `episodes`. There is no fact-level PII boolean on `knowledge_fact` — fact-level PII is a predicate policy, enforced by the row-policy fence above. |
+| Episode user gate | The episode fetch reuses `byIds`' fail-closed user gate, keyed to the fact's own `userId` when the fact is user-scoped (the caller already passed the fact-level gate), else to the caller's pinned user scope. |
+
+## Example
+
+```bash
+export BRAIN_KEY=sk_...
+curl -s -H "Authorization: Bearer $BRAIN_KEY" \
+  https://brain.example.com/v1/facts/f1 | jq .
+
+curl -s -H "Authorization: Bearer $BRAIN_KEY" \
+  https://brain.example.com/v1/facts/f1/provenance | jq .
+```
+
+Typical agent flow: a retrieval surface cites `factId`s → the consumer
+renders "why do you remember this?" → one provenance call returns the
+dated, attributed transcript lines to show the user.

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1331,6 +1331,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
           'Raw-substrate driver v1 (docs/roadmap/raw-substrate-driver-2026-08.md): public read API over the L0 episode substrate — GET /v1/episodes (keyset cursor over occurredAt+id, filters conversationId/speaker/since/until) and GET /v1/episodes/export (NDJSON stream, paged internally). Lets any consumer build its own projection without touching SurrealDB. PII fence follows the read-lane precedent: without brain:read_pii only rows with empty piiClass are visible. Off (default) → routes answer 404.',
       },
       {
+        key: 'FACTS_API_ENABLED',
+        category: 'pipeline',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Fact read + provenance API ("show me why I remember this"): GET /v1/facts/:id serves the fact as stored (aspect/statement/confidence/validFrom, source attribution, retracted flag, derivedVersion) and GET /v1/facts/:id/provenance serves its verbatim grounding turns (source.episodeIds via the shared episode read port, text capped at 600 chars). Every miss is a 404 — tenant fence, fail-closed user scope (another user\'s fact is indistinguishable from absent), registry-backed row policy on scope-fenced predicates; episode text respects brain:read_pii. POST /v1/facts/:id/retract is deliberately NOT gated by this flag (write/GDPR path). Off (default) → read routes answer 404.',
+      },
+      {
         key: 'PROJECTIONS_API_ENABLED',
         category: 'pipeline',
         defaultValue: '0',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -490,6 +490,9 @@ const KNOWN_BOOLEAN_FLAGS = [
   'SYNTHESIZE_INSTRUCTION_LANE',
   // Raw-substrate driver v1: public episodes read API + NDJSON export.
   'EPISODES_API_ENABLED',
+  // Fact read + provenance API: GET /v1/facts/:id and /:id/provenance
+  // (grounding episodes). The retract write path stays ungated (GDPR).
+  'FACTS_API_ENABLED',
   // Raw-substrate driver v1 surface 3: projections registry API + rebuild verb.
   'PROJECTIONS_API_ENABLED',
   // Raw-substrate driver v1 surface 4: new-episode webhook push (watermark

--- a/src/facts/facts.controller.ts
+++ b/src/facts/facts.controller.ts
@@ -1,6 +1,16 @@
-import { Body, Controller, Param, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import { PolicyAction } from '../policy/action-registry';
+import { envFlagEnabled } from '../common/env-validation';
 import { FactsService } from './facts.service';
 import { RetractFactDto } from './dto/retract.dto';
 import { AuthenticatedRequest } from '../auth/api-key.types';
@@ -9,6 +19,45 @@ import { AuthenticatedRequest } from '../auth/api-key.types';
 @UseGuards(ApiKeyGuard)
 export class FactsController {
   constructor(private readonly facts: FactsService) {}
+
+  /**
+   * Read-surface gate (FACTS_API_ENABLED, default off → 404 —
+   * indistinguishable from an absent route; same pattern as
+   * EPISODES_API_ENABLED). Applies ONLY to the GET routes: retract is a
+   * write/GDPR path and stays flag-independent — a tenant must always be
+   * able to remove a fact, whether or not the read API is switched on.
+   */
+  private assertEnabled(): void {
+    if (!envFlagEnabled(process.env.FACTS_API_ENABLED)) {
+      throw new NotFoundException();
+    }
+  }
+
+  /** The fact itself — "what do you remember, and where is it from". */
+  @Get(':id')
+  @RequireScopes('brain:read')
+  @PolicyAction('get_fact')
+  async get(@Req() req: AuthenticatedRequest, @Param('id') id: string) {
+    this.assertEnabled();
+    return this.facts.getFact({
+      companyId: req.brainAuth.companyId,
+      factId: id,
+      scopes: req.brainAuth.scopes,
+    });
+  }
+
+  /** Grounding episodes — "show me why I remember this". */
+  @Get(':id/provenance')
+  @RequireScopes('brain:read')
+  @PolicyAction('get_fact_provenance')
+  async provenance(@Req() req: AuthenticatedRequest, @Param('id') id: string) {
+    this.assertEnabled();
+    return this.facts.getProvenance({
+      companyId: req.brainAuth.companyId,
+      factId: id,
+      scopes: req.brainAuth.scopes,
+    });
+  }
 
   // Default scope is brain:write; FactsService elevates to brain:admin
   // for billing_event / human_declared / source.kind='legal' facts —

--- a/src/facts/facts.module.ts
+++ b/src/facts/facts.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
+import { EpisodesModule } from '../episodes/episodes.module';
 import { FactsController } from './facts.controller';
 import { FactsService } from './facts.service';
 
 @Module({
+  // EpisodesModule supplies the L0 read port (EpisodeReadStoreService)
+  // the provenance surface fetches grounding turns through — one PII
+  // fence + user gate implementation, shared with the synthesize lanes.
+  imports: [EpisodesModule],
   controllers: [FactsController],
   providers: [FactsService],
   exports: [FactsService],

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -3,8 +3,10 @@ import { Surreal } from 'surrealdb';
 import { SurrealService, dbMerge } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
+import { EpisodeReadStoreService } from '../episodes/episode-read-store.service';
 import { RetractFactDto } from './dto/retract.dto';
 import { BrainScope } from '../auth/api-key.types';
+import { pinUserScope } from '../auth/user-scope';
 import {
   makeRowPolicyFilter,
   type PolicyFilterableRow,
@@ -79,6 +81,69 @@ export interface RetractOptions {
   callerScopes?: ReadonlyArray<BrainScope>;
 }
 
+/**
+ * Per-episode text budget of the provenance surface. Mirrors the
+ * assistant-lane practice (ASSISTANT_LINE_CHAR_CAP in
+ * synthesize/episode-lane.service.ts): a turn can be up to 16K chars at
+ * ingest, and provenance is a grounding view, not a transcript export —
+ * 600 chars keeps the evidential sentence(s) intact without letting one
+ * verbose turn dominate the response.
+ */
+const PROVENANCE_TEXT_CHAR_CAP = 600;
+
+/** Wire shape of GET /v1/facts/:id. */
+export interface FactReadResult {
+  factId: string;
+  /** The fact's predicate — what the memory is ABOUT. */
+  aspect: string;
+  /** The fact's object — what is remembered. */
+  statement: string;
+  confidence: number;
+  validFrom: string;
+  /** Per-user scope key (migration 0055); absent = tenant-global. */
+  userId?: string;
+  /** source.kind when the deriver stamped one (typed atoms). */
+  kind?: string;
+  vertical?: string;
+  recorder?: string;
+  conversationId?: string;
+  retracted: boolean;
+  derivedVersion?: string;
+}
+
+export interface FactProvenanceEpisode {
+  episodeId: string;
+  conversationId?: string;
+  speaker?: string;
+  occurredAt: string;
+  /** Verbatim turn text, capped at PROVENANCE_TEXT_CHAR_CAP chars. */
+  text: string;
+}
+
+/** Wire shape of GET /v1/facts/:id/provenance. */
+export interface FactProvenanceResult {
+  factId: string;
+  /** Grounding turns (source.episodeIds), chronological. */
+  episodes: FactProvenanceEpisode[];
+}
+
+interface FactReadOptions {
+  companyId: string;
+  factId: string;
+  scopes: readonly BrainScope[];
+}
+
+/** Row shape loadVisibleFact selects (superset of PolicyFilterableRow). */
+interface FactReadRow extends PolicyFilterableRow {
+  id: unknown;
+  object?: unknown;
+  confidence?: unknown;
+  validFrom?: unknown;
+  retractedAt?: unknown;
+  status?: unknown;
+  derivedVersion?: unknown;
+}
+
 export interface ListCompetingResult {
   entityId: string;
   asOf?: string;
@@ -94,12 +159,174 @@ export interface ListCompetingResult {
 export class FactsService {
   private readonly logger = new Logger(FactsService.name);
 
+  // eslint-disable-next-line max-params -- Nest DI constructor; each param is an injection token and cannot be folded into an options object without breaking DI
   constructor(
     private readonly surreal: SurrealService,
+    private readonly episodes: EpisodeReadStoreService,
     @Optional() private readonly metrics?: MetricsService,
     @Optional()
     private readonly predicateRegistry?: PredicateRegistryService,
   ) {}
+
+  /**
+   * GET /v1/facts/:id — the fact as stored, with its source attribution.
+   * Retracted facts still resolve (retracted: true) — "why did I stop
+   * remembering this" is part of the trust story; only visibility fences
+   * turn into 404s.
+   *
+   * Fences (each a 404, never a 403 — a 403 would confirm existence):
+   *  - tenant: withScopedCompany pins the per-tenant database, same as
+   *    retract — a foreign tenant's fact id simply is not present here;
+   *  - user scope (0055): via pinUserScope — a user-bound token reads
+   *    tenant-global facts and its OWN user-scoped facts; M2M reads all;
+   *  - row policy: the registry-backed scope fence + ABAC verdict shared
+   *    with the fact lanes (makeRowPolicyFilter) — an operator
+   *    scope-fenced predicate is absent to callers without the scope.
+   */
+  async getFact(opts: FactReadOptions): Promise<FactReadResult> {
+    return this.surreal.withScopedCompany(
+      opts.companyId,
+      opts.scopes,
+      async (db) => {
+        const fact = await this.loadVisibleFact(db, opts);
+        const source = (fact.source ?? {}) as Record<string, unknown>;
+        const str = (v: unknown): string | undefined =>
+          typeof v === 'string' && v.length > 0 ? v : undefined;
+        const optional = <K extends string>(
+          key: K,
+          value: string | undefined,
+        ): Partial<Record<K, string>> =>
+          value !== undefined ? ({ [key]: value } as Record<K, string>) : {};
+        return {
+          factId: String(fact.id),
+          aspect: fact.predicate,
+          statement: String(fact.object ?? ''),
+          confidence: typeof fact.confidence === 'number' ? fact.confidence : 0,
+          validFrom: toIso(fact.validFrom),
+          ...optional('userId', str(fact.userId)),
+          ...optional('kind', str(source.kind)),
+          ...optional('vertical', str(source.vertical)),
+          ...optional('recorder', str(source.recorder)),
+          ...optional('conversationId', str(source.conversationId)),
+          retracted: Boolean(fact.retractedAt) || fact.status === 'retracted',
+          ...optional('derivedVersion', str(fact.derivedVersion)),
+        };
+      },
+    );
+  }
+
+  /**
+   * GET /v1/facts/:id/provenance — the verbatim turns this fact was
+   * derived from ("show me why I remember this"). Episode ids come from
+   * the fact's own grounding stamp (source.episodeIds — the same stamp
+   * the synthesize lanes read); the rows come from the shared episode
+   * read port, so the PII fence and the fail-closed user gate have ONE
+   * implementation.
+   *
+   * Episode user scope: a user-scoped fact's grounding turns carry that
+   * user's scope — the caller already passed the fact-level gate, so the
+   * fetch is keyed to the FACT's user; a tenant-global fact falls back
+   * to the caller's own pinned scope (M2M → tenant-global turns only).
+   */
+  async getProvenance(opts: FactReadOptions): Promise<FactProvenanceResult> {
+    return this.surreal.withScopedCompany(
+      opts.companyId,
+      opts.scopes,
+      async (db) => {
+        const fact = await this.loadVisibleFact(db, opts);
+        const source = (fact.source ?? {}) as { episodeIds?: unknown };
+        const ids = Array.isArray(source.episodeIds)
+          ? [
+              ...new Set(
+                source.episodeIds
+                  .map(String)
+                  .filter((e) => e.startsWith('episode:')),
+              ),
+            ]
+          : [];
+        if (ids.length === 0) return { factId: String(fact.id), episodes: [] };
+        const rows = await this.episodes.byIds({
+          companyId: opts.companyId,
+          ids,
+          includePii: opts.scopes.includes('brain:read_pii'),
+          userId:
+            typeof fact.userId === 'string' && fact.userId.length > 0
+              ? fact.userId
+              : pinUserScope(undefined),
+          db,
+        });
+        const episodes = rows
+          .slice()
+          .sort(
+            (a, b) =>
+              new Date(toIso(a.occurredAt)).getTime() -
+              new Date(toIso(b.occurredAt)).getTime(),
+          )
+          .map(
+            (r): FactProvenanceEpisode => ({
+              episodeId: String(r.id),
+              ...(r.conversationId !== undefined
+                ? { conversationId: r.conversationId }
+                : {}),
+              ...(r.speaker !== undefined ? { speaker: r.speaker } : {}),
+              occurredAt: toIso(r.occurredAt),
+              text:
+                r.text.length > PROVENANCE_TEXT_CHAR_CAP
+                  ? `${r.text.slice(0, PROVENANCE_TEXT_CHAR_CAP - 1)}…`
+                  : r.text,
+            }),
+          );
+        return { factId: String(fact.id), episodes };
+      },
+    );
+  }
+
+  /**
+   * Fetch one fact row and apply every read fence (user scope + row
+   * policy). Shared by getFact and getProvenance so the two endpoints
+   * can never disagree on what "visible" means. Throws NotFound on any
+   * miss — the caller cannot distinguish "absent" from "fenced".
+   */
+  private async loadVisibleFact(
+    db: Surreal,
+    opts: FactReadOptions,
+  ): Promise<FactReadRow> {
+    const ref = this.normalizeFactId(opts.factId);
+    const [rows] = await db.query<[FactReadRow[]]>(
+      `SELECT id, predicate, object, confidence, validFrom, validUntil,
+              recordedAt, retractedAt, status, source, userId,
+              derivedVersion, trustSnapshot, corroboration
+         FROM type::record('knowledge_fact', $rid) LIMIT 1`,
+      { rid: ref.id },
+    );
+    const notFound = () =>
+      new NotFoundException(`Fact ${opts.factId} not found`);
+    const fact = rows?.[0];
+    if (!fact) throw notFound();
+    // User scope (0055): 404, not 403 — don't leak existence.
+    const scopeUserId = pinUserScope(undefined);
+    if (
+      scopeUserId !== undefined &&
+      typeof fact.userId === 'string' &&
+      fact.userId.length > 0 &&
+      fact.userId !== scopeUserId
+    ) {
+      throw notFound();
+    }
+    // Registry-backed row policy (scope fence + ABAC) — same seam as the
+    // audit-fixed fact lanes under src/synthesize/.
+    const rowPolicy = makeRowPolicyFilter({
+      callerScopes: opts.scopes,
+      surface: 'fact_read',
+      policyLookup: await this.predicateRegistry?.rowPolicyLookup(
+        opts.companyId,
+      ),
+    });
+    const visible = rowPolicy.filter(fact);
+    rowPolicy.finish();
+    if (!visible) throw notFound();
+    return fact;
+  }
 
   async retract({
     companyId,

--- a/src/policy/action-registry.ts
+++ b/src/policy/action-registry.ts
@@ -42,6 +42,15 @@ export const ACTIONS: Record<string, ActionSpec> = {
     title: 'Entity name autocomplete',
   },
   get_competing_facts: { kind: 'read', family: 'mcp_read', title: 'Competing facts' },
+  // Fact read + provenance API (trust surface). Tool-shaped names, not
+  // rest.* — a future get_fact MCP tool reuses the same action, the
+  // convention REST search / entity reads already follow.
+  get_fact: { kind: 'read', family: 'mcp_read', title: 'Get fact' },
+  get_fact_provenance: {
+    kind: 'read',
+    family: 'mcp_read',
+    title: 'Fact provenance (grounding episodes)',
+  },
   summarize_entity: { kind: 'read', family: 'mcp_read', title: 'Summarize entity' },
   detect_contradiction: { kind: 'read', family: 'mcp_read', title: 'Detect contradiction' },
   why: { kind: 'read', family: 'mcp_read', title: 'Code-memory why' },

--- a/test/fact-provenance.unit-spec.ts
+++ b/test/fact-provenance.unit-spec.ts
@@ -1,0 +1,469 @@
+import { NotFoundException } from '@nestjs/common';
+import { FactsController } from '../src/facts/facts.controller';
+import { FactsService } from '../src/facts/facts.service';
+import { EpisodeReadStoreService } from '../src/episodes/episode-read-store.service';
+import { runWithRequestContext } from '../src/common/request-context';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { PredicateRegistryService } from '../src/ai/predicate-registry.service';
+import type { AuthenticatedRequest, BrainScope } from '../src/auth/api-key.types';
+import type { RetractFactDto } from '../src/facts/dto/retract.dto';
+
+/**
+ * Fact read + provenance API ("show me why I remember this").
+ *
+ * The stub keeps per-tenant row sets and answers the two SQL shapes the
+ * surface issues — the fact fetch (type::record) and the episode byIds
+ * read. Episode PII/user fences are applied the way the REAL
+ * EpisodeReadStoreService SQL would (the stub inspects the gate strings
+ * the service composed), so these tests pin both the fact-level fences
+ * (in FactsService) and the parameters handed to the shared episode
+ * read port.
+ */
+
+interface Recorded {
+  sql: string;
+  params?: Record<string, unknown>;
+}
+
+type Row = Record<string, unknown>;
+
+const ridOf = (id: unknown): string =>
+  String((id as { rid?: unknown })?.rid ?? id);
+
+function makeStack(opts: {
+  factsByCompany: Record<string, Row[]>;
+  episodesByCompany?: Record<string, Row[]>;
+  policy?: Record<string, { requiresScope?: string; piiClass: string }>;
+}): { svc: FactsService; queries: Recorded[] } {
+  const queries: Recorded[] = [];
+  const dbFor = (companyId: string) => ({
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      queries.push({ sql, params });
+      if (sql.includes("type::record('knowledge_fact'")) {
+        const rows = (opts.factsByCompany[companyId] ?? []).filter(
+          (f) => String(f.id) === `knowledge_fact:${String(params?.rid)}`,
+        );
+        return [rows];
+      }
+      if (sql.includes('FROM episode')) {
+        const wanted = ((params?.ids as unknown[]) ?? []).map(ridOf);
+        let rows = (opts.episodesByCompany?.[companyId] ?? []).filter((e) =>
+          wanted.includes(String(e.id)),
+        );
+        if (sql.includes('piiClass IS NONE')) {
+          rows = rows.filter((e) => e.piiClass === undefined);
+        }
+        if (sql.includes('userId = $scopeUserId')) {
+          rows = rows.filter(
+            (e) => e.userId === undefined || e.userId === params?.scopeUserId,
+          );
+        } else {
+          rows = rows.filter((e) => e.userId === undefined);
+        }
+        return [rows];
+      }
+      return [[]];
+    },
+  });
+  const surreal = {
+    withScopedCompany: async (
+      companyId: string,
+      _scopes: readonly string[],
+      fn: (db: unknown) => Promise<unknown>,
+    ) => fn(dbFor(companyId)),
+    withCompany: async (
+      companyId: string,
+      fn: (db: unknown) => Promise<unknown>,
+    ) => fn(dbFor(companyId)),
+  } as unknown as SurrealService;
+  const episodes = new EpisodeReadStoreService(surreal);
+  const registry = opts.policy
+    ? ({
+        rowPolicyLookup:
+          async () => (p: string) =>
+            opts.policy?.[p] ?? { piiClass: 'none' },
+      } as unknown as PredicateRegistryService)
+    : undefined;
+  return {
+    svc: new FactsService(surreal, episodes, undefined, registry),
+    queries,
+  };
+}
+
+const READ = ['brain:read'] as BrainScope[];
+const READ_PII = ['brain:read', 'brain:read_pii'] as BrainScope[];
+
+const LONG_TEXT = 'On the trip we talked about routes for hours. '.repeat(20); // ~920 chars
+
+const FACT_GLOBAL: Row = {
+  id: 'knowledge_fact:f1',
+  predicate: 'preference',
+  object: 'likes hiking in the mountains',
+  confidence: 0.92,
+  validFrom: '2026-08-01T00:00:00.000Z',
+  status: 'active',
+  derivedVersion: 'wd-v3s',
+  source: {
+    kind: 'fact',
+    vertical: 'dialogue',
+    recorder: 'session-deriver-v1',
+    conversationId: 'conv-1',
+    episodeIds: ['episode:e2', 'episode:e1'],
+  },
+};
+
+const EPISODES: Row[] = [
+  {
+    id: 'episode:e1',
+    conversationId: 'conv-1',
+    speaker: 'Caroline',
+    text: 'I love hiking, we should plan a trip!',
+    occurredAt: '2026-07-01T10:00:00.000Z',
+  },
+  {
+    id: 'episode:e2',
+    conversationId: 'conv-1',
+    speaker: 'Melanie',
+    text: LONG_TEXT,
+    occurredAt: '2026-07-02T10:00:00.000Z',
+  },
+];
+
+describe('GET /v1/facts/:id — fact read', () => {
+  it('happy path: serves the fact with its source attribution', async () => {
+    const { svc } = makeStack({ factsByCompany: { co_a: [FACT_GLOBAL] } });
+    const res = await svc.getFact({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    expect(res).toEqual({
+      factId: 'knowledge_fact:f1',
+      aspect: 'preference',
+      statement: 'likes hiking in the mountains',
+      confidence: 0.92,
+      validFrom: '2026-08-01T00:00:00.000Z',
+      kind: 'fact',
+      vertical: 'dialogue',
+      recorder: 'session-deriver-v1',
+      conversationId: 'conv-1',
+      retracted: false,
+      derivedVersion: 'wd-v3s',
+    });
+  });
+
+  it('a retracted fact still resolves, flagged retracted: true', async () => {
+    const { svc } = makeStack({
+      factsByCompany: {
+        co_a: [
+          {
+            ...FACT_GLOBAL,
+            status: 'retracted',
+            retractedAt: '2026-08-10T00:00:00.000Z',
+          },
+        ],
+      },
+    });
+    const res = await svc.getFact({
+      companyId: 'co_a',
+      factId: 'knowledge_fact:f1',
+      scopes: READ,
+    });
+    expect(res.retracted).toBe(true);
+  });
+
+  it('missing fact → 404', async () => {
+    const { svc } = makeStack({ factsByCompany: { co_a: [FACT_GLOBAL] } });
+    await expect(
+      svc.getFact({ companyId: 'co_a', factId: 'nope', scopes: READ }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it("another tenant's fact id → 404 (tenant fence)", async () => {
+    const { svc } = makeStack({ factsByCompany: { co_a: [FACT_GLOBAL] } });
+    await expect(
+      svc.getFact({ companyId: 'co_b', factId: 'f1', scopes: READ }),
+    ).rejects.toThrow(NotFoundException);
+  });
+});
+
+describe('user scope (0055) on the fact read', () => {
+  const USER_FACT: Row = { ...FACT_GLOBAL, userId: 'u2' };
+
+  it("user-bound token: another user's fact → 404, not 403", async () => {
+    const { svc } = makeStack({ factsByCompany: { co_a: [USER_FACT] } });
+    await runWithRequestContext(
+      { correlationId: 'test', authUserId: 'u1' },
+      async () => {
+        await expect(
+          svc.getFact({ companyId: 'co_a', factId: 'f1', scopes: READ }),
+        ).rejects.toThrow(NotFoundException);
+        await expect(
+          svc.getProvenance({ companyId: 'co_a', factId: 'f1', scopes: READ }),
+        ).rejects.toThrow(NotFoundException);
+      },
+    );
+  });
+
+  it('user-bound token: OWN user-scoped fact and tenant-global facts resolve', async () => {
+    const { svc } = makeStack({
+      factsByCompany: {
+        co_a: [USER_FACT, { ...FACT_GLOBAL, id: 'knowledge_fact:f2' }],
+      },
+    });
+    await runWithRequestContext(
+      { correlationId: 'test', authUserId: 'u2' },
+      async () => {
+        const own = await svc.getFact({
+          companyId: 'co_a',
+          factId: 'f1',
+          scopes: READ,
+        });
+        expect(own.userId).toBe('u2');
+        const global = await svc.getFact({
+          companyId: 'co_a',
+          factId: 'f2',
+          scopes: READ,
+        });
+        expect(global.userId).toBeUndefined();
+      },
+    );
+  });
+
+  it("M2M (no user-bound token) reads a user-scoped fact, and the episode fetch is keyed to the FACT's user", async () => {
+    const { svc, queries } = makeStack({
+      factsByCompany: { co_a: [USER_FACT] },
+      episodesByCompany: {
+        co_a: [
+          { ...EPISODES[0], userId: 'u2' },
+          { ...EPISODES[1], userId: 'u2' },
+        ],
+      },
+    });
+    const fact = await svc.getFact({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    expect(fact.userId).toBe('u2');
+    const prov = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    expect(prov.episodes.map((e) => e.episodeId)).toEqual([
+      'episode:e1',
+      'episode:e2',
+    ]);
+    const episodeQuery = queries.find((q) => q.sql.includes('FROM episode'));
+    expect(episodeQuery?.sql).toContain(
+      '(userId IS NONE OR userId = $scopeUserId)',
+    );
+    expect(episodeQuery?.params?.scopeUserId).toBe('u2');
+  });
+});
+
+describe('GET /v1/facts/:id/provenance — grounding episodes', () => {
+  it('happy path: chronological grounding turns, text capped at 600 chars', async () => {
+    const { svc } = makeStack({
+      factsByCompany: { co_a: [FACT_GLOBAL] },
+      episodesByCompany: { co_a: EPISODES },
+    });
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    expect(res.factId).toBe('knowledge_fact:f1');
+    // source.episodeIds order is [e2, e1]; the response is chronological.
+    expect(res.episodes.map((e) => e.episodeId)).toEqual([
+      'episode:e1',
+      'episode:e2',
+    ]);
+    expect(res.episodes[0]).toEqual({
+      episodeId: 'episode:e1',
+      conversationId: 'conv-1',
+      speaker: 'Caroline',
+      occurredAt: '2026-07-01T10:00:00.000Z',
+      text: 'I love hiking, we should plan a trip!',
+    });
+    expect(res.episodes[1].text.length).toBe(600);
+    expect(res.episodes[1].text.endsWith('…')).toBe(true);
+  });
+
+  it('a fact with no grounding stamp serves an empty episode list', async () => {
+    const { svc } = makeStack({
+      factsByCompany: {
+        co_a: [{ ...FACT_GLOBAL, source: { vertical: 'dialogue' } }],
+      },
+    });
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    expect(res.episodes).toEqual([]);
+  });
+
+  it('PII-classed turns are fenced out without brain:read_pii, served with it', async () => {
+    const piiEpisode: Row = {
+      id: 'episode:e3',
+      conversationId: 'conv-1',
+      speaker: 'Caroline',
+      text: 'My phone number is 555-0100, call me about the trip.',
+      occurredAt: '2026-07-03T10:00:00.000Z',
+      piiClass: ['contact'],
+    };
+    const fact: Row = {
+      ...FACT_GLOBAL,
+      source: {
+        ...(FACT_GLOBAL.source as Row),
+        episodeIds: ['episode:e1', 'episode:e3'],
+      },
+    };
+    const stack = makeStack({
+      factsByCompany: { co_a: [fact] },
+      episodesByCompany: { co_a: [...EPISODES, piiEpisode] },
+    });
+    const without = await stack.svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    expect(without.episodes.map((e) => e.episodeId)).toEqual(['episode:e1']);
+    const episodeQuery = stack.queries.find((q) =>
+      q.sql.includes('FROM episode'),
+    );
+    expect(episodeQuery?.sql).toContain('piiClass IS NONE');
+
+    const withScope = await makeStack({
+      factsByCompany: { co_a: [fact] },
+      episodesByCompany: { co_a: [...EPISODES, piiEpisode] },
+    }).svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ_PII,
+    });
+    expect(withScope.episodes.map((e) => e.episodeId)).toEqual([
+      'episode:e1',
+      'episode:e3',
+    ]);
+  });
+});
+
+describe('registry-backed row policy (scope-fenced predicates)', () => {
+  const FENCED_FACT: Row = {
+    ...FACT_GLOBAL,
+    predicate: 'health_status',
+  };
+  const policy = {
+    health_status: { requiresScope: 'brain:read_pii', piiClass: 'health' },
+  };
+
+  it('a scope-fenced predicate is a 404 to callers without the scope', async () => {
+    const { svc } = makeStack({
+      factsByCompany: { co_a: [FENCED_FACT] },
+      policy,
+    });
+    await expect(
+      svc.getFact({ companyId: 'co_a', factId: 'f1', scopes: READ }),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      svc.getProvenance({ companyId: 'co_a', factId: 'f1', scopes: READ }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('the same fact resolves for a caller holding the scope', async () => {
+    const { svc } = makeStack({
+      factsByCompany: { co_a: [FENCED_FACT] },
+      episodesByCompany: { co_a: EPISODES },
+      policy,
+    });
+    const res = await svc.getFact({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ_PII,
+    });
+    expect(res.aspect).toBe('health_status');
+  });
+});
+
+describe('FACTS_API_ENABLED gate (controller)', () => {
+  const saved = process.env.FACTS_API_ENABLED;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.FACTS_API_ENABLED;
+    else process.env.FACTS_API_ENABLED = saved;
+  });
+
+  function makeController(): {
+    ctl: FactsController;
+    facts: {
+      getFact: jest.Mock;
+      getProvenance: jest.Mock;
+      retract: jest.Mock;
+    };
+    req: AuthenticatedRequest;
+  } {
+    const facts = {
+      getFact: jest.fn(async () => ({ factId: 'knowledge_fact:f1' })),
+      getProvenance: jest.fn(async () => ({
+        factId: 'knowledge_fact:f1',
+        episodes: [],
+      })),
+      retract: jest.fn(async () => ({
+        factId: 'knowledge_fact:f1',
+        retractedAt: '2026-08-21T00:00:00.000Z',
+        cascadedFactIds: [],
+        revivedFactIds: [],
+      })),
+    };
+    return {
+      ctl: new FactsController(facts as unknown as FactsService),
+      facts,
+      req: {
+        brainAuth: {
+          companyId: 'co_a',
+          scopes: ['brain:read', 'brain:write'],
+        },
+      } as unknown as AuthenticatedRequest,
+    };
+  }
+
+  it('flag off (default): both GET routes 404 before touching the service', async () => {
+    delete process.env.FACTS_API_ENABLED;
+    const { ctl, facts, req } = makeController();
+    await expect(ctl.get(req, 'f1')).rejects.toThrow(NotFoundException);
+    await expect(ctl.provenance(req, 'f1')).rejects.toThrow(NotFoundException);
+    expect(facts.getFact).not.toHaveBeenCalled();
+    expect(facts.getProvenance).not.toHaveBeenCalled();
+  });
+
+  it('flag off: retract stays available (write/GDPR path is flag-independent)', async () => {
+    delete process.env.FACTS_API_ENABLED;
+    const { ctl, facts, req } = makeController();
+    const dto = {
+      reason: 'user request',
+      retractedBy: { source: 'human' },
+    } as RetractFactDto;
+    const res = await ctl.retract(req, 'f1', dto);
+    expect(facts.retract).toHaveBeenCalledTimes(1);
+    expect(res.factId).toBe('knowledge_fact:f1');
+  });
+
+  it('flag on: GET routes reach the service with the request auth', async () => {
+    process.env.FACTS_API_ENABLED = '1';
+    const { ctl, facts, req } = makeController();
+    await ctl.get(req, 'f1');
+    await ctl.provenance(req, 'f1');
+    expect(facts.getFact).toHaveBeenCalledWith({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: ['brain:read', 'brain:write'],
+    });
+    expect(facts.getProvenance).toHaveBeenCalledWith({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: ['brain:read', 'brain:write'],
+    });
+  });
+});


### PR DESCRIPTION
## What

Two read endpoints on the facts controller — the "show me why I remember this" surface. Default-off behind `FACTS_API_ENABLED` (404 when off); the existing `POST /v1/facts/:id/retract` stays flag-independent (GDPR path).

- **`GET /v1/facts/:id`** — the fact itself: `{ factId, aspect, statement, confidence, validFrom, userId?, kind?, vertical?, recorder?, conversationId?, retracted, derivedVersion? }`. Retracted facts resolve with `retracted: true`; only visibility fences 404.
- **`GET /v1/facts/:id/provenance`** — grounding episodes from `source.episodeIds`: `{ factId, episodes: [{ episodeId, conversationId?, speaker?, occurredAt, text }] }`, chronological, text capped at 600 chars.

## Security semantics (all misses 404 — existence never leaks)

- Tenant fence via `withScopedCompany` (same as retract).
- `pinUserScope`: user-bound token sees tenant-global + own user-scoped facts; another user's fact → 404; M2M reads all. Episode fetch keyed to the fact's own user scope.
- Row policy: `makeRowPolicyFilter` with the registry-backed lookup — operator scope-fenced predicates 404 for callers without the scope.
- PII episode text only with `brain:read_pii` (reuses `EpisodeReadStoreService.byIds` includePii).

## Notes

- No fact-level PII boolean exists on `knowledge_fact` (verified against migrations 0005/0055) — fact-level PII is predicate policy, enforced by the row-policy gate; documented in `docs/fact-provenance-api.md`.
- New policy actions `get_fact` / `get_fact_provenance` registered as read actions.
- Flag-budget goldens untouched (FACTS_ prefix is outside the engine regex); config-catalog + env-validation entries added.

## Gates

tsc clean, eslint clean, new spec 15/15, flag-budget + config-catalog-truth 9/9, adjacent policy/abac/env sweep 101/101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB