### PR TITLE
chore(lint): enable type-aware ESLint + no-floating-promises/no-misused-promises, fix fallout

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -79,9 +79,19 @@ export default tseslint.config(
       sourceType: 'module',
       globals: { ...globals.node, ...globals.jest },
       parserOptions: {
-        // Avoid type-aware linting for now (slow on a Nest app, and we lint
-        // both src/ and test/ which would need separate tsconfigs).
-        project: false,
+        // Type-aware linting is ON: the promise-safety rules
+        // (no-floating-promises / no-misused-promises / await-thenable)
+        // need the type-checker.
+        //
+        // We use the explicit `project` array rather than the newer
+        // `projectService: true`. projectService resolves each file to its
+        // NEAREST tsconfig.json — which for test/ files is the root
+        // tsconfig.json, and that config *excludes* test/. The service then
+        // refuses every spec with "not found by the project service". The
+        // two-config array below is the documented fallback: tsconfig.json
+        // covers src/, tsconfig.spec.json covers src/ + test/.
+        project: ['./tsconfig.json', './tsconfig.spec.json'],
+        tsconfigRootDir: import.meta.dirname,
       },
     },
     settings: {
@@ -97,6 +107,16 @@ export default tseslint.config(
       ],
       '@typescript-eslint/no-empty-object-type': 'off',
       'prefer-const': 'warn',
+
+      // ── Promise-safety (type-aware) ───────────────────────────────
+      // An unawaited async call is a real bug class: fire-and-forget DB
+      // writes, unhandled rejections that crash the process on an
+      // unrelated tick. These need the type-checker (projectService,
+      // above). `require-await` is deliberately NOT enabled — it flags
+      // intentionally-async interface impls and is too noisy.
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
       'prettier/prettier': 'off', // formatting handled by `pnpm format`, not lint
 
       // ── Clean architecture / DRY hard gates ───────────────────────
@@ -155,6 +175,25 @@ export default tseslint.config(
       'sonarjs/cognitive-complexity': 'off',
       'sonarjs/no-identical-functions': 'off',
       'sonarjs/no-duplicated-branches': 'off',
+    },
+  },
+  {
+    // The two real-e2e specs below genuinely exercise the `@inite/knowledge`
+    // SDK that lives in the sibling ../inite-shared repo, which is NOT
+    // checked out in the build-test gate. tsconfig.spec.json therefore
+    // *excludes* them (see its comment), so the type-aware parser has no
+    // program for them — `project` would throw "not found by the project".
+    // Drop them to a non-type-aware parse and switch the type-aware rules
+    // off here (they can't run without a program). Everything else still
+    // lints. This mirrors the tsconfig.spec.json exclusion 1:1.
+    files: ['test/brain.real-e2e-spec.ts', 'test/dreams.real-e2e-spec.ts'],
+    languageOptions: {
+      parserOptions: { project: false, projectService: false },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/no-misused-promises': 'off',
+      '@typescript-eslint/await-thenable': 'off',
     },
   },
 );

--- a/src/admin/admin-jobs.controller.ts
+++ b/src/admin/admin-jobs.controller.ts
@@ -599,10 +599,11 @@ export class AdminJobsController {
   @Get('changefeed/state')
   @RequireScopes('brain:admin')
   async changefeedState(): Promise<ChangefeedStateResponse> {
-    const [stats, cursors] = await Promise.all([
-      this.changefeed.stats(),
-      this.changefeed.cursorState(),
-    ]);
+    // stats() is synchronous (a plain snapshot getter); only cursorState() is
+    // async — so read stats() directly and await the one Promise rather than
+    // wrapping a non-Thenable in Promise.all.
+    const stats = this.changefeed.stats();
+    const cursors = await this.changefeed.cursorState();
     // sources is readonly string[] on the service to keep callers from
     // mutating the constant; on the wire it's just an array.
     return {

--- a/src/admin/intent-classifier.worker.ts
+++ b/src/admin/intent-classifier.worker.ts
@@ -86,7 +86,7 @@ async function classify(p: {
   return { labels: out.labels, scores: out.scores };
 }
 
-parentPort.on('message', async (msg: Inbound) => {
+const onMessage = async (msg: Inbound): Promise<void> => {
   try {
     if (msg.kind === 'warmup') {
       await warmup(msg.payload);
@@ -101,4 +101,16 @@ parentPort.on('message', async (msg: Inbound) => {
   } catch (e) {
     reply({ id: msg.id, ok: false, error: (e as Error).message });
   }
+};
+
+// The message listener is void-returning and each message is handled
+// independently, so the async work runs detached. onMessage already reports
+// business failures to the parent via reply(); the .catch guards only a
+// catastrophic reply()/port failure from becoming an unhandledRejection.
+parentPort.on('message', (msg: Inbound) => {
+  void onMessage(msg).catch((err) => {
+    console.error(
+      `intent-classifier worker handler crashed: ${(err as Error).message}`,
+    );
+  });
 });

--- a/src/ai/cross-encoder/cross-encoder.worker.ts
+++ b/src/ai/cross-encoder/cross-encoder.worker.ts
@@ -108,7 +108,7 @@ async function score(p: {
   return scores;
 }
 
-parentPort.on('message', async (msg: Inbound) => {
+const onMessage = async (msg: Inbound): Promise<void> => {
   try {
     if (msg.kind === 'warmup') {
       await warmup(msg.payload);
@@ -123,4 +123,16 @@ parentPort.on('message', async (msg: Inbound) => {
   } catch (e) {
     reply({ id: msg.id, ok: false, error: (e as Error).message });
   }
+};
+
+// The message listener is void-returning and each message is handled
+// independently, so the async work runs detached. onMessage already reports
+// business failures to the parent via reply(); the .catch guards only a
+// catastrophic reply()/port failure from becoming an unhandledRejection.
+parentPort.on('message', (msg: Inbound) => {
+  void onMessage(msg).catch((err) => {
+    console.error(
+      `cross-encoder worker handler crashed: ${(err as Error).message}`,
+    );
+  });
 });

--- a/src/ai/embedder/bge-m3.worker.ts
+++ b/src/ai/embedder/bge-m3.worker.ts
@@ -101,7 +101,7 @@ async function embedMany(texts: string[]): Promise<number[][]> {
   return out;
 }
 
-parentPort.on('message', async (msg: Inbound) => {
+const onMessage = async (msg: Inbound): Promise<void> => {
   try {
     if (msg.kind === 'warmup') {
       await warmup(msg.payload);
@@ -124,4 +124,14 @@ parentPort.on('message', async (msg: Inbound) => {
   } catch (e) {
     reply({ id: msg.id, ok: false, error: (e as Error).message });
   }
+};
+
+// The message listener is void-returning and each message is handled
+// independently, so the async work runs detached. onMessage already reports
+// business failures to the parent via reply(); the .catch guards only a
+// catastrophic reply()/port failure from becoming an unhandledRejection.
+parentPort.on('message', (msg: Inbound) => {
+  void onMessage(msg).catch((err) => {
+    console.error(`bge-m3 worker handler crashed: ${(err as Error).message}`);
+  });
 });

--- a/src/ai/extractor-runner.service.ts
+++ b/src/ai/extractor-runner.service.ts
@@ -189,7 +189,10 @@ export class ExtractorRunnerService {
       ),
     );
     const results = await Promise.all(
-      rawJsons.map((rj) =>
+      // async wrapper: every slot resolves to a Promise (the failed-pass
+      // slots to a resolved null) so Promise.all receives an all-thenable
+      // iterable — same result array, positions preserved.
+      rawJsons.map(async (rj) =>
         rj
           ? this.assembleResult({
               companyId: args.companyId,
@@ -266,7 +269,10 @@ export class ExtractorRunnerService {
       ),
     );
     const results = await Promise.all(
-      rawJsons.map((rj) =>
+      // async wrapper: every slot resolves to a Promise (the failed-pass
+      // slots to a resolved null) so Promise.all receives an all-thenable
+      // iterable — same result array, positions preserved.
+      rawJsons.map(async (rj) =>
         rj
           ? this.assembleResult({
               companyId: args.companyId,

--- a/src/ai/local-ner.worker.ts
+++ b/src/ai/local-ner.worker.ts
@@ -89,7 +89,7 @@ async function extract(p: { text: string }): Promise<unknown[]> {
   }));
 }
 
-parentPort.on('message', async (msg: Inbound) => {
+const onMessage = async (msg: Inbound): Promise<void> => {
   try {
     if (msg.kind === 'warmup') {
       await warmup(msg.payload);
@@ -104,4 +104,14 @@ parentPort.on('message', async (msg: Inbound) => {
   } catch (e) {
     reply({ id: msg.id, ok: false, error: (e as Error).message });
   }
+};
+
+// The message listener is void-returning and each message is handled
+// independently, so the async work runs detached. onMessage already reports
+// business failures to the parent via reply(); the .catch guards only a
+// catastrophic reply()/port failure from becoming an unhandledRejection.
+parentPort.on('message', (msg: Inbound) => {
+  void onMessage(msg).catch((err) => {
+    console.error(`local-ner worker handler crashed: ${(err as Error).message}`);
+  });
 });

--- a/src/jobs/job-worker-runner.ts
+++ b/src/jobs/job-worker-runner.ts
@@ -56,7 +56,7 @@ if (!parentPort) {
 
 const port = parentPort;
 
-port.on('message', async (msg: Inbound) => {
+const onMessage = async (msg: Inbound): Promise<void> => {
   if (msg.kind === 'shutdown') {
     port.postMessage({ id: msg.id, ok: true, result: null } satisfies Outbound);
     // Let the parent close the worker cleanly via worker.terminate().
@@ -86,6 +86,16 @@ port.on('message', async (msg: Inbound) => {
       name: err.name,
     } satisfies Outbound);
   }
+};
+
+// The message listener is void-returning and each request is independent, so
+// the async work runs detached. onMessage reports run failures back to the
+// parent via postMessage; the .catch guards only a catastrophic postMessage
+// failure (e.g. the shutdown ack) from becoming an unhandledRejection.
+port.on('message', (msg: Inbound) => {
+  void onMessage(msg).catch((err) => {
+    console.error(`job worker handler crashed: ${(err as Error).message}`);
+  });
 });
 
 // Boot ack — parent waits on this before considering the worker

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,8 +134,17 @@ async function bootstrap() {
     clearTimeout(t);
     process.exit(0);
   };
-  process.on('SIGTERM', onTerm);
-  process.on('SIGINT', onTerm);
+  // process.on's listener type is (...args) => void, but onTerm is async.
+  // Wrap it so a rejection (e.g. shutdownTracing throwing) is logged and
+  // forces exit instead of surfacing as an unhandledRejection mid-shutdown.
+  const onTermListener = () => {
+    void onTerm().catch((err) => {
+      logger.error(`Shutdown handler failed: ${(err as Error).message}`);
+      process.exit(1);
+    });
+  };
+  process.on('SIGTERM', onTermListener);
+  process.on('SIGINT', onTermListener);
 }
 
 bootstrap().catch((err) => {


### PR DESCRIPTION
## Summary

Closes the highest-value quality gap after strict: type-aware linting was off (`parserOptions.project: false`), so the promise-safety rules that catch fire-and-forget async bugs were never enforced. Enables them as errors.

**Violation counts (all in src/):** `no-floating-promises` **0** (clean — no fire-and-forget bugs), `no-misused-promises` **7**, `await-thenable` **3**.

**2 real latent unhandled-rejection bugs closed:**
- `main.ts` — the `SIGTERM`/`SIGINT` handler was an async fn passed to `process.on` (typed `=> void`); a `shutdownTracing()` rejection would surface as an unhandledRejection mid-shutdown. Now logs + `exit(1)`. Happy path byte-identical.
- `job-worker-runner.ts` — the shutdown-branch `postMessage` ack sat outside the try/catch; a failed ack was unhandled. Now guarded.

**The rest:** 5 detached worker/handler message listeners wrapped as `void fn().catch(log)` (never a bare void — every one logs); `changefeedState` was wrapping a **synchronous** `stats()` in `Promise.all` (fixed to a direct read + one await); an extractor async-map slot made uniformly Thenable. Zero bare void-silencers, zero `@ts-ignore`/`as any`/`eslint-disable`.

**Config note:** used the explicit `project: ['./tsconfig.json','./tsconfig.spec.json']` array, not `projectService: true` — projectService resolves `test/` files to the root tsconfig that *excludes* test/, rejecting all specs and OOMing past 8GB. Real-e2e specs (excluded from tsconfig.spec) get a scoped rule-off block.

## Tests

typecheck clean; `pnpm lint:ci` clean, **~8.7s** (type-aware, far under the CI budget vs ~4.5s before); full unit suite **263 suites / 2293 tests green** (incl. `job-worker-pool.unit-spec.ts` which spawns real worker threads through the rewritten runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB