### PR TITLE
feat(db): write-time derived-staleness event (0089) — closes the 0072 nightly-drain hole

### DIFF
--- a/src/compaction/recompose.service.ts
+++ b/src/compaction/recompose.service.ts
@@ -51,6 +51,17 @@ const CONTENT_CHANGED = new Set(['superseded', 'retracted']);
  * has not moved), and needs no edit to a 22-argument stored function whose
  * positional contract is a documented footgun.
  *
+ * SINCE 0089 the drain is the BACKSTOP, not the primary path: the
+ * `fact_staleness` DEFINE EVENT (migration 0089) calls fn::mark_derived_stale
+ * at write time, inside the transaction that flips a live parent to
+ * 'superseded'/'retracted' — dependents are stale within the same write, not
+ * the next morning. The drain stays for what the event cannot see: rows
+ * changed while the event was absent (pre-0089 history, an operator
+ * REMOVE EVENT window) and derived-world parents (the event's
+ * `derivedVersion IS NONE` guard excludes them so derive runs cannot storm
+ * it). Re-marking an already-stale row is free (`staleAt IS NONE` filter),
+ * so the two paths compose without coordination.
+ *
  * No feature flag: a summary that contradicts a corrected fact is a bug, not a
  * configuration.
  */

--- a/src/db/migrations/0072_derived_staleness.surql
+++ b/src/db/migrations/0072_derived_staleness.surql
@@ -21,6 +21,12 @@
 -- So this migration marks, and a recompute pass acts. A stale summary keeps
 -- being served in the meantime: it is stale, but it is better than the nothing
 -- that hiding it would leave behind.
+--
+-- SINCE 0089: marking is no longer nightly-only. A DEFINE EVENT on
+-- knowledge_fact (fact_staleness, 0089) calls fn::mark_derived_stale the
+-- moment a LIVE parent's status transitions to 'superseded'/'retracted' —
+-- the changefeed drain below remains as the catch-all backstop (pre-event
+-- history, derived-world parents, REMOVE EVENT windows).
 
 DEFINE FIELD IF NOT EXISTS staleAt ON knowledge_fact TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS staleReason ON knowledge_fact TYPE option<string>;

--- a/src/db/migrations/0089_staleness_event.surql
+++ b/src/db/migrations/0089_staleness_event.surql
@@ -1,0 +1,88 @@
+-- 0089_staleness_event — write-time derived-fact staleness (closes the
+-- 0072 latency window).
+--
+-- 0072 built the machinery — staleAt/staleReason + fn::mark_derived_stale —
+-- but left the TRIGGER nightly: RecomposeService drains the changefeed at
+-- 03:05 UTC and only then marks the derived descendants of superseded /
+-- retracted parents. Between a parent's correction and the next drain a
+-- compaction summary keeps serving the stale value for up to 24h. This event
+-- closes that window: the moment a parent's status TRANSITIONS into
+-- 'superseded' or 'retracted', its reverse-derivedFrom closure is marked
+-- stale inside the same transaction, by the same stored function the drain
+-- calls.
+--
+-- THE GUARD (every clause is a storm defence — all four proven on a real
+-- SurrealDB 3.1.5 with the derive-flip shapes, see
+-- test/staleness-event.e2e-spec.ts):
+--
+--   1. $event = 'UPDATE' — never CREATE, never DELETE. The batch deriver
+--      bulk-CREATEs rows that are BORN 'superseded' (supersede chains inside
+--      a derived world) — a freshly created row cannot have pre-existing
+--      dependents, so firing there is pure waste. And promoteStaging's
+--      atomic flip DELETEs the whole final version in one statement — with
+--      no DELETE arm the event does not even evaluate there.
+--
+--   2. $before.status != $after.status — the cheap TRANSITION check. No-op
+--      UPDATEs, content edits, and every non-status write fall through. This
+--      clause is also the RECURSION guard: fn::mark_derived_stale writes
+--      only staleAt/staleReason, never status, so its own UPDATEs re-enter
+--      the WHEN and evaluate false — marking cannot re-fire the event.
+--
+--   3. $after.status IN ['superseded', 'retracted'] — the same
+--      CONTENT_CHANGED vocabulary the nightly drain filters on
+--      (recompose.service.ts). Direction matters: the REVIVE transitions
+--      ('superseded' -> 'active' in promoteStaging's targeted flip and in
+--      reviveSupersededBy, 'retracted' -> 'active' in fn::revive) do not
+--      match. 'compacted' is deliberately absent for 0072's reason:
+--      compaction sets its sources to 'compacted' in the pass that CREATES
+--      the summary from them — treating that as a change would mark every
+--      summary stale at birth. No separate retractedAt clause is needed:
+--      audited 2026-08 — every live writer that sets retractedAt flips
+--      status in the same statement (fn::cascade_retract 0069, the retract
+--      API's merge, recompose's retractOrphan); the only statements that
+--      ever wrote retractedAt without being paired to a status flip were
+--      pre-0033 fn::resolve_fact versions, long overwritten.
+--
+--   4. $after.derivedVersion IS NONE — derive-run rows are excluded
+--      entirely. During a derive run fn::resolve_facts performs thousands
+--      of genuine supersede transitions inside the staging namespace;
+--      staging/derived-world rows never carry compaction-summary dependents
+--      in the live world, so each fire would pay fn::mark_derived_stale's
+--      CONTAINSANY table pass for nothing. Pinned-world compaction
+--      summaries (compaction CAN run over a pinned derived version) keep
+--      the nightly-drain path they had before this migration — no
+--      regression, just no low-latency upgrade for them.
+--
+-- COST. A genuine fire runs one CONTAINSANY pass over knowledge_fact per
+-- recursion level. Measured on 3.1.5: the query planner does NOT serve
+-- CONTAINSANY from a standard index (EXPLAIN shows TableScan with or
+-- without an index on derivedFrom), so no index is added here — it would be
+-- dead weight on every write. The firing population (real supersede/retract
+-- transitions on live rows) is exactly the population the drain scanned for
+-- anyway; the work moved from 03:05 to write time.
+--
+-- DEPTH. fn::mark_derived_stale recurses level by level; `staleAt IS NONE`
+-- makes marking monotone, so it terminates even on cyclic derivedFrom data.
+-- A chain deeper than SurrealDB's computation-depth limit would abort the
+-- triggering write — compaction lineage is depth <= 3 in practice.
+--
+-- BACKSTOP. The nightly drain (RecomposeService.invalidate) stays as the
+-- catch-all: it covers rows written while the event was absent (pre-0089
+-- history, an operator REMOVE EVENT window), derived-world parents excluded
+-- by clause 4, and any future writer whose transition shape the guard does
+-- not anticipate.
+--
+-- REMOVAL. Events are schema, not runtime configuration — there is no flag.
+-- To disable on a tenant:
+--     REMOVE EVENT fact_staleness ON TABLE knowledge_fact;
+-- The nightly drain then carries the whole load again, exactly as pre-0089.
+
+DEFINE EVENT OVERWRITE fact_staleness ON TABLE knowledge_fact
+    WHEN $event = 'UPDATE'
+        AND $before.status != $after.status
+        AND $after.status IN ['superseded', 'retracted']
+        AND $after.derivedVersion IS NONE
+    THEN {
+        -- Same reason string the drain writes — one vocabulary downstream.
+        fn::mark_derived_stale([$after.id], 'parent_changed', time::now());
+    };

--- a/test/staleness-event.e2e-spec.ts
+++ b/test/staleness-event.e2e-spec.ts
@@ -1,0 +1,389 @@
+/**
+ * e2e for the 0089 `fact_staleness` DEFINE EVENT — write-time derived-fact
+ * staleness marking (the low-latency path in front of the nightly drain).
+ *
+ * Four claims, each against a real SurrealDB:
+ *
+ *   1. THE STORM TEST. A full derive-shaped flip — bulk-inserted staged rows
+ *      (including rows BORN 'superseded'), then the real promoteStaging()
+ *      (targeted shape with its superseded->active revive UPDATE, and the
+ *      full-run shape with its wholesale DELETE) — triggers ZERO
+ *      fn::mark_derived_stale marking. Evidence is canary-based: every storm
+ *      row gets a live-world canary child whose derivedFrom points at it; if
+ *      the event had fired on ANY storm row, fn::mark_derived_stale would
+ *      have stamped that row's canary. All canaries staying unstamped ==
+ *      zero fires.
+ *
+ *   2. Supersede a parent via fn::resolve_fact (real ingest route) — the
+ *      dependent summary is stale IMMEDIATELY, with the drain provably
+ *      never having run (no changefeed cursor row for this tenant).
+ *
+ *   3. Retract — both the cascade shape (POST :id/retract ->
+ *      fn::cascade_retract) and the no-cascade shape (recompose
+ *      retractOrphan's direct status flip) mark dependents at write time.
+ *
+ *   4. RECURSION. One transition on the root of a 3-level derivedFrom chain
+ *      marks every level and terminates; the staleness stamping itself
+ *      (staleAt/staleReason writes, status untouched) never re-fires the
+ *      event; repeated transitions are idempotent.
+ */
+import type { Surreal } from 'surrealdb';
+import { StringRecordId } from 'surrealdb';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import {
+  newRunToken,
+  promoteStaging,
+  stagingNamespace,
+} from '../src/admin/derive-staging';
+
+const ENTITY_ID = 'knowledge_entity:staleness_evt';
+
+describe('0089 fact_staleness event', () => {
+  let f: AppFixture;
+  let surreal: SurrealService;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const inDb = <T>(cb: (db: Surreal) => Promise<T>): Promise<T> =>
+    surreal.withCompany(f.companyId, cb);
+
+  const rid = (id: string) => new StringRecordId(id);
+
+  /** Minimal SCHEMAFULL-valid knowledge_fact row for direct seeding. */
+  const factRow = (
+    id: string,
+    over: Record<string, unknown> = {},
+  ): Record<string, unknown> => ({
+    id: rid(id),
+    entityId: rid(ENTITY_ID),
+    predicate: 'e2e_staleness',
+    object: `object for ${id}`,
+    confidence: 0.9,
+    validFrom: new Date(),
+    source: { vertical: 'e2e', eventId: 'staleness.seed' },
+    status: 'active',
+    ...over,
+  });
+
+  const staleOf = async (ids: string[]) =>
+    inDb(async (db) => {
+      const [rows] = await db.query<[Array<{ id: unknown; staleAt: unknown; staleReason: unknown }>]>(
+        `SELECT id, staleAt, staleReason FROM knowledge_fact WHERE id IN $ids`,
+        { ids: ids.map(rid) },
+      );
+      return new Map(
+        ((rows as any[]) ?? []).map((r) => [String(r.id), r]),
+      );
+    });
+
+  const tenantStaleCount = async (): Promise<number> =>
+    inDb(async (db) => {
+      const [rows] = await db.query<[Array<{ count: number }>]>(
+        `SELECT count() FROM knowledge_fact WHERE staleAt IS NOT NONE GROUP ALL`,
+      );
+      return ((rows as any[]) ?? [])[0]?.count ?? 0;
+    });
+
+  beforeAll(async () => {
+    f = await createApp();
+    surreal = f.app.get(SurrealService);
+    await inDb((db) =>
+      db.query(
+        `CREATE ${ENTITY_ID} SET type = 'other', canonicalName = 'staleness e2e'`,
+      ),
+    );
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  // ── 1. THE STORM TEST ────────────────────────────────────────────────
+  it('a full derive-shaped flip triggers zero mark_derived_stale work', async () => {
+    const FINAL = 'e2estorm';
+    const ns = stagingNamespace(FINAL, newRunToken());
+    const staleBefore = await tenantStaleCount();
+
+    // Storm-row ids, chosen up front so canaries can reference them
+    // BEFORE they exist (record links need no referential existence) —
+    // that way even a misfire on the CREATE direction would stamp a canary.
+    const convA = Array.from({ length: 40 }, (_, i) => `knowledge_fact:storm_a${i}`);
+    const revivable = Array.from({ length: 20 }, (_, i) => `knowledge_fact:storm_r${i}`);
+    const convB = Array.from({ length: 20 }, (_, i) => `knowledge_fact:storm_b${i}`);
+    const stagedB = Array.from({ length: 80 }, (_, i) => `knowledge_fact:storm_s${i}`);
+    const stagedFull = Array.from({ length: 80 }, (_, i) => `knowledge_fact:storm_f${i}`);
+    const stormIds = [...convA, ...revivable, ...convB, ...stagedB, ...stagedFull];
+    const canaryIds = stormIds.map((id) => id.replace('knowledge_fact:storm_', 'knowledge_fact:canary_'));
+
+    await inDb(async (db) => {
+      // Canaries first: live-world (derivedVersion NONE) children, one per
+      // storm row.
+      await db.query(`INSERT INTO knowledge_fact $rows`, {
+        rows: stormIds.map((id, i) =>
+          factRow(canaryIds[i], { derivedFrom: [rid(id)] }),
+        ),
+      });
+      // The final world: convA rows, 20 of them superseded-by-convB (the
+      // revive population), and convB rows the targeted flip will DELETE.
+      await db.query(`INSERT INTO knowledge_fact $rows`, {
+        rows: [
+          ...convA.map((id) =>
+            factRow(id, {
+              derivedVersion: FINAL,
+              source: { vertical: 'e2e', conversationId: 'convA' },
+            }),
+          ),
+          ...revivable.map((id, i) =>
+            factRow(id, {
+              derivedVersion: FINAL,
+              status: 'superseded',
+              supersededBy: rid(convB[i]),
+              source: { vertical: 'e2e', conversationId: 'convA' },
+            }),
+          ),
+          ...convB.map((id) =>
+            factRow(id, {
+              derivedVersion: FINAL,
+              source: { vertical: 'e2e', conversationId: 'convB' },
+            }),
+          ),
+        ],
+      });
+      // The staged world: bulk insert, half of it BORN 'superseded' — the
+      // deriver writes supersede chains directly into staging.
+      await db.query(`INSERT INTO knowledge_fact $rows`, {
+        rows: stagedB.map((id, i) =>
+          factRow(id, {
+            derivedVersion: ns.staging,
+            status: i % 2 === 0 ? 'active' : 'superseded',
+            source: { vertical: 'e2e', conversationId: 'convB' },
+          }),
+        ),
+      });
+      // Mid-run deriver writes also UPDATE staged rows into 'superseded'
+      // (fn::resolve_facts slot supersede). Guard clause 4 must keep the
+      // event silent on version-stamped rows.
+      await db.query(
+        `UPDATE knowledge_fact SET status = 'superseded'
+          WHERE derivedVersion = $staging AND status = 'active' AND id IN $ids`,
+        { staging: ns.staging, ids: stagedB.slice(0, 10).map(rid) },
+      );
+
+      // TARGETED flip: DELETE final convB + promote staged convB + the
+      // revive UPDATE flipping convA rows superseded -> active.
+      await promoteStaging(db, ns, { conversationId: 'convB' });
+    });
+
+    // The revive direction must have genuinely run (the storm is real)…
+    const revived = await staleOf(revivable);
+    await inDb(async (db) => {
+      const [rows] = await db.query<[Array<{ count: number }>]>(
+        `SELECT count() FROM knowledge_fact
+          WHERE id IN $ids AND status = 'active' GROUP ALL`,
+        { ids: revivable.map(rid) },
+      );
+      expect(((rows as any[]) ?? [])[0]?.count).toBe(revivable.length);
+    });
+    expect(revived.size).toBe(revivable.length);
+
+    // FULL flip: fresh staging namespace, then the wholesale
+    // DELETE-final + staging->final UPDATE.
+    const ns2 = stagingNamespace(FINAL, newRunToken());
+    await inDb(async (db) => {
+      await db.query(`INSERT INTO knowledge_fact $rows`, {
+        rows: stagedFull.map((id, i) =>
+          factRow(id, {
+            derivedVersion: ns2.staging,
+            status: i % 3 === 0 ? 'superseded' : 'active',
+            source: { vertical: 'e2e', conversationId: 'convA' },
+          }),
+        ),
+      });
+      await promoteStaging(db, ns2);
+      // Flip really happened: the final world is exactly the promoted set.
+      const [rows] = await db.query<[Array<{ count: number }>]>(
+        `SELECT count() FROM knowledge_fact WHERE derivedVersion = $v GROUP ALL`,
+        { v: FINAL },
+      );
+      expect(((rows as any[]) ?? [])[0]?.count).toBe(stagedFull.length);
+    });
+
+    // ZERO fires: no canary was stamped, and the tenant-wide stale count
+    // did not move.
+    const canaries = await staleOf(canaryIds);
+    expect(canaries.size).toBe(canaryIds.length);
+    for (const [id, row] of canaries) {
+      expect({ id, staleAt: row.staleAt ?? null }).toEqual({ id, staleAt: null });
+    }
+    expect(await tenantStaleCount()).toBe(staleBefore);
+  });
+
+  // ── 2. Supersede via fn::resolve_fact ────────────────────────────────
+  it('marks the dependent stale in the same write as a resolve_fact supersede', async () => {
+    const entity = { vertical: 'rent', id: 'staleness_evt_supersede' };
+    const ts = new Date(Date.now() - 10 * 86_400_000).toISOString();
+
+    const first = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: entity,
+      predicate: 'status',
+      object: 'trial',
+      validFrom: ts,
+      source: { vertical: 'rent', eventId: 'auth.decide' },
+      confidence: 0.9,
+    });
+    expect(first.body.outcome).toBe('INSERTED');
+    const parentId = first.body.factId as string;
+
+    const summaryId = 'knowledge_fact:sup_summary';
+    await inDb((db) =>
+      db.query(`INSERT INTO knowledge_fact $rows`, {
+        rows: [
+          factRow(summaryId, {
+            derivedFrom: [rid(parentId)],
+            source: { kind: 'compaction-summary', vertical: 'e2e' },
+          }),
+        ],
+      }),
+    );
+
+    // Same-instant re-decide — the proven SUPERSEDED shape
+    // (backdated-supersede.e2e-spec.ts): fn::resolve_fact flips the
+    // incumbent active -> superseded inside its own transaction.
+    const second = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: entity,
+      predicate: 'status',
+      object: 'premium',
+      validFrom: ts,
+      source: { vertical: 'rent', eventId: 'auth.redecide' },
+      confidence: 0.9,
+    });
+    expect(second.body.outcome).toBe('SUPERSEDED');
+    expect(second.body.supersededFactIds).toContain(parentId);
+
+    // Stale IMMEDIATELY — no drain ran: this tenant has no recompose
+    // changefeed cursor at all.
+    const marked = (await staleOf([summaryId])).get(summaryId)!;
+    expect(marked.staleAt).toBeTruthy();
+    expect(marked.staleReason).toBe('parent_changed');
+    await inDb(async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT * FROM changefeed_state WHERE source = 'recompose:knowledge_fact'`,
+      );
+      expect((rows as any[]) ?? []).toHaveLength(0);
+    });
+  });
+
+  // ── 3. Retract: cascade shape and orphan shape ───────────────────────
+  it('marks dependents during fn::cascade_retract and on a direct retract flip', async () => {
+    const entity = { vertical: 'rent', id: 'staleness_evt_retract' };
+    const ingest = await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: entity,
+      predicate: 'status',
+      object: 'active-customer',
+      validFrom: new Date().toISOString(),
+      source: { vertical: 'rent', eventId: 'auth.decide' },
+      confidence: 0.9,
+    });
+    expect(ingest.body.outcome).toBe('INSERTED');
+    const rootId = ingest.body.factId as string;
+
+    const s1 = 'knowledge_fact:ret_s1';
+    const s2 = 'knowledge_fact:ret_s2';
+    await inDb((db) =>
+      db.query(`INSERT INTO knowledge_fact $rows`, {
+        rows: [
+          factRow(s1, { derivedFrom: [rid(rootId)] }),
+          factRow(s2, { derivedFrom: [rid(s1)] }),
+        ],
+      }),
+    );
+
+    const retract = await f.http
+      .post(`/v1/facts/${encodeURIComponent(rootId)}/retract`)
+      .set(auth())
+      .send({ reason: 'e2e retract', retractedBy: { source: 'human' } });
+    expect(retract.status).toBe(201);
+    expect(retract.body.cascadedFactIds).toEqual(
+      expect.arrayContaining([s1, s2]),
+    );
+
+    // Level ordering: cascade level 1 retracts s1 — that transition fires
+    // the event, which marks s2 stale BEFORE level 2 retracts it. s1
+    // itself is never marked (by the time the root's own transition fires,
+    // s1 is already retracted and fn::mark_derived_stale skips it).
+    const rows = await staleOf([rootId, s1, s2]);
+    expect(rows.get(rootId)!.staleAt ?? null).toBeNull();
+    expect(rows.get(s1)!.staleAt ?? null).toBeNull();
+    expect(rows.get(s2)!.staleAt).toBeTruthy();
+    expect(rows.get(s2)!.staleReason).toBe('parent_changed');
+
+    // The NO-cascade retract shape (recompose retractOrphan): a direct
+    // status flip with no fn::cascade_retract in sight still marks the
+    // dependent at write time — this is the case the event alone covers.
+    const orphan = 'knowledge_fact:ret_orphan';
+    const orphanChild = 'knowledge_fact:ret_orphan_child';
+    await inDb(async (db) => {
+      await db.query(`INSERT INTO knowledge_fact $rows`, {
+        rows: [
+          factRow(orphan),
+          factRow(orphanChild, { derivedFrom: [rid(orphan)] }),
+        ],
+      });
+      await db.query(
+        `UPDATE $id SET status = 'retracted', retractedAt = time::now(),
+           retractedBy = 'system', retractionReason = 'e2e orphan'`,
+        { id: rid(orphan) },
+      );
+    });
+    const orphanRows = await staleOf([orphanChild]);
+    expect(orphanRows.get(orphanChild)!.staleAt).toBeTruthy();
+  });
+
+  // ── 4. Recursion: 3-level chain, no loop, stamping never re-fires ────
+  it('marks a 3-level chain from one transition and cannot re-fire itself', async () => {
+    const root = 'knowledge_fact:rec_root';
+    const l1 = 'knowledge_fact:rec_l1';
+    const l2 = 'knowledge_fact:rec_l2';
+    const l3 = 'knowledge_fact:rec_l3';
+    await inDb((db) =>
+      db.query(`INSERT INTO knowledge_fact $rows`, {
+        rows: [
+          factRow(root),
+          factRow(l1, { derivedFrom: [rid(root)] }),
+          factRow(l2, { derivedFrom: [rid(l1)] }),
+          factRow(l3, { derivedFrom: [rid(l2)] }),
+        ],
+      }),
+    );
+
+    // One transition. If the staleness stamp could re-fire the event this
+    // would loop forever and the query would never return (jest timeout).
+    await inDb((db) =>
+      db.query(`UPDATE $id SET status = 'superseded'`, { id: rid(root) }),
+    );
+
+    const marked = await staleOf([root, l1, l2, l3]);
+    expect(marked.get(root)!.staleAt ?? null).toBeNull();
+    for (const id of [l1, l2, l3]) {
+      expect(marked.get(id)!.staleAt).toBeTruthy();
+      expect(marked.get(id)!.staleReason).toBe('parent_changed');
+    }
+    const stamps = [l1, l2, l3].map((id) => String(marked.get(id)!.staleAt));
+
+    const countBefore = await tenantStaleCount();
+    await inDb(async (db) => {
+      // A non-status write on a stale row: transition clause is false.
+      await db.query(`UPDATE $id SET confidence = 0.5`, { id: rid(l1) });
+      // Repeated transitions are idempotent: revive (guard direction never
+      // matches) and re-supersede (fires, but `staleAt IS NONE` makes the
+      // marking a no-op).
+      await db.query(`UPDATE $id SET status = 'active'`, { id: rid(root) });
+      await db.query(`UPDATE $id SET status = 'superseded'`, { id: rid(root) });
+    });
+    expect(await tenantStaleCount()).toBe(countBefore);
+    const after = await staleOf([l1, l2, l3]);
+    expect([l1, l2, l3].map((id) => String(after.get(id)!.staleAt))).toEqual(
+      stamps,
+    );
+  });
+});


### PR DESCRIPTION
## What

`DEFINE EVENT fact_staleness ON knowledge_fact` (migration 0089) marks derived dependents stale the moment a parent is superseded/retracted — write-time latency instead of the 03:05 nightly drain. The drain stays as the crash backstop (documented in recompose.service + the 0072 header addendum).

## The guard (four clauses, each a storm defence)

UPDATE-only (deriver bulk-CREATEs born-superseded rows; the flip DELETEs wholesale — no CREATE/DELETE arms) · status-transition check (doubles as the recursion guard: `fn::mark_derived_stale` writes only staleAt/staleReason, never status) · the drain's exact status vocabulary (the flip's revive direction superseded→active doesn't match; retractedAt needs no separate clause — every live writer sets it with status in the same statement, audited) · `derivedVersion IS NONE` (probe finding: the 3.1.5 planner never serves CONTAINSANY from an index → every fire is a table pass, and `fn::resolve_facts` performs thousands of genuine transitions inside staging mid-derive — this clause silences the whole derive run, not just the flip).

## Evidence (real Surreal, canary-instrumented, 4/4 twice)

- **Storm test**: 240 rows — staged bulk inserts, mid-run staging supersedes, real `promoteStaging` targeted flip (revive genuinely exercised) and full flip → **zero canaries stamped, stale-count delta 0**.
- Supersede via `fn::resolve_fact` → dependent stale in the same write, drain provably never ran (no changefeed cursor row exists).
- Retract cascade + the orphan-flip case only the event covers; 3-level recursion chain terminates, idempotent re-stamps byte-stable.
- `brain.e2e` 15/15 with the event live; full unit 255/2154; flag-budget + catalog-truth green (no new flags — events are schema; removal ritual documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB