### PR TITLE
feat(strategy): ReasoningBank-shape strategy-memory lane — separate store, k=1 advisory retrieval, distill + lifecycle cron

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1702,6 +1702,43 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
         description:
           'Promote old corroborated append_only fact groups into a durable summary. Bounded by COMPACTION_PROMOTION_MAX_GROUPS per run.',
       },
+      // ── Strategy-memory lane (G4) ────────────────────────────
+      {
+        key: 'STRATEGY_MEMORY_ENABLED',
+        category: 'pipeline',
+        defaultValue: '0',
+        runtimeMutable: false,
+        isBooleanFlag: true,
+        description:
+          "Strategy-memory lane master switch (migration 0092, ReasoningBank shape): a SEPARATE strategy_memory store of distilled how-to-answer lessons — advice, never evidence, structurally isolated from every fact lane. On → the 'strategy' lane joins the profile lane set (requires the answer router), the /v1/admin/strategy endpoints answer, and the lifecycle cron may run. Serving additionally requires STRATEGY_RETRIEVAL_ENABLED. Off (default) → endpoints 404, lane absent, cron inert.",
+      },
+      {
+        key: 'STRATEGY_RETRIEVAL_ENABLED',
+        category: 'pipeline',
+        defaultValue: '0',
+        runtimeMutable: false,
+        isBooleanFlag: true,
+        description:
+          'Read-side serving switch of the strategy-memory lane: on (with the master flag) the evidence collector retrieves k=1 (hard cap 2) active strategy items above STRATEGY_SIMILARITY_FLOOR and renders them as a fenced ADVISORY section for the GENERATOR ONLY — the verifier never sees them (documented parity exception: guidance, not evidence). Off (default) → distill/list/curate still work, nothing is served.',
+      },
+      {
+        key: 'STRATEGY_SIMILARITY_FLOOR',
+        category: 'pipeline',
+        defaultValue: '0.4',
+        runtimeMutable: false,
+        isBooleanFlag: false,
+        description:
+          'Cosine-similarity floor for strategy-memory serving: the k=1 retrieval returns nothing when the best active item scores below this (an irrelevant best-match must serve no advice). JS-side brute cosine over the small curated table — no HNSW.',
+      },
+      {
+        key: 'STRATEGY_DISTILL_CRON_ENABLED',
+        category: 'pipeline',
+        defaultValue: '0',
+        runtimeMutable: false,
+        isBooleanFlag: true,
+        description:
+          'Nightly strategy-memory lifecycle sweep at 03:52 UTC (G7 host slot, requires STRATEGY_MEMORY_ENABLED): auto-deprecates items whose evidence.nContradict ≥ 2 or that went 90 days without validation (Memp/ExpeL lifecycle). Distillation itself stays operator-invoked via POST /v1/admin/strategy/distill in v1.',
+      },
       // ── Jobs ─────────────────────────────────────────────────
       {
         key: 'JOBS_QUEUE_MODE',

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -35,6 +35,7 @@ import { SourcesModule } from './sources/sources.module';
 import { DocumentsModule } from './documents/documents.module';
 import { FeedbackModule } from './feedback/feedback.module';
 import { UsersModule } from './users/users.module';
+import { StrategyModule } from './strategy/strategy.module';
 
 @Module({
   imports: [
@@ -109,6 +110,7 @@ import { UsersModule } from './users/users.module';
     DocumentsModule,
     EpisodesModule,
     UsersModule,
+    StrategyModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -128,6 +128,11 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // "is a number" contract here (≥1 is accepted and means "no penalty").
   nonNegativeFloat(env, 'SEARCH_CHATTER_PENALTY', errors);
 
+  // ── G4 strategy-memory lane ────────────────────────────────────────
+  // Serving similarity floor (default 0.4); a typo would silently fall
+  // back to the default in the constructor-captured read.
+  nonNegativeFloat(env, 'STRATEGY_SIMILARITY_FLOOR', errors);
+
   // ── Phase A read-path (typed-memory roadmap 2026-07) ───────────────
   positiveInt(env, 'SEARCH_FACT_CENTRIC_BUDGET', errors);
   positiveInt(env, 'SYNTHESIZE_EXTRA_EVIDENCE_CAP', errors);
@@ -694,6 +699,12 @@ const KNOWN_BOOLEAN_FLAGS = [
   // Dev/test only — permits http + loopback endpoints (disables the
   // egress guard's SSRF fence for pack tool calls).
   'MCP_PACK_TOOLS_ALLOW_HTTP',
+  // G4 strategy-memory lane (0092): master switch (lane + admin
+  // endpoints + cron), read-side serving switch, and the nightly
+  // lifecycle-sweep cron. All default off.
+  'STRATEGY_MEMORY_ENABLED',
+  'STRATEGY_RETRIEVAL_ENABLED',
+  'STRATEGY_DISTILL_CRON_ENABLED',
 ];
 
 /**

--- a/src/db/migrations/0092_strategy_memory.surql
+++ b/src/db/migrations/0092_strategy_memory.surql
@@ -1,0 +1,48 @@
+-- 0092: strategy_memory — the ReasoningBank-shape strategy lane
+-- (docs/roadmap/sota-gap-build-2026-08.md G4). Procedural "how to
+-- answer" lessons distilled from judged post-mortems. Advice, not
+-- evidence: a SEPARATE table by design, so leakage into fact
+-- retrieval is structural — no fact-lane query can return a strategy
+-- row, the table is never unioned with knowledge_fact lanes, and it
+-- is excluded from grounding/provenance (the field rule: procedural
+-- memory lives in a separate store, separate retrieval call,
+-- separate prompt section).
+--
+-- Item shape (ReasoningBank, arXiv 2509.25140): title + situation
+-- (preconditions — question class / genre / temporal shape) +
+-- strategy (2-5 sentences of why/when, never replayable step
+-- scripts; failures become preventative lessons) + polarity
+-- do|avoid. Lifecycle (Memp deprecate-on-feedback + ExpeL vote
+-- counters): candidate -> active on confirmation; the evidence
+-- counters feed auto-deprecation (nContradict >= 2 or 90d without
+-- validation) in the distill cron sweep.
+
+DEFINE TABLE IF NOT EXISTS strategy_memory SCHEMAFULL;
+
+DEFINE FIELD IF NOT EXISTS companyId ON strategy_memory TYPE string;
+DEFINE FIELD IF NOT EXISTS title ON strategy_memory TYPE string;
+-- Preconditions: which question class / genre / temporal shape this
+-- item applies to — the generator is told to assess applicability.
+DEFINE FIELD IF NOT EXISTS situation ON strategy_memory TYPE string;
+-- 2-5 sentences, why/when — strategy-level, never step scripts.
+DEFINE FIELD IF NOT EXISTS strategy ON strategy_memory TYPE string;
+DEFINE FIELD IF NOT EXISTS polarity ON strategy_memory TYPE string
+  ASSERT $value INSIDE ['do', 'avoid'];
+DEFINE FIELD IF NOT EXISTS status ON strategy_memory TYPE string
+  ASSERT $value INSIDE ['candidate', 'active', 'deprecated'];
+-- {source, runIds, nSupport, nContradict, lastValidatedAt} — open
+-- shape so distillation sources can annotate without a migration.
+DEFINE FIELD IF NOT EXISTS evidence ON strategy_memory TYPE object FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS embedding ON strategy_memory TYPE option<array<float>>;
+DEFINE FIELD IF NOT EXISTS scope ON strategy_memory TYPE string
+  ASSERT $value INSIDE ['tenant', 'global'];
+DEFINE FIELD IF NOT EXISTS createdAt ON strategy_memory TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS updatedAt ON strategy_memory TYPE datetime DEFAULT time::now();
+
+-- Serving reads filter (companyId, status='active').
+DEFINE INDEX IF NOT EXISTS strategy_company_status_idx ON strategy_memory
+  FIELDS companyId, status;
+-- v1 dedup guard: one item per title per tenant (the dedup-merge
+-- ADD/UPDATE/NOOP pass keys on similarity, this pins exact repeats).
+DEFINE INDEX IF NOT EXISTS strategy_company_title_idx ON strategy_memory
+  FIELDS companyId, title UNIQUE;

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -248,7 +248,8 @@ export type LaneId =
   | 'preference'
   | 'recency'
   | 'summary'
-  | 'instruction';
+  | 'instruction'
+  | 'strategy';
 
 export const ALL_LANES: readonly LaneId[] = [
   'temporal',
@@ -258,6 +259,7 @@ export const ALL_LANES: readonly LaneId[] = [
   'recency',
   'summary',
   'instruction',
+  'strategy',
 ];
 
 export interface RetrievalProfile {
@@ -610,6 +612,12 @@ function resolveForGenre(
     for (const lane of ALL_LANES) {
       if (lane === 'instruction') {
         if (envFlagEnabled(env.SYNTHESIZE_INSTRUCTION_LANE)) lanes.add(lane);
+      } else if (lane === 'strategy') {
+        // G4 strategy-memory lane: own master flag (the instruction-
+        // lane idiom); the read-side serving switch
+        // (STRATEGY_RETRIEVAL_ENABLED) gates separately inside
+        // StrategyMemoryService — lane membership alone serves nothing.
+        if (envFlagEnabled(env.STRATEGY_MEMORY_ENABLED)) lanes.add(lane);
       } else {
         lanes.add(lane);
       }

--- a/src/strategy/strategy-admin.controller.ts
+++ b/src/strategy/strategy-admin.controller.ts
@@ -1,0 +1,176 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { AuthenticatedRequest } from '../auth/api-key.types';
+import { ApiKeyService } from '../auth/api-key.service';
+import {
+  StrategyMemoryService,
+  type StrategyItem,
+  type StrategyStatus,
+} from './strategy-memory.service';
+import {
+  StrategyDistillService,
+  type DistillStats,
+  type PostMortem,
+} from './strategy-distill.service';
+
+/**
+ * Admin surface of the strategy-memory lane (G4). Operator-invoked,
+ * admin-scoped, gated by STRATEGY_MEMORY_ENABLED (default off → 404,
+ * indistinguishable from "not deployed" — the EPISODES_API_ENABLED
+ * idiom). Deliberately NOT in the platform OpenAPI document: the
+ * admin/ops surface is out of scope there by design
+ * (scripts/build-openapi.ts).
+ *
+ *   POST  /v1/admin/strategy/distill — post-mortem batch → ≤3
+ *         dedup-merged candidate items (the eval-harness feed).
+ *   GET   /v1/admin/strategy         — list (status filter).
+ *   PATCH /v1/admin/strategy/:id     — status flip (candidate→active
+ *         confirmation, manual deprecation).
+ */
+
+const STATUSES: readonly StrategyStatus[] = [
+  'candidate',
+  'active',
+  'deprecated',
+];
+
+const MAX_POST_MORTEMS = 50;
+
+@Controller('v1/admin/strategy')
+@UseGuards(ApiKeyGuard)
+export class StrategyAdminController {
+  constructor(
+    private readonly strategies: StrategyMemoryService,
+    private readonly distiller: StrategyDistillService,
+    private readonly apiKeys: ApiKeyService,
+  ) {}
+
+  private assertEnabled(): void {
+    if (!this.strategies.isEnabled()) {
+      throw new NotFoundException();
+    }
+  }
+
+  private resolveTenant(req: AuthenticatedRequest, tenant?: string): string {
+    const resolved = tenant?.trim() || req.brainAuth.companyId;
+    if (
+      resolved !== req.brainAuth.companyId &&
+      !this.apiKeys.knownCompanyIds().includes(resolved)
+    ) {
+      throw new BadRequestException(
+        `Unknown tenant '${resolved}' — not a registered tenant`,
+      );
+    }
+    return resolved;
+  }
+
+  @Post('distill')
+  @RequireScopes('brain:admin')
+  async distill(
+    @Req() req: AuthenticatedRequest,
+    @Body()
+    body: {
+      tenant?: string;
+      runId?: string;
+      postMortems?: PostMortem[];
+    } = {},
+  ): Promise<DistillStats> {
+    this.assertEnabled();
+    const tenant = this.resolveTenant(req, body.tenant);
+    const postMortems = body.postMortems;
+    if (!Array.isArray(postMortems) || postMortems.length === 0) {
+      throw new BadRequestException('postMortems must be a non-empty array');
+    }
+    if (postMortems.length > MAX_POST_MORTEMS) {
+      throw new BadRequestException(
+        `postMortems capped at ${MAX_POST_MORTEMS} per call`,
+      );
+    }
+    for (const [i, pm] of postMortems.entries()) {
+      for (const field of [
+        'question',
+        'goldAnswer',
+        'ourAnswer',
+        'diagnosis',
+      ] as const) {
+        if (typeof pm?.[field] !== 'string' || !pm[field].trim()) {
+          throw new BadRequestException(
+            `postMortems[${i}].${field} must be a non-empty string`,
+          );
+        }
+      }
+    }
+    return this.distiller.distillFromPostMortems(
+      tenant,
+      postMortems,
+      body.runId?.trim() || undefined,
+    );
+  }
+
+  @Get()
+  @RequireScopes('brain:admin')
+  async list(
+    @Req() req: AuthenticatedRequest,
+    @Query() q: { tenant?: string; status?: string; limit?: string },
+  ): Promise<{ strategies: StrategyItem[] }> {
+    this.assertEnabled();
+    const resolved = this.resolveTenant(req, q.tenant);
+    if (
+      q.status !== undefined &&
+      !STATUSES.includes(q.status as StrategyStatus)
+    ) {
+      throw new BadRequestException(
+        `status must be one of ${STATUSES.join('/')}`,
+      );
+    }
+    const parsedLimit =
+      q.limit !== undefined ? parseInt(q.limit, 10) : undefined;
+    if (
+      parsedLimit !== undefined &&
+      (!Number.isFinite(parsedLimit) || parsedLimit < 1 || parsedLimit > 200)
+    ) {
+      throw new BadRequestException('limit must be 1..200');
+    }
+    const strategies = await this.strategies.list(resolved, {
+      status: q.status as StrategyStatus | undefined,
+      limit: parsedLimit,
+    });
+    return { strategies };
+  }
+
+  @Patch(':id')
+  @RequireScopes('brain:admin')
+  async updateStatus(
+    @Req() req: AuthenticatedRequest,
+    @Param('id') id: string,
+    @Body() body: { tenant?: string; status?: string } = {},
+  ): Promise<StrategyItem> {
+    this.assertEnabled();
+    const tenant = this.resolveTenant(req, body.tenant);
+    if (!STATUSES.includes(body.status as StrategyStatus)) {
+      throw new BadRequestException(
+        `status must be one of ${STATUSES.join('/')}`,
+      );
+    }
+    if (!id || id.length > 128) {
+      throw new BadRequestException('id must be a strategy record id');
+    }
+    return this.strategies.updateStatus(
+      tenant,
+      id,
+      body.status as StrategyStatus,
+    );
+  }
+}

--- a/src/strategy/strategy-distill.service.ts
+++ b/src/strategy/strategy-distill.service.ts
@@ -1,0 +1,435 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron } from '@nestjs/schedule';
+import type OpenAI from 'openai';
+import {
+  chatCallParams,
+  createOpenAiClientOrThrow,
+} from '../ai/openai-client';
+import { ApiKeyService } from '../auth/api-key.service';
+import { envFlagEnabled } from '../common/env-validation';
+import {
+  StrategyMemoryService,
+  type ScoredStrategyItem,
+  type StrategyEvidence,
+  type StrategyItem,
+  type StrategyPolarity,
+} from './strategy-memory.service';
+
+/**
+ * StrategyDistillService — G4's distiller plus the G7 sleep-time
+ * sweep host (docs/roadmap/sota-gap-build-2026-08.md), built on the
+ * PromotionRunnerService template: env-gated cron, constructor-
+ * captured knobs, bounded per run, stats return.
+ *
+ * v1 distillation source = structured post-mortems from the eval
+ * harness (ground truth with a diagnosis — no LLM judge noise, the
+ * weakest ReasoningBank component deleted). One LLM call turns a
+ * post-mortem batch into ≤3 strategy items (strategy-level, never
+ * procedure-level; failures become preventative lessons), then each
+ * item goes through a Mem0-style dedup-merge: retrieve the top-3
+ * similar existing items and let the LLM decide ADD / UPDATE / NOOP —
+ * UPDATE merges the evidence counters instead of growing the table.
+ *
+ * The nightly cron (STRATEGY_DISTILL_CRON_ENABLED, requires the
+ * STRATEGY_MEMORY_ENABLED master) runs the G4 lifecycle sweep:
+ * auto-deprecate on nContradict ≥ 2 or 90 days unvalidated. It is
+ * the G7 host slot — later consolidation ops (contradiction sweep,
+ * digest refresh) mount alongside the same sweep loop.
+ */
+
+export interface PostMortem {
+  question: string;
+  goldAnswer: string;
+  ourAnswer: string;
+  diagnosis: string;
+}
+
+export interface DistillStats {
+  companyId: string;
+  postMortems: number;
+  proposed: number;
+  added: number;
+  updated: number;
+  noop: number;
+}
+
+export interface SweepRunStats {
+  tenants: number;
+  scanned: number;
+  deprecated: number;
+  failed: number;
+}
+
+/** Hard bound per distill call (ReasoningBank: ≤3 items per batch). */
+export const DISTILL_MAX_ITEMS = 3;
+
+/** Dedup-merge neighbor count (Mem0 idiom, G4 v1: top-3). */
+const MERGE_NEIGHBORS = 3;
+
+const DISTILL_SYSTEM = `You are a strategy distiller for an answer-synthesis memory system.
+
+You receive post-mortems of judged answers: the question, the gold answer, our answer, and a diagnosis of what went wrong (or right). Distill AT MOST ${DISTILL_MAX_ITEMS} reusable strategy items.
+
+Rules:
+- STRATEGY-LEVEL, never procedure-level: each item says WHY and WHEN an approach helps, in 2-5 sentences. Never step-by-step scripts, never verbatim answers, never question-specific facts.
+- Failures become PREVENTATIVE lessons ("avoid X because Y"), not replayable procedures.
+- "situation" states the preconditions: the question class, genre, or temporal shape where the item applies.
+- "polarity" is "do" for a transferable strategy, "avoid" for a preventative lesson.
+- Prefer fewer, more transferable items. Output zero items when the post-mortems teach nothing reusable.
+
+Output strictly the JSON shape requested by the schema.`;
+
+const MERGE_SYSTEM = `You are the dedup-merge arbiter for a strategy memory (Mem0-style ADD/UPDATE/NOOP).
+
+You receive one NEW strategy item and up to ${MERGE_NEIGHBORS} EXISTING items (each with an id). Decide:
+- "ADD" when the new item teaches something none of the existing items covers.
+- "UPDATE" when an existing item covers the same lesson and should absorb the new one — return that item's id in "targetId", plus the merged "strategy" and "situation" texts (keep them strategy-level, 2-5 sentences).
+- "NOOP" when the new item adds nothing over the existing ones.
+
+Output strictly the JSON shape requested by the schema.`;
+
+interface DistilledItemShape {
+  title: string;
+  situation: string;
+  strategy: string;
+  polarity: StrategyPolarity;
+}
+
+export interface MergeDecision {
+  action: 'ADD' | 'UPDATE' | 'NOOP';
+  targetId?: string;
+  strategy?: string;
+  situation?: string;
+}
+
+/**
+ * Parse the merge-arbiter output. Conservative on garbage: anything
+ * unparseable or with an unknown action is NOOP (no silent growth
+ * from a malformed decision; the batch can be re-run). UPDATE without
+ * a usable targetId also degrades to NOOP.
+ */
+export function parseMergeDecision(
+  raw: string | null | undefined,
+  knownIds: string[],
+): MergeDecision {
+  if (!raw) return { action: 'NOOP' };
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return { action: 'NOOP' };
+  }
+  const action = String(parsed.action ?? '').toUpperCase();
+  if (action === 'ADD') return { action: 'ADD' };
+  if (action === 'UPDATE') {
+    const targetId = String(parsed.targetId ?? '');
+    if (!knownIds.includes(targetId)) return { action: 'NOOP' };
+    return {
+      action: 'UPDATE',
+      targetId,
+      strategy:
+        typeof parsed.strategy === 'string' && parsed.strategy.trim()
+          ? parsed.strategy
+          : undefined,
+      situation:
+        typeof parsed.situation === 'string' && parsed.situation.trim()
+          ? parsed.situation
+          : undefined,
+    };
+  }
+  return { action: 'NOOP' };
+}
+
+/** Evidence merge for the UPDATE arm: counters add, provenance unions. */
+export function mergeEvidence(
+  existing: StrategyEvidence,
+  incoming: StrategyEvidence,
+): StrategyEvidence {
+  const runIds = [
+    ...new Set([...(existing.runIds ?? []), ...(incoming.runIds ?? [])]),
+  ];
+  return {
+    ...existing,
+    ...incoming,
+    ...(runIds.length > 0 ? { runIds } : {}),
+    nSupport: (existing.nSupport ?? 0) + (incoming.nSupport ?? 0),
+    nContradict: (existing.nContradict ?? 0) + (incoming.nContradict ?? 0),
+    lastValidatedAt:
+      incoming.lastValidatedAt ?? existing.lastValidatedAt ?? undefined,
+  };
+}
+
+@Injectable()
+export class StrategyDistillService {
+  private readonly logger = new Logger(StrategyDistillService.name);
+  private readonly openai: OpenAI;
+  private readonly model: string;
+  private readonly cronEnabled: boolean;
+  private sweepInFlight = false;
+
+  constructor(
+    private readonly strategies: StrategyMemoryService,
+    private readonly apiKeys: ApiKeyService,
+    config: ConfigService,
+  ) {
+    this.openai = createOpenAiClientOrThrow(config);
+    this.model = config.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini');
+    this.cronEnabled = envFlagEnabled(
+      config.get<string>('STRATEGY_DISTILL_CRON_ENABLED'),
+    );
+  }
+
+  /**
+   * Distill one post-mortem batch into ≤3 dedup-merged strategy
+   * items. Every item lands as status='candidate' — activation is a
+   * deliberate operator flip (PATCH), never automatic.
+   */
+  async distillFromPostMortems(
+    companyId: string,
+    postMortems: PostMortem[],
+    runId?: string,
+  ): Promise<DistillStats> {
+    const stats: DistillStats = {
+      companyId,
+      postMortems: postMortems.length,
+      proposed: 0,
+      added: 0,
+      updated: 0,
+      noop: 0,
+    };
+    if (postMortems.length === 0) return stats;
+    const items = await this.proposeItems(postMortems);
+    stats.proposed = items.length;
+    const evidence: StrategyEvidence = {
+      source: 'post_mortem',
+      ...(runId ? { runIds: [runId] } : {}),
+      nSupport: 1,
+      nContradict: 0,
+      lastValidatedAt: new Date().toISOString(),
+    };
+    for (const item of items) {
+      const outcome = await this.dedupMerge(companyId, item, evidence);
+      stats[outcome]++;
+    }
+    this.logger.log(
+      `[strategy.distill] companyId=${companyId} postMortems=${stats.postMortems} ` +
+        `proposed=${stats.proposed} added=${stats.added} updated=${stats.updated} noop=${stats.noop}`,
+    );
+    return stats;
+  }
+
+  /**
+   * Nightly lifecycle sweep at 03:52 UTC — after compaction (03:17)
+   * and the calibration refits (03:42/03:51), before dreams (04:00).
+   * Env-gated and reentrancy-guarded; per-tenant failures are
+   * contained (the MemoryQualityService fan-out idiom).
+   */
+  @Cron('52 3 * * *', { timeZone: 'UTC' })
+  async runNightlySweep(): Promise<SweepRunStats> {
+    const stats: SweepRunStats = {
+      tenants: 0,
+      scanned: 0,
+      deprecated: 0,
+      failed: 0,
+    };
+    if (!this.cronEnabled || !this.strategies.isEnabled()) return stats;
+    if (this.sweepInFlight) {
+      this.logger.warn('strategy sweep skipped — previous run still in flight');
+      return stats;
+    }
+    this.sweepInFlight = true;
+    try {
+      const tenants = this.apiKeys.knownCompanyIds();
+      stats.tenants = tenants.length;
+      for (const companyId of tenants) {
+        try {
+          const swept = await this.strategies.deprecateSweep(companyId);
+          stats.scanned += swept.scanned;
+          stats.deprecated += swept.deprecated;
+        } catch (e) {
+          stats.failed++;
+          this.logger.warn(
+            `strategy sweep for ${companyId} failed: ${(e as Error).message}`,
+          );
+        }
+      }
+      return stats;
+    } finally {
+      this.sweepInFlight = false;
+    }
+  }
+
+  private async proposeItems(
+    postMortems: PostMortem[],
+  ): Promise<DistilledItemShape[]> {
+    const user = postMortems
+      .map(
+        (pm, i) =>
+          `Post-mortem ${i + 1}:\n` +
+          `Question: ${pm.question}\n` +
+          `Gold answer: ${pm.goldAnswer}\n` +
+          `Our answer: ${pm.ourAnswer}\n` +
+          `Diagnosis: ${pm.diagnosis}`,
+      )
+      .join('\n\n');
+    const res = await this.openai.chat.completions.create({
+      model: this.model,
+      messages: [
+        { role: 'system', content: DISTILL_SYSTEM },
+        { role: 'user', content: user },
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'distilled_strategies',
+          strict: true,
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              items: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: {
+                    title: { type: 'string' },
+                    situation: { type: 'string' },
+                    strategy: { type: 'string' },
+                    polarity: { type: 'string', enum: ['do', 'avoid'] },
+                  },
+                  required: ['title', 'situation', 'strategy', 'polarity'],
+                },
+              },
+            },
+            required: ['items'],
+          },
+        },
+      },
+      ...chatCallParams(this.model, { temperature: 0, visibleCap: 1200 }),
+    });
+    const raw = res.choices?.[0]?.message?.content;
+    let items: DistilledItemShape[] = [];
+    try {
+      const parsed = JSON.parse(raw ?? '{}') as { items?: DistilledItemShape[] };
+      items = Array.isArray(parsed.items) ? parsed.items : [];
+    } catch (e) {
+      this.logger.warn(`distill output unparseable: ${(e as Error).message}`);
+    }
+    return items
+      .filter(
+        (i) =>
+          typeof i.title === 'string' &&
+          i.title.trim() &&
+          typeof i.situation === 'string' &&
+          typeof i.strategy === 'string' &&
+          (i.polarity === 'do' || i.polarity === 'avoid'),
+      )
+      .slice(0, DISTILL_MAX_ITEMS);
+  }
+
+  /** One item through the ADD/UPDATE/NOOP gate against its neighbors. */
+  private async dedupMerge(
+    companyId: string,
+    item: DistilledItemShape,
+    evidence: StrategyEvidence,
+  ): Promise<'added' | 'updated' | 'noop'> {
+    const neighbors = await this.strategies.findSimilar(
+      companyId,
+      `${item.title}\n${item.situation}`,
+      MERGE_NEIGHBORS,
+    );
+    const decision =
+      neighbors.length === 0
+        ? ({ action: 'ADD' } as MergeDecision)
+        : await this.decideMerge(item, neighbors);
+    if (decision.action === 'UPDATE' && decision.targetId) {
+      const target = neighbors.find((n) => n.strategyId === decision.targetId);
+      await this.strategies.mergeUpdate(companyId, decision.targetId, {
+        strategy: decision.strategy,
+        situation: decision.situation,
+        evidence: mergeEvidence(target?.evidence ?? {}, evidence),
+      });
+      return 'updated';
+    }
+    if (decision.action === 'ADD') {
+      await this.createDeduped(companyId, item, evidence);
+      return 'added';
+    }
+    return 'noop';
+  }
+
+  /** ADD arm; a unique-title collision degrades to NOOP (exact twin). */
+  private async createDeduped(
+    companyId: string,
+    item: DistilledItemShape,
+    evidence: StrategyEvidence,
+  ): Promise<StrategyItem | null> {
+    try {
+      return await this.strategies.create(companyId, {
+        ...item,
+        status: 'candidate',
+        evidence,
+      });
+    } catch (e) {
+      this.logger.warn(
+        `strategy ADD skipped (title '${item.title}'): ${(e as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  private async decideMerge(
+    item: DistilledItemShape,
+    neighbors: ScoredStrategyItem[],
+  ): Promise<MergeDecision> {
+    const user =
+      `NEW item:\n${renderMergeItem(item)}\n\nEXISTING items:\n` +
+      neighbors
+        .map((n) => `id: ${n.strategyId}\n${renderMergeItem(n)}`)
+        .join('\n---\n');
+    const res = await this.openai.chat.completions.create({
+      model: this.model,
+      messages: [
+        { role: 'system', content: MERGE_SYSTEM },
+        { role: 'user', content: user },
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'merge_decision',
+          strict: true,
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              action: { type: 'string', enum: ['ADD', 'UPDATE', 'NOOP'] },
+              targetId: { type: ['string', 'null'] },
+              strategy: { type: ['string', 'null'] },
+              situation: { type: ['string', 'null'] },
+            },
+            required: ['action', 'targetId', 'strategy', 'situation'],
+          },
+        },
+      },
+      ...chatCallParams(this.model, { temperature: 0, visibleCap: 600 }),
+    });
+    return parseMergeDecision(
+      res.choices?.[0]?.message?.content,
+      neighbors.map((n) => n.strategyId),
+    );
+  }
+}
+
+function renderMergeItem(i: {
+  title: string;
+  situation: string;
+  strategy: string;
+  polarity: string;
+}): string {
+  return (
+    `title: ${i.title}\npolarity: ${i.polarity}\n` +
+    `situation: ${i.situation}\nstrategy: ${i.strategy}`
+  );
+}

--- a/src/strategy/strategy-memory.service.ts
+++ b/src/strategy/strategy-memory.service.ts
@@ -1,0 +1,441 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SurrealService } from '../db/surreal.service';
+import { EmbedderService } from '../ai/embedder.service';
+import { envFlagEnabled } from '../common/env-validation';
+import { cosineSimilarity } from '../common/vector-math';
+
+/**
+ * StrategyMemoryService — the ReasoningBank-shape strategy store
+ * (docs/roadmap/sota-gap-build-2026-08.md G4, migration 0092).
+ *
+ * Items are procedural "how to answer" lessons (situation
+ * preconditions + a 2-5 sentence why/when strategy, polarity
+ * do|avoid), distilled from judged post-mortems. They are ADVICE,
+ * never evidence: the table is separate from every fact lane by
+ * design, so fact retrieval structurally cannot return a strategy row
+ * and a strategy row can never be cited.
+ *
+ * Retrieval contract (ReasoningBank k-sensitivity, validated
+ * externally: WebArena 49.7% at k=1 vs 44.4% at k=4 — more
+ * strategies actively hurt): k defaults to 1 and is HARD-capped at 2,
+ * with a similarity floor (STRATEGY_SIMILARITY_FLOOR, default 0.4)
+ * so an irrelevant best-match serves nothing. Only status='active'
+ * items are served. Cosine scoring is JS-side over a small N — the
+ * CommunityService / ProceduralMemoryService.match idiom; strategy
+ * memory is a curated distillate (O(10¹-10²) rows), not a fact
+ * firehose, so no HNSW index.
+ */
+
+export type StrategyPolarity = 'do' | 'avoid';
+export type StrategyStatus = 'candidate' | 'active' | 'deprecated';
+export type StrategyScope = 'tenant' | 'global';
+
+/** Vote counters + provenance (Memp/ExpeL lifecycle inputs). */
+export interface StrategyEvidence extends Record<string, unknown> {
+  source?: string;
+  runIds?: string[];
+  nSupport?: number;
+  nContradict?: number;
+  lastValidatedAt?: string;
+}
+
+export interface StrategyItem {
+  strategyId: string;
+  companyId: string;
+  title: string;
+  situation: string;
+  strategy: string;
+  polarity: StrategyPolarity;
+  status: StrategyStatus;
+  evidence: StrategyEvidence;
+  scope: StrategyScope;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ScoredStrategyItem extends StrategyItem {
+  similarity: number;
+}
+
+export interface CreateStrategyArgs {
+  title: string;
+  situation: string;
+  strategy: string;
+  polarity: StrategyPolarity;
+  status?: StrategyStatus;
+  evidence?: StrategyEvidence;
+  scope?: StrategyScope;
+}
+
+/** Retrieval k is hard-capped: k=1 default, 2 absolute max (G4). */
+export const STRATEGY_RETRIEVAL_MAX_K = 2;
+
+/** Auto-deprecation thresholds (G4 lifecycle). */
+export const STRATEGY_MAX_CONTRADICT = 2;
+export const STRATEGY_STALE_DAYS = 90;
+
+/** Clamp a requested k into [1, STRATEGY_RETRIEVAL_MAX_K]; default 1. */
+export function clampStrategyK(k?: number): number {
+  if (k === undefined || !Number.isFinite(k) || k < 1) return 1;
+  return Math.min(Math.floor(k), STRATEGY_RETRIEVAL_MAX_K);
+}
+
+/**
+ * Pure lifecycle decision for the cron sweep: deprecate when the
+ * contradiction counter reached the threshold, or the item went
+ * STRATEGY_STALE_DAYS without validation (lastValidatedAt, falling
+ * back to createdAt for never-validated items).
+ */
+export function shouldDeprecate(
+  item: Pick<StrategyItem, 'evidence' | 'createdAt'>,
+  now: Date,
+): boolean {
+  const contradictions =
+    typeof item.evidence?.nContradict === 'number'
+      ? item.evidence.nContradict
+      : 0;
+  if (contradictions >= STRATEGY_MAX_CONTRADICT) return true;
+  const anchorRaw = item.evidence?.lastValidatedAt ?? item.createdAt;
+  const anchor = Date.parse(String(anchorRaw));
+  if (!Number.isFinite(anchor)) return false;
+  const ageDays = (now.getTime() - anchor) / (24 * 60 * 60 * 1000);
+  return ageDays > STRATEGY_STALE_DAYS;
+}
+
+/** One advisory prompt line per served item (title + preconditions + lesson). */
+export function renderStrategyNote(item: ScoredStrategyItem): string {
+  const tag = item.polarity === 'avoid' ? 'AVOID' : 'DO';
+  return `[${tag}] ${item.title} — applies when: ${item.situation}. ${item.strategy}`;
+}
+
+interface RawStrategyRow {
+  id: unknown;
+  companyId?: string;
+  title?: string;
+  situation?: string;
+  strategy?: string;
+  polarity?: string;
+  status?: string;
+  evidence?: Record<string, unknown>;
+  embedding?: number[];
+  scope?: string;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+}
+
+const STRATEGY_ROW_FIELDS =
+  'id, companyId, title, situation, strategy, polarity, status, ' +
+  'evidence, scope, createdAt, updatedAt';
+
+@Injectable()
+export class StrategyMemoryService {
+  private readonly logger = new Logger(StrategyMemoryService.name);
+  // Feature master switch + read-side serving switch + similarity
+  // floor: constructor-captured knobs (the PromotionRunnerService
+  // template) — catalogued runtimeMutable:false.
+  private readonly enabled: boolean;
+  private readonly retrievalEnabled: boolean;
+  private readonly similarityFloor: number;
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly embedder: EmbedderService,
+    config: ConfigService,
+  ) {
+    this.enabled = envFlagEnabled(
+      config.get<string>('STRATEGY_MEMORY_ENABLED'),
+    );
+    this.retrievalEnabled = envFlagEnabled(
+      config.get<string>('STRATEGY_RETRIEVAL_ENABLED'),
+    );
+    // Unset/blank must NOT collapse to Number('')===0 (the
+    // nonNegativeFloatEnv lesson): an absent knob means DEFAULT 0.4,
+    // not "no floor".
+    const rawFloor = (
+      config.get<string>('STRATEGY_SIMILARITY_FLOOR') ?? ''
+    ).trim();
+    const floor = rawFloor === '' ? Number.NaN : Number(rawFloor);
+    this.similarityFloor =
+      Number.isFinite(floor) && floor >= 0 ? floor : 0.4;
+  }
+
+  /** Whole-feature master switch (lane + endpoints + cron). */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /** Read-side serving switch — gates retrieve() on top of the master. */
+  isRetrievalEnabled(): boolean {
+    return this.enabled && this.retrievalEnabled;
+  }
+
+  async create(
+    companyId: string,
+    args: CreateStrategyArgs,
+  ): Promise<StrategyItem> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      // Embed the retrieval key: situation carries the preconditions
+      // the query is matched against; title disambiguates near-twins.
+      const embedding = await this.embedder.embed(
+        `${args.title}\n${args.situation}`,
+      );
+      const [row] = await db.query<RawStrategyRow[]>(
+        `CREATE ONLY strategy_memory CONTENT {
+            companyId: $companyId,
+            title: $title,
+            situation: $situation,
+            strategy: $strategy,
+            polarity: $polarity,
+            status: $status,
+            evidence: $evidence,
+            embedding: $embedding,
+            scope: $scope,
+            createdAt: time::now(),
+            updatedAt: time::now()
+         }`,
+        {
+          companyId,
+          title: args.title,
+          situation: args.situation,
+          strategy: args.strategy,
+          polarity: args.polarity,
+          status: args.status ?? 'candidate',
+          evidence: args.evidence ?? {},
+          embedding,
+          scope: args.scope ?? 'tenant',
+        },
+      );
+      if (!row) throw new Error('strategy_memory CREATE returned nothing');
+      this.logger.log(
+        `[strategy.created] companyId=${companyId} id=${String(row.id)} status=${row.status}`,
+      );
+      return mapStrategyRow(row);
+    });
+  }
+
+  async list(
+    companyId: string,
+    args: { status?: StrategyStatus; limit?: number } = {},
+  ): Promise<StrategyItem[]> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const filter = args.status
+        ? 'WHERE companyId = $companyId AND status = $status'
+        : 'WHERE companyId = $companyId';
+      const [rows] = await db.query<RawStrategyRow[][]>(
+        `SELECT ${STRATEGY_ROW_FIELDS}
+           FROM strategy_memory
+           ${filter}
+           ORDER BY updatedAt DESC
+           LIMIT $limit`,
+        {
+          companyId,
+          limit: args.limit ?? 50,
+          ...(args.status ? { status: args.status } : {}),
+        },
+      );
+      return ((rows as RawStrategyRow[]) ?? []).map(mapStrategyRow);
+    });
+  }
+
+  /** Status flip (candidate→active confirmation, manual deprecation). */
+  async updateStatus(
+    companyId: string,
+    strategyIdRaw: string,
+    status: StrategyStatus,
+  ): Promise<StrategyItem> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const tail = idTail(strategyIdRaw);
+      const [rows] = await db.query<RawStrategyRow[][]>(
+        `UPDATE type::record('strategy_memory', $tail)
+           SET status = $status, updatedAt = time::now()
+           WHERE companyId = $companyId
+           RETURN AFTER`,
+        { tail, status, companyId },
+      );
+      const updated = (rows as RawStrategyRow[])?.[0];
+      if (!updated) {
+        throw new NotFoundException(`Strategy ${strategyIdRaw} not found`);
+      }
+      return mapStrategyRow(updated);
+    });
+  }
+
+  /** Merge-update of an existing item (the dedup-merge UPDATE arm). */
+  async mergeUpdate(
+    companyId: string,
+    strategyIdRaw: string,
+    patch: { strategy?: string; situation?: string; evidence: StrategyEvidence },
+  ): Promise<StrategyItem> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const tail = idTail(strategyIdRaw);
+      const sets = [
+        'evidence = $evidence',
+        'updatedAt = time::now()',
+        ...(patch.strategy ? ['strategy = $strategy'] : []),
+        ...(patch.situation ? ['situation = $situation'] : []),
+      ].join(', ');
+      const [rows] = await db.query<RawStrategyRow[][]>(
+        `UPDATE type::record('strategy_memory', $tail)
+           SET ${sets}
+           WHERE companyId = $companyId
+           RETURN AFTER`,
+        {
+          tail,
+          companyId,
+          evidence: patch.evidence,
+          ...(patch.strategy ? { strategy: patch.strategy } : {}),
+          ...(patch.situation ? { situation: patch.situation } : {}),
+        },
+      );
+      const updated = (rows as RawStrategyRow[])?.[0];
+      if (!updated) {
+        throw new NotFoundException(`Strategy ${strategyIdRaw} not found`);
+      }
+      return mapStrategyRow(updated);
+    });
+  }
+
+  /**
+   * Serving retrieval: brute cosine over ACTIVE items only, floor
+   * applied, k clamped to [1,2] (default 1). Empty when the read side
+   * is off — the read flag is a hard gate here so no caller can serve
+   * strategies past it.
+   */
+  async retrieve(
+    companyId: string,
+    query: string,
+    k?: number,
+  ): Promise<ScoredStrategyItem[]> {
+    if (!this.isRetrievalEnabled()) return [];
+    return this.scoredMatch(companyId, query, {
+      statuses: ['active'],
+      k: clampStrategyK(k),
+      floor: this.similarityFloor,
+    });
+  }
+
+  /**
+   * Dedup-merge neighbor lookup (write path): top-k similar items
+   * over candidate+active regardless of the serving flag — the
+   * distiller must see near-twins even while serving is off. No
+   * similarity floor: the merge LLM judges relatedness itself.
+   */
+  async findSimilar(
+    companyId: string,
+    text: string,
+    k = 3,
+  ): Promise<ScoredStrategyItem[]> {
+    return this.scoredMatch(companyId, text, {
+      statuses: ['candidate', 'active'],
+      k,
+      floor: 0,
+    });
+  }
+
+  private async scoredMatch(
+    companyId: string,
+    text: string,
+    opts: { statuses: StrategyStatus[]; k: number; floor: number },
+  ): Promise<ScoredStrategyItem[]> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const q = await this.embedder.embed(text);
+      const [rows] = await db.query<RawStrategyRow[][]>(
+        `SELECT ${STRATEGY_ROW_FIELDS}, embedding
+           FROM strategy_memory
+           WHERE companyId = $companyId
+             AND status INSIDE $statuses
+             AND embedding != NONE`,
+        { companyId, statuses: opts.statuses },
+      );
+      const scored: ScoredStrategyItem[] = [];
+      for (const r of (rows as RawStrategyRow[]) ?? []) {
+        const emb = Array.isArray(r.embedding) ? r.embedding : null;
+        if (!emb) continue;
+        const sim = cosineSimilarity(q, emb);
+        if (sim < opts.floor) continue;
+        scored.push({ ...mapStrategyRow(r), similarity: sim });
+      }
+      scored.sort((a, b) => b.similarity - a.similarity);
+      return scored.slice(0, opts.k);
+    });
+  }
+
+  /**
+   * Lifecycle sweep (cron host): auto-deprecate items whose evidence
+   * says they stopped working (nContradict ≥ 2) or that went 90d
+   * without validation. Bounded by the tenant's own table size —
+   * strategy memory is a curated distillate.
+   */
+  async deprecateSweep(
+    companyId: string,
+    now: Date = new Date(),
+  ): Promise<{ companyId: string; scanned: number; deprecated: number }> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<RawStrategyRow[][]>(
+        `SELECT ${STRATEGY_ROW_FIELDS}
+           FROM strategy_memory
+           WHERE companyId = $companyId
+             AND status INSIDE ['candidate', 'active']`,
+        { companyId },
+      );
+      const items = ((rows as RawStrategyRow[]) ?? []).map(mapStrategyRow);
+      let deprecated = 0;
+      for (const item of items) {
+        if (!shouldDeprecate(item, now)) continue;
+        try {
+          await db.query(
+            `UPDATE type::record('strategy_memory', $tail)
+               SET status = 'deprecated', updatedAt = time::now()`,
+            { tail: idTail(item.strategyId) },
+          );
+          deprecated++;
+        } catch (e) {
+          this.logger.warn(
+            `deprecate ${item.strategyId} failed: ${(e as Error).message}`,
+          );
+        }
+      }
+      if (deprecated > 0) {
+        this.logger.log(
+          `[strategy.sweep] companyId=${companyId} deprecated=${deprecated}/${items.length}`,
+        );
+      }
+      return { companyId, scanned: items.length, deprecated };
+    });
+  }
+}
+
+function idTail(raw: string): string {
+  return raw.startsWith('strategy_memory:')
+    ? raw.slice('strategy_memory:'.length)
+    : raw;
+}
+
+function mapStrategyRow(r: RawStrategyRow): StrategyItem {
+  return {
+    strategyId: String(r.id),
+    companyId: String(r.companyId ?? ''),
+    title: String(r.title ?? ''),
+    situation: String(r.situation ?? ''),
+    strategy: String(r.strategy ?? ''),
+    polarity: (r.polarity === 'avoid' ? 'avoid' : 'do') as StrategyPolarity,
+    status: (['candidate', 'active', 'deprecated'].includes(String(r.status))
+      ? r.status
+      : 'candidate') as StrategyStatus,
+    evidence: (r.evidence ?? {}) as StrategyEvidence,
+    scope: (r.scope === 'global' ? 'global' : 'tenant') as StrategyScope,
+    createdAt: toIso(r.createdAt),
+    updatedAt: toIso(r.updatedAt),
+  };
+}
+
+function toIso(v: unknown): string {
+  if (v == null) return '';
+  if (v instanceof Date) return v.toISOString();
+  if (typeof v === 'string') return v;
+  if (typeof (v as { toDate?: () => Date }).toDate === 'function') {
+    return (v as { toDate: () => Date }).toDate().toISOString();
+  }
+  return String(v);
+}

--- a/src/strategy/strategy.module.ts
+++ b/src/strategy/strategy.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { StrategyMemoryService } from './strategy-memory.service';
+import { StrategyDistillService } from './strategy-distill.service';
+import { StrategyAdminController } from './strategy-admin.controller';
+
+/**
+ * Strategy-memory lane (G4) + distill/lifecycle cron (G7 host).
+ * SurrealService / EmbedderService / ApiKeyService arrive via the
+ * global modules; StrategyMemoryService is exported for the
+ * synthesize-side evidence collector (@Optional dep).
+ */
+@Module({
+  controllers: [StrategyAdminController],
+  providers: [StrategyMemoryService, StrategyDistillService],
+  exports: [StrategyMemoryService],
+})
+export class StrategyModule {}

--- a/src/synthesize/answer-router.ts
+++ b/src/synthesize/answer-router.ts
@@ -241,6 +241,23 @@ export const STANDING_INSTRUCTIONS_INSTRUCTION =
   'trigger does not match.\n';
 
 /**
+ * G4 strategy-memory lane frame (ReasoningBank shape,
+ * docs/roadmap/sota-gap-build-2026-08.md). Renders ahead of the fenced
+ * ADVISORY section: the notes are distilled how-to-answer lessons —
+ * guidance about approach, never evidence about the user. The frame
+ * makes the applicability check explicit (a strategy for the wrong
+ * question class must be ignored, not obeyed) and forbids citing them.
+ */
+export const STRATEGY_ADVISORY_INSTRUCTION =
+  'Advisory strategy notes follow (distilled lessons from previous ' +
+  'answers): they are guidance about HOW to approach an answer, NOT ' +
+  'evidence about the user. Before using a note, explicitly assess ' +
+  'whether its stated situation applies to THIS question — ignore it ' +
+  'when it does not. Never cite a strategy note, never treat it as a ' +
+  'fact, and never let it introduce claims the retrieved evidence ' +
+  'does not support.\n';
+
+/**
  * T4: deterministic second retrieval probe that pulls the user's stored
  * preferences into evidence — recommendation queries rarely surface
  * them by similarity (the query is about hotels, not about tastes).
@@ -355,6 +372,10 @@ export const LANE_REGISTRY: readonly Lane[] = [
   { id: 'contradiction', instruction: CONTRADICTION_NOTE_INSTRUCTION },
   { id: 'recency' },
   { id: 'instruction', instruction: STANDING_INSTRUCTIONS_INSTRUCTION },
+  // G4 strategy lane: advisory, never routed (no detect) — the notes
+  // ride their own fenced prompt section, k≤2 (default 1) from the
+  // separate strategy_memory store.
+  { id: 'strategy', instruction: STRATEGY_ADVISORY_INSTRUCTION },
 ];
 
 const LANE_BY_ID = new Map(LANE_REGISTRY.map((l) => [l.id, l]));

--- a/src/synthesize/evidence-collector.service.ts
+++ b/src/synthesize/evidence-collector.service.ts
@@ -15,6 +15,10 @@ import {
   wantsVerbatimEvidence,
 } from './evidence-gates';
 import { CrossEncoderService } from '../ai/cross-encoder.service';
+import {
+  StrategyMemoryService,
+  renderStrategyNote,
+} from '../strategy/strategy-memory.service';
 import { EpisodeLaneService } from './episode-lane.service';
 import { SegmentLaneService } from './segment-lane.service';
 import { InsightLaneService } from './insight-lane.service';
@@ -94,6 +98,23 @@ export interface CollectedEvidence {
    * exactly the updateStories contract.
    */
   groundingQuotes?: Map<string, string>;
+  /**
+   * G4 strategy lane: rendered advisory notes (k≤2, default 1) from
+   * the separate strategy_memory store; undefined when the lane is off
+   * the profile or read-side serving is disabled.
+   *
+   * DELIBERATE EXCEPTION to the evidence-parity invariant (audit W5
+   * #22 — "whatever the generator sees the verifier must see"): these
+   * notes go to the GENERATOR only, in a fenced ADVISORY section, and
+   * are NEVER handed to the verifier as evidence. They are advice
+   * about HOW to answer, not support for WHAT is answered — presenting
+   * them as evidence would let an unsupported claim verify as
+   * supported just because a strategy note mentioned its topic. The
+   * parity invariant covers evidence; advisory guidance is not
+   * evidence. (Mirrored in verifier.ts where the invariant is
+   * documented.)
+   */
+  strategyNotes?: string[];
 }
 
 @Injectable()
@@ -114,6 +135,7 @@ export class EvidenceCollectorService {
     @Optional() private readonly updateStory?: UpdateStoryService,
     @Optional() private readonly digestLane?: DigestLaneService,
     @Optional() private readonly crossEncoder?: CrossEncoderService,
+    @Optional() private readonly strategyMemory?: StrategyMemoryService,
   ) {}
 
   /**
@@ -143,6 +165,7 @@ export class EvidenceCollectorService {
       updateStories,
       digestLines,
       groundingQuotes,
+      strategyNotes,
     ] = await Promise.all([
       this.collectStandingInstructions(opts),
       this.collectTranscriptLines(opts, timelineEvidence),
@@ -150,6 +173,7 @@ export class EvidenceCollectorService {
       this.collectUpdateStories(opts),
       this.collectDigestLines(opts),
       this.collectGroundingQuotes(opts),
+      this.collectStrategyNotes(opts),
     ]);
     // V12 §2: digests merge AHEAD of retrieved insight lines under
     // the same slot — generator, verifier and NLI judge all see them
@@ -177,7 +201,44 @@ export class EvidenceCollectorService {
       timelineEvidence,
       updateStories,
       groundingQuotes,
+      strategyNotes,
     };
+  }
+
+  /**
+   * G4 strategy lane — gated on profile lane membership AND the
+   * service's own read-side flag (this service reads no env; the
+   * flags live behind StrategyMemoryService, which returns [] when
+   * serving is off). Advisory-only output: see the strategyNotes
+   * parity-exception note on CollectedEvidence. Degrades to undefined
+   * on any failure — advice must never fail an answer.
+   */
+  private async collectStrategyNotes({
+    profile,
+    companyId,
+    query,
+  }: {
+    profile: RetrievalProfile;
+    companyId: string;
+    query: string;
+  }): Promise<string[] | undefined> {
+    if (!profile.lanes.has('strategy') || !this.strategyMemory) {
+      return undefined;
+    }
+    if (!this.strategyMemory.isRetrievalEnabled()) return undefined;
+    if (getAbortSignal()?.aborted) return undefined;
+    try {
+      const items = await withSpan('synthesize.strategy_notes', () =>
+        this.strategyMemory!.retrieve(companyId, query),
+      );
+      if (items.length === 0) return undefined;
+      return items.map(renderStrategyNote);
+    } catch (e) {
+      this.logger.warn(
+        `strategy notes failed (companyId=${companyId}): ${(e as Error).message}`,
+      );
+      return undefined;
+    }
   }
 
   /**

--- a/src/synthesize/generator-client.ts
+++ b/src/synthesize/generator-client.ts
@@ -82,6 +82,11 @@ export interface GenerateRequest {
   /** V13 G2 (profile.answerConditioning): per-shape reading frame. */
   shapeInstruction?: string;
   /**
+   * G4 strategy lane: fenced advisory notes — GENERATOR-ONLY, the
+   * documented verifier-parity exception (advice, not evidence).
+   */
+  strategyNotes?: string[];
+  /**
    * V13 constrained search loop: expose the ONE-round refine
    * affordance — the schema gains a nullable `refineQuery` and the
    * system prompt the matching rule. The second (forced-answer) call

--- a/src/synthesize/generator-prompt.ts
+++ b/src/synthesize/generator-prompt.ts
@@ -4,6 +4,7 @@ import {
   CONTRADICTION_DATE_ARBITRATION_INSTRUCTION,
   ORDERING_LANE_INSTRUCTION,
   STANDING_INSTRUCTIONS_INSTRUCTION,
+  STRATEGY_ADVISORY_INSTRUCTION,
   ENUM_STRICT_CLAUSE,
   laneInstructionFor,
   type LaneId,
@@ -34,6 +35,7 @@ export function buildGeneratorUserMessage({
   enumStrict,
   dateMathLines,
   shapeInstruction,
+  strategyNotes,
 }: {
   query: string;
   factLines: string[];
@@ -98,6 +100,14 @@ export function buildGeneratorUserMessage({
    * instruction from answer-shape.ts; composes with the lane frame.
    */
   shapeInstruction?: string;
+  /**
+   * G4 strategy lane: advisory notes rendered as a clearly fenced
+   * section at the END of the message — guidance, not evidence.
+   * GENERATOR-ONLY by design: the verifier never sees these (the
+   * documented parity exception; see CollectedEvidence.strategyNotes
+   * and verifier.ts). Empty/undefined = no section, byte-identical.
+   */
+  strategyNotes?: string[];
 }): string {
   const langInstruction = answerLang
     ? `\n\nLanguage policy: write your answer in ${answerLang} (ISO 639-1). Keep citation spans in their original language.`
@@ -149,5 +159,19 @@ export function buildGeneratorUserMessage({
     dateMathLines && dateMathLines.length > 0
       ? `\n\nDate table (computed from the fact date stamps — trust it over your own arithmetic; gaps are between EVIDENCE dates, not from today):\n${dateMathLines.join('\n')}`
       : '';
-  return `Query: ${query}\n${dateInstruction}${shapeInstruction ?? ''}${laneInstruction}${instructionSection}${conflictSection}\nRetrieved facts:\n${factLines.join('\n')}${transcriptSection}${insightSection}${dateMathSection}${langInstruction}`;
+  return `Query: ${query}\n${dateInstruction}${shapeInstruction ?? ''}${laneInstruction}${instructionSection}${conflictSection}\nRetrieved facts:\n${factLines.join('\n')}${transcriptSection}${insightSection}${dateMathSection}${renderStrategySection(strategyNotes)}${langInstruction}`;
+}
+
+/**
+ * G4 advisory section — hard-fenced so the model cannot mistake advice
+ * for evidence; rendered after every evidence section. Empty input =
+ * empty string (byte-identical prompt without the lane).
+ */
+function renderStrategySection(strategyNotes?: string[]): string {
+  if (!strategyNotes || strategyNotes.length === 0) return '';
+  const notes = strategyNotes.map((n) => `- ${n}`).join('\n');
+  return (
+    `\n\n=== ADVISORY STRATEGY NOTES (guidance, not evidence — never cite) ===\n` +
+    `${STRATEGY_ADVISORY_INSTRUCTION}${notes}\n=== END ADVISORY STRATEGY NOTES ===`
+  );
 }

--- a/src/synthesize/synthesize.module.ts
+++ b/src/synthesize/synthesize.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { SearchModule } from '../search/search.module';
 import { EpisodesModule } from '../episodes/episodes.module';
 import { AnswerCacheModule } from '../answer-cache/answer-cache.module';
+import { StrategyModule } from '../strategy/strategy.module';
 import { SynthesizeController } from './synthesize.controller';
 import { SynthesizeService } from './synthesize.service';
 import { EpisodeLaneService } from './episode-lane.service';
@@ -14,7 +15,7 @@ import { DigestLaneService } from './digest-lane.service';
 import { EvidenceCollectorService } from './evidence-collector.service';
 
 @Module({
-  imports: [SearchModule, EpisodesModule, AnswerCacheModule],
+  imports: [SearchModule, EpisodesModule, AnswerCacheModule, StrategyModule],
   controllers: [SynthesizeController],
   providers: [
     SynthesizeService,

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -55,6 +55,7 @@ import { runVerifier, type VerifierOutput } from './verifier';
 import { miniCheckConsistent } from './minicheck-client';
 export { buildGeneratorUserMessage } from './generator-prompt';
 import { EvidenceCollectorService } from './evidence-collector.service';
+import type { CollectedEvidence } from './evidence-collector.service';
 import {
   AnswerCacheService,
   type AnswerCacheBeginResult,
@@ -305,6 +306,7 @@ export class SynthesizeService {
       timelineEvidence,
       updateStories,
       groundingQuotes,
+      strategyNotes,
     } = this.evidenceCollector
       ? await this.evidenceCollector.collect({
           profile,
@@ -320,14 +322,7 @@ export class SynthesizeService {
           factIds: [...factIndex.keys()],
           evidence,
         })
-      : {
-          transcriptLines: [],
-          insightLines: [],
-          instructions: undefined,
-          timelineEvidence: wantsTimelineEvidence(profile, dto.query),
-          updateStories: undefined,
-          groundingQuotes: undefined,
-        };
+      : this.emptyCollected(profile, dto.query);
 
     // V10 §2 update stories + multiworld §10 grounding quotes: both
     // suffix maps land on the SAME lines the generator and the
@@ -381,6 +376,7 @@ export class SynthesizeService {
         insightLines,
         instructions,
         timelineEvidence,
+        strategyNotes,
       },
     });
     if ('failed' in produced) return produced.failed;
@@ -454,6 +450,11 @@ export class SynthesizeService {
               // V13 date-table parity: the auditor sees the same
               // computed table the generator saw.
               dateMathLines,
+              // G4 strategyNotes are DELIBERATELY absent — the one
+              // documented exception to the W5 #22 parity invariant:
+              // advisory strategy notes are guidance, not evidence,
+              // and must never make an unsupported claim verify as
+              // supported (see verifier.ts + CollectedEvidence).
               // V11 §2 arm (a): the audit may run on a stronger judge
               // than the generator; empty override = same model.
               model: profile.verifierModel || model,
@@ -508,6 +509,26 @@ export class SynthesizeService {
       await this.answerCache?.admit(cache.ctx, final, verdict.verdict);
     }
     return final;
+  }
+
+  /**
+   * Collector-absent fallback (unit fixtures, trimmed deployments):
+   * empty sections; only the timeline gate is still computed, exactly
+   * as the collector would.
+   */
+  private emptyCollected(
+    profile: RetrievalProfile,
+    query: string,
+  ): CollectedEvidence {
+    return {
+      transcriptLines: [],
+      insightLines: [],
+      instructions: undefined,
+      timelineEvidence: wantsTimelineEvidence(profile, query),
+      updateStories: undefined,
+      groundingQuotes: undefined,
+      strategyNotes: undefined,
+    };
   }
 
   /**
@@ -571,6 +592,10 @@ export class SynthesizeService {
               conflicts: detectEvidenceConflicts(args.results, profile.lanes),
               dateMathLines: args.dateMathLines,
               shapeInstruction: args.shapeInstruction,
+              // G4 strategy lane: advisory notes, GENERATOR-ONLY — the
+              // documented exception to the W5 #22 evidence-parity
+              // invariant (advice, not evidence; see verifier.ts).
+              strategyNotes: collected.strategyNotes,
               // V13 search loop: round 1 exposes the refine affordance.
               allowRefine: profile.searchLoop,
             }),
@@ -637,6 +662,8 @@ export class SynthesizeService {
       insightLines: string[];
       instructions?: string[];
       timelineEvidence: boolean;
+      /** G4 advisory notes — generator-only (parity exception). */
+      strategyNotes?: string[];
     };
   }): Promise<{
     results: SearchHit[];
@@ -694,6 +721,7 @@ export class SynthesizeService {
             conflicts: detectEvidenceConflicts(prepared.results, profile.lanes),
             dateMathLines,
             shapeInstruction: args.shapeInstruction,
+            strategyNotes: collected.strategyNotes,
           }),
         ),
       );

--- a/src/synthesize/verifier.ts
+++ b/src/synthesize/verifier.ts
@@ -17,6 +17,19 @@ import type { MetricsService } from '../metrics/metrics.service';
  * answers, and every other mode shipped quoted L0 content with zero
  * faithfulness scoring. Whatever the generator may answer from, the
  * verifier must judge against.
+ *
+ * ONE deliberate exception (G4 strategy lane): the generator's fenced
+ * ADVISORY strategy notes are NOT part of this bundle. They are
+ * guidance about HOW to answer (question-class strategies distilled
+ * from post-mortems), not evidence about the user — the parity
+ * invariant exists so the auditor can judge every claim SOURCE the
+ * generator had; a strategy note is not a claim source, and handing
+ * it to the auditor as evidence would let an unsupported claim verify
+ * as "supported" merely because an advisory note mentioned its topic.
+ * The generator frame forbids answering FROM the notes
+ * (STRATEGY_ADVISORY_INSTRUCTION), and this asymmetry is the
+ * enforcement: a note-derived claim has no supporting evidence here
+ * and fails the audit. See CollectedEvidence.strategyNotes.
  */
 export interface VerifierOutput {
   verdict: 'supported' | 'partial' | 'unsupported';

--- a/test/answer-router.unit-spec.ts
+++ b/test/answer-router.unit-spec.ts
@@ -12,6 +12,7 @@ import {
   buildWideProbeQuery,
   extractStandingInstructions,
   STANDING_INSTRUCTIONS_INSTRUCTION,
+  STRATEGY_ADVISORY_INSTRUCTION,
   formatElapsed,
   detectVerbatimShape,
   TEMPORAL_LANE_INSTRUCTION,
@@ -558,6 +559,66 @@ describe('T7 instruction lane', () => {
         buildGeneratorUserMessage(base),
       );
     }
+  });
+});
+
+describe('G4 strategy lane — fenced ADVISORY prompt section', () => {
+  const base = {
+    query: 'How many weeks ago did I attend the sale?',
+    factLines: ['[knowledge_fact:x] u — attended: sale (as of 2022-11-17)'],
+    answerLang: null as string | null,
+  };
+  const note =
+    '[DO] compute-then-answer — applies when: temporal questions. Use the date table.';
+
+  it('renders the notes inside a hard fence with the applicability frame', () => {
+    const msg = buildGeneratorUserMessage({ ...base, strategyNotes: [note] });
+    expect(msg).toContain(
+      '=== ADVISORY STRATEGY NOTES (guidance, not evidence — never cite) ===',
+    );
+    expect(msg).toContain('=== END ADVISORY STRATEGY NOTES ===');
+    expect(msg).toContain(STRATEGY_ADVISORY_INSTRUCTION.trim());
+    expect(msg).toContain(`- ${note}`);
+    // The section renders AFTER the evidence sections — advice never
+    // interleaves with the fact list.
+    expect(msg.indexOf('Retrieved facts:')).toBeLessThan(
+      msg.indexOf('=== ADVISORY STRATEGY NOTES'),
+    );
+  });
+
+  it('absent/empty notes → byte-identical prompt (no residue)', () => {
+    for (const strategyNotes of [undefined, [] as string[]]) {
+      expect(buildGeneratorUserMessage({ ...base, strategyNotes })).toBe(
+        buildGeneratorUserMessage(base),
+      );
+    }
+    expect(buildGeneratorUserMessage(base)).not.toContain('ADVISORY');
+  });
+});
+
+describe('G4 strategy lane — profile membership gating', () => {
+  it('joins the lane set only under router + STRATEGY_MEMORY_ENABLED', () => {
+    const routerOnly = resolveRetrievalProfile({
+      SYNTHESIZE_ANSWER_ROUTER_ENABLED: '1',
+    } as NodeJS.ProcessEnv);
+    expect(routerOnly.lanes.has('strategy')).toBe(false);
+    const flagOnly = resolveRetrievalProfile({
+      STRATEGY_MEMORY_ENABLED: '1',
+    } as NodeJS.ProcessEnv);
+    expect(flagOnly.lanes.size).toBe(0);
+    const both = resolveRetrievalProfile({
+      SYNTHESIZE_ANSWER_ROUTER_ENABLED: '1',
+      STRATEGY_MEMORY_ENABLED: '1',
+    } as NodeJS.ProcessEnv);
+    expect(both.lanes.has('strategy')).toBe(true);
+  });
+
+  it('the strategy lane is advisory-only: no detect, never routed', () => {
+    const entry = LANE_REGISTRY.find((l) => l.id === 'strategy');
+    expect(entry).toBeDefined();
+    expect(entry?.detect).toBeUndefined();
+    expect(entry?.instruction).toBe(STRATEGY_ADVISORY_INSTRUCTION);
+    expect(entry?.probe).toBeUndefined();
   });
 });
 

--- a/test/evidence-collector.unit-spec.ts
+++ b/test/evidence-collector.unit-spec.ts
@@ -213,6 +213,87 @@ describe('EvidenceCollectorService branches', () => {
     expect(calls).toEqual([{ companyId: 'c1', userId: 'user-b' }]);
   });
 
+  it('strategy notes gate on lane membership AND the read-side flag', async () => {
+    const calls: string[] = [];
+    const makeStrategy = (retrievalOn: boolean) =>
+      ({
+        isRetrievalEnabled: () => retrievalOn,
+        retrieve: async (_companyId: string, query: string) => {
+          calls.push(query);
+          return [
+            {
+              strategyId: 'strategy_memory:s1',
+              title: 'check temporal shape',
+              situation: 'temporal questions',
+              strategy: 'Compute from the date table.',
+              polarity: 'do',
+              similarity: 0.9,
+            },
+          ];
+        },
+      }) as unknown as import('../src/strategy/strategy-memory.service').StrategyMemoryService;
+    const make = (retrievalOn: boolean) =>
+      new EvidenceCollectorService(
+        noSearch,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        makeStrategy(retrievalOn),
+      );
+
+    // Lane off the profile → no call, undefined.
+    const laneOff = await make(true).collect(collectorArgs(profileWith({})));
+    expect(laneOff.strategyNotes).toBeUndefined();
+    expect(calls).toHaveLength(0);
+
+    // Lane on, read-side flag off → no call, undefined.
+    const laneOnProfile = profileWith({});
+    (laneOnProfile as { lanes: ReadonlySet<string> }).lanes = new Set([
+      'strategy',
+    ]);
+    const servingOff = await make(false).collect(collectorArgs(laneOnProfile));
+    expect(servingOff.strategyNotes).toBeUndefined();
+    expect(calls).toHaveLength(0);
+
+    // Lane on + serving on → rendered advisory notes.
+    const on = await make(true).collect(collectorArgs(laneOnProfile));
+    expect(on.strategyNotes).toEqual([
+      '[DO] check temporal shape — applies when: temporal questions. Compute from the date table.',
+    ]);
+    expect(calls).toEqual([ORDER_QUERY]);
+  });
+
+  it('a strategy retrieval failure degrades to no advisory section', async () => {
+    const strategy = {
+      isRetrievalEnabled: () => true,
+      retrieve: async () => {
+        throw new Error('strategy store down');
+      },
+    } as unknown as import('../src/strategy/strategy-memory.service').StrategyMemoryService;
+    const svc = new EvidenceCollectorService(
+      noSearch,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      strategy,
+    );
+    const profile = profileWith({});
+    (profile as { lanes: ReadonlySet<string> }).lanes = new Set(['strategy']);
+    const out = await svc.collect(collectorArgs(profile));
+    expect(out.strategyNotes).toBeUndefined();
+    expect(out.transcriptLines).toEqual([]);
+  });
+
   it('grounding quotes gate on factsAsKeys AND factIds, capped best-first', async () => {
     const seen: string[][] = [];
     const episodeLane = {

--- a/test/strategy-memory.e2e-spec.ts
+++ b/test/strategy-memory.e2e-spec.ts
@@ -1,0 +1,317 @@
+/**
+ * G4 strategy-memory lane e2e (docs/roadmap/sota-gap-build-2026-08.md):
+ *
+ *   1. Flags off → the admin surface 404s (indistinguishable from
+ *      "not deployed").
+ *   2. Master on, retrieval off → distill / list / status-flip work,
+ *      but synthesize serves NO advisory section even with an active
+ *      item and the lane in the profile.
+ *   3. Both on → the generator prompt carries the fenced ADVISORY
+ *      note; the VERIFIER prompt does not (the documented parity
+ *      exception).
+ *   4. LEAKAGE (the structural guarantee): a strategy item whose text
+ *      matches the query appears in NO fact-lane search result and in
+ *      NO synthesize citation — the separate table makes this
+ *      structural; this spec pins it stays that way.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSynthesizeOpenAi } from './test-doubles';
+import { StrategyMemoryService } from '../src/strategy/strategy-memory.service';
+import { StrategyDistillService } from '../src/strategy/strategy-distill.service';
+
+const STRATEGY_ENV_KEYS = [
+  'STRATEGY_MEMORY_ENABLED',
+  'STRATEGY_RETRIEVAL_ENABLED',
+  'STRATEGY_SIMILARITY_FLOOR',
+  'STRATEGY_DISTILL_CRON_ENABLED',
+  'SYNTHESIZE_ANSWER_ROUTER_ENABLED',
+];
+
+function clearStrategyEnv(): void {
+  for (const k of STRATEGY_ENV_KEYS) delete process.env[k];
+}
+
+/** Scripted OpenAI stub for the distiller (the mockSynthesizeOpenAi idiom). */
+function mockDistillOpenAi(
+  svc: StrategyDistillService,
+  responses: string[],
+): { calls: number } {
+  const state = { calls: 0 };
+  const stub = {
+    chat: {
+      completions: {
+        create: async () => {
+          const content =
+            responses[state.calls] ?? responses[responses.length - 1] ?? '{}';
+          state.calls++;
+          return { choices: [{ message: { content } }] };
+        },
+      },
+    },
+  };
+  (svc as unknown as { openai: typeof stub }).openai = stub;
+  return state;
+}
+
+const POST_MORTEM = {
+  question: 'How many weeks ago did I attend the sale?',
+  goldAnswer: '3 weeks ago',
+  ourAnswer: '5 weeks ago',
+  diagnosis: 'freehand date arithmetic instead of the computed table',
+};
+
+const DISTILLED = JSON.stringify({
+  items: [
+    {
+      title: 'trust the computed date table',
+      situation: 'temporal-distance questions with dated evidence',
+      strategy:
+        'Derive elapsed intervals from the computed date table rather than freehand arithmetic, because manual calendar math is the dominant temporal failure mode.',
+      polarity: 'do',
+    },
+  ],
+});
+
+describe('strategy lane — flags off (default)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    clearStrategyEnv();
+    f = await createApp();
+  });
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('admin endpoints 404 — indistinguishable from not deployed', async () => {
+    const distill = await f.http
+      .post('/v1/admin/strategy/distill')
+      .set(auth())
+      .send({ postMortems: [POST_MORTEM] });
+    expect(distill.status).toBe(404);
+    const list = await f.http.get('/v1/admin/strategy').set(auth());
+    expect(list.status).toBe(404);
+    const patch = await f.http
+      .patch('/v1/admin/strategy/some-id')
+      .set(auth())
+      .send({ status: 'active' });
+    expect(patch.status).toBe(404);
+  });
+
+  it('the DI-level retrieve serves nothing (master off)', async () => {
+    const svc = f.app.get(StrategyMemoryService);
+    expect(svc.isEnabled()).toBe(false);
+    expect(await svc.retrieve(f.companyId, 'anything')).toEqual([]);
+  });
+});
+
+describe('strategy lane — master on, retrieval off', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    clearStrategyEnv();
+    process.env.STRATEGY_MEMORY_ENABLED = '1';
+    process.env.SYNTHESIZE_ANSWER_ROUTER_ENABLED = '1';
+    f = await createApp();
+    await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: { vertical: 'rent', id: 'strategy_e2e_tenant' },
+      predicate: 'status',
+      object: 'engineer',
+      validFrom: '2026-04-01',
+      source: { vertical: 'rent', eventId: 'auth.profile_updated' },
+    });
+  });
+  afterAll(async () => {
+    clearStrategyEnv();
+    if (f) await f.close();
+  });
+
+  it('distill lands ≤3 dedup-merged candidate items; re-distill NOOPs', async () => {
+    const distiller = f.app.get(StrategyDistillService);
+    mockDistillOpenAi(distiller, [DISTILLED]);
+    const first = await f.http
+      .post('/v1/admin/strategy/distill')
+      .set(auth())
+      .send({ postMortems: [POST_MORTEM], runId: 'run-1' });
+    expect(first.status).toBe(201);
+    expect(first.body).toMatchObject({
+      companyId: f.companyId,
+      postMortems: 1,
+      proposed: 1,
+      added: 1,
+      updated: 0,
+      noop: 0,
+    });
+
+    // Same batch again: the dedup-merge arbiter (scripted NOOP after
+    // the proposal) keeps the table at one row.
+    mockDistillOpenAi(distiller, [DISTILLED, '{"action":"NOOP"}']);
+    const second = await f.http
+      .post('/v1/admin/strategy/distill')
+      .set(auth())
+      .send({ postMortems: [POST_MORTEM], runId: 'run-2' });
+    expect(second.status).toBe(201);
+    expect(second.body).toMatchObject({ added: 0, updated: 0, noop: 1 });
+
+    const list = await f.http.get('/v1/admin/strategy').set(auth());
+    expect(list.status).toBe(200);
+    expect(list.body.strategies).toHaveLength(1);
+    expect(list.body.strategies[0]).toMatchObject({
+      title: 'trust the computed date table',
+      status: 'candidate',
+      polarity: 'do',
+    });
+    expect(list.body.strategies[0].evidence.runIds).toEqual(['run-1']);
+  });
+
+  it('PATCH flips candidate → active; the status filter serves it', async () => {
+    const list = await f.http.get('/v1/admin/strategy').set(auth());
+    const id = list.body.strategies[0].strategyId as string;
+    const patch = await f.http
+      .patch(`/v1/admin/strategy/${encodeURIComponent(id)}`)
+      .set(auth())
+      .send({ status: 'active' });
+    expect(patch.status).toBe(200);
+    expect(patch.body.status).toBe('active');
+    const active = await f.http
+      .get('/v1/admin/strategy?status=active')
+      .set(auth());
+    expect(active.body.strategies).toHaveLength(1);
+    const candidates = await f.http
+      .get('/v1/admin/strategy?status=candidate')
+      .set(auth());
+    expect(candidates.body.strategies).toHaveLength(0);
+  });
+
+  it('serving stays OFF: no ADVISORY section reaches the generator', async () => {
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer: 'ok', citedFactIds: [] }),
+      JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+    ]);
+    const res = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: 'engineer' });
+    expect(res.status).toBe(201);
+    expect(state.calls.length).toBeGreaterThan(0);
+    for (const call of state.calls) {
+      expect(call.user).not.toContain('ADVISORY STRATEGY NOTES');
+      expect(call.user).not.toContain('trust the computed date table');
+    }
+  });
+});
+
+describe('strategy lane — both flags on (serving)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const STRATEGY_TEXT =
+    'Derive elapsed intervals from the computed date table rather than freehand arithmetic.';
+
+  beforeAll(async () => {
+    clearStrategyEnv();
+    process.env.STRATEGY_MEMORY_ENABLED = '1';
+    process.env.STRATEGY_RETRIEVAL_ENABLED = '1';
+    process.env.SYNTHESIZE_ANSWER_ROUTER_ENABLED = '1';
+    f = await createApp();
+    await f.http.post('/v1/ingest/fact').set(auth()).send({
+      entityRef: { vertical: 'rent', id: 'strategy_e2e_tenant2' },
+      predicate: 'status',
+      object: 'engineer',
+      validFrom: '2026-04-01',
+      source: { vertical: 'rent', eventId: 'auth.profile_updated' },
+    });
+    // Seed an ACTIVE item at the service level (manual/API seeding is
+    // the v1 source; DI keeps the LLM out of the seed path). The item
+    // embeds `${title}\n${situation}` — with an empty situation the
+    // StubEmbedder trims to exactly the query text, so the cosine is
+    // 1.0 and the default 0.4 floor passes (identical-text property;
+    // the floor semantics themselves are unit-pinned).
+    await f.app.get(StrategyMemoryService).create(f.companyId, {
+      title: 'engineer',
+      situation: '',
+      strategy: STRATEGY_TEXT,
+      polarity: 'do',
+      status: 'active',
+    });
+  });
+  afterAll(async () => {
+    clearStrategyEnv();
+    if (f) await f.close();
+  });
+
+  it('the generator sees the fenced ADVISORY note; the verifier does NOT (parity exception)', async () => {
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer: 'ok', citedFactIds: [] }),
+      JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+    ]);
+    const res = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: 'engineer' });
+    expect(res.status).toBe(201);
+    expect(state.calls.length).toBeGreaterThanOrEqual(2);
+    const generatorCall = state.calls[0];
+    expect(generatorCall.user).toContain('=== ADVISORY STRATEGY NOTES');
+    expect(generatorCall.user).toContain(STRATEGY_TEXT);
+    expect(generatorCall.user).toContain('=== END ADVISORY STRATEGY NOTES ===');
+    // Every later call in this flow is the verifier: advisory content
+    // must be absent from ALL of them.
+    for (const call of state.calls.slice(1)) {
+      expect(call.user).not.toContain('ADVISORY STRATEGY NOTES');
+      expect(call.user).not.toContain(STRATEGY_TEXT);
+    }
+  });
+
+  it('LEAKAGE: a strategy item matching the query contaminates no search result and no citation', async () => {
+    // Seed a strategy whose embedded text EQUALS the query — identical
+    // text gives cosine 1.0 under the StubEmbedder, so if strategy
+    // rows could enter a fact lane at all, this would be the top hit.
+    const query = 'the sale happened three weeks before the visit';
+    await f.app.get(StrategyMemoryService).create(f.companyId, {
+      title: query,
+      situation: '',
+      strategy: query,
+      polarity: 'do',
+      status: 'active',
+    });
+
+    const search = await f.http
+      .post('/v1/search')
+      .set(auth())
+      .send({ query });
+    expect(search.status).toBe(201);
+    const body = JSON.stringify(search.body);
+    expect(body).not.toContain('strategy_memory');
+    for (const hit of search.body.results ?? []) {
+      for (const fact of hit.facts ?? []) {
+        expect(String(fact.object)).not.toBe(query);
+        expect(String(fact.factId)).not.toContain('strategy_memory');
+      }
+    }
+
+    // Synthesize on the same query: citations may only ever point at
+    // knowledge_fact rows — never at the strategy table.
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer: 'no evidence', citedFactIds: [] }),
+      JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+    ]);
+    const synth = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: 'engineer' });
+    expect(synth.status).toBe(201);
+    expect(JSON.stringify(synth.body.citations ?? [])).not.toContain(
+      'strategy_memory',
+    );
+    // The strategy text may appear ONLY inside the fenced advisory
+    // section of the generator prompt — never among the fact lines.
+    const generatorCall = state.calls[0];
+    const factSection = generatorCall.user.split(
+      '=== ADVISORY STRATEGY NOTES',
+    )[0];
+    expect(factSection).not.toContain(query);
+  });
+});

--- a/test/strategy-memory.unit-spec.ts
+++ b/test/strategy-memory.unit-spec.ts
@@ -1,0 +1,438 @@
+/**
+ * G4 strategy-memory lane (docs/roadmap/sota-gap-build-2026-08.md) —
+ * the retrieval contract (k hard-capped at 2, default 1; similarity
+ * floor; only 'active' served), the dedup-merge decision handling
+ * (Mem0 ADD/UPDATE/NOOP), the lifecycle sweep (nContradict ≥ 2 / 90d
+ * unvalidated → deprecated), and the STRUCTURAL leakage pin: the fact
+ * retrieval stack must never touch the strategy_memory table — the
+ * separate-store isolation is the design's load-bearing guarantee.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { ConfigService } from '@nestjs/config';
+import {
+  StrategyMemoryService,
+  clampStrategyK,
+  shouldDeprecate,
+  renderStrategyNote,
+  STRATEGY_RETRIEVAL_MAX_K,
+  type ScoredStrategyItem,
+  type StrategyItem,
+} from '../src/strategy/strategy-memory.service';
+import {
+  parseMergeDecision,
+  mergeEvidence,
+} from '../src/strategy/strategy-distill.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { EmbedderService } from '../src/ai/embedder.service';
+
+// ── stubs ────────────────────────────────────────────────────────────
+
+/** Embedder keyed on a text→vector map; unknown text = zero vector. */
+function stubEmbedder(vectors: Record<string, number[]>): EmbedderService {
+  return {
+    embed: async (text: string) => vectors[text] ?? [0, 0],
+  } as unknown as EmbedderService;
+}
+
+interface QueryCall {
+  sql: string;
+  params?: Record<string, unknown>;
+}
+
+/** Surreal stub: withCompany hands out a db whose query is scripted. */
+function stubSurreal(
+  respond: (sql: string, params?: Record<string, unknown>) => unknown[],
+  calls: QueryCall[] = [],
+): SurrealService {
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      calls.push({ sql, params });
+      return respond(sql, params);
+    },
+  };
+  return {
+    withCompany: async (_companyId: string, fn: (d: unknown) => unknown) =>
+      fn(db),
+  } as unknown as SurrealService;
+}
+
+function stubConfig(env: Record<string, string>): ConfigService {
+  return {
+    get: (key: string, dflt?: string) => env[key] ?? dflt,
+  } as unknown as ConfigService;
+}
+
+const BOTH_ON = {
+  STRATEGY_MEMORY_ENABLED: '1',
+  STRATEGY_RETRIEVAL_ENABLED: '1',
+};
+
+function row(over: Partial<Record<string, unknown>> = {}) {
+  const { id, ...rest } = over;
+  return {
+    companyId: 'c1',
+    title: 'temporal questions need the date table',
+    situation: 'temporal question class',
+    strategy: 'Compute intervals from the date table, never freehand.',
+    polarity: 'do',
+    status: 'active',
+    evidence: { nSupport: 1, nContradict: 0 },
+    embedding: [1, 0],
+    scope: 'tenant',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    ...rest,
+    id: `strategy_memory:${String(id ?? 'a1')}`,
+  };
+}
+
+// ── k-cap ────────────────────────────────────────────────────────────
+
+describe('strategy retrieval k-cap (ReasoningBank k-sensitivity)', () => {
+  it('clamps k into [1, 2]: default 1, hard cap 2', () => {
+    expect(clampStrategyK()).toBe(1);
+    expect(clampStrategyK(undefined)).toBe(1);
+    expect(clampStrategyK(0)).toBe(1);
+    expect(clampStrategyK(-3)).toBe(1);
+    expect(clampStrategyK(1)).toBe(1);
+    expect(clampStrategyK(2)).toBe(2);
+    expect(clampStrategyK(3)).toBe(2);
+    expect(clampStrategyK(100)).toBe(2);
+    expect(clampStrategyK(Number.NaN)).toBe(1);
+    expect(STRATEGY_RETRIEVAL_MAX_K).toBe(2);
+  });
+
+  it('retrieve(k=5) serves at most 2 items even with 3 matches', async () => {
+    const svc = new StrategyMemoryService(
+      stubSurreal((sql) =>
+        sql.includes('FROM strategy_memory')
+          ? [[row({ id: 'a1' }), row({ id: 'a2' }), row({ id: 'a3' })]]
+          : [[]],
+      ),
+      stubEmbedder({ q: [1, 0] }),
+      stubConfig(BOTH_ON),
+    );
+    const out = await svc.retrieve('c1', 'q', 5);
+    expect(out).toHaveLength(2);
+  });
+
+  it('retrieve without k serves exactly 1 item', async () => {
+    const svc = new StrategyMemoryService(
+      stubSurreal((sql) =>
+        sql.includes('FROM strategy_memory')
+          ? [[row({ id: 'a1' }), row({ id: 'a2' })]]
+          : [[]],
+      ),
+      stubEmbedder({ q: [1, 0] }),
+      stubConfig(BOTH_ON),
+    );
+    const out = await svc.retrieve('c1', 'q');
+    expect(out).toHaveLength(1);
+  });
+});
+
+// ── similarity floor ─────────────────────────────────────────────────
+
+describe('strategy retrieval similarity floor', () => {
+  it('drops items below the floor; best-first above it', async () => {
+    // query [1,0]: a1 sim=1.0, a2 sim=0.0 (orthogonal) — floor 0.4
+    // keeps only a1.
+    const svc = new StrategyMemoryService(
+      stubSurreal((sql) =>
+        sql.includes('FROM strategy_memory')
+          ? [[row({ id: 'a2', embedding: [0, 1] }), row({ id: 'a1' })]]
+          : [[]],
+      ),
+      stubEmbedder({ q: [1, 0] }),
+      stubConfig(BOTH_ON),
+    );
+    const out = await svc.retrieve('c1', 'q', 2);
+    expect(out.map((i) => i.strategyId)).toEqual(['strategy_memory:a1']);
+    expect(out[0].similarity).toBeCloseTo(1.0);
+  });
+
+  it('an irrelevant best-match serves nothing (floor wins over k)', async () => {
+    const svc = new StrategyMemoryService(
+      stubSurreal((sql) =>
+        sql.includes('FROM strategy_memory')
+          ? [[row({ id: 'a1', embedding: [0, 1] })]]
+          : [[]],
+      ),
+      stubEmbedder({ q: [1, 0] }),
+      stubConfig(BOTH_ON),
+    );
+    expect(await svc.retrieve('c1', 'q')).toEqual([]);
+  });
+
+  it('the floor is the STRATEGY_SIMILARITY_FLOOR knob (default 0.4)', async () => {
+    // sim = cos([1,0],[1,1]) ≈ 0.707: below a 0.9 floor, above default.
+    const make = (env: Record<string, string>) =>
+      new StrategyMemoryService(
+        stubSurreal((sql) =>
+          sql.includes('FROM strategy_memory')
+            ? [[row({ id: 'a1', embedding: [1, 1] })]]
+            : [[]],
+        ),
+        stubEmbedder({ q: [1, 0] }),
+        stubConfig(env),
+      );
+    expect(await make(BOTH_ON).retrieve('c1', 'q')).toHaveLength(1);
+    expect(
+      await make({ ...BOTH_ON, STRATEGY_SIMILARITY_FLOOR: '0.9' }).retrieve(
+        'c1',
+        'q',
+      ),
+    ).toEqual([]);
+  });
+});
+
+// ── status filter + flag gates ───────────────────────────────────────
+
+describe('strategy retrieval status filter and flag gates', () => {
+  it('serving queries restrict to status=active only', async () => {
+    const calls: QueryCall[] = [];
+    const svc = new StrategyMemoryService(
+      stubSurreal((sql) => (sql.includes('FROM strategy_memory') ? [[]] : [[]]), calls),
+      stubEmbedder({ q: [1, 0] }),
+      stubConfig(BOTH_ON),
+    );
+    await svc.retrieve('c1', 'q');
+    const serving = calls.find((c) => c.sql.includes('FROM strategy_memory'));
+    expect(serving?.params?.statuses).toEqual(['active']);
+  });
+
+  it('findSimilar (dedup write path) sees candidate+active, floor-free', async () => {
+    const calls: QueryCall[] = [];
+    const svc = new StrategyMemoryService(
+      stubSurreal(
+        (sql) =>
+          sql.includes('FROM strategy_memory')
+            ? [[row({ id: 'c1row', status: 'candidate', embedding: [0, 1] })]]
+            : [[]],
+        calls,
+      ),
+      stubEmbedder({ q: [1, 0] }),
+      stubConfig(BOTH_ON),
+    );
+    const out = await svc.findSimilar('c1', 'q');
+    // Orthogonal (sim 0) still returned — the merge LLM judges.
+    expect(out).toHaveLength(1);
+    const call = calls.find((c) => c.sql.includes('FROM strategy_memory'));
+    expect(call?.params?.statuses).toEqual(['candidate', 'active']);
+  });
+
+  it('retrieve is empty (and hits no DB) when either flag is off', async () => {
+    const gateCases: Array<Record<string, string>> = [
+      {},
+      { STRATEGY_MEMORY_ENABLED: '1' },
+      { STRATEGY_RETRIEVAL_ENABLED: '1' },
+    ];
+    for (const env of gateCases) {
+      const calls: QueryCall[] = [];
+      const svc = new StrategyMemoryService(
+        stubSurreal(() => [[row()]], calls),
+        stubEmbedder({ q: [1, 0] }),
+        stubConfig(env),
+      );
+      expect(await svc.retrieve('c1', 'q')).toEqual([]);
+      expect(calls).toHaveLength(0);
+    }
+  });
+});
+
+// ── dedup-merge decision handling ────────────────────────────────────
+
+describe('dedup-merge decision handling (Mem0 ADD/UPDATE/NOOP)', () => {
+  const ids = ['strategy_memory:x1', 'strategy_memory:x2'];
+
+  it('parses the three actions', () => {
+    expect(parseMergeDecision('{"action":"ADD"}', ids)).toEqual({
+      action: 'ADD',
+    });
+    expect(parseMergeDecision('{"action":"NOOP"}', ids)).toEqual({
+      action: 'NOOP',
+    });
+    expect(
+      parseMergeDecision(
+        '{"action":"UPDATE","targetId":"strategy_memory:x2","strategy":"s","situation":"c"}',
+        ids,
+      ),
+    ).toEqual({
+      action: 'UPDATE',
+      targetId: 'strategy_memory:x2',
+      strategy: 's',
+      situation: 'c',
+    });
+  });
+
+  it('garbage degrades to NOOP — a malformed decision must not grow the table', () => {
+    expect(parseMergeDecision(undefined, ids).action).toBe('NOOP');
+    expect(parseMergeDecision('', ids).action).toBe('NOOP');
+    expect(parseMergeDecision('not json', ids).action).toBe('NOOP');
+    expect(parseMergeDecision('{"action":"DELETE"}', ids).action).toBe('NOOP');
+  });
+
+  it('UPDATE with an unknown/hallucinated targetId degrades to NOOP', () => {
+    expect(
+      parseMergeDecision(
+        '{"action":"UPDATE","targetId":"strategy_memory:nope"}',
+        ids,
+      ).action,
+    ).toBe('NOOP');
+    expect(parseMergeDecision('{"action":"UPDATE"}', ids).action).toBe('NOOP');
+  });
+
+  it('mergeEvidence sums vote counters and unions run provenance', () => {
+    const merged = mergeEvidence(
+      {
+        source: 'post_mortem',
+        runIds: ['r1'],
+        nSupport: 2,
+        nContradict: 1,
+        lastValidatedAt: '2026-08-01T00:00:00.000Z',
+      },
+      { runIds: ['r1', 'r2'], nSupport: 1, nContradict: 0, lastValidatedAt: '2026-08-20T00:00:00.000Z' },
+    );
+    expect(merged.nSupport).toBe(3);
+    expect(merged.nContradict).toBe(1);
+    expect(merged.runIds).toEqual(['r1', 'r2']);
+    expect(merged.lastValidatedAt).toBe('2026-08-20T00:00:00.000Z');
+    expect(merged.source).toBe('post_mortem');
+  });
+});
+
+// ── lifecycle sweep ──────────────────────────────────────────────────
+
+describe('strategy lifecycle sweep (auto-deprecation)', () => {
+  const now = new Date('2026-08-23T00:00:00.000Z');
+  const base: Pick<StrategyItem, 'evidence' | 'createdAt'> = {
+    evidence: { nContradict: 0, lastValidatedAt: '2026-08-20T00:00:00.000Z' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  it('deprecates on nContradict >= 2', () => {
+    expect(shouldDeprecate(base, now)).toBe(false);
+    expect(
+      shouldDeprecate({ ...base, evidence: { ...base.evidence, nContradict: 1 } }, now),
+    ).toBe(false);
+    expect(
+      shouldDeprecate({ ...base, evidence: { ...base.evidence, nContradict: 2 } }, now),
+    ).toBe(true);
+    expect(
+      shouldDeprecate({ ...base, evidence: { ...base.evidence, nContradict: 5 } }, now),
+    ).toBe(true);
+  });
+
+  it('deprecates past 90 days unvalidated; createdAt anchors the never-validated', () => {
+    const recent = { evidence: { lastValidatedAt: '2026-06-01T00:00:00.000Z' }, createdAt: '2026-01-01T00:00:00.000Z' };
+    const stale = { evidence: { lastValidatedAt: '2026-05-01T00:00:00.000Z' }, createdAt: '2026-01-01T00:00:00.000Z' };
+    expect(shouldDeprecate(recent, now)).toBe(false);
+    expect(shouldDeprecate(stale, now)).toBe(true);
+    // Never validated → createdAt is the staleness anchor.
+    expect(
+      shouldDeprecate({ evidence: {}, createdAt: '2026-08-01T00:00:00.000Z' }, now),
+    ).toBe(false);
+    expect(
+      shouldDeprecate({ evidence: {}, createdAt: '2026-01-01T00:00:00.000Z' }, now),
+    ).toBe(true);
+  });
+
+  it('deprecateSweep flips exactly the qualifying rows', async () => {
+    const calls: QueryCall[] = [];
+    const svc = new StrategyMemoryService(
+      stubSurreal(
+        (sql) =>
+          sql.includes('FROM strategy_memory')
+            ? [
+                [
+                  row({ id: 'keep', evidence: { nContradict: 0, lastValidatedAt: '2026-08-20T00:00:00.000Z' } }),
+                  row({ id: 'contradicted', evidence: { nContradict: 2 } }),
+                  row({ id: 'stale', evidence: { lastValidatedAt: '2026-01-01T00:00:00.000Z' } }),
+                ],
+              ]
+            : [[]],
+        calls,
+      ),
+      stubEmbedder({}),
+      stubConfig({ STRATEGY_MEMORY_ENABLED: '1' }),
+    );
+    const stats = await svc.deprecateSweep('c1', new Date('2026-08-23T00:00:00.000Z'));
+    expect(stats).toEqual({ companyId: 'c1', scanned: 3, deprecated: 2 });
+    const updates = calls.filter((c) => c.sql.includes("status = 'deprecated'"));
+    expect(updates.map((c) => c.params?.tail).sort()).toEqual([
+      'contradicted',
+      'stale',
+    ]);
+  });
+});
+
+// ── advisory rendering ───────────────────────────────────────────────
+
+describe('renderStrategyNote', () => {
+  it('renders polarity tag + preconditions + lesson', () => {
+    const item = {
+      title: 'commit on dated conflicts',
+      situation: 'knowledge-update questions',
+      strategy: 'Prefer the latest dated value.',
+      polarity: 'avoid',
+    } as unknown as ScoredStrategyItem;
+    expect(renderStrategyNote(item)).toBe(
+      '[AVOID] commit on dated conflicts — applies when: knowledge-update questions. Prefer the latest dated value.',
+    );
+  });
+});
+
+// ── STRUCTURAL leakage pin ───────────────────────────────────────────
+
+/**
+ * The separate-table guarantee, pinned at the source level: the fact
+ * retrieval stack (search + ingest + facts + multi-hop) must never
+ * reference the strategy_memory table or the strategy module. If this
+ * fails, someone unioned strategy rows into a fact lane — the exact
+ * leakage the G4 design makes structurally impossible.
+ */
+describe('structural leakage pin — fact lanes never touch strategy_memory', () => {
+  const SRC = join(__dirname, '..', 'src');
+  const FACT_STACK_DIRS = ['search', 'ingest', 'facts', 'multi-hop'];
+
+  function walk(dir: string): string[] {
+    const out: string[] = [];
+    for (const name of readdirSync(dir)) {
+      const p = join(dir, name);
+      if (statSync(p).isDirectory()) out.push(...walk(p));
+      else if (p.endsWith('.ts')) out.push(p);
+    }
+    return out;
+  }
+
+  it('no fact-stack source mentions strategy_memory or imports src/strategy', () => {
+    const offenders: string[] = [];
+    for (const dir of FACT_STACK_DIRS) {
+      for (const file of walk(join(SRC, dir))) {
+        const text = readFileSync(file, 'utf8');
+        if (text.includes('strategy_memory') || text.includes("/strategy/")) {
+          offenders.push(file);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('the synthesize side reaches strategy ONLY through the advisory collector', () => {
+    // Module wiring (DI) is not data flow — the collector is the one
+    // place strategy content enters a prompt.
+    const allowed = new Set([
+      'evidence-collector.service.ts',
+      'synthesize.module.ts',
+    ]);
+    const offenders: string[] = [];
+    for (const file of walk(join(SRC, 'synthesize'))) {
+      const text = readFileSync(file, 'utf8');
+      if (!text.includes("from '../strategy/")) continue;
+      const name = file.split('/').pop() ?? file;
+      if (!allowed.has(name)) offenders.push(file);
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

G4 + G7 host from the [SOTA gap build program](../blob/main/docs/roadmap/sota-gap-build-2026-08.md) (#309): a failure-distilled strategy memory in the ReasoningBank shape, kept structurally separate from facts so it can never contaminate grounded retrieval.

- **Separate `strategy_memory` table (migration 0092), separate lane, separate prompt section.** The research's hard rule — nobody mixes procedural memory with factual retrieval; leakage must be structural, not filter-discipline. A leakage e2e seeds a query-matching strategy item (cosine 1.0) and asserts zero contamination of search results, fact lines, and citations.
- **k=1 advisory retrieval** (hard cap 2, similarity floor default 0.4, active-only): ReasoningBank's own k-sensitivity (49.7%@k1 → 44.4%@k4 — more strategies hurt). Strategy notes render in a fenced `=== ADVISORY STRATEGY NOTES ===` generator section with an explicit "assess applicability before use" instruction.
- **Verifier-parity exception (documented at the W5 #22 invariant):** strategy notes go to the generator but are deliberately **withheld from the verifier** — they are advice, not evidence, and must never make an unsupported claim verify as supported.
- **Distillation + lifecycle:** `StrategyDistillService` (PromotionRunner template) distills ≤3 items/batch from post-mortems via `chatCallParams`, Mem0-style ADD/UPDATE/NOOP dedup-merge against top-3 neighbors; nightly cron hosts the G7 sweep with evidence-counter updates + auto-deprecate (nContradict≥2 or 90d unvalidated). Admin endpoints: POST `/v1/admin/strategy/distill`, GET `/v1/admin/strategy`, PATCH `/v1/admin/strategy/:id`.
- **Flags:** `STRATEGY_MEMORY_ENABLED` (master), `STRATEGY_RETRIEVAL_ENABLED` (read side), `STRATEGY_DISTILL_CRON_ENABLED`, `STRATEGY_SIMILARITY_FLOOR` — all default off/inert. STRATEGY_ escapes the engine flag-budget prefix (no golden edit).

## Tests

Full unit suite **260 suites / 2249 tests green** (rebased onto main incl. #310/#311/#312; the answer-cache × strategy conflict in synthesize.service/module resolved so both the G1 admission seam and the G4 strategy threading coexist); new strategy unit spec 19 tests, e2e 7/7 (flags-off 404s; distill→list→PATCH; generator-sees/verifier-doesn't; structural leakage). typecheck + lint clean. One real bug caught mid-build (blank `STRATEGY_SIMILARITY_FLOOR` collapsing to 0) fixed + pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB