### PR TITLE
fix(fovea): route L3 through the answer-integrity gate (audit R2 P1)

### DIFF
--- a/src/synthesize/answer-integrity.ts
+++ b/src/synthesize/answer-integrity.ts
@@ -27,9 +27,12 @@ export interface AnswerIntegrityDeps {
 
 /**
  * The finalize context handed to finalizeAndAdmit. `dto`+`profile` are present
- * ONLY on the primary serving path; when both are set the answer-integrity arm
- * resolves. The L3 fail-flip path passes just `cache`, so its raw-transcript
- * answer is never gated.
+ * on BOTH serving paths — the primary serve AND the L3 fail-flip — so both
+ * resolve the answer-integrity arm. (Historically the L3 path passed just
+ * `cache` and bypassed the gate; it now carries dto/profile/model so its
+ * raw-transcript answer — the most exposed to belief distortion and to uncited
+ * "supported" answers — is gated end-to-end. `cache`-only remains supported and
+ * simply yields an empty gate.)
  */
 export interface FinalizeContext {
   cache: AnswerCacheBeginResult | undefined;
@@ -40,11 +43,19 @@ export interface FinalizeContext {
 
 /**
  * Resolve the Part A + Part C gate flags for finalizeVerdict. Returns an empty
- * object — no LLM call — unless the primary path supplied dto+profile AND the
- * verdict is `supported`. Part C (FOVEA_REQUIRE_CITATIONS) is a pure flag; Part
- * A (FOVEA_PLAUSIBILITY_CHECK) runs ONE extra LLM plausibility judge over the
+ * object — no LLM call — unless the caller supplied dto+profile AND the verdict
+ * is `supported`. Both the primary serve and the L3 flip supply dto+profile, so
+ * both are gated. Part C (FOVEA_REQUIRE_CITATIONS) is a pure flag; Part A
+ * (FOVEA_PLAUSIBILITY_CHECK) runs ONE extra LLM plausibility judge over the
  * cited premises (see resolvePlausibilityDowngrade). The auditor model is
  * profile.verifierModel || the synthesis model.
+ *
+ * Consequence on L3: an L3 answer that grounds on the raw transcript may be
+ * UNCITED by design ("claims from transcript need no citation"). With
+ * FOVEA_REQUIRE_CITATIONS on, such an answer therefore abstains — the correct
+ * end-to-end reading of the citation-bearing promise. An operator enabling
+ * require-citations is explicitly opting into "no uncited answers, including
+ * L3". (Default-off, so no prod impact.)
  *
  * NOTE on the serving-cost boundary: the judge fires on a `supported` verdict
  * when the flag is on and cited premises exist. In the narrow lenient +

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -444,8 +444,10 @@ export class SynthesizeService {
     // and returns the L3 answer when re-verification flips fail→pass;
     // else (null) the normal abstention/decline exit runs. Trigger matrix
     // + anchor requirement live in tryL3Escalation / the L3 service.
-    // On no-flip, finalizePrimary runs (resolving the default-off verifier
-    // answer-integrity arm, Parts A + C); the L3 flip path skips it.
+    // BOTH exits resolve the default-off verifier answer-integrity arm (Parts
+    // A + C): on no-flip the primary finalizeAndAdmit runs it, and the L3 flip
+    // path runs it too (its raw-transcript answer is the most exposed, so the
+    // gate is end-to-end).
     return (
       (await this.tryL3Escalation({
         cache,
@@ -540,16 +542,30 @@ export class SynthesizeService {
       ...(adaptiveL3 ? { adaptiveL3 } : {}),
     });
     if (!l3) return null;
-    return this.finalizeAndAdmit({ cache: args.cache }, l3.verdict, {
-      answer: l3.answer,
-      citations: l3.citations,
-      results: args.results,
-      guardrails: args.guardrails,
-      decisionLog: args.explain
-        ? buildDecisionLog(args.results, new Set(l3.citations.map((c) => c.factId)))
-        : undefined,
-      abstention: profile.abstentionCalibration,
-    });
+    // Route the L3 supported answer through the SAME answer-integrity gate as
+    // the primary serve (Parts A + C) by carrying dto/profile/model into the
+    // finalize context. The L3 answer grounds on the RAW TRANSCRIPT — the path
+    // most exposed to belief distortion and to uncited "supported" answers — so
+    // the gate MUST be end-to-end here. Both flags off ⇒ empty gate ⇒ the L3
+    // serve is byte-identical to before (resolveAnswerIntegrity makes no LLM
+    // call and returns {} when PLAUSIBILITY_CHECK is off, and REQUIRE_CITATIONS
+    // off is a no-op). Cache-admit ordering is unchanged: gate → finalizeVerdict
+    // → admit(final); a downgraded L3 abstain (reason=low_coverage, citations=[])
+    // is rejected by admit()'s existing gate, so it is never cached.
+    return this.finalizeAndAdmit(
+      { cache: args.cache, dto: args.dto, profile: args.profile, model: args.model },
+      l3.verdict,
+      {
+        answer: l3.answer,
+        citations: l3.citations,
+        results: args.results,
+        guardrails: args.guardrails,
+        decisionLog: args.explain
+          ? buildDecisionLog(args.results, new Set(l3.citations.map((c) => c.factId)))
+          : undefined,
+        abstention: profile.abstentionCalibration,
+      },
+    );
   }
 
   /**
@@ -625,13 +641,15 @@ export class SynthesizeService {
    * verdict/answer/reason/citations and no-ops otherwise, so abstentions,
    * unverified returns, low_coverage and partial verdicts are never cached.
    *
-   * `ctx.dto`+`ctx.profile` are supplied ONLY on the PRIMARY serving path;
-   * when present they resolve the default-off verifier answer-integrity arm
-   * (Parts A + C — answer-integrity.ts) over the supported verdict and merge
-   * the gate flags into finalizeVerdict. The L3 fail-flip path omits them, so
-   * its raw-transcript answer is untouched. BOTH flags off ⇒ empty gate ⇒
-   * byte-identical serve either way. The auditor model (profile.verifierModel
-   * || synthesis model) is resolved here so the caller carries no branch.
+   * `ctx.dto`+`ctx.profile` are supplied by BOTH serving paths — the primary
+   * serve AND the L3 flip — so both resolve the default-off verifier
+   * answer-integrity arm (Parts A + C — answer-integrity.ts) over the supported
+   * verdict and merge the gate flags into finalizeVerdict. BOTH flags off ⇒
+   * empty gate ⇒ byte-identical serve on either path (no LLM call, no flag
+   * effect). A gate downgrade produces a low_coverage/zero-citation result that
+   * admit() rejects, so a downgraded answer is never cached. The auditor model
+   * (profile.verifierModel || synthesis model) is resolved here so the caller
+   * carries no branch.
    */
   private async finalizeAndAdmit(
     ctx: FinalizeContext,

--- a/test/l3-escalation.e2e-spec.ts
+++ b/test/l3-escalation.e2e-spec.ts
@@ -60,6 +60,24 @@ describe('G2 L3 escalation e2e', () => {
     return m ? parseInt(m[1]!, 10) : 0;
   }
 
+  async function counter(app: AppFixture, name: string): Promise<number> {
+    const metrics = app.app.get(MetricsService);
+    const { body } = await metrics.serialize();
+    const m = body.match(new RegExp(`^${name} (\\d+)`, 'm'));
+    return m ? parseInt(m[1]!, 10) : 0;
+  }
+
+  // A flipping L3 re-verification (supported + answering).
+  const L3_VERIFY_PASS = JSON.stringify({
+    verdict: 'supported',
+    unsupportedClaims: [],
+    questionAnswered: true,
+  });
+  const JUDGE_IMPLAUSIBLE = JSON.stringify({
+    plausible: false,
+    rationale: 'the cited transcript premise is a sandbox-only counterfactual',
+  });
+
   beforeAll(async () => {
     delete process.env.RETRIEVAL_L3_ESCALATION;
     f = await createApp();
@@ -119,8 +137,15 @@ describe('G2 L3 escalation e2e', () => {
     });
   });
 
+  afterEach(() => {
+    delete process.env.FOVEA_PLAUSIBILITY_CHECK;
+    delete process.env.FOVEA_REQUIRE_CITATIONS;
+  });
+
   afterAll(async () => {
     delete process.env.RETRIEVAL_L3_ESCALATION;
+    delete process.env.FOVEA_PLAUSIBILITY_CHECK;
+    delete process.env.FOVEA_REQUIRE_CITATIONS;
     if (f) await f.close();
     if (f2) await f2.close();
   });
@@ -183,5 +208,93 @@ describe('G2 L3 escalation e2e', () => {
     // Trigger fired but no session anchor → no generation escalation.
     expect(state.calls.length).toBe(2);
     expect(await l3Count(f2, 'skipped_no_anchor')).toBe(skipBefore + 1);
+  });
+
+  // ── Answer-integrity gate on the L3 flip path ─────────────────────
+  // The L3 answer grounds on the RAW TRANSCRIPT, so it MUST pass through the
+  // same default-off Part A + Part C guards as the primary serve.
+
+  it('L3 flip + FOVEA_PLAUSIBILITY_CHECK on + implausible judge → downgraded to abstain (not served)', async () => {
+    process.env.RETRIEVAL_L3_ESCALATION = '1';
+    process.env.FOVEA_PLAUSIBILITY_CHECK = '1';
+    const flippedBefore = await l3Count(f, 'flipped');
+    const downgradeBefore = await counter(f, 'brain_plausibility_downgrade_total');
+    // gen → verify(fail) → L3 gen(cited) → L3 verify(pass) → plausibility judge.
+    const state = mockSynthesizeOpenAi(f.app, [
+      R1_GEN,
+      R1_VERIFY,
+      JSON.stringify({ answer: L3_ANSWER, citedFactIds: [anchoredFactId] }),
+      L3_VERIFY_PASS,
+      JUDGE_IMPLAUSIBLE,
+    ]);
+    const res = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: ANCHOR_QUERY, limit: 5 });
+    expect(res.status).toBe(201);
+    // The L3 supported answer is withheld — abstain instead of serving the
+    // belief-distorted, transcript-grounded answer.
+    expect(res.body.answer).not.toBe(L3_ANSWER);
+    expect(res.body.reason).toBe('low_coverage');
+    expect(res.body.citations ?? []).toEqual([]);
+    // The L3 still flipped (the ladder is untouched); the gate ran AFTER.
+    expect(await l3Count(f, 'flipped')).toBe(flippedBefore + 1);
+    // The fifth call is the plausibility auditor over the L3 answer's premise.
+    expect(state.calls.length).toBe(5);
+    expect(state.calls[4]!.system).toContain('plausibility auditor');
+    expect(await counter(f, 'brain_plausibility_downgrade_total')).toBe(downgradeBefore + 1);
+  });
+
+  it('L3 flip + FOVEA_REQUIRE_CITATIONS on + uncited L3 answer → abstain', async () => {
+    process.env.RETRIEVAL_L3_ESCALATION = '1';
+    process.env.FOVEA_REQUIRE_CITATIONS = '1';
+    const flippedBefore = await l3Count(f, 'flipped');
+    const guardBefore = await counter(f, 'brain_citation_guard_abstain_total');
+    // The L3 raw-transcript answer is UNCITED by design; require-citations then
+    // abstains it (the correct end-to-end reading of the citation promise). No
+    // plausibility judge — Part C is a pure post-verdict decision → 4 calls.
+    const state = mockSynthesizeOpenAi(f.app, [
+      R1_GEN,
+      R1_VERIFY,
+      JSON.stringify({ answer: L3_ANSWER, citedFactIds: [] as string[] }),
+      L3_VERIFY_PASS,
+    ]);
+    const res = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: ANCHOR_QUERY, limit: 5 });
+    expect(res.status).toBe(201);
+    expect(res.body.answer).not.toBe(L3_ANSWER);
+    expect(res.body.reason).toBe('low_coverage');
+    expect(res.body.citations ?? []).toEqual([]);
+    expect(await l3Count(f, 'flipped')).toBe(flippedBefore + 1);
+    expect(state.calls.length).toBe(4);
+    expect(await counter(f, 'brain_citation_guard_abstain_total')).toBe(guardBefore + 1);
+  });
+
+  it('both integrity flags off → L3 serves byte-identical (cited answer, no reason, no extra call)', async () => {
+    process.env.RETRIEVAL_L3_ESCALATION = '1';
+    // FOVEA_PLAUSIBILITY_CHECK + FOVEA_REQUIRE_CITATIONS both unset (afterEach).
+    const flippedBefore = await l3Count(f, 'flipped');
+    const downgradeBefore = await counter(f, 'brain_plausibility_downgrade_total');
+    const state = mockSynthesizeOpenAi(f.app, [
+      R1_GEN,
+      R1_VERIFY,
+      JSON.stringify({ answer: L3_ANSWER, citedFactIds: [anchoredFactId] }),
+      L3_VERIFY_PASS,
+    ]);
+    const res = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: ANCHOR_QUERY, limit: 5 });
+    expect(res.status).toBe(201);
+    // The L3 answer serves exactly as before, with its citation intact.
+    expect(res.body.answer).toBe(L3_ANSWER);
+    expect(res.body.reason).toBeUndefined();
+    expect(res.body.citations?.map((c: { factId: string }) => c.factId)).toContain(anchoredFactId);
+    // Exactly gen + verify + L3 gen + L3 verify — NO fifth (judge) call.
+    expect(state.calls.length).toBe(4);
+    expect(await l3Count(f, 'flipped')).toBe(flippedBefore + 1);
+    expect(await counter(f, 'brain_plausibility_downgrade_total')).toBe(downgradeBefore);
   });
 });


### PR DESCRIPTION
## fix(fovea): route L3 through the answer-integrity gate (audit R2 P1)

Verified P1: the verifier answer-integrity arm (#337, Parts A `FOVEA_PLAUSIBILITY_CHECK` + C `FOVEA_REQUIRE_CITATIONS`) resolved ONLY on the primary serving path — the **L3 fail-flip path** called `finalizeAndAdmit({cache})`, so `resolveAnswerIntegrity` early-returned `{}` and neither gate ran. L3 is the path that grounds on the RAW TRANSCRIPT (most exposed to belief distortion and to uncited "supported" answers), so the gates were not end-to-end.

### Fix (one call)
`tryL3Escalation` now passes the **same finalize context the primary serve uses** — `{cache, dto, profile, model}` — into `finalizeAndAdmit`. Since `verifierPasses` requires `verdict==='supported'`, every L3 flip carries a supported verdict, so both gates fire. Pure additive-on-the-finalize change: the L3 trigger / anchor / monotone ladder and raw-transcript assembly are untouched (typed-evidence remains the separate #71 track).

- **Plausibility (A) on L3:** an L3 answer built on a cited counterfactual transcript premise downgrades to abstain when the flag is on.
- **Require-citations (C) on L3:** L3 raw-transcript answers can be uncited by design; with the flag on, `finalizeVerdict`'s existing `requireCitations && citations.length===0` branch abstains them — the correct end-to-end reading of the citation-bearing promise. Documented: enabling require-citations is explicitly opting into "no uncited answers, including L3." Default-off → no prod impact.

### Safety
- **Byte-identical both flags off:** `resolvePlausibilityDowngrade` returns false at `if (!plausibilityCheckEnabled()) return false` before any LLM call → `{}` → identical `finalizeVerdict` args → identical serve. Proven by the new regression: both flags off → L3 serves with its citation, `reason` undefined, **exactly 4 LLM calls (no 5th judge)**.
- **Cache-admit ordering unchanged:** gate → finalizeVerdict → admit(final); a downgraded L3 (`reason=low_coverage, citations=[]`) is rejected by admit()'s existing gate, so it's never cached.

### Tests
`l3-escalation.e2e-spec.ts` +3 (L3+plausibility→downgrade, L3+require-citations+uncited→abstain, both-off→byte-identical); answer-integrity + fovea-cascade regression pass. Full unit suite 2389 green; typecheck / lint:ci / format:check clean; gate goldens (flag-budget, config-catalog-truth, env-validation, engine-gates) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
