### PR TITLE
chore(release): hygiene before 2.0.0 — renew-at-flip fencing, stale docs, version-agnostic openapi gate

### DIFF
--- a/src/admin/derive-staging.ts
+++ b/src/admin/derive-staging.ts
@@ -28,19 +28,16 @@ import type { LeaderLeaseService } from '../jobs/leader-lease.service';
  *      not per-run — re-acquire by the same leaderId succeeds).
  *
  *   3. Atomic flip — after a CLEAN run, promoteStaging() replaces the
- *      final world with the staged one: per table, DELETE the final
- *      version's rows then UPDATE staging rows SET derivedVersion =
- *      final, both inside ONE SurrealDB BEGIN/COMMIT transaction
- *      (runTransaction), so readers of that table see either the old
- *      world or the new one — never empty, never mixed. The flip is
- *      table-by-table (knowledge_fact first, conversation_digest
- *      second): between the two transactions there is a bounded window
- *      where new facts coexist with old digests — facts are the
- *      load-bearing surface, digests auxiliary narrative, hence the
- *      ordering. A failed or degraded run never calls the flip: the
+ *      final world with the staged one: DELETE the final version's
+ *      rows then UPDATE staging rows SET derivedVersion = final, for
+ *      BOTH tables (knowledge_fact and conversation_digest) inside ONE
+ *      SurrealDB BEGIN/COMMIT transaction (runTransaction, audit
+ *      2026-08-21) — readers see either the old world or the new one,
+ *      never empty, never mixed, and never new facts narrated by old
+ *      digests. A failed or degraded run never calls the flip: the
  *      final world stays byte-identical and the staging rows are swept
- *      (best-effort; sweepStagingRows at the start of the next run for
- *      the same version catches what a crash stranded).
+ *      (best-effort; the prefix orphan GC at the start of the next run
+ *      for the same version catches what a crash stranded).
  */
 
 export const STAGING_SUFFIX = '.staging';
@@ -117,6 +114,13 @@ export interface DeriveLease {
    *  heartbeat past the TTL is indistinguishable from a lost lease).
    *  Promotion MUST check this fence before flipping staging → final. */
   isLost(): boolean;
+  /** Fresh SYNCHRONOUS ownership proof, for the moment before the
+   *  flip: re-acquires the lease right now (a held lease renews; a
+   *  stale pod that slept past the TTL while another pod took over
+   *  gets false). Any uncertainty → false and the isLost fence is set.
+   *  Closes the residual stale-isLost window the async heartbeat
+   *  cannot (audit round 4 hardening). */
+  renew(): Promise<boolean>;
   /** Idempotent; call in finally. */
   release(): Promise<void>;
 }
@@ -190,6 +194,22 @@ export async function acquireDeriveLease(args: {
   return {
     name,
     isLost: () => lost,
+    renew: async () => {
+      if (lost || released) return false;
+      if (!lease) return true; // in-process-only guard: nothing to renew
+      try {
+        const ok = await lease.tryAcquire(name, LEASE_TTL_SECONDS);
+        if (!ok) lost = true;
+        return ok;
+      } catch (e) {
+        lost = true;
+        logger.warn(
+          `derive lease renew failed — promotion fenced: ` +
+            `${(e as Error).message}`,
+        );
+        return false;
+      }
+    },
     release: async () => {
       if (released) return;
       released = true;

--- a/src/admin/window-deriver.service.ts
+++ b/src/admin/window-deriver.service.ts
@@ -300,12 +300,13 @@ export class WindowDeriverService {
       }
       return result;
     }
-    // Audit 2026-08-21 (lease fencing): a lease definitively lost
-    // mid-run means a competing pod may be building — or may already
-    // have swept — this very staging namespace. Promoting would flip a
-    // world of unknown provenance; refuse, mark failed, leave staging
-    // for forensics (the next run's sweep reaps it).
-    if (lease.isLost()) {
+    // Audit 2026-08-21 (lease fencing) + round-4 hardening: prove
+    // ownership SYNCHRONOUSLY at the flip boundary — a stale pod that
+    // slept past the TTL still holds isLost=false from its last
+    // heartbeat, but the fresh renew fails and fences it. Per-run
+    // staging already guarantees no data mixing; this closes the
+    // stale-overwrite of a newer pod's promoted world.
+    if (lease.isLost() || !(await lease.renew())) {
       await this.registry?.fail({ companyId, name: 'facts', version });
       this.logger.error(
         `derive '${version}' for ${companyId}: lease lost mid-run — ` +

--- a/test/derive-staging.unit-spec.ts
+++ b/test/derive-staging.unit-spec.ts
@@ -585,6 +585,22 @@ describe('derive lease fencing (isLost)', () => {
     await handle.release();
   });
 
+  it('renew() proves ownership at the flip boundary; a stale pod is fenced', async () => {
+    // Round-4 hardening: the async heartbeat's isLost can be stale for
+    // a pod that slept past the TTL — the synchronous renew cannot.
+    let holderIsUs = true;
+    const handle = await acquireWith(async () => holderIsUs);
+    await expect(handle.renew()).resolves.toBe(true);
+    expect(handle.isLost()).toBe(false);
+    holderIsUs = false; // another pod took the lease while we slept
+    await expect(handle.renew()).resolves.toBe(false);
+    expect(handle.isLost()).toBe(true);
+    // Once fenced, renew never un-fences.
+    holderIsUs = true;
+    await expect(handle.renew()).resolves.toBe(false);
+    await handle.release();
+  });
+
   it('a heartbeat ERROR also sets the fence (fail-closed, round 3)', async () => {
     // Any renewal uncertainty fences promotion — an erroring heartbeat
     // past the TTL is indistinguishable from a lost lease. Per-run

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -70,7 +70,16 @@ describe('docs/openapi.json', () => {
   });
 
   it('matches the committed artifact (regenerate: pnpm openapi:build)', () => {
-    expect(committed).toEqual(built);
+    // info.version is compared normalized: the built document reads
+    // package.json at test time, and a release-please version bump
+    // must not fail main CI until someone regenerates — every OTHER
+    // byte still gates strictly. (The committed version catches up on
+    // the next `pnpm openapi:build`.)
+    const stripVersion = (doc: Json): Json => ({
+      ...doc,
+      info: { ...(doc.info as Json), version: 'NORMALIZED' },
+    });
+    expect(stripVersion(committed)).toEqual(stripVersion(built));
   });
 
   // The landing serves a second copy at brain.inite.ai/openapi.json — the URL


### PR DESCRIPTION
Release-hygiene items from the RC-GO audit round, before cutting 2.0.0.

- **`DeriveLease.renew()`** — the auditor's recommended hardening: a fresh **synchronous** ownership proof at the flip boundary. A stale pod that slept past the TTL still carries `isLost=false` from its last heartbeat; the renew fails against the CAS lease and fences promotion. Per-run staging namespaces already prevented data mixing — this closes the residual stale overwrite of a newer pod's promoted world. Once fenced, renew never un-fences (tested).
- **derive-staging module header** updated to the atomic single-transaction flip — the text still described the retired two-transaction scheme.
- **openapi drift gate** now compares `info.version` normalized: the built document reads `package.json` at test time, so a release-please version bump used to be guaranteed to fail main CI until someone regenerated the committed artifact. Every other byte still gates strictly; the committed version catches up on the next `pnpm openapi:build`.

Jest open-handles/forceExit noted by the audit is left as-is for now (pre-existing, needs its own investigation; `forceExit` is confined to the e2e configs).

Gates: full unit 2154 green (incl. new renew-fence tests), eslint, tsc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB