### PR TITLE
feat(auth): hierarchical scope-tag foundation — scope column + parity-proven visibility evaluator (default-off)

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -591,6 +591,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
           'DB-level PERMISSIONS PII fence (0057). Inert for the system-user pool — the app-layer JS filter is the enforcing gate.',
       },
       {
+        key: 'SCOPE_TAGS_ENABLED',
+        category: 'auth',
+        defaultValue: '0',
+        runtimeMutable: true,
+        isBooleanFlag: true,
+        description:
+          'G6 hierarchical scope-tag fence (migration 0093). When on, the scope-tag visibility evaluator runs as an ADDITIONAL AND-fence alongside the untouched migration-0055 userId filter at every per-user read seam (episode L0 reads, fact search legs, get-fact/provenance) — a row must pass BOTH. Composed with AND it can only narrow, never open, what userId filtering already returns; for current single-tag data (every row scope is [] or [user:<id>]) the two fences keep provably identical row sets, so enabling it changes nothing (the parity property that makes it safe to ship on). Fail-closed: a record scope with an unparseable or unknown-namespace tag is hidden from a scoped principal. Off (default) → the scope column is written by backfill/ingest but never read for filtering; enforcement is byte-identical pre-0093. Steps 3-5 (ABAC widen / share-up staging / revocation tokens) are a follow-up.',
+      },
+      {
         key: 'SOURCE_META_STRICT',
         category: 'pipeline',
         defaultValue: '0',

--- a/src/admin/segment-composer.service.ts
+++ b/src/admin/segment-composer.service.ts
@@ -3,6 +3,7 @@ import { StringRecordId, type Surreal } from 'surrealdb';
 import { SurrealService, runTransaction } from '../db/surreal.service';
 import { FactEmbeddingService } from '../ingest/fact-embedding.service';
 import { EpisodeReadStoreService } from '../episodes/episode-read-store.service';
+import { scopeForUser } from '../auth/scope-tags';
 import {
   segmentSessions,
   type EpisodeRow,
@@ -162,6 +163,10 @@ export class SegmentComposerService {
         occurredAt: new Date(w.turns[0].occurredAt as string),
         piiClass: pii.length > 0 ? pii : undefined,
         userId: userIds.length === 1 ? userIds[0] : undefined,
+        // G6 step 1: mirror the per-user scope as a scope tag (0093).
+        // A mixed-user window stays tenant-global ([]) — same rule as
+        // the userId stamp above.
+        scope: scopeForUser(userIds.length === 1 ? userIds[0] : undefined),
         embedding: vectors[i],
         recorder: SEGMENT_RECORDER,
         generation,

--- a/src/auth/scope-tags.ts
+++ b/src/auth/scope-tags.ts
@@ -1,0 +1,78 @@
+/**
+ * Scope-tag grammar (G6 step 1, docs/roadmap/sota-gap-build-2026-08.md).
+ *
+ * Generalizes the single per-user scope key (migration 0055's `userId`)
+ * into a tag model that later steps extend to org/team membership. A
+ * scope tag is `<namespace>:<id>`. Today the ONLY namespace stamped on
+ * data is `user`; `org`/`team` are RESERVED here so the parser accepts
+ * them the moment steps 3-5 (ABAC widen / share-up / revocation) start
+ * writing them, but no code emits them yet.
+ *
+ * A record's `scope` column is an array of tags interpreted as ONE
+ * AND-set clause (the record requires ALL its tags to be satisfied).
+ * For step-1 data every record carries exactly ONE tag (`user:<id>`) or
+ * an empty array (tenant-global). Visibility (`visibleUnderScope`, in
+ * scope-visibility.ts) is the OR-of-ANDs evaluation that the multi-tag /
+ * multi-clause shapes of later steps generalize to.
+ *
+ * Pure module — no NestJS, no DB, no request context. Importable from
+ * services, pure internals, and SQL-fragment builders alike.
+ */
+
+/** Active namespace: a single end-user's slice of the tenant (0055). */
+export const USER_NAMESPACE = 'user';
+/** Reserved for step 3+ (ABAC org widen). No writer emits it in step 1. */
+export const ORG_NAMESPACE = 'org';
+/** Reserved for step 3+ (team membership). No writer emits it in step 1. */
+export const TEAM_NAMESPACE = 'team';
+
+/**
+ * Namespaces the grammar recognizes. A tag whose namespace is NOT in
+ * this set is treated as UNPARSEABLE by `parseTag` (→ fail-closed in the
+ * evaluator) — an unknown namespace must never default a record open.
+ */
+export const KNOWN_NAMESPACES: ReadonlySet<string> = new Set([
+  USER_NAMESPACE,
+  ORG_NAMESPACE,
+  TEAM_NAMESPACE,
+]);
+
+export interface ParsedTag {
+  namespace: string;
+  id: string;
+}
+
+/** The scope tag for a single end-user: `user:<userId>`. */
+export function userTag(userId: string): string {
+  return `${USER_NAMESPACE}:${userId}`;
+}
+
+/**
+ * Parse a scope tag into `{ namespace, id }`, or `null` when the tag is
+ * malformed OR carries an unknown namespace. Splitting on the FIRST
+ * colon lets an id itself contain colons (record ids do). A null return
+ * is the fail-closed signal the evaluator keys on: an unparseable tag in
+ * a record scope hides that record from a scoped principal.
+ */
+export function parseTag(tag: string): ParsedTag | null {
+  if (typeof tag !== 'string') return null;
+  const sep = tag.indexOf(':');
+  // Reject: no separator, empty namespace, empty id.
+  if (sep <= 0 || sep === tag.length - 1) return null;
+  const namespace = tag.slice(0, sep);
+  const id = tag.slice(sep + 1);
+  if (!KNOWN_NAMESPACES.has(namespace)) return null;
+  return { namespace, id };
+}
+
+/**
+ * The record scope for a write attributed to `userId`:
+ *   - a defined userId → `['user:<userId>']` (the one-clause AND-set);
+ *   - undefined → `[]` (tenant-global, the `userId IS NONE` meaning).
+ *
+ * This is the single place a per-user write turns into a scope, so the
+ * org/team extension of later steps has one call site to widen.
+ */
+export function scopeForUser(userId: string | undefined): string[] {
+  return userId ? [userTag(userId)] : [];
+}

--- a/src/auth/scope-visibility.ts
+++ b/src/auth/scope-visibility.ts
@@ -1,0 +1,123 @@
+/**
+ * Scope-tag visibility (G6 step 2, docs/roadmap/sota-gap-build-2026-08.md).
+ *
+ * The read-side evaluator for the scope-tag model, gated behind
+ * `SCOPE_TAGS_ENABLED` (default off). The load-bearing safety property:
+ * when the flag is ON the evaluator runs as an ADDITIONAL fence
+ * ALONGSIDE the existing `userId` filter (migration 0055), never as a
+ * replacement — a row must pass BOTH. Composed with AND, the flag can
+ * only ever NARROW what the userId filter already returns, so enabling
+ * it can never OPEN access that userId filtering closed. For current
+ * single-tag data the two fences keep provably identical row sets (see
+ * scope-tags-parity.e2e-spec.ts), which is what makes shipping it
+ * enabled safe.
+ *
+ * Pure evaluator + a request-context-derived principal + a SQL-fragment
+ * helper for the seams whose userId fence is a WHERE clause.
+ */
+import { envFlagEnabled } from '../common/env-validation';
+import { getRequestContext } from '../common/request-context';
+import { parseTag, userTag } from './scope-tags';
+
+/**
+ * A principal that holds tenant-wide authority (an M2M credential with
+ * no end-user identity, or a background/internal context). It sees every
+ * row in the tenant, matching today's behavior where such a caller has
+ * no `userId` ownership fence applied. Represented as an explicit symbol
+ * — never a magic string — so it can never collide with a real tag.
+ */
+export const TENANT_WIDE: unique symbol = Symbol('scope.tenant_wide');
+
+/** A principal is either tenant-wide, or a concrete set of held tags. */
+export type PrincipalScope = typeof TENANT_WIDE | readonly string[];
+
+/** Whether the scope-tag fence is active. Read per-call (runtime-mutable). */
+export function scopeTagsEnabled(): boolean {
+  return envFlagEnabled(process.env.SCOPE_TAGS_ENABLED);
+}
+
+/**
+ * Does `principal` satisfy a record whose `recordScope` is ONE AND-set
+ * clause? OR-of-ANDs, restricted to the one-clause-per-record shape of
+ * step-1 data:
+ *   - empty record scope (`[]`) → tenant-global, visible to everyone in
+ *     the tenant (matches `userId IS NONE`);
+ *   - a tenant-wide principal (M2M) → sees every row, unconditionally;
+ *   - otherwise the principal must hold ALL of the clause's tags
+ *     (`clause ⊆ principalTags`). Step-1 records carry exactly one tag,
+ *     so this reduces to "the principal holds that tag".
+ *
+ * FAIL CLOSED: any tag in the record scope that is unparseable or of an
+ * unknown namespace hides the record from a scoped principal — an
+ * unrecognized tag is never treated as absent (which would default the
+ * record open). A tenant-wide principal is the tenant boundary itself
+ * and still sees such rows, so enabling the flag never hides data an
+ * M2M caller sees today (the parity property, extended to malformed
+ * tags).
+ */
+export function visibleUnderScope(
+  recordScope: readonly string[],
+  principal: PrincipalScope,
+): boolean {
+  // Tenant-global content: visible to everyone in the tenant.
+  if (recordScope.length === 0) return true;
+  // Tenant-wide authority: sees the whole tenant, malformed tags included
+  // (it already does today, with no userId fence) — preserves parity.
+  if (principal === TENANT_WIDE) return true;
+  // Scoped principal: satisfy the AND-set, failing closed on any tag we
+  // cannot parse or whose namespace we do not recognize.
+  for (const tag of recordScope) {
+    if (parseTag(tag) === null) return false;
+    if (!principal.includes(tag)) return false;
+  }
+  return true;
+}
+
+/**
+ * The tags the current request's principal holds, derived from the ALS
+ * request context (the same source `pinUserScope` reads):
+ *   - a user-bound token (authUserId set by ApiKeyGuard) → `['user:<id>']`;
+ *   - an M2M credential or a background context (no authUserId) →
+ *     TENANT_WIDE.
+ *
+ * Mirrors `pinUserScope(undefined)`: where that returns the token's
+ * end-user (fencing reads) or undefined (unrestricted), this returns the
+ * held tag set or TENANT_WIDE.
+ */
+export function principalScopeTags(): PrincipalScope {
+  const authUserId = getRequestContext()?.authUserId;
+  return authUserId ? [userTag(authUserId)] : TENANT_WIDE;
+}
+
+/**
+ * The SQL fence for the seams whose userId filter is a WHERE clause
+ * (episode L0 reads, fact search legs). Returns an ADDED AND-condition
+ * that mirrors the `userId` filter tag-for-tag against the `scope`
+ * column, or an empty fragment when the flag is off (fully inert — the
+ * userId filter stays the sole enforcement). Never rewrites the userId
+ * filter; it is only ever appended.
+ *
+ * Derived from the SAME scoped `userId` that drives the userId filter,
+ * so parity is structural: for step-1 data where `scope` mirrors
+ * `userId`, the added clause keeps exactly the rows the userId clause
+ * keeps. Fail-closed by construction — a row whose scope is neither `[]`
+ * nor the principal's single `user:<id>` tag matches neither branch and
+ * is hidden.
+ *
+ * @param userId the request's scoped end-user (undefined = tenant-global)
+ * @param param  bound-parameter name to use for the principal tag
+ */
+export function scopeFenceSql(
+  userId: string | undefined,
+  param = 'principalScopeTag',
+): { clause: string; params: Record<string, unknown> } {
+  if (!scopeTagsEnabled()) return { clause: '', params: {} };
+  if (!userId) {
+    // No scoped user → tenant-global only, mirroring `userId IS NONE`.
+    return { clause: 'AND scope = []', params: {} };
+  }
+  return {
+    clause: `AND (scope = [] OR scope = [$${param}])`,
+    params: { [param]: userTag(userId) },
+  };
+}

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -702,6 +702,11 @@ const KNOWN_BOOLEAN_FLAGS = [
   // maintained count() rollup tables instead of live GROUP aggregates.
   // Off (default) → byte-identical pre-0088 live counting.
   'STATS_VIEWS_ENABLED',
+  // G6 scope-tag fence (0093): the scope-tag visibility evaluator runs
+  // as an ADDITIONAL AND-fence alongside the untouched 0055 userId
+  // filter. Off (default) → the scope column is written but never read;
+  // enforcement is byte-identical pre-0093.
+  'SCOPE_TAGS_ENABLED',
   'INDEXER_WEBHOOK_PUSH_ENABLED',
   'REINDEX_ON_PACK_INSTALL',
   'DOCUMENT_ALLOW_UNGROUNDED_EXTERNAL',

--- a/src/db/migrations/0093_scope_tags.surql
+++ b/src/db/migrations/0093_scope_tags.surql
@@ -1,0 +1,78 @@
+-- 0093: scope-tag foundation — a per-row `scope` column mirroring the
+-- 0055 `userId` scope, backfilled behavior-identically (G6 step 1 of
+-- docs/roadmap/sota-gap-build-2026-08.md).
+--
+-- Generalizes the single caller-asserted `userId` (migration 0055,
+-- extended to L0 by 0073/0075) into a scope-tag model that later steps
+-- extend to org/team membership. A `scope` is an array of tags, each
+-- `<namespace>:<id>`, interpreted as ONE AND-set clause. TAG GRAMMAR:
+--   * `user:<id>` — the ONLY namespace written today; the exact
+--     one-clause equivalent of a row's `userId`.
+--   * `org:<id>` / `team:<id>` — RESERVED for the later steps (ABAC
+--     write/widen, share-up via staging, revocation tokens). No writer
+--     emits them here; the parser (src/auth/scope-tags.ts) accepts them
+--     so those steps are a data change, not a migration.
+--
+-- Empty scope (`[]`) is tenant-global — the `userId IS NONE` meaning.
+-- The column covers the SAME set of tables that carry a `userId` scope
+-- column subject to per-user READ visibility: knowledge_fact,
+-- knowledge_entity, knowledge_edge, episode, episode_segment. Two
+-- userId-bearing tables are DELIBERATELY excluded: `answer_cache`
+-- (0091) — its userId is a cache-partition key folded into the row
+-- hash id and double-fenced there, not a visibility scope, and the rows
+-- are ephemeral; and `conversation_digest` (0087) — it already carries
+-- its own array-scope mechanism (`userScopes`), whose folding into this
+-- tag grammar is a later step.
+--
+-- BEHAVIOR-IDENTICAL. This migration is inert until SCOPE_TAGS_ENABLED
+-- is turned on, and even then the evaluator is an ADDITIONAL fence
+-- composed with AND alongside the untouched userId filter, so it can
+-- only narrow — never open — what userId filtering already returns. The
+-- scope index mirrors the userId index where one exists (0055 defined
+-- fact_user_idx / entity_user_idx; edge/episode/segment have none).
+--
+-- BACKFILL is explicit for BOTH branches and only fills unpopulated
+-- rows: DEFINE FIELD ... DEFAULT applies at write time, not
+-- retroactively, so pre-migration rows read as `scope IS NONE` until set
+-- here. Guarding on `(scope IS NONE OR scope = [])` makes it idempotent
+-- and never clobbers a scope a rolling-deploy write may have already
+-- stamped.
+
+-- ── knowledge_fact ──────────────────────────────────────────────
+DEFINE FIELD IF NOT EXISTS scope ON knowledge_fact TYPE array<string> DEFAULT [];
+DEFINE INDEX IF NOT EXISTS fact_scope_idx ON knowledge_fact FIELDS scope;
+UPDATE knowledge_fact SET scope = ['user:' + userId]
+  WHERE userId IS NOT NONE AND (scope IS NONE OR scope = []);
+UPDATE knowledge_fact SET scope = []
+  WHERE userId IS NONE AND scope IS NONE;
+
+-- ── knowledge_entity ────────────────────────────────────────────
+DEFINE FIELD IF NOT EXISTS scope ON knowledge_entity TYPE array<string> DEFAULT [];
+DEFINE INDEX IF NOT EXISTS entity_scope_idx ON knowledge_entity FIELDS scope;
+UPDATE knowledge_entity SET scope = ['user:' + userId]
+  WHERE userId IS NOT NONE AND (scope IS NONE OR scope = []);
+UPDATE knowledge_entity SET scope = []
+  WHERE userId IS NONE AND scope IS NONE;
+
+-- ── knowledge_edge ──────────────────────────────────────────────
+-- Edges carry the userId column (0055) but no write path stamps it —
+-- every edge is tenant-global — so the backfill only ever sets [].
+DEFINE FIELD IF NOT EXISTS scope ON knowledge_edge TYPE array<string> DEFAULT [];
+UPDATE knowledge_edge SET scope = ['user:' + userId]
+  WHERE userId IS NOT NONE AND (scope IS NONE OR scope = []);
+UPDATE knowledge_edge SET scope = []
+  WHERE userId IS NONE AND scope IS NONE;
+
+-- ── episode (L0 substrate, 0073) ────────────────────────────────
+DEFINE FIELD IF NOT EXISTS scope ON episode TYPE array<string> DEFAULT [];
+UPDATE episode SET scope = ['user:' + userId]
+  WHERE userId IS NOT NONE AND (scope IS NONE OR scope = []);
+UPDATE episode SET scope = []
+  WHERE userId IS NONE AND scope IS NONE;
+
+-- ── episode_segment (0075) ──────────────────────────────────────
+DEFINE FIELD IF NOT EXISTS scope ON episode_segment TYPE array<string> DEFAULT [];
+UPDATE episode_segment SET scope = ['user:' + userId]
+  WHERE userId IS NOT NONE AND (scope IS NONE OR scope = []);
+UPDATE episode_segment SET scope = []
+  WHERE userId IS NONE AND scope IS NONE;

--- a/src/episodes/episode-read-store.service.ts
+++ b/src/episodes/episode-read-store.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
+import { scopeFenceSql } from '../auth/scope-visibility';
 
 /**
  * Read port over the L0 episode substrate (raw-substrate driver v1,
@@ -90,6 +91,20 @@ export class EpisodeReadStoreService {
     return userId ? { scopeUserId: userId } : {};
   }
 
+  /**
+   * G6 scope-tag fence (SCOPE_TAGS_ENABLED, default off). An ADDED
+   * AND-condition mirroring userGate against the `scope` column, or an
+   * empty fragment when the flag is off (userGate stays the sole
+   * enforcement). Defense-in-depth — composed with AND, never replacing
+   * userGate, so it can only narrow, never open. See scope-visibility.ts.
+   */
+  private scopeGate(userId: string | undefined): {
+    clause: string;
+    params: Record<string, unknown>;
+  } {
+    return scopeFenceSql(userId);
+  }
+
   private async run<T>(
     companyId: string,
     db: EpisodeDb | undefined,
@@ -163,12 +178,17 @@ export class EpisodeReadStoreService {
         ? Math.min(Math.floor(opts.cap), CONVERSATION_TURNS_CAP)
         : CONVERSATION_TURNS_CAP;
     return this.run(opts.companyId, opts.db, async (db) => {
-      const gates = `${this.piiGate(opts.includePii)} ${this.userGate(opts.userId)}`;
+      const scope = this.scopeGate(opts.userId);
+      const gates = `${this.piiGate(opts.includePii)} ${this.userGate(opts.userId)} ${scope.clause}`;
       const [rows] = await db.query<[EpisodeTurnRow[]]>(
         `SELECT id, speaker, text, occurredAt, piiClass, userId FROM episode
           WHERE conversationId = $conv ${gates}
           ORDER BY occurredAt ASC, id ASC LIMIT ${cap}`,
-        { conv: opts.conversationId, ...this.userParams(opts.userId) },
+        {
+          conv: opts.conversationId,
+          ...this.userParams(opts.userId),
+          ...scope.params,
+        },
       );
       return rows ?? [];
     });
@@ -198,18 +218,20 @@ export class EpisodeReadStoreService {
       ? { speakerSuffix: opts.speakerSuffix.toLowerCase() }
       : {};
     return this.run(opts.companyId, opts.db, async (db) => {
+      const scope = this.scopeGate(opts.userId);
       const [rows] = await db.query<
         [Array<EpisodeQuoteRow & { score?: number }>]
       >(
         `SELECT id, conversationId, speaker, text, occurredAt, search::score(1) AS score
            FROM episode
-          WHERE text @1@ $q ${this.piiGate(opts.includePii)} ${this.userGate(opts.userId)} ${speakerGate}
+          WHERE text @1@ $q ${this.piiGate(opts.includePii)} ${this.userGate(opts.userId)} ${scope.clause} ${speakerGate}
           ORDER BY score DESC
           LIMIT $k`,
         {
           q: opts.query,
           k: opts.limit,
           ...this.userParams(opts.userId),
+          ...scope.params,
           ...speakerParams,
         },
       );
@@ -228,12 +250,14 @@ export class EpisodeReadStoreService {
   }): Promise<EpisodeQuoteRow[]> {
     if (opts.ids.length === 0) return [];
     return this.run(opts.companyId, opts.db, async (db) => {
+      const scope = this.scopeGate(opts.userId);
       const [rows] = await db.query<[EpisodeQuoteRow[]]>(
         `SELECT id, conversationId, speaker, text, occurredAt FROM episode
-          WHERE id INSIDE $ids ${this.piiGate(opts.includePii)} ${this.userGate(opts.userId)}`,
+          WHERE id INSIDE $ids ${this.piiGate(opts.includePii)} ${this.userGate(opts.userId)} ${scope.clause}`,
         {
           ids: opts.ids.map((id) => new StringRecordId(id)),
           ...this.userParams(opts.userId),
+          ...scope.params,
         },
       );
       return rows ?? [];
@@ -258,11 +282,13 @@ export class EpisodeReadStoreService {
     db?: EpisodeDb;
   }): Promise<EpisodeQuoteRow[]> {
     return this.run(opts.companyId, opts.db, async (db) => {
-      const gates = `${this.piiGate(opts.includePii)} ${this.userGate(opts.userId)}`;
+      const scope = this.scopeGate(opts.userId);
+      const gates = `${this.piiGate(opts.includePii)} ${this.userGate(opts.userId)} ${scope.clause}`;
       const params = {
         conv: opts.conversationId,
         c: new Date(opts.centerIso),
         ...this.userParams(opts.userId),
+        ...scope.params,
       };
       const [before, after] = await Promise.all([
         db
@@ -383,6 +409,14 @@ export class EpisodeReadStoreService {
         params.scopeUserId = opts.userId;
       } else {
         where.push('userId IS NONE');
+      }
+      // G6 scope-tag fence (SCOPE_TAGS_ENABLED) — ADDED alongside the
+      // userId fence, inert when off. The scopeFenceSql clause carries a
+      // leading `AND `; strip it since this builder joins with ` AND `.
+      const scope = scopeFenceSql(opts.userId);
+      if (scope.clause) {
+        where.push(scope.clause.replace(/^AND\s+/, ''));
+        Object.assign(params, scope.params);
       }
       const whereSql = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
       const [rows] = await db.query<[EpisodePageRow[]]>(

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -8,6 +8,11 @@ import { RetractFactDto } from './dto/retract.dto';
 import { BrainScope } from '../auth/api-key.types';
 import { pinUserScope } from '../auth/user-scope';
 import {
+  principalScopeTags,
+  scopeTagsEnabled,
+  visibleUnderScope,
+} from '../auth/scope-visibility';
+import {
   makeRowPolicyFilter,
   type PolicyFilterableRow,
 } from '../policy/row-filter';
@@ -191,6 +196,8 @@ interface FactReadRow extends PolicyFilterableRow {
   retractedAt?: unknown;
   status?: unknown;
   derivedVersion?: unknown;
+  /** Scope-tag AND-set (migration 0093); absent/empty = tenant-global. */
+  scope?: unknown;
 }
 
 export interface ListCompetingResult {
@@ -358,7 +365,7 @@ export class FactsService {
     const ref = this.normalizeFactId(opts.factId);
     const [rows] = await db.query<[FactReadRow[]]>(
       `SELECT id, predicate, object, confidence, validFrom, validUntil,
-              recordedAt, retractedAt, status, source, userId,
+              recordedAt, retractedAt, status, source, userId, scope,
               derivedVersion, trustSnapshot, corroboration
          FROM type::record('knowledge_fact', $rid) LIMIT 1`,
       { rid: ref.id },
@@ -376,6 +383,19 @@ export class FactsService {
       fact.userId !== scopeUserId
     ) {
       throw notFound();
+    }
+    // G6 scope-tag fence (SCOPE_TAGS_ENABLED) — ADDED alongside the
+    // userId ownership check above, never replacing it. Composed as an
+    // extra AND, it can only narrow visibility; a row hidden here (an
+    // unparseable or non-matching scope tag) is a 404 exactly like the
+    // userId miss. Inert when the flag is off. See scope-visibility.ts.
+    if (scopeTagsEnabled()) {
+      const recordScope = Array.isArray(fact.scope)
+        ? (fact.scope as unknown[]).map((t) => String(t))
+        : [];
+      if (!visibleUnderScope(recordScope, principalScopeTags())) {
+        throw notFound();
+      }
     }
     // Registry-backed row policy (scope fence + ABAC) — same seam as the
     // audit-fixed fact lanes under src/synthesize/.

--- a/src/ingest/entity-upsert.service.ts
+++ b/src/ingest/entity-upsert.service.ts
@@ -8,6 +8,7 @@ import {
 import { EntityResolverService } from './entity-resolver.service';
 import { IngestFactDto } from './dto/ingest-fact.dto';
 import { externalRefKey } from './ingest-utils';
+import { scopeForUser } from '../auth/scope-tags';
 
 /**
  * Entity-resolution slice of the ingest pipeline: turn a caller-supplied
@@ -62,7 +63,10 @@ export class EntityUpsertService {
       type: 'other',
       canonicalName: ref.id,
       externalRefs: { [refKey]: ref.id },
-      ...(userId ? { userId } : {}),
+      // G6 step 1: mirror the per-user scope as a scope tag (0093) next
+      // to the userId stamp. The named-entity path stays tenant-global
+      // (no userId → the scope field DEFAULT [] holds).
+      ...(userId ? { userId, scope: scopeForUser(userId) } : {}),
     }));
   }
 

--- a/src/ingest/episode-store.service.ts
+++ b/src/ingest/episode-store.service.ts
@@ -4,6 +4,7 @@ import { SurrealService } from '../db/surreal.service';
 import { envFlagEnabled } from '../common/env-validation';
 import { detectLanguage } from '../ai/locale/language-detector';
 import { redactPiiWithReport } from './ingest-utils';
+import { scopeForUser } from '../auth/scope-tags';
 import { sanitizeIngestText } from '../common/text-sanitizer';
 import type { IngestMentionDto, KnownEntity } from './dto/ingest-mention.dto';
 
@@ -64,6 +65,9 @@ export class EpisodeStoreService {
         // Audit 2026-08-21 P0: the per-user scope rides the episode row —
         // every L0 read surface fences on it (fail-closed, 0055 model).
         userId: dto.userId,
+        // G6 step 1: mirror it as a scope tag (0093) so the scope fence
+        // and the userId fence stay in lockstep going forward.
+        scope: scopeForUser(dto.userId),
         lang: lang === 'und' ? undefined : lang,
         source: {
           vertical: dto.contextRef.vertical,

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
-import { Surreal } from 'surrealdb';
+import { StringRecordId, Surreal } from 'surrealdb';
 import { retryOnUniqueViolation } from '../db/surreal.service';
+import { scopeForUser } from '../auth/scope-tags';
 import { MetricsService } from '../metrics/metrics.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { detectLanguage } from '../ai/locale/language-detector';
@@ -260,6 +261,52 @@ export class FactResolverService {
   }
 
   /**
+   * G6 scope-tag stamp (step 1): mirror the per-user scope onto the
+   * row's `scope` column so new personal facts carry ['user:<id>'] the
+   * way the 0093 backfill set it for existing rows — the forward half of
+   * the backfill invariant. The fact CREATE itself lives inside the
+   * audit-hardened `fn::resolve_fact`, which stamps `userId`; rather than
+   * reopen that function we mirror the derived scope in a targeted
+   * follow-up UPDATE on the row(s) it returned. No-op for tenant-global
+   * writes (userId undefined → the field DEFAULT [] already holds), so
+   * the benchmark/eval path (which never stamps a userId) is untouched.
+   *
+   * STAMPING ONLY — never authorization, and best-effort. The read fence
+   * is composed with AND alongside the binding userId filter, so a fact
+   * left at scope=[] by a failed stamp is still correctly fenced by
+   * userId; the scope column can never OPEN access it lacks. A failure
+   * therefore warns instead of failing the ingest.
+   */
+  private async stampFactScope(
+    db: {
+      query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T>;
+    },
+    items: Array<{ userId?: string; factId: unknown }>,
+  ): Promise<void> {
+    const byUser = new Map<string, StringRecordId[]>();
+    for (const it of items) {
+      if (!it.userId || it.factId === undefined || it.factId === null) continue;
+      const tail = idTailOf(String(it.factId));
+      const ids = byUser.get(it.userId) ?? [];
+      ids.push(new StringRecordId(`knowledge_fact:${tail}`));
+      byUser.set(it.userId, ids);
+    }
+    if (byUser.size === 0) return;
+    try {
+      for (const [userId, ids] of byUser) {
+        await db.query(
+          `UPDATE knowledge_fact SET scope = $scope WHERE id IN $ids`,
+          { scope: scopeForUser(userId), ids },
+        );
+      }
+    } catch (e) {
+      this.logger.warn(
+        `scope-tag stamp failed (non-fatal, userId scope still fences): ${(e as Error).message}`,
+      );
+    }
+  }
+
+  /**
    * Resolve a set of append_only facts in ONE round-trip via the stored
    * `fn::resolve_facts` (migration 0071), which maps `fn::resolve_fact` over the
    * array server-side and returns the results in order. Safe without the resolve
@@ -316,7 +363,12 @@ export class FactResolverService {
       `RETURN fn::resolve_facts($facts, $cfg)`,
       { facts, cfg },
     );
-    return (rows as any[]) ?? [];
+    const out = (rows as any[]) ?? [];
+    await this.stampFactScope(
+      db,
+      prepared.map((c, k) => ({ userId: c.userId, factId: out[k]?.factId })),
+    );
+    return out;
   }
 
   /**
@@ -428,7 +480,7 @@ export class FactResolverService {
    * entity+predicate — retry sees the racing committer's row and
    * supersedes/competes on the second attempt.
    */
-  private resolveFactCall(
+  private async resolveFactCall(
     db: Surreal,
     p: {
       companyId: string;
@@ -462,9 +514,9 @@ export class FactResolverService {
     // canon serialize onto the same slot — their candidate sets are the
     // same rows now that resolution keys on `predicateAlias ?? predicate`.
     const lockKey = `${p.companyId}\x00${p.entityId}\x00${p.predicateAlias ?? p.predicate}`;
-    return this.resolveLock.run(lockKey, () =>
+    const r = await this.resolveLock.run(lockKey, () =>
       retryOnUniqueViolation(async () => {
-        const [r] = await db.query<[any]>(
+        const [row] = await db.query<[any]>(
           `RETURN fn::resolve_fact(
             type::record('knowledge_entity', $eid),
             $predicate, $object, $object_meta, $embedding,
@@ -503,9 +555,14 @@ export class FactResolverService {
             derived_version: p.derivedVersion,
           },
         );
-        return r;
+        return row;
       }),
     );
+    // G6 step 1: mirror the userId scope onto the new row's scope column.
+    // Outside the retry closure so a stamp hiccup never re-runs the
+    // resolver (which would double-create the fact).
+    await this.stampFactScope(db, [{ userId: p.userId, factId: r?.factId }]);
+    return r;
   }
 
   private cfgNum(key: string, fallback: number): number {

--- a/src/search/internals/where-builder.ts
+++ b/src/search/internals/where-builder.ts
@@ -5,6 +5,7 @@ import {
   derivedVersionFence,
   type ReadPin,
 } from '../../episodes/read-pin.service';
+import { scopeFenceSql } from '../../auth/scope-visibility';
 
 /**
  * Compose the WHERE-clause fragment that every leg query shares.
@@ -100,6 +101,18 @@ export function buildBaseWhere({
     params.scopeUserId = dto.userId;
   } else {
     clauses.push(`AND userId IS NONE`);
+  }
+
+  // ── Scope-tag fence (G6, SCOPE_TAGS_ENABLED) — FAIL-CLOSED ─────
+  // An ADDED AND-condition mirroring the userId filter above against
+  // the `scope` column, inert when the flag is off (userId stays the
+  // sole enforcement). Composed with AND, it can only narrow — never
+  // open — what userId filtering returns; for single-tag data the two
+  // fences keep provably identical row sets. See scope-visibility.ts.
+  const scope = scopeFenceSql(dto.userId);
+  if (scope.clause) {
+    clauses.push(scope.clause);
+    Object.assign(params, scope.params);
   }
 
   // ── Derived-version namespace (substrate redesign P3 v1) ───────

--- a/test/scope-tags-parity.e2e-spec.ts
+++ b/test/scope-tags-parity.e2e-spec.ts
@@ -1,0 +1,242 @@
+/**
+ * G6 scope-tag foundation — PARITY proof (step 2 of
+ * docs/roadmap/sota-gap-build-2026-08.md) against a REAL SurrealDB.
+ *
+ * The load-bearing guarantee: turning SCOPE_TAGS_ENABLED ON changes
+ * NOTHING for current single-tag data. The scope evaluator runs as an
+ * ADDITIONAL AND-fence alongside the untouched migration-0055 userId
+ * filter, so for data where `scope` mirrors `userId` the two fences keep
+ * IDENTICAL row sets — which is what makes shipping the flag enabled
+ * safe later.
+ *
+ * Seeds user-A facts, user-B facts, and tenant-global facts, then for
+ * EACH of {flag off, flag on} snapshots what user-A, user-B, and an M2M
+ * caller see through search + get-fact + provenance. Asserts the two
+ * snapshots are byte-identical (parity), that A never sees B's rows (and
+ * vice versa), and that M2M sees every fact by id.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+describe('scope-tags parity (SCOPE_TAGS_ENABLED off ≡ on)', () => {
+  let f: AppFixture;
+  // Main key = M2M (tenant-wide, no bound user). Two user-bound tokens.
+  const READ = ['brain:read', 'brain:read_pii'];
+  let aToken: string;
+  let bToken: string;
+
+  let globalFactId: string;
+  let aFactId: string;
+  let bFactId: string;
+
+  const savedFlag = process.env.SCOPE_TAGS_ENABLED;
+  const savedFactsApi = process.env.FACTS_API_ENABLED;
+
+  const m2m = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const asToken = (t: string) => ({ Authorization: `Bearer ${t}` });
+
+  beforeAll(async () => {
+    // get-fact / provenance routes are gated behind this flag.
+    process.env.FACTS_API_ENABLED = '1';
+    f = await createApp({
+      companyId: 'co_scope_parity_e2e',
+      extraKeys: [
+        { scopes: READ, userId: 'user_a' },
+        { scopes: READ, userId: 'user_b' },
+      ],
+    });
+    aToken = f.extraApiKeys[0];
+    bToken = f.extraApiKeys[1];
+
+    // Seed via M2M asserting the scope in the body. The write path stamps
+    // both userId (0055) AND scope (0093) regardless of the read flag, so
+    // the facts carry real scope tags for the flag-on fence to act on.
+    const ingest = async (body: Record<string, unknown>): Promise<string> => {
+      const r = await f.http.post('/v1/ingest/fact').set(m2m()).send({
+        validFrom: '2026-01-01',
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+        ...body,
+      });
+      expect([200, 201]).toContain(r.status);
+      return r.body.factId as string;
+    };
+
+    globalFactId = await ingest({
+      entityRef: { vertical: 'rent', id: 'sp_global' },
+      predicate: 'note_probe',
+      object: 'scopeparity marker global tenant',
+    });
+    aFactId = await ingest({
+      entityRef: { vertical: 'rent', id: 'sp_alpha' },
+      predicate: 'note_probe',
+      object: 'scopeparity marker alpha personal',
+      userId: 'user_a',
+    });
+    bFactId = await ingest({
+      entityRef: { vertical: 'rent', id: 'sp_beta' },
+      predicate: 'note_probe',
+      object: 'scopeparity marker beta personal',
+      userId: 'user_b',
+    });
+  });
+
+  afterAll(async () => {
+    if (savedFlag === undefined) delete process.env.SCOPE_TAGS_ENABLED;
+    else process.env.SCOPE_TAGS_ENABLED = savedFlag;
+    if (savedFactsApi === undefined) delete process.env.FACTS_API_ENABLED;
+    else process.env.FACTS_API_ENABLED = savedFactsApi;
+    if (f) await f.close();
+  });
+
+  /** GET /v1/facts/:id → true when visible (200), false when fenced (404). */
+  const getFactVisible = async (
+    headers: Record<string, string>,
+    factId: string,
+  ): Promise<boolean> => {
+    const r = await f.http
+      .get(`/v1/facts/${encodeURIComponent(factId)}`)
+      .set(headers);
+    if (r.status === 200) return true;
+    expect(r.status).toBe(404);
+    return false;
+  };
+
+  /** GET /v1/facts/:id/provenance → true when visible (200), false (404). */
+  const provVisible = async (
+    headers: Record<string, string>,
+    factId: string,
+  ): Promise<boolean> => {
+    const r = await f.http
+      .get(`/v1/facts/${encodeURIComponent(factId)}/provenance`)
+      .set(headers);
+    if (r.status === 200) return true;
+    expect(r.status).toBe(404);
+    return false;
+  };
+
+  /** Objects a caller can see via search (userId pinned for bound tokens). */
+  const searchObjects = async (
+    headers: Record<string, string>,
+    userId?: string,
+  ): Promise<string[]> => {
+    const r = await f.http
+      .post('/v1/search')
+      .set(headers)
+      .send({ query: 'scopeparity marker', limit: 20, ...(userId ? { userId } : {}) });
+    expect(r.status).toBe(201);
+    return (r.body.results as Array<{ facts: Array<{ object: string }> }>)
+      .flatMap((h) => h.facts ?? [])
+      .map((fa) => fa.object)
+      .filter((o) => o.includes('scopeparity'))
+      .sort();
+  };
+
+  /** The full visibility matrix for the three principals. */
+  const snapshot = async () => {
+    const principals: Array<{
+      name: string;
+      headers: Record<string, string>;
+      searchUserId?: string;
+    }> = [
+      { name: 'm2m', headers: m2m() },
+      { name: 'user_a', headers: asToken(aToken) },
+      { name: 'user_b', headers: asToken(bToken) },
+    ];
+    const out: Record<string, unknown> = {};
+    for (const p of principals) {
+      out[p.name] = {
+        getFact: {
+          global: await getFactVisible(p.headers, globalFactId),
+          a: await getFactVisible(p.headers, aFactId),
+          b: await getFactVisible(p.headers, bFactId),
+        },
+        provenance: {
+          global: await provVisible(p.headers, globalFactId),
+          a: await provVisible(p.headers, aFactId),
+          b: await provVisible(p.headers, bFactId),
+        },
+        // Bound tokens pin their own userId; M2M asserts none → global.
+        search: await searchObjects(p.headers),
+      };
+    }
+    return out;
+  };
+
+  it('the write path stamps the scope column mirroring userId (step 1)', async () => {
+    // Parity alone can pass vacuously (userId is the binding fence), so
+    // prove the scope column is actually populated — the write-stamp is
+    // what gives the flag-on fence real tags to act on.
+    const surreal = f.app.get(SurrealService);
+    const scopeOf = async (factId: string): Promise<unknown> =>
+      surreal.withCompany(f.companyId, async (db) => {
+        const [rows] = await db.query<[Array<{ scope: unknown; userId: unknown }>]>(
+          `SELECT scope, userId FROM type::record('knowledge_fact', $tail)`,
+          { tail: factId.split(':')[1] },
+        );
+        return (rows as Array<{ scope: unknown }>)[0]?.scope;
+      });
+    expect(await scopeOf(aFactId)).toEqual(['user:user_a']);
+    expect(await scopeOf(bFactId)).toEqual(['user:user_b']);
+    // Tenant-global fact carries the empty AND-set (DEFAULT []).
+    expect(await scopeOf(globalFactId)).toEqual([]);
+  });
+
+  it('flag OFF and flag ON produce IDENTICAL visibility (parity)', async () => {
+    delete process.env.SCOPE_TAGS_ENABLED;
+    const off = await snapshot();
+
+    process.env.SCOPE_TAGS_ENABLED = '1';
+    const on = await snapshot();
+
+    delete process.env.SCOPE_TAGS_ENABLED;
+
+    // The whole point: enabling the flag changes nothing for step-1 data.
+    expect(on).toEqual(off);
+  });
+
+  it('user A never sees user B rows, and vice versa (both flag states)', async () => {
+    for (const flag of [undefined, '1'] as const) {
+      if (flag === undefined) delete process.env.SCOPE_TAGS_ENABLED;
+      else process.env.SCOPE_TAGS_ENABLED = flag;
+
+      // get-fact: A sees global + its own, never B's; symmetric for B.
+      expect(await getFactVisible(asToken(aToken), globalFactId)).toBe(true);
+      expect(await getFactVisible(asToken(aToken), aFactId)).toBe(true);
+      expect(await getFactVisible(asToken(aToken), bFactId)).toBe(false);
+      expect(await getFactVisible(asToken(bToken), bFactId)).toBe(true);
+      expect(await getFactVisible(asToken(bToken), aFactId)).toBe(false);
+
+      // search: A's results carry alpha (own) + global, never beta.
+      const aSeen = await searchObjects(asToken(aToken));
+      expect(aSeen).toContain('scopeparity marker alpha personal');
+      expect(aSeen).toContain('scopeparity marker global tenant');
+      expect(aSeen).not.toContain('scopeparity marker beta personal');
+
+      const bSeen = await searchObjects(asToken(bToken));
+      expect(bSeen).toContain('scopeparity marker beta personal');
+      expect(bSeen).not.toContain('scopeparity marker alpha personal');
+    }
+    delete process.env.SCOPE_TAGS_ENABLED;
+  });
+
+  it('M2M sees every fact by id; its unscoped search stays tenant-global', async () => {
+    for (const flag of [undefined, '1'] as const) {
+      if (flag === undefined) delete process.env.SCOPE_TAGS_ENABLED;
+      else process.env.SCOPE_TAGS_ENABLED = flag;
+
+      // Tenant-wide authority: reads any user's fact by id.
+      expect(await getFactVisible(m2m(), globalFactId)).toBe(true);
+      expect(await getFactVisible(m2m(), aFactId)).toBe(true);
+      expect(await getFactVisible(m2m(), bFactId)).toBe(true);
+
+      // An M2M search that asserts no userId still sees tenant-global only
+      // (matching today's userGate) — personal rows need an explicit scope.
+      const seen = await searchObjects(m2m());
+      expect(seen).toContain('scopeparity marker global tenant');
+      expect(seen).not.toContain('scopeparity marker alpha personal');
+      expect(seen).not.toContain('scopeparity marker beta personal');
+    }
+    delete process.env.SCOPE_TAGS_ENABLED;
+  });
+});

--- a/test/scope-tags.unit-spec.ts
+++ b/test/scope-tags.unit-spec.ts
@@ -1,0 +1,169 @@
+/**
+ * G6 scope-tag foundation — grammar + visibility evaluator + principal
+ * derivation + SQL-fence unit coverage (steps 1-2 of
+ * docs/roadmap/sota-gap-build-2026-08.md).
+ *
+ * The evaluator is a SECURITY fence: the truth table below pins the
+ * fail-closed behavior (unparseable / unknown-namespace / non-matching
+ * → hidden) and the tenant-wide (M2M) sees-all behavior that the
+ * flag-on parity property rests on.
+ */
+import {
+  KNOWN_NAMESPACES,
+  parseTag,
+  scopeForUser,
+  userTag,
+} from '../src/auth/scope-tags';
+import {
+  TENANT_WIDE,
+  principalScopeTags,
+  scopeFenceSql,
+  scopeTagsEnabled,
+  visibleUnderScope,
+} from '../src/auth/scope-visibility';
+import { runWithRequestContext } from '../src/common/request-context';
+
+describe('scope-tags grammar', () => {
+  it('userTag builds user:<id>', () => {
+    expect(userTag('bob')).toBe('user:bob');
+    expect(userTag('u_42:x')).toBe('user:u_42:x');
+  });
+
+  it('scopeForUser maps userId → one-clause AND-set, undefined → global', () => {
+    expect(scopeForUser('bob')).toEqual(['user:bob']);
+    expect(scopeForUser(undefined)).toEqual([]);
+  });
+
+  describe('parseTag', () => {
+    it('parses the active user namespace', () => {
+      expect(parseTag('user:bob')).toEqual({ namespace: 'user', id: 'bob' });
+    });
+
+    it('accepts the reserved org/team namespaces (step 3+)', () => {
+      expect(parseTag('org:acme')).toEqual({ namespace: 'org', id: 'acme' });
+      expect(parseTag('team:blue')).toEqual({ namespace: 'team', id: 'blue' });
+      expect(KNOWN_NAMESPACES.has('org')).toBe(true);
+      expect(KNOWN_NAMESPACES.has('team')).toBe(true);
+    });
+
+    it('keeps colons inside the id (record ids)', () => {
+      expect(parseTag('user:knowledge_entity:abc')).toEqual({
+        namespace: 'user',
+        id: 'knowledge_entity:abc',
+      });
+    });
+
+    it('fails closed on malformed or unknown-namespace tags', () => {
+      expect(parseTag('bob')).toBeNull(); // no separator
+      expect(parseTag(':bob')).toBeNull(); // empty namespace
+      expect(parseTag('user:')).toBeNull(); // empty id
+      expect(parseTag('evil:bob')).toBeNull(); // unknown namespace
+      expect(parseTag('')).toBeNull();
+      expect(parseTag('USER:bob')).toBeNull(); // case-sensitive
+    });
+  });
+});
+
+describe('visibleUnderScope — evaluator truth table', () => {
+  const A = ['user:a'];
+  const B = ['user:b'];
+
+  it('empty record scope is tenant-global → visible to everyone', () => {
+    expect(visibleUnderScope([], A)).toBe(true);
+    expect(visibleUnderScope([], B)).toBe(true);
+    expect(visibleUnderScope([], TENANT_WIDE)).toBe(true);
+  });
+
+  it('a matching single tag is visible to its principal', () => {
+    expect(visibleUnderScope(['user:a'], A)).toBe(true);
+  });
+
+  it('a non-matching single tag is hidden', () => {
+    expect(visibleUnderScope(['user:a'], B)).toBe(false);
+    expect(visibleUnderScope(['user:b'], A)).toBe(false);
+  });
+
+  it('fails closed on an unparseable / unknown-namespace record tag', () => {
+    expect(visibleUnderScope(['evil:a'], A)).toBe(false);
+    expect(visibleUnderScope(['garbage'], A)).toBe(false);
+    expect(visibleUnderScope(['user:'], A)).toBe(false);
+    // Even a record that also carries the principal's valid tag is hidden
+    // if ANY tag in the AND-set is unparseable.
+    expect(visibleUnderScope(['user:a', 'evil:x'], A)).toBe(false);
+  });
+
+  it('a tenant-wide (M2M) principal sees everything, including malformed', () => {
+    expect(visibleUnderScope(['user:a'], TENANT_WIDE)).toBe(true);
+    expect(visibleUnderScope(['user:b'], TENANT_WIDE)).toBe(true);
+    expect(visibleUnderScope(['evil:x'], TENANT_WIDE)).toBe(true);
+  });
+
+  it('a multi-tag AND-set clause requires ALL its tags', () => {
+    const AB = ['user:a', 'org:acme'];
+    // Principal holds only user:a → does not satisfy the full AND-set.
+    expect(visibleUnderScope(AB, ['user:a'])).toBe(false);
+    // Principal holds both tags → satisfied.
+    expect(visibleUnderScope(AB, ['user:a', 'org:acme'])).toBe(true);
+    // Extra principal tags are fine (superset satisfies the clause).
+    expect(visibleUnderScope(['user:a'], ['user:a', 'org:acme'])).toBe(true);
+  });
+});
+
+describe('principalScopeTags — request-context derivation', () => {
+  it('a user-bound token → ["user:<authUserId>"]', () => {
+    const tags = runWithRequestContext(
+      { correlationId: 'c1', authUserId: 'user_a' },
+      () => principalScopeTags(),
+    );
+    expect(tags).toEqual(['user:user_a']);
+  });
+
+  it('an M2M credential (no authUserId) → TENANT_WIDE', () => {
+    const tags = runWithRequestContext({ correlationId: 'c2' }, () =>
+      principalScopeTags(),
+    );
+    expect(tags).toBe(TENANT_WIDE);
+  });
+
+  it('a background context (no request context) → TENANT_WIDE', () => {
+    expect(principalScopeTags()).toBe(TENANT_WIDE);
+  });
+});
+
+describe('scopeFenceSql — flag-gated SQL mirror of the userId filter', () => {
+  const saved = process.env.SCOPE_TAGS_ENABLED;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.SCOPE_TAGS_ENABLED;
+    else process.env.SCOPE_TAGS_ENABLED = saved;
+  });
+
+  it('is fully inert when the flag is off', () => {
+    delete process.env.SCOPE_TAGS_ENABLED;
+    expect(scopeTagsEnabled()).toBe(false);
+    expect(scopeFenceSql('user_a')).toEqual({ clause: '', params: {} });
+    expect(scopeFenceSql(undefined)).toEqual({ clause: '', params: {} });
+  });
+
+  it('mirrors the userId filter tag-for-tag when on', () => {
+    process.env.SCOPE_TAGS_ENABLED = '1';
+    expect(scopeTagsEnabled()).toBe(true);
+    // Scoped user → global OR own tag.
+    expect(scopeFenceSql('user_a')).toEqual({
+      clause: 'AND (scope = [] OR scope = [$principalScopeTag])',
+      params: { principalScopeTag: 'user:user_a' },
+    });
+    // No scoped user → tenant-global only (mirrors `userId IS NONE`).
+    expect(scopeFenceSql(undefined)).toEqual({
+      clause: 'AND scope = []',
+      params: {},
+    });
+  });
+
+  it('honors a custom bound-parameter name', () => {
+    process.env.SCOPE_TAGS_ENABLED = 'true';
+    expect(scopeFenceSql('user_a', 'pTag')).toEqual({
+      clause: 'AND (scope = [] OR scope = [$pTag])',
+      params: { pTag: 'user:user_a' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

G6 (steps 1-2 of 5) from the [SOTA gap build program](../blob/main/docs/roadmap/sota-gap-build-2026-08.md) (#309): the foundation for generalizing single-`userId` scoping to Spectron-style hierarchical scope tags — built as a security-critical, no-op-until-used isolation fence. **Steps 3-5 (ABAC write/widen policies, share-up via staging, revocation/consistency tokens) are a follow-up PR** — this ships only the inert foundation.

**The load-bearing safety property:** when `SCOPE_TAGS_ENABLED` is on, the scope evaluator runs as an **additional AND-fence alongside** the existing userId filter, never a replacement. Composed with AND, the flag can only ever *narrow* what userId filtering returns — it can never OPEN access userId filtering closed. For current single-tag data the two fences keep provably identical row sets, which is what makes shipping it enabled later safe.

- **Step 1 — scope column (migration 0093):** `scope array<string> DEFAULT []` on the five visibility-scoped tables (knowledge_fact/entity/edge, episode, episode_segment), backfilled `['user:'+userId]` for user rows, `[]` (= tenant-global, mirroring `userId IS NONE`) for global. Index mirrors the userId index. `answer_cache` excluded (userId is a cache-partition key, not visibility) and `conversation_digest` excluded (own `userScopes` array) — documented in the migration header. Write paths stamp `scope = scopeForUser(userId)` next to every userId write.
- **Step 2 — evaluator (`src/auth/scope-visibility.ts`, `scope-tags.ts`):** OR-of-ANDs `visibleUnderScope`; empty scope → tenant-global; `TENANT_WIDE` symbol for M2M (never a magic string); **fail-closed on any unparseable/unknown-namespace tag**. `scopeFenceSql` mirrors `userGate` branch-for-branch (undefined→`scope=[]`, defined→`scope=[] OR scope=[tag]`) so parity is structural. Wired into episode reads, `loadVisibleFact`, and the shared search `buildBaseWhere` — each a one-line added AND gated on the flag; userId filters untouched.

## Parity proof

`test/scope-tags-parity.e2e-spec.ts` (4/4) asserts **byte-identical returned row sets flag-off vs flag-on** (`expect(on).toEqual(off)`) across search + get-fact + provenance for user A / user B / M2M, plus direct scope-column assertions and cross-user isolation — in both flag states. Turning the flag on changes nothing for current data.

## Tests

New unit `scope-tags` 18 tests (grammar, evaluator truth table incl. fail-closed + AND-set, principal derivation); full unit suite **263 suites / 2293 tests green**; parity e2e 4/4; regression guards `user-scope` + `artifacts-user-scope` 5/5 unchanged. typecheck + lint clean. `SCOPE_TAGS_ENABLED` escapes the engine flag-budget prefix (no golden edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB