### PR TITLE
chore(ci): supply-chain CVE gate + secret scan + gate cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,35 @@ jobs:
         working-directory: brain-landing
         run: pnpm test
 
+  # Supply-chain CVE gate. scorecard.yml + dependency-review.yml are both
+  # gated on `repository.private == false`, so they no-op while this repo
+  # is private — a lockfile dependency with a known CVE could merge
+  # ungated despite SECURITY.md declaring supply-chain in scope. This job
+  # runs `pnpm audit` regardless of visibility and blocks on high/critical.
+  # `--ignore-workspace` matches the install: it audits THIS repo's
+  # lockfile only, never a stray parent pnpm workspace.
+  supply-chain:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install
+        run: pnpm install --frozen-lockfile --ignore-workspace
+
+      # Blocks the PR on any high/critical advisory in the resolved
+      # dependency tree. Dependabot (4 ecosystems) still opens the fix PRs;
+      # this is the gate that stops a known-vulnerable tree from merging.
+      - name: pnpm audit (high+ blocks)
+        run: pnpm audit --audit-level=high --ignore-workspace
+
   real-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,32 @@
+name: Secret scan
+
+# Committed secret detection. Complements GitHub-native push protection
+# (which can't be verified from the tree) with an in-repo, in-CI gate.
+# TruffleHog OSS — no license key required (unlike gitleaks-action for
+# orgs). Runs `--only-verified` so it blocks only on secrets it can prove
+# are live, keeping false positives from gating merges.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  trufflehog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so the scan covers the whole PR range, not just
+          # the tip commit.
+          fetch-depth: 0
+
+      - name: TruffleHog OSS (verified secrets block)
+        uses: trufflesecurity/trufflehog@bcfcf73aaf4759d4dadc2783177c245a02792318 # v3.97.0
+        with:
+          extra_args: --only-verified

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -134,7 +134,9 @@ export default tseslint.config(
       'sonarjs/no-identical-functions': 'error',
       'sonarjs/no-duplicated-branches': 'error',
 
-      // ── god-file / complexity warnings (advisory) ─────────────────
+      // ── god-file / complexity budgets ─────────────────────────────
+      // All 'error' — with lint:ci running `--max-warnings 0` these are
+      // hard, merge-blocking gates, not advisory warnings.
       ...sizeGates,
     },
   },

--- a/package.json
+++ b/package.json
@@ -149,22 +149,5 @@
       "protobufjs@7": "^7.6.5",
       "protobufjs@8": "^8.6.6"
     }
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
## Summary

Closes the one real posture gap from the code-quality + security audit (both audits: gates are otherwise written down AND enforced, and the 8-PR feature wave spot-checked clean).

- **Supply-chain CVE gate** (the top finding): `scorecard.yml` and `dependency-review.yml` are both gated on `repository.private == false`, so they **no-op while this repo is private** — a lockfile dependency with a known CVE could merge ungated despite SECURITY.md declaring supply-chain in scope. New `supply-chain` job runs `pnpm audit --audit-level=high --ignore-workspace` regardless of visibility, blocking on high/critical. **Clean today** — 0 advisories in this repo's resolved tree (the `--ignore-workspace` flag matters: without it, pnpm audits a stray parent workspace and reports sibling projects' CVEs).
- **Secret scan**: TruffleHog OSS (`--only-verified` so only provable-live secrets block; no org license key needed, unlike gitleaks-action), SHA-pinned, on push + PR.
- **Gate-comment fix**: `eslint.config.mjs` mislabeled the size/complexity budgets as "advisory" — they are `error` and merge-blocking under `lint:ci`'s `--max-warnings 0`. Comment corrected.
- **Dead-config cleanup**: removed the vestigial root `jest` block in package.json (`testRegex .*\.spec\.ts$` matched 0 files; every test script uses `./test/jest-*.json`).

Config-only, no source/behavior change. Follow-ups in flight: tsconfig `strict`, type-aware ESLint + `no-floating-promises`, `noUncheckedIndexedAccess`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB