### PR TITLE
fix(brain-landing): fail-closed end-user BFF exchange + pin userId to session (audit R2 P0)

### DIFF
--- a/brain-landing/__tests__/app-proxy-auth.test.ts
+++ b/brain-landing/__tests__/app-proxy-auth.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Authorization guard rails for the end-user BFF (`/api/app/proxy`).
+ *
+ * Regression coverage for the P0 fixed here: on token-exchange failure the
+ * BFF must NOT fall back to the tenant-wide M2M credential (which the brain
+ * backend lets assert ANY userId), and a client must not be able to pin the
+ * request to another user's slice by passing its own `userId`.
+ *
+ * The whole chain runs for real (route → brainFetch → getBrainToken); only
+ * the JWT verifier (session) and the network (`fetch`) are stubbed, so these
+ * assert the actual fail-closed behaviour rather than a mock of it.
+ */
+import { describe, it, expect, beforeAll, vi, type Mock } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// `server-only` throws outside a server bundling context; neutralise it so
+// the server modules under test import in the node test environment.
+vi.mock('server-only', () => ({}))
+
+// Fixed session: every request in this suite is user "alice". `isAdmin`
+// stays false — the end-user surface, not the admin panel.
+const SESSION_USER = 'alice-user-id'
+vi.mock('@/lib/jwt-verify', () => ({
+  verifyAccessToken: vi.fn(async () => ({
+    sub: SESSION_USER,
+    email: 'alice@test.com',
+  })),
+  isAdminFromToken: () => false,
+}))
+
+// brain-api reads these at module load — set before the dynamic import.
+process.env.BRAIN_APP_ENABLED = '1'
+process.env.OAUTH_CLIENT_SECRET = 'test-secret'
+process.env.OAUTH_CLIENT_ID = 'brain-landing'
+process.env.AUTH_SERVICE_URL = 'https://auth.test'
+process.env.BRAIN_API_URL = 'https://brain.test'
+
+const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange'
+const CLIENT_CREDENTIALS_GRANT = 'client_credentials'
+
+type Route = typeof import('@/app/api/app/proxy/[...path]/route')
+let route: Route
+
+beforeAll(async () => {
+  route = await import('@/app/api/app/proxy/[...path]/route')
+})
+
+/** Stub `fetch`: auth-service token endpoint + brain backend. */
+function stubFetch(opts: { exchangeOk: boolean }): Mock {
+  const f = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url)
+    if (u.includes('/oauth/token')) {
+      const grant = new URLSearchParams(
+        (init?.body as URLSearchParams | undefined) ?? '',
+      ).get('grant_type')
+      if (grant === TOKEN_EXCHANGE_GRANT) {
+        return opts.exchangeOk
+          ? json({ access_token: 'EXCHANGED-TOKEN', expires_in: 300 })
+          : new Response('exchange grant denied', { status: 401 })
+      }
+      // client_credentials (anonymous, tenant-wide M2M) mint.
+      return json({ access_token: 'M2M-TOKEN', expires_in: 300 })
+    }
+    if (u.includes('brain.test')) {
+      return json({ ok: true, url: u })
+    }
+    throw new Error(`unexpected fetch to ${u}`)
+  })
+  globalThis.fetch = f as unknown as typeof fetch
+  return f
+}
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function backendCalls(f: Mock): unknown[][] {
+  return f.mock.calls.filter(([u]) => String(u).includes('brain.test'))
+}
+
+function tokenCalls(f: Mock, grant: string): unknown[][] {
+  return f.mock.calls.filter(
+    ([u, init]) =>
+      String(u).includes('/oauth/token') &&
+      new URLSearchParams(
+        ((init as RequestInit | undefined)?.body as URLSearchParams) ?? '',
+      ).get('grant_type') === grant,
+  )
+}
+
+// Monotonic across the whole file: every request gets a globally-unique
+// session token so brain-api's per-token exchange cache never bleeds a
+// success from one test into another.
+let seq = 0
+/** Unique session cookie token per request → isolate the exchange cache. */
+function req(
+  path: string,
+  init?: { method?: string; body?: unknown },
+): NextRequest {
+  const token = `session-token-${++seq}`
+  const headers: Record<string, string> = { cookie: `access_token=${token}` }
+  if (init?.body !== undefined) headers['content-type'] = 'application/json'
+  return new NextRequest(`https://app.local/api/app/proxy/${path}`, {
+    method: init?.method ?? 'GET',
+    headers,
+    body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+  })
+}
+
+describe('end-user proxy — fail-closed token exchange', () => {
+  it('denies (403) and never mints/uses an M2M token when the exchange fails', async () => {
+    const f = stubFetch({ exchangeOk: false })
+
+    const res = await route.GET(req('v1/stats/overview?userId=someone-else'))
+
+    // Fail closed: authorization error, not a silent downgrade.
+    expect(res.status).toBe(403)
+
+    // The anonymous, tenant-wide M2M credential was never minted…
+    expect(tokenCalls(f, CLIENT_CREDENTIALS_GRANT)).toHaveLength(0)
+    // …and the backend was never hit with an elevated credential.
+    expect(backendCalls(f)).toHaveLength(0)
+    // The only outbound call was the (failed) identity-preserving exchange.
+    expect(tokenCalls(f, TOKEN_EXCHANGE_GRANT)).toHaveLength(1)
+  })
+})
+
+describe('end-user proxy — userId is pinned to the session user', () => {
+  it('overrides a client-supplied ?userId= in the query with the session user', async () => {
+    const f = stubFetch({ exchangeOk: true })
+
+    const res = await route.GET(req('v1/stats/overview?userId=someone-else'))
+
+    expect(res.status).toBe(200)
+    const [backendUrl] = backendCalls(f)[0] as [string, RequestInit]
+    expect(new URL(backendUrl).searchParams.get('userId')).toBe(SESSION_USER)
+  })
+
+  it('overrides a client-supplied userId in the body with the session user', async () => {
+    const f = stubFetch({ exchangeOk: true })
+
+    const res = await route.POST(
+      req('v1/search?userId=query-attacker', {
+        method: 'POST',
+        body: { query: 'hello', userId: 'body-attacker' },
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const [backendUrl, backendInit] = backendCalls(f)[0] as [
+      string,
+      RequestInit,
+    ]
+    // Both surfaces are neutralised.
+    expect(new URL(backendUrl).searchParams.get('userId')).toBe(SESSION_USER)
+    expect(JSON.parse(backendInit.body as string).userId).toBe(SESSION_USER)
+  })
+})
+
+describe('end-user proxy — happy path unchanged', () => {
+  it('forwards the exchanged bearer to the backend (no M2M mint)', async () => {
+    const f = stubFetch({ exchangeOk: true })
+
+    const res = await route.GET(req('v1/stats/overview'))
+
+    expect(res.status).toBe(200)
+    expect(tokenCalls(f, TOKEN_EXCHANGE_GRANT)).toHaveLength(1)
+    expect(tokenCalls(f, CLIENT_CREDENTIALS_GRANT)).toHaveLength(0)
+
+    const [, backendInit] = backendCalls(f)[0] as [string, RequestInit]
+    const auth = (backendInit.headers as Record<string, string>).Authorization
+    expect(auth).toBe('Bearer EXCHANGED-TOKEN')
+  })
+})

--- a/brain-landing/app/api/app/proxy/[...path]/route.ts
+++ b/brain-landing/app/api/app/proxy/[...path]/route.ts
@@ -110,14 +110,40 @@ async function forward(
 
   // Ride the user's identity downstream via token exchange: brain then
   // scopes memory to org (tenant) + sub (this user) instead of the
-  // anonymous service identity. Dev-bypass sessions have no token and
-  // keep the M2M path.
+  // anonymous service identity. A real session carries a token; dev-bypass
+  // sessions have none and keep the M2M operator path (local dev only —
+  // dev-bypass is disabled in production).
+  const userToken = await extractAccessToken(request)
+  const hasUserIdentity = Boolean(userToken)
+
+  // Pin the backend userId to the SESSION user on the authenticated
+  // end-user path. `userId` on brain read/write DTOs is caller-asserted,
+  // so a client must not be able to reach another user's slice by passing
+  // ?userId= or a userId in the body. Override any client-supplied value
+  // with the session's own id (both surfaces). We only rewrite a userId
+  // the client actually sent — never inject one — so endpoints whose DTO
+  // has no userId field (e.g. ingest/link) aren't tripped by the backend's
+  // forbidNonWhitelisted validation. Omitted userIds are scoped to the
+  // session user by the backend's pinUserScope on the exchanged token; the
+  // fail-closed exchange below guarantees that token is always present.
+  if (hasUserIdentity) {
+    if ('userId' in query) query.userId = session.userId
+    if (body && typeof body === 'object' && !Array.isArray(body) && 'userId' in body) {
+      ;(body as Record<string, unknown>).userId = session.userId
+    }
+  }
+
   const res = await brainFetch(`/${subpath}`, {
     method: request.method as 'GET' | 'POST' | 'PUT' | 'DELETE',
     body,
     query,
     scope: USER_SCOPE,
-    userToken: await extractAccessToken(request),
+    userToken,
+    // Fail closed: if the identity-preserving exchange fails for a real
+    // end-user session, deny (403) instead of falling back to the
+    // tenant-wide M2M credential (which the backend would let assert ANY
+    // userId). Only the user-less dev-bypass/system path may ride M2M.
+    requireUserIdentity: hasUserIdentity,
     headers: forwardDebug ? { 'X-Brain-Debug': '1' } : undefined,
   })
 

--- a/brain-landing/lib/brain-api.ts
+++ b/brain-landing/lib/brain-api.ts
@@ -17,6 +17,15 @@
  * used for calls with no user in scope and as a graceful degrade while
  * the auth-service hasn't granted the token-exchange grant yet.
  * Tokens of both kinds are cached in-process until ~30s before expiry.
+ *
+ * SECURITY: the M2M credential holds tenant-wide authority and the brain
+ * backend lets it assert ANY userId (by design, for real M2M). So the
+ * graceful-degrade fallback must NEVER kick in for an end-user request —
+ * that would silently upgrade one user's session to cross-user authority.
+ * Callers on the end-user path pass `requireUserIdentity: true`, which
+ * makes a failed exchange throw {@link TokenExchangeError} (→ fail closed)
+ * instead of degrading. The fallback survives only for genuinely
+ * user-less / system / admin-operator calls.
  */
 
 // Hard server-only gate. The OAUTH_CLIENT_SECRET this module mints
@@ -209,20 +218,51 @@ async function getExchangedToken(
 }
 
 /**
+ * Thrown when an end-user request (`requireUserIdentity: true`) cannot
+ * obtain an identity-preserving token. Callers translate it into a
+ * fail-closed authorization error — the request is denied rather than
+ * executed with the anonymous, tenant-wide M2M credential.
+ */
+export class TokenExchangeError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'TokenExchangeError'
+  }
+}
+
+/**
  * Resolve the bearer token for a brain call. With a user session token,
  * prefer the identity-preserving exchange; degrade to the anonymous M2M
  * mint when exchange is unavailable (grant not provisioned yet, subject
  * token lacking brain scopes) so the dashboard keeps working during the
  * auth-service rollout.
+ *
+ * Fail-closed switch: when `requireUserIdentity` is set AND a `userToken`
+ * is present, a failed exchange throws {@link TokenExchangeError} instead
+ * of degrading to the tenant-wide M2M credential. The end-user BFF sets
+ * this so a broken/unprovisioned exchange can never elevate a user
+ * session to cross-user authority. It has no effect when no `userToken`
+ * is supplied (genuinely user-less / dev-bypass / system calls still mint
+ * M2M), and it is left off by the admin BFF, whose operator identity is
+ * legitimately tenant-wide.
  */
 export async function getBrainToken(opts: {
   scope: string
   userToken?: string | null
+  requireUserIdentity?: boolean
 }): Promise<string> {
   if (opts.userToken) {
     try {
       return await getExchangedToken(opts.userToken, opts.scope)
     } catch (err) {
+      if (opts.requireUserIdentity) {
+        // Fail closed: an authenticated end-user session must never be
+        // downgraded to the anonymous, tenant-wide M2M credential.
+        // Denying is safer than executing with cross-user authority.
+        throw new TokenExchangeError(
+          `token exchange failed for an end-user session; refusing to fall back to tenant-wide M2M authority: ${(err as Error).message}`,
+        )
+      }
       console.warn(
         `[brain-api] token exchange unavailable, falling back to client_credentials: ${(err as Error).message}`,
       )
@@ -260,6 +300,13 @@ export interface BrainFetchOptions {
    * anonymous M2M mint.
    */
   userToken?: string | null
+  /**
+   * Fail-closed switch for the end-user path. When true and
+   * {@link userToken} is present, a failed exchange makes this call
+   * return an authorization error (403) rather than silently degrading
+   * to the tenant-wide M2M credential. See {@link getBrainToken}.
+   */
+  requireUserIdentity?: boolean
 }
 
 export interface BrainResponse<T = unknown> {
@@ -289,8 +336,22 @@ export async function brainFetch<T = unknown>(
     token = options.apiKey
   } else {
     try {
-      token = await getBrainToken({ scope, userToken: options.userToken })
+      token = await getBrainToken({
+        scope,
+        userToken: options.userToken,
+        requireUserIdentity: options.requireUserIdentity,
+      })
     } catch (err) {
+      // Fail-closed exchange (end-user path): surface a denial and never
+      // issue the backend request with a fallback credential.
+      if (err instanceof TokenExchangeError) {
+        return {
+          ok: false,
+          status: 403,
+          data: null,
+          error: (err as Error).message,
+        }
+      }
       return {
         ok: false,
         status: 500,


### PR DESCRIPTION
## fix(brain-landing): fail-closed end-user BFF exchange + pin userId to session (audit R2 P0)

Verified **P0**: on RFC-8693 token-exchange failure the end-user BFF fell back to a tenant-wide **M2M** credential (`brain-landing/lib/brain-api.ts`), the proxy forwarded the client-supplied `userId` unchanged, and the backend lets M2M assert **any** userId (by design) — so a broken/unprovisioned exchange could execute a user request with **cross-user / tenant-wide** authority. Gated by `BRAIN_APP_ENABLED=0` today; a blocker for the public app.

### Fail-closed mechanism
`getBrainToken`/`brainFetch` gained a `requireUserIdentity` opt-in. When set **and a user token is present**, a failed exchange throws the new `TokenExchangeError` instead of degrading to the `client_credentials` M2M mint; `brainFetch` maps it to `{ok:false, status:403}`, and the end-user proxy returns that 403. The M2M fallback survives **only** for the genuinely user-less/system path and the admin BFF/SSE (which don't pass the flag) — real M2M + admin behavior untouched.

### userId pinned to session
In the proxy, on the authenticated-session path any client-supplied `userId` is **overridden** with `session.userId` (in both query and JSON body). It rewrites only a `userId` the client actually sent (never injects one) — because the backend's `ValidationPipe({forbidNonWhitelisted:true})` would 400 endpoints that have no `userId` field; omitted userIds are correctly scoped by the backend's `pinUserScope` on the now-guaranteed identity-preserving token.

### Defense-in-depth (backend, unchanged)
`src/auth/user-scope.ts` already pins a user-bound token: a mismatching `userId` is a 403, an omitted one defaults to the token's user. The intentional M2M-any-userId authority is left as-is. **No backend files changed.**

### Tests / verification
- New `__tests__/app-proxy-auth.test.ts` drives the real route→brainFetch→getBrainToken chain (only the JWT verifier + `fetch` stubbed): **exchange-failure → 403, zero `client_credentials` mints, zero backend calls**; query-userId override; body-userId override; happy path (exchanged bearer forwarded, no M2M mint).
- brain-landing `vitest` 34/34 (+4), `tsc --noEmit` clean, `eslint` on the 3 changed files clean. `BRAIN_APP_ENABLED` gating untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
