### PR TITLE
chore(db,docs): remove dead server functions, publish strict-eval methodology, §10 literature update

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The hub with per-persona routing lives at [`docs/README.md`](docs/README.md).
 | **Understand it** | [Architecture](docs/architecture.md) · [API reference](docs/api.md) · [OpenAPI 3.1 spec](docs/openapi.json) (platform surface, generated) · [Data model](docs/data-model.md) · [Bitemporal semantics](docs/bitemporal-semantics.md) · [Source reputation & trust](docs/source-reputation.md) · [ABAC access policies](docs/abac.md) · [Document pipeline](docs/document-pipeline.md) · [Fact provenance API](docs/fact-provenance-api.md) · [User profile API](docs/user-profile-api.md) |
 | **Extend it** | [Domain Packs](docs/domain-packs.md) (registry + marketplace + seed documents) · [External indexer protocol](docs/indexer-protocol.md) · [MCP pack tools](docs/mcp-pack-tools.md) · [Listing playbook](docs/distribution.md) · [Code memory](docs/roadmap/code-memory-domain.md) |
 | **Run it** | [Operations](docs/operations.md) · [Operator playbook](docs/operator-playbook.md) · [Deploy runbook](docs/DEPLOY.md) |
-| **Measure it** | [Eval harness](docs/eval.md) · [LoCoMo benchmark](docs/locomo.md) |
+| **Measure it** | [Eval methodology](docs/eval-methodology.md) (strict-judge protocol + measured judge inflation) · [Eval harness](docs/eval.md) · [LoCoMo benchmark](docs/locomo.md) |
 
 A reader-friendly version of the docs lives at
 **[brain.inite.ai/en/docs](https://brain.inite.ai/en/docs)** (also in Russian).

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,12 @@ with one row per document.
 | [Document pipeline](document-pipeline.md) | Source → Indexer → Candidates → Brain: composable indexers, staged candidates, origin-keyed corroboration, re-indexing, external indexers, seed documents. |
 | [Fact provenance API](fact-provenance-api.md) | `GET /v1/facts/:id` + `/provenance` — the fact and the verbatim turns it came from ("show me why I remember this"). Flag-gated, ownership-fenced. |
 | [User profile API](user-profile-api.md) | `GET /v1/users/:userId/profile` — deterministic, prompt-ready assembly of one user's own memory (strict user scope). Flag-gated. |
+## Measure it
+
+| Doc | Purpose |
+|---|---|
+| [Eval methodology](eval-methodology.md) | The public strict-eval statement: strict-judge protocol, measured judge inflation, lenient-vs-strict conversion factors, our numbers with CIs. |
+| [Eval protocol](eval-protocol.md) | The full three-axis protocol (LoCoMo / LongMemEval / BEAM): harness design and per-axis rules. |
 | [Eval harness](eval.md) | Production-gate retrieval + lifecycle eval. Load your CRM via JSON or Wikidata. |
 | [LoCoMo benchmark](locomo.md) | Long-term conversational memory eval — apples-to-apples vs Mem0 / Zep / MemGPT. |
 

--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -1,0 +1,159 @@
+# Strict evaluation methodology
+
+Why our memory-benchmark numbers look lower than most published ones,
+why that is deliberate, and how to convert between the two currencies.
+
+Long-term-memory benchmark scores are not a scalar — they are a
+**currency**. The same engine, answering the same questions, moves by
+double digits depending on the judge prompt, the answer model, the
+category accounting, and whether abstention is scored honestly. We
+measured those conversion factors instead of riding them. This page is
+the public statement of the protocol; the full per-axis detail
+(LoCoMo / LongMemEval / BEAM harness design) lives in
+[eval-protocol.md](eval-protocol.md), and the LoCoMo runner docs in
+[locomo.md](locomo.md).
+
+## 1. The strict-judge protocol
+
+1. **Fixed strict judge, never a lever.** Every leg is graded by the
+   same pinned judge model (gpt-4.1-mini) with a fixed, verbatim,
+   version-bumped prompt ([locomo.md](locomo.md#llm-judge-scoring---judge)).
+   The prompt contains no "be generous" / "give benefit of the doubt"
+   instructions: a prediction is CORRECT only if it conveys the gold
+   answer's essential information, and numeric values and dates must
+   match in meaning. Judge upgrades between legs are forbidden — the
+   judge is a controlled variable.
+2. **Held-out gold.** LoCoMo conversations 1–5 are the iteration set;
+   6–10 are touched only to confirm milestones. The guard demonstrably
+   works: our largest gain measured *larger* on held-out than on dev
+   (+6.6pp vs +3.8pp) — the opposite of what overfitting produces.
+3. **Abstention counted honestly.** LoCoMo category 5 (adversarial:
+   the gold answer is a refusal) is excluded from the headline — its
+   answer key is unusable, and every credible harness excludes it; the
+   difference is whether they say so. We score it separately as an
+   abstention rate. LongMemEval's `_abs` subset and BEAM abstention use
+   one shared decline-detection implementation. A confabulated specific
+   answer is never credited.
+4. **Own full-context baseline.** The FC baseline is computed on our
+   harness, same judge, same questions, same rendering of image
+   captions. All claims are deltas against our own FC — never against
+   numbers lifted from other papers.
+5. **Paired statistics on every A/B.** Per-question McNemar with
+   discordant counts reported. Measured noise floors are enforced:
+   dev-5 headline deltas under ~2.2pp (n=762) are noise; re-deriving
+   the same world with the same code moves the headline ±0.8pp and
+   single categories up to ±3.5pp, so derive-side effects must clear
+   ~4pp per category to be readable. Nulls and regressions are recorded
+   with the same rigor as wins.
+6. **Judge-calibration probe (standing gate).** Any new eval axis must
+   score a set of intentionally-wrong, topically-adjacent answers and
+   report the judge's acceptance rate next to the headline. An axis
+   without this number is not evidence; a 90+ on it is not a result.
+7. **Run hygiene and token accounting.** Dead-answer counts reported
+   per run; infrastructure-corrupted runs discarded and re-run, never
+   reported; per-question generator prompt/completion tokens
+   (avg/p90/max) carried in every report — accuracy-per-token is a
+   first-class result.
+
+## 2. Measured judge inflation
+
+Numbers we recorded on our own harness while calibrating the protocol:
+
+- **A lenient judge accepts ~62.8% of deliberately wrong answers.**
+  Probing the standard gpt-4o-mini LoCoMo judge configuration with
+  intentionally wrong but topically adjacent answers, it graded 62.8%
+  of them CORRECT. Vague topical adjacency passes; only crisp factual
+  contradiction reliably fails.
+- **~6.4% of the LoCoMo gold key is broken** (hallucinated facts,
+  wrong temporal reasoning, wrong speaker attribution), which puts the
+  **theoretical ceiling for a perfect system at ≈93.6%** under exact
+  judging. Per-category ceilings sit correspondingly below 100.
+- **Generator inflation:** the same full-context baseline moves
+  **72.6% → 92.6%** from an answer-model + CoT prompt swap alone — no
+  memory system involved. Headline numbers that don't pin the answer
+  model are measuring the generator.
+- **Accounting drift:** mem0-lineage harnesses have shipped shifted
+  category labels (per-category tables silently permuted), and one
+  public incident inflated a headline by ~25pp through category-5
+  accounting alone.
+
+These findings are now **independently confirmed by Penfield Labs'
+public audit** ([We audited LoCoMo: 6.4% of the answer key is wrong,
+and the judge accepts up to 63% of intentionally wrong answers](https://dev.to/penfieldlabs/we-audited-locomo-64-of-the-answer-key-is-wrong-and-the-judge-accepts-up-to-63-of-intentionally-33lg)):
+auditing all 1,540 scored questions they find 99 broken gold answers
+(6.4%), a 62.81% judge acceptance rate for intentionally wrong
+topically-adjacent probes under the standard gpt-4o-mini judge, and
+the same ≈93.6% ceiling.
+
+## 3. Lenient headlines are a different currency
+
+Vendor-published LoCoMo numbers in the low 90s exist and are
+reproducible under their own protocols — mem0's benchmark overview
+([AI Memory Benchmarks in 2026](https://mem0.ai/blog/ai-memory-benchmarks-in-2026))
+and the research page it links report per-category LoCoMo scores
+around 92 (temporal) and 91 (multi-hop) for their stack, with
+open-domain at 72.7. The widely reused mem0-lineage evaluation
+harness those numbers ride instructs its LLM judge to grade
+generously; under a judge configuration with that property we measured
+the 62.8% wrong-answer acceptance above. Those scores and ours are
+therefore **different currencies, not different engines** — both
+internally consistent, not mutually comparable.
+
+Conversion factors we measured between the currencies:
+
+| Conversion | Factor | How measured |
+|---|---|---|
+| Strict binary → official BEAM nugget (rubric partial credit) | ≈ 1.3× | our own paired reading of the same run (0.353 binary vs 0.46 nugget) |
+| Strict nugget → lenient vendor-harness (BEAM) | ≈ 1.5–2.0× | currency triangulation against the AMB vendor leaderboard |
+| Single-lane extreme (BEAM contradiction resolution) | ≥ 12× | 0.006–0.05 strict for *all* published systems vs 60+ on a vendor harness |
+| LoCoMo / LongMemEval unpinned vendor claims | +20–40pp | cross-protocol comparison of published vs pinned re-runs |
+
+Applying the ceiling and acceptance-rate corrections, our strict
+LoCoMo 77.8 is plausibly equivalent to a mid-80s score in the lenient
+currency — stated as an estimate, because the honest direction of
+travel is pinning protocols, not converting headlines.
+
+## 4. Our numbers, in strict currency
+
+All rows: answer model gpt-4o-mini, strict gpt-4.1-mini judge,
+category-5 excluded from LoCoMo headlines, per-question paired stats.
+CIs are 95% binomial intervals on the judged denominator; for any
+*delta* the load-bearing statistic is the paired McNemar, not CI
+overlap.
+
+| Axis | Result | n | 95% CI |
+|---|---|---|---|
+| LoCoMo headline (cats 1–4, dev-5 control) | **77.8%** | 762 | 74.8–80.7 |
+| LoCoMo held-out vs own full-context | **76.3% vs 69.0%** | — | McNemar p=8e-05, discordants 131:74 |
+| LongMemEval-S (full 500) | **48.0%** | 500 | 43.6–52.4 |
+| BEAM-100K, strict binary | **35.3%** | 360 judged | 30.4–40.3 |
+| BEAM-100K, official nugget scoring | **0.46** | — | vs the 0.358 published LIGHT anchor |
+| BEAM contradiction resolution, strict binary | **52–55%** | two paired legs | vs ≤5% for all configs in the original paper |
+
+Context for the LoCoMo rows: the memory system beats our own
+full-context baseline at roughly **16% of the FC prompt tokens per
+question**, and the held-out category profile is single-hop 84.9,
+temporal 73.9 (FC: 30.9), open-domain 58.0 (FC: 40.0), multi-hop 60.0
+(FC: 59.3). Against the ≈93.6% gold ceiling, 77.8 strict is
+frontier-competitive; chasing >85 by protocol imitation would be
+measurement inflation, not engine improvement.
+
+## 5. Comparing against these numbers
+
+For any joint evaluation we pin, per leg, **before** numbers are
+exchanged: dataset file hash, category/ability mapping, judge model +
+prompt + a judge-calibration probe (acceptance rate on intentionally
+wrong answers), answer model, denominator rules (category-5 in/out),
+abstention convention, retrieval token budget, and the paired-test
+methodology. We are happy to run partner systems through this harness
+and/or re-run ours through theirs; under matched protocols, deltas are
+meaningful — absolute numbers alone are not.
+
+## See also
+
+- [eval-protocol.md](eval-protocol.md) — the full three-axis protocol
+  (LoCoMo / LongMemEval / BEAM harness design and per-axis rules).
+- [locomo.md](locomo.md) — running the LoCoMo axis, judge prompt
+  verbatim, cost.
+- [eval.md](eval.md) — the in-house production retrieval gate that
+  runs in CI.

--- a/docs/roadmap/graph-research-2026-08.md
+++ b/docs/roadmap/graph-research-2026-08.md
@@ -39,7 +39,13 @@ only by the MCP tool and the admin demo chat); multi-hop edge expansion
 
 **Write-only / rotting fields:** `knowledge_edge.invalidatedAt` has NO
 writer anywhere (edge_invalidated_idx indexes a permanently-NONE
-column); `weight` is hardcoded 1.0 on every automatic path; per-edge
+column). [Update 2026-08-22: still no writer, but no longer
+reader-free — the edge fence (`search/internals/edge-fence.ts`) now
+gates every fenced edge read on `invalidatedAt IS NONE`, the community
+builder filters on it, and the entity relations read filters AND
+projects it. Field + index therefore kept in the 0090 dead-native
+cleanup; the actionable gap remains the missing writer.]
+`weight` is hardcoded 1.0 on every automatic path; per-edge
 extraction confidence is stored into `source` and never read; edge
 `kind` is a free vocabulary with no registry (works_at vs employed_by =
 two distinct edges forever — contrast the fact-predicate registry);

--- a/docs/roadmap/memory-research-2026-08.md
+++ b/docs/roadmap/memory-research-2026-08.md
@@ -614,6 +614,41 @@ write-pack derive (typed-atoms + time-pack, new version) vs arm B —
 ~$20-25 — which confirms or kills both construction-side effects at
 n=500 in a single paired measurement instead of per-axis dribbles.
 
+### §10 literature update (2026-08-22) — the parked direction gains independent support
+
+Three papers landed on the exact shape the ladder measured:
+
+- **MemIR (arXiv 2605.25869)** names our SSA failure mode outright —
+  **"provenance-role collapse"** — and its fix is a three-way
+  separation of *raw evidence / retrieval cues / truth-bearing
+  claims*: memories that anchor retrieval are not the same objects as
+  memories that answer, and both must keep a pointer to the evidence
+  they came from. That is our typed-atoms design (M2 `kind` tags over
+  one substrate, facts-as-keys pointing at verbatim turns) stated as
+  the paper's central mechanism rather than a passing label.
+- **Eywa (arXiv 2605.30771)** — "**evidence before belief**": raw
+  observations are stored first-class and beliefs are derived views
+  over them, with a **deterministic zero-LLM read path** over the
+  evidence store. That is our episode substrate → derived-worlds
+  architecture (immutable L0, versioned derivations, LLM-free
+  ingest). Their benchmark numbers remain non-comparable (self-run
+  in-house suite — see the eval-protocol caveat); the support here is
+  architectural, not numeric.
+- **ScrubJay-MEM (arXiv 2608.04746)** adds **per-type perishability**:
+  memory types decay on different clocks (preferences drift, events
+  don't, identity facts persist). For us this is a concrete NEXT lever
+  that only exists *because* atoms are typed — type-conditioned
+  temporal decay over the M2 `kind` vocabulary (a principled successor
+  to the fovea program's salience-decay interest, this time with a
+  published mechanism rather than vendor prose).
+
+Frame: the parked SSA 57.1-vs-42.9 direction (p≈0.06, direction not
+effect) now has independent literature support from three unrelated
+groups converging on typed atoms over one evidence substrate. The
+decision bar is unchanged — the recorded next step remains the ONE
+decision-grade full-500 combined write-pack confirm (~$20-25) above;
+the literature moves the prior, not the statistics.
+
 ## 11. Genre presets (built 2026-08-21, branch feat/genre-presets)
 
 The measured genre-dependence of the engine is now a PRESET LAYER

--- a/src/artifacts/artifacts.service.ts
+++ b/src/artifacts/artifacts.service.ts
@@ -264,12 +264,13 @@ export class ArtifactsService {
     rid: string,
     scopes: BrainScope[],
   ): Promise<FactRow[]> {
-    // Mirrors fn::active_facts_for (migration 0003) but pins the
+    // Mirrors fn::active_facts_for (migration 0003; removed as dead in
+    // 0090 — this inline query is the live implementation) but pins the
     // tenant-GLOBAL scope: artifacts are a tenant-wide surface with no
     // per-user concept (like graph_retrieve), so a per-user fact
     // (userId != NONE, migration 0055) must never be compiled into a
-    // dossier served to the whole tenant. The stored fn predates 0055 and
-    // has no scope arg, so we query inline instead of extending it.
+    // dossier served to the whole tenant. The stored fn predated 0055 and
+    // had no scope arg, so we queried inline instead of extending it.
     // LIMIT: compile() consumes a bounded slice of the newest facts, but
     // this ran unbounded on the artifact read path — a long-lived entity
     // shipped its entire fact history per cache miss. 500 newest is far

--- a/src/db/migrations/0090_remove_dead_server_functions.surql
+++ b/src/db/migrations/0090_remove_dead_server_functions.surql
@@ -1,0 +1,42 @@
+-- 0090_remove_dead_server_functions — drop two stored functions that
+-- have had zero callers for their entire recent history. Evidence for
+-- each removal (repo-wide grep over src/, test/, scripts/, docs/ —
+-- node_modules excluded — as of this migration):
+--
+-- 1. fn::find_competing_facts (defined in 0003_server_functions.surql)
+--    Built for the ingestFact conflict-resolution path: fetch the
+--    candidate set server-side, score in JS. That path was superseded
+--    by fn::resolve_fact (0006, revised 0079), which performs its own
+--    candidate scan inside the function — the separate fetch primitive
+--    was never called again. Remaining mentions are comments only:
+--    a historical note in 0006_resolve_fact_fn.surql:115. No
+--    `fn::find_competing_facts(` call site exists anywhere in src/ or
+--    test/.
+--
+-- 2. fn::active_facts_for (defined in 0003_server_functions.surql)
+--    Built for knowledge-artifact compilation. The live artifact path
+--    (ArtifactsService.fetchActiveFacts, src/artifacts/artifacts.service.ts)
+--    deliberately queries inline instead: it needs the per-user scope
+--    fence introduced in 0055, which this stored fn predates and has
+--    no argument for. The JS mirror stays — this migration removes
+--    only the uncalled stored fn. Remaining mentions are comments
+--    only (the mirror's own comment and a test-header history note in
+--    test/artifacts-user-scope.e2e-spec.ts). No `fn::active_facts_for(`
+--    call site exists anywhere in src/ or test/.
+--
+-- Deliberately NOT removed — knowledge_edge.invalidatedAt and its
+-- index edge_invalidated_idx (0059_perf_indexes.surql): the
+-- graph-research 2026-08 note (docs/roadmap/graph-research-2026-08.md)
+-- records the field has no writer, which is still true, but it is NOT
+-- reader-free: the edge fence (src/search/internals/edge-fence.ts)
+-- gates every fenced edge read on `invalidatedAt IS NONE`, the
+-- community builder filters on it twice
+-- (src/communities/community-builder.service.ts), and the entity
+-- relations read both filters on it and projects it to API clients
+-- (src/entities/entities.service.ts). Dropping the field would change
+-- the meaning of those reads the day a writer appears; the actionable
+-- gap is the missing writer (edge invalidation), tracked in the
+-- roadmap doc — not the field.
+
+REMOVE FUNCTION IF EXISTS fn::find_competing_facts;
+REMOVE FUNCTION IF EXISTS fn::active_facts_for;


### PR DESCRIPTION
## 1. Dead-native cleanup — migration 0090

Removes two provably dead stored functions (repo-wide zero call sites, evidence in the migration header): `fn::find_competing_facts` and `fn::active_facts_for` (both 0003-era, superseded by `fn::resolve_fact`; the deliberate JS mirror in artifacts.service stays, its comment updated).

**Deliberately KEPT**: `knowledge_edge.invalidatedAt` + `edge_invalidated_idx` — the roadmap's "no writer" claim still holds, but the field is NOT reader-free: the edge fence gates on `invalidatedAt IS NONE` on every fenced edge read, communities and the entities API filter/project it. Documented as write-only-but-load-bearing in the graph-research doc.

## 2. `docs/eval-methodology.md` — the public strict-currency statement

The strict protocol (pinned judge, no be-generous instructions, held-out gold, honest abstention, paired McNemar with our measured noise floors), our recorded judge-inflation numbers (62.8% wrong-answer acceptance, 6.4% broken gold keys, ≈93.6% ceiling) with the independent Penfield Labs audit cited — their published numbers match ours exactly; lenient-vs-strict conversion factors stated factually with primary-source citations (mem0's own posts quoted precisely, per-category, no strawmen); our numbers restated in strict currency with 95% CIs. Linked from the docs hub (new "Measure it" section) and the root README.

## 3. §10 literature update

The parked typed-worlds program reframed with its new literature support: MemIR ("provenance-role collapse", typed memory IR), Eywa ("evidence before belief", zero-LLM read path), ScrubJay-MEM (per-type perishability → the concrete next lever over `source.kind`). Closes honestly: literature moves the prior, not the statistics — the full-500 combined confirm remains the recorded decision step.

## Gates

tsc clean, eslint clean, full unit **255 suites / 2154 tests**. Migration numbering: 0090 (0088/0089 reserved for the in-flight views/event branches; the migrator sorts lexicographically, no contiguity requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB