### PR TITLE
feat(retrieval): genre preset layer — measured defaults per RETRIEVAL_GENRE

### DIFF
--- a/docs/roadmap/memory-research-2026-08.md
+++ b/docs/roadmap/memory-research-2026-08.md
@@ -613,3 +613,84 @@ if/when the owner wants it: ONE full-500 shot on a fresh combined
 write-pack derive (typed-atoms + time-pack, new version) vs arm B —
 ~$20-25 — which confirms or kills both construction-side effects at
 n=500 in a single paired measurement instead of per-axis dribbles.
+
+## 11. Genre presets (built 2026-08-21, branch feat/genre-presets)
+
+The measured genre-dependence of the engine is now a PRESET LAYER
+(`src/search/genre-presets.ts`): each `RetrievalGenre` ships tuned
+defaults for the measured levers, and explicit configuration always
+wins. This is the §6 platform posture made concrete — "per-genre
+configuration, not removal; the segment-lane precedent: genre-dependent
+sign, resolved by profile".
+
+### Precedence contract (strict, resolved per field)
+
+```
+per-company overlay field  >  explicit env key  >  genre preset  >  code default
+```
+
+- A preset value applies ONLY where the corresponding env key is unset.
+  An explicitly SET key — including an explicit `0` on a boolean — is
+  the operator's word and beats the preset in both directions
+  (`presetFlag` checks unset before parsing, because `envFlagEnabled`
+  cannot tell unset from `0`).
+- Legacy keys keep their historical explicitness: the per-lane verbatim
+  flags imply `'always'` only when one of them is ENABLED (their falsy
+  state defers to the preset); `SYNTHESIZE_DATE_CONTEXT` set to ANY
+  value — including the measured LoCoMo pin `=0` — is explicit and
+  beats the preset.
+- When a company overlay changes `genre` itself,
+  `resolveRetrievalProfileFor` resolves the overlay genre FIRST,
+  re-derives the preset-backed base for THAT genre, then applies the
+  remaining overlay fields on top.
+- Preset-INELIGIBLE by design: `genre`, `lanes`, numeric caps/budgets,
+  string knobs (`verifierModel`, `assistantLaneMatch`), and the infra
+  execution modes (`coverageScanMode`/`coverageLexMode`/`scanHnsw*` —
+  per-tenant enable rituals, never genre semantics).
+
+### Preset table (evidence-pinned; inclusion needs a measured on-genre positive and no on-genre negative)
+
+| genre | lever | preset | evidence |
+|---|---|---|---|
+| dialogue | `verbatimEvidence` | `'always'` | Genre law, measured twice (`typed-answer-dispatch-2026-07.md` §3): segment lane **+3.8pp LoCoMo** two-human dialogue; `'always'` = the diary-genre profile (the old lane flags ON) |
+| dialogue | `dateAnchoring` | `'none'` | Date context **−7.1pp on LoCoMo** by gold convention (`typed-answer-dispatch-2026-07.md` §3); "LoCoMo-convention eval profiles must pin =0" (`measure-ladder-2026-08-results.md` E2); armK guard: session-date defaults ARE the LoCoMo answer convention (§5 above) |
+| assistant_chat | `sceneTraces` | `true` | Dual-trace scene anchors **+20.2pp LongMemEval-S** (95% CI +12.1..+29.3; temporal +40pp, KU +25pp, MS +30pp) in the controlled pair (§5 B10 + §7). Read-side render only — byte-identical against worlds derived without `DERIVER_SCENE_TRACE` |
+| assistant_chat | `abstentionCalibration` | `'verifier'` | The V9 verdict-decline win: **+17.5pp** on the abstention row, BEAM first-person assistant chats (`v10-audit-2026-08.md`; "our 'verifier' arm at 0.85 is competitive with anything published"). Zero marginal model calls — the verifier already runs in lenient guardrails; `'answer'` guardrails stay exempt |
+| documents | — | *(empty)* | The axis is unmeasured — "we have NO non-conversational eval axis" (§6). Pure code defaults until a documents-genre eval exists |
+
+The segment-lane law is respected in BOTH directions: `'always'` is
+preset for dialogue only; assistant_chat keeps `shape_conditioned`
+(segment lane −28pp LongMemEval / −18.6pp BEAM, `typed-answer-dispatch-2026-07.md` §3).
+
+### Deliberately left out (evidence says no, or not yet)
+
+- **Digest evidence / digest lanes** — the +5.0 strict is BEAM-measured
+  WITH a recorded conflicting negative on the same benchmark
+  (abstention −7.5, summ nugget −1.9 lane bleed, §5 B7); the
+  `summary_ku` gate that should fix the bleed is built but unmeasured
+  (§2 item 0.4). Also inert without `DERIVER_DIGEST` worlds.
+- **Raw window** — measured NEGATIVE on assistant_chat SSA (23.2/32.1
+  vs 42.9 base, §10); facts-as-anchor cannot reach unextracted gold.
+- **Assistant lane / facts-as-keys (multiworld M3/M4)** — program
+  PARKED for statistical honesty (§10: p≈0.06 direction, not a
+  confirmed effect).
+- **V13 read levers** (`timeFilter`, `dateMath`, `answerConditioning`,
+  `noiseFilter`, `searchLoop`) — built default-off with expectations,
+  not measurements (§5 B3-B8); LoCoMo read-side is explicitly "not
+  worth chasing" (§2: six nulls, ±2.2pp floor).
+- **`temporalMode='overlap_boost'`** — measured +1.6 n.s. only; no
+  recorded positive in the pinned docs.
+- **`verifierModel='gpt-5-mini'`** — direction-positive at n=40, the
+  default-on decision explicitly awaits the n≥120 confirm (§2 item 0.2).
+- **`verbatimEvidence='fused'/'routed'` for dialogue** — LoCoMo +1.4pp
+  sits outside the pinned doc set and next to a pooled −5.0pp with only
+  the verbatim-shaped class winning (validate-2026-08 V6 pairs); the
+  dispatch stays an explicit per-tenant choice.
+
+Unit pins: `test/genre-presets.unit-spec.ts` (precedence matrix +
+full-effective-profile snapshot per genre, so any future preset edit is
+a visible diff). Note the default-genre behavior change this ships:
+`assistant_chat` (the boot default) now resolves
+`abstentionCalibration='verifier'` and `sceneTraces=true` unless env
+says otherwise; `RETRIEVAL_ABSTENTION_CALIBRATION=off` restores the
+legacy lenient contract.

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -761,7 +761,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
         runtimeMutable: true,
         isBooleanFlag: false,
         description:
-          'Default-profile genre tag: dialogue | assistant_chat | documents. The genre dimensions the engine actually branches on are RETRIEVAL_VERBATIM_EVIDENCE and RETRIEVAL_DATE_ANCHORING; this names the corpus so per-tenant overrides read as intent.',
+          "Default-profile genre tag: dialogue | assistant_chat | documents. Each genre carries a PRESET of tuned defaults for the measured levers (src/search/genre-presets.ts — e.g. dialogue: verbatim 'always' + date anchoring 'none'; assistant_chat: scene traces + verifier abstention; documents: none — unmeasured axis). A preset value applies only where the corresponding env key is unset: explicit env key > genre preset > code default, and a per-company overlay field (RETRIEVAL_PROFILE_OVERRIDES) beats all three; an overlay that changes genre re-derives that genre's preset-backed base first.",
       },
       {
         key: 'RETRIEVAL_VERBATIM_EVIDENCE',

--- a/src/search/genre-presets.ts
+++ b/src/search/genre-presets.ts
@@ -1,0 +1,109 @@
+import type {
+  RetrievalGenre,
+  RetrievalProfile,
+} from './retrieval-profile';
+
+/**
+ * Genre presets — per-genre tuned defaults for the measured levers.
+ *
+ * Precedence contract (strict, resolved per field):
+ *
+ *   per-company overlay field  >  explicit env key  >  genre preset  >
+ *   code default
+ *
+ * A preset value applies ONLY where the corresponding env key is unset;
+ * an explicitly SET key — including an explicit '0' on a boolean — is
+ * the operator's word and wins over the preset in both directions.
+ * When a company overlay changes `genre` itself, the overlay genre
+ * resolves FIRST: the preset-backed base is re-derived for THAT genre,
+ * then the remaining overlay fields apply on top
+ * (`resolveRetrievalProfileFor`).
+ *
+ * Inclusion rules (owner directive, 2026-08-21) — a lever enters a
+ * genre's preset ONLY if:
+ *   1. the profile field exists in RetrievalProfile today (no new
+ *      dimensions, no new env keys — the flag-budget goldens are
+ *      byte-frozen);
+ *   2. the roadmap docs record a measured POSITIVE for that lever on
+ *      that genre's benchmark family (LoCoMo → dialogue;
+ *      LongMemEval/BEAM assistant chats → assistant_chat);
+ *   3. no conflicting negative is recorded on the same genre.
+ * In doubt → leave the lever out. Each entry carries its doc anchor.
+ *
+ * Deliberately preset-INELIGIBLE fields: `genre` itself and `lanes`
+ * (structural, not tuning), numeric caps/budgets and string knobs
+ * (deployment tuning, not genre semantics), and the infra execution
+ * modes (`coverageScanMode`/`coverageLexMode`/`scanHnsw*` — enable
+ * ritual per tenant, never per genre).
+ *
+ * This module reads NO env keys — it is pure data; resolution threading
+ * lives in retrieval-profile.ts (the one engine file allowed to read
+ * the environment).
+ */
+export type GenrePreset = Partial<
+  Pick<
+    RetrievalProfile,
+    | 'verbatimEvidence'
+    | 'insightEvidence'
+    | 'timelineEvidence'
+    | 'dateAnchoring'
+    | 'temporalMode'
+    | 'abstentionCalibration'
+    | 'digestLanes'
+    | 'segmentRerank'
+    | 'factRerank'
+    | 'mentionDates'
+    | 'sceneTraces'
+    | 'enumStrict'
+    | 'wideProbe'
+    | 'entityExpansion'
+    | 'salienceScoring'
+    | 'updateStoryRendering'
+    | 'orderingFrame'
+    | 'verifierTopicCoverage'
+    | 'digestEvidence'
+    | 'rawWindow'
+    | 'assistantLane'
+    | 'factsAsKeys'
+    | 'timeFilter'
+    | 'dateMath'
+    | 'answerConditioning'
+    | 'noiseFilter'
+    | 'searchLoop'
+  >
+>;
+
+export const GENRE_PRESETS: Record<RetrievalGenre, GenrePreset> = {
+  dialogue: {
+    // Genre law, measured twice (typed-answer-dispatch-2026-07.md §3):
+    // segment lane +3.8pp on LoCoMo two-human dialogue (vs −28pp
+    // LongMemEval / −18.6pp BEAM on assistant chats — never preset
+    // there); 'always' is the diary-genre profile, the old lane flags ON.
+    verbatimEvidence: 'always',
+    // LoCoMo-convention golds: date context measurably hurts —
+    // −7.1pp by gold convention (typed-answer-dispatch-2026-07.md §3);
+    // "LoCoMo-convention eval profiles must pin =0"
+    // (measure-ladder-2026-08-results.md E2); armK guard: session-date
+    // defaults ARE the LoCoMo answer convention
+    // (memory-research-2026-08.md §5).
+    dateAnchoring: 'none',
+  },
+  assistant_chat: {
+    // Dual-trace scene anchors: +20.2pp LongMemEval-S overall
+    // (95% CI +12.1..+29.3; temporal +40pp, KU +25pp, multi-session
+    // +30pp) in the controlled pair (memory-research-2026-08.md §5 B10
+    // + §7). Read-side render only — byte-identical against worlds
+    // derived without the DERIVER_SCENE_TRACE stamp.
+    sceneTraces: true,
+    // The V9 verdict-decline win: +17.5pp on the abstention row, BEAM
+    // first-person assistant chats (v10-audit-2026-08.md, test-pin
+    // registry; "our 'verifier' arm at 0.85 is competitive with
+    // anything published"). Zero marginal model calls — the verifier
+    // already runs in lenient guardrails; 'answer' mode stays exempt.
+    abstentionCalibration: 'verifier',
+  },
+  // The documents axis is unmeasured — "we have NO non-conversational
+  // eval axis" (memory-research-2026-08.md §6). Pure code defaults
+  // until a documents-genre eval exists.
+  documents: {},
+};

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -11,6 +11,7 @@ import {
   resolveExpansionConfig,
   type ExpansionConfig,
 } from './internals/edge-expansion';
+import { GENRE_PRESETS } from './genre-presets';
 
 /**
  * RetrievalProfile — the per-tenant configuration object that replaced
@@ -25,6 +26,12 @@ import {
  * nothing below the resolution point reads process.env for these
  * dimensions. Env keeps one job: the default profile at boot, plus
  * optional per-tenant overrides (RETRIEVAL_PROFILE_OVERRIDES).
+ *
+ * Between the env layer and the code defaults sits the GENRE PRESET
+ * layer (genre-presets.ts): each genre ships tuned defaults for the
+ * measured levers, applied per field only where the corresponding env
+ * key is unset — explicit env key > genre preset > code default, and a
+ * per-company overlay field beats all three.
  */
 
 export type RetrievalGenre = 'dialogue' | 'assistant_chat' | 'documents';
@@ -529,16 +536,74 @@ function enumEnv<T extends string>(
   return (allowed as readonly string[]).includes(v) ? (v as T) : undefined;
 }
 
+const GENRES = ['dialogue', 'assistant_chat', 'documents'] as const;
+
+/** The genre dimension resolved alone — the preset lookup needs it
+ *  before any other field can resolve. */
+function resolveGenre(env: NodeJS.ProcessEnv): RetrievalGenre {
+  return enumEnv(env, 'RETRIEVAL_GENRE', GENRES) ?? 'assistant_chat';
+}
+
+/** Legacy per-lane keys imply 'always' ONLY when one of them is
+ *  enabled; their falsy state is indistinguishable from unset, so it
+ *  defers to the genre preset (the first-class key
+ *  RETRIEVAL_VERBATIM_EVIDENCE is the explicit off switch). */
+function legacyVerbatimMode(
+  env: NodeJS.ProcessEnv,
+): VerbatimEvidenceMode | undefined {
+  return envFlagEnabled(env.SEARCH_EPISODIC_LANE_ENABLED) ||
+    envFlagEnabled(env.SYNTHESIZE_SOURCE_EXCERPTS) ||
+    envFlagEnabled(env.SEARCH_SEGMENT_LANE_ENABLED)
+    ? 'always'
+    : undefined;
+}
+
+/** SYNTHESIZE_DATE_CONTEXT set to ANY value is an explicit operator
+ *  choice (E2 made date context default-on, so an explicit '0' is the
+ *  measured LoCoMo pin and must beat a preset); unset defers to the
+ *  genre preset. */
+function legacyDateAnchoring(
+  env: NodeJS.ProcessEnv,
+): DateAnchoring | undefined {
+  if (env.SYNTHESIZE_DATE_CONTEXT === undefined) return undefined;
+  return envFlagNotDisabled(env.SYNTHESIZE_DATE_CONTEXT) ? 'absolute' : 'none';
+}
+
+/** env ?? preset ?? off for boolean profile fields. envFlagEnabled
+ *  cannot tell unset from an explicit '0', so the unset check comes
+ *  first: a SET key — including an explicit '0' — is the operator's
+ *  word and beats the preset in both directions. */
+function presetFlag(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  preset: boolean | undefined,
+): boolean {
+  if (env[name] === undefined) return preset ?? false;
+  return envFlagEnabled(env[name]);
+}
+
 /**
  * The boot-default profile, from env. The enum dimensions have
  * first-class keys (RETRIEVAL_GENRE / RETRIEVAL_VERBATIM_EVIDENCE /
  * RETRIEVAL_DATE_ANCHORING); when unset they derive from the legacy
  * per-lane keys so existing deployments resolve to the same behavior.
  * This function is the ONLY place those env keys are read.
+ *
+ * Field precedence (genre-presets.ts): explicit env key > genre preset
+ * > code default. The preset partial for the resolved genre fills only
+ * the fields whose env keys are unset.
  */
 export function resolveRetrievalProfile(
   env: NodeJS.ProcessEnv = process.env,
 ): RetrievalProfile {
+  return resolveForGenre(resolveGenre(env), env);
+}
+
+function resolveForGenre(
+  genre: RetrievalGenre,
+  env: NodeJS.ProcessEnv,
+): RetrievalProfile {
+  const preset = GENRE_PRESETS[genre];
   const routerOn = envFlagEnabled(env.SYNTHESIZE_ANSWER_ROUTER_ENABLED);
   const lanes = new Set<LaneId>();
   if (routerOn) {
@@ -550,17 +615,8 @@ export function resolveRetrievalProfile(
       }
     }
   }
-  const legacyVerbatimAlways =
-    envFlagEnabled(env.SEARCH_EPISODIC_LANE_ENABLED) ||
-    envFlagEnabled(env.SYNTHESIZE_SOURCE_EXCERPTS) ||
-    envFlagEnabled(env.SEARCH_SEGMENT_LANE_ENABLED);
   return {
-    genre:
-      enumEnv(env, 'RETRIEVAL_GENRE', [
-        'dialogue',
-        'assistant_chat',
-        'documents',
-      ] as const) ?? 'assistant_chat',
+    genre,
     verbatimEvidence:
       enumEnv(env, 'RETRIEVAL_VERBATIM_EVIDENCE', [
         'off',
@@ -568,19 +624,26 @@ export function resolveRetrievalProfile(
         'always',
         'fused',
         'routed',
-      ] as const) ?? (legacyVerbatimAlways ? 'always' : 'shape_conditioned'),
+      ] as const) ??
+      legacyVerbatimMode(env) ??
+      preset.verbatimEvidence ??
+      'shape_conditioned',
     insightEvidence:
       enumEnv(env, 'RETRIEVAL_INSIGHT_EVIDENCE', [
         'off',
         'routed',
         'query_arc',
-      ] as const) ?? 'off',
+      ] as const) ??
+      preset.insightEvidence ??
+      'off',
     timelineEvidence:
       enumEnv(env, 'RETRIEVAL_TIMELINE_EVIDENCE', [
         'off',
         'routed',
         'scan',
-      ] as const) ?? 'off',
+      ] as const) ??
+      preset.timelineEvidence ??
+      'off',
     coverageScanMode:
       enumEnv(env, 'RETRIEVAL_COVERAGE_SCAN_MODE', [
         'brute',
@@ -599,53 +662,100 @@ export function resolveRetrievalProfile(
         'session_date',
         'absolute',
       ] as const) ??
-      (envFlagNotDisabled(env.SYNTHESIZE_DATE_CONTEXT) ? 'absolute' : 'none'),
+      legacyDateAnchoring(env) ??
+      preset.dateAnchoring ??
+      'absolute',
     temporalMode:
       enumEnv(env, 'RETRIEVAL_TEMPORAL_MODE', [
         'filter',
         'overlap_boost',
-      ] as const) ?? 'filter',
+      ] as const) ??
+      preset.temporalMode ??
+      'filter',
     factBudget: positiveIntEnv(env, 'SEARCH_FACT_CENTRIC_BUDGET', 48),
     quotesPerPrompt: positiveIntEnv(env, 'SEARCH_EPISODIC_LANE_TOPK', 8),
     sourceExcerptsCap: positiveIntEnv(env, 'SYNTHESIZE_SOURCE_EXCERPTS_CAP', 16),
     segmentTopK: positiveIntEnv(env, 'SEARCH_SEGMENT_LANE_TOPK', 5),
-    segmentRerank: envFlagEnabled(env.SEARCH_SEGMENT_LANE_RERANK),
-    factRerank: envFlagEnabled(env.SEARCH_FACT_RERANK),
-    mentionDates: envFlagEnabled(env.RETRIEVAL_MENTION_DATES),
-    sceneTraces: envFlagEnabled(env.RETRIEVAL_SCENE_TRACES),
-    enumStrict: envFlagEnabled(env.RETRIEVAL_ENUM_STRICT),
+    segmentRerank: presetFlag(
+      env,
+      'SEARCH_SEGMENT_LANE_RERANK',
+      preset.segmentRerank,
+    ),
+    factRerank: presetFlag(env, 'SEARCH_FACT_RERANK', preset.factRerank),
+    mentionDates: presetFlag(
+      env,
+      'RETRIEVAL_MENTION_DATES',
+      preset.mentionDates,
+    ),
+    sceneTraces: presetFlag(env, 'RETRIEVAL_SCENE_TRACES', preset.sceneTraces),
+    enumStrict: presetFlag(env, 'RETRIEVAL_ENUM_STRICT', preset.enumStrict),
     extraEvidenceCap: positiveIntEnv(env, 'SYNTHESIZE_EXTRA_EVIDENCE_CAP', 40),
-    wideProbe: envFlagEnabled(env.SYNTHESIZE_LANE_WIDE_PROBE),
+    wideProbe: presetFlag(env, 'SYNTHESIZE_LANE_WIDE_PROBE', preset.wideProbe),
     wideProbeLimit: positiveIntEnv(env, 'SYNTHESIZE_WIDE_PROBE_LIMIT', 12),
-    entityExpansion: envFlagEnabled(env.RETRIEVAL_ENTITY_EXPANSION),
-    salienceScoring: envFlagEnabled(env.RETRIEVAL_SALIENCE_SCORING),
-    updateStoryRendering: envFlagEnabled(env.RETRIEVAL_UPDATE_STORY),
-    orderingFrame: envFlagEnabled(env.RETRIEVAL_ORDERING_FRAME),
+    entityExpansion: presetFlag(
+      env,
+      'RETRIEVAL_ENTITY_EXPANSION',
+      preset.entityExpansion,
+    ),
+    salienceScoring: presetFlag(
+      env,
+      'RETRIEVAL_SALIENCE_SCORING',
+      preset.salienceScoring,
+    ),
+    updateStoryRendering: presetFlag(
+      env,
+      'RETRIEVAL_UPDATE_STORY',
+      preset.updateStoryRendering,
+    ),
+    orderingFrame: presetFlag(
+      env,
+      'RETRIEVAL_ORDERING_FRAME',
+      preset.orderingFrame,
+    ),
     abstentionCalibration:
       enumEnv(env, 'RETRIEVAL_ABSTENTION_CALIBRATION', [
         'off',
         'coverage',
         'verifier',
         'minicheck',
-      ] as const) ?? 'off',
-    verifierTopicCoverage: envFlagEnabled(env.RETRIEVAL_VERIFIER_TOPIC_COVERAGE),
+      ] as const) ??
+      preset.abstentionCalibration ??
+      'off',
+    verifierTopicCoverage: presetFlag(
+      env,
+      'RETRIEVAL_VERIFIER_TOPIC_COVERAGE',
+      preset.verifierTopicCoverage,
+    ),
     verifierModel: modelIdEnv(env, 'RETRIEVAL_VERIFIER_MODEL'),
-    digestEvidence: envFlagEnabled(env.RETRIEVAL_DIGEST_EVIDENCE),
+    digestEvidence: presetFlag(
+      env,
+      'RETRIEVAL_DIGEST_EVIDENCE',
+      preset.digestEvidence,
+    ),
     digestLanes:
       enumEnv(env, 'RETRIEVAL_DIGEST_LANES', ['all', 'summary_ku'] as const) ??
+      preset.digestLanes ??
       'all',
-    rawWindow: envFlagEnabled(env.RETRIEVAL_RAW_WINDOW),
+    rawWindow: presetFlag(env, 'RETRIEVAL_RAW_WINDOW', preset.rawWindow),
     rawWindowSpan: positiveIntEnv(env, 'RETRIEVAL_RAW_WINDOW_SPAN', 2),
-    assistantLane: envFlagEnabled(env.RETRIEVAL_ASSISTANT_LANE),
+    assistantLane: presetFlag(
+      env,
+      'RETRIEVAL_ASSISTANT_LANE',
+      preset.assistantLane,
+    ),
     assistantLaneTopK: positiveIntEnv(env, 'RETRIEVAL_ASSISTANT_LANE_TOPK', 6),
     assistantLaneMatch: speakerMatchEnv(env, 'RETRIEVAL_ASSISTANT_LANE_MATCH'),
-    factsAsKeys: envFlagEnabled(env.RETRIEVAL_FACTS_AS_KEYS),
+    factsAsKeys: presetFlag(env, 'RETRIEVAL_FACTS_AS_KEYS', preset.factsAsKeys),
     factsAsKeysCap: positiveIntEnv(env, 'RETRIEVAL_FACTS_AS_KEYS_CAP', 8),
-    timeFilter: envFlagEnabled(env.RETRIEVAL_TIME_FILTER),
-    dateMath: envFlagEnabled(env.RETRIEVAL_DATE_MATH),
-    answerConditioning: envFlagEnabled(env.RETRIEVAL_ANSWER_CONDITIONING),
-    noiseFilter: envFlagEnabled(env.RETRIEVAL_NOISE_FILTER),
-    searchLoop: envFlagEnabled(env.RETRIEVAL_SEARCH_LOOP),
+    timeFilter: presetFlag(env, 'RETRIEVAL_TIME_FILTER', preset.timeFilter),
+    dateMath: presetFlag(env, 'RETRIEVAL_DATE_MATH', preset.dateMath),
+    answerConditioning: presetFlag(
+      env,
+      'RETRIEVAL_ANSWER_CONDITIONING',
+      preset.answerConditioning,
+    ),
+    noiseFilter: presetFlag(env, 'RETRIEVAL_NOISE_FILTER', preset.noiseFilter),
+    searchLoop: presetFlag(env, 'RETRIEVAL_SEARCH_LOOP', preset.searchLoop),
     abstentionMinTopScore: nonNegativeFloatEnv(
       env,
       'RETRIEVAL_ABSTENTION_MIN_SCORE',
@@ -662,28 +772,48 @@ export function resolveRetrievalProfile(
 
 const LANE_ID_SET = new Set<string>(ALL_LANES);
 
+/** The tenant's parsed overlay object from RETRIEVAL_PROFILE_OVERRIDES,
+ *  or undefined when absent/malformed (per-tenant fail-open to base —
+ *  the JSON shape itself is boot-validated in env-validation). */
+function tenantOverlay(
+  companyId: string,
+  env: NodeJS.ProcessEnv,
+): Record<string, unknown> | undefined {
+  const raw = env.RETRIEVAL_PROFILE_OVERRIDES;
+  if (!raw || !raw.trim()) return undefined;
+  let overrides: Record<string, Record<string, unknown>>;
+  try {
+    overrides = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  const o = overrides?.[companyId];
+  return o && typeof o === 'object' ? o : undefined;
+}
+
 /**
  * Per-tenant profile resolution: the boot default overlaid with the
  * tenant's entry in RETRIEVAL_PROFILE_OVERRIDES (a JSON object mapping
  * companyId → partial profile; `lanes` as an array of LaneIds).
- * Unknown fields and malformed overrides are ignored per-tenant — the
- * JSON shape itself is boot-validated in env-validation.
+ * Unknown fields and malformed overrides are ignored per-tenant.
+ *
+ * The overlay's `genre` resolves FIRST: a tenant pinned to another
+ * genre gets THAT genre's preset-backed base (genre-presets.ts), then
+ * the remaining overlay fields apply on top — so per-field precedence
+ * is overlay field > explicit env key > genre preset > code default.
  */
 export function resolveRetrievalProfileFor(
   companyId: string,
   env: NodeJS.ProcessEnv = process.env,
 ): RetrievalProfile {
-  const base = resolveRetrievalProfile(env);
-  const raw = env.RETRIEVAL_PROFILE_OVERRIDES;
-  if (!raw || !raw.trim()) return base;
-  let overrides: Record<string, Record<string, unknown>>;
-  try {
-    overrides = JSON.parse(raw);
-  } catch {
-    return base;
-  }
-  const o = overrides?.[companyId];
-  if (!o || typeof o !== 'object') return base;
+  const o = tenantOverlay(companyId, env);
+  const overlayGenre =
+    o && typeof o.genre === 'string' &&
+    (GENRES as readonly string[]).includes(o.genre)
+      ? (o.genre as RetrievalGenre)
+      : resolveGenre(env);
+  const base = resolveForGenre(overlayGenre, env);
+  if (!o) return base;
   const merged: RetrievalProfile = { ...base };
   // Data-driven like the numeric/boolean loops below — every enum
   // field overlays through one loop (a per-field if-ladder pushed the

--- a/test/abstention-calibration.unit-spec.ts
+++ b/test/abstention-calibration.unit-spec.ts
@@ -87,9 +87,21 @@ describe('the abstention answer', () => {
 });
 
 describe('RETRIEVAL_ABSTENTION_CALIBRATION profile point', () => {
-  it('defaults off; coverage round-trips; garbage rejects to off', () => {
+  it('genre-preset default; coverage round-trips; garbage rejects to preset', () => {
+    // The default genre (assistant_chat) presets 'verifier' — the V9
+    // verdict-decline win (genre-presets.ts). Explicit env still wins.
     expect(
       resolveRetrievalProfile({} as NodeJS.ProcessEnv).abstentionCalibration,
+    ).toBe('verifier');
+    expect(
+      resolveRetrievalProfile({
+        RETRIEVAL_ABSTENTION_CALIBRATION: 'off',
+      } as NodeJS.ProcessEnv).abstentionCalibration,
+    ).toBe('off');
+    expect(
+      resolveRetrievalProfile({
+        RETRIEVAL_GENRE: 'documents',
+      } as NodeJS.ProcessEnv).abstentionCalibration,
     ).toBe('off');
     expect(
       resolveRetrievalProfile({
@@ -101,11 +113,13 @@ describe('RETRIEVAL_ABSTENTION_CALIBRATION profile point', () => {
         RETRIEVAL_ABSTENTION_CALIBRATION: 'verifier',
       } as NodeJS.ProcessEnv).abstentionCalibration,
     ).toBe('verifier');
+    // An invalid value reads as unset, so it falls back to the genre
+    // preset ('verifier' on the default genre), not to 'off'.
     expect(
       resolveRetrievalProfile({
         RETRIEVAL_ABSTENTION_CALIBRATION: 'always',
       } as NodeJS.ProcessEnv).abstentionCalibration,
-    ).toBe('off');
+    ).toBe('verifier');
   });
 
   it('floors default and parse from env', () => {
@@ -140,8 +154,10 @@ describe('RETRIEVAL_ABSTENTION_CALIBRATION profile point', () => {
     expect(beamco.abstentionCalibration).toBe('coverage');
     expect(beamco.abstentionMinTopScore).toBeCloseTo(0.42);
     expect(beamco.abstentionMinEvidence).toBe(3);
+    // A tenant without an overlay rides the default genre's preset
+    // ('verifier' on assistant_chat — genre-presets.ts).
     expect(resolveRetrievalProfileFor('other', env).abstentionCalibration).toBe(
-      'off',
+      'verifier',
     );
   });
 });

--- a/test/genre-presets.unit-spec.ts
+++ b/test/genre-presets.unit-spec.ts
@@ -1,0 +1,261 @@
+import {
+  resolveRetrievalProfile,
+  resolveRetrievalProfileFor,
+  type RetrievalProfile,
+} from '../src/search/retrieval-profile';
+import { GENRE_PRESETS } from '../src/search/genre-presets';
+
+/**
+ * Genre preset layer (genre-presets.ts): each genre ships tuned
+ * defaults for the measured levers; explicit configuration always wins.
+ *
+ * Precedence under test (strict, per field):
+ *   per-company overlay field > explicit env key > genre preset >
+ *   code default
+ * plus: a company overlay that changes `genre` re-derives the
+ * preset-backed base for THAT genre before the remaining overlay
+ * fields apply.
+ */
+
+const env = (e: Record<string, string>) => e as NodeJS.ProcessEnv;
+
+/** Wire shape for full-profile equality: lanes as a sorted array. */
+const wire = (p: RetrievalProfile) => ({ ...p, lanes: [...p.lanes].sort() });
+
+describe('genre presets — default genre', () => {
+  it('the default genre (assistant_chat) gets its preset', () => {
+    const p = resolveRetrievalProfile(env({}));
+    expect(p.genre).toBe('assistant_chat');
+    expect(p.sceneTraces).toBe(true);
+    expect(p.abstentionCalibration).toBe('verifier');
+  });
+
+  it('RETRIEVAL_GENRE=dialogue gets the dialogue preset', () => {
+    const p = resolveRetrievalProfile(env({ RETRIEVAL_GENRE: 'dialogue' }));
+    expect(p.verbatimEvidence).toBe('always');
+    expect(p.dateAnchoring).toBe('none');
+    // Dialogue does NOT inherit the assistant_chat levers.
+    expect(p.sceneTraces).toBe(false);
+    expect(p.abstentionCalibration).toBe('off');
+  });
+});
+
+describe('genre presets — explicit env beats preset', () => {
+  it('enum key set → env wins over the preset', () => {
+    expect(
+      resolveRetrievalProfile(
+        env({
+          RETRIEVAL_GENRE: 'dialogue',
+          RETRIEVAL_VERBATIM_EVIDENCE: 'shape_conditioned',
+        }),
+      ).verbatimEvidence,
+    ).toBe('shape_conditioned');
+    expect(
+      resolveRetrievalProfile(
+        env({
+          RETRIEVAL_GENRE: 'dialogue',
+          RETRIEVAL_DATE_ANCHORING: 'absolute',
+        }),
+      ).dateAnchoring,
+    ).toBe('absolute');
+    expect(
+      resolveRetrievalProfile(env({ RETRIEVAL_ABSTENTION_CALIBRATION: 'off' }))
+        .abstentionCalibration,
+    ).toBe('off');
+  });
+
+  it("boolean key explicitly '0' beats a preset-on (unset defers)", () => {
+    // assistant_chat presets sceneTraces=true; an explicit 0 wins.
+    expect(
+      resolveRetrievalProfile(env({ RETRIEVAL_SCENE_TRACES: '0' }))
+        .sceneTraces,
+    ).toBe(false);
+    expect(
+      resolveRetrievalProfile(env({ RETRIEVAL_SCENE_TRACES: '1' }))
+        .sceneTraces,
+    ).toBe(true);
+    expect(resolveRetrievalProfile(env({})).sceneTraces).toBe(true);
+  });
+
+  it('legacy SYNTHESIZE_DATE_CONTEXT set to ANY value is explicit', () => {
+    // Explicit legacy ON beats the dialogue preset ('none').
+    expect(
+      resolveRetrievalProfile(
+        env({ RETRIEVAL_GENRE: 'dialogue', SYNTHESIZE_DATE_CONTEXT: '1' }),
+      ).dateAnchoring,
+    ).toBe('absolute');
+    // Explicit legacy OFF is the measured LoCoMo pin on any genre.
+    expect(
+      resolveRetrievalProfile(env({ SYNTHESIZE_DATE_CONTEXT: '0' }))
+        .dateAnchoring,
+    ).toBe('none');
+  });
+
+  it('legacy lane flags force always on any genre (enable-only)', () => {
+    expect(
+      resolveRetrievalProfile(env({ SEARCH_SEGMENT_LANE_ENABLED: '1' }))
+        .verbatimEvidence,
+    ).toBe('always');
+    // Their falsy state reads as unset → the genre preset applies.
+    expect(
+      resolveRetrievalProfile(
+        env({ RETRIEVAL_GENRE: 'dialogue', SEARCH_SEGMENT_LANE_ENABLED: '0' }),
+      ).verbatimEvidence,
+    ).toBe('always');
+  });
+});
+
+describe('genre presets — per-company overlay', () => {
+  it('an overlay genre re-applies THAT genre preset for the company', () => {
+    const e = env({
+      RETRIEVAL_PROFILE_OVERRIDES: JSON.stringify({
+        diaryco: { genre: 'dialogue' },
+      }),
+    });
+    const p = resolveRetrievalProfileFor('diaryco', e);
+    expect(p.genre).toBe('dialogue');
+    expect(p.verbatimEvidence).toBe('always');
+    expect(p.dateAnchoring).toBe('none');
+    // The default genre's preset no longer applies to this company.
+    expect(p.abstentionCalibration).toBe('off');
+    expect(p.sceneTraces).toBe(false);
+    // Other tenants keep the default genre + its preset.
+    const other = resolveRetrievalProfileFor('other', e);
+    expect(other.genre).toBe('assistant_chat');
+    expect(other.abstentionCalibration).toBe('verifier');
+  });
+
+  it('an explicit env key still beats the overlay genre preset', () => {
+    const e = env({
+      RETRIEVAL_VERBATIM_EVIDENCE: 'off',
+      RETRIEVAL_PROFILE_OVERRIDES: JSON.stringify({
+        diaryco: { genre: 'dialogue' },
+      }),
+    });
+    expect(resolveRetrievalProfileFor('diaryco', e).verbatimEvidence).toBe(
+      'off',
+    );
+  });
+
+  it('an overlay field beats the preset (and everything else)', () => {
+    const e = env({
+      RETRIEVAL_PROFILE_OVERRIDES: JSON.stringify({
+        diaryco: { genre: 'dialogue', verbatimEvidence: 'fused' },
+        chatco: { sceneTraces: false, abstentionCalibration: 'coverage' },
+      }),
+    });
+    const diary = resolveRetrievalProfileFor('diaryco', e);
+    expect(diary.verbatimEvidence).toBe('fused');
+    // Untouched preset fields survive next to the overlaid one.
+    expect(diary.dateAnchoring).toBe('none');
+    const chat = resolveRetrievalProfileFor('chatco', e);
+    expect(chat.sceneTraces).toBe(false);
+    expect(chat.abstentionCalibration).toBe('coverage');
+  });
+});
+
+describe('genre presets — documents axis', () => {
+  it('documents has an EMPTY preset (unmeasured axis)', () => {
+    expect(GENRE_PRESETS.documents).toEqual({});
+  });
+
+  it('documents resolves to pure code defaults', () => {
+    const p = resolveRetrievalProfile(env({ RETRIEVAL_GENRE: 'documents' }));
+    expect(p.verbatimEvidence).toBe('shape_conditioned');
+    expect(p.dateAnchoring).toBe('absolute');
+    expect(p.abstentionCalibration).toBe('off');
+    expect(p.sceneTraces).toBe(false);
+  });
+});
+
+describe('genre presets — full effective profile per genre (snapshot)', () => {
+  // The full resolved profile per genre with nothing else set. Any
+  // future preset edit MUST show up as a diff in exactly these
+  // literals — that visibility is the point of the test.
+  const CODE_DEFAULTS = {
+    verbatimEvidence: 'shape_conditioned',
+    insightEvidence: 'off',
+    timelineEvidence: 'off',
+    coverageScanMode: 'brute',
+    coverageLexMode: 'phrase',
+    scanHnswEf: 400,
+    scanHnswOverfetch: 4,
+    dateAnchoring: 'absolute',
+    temporalMode: 'filter',
+    factBudget: 48,
+    quotesPerPrompt: 8,
+    sourceExcerptsCap: 16,
+    segmentTopK: 5,
+    segmentRerank: false,
+    factRerank: false,
+    mentionDates: false,
+    sceneTraces: false,
+    enumStrict: false,
+    extraEvidenceCap: 40,
+    wideProbe: false,
+    wideProbeLimit: 12,
+    entityExpansion: false,
+    salienceScoring: false,
+    updateStoryRendering: false,
+    orderingFrame: false,
+    abstentionCalibration: 'off',
+    verifierTopicCoverage: false,
+    verifierModel: '',
+    digestEvidence: false,
+    digestLanes: 'all',
+    rawWindow: false,
+    rawWindowSpan: 2,
+    assistantLane: false,
+    assistantLaneTopK: 6,
+    assistantLaneMatch: 'assistant',
+    factsAsKeys: false,
+    factsAsKeysCap: 8,
+    timeFilter: false,
+    dateMath: false,
+    answerConditioning: false,
+    noiseFilter: false,
+    searchLoop: false,
+    abstentionMinTopScore: 0.35,
+    abstentionMinEvidence: 2,
+    lanes: [] as string[],
+  };
+
+  it('dialogue', () => {
+    expect(
+      wire(resolveRetrievalProfile(env({ RETRIEVAL_GENRE: 'dialogue' }))),
+    ).toEqual({
+      ...CODE_DEFAULTS,
+      genre: 'dialogue',
+      // preset: segment-lane genre law (+3.8pp LoCoMo, measured twice)
+      verbatimEvidence: 'always',
+      // preset: LoCoMo gold convention (date context −7.1pp; E2 pin)
+      dateAnchoring: 'none',
+    });
+  });
+
+  it('assistant_chat (the default genre)', () => {
+    const expected = {
+      ...CODE_DEFAULTS,
+      genre: 'assistant_chat',
+      // preset: dual-trace scene anchors (+20.2pp LongMemEval-S)
+      sceneTraces: true,
+      // preset: V9 verdict-decline win (+17.5pp abstention, BEAM)
+      abstentionCalibration: 'verifier',
+    };
+    expect(wire(resolveRetrievalProfile(env({})))).toEqual(expected);
+    expect(
+      wire(
+        resolveRetrievalProfile(env({ RETRIEVAL_GENRE: 'assistant_chat' })),
+      ),
+    ).toEqual(expected);
+  });
+
+  it('documents', () => {
+    expect(
+      wire(resolveRetrievalProfile(env({ RETRIEVAL_GENRE: 'documents' }))),
+    ).toEqual({
+      ...CODE_DEFAULTS,
+      genre: 'documents',
+    });
+  });
+});

--- a/test/minicheck-client.unit-spec.ts
+++ b/test/minicheck-client.unit-spec.ts
@@ -127,8 +127,10 @@ describe('RETRIEVAL_ABSTENTION_CALIBRATION=minicheck profile point', () => {
     expect(
       resolveRetrievalProfileFor('beamco', env).abstentionCalibration,
     ).toBe('minicheck');
+    // No overlay → the default genre's preset applies ('verifier' on
+    // assistant_chat — genre-presets.ts), not 'off'.
     expect(
       resolveRetrievalProfileFor('other', env).abstentionCalibration,
-    ).toBe('off');
+    ).toBe('verifier');
   });
 });

--- a/test/synthesize.unit-spec.ts
+++ b/test/synthesize.unit-spec.ts
@@ -298,29 +298,44 @@ describe('SynthesizeService', () => {
   });
 
   it('lenient mode + unsupported verdict still returns the answer with reason', async () => {
-    const search = makeSearch([
-      makeHit('cust_a', [
-        { factId: 'f1', predicate: 'name', object: 'Maya' },
-      ]),
-    ]);
-    const { svc } = makeSvc(
-      search,
-      {},
-      [
-        JSON.stringify({
-          answer: 'Maya bought a new fridge [f1].',
-          citedFactIds: ['f1'],
-        }),
-        JSON.stringify({
-          verdict: 'unsupported',
-          unsupportedClaims: ['Maya bought a new fridge'],
-        }),
-      ],
-    );
-    const out = await svc.synthesize({ companyId: 'co_x', dto: { ...baseDto, synthesisGuardrails: 'lenient' }, callerScopes: ['brain:read'] });
-    expect(out.answer).toContain('fridge');
-    expect(out.reason).toBe('verifier_failed');
-    expect(out.citations.map((c) => c.factId)).toEqual(['f1']);
+    // This pins the LEGACY lenient contract, which needs
+    // abstentionCalibration='off' — the default genre's preset is now
+    // 'verifier' (genre-presets.ts), which turns this exact case into
+    // a decline; the decline path has its own pins in
+    // synthesize-verification.unit-spec. Explicit env beats the preset.
+    const saved = process.env.RETRIEVAL_ABSTENTION_CALIBRATION;
+    process.env.RETRIEVAL_ABSTENTION_CALIBRATION = 'off';
+    try {
+      const search = makeSearch([
+        makeHit('cust_a', [
+          { factId: 'f1', predicate: 'name', object: 'Maya' },
+        ]),
+      ]);
+      const { svc } = makeSvc(
+        search,
+        {},
+        [
+          JSON.stringify({
+            answer: 'Maya bought a new fridge [f1].',
+            citedFactIds: ['f1'],
+          }),
+          JSON.stringify({
+            verdict: 'unsupported',
+            unsupportedClaims: ['Maya bought a new fridge'],
+          }),
+        ],
+      );
+      const out = await svc.synthesize({ companyId: 'co_x', dto: { ...baseDto, synthesisGuardrails: 'lenient' }, callerScopes: ['brain:read'] });
+      expect(out.answer).toContain('fridge');
+      expect(out.reason).toBe('verifier_failed');
+      expect(out.citations.map((c) => c.factId)).toEqual(['f1']);
+    } finally {
+      if (saved === undefined) {
+        delete process.env.RETRIEVAL_ABSTENTION_CALIBRATION;
+      } else {
+        process.env.RETRIEVAL_ABSTENTION_CALIBRATION = saved;
+      }
+    }
   });
 
   it('off mode skips verifier — answer returned without verdict', async () => {


### PR DESCRIPTION
## ⚠️ Contains a default-behavior change — owner decision requested

The boot-default genre (`assistant_chat`) now resolves `abstentionCalibration='verifier'` and `sceneTraces=true` unless env says otherwise. `sceneTraces` is render-only (byte-identical on worlds without stamps), but the abstention change flips the live lenient-guardrail contract: unsupported answers **decline** instead of returning with a reason. `RETRIEVAL_ABSTENTION_CALIBRATION=off` restores the legacy contract. Merge = accepting that new default.

## What

A preset layer over `RETRIEVAL_GENRE`: each genre ships tuned defaults for the measured levers, while explicit configuration always wins. Precedence (tested both ways, including explicit `'0'` beating a boolean preset-on): **company overlay field > explicit env > genre preset > code default**; when the company overlay changes `genre` itself, that genre's preset base is re-derived first.

## Preset table (evidence-pinned; each entry cites its measured verdict in code and in doc §11)

| genre | lever | value | evidence |
|---|---|---|---|
| dialogue | verbatimEvidence | 'always' | segment lane +3.8pp LoCoMo (genre law, measured twice) |
| dialogue | dateAnchoring | 'none' | date context −7.1pp LoCoMo by gold convention |
| assistant_chat | sceneTraces | true | dual-trace +20.2pp LME-S (CI +12.1..+29.3), controlled pair |
| assistant_chat | abstentionCalibration | 'verifier' | +17.5pp abstention row, zero extra model calls |
| documents | *(empty)* | — | unmeasured axis |

The segment-lane genre law is respected in both directions ('always' never applies to assistant_chat: −28pp LME / −18.6pp BEAM). Deliberately left out with doc citations (§11): digest lanes (recorded bleed), raw window (measured negative), multiworld M3/M4 (parked at p≈0.06), all unmeasured V13 read levers, overlap_boost (n.s.), verifierModel swap (awaits confirm).

## Mechanics

- `src/search/genre-presets.ts` — pure data, zero env reads (S5.2 stays one-file).
- `retrieval-profile.ts` — real `env ?? preset ?? default` per field; `presetFlag()` distinguishes unset from explicit '0'; legacy `SYNTHESIZE_DATE_CONTEXT` (incl. `=0`) counts as explicit and beats presets.
- No new env keys; both flag-budget goldens byte-identical.
- `test/genre-presets.unit-spec.ts` (14 tests) incl. full effective-profile snapshot per genre — future preset edits are visible diffs.
- Doc: `memory-research-2026-08.md` §11 (genre × lever × evidence + precedence contract).

## Gates

eslint clean, tsc clean, flag-budget + config-catalog-truth green, **full unit suite 254/254 (2181 tests)**. Three existing default assertions updated to pin the legacy contract explicitly where they relied on the old boot default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB