### PR TITLE
fix(deriver,search): fail-closed grounding scope, per-run staging fencing, trust band default off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -604,7 +604,9 @@ SEARCH_FACT_CENTRIC_BUDGET=48
 # Rolling user profile API (GET /v1/users/:userId/profile), deterministic v1.
 #USER_PROFILE_API_ENABLED=0
 # Rerank band contract (audit 2026-08-21 P1): rerankers reorder only within
-# this fused-score band; wider gaps (trust priors) survive. 0 disables.
+# this fused-score band; wider gaps (trust priors) survive. 0 (default) = off;
+# a non-zero band reshapes ranking even without trust — enable after a
+# benchmark/canary, alongside SEARCH_TRUST_BETA (measured contract: 0.1).
 #SEARCH_RERANK_TRUST_BAND=0.1
 # Eval-harness plumbing: admin keys may address another tenant per call via
 # X-Brain-Tenant (LongMemEval/BEAM per-question isolation); episode-only

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -331,7 +331,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       {
         key: 'SEARCH_RERANK_TRUST_BAND',
         category: 'search',
-        defaultValue: '0.1',
+        defaultValue: '0',
         runtimeMutable: false,
         isBooleanFlag: false,
         description:
@@ -340,7 +340,10 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
           '— trust priors above all, since SEARCH_TRUST_BETA rides the ' +
           'fused score — survives every rerank stage instead of being ' +
           'silently erased by reranker priority (audit 2026-08-21 P1). ' +
-          '0 disables the band and restores absolute reranker priority.',
+          '0 (default) disables the band; a non-zero band reshapes ' +
+          'ranking even without trust, so enable after a benchmark/' +
+          'canary and always alongside SEARCH_TRUST_BETA — 0.1 is the ' +
+          'measured contract the fact-trust e2e pins.',
       },
       {
         key: 'SEARCH_TOKEN_COUNT_OFFLOAD',

--- a/src/admin/derive-row-builder.ts
+++ b/src/admin/derive-row-builder.ts
@@ -103,6 +103,12 @@ export function buildDerivedRows({
     const groundingTurns = p.turns.filter(
       (t) => t >= 0 && t < session.length,
     );
+    // Fail-closed (audit 2026-08-21 P0 round 2): a proposition with NO
+    // turns, or with ANY out-of-range index, has unreliable grounding —
+    // its scope cannot be trusted, so the row is dropped rather than
+    // published tenant-global (groundingInvalid; the caller filters).
+    const groundingInvalid =
+      p.turns.length === 0 || groundingTurns.length !== p.turns.length;
     const scopeUsers = [
       ...new Set(
         groundingTurns
@@ -126,6 +132,7 @@ export function buildDerivedRows({
     return {
       userId: scopeUsers.length === 1 ? scopeUsers[0] : undefined,
       crossUserScope: scopeUsers.length > 1,
+      groundingInvalid,
       entityId: subjectEntity,
       predicate: aspect || 'other',
       object: p.proposition,

--- a/src/admin/derive-staging.ts
+++ b/src/admin/derive-staging.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import type { Surreal } from 'surrealdb';
 import { runTransaction } from '../db/surreal.service';
 import type { LeaderLeaseService } from '../jobs/leader-lease.service';
@@ -48,12 +48,25 @@ export const STAGING_SUFFIX = '.staging';
 export interface DeriveNamespace {
   /** The version readers pin — untouched until the flip. */
   final: string;
-  /** `<final>.staging` — the only namespace a run writes into. */
+  /** `<final>.staging.<runToken>` — the only namespace THIS run writes
+   *  into. Per-run unique (audit 2026-08-21 P1 round 2): even if the
+   *  lease fails open — heartbeat errors past the TTL, a competing pod
+   *  acquiring — two runs can never interleave rows in one staging
+   *  namespace; each flip promotes an internally consistent world. */
   staging: string;
 }
 
-export function stagingNamespace(version: string): DeriveNamespace {
-  return { final: version, staging: `${version}${STAGING_SUFFIX}` };
+export function stagingNamespace(
+  version: string,
+  runToken?: string,
+): DeriveNamespace {
+  const suffix = runToken ? `${STAGING_SUFFIX}.${runToken}` : STAGING_SUFFIX;
+  return { final: version, staging: `${version}${suffix}` };
+}
+
+/** Short per-run staging token — see DeriveNamespace.staging. */
+export function newRunToken(): string {
+  return randomUUID().slice(0, 8);
 }
 
 /** Narrow query-only view of the scoped connection (same shape the
@@ -98,11 +111,11 @@ export function deriveLeaseName(companyId: string, version: string): string {
 
 export interface DeriveLease {
   name: string;
-  /** True once a heartbeat renewal definitively failed (`tryAcquire`
-   *  returned false) — a competing pod may hold the lease. Promotion
-   *  MUST check this fence before flipping staging → final (audit
-   *  2026-08-21: a lost lease used to be log-only, and the run kept
-   *  going all the way through promotion). */
+  /** True once a heartbeat renewal failed for ANY reason — a
+   *  definitive loss (`tryAcquire` → false: a competing pod holds it)
+   *  or an error (fail-closed, audit 2026-08-21 round 2: an erroring
+   *  heartbeat past the TTL is indistinguishable from a lost lease).
+   *  Promotion MUST check this fence before flipping staging → final. */
   isLost(): boolean;
   /** Idempotent; call in finally. */
   release(): Promise<void>;
@@ -145,7 +158,7 @@ export async function acquireDeriveLease(args: {
             if (!ok) {
               // Cannot safely abort a run mid-LLM-call; mark the fence —
               // promotion checks isLost() and refuses to flip (a
-              // competing pod may be building the same staging).
+              // competing pod may be building the same version).
               lost = true;
               logger.warn(
                 `derive lease '${name}' lost mid-run — a concurrent ` +
@@ -153,13 +166,18 @@ export async function acquireDeriveLease(args: {
               );
             }
           },
-          (e: unknown) =>
-            // Transient heartbeat errors (network blips) do NOT set the
-            // fence — only a definitive "someone else holds it" does;
-            // the lease TTL is the backstop for a truly dead pod.
+          (e: unknown) => {
+            // Fail-closed (audit 2026-08-21 P1 round 2): ANY renewal
+            // uncertainty sets the fence — an erroring heartbeat past
+            // the TTL is indistinguishable from a lost lease. Per-run
+            // staging namespaces keep the data safe either way; the
+            // fence only refuses a flip we can no longer claim to own.
+            lost = true;
             logger.warn(
-              `derive lease heartbeat failed: ${(e as Error).message}`,
-            ),
+              `derive lease heartbeat failed — promotion fenced: ` +
+                `${(e as Error).message}`,
+            );
+          },
         );
       }, LEASE_HEARTBEAT_MS);
       heartbeat.unref?.();
@@ -210,6 +228,32 @@ export async function sweepStagingRows(
     await db.query(`DELETE ${table} WHERE derivedVersion = $version`, {
       version: staging,
     });
+  }
+}
+
+/**
+ * Reap EVERY staging namespace of a version — `<version>.staging` and
+ * all per-run `<version>.staging.<token>` orphans a crashed run
+ * stranded (the run-start GC, under the lease; per-run tokens mean the
+ * exact orphan names are unknowable in advance).
+ */
+export async function sweepStagingOrphans(
+  db: DeriveDb,
+  version: string,
+): Promise<void> {
+  const prefix = `${version}${STAGING_SUFFIX}`;
+  for (const table of STAGED_TABLES) {
+    const [rows] = await db.query<[Array<{ id: unknown }>]>(
+      `SELECT id FROM ${table}
+        WHERE string::starts_with(derivedVersion ?? '', $prefix) LIMIT 1`,
+      { prefix },
+    );
+    if (!rows || rows.length === 0) continue;
+    await db.query(
+      `DELETE ${table}
+        WHERE string::starts_with(derivedVersion ?? '', $prefix)`,
+      { prefix },
+    );
   }
 }
 

--- a/src/admin/deriver-client.ts
+++ b/src/admin/deriver-client.ts
@@ -685,7 +685,15 @@ function deriverRequest(
                   aspect: { type: 'string' },
                   proposition: { type: 'string' },
                   occurred_on: { type: ['string', 'null'] },
-                  turns: { type: 'array', items: { type: 'integer' } },
+                  // minItems 1 (audit 2026-08-21 P0): an ungrounded
+                  // proposition has no scope evidence — the row builder
+                  // fail-closed-drops it, and the schema refuses it at
+                  // the source.
+                  turns: {
+                    type: 'array',
+                    items: { type: 'integer' },
+                    minItems: 1,
+                  },
                   ...(sceneTrace
                     ? { scene: { type: ['string', 'null'] } }
                     : {}),

--- a/src/admin/window-deriver.service.ts
+++ b/src/admin/window-deriver.service.ts
@@ -61,8 +61,10 @@ import {
 import {
   STAGING_SUFFIX,
   acquireDeriveLease,
+  newRunToken,
   promoteStaging,
   stagingNamespace,
+  sweepStagingOrphans,
   sweepStagingRows,
   type DeriveLease,
   type DeriveNamespace,
@@ -186,7 +188,10 @@ export class WindowDeriverService {
     // staging namespace, a clean run promotes it in one flip, and a
     // per-(tenant, version) lease makes a concurrent derive fail fast
     // instead of interleaving rows — see derive-staging.ts.
-    const ns = stagingNamespace(version);
+    // Per-run staging token (audit 2026-08-21 P1 round 2): even a
+    // fenced-open lease race cannot interleave two runs' rows — each
+    // run owns a unique `<version>.staging.<token>` namespace.
+    const ns = stagingNamespace(version, newRunToken());
     const lease = await acquireDeriveLease({
       companyId,
       version,
@@ -240,9 +245,11 @@ export class WindowDeriverService {
     });
     try {
       await this.surreal.withCompany(companyId, async (db) => {
-        // Orphaned staging rows of a PRIOR crashed run for this version:
-        // the lease guarantees they have no live owner — sweep first.
-        await sweepStagingRows(db, ns.staging);
+        // Orphaned staging rows of PRIOR crashed runs for this version
+        // (any `<version>.staging*` namespace — per-run tokens make the
+        // exact names unknowable): the lease says they have no live
+        // owner — sweep first.
+        await sweepStagingOrphans(db, version);
         const convs = await this.episodes.conversationCounts(db);
         for (const conv of convs) {
           const conversationId = conv.conversationId;
@@ -711,19 +718,22 @@ export class WindowDeriverService {
         conversationId,
       });
       // Audit 2026-08-21 P0: a proposition grounded in turns of two or
-      // more users fits no single scope — drop it (with its resolved
-      // twin, keeping every downstream array index-aligned) rather
-      // than land it tenant-global.
+      // more users fits no single scope, and one with empty/invalid
+      // grounding (round 2) has no trustworthy scope at all — both are
+      // dropped (with their resolved twins, keeping every downstream
+      // array index-aligned) rather than landed tenant-global.
+      const dropRow = (r: (typeof builtRows)[number]) =>
+        r.crossUserScope || r.groundingInvalid;
       const crossUser = builtRows.filter((r) => r.crossUserScope).length;
-      if (crossUser > 0) {
+      const ungrounded = builtRows.filter((r) => r.groundingInvalid).length;
+      if (crossUser > 0 || ungrounded > 0) {
         this.logger.warn(
-          `derive ${conversationId}: dropped ${crossUser} cross-user-scoped proposition(s)`,
+          `derive ${conversationId}: dropped ${crossUser} cross-user-scoped ` +
+            `and ${ungrounded} invalid-grounding proposition(s)`,
         );
       }
-      const keptResolved = resolved.filter(
-        (_, i) => !builtRows[i].crossUserScope,
-      );
-      const rows = builtRows.filter((r) => !r.crossUserScope);
+      const keptResolved = resolved.filter((_, i) => !dropRow(builtRows[i]));
+      const rows = builtRows.filter((r) => !dropRow(r));
       // V9 §1: value-bearing aspects take the bitemporal_event
       // lifecycle when the profile asks; V9 phase 0: the resolver
       // batch degrades per-row instead of failing the conversation —

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -118,6 +118,7 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
 
   // ── fact_trust ranking knobs (source-reputation Phase 5) ──────────
   nonNegativeFloat(env, 'SEARCH_TRUST_BETA', errors);
+  nonNegativeFloat(env, 'SEARCH_RERANK_TRUST_BAND', errors);
   nonNegativeFloat(env, 'SEARCH_CORROBORATION_GAMMA', errors);
   nonNegativeFloat(env, 'SEARCH_AUTHORITY_DELTA', errors);
   nonNegativeFloat(env, 'SYNTHESIZE_MIN_FACT_TRUST', errors);

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -987,18 +987,6 @@ function nonNegativeFloat(env: NodeJS.ProcessEnv, name: string): number {
   return Number.isFinite(v) && v > 0 ? v : 0;
 }
 
-/** Like nonNegativeFloat but with a non-zero default — an explicit `0`
- *  is honored (the knob's documented off switch). */
-function nonNegativeFloatDefault(
-  env: NodeJS.ProcessEnv,
-  name: string,
-  dflt: number,
-): number {
-  const raw = env[name];
-  if (raw === undefined || raw === '') return dflt;
-  const v = Number(raw);
-  return Number.isFinite(v) && v >= 0 ? v : dflt;
-}
 
 /**
  * Penalty multiplier; OFF is 1.0. Returns the value only when it's a
@@ -1031,11 +1019,11 @@ export function resolveSearchTuning(
     crossEncoderWindow: tuningInt(env, 'SEARCH_CROSS_ENCODER_WINDOW', 50),
     factRerankWindow: tuningInt(env, 'SEARCH_FACT_RERANK_WINDOW', 64),
     rerankSkipMargin: nonNegativeFloat(env, 'SEARCH_RERANK_SKIP_MARGIN'),
-    rerankTrustBand: nonNegativeFloatDefault(
-      env,
-      'SEARCH_RERANK_TRUST_BAND',
-      0.1,
-    ),
+    // Default 0 = band off (audit round 3: a non-zero band reshapes
+    // ranking even without a trust experiment — enable after a
+    // benchmark/canary, and always alongside SEARCH_TRUST_BETA, where
+    // 0.1 is the measured contract the fact-trust e2e pins).
+    rerankTrustBand: nonNegativeFloat(env, 'SEARCH_RERANK_TRUST_BAND'),
     stageBudgets: resolveStageBudgets(env),
     tokenCountOffload: envFlagEnabled(env.SEARCH_TOKEN_COUNT_OFFLOAD ?? '1'),
     tokenOffloadMinHits: tuningInt(env, 'SEARCH_TOKEN_OFFLOAD_MIN_HITS', 24),

--- a/test/derive-staging.unit-spec.ts
+++ b/test/derive-staging.unit-spec.ts
@@ -162,7 +162,8 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
     // (source survives the flip untouched).
     expect(derived.length).toBeGreaterThan(0);
     for (const row of derived) {
-      expect(row.derivedVersion).toBe(STAGING);
+      // Per-run staging token: `<version>.staging.<token>`.
+      expect(String(row.derivedVersion).startsWith(`${STAGING}.`)).toBe(true);
       expect((row.source as Record<string, unknown>).recorder).toBe(
         WINDOW_DERIVER_VERSION,
       );
@@ -172,7 +173,7 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
     for (const q of queries) {
       if (q.sql.includes('BEGIN TRANSACTION')) continue;
       if (q.params && 'version' in q.params) {
-        expect(q.params.version).toBe(STAGING);
+        expect(String(q.params.version).startsWith(STAGING)).toBe(true);
       }
     }
     const flips = queries.filter((q) => q.sql.includes('BEGIN TRANSACTION'));
@@ -192,10 +193,8 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
       'UPDATE conversation_digest SET derivedVersion = $final',
     );
     for (const flip of flips) {
-      expect(flip.params).toMatchObject({
-        final: WINDOW_DERIVER_VERSION,
-        staging: STAGING,
-      });
+      expect(flip.params?.final).toBe(WINDOW_DERIVER_VERSION);
+      expect(String(flip.params?.staging).startsWith(`${STAGING}.`)).toBe(true);
     }
   });
 
@@ -211,7 +210,7 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
     );
     for (const q of queries) {
       if (q.params && 'version' in q.params) {
-        expect(q.params.version).toBe(STAGING);
+        expect(String(q.params.version).startsWith(STAGING)).toBe(true);
       }
     }
     // Best-effort staging GC ran (probe said rows exist → DELETE).
@@ -223,7 +222,8 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
         ),
     );
     expect(sweeps.length).toBeGreaterThan(0);
-    for (const s of sweeps) expect(s.params?.version).toBe(STAGING);
+    for (const s of sweeps)
+      expect(String(s.params?.version).startsWith(`${STAGING}.`)).toBe(true);
   });
 
   it('degraded run: no flip, staging swept, registry fails — never built', async () => {
@@ -271,16 +271,19 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
   it('orphaned staging rows of a crashed prior run are swept at start', async () => {
     const { svc, queries } = makeSvc(ONE_PROP, { stagingRows: true });
     await svc.run('co_x');
+    // Per-run tokens (audit round 3) make orphan names unknowable, so
+    // the run-start GC sweeps by PREFIX across every staging namespace.
     const firstDelete = queries.findIndex(
       (q) =>
-        q.sql.includes('DELETE knowledge_fact WHERE derivedVersion = $version'),
+        q.sql.includes('DELETE knowledge_fact') &&
+        q.sql.includes('string::starts_with'),
     );
     const firstEpisodeRead = queries.findIndex((q) =>
       q.sql.includes('GROUP BY conversationId'),
     );
     expect(firstDelete).toBeGreaterThanOrEqual(0);
     expect(firstDelete).toBeLessThan(firstEpisodeRead);
-    expect(queries[firstDelete].params?.version).toBe(STAGING);
+    expect(queries[firstDelete].params?.prefix).toBe(STAGING);
   });
 
   it("registry becomes 'built' only AFTER the flip transactions", async () => {
@@ -582,12 +585,16 @@ describe('derive lease fencing (isLost)', () => {
     await handle.release();
   });
 
-  it('a transient heartbeat error does NOT set the fence', async () => {
+  it('a heartbeat ERROR also sets the fence (fail-closed, round 3)', async () => {
+    // Any renewal uncertainty fences promotion — an erroring heartbeat
+    // past the TTL is indistinguishable from a lost lease. Per-run
+    // staging namespaces keep the data safe; the fence only refuses a
+    // flip this run can no longer claim to own.
     const handle = await acquireWith(async () => {
       throw new Error('network blip');
     });
     await jest.advanceTimersByTimeAsync(200_001);
-    expect(handle.isLost()).toBe(false);
+    expect(handle.isLost()).toBe(true);
     await handle.release();
   });
 });

--- a/test/derive-user-scope.unit-spec.ts
+++ b/test/derive-user-scope.unit-spec.ts
@@ -79,6 +79,28 @@ describe('derive user scope (audit 2026-08-21 P0)', () => {
     expect(row.crossUserScope).toBe(true);
   });
 
+  it('empty turns → invalid grounding, never a tenant-global fact (round 3)', () => {
+    const [row] = build([[]]);
+    expect(row.groundingInvalid).toBe(true);
+    expect(row.userId).toBeUndefined();
+  });
+
+  it('a negative index poisons the whole proposition', () => {
+    const [row] = build([[-1, 1]]);
+    expect(row.groundingInvalid).toBe(true);
+  });
+
+  it('an out-of-range index poisons the whole proposition', () => {
+    const [row] = build([[1, 99]]);
+    expect(row.groundingInvalid).toBe(true);
+  });
+
+  it('fully valid grounding stays valid', () => {
+    const [row] = build([[0, 1]]);
+    expect(row.groundingInvalid).toBe(false);
+    expect(row.userId).toBe('user-a');
+  });
+
   it('rollup/compose pools never accept user-scoped rows', () => {
     const rows = build([[1], [0]]);
     const pool: RollupMember[] = [];

--- a/test/fact-trust-ranking.e2e-spec.ts
+++ b/test/fact-trust-ranking.e2e-spec.ts
@@ -22,11 +22,17 @@ describe('fact_trust in ranking (Phase 5, SEARCH_TRUST_BETA=1)', () => {
 
   beforeAll(async () => {
     process.env.SEARCH_TRUST_BETA = '1';
+    // The band is part of the trust-ranking contract: without it a
+    // reranker permutation can erase the trust-adjusted order (audit
+    // 2026-08-21 P1). Default is 0 (off) — a trust experiment enables
+    // both knobs together, exactly as this suite does.
+    process.env.SEARCH_RERANK_TRUST_BAND = '0.1';
     f = await createApp({ companyId: 'co_fact_trust_e2e' });
   });
 
   afterAll(async () => {
     delete process.env.SEARCH_TRUST_BETA;
+    delete process.env.SEARCH_RERANK_TRUST_BAND;
     if (f) await f.close();
   });
 

--- a/test/window-deriver.unit-spec.ts
+++ b/test/window-deriver.unit-spec.ts
@@ -188,9 +188,12 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
     // Audit 2026-08-19 P1: in-run writes (and their namespace-claim
     // deletes) live in `<version>.staging`; the final version is only
     // ever touched by the atomic flip at the end of a clean run.
+    // Per-run token (audit round 3): `<version>.staging.<token>`.
     const staging = `${WINDOW_DERIVER_VERSION}.staging`;
-    const del = queries.find((q) => q.sql.includes('DELETE knowledge_fact'));
-    expect(del?.params?.version).toBe(staging);
+    const del = queries.find(
+      (q) => q.sql.includes('DELETE knowledge_fact') && q.params?.version,
+    );
+    expect(String(del?.params?.version).startsWith(`${staging}.`)).toBe(true);
     const flip = queries.find(
       (q) =>
         q.sql.includes('BEGIN TRANSACTION') &&
@@ -200,16 +203,14 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
     expect(flip?.sql).toContain(
       'DELETE knowledge_fact WHERE derivedVersion = $final',
     );
-    expect(flip?.params).toMatchObject({
-      final: WINDOW_DERIVER_VERSION,
-      staging,
-    });
+    expect(flip?.params?.final).toBe(WINDOW_DERIVER_VERSION);
+    expect(String(flip?.params?.staging).startsWith(`${staging}.`)).toBe(true);
     // S4/0079: the write goes through the ONE write primitive
     // (fn::resolve_facts via FactResolverService), not a raw INSERT.
     const rows = derived;
     expect(rows).toHaveLength(2);
     expect(rows[0].predicate).toBe('pets');
-    expect(rows[0].derivedVersion).toBe(staging);
+    expect(String(rows[0].derivedVersion).startsWith(`${staging}.`)).toBe(true);
     expect(String(rows[0].object)).toContain('Luna and Oliver');
     const source = rows[0].source as Record<string, unknown>;
     expect(source.recorder).toBe(WINDOW_DERIVER_VERSION);
@@ -299,7 +300,11 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
       ).toBe(true);
       // Digest writes stage like fact writes; the digest flip
       // transaction promotes them alongside the facts.
-      expect(write?.params?.version).toBe(`${WINDOW_DERIVER_VERSION}.staging`);
+      expect(
+        String(write?.params?.version).startsWith(
+          `${WINDOW_DERIVER_VERSION}.staging.`,
+        ),
+      ).toBe(true);
       expect(
         on.queries.some(
           (q) =>


### PR DESCRIPTION
Closes both critical remains of audit round 3 (conditional NO-GO for multi-pod user-scoped derive).

## P0 — empty/invalid grounding can no longer produce a tenant-global fact

A proposition with `turns: []` (now also refused at the source: `minItems: 1` in the deriver JSON schema) or ANY out-of-range grounding index used to fall through the scope rule silently global (`groundingTurns=[]` → `scopeUsers=[]` → `userId` undefined, `crossUserScope` false). Fail-closed now: such rows are `groundingInvalid` and dropped with a warn — an untrustworthy grounding means an untrustworthy scope. Test matrix per the audit: `[]`, negative index, out-of-range index, mixed valid+invalid (dropped), fully valid (kept).

## P1 — the lease is now backed by real fencing

- **Per-run staging namespace** `<version>.staging.<token>`: even a fenced-open race (heartbeat errors past the TTL, a competing pod acquiring the lease) cannot interleave two runs' rows in one namespace — each flip promotes an internally consistent world. This also defuses the `isLost` TOCTOU window: the worst case degrades to a wasteful double-flip of two complete worlds, never a mixed one.
- **Fail-closed heartbeat**: ANY renewal uncertainty — an error, not only a definitive `tryAcquire → false` — sets the `isLost` fence that promotion checks before flipping.
- **Prefix orphan GC**: the run-start sweep reaps ALL `<version>.staging*` namespaces via `string::starts_with` (per-run tokens make exact orphan names unknowable in advance).

## Minor tails from the same round

- `SEARCH_RERANK_TRUST_BAND` default `0.1` → **`0`** (a non-zero band reshapes ranking even without a trust experiment — enable after a benchmark/canary). The band is part of the trust-ranking contract, so the `fact-trust-ranking` e2e pins BOTH knobs (`SEARCH_TRUST_BETA=1` + band `0.1`), exactly as a trust experiment would. Default prod ranking is byte-identical to pre-#298.
- The band knob joins strict env validation.
- Catalog + `.env.example` synchronized (default and canary guidance).

## Gates

unit full green (grounding matrix ×5, fail-closed heartbeat, per-run-token contract updates in the staging/deriver specs), **e2e 83/83 suites / 348/348** on real Surreal, eslint clean, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB