### PR TITLE
fix(stats): user-scope overview counts for userId-pinned callers (privacy leak)

### DIFF
--- a/src/stats/stats.controller.ts
+++ b/src/stats/stats.controller.ts
@@ -6,7 +6,10 @@ import { StatsService } from './stats.service';
 
 /**
  * Per-company memory stats for the end-user "Usage" page. Read-scope;
- * companyId comes from the authenticated credential.
+ * companyId comes from the authenticated credential. A userId-pinned
+ * (end-user) token scopes the counts to its own + tenant-global memory
+ * (audit F3) — brainAuth.userId is absent for M2M / admin callers, who
+ * still see the tenant-wide aggregate.
  */
 @Controller('v1/stats')
 @UseGuards(ApiKeyGuard)
@@ -17,6 +20,6 @@ export class StatsController {
   @RequireScopes('brain:read')
   @PolicyAction('rest.stats.overview')
   async overview(@Req() req: AuthenticatedRequest) {
-    return this.stats.overview(req.brainAuth.companyId, req.brainAuth.scopes);
+    return this.stats.overview(req.brainAuth.companyId, req.brainAuth.scopes, req.brainAuth.userId);
   }
 }

--- a/src/stats/stats.service.ts
+++ b/src/stats/stats.service.ts
@@ -8,7 +8,15 @@ export interface MemoryStats {
   factsActive: number;
   factsCompeting: number;
   factsRetracted: number;
-  communities: number;
+  /**
+   * Tenant-wide community count. Communities are graph clusters built
+   * over the WHOLE tenant entity graph — community_node carries no
+   * userId (migrations 0036 / 0055), so a per-user community count is
+   * not derivable. OMITTED for a userId-pinned (end-user) caller: a
+   * tenant-global figure on a personal "Usage" page would be a metadata
+   * leak. Present (tenant-wide) only for M2M / admin callers.
+   */
+  communities?: number;
   /** Facts recorded (learned) in the last 7 days. */
   factsLast7d: number;
   asOf: string;
@@ -28,15 +36,27 @@ export interface MemoryStats {
  *     moving window and stays a live count in both paths. A failing
  *     view read (pre-migration tenant) logs once per tenant and falls
  *     back to the live path.
+ *
+ * Per-user scope (audit F3): a userId-pinned caller (end-user token)
+ * sees only its OWN + tenant-global counts, never the tenant aggregate.
+ * knowledge_entity / knowledge_fact carry userId (migration 0055) and
+ * are filtered `(userId IS NONE OR userId = $userId)` — the same read
+ * predicate the fact/entity/search lanes use; community_node has no
+ * userId (tenant-wide clusters) so its count is omitted for such a
+ * caller. The 0088 views are tenant-wide GROUP-ALL materializations (no
+ * userId partition), so a userId-pinned caller always takes the live,
+ * user-scoped path below regardless of the flag; only M2M / admin
+ * callers read the views. The LRU key carries the pinned userId.
  */
 @Injectable()
 export class StatsService {
   private readonly logger = new Logger(StatsService.name);
-  /** 30s per-tenant cache: six COUNT aggregates over the largest tables
-   *  per dashboard page-load is pure waste — counts move slower than
-   *  users refresh. Keyed by tenant only (the counts are not
-   *  scope-dependent; the scoped connection matters for row reads, not
-   *  aggregates over statuses). */
+  /** 30s cache: several COUNT aggregates over the largest tables per
+   *  dashboard page-load is pure waste — counts move slower than users
+   *  refresh. Keyed by tenant for an M2M / admin caller, and by
+   *  tenant+userId for a userId-pinned caller (audit F3) so one user's
+   *  cached overview is never served to another user or to the
+   *  tenant-wide caller. */
   private readonly cache = new LRUCache<string, { stats: MemoryStats; at: number }>(500);
   private static readonly CACHE_TTL_MS = 30_000;
   /** Tenants whose view-read failure has already been logged (log once). */
@@ -44,9 +64,18 @@ export class StatsService {
 
   constructor(private readonly surreal: SurrealService) {}
 
-  async overview(companyId: string, scopes: readonly string[]): Promise<MemoryStats> {
+  async overview(
+    companyId: string,
+    scopes: readonly string[],
+    userId?: string,
+  ): Promise<MemoryStats> {
     const nowMs = Date.now();
-    if (envFlagEnabled(process.env.STATS_VIEWS_ENABLED)) {
+    // The 0088 views are tenant-wide GROUP-ALL materializations with no
+    // userId partition, so they can only serve a caller WITHOUT a pinned
+    // userId. A userId-pinned (end-user) caller always takes the live,
+    // user-scoped path below — regardless of STATS_VIEWS_ENABLED — so it
+    // never reads the tenant aggregate (audit F3).
+    if (userId === undefined && envFlagEnabled(process.env.STATS_VIEWS_ENABLED)) {
       try {
         return await this.overviewFromViews(companyId, scopes, nowMs);
       } catch (err) {
@@ -60,31 +89,67 @@ export class StatsService {
         // fall through to the live path below
       }
     }
-    const cached = this.cache.get(companyId);
+    // Cache key carries the pinned userId so a per-user overview is never
+    // served to another user or to the tenant-wide M2M caller (and vice
+    // versa). companyId is validated `[A-Za-z0-9_-]+` (withScopedCompany)
+    // and cannot contain a space, so the first space unambiguously
+    // delimits companyId from userId — a tenant-only key can never
+    // collide with a per-user key, whatever the userId contains.
+    const cacheKey = userId === undefined ? companyId : `${companyId} ${userId}`;
+    const cached = this.cache.get(cacheKey);
     if (cached && nowMs - cached.at < StatsService.CACHE_TTL_MS) {
       return cached.stats;
     }
     const weekAgoIso = new Date(nowMs - 7 * 24 * 60 * 60 * 1000).toISOString();
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
+      if (userId === undefined) {
+        // Tenant-wide (M2M / admin) — byte-identical to the pre-F3 query.
+        const sql = `
+          SELECT count() AS c FROM knowledge_entity GROUP ALL;
+          SELECT count() AS c FROM knowledge_fact WHERE status = 'active' GROUP ALL;
+          SELECT count() AS c FROM knowledge_fact WHERE status = 'competing' GROUP ALL;
+          SELECT count() AS c FROM knowledge_fact WHERE status = 'retracted' GROUP ALL;
+          SELECT count() AS c FROM community_node GROUP ALL;
+          SELECT count() AS c FROM knowledge_fact WHERE recordedAt > type::datetime($weekAgoIso) GROUP ALL;
+        `;
+        const res = (await db.query<unknown[]>(sql, { weekAgoIso })) as unknown[];
+        const stats: MemoryStats = {
+          entities: countOf(res[0]),
+          factsActive: countOf(res[1]),
+          factsCompeting: countOf(res[2]),
+          factsRetracted: countOf(res[3]),
+          communities: countOf(res[4]),
+          factsLast7d: countOf(res[5]),
+          asOf: new Date(nowMs).toISOString(),
+        };
+        this.cache.set(cacheKey, { stats, at: nowMs });
+        return stats;
+      }
+      // Per-user (audit F3): every user-scopable table (knowledge_entity /
+      // knowledge_fact carry userId — migration 0055) is filtered to the
+      // caller's own rows PLUS tenant-global rows via the SAME read
+      // predicate the fact/entity/search lanes use. `gate` is a constant
+      // literal; $userId is a bound parameter. community_node has no
+      // userId, so its tenant-wide count is OMITTED here (not leaked to an
+      // end user).
+      const gate = '(userId IS NONE OR userId = $userId)';
       const sql = `
-        SELECT count() AS c FROM knowledge_entity GROUP ALL;
-        SELECT count() AS c FROM knowledge_fact WHERE status = 'active' GROUP ALL;
-        SELECT count() AS c FROM knowledge_fact WHERE status = 'competing' GROUP ALL;
-        SELECT count() AS c FROM knowledge_fact WHERE status = 'retracted' GROUP ALL;
-        SELECT count() AS c FROM community_node GROUP ALL;
-        SELECT count() AS c FROM knowledge_fact WHERE recordedAt > type::datetime($weekAgoIso) GROUP ALL;
+        SELECT count() AS c FROM knowledge_entity WHERE ${gate} GROUP ALL;
+        SELECT count() AS c FROM knowledge_fact WHERE status = 'active' AND ${gate} GROUP ALL;
+        SELECT count() AS c FROM knowledge_fact WHERE status = 'competing' AND ${gate} GROUP ALL;
+        SELECT count() AS c FROM knowledge_fact WHERE status = 'retracted' AND ${gate} GROUP ALL;
+        SELECT count() AS c FROM knowledge_fact WHERE recordedAt > type::datetime($weekAgoIso) AND ${gate} GROUP ALL;
       `;
-      const res = (await db.query<unknown[]>(sql, { weekAgoIso })) as unknown[];
+      const res = (await db.query<unknown[]>(sql, { weekAgoIso, userId })) as unknown[];
       const stats: MemoryStats = {
         entities: countOf(res[0]),
         factsActive: countOf(res[1]),
         factsCompeting: countOf(res[2]),
         factsRetracted: countOf(res[3]),
-        communities: countOf(res[4]),
-        factsLast7d: countOf(res[5]),
+        factsLast7d: countOf(res[4]),
         asOf: new Date(nowMs).toISOString(),
       };
-      this.cache.set(companyId, { stats, at: nowMs });
+      this.cache.set(cacheKey, { stats, at: nowMs });
       return stats;
     });
   }

--- a/test/stats-views.e2e-spec.ts
+++ b/test/stats-views.e2e-spec.ts
@@ -208,3 +208,138 @@ describe('stats views (migration 0088, real SurrealDB)', () => {
     delete process.env.STATS_VIEWS_ENABLED;
   });
 });
+
+/**
+ * Per-user scope on /v1/stats/overview (audit F3): a userId-pinned
+ * end-user token must see only its OWN + tenant-global counts, never the
+ * tenant aggregate spanning every user. Two user-bound tokens (user_a /
+ * user_b) plus the M2M fixture key exercise the three cases in one boot.
+ */
+describe('stats overview per-user scope (audit F3, real SurrealDB)', () => {
+  let f: AppFixture;
+  const M2M = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const A = () => ({ Authorization: `Bearer ${f.extraApiKeys[0]}` });
+  const B = () => ({ Authorization: `Bearer ${f.extraApiKeys[1]}` });
+  const savedFlag = process.env.STATS_VIEWS_ENABLED;
+
+  // Fresh tenant DB → counts start at 0, so the expectations are exact.
+  const GLOBAL_FACTS = 2;
+  const A_FACTS = 3;
+  const B_FACTS = 4;
+
+  beforeAll(async () => {
+    // Flag off: the M2M path uses the live tenant-wide counts. User
+    // callers ignore the flag regardless (views are tenant-wide).
+    delete process.env.STATS_VIEWS_ENABLED;
+    f = await createApp({
+      companyId: 'co_stats_userscope_e2e',
+      extraKeys: [
+        { scopes: ['brain:read', 'brain:write'], userId: 'user_a' },
+        { scopes: ['brain:read', 'brain:write'], userId: 'user_b' },
+      ],
+    });
+
+    // The M2M key mints tenant-global rows (userId IS NONE); each
+    // user-bound key mints rows stamped with its own userId. Distinct
+    // entity ids so every ingest INSERTs a fresh active fact + entity.
+    for (let i = 0; i < GLOBAL_FACTS; i++) {
+      await ingestAs(M2M(), `g_subject_${i}`, `g_claim_${i}`, `global claim ${i}`);
+    }
+    for (let i = 0; i < A_FACTS; i++) {
+      await ingestAs(A(), `a_subject_${i}`, `a_claim_${i}`, `user a claim ${i}`);
+    }
+    for (let i = 0; i < B_FACTS; i++) {
+      await ingestAs(B(), `b_subject_${i}`, `b_claim_${i}`, `user b claim ${i}`);
+    }
+  });
+
+  afterAll(async () => {
+    if (savedFlag === undefined) delete process.env.STATS_VIEWS_ENABLED;
+    else process.env.STATS_VIEWS_ENABLED = savedFlag;
+    if (f) await f.close();
+  });
+
+  async function ingestAs(
+    header: Record<string, string>,
+    id: string,
+    predicate: string,
+    object: string,
+  ) {
+    const res = await f.http
+      .post('/v1/ingest/fact')
+      .set(header)
+      .send({
+        entityRef: { vertical: 'rent', id },
+        predicate,
+        object,
+        validFrom: '2026-01-01',
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+      });
+    expect([200, 201]).toContain(res.status);
+    return res.body.factId as string;
+  }
+
+  interface Overview {
+    entities: number;
+    factsActive: number;
+    factsCompeting: number;
+    factsRetracted: number;
+    communities?: number;
+    factsLast7d: number;
+  }
+
+  async function overview(header: Record<string, string>): Promise<Overview> {
+    const res = await f.http.get('/v1/stats/overview').set(header);
+    expect(res.status).toBe(200);
+    return res.body as Overview;
+  }
+
+  it('user A sees only its own + tenant-global counts, never user B activity', async () => {
+    const a = await overview(A());
+    // A's own facts PLUS the tenant-global facts — and nothing of B's.
+    expect(a.factsActive).toBe(A_FACTS + GLOBAL_FACTS); // 5, not 9
+    expect(a.entities).toBe(A_FACTS + GLOBAL_FACTS);
+    expect(a.factsLast7d).toBe(A_FACTS + GLOBAL_FACTS);
+    // community_node has no userId → the tenant figure is omitted.
+    expect(a.communities).toBeUndefined();
+  });
+
+  it('user B sees only its own + tenant-global counts, never user A activity', async () => {
+    const b = await overview(B());
+    expect(b.factsActive).toBe(B_FACTS + GLOBAL_FACTS); // 6, not 9
+    expect(b.entities).toBe(B_FACTS + GLOBAL_FACTS);
+    expect(b.communities).toBeUndefined();
+  });
+
+  it('the two users never see each other: A ≠ B, and neither equals the tenant aggregate', async () => {
+    const a = await overview(A());
+    const b = await overview(B());
+    const tenant = await overview(M2M());
+    // Each user is strictly below the tenant total by exactly the OTHER
+    // user's contribution — proof that no cross-user rows bleed in.
+    expect(tenant.factsActive).toBe(GLOBAL_FACTS + A_FACTS + B_FACTS); // 9
+    expect(tenant.factsActive - a.factsActive).toBe(B_FACTS); // A excludes all of B
+    expect(tenant.factsActive - b.factsActive).toBe(A_FACTS); // B excludes all of A
+    expect(a.factsActive).not.toBe(b.factsActive);
+  });
+
+  it('M2M / admin caller (no pinned userId) still sees tenant-wide counts incl. communities', async () => {
+    const tenant = await overview(M2M());
+    expect(tenant.factsActive).toBe(GLOBAL_FACTS + A_FACTS + B_FACTS); // 9
+    expect(tenant.entities).toBe(GLOBAL_FACTS + A_FACTS + B_FACTS); // 9
+    // Tenant-global community count is present (a number) for M2M.
+    expect(typeof tenant.communities).toBe('number');
+  });
+
+  it('the cache key does not cross users: back-to-back A/B calls stay scoped', async () => {
+    // A is fetched first (populating the per-user cache entry), then B. A
+    // shared tenant-only cache key would serve A's cached numbers to B.
+    const a1 = await overview(A());
+    const b = await overview(B());
+    const a2 = await overview(A());
+    expect(a1.factsActive).toBe(A_FACTS + GLOBAL_FACTS); // 5
+    expect(b.factsActive).toBe(B_FACTS + GLOBAL_FACTS); // 6 — NOT A's 5
+    expect(a2.factsActive).toBe(a1.factsActive); // A's own cached entry
+  });
+});

--- a/test/stats-views.unit-spec.ts
+++ b/test/stats-views.unit-spec.ts
@@ -128,6 +128,120 @@ describe('StatsService view gating (STATS_VIEWS_ENABLED)', () => {
   });
 });
 
+describe('StatsService per-user scope (audit F3)', () => {
+  const savedFlag = process.env.STATS_VIEWS_ENABLED;
+
+  afterEach(() => {
+    if (savedFlag === undefined) delete process.env.STATS_VIEWS_ENABLED;
+    else process.env.STATS_VIEWS_ENABLED = savedFlag;
+  });
+
+  /** Per-statement results for the USER-scoped live query (5 statements,
+   *  no community_node). */
+  function userScopedResults(): unknown[] {
+    return [
+      [{ c: 4 }], // entities (own + tenant-global)
+      [{ c: 3 }], // active
+      [{ c: 1 }], // competing
+      [{ c: 0 }], // retracted
+      [{ c: 2 }], // last 7d
+    ];
+  }
+
+  it('scopes every count to own+global, omits the tenant-global community count, keys cache by user', async () => {
+    delete process.env.STATS_VIEWS_ENABLED;
+    const query = jest.fn(async (_sql: string, _binds?: Record<string, unknown>) =>
+      userScopedResults(),
+    );
+    const { svc } = makeStatsService(query);
+
+    const stats = await svc.overview('t1', ['brain:read'], 'user_a');
+    expect(stats).toMatchObject({
+      entities: 4,
+      factsActive: 3,
+      factsCompeting: 1,
+      factsRetracted: 0,
+      factsLast7d: 2,
+    });
+    // community_node carries no userId → the count is OMITTED (not 0, not
+    // the tenant figure) for an end-user caller.
+    expect(stats.communities).toBeUndefined();
+    expect('communities' in stats).toBe(false);
+
+    const call = query.mock.calls[0]!;
+    const sql = call[0] as string;
+    const binds = call[1] as Record<string, unknown>;
+    expect(sql).toContain('(userId IS NONE OR userId = $userId)');
+    expect(sql).not.toContain('community_node');
+    expect(binds).toMatchObject({ userId: 'user_a' });
+
+    // Cached under the per-user key: a second identical call hits the LRU.
+    await svc.overview('t1', ['brain:read'], 'user_a');
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('cache key is per-user: user B is never served user A cached counts', async () => {
+    delete process.env.STATS_VIEWS_ENABLED;
+    const perUser: Record<string, unknown[]> = {
+      user_a: [[{ c: 4 }], [{ c: 3 }], [{ c: 1 }], [{ c: 0 }], [{ c: 2 }]],
+      user_b: [[{ c: 9 }], [{ c: 8 }], [{ c: 0 }], [{ c: 1 }], [{ c: 5 }]],
+    };
+    let current = 'user_a';
+    const query = jest.fn(async (_sql: string) => perUser[current]!);
+    const { svc } = makeStatsService(query);
+
+    const a = await svc.overview('t1', ['brain:read'], 'user_a');
+    current = 'user_b';
+    const b = await svc.overview('t1', ['brain:read'], 'user_b');
+
+    expect(a.factsActive).toBe(3);
+    expect(b.factsActive).toBe(8); // B's own numbers, NOT A's cached 3
+    // Distinct cache keys → two DB round-trips; a tenant-only key would
+    // have served A's cached entry to B on the second call.
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it('takes the live user-scoped path even when STATS_VIEWS_ENABLED=on (views are tenant-wide)', async () => {
+    process.env.STATS_VIEWS_ENABLED = '1';
+    const query = jest.fn(async (_sql: string) => userScopedResults());
+    const { svc } = makeStatsService(query);
+
+    const stats = await svc.overview('t1', ['brain:read'], 'user_a');
+    expect(stats.factsActive).toBe(3);
+    const sql = query.mock.calls[0]![0];
+    // A userId-pinned caller must NOT read the tenant-wide rollup views.
+    expect(sql).not.toContain('stats_entity_total');
+    expect(sql).not.toContain('stats_fact_by_status');
+    expect(sql).toContain('(userId IS NONE OR userId = $userId)');
+  });
+
+  it('M2M and user callers use different cache keys AND different queries', async () => {
+    delete process.env.STATS_VIEWS_ENABLED;
+    // One mock, two shapes: the user path is recognisable by its gate.
+    const query = jest.fn(async (sql: string) =>
+      sql.includes('userId = $userId') ? userScopedResults() : legacyStatsResults(),
+    );
+    const { svc } = makeStatsService(query);
+
+    const m2m = await svc.overview('t1', ['brain:read']); // cache key 't1'
+    const user = await svc.overview('t1', ['brain:read'], 'user_a'); // key 't1 user_a'
+
+    // M2M is unchanged: tenant-wide counts, community count still present.
+    expect(m2m).toMatchObject({ entities: 7, factsActive: 5, factsCompeting: 2 });
+    expect(m2m.communities).toBe(3);
+    // User caller got its OWN scoped numbers, NOT the M2M cache entry, and
+    // no community count.
+    expect(user).toMatchObject({ entities: 4, factsActive: 3 });
+    expect(user.communities).toBeUndefined();
+    // Two distinct keys → two DB round-trips; a shared tenant-only key
+    // would have served the M2M entry to the user (query called once).
+    expect(query).toHaveBeenCalledTimes(2);
+    const m2mSql = query.mock.calls[0]![0];
+    expect(m2mSql).toContain('FROM community_node');
+    expect(m2mSql).not.toContain('(userId IS NONE OR userId = $userId)');
+  });
+});
+
 /** Per-statement results for the LEGACY admin collectTenant query. */
 function legacyAdminResults(): unknown[] {
   return [


### PR DESCRIPTION
## fix(stats): user-scope /v1/stats/overview counts (privacy leak F3)

External-audit finding, verified: `stats.service.ts` `overview()` counted `knowledge_entity` / `knowledge_fact` / `community_node` company-wide and cached by `companyId` alone, while `/v1/stats/overview` requires only `brain:read` and is framed as the end-user "Usage" page. So a **userId-pinned end-user token saw tenant-aggregate counts spanning all users** — a per-user metadata bleed (counts only, not content). This was the one audit finding live in prod, unflagged, end-user-reachable.

### Fix
Per-table, verified against migrations 0036 / 0055:

| Table | has `userId`? | userId-pinned caller |
|---|---|---|
| `knowledge_fact`, `knowledge_entity` | yes (0055) | filtered `(userId IS NONE OR userId = $userId)` — own + tenant-global rows |
| `community_node` | no (tenant-wide graph clusters) | **omitted** — no per-user count is derivable; leaking the tenant figure would be the same bleed |

- The predicate mirrors the canonical read gate (`where-builder.ts`, `episode-read-store`, segment/insight legs) — not invented.
- **Cache key**: `companyId` for M2M/admin (unchanged), `` `${companyId} ${userId}` `` for a userId-pinned caller (companyId is `[A-Za-z0-9_-]+`, so the space can't collide).
- **Both paths scoped**: the 0088 computed views are tenant-wide `GROUP ALL` with no userId partition → a userId-pinned caller always takes the live user-scoped path regardless of `STATS_VIEWS_ENABLED`; only M2M/admin read the views. M2M live query byte-identical to before. `MemoryStats.communities` is now optional (only reader is an M2M e2e assertion — unaffected).
- No feature flag — this is a privacy correctness fix; prod SHOULD change from leaking to not-leaking.

### Tests
- Two-user, one-tenant e2e (real SurrealDB): A sees only A+global (5, not tenant 9), B sees only B+global (6); `tenant − A === B_facts` and vice-versa prove no cross-user bleed; back-to-back A/B calls prove the cache key doesn't cross users; M2M regression still sees tenant-wide counts incl. `communities`.
- Unit: scoped predicate present, `community_node` absent, `communities` omitted, userId in binds, per-user cache separation, view-bypass when flag on, M2M unchanged.

typecheck / lint:ci / format:check clean; full unit suite green; stats e2e 12/12 on Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
