### PR TITLE
feat(users): rolling user profile API behind USER_PROFILE_API_ENABLED

### DIFF
--- a/docs/user-profile-api.md
+++ b/docs/user-profile-api.md
@@ -1,0 +1,100 @@
+# User Profile API (rolling user profile, v1)
+
+`GET /v1/users/:userId/profile` — a deterministic, query-time assembly of
+what the platform knows about one end-user, shaped for direct prompt
+injection by consumers (paste `profileText` into a system prompt as-is).
+
+Deterministic v1 — no narrative synthesis yet: the profile is a grouped,
+capped, stably-ordered projection of the stored fact rows; no LLM call
+happens anywhere on this path, and the same memory state always renders
+the same profile. The intended v2 folds these facts into a rolling
+LLM-written narrative that is updated incrementally as new facts land,
+instead of being re-derived from scratch per request.
+
+## Enabling
+
+Gated by `USER_PROFILE_API_ENABLED` (default off). While off, the routes
+answer 404 — indistinguishable from an absent route. Read per-request, so
+a flip needs no restart.
+
+## Auth semantics
+
+- Guard: API key / bearer token, scope `brain:read`, ABAC action
+  `get_user_profile` (read kind).
+- User-scope pin (migration 0055 semantics): an M2M credential may fetch
+  any user's profile; a user-bound token (auth-service token with
+  `org` + `sub`) may fetch only its own — a mismatching `:userId` is 403.
+- Visibility is the fact-lane read contract: tenant-global rows plus the
+  named user's personal rows (`userId IS NONE OR userId = $user`), the
+  pinned derived world unioned with the legacy namespace
+  (`derivedVersion IS NONE OR <read-pin fence>`), lifecycle-closed rows
+  excluded (retracted / superseded / compacted / corroborating /
+  competing), and the registry-backed row policy applied — predicates
+  fenced with `requiresScope: brain:read_pii` appear only for callers
+  holding that scope.
+
+## Request
+
+| Param | In | Meaning |
+| --- | --- | --- |
+| `userId` | path | End-user scope key (pinned as above). |
+| `maxFacts` | query | Global fact budget. Default 60, hard cap 200. |
+| `lang` | query | Locale filter: keeps facts with this `lang` or none. |
+
+## Response
+
+```json
+{
+  "userId": "did:key:z6MkUser",
+  "generatedAt": "2026-08-21T10:00:00.000Z",
+  "factCount": 3,
+  "sections": [
+    {
+      "aspect": "identity",
+      "facts": [
+        {
+          "factId": "knowledge_fact:f001",
+          "statement": "Alex is a vegetarian",
+          "validFrom": "2026-01-15T00:00:00.000Z",
+          "confidence": 0.9,
+          "kind": "persona_attr"
+        }
+      ]
+    },
+    {
+      "aspect": "work",
+      "facts": [
+        {
+          "factId": "knowledge_fact:f002",
+          "statement": "Alex works at Acme",
+          "validFrom": "2026-02-03T12:00:00.000Z",
+          "confidence": 0.85,
+          "lastSeenAt": "2026-07-01T00:00:00.000Z"
+        },
+        {
+          "factId": "knowledge_fact:f003",
+          "statement": "Alex leads the search team",
+          "validFrom": "2026-01-20T00:00:00.000Z",
+          "confidence": 0.8
+        }
+      ]
+    }
+  ],
+  "profileText": "- [identity] Alex is a vegetarian (as of 2026-01-15)\n- [work] Alex works at Acme (as of 2026-02-03)\n- [work] Alex leads the search team (as of 2026-01-20)"
+}
+```
+
+## Assembly rules (all deterministic)
+
+- Facts group by predicate — an aspect slug (`identity`, `work`, …) in
+  derived worlds, a vocabulary predicate for ingested facts.
+- `statement` is the fact object verbatim; `kind` surfaces `source.kind`
+  when the typed deriver stamped one; `lastSeenAt` surfaces
+  `corroboration.lastAt` (last independent corroboration) when any.
+- Within a section: `validFrom` DESC, ties by `factId` ASC.
+- Section order: sections containing a `persona_attr` atom first, then
+  fact count DESC, then aspect ASC.
+- Caps: 5 facts per aspect, then the global `maxFacts` budget applied
+  walking sections in their final order.
+- `profileText` is one line per fact in exactly the response order:
+  `- [aspect] statement (as of YYYY-MM-DD)`.

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1349,6 +1349,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
           'Raw-substrate driver v1, surface 4 (migration 0077): new-episode webhook push for external projection builders. POST/GET/DELETE /v1/episodes/subscriptions registers HTTPS endpoints (per-subscription HMAC secret returned once); a per-minute dispatcher polls each tenant watermark over recordedAt (deliberately NOT changefeed-driven — 0073 keeps the episode table feed-free for GDPR) and POSTs metadata-only batches (ids/attribution/timestamps, never text) signed X-Brain-Signature: sha256=<hmac>. At-least-once delivery, CAS watermark advance, circuit breaker, auto-deactivate at 100 consecutive failures. Enable on ONE role (worker) in prod. Off (default) → routes 404, dispatcher inert.',
       },
       {
+        key: 'USER_PROFILE_API_ENABLED',
+        category: 'pipeline',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          "Rolling user profile v1 (docs/user-profile-api.md): GET /v1/users/:userId/profile — a deterministic query-time assembly of the active facts visible in one end-user's scope (ingested user-stamped facts + the pinned derived world's typed atoms), grouped by predicate/aspect, persona_attr-first, capped per aspect and globally, rendered as prompt-injectable profileText. No LLM calls. User-bound tokens read only their own profile (403 on mismatch); PII-fenced predicates require brain:read_pii. Off (default) → routes answer 404.",
+      },
+      {
         key: 'SYNTHESIZE_INSTRUCTION_LANE',
         category: 'pipeline',
         defaultValue: '0',

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -34,6 +34,7 @@ import { RegistryModule } from './registry/registry.module';
 import { SourcesModule } from './sources/sources.module';
 import { DocumentsModule } from './documents/documents.module';
 import { FeedbackModule } from './feedback/feedback.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -107,6 +108,7 @@ import { FeedbackModule } from './feedback/feedback.module';
     SourcesModule,
     DocumentsModule,
     EpisodesModule,
+    UsersModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -495,6 +495,10 @@ const KNOWN_BOOLEAN_FLAGS = [
   // Raw-substrate driver v1 surface 4: new-episode webhook push (watermark
   // poll over recordedAt, metadata-only payloads, HMAC-signed).
   'EPISODE_SUBSCRIPTIONS_ENABLED',
+  // Rolling user profile v1: GET /v1/users/:userId/profile —
+  // deterministic per-user profile assembly for prompt injection.
+  // Default off → routes 404.
+  'USER_PROFILE_API_ENABLED',
   // E3b object normalization: the extractor proposes a minimal clean value
   // alongside the verbatim span; the server admits it only when every word
   // appears in the grounded span. Default off pending a paid confirm leg.

--- a/src/policy/action-registry.ts
+++ b/src/policy/action-registry.ts
@@ -106,6 +106,10 @@ export const ACTIONS: Record<string, ActionSpec> = {
   'rest.episodes.subscriptions': { kind: 'read', family: 'rest', title: 'List episode webhooks' },
   'rest.episodes.unsubscribe': { kind: 'admin', family: 'rest', title: 'Delete an episode webhook' },
   'rest.registry.checkout': { kind: 'write', family: 'rest', title: 'Create pack checkout session' },
+  // Rolling user profile v1 (USER_PROFILE_API_ENABLED). MCP-tool-style
+  // name (the get_entity_profile precedent) so a future MCP surface
+  // shares the action; REST-only today.
+  get_user_profile: { kind: 'read', family: 'rest', title: 'Get user profile' },
 };
 
 /**

--- a/src/users/dto/user-profile.dto.ts
+++ b/src/users/dto/user-profile.dto.ts
@@ -1,0 +1,44 @@
+/**
+ * Wire contract of GET /v1/users/:userId/profile (rolling user profile
+ * v1 — deterministic query-time assembly, no LLM calls). Consumers
+ * paste `profileText` straight into prompts; `sections` is the same
+ * content structured for programmatic use.
+ */
+
+/** Per-aspect fact cap — a profile line-item budget, not a recall knob. */
+export const PER_ASPECT_CAP = 5;
+/** Default global fact budget when the caller omits ?maxFacts=. */
+export const DEFAULT_MAX_FACTS = 60;
+/** Hard ceiling on ?maxFacts= — beyond this a profile stops being one. */
+export const HARD_MAX_FACTS = 200;
+
+export interface ProfileFactWire {
+  factId: string;
+  /** The fact's object verbatim — deterministic v1 renders, never rewrites. */
+  statement: string;
+  /** ISO instant the fact became valid (bitemporal validity axis). */
+  validFrom: string;
+  confidence: number;
+  /** Last independent corroboration (`corroboration.lastAt`), when any. */
+  lastSeenAt?: string;
+  /** Typed-atom kind (`source.kind`, DERIVER_TYPED_ATOMS), when stamped. */
+  kind?: string;
+}
+
+export interface ProfileSectionWire {
+  /** The grouping key: the fact predicate — an aspect slug in derived
+   *  worlds (identity, work, …), a vocabulary predicate for ingested
+   *  facts (lives_in, …). */
+  aspect: string;
+  facts: ProfileFactWire[];
+}
+
+export interface UserProfileWire {
+  userId: string;
+  generatedAt: string;
+  /** Facts included after the per-aspect and global caps. */
+  factCount: number;
+  sections: ProfileSectionWire[];
+  /** One line per fact: `- [aspect] statement (as of YYYY-MM-DD)`. */
+  profileText: string;
+}

--- a/src/users/user-profile.controller.ts
+++ b/src/users/user-profile.controller.ts
@@ -1,0 +1,70 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
+import { AuthenticatedRequest } from '../auth/api-key.types';
+import { envFlagEnabled } from '../common/env-validation';
+import { pinUserScope } from '../auth/user-scope';
+import { UserProfileService } from './user-profile.service';
+import {
+  DEFAULT_MAX_FACTS,
+  HARD_MAX_FACTS,
+  type UserProfileWire,
+} from './dto/user-profile.dto';
+
+/**
+ * Rolling user profile v1: GET /v1/users/:userId/profile — a
+ * deterministic, prompt-injectable projection of one end-user's
+ * memory. Gated by USER_PROFILE_API_ENABLED (default off → 404,
+ * indistinguishable from an absent route — the episodes-API precedent).
+ *
+ * Auth follows the user-scope pin (0055): an M2M credential may fetch
+ * any user's profile; a user-bound token only its own (mismatch → 403).
+ */
+@Controller('v1/users')
+@UseGuards(ApiKeyGuard)
+export class UserProfileController {
+  constructor(private readonly profiles: UserProfileService) {}
+
+  private assertEnabled(): void {
+    if (!envFlagEnabled(process.env.USER_PROFILE_API_ENABLED)) {
+      throw new NotFoundException();
+    }
+  }
+
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Param/@Query binding, cannot be folded into an options object without breaking Nest param resolution
+  @Get(':userId/profile')
+  @RequireScopes('brain:read')
+  @PolicyAction('get_user_profile')
+  async getProfile(
+    @Req() req: AuthenticatedRequest,
+    @Param('userId') userId: string,
+    @Query('maxFacts') maxFacts?: string,
+    @Query('lang') lang?: string,
+  ): Promise<UserProfileWire> {
+    this.assertEnabled();
+    // A user-bound token may read only its own profile — the pin
+    // throws 403 when the path names another user. M2M reads any.
+    const pinned = pinUserScope(userId) ?? userId;
+    const parsed =
+      maxFacts !== undefined ? parseInt(maxFacts, 10) : DEFAULT_MAX_FACTS;
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      throw new BadRequestException(`maxFacts must be 1..${HARD_MAX_FACTS}`);
+    }
+    return this.profiles.getProfile({
+      companyId: req.brainAuth.companyId,
+      userId: pinned,
+      callerScopes: req.brainAuth.scopes,
+      maxFacts: Math.min(parsed, HARD_MAX_FACTS),
+      lang: lang?.trim() || undefined,
+    });
+  }
+}

--- a/src/users/user-profile.service.ts
+++ b/src/users/user-profile.service.ts
@@ -1,0 +1,250 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import {
+  ReadPinService,
+  derivedVersionFence,
+} from '../episodes/read-pin.service';
+import {
+  makeRowPolicyFilter,
+  type PolicyFilterableRow,
+} from '../policy/row-filter';
+import { PredicateRegistryService } from '../ai/predicate-registry.service';
+import {
+  PER_ASPECT_CAP,
+  type ProfileFactWire,
+  type ProfileSectionWire,
+  type UserProfileWire,
+} from './dto/user-profile.dto';
+
+/**
+ * Rolling user profile v1 (USER_PROFILE_API_ENABLED): a deterministic
+ * query-time assembly of what the platform knows about one end-user,
+ * shaped for direct prompt injection. No LLM calls anywhere — the
+ * profile is a grouped, capped, stably-ordered projection of the
+ * active fact rows visible in that user's scope.
+ *
+ * Same read contracts as the fact lanes:
+ *  - user scope fail-closed idiom of the search where-builder (0055):
+ *    tenant-global rows + that user's personal rows, never anyone
+ *    else's. Derived typed atoms are tenant-global (the deriver does
+ *    not stamp userId), so the global half is what carries them.
+ *  - derived-world fence: ingested facts (derivedVersion IS NONE) AND
+ *    the tenant's pinned derived world(s) read together —
+ *    `(derivedVersion IS NONE OR <fence>)`.
+ *  - lifecycle: the where-builder's "actual now" closure (retracted /
+ *    compacted / corroborating out; superseded admitted only across a
+ *    future-dated supersede gap; validity interval must contain now).
+ *    'competing' is additionally excluded — a profile asserts current
+ *    truth, not both sides of an unadjudicated duel.
+ *  - predicate scope-fence + ABAC row verdict via makeRowPolicyFilter
+ *    (registry-backed lookup), which is also the PII gate: predicates
+ *    fenced with requiresScope 'brain:read_pii' surface only to
+ *    callers holding that scope.
+ */
+
+/** Overfetch headroom over the caps: the row fence and the per-aspect
+ *  cap both drop rows after the query, so the fetch is sized well past
+ *  the hard response cap (200). */
+const FETCH_CAP = 1000;
+
+/** The one projection every policy-filtered fact read uses, plus the
+ *  profile's own columns (the row filter reads source / trustSnapshot /
+ *  corroboration / userId — audit 2026-08-19 P1). */
+const PROFILE_PROJECTION =
+  'id, predicate, object, confidence, validFrom, validUntil, ' +
+  'source, trustSnapshot, corroboration, userId';
+
+interface ProfileRow extends PolicyFilterableRow {
+  object: string;
+  confidence?: number;
+  validFrom: Date | string;
+}
+
+function toIso(v: Date | string): string {
+  return v instanceof Date ? v.toISOString() : new Date(v).toISOString();
+}
+
+function toWireFact(r: ProfileRow): ProfileFactWire {
+  const source = r.source as { kind?: unknown } | null | undefined;
+  const kind = typeof source?.kind === 'string' ? source.kind : undefined;
+  const lastAt = (r.corroboration as { lastAt?: Date | string } | null)?.lastAt;
+  return {
+    factId: String(r.id),
+    statement: r.object,
+    validFrom: toIso(r.validFrom),
+    confidence: typeof r.confidence === 'number' ? r.confidence : 0,
+    ...(lastAt !== undefined ? { lastSeenAt: toIso(lastAt) } : {}),
+    ...(kind !== undefined ? { kind } : {}),
+  };
+}
+
+/** Deterministic within-section order: validFrom DESC, factId ASC. */
+function compareFacts(a: ProfileFactWire, b: ProfileFactWire): number {
+  if (a.validFrom !== b.validFrom) return a.validFrom < b.validFrom ? 1 : -1;
+  return a.factId < b.factId ? -1 : a.factId > b.factId ? 1 : 0;
+}
+
+interface SectionDraft {
+  aspect: string;
+  /** Any persona_attr typed atom promotes the whole section. */
+  persona: boolean;
+  /** Group size BEFORE the per-aspect cap — the ordering signal. */
+  poolSize: number;
+  facts: ProfileFactWire[];
+}
+
+/** persona_attr-first, then fact count DESC, then aspect ASC — every
+ *  key is a stable sort key, so equal inputs render equal profiles. */
+function compareSections(a: SectionDraft, b: SectionDraft): number {
+  if (a.persona !== b.persona) return a.persona ? -1 : 1;
+  if (a.poolSize !== b.poolSize) return b.poolSize - a.poolSize;
+  return a.aspect < b.aspect ? -1 : a.aspect > b.aspect ? 1 : 0;
+}
+
+/** Group by predicate/aspect, cap per aspect, order sections, then cut
+ *  to the global budget walking sections in their final order. */
+function assembleSections(
+  rows: ProfileRow[],
+  maxFacts: number,
+): ProfileSectionWire[] {
+  const groups = new Map<string, ProfileFactWire[]>();
+  for (const r of rows) {
+    const list = groups.get(r.predicate);
+    if (list) list.push(toWireFact(r));
+    else groups.set(r.predicate, [toWireFact(r)]);
+  }
+  const drafts: SectionDraft[] = [...groups.entries()].map(
+    ([aspect, facts]) => {
+      facts.sort(compareFacts);
+      return {
+        aspect,
+        persona: facts.some((f) => f.kind === 'persona_attr'),
+        poolSize: facts.length,
+        facts: facts.slice(0, PER_ASPECT_CAP),
+      };
+    },
+  );
+  drafts.sort(compareSections);
+
+  const sections: ProfileSectionWire[] = [];
+  let taken = 0;
+  for (const d of drafts) {
+    if (taken >= maxFacts) break;
+    const facts = d.facts.slice(0, maxFacts - taken);
+    taken += facts.length;
+    sections.push({ aspect: d.aspect, facts });
+  }
+  return sections;
+}
+
+/** `- [aspect] statement (as of YYYY-MM-DD)` — one line per fact, in
+ *  the exact section/fact order of the structured response. */
+function renderProfileText(sections: ProfileSectionWire[]): string {
+  const lines: string[] = [];
+  for (const s of sections) {
+    for (const f of s.facts) {
+      lines.push(
+        `- [${s.aspect}] ${f.statement} (as of ${f.validFrom.slice(0, 10)})`,
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+@Injectable()
+export class UserProfileService {
+  private readonly logger = new Logger(UserProfileService.name);
+
+  constructor(
+    private readonly surreal: SurrealService,
+    @Optional() private readonly readPin?: ReadPinService,
+    @Optional()
+    private readonly predicateRegistry?: PredicateRegistryService,
+  ) {}
+
+  async getProfile(opts: {
+    companyId: string;
+    /** Already pinned by the controller (pinUserScope). */
+    userId: string;
+    callerScopes: readonly string[];
+    maxFacts: number;
+    lang?: string;
+  }): Promise<UserProfileWire> {
+    const { companyId, userId, callerScopes, maxFacts, lang } = opts;
+    const derivedVersion =
+      (await this.readPin?.resolveRead(companyId)) ??
+      ReadPinService.bootstrapRead();
+    // The read-pin fence for the derived half, UNIONED with the legacy
+    // namespace: the profile reads ingested user facts AND the pinned
+    // derived world's typed atoms in one pass.
+    const fence = derivedVersionFence(derivedVersion);
+    const worldClause = `(derivedVersion IS NONE OR ${fence.clause.replace(/^AND\s+/, '')})`;
+
+    const clauses = [
+      // User scope (0055) — the search where-builder idiom: global +
+      // this user's rows. Derived typed atoms ride the global half.
+      `(userId IS NONE OR userId = $scopeUserId)`,
+      worldClause,
+      // Lifecycle "actual now" closure — copied from the search
+      // where-builder (incl. the future-dated-supersede gap rule).
+      `retractedAt IS NONE`,
+      `status != 'competing'`,
+      `validFrom <= time::now()`,
+      `(validUntil IS NONE OR validUntil > time::now())`,
+      `status != 'compacted'`,
+      `status != 'corroborating'`,
+      `(status != 'superseded' OR validUntil > time::now())`,
+    ];
+    const params: Record<string, unknown> = {
+      scopeUserId: userId,
+      fetchCap: FETCH_CAP,
+      ...fence.params,
+    };
+    if (lang) {
+      // Locale filter, soft on unstamped rows (the where-builder idiom).
+      clauses.push(`(lang = $langFilter OR lang IS NONE)`);
+      params.langFilter = lang;
+    }
+
+    // Predicate scope-fence (the PII gate) + ABAC row verdict — the
+    // same seam every fact read surface applies.
+    const rowPolicy = makeRowPolicyFilter({
+      callerScopes,
+      surface: 'user_profile',
+      policyLookup: await this.predicateRegistry?.rowPolicyLookup(companyId),
+    });
+
+    const rows = await this.surreal.withScopedCompany(
+      companyId,
+      callerScopes,
+      async (db) => {
+        const [res] = await db.query<[ProfileRow[]]>(
+          `SELECT ${PROFILE_PROJECTION}
+             FROM knowledge_fact
+            WHERE ${clauses.join('\n              AND ')}
+            ORDER BY validFrom DESC, id ASC
+            LIMIT $fetchCap`,
+          params,
+        );
+        return res ?? [];
+      },
+    );
+    const visible = rows.filter((r) => rowPolicy.filter(r));
+    rowPolicy.finish();
+    if (rows.length >= FETCH_CAP) {
+      this.logger.warn(
+        `user profile fetch hit the ${FETCH_CAP}-row cap ` +
+          `(companyId=${companyId}) — oldest facts may be missing`,
+      );
+    }
+
+    const sections = assembleSections(visible, maxFacts);
+    return {
+      userId,
+      generatedAt: new Date().toISOString(),
+      factCount: sections.reduce((n, s) => n + s.facts.length, 0),
+      sections,
+      profileText: renderProfileText(sections),
+    };
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { EpisodesModule } from '../episodes/episodes.module';
+import { UserProfileController } from './user-profile.controller';
+import { UserProfileService } from './user-profile.service';
+
+/**
+ * Per-user surfaces. v1 owns the rolling user profile read
+ * (docs/user-profile-api.md) — a deterministic query-time projection
+ * of one end-user's memory for prompt injection. GDPR user-forget
+ * stays in EntitiesModule next to the entity cascade it reuses.
+ */
+@Module({
+  // EpisodesModule supplies ReadPinService (the per-tenant derived-world
+  // pin the profile's world fence resolves through).
+  imports: [AuthModule, EpisodesModule],
+  controllers: [UserProfileController],
+  providers: [UserProfileService],
+})
+export class UsersModule {}

--- a/test/user-profile.unit-spec.ts
+++ b/test/user-profile.unit-spec.ts
@@ -1,0 +1,418 @@
+/**
+ * Rolling user profile v1 (USER_PROFILE_API_ENABLED) — deterministic
+ * query-time assembly over a stubbed DB:
+ *
+ *  - SQL contract: user-scope idiom, combined derived-world fence,
+ *    lifecycle "actual now" closure (the filtering itself is the DB's
+ *    job — the gate here is that the clauses are present, the
+ *    digest-lane precedent);
+ *  - grouping by predicate/aspect + per-aspect and global caps;
+ *  - persona_attr-first section ordering;
+ *  - PII gating both ways via the predicate scope-fence;
+ *  - controller auth: user-token mismatch 403, M2M passthrough,
+ *    flag-off 404;
+ *  - determinism: same rows in any arrival order → identical output.
+ */
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { UserProfileService } from '../src/users/user-profile.service';
+import { UserProfileController } from '../src/users/user-profile.controller';
+import type { UserProfileWire } from '../src/users/dto/user-profile.dto';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { ReadPinService } from '../src/episodes/read-pin.service';
+import type { PredicateRegistryService } from '../src/ai/predicate-registry.service';
+import type { AuthenticatedRequest } from '../src/auth/api-key.types';
+import { runWithRequestContext } from '../src/common/request-context';
+
+type Row = Record<string, unknown>;
+type Capture = { sql: string; params?: Record<string, unknown> };
+
+function makeService(opts: {
+  rows: Row[];
+  capture?: Capture[];
+  readPin?: string | null;
+  piiPredicates?: string[];
+}): UserProfileService {
+  const surreal = {
+    withScopedCompany: async (
+      _c: string,
+      _scopes: readonly string[],
+      fn: (db: unknown) => Promise<unknown>,
+    ) =>
+      fn({
+        query: async (sql: string, params?: Record<string, unknown>) => {
+          opts.capture?.push({ sql, params });
+          return [opts.rows];
+        },
+      }),
+  } as unknown as SurrealService;
+  const readPin =
+    opts.readPin !== undefined
+      ? ({
+          resolveRead: async () => opts.readPin,
+        } as unknown as ReadPinService)
+      : undefined;
+  const registry = {
+    rowPolicyLookup: async () => (predicate: string) => ({
+      piiClass: opts.piiPredicates?.includes(predicate) ? 'sensitive' : 'none',
+      ...(opts.piiPredicates?.includes(predicate)
+        ? { requiresScope: 'brain:read_pii' }
+        : {}),
+    }),
+  } as unknown as PredicateRegistryService;
+  return new UserProfileService(surreal, readPin, registry);
+}
+
+let seq = 0;
+function row(overrides: Row): Row {
+  seq += 1;
+  return {
+    id: `knowledge_fact:f${String(seq).padStart(3, '0')}`,
+    predicate: 'work',
+    object: `fact ${seq}`,
+    confidence: 0.9,
+    validFrom: new Date('2026-06-01T00:00:00Z'),
+    source: {},
+    userId: 'u1',
+    ...overrides,
+  };
+}
+
+const baseOpts = {
+  companyId: 'c1',
+  userId: 'u1',
+  callerScopes: ['brain:read'] as const,
+  maxFacts: 60,
+};
+
+describe('UserProfileService — SQL contract', () => {
+  beforeEach(() => {
+    seq = 0;
+  });
+
+  it('applies user scope, combined derived fence, and the lifecycle closure', async () => {
+    const capture: Capture[] = [];
+    const svc = makeService({ rows: [], capture, readPin: 'wd-v1' });
+    await svc.getProfile({ ...baseOpts });
+    const { sql, params } = capture[0];
+    // User scope: fail-closed idiom — global + this user's rows.
+    expect(sql).toContain('(userId IS NONE OR userId = $scopeUserId)');
+    expect(params?.scopeUserId).toBe('u1');
+    // Combined world fence: legacy namespace UNION the pinned world.
+    expect(sql).toContain(
+      '(derivedVersion IS NONE OR derivedVersion = $derivedVersion)',
+    );
+    expect(params?.derivedVersion).toBe('wd-v1');
+    // Lifecycle: the where-builder "actual now" closure + no competing.
+    expect(sql).toContain('retractedAt IS NONE');
+    expect(sql).toContain(`status != 'competing'`);
+    expect(sql).toContain(`status != 'compacted'`);
+    expect(sql).toContain(`status != 'corroborating'`);
+    expect(sql).toContain(
+      `(status != 'superseded' OR validUntil > time::now())`,
+    );
+    expect(sql).toContain('validFrom <= time::now()');
+    expect(sql).toContain('(validUntil IS NONE OR validUntil > time::now())');
+    // Deterministic fetch order.
+    expect(sql).toContain('ORDER BY validFrom DESC, id ASC');
+  });
+
+  it('no pin → the legacy namespace collapses to a tautology, not a leak', async () => {
+    const capture: Capture[] = [];
+    const svc = makeService({ rows: [], capture, readPin: null });
+    await svc.getProfile({ ...baseOpts });
+    expect(capture[0].sql).toContain(
+      '(derivedVersion IS NONE OR derivedVersion IS NONE)',
+    );
+  });
+
+  it('lang filter is soft on unstamped rows and only added when asked', async () => {
+    const capture: Capture[] = [];
+    const svc = makeService({ rows: [], capture, readPin: null });
+    await svc.getProfile({ ...baseOpts, lang: 'en' });
+    expect(capture[0].sql).toContain('(lang = $langFilter OR lang IS NONE)');
+    expect(capture[0].params?.langFilter).toBe('en');
+    const capture2: Capture[] = [];
+    const svc2 = makeService({ rows: [], capture: capture2, readPin: null });
+    await svc2.getProfile({ ...baseOpts });
+    expect(capture2[0].sql).not.toContain('langFilter');
+  });
+});
+
+describe('UserProfileService — assembly', () => {
+  beforeEach(() => {
+    seq = 0;
+  });
+
+  it('groups by predicate/aspect and orders facts validFrom DESC', async () => {
+    const svc = makeService({
+      rows: [
+        row({
+          predicate: 'work',
+          object: 'older',
+          validFrom: new Date('2026-01-01T00:00:00Z'),
+        }),
+        row({
+          predicate: 'work',
+          object: 'newer',
+          validFrom: new Date('2026-05-01T00:00:00Z'),
+        }),
+        row({ predicate: 'travel', object: 'trip' }),
+      ],
+      readPin: null,
+    });
+    const res = await svc.getProfile({ ...baseOpts });
+    expect(res.factCount).toBe(3);
+    const work = res.sections.find((s) => s.aspect === 'work');
+    expect(work?.facts.map((f) => f.statement)).toEqual(['newer', 'older']);
+    expect(res.sections.map((s) => s.aspect)).toEqual(['work', 'travel']);
+  });
+
+  it('caps each aspect at 5 and the whole profile at maxFacts', async () => {
+    const rows: Row[] = [];
+    for (let i = 0; i < 7; i++) {
+      rows.push(
+        row({
+          predicate: 'work',
+          validFrom: new Date(`2026-03-0${i + 1}T00:00:00Z`),
+        }),
+      );
+    }
+    for (let i = 0; i < 3; i++) rows.push(row({ predicate: 'travel' }));
+    const svc = makeService({ rows, readPin: null });
+    const capped = await svc.getProfile({ ...baseOpts });
+    expect(
+      capped.sections.find((s) => s.aspect === 'work')?.facts,
+    ).toHaveLength(5);
+    // Newest 5 of the 7 survive the per-aspect cap.
+    expect(
+      capped.sections
+        .find((s) => s.aspect === 'work')
+        ?.facts.map((f) => f.validFrom.slice(0, 10)),
+    ).toEqual([
+      '2026-03-07',
+      '2026-03-06',
+      '2026-03-05',
+      '2026-03-04',
+      '2026-03-03',
+    ]);
+    const svc2 = makeService({ rows, readPin: null });
+    const tight = await svc2.getProfile({ ...baseOpts, maxFacts: 6 });
+    expect(tight.factCount).toBe(6);
+    // Global cut walks sections in order: 5 work + 1 travel.
+    expect(tight.sections.map((s) => s.facts.length)).toEqual([5, 1]);
+  });
+
+  it('orders sections persona_attr-first, then by fact count, then aspect', async () => {
+    const svc = makeService({
+      rows: [
+        row({ predicate: 'work' }),
+        row({ predicate: 'work' }),
+        row({ predicate: 'work' }),
+        row({ predicate: 'travel' }),
+        row({ predicate: 'travel' }),
+        row({ predicate: 'identity', source: { kind: 'persona_attr' } }),
+        row({ predicate: 'events', source: { kind: 'event' } }),
+        row({ predicate: 'activities' }),
+      ],
+      readPin: null,
+    });
+    const res = await svc.getProfile({ ...baseOpts });
+    expect(res.sections.map((s) => s.aspect)).toEqual([
+      'identity', // persona_attr tier first
+      'work', // then count DESC
+      'travel',
+      'activities', // count ties broken by aspect ASC
+      'events',
+    ]);
+    expect(
+      res.sections.find((s) => s.aspect === 'identity')?.facts[0].kind,
+    ).toBe('persona_attr');
+    expect(
+      res.sections.find((s) => s.aspect === 'events')?.facts[0].kind,
+    ).toBe('event');
+    expect(
+      res.sections.find((s) => s.aspect === 'work')?.facts[0].kind,
+    ).toBeUndefined();
+  });
+
+  it('renders profileText one line per fact, sections persona-first', async () => {
+    const svc = makeService({
+      rows: [
+        row({
+          predicate: 'work',
+          object: 'Alex works at Acme',
+          validFrom: new Date('2026-02-03T12:00:00Z'),
+        }),
+        row({
+          predicate: 'identity',
+          object: 'Alex is a vegetarian',
+          validFrom: new Date('2026-01-15T00:00:00Z'),
+          source: { kind: 'persona_attr' },
+        }),
+      ],
+      readPin: null,
+    });
+    const res = await svc.getProfile({ ...baseOpts });
+    expect(res.profileText).toBe(
+      '- [identity] Alex is a vegetarian (as of 2026-01-15)\n' +
+        '- [work] Alex works at Acme (as of 2026-02-03)',
+    );
+  });
+
+  it('surfaces lastSeenAt from corroboration.lastAt when present', async () => {
+    const svc = makeService({
+      rows: [
+        row({
+          corroboration: { count: 2, lastAt: new Date('2026-07-01T00:00:00Z') },
+        }),
+        row({}),
+      ],
+      readPin: null,
+    });
+    const res = await svc.getProfile({ ...baseOpts });
+    const [first, second] = res.sections[0].facts;
+    // Rows share validFrom → factId ASC keeps f001 (corroborated) first.
+    expect(first.lastSeenAt).toBe('2026-07-01T00:00:00.000Z');
+    expect(second.lastSeenAt).toBeUndefined();
+  });
+
+  it('gates PII predicates on brain:read_pii — both ways', async () => {
+    const rows = [
+      row({ predicate: 'health_note', object: 'secret' }),
+      row({ predicate: 'work', object: 'public' }),
+    ];
+    const without = await makeService({
+      rows,
+      readPin: null,
+      piiPredicates: ['health_note'],
+    }).getProfile({ ...baseOpts });
+    expect(without.factCount).toBe(1);
+    expect(without.profileText).not.toContain('secret');
+    const withPii = await makeService({
+      rows,
+      readPin: null,
+      piiPredicates: ['health_note'],
+    }).getProfile({
+      ...baseOpts,
+      callerScopes: ['brain:read', 'brain:read_pii'],
+    });
+    expect(withPii.factCount).toBe(2);
+    expect(withPii.profileText).toContain('secret');
+  });
+
+  it('is deterministic: same rows in any arrival order → identical output', async () => {
+    const rows = [
+      row({ predicate: 'work', object: 'a' }),
+      row({ predicate: 'travel', object: 'b' }),
+      row({
+        predicate: 'identity',
+        object: 'c',
+        source: { kind: 'persona_attr' },
+      }),
+      row({
+        predicate: 'work',
+        object: 'd',
+        validFrom: new Date('2026-07-01T00:00:00Z'),
+      }),
+    ];
+    const strip = (r: UserProfileWire): Omit<UserProfileWire, 'generatedAt'> => {
+      const { generatedAt: _g, ...rest } = r;
+      return rest;
+    };
+    const forward = await makeService({ rows, readPin: null }).getProfile({
+      ...baseOpts,
+    });
+    const reversed = await makeService({
+      rows: [...rows].reverse(),
+      readPin: null,
+    }).getProfile({ ...baseOpts });
+    expect(strip(forward)).toEqual(strip(reversed));
+    expect(JSON.stringify(strip(forward))).toBe(
+      JSON.stringify(strip(reversed)),
+    );
+  });
+});
+
+describe('UserProfileController — flag gate + user-scope pin', () => {
+  const FLAG = 'USER_PROFILE_API_ENABLED';
+  const saved = process.env[FLAG];
+  afterEach(() => {
+    if (saved === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = saved;
+  });
+
+  function makeController(): {
+    controller: UserProfileController;
+    calls: Array<Record<string, unknown>>;
+  } {
+    const calls: Array<Record<string, unknown>> = [];
+    const service = {
+      getProfile: async (opts: Record<string, unknown>) => {
+        calls.push(opts);
+        return {
+          userId: opts.userId,
+          generatedAt: 'now',
+          factCount: 0,
+          sections: [],
+          profileText: '',
+        };
+      },
+    } as unknown as UserProfileService;
+    return { controller: new UserProfileController(service), calls };
+  }
+
+  const req = {
+    brainAuth: { companyId: 'c1', scopes: ['brain:read'] },
+  } as unknown as AuthenticatedRequest;
+
+  it('404s while the flag is off — indistinguishable from an absent route', async () => {
+    delete process.env[FLAG];
+    const { controller } = makeController();
+    await expect(controller.getProfile(req, 'u1')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('M2M credential (no authUserId) reads any user profile', async () => {
+    process.env[FLAG] = '1';
+    const { controller, calls } = makeController();
+    await runWithRequestContext({ correlationId: 't1' }, async () => {
+      await controller.getProfile(req, 'someone-else');
+    });
+    expect(calls[0].userId).toBe('someone-else');
+    expect(calls[0].maxFacts).toBe(60);
+  });
+
+  it('user-bound token: own profile passes, another user 403s', async () => {
+    process.env[FLAG] = '1';
+    const { controller, calls } = makeController();
+    await runWithRequestContext(
+      { correlationId: 't2', authUserId: 'u1' },
+      async () => {
+        await controller.getProfile(req, 'u1');
+        await expect(controller.getProfile(req, 'u2')).rejects.toThrow(
+          ForbiddenException,
+        );
+      },
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].userId).toBe('u1');
+  });
+
+  it('clamps maxFacts to the hard cap and rejects garbage', async () => {
+    process.env[FLAG] = '1';
+    const { controller, calls } = makeController();
+    await controller.getProfile(req, 'u1', '500');
+    expect(calls[0].maxFacts).toBe(200);
+    await expect(controller.getProfile(req, 'u1', '0')).rejects.toThrow(
+      BadRequestException,
+    );
+    await expect(controller.getProfile(req, 'u1', 'abc')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+});


### PR DESCRIPTION
## What

`GET /v1/users/:userId/profile?maxFacts=&lang=` — a deterministic, query-time assembly of what the platform knows about a user, shaped for direct prompt injection by consumers (`profileText`). Zero LLM calls in v1; the intended v2 (LLM-folded rolling narrative) is sketched in `docs/user-profile-api.md`. Default-off behind `USER_PROFILE_API_ENABLED` (404 when off).

Response: `{ userId, generatedAt, factCount, sections: [{ aspect, facts: [{ factId, statement, validFrom, confidence, lastSeenAt?, kind? }] }], profileText }` — sections persona_attr-first, then fact count; facts validFrom DESC; 5-per-aspect cap + global `maxFacts` budget (default 60, hard cap 200); fully deterministic ordering.

## Read path

Single SELECT over `knowledge_fact` with: the where-builder "actual now" lifecycle closure (retracted/superseded/competing excluded — a profile asserts current truth), the user-scope idiom `(userId IS NONE OR userId = $u)` so derived typed atoms (persona_attr rides in `source.kind`) are included, the combined world fence `(derivedVersion IS NONE OR <read-pin fence>)`, and `makeRowPolicyFilter` with the registry-backed lookup — which is also the PII gate (`requiresScope: brain:read_pii` predicates drop without the scope).

## Auth

`brain:read` + new `get_user_profile` read action; `pinUserScope(:userId)` — user-bound token only fetches its own profile (mismatch 403), M2M any.

## Notes

- `lastSeenAt` maps to `corroboration.lastAt` (migration 0047) — the only honest "last independently seen" signal on the row.
- Flag-budget goldens untouched (USER_ prefix outside the engine regex); config-catalog + env-validation entries added.
- OpenAPI/zod contracts not extended in this PR (drift gate green); easy follow-up.

## Gates

tsc clean, eslint clean, new spec 14/14, flag-budget + config-catalog-truth 9/9, adjacent auth/user-scope/contracts sweeps 103 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB