### PR TITLE
feat(db): computed views for tenant counters behind STATS_VIEWS_ENABLED

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -3,6 +3,7 @@ import { ApiKeyService } from '../auth/api-key.service';
 import { SurrealService } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { mapWithLimit } from '../common/parallel';
+import { envFlagEnabled } from '../common/env-validation';
 
 /** Per-tenant fan-out concurrency for admin cross-tenant reads. */
 const TENANT_FANOUT = 4;
@@ -121,6 +122,8 @@ export interface AuditPage {
 @Injectable()
 export class AdminService {
   private readonly logger = new Logger(AdminService.name);
+  /** Tenants whose view-read failure has already been logged (log once). */
+  private readonly viewFallbackLogged = new Set<string>();
 
   constructor(
     private readonly apiKeys: ApiKeyService,
@@ -696,6 +699,24 @@ export class AdminService {
     deadLetter24h: number;
     forgotten24h: number;
   }> {
+    // STATS_VIEWS_ENABLED: read the entity/fact counters from the 0088
+    // computed tables (incrementally maintained by SurrealDB on source
+    // writes) instead of re-aggregating live. The 24h moving windows and
+    // the last-20 row reads stay live in both paths. A failing view read
+    // (pre-0088 tenant) logs once per tenant and falls back live.
+    if (envFlagEnabled(process.env.STATS_VIEWS_ENABLED)) {
+      try {
+        return await this.collectTenantFromViews(companyId, dayAgoIso);
+      } catch (err) {
+        if (!this.viewFallbackLogged.has(companyId)) {
+          this.viewFallbackLogged.add(companyId);
+          this.logger.warn(
+            `stats views unavailable for ${companyId} (pre-0088 tenant?), ` +
+              `falling back to live counts: ${(err as Error).message}`,
+          );
+        }
+      }
+    }
     return this.surreal.withCompany(companyId, async (db) => {
       // Batched: counts + last-20 + 24h-window all in one round-trip
       // per tenant. SurrealDB returns one result array per statement
@@ -752,6 +773,71 @@ export class AdminService {
   }
 
   /**
+   * View-backed variant of collectTenant: the three plain counters come
+   * from the 0088 rollup tables (one row fetch each); everything
+   * time-windowed or row-shaped stays identical to the live path.
+   */
+  private async collectTenantFromViews(
+    companyId: string,
+    dayAgoIso: string,
+  ): Promise<{
+    row: AdminTenantRow;
+    deadLetter: AdminDeadLetterRow[];
+    forgotten: AdminForgottenRow[];
+    deadLetter24h: number;
+    forgotten24h: number;
+  }> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const sql = `
+        SELECT n FROM stats_entity_total;
+        SELECT n, status FROM stats_fact_by_status;
+        SELECT id, reason, rejectedAt, payload FROM ingest_dead_letter
+          ORDER BY rejectedAt DESC LIMIT 20;
+        SELECT count() AS c FROM ingest_dead_letter
+          WHERE rejectedAt > type::datetime($dayAgoIso) GROUP ALL;
+        SELECT entityIdHash, reason, forgottenAt, factsDeleted, edgesDeleted
+          FROM forgotten_entity ORDER BY forgottenAt DESC LIMIT 20;
+        SELECT count() AS c FROM forgotten_entity
+          WHERE forgottenAt > type::datetime($dayAgoIso) GROUP ALL;
+      `;
+      const res = (await db.query<any[]>(sql, { dayAgoIso })) as any[];
+
+      const entities = viewCountOf(res[0]);
+      const byStatus = statusCountsOf(res[1]);
+      const deadLetterRows = (res[2] ?? []) as any[];
+      const dl24 = countOf(res[3]);
+      const forgottenRows = (res[4] ?? []) as any[];
+      const fg24 = countOf(res[5]);
+
+      return {
+        row: {
+          companyId,
+          entities,
+          factsActive: byStatus.get('active') ?? 0,
+          factsRetracted: byStatus.get('retracted') ?? 0,
+        },
+        deadLetter: deadLetterRows.map((r) => ({
+          companyId,
+          id: String(r.id),
+          reason: r.reason,
+          rejectedAt: new Date(r.rejectedAt).toISOString(),
+          payload: r.payload ?? {},
+        })),
+        forgotten: forgottenRows.map((r) => ({
+          companyId,
+          entityIdHash: r.entityIdHash,
+          reason: r.reason,
+          forgottenAt: new Date(r.forgottenAt).toISOString(),
+          factsDeleted: r.factsDeleted ?? 0,
+          edgesDeleted: r.edgesDeleted ?? 0,
+        })),
+        deadLetter24h: dl24,
+        forgotten24h: fg24,
+      };
+    });
+  }
+
+  /**
    * Drop a tenant's entire per-tenant database. The caller is responsible
    * for authorising this (the admin API restricts it to ephemeral eval_*
    * tenants) — this just performs the DB-level teardown.
@@ -765,6 +851,25 @@ function countOf(stmtResult: any): number {
   if (!Array.isArray(stmtResult) || stmtResult.length === 0) return 0;
   const first = stmtResult[0];
   return typeof first?.c === 'number' ? first.c : 0;
+}
+
+/** Single-row GROUP ALL view: absent row (empty source) reads as 0. */
+function viewCountOf(stmtResult: any): number {
+  if (!Array.isArray(stmtResult) || stmtResult.length === 0) return 0;
+  const first = stmtResult[0];
+  return typeof first?.n === 'number' ? first.n : 0;
+}
+
+/** GROUP BY status view rows → status → n. Missing groups read as 0. */
+function statusCountsOf(stmtResult: any): Map<string, number> {
+  const out = new Map<string, number>();
+  if (!Array.isArray(stmtResult)) return out;
+  for (const row of stmtResult as Array<{ n?: unknown; status?: unknown }>) {
+    if (typeof row?.status === 'string' && typeof row?.n === 'number') {
+      out.set(row.status, row.n);
+    }
+  }
+  return out;
 }
 
 function sum(xs: number[]): number {

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1540,6 +1540,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
           'Facet routing (dialogue profile only): a turn containing a list (3+ items) or a proper name also gets a SPECIALIST extraction pass whose only contract is that one thing, unioned with the general pass. Strictly additive recall — the general pass still runs and the union deduplicates. The router is a local heuristic, not an LLM call. Costs one extra extraction call per detected facet. Requires re-ingest.',
       },
       {
+        key: 'STATS_VIEWS_ENABLED',
+        category: 'misc',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'Tenant counter reads (StatsService.overview Usage page, admin dashboard per-tenant counters) come from the 0088 incrementally-maintained count() rollup tables (stats_entity_total / stats_fact_by_status / stats_community_total) instead of live GROUP aggregates. Counts only — SurrealDB incremental view maintenance is exact for count() but has known upstream bugs for median/stddev-class aggregates. The view path bypasses the 30s LRU (the view IS the cache); moving-window counts (facts last 7d, dead-letter/forgotten last 24h) stay live in both paths. A failing view read (pre-0088 tenant) logs once per tenant and falls back to live counting. Off (default) → byte-identical pre-0088 behavior.',
+      },
+      {
         key: 'LIVE_SUBSCRIPTIONS_ENABLED',
         category: 'misc',
         defaultValue: '0',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -661,6 +661,10 @@ const KNOWN_BOOLEAN_FLAGS = [
   // FLAG_VALUES still parses as OFF, i.e. in-thread NLI inference.
   'CHAT_ROUTE_NLI_WORKER',
   'THROTTLE_DISABLED',
+  // 0088 stats views: tenant counter reads come from the incrementally
+  // maintained count() rollup tables instead of live GROUP aggregates.
+  // Off (default) → byte-identical pre-0088 live counting.
+  'STATS_VIEWS_ENABLED',
   'INDEXER_WEBHOOK_PUSH_ENABLED',
   'REINDEX_ON_PACK_INSTALL',
   'DOCUMENT_ALLOW_UNGROUNDED_EXTERNAL',

--- a/src/db/migrations/0088_stats_views.surql
+++ b/src/db/migrations/0088_stats_views.surql
@@ -1,0 +1,41 @@
+-- 0088: stats views — incrementally-maintained count() rollups for the
+-- tenant counter surfaces (first `AS SELECT` computed tables in the
+-- schema).
+--
+-- Why: StatsService.overview (end-user Usage page) and the admin
+-- dashboard fan-out (AdminService.collectTenant) re-run the same COUNT
+-- aggregates over the largest tables on every page load. A computed
+-- table makes SurrealDB maintain the counts on source writes instead:
+-- the read becomes an O(#groups) row fetch, and write amplification is
+-- one tiny rollup-row update per source mutation.
+--
+-- Why counts ONLY: SurrealDB's incremental view maintenance has known
+-- upstream bugs for non-invertible aggregates (math::median /
+-- math::stddev drift after deletes/updates because they cannot be
+-- decremented exactly). count() is exactly invertible — +1 on create,
+-- -1 on delete, group-move on update — so count rollups are the safe
+-- class. Keep median/stddev-style rollups OUT of computed tables until
+-- upstream fixes land.
+--
+-- 3.1.5 semantics: the initial materialization runs the full SELECT at
+-- DEFINE time, so tenants that already hold data get correct counts the
+-- moment this migration applies (tenant tables are moderate — this is a
+-- one-off scan per tenant DB). After that the table updates
+-- incrementally on every source write. SurrealDB 3.2 makes computed
+-- tables read-only — we never write them, so that upgrade is a no-op
+-- for these tables.
+--
+-- Read path: STATS_VIEWS_ENABLED (default off) gates the view reads in
+-- StatsService / AdminService; flag off = the live GROUP queries,
+-- byte-identical to pre-0088 behavior. Time-windowed counts (facts last
+-- 7d, dead-letter/forgotten last 24h) stay live in BOTH paths — a
+-- moving window cannot be a static view.
+
+DEFINE TABLE IF NOT EXISTS stats_entity_total AS
+  SELECT count() AS n FROM knowledge_entity GROUP ALL;
+
+DEFINE TABLE IF NOT EXISTS stats_fact_by_status AS
+  SELECT count() AS n, status FROM knowledge_fact GROUP BY status;
+
+DEFINE TABLE IF NOT EXISTS stats_community_total AS
+  SELECT count() AS n FROM community_node GROUP ALL;

--- a/src/stats/stats.service.ts
+++ b/src/stats/stats.service.ts
@@ -1,6 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { SurrealService } from '../db/surreal.service';
 import { LRUCache } from '../common/lru-cache';
+import { envFlagEnabled } from '../common/env-validation';
 
 export interface MemoryStats {
   entities: number;
@@ -17,9 +18,20 @@ export interface MemoryStats {
  * StatsService — cheap per-company memory counts for the end-user
  * "Usage" surface. One batched round-trip of COUNT aggregates, run on a
  * scope-bound connection so PII permissions still apply.
+ *
+ * Two read paths behind STATS_VIEWS_ENABLED (default off):
+ *   - off: live GROUP aggregates + 30s LRU (pre-0088 behavior).
+ *   - on: the 0088 computed tables (stats_entity_total /
+ *     stats_fact_by_status / stats_community_total) — SurrealDB keeps
+ *     them incrementally up to date on source writes, so the view IS
+ *     the cache and the LRU is deliberately bypassed. factsLast7d is a
+ *     moving window and stays a live count in both paths. A failing
+ *     view read (pre-migration tenant) logs once per tenant and falls
+ *     back to the live path.
  */
 @Injectable()
 export class StatsService {
+  private readonly logger = new Logger(StatsService.name);
   /** 30s per-tenant cache: six COUNT aggregates over the largest tables
    *  per dashboard page-load is pure waste — counts move slower than
    *  users refresh. Keyed by tenant only (the counts are not
@@ -30,6 +42,8 @@ export class StatsService {
     { stats: MemoryStats; at: number }
   >(500);
   private static readonly CACHE_TTL_MS = 30_000;
+  /** Tenants whose view-read failure has already been logged (log once). */
+  private readonly viewFallbackLogged = new Set<string>();
 
   constructor(private readonly surreal: SurrealService) {}
 
@@ -38,6 +52,20 @@ export class StatsService {
     scopes: readonly string[],
   ): Promise<MemoryStats> {
     const nowMs = Date.now();
+    if (envFlagEnabled(process.env.STATS_VIEWS_ENABLED)) {
+      try {
+        return await this.overviewFromViews(companyId, scopes, nowMs);
+      } catch (err) {
+        if (!this.viewFallbackLogged.has(companyId)) {
+          this.viewFallbackLogged.add(companyId);
+          this.logger.warn(
+            `stats views unavailable for ${companyId} (pre-0088 tenant?), ` +
+              `falling back to live counts: ${(err as Error).message}`,
+          );
+        }
+        // fall through to the live path below
+      }
+    }
     const cached = this.cache.get(companyId);
     if (cached && nowMs - cached.at < StatsService.CACHE_TTL_MS) {
       return cached.stats;
@@ -66,10 +94,62 @@ export class StatsService {
       return stats;
     });
   }
+
+  /**
+   * View-backed read: three rollup-table fetches + the one live moving
+   * window. No LRU on this path — the computed tables are already the
+   * cached counts, and skipping the LRU means the flag flip is visible
+   * immediately instead of after a TTL.
+   */
+  private async overviewFromViews(
+    companyId: string,
+    scopes: readonly string[],
+    nowMs: number,
+  ): Promise<MemoryStats> {
+    const weekAgoIso = new Date(nowMs - 7 * 24 * 60 * 60 * 1000).toISOString();
+    return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
+      const sql = `
+        SELECT n FROM stats_entity_total;
+        SELECT n, status FROM stats_fact_by_status;
+        SELECT n FROM stats_community_total;
+        SELECT count() AS c FROM knowledge_fact WHERE recordedAt > type::datetime($weekAgoIso) GROUP ALL;
+      `;
+      const res = (await db.query<unknown[]>(sql, { weekAgoIso })) as unknown[];
+      const byStatus = statusCountsOf(res[1]);
+      return {
+        entities: viewCountOf(res[0]),
+        factsActive: byStatus.get('active') ?? 0,
+        factsCompeting: byStatus.get('competing') ?? 0,
+        factsRetracted: byStatus.get('retracted') ?? 0,
+        communities: viewCountOf(res[2]),
+        factsLast7d: countOf(res[3]),
+        asOf: new Date(nowMs).toISOString(),
+      };
+    });
+  }
 }
 
 function countOf(stmtResult: unknown): number {
   if (!Array.isArray(stmtResult) || stmtResult.length === 0) return 0;
   const first = stmtResult[0] as { c?: unknown };
   return typeof first?.c === 'number' ? first.c : 0;
+}
+
+/** Single-row GROUP ALL view: absent row (empty source) reads as 0. */
+function viewCountOf(stmtResult: unknown): number {
+  if (!Array.isArray(stmtResult) || stmtResult.length === 0) return 0;
+  const first = stmtResult[0] as { n?: unknown };
+  return typeof first?.n === 'number' ? first.n : 0;
+}
+
+/** GROUP BY status view rows → status → n. Missing groups read as 0. */
+function statusCountsOf(stmtResult: unknown): Map<string, number> {
+  const out = new Map<string, number>();
+  if (!Array.isArray(stmtResult)) return out;
+  for (const row of stmtResult as Array<{ n?: unknown; status?: unknown }>) {
+    if (typeof row?.status === 'string' && typeof row?.n === 'number') {
+      out.set(row.status, row.n);
+    }
+  }
+  return out;
 }

--- a/test/stats-views.e2e-spec.ts
+++ b/test/stats-views.e2e-spec.ts
@@ -1,0 +1,208 @@
+/**
+ * Migration 0088 stats views against a REAL SurrealDB (testcontainers,
+ * 3.1.5): the first `AS SELECT` computed tables in the schema.
+ *
+ * Verifies the three properties the flag rollout rests on:
+ *   1. the views track live GROUP counts INCREMENTALLY in both
+ *      directions — creates increment, status flips move rows between
+ *      groups, deletes decrement;
+ *   2. a view defined AFTER data exists materializes the current counts
+ *      at DEFINE time (what production tenants see when 0088 applies);
+ *   3. STATS_VIEWS_ENABLED=on serves the same numbers through
+ *      /v1/stats/overview and the admin fan-out as the flag-off live
+ *      path, and off stays the legacy behavior.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { AdminService } from '../src/admin/admin.service';
+
+interface LiveCounts {
+  entities: number;
+  active: number;
+  competing: number;
+  retracted: number;
+}
+
+describe('stats views (migration 0088, real SurrealDB)', () => {
+  let f: AppFixture;
+  let surreal: SurrealService;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const savedFlag = process.env.STATS_VIEWS_ENABLED;
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_stats_views_e2e' });
+    surreal = f.app.get(SurrealService);
+  });
+
+  afterAll(async () => {
+    if (savedFlag === undefined) delete process.env.STATS_VIEWS_ENABLED;
+    else process.env.STATS_VIEWS_ENABLED = savedFlag;
+    if (f) await f.close();
+  });
+
+  async function ingestFact(subjectId: string, predicate: string, object: string) {
+    const res = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: { vertical: 'rent', id: subjectId },
+      predicate,
+      object,
+      validFrom: '2026-01-01',
+      confidence: 0.9,
+      source: { vertical: 'rent', recorder: 'bot' },
+    });
+    expect([200, 201]).toContain(res.status);
+    return res.body.factId as string;
+  }
+
+  async function liveCounts(): Promise<LiveCounts> {
+    return surreal.withCompany(f.companyId, async (db) => {
+      const res = (await db.query<unknown[]>(`
+        SELECT count() AS c FROM knowledge_entity GROUP ALL;
+        SELECT count() AS c FROM knowledge_fact WHERE status = 'active' GROUP ALL;
+        SELECT count() AS c FROM knowledge_fact WHERE status = 'competing' GROUP ALL;
+        SELECT count() AS c FROM knowledge_fact WHERE status = 'retracted' GROUP ALL;
+      `)) as Array<Array<{ c?: number }>>;
+      return {
+        entities: res[0]?.[0]?.c ?? 0,
+        active: res[1]?.[0]?.c ?? 0,
+        competing: res[2]?.[0]?.c ?? 0,
+        retracted: res[3]?.[0]?.c ?? 0,
+      };
+    });
+  }
+
+  async function viewCounts(): Promise<LiveCounts> {
+    return surreal.withCompany(f.companyId, async (db) => {
+      const res = (await db.query<unknown[]>(`
+        SELECT n FROM stats_entity_total;
+        SELECT n, status FROM stats_fact_by_status;
+      `)) as Array<Array<{ n?: number; status?: string }>>;
+      const byStatus = new Map<string, number>();
+      for (const row of res[1] ?? []) {
+        if (typeof row.status === 'string' && typeof row.n === 'number') {
+          byStatus.set(row.status, row.n);
+        }
+      }
+      return {
+        entities: res[0]?.[0]?.n ?? 0,
+        active: byStatus.get('active') ?? 0,
+        competing: byStatus.get('competing') ?? 0,
+        retracted: byStatus.get('retracted') ?? 0,
+      };
+    });
+  }
+
+  const factIds: string[] = [];
+
+  it('views exist after migration and track ingested rows incrementally', async () => {
+    factIds.push(await ingestFact('stats_subject_a', 'claim_alpha', 'first claim'));
+    factIds.push(await ingestFact('stats_subject_a', 'claim_beta', 'second claim'));
+    factIds.push(await ingestFact('stats_subject_b', 'claim_gamma', 'third claim'));
+    factIds.push(await ingestFact('stats_subject_b', 'claim_delta', 'fourth claim'));
+
+    const live = await liveCounts();
+    const view = await viewCounts();
+    expect(live.active).toBeGreaterThanOrEqual(4);
+    expect(view).toEqual(live);
+  });
+
+  it('status flips move rows between view groups (both directions)', async () => {
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `UPDATE type::record('knowledge_fact', $a) SET status = 'competing';
+         UPDATE type::record('knowledge_fact', $b) SET status = 'retracted';`,
+        { a: factIds[0].split(':')[1], b: factIds[1].split(':')[1] },
+      );
+    });
+
+    const live = await liveCounts();
+    const view = await viewCounts();
+    expect(live.competing).toBeGreaterThanOrEqual(1);
+    expect(live.retracted).toBeGreaterThanOrEqual(1);
+    expect(view).toEqual(live);
+
+    // Flip one back — the group counts must decrement/increment again.
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `UPDATE type::record('knowledge_fact', $a) SET status = 'active'`,
+        { a: factIds[0].split(':')[1] },
+      );
+    });
+    expect(await viewCounts()).toEqual(await liveCounts());
+  });
+
+  it('deletes decrement the view counts', async () => {
+    const before = await viewCounts();
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(`DELETE type::record('knowledge_fact', $t)`, {
+        t: factIds[3].split(':')[1],
+      });
+    });
+    const live = await liveCounts();
+    const view = await viewCounts();
+    expect(view.active).toBe(before.active - 1);
+    expect(view).toEqual(live);
+  });
+
+  it('a view defined AFTER data exists materializes current counts at DEFINE time', async () => {
+    // This is the production-migration case: tenant tables already hold
+    // rows when 0088 applies. 3.1.5 runs the full SELECT once at DEFINE.
+    const live = await liveCounts();
+    const probed = await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `DEFINE TABLE stats_probe_initial AS
+           SELECT count() AS n FROM knowledge_entity GROUP ALL`,
+      );
+      const res = (await db.query<unknown[]>(
+        `SELECT n FROM stats_probe_initial`,
+      )) as Array<Array<{ n?: number }>>;
+      await db.query(`REMOVE TABLE stats_probe_initial`);
+      return res[0]?.[0]?.n ?? 0;
+    });
+    expect(probed).toBe(live.entities);
+  });
+
+  it('flag on serves view-backed numbers through /v1/stats/overview; flag off stays legacy', async () => {
+    const live = await liveCounts();
+
+    process.env.STATS_VIEWS_ENABLED = '1';
+    const on = await f.http.get('/v1/stats/overview').set(auth());
+    expect(on.status).toBe(200);
+    expect(on.body).toMatchObject({
+      entities: live.entities,
+      factsActive: live.active,
+      factsCompeting: live.competing,
+      factsRetracted: live.retracted,
+    });
+
+    delete process.env.STATS_VIEWS_ENABLED;
+    const off = await f.http.get('/v1/stats/overview').set(auth());
+    expect(off.status).toBe(200);
+    // Same data state → identical numbers on the legacy live path.
+    const { asOf: _onAsOf, ...onRest } = on.body;
+    const { asOf: _offAsOf, ...offRest } = off.body;
+    expect(offRest).toEqual(onRest);
+  });
+
+  it('flag on: overview reflects a write immediately (no 30s LRU on the view path)', async () => {
+    process.env.STATS_VIEWS_ENABLED = '1';
+    const before = await f.http.get('/v1/stats/overview').set(auth());
+    factIds.push(await ingestFact('stats_subject_c', 'claim_epsilon', 'fifth claim'));
+    const after = await f.http.get('/v1/stats/overview').set(auth());
+    expect(after.body.factsActive).toBe(before.body.factsActive + 1);
+    delete process.env.STATS_VIEWS_ENABLED;
+  });
+
+  it('admin fan-out reads the same counters from the views', async () => {
+    process.env.STATS_VIEWS_ENABLED = '1';
+    const live = await liveCounts();
+    const overview = await f.app.get(AdminService).buildOverview();
+    const row = overview.tenants.find((t) => t.companyId === f.companyId);
+    expect(row).toEqual({
+      companyId: f.companyId,
+      entities: live.entities,
+      factsActive: live.active,
+      factsRetracted: live.retracted,
+    });
+    delete process.env.STATS_VIEWS_ENABLED;
+  });
+});

--- a/test/stats-views.unit-spec.ts
+++ b/test/stats-views.unit-spec.ts
@@ -1,0 +1,246 @@
+/**
+ * STATS_VIEWS_ENABLED gating + fallback unit tests (migration 0088).
+ *
+ * StatsService.overview and AdminService.collectTenant each have two
+ * read paths: flag off → the legacy live GROUP aggregates (with the
+ * 30s LRU in StatsService); flag on → the 0088 count() rollup views,
+ * no LRU (the view IS the cache), and an error on the view read falls
+ * back to the live path with a once-per-tenant warning.
+ */
+import { StatsService } from '../src/stats/stats.service';
+import { AdminService } from '../src/admin/admin.service';
+
+/** Per-statement results for the LEGACY six-count stats query. */
+function legacyStatsResults(): unknown[] {
+  return [
+    [{ c: 7 }], // entities
+    [{ c: 5 }], // active
+    [{ c: 2 }], // competing
+    [{ c: 1 }], // retracted
+    [{ c: 3 }], // communities
+    [{ c: 4 }], // last 7d
+  ];
+}
+
+/** Per-statement results for the VIEW-backed stats query. */
+function viewStatsResults(): unknown[] {
+  return [
+    [{ n: 7 }], // stats_entity_total
+    [
+      { n: 5, status: 'active' },
+      { n: 1, status: 'retracted' },
+      { n: 9, status: 'superseded' }, // not surfaced — must be ignored
+    ], // stats_fact_by_status (no 'competing' group → 0)
+    [], // stats_community_total — empty source, no row yet
+    [{ c: 4 }], // last 7d (live in both paths)
+  ];
+}
+
+function makeStatsService(query: jest.Mock) {
+  const db = { query };
+  const surreal = {
+    withScopedCompany: jest.fn(
+      (_c: string, _s: readonly string[], fn: (d: unknown) => unknown) =>
+        fn(db),
+    ),
+  };
+  const svc = new StatsService(surreal as never);
+  const warn = jest.fn();
+  (svc as unknown as { logger: { warn: jest.Mock } }).logger = { warn };
+  return { svc, warn };
+}
+
+describe('StatsService view gating (STATS_VIEWS_ENABLED)', () => {
+  const savedFlag = process.env.STATS_VIEWS_ENABLED;
+
+  afterEach(() => {
+    if (savedFlag === undefined) delete process.env.STATS_VIEWS_ENABLED;
+    else process.env.STATS_VIEWS_ENABLED = savedFlag;
+  });
+
+  it('flag off: runs the legacy GROUP queries and serves the 30s LRU', async () => {
+    delete process.env.STATS_VIEWS_ENABLED;
+    const query = jest.fn(async (_sql: string) => legacyStatsResults());
+    const { svc } = makeStatsService(query);
+
+    const first = await svc.overview('t1', []);
+    expect(first).toMatchObject({
+      entities: 7,
+      factsActive: 5,
+      factsCompeting: 2,
+      factsRetracted: 1,
+      communities: 3,
+      factsLast7d: 4,
+    });
+    const sql = query.mock.calls[0][0];
+    expect(sql).toContain("WHERE status = 'active'");
+    expect(sql).not.toContain('stats_fact_by_status');
+
+    // Second call inside the TTL is served from the LRU — no new query.
+    const second = await svc.overview('t1', []);
+    expect(second).toBe(first);
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('flag on: reads the 0088 views, bypasses the LRU, maps missing groups to 0', async () => {
+    process.env.STATS_VIEWS_ENABLED = '1';
+    const query = jest.fn(async (_sql: string) => viewStatsResults());
+    const { svc } = makeStatsService(query);
+
+    const stats = await svc.overview('t1', []);
+    expect(stats).toMatchObject({
+      entities: 7,
+      factsActive: 5,
+      factsCompeting: 0, // group absent in the view → 0
+      factsRetracted: 1,
+      communities: 0, // GROUP ALL view with no row yet → 0
+      factsLast7d: 4,
+    });
+    const sql = query.mock.calls[0][0];
+    expect(sql).toContain('stats_entity_total');
+    expect(sql).toContain('stats_fact_by_status');
+    expect(sql).toContain('stats_community_total');
+    // The moving window stays a live count even on the view path.
+    expect(sql).toContain('recordedAt > type::datetime($weekAgoIso)');
+
+    // No LRU on the view path — the second call queries again.
+    await svc.overview('t1', []);
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it('flag on + view read error: falls back to live counts and warns once per tenant', async () => {
+    process.env.STATS_VIEWS_ENABLED = '1';
+    const query = jest.fn(async (sql: string) => {
+      if (sql.includes('stats_entity_total')) {
+        throw new Error('no such table');
+      }
+      return legacyStatsResults();
+    });
+    const { svc, warn } = makeStatsService(query);
+
+    const stats = await svc.overview('t1', []);
+    expect(stats.entities).toBe(7);
+    expect(stats.factsCompeting).toBe(2); // legacy result, not the view one
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    // Fallback caches like the legacy path; failing again logs nothing new.
+    await svc.overview('t1', []);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+/** Per-statement results for the LEGACY admin collectTenant query. */
+function legacyAdminResults(): unknown[] {
+  return [
+    [{ c: 7 }], // entities
+    [{ c: 5 }], // active
+    [{ c: 1 }], // retracted
+    [], // dead-letter last 20
+    [{ c: 0 }], // dead-letter 24h
+    [], // forgotten last 20
+    [{ c: 0 }], // forgotten 24h
+  ];
+}
+
+/** Per-statement results for the VIEW-backed admin collectTenant query. */
+function viewAdminResults(): unknown[] {
+  return [
+    [{ n: 7 }], // stats_entity_total
+    [
+      { n: 5, status: 'active' },
+      { n: 2, status: 'competing' }, // admin row does not surface it
+      { n: 1, status: 'retracted' },
+    ],
+    [], // dead-letter last 20
+    [{ c: 0 }], // dead-letter 24h
+    [], // forgotten last 20
+    [{ c: 0 }], // forgotten 24h
+  ];
+}
+
+type CollectTenantResult = {
+  row: { companyId: string; entities: number; factsActive: number; factsRetracted: number };
+};
+
+function makeAdminService(query: jest.Mock) {
+  const db = { query };
+  const surreal = {
+    withCompany: jest.fn((_c: string, fn: (d: unknown) => unknown) => fn(db)),
+  };
+  const svc = new AdminService(
+    { knownCompanyIds: () => ['t1'] } as never,
+    surreal as never,
+    {} as never,
+  );
+  const warn = jest.fn();
+  (svc as unknown as { logger: { warn: jest.Mock } }).logger = { warn };
+  const collect = (companyId: string) =>
+    (
+      svc as unknown as {
+        collectTenant: (c: string, d: string) => Promise<CollectTenantResult>;
+      }
+    ).collectTenant(companyId, new Date().toISOString());
+  return { collect, warn };
+}
+
+describe('AdminService.collectTenant view gating (STATS_VIEWS_ENABLED)', () => {
+  const savedFlag = process.env.STATS_VIEWS_ENABLED;
+
+  afterEach(() => {
+    if (savedFlag === undefined) delete process.env.STATS_VIEWS_ENABLED;
+    else process.env.STATS_VIEWS_ENABLED = savedFlag;
+  });
+
+  it('flag off: runs the legacy GROUP queries', async () => {
+    delete process.env.STATS_VIEWS_ENABLED;
+    const query = jest.fn(async (_sql: string) => legacyAdminResults());
+    const { collect } = makeAdminService(query);
+
+    const out = await collect('t1');
+    expect(out.row).toEqual({
+      companyId: 't1',
+      entities: 7,
+      factsActive: 5,
+      factsRetracted: 1,
+    });
+    const sql = query.mock.calls[0][0];
+    expect(sql).toContain("WHERE status = 'active'");
+    expect(sql).not.toContain('stats_fact_by_status');
+  });
+
+  it('flag on: reads the views; windows and row reads stay live', async () => {
+    process.env.STATS_VIEWS_ENABLED = '1';
+    const query = jest.fn(async (_sql: string) => viewAdminResults());
+    const { collect } = makeAdminService(query);
+
+    const out = await collect('t1');
+    expect(out.row).toEqual({
+      companyId: 't1',
+      entities: 7,
+      factsActive: 5,
+      factsRetracted: 1,
+    });
+    const sql = query.mock.calls[0][0];
+    expect(sql).toContain('stats_entity_total');
+    expect(sql).toContain('stats_fact_by_status');
+    expect(sql).toContain('rejectedAt > type::datetime($dayAgoIso)');
+  });
+
+  it('flag on + view read error: falls back live and warns once per tenant', async () => {
+    process.env.STATS_VIEWS_ENABLED = '1';
+    const query = jest.fn(async (sql: string) => {
+      if (sql.includes('stats_entity_total')) {
+        throw new Error('no such table');
+      }
+      return legacyAdminResults();
+    });
+    const { collect, warn } = makeAdminService(query);
+
+    const out = await collect('t1');
+    expect(out.row.entities).toBe(7);
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    await collect('t1');
+    expect(warn).toHaveBeenCalledTimes(1); // logged once per tenant
+  });
+});


### PR DESCRIPTION
## What

The first `DEFINE TABLE … AS SELECT` computed views in the codebase (migration 0088) — Surreal maintains the counters incrementally instead of TS re-aggregating on every call:

- `stats_entity_total`, `stats_fact_by_status`, `stats_community_total` — backing the `/v1/stats/overview` counters and the admin tenant dashboard rows. (The brief guessed "edges"; the service actually counts communities — the views mirror the service, no speculative views added.) Moving-window counts (7d/24h) stay live — a moving window can't be a static view.
- Counts only, deliberately: upstream incremental-update bugs affect median/stddev, not count(); 3.2 makes views read-only (we never write them). Both notes in the migration header.

## Wiring

`STATS_VIEWS_ENABLED` (default off, runtime-mutable, outside the engine-flag regex — **both flag goldens untouched**). Off = byte-identical legacy path. On = view reads, the 30s LRU bypassed (the view IS the cache), once-per-tenant warn + live fallback on view-read errors.

## Evidence (real Surreal via testcontainers)

e2e 7/7: views match live GROUP counts; status flips move rows between groups both directions; deletes decrement; flag-on == flag-off numbers over the HTTP surface; writes visible immediately on the view path. Pinned semantics: DEFINE-time initial materialization over pre-existing rows (what production tenants see when 0088 applies) and exact incremental count maintenance. compaction + abac-row-filter e2e re-run green (view maintenance doesn't break either connection pool).

Full unit 256 suites / 2160 tests, tsc/eslint clean, flag-budget + catalog-truth green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB