### PR TITLE
feat(fovea): focus-signal capture + per-class calibration foundation (serving-neutral, default-off)

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -386,6 +386,18 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: false,
     isBooleanFlag: true,
   },
+  {
+    key: 'FOVEA_FOCUS_CAPTURE',
+    category: 'calibration',
+    defaultValue: '0',
+    // Read at call time (FocusSignalService.captureEnabled / the admin
+    // 404 guard) — never captured in a constructor — so a flip takes
+    // effect without restart.
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Fovea optics (Optics-1): capture the per-query focus signal at the synthesize verdict point and expose the admin fit/measure surface. Serving-neutral — nothing consumes the calibrated signal yet. Off = byte-identical serving.',
+  },
   // ── Cost ────────────────────────────────────────────
   {
     key: 'COST_CHAT_PROMPT_USD_PER_MTOK',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -704,6 +704,13 @@ const KNOWN_BOOLEAN_FLAGS = [
   'STRATEGY_MEMORY_ENABLED',
   'STRATEGY_RETRIEVAL_ENABLED',
   'STRATEGY_DISTILL_CRON_ENABLED',
+  // Fovea optics (Optics-1, docs/roadmap/fovea-optics-2026-08.md): capture
+  // the focus signal at the synthesize verdict point + expose the admin
+  // fit/measure surface. SERVING-NEUTRAL — nothing consumes the calibrated
+  // signal yet. Default off = byte-identical serving (guarded no-op capture,
+  // admin routes 404). Outside ENGINE_PREFIX by design (a measurement
+  // scaffold, not an engine fork), so it sits off the flag budget.
+  'FOVEA_FOCUS_CAPTURE',
 ];
 
 /**

--- a/src/common/fovea-flags.ts
+++ b/src/common/fovea-flags.ts
@@ -1,0 +1,15 @@
+import { envFlagEnabled } from './env-validation';
+
+/**
+ * Fovea optics (Optics-1) master flag — FOVEA_FOCUS_CAPTURE.
+ *
+ * The env read lives here in the common layer, NOT inside the engine dirs
+ * (src/synthesize/ takes resolved config only — engine-gates S5.2). It is
+ * consumed by the synthesize focus-signal capture path and the admin
+ * fit/measure surface. Read at call time so a flip is runtime-mutable (no
+ * restart). Default off → serving-neutral: the capture is a guarded no-op
+ * and the admin routes 404.
+ */
+export function focusCaptureEnabled(): boolean {
+  return envFlagEnabled(process.env.FOVEA_FOCUS_CAPTURE);
+}

--- a/src/db/migrations/0094_focus_signal_sample.surql
+++ b/src/db/migrations/0094_focus_signal_sample.surql
@@ -1,0 +1,71 @@
+-- 0094: fovea optics (Optics-1 foundation) — focus-signal capture +
+-- per-class calibration storage. Companion to
+-- docs/roadmap/fovea-optics-2026-08.md §3, §4.2.
+--
+-- SERVING-NEUTRAL: these tables are WRITTEN behind FOVEA_FOCUS_CAPTURE
+-- (default off) and READ only by the admin fit/measure surface. Nothing
+-- on the serving path consumes them yet (Optics-2/3 will wire depth /
+-- threshold / lens-suppression). The schema exists so the §3
+-- measurement (ECE / reliability diagram) can run once samples exist.
+--
+-- Two tables:
+--   focus_signal_sample — one row per captured (signal, outcome) sample.
+--     `correct` is option<int> (NONE until the eval harness backfills the
+--     label — the synthesize DTO carries no expected answer, so
+--     correctness is unknowable at serving time).
+--   focus_calibration — the fitted per-query-class isotonic maps
+--     (fitPerClass output), one versioned row per class. Mirrors the
+--     calibration_table (0019) row shape — thresholds/values arrays — so
+--     it reuses the same PAV serialization idiom.
+
+DEFINE TABLE IF NOT EXISTS focus_signal_sample SCHEMAFULL;
+
+-- Owning tenant (rows are also physically scoped to the per-company DB via
+-- withCompany; the column is kept for cross-tenant fit aggregation later).
+DEFINE FIELD IF NOT EXISTS companyId ON focus_signal_sample TYPE string;
+-- Opaque application-generated key. The eval harness discovers it via the
+-- list endpoint and backfills `correct` by it — no RecordId round-tripping.
+DEFINE FIELD IF NOT EXISTS sampleId ON focus_signal_sample TYPE string;
+-- Calibration class = routed LaneId, or 'default' for unrouted queries.
+DEFINE FIELD IF NOT EXISTS queryClass ON focus_signal_sample TYPE string;
+-- The signal inputs (all in [0,1]) — see FocusSignal in focus-signal.ts.
+DEFINE FIELD IF NOT EXISTS topScore ON focus_signal_sample TYPE float;
+DEFINE FIELD IF NOT EXISTS coverageScore ON focus_signal_sample TYPE float;
+DEFINE FIELD IF NOT EXISTS verifierVerdict ON focus_signal_sample TYPE string;
+DEFINE FIELD IF NOT EXISTS retrievalGap ON focus_signal_sample TYPE float;
+-- The raw blended confidence at capture time (rawFocusConfidence) — stored
+-- so a later refit need not recompute it and so drift in the blend is
+-- auditable against historical samples.
+DEFINE FIELD IF NOT EXISTS rawConfidence ON focus_signal_sample TYPE float;
+-- Observed outcome: 1 correct, 0 incorrect. NONE until labeled.
+DEFINE FIELD IF NOT EXISTS correct ON focus_signal_sample TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS createdAt ON focus_signal_sample TYPE datetime
+    DEFAULT time::now();
+
+-- Fit reads samples by class (and filters to labeled rows); the measure
+-- surface pages recent samples.
+DEFINE INDEX IF NOT EXISTS focus_sample_class_idx ON focus_signal_sample
+    FIELDS queryClass;
+DEFINE INDEX IF NOT EXISTS focus_sample_created_idx ON focus_signal_sample
+    FIELDS createdAt;
+DEFINE INDEX IF NOT EXISTS focus_sample_id_idx ON focus_signal_sample
+    FIELDS sampleId UNIQUE;
+
+DEFINE TABLE IF NOT EXISTS focus_calibration SCHEMAFULL;
+
+-- The query-class this map calibrates ('default' = shared/fallback map).
+DEFINE FIELD IF NOT EXISTS queryClass ON focus_calibration TYPE string;
+-- The fitted PAV map (same encoding as calibration_table): thresholds[i]
+-- is the upper bound of bin i, values[i] the calibrated value emitted when
+-- raw <= thresholds[i].
+DEFINE FIELD IF NOT EXISTS thresholds ON focus_calibration TYPE array<float>;
+DEFINE FIELD IF NOT EXISTS values     ON focus_calibration TYPE array<float>;
+-- Diagnostic — labeled pairs that fitted this row.
+DEFINE FIELD IF NOT EXISTS sampleCount ON focus_calibration TYPE int DEFAULT 0;
+-- Monotone version counter; the reader picks max(version) per class.
+DEFINE FIELD IF NOT EXISTS version ON focus_calibration TYPE int DEFAULT 1;
+DEFINE FIELD IF NOT EXISTS createdAt ON focus_calibration TYPE datetime
+    DEFAULT time::now();
+
+DEFINE INDEX IF NOT EXISTS focus_calibration_key_idx ON focus_calibration
+    FIELDS queryClass, version;

--- a/src/synthesize/focus-admin.controller.ts
+++ b/src/synthesize/focus-admin.controller.ts
@@ -1,0 +1,105 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { FocusSignalService } from './focus-signal.service';
+
+/**
+ * Fovea optics admin surface (Optics-1) — fit + measure the focus signal.
+ * Companion to docs/roadmap/fovea-optics-2026-08.md §3.
+ *
+ * Operator / eval-harness only (brain:admin). Gated by the same master
+ * flag as capture: with FOVEA_FOCUS_CAPTURE off the whole feature is
+ * dormant, so these routes 404 (indistinguishable from absent — the
+ * EPISODES_API idiom). This surface is what runs the §3 ECE / reliability
+ * measurement once labeled samples exist. It does NOT touch serving:
+ * fitting persists a calibration nothing on the answer path reads yet.
+ */
+@Controller('v1/admin/focus')
+@UseGuards(ApiKeyGuard)
+export class FocusAdminController {
+  constructor(private readonly focus: FocusSignalService) {}
+
+  private assertEnabled(): void {
+    if (!FocusSignalService.captureEnabled()) throw new NotFoundException();
+  }
+
+  /** Recent samples (sampleId + class + label state) for backfill discovery. */
+  @Get('samples')
+  @RequireScopes('brain:admin')
+  async samples(
+    @Req() req: AuthenticatedRequest,
+    @Query('limit') limit?: string,
+    @Query('unlabeled') unlabeled?: string,
+  ): Promise<{
+    samples: Array<{
+      sampleId: string;
+      queryClass: string;
+      correct: number | null;
+      createdAt: string | null;
+    }>;
+  }> {
+    this.assertEnabled();
+    const parsed = limit !== undefined ? parseInt(limit, 10) : undefined;
+    const rows = await this.focus.listSamples(req.brainAuth.companyId, {
+      ...(parsed !== undefined && Number.isFinite(parsed) ? { limit: parsed } : {}),
+      onlyUnlabeled: unlabeled === '1' || unlabeled === 'true',
+    });
+    return { samples: rows };
+  }
+
+  /** Backfill outcome labels (the eval-harness path). */
+  @Post('label')
+  @RequireScopes('brain:admin')
+  async label(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { labels?: Array<{ sampleId?: string; correct?: number }> },
+  ): Promise<{ updated: number }> {
+    this.assertEnabled();
+    const raw = body?.labels;
+    if (!Array.isArray(raw) || raw.length === 0) {
+      throw new BadRequestException('labels[] required and must be non-empty');
+    }
+    const labels = raw.map((l) => {
+      if (!l || typeof l.sampleId !== 'string' || (l.correct !== 0 && l.correct !== 1)) {
+        throw new BadRequestException('each label needs a sampleId and correct ∈ {0,1}');
+      }
+      return { sampleId: l.sampleId, correct: l.correct as 0 | 1 };
+    });
+    const updated = await this.focus.labelSamples(req.brainAuth.companyId, labels);
+    return { updated };
+  }
+
+  /** Fit per-class isotonic calibration from labeled samples and persist. */
+  @Post('fit')
+  @RequireScopes('brain:admin')
+  async fit(@Req() req: AuthenticatedRequest): Promise<{
+    sampleCount: number;
+    classes: Array<{ queryClass: string; bins: number; sampleCount: number }>;
+  }> {
+    this.assertEnabled();
+    return this.focus.fitAndPersist(req.brainAuth.companyId);
+  }
+
+  /** The §3 reliability report (ECE + diagram, global and per-class). */
+  @Get('reliability')
+  @RequireScopes('brain:admin')
+  async reliability(
+    @Req() req: AuthenticatedRequest,
+    @Query('bins') bins?: string,
+  ): Promise<unknown> {
+    this.assertEnabled();
+    const parsed = bins !== undefined ? parseInt(bins, 10) : 10;
+    const nBins = Number.isFinite(parsed) && parsed >= 1 && parsed <= 100 ? parsed : 10;
+    return this.focus.reliability(req.brainAuth.companyId, nBins);
+  }
+}

--- a/src/synthesize/focus-signal.service.ts
+++ b/src/synthesize/focus-signal.service.ts
@@ -1,0 +1,310 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { focusCaptureEnabled } from '../common/fovea-flags';
+import { SurrealService } from '../db/surreal.service';
+import type { SearchHit } from '../search/search.types';
+import type { LaneId } from './answer-router';
+import {
+  buildFocusSignal,
+  calibratedConfidence as calibratedConfidenceOf,
+  computeReliability,
+  fitPerClass,
+  queryClassOf,
+  rawFocusConfidence,
+  type FocusOutcomeSample,
+  type FocusSignal,
+  type FocusVerdict,
+  type PerClassCalibration,
+  type ReliabilityReport,
+} from './focus-signal';
+
+/**
+ * FocusSignalService — capture + fit + measure for the fovea focus signal
+ * (Optics-1). Companion to docs/roadmap/fovea-optics-2026-08.md.
+ *
+ * SERVING-NEUTRAL: `maybeCapture` is a no-op unless FOVEA_FOCUS_CAPTURE is
+ * on, and NOTHING on the serving path reads the persisted calibration. The
+ * fit + reliability surface (admin-only) is the §3 measurement that runs
+ * once labeled samples exist. Persistence follows the calibration_table
+ * idiom (versioned rows, thresholds/values arrays, withCompany scope) —
+ * this is not a parallel calibration mechanism, it is the per-class focus
+ * analogue keyed by queryClass.
+ */
+@Injectable()
+export class FocusSignalService {
+  private readonly logger = new Logger(FocusSignalService.name);
+
+  constructor(private readonly surreal: SurrealService) {}
+
+  /** Master flag — delegates to the common-layer reader (engine dirs take
+   *  no direct env reads; see fovea-flags.ts / engine-gates S5.2). Read at
+   *  call time so the knob is runtime-mutable (config-catalog runtimeMutable). */
+  static captureEnabled(): boolean {
+    return focusCaptureEnabled();
+  }
+
+  /**
+   * Record one (signal, outcome=unlabeled) sample at the synthesize verdict
+   * decision point. Guarded FIRST by the master flag: when off this returns
+   * before touching `results` or the DB — zero hot-path cost, byte-identical
+   * serving. Never throws into the caller: a capture failure is logged and
+   * swallowed so the synthesize response is unaffected.
+   */
+  async maybeCapture(
+    companyId: string,
+    args: { results: readonly SearchHit[]; verdict: FocusVerdict; lane: LaneId | null },
+  ): Promise<void> {
+    if (!FocusSignalService.captureEnabled()) return;
+    try {
+      const factScores: number[] = [];
+      for (const hit of args.results) {
+        for (const f of hit.facts) factScores.push(f.score);
+      }
+      const signal = buildFocusSignal({
+        queryClass: queryClassOf(args.lane),
+        factScores,
+        verifierVerdict: args.verdict,
+      });
+      await this.insertSample(companyId, signal);
+    } catch (e) {
+      this.logger.warn(`focus-signal capture failed (${(e as Error).message}); ignored`);
+    }
+  }
+
+  private async insertSample(companyId: string, sig: FocusSignal): Promise<void> {
+    await this.surreal.withCompany(companyId, async (db) => {
+      await db.query(
+        `CREATE focus_signal_sample CONTENT {
+            companyId: $companyId,
+            sampleId: $sampleId,
+            queryClass: $queryClass,
+            topScore: $topScore,
+            coverageScore: $coverageScore,
+            verifierVerdict: $verifierVerdict,
+            retrievalGap: $retrievalGap,
+            rawConfidence: $rawConfidence,
+            correct: NONE
+         }`,
+        {
+          companyId,
+          sampleId: randomUUID(),
+          queryClass: sig.queryClass,
+          topScore: sig.topScore,
+          coverageScore: sig.coverageScore,
+          verifierVerdict: sig.verifierVerdict,
+          retrievalGap: sig.retrievalGap,
+          rawConfidence: rawFocusConfidence(sig),
+        },
+      );
+    });
+  }
+
+  // ── Admin surface: backfill labels, fit, measure ──────────────────
+
+  /**
+   * Backfill outcome labels by sampleId (the eval-harness path — the
+   * synthesize DTO carries no expected answer, so correctness is set here
+   * after the harness scores the answer). Returns the number of rows
+   * updated.
+   */
+  async labelSamples(
+    companyId: string,
+    labels: ReadonlyArray<{ sampleId: string; correct: 0 | 1 }>,
+  ): Promise<number> {
+    if (labels.length === 0) return 0;
+    return this.surreal.withCompany(companyId, async (db) => {
+      // Two statements: the FOR loop applies each label, the trailing SELECT
+      // reports which of the requested ids are now labeled. db.query returns
+      // one result per statement — the SELECT's rows are the last element.
+      const results = await db.query(
+        `FOR $l IN $labels {
+            UPDATE focus_signal_sample SET correct = $l.correct
+              WHERE sampleId = $l.sampleId;
+         };
+         SELECT sampleId FROM focus_signal_sample
+            WHERE sampleId IN $ids AND correct IS NOT NONE;`,
+        { labels, ids: labels.map((l) => l.sampleId) },
+      );
+      const rows = (results as unknown[])[results.length - 1];
+      return Array.isArray(rows) ? rows.length : 0;
+    });
+  }
+
+  /** Load every LABELED sample for a tenant as calibration input. */
+  private async loadLabeledSamples(companyId: string): Promise<FocusOutcomeSample[]> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<
+        [
+          Array<{
+            queryClass: string;
+            topScore: number;
+            coverageScore: number;
+            verifierVerdict: string;
+            retrievalGap: number;
+            correct: number;
+          }>,
+        ]
+      >(
+        `SELECT queryClass, topScore, coverageScore, verifierVerdict,
+                retrievalGap, correct
+            FROM focus_signal_sample
+            WHERE correct IS NOT NONE
+            LIMIT 100000`,
+      );
+      return (rows ?? []).map((r) => ({
+        queryClass: r.queryClass,
+        topScore: r.topScore,
+        coverageScore: r.coverageScore,
+        verifierVerdict: normalizeVerdict(r.verifierVerdict),
+        retrievalGap: r.retrievalGap,
+        correct: r.correct === 1 ? 1 : 0,
+      }));
+    });
+  }
+
+  /**
+   * Fit per-class isotonic calibration from labeled samples and persist one
+   * versioned row per class (calibration_table idiom). Returns a summary.
+   */
+  async fitAndPersist(companyId: string): Promise<{
+    sampleCount: number;
+    classes: Array<{ queryClass: string; bins: number; sampleCount: number }>;
+  }> {
+    const samples = await this.loadLabeledSamples(companyId);
+    const cal = fitPerClass(samples);
+    const persisted = await this.persistCalibration(companyId, cal);
+    return { sampleCount: samples.length, classes: persisted };
+  }
+
+  private async persistCalibration(
+    companyId: string,
+    cal: PerClassCalibration,
+  ): Promise<Array<{ queryClass: string; bins: number; sampleCount: number }>> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const out: Array<{ queryClass: string; bins: number; sampleCount: number }> = [];
+      for (const [queryClass, map] of Object.entries(cal)) {
+        const [latest] = await db.query<[Array<{ version: number }>]>(
+          `SELECT version FROM focus_calibration
+              WHERE queryClass = $q ORDER BY version DESC LIMIT 1`,
+          { q: queryClass },
+        );
+        const next = Array.isArray(latest) && latest[0]?.version ? latest[0].version + 1 : 1;
+        await db.query(
+          `CREATE focus_calibration CONTENT {
+              queryClass: $q,
+              thresholds: $t,
+              values: $v,
+              sampleCount: $sc,
+              version: $version
+           }`,
+          {
+            q: queryClass,
+            t: map.thresholds,
+            v: map.values,
+            sc: map.sampleCount,
+            version: next,
+          },
+        );
+        out.push({ queryClass, bins: map.thresholds.length, sampleCount: map.sampleCount });
+      }
+      return out;
+    });
+  }
+
+  /** Load the latest persisted per-class calibration (max version/class). */
+  async loadCalibration(companyId: string): Promise<PerClassCalibration> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<
+        [
+          Array<{
+            queryClass: string;
+            thresholds: number[];
+            values: number[];
+            sampleCount: number;
+            version: number;
+          }>,
+        ]
+      >(
+        `SELECT queryClass, thresholds, values, sampleCount, version
+            FROM focus_calibration ORDER BY version DESC`,
+      );
+      const cal: PerClassCalibration = {};
+      for (const r of rows ?? []) {
+        // First row per class wins (rows are version-desc ordered).
+        if (cal[r.queryClass]) continue;
+        if (!Array.isArray(r.thresholds) || !Array.isArray(r.values)) continue;
+        cal[r.queryClass] = {
+          thresholds: r.thresholds,
+          values: r.values,
+          sampleCount: r.sampleCount,
+        };
+      }
+      return cal;
+    });
+  }
+
+  /**
+   * The §3 reliability report (ECE + diagram, global and per-class) over
+   * the labeled samples. This is the honest gate: ship no adaptive optic
+   * whose driving signal hasn't passed it.
+   */
+  async reliability(
+    companyId: string,
+    bins = 10,
+  ): Promise<ReliabilityReport & { sampleCount: number }> {
+    const samples = await this.loadLabeledSamples(companyId);
+    return { ...computeReliability(samples, bins), sampleCount: samples.length };
+  }
+
+  /** Apply the latest persisted calibration to a live signal — provided for
+   *  Optics-2/3 (NOT called on the serving path in this PR). */
+  async calibrate(companyId: string, sig: FocusSignal): Promise<number> {
+    const cal = await this.loadCalibration(companyId);
+    return calibratedConfidenceOf(cal, sig);
+  }
+
+  /** List recent samples (id + class + label state) so the harness can
+   *  discover sampleIds to backfill. */
+  async listSamples(
+    companyId: string,
+    opts: { limit?: number; onlyUnlabeled?: boolean } = {},
+  ): Promise<
+    Array<{
+      sampleId: string;
+      queryClass: string;
+      correct: number | null;
+      createdAt: string | null;
+    }>
+  > {
+    const limit = Math.min(Math.max(opts.limit ?? 100, 1), 1000);
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<
+        [
+          Array<{
+            sampleId: string;
+            queryClass: string;
+            correct: number | null;
+            createdAt: string | null;
+          }>,
+        ]
+      >(
+        `SELECT sampleId, queryClass, correct, createdAt
+            FROM focus_signal_sample
+            ${opts.onlyUnlabeled ? 'WHERE correct IS NONE' : ''}
+            ORDER BY createdAt DESC
+            LIMIT ${limit}`,
+      );
+      return (rows ?? []).map((r) => ({
+        sampleId: r.sampleId,
+        queryClass: r.queryClass,
+        correct: r.correct ?? null,
+        createdAt: r.createdAt ? new Date(r.createdAt).toISOString() : null,
+      }));
+    });
+  }
+}
+
+/** Coerce a stored verdict string back into the FocusVerdict union. */
+function normalizeVerdict(v: string): FocusVerdict {
+  return v === 'supported' || v === 'partial' || v === 'unsupported' ? v : 'none';
+}

--- a/src/synthesize/focus-signal.ts
+++ b/src/synthesize/focus-signal.ts
@@ -1,0 +1,325 @@
+/**
+ * Fovea optics — the focus signal (Optics-1 foundation).
+ *
+ * Companion to docs/roadmap/fovea-optics-2026-08.md §2-§4.2. The fovea
+ * cascade decides WHERE to spend high resolution (L3 escalation, the
+ * abstention floor, lens suppression). Today those decisions read a
+ * static constant. The researched plan makes them adaptive — but §3 is
+ * emphatic that adaptive allocation AMPLIFIES a bad signal, so the honest
+ * prerequisite is not any adaptive decision: it is a SINGLE per-query-class
+ * calibrated confidence signal whose trustworthiness is measured (ECE /
+ * reliability diagram) BEFORE anything consumes it.
+ *
+ * This module is that foundation, and nothing else:
+ *   - `FocusSignal` — the signal's definition (the three inputs §2 names:
+ *     verifier verdict, evidence coverage, retrieval score distribution).
+ *   - `rawFocusConfidence` — a documented, monotone blend → [0,1]. This is
+ *     the RAW signal; calibration corrects it.
+ *   - `queryClassOf` — LaneId → calibration class (encodes the genre law:
+ *     a lane that is +LoCoMo is −28pp on assistant-chats, so a single
+ *     global threshold is miscalibrated across classes).
+ *   - `fitPerClass` / `calibratedConfidence` — per-class isotonic
+ *     calibration, REUSING the in-repo PAV primitive (isotonic.ts). No new
+ *     PAV; no parallel calibration mechanism.
+ *   - `computeReliability` — the §3 measurement (ECE + reliability-diagram
+ *     bins, global and per-class).
+ *
+ * Pure module — no DI, no IO, no env. Persistence + capture live in
+ * focus-signal.service.ts; the decision-point wiring is one guarded call
+ * in synthesize.service.ts. SERVING-NEUTRAL: nothing here is consumed by
+ * the serving path yet (Optics-2/3 wire depth / threshold / suppression).
+ */
+
+import {
+  applyMap,
+  fitIsotonic,
+  type CalibrationMap,
+  type CalibrationPair,
+} from '../ai/calibration/isotonic';
+import type { LaneId } from './answer-router';
+
+/** The verifier verdict, extended with 'none' for the paths where no
+ *  verifier ran (off/answer modes, pre-verifier abstention exits). */
+export type FocusVerdict = 'supported' | 'partial' | 'unsupported' | 'none';
+
+/**
+ * The focus signal at the verdict/abstention decision point — the three
+ * inputs §2 identifies, plus the query class that keys calibration.
+ */
+export interface FocusSignal {
+  /** Calibration class (see `queryClassOf`) — the routed LaneId, or
+   *  'default' for unrouted queries. */
+  queryClass: string;
+  /** Best (top-1) per-fact retrieval score across the evidence, in [0,1].
+   *  The abstention floor's `minTopScore` reads the same value. */
+  topScore: number;
+  /** Mean per-fact retrieval score across the retained evidence, in [0,1]
+   *  — how strongly, on average, the evidence matches the question. The
+   *  §3 "coverage_score" whose calibration this module measures. */
+  coverageScore: number;
+  /** The verifier's grounding verdict, or 'none' when no verifier ran. */
+  verifierVerdict: FocusVerdict;
+  /** top1 − topN: the spread of the retained score distribution. A wide
+   *  gap means the top hit stands out (a distinctive, confident retrieval);
+   *  a flat distribution (small gap) means ambiguous evidence. In [0,1]. */
+  retrievalGap: number;
+}
+
+/** A captured signal paired with its observed outcome (1 = the answer was
+ *  correct, 0 = incorrect). The outcome is unknown at serving time — it is
+ *  backfilled by the eval harness — so calibration/measurement operate on
+ *  labeled samples only. */
+export type FocusOutcomeSample = FocusSignal & { correct: 0 | 1 };
+
+/** Per-query-class calibration: one PAV map per class, plus a shared
+ *  'default' map used for unrouted queries and as the sparse-class
+ *  fallback. */
+export type PerClassCalibration = Record<string, CalibrationMap>;
+
+/**
+ * Minimum labeled samples a class needs before it earns its OWN calibration
+ * map. Below this a class falls back to the shared 'default' map (fit over
+ * every sample) — a per-class isotonic fit on a handful of points overfits
+ * and is worse than the pooled prior. 30 mirrors the ~100-200/class the
+ * roadmap targets while still admitting sparse lanes to the fallback rather
+ * than dropping them. (The nightly fact-calibration refit uses a 40-pair
+ * global floor; this is the per-class analogue.)
+ */
+export const MIN_CLASS_SAMPLES = 30;
+
+/** The shared/fallback calibration-class key. */
+export const DEFAULT_CLASS = 'default';
+
+// ── Raw signal ─────────────────────────────────────────────────────
+
+/**
+ * Verdict → a numeric score in [0,1]. supported (fully grounded) is the
+ * strongest positive evidence; partial is a half-signal; unsupported and
+ * 'none' (no verdict available) both contribute nothing.
+ */
+function verdictScore(v: FocusVerdict): number {
+  switch (v) {
+    case 'supported':
+      return 1;
+    case 'partial':
+      return 0.5;
+    default:
+      return 0; // 'unsupported' | 'none'
+  }
+}
+
+// Blend weights — documented, and deliberately simple. Every term is a
+// POSITIVE contribution, so `rawFocusConfidence` is monotone-nondecreasing
+// in each input (the property the calibrator and the reliability
+// measurement both assume). Coverage and verdict carry the most weight
+// (they are the two signals §2 leans on); topScore and the distribution
+// gap are refinements. Sum = 1, so the output stays in [0,1].
+const W_COVERAGE = 0.35;
+const W_VERDICT = 0.35;
+const W_GAP = 0.15;
+const W_TOP = 0.15;
+
+/**
+ * The RAW focus confidence in [0,1] — a documented, monotone blend of the
+ * four inputs. This is deliberately crude: it is the signal calibration
+ * CORRECTS. Its job is only to be monotone-ish and cheap; `fitPerClass`
+ * learns the actual raw→P(correct) shape per class.
+ */
+export function rawFocusConfidence(sig: FocusSignal): number {
+  const cov = clamp01(sig.coverageScore);
+  const top = clamp01(sig.topScore);
+  const gap = clamp01(sig.retrievalGap);
+  const verdict = verdictScore(sig.verifierVerdict);
+  return clamp01(W_COVERAGE * cov + W_VERDICT * verdict + W_GAP * gap + W_TOP * top);
+}
+
+/**
+ * Build a `FocusSignal` from a bag of per-fact retrieval scores plus the
+ * verdict and class. Pure — the service flattens `SearchHit[]` into scores
+ * and calls this, so the arithmetic stays unit-testable without domain
+ * types. `factScores` need not be sorted.
+ */
+export function buildFocusSignal(input: {
+  queryClass: string;
+  factScores: readonly number[];
+  verifierVerdict: FocusVerdict;
+}): FocusSignal {
+  const scores = input.factScores.filter((s) => Number.isFinite(s)).map(clamp01);
+  if (scores.length === 0) {
+    return {
+      queryClass: input.queryClass,
+      topScore: 0,
+      coverageScore: 0,
+      verifierVerdict: input.verifierVerdict,
+      retrievalGap: 0,
+    };
+  }
+  const sorted = [...scores].sort((a, b) => b - a);
+  const topScore = sorted[0]!;
+  const lastScore = sorted[sorted.length - 1]!;
+  const mean = sorted.reduce((a, b) => a + b, 0) / sorted.length;
+  return {
+    queryClass: input.queryClass,
+    topScore,
+    coverageScore: clamp01(mean),
+    verifierVerdict: input.verifierVerdict,
+    retrievalGap: clamp01(topScore - lastScore),
+  };
+}
+
+/**
+ * LaneId → calibration class. Unrouted queries (null) map to 'default'.
+ * One class per lane by design: the segment-lane genre law says a lane's
+ * value flips sign across genres, so its calibration must be per-class.
+ */
+export function queryClassOf(laneId: LaneId | null | undefined): string {
+  return laneId ?? DEFAULT_CLASS;
+}
+
+// ── Per-class calibration (reuses isotonic.ts) ─────────────────────
+
+/**
+ * Fit one isotonic calibration map per query-class from labeled samples,
+ * mapping rawFocusConfidence → P(correct). Grouping is by `queryClass`.
+ *
+ *   - A shared 'default' map is ALWAYS fit over EVERY sample. It is both
+ *     the map for unrouted ('default') queries and the fallback for any
+ *     class below MIN_CLASS_SAMPLES.
+ *   - Each class with ≥ MIN_CLASS_SAMPLES labeled samples earns its own
+ *     map, fit on its samples alone.
+ *   - Sparse classes get no own map — `calibratedConfidence` falls through
+ *     to 'default'. A missed per-class fit therefore degrades to the pooled
+ *     prior, never to nothing.
+ *
+ * Reuses `fitIsotonic` (the PAV primitive) throughout — no new regression.
+ */
+export function fitPerClass(samples: readonly FocusOutcomeSample[]): PerClassCalibration {
+  const byClass = new Map<string, CalibrationPair[]>();
+  const all: CalibrationPair[] = [];
+  for (const s of samples) {
+    const pair: CalibrationPair = {
+      rawConfidence: rawFocusConfidence(s),
+      correctness: s.correct,
+    };
+    all.push(pair);
+    const bucket = byClass.get(s.queryClass);
+    if (bucket) bucket.push(pair);
+    else byClass.set(s.queryClass, [pair]);
+  }
+  const out: PerClassCalibration = { [DEFAULT_CLASS]: fitIsotonic(all) };
+  for (const [cls, pairs] of byClass) {
+    if (cls === DEFAULT_CLASS) continue; // the shared map already covers it
+    if (pairs.length >= MIN_CLASS_SAMPLES) out[cls] = fitIsotonic(pairs);
+  }
+  return out;
+}
+
+/**
+ * Apply the calibrated map for a signal's class to its raw confidence.
+ * Uses the class's own map when present, else the shared 'default' map,
+ * else (empty calibration) the raw value unchanged.
+ */
+export function calibratedConfidence(cal: PerClassCalibration, sig: FocusSignal): number {
+  const raw = rawFocusConfidence(sig);
+  const map = cal[sig.queryClass] ?? cal[DEFAULT_CLASS];
+  return map ? applyMap(map, raw) : raw;
+}
+
+// ── §3 measurement: reliability diagram + ECE ──────────────────────
+
+export interface ReliabilityBin {
+  /** Lower edge of the bin on the predicted-probability axis. */
+  binLo: number;
+  /** Upper edge of the bin. */
+  binHi: number;
+  /** Mean predicted probability of the samples in the bin (bin center when
+   *  empty — a plotting placeholder that contributes 0 to ECE). */
+  meanPred: number;
+  /** Observed correctness fraction of the samples in the bin (0 when
+   *  empty). */
+  empirical: number;
+  /** Number of samples in the bin. */
+  count: number;
+}
+
+export interface ReliabilityReport {
+  /** Global expected calibration error over all samples, in [0,1]. */
+  ece: number;
+  /** ECE computed independently per query-class. */
+  perClassEce: Record<string, number>;
+  /** The global reliability diagram — one entry per bin. */
+  diagram: ReliabilityBin[];
+}
+
+/**
+ * The §3 measurement: bin the RAW focus confidence, compare mean predicted
+ * vs observed correctness per bin, and report ECE + the reliability diagram
+ * — globally and per query-class.
+ *
+ * ECE = Σ_bins (count_bin / N) · |meanPred_bin − empirical_bin|.
+ *
+ * Predicting with `rawFocusConfidence` (NOT a calibrated value) is
+ * deliberate: this measures whether the RAW signal is trustworthy, which is
+ * the gate §3 requires before any adaptive optic is wired. A low ECE means
+ * adaptive gating will help; a high/miscalibrated-per-class ECE is itself
+ * the finding — fix calibration (fitPerClass) first.
+ */
+export function computeReliability(
+  samples: readonly FocusOutcomeSample[],
+  bins = 10,
+): ReliabilityReport {
+  const global = reliabilityFor(samples, bins);
+  const classes = new Set(samples.map((s) => s.queryClass));
+  const perClassEce: Record<string, number> = {};
+  for (const cls of classes) {
+    perClassEce[cls] = reliabilityFor(
+      samples.filter((s) => s.queryClass === cls),
+      bins,
+    ).ece;
+  }
+  return { ece: global.ece, perClassEce, diagram: global.diagram };
+}
+
+/** Global ECE + diagram over one sample set. */
+function reliabilityFor(
+  samples: readonly FocusOutcomeSample[],
+  bins: number,
+): { ece: number; diagram: ReliabilityBin[] } {
+  const nBins = Math.max(1, Math.floor(bins));
+  const predSum = new Array<number>(nBins).fill(0);
+  const correctSum = new Array<number>(nBins).fill(0);
+  const counts = new Array<number>(nBins).fill(0);
+  for (const s of samples) {
+    const p = rawFocusConfidence(s);
+    let idx = Math.floor(p * nBins);
+    if (idx >= nBins) idx = nBins - 1;
+    if (idx < 0) idx = 0;
+    predSum[idx]! += p;
+    correctSum[idx]! += s.correct;
+    counts[idx]! += 1;
+  }
+  const total = samples.length;
+  const diagram: ReliabilityBin[] = [];
+  let ece = 0;
+  for (let i = 0; i < nBins; i++) {
+    const binLo = i / nBins;
+    const binHi = (i + 1) / nBins;
+    const count = counts[i]!;
+    if (count === 0) {
+      diagram.push({ binLo, binHi, meanPred: (binLo + binHi) / 2, empirical: 0, count: 0 });
+      continue;
+    }
+    const meanPred = predSum[i]! / count;
+    const empirical = correctSum[i]! / count;
+    diagram.push({ binLo, binHi, meanPred, empirical, count });
+    ece += (count / total) * Math.abs(meanPred - empirical);
+  }
+  return { ece: total === 0 ? 0 : ece, diagram };
+}
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}

--- a/src/synthesize/synthesize.module.ts
+++ b/src/synthesize/synthesize.module.ts
@@ -4,7 +4,9 @@ import { EpisodesModule } from '../episodes/episodes.module';
 import { AnswerCacheModule } from '../answer-cache/answer-cache.module';
 import { StrategyModule } from '../strategy/strategy.module';
 import { SynthesizeController } from './synthesize.controller';
+import { FocusAdminController } from './focus-admin.controller';
 import { SynthesizeService } from './synthesize.service';
+import { FocusSignalService } from './focus-signal.service';
 import { EpisodeLaneService } from './episode-lane.service';
 import { SegmentLaneService } from './segment-lane.service';
 import { InsightLaneService } from './insight-lane.service';
@@ -17,9 +19,10 @@ import { L3EscalationService } from './l3-escalation.service';
 
 @Module({
   imports: [SearchModule, EpisodesModule, AnswerCacheModule, StrategyModule],
-  controllers: [SynthesizeController],
+  controllers: [SynthesizeController, FocusAdminController],
   providers: [
     SynthesizeService,
+    FocusSignalService,
     EvidenceCollectorService,
     EpisodeLaneService,
     SegmentLaneService,

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -39,6 +39,8 @@ export { buildGeneratorUserMessage } from './generator-prompt';
 import { EvidenceCollectorService } from './evidence-collector.service';
 import type { CollectedEvidence } from './evidence-collector.service';
 import { L3EscalationService } from './l3-escalation.service';
+import { FocusSignalService } from './focus-signal.service';
+import type { FocusVerdict } from './focus-signal';
 import {
   AnswerCacheService,
   type AnswerCacheBeginResult,
@@ -116,6 +118,7 @@ export class SynthesizeService {
     @Optional() private readonly evidenceCollector?: EvidenceCollectorService,
     @Optional() private readonly answerCache?: AnswerCacheService,
     @Optional() private readonly l3?: L3EscalationService,
+    @Optional() private readonly focusSignal?: FocusSignalService,
   ) {
     this.openai = createOpenAiClientOrThrow(this.configService);
     this.defaultModel = this.configService.get<string>(
@@ -223,9 +226,8 @@ export class SynthesizeService {
       profile.extraEvidenceCap,
     );
 
-    const answerMode = guardrails === 'answer';
     const prepareOpts = this.buildPrepareOpts({
-      answerMode,
+      answerMode: guardrails === 'answer',
       explain,
       lane,
       asOf: dto.asOf,
@@ -418,6 +420,9 @@ export class SynthesizeService {
       });
     }
 
+    // Optics-1 focus capture — SERVING-NEUTRAL guarded no-op (see method).
+    await this.maybeCaptureFocusSignal(companyId, { results, verdict: verdict.verdict, lane });
+
     // G2 L3 escalation — the pre-abstention seam. On a verifier-fail with
     // an anchoring session it escalates ONCE to full-raw-session context
     // and returns the L3 answer when re-verification flips fail→pass;
@@ -451,6 +456,20 @@ export class SynthesizeService {
         abstention: profile.abstentionCalibration,
       })
     );
+  }
+
+  /**
+   * Optics-1 focus-signal capture — a guarded no-op when the flag is off
+   * (or the service is absent). Extracted so synthesize() keeps a single
+   * capture call on the serving path and stays within its line budget.
+   * SERVING-NEUTRAL: nothing consumes the captured signal yet.
+   */
+  private async maybeCaptureFocusSignal(
+    companyId: string,
+    signal: { results: SearchHit[]; verdict: FocusVerdict; lane: LaneId | null },
+  ): Promise<void> {
+    if (!this.focusSignal || !FocusSignalService.captureEnabled()) return;
+    await this.focusSignal.maybeCapture(companyId, signal);
   }
 
   /**

--- a/test/engine-gates.unit-spec.ts
+++ b/test/engine-gates.unit-spec.ts
@@ -152,6 +152,11 @@ describe('S5.5 — dead exports in the engine dirs', () => {
     'detectLane',
     'mergeExtraHits',
     'rrfFuse',
+    // Fovea optics (Optics-1) documented constants — the per-class fit
+    // threshold and the shared/fallback class key. Pinned by the
+    // focus-signal unit spec; no serving consumer yet (Optics-2/3).
+    'MIN_CLASS_SAMPLES',
+    'DEFAULT_CLASS',
   ]);
   const TESTS = walk(join(ROOT, 'test'))
     .map((f) => readFileSync(f, 'utf8'))

--- a/test/focus-signal.e2e-spec.ts
+++ b/test/focus-signal.e2e-spec.ts
@@ -1,0 +1,175 @@
+/**
+ * e2e — fovea focus-signal capture + admin fit/measure surface (Optics-1).
+ *
+ * Verifies the serving-neutral contract:
+ *   - FOVEA_FOCUS_CAPTURE off → a /v1/synthesize writes NO focus_signal_sample
+ *     row (guarded no-op) and the admin surface 404s.
+ *   - FOVEA_FOCUS_CAPTURE on → a /v1/synthesize records exactly one sample,
+ *     companyId-scoped, at the verdict decision point.
+ *   - The admin fit endpoint persists a per-class CalibrationMap and the
+ *     reliability endpoint returns the §3 ECE report.
+ */
+import { randomUUID } from 'node:crypto';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSynthesizeOpenAi } from './test-doubles';
+import { SurrealService } from '../src/db/surreal.service';
+
+describe('Fovea Optics-1 — focus-signal capture + calibration surface', () => {
+  let f: AppFixture;
+  let surreal: SurrealService;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const sampleCount = async (): Promise<number> =>
+    surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ sampleId: string }>]>(
+        'SELECT sampleId FROM focus_signal_sample',
+      );
+      return Array.isArray(rows) ? rows.length : 0;
+    });
+
+  const runSynthesize = async (query: string): Promise<void> => {
+    const searchRes = await f.http.post('/v1/search').set(auth()).send({ query, limit: 5 });
+    const factId = searchRes.body.results[0]?.facts[0]?.factId;
+    expect(factId).toBeTruthy();
+    mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer: `Answer [${factId}].`, citedFactIds: [factId] }),
+      JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+    ]);
+    const res = await f.http.post('/v1/synthesize').set(auth()).send({ query, limit: 5 });
+    expect(res.status).toBe(201);
+  };
+
+  beforeAll(async () => {
+    delete process.env.FOVEA_FOCUS_CAPTURE;
+    f = await createApp();
+    surreal = f.app.get(SurrealService);
+    await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'focus_tenant' },
+        predicate: 'status',
+        object: 'engineer',
+        validFrom: '2026-04-01',
+        source: { vertical: 'rent', eventId: 'auth.profile_updated' },
+        confidence: 0.9,
+      });
+  });
+
+  afterAll(async () => {
+    delete process.env.FOVEA_FOCUS_CAPTURE;
+    if (f) await f.close();
+  });
+
+  it('writes NO sample when the flag is off (serving-neutral)', async () => {
+    delete process.env.FOVEA_FOCUS_CAPTURE;
+    const before = await sampleCount();
+    await runSynthesize('engineer');
+    const after = await sampleCount();
+    expect(after).toBe(before);
+  });
+
+  it('404s the admin surface when the master flag is off', async () => {
+    delete process.env.FOVEA_FOCUS_CAPTURE;
+    const rel = await f.http.get('/v1/admin/focus/reliability').set(auth());
+    expect(rel.status).toBe(404);
+    const fit = await f.http.post('/v1/admin/focus/fit').set(auth()).send({});
+    expect(fit.status).toBe(404);
+  });
+
+  it('records exactly one companyId-scoped sample when the flag is on', async () => {
+    process.env.FOVEA_FOCUS_CAPTURE = '1';
+    const before = await sampleCount();
+    await runSynthesize('engineer');
+    const after = await sampleCount();
+    expect(after).toBe(before + 1);
+
+    const row = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<
+        [
+          Array<{
+            companyId: string;
+            queryClass: string;
+            verifierVerdict: string;
+            correct: number | null;
+          }>,
+        ]
+      >(
+        'SELECT companyId, queryClass, verifierVerdict, correct, createdAt FROM focus_signal_sample ORDER BY createdAt DESC LIMIT 1',
+      );
+      return rows?.[0];
+    });
+    expect(row?.companyId).toBe(f.companyId);
+    expect(typeof row?.queryClass).toBe('string');
+    // Unlabeled at capture time — correctness is backfilled by the harness.
+    expect(row?.correct == null).toBe(true);
+  });
+
+  it('fits a per-class CalibrationMap and returns an ECE report', async () => {
+    process.env.FOVEA_FOCUS_CAPTURE = '1';
+    // Seed ~40 labeled samples directly so the default class earns a map.
+    await surreal.withCompany(f.companyId, async (db) => {
+      for (let i = 0; i < 40; i++) {
+        const x = (i + 0.5) / 40;
+        await db.query(
+          `CREATE focus_signal_sample CONTENT {
+              companyId: $c, sampleId: $s, queryClass: 'default',
+              topScore: $x, coverageScore: $x, retrievalGap: $x,
+              verifierVerdict: 'none', rawConfidence: $r, correct: $correct
+           }`,
+          {
+            c: f.companyId,
+            s: randomUUID(),
+            x,
+            r: 0.65 * x,
+            correct: x > 0.5 ? 1 : 0,
+          },
+        );
+      }
+    });
+
+    const fit = await f.http.post('/v1/admin/focus/fit').set(auth()).send({});
+    expect(fit.status).toBe(201);
+    expect(fit.body.sampleCount).toBeGreaterThanOrEqual(40);
+    expect(Array.isArray(fit.body.classes)).toBe(true);
+    expect(fit.body.classes.some((c: { queryClass: string }) => c.queryClass === 'default')).toBe(
+      true,
+    );
+
+    // A CalibrationMap row was persisted.
+    const persisted = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<
+        [Array<{ queryClass: string; thresholds: number[]; values: number[] }>]
+      >('SELECT queryClass, thresholds, values FROM focus_calibration');
+      return rows ?? [];
+    });
+    const def = persisted.find((r) => r.queryClass === 'default');
+    expect(def).toBeDefined();
+    expect(Array.isArray(def!.thresholds)).toBe(true);
+    expect(def!.thresholds.length).toBe(def!.values.length);
+
+    // §3 measurement returns a numeric ECE + diagram.
+    const rel = await f.http.get('/v1/admin/focus/reliability').set(auth());
+    expect(rel.status).toBe(200);
+    expect(typeof rel.body.ece).toBe('number');
+    expect(Array.isArray(rel.body.diagram)).toBe(true);
+    expect(rel.body.sampleCount).toBeGreaterThanOrEqual(40);
+  });
+
+  it('backfills outcome labels by sampleId', async () => {
+    process.env.FOVEA_FOCUS_CAPTURE = '1';
+    // The one captured (unlabeled) sample from the flag-on test.
+    const list = await f.http.get('/v1/admin/focus/samples?unlabeled=1').set(auth());
+    expect(list.status).toBe(200);
+    const target = list.body.samples[0];
+    expect(target?.sampleId).toBeTruthy();
+
+    const res = await f.http
+      .post('/v1/admin/focus/label')
+      .set(auth())
+      .send({ labels: [{ sampleId: target.sampleId, correct: 1 }] });
+    expect(res.status).toBe(201);
+    expect(res.body.updated).toBe(1);
+  });
+});

--- a/test/focus-signal.unit-spec.ts
+++ b/test/focus-signal.unit-spec.ts
@@ -1,0 +1,247 @@
+/**
+ * Unit spec — fovea focus signal (Optics-1 pure module).
+ *
+ * Covers the raw signal (monotonicity + bounds), class mapping, signal
+ * construction from fact scores, per-class isotonic fit + sparse-class
+ * fallback, calibrated confidence, and the §3 reliability/ECE measurement
+ * (perfectly-calibrated → ECE≈0, miscalibrated → ECE>0, per-class split).
+ */
+import { applyMap } from '../src/ai/calibration/isotonic';
+import {
+  buildFocusSignal,
+  calibratedConfidence,
+  computeReliability,
+  DEFAULT_CLASS,
+  fitPerClass,
+  MIN_CLASS_SAMPLES,
+  queryClassOf,
+  rawFocusConfidence,
+  type FocusOutcomeSample,
+  type FocusSignal,
+  type FocusVerdict,
+} from '../src/synthesize/focus-signal';
+
+/** Construct a signal whose rawFocusConfidence is exactly `p` (used to
+ *  drive the reliability tests to known bins). raw = 0.65·x + 0.35·v with
+ *  x = coverage = gap = top and v ∈ {0,1}; solve for x per target. */
+function signalWithRaw(p: number, queryClass = DEFAULT_CLASS): FocusSignal {
+  const useSupported = p > 0.65;
+  const v = useSupported ? 1 : 0;
+  const x = Math.min(1, Math.max(0, (p - 0.35 * v) / 0.65));
+  return {
+    queryClass,
+    topScore: x,
+    coverageScore: x,
+    retrievalGap: x,
+    verifierVerdict: useSupported ? 'supported' : 'none',
+  };
+}
+
+describe('rawFocusConfidence', () => {
+  const base: FocusSignal = {
+    queryClass: 'temporal',
+    topScore: 0.4,
+    coverageScore: 0.4,
+    retrievalGap: 0.4,
+    verifierVerdict: 'partial',
+  };
+
+  it('stays within [0,1] at the extremes and clamps out-of-range inputs', () => {
+    expect(
+      rawFocusConfidence({
+        queryClass: 'x',
+        topScore: 0,
+        coverageScore: 0,
+        retrievalGap: 0,
+        verifierVerdict: 'none',
+      }),
+    ).toBe(0);
+    expect(
+      rawFocusConfidence({
+        queryClass: 'x',
+        topScore: 1,
+        coverageScore: 1,
+        retrievalGap: 1,
+        verifierVerdict: 'supported',
+      }),
+    ).toBe(1);
+    // Out-of-range inputs are clamped, never overflow.
+    const over = rawFocusConfidence({
+      queryClass: 'x',
+      topScore: 5,
+      coverageScore: 9,
+      retrievalGap: -3,
+      verifierVerdict: 'supported',
+    });
+    expect(over).toBeGreaterThanOrEqual(0);
+    expect(over).toBeLessThanOrEqual(1);
+  });
+
+  it('is monotone-nondecreasing in each continuous input', () => {
+    const up = (patch: Partial<FocusSignal>) => rawFocusConfidence({ ...base, ...patch });
+    expect(up({ coverageScore: 0.9 })).toBeGreaterThan(rawFocusConfidence(base));
+    expect(up({ topScore: 0.9 })).toBeGreaterThan(rawFocusConfidence(base));
+    expect(up({ retrievalGap: 0.9 })).toBeGreaterThan(rawFocusConfidence(base));
+  });
+
+  it('orders the verdict contribution supported > partial > unsupported = none', () => {
+    const withVerdict = (verifierVerdict: FocusVerdict) =>
+      rawFocusConfidence({ ...base, verifierVerdict });
+    expect(withVerdict('supported')).toBeGreaterThan(withVerdict('partial'));
+    expect(withVerdict('partial')).toBeGreaterThan(withVerdict('unsupported'));
+    expect(withVerdict('unsupported')).toBe(withVerdict('none'));
+  });
+});
+
+describe('queryClassOf', () => {
+  it('maps a LaneId to itself and null/undefined to the default class', () => {
+    expect(queryClassOf('temporal')).toBe('temporal');
+    expect(queryClassOf('enumeration')).toBe('enumeration');
+    expect(queryClassOf(null)).toBe(DEFAULT_CLASS);
+    expect(queryClassOf(undefined)).toBe(DEFAULT_CLASS);
+  });
+});
+
+describe('buildFocusSignal', () => {
+  it('computes topScore, mean coverage, and top1−topN gap from fact scores', () => {
+    const sig = buildFocusSignal({
+      queryClass: 'temporal',
+      factScores: [0.5, 0.9, 0.1],
+      verifierVerdict: 'supported',
+    });
+    expect(sig.topScore).toBeCloseTo(0.9, 10);
+    expect(sig.coverageScore).toBeCloseTo((0.5 + 0.9 + 0.1) / 3, 10);
+    expect(sig.retrievalGap).toBeCloseTo(0.9 - 0.1, 10);
+    expect(sig.queryClass).toBe('temporal');
+    expect(sig.verifierVerdict).toBe('supported');
+  });
+
+  it('returns an all-zero signal for empty evidence', () => {
+    const sig = buildFocusSignal({ queryClass: 'x', factScores: [], verifierVerdict: 'none' });
+    expect(sig.topScore).toBe(0);
+    expect(sig.coverageScore).toBe(0);
+    expect(sig.retrievalGap).toBe(0);
+  });
+
+  it('clamps out-of-range and drops non-finite scores', () => {
+    const sig = buildFocusSignal({
+      queryClass: 'x',
+      factScores: [2, -1, Number.NaN, 0.5],
+      verifierVerdict: 'partial',
+    });
+    // 2→1, -1→0, NaN dropped, 0.5 kept.
+    expect(sig.topScore).toBe(1);
+    expect(sig.coverageScore).toBeCloseTo((1 + 0 + 0.5) / 3, 10);
+    expect(sig.retrievalGap).toBe(1);
+  });
+});
+
+describe('fitPerClass + calibratedConfidence', () => {
+  function samplesFor(queryClass: string, n: number): FocusOutcomeSample[] {
+    // Monotone-ish: correct becomes likely as raw rises.
+    const out: FocusOutcomeSample[] = [];
+    for (let i = 0; i < n; i++) {
+      const p = (i + 0.5) / n;
+      const sig = signalWithRaw(p, queryClass);
+      out.push({ ...sig, correct: p > 0.5 ? 1 : 0 });
+    }
+    return out;
+  }
+
+  it('fits an own map for populated classes and falls back to default for sparse ones', () => {
+    const samples = [
+      ...samplesFor('temporal', MIN_CLASS_SAMPLES + 10),
+      ...samplesFor('preference', 5), // below MIN → no own map
+    ];
+    const cal = fitPerClass(samples);
+    expect(cal[DEFAULT_CLASS]).toBeDefined();
+    expect(cal['temporal']).toBeDefined();
+    expect(cal['preference']).toBeUndefined();
+    // The default map is fit over EVERY sample.
+    expect(cal[DEFAULT_CLASS]!.sampleCount).toBe(samples.length);
+    expect(cal['temporal']!.sampleCount).toBe(MIN_CLASS_SAMPLES + 10);
+  });
+
+  it('calibratedConfidence uses the class map, falls back to default, else identity', () => {
+    const samples = samplesFor('temporal', MIN_CLASS_SAMPLES + 10);
+    const cal = fitPerClass(samples);
+
+    const temporalSig = signalWithRaw(0.8, 'temporal');
+    expect(calibratedConfidence(cal, temporalSig)).toBeCloseTo(
+      applyMap(cal['temporal']!, rawFocusConfidence(temporalSig)),
+      10,
+    );
+
+    // Unknown class → default map.
+    const unknownSig = signalWithRaw(0.8, 'summary');
+    expect(calibratedConfidence(cal, unknownSig)).toBeCloseTo(
+      applyMap(cal[DEFAULT_CLASS]!, rawFocusConfidence(unknownSig)),
+      10,
+    );
+
+    // Empty calibration → identity (raw passthrough).
+    expect(calibratedConfidence({}, unknownSig)).toBeCloseTo(rawFocusConfidence(unknownSig), 10);
+
+    // Output stays in [0,1].
+    const c = calibratedConfidence(cal, temporalSig);
+    expect(c).toBeGreaterThanOrEqual(0);
+    expect(c).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('computeReliability (§3 ECE + diagram)', () => {
+  /** A perfectly-calibrated set: at each bin center, empirical == predicted. */
+  function perfectlyCalibrated(queryClass: string, perBin = 100, bins = 10): FocusOutcomeSample[] {
+    const out: FocusOutcomeSample[] = [];
+    for (let b = 0; b < bins; b++) {
+      const center = (b + 0.5) / bins;
+      const correctCount = Math.round(center * perBin);
+      for (let i = 0; i < perBin; i++) {
+        out.push({ ...signalWithRaw(center, queryClass), correct: i < correctCount ? 1 : 0 });
+      }
+    }
+    return out;
+  }
+
+  it('reports ECE ≈ 0 for a perfectly-calibrated set', () => {
+    const report = computeReliability(perfectlyCalibrated(DEFAULT_CLASS), 10);
+    expect(report.ece).toBeLessThan(0.01);
+    expect(report.diagram).toHaveLength(10);
+    // Bin edges tile [0,1] with no gaps.
+    expect(report.diagram[0]!.binLo).toBe(0);
+    expect(report.diagram[9]!.binHi).toBeCloseTo(1, 10);
+    // Populated bins carry counts.
+    expect(report.diagram.every((d) => d.count > 0)).toBe(true);
+  });
+
+  it('reports ECE > 0 for a miscalibrated (overconfident) set', () => {
+    // High predicted (~0.9) but always wrong → large calibration gap.
+    const bad: FocusOutcomeSample[] = Array.from({ length: 100 }, () => ({
+      ...signalWithRaw(0.9, DEFAULT_CLASS),
+      correct: 0 as const,
+    }));
+    const report = computeReliability(bad, 10);
+    expect(report.ece).toBeGreaterThan(0.5);
+  });
+
+  it('splits ECE per query-class', () => {
+    const samples = [
+      ...perfectlyCalibrated('good'),
+      ...Array.from({ length: 100 }, () => ({
+        ...signalWithRaw(0.9, 'bad'),
+        correct: 0 as const,
+      })),
+    ];
+    const report = computeReliability(samples, 10);
+    expect(report.perClassEce['good']).toBeLessThan(0.01);
+    expect(report.perClassEce['bad']).toBeGreaterThan(0.5);
+  });
+
+  it('is empty-input safe (ECE 0, all bins zero-count)', () => {
+    const report = computeReliability([], 10);
+    expect(report.ece).toBe(0);
+    expect(report.diagram).toHaveLength(10);
+    expect(report.diagram.every((d) => d.count === 0)).toBe(true);
+    expect(report.perClassEce).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Optics-1 from [fovea-optics](../blob/main/docs/roadmap/fovea-optics-2026-08.md): the foundation for adaptive focusing. **Serving-behavior-neutral and default-off** — it captures the focus signal and fits per-class calibration, but nothing consumes the calibrated signal yet (Optics-2 confidence-gated L3, Optics-3 lens-suppression follow). This is the honest §3 prerequisite: everything adaptive hinges on the signal being calibrated, so we build the measurement + calibration BEFORE any adaptive decision.

- **`focus-signal.ts` (pure):** `FocusSignal`, `rawFocusConfidence` (documented monotone blend — 0.35 coverage / 0.35 verdict / 0.15 retrieval-gap / 0.15 top-score), per-class isotonic (`fitPerClass`/`calibratedConfidence`, shared `default` map below `MIN_CLASS_SAMPLES=30`), and `computeReliability` (ECE + reliability diagram, global + per-class — the §3 measurement). **Reuses the existing `isotonic.ts` PAV primitive — no new regression code.**
- **Capture:** migration 0094 `focus_signal_sample` (+ `focus_calibration`) tables; behind `FOVEA_FOCUS_CAPTURE` (default off), one guarded companyId-scoped record at the synthesize decision point. `correct` is null at serving time (the DTO has no expected-answer field, by design) — the eval harness backfills via `POST /v1/admin/focus/label`.
- **Fit + measure surface:** `brain:admin` endpoints `/v1/admin/focus/{samples,label,fit,reliability}` (404 when flag off) — this is what runs §3 once samples exist.

**Serving byte-identical when off:** `maybeCaptureFocusSignal` short-circuits before touching results or the DB; nothing reads the persisted calibration on the answer path.

## Tests

Unit `focus-signal` 13 (blend monotonicity/bounds, per-class fit + sparse fallback, ECE≈0 calibrated / >0.5 miscalibrated / per-class split); e2e 5 (flag-off no row + 404; flag-on companyId-scoped sample; fit persists a map + numeric ECE; label backfill). Full unit suite **264 suites / 2306 tests green**; typecheck + lint + format:check clean. `FOVEA_` is outside the engine flag-budget prefix (no golden edit); only the engine-gates dead-export test-seam allowlist got two documented constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
