### PR TITLE
feat(mri): measurement layer — MRI report + economics Pareto reporter (read-only, honest pending-eval)

### DIFF
--- a/docs/roadmap/measurable-economics-mri-2026-08.md
+++ b/docs/roadmap/measurable-economics-mri-2026-08.md
@@ -1,0 +1,150 @@
+# Measurable economics + Memory Reliability Index (2026-08)
+
+The external audit (2026-08-24) named two strategic bets we had *ingredients*
+for but had not *worked through*:
+
+- **Bet #2 — adaptive optics with measurable economics.** The adaptive half is
+  built (Optics-1 calibration; §4.1 L3-depth, §4.2 abstention, §4.3
+  lens-suppression as dynamic budget). The **measurable** half is a scaffold:
+  the ECE/Brier reliability cockpit exists (`admin.controller.ts:197`) but runs
+  against a bootstrap gold set that is **empty on dev → 0/0**, and there is **no
+  accuracy–latency–cost Pareto curve** and no "ship only on a proven curve
+  improvement" gate.
+- **Bet #3 — experience memory + a public Memory Reliability Index.** Strategy
+  memory (G4) is a *partial* experience memory (strategies that worked/failed,
+  k=1); it is **not** extended to tool trajectories / verified outcomes. The
+  **MRI does not exist** — its seven dimensions map to *scattered* components
+  (poisoning = MINJA #312; isolation = user-scope + G6 + the stats fix;
+  abstention = §4.2; premise-awareness = MemTrap shakedown + the verifier arm;
+  citation = the require-citations guard; freshness = the answer-cache, whose
+  invalidation is *incomplete*) but nothing is packaged as a measured index.
+
+The common blocker of both is **one parked thing**: the paid accuracy eval +
+materialized gold labels (no-spend). This doc separates, per bet, **what is free
+to build now** (the measurement *structure* — collectors, index, curve harness,
+the experience schema) from **what only fills with real numbers once the eval is
+unfrozen**. We build the free scaffolds; the accuracy-dependent cells read
+`N/A — pending eval` honestly rather than a fabricated number.
+
+---
+
+## Part 1 — Economics / the accuracy–latency–cost Pareto policy (bet #2)
+
+Goal: make "ship a change only when it *provably* moves the accuracy–cost–latency
+frontier the right way" a *mechanism*, not a slogan.
+
+### 1.1 The three axes and their sources
+
+| Axis | Metric | Source (free) | Source (real numbers) |
+|---|---|---|---|
+| **Accuracy** | end-task correctness | verifier `supported`-rate as a **cheap online proxy** (already emitted); reliability ECE against gold | paid eval (LoCoMo/LME/BEAM) — parked |
+| **Latency** | p50/p95 synth wall-clock | existing spans/telemetry (`synthesize.*` timings) | same (already real) |
+| **Cost** | tokens × price | existing `COST_*_USD_PER_MTOK` + per-call token counts | same (already real) |
+
+Latency and cost are **already real** (telemetry). Only the accuracy axis has a
+free *proxy* (verifier supported-rate + ECE) and a *true* value that waits on
+eval. So the curve is drawable **today** with the proxy on the y-axis, and
+becomes authoritative when the eval axis is unfrozen.
+
+### 1.2 The artifact
+
+A `PolicyOperatingPoint` record per (config, flag-vector): `{accuracyProxy,
+eceOrNull, latencyP50, latencyP95, costPerQuery, flags[]}`, collected over a
+run. A small reporter renders the **Pareto frontier** over the operating points
+and flags dominated points. This is where each optic's flag combination gets
+plotted, so "does §4.1/§4.2/§4.3 earn its cost?" becomes a point on a chart, not
+a claim.
+
+### 1.3 The ship-gate (the actual policy)
+
+A change is **promotable** only if its operating point is **not dominated** on
+(accuracyProxy↑, cost↓, latency↓) versus the current default AND — once eval is
+unfrozen — its true-accuracy delta is non-negative within noise. Until eval is
+unfrozen the gate runs on the **proxy + cost + latency** only and is advisory
+(it *reports* domination, does not block). This matches the "no-spend, measure
+free first" discipline.
+
+**Free now:** the operating-point collector, the Pareto reporter, the proxy
+accuracy signal, latency/cost wiring. **Waits on eval:** the true-accuracy axis
+and the hard promote gate.
+
+---
+
+## Part 2 — The Memory Reliability Index (bet #3)
+
+Seven dimensions. Each row states its **collector** and whether it is **free**
+(computable from existing tests/telemetry/mechanisms today) or **eval-gated**
+(needs the parked accuracy program). The MRI is an *aggregator over signals we
+already emit* — not new science.
+
+| # | Dimension | Definition | Collector | Status |
+|---|---|---|---|---|
+| 1 | **Correctness** | end-task answer correctness | paid eval | **eval-gated** → `N/A pending eval` |
+| 1b | **Premise awareness** | resists belief-distortion (cited-counterfactual) | MemTrap shakedown pass-rate + `FOVEA_PLAUSIBILITY_CHECK` downgrades | **free** (structural) |
+| 2 | **Freshness / stale-answer rate** | fraction of served answers invalidated by a newer fact | answer-cache invalidation telemetry — **requires F1 fix first** (additive-write invalidation) | **free after F1** |
+| 3 | **Citation coverage** | % of served `supported` answers carrying ≥1 citation | verdict telemetry + the require-citations guard counter | **free** |
+| 4 | **Poisoning resistance** | MINJA-class injection GAP count | MINJA red-team suite (#312) result (0 GAP) | **free** |
+| 5 | **Tenant/user isolation** | cross-user/tenant leak count | user-scope + G6 + stats-fix e2e pass-rate | **free** |
+| 6 | **Abstention calibration** | ECE of the abstain decision vs correctness | §4.2 focus-signal reliability | **eval-gated** (needs labels) |
+| 7 | **Cost & latency** | tokens/$/p95 per query | telemetry (= Part 1 axes) | **free** |
+
+**Free now (5 of 7 fully or structurally):** premise-awareness, citation
+coverage, poisoning resistance, isolation, cost/latency. **Gated:** correctness
++ abstention-calibration (need eval); freshness (needs F1 fix, then free).
+
+### 2.1 The artifact
+
+An `MriReport` = `{ generatedAt, dimensions: {name → {value | 'pending-eval',
+source, asOf}} }`, produced by an aggregator that reads each collector. Surface:
+an admin endpoint `/v1/admin/mri` (brain:admin) and a `pnpm mri:report` that
+writes a signed markdown snapshot. The public version is the same report with
+tenant identifiers stripped — that becomes the "Memory Reliability Index" we can
+publish, honest about which cells are still `pending-eval`.
+
+---
+
+## Part 3 — Experience memory: strategy → tool trajectories (bet #3)
+
+G4 strategy memory today stores a distilled *advice string* per (worked/failed)
+strategy. The bet is to store **tool trajectories + verified outcomes** — the
+agent's *experience*, not just conversational facts.
+
+**Extension (default-off, additive):**
+- New optional fields on the strategy item: `trajectory?: ToolStep[]`
+  (`{tool, argsDigest, resultDigest, ok}`), `verifiedOutcome?: 'success' |
+  'failure' | 'unknown'`, `outcomeEvidenceRef?`.
+- Capture: when a consumer reports a completed tool run + outcome (a new
+  ingest surface), distill it into a trajectory-bearing strategy item (reuse the
+  existing Mem0 ADD/UPDATE/NOOP dedup).
+- Retrieval: unchanged lane (k=1, advisory, **verifier-parity exception stays** —
+  a trajectory is advice, not evidence), but a retrieved item can now carry its
+  trajectory into the generator's fenced advisory section.
+- Migration adds the optional columns; flag `STRATEGY_TRAJECTORIES_ENABLED`
+  default-off. LongMemEval-V2 (arXiv 2605.12493) is the benchmark this targets;
+  we have a smoke (`var/lme-v2smoke.json`) but no measured run — that stays
+  parked with the rest of the eval.
+
+**Cognitive-trap caveat (from the MemTrap work):** a trajectory-bearing strategy
+memory is *more* exposed to Cognitive-Bias / Trauma fixation than the advice
+string (it carries a concrete past path). Enabling it must ride the §4.3
+lens-suppression + the verifier arm, and its own trap-shakedown scenario.
+
+---
+
+## Build plan (what ships free, in order)
+
+1. **MRI aggregator + report** (`/v1/admin/mri` + `mri:report`) — packages the 5
+   free dimensions now; `pending-eval` for correctness/abstention; wired to F1
+   for freshness once fixed. *Free.*
+2. **Economics operating-point collector + Pareto reporter** — proxy accuracy +
+   latency + cost per flag-vector; advisory domination report. *Free.*
+3. **F1 answer-cache freshness fix** — unblocks the freshness dimension (and is a
+   before-enable hardening item regardless).
+4. **Strategy trajectories** (`STRATEGY_TRAJECTORIES_ENABLED`, default-off) —
+   the experience-memory extension. *Free to build; measured only under LME-V2,
+   parked.*
+
+**Waits on the owner un-parking eval:** the true-accuracy axis, the hard
+promote-gate, the correctness + abstention-calibration MRI cells, the LME-V2
+number. Everything else is buildable now and is honest scaffolding: real where
+we have telemetry/tests, `pending-eval` where we don't.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "test:eval": "pnpm build && jest --config ./test/jest-e2e-real.json --runInBand --testPathPatterns=quality",
     "eval:diff": "ts-node -r tsconfig-paths/register scripts/eval-baseline-diff.ts",
     "openapi:build": "ts-node -T scripts/build-openapi.ts",
+    "mri:report": "ts-node -T scripts/mri-report.ts",
+    "mri:record-suite": "ts-node -T scripts/mri-record-suite.ts",
     "bench:router": "ts-node -r tsconfig-paths/register scripts/bench-chat-router.ts",
     "capture:decisions": "ts-node -r tsconfig-paths/register scripts/capture-decisions.ts",
     "label:decisions": "ts-node -r tsconfig-paths/register scripts/label-decisions.ts",

--- a/scripts/mri-record-suite.ts
+++ b/scripts/mri-record-suite.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env -S npx ts-node -T
+/**
+ * mri-record-suite — record a STRUCTURAL MRI dimension's suite pass status into
+ * the ledger (docs/mri/suite-status.json) from a REAL Jest run.
+ *
+ * This is the only writer of the ledger. A `pass` is therefore always backed by
+ * an actual green run at a named commit — never hand-edited, never guessed. The
+ * MRI report reads the ledger for premise-awareness / poisoning-resistance /
+ * tenant-user-isolation and renders whatever the last real run recorded.
+ *
+ * Run:
+ *   pnpm mri:record-suite tenant-user-isolation --config test/jest-unit.json
+ *   pnpm mri:record-suite minja-redteam --config test/jest-e2e.json --gap 0
+ *
+ * Flags:
+ *   --config <path>   Jest config (default test/jest-unit.json)
+ *   --gap <n>         Domain gap count to record (e.g. MINJA GAP count)
+ *   --files a,b       Override the suite file list (comma-separated)
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import {
+  ALL_SUITE_SPECS,
+  DEFAULT_LEDGER_PATH,
+  type SuiteLedger,
+  type SuiteLedgerEntry,
+} from '../src/mri/suite-status';
+
+interface Args {
+  key: string;
+  config: string;
+  gap?: number;
+  files?: string[];
+}
+
+function parseArgs(argv: string[]): Args {
+  const key = argv[0];
+  if (!key || key.startsWith('--')) {
+    throw new Error(
+      'usage: mri:record-suite <suiteKey> [--config <path>] [--gap <n>] [--files a,b]',
+    );
+  }
+  const out: Args = { key, config: 'test/jest-unit.json' };
+  for (let i = 1; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const val = argv[i + 1];
+    if (flag === '--config' && val) {
+      out.config = val;
+      i += 1;
+    } else if (flag === '--gap' && val) {
+      out.gap = Number(val);
+      i += 1;
+    } else if (flag === '--files' && val) {
+      out.files = val.split(',').map((s) => s.trim());
+      i += 1;
+    }
+  }
+  return out;
+}
+
+function gitCommit(): string | undefined {
+  try {
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf8' }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+interface JestJson {
+  success: boolean;
+  numPassedTests: number;
+  numFailedTests: number;
+}
+
+function runJest(config: string, files: string[]): JestJson {
+  // Patterns must override the worktree ignore defaults (jest configs ignore
+  // /.claude/worktrees/, which would otherwise skip everything here).
+  const pattern = files.map((f) => f.replace(/[.]/g, '\\.')).join('|');
+  const args = [
+    'jest',
+    '--config',
+    config,
+    '--json',
+    `--testPathPatterns=${pattern}`,
+    '--testPathIgnorePatterns',
+    '/node_modules/',
+    '--modulePathIgnorePatterns',
+    '/node_modules/',
+  ];
+  let stdout = '';
+  try {
+    stdout = execFileSync('npx', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] });
+  } catch (err) {
+    // Jest exits non-zero on failing tests; the JSON is still on stdout.
+    const e = err as { stdout?: string | Buffer };
+    stdout = typeof e.stdout === 'string' ? e.stdout : (e.stdout?.toString() ?? '');
+  }
+  const start = stdout.indexOf('{');
+  const end = stdout.lastIndexOf('}');
+  if (start === -1 || end === -1) {
+    throw new Error(`could not parse Jest --json output for ${files.join(',')}`);
+  }
+  const parsed = JSON.parse(stdout.slice(start, end + 1)) as JestJson;
+  return parsed;
+}
+
+function loadLedger(path: string): SuiteLedger {
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as SuiteLedger;
+  } catch {
+    return {};
+  }
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const spec = ALL_SUITE_SPECS.find((s) => s.key === args.key);
+  const files = args.files ?? spec?.files;
+  if (!files || files.length === 0) {
+    throw new Error(`unknown suite key '${args.key}' and no --files given`);
+  }
+
+  const result = runJest(args.config, files);
+  const commit = gitCommit();
+  const entry: SuiteLedgerEntry = {
+    status: result.success ? 'pass' : 'fail',
+    numPassed: result.numPassedTests,
+    numFailed: result.numFailedTests,
+    recordedAt: new Date().toISOString(),
+    ...(commit ? { commit } : {}),
+    ...(args.gap !== undefined ? { gapCount: args.gap } : {}),
+  };
+
+  const ledger = loadLedger(DEFAULT_LEDGER_PATH);
+  ledger[args.key] = entry;
+  mkdirSync(dirname(DEFAULT_LEDGER_PATH), { recursive: true });
+  writeFileSync(DEFAULT_LEDGER_PATH, JSON.stringify(ledger, null, 2) + '\n', 'utf8');
+  process.stdout.write(
+    `recorded ${args.key}: ${entry.status} (${entry.numPassed}/${entry.numFailed}) → ${DEFAULT_LEDGER_PATH}\n`,
+  );
+}
+
+main();

--- a/scripts/mri-report.ts
+++ b/scripts/mri-report.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env -S npx ts-node -T
+/**
+ * mri-report — generate a Memory Reliability Index snapshot and write it as
+ * markdown + JSON under var/mri/.
+ *
+ * Two honest modes:
+ *   1. LIVE (recommended): set MRI_ENDPOINT_URL + MRI_ADMIN_KEY to point at a
+ *      running brain; the script fetches GET /v1/admin/mri (real telemetry).
+ *   2. COLD (default): no running server — the script builds the report from an
+ *      EMPTY telemetry reader + the committed suite-status ledger. Live cells
+ *      then render `pending-eval` with reason "no traffic in window" (honest —
+ *      a cold process observed no queries), and structural cells render the
+ *      ledger's last-recorded status. It NEVER fabricates a number.
+ *
+ * Run:
+ *   pnpm mri:report
+ *   MRI_ENDPOINT_URL=http://localhost:3033 MRI_ADMIN_KEY=key_… pnpm mri:report
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { readerFromPromJson } from '../src/mri/metrics-reader';
+import { buildMriReport } from '../src/mri/mri-collectors';
+import { loadSuiteLedger } from '../src/mri/suite-status';
+import { renderMriMarkdown } from '../src/mri/mri-markdown';
+import type { MriReport } from '../src/mri/mri.types';
+
+async function fetchLive(url: string, key: string): Promise<MriReport> {
+  const res = await fetch(`${url.replace(/\/$/, '')}/v1/admin/mri`, {
+    headers: { Authorization: `Bearer ${key}` },
+  });
+  if (!res.ok) {
+    throw new Error(`GET /v1/admin/mri returned ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as MriReport;
+}
+
+function buildCold(): MriReport {
+  // Empty reader → no counters/histograms; live dims render pending honestly.
+  const reader = readerFromPromJson([]);
+  const ledger = loadSuiteLedger();
+  return buildMriReport(reader, ledger);
+}
+
+async function main(): Promise<void> {
+  const url = process.env.MRI_ENDPOINT_URL;
+  const key = process.env.MRI_ADMIN_KEY;
+
+  let report: MriReport;
+  let mode: string;
+  if (url && key) {
+    report = await fetchLive(url, key);
+    mode = `live (${url})`;
+  } else {
+    report = buildCold();
+    mode = 'cold (no MRI_ENDPOINT_URL/MRI_ADMIN_KEY — live cells pending, structural from ledger)';
+  }
+
+  const outDir = join('var', 'mri');
+  mkdirSync(outDir, { recursive: true });
+  const md = renderMriMarkdown(report);
+  writeFileSync(join(outDir, 'latest.md'), md, 'utf8');
+  writeFileSync(join(outDir, 'latest.json'), JSON.stringify(report, null, 2) + '\n', 'utf8');
+
+  process.stdout.write(`MRI snapshot written to var/mri/latest.{md,json} — mode: ${mode}\n`);
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`mri-report failed: ${(err as Error).message}\n`);
+  process.exit(1);
+});

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -36,6 +36,7 @@ import { DocumentsModule } from './documents/documents.module';
 import { FeedbackModule } from './feedback/feedback.module';
 import { UsersModule } from './users/users.module';
 import { StrategyModule } from './strategy/strategy.module';
+import { MriModule } from './mri/mri.module';
 
 @Module({
   imports: [
@@ -105,6 +106,7 @@ import { StrategyModule } from './strategy/strategy.module';
     EpisodesModule,
     UsersModule,
     StrategyModule,
+    MriModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/src/contracts/admin/mri.schema.ts
+++ b/src/contracts/admin/mri.schema.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+/**
+ * Wire contract for GET /v1/admin/mri (Memory Reliability Index) and
+ * GET /v1/admin/mri/operating-point.
+ *
+ * Admin/ops surface — deliberately NOT in the platform OpenAPI document
+ * (scripts/build-openapi.ts scopes that to the community API). The shape is
+ * pinned here and drift-guarded by test/contracts-admin-mri.unit-spec.ts, the
+ * same way the calibration cockpit is.
+ *
+ * Every dimension value is a real number/string or an honest sentinel
+ * (`'pending-eval'` / `'unrecorded'`); the union is left open (number|string)
+ * so both render without a discriminated branch.
+ */
+
+export const PolicyOperatingPointSchema = z.object({
+  flags: z.array(z.string()),
+  accuracyProxy: z.number().nullable(),
+  ece: z.number().nullable(),
+  latencyP50: z.number().nullable(),
+  latencyP95: z.number().nullable(),
+  costPerQuery: z.number().nullable(),
+  sampleCount: z.number(),
+});
+
+export const MriDimensionSchema = z.object({
+  value: z.union([z.number(), z.string()]),
+  unit: z.string().optional(),
+  source: z.string(),
+  asOf: z.string(),
+  evalGated: z.boolean(),
+  reason: z.string().optional(),
+  kind: z.enum(['live', 'structural', 'pending']),
+});
+
+export const MriReportSchema = z.object({
+  generatedAt: z.string(),
+  dimensions: z.record(z.string(), MriDimensionSchema),
+  operatingPoint: PolicyOperatingPointSchema,
+});
+
+export type MriReportContract = z.infer<typeof MriReportSchema>;
+export type MriDimensionContract = z.infer<typeof MriDimensionSchema>;
+export type PolicyOperatingPointContract = z.infer<typeof PolicyOperatingPointSchema>;

--- a/src/mri/economics.ts
+++ b/src/mri/economics.ts
@@ -1,0 +1,242 @@
+import type { MetricsReader } from './metrics-reader';
+import { histogramQuantile, sumCounter } from './metrics-reader';
+
+/**
+ * Part 1 — the economics operating-point + Pareto reporter
+ * (docs/roadmap/measurable-economics-mri-2026-08.md §1).
+ *
+ * A policy operating-point is one row on the accuracy × cost × latency
+ * surface: "with THIS flag set, over THIS window, the pipeline served at
+ * this proxy-accuracy, this $/query, this p50/p95". Every axis except
+ * accuracy comes straight off existing telemetry. The accuracy axis is a
+ * cheap ONLINE PROXY — the verifier `supported`-rate — NOT a true accuracy
+ * claim; the field is named `accuracyProxy` and labelled "proxy" everywhere
+ * so it can never be mistaken for the parked paid-eval number.
+ *
+ * The reporter renders the Pareto frontier over a set of points and flags
+ * the dominated ones (accuracy↑ better, cost↓ better, latency↓ better). The
+ * ship-gate is ADVISORY ONLY (§1.3): it REPORTS that a candidate is
+ * dominated; it never blocks. Latency/cost are real; only accuracy is a
+ * proxy until the eval is unfrozen.
+ */
+
+/** USD per 1,000,000 tokens. Assumed list price — the token COUNTS are exact
+ *  telemetry; this table is only the unit conversion and is overridable so a
+ *  deployment can price its own models. Kept deliberately conservative and
+ *  explicit: a wrong price shifts the $ axis uniformly, it never fabricates a
+ *  measurement. */
+export interface PriceTable {
+  chatPromptPerMillion: number;
+  chatCompletionPerMillion: number;
+  embedPromptPerMillion: number;
+}
+
+export const DEFAULT_PRICE_TABLE: PriceTable = {
+  chatPromptPerMillion: 0.15,
+  chatCompletionPerMillion: 0.6,
+  embedPromptPerMillion: 0.02,
+};
+
+/**
+ * One point on the accuracy × cost × latency surface. The literal shape from
+ * §1: `flags`, `accuracyProxy`, `ece`, `latencyP50`, `latencyP95`,
+ * `costPerQuery`. Measured axes are `number | null` — null means "no telemetry
+ * in the window", never a fabricated zero (the inviolable rule). `ece` is null
+ * until calibration labels exist. `sampleCount` carries the provenance (how
+ * many synthesize calls the window saw) so a consumer can see an empty window.
+ */
+export interface PolicyOperatingPoint {
+  /** Flags that describe this operating point (caller-supplied — telemetry
+   *  does not record which flags were live for a window). */
+  flags: string[];
+  /** Verifier `supported`-rate in [0,1]. A PROXY, never a true-accuracy claim.
+   *  null when the window saw no synthesize traffic. */
+  accuracyProxy: number | null;
+  /** Expected Calibration Error. null until a labeled gold set exists. */
+  ece: number | null;
+  /** Median query latency in seconds (search-stage histogram). null = no
+   *  samples. */
+  latencyP50: number | null;
+  /** p95 query latency in seconds. null = no samples. */
+  latencyP95: number | null;
+  /** Estimated USD per query (exact token counters × assumed price table).
+   *  null = no traffic. */
+  costPerQuery: number | null;
+  /** synthesize invocations observed in the window (provenance for the axes). */
+  sampleCount: number;
+}
+
+export interface CollectOperatingPointOptions {
+  /** Label the flags that were live for this window (default []). */
+  flags?: string[];
+  /** Override the price table used for the $ axis. */
+  pricing?: PriceTable;
+}
+
+/**
+ * Assemble ONE operating point from a telemetry reader over the current
+ * window. accuracyProxy = supported-rate = synthesize{outcome=ok} ÷ synthesize
+ * total. Cost = (prompt/completion/embed tokens × price) ÷ query count. Latency
+ * = search-duration histogram quantiles (the only per-query latency histogram
+ * the pipeline emits; there is no end-to-end synthesize histogram, and adding
+ * one would touch the serving path). ece stays null — no labels here.
+ */
+export function collectOperatingPoint(
+  reader: MetricsReader,
+  options: CollectOperatingPointOptions = {},
+): PolicyOperatingPoint {
+  const pricing = options.pricing ?? DEFAULT_PRICE_TABLE;
+  const flags = options.flags ?? [];
+
+  const synthTotal = sumCounter(reader, 'brain_synthesize_total');
+  const synthOk = sumCounter(reader, 'brain_synthesize_total', { outcome: 'ok' });
+  const accuracyProxy = synthTotal > 0 ? synthOk / synthTotal : null;
+
+  const chatPrompt = sumCounter(reader, 'brain_openai_tokens_total', {
+    kind: 'chat',
+    type: 'prompt',
+  });
+  const chatCompletion = sumCounter(reader, 'brain_openai_tokens_total', {
+    kind: 'chat',
+    type: 'completion',
+  });
+  const embedPrompt = sumCounter(reader, 'brain_openai_tokens_total', {
+    kind: 'embed',
+    type: 'prompt',
+  });
+  const totalCostUsd =
+    (chatPrompt * pricing.chatPromptPerMillion +
+      chatCompletion * pricing.chatCompletionPerMillion +
+      embedPrompt * pricing.embedPromptPerMillion) /
+    1_000_000;
+  const costPerQuery = synthTotal > 0 ? totalCostUsd / synthTotal : null;
+
+  const latency = reader.histogram('brain_search_duration_seconds');
+  const latencyP50 = latency ? histogramQuantile(latency, 0.5) : null;
+  const latencyP95 = latency ? histogramQuantile(latency, 0.95) : null;
+
+  return {
+    flags,
+    accuracyProxy,
+    ece: null,
+    latencyP50,
+    latencyP95,
+    costPerQuery,
+    sampleCount: synthTotal,
+  };
+}
+
+/** True iff every axis the frontier compares is present (not null). */
+export function hasCompleteAxes(p: PolicyOperatingPoint): boolean {
+  return p.accuracyProxy !== null && p.costPerQuery !== null && p.latencyP95 !== null;
+}
+
+/**
+ * Pareto domination over (accuracyProxy↑, costPerQuery↓, latencyP95↓): `a`
+ * dominates `b` iff `a` is no worse on every axis and strictly better on at
+ * least one. Only defined when both points have complete axes.
+ */
+export function dominates(a: PolicyOperatingPoint, b: PolicyOperatingPoint): boolean {
+  if (!hasCompleteAxes(a) || !hasCompleteAxes(b)) return false;
+  const aAcc = a.accuracyProxy as number;
+  const bAcc = b.accuracyProxy as number;
+  const aCost = a.costPerQuery as number;
+  const bCost = b.costPerQuery as number;
+  const aLat = a.latencyP95 as number;
+  const bLat = b.latencyP95 as number;
+
+  const noWorse = aAcc >= bAcc && aCost <= bCost && aLat <= bLat;
+  const strictlyBetter = aAcc > bAcc || aCost < bCost || aLat < bLat;
+  return noWorse && strictlyBetter;
+}
+
+export interface DominatedPoint {
+  point: PolicyOperatingPoint;
+  dominatedBy: PolicyOperatingPoint;
+}
+
+export interface ParetoReport {
+  /** Non-dominated points (the frontier). */
+  frontier: PolicyOperatingPoint[];
+  /** Dominated points, each paired with a point that dominates it. */
+  dominated: DominatedPoint[];
+  /** Points excluded from the comparison for missing an axis (null value). */
+  insufficientData: PolicyOperatingPoint[];
+}
+
+/**
+ * Render the Pareto frontier over a set of operating points and flag the
+ * dominated ones. Points missing an axis are set aside as insufficientData
+ * (never silently treated as zero). Advisory reporting only — this computes
+ * the frontier, it does not gate anything.
+ */
+export function paretoFrontier(points: PolicyOperatingPoint[]): ParetoReport {
+  const complete = points.filter(hasCompleteAxes);
+  const insufficientData = points.filter((p) => !hasCompleteAxes(p));
+
+  const frontier: PolicyOperatingPoint[] = [];
+  const dominated: DominatedPoint[] = [];
+
+  for (const p of complete) {
+    const dominator = complete.find((q) => q !== p && dominates(q, p));
+    if (dominator) dominated.push({ point: p, dominatedBy: dominator });
+    else frontier.push(p);
+  }
+
+  return { frontier, dominated, insufficientData };
+}
+
+export interface ShipGateAdvisory {
+  /** Whether an incumbent dominates the candidate on the three axes. */
+  candidateDominated: boolean;
+  /** The dominating incumbent, if any. */
+  dominatedBy: PolicyOperatingPoint | null;
+  /** Human-readable advisory sentence. */
+  advisory: string;
+  /** ALWAYS false — this gate reports, it never blocks (§1.3). */
+  blocking: false;
+}
+
+/**
+ * Advisory ship-gate (§1.3): report whether `candidate` is dominated by any
+ * `incumbent`. Deliberately never blocks — `blocking` is a literal `false`.
+ * Until the eval is unfrozen the accuracy axis is a proxy, so a domination
+ * verdict is advice, not a merge gate.
+ */
+export function shipGateAdvisory(
+  candidate: PolicyOperatingPoint,
+  incumbents: PolicyOperatingPoint[],
+): ShipGateAdvisory {
+  if (!hasCompleteAxes(candidate)) {
+    return {
+      candidateDominated: false,
+      dominatedBy: null,
+      advisory:
+        'advisory: candidate has no telemetry on ≥1 axis (proxy-accuracy / cost / p95); ' +
+        'no domination verdict possible.',
+      blocking: false,
+    };
+  }
+  const dominator = incumbents.find((q) => dominates(q, candidate)) ?? null;
+  if (dominator) {
+    return {
+      candidateDominated: true,
+      dominatedBy: dominator,
+      advisory:
+        `advisory: candidate is DOMINATED (proxy-accuracy ${fmt(candidate.accuracyProxy)}, ` +
+        `$${fmt(candidate.costPerQuery)}/q, p95 ${fmt(candidate.latencyP95)}s) by an incumbent ` +
+        `[${dominator.flags.join(',') || 'baseline'}]. Not blocking — accuracy is a proxy until eval is unfrozen.`,
+      blocking: false,
+    };
+  }
+  return {
+    candidateDominated: false,
+    dominatedBy: null,
+    advisory: 'advisory: candidate is on the frontier (not dominated by any incumbent).',
+    blocking: false,
+  };
+}
+
+function fmt(v: number | null): string {
+  return v === null ? 'n/a' : v.toPrecision(3);
+}

--- a/src/mri/metrics-reader.ts
+++ b/src/mri/metrics-reader.ts
@@ -1,0 +1,145 @@
+/**
+ * MetricsReader — the narrow, stubbable telemetry-source layer the MRI
+ * aggregator and the economics collector read from. It is a pure read view
+ * over a Prometheus snapshot: no live per-request hooks, no serving-path
+ * touch. The production reader is built from `MetricsService.registry`'s
+ * `getMetricsAsJSON()` output; unit tests hand-build the same JSON shape, so
+ * the aggregator is fully exercisable without a running registry.
+ */
+
+/** A single label-set + value from a counter/gauge series. */
+export interface CounterSeries {
+  labels: Record<string, string>;
+  value: number;
+}
+
+/** A histogram flattened to cumulative buckets + sum + count. */
+export interface HistogramData {
+  /** Cumulative buckets, ascending `le`, including +Inf as Number.POSITIVE_INFINITY. */
+  buckets: Array<{ le: number; cumulativeCount: number }>;
+  sum: number;
+  count: number;
+}
+
+export interface MetricsReader {
+  /** All series for a counter/gauge metric by name (empty if absent). */
+  counter(name: string): CounterSeries[];
+  /** Histogram data for a metric by name, or null if absent / has no samples. */
+  histogram(name: string): HistogramData | null;
+}
+
+/** The subset of prom-client's `getMetricsAsJSON()` element shape we consume. */
+export interface PromMetricJson {
+  name: string;
+  type: string;
+  values: Array<{
+    value: number;
+    labels?: Record<string, string | number> | undefined;
+    metricName?: string | undefined;
+  }>;
+}
+
+/** The `registry.getMetricsAsJSON()` surface — kept tiny so callers can stub it. */
+export interface PromRegistryLike {
+  getMetricsAsJSON(): Promise<PromMetricJson[]>;
+}
+
+function normLabels(labels: Record<string, string | number> | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!labels) return out;
+  for (const [k, v] of Object.entries(labels)) out[k] = String(v);
+  return out;
+}
+
+/**
+ * Build a MetricsReader from a prom-client JSON snapshot. Counters/gauges map
+ * straight through; histograms are re-assembled from their `_bucket` (with the
+ * `le` label), `_sum`, and `_count` value rows into a HistogramData.
+ */
+export function readerFromPromJson(metrics: PromMetricJson[]): MetricsReader {
+  const byName = new Map<string, PromMetricJson>();
+  for (const m of metrics) byName.set(m.name, m);
+
+  return {
+    counter(name: string): CounterSeries[] {
+      const m = byName.get(name);
+      if (!m) return [];
+      return m.values
+        .filter((v) => v.metricName === undefined || v.metricName === name)
+        .map((v) => ({ labels: normLabels(v.labels), value: v.value }));
+    },
+    histogram(name: string): HistogramData | null {
+      const m = byName.get(name);
+      if (!m) return null;
+      const buckets: Array<{ le: number; cumulativeCount: number }> = [];
+      let sum = 0;
+      let count = 0;
+      for (const v of m.values) {
+        const metricName = v.metricName ?? name;
+        if (metricName === `${name}_bucket`) {
+          const leRaw = v.labels?.['le'];
+          if (leRaw === undefined) continue;
+          const le = leRaw === '+Inf' ? Number.POSITIVE_INFINITY : Number(leRaw);
+          if (Number.isNaN(le)) continue;
+          buckets.push({ le, cumulativeCount: v.value });
+        } else if (metricName === `${name}_sum`) {
+          sum = v.value;
+        } else if (metricName === `${name}_count`) {
+          count = v.value;
+        }
+      }
+      if (buckets.length === 0 && count === 0) return null;
+      buckets.sort((a, b) => a.le - b.le);
+      return { buckets, sum, count };
+    },
+  };
+}
+
+/**
+ * Sum a counter's series, optionally filtered to series that match ALL of the
+ * given labels. Missing metric → 0 (honest: no traffic recorded).
+ */
+export function sumCounter(
+  reader: MetricsReader,
+  name: string,
+  match?: Record<string, string>,
+): number {
+  const series = reader.counter(name);
+  let total = 0;
+  for (const s of series) {
+    if (match && !Object.entries(match).every(([k, v]) => s.labels[k] === v)) continue;
+    total += s.value;
+  }
+  return total;
+}
+
+/**
+ * Prometheus-style `histogram_quantile`: linear interpolation within the bucket
+ * where the cumulative count crosses `q · count`. Returns null when the
+ * histogram has no samples. This is the same estimator Prometheus uses — an
+ * honest approximation off the emitted buckets, not a claimed exact latency.
+ */
+export function histogramQuantile(hist: HistogramData, q: number): number | null {
+  if (hist.count <= 0 || hist.buckets.length === 0) return null;
+  const target = q * hist.count;
+  const buckets = hist.buckets;
+
+  let prevLe = 0;
+  let prevCount = 0;
+  for (const b of buckets) {
+    if (b.cumulativeCount >= target) {
+      if (b.le === Number.POSITIVE_INFINITY) {
+        // Everything past the last finite bound sits in +Inf — report that
+        // bound (the largest finite bucket edge) rather than Infinity.
+        return prevLe;
+      }
+      const bucketCount = b.cumulativeCount - prevCount;
+      if (bucketCount <= 0) return b.le;
+      const fraction = (target - prevCount) / bucketCount;
+      return prevLe + fraction * (b.le - prevLe);
+    }
+    prevLe = b.le === Number.POSITIVE_INFINITY ? prevLe : b.le;
+    prevCount = b.cumulativeCount;
+  }
+  return prevLe;
+}

--- a/src/mri/mri-admin.controller.ts
+++ b/src/mri/mri-admin.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, NotFoundException, Req, UseGuards } from '@nestjs/common';
+import { ApiKeyGuard } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { MriService } from './mri.service';
+import type { MriReport } from './mri.types';
+import type { PolicyOperatingPoint } from './economics';
+
+/**
+ * MRI admin surface (measurable-economics-mri-2026-08.md §1-2).
+ *
+ * Operator / eval-harness only. Authenticated by ApiKeyGuard, but the handler
+ * itself 404s when the caller lacks `brain:admin` — indistinguishable from
+ * "route not deployed" (the EPISODES_API / focus-admin idiom). This surface is
+ * READ-ONLY: it serves the latest generated snapshot of live telemetry + the
+ * suite-status ledger; nothing here touches the answer path.
+ *
+ * Deliberately NOT in the platform OpenAPI document — the admin/ops surface is
+ * out of scope there by design (scripts/build-openapi.ts). The wire contract is
+ * pinned by test/contracts-admin-mri.unit-spec.ts against MriReportSchema, the
+ * same way the calibration cockpit is.
+ */
+@Controller('v1/admin/mri')
+@UseGuards(ApiKeyGuard)
+export class MriAdminController {
+  constructor(private readonly mri: MriService) {}
+
+  private assertAdmin(req: AuthenticatedRequest): void {
+    if (!req.brainAuth.scopes.includes('brain:admin')) {
+      throw new NotFoundException();
+    }
+  }
+
+  /** The full MRI report — §2 dimensions + the §1 live operating point. */
+  @Get()
+  async report(@Req() req: AuthenticatedRequest): Promise<MriReport> {
+    this.assertAdmin(req);
+    return this.mri.generate();
+  }
+
+  /** Just the Part 1 live operating point (proxy-accuracy × cost × latency). */
+  @Get('operating-point')
+  async operatingPoint(@Req() req: AuthenticatedRequest): Promise<PolicyOperatingPoint> {
+    this.assertAdmin(req);
+    const report = await this.mri.generate();
+    return report.operatingPoint;
+  }
+}

--- a/src/mri/mri-collectors.ts
+++ b/src/mri/mri-collectors.ts
@@ -1,0 +1,296 @@
+import type { MetricsReader } from './metrics-reader';
+import { sumCounter } from './metrics-reader';
+import type { MriDimension, MriReport } from './mri.types';
+import {
+  collectOperatingPoint,
+  type CollectOperatingPointOptions,
+  type PolicyOperatingPoint,
+} from './economics';
+import {
+  ISOLATION_SUITE,
+  PREMISE_SUITE,
+  POISONING_SUITE,
+  type SuiteLedger,
+  type SuiteSpec,
+} from './suite-status';
+
+/**
+ * The MRI aggregator (§2 table). Pure over an injected telemetry reader + a
+ * suite-status ledger, so the whole thing is unit-testable with a stub source.
+ * Every cell is honestly one of:
+ *   - LIVE       — a real number off Prometheus counters/histograms
+ *   - STRUCTURAL — a suite's last-recorded pass status (never a guessed pass)
+ *   - PENDING    — the `'pending-eval'` sentinel + a reason (labels/eval/F1)
+ */
+
+/** No real value available (empty window / not-yet-labeled) → honest sentinel. */
+function pendingCell(args: {
+  source: string;
+  reason: string;
+  evalGated: boolean;
+  kind: 'live' | 'pending';
+  asOf: string;
+}): MriDimension {
+  return {
+    value: 'pending-eval',
+    source: args.source,
+    asOf: args.asOf,
+    evalGated: args.evalGated,
+    reason: args.reason,
+    kind: args.kind,
+  };
+}
+
+/** Premise-awareness / poisoning / isolation share the ledger-backed shape. */
+function structuralDim(
+  spec: SuiteSpec,
+  args: { ledger: SuiteLedger; nowIso: string; preferNumericGap?: boolean },
+): MriDimension {
+  const { ledger, nowIso } = args;
+  const entry = ledger[spec.key];
+  const suiteRef = spec.files.join(', ');
+  const docRef = spec.doc ? ` (${spec.doc})` : '';
+  if (!entry) {
+    return {
+      value: 'unrecorded',
+      source: `suite ${suiteRef}${docRef}`,
+      asOf: nowIso,
+      evalGated: false,
+      kind: 'structural',
+      reason: `suite present but last-run status not recorded — run \`pnpm mri:record-suite ${spec.key}\``,
+    };
+  }
+  const commitRef = entry.commit ? ` @ ${entry.commit}` : '';
+  const gapNote = entry.gapCount !== undefined ? `, gapCount=${entry.gapCount}` : '';
+  const countNote =
+    entry.numPassed !== undefined || entry.numFailed !== undefined
+      ? `, tests ${entry.numPassed ?? 0} passed/${entry.numFailed ?? 0} failed`
+      : '';
+  const source = `suite ${suiteRef} — status ${entry.status}, recorded ${entry.recordedAt}${commitRef}${gapNote}${countNote}`;
+  if (args.preferNumericGap && entry.gapCount !== undefined) {
+    return {
+      value: entry.gapCount,
+      unit: 'gaps',
+      source,
+      asOf: entry.recordedAt,
+      evalGated: false,
+      kind: 'structural',
+    };
+  }
+  return {
+    value: entry.status,
+    source,
+    asOf: entry.recordedAt,
+    evalGated: false,
+    kind: 'structural',
+  };
+}
+
+/**
+ * Premise-awareness — structural. MemTrap shakedown pass status, enriched with
+ * the FOVEA_PLAUSIBILITY_CHECK downgrade counter IF the serving path emits one
+ * (it currently does not — noted in source, never fabricated).
+ */
+function premiseAwarenessDim(
+  reader: MetricsReader,
+  ledger: SuiteLedger,
+  nowIso: string,
+): MriDimension {
+  const base = structuralDim(PREMISE_SUITE, { ledger, nowIso });
+  const plausibilitySeries = reader.counter('brain_fovea_plausibility_downgrade_total');
+  if (plausibilitySeries.length > 0) {
+    const downgrades = sumCounter(reader, 'brain_fovea_plausibility_downgrade_total');
+    return { ...base, source: `${base.source}; FOVEA_PLAUSIBILITY_CHECK downgrades=${downgrades}` };
+  }
+  return {
+    ...base,
+    source: `${base.source}; FOVEA_PLAUSIBILITY_CHECK downgrade counter not emitted`,
+  };
+}
+
+/**
+ * Citation coverage — % of served `supported` answers with ≥1 citation. Wired
+ * forward-compatibly: computes the real ratio IF the serving path emits the
+ * supported / supported-cited counters. It does NOT today, and adding the
+ * increment would edit synthesize.service.ts/verdict.ts (out of scope for this
+ * read-only layer), so it renders the honest sentinel with that reason.
+ */
+function citationCoverageDim(reader: MetricsReader, nowIso: string): MriDimension {
+  const supportedSeries = reader.counter('brain_synthesize_supported_total');
+  const supported = sumCounter(reader, 'brain_synthesize_supported_total');
+  const cited = sumCounter(reader, 'brain_synthesize_supported_cited_total');
+  if (supportedSeries.length > 0 && supported > 0) {
+    return {
+      value: cited / supported,
+      unit: 'ratio',
+      source: 'brain_synthesize_supported_cited_total ÷ brain_synthesize_supported_total',
+      asOf: nowIso,
+      evalGated: false,
+      kind: 'live',
+    };
+  }
+  return pendingCell({
+    source: 'synthesize verdict/citation counters (not emitted by serving path)',
+    reason:
+      'no citation-vs-supported counter is emitted on the serving path; computing % of supported ' +
+      'answers with ≥1 citation requires instrumenting synthesize.service.ts/verdict.ts, which this ' +
+      'read-only measurement layer must not touch. Auto-fills once brain_synthesize_supported_total ' +
+      '& brain_synthesize_supported_cited_total appear.',
+    evalGated: false,
+    kind: 'live',
+    asOf: nowIso,
+  });
+}
+
+/** Cost & latency — live (Part 1 axes). tokens/query off the token counters. */
+function tokensPerQueryDim(reader: MetricsReader, nowIso: string): MriDimension {
+  const synthTotal = sumCounter(reader, 'brain_synthesize_total');
+  const tokens = sumCounter(reader, 'brain_openai_tokens_total');
+  if (synthTotal <= 0) {
+    return pendingCell({
+      source: 'brain_openai_tokens_total ÷ brain_synthesize_total',
+      reason: 'no synthesize traffic in the current window (0 queries) — no rate to report',
+      evalGated: false,
+      kind: 'live',
+      asOf: nowIso,
+    });
+  }
+  return {
+    value: tokens / synthTotal,
+    unit: 'tokens/query',
+    source: 'brain_openai_tokens_total ÷ brain_synthesize_total',
+    asOf: nowIso,
+    evalGated: false,
+    kind: 'live',
+  };
+}
+
+function costLatencyDims(
+  point: PolicyOperatingPoint,
+  nowIso: string,
+): Record<string, MriDimension> {
+  const costSource =
+    'brain_openai_tokens_total × assumed price table (tokens exact; USD conversion assumed) ÷ brain_synthesize_total';
+  const latencySource =
+    'brain_search_duration_seconds histogram quantile (search-stage; no end-to-end query histogram is emitted)';
+
+  const cost: MriDimension =
+    point.costPerQuery === null
+      ? pendingCell({
+          source: costSource,
+          reason: 'no synthesize traffic in the current window (0 queries)',
+          evalGated: false,
+          kind: 'live',
+          asOf: nowIso,
+        })
+      : {
+          value: point.costPerQuery,
+          unit: 'USD/query',
+          source: costSource,
+          asOf: nowIso,
+          evalGated: false,
+          kind: 'live',
+        };
+
+  const p50: MriDimension =
+    point.latencyP50 === null
+      ? pendingCell({
+          source: latencySource,
+          reason: 'no search-latency samples in the current window',
+          evalGated: false,
+          kind: 'live',
+          asOf: nowIso,
+        })
+      : {
+          value: point.latencyP50,
+          unit: 'seconds',
+          source: latencySource,
+          asOf: nowIso,
+          evalGated: false,
+          kind: 'live',
+        };
+
+  const p95: MriDimension =
+    point.latencyP95 === null
+      ? pendingCell({
+          source: latencySource,
+          reason: 'no search-latency samples in the current window',
+          evalGated: false,
+          kind: 'live',
+          asOf: nowIso,
+        })
+      : {
+          value: point.latencyP95,
+          unit: 'seconds',
+          source: latencySource,
+          asOf: nowIso,
+          evalGated: false,
+          kind: 'live',
+        };
+
+  return { costPerQueryUsd: cost, latencyP50Seconds: p50, latencyP95Seconds: p95 };
+}
+
+export interface BuildMriReportOptions {
+  now?: Date;
+  operatingPoint?: CollectOperatingPointOptions;
+}
+
+/**
+ * Assemble the full MRI report from a telemetry reader + a suite-status ledger.
+ * Pure and deterministic (given `now`) — the service supplies a live reader and
+ * the committed ledger; unit tests supply a stub reader and an in-memory ledger.
+ */
+export function buildMriReport(
+  reader: MetricsReader,
+  ledger: SuiteLedger,
+  options: BuildMriReportOptions = {},
+): MriReport {
+  const now = options.now ?? new Date();
+  const nowIso = now.toISOString();
+  const point = collectOperatingPoint(reader, options.operatingPoint ?? {});
+
+  const dimensions: Record<string, MriDimension> = {
+    // Structural (suite-backed) ------------------------------------------
+    premiseAwareness: premiseAwarenessDim(reader, ledger, nowIso),
+    poisoningResistance: structuralDim(POISONING_SUITE, { ledger, nowIso, preferNumericGap: true }),
+    tenantUserIsolation: structuralDim(ISOLATION_SUITE, { ledger, nowIso }),
+
+    // Live telemetry -----------------------------------------------------
+    citationCoverage: citationCoverageDim(reader, nowIso),
+    tokensPerQuery: tokensPerQueryDim(reader, nowIso),
+    ...costLatencyDims(point, nowIso),
+
+    // Pending — freshness is blocked on F1 (must land first; not built here)
+    freshnessStaleAnswerRate: pendingCell({
+      source: 'answer-cache invalidation telemetry (brain_answer_cache_total{rejected_stale})',
+      reason:
+        'blocked on F1 answer-cache additive-write invalidation — the stale-answer rate is only ' +
+        'meaningful once F1 lands; F1 is out of scope for this measurement layer',
+      evalGated: false,
+      kind: 'pending',
+      asOf: nowIso,
+    }),
+
+    // Pending — eval-gated (need a labeled gold set)
+    abstentionCalibration: pendingCell({
+      source: 'Fovea §4.2 focus-signal reliability (per-class ECE over labeled abstain decisions)',
+      reason:
+        'eval-gated: needs a labeled gold set (correct/abstain outcomes) to compute focus-signal ' +
+        'reliability; no labels exist yet',
+      evalGated: true,
+      kind: 'pending',
+      asOf: nowIso,
+    }),
+    correctness: pendingCell({
+      source: 'parked paid-accuracy eval (strict-judged LoCoMo / LME / BEAM)',
+      reason:
+        'eval-gated: the paid-accuracy eval is frozen; no true-correctness number until it is unfrozen',
+      evalGated: true,
+      kind: 'pending',
+      asOf: nowIso,
+    }),
+  };
+
+  return { generatedAt: nowIso, dimensions, operatingPoint: point };
+}

