### PR TITLE
feat(fovea): lens-suppression governor — subtractive per-class lane suppression (adaptive, static fallback, default-off)

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -444,6 +444,29 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Fovea optics (Optics §4.2): abstain (return NOT_IN_MEMORY) when the calibrated pre-answer focus confidence < this threshold in (0,1]. Ignored unless FOVEA_ADAPTIVE_ABSTAIN is on with a usable pre-answer model. Default 0.5.',
   },
+  {
+    key: 'FOVEA_LENS_SUPPRESS',
+    category: 'calibration',
+    // Read at call time (LensSuppressionService.suppressEnabled → fovea-flags)
+    // on the synthesize seam before the answer cache — never captured in a
+    // constructor — so a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Fovea optics (Optics §4.3): subtractive lens-suppression governor — for the query class, REMOVE off-task / trap-inducing lanes from the effective active set (never add, never reorder) before retrieval and before the answer-cache key is computed. Requires a persisted per-class lens_suppression model (admin fit); with none — or the flag off, or a low-confidence class match — routing is byte-identical to the static lane set. Off = static.',
+  },
+  {
+    key: 'FOVEA_LENS_SUPPRESS_MIN_COSINE',
+    category: 'calibration',
+    // Read at call time (LensSuppressionService.minCosine → fovea-flags) per
+    // request; runtime-mutable.
+    defaultValue: '0.5',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Fovea optics (Optics §4.3): suppress lanes only when the nearest class centroid cosine similarity to the query embedding is >= this floor in [-1,1]; below it the class match is uncertain and routing is left unchanged. Ignored unless FOVEA_LENS_SUPPRESS is on with a usable model. Default 0.5.',
+  },
   // ── Cost ────────────────────────────────────────────
   {
     key: 'COST_CHAT_PROMPT_USD_PER_MTOK',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -727,6 +727,15 @@ const KNOWN_BOOLEAN_FLAGS = [
   // threshold knob (FOVEA_ADAPTIVE_ABSTAIN_THRESHOLD) is a float, not a
   // boolean flag.
   'FOVEA_ADAPTIVE_ABSTAIN',
+  // Fovea optics (Optics §4.3): the subtractive lens-suppression governor —
+  // for the query class, REMOVE off-task / trap-inducing lanes from the
+  // effective active set before retrieval + before the answer-cache key.
+  // Requires a usable per-class lens_suppression model; with none — or off,
+  // or a low-confidence class match — routing is byte-identical to the static
+  // lane set. Outside ENGINE_PREFIX by design (the FOVEA_ family sits off the
+  // flag budget). The min-cosine floor (FOVEA_LENS_SUPPRESS_MIN_COSINE) is a
+  // float, not a boolean flag.
+  'FOVEA_LENS_SUPPRESS',
 ];
 
 /**

--- a/src/common/fovea-flags.ts
+++ b/src/common/fovea-flags.ts
@@ -79,3 +79,38 @@ export function adaptiveAbstainThreshold(): number {
   const v = Number(raw);
   return Number.isFinite(v) && v > 0 && v <= 1 ? v : DEFAULT_ADAPTIVE_ABSTAIN_THRESHOLD;
 }
+
+/** Default nearest-centroid cosine floor for lens suppression (Optics §4.3). */
+const DEFAULT_LENS_SUPPRESS_MIN_COSINE = 0.5;
+
+/**
+ * Fovea optics (Optics §4.3) master flag — FOVEA_LENS_SUPPRESS.
+ *
+ * When on AND a usable per-class suppression model is loaded, the
+ * lens-suppression governor SUBTRACTS off-task / trap-inducing lanes from a
+ * query's effective active lane set BEFORE retrieval and before the
+ * answer-cache key is computed (docs/roadmap/fovea-optics-2026-08.md §4.3).
+ * Subtractive only — it can never add a lane or reorder. The env read lives
+ * here in the common layer, NOT inside the engine dirs (engine-gates S5.2).
+ * Read at call time so a flip is runtime-mutable. Default off, AND with no
+ * usable model — or a low-confidence class match — routing is byte-identical
+ * to the static lane set (the load-bearing safety property).
+ */
+export function lensSuppressEnabled(): boolean {
+  return envFlagEnabled(process.env.FOVEA_LENS_SUPPRESS);
+}
+
+/**
+ * Optics §4.3 confidence floor (FOVEA_LENS_SUPPRESS_MIN_COSINE): suppress
+ * lanes only when the nearest class centroid's cosine similarity to the query
+ * embedding is ≥ this value; below it the class match is uncertain and the
+ * lane set is left unchanged. A non-boolean knob resolved here in the common
+ * layer so the engine dirs take a resolved number. Cosine lives in [-1,1], so
+ * the full range is accepted; unset, blank, or out of range → the 0.5 default.
+ */
+export function lensSuppressMinCosine(): number {
+  const raw = process.env.FOVEA_LENS_SUPPRESS_MIN_COSINE;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_LENS_SUPPRESS_MIN_COSINE;
+  const v = Number(raw);
+  return Number.isFinite(v) && v >= -1 && v <= 1 ? v : DEFAULT_LENS_SUPPRESS_MIN_COSINE;
+}

--- a/src/db/migrations/0096_lens_suppression.surql
+++ b/src/db/migrations/0096_lens_suppression.surql
@@ -1,0 +1,53 @@
+-- 0096: fovea optics (Optics §4.3) — the lens-suppression governor's
+-- per-(company, class) suppression model. Companion to
+-- docs/roadmap/fovea-optics-2026-08.md §4.3 and the trap-resistance
+-- shakedown docs/roadmap/memtrap-shakedown-2026-08.md.
+--
+-- WHAT this stores. The governor is SUBTRACTIVE: for a query's learned
+-- class it REMOVES off-task / trap-inducing lanes from the effective
+-- active set (never adds, never reorders). A row is one learned class:
+--   centroid      — the class's query-embedding centroid (nearest-centroid
+--                   match, Semantic Router pattern; cosine ≥ a floor knob).
+--   suppressLanes — the LaneIds this class hard-suppresses (the genre-toxic
+--                   combinations; the shakedown's trap carriers are the
+--                   instruction + strategy lanes).
+--   sampleCount   — labeled samples behind the class. A "usable model" needs
+--                   at least one class with sampleCount > 0 (mirrors
+--                   focus-signal's hasUsableCalibration); an empty/bootstrap
+--                   model falls back to today's static routing.
+--
+-- SERVING-NEUTRAL WITHOUT A MODEL: this table is READ on the serving path
+-- ONLY behind FOVEA_LENS_SUPPRESS (default off) AND only when a usable
+-- model is persisted. Flag off, no model, or a low-confidence class match
+-- → the effective profile is the ORIGINAL lane set, byte-identical.
+--
+-- The training data is OFFLINE ablation-mined and PARKED, so the admin
+-- `fit` is a THIN INGEST of externally-provided (class, centroid,
+-- suppressLanes) rows rather than a serving-time learner. Persistence
+-- mirrors the focus_calibration versioning idiom (0094/0095): one
+-- versioned row per class, the reader picks max(version) per class.
+
+DEFINE TABLE IF NOT EXISTS lens_suppression SCHEMAFULL;
+
+-- Owning tenant (rows are also physically scoped to the per-company DB via
+-- withCompany; the column is kept for cross-tenant aggregation later).
+DEFINE FIELD IF NOT EXISTS companyId ON lens_suppression TYPE string;
+-- The learned class key (the fovea query-class analogue — a routed LaneId,
+-- an ablation-mined cluster label, or 'default'). Free string.
+DEFINE FIELD IF NOT EXISTS classId ON lens_suppression TYPE string;
+-- The class's query-embedding centroid (nearest-centroid match).
+DEFINE FIELD IF NOT EXISTS centroid ON lens_suppression TYPE array<float>;
+-- The LaneIds this class hard-suppresses (validated against the LaneId
+-- union at read time — unknown ids are dropped, never a routing add).
+DEFINE FIELD IF NOT EXISTS suppressLanes ON lens_suppression TYPE array<string>;
+-- Labeled samples behind this class; usability gate = some class > 0.
+DEFINE FIELD IF NOT EXISTS sampleCount ON lens_suppression TYPE int DEFAULT 0;
+-- Monotone version counter; the reader picks max(version) per class.
+DEFINE FIELD IF NOT EXISTS version ON lens_suppression TYPE int DEFAULT 1;
+DEFINE FIELD IF NOT EXISTS createdAt ON lens_suppression TYPE datetime
+    DEFAULT time::now();
+
+-- The max-version-per-class read is index-served. (Non-unique — the
+-- reader orders by version DESC and takes the first row per class.)
+DEFINE INDEX IF NOT EXISTS lens_suppression_key_idx ON lens_suppression
+    FIELDS classId, version;

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -245,6 +245,22 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // Optics §4.3 (docs/roadmap/fovea-optics-2026-08.md §4.3): the
+  // lens-suppression governor's per-request outcome —
+  //   suppressed     — a confident class match removed ≥1 active lane
+  //   no_model       — flag on, no usable per-class suppression model
+  //   low_confidence — the nearest centroid's cosine is below the floor
+  //   floor_kept     — a match would empty the active set → original kept
+  //   no_op          — a confident match whose suppress set is disjoint
+  // Emitted only when the flag is on (nothing on the hot path when off).
+  // A separate series, distinct from the synthesize outcome counter.
+  readonly lensSuppressionCount = new Counter({
+    name: 'brain_lens_suppression_total',
+    help: 'Lens-suppression governor outcomes (Optics §4.3)',
+    labelNames: ['outcome'] as const,
+    registers: [this.registry],
+  });
+
   // Cross-encoder outcomes:
   //   invoked          — Cohere call returned a non-identity permutation
   //   error            — Cohere fallback to identity (timeout / 4xx / 5xx)
@@ -581,6 +597,12 @@ export class MetricsService implements OnModuleInit {
 
   countAbstainPath(path: 'adaptive' | 'static'): void {
     this.abstainPathCount.inc({ path } as LabelValues<'path'>);
+  }
+
+  countLensSuppression(
+    outcome: 'suppressed' | 'no_model' | 'low_confidence' | 'floor_kept' | 'no_op',
+  ): void {
+    this.lensSuppressionCount.inc({ outcome } as LabelValues<'outcome'>);
   }
 
   countRetract(): void {

--- a/src/synthesize/lens-admin.controller.ts
+++ b/src/synthesize/lens-admin.controller.ts
@@ -1,0 +1,98 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { LensSuppressionService, type LensSuppressionFitClass } from './lens-suppression.service';
+
+/**
+ * Fovea optics admin surface (Optics §4.3) — load + fit the lens-suppression
+ * model. Companion to docs/roadmap/fovea-optics-2026-08.md §4.3.
+ *
+ * Operator / eval-harness only (brain:admin). Gated by the same master flag
+ * as the governor: with FOVEA_LENS_SUPPRESS off the whole feature is dormant,
+ * so these routes 404 (indistinguishable from absent — the focus-admin
+ * idiom). The `fit` is a THIN INGEST of externally-mined (class, centroid,
+ * suppressLanes) rows — the training data is offline/parked, so this surface
+ * persists provided rows rather than learning at serving time.
+ */
+@Controller('v1/admin/lens-suppression')
+@UseGuards(ApiKeyGuard)
+export class LensAdminController {
+  constructor(private readonly lens: LensSuppressionService) {}
+
+  private assertEnabled(): void {
+    if (!LensSuppressionService.suppressEnabled()) throw new NotFoundException();
+  }
+
+  /** List the latest suppression class per classId (max version). */
+  @Get('classes')
+  @RequireScopes('brain:admin')
+  async classes(@Req() req: AuthenticatedRequest): Promise<{
+    classes: Array<{
+      classId: string;
+      suppressLanes: string[];
+      sampleCount: number;
+      version: number;
+      centroidDim: number;
+    }>;
+  }> {
+    this.assertEnabled();
+    const rows = await this.lens.listClasses(req.brainAuth.companyId);
+    return { classes: rows };
+  }
+
+  /** Ingest externally-mined per-class suppression rows (versioned). */
+  @Post('fit')
+  @RequireScopes('brain:admin')
+  async fit(
+    @Req() req: AuthenticatedRequest,
+    @Body()
+    body: {
+      classes?: Array<{
+        classId?: unknown;
+        centroid?: unknown;
+        suppressLanes?: unknown;
+        sampleCount?: unknown;
+      }>;
+    },
+  ): Promise<{ persisted: number; classes: string[] }> {
+    this.assertEnabled();
+    const raw = body?.classes;
+    if (!Array.isArray(raw) || raw.length === 0) {
+      throw new BadRequestException('classes[] required and must be non-empty');
+    }
+    const classes: LensSuppressionFitClass[] = raw.map((c) => {
+      if (
+        !c ||
+        typeof c.classId !== 'string' ||
+        c.classId.trim() === '' ||
+        !Array.isArray(c.centroid) ||
+        !c.centroid.every((n) => typeof n === 'number' && Number.isFinite(n)) ||
+        !Array.isArray(c.suppressLanes) ||
+        !c.suppressLanes.every((l) => typeof l === 'string') ||
+        typeof c.sampleCount !== 'number' ||
+        !Number.isFinite(c.sampleCount) ||
+        c.sampleCount < 0
+      ) {
+        throw new BadRequestException(
+          'each class needs a classId, a numeric centroid[], a string suppressLanes[], and a non-negative sampleCount',
+        );
+      }
+      return {
+        classId: c.classId,
+        centroid: c.centroid as number[],
+        suppressLanes: c.suppressLanes as string[],
+        sampleCount: c.sampleCount,
+      };
+    });
+    return this.lens.fitAndPersist(req.brainAuth.companyId, classes);
+  }
+}

--- a/src/synthesize/lens-suppression.service.ts
+++ b/src/synthesize/lens-suppression.service.ts
@@ -1,0 +1,247 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { lensSuppressEnabled, lensSuppressMinCosine } from '../common/fovea-flags';
+import { SurrealService } from '../db/surreal.service';
+import { EmbedderService } from '../ai/embedder.service';
+import { MetricsService } from '../metrics/metrics.service';
+import type { RetrievalProfile } from '../search/retrieval-profile';
+import {
+  decideSuppression,
+  isUsableModel,
+  toLaneId,
+  type LensSuppressionClass,
+  type LensSuppressionModel,
+} from './lens-suppression';
+
+/** One class row as accepted by the admin `fit` ingest. */
+export interface LensSuppressionFitClass {
+  classId: string;
+  centroid: number[];
+  suppressLanes: string[];
+  sampleCount: number;
+}
+
+/**
+ * LensSuppressionService — load + fit + list for the fovea lens-suppression
+ * governor (Optics §4.3). Companion to docs/roadmap/fovea-optics-2026-08.md.
+ *
+ * The DECISION is pure (lens-suppression.ts, decideSuppression); this service
+ * owns only persistence and the runtime-flag statics. Persistence follows the
+ * focus_calibration versioning idiom (versioned rows per class, max(version)
+ * wins, withCompany scope) — it is not a parallel mechanism.
+ *
+ * The training data is OFFLINE ablation-mined and PARKED, so `fitAndPersist`
+ * is a THIN INGEST of externally-provided (class, centroid, suppressLanes)
+ * rows, not a serving-time learner. Nothing here reads env directly: the flag
+ * statics delegate to the common layer (fovea-flags.ts) so the engine dir
+ * stays env-free (engine-gates S5.2).
+ */
+@Injectable()
+export class LensSuppressionService {
+  private readonly logger = new Logger(LensSuppressionService.name);
+
+  constructor(
+    private readonly surreal: SurrealService,
+    @Optional() private readonly embedder?: EmbedderService,
+    @Optional() private readonly metrics?: MetricsService,
+  ) {}
+
+  /**
+   * The governor's serving entry point (Optics §4.3). Returns the EFFECTIVE
+   * profile: the original with off-task / trap-inducing lanes SUBTRACTED for
+   * this query's learned class. Subtractive only — it can never add a lane or
+   * reorder (the decision is set-minus, see decideSuppression).
+   *
+   * Load-bearing safety property: flag off, embedder absent, no usable model,
+   * a low-confidence class match, or ANY failure → the SAME `profile` object
+   * returned unchanged (`effectiveProfile === profile`), so routing AND the
+   * answer-cache key are byte-identical to today. A fresh object (with a
+   * strict-subset lane set) is returned only when a confident class match
+   * actually removed a lane. Env reads live in the common layer (the flag
+   * statics), never a direct env read here (engine-gates S5.2). The embed
+   * reuses the CACHED EmbedderService — the retrieval pipeline embeds the same
+   * query, so this is a cache hit (or one cheap call).
+   */
+  async effectiveProfile(
+    companyId: string,
+    profile: RetrievalProfile,
+    dto: { query: string },
+  ): Promise<RetrievalProfile> {
+    if (!this.embedder || !LensSuppressionService.suppressEnabled()) return profile;
+    try {
+      const model = await this.loadModel(companyId);
+      if (!isUsableModel(model)) {
+        this.metrics?.countLensSuppression('no_model');
+        return profile;
+      }
+      const queryEmbedding = await this.embedder.embed(dto.query);
+      const decision = decideSuppression({
+        model,
+        queryEmbedding,
+        activeLanes: profile.lanes,
+        minCosine: LensSuppressionService.minCosine(),
+      });
+      this.metrics?.countLensSuppression(decision.outcome);
+      if (decision.outcome !== 'suppressed') return profile;
+      this.logger.debug(
+        `lens suppression: class=${decision.classId} cos=${decision.cosine?.toFixed(3)} removed=[${decision.removed.join(',')}]`,
+      );
+      return { ...profile, lanes: decision.effectiveLanes };
+    } catch (e) {
+      this.logger.warn(`lens suppression failed; static lane routing: ${(e as Error).message}`);
+      return profile;
+    }
+  }
+
+  /** Master flag — delegates to the common-layer reader (engine dirs take no
+   *  direct env reads; see fovea-flags.ts / engine-gates S5.2). Read at call
+   *  time so the knob is runtime-mutable. Off ⇒ static lane routing. */
+  static suppressEnabled(): boolean {
+    return lensSuppressEnabled();
+  }
+
+  /** Optics §4.3 nearest-centroid cosine floor — the common-layer reader
+   *  (default 0.5). Below it a class match is uncertain and lanes are kept. */
+  static minCosine(): number {
+    return lensSuppressMinCosine();
+  }
+
+  /**
+   * Load the latest persisted per-class suppression model for a tenant
+   * (max version per class). Unknown/malformed suppress-lane ids are dropped
+   * at read time (toLaneId) so a stale entry can never introduce a routing
+   * ADD. Returns [] when nothing is persisted → the governor stays static.
+   */
+  async loadModel(companyId: string): Promise<LensSuppressionModel> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<
+        [
+          Array<{
+            classId: string;
+            centroid: number[];
+            suppressLanes: string[];
+            sampleCount: number;
+            version: number;
+          }>,
+        ]
+      >(
+        `SELECT classId, centroid, suppressLanes, sampleCount, version
+            FROM lens_suppression
+            ORDER BY version DESC`,
+      );
+      const byClass = new Map<string, LensSuppressionClass>();
+      for (const r of rows ?? []) {
+        // First row per class wins (rows are version-desc ordered).
+        if (byClass.has(r.classId)) continue;
+        if (!Array.isArray(r.centroid) || !Array.isArray(r.suppressLanes)) continue;
+        const suppressLanes = r.suppressLanes
+          .map(toLaneId)
+          .filter((l): l is NonNullable<typeof l> => l !== null);
+        byClass.set(r.classId, {
+          classId: r.classId,
+          centroid: r.centroid,
+          suppressLanes,
+          sampleCount: typeof r.sampleCount === 'number' ? r.sampleCount : 0,
+        });
+      }
+      return [...byClass.values()];
+    });
+  }
+
+  /**
+   * THIN INGEST of externally-mined suppression rows (the training data is
+   * offline/parked). Each class is persisted as a NEW versioned row
+   * (calibration_table idiom); the reader picks max(version) per class.
+   * Unknown lane ids are dropped. Returns the persisted class ids.
+   */
+  async fitAndPersist(
+    companyId: string,
+    classes: readonly LensSuppressionFitClass[],
+  ): Promise<{ persisted: number; classes: string[] }> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const out: string[] = [];
+      for (const c of classes) {
+        const suppressLanes = c.suppressLanes
+          .map(toLaneId)
+          .filter((l): l is NonNullable<typeof l> => l !== null);
+        const [latest] = await db.query<[Array<{ version: number }>]>(
+          `SELECT version FROM lens_suppression
+              WHERE classId = $classId ORDER BY version DESC LIMIT 1`,
+          { classId: c.classId },
+        );
+        const next = Array.isArray(latest) && latest[0]?.version ? latest[0].version + 1 : 1;
+        await db.query(
+          `CREATE lens_suppression CONTENT {
+              companyId: $companyId,
+              classId: $classId,
+              centroid: $centroid,
+              suppressLanes: $suppressLanes,
+              sampleCount: $sampleCount,
+              version: $version
+           }`,
+          {
+            companyId,
+            classId: c.classId,
+            centroid: c.centroid,
+            suppressLanes,
+            sampleCount: c.sampleCount,
+            version: next,
+          },
+        );
+        out.push(c.classId);
+      }
+      return { persisted: out.length, classes: out };
+    });
+  }
+
+  /** List the latest suppression class per classId (max version) — the admin
+   *  read surface. Centroid vectors are omitted (bulky, not operator-useful). */
+  async listClasses(companyId: string): Promise<
+    Array<{
+      classId: string;
+      suppressLanes: string[];
+      sampleCount: number;
+      version: number;
+      centroidDim: number;
+    }>
+  > {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const [rows] = await db.query<
+        [
+          Array<{
+            classId: string;
+            centroid: number[];
+            suppressLanes: string[];
+            sampleCount: number;
+            version: number;
+          }>,
+        ]
+      >(
+        `SELECT classId, centroid, suppressLanes, sampleCount, version
+            FROM lens_suppression
+            ORDER BY version DESC`,
+      );
+      const seen = new Set<string>();
+      const out: Array<{
+        classId: string;
+        suppressLanes: string[];
+        sampleCount: number;
+        version: number;
+        centroidDim: number;
+      }> = [];
+      for (const r of rows ?? []) {
+        if (seen.has(r.classId)) continue;
+        seen.add(r.classId);
+        out.push({
+          classId: r.classId,
+          suppressLanes: Array.isArray(r.suppressLanes)
+            ? r.suppressLanes.map(toLaneId).filter((l): l is NonNullable<typeof l> => l !== null)
+            : [],
+          sampleCount: typeof r.sampleCount === 'number' ? r.sampleCount : 0,
+          version: r.version,
+          centroidDim: Array.isArray(r.centroid) ? r.centroid.length : 0,
+        });
+      }
+      return out;
+    });
+  }
+}

--- a/src/synthesize/lens-suppression.ts
+++ b/src/synthesize/lens-suppression.ts
@@ -1,0 +1,167 @@
+/**
+ * Fovea optics — the lens-suppression governor (Optics §4.3).
+ *
+ * Companion to docs/roadmap/fovea-optics-2026-08.md §4.3, sharpened by the
+ * trap-resistance shakedown docs/roadmap/memtrap-shakedown-2026-08.md. §4.3
+ * is emphatic that against a strong hybrid-always baseline a POSITIVE router
+ * mostly risks regressions (every misroute is a lane holding the gold that
+ * never fired); the real lever is PRECISION OF SUPPRESSION — not firing the
+ * lanes that inject noise for this query-class. The shakedown named the trap
+ * carriers: the instruction and strategy lanes (Task Boundary / Cognitive
+ * Bias / Trauma).
+ *
+ * This module is the pure decision, and nothing else — no DI, no IO, no env.
+ * The single chokepoint for ALL lanes is `RetrievalProfile.lanes`
+ * (`ReadonlySet<LaneId>`): routeLane iterates the registry restricted to it,
+ * every evidence-conditional lane gates via `profile.lanes.has(...)`. So
+ * suppression = subtract lanes from that set at ONE point. Because it is
+ * set-minus, it is SUBTRACTIVE BY CONSTRUCTION — the output is always a
+ * subset of the input; it can never add a lane and never reorder.
+ *
+ * Degrades gracefully (the §4.3 failure-mode contract): a missed suppression
+ * = today's behavior. The floor is that we NEVER empty a non-empty active
+ * set — if a class would suppress every active lane we keep the original.
+ * The failure mode must be "kept a slightly noisy lane", never "dropped the
+ * lane holding the gold".
+ */
+
+import type { LaneId } from '../search/retrieval-profile';
+import { ALL_LANES } from '../search/retrieval-profile';
+import { cosineSimilarity } from '../common/vector-math';
+
+/** One learned class of the suppression model: a query-embedding centroid
+ *  (nearest-centroid match) and the LaneIds it hard-suppresses. */
+export interface LensSuppressionClass {
+  /** The learned class key (a routed LaneId, an ablation-mined cluster
+   *  label, or 'default'). */
+  classId: string;
+  /** The class's query-embedding centroid — cosine-matched to the query. */
+  centroid: number[];
+  /** LaneIds this class hard-suppresses for its query-class. */
+  suppressLanes: readonly LaneId[];
+  /** Labeled samples behind the class (the usability gate reads this). */
+  sampleCount: number;
+}
+
+/** The persisted per-class suppression model (one entry per class). */
+export type LensSuppressionModel = readonly LensSuppressionClass[];
+
+/** The governor's decision outcome (telemetry label + control flow):
+ *   - suppressed     — a confident class match removed ≥1 active lane; the
+ *                      effective set is a strict, non-empty subset.
+ *   - no_model       — no usable model → the original set (byte-identical).
+ *   - low_confidence — the nearest centroid's cosine is below the floor →
+ *                      the original set (uncertain → today's behavior).
+ *   - floor_kept     — a confident class match would suppress EVERY active
+ *                      lane; the floor keeps the original set (never empty).
+ *   - no_op          — a confident class match, but its suppress set is
+ *                      disjoint from the active lanes → the original set. */
+export type SuppressionOutcome =
+  'suppressed' | 'no_model' | 'low_confidence' | 'floor_kept' | 'no_op';
+
+/** The pure governor decision. `effectiveLanes` is the SAME reference as the
+ *  input `activeLanes` for every non-'suppressed' outcome (so the caller can
+ *  return the original profile object unchanged — byte-identical), and a
+ *  fresh strict subset only when `outcome === 'suppressed'`. */
+export interface SuppressionDecision {
+  effectiveLanes: ReadonlySet<LaneId>;
+  outcome: SuppressionOutcome;
+  /** Active lanes actually removed (empty unless outcome is 'suppressed'). */
+  removed: LaneId[];
+  /** The matched class, when a class was confidently matched. */
+  classId?: string;
+  /** The matched class's cosine to the query, when matched. */
+  cosine?: number;
+}
+
+const LANE_SET: ReadonlySet<string> = new Set<string>(ALL_LANES);
+
+/** Coerce a stored lane string to a LaneId (drops unknown ids — a stale or
+ *  malformed suppress entry can never introduce a routing ADD). */
+export function toLaneId(value: unknown): LaneId | null {
+  return typeof value === 'string' && LANE_SET.has(value) ? (value as LaneId) : null;
+}
+
+/**
+ * Whether a loaded model is USABLE — the load-bearing safety predicate that
+ * decides adaptive-vs-static (mirrors focus-signal's hasUsableCalibration).
+ * Usable iff at least one class was fit from real samples (sampleCount > 0)
+ * AND carries a non-empty centroid to match against. An empty model ([]) and
+ * a bootstrap model (all sampleCount 0, or centroid-less rows) both return
+ * false, so an unconfigured or freshly-bootstrapped tenant falls back to the
+ * static lane set and routes byte-identically to today.
+ */
+export function isUsableModel(model: LensSuppressionModel): boolean {
+  return model.some((c) => c.sampleCount > 0 && c.centroid.length > 0);
+}
+
+/**
+ * The subtractive governor decision. Nearest-centroid over the usable
+ * classes (reusing the shared cosine primitive, common/vector-math); below
+ * the cosine floor → unchanged (uncertain → today's behavior). Otherwise
+ * subtract the matched class's suppress lanes from the active set, with the
+ * non-empty floor. SUBTRACTIVE BY CONSTRUCTION: `effectiveLanes ⊆ activeLanes`
+ * for every outcome, and equal (same reference) for everything except
+ * 'suppressed'.
+ */
+export function decideSuppression(args: {
+  model: LensSuppressionModel;
+  queryEmbedding: number[];
+  activeLanes: ReadonlySet<LaneId>;
+  minCosine: number;
+}): SuppressionDecision {
+  const { model, queryEmbedding, activeLanes, minCosine } = args;
+  if (!isUsableModel(model)) {
+    return { effectiveLanes: activeLanes, outcome: 'no_model', removed: [] };
+  }
+  // Nearest-centroid over the usable classes only. A dimension mismatch — a
+  // malformed / truncated centroid, or an empty query embedding — is skipped
+  // outright, so it can never be a false nearest match (degrades to
+  // low_confidence, never to a wrong suppress).
+  let best: { cls: LensSuppressionClass; cosine: number } | undefined;
+  for (const cls of model) {
+    if (!(cls.sampleCount > 0) || cls.centroid.length === 0) continue;
+    if (cls.centroid.length !== queryEmbedding.length) continue;
+    const cosine = cosineSimilarity(queryEmbedding, cls.centroid);
+    if (!best || cosine > best.cosine) best = { cls, cosine };
+  }
+  if (!best || best.cosine < minCosine) {
+    return {
+      effectiveLanes: activeLanes,
+      outcome: 'low_confidence',
+      removed: [],
+      ...(best ? { classId: best.cls.classId, cosine: best.cosine } : {}),
+    };
+  }
+  const suppress = new Set<LaneId>(best.cls.suppressLanes);
+  const removed = [...activeLanes].filter((l) => suppress.has(l));
+  if (removed.length === 0) {
+    // Confident match, but nothing to remove (disjoint / empty suppress set).
+    return {
+      effectiveLanes: activeLanes,
+      outcome: 'no_op',
+      removed: [],
+      classId: best.cls.classId,
+      cosine: best.cosine,
+    };
+  }
+  const reduced = new Set<LaneId>([...activeLanes].filter((l) => !suppress.has(l)));
+  if (reduced.size === 0) {
+    // The floor: never empty a non-empty active set. A missed suppression is
+    // today's behavior; dropping the last lane could drop the gold.
+    return {
+      effectiveLanes: activeLanes,
+      outcome: 'floor_kept',
+      removed,
+      classId: best.cls.classId,
+      cosine: best.cosine,
+    };
+  }
+  return {
+    effectiveLanes: reduced,
+    outcome: 'suppressed',
+    removed,
+    classId: best.cls.classId,
+    cosine: best.cosine,
+  };
+}

--- a/src/synthesize/synthesize.module.ts
+++ b/src/synthesize/synthesize.module.ts
@@ -5,8 +5,10 @@ import { AnswerCacheModule } from '../answer-cache/answer-cache.module';
 import { StrategyModule } from '../strategy/strategy.module';
 import { SynthesizeController } from './synthesize.controller';
 import { FocusAdminController } from './focus-admin.controller';
+import { LensAdminController } from './lens-admin.controller';
 import { SynthesizeService } from './synthesize.service';
 import { FocusSignalService } from './focus-signal.service';
+import { LensSuppressionService } from './lens-suppression.service';
 import { EpisodeLaneService } from './episode-lane.service';
 import { SegmentLaneService } from './segment-lane.service';
 import { InsightLaneService } from './insight-lane.service';
@@ -19,10 +21,11 @@ import { L3EscalationService } from './l3-escalation.service';
 
 @Module({
   imports: [SearchModule, EpisodesModule, AnswerCacheModule, StrategyModule],
-  controllers: [SynthesizeController, FocusAdminController],
+  controllers: [SynthesizeController, FocusAdminController, LensAdminController],
   providers: [
     SynthesizeService,
     FocusSignalService,
+    LensSuppressionService,
     EvidenceCollectorService,
     EpisodeLaneService,
     SegmentLaneService,

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -48,6 +48,7 @@ import {
   queryClassOf,
 } from './focus-signal';
 import type { FocusVerdict, PerClassCalibration } from './focus-signal';
+import { LensSuppressionService } from './lens-suppression.service';
 import {
   AnswerCacheService,
   type AnswerCacheBeginResult,
@@ -126,6 +127,7 @@ export class SynthesizeService {
     @Optional() private readonly answerCache?: AnswerCacheService,
     @Optional() private readonly l3?: L3EscalationService,
     @Optional() private readonly focusSignal?: FocusSignalService,
+    @Optional() private readonly lensSuppression?: LensSuppressionService,
   ) {
     this.openai = createOpenAiClientOrThrow(this.configService);
     this.defaultModel = this.configService.get<string>(
@@ -187,6 +189,16 @@ export class SynthesizeService {
     const model = dto.synthesisModel ?? this.defaultModel;
     const explain = dto.explain === true;
 
+    // Optics §4.3 lens-suppression governor: rebind `profile` to the EFFECTIVE
+    // profile — off-task / trap-inducing lanes SUBTRACTED for this query's
+    // learned class (never added, never reordered) — so EVERY downstream seam
+    // (routeLane, evidence collector, detectEvidenceConflicts, markRecency, L3,
+    // abstention) sees the reduced set. BEFORE the answer cache begins, so the
+    // cache key (profileHash includes profile.lanes) reflects the effective
+    // lanes. Flag off / deps absent / no-model / low-confidence → the SAME
+    // profile object (byte-identical, same cache key). See LensSuppressionService.
+    profile = (await this.lensSuppression?.effectiveProfile(companyId, profile, dto)) ?? profile;
+
     // G1 answer cache (SYNTHESIZE_ANSWER_CACHE): exact-key serve with
     // check-on-read fact-lifecycle gating, BEFORE retrieval; a miss
     // carries the key context to the admit hook (finalizeAndAdmit).
@@ -245,7 +257,6 @@ export class SynthesizeService {
     // `let`: the V13 search loop may replace the evidence set with the
     // refined round's union before citations resolve.
     let { results, factIndex } = prepared;
-    const { factLines } = prepared;
 
     // V9 §4 coverage abstention + Optics §4.2 pre-answer capture/gate (seam).
     const abstained = await this.maybeCoverageAbstain(companyId, lane, {
@@ -290,7 +301,7 @@ export class SynthesizeService {
     // suffix maps land on the SAME lines the generator and the
     // verifier read (prompt-side only; citations and ranking
     // untouched).
-    let promptFactLines = applyFactSuffixes(factLines, [updateStories, groundingQuotes]);
+    let promptFactLines = applyFactSuffixes(prepared.factLines, [updateStories, groundingQuotes]);
 
     // V13 answer-side frames, both profile-gated and both pure:
     // the computed date table (generator and verifier read the same

--- a/test/fovea-lens-suppress.e2e-spec.ts
+++ b/test/fovea-lens-suppress.e2e-spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Fovea optics (Optics §4.3, docs/roadmap/fovea-optics-2026-08.md §4.3) —
+ * the lens-suppression governor, e2e over a real SurrealDB (testcontainer).
+ * The generator + verifier are scripted via mockSynthesizeOpenAi; the query
+ * EMBEDDING goes to the real (deterministic, cached) EmbedderService, which
+ * is untouched by the chat mock — so a seeded centroid equal to embed(QUERY)
+ * matches the serving-time embedding with cosine 1.0.
+ *
+ * The trap carrier under test is the INSTRUCTION lane (memtrap-shakedown
+ * class 1): with the router + instruction lane on, an "always ..." preference
+ * fact renders as a generator-only "Standing instructions:" section. The
+ * governor suppresses that lane for the query's class.
+ *
+ * Three scenarios (router + instruction lane on throughout):
+ *   1. flag OFF (control tenant) → the lane reaches the prompt (baseline).
+ *   2. flag ON, NO model (control tenant) → the lane STILL reaches the prompt
+ *      (the load-bearing byte-identical fallback: no usable model → static).
+ *   3. flag ON, a seeded model that suppresses 'instruction' near the query
+ *      centroid → the lane does NOT reach the generator prompt (suppressed).
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSynthesizeOpenAi } from './test-doubles';
+import { SurrealService } from '../src/db/surreal.service';
+import { MetricsService } from '../src/metrics/metrics.service';
+import { EmbedderService } from '../src/ai/embedder.service';
+
+describe('Fovea Optics §4.3 lens-suppression governor e2e', () => {
+  // Seeded-model tenant (suppresses) and an isolated no-model tenant (control),
+  // so the two scenarios cannot see each other's rows.
+  let fSuppress: AppFixture;
+  let fControl: AppFixture;
+  const authSuppress = () => ({ Authorization: `Bearer ${fSuppress.apiKey}` });
+  const authControl = () => ({ Authorization: `Bearer ${fControl.apiKey}` });
+
+  const QUERY = 'what is the status of proj lens';
+  const INSTRUCTION_MARKER = 'Standing instructions:';
+
+  // Ingest an answerable status fact + an "always ..." instruction pref fact.
+  async function seedFacts(app: AppFixture, auth: () => Record<string, string>): Promise<string> {
+    const status = await app.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'proj_lens' },
+        predicate: 'status',
+        object: 'active launch phase',
+        validFrom: new Date('2026-04-01').toISOString(),
+        source: { vertical: 'rent', messageId: 'm_lens_a' },
+        confidence: 0.9,
+      });
+    const statusFactId = status.body.factId as string;
+    expect(statusFactId).toBeTruthy();
+    await app.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'proj_lens' },
+        predicate: 'preferences',
+        object: 'Always include code examples when I ask about implementation.',
+        validFrom: new Date('2026-04-01').toISOString(),
+        source: { vertical: 'rent', messageId: 'm_lens_b' },
+        confidence: 0.9,
+      });
+    return statusFactId;
+  }
+
+  const genFor = (factId: string) => [
+    JSON.stringify({ answer: `The status is active [${factId}].`, citedFactIds: [factId] }),
+    JSON.stringify({ verdict: 'supported', unsupportedClaims: [], questionAnswered: true }),
+  ];
+
+  // Round-1 generator prompt (user message) that /v1/synthesize sent.
+  async function generatorPrompt(app: AppFixture, factId: string): Promise<string> {
+    const state = mockSynthesizeOpenAi(app.app, genFor(factId));
+    const res = await app.http
+      .post('/v1/synthesize')
+      .set({ Authorization: `Bearer ${app.apiKey}` })
+      .send({ query: QUERY, limit: 5 });
+    expect(res.status).toBe(201);
+    expect(state.calls.length).toBeGreaterThanOrEqual(1);
+    return state.calls[0]!.user;
+  }
+
+  async function suppressCount(app: AppFixture, outcome: string): Promise<number> {
+    const metrics = app.app.get(MetricsService);
+    const { body } = await metrics.serialize();
+    const m = body.match(
+      new RegExp(`brain_lens_suppression_total\\{outcome="${outcome}"\\} (\\d+)`),
+    );
+    return m ? parseInt(m[1]!, 10) : 0;
+  }
+
+  beforeAll(async () => {
+    delete process.env.FOVEA_LENS_SUPPRESS;
+    delete process.env.FOVEA_LENS_SUPPRESS_MIN_COSINE;
+    delete process.env.SYNTHESIZE_ANSWER_CACHE;
+    // Router + instruction lane on so the instruction lane is in profile.lanes
+    // (and thus a suppressible target).
+    process.env.SYNTHESIZE_ANSWER_ROUTER_ENABLED = '1';
+    process.env.SYNTHESIZE_INSTRUCTION_LANE = '1';
+
+    fSuppress = await createApp();
+    fControl = await createApp();
+
+    const suppressFactId = await seedFacts(fSuppress, authSuppress);
+    const controlFactId = await seedFacts(fControl, authControl);
+    (fSuppress as unknown as { factId: string }).factId = suppressFactId;
+    (fControl as unknown as { factId: string }).factId = controlFactId;
+
+    // Seed a USABLE suppression model on the SUPPRESS tenant only: one class
+    // whose centroid IS the query embedding (cosine 1.0 ≥ the 0.5 floor),
+    // suppressing the instruction lane.
+    const embedder = fSuppress.app.get(EmbedderService);
+    const centroid = await embedder.embed(QUERY);
+    expect(centroid.length).toBeGreaterThan(0);
+    const surreal = fSuppress.app.get(SurrealService);
+    await surreal.withCompany(fSuppress.companyId, async (db) => {
+      await db.query(
+        `CREATE lens_suppression CONTENT {
+           companyId: $c, classId: 'default', centroid: $centroid,
+           suppressLanes: ['instruction'], sampleCount: 100, version: 1
+         }`,
+        { c: fSuppress.companyId, centroid },
+      );
+    });
+  });
+
+  afterAll(async () => {
+    delete process.env.FOVEA_LENS_SUPPRESS;
+    delete process.env.FOVEA_LENS_SUPPRESS_MIN_COSINE;
+    delete process.env.SYNTHESIZE_ANSWER_ROUTER_ENABLED;
+    delete process.env.SYNTHESIZE_INSTRUCTION_LANE;
+    if (fSuppress) await fSuppress.close();
+    if (fControl) await fControl.close();
+  });
+
+  it('flag OFF → the instruction lane reaches the generator prompt (baseline)', async () => {
+    delete process.env.FOVEA_LENS_SUPPRESS;
+    const factId = (fControl as unknown as { factId: string }).factId;
+    const prompt = await generatorPrompt(fControl, factId);
+    expect(prompt).toContain(INSTRUCTION_MARKER);
+  });
+
+  it('flag ON + NO model → byte-identical: the lane STILL reaches the prompt', async () => {
+    process.env.FOVEA_LENS_SUPPRESS = '1';
+    const factId = (fControl as unknown as { factId: string }).factId;
+    const before = await suppressCount(fControl, 'no_model');
+    const prompt = await generatorPrompt(fControl, factId);
+    expect(prompt).toContain(INSTRUCTION_MARKER);
+    // The governor engaged but found no usable model → static fallback.
+    expect(await suppressCount(fControl, 'no_model')).toBe(before + 1);
+  });
+
+  it('flag ON + seeded model near the query centroid → the lane is SUPPRESSED', async () => {
+    process.env.FOVEA_LENS_SUPPRESS = '1';
+    const factId = (fSuppress as unknown as { factId: string }).factId;
+    const before = await suppressCount(fSuppress, 'suppressed');
+    const prompt = await generatorPrompt(fSuppress, factId);
+    // The instruction lane was subtracted for this query's class, so its
+    // generator-only section never reached the prompt.
+    expect(prompt).not.toContain(INSTRUCTION_MARKER);
+    expect(await suppressCount(fSuppress, 'suppressed')).toBe(before + 1);
+  });
+});

--- a/test/lens-suppression.unit-spec.ts
+++ b/test/lens-suppression.unit-spec.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit spec — fovea lens-suppression governor (Optics §4.3 pure module).
+ *
+ * Covers cosine similarity (bounds + degenerate cases), the usable-model
+ * predicate (empty / bootstrap → not usable), and the subtractive decision:
+ *   - class present + cosine ≥ floor → a strictly-reduced set (suppressed)
+ *   - below floor → unchanged (low_confidence)
+ *   - a match that would empty the set → the ORIGINAL set (floor_kept)
+ *   - a disjoint suppress set → unchanged (no_op)
+ *   - the SUBTRACTIVE INVARIANT: output ⊆ input, never a new lane, never
+ *     reordered; and BYTE-IDENTICAL: every non-suppressed outcome returns the
+ *     SAME set reference it was given.
+ */
+import type { LaneId } from '../src/search/retrieval-profile';
+import {
+  decideSuppression,
+  isUsableModel,
+  toLaneId,
+  type LensSuppressionModel,
+} from '../src/synthesize/lens-suppression';
+
+const lanes = (...ids: LaneId[]): ReadonlySet<LaneId> => new Set<LaneId>(ids);
+
+describe('toLaneId', () => {
+  it('accepts valid LaneIds and drops everything else', () => {
+    expect(toLaneId('instruction')).toBe('instruction');
+    expect(toLaneId('strategy')).toBe('strategy');
+    expect(toLaneId('not_a_lane')).toBeNull();
+    expect(toLaneId(42)).toBeNull();
+    expect(toLaneId(undefined)).toBeNull();
+  });
+});
+
+describe('isUsableModel', () => {
+  it('is false for an empty model (nothing persisted)', () => {
+    expect(isUsableModel([])).toBe(false);
+  });
+
+  it('is false for a bootstrap model (all sampleCount 0 or centroid-less)', () => {
+    expect(
+      isUsableModel([
+        { classId: 'default', centroid: [0.1, 0.2], suppressLanes: [], sampleCount: 0 },
+      ]),
+    ).toBe(false);
+    expect(
+      isUsableModel([
+        { classId: 'default', centroid: [], suppressLanes: ['instruction'], sampleCount: 99 },
+      ]),
+    ).toBe(false);
+  });
+
+  it('is true once one class is fit from real samples with a centroid', () => {
+    expect(
+      isUsableModel([
+        {
+          classId: 'default',
+          centroid: [0.1, 0.2],
+          suppressLanes: ['instruction'],
+          sampleCount: 5,
+        },
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe('decideSuppression', () => {
+  const model: LensSuppressionModel = [
+    // Matches [1,0,0] with cosine 1; suppresses the instruction + strategy lanes.
+    {
+      classId: 'trap',
+      centroid: [1, 0, 0],
+      suppressLanes: ['instruction', 'strategy'],
+      sampleCount: 100,
+    },
+    // Orthogonal to [1,0,0] (cosine 0); a decoy class.
+    { classId: 'other', centroid: [0, 1, 0], suppressLanes: ['temporal'], sampleCount: 100 },
+  ];
+
+  it('no usable model → unchanged, same reference (no_model)', () => {
+    const active = lanes('instruction', 'strategy', 'temporal');
+    const d = decideSuppression({
+      model: [],
+      queryEmbedding: [1, 0, 0],
+      activeLanes: active,
+      minCosine: 0.5,
+    });
+    expect(d.outcome).toBe('no_model');
+    expect(d.effectiveLanes).toBe(active); // SAME reference — byte-identical
+    expect(d.removed).toEqual([]);
+  });
+
+  it('class present + cosine ≥ floor → strictly reduced set (suppressed)', () => {
+    const active = lanes('instruction', 'strategy', 'temporal');
+    const d = decideSuppression({
+      model,
+      queryEmbedding: [1, 0, 0],
+      activeLanes: active,
+      minCosine: 0.5,
+    });
+    expect(d.outcome).toBe('suppressed');
+    expect(d.classId).toBe('trap');
+    expect(d.cosine).toBeCloseTo(1, 10);
+    expect([...d.effectiveLanes].sort()).toEqual(['temporal']);
+    expect(d.removed.sort()).toEqual(['instruction', 'strategy']);
+    // Subtractive: a strict, non-empty subset of the input.
+    expect(d.effectiveLanes.size).toBeLessThan(active.size);
+    expect(d.effectiveLanes.size).toBeGreaterThan(0);
+    for (const l of d.effectiveLanes) expect(active.has(l)).toBe(true);
+  });
+
+  it('below the cosine floor → unchanged, same reference (low_confidence)', () => {
+    const active = lanes('instruction', 'strategy', 'temporal');
+    // Query orthogonal to the trap centroid: best cosine is 0 (the decoy),
+    // below the 0.5 floor → uncertain → today's behaviour.
+    const d = decideSuppression({
+      model,
+      queryEmbedding: [0, 0, 1],
+      activeLanes: active,
+      minCosine: 0.5,
+    });
+    expect(d.outcome).toBe('low_confidence');
+    expect(d.effectiveLanes).toBe(active); // SAME reference — byte-identical
+    expect(d.removed).toEqual([]);
+  });
+
+  it('a match that would empty the active set → the ORIGINAL set kept (floor_kept)', () => {
+    const active = lanes('instruction', 'strategy');
+    const d = decideSuppression({
+      model,
+      queryEmbedding: [1, 0, 0],
+      activeLanes: active,
+      minCosine: 0.5,
+    });
+    expect(d.outcome).toBe('floor_kept');
+    expect(d.effectiveLanes).toBe(active); // never emptied — same reference
+    expect(d.removed.sort()).toEqual(['instruction', 'strategy']);
+  });
+
+  it('a disjoint suppress set → unchanged, same reference (no_op)', () => {
+    const active = lanes('temporal'); // trap suppresses instruction+strategy — disjoint
+    const d = decideSuppression({
+      model,
+      queryEmbedding: [1, 0, 0],
+      activeLanes: active,
+      minCosine: 0.5,
+    });
+    expect(d.outcome).toBe('no_op');
+    expect(d.effectiveLanes).toBe(active);
+    expect(d.removed).toEqual([]);
+  });
+
+  it('a centroid whose dimension differs from the query is never a match', () => {
+    const active = lanes('instruction', 'strategy', 'temporal');
+    // Query has 4 dims; every model centroid has 3 → all skipped → uncertain.
+    const d = decideSuppression({
+      model,
+      queryEmbedding: [1, 0, 0, 0],
+      activeLanes: active,
+      minCosine: 0.5,
+    });
+    expect(d.outcome).toBe('low_confidence');
+    expect(d.effectiveLanes).toBe(active);
+    expect(d.removed).toEqual([]);
+  });
+
+  it('SUBTRACTIVE INVARIANT: output ⊆ input and never a new lane, across cases', () => {
+    const active = lanes('instruction', 'strategy', 'temporal', 'preference');
+    const cases = [
+      { queryEmbedding: [1, 0, 0], minCosine: 0.5 }, // suppress
+      { queryEmbedding: [0, 0, 1], minCosine: 0.5 }, // low_confidence
+      { queryEmbedding: [1, 0, 0], minCosine: 0.999 }, // just-below → low_confidence
+      { queryEmbedding: [0, 1, 0], minCosine: 0.5 }, // 'other' → suppresses temporal
+    ];
+    for (const c of cases) {
+      const d = decideSuppression({ model, activeLanes: active, ...c });
+      // ⊆ input, never larger, never a lane the input lacked.
+      expect(d.effectiveLanes.size).toBeLessThanOrEqual(active.size);
+      for (const l of d.effectiveLanes) expect(active.has(l)).toBe(true);
+      // Non-suppressed outcomes preserve the exact input reference.
+      if (d.outcome !== 'suppressed') expect(d.effectiveLanes).toBe(active);
+    }
+  });
+});


### PR DESCRIPTION
## Optics §4.3 — lens-suppression governor

Fourth step of the fovea optics program (`docs/roadmap/fovea-optics-2026-08.md` §4.3), sharpened by the trap-resistance shakedown (#333). Subtractive lens suppression: for a query's learned class, REMOVE off-task / trap-inducing lanes from the effective active set — never add, never reorder. Behind default-off `FOVEA_LENS_SUPPRESS`, byte-identical static fallback.

### How it works
- **Single chokepoint.** `profile.lanes` gates every lane (routeLane + evidence-conditional contradiction/recency/instruction/strategy). A one-line seam rebinds `profile` to the **effective** profile (`profile.lanes \ suppressedLanesForClass`) at the top of synthesize — so every downstream seam sees the reduced set. Placed **before** `answerCache.begin` so the cache key (profileHash includes `lanes`) tracks the effective set (no cross-flag serve).
- **Class detection.** Embed the query (reuse `EmbedderService`, cache-hit) → nearest class centroid by cosine; below a confidence floor (`FOVEA_LENS_SUPPRESS_MIN_COSINE`, default 0.5) → don't suppress.
- **Subtractive by construction.** Set-minus can only remove; unit test asserts `effectiveLanes ⊆ activeLanes`, never a new lane, never a reorder. Non-empty floor: if suppression would empty a non-empty set, keep the original (`floor_kept`) — the failure mode is "kept a slightly noisy lane", never "dropped the lane holding the gold".
- **Trap-informed.** The shakedown mapped the trap carriers to the instruction + strategy lanes; those are the prioritized suppression targets.
- **Persistence.** Migration `0096` `lens_suppression` (per-(company,class): centroid + suppressLanes + version). Admin `/v1/admin/lens-suppression/{classes,fit}` (brain:admin, 404 when flag off). Training data = offline ablation-mined labels (parked) → ships inert on dev until a model is fit.

### Byte-identical safety
`effectiveProfile` returns the **same `profile` object** (`=== profile`) on every non-suppressed path: flag off, embedder absent, no usable model, cosine below floor, disjoint suppress set, would-empty floor, or any exception. Unit + e2e prove flag-off / flag-on-no-model both let the instruction lane reach the prompt; only a seeded-model tenant suppresses. Env reads live in `common/fovea-flags.ts` (engine-gates S5.2).

### Tests / gates
- `lens-suppression.unit-spec.ts` (subtractive invariant + byte-identical fallback + usable-model predicate); `fovea-lens-suppress.e2e-spec.ts` (3, Docker).
- Full unit suite green (2341); typecheck / lint:ci / format:check clean; gate goldens (flag-budget, config-catalog-truth, env-validation, engine-gates S5.2/S5.5/S5.6) green. FOVEA_ env route → retrieval-profile golden untouched.
- Telemetry: `brain_lens_suppression_total{outcome}` (suppressed / no_model / low_confidence / floor_kept / no_op).

Prod serving unchanged until the flag is on AND a per-class suppression model exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
