### PR TITLE
chore(ci): coverage ratchet floor on the unit suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,15 @@ jobs:
       # conflict-explainer, chat-router gates, …). These were defined in
       # package.json but never wired into CI, so a regression in any of
       # them shipped green. Now a hard gate on every PR.
-      - name: Unit tests
-        run: pnpm test:unit
+      # --coverage activates the coverageThreshold floor in jest-unit.json
+      # (an all-src ratchet: statements/lines 52%, branches 40%, functions
+      # 45% — a few points under the current ~57/45/50/58 to prevent
+      # backslide without brittleness; the threshold is inert without
+      # --coverage, so local `pnpm test:unit` stays fast). Unit-only
+      # coverage — the e2e suite carries additional real path coverage
+      # that isn't collected here.
+      - name: Unit tests (+ coverage ratchet)
+        run: pnpm test:unit -- --coverage
 
       # Socket suite: the 6 specs that bind real loopback HTTP servers
       # (.listen(0, '127.0.0.1')) live behind their own *.socket-spec.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       # coverage — the e2e suite carries additional real path coverage
       # that isn't collected here.
       - name: Unit tests (+ coverage ratchet)
-        run: pnpm test:unit -- --coverage
+        run: pnpm test:unit:cov
 
       # Socket suite: the 6 specs that bind real loopback HTTP servers
       # (.listen(0, '127.0.0.1')) live behind their own *.socket-spec.ts

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:ci": "eslint \"{src,test}/**/*.ts\" --max-warnings 0",
     "test": "jest --config ./test/jest-unit.json",
     "test:unit": "jest --config ./test/jest-unit.json",
+    "test:unit:cov": "jest --config ./test/jest-unit.json --coverage",
     "test:socket": "jest --config ./test/jest-socket.json",
     "test:watch": "jest --config ./test/jest-unit.json --watch",
     "test:e2e": "jest --config ./test/jest-e2e.json",

--- a/test/jest-unit.json
+++ b/test/jest-unit.json
@@ -14,5 +14,22 @@
   "testTimeout": 30000,
   "moduleNameMapper": {
     "^@/(.*)$": "<rootDir>/src/$1"
+  },
+  "collectCoverageFrom": [
+    "src/**/*.ts",
+    "!src/**/*.worker.ts",
+    "!src/main.ts",
+    "!src/**/*.module.ts",
+    "!src/**/dto/*.ts",
+    "!src/db/migrations/**",
+    "!src/**/*.d.ts"
+  ],
+  "coverageThreshold": {
+    "global": {
+      "statements": 52,
+      "branches": 40,
+      "functions": 45,
+      "lines": 52
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds an all-src unit-coverage floor to prevent backslide — the last of the audit's coverage gap, done as a genuine ratchet rather than skipped.

- `jest-unit.json`: `collectCoverageFrom` over `src/**` (excluding workers / main / `*.module.ts` / DTOs / migrations — none unit-testable) + a global `coverageThreshold`: **statements/lines 52%, branches 40%, functions 45%** — a few points under the measured current (~57.2 / 44.7 / 49.9 / 57.8) so normal fluctuation doesn't break CI while a real regression (deleted tests) trips it.
- `ci.yml`: the unit step now passes `--coverage` to activate the threshold. The threshold is **inert without `--coverage`**, so local `pnpm test:unit` stays fast.

Honest scope: this is unit-only coverage — the 90-spec e2e suite carries additional real path coverage that isn't collected here. The floor is a backslide guard, not an aspirational target (documented in the config comment).

Verified: `pnpm test:unit -- --coverage` exits 0 (threshold met with headroom), 263 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB