### PR TITLE
feat(strategy): tool-trajectory experience memory (bet #3, default-off)

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1905,6 +1905,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Nightly strategy-memory lifecycle sweep at 03:52 UTC (G7 host slot, requires STRATEGY_MEMORY_ENABLED): auto-deprecates items whose evidence.nContradict ≥ 2 or that went 90 days without validation (Memp/ExpeL lifecycle). Distillation itself stays operator-invoked via POST /v1/admin/strategy/distill in v1.',
   },
+  {
+    key: 'STRATEGY_TRAJECTORIES_ENABLED',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: false,
+    isBooleanFlag: true,
+    description:
+      'Experience-memory extension of the strategy lane (migration 0098, bet #3 Part 3): store TOOL TRAJECTORIES + verified outcomes alongside the advice string. On (with STRATEGY_MEMORY_ENABLED) → the POST /v1/admin/strategy/trajectory capture endpoint answers (a completed tool-run + outcome distills into a trajectory-bearing item via the same Mem0 dedup), and served items render their past tool path into the GENERATOR advisory. Args/results are stored as one-way DIGESTS, never raw (no secrets/PII). The G4 verifier-parity exception is INVIOLABLE — a trajectory reaches the generator only, never the verifier or citations; it is more trap-exposed than the advice string, so enabling should ride §4.3 lens-suppression + the verifier answer-integrity arm. Off (default) → capture 404s, no trajectory column is written or read (byte-identical to pre-0098).',
+  },
   // ── Jobs ─────────────────────────────────────────────────
   {
     key: 'JOBS_QUEUE_MODE',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -704,6 +704,11 @@ const KNOWN_BOOLEAN_FLAGS = [
   'STRATEGY_MEMORY_ENABLED',
   'STRATEGY_RETRIEVAL_ENABLED',
   'STRATEGY_DISTILL_CRON_ENABLED',
+  // Experience-memory extension (0098, bet #3 Part 3): the trajectory
+  // capture surface + trajectory column read/write, on top of the
+  // master. Default off ⇒ no trajectory column is written or selected
+  // and the capture endpoint 404s (byte-identical to pre-0098).
+  'STRATEGY_TRAJECTORIES_ENABLED',
   // Fovea optics (Optics-1, docs/roadmap/fovea-optics-2026-08.md): capture
   // the focus signal at the synthesize verdict point + expose the admin
   // fit/measure surface. SERVING-NEUTRAL — nothing consumes the calibrated

--- a/src/db/migrations/0098_strategy_trajectories.surql
+++ b/src/db/migrations/0098_strategy_trajectories.surql
@@ -1,0 +1,48 @@
+-- 0098: strategy_memory tool trajectories + verified outcomes — the
+-- experience-memory extension of G4 (bet #3, Part 3 of
+-- docs/roadmap/measurable-economics-mri-2026-08.md). G4 today stores a
+-- distilled ADVICE STRING per worked/failed strategy; this adds the
+-- agent's *experience* — the concrete tool path it took and whether the
+-- outcome was verified.
+--
+-- ADDITIVE + OPTIONAL by construction: every column is option<...>, so
+-- existing rows are unaffected and NO backfill is needed. A write that
+-- omits these fields stores nothing for them (verified on SurrealDB
+-- 3.2.4: an existing-shape CREATE leaves all three NONE; a SELECT of the
+-- new columns on a pre-0098 row returns NONE, never an error). The whole
+-- feature is gated OFF by STRATEGY_TRAJECTORIES_ENABLED at the service
+-- layer — flag off ⇒ these columns are never written and never selected,
+-- so serving is byte-identical to pre-0098.
+--
+-- COGNITIVE-TRAP CAVEAT (MemTrap work, §Part 3): a trajectory-bearing
+-- item is MORE exposed to Cognitive-Bias / Trauma fixation than the bare
+-- advice string — it carries a concrete past path that can misfire on a
+-- surface-similar new task. Enabling this must ride the §4.3
+-- lens-suppression governor + the verifier answer-integrity arm. The
+-- trajectory stays ADVISORY: it is rendered for the GENERATOR only and
+-- never enters the verifier bundle or citations (the G4 verifier-parity
+-- exception is INVIOLABLE — a trajectory is advice, not evidence).
+--
+-- Element shape (typed subfields, NOT a FLEXIBLE object array): SurrealDB
+-- 3.x rejects `FLEXIBLE`-typed elements under an `option<array>` parent
+-- (see 0016's note), but a fixed-shape element with explicitly typed
+-- subfields applies cleanly and preserves every key. argsDigest /
+-- resultDigest are SHORT ONE-WAY DIGESTS of the sanitized payload, never
+-- the raw tool args/results — no secrets or PII are stored verbatim (see
+-- src/strategy/trajectory-digest.ts).
+
+-- Ordered tool steps: [{tool, argsDigest, resultDigest, ok}].
+DEFINE FIELD IF NOT EXISTS trajectory ON strategy_memory TYPE option<array<object>>;
+DEFINE FIELD IF NOT EXISTS trajectory[*].tool ON strategy_memory TYPE string;
+DEFINE FIELD IF NOT EXISTS trajectory[*].argsDigest ON strategy_memory TYPE string;
+DEFINE FIELD IF NOT EXISTS trajectory[*].resultDigest ON strategy_memory TYPE string;
+DEFINE FIELD IF NOT EXISTS trajectory[*].ok ON strategy_memory TYPE bool;
+
+-- Verified end-of-run outcome. ASSERT permits NONE (0052 idiom) so the
+-- option column is truly optional; a bogus value is rejected at write.
+DEFINE FIELD IF NOT EXISTS verifiedOutcome ON strategy_memory TYPE option<string>
+  ASSERT $value = NONE OR $value INSIDE ['success', 'failure', 'unknown'];
+
+-- Opaque reference to the evidence that verified the outcome (a run id /
+-- eval-record pointer) — provenance only, never a payload.
+DEFINE FIELD IF NOT EXISTS outcomeEvidenceRef ON strategy_memory TYPE option<string>;

--- a/src/strategy/strategy-admin.controller.ts
+++ b/src/strategy/strategy-admin.controller.ts
@@ -23,7 +23,10 @@ import {
   StrategyDistillService,
   type DistillStats,
   type PostMortem,
+  type TrajectoryCaptureStats,
+  type TrajectoryRun,
 } from './strategy-distill.service';
+import { TRAJECTORY_MAX_STEPS, isVerifiedOutcome, type RawToolStep } from './trajectory-digest';
 
 /**
  * Admin surface of the strategy-memory lane (G4). Operator-invoked,
@@ -33,16 +36,23 @@ import {
  * admin/ops surface is out of scope there by design
  * (scripts/build-openapi.ts).
  *
- *   POST  /v1/admin/strategy/distill — post-mortem batch → ≤3
+ *   POST  /v1/admin/strategy/distill    — post-mortem batch → ≤3
  *         dedup-merged candidate items (the eval-harness feed).
- *   GET   /v1/admin/strategy         — list (status filter).
- *   PATCH /v1/admin/strategy/:id     — status flip (candidate→active
+ *   POST  /v1/admin/strategy/trajectory — completed tool-run + verified
+ *         outcome → one trajectory-bearing candidate item (bet #3,
+ *         Part 3). ADDITIONALLY gated by STRATEGY_TRAJECTORIES_ENABLED:
+ *         off → 404, indistinguishable from not deployed, no effect.
+ *   GET   /v1/admin/strategy            — list (status filter).
+ *   PATCH /v1/admin/strategy/:id        — status flip (candidate→active
  *         confirmation, manual deprecation).
  */
 
 const STATUSES: readonly StrategyStatus[] = ['candidate', 'active', 'deprecated'];
 
 const MAX_POST_MORTEMS = 50;
+
+/** Cap on the free-text task/ref fields of a captured trajectory. */
+const MAX_TRAJECTORY_TEXT = 2000;
 
 @Controller('v1/admin/strategy')
 @UseGuards(ApiKeyGuard)
@@ -55,6 +65,17 @@ export class StrategyAdminController {
 
   private assertEnabled(): void {
     if (!this.strategies.isEnabled()) {
+      throw new NotFoundException();
+    }
+  }
+
+  /**
+   * Capture is gated by BOTH the master and STRATEGY_TRAJECTORIES_ENABLED:
+   * with the extension off the route 404s (no effect → byte-identical to
+   * pre-0098), exactly like the whole lane 404s with the master off.
+   */
+  private assertTrajectoriesEnabled(): void {
+    if (!this.strategies.isTrajectoriesEnabled()) {
       throw new NotFoundException();
     }
   }
@@ -102,6 +123,76 @@ export class StrategyAdminController {
       postMortems,
       body.runId?.trim() || undefined,
     );
+  }
+
+  /**
+   * Capture surface for the experience-memory extension (bet #3): a
+   * completed tool run + its verified outcome → one trajectory-bearing
+   * candidate item, through the SAME dedup-merge as /distill. Raw tool
+   * args/results are DIGESTED before storage (no secrets/PII kept
+   * verbatim). The trajectory is advice, not evidence — it will only ever
+   * reach the generator advisory, never the verifier or citations.
+   */
+  @Post('trajectory')
+  @RequireScopes('brain:admin')
+  async trajectory(
+    @Req() req: AuthenticatedRequest,
+    @Body()
+    body: {
+      tenant?: string;
+      runId?: string;
+      task?: string;
+      outcome?: string;
+      outcomeEvidenceRef?: string;
+      steps?: Array<{ tool?: unknown; args?: unknown; result?: unknown; ok?: unknown }>;
+    } = {},
+  ): Promise<TrajectoryCaptureStats> {
+    this.assertEnabled();
+    this.assertTrajectoriesEnabled();
+    const tenant = this.resolveTenant(req, body.tenant);
+    if (typeof body.task !== 'string' || !body.task.trim()) {
+      throw new BadRequestException('task must be a non-empty string');
+    }
+    if (body.task.length > MAX_TRAJECTORY_TEXT) {
+      throw new BadRequestException(`task capped at ${MAX_TRAJECTORY_TEXT} chars`);
+    }
+    if (!isVerifiedOutcome(body.outcome)) {
+      throw new BadRequestException('outcome must be one of success/failure/unknown');
+    }
+    if (
+      body.outcomeEvidenceRef !== undefined &&
+      (typeof body.outcomeEvidenceRef !== 'string' ||
+        body.outcomeEvidenceRef.length > MAX_TRAJECTORY_TEXT)
+    ) {
+      throw new BadRequestException(
+        `outcomeEvidenceRef must be a string ≤ ${MAX_TRAJECTORY_TEXT} chars`,
+      );
+    }
+    const steps = body.steps;
+    if (!Array.isArray(steps) || steps.length === 0) {
+      throw new BadRequestException('steps must be a non-empty array');
+    }
+    if (steps.length > TRAJECTORY_MAX_STEPS) {
+      throw new BadRequestException(`steps capped at ${TRAJECTORY_MAX_STEPS} per run`);
+    }
+    const rawSteps: RawToolStep[] = steps.map((s, i) => {
+      if (typeof s?.tool !== 'string' || !s.tool.trim()) {
+        throw new BadRequestException(`steps[${i}].tool must be a non-empty string`);
+      }
+      if (typeof s.ok !== 'boolean') {
+        throw new BadRequestException(`steps[${i}].ok must be a boolean`);
+      }
+      // args/result are arbitrary and DIGESTED, not stored raw — passed
+      // through untouched here for the digester to hash + redact.
+      return { tool: s.tool, args: s.args, result: s.result, ok: s.ok };
+    });
+    const run: TrajectoryRun = {
+      task: body.task,
+      outcome: body.outcome,
+      steps: rawSteps,
+      ...(body.outcomeEvidenceRef ? { outcomeEvidenceRef: body.outcomeEvidenceRef } : {}),
+    };
+    return this.distiller.distillFromTrajectory(tenant, run, body.runId?.trim() || undefined);
   }
 
   @Get()

--- a/src/strategy/strategy-distill.service.ts
+++ b/src/strategy/strategy-distill.service.ts
@@ -12,6 +12,13 @@ import {
   type StrategyItem,
   type StrategyPolarity,
 } from './strategy-memory.service';
+import {
+  toTrajectory,
+  type RawToolStep,
+  type ToolStep,
+  type TrajectoryBundle,
+  type VerifiedOutcome,
+} from './trajectory-digest';
 
 /**
  * StrategyDistillService — G4's distiller plus the G7 sleep-time
@@ -51,6 +58,28 @@ export interface DistillStats {
   noop: number;
 }
 
+/**
+ * A completed tool run reported by a consumer for capture (bet #3,
+ * Part 3): the task it was solving, the ordered tool steps it took, and
+ * the VERIFIED outcome. `steps` carry raw args/results — they are digested
+ * (never stored verbatim) by toTrajectory before anything is persisted.
+ */
+export interface TrajectoryRun {
+  task: string;
+  outcome: VerifiedOutcome;
+  outcomeEvidenceRef?: string | undefined;
+  steps: RawToolStep[];
+}
+
+export interface TrajectoryCaptureStats {
+  companyId: string;
+  steps: number;
+  proposed: number;
+  added: number;
+  updated: number;
+  noop: number;
+}
+
 export interface SweepRunStats {
   tenants: number;
   scanned: number;
@@ -83,6 +112,29 @@ You receive one NEW strategy item and up to ${MERGE_NEIGHBORS} EXISTING items (e
 - "ADD" when the new item teaches something none of the existing items covers.
 - "UPDATE" when an existing item covers the same lesson and should absorb the new one — return that item's id in "targetId", plus the merged "strategy" and "situation" texts (keep them strategy-level, 2-5 sentences).
 - "NOOP" when the new item adds nothing over the existing ones.
+
+Output strictly the JSON shape requested by the schema.`;
+
+/**
+ * Trajectory distiller (bet #3, Part 3): turn ONE completed tool run +
+ * its verified outcome into a single reusable strategy item. The output
+ * item is stored ALONGSIDE the concrete trajectory (advice + experience).
+ *
+ * Trap discipline (MemTrap): a concrete past path is MORE prone to
+ * misfire on a surface-similar new task than a generic advice string, so
+ * the lesson itself must stay strategy-level and transferable — the
+ * trajectory is provenance, not a script to replay.
+ */
+const TRAJECTORY_DISTILL_SYSTEM = `You are a strategy distiller for an answer-synthesis memory system that also records the agent's tool experience.
+
+You receive ONE completed tool run: the task, the ordered tools that were used (each marked ok/failed), and the VERIFIED outcome (success / failure / unknown). Distill AT MOST ONE reusable strategy item.
+
+Rules:
+- STRATEGY-LEVEL and TRANSFERABLE: state WHY and WHEN this kind of approach helps (or, on failure, what to avoid and why), in 2-5 sentences. NEVER a step-by-step replay of these exact tool calls, never task-specific facts, never verbatim arguments.
+- A concrete past path can misfire on a surface-similar but different task — write the lesson so it only fires when its stated situation genuinely applies.
+- "situation" states the preconditions (task class / shape) where the item applies.
+- "polarity" is "do" for a transferable strategy (typically from a success) or "avoid" for a preventative lesson (typically from a failure).
+- Output zero items when the run teaches nothing reusable.
 
 Output strictly the JSON shape requested by the schema.`;
 
@@ -199,12 +251,72 @@ export class StrategyDistillService {
       lastValidatedAt: new Date().toISOString(),
     };
     for (const item of items) {
-      const outcome = await this.dedupMerge(companyId, item, evidence);
+      const outcome = await this.dedupMerge(companyId, item, { evidence });
       stats[outcome]++;
     }
     this.logger.log(
       `[strategy.distill] companyId=${companyId} postMortems=${stats.postMortems} ` +
         `proposed=${stats.proposed} added=${stats.added} updated=${stats.updated} noop=${stats.noop}`,
+    );
+    return stats;
+  }
+
+  /**
+   * Capture ONE completed tool run + verified outcome as a
+   * trajectory-bearing strategy item (bet #3, Part 3;
+   * STRATEGY_TRAJECTORIES_ENABLED). REUSES the same Mem0 ADD/UPDATE/NOOP
+   * dedup as the post-mortem path — only the distill prompt and the
+   * attached experience bundle differ. The raw args/results are digested
+   * (toTrajectory) BEFORE anything is proposed or stored: no secrets/PII
+   * are persisted, and the LLM proposer is shown only the tool NAMES +
+   * ok/fail + task, never raw payloads.
+   *
+   * TRAP CAVEAT (MemTrap): the stored trajectory is more prone to
+   * Cognitive-Bias / Trauma fixation than a bare advice string — enabling
+   * serving must ride the §4.3 lens-suppression governor + the verifier
+   * answer-integrity arm. The structural containment is unchanged: the
+   * trajectory reaches the GENERATOR advisory only, never the verifier or
+   * citations (the G4 verifier-parity exception).
+   */
+  async distillFromTrajectory(
+    companyId: string,
+    run: TrajectoryRun,
+    runId?: string,
+  ): Promise<TrajectoryCaptureStats> {
+    const trajectory = toTrajectory(run.steps);
+    const stats: TrajectoryCaptureStats = {
+      companyId,
+      steps: trajectory.length,
+      proposed: 0,
+      added: 0,
+      updated: 0,
+      noop: 0,
+    };
+    // Defensive gate: never write trajectory columns when the flag is off
+    // (the controller already 404s the capture route — belt and braces).
+    if (!this.strategies.isTrajectoriesEnabled()) return stats;
+    const bundle: TrajectoryBundle = {
+      trajectory,
+      verifiedOutcome: run.outcome,
+      ...(run.outcomeEvidenceRef ? { outcomeEvidenceRef: run.outcomeEvidenceRef } : {}),
+    };
+    const items = await this.proposeTrajectoryItem(run, trajectory);
+    stats.proposed = items.length;
+    const evidence: StrategyEvidence = {
+      source: 'tool_trajectory',
+      ...(runId ? { runIds: [runId] } : {}),
+      nSupport: 1,
+      nContradict: 0,
+      lastValidatedAt: new Date().toISOString(),
+    };
+    for (const item of items) {
+      const outcome = await this.dedupMerge(companyId, item, { evidence, bundle });
+      stats[outcome]++;
+    }
+    this.logger.log(
+      `[strategy.trajectory] companyId=${companyId} steps=${stats.steps} ` +
+        `proposed=${stats.proposed} added=${stats.added} updated=${stats.updated} ` +
+        `noop=${stats.noop} outcome=${run.outcome}`,
     );
     return stats;
   }
@@ -259,10 +371,39 @@ export class StrategyDistillService {
           `Diagnosis: ${pm.diagnosis}`,
       )
       .join('\n\n');
+    return (await this.proposeFromMessages(DISTILL_SYSTEM, user)).slice(0, DISTILL_MAX_ITEMS);
+  }
+
+  /**
+   * Trajectory capture proposer (bet #3): one strategy item from a
+   * completed tool run. The user message carries only the task, verified
+   * outcome, and the tool NAMES + ok/fail — never raw args/results (those
+   * were digested before this point). At most one item.
+   */
+  private async proposeTrajectoryItem(
+    run: TrajectoryRun,
+    trajectory: ToolStep[],
+  ): Promise<DistilledItemShape[]> {
+    const path =
+      trajectory.map((s, i) => `${i + 1}. ${s.tool} — ${s.ok ? 'ok' : 'failed'}`).join('\n') ||
+      '(no tool steps)';
+    const user =
+      `Task: ${run.task}\n` + `Verified outcome: ${run.outcome}\n` + `Tool path taken:\n${path}`;
+    return (await this.proposeFromMessages(TRAJECTORY_DISTILL_SYSTEM, user)).slice(0, 1);
+  }
+
+  /**
+   * Shared distill LLM call: one system+user pair through the structured
+   * `distilled_strategies` schema, parsed and validated. The post-mortem
+   * and trajectory proposers differ only in prompt — the schema, JSON
+   * handling, and item validation are identical (and unchanged from the
+   * original proposeItems body).
+   */
+  private async proposeFromMessages(system: string, user: string): Promise<DistilledItemShape[]> {
     const res = await this.openai.chat.completions.create({
       model: this.model,
       messages: [
-        { role: 'system', content: DISTILL_SYSTEM },
+        { role: 'system', content: system },
         { role: 'user', content: user },
       ],
       response_format: {
@@ -303,23 +444,26 @@ export class StrategyDistillService {
     } catch (e) {
       this.logger.warn(`distill output unparseable: ${(e as Error).message}`);
     }
-    return items
-      .filter(
-        (i) =>
-          typeof i.title === 'string' &&
-          i.title.trim() &&
-          typeof i.situation === 'string' &&
-          typeof i.strategy === 'string' &&
-          (i.polarity === 'do' || i.polarity === 'avoid'),
-      )
-      .slice(0, DISTILL_MAX_ITEMS);
+    return items.filter(
+      (i) =>
+        typeof i.title === 'string' &&
+        i.title.trim() &&
+        typeof i.situation === 'string' &&
+        typeof i.strategy === 'string' &&
+        (i.polarity === 'do' || i.polarity === 'avoid'),
+    );
   }
 
-  /** One item through the ADD/UPDATE/NOOP gate against its neighbors. */
+  /**
+   * One item through the ADD/UPDATE/NOOP gate against its neighbors.
+   * `bundle` (trajectory capture only) attaches the experience to the
+   * created row (ADD) or the merged target (UPDATE); the post-mortem path
+   * passes none and behaves exactly as before.
+   */
   private async dedupMerge(
     companyId: string,
     item: DistilledItemShape,
-    evidence: StrategyEvidence,
+    ctx: { evidence: StrategyEvidence; bundle?: TrajectoryBundle | undefined },
   ): Promise<'added' | 'updated' | 'noop'> {
     const neighbors = await this.strategies.findSimilar(
       companyId,
@@ -335,12 +479,13 @@ export class StrategyDistillService {
       await this.strategies.mergeUpdate(companyId, decision.targetId, {
         strategy: decision.strategy,
         situation: decision.situation,
-        evidence: mergeEvidence(target?.evidence ?? {}, evidence),
+        evidence: mergeEvidence(target?.evidence ?? {}, ctx.evidence),
+        ...bundleFields(ctx.bundle),
       });
       return 'updated';
     }
     if (decision.action === 'ADD') {
-      await this.createDeduped(companyId, item, evidence);
+      await this.createDeduped(companyId, item, ctx);
       return 'added';
     }
     return 'noop';
@@ -350,13 +495,14 @@ export class StrategyDistillService {
   private async createDeduped(
     companyId: string,
     item: DistilledItemShape,
-    evidence: StrategyEvidence,
+    ctx: { evidence: StrategyEvidence; bundle?: TrajectoryBundle | undefined },
   ): Promise<StrategyItem | null> {
     try {
       return await this.strategies.create(companyId, {
         ...item,
         status: 'candidate',
-        evidence,
+        evidence: ctx.evidence,
+        ...bundleFields(ctx.bundle),
       });
     } catch (e) {
       this.logger.warn(`strategy ADD skipped (title '${item.title}'): ${(e as Error).message}`);
@@ -414,4 +560,23 @@ function renderMergeItem(i: {
     `title: ${i.title}\npolarity: ${i.polarity}\n` +
     `situation: ${i.situation}\nstrategy: ${i.strategy}`
   );
+}
+
+/**
+ * Spread the experience bundle into a create/mergeUpdate arg — empty when
+ * there is no bundle (the post-mortem path), so those writes are
+ * unchanged. The actual "write only when the flag is on" gate lives in
+ * StrategyMemoryService.trajectoryWriteFragment.
+ */
+function bundleFields(bundle?: TrajectoryBundle): {
+  trajectory?: ToolStep[];
+  verifiedOutcome?: VerifiedOutcome;
+  outcomeEvidenceRef?: string | undefined;
+} {
+  if (!bundle) return {};
+  return {
+    trajectory: bundle.trajectory,
+    verifiedOutcome: bundle.verifiedOutcome,
+    outcomeEvidenceRef: bundle.outcomeEvidenceRef,
+  };
 }

--- a/src/strategy/strategy-memory.service.ts
+++ b/src/strategy/strategy-memory.service.ts
@@ -4,6 +4,12 @@ import { SurrealService } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { envFlagEnabled } from '../common/env-validation';
 import { cosineSimilarity } from '../common/vector-math';
+import {
+  isVerifiedOutcome,
+  renderTrajectorySuffix,
+  type ToolStep,
+  type VerifiedOutcome,
+} from './trajectory-digest';
 
 /**
  * StrategyMemoryService — the ReasoningBank-shape strategy store
@@ -52,6 +58,19 @@ export interface StrategyItem {
   scope: StrategyScope;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Experience-memory extension (0098, STRATEGY_TRAJECTORIES_ENABLED):
+   * the concrete tool path + verified outcome distilled alongside the
+   * advice. Present ONLY when the trajectories flag is on AND the row
+   * carries one — the read path does not even select these columns when
+   * the flag is off, so an item is byte-identical to pre-0098 otherwise.
+   * Rendered for the GENERATOR advisory only, never the verifier /
+   * citations (the G4 verifier-parity exception; more trap-exposed than
+   * the advice string — see trajectory-digest.ts).
+   */
+  trajectory?: ToolStep[] | undefined;
+  verifiedOutcome?: VerifiedOutcome | undefined;
+  outcomeEvidenceRef?: string | undefined;
 }
 
 export interface ScoredStrategyItem extends StrategyItem {
@@ -66,6 +85,14 @@ export interface CreateStrategyArgs {
   status?: StrategyStatus;
   evidence?: StrategyEvidence;
   scope?: StrategyScope;
+  /**
+   * Experience-memory fields (0098). Written ONLY when the trajectories
+   * flag is on (a hard service-side gate — see create()); when off they
+   * are silently dropped so no trajectory column is ever written.
+   */
+  trajectory?: ToolStep[] | undefined;
+  verifiedOutcome?: VerifiedOutcome | undefined;
+  outcomeEvidenceRef?: string | undefined;
 }
 
 /** Retrieval k is hard-capped: k=1 default, 2 absolute max (G4). */
@@ -101,10 +128,21 @@ export function shouldDeprecate(
   return ageDays > STRATEGY_STALE_DAYS;
 }
 
-/** One advisory prompt line per served item (title + preconditions + lesson). */
+/**
+ * One advisory prompt line per served item (title + preconditions +
+ * lesson). When the served item carries a tool trajectory (0098,
+ * STRATEGY_TRAJECTORIES_ENABLED) a compact past-path suffix is appended
+ * — GENERATOR-only guidance, never evidence. Without a trajectory the
+ * output is byte-identical to pre-0098 (the suffix is ''), which is why
+ * an item read with the flag off — where the columns are never selected
+ * and `trajectory` stays undefined — renders exactly as it did before.
+ */
 export function renderStrategyNote(item: ScoredStrategyItem): string {
   const tag = item.polarity === 'avoid' ? 'AVOID' : 'DO';
-  return `[${tag}] ${item.title} — applies when: ${item.situation}. ${item.strategy}`;
+  return (
+    `[${tag}] ${item.title} — applies when: ${item.situation}. ${item.strategy}` +
+    renderTrajectorySuffix(item)
+  );
 }
 
 interface RawStrategyRow {
@@ -120,11 +158,20 @@ interface RawStrategyRow {
   scope?: string;
   createdAt?: unknown;
   updatedAt?: unknown;
+  // 0098 columns — selected ONLY when the trajectories flag is on
+  // (TRAJECTORY_ROW_FIELDS), so on the off path they are always absent
+  // and the mapper leaves the item byte-identical to pre-0098.
+  trajectory?: unknown;
+  verifiedOutcome?: unknown;
+  outcomeEvidenceRef?: unknown;
 }
 
 const STRATEGY_ROW_FIELDS =
   'id, companyId, title, situation, strategy, polarity, status, ' +
   'evidence, scope, createdAt, updatedAt';
+
+/** 0098 additive columns, appended to the SELECT only when serving trajectories. */
+const TRAJECTORY_ROW_FIELDS = 'trajectory, verifiedOutcome, outcomeEvidenceRef';
 
 @Injectable()
 export class StrategyMemoryService {
@@ -134,6 +181,7 @@ export class StrategyMemoryService {
   // template) — catalogued runtimeMutable:false.
   private readonly enabled: boolean;
   private readonly retrievalEnabled: boolean;
+  private readonly trajectoriesEnabled: boolean;
   private readonly similarityFloor: number;
 
   constructor(
@@ -143,6 +191,11 @@ export class StrategyMemoryService {
   ) {
     this.enabled = envFlagEnabled(config.get<string>('STRATEGY_MEMORY_ENABLED'));
     this.retrievalEnabled = envFlagEnabled(config.get<string>('STRATEGY_RETRIEVAL_ENABLED'));
+    // Experience-memory extension (0098): mirrors how STRATEGY_MEMORY_
+    // ENABLED is read — constructor-captured, runtimeMutable:false. Off
+    // (default) ⇒ trajectory columns are never written or selected, so
+    // serving is byte-identical to pre-0098.
+    this.trajectoriesEnabled = envFlagEnabled(config.get<string>('STRATEGY_TRAJECTORIES_ENABLED'));
     // Unset/blank must NOT collapse to Number('')===0 (the
     // nonNegativeFloatEnv lesson): an absent knob means DEFAULT 0.4,
     // not "no floor".
@@ -161,11 +214,62 @@ export class StrategyMemoryService {
     return this.enabled && this.retrievalEnabled;
   }
 
+  /**
+   * Experience-memory switch (0098): gates trajectory capture (write)
+   * and trajectory column serving (read) on top of the master. Off ⇒ no
+   * trajectory column is written or selected → byte-identical to pre-0098.
+   */
+  isTrajectoriesEnabled(): boolean {
+    return this.enabled && this.trajectoriesEnabled;
+  }
+
+  /**
+   * Build the SurrealQL fragment + params for the 0098 experience columns
+   * shared by create() (CONTENT `key: $key`) and mergeUpdate() (SET
+   * `key = $key`). Returns EMPTY fragments when the trajectories flag is
+   * off — the load-bearing "no trajectory written when off" guarantee —
+   * and includes only the fields actually supplied (so the option<string>
+   * ASSERT is never handed a NULL).
+   */
+  private trajectoryWriteFragment(fields: {
+    trajectory?: ToolStep[] | undefined;
+    verifiedOutcome?: VerifiedOutcome | undefined;
+    outcomeEvidenceRef?: string | undefined;
+  }): { content: string; set: string; params: Record<string, unknown> } {
+    if (!this.trajectoriesEnabled) return { content: '', set: '', params: {} };
+    const cols: string[] = [];
+    const params: Record<string, unknown> = {};
+    if (fields.trajectory !== undefined) {
+      cols.push('trajectory');
+      params.trajectory = fields.trajectory;
+    }
+    if (fields.verifiedOutcome !== undefined) {
+      cols.push('verifiedOutcome');
+      params.verifiedOutcome = fields.verifiedOutcome;
+    }
+    if (fields.outcomeEvidenceRef !== undefined) {
+      cols.push('outcomeEvidenceRef');
+      params.outcomeEvidenceRef = fields.outcomeEvidenceRef;
+    }
+    return {
+      content: cols.map((c) => `,\n            ${c}: $${c}`).join(''),
+      set: cols.map((c) => `${c} = $${c}`).join(', '),
+      params,
+    };
+  }
+
   async create(companyId: string, args: CreateStrategyArgs): Promise<StrategyItem> {
     return this.surreal.withCompany(companyId, async (db) => {
       // Embed the retrieval key: situation carries the preconditions
       // the query is matched against; title disambiguates near-twins.
       const embedding = await this.embedder.embed(`${args.title}\n${args.situation}`);
+      // 0098 experience fields: a HARD service-side gate — only when the
+      // trajectories flag is on AND a field was supplied does it enter the
+      // CONTENT. Off ⇒ this fragment is empty and the CREATE is
+      // byte-identical to pre-0098. (Each field is included individually
+      // rather than passing null, so the option<string> ASSERT is never
+      // handed a NULL it would reject.)
+      const traj = this.trajectoryWriteFragment(args);
       const [row] = await db.query<RawStrategyRow[]>(
         `CREATE ONLY strategy_memory CONTENT {
             companyId: $companyId,
@@ -178,7 +282,7 @@ export class StrategyMemoryService {
             embedding: $embedding,
             scope: $scope,
             createdAt: time::now(),
-            updatedAt: time::now()
+            updatedAt: time::now()${traj.content}
          }`,
         {
           companyId,
@@ -190,6 +294,7 @@ export class StrategyMemoryService {
           evidence: args.evidence ?? {},
           embedding,
           scope: args.scope ?? 'tenant',
+          ...traj.params,
         },
       );
       if (!row) throw new Error('strategy_memory CREATE returned nothing');
@@ -255,15 +360,23 @@ export class StrategyMemoryService {
       strategy?: string | undefined;
       situation?: string | undefined;
       evidence: StrategyEvidence;
+      // 0098: the UPDATE arm of a trajectory capture attaches the latest
+      // experience. Written only when the trajectories flag is on (the
+      // shared write-fragment gate); dropped otherwise.
+      trajectory?: ToolStep[] | undefined;
+      verifiedOutcome?: VerifiedOutcome | undefined;
+      outcomeEvidenceRef?: string | undefined;
     },
   ): Promise<StrategyItem> {
     return this.surreal.withCompany(companyId, async (db) => {
       const tail = idTail(strategyIdRaw);
+      const traj = this.trajectoryWriteFragment(patch);
       const sets = [
         'evidence = $evidence',
         'updatedAt = time::now()',
         ...(patch.strategy ? ['strategy = $strategy'] : []),
         ...(patch.situation ? ['situation = $situation'] : []),
+        ...(traj.set ? [traj.set] : []),
       ].join(', ');
       const [rows] = await db.query<RawStrategyRow[][]>(
         `UPDATE type::record('strategy_memory', $tail)
@@ -276,6 +389,7 @@ export class StrategyMemoryService {
           evidence: patch.evidence,
           ...(patch.strategy ? { strategy: patch.strategy } : {}),
           ...(patch.situation ? { situation: patch.situation } : {}),
+          ...traj.params,
         },
       );
       const updated = (rows as RawStrategyRow[])?.[0];
@@ -322,8 +436,15 @@ export class StrategyMemoryService {
   ): Promise<ScoredStrategyItem[]> {
     return this.surreal.withCompany(companyId, async (db) => {
       const q = await this.embedder.embed(text);
+      // 0098: the trajectory columns are appended to the projection ONLY
+      // when the flag is on. Off ⇒ the SELECT is character-identical to
+      // pre-0098, the rows carry no trajectory, and every served/mapped
+      // item is byte-identical (mapStrategyRow leaves the fields off).
+      const projection = this.trajectoriesEnabled
+        ? `${STRATEGY_ROW_FIELDS}, ${TRAJECTORY_ROW_FIELDS}, embedding`
+        : `${STRATEGY_ROW_FIELDS}, embedding`;
       const [rows] = await db.query<RawStrategyRow[][]>(
-        `SELECT ${STRATEGY_ROW_FIELDS}, embedding
+        `SELECT ${projection}
            FROM strategy_memory
            WHERE companyId = $companyId
              AND status INSIDE $statuses
@@ -391,7 +512,7 @@ function idTail(raw: string): string {
 }
 
 function mapStrategyRow(r: RawStrategyRow): StrategyItem {
-  return {
+  const item: StrategyItem = {
     strategyId: String(r.id),
     companyId: String(r.companyId ?? ''),
     title: String(r.title ?? ''),
@@ -406,6 +527,34 @@ function mapStrategyRow(r: RawStrategyRow): StrategyItem {
     createdAt: toIso(r.createdAt),
     updatedAt: toIso(r.updatedAt),
   };
+  // 0098: attach experience fields ONLY when the row actually carries
+  // them. On the flag-off path they are never selected, so they are
+  // undefined here and the item is byte-identical to pre-0098. (An empty
+  // stored trajectory also maps to "absent" so it never renders.)
+  const trajectory = mapTrajectory(r.trajectory);
+  if (trajectory) item.trajectory = trajectory;
+  if (isVerifiedOutcome(r.verifiedOutcome)) item.verifiedOutcome = r.verifiedOutcome;
+  if (typeof r.outcomeEvidenceRef === 'string' && r.outcomeEvidenceRef) {
+    item.outcomeEvidenceRef = r.outcomeEvidenceRef;
+  }
+  return item;
+}
+
+/** Parse a stored trajectory column into typed ToolStep[]; undefined when absent/empty. */
+function mapTrajectory(raw: unknown): ToolStep[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const steps: ToolStep[] = [];
+  for (const s of raw) {
+    if (!s || typeof s !== 'object') continue;
+    const o = s as Record<string, unknown>;
+    steps.push({
+      tool: typeof o.tool === 'string' ? o.tool : '',
+      argsDigest: typeof o.argsDigest === 'string' ? o.argsDigest : '',
+      resultDigest: typeof o.resultDigest === 'string' ? o.resultDigest : '',
+      ok: o.ok === true,
+    });
+  }
+  return steps.length > 0 ? steps : undefined;
 }
 
 function toIso(v: unknown): string {

--- a/src/strategy/trajectory-digest.ts
+++ b/src/strategy/trajectory-digest.ts
@@ -1,0 +1,133 @@
+import { createHash } from 'node:crypto';
+import { sanitizePackText, stripUnsafeUnicode } from '../common/text-sanitizer';
+
+/**
+ * Trajectory digesting for the experience-memory extension of G4 (bet #3,
+ * Part 3 of docs/roadmap/measurable-economics-mri-2026-08.md).
+ *
+ * A "trajectory" is the ordered tool path an agent took to reach an
+ * answer, plus whether the run's outcome was verified. We store it as
+ * ADVICE (the G4 verifier-parity exception: a trajectory never enters the
+ * verifier bundle or citations), and it rides the STRATEGY_TRAJECTORIES_
+ * ENABLED flag — default off, byte-identical serving when off.
+ *
+ * SECURITY POSTURE — DIGESTS, NOT RAW PAYLOADS. Tool args/results are the
+ * most likely place for secrets or PII (API keys, tokens, user data). We
+ * therefore NEVER store them verbatim: `argsDigest` / `resultDigest` are
+ * short one-way SHA-256 prefixes over the NFC-sanitized canonical JSON of
+ * the payload. The digest identifies a payload (dedup/provenance) without
+ * revealing it. The tool NAME is a function identifier (not sensitive) and
+ * is kept in clear text, sanitized + length-capped via the shared
+ * text-sanitizer.
+ *
+ * COGNITIVE-TRAP CAVEAT (MemTrap): a stored past path can misfire on a
+ * surface-similar new task (Cognitive-Bias / Trauma fixation), MORE so
+ * than a bare advice string. Enabling trajectory serving must ride the
+ * §4.3 lens-suppression governor + the verifier answer-integrity arm; the
+ * structural containment here is that the render below feeds the GENERATOR
+ * advisory section only — see strategy-memory.service.renderStrategyNote.
+ */
+
+/** Digest length (hex chars) — enough to identify a payload, reveals nothing. */
+export const TRAJECTORY_DIGEST_LEN = 16;
+
+/** Tool-name clear-text cap (a function identifier, not free text). */
+export const TRAJECTORY_TOOL_CAP = 80;
+
+/** Hard bound on stored steps per trajectory (keeps the row + prompt small). */
+export const TRAJECTORY_MAX_STEPS = 32;
+
+export type VerifiedOutcome = 'success' | 'failure' | 'unknown';
+
+export const VERIFIED_OUTCOMES: readonly VerifiedOutcome[] = ['success', 'failure', 'unknown'];
+
+export function isVerifiedOutcome(v: unknown): v is VerifiedOutcome {
+  return typeof v === 'string' && (VERIFIED_OUTCOMES as readonly string[]).includes(v);
+}
+
+/** Stored, sanitized tool step: clear-text tool name + payload digests + ok. */
+export interface ToolStep {
+  tool: string;
+  argsDigest: string;
+  resultDigest: string;
+  ok: boolean;
+}
+
+/** Raw capture-time step from a consumer (args/result may be anything). */
+export interface RawToolStep {
+  tool: string;
+  args?: unknown;
+  result?: unknown;
+  ok: boolean;
+}
+
+/** The verified experience captured alongside the distilled strategy item. */
+export interface TrajectoryBundle {
+  trajectory: ToolStep[];
+  verifiedOutcome: VerifiedOutcome;
+  outcomeEvidenceRef?: string | undefined;
+}
+
+/**
+ * Deterministic stable JSON of an arbitrary value — object keys sorted so
+ * the digest is stable across key ordering. Pure; no IO.
+ */
+function stableStringify(value: unknown): string {
+  if (value === undefined) return 'null';
+  return JSON.stringify(value, (_k, v) => {
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      const rec = v as Record<string, unknown>;
+      return Object.keys(rec)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, k) => {
+          acc[k] = rec[k];
+          return acc;
+        }, {});
+    }
+    return v as unknown;
+  });
+}
+
+/**
+ * One-way short digest of a payload: sanitize invisibles out of the
+ * canonical JSON, then SHA-256 and truncate. A raw secret in `value`
+ * never survives — only its hash prefix does.
+ */
+export function digestPayload(value: unknown): string {
+  const canonical = stripUnsafeUnicode(stableStringify(value));
+  return createHash('sha256').update(canonical).digest('hex').slice(0, TRAJECTORY_DIGEST_LEN);
+}
+
+/** Redact a raw capture step into the stored, digest-only ToolStep. */
+export function toToolStep(raw: RawToolStep): ToolStep {
+  return {
+    tool: sanitizePackText(raw.tool, TRAJECTORY_TOOL_CAP),
+    argsDigest: digestPayload(raw.args),
+    resultDigest: digestPayload(raw.result),
+    ok: raw.ok === true,
+  };
+}
+
+/** Redact + cap a list of raw steps into the stored trajectory. */
+export function toTrajectory(steps: RawToolStep[]): ToolStep[] {
+  return steps.slice(0, TRAJECTORY_MAX_STEPS).map(toToolStep);
+}
+
+/**
+ * Advisory render of a trajectory for the GENERATOR's fenced strategy
+ * note (never the verifier). Compact past-path summary — tool sequence
+ * with per-step ok/fail and the verified outcome. The opaque payload
+ * digests are STORAGE-only provenance (dedup / audit); surfacing 16-hex
+ * hashes in the prompt would be noise, so they are deliberately not
+ * rendered. Empty trajectory ⇒ '' (byte-identical to a note without one).
+ */
+export function renderTrajectorySuffix(item: {
+  trajectory?: ToolStep[] | undefined;
+  verifiedOutcome?: VerifiedOutcome | undefined;
+}): string {
+  const steps = item.trajectory;
+  if (!steps || steps.length === 0) return '';
+  const path = steps.map((s) => `${s.tool}(${s.ok ? 'ok' : 'fail'})`).join(' → ');
+  const outcome = item.verifiedOutcome ? `, verified ${item.verifiedOutcome}` : '';
+  return ` [past tool path: ${path}${outcome}]`;
+}

--- a/test/strategy-trajectories.e2e-spec.ts
+++ b/test/strategy-trajectories.e2e-spec.ts
@@ -1,0 +1,315 @@
+/**
+ * Strategy trajectories e2e — the experience-memory extension of G4
+ * (bet #3, Part 3 of docs/roadmap/measurable-economics-mri-2026-08.md).
+ *
+ *   1. Trajectories OFF (default), master ON → the capture endpoint 404s
+ *      (no effect), /distill still works, and a served plain item is
+ *      BYTE-IDENTICAL (no "past tool path" in the prompt) — the flag-off
+ *      guarantee.
+ *   2. All ON → a completed tool-run + outcome distills into a
+ *      trajectory-bearing item through the SAME Mem0 dedup (ADD → NOOP →
+ *      UPDATE); DIGESTS, not raw payloads, are stored (a planted secret
+ *      never lands in the row).
+ *   3. All ON, serving → the trajectory reaches the GENERATOR advisory
+ *      section but NEVER the verifier bundle and NEVER citations (the G4
+ *      verifier-parity exception, now carrying an experience).
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSynthesizeOpenAi } from './test-doubles';
+import { StrategyMemoryService } from '../src/strategy/strategy-memory.service';
+import { StrategyDistillService } from '../src/strategy/strategy-distill.service';
+import { digestPayload } from '../src/strategy/trajectory-digest';
+
+const STRATEGY_ENV_KEYS = [
+  'STRATEGY_MEMORY_ENABLED',
+  'STRATEGY_RETRIEVAL_ENABLED',
+  'STRATEGY_TRAJECTORIES_ENABLED',
+  'STRATEGY_SIMILARITY_FLOOR',
+  'SYNTHESIZE_ANSWER_ROUTER_ENABLED',
+];
+
+function clearStrategyEnv(): void {
+  for (const k of STRATEGY_ENV_KEYS) delete process.env[k];
+}
+
+/** Scripted OpenAI stub for the distiller (the mockSynthesizeOpenAi idiom). */
+function mockDistillOpenAi(svc: StrategyDistillService, responses: string[]): { calls: number } {
+  const state = { calls: 0 };
+  const stub = {
+    chat: {
+      completions: {
+        create: async () => {
+          const content = responses[state.calls] ?? responses[responses.length - 1] ?? '{}';
+          state.calls++;
+          return { choices: [{ message: { content } }] };
+        },
+      },
+    },
+  };
+  (svc as unknown as { openai: typeof stub }).openai = stub;
+  return state;
+}
+
+const distilledItem = (over: Partial<Record<string, string>> = {}): string =>
+  JSON.stringify({
+    items: [
+      {
+        title: over.title ?? 'onboarding lookup strategy',
+        situation: over.situation ?? '',
+        strategy:
+          over.strategy ??
+          'When onboarding-status is asked, check the profile record first — the direct lookup resolved it here.',
+        polarity: over.polarity ?? 'do',
+      },
+    ],
+  });
+
+const ingestFact = async (f: AppFixture, id: string): Promise<void> => {
+  await f.http
+    .post('/v1/ingest/fact')
+    .set({ Authorization: `Bearer ${f.apiKey}` })
+    .send({
+      entityRef: { vertical: 'rent', id },
+      predicate: 'status',
+      object: 'engineer',
+      validFrom: '2026-04-01',
+      source: { vertical: 'rent', eventId: 'auth.profile_updated' },
+    });
+};
+
+// ── 1. Trajectories OFF (default): capture 404s, serving byte-identical ───
+
+describe('strategy trajectories — flag OFF (default), master ON', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const STRATEGY_TEXT = 'Check the profile record first for onboarding-status questions.';
+
+  beforeAll(async () => {
+    clearStrategyEnv();
+    process.env.STRATEGY_MEMORY_ENABLED = '1';
+    process.env.STRATEGY_RETRIEVAL_ENABLED = '1';
+    process.env.SYNTHESIZE_ANSWER_ROUTER_ENABLED = '1';
+    // STRATEGY_TRAJECTORIES_ENABLED deliberately unset → off.
+    f = await createApp();
+    await ingestFact(f, 'traj_off_tenant');
+    // Even if a trajectory is passed, the flag-off create MUST NOT write
+    // it (the service-side gate) — proving no trajectory column on the
+    // off path regardless of caller input.
+    await f.app.get(StrategyMemoryService).create(f.companyId, {
+      title: 'engineer',
+      situation: '',
+      strategy: STRATEGY_TEXT,
+      polarity: 'do',
+      status: 'active',
+      trajectory: [{ tool: 'should_not_persist', argsDigest: 'x', resultDigest: 'y', ok: true }],
+      verifiedOutcome: 'success',
+    });
+  });
+  afterAll(async () => {
+    clearStrategyEnv();
+    if (f) await f.close();
+  });
+
+  it('the capture endpoint 404s — indistinguishable from not deployed', async () => {
+    const r = await f.http
+      .post('/v1/admin/strategy/trajectory')
+      .set(auth())
+      .send({
+        task: 'resolve onboarding status',
+        outcome: 'success',
+        steps: [{ tool: 'lookup', args: { id: 1 }, result: { ok: true }, ok: true }],
+      });
+    expect(r.status).toBe(404);
+  });
+
+  it('serving is BYTE-IDENTICAL: the advisory note carries no trajectory', async () => {
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer: 'ok', citedFactIds: [] }),
+      JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+    ]);
+    const res = await f.http.post('/v1/synthesize').set(auth()).send({ query: 'engineer' });
+    expect(res.status).toBe(201);
+    const generatorCall = state.calls[0]!;
+    // The classic advisory note serves; the trajectory the caller tried to
+    // attach was never written and never renders.
+    expect(generatorCall.user).toContain('=== ADVISORY STRATEGY NOTES');
+    expect(generatorCall.user).toContain(STRATEGY_TEXT);
+    expect(generatorCall.user).not.toContain('past tool path');
+    expect(generatorCall.user).not.toContain('should_not_persist');
+  });
+});
+
+// ── 2 + 3. All ON: capture (ADD/NOOP/UPDATE, digests) + generator-only ────
+
+describe('strategy trajectories — all flags ON', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const SECRET = 'sk-live-SUPER-SECRET-9f8e7d';
+  const RAW_ARGS = { apiKey: SECRET, endpoint: 'https://api.example/profile' };
+  const RAW_RESULT = { status: 200, body: 'user-private-record-ZZZ' };
+
+  beforeAll(async () => {
+    clearStrategyEnv();
+    process.env.STRATEGY_MEMORY_ENABLED = '1';
+    process.env.STRATEGY_RETRIEVAL_ENABLED = '1';
+    process.env.STRATEGY_TRAJECTORIES_ENABLED = '1';
+    process.env.SYNTHESIZE_ANSWER_ROUTER_ENABLED = '1';
+    f = await createApp();
+    await ingestFact(f, 'traj_on_tenant');
+  });
+  afterAll(async () => {
+    clearStrategyEnv();
+    if (f) await f.close();
+  });
+
+  it('captures a tool-run as a trajectory-bearing item; DIGESTS (not raw payloads) are stored', async () => {
+    const distiller = f.app.get(StrategyDistillService);
+    // Empty table → ADD (proposal only; no neighbors → no merge call).
+    mockDistillOpenAi(distiller, [distilledItem({ title: 'onboarding lookup strategy' })]);
+    const add = await f.http
+      .post('/v1/admin/strategy/trajectory')
+      .set(auth())
+      .send({
+        runId: 'run-t1',
+        task: 'resolve the user onboarding status',
+        outcome: 'success',
+        outcomeEvidenceRef: 'eval:run-t1#q3',
+        steps: [
+          { tool: 'profile_lookup', args: RAW_ARGS, result: RAW_RESULT, ok: true },
+          { tool: 'status_check', args: { id: 42 }, result: { onboarded: true }, ok: true },
+        ],
+      });
+    expect(add.status).toBe(201);
+    expect(add.body).toMatchObject({ steps: 2, proposed: 1, added: 1, updated: 0, noop: 0 });
+
+    // Read the stored item back through the service (list() omits the
+    // trajectory columns by design; findSimilar selects them when the
+    // flag is on). Assert digests, never the raw secret.
+    const strategy = f.app.get(StrategyMemoryService);
+    const found = await strategy.findSimilar(f.companyId, 'onboarding lookup strategy');
+    expect(found.length).toBeGreaterThanOrEqual(1);
+    const item = found[0]!;
+    expect(item.verifiedOutcome).toBe('success');
+    expect(item.outcomeEvidenceRef).toBe('eval:run-t1#q3');
+    expect(item.trajectory).toBeDefined();
+    expect(item.trajectory!).toHaveLength(2);
+    const [s0] = item.trajectory!;
+    expect(s0!.tool).toBe('profile_lookup');
+    expect(s0!.ok).toBe(true);
+    // The digest is the deterministic hash — and the raw secret/PII is
+    // NOWHERE in the stored row.
+    expect(s0!.argsDigest).toBe(digestPayload(RAW_ARGS));
+    expect(s0!.resultDigest).toBe(digestPayload(RAW_RESULT));
+    const serialized = JSON.stringify(item.trajectory);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain('user-private-record-ZZZ');
+    expect(serialized).not.toContain('api.example');
+  });
+
+  it('re-capturing the same run NOOPs (dedup); a related run UPDATEs the target', async () => {
+    const distiller = f.app.get(StrategyDistillService);
+    const strategy = f.app.get(StrategyMemoryService);
+
+    // Same run again: proposal (call 0) then the arbiter NOOPs (call 1).
+    mockDistillOpenAi(distiller, [
+      distilledItem({ title: 'onboarding lookup strategy' }),
+      '{"action":"NOOP"}',
+    ]);
+    const noop = await f.http
+      .post('/v1/admin/strategy/trajectory')
+      .set(auth())
+      .send({
+        task: 'resolve the user onboarding status again',
+        outcome: 'success',
+        steps: [{ tool: 'profile_lookup', args: { id: 7 }, result: {}, ok: true }],
+      });
+    expect(noop.status).toBe(201);
+    expect(noop.body).toMatchObject({ added: 0, updated: 0, noop: 1 });
+
+    // A related run that the arbiter merges into the existing item.
+    const existing = await strategy.findSimilar(f.companyId, 'onboarding lookup strategy');
+    const targetId = existing[0]!.strategyId;
+    mockDistillOpenAi(distiller, [
+      distilledItem({ title: 'onboarding lookup strategy v2' }),
+      JSON.stringify({
+        action: 'UPDATE',
+        targetId,
+        strategy: 'Check the profile record first for onboarding-status questions.',
+        situation: '',
+      }),
+    ]);
+    const upd = await f.http
+      .post('/v1/admin/strategy/trajectory')
+      .set(auth())
+      .send({
+        task: 'confirm onboarding completion',
+        outcome: 'failure',
+        steps: [{ tool: 'profile_lookup', args: { id: 9 }, result: {}, ok: false }],
+      });
+    expect(upd.status).toBe(201);
+    expect(upd.body).toMatchObject({ added: 0, updated: 1, noop: 0 });
+
+    // The UPDATE attached the newest experience (failure outcome) to the
+    // merged target — dedup grew evidence, not the table.
+    const list = await f.http.get('/v1/admin/strategy').set(auth());
+    expect(list.body.strategies).toHaveLength(1);
+    const merged = await strategy.findSimilar(f.companyId, 'onboarding lookup strategy');
+    expect(merged[0]!.verifiedOutcome).toBe('failure');
+  });
+
+  it('a captured trajectory reaches the GENERATOR advisory but NOT the verifier or citations', async () => {
+    // Seed an ACTIVE trajectory-bearing item whose retrieval key == the
+    // query (StubEmbedder identical-text ⇒ cosine 1.0), so it is served.
+    const strategy = f.app.get(StrategyMemoryService);
+    const NOTE_STRATEGY = 'Prefer the direct profile lookup for status questions.';
+    await strategy.create(f.companyId, {
+      title: 'engineer',
+      situation: '',
+      strategy: NOTE_STRATEGY,
+      polarity: 'do',
+      status: 'active',
+      trajectory: [
+        {
+          tool: 'profile_lookup',
+          argsDigest: 'deadbeefdeadbeef',
+          resultDigest: 'cafecafecafecafe',
+          ok: true,
+        },
+        {
+          tool: 'status_check',
+          argsDigest: 'f00df00df00df00d',
+          resultDigest: '0ff00ff00ff00ff0',
+          ok: true,
+        },
+      ],
+      verifiedOutcome: 'success',
+    });
+    const PAST_PATH = '[past tool path: profile_lookup(ok) → status_check(ok), verified success]';
+
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer: 'ok', citedFactIds: [] }),
+      JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+    ]);
+    const res = await f.http.post('/v1/synthesize').set(auth()).send({ query: 'engineer' });
+    expect(res.status).toBe(201);
+    expect(state.calls.length).toBeGreaterThanOrEqual(2);
+
+    // (a) The trajectory rendered into the fenced advisory for the GENERATOR.
+    const generatorCall = state.calls[0]!;
+    expect(generatorCall.user).toContain('=== ADVISORY STRATEGY NOTES');
+    expect(generatorCall.user).toContain(NOTE_STRATEGY);
+    expect(generatorCall.user).toContain(PAST_PATH);
+
+    // (b) The verifier-parity exception STAYS: no later (verifier) call
+    // sees the advisory OR the trajectory.
+    for (const call of state.calls.slice(1)) {
+      expect(call.user).not.toContain('ADVISORY STRATEGY NOTES');
+      expect(call.user).not.toContain(NOTE_STRATEGY);
+      expect(call.user).not.toContain('past tool path');
+    }
+    // (c) Never a citation — advice (with experience) is not evidence.
+    expect(JSON.stringify(res.body.citations ?? [])).not.toContain('strategy_memory');
+    expect(JSON.stringify(res.body.citations ?? [])).not.toContain('past tool path');
+  });
+});

--- a/test/strategy-trajectories.unit-spec.ts
+++ b/test/strategy-trajectories.unit-spec.ts
@@ -1,0 +1,280 @@
+/**
+ * Strategy trajectories — experience-memory extension of G4 (bet #3,
+ * Part 3 of docs/roadmap/measurable-economics-mri-2026-08.md). Pure-logic
+ * coverage:
+ *   · digesting is one-way and stable — raw args/results (secrets/PII) are
+ *     NEVER stored verbatim, only short SHA-256 prefixes;
+ *   · toToolStep / toTrajectory redact + cap;
+ *   · renderStrategyNote is BYTE-IDENTICAL to pre-0098 without a
+ *     trajectory, and appends the past-tool-path suffix (generator-only)
+ *     with one;
+ *   · the READ GATE: with STRATEGY_TRAJECTORIES_ENABLED off the SELECT
+ *     projection never names the trajectory columns (so serving is
+ *     byte-identical), and names them only when on.
+ */
+import { ConfigService } from '@nestjs/config';
+import {
+  StrategyMemoryService,
+  renderStrategyNote,
+  type ScoredStrategyItem,
+} from '../src/strategy/strategy-memory.service';
+import {
+  TRAJECTORY_DIGEST_LEN,
+  TRAJECTORY_MAX_STEPS,
+  digestPayload,
+  isVerifiedOutcome,
+  renderTrajectorySuffix,
+  toToolStep,
+  toTrajectory,
+  type ToolStep,
+} from '../src/strategy/trajectory-digest';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { EmbedderService } from '../src/ai/embedder.service';
+
+// ── stubs (mirrors strategy-memory.unit-spec.ts) ─────────────────────────
+
+function stubEmbedder(vectors: Record<string, number[]>): EmbedderService {
+  return {
+    embed: async (text: string) => vectors[text] ?? [0, 0],
+  } as unknown as EmbedderService;
+}
+
+interface QueryCall {
+  sql: string;
+  params?: Record<string, unknown> | undefined;
+}
+
+function stubSurreal(
+  respond: (sql: string, params?: Record<string, unknown>) => unknown[],
+  calls: QueryCall[] = [],
+): SurrealService {
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      calls.push({ sql, params });
+      return respond(sql, params);
+    },
+  };
+  return {
+    withCompany: async (_companyId: string, fn: (d: unknown) => unknown) => fn(db),
+  } as unknown as SurrealService;
+}
+
+function stubConfig(env: Record<string, string>): ConfigService {
+  return {
+    get: (key: string, dflt?: string) => env[key] ?? dflt,
+  } as unknown as ConfigService;
+}
+
+const TRAJ_STEP: ToolStep = {
+  tool: 'web_search',
+  argsDigest: 'a1b2c3d4e5f60718',
+  resultDigest: 'ffeeddccbbaa9988',
+  ok: true,
+};
+
+function trajRow(over: Partial<Record<string, unknown>> = {}) {
+  const { id, ...rest } = over;
+  return {
+    companyId: 'c1',
+    title: 'onboarding lookup',
+    situation: 'account-status question',
+    strategy: 'Check the profile record first.',
+    polarity: 'do',
+    status: 'active',
+    evidence: { nSupport: 1, nContradict: 0 },
+    embedding: [1, 0],
+    scope: 'tenant',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    trajectory: [TRAJ_STEP],
+    verifiedOutcome: 'success',
+    outcomeEvidenceRef: 'run:xyz',
+    ...rest,
+    id: `strategy_memory:${String(id ?? 'a1')}`,
+  };
+}
+
+// ── digesting: one-way, stable, secret-safe ──────────────────────────────
+
+describe('digestPayload — hashes, never raw payloads', () => {
+  it('returns a short lowercase hex digest, not the payload', () => {
+    const d = digestPayload({ apiKey: 'sk-SECRET-12345', q: 'hello' });
+    expect(d).toMatch(new RegExp(`^[0-9a-f]{${TRAJECTORY_DIGEST_LEN}}$`));
+    expect(d).not.toContain('sk-SECRET-12345');
+    expect(d).not.toContain('hello');
+  });
+
+  it('is deterministic and stable across object key ordering', () => {
+    expect(digestPayload({ a: 1, b: 2 })).toBe(digestPayload({ b: 2, a: 1 }));
+    expect(digestPayload('same')).toBe(digestPayload('same'));
+  });
+
+  it('distinguishes different payloads', () => {
+    expect(digestPayload({ q: 'a' })).not.toBe(digestPayload({ q: 'b' }));
+  });
+
+  it('handles undefined/null without leaking or throwing', () => {
+    expect(digestPayload(undefined)).toMatch(/^[0-9a-f]+$/);
+    expect(digestPayload(null)).toMatch(/^[0-9a-f]+$/);
+  });
+});
+
+describe('toToolStep / toTrajectory — redact + cap', () => {
+  it('stores DIGESTS of args/result, never the raw values', () => {
+    const secretArgs = { token: 'bearer-abc-SECRET', url: 'https://x' };
+    const secretResult = { body: 'private-user-data-XYZ' };
+    const step = toToolStep({
+      tool: 'http_fetch',
+      args: secretArgs,
+      result: secretResult,
+      ok: true,
+    });
+    expect(step.tool).toBe('http_fetch');
+    expect(step.ok).toBe(true);
+    // Digests equal the deterministic hash and contain none of the secret.
+    expect(step.argsDigest).toBe(digestPayload(secretArgs));
+    expect(step.resultDigest).toBe(digestPayload(secretResult));
+    const serialized = JSON.stringify(step);
+    expect(serialized).not.toContain('SECRET');
+    expect(serialized).not.toContain('private-user-data-XYZ');
+    expect(serialized).not.toContain('bearer-abc');
+  });
+
+  it('coerces ok to a STRICT boolean (only literal true is true) and sanitizes the tool name', () => {
+    const zwsp = String.fromCharCode(0x200b); // zero-width space
+    const step = toToolStep({ tool: `we${zwsp}ird`, args: {}, result: {}, ok: true });
+    expect(step.ok).toBe(true);
+    // zero-width space stripped by the shared text sanitizer.
+    expect(step.tool).toBe('weird');
+    // Strict `=== true`: a truthy-but-not-true ok defensively becomes false.
+    expect(toToolStep({ tool: 't', args: {}, result: {}, ok: 1 as unknown as boolean }).ok).toBe(
+      false,
+    );
+    expect(toToolStep({ tool: 't', args: {}, result: {}, ok: 0 as unknown as boolean }).ok).toBe(
+      false,
+    );
+  });
+
+  it('caps the stored trajectory at TRAJECTORY_MAX_STEPS', () => {
+    const many = Array.from({ length: TRAJECTORY_MAX_STEPS + 10 }, (_, i) => ({
+      tool: `t${i}`,
+      args: { i },
+      result: {},
+      ok: true,
+    }));
+    expect(toTrajectory(many)).toHaveLength(TRAJECTORY_MAX_STEPS);
+  });
+});
+
+describe('isVerifiedOutcome', () => {
+  it('accepts only the three enum values', () => {
+    expect(isVerifiedOutcome('success')).toBe(true);
+    expect(isVerifiedOutcome('failure')).toBe(true);
+    expect(isVerifiedOutcome('unknown')).toBe(true);
+    expect(isVerifiedOutcome('bogus')).toBe(false);
+    expect(isVerifiedOutcome(undefined)).toBe(false);
+    expect(isVerifiedOutcome(1)).toBe(false);
+  });
+});
+
+// ── advisory rendering: byte-identical without a trajectory ───────────────
+
+describe('renderTrajectorySuffix', () => {
+  it('is empty for an item with no trajectory (byte-identical fallback)', () => {
+    expect(renderTrajectorySuffix({})).toBe('');
+    expect(renderTrajectorySuffix({ trajectory: [] })).toBe('');
+  });
+
+  it('renders the tool path with per-step ok/fail and the verified outcome', () => {
+    expect(
+      renderTrajectorySuffix({
+        trajectory: [
+          { tool: 'web_search', argsDigest: 'x', resultDigest: 'y', ok: true },
+          { tool: 'calc', argsDigest: 'x', resultDigest: 'y', ok: false },
+        ],
+        verifiedOutcome: 'success',
+      }),
+    ).toBe(' [past tool path: web_search(ok) → calc(fail), verified success]');
+  });
+
+  it('omits the outcome clause when there is no verified outcome', () => {
+    expect(
+      renderTrajectorySuffix({
+        trajectory: [{ tool: 't', argsDigest: 'x', resultDigest: 'y', ok: true }],
+      }),
+    ).toBe(' [past tool path: t(ok)]');
+  });
+});
+
+describe('renderStrategyNote — additive, generator-only', () => {
+  const base = {
+    title: 'commit on dated conflicts',
+    situation: 'knowledge-update questions',
+    strategy: 'Prefer the latest dated value.',
+    polarity: 'do',
+  } as unknown as ScoredStrategyItem;
+
+  it('is BYTE-IDENTICAL to pre-0098 when the item carries no trajectory', () => {
+    expect(renderStrategyNote(base)).toBe(
+      '[DO] commit on dated conflicts — applies when: knowledge-update questions. Prefer the latest dated value.',
+    );
+  });
+
+  it('appends the past-tool-path suffix when a trajectory is present', () => {
+    const withTraj = {
+      ...base,
+      trajectory: [TRAJ_STEP],
+      verifiedOutcome: 'success',
+    } as unknown as ScoredStrategyItem;
+    expect(renderStrategyNote(withTraj)).toBe(
+      '[DO] commit on dated conflicts — applies when: knowledge-update questions. ' +
+        'Prefer the latest dated value. [past tool path: web_search(ok), verified success]',
+    );
+  });
+});
+
+// ── the READ GATE: projection is byte-identical when the flag is off ──────
+
+describe('trajectory read gate (byte-identical serving when off)', () => {
+  const BOTH_ON = { STRATEGY_MEMORY_ENABLED: '1', STRATEGY_RETRIEVAL_ENABLED: '1' };
+
+  it('OFF: the serving SELECT never names the trajectory columns', async () => {
+    const calls: QueryCall[] = [];
+    const svc = new StrategyMemoryService(
+      // Model reality: with the flag off the DB would not return trajectory
+      // columns, so the stub returns a plain row (no trajectory).
+      stubSurreal(
+        (sql) =>
+          sql.includes('FROM strategy_memory') ? [[trajRow({ trajectory: undefined })]] : [[]],
+        calls,
+      ),
+      stubEmbedder({ q: [1, 0] }),
+      stubConfig(BOTH_ON), // STRATEGY_TRAJECTORIES_ENABLED unset → off
+    );
+    const out = await svc.retrieve('c1', 'q');
+    const serving = calls.find((c) => c.sql.includes('FROM strategy_memory'));
+    expect(serving?.sql).not.toContain('trajectory');
+    expect(serving?.sql).not.toContain('verifiedOutcome');
+    // Item is byte-identical to pre-0098 — no experience fields, classic note.
+    expect(out[0]!.trajectory).toBeUndefined();
+    expect(renderStrategyNote(out[0]!)).not.toContain('past tool path');
+  });
+
+  it('ON: the serving SELECT names the trajectory columns and they map through', async () => {
+    const calls: QueryCall[] = [];
+    const svc = new StrategyMemoryService(
+      stubSurreal((sql) => (sql.includes('FROM strategy_memory') ? [[trajRow()]] : [[]]), calls),
+      stubEmbedder({ q: [1, 0] }),
+      stubConfig({ ...BOTH_ON, STRATEGY_TRAJECTORIES_ENABLED: '1' }),
+    );
+    const out = await svc.retrieve('c1', 'q');
+    const serving = calls.find((c) => c.sql.includes('FROM strategy_memory'));
+    expect(serving?.sql).toContain('trajectory');
+    expect(serving?.sql).toContain('verifiedOutcome');
+    expect(out[0]!.trajectory).toEqual([TRAJ_STEP]);
+    expect(out[0]!.verifiedOutcome).toBe('success');
+    expect(renderStrategyNote(out[0]!)).toContain(
+      '[past tool path: web_search(ok), verified success]',
+    );
+  });
+});

--- a/test/strategy-trajectory-trap.e2e-spec.ts
+++ b/test/strategy-trajectory-trap.e2e-spec.ts
@@ -1,0 +1,161 @@
+/**
+ * Trajectory trap shakedown — the MemTrap "Cognitive-Bias / Trauma
+ * fixation" exposure of a TRAJECTORY-BEARING strategy memory (bet #3,
+ * Part 3; mirrors test/memtrap-shakedown.e2e-spec.ts scenario 2).
+ *
+ * WHY A DEDICATED SCENARIO. A bare advice string already reaches the
+ * generator invisibly to the verifier (memtrap scenario 2). A trajectory-
+ * bearing item is MORE exposed: it additionally carries a CONCRETE PAST
+ * PATH (a specific tool sequence that worked once) that can misfire on a
+ * surface-similar but genuinely different task — the essence of Cognitive-
+ * Bias fixation. This suite maps that exposure precisely and gates it
+ * against regression.
+ *
+ * WHAT IT CAN AND CANNOT DO — read before extending. The generator +
+ * verifier are SCRIPTED stubs and the embedder is a deterministic double;
+ * this suite therefore makes NO accuracy/quality claim about whether a
+ * real model is actually misled. It is a PLUMBING + posture diagnostic:
+ * it asserts (a) the trap trajectory reaches the GENERATOR advisory (the
+ * fixation carrier) and (b) our current STRUCTURAL posture holds — the
+ * trajectory stays OUT of the verifier bundle and citations (the G4
+ * verifier-parity exception is inviolable). Under the stub embedder the
+ * strategy's retrieval key is made to coincide with the spring query to
+ * model embedding proximity between two surface-similar tasks
+ * deterministically; the plumbing finding is independent of why retrieval
+ * matched.
+ *
+ * MITIGATIONS (documented, NOT asserted here — they are the enabling
+ * pre-reqs, not this suite's subject): serving trajectory memory should
+ * ride the §4.3 lens-suppression governor + the verifier answer-integrity
+ * arm (FOVEA_PLAUSIBILITY_CHECK / require-citations). This suite only
+ * pins the posture those arms are meant to harden.
+ *
+ * VERDICT: EXPOSED (invisible to the verifier) — same class as memtrap
+ * scenario 2, now with a concrete past path amplifying the fixation. No
+ * structural defense in the base pipeline catches a trajectory-induced
+ * fixation; that is the honest posture, asserted, not papered over.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSynthesizeOpenAi } from './test-doubles';
+import { StrategyMemoryService } from '../src/strategy/strategy-memory.service';
+
+const FLAG_ENV: Record<string, string> = {
+  SYNTHESIZE_ANSWER_ROUTER_ENABLED: '1',
+  STRATEGY_MEMORY_ENABLED: '1',
+  STRATEGY_RETRIEVAL_ENABLED: '1',
+  STRATEGY_TRAJECTORIES_ENABLED: '1',
+  // Keep abstention off so a thin-evidence query never pre-abstains before
+  // generation — deterministic generate+verify pair (2 LLM calls).
+  RETRIEVAL_ABSTENTION_CALIBRATION: 'off',
+};
+
+describe('trajectory trap shakedown (Cognitive-Bias fixation, trajectory-bearing)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const savedEnv: Record<string, string | undefined> = {};
+
+  // The A-task past path that SUCCEEDED once and is now over-applied to a
+  // surface-similar B-task. The trap lives in both the advice AND the
+  // concrete tool path it carries.
+  const SPRING_QUERY = 'crimson-widget calibration puzzle';
+  const TRAP_STRATEGY =
+    'Reuse the single-shot cached-estimate path that worked before: read the cache and stop.';
+  let biasFactId: string;
+
+  beforeAll(async () => {
+    for (const k of Object.keys(FLAG_ENV)) {
+      savedEnv[k] = process.env[k];
+      process.env[k] = FLAG_ENV[k]!;
+    }
+    f = await createApp({ companyId: 'co_traj_trap_e2e' });
+
+    // A grounding fact for the B-task, user-scoped for isolation.
+    const r = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'prob_bias_traj' },
+        predicate: 'ledger',
+        object: 'crimson-widget calibration puzzle',
+        validFrom: new Date('2026-04-01').toISOString(),
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+        userId: 'u_traj_bias',
+      });
+    expect([200, 201]).toContain(r.status);
+    biasFactId = r.body.factId as string;
+
+    // Seed the trajectory-bearing trap item. Retrieval key (title, empty
+    // situation) == the spring query ⇒ served for exactly that query. The
+    // trajectory is a concrete cached-only path that "verified success"
+    // for the A-task — precisely what makes it misfire on B.
+    await f.app.get(StrategyMemoryService).create(f.companyId, {
+      title: SPRING_QUERY,
+      situation: '',
+      strategy: TRAP_STRATEGY,
+      polarity: 'do',
+      status: 'active',
+      trajectory: [
+        {
+          tool: 'cache_read',
+          argsDigest: 'aaaabbbbccccdddd',
+          resultDigest: 'eeeeffff00001111',
+          ok: true,
+        },
+      ],
+      verifiedOutcome: 'success',
+    });
+  });
+
+  afterAll(async () => {
+    for (const k of Object.keys(FLAG_ENV)) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    if (f) await f.close();
+  });
+
+  it('the trap trajectory reaches the generator but never the verifier or citations (EXPOSED, verifier-blind)', async () => {
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({
+        answer: 'Calibration resolved via the crimson-widget calibration puzzle record.',
+        citedFactIds: [biasFactId],
+      }),
+      JSON.stringify({ verdict: 'supported', unsupportedClaims: [], questionAnswered: true }),
+    ]);
+    const r = await f.http.post('/v1/synthesize').set(auth()).send({
+      query: SPRING_QUERY,
+      userId: 'u_traj_bias',
+    });
+    expect(r.status).toBe(201);
+    expect(r.body.answer).toBeTruthy();
+    expect(state.calls.length).toBe(2);
+    expect(r.body.citations?.[0]?.factId).toBe(biasFactId);
+
+    const PAST_PATH = '[past tool path: cache_read(ok), verified success]';
+
+    // (a) FIXATION CARRIER: the trap strategy AND its concrete past path
+    // reached the GENERATOR prompt, in the fenced advisory section.
+    expect(state.calls[0]!.user).toContain('=== ADVISORY STRATEGY NOTES');
+    expect(state.calls[0]!.user).toContain(TRAP_STRATEGY);
+    expect(state.calls[0]!.user).toContain(PAST_PATH);
+
+    // (b) POSTURE HELD: by the G4 parity exception the note — advice AND
+    // trajectory — is DELIBERATELY absent from the verifier's evidence
+    // bundle, so a trajectory-induced fixation is structurally invisible
+    // to the grounding audit (the exposure this scenario documents).
+    expect(state.calls[1]!.user).not.toContain('ADVISORY STRATEGY NOTES');
+    expect(state.calls[1]!.user).not.toContain(TRAP_STRATEGY);
+    expect(state.calls[1]!.user).not.toContain('past tool path');
+
+    // (c) It is never a citation — advice-with-experience is not evidence.
+    expect(JSON.stringify(r.body.citations ?? [])).not.toContain(TRAP_STRATEGY);
+    expect(JSON.stringify(r.body.citations ?? [])).not.toContain('past tool path');
+    expect(JSON.stringify(r.body.citations ?? [])).not.toContain('strategy_memory');
+    // (a)+(b)+(c) ⇒ EXPOSED. Honest posture: the base pipeline carries the
+    // trajectory to the generator and cannot catch its fixation at the
+    // verifier; §4.3 suppression + the verifier answer-integrity arm are
+    // the intended (separately-gated) mitigations, not asserted here.
+  });
+});


### PR DESCRIPTION
## feat(strategy): tool-trajectory experience memory (bet #3, default-off)

The experience-memory half of strategic bet #3 (`docs/roadmap/measurable-economics-mri-2026-08.md` Part 3): extends G4 strategy memory from a distilled *advice string* to **tool trajectories + verified outcomes** — the agent's experience, not just conversational facts. Behind default-off `STRATEGY_TRAJECTORIES_ENABLED`; prod byte-identical until enabled. Targets LongMemEval-V2 (parked eval).

### What it adds
- **Capture** — `POST /v1/admin/strategy/trajectory` (brain:admin, 404 when off): `{task, outcome, steps:[{tool,args,result,ok}], ...}` → `StrategyDistillService.distillFromTrajectory`, distilled through the **existing Mem0 ADD/UPDATE/NOOP dedup** (shared `proposeFromMessages` seam; the post-mortem path is byte-unchanged).
- **Schema** (migration `0098`) — three optional columns on `strategy_memory`: `trajectory` (typed `[*].{tool,argsDigest,resultDigest,ok}`), `verifiedOutcome` (NONE|success|failure|unknown), `outcomeEvidenceRef`. All four DDL variants were probed against a throwaway v3.2.4 container — the typed-subfield form is the only one that applies AND leaves omitted fields truly NONE AND round-trips.
- **Digests, not raw payloads** (`trajectory-digest.ts`) — `argsDigest`/`resultDigest` are 16-hex SHA-256 prefixes over NFC-sanitized stable-JSON (repo `text-sanitizer`); tool name sanitized+capped; steps capped 32. A planted `sk-live-SECRET` is asserted never stored verbatim.

### Verifier-parity preserved (inviolable)
Retrieval shape unchanged (k=1 advisory). A trajectory only enriches `renderStrategyNote` with a `[past tool path: …]` suffix on the **generator-only** `strategyNotes` path; the verifier call still omits `strategyNotes`. `STRATEGY_ADVISORY_INSTRUCTION` untouched. A trajectory NEVER reaches the verifier bundle or citations — asserted.

### Trap caveat (honest)
`strategy-trajectory-trap.e2e-spec.ts` (mirrors the MemTrap shakedown): a trajectory whose past path would misfire on a surface-similar task → verdict **EXPOSED (verifier-blind)** — it reaches the generator advisory (a fixation carrier) but stays structurally out of the verifier/citations. A trajectory-bearing memory is MORE Cognitive-Bias/Trauma exposed than an advice string; enabling it should ride §4.3 lens-suppression + the verifier answer-integrity arm (documented in code + migration).

### Byte-identical when off
(1) `scoredMatch` projection omits the trajectory columns at SQL level; (2) `create`/`mergeUpdate` write no trajectory fields even if a caller passes one; (3) capture endpoint 404s; (4) `renderStrategyNote` with no trajectory is byte-identical to pre-0098 — all asserted.

### Tests / gates
typecheck / lint:ci / format:check clean; full unit suite 2404 green (+22-case unit spec); strategy e2e 13/13 on Docker (v3.2.4 applying 0098, no regression); gate goldens (flag-budget, config-catalog-truth, env-validation, engine-gates S5.2/S5.5) green. `STRATEGY_` outside the flag-budget ENGINE_PREFIX.

> Merge ordering: this carries migration **0098**; merge after the F1 answer-cache fix (0097) so migration numbers stay contiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
