### PR TITLE
fix(security,search): release blockers — derive user scope, retract ownership, rerank trust band

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -552,6 +552,11 @@ SEARCH_FACT_CENTRIC_BUDGET=48
 # P3 v1: derived-namespace pin — read only facts of this derivedVersion
 # (batch-written by POST /v1/admin/maintenance/derive). Unset = legacy.
 #RETRIEVAL_DERIVED_VERSION=
+# Multiworld (§10): additional derived worlds UNIONED into the read set
+# alongside the primary pin (comma-separated). EXPERIMENTAL — only for a
+# measured complementary pair, never two full snapshots (record-id dedupe
+# only, no per-world budgets).
+#RETRIEVAL_DERIVED_VERSIONS=
 #WINDOW_DERIVER_MODEL=gpt-4o-mini
 # A1: provenance lane — verbatim source turns of the evidence facts
 # quoted in the synthesis prompt (restores derivation-lost detail).
@@ -589,6 +594,18 @@ SEARCH_FACT_CENTRIC_BUDGET=48
 # Raw-substrate driver v1: public episodes read API + NDJSON export
 # (GET /v1/episodes, GET /v1/episodes/export). PII-fenced like the lanes.
 #EPISODES_API_ENABLED=0
+# New-episode webhook subscriptions (POST/GET/DELETE /v1/episodes/subscriptions).
+#EPISODE_SUBSCRIPTIONS_ENABLED=0
+# Projections registry read API (GET /v1/projections, POST …/rebuild).
+#PROJECTIONS_API_ENABLED=0
+# Fact read + provenance API (GET /v1/facts/:id, …/provenance) — the
+# "show me why I remember this" surface; retract stays flag-independent.
+#FACTS_API_ENABLED=0
+# Rolling user profile API (GET /v1/users/:userId/profile), deterministic v1.
+#USER_PROFILE_API_ENABLED=0
+# Rerank band contract (audit 2026-08-21 P1): rerankers reorder only within
+# this fused-score band; wider gaps (trust priors) survive. 0 disables.
+#SEARCH_RERANK_TRUST_BAND=0.1
 # Eval-harness plumbing: admin keys may address another tenant per call via
 # X-Brain-Tenant (LongMemEval/BEAM per-question isolation); episode-only
 # ingest skips LLM extraction (world built in batch by /maintenance/derive).

--- a/src/admin/aspect-rollups.ts
+++ b/src/admin/aspect-rollups.ts
@@ -156,6 +156,7 @@ export function accumulateLanded(
     object: string;
     validFrom: Date;
     source?: { episodeIds?: unknown };
+    userId?: string;
   }>,
   opts: {
     outcomes: Array<{ outcome: string }>;
@@ -166,6 +167,10 @@ export function accumulateLanded(
   rows.forEach((r, i) => {
     const o = outcomes[i]?.outcome;
     if (o === 'SKIPPED' || o === 'REJECTED') return;
+    // Audit 2026-08-21 P0: user-scoped rows never feed the rollup /
+    // compose pools — those aggregates land tenant-global, which would
+    // launder one user's facts into everyone's view.
+    if (typeof r.userId === 'string' && r.userId.length > 0) return;
     const eps = Array.isArray(r.source?.episodeIds)
       ? (r.source.episodeIds as unknown[]).filter(
           (e): e is string => typeof e === 'string',

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -329,6 +329,20 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
         isBooleanFlag: false,
       },
       {
+        key: 'SEARCH_RERANK_TRUST_BAND',
+        category: 'search',
+        defaultValue: '0.1',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Fused-score band width the rerank stages (cross-encoder and ' +
+          'LLM) may reorder WITHIN. A fused-score gap wider than the band ' +
+          '— trust priors above all, since SEARCH_TRUST_BETA rides the ' +
+          'fused score — survives every rerank stage instead of being ' +
+          'silently erased by reranker priority (audit 2026-08-21 P1). ' +
+          '0 disables the band and restores absolute reranker priority.',
+      },
+      {
         key: 'SEARCH_TOKEN_COUNT_OFFLOAD',
         category: 'search',
         defaultValue: '1',

--- a/src/admin/derive-row-builder.ts
+++ b/src/admin/derive-row-builder.ts
@@ -91,15 +91,32 @@ export function buildDerivedRows({
       resolveExtractionProfile().deriveSceneTrace && p.scene?.trim()
         ? { scene: p.scene.trim().slice(0, 200) }
         : {};
+    // Release blocker (audit 2026-08-21 P0): the per-user scope of the
+    // grounding turns must survive derivation — an episode ingested
+    // under INGEST_EPISODE_ONLY with a userId used to derive into a
+    // TENANT-GLOBAL fact, visible to every other user. Scope rule, per
+    // proposition: grounded only in global turns → global fact;
+    // grounded in exactly one user's turns (global turns may ride
+    // along) → that user's fact; grounded in turns of TWO OR MORE
+    // users → the row is poisoned for any single scope and must be
+    // dropped (crossUserScope; the caller filters and warns).
+    const groundingTurns = p.turns.filter(
+      (t) => t >= 0 && t < session.length,
+    );
+    const scopeUsers = [
+      ...new Set(
+        groundingTurns
+          .map((t) => session[t].userId)
+          .filter((u): u is string => typeof u === 'string' && u.length > 0),
+      ),
+    ];
     // Provenance (recorder / trust) carries the FINAL version — it
     // survives the flip untouched; only derivedVersion is staged.
     const source = {
       vertical: 'derived',
       recorder: ns.final,
       conversationId,
-      episodeIds: p.turns
-        .filter((t) => t >= 0 && t < session.length)
-        .map((t) => String(session[t].id)),
+      episodeIds: groundingTurns.map((t) => String(session[t].id)),
       ...salience,
       ...mention,
       ...scene,
@@ -107,6 +124,8 @@ export function buildDerivedRows({
       ...typedAtomKind(p),
     };
     return {
+      userId: scopeUsers.length === 1 ? scopeUsers[0] : undefined,
+      crossUserScope: scopeUsers.length > 1,
       entityId: subjectEntity,
       predicate: aspect || 'other',
       object: p.proposition,

--- a/src/admin/window-deriver.service.ts
+++ b/src/admin/window-deriver.service.ts
@@ -679,7 +679,7 @@ export class WindowDeriverService {
       // namespace — still one round-trip per session, but the resolver
       // stamps the trust snapshot, locale and status instead of a raw
       // INSERT hand-copying its contract.
-      const rows = buildDerivedRows({
+      const builtRows = buildDerivedRows({
         resolved,
         vectors,
         sessionDate,
@@ -687,6 +687,20 @@ export class WindowDeriverService {
         ns,
         conversationId,
       });
+      // Audit 2026-08-21 P0: a proposition grounded in turns of two or
+      // more users fits no single scope — drop it (with its resolved
+      // twin, keeping every downstream array index-aligned) rather
+      // than land it tenant-global.
+      const crossUser = builtRows.filter((r) => r.crossUserScope).length;
+      if (crossUser > 0) {
+        this.logger.warn(
+          `derive ${conversationId}: dropped ${crossUser} cross-user-scoped proposition(s)`,
+        );
+      }
+      const keptResolved = resolved.filter(
+        (_, i) => !builtRows[i].crossUserScope,
+      );
+      const rows = builtRows.filter((r) => !r.crossUserScope);
       // V9 §1: value-bearing aspects take the bitemporal_event
       // lifecycle when the profile asks; V9 phase 0: the resolver
       // batch degrades per-row instead of failing the conversation —
@@ -700,10 +714,15 @@ export class WindowDeriverService {
       ).length;
       result.propositions += rows.length - unlandedRows;
       if (rollupPool) {
-        collectRollupPool({ rollupPool, resolved, rows, outcomes });
+        collectRollupPool({ rollupPool, resolved: keptResolved, rows, outcomes });
       }
       if (composePool) {
-        collectRollupPool({ rollupPool: composePool, resolved, rows, outcomes });
+        collectRollupPool({
+          rollupPool: composePool,
+          resolved: keptResolved,
+          rows,
+          outcomes,
+        });
       }
     }
     // 0087: the folded window's distinct user scopes = policy metadata.

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -339,15 +339,58 @@ export class FactsService {
       const now = new Date();
 
       // Verify the fact exists and is currently active. SELECT extra
-      // predicate + source so the admin-scope gate below can read them.
+      // predicate + source so the admin-scope gate below can read them,
+      // and userId for the ownership fence.
       const [existingRows] = await db.query<any[][]>(
-        `SELECT id, status, retractedAt, validFrom, predicate, source
+        `SELECT id, status, retractedAt, validFrom, predicate, source,
+                userId
            FROM type::record('knowledge_fact', $rid) LIMIT 1`,
         { rid: ref.id },
       );
       const existing = (existingRows as any[])?.[0];
       if (!existing) {
         throw new NotFoundException(`Fact ${factId} not found`);
+      }
+
+      // Release blocker (audit 2026-08-21 P0): retract used to mutate
+      // with no ownership fence at all — a user-bound brain:write token
+      // could retract any fact by id. Same semantics as the read path:
+      // another user's fact is a 404 (existence never leaks); a
+      // tenant-global fact is retractable by a user-bound token only
+      // with brain:admin (it IS readable, so 403 leaks nothing new).
+      // In-process legacy callers run outside a request context, where
+      // pinUserScope(undefined) is undefined → unrestricted, as before.
+      const retractUserScope = pinUserScope(undefined);
+      if (retractUserScope !== undefined) {
+        const owner =
+          typeof existing.userId === 'string' && existing.userId.length > 0
+            ? existing.userId
+            : undefined;
+        if (owner !== undefined && owner !== retractUserScope) {
+          throw new NotFoundException(`Fact ${factId} not found`);
+        }
+        if (owner === undefined && !callerScopes?.includes('brain:admin')) {
+          throw new ForbiddenException(
+            'retract of a tenant-global fact requires an M2M token or brain:admin',
+          );
+        }
+      }
+
+      // Registry-backed row policy — a predicate the caller cannot see
+      // is a predicate the caller cannot retract (404, same as read).
+      if (callerScopes) {
+        const rowPolicy = makeRowPolicyFilter({
+          callerScopes,
+          surface: 'fact_read',
+          policyLookup: await this.predicateRegistry?.rowPolicyLookup(
+            companyId,
+          ),
+        });
+        const visible = rowPolicy.filter(existing);
+        rowPolicy.finish();
+        if (!visible) {
+          throw new NotFoundException(`Fact ${factId} not found`);
+        }
       }
 
       // Predicate-class authorization: billing_event / human_declared /

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -356,6 +356,10 @@ export class FactResolverService {
       lang?: string;
       script?: string;
       derivedVersion: string;
+      /** Per-user scope of the grounding turns (audit 2026-08-21 P0) —
+       *  absent = tenant-global. Conflict resolution is scope-local
+       *  (0055: fn::resolve_fact scopes candidates by $user_id). */
+      userId?: string;
     }>,
     opts: { slotSemantics?: boolean } = {},
   ): Promise<ResolveOutcome[]> {
@@ -374,6 +378,7 @@ export class FactResolverService {
       lang: r.lang,
       script: r.script,
       derivedVersion: r.derivedVersion,
+      userId: r.userId,
     }));
     try {
       return (await this.resolveAppendOnlyBatch(

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -954,6 +954,11 @@ export interface SearchTuning {
   /** Fact-pool slice the fact-level rerank pass rescoring can afford. */
   factRerankWindow: number;
   rerankSkipMargin: number;
+  /** Fused-score band width the rerankers may reorder WITHIN. A score
+   *  gap wider than the band (trust priors above all — SEARCH_TRUST_BETA
+   *  rides the fused score) survives every rerank stage; 0 disables and
+   *  restores absolute reranker priority. */
+  rerankTrustBand: number;
   stageBudgets: StageBudgets;
   /** Token-count worker offload (response shaping). */
   tokenCountOffload: boolean;
@@ -980,6 +985,19 @@ function tuningInt(
 function nonNegativeFloat(env: NodeJS.ProcessEnv, name: string): number {
   const v = Number(env[name] ?? 0);
   return Number.isFinite(v) && v > 0 ? v : 0;
+}
+
+/** Like nonNegativeFloat but with a non-zero default — an explicit `0`
+ *  is honored (the knob's documented off switch). */
+function nonNegativeFloatDefault(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  dflt: number,
+): number {
+  const raw = env[name];
+  if (raw === undefined || raw === '') return dflt;
+  const v = Number(raw);
+  return Number.isFinite(v) && v >= 0 ? v : dflt;
 }
 
 /**
@@ -1013,6 +1031,11 @@ export function resolveSearchTuning(
     crossEncoderWindow: tuningInt(env, 'SEARCH_CROSS_ENCODER_WINDOW', 50),
     factRerankWindow: tuningInt(env, 'SEARCH_FACT_RERANK_WINDOW', 64),
     rerankSkipMargin: nonNegativeFloat(env, 'SEARCH_RERANK_SKIP_MARGIN'),
+    rerankTrustBand: nonNegativeFloatDefault(
+      env,
+      'SEARCH_RERANK_TRUST_BAND',
+      0.1,
+    ),
     stageBudgets: resolveStageBudgets(env),
     tokenCountOffload: envFlagEnabled(env.SEARCH_TOKEN_COUNT_OFFLOAD ?? '1'),
     tokenOffloadMinHits: tuningInt(env, 'SEARCH_TOKEN_OFFLOAD_MIN_HITS', 24),

--- a/src/search/search-rerank.service.ts
+++ b/src/search/search-rerank.service.ts
@@ -127,6 +127,17 @@ export class SearchRerankService {
       this.metrics?.countCrossEncoder('skipped_singleton');
     }
 
+    // Release blocker (audit 2026-08-21 P1): the cross-encoder's
+    // permutation used to override fused-score ORDER unconditionally,
+    // erasing every score-side prior — trust (SEARCH_TRUST_BETA) above
+    // all: the beta moved the score but could never move the ranking.
+    // Contract: rerankers refine order only WITHIN a fused-score band;
+    // a gap wider than the band survives every rerank stage.
+    candidatesForRerank = this.applyScoreBandOrder(
+      candidatesForRerank,
+      ctx.tuning?.rerankTrustBand ?? 0,
+    );
+
     const rerankSkipMargin = ctx.tuning?.rerankSkipMargin ?? 0;
     // shouldSkipRerankByMargin compares fused rankScore of top-1 vs top-2.
     // After runCrossEncoder, candidatesForRerank is ordered by cross-encoder
@@ -151,11 +162,14 @@ export class SearchRerankService {
       return candidatesForRerank;
     }
 
-    return this.runLlmRerank({
+    const llmOrdered = await this.runLlmRerank({
       candidatesForRerank,
       ctx,
       neighboursByEntity: neighboursByEntity ?? new Map(),
     });
+    // Same band contract over the LLM reranker's output — no rerank
+    // stage may invert a fused-score gap wider than the band.
+    return this.applyScoreBandOrder(llmOrdered, ctx.tuning?.rerankTrustBand ?? 0);
   }
 
   /**
@@ -208,6 +222,26 @@ export class SearchRerankService {
     );
     this.metrics?.countCrossEncoder(timedOut ? 'fact_error' : 'fact_invoked');
     if (!timedOut) remapWindowScores(rows, perm);
+  }
+
+  /**
+   * The band contract (audit 2026-08-21 P1): reranker output may only
+   * reorder buckets whose fused rankScore falls in the same band —
+   * sort key (band desc, reranker position asc). Deterministic and
+   * transitive (unlike a pairwise margin comparator). Band 0 → no-op.
+   */
+  private applyScoreBandOrder(
+    buckets: EntityBucket[],
+    band: number,
+  ): EntityBucket[] {
+    if (!(band > 0) || buckets.length <= 1) return buckets;
+    const pos = new Map(buckets.map((b, i) => [b.entityId, i] as const));
+    return [...buckets].sort((a, b) => {
+      const bandA = Math.floor(a.rankScore / band);
+      const bandB = Math.floor(b.rankScore / band);
+      if (bandA !== bandB) return bandB - bandA;
+      return (pos.get(a.entityId) ?? 0) - (pos.get(b.entityId) ?? 0);
+    });
   }
 
   // eslint-disable-next-line max-params

--- a/test/derive-user-scope.unit-spec.ts
+++ b/test/derive-user-scope.unit-spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Release blocker (audit 2026-08-21 P0): the per-user scope of the
+ * grounding turns must survive derivation. Pins the scope rule of
+ * buildDerivedRows (global / single-user / cross-user) and the
+ * rollup-pool exclusion of user-scoped rows in accumulateLanded.
+ */
+import { buildDerivedRows } from '../src/admin/derive-row-builder';
+import { accumulateLanded, type RollupMember } from '../src/admin/aspect-rollups';
+import type { EpisodeRow } from '../src/episodes/session-window';
+import type { DerivedProposition } from '../src/admin/deriver-client';
+
+const SESSION: EpisodeRow[] = [
+  {
+    id: 'episode:a0',
+    speaker: 'Alice',
+    text: 'my private plan',
+    occurredAt: '2026-08-01T10:00:00Z',
+    userId: 'user-a',
+  },
+  {
+    id: 'episode:g1',
+    speaker: 'Bot',
+    text: 'a tenant-global turn',
+    occurredAt: '2026-08-01T10:01:00Z',
+  },
+  {
+    id: 'episode:b2',
+    speaker: 'Bob',
+    text: 'my other private plan',
+    occurredAt: '2026-08-01T10:02:00Z',
+    userId: 'user-b',
+  },
+] as EpisodeRow[];
+
+const NS = { final: 'wd-t', staging: 'wd-t.staging' } as never;
+
+function prop(turns: number[]): DerivedProposition {
+  return {
+    subject: 'Alice',
+    aspect: 'plans',
+    proposition: 'a derived plan',
+    occurred_on: null,
+    turns,
+  } as DerivedProposition;
+}
+
+function build(turnsPerProp: number[][]) {
+  return buildDerivedRows({
+    resolved: turnsPerProp.map((turns) => ({
+      p: prop(turns),
+      entityId: 'knowledge_entity:alice',
+    })),
+    vectors: turnsPerProp.map(() => [1, 0]),
+    sessionDate: new Date('2026-08-01T00:00:00Z'),
+    session: SESSION,
+    ns: NS,
+    conversationId: 'conv-1',
+  });
+}
+
+describe('derive user scope (audit 2026-08-21 P0)', () => {
+  it('grounded only in global turns → tenant-global row', () => {
+    const [row] = build([[1]]);
+    expect(row.userId).toBeUndefined();
+    expect(row.crossUserScope).toBe(false);
+  });
+
+  it("grounded in one user's turns (global ride-along ok) → that user's row", () => {
+    const [own, mixed] = build([[0], [0, 1]]);
+    expect(own.userId).toBe('user-a');
+    expect(own.crossUserScope).toBe(false);
+    expect(mixed.userId).toBe('user-a');
+    expect(mixed.crossUserScope).toBe(false);
+  });
+
+  it('grounded in turns of two users → poisoned for any scope (crossUserScope)', () => {
+    const [row] = build([[0, 2]]);
+    expect(row.userId).toBeUndefined();
+    expect(row.crossUserScope).toBe(true);
+  });
+
+  it('rollup/compose pools never accept user-scoped rows', () => {
+    const rows = build([[1], [0]]);
+    const pool: RollupMember[] = [];
+    accumulateLanded(pool, rows, {
+      outcomes: rows.map(() => ({ outcome: 'INSERTED' })),
+    });
+    expect(pool).toHaveLength(1);
+    expect(pool[0].entityId).toBe('knowledge_entity:alice');
+  });
+});

--- a/test/fact-provenance.unit-spec.ts
+++ b/test/fact-provenance.unit-spec.ts
@@ -467,3 +467,121 @@ describe('FACTS_API_ENABLED gate (controller)', () => {
     });
   });
 });
+
+/**
+ * Release blocker (audit 2026-08-21 P0): retract used to mutate with no
+ * ownership fence. These pin the fence matrix — every deny throws
+ * BEFORE any mutation reaches the DB (the stub records queries; a
+ * SELECT is the only shape a denied retract may issue).
+ */
+describe('FactsService.retract() — ownership fence', () => {
+  const WRITE = ['brain:write'] as BrainScope[];
+  const WRITE_ADMIN = ['brain:write', 'brain:admin'] as BrainScope[];
+  const dto = { reason: 'test' } as RetractFactDto;
+
+  const USER_FACT_U2: Row = {
+    id: 'knowledge_fact:f1',
+    predicate: 'preference',
+    object: 'private note',
+    status: 'active',
+    userId: 'u2',
+    source: { vertical: 'dialogue', recorder: 'r' },
+  };
+
+  const onlySelects = (queries: Recorded[]) =>
+    queries.every((q) => q.sql.trimStart().toUpperCase().startsWith('SELECT'));
+
+  it("user-bound token: another user's fact → 404, zero mutations", async () => {
+    const { svc, queries } = makeStack({
+      factsByCompany: { co_a: [USER_FACT_U2] },
+    });
+    await runWithRequestContext(
+      { correlationId: 'test', authUserId: 'u1' },
+      async () => {
+        await expect(
+          svc.retract({
+            companyId: 'co_a',
+            factId: 'f1',
+            dto,
+            callerScopes: WRITE,
+          }),
+        ).rejects.toThrow(NotFoundException);
+      },
+    );
+    expect(onlySelects(queries)).toBe(true);
+  });
+
+  it('user-bound token: tenant-global fact without brain:admin → 403, zero mutations', async () => {
+    const { svc, queries } = makeStack({
+      factsByCompany: { co_a: [{ ...FACT_GLOBAL }] },
+    });
+    await runWithRequestContext(
+      { correlationId: 'test', authUserId: 'u1' },
+      async () => {
+        await expect(
+          svc.retract({
+            companyId: 'co_a',
+            factId: 'f1',
+            dto,
+            callerScopes: WRITE,
+          }),
+        ).rejects.toThrow('requires an M2M token or brain:admin');
+      },
+    );
+    expect(onlySelects(queries)).toBe(true);
+  });
+
+  it('user-bound token: OWN fact passes the fence (mutation reached)', async () => {
+    const { svc } = makeStack({
+      factsByCompany: { co_a: [{ ...USER_FACT_U2, userId: 'u1' }] },
+    });
+    await runWithRequestContext(
+      { correlationId: 'test', authUserId: 'u1' },
+      async () => {
+        // The stub has no dbMerge surface — reaching the mutation step
+        // (past every fence) throws a non-HTTP error, which is the
+        // assertion: the fence did NOT stop an owner.
+        await expect(
+          svc.retract({
+            companyId: 'co_a',
+            factId: 'f1',
+            dto,
+            callerScopes: WRITE,
+          }),
+        ).rejects.not.toThrow(NotFoundException);
+      },
+    );
+  });
+
+  it('user-bound token + brain:admin: tenant-global fact passes the fence', async () => {
+    const { svc } = makeStack({
+      factsByCompany: { co_a: [{ ...FACT_GLOBAL }] },
+    });
+    await runWithRequestContext(
+      { correlationId: 'test', authUserId: 'u1' },
+      async () => {
+        await expect(
+          svc.retract({
+            companyId: 'co_a',
+            factId: 'f1',
+            dto,
+            callerScopes: WRITE_ADMIN,
+          }),
+        ).rejects.not.toThrow(NotFoundException);
+      },
+    );
+  });
+
+  it('scope-fenced predicate → 404 for callers without the scope, zero mutations', async () => {
+    const { svc, queries } = makeStack({
+      factsByCompany: { co_a: [{ ...FACT_GLOBAL }] },
+      policy: {
+        preference: { requiresScope: 'brain:read_pii', piiClass: 'none' },
+      },
+    });
+    await expect(
+      svc.retract({ companyId: 'co_a', factId: 'f1', dto, callerScopes: WRITE }),
+    ).rejects.toThrow(NotFoundException);
+    expect(onlySelects(queries)).toBe(true);
+  });
+});

--- a/test/rerank-trust-band.unit-spec.ts
+++ b/test/rerank-trust-band.unit-spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Release blocker (audit 2026-08-21 P1): reranker priority used to
+ * override the fused rankScore ORDER unconditionally, erasing the
+ * trust prior (SEARCH_TRUST_BETA rides the fused score). Pins the band
+ * contract: rerank stages reorder only WITHIN a fused-score band; a
+ * gap wider than the band survives; band 0 restores the old behavior.
+ */
+import { SearchRerankService } from '../src/search/search-rerank.service';
+import type { EntityBucket } from '../src/search/internals/types';
+import type { PipelineContext } from '../src/search/pipeline-context';
+import type { RerankerService } from '../src/ai/reranker.service';
+import type { CrossEncoderService } from '../src/ai/cross-encoder.service';
+
+function bucket(entityId: string, rankScore: number): EntityBucket {
+  return {
+    entityId,
+    rankScore,
+    facts: [
+      {
+        score: rankScore,
+        row: {
+          predicate: 'p',
+          object: `fact of ${entityId}`,
+          entity: { type: 'other', canonicalName: entityId },
+        },
+      },
+    ],
+  } as unknown as EntityBucket;
+}
+
+/** Cross-encoder stub that always INVERTS the candidate order. */
+const invertingCrossEncoder = {
+  isEnabled: () => true,
+  isLocalOnly: () => false,
+  rerank: async (_q: string, inputs: unknown[]) =>
+    inputs.map((_, i) => inputs.length - 1 - i),
+} as unknown as CrossEncoderService;
+
+const disabledReranker = {
+  isEnabled: () => false,
+} as unknown as RerankerService;
+
+function ctxWith(trustBand: number): PipelineContext {
+  return {
+    limit: 5,
+    dto: { query: 'test query' },
+    tuning: { rerankTrustBand: trustBand, rerankSkipMargin: 0 },
+  } as unknown as PipelineContext;
+}
+
+async function run(trustBand: number): Promise<string[]> {
+  const svc = new SearchRerankService(disabledReranker, invertingCrossEncoder);
+  // Trusted source 0.471 vs neutral 0.325 — the exact audit repro: the
+  // trust factor moved the score, the cross-encoder erased the order.
+  const byEntity = new Map([
+    ['trusted', bucket('trusted', 0.471)],
+    ['neutral', bucket('neutral', 0.325)],
+  ]);
+  const out = await svc.runRerankStage({ byEntity, ctx: ctxWith(trustBand) });
+  return out.map((b) => b.entityId);
+}
+
+describe('rerank trust band (audit 2026-08-21 P1)', () => {
+  it('a fused-score gap wider than the band survives the cross-encoder', async () => {
+    await expect(run(0.1)).resolves.toEqual(['trusted', 'neutral']);
+  });
+
+  it('band 0 restores absolute reranker priority (documented off switch)', async () => {
+    await expect(run(0)).resolves.toEqual(['neutral', 'trusted']);
+  });
+
+  it('within one band the cross-encoder order wins', async () => {
+    const svc = new SearchRerankService(disabledReranker, invertingCrossEncoder);
+    const byEntity = new Map([
+      ['a', bucket('a', 0.4201)],
+      ['b', bucket('b', 0.4209)],
+    ]);
+    const out = await svc.runRerankStage({ byEntity, ctx: ctxWith(0.1) });
+    // The stage feeds the CE a score-sorted window [b, a]; the stub
+    // inverts it to [a, b]. Same 0.1 band → that CE order stands.
+    expect(out.map((x) => x.entityId)).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
Closes the three NO-GO blockers from the external release audit (2026-08-21).

## Blocker 1 (P0) — derived facts dropped the episode userId

An episode ingested user-scoped (INGEST_EPISODE_ONLY) derived into a **tenant-global** fact visible to every other user. Fix — scope rule per proposition, from its grounding turns:

- grounded only in global turns → tenant-global fact;
- grounded in exactly one user's turns (global turns may ride along) → **that user's fact**;
- grounded in turns of two or more users → **dropped with a warn** (poisoned for any single scope; the resolved/rows arrays stay index-aligned for the rollup pools).

`userId` threads through `resolveDerivedBatch` into `fn::resolve_fact`'s `$user_id` (0055 — conflict resolution stays scope-local). User-scoped rows are excluded from the tenant-global rollup/compose pools (aggregates can't launder one user's facts into everyone's view).

## Blocker 2 (P0) — retract had no ownership fence

A user-bound `brain:write` token could retract any fact by id (root `withCompany`, no userId read, no row policy). Now, before any mutation:

- another user's fact → **404** (existence never leaks; test pins zero non-SELECT queries);
- a tenant-global fact under a user-bound token → **403** unless `brain:admin` (the fact is readable, so 403 leaks nothing new); M2M unrestricted;
- registry row policy applies — an unseeable predicate is an unretractable one (404).

In-process legacy callers (no request context) behave as before. Retract stays flag-independent (GDPR path) — unchanged.

## Blocker 3 (P1) — reranker priority erased the trust prior

`fact-centric` gave the reranker permutation absolute precedence over fused score, so `SEARCH_TRUST_BETA` moved the score but could never move the ranking — the deterministic `fact-trust-ranking` e2e failure (0.471/1.45× losing to 0.325/1×). New contract, applied to BOTH rerank stages (cross-encoder and LLM):

> a rerank stage may reorder buckets only **within a fused-score band** (`SEARCH_RERANK_TRUST_BAND`, default 0.1); a gap wider than the band — trust priors included — survives every rerank stage. `0` disables the band and restores absolute reranker priority.

Band sort is `(band desc, reranker position asc)` — deterministic and transitive, unlike a pairwise margin comparator. Not a weakened test: the code contract changed, the test is untouched.

## Also

`.env.example` catches up on the five flag-gated surfaces (FACTS_API, USER_PROFILE_API, EPISODE_SUBSCRIPTIONS, PROJECTIONS_API, RETRIEVAL_DERIVED_VERSIONS with the complementary-pair-only warning) + the new band knob.

## Gates

- unit **2147** (new: derive-scope matrix ×4, retract fence ×5, trust band ×3), socket **106**
- **e2e 83/83 suites, 348/348 tests** — the auditor's release gate, `fact-trust-ranking` now green
- eslint clean, tsc clean, flag-budget + config-catalog-truth green (no new engine flags; SEARCH_RERANK_TRUST_BAND is a numeric tuning knob)

Follow-up branch (next): lease fencing before promotion, single-transaction facts+digest flip, user-profile global-row tightening. USER_PROFILE_API_ENABLED and multiworld union remain default-off per the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB