### PR TITLE
fix(answer-cache): additive-write freshness probe + hardening (scope-before-cap, new-entity TTL, language-agnostic enum) — audit F1 + R2

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1601,7 +1601,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: true,
     isBooleanFlag: false,
     description:
-      'TTL backstop for SYNTHESIZE_ANSWER_CACHE entries, in hours (positive integer, default 24). An expired entry is a plain miss and is overwritten in place by the next admission; check-on-read remains the correctness backbone — the TTL only bounds how long an entry whose facts never change keeps serving without a fresh synthesis.',
+      "TTL backstop for SYNTHESIZE_ANSWER_CACHE entries, in hours (positive integer, default 24). An expired entry is a plain miss and is overwritten in place by the next admission; check-on-read remains the correctness backbone. It is ALSO the operator-set new-entity staleness bound: the additive-write freshness probe only scans an answer's CITED entities, so a newly-relevant fact on a BRAND-NEW entity (one the original retrieval never touched) cannot be probed without re-retrieval — that residual is bounded, for every cached answer, ONLY by this TTL. Lower it to tighten the new-entity window; there is no claim of full freshness beyond it.",
   },
   {
     key: 'SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS',
@@ -1610,7 +1610,16 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: true,
     isBooleanFlag: false,
     description:
-      "Shorter TTL (hours, positive integer, default 1) for OPEN-ENUMERATION answers in SYNTHESIZE_ANSWER_CACHE — the 'list all X' / counting / ordering shapes. The additive-write freshness probe (audit F1) invalidates a cached answer when a newer fact lands on one of its CITED entities, but an enumeration's new item often lands on an entity that was not yet cited, which the entity-scoped probe cannot see; the short TTL bounds how long such a now-incomplete list keeps serving. Applied as min(this, SYNTHESIZE_ANSWER_CACHE_TTL_HOURS) so it is never longer than the regular TTL.",
+      "Shorter TTL (hours, positive integer, default 1) for OPEN-ENUMERATION answers in SYNTHESIZE_ANSWER_CACHE — the 'list all X' / counting / ordering shapes. The additive-write freshness probe (audit F1) invalidates a cached answer when a newer fact lands on one of its CITED entities, but an enumeration's new item often lands on an entity that was not yet cited, which the entity-scoped probe cannot see; the short TTL bounds how long such a now-incomplete list keeps serving. An answer is treated as enumeration-shaped when the query matches the enumeration lexicon OR — language-agnostically — the answer cites at least SYNTHESIZE_ANSWER_CACHE_ENUM_MIN_CITATIONS facts. Applied as min(this, SYNTHESIZE_ANSWER_CACHE_TTL_HOURS) so it is never longer than the regular TTL.",
+  },
+  {
+    key: 'SYNTHESIZE_ANSWER_CACHE_ENUM_MIN_CITATIONS',
+    category: 'pipeline',
+    defaultValue: '5',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      "Language-agnostic enum guard for SYNTHESIZE_ANSWER_CACHE (positive integer, default 5). The query-shape enum detector keys on English 'list all X' / counting phrasing, so a non-English enumeration would miss the shorter enum TTL despite carrying the same new-entity exposure. This threshold adds a language-independent answer-shape signal: an admitted answer that cites at least this many facts is treated as enumeration-shaped (open list) whatever the query language, and drops to SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS. Raise it to short-TTL only very broad answers; a small factoid answer (few citations) always keeps the regular TTL.",
   },
   {
     key: 'BRAIN_TENANT_OVERRIDE_ENABLED',

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1604,6 +1604,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'TTL backstop for SYNTHESIZE_ANSWER_CACHE entries, in hours (positive integer, default 24). An expired entry is a plain miss and is overwritten in place by the next admission; check-on-read remains the correctness backbone — the TTL only bounds how long an entry whose facts never change keeps serving without a fresh synthesis.',
   },
   {
+    key: 'SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS',
+    category: 'pipeline',
+    defaultValue: '1',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      "Shorter TTL (hours, positive integer, default 1) for OPEN-ENUMERATION answers in SYNTHESIZE_ANSWER_CACHE — the 'list all X' / counting / ordering shapes. The additive-write freshness probe (audit F1) invalidates a cached answer when a newer fact lands on one of its CITED entities, but an enumeration's new item often lands on an entity that was not yet cited, which the entity-scoped probe cannot see; the short TTL bounds how long such a now-incomplete list keeps serving. Applied as min(this, SYNTHESIZE_ANSWER_CACHE_TTL_HOURS) so it is never longer than the regular TTL.",
+  },
+  {
     key: 'BRAIN_TENANT_OVERRIDE_ENABLED',
     category: 'auth',
     defaultValue: '0',

--- a/src/answer-cache/answer-cache.service.ts
+++ b/src/answer-cache/answer-cache.service.ts
@@ -37,9 +37,19 @@ export type InvalidationCause =
   'superseded' | 'retracted' | 'expired_validity' | 'missing' | 'newer_fact';
 
 /** Cap on freshness-probe candidate rows pulled per read. The probe only
- *  needs existence of ONE scope+policy-visible newer fact; a bounded scan
- *  keeps the read cheap, and >cap newer facts on a cited entity is itself
- *  overwhelming evidence of an additive write (fail-closed: invalidate). */
+ *  needs existence of ONE scope+policy-visible newer fact.
+ *
+ *  Gap 1 (cap-before-scope): the DB query applies the user-scope gate in
+ *  SQL, but the ABAC row policy + predicate-scope gate can only be applied
+ *  in JS, AFTER the DB LIMIT. So a naive `LIMIT cap` could hand back `cap`
+ *  rows that the row policy will all discard while a genuinely visible
+ *  newer fact sits beyond the cap — a stale serve. The fix: fetch cap + 1
+ *  and treat a FULL page (> cap candidates) as fail-closed evidence of an
+ *  additive write (invalidate), because the JS fences ran only over the
+ *  returned page and a visible fact could sit past it. A false invalidation
+ *  costs one cache miss; a stale serve is a correctness bug. Under the cap,
+ *  the page is EXHAUSTIVE — every newer fact was seen — so the visible-fact
+ *  check is exact. See hasNewerVisibleFact. */
 const FRESHNESS_PROBE_CAP = 25;
 
 /**
@@ -211,8 +221,17 @@ interface CitedFactRow {
  * fresh synthesis. The `newer_fact` axis (audit F1) closes the additive
  * hole: an answer whose cited facts all stay active is still invalidated
  * when a NEW active fact lands on one of its entities (the cat→dog case).
- * Open-enumeration answers additionally carry a much shorter TTL, since
- * their additive item can land on an entity the probe does not cover.
+ * The probe is fetched cap+1 and a full page fails closed, so a
+ * row-policy-visible newer fact can never be hidden behind a crowd of
+ * fenced-away rows past the cap (hardening gap 1). It only covers the
+ * answer's CITED entities: a newly-relevant fact on a BRAND-NEW entity
+ * cannot be seen without re-retrieval, so that residual is bounded — for
+ * EVERY answer — only by the TTL (the operator-set new-entity staleness
+ * knob, hardening gap 2; no claim of full freshness beyond it).
+ * Open-enumeration answers — detected by query shape OR, language-
+ * agnostically, by a broad cited-fact count (hardening gap 3) —
+ * additionally carry a much shorter TTL, since their additive item most
+ * often lands on an entity the probe does not cover.
  * Fail-closed: there are no events on the serving path, so a lost event
  * can never serve a dead fact. Poisoning posture: admission only from
  * verified grounded answers, per-user key partitioning (NDSS'26
@@ -305,11 +324,24 @@ export class AnswerCacheService {
     ) {
       return;
     }
-    const ttlHours = this.ttlHours(ctx.isEnumeration);
-    const expiresAt = new Date(Date.now() + ttlHours * 3_600_000);
     const answer = result.answer;
     const citedFactIds = result.citations.map((c) => c.factId);
     const entityIds = [...new Set(result.citations.map((c) => c.entityId).filter(Boolean))];
+    // Gap 3 — language-agnostic enum guard. ctx.isEnumeration keys on the
+    // English ENUMERATION_PATTERNS ("list all X" / "how many …"), so a
+    // non-English enumeration (the service answers 12 languages; see
+    // ai/locale/language-detector.ts) misses the short-TTL guard while
+    // carrying the SAME new-entity exposure. Add a LANGUAGE-AGNOSTIC
+    // answer-shape signal that needs no query-language regex: an answer
+    // that enumerated many items (cited-fact count ≥ threshold) is an open
+    // list whatever the query's language, and its next item is exactly the
+    // kind of additive write that lands on a not-yet-cited entity the
+    // freshness probe can't see. Either signal drops the entry to the short
+    // TTL. Off (default threshold) never shortens a small factoid answer.
+    const broadAnswer =
+      citedFactIds.length >= this.readPositiveInt('SYNTHESIZE_ANSWER_CACHE_ENUM_MIN_CITATIONS', 5);
+    const ttlHours = this.ttlHours(ctx.isEnumeration || broadAnswer);
+    const expiresAt = new Date(Date.now() + ttlHours * 3_600_000);
     try {
       await this.surreal.withCompany(ctx.companyId, async (db) => {
         // Record id = queryHash, so re-admission after invalidation or
@@ -362,25 +394,43 @@ export class AnswerCacheService {
   }
 
   /**
-   * TTL in hours. Regular answers get SYNTHESIZE_ANSWER_CACHE_TTL_HOURS
-   * (default 24). Open-enumeration answers ("list all X" / counting /
-   * ordering) get min(regular, SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS,
-   * default 1): an additive write most often adds an item on an entity
-   * NOT among this answer's citations, which the entity-scoped freshness
-   * probe cannot see — so a short TTL bounds how long a now-incomplete
-   * list keeps serving. The min() guarantees the enumeration TTL can only
-   * ever be SHORTER than the regular one, whatever the operator sets.
+   * TTL in hours — the bounded staleness window.
+   *
+   * Gap 2 (the new-entity residual): the freshness probe scans only the
+   * answer's CITED entities. A newly-relevant fact on a BRAND-NEW entity —
+   * one the original retrieval never touched, so it is not in entityIds —
+   * cannot be probed without re-running retrieval, which the cache exists
+   * to avoid. That residual is real for EVERY cached answer (a new entity
+   * is always possible), and it is bounded ONLY by the TTL. So the regular
+   * TTL (SYNTHESIZE_ANSWER_CACHE_TTL_HOURS, default 24) is not just a reaper
+   * — it is the operator-set global new-entity staleness bound. Lower it to
+   * tighten that bound; there is no claim of full freshness beyond it.
+   *
+   * `shortWindow` answers (open enumerations by query shape OR by the
+   * language-agnostic broad-answer signal — see admit()) get
+   * min(regular, SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS, default 1): their
+   * additive item most often lands on an entity NOT among the citations,
+   * exactly the new-entity blind spot, so they carry a tighter bound. The
+   * min() guarantees the short window can only ever be SHORTER than the
+   * regular one, whatever the operator sets.
    */
-  private ttlHours(isEnumeration: boolean): number {
+  private ttlHours(shortWindow: boolean): number {
     const regular = this.readPositiveHours('SYNTHESIZE_ANSWER_CACHE_TTL_HOURS', '24', 24);
-    if (!isEnumeration) return regular;
-    const enumeration = this.readPositiveHours('SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS', '1', 1);
-    return Math.min(regular, enumeration);
+    if (!shortWindow) return regular;
+    const short = this.readPositiveHours('SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS', '1', 1);
+    return Math.min(regular, short);
   }
 
   private readPositiveHours(key: string, dflt: string, fallback: number): number {
     const raw = this.configService.get<string>(key, dflt);
     const v = parseInt(raw ?? dflt, 10);
+    return Number.isFinite(v) && v > 0 ? v : fallback;
+  }
+
+  /** Positive-integer env read with a numeric fallback (invalid → fallback). */
+  private readPositiveInt(key: string, fallback: number): number {
+    const raw = this.configService.get<string>(key, String(fallback));
+    const v = parseInt(raw ?? String(fallback), 10);
     return Number.isFinite(v) && v > 0 ? v : fallback;
   }
 
@@ -538,7 +588,7 @@ export class AnswerCacheService {
               AND status = 'active'
               AND recordedAt > $answerCreatedAt
               ${probeUserGate}
-            LIMIT ${FRESHNESS_PROBE_CAP}`,
+            LIMIT ${FRESHNESS_PROBE_CAP + 1}`,
           {
             ids: ids.map((id) => new StringRecordId(id)),
             entityIds: entityIds.map((id) => new StringRecordId(id)),
@@ -625,9 +675,21 @@ export class AnswerCacheService {
    * candidate newer fact on a cited entity survives the SAME JS-side
    * fences the cited-fact re-check applies (user-scope pin + row policy).
    * The DB query already scoped candidates to the answer's user partition
-   * and to recordedAt newer than the answer's createdAt.
+   * (in SQL) and to recordedAt newer than the answer's createdAt.
+   *
+   * Gap-1 overflow guard (fail-closed): the DB fetched FRESHNESS_PROBE_CAP
+   * + 1 candidates. The ABAC row policy + predicate-scope gate can only be
+   * evaluated here, in JS, AFTER that DB LIMIT — so if the DB returned a
+   * FULL page (> cap rows), more newer facts exist on the cited entities
+   * than we can scope-check, and a row-policy-VISIBLE newer fact could sit
+   * beyond the cap where the fences never reached it. We cannot prove
+   * freshness, so we invalidate. This is what stops the cap from ever
+   * HIDING a visible newer fact behind a crowd of fenced-away rows: a full
+   * page is itself the additive-write signal. Under the cap the page is
+   * exhaustive, so the per-row visible check below is exact.
    */
   private hasNewerVisibleFact(newer: CitedFactRow[], fences: ReadFences): boolean {
+    if (newer.length > FRESHNESS_PROBE_CAP) return true; // full page — fail closed
     for (const f of newer) {
       if (this.fencedAway(f, fences.scopeUserId)) continue; // invisible to this caller
       if (!fences.rowPolicy.filter(f)) continue; // policy-denied — caller can't see it

--- a/src/answer-cache/answer-cache.service.ts
+++ b/src/answer-cache/answer-cache.service.ts
@@ -5,10 +5,11 @@ import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { envFlagEnabled } from '../common/env-validation';
 import { pinUserScope } from '../auth/user-scope';
-import { makeRowPolicyFilter } from '../policy/row-filter';
+import { makeRowPolicyFilter, type RowPolicyFilter } from '../policy/row-filter';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { ReadPinService, type ReadPin } from '../episodes/read-pin.service';
+import { detectEnumerationShape } from '../synthesize/answer-router';
 import type { RetrievalProfile } from '../search/retrieval-profile';
 import type { SynthesizeDto } from '../synthesize/dto/synthesize.dto';
 import type { SynthesizeResult } from '../synthesize/synthesize.types';
@@ -29,24 +30,32 @@ export const ANSWER_CACHE_PROMPT_VERSION = 1;
 /** Table + record-id namespace of the cache rows (migration 0091). */
 const TABLE = 'answer_cache';
 
-/** Mirrors the migration-0091 ASSERT on answer_cache.invalidationCause. */
-export type InvalidationCause = 'superseded' | 'retracted' | 'expired_validity' | 'missing';
+/** Mirrors the migration-0091/0097 ASSERT on answer_cache.invalidationCause.
+ *  `newer_fact` (0097) = the additive-write freshness cause: a NEW active
+ *  fact appeared on a cited entity after the answer was built. */
+export type InvalidationCause =
+  'superseded' | 'retracted' | 'expired_validity' | 'missing' | 'newer_fact';
+
+/** Cap on freshness-probe candidate rows pulled per read. The probe only
+ *  needs existence of ONE scope+policy-visible newer fact; a bounded scan
+ *  keeps the read cheap, and >cap newer facts on a cited entity is itself
+ *  overwhelming evidence of an additive write (fail-closed: invalidate). */
+const FRESHNESS_PROBE_CAP = 25;
 
 /**
- * Exact-match key normalization: NFC unicode form, lowercase, collapsed
- * whitespace, trailing punctuation stripped. Deliberately conservative
- * — two queries share a key only when they are the same question up to
- * typography. NO stemming, NO stopwords, NO embeddings (v1 doctrine:
- * zero false-hit surface by construction).
+ * Exact-match key normalization: Unicode NFC form + whitespace collapse
+ * ONLY. Deliberately conservative — two queries share a key only when
+ * they are byte-identical up to unicode composition and runs of
+ * whitespace. NO case-folding (F1: `getUserById` and `getuserbyid` are
+ * distinct identifiers and must not collide), NO trailing-punctuation
+ * stripping ("do it." vs "do it?" can be different questions), NO
+ * stemming, NO stopwords, NO embeddings (v1 doctrine: zero false-hit
+ * surface by construction). The key already partitions on
+ * company/user/profile/model/prompt-version/derived-pin, so tightening
+ * the text normalization only ever narrows a hit, never widens one.
  */
 export function normalizeQuery(query: string): string {
-  return query
-    .normalize('NFC')
-    .toLowerCase()
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(/[.,;:!?…]+$/u, '')
-    .trim();
+  return query.normalize('NFC').replace(/\s+/g, ' ').trim();
 }
 
 /** Recursively key-sorted JSON — Sets become sorted arrays, undefined
@@ -135,6 +144,10 @@ export interface AnswerCacheStoreContext {
   profileHash: string;
   model: string;
   normalizedQuery: string;
+  /** Open-enumeration query shape ("list all X" / counting / ordering) —
+   *  admit() keys a shorter TTL on it (additive writes on NOT-yet-cited
+   *  entities escape the entity-scoped freshness probe). */
+  isEnumeration: boolean;
 }
 
 export interface AnswerCacheBeginResult {
@@ -149,8 +162,18 @@ interface CacheRow {
   answer: string;
   citedFactIds: string[];
   entityIds: string[];
+  /** Answer admission time — the freshness probe's "newer than" cutoff. */
+  createdAt: Date | string;
   expiresAt: Date | string;
   invalidatedAt?: Date | string | null;
+}
+
+/** The two read fences the fact read path applies, threaded together
+ *  into the cited-fact check and the freshness probe so both enforce the
+ *  IDENTICAL user-scope pin + row policy. */
+interface ReadFences {
+  scopeUserId: string | undefined;
+  rowPolicy: RowPolicyFilter;
 }
 
 interface CitedFactRow {
@@ -175,17 +198,26 @@ interface CitedFactRow {
  * AnswerCacheService — G1 fact-lifecycle-gated answer reuse
  * (docs/roadmap/sota-gap-build-2026-08.md).
  *
- * Serving tier: EXACT normalized-key match only, gated by CHECK-ON-READ
- * — one batch re-read of the cited facts through the same user-scope
- * pin and row-policy fences the fact read path applies. The entry
- * serves only while every cited fact is still `active` and inside its
- * validity window; any failure (superseded / retracted / expired
- * validity / missing-or-fenced) stamps the entry invalidated with its
- * cause and the request falls through to fresh synthesis. Fail-closed:
- * there are no events on the serving path, so a lost event can never
- * serve a dead fact. Poisoning posture: admission only from verified
- * grounded answers, per-user key partitioning (NDSS'26 semantic-cache
- * poisoning + CacheAttack both exploit shared/unverified admission).
+ * Serving tier: EXACT normalized-key match only (NFC + whitespace-
+ * collapse; case- and punctuation-preserving so distinct identifiers
+ * never collide), gated by CHECK-ON-READ — one batch re-read of the
+ * cited facts PLUS an additive-write freshness probe, all through the
+ * same user-scope pin and row-policy fences the fact read path applies.
+ * The entry serves only while every cited fact is still `active` and
+ * inside its validity window AND no newer visible fact has appeared on a
+ * cited entity since the answer was built; any failure (superseded /
+ * retracted / expired validity / missing-or-fenced / newer_fact) stamps
+ * the entry invalidated with its cause and the request falls through to
+ * fresh synthesis. The `newer_fact` axis (audit F1) closes the additive
+ * hole: an answer whose cited facts all stay active is still invalidated
+ * when a NEW active fact lands on one of its entities (the cat→dog case).
+ * Open-enumeration answers additionally carry a much shorter TTL, since
+ * their additive item can land on an entity the probe does not cover.
+ * Fail-closed: there are no events on the serving path, so a lost event
+ * can never serve a dead fact. Poisoning posture: admission only from
+ * verified grounded answers, per-user key partitioning (NDSS'26
+ * semantic-cache poisoning + CacheAttack both exploit shared/unverified
+ * admission).
  *
  * v2 (deferred by design): embedding-similarity candidates promoted to
  * servable only after async judge verification — never served
@@ -273,7 +305,7 @@ export class AnswerCacheService {
     ) {
       return;
     }
-    const ttlHours = this.ttlHours();
+    const ttlHours = this.ttlHours(ctx.isEnumeration);
     const expiresAt = new Date(Date.now() + ttlHours * 3_600_000);
     const answer = result.answer;
     const citedFactIds = result.citations.map((c) => c.factId);
@@ -329,10 +361,27 @@ export class AnswerCacheService {
     }
   }
 
-  private ttlHours(): number {
-    const raw = this.configService.get<string>('SYNTHESIZE_ANSWER_CACHE_TTL_HOURS', '24');
-    const v = parseInt(raw, 10);
-    return Number.isFinite(v) && v > 0 ? v : 24;
+  /**
+   * TTL in hours. Regular answers get SYNTHESIZE_ANSWER_CACHE_TTL_HOURS
+   * (default 24). Open-enumeration answers ("list all X" / counting /
+   * ordering) get min(regular, SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS,
+   * default 1): an additive write most often adds an item on an entity
+   * NOT among this answer's citations, which the entity-scoped freshness
+   * probe cannot see — so a short TTL bounds how long a now-incomplete
+   * list keeps serving. The min() guarantees the enumeration TTL can only
+   * ever be SHORTER than the regular one, whatever the operator sets.
+   */
+  private ttlHours(isEnumeration: boolean): number {
+    const regular = this.readPositiveHours('SYNTHESIZE_ANSWER_CACHE_TTL_HOURS', '24', 24);
+    if (!isEnumeration) return regular;
+    const enumeration = this.readPositiveHours('SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS', '1', 1);
+    return Math.min(regular, enumeration);
+  }
+
+  private readPositiveHours(key: string, dflt: string, fallback: number): number {
+    const raw = this.configService.get<string>(key, dflt);
+    const v = parseInt(raw ?? dflt, 10);
+    return Number.isFinite(v) && v > 0 ? v : fallback;
   }
 
   private async buildContext(
@@ -382,6 +431,7 @@ export class AnswerCacheService {
       profileHash,
       model: opts.model,
       normalizedQuery,
+      isEnumeration: detectEnumerationShape(normalizedQuery),
     };
   }
 
@@ -395,7 +445,7 @@ export class AnswerCacheService {
       // clause double-fences both (a user-scoped query must never hit
       // a global entry and vice versa).
       const [rows] = await db.query<[CacheRow[]]>(
-        `SELECT id, answer, citedFactIds, entityIds, expiresAt,
+        `SELECT id, answer, citedFactIds, entityIds, createdAt, expiresAt,
                 invalidatedAt
            FROM type::record($tb, $key)
           WHERE companyId = $companyId
@@ -434,13 +484,20 @@ export class AnswerCacheService {
   }
 
   /**
-   * CHECK-ON-READ — the correctness core. One batch SELECT of the
-   * cited facts through the SAME fences the fact read path applies
-   * (facts.service.ts loadVisibleFact): user-scope pin via
+   * CHECK-ON-READ — the correctness core. One batch SELECT of (1) the
+   * cited facts, (2) their entity names, and (3) the ADDITIVE-WRITE
+   * freshness probe — all through the SAME fences the fact read path
+   * applies (facts.service.ts loadVisibleFact): user-scope pin via
    * pinUserScope + registry-backed row policy via makeRowPolicyFilter.
-   * Fail-closed: a fact that is absent OR fenced away from this caller
-   * is 'missing' (indistinguishable by design — existence never
-   * leaks); any fence uncertainty is a miss, never a serve.
+   *
+   * The entry serves only when EVERY cited fact is still active + valid
+   * AND no newer visible fact has appeared on a cited entity since the
+   * answer was built. Fail-closed on both axes: a cited fact that is
+   * absent OR fenced away is 'missing' (existence never leaks); a newer
+   * scope+policy-visible fact on a cited entity is 'newer_fact' (audit
+   * F1 — the additive cat→dog case: the cited 'cat' fact stays active,
+   * but a 'dog' fact was added, so the cached answer is stale). Any fence
+   * uncertainty is a miss, never a serve.
    */
   private async checkOnRead(
     ctx: AnswerCacheStoreContext,
@@ -449,24 +506,51 @@ export class AnswerCacheService {
   ): Promise<{ cause: InvalidationCause } | { citations: Citation[] }> {
     const ids = row.citedFactIds ?? [];
     if (ids.length === 0) return { cause: 'missing' };
-    const { facts, names } = await this.surreal.withScopedCompany(
+    const entityIds = row.entityIds ?? [];
+    const answerCreatedAt =
+      row.createdAt instanceof Date ? row.createdAt : new Date(String(row.createdAt));
+    // Freshness-probe user gate — mirrors the retrieval where-builder
+    // EXACTLY (search/internals/where-builder.ts): a user-scoped answer
+    // saw global + its OWN facts; a tenant-global answer saw global only.
+    // This DB-level gate (keyed on the answer's ctx.userId partition) is
+    // what keeps an M2M answer for user_a immune to a new user_b fact and
+    // a global answer immune to any per-user fact — the probe can only
+    // fire on a fact the answer's scope would actually have retrieved.
+    const probeUserGate = ctx.userId
+      ? 'AND (userId IS NONE OR userId = $probeScopeUserId)'
+      : 'AND userId IS NONE';
+    const { facts, names, newer } = await this.surreal.withScopedCompany(
       ctx.companyId,
       callerScopes,
       async (db) => {
-        const [factRows, entityRows] = await db.query<
-          [CitedFactRow[], Array<{ id: unknown; canonicalName: string }>]
+        const [factRows, entityRows, newerRows] = await db.query<
+          [CitedFactRow[], Array<{ id: unknown; canonicalName: string }>, CitedFactRow[]]
         >(
           `SELECT id, predicate, object, entityId, status, validUntil,
                   retractedAt, userId, source, trustSnapshot, corroboration
              FROM knowledge_fact WHERE id INSIDE $ids;
            SELECT id, canonicalName FROM knowledge_entity
-            WHERE id INSIDE $entityIds`,
+            WHERE id INSIDE $entityIds;
+           SELECT id, predicate, object, entityId, status, userId, source,
+                  trustSnapshot, corroboration
+             FROM knowledge_fact
+            WHERE entityId INSIDE $entityIds
+              AND status = 'active'
+              AND recordedAt > $answerCreatedAt
+              ${probeUserGate}
+            LIMIT ${FRESHNESS_PROBE_CAP}`,
           {
             ids: ids.map((id) => new StringRecordId(id)),
-            entityIds: (row.entityIds ?? []).map((id) => new StringRecordId(id)),
+            entityIds: entityIds.map((id) => new StringRecordId(id)),
+            answerCreatedAt,
+            ...(ctx.userId ? { probeScopeUserId: ctx.userId } : {}),
           },
         );
-        return { facts: factRows ?? [], names: entityRows ?? [] };
+        return {
+          facts: factRows ?? [],
+          names: entityRows ?? [],
+          newer: newerRows ?? [],
+        };
       },
     );
     const byId = new Map(facts.map((f) => [String(f.id), f]));
@@ -479,44 +563,51 @@ export class AnswerCacheService {
       surface: 'answer_cache_read',
       policyLookup: await this.predicateRegistry?.rowPolicyLookup(ctx.companyId),
     });
+    const fences: ReadFences = { scopeUserId, rowPolicy };
+    const cited = this.evaluateCitedFacts(ids, { byId, nameById }, fences);
+    // Additive-write freshness probe (audit F1) runs ONLY when every cited
+    // fact still validated — a more specific lifecycle cause
+    // (retracted/superseded/…) takes precedence over 'newer_fact' for
+    // observability. A newer visible fact on a cited entity means the
+    // store changed under this answer: fail closed to a fresh synthesis.
+    const result: { cause: InvalidationCause } | { citations: Citation[] } =
+      'cause' in cited
+        ? cited
+        : this.hasNewerVisibleFact(newer, fences)
+          ? { cause: 'newer_fact' }
+          : cited;
+    rowPolicy.finish();
+    return result;
+  }
+
+  /**
+   * Per-cited-fact lifecycle gate (extracted from checkOnRead). Every
+   * cited fact must be visible under the user-scope + row-policy fences
+   * AND still `active` inside its validity window; the FIRST failure
+   * returns its cause, fail-closed. On success the citations are rebuilt
+   * from the LIVE fact rows.
+   */
+  private evaluateCitedFacts(
+    ids: string[],
+    lookups: { byId: Map<string, CitedFactRow>; nameById: Map<string, string> },
+    fences: ReadFences,
+  ): { cause: InvalidationCause } | { citations: Citation[] } {
+    const { byId, nameById } = lookups;
+    const { scopeUserId, rowPolicy } = fences;
     const citations: Citation[] = [];
-    let cause: InvalidationCause | undefined;
     for (const id of ids) {
       const fact = byId.get(id);
-      if (!fact) {
-        cause = 'missing';
-        break;
+      if (!fact) return { cause: 'missing' };
+      // fenced/denied = absent (existence never leaks to a caller).
+      if (this.fencedAway(fact, scopeUserId) || !rowPolicy.filter(fact)) {
+        return { cause: 'missing' };
       }
-      if (
-        scopeUserId !== undefined &&
-        typeof fact.userId === 'string' &&
-        fact.userId.length > 0 &&
-        fact.userId !== scopeUserId
-      ) {
-        cause = 'missing'; // fenced = absent, existence never leaks
-        break;
-      }
-      if (!rowPolicy.filter(fact)) {
-        cause = 'missing';
-        break;
-      }
-      if (fact.status === 'retracted' || fact.retractedAt) {
-        cause = 'retracted';
-        break;
-      }
-      if (fact.status === 'superseded') {
-        cause = 'superseded';
-        break;
-      }
-      if (fact.status !== 'active') {
-        // competing/compacted — the fact left the servable lifecycle
-        // state the answer was verified against; fail closed.
-        cause = 'missing';
-        break;
-      }
+      if (fact.status === 'retracted' || fact.retractedAt) return { cause: 'retracted' };
+      if (fact.status === 'superseded') return { cause: 'superseded' };
+      // competing/compacted — left the servable lifecycle state; fail closed.
+      if (fact.status !== 'active') return { cause: 'missing' };
       if (fact.validUntil && toMs(fact.validUntil) <= Date.now()) {
-        cause = 'expired_validity';
-        break;
+        return { cause: 'expired_validity' };
       }
       citations.push({
         factId: id,
@@ -526,8 +617,37 @@ export class AnswerCacheService {
         object: fact.object,
       });
     }
-    rowPolicy.finish();
-    return cause ? { cause } : { citations };
+    return { citations };
+  }
+
+  /**
+   * Additive-write freshness probe (audit F1): true when at least one
+   * candidate newer fact on a cited entity survives the SAME JS-side
+   * fences the cited-fact re-check applies (user-scope pin + row policy).
+   * The DB query already scoped candidates to the answer's user partition
+   * and to recordedAt newer than the answer's createdAt.
+   */
+  private hasNewerVisibleFact(newer: CitedFactRow[], fences: ReadFences): boolean {
+    for (const f of newer) {
+      if (this.fencedAway(f, fences.scopeUserId)) continue; // invisible to this caller
+      if (!fences.rowPolicy.filter(f)) continue; // policy-denied — caller can't see it
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Shared user-scope fence (loadVisibleFact semantics): a fact bound to
+   * ANOTHER user is invisible — existence never leaks. M2M (scopeUserId
+   * undefined) sees all. Used by both the cited-fact check and the probe.
+   */
+  private fencedAway(fact: { userId?: string | null }, scopeUserId: string | undefined): boolean {
+    return (
+      scopeUserId !== undefined &&
+      typeof fact.userId === 'string' &&
+      fact.userId.length > 0 &&
+      fact.userId !== scopeUserId
+    );
   }
 
   private async invalidate(ctx: AnswerCacheStoreContext, cause: InvalidationCause): Promise<void> {

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -145,6 +145,7 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
 
   // ── G1 answer cache (fact-lifecycle-gated answer reuse) ────────────
   positiveInt(env, 'SYNTHESIZE_ANSWER_CACHE_TTL_HOURS', errors);
+  positiveInt(env, 'SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS', errors);
 
   // ── Agent-in-loop QA ───────────────────────────────────────────────
   positiveInt(env, 'AGENT_QA_MAX_ROUNDS', errors);

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -146,6 +146,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // ── G1 answer cache (fact-lifecycle-gated answer reuse) ────────────
   positiveInt(env, 'SYNTHESIZE_ANSWER_CACHE_TTL_HOURS', errors);
   positiveInt(env, 'SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS', errors);
+  // Language-agnostic enum guard: cited-fact count at which an answer is
+  // treated as enumeration-shaped (short TTL) regardless of query language.
+  positiveInt(env, 'SYNTHESIZE_ANSWER_CACHE_ENUM_MIN_CITATIONS', errors);
 
   // ── Agent-in-loop QA ───────────────────────────────────────────────
   positiveInt(env, 'AGENT_QA_MAX_ROUNDS', errors);

--- a/src/db/migrations/0097_answer_cache_newer_fact.surql
+++ b/src/db/migrations/0097_answer_cache_newer_fact.surql
@@ -1,0 +1,20 @@
+-- 0097: widen answer_cache.invalidationCause with 'newer_fact' — the
+-- additive-write freshness cause (audit F1, docs/roadmap/
+-- measurable-economics-mri-2026-08.md freshness dimension).
+--
+-- The 0091 check-on-read only re-validated the facts a cached answer
+-- already CITED, so an ADDITIVE write — a NEW active fact on a cited
+-- entity, with none of the cited facts touched — could not invalidate a
+-- now-stale/incomplete answer (it lived until expiresAt). The read-side
+-- freshness probe (answer-cache.service.ts checkOnRead) now also looks
+-- for any active fact on the cited answer's entities whose recordedAt is
+-- newer than the answer's createdAt, under the SAME user-scope + row-
+-- policy fences as the cited-fact re-check; a match stamps this cause and
+-- falls through to a fresh synthesis. Fail-closed: a false probe hit
+-- costs one cache miss, never a stale serve.
+--
+-- OVERWRITE (not a fresh field) so the ASSERT set gains 'newer_fact'
+-- while every other column definition from 0091 is untouched.
+DEFINE FIELD OVERWRITE invalidationCause ON answer_cache TYPE option<string>
+  ASSERT $value = NONE
+      OR $value INSIDE ['superseded', 'retracted', 'expired_validity', 'missing', 'newer_fact'];

--- a/src/synthesize/answer-router.ts
+++ b/src/synthesize/answer-router.ts
@@ -92,6 +92,17 @@ const ENUMERATION_PATTERNS: RegExp[] = [
 ];
 
 /**
+ * Open-enumeration shape — the "list all X / how many / order" family
+ * whose answer set GROWS with additive writes (a new item on a NOT-yet-
+ * cited entity that the entity-scoped freshness probe cannot see). The
+ * answer cache keys a much shorter TTL on this so those answers do not
+ * outlive the next write. Shares ENUMERATION_PATTERNS with the routing
+ * lane; profile-independent (offline/pure), like detectOrderingShape. */
+export function detectEnumerationShape(query: string): boolean {
+  return ENUMERATION_PATTERNS.some((p) => p.test(query ?? ''));
+}
+
+/**
  * T4 preference/recommendation questions: the failure mode is a generic
  * suggestion that ignores stored preferences (PrefEval: verbatim
  * preference injection beats CoT — the fix is retrieval + conditioning,

--- a/test/answer-cache.e2e-spec.ts
+++ b/test/answer-cache.e2e-spec.ts
@@ -86,14 +86,16 @@ describe('G1 answer cache e2e', () => {
     expect(afterStore).toHaveLength(1);
     expect(afterStore[0]!.hitCount).toBe(0);
 
-    // Second identical query (typographic variant): served from the
-    // cache — the scripted DIFFERENT answer must never surface, and
-    // the OpenAI stub must never be called.
+    // Second query, a WHITESPACE-only variant (leading/trailing/internal
+    // runs collapse under NFC + whitespace normalization): served from
+    // the cache — the scripted DIFFERENT answer must never surface, and
+    // the OpenAI stub must never be called. Case/punctuation now DO
+    // partition the key (F1), so the variant keeps both identical.
     const state2 = mockRound('A DIFFERENT answer that must not surface.', factId);
     const res2 = await f.http
       .post('/v1/synthesize')
       .set(auth())
-      .send({ query: `  ${QUERY.toUpperCase()}?`, limit: 5 });
+      .send({ query: '   tier:    sapphire-crest  ', limit: 5 });
     expect(res2.status).toBe(201);
     expect(res2.body.cached).toBe(true);
     expect(res2.body.answer).toBe('The tier is sapphire-crest.');
@@ -175,5 +177,121 @@ describe('G1 answer cache e2e', () => {
 
     const userRows = (await cacheRows()).filter((r) => r.userId);
     expect(userRows.map((r) => r.userId).sort()).toEqual(['user_a', 'user_b']);
+  });
+
+  it('additive write on a cited entity → freshness probe invalidates (newer_fact) and re-synthesizes', async () => {
+    // Cited fact on entity E (the cat→dog scenario's "cat").
+    const ingest = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'cust_answer_cache_additive' },
+        predicate: 'tier',
+        object: 'topaz-01',
+        validFrom: new Date('2026-04-03').toISOString(),
+        source: { vertical: 'rent', messageId: 'm_ac_add_1' },
+        confidence: 0.9,
+      });
+    const addFactId = ingest.body.factId as string;
+    expect(addFactId).toBeTruthy();
+    const addQuery = 'tier: topaz-01';
+
+    // 1) miss → store.
+    mockRound('Additive tier is topaz-01.', addFactId);
+    const r1 = await f.http.post('/v1/synthesize').set(auth()).send({ query: addQuery, limit: 5 });
+    expect(r1.status).toBe(201);
+    expect(r1.body.cached).toBeUndefined();
+    expect(r1.body.answer).toBe('Additive tier is topaz-01.');
+
+    // 2) identical read serves cached — no additive write yet (the
+    //    freshness probe must NOT over-invalidate a still-fresh answer).
+    const s2 = mockRound('MUST NOT SURFACE (no additive write yet).', addFactId);
+    const r2 = await f.http.post('/v1/synthesize').set(auth()).send({ query: addQuery, limit: 5 });
+    expect(r2.status).toBe(201);
+    expect(r2.body.cached).toBe(true);
+    expect(r2.body.answer).toBe('Additive tier is topaz-01.');
+    expect(s2.calls.length).toBe(0);
+
+    // 3) ADDITIVE write: a NEW active fact on the SAME entity, a DIFFERENT
+    //    predicate — the cited 'tier' fact stays active (nothing cited is
+    //    touched), exactly the case the cited-fact re-check cannot catch.
+    const add2 = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'cust_answer_cache_additive' },
+        predicate: 'plan',
+        object: 'premium',
+        validFrom: new Date('2026-04-10').toISOString(),
+        source: { vertical: 'rent', messageId: 'm_ac_add_2' },
+        confidence: 0.9,
+      });
+    expect(add2.body.factId).toBeTruthy();
+
+    // 4) read again: the entity-scoped freshness probe finds the newer
+    //    fact → MISS (the stale cached answer must NOT surface) → a fresh
+    //    synthesis runs (generator + verifier both called).
+    const s4 = mockRound('Fresh answer after the additive write.', addFactId);
+    const r4 = await f.http.post('/v1/synthesize').set(auth()).send({ query: addQuery, limit: 5 });
+    expect(r4.status).toBe(201);
+    expect(r4.body.cached).toBeUndefined();
+    expect(r4.body.answer).toBe('Fresh answer after the additive write.');
+    expect(s4.calls.length).toBe(2);
+  });
+
+  it('M2M explicit-user scope: a new fact for another user does not invalidate a user-scoped hit', async () => {
+    // User A's answer cites a fact scoped to scope_user_a on entity E.
+    const ingest = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'cust_answer_cache_scope' },
+        predicate: 'tier',
+        object: 'jade-07',
+        validFrom: new Date('2026-04-04').toISOString(),
+        source: { vertical: 'rent', messageId: 'm_ac_scope_1' },
+        confidence: 0.9,
+        userId: 'scope_user_a',
+      });
+    const aFactId = ingest.body.factId as string;
+    expect(aFactId).toBeTruthy();
+    const scopeQuery = 'tier: jade-07';
+
+    mockRound('Jade-07 for user A.', aFactId);
+    const rA1 = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: scopeQuery, limit: 5, userId: 'scope_user_a' });
+    expect(rA1.status).toBe(201);
+    expect(rA1.body.cached).toBeUndefined();
+
+    // A NEW active fact on the SAME entity but for a DIFFERENT user — out
+    // of user A's scope (the retrieval that built A's answer never saw it).
+    const addB = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'cust_answer_cache_scope' },
+        predicate: 'plan',
+        object: 'gold',
+        validFrom: new Date('2026-04-11').toISOString(),
+        source: { vertical: 'rent', messageId: 'm_ac_scope_2' },
+        confidence: 0.9,
+        userId: 'scope_user_b',
+      });
+    expect(addB.body.factId).toBeTruthy();
+
+    // User A reads again: the probe's user gate excludes user B's fact, so
+    // it does NOT fire — the cached answer still serves (no cross-scope
+    // invalidation).
+    const sA2 = mockRound('MUST NOT SURFACE (cross-scope fact).', aFactId);
+    const rA2 = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: scopeQuery, limit: 5, userId: 'scope_user_a' });
+    expect(rA2.status).toBe(201);
+    expect(rA2.body.cached).toBe(true);
+    expect(rA2.body.answer).toBe('Jade-07 for user A.');
+    expect(sA2.calls.length).toBe(0);
   });
 });

--- a/test/answer-cache.unit-spec.ts
+++ b/test/answer-cache.unit-spec.ts
@@ -24,12 +24,19 @@ import {
 // ── Key construction ───────────────────────────────────────────────
 
 describe('normalizeQuery', () => {
-  it('lowercases and collapses whitespace', () => {
-    expect(normalizeQuery('  What   Is\tThe  Plan ')).toBe('what is the plan');
+  it('collapses whitespace and trims, preserving case', () => {
+    // F1: NFC + whitespace-collapse ONLY — case is preserved.
+    expect(normalizeQuery('  What   Is\tThe  Plan ')).toBe('What Is The Plan');
   });
 
-  it('strips trailing punctuation only', () => {
-    expect(normalizeQuery('what is the plan?!…')).toBe('what is the plan');
+  it('preserves case so distinct-case identifiers do not collide', () => {
+    // getUserById vs getuserbyid are different symbols — must not fold.
+    expect(normalizeQuery('getUserById')).toBe('getUserById');
+    expect(normalizeQuery('getUserById')).not.toBe(normalizeQuery('getuserbyid'));
+  });
+
+  it('preserves punctuation (no trailing-punctuation stripping)', () => {
+    expect(normalizeQuery('what is the plan?!…')).toBe('what is the plan?!…');
     expect(normalizeQuery('what, is: the plan')).toBe('what, is: the plan');
   });
 
@@ -85,8 +92,22 @@ describe('computeCacheKey', () => {
     query: 'what is the plan',
   };
 
-  it('normalization makes typographic variants share a key', () => {
-    expect(computeCacheKey({ ...base, query: '  What IS the   plan?' })).toBe(
+  it('whitespace-only variants share a key (NFC + whitespace collapse)', () => {
+    expect(computeCacheKey({ ...base, query: '  what   is the  plan  ' })).toBe(
+      computeCacheKey(base),
+    );
+  });
+
+  it('case-only variants produce DIFFERENT keys (F1: no case-folding)', () => {
+    const key = computeCacheKey(base);
+    expect(computeCacheKey({ ...base, query: 'What IS the plan' })).not.toBe(key);
+    expect(computeCacheKey({ ...base, query: 'getUserById' })).not.toBe(
+      computeCacheKey({ ...base, query: 'getuserbyid' }),
+    );
+  });
+
+  it('trailing-punctuation variants produce DIFFERENT keys (no strip)', () => {
+    expect(computeCacheKey({ ...base, query: 'what is the plan?' })).not.toBe(
       computeCacheKey(base),
     );
   });
@@ -119,16 +140,21 @@ interface QueryCall {
 function makeHarness(opts: {
   flag?: string;
   ttl?: string;
+  enumTtl?: string;
   cacheRow?: Record<string, unknown> | null;
   factRows?: Array<Record<string, unknown>>;
   entityRows?: Array<Record<string, unknown>>;
+  /** Freshness-probe candidate rows (3rd statement of the check-on-read
+   *  batch) — active facts on a cited entity newer than the answer. */
+  probeRows?: Array<Record<string, unknown>>;
 }) {
   const calls: QueryCall[] = [];
   const db = {
     query: async (sql: string, params: Record<string, unknown> = {}) => {
       calls.push({ sql, params });
       if (/FROM knowledge_fact/.test(sql)) {
-        return [opts.factRows ?? [], opts.entityRows ?? []];
+        // check-on-read batch: [cited facts, entity names, newer-fact probe].
+        return [opts.factRows ?? [], opts.entityRows ?? [], opts.probeRows ?? []];
       }
       if (/^\s*SELECT/.test(sql)) {
         return [opts.cacheRow ? [opts.cacheRow] : []];
@@ -146,7 +172,9 @@ function makeHarness(opts: {
         ? (opts.flag ?? '1')
         : key === 'SYNTHESIZE_ANSWER_CACHE_TTL_HOURS'
           ? (opts.ttl ?? dflt)
-          : dflt,
+          : key === 'SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS'
+            ? (opts.enumTtl ?? dflt)
+            : dflt,
   } as unknown as ConfigService;
   const outcomes: string[] = [];
   const metrics = {
@@ -175,8 +203,24 @@ function liveCacheRow(over: Record<string, unknown> = {}) {
     answer: 'Acme is gold tier.',
     citedFactIds: ['knowledge_fact:f1'],
     entityIds: ['knowledge_entity:e1'],
+    createdAt: new Date(Date.now() - 3_600_000),
     expiresAt: new Date(Date.now() + 3_600_000),
     invalidatedAt: null,
+    ...over,
+  };
+}
+
+/** A newer active fact on the cited entity — the additive-write signal.
+ *  (The mocked DB returns these verbatim as the probe result; the real
+ *  `recordedAt > createdAt` filtering is exercised in the e2e twin.) */
+function newerFact(over: Record<string, unknown> = {}) {
+  return {
+    id: 'knowledge_fact:f2',
+    predicate: 'pet',
+    object: 'dog',
+    entityId: 'knowledge_entity:e1',
+    status: 'active',
+    userId: null,
     ...over,
   };
 }
@@ -342,6 +386,82 @@ describe('AnswerCacheService.begin — check-on-read rejection matrix', () => {
   });
 });
 
+describe('AnswerCacheService.begin — additive-write freshness probe (F1)', () => {
+  it('newer active fact on a cited entity → rejected_stale, cause=newer_fact, miss', async () => {
+    // The cat→dog case: the cited fact ('cat') stays active, but a new
+    // ('dog') fact landed on the same entity → the cached answer is stale.
+    const h = makeHarness({
+      cacheRow: liveCacheRow(),
+      factRows: [activeFact()], // cited fact still active
+      entityRows: [{ id: 'knowledge_entity:e1', canonicalName: 'Acme' }],
+      probeRows: [newerFact()], // additive write on the cited entity
+    });
+    const out = await h.svc.begin(beginArgs());
+    expect(out?.hit).toBeUndefined();
+    expect(out?.ctx).toBeDefined(); // falls through to fresh synthesis
+    const invalidation = h.calls.find((c) => /invalidatedAt = time::now\(\)/.test(c.sql));
+    expect(invalidation?.params.cause).toBe('newer_fact');
+    expect(h.outcomes).toEqual(['rejected_stale']);
+  });
+
+  it('no newer fact → serves the hit (probe never over-invalidates)', async () => {
+    const h = makeHarness({
+      cacheRow: liveCacheRow(),
+      factRows: [activeFact()],
+      entityRows: [{ id: 'knowledge_entity:e1', canonicalName: 'Acme' }],
+      probeRows: [], // no additive write
+    });
+    const out = await h.svc.begin(beginArgs());
+    expect(out?.hit?.cached).toBe(true);
+    expect(out?.hit?.answer).toBe('Acme is gold tier.');
+    expect(h.outcomes).toEqual(['hit']);
+    expect(h.calls.some((c) => /invalidatedAt = time::now\(\)/.test(c.sql))).toBe(false);
+  });
+
+  it('probe query scopes to the answer partition (user-pinned → global + own)', async () => {
+    // Needs a live row so check-on-read (and its probe) actually runs.
+    const h = makeHarness({
+      cacheRow: liveCacheRow(),
+      factRows: [activeFact()],
+      entityRows: [{ id: 'knowledge_entity:e1', canonicalName: 'Acme' }],
+    });
+    await h.svc.begin(beginArgs({ userId: 'user_a' }));
+    const probe = h.calls.find((c) => /recordedAt > \$answerCreatedAt/.test(c.sql));
+    expect(probe).toBeDefined();
+    // A user-pinned answer's probe sees global + its OWN facts only — a
+    // new user_b fact is out of scope and cannot cross-invalidate it.
+    expect(probe!.sql).toContain('(userId IS NONE OR userId = $probeScopeUserId)');
+    expect(probe!.params.probeScopeUserId).toBe('user_a');
+  });
+
+  it('probe query scopes a tenant-global answer to global facts only', async () => {
+    const h = makeHarness({
+      cacheRow: liveCacheRow(),
+      factRows: [activeFact()],
+      entityRows: [{ id: 'knowledge_entity:e1', canonicalName: 'Acme' }],
+    });
+    await h.svc.begin(beginArgs()); // no userId → tenant-global (M2M)
+    const probe = h.calls.find((c) => /recordedAt > \$answerCreatedAt/.test(c.sql));
+    expect(probe).toBeDefined();
+    expect(probe!.sql).toContain('AND userId IS NONE');
+    expect(probe!.sql).not.toContain('$probeScopeUserId');
+  });
+
+  it('a more specific lifecycle cause wins over newer_fact', async () => {
+    // A retracted cited fact AND a newer fact: the retraction is reported
+    // (the probe never runs once a cited fact already failed).
+    const h = makeHarness({
+      cacheRow: liveCacheRow(),
+      factRows: [activeFact({ status: 'retracted' })],
+      entityRows: [{ id: 'knowledge_entity:e1', canonicalName: 'Acme' }],
+      probeRows: [newerFact()],
+    });
+    await h.svc.begin(beginArgs());
+    const invalidation = h.calls.find((c) => /invalidatedAt = time::now\(\)/.test(c.sql));
+    expect(invalidation?.params.cause).toBe('retracted');
+  });
+});
+
 describe('AnswerCacheService.admit — admission rules', () => {
   const ctx: AnswerCacheStoreContext = {
     key: 'a'.repeat(64),
@@ -349,6 +469,7 @@ describe('AnswerCacheService.admit — admission rules', () => {
     profileHash: 'ph',
     model: 'gpt-4o-mini',
     normalizedQuery: 'what tier is acme',
+    isEnumeration: false,
   };
   const grounded: SynthesizeResult = {
     answer: 'Acme is gold tier.',
@@ -385,6 +506,30 @@ describe('AnswerCacheService.admit — admission rules', () => {
     const expiresAt = (upsert.params.expiresAt as Date).getTime();
     expect(expiresAt).toBeGreaterThanOrEqual(before + 2 * 3_600_000 - 5_000);
     expect(expiresAt).toBeLessThanOrEqual(before + 2 * 3_600_000 + 60_000);
+  });
+
+  it('open-enumeration answers get the shorter enum TTL (min of the two)', async () => {
+    const enumCtx: AnswerCacheStoreContext = { ...ctx, isEnumeration: true };
+    const h = makeHarness({ ttl: '24', enumTtl: '1' });
+    const before = Date.now();
+    await h.svc.admit(enumCtx, grounded, 'supported');
+    const upsert = h.calls.find((c) => /UPSERT/.test(c.sql))!;
+    const expiresAt = (upsert.params.expiresAt as Date).getTime();
+    // 1h enum TTL, not the 24h regular one.
+    expect(expiresAt).toBeLessThanOrEqual(before + 1 * 3_600_000 + 60_000);
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 1 * 3_600_000 - 5_000);
+  });
+
+  it('enum TTL is clamped to never exceed the regular TTL', async () => {
+    // Operator sets enum TTL LONGER than regular → min() keeps regular.
+    const enumCtx: AnswerCacheStoreContext = { ...ctx, isEnumeration: true };
+    const h = makeHarness({ ttl: '2', enumTtl: '9' });
+    const before = Date.now();
+    await h.svc.admit(enumCtx, grounded, 'supported');
+    const upsert = h.calls.find((c) => /UPSERT/.test(c.sql))!;
+    const expiresAt = (upsert.params.expiresAt as Date).getTime();
+    expect(expiresAt).toBeLessThanOrEqual(before + 2 * 3_600_000 + 60_000);
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 2 * 3_600_000 - 5_000);
   });
 
   it.each([

--- a/test/answer-cache.unit-spec.ts
+++ b/test/answer-cache.unit-spec.ts
@@ -1,6 +1,7 @@
 import type { ConfigService } from '@nestjs/config';
 import type { SurrealService } from '../src/db/surreal.service';
 import type { MetricsService } from '../src/metrics/metrics.service';
+import type { PredicateRegistryService } from '../src/ai/predicate-registry.service';
 import type { SynthesizeDto } from '../src/synthesize/dto/synthesize.dto';
 import type { SynthesizeResult } from '../src/synthesize/synthesize.types';
 import { resolveRetrievalProfile } from '../src/search/retrieval-profile';
@@ -141,12 +142,17 @@ function makeHarness(opts: {
   flag?: string;
   ttl?: string;
   enumTtl?: string;
+  enumMinCitations?: string;
   cacheRow?: Record<string, unknown> | null;
   factRows?: Array<Record<string, unknown>>;
   entityRows?: Array<Record<string, unknown>>;
   /** Freshness-probe candidate rows (3rd statement of the check-on-read
    *  batch) — active facts on a cited entity newer than the answer. */
   probeRows?: Array<Record<string, unknown>>;
+  /** Predicate the row-policy fences off (requiresScope the caller lacks)
+   *  — used to model DB rows that survive the SQL scope gate but are then
+   *  discarded by the JS row-policy (the gap-1 cap-before-scope vector). */
+  deniedPredicate?: string;
 }) {
   const calls: QueryCall[] = [];
   const db = {
@@ -154,7 +160,13 @@ function makeHarness(opts: {
       calls.push({ sql, params });
       if (/FROM knowledge_fact/.test(sql)) {
         // check-on-read batch: [cited facts, entity names, newer-fact probe].
-        return [opts.factRows ?? [], opts.entityRows ?? [], opts.probeRows ?? []];
+        // Model the DB-side LIMIT on the probe so cap-before-scope behaves
+        // like the real query: only the first N candidate rows reach JS,
+        // BEFORE the row-policy fences run (the gap-1 regression surface).
+        const probe = opts.probeRows ?? [];
+        const limit = /LIMIT (\d+)/.exec(sql);
+        const capped = limit ? probe.slice(0, parseInt(limit[1]!, 10)) : probe;
+        return [opts.factRows ?? [], opts.entityRows ?? [], capped];
       }
       if (/^\s*SELECT/.test(sql)) {
         return [opts.cacheRow ? [opts.cacheRow] : []];
@@ -167,20 +179,38 @@ function makeHarness(opts: {
     withScopedCompany: async (_c: string, _s: string[], fn: (d: typeof db) => unknown) => fn(db),
   } as unknown as SurrealService;
   const config = {
-    get: (key: string, dflt?: string) =>
-      key === 'SYNTHESIZE_ANSWER_CACHE'
-        ? (opts.flag ?? '1')
-        : key === 'SYNTHESIZE_ANSWER_CACHE_TTL_HOURS'
-          ? (opts.ttl ?? dflt)
-          : key === 'SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS'
-            ? (opts.enumTtl ?? dflt)
-            : dflt,
+    get: (key: string, dflt?: string) => {
+      switch (key) {
+        case 'SYNTHESIZE_ANSWER_CACHE':
+          return opts.flag ?? '1';
+        case 'SYNTHESIZE_ANSWER_CACHE_TTL_HOURS':
+          return opts.ttl ?? dflt;
+        case 'SYNTHESIZE_ANSWER_CACHE_ENUM_TTL_HOURS':
+          return opts.enumTtl ?? dflt;
+        case 'SYNTHESIZE_ANSWER_CACHE_ENUM_MIN_CITATIONS':
+          return opts.enumMinCitations ?? dflt;
+        default:
+          return dflt;
+      }
+    },
   } as unknown as ConfigService;
   const outcomes: string[] = [];
   const metrics = {
     countAnswerCache: (o: string) => outcomes.push(o),
   } as unknown as MetricsService;
-  const svc = new AnswerCacheService(surreal, config, undefined, undefined, metrics);
+  // Registry-backed row policy: mark deniedPredicate as requiring a scope
+  // the caller (['brain:read']) does not hold, so makeRowPolicyFilter's
+  // predicate-scope gate discards those rows in JS — exactly the fence that
+  // runs AFTER the DB LIMIT. Absent → static seed policy (all-visible).
+  const predicateRegistry = opts.deniedPredicate
+    ? ({
+        rowPolicyLookup: async (_c: string) => (predicate: string) =>
+          predicate === opts.deniedPredicate
+            ? { requiresScope: 'brain:read_pii', piiClass: 'sensitive' }
+            : { piiClass: 'none' },
+      } as unknown as PredicateRegistryService)
+    : undefined;
+  const svc = new AnswerCacheService(surreal, config, undefined, predicateRegistry, metrics);
   return { svc, calls, outcomes };
 }
 
@@ -460,6 +490,61 @@ describe('AnswerCacheService.begin — additive-write freshness probe (F1)', () 
     const invalidation = h.calls.find((c) => /invalidatedAt = time::now\(\)/.test(c.sql));
     expect(invalidation?.params.cause).toBe('retracted');
   });
+
+  it('a visible newer fact is NOT hidden behind >cap row-policy-fenced rows (gap 1)', async () => {
+    // The cap-before-scope bug: the DB LIMIT precedes the JS row-policy, so
+    // 30 newer facts the row-policy will fence (predicate 'secret',
+    // requiresScope the caller lacks) crowd the front of the probe result,
+    // then ONE genuinely visible newer fact ('plan'). Under a naive
+    // `LIMIT cap` the DB would return only the 25 fenced rows and the
+    // visible one would never be seen → STALE HIT. The cap+1 fetch + the
+    // full-page fail-closed guard invalidates instead.
+    const fenced = Array.from({ length: 30 }, (_, i) =>
+      newerFact({ id: `knowledge_fact:secret_${i}`, predicate: 'secret', object: 'x' }),
+    );
+    const visible = newerFact({
+      id: 'knowledge_fact:plan1',
+      predicate: 'plan',
+      object: 'premium',
+    });
+    const h = makeHarness({
+      cacheRow: liveCacheRow(),
+      factRows: [activeFact()], // cited 'tier' fact stays active + visible
+      entityRows: [{ id: 'knowledge_entity:e1', canonicalName: 'Acme' }],
+      probeRows: [...fenced, visible],
+      deniedPredicate: 'secret',
+    });
+    const out = await h.svc.begin(beginArgs());
+    expect(out?.hit).toBeUndefined(); // MUST NOT serve the stale answer
+    expect(out?.ctx).toBeDefined(); // falls through to fresh synthesis
+    const invalidation = h.calls.find((c) => /invalidatedAt = time::now\(\)/.test(c.sql));
+    expect(invalidation?.params.cause).toBe('newer_fact');
+    expect(h.outcomes).toEqual(['rejected_stale']);
+    // The probe fetches cap + 1 (26) so a full page can fail closed.
+    const probe = h.calls.find((c) => /recordedAt > \$answerCreatedAt/.test(c.sql))!;
+    expect(probe.sql).toContain('LIMIT 26');
+  });
+
+  it('row-policy-fenced newer facts UNDER the cap do not over-invalidate (serves)', async () => {
+    // A few newer facts, ALL row-policy-denied and none visible: the probe
+    // must NOT fire (they are invisible to this caller, never part of its
+    // answer), and the count is under the cap so the page is exhaustive —
+    // the answer genuinely serves. Confirms the fences still gate the probe.
+    const fenced = Array.from({ length: 3 }, (_, i) =>
+      newerFact({ id: `knowledge_fact:secret_${i}`, predicate: 'secret' }),
+    );
+    const h = makeHarness({
+      cacheRow: liveCacheRow(),
+      factRows: [activeFact()],
+      entityRows: [{ id: 'knowledge_entity:e1', canonicalName: 'Acme' }],
+      probeRows: fenced,
+      deniedPredicate: 'secret',
+    });
+    const out = await h.svc.begin(beginArgs());
+    expect(out?.hit?.cached).toBe(true);
+    expect(h.outcomes).toEqual(['hit']);
+    expect(h.calls.some((c) => /invalidatedAt = time::now\(\)/.test(c.sql))).toBe(false);
+  });
 });
 
 describe('AnswerCacheService.admit — admission rules', () => {
@@ -518,6 +603,69 @@ describe('AnswerCacheService.admit — admission rules', () => {
     // 1h enum TTL, not the 24h regular one.
     expect(expiresAt).toBeLessThanOrEqual(before + 1 * 3_600_000 + 60_000);
     expect(expiresAt).toBeGreaterThanOrEqual(before + 1 * 3_600_000 - 5_000);
+  });
+
+  it('new-entity residual: a regular answer still carries the bounded regular TTL', async () => {
+    // The freshness probe only scans an answer's CITED entities, so a fact
+    // on a BRAND-NEW entity can't be probed without re-retrieval; that
+    // residual is bounded — for every answer — ONLY by the regular TTL. A
+    // plain (non-enum, few-citation) answer must therefore still be admitted
+    // with a finite expiresAt == the regular TTL window (the new-entity
+    // staleness bound), never an unbounded serve.
+    const h = makeHarness({ ttl: '24' });
+    const before = Date.now();
+    await h.svc.admit(ctx, grounded, 'supported');
+    const upsert = h.calls.find((c) => /UPSERT/.test(c.sql))!;
+    const expiresAt = (upsert.params.expiresAt as Date).getTime();
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 24 * 3_600_000 - 5_000);
+    expect(expiresAt).toBeLessThanOrEqual(before + 24 * 3_600_000 + 60_000);
+  });
+
+  it('language-agnostic enum guard: a broad many-citation answer gets the short TTL (gap 3)', async () => {
+    // ctx.isEnumeration is FALSE — the query missed the English enum regex
+    // (e.g. a non-English "list all X"). But the ANSWER enumerated many
+    // items, so the cited-fact-count signal (>= threshold) drops it to the
+    // short enum TTL with NO query-language regex involved.
+    const broad: SynthesizeResult = {
+      answer: 'Six items: a, b, c, d, e, f.',
+      citations: Array.from({ length: 6 }, (_, i) => ({
+        factId: `knowledge_fact:f${i}`,
+        entityId: `knowledge_entity:e${i}`,
+        canonicalName: `E${i}`,
+        predicate: 'item',
+        object: `v${i}`,
+      })),
+      results: [],
+    };
+    const h = makeHarness({ ttl: '24', enumTtl: '1', enumMinCitations: '5' });
+    const before = Date.now();
+    await h.svc.admit({ ...ctx, isEnumeration: false }, broad, 'supported');
+    const upsert = h.calls.find((c) => /UPSERT/.test(c.sql))!;
+    const expiresAt = (upsert.params.expiresAt as Date).getTime();
+    // 1h short TTL, not the 24h regular one — the language-agnostic path.
+    expect(expiresAt).toBeLessThanOrEqual(before + 1 * 3_600_000 + 60_000);
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 1 * 3_600_000 - 5_000);
+  });
+
+  it('below the citation threshold a non-enum answer keeps the regular TTL', async () => {
+    const small: SynthesizeResult = {
+      answer: 'Two: a, b.',
+      citations: Array.from({ length: 2 }, (_, i) => ({
+        factId: `knowledge_fact:f${i}`,
+        entityId: `knowledge_entity:e${i}`,
+        canonicalName: `E${i}`,
+        predicate: 'item',
+        object: `v${i}`,
+      })),
+      results: [],
+    };
+    const h = makeHarness({ ttl: '24', enumTtl: '1', enumMinCitations: '5' });
+    const before = Date.now();
+    await h.svc.admit({ ...ctx, isEnumeration: false }, small, 'supported');
+    const upsert = h.calls.find((c) => /UPSERT/.test(c.sql))!;
+    const expiresAt = (upsert.params.expiresAt as Date).getTime();
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 24 * 3_600_000 - 5_000);
+    expect(expiresAt).toBeLessThanOrEqual(before + 24 * 3_600_000 + 60_000);
   });
 
   it('enum TTL is clamped to never exceed the regular TTL', async () => {

--- a/test/fovea-cascade.e2e-spec.ts
+++ b/test/fovea-cascade.e2e-spec.ts
@@ -298,7 +298,11 @@ describe('fovea cascade shakedown — full stack composed', () => {
     expect(r1.body.cached).toBeUndefined();
     expect(s1.calls.length).toBe(2);
 
-    // Repeat (typographic variant): served from cache, LLM never called.
+    // Repeat (whitespace variant): served from cache, LLM never called.
+    // Post-F1 the cache key normalizes NFC + whitespace ONLY — case and
+    // punctuation are now key-distinguishing (so `getUserById` never
+    // collides with `getuserbyid`), so the variant here only pads
+    // whitespace, which still normalizes to the same key.
     const hitBefore = await cacheMetric('hit');
     const s2 = mockSynthesizeOpenAi(f.app, [
       JSON.stringify({
@@ -307,7 +311,7 @@ describe('fovea cascade shakedown — full stack composed', () => {
       }),
       JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
     ]);
-    const r2 = await synth({ query: `  ${CACHE_QUERY.toUpperCase()}?`, userId: 'u_cache' });
+    const r2 = await synth({ query: `  ${CACHE_QUERY}  `, userId: 'u_cache' });
     expect(r2.status).toBe(201);
     expect(r2.body.cached).toBe(true);
     expect(r2.body.answer).toBe('The tier is sapphire-cache.');


### PR DESCRIPTION
## fix(answer-cache): additive-write freshness + hardening (audit F1 + R2 residuals)

Two commits: the F1 freshness probe, then the audit-R2 hardening of its residual gaps. Cache is **default-OFF** → before-enable hardening, prod byte-identical until enabled.

### Commit 1 — F1 additive-write freshness probe
Check-on-read previously re-validated only the CITED facts, so an additive write (new active fact on a cited entity, cited facts untouched) couldn't invalidate a stale answer. Added a read-side probe: active facts on the cited entities with `recordedAt > answer.createdAt`, under the same `pinUserScope` + `makeRowPolicyFilter` fences → any survivor invalidates (`cause=newer_fact`, fail-closed). Normalization tightened to **NFC + whitespace only** (dropped case-fold + trailing-punctuation → distinct identifiers no longer collide). Enum shapes get a short TTL. Migration `0097`.

### Commit 2 — hardening the three R2 residuals
1. **Cap-before-scope bug (the real one).** The DB `LIMIT` ran before the JS ABAC row-policy, so 25 fenced-away rows could hide a visible newer fact → stale hit. The ABAC verdict can't be pushed into SurrealQL (needs request PolicyContext + per-row PII/trust), so: **fetch `CAP+1` and fail-closed on a full page** — under the cap the page is exhaustive (exact visible-check), at/over the cap freshness can't be proven → invalidate. A visible newer fact can never be hidden behind a crowd of fenced rows. Regression: 30 row-policy-fenced newer facts in front of 1 visible newer fact → invalidates (the old path would have served stale).
2. **New-entity residual** — a fact on a brand-new entity can't be probed without re-retrieval; documented honestly that this is bounded **only** by the regular TTL (operator knob), no false full-freshness claim.
3. **Language-agnostic enum guard** — the service answers 12 languages; the English-regex enum guard missed non-English "list all". Added an answer-shape signal at admit (≥`SYNTHESIZE_ANSWER_CACHE_ENUM_MIN_CITATIONS`, default 5, citations → enum-shaped → short TTL), regex kept as an OR fast-path.

### Safety / tests
- Default-off byte-identical (flag off → `begin()` returns before any probe). Fences never widened; applied before the cap decision.
- answer-cache unit 120 total (incl. the >25-fenced regression, under-cap no-over-invalidation, new-entity TTL bound, language-agnostic enum, case-distinct-key); full unit suite 2404; answer-cache e2e 6/6 on Docker v3.2.4 (additive-write + M2M-scope); typecheck / lint:ci / format:check clean; flag-budget + config-catalog-truth green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)