### PR TITLE
fix(deriver,users): lease fencing, single-transaction flip, strict profile scope

### DIFF
--- a/docs/user-profile-api.md
+++ b/docs/user-profile-api.md
@@ -24,8 +24,13 @@ a flip needs no restart.
 - User-scope pin (migration 0055 semantics): an M2M credential may fetch
   any user's profile; a user-bound token (auth-service token with
   `org` + `sub`) may fetch only its own — a mismatching `:userId` is 403.
-- Visibility is the fact-lane read contract: tenant-global rows plus the
-  named user's personal rows (`userId IS NONE OR userId = $user`), the
+- Visibility is STRICT user scope (audit 2026-08-21): only the named
+  user's personal rows (`userId = $user`) — a tenant-global row is
+  knowledge about an arbitrary entity, not established to be about this
+  user, and never enters a profile. The user's own derived facts carry
+  `userId` by construction (the deriver's grounding-turn scope rule).
+  Tenant-global rows with an explicit subject/entity binding to the
+  user are the documented v2. The rest of the read contract: the
   pinned derived world unioned with the legacy namespace
   (`derivedVersion IS NONE OR <read-pin fence>`), lifecycle-closed rows
   excluded (retracted / superseded / compacted / corroborating /

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1180,7 +1180,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
         runtimeMutable: true,
         isBooleanFlag: false,
         description:
-          'Per-tenant retrieval-profile overrides: JSON object mapping companyId → partial profile ({genre, verbatimEvidence, insightEvidence, timelineEvidence, coverageScanMode, coverageLexMode, dateAnchoring, temporalMode, abstentionCalibration, abstentionMinTopScore, abstentionMinEvidence, factBudget, quotesPerPrompt, sourceExcerptsCap, segmentTopK, segmentRerank, extraEvidenceCap, wideProbe, wideProbeLimit, scanHnswEf, scanHnswOverfetch, entityExpansion, salienceScoring, updateStoryRendering, orderingFrame, verifierTopicCoverage, lanes:[…]}). Resolved once per request in the auth guard.',
+          'Per-tenant retrieval-profile overrides: JSON object mapping companyId → partial profile. Every field of the RetrievalProfile is overridable — the authoritative field list is the wire contract (src/contracts/admin/retrieval-profile.schema.ts, pinned key-for-key against the profile by the contracts gate) rather than a copy here that drifts. Precedence: overlay field > explicit env > genre preset > code default; an overlay `genre` re-derives that genre’s preset base first (see genre-presets.ts). Resolved once per request in the auth guard.',
       },
       {
         key: 'SYNTHESIZE_EXTRA_EVIDENCE_CAP',

--- a/src/admin/derive-staging.ts
+++ b/src/admin/derive-staging.ts
@@ -98,6 +98,12 @@ export function deriveLeaseName(companyId: string, version: string): string {
 
 export interface DeriveLease {
   name: string;
+  /** True once a heartbeat renewal definitively failed (`tryAcquire`
+   *  returned false) — a competing pod may hold the lease. Promotion
+   *  MUST check this fence before flipping staging → final (audit
+   *  2026-08-21: a lost lease used to be log-only, and the run kept
+   *  going all the way through promotion). */
+  isLost(): boolean;
   /** Idempotent; call in finally. */
   release(): Promise<void>;
 }
@@ -128,6 +134,7 @@ export async function acquireDeriveLease(args: {
   if (inFlight.has(key)) throw conflict();
   inFlight.add(key);
   let heartbeat: NodeJS.Timeout | undefined;
+  let lost = false;
   try {
     if (lease) {
       const got = await lease.tryAcquire(name, LEASE_TTL_SECONDS);
@@ -136,15 +143,20 @@ export async function acquireDeriveLease(args: {
         void lease.tryAcquire(name, LEASE_TTL_SECONDS).then(
           (ok) => {
             if (!ok) {
-              // Cannot safely abort a run mid-LLM-call; surface loudly —
-              // a competing pod may now start a derive for this pair.
+              // Cannot safely abort a run mid-LLM-call; mark the fence —
+              // promotion checks isLost() and refuses to flip (a
+              // competing pod may be building the same staging).
+              lost = true;
               logger.warn(
                 `derive lease '${name}' lost mid-run — a concurrent ` +
-                  `derive may start on another pod`,
+                  `derive may start on another pod; promotion is fenced`,
               );
             }
           },
           (e: unknown) =>
+            // Transient heartbeat errors (network blips) do NOT set the
+            // fence — only a definitive "someone else holds it" does;
+            // the lease TTL is the backstop for a truly dead pod.
             logger.warn(
               `derive lease heartbeat failed: ${(e as Error).message}`,
             ),
@@ -159,6 +171,7 @@ export async function acquireDeriveLease(args: {
   let released = false;
   return {
     name,
+    isLost: () => lost,
     release: async () => {
       if (released) return;
       released = true;
@@ -219,6 +232,9 @@ export async function promoteStaging(
   opts: { conversationId?: string } = {},
 ): Promise<void> {
   const conv = opts.conversationId;
+  // Audit 2026-08-21: facts and digests flip in ONE transaction — the
+  // old two-transaction shape could commit the fact-world and then fail
+  // the digest flip, leaving a new fact-world narrated by old digests.
   await runTransaction(db as unknown as Surreal, (tx) => {
     tx.bind('final', ns.final).bind('staging', ns.staging);
     if (conv) {
@@ -247,20 +263,6 @@ export async function promoteStaging(
           `UPDATE knowledge_fact SET derivedVersion = $final
             WHERE derivedVersion = $staging AND source.conversationId = $conv`,
         )
-        .add(`RETURN true`);
-    } else {
-      tx.add(`DELETE knowledge_fact WHERE derivedVersion = $final`)
-        .add(
-          `UPDATE knowledge_fact SET derivedVersion = $final
-            WHERE derivedVersion = $staging`,
-        )
-        .add(`RETURN true`);
-    }
-  });
-  await runTransaction(db as unknown as Surreal, (tx) => {
-    tx.bind('final', ns.final).bind('staging', ns.staging);
-    if (conv) {
-      tx.bind('conv', conv)
         .add(
           `DELETE conversation_digest
             WHERE derivedVersion = $final AND conversationId = $conv`,
@@ -271,7 +273,12 @@ export async function promoteStaging(
         )
         .add(`RETURN true`);
     } else {
-      tx.add(`DELETE conversation_digest WHERE derivedVersion = $final`)
+      tx.add(`DELETE knowledge_fact WHERE derivedVersion = $final`)
+        .add(
+          `UPDATE knowledge_fact SET derivedVersion = $final
+            WHERE derivedVersion = $staging`,
+        )
+        .add(`DELETE conversation_digest WHERE derivedVersion = $final`)
         .add(
           `UPDATE conversation_digest SET derivedVersion = $final
             WHERE derivedVersion = $staging`,

--- a/src/admin/window-deriver.service.ts
+++ b/src/admin/window-deriver.service.ts
@@ -64,6 +64,7 @@ import {
   promoteStaging,
   stagingNamespace,
   sweepStagingRows,
+  type DeriveLease,
   type DeriveNamespace,
 } from './derive-staging';
 import { buildDerivedRows, collectRollupPool } from './derive-row-builder';
@@ -193,7 +194,14 @@ export class WindowDeriverService {
       logger: this.logger,
     });
     try {
-      return await this.runStaged({ companyId, version, ns, opts, activePin });
+      return await this.runStaged({
+        companyId,
+        version,
+        ns,
+        opts,
+        activePin,
+        lease,
+      });
     } finally {
       await lease.release();
     }
@@ -207,8 +215,10 @@ export class WindowDeriverService {
     ns: DeriveNamespace;
     opts: { conversationId?: string; activate?: boolean };
     activePin: string | undefined;
+    /** Promotion fence (audit 2026-08-21): checked before the flip. */
+    lease: DeriveLease;
   }): Promise<DeriveRunResult> {
-    const { companyId, version, ns, opts, activePin } = args;
+    const { companyId, version, ns, opts, activePin, lease } = args;
     const result: DeriveRunResult = {
       conversations: 0,
       sessions: 0,
@@ -283,21 +293,34 @@ export class WindowDeriverService {
       }
       return result;
     }
-    // Atomic flip: staging → final (DELETE final + UPDATE staging, one
-    // BEGIN/COMMIT per table). A run that attempted no conversation has
-    // nothing to promote — flipping would wipe the final world with an
-    // empty staging namespace.
+    // Audit 2026-08-21 (lease fencing): a lease definitively lost
+    // mid-run means a competing pod may be building — or may already
+    // have swept — this very staging namespace. Promoting would flip a
+    // world of unknown provenance; refuse, mark failed, leave staging
+    // for forensics (the next run's sweep reaps it).
+    if (lease.isLost()) {
+      await this.registry?.fail({ companyId, name: 'facts', version });
+      this.logger.error(
+        `derive '${version}' for ${companyId}: lease lost mid-run — ` +
+          `promotion fenced; staging left in place, world NOT flipped`,
+      );
+      result.status = 'failed';
+      return result;
+    }
+    // Atomic flip: staging → final (DELETE final + UPDATE staging,
+    // facts + digests in ONE BEGIN/COMMIT). A run that attempted no
+    // conversation has nothing to promote — flipping would wipe the
+    // final world with an empty staging namespace.
     if (result.conversations > 0) {
       try {
         await this.surreal.withCompany(companyId, (db) =>
           promoteStaging(db, ns, { conversationId: opts.conversationId }),
         );
       } catch (e) {
-        // Facts and digests flip in separate transactions; a failure
-        // here can leave facts promoted with digests still staged. The
-        // registry marks the world failed either way, and staging is
-        // LEFT in place (forensics) — the next run for this version
-        // sweeps it.
+        // The single-transaction flip failed whole: final world
+        // untouched, staging intact. The registry marks the world
+        // failed, and staging is LEFT in place (forensics) — the next
+        // run for this version sweeps it.
         await this.registry?.fail({ companyId, name: 'facts', version });
         throw e;
       }

--- a/src/users/user-profile.service.ts
+++ b/src/users/user-profile.service.ts
@@ -181,9 +181,15 @@ export class UserProfileService {
     const worldClause = `(derivedVersion IS NONE OR ${fence.clause.replace(/^AND\s+/, '')})`;
 
     const clauses = [
-      // User scope (0055) — the search where-builder idiom: global +
-      // this user's rows. Derived typed atoms ride the global half.
-      `(userId IS NONE OR userId = $scopeUserId)`,
+      // Audit 2026-08-21: STRICT user scope — a profile asserts facts
+      // OF this user, and a tenant-global row is any knowledge about
+      // any entity in the tenant, not established to be about them.
+      // Derived facts grounded in this user's turns carry userId by
+      // construction (derive-row-builder scope rule), so nothing of
+      // the user's own derived memory is lost by the strict filter.
+      // Global rows return only with an explicit subject/entity
+      // binding — the documented v2.
+      `userId = $scopeUserId`,
       worldClause,
       // Lifecycle "actual now" closure — copied from the search
       // where-builder (incl. the future-dated-supersede gap rule).

--- a/test/derive-staging.unit-spec.ts
+++ b/test/derive-staging.unit-spec.ts
@@ -6,6 +6,7 @@ import {
 } from '../src/admin/window-deriver.service';
 import {
   STAGING_SUFFIX,
+  acquireDeriveLease,
   deriveLeaseName,
   promoteStaging,
   stagingNamespace,
@@ -175,17 +176,19 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
       }
     }
     const flips = queries.filter((q) => q.sql.includes('BEGIN TRANSACTION'));
-    expect(flips.length).toBe(2); // knowledge_fact, then conversation_digest
+    // Audit 2026-08-21: facts AND digests flip in ONE transaction — a
+    // committed fact-world can never be narrated by old digests.
+    expect(flips.length).toBe(1);
     expect(flips[0].sql).toContain(
       'DELETE knowledge_fact WHERE derivedVersion = $final',
     );
     expect(flips[0].sql).toContain(
       'UPDATE knowledge_fact SET derivedVersion = $final',
     );
-    expect(flips[1].sql).toContain(
+    expect(flips[0].sql).toContain(
       'DELETE conversation_digest WHERE derivedVersion = $final',
     );
-    expect(flips[1].sql).toContain(
+    expect(flips[0].sql).toContain(
       'UPDATE conversation_digest SET derivedVersion = $final',
     );
     for (const flip of flips) {
@@ -295,7 +298,7 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
     });
     const res = await svc.run('co_x');
     expect(res.status).toBe('ok');
-    expect(events).toEqual(['begin', 'flip', 'flip', 'complete']);
+    expect(events).toEqual(['begin', 'flip', 'complete']);
   });
 
   it('targeted re-derive flips only that conversation and revives its supersede losers', async () => {
@@ -303,7 +306,7 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
     const res = await svc.run('co_x', { conversationId: 'conv-1' });
     expect(res.conversations).toBe(1);
     const flips = queries.filter((q) => q.sql.includes('BEGIN TRANSACTION'));
-    expect(flips.length).toBe(2);
+    expect(flips.length).toBe(1);
     // Conversation-scoped DELETE/UPDATE — a targeted flip must never
     // wipe the other conversations of the final world.
     expect(flips[0].sql).toContain('source.conversationId = $conv');
@@ -314,7 +317,8 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
     // now runs against the FINAL world at flip time.
     expect(flips[0].sql).toContain("status = 'superseded'");
     expect(flips[0].sql).toContain('supersededBy IN');
-    expect(flips[1].sql).toContain('conversationId = $conv');
+    // Digest slice flips inside the SAME transaction.
+    expect(flips[0].sql).toContain('DELETE conversation_digest');
     expect(flips[0].params?.conv).toBe('conv-1');
   });
 });
@@ -434,23 +438,27 @@ describe('promoteStaging / sweepStagingRows primitives', () => {
     return { queries, db };
   }
 
-  it('full flip: one DELETE-then-UPDATE transaction per table', async () => {
+  it('full flip: facts + digests in ONE DELETE-then-UPDATE transaction', async () => {
     const { db, queries } = mockDb();
     await promoteStaging(db, stagingNamespace('wd-v9'));
-    expect(queries).toHaveLength(2);
-    for (const q of queries) {
-      expect(q.sql).toContain('BEGIN TRANSACTION');
-      expect(q.sql).toContain('COMMIT TRANSACTION');
-      expect(q.params).toMatchObject({
-        final: 'wd-v9',
-        staging: 'wd-v9.staging',
-      });
-      // DELETE of the final world precedes the promoting UPDATE inside
-      // the same transaction — readers see old world or new, never both.
-      expect(q.sql.indexOf('DELETE')).toBeLessThan(q.sql.indexOf('UPDATE'));
-    }
-    expect(queries[0].sql).toContain('knowledge_fact');
-    expect(queries[1].sql).toContain('conversation_digest');
+    // Audit 2026-08-21: one transaction covers BOTH tables — a failure
+    // can never leave a new fact-world narrated by old digests.
+    expect(queries).toHaveLength(1);
+    const q = queries[0];
+    expect(q.sql).toContain('BEGIN TRANSACTION');
+    expect(q.sql).toContain('COMMIT TRANSACTION');
+    expect(q.params).toMatchObject({
+      final: 'wd-v9',
+      staging: 'wd-v9.staging',
+    });
+    // Per table, the DELETE of the final world precedes the promoting
+    // UPDATE — readers see old world or new, never both.
+    expect(q.sql.indexOf('DELETE knowledge_fact')).toBeLessThan(
+      q.sql.indexOf('UPDATE knowledge_fact'),
+    );
+    expect(q.sql.indexOf('DELETE conversation_digest')).toBeLessThan(
+      q.sql.indexOf('UPDATE conversation_digest'),
+    );
   });
 
   it('targeted flip scopes every statement to the conversation', async () => {
@@ -458,7 +466,7 @@ describe('promoteStaging / sweepStagingRows primitives', () => {
     await promoteStaging(db, stagingNamespace('wd-v9'), {
       conversationId: 'conv-7',
     });
-    expect(queries).toHaveLength(2);
+    expect(queries).toHaveLength(1);
     expect(queries[0].params?.conv).toBe('conv-7');
     // Revive of cross-conversation supersede losers runs first, inside
     // the same transaction as the replace.
@@ -466,7 +474,10 @@ describe('promoteStaging / sweepStagingRows primitives', () => {
       queries[0].sql.indexOf('DELETE knowledge_fact'),
     );
     expect(queries[0].sql).toContain('source.conversationId = $conv');
-    expect(queries[1].sql).toContain('conversationId = $conv');
+    // Digest slice flips inside the SAME transaction, same scoping.
+    expect(queries[0].sql).toContain(
+      'DELETE conversation_digest\n            WHERE derivedVersion = $final AND conversationId = $conv',
+    );
   });
 
   it('sweep probes before deleting and scopes to the staging namespace', async () => {
@@ -529,5 +540,54 @@ describe('gc staging protection', () => {
     // The in-flight (registry-protected) world keeps its staging rows;
     // the crashed orphan whose base is gone is reaped.
     expect(res.deleted).toEqual({ 'wd-old.staging': 7 });
+  });
+});
+
+/**
+ * Lease fencing (audit 2026-08-21): a heartbeat renewal that
+ * DEFINITIVELY fails (tryAcquire → false: a competing pod holds the
+ * lease) sets the isLost fence promotion checks before flipping.
+ * Transient heartbeat ERRORS (network blips) do not set it — the lease
+ * TTL is the backstop for a truly dead pod.
+ */
+describe('derive lease fencing (isLost)', () => {
+  afterEach(() => jest.useRealTimers());
+
+  async function acquireWith(heartbeat: () => Promise<boolean>) {
+    jest.useFakeTimers();
+    let first = true;
+    const lease = {
+      tryAcquire: async () => {
+        if (first) {
+          first = false;
+          return true;
+        }
+        return heartbeat();
+      },
+      release: async () => undefined,
+    } as unknown as import('../src/jobs/leader-lease.service').LeaderLeaseService;
+    return acquireDeriveLease({
+      companyId: 'co_fence',
+      version: 'wd-fence',
+      lease,
+      logger: { warn: () => undefined },
+    });
+  }
+
+  it('definitive heartbeat loss sets the fence', async () => {
+    const handle = await acquireWith(async () => false);
+    expect(handle.isLost()).toBe(false);
+    await jest.advanceTimersByTimeAsync(200_001);
+    expect(handle.isLost()).toBe(true);
+    await handle.release();
+  });
+
+  it('a transient heartbeat error does NOT set the fence', async () => {
+    const handle = await acquireWith(async () => {
+      throw new Error('network blip');
+    });
+    await jest.advanceTimersByTimeAsync(200_001);
+    expect(handle.isLost()).toBe(false);
+    await handle.release();
   });
 });

--- a/test/user-profile.unit-spec.ts
+++ b/test/user-profile.unit-spec.ts
@@ -98,8 +98,12 @@ describe('UserProfileService — SQL contract', () => {
     const svc = makeService({ rows: [], capture, readPin: 'wd-v1' });
     await svc.getProfile({ ...baseOpts });
     const { sql, params } = capture[0];
-    // User scope: fail-closed idiom — global + this user's rows.
-    expect(sql).toContain('(userId IS NONE OR userId = $scopeUserId)');
+    // Audit 2026-08-21: STRICT user scope — tenant-global rows are
+    // knowledge about arbitrary entities, not facts OF this user, and
+    // must never leak into a profile. The user's own derived facts
+    // carry userId by construction (derive-row-builder scope rule).
+    expect(sql).toContain('userId = $scopeUserId');
+    expect(sql).not.toContain('userId IS NONE');
     expect(params?.scopeUserId).toBe('u1');
     // Combined world fence: legacy namespace UNION the pinned world.
     expect(sql).toContain(


### PR DESCRIPTION
The "important" (non-blocker) items from the external release audit, following #298.

## Lease fencing before promotion

A heartbeat renewal that **definitively** fails (`tryAcquire` → false: a competing pod holds the lease) now sets an `isLost` fence on the derive lease; promotion checks it and refuses to flip — the run fails loudly, the registry marks the world failed, staging stays in place for forensics (the next run's sweep reaps it). Transient heartbeat *errors* (network blips) do not set the fence — the lease TTL remains the backstop for a truly dead pod.

## Single-transaction promotion

Facts and digests flip in **one** BEGIN/COMMIT (both the full and the conversation-targeted shapes) — the old two-transaction shape could commit the fact-world and then fail the digest flip, leaving a new fact-world narrated by old digests. The derive-staging spec contract is updated accordingly (one flip transaction, per-table DELETE-before-UPDATE order pinned inside it).

## Strict user-profile scope

`GET /v1/users/:userId/profile` selects **only** `userId = $user` rows. A tenant-global row is knowledge about an arbitrary entity, not established to be about this user — it never enters a profile. Nothing of the user's own derived memory is lost: since #298, derived facts grounded in a user's turns carry `userId` by construction. Tenant-global rows with an explicit subject/entity binding are the documented v2. (`USER_PROFILE_API_ENABLED` remains default-off per the audit.)

## Config drift

`RETRIEVAL_PROFILE_OVERRIDES` catalog description now points at the wire contract (`src/contracts/admin/retrieval-profile.schema.ts`, pinned key-for-key by the contracts gate) as the authoritative field list instead of an inline copy that had drifted, and documents the preset-layer precedence.

## Gates

unit full green (derive-staging contract updated + 2 new `isLost` fence tests, 17/17), **e2e 83/83 suites / 348/348** on real Surreal, eslint clean, tsc clean.

Remaining from the audit, deliberately not here: multiworld union stays experimental & default-off (documented); landing lint warnings (54) are a separate cosmetic pass; release metadata lands via release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB