### PR TITLE
chore(types): enable exactOptionalPropertyTypes

### DIFF
--- a/src/admin/admin-aggregates.controller.ts
+++ b/src/admin/admin-aggregates.controller.ts
@@ -61,7 +61,7 @@ export class AdminAggregatesController {
   private validate(
     req: AuthenticatedRequest,
     body: { tenant?: string; version?: string },
-  ): { tenant: string; version?: string } {
+  ): { tenant: string; version?: string | undefined } {
     const tenant = body.tenant?.trim() || req.brainAuth.companyId;
     if (
       tenant !== req.brainAuth.companyId &&

--- a/src/admin/admin-jobs.controller.ts
+++ b/src/admin/admin-jobs.controller.ts
@@ -105,15 +105,20 @@ export class AdminJobsController {
     @Query('limit') limit?: string,
   ): Promise<JobsListResponse> {
     const parsedLimit = limit ? parseInt(limit, 10) : undefined;
+    const jobTypeVal = (jobType?.trim() as JobType) || undefined;
+    const statusVal = (status?.trim() as JobStatus) || undefined;
+    const sinceVal = since?.trim() || undefined;
+    const companyIdVal = companyId?.trim() || undefined;
+    const limitVal =
+      parsedLimit !== undefined && Number.isFinite(parsedLimit)
+        ? parsedLimit
+        : undefined;
     const rows = await this.jobs.list({
-      jobType: (jobType?.trim() as JobType) || undefined,
-      status: (status?.trim() as JobStatus) || undefined,
-      since: since?.trim() || undefined,
-      companyId: companyId?.trim() || undefined,
-      limit:
-        parsedLimit !== undefined && Number.isFinite(parsedLimit)
-          ? parsedLimit
-          : undefined,
+      ...(jobTypeVal !== undefined ? { jobType: jobTypeVal } : {}),
+      ...(statusVal !== undefined ? { status: statusVal } : {}),
+      ...(sinceVal !== undefined ? { since: sinceVal } : {}),
+      ...(companyIdVal !== undefined ? { companyId: companyIdVal } : {}),
+      ...(limitVal !== undefined ? { limit: limitVal } : {}),
     });
     return { jobs: rows } satisfies JobsListResponse;
   }
@@ -355,10 +360,11 @@ export class AdminJobsController {
     });
     void (async () => {
       try {
+        const reindexTenant = body.tenant?.trim() || undefined;
         const result = await this.reindex.run({
-          tenant: body.tenant?.trim() || undefined,
+          ...(reindexTenant !== undefined ? { tenant: reindexTenant } : {}),
           dryRun: body.dryRun === true,
-          maxFacts: body.maxFacts ?? undefined,
+          ...(body.maxFacts !== undefined ? { maxFacts: body.maxFacts } : {}),
         });
         await this.jobs.finish(row, {
           status: 'succeeded',

--- a/src/admin/admin-policy-decisions.controller.ts
+++ b/src/admin/admin-policy-decisions.controller.ts
@@ -31,12 +31,15 @@ export class AdminPolicyDecisionsController {
       before?: string;
     },
   ): Promise<PolicyDecisionsResponse> {
+    const parsedLimit = q.limit ? parseInt(q.limit, 10) : undefined;
     return (await this.decisions.feed(req.brainAuth.companyId, {
       ...(q.policySet ? { policySet: q.policySet } : {}),
       ...(q.decision ? { decision: q.decision } : {}),
       ...(q.kind ? { kind: q.kind } : {}),
       ...(q.action ? { action: q.action } : {}),
-      ...(q.limit ? { limit: parseInt(q.limit, 10) || undefined } : {}),
+      ...(parsedLimit !== undefined && Number.isFinite(parsedLimit)
+        ? { limit: parsedLimit }
+        : {}),
       ...(q.before ? { before: q.before } : {}),
     })) satisfies PolicyDecisionsResponse;
   }

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -175,13 +175,15 @@ export class AdminController {
     @Query('maxFacts') maxFacts?: string,
   ): Promise<ReindexRunResponse> {
     const parsedMaxFacts = maxFacts ? parseInt(maxFacts, 10) : undefined;
+    const reindexTenant = tenant?.trim() || undefined;
+    const reindexMaxFacts =
+      parsedMaxFacts !== undefined && Number.isFinite(parsedMaxFacts)
+        ? parsedMaxFacts
+        : undefined;
     return (await this.reindex.run({
-      tenant: tenant?.trim() || undefined,
+      ...(reindexTenant !== undefined ? { tenant: reindexTenant } : {}),
       dryRun: dryRun === 'true',
-      maxFacts:
-        parsedMaxFacts !== undefined && Number.isFinite(parsedMaxFacts)
-          ? parsedMaxFacts
-          : undefined,
+      ...(reindexMaxFacts !== undefined ? { maxFacts: reindexMaxFacts } : {}),
     })) satisfies ReindexRunResponse;
   }
 

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -77,12 +77,12 @@ export interface AuditEventRow {
 }
 
 export interface AuditQuery {
-  companyId?: string;
-  source?: string;
-  op?: string;
-  since?: string;
-  before?: string;
-  limit?: number;
+  companyId?: string | undefined;
+  source?: string | undefined;
+  op?: string | undefined;
+  since?: string | undefined;
+  before?: string | undefined;
+  limit?: number | undefined;
 }
 
 export interface CostBucket {
@@ -440,9 +440,9 @@ export class AdminService {
    * page; the overview already shows last 20.
    */
   async listDeadLetter(filter: {
-    companyId?: string;
-    reason?: string;
-    limit?: number;
+    companyId?: string | undefined;
+    reason?: string | undefined;
+    limit?: number | undefined;
   }): Promise<AdminDeadLetterRow[]> {
     const tenants = filter.companyId
       ? [filter.companyId]
@@ -516,10 +516,10 @@ export class AdminService {
    * page; also drives the GDPR export endpoint.
    */
   async listForgotten(filter: {
-    companyId?: string;
-    reason?: string;
-    since?: string;
-    limit?: number;
+    companyId?: string | undefined;
+    reason?: string | undefined;
+    since?: string | undefined;
+    limit?: number | undefined;
   }): Promise<AdminForgottenRow[]> {
     const tenants = filter.companyId
       ? [filter.companyId]

--- a/src/admin/aggregate-composer.service.ts
+++ b/src/admin/aggregate-composer.service.ts
@@ -121,7 +121,7 @@ export class AggregateComposerService {
    */
   async run(
     companyId: string,
-    opts: { entities?: number; version?: string } = {},
+    opts: { entities?: number | undefined; version?: string | undefined } = {},
   ): Promise<AggregateRunResult> {
     const r = await runInsightComposer(
       { surreal: this.surreal, embedding: this.embedding, logger: this.logger },

--- a/src/admin/arc-composer.service.ts
+++ b/src/admin/arc-composer.service.ts
@@ -158,7 +158,7 @@ export class ArcComposerService {
    */
   async run(
     companyId: string,
-    opts: { entities?: number; version?: string } = {},
+    opts: { entities?: number | undefined; version?: string | undefined } = {},
   ): Promise<ArcRunResult> {
     const r = await runInsightComposer(
       { surreal: this.surreal, embedding: this.embedding, logger: this.logger },

--- a/src/admin/chat-router-internals/types.ts
+++ b/src/admin/chat-router-internals/types.ts
@@ -55,11 +55,19 @@ export interface ChatRoute {
 
 export interface ValidationReport {
   acceptedEdits: number;
-  droppedEdits: Array<{ op: string; reason: string; span?: Span }>;
+  droppedEdits: Array<{ op: string; reason: string; span?: Span | undefined }>;
   acceptedMentions: number;
-  droppedMentions: Array<{ canonical?: string; reason: string; span?: Span }>;
+  droppedMentions: Array<{
+    canonical?: string | undefined;
+    reason: string;
+    span?: Span | undefined;
+  }>;
   acceptedHints: number;
-  droppedHints: Array<{ predicateId?: string; reason: string; span?: Span }>;
+  droppedHints: Array<{
+    predicateId?: string | undefined;
+    reason: string;
+    span?: Span | undefined;
+  }>;
   asOfStatus: 'grounded' | 'ungrounded' | 'absent';
   validFromStatus: 'grounded' | 'ungrounded' | 'absent';
 }

--- a/src/admin/chat-router-internals/validator.ts
+++ b/src/admin/chat-router-internals/validator.ts
@@ -317,7 +317,7 @@ function collectTemporalAnchors({
   message: string;
   normalizedInput: string;
   report: ValidationReport;
-}): { asOf?: TemporalAnchor; validFrom?: TemporalAnchor } {
+}): { asOf?: TemporalAnchor | undefined; validFrom?: TemporalAnchor | undefined } {
   let asOf: TemporalAnchor | undefined;
   if (parsed.intent === 'ask' && parsed.asOf) {
     const span = validateSpan(message, normalizedInput, parsed.asOf.anchorSpan);

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -36,9 +36,9 @@ export interface ConfigEntry {
   /** Whether the knob is a true boolean ("0"|"1" / "true"|"false") so the UI can render a toggle. */
   isBooleanFlag: boolean;
   /** Hint for the operator. Tiny, not a full doc. */
-  description?: string;
+  description?: string | undefined;
   /** Whether the current value exposes a secret (API key, etc) — masked in the UI. */
-  secret?: boolean;
+  secret?: boolean | undefined;
 }
 
 /**

--- a/src/admin/demo-pipeline.service.ts
+++ b/src/admin/demo-pipeline.service.ts
@@ -27,7 +27,7 @@ export class DemoPipelineService {
 
   async ingestMention(
     tenant: string,
-    body: { text: string; vertical?: string },
+    body: { text: string; vertical?: string | undefined },
   ) {
     return this.ingest.ingestMention(tenant, {
       text: body.text,
@@ -38,12 +38,20 @@ export class DemoPipelineService {
 
   async runSearch(
     tenant: string,
-    body: { query: string; limit?: number; asOf?: string },
+    body: {
+      query: string;
+      limit?: number | undefined;
+      asOf?: string | undefined;
+    },
     scopes: readonly BrainScope[],
   ) {
     return this.search.search(
       tenant,
-      { query: body.query, limit: body.limit ?? 5, asOf: body.asOf },
+      {
+        query: body.query,
+        limit: body.limit ?? 5,
+        ...(body.asOf !== undefined ? { asOf: body.asOf } : {}),
+      },
       [...scopes],
     );
   }
@@ -137,7 +145,7 @@ export class DemoPipelineService {
     });
     const search = await this.search.search(
       tenant,
-      { query: queryText, limit: 5, asOf },
+      { query: queryText, limit: 5, ...(asOf !== undefined ? { asOf } : {}) },
       [...scopes],
     );
     return {

--- a/src/admin/derive-row-builder.ts
+++ b/src/admin/derive-row-builder.ts
@@ -14,6 +14,24 @@ import type { EpisodeRow } from '../episodes/session-window';
  * functions of (propositions, session, namespace) — no service state.
  */
 
+/**
+ * exactOptionalPropertyTypes-safe scope fields: present only when defined.
+ * Downstream resolveAppendOnlyBatch (fact-resolver) already treats an absent
+ * key identically to an explicit undefined value (`if (c.lang !== undefined)
+ * f.lang = c.lang`, same for script/userId), so omitting is behavior-neutral.
+ */
+function derivedScopeFields(
+  lang: string | undefined,
+  script: string | undefined,
+  userId: string | undefined,
+): { lang?: string; script?: string; userId?: string } {
+  return {
+    ...(lang !== undefined ? { lang } : {}),
+    ...(script !== undefined ? { script } : {}),
+    ...(userId !== undefined ? { userId } : {}),
+  };
+}
+
 /** Row construction for one session's resolved propositions. */
 export function buildDerivedRows({
   resolved,
@@ -144,16 +162,14 @@ export function buildDerivedRows({
       // Multiworld §10: on-contract kinds only (off-enum → untyped).
       ...typedAtomKind(p),
     };
+    const scopeUserId = scopeUsers.length === 1 ? scopeUsers[0] : undefined;
     return {
-      userId: scopeUsers.length === 1 ? scopeUsers[0] : undefined,
       crossUserScope: scopeUsers.length > 1,
       groundingInvalid,
       entityId: subjectEntity,
       predicate: aspect || 'other',
       object: p.proposition,
       confidence: 0.85,
-      lang,
-      script,
       validFrom,
       source,
       sourceTrust: sourceTrustFor({
@@ -162,6 +178,7 @@ export function buildDerivedRows({
       }),
       embedding: vectors[i]!, // vectors is 1:1 with resolved ⇒ in-bounds
       derivedVersion: ns.staging,
+      ...derivedScopeFields(lang, script, scopeUserId),
     };
   });
 }

--- a/src/admin/derive-staging.ts
+++ b/src/admin/derive-staging.ts
@@ -135,7 +135,7 @@ type LeaseLogger = { warn(message: string): void };
 export async function acquireDeriveLease(args: {
   companyId: string;
   version: string;
-  lease?: LeaderLeaseService;
+  lease?: LeaderLeaseService | undefined;
   logger: LeaseLogger;
 }): Promise<DeriveLease> {
   const { companyId, version, lease, logger } = args;
@@ -293,7 +293,7 @@ export async function sweepStagingOrphans(
 export async function promoteStaging(
   db: DeriveDb,
   ns: DeriveNamespace,
-  opts: { conversationId?: string } = {},
+  opts: { conversationId?: string | undefined } = {},
 ): Promise<void> {
   const conv = opts.conversationId;
   // Audit 2026-08-21: facts and digests flip in ONE transaction — the

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -154,7 +154,10 @@ export class DomainPackInstallService {
   async install(
     companyId: string,
     manifest: DomainPackManifest,
-    opts: { expectedChecksum?: string; acceptMcpTools?: boolean } = {},
+    opts: {
+      expectedChecksum?: string | undefined;
+      acceptMcpTools?: boolean | undefined;
+    } = {},
   ): Promise<{
     packId: string;
     version: string;
@@ -328,7 +331,7 @@ export class DomainPackInstallService {
     newIds: string[];
     mint: {
       wantsWebhook: boolean;
-      mintedInstallId?: string;
+      mintedInstallId?: string | undefined;
       mcpChecksum: string | null;
       mcpSet: string;
     };

--- a/src/admin/insight-composer-kernel.ts
+++ b/src/admin/insight-composer-kernel.ts
@@ -70,7 +70,7 @@ export interface InsightComposerSpec<P> {
       entityId: StringRecordId;
       facts: FactRowLite[];
       vector: number[];
-      version?: string;
+      version?: string | undefined;
     },
   ): Record<string, unknown>;
 }
@@ -100,7 +100,11 @@ type QueryDb = {
 export async function runInsightComposer<P>(
   deps: KernelDeps,
   spec: InsightComposerSpec<P>,
-  opts: { companyId: string; entities?: number; version?: string },
+  opts: {
+    companyId: string;
+    entities?: number | undefined;
+    version?: string | undefined;
+  },
 ): Promise<ComposerRunResult> {
   const { companyId } = opts;
   const entityCap = Math.min(Math.max(opts.entities ?? 12, 1), 50);
@@ -146,7 +150,7 @@ async function composeEntity<P>(
   ctx: {
     spec: InsightComposerSpec<P>;
     entityId: string;
-    version?: string;
+    version?: string | undefined;
     versionClause: string;
   },
 ): Promise<number> {

--- a/src/admin/operator-action.service.ts
+++ b/src/admin/operator-action.service.ts
@@ -56,10 +56,10 @@ export class OperatorActionService {
   }
 
   async list(filter: {
-    actor?: string;
-    pathPrefix?: string;
-    since?: string;
-    limit?: number;
+    actor?: string | undefined;
+    pathPrefix?: string | undefined;
+    since?: string | undefined;
+    limit?: number | undefined;
   }): Promise<OperatorActionRow[]> {
     if (!this.surreal || !this.apiKeys) return [];
     const tenants = filter.actor

--- a/src/admin/pack-eval.service.ts
+++ b/src/admin/pack-eval.service.ts
@@ -68,7 +68,9 @@ export class PackEvalService {
               text: fixture.text,
               companyId,
               packId: manifest.id,
-              options: manifest.indexer?.dedicated,
+              ...(manifest.indexer?.dedicated !== undefined
+                ? { options: manifest.indexer.dedicated }
+                : {}),
             })
           : await this.extractor.extract(fixture.text, companyId);
       results.push(scoreFixture(manifest.id, fixture, extraction));

--- a/src/admin/scenario-eval.service.ts
+++ b/src/admin/scenario-eval.service.ts
@@ -46,7 +46,7 @@ export class ScenarioEvalService {
           {
             query: expectation.query,
             limit: 10,
-            asOf: expectation.asOf,
+            ...(expectation.asOf !== undefined ? { asOf: expectation.asOf } : {}),
             ...(expectation.predicates ? { predicates: expectation.predicates } : {}),
           },
           callerScopes,
@@ -58,10 +58,10 @@ export class ScenarioEvalService {
         totalMs: captured.trace.totalMs,
         spans: captured.trace.spans.map((s) => ({
           id: s.id,
-          parentId: s.parentId,
           name: s.name,
           startedAt: s.startedAt,
-          durationMs: s.durationMs,
+          ...(s.parentId !== undefined ? { parentId: s.parentId } : {}),
+          ...(s.durationMs !== undefined ? { durationMs: s.durationMs } : {}),
           ...(s.error ? { error: s.error } : {}),
         })),
       };
@@ -110,7 +110,7 @@ export class ScenarioEvalService {
       rankOfExpected,
       topEntityRef,
       factPredicateMatched,
-      asOf: expectation.asOf,
+      ...(expectation.asOf !== undefined ? { asOf: expectation.asOf } : {}),
       durationMs: Date.now() - t0,
       hitCount: hits.length,
       topHits: hits.slice(0, 3).map((h) => ({
@@ -155,7 +155,7 @@ export class ScenarioEvalService {
       description: a.description,
       kind: a.kind,
       passed,
-      detail,
+      ...(detail !== undefined ? { detail } : {}),
       durationMs: Date.now() - t0,
     });
 
@@ -169,7 +169,7 @@ export class ScenarioEvalService {
         {
           query: a.query,
           limit: 20,
-          asOf: a.asOf,
+          ...(a.asOf !== undefined ? { asOf: a.asOf } : {}),
           includeRetracted: a.includeRetracted ?? false,
         },
         ['brain:read', 'brain:read_pii'],

--- a/src/admin/scenario-runner.service.ts
+++ b/src/admin/scenario-runner.service.ts
@@ -147,7 +147,7 @@ export class ScenarioRunnerService {
         setupSummary,
         queryResults,
         memoryAssertionResults,
-        identityMergeResult,
+        ...(identityMergeResult !== undefined ? { identityMergeResult } : {}),
         ...(scenario.synthesizeQueries?.length
           ? {
               synthesizeSkipped: {

--- a/src/admin/scenario-write.service.ts
+++ b/src/admin/scenario-write.service.ts
@@ -24,8 +24,8 @@ export class ScenarioWriteService {
       predicate: step.predicate,
       object: step.object,
       validFrom: step.validFrom,
-      validUntil: step.validUntil,
-      confidence: step.confidence,
+      ...(step.validUntil !== undefined ? { validUntil: step.validUntil } : {}),
+      ...(step.confidence !== undefined ? { confidence: step.confidence } : {}),
       source: step.source,
     });
     return res.factId ?? null;
@@ -35,7 +35,9 @@ export class ScenarioWriteService {
     await this.ingest.ingestMention(companyId, {
       text: step.text,
       contextRef: step.contextRef,
-      knownEntities: step.knownEntities,
+      ...(step.knownEntities !== undefined
+        ? { knownEntities: step.knownEntities }
+        : {}),
       emittedAt: step.emittedAt,
     });
   }

--- a/src/admin/window-deriver.service.ts
+++ b/src/admin/window-deriver.service.ts
@@ -159,7 +159,7 @@ export class WindowDeriverService {
     companyId: string,
     opts: {
       version?: string;
-      conversationId?: string;
+      conversationId?: string | undefined;
       activate?: boolean;
       force?: boolean;
     } = {},
@@ -218,7 +218,7 @@ export class WindowDeriverService {
     companyId: string;
     version: string;
     ns: DeriveNamespace;
-    opts: { conversationId?: string; activate?: boolean };
+    opts: { conversationId?: string | undefined; activate?: boolean };
     activePin: string | undefined;
     /** Promotion fence (audit 2026-08-21): checked before the flip. */
     lease: DeriveLease;

--- a/src/agent-qa/agent-qa.service.ts
+++ b/src/agent-qa/agent-qa.service.ts
@@ -141,7 +141,7 @@ export interface AgentQaInput {
   companyId: string;
   question: string;
   callerScopes: string[];
-  asOf?: string;
+  asOf?: string | undefined;
 }
 
 export interface AgentQaResult {
@@ -351,7 +351,7 @@ export class AgentQaService {
     input: AgentQaInput;
     name: string;
     query: string;
-    mask?: Set<string>;
+    mask?: Set<string> | undefined;
   }): Promise<string> {
     if (name === 'timeline') return this.runTimeline(input, query);
     if (name === 'grep_episodes') return this.runGrep(input, query);

--- a/src/ai/calibration/calibration-refit-job.service.ts
+++ b/src/ai/calibration/calibration-refit-job.service.ts
@@ -14,7 +14,7 @@ export interface RunTrackedOptions {
   jobType: JobType;
   /** DistributedLeaseGuard key — distinct from jobType. */
   guardKey: string;
-  trigger?: RefitTrigger;
+  trigger?: RefitTrigger | undefined;
   /** The actual refit, given a per-tenant progress callback. */
   fn: (onProgress: RefitProgress) => Promise<RefitOutcome>;
 }
@@ -58,7 +58,9 @@ export class CalibrationRefitJobService {
           jobType: opts.jobType,
           companyId: hostTenant,
           triggeredBy: opts.trigger?.triggeredBy ?? 'cron',
-          triggeredByActor: opts.trigger?.triggeredByActor,
+          ...(opts.trigger?.triggeredByActor !== undefined
+            ? { triggeredByActor: opts.trigger.triggeredByActor }
+            : {}),
         });
       } catch (e) {
         this.logger.warn(

--- a/src/ai/calibration/calibration-refit-runner.service.ts
+++ b/src/ai/calibration/calibration-refit-runner.service.ts
@@ -119,7 +119,7 @@ export class CalibrationRefitRunnerService {
       version: number;
       sampleCount: number;
       bins: number;
-      createdAt?: string;
+      createdAt?: string | undefined;
     }>
   > {
     const tenants = this.apiKeys.knownCompanyIds();

--- a/src/ai/extractor-cache.service.ts
+++ b/src/ai/extractor-cache.service.ts
@@ -55,9 +55,9 @@ export class ExtractorCacheService {
     text: string;
     companyId: string;
     predicateVocabHash: string;
-    scPasses?: number;
-    speaker?: string;
-    addressee?: string;
+    scPasses?: number | undefined;
+    speaker?: string | undefined;
+    addressee?: string | undefined;
   }): string {
     // scPasses is part of the key: a single-pass cached result lacks the
     // semantic-entropy fields a >1-pass run produces, so serving it after

--- a/src/ai/extractor-internals/edge-validator.ts
+++ b/src/ai/extractor-internals/edge-validator.ts
@@ -14,10 +14,10 @@ export function validateEdges(
   clauses: string[],
 ): {
   edges: ExtractedEdge[];
-  dropped: Array<{ kind?: string; reason: string }>;
+  dropped: Array<{ kind?: string | undefined; reason: string }>;
 } {
   const edges: ExtractedEdge[] = [];
-  const dropped: Array<{ kind?: string; reason: string }> = [];
+  const dropped: Array<{ kind?: string | undefined; reason: string }> = [];
   const rawEdges =
     typeof parsed === 'object' && parsed !== null
       ? (parsed as Record<string, unknown>).edges

--- a/src/ai/extractor-internals/semantic-entropy.ts
+++ b/src/ai/extractor-internals/semantic-entropy.ts
@@ -32,7 +32,7 @@ export interface PassFact {
    * person's pass as agreement. Optional so single-entity callers and
    * older fixtures keep working.
    */
-  entity?: string | number;
+  entity?: string | number | undefined;
 }
 
 /**

--- a/src/ai/extractor-internals/types.ts
+++ b/src/ai/extractor-internals/types.ts
@@ -14,7 +14,7 @@ export interface ExtractedEntity {
     | 'location'
     | 'other';
   /** Optional canonical clue ("Apple Inc.", "Acme Corp"). */
-  canonical?: string;
+  canonical?: string | undefined;
 }
 
 export interface ExtractedFact {
@@ -32,7 +32,7 @@ export interface ExtractedFact {
   object: string;
   confidence: number;
   /** The clause this fact was anchored to (verbatim sub-span). */
-  clause?: string;
+  clause?: string | undefined;
   /**
    * The verbatim grounded span the object was derived from. Equal to
    * `object` unless object normalization rewrote the stored value

--- a/src/ai/extractor-llm.service.ts
+++ b/src/ai/extractor-llm.service.ts
@@ -111,15 +111,15 @@ export class ExtractorLlmService {
   async callLlm(args: {
     trimmed: string;
     systemPrompt: string;
-    temperature?: number;
-    model?: string;
+    temperature?: number | undefined;
+    model?: string | undefined;
     /**
      * Per-turn speaker framing prepended to the user message (see
      * buildConversationContext). Grounding still runs against `trimmed`
      * alone, so the prefix drives coreference without polluting valueSpan
      * containment. Empty/absent → byte-identical to the pre-coreference call.
      */
-    contextPrefix?: string;
+    contextPrefix?: string | undefined;
   }): Promise<unknown> {
     const { trimmed, systemPrompt } = args;
     const temperature = args.temperature ?? 0.1;

--- a/src/ai/extractor-runner.service.ts
+++ b/src/ai/extractor-runner.service.ts
@@ -88,8 +88,8 @@ export class ExtractorRunnerService {
     trimmed: string;
     companyId: string;
     snapshot: Snapshot;
-    overrides?: RunOverrides;
-    context?: ConversationContext;
+    overrides?: RunOverrides | undefined;
+    context?: ConversationContext | undefined;
   }): Promise<ExtractionResult | null> {
     const { trimmed, companyId, snapshot, overrides, context } = args;
     const systemPrompt = this.llm.composeSystemPrompt(snapshot);
@@ -159,9 +159,9 @@ export class ExtractorRunnerService {
     trimmed: string;
     snapshot: Snapshot;
     systemPrompt: string;
-    contextPrefix?: string;
-    context?: ConversationContext;
-    overrides?: RunOverrides;
+    contextPrefix?: string | undefined;
+    context?: ConversationContext | undefined;
+    overrides?: RunOverrides | undefined;
   }): Promise<ExtractionResult | null> {
     const N = args.overrides?.scPasses ?? this.llm.scPasses;
     // Even temperature spread across [0.1, 0.7].
@@ -240,9 +240,9 @@ export class ExtractorRunnerService {
     snapshot: Snapshot;
     systemPrompt: string;
     facets: Facet[];
-    contextPrefix?: string;
-    context?: ConversationContext;
-    overrides?: RunOverrides;
+    contextPrefix?: string | undefined;
+    context?: ConversationContext | undefined;
+    overrides?: RunOverrides | undefined;
   }): Promise<ExtractionResult | null> {
     const prompts = [
       args.systemPrompt,
@@ -302,7 +302,7 @@ export class ExtractorRunnerService {
     trimmed: string;
     snapshot: Snapshot;
     rawJson: unknown;
-    context?: ConversationContext;
+    context?: ConversationContext | undefined;
   }): Promise<ExtractionResult> {
     const { companyId, trimmed, snapshot, rawJson, context } = args;
 

--- a/src/answer-cache/answer-cache.service.ts
+++ b/src/answer-cache/answer-cache.service.ts
@@ -103,7 +103,7 @@ export function canonicalDerivedPin(pin: ReadPin): string {
 export interface AnswerCacheKeyInput {
   companyId: string;
   /** Pinned end-user scope; undefined = tenant-global (M2M). */
-  userId?: string;
+  userId?: string | undefined;
   profileHash: string;
   model: string;
   derivedVersionPin: ReadPin;
@@ -135,7 +135,7 @@ function sha256(text: string): string {
 export interface AnswerCacheStoreContext {
   key: string;
   companyId: string;
-  userId?: string;
+  userId?: string | undefined;
   profileHash: string;
   model: string;
   normalizedQuery: string;

--- a/src/auth/jwks.service.ts
+++ b/src/auth/jwks.service.ts
@@ -35,11 +35,11 @@ const VALID_SCOPES: ReadonlySet<BrainScope> = new Set([
 export class JwksService implements OnModuleInit {
   private readonly logger = new Logger(JwksService.name);
   private jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
-  private issuer?: string;
+  private issuer?: string | undefined;
   private audience?: string;
   private algorithms: string[] = ['RS256'];
   /** Canonical deployment URL — matches RFC 9396 grant `locations`. */
-  private publicUrl?: string;
+  private publicUrl?: string | undefined;
 
   constructor(
     private readonly configService: ConfigService,
@@ -101,8 +101,8 @@ export class JwksService implements OnModuleInit {
     let payload: JWTPayload;
     try {
       ({ payload } = await jwtVerify(token, this.jwks, {
-        issuer: this.issuer,
-        audience: this.audience,
+        ...(this.issuer !== undefined ? { issuer: this.issuer } : {}),
+        ...(this.audience !== undefined ? { audience: this.audience } : {}),
         algorithms: this.algorithms,
       }));
     } catch (e) {

--- a/src/auth/ssf-receiver.service.ts
+++ b/src/auth/ssf-receiver.service.ts
@@ -100,8 +100,9 @@ export class SsfReceiverService implements OnModuleInit, OnModuleDestroy {
   async applySet(jti: string, setJwt: string): Promise<void> {
     if (!this.jwks) return;
     try {
+      const issuer = this.config.get<string>('AUTH_SERVICE_ISSUER');
       const { payload } = await jwtVerify(setJwt, this.jwks, {
-        issuer: this.config.get<string>('AUTH_SERVICE_ISSUER'),
+        ...(issuer !== undefined ? { issuer } : {}),
       });
       const claims = payload as SetClaims;
       const subject = claims.sub_id?.sub;

--- a/src/code-memory/capture/llm-verifier.ts
+++ b/src/code-memory/capture/llm-verifier.ts
@@ -86,7 +86,7 @@ export function applyVerdicts(
 
 function parseVerdicts(
   raw: string,
-): Array<{ keep?: boolean; confidence?: number }> | null {
+): Array<{ keep?: boolean | undefined; confidence?: number | undefined }> | null {
   const fenced = /```(?:json)?\s*([\s\S]*?)```/.exec(raw);
   const body = fenced?.[1] ?? raw;
   const start = body.search(/[[{]/);

--- a/src/code-memory/capture/types.ts
+++ b/src/code-memory/capture/types.ts
@@ -74,7 +74,7 @@ export interface DecisionCandidate {
   /** Optional file:line provenance. */
   location?: string;
   validFrom: string;
-  confidence?: number;
+  confidence?: number | undefined;
 }
 
 /** Layer 1 — cheap admit/reject gate. Swap the heuristic impl for a trained

--- a/src/common/activity-tracker.service.ts
+++ b/src/common/activity-tracker.service.ts
@@ -4,7 +4,7 @@ export interface InFlightRequest {
   id: string;
   method: string;
   path: string;
-  companyId?: string;
+  companyId?: string | undefined;
   startedAtMs: number;
 }
 

--- a/src/common/debug-trace-core.ts
+++ b/src/common/debug-trace-core.ts
@@ -13,16 +13,16 @@ import type { Request, Response, NextFunction } from 'express';
 
 export interface DebugSpan {
   id: string;
-  parentId?: string;
+  parentId?: string | undefined;
   name: string;
   startedAt: number;
   durationMs?: number;
-  attributes?: Record<string, unknown>;
+  attributes?: Record<string, unknown> | undefined;
   error?: string;
 }
 
 export interface DebugArtifact {
-  spanId?: string;
+  spanId?: string | undefined;
   name: string;
   ts: number;
   value: unknown;
@@ -48,7 +48,7 @@ export interface DebugTraceSnapshot {
   path: string;
   status: number;
   durationMs: number;
-  companyId?: string;
+  companyId?: string | undefined;
   spans: DebugSpan[];
   artifacts: DebugArtifact[];
   /** Set when the underlying handler threw. */

--- a/src/common/gen-ai-observability.ts
+++ b/src/common/gen-ai-observability.ts
@@ -97,8 +97,8 @@ export async function withGenAiCall<R extends OpenAiLikeResponse | unknown>(
           kind: spec.kind,
           outcome: 'ok',
           durationSeconds: elapsed,
-          promptTokens,
-          completionTokens,
+          ...(promptTokens !== undefined ? { promptTokens } : {}),
+          ...(completionTokens !== undefined ? { completionTokens } : {}),
         });
         return res;
       } catch (err) {

--- a/src/common/request-context.ts
+++ b/src/common/request-context.ts
@@ -30,7 +30,7 @@ export interface RequestContext {
    * their OpenAI / fetch calls so a cancelled request stops burning
    * tokens. Undefined for background contexts (cron, startup).
    */
-  abortSignal?: AbortSignal;
+  abortSignal?: AbortSignal | undefined;
   /**
    * ABAC policy context for the authenticated key, stamped by
    * ApiKeyGuard after credential + action gating. Read surfaces pick

--- a/src/communities/community-builder.service.ts
+++ b/src/communities/community-builder.service.ts
@@ -491,7 +491,7 @@ export class CommunityBuilderService {
         predicate: f.predicate,
         object: f.object,
         validFrom: toIso(f.validFrom),
-        validUntil: f.validUntil ? toIso(f.validUntil) : undefined,
+        ...(f.validUntil ? { validUntil: toIso(f.validUntil) } : {}),
         confidence: typeof f.confidence === 'number' ? f.confidence : 0.5,
       }));
     return { label, summaryInput };

--- a/src/communities/community.service.ts
+++ b/src/communities/community.service.ts
@@ -52,7 +52,7 @@ export class CommunityService {
     args: {
       query: string;
       limit?: number;
-      minSimilarity?: number;
+      minSimilarity?: number | undefined;
       callerScopes?: readonly string[];
     },
   ): Promise<ScoredCommunity[]> {

--- a/src/compaction/summary-generator.ts
+++ b/src/compaction/summary-generator.ts
@@ -10,7 +10,7 @@ export interface FactToSummarize {
   predicate: string;
   object: string;
   validFrom: string;
-  validUntil?: string;
+  validUntil?: string | undefined;
   confidence: number;
 }
 

--- a/src/diff/memory-diff.service.ts
+++ b/src/diff/memory-diff.service.ts
@@ -145,7 +145,7 @@ export class MemoryDiffService {
       const createdFacts: FactRef[] = createdClipped
         .filter((r) => rowFilter.filter(r))
         .map(rowToFactRef);
-      const retracted: Array<FactRef & { supersededBy?: string }> =
+      const retracted: Array<FactRef & { supersededBy?: string | undefined }> =
         retractedClipped
         .filter((r) => rowFilter.filter(r))
         .map((r) => ({
@@ -386,16 +386,16 @@ export interface FactRef {
   object: string;
   confidence: number;
   validFrom: string;
-  validUntil?: string;
+  validUntil?: string | undefined;
   recordedAt: string;
-  retractedAt?: string;
+  retractedAt?: string | undefined;
 }
 
 export interface ChangedFact {
   factId: string;
   replacedBy: string;
   before: FactRef;
-  after?: FactRef;
+  after?: FactRef | undefined;
 }
 
 export interface EntityRef {
@@ -409,7 +409,7 @@ export interface EntityRef {
 export interface ForgottenRef {
   entityIdHash: string;
   reason: string;
-  requestId?: string;
+  requestId?: string | undefined;
   forgottenAt: string;
 }
 

--- a/src/documents/candidate-commit.service.ts
+++ b/src/documents/candidate-commit.service.ts
@@ -34,8 +34,8 @@ interface StatusUpdate {
   id: string;
   kind: CandidateKind;
   status: 'committed' | 'merged' | 'rejected';
-  statusReason?: string;
-  commitRef?: string;
+  statusReason?: string | undefined;
+  commitRef?: string | undefined;
 }
 
 /**

--- a/src/documents/candidate-merge.ts
+++ b/src/documents/candidate-merge.ts
@@ -19,7 +19,7 @@ export interface MergedEntity {
   key: string;
   name: string;
   type: string;
-  canonical?: string;
+  canonical?: string | undefined;
   /** Leader first; the rest fold to status 'merged'. */
   candidateIds: string[];
 }
@@ -39,8 +39,8 @@ export interface MergedFact {
   object: string;
   /** max across contributors */
   confidence: number;
-  entropy?: number;
-  clause?: string;
+  entropy?: number | undefined;
+  clause?: string | undefined;
   /** Leader's indexer — becomes the committed fact's source.recorder. */
   recorder: string;
   leaderId: string;
@@ -101,7 +101,7 @@ function mergeEntities(rows: CandidateRow[], ctx: MergeContext): MergedEntity[] 
   const items: Array<{
     row: CandidateRow;
     name: string;
-    canonical?: string;
+    canonical?: string | undefined;
     nameKey: string;
   }> = [];
   // Pass 1: register aliases and union each candidate's own aliases.

--- a/src/documents/candidate-store.service.ts
+++ b/src/documents/candidate-store.service.ts
@@ -20,8 +20,8 @@ export interface CandidateRow {
   kind: CandidateKind;
   confidence: number;
   status: string;
-  statusReason?: string;
-  commitRef?: string;
+  statusReason?: string | undefined;
+  commitRef?: string | undefined;
   // A heterogeneous JSON blob whose shape differs by `kind`
   // (entity / fact / relation). Each consumer narrows the fields it
   // reads (candidate-merge.ts guards predicate/object as strings; the
@@ -85,8 +85,8 @@ export interface RunRow {
   packVersion: string;
   status: string;
   external: boolean;
-  claimToken?: string;
-  createdAt?: Date;
+  claimToken?: string | undefined;
+  createdAt?: Date | undefined;
 }
 
 /**
@@ -127,8 +127,8 @@ export class CandidateStoreService {
       docId: string;
       packId: string;
       packVersion: string;
-      model?: string;
-      registryVersionHash?: string;
+      model?: string | undefined;
+      registryVersionHash?: string | undefined;
       /** Run belongs to an external (out-of-process) indexer — 0062. */
       external?: boolean;
     },
@@ -569,8 +569,8 @@ export class CandidateStoreService {
     updates: Array<{
       id: string;
       status: string;
-      statusReason?: string;
-      commitRef?: string;
+      statusReason?: string | undefined;
+      commitRef?: string | undefined;
     }>,
   ): Promise<void> {
     if (!updates.length) return;

--- a/src/documents/document-store.service.ts
+++ b/src/documents/document-store.service.ts
@@ -30,7 +30,7 @@ export interface StoredDocument {
   chunkCount: number;
   hasContent: boolean;
   vertical: string;
-  recorder?: string;
+  recorder?: string | undefined;
   occurredAt: Date;
   status: string;
   /**
@@ -177,7 +177,7 @@ export class DocumentStoreService {
    */
   async listReindexable(
     companyId: string,
-    p: { afterId?: string; limit: number },
+    p: { afterId?: string | undefined; limit: number },
   ): Promise<StoredDocument[]> {
     return this.surreal.withCompany(companyId, async (db) => {
       const rows = await queryRows<Record<string, unknown>>(

--- a/src/documents/dto/ingest-document.dto.ts
+++ b/src/documents/dto/ingest-document.dto.ts
@@ -17,7 +17,7 @@ import { Type } from 'class-transformer';
  */
 export interface DocumentContextRef {
   vertical: string;
-  recorder?: string;
+  recorder?: string | undefined;
 }
 
 /** Static hard cap on document text; DOC_MAX_CHARS (env) may lower it. */

--- a/src/documents/external-candidates.service.ts
+++ b/src/documents/external-candidates.service.ts
@@ -84,7 +84,7 @@ export class ExternalCandidatesService {
     docId: string;
     dto: SubmitCandidatesDto;
     /** Per-pack binding of the calling key; absent = unrestricted. */
-    keyPackIds?: string[];
+    keyPackIds?: string[] | undefined;
   }): Promise<ExternalSubmissionResult> {
     const { companyId, docId, dto } = p;
     // G9 write-anomaly signal (one increment per external submission —

--- a/src/documents/indexer-dispatch.service.ts
+++ b/src/documents/indexer-dispatch.service.ts
@@ -44,7 +44,7 @@ export class IndexerDispatchService {
     companyId: string;
     doc: StoredDocument;
     chunks: DocumentChunk[];
-    indexers?: IndexerSelection;
+    indexers?: IndexerSelection | undefined;
   }): Promise<IndexerRunResult[]> {
     const results: IndexerRunResult[] = [
       await this.runs.runGeneral(p),
@@ -118,7 +118,7 @@ export class IndexerDispatchService {
     companyId: string;
     doc: StoredDocument;
     chunks: DocumentChunk[];
-    indexers?: IndexerSelection;
+    indexers?: IndexerSelection | undefined;
   }): Promise<IndexerBinding[]> {
     return this.selectRouted(p, 'dedicated');
   }
@@ -128,7 +128,7 @@ export class IndexerDispatchService {
     companyId: string;
     doc: StoredDocument;
     chunks: DocumentChunk[];
-    indexers?: IndexerSelection;
+    indexers?: IndexerSelection | undefined;
   }): Promise<IndexerBinding[]> {
     return this.selectRouted(p, 'external');
   }
@@ -143,7 +143,7 @@ export class IndexerDispatchService {
     companyId: string;
     doc: StoredDocument;
     chunks: DocumentChunk[];
-    indexers?: IndexerSelection;
+    indexers?: IndexerSelection | undefined;
   }): Promise<IndexerRunResult[]> {
     if (
       !p.doc.hasContent &&
@@ -192,7 +192,7 @@ export class IndexerDispatchService {
       companyId: string;
       doc: StoredDocument;
       chunks: DocumentChunk[];
-      indexers?: IndexerSelection;
+      indexers?: IndexerSelection | undefined;
     },
     mode: 'dedicated' | 'external',
   ): Promise<IndexerBinding[]> {

--- a/src/documents/indexer-run.service.ts
+++ b/src/documents/indexer-run.service.ts
@@ -35,7 +35,7 @@ export interface IndexerRunSpec {
   packVersion: string;
   executionMode: IndexerExecutionMode;
   model: string;
-  registryVersionHash?: string;
+  registryVersionHash?: string | undefined;
   /** The actual extraction — union or pack-scoped dedicated. */
   extract: (chunkText: string) => Promise<ExtractionResult>;
   /**
@@ -43,7 +43,7 @@ export interface IndexerRunSpec {
    * deploy finalizes the run 'failed' instead of orphaning it 'running';
    * createRun then reopens it on the retry. Absent on the sync HTTP path.
    */
-  abortSignal?: AbortSignal;
+  abortSignal?: AbortSignal | undefined;
 }
 
 /**

--- a/src/documents/indexer-work.service.ts
+++ b/src/documents/indexer-work.service.ts
@@ -65,10 +65,10 @@ export class IndexerWorkService {
 
   async listWork(p: {
     companyId: string;
-    packId?: string;
-    limit?: number;
+    packId?: string | undefined;
+    limit?: number | undefined;
     /** Per-pack binding of the calling key; absent = unrestricted. */
-    keyPackIds?: string[];
+    keyPackIds?: string[] | undefined;
   }): Promise<IndexerWorkListResponse> {
     const externalPacks = boundPacks(
       await this.externalPackIds(p.companyId),
@@ -111,7 +111,7 @@ export class IndexerWorkService {
   async claim(p: {
     companyId: string;
     runId: string;
-    keyPackIds?: string[];
+    keyPackIds?: string[] | undefined;
   }): Promise<ClaimWorkResponse> {
     const run = await this.getExternalRun(p.companyId, p.runId);
     assertKeyBoundToPack(p.keyPackIds, run.packId);
@@ -180,7 +180,7 @@ export class IndexerWorkService {
   async content(p: {
     companyId: string;
     runId: string;
-    keyPackIds?: string[];
+    keyPackIds?: string[] | undefined;
   }): Promise<WorkContentResponse> {
     const run = await this.getExternalRun(p.companyId, p.runId);
     if (run.status !== 'pending' && run.status !== 'running') {
@@ -215,8 +215,8 @@ export class IndexerWorkService {
     companyId: string;
     runId: string;
     claimToken: string;
-    error?: string;
-    permanent?: boolean;
+    error?: string | undefined;
+    permanent?: boolean | undefined;
   }): Promise<FailWorkResponse> {
     // Default RELEASE: back to 'pending' so the next poll rediscovers the
     // work (beats squatting on the claim until the lease expires).

--- a/src/dreams/dreams.service.ts
+++ b/src/dreams/dreams.service.ts
@@ -362,10 +362,12 @@ export class DreamsService implements OnModuleInit {
   }: {
     companyId: string;
     operations: DreamsOperation[];
-    triggered?: {
-      triggeredBy?: 'cron' | 'manual' | 'startup';
-      triggeredByActor?: string;
-    };
+    triggered?:
+      | {
+          triggeredBy?: 'cron' | 'manual' | 'startup';
+          triggeredByActor?: string;
+        }
+      | undefined;
     opts?: { skipJobRowLifecycle?: boolean; abortSignal?: AbortSignal };
   }): Promise<DreamsTenantStats> {
     const t0 = Date.now();
@@ -445,7 +447,7 @@ export class DreamsService implements OnModuleInit {
     opSet: Set<DreamsOperation>;
     stats: DreamsTenantStats;
     jobRow: JobRunRow | null;
-    signal?: AbortSignal;
+    signal?: AbortSignal | undefined;
   }): Promise<void> {
     const { db, companyId, opSet, stats, jobRow, signal } = args;
     // Audit W2 #10: dreams used to be version-BLIND — dedup drew identity

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -41,15 +41,15 @@ export interface EntityProfile {
    * Callers should treat the entity as a redirect — fetch `mergedInto`
    * to get the survivor's profile. Both fields are absent on live entities.
    */
-  mergedAt?: string;
-  mergedInto?: string;
+  mergedAt?: string | undefined;
+  mergedInto?: string | undefined;
   facts: Array<{
     factId: string;
     predicate: string;
     object: string;
     confidence: number;
     validFrom: string;
-    validUntil?: string;
+    validUntil?: string | undefined;
     status: string;
   }>;
 }
@@ -79,7 +79,7 @@ export interface GetProfileOptions {
   entityIdRaw: string;
   asOfRaw: string | undefined;
   /** Transaction-time cutoff — replay what the graph believed at T. */
-  recordedAtRaw?: string;
+  recordedAtRaw?: string | undefined;
   scopes: BrainScope[];
 }
 
@@ -100,7 +100,7 @@ export interface GetTimelineOptions {
    * events with recordedAt <= T, retraction events with retractedAt <= T.
    * Distinct from `until`, which is an audit paging window over rows.
    */
-  recordedAtRaw?: string;
+  recordedAtRaw?: string | undefined;
   scopes: BrainScope[];
 }
 
@@ -109,7 +109,7 @@ export interface GetConnectionsOptions {
   entityIdRaw: string;
   kind: string | undefined;
   scopes?: BrainScope[];
-  asOf?: string;
+  asOf?: string | undefined;
 }
 
 export interface ForgetOptions {
@@ -122,7 +122,7 @@ export interface ForgetOptions {
 export interface AutocompleteOptions {
   companyId: string;
   q: string;
-  limit?: number;
+  limit?: number | undefined;
   scopes: BrainScope[];
 }
 
@@ -208,7 +208,7 @@ export interface TimelineRetractedEvent {
   factId: string;
   retractedBy: unknown;
   reason: unknown;
-  supersededBy?: string;
+  supersededBy?: string | undefined;
 }
 
 export type TimelineEvent = TimelineRecordedEvent | TimelineRetractedEvent;
@@ -227,7 +227,7 @@ export interface ConnectionEdge {
   weight: number;
   source: unknown;
   createdAt: string;
-  neighbour?: ConnectionNeighbour;
+  neighbour?: ConnectionNeighbour | undefined;
   direction: 'outbound' | 'inbound';
 }
 

--- a/src/episodes/episode-read-store.service.ts
+++ b/src/episodes/episode-read-store.service.ts
@@ -245,8 +245,8 @@ export class EpisodeReadStoreService {
     ids: string[];
     includePii: boolean;
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
-    db?: EpisodeDb;
+    userId?: string | undefined;
+    db?: EpisodeDb | undefined;
   }): Promise<EpisodeQuoteRow[]> {
     if (opts.ids.length === 0) return [];
     return this.run(opts.companyId, opts.db, async (db) => {
@@ -368,13 +368,13 @@ export class EpisodeReadStoreService {
     companyId: string;
     includePii: boolean;
     limit: number;
-    conversationId?: string;
-    speaker?: string;
-    sinceIso?: string;
-    untilIso?: string;
+    conversationId?: string | undefined;
+    speaker?: string | undefined;
+    sinceIso?: string | undefined;
+    untilIso?: string | undefined;
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
-    after?: { occurredAtIso: string; id: string };
+    userId?: string | undefined;
+    after?: { occurredAtIso: string; id: string } | undefined;
   }): Promise<EpisodePageRow[]> {
     return this.run(opts.companyId, undefined, async (db) => {
       const where: string[] = [];

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -66,7 +66,7 @@ export interface CompetingFactRecord {
   object: string;
   confidence: number;
   validFrom: string;
-  validUntil?: string;
+  validUntil?: string | undefined;
   recordedAt: string;
   source?: unknown;
 }
@@ -202,7 +202,7 @@ interface FactReadRow extends PolicyFilterableRow {
 
 export interface ListCompetingResult {
   entityId: string;
-  asOf?: string;
+  asOf?: string | undefined;
   /**
    * Groups, one per (entityId, predicate). Within a group, every fact
    * was placed at status='competing' by the conflict resolver and is
@@ -793,7 +793,7 @@ export class FactsService {
       object: string;
       confidence: number;
       validFrom: string;
-      validUntil?: string;
+      validUntil?: string | undefined;
       recordedAt: string;
       status: string;
     }>;

--- a/src/feedback/feedback.service.ts
+++ b/src/feedback/feedback.service.ts
@@ -41,7 +41,7 @@ export class FeedbackService {
     companyId: string;
     factId: string;
     verdict: FeedbackVerdict;
-    reason?: string;
+    reason?: string | undefined;
     actor: string;
   }): Promise<RecordFeedbackResult> {
     return this.surreal.withCompany(p.companyId, async (db) => {

--- a/src/indexers/dedicated-extractor.service.ts
+++ b/src/indexers/dedicated-extractor.service.ts
@@ -45,7 +45,7 @@ export class DedicatedExtractorService {
     text: string;
     companyId: string;
     packId: string;
-    options?: DedicatedRunOptions;
+    options?: DedicatedRunOptions | undefined;
   }): Promise<ExtractionResult> {
     const { value: trimmed } = clampLlmInputText(p.text, 'mentionText');
     if (!trimmed) return { entities: [], facts: [], edges: [] };
@@ -82,7 +82,10 @@ export class DedicatedExtractorService {
       trimmed,
       companyId: p.companyId,
       snapshot,
-      overrides: { model: p.options?.model, scPasses },
+      overrides: {
+        ...(p.options?.model !== undefined ? { model: p.options.model } : {}),
+        scPasses,
+      },
     });
     if (!result) {
       // Transient LLM failure — same no-cache contract as the union path.

--- a/src/indexers/routing.ts
+++ b/src/indexers/routing.ts
@@ -14,9 +14,9 @@ export interface IndexerBinding {
   packVersion: string;
   mode: 'virtual' | 'dedicated' | 'external';
   description: string;
-  relevance?: IndexerRelevance;
-  dedicated?: IndexerDescriptor['dedicated'];
-  external?: IndexerDescriptor['external'];
+  relevance?: IndexerRelevance | undefined;
+  dedicated?: IndexerDescriptor['dedicated'] | undefined;
+  external?: IndexerDescriptor['external'] | undefined;
 }
 
 export interface RoutingInput {
@@ -24,7 +24,7 @@ export interface RoutingInput {
   /** Document head (first few KB) — the cheap trigger surface. */
   head: string;
   /** Explicit per-request indexer selection (L0). */
-  requested?: string[];
+  requested?: string[] | undefined;
 }
 
 export interface RuleRoutingResult {

--- a/src/indexers/snapshot-filter.ts
+++ b/src/indexers/snapshot-filter.ts
@@ -20,7 +20,7 @@ import type {
 
 export function filterSnapshotForPack(
   full: PredicateSnapshot,
-  opts: { packId: string; includeCorePredicates?: boolean },
+  opts: { packId: string; includeCorePredicates?: boolean | undefined },
 ): PredicateSnapshot {
   const includeCore = opts.includeCorePredicates !== false;
   const prefix = opts.packId + PACK_NAMESPACE_SEP;

--- a/src/ingest/conflict-explainer.ts
+++ b/src/ingest/conflict-explainer.ts
@@ -85,8 +85,8 @@ export interface ResolverConflictPayload {
   outcome: ConflictOutcome;
   factId: string;
   bestOpponentId: string;
-  supersededFactIds?: string[];
-  competingFactIds?: string[];
+  supersededFactIds?: string[] | undefined;
+  competingFactIds?: string[] | undefined;
   scoreBreakdown: ConflictScoreBreakdown;
   dominantDimension: ConflictDimension;
   slotDelta: ConflictSlotDelta;

--- a/src/ingest/dto/ingest-fact.dto.ts
+++ b/src/ingest/dto/ingest-fact.dto.ts
@@ -98,7 +98,7 @@ export class IngestFactDto {
    * asserts the user.
    */
   @IsOptional() @IsString() @MaxLength(200)
-  userId?: string;
+  userId?: string | undefined;
 
   @IsOptional() @IsObject()
   metadata?: Record<string, unknown>;

--- a/src/ingest/dto/ingest-mention.dto.ts
+++ b/src/ingest/dto/ingest-mention.dto.ts
@@ -68,7 +68,7 @@ export class IngestMentionDto {
    * as a bare-entityId direct fact ingest).
    */
   @IsOptional() @IsString() @MaxLength(200)
-  userId?: string;
+  userId?: string | undefined;
 
   @IsISO8601()
   emittedAt!: string;

--- a/src/ingest/entity-upsert.service.ts
+++ b/src/ingest/entity-upsert.service.ts
@@ -114,7 +114,7 @@ export class EntityUpsertService {
     incomingFacts = [],
   }: {
     db: Surreal;
-    e: { name: string; type: string; canonical?: string };
+    e: { name: string; type: string; canonical?: string | undefined };
     hint: { vertical: string; id: string; role?: string } | undefined;
     _contextRef: { vertical: string };
     incomingFacts?: string[];

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -102,24 +102,24 @@ export class FactResolverService {
        * so coinages of one canon dedup/corroborate. Omit when the
        * predicate is already canonical.
        */
-      predicateAlias?: string;
+      predicateAlias?: string | undefined;
       /** The string form stored in `object` and used for locale detection. */
       object: string;
-      objectMeta?: object;
+      objectMeta?: object | undefined;
       /** Exact text to embed; defaults to `${predicate}: ${object}`. */
-      embeddingText?: string;
+      embeddingText?: string | undefined;
       /** When supplied, skips the embed round-trip (batched mention path). */
-      precomputedEmbedding?: number[];
+      precomputedEmbedding?: number[] | undefined;
       confidence: number;
       validFrom: Date;
-      validUntil?: Date;
+      validUntil?: Date | undefined;
       source: unknown;
-      entropy?: number;
+      entropy?: number | undefined;
       /** Per-user scope (migration 0055); undefined = tenant-global. */
-      userId?: string;
+      userId?: string | undefined;
       /** Derived-world namespace (0074/0079); undefined = live world. */
-      derivedVersion?: string;
-      recordOutcomeMetric?: boolean;
+      derivedVersion?: string | undefined;
+      recordOutcomeMetric?: boolean | undefined;
     },
   ): Promise<{ result: ResolveOutcome; semantics: string }> {
     // Read policy from the per-tenant registry. Pre-warm the snapshot so the
@@ -287,7 +287,7 @@ export class FactResolverService {
     db: {
       query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T>;
     },
-    items: Array<{ userId?: string; factId: unknown }>,
+    items: Array<{ userId?: string | undefined; factId: unknown }>,
   ): Promise<void> {
     const byUser = new Map<string, StringRecordId[]>();
     for (const it of items) {
@@ -492,21 +492,21 @@ export class FactResolverService {
       companyId: string;
       entityId: string;
       predicate: string;
-      predicateAlias?: string;
+      predicateAlias?: string | undefined;
       object: string;
-      objectMeta?: object;
+      objectMeta?: object | undefined;
       embedding: number[];
       confidence: number;
       validFrom: Date;
-      validUntil?: Date;
+      validUntil?: Date | undefined;
       source: unknown;
       sourceTrust: number;
       semantics: string;
-      lang?: string;
-      script?: string;
-      entropy?: number;
-      userId?: string;
-      derivedVersion?: string;
+      lang?: string | undefined;
+      script?: string | undefined;
+      entropy?: number | undefined;
+      userId?: string | undefined;
+      derivedVersion?: string | undefined;
     },
   ): Promise<ResolveOutcome> {
     // Serialize resolves on the same (company, entity, predicate). Under

--- a/src/ingest/mention-extraction.service.ts
+++ b/src/ingest/mention-extraction.service.ts
@@ -8,9 +8,9 @@ import { envFlagEnabled } from '../common/env-validation';
 
 export interface MentionSource {
   vertical: string;
-  eventId?: string;
-  conversationId?: string;
-  messageId?: string;
+  eventId?: string | undefined;
+  conversationId?: string | undefined;
+  messageId?: string | undefined;
   recorder: string;
 }
 
@@ -60,7 +60,12 @@ export class MentionExtractionService {
     const addressee = dto.knownEntities?.find((k) => k.role === 'addressee');
     const context =
       speaker?.name || addressee?.name
-        ? { speakerName: speaker?.name, addresseeName: addressee?.name }
+        ? {
+            ...(speaker?.name !== undefined ? { speakerName: speaker.name } : {}),
+            ...(addressee?.name !== undefined
+              ? { addresseeName: addressee.name }
+              : {}),
+          }
         : undefined;
 
     const extraction = await traceSpan('ingest.nlu.extract', () =>

--- a/src/ingest/mention-persist.service.ts
+++ b/src/ingest/mention-persist.service.ts
@@ -201,7 +201,7 @@ export class MentionPersistService {
    * guarded (INSERTED_HISTORICAL); bitemporal is not.
    */
   private factValidFrom(
-    f: { predicate: string; clause?: string },
+    f: { predicate: string; clause?: string | undefined },
     dto: IngestMentionDto,
     eventTimeOn: boolean,
   ): Date {
@@ -297,16 +297,16 @@ export class MentionPersistService {
       entityId: string;
       f: {
         predicate: string;
-        predicateAlias?: string;
+        predicateAlias?: string | undefined;
         object: string;
         confidence: number;
-        extractionEntropy?: number;
+        extractionEntropy?: number | undefined;
       };
       source: MentionSource;
       validFrom: Date;
       precomputedEmbedding: number[] | undefined;
       /** Per-user scope (audit 2026-08-21 P0) — stamps the fact row. */
-      userId?: string;
+      userId?: string | undefined;
     },
   ): Promise<string | null> {
     const { f } = p;

--- a/src/ingest/predictor-internals.ts
+++ b/src/ingest/predictor-internals.ts
@@ -61,7 +61,7 @@ export interface PredictResolveArgs {
    * record_fact. Omitted = tenant-global only (fail-closed), which is
    * the wrong opponent set for user-scoped candidates.
    */
-  userId?: string;
+  userId?: string | undefined;
 }
 
 export interface OpposingFact {
@@ -70,7 +70,7 @@ export interface OpposingFact {
   object: string;
   confidence: number;
   validFrom: string;
-  validUntil?: string;
+  validUntil?: string | undefined;
   recordedAt: string;
 }
 

--- a/src/jobs/job-claim.service.ts
+++ b/src/jobs/job-claim.service.ts
@@ -50,7 +50,7 @@ export interface JobClaim {
    * span as a child of the producer, so trace viewers stitch the
    * full publish→queue→process waterfall together.
    */
-  traceparent?: string;
+  traceparent?: string | undefined;
 }
 
 /**

--- a/src/jobs/job-run.service.ts
+++ b/src/jobs/job-run.service.ts
@@ -53,7 +53,7 @@ export interface JobRunRow {
   error?: { message: string; name?: string; stack?: string } | null;
   cancelRequested: boolean;
   /** Phase J/K claim fields — populated when status='running'. */
-  attempts?: number;
+  attempts?: number | undefined;
   claimedBy?: string | null;
   claimedAt?: string | null;
   leaseUntil?: string | null;
@@ -211,7 +211,7 @@ export class JobRunService {
     jobType: JobType;
     companyId: string;
     triggeredBy: 'cron' | 'manual' | 'startup';
-    triggeredByActor?: string;
+    triggeredByActor?: string | undefined;
     initialProgress?: JobProgress;
   }): Promise<JobRunRow> {
     const runId = randomUUID();

--- a/src/jobs/worker-loop.types.ts
+++ b/src/jobs/worker-loop.types.ts
@@ -36,7 +36,7 @@ export interface RegisteredHandler {
    * exports `run(input): Promise<output>`.
    */
   cpuBound?: boolean;
-  workerModule?: string;
+  workerModule?: string | undefined;
 }
 
 /** Leader/lifecycle control surface the poller reads on each cycle. */

--- a/src/live/live-subscription.manager.ts
+++ b/src/live/live-subscription.manager.ts
@@ -58,7 +58,7 @@ interface Subscriber {
   id: string;
   callerScopes: readonly string[];
   sink: (event: LiveEvent) => void;
-  policyLookup?: PredicatePolicyLookup;
+  policyLookup?: PredicatePolicyLookup | undefined;
   /** Bounded outbox depth; overflow → resync signal, never unbounded memory. */
   queued: number;
 }

--- a/src/mcp/code-memory-tools.ts
+++ b/src/mcp/code-memory-tools.ts
@@ -112,7 +112,7 @@ export function registerCodeMemoryReadTools(opts: {
       const decisions = await deps.codeSearch.recall({
         companyId,
         query: args.query,
-        limit: args.limit,
+        ...(args.limit !== undefined ? { limit: args.limit } : {}),
         scopes,
       });
       const out = { query: args.query, found: decisions.length, decisions };
@@ -172,7 +172,7 @@ export function registerCodeMemoryWriteTools(opts: {
         predicate: codeMemoryPredicateId(args.kind),
         object: args.text,
         validFrom: args.validFrom ?? new Date().toISOString(),
-        confidence: args.confidence,
+        ...(args.confidence !== undefined ? { confidence: args.confidence } : {}),
         source: {
           vertical: CODE_VERTICAL,
           recorder: 'code_memory',

--- a/src/mcp/community-tools.ts
+++ b/src/mcp/community-tools.ts
@@ -43,7 +43,7 @@ export function registerCommunityTools(
     async (args) => {
       const out = await communities.search(companyId, {
         query: args.query,
-        limit: args.limit,
+        ...(args.limit !== undefined ? { limit: args.limit } : {}),
         minSimilarity: args.minSimilarity,
         callerScopes: scopes,
       });
@@ -66,7 +66,10 @@ export function registerCommunityTools(
       },
     },
     async (args) => {
-      const out = await communities.list(companyId, { limit: args.limit, callerScopes: scopes });
+      const out = await communities.list(companyId, {
+        ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        callerScopes: scopes,
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
         structuredContent: asStructuredContent({ communities: out }),

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -11,6 +11,7 @@ import {
 import { Request, Response } from 'express';
 import { Throttle } from '@nestjs/throttler';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import { PolicyAction } from '../policy/action-registry';
 import { POLICY_ACTION_EXEMPT } from '../policy/policy-gate.service';
@@ -91,16 +92,25 @@ export class McpController {
       actorId: auth.actorId,
       mcpGrantedActions: auth.mcpGrantedActions,
     });
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined, // stateless
-    });
+    // Stateless mode: omitting sessionIdGenerator entirely reads the same
+    // as an explicit `undefined` (the SDK just stores whatever the key
+    // holds — absent and `undefined` are indistinguishable at that read),
+    // and exactOptionalPropertyTypes forbids writing the literal undefined.
+    const transport = new StreamableHTTPServerTransport({});
 
     res.on('close', () => {
       transport.close().catch(() => {});
       server.close().catch(() => {});
     });
 
-    await server.connect(transport);
+    // Bridge a self-inconsistency in @modelcontextprotocol/sdk's own .d.ts
+    // that surfaces under exactOptionalPropertyTypes: the Transport interface
+    // declares `onclose?/onerror?/onmessage?: () => void` (optional) while
+    // StreamableHTTPServerTransport implements them as accessors typed
+    // `(() => void) | undefined`, so the concrete class no longer structurally
+    // satisfies its own interface. The runtime value genuinely is a valid
+    // Transport; this asserts the SDK's own contract, not our types.
+    await server.connect(transport as Transport);
     await transport.handleRequest(req, res, req.body);
   }
 }

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -265,24 +265,24 @@ export class McpService {
        * actor) fence. Falls back to a per-tenant sentinel for callers
        * that don't thread it (unit fixtures).
        */
-      actorKeyHash?: string;
+      actorKeyHash?: string | undefined;
       /**
        * Resolved ABAC context from ApiKeyGuard; undefined = no
        * policies attached, tool surface identical to pre-ABAC.
        */
-      policy?: PolicyContext;
+      policy?: PolicyContext | undefined;
       /**
        * Per-pack key binding (ApiKeyRecord.packIds): a bound key sees
        * only its packs' declared tools; absent = every consented pack.
        */
-      packIds?: string[];
+      packIds?: string[] | undefined;
       /** Acting client (agent) identity — provenance attribution. */
-      actorId?: string;
+      actorId?: string | undefined;
       /**
        * RFC 9396 inite_mcp_resource grant (ApiKeyRecord.mcpGrantedActions):
        * undefined = gate inactive; [] = granted nothing (all tools removed).
        */
-      mcpGrantedActions?: string[];
+      mcpGrantedActions?: string[] | undefined;
     },
   ): Promise<McpServer> {
     const actorKeyHash = caller?.actorKeyHash;

--- a/src/mcp/pack-tools.ts
+++ b/src/mcp/pack-tools.ts
@@ -100,10 +100,11 @@ function registerSearchQueryTool(ctx: QueryToolContext): void {
   const predicates = tool.query.predicates?.length
     ? tool.query.predicates.map((l) => composePredicateId(binding.packId, l))
     : [...binding.namespacedPredicates];
+  const title = renderPackToolTitle(tool);
   server.registerTool(
     fullName,
     {
-      title: renderPackToolTitle(tool),
+      ...(title !== undefined ? { title } : {}),
       description: renderPackToolDescription({
         packId: binding.packId,
         version: binding.version,
@@ -114,7 +115,7 @@ function registerSearchQueryTool(ctx: QueryToolContext): void {
         limit: z.number().int().min(1).max(20).optional(),
       },
     },
-    async (args: { query: string; limit?: number }) => {
+    async (args: { query: string; limit?: number | undefined }) => {
       const limit = Math.min(args.limit ?? tool.query.defaultLimit ?? 10, 20);
       const out = await deps.search.search(
         companyId,
@@ -122,7 +123,9 @@ function registerSearchQueryTool(ctx: QueryToolContext): void {
           query: args.query,
           limit,
           predicates,
-          minConfidence: tool.query.minConfidence,
+          ...(tool.query.minConfidence !== undefined
+            ? { minConfidence: tool.query.minConfidence }
+            : {}),
         },
         scopes,
       );
@@ -140,10 +143,11 @@ function registerFactsByPredicateTool(ctx: QueryToolContext): void {
   // the enum makes any predicate OUTSIDE the declared set a schema
   // error before the handler runs.
   const locals = tool.query.predicates as [string, ...string[]];
+  const title = renderPackToolTitle(tool);
   server.registerTool(
     fullName,
     {
-      title: renderPackToolTitle(tool),
+      ...(title !== undefined ? { title } : {}),
       description: renderPackToolDescription({
         packId: binding.packId,
         version: binding.version,
@@ -161,11 +165,15 @@ function registerFactsByPredicateTool(ctx: QueryToolContext): void {
         limit: z.number().int().min(1).max(50).optional(),
       },
     },
-    async (args: { predicate: string; entity?: string; limit?: number }) => {
+    async (args: {
+      predicate: string;
+      entity?: string | undefined;
+      limit?: number | undefined;
+    }) => {
       const out = await deps.facts.listByPredicate({
         companyId,
         predicate: composePredicateId(binding.packId, args.predicate),
-        entityIdRaw: args.entity,
+        ...(args.entity !== undefined ? { entityIdRaw: args.entity } : {}),
         limit: Math.min(args.limit ?? tool.query.defaultLimit ?? 10, 50),
         scopes,
       });
@@ -192,10 +200,11 @@ function registerExternalTool(ctx: ExternalToolContext): void {
   // Only declared params are forwarded — the SDK's schema parse strips
   // extras, but the handler is also called directly in unit fixtures.
   const declared = new Set((tool.params ?? []).map((p) => p.name));
+  const title = renderPackToolTitle(tool);
   server.registerTool(
     fullName,
     {
-      title: renderPackToolTitle(tool),
+      ...(title !== undefined ? { title } : {}),
       description: renderPackToolDescription({
         packId: binding.packId,
         version: binding.version,

--- a/src/mcp/procedural-tools.ts
+++ b/src/mcp/procedural-tools.ts
@@ -44,8 +44,10 @@ export function registerProceduralReadTools(
       const out = await deps.procedural.match(companyId, {
         callerScopes: scopes,
         query: args.query,
-        limit: args.limit,
-        minSimilarity: args.minSimilarity,
+        ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        ...(args.minSimilarity !== undefined
+          ? { minSimilarity: args.minSimilarity }
+          : {}),
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
@@ -69,8 +71,10 @@ export function registerProceduralReadTools(
     async (args) => {
       const out = await deps.procedural.list(companyId, {
         callerScopes: scopes,
-        limit: args.limit,
-        includeRetired: args.includeRetired,
+        ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        ...(args.includeRetired !== undefined
+          ? { includeRetired: args.includeRetired }
+          : {}),
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],

--- a/src/mcp/read-tools.ts
+++ b/src/mcp/read-tools.ts
@@ -137,11 +137,13 @@ function registerSearchTools({
         companyId,
         {
           query: args.query,
-          limit: args.limit,
-          predicates: args.predicates,
-          asOf: args.asOf,
-          minConfidence: args.minConfidence,
-          userId: args.userId,
+          ...(args.limit !== undefined ? { limit: args.limit } : {}),
+          ...(args.predicates !== undefined ? { predicates: args.predicates } : {}),
+          ...(args.asOf !== undefined ? { asOf: args.asOf } : {}),
+          ...(args.minConfidence !== undefined
+            ? { minConfidence: args.minConfidence }
+            : {}),
+          ...(args.userId !== undefined ? { userId: args.userId } : {}),
         },
         scopes,
       );
@@ -199,13 +201,15 @@ function registerSearchTools({
         companyId,
         dto: {
           query: args.query,
-          maxHops: args.maxHops,
-          synthesize: args.synthesize,
-          synthesisGuardrails: args.synthesisGuardrails,
-          asOf: args.asOf,
-          predicates: args.predicates,
-          limit: args.limit,
-          userId: args.userId,
+          ...(args.maxHops !== undefined ? { maxHops: args.maxHops } : {}),
+          ...(args.synthesize !== undefined ? { synthesize: args.synthesize } : {}),
+          ...(args.synthesisGuardrails !== undefined
+            ? { synthesisGuardrails: args.synthesisGuardrails }
+            : {}),
+          ...(args.asOf !== undefined ? { asOf: args.asOf } : {}),
+          ...(args.predicates !== undefined ? { predicates: args.predicates } : {}),
+          ...(args.limit !== undefined ? { limit: args.limit } : {}),
+          ...(args.userId !== undefined ? { userId: args.userId } : {}),
         },
         callerScopes: scopes,
         onProgress: reporter,
@@ -254,12 +258,16 @@ function registerSearchTools({
         companyId,
         dto: {
           query: args.query,
-          limit: args.limit,
-          predicates: args.predicates,
-          asOf: args.asOf,
-          minConfidence: args.minConfidence,
-          synthesisGuardrails: args.synthesisGuardrails,
-          userId: args.userId,
+          ...(args.limit !== undefined ? { limit: args.limit } : {}),
+          ...(args.predicates !== undefined ? { predicates: args.predicates } : {}),
+          ...(args.asOf !== undefined ? { asOf: args.asOf } : {}),
+          ...(args.minConfidence !== undefined
+            ? { minConfidence: args.minConfidence }
+            : {}),
+          ...(args.synthesisGuardrails !== undefined
+            ? { synthesisGuardrails: args.synthesisGuardrails }
+            : {}),
+          ...(args.userId !== undefined ? { userId: args.userId } : {}),
         },
         callerScopes: scopes,
         onProgress: reporter,
@@ -271,6 +279,16 @@ function registerSearchTools({
     },
   );
 
+  registerMemoryDiffTool({ server, companyId, scopes, deps });
+}
+
+// Split out of registerSearchTools for the max-lines-per-function gate.
+function registerMemoryDiffTool({
+  server,
+  companyId,
+  scopes,
+  deps,
+}: RegisterReadToolsOptions): void {
   // ── memory_diff ───────────────────────────────────────────────────
   server.registerTool(
     'memory_diff',
@@ -297,8 +315,8 @@ function registerSearchTools({
         {
           from: args.from,
           to: args.to,
-          entityIds: args.entityIds,
-          predicates: args.predicates,
+          ...(args.entityIds !== undefined ? { entityIds: args.entityIds } : {}),
+          ...(args.predicates !== undefined ? { predicates: args.predicates } : {}),
         },
         scopes,
       );
@@ -465,7 +483,11 @@ function registerEntityReadTools({
       }
       const out = await deps.summarizer.summarize(
         companyId,
-        { entityId: args.entityId, asOf: args.asOf, styleHint: args.styleHint },
+        {
+          entityId: args.entityId,
+          ...(args.asOf !== undefined ? { asOf: args.asOf } : {}),
+          ...(args.styleHint !== undefined ? { styleHint: args.styleHint } : {}),
+        },
         scopes,
       );
       return {
@@ -502,8 +524,8 @@ function registerEntityReadTools({
     },
     async (args) => {
       const out = await deps.facts.listCompeting(companyId, args.entityId, {
-        predicate: args.predicate,
-        asOf: args.asOf,
+        ...(args.predicate !== undefined ? { predicate: args.predicate } : {}),
+        ...(args.asOf !== undefined ? { asOf: args.asOf } : {}),
         callerScopes: scopes,
       });
       return {
@@ -596,10 +618,10 @@ function registerDetectContradictionTool({
           predicate: args.predicate,
           object: args.object,
           validFrom: args.validFrom,
-          validUntil: args.validUntil,
-          confidence: args.confidence,
+          ...(args.validUntil !== undefined ? { validUntil: args.validUntil } : {}),
+          ...(args.confidence !== undefined ? { confidence: args.confidence } : {}),
           source: { vertical: args.sourceVertical },
-          userId: args.userId,
+          ...(args.userId !== undefined ? { userId: args.userId } : {}),
         },
         scopes,
       );

--- a/src/mcp/sampling.ts
+++ b/src/mcp/sampling.ts
@@ -28,7 +28,7 @@ export interface SamplingSummarizeResult {
   factsConsidered: number;
   sampledBy: 'client_llm' | 'local_template';
   modelUsed?: string;
-  asOf?: string;
+  asOf?: string | undefined;
 }
 
 export interface SummarizeViaClientSamplingOptions {
@@ -119,7 +119,7 @@ async function fallback({
 }): Promise<SamplingSummarizeResult> {
   const out = await summarizer.summarize(
     companyId,
-    { entityId, asOf, styleHint: 'neutral' },
+    { entityId, ...(asOf !== undefined ? { asOf } : {}), styleHint: 'neutral' },
     scopes,
   );
   return {

--- a/src/mcp/write-tools.ts
+++ b/src/mcp/write-tools.ts
@@ -21,7 +21,7 @@ export interface WriteToolDeps {
   documents?: DocumentIngestService;
   feedback?: FeedbackService;
   /** G9 write-anomaly counter — record_fact fires the `mcp` origin path. */
-  metrics?: MetricsService;
+  metrics?: MetricsService | undefined;
 }
 
 export interface AdminToolDeps {
@@ -53,9 +53,9 @@ export function registerWriteTools({
   deps: WriteToolDeps;
   scopes: BrainScope[];
   /** Caller key hash — actor identity for record_feedback's one-vote fence. */
-  actorKeyHash?: string;
+  actorKeyHash?: string | undefined;
   /** Acting client (agent) identity — stamped into fact provenance. */
-  actorId?: string;
+  actorId?: string | undefined;
 }): void {
   // The recorder names WHICH agent wrote the fact (token act/client_id),
   // not just that "an MCP agent" did — feeds per-agent trust and audits.
@@ -97,9 +97,9 @@ export function registerWriteTools({
         predicate: args.predicate,
         object: args.object,
         validFrom: args.validFrom,
-        validUntil: args.validUntil,
-        confidence: args.confidence,
-        userId: args.userId,
+        ...(args.validUntil !== undefined ? { validUntil: args.validUntil } : {}),
+        ...(args.confidence !== undefined ? { confidence: args.confidence } : {}),
+        ...(args.userId !== undefined ? { userId: args.userId } : {}),
         source: { vertical: args.sourceVertical, recorder },
       });
       return {
@@ -146,7 +146,7 @@ export function registerWriteTools({
         from: args.from,
         to: args.to,
         kind: args.kind,
-        weight: args.weight,
+        ...(args.weight !== undefined ? { weight: args.weight } : {}),
         source: { vertical: args.sourceVertical },
       });
       return {
@@ -183,12 +183,20 @@ export function registerWriteTools({
       // the HTTP path in facts.controller.ts. Omitting it would skip
       // the check entirely (FactsService treats undefined as a legacy
       // in-process caller).
+      const retractedBy = args.retractedBy
+        ? {
+            source: args.retractedBy.source,
+            ...(args.retractedBy.userId !== undefined
+              ? { userId: args.retractedBy.userId }
+              : {}),
+          }
+        : ({ source: 'system' } as const);
       const out = await deps.facts.retract({
         companyId,
         factId: args.factId,
         dto: {
           reason: args.reason,
-          retractedBy: args.retractedBy ?? { source: 'system' },
+          retractedBy,
         },
         callerScopes: scopes,
       });
@@ -223,8 +231,10 @@ export function registerWriteTools({
       const out = await deps.procedural.record(companyId, {
         trigger: args.trigger,
         action: args.action,
-        priority: args.priority,
-        decayHalfLifeDays: args.decayHalfLifeDays,
+        ...(args.priority !== undefined ? { priority: args.priority } : {}),
+        ...(args.decayHalfLifeDays !== undefined
+          ? { decayHalfLifeDays: args.decayHalfLifeDays }
+          : {}),
         source: { kind: args.sourceKind ?? 'operator' },
       });
       return {
@@ -274,7 +284,7 @@ function registerFeedbackTool({
   server: McpServer;
   companyId: string;
   deps: WriteToolDeps;
-  actorKeyHash?: string;
+  actorKeyHash?: string | undefined;
 }): void {
   if (!deps.feedback) return;
   const feedback = deps.feedback;
@@ -295,7 +305,7 @@ function registerFeedbackTool({
         companyId,
         factId: args.factId,
         verdict: args.verdict,
-        reason: args.reason,
+        ...(args.reason !== undefined ? { reason: args.reason } : {}),
         actor: actorKeyHash ?? `mcp:${companyId}`,
       });
       return {
@@ -421,11 +431,13 @@ function registerIngestDocumentTool({
       const out = await documents.ingestDocument(companyId, {
         kind: args.kind,
         text: args.text,
-        title: args.title,
-        originUri: args.originUri,
+        ...(args.title !== undefined ? { title: args.title } : {}),
+        ...(args.originUri !== undefined ? { originUri: args.originUri } : {}),
         occurredAt: args.occurredAt,
         contextRef: { vertical: args.vertical, recorder },
-        storeContent: args.storeContent,
+        ...(args.storeContent !== undefined
+          ? { storeContent: args.storeContent }
+          : {}),
         indexers: args.indexers ?? 'general',
         mode: 'sync',
       });

--- a/src/multi-hop/multi-hop-chain.service.ts
+++ b/src/multi-hop/multi-hop-chain.service.ts
@@ -319,7 +319,7 @@ export class MultiHopChainService {
             companyId,
             entityIds: priorEntityIds,
             callerScopes,
-            userId: dto.userId,
+            ...(dto.userId !== undefined ? { userId: dto.userId } : {}),
           });
         } catch (err) {
           this.logger.warn(
@@ -328,33 +328,47 @@ export class MultiHopChainService {
         }
       }
     }
-    const hopDto = {
-      ...dto,
-      query: hop.subQuery,
-      // The planner emits an empty/null predicates list when it
-      // can't disambiguate; honour that as "no filter" rather than
-      // an empty INSIDE clause that would match nothing.
-      predicates: hop.predicates && hop.predicates.length > 0
+    // The planner emits an empty/null predicates list when it can't
+    // disambiguate; honour that as "no filter" rather than an empty
+    // INSIDE clause that would match nothing.
+    const predicatesOverride =
+      hop.predicates && hop.predicates.length > 0
         ? hop.predicates
-        : dto.predicates,
-      // The planner is an LLM: a malformed hop.asOf ("2023-04",
-      // "three months in") became an Invalid Date param and 500'd the
-      // whole request (live LME-500 finding, q 0ddfec37). Unparseable
-      // planner dates degrade to the caller's asOf, never to an error.
-      asOf:
-        hop.asOf && !Number.isNaN(Date.parse(hop.asOf))
-          ? hop.asOf
-          : dto.asOf,
+        : dto.predicates;
+    // The planner is an LLM: a malformed hop.asOf ("2023-04", "three
+    // months in") became an Invalid Date param and 500'd the whole
+    // request (live LME-500 finding, q 0ddfec37). Unparseable planner
+    // dates degrade to the caller's asOf, never to an error.
+    const asOfOverride =
+      hop.asOf && !Number.isNaN(Date.parse(hop.asOf)) ? hop.asOf : dto.asOf;
+    // Base spread minus the keys we recompute below: predicates/asOf/
+    // entityIds get their overridden value (or stay ABSENT, matching
+    // SearchDto's optional contract) instead of the caller's raw one,
+    // and the multi-hop-specific keys never belong on a SearchDto —
+    // dropping them here (rather than setting `undefined`) is what
+    // actually keeps them from tripping the SearchDto whitelist when
+    // re-validated downstream.
+    const {
+      predicates: _droppedPredicates,
+      asOf: _droppedAsOf,
+      entityIds: _droppedEntityIds,
+      maxHops: _droppedMaxHops,
+      synthesize: _droppedSynthesize,
+      synthesisGuardrails: _droppedSynthesisGuardrails,
+      synthesisModel: _droppedSynthesisModel,
+      ...dtoRest
+    } = dto;
+    const hopDto = {
+      ...dtoRest,
+      query: hop.subQuery,
+      ...(predicatesOverride !== undefined
+        ? { predicates: predicatesOverride }
+        : {}),
+      ...(asOfOverride !== undefined ? { asOf: asOfOverride } : {}),
       // Anchor only when explicitly requested — for 'intersect' /
       // 'union' the search runs unconstrained and combination
       // happens after the fact.
-      entityIds: anchorIds,
-      // Drop multi-hop-specific keys so they don't accidentally trip
-      // the SearchDto whitelist when re-validated downstream.
-      maxHops: undefined,
-      synthesize: undefined,
-      synthesisGuardrails: undefined,
-      synthesisModel: undefined,
+      ...(anchorIds !== undefined ? { entityIds: anchorIds } : {}),
     };
     const out = await this.search.search(companyId, hopDto, callerScopes);
     return { hits: out.results };

--- a/src/multi-hop/multi-hop.types.ts
+++ b/src/multi-hop/multi-hop.types.ts
@@ -36,7 +36,7 @@ export interface MultiHopResult {
   /** Set when synthesize=true was requested. */
   synthesis?: {
     answer: string | null;
-    reason?: SynthesisReason;
+    reason?: SynthesisReason | undefined;
     citations: Citation[];
     /** Generator-call token cost (context-minimization accounting). */
     tokenUsage?: { promptTokens: number; completionTokens: number };

--- a/src/policy/policy-compile.ts
+++ b/src/policy/policy-compile.ts
@@ -114,7 +114,7 @@ function compileCondition(cond: MatchCondition): CompiledCondition {
 function compileSourceRule(rule: {
   id: string;
   effect: 'allow' | 'deny';
-  match?: MatchCondition[];
+  match?: MatchCondition[] | undefined;
 }): CompiledSourceRule {
   return {
     id: rule.id,
@@ -126,7 +126,7 @@ function compileSourceRule(rule: {
 function compileActionRule(rule: {
   id: string;
   effect: 'allow' | 'deny';
-  actions?: string[];
+  actions?: string[] | undefined;
 }): CompiledActionRule {
   const names = new Set<string>();
   const macros = new Set<PolicyMacro>();

--- a/src/policy/policy-decision.sink.ts
+++ b/src/policy/policy-decision.sink.ts
@@ -10,8 +10,8 @@ export interface PolicyDecisionRow {
   mode: 'report_only' | 'enforce';
   action?: string;
   policySet?: string;
-  ruleId?: string;
-  requestId?: string;
+  ruleId?: string | undefined;
+  requestId?: string | undefined;
   rowCounts?: { total: number; denied: number };
   sampleFactIds?: string[];
   samplePredicates?: string[];

--- a/src/policy/policy-engine.ts
+++ b/src/policy/policy-engine.ts
@@ -127,7 +127,7 @@ export function toRowView(
     source?: unknown;
     trustSnapshot?: PolicyRowView['trustSnapshot'];
     corroboration?: PolicyRowView['corroboration'];
-    userId?: string | null;
+    userId?: string | null | undefined;
   },
   piiClassOf: (predicate: string) => string,
 ): PolicyRowView {

--- a/src/policy/policy-gate.service.ts
+++ b/src/policy/policy-gate.service.ts
@@ -87,7 +87,7 @@ export class PolicyGateService {
     ctx: PolicyContext;
     action: string;
     kind: ActionKind;
-    requestId?: string;
+    requestId?: string | undefined;
   }): void {
     const evaluation = evaluateAction(ctx, action, kind);
     const denies = evaluation.verdicts.filter((v) => v.verdict === 'deny');

--- a/src/policy/policy-resolver.service.ts
+++ b/src/policy/policy-resolver.service.ts
@@ -15,8 +15,8 @@ import {
 /** Who is asking: credential hash + claim-carried set names + acting client. */
 export interface PolicySubject {
   keyHash: string;
-  claimNames?: readonly string[];
-  actorId?: string;
+  claimNames?: readonly string[] | undefined;
+  actorId?: string | undefined;
 }
 
 /** Raw access_policy row: name is stringified, document is compiled. */

--- a/src/policy/row-filter.ts
+++ b/src/policy/row-filter.ts
@@ -91,7 +91,7 @@ export function makeRowPolicyFilter(opts: {
    * sees the static code-side seed (the pre-registry behaviour, kept as
    * the fallback for callers with no tenant in hand).
    */
-  policyLookup?: PredicatePolicyLookup;
+  policyLookup?: PredicatePolicyLookup | undefined;
 }): RowPolicyFilter {
   const ctx = opts.policy !== undefined ? opts.policy : getPolicyContext();
   const scopes = opts.callerScopes;

--- a/src/procedural/procedural-memory.service.ts
+++ b/src/procedural/procedural-memory.service.ts
@@ -286,10 +286,10 @@ export interface ProcedureRecord {
   trigger: string;
   action: string;
   priority: number;
-  decayHalfLifeDays?: number;
+  decayHalfLifeDays?: number | undefined;
   source: Record<string, unknown>;
   createdAt: string;
-  retiredAt?: string;
+  retiredAt?: string | undefined;
 }
 
 export interface MatchedProcedure extends ProcedureRecord {

--- a/src/registry/marketplace-admin.controller.ts
+++ b/src/registry/marketplace-admin.controller.ts
@@ -133,9 +133,11 @@ export class MarketplaceAdminController {
       companyId: req.brainAuth.companyId,
       profile: {
         displayName: body?.displayName,
-        url: body?.url,
-        bio: body?.bio,
-        contactEmail: body?.contactEmail,
+        ...(body?.url !== undefined ? { url: body.url } : {}),
+        ...(body?.bio !== undefined ? { bio: body.bio } : {}),
+        ...(body?.contactEmail !== undefined
+          ? { contactEmail: body.contactEmail }
+          : {}),
       },
     });
   }
@@ -183,9 +185,9 @@ export class MarketplaceAdminController {
         companyId: req.brainAuth.companyId,
         priceCode: meta.priceCode,
         packId,
-        successUrl: body?.successUrl,
-        errorUrl: body?.errorUrl,
-        idempotencyKey,
+        ...(body?.successUrl !== undefined ? { successUrl: body.successUrl } : {}),
+        ...(body?.errorUrl !== undefined ? { errorUrl: body.errorUrl } : {}),
+        ...(idempotencyKey !== undefined ? { idempotencyKey } : {}),
       })
       .catch((e) => this.rethrowBilling(e));
   }

--- a/src/registry/pack-registry.service.ts
+++ b/src/registry/pack-registry.service.ts
@@ -87,13 +87,13 @@ export class PackRegistryService {
    *  stores it. Idempotent for an identical republish. */
   async publish(input: {
     manifest: DomainPackManifest;
-    publishedBy?: string;
-    keywords?: string[];
-    expectedChecksum?: string;
+    publishedBy?: string | undefined;
+    keywords?: string[] | undefined;
+    expectedChecksum?: string | undefined;
     /** Set by the pull-only mirror (RegistryMirrorService): the upstream
      *  base URL the version was pulled from. Never set on operator
      *  publishes — the field is what fences mirrored yanks off local rows. */
-    origin?: string;
+    origin?: string | undefined;
   }): Promise<PublishPackResponse> {
     const { manifest } = input;
     if (!manifest || typeof manifest !== 'object') {
@@ -199,11 +199,11 @@ export class PackRegistryService {
    *  filtered by free-text q / publisher / tag. Packs with only yanked versions
    *  are omitted (nothing installable). */
   async list(filter: {
-    q?: string;
-    publisher?: string;
-    tag?: string;
-    limit?: number;
-    offset?: number;
+    q?: string | undefined;
+    publisher?: string | undefined;
+    tag?: string | undefined;
+    limit?: number | undefined;
+    offset?: number | undefined;
   }): Promise<RegistryPackSummary[]> {
     // Manifest-less projection: the summary needs none of the (potentially
     // large) manifest JSON, and this path serves the public UI on every hit.
@@ -293,7 +293,7 @@ export class PackRegistryService {
    *  exists, and 402/503 for an unpurchased/unverifiable paid pack. */
   async resolveForInstall(args: {
     packId: string;
-    version?: string;
+    version?: string | undefined;
     /** The installing tenant — the paid-pack gate's entitlement subject. */
     companyId: string;
   }): Promise<{ manifest: DomainPackManifest; checksum: string }> {
@@ -356,7 +356,7 @@ export class PackRegistryService {
     packId: string;
     version: string;
     yanked: boolean;
-    reason?: string;
+    reason?: string | undefined;
   }): Promise<YankPackResponse> {
     const { packId, version, yanked, reason } = args;
     return this.surreal.withAdminDb(async (db) => {

--- a/src/registry/registry-mirror-sync.ts
+++ b/src/registry/registry-mirror-sync.ts
@@ -63,7 +63,7 @@ export interface MirrorSyncOptions {
   /** Upstream base URL (scheme + host [+ port]), no trailing slash. */
   upstreamBase: string;
   /** Optional bearer for the upstream's /v1/registry reads. */
-  token?: string;
+  token?: string | undefined;
   local: MirrorLocalRegistry;
   logger: MirrorLogger;
   /** Injectable for tests; defaults to global fetch. */
@@ -73,7 +73,7 @@ export interface MirrorSyncOptions {
   /** Manifest-fetch budget per run (default 200). */
   maxVersionsPerRun?: number;
   /** Outer cancellation (job lease loss / shutdown). */
-  signal?: AbortSignal;
+  signal?: AbortSignal | undefined;
 }
 
 export interface MirrorSyncSummary {
@@ -108,12 +108,12 @@ interface UpstreamVersionRow {
 
 interface SyncCtx {
   base: string;
-  token?: string;
+  token?: string | undefined;
   local: MirrorLocalRegistry;
   logger: MirrorLogger;
   fetchImpl: typeof fetch;
   timeoutMs: number;
-  signal?: AbortSignal;
+  signal?: AbortSignal | undefined;
   /** Remaining manifest fetches this run. */
   budget: number;
   maxVersions: number;

--- a/src/search/dto/search.dto.ts
+++ b/src/search/dto/search.dto.ts
@@ -55,7 +55,7 @@ export class SearchDto {
    * every other request field.
    */
   @IsOptional() @IsString() @MaxLength(200)
-  userId?: string;
+  userId?: string | undefined;
 
   @IsOptional() @IsNumber() @Min(0) @Max(1)
   minConfidence?: number;

--- a/src/search/internals/edge-expansion.ts
+++ b/src/search/internals/edge-expansion.ts
@@ -165,10 +165,12 @@ export interface ExpandViaEdgesOptions {
    * served from it; only the uncovered seeds hit the DB — saving the separate
    * round-trip for everything the vector KNN already surfaced.
    */
-  prefetchedNeighbours?: Map<
-    string,
-    { outNeighbours: NeighbourEdge[] | null; inNeighbours: NeighbourEdge[] | null }
-  >;
+  prefetchedNeighbours?:
+    | Map<
+        string,
+        { outNeighbours: NeighbourEdge[] | null; inNeighbours: NeighbourEdge[] | null }
+      >
+    | undefined;
 }
 
 /**

--- a/src/search/internals/graph-retrieve.ts
+++ b/src/search/internals/graph-retrieve.ts
@@ -24,7 +24,7 @@ export interface GraphEntity {
   entityId: string;
   type: string;
   canonicalName: string;
-  externalRefs?: Record<string, string>;
+  externalRefs?: Record<string, string> | undefined;
 }
 
 export interface GraphFactRow {
@@ -67,7 +67,7 @@ export interface GraphRetrieveHit {
     object: string;
     confidence: number;
     validFrom: string;
-    validUntil?: string;
+    validUntil?: string | undefined;
     status: string;
     score: number;
     breakdown?: ScoreBreakdown;

--- a/src/search/internals/neighbours.ts
+++ b/src/search/internals/neighbours.ts
@@ -29,7 +29,7 @@ export async function fetchNeighbours({
   logger: { warn: (msg: string) => void };
   entityIds: string[];
   /** Caller's end-user scope; omitted → tenant-global edges/peers only. */
-  userId?: string;
+  userId?: string | undefined;
 }): Promise<Map<string, Neighbour[]>> {
   const out = new Map<string, Neighbour[]>();
   if (entityIds.length === 0) return out;
@@ -134,7 +134,7 @@ export async function expandEntityIdsViaEdges({
   logger: { warn: (msg: string) => void };
   entityIds: string[];
   /** Caller's end-user scope; omitted → tenant-global edges/peers only. */
-  userId?: string;
+  userId?: string | undefined;
 }): Promise<string[]> {
   if (entityIds.length === 0) return entityIds;
   const rids = entityIds.map((raw) => {

--- a/src/search/internals/segment-leg.ts
+++ b/src/search/internals/segment-leg.ts
@@ -36,7 +36,7 @@ export interface SegmentLegOptions {
   /** Candidates per leg (the lane idiom: max(topK*3, 12)). */
   fetchK: number;
   callerScopes: string[];
-  userId?: string;
+  userId?: string | undefined;
   mode: 'hybrid' | 'vector' | 'lexical';
 }
 

--- a/src/search/internals/types.ts
+++ b/src/search/internals/types.ts
@@ -70,7 +70,7 @@ export interface FactRow {
   // parser's `ORDER BY` resolver and silently returns rows in
   // record-id order instead of by score.
   simScore?: number;
-  bm25Score?: number;
+  bm25Score?: number | undefined;
   /** BM25 match snippet from search::highlight, set by the lexical leg when
    *  SEARCH_HIGHLIGHT_ENABLED is on. Absent on vector-only rows. */
   highlight?: string;

--- a/src/search/internals/where-builder.ts
+++ b/src/search/internals/where-builder.ts
@@ -24,7 +24,7 @@ export interface BaseWhereOptions {
    * facts that haven't been backfilled — keeping them visible
    * avoids regressing recall while the corpus catches up).
    */
-  langFilter?: string;
+  langFilter?: string | undefined;
 }
 
 export interface BuildBaseWhereOptions {

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -653,10 +653,12 @@ export class SearchService {
     baseWhere: { sql: string; params: Record<string, unknown> };
     ctx: PipelineContext;
     rowFilterFn: (row: FactRow) => boolean;
-    prefetchedNeighbours?: Map<
-      string,
-      { outNeighbours: NeighbourEdge[] | null; inNeighbours: NeighbourEdge[] | null }
-    >;
+    prefetchedNeighbours?:
+      | Map<
+          string,
+          { outNeighbours: NeighbourEdge[] | null; inNeighbours: NeighbourEdge[] | null }
+        >
+      | undefined;
   }): Promise<void> {
     if (byEntity.size < 1) return;
     await withSpan(

--- a/src/search/search.types.ts
+++ b/src/search/search.types.ts
@@ -22,12 +22,12 @@ export interface SearchHit {
     object: string;
     confidence: number;
     validFrom: string;
-    validUntil?: string;
+    validUntil?: string | undefined;
     status: string;
     /** Write-time source key (trustSnapshot, migration 0044) — lets a
      *  caller chase a citation back to WHO claimed it. Absent on
      *  pre-0044 facts. */
-    sourceKey?: string;
+    sourceKey?: string | undefined;
     /** DERIVER_MENTION_STAMP anchor (V12 §1): event time of the fact's
      *  first grounding turn, from source.mentionedAt. Absent on
      *  unstamped rows. */

--- a/src/sources/sources.service.ts
+++ b/src/sources/sources.service.ts
@@ -64,7 +64,7 @@ export class SourcesService {
    *  each summary (public /v1/sources?domain= projection). */
   async list(
     companyId: string,
-    opts?: { domain?: string },
+    opts?: { domain?: string | undefined },
   ): Promise<SourceSummary[]> {
     return this.surreal.withCompany(companyId, async (db) => {
       const declaredRows = await queryRows<DeclaredRow>(

--- a/src/strategy/strategy-distill.service.ts
+++ b/src/strategy/strategy-distill.service.ts
@@ -99,8 +99,8 @@ interface DistilledItemShape {
 export interface MergeDecision {
   action: 'ADD' | 'UPDATE' | 'NOOP';
   targetId?: string;
-  strategy?: string;
-  situation?: string;
+  strategy?: string | undefined;
+  situation?: string | undefined;
 }
 
 /**

--- a/src/strategy/strategy-memory.service.ts
+++ b/src/strategy/strategy-memory.service.ts
@@ -37,7 +37,7 @@ export interface StrategyEvidence extends Record<string, unknown> {
   runIds?: string[];
   nSupport?: number;
   nContradict?: number;
-  lastValidatedAt?: string;
+  lastValidatedAt?: string | undefined;
 }
 
 export interface StrategyItem {
@@ -216,7 +216,7 @@ export class StrategyMemoryService {
 
   async list(
     companyId: string,
-    args: { status?: StrategyStatus; limit?: number } = {},
+    args: { status?: StrategyStatus | undefined; limit?: number | undefined } = {},
   ): Promise<StrategyItem[]> {
     return this.surreal.withCompany(companyId, async (db) => {
       const filter = args.status
@@ -265,7 +265,11 @@ export class StrategyMemoryService {
   async mergeUpdate(
     companyId: string,
     strategyIdRaw: string,
-    patch: { strategy?: string; situation?: string; evidence: StrategyEvidence },
+    patch: {
+      strategy?: string | undefined;
+      situation?: string | undefined;
+      evidence: StrategyEvidence;
+    },
   ): Promise<StrategyItem> {
     return this.surreal.withCompany(companyId, async (db) => {
       const tail = idTail(strategyIdRaw);

--- a/src/summarize-entity/summarize-entity.service.ts
+++ b/src/summarize-entity/summarize-entity.service.ts
@@ -222,13 +222,13 @@ export interface SummarizeResult {
   summary: string;
   factsConsidered: number;
   style: SummarizeStyle;
-  asOf?: string;
+  asOf?: string | undefined;
   /**
    * Event-time the summary reflects — the max validFrom across the facts
    * considered (graphiti-style event-time watermark). Lets the caller
    * reason about "as of when", independent of when it was computed.
    */
-  asOfValid?: string;
+  asOfValid?: string | undefined;
   /** True when this exact (entityId, asOf, style) was served from the LRU. */
   cached: boolean;
 }

--- a/src/synthesize/answer-router.ts
+++ b/src/synthesize/answer-router.ts
@@ -530,7 +530,7 @@ export function detectEvidenceConflicts(
   if (!lanes.has('contradiction')) return [];
   const bySlot = new Map<
     string,
-    Array<{ factId: string; object: string; status?: string }>
+    Array<{ factId: string; object: string; status?: string | undefined }>
   >();
   for (const r of results) {
     for (const f of r.facts) {

--- a/src/synthesize/decision-log.ts
+++ b/src/synthesize/decision-log.ts
@@ -41,7 +41,7 @@ export interface DecisionLogEntry {
   /** True iff the synthesizer's generator emitted [fid:...] for this fact. */
   picked: boolean;
   /** Populated only when `picked === false`. Deterministic, template-derived. */
-  rejectReason?: DecisionRejectReason;
+  rejectReason?: DecisionRejectReason | undefined;
   /** All multiplicative score components that placed the fact. */
   scoreBreakdown: ScoreBreakdown;
 }

--- a/src/synthesize/digest-lane.service.ts
+++ b/src/synthesize/digest-lane.service.ts
@@ -41,7 +41,7 @@ export class DigestLaneService {
     companyId: string;
     /** Scope key of the asking end-user; omitted → tenant-global
      *  caller, no user gate (M2M reads the whole tenant today). */
-    userId?: string;
+    userId?: string | undefined;
   }): Promise<string[]> {
     try {
       const derivedVersion =

--- a/src/synthesize/episode-lane.service.ts
+++ b/src/synthesize/episode-lane.service.ts
@@ -106,7 +106,7 @@ export class EpisodeLaneService {
     query: string;
     callerScopes: string[];
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
+    userId?: string | undefined;
     /** Quotes per prompt (profile.quotesPerPrompt). */
     limit: number;
   }): Promise<string[]> {
@@ -116,7 +116,7 @@ export class EpisodeLaneService {
         query: opts.query,
         limit: opts.limit,
         includePii: opts.callerScopes.includes('brain:read_pii'),
-        userId: opts.userId,
+        ...(opts.userId !== undefined ? { userId: opts.userId } : {}),
       });
       return renderQuoteLines(rows);
     } catch (e) {
@@ -156,7 +156,7 @@ export class EpisodeLaneService {
     query: string;
     callerScopes: string[];
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
+    userId?: string | undefined;
     /** Quotes per prompt (profile.assistantLaneTopK). */
     limit: number;
     /** Speaker suffix identifying the role (profile.assistantLaneMatch). */
@@ -168,7 +168,7 @@ export class EpisodeLaneService {
         query: opts.query,
         limit: opts.limit,
         includePii: opts.callerScopes.includes('brain:read_pii'),
-        userId: opts.userId,
+        ...(opts.userId !== undefined ? { userId: opts.userId } : {}),
         speakerSuffix: opts.match,
       });
       return renderQuoteLines(
@@ -204,7 +204,7 @@ export class EpisodeLaneService {
     factIds: string[];
     callerScopes: string[];
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
+    userId?: string | undefined;
     /** Excerpts per prompt (profile.sourceExcerptsCap). */
     cap: number;
   }): Promise<string[]> {
@@ -221,7 +221,7 @@ export class EpisodeLaneService {
           companyId: opts.companyId,
           ids: episodeIds,
           includePii: opts.callerScopes.includes('brain:read_pii'),
-          userId: opts.userId,
+          ...(opts.userId !== undefined ? { userId: opts.userId } : {}),
           db,
         });
         return renderQuoteLines(rows);
@@ -250,7 +250,7 @@ export class EpisodeLaneService {
     factIds: string[];
     callerScopes: string[];
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
+    userId?: string | undefined;
     /** Grounding anchors to expand (top evidence order). */
     anchors: number;
     /** Neighbor turns each side of an anchor (profile.rawWindowSpan). */
@@ -269,7 +269,7 @@ export class EpisodeLaneService {
           companyId: opts.companyId,
           ids: anchorIds,
           includePii,
-          userId: opts.userId,
+          ...(opts.userId !== undefined ? { userId: opts.userId } : {}),
           db,
         });
         const windows = await Promise.all(
@@ -282,7 +282,7 @@ export class EpisodeLaneService {
                 centerIso: new Date(r.occurredAt as string).toISOString(),
                 span: opts.span,
                 includePii,
-                userId: opts.userId,
+                ...(opts.userId !== undefined ? { userId: opts.userId } : {}),
                 db,
               }),
             ),
@@ -322,7 +322,7 @@ export class EpisodeLaneService {
     factIds: string[];
     callerScopes: string[];
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
+    userId?: string | undefined;
   }): Promise<Map<string, string>> {
     if (opts.factIds.length === 0) return new Map();
     try {
@@ -347,7 +347,7 @@ export class EpisodeLaneService {
           companyId: opts.companyId,
           ids: [...new Set(anchorByFact.values())],
           includePii: opts.callerScopes.includes('brain:read_pii'),
-          userId: opts.userId,
+          ...(opts.userId !== undefined ? { userId: opts.userId } : {}),
           db,
         });
         const rowById = new Map(rows.map((r) => [String(r.id), r]));

--- a/src/synthesize/evidence-collector.service.ts
+++ b/src/synthesize/evidence-collector.service.ts
@@ -76,7 +76,7 @@ export interface CollectedEvidence {
   /** Derived-insight lines (V8 §1), own budget slot. */
   insightLines: string[];
   /** T7 standing instructions; undefined = section omitted. */
-  instructions?: string[];
+  instructions?: string[] | undefined;
   /**
    * V8 §2 / V9 §2: the transcript section is the MENTION RECORD for
    * this query — computed once here so the generator and verifier
@@ -89,7 +89,7 @@ export interface CollectedEvidence {
    * when the profile has the lane off or nothing has history. Applied
    * by the caller to the SAME fact lines both prompts read.
    */
-  updateStories?: Map<string, string>;
+  updateStories?: Map<string, string> | undefined;
   /**
    * Multiworld §10 facts-as-keys: factId → rendered grounding quote
    * (" [source YYYY-MM-DD speaker: …]") for the top evidence facts;
@@ -97,7 +97,7 @@ export interface CollectedEvidence {
    * Applied by the caller to the SAME fact lines both prompts read —
    * exactly the updateStories contract.
    */
-  groundingQuotes?: Map<string, string>;
+  groundingQuotes?: Map<string, string> | undefined;
   /**
    * G4 strategy lane: rendered advisory notes (k≤2, default 1) from
    * the separate strategy_memory store; undefined when the lane is off
@@ -114,7 +114,7 @@ export interface CollectedEvidence {
    * evidence. (Mirrored in verifier.ts where the invariant is
    * documented.)
    */
-  strategyNotes?: string[];
+  strategyNotes?: string[] | undefined;
 }
 
 @Injectable()
@@ -149,7 +149,7 @@ export class EvidenceCollectorService {
     companyId: string;
     query: string;
     callerScopes: string[];
-    userId?: string;
+    userId?: string | undefined;
     /** The caller's full request — secondary searches (instruction
      *  probe) inherit its filter contract (audit 2026-08-19 P1). */
     dto?: SearchDto;
@@ -257,7 +257,7 @@ export class EvidenceCollectorService {
     companyId: string;
     callerScopes: string[];
     factIds: string[];
-    userId?: string;
+    userId?: string | undefined;
   }): Promise<Map<string, string> | undefined> {
     if (!profile.factsAsKeys || !this.episodeLane) return undefined;
     if (factIds.length === 0) return undefined;
@@ -307,7 +307,7 @@ export class EvidenceCollectorService {
     profile: RetrievalProfile;
     lane: LaneId | null;
     companyId: string;
-    userId?: string;
+    userId?: string | undefined;
   }): Promise<string[]> {
     if (!opts.profile.digestEvidence || !this.digestLane) return [];
     if (
@@ -342,7 +342,7 @@ export class EvidenceCollectorService {
     companyId: string;
     callerScopes: string[];
     factIds: string[];
-    userId?: string;
+    userId?: string | undefined;
   }): Promise<Map<string, string> | undefined> {
     if (!profile.updateStoryRendering || !this.updateStory) return undefined;
     if (factIds.length === 0) return undefined;
@@ -377,7 +377,7 @@ export class EvidenceCollectorService {
       query: string;
       callerScopes: string[];
       factIds: string[];
-      userId?: string;
+      userId?: string | undefined;
     },
     timelineActive: boolean,
   ): Promise<string[]> {
@@ -511,7 +511,7 @@ export class EvidenceCollectorService {
     companyId: string;
     query: string;
     callerScopes: string[];
-    userId?: string;
+    userId?: string | undefined;
   }): Promise<string[]> {
     const { profile, lane, companyId, query, callerScopes, userId } = opts;
     if (!wantsInsightEvidence(profile, lane)) return [];

--- a/src/synthesize/fact-index.ts
+++ b/src/synthesize/fact-index.ts
@@ -36,21 +36,21 @@ export function buildFactIndex(
      * precomputed [elapsed: …] suffix, so interval arithmetic happens
      * here — in code — and never in the generator.
      */
-    elapsedAsOf?: string;
+    elapsedAsOf?: string | undefined;
     /**
      * Enumeration lane (T2): render fact lines in chronological
      * validFrom order (undated last, otherwise stable) so exhaustive
      * list answers read off an ordered timeline. Sorting happens here —
      * in code — never by the generator.
      */
-    chronological?: boolean;
+    chronological?: boolean | undefined;
     /**
      * T5 update arbitration: on slots (entity+predicate) holding ≥2
      * dated, disagreeing statements, tag the max(validFrom) one with
      * "[most recent for this slot]" — knowledge-update misses answer
      * STALE values; the marker makes recency selection a read-off.
      */
-    markRecency?: boolean;
+    markRecency?: boolean | undefined;
     /**
      * V12 mention anchoring (profile.mentionDates): append
      * "(mentioned YYYY-MM-DD)" when the DERIVER_MENTION_STAMP anchor
@@ -59,13 +59,13 @@ export function buildFactIndex(
      * only the (possibly collapsed) validity date. Unstamped facts and
      * same-day anchors render nothing.
      */
-    mentionDates?: boolean;
+    mentionDates?: boolean | undefined;
     /**
      * V13 scene traces (profile.sceneTraces): append "(context: …)"
      * from the deriver-stamped source.scene — the situational anchor
      * the dual-trace encoding wrote. Unstamped facts render nothing.
      */
-    sceneTraces?: boolean;
+    sceneTraces?: boolean | undefined;
   },
 ): FactIndexResult {
   const factIndex = new Map<string, Citation>();
@@ -118,9 +118,9 @@ export function buildFactIndex(
 function factLineSuffixes(
   f: SearchHit['facts'][number],
   opts?: {
-    elapsedAsOf?: string;
-    mentionDates?: boolean;
-    sceneTraces?: boolean;
+    elapsedAsOf?: string | undefined;
+    mentionDates?: boolean | undefined;
+    sceneTraces?: boolean | undefined;
   },
 ): string {
   const elapsed = opts?.elapsedAsOf

--- a/src/synthesize/generator-client.ts
+++ b/src/synthesize/generator-client.ts
@@ -47,52 +47,52 @@ Output strictly the JSON shape requested by the schema. Do not include preamble,
 
 export interface GenerateRequest {
   openai: OpenAI;
-  metrics?: MetricsService;
+  metrics?: MetricsService | undefined;
   /** For the salvage warning; the orchestrator's logger. */
-  logger?: { warn(message: string): void };
+  logger?: { warn(message: string): void } | undefined;
   query: string;
   factLines: string[];
   /** Episodic-lane quotes (P2) — rendered as a separate typed section. */
-  transcriptLines?: string[];
+  transcriptLines?: string[] | undefined;
   /** V8 §1: derived insights — their own section, own budget slot. */
-  insightLines?: string[];
+  insightLines?: string[] | undefined;
   /** V8 §2: transcript excerpts are the mention record (ordering ask). */
-  timelineEvidence?: boolean;
+  timelineEvidence?: boolean | undefined;
   /** V10 §3: order-of-mention frame replaces the enumeration frame. */
-  orderingFrame?: boolean;
+  orderingFrame?: boolean | undefined;
   /** V10 §2b: date-arbitrated conflict frame (updateStoryRendering). */
-  dateArbitratedConflicts?: boolean;
+  dateArbitratedConflicts?: boolean | undefined;
   /** V10 §4: insight lines are a query-time topic record. */
-  arcInsights?: boolean;
+  arcInsights?: boolean | undefined;
   model: string;
   answerLang: string | null;
-  neverAbstain?: boolean;
+  neverAbstain?: boolean | undefined;
   /** ISO date the answer should treat as "today" (SYNTHESIZE_DATE_CONTEXT). */
-  dateContext?: string;
+  dateContext?: string | undefined;
   /** T1 typed dispatch lane, when the router matched. */
-  lane?: LaneId | null;
+  lane?: LaneId | null | undefined;
   /** §8 item 3: enumeration scope discipline (profile.enumStrict). */
-  enumStrict?: boolean;
+  enumStrict?: boolean | undefined;
   /** T7: standing user instructions for their own section. */
-  instructions?: string[];
+  instructions?: string[] | undefined;
   /** T3: COMPETING conflict pairs detected in the evidence. */
-  conflicts?: Array<{ factIds: string[]; label: string }>;
+  conflicts?: Array<{ factIds: string[]; label: string }> | undefined;
   /** V13 (profile.dateMath): computed date table lines. */
-  dateMathLines?: string[];
+  dateMathLines?: string[] | undefined;
   /** V13 G2 (profile.answerConditioning): per-shape reading frame. */
-  shapeInstruction?: string;
+  shapeInstruction?: string | undefined;
   /**
    * G4 strategy lane: fenced advisory notes — GENERATOR-ONLY, the
    * documented verifier-parity exception (advice, not evidence).
    */
-  strategyNotes?: string[];
+  strategyNotes?: string[] | undefined;
   /**
    * V13 constrained search loop: expose the ONE-round refine
    * affordance — the schema gains a nullable `refineQuery` and the
    * system prompt the matching rule. The second (forced-answer) call
    * simply omits this, so the cap is structural, not behavioral.
    */
-  allowRefine?: boolean;
+  allowRefine?: boolean | undefined;
 }
 
 /** V13 refine affordance — appended to either system prompt. */

--- a/src/synthesize/generator-prompt.ts
+++ b/src/synthesize/generator-prompt.ts
@@ -40,12 +40,12 @@ export function buildGeneratorUserMessage({
   query: string;
   factLines: string[];
   /** Episodic-lane quotes (P2) — separate typed section after the facts. */
-  transcriptLines?: string[];
+  transcriptLines?: string[] | undefined;
   /**
    * Derived insights (V8 §1) — aggregates and summaries in their own
    * separately-budgeted section, so they never displace fact lines.
    */
-  insightLines?: string[];
+  insightLines?: string[] | undefined;
   /**
    * V8 §2: the transcript excerpts were collected as TIMELINE evidence
    * for an ordering-shaped question — flag them as the mention record
@@ -53,14 +53,14 @@ export function buildGeneratorUserMessage({
    * sequence, not from fact date stamps (event-time extraction
    * collapses a session's mentions onto one date).
    */
-  timelineEvidence?: boolean;
+  timelineEvidence?: boolean | undefined;
   /**
    * V10 §3: the ordering frame replaces the (enumeration) lane frame —
    * short aspect labels in the mention record's order, honor the
    * requested N. Set only when the mention record fired AND the
    * profile opted in (orderingFrame && timelineEvidence).
    */
-  orderingFrame?: boolean;
+  orderingFrame?: boolean | undefined;
   /**
    * V10 §2b: date-arbitrating conflict frame — different-day conflict
    * pairs commit to the latest value and note the earlier as
@@ -68,38 +68,38 @@ export function buildGeneratorUserMessage({
    * profile.updateStoryRendering; off = the blanket hedge frame,
    * byte-identical.
    */
-  dateArbitratedConflicts?: boolean;
+  dateArbitratedConflicts?: boolean | undefined;
   /**
    * V10 §4: the insight lines are a query-time TOPIC RECORD (dated
    * atomic beats assembled for the asked topic) rather than stored
    * summaries — the header must say what the section is.
    */
-  arcInsights?: boolean;
+  arcInsights?: boolean | undefined;
   answerLang: string | null;
-  dateContext?: string;
+  dateContext?: string | undefined;
   /** T1 typed dispatch: lane-specific answer instruction. */
-  lane?: LaneId | null;
+  lane?: LaneId | null | undefined;
   /** T7: standing user instructions rendered as their own section. */
-  instructions?: string[];
+  instructions?: string[] | undefined;
   /** T3: write-side COMPETING conflict pairs present in the evidence. */
-  conflicts?: Array<{ factIds: string[]; label: string }>;
+  conflicts?: Array<{ factIds: string[]; label: string }> | undefined;
   /**
    * §8 item 3 (profile.enumStrict): scope discipline appended to the
    * enumeration lane frame — the measured judge-sink class is answers
    * listing the gold items PLUS thematically adjacent extras.
    */
-  enumStrict?: boolean;
+  enumStrict?: boolean | undefined;
   /**
    * V13 (profile.dateMath): computed date table — weekday + exact
    * event-to-event gaps for every dated evidence day, so the model
    * never does raw calendar arithmetic. Empty/undefined = no section.
    */
-  dateMathLines?: string[];
+  dateMathLines?: string[] | undefined;
   /**
    * V13 G2 (profile.answerConditioning): the per-shape reading
    * instruction from answer-shape.ts; composes with the lane frame.
    */
-  shapeInstruction?: string;
+  shapeInstruction?: string | undefined;
   /**
    * G4 strategy lane: advisory notes rendered as a clearly fenced
    * section at the END of the message — guidance, not evidence.
@@ -107,7 +107,7 @@ export function buildGeneratorUserMessage({
    * documented parity exception; see CollectedEvidence.strategyNotes
    * and verifier.ts). Empty/undefined = no section, byte-identical.
    */
-  strategyNotes?: string[];
+  strategyNotes?: string[] | undefined;
 }): string {
   const langInstruction = answerLang
     ? `\n\nLanguage policy: write your answer in ${answerLang} (ISO 639-1). Keep citation spans in their original language.`

--- a/src/synthesize/insight-lane.service.ts
+++ b/src/synthesize/insight-lane.service.ts
@@ -44,7 +44,7 @@ export class InsightLaneService {
     query: string;
     callerScopes: string[];
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
+    userId?: string | undefined;
   }): Promise<string[]> {
     const fetchK = Math.max(INSIGHT_TOP_K * 3, 12);
     try {
@@ -61,7 +61,7 @@ export class InsightLaneService {
             queryVector,
             fetchK,
             callerScopes: opts.callerScopes,
-            userId: opts.userId,
+            ...(opts.userId !== undefined ? { userId: opts.userId } : {}),
             derivedVersion,
           });
           return fuse(vectorRows, lexicalRows, 'hybrid');

--- a/src/synthesize/l3-escalation.service.ts
+++ b/src/synthesize/l3-escalation.service.ts
@@ -80,7 +80,7 @@ export interface L3EscalateInput {
   /** The fact lines the verifier already saw (evidence parity). */
   factLines: string[];
   answerLang: string | null;
-  dateMathLines?: string[];
+  dateMathLines?: string[] | undefined;
 }
 
 /** A flipped L3 answer to finalise; null = fall through to abstention. */
@@ -204,10 +204,10 @@ export class L3EscalationService {
    */
   private async resolveAnchors(
     input: L3EscalateInput,
-    fences: { includePii: boolean; userId?: string },
+    fences: { includePii: boolean; userId?: string | undefined },
   ): Promise<{
     anchors: L3SessionAnchor[];
-    episodeById: Map<string, { conversationId: string; atMs?: number }>;
+    episodeById: Map<string, { conversationId: string; atMs?: number | undefined }>;
   }> {
     const factScore = new Map<string, number>();
     for (const hit of input.results) {
@@ -252,11 +252,11 @@ export class L3EscalationService {
       companyId: input.companyId,
       ids: [...allEpisodeIds],
       includePii: fences.includePii,
-      userId: fences.userId,
+      ...(fences.userId !== undefined ? { userId: fences.userId } : {}),
     });
     const episodeById = new Map<
       string,
-      { conversationId: string; atMs?: number }
+      { conversationId: string; atMs?: number | undefined }
     >();
     for (const r of episodeRows) {
       if (!r.conversationId) continue;
@@ -295,9 +295,9 @@ export class L3EscalationService {
     input: L3EscalateInput,
     args: {
       sessionIds: string[];
-      episodeById: Map<string, { conversationId: string; atMs?: number }>;
+      episodeById: Map<string, { conversationId: string; atMs?: number | undefined }>;
       includePii: boolean;
-      userId?: string;
+      userId?: string | undefined;
     },
   ): Promise<L3Context> {
     const sessions = await Promise.all(
@@ -307,7 +307,7 @@ export class L3EscalationService {
             companyId: input.companyId,
             conversationId,
             includePii: args.includePii,
-            userId: args.userId,
+            ...(args.userId !== undefined ? { userId: args.userId } : {}),
           })
           .then((turns) => ({ conversationId, turns })),
       ),
@@ -333,7 +333,7 @@ export class L3EscalationService {
               centerIso: new Date(v.atMs).toISOString(),
               span,
               includePii: args.includePii,
-              userId: args.userId,
+              ...(args.userId !== undefined ? { userId: args.userId } : {}),
             }),
       ),
     );

--- a/src/synthesize/l3-escalation.ts
+++ b/src/synthesize/l3-escalation.ts
@@ -25,7 +25,7 @@ export interface L3TriggerInput {
   l3Escalation: boolean;
   verdict: VerifierOutput['verdict'];
   /** V10 §5 topic-coverage judgment, when the audit produced it. */
-  questionAnswered?: boolean;
+  questionAnswered?: boolean | undefined;
   /** Coverage floor result over the retrieved evidence (below floor →
    *  covered=false, the escalation-eligible state). */
   covered: boolean;
@@ -90,7 +90,7 @@ export function verifierPasses(
 export interface L3SessionAnchor {
   conversationId: string;
   score: number;
-  atMs?: number;
+  atMs?: number | undefined;
 }
 
 /** [from, to) window the query named, for temporal-overlap preference. */

--- a/src/synthesize/mention-scan.service.ts
+++ b/src/synthesize/mention-scan.service.ts
@@ -62,7 +62,7 @@ export class MentionScanService {
     query: string;
     callerScopes: string[];
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
+    userId?: string | undefined;
     /** V10 §3: collapse near-duplicate aspect mentions (orderingFrame). */
     dedupeAspects?: boolean;
     /** Dense-leg mode (V11 §5 scale gate); omitted → the exact scan. */

--- a/src/synthesize/mention-scan.ts
+++ b/src/synthesize/mention-scan.ts
@@ -123,7 +123,7 @@ export interface ScanRow {
   text: string;
   occurredAt: number;
   /** Cosine similarity vs the topic embedding (dense leg). */
-  sim?: number;
+  sim?: number | undefined;
   /** BM25 hit on the topic phrase (lexical leg). */
   lex?: number;
 }

--- a/src/synthesize/minicheck-client.ts
+++ b/src/synthesize/minicheck-client.ts
@@ -22,7 +22,7 @@ export interface MiniCheckRequest {
   /** The claim under check (declarative text). */
   claim: string;
   fetchImpl?: typeof fetch;
-  signal?: AbortSignal;
+  signal?: AbortSignal | undefined;
 }
 
 /** True = the claim is consistent with the document (grounded). */
@@ -43,7 +43,7 @@ export async function miniCheckConsistent(
       // truncates them silently, so size it explicitly.
       options: { temperature: 0, num_ctx: 8192, num_predict: 8 },
     }),
-    signal: req.signal,
+    ...(req.signal !== undefined ? { signal: req.signal } : {}),
   });
   if (!res.ok) {
     throw new Error(`minicheck HTTP ${res.status}`);

--- a/src/synthesize/query-arc.service.ts
+++ b/src/synthesize/query-arc.service.ts
@@ -95,7 +95,7 @@ export class QueryArcService {
     query: string;
     callerScopes: string[];
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
+    userId?: string | undefined;
     /** Dense-leg mode (V11 §5 scale gate); omitted → the exact scan. */
     scan?: CoverageScanTuning;
     /** Lexical-leg shape (V11 A2); omitted → the legacy phrase matcher. */

--- a/src/synthesize/query-arc.ts
+++ b/src/synthesize/query-arc.ts
@@ -70,7 +70,7 @@ export interface ArcBeat {
   /** ISO-ish validFrom string; first 10 chars are the day stamp. */
   validFrom: string;
   /** Cosine similarity vs the topic embedding (dense leg). */
-  sim?: number;
+  sim?: number | undefined;
   /** BM25 hit on the topic phrase (lexical leg). */
   lex?: number;
 }

--- a/src/synthesize/segment-lane.service.ts
+++ b/src/synthesize/segment-lane.service.ts
@@ -46,7 +46,7 @@ export class SegmentLaneService {
     query: string;
     callerScopes: string[];
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
+    userId?: string | undefined;
     /** Segments per prompt (profile.segmentTopK). */
     topK: number;
     /** Listwise-rerank the fused pool (profile.segmentRerank). */

--- a/src/synthesize/synthesize.helpers.ts
+++ b/src/synthesize/synthesize.helpers.ts
@@ -27,7 +27,7 @@ export function resolveAnswerFrames(args: {
   profile: RetrievalProfile;
   query: string;
   results: SearchHit[];
-}): { dateMathLines?: string[]; shapeInstruction?: string } {
+}): { dateMathLines?: string[] | undefined; shapeInstruction?: string | undefined } {
   const shape = args.profile.answerConditioning
     ? detectAnswerShape(args.query)
     : null;

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -518,7 +518,7 @@ export class SynthesizeService {
     results: SearchHit[];
     factIndex: ReturnType<typeof buildFactIndex>['factIndex'];
     promptFactLines: string[];
-    dateMathLines?: string[];
+    dateMathLines?: string[] | undefined;
     guardrails: SynthesisGuardrails;
     explain: boolean;
   }): Promise<SynthesizeResult | null> {
@@ -614,7 +614,7 @@ export class SynthesizeService {
       results: SearchHit[];
       factIndex: ReturnType<typeof buildFactIndex>['factIndex'];
       promptFactLines: string[];
-      dateMathLines?: string[];
+      dateMathLines?: string[] | undefined;
     },
   ): Promise<
     | { failed: SynthesizeResult }
@@ -622,7 +622,7 @@ export class SynthesizeService {
         results: SearchHit[];
         factIndex: ReturnType<typeof buildFactIndex>['factIndex'];
         promptFactLines: string[];
-        dateMathLines?: string[];
+        dateMathLines?: string[] | undefined;
         generated: GeneratorOutput;
         /** Whether the one search-loop refine round actually ran (the
          *  G2 L3 trigger requires a refine to precede escalation when
@@ -727,24 +727,24 @@ export class SynthesizeService {
     generated: GeneratorOutput;
     evidence: SearchHit[];
     prepareOpts: Parameters<SynthesizeService['prepareEvidence']>[1];
-    updateStories?: Map<string, string>;
+    updateStories?: Map<string, string> | undefined;
     /** Multiworld §10 facts-as-keys: quotes for the ROUND-1 top facts —
      *  refined-in facts stand without quotes (unmatched lines pass). */
-    groundingQuotes?: Map<string, string>;
-    shapeInstruction?: string;
+    groundingQuotes?: Map<string, string> | undefined;
+    shapeInstruction?: string | undefined;
     collected: {
       transcriptLines: string[];
       insightLines: string[];
-      instructions?: string[];
+      instructions?: string[] | undefined;
       timelineEvidence: boolean;
       /** G4 advisory notes — generator-only (parity exception). */
-      strategyNotes?: string[];
+      strategyNotes?: string[] | undefined;
     };
   }): Promise<{
     results: SearchHit[];
     factIndex: ReturnType<typeof buildFactIndex>['factIndex'];
     promptFactLines: string[];
-    dateMathLines?: string[];
+    dateMathLines?: string[] | undefined;
     generated: GeneratorOutput;
   } | null> {
     const { profile, dto, collected } = args;
@@ -895,15 +895,15 @@ export class SynthesizeService {
       answerMode: boolean;
       explain: boolean;
       /** T1 temporal lane: asOf for precomputed [elapsed] annotations. */
-      elapsedAsOf?: string;
+      elapsedAsOf?: string | undefined;
       /** T2 enumeration lane: chronological fact-line ordering. */
-      chronological?: boolean;
+      chronological?: boolean | undefined;
       /** T5: mark the newest fact of multi-statement slots. */
-      markRecency?: boolean;
+      markRecency?: boolean | undefined;
       /** V12: mention-date suffix on stamped facts (profile.mentionDates). */
-      mentionDates?: boolean;
+      mentionDates?: boolean | undefined;
       /** V13: "(context: …)" scene suffix (profile.sceneTraces). */
-      sceneTraces?: boolean;
+      sceneTraces?: boolean | undefined;
     },
   ):
     | { empty: SynthesizeResult }
@@ -1022,11 +1022,11 @@ export class SynthesizeService {
     query: string;
     answer: string;
     factLines: string[];
-    transcriptLines?: string[];
-    insightLines?: string[];
-    timelineEvidence?: boolean;
-    topicCoverage?: boolean;
-    dateMathLines?: string[];
+    transcriptLines?: string[] | undefined;
+    insightLines?: string[] | undefined;
+    timelineEvidence?: boolean | undefined;
+    topicCoverage?: boolean | undefined;
+    dateMathLines?: string[] | undefined;
     model: string;
   }): Promise<VerifierOutput> {
     return runVerifier({

--- a/src/synthesize/update-story.service.ts
+++ b/src/synthesize/update-story.service.ts
@@ -59,7 +59,7 @@ export class UpdateStoryService {
     factIds: string[];
     callerScopes: string[];
     /** Scope key of the asking end-user; omitted → tenant-global only. */
-    userId?: string;
+    userId?: string | undefined;
   }): Promise<Map<string, string>> {
     if (opts.factIds.length === 0) return new Map();
     const piiGate = opts.callerScopes.includes('brain:read_pii')

--- a/src/synthesize/update-story.ts
+++ b/src/synthesize/update-story.ts
@@ -29,7 +29,7 @@ export interface PreviousValue {
   object: string;
   /** When the old value stopped being current (loser validUntil =
    *  winner validFrom under the resolver contract). */
-  validUntil?: string;
+  validUntil?: string | undefined;
 }
 
 function toDay(value?: string): string | undefined {

--- a/src/synthesize/verdict.ts
+++ b/src/synthesize/verdict.ts
@@ -22,8 +22,8 @@ import type {
  */
 
 export interface VerdictDeps {
-  metrics?: Pick<MetricsService, 'countSynthesize'>;
-  logger?: { debug(message: string): void };
+  metrics?: Pick<MetricsService, 'countSynthesize'> | undefined;
+  logger?: { debug(message: string): void } | undefined;
 }
 
 /**
@@ -47,13 +47,13 @@ export function finalizeVerdict(
     abstention,
   }: {
     verdict: 'supported' | 'partial' | 'unsupported';
-    questionAnswered?: boolean;
+    questionAnswered?: boolean | undefined;
     answer: string;
     citations: Citation[];
     results: SynthesizeResult['results'];
     guardrails: SynthesisGuardrails;
-    decisionLog?: DecisionLogEntry[];
-    abstention?: RetrievalProfile['abstentionCalibration'];
+    decisionLog?: DecisionLogEntry[] | undefined;
+    abstention?: RetrievalProfile['abstentionCalibration'] | undefined;
   },
 ): SynthesizeResult {
   if (verdict === 'supported') {
@@ -138,7 +138,7 @@ export function unverifiedReturn(
     generated: GeneratorOutput;
     citations: Citation[];
     results: SearchHit[];
-    decisionLog?: DecisionLogEntry[];
+    decisionLog?: DecisionLogEntry[] | undefined;
   },
 ): SynthesizeResult | null {
   if (

--- a/src/synthesize/verifier.ts
+++ b/src/synthesize/verifier.ts
@@ -72,30 +72,30 @@ Two additional rules for this audit:
 
 export interface VerifyRequest {
   openai: OpenAI;
-  metrics?: MetricsService;
+  metrics?: MetricsService | undefined;
   query: string;
   answer: string;
   factLines: string[];
   /** Verbatim source turns the generator was allowed to answer from. */
-  transcriptLines?: string[];
+  transcriptLines?: string[] | undefined;
   /** Derived insights (V8 §1) the generator was allowed to answer from. */
-  insightLines?: string[];
+  insightLines?: string[] | undefined;
   /**
    * V8 §2 / V9 §2: the transcript excerpts were collected as the
    * MENTION RECORD for an ordering question — label them so the auditor
    * treats excerpt sequence as valid support for order claims (the
    * generator was explicitly told to prefer it over fact date stamps).
    */
-  timelineEvidence?: boolean;
+  timelineEvidence?: boolean | undefined;
   /**
    * V10 §5: enable the topic-coverage audit — relationship-claim
    * strictness plus the `questionAnswered` judgment. Off =
    * byte-identical prompt and schema.
    */
-  topicCoverage?: boolean;
+  topicCoverage?: boolean | undefined;
   /** V13 (profile.dateMath): the computed date table the generator
    *  saw — weekday/gap claims grounded in it must not be flagged. */
-  dateMathLines?: string[];
+  dateMathLines?: string[] | undefined;
   model: string;
 }
 
@@ -112,10 +112,10 @@ function buildVerifierUserMessage({
   query: string;
   answer: string;
   factLines: string[];
-  transcriptLines?: string[];
-  insightLines?: string[];
-  timelineEvidence?: boolean;
-  dateMathLines?: string[];
+  transcriptLines?: string[] | undefined;
+  insightLines?: string[] | undefined;
+  timelineEvidence?: boolean | undefined;
+  dateMathLines?: string[] | undefined;
 }): string {
   const sections = [`Source facts:\n${factLines.join('\n')}`];
   if (transcriptLines && transcriptLines.length > 0) {

--- a/src/users/user-profile.service.ts
+++ b/src/users/user-profile.service.ts
@@ -168,7 +168,7 @@ export class UserProfileService {
     userId: string;
     callerScopes: readonly string[];
     maxFacts: number;
-    lang?: string;
+    lang?: string | undefined;
   }): Promise<UserProfileWire> {
     const { companyId, userId, callerScopes, maxFacts, lang } = opts;
     const derivedVersion =

--- a/test/agent-qa.unit-spec.ts
+++ b/test/agent-qa.unit-spec.ts
@@ -175,8 +175,10 @@ describe('AgentQaService', () => {
     it('timeline tool renders chronological facts of the pinned world', async () => {
       process.env.AGENT_QA_TOOLS_V2 = '1';
       process.env.RETRIEVAL_DERIVED_VERSION = 'wd-v2';
-      const queries: Array<{ sql: string; params?: Record<string, unknown> }> =
-        [];
+      const queries: Array<{
+        sql: string;
+        params?: Record<string, unknown> | undefined;
+      }> = [];
       const surreal = {
         withCompany: async (_c: string, fn: (d: unknown) => Promise<unknown>) =>
           fn({

--- a/test/aggregate-composer.unit-spec.ts
+++ b/test/aggregate-composer.unit-spec.ts
@@ -12,9 +12,9 @@ function makeSvc(opts: {
   llm: unknown;
 }): {
   svc: AggregateComposerService;
-  queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+  queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
 } {
-  const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+  const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
   const db = {
     query: async (sql: string, params?: Record<string, unknown>) => {
       queries.push({ sql, params });

--- a/test/answer-cache.unit-spec.ts
+++ b/test/answer-cache.unit-spec.ts
@@ -80,7 +80,6 @@ describe('canonicalDerivedPin', () => {
 describe('computeCacheKey', () => {
   const base = {
     companyId: 'co_a',
-    userId: undefined as string | undefined,
     profileHash: 'ph1',
     model: 'gpt-4o-mini',
     derivedVersionPin: null,
@@ -378,7 +377,6 @@ describe('AnswerCacheService.admit — admission rules', () => {
   const ctx: AnswerCacheStoreContext = {
     key: 'a'.repeat(64),
     companyId: 'co_test',
-    userId: undefined,
     profileHash: 'ph',
     model: 'gpt-4o-mini',
     normalizedQuery: 'what tier is acme',

--- a/test/answer-router.unit-spec.ts
+++ b/test/answer-router.unit-spec.ts
@@ -555,9 +555,12 @@ describe('T7 instruction lane', () => {
     expect(msg).toContain(STANDING_INSTRUCTIONS_INSTRUCTION.trim());
     expect(msg).toContain('- always format code with syntax highlighting');
     for (const instructions of [undefined, [] as string[]]) {
-      expect(buildGeneratorUserMessage({ ...base, instructions })).toBe(
-        buildGeneratorUserMessage(base),
-      );
+      expect(
+        buildGeneratorUserMessage({
+          ...base,
+          ...(instructions !== undefined ? { instructions } : {}),
+        }),
+      ).toBe(buildGeneratorUserMessage(base));
     }
   });
 });
@@ -588,9 +591,12 @@ describe('G4 strategy lane — fenced ADVISORY prompt section', () => {
 
   it('absent/empty notes → byte-identical prompt (no residue)', () => {
     for (const strategyNotes of [undefined, [] as string[]]) {
-      expect(buildGeneratorUserMessage({ ...base, strategyNotes })).toBe(
-        buildGeneratorUserMessage(base),
-      );
+      expect(
+        buildGeneratorUserMessage({
+          ...base,
+          ...(strategyNotes !== undefined ? { strategyNotes } : {}),
+        }),
+      ).toBe(buildGeneratorUserMessage(base));
     }
     expect(buildGeneratorUserMessage(base)).not.toContain('ADVISORY');
   });

--- a/test/arc-composer.unit-spec.ts
+++ b/test/arc-composer.unit-spec.ts
@@ -29,9 +29,9 @@ function makeSvc(opts: {
   llm: unknown;
 }): {
   svc: ArcComposerService;
-  queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+  queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
 } {
-  const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+  const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
   const db = {
     query: async (sql: string, params?: Record<string, unknown>) => {
       queries.push({ sql, params });

--- a/test/beam-nugget-judge.unit-spec.ts
+++ b/test/beam-nugget-judge.unit-spec.ts
@@ -22,7 +22,7 @@ function stubOpenAi(replies: string[]): {
 } {
   let i = 0;
   const create = jest.fn(async () => ({
-    choices: [{ message: { content: replies[i++] } }],
+    choices: [{ message: { content: replies[i++] ?? null } }],
   }));
   return { client: { chat: { completions: { create } } }, create };
 }

--- a/test/changefeed-consumer.unit-spec.ts
+++ b/test/changefeed-consumer.unit-spec.ts
@@ -12,7 +12,7 @@
  */
 import { ChangefeedDrainService } from '../src/audit/changefeed-drain.service';
 
-type Captured = { sql: string; params?: Record<string, unknown> };
+type Captured = { sql: string; params?: Record<string, unknown> | undefined };
 
 function mkSurreal(opts: {
   cursors?: Record<string, number>;

--- a/test/compaction-version-fence.unit-spec.ts
+++ b/test/compaction-version-fence.unit-spec.ts
@@ -12,9 +12,9 @@ import type { ReadPinService } from '../src/episodes/read-pin.service';
  */
 function makeRunner(pin: string | null): {
   svc: CompactionRunnerService;
-  queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+  queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
 } {
-  const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+  const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
   const db = {
     query: async (sql: string, params?: Record<string, unknown>) => {
       queries.push({ sql, params });

--- a/test/compaction.unit-spec.ts
+++ b/test/compaction.unit-spec.ts
@@ -25,7 +25,7 @@ class StubConfig {
 
 interface QueryCall {
   sql: string;
-  params?: Record<string, unknown>;
+  params?: Record<string, unknown> | undefined;
 }
 
 interface CandidateRow {

--- a/test/conflict-explainer.unit-spec.ts
+++ b/test/conflict-explainer.unit-spec.ts
@@ -61,7 +61,6 @@ describe('buildConflictExplanation', () => {
     const e = buildConflictExplanation(
       makePayload({
         outcome: 'COMPETING',
-        supersededFactIds: undefined,
         competingFactIds: ['fact:old', 'fact:older'],
       }),
     );
@@ -100,7 +99,6 @@ describe('buildConflictExplanation', () => {
     const e = buildConflictExplanation(
       makePayload({
         outcome: 'COMPETING',
-        supersededFactIds: undefined,
         competingFactIds: ['fact:old'],
       }),
     );

--- a/test/conformal-guardrail.unit-spec.ts
+++ b/test/conformal-guardrail.unit-spec.ts
@@ -27,7 +27,7 @@ function hit(entityId: string, facts: Array<{ factId: string; calibrated?: numbe
       validFrom: '2026-01-01',
       status: 'active',
       score: 0.5,
-      breakdown: f.calibrated !== undefined ? makeBreakdown(f.calibrated) : undefined,
+      ...(f.calibrated !== undefined ? { breakdown: makeBreakdown(f.calibrated) } : {}),
     })),
     score: 0.5,
   };

--- a/test/derive-staging.unit-spec.ts
+++ b/test/derive-staging.unit-spec.ts
@@ -46,7 +46,7 @@ const ONE_PROP = {
 
 interface Recorded {
   sql: string;
-  params?: Record<string, unknown>;
+  params?: Record<string, unknown> | undefined;
 }
 
 function makeSvc(

--- a/test/derive-user-scope.unit-spec.ts
+++ b/test/derive-user-scope.unit-spec.ts
@@ -134,7 +134,10 @@ describe('char-span grounding quotes (G3, DERIVER_SPANS)', () => {
   ) {
     return buildDerivedRows({
       resolved: [
-        { p: { ...prop(turns), quotes }, entityId: 'knowledge_entity:alice' },
+        {
+          p: { ...prop(turns), ...(quotes !== undefined ? { quotes } : {}) },
+          entityId: 'knowledge_entity:alice',
+        },
       ],
       vectors: [[1, 0]],
       sessionDate: new Date('2026-08-01T00:00:00Z'),

--- a/test/digest-lane.unit-spec.ts
+++ b/test/digest-lane.unit-spec.ts
@@ -16,7 +16,7 @@ import {
 
 function makeLane(
   rows: Array<Record<string, unknown>>,
-  capture?: Array<{ sql: string; params?: Record<string, unknown> }>,
+  capture?: Array<{ sql: string; params?: Record<string, unknown> | undefined }>,
 ): DigestLaneService {
   const surreal = {
     withCompany: async (_c: string, fn: (db: unknown) => Promise<unknown>) =>
@@ -32,7 +32,7 @@ function makeLane(
 
 describe('DigestLaneService', () => {
   it('renders dated digest blocks newest-first with the world gate', async () => {
-    const capture: Array<{ sql: string; params?: Record<string, unknown> }> =
+    const capture: Array<{ sql: string; params?: Record<string, unknown> | undefined }> =
       [];
     const lane = makeLane(
       [
@@ -101,7 +101,7 @@ describe('digest user-scope policy (0087, V11 item 10)', () => {
    *  or exactly [$digestUserId]. Keeps the matrix behavioral while the
    *  SQL-shape assertions below pin the clause itself. */
   function makePolicyLane(
-    capture: Array<{ sql: string; params?: Record<string, unknown> }>,
+    capture: Array<{ sql: string; params?: Record<string, unknown> | undefined }>,
   ): DigestLaneService {
     const surreal = {
       withCompany: async (
@@ -132,7 +132,7 @@ describe('digest user-scope policy (0087, V11 item 10)', () => {
     lines.map((l) => l.split('\n')[1]);
 
   it('tenant-global caller (no userId) sees every digest, no user gate', async () => {
-    const capture: Array<{ sql: string; params?: Record<string, unknown> }> =
+    const capture: Array<{ sql: string; params?: Record<string, unknown> | undefined }> =
       [];
     const lines = await makePolicyLane(capture).digestLines({
       companyId: 'c1',
@@ -149,7 +149,7 @@ describe('digest user-scope policy (0087, V11 item 10)', () => {
   });
 
   it('user-scoped caller sees global + own only; other-user and mixed-scope excluded', async () => {
-    const capture: Array<{ sql: string; params?: Record<string, unknown> }> =
+    const capture: Array<{ sql: string; params?: Record<string, unknown> | undefined }> =
       [];
     const lines = await makePolicyLane(capture).digestLines({
       companyId: 'c1',

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -218,7 +218,7 @@ describe('validateSeedDocuments (via validatePack)', () => {
         pack({
           seedDocuments: [
             seed({
-              meta: { nested: { deep: true } } as unknown as PackSeedDocument['meta'],
+              meta: { nested: { deep: true } } as unknown as NonNullable<PackSeedDocument['meta']>,
             }),
           ],
         }),

--- a/test/dreams-version-fence.unit-spec.ts
+++ b/test/dreams-version-fence.unit-spec.ts
@@ -16,9 +16,9 @@ import type { EntityJudgeService } from '../src/ai/entity-judge.service';
  */
 function recordingDb(): {
   db: Surreal;
-  queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+  queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
 } {
-  const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+  const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
   const db = {
     query: async (sql: string, params?: Record<string, unknown>) => {
       queries.push({ sql, params });

--- a/test/episode-subscription.unit-spec.ts
+++ b/test/episode-subscription.unit-spec.ts
@@ -9,9 +9,9 @@ function makeService(opts: {
   meta?: Array<Record<string, unknown>>;
 }): {
   svc: EpisodeSubscriptionService;
-  queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+  queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
 } {
-  const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+  const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
   const surreal = {
     withCompany: async (_co: string, fn: (db: unknown) => Promise<unknown>) =>
       fn({

--- a/test/eval-harness.socket-spec.ts
+++ b/test/eval-harness.socket-spec.ts
@@ -143,7 +143,7 @@ describe('runWorlds', () => {
 
   interface RecordedCall {
     url: string;
-    tenant?: string;
+    tenant?: string | undefined;
     body: Record<string, any>;
   }
 

--- a/test/eval/fixtures/fat-tenant.generator.ts
+++ b/test/eval/fixtures/fat-tenant.generator.ts
@@ -157,8 +157,8 @@ export function buildFatTenant(opts: FatTenantOpts = {}): FatTenantFixture {
   const forgottenCustomers: Array<{
     id: string;
     fullName: string;
-    complaintObject?: string;
-    paymentObject?: string;
+    complaintObject?: string | undefined;
+    paymentObject?: string | undefined;
   }> = [];
   // Track retracted complaints so memory assertions can verify the
   // object string disappears from default search.
@@ -618,7 +618,7 @@ export function buildFatTenant(opts: FatTenantOpts = {}): FatTenantFixture {
         setup,
         queries,
         memoryAssertions,
-        miaTests: miaTests.length > 0 ? miaTests : undefined,
+        ...(miaTests.length > 0 ? { miaTests } : {}),
       },
     ],
     stats: {

--- a/test/eval/harness/report.ts
+++ b/test/eval/harness/report.ts
@@ -11,16 +11,16 @@ import { EvalScore, EvalWorld } from './types';
 export interface GroupAccuracy {
   group: string;
   n: number;
-  judgeAccuracy?: number;
+  judgeAccuracy?: number | undefined;
 }
 
 export interface AxisReport {
   n: number;
-  judgeAccuracy?: number;
+  judgeAccuracy?: number | undefined;
   judgedN: number;
   byGroup: GroupAccuracy[];
-  abstention: { n: number; abstainedRate?: number };
-  avgPromptTokens?: number;
+  abstention: { n: number; abstainedRate?: number | undefined };
+  avgPromptTokens?: number | undefined;
   errored: number;
   /**
    * BEAM official-protocol aggregate (--nugget-judge): mean nugget

--- a/test/eval/harness/types.ts
+++ b/test/eval/harness/types.ts
@@ -69,7 +69,7 @@ export interface EvalScore {
   prediction: string;
   isAbstention: boolean;
   abstained: boolean;
-  promptTokens?: number;
+  promptTokens?: number | undefined;
   errored?: string;
   judgeCorrect?: boolean;
   [meta: string]: unknown;

--- a/test/eval/http-brain-client.ts
+++ b/test/eval/http-brain-client.ts
@@ -105,7 +105,7 @@ export class HttpBrainClient {
       const res = await f(`${opts.baseUrl}${path}`, {
         method,
         headers,
-        body: body === undefined ? undefined : JSON.stringify(body),
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
       });
       if (!res.ok) {
         const text = await res.text().catch(() => '');

--- a/test/eval/loaders/json-directory.loader.ts
+++ b/test/eval/loaders/json-directory.loader.ts
@@ -205,8 +205,8 @@ function parseDirectory(parsed: unknown, origin: string): LoadedDirectory {
         predicate,
         object,
         validFrom,
-        validUntil,
-        confidence,
+        ...(validUntil !== undefined ? { validUntil } : {}),
+        ...(confidence !== undefined ? { confidence } : {}),
         source,
         ...(tag ? { tag } : {}),
       });
@@ -277,9 +277,9 @@ function parseDirectory(parsed: unknown, origin: string): LoadedDirectory {
     queries: Array.isArray(obj.queries)
       ? (obj.queries as QueryExpectation[])
       : [],
-    memoryAssertions: Array.isArray(obj.memoryAssertions)
-      ? (obj.memoryAssertions as MemoryAssertion[])
-      : undefined,
+    ...(Array.isArray(obj.memoryAssertions)
+      ? { memoryAssertions: obj.memoryAssertions as MemoryAssertion[] }
+      : {}),
   };
 
   return {

--- a/test/eval/locomo/claude-agent.ts
+++ b/test/eval/locomo/claude-agent.ts
@@ -19,6 +19,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { QaAgent } from './runner';
 
 export interface ClaudeMcpAgentOptions {
@@ -72,7 +73,14 @@ export async function createClaudeMcpAgent(opts: {
     },
   );
   const mcp = new McpClient({ name: 'locomo-claude', version: '0.1.0' });
-  await mcp.connect(transport);
+  // Bridge a self-inconsistency in @modelcontextprotocol/sdk's own .d.ts
+  // that surfaces under exactOptionalPropertyTypes: the Transport interface
+  // declares `sessionId?: string` while StreamableHTTPClientTransport
+  // implements it as `get sessionId(): string | undefined`, so the concrete
+  // class no longer structurally satisfies its own interface. The runtime
+  // value genuinely is a valid Transport; this asserts the SDK's own
+  // contract, it is not laundering any of our types.
+  await mcp.connect(transport as Transport);
 
   const toolsList = await mcp.listTools();
   const tools: ToolDef[] = toolsList.tools.map((t) => ({

--- a/test/eval/locomo/ingest.ts
+++ b/test/eval/locomo/ingest.ts
@@ -37,7 +37,7 @@ export interface IngestSink {
      * Optional tenant pin — defaults to the api-key's companyId. Kept
      * on the interface so a future admin-key sink can route per-call.
      */
-    companyId?: string;
+    companyId?: string | undefined;
     entityId: string;
     name: string;
     validFrom: string;
@@ -45,7 +45,7 @@ export interface IngestSink {
 
   /** Stream one conversation turn into brain's NLU extractor. */
   ingestMention(input: {
-    companyId?: string;
+    companyId?: string | undefined;
     speakerEntityId: string;
     /** Speaker display name — drives first-person coreference in the extractor. */
     speakerName: string;
@@ -53,7 +53,7 @@ export interface IngestSink {
      * The addressed participant (the other speaker in 2-party dialogue) —
      * drives second-person ("you") coreference. Omitted when ambiguous.
      */
-    addressee?: { entityId: string; name: string };
+    addressee?: { entityId: string; name: string } | undefined;
     text: string;
     validFrom: string;
     sourceMessageId: string;
@@ -71,7 +71,7 @@ export interface IngestPlan {
   mentions: Array<{
     speakerEntityId: string;
     speakerName: string;
-    addressee?: { entityId: string; name: string };
+    addressee?: { entityId: string; name: string } | undefined;
     text: string;
     validFrom: string;
     sourceMessageId: string;

--- a/test/eval/locomo/runner.ts
+++ b/test/eval/locomo/runner.ts
@@ -52,7 +52,11 @@ export function isAbstention(prediction: string): boolean {
 /** Agents may return a bare answer string or an answer with token cost. */
 export type AgentAnswer =
   | string
-  | { answer: string; promptTokens?: number; completionTokens?: number };
+  | {
+      answer: string;
+      promptTokens?: number | undefined;
+      completionTokens?: number | undefined;
+    };
 
 export interface QaAgent {
   /** companyId is the per-sample brain tenant the conversation lives in. */
@@ -76,7 +80,7 @@ export interface QuestionScore {
   adversarial: number;
   /** True when the agent declined to answer. For cat5 this is correctness. */
   abstained: boolean;
-  errored?: string;
+  errored?: string | undefined;
   /** LLM-judge verdict (--judge). undefined when judge off or errored. */
   judgeCorrect?: boolean;
   /** Judge error message — recorded, never fails the run. */
@@ -128,7 +132,7 @@ export interface RunReport {
   generatedAt: string;
   totalQuestions: number;
   /** Per-question generator token accounting, when agents report usage. */
-  tokens?: TokenSummary;
+  tokens?: TokenSummary | undefined;
   /**
    * Headline metrics over the ANSWERABLE categories (1-4) only.
    * `n` is the count of cat1-4 questions, not the grand total — this is
@@ -335,6 +339,7 @@ async function scoreQuestion(
   let completionTokens: number | undefined;
   let errored: string | undefined;
   try {
+    const latestSessionDate = conv.sessions[conv.sessions.length - 1]?.dateTime;
     const raw = await withTimeout(
       agent.answer({
         companyId,
@@ -343,7 +348,7 @@ async function scoreQuestion(
         // temporal questions the agent can derive one from the wording.
         // We surface the latest session timestamp so the natural
         // "default = actual now" cursor is up-to-date.
-        asOf: conv.sessions[conv.sessions.length - 1]?.dateTime,
+        ...(latestSessionDate !== undefined ? { asOf: latestSessionDate } : {}),
       }),
       timeoutMs,
     );

--- a/test/eval/metrics/faithfulness.ts
+++ b/test/eval/metrics/faithfulness.ts
@@ -41,7 +41,7 @@ export interface FaithfulnessInput {
   answer: string;
   sourceFacts: FaithfulnessSourceFact[];
   /** Default OPENAI_CHAT_MODEL or 'gpt-4o-mini'. */
-  model?: string;
+  model?: string | undefined;
 }
 
 export interface FaithfulnessClaim {

--- a/test/eval/runner/aggregator.ts
+++ b/test/eval/runner/aggregator.ts
@@ -197,7 +197,7 @@ export class Aggregator {
       {
         name: 'faithfulness:pass-rate',
         value: synthPassRate,
-        threshold: synthOutcomes.length > 0 ? 0.8 : undefined,
+        ...(synthOutcomes.length > 0 ? { threshold: 0.8 } : {}),
         n: synthOutcomes.length,
       },
       // Pure diagnostic count (no threshold) — gate semantics are
@@ -241,7 +241,7 @@ export class Aggregator {
             ? null
             : synthOutcomes.filter((o) => o.faithfulnessFloor > 0).length /
               synthOutcomes.length,
-        threshold: synthOutcomes.length > 0 ? 0.95 : undefined,
+        ...(synthOutcomes.length > 0 ? { threshold: 0.95 } : {}),
         n: synthOutcomes.length,
       },
       {
@@ -255,7 +255,7 @@ export class Aggregator {
             : 1 -
               synthOutcomes.filter((o) => o.answer === null).length /
                 synthOutcomes.length,
-        threshold: synthOutcomes.length > 0 ? 0.7 : undefined,
+        ...(synthOutcomes.length > 0 ? { threshold: 0.7 } : {}),
         n: synthOutcomes.length,
       },
       {
@@ -267,7 +267,7 @@ export class Aggregator {
           synthOutcomes.length === 0
             ? null
             : 1 - synthVerifierFailures / synthOutcomes.length,
-        threshold: synthOutcomes.length > 0 ? 0.95 : undefined,
+        ...(synthOutcomes.length > 0 ? { threshold: 0.95 } : {}),
         n: synthOutcomes.length,
       },
       // ── Hallucination resistance (false-premise / expectRefusal) ──────
@@ -279,7 +279,7 @@ export class Aggregator {
       {
         name: 'hallucination-resistance:refusal-rate',
         value: synthRefusalRate,
-        threshold: refusalOutcomes.length > 0 ? 0.8 : undefined,
+        ...(refusalOutcomes.length > 0 ? { threshold: 0.8 } : {}),
         n: refusalOutcomes.length,
       },
       {
@@ -357,7 +357,7 @@ function phase4Metrics(
     {
       name: 'answer-language-correctness',
       value: langGated.length === 0 ? null : langCorrect / langGated.length,
-      threshold: langGated.length > 0 ? 0.95 : undefined,
+      ...(langGated.length > 0 ? { threshold: 0.95 } : {}),
       n: langGated.length,
     },
     {
@@ -366,7 +366,7 @@ function phase4Metrics(
         synthWithAnswer.length === 0
           ? null
           : citedAnswers / synthWithAnswer.length,
-      threshold: synthWithAnswer.length > 0 ? 0.8 : undefined,
+      ...(synthWithAnswer.length > 0 ? { threshold: 0.8 } : {}),
       n: synthWithAnswer.length,
     },
     {

--- a/test/eval/runner/faithfulness-checker.ts
+++ b/test/eval/runner/faithfulness-checker.ts
@@ -115,7 +115,7 @@ export class FaithfulnessChecker {
             scenarioId: scenario.id,
             query: e.query,
             answer: refused ? null : answer,
-            reason: res.reason,
+            ...(res.reason !== undefined ? { reason: res.reason } : {}),
             faithfulness: null,
             totalClaims: 0,
             passed: refused,
@@ -123,7 +123,9 @@ export class FaithfulnessChecker {
             refused,
             faithfulnessFloor: floor,
             answerLangDetected: diag.answerLangDetected,
-            answerLangCorrect: diag.answerLangCorrect,
+            ...(diag.answerLangCorrect !== undefined
+              ? { answerLangCorrect: diag.answerLangCorrect }
+              : {}),
             decisionLogCitationCount: diag.decisionLogCitationCount,
             avgExtractionEntropy: diag.avgExtractionEntropy,
           });
@@ -138,13 +140,15 @@ export class FaithfulnessChecker {
             scenarioId: scenario.id,
             query: e.query,
             answer: null,
-            reason: res.reason,
+            ...(res.reason !== undefined ? { reason: res.reason } : {}),
             faithfulness: null,
             totalClaims: 0,
             passed: !!e.allowEmptyAnswer,
             faithfulnessFloor: floor,
             answerLangDetected: diag.answerLangDetected,
-            answerLangCorrect: diag.answerLangCorrect,
+            ...(diag.answerLangCorrect !== undefined
+              ? { answerLangCorrect: diag.answerLangCorrect }
+              : {}),
             decisionLogCitationCount: diag.decisionLogCitationCount,
             avgExtractionEntropy: diag.avgExtractionEntropy,
           });
@@ -228,7 +232,9 @@ export class FaithfulnessChecker {
           passed,
           faithfulnessFloor: floor,
           answerLangDetected: diag.answerLangDetected,
-          answerLangCorrect: diag.answerLangCorrect,
+          ...(diag.answerLangCorrect !== undefined
+            ? { answerLangCorrect: diag.answerLangCorrect }
+            : {}),
           decisionLogCitationCount: diag.decisionLogCitationCount,
           avgExtractionEntropy: diag.avgExtractionEntropy,
         });

--- a/test/eval/runner/scenario-runner.ts
+++ b/test/eval/runner/scenario-runner.ts
@@ -59,7 +59,7 @@ export class ScenarioRunner {
       vertical: scenario.vertical,
       queryResults,
       extractionResults: extractions,
-      identityMergeResult: identityMerge,
+      ...(identityMerge !== undefined ? { identityMergeResult: identityMerge } : {}),
       memoryAssertionResults,
       miaTestResults,
       synthesizeOutcomes,

--- a/test/eval/runner/setup-applier.ts
+++ b/test/eval/runner/setup-applier.ts
@@ -21,7 +21,7 @@ export class SetupApplier {
 
   async apply(scenario: Scenario): Promise<{
     extractions: ExtractionResult[];
-    identityMerge?: IdentityMergeResult;
+    identityMerge?: IdentityMergeResult | undefined;
   }> {
     const extractions: ExtractionResult[] = [];
     // Tag → factId map. Lets retract steps reference an earlier

--- a/test/evidence-collector.unit-spec.ts
+++ b/test/evidence-collector.unit-spec.ts
@@ -338,7 +338,7 @@ describe('EvidenceCollectorService branches', () => {
  */
 describe('cross-user evidence isolation (V11 item 10)', () => {
   const A_SECRET = 'A-SECRET: user A rents a flat in Lisbon';
-  const laneCalls: Array<{ lane: string; userId?: string }> = [];
+  const laneCalls: Array<{ lane: string; userId?: string | undefined }> = [];
   const scopedLines = (lane: string, userId: string | undefined): string[] => {
     laneCalls.push({ lane, userId });
     return userId === undefined || userId === 'user-a'
@@ -413,7 +413,7 @@ describe('cross-user evidence isolation (V11 item 10)', () => {
       ...collectorArgs(fullProfile()),
       lane: 'summary' as const,
       factIds: ['f1'],
-      userId,
+      ...(userId !== undefined ? { userId } : {}),
     };
   }
 

--- a/test/extraction-pattern.unit-spec.ts
+++ b/test/extraction-pattern.unit-spec.ts
@@ -6,7 +6,7 @@
 import { ExtractionPatternService } from '../src/ai/extraction-pattern.service';
 
 type Surreal = {
-  query: jest.Mock<Promise<unknown>, [string, Record<string, unknown>?]>;
+  query: jest.Mock<Promise<unknown>, [string, (Record<string, unknown> | undefined)?]>;
 };
 
 interface MockedSurrealService {

--- a/test/extractor-edges.unit-spec.ts
+++ b/test/extractor-edges.unit-spec.ts
@@ -28,9 +28,9 @@ function parseEdges(
   raw: unknown,
   entityCount: number,
   clauses: string[],
-): { edges: ParsedEdge[]; dropped: Array<{ reason: string; kind?: string }> } {
+): { edges: ParsedEdge[]; dropped: Array<{ reason: string; kind?: string | undefined }> } {
   const edges: ParsedEdge[] = [];
-  const dropped: Array<{ reason: string; kind?: string }> = [];
+  const dropped: Array<{ reason: string; kind?: string | undefined }> = [];
   if (!Array.isArray(raw)) return { edges, dropped };
   for (const e of raw as RawEdge[]) {
     if (!e || typeof e !== 'object') continue;

--- a/test/fact-provenance.unit-spec.ts
+++ b/test/fact-provenance.unit-spec.ts
@@ -22,7 +22,7 @@ import type { RetractFactDto } from '../src/facts/dto/retract.dto';
 
 interface Recorded {
   sql: string;
-  params?: Record<string, unknown>;
+  params?: Record<string, unknown> | undefined;
 }
 
 type Row = Record<string, unknown>;

--- a/test/forget-l0-cascade.unit-spec.ts
+++ b/test/forget-l0-cascade.unit-spec.ts
@@ -11,7 +11,7 @@ import type { ConfigService } from '@nestjs/config';
  */
 interface Recorded {
   sql: string;
-  params?: Record<string, unknown>;
+  params?: Record<string, unknown> | undefined;
 }
 
 function makeDb(rowsFor: (sql: string) => unknown[]): {

--- a/test/gate-kinds-golden.unit-spec.ts
+++ b/test/gate-kinds-golden.unit-spec.ts
@@ -97,7 +97,7 @@ describe('multi-label kinds heads', () => {
 
   it('a v1 model (no kinds) yields no kind predictions', () => {
     const v1 = trainGate(
-      trainExamples(GATE_GOLDEN).map((e) => ({ ...e, kinds: undefined })),
+      trainExamples(GATE_GOLDEN).map(({ kinds: _kinds, ...rest }) => rest),
       { epochs: 20, seed: 7 },
     );
     expect(v1.version).toBe(1);

--- a/test/insight-lane.unit-spec.ts
+++ b/test/insight-lane.unit-spec.ts
@@ -22,9 +22,9 @@ import type { SearchDto } from '../src/search/dto/search.dto';
  */
 function recordingDb(perQuery: Record<string, unknown[]>): {
   db: Pick<Surreal, 'query'>;
-  queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+  queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
 } {
-  const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+  const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
   const db = {
     query: async (sql: string, params?: Record<string, unknown>) => {
       queries.push({ sql, params });

--- a/test/job-claim.unit-spec.ts
+++ b/test/job-claim.unit-spec.ts
@@ -10,7 +10,7 @@ import { JobClaimService } from '../src/jobs/job-claim.service';
 
 interface QueryCall {
   sql: string;
-  params?: Record<string, unknown>;
+  params?: Record<string, unknown> | undefined;
 }
 
 function mkDbScript(steps: Array<(call: QueryCall) => unknown[] | Error>) {
@@ -291,8 +291,10 @@ describe('JobClaimService', () => {
     // atomic statement — so no concurrent reaper can read-then-write the same
     // expired row. The service is now a thin caller: pass the knobs, return
     // the counts. We assert the wiring (fn name + params + result mapping).
-    let captured: { sql: string; params?: Record<string, unknown> } | null =
-      null;
+    let captured: {
+      sql: string;
+      params?: Record<string, unknown> | undefined;
+    } | null = null;
     const db = {
       query: async (sql: string, params?: Record<string, unknown>) => {
         captured = { sql, params };

--- a/test/jobs-otel.unit-spec.ts
+++ b/test/jobs-otel.unit-spec.ts
@@ -16,7 +16,7 @@ import { JobDispatcherService } from '../src/jobs/job-dispatcher.service';
 
 describe('Jobs OTel handoff — wire contract', () => {
   it('enqueue includes traceparent: $traceparent in the CREATE statement when the propagator injects one', async () => {
-    const captured: { sql: string; params?: Record<string, unknown> }[] = [];
+    const captured: { sql: string; params?: Record<string, unknown> | undefined }[] = [];
     const db = {
       query: async (sql: string, params?: Record<string, unknown>) => {
         captured.push({ sql, params });

--- a/test/l0-user-scope.unit-spec.ts
+++ b/test/l0-user-scope.unit-spec.ts
@@ -14,9 +14,9 @@ import type { LeaderLeaseService } from '../src/jobs/leader-lease.service';
  */
 function recorder(): {
   surreal: SurrealService;
-  queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+  queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
 } {
-  const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+  const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
   const surreal = {
     withCompany: async (_co: string, fn: (db: unknown) => Promise<unknown>) =>
       fn({
@@ -108,7 +108,7 @@ describe('L0 user-scope fence (0055) — segment lane', () => {
 
   function makeLane(): {
     svc: SegmentLaneService;
-    queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+    queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
   } {
     const { surreal, queries } = recorder();
     const embedder = {

--- a/test/l3-escalation.unit-spec.ts
+++ b/test/l3-escalation.unit-spec.ts
@@ -35,7 +35,6 @@ describe('l3TriggerDecision — the monotone trigger matrix', () => {
   const base = {
     l3Escalation: true,
     verdict: 'unsupported' as VerifierOutput['verdict'],
-    questionAnswered: undefined,
     covered: false,
     refineAttempted: false,
     searchLoop: false,
@@ -288,7 +287,6 @@ function baseInput(openai: OpenAI, profile: RetrievalProfile) {
     factIndex: factIndexOf(),
     factLines: [`[${FACT_ID}] tier (topic) — tier: sapphire`],
     answerLang: null,
-    dateMathLines: undefined,
   };
 }
 

--- a/test/mcp-policy-gate.unit-spec.ts
+++ b/test/mcp-policy-gate.unit-spec.ts
@@ -71,7 +71,7 @@ function buildWithPolicy(policy?: PolicyContext): Promise<McpServer> {
   );
   return svc.buildServer('co_test', ['brain:read', 'brain:write', 'brain:admin'], {
     actorKeyHash: 'sha256:test',
-    policy,
+    ...(policy !== undefined ? { policy } : {}),
   });
 }
 

--- a/test/memory-assertions.unit-spec.ts
+++ b/test/memory-assertions.unit-spec.ts
@@ -34,7 +34,7 @@ describe('MemoryAssertionsChecker', () => {
       description: '',
       setup: [],
       queries: [],
-      memoryAssertions: assertions,
+      ...(assertions !== undefined ? { memoryAssertions: assertions } : {}),
     };
   }
 

--- a/test/migrator.unit-spec.ts
+++ b/test/migrator.unit-spec.ts
@@ -15,7 +15,7 @@ import { SchemaMigrator } from '../src/db/migrator.service';
 
 interface QueryCall {
   sql: string;
-  params?: Record<string, unknown>;
+  params?: Record<string, unknown> | undefined;
 }
 
 function makeFakeConn(initiallyApplied: string[] = []) {

--- a/test/projection-registry.unit-spec.ts
+++ b/test/projection-registry.unit-spec.ts
@@ -8,9 +8,9 @@ import type { AuthenticatedRequest } from '../src/auth/api-key.types';
 
 function makeRegistry(rowsPerQuery: unknown[][] = [[]]): {
   svc: ProjectionRegistryService;
-  queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+  queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
 } {
-  const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+  const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
   const surreal = {
     withCompany: async (_co: string, fn: (db: unknown) => Promise<unknown>) =>
       fn({

--- a/test/registry-mirror.unit-spec.ts
+++ b/test/registry-mirror.unit-spec.ts
@@ -128,11 +128,13 @@ function runSync(args: {
 }) {
   return syncRegistryMirror({
     upstreamBase: args.upstreamBase ?? BASE,
-    token: args.token,
     local: args.local.port,
     logger: args.logger.logger,
     fetchImpl: args.upstream.fetchImpl,
-    maxVersionsPerRun: args.maxVersionsPerRun,
+    ...(args.token !== undefined ? { token: args.token } : {}),
+    ...(args.maxVersionsPerRun !== undefined
+      ? { maxVersionsPerRun: args.maxVersionsPerRun }
+      : {}),
   });
 }
 

--- a/test/segment-fusion-leg.unit-spec.ts
+++ b/test/segment-fusion-leg.unit-spec.ts
@@ -14,9 +14,9 @@ import type { PipelineContext } from '../src/search/pipeline-context';
  */
 function recordingDb(perQuery: Record<string, unknown[]>): {
   db: Pick<Surreal, 'query'>;
-  queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+  queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
 } {
-  const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+  const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
   const db = {
     query: async (sql: string, params?: Record<string, unknown>) => {
       queries.push({ sql, params });

--- a/test/segment-lane.unit-spec.ts
+++ b/test/segment-lane.unit-spec.ts
@@ -66,7 +66,7 @@ describe('rrfFuse', () => {
 
 describe('SegmentComposerService', () => {
   it('windows sessions, embeds, and writes segments idempotently', async () => {
-    const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+    const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
     const db = {
       query: async (sql: string, params?: Record<string, unknown>) => {
         queries.push({ sql, params });

--- a/test/strategy-memory.unit-spec.ts
+++ b/test/strategy-memory.unit-spec.ts
@@ -37,7 +37,7 @@ function stubEmbedder(vectors: Record<string, number[]>): EmbedderService {
 
 interface QueryCall {
   sql: string;
-  params?: Record<string, unknown>;
+  params?: Record<string, unknown> | undefined;
 }
 
 /** Surreal stub: withCompany hands out a db whose query is scripted. */

--- a/test/user-profile.unit-spec.ts
+++ b/test/user-profile.unit-spec.ts
@@ -28,7 +28,7 @@ import type { AuthenticatedRequest } from '../src/auth/api-key.types';
 import { runWithRequestContext } from '../src/common/request-context';
 
 type Row = Record<string, unknown>;
-type Capture = { sql: string; params?: Record<string, unknown> };
+type Capture = { sql: string; params?: Record<string, unknown> | undefined };
 
 function makeService(opts: {
   rows: Row[];

--- a/test/verifier-topic-coverage.unit-spec.ts
+++ b/test/verifier-topic-coverage.unit-spec.ts
@@ -24,8 +24,8 @@ interface CapturedRequest {
     properties: Record<string, unknown>;
     required: string[];
   };
-  temperature?: number;
-  maxCompletionTokens?: number;
+  temperature?: number | undefined;
+  maxCompletionTokens?: number | undefined;
 }
 
 function mockOpenAi(response: Record<string, unknown>, captured: CapturedRequest[]) {

--- a/test/window-deriver.unit-spec.ts
+++ b/test/window-deriver.unit-spec.ts
@@ -96,10 +96,10 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
     },
   ): {
     svc: WindowDeriverService;
-    queries: Array<{ sql: string; params?: Record<string, unknown> }>;
+    queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
     derived: Array<Record<string, unknown>>;
   } {
-    const queries: Array<{ sql: string; params?: Record<string, unknown> }> = [];
+    const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
     const db = {
       query: async (sql: string, params?: Record<string, unknown>) => {
         queries.push({ sql, params });
@@ -478,8 +478,10 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
 
     it('gc reaps residual versions but never the pin, keeps, or legacy', async () => {
       process.env.RETRIEVAL_DERIVED_VERSION = 'wd-v3';
-      const queries: Array<{ sql: string; params?: Record<string, unknown> }> =
-        [];
+      const queries: Array<{
+        sql: string;
+        params?: Record<string, unknown> | undefined;
+      }> = [];
       const db = {
         query: async (sql: string, params?: Record<string, unknown>) => {
           queries.push({ sql, params });
@@ -549,8 +551,10 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
 
     it('gc keep-set includes registry live/building/built worlds even with no pin', async () => {
       delete process.env.RETRIEVAL_DERIVED_VERSION;
-      const queries: Array<{ sql: string; params?: Record<string, unknown> }> =
-        [];
+      const queries: Array<{
+        sql: string;
+        params?: Record<string, unknown> | undefined;
+      }> = [];
       const db = {
         query: async (sql: string, params?: Record<string, unknown>) => {
           queries.push({ sql, params });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "baseUrl": "./",
     "skipLibCheck": true,
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "forceConsistentCasingInFileNames": false,


### PR DESCRIPTION
## Summary

The last deferred strictness flip: `exactOptionalPropertyTypes` makes `{ x?: T }` mean present-with-T-or-absent, no longer `x: T | undefined`. **All 427 errors fixed** (314 src + 113 test across 183 files), each with the semantically-correct fix, not a blanket widen.

**Three-way split:**
- **~414 widen `x?: T` → `x?: T | undefined`** — the honest answer for DTO/wire/zod shapes and row-builder interfaces whose persistence collapses undefined==absent. **Surgical** — only the fields that actually carry undefined (e.g. `PolicyDecisionRow` got only `ruleId`/`requestId`, not the whole interface).
- **106 conditional-omit** `...(v !== undefined ? { x: v } : {})` — object construction feeding out-of-scope DTOs (`SearchDto`, `MultiHopDto`, `IngestFactDto`) and lib calls that ignore absent keys (jose `jwtVerify`, `RequestInit.signal`).
- **3 restructures.**

**Behavior-adjacent key-omissions — each verified safe** (fact-resolver gates `if (c.lang !== undefined)` before the Surreal write; `JobRunService.start` does `?? null` before insert; report objects are `JSON.stringify`-serialized where absent≡undefined). **No Surreal UPDATE changed to omit a field it used to null out.** The full unit suite passing confirms the conditional-omit sites are runtime-equivalent.

**Sole cast:** 2 documented `as Transport` at the MCP `server.connect()` boundaries — `@modelcontextprotocol/sdk`'s own `.d.ts` is self-inconsistent under the flag (interface `onclose?: () => void` vs class accessor `(() => void) | undefined`); the cast asserts the SDK's runtime contract, launders none of our types. No `@ts-ignore`, no `as any`, no per-file disable.

## Tests

typecheck clean; lint `--max-warnings 0` clean; full unit suite **263 suites / 2293 tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB