### PR TITLE
docs(release): README + API reference catch up with the 2.0 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,22 @@ flowchart LR
   then commit). Stored documents can be **re-indexed** when a new pack lands,
   and corroboration is keyed on the *origin document*, so two indexers reading
   the same source never masquerade as independent evidence.
+- **Per-user memory scope, provenance-first.** A fact can belong to one end
+  user, and that scope survives the whole pipeline — episode ingest, derived
+  worlds, retrieval, profiles, retraction (ownership-fenced). Every derived
+  fact keeps pointers to the verbatim turns it came from:
+  `GET /v1/facts/:id/provenance` shows *why the system remembers*, and
+  `GET /v1/users/:id/profile` assembles a deterministic, prompt-ready profile
+  from one user's own memory — no silent fact-mining, nothing you can't
+  inspect or erase.
+- **Versioned derived worlds.** Memory can be re-derived from the raw episode
+  substrate (session-window derivation: the whole conversation as the unit of
+  understanding, not one turn) into a NEW versioned world — built in a
+  per-run staging namespace under a lease and promoted with one atomic flip —
+  while readers stay pinned to the previous world until the swap.
 - **A forget that deletes.** GDPR erasure is a synchronous hard cascade —
   facts, edges, and embeddings gone, only an HMAC tombstone left to prove it.
+  Works at entity scope and at end-user scope (`POST /v1/users/:id/forget`).
 - **Native MCP.** A per-tenant Streamable HTTP endpoint with scope-aware tools.
   Hermes, Claude Desktop, Cursor, Goose, n8n — same URL, no glue code; stdio-only
   harnesses connect via the [`@inite/brain-mcp`](https://www.npmjs.com/package/@inite/brain-mcp) connector.
@@ -302,7 +316,7 @@ The hub with per-persona routing lives at [`docs/README.md`](docs/README.md).
 | | |
 |---|---|
 | **Get going** | [Getting started](docs/getting-started.md) · [Migration guide](docs/migration-guide.md) |
-| **Understand it** | [Architecture](docs/architecture.md) · [API reference](docs/api.md) · [OpenAPI 3.1 spec](docs/openapi.json) (platform surface, generated) · [Data model](docs/data-model.md) · [Bitemporal semantics](docs/bitemporal-semantics.md) · [Source reputation & trust](docs/source-reputation.md) · [ABAC access policies](docs/abac.md) · [Document pipeline](docs/document-pipeline.md) |
+| **Understand it** | [Architecture](docs/architecture.md) · [API reference](docs/api.md) · [OpenAPI 3.1 spec](docs/openapi.json) (platform surface, generated) · [Data model](docs/data-model.md) · [Bitemporal semantics](docs/bitemporal-semantics.md) · [Source reputation & trust](docs/source-reputation.md) · [ABAC access policies](docs/abac.md) · [Document pipeline](docs/document-pipeline.md) · [Fact provenance API](docs/fact-provenance-api.md) · [User profile API](docs/user-profile-api.md) |
 | **Extend it** | [Domain Packs](docs/domain-packs.md) (registry + marketplace + seed documents) · [External indexer protocol](docs/indexer-protocol.md) · [MCP pack tools](docs/mcp-pack-tools.md) · [Listing playbook](docs/distribution.md) · [Code memory](docs/roadmap/code-memory-domain.md) |
 | **Run it** | [Operations](docs/operations.md) · [Operator playbook](docs/operator-playbook.md) · [Deploy runbook](docs/DEPLOY.md) |
 | **Measure it** | [Eval harness](docs/eval.md) · [LoCoMo benchmark](docs/locomo.md) |
@@ -343,12 +357,21 @@ counters and pull-only mirroring, marketplace with paid packs, pack-declared
 MCP tools, seed documents), OpenAPI 3.1 platform spec, worker-thread offloads
 + `PROCESS_ROLE` api/worker split, code memory (record *why* a decision was
 made, drift-resistant symbol anchors), eval-gated CI, off-hours
-self-improvement (dreams).
+self-improvement (dreams), the raw episode substrate with versioned derived
+worlds (atomic per-run staged rebuilds, lease-fenced promotion, read pins),
+end-to-end per-user memory scope (episode ingest → derivation → retrieval →
+profile → ownership-fenced retraction), fact-provenance + rolling
+user-profile read APIs, measured genre presets over the retrieval profile,
+and long-horizon conversational memory benchmarks run under a strict judge
+([LoCoMo](docs/locomo.md), LongMemEval, BEAM — protocol in
+[docs/eval-protocol.md](docs/eval-protocol.md)).
 
-Exploring (issues + ideas welcome): extractor span-grounding offload (profile
-first), worker-pool right-sizing as more handlers move to threads, and the
-full paid LoCoMo run with published numbers. Temporal was evaluated and
-deliberately not adopted — the re-evaluation triggers live in
+Exploring (issues + ideas welcome): a non-conversational (document / KG) eval
+axis on the same harness, failure-memory for agents (distill what went wrong
+into reusable strategies), prospective-memory / preference-drift benchmarks,
+extractor span-grounding offload, and worker-pool right-sizing as more
+handlers move to threads. Temporal was evaluated and deliberately not
+adopted — the re-evaluation triggers live in
 [docs/roadmap/platform-gap-2026-07.md](docs/roadmap/platform-gap-2026-07.md).
 Have a use case? Open an issue.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,8 @@ with one row per document.
 | [Source reputation & trust](source-reputation.md) | Domain-scoped trust, corroboration, feedback loop, trust in ranking. |
 | [ABAC access policies](abac.md) | Per-key policy sets: action gating + row-level read filtering, rollout runbook. |
 | [Document pipeline](document-pipeline.md) | Source → Indexer → Candidates → Brain: composable indexers, staged candidates, origin-keyed corroboration, re-indexing, external indexers, seed documents. |
+| [Fact provenance API](fact-provenance-api.md) | `GET /v1/facts/:id` + `/provenance` — the fact and the verbatim turns it came from ("show me why I remember this"). Flag-gated, ownership-fenced. |
+| [User profile API](user-profile-api.md) | `GET /v1/users/:userId/profile` — deterministic, prompt-ready assembly of one user's own memory (strict user scope). Flag-gated. |
 | [Eval harness](eval.md) | Production-gate retrieval + lifecycle eval. Load your CRM via JSON or Wikidata. |
 | [LoCoMo benchmark](locomo.md) | Long-term conversational memory eval — apples-to-apples vs Mem0 / Zep / MemGPT. |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,6 +74,9 @@ Protocol: [indexer-protocol.md](indexer-protocol.md).
 | `GET /v1/entities/autocomplete?q=` | Entity-name typeahead over the edge-ngram `prefix` fulltext index (word-start match, BM25-ranked via `search::score`). `?limit=` 1–25 (default 10); a query under 2 chars returns empty. Live, tenant-global entities only (merged-away redirects and personal-scoped entities excluded). |
 | `GET /v1/entities/:id` | Entity profile + active facts (PII-gated by scope). `?asOf=` slices world-time; `?recordedAt=` slices transaction-time (what the graph believed at T — a later retract/supersede is ignored). |
 | `GET /v1/entities/:id/timeline` | Bitemporal sweep — `fact.recorded` / `fact.retracted` events on the transaction-time axis. `?since=`/`?until=` page the window; `?recordedAt=` cuts to events known by T. |
+| `GET /v1/facts/:id` | One fact by id: statement, aspect, validity, user scope, provenance coordinates, `retracted` flag. Every visibility fence (tenant, user scope, row policy) answers 404 — existence never leaks. Flag `FACTS_API_ENABLED`. |
+| `GET /v1/facts/:id/provenance` | The verbatim grounding turns behind a fact (`source.episodeIds`), chronological, text capped; PII-classed text needs `brain:read_pii`. Flag `FACTS_API_ENABLED`. |
+| `GET /v1/users/:userId/profile` | Deterministic, prompt-ready profile of one user's OWN memory (strict `userId` scope; persona-first sections + `profileText`). A user-bound token only fetches its own profile; M2M any. Flag `USER_PROFILE_API_ENABLED`. |
 | `GET /v1/entities/:id/connections` | Typed edges + direct neighbours. |
 | `GET /v1/artifacts/:type/:entityId` | Derived artifacts (profile / digest / etc) with manual `recompile` POST. |
 | `GET /v1/sources` | Read-only trust inputs: declared `type`/`authLevel` ⋈ learned reputation, one row per source. Filters `domain` / `type` / `minSamples`, paginated (`limit` ≤ 200 / `offset`). Public projection — operator annotations (`owner`/`note`) stay on the admin surface. |
@@ -104,7 +107,7 @@ All routes 404 until their flag is on.
 
 | Endpoint | Notes |
 |---|---|
-| `POST /v1/facts/:id/retract` | Mark a fact retracted with reason; survives in audit trail. |
+| `POST /v1/facts/:id/retract` | Mark a fact retracted with reason; survives in audit trail. Ownership-fenced: a user-bound token retracts only its own user-scoped facts (another user's → 404); a tenant-global fact needs an M2M token or `brain:admin`; row policy applies. Always available (GDPR path — independent of `FACTS_API_ENABLED`). |
 | `POST /v1/feedback` | Retrieval feedback: `helpful` / `not_helpful` / `incorrect` per fact. One standing vote per caller key (repeat replaces); `helpful`/`incorrect` feed the nightly source-trust refit. **Affects the SOURCE's trust for facts ingested AFTER the refit — it does not demote the flagged fact or the existing corpus** (ranking reads each fact's write-time trust snapshot). Also on MCP as `record_feedback`. |
 | `POST /v1/entities/:id/forget` | Hard GDPR cascade — facts + edges + embeddings deleted, HMAC tombstone retained. |
 | `POST /v1/users/:userId/forget` | GDPR erasure of one end-user's memory scope (migration 0055): personal facts (incl. those on shared entities), personal entities + edges + dedup refs, usage/feedback rows, audit mirror. |


### PR DESCRIPTION
Pre-release docs pass. README was last touched 2026-07-17 — a month behind the code.

- **README**: new Why-Brain bullets — per-user memory scope with provenance-first reads (`/v1/facts/:id/provenance`, `/v1/users/:id/profile`) and versioned derived worlds (session-window derivation, per-run staged atomic promotion); user-scope forget mentioned next to entity forget; the two new API docs linked in the documentation table; the roadmap's Shipped list catches up (episode substrate + derived worlds, end-to-end user scope, new read APIs, genre presets, strict-judge benchmark program) and Exploring now lists the actual frontier (doc/KG eval axis, failure-memory, prospective memory) instead of the long-completed paid LoCoMo run.
- **docs/README.md** (hub): rows for the two new API docs.
- **docs/api.md**: the three new read endpoints with their fence semantics (404-never-leaks, PII scope, strict user scope), and the retract row now documents the ownership fence + deliberate flag-independence (GDPR path).

Docs-only; no code. CHANGELOG/version arrive via release-please (#282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB