### PR TITLE
chore(types): eliminate explicit any in src, enable no-explicit-any

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -100,7 +100,13 @@ export default tseslint.config(
       },
     },
     rules: {
-      '@typescript-eslint/no-explicit-any': 'off',
+      // Production code is typed — no `any` escape hatch. SurrealDB
+      // query results go through the generic `queryRows<T>` / typed
+      // `db.query<[Row[]]>()` idiom (see src/db/surreal.service.ts);
+      // genuinely-dynamic payloads use `unknown` + narrowing. The
+      // handful of unavoidable spots carry a per-line disable with a
+      // reason. Tests keep `any` for mocks/fixtures (override below).
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': [
         'warn',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
@@ -167,6 +173,9 @@ export default tseslint.config(
     // ("explicit > clever" is the standing rule for tests).
     files: ['test/**/*.ts', '**/*.spec.ts', '**/*.unit-spec.ts'],
     rules: {
+      // Mocks/fixtures legitimately use `any` (partial stubs, cast doubles);
+      // typing them precisely is low-value churn. Kept ON for src only.
+      '@typescript-eslint/no-explicit-any': 'off',
       'max-lines': 'off',
       'max-lines-per-function': 'off',
       'max-classes-per-file': 'off',

--- a/src/admin/admin-demo.controller.ts
+++ b/src/admin/admin-demo.controller.ts
@@ -23,6 +23,7 @@ import { DemoPipelineService } from './demo-pipeline.service';
 import { DemoStateService } from './demo-state.service';
 import { DemoChatService } from './demo-chat.service';
 import { policyFor } from '../ingest/conflict-resolver';
+import type { SearchHit } from '../search/search.types';
 
 /**
  * Default demo tenant — used when the admin overview / router-stats
@@ -182,18 +183,22 @@ export class AdminDemoController {
           scopes: askScopes,
         }),
       );
-      const result = captured.result as any;
-      if (result.search) {
-        result.search = {
-          results: enrichResults(
-            result.search.results,
-            captured.trace.artifacts,
-            result.strategy,
-          ),
-        };
-      }
+      const result = captured.result;
+      const shaped =
+        'search' in result
+          ? {
+              ...result,
+              search: {
+                results: enrichResults(
+                  result.search.results,
+                  captured.trace.artifacts,
+                  result.strategy,
+                ),
+              },
+            }
+          : result;
       return {
-        ...result,
+        ...shaped,
         trace: {
           requestId: captured.trace.requestId,
           totalMs: captured.trace.totalMs,
@@ -274,10 +279,10 @@ export class AdminDemoController {
  * fact.
  */
 function enrichResults(
-  results: any[],
+  results: SearchHit[],
   artifacts: Array<{ name: string; value: unknown }> = [],
   strategy: 'graph' | 'graph→vector' = 'graph→vector',
-): any[] {
+) {
   const vec = new Map<string, number>();
   const lex = new Map<string, number>();
   for (const a of artifacts) {
@@ -297,7 +302,7 @@ function enrichResults(
   }
   return results.map((r) => ({
     ...r,
-    facts: r.facts.map((f: any) => {
+    facts: r.facts.map((f) => {
       const policy = policyFor(f.predicate);
       const factId = String(f.factId);
       const vScore = vec.get(factId) ?? null;

--- a/src/admin/admin-infra.service.ts
+++ b/src/admin/admin-infra.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 import { ApiKeyService } from '../auth/api-key.service';
 import type { MigrationsResponse } from '../contracts/admin/migrations.schema';
 
@@ -42,10 +42,10 @@ export class AdminInfraService {
     for (const companyId of tenants) {
       try {
         const applied = await this.surreal.withCompany(companyId, async (db) => {
-          const res = (await db.query<any[]>(
+          const rows = await queryRows<{ migrationId: string }>(
+            db,
             `SELECT migrationId FROM schema_migrations`,
-          )) as any[];
-          const rows = (res[0] ?? []) as Array<{ migrationId: string }>;
+          );
           return rows.map((r) => r.migrationId).sort();
         });
         const appliedSet = new Set(applied);

--- a/src/admin/admin-jobs.controller.ts
+++ b/src/admin/admin-jobs.controller.ts
@@ -485,14 +485,15 @@ export class AdminJobsController {
     const emits: Array<Record<string, unknown>> = [];
     for (const companyId of tenants) {
       try {
-        const rows = (await this.dreams.emitsForRun(companyId, runId)) as Array<
-          Record<string, any>
-        >;
+        const rows = await this.dreams.emitsForRun(companyId, runId);
         for (const r of rows) {
           emits.push({
             runId: r.runId,
             kind: r.kind,
-            ts: typeof r.ts === 'string' ? r.ts : new Date(r.ts).toISOString(),
+            ts:
+              typeof r.ts === 'string'
+                ? r.ts
+                : new Date(r.ts as string | number | Date).toISOString(),
             subject: r.subject ?? null,
             object: r.object ?? null,
             detail: r.detail ?? null,

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ApiKeyService } from '../auth/api-key.service';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { mapWithLimit } from '../common/parallel';
 import { envFlagEnabled } from '../common/env-validation';
@@ -110,6 +110,56 @@ export interface AuditPage {
   hourly: Array<{ hour: string; count: number }>;
 }
 
+// ── Local DB row shapes ────────────────────────────────────────────────
+// Column projections of the SurrealDB reads below. Fields carry the type
+// the mapping code depends on; genuinely-dynamic columns funnelled through
+// String()/Number()/new Date() are typed `unknown`.
+
+/** `count() AS c ... GROUP ALL` result row. */
+interface CountRow { c?: number }
+
+/** `SELECT n FROM stats_entity_total` computed-view row. */
+interface ViewCountRow { n?: number }
+
+/** `SELECT n, status FROM stats_fact_by_status` computed-view row. */
+interface StatusCountRow { n?: number; status?: string }
+
+/** Columns read from `ingest_dead_letter`. */
+interface DeadLetterRow {
+  id?: unknown;
+  reason: string;
+  rejectedAt: string | Date;
+  payload?: Record<string, unknown>;
+}
+
+/** Columns read from `forgotten_entity`. */
+interface ForgottenRow {
+  entityIdHash: string;
+  reason: string;
+  forgottenAt: string | Date;
+  factsDeleted?: number;
+  edgesDeleted?: number;
+}
+
+/** Columns read from `audit_event`. */
+interface AuditEventDbRow {
+  id?: unknown;
+  source?: unknown;
+  recordId?: unknown;
+  op?: unknown;
+  ts: string | Date;
+  versionstamp?: unknown;
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+  consumedBy?: unknown;
+}
+
+/** PII-classed predicate rows from `knowledge_predicate`. */
+interface PiiPredicateRow { predicateId: string; piiClass: string; requiresScope?: string }
+
+/** Per-(predicate,status) fact counts for the PII inventory. */
+interface PiiCountRow { predicate?: string; status?: string; c?: unknown }
+
 /**
  * Cross-tenant read-only fan-out for the admin dashboard.
  *
@@ -203,14 +253,18 @@ export class AdminService {
    * Prometheus.
    */
   private async snapshotMetrics(): Promise<AdminMetrics> {
-    type Bucket = { name: string; labels?: Record<string, string>; value: number };
+    type Bucket = {
+      name: string;
+      labels?: Partial<Record<string, string | number>>;
+      value: number;
+    };
     const byName: Record<string, Bucket[]> = {};
     try {
       const all = await this.metrics.registry.getMetricsAsJSON();
       for (const m of all) {
         if (!m.name.startsWith('brain_')) continue;
-        const values = (m as { values?: any[] }).values ?? [];
-        byName[m.name] = values.map((v: any) => ({
+        const values = m.values ?? [];
+        byName[m.name] = values.map((v) => ({
           name: m.name,
           labels: v.labels ?? {},
           value: typeof v.value === 'number' ? v.value : 0,
@@ -370,8 +424,8 @@ export class AdminService {
     try {
       const all = await this.metrics.registry.getMetricsAsJSON();
       const m = all.find((x) => x.name === name);
-      const values = (m as { values?: any[] })?.values ?? [];
-      return values.map((v: any) => ({
+      const values = m?.values ?? [];
+      return values.map((v) => ({
         value: typeof v.value === 'number' ? v.value : 0,
         labels: (v.labels as Record<string, string>) ?? {},
       }));
@@ -406,15 +460,15 @@ export class AdminService {
       items: tenants,
       concurrency: TENANT_FANOUT,
       fn: async (companyId) => {
-        const rows = await this.surreal.withCompany(companyId, async (db) => {
-          const res = (await db.query<any[]>(
+        const rows = await this.surreal.withCompany(companyId, async (db) =>
+          queryRows<DeadLetterRow>(
+            db,
             `SELECT id, reason, rejectedAt, payload
                FROM ingest_dead_letter ${whereSql}
               ORDER BY rejectedAt DESC LIMIT ${limit}`,
             params,
-          )) as any[];
-          return (res[0] ?? []) as any[];
-        });
+          ),
+        );
         return rows.map((r) => ({
           companyId,
           id: String(r.id),
@@ -442,11 +496,11 @@ export class AdminService {
   async deleteDeadLetter(companyId: string, id: string): Promise<boolean> {
     try {
       return await this.surreal.withCompany(companyId, async (db) => {
-        const res = (await db.query<any[]>(
+        const rows = await queryRows<unknown>(
+          db,
           `DELETE ingest_dead_letter WHERE id = $id RETURN BEFORE`,
           { id },
-        )) as any[];
-        const rows = (res[0] ?? []) as any[];
+        );
         return rows.length > 0;
       });
     } catch (e) {
@@ -487,15 +541,15 @@ export class AdminService {
       items: tenants,
       concurrency: TENANT_FANOUT,
       fn: async (companyId) => {
-        const rows = await this.surreal.withCompany(companyId, async (db) => {
-          const res = (await db.query<any[]>(
+        const rows = await this.surreal.withCompany(companyId, async (db) =>
+          queryRows<ForgottenRow>(
+            db,
             `SELECT entityIdHash, reason, forgottenAt, factsDeleted, edgesDeleted
                FROM forgotten_entity ${whereSql}
               ORDER BY forgottenAt DESC LIMIT ${limit}`,
             params,
-          )) as any[];
-          return (res[0] ?? []) as any[];
-        });
+          ),
+        );
         return rows.map((r) => ({
           companyId,
           entityIdHash: r.entityIdHash,
@@ -551,26 +605,31 @@ export class AdminService {
         const { rows, counts } = await this.surreal.withCompany(
           companyId,
           async (db) => {
-            const res = (await db.query<any[]>(
+            const predRows = await queryRows<PiiPredicateRow>(
+              db,
               `SELECT predicateId, piiClass, requiresScope FROM knowledge_predicate
                 WHERE piiClass != 'none'`,
-            )) as any[];
-            const preds = ((res[0] ?? []) as any[]).map((p) => p.predicateId);
+            );
+            const preds = predRows.map((p) => p.predicateId);
             if (preds.length === 0) {
-              return { rows: [] as any[], counts: new Map<string, number>() };
+              return {
+                rows: [] as PiiPredicateRow[],
+                counts: new Map<string, number>(),
+              };
             }
-            const [countRows] = (await db.query<any[]>(
+            const countRows = await queryRows<PiiCountRow>(
+              db,
               `SELECT predicate, status, count() AS c FROM knowledge_fact
                 WHERE predicate INSIDE $preds
                   AND status INSIDE ['active', 'retracted']
                 GROUP BY predicate, status`,
               { preds },
-            )) as any[];
+            );
             const counts = new Map<string, number>();
-            for (const r of (countRows as any[]) ?? []) {
+            for (const r of countRows) {
               counts.set(`${r.predicate}|${r.status}`, Number(r.c) || 0);
             }
-            return { rows: (res[0] ?? []) as any[], counts };
+            return { rows: predRows, counts };
           },
         );
         for (const p of rows) {
@@ -644,8 +703,7 @@ export class AdminService {
               FROM audit_event ${whereSql}
               ORDER BY ts DESC LIMIT ${limit};
           `;
-          const out = (await db.query<any[]>(sql, bindings)) as any[];
-          return (out[0] ?? []) as any[];
+          return queryRows<AuditEventDbRow>(db, sql, bindings);
         });
         return rows.map((r) => ({
           row: {
@@ -734,14 +792,24 @@ export class AdminService {
         SELECT count() AS c FROM forgotten_entity
           WHERE forgottenAt > type::datetime($dayAgoIso) GROUP ALL;
       `;
-      const res = (await db.query<any[]>(sql, { dayAgoIso })) as any[];
+      const res = await db.query<
+        [
+          CountRow[],
+          CountRow[],
+          CountRow[],
+          DeadLetterRow[],
+          CountRow[],
+          ForgottenRow[],
+          CountRow[],
+        ]
+      >(sql, { dayAgoIso });
 
       const c0 = countOf(res[0]);
       const c1 = countOf(res[1]);
       const c2 = countOf(res[2]);
-      const deadLetterRows = (res[3] ?? []) as any[];
+      const deadLetterRows = res[3] ?? [];
       const dl24 = countOf(res[4]);
-      const forgottenRows = (res[5] ?? []) as any[];
+      const forgottenRows = res[5] ?? [];
       const fg24 = countOf(res[6]);
 
       return {
@@ -800,13 +868,22 @@ export class AdminService {
         SELECT count() AS c FROM forgotten_entity
           WHERE forgottenAt > type::datetime($dayAgoIso) GROUP ALL;
       `;
-      const res = (await db.query<any[]>(sql, { dayAgoIso })) as any[];
+      const res = await db.query<
+        [
+          ViewCountRow[],
+          StatusCountRow[],
+          DeadLetterRow[],
+          CountRow[],
+          ForgottenRow[],
+          CountRow[],
+        ]
+      >(sql, { dayAgoIso });
 
       const entities = viewCountOf(res[0]);
       const byStatus = statusCountsOf(res[1]);
-      const deadLetterRows = (res[2] ?? []) as any[];
+      const deadLetterRows = res[2] ?? [];
       const dl24 = countOf(res[3]);
-      const forgottenRows = (res[4] ?? []) as any[];
+      const forgottenRows = res[4] ?? [];
       const fg24 = countOf(res[5]);
 
       return {
@@ -847,24 +924,24 @@ export class AdminService {
   }
 }
 
-function countOf(stmtResult: any): number {
+function countOf(stmtResult: CountRow[]): number {
   if (!Array.isArray(stmtResult) || stmtResult.length === 0) return 0;
   const first = stmtResult[0];
   return typeof first?.c === 'number' ? first.c : 0;
 }
 
 /** Single-row GROUP ALL view: absent row (empty source) reads as 0. */
-function viewCountOf(stmtResult: any): number {
+function viewCountOf(stmtResult: ViewCountRow[]): number {
   if (!Array.isArray(stmtResult) || stmtResult.length === 0) return 0;
   const first = stmtResult[0];
   return typeof first?.n === 'number' ? first.n : 0;
 }
 
 /** GROUP BY status view rows → status → n. Missing groups read as 0. */
-function statusCountsOf(stmtResult: any): Map<string, number> {
+function statusCountsOf(stmtResult: StatusCountRow[]): Map<string, number> {
   const out = new Map<string, number>();
   if (!Array.isArray(stmtResult)) return out;
-  for (const row of stmtResult as Array<{ n?: unknown; status?: unknown }>) {
+  for (const row of stmtResult) {
     if (typeof row?.status === 'string' && typeof row?.n === 'number') {
       out.set(row.status, row.n);
     }

--- a/src/admin/demo-pipeline.service.ts
+++ b/src/admin/demo-pipeline.service.ts
@@ -4,6 +4,7 @@ import { traceArtifact, traceSpan } from '../common/debug-trace';
 import { IngestService } from '../ingest/ingest.service';
 import { SearchService } from '../search/search.service';
 import { DreamsService } from '../dreams/dreams.service';
+import type { DreamsOperation } from '../dreams/dto/run-dreams.dto';
 import type { ChatRoute } from './chat-router.service';
 
 /**
@@ -32,7 +33,7 @@ export class DemoPipelineService {
       text: body.text,
       contextRef: { vertical: body.vertical ?? 'shop' },
       emittedAt: new Date().toISOString(),
-    } as any);
+    });
   }
 
   async runSearch(
@@ -42,13 +43,13 @@ export class DemoPipelineService {
   ) {
     return this.search.search(
       tenant,
-      { query: body.query, limit: body.limit ?? 5, asOf: body.asOf } as any,
-      scopes as any,
+      { query: body.query, limit: body.limit ?? 5, asOf: body.asOf },
+      [...scopes],
     );
   }
 
-  async runDreams(tenant: string, operations: string[]) {
-    return this.dreams.runForTenant(tenant, operations as any);
+  async runDreams(tenant: string, operations: DreamsOperation[]) {
+    return this.dreams.runForTenant(tenant, operations);
   }
 
   /** Tell flow: ingest the mention, then best-effort inline dedup. */
@@ -58,7 +59,7 @@ export class DemoPipelineService {
       text: route.normalizedMessage,
       contextRef: { vertical: 'shop' },
       emittedAt,
-    } as any);
+    });
     // Lazy fast-path identity resolution. Mirrors how a brain SHOULD
     // behave in production: cheap inline dedup runs in the moment so an
     // obvious dupe (typo, alias) gets stitched immediately and the next
@@ -136,8 +137,8 @@ export class DemoPipelineService {
     });
     const search = await this.search.search(
       tenant,
-      { query: queryText, limit: 5, asOf } as any,
-      scopes as any,
+      { query: queryText, limit: 5, asOf },
+      [...scopes],
     );
     return {
       route,

--- a/src/admin/demo-state.service.ts
+++ b/src/admin/demo-state.service.ts
@@ -19,7 +19,7 @@ export class DemoStateService {
   ): Promise<{ entities: number; facts: number; lastIngestAt: string | null }> {
     try {
       return await this.surreal.withCompany(tenant, async (db) => {
-        const [eRows, fRows, lastRows] = (await db.query<
+        const [eRows, fRows, lastRows] = await db.query<
           [
             Array<{ c: number }>,
             Array<{ c: number }>,
@@ -29,11 +29,10 @@ export class DemoStateService {
           `SELECT count() AS c FROM knowledge_entity WHERE mergedInto IS NONE GROUP ALL;
            SELECT count() AS c FROM knowledge_fact WHERE retractedAt IS NONE GROUP ALL;
            SELECT recordedAt FROM knowledge_fact ORDER BY recordedAt DESC LIMIT 1;`,
-        )) as any;
-        const entities = (eRows as Array<{ c: number }>)?.[0]?.c ?? 0;
-        const facts = (fRows as Array<{ c: number }>)?.[0]?.c ?? 0;
-        const lastAt = (lastRows as Array<{ recordedAt?: string }>)?.[0]
-          ?.recordedAt;
+        );
+        const entities = eRows?.[0]?.c ?? 0;
+        const facts = fRows?.[0]?.c ?? 0;
+        const lastAt = lastRows?.[0]?.recordedAt;
         return { entities, facts, lastIngestAt: lastAt ?? null };
       });
     } catch {

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -7,7 +7,7 @@ import {
   Optional,
 } from '@nestjs/common';
 import type { Surreal } from 'surrealdb';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 import { JobClaimService } from '../jobs/job-claim.service';
 import { envFlagEnabled } from '../common/env-validation';
 import { EmbedderService } from '../ai/embedder.service';
@@ -47,6 +47,26 @@ export interface AvailablePack {
   description: string;
   predicateCount: number;
   builtin: boolean;
+}
+
+/** Columns read back from `domain_pack` on install / upgrade / uninstall. */
+interface DomainPackRow {
+  id?: unknown;
+  version?: unknown;
+  manifest?: DomainPackManifest;
+  webhookSecret?: unknown;
+  installId?: unknown;
+  acceptedMcpTools?: unknown;
+  acceptedMcpToolsChecksum?: unknown;
+}
+
+/** `listInstalled` projection of `domain_pack`. */
+interface InstalledPackRow {
+  packId?: unknown;
+  version?: unknown;
+  installedAt: string | Date;
+  manifest?: { predicates?: unknown };
+  checksum?: unknown;
 }
 
 /** Outcome of the seed-documents install hook. Contract mirror:
@@ -114,18 +134,20 @@ export class DomainPackInstallService {
 
   async listInstalled(companyId: string): Promise<InstalledPack[]> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<InstalledPackRow>(
+        db,
         `SELECT packId, version, installedAt, manifest, checksum FROM domain_pack WHERE status = 'active'`,
       );
-      return ((rows as any[]) ?? []).map((r) => ({
-        packId: String(r.packId),
-        version: String(r.version),
-        installedAt: new Date(r.installedAt).toISOString(),
-        predicateCount: Array.isArray(r.manifest?.predicates)
-          ? r.manifest.predicates.length
-          : 0,
-        checksum: r.checksum ? String(r.checksum) : null,
-      }));
+      return rows.map((r) => {
+        const preds = r.manifest?.predicates;
+        return {
+          packId: String(r.packId),
+          version: String(r.version),
+          installedAt: new Date(r.installedAt).toISOString(),
+          predicateCount: Array.isArray(preds) ? preds.length : 0,
+          checksum: r.checksum ? String(r.checksum) : null,
+        };
+      });
     });
   }
 
@@ -214,11 +236,12 @@ export class DomainPackInstallService {
       : `, acceptedMcpTools = NONE, acceptedMcpToolsChecksum = NONE`;
     let mintedInstallId: string | undefined;
     const seeded = await this.surreal.withCompany(companyId, async (db) => {
-      const [existing] = await db.query<[any[]]>(
+      const existing = await queryRows<DomainPackRow>(
+        db,
         `SELECT id, version, manifest, webhookSecret, installId, acceptedMcpTools, acceptedMcpToolsChecksum FROM domain_pack WHERE packId = $packId LIMIT 1`,
         { packId: manifest.id },
       );
-      const row = ((existing as any[]) ?? [])[0];
+      const row = existing[0];
       const consentMessage = mcpConsentRequired({
         manifest,
         acceptMcpTools: opts.acceptMcpTools,
@@ -299,7 +322,7 @@ export class DomainPackInstallService {
    */
   private async applyPackUpgrade(opts: {
     db: Surreal;
-    row: any;
+    row: DomainPackRow;
     manifest: DomainPackManifest;
     checksum: string;
     newIds: string[];
@@ -517,17 +540,19 @@ export class DomainPackInstallService {
       );
     }
     const deprecated = await this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<DomainPackRow>(
+        db,
         `SELECT id FROM domain_pack WHERE packId = $packId AND status = 'active' LIMIT 1`,
         { packId },
       );
-      const row = ((rows as any[]) ?? [])[0];
+      const row = rows[0];
       if (!row) {
         throw new NotFoundException(`pack "${packId}" is not installed`);
       }
       // Deprecate the pack's predicates (status only — facts on them survive).
       const prefix = `${packId}__`;
-      const [updated] = await db.query<[any[]]>(
+      const updated = await queryRows<unknown>(
+        db,
         `UPDATE knowledge_predicate SET status = 'deprecated'
            WHERE string::starts_with(predicateId, $prefix) AND status != 'deprecated'
            RETURN AFTER`,
@@ -537,7 +562,7 @@ export class DomainPackInstallService {
         `UPDATE $id SET status = 'removed', updatedAt = time::now()`,
         { id: row.id },
       );
-      return ((updated as any[]) ?? []).length;
+      return updated.length;
     });
 
     this.registry.invalidate(companyId);

--- a/src/admin/operator-action.service.ts
+++ b/src/admin/operator-action.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ApiKeyService } from '../auth/api-key.service';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 
 export interface OperatorActionRow {
   ts: string;
@@ -13,6 +13,19 @@ export interface OperatorActionRow {
   query?: Record<string, unknown> | null;
   bodySummary?: Record<string, unknown> | null;
   companyId: string;
+}
+
+/** Columns read back from `operator_action`. */
+interface OperatorActionDbRow {
+  ts: string | Date;
+  actor: string;
+  scopes?: unknown;
+  method: string;
+  path: string;
+  status: number;
+  durationMs?: number;
+  query?: Record<string, unknown> | null;
+  bodySummary?: Record<string, unknown> | null;
 }
 
 /**
@@ -67,16 +80,16 @@ export class OperatorActionService {
     const out: OperatorActionRow[] = [];
     for (const companyId of tenants) {
       try {
-        const rows = await this.surreal.withCompany(companyId, async (db) => {
-          const res = (await db.query<any[]>(
+        const rows = await this.surreal.withCompany(companyId, async (db) =>
+          queryRows<OperatorActionDbRow>(
+            db,
             `SELECT ts, actor, scopes, method, path, status, durationMs,
                     query, bodySummary
                FROM operator_action ${whereSql}
               ORDER BY ts DESC LIMIT ${limit}`,
             params,
-          )) as any[];
-          return (res[0] ?? []) as any[];
-        });
+          ),
+        );
         for (const r of rows) {
           out.push({
             ts: typeof r.ts === 'string' ? r.ts : new Date(r.ts).toISOString(),

--- a/src/admin/scenario-eval.service.ts
+++ b/src/admin/scenario-eval.service.ts
@@ -36,9 +36,7 @@ export class ScenarioEvalService {
 
     let hits: SearchHit[] = [];
     let error: string | undefined;
-    let traceCapture:
-      | { requestId: string; totalMs: number; spans: any[] }
-      | undefined;
+    let traceCapture: NonNullable<ScenarioQueryResult['trace']> | undefined;
     try {
       // Capture the in-process debug trace so the demo deck can render
       // the per-stage waterfall (vector / lexical / fusion / reranker).
@@ -50,8 +48,8 @@ export class ScenarioEvalService {
             limit: 10,
             asOf: expectation.asOf,
             ...(expectation.predicates ? { predicates: expectation.predicates } : {}),
-          } as any,
-          callerScopes as any,
+          },
+          callerScopes,
         ),
       );
       hits = captured.result.results;
@@ -173,8 +171,8 @@ export class ScenarioEvalService {
           limit: 20,
           asOf: a.asOf,
           includeRetracted: a.includeRetracted ?? false,
-        } as any,
-        ['brain:read', 'brain:read_pii'] as any,
+        },
+        ['brain:read', 'brain:read_pii'],
       );
 
       if (a.kind === 'no_search_match') {
@@ -293,13 +291,13 @@ export class ScenarioEvalService {
     companyId: string,
     ref: string,
   ): Promise<string | null> {
-    const [, id] = ref.split('.', 2);
+    const [, id = ''] = ref.split('.', 2);
     const refTag = parseRefTag(ref).refKey;
     try {
       const res = await this.search.search(
         companyId,
-        { query: id, limit: 10 } as any,
-        ['brain:read', 'brain:read_pii'] as any,
+        { query: id, limit: 10 },
+        ['brain:read', 'brain:read_pii'],
       );
       const hit = res.results.find((r) => r.externalRefs?.[refTag] === id);
       return hit?.entityId ?? null;

--- a/src/admin/scenario-lifecycle.service.ts
+++ b/src/admin/scenario-lifecycle.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { FactsService } from '../facts/facts.service';
 import { EntitiesService } from '../entities/entities.service';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryFirst } from '../db/surreal.service';
 import type { SetupRetractStep, SetupForgetStep } from '../eval/types';
 import { safe } from './scenario-runner-utils';
 
@@ -76,12 +76,12 @@ export class ScenarioLifecycleService {
     refKey: string,
   ): Promise<string | null> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const first = await queryFirst<unknown>(
+        db,
         `SELECT VALUE entity FROM entity_external_ref WHERE key = $key LIMIT 1`,
         { key: refKey },
       );
-      const arr = (rows as any[]) ?? [];
-      return arr[0] ? String(arr[0]) : null;
+      return first ? String(first) : null;
     });
   }
 }

--- a/src/ai/extractor-internals/edge-validator.ts
+++ b/src/ai/extractor-internals/edge-validator.ts
@@ -9,7 +9,7 @@ import type { ExtractedEdge } from './types';
  * Returns surviving edges + drop diagnostics for trace emission.
  */
 export function validateEdges(
-  parsed: any,
+  parsed: unknown,
   entityCount: number,
   clauses: string[],
 ): {
@@ -18,9 +18,13 @@ export function validateEdges(
 } {
   const edges: ExtractedEdge[] = [];
   const dropped: Array<{ kind?: string; reason: string }> = [];
-  if (!Array.isArray(parsed.edges)) return { edges, dropped };
+  const rawEdges =
+    typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>).edges
+      : undefined;
+  if (!Array.isArray(rawEdges)) return { edges, dropped };
 
-  for (const e of parsed.edges as Array<Record<string, unknown>>) {
+  for (const e of rawEdges as Array<Record<string, unknown>>) {
     if (!e || typeof e !== 'object') continue;
     const from = Number(e.fromEntityIndex);
     const to = Number(e.toEntityIndex);

--- a/src/ai/extractor-internals/grounding.ts
+++ b/src/ai/extractor-internals/grounding.ts
@@ -30,6 +30,11 @@ export function normalizeForGrounding(s: string): string {
   return s.replace(/\s+/g, ' ').trim().toLowerCase();
 }
 
+/** Object-shape guard for narrowing raw LLM JSON before field access. */
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
 // Letters from word-SPACED scripts (Latin + Latin-1/extended + Cyrillic).
 // For these, a span embedded inside a larger word ("act" inside "active") is
 // a false ground and must be rejected. Word-UNSPACED scripts (CJK, Thai, …)
@@ -121,24 +126,27 @@ export function normalizeEntityType(t: unknown): ExtractedEntity['type'] {
 }
 
 /** Parse the entities[] array from the raw LLM JSON. */
-export function parseEntities(parsed: any): ExtractedEntity[] {
-  if (!Array.isArray(parsed.entities)) return [];
-  return parsed.entities
-    .filter((e: any) => e && typeof e.name === 'string')
-    .map((e: any) => ({
-      name: String(e.name).trim(),
+export function parseEntities(parsed: unknown): ExtractedEntity[] {
+  const entities = isRecord(parsed) ? parsed.entities : undefined;
+  if (!Array.isArray(entities)) return [];
+  const out: ExtractedEntity[] = [];
+  for (const e of entities as unknown[]) {
+    if (!isRecord(e) || typeof e.name !== 'string') continue;
+    out.push({
+      name: e.name.trim(),
       type: normalizeEntityType(e.type),
       canonical:
-        e.canonical && typeof e.canonical === 'string'
-          ? e.canonical.trim()
-          : undefined,
-    }));
+        typeof e.canonical === 'string' ? e.canonical.trim() : undefined,
+    });
+  }
+  return out;
 }
 
 /** Parse the clauses[] array — verbatim string sub-spans. */
-export function parseClauses(parsed: any): string[] {
-  if (!Array.isArray(parsed.clauses)) return [];
-  return parsed.clauses.filter((c: unknown) => typeof c === 'string');
+export function parseClauses(parsed: unknown): string[] {
+  const clauses = isRecord(parsed) ? parsed.clauses : undefined;
+  if (!Array.isArray(clauses)) return [];
+  return (clauses as unknown[]).filter((c): c is string => typeof c === 'string');
 }
 
 /**
@@ -146,28 +154,34 @@ export function parseClauses(parsed: any): string[] {
  * entityIndex in bounds, predicate is a string, valueSpan is a string.
  */
 export function parseRawFacts(
-  parsed: any,
+  parsed: unknown,
   entityCount: number,
 ): RawExtractedFact[] {
-  if (!Array.isArray(parsed.facts)) return [];
-  return parsed.facts
-    .filter(
-      (f: any) =>
-        f &&
-        Number.isInteger(f.entityIndex) &&
-        f.entityIndex >= 0 &&
-        f.entityIndex < entityCount &&
-        typeof f.predicate === 'string' &&
-        typeof f.valueSpan === 'string',
-    )
-    .map((f: any) => ({
+  const facts = isRecord(parsed) ? parsed.facts : undefined;
+  if (!Array.isArray(facts)) return [];
+  const out: RawExtractedFact[] = [];
+  for (const f of facts as unknown[]) {
+    if (
+      !isRecord(f) ||
+      typeof f.entityIndex !== 'number' ||
+      !Number.isInteger(f.entityIndex) ||
+      f.entityIndex < 0 ||
+      f.entityIndex >= entityCount ||
+      typeof f.predicate !== 'string' ||
+      typeof f.valueSpan !== 'string'
+    ) {
+      continue;
+    }
+    out.push({
       entityIndex: f.entityIndex,
       clauseIndex:
-        Number.isInteger(f.clauseIndex) && f.clauseIndex >= 0
+        typeof f.clauseIndex === 'number' &&
+        Number.isInteger(f.clauseIndex) &&
+        f.clauseIndex >= 0
           ? f.clauseIndex
           : undefined,
-      predicate: String(f.predicate).trim(),
-      valueSpan: String(f.valueSpan).trim(),
+      predicate: f.predicate.trim(),
+      valueSpan: f.valueSpan.trim(),
       confidence:
         typeof f.confidence === 'number'
           ? Math.max(0, Math.min(1, f.confidence))
@@ -175,7 +189,9 @@ export function parseRawFacts(
       ...(typeof f.object === 'string' && f.object.trim()
         ? { object: f.object.trim() }
         : {}),
-    }));
+    });
+  }
+  return out;
 }
 
 /**

--- a/src/ai/extractor-llm.service.ts
+++ b/src/ai/extractor-llm.service.ts
@@ -120,7 +120,7 @@ export class ExtractorLlmService {
      * containment. Empty/absent → byte-identical to the pre-coreference call.
      */
     contextPrefix?: string;
-  }): Promise<any> {
+  }): Promise<unknown> {
     const { trimmed, systemPrompt } = args;
     const temperature = args.temperature ?? 0.1;
     const model = args.model ?? this.model;

--- a/src/ai/extractor-runner.service.ts
+++ b/src/ai/extractor-runner.service.ts
@@ -301,7 +301,7 @@ export class ExtractorRunnerService {
     companyId: string;
     trimmed: string;
     snapshot: Snapshot;
-    rawJson: any;
+    rawJson: unknown;
     context?: ConversationContext;
   }): Promise<ExtractionResult> {
     const { companyId, trimmed, snapshot, rawJson, context } = args;

--- a/src/artifacts/artifacts.service.ts
+++ b/src/artifacts/artifacts.service.ts
@@ -3,8 +3,11 @@ import { Surreal, StringRecordId } from 'surrealdb';
 import {
   SurrealService,
   retryOnUniqueViolation,
+  queryRows,
+  queryFirst,
 } from '../db/surreal.service';
 import { policyFor } from '../ingest/conflict-resolver';
+import type { FactSource } from '../ingest/dto/ingest-fact.dto';
 import { BrainScope } from '../auth/api-key.types';
 import {
   TEMPLATES,
@@ -74,6 +77,45 @@ export interface KnowledgeArtifact {
 
 type FactRow = TemplateFactRow;
 
+/** knowledge_entity existence probe. */
+interface EntityIdRow {
+  id: unknown;
+}
+
+/** The wrapped `payload` column: `{ payload, _citations }` (see upsertArtifact). */
+interface WrappedPayload {
+  payload?: Record<string, unknown>;
+  _citations?: KnowledgeArtifact['citations'];
+}
+
+/** A cached knowledge_artifact row as read by fetchCached. */
+interface CachedArtifactRow {
+  payload?: WrappedPayload;
+  sourceFactIds?: unknown[];
+  builtAt: string;
+  staleAfterMs?: number;
+  dirty?: unknown;
+}
+
+/** A knowledge_artifact row after an UPSERT's `RETURN AFTER`. */
+interface StoredArtifactRow {
+  builtAt: string;
+  staleAfterMs?: number;
+  dirty?: unknown;
+}
+
+/** A knowledge_fact row as read by fetchActiveFacts (columns it SELECTs). */
+interface ActiveFactRow {
+  id: unknown;
+  predicate: string;
+  object: string;
+  confidence: number;
+  validFrom: string;
+  recordedAt: string;
+  source: FactSource;
+  status: string;
+}
+
 export interface GetArtifactOptions {
   companyId: string;
   entityIdRaw: string;
@@ -103,11 +145,12 @@ export class ArtifactsService {
     const ref = this.normalizeEntityId(entityIdRaw);
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       // 1. Verify entity exists.
-      const [entRows] = await db.query<any[][]>(
+      const ent = await queryFirst<EntityIdRow>(
+        db,
         `SELECT id FROM type::record('knowledge_entity', $rid) LIMIT 1`,
         { rid: ref.id },
       );
-      if (!(entRows as any[])?.[0]) {
+      if (!ent) {
         throw new NotFoundException(`Entity ${entityIdRaw} not found`);
       }
 
@@ -166,11 +209,12 @@ export class ArtifactsService {
   }: RecompileArtifactOptions): Promise<KnowledgeArtifact> {
     const ref = this.normalizeEntityId(entityIdRaw);
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
-      const [entRows] = await db.query<any[][]>(
+      const ent = await queryFirst<EntityIdRow>(
+        db,
         `SELECT id FROM type::record('knowledge_entity', $rid) LIMIT 1`,
         { rid: ref.id },
       );
-      if (!(entRows as any[])?.[0]) {
+      if (!ent) {
         throw new NotFoundException(`Entity ${entityIdRaw} not found`);
       }
       // Observe dirty BEFORE reading facts so the CAS in upsertArtifact can
@@ -237,7 +281,8 @@ export class ArtifactsService {
     staleAfterMs: number;
     dirty: boolean;
   } | null> {
-    const [rows] = await db.query<any[][]>(
+    const row = await queryFirst<CachedArtifactRow>(
+      db,
       `SELECT payload, sourceFactIds, builtAt, staleAfterMs, dirty
        FROM knowledge_artifact
        WHERE entityId = type::record('knowledge_entity', $rid)
@@ -245,7 +290,6 @@ export class ArtifactsService {
        LIMIT 1`,
       { rid, type: artifactType },
     );
-    const row = ((rows as any[]) ?? [])[0];
     if (!row) return null;
     const payload = (row.payload?.payload ?? row.payload) as Record<string, unknown>;
     const citations = (row.payload?._citations ?? {}) as KnowledgeArtifact['citations'];
@@ -275,7 +319,8 @@ export class ArtifactsService {
     // this ran unbounded on the artifact read path — a long-lived entity
     // shipped its entire fact history per cache miss. 500 newest is far
     // beyond what any template renders.
-    const [rows] = await db.query<[any[]]>(
+    const rows = await queryRows<ActiveFactRow>(
+      db,
       `SELECT id, predicate, object, confidence, validFrom, validUntil,
               recordedAt, source, status
          FROM knowledge_fact
@@ -286,15 +331,15 @@ export class ArtifactsService {
          LIMIT 500`,
       { rid },
     );
-    return ((rows as any[]) ?? [])
-      .filter((f: any) => {
+    return rows
+      .filter((f) => {
         const policy = policyFor(f.predicate);
         if (policy.requiresScope && !scopes.includes(policy.requiresScope)) {
           return false;
         }
         return true;
       })
-      .map((f: any) => ({
+      .map((f) => ({
         id: f.id,
         predicate: f.predicate,
         object: f.object,
@@ -337,7 +382,8 @@ export class ArtifactsService {
     // the UPDATE and both CREATE → one hits the (entityId, artifactType)
     // UNIQUE index. On retry the UPDATE now finds the winner's row.
     const row = await retryOnUniqueViolation(async () => {
-      const [updRows] = await db.query<any[][]>(
+      const updated = await queryFirst<StoredArtifactRow>(
+        db,
         // CAS on dirty: clear it only if the flag still matches what we
         // observed before reading facts. migration 0004 defines a DB EVENT
         // that flips dirty=true whenever a relevant fact changes, so a fact
@@ -361,9 +407,9 @@ export class ArtifactsService {
           expectedDirty,
         },
       );
-      const updated = ((updRows as any[]) ?? [])[0];
       if (updated) return updated;
-      const [creRows] = await db.query<any[][]>(
+      const created = await queryFirst<StoredArtifactRow>(
+        db,
         `CREATE knowledge_artifact CONTENT {
             entityId: type::record('knowledge_entity', $rid),
             artifactType: $type,
@@ -373,7 +419,10 @@ export class ArtifactsService {
          } RETURN AFTER`,
         { rid, type: artifactType, wrapped, facts: factRecords },
       );
-      return ((creRows as any[]) ?? [])[0];
+      if (!created) {
+        throw new Error('upsertArtifact: CREATE returned no row');
+      }
+      return created;
     });
     return {
       payload,

--- a/src/artifacts/templates.ts
+++ b/src/artifacts/templates.ts
@@ -17,6 +17,8 @@
  * ARTIFACT_FIELD_TO_PREDICATE below.
  */
 
+import type { FactSource } from '../ingest/dto/ingest-fact.dto';
+
 export interface FactRow {
   id: unknown;
   predicate: string;
@@ -24,7 +26,7 @@ export interface FactRow {
   confidence: number;
   validFrom: string;
   recordedAt: string;
-  source: any;
+  source: FactSource;
   status: string;
 }
 
@@ -32,7 +34,7 @@ export interface Citation {
   factId: string;
   confidence: number;
   recordedAt: string;
-  source: any;
+  source: FactSource;
 }
 
 export interface CompiledArtifact {

--- a/src/audit/changefeed-drain.service.ts
+++ b/src/audit/changefeed-drain.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import type { Surreal } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { redactAfterImage } from './changefeed-redaction';
@@ -170,7 +171,7 @@ export class ChangefeedDrainService {
 
   // ── Wire-format helpers ──────────────────────────────────────────
 
-  private async loadCursor(db: any, source: string): Promise<number> {
+  private async loadCursor(db: Surreal, source: string): Promise<number> {
     const [rows] = await db.query(
       `SELECT lastVersionstamp FROM changefeed_state
         WHERE source = $s LIMIT 1`,
@@ -181,7 +182,7 @@ export class ChangefeedDrainService {
   }
 
   private async fetchChanges(
-    db: any,
+    db: Surreal,
     source: string,
     since: number,
   ): Promise<Array<Record<string, unknown>>> {
@@ -253,7 +254,7 @@ export class ChangefeedDrainService {
   }
 
   private async advanceCursor(
-    db: any,
+    db: Surreal,
     source: string,
     versionstamp: number,
   ): Promise<void> {

--- a/src/auth/api-key.service.ts
+++ b/src/auth/api-key.service.ts
@@ -47,8 +47,11 @@ export class ApiKeyService implements OnModuleInit {
       // malformed value is a boot error, not a silently ignored field —
       // an operator who typed `"policies": "readonly"` believes the key
       // is restricted.
-      if (k.policyNames !== undefined || (k as any).policies !== undefined) {
-        const names = (k as any).policies ?? k.policyNames;
+      // `policies` is a legacy field name the typed ApiKey no longer carries
+      // (it has `policyNames`); read it through a narrow local shape.
+      const legacy = k as { policies?: unknown };
+      if (k.policyNames !== undefined || legacy.policies !== undefined) {
+        const names = legacy.policies ?? k.policyNames;
         if (
           !Array.isArray(names) ||
           names.some((n: unknown) => typeof n !== 'string')
@@ -58,7 +61,7 @@ export class ApiKeyService implements OnModuleInit {
           );
         }
         k.policyNames = names;
-        delete (k as any).policies;
+        delete legacy.policies;
       }
       // Optional per-pack indexer binding: `"packIds": ["my_pack", …]`.
       // Same malformed-is-a-boot-error stance as policies — an operator

--- a/src/code-memory/capture/http-sink.ts
+++ b/src/code-memory/capture/http-sink.ts
@@ -19,7 +19,7 @@ type FetchLike = (
     body: string;
     signal?: AbortSignal;
   },
-) => Promise<{ ok: boolean; status: number; json: () => Promise<any> }>;
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
 
 const CODE_VERTICAL = 'code';
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -61,7 +61,7 @@ export class HttpDecisionSink implements DecisionSink {
     };
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), this.timeoutMs);
-    let res: { ok: boolean; status: number; json: () => Promise<any> };
+    let res: { ok: boolean; status: number; json: () => Promise<unknown> };
     try {
       res = await this.fetchImpl(`${this.opts.baseUrl}/v1/ingest/fact`, {
         method: 'POST',
@@ -84,6 +84,7 @@ export class HttpDecisionSink implements DecisionSink {
       throw new Error(`ingest POST failed: ${res.status}`);
     }
     const json = await res.json();
-    return { outcome: String(json?.outcome ?? 'UNKNOWN') };
+    const outcome = (json as { outcome?: unknown })?.outcome;
+    return { outcome: String(outcome ?? 'UNKNOWN') };
   }
 }

--- a/src/code-memory/code-memory-anchor.service.ts
+++ b/src/code-memory/code-memory-anchor.service.ts
@@ -1,8 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import type { Surreal } from 'surrealdb';
 import {
   SurrealService,
   retryOnUniqueViolation,
   isUniqueViolation,
+  queryRows,
+  queryFirst,
 } from '../db/surreal.service';
 import { BrainScope } from '../auth/api-key.types';
 import { CODE_MEMORY_PACK } from '../ai/domain-packs';
@@ -11,6 +14,18 @@ export interface AnchorRow {
   anchor: string;
   entityId: string;
   factIds: string[];
+}
+
+/** A code-memory knowledge_fact row as read by listAnchors. */
+interface AnchorFactRow {
+  id: unknown;
+  entityId: unknown;
+  refs?: Record<string, string> | null;
+}
+
+/** The entity row read to mirror externalRefs during reanchor. */
+interface EntityRefsRow {
+  externalRefs?: Record<string, string> | null;
 }
 
 /**
@@ -40,7 +55,8 @@ export class CodeMemoryAnchorService {
       // Half-open predicate range rides fact_predicate_idx; the previous
       // string::starts_with defeated the index (full scan + per-row
       // entityId deref). LIMIT bounds the admin listing.
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<AnchorFactRow>(
+        db,
         `SELECT id, entityId, entityId.externalRefs AS refs
            FROM knowledge_fact
            WHERE predicate >= $prefix AND predicate < $prefixEnd
@@ -49,7 +65,7 @@ export class CodeMemoryAnchorService {
         { prefix: this.prefix, prefixEnd: `${this.prefix}￿` },
       );
       const byAnchor = new Map<string, AnchorRow>();
-      for (const r of (rows as any[]) ?? []) {
+      for (const r of rows) {
         const anchor = anchorOf(r.refs);
         if (!anchor) continue;
         const existing = byAnchor.get(anchor);
@@ -83,7 +99,8 @@ export class CodeMemoryAnchorService {
       // retractedAt IS NONE) keeps superseded rows untouched: they carry
       // the retractionReason = 'superseded' sentinel that revive +
       // calibration depend on, and they are already out of every read.
-      const [updated] = await db.query<[any[]]>(
+      const updated = await queryRows<{ id: unknown }>(
+        db,
         `UPDATE knowledge_fact
            SET status = 'retracted',
                retractedAt = time::now(),
@@ -96,7 +113,7 @@ export class CodeMemoryAnchorService {
            RETURN AFTER`,
         { eid: idTail(entityId), prefix: this.prefix, reason },
       );
-      const n = ((updated as any[]) ?? []).length;
+      const n = updated.length;
       this.logger.log(
         `Invalidated ${n} code-memory fact(s) at anchor ${anchor} (${companyId}): ${reason}`,
       );
@@ -129,11 +146,12 @@ export class CodeMemoryAnchorService {
         throw e;
       }
       // Mirror into the entity's externalRefs map (read-merge-write).
-      const [ent] = await db.query<[any[]]>(
+      const ent = await queryFirst<EntityRefsRow>(
+        db,
         `SELECT externalRefs FROM type::record('knowledge_entity', $eid) LIMIT 1`,
         { eid: idTail(entityId) },
       );
-      const refs = ((ent as any[]) ?? [])[0]?.externalRefs ?? {};
+      const refs = ent?.externalRefs ?? {};
       await db.query(
         `UPDATE type::record('knowledge_entity', $eid) SET externalRefs = $refs`,
         { eid: idTail(entityId), refs: { ...refs, [newKey]: newAnchor } },
@@ -145,14 +163,17 @@ export class CodeMemoryAnchorService {
     });
   }
 
-  private async resolveEntity(db: any, anchor: string): Promise<string | null> {
+  private async resolveEntity(
+    db: Surreal,
+    anchor: string,
+  ): Promise<string | null> {
     const key = externalRefKey('code', anchor);
-    const [rows] = await db.query(
+    const first = await queryFirst<unknown>(
+      db,
       `SELECT VALUE entity FROM entity_external_ref WHERE key = $key LIMIT 1`,
       { key },
     );
-    const arr = (rows as any[]) ?? [];
-    return arr[0] ? String(arr[0]) : null;
+    return first ? String(first) : null;
   }
 }
 

--- a/src/code-memory/code-memory-search.service.ts
+++ b/src/code-memory/code-memory-search.service.ts
@@ -1,10 +1,13 @@
 import { Injectable, Optional } from '@nestjs/common';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { BrainScope } from '../auth/api-key.types';
 import { CODE_MEMORY_PACK, codeMemoryKindOf } from '../ai/domain-packs';
-import { makeRowPolicyFilter } from '../policy/row-filter';
+import {
+  makeRowPolicyFilter,
+  type PolicyFilterableRow,
+} from '../policy/row-filter';
 
 export interface RecalledDecision {
   anchor: string;
@@ -12,6 +15,14 @@ export interface RecalledDecision {
   text: string;
   score: number;
   validFrom: string;
+}
+
+/** A code-memory fact row as read by recall (extends the row-policy shape). */
+interface RecallRow extends PolicyFilterableRow {
+  object: unknown;
+  validFrom?: string | Date | null;
+  refs?: Record<string, string> | null;
+  score?: unknown;
 }
 
 /**
@@ -56,7 +67,8 @@ export class CodeMemorySearchService {
         // without them an invalidated anchor's facts (retractedAt set but
         // status left 'active' by older writes) and future-dated decisions
         // would surface in recall while every other read path hides them.
-        const [rows] = await db.query<[any[]]>(
+        const rows = await queryRows<RecallRow>(
+          db,
           `SELECT
              predicate,
              object,
@@ -96,9 +108,7 @@ export class CodeMemorySearchService {
             opts.companyId,
           ),
         });
-        const visible = ((rows as any[]) ?? []).filter((r) =>
-          rowPolicy.filter(r as { predicate: string }),
-        );
+        const visible = rows.filter((r) => rowPolicy.filter(r));
         rowPolicy.finish();
         return visible.map((r) => ({
           anchor: anchorOf(r.refs),

--- a/src/common/trace-buffer.service.ts
+++ b/src/common/trace-buffer.service.ts
@@ -1,9 +1,27 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Subject } from 'rxjs';
-import type { DebugTraceSnapshot } from './debug-trace-core';
-import { SurrealService } from '../db/surreal.service';
+import type {
+  DebugTraceSnapshot,
+  DebugSpan,
+  DebugArtifact,
+} from './debug-trace-core';
+import { SurrealService, queryFirst } from '../db/surreal.service';
 import { envFlagEnabled } from '../common/env-validation';
+
+/** A persisted debug_trace row as read by get() (columns it SELECTs). */
+interface DebugTraceRow {
+  requestId: string;
+  ts: string | number | Date;
+  method: string;
+  path: string;
+  status: number;
+  durationMs: number;
+  companyId?: string;
+  spans?: DebugSpan[];
+  artifacts?: DebugArtifact[];
+  errored?: { message: string; name?: string };
+}
 
 /**
  * Ring buffer of per-request debug snapshots.
@@ -147,15 +165,14 @@ export class TraceBufferService {
     if (!this.persistEnabled || !this.surreal || !companyId) return undefined;
     try {
       return await this.surreal.withCompany(companyId, async (db) => {
-        const res = (await db.query<any[]>(
+        const row = await queryFirst<DebugTraceRow>(
+          db,
           `SELECT requestId, ts, method, path, status, durationMs, companyId,
                   spans, artifacts, errored
              FROM debug_trace
             WHERE requestId = $r AND companyId = $c LIMIT 1`,
           { r: requestId, c: companyId },
-        )) as any[];
-        const rows = (res[0] ?? []) as any[];
-        const row = rows[0];
+        );
         if (!row) return undefined;
         return {
           requestId: row.requestId,

--- a/src/compaction/compaction-runner.service.ts
+++ b/src/compaction/compaction-runner.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import type { Surreal } from 'surrealdb';
 import { StringRecordId } from 'surrealdb';
 import { SurrealService, dbCreate } from '../db/surreal.service';
 import { ReadPinService } from '../episodes/read-pin.service';
@@ -177,7 +178,7 @@ export class CompactionRunnerService {
    * summaries created.
    */
   private async createSummaries(
-    db: any,
+    db: Surreal,
     candidates: CandidateFactRow[],
     derivedVersion: string | null,
   ): Promise<number> {

--- a/src/compaction/recompose.service.ts
+++ b/src/compaction/recompose.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, Logger, OnModuleInit, Optional } from '@nestjs/comm
 import { Cron } from '@nestjs/schedule';
 import type { Surreal } from 'surrealdb';
 import { StringRecordId } from 'surrealdb';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows, queryFirst } from '../db/surreal.service';
 import { ApiKeyService } from '../auth/api-key.service';
 import { JobClaimService } from '../jobs/job-claim.service';
 import { WorkerLoopService } from '../jobs/worker-loop.service';
@@ -27,6 +27,41 @@ const CURSOR = 'recompose:knowledge_fact';
  * chase its own tail forever.
  */
 const CONTENT_CHANGED = new Set(['superseded', 'retracted']);
+
+/** One `SHOW CHANGES` batch row: a versionstamp plus its changefeed items. */
+interface ShowChangesRow {
+  versionstamp?: number | string;
+  changes?: unknown[];
+}
+
+/** The `changefeed_state` cursor row this pass reads/advances. */
+interface CursorRow {
+  lastVersionstamp?: number;
+}
+
+/** A stale compaction summary awaiting re-derivation. */
+interface StaleSummaryRow {
+  id: unknown;
+  predicate?: unknown;
+  derivedFrom?: unknown[];
+  staleAt?: unknown;
+}
+
+/**
+ * A knowledge_fact row as selected by the recompose SELECTs. The temporal and
+ * scalar columns funnel through String()/Number()/isoOf(), so they are typed
+ * `unknown`; the shape reflects exactly the columns the SELECTs return.
+ */
+interface FactRow {
+  id: unknown;
+  predicate: unknown;
+  object: unknown;
+  confidence?: unknown;
+  validFrom: unknown;
+  validUntil?: unknown;
+  retractedAt?: unknown;
+  supersededBy?: unknown;
+}
 
 /**
  * RecomposeService — Phase 1 of docs/roadmap/cascade-recompose-2026-07.md.
@@ -135,18 +170,18 @@ export class RecomposeService implements OnModuleInit {
   async invalidate(companyId: string): Promise<number> {
     return this.surreal.withCompany(companyId, async (db) => {
       const since = await loadCursor(db);
-      const [rows] = await db.query<[any[]]>(
+      const changes = await queryRows<ShowChangesRow>(
+        db,
         `SHOW CHANGES FOR TABLE knowledge_fact SINCE ${since} LIMIT ${this.batchLimit}`,
       );
-      const changes = (rows as any[]) ?? [];
       let highest = since;
       const changed: string[] = [];
       for (const c of changes) {
-        const vs = Number(c?.versionstamp ?? 0);
+        const vs = Number(c.versionstamp ?? 0);
         // SINCE is inclusive of the boundary — skip the row the cursor sits on.
         if (vs <= since) continue;
         if (vs > highest) highest = vs;
-        for (const item of (c?.changes as any[]) ?? []) {
+        for (const item of c.changes ?? []) {
           // `changefeedRow`, not `item.update` — on an UPDATE the latter is a
           // patch ARRAY and reading `.id` off it yields undefined, which is how
           // a drain silently sees creates only.
@@ -183,7 +218,8 @@ export class RecomposeService implements OnModuleInit {
     companyId: string,
   ): Promise<{ recomputed: number; retracted: number }> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<StaleSummaryRow>(
+        db,
         `SELECT id, predicate, derivedFrom, staleAt FROM knowledge_fact
           WHERE staleAt IS NOT NONE
             AND retractedAt IS NONE
@@ -192,7 +228,7 @@ export class RecomposeService implements OnModuleInit {
       );
       let recomputed = 0;
       let retracted = 0;
-      for (const summary of (rows as any[]) ?? []) {
+      for (const summary of rows) {
         const parents = await this.currentParents(db, summary.derivedFrom ?? []);
         if (parents.length === 0) {
           await this.retractOrphan(db, String(summary.id));
@@ -216,14 +252,15 @@ export class RecomposeService implements OnModuleInit {
     recorded: unknown[],
   ): Promise<FactToSummarize[]> {
     if (recorded.length === 0) return [];
-    const [rows] = await db.query<[any[]]>(
+    const rows = await queryRows<FactRow>(
+      db,
       `SELECT id, predicate, object, confidence, validFrom, validUntil,
               retractedAt, supersededBy
          FROM knowledge_fact WHERE id INSIDE $ids`,
       { ids: recorded.map((r) => new StringRecordId(String(r))) },
     );
     const out: FactToSummarize[] = [];
-    for (const row of (rows as any[]) ?? []) {
+    for (const row of rows) {
       const live = await this.followSupersedes(db, row);
       if (!live || live.retractedAt) continue;
       out.push({
@@ -240,16 +277,20 @@ export class RecomposeService implements OnModuleInit {
   }
 
   /** Walk supersededBy to the current row. Bounded at 8 hops. */
-  private async followSupersedes(db: Surreal, row: any): Promise<any | null> {
-    let current = row;
-    for (let hop = 0; hop < 8 && current?.supersededBy; hop++) {
-      const [next] = await db.query<[any[]]>(
+  private async followSupersedes(
+    db: Surreal,
+    row: FactRow,
+  ): Promise<FactRow | null> {
+    let current: FactRow = row;
+    for (let hop = 0; hop < 8 && current.supersededBy; hop++) {
+      const next = await queryRows<FactRow>(
+        db,
         `SELECT id, predicate, object, confidence, validFrom, validUntil,
                 retractedAt, supersededBy
            FROM knowledge_fact WHERE id = $id`,
         { id: new StringRecordId(String(current.supersededBy)) },
       );
-      const found = ((next as any[]) ?? [])[0];
+      const found = next[0];
       if (!found) return current;
       current = found;
     }
@@ -305,11 +346,12 @@ export class RecomposeService implements OnModuleInit {
 }
 
 async function loadCursor(db: Surreal): Promise<number> {
-  const [rows] = await db.query<[any[]]>(
+  const row = await queryFirst<CursorRow>(
+    db,
     `SELECT lastVersionstamp FROM changefeed_state WHERE source = $s LIMIT 1`,
     { s: CURSOR },
   );
-  return ((rows as any[]) ?? [])[0]?.lastVersionstamp ?? 0;
+  return row?.lastVersionstamp ?? 0;
 }
 
 async function advanceCursor(db: Surreal, versionstamp: number): Promise<void> {

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -722,6 +722,46 @@ export async function dbMerge<T extends Record<string, unknown>>(
   return arr[0]!; // length > 0 guaranteed by the guard above
 }
 
+/**
+ * Run a single-statement SELECT/UPDATE/DELETE and return its row array,
+ * typed as `T[]`. `db.query<[T[]]>()` types the one result slot; the
+ * `?? []` guards the (impossible-in-practice, but typed-as-optional) empty
+ * response so callers always get an array to map/filter over.
+ *
+ * This is the typed replacement for the `(await db.query(sql)) as any` /
+ * `(rows as any[]) ?? []` idiom that used to litter the store services.
+ * Pass a row interface reflecting the columns the SELECT actually returns:
+ *
+ *   interface CountRow { c: number }
+ *   const [{ c }] = await queryRows<CountRow>(db, 'SELECT count() AS c ...');
+ *
+ * For multi-statement batches (LET/RETURN, several SELECTs), call
+ * `db.query<[A[], B[]]>()` directly and index the tuple — this helper is
+ * for the common single-statement case.
+ */
+export async function queryRows<T>(
+  db: Surreal,
+  sql: string,
+  vars?: Record<string, unknown>,
+): Promise<T[]> {
+  const [rows] = await db.query<[T[]]>(sql, vars);
+  return (rows as T[]) ?? [];
+}
+
+/**
+ * Run a single-statement query and return only its first row (or
+ * `undefined` when the query matched nothing). Typed convenience over
+ * `queryRows` for the `LIMIT 1` / by-id lookup shape.
+ */
+export async function queryFirst<T>(
+  db: Surreal,
+  sql: string,
+  vars?: Record<string, unknown>,
+): Promise<T | undefined> {
+  const rows = await queryRows<T>(db, sql, vars);
+  return rows[0];
+}
+
 function tableOf(rid: string): string {
   const idx = rid.indexOf(':');
   return idx === -1 ? rid : rid.slice(0, idx);

--- a/src/diff/memory-diff.service.ts
+++ b/src/diff/memory-diff.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { StringRecordId } from 'surrealdb';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
-import { makeRowPolicyFilter } from '../policy/row-filter';
+import { makeRowPolicyFilter, PolicyFilterableRow } from '../policy/row-filter';
 
 /**
  * memory_diff — return everything brain learned (and unlearned) between
@@ -80,7 +80,8 @@ export class MemoryDiffService {
       // CREATED: facts whose recordedAt landed in [from, to). We don't
       // care whether they were later retracted — at the moment of
       // creation, the agent learned something.
-      const [createdRows] = await db.query<any[][]>(
+      const createdRows = await queryRows<FactRow>(
+        db,
         `SELECT ${FACT_FIELDS}
            FROM knowledge_fact
            WHERE recordedAt >= $from AND recordedAt < $to
@@ -93,7 +94,8 @@ export class MemoryDiffService {
       // window. status=='superseded' rides on supersededBy — we'll
       // partition that out as `changedFacts` so the caller sees the
       // replacement, not just the disappearance.
-      const [retractedRows] = await db.query<any[][]>(
+      const retractedRows = await queryRows<FactRow>(
+        db,
         `SELECT ${FACT_FIELDS}, supersededBy
            FROM knowledge_fact
            WHERE retractedAt >= $from AND retractedAt < $to
@@ -103,7 +105,8 @@ export class MemoryDiffService {
       );
 
       // NEW ENTITIES — knowledge_entity.createdAt within window.
-      const [newEntityRows] = await db.query<any[][]>(
+      const newEntityRows = await queryRows<NewEntityRow>(
+        db,
         `SELECT id, type, canonicalName, externalRefs, createdAt
            FROM knowledge_entity
            WHERE createdAt >= $from AND createdAt < $to
@@ -116,7 +119,8 @@ export class MemoryDiffService {
       // Note: we cannot scope by entityId here (the original id is
       // hashed in the tombstone), so the entityIds filter is ignored
       // for this section.
-      const [forgottenRows] = await db.query<any[][]>(
+      const forgottenRows = await queryRows<ForgottenRowDb>(
+        db,
         `SELECT entityIdHash, reason, requestId, forgottenAt
            FROM forgotten_entity
            WHERE forgottenAt >= $from AND forgottenAt < $to
@@ -126,17 +130,17 @@ export class MemoryDiffService {
 
       let truncated = false;
       const clip = <T>(rows: T[] | undefined | null): T[] => {
-        const list = (rows as T[]) ?? [];
+        const list = rows ?? [];
         if (list.length > SECTION_CAP) {
           truncated = true;
           return list.slice(0, SECTION_CAP);
         }
         return list;
       };
-      const createdClipped = clip(createdRows as any[]);
-      const retractedClipped = clip(retractedRows as any[]);
-      const newEntityClipped = clip(newEntityRows as any[]);
-      const forgottenClipped = clip(forgottenRows as any[]);
+      const createdClipped = clip(createdRows);
+      const retractedClipped = clip(retractedRows);
+      const newEntityClipped = clip(newEntityRows);
+      const forgottenClipped = clip(forgottenRows);
 
       const createdFacts: FactRef[] = createdClipped
         .filter((r) => rowFilter.filter(r))
@@ -194,13 +198,14 @@ export class MemoryDiffService {
       );
       const replacementMap = new Map<string, FactRef>();
       if (replacementIds.length > 0) {
-        const [afterRows] = await db.query<any[][]>(
+        const afterRows = await queryRows<FactRow>(
+          db,
           `SELECT ${FACT_FIELDS}
              FROM knowledge_fact
              WHERE id INSIDE $ids`,
           { ids: replacementIds.map((id) => new StringRecordId(id)) },
         );
-        for (const r of (afterRows as any[]) ?? []) {
+        for (const r of afterRows) {
           if (rowFilter.filter(r)) {
             const ref = rowToFactRef(r);
             replacementMap.set(ref.factId, ref);
@@ -218,17 +223,17 @@ export class MemoryDiffService {
       const netCreated = createdFacts.filter((c) => !supersedeeIds.has(c.factId));
 
       const newEntities: EntityRef[] = newEntityClipped.map(
-        (r: any) => ({
+        (r) => ({
           entityId: String(r.id),
           type: r.type ? String(r.type) : 'unknown',
           canonicalName: r.canonicalName ? String(r.canonicalName) : '',
-          externalRefs: (r.externalRefs ?? {}) as Record<string, string>,
+          externalRefs: r.externalRefs ?? {},
           createdAt: toIso(r.createdAt),
         }),
       );
 
       const forgottenEntities: ForgottenRef[] = forgottenClipped.map(
-        (r: any) => ({
+        (r) => ({
         entityIdHash: String(r.entityIdHash),
         reason: String(r.reason),
         requestId: r.requestId ? String(r.requestId) : undefined,
@@ -269,6 +274,38 @@ const FACT_FIELDS =
  * — callers narrow the window to page through.
  */
 const SECTION_CAP = 500;
+
+// --- Local DB row shapes: only the columns each SELECT actually reads.
+// Values funnelled through String()/toIso()/typeof are `unknown`; fact
+// rows extend PolicyFilterableRow so they drop into rowFilter.filter().
+
+interface FactRow extends PolicyFilterableRow {
+  id: unknown;
+  entityId: unknown;
+  object: unknown;
+  confidence: unknown;
+  validFrom: unknown;
+  validUntil?: unknown;
+  recordedAt: unknown;
+  retractedAt?: unknown;
+  /** Present only on the retracted-bucket SELECT (`, supersededBy`). */
+  supersededBy?: unknown;
+}
+
+interface NewEntityRow {
+  id: unknown;
+  type?: unknown;
+  canonicalName?: unknown;
+  externalRefs?: Record<string, string>;
+  createdAt: unknown;
+}
+
+interface ForgottenRowDb {
+  entityIdHash: unknown;
+  reason: unknown;
+  requestId?: unknown;
+  forgottenAt: unknown;
+}
 
 interface ScopingClauses {
   factClause: string;
@@ -312,7 +349,7 @@ function buildScoping(args: MemoryDiffArgs): ScopingClauses {
   };
 }
 
-function rowToFactRef(r: any): FactRef {
+function rowToFactRef(r: FactRow): FactRef {
   return {
     factId: String(r.id),
     entityId: String(r.entityId),

--- a/src/documents/candidate-merge.ts
+++ b/src/documents/candidate-merge.ts
@@ -218,7 +218,7 @@ function foldFactIntoGroup(p: {
     candidateId: row.id,
     indexerId: String(payload.indexerId ?? 'core'),
     packVersion: String(payload.packVersion ?? '0'),
-    model: payload.model ?? null,
+    model: typeof payload.model === 'string' ? payload.model : null,
     confidence: row.confidence,
     chunkSeq: row.chunkSeq,
   };
@@ -226,11 +226,14 @@ function foldFactIntoGroup(p: {
   if (!group) {
     p.factGroups.set(p.groupKey, {
       entityKey: p.entityKey,
-      predicate: payload.predicate,
-      object: payload.object,
+      // predicate/object are guaranteed strings by the guard in mergeFacts
+      // before this fold runs; String() is an identity coercion that keeps
+      // the assignment typed without an `any` payload.
+      predicate: String(payload.predicate),
+      object: String(payload.object),
       confidence: row.confidence,
       entropy: numOrUndefined(payload.extractionEntropy),
-      clause: payload.clause,
+      clause: typeof payload.clause === 'string' ? payload.clause : undefined,
       recorder: contributor.indexerId,
       leaderId: row.id,
       leaderChunkSeq: row.chunkSeq,
@@ -248,7 +251,9 @@ function foldFactIntoGroup(p: {
     group.confidence = row.confidence;
     group.recorder = contributor.indexerId;
     group.entropy = numOrUndefined(payload.extractionEntropy);
-    group.clause = payload.clause ?? group.clause;
+    group.clause =
+      (typeof payload.clause === 'string' ? payload.clause : undefined) ??
+      group.clause;
   } else {
     group.mergedIds.push(row.id);
   }

--- a/src/documents/candidate-store.service.ts
+++ b/src/documents/candidate-store.service.ts
@@ -4,6 +4,8 @@ import {
   SurrealService,
   dbCreate,
   isUniqueViolation,
+  queryFirst,
+  queryRows,
 } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { idTailOf } from '../ingest/ingest-utils';
@@ -20,7 +22,53 @@ export interface CandidateRow {
   status: string;
   statusReason?: string;
   commitRef?: string;
-  payload: Record<string, any>;
+  // A heterogeneous JSON blob whose shape differs by `kind`
+  // (entity / fact / relation). Each consumer narrows the fields it
+  // reads (candidate-merge.ts guards predicate/object as strings; the
+  // redaction path spreads it as a record) — `unknown` values keep those
+  // reads honest without an `any` escape hatch.
+  payload: Record<string, unknown>;
+}
+
+/** count()…GROUP ALL projection — `c` is the group count. */
+interface CountRow {
+  c?: number;
+}
+
+/**
+ * indexer_run row across the reopen/list/claim reads. Every field is a raw
+ * DB value funneled through String()/Number()/new Date(), so `unknown` +
+ * per-site coercion is the honest shape; individual SELECTs project a
+ * subset of these columns.
+ */
+interface RunLedgerRow {
+  id: unknown;
+  docId?: unknown;
+  packId?: unknown;
+  packVersion?: unknown;
+  status?: unknown;
+  external?: unknown;
+  claimToken?: unknown;
+  createdAt?: unknown;
+}
+
+/** candidate → parent-document status probe (findDocsNeedingCommit). */
+interface DocCommitRow {
+  docId?: unknown;
+  docStatus?: unknown;
+}
+
+/** A candidate row as `SELECT *` returns it, before coercion to CandidateRow. */
+interface CandidateDbRow {
+  id: unknown;
+  runId?: unknown;
+  chunkSeq?: unknown;
+  kind: CandidateKind;
+  confidence?: unknown;
+  status?: unknown;
+  statusReason?: unknown;
+  commitRef?: unknown;
+  payload?: Record<string, unknown>;
 }
 
 export interface RunHandle {
@@ -99,13 +147,13 @@ export class CandidateStoreService {
         return { runId: String(row.id), created: true };
       } catch (err) {
         if (!isUniqueViolation(err)) throw err;
-        const [rows] = await db.query<[any[]]>(
+        const existing = await queryFirst<RunLedgerRow>(
+          db,
           `SELECT id, status, createdAt FROM indexer_run
            WHERE docId = type::record('source_document', $doc)
              AND packId = $pack AND packVersion = $ver LIMIT 1`,
           { doc: idTailOf(p.docId), pack: p.packId, ver: p.packVersion },
         );
-        const existing = ((rows as any[]) ?? [])[0];
         if (!existing) throw err;
         const status = String(existing.status);
         const runId = String(existing.id);
@@ -123,7 +171,9 @@ export class CandidateStoreService {
           // fields clear with NONE (never NULL — 0049 is SCHEMAFULL).
           // Two statements → two result slots; the CAS verdict is the
           // UPDATE's (slot 1), not the DELETE's (slot 0).
-          const res = await db.query<[any[], any[]]>(
+          // Two statements → two result slots. The DELETE's rows (slot 0)
+          // are unread; the CAS verdict is the UPDATE's RETURN AFTER (slot 1).
+          const res = await db.query<[unknown[], unknown[]]>(
             `DELETE candidate WHERE runId = type::record('indexer_run', $run);
              UPDATE type::record('indexer_run', $run) SET
                status = 'running', createdAt = time::now(),
@@ -132,7 +182,7 @@ export class CandidateStoreService {
              RETURN AFTER`,
             { run: idTailOf(runId), observed: status },
           );
-          const swapped = (res[1] as any[]) ?? [];
+          const swapped = res[1] ?? [];
           if (swapped.length === 0) {
             // Lost the race — another job reopened it and is extracting.
             return { runId, created: false };
@@ -219,13 +269,13 @@ export class CandidateStoreService {
     const releaseWhere = `external = true AND status = 'running'
              AND createdAt < time::now() - duration::from_millis($ms)`;
     return this.surreal.withCompany(companyId, async (db) => {
-      const [failRows, releaseRows] = await db.query<[any[], any[]]>(
+      const [failRows, releaseRows] = await db.query<[CountRow[], CountRow[]]>(
         `SELECT count() AS c FROM indexer_run WHERE ${failWhere} GROUP ALL;
          SELECT count() AS c FROM indexer_run WHERE ${releaseWhere} GROUP ALL`,
         { ms: staleRunMs(), extMs: externalPendingTtlMs() },
       );
-      const failed = Number(((failRows as any[]) ?? [])[0]?.c ?? 0);
-      const released = Number(((releaseRows as any[]) ?? [])[0]?.c ?? 0);
+      const failed = Number(failRows?.[0]?.c ?? 0);
+      const released = Number(releaseRows?.[0]?.c ?? 0);
       if (failed > 0) {
         await db.query(
           `UPDATE indexer_run SET
@@ -274,13 +324,14 @@ export class CandidateStoreService {
     return this.surreal.withCompany(companyId, async (db) => {
       // Record-link traversal (docId.status) fetches the parent document's
       // status; dedup + cap happen in TS to avoid a GROUP-BY-VALUE idiom.
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<DocCommitRow>(
+        db,
         `SELECT docId, docId.status AS docStatus FROM candidate
            WHERE status = 'pending' LIMIT 5000`,
       );
       const seen = new Set<string>();
       const out: string[] = [];
-      for (const r of ((rows as any[]) ?? []) as any[]) {
+      for (const r of rows) {
         const docStatus = String(r.docStatus ?? '');
         // 'purged' facts have no source text left to commit against;
         // everything else with pending candidates is a lost commit —
@@ -423,13 +474,14 @@ export class CandidateStoreService {
     return this.surreal.withCompany(companyId, async (db) => {
       // SurrealDB 3.x: the ORDER BY field must be in the projection
       // ("Missing order idiom" otherwise) — createdAt rides along.
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<RunLedgerRow>(
+        db,
         `SELECT id, packId, packVersion, status, createdAt FROM indexer_run
          WHERE docId = type::record('source_document', $doc)
          ORDER BY createdAt ASC`,
         { doc: idTailOf(docId) },
       );
-      return (((rows as any[]) ?? []) as any[]).map((r) => ({
+      return rows.map((r) => ({
         runId: String(r.id),
         packId: String(r.packId),
         packVersion: String(r.packVersion),
@@ -442,13 +494,13 @@ export class CandidateStoreService {
   async getRun(companyId: string, runId: string): Promise<RunRow | null> {
     return this.surreal.withCompany(companyId, async (db) => {
       // Point-read by record id (no table scan under SSI — the #169 idiom).
-      const [rows] = await db.query<[any[]]>(
+      const r = await queryFirst<RunLedgerRow>(
+        db,
         `SELECT id, docId, packId, packVersion, status, external,
                 claimToken, createdAt
            FROM type::record('indexer_run', $run)`,
         { run: idTailOf(runId) },
       );
-      const r = ((rows as any[]) ?? [])[0];
       if (!r) return null;
       return {
         runId: String(r.id),
@@ -486,7 +538,8 @@ export class CandidateStoreService {
    */
   async countNonTerminalRuns(companyId: string, docId: string): Promise<number> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const row = await queryFirst<CountRow>(
+        db,
         `SELECT count() AS c FROM indexer_run
          WHERE docId = type::record('source_document', $doc)
            AND status IN ['pending', 'running']
@@ -494,7 +547,6 @@ export class CandidateStoreService {
          GROUP ALL`,
         { doc: idTailOf(docId) },
       );
-      const row = ((rows as any[]) ?? [])[0];
       return row ? Number(row.c) : 0;
     });
   }
@@ -554,14 +606,15 @@ export class CandidateStoreService {
     db: Surreal,
     p: { docId: string; onlyPending: boolean },
   ): Promise<CandidateRow[]> {
-    const [rows] = await db.query<[any[]]>(
+    const rows = await queryRows<CandidateDbRow>(
+      db,
       `SELECT * FROM candidate
        WHERE docId = type::record('source_document', $doc)
          ${p.onlyPending ? `AND status = 'pending'` : ''}
        ORDER BY chunkSeq ASC, createdAt ASC`,
       { doc: idTailOf(p.docId) },
     );
-    return (((rows as any[]) ?? []) as any[]).map((r) => ({
+    return rows.map((r) => ({
       id: String(r.id),
       runId: String(r.runId),
       chunkSeq: Number(r.chunkSeq),

--- a/src/documents/candidate-sweeper.service.ts
+++ b/src/documents/candidate-sweeper.service.ts
@@ -1,12 +1,17 @@
 import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryFirst, queryRows } from '../db/surreal.service';
 import { ApiKeyService } from '../auth/api-key.service';
 import { JobClaimService } from '../jobs/job-claim.service';
 import { WorkerLoopService, JobContext } from '../jobs/worker-loop.service';
 import { CandidateStoreService } from './candidate-store.service';
 import { markFactsProvenancePurged } from './document-store.service';
 import { idTailOf as idTail } from '../ingest/ingest-utils';
+
+/** count()…GROUP ALL projection — `c` is the group count. */
+interface CountRow {
+  c?: number;
+}
 
 /**
  * Nightly hygiene for the Candidates layer — SurrealDB has no row TTL,
@@ -101,12 +106,15 @@ export class CandidateSweeperService implements OnModuleInit {
       });
       // Document retention leg: expired retainUntil → chunks go, header +
       // contentHash stay (idempotency + committed provenance survive).
-      const [purgedDocs] = await db.query<[any[]]>(
+      // SELECT VALUE id → a flat array of record ids; String() normalizes
+      // each (RecordId or bare string) to its 'source_document:<tail>' form.
+      const purgedDocs = await queryRows<unknown>(
+        db,
         `SELECT VALUE id FROM source_document
          WHERE retainUntil != NONE AND retainUntil < time::now()
            AND status != 'purged'`,
       );
-      const purgeIds = ((purgedDocs as any[]) ?? []).map(String);
+      const purgeIds = purgedDocs.map(String);
       let factsFlagged = 0;
       for (const docId of purgeIds) {
         const tail = docId.slice(docId.indexOf(':') + 1);
@@ -174,11 +182,12 @@ export class CandidateSweeperService implements OnModuleInit {
       params: Record<string, unknown>;
     },
   ): Promise<number> {
-    const [rows] = await db.query<[any[]]>(
+    const row = await queryFirst<CountRow>(
+      db,
       `SELECT count() AS c FROM candidate WHERE ${p.countWhere} GROUP ALL`,
       p.params,
     );
-    const count = ((rows as any[]) ?? [])[0]?.c ?? 0;
+    const count = row?.c ?? 0;
     if (count > 0) {
       await db.query(p.mutation, p.params);
     }

--- a/src/documents/document-store.service.ts
+++ b/src/documents/document-store.service.ts
@@ -10,6 +10,8 @@ import {
   SurrealService,
   dbCreate,
   isUniqueViolation,
+  queryFirst,
+  queryRows,
 } from '../db/surreal.service';
 import { envFlagEnabled } from '../common/env-validation';
 import { sanitizeIngestText } from '../common/text-sanitizer';
@@ -159,11 +161,11 @@ export class DocumentStoreService {
 
   async getById(companyId: string, docId: string): Promise<StoredDocument | null> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const row = await queryFirst<Record<string, unknown>>(
+        db,
         `SELECT * FROM type::record('source_document', $id)`,
         { id: idTailOf(docId) },
       );
-      const row = ((rows as any[]) ?? [])[0];
       return row ? mapDoc(row) : null;
     });
   }
@@ -178,26 +180,28 @@ export class DocumentStoreService {
     p: { afterId?: string; limit: number },
   ): Promise<StoredDocument[]> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<Record<string, unknown>>(
+        db,
         `SELECT * FROM source_document
          WHERE hasContent = true AND status != 'purged'
            ${p.afterId ? `AND id > type::record('source_document', $after)` : ''}
          ORDER BY id ASC LIMIT $limit`,
         { after: p.afterId ? idTailOf(p.afterId) : undefined, limit: p.limit },
       );
-      return (((rows as any[]) ?? []) as Record<string, unknown>[]).map(mapDoc);
+      return rows.map(mapDoc);
     });
   }
 
   /** Stored chunks (empty for hasContent=false documents). */
   async getChunks(companyId: string, docId: string): Promise<DocumentChunk[]> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<DocumentChunk>(
+        db,
         `SELECT seq, text, charStart, charEnd FROM source_chunk
          WHERE docId = type::record('source_document', $id) ORDER BY seq ASC`,
         { id: idTailOf(docId) },
       );
-      return (((rows as any[]) ?? []) as DocumentChunk[]).map((r) => ({
+      return rows.map((r) => ({
         seq: r.seq,
         text: r.text,
         charStart: r.charStart,
@@ -226,11 +230,12 @@ export class DocumentStoreService {
    */
   async purgeContent(companyId: string, docId: string): Promise<boolean> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const existing = await queryFirst<{ id: unknown }>(
+        db,
         `SELECT id FROM type::record('source_document', $id)`,
         { id: idTailOf(docId) },
       );
-      if (!((rows as any[]) ?? [])[0]) return false;
+      if (!existing) return false;
       await db.query(
         `DELETE source_chunk WHERE docId = type::record('source_document', $id)`,
         { id: idTailOf(docId) },
@@ -254,11 +259,11 @@ export class DocumentStoreService {
     db: Surreal,
     contentHash: string,
   ): Promise<StoredDocument | null> {
-    const [rows] = await db.query<[any[]]>(
+    const row = await queryFirst<Record<string, unknown>>(
+      db,
       `SELECT * FROM source_document WHERE contentHash = $h LIMIT 1`,
       { h: contentHash },
     );
-    const row = ((rows as any[]) ?? [])[0];
     return row ? mapDoc(row) : null;
   }
 }

--- a/src/documents/indexer-webhook.service.ts
+++ b/src/documents/indexer-webhook.service.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'node:crypto';
 import { Injectable, Logger } from '@nestjs/common';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryFirst } from '../db/surreal.service';
 import { envFlagEnabled } from '../common/env-validation';
 
 /** Payload of the work_available push (also the HMAC-signed bytes). */
@@ -127,12 +127,13 @@ export class IndexerWebhookService {
     packId: string,
   ): Promise<string | null> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const row = await queryFirst<{ webhookSecret?: unknown }>(
+        db,
         `SELECT webhookSecret FROM domain_pack
            WHERE packId = $packId AND status = 'active' LIMIT 1`,
         { packId },
       );
-      const secret = ((rows as any[]) ?? [])[0]?.webhookSecret;
+      const secret = row?.webhookSecret;
       return secret ? String(secret) : null;
     });
   }

--- a/src/documents/indexer-work.service.ts
+++ b/src/documents/indexer-work.service.ts
@@ -5,7 +5,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 import { idTailOf } from '../ingest/ingest-utils';
 import { IndexerRouterService } from '../indexers/indexer-router.service';
 import type {
@@ -24,6 +24,16 @@ import {
 
 const DEFAULT_LIST_LIMIT = 50;
 const MAX_LIST_LIMIT = 200;
+
+/** indexer_run projection for the external work-discovery list. */
+interface WorkRow {
+  id: unknown;
+  docId?: unknown;
+  packId?: unknown;
+  packVersion?: unknown;
+  createdAt?: unknown;
+  docHasContent?: unknown;
+}
 
 /**
  * The pull side of the external-indexer seam (scope `indexer:write`):
@@ -72,7 +82,8 @@ export class IndexerWorkService {
     return this.surreal.withCompany(p.companyId, async (db) => {
       // docId.hasContent is a record-link traversal (findDocsNeedingCommit
       // precedent). ORDER BY field rides in the projection (3.x idiom).
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<WorkRow>(
+        db,
         `SELECT id, docId, packId, packVersion, createdAt,
                 docId.hasContent AS docHasContent
            FROM indexer_run
@@ -82,7 +93,7 @@ export class IndexerWorkService {
            LIMIT ${limit}`,
         { pack: p.packId },
       );
-      const work = (((rows as any[]) ?? []) as any[])
+      const work = rows
         // An uninstalled pack's leftover rows are not servable work.
         .filter((r) => externalPacks.has(String(r.packId)))
         .map((r) => ({
@@ -115,7 +126,8 @@ export class IndexerWorkService {
       // window (an abandoned claim whose lease expired). A live 'running'
       // claim loses. createdAt doubles as the lease clock, exactly like
       // createRun's reopen.
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<unknown>(
+        db,
         `UPDATE type::record('indexer_run', $run) SET
            status = 'running', claimToken = $tok,
            claimedAt = time::now(), createdAt = time::now(),
@@ -127,7 +139,7 @@ export class IndexerWorkService {
          RETURN AFTER`,
         { run: idTailOf(p.runId), tok: token, staleMs: staleRunMs() },
       );
-      return (((rows as any[]) ?? []) as any[])[0] ?? null;
+      return rows[0] ?? null;
     });
     if (!claimed) {
       throw new ConflictException(
@@ -150,13 +162,14 @@ export class IndexerWorkService {
     claimToken: string;
   }): Promise<HeartbeatWorkResponse> {
     const renewed = await this.surreal.withCompany(p.companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<unknown>(
+        db,
         `UPDATE type::record('indexer_run', $run) SET createdAt = time::now()
          WHERE external = true AND status = 'running' AND claimToken = $tok
          RETURN AFTER`,
         { run: idTailOf(p.runId), tok: p.claimToken },
       );
-      return (((rows as any[]) ?? []) as any[])[0] ?? null;
+      return rows[0] ?? null;
     });
     if (!renewed) {
       throw new ConflictException('claim lost: token mismatch or run not running');
@@ -214,7 +227,8 @@ export class IndexerWorkService {
       : `status = 'pending', claimToken = NONE, claimedAt = NONE,
          createdAt = time::now(), error = { message: $msg }`;
     const updated = await this.surreal.withCompany(p.companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<unknown>(
+        db,
         `UPDATE type::record('indexer_run', $run) SET ${set}
          WHERE external = true AND status = 'running' AND claimToken = $tok
          RETURN AFTER`,
@@ -224,7 +238,7 @@ export class IndexerWorkService {
           msg: p.error?.slice(0, 500) ?? 'released_by_indexer',
         },
       );
-      return (((rows as any[]) ?? []) as any[])[0] ?? null;
+      return rows[0] ?? null;
     });
     if (!updated) {
       throw new ConflictException('claim lost: token mismatch or run not running');

--- a/src/documents/pack-seed-ingest.service.ts
+++ b/src/documents/pack-seed-ingest.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryFirst } from '../db/surreal.service';
 import { JobClaimService } from '../jobs/job-claim.service';
 import { WorkerLoopService, JobContext } from '../jobs/worker-loop.service';
 import type { DomainPackManifest, PackSeedDocument } from '../ai/domain-packs';
@@ -119,15 +119,13 @@ export class PackSeedIngestService implements OnModuleInit {
     companyId: string,
     p: { packId: string; packVersion: string },
   ): Promise<PackSeedDocument[] | null> {
-    const row = await this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+    const row = await this.surreal.withCompany(companyId, (db) =>
+      queryFirst<{ version: unknown; manifest?: DomainPackManifest }>(
+        db,
         `SELECT version, manifest FROM domain_pack WHERE packId = $packId AND status = 'active' LIMIT 1`,
         { packId: p.packId },
-      );
-      return ((rows as any[]) ?? [])[0] as
-        | { version: unknown; manifest?: DomainPackManifest }
-        | undefined;
-    });
+      ),
+    );
     if (!row) {
       this.logger.log(
         `pack_seed_ingest skipped — pack ${p.packId} is not installed for ${companyId}`,

--- a/src/dreams/dreams.service.ts
+++ b/src/dreams/dreams.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
+import type { Surreal } from 'surrealdb';
 import { ApiKeyService } from '../auth/api-key.service';
 import { SurrealService } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
@@ -439,7 +440,7 @@ export class DreamsService implements OnModuleInit {
    *  under one tenant connection. Each leg is gated on the requested op set and
    *  writes progress to the job row. Extracted from runForTenantInner. */
   private async runGraphLegs(args: {
-    db: any;
+    db: Surreal;
     companyId: string;
     opSet: Set<DreamsOperation>;
     stats: DreamsTenantStats;
@@ -591,7 +592,7 @@ export class DreamsService implements OnModuleInit {
    * job_run.result are the source of truth.
    */
   private async writeEmits(
-    db: any,
+    db: Surreal,
     runId: string,
     stats: DreamsTenantStats,
   ): Promise<void> {

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException, Optional } from '@nestjs/common';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows, queryFirst } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { ForgetEntityDto } from './dto/forget.dto';
@@ -10,7 +10,7 @@ import {
   blockedPredicates,
   activeFactWhere,
 } from './entity-read.helpers';
-import { makeRowPolicyFilter } from '../policy/row-filter';
+import { makeRowPolicyFilter, PolicyFilterableRow } from '../policy/row-filter';
 
 // Centralised SELECT-clause field lists. Adding a new field to a table
 // touches one place here, not every read site. The strings below are
@@ -138,6 +138,99 @@ const AUTOCOMPLETE_MIN_CHARS = 2;
 const AUTOCOMPLETE_DEFAULT_LIMIT = 10;
 const AUTOCOMPLETE_MAX_LIMIT = 25;
 
+// --- Local DB row shapes: only the columns each SELECT actually returns.
+// Date-typed columns are `string | Date` (the JS SDK hands back a Date for
+// native datetime, a string for ISO literals) so they funnel through
+// `new Date(...)`; opaque passthrough columns are `unknown`. Fact rows
+// extend PolicyFilterableRow so they drop straight into rowPolicy.filter().
+
+interface EntityProfileRow {
+  id: unknown;
+  type: string;
+  canonicalName: string;
+  externalRefs?: Record<string, string>;
+  mergedAt?: string | Date;
+  mergedInto?: unknown;
+}
+
+interface FactProfileRow extends PolicyFilterableRow {
+  id: unknown;
+  object: string;
+  confidence: number;
+  validFrom: string | Date;
+  validUntil?: string | Date;
+  status: string;
+}
+
+interface FactTimelineRow extends PolicyFilterableRow {
+  id: unknown;
+  object: string;
+  confidence: number;
+  recordedAt: string | Date;
+  retractedAt?: string | Date | null;
+  retractedBy?: unknown;
+  retractionReason?: unknown;
+  supersededBy?: unknown;
+}
+
+interface EdgeEntityProjection {
+  id: unknown;
+  type: string;
+  canonicalName: string;
+}
+
+interface EdgeRow {
+  id: unknown;
+  in: unknown;
+  out: unknown;
+  kind: string;
+  weight: number;
+  source: unknown;
+  createdAt: string | Date;
+  invalidatedAt?: unknown;
+  toEntity?: EdgeEntityProjection | null;
+  fromEntity?: EdgeEntityProjection | null;
+}
+
+export interface TimelineRecordedEvent {
+  type: 'fact.recorded';
+  at: string;
+  factId: string;
+  predicate: string;
+  object: string;
+  source: unknown;
+  confidence: number;
+}
+
+export interface TimelineRetractedEvent {
+  type: 'fact.retracted';
+  at: string;
+  factId: string;
+  retractedBy: unknown;
+  reason: unknown;
+  supersededBy?: string;
+}
+
+export type TimelineEvent = TimelineRecordedEvent | TimelineRetractedEvent;
+
+export interface ConnectionNeighbour {
+  id: string;
+  type: string;
+  canonicalName: string;
+}
+
+export interface ConnectionEdge {
+  edgeId: string;
+  from: string;
+  to: string;
+  kind: string;
+  weight: number;
+  source: unknown;
+  createdAt: string;
+  neighbour?: ConnectionNeighbour;
+  direction: 'outbound' | 'inbound';
+}
+
 @Injectable()
 export class EntitiesService {
   // Fourth dep is the tenant predicate registry — the row fence must see
@@ -163,12 +256,12 @@ export class EntitiesService {
     const txAt = recordedAtRaw ? new Date(recordedAtRaw) : null;
 
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
-      const [entRows] = await db.query<any[][]>(
+      const entity = await queryFirst<EntityProfileRow>(
+        db,
         `SELECT ${ENTITY_PROFILE_FIELDS}
          FROM type::record('knowledge_entity', $rid) LIMIT 1`,
         { rid: ref.id },
       );
-      const entity = (entRows as any[])?.[0];
       if (!entity) {
         throw new NotFoundException(`Entity ${entityIdRaw} not found`);
       }
@@ -191,7 +284,8 @@ export class EntitiesService {
         ...asOfClauses,
       ];
       const params: Record<string, unknown> = { rid: ref.id, ...asOfParams };
-      const [factRows] = await db.query<any[][]>(
+      const factRows = await queryRows<FactProfileRow>(
+        db,
         `SELECT ${FACT_PROFILE_FIELDS}
          FROM knowledge_fact
          WHERE ${baseClauses.join(' AND ')}
@@ -205,9 +299,7 @@ export class EntitiesService {
         surface: 'entity_profile',
         policyLookup: await this.predicateRegistry?.rowPolicyLookup(companyId),
       });
-      const facts = ((factRows as any[]) ?? []).filter((f) =>
-        rowPolicy.filter(f),
-      );
+      const facts = factRows.filter((f) => rowPolicy.filter(f));
       rowPolicy.finish();
 
       return {
@@ -261,12 +353,12 @@ export class EntitiesService {
       companyId,
       scopes,
       async (db) => {
-        const [rows] = await db.query<[any[]]>(
+        const rows = await queryRows<unknown>(
+          db,
           `SELECT VALUE entity FROM entity_external_ref WHERE key = $key LIMIT 1`,
           { key },
         );
-        const arr = (rows as any[]) ?? [];
-        return arr[0] ? String(arr[0]) : null;
+        return rows[0] ? String(rows[0]) : null;
       },
     );
     if (!entityId) return null;
@@ -320,7 +412,9 @@ export class EntitiesService {
       // check stays a single network hop. Avoids math::max aggregation,
       // which returns NONE over datetimes on this SurrealDB build.
       const where = baseClauses.join(' AND ');
-      const [recRows, valRows] = await db.query<[any[], any[]]>(
+      const [recRows, valRows] = await db.query<
+        [Array<{ recordedAt: unknown }>, Array<{ validFrom: unknown }>]
+      >(
         `SELECT recordedAt FROM knowledge_fact WHERE ${where}
            ORDER BY recordedAt DESC LIMIT 1;
          SELECT validFrom FROM knowledge_fact WHERE ${where}
@@ -334,8 +428,8 @@ export class EntitiesService {
             ? v.toISOString()
             : new Date(String(v)).toISOString();
       return {
-        maxRecordedAt: toIso((recRows as any[])?.[0]?.recordedAt),
-        maxValidFrom: toIso((valRows as any[])?.[0]?.validFrom),
+        maxRecordedAt: toIso(recRows[0]?.recordedAt),
+        maxValidFrom: toIso(valRows[0]?.validFrom),
       };
     });
   }
@@ -347,7 +441,7 @@ export class EntitiesService {
     untilRaw,
     recordedAtRaw,
     scopes,
-  }: GetTimelineOptions): Promise<{ entityId: string; events: any[] }> {
+  }: GetTimelineOptions): Promise<{ entityId: string; events: TimelineEvent[] }> {
     const ref = normalizeEntityId(entityIdRaw);
     const since = sinceRaw ? new Date(sinceRaw) : null;
     const until = untilRaw ? new Date(untilRaw) : null;
@@ -371,7 +465,8 @@ export class EntitiesService {
       // a long-lived entity ships its entire history per request. Callers
       // page with since/until (the window params above); 1000 rows is
       // ~an order of magnitude beyond what any UI renders at once.
-      const [factRows] = await db.query<any[][]>(
+      const factRows = await queryRows<FactTimelineRow>(
+        db,
         `SELECT ${FACT_TIMELINE_FIELDS}
          FROM knowledge_fact
          WHERE ${clauses.join(' AND ')}
@@ -384,12 +479,10 @@ export class EntitiesService {
         surface: 'entity_timeline',
         policyLookup: await this.predicateRegistry?.rowPolicyLookup(companyId),
       });
-      const rows = ((factRows as any[]) ?? []).filter((f) =>
-        rowPolicy.filter(f),
-      );
+      const rows = factRows.filter((f) => rowPolicy.filter(f));
       rowPolicy.finish();
 
-      const events: any[] = [];
+      const events: TimelineEvent[] = [];
       for (const f of rows) {
         events.push({
           type: 'fact.recorded',
@@ -426,7 +519,7 @@ export class EntitiesService {
     kind,
     scopes = [],
     asOf,
-  }: GetConnectionsOptions): Promise<{ entityId: string; edges: any[] }> {
+  }: GetConnectionsOptions): Promise<{ entityId: string; edges: ConnectionEdge[] }> {
     const ref = normalizeEntityId(entityIdRaw);
 
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
@@ -461,14 +554,12 @@ export class EntitiesService {
         FROM type::record('knowledge_entity', $rid)<-knowledge_edge
         WHERE 1=1${asOfParam}${kindParam}
       `;
-      const [outRowsResult, inRowsResult] = await Promise.all([
-        db.query<any[][]>(outSql, { rid: ref.id, kind, asOf }),
-        db.query<any[][]>(inSql, { rid: ref.id, kind, asOf }),
+      const [outRows, inRows] = await Promise.all([
+        queryRows<EdgeRow>(db, outSql, { rid: ref.id, kind, asOf }),
+        queryRows<EdgeRow>(db, inSql, { rid: ref.id, kind, asOf }),
       ]);
-      const outRows = ((outRowsResult[0] as any[]) ?? []) as any[];
-      const inRows = ((inRowsResult[0] as any[]) ?? []) as any[];
-      const edges = [
-        ...outRows.map((e: any) => ({
+      const edges: ConnectionEdge[] = [
+        ...outRows.map((e) => ({
           edgeId: String(e.id),
           from: String(e.in),
           to: String(e.out),
@@ -485,7 +576,7 @@ export class EntitiesService {
             : undefined,
           direction: 'outbound' as const,
         })),
-        ...inRows.map((e: any) => ({
+        ...inRows.map((e) => ({
           edgeId: String(e.id),
           from: String(e.in),
           to: String(e.out),

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, NotFoundException, Optional } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config';
 import { createHmac } from 'node:crypto';
 import { StringRecordId } from 'surrealdb';
-import { SurrealService, dbCreate } from '../db/surreal.service';
+import { SurrealService, dbCreate, queryRows, queryFirst } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { normalizeEntityId } from './entity-read.helpers';
 import { ForgetOptions, ForgetResult } from './entities.service';
@@ -45,11 +45,11 @@ export class EntityForgetService {
 
     const result = await this.surreal.withCompany(companyId, async (db) => {
       // Verify exists
-      const [entRows] = await db.query<any[][]>(
+      const entity = await queryFirst<{ id: unknown }>(
+        db,
         `SELECT id FROM type::record('knowledge_entity', $rid) LIMIT 1`,
         { rid: ref.id },
       );
-      const entity = (entRows as any[])?.[0];
       if (!entity) {
         throw new NotFoundException(`Entity ${entityIdRaw} not found`);
       }
@@ -65,18 +65,20 @@ export class EntityForgetService {
       // post-image in `audit_event.after`, including PII fact `object`
       // values. Without this, a GDPR-erased subject stayed fully
       // reconstructable from audit_event indefinitely.
-      const [factIdRows] = await db.query<any[][]>(
+      const factIdRows = await queryRows<{ id: unknown }>(
+        db,
         `SELECT id FROM knowledge_fact
          WHERE entityId = type::record('knowledge_entity', $rid)`,
         { rid: ref.id },
       );
-      const [edgeIdRows] = await db.query<any[][]>(
+      const edgeIdRows = await queryRows<{ id: unknown }>(
+        db,
         `SELECT id FROM knowledge_edge
          WHERE in = type::record('knowledge_entity', $rid) OR out = type::record('knowledge_entity', $rid)`,
         { rid: ref.id },
       );
-      const factIds = ((factIdRows as any[]) ?? []).map((r) => String(r.id));
-      const edgeIds = ((edgeIdRows as any[]) ?? []).map((r) => String(r.id));
+      const factIds = factIdRows.map((r) => String(r.id));
+      const edgeIds = edgeIdRows.map((r) => String(r.id));
       const factsDeleted = factIds.length;
       const edgesDeleted = edgeIds.length;
 
@@ -89,7 +91,8 @@ export class EntityForgetService {
       // A turn that grounds facts of several subjects is deleted whole: the
       // other subjects keep their derived facts (separate rows), they lose
       // only the raw turn. Erasure wins over retention.
-      const [groundingRows] = await db.query<any[][]>(
+      const groundingRows = await queryRows<{ eps: unknown }>(
+        db,
         `SELECT source.episodeIds AS eps FROM knowledge_fact
          WHERE entityId = type::record('knowledge_entity', $rid)
            AND source.episodeIds IS NOT NONE`,
@@ -97,7 +100,7 @@ export class EntityForgetService {
       );
       const episodeIds = [
         ...new Set(
-          ((groundingRows as any[]) ?? []).flatMap((r) =>
+          groundingRows.flatMap((r) =>
             Array.isArray(r.eps) ? r.eps.map((e: unknown) => String(e)) : [],
           ),
         ),
@@ -108,16 +111,18 @@ export class EntityForgetService {
         const refs = episodeIds.map((id) => new StringRecordId(id));
         // Segments are a rebuildable projection over the same turns — a
         // segment that quotes an erased episode must go with it.
-        const [segRows] = await db.query<any[][]>(
+        const segRows = await queryRows<unknown>(
+          db,
           `DELETE episode_segment WHERE episodeIds CONTAINSANY $eps RETURN BEFORE`,
           { eps: refs },
         );
-        segmentsDeleted = ((segRows as any[]) ?? []).length;
-        const [epRows] = await db.query<any[][]>(
+        segmentsDeleted = segRows.length;
+        const epRows = await queryRows<unknown>(
+          db,
           `DELETE episode WHERE id INSIDE $eps RETURN BEFORE`,
           { eps: refs },
         );
-        episodesDeleted = ((epRows as any[]) ?? []).length;
+        episodesDeleted = epRows.length;
       }
 
       // Cascade hard-delete. Embedding columns die with the rows.
@@ -161,11 +166,12 @@ export class EntityForgetService {
       // changefeed-consumer redactAfterImage) so re-mirrored rows carry
       // no raw PII; this purge removes the already-materialised rows.
       const recordIds = [entityIdStr, ...factIds, ...edgeIds];
-      const [auditDeleted] = await db.query<any[][]>(
+      const auditDeleted = await queryRows<unknown>(
+        db,
         `DELETE audit_event WHERE recordId IN $ids RETURN BEFORE`,
         { ids: recordIds },
       );
-      const auditEventsDeleted = ((auditDeleted as any[]) ?? []).length;
+      const auditEventsDeleted = auditDeleted.length;
 
       // dream_emit: subject/object hold the entity/fact ids the dreams
       // resolver linked or superseded — purge any referencing the

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -1,6 +1,6 @@
 import { ForbiddenException, Injectable, Logger, NotFoundException, Optional } from '@nestjs/common';
 import { Surreal } from 'surrealdb';
-import { SurrealService, dbMerge } from '../db/surreal.service';
+import { SurrealService, dbMerge, queryFirst, queryRows } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { EpisodeReadStoreService } from '../episodes/episode-read-store.service';
@@ -209,6 +209,34 @@ export interface ListCompetingResult {
    * still unretracted at `asOf` (or now if asOf is omitted).
    */
   groups: CompetingFactGroup[];
+}
+
+/**
+ * Columns retract() selects to run its authorization + revive logic.
+ * Superset of PolicyFilterableRow so the registry row-policy gate can
+ * filter it; datetime fields feed `new Date(...)`, hence string | Date.
+ */
+interface RetractExistingRow extends PolicyFilterableRow {
+  status?: unknown;
+  retractedAt?: string | Date;
+  validFrom?: string | Date;
+  validUntil?: string | Date;
+}
+
+/**
+ * Columns the competing / by-predicate fact reads select. Superset of
+ * PolicyFilterableRow so the row-policy filter and the response mapper
+ * share one row type; every value the mapper consumes funnels through
+ * String()/toIso()/typeof, so `unknown` is precise enough.
+ */
+interface CompetingReadRow extends PolicyFilterableRow {
+  entityId?: unknown;
+  object?: unknown;
+  confidence?: unknown;
+  validFrom?: unknown;
+  validUntil?: unknown;
+  recordedAt?: unknown;
+  status?: unknown;
 }
 
 @Injectable()
@@ -425,13 +453,13 @@ export class FactsService {
       // Verify the fact exists and is currently active. SELECT extra
       // predicate + source so the admin-scope gate below can read them,
       // and userId for the ownership fence.
-      const [existingRows] = await db.query<any[][]>(
+      const existing = await queryFirst<RetractExistingRow>(
+        db,
         `SELECT id, status, retractedAt, validFrom, predicate, source,
                 userId
            FROM type::record('knowledge_fact', $rid) LIMIT 1`,
         { rid: ref.id },
       );
-      const existing = (existingRows as any[])?.[0];
       if (!existing) {
         throw new NotFoundException(`Fact ${factId} not found`);
       }
@@ -567,7 +595,8 @@ export class FactsService {
     // on). Explicit `= NONE` — MERGE with JSON null does not unset an
     // option<datetime> field. With fact_superseded_by_idx (0059) the
     // WHERE is an index probe, not a table scan.
-    const [rows] = await db.query<any[][]>(
+    const rows = await queryRows<{ id: unknown }>(
+      db,
       `UPDATE knowledge_fact SET
           status = 'active',
           retractedAt = NONE,
@@ -582,7 +611,7 @@ export class FactsService {
         RETURN id`,
       { rid },
     );
-    return (((rows as Array<{ id: unknown }>) ?? [])).map((r) => String(r.id));
+    return rows.map((r) => String(r.id));
   }
 
   /**
@@ -676,7 +705,8 @@ export class FactsService {
         clauses.push(`retractedAt IS NONE`);
       }
 
-      const [rows] = await db.query<any[][]>(
+      const rows = await queryRows<CompetingReadRow>(
+        db,
         `SELECT id, entityId, predicate, object, confidence,
                 validFrom, validUntil, recordedAt, source,
                 trustSnapshot, corroboration
@@ -695,12 +725,10 @@ export class FactsService {
         surface: 'competing_facts',
         policyLookup: await this.predicateRegistry?.rowPolicyLookup(companyId),
       });
-      const visible = (((rows as any[]) ?? []) as PolicyFilterableRow[]).filter(
-        (r) => rowPolicy.filter(r),
-      );
+      const visible = rows.filter((r) => rowPolicy.filter(r));
       rowPolicy.finish();
 
-      const records: CompetingFactRecord[] = (visible as any[]).map(
+      const records: CompetingFactRecord[] = visible.map(
         (r): CompetingFactRecord => ({
           factId: String(r.id),
           entityId: String(r.entityId),
@@ -788,7 +816,8 @@ export class FactsService {
       }
       // ×2 headroom so the scope/ABAC row fence doesn't starve the page.
       const overfetch = Math.min(limit * 2, 100);
-      const [rows] = await db.query<any[][]>(
+      const rows = await queryRows<CompetingReadRow>(
+        db,
         `SELECT id, entityId, predicate, object, confidence,
                 validFrom, validUntil, recordedAt, status,
                 source, trustSnapshot, corroboration, userId
@@ -803,11 +832,9 @@ export class FactsService {
         surface: 'pack_facts_by_predicate',
         policyLookup: await this.predicateRegistry?.rowPolicyLookup(companyId),
       });
-      const visible = (((rows as any[]) ?? []) as PolicyFilterableRow[]).filter(
-        (r) => rowPolicy.filter(r),
-      );
+      const visible = rows.filter((r) => rowPolicy.filter(r));
       rowPolicy.finish();
-      const facts = (visible as any[]).slice(0, limit).map((r) => ({
+      const facts = visible.slice(0, limit).map((r) => ({
         factId: String(r.id),
         entityId: String(r.entityId),
         predicate: String(r.predicate),

--- a/src/indexers/indexer-router.service.ts
+++ b/src/indexers/indexer-router.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { BUILTIN_PACKS } from '../ai/domain-packs';
 import type { DomainPackManifest } from '../ai/domain-packs/manifest';
@@ -129,12 +129,11 @@ export class IndexerRouterService {
   ): Promise<DomainPackManifest[]> {
     try {
       return await this.surreal.withCompany(companyId, async (db) => {
-        const [rows] = await db.query<[any[]]>(
+        const rows = await queryRows<{ manifest: DomainPackManifest }>(
+          db,
           `SELECT manifest FROM domain_pack WHERE status = 'active'`,
         );
-        return (((rows as any[]) ?? []) as Array<{ manifest: DomainPackManifest }>)
-          .map((r) => r.manifest)
-          .filter(Boolean);
+        return rows.map((r) => r.manifest).filter(Boolean);
       });
     } catch (e) {
       this.logger.warn(

--- a/src/ingest/edge-writer.ts
+++ b/src/ingest/edge-writer.ts
@@ -1,5 +1,10 @@
 import { Surreal, StringRecordId } from 'surrealdb';
-import { isUniqueViolation } from '../db/surreal.service';
+import { isUniqueViolation, queryFirst } from '../db/surreal.service';
+
+/** `knowledge_edge` row projection — only `id` is read back. */
+interface EdgeIdRow {
+  id: unknown;
+}
 
 /**
  * Create a knowledge_edge between two ALREADY-resolved entity IDs.
@@ -22,7 +27,8 @@ export async function createEdgeBetween(
   const fromRid = new StringRecordId(p.fromEntityId);
   const toRid = new StringRecordId(p.toEntityId);
   try {
-    const [edgeRows] = await db.query<[any[]]>(
+    const edge = await queryFirst<EdgeIdRow>(
+      db,
       `RELATE $from->knowledge_edge->$to CONTENT { kind: $kind, weight: $weight, source: $source } RETURN AFTER`,
       {
         from: fromRid,
@@ -32,15 +38,14 @@ export async function createEdgeBetween(
         source: p.source,
       },
     );
-    const edge = ((edgeRows as any[]) ?? [])[0];
     return edge ? String(edge.id) : null;
   } catch (err) {
     if (!isUniqueViolation(err)) throw err;
-    const [existingRows] = await db.query<[any[]]>(
+    const existing = await queryFirst<EdgeIdRow>(
+      db,
       `SELECT id FROM knowledge_edge WHERE in = $from AND out = $to AND kind = $kind LIMIT 1`,
       { from: fromRid, to: toRid, kind: p.kind },
     );
-    const existing = ((existingRows as any[]) ?? [])[0];
     return existing ? String(existing.id) : null;
   }
 }

--- a/src/ingest/entity-upsert.service.ts
+++ b/src/ingest/entity-upsert.service.ts
@@ -2,11 +2,13 @@ import { Injectable, Optional } from '@nestjs/common';
 import { Surreal } from 'surrealdb';
 import {
   dbCreate,
+  queryFirst,
+  queryRows,
   retryOnUniqueViolation,
   runTransaction,
 } from '../db/surreal.service';
 import { EntityResolverService } from './entity-resolver.service';
-import { IngestFactDto } from './dto/ingest-fact.dto';
+import { EntityRef, IngestFactDto } from './dto/ingest-fact.dto';
 import { externalRefKey } from './ingest-utils';
 import { scopeForUser } from '../auth/scope-tags';
 
@@ -96,11 +98,11 @@ export class EntityUpsertService {
   }
 
   private async lookupExternalRef(db: Surreal, key: string): Promise<string | null> {
-    const [rows] = await db.query<[any[]]>(
+    const arr = await queryRows<unknown>(
+      db,
       `SELECT VALUE entity FROM entity_external_ref WHERE key = $key LIMIT 1`,
       { key },
     );
-    const arr = (rows as any[]) ?? [];
     return arr[0] ? String(arr[0]) : null;
   }
 
@@ -142,7 +144,8 @@ export class EntityUpsertService {
     // private entity and leak its identity (externalRefs, canonicalName)
     // onto the global surface. Mirrors the scope fence on the embedding
     // resolver (entity-resolver.service.ts).
-    const [nRows] = await db.query<any[][]>(
+    const nRow = await queryFirst<{ id: unknown }>(
+      db,
       `SELECT id FROM knowledge_entity
        WHERE (canonicalNameLc = $name
           OR aliases CONTAINS $rawName)
@@ -150,7 +153,6 @@ export class EntityUpsertService {
        LIMIT 1`,
       { name: target, rawName: e.name },
     );
-    const nRow = ((nRows as any[]) ?? [])[0];
     if (nRow) return String(nRow.id);
 
     // 3. Inline entity resolution (graphiti-style, opt-in). Before minting
@@ -168,7 +170,7 @@ export class EntityUpsertService {
       if (resolved) return resolved;
     }
 
-    const created = await dbCreate<any>(db, 'knowledge_entity', {
+    const created = await dbCreate<{ id: unknown }>(db, 'knowledge_entity', {
       type: this.normalizeEntityType(e.type),
       canonicalName: e.canonical ?? e.name,
       aliases: [e.name],
@@ -179,7 +181,7 @@ export class EntityUpsertService {
 
   async resolveOrCreateBareRef(
     db: Surreal,
-    ref: { vertical: string; id: string } | { entityId: string },
+    ref: EntityRef,
   ): Promise<string> {
     if ('entityId' in ref && ref.entityId) {
       return ref.entityId.includes(':') ? ref.entityId : `knowledge_entity:${ref.entityId}`;

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { StringRecordId, Surreal } from 'surrealdb';
-import { retryOnUniqueViolation } from '../db/surreal.service';
+import { queryRows, retryOnUniqueViolation } from '../db/surreal.service';
 import { scopeForUser } from '../auth/scope-tags';
 import { MetricsService } from '../metrics/metrics.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
@@ -121,7 +121,7 @@ export class FactResolverService {
       derivedVersion?: string;
       recordOutcomeMetric?: boolean;
     },
-  ): Promise<{ result: any; semantics: string }> {
+  ): Promise<{ result: ResolveOutcome; semantics: string }> {
     // Read policy from the per-tenant registry. Pre-warm the snapshot so the
     // cache is populated before the synchronous policyFor() lookup. Defensive:
     // a registry bootstrap failure must not 500 the ingest — policyFor falls
@@ -156,7 +156,7 @@ export class FactResolverService {
   async resolveMany(
     db: Surreal,
     inputs: Parameters<FactResolverService['resolve']>[1][],
-  ): Promise<Array<{ result: any; semantics: string }>> {
+  ): Promise<Array<{ result: ResolveOutcome; semantics: string }>> {
     if (inputs.length === 0) return [];
     const firstCompanyId = inputs[0]!.companyId; // inputs non-empty (checked)
     try {
@@ -170,7 +170,7 @@ export class FactResolverService {
     const prepared = await Promise.all(
       inputs.map((p) => this.buildResolveCall(p)),
     );
-    const results: any[] = new Array(inputs.length);
+    const results: ResolveOutcome[] = new Array(inputs.length);
     const appendIdx: number[] = [];
     const restIdx: number[] = [];
     prepared.forEach((c, i) =>
@@ -184,7 +184,7 @@ export class FactResolverService {
           // appendIdx holds valid indices into `prepared` (built above).
           appendIdx.map((i) => prepared[i]!),
         );
-        appendIdx.forEach((i, k) => (results[i] = batch[k]));
+        appendIdx.forEach((i, k) => (results[i] = batch[k]!));
       } catch (e) {
         this.logger.warn(
           `ingest: batched fact resolve fell back to per-fact: ${(e as Error).message}`,
@@ -200,13 +200,14 @@ export class FactResolverService {
     }
 
     // Post-call side effects (HyPE + metric) per fact, in order.
-    const out: Array<{ result: any; semantics: string }> = [];
+    const out: Array<{ result: ResolveOutcome; semantics: string }> = [];
     for (let i = 0; i < inputs.length; i++) {
       // prepared.length === inputs.length ⇒ both indices are in-bounds.
       const input = inputs[i]!;
       const prep = prepared[i]!;
-      await this.postResolve(db, input, results[i]);
-      out.push({ result: results[i], semantics: prep.semantics });
+      const res = results[i]!;
+      await this.postResolve(db, input, res);
+      out.push({ result: res, semantics: prep.semantics });
     }
     return out;
   }
@@ -257,7 +258,7 @@ export class FactResolverService {
   private async postResolve(
     db: Surreal,
     p: Parameters<FactResolverService['resolve']>[1],
-    result: any,
+    result: ResolveOutcome,
   ): Promise<void> {
     const outcome = result?.outcome;
     if (p.recordOutcomeMetric && outcome) {
@@ -327,7 +328,7 @@ export class FactResolverService {
   private async resolveAppendOnlyBatch(
     db: Surreal,
     prepared: Parameters<FactResolverService['resolveFactCall']>[1][],
-  ): Promise<any[]> {
+  ): Promise<ResolveOutcome[]> {
     const facts = prepared.map((c) => {
       const f: Record<string, unknown> = {
         eid: idTailOf(c.entityId),
@@ -364,11 +365,11 @@ export class FactResolverService {
       reject_threshold: this.conflict.rejectThreshold,
       margin_for_supersede: this.conflict.marginForSupersede,
     };
-    const [rows] = await db.query<[any[]]>(
+    const out = await queryRows<ResolveOutcome>(
+      db,
       `RETURN fn::resolve_facts($facts, $cfg)`,
       { facts, cfg },
     );
-    const out = (rows as any[]) ?? [];
     await this.stampFactScope(
       db,
       prepared.map((c, k) => ({ userId: c.userId, factId: out[k]?.factId })),
@@ -507,7 +508,7 @@ export class FactResolverService {
       userId?: string;
       derivedVersion?: string;
     },
-  ): Promise<any> {
+  ): Promise<ResolveOutcome> {
     // Serialize resolves on the same (company, entity, predicate). Under
     // SurrealDB 3.x the OCC read-conflict that let racing single_active
     // resolves retry-and-supersede no longer fires for the function's
@@ -521,7 +522,7 @@ export class FactResolverService {
     const lockKey = `${p.companyId}\x00${p.entityId}\x00${p.predicateAlias ?? p.predicate}`;
     const r = await this.resolveLock.run(lockKey, () =>
       retryOnUniqueViolation(async () => {
-        const [row] = await db.query<[any]>(
+        const [row] = await db.query<[ResolveOutcome]>(
           `RETURN fn::resolve_fact(
             type::record('knowledge_entity', $eid),
             $predicate, $object, $object_meta, $embedding,

--- a/src/ingest/ingest-predictor.service.ts
+++ b/src/ingest/ingest-predictor.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Surreal } from 'surrealdb';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryFirst, queryRows } from '../db/surreal.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { PredictScoringService } from './predict-scoring.service';
 import {
@@ -143,7 +143,8 @@ export class IngestPredictionService {
       const tail = entityId.startsWith('knowledge_entity:')
         ? entityId.slice('knowledge_entity:'.length)
         : entityId;
-      const [rows] = await db.query<any[][]>(
+      const priors = await queryRows<PriorRow>(
+        db,
         `SELECT id, predicate, object, confidence, validFrom, validUntil,
                 recordedAt, ${isBitemporal ? 'embedding, ' : ''}source, status,
                 userId, trustSnapshot, corroboration
@@ -159,7 +160,6 @@ export class IngestPredictionService {
           ? { eid: tail, predicate: args.predicate, userId: args.userId }
           : { eid: tail, predicate: args.predicate },
       );
-      const priors = ((rows as any[]) ?? []) as PriorRow[];
 
       // The caller only sees an opposing fact it is allowed to read. The
       // priors themselves are untouched — the decision below runs on the
@@ -324,20 +324,20 @@ export class IngestPredictionService {
       const tail = ref.entityId.startsWith('knowledge_entity:')
         ? ref.entityId.slice('knowledge_entity:'.length)
         : ref.entityId;
-      const [rows] = await db.query<any[][]>(
+      const row = await queryFirst<{ id: unknown }>(
+        db,
         `SELECT id FROM type::record('knowledge_entity', $tail) LIMIT 1`,
         { tail },
       );
-      const row = (rows as any[])?.[0];
       return row ? String(row.id) : null;
     }
     const ext = ref as { vertical: string; id: string };
     const key = `${ext.vertical.replace(/\./g, '__')}__${ext.id.replace(/\./g, '__')}`;
-    const [rows] = await db.query<[any[]]>(
+    const arr = await queryRows<unknown>(
+      db,
       `SELECT VALUE entity FROM entity_external_ref WHERE key = $key LIMIT 1`,
       { key },
     );
-    const arr = (rows as any[]) ?? [];
     return arr[0] ? String(arr[0]) : null;
   }
 }

--- a/src/ingest/link-ingest.service.ts
+++ b/src/ingest/link-ingest.service.ts
@@ -3,6 +3,8 @@ import { StringRecordId } from 'surrealdb';
 import {
   SurrealService,
   isUniqueViolation,
+  queryFirst,
+  queryRows,
   retryOnUniqueViolation,
 } from '../db/surreal.service';
 import { IngestLinkDto } from './dto/ingest-link.dto';
@@ -26,8 +28,8 @@ export class LinkIngestService {
 
   async ingestLink(companyId: string, dto: IngestLinkDto) {
     return this.surreal.withCompany(companyId, async (db) => {
-      const fromId = await this.entities.resolveOrCreateBareRef(db, dto.from as any);
-      const toId = await this.entities.resolveOrCreateBareRef(db, dto.to as any);
+      const fromId = await this.entities.resolveOrCreateBareRef(db, dto.from);
+      const toId = await this.entities.resolveOrCreateBareRef(db, dto.to);
 
       // identity_of merge. The merge sets toId.mergedInto = fromId.
       // If fromId already resolves (transitively) back to toId, both ends end
@@ -96,7 +98,8 @@ export class LinkIngestService {
       const toRid = new StringRecordId(toId);
       let edgeId: string | null = null;
       try {
-        const [edgeRows] = await db.query<[any[]]>(
+        const edgeRows = await queryRows<{ id: unknown }>(
+          db,
           `RELATE $from->knowledge_edge->$to CONTENT { kind: $kind, weight: $weight, source: $source } RETURN AFTER`,
           {
             from: fromRid,
@@ -106,15 +109,15 @@ export class LinkIngestService {
             source: dto.source,
           },
         );
-        const edge = ((edgeRows as any[]) ?? [])[0];
+        const edge = edgeRows[0];
         edgeId = edge ? String(edge.id) : null;
       } catch (err) {
         if (!isUniqueViolation(err)) throw err;
-        const [existingRows] = await db.query<[any[]]>(
+        const existing = await queryFirst<{ id: unknown }>(
+          db,
           `SELECT id FROM knowledge_edge WHERE in = $from AND out = $to AND kind = $kind LIMIT 1`,
           { from: fromRid, to: toRid, kind: dto.kind },
         );
-        const existing = ((existingRows as any[]) ?? [])[0];
         edgeId = existing ? String(existing.id) : null;
         this.logger.debug(
           `[knowledge.edge.idempotent] companyId=${companyId} kind=${dto.kind} ${fromId} → ${toId} (already existed)`,

--- a/src/ingest/mention-extraction.service.ts
+++ b/src/ingest/mention-extraction.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ExtractorService } from '../ai/extractor.service';
+import { ExtractorService, type ExtractionResult } from '../ai/extractor.service';
 import { IngestMentionDto } from './dto/ingest-mention.dto';
 import { traceArtifact, traceSpan } from '../common/debug-trace';
 import { redactPii } from './ingest-utils';
@@ -18,7 +18,7 @@ export type MentionPrep =
   | { skip: 'empty' | 'no_entities' }
   | {
       skip: null;
-      extraction: any;
+      extraction: ExtractionResult;
       source: MentionSource;
       /** Per-fact embeddings aligned with extraction.facts; [] on failure. */
       factEmbeddings: number[][];

--- a/src/ingest/mention-persist.service.ts
+++ b/src/ingest/mention-persist.service.ts
@@ -8,6 +8,8 @@ import { EntityUpsertService } from './entity-upsert.service';
 import { FactResolverService } from './fact-resolver.service';
 import { createEdgeBetween } from './edge-writer';
 import { MentionSource } from './mention-extraction.service';
+import type { ExtractionResult } from '../ai/extractor.service';
+import type { ResolveOutcome } from './conflict-resolver';
 import {
   isFirstPersonSelfReference,
   isSecondPersonReference,
@@ -43,7 +45,7 @@ export class MentionPersistService {
   async persistAll(p: {
     companyId: string;
     dto: IngestMentionDto;
-    extraction: any;
+    extraction: ExtractionResult;
     source: MentionSource;
     factEmbeddings: number[][];
   }): Promise<MentionPersistResult> {
@@ -105,7 +107,7 @@ export class MentionPersistService {
 
   private async persistEntities(
     db: Surreal,
-    p: { extraction: any; dto: IngestMentionDto },
+    p: { extraction: ExtractionResult; dto: IngestMentionDto },
   ): Promise<string[]> {
     const { extraction, dto } = p;
     // Speaker/addressee anchors for coreference. The OLD code paired
@@ -119,7 +121,7 @@ export class MentionPersistService {
     const addresseeHint = dto.knownEntities?.find((k) => k.role === 'addressee');
     const entityIds: string[] = [];
     for (let i = 0; i < extraction.entities.length; i++) {
-      const e = extraction.entities[i];
+      const e = extraction.entities[i]!;
       const knownHint = this.hintFor(e, speakerHint, addresseeHint);
       // The entity's freshly-extracted facts feed the inline-resolution judge
       // (the "new" side — these aren't written yet).
@@ -148,7 +150,7 @@ export class MentionPersistService {
     p: {
       companyId: string;
       dto: IngestMentionDto;
-      extraction: any;
+      extraction: ExtractionResult;
       source: MentionSource;
       factEmbeddings: number[][];
       entityIds: string[];
@@ -163,7 +165,7 @@ export class MentionPersistService {
       return this.persistFactsBatched(db, p, eventTimeOn);
     }
     for (let i = 0; i < extraction.facts.length; i++) {
-      const f = extraction.facts[i];
+      const f = extraction.facts[i]!;
       const eid = entityIds[f.entityIndex];
       if (!eid) continue;
       const validFrom = this.factValidFrom(f, dto, eventTimeOn);
@@ -226,7 +228,7 @@ export class MentionPersistService {
     p: {
       companyId: string;
       dto: IngestMentionDto;
-      extraction: any;
+      extraction: ExtractionResult;
       source: MentionSource;
       factEmbeddings: number[][];
       entityIds: string[];
@@ -239,7 +241,7 @@ export class MentionPersistService {
       input: Parameters<FactResolverService['resolve']>[1];
     }> = [];
     for (let i = 0; i < extraction.facts.length; i++) {
-      const f = extraction.facts[i];
+      const f = extraction.facts[i]!;
       const eid = entityIds[f.entityIndex];
       if (!eid) continue;
       specs.push({
@@ -334,7 +336,7 @@ export class MentionPersistService {
    */
   private emitFactOutcome(
     f: { predicate: string; object: string },
-    result: any,
+    result: ResolveOutcome,
     semantics: string,
   ): string | null {
     const factId = result?.factId ? String(result.factId) : null;
@@ -363,7 +365,7 @@ export class MentionPersistService {
    */
   private async persistEdges(
     db: Surreal,
-    p: { extraction: any; entityIds: string[]; dto: IngestMentionDto },
+    p: { extraction: ExtractionResult; entityIds: string[]; dto: IngestMentionDto },
   ): Promise<string[]> {
     const { extraction, entityIds, dto } = p;
     if (envFlagEnabled(process.env.INGEST_BATCH_EDGES)) {
@@ -419,7 +421,7 @@ export class MentionPersistService {
    */
   private async persistEdgesBatched(
     db: Surreal,
-    p: { extraction: any; entityIds: string[]; dto: IngestMentionDto },
+    p: { extraction: ExtractionResult; entityIds: string[]; dto: IngestMentionDto },
   ): Promise<string[]> {
     const { extraction, entityIds, dto } = p;
     // Deduplicate candidates within the batch: the extraction can emit the

--- a/src/ingest/predict-scoring.service.ts
+++ b/src/ingest/predict-scoring.service.ts
@@ -78,7 +78,7 @@ export class PredictScoringService {
             confidence: p.confidence ?? 0.7,
             sourceTrust:
               typeof p.source === 'object' && p.source !== null
-                ? sourceTrustFor(p.source as any)
+                ? sourceTrustFor(p.source as Parameters<typeof sourceTrustFor>[0])
                 : SOURCE_TRUST.default,
             recordedAt: new Date(p.recordedAt),
             authority: 0,
@@ -119,7 +119,7 @@ export class PredictScoringService {
           confidence: p.confidence ?? 0.7,
           sourceTrust:
             typeof p.source === 'object' && p.source !== null
-              ? sourceTrustFor(p.source as any)
+              ? sourceTrustFor(p.source as Parameters<typeof sourceTrustFor>[0])
               : SOURCE_TRUST.default,
           recordedAt: new Date(p.recordedAt),
           authority: 0,

--- a/src/jobs/job-claim.service.ts
+++ b/src/jobs/job-claim.service.ts
@@ -7,9 +7,30 @@ import {
   runTransaction,
   retryOnUniqueViolation,
   isUniqueViolation,
+  queryRows,
+  queryFirst,
 } from '../db/surreal.service';
 import { withSpan } from '../common/tracing';
 import type { JobType, JobStatus } from './job-run.service';
+
+/** SurrealDB returns datetimes as a Date on 3.x and an ISO string via JSON. */
+type RawDateTime = string | number | Date;
+
+/** UPDATE … RETURN id ownership-guard rows — only the row COUNT is read. */
+interface IdRow {
+  id: unknown;
+}
+
+/** SELECT projection behind the /admin/leases active-claims snapshot. */
+interface ActiveClaimRow {
+  runId: string;
+  jobType: string;
+  claimedBy: string;
+  claimedAt: RawDateTime;
+  leaseUntil: RawDateTime;
+  heartbeatAt: RawDateTime;
+  attempts?: number;
+}
 
 export interface JobClaim {
   /** Surreal record id, e.g. `job_run:abcd1234`. */
@@ -265,7 +286,8 @@ export class JobClaimService {
     if (!this.surreal) return { stillOwned: true, cancelRequested: false };
     try {
       return await this.surreal.withCompany(input.companyId, async (db) => {
-        const [rows] = (await db.query<any[]>(
+        const rows = await queryRows<{ cancelRequested?: boolean }>(
+          db,
           `UPDATE type::record($rid) SET
               leaseUntil = type::datetime($until),
               heartbeatAt = time::now()
@@ -278,15 +300,14 @@ export class JobClaimService {
               Date.now() + input.ttlSeconds * 1000,
             ).toISOString(),
           },
-        )) as any[];
-        const arr = (rows ?? []) as Array<{ cancelRequested?: boolean }>;
-        if (arr.length === 0) {
+        );
+        if (rows.length === 0) {
           // Someone reaped us OR we never owned this row.
           return { stillOwned: false, cancelRequested: false };
         }
         return {
           stillOwned: true,
-          cancelRequested: arr[0]?.cancelRequested === true,
+          cancelRequested: rows[0]?.cancelRequested === true,
         };
       });
     } catch (e) {
@@ -320,7 +341,8 @@ export class JobClaimService {
     if (!this.surreal) return;
     try {
       await this.surreal.withCompany(input.companyId, async (db) => {
-        const [rows] = (await db.query<any[]>(
+        const rows = await queryRows<IdRow>(
+          db,
           // Ownership guard: only write the terminal status if WE still
           // own the running row. A worker that GC-paused past its lease,
           // got zombie-reaped, and had the row re-claimed by another pod
@@ -340,8 +362,8 @@ export class JobClaimService {
             me: this.workerId,
             result: input.result ?? null,
           },
-        )) as any[];
-        if (((rows ?? []) as unknown[]).length === 0) {
+        );
+        if (rows.length === 0) {
           this.logger.warn(
             `complete(${input.recordId}) no-op — claim no longer owned by ${this.workerId}; another worker re-claimed it`,
           );
@@ -391,7 +413,8 @@ export class JobClaimService {
             const visibleAfter = new Date(
               Date.now() + backoffMs,
             ).toISOString();
-            const [rows] = (await db.query<any[]>(
+            const rows = await queryRows<IdRow>(
+              db,
               `UPDATE type::record($rid) SET
                   status = 'pending',
                   error = $err,
@@ -405,10 +428,11 @@ export class JobClaimService {
                 err: input.error,
                 visibleAfter,
               },
-            )) as any[];
-            return ((rows ?? []) as unknown[]).length;
+            );
+            return rows.length;
           }
-          const [rows] = (await db.query<any[]>(
+          const rows = await queryRows<IdRow>(
+            db,
             `UPDATE type::record($rid) SET
                 status = 'failed',
                 finishedAt = time::now(),
@@ -417,8 +441,8 @@ export class JobClaimService {
               WHERE claimedBy = $me AND status = 'running'
               RETURN id`,
             { rid: input.recordId, me: this.workerId, err: input.error },
-          )) as any[];
-          return ((rows ?? []) as unknown[]).length;
+          );
+          return rows.length;
         },
       );
       if (affected === 0) {
@@ -449,7 +473,8 @@ export class JobClaimService {
     if (!this.surreal) return;
     try {
       await this.surreal.withCompany(input.companyId, async (db) => {
-        const [rows] = (await db.query<any[]>(
+        const rows = await queryRows<IdRow>(
+          db,
           // Ownership guard — same rationale as complete()/fail().
           `UPDATE type::record($rid) SET
               status = 'cancelled',
@@ -459,8 +484,8 @@ export class JobClaimService {
             WHERE claimedBy = $me AND status = 'running'
             RETURN id`,
           { rid: input.recordId, me: this.workerId, result: input.result ?? null },
-        )) as any[];
-        if (((rows ?? []) as unknown[]).length === 0) {
+        );
+        if (rows.length === 0) {
           this.logger.warn(
             `cancelled(${input.recordId}) no-op — claim no longer owned by ${this.workerId}; another worker re-claimed it`,
           );
@@ -545,16 +570,16 @@ export class JobClaimService {
     }> = [];
     for (const companyId of companyIds) {
       try {
-        const rows = await this.surreal.withCompany(companyId, async (db) => {
-          const [res] = (await db.query<any[]>(
+        const rows = await this.surreal.withCompany(companyId, (db) =>
+          queryRows<ActiveClaimRow>(
+            db,
             `SELECT runId, jobType, claimedBy, claimedAt, leaseUntil,
                     heartbeatAt, attempts
                FROM job_run
               WHERE status = 'running' AND claimedBy IS NOT NONE
               ORDER BY claimedAt DESC LIMIT 50`,
-          )) as any[];
-          return (res ?? []) as any[];
-        });
+          ),
+        );
         for (const r of rows) {
           out.push({
             runId: r.runId,
@@ -584,13 +609,13 @@ export class JobClaimService {
     if (!this.surreal) return null;
     try {
       return await this.surreal.withCompany(companyId, async (db) => {
-        const [rows] = (await db.query<any[]>(
+        const row = await queryFirst<{ runId?: string }>(
+          db,
           `SELECT runId FROM job_run
              WHERE jobType = $jobType AND dedupKey = $dk LIMIT 1`,
           { jobType, dk: dedupKey },
-        )) as any[];
-        const arr = (rows ?? []) as Array<{ runId?: string }>;
-        return arr[0]?.runId ?? null;
+        );
+        return row?.runId ?? null;
       });
     } catch {
       return null;

--- a/src/jobs/job-run.service.ts
+++ b/src/jobs/job-run.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'node:crypto';
 import { Subject } from 'rxjs';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows, queryFirst } from '../db/surreal.service';
 import { ApiKeyService } from '../auth/api-key.service';
 import { LRUCache } from '../common/lru-cache';
 
@@ -91,10 +91,37 @@ function buildJobRunListWhere(filter: {
   return { whereSql, params };
 }
 
+/** SurrealDB returns datetimes as a Date on 3.x and an ISO string via JSON. */
+type RawDateTime = string | number | Date;
+
+/** Raw job_run row as SELECTed — trust boundary for mapJobRunRow / get().
+ *  Datetime columns arrive as Date | string; the mapper normalizes to ISO. */
+interface JobRunRawRow {
+  runId: string;
+  jobType: JobType;
+  status: JobStatus;
+  triggeredBy?: JobRunRow['triggeredBy'] | null;
+  triggeredByActor?: string | null;
+  startedAt: RawDateTime;
+  finishedAt?: RawDateTime | null;
+  progress?: JobProgress | null;
+  payload?: Record<string, unknown> | null;
+  result?: Record<string, unknown> | null;
+  error?: JobRunRow['error'];
+  cancelRequested?: boolean;
+  attempts?: number | null;
+  claimedBy?: string | null;
+  claimedAt?: RawDateTime | null;
+  leaseUntil?: RawDateTime | null;
+  heartbeatAt?: RawDateTime | null;
+  visibleAfter?: RawDateTime | null;
+}
+
 /** Project a raw job_run DB row onto the API shape (datetimes → ISO strings,
  *  null-coalesced optionals). Pure — extracted from JobRunService.list. */
-function mapJobRunRow(r: any, companyId: string): JobRunRow {
-  const iso = (v: unknown): string | null => (v ? new Date(v as string).toISOString() : null);
+function mapJobRunRow(r: JobRunRawRow, companyId: string): JobRunRow {
+  const iso = (v: RawDateTime | null | undefined): string | null =>
+    v ? new Date(v).toISOString() : null;
   return {
     runId: r.runId,
     jobType: r.jobType,
@@ -314,7 +341,8 @@ export class JobRunService {
       const updated = await this.surreal.withCompany(companyId, async (db) => {
         // Atomic: take pending rows straight to cancelled, flag running
         // rows. RETURN status so we can tell the caller which path fired.
-        const res = (await db.query<any[]>(
+        const rows = await queryRows<{ status?: string }>(
+          db,
           `UPDATE job_run SET
               cancelRequested = true,
               status = IF status = 'pending' THEN 'cancelled' ELSE status END,
@@ -325,8 +353,7 @@ export class JobRunService {
               AND status IN ['pending', 'running']
             RETURN status`,
           { runId },
-        )) as any[];
-        const rows = (res[0] ?? []) as Array<{ status?: string }>;
+        );
         // A pending row taken straight to 'cancelled' is terminal — finish()
         // will never run for it, so drop the in-process hint here. Running
         // rows keep it until finish() (inline) or LRU eviction (queue).
@@ -352,13 +379,13 @@ export class JobRunService {
     if (!this.persistEnabled || !this.surreal) return false;
     try {
       return await this.surreal.withCompany(companyId, async (db) => {
-        const res = (await db.query<any[]>(
+        const row = await queryFirst<{ cancelRequested?: boolean }>(
+          db,
           `SELECT cancelRequested FROM job_run
             WHERE runId = $runId AND companyId = $companyId LIMIT 1`,
           { runId, companyId },
-        )) as any[];
-        const rows = (res[0] ?? []) as Array<{ cancelRequested?: boolean }>;
-        return rows[0]?.cancelRequested === true;
+        );
+        return row?.cancelRequested === true;
       });
     } catch {
       return false;
@@ -399,17 +426,17 @@ export class JobRunService {
     companyId: string,
     where: { whereSql: string; params: Record<string, unknown> },
     limit: number,
-  ): Promise<any[]> {
+  ): Promise<JobRunRawRow[]> {
     try {
-      return await this.surreal!.withCompany(companyId, async (db) => {
-        const res = (await db.query<any[]>(
+      return await this.surreal!.withCompany(companyId, (db) =>
+        queryRows<JobRunRawRow>(
+          db,
           `SELECT ${JOB_RUN_LIST_COLUMNS}
                FROM job_run ${where.whereSql}
               ORDER BY startedAt DESC LIMIT ${limit}`,
           where.params,
-        )) as any[];
-        return (res[0] ?? []) as any[];
-      });
+        ),
+      );
     } catch (e) {
       this.logger.warn(
         `job_run list failed for ${companyId}: ${(e as Error).message}`,
@@ -422,45 +449,19 @@ export class JobRunService {
     if (!this.persistEnabled || !this.surreal) return null;
     try {
       return await this.surreal.withCompany(companyId, async (db) => {
-        const res = (await db.query<any[]>(
+        const r = await queryFirst<JobRunRawRow>(
+          db,
           `SELECT runId, jobType, status, triggeredBy, triggeredByActor,
                   startedAt, finishedAt, progress, payload, result, error,
                   cancelRequested, attempts, claimedBy, claimedAt,
                   leaseUntil, heartbeatAt, visibleAfter
              FROM job_run WHERE runId = $runId LIMIT 1`,
           { runId },
-        )) as any[];
-        const r = ((res[0] ?? []) as any[])[0];
+        );
         if (!r) return null;
-        return {
-          runId: r.runId,
-          jobType: r.jobType,
-          status: r.status,
-          triggeredBy: r.triggeredBy ?? 'cron',
-          triggeredByActor: r.triggeredByActor ?? null,
-          startedAt: new Date(r.startedAt).toISOString(),
-          finishedAt: r.finishedAt
-            ? new Date(r.finishedAt).toISOString()
-            : null,
-          progress: r.progress ?? null,
-          payload: r.payload ?? null,
-          result: r.result ?? null,
-          error: r.error ?? null,
-          cancelRequested: r.cancelRequested === true,
-          attempts: typeof r.attempts === 'number' ? r.attempts : undefined,
-          claimedBy: r.claimedBy ?? null,
-          claimedAt: r.claimedAt ? new Date(r.claimedAt).toISOString() : null,
-          leaseUntil: r.leaseUntil
-            ? new Date(r.leaseUntil).toISOString()
-            : null,
-          heartbeatAt: r.heartbeatAt
-            ? new Date(r.heartbeatAt).toISOString()
-            : null,
-          visibleAfter: r.visibleAfter
-            ? new Date(r.visibleAfter).toISOString()
-            : null,
-          companyId,
-        } as JobRunRow;
+        // Same projection as the cross-tenant list — reuse the mapper
+        // instead of duplicating the datetime/null-coalesce shaping.
+        return mapJobRunRow(r, companyId);
       });
     } catch (e) {
       this.logger.warn(`job_run get failed (${runId}): ${(e as Error).message}`);

--- a/src/jobs/leader-lease.service.ts
+++ b/src/jobs/leader-lease.service.ts
@@ -1,6 +1,23 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { hostname } from 'node:os';
-import { SurrealService, runTransaction, retryOnUniqueViolation } from '../db/surreal.service';
+import {
+  SurrealService,
+  runTransaction,
+  retryOnUniqueViolation,
+  queryRows,
+} from '../db/surreal.service';
+
+/** SurrealDB returns datetimes as a Date on 3.x and an ISO string via JSON. */
+type RawDateTime = string | number | Date;
+
+/** Raw leader_lease row for the read-only /admin/maintenance view. */
+interface LeaseRow {
+  name: string;
+  leaderId: string;
+  leaseUntil: RawDateTime;
+  heartbeatAt: RawDateTime;
+  acquiredAt: RawDateTime;
+}
 
 /**
  * Acquire / renew / release named leases in `leader_lease` (migration
@@ -131,10 +148,10 @@ export class LeaderLeaseService {
     if (!this.surreal) return [];
     try {
       return await this.surreal.withAdminDb(async (db) => {
-        const res = (await db.query<any[]>(
+        const rows = await queryRows<LeaseRow>(
+          db,
           `SELECT name, leaderId, leaseUntil, heartbeatAt, acquiredAt FROM leader_lease`,
-        )) as any[];
-        const rows = (res[0] ?? []) as any[];
+        );
         return rows.map((r) => ({
           name: r.name,
           leaderId: r.leaderId,

--- a/src/live/live-subscription.manager.ts
+++ b/src/live/live-subscription.manager.ts
@@ -3,10 +3,17 @@ import { ConfigService } from '@nestjs/config';
 import { Surreal, Table } from 'surrealdb';
 import type { LiveSubscription } from 'surrealdb';
 import { envFlagEnabled } from '../common/env-validation';
+import { queryRows } from '../db/surreal.service';
 import {
   makeRowPolicyFilter,
   type PredicatePolicyLookup,
 } from '../policy/row-filter';
+
+/** One `SHOW CHANGES` batch row: a versionstamp plus its changefeed items. */
+interface ChangefeedShowRow {
+  versionstamp?: number | string;
+  changes?: unknown[];
+}
 
 /** One knowledge-fact change delivered to a subscriber. */
 export interface LiveFactEvent {
@@ -235,17 +242,17 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
   async catchUp(companyId: string): Promise<number> {
     const channel = this.channels.get(companyId);
     if (!channel) return 0;
-    const [rows] = await channel.conn.query<[any[]]>(
+    const changes = await queryRows<ChangefeedShowRow>(
+      channel.conn,
       `SHOW CHANGES FOR TABLE ${TABLE} SINCE ${channel.versionstamp} LIMIT 1000`,
     );
-    const changes = (rows as any[]) ?? [];
     let emitted = 0;
     let highest = channel.versionstamp;
     for (const change of changes) {
-      const vs = Number(change?.versionstamp ?? 0);
+      const vs = Number(change.versionstamp ?? 0);
       if (vs <= channel.versionstamp) continue;
       if (vs > highest) highest = vs;
-      for (const item of (change?.changes as any[]) ?? []) {
+      for (const item of change.changes ?? []) {
         const event = toReplayEvent(item);
         if (!event) continue;
         // Already pushed over the socket — replay must not double-deliver.
@@ -341,12 +348,12 @@ export function dbNameFor(companyId: string): string {
  */
 async function currentVersionstamp(conn: Surreal): Promise<number> {
   try {
-    const [rows] = await conn.query<[any[]]>(
+    const changes = await queryRows<ChangefeedShowRow>(
+      conn,
       `SHOW CHANGES FOR TABLE ${TABLE} SINCE 0 LIMIT 100000`,
     );
-    const changes = (rows as any[]) ?? [];
     return changes.reduce(
-      (max, c) => Math.max(max, Number(c?.versionstamp ?? 0)),
+      (max, c) => Math.max(max, Number(c.versionstamp ?? 0)),
       0,
     );
   } catch {
@@ -360,7 +367,7 @@ export function toFactEvent(
   via: 'live' | 'replay',
 ): LiveFactEvent | null {
   const value = (msg?.value ?? {}) as Record<string, unknown>;
-  const factId = String((msg as any)?.recordId ?? value.id ?? '');
+  const factId = String(msg?.recordId ?? value.id ?? '');
   if (!factId || typeof value.predicate !== 'string') return null;
   return {
     kind: 'fact',

--- a/src/mcp/code-memory-tools.ts
+++ b/src/mcp/code-memory-tools.ts
@@ -4,6 +4,7 @@ import type { IngestService } from '../ingest/ingest.service';
 import type { EntitiesService } from '../entities/entities.service';
 import type { CodeMemorySearchService } from '../code-memory/code-memory-search.service';
 import type { BrainScope } from '../auth/api-key.types';
+import { asStructuredContent } from './structured';
 import {
   CODE_MEMORY_KINDS,
   CODE_MEMORY_PREDICATE_IDS,
@@ -91,7 +92,7 @@ export function registerCodeMemoryReadTools(opts: {
       };
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -117,7 +118,7 @@ export function registerCodeMemoryReadTools(opts: {
       const out = { query: args.query, found: decisions.length, decisions };
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -183,7 +184,7 @@ export function registerCodeMemoryWriteTools(opts: {
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );

--- a/src/mcp/community-tools.ts
+++ b/src/mcp/community-tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { CommunityService } from '../communities/community.service';
+import { asStructuredContent } from './structured';
 
 /**
  * Registers the topic-community read scope (graphiti-style communities)
@@ -48,7 +49,7 @@ export function registerCommunityTools(
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: { communities: out } as any,
+        structuredContent: asStructuredContent({ communities: out }),
       };
     },
   );
@@ -68,7 +69,7 @@ export function registerCommunityTools(
       const out = await communities.list(companyId, { limit: args.limit, callerScopes: scopes });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: { communities: out } as any,
+        structuredContent: asStructuredContent({ communities: out }),
       };
     },
   );
@@ -88,7 +89,7 @@ export function registerCommunityTools(
       const out = await communities.forEntity(companyId, args.entityId, scopes);
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: { communities: out } as any,
+        structuredContent: asStructuredContent({ communities: out }),
       };
     },
   );

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -101,6 +101,6 @@ export class McpController {
     });
 
     await server.connect(transport);
-    await transport.handleRequest(req, res, (req as any).body);
+    await transport.handleRequest(req, res, req.body);
   }
 }

--- a/src/mcp/pack-tools-reader.service.ts
+++ b/src/mcp/pack-tools-reader.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 import { LRUCache } from '../common/lru-cache';
 import {
   composePredicateId,
@@ -75,15 +75,15 @@ export class PackToolsReaderService {
   }
 
   private async loadFresh(companyId: string): Promise<PackToolBinding[]> {
-    const rows = await this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+    const rows = await this.surreal.withCompany(companyId, (db) =>
+      queryRows<Record<string, unknown>>(
+        db,
         `SELECT packId, version, manifest, installId, webhookSecret,
                 acceptedMcpTools, acceptedMcpToolsChecksum
            FROM domain_pack
           WHERE status = 'active' AND manifest.mcpTools != NONE`,
-      );
-      return ((rows as any[]) ?? []) as Array<Record<string, unknown>>;
-    });
+      ),
+    );
     const bindings: PackToolBinding[] = [];
     for (const row of rows) {
       const binding = this.toBinding(row);

--- a/src/mcp/pack-tools.ts
+++ b/src/mcp/pack-tools.ts
@@ -20,6 +20,7 @@ import {
   renderPackToolTitle,
   sanitizePackText,
 } from './pack-tool-render';
+import { asStructuredContent } from './structured';
 
 /**
  * Registration of pack-declared MCP tools (docs/mcp-pack-tools.md) on a
@@ -127,7 +128,7 @@ function registerSearchQueryTool(ctx: QueryToolContext): void {
       );
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -170,7 +171,7 @@ function registerFactsByPredicateTool(ctx: QueryToolContext): void {
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -210,7 +211,7 @@ function registerExternalTool(ctx: ExternalToolContext): void {
       return {
         content: out.content,
         ...(out.structuredContent
-          ? { structuredContent: out.structuredContent as any }
+          ? { structuredContent: out.structuredContent }
           : {}),
       };
     },

--- a/src/mcp/procedural-tools.ts
+++ b/src/mcp/procedural-tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ProceduralMemoryService } from '../procedural/procedural-memory.service';
+import { asStructuredContent } from './structured';
 
 export interface ProceduralReadDeps {
   /** Caller scopes — routes these reads through the scoped pool. */
@@ -48,7 +49,7 @@ export function registerProceduralReadTools(
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: { matches: out } as any,
+        structuredContent: asStructuredContent({ matches: out }),
       };
     },
   );
@@ -73,7 +74,7 @@ export function registerProceduralReadTools(
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: { procedures: out } as any,
+        structuredContent: asStructuredContent({ procedures: out }),
       };
     },
   );

--- a/src/mcp/read-tools.ts
+++ b/src/mcp/read-tools.ts
@@ -18,6 +18,7 @@ import {
   type ProgressReporter,
 } from './progress-reporter';
 import { summarizeViaClientSampling } from './sampling';
+import { asStructuredContent } from './structured';
 
 /**
  * Collaborators the read surface needs. Mirrors the constructor seam of
@@ -146,7 +147,7 @@ function registerSearchTools({
       );
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -211,7 +212,7 @@ function registerSearchTools({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -265,7 +266,7 @@ function registerSearchTools({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -303,7 +304,7 @@ function registerSearchTools({
       );
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -357,7 +358,7 @@ function registerGraphRetrieveTool({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -390,7 +391,7 @@ function registerEntityReadTools({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -418,7 +419,7 @@ function registerEntityReadTools({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -459,7 +460,7 @@ function registerEntityReadTools({
         });
         return {
           content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-          structuredContent: out as any,
+          structuredContent: asStructuredContent(out),
         };
       }
       const out = await deps.summarizer.summarize(
@@ -469,7 +470,10 @@ function registerEntityReadTools({
       );
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: { ...out, sampledBy: 'local_template' } as any,
+        structuredContent: {
+          ...out,
+          sampledBy: 'local_template',
+        } as Record<string, unknown>,
       };
     },
   );
@@ -504,7 +508,7 @@ function registerEntityReadTools({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -542,7 +546,7 @@ function registerEntityReadTools({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -588,7 +592,7 @@ function registerDetectContradictionTool({
       const out = await deps.predictor.predict(
         companyId,
         {
-          entityRef: args.entityRef as any,
+          entityRef: args.entityRef,
           predicate: args.predicate,
           object: args.object,
           validFrom: args.validFrom,
@@ -601,7 +605,7 @@ function registerDetectContradictionTool({
       );
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );

--- a/src/mcp/source-tools.ts
+++ b/src/mcp/source-tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { SourcesService } from '../sources/sources.service';
+import { asStructuredContent } from './structured';
 
 export interface SourceToolDeps {
   sources: SourcesService;
@@ -35,7 +36,7 @@ export function registerSourceReadTools(opts: {
       const out = await deps.sources.detail(companyId, args.sourceKey);
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );

--- a/src/mcp/structured.ts
+++ b/src/mcp/structured.ts
@@ -1,0 +1,19 @@
+/**
+ * Coerce a typed tool-result object into MCP's `structuredContent` shape.
+ *
+ * The MCP SDK types a tool result's `structuredContent` field as
+ * `Record<string, unknown>` — arbitrary JSON. Brain's tool handlers return
+ * concrete domain objects (SearchResult, EntityProfile, …) that ARE plain
+ * JSON (they're `JSON.stringify`d into the sibling text block on the same
+ * return), but their declared interfaces carry no string index signature,
+ * so TypeScript won't structurally accept them as `Record<string, unknown>`.
+ *
+ * This is the single sanctioned spot for that safe object→record coercion:
+ * a value of a known object type is, at runtime, exactly a string-keyed
+ * record of unknown-typed values. Routing every call site through here
+ * keeps the coercion named, documented, and out of the handlers — instead
+ * of an `as any` (or a scattered `as unknown as …`) per tool.
+ */
+export function asStructuredContent(out: object): Record<string, unknown> {
+  return out as unknown as Record<string, unknown>;
+}

--- a/src/mcp/write-tools.ts
+++ b/src/mcp/write-tools.ts
@@ -12,6 +12,7 @@ import { DOC_TEXT_HARD_CAP } from '../documents/dto/ingest-document.dto';
 import { docMaxChars } from '../documents/documents-gate';
 import type { BrainScope } from '../auth/api-key.types';
 import type { MetricsService } from '../metrics/metrics.service';
+import { asStructuredContent } from './structured';
 
 export interface WriteToolDeps {
   ingest: IngestService;
@@ -92,7 +93,7 @@ export function registerWriteTools({
       // `fact` path — query per-path, don't sum labels.
       deps.metrics?.countIngestWrite('mcp');
       const out = await deps.ingest.ingestFact(companyId, {
-        entityRef: args.entityRef as any,
+        entityRef: args.entityRef,
         predicate: args.predicate,
         object: args.object,
         validFrom: args.validFrom,
@@ -103,7 +104,7 @@ export function registerWriteTools({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -142,15 +143,15 @@ export function registerWriteTools({
     },
     async (args) => {
       const out = await deps.ingest.ingestLink(companyId, {
-        from: args.from as any,
-        to: args.to as any,
+        from: args.from,
+        to: args.to,
         kind: args.kind,
         weight: args.weight,
         source: { vertical: args.sourceVertical },
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -193,7 +194,7 @@ export function registerWriteTools({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -228,7 +229,7 @@ export function registerWriteTools({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -250,7 +251,7 @@ export function registerWriteTools({
       const out = await deps.procedural.retire(companyId, args.procedureId);
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -299,7 +300,7 @@ function registerFeedbackTool({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -344,7 +345,7 @@ export function registerAdminTools(
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );
@@ -430,7 +431,7 @@ function registerIngestDocumentTool({
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
-        structuredContent: out as any,
+        structuredContent: asStructuredContent(out),
       };
     },
   );

--- a/src/policy/meta-union.ts
+++ b/src/policy/meta-union.ts
@@ -2,7 +2,7 @@ import { Logger } from '@nestjs/common';
 import { LRUCache } from '../common/lru-cache';
 import { envFlagEnabled } from '../common/env-validation';
 import { policyFor } from '../ingest/conflict-resolver';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 import { evaluateRow, toRowView } from './policy-engine';
 import { PolicyContext, PolicyRowView } from './policy.types';
 
@@ -37,6 +37,12 @@ const metaCache = new LRUCache<
   string,
   { meta: Record<string, unknown> | null; at: number }
 >(10_000);
+
+/** Raw source_document projection for the origin-meta batch lookup. */
+interface SourceDocMetaRow {
+  contentHash: unknown;
+  meta?: unknown;
+}
 
 export interface MetaUnionRow {
   predicate: string;
@@ -97,14 +103,14 @@ export async function applyMetaUnion<T extends MetaUnionRow>(opts: {
   if (wanted.size > 0) {
     try {
       const hashes = [...wanted].map((k) => k.slice('doc:'.length));
-      const found = await surreal.withCompany(companyId, async (db) => {
-        const [r] = await db.query<[any[]]>(
+      const found = await surreal.withCompany(companyId, (db) =>
+        queryRows<SourceDocMetaRow>(
+          db,
           `SELECT contentHash, meta FROM source_document
             WHERE contentHash INSIDE $hashes`,
           { hashes },
-        );
-        return (r as any[]) ?? [];
-      });
+        ),
+      );
       const at = Date.now();
       for (const doc of found) {
         metaCache.set(cacheKey(companyId, `doc:${String(doc.contentHash)}`), {

--- a/src/policy/policy-decisions.service.ts
+++ b/src/policy/policy-decisions.service.ts
@@ -1,7 +1,40 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 import { PolicyStoreService } from './policy-store.service';
 import { keyIdOf } from './policy-keys.service';
+
+/** SurrealDB returns datetimes as a Date on 3.x and an ISO string via JSON. */
+type RawDateTime = string | number | Date;
+
+/** Raw policy_decision row (SELECT *) before mapEvent shaping. Values that
+ *  are stringified / numeric-coerced downstream are typed `unknown`. */
+interface PolicyDecisionRow {
+  id: unknown;
+  ts: RawDateTime;
+  keyHash?: unknown;
+  kind: DecisionEvent['kind'];
+  decision: DecisionEvent['decision'];
+  mode: DecisionEvent['mode'];
+  action?: unknown;
+  policySet?: unknown;
+  ruleId?: unknown;
+  requestId?: unknown;
+  rowCounts?: { total?: unknown; denied?: unknown } | null;
+  samplePredicates?: unknown;
+  sampled?: unknown;
+}
+
+/** Projected columns behind the report_only → enforce stats aggregation.
+ *  action/policySet/ruleId/keyHash are string columns — typed concretely so
+ *  the rule-key template literal and the map keys stay string-safe. */
+interface PolicyDecisionStatRow {
+  ts: RawDateTime;
+  decision: DecisionEvent['decision'];
+  action?: string;
+  policySet?: string;
+  ruleId?: string;
+  keyHash?: string;
+}
 
 export interface DecisionEvent {
   id: string;
@@ -102,14 +135,14 @@ export class PolicyDecisionsService {
       params.before = before;
     }
     const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
-    const rows = await this.surreal.withCompany(companyId, async (db) => {
-      const [r] = await db.query<[any[]]>(
+    const rows = await this.surreal.withCompany(companyId, (db) =>
+      queryRows<PolicyDecisionRow>(
+        db,
         `SELECT * FROM policy_decision ${where}
           ORDER BY ts DESC LIMIT $limit`,
         params,
-      );
-      return (r as any[]) ?? [];
-    });
+      ),
+    );
     const page = rows.slice(0, limit);
     const decisions = page.map(mapEvent);
     return {
@@ -122,16 +155,16 @@ export class PolicyDecisionsService {
 
   async stats(companyId: string, windowDays = 7): Promise<DecisionsStats> {
     const days = Math.min(Math.max(windowDays, 1), 30);
-    const rows = await this.surreal.withCompany(companyId, async (db) => {
-      const [r] = await db.query<[any[]]>(
+    const rows = await this.surreal.withCompany(companyId, (db) =>
+      queryRows<PolicyDecisionStatRow>(
+        db,
         `SELECT ts, decision, action, policySet, ruleId, keyHash
            FROM policy_decision
           WHERE ts > time::now() - ${days}d
           ORDER BY ts DESC
           LIMIT ${STATS_ROW_CAP}`,
-      );
-      return (r as any[]) ?? [];
-    });
+      ),
+    );
 
     const series = new Map<string, { allow: number; deny: number; wouldDeny: number }>();
     const deniedActions = new Map<string, number>();
@@ -212,7 +245,7 @@ export class PolicyDecisionsService {
   }
 }
 
-function mapEvent(row: any): DecisionEvent {
+function mapEvent(row: PolicyDecisionRow): DecisionEvent {
   return {
     id: String(row.id),
     ts: new Date(row.ts).toISOString(),

--- a/src/policy/policy-resolver.service.ts
+++ b/src/policy/policy-resolver.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { LRUCache } from '../common/lru-cache';
 import { envFlagEnabled } from '../common/env-validation';
 import { MetricsService } from '../metrics/metrics.service';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
 import { compilePolicySet, denyAllSet } from './policy-compile';
 import {
   CompiledPolicySet,
@@ -17,6 +17,19 @@ export interface PolicySubject {
   keyHash: string;
   claimNames?: readonly string[];
   actorId?: string;
+}
+
+/** Raw access_policy row: name is stringified, document is compiled. */
+interface AccessPolicyRow {
+  name: unknown;
+  mode?: unknown;
+  document: unknown;
+}
+
+/** Raw policy_binding row: subject → attached policy set names. */
+interface PolicyBindingRow {
+  subject: unknown;
+  policyNames?: unknown;
 }
 
 interface TenantPolicySnapshot {
@@ -185,22 +198,24 @@ export class PolicyResolverService {
 
   private async loadFresh(companyId: string): Promise<TenantPolicySnapshot> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [policyRows] = await db.query<[any[]]>(
+      const policyRows = await queryRows<AccessPolicyRow>(
+        db,
         `SELECT name, mode, document FROM access_policy`,
       );
-      const [bindingRows] = await db.query<[any[]]>(
+      const bindingRows = await queryRows<PolicyBindingRow>(
+        db,
         `SELECT subject, policyNames FROM policy_binding`,
       );
       const sets = new Map<string, CompiledPolicySet>();
       const knownNames = new Set<string>();
-      for (const r of (policyRows as any[]) ?? []) {
+      for (const r of policyRows) {
         const name = String(r.name);
         knownNames.add(name);
         const compiled = compilePolicySet(r.document as PolicyDocument);
         if (compiled) sets.set(name, compiled);
       }
       const bindings = new Map<string, string[]>();
-      for (const r of (bindingRows as any[]) ?? []) {
+      for (const r of bindingRows) {
         bindings.set(
           String(r.subject),
           ((r.policyNames as string[]) ?? []).map(String),

--- a/src/policy/policy-store.service.ts
+++ b/src/policy/policy-store.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { StringRecordId } from 'surrealdb';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows, queryFirst } from '../db/surreal.service';
 import { sanitizeSourceMeta } from './source-meta';
 import { PolicyResolverService } from './policy-resolver.service';
 import {
@@ -48,6 +48,31 @@ export interface FactPolicyView {
 
 const SUBJECT_SHAPE = /^(key|jwt|agent):[A-Za-z0-9:._-]{1,200}$/;
 
+/** Row shape of the `access_policy` table (migration 0056). */
+interface AccessPolicyRow {
+  name: unknown;
+  mode: unknown;
+  document: PolicyDocument;
+  version?: unknown;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+  updatedBy?: unknown;
+}
+
+/** Row shape of the `policy_binding` table. */
+interface PolicyBindingRow {
+  subject: unknown;
+  policyNames?: string[];
+  updatedAt?: unknown;
+}
+
+/** `source_document` projection used by the source-meta backfill. */
+interface SourceDocMetaRow {
+  id: unknown;
+  meta?: unknown;
+  createdAt?: unknown;
+}
+
 /**
  * CRUD over the per-tenant ABAC tables (migration 0056). Writes are
  * admin-only and run on the root pool; every mutation invalidates the
@@ -82,21 +107,23 @@ export class PolicyStoreService {
 
   async list(companyId: string): Promise<StoredPolicySet[]> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<AccessPolicyRow>(
+        db,
         `SELECT * FROM access_policy ORDER BY name`,
       );
-      const [bindings] = await db.query<[any[]]>(
+      const bindings = await queryRows<PolicyBindingRow>(
+        db,
         `SELECT subject, policyNames FROM policy_binding`,
       );
       const attachedBy = new Map<string, string[]>();
-      for (const b of (bindings as any[]) ?? []) {
-        for (const name of (b.policyNames as string[]) ?? []) {
+      for (const b of bindings) {
+        for (const name of b.policyNames ?? []) {
           const list = attachedBy.get(name) ?? [];
           list.push(String(b.subject));
           attachedBy.set(name, list);
         }
       }
-      return ((rows as any[]) ?? []).map((r) => mapRow(r, attachedBy));
+      return rows.map((r) => mapRow(r, attachedBy));
     });
   }
 
@@ -159,7 +186,8 @@ export class PolicyStoreService {
       });
     }
     await this.surreal.withCompany(companyId, async (db) => {
-      const [updated] = await db.query<[any[]]>(
+      const updated = await queryRows<AccessPolicyRow>(
+        db,
         `UPDATE access_policy SET
            mode = $mode, document = $document, version = version + 1,
            updatedAt = time::now(), updatedBy = $updatedBy
@@ -172,7 +200,7 @@ export class PolicyStoreService {
           updatedBy,
         },
       );
-      if (((updated as any[]) ?? []).length === 0) {
+      if (updated.length === 0) {
         // Raced with a concurrent writer between our read and write.
         throw new ConflictException({ error: 'version_conflict', current });
       }
@@ -198,12 +226,13 @@ export class PolicyStoreService {
 
   async listBindings(companyId: string): Promise<StoredBinding[]> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+      const rows = await queryRows<PolicyBindingRow>(
+        db,
         `SELECT * FROM policy_binding ORDER BY subject`,
       );
-      return ((rows as any[]) ?? []).map((r) => ({
+      return rows.map((r) => ({
         subject: String(r.subject),
-        policyNames: ((r.policyNames as string[]) ?? []).map(String),
+        policyNames: (r.policyNames ?? []).map(String),
         updatedAt: String(r.updatedAt ?? ''),
       }));
     });
@@ -229,19 +258,19 @@ export class PolicyStoreService {
     }
     await this.surreal.withCompany(companyId, async (db) => {
       for (const subject of attach) {
-        const [rows] = await db.query<[any[]]>(
+        const rows = await queryRows<PolicyBindingRow>(
+          db,
           `SELECT policyNames FROM policy_binding WHERE subject = $subject`,
           { subject },
         );
-        const existing: string[] =
-          ((rows as any[])?.[0]?.policyNames as string[]) ?? [];
+        const existing: string[] = rows[0]?.policyNames ?? [];
         if (existing.includes(name)) continue;
         if (existing.length >= MAX_SETS_PER_KEY) {
           throw new BadRequestException(
             `Subject '${subject}' already carries ${existing.length} policy sets (max ${MAX_SETS_PER_KEY})`,
           );
         }
-        if (rows && (rows as any[]).length > 0) {
+        if (rows.length > 0) {
           await db.query(
             `UPDATE policy_binding SET policyNames += $name,
                updatedAt = time::now() WHERE subject = $subject`,
@@ -291,17 +320,17 @@ export class PolicyStoreService {
       )
       .filter((id) => FACT_ID_SHAPE.test(id));
     if (ids.length === 0) return out;
-    const rows = await this.surreal.withCompany(companyId, async (db) => {
-      const [r] = await db.query<[any[]]>(
+    const rows = await this.surreal.withCompany(companyId, async (db) =>
+      queryRows<FactPolicyView>(
+        db,
         `SELECT id, predicate, source, trustSnapshot, corroboration, userId
            FROM knowledge_fact
           WHERE id INSIDE $ids`,
         { ids: ids.map((id) => new StringRecordId(`knowledge_fact:${id}`)) },
-      );
-      return (r as any[]) ?? [];
-    });
+      ),
+    );
     for (const row of rows) {
-      out.set(String(row.id), row as FactPolicyView);
+      out.set(String(row.id), row);
     }
     return out;
   }
@@ -318,13 +347,17 @@ export class PolicyStoreService {
     maxDocs = 200,
   ): Promise<{ documentsProcessed: number; factsUpdated: number; remaining: number }> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [docsOut] = await db.query<[any[]]>(
+      const docsOut = await queryRows<SourceDocMetaRow>(
+        db,
         `SELECT id, meta, createdAt FROM source_document
           WHERE meta != NONE
           ORDER BY createdAt ASC`,
       );
-      const docs = ((docsOut as any[]) ?? []).filter(
-        (d) => d.meta && typeof d.meta === 'object' && Object.keys(d.meta).length > 0,
+      const docs = docsOut.filter(
+        (d) =>
+          d.meta &&
+          typeof d.meta === 'object' &&
+          Object.keys(d.meta).length > 0,
       );
       let factsUpdated = 0;
       let documentsProcessed = 0;
@@ -332,14 +365,15 @@ export class PolicyStoreService {
         const { meta } = sanitizeSourceMeta(doc.meta);
         documentsProcessed += 1;
         if (!meta) continue;
-        const [updated] = await db.query<[any[]]>(
+        const updated = await queryRows<unknown>(
+          db,
           `UPDATE knowledge_fact SET source.meta = $meta
             WHERE source.documentId = $docId
               AND source.meta IS NONE
             RETURN VALUE id`,
           { meta, docId: String(doc.id) },
         );
-        factsUpdated += ((updated as any[]) ?? []).length;
+        factsUpdated += updated.length;
       }
       return {
         documentsProcessed,
@@ -361,7 +395,8 @@ export class PolicyStoreService {
       // recordedAt must be IN the projection — SurrealQL 3.x refuses to
       // ORDER BY a field the SELECT didn't materialize (the "order
       // idiom" gotcha, see docs/document-pipeline.md).
-      const [rows] = await db.query<[any[]]>(
+      return queryRows<FactPolicyView>(
+        db,
         `SELECT id, predicate, source, trustSnapshot, corroboration,
                 userId, recordedAt
            FROM knowledge_fact
@@ -372,7 +407,6 @@ export class PolicyStoreService {
           LIMIT $limit`,
         { limit },
       );
-      return ((rows as any[]) ?? []) as FactPolicyView[];
     });
   }
 
@@ -396,14 +430,20 @@ export class PolicyStoreService {
     if (!FACT_ID_SHAPE.test(id)) {
       throw new BadRequestException(`Malformed factId '${factIdRaw}'`);
     }
-    const row = await this.surreal.withCompany(companyId, async (db) => {
-      const [rows] = await db.query<[any[]]>(
+    const row = await this.surreal.withCompany(companyId, async (db) =>
+      queryFirst<{
+        predicate: string;
+        source?: unknown;
+        trustSnapshot?: { authority?: number } | null;
+        corroboration?: { count?: number } | null;
+        userId?: string | null;
+      }>(
+        db,
         `SELECT predicate, source, trustSnapshot, corroboration, userId
            FROM type::record('knowledge_fact', $id) LIMIT 1`,
         { id },
-      );
-      return ((rows as any[]) ?? [])[0];
-    });
+      ),
+    );
     if (!row) throw new NotFoundException(`Fact ${factIdRaw} not found`);
     return row;
   }
@@ -411,7 +451,10 @@ export class PolicyStoreService {
 
 const FACT_ID_SHAPE = /^[A-Za-z0-9_]+$/;
 
-function mapRow(r: any, attachedBy: Map<string, string[]>): StoredPolicySet {
+function mapRow(
+  r: AccessPolicyRow,
+  attachedBy: Map<string, string[]>,
+): StoredPolicySet {
   return {
     name: String(r.name),
     mode: String(r.mode) as PolicyMode,

--- a/src/procedural/procedural-memory.service.ts
+++ b/src/procedural/procedural-memory.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows, queryFirst } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 
 /**
@@ -40,7 +40,7 @@ export class ProceduralMemoryService {
     return this.surreal.withCompany(companyId, async (db) => {
       const embedding = await this.embedder.embed(args.trigger);
 
-      const [row] = await db.query<any[]>(
+      const [row] = await db.query<[ProcedureRowDb]>(
         `CREATE ONLY procedural_memory CONTENT {
             trigger: $trigger,
             triggerEmbedding: $embedding,
@@ -59,11 +59,11 @@ export class ProceduralMemoryService {
           source: args.source ?? { kind: 'operator' },
         },
       );
-      const created = (row as any) ?? null;
+      const created = row ?? null;
       if (!created) throw new Error('procedural_memory CREATE returned nothing');
 
       this.logger.log(
-        `[procedural.recorded] companyId=${companyId} id=${String(created.id)} priority=${created.priority}`,
+        `[procedural.recorded] companyId=${companyId} id=${String(created.id)} priority=${String(created.priority)}`,
       );
 
       return mapRow(created);
@@ -98,21 +98,21 @@ export class ProceduralMemoryService {
       // call. Doing it server-side today would require maintaining a
       // dimension-pinned vector index, which the embedder can swap at
       // runtime.
-      const [rows] = await db.query<any[][]>(
+      const rows = await queryRows<ProcedureRowDb>(
+        db,
         `SELECT id, trigger, triggerEmbedding, action, priority,
                 decayHalfLifeDays, source, createdAt
            FROM procedural_memory
            WHERE retiredAt IS NONE
            ORDER BY priority ASC`,
       );
-      const procs = ((rows as any[]) ?? []) as any[];
 
       const qNorm = vectorNorm(queryEmbedding);
       const minSim = args.minSimilarity ?? 0.4;
       const limit = args.limit ?? 5;
 
       const scored: MatchedProcedure[] = [];
-      for (const p of procs) {
+      for (const p of rows) {
         const emb = Array.isArray(p.triggerEmbedding)
           ? (p.triggerEmbedding as number[])
           : null;
@@ -138,7 +138,8 @@ export class ProceduralMemoryService {
   ): Promise<ProcedureRecord[]> {
     return this.run(companyId, args.callerScopes, async (db) => {
       const filter = args.includeRetired ? '' : 'WHERE retiredAt IS NONE';
-      const [rows] = await db.query<any[][]>(
+      const rows = await queryRows<ProcedureRowDb>(
+        db,
         `SELECT id, trigger, action, priority, decayHalfLifeDays,
                 source, createdAt, retiredAt
            FROM procedural_memory
@@ -147,7 +148,7 @@ export class ProceduralMemoryService {
            LIMIT $limit`,
         { limit: args.limit ?? 50 },
       );
-      return ((rows as any[]) ?? []).map(mapRow);
+      return rows.map(mapRow);
     });
   }
 
@@ -171,14 +172,14 @@ export class ProceduralMemoryService {
       const tail = procedureIdRaw.startsWith('procedural_memory:')
         ? procedureIdRaw.slice('procedural_memory:'.length)
         : procedureIdRaw;
-      const [rows] = await db.query<any[][]>(
+      const updated = await queryFirst<ProcedureRowDb>(
+        db,
         `UPDATE type::record('procedural_memory', $tail)
            SET retiredAt = time::now()
            WHERE retiredAt IS NONE
            RETURN AFTER`,
         { tail },
       );
-      const updated = (rows as any[])?.[0];
       if (!updated) {
         throw new NotFoundException(
           `Procedural memory ${procedureIdRaw} not found (or already retired)`,
@@ -192,7 +193,22 @@ export class ProceduralMemoryService {
   }
 }
 
-function mapRow(row: any): ProcedureRecord {
+// Columns the procedural_memory SELECTs return. Every value funnels
+// through String()/typeof/toIso in mapRow, so `unknown` is the honest
+// type; triggerEmbedding is present only on the match() SELECT.
+interface ProcedureRowDb {
+  id: unknown;
+  trigger?: unknown;
+  action?: unknown;
+  priority?: unknown;
+  decayHalfLifeDays?: unknown;
+  source?: unknown;
+  createdAt?: unknown;
+  retiredAt?: unknown;
+  triggerEmbedding?: unknown;
+}
+
+function mapRow(row: ProcedureRowDb): ProcedureRecord {
   return {
     procedureId: String(row.id),
     trigger: String(row.trigger ?? ''),

--- a/src/search/internals/edge-expansion.ts
+++ b/src/search/internals/edge-expansion.ts
@@ -41,7 +41,12 @@ export function selectEdgeExpansionSeeds(
  * Pure (mutates the map in place but no IO) — unit-testable.
  */
 export function mergeExpandedNeighbours<
-  T extends { entityId: string; rankScore: number; bestScore: number; facts: any[] },
+  T extends {
+    entityId: string;
+    rankScore: number;
+    bestScore: number;
+    facts: unknown[];
+  },
 >(
   byEntity: Map<string, T>,
   expansions: Array<{

--- a/src/search/internals/insight-leg.ts
+++ b/src/search/internals/insight-leg.ts
@@ -51,7 +51,7 @@ export interface InsightRow {
   score?: number;
   // Policy fields (audit 2026-08-19 P1): the insight lane's row filter
   // reads these — a projection without them judged rules over null.
-  source?: unknown;
+  source?: Record<string, unknown> | null;
   trustSnapshot?: {
     authority?: number;
     declaredTrust?: number;
@@ -85,6 +85,9 @@ function budgetText(text: string): string {
   return `${atWord.trimEnd()} […]`;
 }
 
+/** Synthetic source stamped on insight rows that carry none from the DB. */
+const INSIGHT_FALLBACK_SOURCE: Record<string, unknown> = { vertical: 'insight' };
+
 function toFactRow(r: InsightRow, kind: 'vector' | 'lexical'): FactRow {
   const valid = String(r.validFrom ?? '');
   return {
@@ -96,7 +99,7 @@ function toFactRow(r: InsightRow, kind: 'vector' | 'lexical'): FactRow {
     validFrom: valid,
     recordedAt: new Date().toISOString(),
     status: 'active',
-    source: r.source ?? { vertical: 'insight' },
+    source: r.source ?? INSIGHT_FALLBACK_SOURCE,
     ...(r.trustSnapshot !== undefined ? { trustSnapshot: r.trustSnapshot } : {}),
     ...(r.corroboration !== undefined ? { corroboration: r.corroboration } : {}),
     ...(r.userId !== undefined ? { userId: r.userId } : {}),

--- a/src/search/internals/types.ts
+++ b/src/search/internals/types.ts
@@ -4,6 +4,7 @@
  * (DB projection), so each stage can be typed precisely.
  */
 
+
 /**
  * Stage label identifying which retrieval leg surfaced a fact.
  * Carried end-to-end so DecisionLog can attribute each retrieved fact
@@ -42,7 +43,13 @@ export interface FactRow {
   recordedAt: string;
   retractedAt?: string;
   status: string;
-  source: any;
+  // The persisted fact `source` is an open, heterogeneous object: a
+  // FactSource core plus fields various write paths stamp on top
+  // (mentionedAt, scene, salience, originKey). Modelled as an open record
+  // (or null, for the insight/synthetic legs that carry no source);
+  // consumers read individual fields defensively (e.g. scoring reads
+  // `source?.evidence` via optional chaining).
+  source: Record<string, unknown> | null;
   // Hydrated via inline projection — entity record inlined.
   entity?: {
     id: unknown;

--- a/src/sources/sources.service.ts
+++ b/src/sources/sources.service.ts
@@ -1,14 +1,48 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { Surreal } from 'surrealdb';
-import { SurrealService } from '../db/surreal.service';
+import { SurrealService, queryRows, queryFirst } from '../db/surreal.service';
 import {
   SOURCE_TYPES,
   type DeclaredSource,
   type DeclareSourceRequest,
   type SourceDetailResponse,
   type SourceSummary,
+  type SourceType,
   type TrustScopeRow,
 } from '../contracts/sources/sources.schema';
+
+/**
+ * source_registry row (columns the mappers read). Date columns are
+ * `string | Date` because the SDK hands datetimes back as Date; the scalar
+ * columns funnel through Number()/String().
+ */
+interface DeclaredRow {
+  sourceKey: unknown;
+  type: SourceType;
+  authLevel: unknown;
+  owner?: string | null;
+  note?: string | null;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+}
+
+/** source_trust row (one learned reputation scope). */
+interface TrustRow {
+  domain?: string | null;
+  agreementRate: unknown;
+  sampleCount: unknown;
+  winCount?: unknown;
+  lossCount?: unknown;
+  lastSeenAt?: string | Date | null;
+}
+
+/** source_trust_history row (reputation-over-time trail). */
+interface HistoryRow {
+  domain?: string | null;
+  agreementRate: unknown;
+  sampleCount: unknown;
+  recordedAt: string | Date;
+}
 
 /**
  * Per-tenant source identity + reputation reads (source-reputation track,
@@ -33,10 +67,12 @@ export class SourcesService {
     opts?: { domain?: string },
   ): Promise<SourceSummary[]> {
     return this.surreal.withCompany(companyId, async (db) => {
-      const [declaredRows] = await db.query<[any[]]>(
+      const declaredRows = await queryRows<DeclaredRow>(
+        db,
         `SELECT * FROM source_registry ORDER BY sourceKey`,
       );
-      const [trustRows] = await db.query<[any[]]>(
+      const trustRows = await queryRows<TrustRow & { sourceKey: unknown }>(
+        db,
         `SELECT sourceKey, domain, agreementRate, sampleCount, winCount,
                 lossCount, lastSeenAt
            FROM source_trust ORDER BY sourceKey`,
@@ -56,10 +92,10 @@ export class SourcesService {
         return fresh;
       };
 
-      for (const r of (declaredRows as any[]) ?? []) {
+      for (const r of declaredRows) {
         summaryOf(String(r.sourceKey)).declared = mapDeclared(r);
       }
-      for (const r of (trustRows as any[]) ?? []) {
+      for (const r of trustRows) {
         const summary = summaryOf(String(r.sourceKey));
         if (r.domain === undefined || r.domain === null) {
           summary.globalTrust = mapTrustScope(r);
@@ -79,25 +115,27 @@ export class SourcesService {
   ): Promise<SourceDetailResponse> {
     return this.surreal.withCompany(companyId, async (db) => {
       const declared = await this.declaredOf(db, sourceKey);
-      const [trustRows] = await db.query<[any[]]>(
+      const trustRows = await queryRows<TrustRow>(
+        db,
         `SELECT domain, agreementRate, sampleCount, winCount, lossCount, lastSeenAt
            FROM source_trust WHERE sourceKey = $k`,
         { k: sourceKey },
       );
-      const [historyRows] = await db.query<[any[]]>(
+      const historyRows = await queryRows<HistoryRow>(
+        db,
         `SELECT domain, agreementRate, sampleCount, recordedAt
            FROM source_trust_history WHERE sourceKey = $k
            ORDER BY recordedAt DESC LIMIT 100`,
         { k: sourceKey },
       );
-      const trust = ((trustRows as any[]) ?? [])
+      const trust = trustRows
         .map(mapTrustScope)
         .sort(byGlobalFirstThenDomain);
       return {
         sourceKey,
         declared,
         trust,
-        history: ((historyRows as any[]) ?? []).map((r) => ({
+        history: historyRows.map((r) => ({
           domain: r.domain ?? null,
           agreementRate: Number(r.agreementRate),
           sampleCount: Number(r.sampleCount),
@@ -175,16 +213,16 @@ export class SourcesService {
     db: Surreal,
     sourceKey: string,
   ): Promise<DeclaredSource | null> {
-    const [rows] = await db.query<[any[]]>(
+    const row = await queryFirst<DeclaredRow>(
+      db,
       `SELECT * FROM source_registry WHERE sourceKey = $k LIMIT 1`,
       { k: sourceKey },
     );
-    const row = ((rows as any[]) ?? [])[0];
     return row ? mapDeclared(row) : null;
   }
 }
 
-function mapDeclared(r: any): DeclaredSource {
+function mapDeclared(r: DeclaredRow): DeclaredSource {
   return {
     sourceKey: String(r.sourceKey),
     type: r.type,
@@ -196,7 +234,7 @@ function mapDeclared(r: any): DeclaredSource {
   };
 }
 
-function mapTrustScope(r: any): TrustScopeRow {
+function mapTrustScope(r: TrustRow): TrustScopeRow {
   return {
     domain: r.domain ?? null,
     agreementRate: Number(r.agreementRate),

--- a/test/insight-lane.unit-spec.ts
+++ b/test/insight-lane.unit-spec.ts
@@ -64,7 +64,7 @@ describe('runInsightLegs', () => {
     expect(vectorRows[0]!.predicate).toBe('aggregate_hobbies');
     expect(vectorRows[0]!.simScore).toBe(0.9);
     expect(lexicalRows[0]!.bm25Score).toBe(3.2);
-    expect(vectorRows[0]!.source.vertical).toBe('insight');
+    expect(vectorRows[0]!.source!.vertical).toBe('insight');
     for (const q of queries) {
       // The pool filter — aggregates by recorder, summaries by prefix.
       expect(q.sql).toContain('source.recorder = $insightRecorder');


### PR DESCRIPTION
## Summary

Closes the largest deferred item: `@typescript-eslint/no-explicit-any` was `off`. **All 421 violations in src/ eliminated** (~213 `as any` + ~73 `: any` + `any[]`/`db.query<any[]>` generics across ~66 files → 0) and the rule flipped to **error**. A real typing campaign, not silenced lint — **zero remaining disables, zero `@ts-ignore`, zero new `as unknown as` laundering**.

**Architectural wins (not per-site patching):**
- `queryRows<T>` / `queryFirst<T>` in `surreal.service.ts` — replaced the ~107 `(await db.query(...)) as any` / `(rows as any[]) ?? []` SurrealDB idioms with typed calls + a minimal row interface per site (real selected columns). Multi-statement batches use typed tuples `db.query<[ARow[], BRow[]]>()`.
- `asStructuredContent()` in `src/mcp/structured.ts` — one named, documented home for the safe typed-object → `Record<string,unknown>` coercion MCP's `structuredContent` needs (~30 sites).
- `unknown` + narrowing for genuinely-dynamic values (LLM JSON, changefeed payloads); reused existing domain types elsewhere and dropped redundant casts.

**Tests exempt from the rule** (via the existing test-override block, documented) — mock/fixture `any` is low-value churn; src is the real code and it's now `any`-free.

## Tests

typecheck clean; `pnpm lint:ci` (`--max-warnings 0`, no-explicit-any=error) exit 0; full unit suite **263 suites / 2293 tests green** — the typed row interfaces changed no runtime behavior (tests corroborate the shapes; zero row-shape bugs surfaced). 71 files, +1462/−623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB