### PR TITLE
feat(fovea): confidence-gated L3 escalation depth (adaptive, static fallback, default-off)

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -398,6 +398,29 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Fovea optics (Optics-1): capture the per-query focus signal at the synthesize verdict point and expose the admin fit/measure surface. Serving-neutral — nothing consumes the calibrated signal yet. Off = byte-identical serving.',
   },
+  {
+    key: 'FOVEA_ADAPTIVE_L3',
+    category: 'calibration',
+    // Read at call time (FocusSignalService.adaptiveL3Enabled → fovea-flags)
+    // on the synthesize L3 seam — never captured in a constructor — so a
+    // flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Fovea optics (Optics-2): make the L3 escalation trigger + session-count adaptive to the calibrated focus confidence, replacing the static coverage floor and scaling #sessions to the deficit (bounded by RETRIEVAL_L3_MAX_SESSIONS). Requires a persisted per-class calibration model (FOVEA_FOCUS_CAPTURE + fit); with none — or the flag off — serving is byte-identical to the static L3. Off = static.',
+  },
+  {
+    key: 'FOVEA_ADAPTIVE_L3_THRESHOLD',
+    category: 'calibration',
+    // Read at call time (FocusSignalService.adaptiveL3EscalateThreshold →
+    // fovea-flags) per request; runtime-mutable.
+    defaultValue: '0.5',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Fovea optics (Optics-2): escalate to L3 when calibrated focus confidence < this threshold in (0,1], and scale #sessions ∝ the deficit below it (capped at RETRIEVAL_L3_MAX_SESSIONS). Ignored unless FOVEA_ADAPTIVE_L3 is on with a usable model. Default 0.5.',
+  },
   // ── Cost ────────────────────────────────────────────
   {
     key: 'COST_CHAT_PROMPT_USD_PER_MTOK',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -711,6 +711,13 @@ const KNOWN_BOOLEAN_FLAGS = [
   // admin routes 404). Outside ENGINE_PREFIX by design (a measurement
   // scaffold, not an engine fork), so it sits off the flag budget.
   'FOVEA_FOCUS_CAPTURE',
+  // Fovea optics (Optics-2, §4.1): make the L3 escalation trigger +
+  // session-count adaptive to the calibrated focus confidence. Requires a
+  // usable per-class calibration model; with none — or off — serving is
+  // byte-identical to the static L3. Outside ENGINE_PREFIX by design (the
+  // FOVEA_ family sits off the flag budget). The escalate threshold knob
+  // (FOVEA_ADAPTIVE_L3_THRESHOLD) is a float, not a boolean flag.
+  'FOVEA_ADAPTIVE_L3',
 ];
 
 /**

--- a/src/common/fovea-flags.ts
+++ b/src/common/fovea-flags.ts
@@ -13,3 +13,35 @@ import { envFlagEnabled } from './env-validation';
 export function focusCaptureEnabled(): boolean {
   return envFlagEnabled(process.env.FOVEA_FOCUS_CAPTURE);
 }
+
+/** Default escalate cutoff on calibrated confidence (Optics-2 §4.1). */
+const DEFAULT_ADAPTIVE_L3_THRESHOLD = 0.5;
+
+/**
+ * Fovea optics (Optics-2) master flag — FOVEA_ADAPTIVE_L3.
+ *
+ * When on AND a usable per-class calibration model is loaded, the L3
+ * escalation trigger + session-count become adaptive to the calibrated
+ * focus confidence (docs/roadmap/fovea-optics-2026-08.md §4.1). The env
+ * read lives here in the common layer, NOT inside the engine dirs
+ * (engine-gates S5.2). Read at call time so a flip is runtime-mutable.
+ * Default off, AND with no calibration model present the serving path is
+ * byte-identical to the static L3 — the load-bearing safety property.
+ */
+export function adaptiveL3Enabled(): boolean {
+  return envFlagEnabled(process.env.FOVEA_ADAPTIVE_L3);
+}
+
+/**
+ * Optics-2 escalate threshold (FOVEA_ADAPTIVE_L3_THRESHOLD): escalate to
+ * L3 when calibrated confidence < this value, and scale #sessions ∝ the
+ * deficit below it. A non-boolean knob resolved here in the common layer
+ * so the engine dirs take a resolved number. Must be in (0,1]; unset,
+ * blank, or out of range → the 0.5 default.
+ */
+export function adaptiveL3EscalateThreshold(): number {
+  const raw = process.env.FOVEA_ADAPTIVE_L3_THRESHOLD;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_ADAPTIVE_L3_THRESHOLD;
+  const v = Number(raw);
+  return Number.isFinite(v) && v > 0 && v <= 1 ? v : DEFAULT_ADAPTIVE_L3_THRESHOLD;
+}

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -212,6 +212,22 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // Optics-2 (docs/roadmap/fovea-optics-2026-08.md §4.1): which sub-
+  // condition fired the L3 trigger —
+  //   adaptive — the calibrated-focus-confidence floor (FOVEA_ADAPTIVE_L3
+  //              on with a usable per-class calibration model)
+  //   static   — the coverage<floor floor (flag off, or no usable model:
+  //              the byte-identical fallback path)
+  // Counted once per fired trigger, in lockstep with the 'fired' branch of
+  // brain_l3_escalation_total. A separate metric (not a new label on the
+  // outcome counter) keeps the existing outcome series stable.
+  readonly l3TriggerPathCount = new Counter({
+    name: 'brain_l3_adaptive_trigger_total',
+    help: 'L3 escalation trigger path: adaptive (calibrated confidence) vs static (coverage floor)',
+    labelNames: ['path'] as const,
+    registers: [this.registry],
+  });
+
   // Cross-encoder outcomes:
   //   invoked          — Cohere call returned a non-identity permutation
   //   error            — Cohere fallback to identity (timeout / 4xx / 5xx)
@@ -540,6 +556,10 @@ export class MetricsService implements OnModuleInit {
     outcome: 'fired' | 'flipped' | 'no_flip' | 'skipped_no_anchor' | 'over_budget_degraded',
   ): void {
     this.l3EscalationCount.inc({ outcome } as LabelValues<'outcome'>);
+  }
+
+  countL3TriggerPath(path: 'adaptive' | 'static'): void {
+    this.l3TriggerPathCount.inc({ path } as LabelValues<'path'>);
   }
 
   countRetract(): void {

--- a/src/synthesize/focus-signal.service.ts
+++ b/src/synthesize/focus-signal.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
-import { focusCaptureEnabled } from '../common/fovea-flags';
+import {
+  adaptiveL3Enabled,
+  adaptiveL3EscalateThreshold,
+  focusCaptureEnabled,
+} from '../common/fovea-flags';
 import { SurrealService } from '../db/surreal.service';
 import type { SearchHit } from '../search/search.types';
 import type { LaneId } from './answer-router';
@@ -41,6 +45,19 @@ export class FocusSignalService {
    *  call time so the knob is runtime-mutable (config-catalog runtimeMutable). */
   static captureEnabled(): boolean {
     return focusCaptureEnabled();
+  }
+
+  /** Optics-2 (§4.1) master flag — delegates to the common-layer reader
+   *  (engine dirs take no direct env reads). Read at call time so the knob
+   *  is runtime-mutable. Off ⇒ the L3 lane runs its static coverage path. */
+  static adaptiveL3Enabled(): boolean {
+    return adaptiveL3Enabled();
+  }
+
+  /** Optics-2 (§4.1) escalate threshold on calibrated confidence — the
+   *  common-layer reader (default 0.5). */
+  static adaptiveL3EscalateThreshold(): number {
+    return adaptiveL3EscalateThreshold();
   }
 
   /**

--- a/src/synthesize/focus-signal.ts
+++ b/src/synthesize/focus-signal.ts
@@ -225,6 +225,19 @@ export function calibratedConfidence(cal: PerClassCalibration, sig: FocusSignal)
   return map ? applyMap(map, raw) : raw;
 }
 
+/**
+ * Whether a loaded calibration is a USABLE model — the Optics-2 gate (§4.1)
+ * that decides adaptive-vs-static. A model is usable only if at least one
+ * class map was fit from real labeled samples (sampleCount > 0). This is
+ * the load-bearing safety predicate: an EMPTY map ({} — nothing persisted)
+ * and a BOOTSTRAP map (fitIsotonic over zero pairs → sampleCount 0) both
+ * return false, so an unconfigured or freshly-bootstrapped tenant falls
+ * back to the static coverage path and serves byte-identically to today.
+ */
+export function hasUsableCalibration(cal: PerClassCalibration): boolean {
+  return Object.values(cal).some((m) => m.sampleCount > 0);
+}
+
 // ── §3 measurement: reliability diagram + ECE ──────────────────────
 
 export interface ReliabilityBin {

--- a/src/synthesize/l3-escalation.service.ts
+++ b/src/synthesize/l3-escalation.service.ts
@@ -21,9 +21,17 @@ import {
   l3Covered,
   verifierPasses,
   rankL3Sessions,
+  adaptiveL3SessionCount,
   estimateTokens,
   type L3SessionAnchor,
+  type L3AdaptiveGate,
 } from './l3-escalation';
+import {
+  buildFocusSignal,
+  calibratedConfidence,
+  queryClassOf,
+  type PerClassCalibration,
+} from './focus-signal';
 
 /**
  * G2 L3 escalation lane (docs/roadmap/sota-gap-build-2026-08.md).
@@ -81,6 +89,15 @@ export interface L3EscalateInput {
   factLines: string[];
   answerLang: string | null;
   dateMathLines?: string[] | undefined;
+  /**
+   * Optics-2 (§4.1) adaptive gate inputs, supplied by synthesize.service
+   * ONLY when FOVEA_ADAPTIVE_L3 is on AND a usable per-class calibration
+   * model is loaded for the tenant. Absent ⇒ the static coverage-floor
+   * path runs (byte-identical to pre-Optics-2 L3). `calibration` is the
+   * loaded per-class map; `threshold` the escalate cutoff on calibrated
+   * confidence.
+   */
+  adaptiveL3?: { calibration: PerClassCalibration; threshold: number } | undefined;
 }
 
 /** A flipped L3 answer to finalise; null = fall through to abstention. */
@@ -123,6 +140,9 @@ export class L3EscalationService {
    */
   async escalate(input: L3EscalateInput): Promise<L3EscalateResult | null> {
     const { profile } = input;
+    // Optics-2 (§4.1): resolve the adaptive confidence gate when the
+    // service was handed a usable model; undefined ⇒ the static path.
+    const adaptive = this.resolveAdaptiveGate(input);
     const reason = l3TriggerDecision({
       l3Escalation: profile.l3Escalation,
       verdict: input.verdict.verdict,
@@ -134,10 +154,14 @@ export class L3EscalationService {
       refineAttempted: input.refineAttempted,
       searchLoop: profile.searchLoop,
       escalated: input.escalated,
+      adaptive,
     });
     if (reason !== 'fire') return null;
+    // Which sub-condition fired — the observability that tells the operator
+    // whether the adaptive optic or the static floor is doing the gating.
+    this.metrics?.countL3TriggerPath(adaptive ? 'adaptive' : 'static');
     try {
-      return await this.runEscalation(input);
+      return await this.runEscalation(input, adaptive);
     } catch (e) {
       // Fail-closed to abstention — the lane must never break synthesis.
       this.logger.warn(
@@ -147,7 +171,43 @@ export class L3EscalationService {
     }
   }
 
-  private async runEscalation(input: L3EscalateInput): Promise<L3EscalateResult | null> {
+  /**
+   * Optics-2 (§4.1) adaptive gate: build the focus signal from the same
+   * per-fact scores + verdict the capture path uses, apply the loaded
+   * per-class calibration, and return {confidence, threshold}. Returns
+   * undefined when no model was supplied (adaptiveL3 absent) — the static
+   * coverage path then runs. Also records the calibrated confidence on the
+   * existing L3 ladder trace for observability. Pure math over pure
+   * helpers (buildFocusSignal / calibratedConfidence); no IO.
+   */
+  private resolveAdaptiveGate(input: L3EscalateInput): L3AdaptiveGate | undefined {
+    const a = input.adaptiveL3;
+    if (!a) return undefined;
+    const factScores: number[] = [];
+    for (const hit of input.results) {
+      for (const f of hit.facts) factScores.push(f.score);
+    }
+    const signal = buildFocusSignal({
+      queryClass: queryClassOf(input.lane),
+      factScores,
+      verifierVerdict: input.verdict.verdict,
+    });
+    const confidence = calibratedConfidence(a.calibration, signal);
+    traceArtifact('synthesize.l3_adaptive', {
+      queryClass: signal.queryClass,
+      confidence,
+      threshold: a.threshold,
+      coverageScore: signal.coverageScore,
+      topScore: signal.topScore,
+      retrievalGap: signal.retrievalGap,
+    });
+    return { confidence, threshold: a.threshold };
+  }
+
+  private async runEscalation(
+    input: L3EscalateInput,
+    adaptive?: L3AdaptiveGate,
+  ): Promise<L3EscalateResult | null> {
     const { profile, dto } = input;
     const includePii = input.callerScopes.includes('brain:read_pii');
     const userId = dto.userId || undefined;
@@ -162,8 +222,19 @@ export class L3EscalationService {
     this.metrics?.countL3Escalation('fired');
 
     const window = input.lane === 'temporal' ? parseQueryTimeRange(dto.query) : null;
+    // Optics-2 (§4.1) depth scaling: on the adaptive path #sessions scales
+    // with the confidence deficit, BOUNDED by the static l3MaxSessions cap;
+    // on the static path it IS l3MaxSessions (byte-identical). Never above
+    // the cap either way — the token cap (assembleContext) is untouched.
+    const maxSessions = adaptive
+      ? adaptiveL3SessionCount({
+          confidence: adaptive.confidence,
+          threshold: adaptive.threshold,
+          maxSessions: profile.l3MaxSessions,
+        })
+      : profile.l3MaxSessions;
     const sessionIds = rankL3Sessions(anchors, {
-      max: profile.l3MaxSessions,
+      max: maxSessions,
       window,
     });
     const ctx = await this.assembleContext(input, {

--- a/src/synthesize/l3-escalation.ts
+++ b/src/synthesize/l3-escalation.ts
@@ -18,7 +18,24 @@ export type L3TriggerReason =
   | 'skip_flag_off'
   | 'skip_verdict_ok'
   | 'skip_covered'
+  | 'skip_confident'
   | 'skip_no_refine';
+
+/**
+ * Optics-2 confidence gate (docs/roadmap/fovea-optics-2026-08.md §4.1).
+ * When supplied, the per-class CALIBRATED confidence REPLACES the static
+ * coverage<floor sub-condition of the trigger: escalate only when
+ * confidence < threshold. The service supplies this ONLY when
+ * FOVEA_ADAPTIVE_L3 is on AND a usable per-class calibration model is
+ * loaded for the tenant — absent, the static coverage path runs, which is
+ * byte-identical to pre-Optics-2 L3.
+ */
+export interface L3AdaptiveGate {
+  /** Calibrated focus confidence in [0,1] for this query's class. */
+  confidence: number;
+  /** Escalate when confidence < threshold (a knob in (0,1]). */
+  threshold: number;
+}
 
 export interface L3TriggerInput {
   /** profile.l3Escalation. */
@@ -27,7 +44,8 @@ export interface L3TriggerInput {
   /** V10 §5 topic-coverage judgment, when the audit produced it. */
   questionAnswered?: boolean | undefined;
   /** Coverage floor result over the retrieved evidence (below floor →
-   *  covered=false, the escalation-eligible state). */
+   *  covered=false, the escalation-eligible state). Consulted only on the
+   *  STATIC path (when `adaptive` is absent). */
   covered: boolean;
   /** Whether the one search-loop refine round already ran this request. */
   refineAttempted: boolean;
@@ -40,26 +58,76 @@ export interface L3TriggerInput {
    * escalated state goes straight to abstain, never re-enters.
    */
   escalated: boolean;
+  /**
+   * Optics-2 (§4.1) adaptive gate. When set, it REPLACES the static
+   * `covered` sub-condition (escalate iff confidence < threshold); when
+   * absent, the static coverage floor runs. EVERYTHING else — the
+   * monotone `escalated` guard, the flag, the verdict-fail gate, the
+   * refine ordering, and (in the service) the anchor requirement — is
+   * unconditional and identical across both paths.
+   */
+  adaptive?: L3AdaptiveGate | undefined;
 }
 
 /**
  * The trigger matrix. Fires only when the fact-grounded answer failed
  * (verifier unsupported/partial, OR the supported-but-not-answering
- * abstain-intent) AND coverage is below floor AND a refine already ran
- * (or the search loop is off) AND nothing escalated yet. Any other
- * combination stays on the normal abstention path.
+ * abstain-intent) AND the escalation-eligibility sub-condition holds AND a
+ * refine already ran (or the search loop is off) AND nothing escalated
+ * yet. Any other combination stays on the normal abstention path.
+ *
+ * The eligibility sub-condition is the ONE thing Optics-2 (§4.1) swaps:
+ * with an `adaptive` gate present, it becomes "calibrated confidence below
+ * threshold"; without one, it stays the static "coverage below floor".
+ * The swap is confined to this sub-condition — every safety guard around
+ * it is shared by both paths, so flag-off / no-model is byte-identical to
+ * the pre-Optics-2 decision.
  */
 export function l3TriggerDecision(input: L3TriggerInput): L3TriggerReason {
   if (input.escalated) return 'skip_already_escalated';
   if (!input.l3Escalation) return 'skip_flag_off';
   const verdictFail = input.verdict !== 'supported' || input.questionAnswered === false;
   if (!verdictFail) return 'skip_verdict_ok';
-  // coverage < floor is required: escalation addresses the residual
-  // where the extracted facts are thin, not where a well-covered set
-  // merely phrased the answer past the auditor.
-  if (input.covered) return 'skip_covered';
+  if (input.adaptive) {
+    // Adaptive path: the calibrated-confidence floor replaces coverage.
+    // A confident answer (conf ≥ threshold) is NOT escalation-eligible.
+    if (input.adaptive.confidence >= input.adaptive.threshold) return 'skip_confident';
+  } else if (input.covered) {
+    // Static path: coverage < floor is required — escalation addresses the
+    // residual where the extracted facts are thin, not where a well-covered
+    // set merely phrased the answer past the auditor.
+    return 'skip_covered';
+  }
   if (input.searchLoop && !input.refineAttempted) return 'skip_no_refine';
   return 'fire';
+}
+
+/**
+ * Optics-2 (§4.1) depth scaling: map the confidence deficit below the
+ * escalate threshold to a session count, ∝ the deficit and BOUNDED by the
+ * static `maxSessions` cap. Lower confidence → more sessions; the result
+ * is always in [1, maxSessions].
+ *
+ *   nSessions = clamp(ceil((threshold − confidence) / threshold · maxSessions), 1, maxSessions)
+ *
+ * HARD SAFETY: the output can only REDISTRIBUTE depth WITHIN the existing
+ * budget — it never exceeds the static `l3MaxSessions` cap and never drops
+ * below one, so the adaptive path is never more resource-aggressive than
+ * static. A degenerate threshold (≤0, cannot scale) falls back to the full
+ * — still capped — budget rather than dividing by zero.
+ */
+export function adaptiveL3SessionCount(args: {
+  confidence: number;
+  threshold: number;
+  maxSessions: number;
+}): number {
+  const cap = Math.max(1, Math.floor(args.maxSessions));
+  if (!(args.threshold > 0)) return cap;
+  const deficit = (args.threshold - args.confidence) / args.threshold;
+  const scaled = Math.ceil(deficit * cap);
+  if (scaled < 1) return 1;
+  if (scaled > cap) return cap;
+  return scaled;
 }
 
 /** Coverage-floor helper bound to the profile knobs (reuses the V9 §4

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -40,7 +40,8 @@ import { EvidenceCollectorService } from './evidence-collector.service';
 import type { CollectedEvidence } from './evidence-collector.service';
 import { L3EscalationService } from './l3-escalation.service';
 import { FocusSignalService } from './focus-signal.service';
-import type { FocusVerdict } from './focus-signal';
+import { hasUsableCalibration } from './focus-signal';
+import type { FocusVerdict, PerClassCalibration } from './focus-signal';
 import {
   AnswerCacheService,
   type AnswerCacheBeginResult,
@@ -502,6 +503,7 @@ export class SynthesizeService {
   }): Promise<SynthesizeResult | null> {
     const { profile } = args;
     if (!this.l3 || !profile.l3Escalation) return null;
+    const adaptiveL3 = await this.resolveAdaptiveL3(args.companyId);
     const l3 = await this.l3.escalate({
       openai: this.openai,
       model: args.model,
@@ -518,6 +520,7 @@ export class SynthesizeService {
       factLines: args.promptFactLines,
       answerLang: args.answerLang,
       dateMathLines: args.dateMathLines,
+      ...(adaptiveL3 ? { adaptiveL3 } : {}),
     });
     if (!l3) return null;
     return this.finalizeAndAdmit(args.cache, l3.verdict, {
@@ -530,6 +533,34 @@ export class SynthesizeService {
         : undefined,
       abstention: profile.abstentionCalibration,
     });
+  }
+
+  /**
+   * Optics-2 (§4.1) adaptive-L3 inputs. Returns the loaded per-class
+   * calibration + escalate threshold ONLY when FOVEA_ADAPTIVE_L3 is on AND
+   * a USABLE model (a class fit from real labeled samples) is persisted for
+   * the tenant; otherwise undefined so the L3 lane takes its static
+   * coverage-floor path. This is the load-bearing safety property: flag off
+   * → undefined → static; no/empty/bootstrap model → undefined → static —
+   * an unconfigured tenant serves byte-identically to the pre-Optics-2 L3.
+   * The env reads live in the common layer (fovea-flags, via the
+   * FocusSignalService statics), never in this engine dir (engine-gates
+   * S5.2). A load failure returns undefined (fail-safe to static).
+   */
+  private async resolveAdaptiveL3(
+    companyId: string,
+  ): Promise<{ calibration: PerClassCalibration; threshold: number } | undefined> {
+    if (!this.focusSignal || !FocusSignalService.adaptiveL3Enabled()) return undefined;
+    try {
+      const calibration = await this.focusSignal.loadCalibration(companyId);
+      if (!hasUsableCalibration(calibration)) return undefined;
+      return { calibration, threshold: FocusSignalService.adaptiveL3EscalateThreshold() };
+    } catch (e) {
+      this.logger.warn(
+        `adaptive-L3 calibration load failed; static fallback: ${(e as Error).message}`,
+      );
+      return undefined;
+    }
   }
 
   /**

--- a/test/fovea-adaptive-l3.e2e-spec.ts
+++ b/test/fovea-adaptive-l3.e2e-spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Fovea optics (Optics-2, docs/roadmap/fovea-optics-2026-08.md §4.1) —
+ * confidence-gated L3 escalation depth, e2e over a real SurrealDB
+ * (testcontainer). The generator + verifier are scripted via
+ * mockSynthesizeOpenAi (the L3 lane reuses the synthesize-owned OpenAI
+ * client, so one queue drives all four calls: round-1 generate → verify →
+ * L3 generate → L3 verify).
+ *
+ * Two scenarios, both with RETRIEVAL_L3_ESCALATION + FOVEA_ADAPTIVE_L3 on:
+ *   - a seeded per-class calibration map that outputs LOW confidence → L3
+ *     fires via the ADAPTIVE path (brain_l3_adaptive_trigger_total path
+ *     ="adaptive"), the L3 answer is returned.
+ *   - NO calibration map persisted → the load-bearing safety property: the
+ *     lane behaves EXACTLY like the static L3 (fires on the same static
+ *     condition, brain_l3_adaptive_trigger_total path="static").
+ *
+ * A fact's grounding session (source.episodeIds) is stamped directly onto
+ * directly-created episode rows so the read path resolves an anchor without
+ * a derive run (same idiom as l3-escalation.e2e-spec.ts).
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSynthesizeOpenAi } from './test-doubles';
+import { SurrealService } from '../src/db/surreal.service';
+import { MetricsService } from '../src/metrics/metrics.service';
+import { StringRecordId } from 'surrealdb';
+
+describe('Fovea Optics-2 adaptive L3 escalation e2e', () => {
+  // Anchored-fact tenant (adaptive path) and an isolated no-model tenant
+  // (static fallback), so the two scenarios cannot see each other's rows.
+  let fAdaptive: AppFixture;
+  let fStatic: AppFixture;
+  const authAdaptive = () => ({ Authorization: `Bearer ${fAdaptive.apiKey}` });
+  const authStatic = () => ({ Authorization: `Bearer ${fStatic.apiKey}` });
+
+  const ANCHOR_OBJECT = 'sapphire-crest-o2';
+  const ANCHOR_QUERY = 'what is the tier sapphire-crest-o2';
+
+  const R1_GEN = JSON.stringify({ answer: 'A thin, unsupported guess.', citedFactIds: [] });
+  const R1_VERIFY = JSON.stringify({
+    verdict: 'unsupported',
+    unsupportedClaims: ['A thin, unsupported guess.'],
+    questionAnswered: false,
+  });
+  const L3_ANSWER = 'The tier is sapphire-crest, per the full session.';
+  const l3Ok = (factId: string) => [
+    JSON.stringify({ answer: L3_ANSWER, citedFactIds: [factId] }),
+    JSON.stringify({ verdict: 'supported', unsupportedClaims: [], questionAnswered: true }),
+  ];
+
+  async function triggerPathCount(app: AppFixture, path: string): Promise<number> {
+    const metrics = app.app.get(MetricsService);
+    const { body } = await metrics.serialize();
+    const m = body.match(new RegExp(`brain_l3_adaptive_trigger_total\\{path="${path}"\\} (\\d+)`));
+    return m ? parseInt(m[1]!, 10) : 0;
+  }
+
+  // Ingest the anchored fact + its grounding episode session on a tenant.
+  async function seedAnchor(app: AppFixture, auth: () => Record<string, string>): Promise<string> {
+    const a = await app.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'cust_o2_anchor' },
+        predicate: 'tier',
+        object: ANCHOR_OBJECT,
+        validFrom: new Date('2026-04-01').toISOString(),
+        source: { vertical: 'rent', messageId: 'm_o2_a' },
+        confidence: 0.9,
+      });
+    const factId = a.body.factId as string;
+    expect(factId).toBeTruthy();
+    const surreal = app.app.get(SurrealService);
+    await surreal.withCompany(app.companyId, async (db) => {
+      await db.query(
+        `CREATE episode:o2ep1 CONTENT {
+           kind: 'turn', messageId: 'm_o2_a', conversationId: 'conv_o2',
+           speaker: 'user', text: $t1, occurredAt: $o1, source: {}
+         };
+         CREATE episode:o2ep2 CONTENT {
+           kind: 'turn', messageId: 'm_o2_a2', conversationId: 'conv_o2',
+           speaker: 'assistant', text: $t2, occurredAt: $o2, source: {}
+         }`,
+        {
+          t1: `My tier is ${ANCHOR_OBJECT}, I confirmed it last week.`,
+          t2: `Understood — you are on ${ANCHOR_OBJECT}.`,
+          o1: new Date('2026-04-01T10:00:00Z'),
+          o2: new Date('2026-04-01T10:01:00Z'),
+        },
+      );
+      await db.query(`UPDATE $rid SET source.episodeIds = ['episode:o2ep1', 'episode:o2ep2']`, {
+        rid: new StringRecordId(factId),
+      });
+    });
+    return factId;
+  }
+
+  beforeAll(async () => {
+    delete process.env.RETRIEVAL_L3_ESCALATION;
+    delete process.env.FOVEA_ADAPTIVE_L3;
+    delete process.env.FOVEA_ADAPTIVE_L3_THRESHOLD;
+    fAdaptive = await createApp();
+    fStatic = await createApp();
+
+    const adaptiveFactId = await seedAnchor(fAdaptive, authAdaptive);
+    const staticFactId = await seedAnchor(fStatic, authStatic);
+    (fStatic as unknown as { staticFactId: string }).staticFactId = staticFactId;
+
+    // Seed a USABLE per-class calibration model on the adaptive tenant only:
+    // a flat 'default' map that outputs 0.05 for any raw confidence, well
+    // below the 0.5 escalate threshold → the adaptive gate always fires.
+    const surreal = fAdaptive.app.get(SurrealService);
+    await surreal.withCompany(fAdaptive.companyId, async (db) => {
+      await db.query(
+        `CREATE focus_calibration CONTENT {
+           queryClass: 'default', thresholds: [1.0], values: [0.05],
+           sampleCount: 100, version: 1
+         }`,
+      );
+    });
+
+    // Store the anchored factId for the adaptive test's L3 citation.
+    (fAdaptive as unknown as { anchoredFactId: string }).anchoredFactId = adaptiveFactId;
+  });
+
+  afterAll(async () => {
+    delete process.env.RETRIEVAL_L3_ESCALATION;
+    delete process.env.FOVEA_ADAPTIVE_L3;
+    delete process.env.FOVEA_ADAPTIVE_L3_THRESHOLD;
+    if (fAdaptive) await fAdaptive.close();
+    if (fStatic) await fStatic.close();
+  });
+
+  it('flag on + seeded low-confidence model → L3 fires via the ADAPTIVE path', async () => {
+    process.env.RETRIEVAL_L3_ESCALATION = '1';
+    process.env.FOVEA_ADAPTIVE_L3 = '1';
+    const factId = (fAdaptive as unknown as { anchoredFactId: string }).anchoredFactId;
+    const adaptiveBefore = await triggerPathCount(fAdaptive, 'adaptive');
+    const state = mockSynthesizeOpenAi(fAdaptive.app, [R1_GEN, R1_VERIFY, ...l3Ok(factId)]);
+    const res = await fAdaptive.http
+      .post('/v1/synthesize')
+      .set(authAdaptive())
+      .send({ query: ANCHOR_QUERY, limit: 5 });
+    expect(res.status).toBe(201);
+    // The adaptive gate fired and the scripted L3 answer flipped the verdict.
+    expect(res.body.answer).toBe(L3_ANSWER);
+    // round-1 generate + verify, then L3 generate + verify.
+    expect(state.calls.length).toBe(4);
+    expect(state.calls[2]!.user).toContain('Full conversation transcripts');
+    // The fired trigger was labeled 'adaptive', not 'static'.
+    expect(await triggerPathCount(fAdaptive, 'adaptive')).toBe(adaptiveBefore + 1);
+  });
+
+  it('flag on + NO calibration model → byte-identical to the STATIC L3', async () => {
+    process.env.RETRIEVAL_L3_ESCALATION = '1';
+    process.env.FOVEA_ADAPTIVE_L3 = '1';
+    const factId = (fStatic as unknown as { staticFactId: string }).staticFactId;
+    // The static tenant has no focus_calibration rows, so the adaptive
+    // resolver returns undefined → the lane runs its static coverage path.
+    const staticBefore = await triggerPathCount(fStatic, 'static');
+    const adaptiveBefore = await triggerPathCount(fStatic, 'adaptive');
+    const state = mockSynthesizeOpenAi(fStatic.app, [R1_GEN, R1_VERIFY, ...l3Ok(factId)]);
+    const res = await fStatic.http
+      .post('/v1/synthesize')
+      .set(authStatic())
+      .send({ query: ANCHOR_QUERY, limit: 5 });
+    expect(res.status).toBe(201);
+    // Same static condition fires the ladder (verifier-fail + below floor).
+    expect(res.body.answer).toBe(L3_ANSWER);
+    expect(state.calls.length).toBe(4);
+    // Fired via the STATIC path — the no-model fallback.
+    expect(await triggerPathCount(fStatic, 'static')).toBe(staticBefore + 1);
+    expect(await triggerPathCount(fStatic, 'adaptive')).toBe(adaptiveBefore);
+  });
+});

--- a/test/l3-escalation.unit-spec.ts
+++ b/test/l3-escalation.unit-spec.ts
@@ -17,8 +17,11 @@ import {
   rankL3Sessions,
   verifierPasses,
   estimateTokens,
+  adaptiveL3SessionCount,
   type L3SessionAnchor,
 } from '../src/synthesize/l3-escalation';
+import { hasUsableCalibration } from '../src/synthesize/focus-signal';
+import type { PerClassCalibration } from '../src/synthesize/focus-signal';
 import { L3EscalationService } from '../src/synthesize/l3-escalation.service';
 import type { SurrealService } from '../src/db/surreal.service';
 import type { EpisodeReadStoreService } from '../src/episodes/episode-read-store.service';
@@ -85,6 +88,143 @@ describe('l3TriggerDecision — the monotone trigger matrix', () => {
   });
 });
 
+// ── pure: Optics-2 adaptive trigger (§4.1) ──────────────────────────
+describe('l3TriggerDecision — the adaptive confidence gate replaces coverage', () => {
+  const base = {
+    l3Escalation: true,
+    verdict: 'unsupported' as VerifierOutput['verdict'],
+    // `covered` set TRUE so a static run here would SKIP: this isolates
+    // that the adaptive gate — not the coverage floor — is what decides.
+    covered: true,
+    refineAttempted: false,
+    searchLoop: false,
+    escalated: false,
+  };
+
+  it('fires when calibrated confidence is below threshold (despite covered=true)', () => {
+    expect(l3TriggerDecision({ ...base, adaptive: { confidence: 0.2, threshold: 0.5 } })).toBe(
+      'fire',
+    );
+  });
+
+  it('skips (skip_confident) when confidence is at/above threshold', () => {
+    expect(l3TriggerDecision({ ...base, adaptive: { confidence: 0.5, threshold: 0.5 } })).toBe(
+      'skip_confident',
+    );
+    expect(l3TriggerDecision({ ...base, adaptive: { confidence: 0.9, threshold: 0.5 } })).toBe(
+      'skip_confident',
+    );
+  });
+
+  it('KEEPS the anchor-adjacent hard guards on the adaptive path', () => {
+    const low = { confidence: 0.1, threshold: 0.5 };
+    // monotone single-shot: already-escalated never re-enters, even low-conf.
+    expect(l3TriggerDecision({ ...base, escalated: true, adaptive: low })).toBe(
+      'skip_already_escalated',
+    );
+    // flag off short-circuits before the confidence gate.
+    expect(l3TriggerDecision({ ...base, l3Escalation: false, adaptive: low })).toBe(
+      'skip_flag_off',
+    );
+    // verdict-ok still wins: confidence only gates a verdict-FAIL.
+    expect(
+      l3TriggerDecision({
+        ...base,
+        verdict: 'supported',
+        questionAnswered: true,
+        adaptive: low,
+      }),
+    ).toBe('skip_verdict_ok');
+    // refine ordering still enforced when the search loop is on.
+    expect(
+      l3TriggerDecision({ ...base, searchLoop: true, refineAttempted: false, adaptive: low }),
+    ).toBe('skip_no_refine');
+  });
+
+  it('no adaptive gate → IDENTICAL decision to the static coverage path', () => {
+    // The load-bearing safety property, at the decision core: for every
+    // combination of the shared inputs, omitting `adaptive` reproduces the
+    // static outcome exactly (adaptive undefined ⇒ the coverage branch).
+    for (const covered of [true, false]) {
+      for (const verdict of ['supported', 'partial', 'unsupported'] as const) {
+        for (const questionAnswered of [undefined, true, false] as const) {
+          for (const searchLoop of [true, false]) {
+            for (const refineAttempted of [true, false]) {
+              const shared = {
+                l3Escalation: true,
+                verdict,
+                questionAnswered,
+                covered,
+                refineAttempted,
+                searchLoop,
+                escalated: false,
+              };
+              // Static reference: today's core, no adaptive field.
+              const staticReason = l3TriggerDecision(shared);
+              // Same inputs, adaptive explicitly undefined → must match.
+              expect(l3TriggerDecision({ ...shared, adaptive: undefined })).toBe(staticReason);
+            }
+          }
+        }
+      }
+    }
+  });
+});
+
+// ── pure: Optics-2 depth scaling (§4.1) ─────────────────────────────
+describe('adaptiveL3SessionCount — #sessions ∝ deficit, capped', () => {
+  it('lowest confidence → the full (capped) budget', () => {
+    expect(adaptiveL3SessionCount({ confidence: 0, threshold: 0.5, maxSessions: 3 })).toBe(3);
+  });
+
+  it('confidence just below threshold → the floor of one session', () => {
+    expect(adaptiveL3SessionCount({ confidence: 0.45, threshold: 0.5, maxSessions: 3 })).toBe(1);
+  });
+
+  it('scales monotonically with the deficit', () => {
+    const a = adaptiveL3SessionCount({ confidence: 0.4, threshold: 0.5, maxSessions: 10 });
+    const b = adaptiveL3SessionCount({ confidence: 0.2, threshold: 0.5, maxSessions: 10 });
+    const c = adaptiveL3SessionCount({ confidence: 0.05, threshold: 0.5, maxSessions: 10 });
+    expect(a).toBeLessThan(b);
+    expect(b).toBeLessThan(c);
+    expect(c).toBeLessThanOrEqual(10);
+  });
+
+  it('NEVER exceeds the static cap and NEVER drops below one', () => {
+    for (const conf of [0, 0.1, 0.3, 0.49, 0.5, 0.99]) {
+      const n = adaptiveL3SessionCount({ confidence: conf, threshold: 0.5, maxSessions: 4 });
+      expect(n).toBeGreaterThanOrEqual(1);
+      expect(n).toBeLessThanOrEqual(4);
+    }
+  });
+
+  it('degenerate threshold (≤0) falls back to the capped budget, no divide-by-zero', () => {
+    expect(adaptiveL3SessionCount({ confidence: 0.2, threshold: 0, maxSessions: 3 })).toBe(3);
+    expect(
+      Number.isFinite(adaptiveL3SessionCount({ confidence: 0.2, threshold: -1, maxSessions: 3 })),
+    ).toBe(true);
+  });
+});
+
+// ── pure: the no-model→static gate predicate ────────────────────────
+describe('hasUsableCalibration — the adaptive-vs-static gate', () => {
+  it('empty map (nothing persisted) → not usable', () => {
+    expect(hasUsableCalibration({})).toBe(false);
+  });
+
+  it('bootstrap-only (all sampleCount 0) → not usable', () => {
+    const boot: PerClassCalibration = { default: { thresholds: [1], values: [1], sampleCount: 0 } };
+    expect(hasUsableCalibration(boot)).toBe(false);
+  });
+
+  it('at least one class fit from real samples → usable', () => {
+    const real: PerClassCalibration = {
+      default: { thresholds: [1], values: [0.6], sampleCount: 120 },
+    };
+    expect(hasUsableCalibration(real)).toBe(true);
+  });
+});
+
 // ── pure: session selection ─────────────────────────────────────────
 describe('rankL3Sessions — density + temporal overlap', () => {
   it('ranks by fact-hit density, then summed score', () => {
@@ -146,6 +286,7 @@ describe('verifierPasses + estimateTokens', () => {
 // ── service: orchestration with mocked IO ───────────────────────────
 interface Mocks {
   outcomes: string[];
+  triggerPaths: string[];
   windowAroundCalls: number;
   conversationTurnsCalls: number;
 }
@@ -196,6 +337,7 @@ function makeService(opts: {
 }): { service: L3EscalationService; mocks: Mocks } {
   const mocks: Mocks = {
     outcomes: [],
+    triggerPaths: [],
     windowAroundCalls: 0,
     conversationTurnsCalls: 0,
   };
@@ -216,6 +358,7 @@ function makeService(opts: {
   } as unknown as EpisodeReadStoreService;
   const metrics = {
     countL3Escalation: (o: string) => mocks.outcomes.push(o),
+    countL3TriggerPath: (p: string) => mocks.triggerPaths.push(p),
     recordOpenAiCall: () => {},
   } as unknown as MetricsService;
   return { service: new L3EscalationService(surreal, episodes, metrics), mocks };
@@ -408,5 +551,142 @@ describe('L3EscalationService.escalate', () => {
     const out = await service.escalate(baseInput(openai, makeProfile({ l3Escalation: false })));
     expect(out).toBeNull();
     expect(mocks.outcomes).toEqual([]);
+  });
+
+  // ── Optics-2 adaptive path (§4.1) ─────────────────────────────────
+  // A flat single-bucket map → applyMap returns `value` for ANY raw
+  // confidence, so the calibrated confidence is deterministic in tests.
+  const flatCalibration = (value: number): PerClassCalibration => ({
+    default: { thresholds: [1], values: [value], sampleCount: 100 },
+  });
+
+  const oneFactSetup = () => ({
+    factEps: [{ id: FACT_ID, eps: ['episode:ep1'] }],
+    episodesByIds: [
+      { id: 'episode:ep1', conversationId: 'conv1', occurredAt: '2026-04-01T00:00:00Z' },
+    ],
+    sessionTurns: {
+      conv1: [
+        {
+          id: 'episode:ep1',
+          speaker: 'user',
+          text: 'my tier is sapphire',
+          occurredAt: '2026-04-01T00:00:00Z',
+        },
+      ],
+    },
+  });
+
+  const flipScript = () =>
+    fakeOpenAi([
+      JSON.stringify({ answer: 'The tier is sapphire.', citedFactIds: [FACT_ID] }),
+      JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+    ]);
+
+  it('no model supplied → the STATIC path, byte-identical fire+flip (safety)', async () => {
+    // adaptiveL3 absent ⇒ the service must reproduce today's static
+    // decision exactly, and label the fired trigger 'static'.
+    const { service, mocks } = makeService(oneFactSetup());
+    const out = await service.escalate(baseInput(flipScript(), makeProfile({})));
+    expect(out?.answer).toBe('The tier is sapphire.');
+    expect(mocks.outcomes).toEqual(['fired', 'flipped']);
+    expect(mocks.triggerPaths).toEqual(['static']);
+  });
+
+  it('adaptive + low confidence → fires via the ADAPTIVE path, flips', async () => {
+    const { service, mocks } = makeService(oneFactSetup());
+    const out = await service.escalate({
+      ...baseInput(flipScript(), makeProfile({})),
+      adaptiveL3: { calibration: flatCalibration(0.1), threshold: 0.5 },
+    });
+    expect(out?.answer).toBe('The tier is sapphire.');
+    expect(mocks.outcomes).toEqual(['fired', 'flipped']);
+    expect(mocks.triggerPaths).toEqual(['adaptive']);
+  });
+
+  it('adaptive + high confidence → skip_confident, suppresses a fire the static floor WOULD have made', async () => {
+    // results score 0.1 is below the coverage floor, so the static path
+    // fires here — but a calibrated confidence of 0.9 (≥ 0.5) suppresses
+    // it. Confidence REPLACES coverage: no generation, no metrics, no IO.
+    const { service, mocks } = makeService(oneFactSetup());
+    const out = await service.escalate({
+      ...baseInput(fakeOpenAi(['{}']), makeProfile({})),
+      adaptiveL3: { calibration: flatCalibration(0.9), threshold: 0.5 },
+    });
+    expect(out).toBeNull();
+    expect(mocks.outcomes).toEqual([]);
+    expect(mocks.triggerPaths).toEqual([]);
+    expect(mocks.conversationTurnsCalls).toBe(0);
+  });
+
+  it('adaptive depth scaling: near-threshold confidence narrows #sessions below the static cap', async () => {
+    const threeSessions = {
+      factEps: [
+        { id: 'knowledge_fact:a', eps: ['episode:ea'] },
+        { id: 'knowledge_fact:b', eps: ['episode:eb'] },
+        { id: 'knowledge_fact:c', eps: ['episode:ec'] },
+      ],
+      episodesByIds: [
+        { id: 'episode:ea', conversationId: 'ca', occurredAt: '2026-04-01T00:00:00Z' },
+        { id: 'episode:eb', conversationId: 'cb', occurredAt: '2026-04-01T00:00:00Z' },
+        { id: 'episode:ec', conversationId: 'cc', occurredAt: '2026-04-01T00:00:00Z' },
+      ],
+      sessionTurns: {
+        ca: [
+          { id: 'episode:ea', speaker: 'user', text: 'tier a', occurredAt: '2026-04-01T00:00:00Z' },
+        ],
+        cb: [
+          { id: 'episode:eb', speaker: 'user', text: 'tier b', occurredAt: '2026-04-01T00:00:00Z' },
+        ],
+        cc: [
+          { id: 'episode:ec', speaker: 'user', text: 'tier c', occurredAt: '2026-04-01T00:00:00Z' },
+        ],
+      },
+    };
+    const threeResults: SearchHit[] = [
+      { factId: 'knowledge_fact:a', score: 0.3 },
+      { factId: 'knowledge_fact:b', score: 0.2 },
+      { factId: 'knowledge_fact:c', score: 0.1 },
+    ].map((s, i) => ({
+      entityId: `knowledge_entity:e${i}`,
+      entityType: 'topic',
+      canonicalName: 'tier',
+      externalRefs: {},
+      facts: [
+        {
+          factId: s.factId,
+          predicate: 'tier',
+          object: 'sapphire',
+          confidence: 0.9,
+          validFrom: '2026-04-01T00:00:00Z',
+          status: 'active',
+          score: s.score,
+        },
+      ],
+      score: s.score,
+    }));
+
+    // Static baseline (no model): uses the full l3MaxSessions=3 cap.
+    {
+      const { service, mocks } = makeService(threeSessions);
+      await service.escalate({
+        ...baseInput(flipScript(), makeProfile({ l3MaxSessions: 3 })),
+        results: threeResults,
+      });
+      expect(mocks.conversationTurnsCalls).toBe(3);
+    }
+
+    // Adaptive: confidence 0.45 just below the 0.5 threshold → deficit 0.1
+    // → ceil(0.1·3)=1 session, even though 3 anchors are available.
+    {
+      const { service, mocks } = makeService(threeSessions);
+      await service.escalate({
+        ...baseInput(flipScript(), makeProfile({ l3MaxSessions: 3 })),
+        results: threeResults,
+        adaptiveL3: { calibration: flatCalibration(0.45), threshold: 0.5 },
+      });
+      expect(mocks.triggerPaths).toEqual(['adaptive']);
+      expect(mocks.conversationTurnsCalls).toBe(1);
+    }
   });
 });


### PR DESCRIPTION
## Optics-2 — confidence-gated L3 escalation depth

Second step of the fovea **optics** program (`docs/roadmap/fovea-optics-2026-08.md` §4.1), building on the Optics-1 focus-signal + per-class calibration foundation (#329). Makes the L3 escalation decision **adaptive to the calibrated focus confidence** instead of the static coverage floor — behind default-off `FOVEA_ADAPTIVE_L3`, with a graceful static fallback.

### How it works
- **Confidence replaces the coverage-floor sub-condition.** In the pure core `l3TriggerDecision`, when an adaptive gate is supplied the eligibility check becomes `calibratedConfidence < escalateThreshold` (default 0.5) instead of `coverage < floor`. The swap is confined to that one sub-condition — the monotone `escalated` guard, the flag gate, the verdict-fail gate, the refine ordering, and the service's anchor requirement are unconditional on both paths (new outcome `skip_confident`).
- **#sessions ∝ deficit, within existing caps.** New pure `adaptiveL3SessionCount` = `clamp(ceil((threshold−conf)/threshold · l3MaxSessions), 1, l3MaxSessions)` — always in `[1, l3MaxSessions]`, token cap untouched. The adaptive path can only **redistribute** depth within the static budget, never exceed it.
- **No-model → static (the load-bearing safety property).** `synthesize.service.resolveAdaptiveL3` supplies the gate only when the flag is on **and** a *usable* per-class model is persisted (`hasUsableCalibration`: ≥1 class fit from real samples; empty/bootstrap map = not usable). Flag off, no model, corrupt/empty map, or a load failure all fall to the static coverage path — byte-identical to pre-Optics-2 L3.
- **Env reads in the common layer.** `common/fovea-flags.ts` (`adaptiveL3Enabled`, `adaptiveL3EscalateThreshold`) — never in engine dirs (engine-gates S5.2), same route as Optics-1's `FOVEA_FOCUS_CAPTURE`.
- **Telemetry.** New `brain_l3_adaptive_trigger_total{path}` counter (adaptive vs static), counted in lockstep with the `fired` branch; existing `brain_l3_escalation_total{outcome}` series left stable. Calibrated confidence recorded on the L3 trace (`synthesize.l3_adaptive`).

### Byte-identical safety
- **Flag off** (default): `resolveAdaptiveL3` returns undefined at the first check, zero DB read → static decision, static session count, identical response bytes.
- **Flag on, no/empty/bootstrap model:** one `loadCalibration` read → `hasUsableCalibration` false → undefined → static path. Confirmed by the new e2e "no calibration model → byte-identical to static L3". The only observable additions on either path are the new metric series + trace, which do not alter response bytes.

### Tests / gates
- Unit `l3-escalation.unit-spec.ts`: 19 → **35** (+16: adaptive trigger, deficit scaling + clamp, `hasUsableCalibration`, no-model==static core sweep, service fire/suppress/depth paths).
- New e2e `fovea-adaptive-l3.e2e-spec.ts` (2); existing `l3-escalation.e2e-spec.ts` (3) unchanged and passing.
- Full unit suite green; `typecheck`, `lint:ci`, `format:check` clean. No RetrievalProfile field added (FOVEA_ env route), so the retrieval-profile / flag-budget goldens are untouched.

### Flags (both default-off / default-safe)
- `FOVEA_ADAPTIVE_L3` (bool, default `0`) — master gate.
- `FOVEA_ADAPTIVE_L3_THRESHOLD` (float in (0,1], default `0.5`) — escalate cutoff + deficit-scaling denominator.

Serving behavior in prod is unchanged until the flag is turned on **and** a per-class calibration model exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
