### PR TITLE
fix(mcp): gate MCP resources with the same ABAC/grant + error sanitization as tools

### DIFF
--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -17,7 +17,7 @@ import { EmbedderService } from '../ai/embedder.service';
 import { BrainScope } from '../auth/api-key.types';
 import { registerCommunityTools } from './community-tools';
 import { MetricsService } from '../metrics/metrics.service';
-import { registerReadTools } from './read-tools';
+import { registerReadTools, READ_RESOURCE_ACTIONS } from './read-tools';
 import { registerProceduralReadTools } from './procedural-tools';
 import { registerWriteTools, registerAdminTools } from './write-tools';
 import { registerCodeMemoryReadTools, registerCodeMemoryWriteTools } from './code-memory-tools';
@@ -36,6 +36,17 @@ import { PackToolProxyService } from './pack-tool-proxy.service';
 import { registerPackTools } from './pack-tools';
 
 const MCP_SERVER_VERSION = '0.3.0';
+
+/**
+ * Registration methods whose surface the resource/prompt gates patch.
+ * registerTool has its own dedicated gates (byte-identical, above); this
+ * covers registerResource today and a future registerPrompt with no code
+ * change beyond an action map + a call site.
+ */
+type RegistrationMethod = 'registerResource' | 'registerPrompt';
+
+/** A patched registration call returns a handle exposing remove(). */
+type RemovableRegistrar = (...args: unknown[]) => { remove(): void };
 
 const HEALTH_TOOLS = [
   'search_knowledge',
@@ -225,6 +236,126 @@ export class McpService {
   }
 
   /**
+   * Error wrapper for the resource surface (and any future
+   * registerPrompt) — the analogue of wrapToolErrors for registration
+   * methods whose handler is the LAST argument and whose result carries
+   * NO isError channel. Without it a thrown handler error reaches the
+   * SDK, which serializes error.message into the JSON-RPC error verbatim:
+   * the same raw SurrealDB leak (record ids, index names, FIELD VALUES)
+   * that wrapToolErrors closes for tools — the read-side gap this fix
+   * shuts.
+   *
+   * Deliberate client-facing errors (HttpException < 500 — not-found,
+   * validation, policy denials) pass through unchanged, matching the tool
+   * wrapper and the REST surface. Everything else is logged in full with
+   * a correlation id and replaced by a generic message.
+   *
+   * Applied BEFORE the policy/grant gates patch the same method, so the
+   * error wrapper ends up outermost and also covers the gate's enforce
+   * call (a policy deny surfaces as its ForbiddenException, never raw).
+   */
+  private wrapRegistrationErrors({
+    server,
+    method,
+  }: {
+    server: McpServer;
+    method: RegistrationMethod;
+  }): void {
+    const surface = method === 'registerResource' ? 'resource' : 'prompt';
+    const bag = server as unknown as Record<RegistrationMethod, RemovableRegistrar>;
+    const raw = bag[method].bind(server);
+    (server as unknown as Record<string, unknown>)[method] = (...args: unknown[]) => {
+      const name = args[0] as string;
+      const handler = args[args.length - 1] as (...h: unknown[]) => unknown;
+      const wrapped = async (...h: unknown[]): Promise<unknown> => {
+        try {
+          return await handler(...h);
+        } catch (e) {
+          if (e instanceof HttpException && e.getStatus() < 500) throw e;
+          const ref = randomUUID().slice(0, 8);
+          this.logger.error(`${surface} ${name} failed (ref ${ref}): ${(e as Error).stack ?? e}`);
+          throw new Error(`internal error while reading ${surface} ${name} (ref ${ref})`);
+        }
+      };
+      return raw(...args.slice(0, -1), wrapped);
+    };
+  }
+
+  /**
+   * ABAC gate for the resource surface (and any future registerPrompt) —
+   * the exact analogue of applyPolicyToolGate. Resolves each
+   * registration's policy action via `actionOf` (a resource reuses its
+   * equivalent read tool's action), then mirrors the tool gate: an
+   * enforce-denied registration is removed immediately (gone from
+   * resources/list, a blind read gets the SDK's unknown-resource error),
+   * and an allowed one gets a per-call wrapper that runs enforceToolAction
+   * (emitting allow/would_deny decisions, throwing on an enforced deny)
+   * before the handler.
+   */
+  private applyPolicyRegistrationGate({
+    server,
+    method,
+    policy,
+    actionOf,
+  }: {
+    server: McpServer;
+    method: RegistrationMethod;
+    policy: PolicyContext;
+    actionOf: (name: string) => string;
+  }): void {
+    const bag = server as unknown as Record<RegistrationMethod, RemovableRegistrar>;
+    const raw = bag[method].bind(server);
+    (server as unknown as Record<string, unknown>)[method] = (...args: unknown[]) => {
+      const action = actionOf(args[0] as string);
+      const handler = args[args.length - 1] as (...h: unknown[]) => unknown;
+      const denied = evaluateAction(policy, action).decision === 'deny';
+      const reg = raw(...args.slice(0, -1), (...h: unknown[]) => {
+        this.policyGate.enforceToolAction(policy, action);
+        return handler(...h);
+      });
+      // Enforce-denied resources unregister immediately, mirroring the
+      // tool gate: gone from resources/list, blind read → unknown-resource.
+      if (denied) reg.remove();
+      return reg;
+    };
+  }
+
+  /**
+   * RFC 9396 grant gate for the resource surface (and any future
+   * registerPrompt) — the analogue of applyGrantToolGate. A registration
+   * stays iff its resolved action is in the granted union or its kind is
+   * covered by a read/write macro grant. Applied AFTER the policy gate;
+   * the two removals are independent, so deny-overrides holds exactly as
+   * for tools (a policy deny removes what a grant allows, and a grant
+   * omission removes what a policy allows).
+   */
+  private applyGrantRegistrationGate({
+    server,
+    method,
+    granted,
+    actionOf,
+  }: {
+    server: McpServer;
+    method: RegistrationMethod;
+    granted: readonly string[];
+    actionOf: (name: string) => string;
+  }): void {
+    const grantSet = new Set(granted);
+    const allows = (action: string): boolean => {
+      if (grantSet.has(action)) return true;
+      const kind = ACTIONS[action]?.kind;
+      return kind !== undefined && grantSet.has(kind);
+    };
+    const bag = server as unknown as Record<RegistrationMethod, RemovableRegistrar>;
+    const raw = bag[method].bind(server);
+    (server as unknown as Record<string, unknown>)[method] = (...args: unknown[]) => {
+      const reg = raw(...args);
+      if (!allows(actionOf(args[0] as string))) reg.remove();
+      return reg;
+    };
+  }
+
+  /**
    * Unauthenticated health probe payload — surfaces version + the
    * read-baseline tool list so setup scripts can confirm the MCP
    * endpoint is reachable BEFORE the operator pastes the API key.
@@ -302,10 +433,34 @@ export class McpService {
       name: 'inite-brain-service',
       version: MCP_SERVER_VERSION,
     });
+    // A resource read resolves to its equivalent read tool's action, so a
+    // grant/policy over get_entity_profile governs the brain://entity/<id>
+    // resource identically. An unmapped resource name falls through to
+    // itself → write-kind → fail-closed under any restriction.
+    const resourceActionOf = (name: string): string => READ_RESOURCE_ACTIONS.get(name) ?? name;
     this.wrapToolErrors(server);
-    if (policy) this.applyPolicyToolGate(server, policy, packToolKinds);
+    // Resources have no isError result channel; gate + error-wrap them
+    // with the SAME machinery as tools so a grant/policy that strips the
+    // entity-read tools also strips the entity resources, and a raw DB
+    // error never leaks through a resource read.
+    this.wrapRegistrationErrors({ server, method: 'registerResource' });
+    if (policy) {
+      this.applyPolicyToolGate(server, policy, packToolKinds);
+      this.applyPolicyRegistrationGate({
+        server,
+        method: 'registerResource',
+        policy,
+        actionOf: resourceActionOf,
+      });
+    }
     if (caller?.mcpGrantedActions !== undefined) {
       this.applyGrantToolGate(server, caller.mcpGrantedActions, packToolKinds);
+      this.applyGrantRegistrationGate({
+        server,
+        method: 'registerResource',
+        granted: caller.mcpGrantedActions,
+        actionOf: resourceActionOf,
+      });
     }
     registerReadTools({
       server,

--- a/src/mcp/read-tools.ts
+++ b/src/mcp/read-tools.ts
@@ -609,6 +609,25 @@ function registerDetectContradictionTool({
 }
 
 /**
+ * Policy-action identity for each read-only MCP resource, keyed by the
+ * resource NAME passed to server.registerResource. A resource is an
+ * entity read, so it reuses the SAME action name as its equivalent read
+ * tool: a grant or ABAC policy that allows (or denies) get_entity_profile
+ * governs the brain://entity/<id> resource identically, and vice versa —
+ * closing the gap where the tool gate covered tools but never resources.
+ *
+ * McpService's resource gate resolves a resource name through this map,
+ * so the ABAC + RFC 9396 grant machinery covers resources exactly as it
+ * covers tools. Keep this in lockstep with the registerResource calls
+ * below — a new resource needs an entry here (an unmapped name falls
+ * through to itself → write-kind → fail-closed under any restriction).
+ */
+export const READ_RESOURCE_ACTIONS: ReadonlyMap<string, string> = new Map([
+  ['entity-profile', 'get_entity_profile'],
+  ['entity-timeline', 'get_entity_timeline'],
+]);
+
+/**
  * Resources are the MCP-native "read-once" surface alongside tools.
  * Clients can list and read URIs without going through a tool call —
  * an LLM can drop a resource ref straight into context. Brain exposes:
@@ -620,6 +639,9 @@ function registerDetectContradictionTool({
  * server-side per-client session state; brain runs in stateless
  * Streamable HTTP mode, so subscribe is a no-op for v1. Streaming via a
  * server-pushed changefeed resource is the v2 lift.
+ *
+ * Each resource's policy action lives in READ_RESOURCE_ACTIONS above so
+ * the McpService resource gate can ABAC/grant-check it like a tool.
  */
 function registerReadResources({
   server,

--- a/test/mcp-grant-gate.unit-spec.ts
+++ b/test/mcp-grant-gate.unit-spec.ts
@@ -59,6 +59,20 @@ function toolNames(server: McpServer): string[] {
   return Object.keys(internals._registeredTools);
 }
 
+// Resources register under _registeredResourceTemplates (ResourceTemplate
+// path) / _registeredResources (static URI). Same private-field
+// inspection the tool tests use — production code never touches it.
+function resourceNames(server: McpServer): string[] {
+  const internals = server as unknown as {
+    _registeredResources?: Record<string, unknown>;
+    _registeredResourceTemplates?: Record<string, unknown>;
+  };
+  return [
+    ...Object.keys(internals._registeredResources ?? {}),
+    ...Object.keys(internals._registeredResourceTemplates ?? {}),
+  ];
+}
+
 function ctxFromDoc(doc: Record<string, unknown>): PolicyContext {
   const parsed: PolicyDocument = PolicyDocumentSchema.parse(doc);
   const compiled = compilePolicySet(parsed);
@@ -94,6 +108,50 @@ describe('MCP RFC 9396 grant gate', () => {
     const names = toolNames(await build({}));
     expect(names).toContain('record_fact');
     expect(names).toContain('search_knowledge');
+  });
+
+  // ── resources ride the SAME grant gate as tools ───────────────────────
+  // A resource read (brain://entity/<id>[/timeline]) reuses its equivalent
+  // read tool's action, so the grant that governs the tool governs the
+  // resource. These pin the read-side gap the fix closes: before it, a
+  // grant that stripped every tool still left the two entity resources
+  // callable (base brain:read + tenant fence only, no consent/ABAC check).
+
+  it('an empty grant strips every tool AND every resource', async () => {
+    const server = await build({ mcpGrantedActions: [] });
+    expect(toolNames(server)).toEqual([]);
+    expect(resourceNames(server)).toEqual([]);
+  });
+
+  it('a foreign grant (different action) exposes zero entity resources', async () => {
+    // search_knowledge is a real action, but it is neither entity resource's
+    // action (get_entity_profile / get_entity_timeline) nor a read macro.
+    const server = await build({ mcpGrantedActions: ['search_knowledge'] });
+    expect(toolNames(server)).toEqual(['search_knowledge']);
+    expect(resourceNames(server)).not.toContain('entity-profile');
+    expect(resourceNames(server)).not.toContain('entity-timeline');
+    expect(resourceNames(server)).toEqual([]);
+  });
+
+  it("the 'read' macro grant keeps both entity resources (normal read access)", async () => {
+    const names = resourceNames(await build({ mcpGrantedActions: ['read'] }));
+    expect(names).toContain('entity-profile');
+    expect(names).toContain('entity-timeline');
+  });
+
+  it('a named get_entity_profile grant keeps only that resource', async () => {
+    const server = await build({ mcpGrantedActions: ['get_entity_profile'] });
+    // Tool + resource for the granted entity read stay; the timeline
+    // resource (get_entity_timeline) is gone, same as its tool.
+    expect(toolNames(server)).toEqual(['get_entity_profile']);
+    expect(resourceNames(server)).toContain('entity-profile');
+    expect(resourceNames(server)).not.toContain('entity-timeline');
+  });
+
+  it('no grant claim = full resource surface (gate inactive)', async () => {
+    const names = resourceNames(await build({}));
+    expect(names).toContain('entity-profile');
+    expect(names).toContain('entity-timeline');
   });
 
   it('policy deny overrides a grant allow', async () => {

--- a/test/mcp-policy-gate.unit-spec.ts
+++ b/test/mcp-policy-gate.unit-spec.ts
@@ -4,6 +4,7 @@
  * report_only policies leave the surface intact. Uses the same
  * `_registeredTools` inspection as mcp-tools.unit-spec.ts.
  */
+import { Logger, NotFoundException } from '@nestjs/common';
 import { McpService } from '../src/mcp/mcp.service';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { compilePolicySet } from '../src/policy/policy-compile';
@@ -78,6 +79,19 @@ function toolNames(server: McpServer): string[] {
   return Object.keys(internals._registeredTools);
 }
 
+// Resources register under _registeredResourceTemplates (ResourceTemplate
+// path). Same private-field inspection the tool tests use.
+function resourceNames(server: McpServer): string[] {
+  const internals = server as unknown as {
+    _registeredResources?: Record<string, unknown>;
+    _registeredResourceTemplates?: Record<string, unknown>;
+  };
+  return [
+    ...Object.keys(internals._registeredResources ?? {}),
+    ...Object.keys(internals._registeredResourceTemplates ?? {}),
+  ];
+}
+
 describe('MCP ABAC tool gate', () => {
   it('readonly enforce policy strips every write tool from the surface', async () => {
     const policy = ctxFromDoc({
@@ -128,6 +142,65 @@ describe('MCP ABAC tool gate', () => {
     expect(names).toContain('record_fact');
     expect(names).toContain('forget_entity');
     expect(enforceCalls).toHaveLength(0);
+  });
+});
+
+// The resource surface (brain://entity/<id>[/timeline]) rides the SAME
+// ABAC gate as tools: each resource resolves to its equivalent read
+// tool's action, so a policy verdict on get_entity_profile /
+// get_entity_timeline governs the matching resource identically. Before
+// the fix, registerResource was never wrapped — an enforce-denied token
+// still read these resources (base brain:read + tenant fence only).
+describe('MCP ABAC gate over resources', () => {
+  it('a readonly-allow enforce policy keeps both entity resources', async () => {
+    const policy = ctxFromDoc({
+      name: 'readonly-agent',
+      posture: { actions: 'deny', reads: 'allow' },
+      mode: 'enforce',
+      rules: [{ id: 'ro', effect: 'allow', kind: 'action', actions: ['@readonly'] }],
+    });
+    const names = resourceNames(await buildWithPolicy(policy));
+    expect(names).toContain('entity-profile');
+    expect(names).toContain('entity-timeline');
+  });
+
+  it('a targeted deny on get_entity_profile removes exactly that resource', async () => {
+    const policy = ctxFromDoc({
+      name: 'no-profile',
+      posture: { actions: 'allow', reads: 'allow' },
+      mode: 'enforce',
+      rules: [{ id: 'np', effect: 'deny', kind: 'action', actions: ['get_entity_profile'] }],
+    });
+    const server = await buildWithPolicy(policy);
+    // Tool + resource for the denied entity read both vanish…
+    expect(toolNames(server)).not.toContain('get_entity_profile');
+    expect(resourceNames(server)).not.toContain('entity-profile');
+    // …while the timeline read (tool + resource) is untouched.
+    expect(toolNames(server)).toContain('get_entity_timeline');
+    expect(resourceNames(server)).toContain('entity-timeline');
+  });
+
+  it('an actions-deny posture with no allow strips every resource', async () => {
+    const policy = ctxFromDoc({
+      name: 'deny-all',
+      posture: { actions: 'deny', reads: 'allow' },
+      mode: 'enforce',
+      rules: [],
+    });
+    expect(resourceNames(await buildWithPolicy(policy))).toEqual([]);
+  });
+
+  it('report_only policy leaves the resource surface intact', async () => {
+    const policy = ctxFromDoc({
+      name: 'watcher',
+      posture: { actions: 'deny', reads: 'allow' },
+      mode: 'report_only',
+      rules: [],
+    });
+    const withPolicy = resourceNames(await buildWithPolicy(policy)).sort();
+    const without = resourceNames(await buildWithPolicy(undefined)).sort();
+    expect(withPolicy).toEqual(without);
+    expect(without).toContain('entity-profile');
   });
 });
 
@@ -225,5 +298,96 @@ describe('MCP ABAC gate over pack-declared tools', () => {
     } finally {
       delete process.env.MCP_PACK_EXTERNAL_TOOLS_ENABLED;
     }
+  });
+});
+
+// Resource handlers get the SAME error sanitization as tools: a resource
+// has no isError result channel, so a thrown handler error would be
+// serialized into the JSON-RPC error message verbatim (raw SurrealDB
+// text: record ids, index names, FIELD VALUES). The wrapper is active
+// regardless of policy/grant, so these build with neither.
+describe('MCP resource handler error sanitization', () => {
+  // entities is the 2nd constructor arg; a throwing stub drives the
+  // resource handler's error path. Everything else is a bare stub.
+  function buildWithEntities(entities: unknown): Promise<McpServer> {
+    const svc = new McpService(
+      {} as never, // search
+      entities as never, // entities
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      stubEmbedder as never, // embedder
+      {} as never, // documents
+      {} as never, // feedback
+      stubPolicyGate as never, // policyGate (unused without a policy)
+      stubPackToolsReader as never,
+      {} as never, // packToolProxy
+    );
+    return svc.buildServer('co_test', ['brain:read'], { actorKeyHash: 'sha256:test' });
+  }
+
+  function resourceReadCallback(
+    server: McpServer,
+    name: string,
+  ): (uri: URL, params: Record<string, unknown>) => Promise<unknown> {
+    const internals = server as unknown as {
+      _registeredResourceTemplates: Record<
+        string,
+        { readCallback: (uri: URL, params: Record<string, unknown>) => Promise<unknown> }
+      >;
+    };
+    return internals._registeredResourceTemplates[name]!.readCallback;
+  }
+
+  it('replaces a raw resource DB error with a generic ref (no leak)', async () => {
+    const logSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    try {
+      const server = await buildWithEntities({
+        getProfile: async () => {
+          throw new Error('SurrealDB parse error at knowledge_entity:e1 value=SSN-999-12-3456');
+        },
+      });
+      const cb = resourceReadCallback(server, 'entity-profile');
+      let thrown: Error | undefined;
+      try {
+        await cb(new URL('brain://entity/e1'), { entityId: 'e1' });
+      } catch (e) {
+        thrown = e as Error;
+      }
+      expect(thrown).toBeDefined();
+      // Client sees a generic message — never the raw DB text or PII value.
+      expect(thrown?.message).toMatch(
+        /internal error while reading resource entity-profile \(ref /,
+      );
+      expect(thrown?.message).not.toContain('SSN-999');
+      expect(thrown?.message).not.toContain('SurrealDB');
+      // …but the full detail is logged for ops (correlation ref).
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(String(logSpy.mock.calls[0]?.[0])).toContain('SSN-999');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('passes a deliberate NotFoundException through unchanged (matches tools)', async () => {
+    const server = await buildWithEntities({
+      getProfile: async () => {
+        throw new NotFoundException('Entity e1 not found');
+      },
+    });
+    const cb = resourceReadCallback(server, 'entity-profile');
+    // HttpException < 500 is a client-facing error: not masked, same as
+    // the tool wrapper and the REST surface.
+    await expect(cb(new URL('brain://entity/e1'), { entityId: 'e1' })).rejects.toThrow(
+      'Entity e1 not found',
+    );
   });
 });


### PR DESCRIPTION
## fix(mcp): gate MCP resources with the same ABAC/grant + error sanitization as tools (P1)

External-audit finding, verified: `applyPolicyToolGate` (`mcp.service.ts`) and the RFC-9396 grant gate monkeypatched **only** `server.registerTool`. The two read-only MCP resources — `entity-profile` (`brain://entity/{id}`) and `entity-timeline` — register via `server.registerResource`, which was never wrapped. So a token whose tools were stripped via a grant or ABAC policy could **still read those resources**, and a raw DB error could surface unsanitized. The base `brain:read` scope + `companyId` tenant fence still applied (NOT a cross-tenant content leak), but it bypassed fine-grained consent/ABAC — warranting a 2.1.1.

### Fix
- **Unified gate over resources** (extensible to a future `registerPrompt`): three new methods mirror the tool gates for the `registerResource` surface — `applyPolicyRegistrationGate` (ABAC), `applyGrantRegistrationGate` (RFC-9396 grant), `wrapRegistrationErrors` (error sanitization). Applied in the same order as tools (policy → grant, error-wrap outermost).
- **Resource → action mapping.** `READ_RESOURCE_ACTIONS` (`read-tools.ts`) maps each resource name to its equivalent read-tool action (`entity-profile → get_entity_profile`, `entity-timeline → get_entity_timeline`). A grant/ABAC policy that denies the entity-read **tool** now denies the **resource** identically, and vice-versa. An unmapped resource name falls through to itself → write-kind → **fail-closed** under any restriction.
- **Enforce-denied resources unregister immediately** — gone from `resources/list`, a blind read gets the SDK's unknown-resource error — mirroring the tool gate. Error wrapper closes the raw-DB-error leak.
- **Tools unchanged** (byte-identical); base scope + tenant fence in the resource handlers preserved — this ADDS the policy/grant/error layer, doesn't replace the scope/fence. A normally-authorized caller reads both resources exactly as before.

### Tests
- `mcp-policy-gate.unit-spec.ts` + `mcp-grant-gate.unit-spec.ts`: an **empty grant** leaves ZERO tools AND ZERO resources; a **foreign grant** exposes zero of the entity resources; a normally-authorized token reads both (regression); a resource handler DB error is sanitized.
- typecheck / lint:ci / format:check clean; MCP unit 66/66 (6 suites); MCP e2e 11/11 (Docker); full unit suite 2341 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