--- a/src/mri/mri-markdown.ts
+++ b/src/mri/mri-markdown.ts
@@ -1,0 +1,95 @@
+import type { MriDimension, MriReport } from './mri.types';
+import type { ParetoReport, PolicyOperatingPoint } from './economics';
+
+/**
+ * Render an MRI report (+ optional Pareto frontier) to a human-readable
+ * markdown snapshot. Pure string-building — no fs, no telemetry. Used by
+ * `pnpm mri:report` to write the committed/human artifact.
+ */
+
+function fmtValue(d: MriDimension): string {
+  if (typeof d.value === 'number') {
+    const n = Number.isInteger(d.value) ? String(d.value) : d.value.toPrecision(4);
+    return d.unit ? `${n} ${d.unit}` : n;
+  }
+  return `\`${d.value}\``;
+}
+
+function fmtNum(v: number | null, digits = 4): string {
+  if (v === null) return 'pending-eval';
+  return Number.isInteger(v) ? String(v) : v.toPrecision(digits);
+}
+
+function operatingPointTable(p: PolicyOperatingPoint): string {
+  const rows: Array<[string, string]> = [
+    ['flags', p.flags.length ? p.flags.join(', ') : '(baseline)'],
+    ['accuracyProxy (verifier supported-rate — PROXY, not true accuracy)', fmtNum(p.accuracyProxy)],
+    ['ece', p.ece === null ? 'pending-eval (needs labels)' : fmtNum(p.ece)],
+    ['latencyP50 (s)', fmtNum(p.latencyP50)],
+    ['latencyP95 (s)', fmtNum(p.latencyP95)],
+    ['costPerQuery (USD, estimate)', fmtNum(p.costPerQuery)],
+    ['sampleCount (synthesize calls in window)', String(p.sampleCount)],
+  ];
+  return ['| Axis | Value |', '| --- | --- |', ...rows.map(([k, v]) => `| ${k} | ${v} |`)].join(
+    '\n',
+  );
+}
+
+export function renderMriMarkdown(report: MriReport, pareto?: ParetoReport): string {
+  const lines: string[] = [];
+  lines.push('# Memory Reliability Index (MRI) snapshot');
+  lines.push('');
+  lines.push(`Generated: ${report.generatedAt}`);
+  lines.push('');
+  lines.push(
+    '> Honest scaffold (measurable-economics-mri-2026-08.md). Every cell is a real value or the ' +
+      '`pending-eval` / `unrecorded` sentinel with a reason — never a fabricated number.',
+  );
+  lines.push('');
+
+  lines.push('## Part 2 — MRI dimensions');
+  lines.push('');
+  lines.push('| Dimension | Kind | Value | Eval-gated | Source / reason |');
+  lines.push('| --- | --- | --- | --- | --- |');
+  for (const [name, d] of Object.entries(report.dimensions)) {
+    const detail = d.reason ? `${d.source} — ${d.reason}` : d.source;
+    lines.push(
+      `| ${name} | ${d.kind} | ${fmtValue(d)} | ${d.evalGated ? 'yes' : 'no'} | ${detail.replace(/\|/g, '\\|')} |`,
+    );
+  }
+  lines.push('');
+
+  lines.push('## Part 1 — economics operating point (live)');
+  lines.push('');
+  lines.push(operatingPointTable(report.operatingPoint));
+  lines.push('');
+
+  if (pareto) {
+    lines.push('## Part 1 — Pareto frontier (advisory)');
+    lines.push('');
+    lines.push(`Frontier (non-dominated): ${pareto.frontier.length} point(s)`);
+    for (const p of pareto.frontier) {
+      lines.push(
+        `- [${p.flags.join(',') || 'baseline'}] proxy=${fmtNum(p.accuracyProxy)} ` +
+          `$${fmtNum(p.costPerQuery)}/q p95=${fmtNum(p.latencyP95)}s`,
+      );
+    }
+    if (pareto.dominated.length) {
+      lines.push('');
+      lines.push('Dominated:');
+      for (const d of pareto.dominated) {
+        lines.push(
+          `- [${d.point.flags.join(',') || 'baseline'}] dominated by ` +
+            `[${d.dominatedBy.flags.join(',') || 'baseline'}]`,
+        );
+      }
+    }
+    if (pareto.insufficientData.length) {
+      lines.push('');
+      lines.push(`Insufficient data (missing an axis): ${pareto.insufficientData.length} point(s)`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n') + '\n';
+}

--- a/src/mri/mri.module.ts
+++ b/src/mri/mri.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { MriAdminController } from './mri-admin.controller';
+import { MriService } from './mri.service';
+
+/**
+ * MRI module (measurable-economics-mri-2026-08.md). Read-only reporting layer:
+ * the admin endpoint + the report generator. MetricsService arrives from the
+ * global MetricsModule; ApiKeyGuard's deps come from the global auth/policy
+ * modules — no imports needed (mirrors StrategyModule).
+ */
+@Module({
+  controllers: [MriAdminController],
+  providers: [MriService],
+  exports: [MriService],
+})
+export class MriModule {}

--- a/src/mri/mri.service.ts
+++ b/src/mri/mri.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { MetricsService } from '../metrics/metrics.service';
+import { readerFromPromJson, type PromMetricJson } from './metrics-reader';
+import { buildMriReport, type BuildMriReportOptions } from './mri-collectors';
+import { loadSuiteLedger, DEFAULT_LEDGER_PATH } from './suite-status';
+import type { MriReport } from './mri.types';
+
+/**
+ * MriService — generates the Memory Reliability Index report from LIVE sources
+ * and persists the latest snapshot so the admin endpoint can serve it.
+ *
+ * READ-ONLY with respect to serving: it reads the Prometheus registry (a
+ * snapshot of counters/histograms the pipeline already emits) and the committed
+ * suite-status ledger. It never touches the answer path — no lane, no verdict,
+ * no synthesize hook.
+ */
+@Injectable()
+export class MriService {
+  private readonly logger = new Logger(MriService.name);
+  private readonly ledgerPath = DEFAULT_LEDGER_PATH;
+  private readonly snapshotPath = join('var', 'mri', 'latest.json');
+
+  constructor(private readonly metrics: MetricsService) {}
+
+  /** Build a fresh report from live telemetry + the ledger, persist, and return. */
+  async generate(options: BuildMriReportOptions = {}): Promise<MriReport> {
+    const json = (await this.metrics.registry.getMetricsAsJSON()) as unknown as PromMetricJson[];
+    const reader = readerFromPromJson(json);
+    const ledger = loadSuiteLedger(this.ledgerPath);
+    const report = buildMriReport(reader, ledger, options);
+    this.persist(report);
+    return report;
+  }
+
+  /** Best-effort durable snapshot (var/ is a runtime artifact, like eval reports). */
+  private persist(report: MriReport): void {
+    try {
+      mkdirSync(dirname(this.snapshotPath), { recursive: true });
+      writeFileSync(this.snapshotPath, JSON.stringify(report, null, 2) + '\n', 'utf8');
+    } catch (err) {
+      this.logger.warn(`MRI snapshot persist failed: ${(err as Error).message}`);
+    }
+  }
+}

--- a/src/mri/mri.types.ts
+++ b/src/mri/mri.types.ts
@@ -1,0 +1,42 @@
+import type { PolicyOperatingPoint } from './economics';
+
+/**
+ * Part 2 — the Memory Reliability Index (MRI) report shape
+ * (docs/roadmap/measurable-economics-mri-2026-08.md §2).
+ *
+ * THE ONE INVIOLABLE RULE: every dimension cell is either a real value backed
+ * by a live source (telemetry / a suite-recorded status) OR the literal
+ * `'pending-eval'` string with a `reason`. A dimension that needs the parked
+ * paid-accuracy eval renders `'pending-eval'`, never a guess. Structural
+ * dimensions may also render `'unrecorded'` (suite present, status not yet
+ * captured by a real run) — again with a reason, never a fabricated pass.
+ */
+
+/** A dimension cell value: a real number/string, or an honest sentinel. */
+export type MriValue = number | string | 'pending-eval';
+
+export interface MriDimension {
+  /** Real measured value, or the `'pending-eval'` / `'unrecorded'` sentinel. */
+  value: MriValue;
+  /** Unit of a numeric value (omitted for sentinels / status strings). */
+  unit?: string;
+  /** Human-readable provenance: which counter / suite / eval produced this. */
+  source: string;
+  /** ISO timestamp the value is as-of. */
+  asOf: string;
+  /** Whether this dimension is blocked on the parked labeled/paid eval. */
+  evalGated: boolean;
+  /** Required whenever value is a sentinel — why it is not a live number. */
+  reason?: string;
+  /** How the dimension resolves: 'live' telemetry, 'structural' suite-backed,
+   *  or 'pending' (eval-/feature-gated). */
+  kind: 'live' | 'structural' | 'pending';
+}
+
+export interface MriReport {
+  generatedAt: string;
+  /** The seven §2 dimensions plus the split cost/latency cells. */
+  dimensions: Record<string, MriDimension>;
+  /** Part 1 live operating point (proxy-accuracy × cost × latency). */
+  operatingPoint: PolicyOperatingPoint;
+}

--- a/src/mri/suite-status.ts
+++ b/src/mri/suite-status.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Suite-status ledger — the honest backbone of the STRUCTURAL MRI dimensions
+ * (premise-awareness, poisoning-resistance, tenant/user isolation).
+ *
+ * These dimensions are not live per-request numbers; they are "verified by
+ * suite X, last recorded status Y". A structural dimension NEVER claims a pass
+ * on its own — it reports exactly what the ledger records, and the ledger is
+ * written ONLY by `scripts/mri-record-suite.ts` from a real Jest run (exit code
+ * + `--json` counts). No hand-editing, so a `pass` is always backed by an
+ * actual green run at a named commit. Absent entry → the report says
+ * `unrecorded` with the recorder command, never a guessed status.
+ */
+
+export interface SuiteLedgerEntry {
+  status: 'pass' | 'fail';
+  /** Passed/failed test counts as reported by Jest. */
+  numPassed?: number;
+  numFailed?: number;
+  /** Domain-specific gap count (e.g. the MINJA red-team GAP count). */
+  gapCount?: number;
+  /** ISO timestamp the run was recorded. */
+  recordedAt: string;
+  /** Git commit the run was recorded at (staleness marker). */
+  commit?: string;
+  note?: string;
+}
+
+export type SuiteLedger = Record<string, SuiteLedgerEntry>;
+
+/** Committed ledger path (produced by `pnpm mri:record-suite`, read at report time). */
+export const DEFAULT_LEDGER_PATH = join('docs', 'mri', 'suite-status.json');
+
+export function loadSuiteLedger(path: string = DEFAULT_LEDGER_PATH): SuiteLedger {
+  if (!existsSync(path)) return {};
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as SuiteLedger;
+    }
+  } catch {
+    // Malformed ledger → treat as empty; the report renders `unrecorded`
+    // rather than crashing or inventing a status.
+  }
+  return {};
+}
+
+/** A structural dimension's binding to the suite(s) that establish it. */
+export interface SuiteSpec {
+  /** Stable ledger key + report dimension binding. */
+  key: string;
+  /** Canonical suite file(s), named in the dimension's `source`. */
+  files: string[];
+  /** Optional design-doc reference. */
+  doc?: string;
+}
+
+export const PREMISE_SUITE: SuiteSpec = {
+  key: 'memtrap-shakedown',
+  files: ['test/memtrap-shakedown.e2e-spec.ts'],
+  doc: 'docs/roadmap/memtrap-shakedown-2026-08.md',
+};
+
+export const POISONING_SUITE: SuiteSpec = {
+  key: 'minja-redteam',
+  files: ['test/memory-injection-redteam.e2e-spec.ts'],
+  doc: 'docs/roadmap/sota-gap-build-2026-08.md',
+};
+
+export const ISOLATION_SUITE: SuiteSpec = {
+  key: 'tenant-user-isolation',
+  files: [
+    'test/user-scope.e2e-spec.ts',
+    'test/user-scope.unit-spec.ts',
+    'test/l0-user-scope.unit-spec.ts',
+    'test/artifacts-user-scope.e2e-spec.ts',
+  ],
+};
+
+export const ALL_SUITE_SPECS: SuiteSpec[] = [PREMISE_SUITE, POISONING_SUITE, ISOLATION_SUITE];

--- a/test/contracts-admin-mri.unit-spec.ts
+++ b/test/contracts-admin-mri.unit-spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Wire-contract drift guard for GET /v1/admin/mri.
+ *
+ * Two-path coverage: a busy window (live cells are numbers, structural cells
+ * carry ledger status) and a cold/empty window (live cells pending, ledger
+ * empty). Both must parse against MriReportSchema — the same drift-gate idiom
+ * as the calibration cockpit.
+ */
+import { MriReportSchema } from '../src/contracts/admin/mri.schema';
+import { buildMriReport } from '../src/mri/mri-collectors';
+import type { CounterSeries, HistogramData, MetricsReader } from '../src/mri/metrics-reader';
+import type { SuiteLedger } from '../src/mri/suite-status';
+
+function stubReader(
+  counters: Record<string, CounterSeries[]>,
+  hist?: HistogramData,
+): MetricsReader {
+  return {
+    counter: (name) => counters[name] ?? [],
+    histogram: (name) => (name === 'brain_search_duration_seconds' ? (hist ?? null) : null),
+  };
+}
+
+const LEDGER: SuiteLedger = {
+  'memtrap-shakedown': { status: 'pass', recordedAt: '2026-08-20T00:00:00.000Z' },
+  'minja-redteam': { status: 'pass', gapCount: 0, recordedAt: '2026-08-20T00:00:00.000Z' },
+  'tenant-user-isolation': { status: 'pass', recordedAt: '2026-08-20T00:00:00.000Z' },
+};
+
+describe('GET /v1/admin/mri — wire contract', () => {
+  it('matches MriReportSchema for a busy window', () => {
+    const reader = stubReader(
+      {
+        brain_synthesize_total: [{ labels: { outcome: 'ok' }, value: 10 }],
+        brain_openai_tokens_total: [{ labels: { kind: 'chat', type: 'prompt' }, value: 1000 }],
+      },
+      {
+        buckets: [
+          { le: 0.1, cumulativeCount: 5 },
+          { le: Number.POSITIVE_INFINITY, cumulativeCount: 10 },
+        ],
+        sum: 1,
+        count: 10,
+      },
+    );
+    const parsed = MriReportSchema.safeParse(buildMriReport(reader, LEDGER, {}));
+    if (!parsed.success) {
+      throw new Error(`MRI (busy) drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+    expect(parsed.data.operatingPoint.sampleCount).toBe(10);
+  });
+
+  it('matches MriReportSchema for a cold/empty window', () => {
+    const parsed = MriReportSchema.safeParse(buildMriReport(stubReader({}), {}, {}));
+    if (!parsed.success) {
+      throw new Error(`MRI (cold) drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+    expect(parsed.data.operatingPoint.accuracyProxy).toBeNull();
+  });
+});

--- a/test/mri-admin.e2e-spec.ts
+++ b/test/mri-admin.e2e-spec.ts
@@ -1,0 +1,62 @@
+/**
+ * GET /v1/admin/mri end-to-end:
+ *   - a brain:admin token gets the MRI report shape (dimensions + operating
+ *     point), parsing against MriReportSchema;
+ *   - a non-admin token gets 404 (indistinguishable from "route not deployed" —
+ *     the focus-admin / EPISODES_API idiom), never 403;
+ *   - no token gets 401.
+ *
+ * Read-only: the endpoint reads the metrics registry + suite-status ledger; it
+ * touches no serving path.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { MriReportSchema } from '../src/contracts/admin/mri.schema';
+
+jest.setTimeout(120_000);
+
+describe('GET /v1/admin/mri (admin-gated, read-only)', () => {
+  let f: AppFixture;
+  let nonAdminKey: string;
+
+  beforeAll(async () => {
+    f = await createApp({ extraKeys: [{ scopes: ['brain:read'] }] });
+    nonAdminKey = f.extraApiKeys[0]!;
+  });
+
+  afterAll(async () => {
+    await f.close();
+  });
+
+  it('returns the MRI report shape for a brain:admin token', async () => {
+    const res = await f.http.get('/v1/admin/mri').set({ Authorization: `Bearer ${f.apiKey}` });
+    expect(res.status).toBe(200);
+    const parsed = MriReportSchema.safeParse(res.body);
+    if (!parsed.success) {
+      throw new Error(`MRI response drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+    expect(typeof parsed.data.generatedAt).toBe('string');
+    expect(Object.keys(parsed.data.dimensions).length).toBeGreaterThan(0);
+    // Eval-gated dims are honestly pending; structural dims are ledger-backed.
+    expect(parsed.data.dimensions.correctness!.value).toBe('pending-eval');
+  });
+
+  it('serves the Part 1 operating point for a brain:admin token', async () => {
+    const res = await f.http
+      .get('/v1/admin/mri/operating-point')
+      .set({ Authorization: `Bearer ${f.apiKey}` });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('accuracyProxy');
+    expect(res.body).toHaveProperty('costPerQuery');
+    expect(res.body).toHaveProperty('sampleCount');
+  });
+
+  it('404s for a non-admin token (indistinguishable from absent)', async () => {
+    const res = await f.http.get('/v1/admin/mri').set({ Authorization: `Bearer ${nonAdminKey}` });
+    expect(res.status).toBe(404);
+  });
+
+  it('401s when unauthenticated', async () => {
+    const res = await f.http.get('/v1/admin/mri');
+    expect(res.status).toBe(401);
+  });
+});

--- a/test/mri-aggregator.unit-spec.ts
+++ b/test/mri-aggregator.unit-spec.ts
@@ -1,0 +1,188 @@
+/**
+ * MRI aggregator (Part 2) — unit coverage with a STUB metrics/source layer.
+ *
+ * Proves the inviolable rule mechanically: free dimensions compute REAL numbers
+ * off the stub telemetry; eval-gated dimensions render `pending-eval`; freshness
+ * renders the F1-blocked reason; structural dimensions render the ledger's
+ * recorded status (or `unrecorded`, never a guessed pass); and every
+ * `pending-eval` / sentinel cell carries a reason.
+ */
+import { buildMriReport } from '../src/mri/mri-collectors';
+import type { CounterSeries, HistogramData, MetricsReader } from '../src/mri/metrics-reader';
+import type { SuiteLedger } from '../src/mri/suite-status';
+
+function stubReader(opts: {
+  counters?: Record<string, CounterSeries[]>;
+  histograms?: Record<string, HistogramData>;
+}): MetricsReader {
+  return {
+    counter: (name) => opts.counters?.[name] ?? [],
+    histogram: (name) => opts.histograms?.[name] ?? null,
+  };
+}
+
+const LATENCY_HIST: HistogramData = {
+  buckets: [
+    { le: 0.05, cumulativeCount: 10 },
+    { le: 0.1, cumulativeCount: 50 },
+    { le: 0.25, cumulativeCount: 90 },
+    { le: 0.5, cumulativeCount: 98 },
+    { le: Number.POSITIVE_INFINITY, cumulativeCount: 100 },
+  ],
+  sum: 12,
+  count: 100,
+};
+
+function busyReader(extra: Record<string, CounterSeries[]> = {}): MetricsReader {
+  return stubReader({
+    counters: {
+      brain_synthesize_total: [
+        { labels: { outcome: 'ok' }, value: 80 },
+        { labels: { outcome: 'verifier_failed' }, value: 20 },
+      ],
+      brain_openai_tokens_total: [
+        { labels: { kind: 'chat', type: 'prompt' }, value: 100_000 },
+        { labels: { kind: 'chat', type: 'completion' }, value: 20_000 },
+        { labels: { kind: 'embed', type: 'prompt' }, value: 5_000 },
+      ],
+      ...extra,
+    },
+    histograms: { brain_search_duration_seconds: LATENCY_HIST },
+  });
+}
+
+const GREEN_LEDGER: SuiteLedger = {
+  'memtrap-shakedown': {
+    status: 'pass',
+    numPassed: 6,
+    numFailed: 0,
+    recordedAt: '2026-08-20T00:00:00.000Z',
+    commit: 'abc1234',
+  },
+  'minja-redteam': { status: 'pass', gapCount: 0, recordedAt: '2026-08-20T00:00:00.000Z' },
+  'tenant-user-isolation': {
+    status: 'pass',
+    numPassed: 12,
+    numFailed: 0,
+    recordedAt: '2026-08-20T00:00:00.000Z',
+  },
+};
+
+describe('buildMriReport — free (live telemetry) dimensions', () => {
+  const report = buildMriReport(busyReader(), GREEN_LEDGER, {
+    now: new Date('2026-08-24T12:00:00.000Z'),
+  });
+
+  it('tokens/query is a real number off the token counters', () => {
+    const d = report.dimensions.tokensPerQuery!;
+    expect(d.value).toBe(1250); // 125,000 tokens / 100 queries
+    expect(d.unit).toBe('tokens/query');
+    expect(d.kind).toBe('live');
+    expect(d.evalGated).toBe(false);
+  });
+
+  it('cost/query is derived from exact token counts × the price table', () => {
+    const d = report.dimensions.costPerQueryUsd!;
+    // (100000*0.15 + 20000*0.6 + 5000*0.02)/1e6 / 100 queries = 0.000271
+    expect(typeof d.value).toBe('number');
+    expect(d.value as number).toBeCloseTo(0.000271, 9);
+    expect(d.unit).toBe('USD/query');
+  });
+
+  it('p50/p95 latency are histogram-quantile numbers', () => {
+    expect(report.dimensions.latencyP50Seconds!.value as number).toBeCloseTo(0.1, 6);
+    expect(report.dimensions.latencyP95Seconds!.value as number).toBeCloseTo(0.40625, 6);
+  });
+
+  it('exposes a live operating point (proxy-accuracy = supported-rate)', () => {
+    const p = report.operatingPoint;
+    expect(p.accuracyProxy).toBeCloseTo(0.8, 6);
+    expect(p.ece).toBeNull();
+    expect(p.sampleCount).toBe(100);
+    expect(p.latencyP95).toBeCloseTo(0.40625, 6);
+  });
+});
+
+describe('buildMriReport — structural (suite-backed) dimensions', () => {
+  it('renders the ledger status for a recorded suite', () => {
+    const report = buildMriReport(busyReader(), GREEN_LEDGER, {});
+    expect(report.dimensions.premiseAwareness!.value).toBe('pass');
+    expect(report.dimensions.premiseAwareness!.kind).toBe('structural');
+    expect(report.dimensions.tenantUserIsolation!.value).toBe('pass');
+    // Poisoning prefers the numeric GAP count (0 = no gaps).
+    expect(report.dimensions.poisoningResistance!.value).toBe(0);
+    expect(report.dimensions.poisoningResistance!.unit).toBe('gaps');
+  });
+
+  it('renders `unrecorded` (never a guessed pass) when the ledger is empty', () => {
+    const report = buildMriReport(busyReader(), {}, {});
+    for (const key of ['premiseAwareness', 'poisoningResistance', 'tenantUserIsolation'] as const) {
+      const d = report.dimensions[key]!;
+      expect(d.value).toBe('unrecorded');
+      expect(d.reason).toMatch(/mri:record-suite/);
+    }
+  });
+
+  it('notes the FOVEA_PLAUSIBILITY_CHECK counter when present', () => {
+    const withCounter = busyReader({
+      brain_fovea_plausibility_downgrade_total: [{ labels: {}, value: 7 }],
+    });
+    const report = buildMriReport(withCounter, GREEN_LEDGER, {});
+    expect(report.dimensions.premiseAwareness!.source).toMatch(/downgrades=7/);
+  });
+});
+
+describe('buildMriReport — pending dimensions carry an honest reason', () => {
+  const report = buildMriReport(busyReader(), GREEN_LEDGER, {});
+
+  it('freshness is F1-blocked (not built here)', () => {
+    const d = report.dimensions.freshnessStaleAnswerRate!;
+    expect(d.value).toBe('pending-eval');
+    expect(d.reason).toMatch(/F1 answer-cache/);
+    expect(d.kind).toBe('pending');
+  });
+
+  it('correctness + abstention are eval-gated', () => {
+    expect(report.dimensions.correctness!.value).toBe('pending-eval');
+    expect(report.dimensions.correctness!.evalGated).toBe(true);
+    expect(report.dimensions.abstentionCalibration!.value).toBe('pending-eval');
+    expect(report.dimensions.abstentionCalibration!.evalGated).toBe(true);
+  });
+
+  it('citation coverage renders pending until the serving path emits the counter', () => {
+    const d = report.dimensions.citationCoverage!;
+    expect(d.value).toBe('pending-eval');
+    expect(d.reason).toMatch(/serving path/);
+  });
+
+  it('citation coverage auto-fills when the counters appear', () => {
+    const withCite = busyReader({
+      brain_synthesize_supported_total: [{ labels: {}, value: 50 }],
+      brain_synthesize_supported_cited_total: [{ labels: {}, value: 45 }],
+    });
+    const d = buildMriReport(withCite, GREEN_LEDGER, {}).dimensions.citationCoverage!;
+    expect(d.value as number).toBeCloseTo(0.9, 6);
+    expect(d.kind).toBe('live');
+  });
+
+  it('every non-numeric sentinel cell carries a reason (the inviolable rule)', () => {
+    for (const d of Object.values(report.dimensions)) {
+      if (typeof d.value === 'string' && (d.value === 'pending-eval' || d.value === 'unrecorded')) {
+        expect(typeof d.reason).toBe('string');
+        expect(d.reason!.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('buildMriReport — empty window never fabricates a number', () => {
+  const report = buildMriReport(stubReader({}), {}, {});
+
+  it('live cells render pending (0 queries), not a fake zero', () => {
+    expect(report.dimensions.tokensPerQuery!.value).toBe('pending-eval');
+    expect(report.dimensions.costPerQueryUsd!.value).toBe('pending-eval');
+    expect(report.dimensions.latencyP95Seconds!.value).toBe('pending-eval');
+    expect(report.operatingPoint.accuracyProxy).toBeNull();
+    expect(report.operatingPoint.sampleCount).toBe(0);
+  });
+});

--- a/test/mri-pareto.unit-spec.ts
+++ b/test/mri-pareto.unit-spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Part 1 economics — operating-point collector, Pareto reporter, advisory
+ * ship-gate, and the telemetry reader / histogram-quantile it rests on.
+ */
+import {
+  collectOperatingPoint,
+  dominates,
+  paretoFrontier,
+  shipGateAdvisory,
+  type PolicyOperatingPoint,
+} from '../src/mri/economics';
+import {
+  histogramQuantile,
+  readerFromPromJson,
+  type PromMetricJson,
+} from '../src/mri/metrics-reader';
+
+function point(over: Partial<PolicyOperatingPoint>): PolicyOperatingPoint {
+  return {
+    flags: [],
+    accuracyProxy: 0.8,
+    ece: null,
+    latencyP50: 0.1,
+    latencyP95: 0.2,
+    costPerQuery: 0.01,
+    sampleCount: 100,
+    ...over,
+  };
+}
+
+const A = point({ flags: ['a'], accuracyProxy: 0.8, latencyP95: 0.2, costPerQuery: 0.01 });
+const B = point({ flags: ['b'], accuracyProxy: 0.7, latencyP95: 0.3, costPerQuery: 0.02 }); // dominated by A
+const C = point({ flags: ['c'], accuracyProxy: 0.9, latencyP95: 0.5, costPerQuery: 0.05 }); // frontier
+const D = point({ flags: ['d'], latencyP95: null, costPerQuery: null }); // missing axes
+
+describe('paretoFrontier', () => {
+  it('separates frontier, dominated, and insufficient-data points', () => {
+    const r = paretoFrontier([A, B, C, D]);
+    expect(r.frontier.map((p) => p.flags[0]).sort()).toEqual(['a', 'c']);
+    expect(r.dominated).toHaveLength(1);
+    expect(r.dominated[0]!.point.flags[0]).toBe('b');
+    expect(r.dominated[0]!.dominatedBy.flags[0]).toBe('a');
+    expect(r.insufficientData.map((p) => p.flags[0])).toEqual(['d']);
+  });
+
+  it('dominates() is true only when weakly-better everywhere + strictly-better once', () => {
+    expect(dominates(A, B)).toBe(true);
+    expect(dominates(A, C)).toBe(false); // A cheaper/faster but lower accuracy
+    expect(dominates(C, A)).toBe(false);
+    expect(dominates(A, D)).toBe(false); // D has null axes
+  });
+});
+
+describe('shipGateAdvisory — advisory only, never blocks', () => {
+  it('flags a dominated candidate but does not block', () => {
+    const g = shipGateAdvisory(B, [A, C]);
+    expect(g.candidateDominated).toBe(true);
+    expect(g.dominatedBy?.flags[0]).toBe('a');
+    expect(g.blocking).toBe(false);
+    expect(g.advisory).toMatch(/DOMINATED/);
+  });
+
+  it('passes a frontier candidate, still non-blocking', () => {
+    const g = shipGateAdvisory(C, [A]);
+    expect(g.candidateDominated).toBe(false);
+    expect(g.blocking).toBe(false);
+  });
+
+  it('reports insufficient data (not a domination verdict) for a null-axis candidate', () => {
+    const g = shipGateAdvisory(D, [A]);
+    expect(g.candidateDominated).toBe(false);
+    expect(g.blocking).toBe(false);
+    expect(g.advisory).toMatch(/no telemetry/);
+  });
+});
+
+describe('collectOperatingPoint — from a telemetry reader', () => {
+  const json: PromMetricJson[] = [
+    {
+      name: 'brain_synthesize_total',
+      type: 'counter',
+      values: [
+        { value: 80, labels: { outcome: 'ok' } },
+        { value: 20, labels: { outcome: 'verifier_failed' } },
+      ],
+    },
+    {
+      name: 'brain_openai_tokens_total',
+      type: 'counter',
+      values: [
+        { value: 100_000, labels: { kind: 'chat', type: 'prompt' } },
+        { value: 20_000, labels: { kind: 'chat', type: 'completion' } },
+        { value: 5_000, labels: { kind: 'embed', type: 'prompt' } },
+      ],
+    },
+    {
+      name: 'brain_search_duration_seconds',
+      type: 'histogram',
+      values: [
+        { value: 10, labels: { le: '0.05' }, metricName: 'brain_search_duration_seconds_bucket' },
+        { value: 50, labels: { le: '0.1' }, metricName: 'brain_search_duration_seconds_bucket' },
+        { value: 90, labels: { le: '0.25' }, metricName: 'brain_search_duration_seconds_bucket' },
+        { value: 98, labels: { le: '0.5' }, metricName: 'brain_search_duration_seconds_bucket' },
+        { value: 100, labels: { le: '+Inf' }, metricName: 'brain_search_duration_seconds_bucket' },
+        { value: 12, labels: {}, metricName: 'brain_search_duration_seconds_sum' },
+        { value: 100, labels: {}, metricName: 'brain_search_duration_seconds_count' },
+      ],
+    },
+  ];
+
+  it('assembles proxy-accuracy, cost, and latency; ece stays null', () => {
+    const p = collectOperatingPoint(readerFromPromJson(json), { flags: ['x'] });
+    expect(p.flags).toEqual(['x']);
+    expect(p.accuracyProxy).toBeCloseTo(0.8, 6);
+    expect(p.ece).toBeNull();
+    expect(p.costPerQuery!).toBeCloseTo(0.000271, 9);
+    expect(p.latencyP50!).toBeCloseTo(0.1, 6);
+    expect(p.latencyP95!).toBeCloseTo(0.40625, 6);
+    expect(p.sampleCount).toBe(100);
+  });
+
+  it('returns nulls (never zeros) for an empty window', () => {
+    const p = collectOperatingPoint(readerFromPromJson([]));
+    expect(p.accuracyProxy).toBeNull();
+    expect(p.costPerQuery).toBeNull();
+    expect(p.latencyP95).toBeNull();
+    expect(p.sampleCount).toBe(0);
+  });
+});
+
+describe('histogramQuantile', () => {
+  it('returns null on an empty histogram', () => {
+    expect(histogramQuantile({ buckets: [], sum: 0, count: 0 }, 0.5)).toBeNull();
+  });
+
+  it('interpolates within the crossing bucket', () => {
+    const hist = readerFromPromJson([
+      {
+        name: 'h',
+        type: 'histogram',
+        values: [
+          { value: 10, labels: { le: '0.05' }, metricName: 'h_bucket' },
+          { value: 50, labels: { le: '0.1' }, metricName: 'h_bucket' },
+          { value: 100, labels: { le: '+Inf' }, metricName: 'h_bucket' },
+          { value: 5, labels: {}, metricName: 'h_sum' },
+          { value: 100, labels: {}, metricName: 'h_count' },
+        ],
+      },
+    ]).histogram('h')!;
+    expect(histogramQuantile(hist, 0.5)).toBeCloseTo(0.1, 6);
+  });
+});


### PR DESCRIPTION
## feat(mri): measurement layer — MRI report + economics Pareto reporter (read-only)

Builds the free scaffolding for the two strategic bets the audit named (bet #2 measurable economics, bet #3 Memory Reliability Index) — turning scattered ingredients into a defined, partially-populated index + cost/accuracy curve. Design doc included (`docs/roadmap/measurable-economics-mri-2026-08.md`).

**Read-only.** New `src/mri/` module only; `synthesize.service.ts` / `verdict.ts` / all lanes / `metrics.service.ts` are **untouched** — the layer reads the Prometheus registry + a suite-status ledger.

### The one rule, honored: never fabricate a number
Every cell is a real value from a live source, a structural result from a named suite, or the literal `pending-eval` with a reason. Measured axes are `number | null` — **null for an empty window, never a fabricated 0**.

| MRI dimension | Kind | Source |
|---|---|---|
| tokens/cost/latency per query | **live** | Prometheus counters/histograms (latency labeled *search-stage* — no e2e synth histogram exists; adding one = serving change) |
| premise-awareness · poisoning-resistance · isolation | **structural** | MemTrap / MINJA / user-scope suites via the ledger (real Jest green + count + commit) |
| citation coverage | **pending** (fwd-compatible) | no supported-with-citation counter exists (adding = serving edit); auto-computes the moment the counter appears |
| freshness/stale-rate | **pending** | "blocked on F1 answer-cache additive-write invalidation" |
| abstention-calibration · correctness | **pending / eval-gated** | needs the parked labeled eval |

### Economics
`PolicyOperatingPoint{flags, accuracyProxy, ece, latencyP50/P95, costPerQuery}`; `accuracyProxy` = verifier `supported`-rate (labeled **proxy** everywhere); `ece` null until labels. `paretoFrontier` flags domination over (accuracy↑, cost↓, latencyP95↓) — weakly-better-on-all + strictly-better-on-≥1; axis-incomplete points → `insufficientData`, never 0. `shipGateAdvisory.blocking` is a literal **false** (advisory only, per the no-spend discipline).

### Surface
- `GET /v1/admin/mri` + `/operating-point` — brain:admin, **404** (not 403) when the scope is absent (focus-admin indistinguishable-from-absent idiom). No serving flag.
- `pnpm mri:report` → `var/mri/latest.{md,json}` (gitignored); `pnpm mri:record-suite` → the only ledger writer (records a real Jest run). Committed ledger deliberately left **absent** → structural dims render `unrecorded` with recorder instructions rather than overclaiming suite status.
- Wire contract pinned by `MriReportSchema` + contract test (admin surface, out of the platform OpenAPI doc, like the calibration cockpit).

### Tests / gates
- MRI unit 48/6 suites (aggregator + Pareto + contract); admin e2e 4/4 on Docker (admin→shape, operating-point→200, non-admin→**404**, unauth→401); full unit suite 2380 green; typecheck / lint:ci / format:check clean; gate goldens (config-catalog-truth, env-validation, engine-gates, openapi-doc) green.

Numbers fill in as telemetry accrues and the ledger is populated by CI; the eval-gated cells fill when the paid accuracy program is un-parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
