### PR TITLE
chore(types): enable noUncheckedIndexedAccess, guard index access

### DIFF
--- a/src/admin/admin-jobs.controller.ts
+++ b/src/admin/admin-jobs.controller.ts
@@ -339,6 +339,9 @@ export class AdminJobsController {
       );
     }
     const hostTenant = tenantFilter || tenants[0];
+    if (!hostTenant) {
+      throw new BadRequestException('No registered tenant to reindex');
+    }
     const row = await this.jobs.start({
       jobType: 'reindex_embeddings',
       companyId: hostTenant,
@@ -400,6 +403,9 @@ export class AdminJobsController {
         : all.map((s) => s.id);
     const tenants = this.apiKeys.knownCompanyIds();
     const hostTenant = tenants[0];
+    if (!hostTenant) {
+      throw new BadRequestException('No registered tenant to run scenarios');
+    }
     const row = await this.jobs.start({
       jobType: 'scenarios_batch',
       companyId: hostTenant,

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -248,7 +248,7 @@ export class AdminController {
         binCount - 1,
         Math.floor(p.rawConfidence * binCount),
       );
-      const bin = bins[idx];
+      const bin = bins[idx]!; // idx ∈ [0, binCount-1] = bins index range
       bin.n += 1;
       bin.meanRaw += p.rawConfidence;
       bin.meanCorrect += p.correctness;

--- a/src/admin/aggregate-composer.service.ts
+++ b/src/admin/aggregate-composer.service.ts
@@ -104,7 +104,8 @@ export class AggregateComposerService {
         status: 'active',
         embedding: ctx.vector,
         derivedFrom: agg.members.map(
-          (m) => new StringRecordId(String(ctx.facts[m].id)),
+          // members are validated in-bounds by the `valid` predicate above.
+          (m) => new StringRecordId(String(ctx.facts[m]!.id)),
         ),
         ...(ctx.version ? { derivedVersion: ctx.version } : {}),
       };

--- a/src/admin/arc-composer.service.ts
+++ b/src/admin/arc-composer.service.ts
@@ -76,7 +76,8 @@ export function validArc(arc: ArcProposal, facts: FactRowLite[]): boolean {
   if (arc.members.length < 2) return false;
   if (!arc.members.every((m) => m >= 0 && m < facts.length)) return false;
   if (arc.narrative.trim().length === 0) return false;
-  const days = new Set(arc.members.map((m) => factDay(facts[m].validFrom)));
+  // members validated in-bounds by the check above.
+  const days = new Set(arc.members.map((m) => factDay(facts[m]!.validFrom)));
   return days.size >= 2;
 }
 
@@ -142,7 +143,8 @@ export class ArcComposerService {
         status: 'active',
         embedding: ctx.vector,
         derivedFrom: arc.members.map(
-          (m) => new StringRecordId(String(ctx.facts[m].id)),
+          // members are validated in-bounds by validArc.
+          (m) => new StringRecordId(String(ctx.facts[m]!.id)),
         ),
         ...(ctx.version ? { derivedVersion: ctx.version } : {}),
       };

--- a/src/admin/aspect-rollups.ts
+++ b/src/admin/aspect-rollups.ts
@@ -131,12 +131,15 @@ function composeGroup(
       }
     }
     if (kept < minMembers) return null;
+    const first = unique[0];
+    const last = unique[unique.length - 1];
+    if (!first || !last) return null; // kept ≥ minMembers ⇒ unique non-empty
     const truncated = kept < unique.length ? `; …and ${unique.length - kept} more` : '';
     return {
-      entityId: unique[0].entityId,
-      predicate: `${unique[0].predicate}_rollup`,
-      object: `Complete ${unique[0].predicate} record (${kept}${truncated ? ` of ${unique.length}` : ''} items): ${parts.join('; ')}${truncated}`,
-      validFrom: unique[unique.length - 1].validFrom,
+      entityId: first.entityId,
+      predicate: `${first.predicate}_rollup`,
+      object: `Complete ${first.predicate} record (${kept}${truncated ? ` of ${unique.length}` : ''} items): ${parts.join('; ')}${truncated}`,
+      validFrom: last.validFrom,
       memberCount: unique.length,
       episodeIds,
     };
@@ -194,5 +197,6 @@ export function majorityEntityId(members: RollupMember[]): string {
   for (const m of members) {
     counts.set(m.entityId, (counts.get(m.entityId) ?? 0) + 1);
   }
-  return [...counts.entries()].sort((a, b) => b[1] - a[1])[0][0];
+  const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  return ranked[0]?.[0] ?? ''; // empty only when members is empty
 }

--- a/src/admin/chat-router-internals/local-prepass.ts
+++ b/src/admin/chat-router-internals/local-prepass.ts
@@ -23,7 +23,7 @@ export function extractTemporalLocally(
   try {
     const results = chrono.parse(message, ref, { forwardDate: false });
     if (!results || results.length === 0) return null;
-    const first = results[0];
+    const first = results[0]!; // non-empty guaranteed by the guard above
     const date = first.start?.date?.();
     if (!date || Number.isNaN(date.getTime())) return null;
     const text = first.text;
@@ -141,7 +141,7 @@ function matchFirstTokenForm({
 }): void {
   const tokens = canonical.split(/\s+/).filter(Boolean);
   if (tokens.length <= 1) return;
-  const firstToken = tokens[0];
+  const firstToken = tokens[0]!; // length ≥ 2 guaranteed by the guard above
   if (firstTokenCollides(firstToken, canonical, knownNames)) return;
   const needle = firstToken.toLowerCase();
   if (needle.length < 2) return;
@@ -171,8 +171,8 @@ function firstTokenCollides(
 
 /** Word-boundary check so "Mariana" isn't matched as "Maria". */
 function isWordBoundary(message: string, idx: number, end: number): boolean {
-  const before = idx > 0 ? message[idx - 1] : ' ';
-  const after = end < message.length ? message[end] : ' ';
+  const before = idx > 0 ? message[idx - 1]! : ' ';
+  const after = end < message.length ? message[end]! : ' ';
   return !isWordChar(before) && !isWordChar(after);
 }
 

--- a/src/admin/chat-router-internals/validator.ts
+++ b/src/admin/chat-router-internals/validator.ts
@@ -102,7 +102,7 @@ export function isValidIso(s: string): boolean {
 export function extractJsonObject(raw: string): string {
   const trimmed = raw.trim();
   const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  const inner = fenceMatch ? fenceMatch[1].trim() : trimmed;
+  const inner = fenceMatch?.[1]?.trim() ?? trimmed;
   const start = inner.indexOf('{');
   if (start < 0) throw new Error('no JSON object found in router response');
   let depth = 0;

--- a/src/admin/collapse-pattern.service.ts
+++ b/src/admin/collapse-pattern.service.ts
@@ -203,8 +203,8 @@ export function extractCollapseEditsLocally(
       const idx = lower.indexOf(needle, from);
       if (idx < 0) break;
       const end = idx + needle.length;
-      const before = idx > 0 ? message[idx - 1] : ' ';
-      const after = end < message.length ? message[end] : ' ';
+      const before = idx > 0 ? message[idx - 1]! : ' ';
+      const after = end < message.length ? message[end]! : ' ';
       const isWordChar = (c: string) => /[\p{L}\p{N}]/u.test(c);
       if (isWordChar(before) || isWordChar(after)) {
         from = end;

--- a/src/admin/derive-row-builder.ts
+++ b/src/admin/derive-row-builder.ts
@@ -80,7 +80,7 @@ export function buildDerivedRows({
       resolveExtractionProfile().deriveMentionStamp && firstTurn !== undefined
         ? {
             mentionedAt: new Date(
-              session[firstTurn].occurredAt as string,
+              session[firstTurn]!.occurredAt as string, // firstTurn < session.length
             ).toISOString(),
             turnIndex: firstTurn,
           }
@@ -113,7 +113,7 @@ export function buildDerivedRows({
     const scopeUsers = [
       ...new Set(
         groundingTurns
-          .map((t) => session[t].userId)
+          .map((t) => session[t]!.userId) // t < session.length (filtered)
           .filter((u): u is string => typeof u === 'string' && u.length > 0),
       ),
     ];
@@ -136,7 +136,7 @@ export function buildDerivedRows({
       vertical: 'derived',
       recorder: ns.final,
       conversationId,
-      episodeIds: groundingTurns.map((t) => String(session[t].id)),
+      episodeIds: groundingTurns.map((t) => String(session[t]!.id)), // t < session.length
       ...salience,
       ...mention,
       ...scene,
@@ -160,7 +160,7 @@ export function buildDerivedRows({
         vertical: 'derived',
         recorder: ns.final,
       }),
-      embedding: vectors[i],
+      embedding: vectors[i]!, // vectors is 1:1 with resolved ⇒ in-bounds
       derivedVersion: ns.staging,
     };
   });

--- a/src/admin/deriver-client.ts
+++ b/src/admin/deriver-client.ts
@@ -221,13 +221,15 @@ async function auditDates(
       ) {
         continue;
       }
+      // d.index validated in-bounds by the guard above ⇒ prop is present.
+      const prop = args.propositions[d.index]!;
       // Apply BOTH values and explicit nulls — clearing a fabricated
       // session-date default is the audit's whole point. The cleared
       // marker survives to the row builder, which renders "undated" as
       // the epoch sentinel instead of the session-date fallback.
       if (d.occurred_on === null) {
-        args.propositions[d.index].occurred_on = null;
-        args.propositions[d.index].dateCleared = true;
+        prop.occurred_on = null;
+        prop.dateCleared = true;
       } else if (
         typeof d.occurred_on === 'string' &&
         ISO_DAY_RE.test(d.occurred_on) &&
@@ -239,8 +241,8 @@ async function auditDates(
           .toISOString()
           .slice(0, 10) === d.occurred_on
       ) {
-        args.propositions[d.index].occurred_on = d.occurred_on;
-        args.propositions[d.index].dateCleared = false;
+        prop.occurred_on = d.occurred_on;
+        prop.dateCleared = false;
       }
     }
   } catch (e) {
@@ -533,7 +535,7 @@ async function gradeSalience(
         g.salience >= 0 &&
         g.salience <= 3
       ) {
-        propositions[g.index].salience = g.salience;
+        propositions[g.index]!.salience = g.salience; // g.index validated above
       }
     }
   } catch (e) {

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -489,14 +489,14 @@ export class DomainPackInstallService {
     } catch {
       embeddings = changed.map(() => null);
     }
-    for (let i = 0; i < changed.length; i++) {
+    for (const [i, def] of changed.entries()) {
       await db.query(
         `UPDATE knowledge_predicate MERGE $content
            WHERE predicateId = $pid AND createdBy = 'admin'`,
         {
-          pid: changed[i].predicateId,
+          pid: def.predicateId,
           content: {
-            ...serializeForInsert(changed[i]),
+            ...serializeForInsert(def),
             ...(embeddings[i] ? { embedding: embeddings[i] } : {}),
           },
         },

--- a/src/admin/hnsw-maintenance.service.ts
+++ b/src/admin/hnsw-maintenance.service.ts
@@ -157,7 +157,7 @@ export class HnswMaintenanceService {
         (info as { indexes?: Record<string, string> })?.indexes ?? {};
       for (const [name, ddl] of Object.entries(indexes)) {
         const m = /DIMENSION\s+(\d+)/i.exec(String(ddl));
-        if (m) out.set(name, parseInt(m[1], 10));
+        if (m) out.set(name, parseInt(m[1]!, 10)); // group 1 mandatory
       }
     }
     return out;

--- a/src/admin/insight-composer-kernel.ts
+++ b/src/admin/insight-composer-kernel.ts
@@ -185,7 +185,7 @@ async function composeEntity<P>(
     spec.buildRow(p, {
       entityId: new StringRecordId(entityId),
       facts,
-      vector: vectors[i],
+      vector: vectors[i]!, // vectors is 1:1 with valid (embedMany) ⇒ in-bounds
       version,
     }),
   );

--- a/src/admin/intent-classifier.service.ts
+++ b/src/admin/intent-classifier.service.ts
@@ -237,7 +237,7 @@ export class IntentClassifierService
     confidence: number;
   } {
     const qIdx = result.labels.indexOf('question');
-    const qScore = qIdx >= 0 ? result.scores[qIdx] : 0;
+    const qScore = qIdx >= 0 ? (result.scores[qIdx] ?? 0) : 0;
     if (qScore >= this.askThreshold) {
       return { intent: 'ask', confidence: qScore };
     }

--- a/src/admin/operator-action.interceptor.ts
+++ b/src/admin/operator-action.interceptor.ts
@@ -29,7 +29,7 @@ export class OperatorActionInterceptor implements NestInterceptor {
     const http = ctx.switchToHttp();
     const req = http.getRequest<Request & Partial<AuthenticatedRequest>>();
     const res = http.getResponse<Response>();
-    const path = (req.originalUrl ?? req.url ?? '').split('?')[0];
+    const path = (req.originalUrl ?? req.url ?? '').split('?')[0] ?? '';
     const isAdminRoute = path.startsWith('/v1/admin/');
     const isSelf =
       path.startsWith('/v1/admin/operator-actions') ||

--- a/src/admin/scenario-eval.service.ts
+++ b/src/admin/scenario-eval.service.ts
@@ -71,7 +71,10 @@ export class ScenarioEvalService {
       error = (e as Error).message;
     }
 
-    const [vertical, id] = expectation.expectedTopEntityRef.split('.', 2);
+    const [vertical = '', id = ''] = expectation.expectedTopEntityRef.split(
+      '.',
+      2,
+    );
     const refTag = `${safe(vertical)}__${safe(id)}`;
     const rank = hits.findIndex((r) => r.externalRefs?.[refTag] === id);
     const rankOfExpected = rank === -1 ? 0 : rank + 1;
@@ -80,7 +83,7 @@ export class ScenarioEvalService {
 
     const factPredicateMatched =
       expectation.expectedFactPredicate && rankOfExpected > 0
-        ? hits[rankOfExpected - 1].facts.some(
+        ? hits[rankOfExpected - 1]!.facts.some( // rankOfExpected>0 ⇒ valid rank
             (f) => f.predicate === expectation.expectedFactPredicate,
           )
         : null;

--- a/src/admin/scenario-runner-utils.ts
+++ b/src/admin/scenario-runner-utils.ts
@@ -2,7 +2,7 @@
 // (write / lifecycle / eval) and the orchestrator.
 
 export function parseRefTag(ref: string): { refKey: string; id: string } {
-  const [vertical, id] = ref.split('.', 2);
+  const [vertical = '', id = ''] = ref.split('.', 2);
   return { refKey: `${safe(vertical)}__${safe(id)}`, id };
 }
 
@@ -12,7 +12,7 @@ export function formatTopRef(
   if (!refs) return null;
   const entries = Object.entries(refs);
   if (entries.length === 0) return null;
-  const [k, v] = entries[0];
+  const [k, v] = entries[0]!; // non-empty guaranteed by the guard above
   const dot = k.indexOf('__');
   if (dot === -1) return `${k}.${v}`;
   return `${k.slice(0, dot)}.${v}`;

--- a/src/admin/scenario-runner.service.ts
+++ b/src/admin/scenario-runner.service.ts
@@ -81,8 +81,7 @@ export class ScenarioRunnerService {
     const factIdsByTag = new Map<string, string>();
 
     try {
-      for (let i = 0; i < scenario.setup.length; i++) {
-        const step = scenario.setup[i];
+      for (const [i, step] of scenario.setup.entries()) {
         try {
           await this.applyStep({
             companyId,

--- a/src/admin/segment-composer.service.ts
+++ b/src/admin/segment-composer.service.ts
@@ -160,7 +160,7 @@ export class SegmentComposerService {
         seq: w.seq,
         episodeIds: w.turns.map((t) => new StringRecordId(String(t.id))),
         text: texts[i],
-        occurredAt: new Date(w.turns[0].occurredAt as string),
+        occurredAt: new Date(w.turns[0]!.occurredAt as string), // windows are non-empty
         piiClass: pii.length > 0 ? pii : undefined,
         userId: userIds.length === 1 ? userIds[0] : undefined,
         // G6 step 1: mirror the per-user scope as a scope tag (0093).

--- a/src/admin/span-anchor.ts
+++ b/src/admin/span-anchor.ts
@@ -91,9 +91,10 @@ export function computeCharSpans(args: {
     if (!Number.isInteger(turn) || turn < 0 || turn >= args.session.length) {
       return;
     }
-    const anchored = anchorQuote(args.session[turn].text, quote);
+    const sessionTurn = args.session[turn]!; // turn validated in-bounds above
+    const anchored = anchorQuote(sessionTurn.text, quote);
     if (anchored) {
-      spans.push({ episodeId: String(args.session[turn].id), ...anchored });
+      spans.push({ episodeId: String(sessionTurn.id), ...anchored });
     }
   });
   return spans;

--- a/src/admin/throttler-observability.interceptor.ts
+++ b/src/admin/throttler-observability.interceptor.ts
@@ -27,7 +27,7 @@ export class ThrottlerObservabilityInterceptor implements NestInterceptor {
     const http = ctx.switchToHttp();
     const req = http.getRequest<Request & Partial<AuthenticatedRequest>>();
     const res = http.getResponse<Response>();
-    const path = (req.originalUrl ?? req.url ?? '').split('?')[0];
+    const path = (req.originalUrl ?? req.url ?? '').split('?')[0] ?? '';
     if (
       path === '/health' ||
       path === '/ready' ||

--- a/src/admin/turn-headers.unit-spec.ts
+++ b/src/admin/turn-headers.unit-spec.ts
@@ -60,7 +60,7 @@ describe('scoreRows queryRange factor (V13 RETRIEVAL_TIME_FILTER)', () => {
   };
 
   it('demotes out-of-period facts and leaves in-period facts intact', () => {
-    const [inRange, outOfRange] = scoreRows({
+    const scoredPair = scoreRows({
       rows: [
         row('2023-05-04T00:00:00.000Z'),
         row('2022-11-04T00:00:00.000Z'),
@@ -68,6 +68,8 @@ describe('scoreRows queryRange factor (V13 RETRIEVAL_TIME_FILTER)', () => {
       now,
       queryRange: range,
     });
+    const inRange = scoredPair[0]!;
+    const outOfRange = scoredPair[1]!;
     expect(inRange.score).toBeGreaterThan(outOfRange.score);
     expect(inRange.breakdown.timeRange).toBeUndefined();
     expect(outOfRange.breakdown.timeRange).toBeLessThan(1);
@@ -75,7 +77,7 @@ describe('scoreRows queryRange factor (V13 RETRIEVAL_TIME_FILTER)', () => {
   });
 
   it('is byte-identical with no range', () => {
-    const [a] = scoreRows({ rows: [row('2022-11-04T00:00:00.000Z')], now });
+    const a = scoreRows({ rows: [row('2022-11-04T00:00:00.000Z')], now })[0]!;
     expect(a.breakdown.timeRange).toBeUndefined();
   });
 
@@ -84,7 +86,7 @@ describe('scoreRows queryRange factor (V13 RETRIEVAL_TIME_FILTER)', () => {
     (r as { source: Record<string, unknown> }).source = {
       mentionedAt: '2023-05-10T00:00:00.000Z',
     };
-    const [scored] = scoreRows({ rows: [r], now, queryRange: range });
+    const scored = scoreRows({ rows: [r], now, queryRange: range })[0]!;
     expect(scored.breakdown.timeRange).toBeUndefined();
   });
 });

--- a/src/admin/window-deriver.service.ts
+++ b/src/admin/window-deriver.service.ts
@@ -583,7 +583,7 @@ export class WindowDeriverService {
         { name: sp },
       );
       if (rows && rows.length === 1) {
-        entityBySpeaker.set(sp.toLowerCase(), String(rows[0].id));
+        entityBySpeaker.set(sp.toLowerCase(), String(rows[0]!.id));
       }
     }
 
@@ -643,7 +643,7 @@ export class WindowDeriverService {
     // session's first day. Off = the historical bare render.
     const turnHeaders = resolveExtractionProfile().deriveTurnHeaders;
     for (const session of segmentSessions(episodes)) {
-      const sessionDate = new Date(session[0].occurredAt as string);
+      const sessionDate = new Date(session[0]!.occurredAt as string); // sessions are non-empty
       const transcript = session.map((e, i) =>
         turnHeaders
           ? `[${i}] (${formatTurnStamp(e.occurredAt as string)}) ${e.speaker ?? 'unknown'}: ${e.text}`
@@ -660,7 +660,7 @@ export class WindowDeriverService {
           );
         }
         const last = new Date(
-          session[session.length - 1].occurredAt as string,
+          session[session.length - 1]!.occurredAt as string,
         );
         if (!digestEventAt || last > digestEventAt) digestEventAt = last;
       }
@@ -686,7 +686,7 @@ export class WindowDeriverService {
           const viaSpeaker =
             turn !== undefined
               ? entityBySpeaker.get(
-                  (session[turn].speaker ?? '').toLowerCase(),
+                  (session[turn]!.speaker ?? '').toLowerCase(), // turn validated in-bounds
                 )
               : undefined;
           const entityId = viaSpeaker ?? fallbackEntity;
@@ -733,7 +733,7 @@ export class WindowDeriverService {
             `and ${ungrounded} invalid-grounding proposition(s)`,
         );
       }
-      const keptResolved = resolved.filter((_, i) => !dropRow(builtRows[i]));
+      const keptResolved = resolved.filter((_, i) => !dropRow(builtRows[i]!)); // parallel to resolved
       const rows = builtRows.filter((r) => !dropRow(r));
       // V9 §1: value-bearing aspects take the bitemporal_event
       // lifecycle when the profile asks; V9 phase 0: the resolver
@@ -865,7 +865,7 @@ export class WindowDeriverService {
           vertical: 'derived',
           recorder: ns.final,
         }),
-        embedding: vectors[i],
+        embedding: vectors[i]!, // vectors is 1:1 with rollups ⇒ in-bounds
         derivedVersion: ns.staging,
       }));
       const outcomes = await this.factResolver.resolveDerivedBatch(db, rows, {
@@ -932,7 +932,8 @@ export class WindowDeriverService {
         compositions.map((c) => c.proposition),
       );
       const rows = compositions.map((c, i) => {
-        const members = c.members.map((m) => pool[m]);
+        // members were filtered to valid pool indices (0 ≤ m < pool.length).
+        const members = c.members.map((m) => pool[m]!);
         const aspect = c.aspect
           .toLowerCase()
           .replace(/[^a-z0-9_]+/g, '_')
@@ -966,7 +967,7 @@ export class WindowDeriverService {
             vertical: 'derived',
             recorder: ns.final,
           }),
-          embedding: vectors[i],
+          embedding: vectors[i]!, // vectors is 1:1 with compositions ⇒ in-bounds
           derivedVersion: ns.staging,
         };
       });

--- a/src/ai/calibration/calibration.service.ts
+++ b/src/ai/calibration/calibration.service.ts
@@ -81,7 +81,7 @@ export class CalibrationService implements OnModuleInit {
     if (this.disabled || !this.surreal || !this.apiKeys) return;
     const tenants = this.apiKeys.knownCompanyIds();
     if (tenants.length === 0) return;
-    const host = tenants[0];
+    const host = tenants[0]!; // non-empty guaranteed by the guard above
     try {
       const map = await this.loadPersistedBootstrap(host);
       if (map) {

--- a/src/ai/calibration/isotonic.ts
+++ b/src/ai/calibration/isotonic.ts
@@ -73,8 +73,9 @@ export function fitIsotonic(
     const c = clamp01(p.rawConfidence);
     let idx = Math.floor(c * binCount);
     if (idx >= binCount) idx = binCount - 1;
-    binSums[idx] += p.correctness;
-    binCounts[idx] += 1;
+    // idx ∈ [0, binCount) ⇒ in-bounds; the `?? 0` is a type-level formality.
+    binSums[idx] = (binSums[idx] ?? 0) + p.correctness;
+    binCounts[idx] = (binCounts[idx] ?? 0) + 1;
   }
 
   // 2. Compute means for non-empty bins. Empty bins are skipped entirely
@@ -83,28 +84,32 @@ export function fitIsotonic(
   // the bin whose upper bound covers the query confidence.
   const populated: Array<{ upper: number; mean: number; weight: number }> = [];
   for (let i = 0; i < binCount; i++) {
-    if (binCounts[i] === 0) continue;
+    // i < binCount = length of all three parallel bin arrays ⇒ in-bounds.
+    const count = binCounts[i]!;
+    if (count === 0) continue;
     populated.push({
-      upper: binUpperBounds[i],
-      mean: binSums[i] / binCounts[i],
-      weight: binCounts[i],
+      upper: binUpperBounds[i]!,
+      mean: binSums[i]! / count,
+      weight: count,
     });
   }
 
   // 3. PAV: collapse adjacent violators (mean[k] > mean[k+1]) by
   // weighted-merging until non-decreasing.
   for (let i = 0; i < populated.length - 1; ) {
-    if (populated[i].mean <= populated[i + 1].mean) {
+    // i < populated.length - 1 ⇒ both i and i+1 are in-bounds.
+    const a = populated[i]!;
+    const b = populated[i + 1]!;
+    if (a.mean <= b.mean) {
       i++;
       continue;
     }
     // Merge i and i+1.
-    const w1 = populated[i].weight;
-    const w2 = populated[i + 1].weight;
-    const mergedMean =
-      (populated[i].mean * w1 + populated[i + 1].mean * w2) / (w1 + w2);
+    const w1 = a.weight;
+    const w2 = b.weight;
+    const mergedMean = (a.mean * w1 + b.mean * w2) / (w1 + w2);
     populated[i] = {
-      upper: populated[i + 1].upper,
+      upper: b.upper,
       mean: mergedMean,
       weight: w1 + w2,
     };
@@ -118,7 +123,7 @@ export function fitIsotonic(
 
   // 4. Force the rightmost threshold to 1.0 so any raw confidence is
   // matched, even if the highest training bin happened to be < 1.0.
-  populated[populated.length - 1].upper = 1;
+  populated[populated.length - 1]!.upper = 1; // non-empty (checked above)
 
   return {
     thresholds: populated.map((p) => p.upper),
@@ -135,9 +140,10 @@ export function fitIsotonic(
 export function applyMap(map: CalibrationMap, rawConfidence: number): number {
   const c = clamp01(rawConfidence);
   for (let i = 0; i < map.thresholds.length; i++) {
-    if (c <= map.thresholds[i]) return clamp01(map.values[i]);
+    // thresholds/values are parallel; i < thresholds.length ⇒ in-bounds.
+    if (c <= map.thresholds[i]!) return clamp01(map.values[i] ?? 1);
   }
-  return clamp01(map.values[map.values.length - 1]);
+  return clamp01(map.values[map.values.length - 1] ?? 1);
 }
 
 function clamp01(x: number): number {

--- a/src/ai/cross-encoder.service.ts
+++ b/src/ai/cross-encoder.service.ts
@@ -254,7 +254,7 @@ export class CrossEncoderService
       // NaN, which would otherwise make the comparator non-deterministic.
       return candidates
         .map((_, i) => i)
-        .sort((a, b) => scores[b] - scores[a] || 0);
+        .sort((a, b) => (scores[b] ?? 0) - (scores[a] ?? 0) || 0);
     } catch (e) {
       this.logger.warn(
         `Local cross-encoder failed: ${(e as Error).message} — falling back to identity`,

--- a/src/ai/cross-encoder/cross-encoder.worker.ts
+++ b/src/ai/cross-encoder/cross-encoder.worker.ts
@@ -92,13 +92,13 @@ async function score(p: {
   const scores: number[] = new Array(p.documents.length).fill(
     Number.NEGATIVE_INFINITY,
   );
-  for (let i = 0; i < p.documents.length; i++) {
+  for (const [i, doc] of p.documents.entries()) {
     // Deadline check between pairs: a slow host must not blow the caller's
     // stage budget. Unscored docs keep -Infinity and sink to the tail (the
     // array length still matches, so the permutation stays valid).
     if (deadline !== undefined && Date.now() > deadline) break;
     const inputs = await tokenizer(p.query, {
-      text_pair: p.documents[i],
+      text_pair: doc,
       padding: true,
       truncation: true,
     });

--- a/src/ai/cross-encoder/local-cross-encoder.provider.ts
+++ b/src/ai/cross-encoder/local-cross-encoder.provider.ts
@@ -270,10 +270,10 @@ export class LocalCrossEncoderProvider {
     const scores: number[] = new Array(documents.length).fill(
       Number.NEGATIVE_INFINITY,
     );
-    for (let i = 0; i < documents.length; i++) {
+    for (const [i, doc] of documents.entries()) {
       if (deadline !== undefined && Date.now() > deadline) break;
       const inputs = await tokenizer(query, {
-        text_pair: documents[i],
+        text_pair: doc,
         padding: true,
         truncation: true,
       });

--- a/src/ai/domain-packs/semver.ts
+++ b/src/ai/domain-packs/semver.ts
@@ -15,7 +15,10 @@ export function compareSemver(a: string, b: string): number {
   const pa = parts(a);
   const pb = parts(b);
   for (let i = 0; i < 3; i++) {
-    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1;
+    // pa/pb are 3-tuples and i < 3 ⇒ both indices are in-bounds.
+    const x = pa[i]!;
+    const y = pb[i]!;
+    if (x !== y) return x < y ? -1 : 1;
   }
   return 0;
 }

--- a/src/ai/embedder.service.ts
+++ b/src/ai/embedder.service.ts
@@ -207,8 +207,7 @@ export class EmbedderService implements OnModuleInit, OnModuleDestroy {
             `for ${missTexts.length} inputs`,
         );
       }
-      for (let j = 0; j < missTexts.length; j++) {
-        const text = missTexts[j];
+      for (const [j, text] of missTexts.entries()) {
         const vec = vecs[j];
         if (!Array.isArray(vec) || vec.length === 0) {
           throw new Error(
@@ -218,7 +217,8 @@ export class EmbedderService implements OnModuleInit, OnModuleDestroy {
         }
         const k = this.cacheKey(provider.providerId, text);
         this.cache.set(k, vec);
-        out[missIdx[j]] = vec;
+        const outIdx = missIdx[j]; // parallel to missTexts
+        if (outIdx !== undefined) out[outIdx] = vec;
       }
     }
     return out;

--- a/src/ai/embedder/openai-embedder.provider.ts
+++ b/src/ai/embedder/openai-embedder.provider.ts
@@ -69,7 +69,9 @@ export class OpenAIEmbedderProvider implements EmbedderProvider {
         },
         { signal: getAbortSignal() },
       );
-      return { vector: res.data[0].embedding, usage: res.usage };
+      const first = res.data[0];
+      if (!first) throw new Error('openai embeddings returned no data');
+      return { vector: first.embedding, usage: res.usage };
     });
   }
 
@@ -115,7 +117,8 @@ export class OpenAIEmbedderProvider implements EmbedderProvider {
       // pre-sorted — positional assignment would map a vector to the
       // wrong text if the API ever reorders a batch.
       for (const d of res.data) {
-        out[sliceIdx[d.index]] = d.embedding;
+        const outIdx = sliceIdx[d.index];
+        if (outIdx !== undefined) out[outIdx] = d.embedding;
       }
     }
     return out;

--- a/src/ai/embedder/reindex-engine.service.ts
+++ b/src/ai/embedder/reindex-engine.service.ts
@@ -88,10 +88,10 @@ export class ReindexEngineService {
             if (page.length < batch) break;
             continue;
           }
-          for (let i = 0; i < page.length; i++) {
+          for (const [i, row] of page.entries()) {
             try {
               await db.query(`UPDATE $id SET embedding = $embedding`, {
-                id: page[i].id,
+                id: row.id,
                 embedding: embeddings[i],
               });
               factsUpdated += 1;

--- a/src/ai/extractor-internals/facet-router.ts
+++ b/src/ai/extractor-internals/facet-router.ts
@@ -67,7 +67,7 @@ export function hasNamedEntity(text: string): boolean {
   for (const sentence of text.split(/(?<=[.!?])\s+/)) {
     const words = sentence.trim().split(/\s+/);
     for (let i = 1; i < words.length; i++) {
-      const w = words[i].replace(/^[^\p{L}]+|[^\p{L}]+$/gu, '');
+      const w = words[i]!.replace(/^[^\p{L}]+|[^\p{L}]+$/gu, ''); // i < length
       if (w.length < 2 || w === 'I') continue;
       if (/^\p{Lu}\p{Ll}+/u.test(w)) return true;
     }

--- a/src/ai/extractor-internals/grounding.ts
+++ b/src/ai/extractor-internals/grounding.ts
@@ -65,8 +65,8 @@ export function isGroundedSpan(
     const before = idx > 0 ? normalizedInput[idx - 1] : undefined;
     const after = normalizedInput[idx + normalizedSpan.length];
     if (
-      boundaryOk(before, normalizedSpan[0]) &&
-      boundaryOk(after, normalizedSpan[normalizedSpan.length - 1])
+      boundaryOk(before, normalizedSpan[0]!) && // non-empty (checked line 60)
+      boundaryOk(after, normalizedSpan[normalizedSpan.length - 1]!)
     ) {
       return true;
     }

--- a/src/ai/extractor-internals/local-synth.ts
+++ b/src/ai/extractor-internals/local-synth.ts
@@ -25,8 +25,7 @@ function entityIndexForFact(
   clauseText: string,
 ): number {
   const clauseLower = clauseText.toLowerCase();
-  for (let i = 0; i < localEntities.length; i++) {
-    const en = localEntities[i];
+  for (const [i, en] of localEntities.entries()) {
     if (clauseLower.includes(en.text.toLowerCase())) {
       // Heuristic: the entity is the subject of the fact when its
       // name appears inside the clause. Multiple candidates are

--- a/src/ai/extractor-internals/merge.ts
+++ b/src/ai/extractor-internals/merge.ts
@@ -58,7 +58,7 @@ export function mergeExtractions(
             object: f.object,
             // Merged index, so the same person across passes is one
             // cluster and two people are never one (audit W3 #5).
-            entity: remaps[p].get(f.entityIndex),
+            entity: remaps[p]!.get(f.entityIndex),
           })),
         ),
       )
@@ -68,7 +68,7 @@ export function mergeExtractions(
   const facts: ExtractionResult['facts'] = [];
   passes.forEach((pass, p) => {
     for (const f of pass.facts) {
-      const entityIndex = remaps[p].get(f.entityIndex);
+      const entityIndex = remaps[p]!.get(f.entityIndex);
       if (entityIndex === undefined) continue;
       const k = clusterKey({
         predicate: f.predicate,
@@ -95,8 +95,8 @@ export function mergeExtractions(
   const seenEdges = new Set<string>();
   passes.forEach((pass, p) => {
     for (const ed of pass.edges) {
-      const from = remaps[p].get(ed.fromEntityIndex);
-      const to = remaps[p].get(ed.toEntityIndex);
+      const from = remaps[p]!.get(ed.fromEntityIndex);
+      const to = remaps[p]!.get(ed.toEntityIndex);
       if (from === undefined || to === undefined) continue;
       const k = `${from}-${ed.kind}-${to}`;
       if (seenEdges.has(k)) continue;

--- a/src/ai/extractor-internals/pattern-emitter.ts
+++ b/src/ai/extractor-internals/pattern-emitter.ts
@@ -45,8 +45,7 @@ export async function persistExtractionPatterns({
     list.push(rf);
     factsByClause.set(rf.clauseIndex, list);
   }
-  for (let i = 0; i < clauses.length; i++) {
-    const clauseText = clauses[i];
+  for (const [i, clauseText] of clauses.entries()) {
     const clauseFacts = (factsByClause.get(i) ?? []).map((f) => ({
       predicate:
         facts.find(

--- a/src/ai/extractor-internals/predicate-canonicalize.ts
+++ b/src/ai/extractor-internals/predicate-canonicalize.ts
@@ -39,7 +39,7 @@ export async function applyLocalPredicateOverrides({
     if (!f.clause) continue;
     const ranked = await selector.rank(f.clause, snapshot, 3);
     if (ranked.length === 0) continue;
-    const top = ranked[0];
+    const top = ranked[0]!; // non-empty guaranteed by the guard above
     if (top.similarity < threshold) continue;
     if (top.predicateId === f.predicate) continue;
     overrides.push({

--- a/src/ai/predicate-registry.service.ts
+++ b/src/ai/predicate-registry.service.ts
@@ -166,10 +166,10 @@ export class PredicateRegistryService {
           );
           embeddings = missing.map(() => null);
         }
-        for (let i = 0; i < missing.length; i++) {
+        for (const [i, def] of missing.entries()) {
           await db.query(`CREATE knowledge_predicate CONTENT $content`, {
             content: {
-              ...serializeForInsert(missing[i]),
+              ...serializeForInsert(def),
               ...(embeddings[i] ? { embedding: embeddings[i] } : {}),
             },
           });
@@ -204,7 +204,7 @@ export class PredicateRegistryService {
           );
           embs = needBackfill.map(() => null);
         }
-        for (let i = 0; i < needBackfill.length; i++) {
+        for (const [i, def] of needBackfill.entries()) {
           const emb = embs[i];
           if (!emb) continue;
           try {
@@ -212,11 +212,11 @@ export class PredicateRegistryService {
               `UPDATE knowledge_predicate
                  SET embedding = $emb, updatedAt = time::now()
                WHERE predicateId = $pid`,
-              { emb, pid: needBackfill[i].predicateId },
+              { emb, pid: def.predicateId },
             );
           } catch (e) {
             this.logger.warn(
-              `Backfill UPDATE failed for ${needBackfill[i].predicateId}: ${(e as Error).message}`,
+              `Backfill UPDATE failed for ${def.predicateId}: ${(e as Error).message}`,
             );
           }
         }
@@ -406,7 +406,7 @@ export class PredicateRegistryService {
       );
       const existing = (existingRows as Array<Record<string, unknown>>) ?? [];
       if (existing.length === 0) return null;
-      const current = deserializeFromRow(existing[0]);
+      const current = deserializeFromRow(existing[0]!); // non-empty (checked)
       const next: PredicateDefinition = { ...current, ...patch };
       // Re-embed when text fields changed — keeps similarity search aligned
       // with operator-authored descriptions.

--- a/src/ai/reranker.service.ts
+++ b/src/ai/reranker.service.ts
@@ -116,7 +116,7 @@ export class RerankerService {
       }
     }
     if (rankings.length === 0) return identity;
-    if (rankings.length === 1) return rankings[0];
+    if (rankings.length === 1) return rankings[0]!;
     return bordaAggregate(rankings, candidates.length);
   }
 
@@ -141,6 +141,7 @@ export class RerankerService {
     const items = presentationOrder
       .map((parentIdx, presIdx) => {
         const c = candidates[parentIdx];
+        if (!c) return `[${presIdx}] `; // out-of-range presentation index
         return `[${presIdx}] ${c.label}\n${c.body}`;
       })
       .join('\n\n');
@@ -208,7 +209,8 @@ Return ONLY a JSON object of the shape {"ranking": [<index>, ...]} listing every
         if (x < 0 || x >= candidates.length) return identity;
         if (seen.has(x)) return identity;
         seen.add(x);
-        validatedParentIdx.push(presentationOrder[x]);
+        // x ∈ [0, candidates.length) = presentationOrder.length ⇒ in-bounds.
+        validatedParentIdx.push(presentationOrder[x]!);
       }
       if (validatedParentIdx.length !== candidates.length) return identity;
       return validatedParentIdx;
@@ -228,7 +230,8 @@ function shuffle<T>(xs: T[]): T[] {
   const out = [...xs];
   for (let i = out.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
-    [out[i], out[j]] = [out[j], out[i]];
+    // i ∈ [1, len-1], j ∈ [0, i] ⇒ both indices are in-bounds.
+    [out[i], out[j]] = [out[j]!, out[i]!];
   }
   return out;
 }
@@ -243,12 +246,14 @@ function shuffle<T>(xs: T[]): T[] {
 function bordaAggregate(rankings: number[][], n: number): number[] {
   const points = new Array<number>(n).fill(0);
   for (const rank of rankings) {
-    for (let pos = 0; pos < rank.length; pos++) {
-      const candidate = rank[pos];
-      points[candidate] += n - pos;
+    for (const [pos, candidate] of rank.entries()) {
+      points[candidate] = (points[candidate] ?? 0) + (n - pos);
     }
   }
-  const indexed = Array.from({ length: n }, (_, i) => ({ idx: i, score: points[i] }));
+  const indexed = Array.from({ length: n }, (_, i) => ({
+    idx: i,
+    score: points[i]!, // i < n = points.length ⇒ in-bounds
+  }));
   indexed.sort((a, b) => b.score - a.score || a.idx - b.idx);
   return indexed.map((x) => x.idx);
 }

--- a/src/audit/changefeed-drain.service.ts
+++ b/src/audit/changefeed-drain.service.ts
@@ -123,11 +123,14 @@ export class ChangefeedDrainService {
             { events },
           );
         }
-        await this.advanceCursor(
-          db,
-          source,
-          batch[batch.length - 1].versionstamp as number,
-        );
+        const lastChange = batch[batch.length - 1];
+        if (lastChange) {
+          await this.advanceCursor(
+            db,
+            source,
+            lastChange.versionstamp as number,
+          );
+        }
         consumed[source] = batch.length;
       }
     });

--- a/src/code-memory/capture/commit-signals.ts
+++ b/src/code-memory/capture/commit-signals.ts
@@ -43,7 +43,7 @@ function parseTrailers(body: string): Record<string, string> {
   const trailers: Record<string, string> = {};
   for (const line of body.split('\n')) {
     const m = /^([A-Za-z][A-Za-z -]*):\s+(.+)$/.exec(line.trim());
-    if (m) trailers[m[1].toLowerCase()] = m[2].trim();
+    if (m) trailers[m[1]!.toLowerCase()] = m[2]!.trim(); // groups 1,2 mandatory
   }
   return trailers;
 }
@@ -55,10 +55,10 @@ export function parseCommitSignals(commit: CommitInput): Layer1Signals {
   const rationaleMarkers = RATIONALE_MARKERS.filter((m) => haystack.includes(m));
   const issueRefs = Array.from(
     `${subject}\n${haystack}`.matchAll(ISSUE_RE),
-    (m) => m[1],
+    (m) => m[1]!, // group 1 mandatory on match
   );
   return {
-    conventionalType: ctMatch ? ctMatch[1] : null,
+    conventionalType: ctMatch?.[1] ?? null,
     trailers: parseTrailers(body),
     issueRefs: Array.from(new Set(issueRefs)),
     bodyLength: body.length,

--- a/src/code-memory/capture/gate-features.ts
+++ b/src/code-memory/capture/gate-features.ts
@@ -68,10 +68,10 @@ export function featurize(
     feats.set(idx, (feats.get(idx) ?? 0) + 1);
   };
   const tokens = tokenize(text);
-  for (let i = 0; i < tokens.length; i++) {
-    add(tokens[i]);
+  for (const [i, tok] of tokens.entries()) {
+    add(tok);
     if (config.ngram >= 2 && i + 1 < tokens.length) {
-      add(`${tokens[i]} ${tokens[i + 1]}`);
+      add(`${tok} ${tokens[i + 1]}`);
     }
   }
   for (const s of structuredFeatures(signals)) add(s);

--- a/src/code-memory/capture/gate-train.ts
+++ b/src/code-memory/capture/gate-train.ts
@@ -53,7 +53,8 @@ function mulberry32(seed: number): () => number {
 function shuffle<T>(arr: T[], rng: () => number): void {
   for (let i = arr.length - 1; i > 0; i--) {
     const j = Math.floor(rng() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
+    // i ∈ [1, len-1], j ∈ [0, i] ⇒ both indices are in-bounds.
+    [arr[i], arr[j]] = [arr[j]!, arr[i]!];
   }
 }
 
@@ -75,6 +76,8 @@ function trainLogistic(
     for (const i of order) {
       const f = feats[i];
       const y = targets[i];
+      // feats/targets are parallel; skip any row whose pair is missing.
+      if (f === undefined || y === undefined) continue;
       let z = bias;
       for (const [k, v] of f) z += (weights.get(k) ?? 0) * v;
       const p = 1 / (1 + Math.exp(-z));

--- a/src/code-memory/capture/llm-extractor.ts
+++ b/src/code-memory/capture/llm-extractor.ts
@@ -81,7 +81,7 @@ export function parseCandidates(
     // model picked something else, fall back to the sole changed file, else drop.
     let anchor = typeof o.anchor === 'string' ? o.anchor : '';
     if (!changed.has(anchor)) {
-      if (commit.changedFiles.length === 1) anchor = commit.changedFiles[0];
+      if (commit.changedFiles.length === 1) anchor = commit.changedFiles[0]!;
       else continue;
     }
     const confidence =
@@ -107,7 +107,7 @@ export function parseCandidates(
 
 function safeParse(raw: string): unknown {
   const fenced = /```(?:json)?\s*([\s\S]*?)```/.exec(raw);
-  const body = fenced ? fenced[1] : raw;
+  const body = fenced?.[1] ?? raw;
   const start = body.search(/[[{]/);
   if (start === -1) return null;
   try {

--- a/src/code-memory/capture/llm-verifier.ts
+++ b/src/code-memory/capture/llm-verifier.ts
@@ -72,14 +72,14 @@ export function applyVerdicts(
   // keep the raw candidates rather than drop by a misaligned index.
   if (!verdicts || verdicts.length !== candidates.length) return candidates;
   const out: DecisionCandidate[] = [];
-  for (let i = 0; i < candidates.length; i++) {
-    const v = verdicts[i];
+  for (const [i, candidate] of candidates.entries()) {
+    const v = verdicts[i]!; // verdicts.length === candidates.length (checked)
     if (v.keep === false) continue;
     const confidence =
       typeof v.confidence === 'number' && v.confidence >= 0 && v.confidence <= 1
         ? v.confidence
-        : candidates[i].confidence;
-    out.push({ ...candidates[i], confidence });
+        : candidate.confidence;
+    out.push({ ...candidate, confidence });
   }
   return out;
 }
@@ -88,7 +88,7 @@ function parseVerdicts(
   raw: string,
 ): Array<{ keep?: boolean; confidence?: number }> | null {
   const fenced = /```(?:json)?\s*([\s\S]*?)```/.exec(raw);
-  const body = fenced ? fenced[1] : raw;
+  const body = fenced?.[1] ?? raw;
   const start = body.search(/[[{]/);
   if (start === -1) return null;
   let parsed: unknown;

--- a/src/code-memory/capture/silver-dataset.ts
+++ b/src/code-memory/capture/silver-dataset.ts
@@ -188,7 +188,7 @@ async function runPool<T>(
       for (;;) {
         const i = next++;
         if (i >= items.length) break;
-        await worker(items[i], i);
+        await worker(items[i]!, i); // i < items.length ⇒ in-bounds
       }
     },
   );

--- a/src/common/egress-guard.ts
+++ b/src/common/egress-guard.ts
@@ -72,6 +72,7 @@ function isBlockedIPv4(ip: string): boolean {
     return true; // unparseable → fail closed
   }
   const [a, b] = parts;
+  if (a === undefined || b === undefined) return true; // fail closed
   return (
     a === 0 ||
     a === 127 ||
@@ -84,10 +85,10 @@ function isBlockedIPv4(ip: string): boolean {
 
 /** ::, ::1, fc00::/7 (ULA), fe80::/10 (link-local), IPv4-mapped. */
 function isBlockedIPv6(ip: string): boolean {
-  const bare = ip.toLowerCase().split('%')[0];
+  const bare = ip.toLowerCase().split('%')[0] ?? '';
   if (bare === '::' || bare === '::1') return true;
   const mapped = bare.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (mapped) return isBlockedIPv4(mapped[1]);
+  if (mapped) return isBlockedIPv4(mapped[1] ?? ''); // '' → parts≠4 → blocked
   const first = parseInt(bare.split(':')[0] || '0', 16);
   if (!Number.isFinite(first)) return true;
   if ((first & 0xfe00) === 0xfc00) return true;

--- a/src/common/in-flight.interceptor.ts
+++ b/src/common/in-flight.interceptor.ts
@@ -22,7 +22,7 @@ export class InFlightInterceptor implements NestInterceptor {
   intercept(ctx: ExecutionContext, next: CallHandler): Observable<unknown> {
     const http = ctx.switchToHttp();
     const req = http.getRequest<Request & Partial<AuthenticatedRequest>>();
-    const path = (req.originalUrl ?? req.url ?? '').split('?')[0];
+    const path = (req.originalUrl ?? req.url ?? '').split('?')[0] ?? '';
     // SSE handlers stay open by design — recording them as "in flight"
     // would make every connected admin browser look like a stuck request.
     if (path.endsWith('/stream')) return next.handle();

--- a/src/common/parallel.ts
+++ b/src/common/parallel.ts
@@ -28,10 +28,11 @@ export async function mapWithLimit<T, R>({
     while (true) {
       const i = cursor++;
       if (i >= items.length) return;
+      const item = items[i]!; // i < items.length ⇒ in-bounds
       try {
-        out[i] = await fn(items[i], i);
+        out[i] = await fn(item, i);
       } catch (e) {
-        onError?.(e as Error, items[i], i);
+        onError?.(e as Error, item, i);
         out[i] = null;
       }
     }

--- a/src/common/vector-math.ts
+++ b/src/common/vector-math.ts
@@ -12,9 +12,12 @@ export function cosineSimilarity(a: number[], b: number[]): number {
   let na = 0;
   let nb = 0;
   for (let i = 0; i < len; i++) {
-    dot += a[i] * b[i];
-    na += a[i] * a[i];
-    nb += b[i] * b[i];
+    // i < len = min(a.length, b.length) ⇒ both indices are in-bounds.
+    const ai = a[i]!;
+    const bi = b[i]!;
+    dot += ai * bi;
+    na += ai * ai;
+    nb += bi * bi;
   }
   const denom = Math.sqrt(na) * Math.sqrt(nb);
   return denom === 0 ? 0 : dot / denom;

--- a/src/communities/community-builder.service.ts
+++ b/src/communities/community-builder.service.ts
@@ -141,8 +141,7 @@ export class CommunityBuilderService {
     const existing = await this.loadExistingCommunities(db);
     const matchedExistingIds = new Set<string>();
 
-    for (let i = 0; i < clusters.length; i++) {
-      const members = clusters[i];
+    for (const [i, members] of clusters.entries()) {
       result.entitiesClustered += members.length;
       const signature = members.join('|');
       const prior = existing.get(signature);
@@ -168,7 +167,7 @@ export class CommunityBuilderService {
       }
       await withSpan(
         'communities.build_one',
-        () => this.buildCommunity(db, members, maxEdgeAt[i], derivedVersion),
+        () => this.buildCommunity(db, members, maxEdgeAt[i] ?? null, derivedVersion),
         { 'community.size': members.length },
       );
       result.communitiesBuilt++;

--- a/src/communities/label-propagation.ts
+++ b/src/communities/label-propagation.ts
@@ -88,7 +88,13 @@ function groupByLabel(
   }
   return [...groups.values()]
     .map((g) => g.sort())
-    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+    .sort((a, b) => {
+      // Every group is constructed with ≥1 member, so [0] is present;
+      // the `?? ''` is a type-level formality.
+      const x = a[0] ?? '';
+      const y = b[0] ?? '';
+      return x < y ? -1 : x > y ? 1 : 0;
+    });
 }
 
 /**

--- a/src/compaction/compaction-runner.service.ts
+++ b/src/compaction/compaction-runner.service.ts
@@ -213,14 +213,17 @@ export class CompactionRunnerService {
       );
       if (!summaryText) continue;
 
-      const earliest = sorted[0].validFrom;
-      const latest = sorted[sorted.length - 1].validUntil ?? sorted[sorted.length - 1].validFrom;
+      // group.length ≥ 2 (checked above) ⇒ sorted is non-empty.
+      const first = sorted[0]!;
+      const last = sorted[sorted.length - 1]!;
+      const earliest = first.validFrom;
+      const latest = last.validUntil ?? last.validFrom;
       const meanConfidence =
         sorted.reduce((acc, g) => acc + g.confidence, 0) / sorted.length;
 
       await dbCreate(db, 'knowledge_fact', {
-        entityId: sorted[0].entityId,
-        predicate: `summary_${sorted[0].predicate}`,
+        entityId: first.entityId,
+        predicate: `summary_${first.predicate}`,
         object: summaryText,
         confidence: meanConfidence,
         validFrom: earliest,
@@ -231,7 +234,7 @@ export class CompactionRunnerService {
         // The summary belongs to the same world as the facts it replaces
         // (audit W2 #10) — otherwise the pinned reader loses both.
         ...(derivedVersion ? { derivedVersion } : {}),
-        ...(sorted[0].userId ? { userId: sorted[0].userId } : {}),
+        ...(first.userId ? { userId: first.userId } : {}),
       });
       created++;
     }

--- a/src/compaction/promotion-runner.service.ts
+++ b/src/compaction/promotion-runner.service.ts
@@ -234,13 +234,15 @@ export class PromotionRunnerService {
       );
     }
 
-    const earliest = members[0].validFrom;
+    const first = members[0];
     const last = members[members.length - 1];
+    if (!first || !last) return 0; // members non-empty (length ≥ minGroup)
+    const earliest = first.validFrom;
     const meanConfidence =
       members.reduce((acc, m) => acc + m.confidence, 0) / members.length;
 
     await dbCreate(db, 'knowledge_fact', {
-      entityId: members[0].entityId,
+      entityId: first.entityId,
       predicate: `summary_${group.predicate}`,
       object: summaryText,
       confidence: meanConfidence,

--- a/src/compaction/recompose.service.ts
+++ b/src/compaction/recompose.service.ts
@@ -264,6 +264,9 @@ export class RecomposeService implements OnModuleInit {
   ): Promise<boolean> {
     const text = await this.summaryGenerator.generate(parents);
     if (!text) return false;
+    const first = parents[0];
+    const last = parents[parents.length - 1];
+    if (!first || !last) return false; // no parents to recompose from
     const meanConfidence =
       parents.reduce((acc, p) => acc + p.confidence, 0) / parents.length;
     await db.query(
@@ -277,10 +280,8 @@ export class RecomposeService implements OnModuleInit {
         id: new StringRecordId(summaryId),
         object: text,
         confidence: meanConfidence,
-        validFrom: parents[0].validFrom,
-        validUntil:
-          parents[parents.length - 1].validUntil ??
-          parents[parents.length - 1].validFrom,
+        validFrom: first.validFrom,
+        validUntil: last.validUntil ?? last.validFrom,
         // Re-point at the CURRENT parents: a superseded parent we followed is
         // no longer what this summary is derived from, and leaving the old id
         // would make the next invalidation pass chase a dead row.

--- a/src/db/migrator.service.ts
+++ b/src/db/migrator.service.ts
@@ -137,22 +137,30 @@ export class SchemaMigrator {
         `No migration files found in ${this.migrationsDir}. Expected NNNN_description.surql`,
       );
     }
-    this.cached = await Promise.all(
-      eligible.map(async (name) => ({
-        id: name.match(FILE_NAME)![1],
-        name,
-        sql: await readFile(join(this.migrationsDir, name), 'utf-8'),
-      })),
+    const manifest: Migration[] = await Promise.all(
+      eligible.map(async (name) => {
+        const id = name.match(FILE_NAME)?.[1];
+        if (id === undefined) {
+          // Unreachable: `eligible` was filtered by FILE_NAME.test above.
+          throw new Error(`Migration file ${name} lacks an NNNN id prefix`);
+        }
+        return {
+          id,
+          name,
+          sql: await readFile(join(this.migrationsDir, name), 'utf-8'),
+        };
+      }),
     );
     // Reject duplicate IDs early — easier to debug than mid-apply.
     const ids = new Set<string>();
-    for (const m of this.cached) {
+    for (const m of manifest) {
       if (ids.has(m.id)) {
         throw new Error(`Duplicate migration id ${m.id} in ${this.migrationsDir}`);
       }
       ids.add(m.id);
     }
-    return this.cached;
+    this.cached = manifest;
+    return manifest;
   }
 
   private async fetchAppliedIds(conn: Surreal): Promise<string[]> {

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -261,7 +261,7 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   async ping(): Promise<boolean> {
     if (this.all.length === 0) return false;
     try {
-      await this.all[0].version();
+      await this.all[0]!.version(); // non-empty guaranteed by the guard above
       return true;
     } catch {
       return false;
@@ -701,7 +701,7 @@ export async function dbCreate<T extends Record<string, unknown>>(
   if (arr.length === 0) {
     throw new Error(`dbCreate(${table}) returned no row`);
   }
-  return arr[0];
+  return arr[0]!; // length > 0 guaranteed by the guard above
 }
 
 export async function dbMerge<T extends Record<string, unknown>>(
@@ -719,7 +719,7 @@ export async function dbMerge<T extends Record<string, unknown>>(
   if (arr.length === 0) {
     throw new Error(`dbMerge(${recordId}) matched no record`);
   }
-  return arr[0];
+  return arr[0]!; // length > 0 guaranteed by the guard above
 }
 
 function tableOf(rid: string): string {

--- a/src/documents/candidate-commit.service.ts
+++ b/src/documents/candidate-commit.service.ts
@@ -201,6 +201,7 @@ function entityUpdates(
   return merge.entities.flatMap((me) => {
     const entityId = entityIds.get(me.key);
     const [leader, ...rest] = me.candidateIds;
+    if (leader === undefined) return []; // no candidate ids → nothing to update
     const leaderUpdate: StatusUpdate = {
       id: leader,
       kind: 'entity',

--- a/src/documents/commit-writer.service.ts
+++ b/src/documents/commit-writer.service.ts
@@ -105,8 +105,7 @@ export class CommitWriterService {
     },
   ): Promise<FactWriteOutcome[]> {
     const outcomes: FactWriteOutcome[] = [];
-    for (let i = 0; i < p.factsToWrite.length; i++) {
-      const mf = p.factsToWrite[i];
+    for (const [i, mf] of p.factsToWrite.entries()) {
       const entityId = p.entityIds.get(mf.entityKey);
       if (!entityId) {
         outcomes.push({ fact: mf, factId: null, outcome: null });

--- a/src/dreams/corroborate.service.ts
+++ b/src/dreams/corroborate.service.ts
@@ -396,11 +396,11 @@ export class DreamsCorroborateService {
     const pairs: Array<{ incumbent: ActiveFactRow; younger: ActiveFactRow }> =
       [];
     for (let j = 1; j < members.length; j++) {
-      const younger = members[j];
+      const younger = members[j]!; // j < members.length ⇒ in-bounds
       if (younger.corroborationCount > 0) continue;
       let best: { incumbent: ActiveFactRow; sim: number } | null = null;
       for (let i = 0; i < j; i++) {
-        const older = members[i];
+        const older = members[i]!; // i < j < members.length ⇒ in-bounds
         if (older.originKey === younger.originKey) continue;
         if (!intervalsOverlap(older, younger)) continue;
         const sim = cosine(older.embedding, younger.embedding);
@@ -544,9 +544,12 @@ function cosine(a: number[], b: number[]): number {
   let na = 0;
   let nb = 0;
   for (let i = 0; i < a.length; i++) {
-    dot += a[i] * b[i];
-    na += a[i] * a[i];
-    nb += b[i] * b[i];
+    // a.length === b.length (checked above) ⇒ both indices are in-bounds.
+    const ai = a[i]!;
+    const bi = b[i]!;
+    dot += ai * bi;
+    na += ai * ai;
+    nb += bi * bi;
   }
   if (na === 0 || nb === 0) return -1;
   return dot / (Math.sqrt(na) * Math.sqrt(nb));

--- a/src/dreams/resolver.service.ts
+++ b/src/dreams/resolver.service.ts
@@ -221,7 +221,7 @@ export class DreamsResolverService {
         (r) => new Date(r.recordedAt as unknown as string).getTime() <= cutoffMs,
       );
       if (!aged) continue;
-      pairs.push({ a: group[0], b: group[1] });
+      pairs.push({ a: group[0]!, b: group[1]! }); // group.length === 2 (checked)
       if (pairs.length >= this.maxPairs) break;
     }
     return pairs;

--- a/src/episodes/episode-subscription.service.ts
+++ b/src/episodes/episode-subscription.service.ts
@@ -182,7 +182,7 @@ export class EpisodeSubscriptionService {
       });
       if (rows.length === 0) continue;
       const toIso = (v: Date | string): string => new Date(v as string).toISOString();
-      const watermark = toIso(rows[rows.length - 1].recordedAt);
+      const watermark = toIso(rows[rows.length - 1]!.recordedAt); // rows non-empty (checked)
       const event: EpisodesAvailableEvent = {
         event: 'episodes_available',
         delivery: 'at-least-once',

--- a/src/episodes/episodes.controller.ts
+++ b/src/episodes/episodes.controller.ts
@@ -151,12 +151,13 @@ export class EpisodesController {
       userId: q.userId,
       after: q.cursor !== undefined ? decodeCursor(q.cursor) : undefined,
     });
+    const lastRow = rows[rows.length - 1];
     return {
       episodes: rows.map(toWire),
       // A full page may end exactly on the last row; the follow-up
       // request then returns [] with no cursor — offset-free and safe.
-      ...(rows.length === limit
-        ? { nextCursor: encodeCursor(rows[rows.length - 1]) }
+      ...(lastRow && rows.length === limit
+        ? { nextCursor: encodeCursor(lastRow) }
         : {}),
     };
   }
@@ -194,6 +195,7 @@ export class EpisodesController {
       }
       if (rows.length < EXPORT_CHUNK) break;
       const last = rows[rows.length - 1];
+      if (!last) break; // rows non-empty here; guard satisfies the checker
       after = { occurredAtIso: toIso(last.occurredAt), id: String(last.id) };
     }
     res.end();

--- a/src/episodes/read-pin.service.ts
+++ b/src/episodes/read-pin.service.ts
@@ -77,7 +77,7 @@ export class ReadPinService {
     const union = ReadPinService.bootstrapUnion();
     if (!union) return single;
     const pins = single && !union.includes(single) ? [...union, single] : union;
-    return pins.length === 1 ? pins[0] : pins;
+    return pins.length === 1 ? pins[0]! : pins;
   }
 
   /**

--- a/src/eval/scenarios/adversarial.scenarios.ts
+++ b/src/eval/scenarios/adversarial.scenarios.ts
@@ -58,7 +58,7 @@ function bulkFactsFor(
       kind: 'fact',
       entityRef: { vertical, id },
       predicate: p,
-      object: objects[i],
+      object: objects[i]!, // objects is parallel to predicates (same length)
       validFrom: new Date(day + i * 86_400_000).toISOString(),
       confidence: 0.85,
       source: { vertical, eventId: `bulk.seed.${i}` },

--- a/src/indexers/routing.ts
+++ b/src/indexers/routing.ts
@@ -100,9 +100,12 @@ export function cosineSimilarity(a: number[], b: number[]): number {
   let na = 0;
   let nb = 0;
   for (let i = 0; i < n; i++) {
-    dot += a[i] * b[i];
-    na += a[i] * a[i];
-    nb += b[i] * b[i];
+    // i < n = min(a.length, b.length) ⇒ both indices are in-bounds.
+    const ai = a[i]!;
+    const bi = b[i]!;
+    dot += ai * bi;
+    na += ai * ai;
+    nb += bi * bi;
   }
   const denom = Math.sqrt(na) * Math.sqrt(nb);
   return denom === 0 ? 0 : dot / denom;

--- a/src/ingest/conflict-resolver.ts
+++ b/src/ingest/conflict-resolver.ts
@@ -167,7 +167,11 @@ export interface ConflictConfig {
   rejectThreshold: number;
 }
 
-export const SOURCE_TRUST: Record<string, number> = {
+// `satisfies` (not a `Record<string, number>` annotation) so each key keeps
+// its concrete presence: static property access (SOURCE_TRUST.billing_event)
+// stays `number` under noUncheckedIndexedAccess. Never indexed by a dynamic
+// key — every read is a literal member.
+export const SOURCE_TRUST = {
   human_declared:           1.00,
   billing_event:            0.95,
   incidents_event:          0.90,
@@ -178,7 +182,7 @@ export const SOURCE_TRUST: Record<string, number> = {
   voice_transcript:         0.40,
   external_webhook:         0.50,
   default:                  0.50,
-};
+} satisfies Record<string, number>;
 
 export function recencyWeight(recordedAt: Date, now: Date = new Date()): number {
   const ageDays = (now.getTime() - recordedAt.getTime()) / (1000 * 60 * 60 * 24);

--- a/src/ingest/event-time.ts
+++ b/src/ingest/event-time.ts
@@ -107,9 +107,13 @@ export function resolveEventTime(
 
   // chrono first (relative expressions, multilingual), English as a secondary
   // pass for a non-English clause that embeds a language-agnostic date.
+  const primary = PARSERS[langKey];
+  const english = PARSERS.en;
   const hit =
-    parseWith(PARSERS[langKey], clause, anchorRaw) ??
-    (langKey !== 'en' ? parseWith(PARSERS.en, clause, anchorRaw) : null);
+    (primary ? parseWith(primary, clause, anchorRaw) : null) ??
+    (langKey !== 'en' && english
+      ? parseWith(english, clause, anchorRaw)
+      : null);
   if (hit) {
     const clamped = clampPast(hit.date, anchor);
     if (clamped) return { date: clamped, expr: hit.expr };
@@ -118,7 +122,7 @@ export function resolveEventTime(
   // Fallback: explicit past year chrono didn't resolve.
   const yr = clause.match(YEAR_FALLBACK);
   if (yr) {
-    const year = parseInt(yr[1], 10);
+    const year = parseInt(yr[1]!, 10); // group 1 is mandatory on match
     if (year < anchor.getUTCFullYear()) {
       const clamped = clampPast(new Date(Date.UTC(year, 0, 1)), anchor);
       if (clamped) return { date: clamped, expr: `year ${year}` };

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -158,11 +158,12 @@ export class FactResolverService {
     inputs: Parameters<FactResolverService['resolve']>[1][],
   ): Promise<Array<{ result: any; semantics: string }>> {
     if (inputs.length === 0) return [];
+    const firstCompanyId = inputs[0]!.companyId; // inputs non-empty (checked)
     try {
-      await this.predicateRegistry.getSnapshot(inputs[0].companyId);
+      await this.predicateRegistry.getSnapshot(firstCompanyId);
     } catch (e) {
       this.logger.warn(
-        `ingest: predicate registry getSnapshot failed for ${inputs[0].companyId}: ${(e as Error).message}; using seed policy`,
+        `ingest: predicate registry getSnapshot failed for ${firstCompanyId}: ${(e as Error).message}; using seed policy`,
       );
     }
 
@@ -180,7 +181,8 @@ export class FactResolverService {
       try {
         const batch = await this.resolveAppendOnlyBatch(
           db,
-          appendIdx.map((i) => prepared[i]),
+          // appendIdx holds valid indices into `prepared` (built above).
+          appendIdx.map((i) => prepared[i]!),
         );
         appendIdx.forEach((i, k) => (results[i] = batch[k]));
       } catch (e) {
@@ -188,20 +190,23 @@ export class FactResolverService {
           `ingest: batched fact resolve fell back to per-fact: ${(e as Error).message}`,
         );
         for (const i of appendIdx) {
-          results[i] = await this.resolveFactCall(db, prepared[i]);
+          results[i] = await this.resolveFactCall(db, prepared[i]!);
         }
       }
     }
     // single_active / bitemporal keep the serialized per-fact path.
     for (const i of restIdx) {
-      results[i] = await this.resolveFactCall(db, prepared[i]);
+      results[i] = await this.resolveFactCall(db, prepared[i]!);
     }
 
     // Post-call side effects (HyPE + metric) per fact, in order.
     const out: Array<{ result: any; semantics: string }> = [];
     for (let i = 0; i < inputs.length; i++) {
-      await this.postResolve(db, inputs[i], results[i]);
-      out.push({ result: results[i], semantics: prepared[i].semantics });
+      // prepared.length === inputs.length ⇒ both indices are in-bounds.
+      const input = inputs[i]!;
+      const prep = prepared[i]!;
+      await this.postResolve(db, input, results[i]);
+      out.push({ result: results[i], semantics: prep.semantics });
     }
     return out;
   }

--- a/src/ingest/ingest-predictor.service.ts
+++ b/src/ingest/ingest-predictor.service.ts
@@ -289,7 +289,7 @@ export class IngestPredictionService {
         if (newer.length > 0) {
           return {
             wouldOutcome: 'INSERTED_HISTORICAL',
-            reasoning: `A newer fact (validFrom ${dateToIso(newer[0].validFrom)}) already exists; the backdated candidate would be inserted as already-superseded history, not supersede the active fact.`,
+            reasoning: `A newer fact (validFrom ${dateToIso(newer[0]!.validFrom)}) already exists; the backdated candidate would be inserted as already-superseded history, not supersede the active fact.`,
             opposingFacts: gate(newer.map(rowToOpposingFact)),
             predicatePolicy: policy,
           };

--- a/src/ingest/mention-persist.service.ts
+++ b/src/ingest/mention-persist.service.ts
@@ -273,7 +273,8 @@ export class MentionPersistService {
     );
     const factIds: string[] = [];
     resolved.forEach((r, k) => {
-      const factId = this.emitFactOutcome(specs[k].f, r.result, r.semantics);
+      // resolved is 1:1 with specs (resolveMany preserves order) ⇒ in-bounds.
+      const factId = this.emitFactOutcome(specs[k]!.f, r.result, r.semantics);
       if (factId) factIds.push(factId);
     });
     return factIds;

--- a/src/ingest/predict-scoring.service.ts
+++ b/src/ingest/predict-scoring.service.ts
@@ -88,6 +88,9 @@ export class PredictScoringService {
       }))
       .sort((a, b) => b.score - a.score);
     const top = scored[0];
+    // Caller guarantees a non-empty `overlapping` (competing.length === 0 is
+    // short-circuited upstream), so `scored` is non-empty — fail loud if not.
+    if (!top) throw new Error('predictSingleActive: no overlapping priors');
     const gap = candidateScore - top.score;
     if (gap > this.conflict.marginForSupersede) {
       return {
@@ -131,7 +134,11 @@ export class PredictScoringService {
     candidateScore: number,
     above: Array<{ opposing: OpposingFact; cosine: number; score: number; row: PriorRow }>,
   ): Omit<PredictResolveResult, 'predicatePolicy'> {
-    const top = above.reduce((acc, c) => (c.score > acc.score ? c : acc), above[0]);
+    const first = above[0];
+    // Caller guarantees a non-empty `above` (competing.length === 0 is
+    // short-circuited upstream) — fail loud rather than reduce over nothing.
+    if (!first) throw new Error('predictBitemporal: no priors above threshold');
+    const top = above.reduce((acc, c) => (c.score > acc.score ? c : acc), first);
     const gap = candidateScore - top.score;
     if (gap > this.conflict.marginForSupersede) {
       return {

--- a/src/ingest/predictor-internals.ts
+++ b/src/ingest/predictor-internals.ts
@@ -143,8 +143,11 @@ export function cosineSimilarity(a: number[], b: number[], aNorm: number): numbe
   let dot = 0;
   let bNorm = 0;
   for (let i = 0; i < a.length; i++) {
-    dot += a[i] * b[i];
-    bNorm += b[i] * b[i];
+    // a.length === b.length (checked above) ⇒ both indices are in-bounds.
+    const ai = a[i]!;
+    const bi = b[i]!;
+    dot += ai * bi;
+    bNorm += bi * bi;
   }
   bNorm = Math.sqrt(bNorm);
   if (bNorm === 0) return 0;

--- a/src/multi-hop/multi-hop-chain.service.ts
+++ b/src/multi-hop/multi-hop-chain.service.ts
@@ -120,8 +120,7 @@ export class MultiHopChainService {
     let runningIds: string[] = [];
     let runningHitsByEntity = new Map<string, SearchHit>();
 
-    for (let i = 0; i < plan.hops.length; i++) {
-      const hop = plan.hops[i];
+    for (const [i, hop] of plan.hops.entries()) {
       onProgress({
         stage: 'hop',
         index: i + 1,

--- a/src/multi-hop/multi-hop-planner.service.ts
+++ b/src/multi-hop/multi-hop-planner.service.ts
@@ -220,8 +220,10 @@ export class MultiHopPlannerService {
     // Defensive: enforce caps + first-hop=seed invariant. The schema
     // says combination is one of the four; we belt-and-braces force
     // hops[0] to be seed because executors downstream rely on it.
-    if (parsed.hops[0].combination !== 'seed') {
-      parsed.hops[0].combination = 'seed';
+    // hops is non-empty (checked above) ⇒ hops[0] is present.
+    const firstHop = parsed.hops[0]!;
+    if (firstHop.combination !== 'seed') {
+      firstHop.combination = 'seed';
     }
     if (parsed.hops.length > maxHops) {
       parsed.hops = parsed.hops.slice(0, maxHops);

--- a/src/policy/policy-decisions.service.ts
+++ b/src/policy/policy-decisions.service.ts
@@ -115,7 +115,7 @@ export class PolicyDecisionsService {
     return {
       decisions,
       ...(rows.length > limit && decisions.length > 0
-        ? { nextCursor: decisions[decisions.length - 1].ts }
+        ? { nextCursor: decisions[decisions.length - 1]!.ts }
         : {}),
     };
   }
@@ -199,7 +199,7 @@ export class PolicyDecisionsService {
         count,
       })),
       topRules: top(rules, 10).map(([key, count]) => {
-        const [policySet, ruleId] = key.split('\u0000');
+        const [policySet = '', ruleId = ''] = key.split('\u0000');
         return { policySet, ruleId, count };
       }),
       byKey: [...byKey.entries()]

--- a/src/policy/policy-simulation.service.ts
+++ b/src/policy/policy-simulation.service.ts
@@ -248,7 +248,7 @@ export class PolicySimulationService {
       });
     }
     const parsedRule = doc.data.rules[0];
-    if (parsedRule.kind !== 'source') {
+    if (!parsedRule || parsedRule.kind !== 'source') {
       throw new BadRequestException('preview-rule only applies to source rules');
     }
     const compiled = this.compile(doc.data);

--- a/src/procedural/procedural-memory.service.ts
+++ b/src/procedural/procedural-memory.service.ts
@@ -233,8 +233,11 @@ function cosineSimilarity(a: number[], b: number[], aNorm: number): number {
   let dot = 0;
   let bNorm = 0;
   for (let i = 0; i < a.length; i++) {
-    dot += a[i] * b[i];
-    bNorm += b[i] * b[i];
+    // a.length === b.length (checked above) ⇒ both indices are in-bounds.
+    const ai = a[i]!;
+    const bi = b[i]!;
+    dot += ai * bi;
+    bNorm += bi * bi;
   }
   bNorm = Math.sqrt(bNorm);
   if (bNorm === 0) return 0;

--- a/src/search/internals/fact-rerank.ts
+++ b/src/search/internals/fact-rerank.ts
@@ -69,8 +69,12 @@ export function remapWindowScores(
   // rows arrive sorted desc by fused score (collectFactWindow), so
   // rows[k].row.score IS the k-th highest original value.
   const ranked = rows.map((r) => r.row.score);
-  for (let k = 0; k < n; k++) {
-    rows[permutation[k]].row.score = ranked[k];
+  for (const [k, target] of permutation.entries()) {
+    const row = rows[target];
+    const score = ranked[k];
+    // Both are in-bounds: permutation is a validated 0..n-1 permutation
+    // and ranked has length n; the guard is a type-level formality.
+    if (row !== undefined && score !== undefined) row.row.score = score;
   }
   return true;
 }

--- a/src/search/internals/rerank-skip.ts
+++ b/src/search/internals/rerank-skip.ts
@@ -19,8 +19,9 @@ export function shouldSkipRerankByMargin(
 ): boolean {
   if (marginThreshold <= 0) return false;
   if (candidates.length < 2) return false;
-  const top = candidates[0].rankScore;
+  // length ≥ 2 guaranteed by the guard above → indices 0 and 1 are in-bounds.
+  const top = candidates[0]!.rankScore;
   if (top <= 0) return false;
-  const gap = (top - candidates[1].rankScore) / top;
+  const gap = (top - candidates[1]!.rankScore) / top;
   return gap >= marginThreshold;
 }

--- a/src/search/internals/scoring.ts
+++ b/src/search/internals/scoring.ts
@@ -268,7 +268,7 @@ export function scoreRows({
     if (!salienceScoring) return 1;
     const s = (source as { salience?: unknown } | null)?.salience;
     return typeof s === 'number' && Number.isInteger(s) && s >= 0 && s <= 3
-      ? SALIENCE_WEIGHTS[s]
+      ? (SALIENCE_WEIGHTS[s] ?? 1)
       : 1;
   };
   // A penalty is only meaningful in (0,1]; anything else (unset, ≥1, invalid)

--- a/src/search/internals/time-range.ts
+++ b/src/search/internals/time-range.ts
@@ -93,14 +93,18 @@ function daySpans(query: string): Array<[number, number]> {
     }
   }
   for (const m of collect(DAY_MONTH_YEAR_RE, query)) {
-    const [d, mo, y] = [Number(m[1]), MONTHS[m[2].toLowerCase()], Number(m[3])];
-    if (validDay(y, mo, d)) {
+    const d = Number(m[1]);
+    const mo = MONTHS[m[2]?.toLowerCase() ?? ''];
+    const y = Number(m[3]);
+    if (mo !== undefined && validDay(y, mo, d)) {
       spans.push([dayStartMs(y, mo, d), dayStartMs(y, mo, d) + DAY_MS]);
     }
   }
   for (const m of collect(MONTH_DAY_YEAR_RE, query)) {
-    const [mo, d, y] = [MONTHS[m[1].toLowerCase()], Number(m[2]), Number(m[3])];
-    if (validDay(y, mo, d)) {
+    const mo = MONTHS[m[1]?.toLowerCase() ?? ''];
+    const d = Number(m[2]);
+    const y = Number(m[3]);
+    if (mo !== undefined && validDay(y, mo, d)) {
       spans.push([dayStartMs(y, mo, d), dayStartMs(y, mo, d) + DAY_MS]);
     }
   }
@@ -108,13 +112,15 @@ function daySpans(query: string): Array<[number, number]> {
 }
 
 function monthSpans(query: string): Array<[number, number]> {
-  return collect(MONTH_YEAR_RE, query)
-    .map((m): [number, number] => {
-      const mo = MONTHS[m[1].toLowerCase()];
-      const y = Number(m[2]);
-      return [Date.UTC(y, mo, 1), Date.UTC(y, mo + 1, 1)];
-    })
-    .filter(([f]) => Number.isFinite(f));
+  const spans: Array<[number, number]> = [];
+  for (const m of collect(MONTH_YEAR_RE, query)) {
+    const mo = MONTHS[m[1]?.toLowerCase() ?? ''];
+    const y = Number(m[2]);
+    if (mo === undefined) continue;
+    const from = Date.UTC(y, mo, 1);
+    if (Number.isFinite(from)) spans.push([from, Date.UTC(y, mo + 1, 1)]);
+  }
+  return spans;
 }
 
 function yearSpans(query: string): Array<[number, number]> {

--- a/src/search/search-rerank.service.ts
+++ b/src/search/search-rerank.service.ts
@@ -289,7 +289,10 @@ export class SearchRerankService {
       { 'cross_encoder.candidates': xInputs.length },
     );
     this.metrics?.countCrossEncoder(timedOut ? 'error' : 'invoked');
-    return xPerm.map((i) => wideCandidates[i]).slice(0, rerankWindow);
+    return xPerm
+      .map((i) => wideCandidates[i])
+      .filter((c): c is EntityBucket => c !== undefined)
+      .slice(0, rerankWindow);
   }
 
   private async runLlmRerank({
@@ -352,6 +355,8 @@ export class SearchRerankService {
       { 'rerank.candidates': rerankInputs.length },
     );
     this.metrics?.countRerank(timedOut ? 'error' : 'invoked');
-    return permutation.map((i) => candidatesForRerank[i]);
+    return permutation
+      .map((i) => candidatesForRerank[i])
+      .filter((c): c is EntityBucket => c !== undefined);
   }
 }

--- a/src/synthesize/date-math.ts
+++ b/src/synthesize/date-math.ts
@@ -68,8 +68,10 @@ export function buildDateMathLines(hits: SearchHit[]): string[] {
     const iso = d.toISOString().slice(0, 10);
     const weekday = WEEKDAYS[d.getUTCDay()];
     if (i === 0) return `${iso} = ${weekday}`;
-    const prev = new Date(days[i - 1]);
-    const gap = Math.round((ms - days[i - 1]) / DAY_MS);
+    // i ≥ 1 here → days[i-1] is an in-bounds element of the mapped array.
+    const prevMs = days[i - 1]!;
+    const prev = new Date(prevMs);
+    const gap = Math.round((ms - prevMs) / DAY_MS);
     return `${iso} = ${weekday}, ${gap} day${gap === 1 ? '' : 's'} after ${prev.toISOString().slice(0, 10)}`;
   });
 }

--- a/src/synthesize/evidence-collector.service.ts
+++ b/src/synthesize/evidence-collector.service.ts
@@ -399,12 +399,12 @@ export class EvidenceCollectorService {
     // 'fused' retrieves them as scored SearchHits inside search, so
     // appending them here would duplicate the evidence.
     const [
-      laneLines,
-      sourceLines,
-      segmentLines,
-      scanLines,
-      windowLines,
-      assistantLines,
+      laneLines = [],
+      sourceLines = [],
+      segmentLines = [],
+      scanLines = [],
+      windowLines = [],
+      assistantLines = [],
     ] = await Promise.all([
         active
           ? this.episodeLane

--- a/src/synthesize/lex-leg.ts
+++ b/src/synthesize/lex-leg.ts
@@ -59,7 +59,8 @@ export function buildLexMatchLeg(opts: {
     const scores = fields.map((_, j) => `search::score(${j + 1})`);
     return {
       where: `(${matchers.join(' OR ')})`,
-      score: scores.length === 1 ? scores[0] : `math::max([${scores.join(', ')}])`,
+      score:
+        scores.length === 1 ? scores[0]! : `math::max([${scores.join(', ')}])`,
       params: { topic },
     };
   }
@@ -74,7 +75,7 @@ export function buildLexMatchLeg(opts: {
       return `search::score(${ref})`;
     });
     perTerm.push(
-      scores.length === 1 ? scores[0] : `math::max([${scores.join(', ')}])`,
+      scores.length === 1 ? scores[0]! : `math::max([${scores.join(', ')}])`,
     );
   });
   return {

--- a/src/synthesize/mention-scan.ts
+++ b/src/synthesize/mention-scan.ts
@@ -233,7 +233,7 @@ export function dedupeMentionLines(lines: string[]): string[] {
 export function pickMentionLine(segmentText: string, terms: string[]): string {
   const lines = (segmentText ?? '').split('\n').filter((l) => l.trim());
   if (lines.length === 0) return '';
-  let bestLine = lines[0];
+  let bestLine = lines[0]!; // non-empty guaranteed by the guard above
   let bestScore = 0;
   for (const line of lines) {
     const lower = line.toLowerCase();

--- a/src/synthesize/segment-lane.service.ts
+++ b/src/synthesize/segment-lane.service.ts
@@ -128,7 +128,10 @@ export class SegmentLaneService {
           body: s.text.slice(0, 600),
         })),
       );
-      return order.slice(0, topK).map((i) => fused[i]);
+      return order
+        .slice(0, topK)
+        .map((i) => fused[i])
+        .filter((s): s is SegmentRow => s !== undefined);
     } catch (e) {
       this.logger.warn(`segment rerank failed: ${(e as Error).message}`);
       return fused.slice(0, topK);

--- a/src/synthesize/synthesize.helpers.ts
+++ b/src/synthesize/synthesize.helpers.ts
@@ -147,7 +147,7 @@ function extractInlineCitations(answer: string): string[] {
   const ids: string[] = [];
   const re = /\[((?:knowledge_fact[:_]|fact[:_])?[A-Za-z0-9]{6,})\]/g;
   let m: RegExpExecArray | null;
-  while ((m = re.exec(answer)) !== null) ids.push(m[1]);
+  while ((m = re.exec(answer)) !== null) ids.push(m[1]!); // group 1 is mandatory
   return ids;
 }
 

--- a/test/abac-action-gate.e2e-spec.ts
+++ b/test/abac-action-gate.e2e-spec.ts
@@ -48,7 +48,8 @@ describe('ABAC action gate (enforce + report_only)', () => {
         { scopes: ['brain:read', 'brain:write'], policies: ['watcher'] },
       ],
     });
-    [readonlyKey, watcherKey] = f.extraApiKeys;
+    readonlyKey = f.extraApiKeys[0]!;
+    watcherKey = f.extraApiKeys[1]!;
     for (const doc of [READONLY_DOC, WATCHER_DOC]) {
       const r = await f.http
         .post('/v1/admin/policy-sets')
@@ -210,7 +211,7 @@ describe('ABAC master switch off — attached policies are inert', () => {
         { scopes: ['brain:read', 'brain:write'], policies: ['readonly-agent'] },
       ],
     });
-    [restrictedKey] = f.extraApiKeys;
+    restrictedKey = f.extraApiKeys[0]!;
   });
 
   afterAll(async () => {

--- a/test/abac-meta-projection.e2e-spec.ts
+++ b/test/abac-meta-projection.e2e-spec.ts
@@ -40,7 +40,7 @@ describe('ABAC source.meta projection', () => {
         { scopes: ['brain:read', 'brain:write'], policies: ['no-pii-class'] },
       ],
     });
-    [restrictedKey] = f.extraApiKeys;
+    restrictedKey = f.extraApiKeys[0]!;
     const created = await f.http
       .post('/v1/admin/policy-sets')
       .set(auth())

--- a/test/abac-meta-union.e2e-spec.ts
+++ b/test/abac-meta-union.e2e-spec.ts
@@ -55,7 +55,7 @@ describe('ABAC meta union + backfill + temporal windows', () => {
         { scopes: ['brain:read', 'brain:write'], policies: ['no-pii-meta'] },
       ],
     });
-    [restrictedKey] = f.extraApiKeys;
+    restrictedKey = f.extraApiKeys[0]!;
     const created = await f.http
       .post('/v1/admin/policy-sets')
       .set(auth())

--- a/test/abac-row-filter.e2e-spec.ts
+++ b/test/abac-row-filter.e2e-spec.ts
@@ -136,7 +136,9 @@ describe('ABAC row filter across read surfaces', () => {
           { scopes: ['brain:read', 'brain:write'], policies: ['shadow-no-hr'] },
         ],
       });
-      [noHrKey, supportOnlyKey, shadowKey] = f.extraApiKeys;
+      noHrKey = f.extraApiKeys[0]!;
+      supportOnlyKey = f.extraApiKeys[1]!;
+      shadowKey = f.extraApiKeys[2]!;
       for (const doc of [NO_HR_DOC, SUPPORT_ONLY_DOC, SHADOW_DOC]) {
         const r = await f.http
           .post('/v1/admin/policy-sets')

--- a/test/abac-simulate.e2e-spec.ts
+++ b/test/abac-simulate.e2e-spec.ts
@@ -43,7 +43,7 @@ describe('ABAC simulation surface', () => {
         { scopes: ['brain:read', 'brain:write'], policies: ['support-reader'] },
       ],
     });
-    [attachedKey] = f.extraApiKeys;
+    attachedKey = f.extraApiKeys[0]!;
     void attachedKey;
     const created = await f.http
       .post('/v1/admin/policy-sets')

--- a/test/agent-qa.unit-spec.ts
+++ b/test/agent-qa.unit-spec.ts
@@ -236,8 +236,8 @@ describe('AgentQaService', () => {
         question: 'How many hikes?',
         callerScopes: ['brain:read'],
       });
-      expect(queries[0].sql).toContain('derivedVersion = $dv');
-      expect(queries[0].params?.dv).toBe('wd-v2');
+      expect(queries[0]!.sql).toContain('derivedVersion = $dv');
+      expect(queries[0]!.params?.dv).toBe('wd-v2');
       const rendered = toolMsgs.find((m) => m.includes('hike'));
       // Chronological: first hike before later hike.
       expect(rendered!.indexOf('first hike')).toBeLessThan(
@@ -305,8 +305,8 @@ describe('AgentQaService', () => {
         question: 'Who performed?',
         callerScopes: ['brain:read'],
       });
-      expect(queries[0].sql).toContain('@1@');
-      expect(queries[0].sql).toContain('piiClass IS NONE');
+      expect(queries[0]!.sql).toContain('@1@');
+      expect(queries[0]!.sql).toContain('piiClass IS NONE');
       expect(toolMsgs.some((m) => m.includes('Matt Patterson sang'))).toBe(
         true,
       );

--- a/test/aggregate-composer.unit-spec.ts
+++ b/test/aggregate-composer.unit-spec.ts
@@ -78,17 +78,17 @@ describe('AggregateComposerService (Lane C v1)', () => {
     expect(res).toMatchObject({ entities: 1, aggregatesWritten: 2, skipped: [] });
     const deletes = queries.filter((q) => q.sql.includes('DELETE knowledge_fact'));
     expect(deletes).toHaveLength(1);
-    expect(deletes[0].params?.recorder).toBe(AGGREGATE_RECORDER);
+    expect(deletes[0]!.params?.recorder).toBe(AGGREGATE_RECORDER);
     // Atomic swap (audit W2): delete + insert share ONE transaction —
     // a reader never sees the entity stripped of its aggregates.
-    expect(deletes[0].sql).toContain('BEGIN TRANSACTION');
-    expect(deletes[0].sql).toContain('INSERT INTO knowledge_fact');
-    const rows = deletes[0].params?.rows as Array<Record<string, unknown>>;
+    expect(deletes[0]!.sql).toContain('BEGIN TRANSACTION');
+    expect(deletes[0]!.sql).toContain('INSERT INTO knowledge_fact');
+    const rows = deletes[0]!.params?.rows as Array<Record<string, unknown>>;
     expect(rows).toHaveLength(2);
-    expect(rows[0].predicate).toBe('aggregate_pets_');
-    expect(rows[1].predicate).toBe('aggregate_activities');
-    expect((rows[0].derivedFrom as unknown[]).length).toBe(2);
-    expect(rows[0].embedding).toEqual([1, 0]);
+    expect(rows[0]!.predicate).toBe('aggregate_pets_');
+    expect(rows[1]!.predicate).toBe('aggregate_activities');
+    expect((rows[0]!.derivedFrom as unknown[]).length).toBe(2);
+    expect(rows[0]!.embedding).toEqual([1, 0]);
   });
 
   it('filters aggregates with <2 members or out-of-range indexes', async () => {
@@ -143,7 +143,7 @@ describe('AggregateComposerService (Lane C v1)', () => {
       q.sql.includes('INSERT INTO knowledge_fact'),
     );
     const rows = swap?.params?.rows as Array<Record<string, unknown>>;
-    expect(rows[0].derivedVersion).toBe('wd-v2');
+    expect(rows[0]!.derivedVersion).toBe('wd-v2');
     const del = queries.find((q) => q.sql.includes('DELETE knowledge_fact'));
     expect(del?.sql).toContain('derivedVersion = $version');
   });

--- a/test/answer-cache.e2e-spec.ts
+++ b/test/answer-cache.e2e-spec.ts
@@ -89,7 +89,7 @@ describe('G1 answer cache e2e', () => {
     expect(state1.calls.length).toBe(2); // generator + verifier ran
     const afterStore = await cacheRows();
     expect(afterStore).toHaveLength(1);
-    expect(afterStore[0].hitCount).toBe(0);
+    expect(afterStore[0]!.hitCount).toBe(0);
 
     // Second identical query (typographic variant): served from the
     // cache — the scripted DIFFERENT answer must never surface, and
@@ -107,7 +107,7 @@ describe('G1 answer cache e2e', () => {
     expect(state2.calls.length).toBe(0);
     const afterServe = await cacheRows();
     expect(afterServe).toHaveLength(1);
-    expect(afterServe[0].hitCount).toBe(1);
+    expect(afterServe[0]!.hitCount).toBe(1);
   });
 
   it('retracting a cited fact → check-on-read invalidates (cause=retracted) and re-synthesizes', async () => {
@@ -131,7 +131,7 @@ describe('G1 answer cache e2e', () => {
     // path) — the invalidated row must survive with its cause.
     const rows = await cacheRows();
     expect(rows).toHaveLength(1);
-    expect(rows[0].invalidationCause).toBe('retracted');
+    expect(rows[0]!.invalidationCause).toBe('retracted');
   });
 
   it('cross-user isolation: same query, different user scope → miss', async () => {

--- a/test/answer-cache.unit-spec.ts
+++ b/test/answer-cache.unit-spec.ts
@@ -288,13 +288,13 @@ describe('AnswerCacheService.begin — serving', () => {
   it('tenant + user double-fence in the lookup WHERE clause', async () => {
     const h = makeHarness({ cacheRow: null });
     await h.svc.begin(beginArgs({ userId: 'user_a' }));
-    const lookup = h.calls[0];
+    const lookup = h.calls[0]!;
     expect(lookup.sql).toContain('companyId = $companyId');
     expect(lookup.sql).toContain('userId = $userId');
     expect(lookup.params.userId).toBe('user_a');
     const h2 = makeHarness({ cacheRow: null });
     await h2.svc.begin(beginArgs());
-    expect(h2.calls[0].sql).toContain('userId IS NONE');
+    expect(h2.calls[0]!.sql).toContain('userId IS NONE');
   });
 });
 

--- a/test/answer-lang.e2e-spec.ts
+++ b/test/answer-lang.e2e-spec.ts
@@ -44,7 +44,7 @@ describe('Phase 4.C e2e — answerLang in generator prompt', () => {
       .send({ query: 'engineer', answerLang: 'ru' });
     expect(res.status).toBe(201);
     expect(state.calls.length).toBeGreaterThan(0);
-    expect(state.calls[0].user).toContain('write your answer in ru');
+    expect(state.calls[0]!.user).toContain('write your answer in ru');
   });
 
   it('falls back to detected query language when DTO omits answerLang', async () => {
@@ -58,6 +58,6 @@ describe('Phase 4.C e2e — answerLang in generator prompt', () => {
       .send({ query: 'кто здесь технический директор' });
     expect(res.status).toBe(201);
     expect(state.calls.length).toBeGreaterThan(0);
-    expect(state.calls[0].user).toContain('write your answer in ru');
+    expect(state.calls[0]!.user).toContain('write your answer in ru');
   });
 });

--- a/test/answer-router.unit-spec.ts
+++ b/test/answer-router.unit-spec.ts
@@ -276,8 +276,8 @@ describe('detectEvidenceConflicts (T3)', () => {
       ]),
     ], LANES);
     expect(conflicts).toHaveLength(1);
-    expect(conflicts[0].label).toBe('has_api_key');
-    expect(conflicts[0].factIds).toEqual([
+    expect(conflicts[0]!.label).toBe('has_api_key');
+    expect(conflicts[0]!.factIds).toEqual([
       'knowledge_fact:f0',
       'knowledge_fact:f1',
     ]);

--- a/test/app-fixture.ts
+++ b/test/app-fixture.ts
@@ -61,7 +61,7 @@ export async function createApp(opts: {
     },
     ...(opts.extraKeys ?? []).map((k, i) => ({
       keyHash:
-        'sha256:' + createHash('sha256').update(extraApiKeys[i]).digest('hex'),
+        'sha256:' + createHash('sha256').update(extraApiKeys[i]!).digest('hex'),
       companyId,
       scopes: k.scopes,
       ...(k.policies ? { policies: k.policies } : {}),

--- a/test/arc-composer.unit-spec.ts
+++ b/test/arc-composer.unit-spec.ts
@@ -135,14 +135,14 @@ describe('ArcComposerService (V9 §3)', () => {
     expect(swap?.sql).toContain('INSERT INTO knowledge_fact');
     const rows = swap?.params?.rows as Array<Record<string, unknown>>;
     expect(rows).toHaveLength(2);
-    expect(rows[0].predicate).toBe('summary_arc_apartment_move_');
-    expect(rows[1].predicate).toBe('summary_arc_running');
-    expect((rows[0].derivedFrom as unknown[]).length).toBe(3);
-    expect(rows[0].embedding).toEqual([1, 0]);
-    expect((rows[0].validFrom as Date).toISOString().slice(0, 10)).toBe(
+    expect(rows[0]!.predicate).toBe('summary_arc_apartment_move_');
+    expect(rows[1]!.predicate).toBe('summary_arc_running');
+    expect((rows[0]!.derivedFrom as unknown[]).length).toBe(3);
+    expect(rows[0]!.embedding).toEqual([1, 0]);
+    expect((rows[0]!.validFrom as Date).toISOString().slice(0, 10)).toBe(
       '2024-06-12',
     );
-    expect(rows[0].source).toMatchObject({ recorder: ARC_RECORDER });
+    expect(rows[0]!.source).toMatchObject({ recorder: ARC_RECORDER });
   });
 
   it('sources exclude both composers and the summary_ prefix', async () => {
@@ -198,7 +198,7 @@ describe('ArcComposerService (V9 §3)', () => {
       q.sql.includes('INSERT INTO knowledge_fact'),
     );
     const rows = swap?.params?.rows as Array<Record<string, unknown>>;
-    expect(rows[0].derivedVersion).toBe('wd-v9');
+    expect(rows[0]!.derivedVersion).toBe('wd-v9');
   });
 
   it('records per-entity failures without failing the run', async () => {

--- a/test/artifacts-user-scope.e2e-spec.ts
+++ b/test/artifacts-user-scope.e2e-spec.ts
@@ -49,7 +49,7 @@ describe('artifacts respect per-user scope', () => {
         `SELECT entityId FROM type::record('knowledge_fact', $tail)`,
         { tail: (anchor.factId as string).split(':')[1] },
       );
-      return String((rows as Array<{ entityId: unknown }>)[0].entityId);
+      return String((rows as Array<{ entityId: unknown }>)[0]!.entityId);
     });
 
     // Personal name on the SAME shared entity (bare-entityId + userId).

--- a/test/aspect-rollups.unit-spec.ts
+++ b/test/aspect-rollups.unit-spec.ts
@@ -35,18 +35,18 @@ describe('composeAspectRollups', () => {
       m('e1', 'work', 'Melanie got promoted.', '2023-06-01'),
     ]);
     expect(out).toHaveLength(1);
-    expect(out[0].predicate).toBe('activities_rollup');
-    expect(out[0].memberCount).toBe(3);
+    expect(out[0]!.predicate).toBe('activities_rollup');
+    expect(out[0]!.memberCount).toBe(3);
     // Chronological member order with day stamps.
-    const i1 = out[0].object.indexOf('pottery');
-    const i2 = out[0].object.indexOf('swam');
-    const i3 = out[0].object.indexOf('camping');
+    const i1 = out[0]!.object.indexOf('pottery');
+    const i2 = out[0]!.object.indexOf('swam');
+    const i3 = out[0]!.object.indexOf('camping');
     expect(i1).toBeGreaterThan(-1);
     expect(i1).toBeLessThan(i2);
     expect(i2).toBeLessThan(i3);
-    expect(out[0].object).toContain('(2023-05-01)');
+    expect(out[0]!.object).toContain('(2023-05-01)');
     // validFrom = newest member.
-    expect(out[0].validFrom.toISOString().slice(0, 10)).toBe('2023-07-01');
+    expect(out[0]!.validFrom.toISOString().slice(0, 10)).toBe('2023-07-01');
   });
 
   it('dedupes identical texts and holds the member floor', () => {
@@ -83,9 +83,9 @@ describe('composeAspectRollups', () => {
     const out = composeAspectRollups(members, { charCap: 800 });
     expect(out).toHaveLength(1);
     // The header/suffix envelope rides INSIDE the cap now.
-    expect(out[0].object.length).toBeLessThanOrEqual(800);
-    expect(out[0].object).toContain('and');
-    expect(out[0].object).toMatch(/…and \d+ more$/);
+    expect(out[0]!.object.length).toBeLessThanOrEqual(800);
+    expect(out[0]!.object).toContain('and');
+    expect(out[0]!.object).toMatch(/…and \d+ more$/);
   });
 
   it('drops a group whose cap keeps fewer than the floor', () => {
@@ -107,8 +107,8 @@ describe('composeAspectRollups V13 review fixes', () => {
       m('e1', 'activities', 'Swam in the lake.', '2023-06-01'),
     ]);
     expect(out).toHaveLength(1);
-    expect(out[0].object).not.toContain('(2023-06-12)');
-    expect(out[0].object).toContain('(2023-05-01)');
+    expect(out[0]!.object).not.toContain('(2023-06-12)');
+    expect(out[0]!.object).toContain('(2023-05-01)');
   });
 
   it('duplicate texts keep the EARLIEST-dated copy', () => {
@@ -119,8 +119,8 @@ describe('composeAspectRollups V13 review fixes', () => {
       m('e1', 'events', 'Baked bread.', '2023-07-01'),
     ]);
     expect(out).toHaveLength(1);
-    expect(out[0].object).toContain('(2023-03-01)');
-    expect(out[0].object).not.toContain('(2023-05-10)');
+    expect(out[0]!.object).toContain('(2023-03-01)');
+    expect(out[0]!.object).not.toContain('(2023-05-10)');
   });
 
   it('unions member episodeIds capped and deduped', () => {
@@ -129,6 +129,6 @@ describe('composeAspectRollups V13 review fixes', () => {
       m('e1', 'events', 'B.', '2023-05-02', { episodeIds: ['ep2', 'ep3'] }),
       m('e1', 'events', 'C.', '2023-05-03'),
     ]);
-    expect(out[0].episodeIds).toEqual(['ep1', 'ep2', 'ep3']);
+    expect(out[0]!.episodeIds).toEqual(['ep1', 'ep2', 'ep3']);
   });
 });

--- a/test/audit-p2-hotpath.unit-spec.ts
+++ b/test/audit-p2-hotpath.unit-spec.ts
@@ -56,7 +56,7 @@ describe('applyOutputShaping tokenBudget (one-pass)', () => {
       tokenBudget: 800,
     } as SearchDto);
     out.forEach((hit, i) => {
-      expect(hit.entityId).toBe(hits[i].entityId);
+      expect(hit.entityId).toBe(hits[i]!.entityId);
     });
   });
 

--- a/test/beam-loader.unit-spec.ts
+++ b/test/beam-loader.unit-spec.ts
@@ -55,8 +55,8 @@ describe('BEAM loader', () => {
     await fs.writeFile(file, JSON.stringify([conv]));
     const loaded = await loadBeam(file);
     expect(loaded).toHaveLength(1);
-    expect(loaded[0].questions[0].ability).toBe('abstention');
-    expect(loaded[0].sessions[1].turns[0].content).toBe('later session');
+    expect(loaded[0]!.questions[0]!.ability).toBe('abstention');
+    expect(loaded[0]!.sessions[1]!.turns[0]!.content).toBe('later session');
   });
 
   it('rejects an empty dataset', async () => {

--- a/test/billing-client.socket-spec.ts
+++ b/test/billing-client.socket-spec.ts
@@ -95,7 +95,7 @@ describe('BillingClientService', () => {
         }
         const ent = /^\/v1\/entitlements\/(.+)$/.exec(url);
         if (req.method === 'GET' && ent) {
-          return respond(200, entitlements[decodeURIComponent(ent[1])] ?? []);
+          return respond(200, entitlements[decodeURIComponent(ent[1]!)] ?? []);
         }
         return respond(404, { message: 'no such stub route' });
       });
@@ -142,7 +142,7 @@ describe('BillingClientService', () => {
 
   it('sends the service key as x-api-key on every call', async () => {
     await client.hasEntitlement({ companyId: 'co_a', key: 'domain_pack:x' });
-    expect(seen[0].headers['x-api-key']).toBe('svc-key-test');
+    expect(seen[0]!.headers['x-api-key']).toBe('svc-key-test');
   });
 
   describe('hasEntitlement + cache', () => {

--- a/test/candidate-grounding.unit-spec.ts
+++ b/test/candidate-grounding.unit-spec.ts
@@ -27,10 +27,10 @@ describe('groundExternalBatch', () => {
       relations: [],
     });
     expect(out.entities).toHaveLength(1);
-    expect(out.entities[0].name).toBe('Acme Corp');
-    expect(out.entities[0].entityIndex).toBe(0); // compacted
+    expect(out.entities[0]!.name).toBe('Acme Corp');
+    expect(out.entities[0]!.entityIndex).toBe(0); // compacted
     expect(out.facts).toHaveLength(1);
-    expect(out.facts[0].entityIndex).toBe(0); // remapped 1 → 0
+    expect(out.facts[0]!.entityIndex).toBe(0); // remapped 1 → 0
     expect(out.dropped).toEqual([
       expect.objectContaining({ kind: 'entity', reason: 'ungrounded_entity' }),
     ]);

--- a/test/candidate-merge.unit-spec.ts
+++ b/test/candidate-merge.unit-spec.ts
@@ -47,7 +47,7 @@ describe('mergeCandidates', () => {
     ];
     const out = mergeCandidates(rows);
     expect(out.entities).toHaveLength(1);
-    expect(out.entities[0].candidateIds).toHaveLength(2);
+    expect(out.entities[0]!.candidateIds).toHaveLength(2);
   });
 
   it('folds a bare-name entity with a canonical-bearing one via alias union', () => {
@@ -83,9 +83,9 @@ describe('mergeCandidates', () => {
     ];
     const out = mergeCandidates(rows);
     expect(out.entities).toHaveLength(1);
-    expect(out.entities[0].candidateIds).toHaveLength(2);
+    expect(out.entities[0]!.candidateIds).toHaveLength(2);
     expect(out.facts).toHaveLength(1);
-    expect(out.facts[0].contributors).toHaveLength(2);
+    expect(out.facts[0]!.contributors).toHaveLength(2);
     expect(out.rejected).toHaveLength(0);
   });
 
@@ -129,7 +129,7 @@ describe('mergeCandidates', () => {
     ];
     const out = mergeCandidates(rows);
     expect(out.facts).toHaveLength(1);
-    const f = out.facts[0];
+    const f = out.facts[0]!;
     expect(f.confidence).toBe(0.9); // max, not noisy-or
     expect(f.recorder).toBe('meetings'); // leader's indexer
     expect(f.contributors).toHaveLength(2);
@@ -182,7 +182,7 @@ describe('mergeCandidates', () => {
     const out = mergeCandidates(rows);
     expect(out.entities).toHaveLength(2);
     const globexKey = out.entities.find((e) => e.name === 'Globex')!.key;
-    expect(out.facts[0].entityKey).toBe(globexKey);
+    expect(out.facts[0]!.entityKey).toBe(globexKey);
   });
 
   it('dedupes relations by (from, to, kind) and rejects self-loops', () => {
@@ -209,7 +209,7 @@ describe('mergeCandidates', () => {
     ];
     const out = mergeCandidates(rows);
     expect(out.relations).toHaveLength(1);
-    expect(out.relations[0].confidence).toBe(0.8);
+    expect(out.relations[0]!.confidence).toBe(0.8);
     expect(out.rejected).toEqual([
       expect.objectContaining({ kind: 'relation', reason: 'orphan_relation' }),
     ]);

--- a/test/candidate-redaction.unit-spec.ts
+++ b/test/candidate-redaction.unit-spec.ts
@@ -55,13 +55,13 @@ const isRedacted = (c: CandidateRow) =>
 describe('redactGatedCandidates', () => {
   it('leaves a non-PII candidate visible when no scope/policy gates it', () => {
     const [c] = redactGatedCandidates([factCandidate('tier')], ['brain:read'], null);
-    expect(c.payload.object).toBe('secret value');
-    expect(c.payload.clause).toBe('the source sentence');
+    expect(c!.payload.object).toBe('secret value');
+    expect(c!.payload.clause).toBe('the source sentence');
   });
 
   it('redacts object AND clause of a PII candidate without brain:read_pii', () => {
     const [c] = redactGatedCandidates([factCandidate('dob')], ['brain:read'], null);
-    expect(isRedacted(c)).toBe(true);
+    expect(isRedacted(c!)).toBe(true);
   });
 
   it('shows the PII candidate to a caller holding brain:read_pii', () => {
@@ -70,7 +70,7 @@ describe('redactGatedCandidates', () => {
       ['brain:read', 'brain:read_pii'],
       null,
     );
-    expect(c.payload.object).toBe('secret value');
+    expect(c!.payload.object).toBe('secret value');
   });
 
   it('redacts a candidate an enforced ABAC rule denies (by predicate)', () => {
@@ -84,14 +84,14 @@ describe('redactGatedCandidates', () => {
       },
     ]);
     const [denied] = redactGatedCandidates([factCandidate('tier')], ['brain:read'], ctx);
-    expect(isRedacted(denied)).toBe(true);
+    expect(isRedacted(denied!)).toBe(true);
     // A different predicate the rule doesn't target stays visible.
     const [kept] = redactGatedCandidates(
       [factCandidate('preference')],
       ['brain:read'],
       ctx,
     );
-    expect(kept.payload.object).toBe('secret value');
+    expect(kept!.payload.object).toBe('secret value');
   });
 
   it('never touches non-fact candidates', () => {
@@ -114,7 +114,7 @@ describe('redactGatedCandidates', () => {
       },
     ]);
     const [c] = redactGatedCandidates([entity], ['brain:read'], denyAll);
-    expect(c.payload.name).toBe('Acme Corp');
-    expect(c.payload.redacted).toBeUndefined();
+    expect(c!.payload.name).toBe('Acme Corp');
+    expect(c!.payload.redacted).toBeUndefined();
   });
 });

--- a/test/changefeed-consumer.unit-spec.ts
+++ b/test/changefeed-consumer.unit-spec.ts
@@ -100,7 +100,7 @@ describe('ChangefeedDrainService', () => {
     );
     expect(inserts).toHaveLength(1);
     expect(
-      ((inserts[0].params?.events ?? []) as unknown[]).length,
+      ((inserts[0]!.params?.events ?? []) as unknown[]).length,
     ).toBe(2);
     // SHOW CHANGES must carry a LIMIT so a cold cursor can't materialise
     // the whole 30-day retention into the process.
@@ -146,7 +146,7 @@ describe('ChangefeedDrainService', () => {
     const inserts = calls.filter((c) =>
       c.sql.startsWith('INSERT INTO audit_event'),
     );
-    expect(((inserts[0].params?.events ?? []) as unknown[]).length).toBe(1);
+    expect(((inserts[0]!.params?.events ?? []) as unknown[]).length).toBe(1);
     const advance = calls.find((c) =>
       c.sql.startsWith('UPSERT changefeed_state'),
     );

--- a/test/chat-router-hints.unit-spec.ts
+++ b/test/chat-router-hints.unit-spec.ts
@@ -101,8 +101,8 @@ describe('extractPredicateHintsLocally', () => {
       maxHints: 3,
     });
     expect(hints).toHaveLength(1);
-    expect(hints[0].predicateId).toBe('address');
-    expect(hints[0].similarity).toBeCloseTo(1, 5);
+    expect(hints[0]!.predicateId).toBe('address');
+    expect(hints[0]!.similarity).toBeCloseTo(1, 5);
   });
 
   it('sorts hints by similarity descending and caps at maxHints', async () => {
@@ -121,8 +121,8 @@ describe('extractPredicateHintsLocally', () => {
       maxHints: 2,
     });
     expect(hints).toHaveLength(2);
-    expect(hints[0].predicateId).toBe('address');
-    expect(hints[1].predicateId).toBe('email');
+    expect(hints[0]!.predicateId).toBe('address');
+    expect(hints[1]!.predicateId).toBe('email');
   });
 
   it('drops predicates whose similarity is below threshold', async () => {
@@ -165,7 +165,7 @@ describe('extractPredicateHintsLocally', () => {
       threshold: 0.4,
       maxHints: 3,
     });
-    expect(hints[0].triggerSpan).toEqual({
+    expect(hints[0]!.triggerSpan).toEqual({
       text: 'where Maria lives',
       start: 0,
       end: 17,

--- a/test/clause-splitter.unit-spec.ts
+++ b/test/clause-splitter.unit-spec.ts
@@ -13,7 +13,7 @@ describe('splitClauses', () => {
   it('single sentence, no conjunction → 1 clause', () => {
     const out = splitClauses('Maria is the CTO at Acme.');
     expect(out).toHaveLength(1);
-    expect(out[0].text).toBe('Maria is the CTO at Acme');
+    expect(out[0]!.text).toBe('Maria is the CTO at Acme');
   });
 
   it('two sentences → 2 clauses', () => {
@@ -67,8 +67,8 @@ describe('splitClauses', () => {
   it('returns offsets that point at the original message slice', () => {
     const src = 'Maria is CTO. She lives in Berlin.';
     const out = splitClauses(src);
-    expect(src.slice(out[0].start, out[0].end)).toBe('Maria is CTO');
-    expect(src.slice(out[1].start, out[1].end)).toBe('She lives in Berlin');
+    expect(src.slice(out[0]!.start, out[0]!.end)).toBe('Maria is CTO');
+    expect(src.slice(out[1]!.start, out[1]!.end)).toBe('She lives in Berlin');
   });
 
   it('does not split on lowercase after period (URLs / abbreviations OK)', () => {
@@ -82,7 +82,7 @@ describe('splitClauses', () => {
     const out = splitClauses(
       'She moved from Berlin and prefers vegan lunch!!',
     );
-    expect(out[1].text).toBe('prefers vegan lunch');
+    expect(out[1]!.text).toBe('prefers vegan lunch');
   });
 
   it('preserves multiple inner conjunctions', () => {

--- a/test/code-memory-anchor.e2e-spec.ts
+++ b/test/code-memory-anchor.e2e-spec.ts
@@ -82,6 +82,6 @@ describe('code-memory Phase 2b — anchor re-validation service', () => {
 
     const viaNew = await activeCodeFacts(ANCHOR_B_NEW);
     expect(viaNew.length).toBe(1);
-    expect(viaNew[0].object).toMatch(/subtle trap/);
+    expect(viaNew[0]!.object).toMatch(/subtle trap/);
   });
 });

--- a/test/code-memory-capture-io.unit-spec.ts
+++ b/test/code-memory-capture-io.unit-spec.ts
@@ -66,7 +66,7 @@ describe('parseCandidates — grounding', () => {
     });
     const out = parseCandidates(raw, single);
     expect(out).toHaveLength(1);
-    expect(out[0].anchor).toBe('src/only.ts');
+    expect(out[0]!.anchor).toBe('src/only.ts');
   });
 
   it('parses fenced ```json``` and skips invalid kinds', () => {
@@ -74,7 +74,7 @@ describe('parseCandidates — grounding', () => {
       '```json\n{"decisions":[{"kind":"nonsense","text":"x","anchor":"src/ingest/ingest.service.ts"},{"kind":"because","text":"real","anchor":"src/ingest/ingest.service.ts"}]}\n```';
     const out = parseCandidates(raw, COMMIT);
     expect(out).toHaveLength(1);
-    expect(out[0].kind).toBe('because');
+    expect(out[0]!.kind).toBe('because');
   });
 
   it('returns [] on unparseable output', () => {
@@ -176,14 +176,14 @@ describe('parseGitLog', () => {
       `${RS}a1211e8${FS}2026-06-27T09:00:00Z${FS}chore: bump${FS}\npackage.json\n`;
     const commits = parseGitLog(raw);
     expect(commits).toHaveLength(2);
-    expect(commits[0].sha).toBe('f0e824b');
-    expect(commits[0].authorDate).toBe('2026-06-28T10:00:00Z');
-    expect(commits[0].message).toMatch(/split service/);
-    expect(commits[0].changedFiles).toEqual([
+    expect(commits[0]!.sha).toBe('f0e824b');
+    expect(commits[0]!.authorDate).toBe('2026-06-28T10:00:00Z');
+    expect(commits[0]!.message).toMatch(/split service/);
+    expect(commits[0]!.changedFiles).toEqual([
       'src/ingest/fact-resolver.service.ts',
       'src/ingest/ingest.service.ts',
     ]);
-    expect(commits[1].changedFiles).toEqual(['package.json']);
+    expect(commits[1]!.changedFiles).toEqual(['package.json']);
   });
 
   it('returns [] on empty input', () => {

--- a/test/code-memory-capture.unit-spec.ts
+++ b/test/code-memory-capture.unit-spec.ts
@@ -153,7 +153,7 @@ describe('runCapturePipeline', () => {
     expect(summary.recorded).toBe(1);
     expect(summary.failures).toBe(0);
     expect(sink.recorded).toHaveLength(1);
-    expect(sink.recorded[0].anchor).toMatch(/fact-resolver/);
+    expect(sink.recorded[0]!.anchor).toMatch(/fact-resolver/);
   });
 
   it('counts an extractor failure without aborting the run', async () => {

--- a/test/code-memory.e2e-spec.ts
+++ b/test/code-memory.e2e-spec.ts
@@ -77,7 +77,7 @@ describe('code-memory Phase 0 — record_decision → why round-trip', () => {
     expect(profile).not.toBeNull();
     const decided = activeOf(profile, 'decided');
     expect(decided).toHaveLength(1);
-    expect(decided[0].object).toMatch(/one fn::resolve_fact gateway/);
+    expect(decided[0]!.object).toMatch(/one fn::resolve_fact gateway/);
   });
 
   it('re-deciding the same anchor supersedes the prior decision (single_active)', async () => {
@@ -94,7 +94,7 @@ describe('code-memory Phase 0 — record_decision → why round-trip', () => {
     const profile = await recall();
     const activeDecided = activeOf(profile, 'decided');
     expect(activeDecided).toHaveLength(1);
-    expect(activeDecided[0].object).toMatch(/HyPE alt-embedding/);
+    expect(activeDecided[0]!.object).toMatch(/HyPE alt-embedding/);
   });
 
   it('gotcha is append_only — accumulates instead of superseding', async () => {

--- a/test/collapse-pattern.unit-spec.ts
+++ b/test/collapse-pattern.unit-spec.ts
@@ -36,9 +36,9 @@ describe('extractCollapseEditsLocally', () => {
     const snap = mkSnap([['moved to', 'lives in']]);
     const out = extractCollapseEditsLocally('Maria moved to Berlin', snap);
     expect(out).toHaveLength(1);
-    expect(out[0].pattern).toBe('moved to');
-    expect(out[0].replacement).toBe('lives in');
-    expect(out[0].span).toEqual({
+    expect(out[0]!.pattern).toBe('moved to');
+    expect(out[0]!.replacement).toBe('lives in');
+    expect(out[0]!.span).toEqual({
       text: 'moved to',
       start: 6,
       end: 14,
@@ -55,7 +55,7 @@ describe('extractCollapseEditsLocally', () => {
     const snap = mkSnap([['moved to', 'lives in']]);
     const out = extractCollapseEditsLocally('She MOVED TO Paris', snap);
     expect(out).toHaveLength(1);
-    expect(out[0].span.text).toBe('MOVED TO');
+    expect(out[0]!.span.text).toBe('MOVED TO');
   });
 
   it('prefers longest match when patterns overlap', () => {
@@ -68,7 +68,7 @@ describe('extractCollapseEditsLocally', () => {
       snap,
     );
     expect(out).toHaveLength(1);
-    expect(out[0].pattern).toBe('moved from');
+    expect(out[0]!.pattern).toBe('moved from');
   });
 
   it('emits multiple non-overlapping matches in one message', () => {
@@ -93,8 +93,8 @@ describe('extractCollapseEditsLocally', () => {
       snap,
     );
     expect(out).toHaveLength(1);
-    expect(out[0].replacement).toBe('живёт в');
-    expect(out[0].span.text).toBe('переехал в');
+    expect(out[0]!.replacement).toBe('живёт в');
+    expect(out[0]!.span.text).toBe('переехал в');
   });
 
   it('matches at message boundaries', () => {
@@ -110,6 +110,6 @@ describe('extractCollapseEditsLocally', () => {
   it('preserves source casing in span.text', () => {
     const snap = mkSnap([['moved to', 'lives in']]);
     const out = extractCollapseEditsLocally('Maria Moved To Berlin', snap);
-    expect(out[0].span.text).toBe('Moved To');
+    expect(out[0]!.span.text).toBe('Moved To');
   });
 });

--- a/test/combined-vector-graph.unit-spec.ts
+++ b/test/combined-vector-graph.unit-spec.ts
@@ -48,8 +48,8 @@ describe('buildNeighbourMap', () => {
     ];
     const map = buildNeighbourMap(rows)!;
     expect(map.size).toBe(2);
-    expect(map.get('knowledge_entity:e1')?.outNeighbours?.[0].peer?.id).toBe('knowledge_entity:n1');
-    expect(map.get('knowledge_entity:e2')?.inNeighbours?.[0].peer?.id).toBe('knowledge_entity:n2');
+    expect(map.get('knowledge_entity:e1')?.outNeighbours?.[0]?.peer?.id).toBe('knowledge_entity:n1');
+    expect(map.get('knowledge_entity:e2')?.inNeighbours?.[0]?.peer?.id).toBe('knowledge_entity:n2');
   });
 });
 

--- a/test/communities.e2e-spec.ts
+++ b/test/communities.e2e-spec.ts
@@ -108,7 +108,7 @@ describe('Communities — build + read surfaces', () => {
   it('find_entity_communities resolves an entity to its cluster', async () => {
     const out = await f.app.get(CommunityService).forEntity(f.companyId, entityA);
     expect(out).toHaveLength(1);
-    expect(out[0].memberCount).toBe(3);
+    expect(out[0]!.memberCount).toBe(3);
   });
 
   it('search returns a community for a topical query', async () => {
@@ -116,7 +116,7 @@ describe('Communities — build + read surfaces', () => {
       .get(CommunityService)
       .search(f.companyId, { query: 'Acme billing', minSimilarity: 0 });
     expect(out.length).toBeGreaterThanOrEqual(1);
-    expect(out[0].similarity).toBeGreaterThanOrEqual(0);
+    expect(out[0]!.similarity).toBeGreaterThanOrEqual(0);
   });
 
   it('REST: list / search / for-entity / stats resolve over HTTP', async () => {

--- a/test/compaction.e2e-spec.ts
+++ b/test/compaction.e2e-spec.ts
@@ -58,7 +58,7 @@ describe('compaction retention pass (real SurrealDB)', () => {
         `SELECT status, embedding FROM type::record('knowledge_fact', $tail)`,
         { tail: factId.split(':')[1] },
       );
-      const fact = (rows as Array<{ status: string; embedding: unknown }>)[0];
+      const fact = (rows as Array<{ status: string; embedding: unknown }>)[0]!;
       expect(fact.status).toBe('compacted');
       expect(fact.embedding ?? null).toBeNull();
     });

--- a/test/compaction.unit-spec.ts
+++ b/test/compaction.unit-spec.ts
@@ -104,11 +104,11 @@ describe('CompactionService — mark + drop (default mode)', () => {
     const stats = await runner.compactAll(['co_a', 'co_b', 'co_c']);
     expect(stats).toHaveLength(3);
     const byTenant = Object.fromEntries(stats.map((s) => [s.companyId, s]));
-    expect(byTenant.co_a.factsCompacted).toBe(12);
-    expect(byTenant.co_b.factsCompacted).toBe(0);
-    expect(byTenant.co_c.factsCompacted).toBe(5);
-    expect(byTenant.co_a.summariesCreated).toBe(0); // summaries off by default
-    expect(byTenant.co_a.bytesFreed).toBe(12 * 6 * 1024);
+    expect(byTenant.co_a!.factsCompacted).toBe(12);
+    expect(byTenant.co_b!.factsCompacted).toBe(0);
+    expect(byTenant.co_c!.factsCompacted).toBe(5);
+    expect(byTenant.co_a!.summariesCreated).toBe(0); // summaries off by default
+    expect(byTenant.co_a!.bytesFreed).toBe(12 * 6 * 1024);
 
     const calls_b = calls.find((c) => c.companyId === 'co_b')!;
     expect(calls_b.calls.some((c) => c.sql.startsWith('UPDATE'))).toBe(false);
@@ -146,7 +146,7 @@ describe('CompactionService — mark + drop (default mode)', () => {
     await runner.compactCompany('co_a');
     const after = Date.now();
 
-    const select = calls[0].calls.find((c) => c.sql.includes('SELECT id, entityId'))!;
+    const select = calls[0]!.calls.find((c) => c.sql.includes('SELECT id, entityId'))!;
     // Date param, not an ISO string — SurrealDB 3.x needs a native
     // datetime (the 2.x `d$cutoff` cast no longer parses).
     const cutoff = select.params!.cutoff as Date;
@@ -207,14 +207,14 @@ describe('CompactionService — summary mode (COMPACTION_SUMMARIES=true)', () =>
     );
 
     const [stats] = await runner.compactAll(['co_a']);
-    expect(stats.factsCompacted).toBe(5);
+    expect(stats!.factsCompacted).toBe(5);
     // Two summaries: tier (3 rows) + name (1 row) — name is singleton, skip
-    expect(stats.summariesCreated).toBe(1);
+    expect(stats!.summariesCreated).toBe(1);
     expect(gen.calls).toHaveLength(1);
-    expect(gen.calls[0].map((f) => f.object)).toEqual(['gold', 'platinum', 'diamond']);
+    expect(gen.calls[0]!.map((f) => f.object)).toEqual(['gold', 'platinum', 'diamond']);
 
     expect(created).toHaveLength(1);
-    const summary = created[0].payload as Record<string, unknown>;
+    const summary = created[0]!.payload as Record<string, unknown>;
     expect(summary.predicate).toBe('summary_tier');
     expect(summary.object).toBe('SUMMARY(3:gold,platinum,diamond)');
     expect((summary.derivedFrom as unknown[]).length).toBe(3);
@@ -222,7 +222,7 @@ describe('CompactionService — summary mode (COMPACTION_SUMMARIES=true)', () =>
     expect(summary.confidence).toBeCloseTo(0.8, 5);
     expect(summary.status).toBe('active');
 
-    const updates = calls[0].calls.filter((c) => c.sql.startsWith('UPDATE'));
+    const updates = calls[0]!.calls.filter((c) => c.sql.startsWith('UPDATE'));
     expect(updates).toHaveLength(1);
   });
 
@@ -242,8 +242,8 @@ describe('CompactionService — summary mode (COMPACTION_SUMMARIES=true)', () =>
       emptyGen,
     );
     const [stats] = await runner.compactAll(['co_a']);
-    expect(stats.factsCompacted).toBe(2);
-    expect(stats.summariesCreated).toBe(0);
+    expect(stats!.factsCompacted).toBe(2);
+    expect(stats!.summariesCreated).toBe(0);
     expect(created).toHaveLength(0);
   });
 
@@ -263,8 +263,8 @@ describe('CompactionService — summary mode (COMPACTION_SUMMARIES=true)', () =>
       gen,
     );
     const [stats] = await runner.compactAll(['co_a']);
-    expect(stats.factsCompacted).toBe(2);
-    expect(stats.summariesCreated).toBe(0);
+    expect(stats!.factsCompacted).toBe(2);
+    expect(stats!.summariesCreated).toBe(0);
     expect(gen.calls).toHaveLength(0);
     expect(created).toHaveLength(0);
   });

--- a/test/conformal-guardrail.e2e-spec.ts
+++ b/test/conformal-guardrail.e2e-spec.ts
@@ -64,7 +64,7 @@ describe('Phase 3.C e2e — conformal guardrail', () => {
     expect(res.status).toBe(201);
     // Generator was called — there's at least one above-floor fact.
     expect(state.calls.length).toBeGreaterThan(0);
-    const generatorUser = state.calls[0].user;
+    const generatorUser = state.calls[0]!.user;
     expect(generatorUser).toContain('high confidence claim');
     // And the low-confidence object never reaches the prompt.
     expect(generatorUser).not.toContain('low confidence claim');

--- a/test/conformal-guardrail.unit-spec.ts
+++ b/test/conformal-guardrail.unit-spec.ts
@@ -50,7 +50,7 @@ describe('applyConformalGuardrail', () => {
     ];
     const r = applyConformalGuardrail(hits, { minCalibratedConfidence: 0.4 });
     expect(r.kept.length).toBe(1);
-    expect(r.kept[0].facts.map((f) => f.factId)).toEqual(['high']);
+    expect(r.kept[0]!.facts.map((f) => f.factId)).toEqual(['high']);
     expect(r.droppedCount).toBe(1);
   });
 
@@ -61,7 +61,7 @@ describe('applyConformalGuardrail', () => {
     ];
     const r = applyConformalGuardrail(hits, { minCalibratedConfidence: 0.5 });
     expect(r.kept.length).toBe(1);
-    expect(r.kept[0].entityId).toBe('e2');
+    expect(r.kept[0]!.entityId).toBe('e2');
     expect(r.droppedCount).toBe(1);
   });
 
@@ -85,6 +85,6 @@ describe('applyConformalGuardrail', () => {
   it('floor === calibratedConfidence keeps the fact (inclusive boundary)', () => {
     const hits = [hit('e1', [{ factId: 'eq', calibrated: 0.5 }])];
     const r = applyConformalGuardrail(hits, { minCalibratedConfidence: 0.5 });
-    expect(r.kept[0].facts.length).toBe(1);
+    expect(r.kept[0]!.facts.length).toBe(1);
   });
 });

--- a/test/decision-log.unit-spec.ts
+++ b/test/decision-log.unit-spec.ts
@@ -52,9 +52,9 @@ describe('buildDecisionLog', () => {
 
     expect(log).toHaveLength(2);
     expect(log[0]).toMatchObject({ factId: 'f1', picked: true });
-    expect(log[0].rejectReason).toBeUndefined();
+    expect(log[0]!.rejectReason).toBeUndefined();
     expect(log[1]).toMatchObject({ factId: 'f2', picked: false });
-    expect(log[1].rejectReason).toBe('not_relevant_to_query');
+    expect(log[1]!.rejectReason).toBe('not_relevant_to_query');
   });
 
   it('flags low-score rejections below the threshold', () => {
@@ -71,7 +71,7 @@ describe('buildDecisionLog', () => {
       ]),
     ];
     const log = buildDecisionLog(hits, new Set(), { lowScoreThreshold: 0.1 });
-    expect(log[0].rejectReason).toBe('low_score');
+    expect(log[0]!.rejectReason).toBe('low_score');
   });
 
   it('flags second occurrence of a predicate as duplicate', () => {
@@ -131,7 +131,7 @@ describe('buildDecisionLog', () => {
       ]),
     ];
     const log = buildDecisionLog(hits, new Set(['fg']));
-    expect(log[0].scoreBreakdown.stages).toEqual(['graph_neighbour', 'lexical']);
+    expect(log[0]!.scoreBreakdown.stages).toEqual(['graph_neighbour', 'lexical']);
   });
 
   it('falls back to a synthetic breakdown when one is missing', () => {
@@ -157,7 +157,7 @@ describe('buildDecisionLog', () => {
       },
     ];
     const log = buildDecisionLog(hits, new Set(['f1']));
-    expect(log[0].scoreBreakdown.finalScore).toBe(0.5);
-    expect(log[0].scoreBreakdown.stages).toEqual([]);
+    expect(log[0]!.scoreBreakdown.finalScore).toBe(0.5);
+    expect(log[0]!.scoreBreakdown.stages).toEqual([]);
   });
 });

--- a/test/derive-staging.unit-spec.ts
+++ b/test/derive-staging.unit-spec.ts
@@ -180,16 +180,16 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
     // Audit 2026-08-21: facts AND digests flip in ONE transaction — a
     // committed fact-world can never be narrated by old digests.
     expect(flips.length).toBe(1);
-    expect(flips[0].sql).toContain(
+    expect(flips[0]!.sql).toContain(
       'DELETE knowledge_fact WHERE derivedVersion = $final',
     );
-    expect(flips[0].sql).toContain(
+    expect(flips[0]!.sql).toContain(
       'UPDATE knowledge_fact SET derivedVersion = $final',
     );
-    expect(flips[0].sql).toContain(
+    expect(flips[0]!.sql).toContain(
       'DELETE conversation_digest WHERE derivedVersion = $final',
     );
-    expect(flips[0].sql).toContain(
+    expect(flips[0]!.sql).toContain(
       'UPDATE conversation_digest SET derivedVersion = $final',
     );
     for (const flip of flips) {
@@ -283,7 +283,7 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
     );
     expect(firstDelete).toBeGreaterThanOrEqual(0);
     expect(firstDelete).toBeLessThan(firstEpisodeRead);
-    expect(queries[firstDelete].params?.prefix).toBe(STAGING);
+    expect(queries[firstDelete]!.params?.prefix).toBe(STAGING);
   });
 
   it("registry becomes 'built' only AFTER the flip transactions", async () => {
@@ -312,17 +312,17 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
     expect(flips.length).toBe(1);
     // Conversation-scoped DELETE/UPDATE — a targeted flip must never
     // wipe the other conversations of the final world.
-    expect(flips[0].sql).toContain('source.conversationId = $conv');
-    expect(flips[0].sql).not.toMatch(
+    expect(flips[0]!.sql).toContain('source.conversationId = $conv');
+    expect(flips[0]!.sql).not.toMatch(
       /DELETE knowledge_fact WHERE derivedVersion = \$final;/,
     );
     // The 0014-shape revive of OTHER conversations' superseded losers
     // now runs against the FINAL world at flip time.
-    expect(flips[0].sql).toContain("status = 'superseded'");
-    expect(flips[0].sql).toContain('supersededBy IN');
+    expect(flips[0]!.sql).toContain("status = 'superseded'");
+    expect(flips[0]!.sql).toContain('supersededBy IN');
     // Digest slice flips inside the SAME transaction.
-    expect(flips[0].sql).toContain('DELETE conversation_digest');
-    expect(flips[0].params?.conv).toBe('conv-1');
+    expect(flips[0]!.sql).toContain('DELETE conversation_digest');
+    expect(flips[0]!.params?.conv).toBe('conv-1');
   });
 });
 
@@ -447,7 +447,7 @@ describe('promoteStaging / sweepStagingRows primitives', () => {
     // Audit 2026-08-21: one transaction covers BOTH tables — a failure
     // can never leave a new fact-world narrated by old digests.
     expect(queries).toHaveLength(1);
-    const q = queries[0];
+    const q = queries[0]!;
     expect(q.sql).toContain('BEGIN TRANSACTION');
     expect(q.sql).toContain('COMMIT TRANSACTION');
     expect(q.params).toMatchObject({
@@ -470,15 +470,15 @@ describe('promoteStaging / sweepStagingRows primitives', () => {
       conversationId: 'conv-7',
     });
     expect(queries).toHaveLength(1);
-    expect(queries[0].params?.conv).toBe('conv-7');
+    expect(queries[0]!.params?.conv).toBe('conv-7');
     // Revive of cross-conversation supersede losers runs first, inside
     // the same transaction as the replace.
-    expect(queries[0].sql.indexOf("status = 'active'")).toBeLessThan(
-      queries[0].sql.indexOf('DELETE knowledge_fact'),
+    expect(queries[0]!.sql.indexOf("status = 'active'")).toBeLessThan(
+      queries[0]!.sql.indexOf('DELETE knowledge_fact'),
     );
-    expect(queries[0].sql).toContain('source.conversationId = $conv');
+    expect(queries[0]!.sql).toContain('source.conversationId = $conv');
     // Digest slice flips inside the SAME transaction, same scoping.
-    expect(queries[0].sql).toContain(
+    expect(queries[0]!.sql).toContain(
       'DELETE conversation_digest\n            WHERE derivedVersion = $final AND conversationId = $conv',
     );
   });
@@ -492,8 +492,8 @@ describe('promoteStaging / sweepStagingRows primitives', () => {
       expect(d.params?.version).toBe('wd-v9.staging');
     }
     // Probe precedes each delete.
-    expect(queries[0].sql).toContain('SELECT id FROM knowledge_fact');
-    expect(queries[1].sql.startsWith('DELETE knowledge_fact')).toBe(true);
+    expect(queries[0]!.sql).toContain('SELECT id FROM knowledge_fact');
+    expect(queries[1]!.sql.startsWith('DELETE knowledge_fact')).toBe(true);
   });
 });
 

--- a/test/derive-user-scope.unit-spec.ts
+++ b/test/derive-user-scope.unit-spec.ts
@@ -60,13 +60,15 @@ function build(turnsPerProp: number[][]) {
 
 describe('derive user scope (audit 2026-08-21 P0)', () => {
   it('grounded only in global turns → tenant-global row', () => {
-    const [row] = build([[1]]);
+    const row = build([[1]])[0]!;
     expect(row.userId).toBeUndefined();
     expect(row.crossUserScope).toBe(false);
   });
 
   it("grounded in one user's turns (global ride-along ok) → that user's row", () => {
-    const [own, mixed] = build([[0], [0, 1]]);
+    const scoped = build([[0], [0, 1]]);
+    const own = scoped[0]!;
+    const mixed = scoped[1]!;
     expect(own.userId).toBe('user-a');
     expect(own.crossUserScope).toBe(false);
     expect(mixed.userId).toBe('user-a');
@@ -74,29 +76,29 @@ describe('derive user scope (audit 2026-08-21 P0)', () => {
   });
 
   it('grounded in turns of two users → poisoned for any scope (crossUserScope)', () => {
-    const [row] = build([[0, 2]]);
+    const row = build([[0, 2]])[0]!;
     expect(row.userId).toBeUndefined();
     expect(row.crossUserScope).toBe(true);
   });
 
   it('empty turns → invalid grounding, never a tenant-global fact (round 3)', () => {
-    const [row] = build([[]]);
+    const row = build([[]])[0]!;
     expect(row.groundingInvalid).toBe(true);
     expect(row.userId).toBeUndefined();
   });
 
   it('a negative index poisons the whole proposition', () => {
-    const [row] = build([[-1, 1]]);
+    const row = build([[-1, 1]])[0]!;
     expect(row.groundingInvalid).toBe(true);
   });
 
   it('an out-of-range index poisons the whole proposition', () => {
-    const [row] = build([[1, 99]]);
+    const row = build([[1, 99]])[0]!;
     expect(row.groundingInvalid).toBe(true);
   });
 
   it('fully valid grounding stays valid', () => {
-    const [row] = build([[0, 1]]);
+    const row = build([[0, 1]])[0]!;
     expect(row.groundingInvalid).toBe(false);
     expect(row.userId).toBe('user-a');
   });
@@ -108,7 +110,7 @@ describe('derive user scope (audit 2026-08-21 P0)', () => {
       outcomes: rows.map(() => ({ outcome: 'INSERTED' })),
     });
     expect(pool).toHaveLength(1);
-    expect(pool[0].entityId).toBe('knowledge_entity:alice');
+    expect(pool[0]!.entityId).toBe('knowledge_entity:alice');
   });
 });
 
@@ -145,7 +147,7 @@ describe('char-span grounding quotes (G3, DERIVER_SPANS)', () => {
   it('flag on: a verifying quote lands as source.charSpans with offsets', () => {
     process.env.DERIVER_SPANS = '1';
     // SESSION[1].text = 'a tenant-global turn'
-    const [row] = buildQuoted([1], ['tenant-global']);
+    const row = buildQuoted([1], ['tenant-global'])[0]!;
     expect(row.source.charSpans).toEqual([
       {
         episodeId: 'episode:g1',
@@ -160,7 +162,7 @@ describe('char-span grounding quotes (G3, DERIVER_SPANS)', () => {
 
   it('flag on: an unverifiable quote drops silently, the fact still lands', () => {
     process.env.DERIVER_SPANS = '1';
-    const [row] = buildQuoted([1], ['never said this']);
+    const row = buildQuoted([1], ['never said this'])[0]!;
     expect(row.source).not.toHaveProperty('charSpans');
     expect(row.object).toBe('a derived plan');
     expect(row.groundingInvalid).toBe(false);
@@ -168,16 +170,16 @@ describe('char-span grounding quotes (G3, DERIVER_SPANS)', () => {
 
   it('flag on: null quote entries contribute no span', () => {
     process.env.DERIVER_SPANS = '1';
-    const [row] = buildQuoted([0, 1], [null, 'tenant-global']);
+    const row = buildQuoted([0, 1], [null, 'tenant-global'])[0]!;
     expect(row.source.charSpans).toHaveLength(1);
-    expect((row.source.charSpans as Array<{ episodeId: string }>)[0].episodeId).toBe(
+    expect((row.source.charSpans as Array<{ episodeId: string }>)[0]!.episodeId).toBe(
       'episode:g1',
     );
   });
 
   it('flag off: quotes are ignored — source shape is byte-identical', () => {
     delete process.env.DERIVER_SPANS;
-    const [row] = buildQuoted([1], ['tenant-global']);
+    const row = buildQuoted([1], ['tenant-global'])[0]!;
     expect(row.source).not.toHaveProperty('charSpans');
   });
 });

--- a/test/deriver-recall.unit-spec.ts
+++ b/test/deriver-recall.unit-spec.ts
@@ -113,7 +113,7 @@ describe('deriver recall (V7)', () => {
       .mockResolvedValueOnce(ok(extra));
     const out = await callDeriver(makeSvc(create));
     expect(out).toHaveLength(2);
-    expect(out[1].proposition).toContain('Lisbon');
+    expect(out[1]!.proposition).toContain('Lisbon');
     // The follow-up turn carries the base list + the completion prompt.
     const followupMessages = create.mock.calls[1][0].messages;
     expect(followupMessages.at(-1).content).toBe(DERIVER_COMPLETION_PROMPT);

--- a/test/digest-lane.unit-spec.ts
+++ b/test/digest-lane.unit-spec.ts
@@ -48,8 +48,8 @@ describe('DigestLaneService', () => {
       'Conversation record (through 2026-03-15):\n[2026-03-12] UI wireframe done. [2026-03-15] API wired.',
     ]);
     // No registry pin in this fixture → the legacy-namespace gate.
-    expect(capture[0].sql).toContain('derivedVersion IS NONE');
-    expect(capture[0].sql).toContain('ORDER BY lastEventAt DESC');
+    expect(capture[0]!.sql).toContain('derivedVersion IS NONE');
+    expect(capture[0]!.sql).toContain('ORDER BY lastEventAt DESC');
   });
 
   it('drops empty summaries and degrades to [] on failure', async () => {
@@ -144,8 +144,8 @@ describe('digest user-scope policy (0087, V11 item 10)', () => {
       'OTHER-A',
       'MIXED-AB',
     ]);
-    expect(capture[0].sql).not.toContain('userScopes');
-    expect(capture[0].params).not.toHaveProperty('digestUserId');
+    expect(capture[0]!.sql).not.toContain('userScopes');
+    expect(capture[0]!.params).not.toHaveProperty('digestUserId');
   });
 
   it('user-scoped caller sees global + own only; other-user and mixed-scope excluded', async () => {
@@ -157,10 +157,10 @@ describe('digest user-scope policy (0087, V11 item 10)', () => {
     });
     expect(summaries(lines)).toEqual(['GLOBAL-NONE', 'GLOBAL-EMPTY', 'OWN-B']);
     // The fail-closed clause rides in SQL — exactly-[user] or empty/NONE.
-    expect(capture[0].sql).toContain('userScopes IS NONE');
-    expect(capture[0].sql).toContain('array::len(userScopes) = 0');
-    expect(capture[0].sql).toContain('userScopes = [$digestUserId]');
-    expect(capture[0].params).toMatchObject({ digestUserId: 'user-b' });
+    expect(capture[0]!.sql).toContain('userScopes IS NONE');
+    expect(capture[0]!.sql).toContain('array::len(userScopes) = 0');
+    expect(capture[0]!.sql).toContain('userScopes = [$digestUserId]');
+    expect(capture[0]!.params).toMatchObject({ digestUserId: 'user-b' });
   });
 });
 

--- a/test/directory.real-e2e-spec.ts
+++ b/test/directory.real-e2e-spec.ts
@@ -104,7 +104,7 @@ describe('Directory eval (jumbo tenant + memory lifecycle)', () => {
       });
       const limitedClient = new HttpBrainClient({
         baseUrl: svc.baseUrl,
-        apiKey: svc.extras[0].plaintext,
+        apiKey: svc.extras[0]!.plaintext,
       });
 
       const runner = new EvalRunner(

--- a/test/document-chunker.unit-spec.ts
+++ b/test/document-chunker.unit-spec.ts
@@ -38,7 +38,7 @@ describe('chunkDocument', () => {
     const text = paragraph.repeat(5); // 25K → must split
     const out = chunkDocument(text);
     // First chunk should end right after a paragraph boundary, not mid-run.
-    expect(out[0].text.endsWith('\n\n')).toBe(true);
+    expect(out[0]!.text.endsWith('\n\n')).toBe(true);
   });
 
   it('consecutive chunks overlap so straddling content is fully visible', () => {
@@ -46,7 +46,7 @@ describe('chunkDocument', () => {
     const text = paragraph.repeat(30);
     const out = chunkDocument(text);
     for (let i = 1; i < out.length; i++) {
-      expect(out[i].charStart).toBeLessThan(out[i - 1].charEnd);
+      expect(out[i]!.charStart).toBeLessThan(out[i - 1]!.charEnd);
     }
   });
 
@@ -54,20 +54,20 @@ describe('chunkDocument', () => {
     const text = 'a'.repeat(50_000);
     const out = chunkDocument(text);
     expect(out.length).toBeGreaterThan(3);
-    expect(out[out.length - 1].charEnd).toBe(text.length);
+    expect(out[out.length - 1]!.charEnd).toBe(text.length);
     for (let i = 1; i < out.length; i++) {
-      expect(out[i].charStart).toBeGreaterThan(out[i - 1].charStart);
+      expect(out[i]!.charStart).toBeGreaterThan(out[i - 1]!.charStart);
     }
   });
 
   it('covers the entire document — no gaps between chunks', () => {
     const text = `${'sentence one. '.repeat(2_000)}`;
     const out = chunkDocument(text);
-    expect(out[0].charStart).toBe(0);
+    expect(out[0]!.charStart).toBe(0);
     for (let i = 1; i < out.length; i++) {
       // Overlap means next start ≤ previous end; never a gap.
-      expect(out[i].charStart).toBeLessThanOrEqual(out[i - 1].charEnd);
+      expect(out[i]!.charStart).toBeLessThanOrEqual(out[i - 1]!.charEnd);
     }
-    expect(out[out.length - 1].charEnd).toBe(text.length);
+    expect(out[out.length - 1]!.charEnd).toBe(text.length);
   });
 });

--- a/test/documents-pipeline.e2e-spec.ts
+++ b/test/documents-pipeline.e2e-spec.ts
@@ -228,7 +228,7 @@ describe('documents pipeline (e2e)', () => {
       });
       const fact = (
         rows as Array<{ status: string; source: Record<string, unknown> }>
-      )[0];
+      )[0]!;
       expect(fact.status).toBe('active');
       expect(fact.source.provenancePurged).toBe(true);
     });

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -306,9 +306,9 @@ describe('diffPackUpgrade', () => {
     const next = pack({ id: 'med', predicates: [bumped] });
     const { changed, removedIds } = diffPackUpgrade('med', prior, next);
     expect(changed).toHaveLength(1);
-    expect(changed[0].predicateId).toBe('med__dx');
-    expect(changed[0].piiClass).toBe('sensitive');
-    expect(changed[0].createdBy).toBe('admin');
+    expect(changed[0]!.predicateId).toBe('med__dx');
+    expect(changed[0]!.piiClass).toBe('sensitive');
+    expect(changed[0]!.createdBy).toBe('admin');
     expect(removedIds).toEqual([]);
   });
 

--- a/test/dreams-corroborate.e2e-spec.ts
+++ b/test/dreams-corroborate.e2e-spec.ts
@@ -68,7 +68,7 @@ describe('dreams corroborate — apply statement (real SurrealDB)', () => {
       );
       const younger = (
         youngerRows as Array<{ status: string; corroborates: unknown }>
-      )[0];
+      )[0]!;
       expect(younger.status).toBe('corroborating');
       expect(String(younger.corroborates)).toBe(incumbentId);
 
@@ -95,7 +95,7 @@ describe('dreams corroborate — apply statement (real SurrealDB)', () => {
               sourceKeys: string[];
             };
           }>
-        )[0].corroboration;
+        )[0]!.corroboration;
       };
 
       const first = await readIncumbent();

--- a/test/dreams-corroborate.unit-spec.ts
+++ b/test/dreams-corroborate.unit-spec.ts
@@ -105,7 +105,7 @@ describe('DreamsCorroborateService', () => {
     const out = await svc.run(db(GROUP, [a, b]) as never);
     expect(out.llmJudgements).toBe(1);
     expect(out.corroborationsApplied).toBe(1);
-    expect(out.corroborations[0].method).toBe('llm');
+    expect(out.corroborations[0]!.method).toBe('llm');
     expect(applied).toHaveLength(1);
   });
 

--- a/test/dreams-orchestrator.unit-spec.ts
+++ b/test/dreams-orchestrator.unit-spec.ts
@@ -234,9 +234,9 @@ describe('DreamsService', () => {
     );
     const out = await svc.runAll(['dedup']);
     expect(out).toHaveLength(3);
-    expect(out[0].error).toBeUndefined();
-    expect(out[1].error).toMatch(/only tenant b is sad/);
-    expect(out[2].error).toBeUndefined();
+    expect(out[0]!.error).toBeUndefined();
+    expect(out[1]!.error).toMatch(/only tenant b is sad/);
+    expect(out[2]!.error).toBeUndefined();
     // ok should fire for the two healthy tenants, failed for the bad one.
     const okCount = (
       metrics.countDreams as jest.Mock
@@ -299,6 +299,6 @@ describe('DreamsService', () => {
     // {enqueued} summary in queue mode); narrow before indexing.
     if (!Array.isArray(out)) throw new Error('expected per-tenant stats array');
     expect(out).toHaveLength(1);
-    expect(out[0].dedup?.identityLinksCreated).toBe(2);
+    expect(out[0]!.dedup?.identityLinksCreated).toBe(2);
   });
 });

--- a/test/edge-fence.unit-spec.ts
+++ b/test/edge-fence.unit-spec.ts
@@ -110,8 +110,8 @@ describe('edge expansion under the fence', () => {
     );
     expect(sql[0]).toContain('peer: out.{id, userId}');
     // The scoped peer never reaches the neighbour-fact fetch.
-    expect(String(params[1].entityIds)).toContain('global');
-    expect(String(params[1].entityIds)).not.toContain('alices');
+    expect(String(params[1]!.entityIds)).toContain('global');
+    expect(String(params[1]!.entityIds)).not.toContain('alices');
   });
 
   it('a scoped caller binds their id into the edge filter', async () => {
@@ -127,7 +127,7 @@ describe('edge expansion under the fence', () => {
       config: { topSeeds: 3, maxNeighboursPerSeed: 5, alpha: 0.4 },
     });
     expect(sql[0]).toContain('userId = $edgeScopeUserId');
-    expect(params[0].edgeScopeUserId).toBe('alice');
+    expect(params[0]!.edgeScopeUserId).toBe('alice');
   });
 
   it('fences prefetched neighbourhoods too (combined-leg path)', async () => {
@@ -249,7 +249,7 @@ describe('PPR under the fence', () => {
     expect(sql[0]).toContain(
       'invalidatedAt IS NONE AND (userId IS NONE OR userId = $edgeScopeUserId)',
     );
-    expect(params[0].edgeScopeUserId).toBe('alice');
+    expect(params[0]!.edgeScopeUserId).toBe('alice');
   });
 });
 

--- a/test/engine-gates.unit-spec.ts
+++ b/test/engine-gates.unit-spec.ts
@@ -126,7 +126,7 @@ describe('S5.4 — layering: episodes ← derive ← search ← synthesize', () 
       const from = LAYER_OF(file);
       if (from === null) continue;
       for (const m of text.matchAll(/from '([^']+)'/g)) {
-        const to = layerOfImport(file, m[1]);
+        const to = layerOfImport(file, m[1]!);
         if (to !== null && to > from) {
           offenders.push(`${file} → ${m[1]}`);
         }
@@ -164,7 +164,7 @@ describe('S5.5 — dead exports in the engine dirs', () => {
       for (const m of text.matchAll(
         /^export (?:async )?(?:function|const|class) (\w+)/gm,
       )) {
-        const name = m[1];
+        const name = m[1]!;
         const re = new RegExp(`\\b${name}\\b`);
         const usedInSrc = [...SOURCES].some(
           ([g, gt]) => g !== file && re.test(gt),

--- a/test/entity-autocomplete.unit-spec.ts
+++ b/test/entity-autocomplete.unit-spec.ts
@@ -58,8 +58,8 @@ describe('EntitiesService.autocomplete', () => {
       { entityId: 'knowledge_entity:2', canonicalName: 'Carlos', type: 'person', score: 0.7 },
     ]);
     expect(captured).toHaveLength(1);
-    expect(captured[0].params.q).toBe('car');
-    const sql = captured[0].sql;
+    expect(captured[0]!.params.q).toBe('car');
+    const sql = captured[0]!.sql;
     expect(sql).toContain('canonicalNameLc @1@ $q');
     expect(sql).toContain('mergedInto IS NONE');
     expect(sql).toContain('userId IS NONE');
@@ -79,7 +79,7 @@ describe('EntitiesService.autocomplete', () => {
     for (const [input, expected] of cases) {
       const { svc, captured } = make();
       await svc.autocomplete({ companyId: 'co_x', q: 'car', limit: input, scopes });
-      expect(captured[0].params.lim).toBe(expected);
+      expect(captured[0]!.params.lim).toBe(expected);
     }
   });
 

--- a/test/episode-lane.unit-spec.ts
+++ b/test/episode-lane.unit-spec.ts
@@ -44,16 +44,16 @@ describe('EpisodeLaneService (P2)', () => {
       '[2023-05-01] Caroline: Show me the horse painting',
       '[2023-06-01] Melanie: I painted a sunset',
     ]);
-    expect(queries[0].sql).toContain('FROM episode');
-    expect(queries[0].sql).toContain('@1@ $q');
+    expect(queries[0]!.sql).toContain('FROM episode');
+    expect(queries[0]!.sql).toContain('@1@ $q');
   });
 
   it('gates piiClass rows away from callers without brain:read_pii', async () => {
     const { svc, queries } = makeLane([]);
     await svc.transcriptLines({ ...base, callerScopes: ['brain:read'] });
-    expect(queries[0].sql).toContain('AND piiClass IS NONE');
+    expect(queries[0]!.sql).toContain('AND piiClass IS NONE');
     await svc.transcriptLines(base);
-    expect(queries[1].sql).not.toContain('piiClass IS NONE');
+    expect(queries[1]!.sql).not.toContain('piiClass IS NONE');
   });
 
   it('degrades to [] on query failure', async () => {
@@ -118,17 +118,17 @@ describe('EpisodeLaneService.sourceExcerpts (A1 provenance lane)', () => {
       '[2023-06-01] Melanie: later turn',
     ]);
     // Fact fetch uses record-id binding, not string interpolation.
-    expect(queries[0].sql).toContain('INSIDE $ids');
-    expect(String((queries[0].params.ids as unknown[])[0])).toBe(
+    expect(queries[0]!.sql).toContain('INSIDE $ids');
+    expect(String((queries[0]!.params.ids as unknown[])[0])).toBe(
       'knowledge_fact:f1',
     );
     // Episode fetch got the deduped id set.
-    expect((queries[1].params.ids as unknown[]).map(String)).toEqual([
+    expect((queries[1]!.params.ids as unknown[]).map(String)).toEqual([
       'episode:e2',
       'episode:e1',
     ]);
     // read_pii caller → no PII gate in the episode query.
-    expect(queries[1].sql).not.toContain('piiClass IS NONE');
+    expect(queries[1]!.sql).not.toContain('piiClass IS NONE');
   });
 
   it('caps episodes first-seen and gates PII without brain:read_pii', async () => {
@@ -142,10 +142,10 @@ describe('EpisodeLaneService.sourceExcerpts (A1 provenance lane)', () => {
       callerScopes: ['brain:read'],
     });
     expect(lines).toHaveLength(1);
-    expect((queries[1].params.ids as unknown[]).map(String)).toEqual([
+    expect((queries[1]!.params.ids as unknown[]).map(String)).toEqual([
       'episode:e1',
     ]);
-    expect(queries[1].sql).toContain('piiClass IS NONE');
+    expect(queries[1]!.sql).toContain('piiClass IS NONE');
   });
 
   it('degrades to [] on DB failure and with empty factIds', async () => {
@@ -183,16 +183,16 @@ describe('EpisodeLaneService.assistantTurns (multiworld §10 assistant lane)', (
     expect(lines).toEqual([
       '[2023-05-01] conv_1__assistant: Use the token bucket',
     ]);
-    expect(queries[0].sql).toContain(
+    expect(queries[0]!.sql).toContain(
       "string::ends_with(string::lowercase(speaker), $speakerSuffix)",
     );
-    expect(queries[0].params.speakerSuffix).toBe('assistant');
+    expect(queries[0]!.params.speakerSuffix).toBe('assistant');
   });
 
   it('lowercases the configured match before binding', async () => {
     const { svc, queries } = makeLane([]);
     await svc.assistantTurns({ ...base, match: 'Assistant' });
-    expect(queries[0].params.speakerSuffix).toBe('assistant');
+    expect(queries[0]!.params.speakerSuffix).toBe('assistant');
   });
 
   it('clamps runaway turns to the per-line budget (audit 2026-08-21 #7)', async () => {
@@ -204,14 +204,14 @@ describe('EpisodeLaneService.assistantTurns (multiworld §10 assistant lane)', (
       },
     ]);
     const [line] = await svc.assistantTurns(base);
-    expect(line.length).toBeLessThan(700);
+    expect(line!.length).toBeLessThan(700);
     expect(line).toContain('…');
   });
 
   it('keeps the PII fence for callers without brain:read_pii', async () => {
     const { svc, queries } = makeLane([]);
     await svc.assistantTurns({ ...base, callerScopes: ['brain:read'] });
-    expect(queries[0].sql).toContain('AND piiClass IS NONE');
+    expect(queries[0]!.sql).toContain('AND piiClass IS NONE');
   });
 
   it('degrades to [] on failure', async () => {

--- a/test/episode-subscription.unit-spec.ts
+++ b/test/episode-subscription.unit-spec.ts
@@ -54,13 +54,13 @@ describe('EpisodeSubscriptionService (driver surface 4)', () => {
     expect(out.id).toBe('episode_subscription:new1');
     expect(out.secret).toMatch(/^[0-9a-f]{64}$/);
     expect(Date.parse(out.watermark)).not.toBeNaN();
-    expect(queries[0].sql).toContain('CREATE episode_subscription');
+    expect(queries[0]!.sql).toContain('CREATE episode_subscription');
   });
 
   it('list never selects the secret column', async () => {
     const { svc, queries } = makeService({ subs: [] });
     await svc.list('co_x');
-    expect(queries[0].sql).not.toContain('secret');
+    expect(queries[0]!.sql).not.toContain('secret');
   });
 
   it('dispatchTick is inert when the flag is off', async () => {
@@ -105,7 +105,7 @@ describe('EpisodeSubscriptionService (driver surface 4)', () => {
     await svc.dispatchTick();
 
     expect(calls).toHaveLength(1);
-    const payload = JSON.parse(calls[0].body);
+    const payload = JSON.parse(calls[0]!.body);
     expect(payload.event).toBe('episodes_available');
     expect(payload.episodes[0]).toEqual({
       id: 'episode:e1',
@@ -116,11 +116,11 @@ describe('EpisodeSubscriptionService (driver surface 4)', () => {
       recordedAt: '2026-08-02T10:00:05.000Z',
     });
     // metadata only — never text
-    expect(calls[0].body).not.toContain('"text"');
+    expect(calls[0]!.body).not.toContain('"text"');
     const expected = createHmac('sha256', 'shh')
-      .update(calls[0].body)
+      .update(calls[0]!.body)
       .digest('hex');
-    expect(calls[0].sig).toBe(`sha256=${expected}`);
+    expect(calls[0]!.sig).toBe(`sha256=${expected}`);
     const advance = queries.find((q) => q.sql.includes('SET watermark'));
     expect(advance).toBeDefined();
     expect(advance?.sql).toContain('WHERE watermark = <datetime> $old');

--- a/test/episode-substrate.unit-spec.ts
+++ b/test/episode-substrate.unit-spec.ts
@@ -113,8 +113,8 @@ describe('EpisodeStoreService (P1)', () => {
     const { svc, queries } = makeStore();
     expect(await svc.captureTurn('co_x', dto())).toBe(true);
     expect(queries).toHaveLength(1);
-    expect(queries[0].sql).toContain('INSERT IGNORE INTO episode');
-    const row = queries[0].params.row as Record<string, unknown>;
+    expect(queries[0]!.sql).toContain('INSERT IGNORE INTO episode');
+    const row = queries[0]!.params.row as Record<string, unknown>;
     expect(row.kind).toBe('turn');
     expect(row.conversationId).toBe('conv-1');
     expect(row.messageId).toBe('m-42');
@@ -145,7 +145,7 @@ describe('EpisodeStoreService (P1)', () => {
     process.env.EPISODE_SUBSTRATE_ENABLED = '1';
     const { svc, queries } = makeStore();
     await svc.captureTurn('co_x', dto({ text: 'call +7 921 123-45-67' }));
-    const row = queries[0].params.row as Record<string, unknown>;
+    const row = queries[0]!.params.row as Record<string, unknown>;
     expect(row.text).toBe('call [PHONE]');
     expect(row.piiClass).toEqual(['phone']);
   });
@@ -189,6 +189,6 @@ describe('MentionIngestService captures the episode before extraction', () => {
     );
     // The episode write happened first — the turn is not lost.
     expect(queries).toHaveLength(1);
-    expect(queries[0].sql).toContain('INSERT IGNORE INTO episode');
+    expect(queries[0]!.sql).toContain('INSERT IGNORE INTO episode');
   });
 });

--- a/test/eval-harness.socket-spec.ts
+++ b/test/eval-harness.socket-spec.ts
@@ -220,8 +220,8 @@ describe('runWorlds', () => {
     // The V2 incident inverted: the poison is now a world-level error,
     // the row is NOT checkpointed, and a resume re-derives it.
     expect(scores).toHaveLength(1);
-    expect(String(scores[0].errored)).toContain('derive degraded');
-    expect(String(scores[0].errored)).toContain('insufficient_quota');
+    expect(String(scores[0]!.errored)).toContain('derive degraded');
+    expect(String(scores[0]!.errored)).toContain('insufficient_quota');
     expect(calls.some((c) => c.url.includes('multi-hop'))).toBe(false);
   });
 
@@ -246,10 +246,10 @@ describe('runWorlds', () => {
 
     const mentions = calls.filter((c) => c.url.includes('/v1/ingest/mention'));
     expect(mentions).toHaveLength(2);
-    expect(mentions[0].body.text).toHaveLength(TURN_CHAR_CAP); // cap applied
-    expect(mentions[0].body.emittedAt).toBe('2023-05-20T02:21:00.000Z');
-    expect(mentions[1].body.emittedAt).toBe('2023-05-20T02:21:30.000Z');
-    expect(mentions[0].body.knownEntities[0].name).toBe('q_1__user');
+    expect(mentions[0]!.body.text).toHaveLength(TURN_CHAR_CAP); // cap applied
+    expect(mentions[0]!.body.emittedAt).toBe('2023-05-20T02:21:00.000Z');
+    expect(mentions[1]!.body.emittedAt).toBe('2023-05-20T02:21:30.000Z');
+    expect(mentions[0]!.body.knownEntities[0].name).toBe('q_1__user');
 
     const derive = calls.find((c) => c.url.includes('/maintenance/derive'));
     expect(derive?.body).toEqual({ version: 'wd-v2', force: true });
@@ -259,8 +259,8 @@ describe('runWorlds', () => {
     expect(qa?.body.asOf).toBe('2023-06-01T00:00:00.000Z');
 
     expect(scores).toHaveLength(1);
-    expect(scores[0].abstained).toBe(true);
-    expect(scores[0].promptTokens).toBe(42);
+    expect(scores[0]!.abstained).toBe(true);
+    expect(scores[0]!.promptTokens).toBe(42);
   });
 
   it('skips fully checkpointed worlds without any HTTP calls', async () => {
@@ -289,7 +289,7 @@ describe('runWorlds', () => {
     });
     expect(calls).toHaveLength(0);
     expect(checkpointed).toBe(1);
-    expect(scores[0].judgeCorrect).toBe(true);
+    expect(scores[0]!.judgeCorrect).toBe(true);
   });
 });
 
@@ -368,7 +368,7 @@ describe('run provenance', () => {
     (out: Record<string, string>) =>
     (args: string[]): string => {
       const key = args.join(' ');
-      if (key in out) return out[key];
+      if (key in out) return out[key]!;
       throw new Error(`no fake for git ${key}`);
     };
 

--- a/test/eval/beam/nugget-judge.ts
+++ b/test/eval/beam/nugget-judge.ts
@@ -133,7 +133,7 @@ export interface NuggetJudge {
 function parseJudgeJson(raw: string): { score?: unknown } {
   let text = raw.trim();
   const fenced = /^```(?:json)?\s*([\s\S]*?)\s*```$/m.exec(text);
-  if (fenced) text = fenced[1];
+  if (fenced) text = fenced[1]!;
   return JSON.parse(text) as { score?: unknown };
 }
 
@@ -151,8 +151,8 @@ export function kendallTauB(x: number[], y: number[]): number | null {
   let tiesY = 0;
   for (let i = 0; i < x.length; i += 1) {
     for (let j = i + 1; j < x.length; j += 1) {
-      const dx = x[i] - x[j];
-      const dy = y[i] - y[j];
+      const dx = x[i]! - x[j]!;
+      const dy = y[i]! - y[j]!;
       if (dx === 0 && dy === 0) continue;
       if (dx === 0) tiesX += 1;
       else if (dy === 0) tiesY += 1;
@@ -189,7 +189,7 @@ async function alignWithLlm(
       }
     }
     if (matched !== null) {
-      systemCanon.push(reference[matched]);
+      systemCanon.push(reference[matched]!);
       used.add(matched);
     } else {
       systemCanon.push(s);

--- a/test/eval/fixtures/fat-tenant.generator.ts
+++ b/test/eval/fixtures/fat-tenant.generator.ts
@@ -142,7 +142,7 @@ export function buildFatTenant(opts: FatTenantOpts = {}): FatTenantFixture {
   const retractedComplaintsFrac = opts.retractedComplaintsFraction ?? 0.03;
   const forgottenCustomersFrac = opts.forgottenCustomersFraction ?? 0.01;
   const rand = mulberry32(seed);
-  const pick = <T>(arr: readonly T[]): T => arr[Math.floor(rand() * arr.length)];
+  const pick = <T>(arr: readonly T[]): T => arr[Math.floor(rand() * arr.length)]!;
 
   const setup: SetupStep[] = [];
   let factCount = 0;

--- a/test/eval/harness/flags.ts
+++ b/test/eval/harness/flags.ts
@@ -20,7 +20,7 @@ export function parseFlags<T extends Record<string, unknown>>(
 ): T {
   const args = { ...defaults } as Record<string, unknown>;
   for (let i = 0; i < argv.length; i++) {
-    const flag = argv[i];
+    const flag = argv[i]!;
     const def = spec[flag];
     if (!def) throw new Error(`unknown flag ${flag}`);
     if (def.type === 'bool') {

--- a/test/eval/harness/pool.ts
+++ b/test/eval/harness/pool.ts
@@ -13,7 +13,7 @@ export async function runPool<T>(
     for (;;) {
       const i = next++;
       if (i >= items.length) return;
-      await worker(items[i], i);
+      await worker(items[i]!, i);
     }
   });
   await Promise.all(lanes);

--- a/test/eval/harness/tenant-client.ts
+++ b/test/eval/harness/tenant-client.ts
@@ -37,7 +37,7 @@ export class TenantClient {
       } catch (e) {
         lastErr = e as Error;
         const m = /^HTTP (\d{3}) /.exec(lastErr.message);
-        const status = m ? parseInt(m[1], 10) : undefined;
+        const status = m ? parseInt(m[1]!, 10) : undefined;
         const retryable =
           status === undefined || status === 429 || status >= 500;
         if (!retryable || attempt === RETRIES) throw lastErr;

--- a/test/eval/loaders/directory-query-bank.ts
+++ b/test/eval/loaders/directory-query-bank.ts
@@ -165,7 +165,7 @@ function sampleDeterministic(
   const rand = mulberry32(seed);
   for (let i = 0; i < k; i++) {
     const j = i + Math.floor(rand() * (arr.length - i));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
+    [arr[i], arr[j]] = [arr[j]!, arr[i]!];
   }
   return arr.slice(0, k);
 }

--- a/test/eval/loaders/json-directory.loader.ts
+++ b/test/eval/loaders/json-directory.loader.ts
@@ -256,8 +256,8 @@ function parseDirectory(parsed: unknown, origin: string): LoadedDirectory {
     const requestId = req<string>(f, 'requestId', fTrail, 'string');
     const [vMaybe, idMaybe] = ref.split('.', 2);
     const entityRef = idMaybe
-      ? { vertical: vMaybe, id: idMaybe }
-      : { vertical: directoryName, id: vMaybe };
+      ? { vertical: vMaybe!, id: idMaybe }
+      : { vertical: directoryName, id: vMaybe! };
     setup.push({
       kind: 'forget',
       entityRef,

--- a/test/eval/locomo/loader.ts
+++ b/test/eval/locomo/loader.ts
@@ -72,7 +72,7 @@ function extractSessions(conv: LocomoRawConversation): LocomoSession[] {
   for (const key of Object.keys(conv)) {
     const match = key.match(/^session_(\d+)$/);
     if (!match) continue;
-    const idx = parseInt(match[1], 10);
+    const idx = parseInt(match[1]!, 10);
     const turnsValue = conv[key];
     if (!Array.isArray(turnsValue)) {
       throw new Error(

--- a/test/eval/locomo/metrics.ts
+++ b/test/eval/locomo/metrics.ts
@@ -153,9 +153,9 @@ function lcsLength(a: string[], b: string[]): number {
   const curr = new Array<number>(n + 1).fill(0);
   for (let i = 1; i <= m; i++) {
     for (let j = 1; j <= n; j++) {
-      curr[j] = a[i - 1] === b[j - 1] ? prev[j - 1] + 1 : Math.max(prev[j], curr[j - 1]);
+      curr[j] = a[i - 1] === b[j - 1] ? prev[j - 1]! + 1 : Math.max(prev[j]!, curr[j - 1]!);
     }
-    for (let j = 0; j <= n; j++) prev[j] = curr[j];
+    for (let j = 0; j <= n; j++) prev[j] = curr[j]!;
   }
-  return prev[n];
+  return prev[n]!;
 }

--- a/test/eval/locomo/runner.ts
+++ b/test/eval/locomo/runner.ts
@@ -401,8 +401,8 @@ export function summarizeTokens(
     p90PromptTokens: prompts[Math.min(
       prompts.length - 1,
       Math.floor(prompts.length * 0.9),
-    )],
-    maxPromptTokens: prompts[prompts.length - 1],
+    )]!,
+    maxPromptTokens: prompts[prompts.length - 1]!,
     avgCompletionTokens: Math.round(
       reported.reduce((a, s) => a + (s.completionTokens ?? 0), 0) /
         reported.length,

--- a/test/eval/metrics/bootstrap.ts
+++ b/test/eval/metrics/bootstrap.ts
@@ -59,7 +59,7 @@ export function bootstrapMeanCI(
     // CI for a single observation is the observation itself —
     // any percentile is the same value. Surface this as a bound
     // pair so callers don't crash on null arithmetic.
-    return { level, lower: values[0], upper: values[0], resamples: 0 };
+    return { level, lower: values[0]!, upper: values[0]!, resamples: 0 };
   }
 
   const rand = mulberry32(seed);
@@ -69,7 +69,7 @@ export function bootstrapMeanCI(
     let sum = 0;
     for (let i = 0; i < n; i++) {
       const idx = Math.floor(rand() * n);
-      sum += values[idx];
+      sum += values[idx]!;
     }
     means[b] = sum / n;
   }
@@ -80,8 +80,8 @@ export function bootstrapMeanCI(
   const upperIdx = Math.min(B - 1, Math.ceil((1 - alpha / 2) * B) - 1);
   return {
     level,
-    lower: means[lowerIdx],
-    upper: means[upperIdx],
+    lower: means[lowerIdx]!,
+    upper: means[upperIdx]!,
     resamples: B,
   };
 }

--- a/test/eval/runner/memory-assertions.ts
+++ b/test/eval/runner/memory-assertions.ts
@@ -228,5 +228,5 @@ export class MemoryAssertionsChecker {
  */
 function parseRefTag(ref: string): { refKey: string; id: string } {
   const [vertical, id] = ref.split('.', 2);
-  return { refKey: `${vertical}__${id}`, id };
+  return { refKey: `${vertical}__${id}`, id: id! };
 }

--- a/test/eval/runner/query-executor.ts
+++ b/test/eval/runner/query-executor.ts
@@ -32,7 +32,7 @@ export class QueryExecutor {
 
     const factPredicateMatched =
       expectation.expectedFactPredicate && rankOfExpected > 0
-        ? res.results[rankOfExpected - 1].facts.some(
+        ? res.results[rankOfExpected - 1]!.facts.some(
             (f) => f.predicate === expectation.expectedFactPredicate,
           )
         : null;

--- a/test/extraction-pattern.unit-spec.ts
+++ b/test/extraction-pattern.unit-spec.ts
@@ -73,8 +73,8 @@ describe('ExtractionPatternService', () => {
     // Lookup uses different casing — should still hit (normalised).
     const hit = await svc.lookup('demo', '  MARIA IS THE CTO AT ACME  ');
     expect(hit).toBeDefined();
-    expect(hit!.facts[0].predicate).toBe('status');
-    expect(hit!.edges[0].kind).toBe('works_at');
+    expect(hit!.facts[0]!.predicate).toBe('status');
+    expect(hit!.edges[0]!.kind).toBe('works_at');
   });
 
   it('record() upserts an entry per clause', async () => {
@@ -98,9 +98,9 @@ describe('ExtractionPatternService', () => {
     ]);
     // Two queries per pattern: UPSERT + sourceCount bump.
     expect(upserts).toHaveLength(2);
-    const upsertSql = upserts[0].sql;
+    const upsertSql = upserts[0]!.sql;
     expect(upsertSql).toContain('UPSERT extraction_pattern');
-    expect(upserts[0].params?.key).toBe('maria is the cto at acme');
+    expect(upserts[0]!.params?.key).toBe('maria is the cto at acme');
   });
 
   it('record() skips empty clause text', async () => {

--- a/test/extractor-edges.unit-spec.ts
+++ b/test/extractor-edges.unit-spec.ts
@@ -141,7 +141,7 @@ describe('Extractor edge parsing — bounds + dedup', () => {
       2,
       clauses,
     );
-    expect(edges[0].kind).toBe('works_at');
+    expect(edges[0]!.kind).toBe('works_at');
   });
 
   it('clamps confidence to [0,1] and defaults when missing', () => {
@@ -154,8 +154,8 @@ describe('Extractor edge parsing — bounds + dedup', () => {
       clauses,
     );
     expect(edges).toHaveLength(2);
-    expect(edges[0].confidence).toBe(1);
-    expect(edges[1].confidence).toBe(0.7);
+    expect(edges[0]!.confidence).toBe(1);
+    expect(edges[1]!.confidence).toBe(0.7);
   });
 
   it('omits clause when clauseIndex out of bounds', () => {
@@ -164,7 +164,7 @@ describe('Extractor edge parsing — bounds + dedup', () => {
       2,
       clauses,
     );
-    expect(edges[0].clause).toBeUndefined();
+    expect(edges[0]!.clause).toBeUndefined();
   });
 
   it('returns [] on non-array input', () => {

--- a/test/extractor-facet-routing.unit-spec.ts
+++ b/test/extractor-facet-routing.unit-spec.ts
@@ -127,7 +127,7 @@ describe('mergeExtractions', () => {
     ]);
     expect(merged.entities.map((e) => e.name)).toEqual(['Melanie', 'Caroline']);
     const adopted = merged.facts.find((f) => f.predicate === 'adopted');
-    expect(merged.entities[adopted!.entityIndex].name).toBe('Caroline');
+    expect(merged.entities[adopted!.entityIndex]!.name).toBe('Caroline');
   });
 
   it('remaps edge endpoints and dedupes edges by entity identity, not position', () => {
@@ -151,8 +151,8 @@ describe('mergeExtractions', () => {
       ),
     ]);
     expect(merged.edges).toHaveLength(1);
-    expect(merged.entities[merged.edges[0].fromEntityIndex].name).toBe('Melanie');
-    expect(merged.entities[merged.edges[0].toEntityIndex].name).toBe('Acme');
+    expect(merged.entities[merged.edges[0]!.fromEntityIndex]!.name).toBe('Melanie');
+    expect(merged.entities[merged.edges[0]!.toEntityIndex]!.name).toBe('Acme');
   });
 
   it('unions facts across passes and drops semantic duplicates', () => {
@@ -177,8 +177,8 @@ describe('mergeExtractions', () => {
       pass([['Tim', 'customer']], [[0, 'read', 'Dune']]),
       pass([['Tim', 'customer']], [[0, 'lives_in', 'Dublin']]),
     ]);
-    expect(merged.facts[0].extractionAgreement).toBeUndefined();
-    expect(merged.facts[0].extractionEntropy).toBeUndefined();
+    expect(merged.facts[0]!.extractionAgreement).toBeUndefined();
+    expect(merged.facts[0]!.extractionEntropy).toBeUndefined();
   });
 
   it('emits self-consistency stats when asked (multi-pass re-rolls)', () => {
@@ -189,7 +189,7 @@ describe('mergeExtractions', () => {
       ],
       { selfConsistency: true },
     );
-    expect(merged.facts[0].extractionAgreement).toBe(1);
+    expect(merged.facts[0]!.extractionAgreement).toBe(1);
   });
 
   it('handles a pass that produced nothing', () => {

--- a/test/extractor-prompt-injection.unit-spec.ts
+++ b/test/extractor-prompt-injection.unit-spec.ts
@@ -114,8 +114,8 @@ describe('ExtractorService — prompt injection resistance', () => {
     });
     const res = await svc.extract('Anna is here', 'co_test');
     expect(res.facts.length).toBe(1);
-    expect(res.facts[0].predicate).toBe('name');
-    expect(res.facts[0].object).toBe('Anna');
+    expect(res.facts[0]!.predicate).toBe('name');
+    expect(res.facts[0]!.object).toBe('Anna');
   });
 
   it('does not emit anything when the LLM returns nothing (null response)', async () => {

--- a/test/extractor-sc-passes.unit-spec.ts
+++ b/test/extractor-sc-passes.unit-spec.ts
@@ -87,8 +87,8 @@ describe('ExtractorService N-pass driver', () => {
     ]);
     const res = await svc.extract('hello A', 'co_test');
     expect(res.facts).toHaveLength(1);
-    expect(res.facts[0].extractionEntropy).toBeUndefined();
-    expect(res.facts[0].extractionAgreement).toBeUndefined();
+    expect(res.facts[0]!.extractionEntropy).toBeUndefined();
+    expect(res.facts[0]!.extractionAgreement).toBeUndefined();
   });
 
   it('three-pass consensus → entropy ≈ 0, agreement = 1', async () => {
@@ -109,8 +109,8 @@ describe('ExtractorService N-pass driver', () => {
     const svc = mkExtractor(3, [allAgree, allAgree, allAgree]);
     const res = await svc.extract('hello A', 'co_test');
     expect(res.facts).toHaveLength(1);
-    expect(res.facts[0].extractionEntropy).toBeCloseTo(0, 3);
-    expect(res.facts[0].extractionAgreement).toBe(1);
+    expect(res.facts[0]!.extractionEntropy).toBeCloseTo(0, 3);
+    expect(res.facts[0]!.extractionAgreement).toBe(1);
   });
 
   it('three-pass disagreement → positive entropy + agreement = 1/3', async () => {

--- a/test/fact-centric-limit.unit-spec.ts
+++ b/test/fact-centric-limit.unit-spec.ts
@@ -47,7 +47,7 @@ describe('selectFactCentric layers over the ranking (W4 #15)', () => {
 
   it('buckets outside the reranked window follow by best fact score', () => {
     const out = selectFactCentric(buckets, 48, { priority: ['e4'] });
-    expect(out[0].entityId).toBe('e4');
+    expect(out[0]!.entityId).toBe('e4');
     expect(out.slice(1).map((b) => b.entityId)).toEqual(['e1', 'e2', 'e3']);
   });
 
@@ -55,7 +55,7 @@ describe('selectFactCentric layers over the ranking (W4 #15)', () => {
     const out = selectFactCentric(buckets, 2, {});
     const facts = out.reduce((a, b) => a + b.facts.length, 0);
     expect(facts).toBe(2);
-    expect(out[0].entityId).toBe('e1');
+    expect(out[0]!.entityId).toBe('e1');
   });
 
   it('no limit → legacy behaviour (every surviving bucket)', () => {

--- a/test/fact-provenance.unit-spec.ts
+++ b/test/fact-provenance.unit-spec.ts
@@ -287,8 +287,8 @@ describe('GET /v1/facts/:id/provenance — grounding episodes', () => {
       occurredAt: '2026-07-01T10:00:00.000Z',
       text: 'I love hiking, we should plan a trip!',
     });
-    expect(res.episodes[1].text.length).toBe(600);
-    expect(res.episodes[1].text.endsWith('…')).toBe(true);
+    expect(res.episodes[1]!.text.length).toBe(600);
+    expect(res.episodes[1]!.text.endsWith('…')).toBe(true);
   });
 
   it('G3: a fact with source.charSpans serves span + textTruncated per episode', async () => {
@@ -330,17 +330,17 @@ describe('GET /v1/facts/:id/provenance — grounding episodes', () => {
       scopes: READ,
     });
     // Wire span is {start, end, exact} only — prefix/suffix stay stored.
-    expect(res.episodes[0].span).toEqual({ start: 7, end: 13, exact: 'hiking' });
-    expect(res.episodes[0].textTruncated).toBe(false);
+    expect(res.episodes[0]!.span).toEqual({ start: 7, end: 13, exact: 'hiking' });
+    expect(res.episodes[0]!.textTruncated).toBe(false);
     // Truncated episode: offsets reference the FULL stored text, and
     // textTruncated says so.
-    expect(res.episodes[1].span).toEqual({
+    expect(res.episodes[1]!.span).toEqual({
       start: 700,
       end: 706,
       exact: 'routes',
     });
-    expect(res.episodes[1].textTruncated).toBe(true);
-    expect(res.episodes[1].text.length).toBe(600);
+    expect(res.episodes[1]!.textTruncated).toBe(true);
+    expect(res.episodes[1]!.text.length).toBe(600);
   });
 
   it('G3: a fact without charSpans keeps the pre-span episode shape', async () => {

--- a/test/fact-rerank.unit-spec.ts
+++ b/test/fact-rerank.unit-spec.ts
@@ -32,8 +32,8 @@ describe('collectFactWindow', () => {
       3,
     );
     expect(rows.map((r) => r.row.score)).toEqual([0.9, 0.7, 0.5]);
-    expect(rows[0].bucket.entityId).toBe('a');
-    expect(rows[1].bucket.entityId).toBe('b');
+    expect(rows[0]!.bucket.entityId).toBe('a');
+    expect(rows[1]!.bucket.entityId).toBe('b');
   });
 
   it('window larger than the pool returns the whole pool', () => {
@@ -100,7 +100,7 @@ describe('fact rerank feeding the fact-centric cut', () => {
     const rows = collectFactWindow([a], 2);
     remapWindowScores(rows, [1, 0]);
     // Tail fact keeps its score; window min (0.8) still above it.
-    expect(a.facts[2].score).toBe(0.3);
+    expect(a.facts[2]!.score).toBe(0.3);
     expect(Math.min(...a.facts.slice(0, 2).map((f) => f.score))).toBe(0.8);
   });
 });

--- a/test/fact-resolver-batch.unit-spec.ts
+++ b/test/fact-resolver-batch.unit-spec.ts
@@ -71,7 +71,7 @@ describe('FactResolverService.resolveMany', () => {
       input('intent', 'c'),
     ]);
     expect(batchQ(queries)).toHaveLength(1);
-    expect(batchQ(queries)[0].params.facts).toHaveLength(3);
+    expect(batchQ(queries)[0]!.params.facts).toHaveLength(3);
     expect(perFactQ(queries)).toHaveLength(0);
     expect(out.map((o) => o.result.factId)).toEqual([
       'knowledge_fact:batch0_a',
@@ -88,12 +88,12 @@ describe('FactResolverService.resolveMany', () => {
       input('status', 's'),
       input('intent', 'c'),
     ]);
-    expect(batchQ(queries)[0].params.facts.map((f: any) => f.object)).toEqual([
+    expect(batchQ(queries)[0]!.params.facts.map((f: any) => f.object)).toEqual([
       'a',
       'c',
     ]);
     expect(perFactQ(queries)).toHaveLength(1);
-    expect(perFactQ(queries)[0].params.object).toBe('s');
+    expect(perFactQ(queries)[0]!.params.object).toBe('s');
     // Result order matches INPUT order: a(batch), s(single), c(batch).
     expect(out.map((o) => o.result.factId)).toEqual([
       'knowledge_fact:batch0_a',

--- a/test/fact-trust-scoring.unit-spec.ts
+++ b/test/fact-trust-scoring.unit-spec.ts
@@ -58,8 +58,8 @@ describe('scoreRows — fact_trust factors', () => {
       now: NOW,
       trustBeta: 2,
     });
-    expect(scored.breakdown.factTrust?.sourceReputation).toBe(0.5);
-    expect(scored.breakdown.factTrust?.trustFactor).toBe(1);
+    expect(scored!.breakdown.factTrust?.sourceReputation).toBe(0.5);
+    expect(scored!.breakdown.factTrust?.trustFactor).toBe(1);
   });
 
   it('beta scales the snapshot ladder: learnedTrust ?? declaredTrust ?? 0.5', () => {
@@ -71,10 +71,10 @@ describe('scoreRows — fact_trust factors', () => {
       now: NOW,
       trustBeta: 1,
     });
-    expect(learned.breakdown.factTrust?.trustFactor).toBeCloseTo(1.4);
-    expect(declaredOnly.breakdown.factTrust?.trustFactor).toBeCloseTo(1.2);
+    expect(learned!.breakdown.factTrust?.trustFactor).toBeCloseTo(1.4);
+    expect(declaredOnly!.breakdown.factTrust?.trustFactor).toBeCloseTo(1.2);
     // trusted fact outranks the identical-otherwise less-trusted one
-    expect(learned.score).toBeGreaterThan(declaredOnly.score);
+    expect(learned!.score).toBeGreaterThan(declaredOnly!.score);
   });
 
   it('gamma rewards corroboration, capped at 3', () => {
@@ -86,8 +86,8 @@ describe('scoreRows — fact_trust factors', () => {
       now: NOW,
       corroborationGamma: 0.1,
     });
-    expect(three.breakdown.factTrust?.corroborationFactor).toBeCloseTo(1.3);
-    expect(ten.breakdown.factTrust?.corroborationFactor).toBeCloseTo(1.3);
+    expect(three!.breakdown.factTrust?.corroborationFactor).toBeCloseTo(1.3);
+    expect(ten!.breakdown.factTrust?.corroborationFactor).toBeCloseTo(1.3);
   });
 
   it('delta scales registry authority; no registry entry is unaffected at ANY delta', () => {
@@ -99,9 +99,9 @@ describe('scoreRows — fact_trust factors', () => {
       now: NOW,
       authorityDelta: 0.5,
     });
-    expect(authoritative.breakdown.factTrust?.authorityFactor).toBeCloseTo(1.4);
-    expect(unregistered.breakdown.factTrust?.authorityFactor).toBe(1);
-    expect(authoritative.score).toBeGreaterThan(unregistered.score);
+    expect(authoritative!.breakdown.factTrust?.authorityFactor).toBeCloseTo(1.4);
+    expect(unregistered!.breakdown.factTrust?.authorityFactor).toBe(1);
+    expect(authoritative!.score).toBeGreaterThan(unregistered!.score);
   });
 
   it('surfaces the "because" decomposition (authority + evidence count)', () => {
@@ -120,7 +120,7 @@ describe('scoreRows — fact_trust factors', () => {
       ],
       now: NOW,
     });
-    expect(scored.breakdown.factTrust).toMatchObject({
+    expect(scored!.breakdown.factTrust).toMatchObject({
       sourceReputation: 0.8,
       authority: 0.9,
       evidenceCount: 2,

--- a/test/facts-list-competing.e2e-spec.ts
+++ b/test/facts-list-competing.e2e-spec.ts
@@ -97,15 +97,15 @@ describe('FactsService.listCompeting — groups competing pairs by predicate', (
 
     expect(out.entityId).toBe(ENT_FULL);
     expect(out.groups).toHaveLength(1);
-    const [group] = out.groups;
+    const group = out.groups[0]!;
     expect(group.predicate).toBe('status');
     expect(group.entityId).toBe(ENT_FULL);
     expect(group.facts).toHaveLength(2);
     const objects = group.facts.map((f) => f.object).sort();
     expect(objects).toEqual(['active', 'churned']);
     // recordedAt-ascending order preserved.
-    expect(group.facts[0].factId).toBe('knowledge_fact:lc_a');
-    expect(group.facts[1].factId).toBe('knowledge_fact:lc_b');
+    expect(group.facts[0]!.factId).toBe('knowledge_fact:lc_a');
+    expect(group.facts[1]!.factId).toBe('knowledge_fact:lc_b');
   });
 
   it('filters to the requested predicate only', async () => {

--- a/test/faithfulness.unit-spec.ts
+++ b/test/faithfulness.unit-spec.ts
@@ -151,7 +151,7 @@ describe('computeFaithfulness', () => {
     });
     // Score = (1 + 0.5*1 + 0) / 3 = 0.5
     expect(out.faithfulness).toBeCloseTo(0.5, 6);
-    expect(out.claims[2].verdict).toBe('not_supported');
+    expect(out.claims[2]!.verdict).toBe('not_supported');
   });
 
   it('verifier returns invalid enum value → padded to not_supported', async () => {
@@ -164,7 +164,7 @@ describe('computeFaithfulness', () => {
       sourceFacts: [],
     });
     expect(out.faithfulness).toBe(0);
-    expect(out.claims[0].verdict).toBe('not_supported');
+    expect(out.claims[0]!.verdict).toBe('not_supported');
   });
 
   it('claim text round-trips through to the score', async () => {

--- a/test/false-premise-checker.unit-spec.ts
+++ b/test/false-premise-checker.unit-spec.ts
@@ -54,7 +54,7 @@ describe('FaithfulnessChecker — false-premise branch', () => {
       .fn()
       .mockResolvedValue(emptyRes({ answer: null, reason: 'no_results' }));
     const { checker, openai } = makeChecker(synthesize);
-    const [out] = await checker.check(fpScenario());
+    const out = (await checker.check(fpScenario()))[0]!;
     expect(out.expectedRefusal).toBe(true);
     expect(out.refused).toBe(true);
     expect(out.passed).toBe(true);
@@ -67,7 +67,7 @@ describe('FaithfulnessChecker — false-premise branch', () => {
       emptyRes({ answer: "I don't have grounded evidence for that." }),
     );
     const { checker } = makeChecker(synthesize);
-    const [out] = await checker.check(fpScenario());
+    const out = (await checker.check(fpScenario()))[0]!;
     expect(out.refused).toBe(true);
     expect(out.passed).toBe(true);
   });
@@ -77,7 +77,7 @@ describe('FaithfulnessChecker — false-premise branch', () => {
       emptyRes({ answer: 'Her brother said the intercom was fine.', citations: [] }),
     );
     const { checker } = makeChecker(synthesize);
-    const [out] = await checker.check(fpScenario());
+    const out = (await checker.check(fpScenario()))[0]!;
     expect(out.refused).toBe(false);
     expect(out.passed).toBe(false);
     expect(out.expectedRefusal).toBe(true);
@@ -86,7 +86,7 @@ describe('FaithfulnessChecker — false-premise branch', () => {
   it('an exception fails closed (not a false pass)', async () => {
     const synthesize = jest.fn().mockRejectedValue(new Error('boom'));
     const { checker } = makeChecker(synthesize);
-    const [out] = await checker.check(fpScenario());
+    const out = (await checker.check(fpScenario()))[0]!;
     expect(out.passed).toBe(false);
   });
 });

--- a/test/fat-tenant.real-e2e-spec.ts
+++ b/test/fat-tenant.real-e2e-spec.ts
@@ -70,7 +70,7 @@ describe('Fat-tenant retrieval eval', () => {
       });
       const limitedClient = new HttpBrainClient({
         baseUrl: svc.baseUrl,
-        apiKey: svc.extras[0].plaintext,
+        apiKey: svc.extras[0]!.plaintext,
       });
 
       const runner = new EvalRunner(

--- a/test/feedback-trust-events.unit-spec.ts
+++ b/test/feedback-trust-events.unit-spec.ts
@@ -43,7 +43,7 @@ describe('buildFeedbackTrustEvents', () => {
   });
 
   it('falls back to the _ recorder like the fact-status events', () => {
-    const [e] = buildFeedbackTrustEvents([{ ...row('helpful'), recorder: null }]);
+    const e = buildFeedbackTrustEvents([{ ...row('helpful'), recorder: null }])[0]!;
     expect(e.sourceKey).toBe('rent:_');
   });
 

--- a/test/feedback.e2e-spec.ts
+++ b/test/feedback.e2e-spec.ts
@@ -64,8 +64,8 @@ describe('retrieval feedback loop', () => {
       );
       const votes = rows as Array<{ verdict: string; reason: string | null }>;
       expect(votes).toHaveLength(1);
-      expect(votes[0].verdict).toBe('incorrect');
-      expect(votes[0].reason).toBe('tier is actually silver');
+      expect(votes[0]!.verdict).toBe('incorrect');
+      expect(votes[0]!.reason).toBe('tier is actually silver');
     });
   });
 
@@ -91,8 +91,8 @@ describe('retrieval feedback loop', () => {
       // The active fact itself is a win; the standing 'incorrect'
       // feedback vote is the loss.
       expect(trust).toBeDefined();
-      expect(trust.lossCount).toBeGreaterThanOrEqual(1);
-      expect(trust.sampleCount).toBeGreaterThanOrEqual(2);
+      expect(trust!.lossCount).toBeGreaterThanOrEqual(1);
+      expect(trust!.sampleCount).toBeGreaterThanOrEqual(2);
     });
   });
 });

--- a/test/flag-budget.unit-spec.ts
+++ b/test/flag-budget.unit-spec.ts
@@ -57,7 +57,7 @@ function currentEngineFlags(): Set<string> {
     /envFlag(?:Enabled|NotDisabled)\(\s*(?:process\.env\.|this\.configService\.get<string>\(.)([A-Z][A-Z0-9_]+)/g;
   for (const f of files) {
     const text = readFileSync(f, 'utf8');
-    for (const m of text.matchAll(parserRead)) keys.add(m[1]);
+    for (const m of text.matchAll(parserRead)) keys.add(m[1]!);
   }
   for (const entry of CONFIG_CATALOG) {
     if (entry.isBooleanFlag) keys.add(entry.key);

--- a/test/gate-kinds-golden.unit-spec.ts
+++ b/test/gate-kinds-golden.unit-spec.ts
@@ -101,6 +101,6 @@ describe('multi-label kinds heads', () => {
       { epochs: 20, seed: 7 },
     );
     expect(v1.version).toBe(1);
-    expect(new TrainedDecisionClassifier(v1).classifyKinds(goldenCommit(GATE_GOLDEN[0]))).toEqual([]);
+    expect(new TrainedDecisionClassifier(v1).classifyKinds(goldenCommit(GATE_GOLDEN[0]!))).toEqual([]);
   });
 });

--- a/test/gen-ai-observability.unit-spec.ts
+++ b/test/gen-ai-observability.unit-spec.ts
@@ -34,11 +34,11 @@ describe('withGenAiCall', () => {
     );
     expect((res as any).id).toBe('resp_abc');
     expect(m.recorded).toHaveLength(1);
-    expect(m.recorded[0].kind).toBe('chat');
-    expect(m.recorded[0].outcome).toBe('ok');
-    expect(m.recorded[0].promptTokens).toBe(12);
-    expect(m.recorded[0].completionTokens).toBe(4);
-    expect(m.recorded[0].durationSeconds).toBeGreaterThanOrEqual(0);
+    expect(m.recorded[0]!.kind).toBe('chat');
+    expect(m.recorded[0]!.outcome).toBe('ok');
+    expect(m.recorded[0]!.promptTokens).toBe(12);
+    expect(m.recorded[0]!.completionTokens).toBe(4);
+    expect(m.recorded[0]!.durationSeconds).toBeGreaterThanOrEqual(0);
   });
 
   it('folds embed response.usage.total_tokens into promptTokens', async () => {
@@ -48,8 +48,8 @@ describe('withGenAiCall', () => {
       m as any,
       async () => ({ usage: { total_tokens: 7 } }),
     );
-    expect(m.recorded[0].promptTokens).toBe(7);
-    expect(m.recorded[0].completionTokens).toBeUndefined();
+    expect(m.recorded[0]!.promptTokens).toBe(7);
+    expect(m.recorded[0]!.completionTokens).toBeUndefined();
   });
 
   it('records outcome=error and re-throws when the inner fn throws', async () => {
@@ -63,7 +63,7 @@ describe('withGenAiCall', () => {
         },
       ),
     ).rejects.toThrow('boom');
-    expect(m.recorded[0].outcome).toBe('error');
+    expect(m.recorded[0]!.outcome).toBe('error');
   });
 
   it('handles missing MetricsService gracefully (Optional inject)', async () => {
@@ -82,8 +82,8 @@ describe('withGenAiCall', () => {
       m as any,
       async () => ({ id: 'r' }),
     );
-    expect(m.recorded[0].outcome).toBe('ok');
-    expect(m.recorded[0].promptTokens).toBeUndefined();
-    expect(m.recorded[0].completionTokens).toBeUndefined();
+    expect(m.recorded[0]!.outcome).toBe('ok');
+    expect(m.recorded[0]!.promptTokens).toBeUndefined();
+    expect(m.recorded[0]!.completionTokens).toBeUndefined();
   });
 });

--- a/test/graph-retrieve.unit-spec.ts
+++ b/test/graph-retrieve.unit-spec.ts
@@ -58,11 +58,11 @@ describe('assembleGraphHits — regression for the Acme/Maria case', () => {
     // Seed comes first (anchor), Maria as the neighbour with the hit.
     expect(out.map((r) => r.entityId)).toEqual(['e_acme', 'e_maria']);
     // Maria's fact is what answers the question.
-    expect(out[1].facts).toHaveLength(1);
-    expect(out[1].facts[0].predicate).toBe('status');
-    expect(out[1].facts[0].object).toBe('CTO at Acme');
+    expect(out[1]!.facts).toHaveLength(1);
+    expect(out[1]!.facts[0]!.predicate).toBe('status');
+    expect(out[1]!.facts[0]!.object).toBe('CTO at Acme');
     // Seed is lifted higher than neighbour.
-    expect(out[0].score).toBeGreaterThan(out[1].score);
+    expect(out[0]!.score).toBeGreaterThan(out[1]!.score);
   });
 
   it('seed with no facts + neighbour with non-hint facts → neighbour DROPPED', () => {
@@ -114,8 +114,8 @@ describe('assembleGraphHits — regression for the Acme/Maria case', () => {
     ] });
 
     expect(out).toHaveLength(1);
-    expect(out[0].entityId).toBe('e_acme');
-    expect(out[0].facts).toEqual([]);
+    expect(out[0]!.entityId).toBe('e_acme');
+    expect(out[0]!.facts).toEqual([]);
   });
 
   it('multiple seeds preserved in input order', () => {
@@ -146,8 +146,8 @@ describe('assembleGraphHits — regression for the Acme/Maria case', () => {
 
     const out = assembleGraphHits({ seedIds: ['e_maria'], entitiesById: entitiesById, factsByEntity: factsByEntity, predicateHints: ['status'] });
 
-    expect(out[0].facts).toHaveLength(1);
-    expect(out[0].facts[0].factId).toBe('f_new');
+    expect(out[0]!.facts).toHaveLength(1);
+    expect(out[0]!.facts[0]!.factId).toBe('f_new');
   });
 
   it('fact score is higher when predicate matches a hint', () => {
@@ -165,7 +165,7 @@ describe('assembleGraphHits — regression for the Acme/Maria case', () => {
 
     const out = assembleGraphHits({ seedIds: ['e_maria'], entitiesById: entitiesById, factsByEntity: factsByEntity, predicateHints: ['status'] });
 
-    const byPredicate = new Map(out[0].facts.map((f) => [f.predicate, f.score]));
+    const byPredicate = new Map(out[0]!.facts.map((f) => [f.predicate, f.score]));
     expect(byPredicate.get('status')).toBeGreaterThan(byPredicate.get('name')!);
   });
 

--- a/test/grounding-spans.unit-spec.ts
+++ b/test/grounding-spans.unit-spec.ts
@@ -81,7 +81,7 @@ describe('applyGroundingGate value word-boundary', () => {
     ];
     const { facts, dropped } = applyGroundingGate('she is active', raw, { clauses: [] });
     expect(facts).toHaveLength(0);
-    expect(dropped[0].reason).toBe('not_grounded');
+    expect(dropped[0]!.reason).toBe('not_grounded');
   });
 });
 
@@ -104,7 +104,7 @@ describe('applyGroundingGate allowUngrounded (dialogue profile, Phase 4)', () =>
       { clauses: [] },
     );
     expect(facts).toHaveLength(0);
-    expect(dropped[0].reason).toBe('not_grounded');
+    expect(dropped[0]!.reason).toBe('not_grounded');
   });
 
   it('KEEPS the normalized value when allowUngrounded=true', () => {
@@ -114,8 +114,8 @@ describe('applyGroundingGate allowUngrounded (dialogue profile, Phase 4)', () =>
       { clauses: [], allowUngrounded: true },
     );
     expect(facts).toHaveLength(1);
-    expect(facts[0].object).toBe('single');
-    expect(facts[0].predicate).toBe('relationship_status');
+    expect(facts[0]!.object).toBe('single');
+    expect(facts[0]!.predicate).toBe('relationship_status');
     expect(dropped).toHaveLength(0);
   });
 
@@ -125,7 +125,7 @@ describe('applyGroundingGate allowUngrounded (dialogue profile, Phase 4)', () =>
     ];
     const { facts, dropped } = applyGroundingGate('anything', empty, { clauses: [], allowUngrounded: true });
     expect(facts).toHaveLength(0);
-    expect(dropped[0].reason).toBe('empty');
+    expect(dropped[0]!.reason).toBe('empty');
   });
 });
 
@@ -158,8 +158,8 @@ describe('object normalization (E3b, EXTRACTION_OBJECT_NORMALIZE)', () => {
       [{ ...camping, object: 'the mountains' }],
       { clauses: [], normalizeObjects: true },
     );
-    expect(facts[0].object).toBe('the mountains');
-    expect(facts[0].valueSpan).toBe('camped in the mountains with my kids');
+    expect(facts[0]!.object).toBe('the mountains');
+    expect(facts[0]!.valueSpan).toBe('camped in the mountains with my kids');
     expect(ungroundedObjects).toHaveLength(0);
   });
 
@@ -169,7 +169,7 @@ describe('object normalization (E3b, EXTRACTION_OBJECT_NORMALIZE)', () => {
       [{ ...camping, object: 'family hiking trip' }],
       { clauses: [], normalizeObjects: true },
     );
-    expect(facts[0].object).toBe('camped in the mountains with my kids');
+    expect(facts[0]!.object).toBe('camped in the mountains with my kids');
     expect(ungroundedObjects).toEqual([
       {
         predicate: 'activity',
@@ -185,7 +185,7 @@ describe('object normalization (E3b, EXTRACTION_OBJECT_NORMALIZE)', () => {
       [{ ...camping, object: 'the mountains' }],
       { clauses: [] },
     );
-    expect(facts[0].object).toBe('camped in the mountains with my kids');
+    expect(facts[0]!.object).toBe('camped in the mountains with my kids');
     expect(ungroundedObjects).toHaveLength(0);
   });
 

--- a/test/hnsw.e2e-spec.ts
+++ b/test/hnsw.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('HNSW vector leg (real SurrealDB)', () => {
     delete process.env.SEARCH_HNSW_ENABLED;
     expect(results.length).toBeGreaterThan(0);
     // canonicalName defaults to the entityRef id at upsert time.
-    expect(results[0].canonicalName).toBe('hnsw_subject');
+    expect(results[0]!.canonicalName).toBe('hnsw_subject');
   });
 
   it('creates indexes with the live dimension and matches the exact scan', async () => {
@@ -77,7 +77,7 @@ describe('HNSW vector leg (real SurrealDB)', () => {
     delete process.env.SEARCH_HNSW_ENABLED;
 
     expect(viaKnn.length).toBeGreaterThan(0);
-    expect(viaKnn[0].canonicalName).toBe(baseline[0].canonicalName);
+    expect(viaKnn[0]!.canonicalName).toBe(baseline[0]!.canonicalName);
   });
 
   it('drop removes the indexes and search still answers', async () => {

--- a/test/insight-lane.unit-spec.ts
+++ b/test/insight-lane.unit-spec.ts
@@ -61,10 +61,10 @@ describe('runInsightLegs', () => {
     });
     expect(vectorRows).toHaveLength(1);
     expect(lexicalRows).toHaveLength(1);
-    expect(vectorRows[0].predicate).toBe('aggregate_hobbies');
-    expect(vectorRows[0].simScore).toBe(0.9);
-    expect(lexicalRows[0].bm25Score).toBe(3.2);
-    expect(vectorRows[0].source.vertical).toBe('insight');
+    expect(vectorRows[0]!.predicate).toBe('aggregate_hobbies');
+    expect(vectorRows[0]!.simScore).toBe(0.9);
+    expect(lexicalRows[0]!.bm25Score).toBe(3.2);
+    expect(vectorRows[0]!.source.vertical).toBe('insight');
     for (const q of queries) {
       // The pool filter — aggregates by recorder, summaries by prefix.
       expect(q.sql).toContain('source.recorder = $insightRecorder');
@@ -90,7 +90,7 @@ describe('runInsightLegs', () => {
       derivedVersion: null,
     });
     expect(queries).toHaveLength(1); // no vector → BM25 only
-    expect(queries[0].sql).toContain('AND derivedVersion IS NONE');
+    expect(queries[0]!.sql).toContain('AND derivedVersion IS NONE');
   });
 
   it('budgets long insight text at a word boundary', async () => {
@@ -104,8 +104,8 @@ describe('runInsightLegs', () => {
       callerScopes: [],
       derivedVersion: 'wd-v2',
     });
-    expect(vectorRows[0].object.length).toBeLessThan(820);
-    expect(vectorRows[0].object.endsWith('[…]')).toBe(true);
+    expect(vectorRows[0]!.object.length).toBeLessThan(820);
+    expect(vectorRows[0]!.object.endsWith('[…]')).toBe(true);
   });
 });
 

--- a/test/intent-classifier-worker.unit-spec.ts
+++ b/test/intent-classifier-worker.unit-spec.ts
@@ -97,7 +97,7 @@ async function warmService(svc: IntentClassifierService): Promise<MockWorker> {
   svc.onModuleInit();
   await waitFor(() => svc.isReady());
   mockOnPost = previous;
-  return mockWorkers[mockWorkers.length - 1];
+  return mockWorkers[mockWorkers.length - 1]!;
 }
 
 beforeEach(() => {
@@ -119,7 +119,7 @@ describe('IntentClassifierService — worker runtime', () => {
     });
     expect(mockWorkers).toHaveLength(1);
     expect(
-      mockWorkers[0].posted.filter((m) => m.kind === 'classify'),
+      mockWorkers[0]!.posted.filter((m) => m.kind === 'classify'),
     ).toHaveLength(0);
     await svc.onApplicationShutdown();
   });
@@ -142,7 +142,7 @@ describe('IntentClassifierService — worker runtime', () => {
     expect(first).toEqual({ intent: 'ask', confidence: 0.82, source: 'nli' });
     const classifyCalls = worker.posted.filter((m) => m.kind === 'classify');
     expect(classifyCalls).toHaveLength(1);
-    expect(classifyCalls[0].payload).toEqual({
+    expect(classifyCalls[0]!.payload).toEqual({
       text: 'where Maria lives',
       labels: ['question', 'statement'],
       hypothesisTemplate: 'This text is a {}.',

--- a/test/isotonic.unit-spec.ts
+++ b/test/isotonic.unit-spec.ts
@@ -15,7 +15,7 @@ describe('fitIsotonic + applyMap', () => {
   it('produces a non-decreasing values sequence (monotone)', () => {
     const m = fitIsotonic(BOOTSTRAP_GOLD_SET);
     for (let i = 1; i < m.values.length; i++) {
-      expect(m.values[i]).toBeGreaterThanOrEqual(m.values[i - 1]);
+      expect(m.values[i]).toBeGreaterThanOrEqual(m.values[i - 1]!);
     }
   });
 
@@ -60,7 +60,7 @@ describe('fitIsotonic + applyMap', () => {
     const m = fitIsotonic(pairs, 10);
     expect(m.values.length).toBeLessThanOrEqual(2);
     for (let i = 1; i < m.values.length; i++) {
-      expect(m.values[i]).toBeGreaterThanOrEqual(m.values[i - 1]);
+      expect(m.values[i]).toBeGreaterThanOrEqual(m.values[i - 1]!);
     }
   });
 

--- a/test/job-claim.unit-spec.ts
+++ b/test/job-claim.unit-spec.ts
@@ -342,6 +342,6 @@ describe('JobClaimService', () => {
     const svc = new JobClaimService(mkSurreal(db));
     const rows = await svc.listActiveClaims(['co_x', 'co_y']);
     expect(rows).toHaveLength(2);
-    expect(rows[0].claimedBy).toBe('host#1');
+    expect(rows[0]!.claimedBy).toBe('host#1');
   });
 });

--- a/test/json-directory.real-e2e-spec.ts
+++ b/test/json-directory.real-e2e-spec.ts
@@ -79,7 +79,7 @@ describe('JSON-directory eval (load + retrieval + lifecycle)', () => {
       });
       const limitedClient = new HttpBrainClient({
         baseUrl: svc.baseUrl,
-        apiKey: svc.extras[0].plaintext,
+        apiKey: svc.extras[0]!.plaintext,
       });
 
       const runner = new EvalRunner(

--- a/test/l0-user-scope.unit-spec.ts
+++ b/test/l0-user-scope.unit-spec.ts
@@ -41,8 +41,8 @@ describe('L0 user-scope fence (0055) — episode read store', () => {
       limit: 5,
       includePii: true,
     });
-    expect(queries[0].sql).toContain(GLOBAL_ONLY);
-    expect(queries[0].params?.scopeUserId).toBeUndefined();
+    expect(queries[0]!.sql).toContain(GLOBAL_ONLY);
+    expect(queries[0]!.params?.scopeUserId).toBeUndefined();
   });
 
   it('searchText: scoped read sees global + own, never another user', async () => {
@@ -54,8 +54,8 @@ describe('L0 user-scope fence (0055) — episode read store', () => {
       includePii: true,
       userId: 'u1',
     });
-    expect(queries[0].sql).toContain(SCOPED);
-    expect(queries[0].params?.scopeUserId).toBe('u1');
+    expect(queries[0]!.sql).toContain(SCOPED);
+    expect(queries[0]!.params?.scopeUserId).toBe('u1');
   });
 
   it('byIds: fenced in both modes', async () => {
@@ -66,30 +66,30 @@ describe('L0 user-scope fence (0055) — episode read store', () => {
       ids: ['episode:e1'],
       includePii: false,
     });
-    expect(queries[0].sql).toContain(GLOBAL_ONLY);
+    expect(queries[0]!.sql).toContain(GLOBAL_ONLY);
     await svc.byIds({
       companyId: 'co_x',
       ids: ['episode:e1'],
       includePii: false,
       userId: 'u1',
     });
-    expect(queries[1].sql).toContain(SCOPED);
-    expect(queries[1].params?.scopeUserId).toBe('u1');
+    expect(queries[1]!.sql).toContain(SCOPED);
+    expect(queries[1]!.params?.scopeUserId).toBe('u1');
   });
 
   it('page (public API): fenced in both modes', async () => {
     const { surreal, queries } = recorder();
     const svc = new EpisodeReadStoreService(surreal);
     await svc.page({ companyId: 'co_x', includePii: false, limit: 10 });
-    expect(queries[0].sql).toContain('userId IS NONE');
+    expect(queries[0]!.sql).toContain('userId IS NONE');
     await svc.page({
       companyId: 'co_x',
       includePii: false,
       limit: 10,
       userId: 'u1',
     });
-    expect(queries[1].sql).toContain('userId = $scopeUserId');
-    expect(queries[1].params?.scopeUserId).toBe('u1');
+    expect(queries[1]!.sql).toContain('userId = $scopeUserId');
+    expect(queries[1]!.params?.scopeUserId).toBe('u1');
   });
 
   it('metaSince stays UNGATED by design (metadata only, no text)', async () => {
@@ -99,8 +99,8 @@ describe('L0 user-scope fence (0055) — episode read store', () => {
       sinceIso: '2026-08-01T00:00:00.000Z',
       limit: 10,
     });
-    expect(queries[0].sql).not.toContain('userId');
-    expect(queries[0].sql).not.toContain('text');
+    expect(queries[0]!.sql).not.toContain('userId');
+    expect(queries[0]!.sql).not.toContain('text');
   });
 });
 

--- a/test/l3-escalation.e2e-spec.ts
+++ b/test/l3-escalation.e2e-spec.ts
@@ -59,7 +59,7 @@ describe('G2 L3 escalation e2e', () => {
     const m = body.match(
       new RegExp(`brain_l3_escalation_total\\{outcome="${outcome}"\\} (\\d+)`),
     );
-    return m ? parseInt(m[1], 10) : 0;
+    return m ? parseInt(m[1]!, 10) : 0;
   }
 
   beforeAll(async () => {
@@ -161,8 +161,8 @@ describe('G2 L3 escalation e2e', () => {
     // round-1 generate + verify, then L3 generate + verify.
     expect(state.calls.length).toBe(4);
     // The L3 generator saw the raw session turns (fenced-section style).
-    expect(state.calls[2].user).toContain('Full conversation transcripts');
-    expect(state.calls[2].user).toContain('conv_l3');
+    expect(state.calls[2]!.user).toContain('Full conversation transcripts');
+    expect(state.calls[2]!.user).toContain('conv_l3');
     expect(await l3Count(f, 'fired')).toBe(firedBefore + 1);
     expect(await l3Count(f, 'flipped')).toBe(flippedBefore + 1);
   });

--- a/test/lifecycle-0085.e2e-spec.ts
+++ b/test/lifecycle-0085.e2e-spec.ts
@@ -245,19 +245,19 @@ function assertActiveIntervalContinuity(rows: SlotFactRow[]): void {
   const active = rows.filter((r) => r.status === 'active');
   for (let i = 0; i < active.length; i++) {
     for (let j = i + 1; j < active.length; j++) {
-      const aFrom = toDate(active[i].validFrom).getTime();
-      const aUntil = active[i].validUntil
-        ? toDate(active[i].validUntil as Date | string).getTime()
+      const aFrom = toDate(active[i]!.validFrom).getTime();
+      const aUntil = active[i]!.validUntil
+        ? toDate(active[i]!.validUntil as Date | string).getTime()
         : Infinity;
-      const bFrom = toDate(active[j].validFrom).getTime();
-      const bUntil = active[j].validUntil
-        ? toDate(active[j].validUntil as Date | string).getTime()
+      const bFrom = toDate(active[j]!.validFrom).getTime();
+      const bUntil = active[j]!.validUntil
+        ? toDate(active[j]!.validUntil as Date | string).getTime()
         : Infinity;
       const overlap = aFrom < bUntil && bFrom < aUntil;
       expect({
         overlap,
-        pair: [active[i].object, active[j].object],
-      }).toEqual({ overlap: false, pair: [active[i].object, active[j].object] });
+        pair: [active[i]!.object, active[j]!.object],
+      }).toEqual({ overlap: false, pair: [active[i]!.object, active[j]!.object] });
     }
   }
 }

--- a/test/live-subscription.unit-spec.ts
+++ b/test/live-subscription.unit-spec.ts
@@ -136,7 +136,7 @@ describe('LiveSubscriptionManager', () => {
       const emitted = await mgr.catchUp('co_x');
       expect(emitted).toBe(1);
       expect(received).toHaveLength(1);
-      expect(received[0].event).toMatchObject({ factId: 'knowledge_fact:b' });
+      expect(received[0]!.event).toMatchObject({ factId: 'knowledge_fact:b' });
     });
 
     it('advances the cursor so the next tick does not repeat the batch', async () => {
@@ -219,7 +219,7 @@ describe('LiveSubscriptionManager', () => {
       });
       addSubscriber('slow', ['brain:read']);
       await mgr.catchUp('co_x');
-      expect(received[0].event).toEqual({ kind: 'resync', reason: 'backpressure' });
+      expect(received[0]!.event).toEqual({ kind: 'resync', reason: 'backpressure' });
     });
 
     it('drops a subscriber whose sink throws, without killing the stream', async () => {

--- a/test/llm-verifier.unit-spec.ts
+++ b/test/llm-verifier.unit-spec.ts
@@ -50,8 +50,8 @@ describe('applyVerdicts', () => {
     });
     const out = applyVerdicts(cands, raw);
     expect(out).toHaveLength(1);
-    expect(out[0].text).toBe('real decision');
-    expect(out[0].confidence).toBe(0.8); // recalibrated by the judge
+    expect(out[0]!.text).toBe('real decision');
+    expect(out[0]!.confidence).toBe(0.8); // recalibrated by the judge
   });
 
   it('fails open on unparseable judge output (keeps raw)', () => {
@@ -67,7 +67,7 @@ describe('applyVerdicts', () => {
     const raw = JSON.stringify([{ keep: true }, { keep: true }]);
     const out = applyVerdicts(cands, raw);
     expect(out).toHaveLength(2);
-    expect(out[0].confidence).toBe(0.9); // unchanged
+    expect(out[0]!.confidence).toBe(0.9); // unchanged
   });
 });
 
@@ -103,7 +103,7 @@ describe('LlmDecisionVerifier.rescore', () => {
       candidate({ text: 'keep me' }),
     ]);
     expect(out.map((c) => c.text)).toEqual(['keep me']);
-    expect(out[0].confidence).toBe(0.7);
+    expect(out[0]!.confidence).toBe(0.7);
   });
 });
 
@@ -128,7 +128,7 @@ describe('labelCommits with a verifier', () => {
       },
     });
     expect(summary.labeled).toBe(1);
-    expect(emitted[0].label).toBe(0); // verifier turned an over-label into a negative
+    expect(emitted[0]!.label).toBe(0); // verifier turned an over-label into a negative
     expect(summary.positive).toBe(0);
   });
 });

--- a/test/local-ner-worker.unit-spec.ts
+++ b/test/local-ner-worker.unit-spec.ts
@@ -61,7 +61,7 @@ function mkConfig(over: Record<string, string> = {}): ConfigService {
 }
 
 function replyToLast(w: FakeWorkerT, ok: boolean, body: unknown): void {
-  const last = w.posted[w.posted.length - 1];
+  const last = w.posted[w.posted.length - 1]!;
   const msg = ok
     ? { id: last.id, ok: true, result: body }
     : { id: last.id, ok: false, error: String(body) };
@@ -81,8 +81,8 @@ describe('LocalNerService — worker runtime', () => {
     await expect(svc.extract('Maria works at Acme')).resolves.toEqual([]);
     // The not-ready call fired a background warmup: worker spawned, warmup RPC posted.
     expect(FakeWorker.instances).toHaveLength(1);
-    const w = FakeWorker.instances[0];
-    expect(w.posted[0].kind).toBe('warmup');
+    const w = FakeWorker.instances[0]!;
+    expect(w.posted[0]!.kind).toBe('warmup');
     // Complete warmup → ready; extract now round-trips through the worker.
     replyToLast(w, true, { ready: true });
     await flush();
@@ -92,7 +92,7 @@ describe('LocalNerService — worker runtime', () => {
   it('scores flow through the worker RPC with min-score filtering intact', async () => {
     const svc = new LocalNerService(mkConfig());
     svc.onModuleInit();
-    const w = FakeWorker.instances[0];
+    const w = FakeWorker.instances[0]!;
     replyToLast(w, true, { ready: true });
     await flush();
 
@@ -120,7 +120,7 @@ describe('LocalNerService — worker runtime', () => {
   it('a worker-side error degrades to [] (existing unavailable behavior)', async () => {
     const svc = new LocalNerService(mkConfig());
     svc.onModuleInit();
-    const w = FakeWorker.instances[0];
+    const w = FakeWorker.instances[0]!;
     replyToLast(w, true, { ready: true });
     await flush();
 
@@ -135,7 +135,7 @@ describe('LocalNerService — worker runtime', () => {
       mkConfig({ EXTRACTOR_LOCAL_NER_TIMEOUT_MS: '25' }),
     );
     svc.onModuleInit();
-    const w = FakeWorker.instances[0];
+    const w = FakeWorker.instances[0]!;
     replyToLast(w, true, { ready: true });
     await flush();
 
@@ -178,7 +178,7 @@ describe('LocalNerService — worker runtime', () => {
   it('onApplicationShutdown terminates the worker and rejects in-flight calls to []', async () => {
     const svc = new LocalNerService(mkConfig());
     svc.onModuleInit();
-    const w = FakeWorker.instances[0];
+    const w = FakeWorker.instances[0]!;
     replyToLast(w, true, { ready: true });
     await flush();
 

--- a/test/local-ner.unit-spec.ts
+++ b/test/local-ner.unit-spec.ts
@@ -70,7 +70,7 @@ describe('LocalNerService — with mocked classifier', () => {
       end: 12,
       score: 0.95,
     });
-    expect(out[1].type).toBe('ORG');
+    expect(out[1]!.type).toBe('ORG');
   });
 
   it('uppercases entity types', async () => {
@@ -81,7 +81,7 @@ describe('LocalNerService — with mocked classifier', () => {
       ]),
     );
     const out = await svc.extract('Berlin');
-    expect(out[0].type).toBe('LOC');
+    expect(out[0]!.type).toBe('LOC');
   });
 
   it('caches results per trimmed input', async () => {

--- a/test/local-predicate-selector.unit-spec.ts
+++ b/test/local-predicate-selector.unit-spec.ts
@@ -89,9 +89,9 @@ describe('LocalPredicateSelectorService.rank', () => {
       preference: [0, 0, 1],
     });
     const ranked = await svc.rank('Maria is the CTO at Acme', snap);
-    expect(ranked[0].predicateId).toBe('status');
-    expect(ranked[0].similarity).toBeCloseTo(1, 5);
-    expect(ranked[1].similarity).toBeLessThan(ranked[0].similarity);
+    expect(ranked[0]!.predicateId).toBe('status');
+    expect(ranked[0]!.similarity).toBeCloseTo(1, 5);
+    expect(ranked[1]!.similarity).toBeLessThan(ranked[0]!.similarity);
   });
 
   it('respects topN cap', async () => {
@@ -123,6 +123,6 @@ describe('LocalPredicateSelectorService.rank', () => {
       preference: [0, 0, 1],
     });
     const ranked = await svc.rank('She lives in Berlin', snap);
-    expect(ranked[0].predicateId).toBe('address');
+    expect(ranked[0]!.predicateId).toBe('address');
   });
 });

--- a/test/locomo-http-shapes.unit-spec.ts
+++ b/test/locomo-http-shapes.unit-spec.ts
@@ -69,9 +69,9 @@ describe('LoCoMo HTTP shapes', () => {
       validFrom: '2023-05-01T12:00:00.000Z',
     });
     expect(calls).toHaveLength(1);
-    expect(calls[0].method).toBe('POST');
-    expect(calls[0].url).toBe('http://brain/v1/ingest/fact');
-    const body = calls[0].body;
+    expect(calls[0]!.method).toBe('POST');
+    expect(calls[0]!.url).toBe('http://brain/v1/ingest/fact');
+    const body = calls[0]!.body;
     expect(body).toMatchObject({
       entityRef: { vertical: 'locomo', id: 'conv_1__alice' },
       predicate: 'name',
@@ -104,8 +104,8 @@ describe('LoCoMo HTTP shapes', () => {
       sourceMessageId: 'locomo:conv-1:D1:5',
     });
     expect(calls).toHaveLength(1);
-    expect(calls[0].url).toBe('http://brain/v1/ingest/mention');
-    const body = calls[0].body;
+    expect(calls[0]!.url).toBe('http://brain/v1/ingest/mention');
+    const body = calls[0]!.body;
     // Required by IngestMentionDto.
     expect(body).toMatchObject({
       text: 'I bought a cat last weekend.',
@@ -157,8 +157,8 @@ describe('LoCoMo HTTP shapes', () => {
       typeof answer === 'string' ? answer : answer.answer,
     ).toBe('Alice bought a cat in May 2023.');
     expect(calls).toHaveLength(1);
-    expect(calls[0].url).toBe('http://brain/v1/search/multi-hop');
-    expect(calls[0].body).toMatchObject({
+    expect(calls[0]!.url).toBe('http://brain/v1/search/multi-hop');
+    expect(calls[0]!.body).toMatchObject({
       query: 'What did Alice buy in May?',
       maxHops: 3,
       synthesize: true,
@@ -186,6 +186,6 @@ describe('LoCoMo HTTP shapes', () => {
     expect(
       typeof answer === 'string' ? answer : answer.answer,
     ).toBe('no information available');
-    expect(calls[0].url).toBe('http://brain/v1/synthesize');
+    expect(calls[0]!.url).toBe('http://brain/v1/synthesize');
   });
 });

--- a/test/locomo-ingest-plan.unit-spec.ts
+++ b/test/locomo-ingest-plan.unit-spec.ts
@@ -73,7 +73,7 @@ describe('LoCoMo ingest planner', () => {
         conversation: { ...fixture.conversation, speaker_a: 'M.A. Singer' },
       }),
     );
-    expect(plan.speakers[0].entityId).toBe('conv_1__m_a_singer');
+    expect(plan.speakers[0]!.entityId).toBe('conv_1__m_a_singer');
   });
 
   it('prefixes multiparty speakers under the same sample namespace', () => {

--- a/test/locomo-judge.unit-spec.ts
+++ b/test/locomo-judge.unit-spec.ts
@@ -106,7 +106,7 @@ describe('runLocomo — judge integration', () => {
   it('no judge → report carries no judge fields (back-compat)', async () => {
     const report = await runLocomo([convWith(qa)], agent);
     expect(report.overall.judgeAccuracy).toBeUndefined();
-    expect(report.perCategory[0].judgeAccuracy).toBeUndefined();
+    expect(report.perCategory[0]!.judgeAccuracy).toBeUndefined();
     expect(report.scores.every((s) => s.judgeCorrect === undefined)).toBe(true);
   });
 
@@ -196,7 +196,7 @@ describe('runLocomo — judge integration', () => {
     const { client } = stubOpenAi([true]);
     const report = await rejudgeScores(scores, createOpenAiJudge(client, 'm'));
     expect(report.overall.judgeAccuracy).toBe(1);
-    expect(report.scores[0].judgeCorrect).toBe(true);
-    expect(report.scores[0].judgeErrored).toBeUndefined();
+    expect(report.scores[0]!.judgeCorrect).toBe(true);
+    expect(report.scores[0]!.judgeErrored).toBeUndefined();
   });
 });

--- a/test/locomo-loader.unit-spec.ts
+++ b/test/locomo-loader.unit-spec.ts
@@ -43,13 +43,13 @@ describe('LoCoMo loader', () => {
     expect(norm.speakerA).toBe('Alice');
     expect(norm.speakerB).toBe('Bob');
     expect(norm.sessions.map((s) => s.index)).toEqual([1, 2]);
-    expect(norm.sessions[0].turns).toHaveLength(2);
-    expect(norm.sessions[1].turns).toHaveLength(1);
+    expect(norm.sessions[0]!.turns).toHaveLength(2);
+    expect(norm.sessions[1]!.turns).toHaveLength(1);
   });
 
   it('parses ISO datetimes through unchanged', () => {
     const norm = normalizeSample(fixture);
-    expect(norm.sessions[0].dateTime).toBe('2023-05-01T12:00:00.000Z');
+    expect(norm.sessions[0]!.dateTime).toBe('2023-05-01T12:00:00.000Z');
   });
 
   it('coerces non-string gold answers to strings (LoCoMo has numeric answers)', () => {
@@ -73,7 +73,7 @@ describe('LoCoMo loader', () => {
 
   it('best-effort parses human "8 May, 2023" form', () => {
     const norm = normalizeSample(fixture);
-    expect(norm.sessions[1].dateTime).toMatch(/^2023-05-08T/);
+    expect(norm.sessions[1]!.dateTime).toMatch(/^2023-05-08T/);
   });
 
   it('surfaces adversarial_answer for cat5 and leaves answer empty', () => {
@@ -89,8 +89,8 @@ describe('LoCoMo loader', () => {
       ] as unknown as typeof fixture.qa,
     };
     const norm = normalizeSample(advSample);
-    expect(norm.qa[0].answer).toBe('');
-    expect(norm.qa[0].adversarialAnswer).toBe('self-care is important');
+    expect(norm.qa[0]!.answer).toBe('');
+    expect(norm.qa[0]!.adversarialAnswer).toBe('self-care is important');
   });
 
   it('loads from disk and reads both shape variants', async () => {
@@ -105,6 +105,6 @@ describe('LoCoMo loader', () => {
 
     expect(wrapped).toHaveLength(1);
     expect(bare).toHaveLength(1);
-    expect(wrapped[0].qa).toHaveLength(1);
+    expect(wrapped[0]!.qa).toHaveLength(1);
   });
 });

--- a/test/marketplace-meta.unit-spec.ts
+++ b/test/marketplace-meta.unit-spec.ts
@@ -55,17 +55,17 @@ describe('mergeMarketplaceMeta', () => {
         ],
       ]),
     );
-    expect(merged.featured).toBe(true);
-    expect(merged.featuredAt).toBe('2026-07-15T00:00:00.000Z');
-    expect(merged.paid).toBe(true);
-    expect(merged.displayPrice).toEqual({ amount: 2900, currency: 'USD' });
+    expect(merged!.featured).toBe(true);
+    expect(merged!.featuredAt).toBe('2026-07-15T00:00:00.000Z');
+    expect(merged!.paid).toBe(true);
+    expect(merged!.displayPrice).toEqual({ amount: 2900, currency: 'USD' });
   });
 
   it('leaves packs without a meta row byte-identical (no stamped keys)', () => {
     const [merged] = mergeMarketplaceMeta([summary()], new Map());
     expect(merged).toEqual(summary());
-    expect('featured' in merged).toBe(false);
-    expect('paid' in merged).toBe(false);
+    expect('featured' in merged!).toBe(false);
+    expect('paid' in merged!).toBe(false);
   });
 
   it('does not stamp false/empty state (unfeatured free row = clean wire)', () => {
@@ -73,9 +73,9 @@ describe('mergeMarketplaceMeta', () => {
       [summary()],
       new Map([['fintech', meta()]]),
     );
-    expect('featured' in merged).toBe(false);
-    expect('paid' in merged).toBe(false);
-    expect('displayPrice' in merged).toBe(false);
+    expect('featured' in merged!).toBe(false);
+    expect('paid' in merged!).toBe(false);
+    expect('displayPrice' in merged!).toBe(false);
   });
 
   it('stamps paid without displayPrice when the meta row lacks one', () => {
@@ -83,8 +83,8 @@ describe('mergeMarketplaceMeta', () => {
       [summary()],
       new Map([['fintech', meta({ paid: true })]]),
     );
-    expect(merged.paid).toBe(true);
-    expect('displayPrice' in merged).toBe(false);
+    expect(merged!.paid).toBe(true);
+    expect('displayPrice' in merged!).toBe(false);
   });
 });
 

--- a/test/marketplace.e2e-spec.ts
+++ b/test/marketplace.e2e-spec.ts
@@ -95,7 +95,7 @@ describe('registry marketplace (e2e)', () => {
         if (req.method === 'GET' && ent) {
           return json(
             200,
-            billing.entitlements[decodeURIComponent(ent[1])] ?? [],
+            billing.entitlements[decodeURIComponent(ent[1]!)] ?? [],
           );
         }
         return json(404, { message: 'no such stub route' });
@@ -121,7 +121,7 @@ describe('registry marketplace (e2e)', () => {
       scopes: ['brain:read', 'brain:write', 'brain:admin', 'registry:publish'],
       extraKeys: [{ scopes: ['registry:curate'] }],
     });
-    curateKey = owner.extraApiKeys[0];
+    curateKey = owner.extraApiKeys[0]!;
     rival = await createApp({
       companyId: `co_mkt_rival_${RUN}`,
       scopes: ['brain:read', 'brain:admin', 'registry:publish'],

--- a/test/mcp-grant-gate.unit-spec.ts
+++ b/test/mcp-grant-gate.unit-spec.ts
@@ -146,7 +146,7 @@ describe('agent-attributed recorder', () => {
       } as never,
     });
 
-    await handlers['record_fact']({
+    await handlers['record_fact']!({
       entityRef: { entityId: 'knowledge_entity:x' },
       predicate: 'works_at',
       object: 'acme',

--- a/test/mcp-tools.unit-spec.ts
+++ b/test/mcp-tools.unit-spec.ts
@@ -156,7 +156,7 @@ describe('McpService.buildServer — scope-gated tool surface', () => {
       expect(tool).toBeDefined();
       // Before the fix the tool hardcoded indexers:'general' with no way to
       // opt into domain-pack routing that the REST twin accepts.
-      expect(Object.keys(tool.inputSchema?.shape ?? {})).toContain('indexers');
+      expect(Object.keys(tool!.inputSchema?.shape ?? {})).toContain('indexers');
     } finally {
       if (prev === undefined) delete process.env.DOCUMENT_INGEST_ENABLED;
       else process.env.DOCUMENT_INGEST_ENABLED = prev;
@@ -244,7 +244,7 @@ describe('retract_fact — caller scopes reach FactsService', () => {
       },
     });
 
-    await handlers['retract_fact']({ factId: 'x', reason: 'test' });
+    await handlers['retract_fact']!({ factId: 'x', reason: 'test' });
 
     expect(captured).toHaveLength(1);
     expect((captured[0] as { callerScopes?: unknown }).callerScopes).toEqual(

--- a/test/memory-assertions.unit-spec.ts
+++ b/test/memory-assertions.unit-spec.ts
@@ -61,7 +61,7 @@ describe('MemoryAssertionsChecker', () => {
         },
       ]),
     );
-    expect(out[0].passed).toBe(true);
+    expect(out[0]!.passed).toBe(true);
   });
 
   it('no_search_match fails when expected ref still surfaces', async () => {
@@ -87,8 +87,8 @@ describe('MemoryAssertionsChecker', () => {
         },
       ]),
     );
-    expect(out[0].passed).toBe(false);
-    expect(out[0].detail).toContain('Forgotten One');
+    expect(out[0]!.passed).toBe(false);
+    expect(out[0]!.detail).toContain('Forgotten One');
   });
 
   it('search_object_present passes when ref surfaces with the object substring', async () => {
@@ -115,7 +115,7 @@ describe('MemoryAssertionsChecker', () => {
         },
       ]),
     );
-    expect(out[0].passed).toBe(true);
+    expect(out[0]!.passed).toBe(true);
   });
 
   it('search_object_present fails when ref surfaces but substring missing', async () => {
@@ -142,8 +142,8 @@ describe('MemoryAssertionsChecker', () => {
         },
       ]),
     );
-    expect(out[0].passed).toBe(false);
-    expect(out[0].detail).toContain('platinum');
+    expect(out[0]!.passed).toBe(false);
+    expect(out[0]!.detail).toContain('platinum');
   });
 
   it('search_object_absent passes when ref is missing entirely (stronger than required)', async () => {
@@ -159,7 +159,7 @@ describe('MemoryAssertionsChecker', () => {
         },
       ]),
     );
-    expect(out[0].passed).toBe(true);
+    expect(out[0]!.passed).toBe(true);
   });
 
   it('search_object_absent fails when ref surfaces with the (forbidden) substring', async () => {
@@ -186,8 +186,8 @@ describe('MemoryAssertionsChecker', () => {
         },
       ]),
     );
-    expect(out[0].passed).toBe(false);
-    expect(out[0].detail).toContain('gold');
+    expect(out[0]!.passed).toBe(false);
+    expect(out[0]!.detail).toContain('gold');
   });
 
   it('search_object_absent passes when ref surfaces but substring not in any fact', async () => {
@@ -214,7 +214,7 @@ describe('MemoryAssertionsChecker', () => {
         },
       ]),
     );
-    expect(out[0].passed).toBe(true);
+    expect(out[0]!.passed).toBe(true);
   });
 
   it('handles assertion-level exceptions gracefully', async () => {
@@ -233,8 +233,8 @@ describe('MemoryAssertionsChecker', () => {
         },
       ]),
     );
-    expect(out[0].passed).toBe(false);
-    expect(out[0].detail).toContain('surreal angry');
+    expect(out[0]!.passed).toBe(false);
+    expect(out[0]!.detail).toContain('surreal angry');
   });
 
   it('returns empty list when scenario has no memory assertions', async () => {
@@ -278,7 +278,7 @@ describe('MemoryAssertionsChecker', () => {
       ]),
     );
     expect(out.length).toBe(2);
-    expect(out[0].passed).toBe(false);
-    expect(out[1].passed).toBe(true);
+    expect(out[0]!.passed).toBe(false);
+    expect(out[1]!.passed).toBe(true);
   });
 });

--- a/test/memory-diff.e2e-spec.ts
+++ b/test/memory-diff.e2e-spec.ts
@@ -172,13 +172,13 @@ describe('MemoryDiffService.diff — window math', () => {
     // Changed = md_t1_2 → md_t2_replacement.
     expect(out.changedFacts).toHaveLength(1);
     const [changed] = out.changedFacts;
-    expect(changed.factId).toBe('knowledge_fact:md_t1_2');
-    expect(changed.replacedBy).toBe('knowledge_fact:md_t2_replacement');
-    expect(changed.before.predicate).toBe('tag');
-    expect(changed.before.object).toBe('tag_2');
-    expect(changed.after).toBeDefined();
-    expect(changed.after?.predicate).toBe('tier');
-    expect(changed.after?.object).toBe('platinum');
+    expect(changed!.factId).toBe('knowledge_fact:md_t1_2');
+    expect(changed!.replacedBy).toBe('knowledge_fact:md_t2_replacement');
+    expect(changed!.before.predicate).toBe('tag');
+    expect(changed!.before.object).toBe('tag_2');
+    expect(changed!.after).toBeDefined();
+    expect(changed!.after?.predicate).toBe('tier');
+    expect(changed!.after?.object).toBe('platinum');
 
     // newEntities = bystander created at T2.
     expect(out.newEntities.map((e) => e.entityId)).toContain(ENT_BYSTANDER_FULL);

--- a/test/mention-persist-batch-edges.unit-spec.ts
+++ b/test/mention-persist-batch-edges.unit-spec.ts
@@ -106,13 +106,13 @@ describe('MentionPersistService batched edge persistence', () => {
     const ids = await run(make(), db, extraction, ['entity:a', 'entity:b', 'entity:c']);
     expect(ids).toEqual(['knowledge_edge:new_0', 'knowledge_edge:new_1']);
     expect(queries).toHaveLength(2);
-    expect(queries[0].sql.trimStart().startsWith('SELECT id FROM knowledge_edge')).toBe(
+    expect(queries[0]!.sql.trimStart().startsWith('SELECT id FROM knowledge_edge')).toBe(
       true,
     );
-    expect(queries[1].sql.trimStart().startsWith('RELATE')).toBe(true);
+    expect(queries[1]!.sql.trimStart().startsWith('RELATE')).toBe(true);
     // Edge content threaded through: kind + source with confidence.
-    expect(queries[1].params.k0).toBe('knows');
-    expect(queries[1].params.s0).toMatchObject({ vertical: 'locomo', confidence: 0.9 });
+    expect(queries[1]!.params.k0).toBe('knows');
+    expect(queries[1]!.params.s0).toMatchObject({ vertical: 'locomo', confidence: 0.9 });
   });
 
   it('re-ingest (all edges already exist) → single round-trip, no RELATE', async () => {
@@ -126,7 +126,7 @@ describe('MentionPersistService batched edge persistence', () => {
     const ids = await run(make(), db, extraction, ['entity:a', 'entity:b', 'entity:c']);
     expect(ids).toEqual(['knowledge_edge:exist_0', 'knowledge_edge:exist_1']);
     expect(queries).toHaveLength(1);
-    expect(queries[0].sql.trimStart().startsWith('SELECT')).toBe(true);
+    expect(queries[0]!.sql.trimStart().startsWith('SELECT')).toBe(true);
   });
 
   it('mixed → existing kept, only missing RELATEd', async () => {
@@ -141,8 +141,8 @@ describe('MentionPersistService batched edge persistence', () => {
     expect(ids).toEqual(['knowledge_edge:exist_0', 'knowledge_edge:new_0']);
     expect(queries).toHaveLength(2);
     // Only ONE edge in the RELATE batch (the missing one).
-    expect(queries[1].params.f1).toBeUndefined();
-    expect(queries[1].params.k0).toBe('likes');
+    expect(queries[1]!.params.f1).toBeUndefined();
+    expect(queries[1]!.params.k0).toBe('likes');
   });
 
   it('in-batch duplicate (from,to,kind) collapses to one candidate', async () => {
@@ -156,7 +156,7 @@ describe('MentionPersistService batched edge persistence', () => {
     const ids = await run(make(), db, extraction, ['entity:a', 'entity:b']);
     expect(ids).toEqual(['knowledge_edge:new_0']);
     // Existence check has exactly one statement (no f1).
-    expect(queries[0].params.f1).toBeUndefined();
+    expect(queries[0]!.params.f1).toBeUndefined();
   });
 
   it('skips self-edges and unresolved entity indexes', async () => {
@@ -170,7 +170,7 @@ describe('MentionPersistService batched edge persistence', () => {
     };
     const ids = await run(make(), db, extraction, ['entity:a', 'entity:b']);
     expect(ids).toEqual(['knowledge_edge:new_0']);
-    expect(queries[0].params.f1).toBeUndefined(); // only the one valid candidate
+    expect(queries[0]!.params.f1).toBeUndefined(); // only the one valid candidate
   });
 
   it('empty edge set → no query, empty result', async () => {
@@ -214,7 +214,7 @@ describe('MentionPersistService batched edge persistence', () => {
     ).persistEdges(db, { extraction, entityIds: ['entity:a', 'entity:b'], dto });
     expect(ids).toEqual(['knowledge_edge:new_0']);
     // Batched shape (existence check first), not the per-edge loop.
-    expect(queries[0].sql.trimStart().startsWith('SELECT id FROM knowledge_edge')).toBe(
+    expect(queries[0]!.sql.trimStart().startsWith('SELECT id FROM knowledge_edge')).toBe(
       true,
     );
   });

--- a/test/mention-user-scope.unit-spec.ts
+++ b/test/mention-user-scope.unit-spec.ts
@@ -66,8 +66,8 @@ describe('mention ingest user-scope pinning (audit 2026-08-21 P0)', () => {
     await runWithRequestContext({ correlationId: 't1' }, () =>
       svc.ingestMention('co_x', { ...baseDto, userId: 'user-42' }),
     );
-    expect(captured[0].userId).toBe('user-42');
-    expect(persisted[0].userId).toBe('user-42');
+    expect(captured[0]!.userId).toBe('user-42');
+    expect(persisted[0]!.userId).toBe('user-42');
   });
 
   it('M2M without an assertion stays tenant-global (unchanged behavior)', async () => {
@@ -76,8 +76,8 @@ describe('mention ingest user-scope pinning (audit 2026-08-21 P0)', () => {
     await runWithRequestContext({ correlationId: 't2' }, () =>
       svc.ingestMention('co_x', { ...baseDto }),
     );
-    expect(captured[0].userId).toBeUndefined();
-    expect(persisted[0].userId).toBeUndefined();
+    expect(captured[0]!.userId).toBeUndefined();
+    expect(persisted[0]!.userId).toBeUndefined();
   });
 
   it('a user-bound token defaults an omitted userId to its own user', async () => {
@@ -87,8 +87,8 @@ describe('mention ingest user-scope pinning (audit 2026-08-21 P0)', () => {
       { correlationId: 't3', authUserId: 'did:key:z6MkUser' },
       () => svc.ingestMention('co_x', { ...baseDto }),
     );
-    expect(captured[0].userId).toBe('did:key:z6MkUser');
-    expect(persisted[0].userId).toBe('did:key:z6MkUser');
+    expect(captured[0]!.userId).toBe('did:key:z6MkUser');
+    expect(persisted[0]!.userId).toBe('did:key:z6MkUser');
   });
 
   it('a user-bound token cannot write another user\'s scope (403)', async () => {
@@ -111,7 +111,7 @@ describe('mention ingest user-scope pinning (audit 2026-08-21 P0)', () => {
       { correlationId: 't5', authUserId: 'did:key:z6MkUser' },
       () => svc.ingestMention('co_x', { ...baseDto }),
     );
-    expect(captured[0].userId).toBe('did:key:z6MkUser');
+    expect(captured[0]!.userId).toBe('did:key:z6MkUser');
     expect(persisted).toHaveLength(0);
   });
 });

--- a/test/metrics.unit-spec.ts
+++ b/test/metrics.unit-spec.ts
@@ -34,7 +34,7 @@ describe('MetricsService', () => {
     // Sum should be ≈ 1.75
     const sumMatch = body.match(/brain_search_duration_seconds_sum (\d+\.?\d*)/);
     expect(sumMatch).toBeTruthy();
-    expect(parseFloat(sumMatch![1])).toBeCloseTo(1.75, 2);
+    expect(parseFloat(sumMatch![1]!)).toBeCloseTo(1.75, 2);
   });
 
   it('counts retracts, forgets, compactions', async () => {

--- a/test/migrator.unit-spec.ts
+++ b/test/migrator.unit-spec.ts
@@ -73,8 +73,8 @@ describe('SchemaMigrator', () => {
     const migrator = new SchemaMigrator(dir);
     const manifest = await migrator.loadManifest();
     expect(manifest.map((m) => m.id)).toEqual(['0001', '0002', '0010']);
-    expect(manifest[0].name).toBe('0001_baseline.surql');
-    expect(manifest[0].sql).toContain('DEFINE TABLE bar');
+    expect(manifest[0]!.name).toBe('0001_baseline.surql');
+    expect(manifest[0]!.sql).toContain('DEFINE TABLE bar');
   });
 
   it('applies all migrations on a fresh database', async () => {
@@ -90,7 +90,7 @@ describe('SchemaMigrator', () => {
     expect(result.alreadyApplied).toEqual([]);
 
     // First call must bootstrap the schema_migrations table
-    expect(calls[0].sql).toContain('DEFINE TABLE IF NOT EXISTS schema_migrations');
+    expect(calls[0]!.sql).toContain('DEFINE TABLE IF NOT EXISTS schema_migrations');
 
     // Both migration bodies were executed
     expect(calls.some((c) => c.sql.includes('DEFINE TABLE a'))).toBe(true);

--- a/test/minicheck-client.unit-spec.ts
+++ b/test/minicheck-client.unit-spec.ts
@@ -65,13 +65,13 @@ describe('miniCheckConsistent', () => {
       ...REQ,
       fetchImpl: fakeFetch({ response: 'Yes' }, { captured }),
     });
-    expect(captured[0].model).toBe('bespoke-minicheck');
-    expect(captured[0].prompt).toBe(
+    expect(captured[0]!.model).toBe('bespoke-minicheck');
+    expect(captured[0]!.prompt).toBe(
       `Document: ${REQ.document}\nClaim: ${REQ.claim}`,
     );
-    expect(captured[0].stream).toBe(false);
-    expect(captured[0].options.temperature).toBe(0);
-    expect(captured[0].options.num_ctx).toBe(8192);
+    expect(captured[0]!.stream).toBe(false);
+    expect(captured[0]!.options.temperature).toBe(0);
+    expect(captured[0]!.options.num_ctx).toBe(8192);
   });
 
   it('throws on HTTP errors and unparseable verdicts', async () => {

--- a/test/operator-action-ts.unit-spec.ts
+++ b/test/operator-action-ts.unit-spec.ts
@@ -37,7 +37,7 @@ describe('OperatorActionService.persist (3.x datetime coercion)', () => {
       companyId: 'evalops',
     });
     expect(capture).toHaveLength(1);
-    const content = capture[0].content as Record<string, unknown>;
+    const content = capture[0]!.content as Record<string, unknown>;
     expect(content.ts).toBeInstanceOf(Date);
     expect((content.ts as Date).toISOString()).toBe('2026-08-07T12:00:00.000Z');
     // Null option fields stay omitted (the 0027 NULL-vs-none contract).

--- a/test/pack-mcp-tools.e2e-spec.ts
+++ b/test/pack-mcp-tools.e2e-spec.ts
@@ -261,7 +261,7 @@ describe('pack-declared MCP tools (e2e)', () => {
 
     // …the plain brain:read key gets zero rows from the SAME tool.
     const plain = await toolCall(
-      f.extraApiKeys[0],
+      f.extraApiKeys[0]!,
       'compliance__find_violations',
       { predicate: 'sanction_status' },
     );
@@ -276,7 +276,7 @@ describe('pack-declared MCP tools (e2e)', () => {
     expect(result.structuredContent).toEqual({ verdict: 'clean', hits: 0 });
 
     expect(endpointHits).toHaveLength(1);
-    const hit = endpointHits[0];
+    const hit = endpointHits[0]!;
     expect(hit.verified).toBe(true);
     const body = JSON.parse(hit.body);
     expect(body).toMatchObject({

--- a/test/pack-registry.e2e-spec.ts
+++ b/test/pack-registry.e2e-spec.ts
@@ -458,11 +458,11 @@ describe('/v1/registry — global pack registry (e2e)', () => {
               signed: false,
               verified: false,
               downloads: 0,
-              versionCount: upstreamPacks[packId].length,
+              versionCount: upstreamPacks[packId]!.length,
             })),
           });
         }
-        const rows = upstreamPacks[parts[3]];
+        const rows = upstreamPacks[parts[3]!];
         if (!rows) {
           res.statusCode = 404;
           return res.end('{}');
@@ -470,8 +470,8 @@ describe('/v1/registry — global pack registry (e2e)', () => {
         if (parts.length === 4) {
           return json({
             packId: parts[3],
-            latestVersion: rows[0].manifest.version,
-            versions: rows.map((v) => versionRow(parts[3], v)),
+            latestVersion: rows[0]!.manifest.version,
+            versions: rows.map((v) => versionRow(parts[3]!, v)),
           });
         }
         const row = rows.find((v) => v.manifest.version === parts[4]);
@@ -543,8 +543,8 @@ describe('/v1/registry — global pack registry (e2e)', () => {
     it('re-sync is idempotent and mirrors upstream yanks only onto origin-matching rows', async () => {
       // Upstream yanks BOTH versions; locally only the mirrored 0.1.0 may
       // follow — 0.2.0 is a local publish and must stay installable.
-      upstreamPacks.mirror_e2e[0].yanked = true;
-      upstreamPacks.mirror_e2e[1].yanked = true;
+      upstreamPacks.mirror_e2e![0]!.yanked = true;
+      upstreamPacks.mirror_e2e![1]!.yanked = true;
 
       const summary = await mirror.sync();
       expect(summary.imported).toBe(0);

--- a/test/pack-seed-ingest.unit-spec.ts
+++ b/test/pack-seed-ingest.unit-spec.ts
@@ -141,7 +141,7 @@ describe('PackSeedIngestService.runForPack', () => {
       ingest.svc,
     );
     await svc.runForPack('co_1', REF);
-    const dto = ingest.calls[0];
+    const dto = ingest.calls[0]!;
     expect(dto.kind).toBe('pack_seed');
     expect(dto.title).toBe('Gardening primer');
     expect(dto.text).toBe('Tomatoes want sun.');
@@ -182,8 +182,8 @@ describe('PackSeedIngestService.runForPack', () => {
       ingest.svc,
     );
     await svc.runForPack('co_1', REF);
-    expect(ingest.calls[0].originUri).toBe('https://example.com/primer');
-    expect(ingest.calls[0].occurredAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(ingest.calls[0]!.originUri).toBe('https://example.com/primer');
+    expect(ingest.calls[0]!.occurredAt).toBe('2026-01-01T00:00:00.000Z');
   });
 
   it('throws "aborted" between documents so the job requeues', async () => {

--- a/test/pack-tools.socket-spec.ts
+++ b/test/pack-tools.socket-spec.ts
@@ -777,8 +777,8 @@ describe('PackToolProxyService — against a real local http server', () => {
 
   it('signs the raw body with the install secret; installId (not companyId) on the wire', async () => {
     const out = await callOnce(proxy());
-    expect(out.content[0].text).toBe('ok');
-    const { headers, body } = received[0];
+    expect(out.content[0]!.text).toBe('ok');
+    const { headers, body } = received[0]!;
     expect(headers['x-brain-event']).toBe('mcp_tool_call');
     expect(headers['content-type']).toBe('application/json');
     const expected =
@@ -804,7 +804,7 @@ describe('PackToolProxyService — against a real local http server', () => {
     };
     const out = await callOnce(proxy());
     expect(out.structuredContent).toEqual({ verdict: 'clean', score: 0.9 });
-    expect(JSON.parse(out.content[0].text)).toEqual({ verdict: 'clean', score: 0.9 });
+    expect(JSON.parse(out.content[0]!.text)).toEqual({ verdict: 'clean', score: 0.9 });
   });
 
   it('timeout yields a clean 424 error, never a raw stack', async () => {

--- a/test/phase-a-readpath.unit-spec.ts
+++ b/test/phase-a-readpath.unit-spec.ts
@@ -47,7 +47,7 @@ describe('mergeExtraHits (evidence union)', () => {
     const out = mergeExtraHits(base, extra, 2);
     expect(out.map((h) => h.entityId)).toEqual(['e1', 'e2']);
     // capped at 2, chosen by score: f3 (0.8), f4 (0.5); f2 dropped
-    expect(out[1].facts.map((f) => f.factId)).toEqual(['f3', 'f4']);
+    expect(out[1]!.facts.map((f) => f.factId)).toEqual(['f3', 'f4']);
   });
 
   it('never duplicates a fact already present in base', () => {
@@ -55,21 +55,21 @@ describe('mergeExtraHits (evidence union)', () => {
     const extra = [hit('e1', [['f1', 0.9], ['f2', 0.4]])];
     const out = mergeExtraHits(base, extra, 10);
     expect(out).toHaveLength(1);
-    expect(out[0].facts.map((f) => f.factId)).toEqual(['f1', 'f2']);
+    expect(out[0]!.facts.map((f) => f.factId)).toEqual(['f1', 'f2']);
   });
 
   it('merges extra facts into an existing base entity without reordering base facts', () => {
     const base = [hit('e1', [['f1', 0.9], ['f2', 0.8]])];
     const extra = [hit('e1', [['f9', 0.95]])];
     const out = mergeExtraHits(base, extra, 10);
-    expect(out[0].facts.map((f) => f.factId)).toEqual(['f1', 'f2', 'f9']);
+    expect(out[0]!.facts.map((f) => f.factId)).toEqual(['f1', 'f2', 'f9']);
   });
 
   it('does not mutate base hits', () => {
     const base = [hit('e1', [['f1', 0.9]])];
     const extra = [hit('e1', [['f2', 0.5]])];
     mergeExtraHits(base, extra, 10);
-    expect(base[0].facts).toHaveLength(1);
+    expect(base[0]!.facts).toHaveLength(1);
   });
 
   it('returns base unchanged for empty extras or zero cap', () => {
@@ -83,7 +83,7 @@ describe('mergeExtraHits (evidence union)', () => {
     const extra = [hit('e1', [['f1', 0.9]]), hit('e1', [['f1', 0.9]])];
     const out = mergeExtraHits(base, extra, 10);
     expect(out).toHaveLength(1);
-    expect(out[0].facts).toHaveLength(1);
+    expect(out[0]!.facts).toHaveLength(1);
   });
 });
 
@@ -143,8 +143,8 @@ describe('selectFactCentric', () => {
     ];
     const out = selectFactCentric(buckets, 2);
     expect(out.map((b) => b.entityId)).toEqual(['strong', 'weak']);
-    expect(out[0].facts).toHaveLength(1); // only the 0.9 made the cut
-    expect(out[1].facts).toHaveLength(1); // 0.8 beat 0.2/0.1
+    expect(out[0]!.facts).toHaveLength(1); // only the 0.9 made the cut
+    expect(out[1]!.facts).toHaveLength(1); // 0.8 beat 0.2/0.1
   });
 
   it('orders rebuilt buckets by their best selected fact', () => {

--- a/test/policy-engine.unit-spec.ts
+++ b/test/policy-engine.unit-spec.ts
@@ -280,9 +280,9 @@ describe('policy-engine row evaluation', () => {
     });
     const traces = explainRow(ctxOf(set), view({ source: { vertical: 'hr' } }));
     expect(traces).toHaveLength(1);
-    expect(traces[0].verdict).toBe('deny');
-    expect(traces[0].decidedBy).toBe('no-hr');
-    expect(traces[0].rules[0].fields?.[0]).toMatchObject({
+    expect(traces[0]!.verdict).toBe('deny');
+    expect(traces[0]!.decidedBy).toBe('no-hr');
+    expect(traces[0]!.rules[0]!.fields?.[0]).toMatchObject({
       attr: 'source.vertical',
       expected: 'hr',
       actual: 'hr',
@@ -358,7 +358,7 @@ describe('PolicyDocumentSchema validation', () => {
         },
       ],
     });
-    expect(parsed.rules[0].enabled).toBe(true);
+    expect(parsed.rules[0]!.enabled).toBe(true);
     expect(parsed.description).toBe('');
   });
 });

--- a/test/policy-resolver-cache.unit-spec.ts
+++ b/test/policy-resolver-cache.unit-spec.ts
@@ -82,7 +82,7 @@ describe('PolicyResolverService', () => {
     const ctx = await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['readonly-agent'] });
     expect(ctx).not.toBeNull();
     expect(ctx!.sets).toHaveLength(1);
-    expect(ctx!.sets[0].name).toBe('readonly-agent');
+    expect(ctx!.sets[0]!.name).toBe('readonly-agent');
     expect(ctx!.resolutionError).toBe(false);
   });
 
@@ -111,8 +111,8 @@ describe('PolicyResolverService', () => {
     const ctx = await resolver.contextFor('co_a', { keyHash: 'sha256:k', claimNames: ['ghost-set'] });
     expect(ctx).not.toBeNull();
     expect(ctx!.resolutionError).toBe(true);
-    expect(ctx!.sets[0].posture).toEqual({ actions: 'deny', reads: 'deny' });
-    expect(ctx!.sets[0].mode).toBe('enforce');
+    expect(ctx!.sets[0]!.posture).toEqual({ actions: 'deny', reads: 'deny' });
+    expect(ctx!.sets[0]!.mode).toBe('enforce');
     expect(resolutionErrors).toHaveLength(1);
   });
 

--- a/test/predicate-alias.unit-spec.ts
+++ b/test/predicate-alias.unit-spec.ts
@@ -40,8 +40,8 @@ describe('predicate alias (W3 0082)', () => {
         companyId: 'co_x',
         logger,
       });
-      expect(facts[0].predicate).toBe('painted_seascape');
-      expect(facts[0].predicateAlias).toBe('painted');
+      expect(facts[0]!.predicate).toBe('painted_seascape');
+      expect(facts[0]!.predicateAlias).toBe('painted');
       expect(decisions).toEqual([
         {
           original: 'painted_seascape',
@@ -67,7 +67,7 @@ describe('predicate alias (W3 0082)', () => {
         companyId: 'co_x',
         logger,
       });
-      expect(facts[0].predicateAlias).toBeUndefined();
+      expect(facts[0]!.predicateAlias).toBeUndefined();
       expect(decisions).toEqual([]);
     });
 
@@ -84,8 +84,8 @@ describe('predicate alias (W3 0082)', () => {
         companyId: 'co_x',
         logger,
       });
-      expect(facts[0].predicateAlias).toBeUndefined();
-      expect(facts[0].predicate).toBe('painted_seascape');
+      expect(facts[0]!.predicateAlias).toBeUndefined();
+      expect(facts[0]!.predicate).toBe('painted_seascape');
     });
   });
 
@@ -114,8 +114,8 @@ describe('predicate alias (W3 0082)', () => {
       const facts = [fact('painted_seascape')];
       await svc.applyPredicateRefinements(facts, null as never, 'co_x');
       // Coinage kept, alias stamped, no local-override ranking ran.
-      expect(facts[0].predicate).toBe('painted_seascape');
-      expect(facts[0].predicateAlias).toBe('painted');
+      expect(facts[0]!.predicate).toBe('painted_seascape');
+      expect(facts[0]!.predicateAlias).toBe('painted');
       expect(localPredicates.rank).not.toHaveBeenCalled();
       expect(registry.canonicalize).toHaveBeenCalledTimes(1);
     });

--- a/test/predict-resolve.e2e-spec.ts
+++ b/test/predict-resolve.e2e-spec.ts
@@ -73,7 +73,7 @@ describe('IngestPredictionService.predict — read-only conflict preflight', () 
     // either-or AND that we surfaced the opposing fact.
     expect(['SUPERSEDED', 'COMPETING']).toContain(out.wouldOutcome);
     expect(out.opposingFacts.length).toBeGreaterThan(0);
-    expect(out.opposingFacts[0].object).toBe('Old Name');
+    expect(out.opposingFacts[0]!.object).toBe('Old Name');
     expect(out.predicatePolicy.semantics).toBe('single_active');
 
     // And the dry-run must NOT have written anything.

--- a/test/procedural-memory.e2e-spec.ts
+++ b/test/procedural-memory.e2e-spec.ts
@@ -55,9 +55,9 @@ describe('ProceduralMemoryService — record / match / list / retire', () => {
     // score cosine=1.0, so the priority-ASC tiebreaker picks the
     // priority=50 one before the priority=200 one.
     expect(matches.length).toBeGreaterThanOrEqual(2);
-    expect(matches[0].priority).toBe(50);
-    expect(matches[0].action).toBe('mention platinum tier 20% discount');
-    expect(matches[1].priority).toBe(200);
+    expect(matches[0]!.priority).toBe(50);
+    expect(matches[0]!.action).toBe('mention platinum tier 20% discount');
+    expect(matches[1]!.priority).toBe(200);
   });
 
   it('match excludes procedures below minSimilarity', async () => {

--- a/test/projection-registry.unit-spec.ts
+++ b/test/projection-registry.unit-spec.ts
@@ -33,9 +33,9 @@ describe('ProjectionRegistryService (driver surface 3)', () => {
       builder: 'window-deriver',
     });
     expect(queries).toHaveLength(1);
-    expect(queries[0].sql).toContain('UPSERT projection:[$name, $version]');
-    expect(queries[0].sql).toContain(`status = 'building'`);
-    expect(queries[0].params).toMatchObject({ name: 'facts', version: 'wd-v3' });
+    expect(queries[0]!.sql).toContain('UPSERT projection:[$name, $version]');
+    expect(queries[0]!.sql).toContain(`status = 'building'`);
+    expect(queries[0]!.params).toMatchObject({ name: 'facts', version: 'wd-v3' });
   });
 
   it('complete(live) demotes the previous live version first', async () => {
@@ -48,9 +48,9 @@ describe('ProjectionRegistryService (driver surface 3)', () => {
       stats: { propositions: 12 },
     });
     expect(queries).toHaveLength(2);
-    expect(queries[0].sql).toContain(`SET status = 'residual'`);
-    expect(queries[0].sql).toContain(`status = 'live'`);
-    expect(queries[1].params).toMatchObject({ status: 'live' });
+    expect(queries[0]!.sql).toContain(`SET status = 'residual'`);
+    expect(queries[0]!.sql).toContain(`status = 'live'`);
+    expect(queries[1]!.params).toMatchObject({ status: 'live' });
   });
 
   it('complete(non-live) writes built without touching other rows', async () => {
@@ -62,7 +62,7 @@ describe('ProjectionRegistryService (driver surface 3)', () => {
       live: false,
     });
     expect(queries).toHaveLength(1);
-    expect(queries[0].params).toMatchObject({ status: 'built' });
+    expect(queries[0]!.params).toMatchObject({ status: 'built' });
   });
 
   it('dropVersions deletes only the reaped versions, skips empty input', async () => {
@@ -74,8 +74,8 @@ describe('ProjectionRegistryService (driver surface 3)', () => {
       name: 'facts',
       versions: ['wd-old'],
     });
-    expect(queries[0].sql).toContain('DELETE projection');
-    expect(queries[0].params).toMatchObject({ versions: ['wd-old'] });
+    expect(queries[0]!.sql).toContain('DELETE projection');
+    expect(queries[0]!.params).toMatchObject({ versions: ['wd-old'] });
   });
 
   it('degrades to a warning when the DB is down (registry must not fail builders)', async () => {

--- a/test/promotion.e2e-spec.ts
+++ b/test/promotion.e2e-spec.ts
@@ -95,12 +95,12 @@ describe('episodic→semantic promotion (real SurrealDB)', () => {
         embedding: number[] | null;
       }>;
       expect(summaries).toHaveLength(1);
-      expect(summaries[0].status).toBe('active');
-      expect(summaries[0].object.length).toBeGreaterThan(0);
-      expect(summaries[0].derivedFrom).toHaveLength(5);
+      expect(summaries[0]!.status).toBe('active');
+      expect(summaries[0]!.object.length).toBeGreaterThan(0);
+      expect(summaries[0]!.derivedFrom).toHaveLength(5);
       // Promotion summaries are embedded — they replace active memory
       // and must stay vector-reachable.
-      expect(Array.isArray(summaries[0].embedding)).toBe(true);
+      expect(Array.isArray(summaries[0]!.embedding)).toBe(true);
 
       const statusOf = async (id: string) => {
         const [rows] = await db.query<[Array<{ status: string }>]>(

--- a/test/public-source-projection.unit-spec.ts
+++ b/test/public-source-projection.unit-spec.ts
@@ -140,7 +140,7 @@ describe('filterAndPage', () => {
   it('type filter matches the DECLARED type (undeclared never matches)', () => {
     const { items, total } = filterAndPage(corpus, { ...page, type: 'human' });
     expect(total).toBe(1);
-    expect(items[0].sourceKey).toBe('rent:human_big');
+    expect(items[0]!.sourceKey).toBe('rent:human_big');
   });
 
   it('minSamples judges the global row when no domain is active', () => {

--- a/test/public-sources.e2e-spec.ts
+++ b/test/public-sources.e2e-spec.ts
@@ -58,7 +58,8 @@ describe('public sources API (trust inputs)', () => {
       companyId: 'co_public_sources_e2e',
       extraKeys: [{ scopes: ['brain:read'] }, { scopes: ['brain:write'] }],
     });
-    [readKey, writeOnlyKey] = f.extraApiKeys;
+    readKey = f.extraApiKeys[0]!;
+    writeOnlyKey = f.extraApiKeys[1]!;
 
     // Declared identities — SENIOR carries the operator annotations the
     // public projection must never leak.
@@ -268,7 +269,7 @@ describe('public sources API — ABAC action gate', () => {
         },
       ],
     });
-    [restrictedKey] = f.extraApiKeys;
+    restrictedKey = f.extraApiKeys[0]!;
     const created = await f.http
       .post('/v1/admin/policy-sets')
       .set({ Authorization: `Bearer ${f.apiKey}` })

--- a/test/quality.real-e2e-spec.ts
+++ b/test/quality.real-e2e-spec.ts
@@ -56,7 +56,7 @@ describe('Quality eval (real OpenAI, multi-vertical scenarios)', () => {
     });
     const limitedClient = new HttpBrainClient({
       baseUrl: svc.baseUrl,
-      apiKey: svc.extras[0].plaintext,
+      apiKey: svc.extras[0]!.plaintext,
     });
 
     // Faithfulness verifier needs its own OpenAI client — runs in the

--- a/test/query-arc.unit-spec.ts
+++ b/test/query-arc.unit-spec.ts
@@ -85,8 +85,8 @@ describe('renderArcLines', () => {
     const [line] = renderArcLines([
       { object: 'x'.repeat(500), validFrom: '2026-01-02' },
     ]);
-    expect(line.length).toBeLessThan(230);
-    expect(line.endsWith('…')).toBe(true);
+    expect(line!.length).toBeLessThan(230);
+    expect(line!.endsWith('…')).toBe(true);
   });
 });
 

--- a/test/recompose.unit-spec.ts
+++ b/test/recompose.unit-spec.ts
@@ -185,7 +185,7 @@ describe('RecomposeService', () => {
         },
       });
       await svc.recompute('co_x');
-      const group = generator.generate.mock.calls[0][0] as any[];
+      const group = generator.generate.mock.calls[0]![0] as any[];
       expect(group.map((g) => g.object)).toEqual(['Under Armour']);
     });
 
@@ -218,7 +218,7 @@ describe('RecomposeService', () => {
       });
       const out = await svc.recompute('co_x');
       expect(out.recomputed).toBe(1);
-      const group = generator.generate.mock.calls[0][0] as any[];
+      const group = generator.generate.mock.calls[0]![0] as any[];
       expect(group.map((g) => g.object)).toEqual(['Dublin']);
     });
 
@@ -253,7 +253,7 @@ describe('RecomposeService', () => {
         },
       });
       await svc.recompute('co_x');
-      const group = generator.generate.mock.calls[0][0] as any[];
+      const group = generator.generate.mock.calls[0]![0] as any[];
       expect(group.map((g) => g.object)).toEqual(['earlier', 'later']);
     });
 

--- a/test/registry-mirror.unit-spec.ts
+++ b/test/registry-mirror.unit-spec.ts
@@ -55,7 +55,7 @@ function fakeUpstream(packs: Record<string, UpstreamVersionFixture[]>) {
       return json({ packs: ids.map((packId) => ({ packId })) });
     }
     const m = /^\/v1\/registry\/packs\/([^/?]+)(?:\/([^/?]+))?$/.exec(path);
-    const packId = m ? decodeURIComponent(m[1]) : '';
+    const packId = m ? decodeURIComponent(m[1]!) : '';
     const version = m?.[2] ? decodeURIComponent(m[2]) : undefined;
     const rows = packs[packId];
     if (!rows) return { ok: false, status: 404 } as Response;
@@ -146,9 +146,9 @@ describe('registry mirror — sync core', () => {
     expect(summary.imported).toBe(1);
     expect(summary.checksumMismatches).toBe(0);
     expect(local.published).toHaveLength(1);
-    expect(local.published[0].origin).toBe(BASE);
-    expect(local.published[0].manifest.id).toBe('alpha');
-    expect(local.published[0].expectedChecksum).toBe(
+    expect(local.published[0]!.origin).toBe(BASE);
+    expect(local.published[0]!.manifest.id).toBe('alpha');
+    expect(local.published[0]!.expectedChecksum).toBe(
       packChecksum(manifest('alpha', '1.0.0')),
     );
   });
@@ -193,7 +193,7 @@ describe('registry mirror — sync core', () => {
       packId: 'mirrored_pack',
       version: '1.0.0',
     });
-    expect(local.yanks[0].reason).toContain('CVE-2026-1');
+    expect(local.yanks[0]!.reason).toContain('CVE-2026-1');
     // Neither the local publish nor the foreign-origin row was touched.
     expect(local.yanks.some((y) => y.packId === 'local_pack')).toBe(false);
     expect(local.yanks.some((y) => y.packId === 'other_origin')).toBe(false);
@@ -308,7 +308,7 @@ describe('registry mirror — sync core', () => {
 
     expect(summary.failures).toBe(1);
     expect(summary.imported).toBe(1);
-    expect(local.published[0].manifest.id).toBe('beta');
+    expect(local.published[0]!.manifest.id).toBe('beta');
   });
 
   it('sends the bearer token when configured and omits it otherwise', async () => {

--- a/test/salience-scoring.unit-spec.ts
+++ b/test/salience-scoring.unit-spec.ts
@@ -48,7 +48,7 @@ describe('scoreRows salience fold', () => {
       rows: [row(source)],
       now: FROZEN_NOW,
       salienceScoring: enabled,
-    })[0].score;
+    })[0]!.score;
 
   it('off → factor exactly 1.0 regardless of the stamp', () => {
     expect(score({ salience: 3 }, false)).toBeCloseTo(score({}, false), 12);
@@ -77,8 +77,8 @@ describe('scoreRows salience fold', () => {
       now: Date.now(),
       salienceScoring: true,
     });
-    expect(scored[0].breakdown.salience).toBeCloseTo(1.25, 12);
-    expect('salience' in scored[1].breakdown).toBe(false);
+    expect(scored[0]!.breakdown.salience).toBeCloseTo(1.25, 12);
+    expect('salience' in scored[1]!.breakdown).toBe(false);
   });
 });
 

--- a/test/scope-tags-parity.e2e-spec.ts
+++ b/test/scope-tags-parity.e2e-spec.ts
@@ -45,8 +45,8 @@ describe('scope-tags parity (SCOPE_TAGS_ENABLED off ≡ on)', () => {
         { scopes: READ, userId: 'user_b' },
       ],
     });
-    aToken = f.extraApiKeys[0];
-    bToken = f.extraApiKeys[1];
+    aToken = f.extraApiKeys[0]!;
+    bToken = f.extraApiKeys[1]!;
 
     // Seed via M2M asserting the scope in the body. The write path stamps
     // both userId (0055) AND scope (0093) regardless of the read flag, so

--- a/test/search-scoring-shaping.unit-spec.ts
+++ b/test/search-scoring-shaping.unit-spec.ts
@@ -94,7 +94,7 @@ describe('assembleHits requireProvenance', () => {
       requireProvenance: true,
     });
     expect(hits).toHaveLength(1);
-    const preds = hits[0].facts.map((f) => f.predicate);
+    const preds = hits[0]!.facts.map((f) => f.predicate);
     expect(preds).toContain('role');
     expect(preds).not.toContain('hobby');
   });
@@ -123,7 +123,7 @@ describe('assembleHits requireProvenance', () => {
       requireProvenance: false,
     });
     expect(hits).toHaveLength(1);
-    expect(hits[0].facts).toHaveLength(1);
+    expect(hits[0]!.facts).toHaveLength(1);
   });
 });
 
@@ -139,11 +139,13 @@ describe('scoreRows chatter penalty', () => {
   });
 
   it('demotes a said fact below a substantive fact at equal fusedScore', () => {
-    const [said, pref] = scoreRows({
+    const scoredPair = scoreRows({
       rows: [fused('said', 'Hey Mel!'), fused('preference', 'sunsets')],
       now: NOW,
       chatterPenalty: 0.35,
     });
+    const said = scoredPair[0]!;
+    const pref = scoredPair[1]!;
     expect(said.score).toBeLessThan(pref.score);
     expect(said.breakdown.chatterPenalty).toBe(0.35);
     // Substantive fact is untouched — no chatterPenalty field.
@@ -151,20 +153,22 @@ describe('scoreRows chatter penalty', () => {
   });
 
   it('penalty 1.0 (default/off) → byte-identical scores, no breakdown field', () => {
-    const [said, pref] = scoreRows({
+    const scoredPair = scoreRows({
       rows: [fused('said', 'Hey Mel!'), fused('preference', 'sunsets')],
       now: NOW,
     });
+    const said = scoredPair[0]!;
+    const pref = scoredPair[1]!;
     expect(said.score).toBeCloseTo(pref.score, 10);
     expect(said.breakdown.chatterPenalty).toBeUndefined();
   });
 
   it('an out-of-range penalty (≥1) is treated as off', () => {
-    const [said] = scoreRows({
+    const said = scoreRows({
       rows: [fused('said', 'x')],
       now: NOW,
       chatterPenalty: 1.5,
-    });
+    })[0]!;
     expect(said.breakdown.chatterPenalty).toBeUndefined();
   });
 });
@@ -185,14 +189,14 @@ describe('assembleHits fact-window shaping', () => {
       topEntities: [bucket(many)],
       entityTypes: undefined,
     });
-    expect(def[0].facts).toHaveLength(5);
+    expect(def[0]!.facts).toHaveLength(5);
 
     const wide = assembleHits({
       topEntities: [bucket(many)],
       entityTypes: undefined,
       factsPerEntity: 10,
     });
-    expect(wide[0].facts).toHaveLength(10);
+    expect(wide[0]!.facts).toHaveLength(10);
   });
 
 });

--- a/test/segment-fusion-leg.unit-spec.ts
+++ b/test/segment-fusion-leg.unit-spec.ts
@@ -53,7 +53,7 @@ describe('runSegmentLegs', () => {
     });
     expect(vectorRows).toHaveLength(1);
     expect(lexicalRows).toHaveLength(1);
-    const row = vectorRows[0];
+    const row = vectorRows[0]!;
     expect(row.predicate).toBe('verbatim');
     expect(String(row.entityId)).toBe('episode_segment:s1');
     expect(row.entity?.type).toBe('segment');
@@ -61,7 +61,7 @@ describe('runSegmentLegs', () => {
     expect(row.confidence).toBe(1);
     expect(row.validFrom).toBe('2023-05-01T10:00:00Z');
     expect(row.simScore).toBe(0.9);
-    expect(lexicalRows[0].bm25Score).toBe(3.2);
+    expect(lexicalRows[0]!.bm25Score).toBe(3.2);
     // PII fence + fail-closed user scope on BOTH queries (0055 / W1 #14).
     for (const q of queries) {
       expect(q.sql).toContain('AND piiClass IS NONE');
@@ -98,7 +98,7 @@ describe('runSegmentLegs', () => {
       mode: 'lexical',
     });
     expect(queries).toHaveLength(1);
-    expect(queries[0].sql).toContain('search::score(1)');
+    expect(queries[0]!.sql).toContain('search::score(1)');
   });
 });
 
@@ -123,8 +123,8 @@ describe('SearchRetrievalService.runSegmentLegStage', () => {
     const buckets = await svc.runSegmentLegStage(db as Surreal, ctx);
     expect(buckets.size).toBe(1);
     const bucket = buckets.get('episode_segment:s1')!;
-    expect(bucket.facts[0].row.predicate).toBe('verbatim');
-    expect(bucket.facts[0].row.stages).toContain('segment');
+    expect(bucket.facts[0]!.row.predicate).toBe('verbatim');
+    expect(bucket.facts[0]!.row.stages).toContain('segment');
     expect(bucket.bestScore).toBeGreaterThan(0);
   });
 

--- a/test/segment-lane.unit-spec.ts
+++ b/test/segment-lane.unit-spec.ts
@@ -54,7 +54,7 @@ describe('rrfFuse', () => {
       [row('a'), row('b'), row('c')],
       [row('c'), row('d')],
     ]);
-    expect(String(fused[0].id)).toBe('c');
+    expect(String(fused[0]!.id)).toBe('c');
     expect(fused).toHaveLength(4);
   });
 
@@ -101,10 +101,10 @@ describe('SegmentComposerService', () => {
     expect(swap?.sql).toContain('DELETE episode_segment');
     const rows = swap?.params?.rows as Array<Record<string, unknown>>;
     expect(rows).toHaveLength(1);
-    expect(rows[0].recorder).toBe(SEGMENT_RECORDER);
-    expect(rows[0].piiClass).toEqual(['phone']);
-    expect(typeof rows[0].generation).toBe('string');
-    expect(String(rows[0].text)).toContain('[2023-05-01] A: q1');
+    expect(rows[0]!.recorder).toBe(SEGMENT_RECORDER);
+    expect(rows[0]!.piiClass).toEqual(['phone']);
+    expect(typeof rows[0]!.generation).toBe('string');
+    expect(String(rows[0]!.text)).toContain('[2023-05-01] A: q1');
   });
 });
 
@@ -156,17 +156,17 @@ describe('SegmentLaneService', () => {
       '[2023-05-01] B: sunset palm tree',
       '[2023-06-01] A: later',
     ]);
-    expect(queries[0].sql).toContain('vector::similarity::cosine');
-    expect(queries[1].sql).toContain('@1@');
+    expect(queries[0]!.sql).toContain('vector::similarity::cosine');
+    expect(queries[1]!.sql).toContain('@1@');
     // read_pii caller → no PII gate.
-    expect(queries[0].sql).not.toContain('piiClass IS NONE');
+    expect(queries[0]!.sql).not.toContain('piiClass IS NONE');
   });
 
   it('gates PII for callers without brain:read_pii', async () => {
     const { svc, queries } = makeLane([[], []]);
     await svc.transcriptLines({ ...base, callerScopes: ['brain:read'] });
-    expect(queries[0].sql).toContain('piiClass IS NONE');
-    expect(queries[1].sql).toContain('piiClass IS NONE');
+    expect(queries[0]!.sql).toContain('piiClass IS NONE');
+    expect(queries[1]!.sql).toContain('piiClass IS NONE');
   });
 
   it('reranks the fused pool when asked and trims to topK', async () => {

--- a/test/semantic-entropy.unit-spec.ts
+++ b/test/semantic-entropy.unit-spec.ts
@@ -13,7 +13,7 @@ describe('semantic-entropy', () => {
       [{ predicate: 'status', object: 'CTO' }],
     ]);
     expect(clusters.size).toBe(1);
-    const [info] = clusters.values();
+    const info = [...clusters.values()][0]!;
     expect(info.count).toBe(3);
   });
 
@@ -42,7 +42,7 @@ describe('semantic-entropy', () => {
       ],
       [{ predicate: 'status', object: 'CTO' }],
     ]);
-    const [info] = clusters.values();
+    const info = [...clusters.values()][0]!;
     expect(info.count).toBe(2);
   });
 

--- a/test/slot-semantics.unit-spec.ts
+++ b/test/slot-semantics.unit-spec.ts
@@ -102,7 +102,7 @@ describe('resolveDerivedBatch (V9 §1 semantics + phase 0 fence)', () => {
       [derivedRow('work'), derivedRow('events')],
       { slotSemantics: true },
     );
-    const facts = calls[0].facts as Array<{ semantics: string }>;
+    const facts = calls[0]!.facts as Array<{ semantics: string }>;
     expect(facts.map((f) => f.semantics)).toEqual([
       'bitemporal_event',
       'append_only',
@@ -120,8 +120,8 @@ describe('resolveDerivedBatch (V9 §1 semantics + phase 0 fence)', () => {
       },
     };
     await svc.resolveDerivedBatch(db, [derivedRow('work')]);
-    const facts = calls[0].facts as Array<{ semantics: string }>;
-    expect(facts[0].semantics).toBe('append_only');
+    const facts = calls[0]!.facts as Array<{ semantics: string }>;
+    expect(facts[0]!.semantics).toBe('append_only');
   });
 
   it('fence: a failed batch degrades to per-row, skipping only the poisoned row', async () => {
@@ -134,7 +134,7 @@ describe('resolveDerivedBatch (V9 §1 semantics + phase 0 fence)', () => {
         if (facts.length > 1) {
           throw new Error('Cannot execute UPDATE statement using value: NONE');
         }
-        if (facts[0].object === 'poison') {
+        if (facts[0]!.object === 'poison') {
           throw new Error('Cannot execute UPDATE statement using value: NONE');
         }
         return [facts.map(() => ({ outcome: 'INSERTED' }))] as unknown as T;
@@ -151,7 +151,7 @@ describe('resolveDerivedBatch (V9 §1 semantics + phase 0 fence)', () => {
       'SKIPPED',
       'INSERTED',
     ]);
-    expect(out[1].reason).toContain('UPDATE statement using value: NONE');
+    expect(out[1]!.reason).toContain('UPDATE statement using value: NONE');
   });
 });
 

--- a/test/span-anchor.unit-spec.ts
+++ b/test/span-anchor.unit-spec.ts
@@ -134,9 +134,9 @@ describe('computeCharSpans — quotes parallel to turns', () => {
       session,
     });
     expect(spans).toHaveLength(2);
-    expect(spans[0].episodeId).toBe('episode:e0');
-    expect(spans[0].exact).toBe('kitten named Luna');
-    expect(spans[1].episodeId).toBe('episode:e1');
+    expect(spans[0]!.episodeId).toBe('episode:e0');
+    expect(spans[0]!.exact).toBe('kitten named Luna');
+    expect(spans[1]!.episodeId).toBe('episode:e1');
   });
 
   it('null quotes, failing quotes and bad turn indices contribute no span', () => {
@@ -155,6 +155,6 @@ describe('computeCharSpans — quotes parallel to turns', () => {
       session,
     });
     expect(spans).toHaveLength(1);
-    expect(spans[0].episodeId).toBe('episode:e0');
+    expect(spans[0]!.episodeId).toBe('episode:e0');
   });
 });

--- a/test/spawn/openai-key-loader.ts
+++ b/test/spawn/openai-key-loader.ts
@@ -18,7 +18,7 @@ export function loadOpenAiKey(env: NodeJS.ProcessEnv = process.env): string {
     if (!existsSync(path)) continue;
     const content = readFileSync(path, 'utf-8');
     const m = content.match(/^OPENAI_API_KEY=(.+)$/m);
-    if (m) return m[1].replace(/^["']|["']$/g, '').trim();
+    if (m) return m[1]!.replace(/^["']|["']$/g, '').trim();
   }
   throw new Error(
     'OPENAI_API_KEY not in env and no fallback .env found. Set it before running real e2e.',

--- a/test/staleness-event.e2e-spec.ts
+++ b/test/staleness-event.e2e-spec.ts
@@ -120,7 +120,7 @@ describe('0089 fact_staleness event', () => {
       // storm row.
       await db.query(`INSERT INTO knowledge_fact $rows`, {
         rows: stormIds.map((id, i) =>
-          factRow(canaryIds[i], { derivedFrom: [rid(id)] }),
+          factRow(canaryIds[i]!, { derivedFrom: [rid(id)] }),
         ),
       });
       // The final world: convA rows, 20 of them superseded-by-convB (the
@@ -137,7 +137,7 @@ describe('0089 fact_staleness event', () => {
             factRow(id, {
               derivedVersion: FINAL,
               status: 'superseded',
-              supersededBy: rid(convB[i]),
+              supersededBy: rid(convB[i]!),
               source: { vertical: 'e2e', conversationId: 'convA' },
             }),
           ),

--- a/test/stats-views.e2e-spec.ts
+++ b/test/stats-views.e2e-spec.ts
@@ -110,7 +110,7 @@ describe('stats views (migration 0088, real SurrealDB)', () => {
       await db.query(
         `UPDATE type::record('knowledge_fact', $a) SET status = 'competing';
          UPDATE type::record('knowledge_fact', $b) SET status = 'retracted';`,
-        { a: factIds[0].split(':')[1], b: factIds[1].split(':')[1] },
+        { a: factIds[0]!.split(':')[1], b: factIds[1]!.split(':')[1] },
       );
     });
 
@@ -124,7 +124,7 @@ describe('stats views (migration 0088, real SurrealDB)', () => {
     await surreal.withCompany(f.companyId, async (db) => {
       await db.query(
         `UPDATE type::record('knowledge_fact', $a) SET status = 'active'`,
-        { a: factIds[0].split(':')[1] },
+        { a: factIds[0]!.split(':')[1] },
       );
     });
     expect(await viewCounts()).toEqual(await liveCounts());
@@ -134,7 +134,7 @@ describe('stats views (migration 0088, real SurrealDB)', () => {
     const before = await viewCounts();
     await surreal.withCompany(f.companyId, async (db) => {
       await db.query(`DELETE type::record('knowledge_fact', $t)`, {
-        t: factIds[3].split(':')[1],
+        t: factIds[3]!.split(':')[1],
       });
     });
     const live = await liveCounts();

--- a/test/stats-views.unit-spec.ts
+++ b/test/stats-views.unit-spec.ts
@@ -72,7 +72,7 @@ describe('StatsService view gating (STATS_VIEWS_ENABLED)', () => {
       communities: 3,
       factsLast7d: 4,
     });
-    const sql = query.mock.calls[0][0];
+    const sql = query.mock.calls[0]![0];
     expect(sql).toContain("WHERE status = 'active'");
     expect(sql).not.toContain('stats_fact_by_status');
 
@@ -96,7 +96,7 @@ describe('StatsService view gating (STATS_VIEWS_ENABLED)', () => {
       communities: 0, // GROUP ALL view with no row yet → 0
       factsLast7d: 4,
     });
-    const sql = query.mock.calls[0][0];
+    const sql = query.mock.calls[0]![0];
     expect(sql).toContain('stats_entity_total');
     expect(sql).toContain('stats_fact_by_status');
     expect(sql).toContain('stats_community_total');
@@ -203,7 +203,7 @@ describe('AdminService.collectTenant view gating (STATS_VIEWS_ENABLED)', () => {
       factsActive: 5,
       factsRetracted: 1,
     });
-    const sql = query.mock.calls[0][0];
+    const sql = query.mock.calls[0]![0];
     expect(sql).toContain("WHERE status = 'active'");
     expect(sql).not.toContain('stats_fact_by_status');
   });
@@ -220,7 +220,7 @@ describe('AdminService.collectTenant view gating (STATS_VIEWS_ENABLED)', () => {
       factsActive: 5,
       factsRetracted: 1,
     });
-    const sql = query.mock.calls[0][0];
+    const sql = query.mock.calls[0]![0];
     expect(sql).toContain('stats_entity_total');
     expect(sql).toContain('stats_fact_by_status');
     expect(sql).toContain('rejectedAt > type::datetime($dayAgoIso)');

--- a/test/strategy-memory.e2e-spec.ts
+++ b/test/strategy-memory.e2e-spec.ts
@@ -253,7 +253,7 @@ describe('strategy lane — both flags on (serving)', () => {
       .send({ query: 'engineer' });
     expect(res.status).toBe(201);
     expect(state.calls.length).toBeGreaterThanOrEqual(2);
-    const generatorCall = state.calls[0];
+    const generatorCall = state.calls[0]!;
     expect(generatorCall.user).toContain('=== ADVISORY STRATEGY NOTES');
     expect(generatorCall.user).toContain(STRATEGY_TEXT);
     expect(generatorCall.user).toContain('=== END ADVISORY STRATEGY NOTES ===');
@@ -308,7 +308,7 @@ describe('strategy lane — both flags on (serving)', () => {
     );
     // The strategy text may appear ONLY inside the fenced advisory
     // section of the generator prompt — never among the fact lines.
-    const generatorCall = state.calls[0];
+    const generatorCall = state.calls[0]!;
     const factSection = generatorCall.user.split(
       '=== ADVISORY STRATEGY NOTES',
     )[0];

--- a/test/strategy-memory.unit-spec.ts
+++ b/test/strategy-memory.unit-spec.ts
@@ -149,7 +149,7 @@ describe('strategy retrieval similarity floor', () => {
     );
     const out = await svc.retrieve('c1', 'q', 2);
     expect(out.map((i) => i.strategyId)).toEqual(['strategy_memory:a1']);
-    expect(out[0].similarity).toBeCloseTo(1.0);
+    expect(out[0]!.similarity).toBeCloseTo(1.0);
   });
 
   it('an irrelevant best-match serves nothing (floor wins over k)', async () => {

--- a/test/synthesize-verification.unit-spec.ts
+++ b/test/synthesize-verification.unit-spec.ts
@@ -39,10 +39,10 @@ function makeService(opts: {
           messages: Array<{ role: string; content: string }>;
         }) => {
           opts.captured.push({
-            system: req.messages[0].content,
-            user: req.messages[1].content,
+            system: req.messages[0]!.content,
+            user: req.messages[1]!.content,
           });
-          const isVerifier = req.messages[0].content.includes('auditor');
+          const isVerifier = req.messages[0]!.content.includes('auditor');
           return {
             choices: [
               {

--- a/test/temporal-overlap.unit-spec.ts
+++ b/test/temporal-overlap.unit-spec.ts
@@ -67,7 +67,7 @@ describe('scoreRows temporal anchor (overlap factor via breakdown)', () => {
       rows: [r],
       now: anchor.getTime(),
       temporalAnchor: anchor,
-    })[0].breakdown.temporalOverlap;
+    })[0]!.breakdown.temporalOverlap;
 
   it('interval containing the anchor → factor 1 (omitted)', () => {
     expect(
@@ -103,7 +103,7 @@ describe('scoreRows temporal anchor (overlap factor via breakdown)', () => {
       now: anchor.getTime(),
       temporalAnchor: anchor,
     });
-    expect(scored[0].score).toBeGreaterThan(scored[1].score);
+    expect(scored[0]!.score).toBeGreaterThan(scored[1]!.score);
   });
 
   it('no anchor → factor absent regardless of interval', () => {
@@ -111,7 +111,7 @@ describe('scoreRows temporal anchor (overlap factor via breakdown)', () => {
       rows: [row('2025-06-01T00:00:00Z')],
       now: anchor.getTime(),
     });
-    expect(scored[0].breakdown.temporalOverlap).toBeUndefined();
+    expect(scored[0]!.breakdown.temporalOverlap).toBeUndefined();
   });
 });
 

--- a/test/test-doubles.ts
+++ b/test/test-doubles.ts
@@ -155,6 +155,6 @@ function hashToVector(text: string, dim: number): number[] {
   let norm = 0;
   for (const v of out) norm += v * v;
   norm = Math.sqrt(norm) || 1;
-  for (let i = 0; i < dim; i++) out[i] /= norm;
+  for (let i = 0; i < dim; i++) out[i] = out[i]! / norm;
   return out;
 }

--- a/test/usage-decay.unit-spec.ts
+++ b/test/usage-decay.unit-spec.ts
@@ -32,10 +32,12 @@ function row(over: Partial<FusedRow> = {}): FusedRow {
 
 describe('scoreRows — usage-aware decay', () => {
   it('restarts the decay clock at lastReadAt', () => {
-    const [stale, used] = scoreRows({
+    const ranked = scoreRows({
       rows: [row(), row({ lastReadAt: new Date(NOW - DAY).toISOString() })],
       now: NOW,
     });
+    const stale = ranked[0]!;
+    const used = ranked[1]!;
     // 120 days at half-life 60 → 0.25; read a day ago → ~0.988.
     expect(stale.breakdown.decay).toBeCloseTo(0.25, 2);
     expect(used.breakdown.decay).toBeGreaterThan(0.95);
@@ -43,7 +45,7 @@ describe('scoreRows — usage-aware decay', () => {
   });
 
   it('a lastReadAt older than recordedAt never penalizes', () => {
-    const [fresh, freshWithStaleRead] = scoreRows({
+    const ranked = scoreRows({
       rows: [
         row({ recordedAt: new Date(NOW).toISOString() }),
         row({
@@ -53,14 +55,16 @@ describe('scoreRows — usage-aware decay', () => {
       ],
       now: NOW,
     });
+    const fresh = ranked[0]!;
+    const freshWithStaleRead = ranked[1]!;
     expect(freshWithStaleRead.score).toBe(fresh.score);
   });
 
   it('no usage stamp → byte-identical to the pre-0053 formula', () => {
-    const [scored] = scoreRows({
+    const scored = scoreRows({
       rows: [row()],
       now: NOW,
-    });
+    })[0]!;
     expect(scored.breakdown.decay).toBeCloseTo(
       Math.exp((-Math.LN2 * 120) / 60),
       10,

--- a/test/usage-ranking.unit-spec.ts
+++ b/test/usage-ranking.unit-spec.ts
@@ -45,12 +45,14 @@ describe('scoreRows — G8 usage ranking factor', () => {
   });
 
   it('readCount 0 / absent is factor exactly 1 at ANY beta (no breakdown)', () => {
-    const [absent, zero] = scoreRows({
+    const ranked = scoreRows({
       rows: [row(), row({ readCount: 0 })],
       now: NOW,
       usageBeta: 5,
     });
-    const baseline = scoreRows({ rows: [row()], now: NOW })[0];
+    const absent = ranked[0]!;
+    const zero = ranked[1]!;
+    const baseline = scoreRows({ rows: [row()], now: NOW })[0]!;
     expect(absent.score).toBe(baseline.score);
     expect(zero.score).toBe(baseline.score);
     expect(absent.breakdown.usage).toBeUndefined();
@@ -58,23 +60,27 @@ describe('scoreRows — G8 usage ranking factor', () => {
   });
 
   it('a used fact outranks its identical-otherwise never-used twin', () => {
-    const [used, unused] = scoreRows({
+    const rankedUsed = scoreRows({
       rows: [row({ readCount: 10 }), row()],
       now: NOW,
       usageBeta: 0.5,
     });
+    const used = rankedUsed[0]!;
+    const unused = rankedUsed[1]!;
     expect(used.score).toBeGreaterThan(unused.score);
     expect(used.breakdown.usage?.readCount).toBe(10);
     expect(used.breakdown.usage?.usageFactor).toBeGreaterThan(1);
   });
 
   it('more reads rank higher (monotonic in readCount below saturation)', () => {
-    const [few, many] = scoreRows({
+    const rankedReads = scoreRows({
       rows: [row({ readCount: 2 }), row({ readCount: 15 })],
       now: NOW,
       usageBeta: 0.5,
       usageSaturation: 20,
     });
+    const few = rankedReads[0]!;
+    const many = rankedReads[1]!;
     expect(many.score).toBeGreaterThan(few.score);
     expect(many.breakdown.usage!.usageFactor).toBeGreaterThan(
       few.breakdown.usage!.usageFactor,
@@ -83,12 +89,14 @@ describe('scoreRows — G8 usage ranking factor', () => {
 
   it('saturation caps the boost: usageFactor never exceeds 1 + beta', () => {
     const beta = 0.5;
-    const [atSat, farBeyond] = scoreRows({
+    const rankedSat = scoreRows({
       rows: [row({ readCount: 20 }), row({ readCount: 100_000 })],
       now: NOW,
       usageBeta: beta,
       usageSaturation: 20,
     });
+    const atSat = rankedSat[0]!;
+    const farBeyond = rankedSat[1]!;
     // At readCount === saturation the squash is ~1.0 → factor ~1 + beta.
     expect(atSat.breakdown.usage!.usageFactor).toBeCloseTo(1 + beta, 5);
     // A hot fact is clamped: squash capped at 1 → factor === 1 + beta exactly.
@@ -97,12 +105,12 @@ describe('scoreRows — G8 usage ranking factor', () => {
   });
 
   it('surfaces raw readCount + usageFactor in the breakdown (explain/debug)', () => {
-    const [scored] = scoreRows({
+    const scored = scoreRows({
       rows: [row({ readCount: 7 })],
       now: NOW,
       usageBeta: 0.3,
       usageSaturation: 20,
-    });
+    })[0]!;
     // log1p(7)/log1p(20) = ln(8)/ln(21) ≈ 0.6830; factor ≈ 1 + 0.3·0.6830 ≈ 1.2049.
     expect(scored.breakdown.usage).toMatchObject({ readCount: 7 });
     expect(scored.breakdown.usage!.usageFactor).toBeCloseTo(1.2049, 4);

--- a/test/user-forget-edge-audit.e2e-spec.ts
+++ b/test/user-forget-edge-audit.e2e-spec.ts
@@ -33,8 +33,8 @@ describe('user-forget purges edge audit_event rows', () => {
         `CREATE knowledge_entity SET type='other', canonicalName='Global Y',
            externalRefs={} RETURN id`,
       );
-      const pid = String((personal as Array<{ id: unknown }>)[0].id);
-      const gid = String((global as Array<{ id: unknown }>)[0].id);
+      const pid = String((personal as Array<{ id: unknown }>)[0]!.id);
+      const gid = String((global as Array<{ id: unknown }>)[0]!.id);
 
       // An edge whose `in` endpoint is the personal entity — user-forget
       // matches it via in.userId = $u. knowledge_edge is TYPE RELATION,
@@ -45,7 +45,7 @@ describe('user-forget purges edge audit_event rows', () => {
            CONTENT { kind: 'related_to', weight: 1.0, source: {} } RETURN AFTER`,
         { from: new StringRecordId(pid), to: new StringRecordId(gid) },
       );
-      const eid = String((edge as Array<{ id: unknown }>)[0].id);
+      const eid = String((edge as Array<{ id: unknown }>)[0]!.id);
 
       // The changefeed mirror row the drain would have written for it.
       await db.query(

--- a/test/user-profile.unit-spec.ts
+++ b/test/user-profile.unit-spec.ts
@@ -97,7 +97,7 @@ describe('UserProfileService — SQL contract', () => {
     const capture: Capture[] = [];
     const svc = makeService({ rows: [], capture, readPin: 'wd-v1' });
     await svc.getProfile({ ...baseOpts });
-    const { sql, params } = capture[0];
+    const { sql, params } = capture[0]!;
     // Audit 2026-08-21: STRICT user scope — tenant-global rows are
     // knowledge about arbitrary entities, not facts OF this user, and
     // must never leak into a profile. The user's own derived facts
@@ -128,7 +128,7 @@ describe('UserProfileService — SQL contract', () => {
     const capture: Capture[] = [];
     const svc = makeService({ rows: [], capture, readPin: null });
     await svc.getProfile({ ...baseOpts });
-    expect(capture[0].sql).toContain(
+    expect(capture[0]!.sql).toContain(
       '(derivedVersion IS NONE OR derivedVersion IS NONE)',
     );
   });
@@ -137,12 +137,12 @@ describe('UserProfileService — SQL contract', () => {
     const capture: Capture[] = [];
     const svc = makeService({ rows: [], capture, readPin: null });
     await svc.getProfile({ ...baseOpts, lang: 'en' });
-    expect(capture[0].sql).toContain('(lang = $langFilter OR lang IS NONE)');
-    expect(capture[0].params?.langFilter).toBe('en');
+    expect(capture[0]!.sql).toContain('(lang = $langFilter OR lang IS NONE)');
+    expect(capture[0]!.params?.langFilter).toBe('en');
     const capture2: Capture[] = [];
     const svc2 = makeService({ rows: [], capture: capture2, readPin: null });
     await svc2.getProfile({ ...baseOpts });
-    expect(capture2[0].sql).not.toContain('langFilter');
+    expect(capture2[0]!.sql).not.toContain('langFilter');
   });
 });
 
@@ -233,13 +233,13 @@ describe('UserProfileService — assembly', () => {
       'events',
     ]);
     expect(
-      res.sections.find((s) => s.aspect === 'identity')?.facts[0].kind,
+      res.sections.find((s) => s.aspect === 'identity')?.facts[0]!.kind,
     ).toBe('persona_attr');
     expect(
-      res.sections.find((s) => s.aspect === 'events')?.facts[0].kind,
+      res.sections.find((s) => s.aspect === 'events')?.facts[0]!.kind,
     ).toBe('event');
     expect(
-      res.sections.find((s) => s.aspect === 'work')?.facts[0].kind,
+      res.sections.find((s) => s.aspect === 'work')?.facts[0]!.kind,
     ).toBeUndefined();
   });
 
@@ -278,10 +278,10 @@ describe('UserProfileService — assembly', () => {
       readPin: null,
     });
     const res = await svc.getProfile({ ...baseOpts });
-    const [first, second] = res.sections[0].facts;
+    const [first, second] = res.sections[0]!.facts;
     // Rows share validFrom → factId ASC keeps f001 (corroborated) first.
-    expect(first.lastSeenAt).toBe('2026-07-01T00:00:00.000Z');
-    expect(second.lastSeenAt).toBeUndefined();
+    expect(first!.lastSeenAt).toBe('2026-07-01T00:00:00.000Z');
+    expect(second!.lastSeenAt).toBeUndefined();
   });
 
   it('gates PII predicates on brain:read_pii — both ways', async () => {
@@ -387,8 +387,8 @@ describe('UserProfileController — flag gate + user-scope pin', () => {
     await runWithRequestContext({ correlationId: 't1' }, async () => {
       await controller.getProfile(req, 'someone-else');
     });
-    expect(calls[0].userId).toBe('someone-else');
-    expect(calls[0].maxFacts).toBe(60);
+    expect(calls[0]!.userId).toBe('someone-else');
+    expect(calls[0]!.maxFacts).toBe(60);
   });
 
   it('user-bound token: own profile passes, another user 403s', async () => {
@@ -404,14 +404,14 @@ describe('UserProfileController — flag gate + user-scope pin', () => {
       },
     );
     expect(calls).toHaveLength(1);
-    expect(calls[0].userId).toBe('u1');
+    expect(calls[0]!.userId).toBe('u1');
   });
 
   it('clamps maxFacts to the hard cap and rejects garbage', async () => {
     process.env[FLAG] = '1';
     const { controller, calls } = makeController();
     await controller.getProfile(req, 'u1', '500');
-    expect(calls[0].maxFacts).toBe(200);
+    expect(calls[0]!.maxFacts).toBe(200);
     await expect(controller.getProfile(req, 'u1', '0')).rejects.toThrow(
       BadRequestException,
     );

--- a/test/user-scope.e2e-spec.ts
+++ b/test/user-scope.e2e-spec.ts
@@ -56,7 +56,7 @@ describe('per-user memory scope', () => {
         `SELECT entityId FROM type::record('knowledge_fact', $tail)`,
         { tail: (anchor.factId as string).split(':')[1] },
       );
-      return String((rows as Array<{ entityId: unknown }>)[0].entityId);
+      return String((rows as Array<{ entityId: unknown }>)[0]!.entityId);
     });
 
     await ingest({
@@ -114,7 +114,7 @@ describe('per-user memory scope', () => {
         `SELECT status FROM type::record('knowledge_fact', $tail)`,
         { tail: (globalTier.factId as string).split(':')[1] },
       );
-      expect((rows as Array<{ status: string }>)[0].status).toBe('active');
+      expect((rows as Array<{ status: string }>)[0]!.status).toBe('active');
     });
   });
 
@@ -135,7 +135,7 @@ describe('per-user memory scope', () => {
       );
       const row = (
         rows as Array<{ entityId: unknown; userId: string | null }>
-      )[0];
+      )[0]!;
       expect(String(row.entityId)).not.toBe(sharedEntityId);
       expect(row.userId).toBe('user_a');
     });

--- a/test/verifier-topic-coverage.unit-spec.ts
+++ b/test/verifier-topic-coverage.unit-spec.ts
@@ -41,7 +41,7 @@ function mockOpenAi(response: Record<string, unknown>, captured: CapturedRequest
           max_completion_tokens?: number;
         }) => {
           captured.push({
-            system: req.messages[0].content,
+            system: req.messages[0]!.content,
             schema: req.response_format.json_schema.schema,
             temperature: req.temperature,
             maxCompletionTokens: req.max_completion_tokens,
@@ -76,9 +76,9 @@ describe('runVerifier topic-coverage audit (V10 §5)', () => {
     });
     expect(out.verdict).toBe('supported');
     expect(out.questionAnswered).toBeUndefined();
-    expect(captured[0].system).not.toContain('questionAnswered');
-    expect(captured[0].schema.properties).not.toHaveProperty('questionAnswered');
-    expect(captured[0].schema.required).toEqual(['verdict', 'unsupportedClaims']);
+    expect(captured[0]!.system).not.toContain('questionAnswered');
+    expect(captured[0]!.schema.properties).not.toHaveProperty('questionAnswered');
+    expect(captured[0]!.schema.required).toEqual(['verdict', 'unsupportedClaims']);
   });
 
   it('on — addendum in the system prompt, questionAnswered in the schema and output', async () => {
@@ -93,10 +93,10 @@ describe('runVerifier topic-coverage audit (V10 §5)', () => {
     });
     expect(out).toMatchObject({ verdict: 'supported', questionAnswered: false });
     // Both tightenings present: relationship claims + the coverage judgment.
-    expect(captured[0].system).toContain('Relationship claims');
-    expect(captured[0].system).toContain('questionAnswered');
-    expect(captured[0].schema.properties).toHaveProperty('questionAnswered');
-    expect(captured[0].schema.required).toContain('questionAnswered');
+    expect(captured[0]!.system).toContain('Relationship claims');
+    expect(captured[0]!.system).toContain('questionAnswered');
+    expect(captured[0]!.schema.properties).toHaveProperty('questionAnswered');
+    expect(captured[0]!.schema.required).toContain('questionAnswered');
   });
 
   it('reasoning-model judge: no temperature param, widened completion cap', async () => {
@@ -112,8 +112,8 @@ describe('runVerifier topic-coverage audit (V10 §5)', () => {
         captured,
       ),
     });
-    expect(captured[0].temperature).toBeUndefined();
-    expect(captured[0].maxCompletionTokens).toBe(2048);
+    expect(captured[0]!.temperature).toBeUndefined();
+    expect(captured[0]!.maxCompletionTokens).toBe(2048);
     // Non-reasoning models keep the deterministic byte-identical call.
     const classic: CapturedRequest[] = [];
     await runVerifier({
@@ -123,8 +123,8 @@ describe('runVerifier topic-coverage audit (V10 §5)', () => {
         classic,
       ),
     });
-    expect(classic[0].temperature).toBe(0);
-    expect(classic[0].maxCompletionTokens).toBe(256);
+    expect(classic[0]!.temperature).toBe(0);
+    expect(classic[0]!.maxCompletionTokens).toBe(256);
   });
 
   it('on — a response without the judgment is a contract violation', async () => {

--- a/test/wikidata-mapper.unit-spec.ts
+++ b/test/wikidata-mapper.unit-spec.ts
@@ -70,7 +70,7 @@ describe('mapWikidataBindings', () => {
       ],
       template,
     );
-    const facts = out.directory.entities[0].facts;
+    const facts = out.directory.entities[0]!.facts;
     expect(facts).toContainEqual(
       expect.objectContaining({ predicate: 'dob', object: '1828-09-09' }),
     );
@@ -87,7 +87,7 @@ describe('mapWikidataBindings', () => {
       ],
       template,
     );
-    const facts = out.directory.entities[0].facts;
+    const facts = out.directory.entities[0]!.facts;
     expect(facts).toContainEqual(
       expect.objectContaining({
         predicate: 'address',
@@ -108,7 +108,7 @@ describe('mapWikidataBindings', () => {
       ],
       template,
     );
-    const objs = out.directory.entities[0].facts.map((f) => f.object);
+    const objs = out.directory.entities[0]!.facts.map((f) => f.object);
     expect(objs).toContain('country: United States');
     expect(objs).toContain('headquarters: San Francisco');
   });
@@ -146,7 +146,7 @@ describe('mapWikidataBindings', () => {
       template,
     );
     expect(out.directory.entities).toHaveLength(1);
-    const facts = out.directory.entities[0].facts;
+    const facts = out.directory.entities[0]!.facts;
     const occupations = facts.filter(
       (f) => f.predicate === 'interacted_with' && f.object.startsWith('occupation:'),
     );
@@ -173,7 +173,7 @@ describe('mapWikidataBindings', () => {
       ],
       template,
     );
-    const facts = out.directory.entities[0].facts;
+    const facts = out.directory.entities[0]!.facts;
     expect(facts).toContainEqual(
       expect.objectContaining({
         predicate: 'interacted_with',
@@ -191,7 +191,7 @@ describe('mapWikidataBindings', () => {
       template,
     );
     expect(out.directory.entities).toHaveLength(1);
-    expect(out.directory.entities[0].id).toBe('q1');
+    expect(out.directory.entities[0]!.id).toBe('q1');
   });
 
   it('returns empty directory on empty bindings', () => {
@@ -212,7 +212,7 @@ describe('mapWikidataBindings', () => {
       ],
       template,
     );
-    const facts = out.directory.entities[0].facts;
+    const facts = out.directory.entities[0]!.facts;
     expect(facts).toContainEqual(
       expect.objectContaining({ predicate: 'name', object: 'Лев Толстой' }),
     );
@@ -248,6 +248,6 @@ describe('mapWikidataBindings', () => {
       [{ item: uri('Q987654'), itemLabel: v('Test') }],
       template,
     );
-    expect(out.directory.entities[0].id).toBe('q987654');
+    expect(out.directory.entities[0]!.id).toBe('q987654');
   });
 });

--- a/test/window-deriver.unit-spec.ts
+++ b/test/window-deriver.unit-spec.ts
@@ -209,17 +209,17 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
     // (fn::resolve_facts via FactResolverService), not a raw INSERT.
     const rows = derived;
     expect(rows).toHaveLength(2);
-    expect(rows[0].predicate).toBe('pets');
-    expect(String(rows[0].derivedVersion).startsWith(`${staging}.`)).toBe(true);
-    expect(String(rows[0].object)).toContain('Luna and Oliver');
-    const source = rows[0].source as Record<string, unknown>;
+    expect(rows[0]!.predicate).toBe('pets');
+    expect(String(rows[0]!.derivedVersion).startsWith(`${staging}.`)).toBe(true);
+    expect(String(rows[0]!.object)).toContain('Luna and Oliver');
+    const source = rows[0]!.source as Record<string, unknown>;
     expect(source.recorder).toBe(WINDOW_DERIVER_VERSION);
     expect(source.episodeIds).toEqual(['episode:e1']);
     // Audit W3 #1: derived rows must carry the fields the read path
     // assumes; the resolver stamps the trust snapshot from sourceTrust.
-    expect(rows[0].lang).toBe('en');
-    expect(rows[0].script).toBeDefined();
-    expect(rows[0].sourceTrust as number).toBeGreaterThan(0);
+    expect(rows[0]!.lang).toBe('en');
+    expect(rows[0]!.script).toBeDefined();
+    expect(rows[0]!.sourceTrust as number).toBeGreaterThan(0);
   });
 
   it('DERIVER_MENTION_STAMP anchors source.mentionedAt to the first grounding turn', async () => {
@@ -240,7 +240,7 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
     delete process.env.DERIVER_MENTION_STAMP;
     const off = makeSvc(props);
     await off.svc.run('co_x');
-    const offSource = off.derived[0].source as Record<string, unknown>;
+    const offSource = off.derived[0]!.source as Record<string, unknown>;
     expect(offSource.mentionedAt).toBeUndefined();
     expect(offSource.turnIndex).toBeUndefined();
 
@@ -248,7 +248,7 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
     try {
       const on = makeSvc(props);
       await on.svc.run('co_x');
-      const src = on.derived[0].source as Record<string, unknown>;
+      const src = on.derived[0]!.source as Record<string, unknown>;
       expect(src.mentionedAt).toBe('2023-05-01T10:01:00.000Z');
       expect(src.turnIndex).toBe(1);
     } finally {
@@ -374,7 +374,7 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
     });
     await svc.run('co_x');
     const rows = derived;
-    expect(rows[0].validFrom).toEqual(new Date('2022-06-15T00:00:00.000Z'));
+    expect(rows[0]!.validFrom).toEqual(new Date('2022-06-15T00:00:00.000Z'));
   });
 
   it('impossible calendar occurred_on falls back to the session date', async () => {
@@ -395,7 +395,7 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
     // whole conversation on conv-48).
     expect(res.propositions).toBe(1);
     const rows = derived;
-    expect(rows[0].validFrom).toEqual(new Date('2023-05-01T10:00:00Z'));
+    expect(rows[0]!.validFrom).toEqual(new Date('2023-05-01T10:00:00Z'));
   });
 
   it('conversationId filter derives only the requested conversation', async () => {
@@ -517,7 +517,7 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
         q.sql.includes('DELETE knowledge_fact'),
       );
       expect(dels).toHaveLength(1);
-      expect(dels[0].params?.version).toBe('wd-v1');
+      expect(dels[0]!.params?.version).toBe('wd-v1');
     });
 
     it('gc REFUSES with no pin, no registry evidence, and no explicit keep', async () => {

--- a/test/worker-loop.unit-spec.ts
+++ b/test/worker-loop.unit-spec.ts
@@ -136,8 +136,8 @@ describe('JobDispatcherService.dispatch', () => {
     };
     await callDispatch(mkDispatcher(claimSvc), claim, reg);
     expect(claimSvc.calls.completed).toHaveLength(1);
-    expect(claimSvc.calls.completed[0].recordId).toBe('job_run:abc');
-    expect(claimSvc.calls.completed[0].result).toEqual({ ok: true });
+    expect(claimSvc.calls.completed[0]!.recordId).toBe('job_run:abc');
+    expect(claimSvc.calls.completed[0]!.result).toEqual({ ok: true });
     expect(claimSvc.calls.failed).toHaveLength(0);
   });
 
@@ -172,8 +172,8 @@ describe('JobDispatcherService.dispatch', () => {
     };
     await callDispatch(mkDispatcher(claimSvc), claim, reg);
     expect(claimSvc.calls.failed).toHaveLength(1);
-    expect(claimSvc.calls.failed[0].attempts).toBe(2);
-    expect((claimSvc.calls.failed[0].error as Error).message).toBe(
+    expect(claimSvc.calls.failed[0]!.attempts).toBe(2);
+    expect((claimSvc.calls.failed[0]!.error as Error).message).toBe(
       'handler boom',
     );
   });

--- a/test/worker-poller-concurrency.unit-spec.ts
+++ b/test/worker-poller-concurrency.unit-spec.ts
@@ -99,7 +99,7 @@ function makeQueue(jobs: Record<string, number>) {
     async (input: { companyId: string; jobType: JobType }) => {
       const key = `${input.jobType}::${input.companyId}`;
       if ((counts[key] ?? 0) <= 0) return null;
-      counts[key] -= 1;
+      counts[key] = (counts[key] ?? 0) - 1;
       seq += 1;
       return {
         recordId: `job_run:${seq}`,
@@ -145,7 +145,7 @@ describe('WorkerPollerService.runLoop — default env stays serial', () => {
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(claimSvc.claimNext).toHaveBeenCalledTimes(1);
 
-    parked[0].release();
+    parked[0]!.release();
     await settle();
     // Dispatch resolved → the loop went around and claimed the second job.
     expect(claimSvc.claimNext.mock.calls.length).toBeGreaterThanOrEqual(2);
@@ -199,7 +199,7 @@ describe('WorkerPollerService.runLoop — per-jobType concurrency', () => {
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(claimSvc.claimNext).toHaveBeenCalledTimes(1);
 
-    parked[0].release();
+    parked[0]!.release();
     await settle();
     // Slot freed → the tenant is eligible again and its next job runs.
     expect(dispatch).toHaveBeenCalledTimes(2);
@@ -227,7 +227,7 @@ describe('WorkerPollerService.runLoop — per-jobType concurrency', () => {
     // Both loops have work available, but only one dispatch may fly.
     expect(dispatch).toHaveBeenCalledTimes(1);
 
-    parked[0].release();
+    parked[0]!.release();
     await settle();
     // Global slot freed → the other jobType's job goes out.
     expect(dispatch).toHaveBeenCalledTimes(2);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "baseUrl": "./",
     "skipLibCheck": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,


### PR DESCRIPTION
## Summary

The highest-correctness-value strictness flip: `noUncheckedIndexedAccess` makes every `arr[i]`/`obj[key]` `T | undefined`, forcing the empty/missing case to be handled. **1131 sites fixed** (314 in src/ — the correctness-critical half — + 817 in test/).

**11 real latent bugs the flag caught** (genuinely reachable-undefined, previously unguarded):
- `search-rerank.service.ts` + `segment-lane.service.ts` — a malformed reranker/cross-encoder permutation silently injected `undefined` entities downstream; now filtered with a type guard.
- `openai-embedder.provider.ts` — empty embeddings response yielded `{vector: undefined}` typed `number[]` (now throws); `sliceIdx[d.index]` could write to `out[undefined]` (now guarded).
- `reranker.service.ts` — `candidates[parentIdx]` from a presentation permutation could crash on `.label`.
- `candidate-commit.service.ts` — an entity with no `candidateIds` emitted a StatusUpdate with `id: undefined`.
- `aspect-rollups.ts` — `entries().sort()[0][0]` threw on empty members.
- `gate-train.ts` — mismatched feats/targets lengths fed `undefined` into the gradient (NaN weights).
- `event-time.ts` — dynamic `PARSERS[langKey]` could pass `undefined` to chrono.
- `admin-jobs.controller.ts` — `tenants[0]` with no registered tenant passed `companyId: undefined` into job start (now 400s).
- `intent-classifier.service.ts` — `scores[qIdx]` mismatch → NaN confidence.
- `changefeed-drain.service.ts` — `batch[last]` undefined at batch-limit 0 while advancing the cursor.

**Fix discipline:** src/ is **~65% real handling** (guard / `??` / destructuring-default / `for…of` restructure / filter-undefined) and ~35% locally-provable `!` (each with an explaining comment — preceding length check, parallel-array index, validated regex group). test/ is overwhelmingly the sanctioned post-`toBeDefined`/`toHaveLength` fixture `!`. No `@ts-ignore`, no new `as any`/`as T` laundering, no per-file flag disable. Happy paths byte-identical; the new throws are on cases callers already short-circuit upstream.

## Tests

typecheck (src+tests) clean; lint `--max-warnings 0` clean (type-aware rules active); full unit suite **263 suites / 2293 tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB