### PR TITLE
fix(mri): honest cells — terminal-outcome proxy, upper-bound cost, pending latency, fail-closed recorder, exposed premise (audit R2 P1)

### DIFF
--- a/scripts/mri-record-suite.ts
+++ b/scripts/mri-record-suite.ts
@@ -3,10 +3,18 @@
  * mri-record-suite — record a STRUCTURAL MRI dimension's suite pass status into
  * the ledger (docs/mri/suite-status.json) from a REAL Jest run.
  *
- * This is the only writer of the ledger. A `pass` is therefore always backed by
- * an actual green run at a named commit — never hand-edited, never guessed. The
- * MRI report reads the ledger for premise-awareness / poisoning-resistance /
- * tenant-user-isolation and renders whatever the last real run recorded.
+ * This is the only writer of the ledger. It is FAIL-CLOSED: a recorded `pass`
+ * ALWAYS corresponds to a real green run of the REAL, canonical suite —
+ *   - the suite key is pinned to its file(s) internally (src/mri/suite-status.ts);
+ *     there is NO `--files` override, so a suite cannot be substituted;
+ *   - a non-zero Jest exit is NEVER recorded as a pass (it records `fail`, or
+ *     refuses to write when the run produced no parseable result / no tests);
+ *   - an exit-0 run that executed ZERO tests is refused (a vacuous pass is not a
+ *     pass);
+ *   - `--gap` must be a bounded non-negative integer.
+ * No hand-editing. The MRI report reads the ledger for premise-awareness /
+ * poisoning-resistance / tenant-user-isolation and renders whatever the last
+ * real run recorded.
  *
  * Run:
  *   pnpm mri:record-suite tenant-user-isolation --config test/jest-unit.json
@@ -14,8 +22,7 @@
  *
  * Flags:
  *   --config <path>   Jest config (default test/jest-unit.json)
- *   --gap <n>         Domain gap count to record (e.g. MINJA GAP count)
- *   --files a,b       Override the suite file list (comma-separated)
+ *   --gap <n>         Domain gap count to record (non-negative integer, ≤ 10000)
  */
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -27,33 +34,53 @@ import {
   type SuiteLedgerEntry,
 } from '../src/mri/suite-status';
 
-interface Args {
+/** Upper bound on `--gap` — a domain gap count is small (e.g. MINJA GAP count). */
+export const MAX_GAP = 10_000;
+
+export interface Args {
   key: string;
   config: string;
   gap?: number;
-  files?: string[];
 }
 
-function parseArgs(argv: string[]): Args {
+function parseGap(raw: string): number {
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`--gap must be a non-negative integer, got '${raw}'`);
+  }
+  const n = Number(raw);
+  if (!Number.isSafeInteger(n) || n < 0 || n > MAX_GAP) {
+    throw new Error(`--gap out of range [0, ${MAX_GAP}], got '${raw}'`);
+  }
+  return n;
+}
+
+/**
+ * Parse argv. Rejects unknown/unsupported flags — in particular `--files`, which
+ * used to allow substituting a canonical suite's file list (a false-green vector).
+ * Canonical suites are pinned to their files in src/mri/suite-status.ts.
+ */
+export function parseArgs(argv: string[]): Args {
   const key = argv[0];
   if (!key || key.startsWith('--')) {
-    throw new Error(
-      'usage: mri:record-suite <suiteKey> [--config <path>] [--gap <n>] [--files a,b]',
-    );
+    throw new Error('usage: mri:record-suite <suiteKey> [--config <path>] [--gap <n>]');
   }
   const out: Args = { key, config: 'test/jest-unit.json' };
   for (let i = 1; i < argv.length; i += 1) {
     const flag = argv[i];
     const val = argv[i + 1];
-    if (flag === '--config' && val) {
+    if (flag === '--config') {
+      if (val === undefined || val.startsWith('--')) throw new Error('--config requires a path');
       out.config = val;
       i += 1;
-    } else if (flag === '--gap' && val) {
-      out.gap = Number(val);
+    } else if (flag === '--gap') {
+      if (val === undefined) throw new Error('--gap requires a value');
+      out.gap = parseGap(val);
       i += 1;
-    } else if (flag === '--files' && val) {
-      out.files = val.split(',').map((s) => s.trim());
-      i += 1;
+    } else {
+      throw new Error(
+        `unknown or unsupported flag '${flag ?? ''}' — canonical suites are pinned to their files ` +
+          'in src/mri/suite-status.ts; `--files` suite substitution is not allowed',
+      );
     }
   }
   return out;
@@ -67,13 +94,30 @@ function gitCommit(): string | undefined {
   }
 }
 
-interface JestJson {
+export interface JestJson {
   success: boolean;
   numPassedTests: number;
   numFailedTests: number;
 }
 
-function runJest(config: string, files: string[]): JestJson {
+/** A Jest invocation's outcome: its process exit code + parsed --json (or null). */
+export interface JestRun {
+  exitCode: number;
+  json: JestJson | null;
+}
+
+function parseJestJson(stdout: string): JestJson | null {
+  const start = stdout.indexOf('{');
+  const end = stdout.lastIndexOf('}');
+  if (start === -1 || end === -1) return null;
+  try {
+    return JSON.parse(stdout.slice(start, end + 1)) as JestJson;
+  } catch {
+    return null;
+  }
+}
+
+function runJest(config: string, files: string[]): JestRun {
   // Patterns must override the worktree ignore defaults (jest configs ignore
   // /.claude/worktrees/, which would otherwise skip everything here).
   const pattern = files.map((f) => f.replace(/[.]/g, '\\.')).join('|');
@@ -89,20 +133,77 @@ function runJest(config: string, files: string[]): JestJson {
     '/node_modules/',
   ];
   let stdout = '';
+  let exitCode = 0;
   try {
     stdout = execFileSync('npx', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] });
   } catch (err) {
-    // Jest exits non-zero on failing tests; the JSON is still on stdout.
-    const e = err as { stdout?: string | Buffer };
+    // Jest exits non-zero on failing tests (JSON still on stdout) OR crashes
+    // (no/garbage JSON). Capture the ACTUAL exit code — it is the load-bearing
+    // signal: a non-zero exit is never recorded as a pass.
+    const e = err as { status?: number | null; stdout?: string | Buffer };
+    exitCode = typeof e.status === 'number' ? e.status : 1;
     stdout = typeof e.stdout === 'string' ? e.stdout : (e.stdout?.toString() ?? '');
   }
-  const start = stdout.indexOf('{');
-  const end = stdout.lastIndexOf('}');
-  if (start === -1 || end === -1) {
-    throw new Error(`could not parse Jest --json output for ${files.join(',')}`);
+  return { exitCode, json: parseJestJson(stdout) };
+}
+
+/**
+ * Turn a Jest run into a ledger entry — FAIL-CLOSED. A `pass` requires ALL of:
+ * exit code 0, `success`, zero failed tests, and at least one PASSED test (a
+ * run that matched no tests is not a pass). Any other exit-0 shape, and every
+ * unparseable / no-tests-executed run, THROWS (refuse to write). A non-zero exit
+ * with real failures records `fail`. So the ledger never gains a false green.
+ */
+export function decideEntry(
+  run: JestRun,
+  opts: { gap?: number; commit?: string; now?: Date } = {},
+): SuiteLedgerEntry {
+  const recordedAt = (opts.now ?? new Date()).toISOString();
+  const extra = {
+    ...(opts.commit ? { commit: opts.commit } : {}),
+    ...(opts.gap !== undefined ? { gapCount: opts.gap } : {}),
+  };
+
+  if (run.json === null) {
+    throw new Error(
+      `refusing to record: could not parse Jest --json output (exit ${run.exitCode}) — the suite ` +
+        'produced no result, so neither pass nor fail can be attested',
+    );
   }
-  const parsed = JSON.parse(stdout.slice(start, end + 1)) as JestJson;
-  return parsed;
+  const { success, numPassedTests, numFailedTests } = run.json;
+  const ranTests = numPassedTests + numFailedTests;
+
+  if (run.exitCode === 0) {
+    if (!success || numFailedTests > 0 || numPassedTests === 0) {
+      throw new Error(
+        `refusing to record a pass: exit 0 but success=${success}, passed=${numPassedTests}, ` +
+          `failed=${numFailedTests} — a pass must be a real green run of real tests`,
+      );
+    }
+    return {
+      status: 'pass',
+      numPassed: numPassedTests,
+      numFailed: numFailedTests,
+      recordedAt,
+      ...extra,
+    };
+  }
+
+  // Non-zero exit → NEVER a pass.
+  if (ranTests === 0) {
+    throw new Error(
+      `refusing to record: Jest exited ${run.exitCode} with no tests executed (crash / no match) — ` +
+        'not a real fail either',
+    );
+  }
+  return {
+    status: 'fail',
+    numPassed: numPassedTests,
+    numFailed: numFailedTests,
+    recordedAt,
+    note: `jest exited ${run.exitCode}`,
+    ...extra,
+  };
 }
 
 function loadLedger(path: string): SuiteLedger {
@@ -117,21 +218,21 @@ function loadLedger(path: string): SuiteLedger {
 function main(): void {
   const args = parseArgs(process.argv.slice(2));
   const spec = ALL_SUITE_SPECS.find((s) => s.key === args.key);
-  const files = args.files ?? spec?.files;
-  if (!files || files.length === 0) {
-    throw new Error(`unknown suite key '${args.key}' and no --files given`);
+  if (!spec) {
+    throw new Error(
+      `unknown suite key '${args.key}' — canonical keys: ${ALL_SUITE_SPECS.map((s) => s.key).join(', ')}`,
+    );
+  }
+  if (!existsSync(args.config)) {
+    throw new Error(`Jest config not found: ${args.config}`);
   }
 
-  const result = runJest(args.config, files);
+  const run = runJest(args.config, spec.files);
   const commit = gitCommit();
-  const entry: SuiteLedgerEntry = {
-    status: result.success ? 'pass' : 'fail',
-    numPassed: result.numPassedTests,
-    numFailed: result.numFailedTests,
-    recordedAt: new Date().toISOString(),
+  const entry = decideEntry(run, {
+    ...(args.gap !== undefined ? { gap: args.gap } : {}),
     ...(commit ? { commit } : {}),
-    ...(args.gap !== undefined ? { gapCount: args.gap } : {}),
-  };
+  });
 
   const ledger = loadLedger(DEFAULT_LEDGER_PATH);
   ledger[args.key] = entry;
@@ -142,4 +243,11 @@ function main(): void {
   );
 }
 
-main();
+if (require.main === module) {
+  try {
+    main();
+  } catch (e) {
+    process.stderr.write(`✗ mri:record-suite failed: ${(e as Error).message}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/mri-report.ts
+++ b/scripts/mri-report.ts
@@ -22,6 +22,7 @@ import { readerFromPromJson } from '../src/mri/metrics-reader';
 import { buildMriReport } from '../src/mri/mri-collectors';
 import { loadSuiteLedger } from '../src/mri/suite-status';
 import { renderMriMarkdown } from '../src/mri/mri-markdown';
+import { plausibilityCheckEnabled } from '../src/common/fovea-flags';
 import type { MriReport } from '../src/mri/mri.types';
 
 async function fetchLive(url: string, key: string): Promise<MriReport> {
@@ -36,9 +37,10 @@ async function fetchLive(url: string, key: string): Promise<MriReport> {
 
 function buildCold(): MriReport {
   // Empty reader → no counters/histograms; live dims render pending honestly.
+  // The premise-awareness DEFENSE state still reflects the real flag (read-only).
   const reader = readerFromPromJson([]);
   const ledger = loadSuiteLedger();
-  return buildMriReport(reader, ledger);
+  return buildMriReport(reader, ledger, { plausibilityCheckEnabled: plausibilityCheckEnabled() });
 }
 
 async function main(): Promise<void> {

--- a/src/contracts/admin/mri.schema.ts
+++ b/src/contracts/admin/mri.schema.ts
@@ -20,7 +20,10 @@ export const PolicyOperatingPointSchema = z.object({
   ece: z.number().nullable(),
   latencyP50: z.number().nullable(),
   latencyP95: z.number().nullable(),
-  costPerQuery: z.number().nullable(),
+  // Renamed from `costPerQuery`: the value is an UPPER BOUND (all-AI tokens ÷
+  // synthesize count), not the true per-answer cost — the token counters are not
+  // separable by subsystem. The name says so to prevent misreading.
+  costPerQueryUpperBound: z.number().nullable(),
   sampleCount: z.number(),
 });
 

--- a/src/mri/economics.ts
+++ b/src/mri/economics.ts
@@ -1,5 +1,5 @@
 import type { MetricsReader } from './metrics-reader';
-import { histogramQuantile, sumCounter } from './metrics-reader';
+import { sumCounter } from './metrics-reader';
 
 /**
  * Part 1 — the economics operating-point + Pareto reporter
@@ -7,17 +7,33 @@ import { histogramQuantile, sumCounter } from './metrics-reader';
  *
  * A policy operating-point is one row on the accuracy × cost × latency
  * surface: "with THIS flag set, over THIS window, the pipeline served at
- * this proxy-accuracy, this $/query, this p50/p95". Every axis except
- * accuracy comes straight off existing telemetry. The accuracy axis is a
+ * this proxy-accuracy, this $/query, this p50/p95". The accuracy axis is a
  * cheap ONLINE PROXY — the verifier `supported`-rate — NOT a true accuracy
  * claim; the field is named `accuracyProxy` and labelled "proxy" everywhere
  * so it can never be mistaken for the parked paid-eval number.
  *
+ * HONESTY FIXES over the first cut (all so a green cell means what it says):
+ *   - accuracyProxy denominator = TERMINAL synthesize outcomes only. A single
+ *     request can bump brain_synthesize_total more than once (the intermediate
+ *     `generator_truncated` / `search_loop_refined` tags), so the raw total is
+ *     NOT the request count. We sum only the per-request terminal set
+ *     (TERMINAL_SYNTHESIZE_OUTCOMES) for the denominator.
+ *   - cost is an UPPER BOUND, not the per-answer cost. The token counters carry
+ *     no per-subsystem label, so `costPerQueryUpperBound` divides GLOBAL AI
+ *     tokens (embed + chat across derive/dreams/ingest/synthesize) by the
+ *     synthesize request count — it over-attributes non-synthesize spend. The
+ *     field name + labels say so; it is never presented as the true answer cost.
+ *   - latency is `null` here: no per-query latency histogram is emitted on the
+ *     serving path (brain_search_duration_seconds is defined but its
+ *     observe() is never called outside a unit test), so the cell renders
+ *     `pending` with that reason rather than a fabricated number.
+ *
  * The reporter renders the Pareto frontier over a set of points and flags
  * the dominated ones (accuracy↑ better, cost↓ better, latency↓ better). The
  * ship-gate is ADVISORY ONLY (§1.3): it REPORTS that a candidate is
- * dominated; it never blocks. Latency/cost are real; only accuracy is a
- * proxy until the eval is unfrozen.
+ * dominated; it never blocks. Only the accuracy axis is a proxy; cost is an
+ * explicit upper bound and latency is pending until a serving-path histogram
+ * exists — so a live operating point lands in `insufficientData` until then.
  */
 
 /** USD per 1,000,000 tokens. Assumed list price — the token COUNTS are exact
@@ -38,31 +54,39 @@ export const DEFAULT_PRICE_TABLE: PriceTable = {
 };
 
 /**
- * One point on the accuracy × cost × latency surface. The literal shape from
- * §1: `flags`, `accuracyProxy`, `ece`, `latencyP50`, `latencyP95`,
- * `costPerQuery`. Measured axes are `number | null` — null means "no telemetry
- * in the window", never a fabricated zero (the inviolable rule). `ece` is null
- * until calibration labels exist. `sampleCount` carries the provenance (how
- * many synthesize calls the window saw) so a consumer can see an empty window.
+ * One point on the accuracy × cost × latency surface: `flags`, `accuracyProxy`,
+ * `ece`, `latencyP50`, `latencyP95`, `costPerQueryUpperBound`. Measured axes are
+ * `number | null` — null means "no telemetry / no serving-path signal", never a
+ * fabricated zero (the inviolable rule). `ece` is null until calibration labels
+ * exist. `sampleCount` carries the provenance (terminal synthesize requests the
+ * window saw) so a consumer can see an empty window.
  */
 export interface PolicyOperatingPoint {
   /** Flags that describe this operating point (caller-supplied — telemetry
    *  does not record which flags were live for a window). */
   flags: string[];
-  /** Verifier `supported`-rate in [0,1]. A PROXY, never a true-accuracy claim.
-   *  null when the window saw no synthesize traffic. */
+  /** Verifier `supported`-rate in [0,1] = ok ÷ TERMINAL synthesize outcomes. A
+   *  PROXY, never a true-accuracy claim. null when the window saw no terminal
+   *  synthesize traffic. */
   accuracyProxy: number | null;
   /** Expected Calibration Error. null until a labeled gold set exists. */
   ece: number | null;
-  /** Median query latency in seconds (search-stage histogram). null = no
-   *  samples. */
+  /** Median query latency in seconds. ALWAYS null today: no per-query latency
+   *  histogram is emitted on the serving path (brain_search_duration_seconds is
+   *  defined but never observed outside a unit test). Kept on the shape so a
+   *  future serving-path histogram fills it without a contract change. */
   latencyP50: number | null;
-  /** p95 query latency in seconds. null = no samples. */
+  /** p95 query latency in seconds. ALWAYS null today (see latencyP50). */
   latencyP95: number | null;
-  /** Estimated USD per query (exact token counters × assumed price table).
-   *  null = no traffic. */
-  costPerQuery: number | null;
-  /** synthesize invocations observed in the window (provenance for the axes). */
+  /** Estimated USD per query — UPPER BOUND, NOT the true per-answer cost. All-AI
+   *  tokens (embed + chat across derive/dreams/ingest/synthesize — the token
+   *  counters carry no per-subsystem label) × assumed price ÷ terminal
+   *  synthesize count, so it over-attributes non-synthesize AI spend to
+   *  synthesize requests. null = no terminal synthesize traffic. */
+  costPerQueryUpperBound: number | null;
+  /** Terminal synthesize requests observed in the window (each request lands in
+   *  exactly one terminal outcome; intermediate outcomes excluded). Provenance
+   *  for the axes and the per-request denominator. */
   sampleCount: number;
 }
 
@@ -74,12 +98,59 @@ export interface CollectOperatingPointOptions {
 }
 
 /**
- * Assemble ONE operating point from a telemetry reader over the current
- * window. accuracyProxy = supported-rate = synthesize{outcome=ok} ÷ synthesize
- * total. Cost = (prompt/completion/embed tokens × price) ÷ query count. Latency
- * = search-duration histogram quantiles (the only per-query latency histogram
- * the pipeline emits; there is no end-to-end synthesize histogram, and adding
- * one would touch the serving path). ece stays null — no labels here.
+ * The synthesize outcomes that fire EXACTLY ONCE per request — the request's
+ * terminal disposition. Each served request lands in exactly one of these, so
+ * their sum is the honest per-request denominator.
+ *
+ * EXCLUDED (intermediate — they fire ALONGSIDE a terminal outcome, so counting
+ * them double-counts the request):
+ *   - `generator_truncated`  — the generator hit the token cap and its partial
+ *      answer was salvaged (generator-client.ts); the salvaged answer still
+ *      flows on to a terminal verdict.
+ *   - `search_loop_refined`  — the V13 constrained refine round ran
+ *      (synthesize.service.ts); "the final outcome is still counted separately".
+ *
+ * Enumerated from metrics.service.ts `countSynthesize`. Keep in sync if a new
+ * TERMINAL outcome is added there — a missing terminal outcome would understate
+ * the denominator and INFLATE the proxy, so this list is the source of truth.
+ */
+export const TERMINAL_SYNTHESIZE_OUTCOMES = [
+  'ok',
+  'no_results',
+  'no_grounded_evidence',
+  'low_coverage',
+  'verifier_partial',
+  'verifier_failed',
+  'generator_error',
+  'verifier_error',
+] as const;
+
+const TERMINAL_SYNTHESIZE_SET: ReadonlySet<string> = new Set(TERMINAL_SYNTHESIZE_OUTCOMES);
+
+/**
+ * Count of TERMINAL synthesize outcomes in the window = number of requests that
+ * reached a final disposition (the honest per-request denominator). Series whose
+ * `outcome` is intermediate or absent are excluded.
+ */
+export function terminalSynthesizeCount(reader: MetricsReader): number {
+  let total = 0;
+  for (const s of reader.counter('brain_synthesize_total')) {
+    const outcome = s.labels['outcome'];
+    if (outcome !== undefined && TERMINAL_SYNTHESIZE_SET.has(outcome)) total += s.value;
+  }
+  return total;
+}
+
+/**
+ * Assemble ONE operating point from a telemetry reader over the current window.
+ *   - accuracyProxy = ok ÷ TERMINAL synthesize outcomes (per-request denominator,
+ *     never the double-counting raw total).
+ *   - costPerQueryUpperBound = (all-AI tokens × price) ÷ terminal count. An UPPER
+ *     BOUND: the token counters are not separable by subsystem, so global AI
+ *     spend is attributed to synthesize requests. NOT the per-answer cost.
+ *   - latency stays null: no per-query latency histogram is emitted on the
+ *     serving path (see the file header) — the dimension renders `pending`.
+ *   - ece stays null — no labels here.
  */
 export function collectOperatingPoint(
   reader: MetricsReader,
@@ -88,9 +159,9 @@ export function collectOperatingPoint(
   const pricing = options.pricing ?? DEFAULT_PRICE_TABLE;
   const flags = options.flags ?? [];
 
-  const synthTotal = sumCounter(reader, 'brain_synthesize_total');
+  const terminalTotal = terminalSynthesizeCount(reader);
   const synthOk = sumCounter(reader, 'brain_synthesize_total', { outcome: 'ok' });
-  const accuracyProxy = synthTotal > 0 ? synthOk / synthTotal : null;
+  const accuracyProxy = terminalTotal > 0 ? synthOk / terminalTotal : null;
 
   const chatPrompt = sumCounter(reader, 'brain_openai_tokens_total', {
     kind: 'chat',
@@ -109,39 +180,37 @@ export function collectOperatingPoint(
       chatCompletion * pricing.chatCompletionPerMillion +
       embedPrompt * pricing.embedPromptPerMillion) /
     1_000_000;
-  const costPerQuery = synthTotal > 0 ? totalCostUsd / synthTotal : null;
-
-  const latency = reader.histogram('brain_search_duration_seconds');
-  const latencyP50 = latency ? histogramQuantile(latency, 0.5) : null;
-  const latencyP95 = latency ? histogramQuantile(latency, 0.95) : null;
+  const costPerQueryUpperBound = terminalTotal > 0 ? totalCostUsd / terminalTotal : null;
 
   return {
     flags,
     accuracyProxy,
     ece: null,
-    latencyP50,
-    latencyP95,
-    costPerQuery,
-    sampleCount: synthTotal,
+    // No per-query latency histogram is emitted on the serving path — never a
+    // fabricated number; the cost/latency dims render this as `pending`.
+    latencyP50: null,
+    latencyP95: null,
+    costPerQueryUpperBound,
+    sampleCount: terminalTotal,
   };
 }
 
 /** True iff every axis the frontier compares is present (not null). */
 export function hasCompleteAxes(p: PolicyOperatingPoint): boolean {
-  return p.accuracyProxy !== null && p.costPerQuery !== null && p.latencyP95 !== null;
+  return p.accuracyProxy !== null && p.costPerQueryUpperBound !== null && p.latencyP95 !== null;
 }
 
 /**
- * Pareto domination over (accuracyProxy↑, costPerQuery↓, latencyP95↓): `a`
- * dominates `b` iff `a` is no worse on every axis and strictly better on at
- * least one. Only defined when both points have complete axes.
+ * Pareto domination over (accuracyProxy↑, costPerQueryUpperBound↓,
+ * latencyP95↓): `a` dominates `b` iff `a` is no worse on every axis and strictly
+ * better on at least one. Only defined when both points have complete axes.
  */
 export function dominates(a: PolicyOperatingPoint, b: PolicyOperatingPoint): boolean {
   if (!hasCompleteAxes(a) || !hasCompleteAxes(b)) return false;
   const aAcc = a.accuracyProxy as number;
   const bAcc = b.accuracyProxy as number;
-  const aCost = a.costPerQuery as number;
-  const bCost = b.costPerQuery as number;
+  const aCost = a.costPerQueryUpperBound as number;
+  const bCost = b.costPerQueryUpperBound as number;
   const aLat = a.latencyP95 as number;
   const bLat = b.latencyP95 as number;
 
@@ -224,7 +293,7 @@ export function shipGateAdvisory(
       dominatedBy: dominator,
       advisory:
         `advisory: candidate is DOMINATED (proxy-accuracy ${fmt(candidate.accuracyProxy)}, ` +
-        `$${fmt(candidate.costPerQuery)}/q, p95 ${fmt(candidate.latencyP95)}s) by an incumbent ` +
+        `$${fmt(candidate.costPerQueryUpperBound)}/q upper-bound, p95 ${fmt(candidate.latencyP95)}s) by an incumbent ` +
         `[${dominator.flags.join(',') || 'baseline'}]. Not blocking — accuracy is a proxy until eval is unfrozen.`,
       blocking: false,
     };

--- a/src/mri/mri-collectors.ts
+++ b/src/mri/mri-collectors.ts
@@ -87,24 +87,73 @@ function structuralDim(
 }
 
 /**
- * Premise-awareness — structural. MemTrap shakedown pass status, enriched with
- * the FOVEA_PLAUSIBILITY_CHECK downgrade counter IF the serving path emits one
- * (it currently does not — noted in source, never fabricated).
+ * Premise-awareness — the actual belief-distortion DEFENSE posture, NOT merely
+ * "the MemTrap suite passed".
+ *
+ * The MemTrap shakedown suite DOCUMENTS AND ASSERTS current EXPOSURES — its
+ * class-4 case asserts that a cited counterfactual/sandbox premise makes a
+ * distorted answer verify as `supported` and be SERVED. So a passing suite means
+ * "the exposures are as documented / gated against regression", NOT "we are
+ * premise-aware". Rendering that as a green `pass` would be a false green.
+ *
+ * The real defense is FOVEA_PLAUSIBILITY_CHECK (the post-grounding plausibility
+ * judge that downgrades an implausible cited premise to an abstain). This cell
+ * therefore reflects that flag's state, resolved read-only by the service from
+ * `plausibilityCheckEnabled()` and passed in:
+ *   - defense OFF  → `exposed` (never a pass): the documented belief-distortion
+ *     answer is live. Backed by the suite that documents the exposure.
+ *   - defense ON   → `defended`: report the live downgrade activity from
+ *     brain_plausibility_downgrade_total (the metric prod actually emits).
  */
-function premiseAwarenessDim(
-  reader: MetricsReader,
-  ledger: SuiteLedger,
-  nowIso: string,
-): MriDimension {
-  const base = structuralDim(PREMISE_SUITE, { ledger, nowIso });
-  const plausibilitySeries = reader.counter('brain_fovea_plausibility_downgrade_total');
-  if (plausibilitySeries.length > 0) {
-    const downgrades = sumCounter(reader, 'brain_fovea_plausibility_downgrade_total');
-    return { ...base, source: `${base.source}; FOVEA_PLAUSIBILITY_CHECK downgrades=${downgrades}` };
+function premiseAwarenessDim(args: {
+  reader: MetricsReader;
+  ledger: SuiteLedger;
+  nowIso: string;
+  plausibilityCheckEnabled: boolean;
+}): MriDimension {
+  const { reader, ledger, nowIso, plausibilityCheckEnabled } = args;
+  const entry = ledger[PREMISE_SUITE.key];
+  const suiteRef = PREMISE_SUITE.files.join(', ');
+  const docRef = PREMISE_SUITE.doc ? ` (${PREMISE_SUITE.doc})` : '';
+  const suiteStatus = entry
+    ? `MemTrap shakedown suite ${suiteRef}${docRef} last-recorded ${entry.status}${
+        entry.commit ? ` @ ${entry.commit}` : ''
+      } (${entry.recordedAt}) — documents current EXPOSURES, not premise-awareness`
+    : `MemTrap shakedown suite ${suiteRef}${docRef} status unrecorded`;
+
+  if (!plausibilityCheckEnabled) {
+    return {
+      value: 'exposed',
+      source: `FOVEA_PLAUSIBILITY_CHECK OFF (no post-grounding plausibility judge); ${suiteStatus}`,
+      asOf: nowIso,
+      evalGated: false,
+      kind: 'structural',
+      reason:
+        'FOVEA_PLAUSIBILITY_CHECK is off, so the belief-distortion defense does not run: a cited ' +
+        'counterfactual/sandbox premise still makes a distorted answer verify as `supported` and be ' +
+        'served (MemTrap shakedown class 4, asserted as a CURRENT exposure). A passing MemTrap suite ' +
+        'only certifies the exposures are as documented, NOT that we are premise-aware — so this is ' +
+        'not a pass.',
+    };
   }
+
+  const downgradeSeries = reader.counter('brain_plausibility_downgrade_total');
+  const downgrades = sumCounter(reader, 'brain_plausibility_downgrade_total');
+  const noActivity =
+    downgradeSeries.length === 0
+      ? {
+          reason:
+            'FOVEA_PLAUSIBILITY_CHECK is on but no supported-answer downgrades have been observed ' +
+            'in the current window (brain_plausibility_downgrade_total absent/zero)',
+        }
+      : {};
   return {
-    ...base,
-    source: `${base.source}; FOVEA_PLAUSIBILITY_CHECK downgrade counter not emitted`,
+    value: 'defended',
+    source: `FOVEA_PLAUSIBILITY_CHECK ON; brain_plausibility_downgrade_total downgrades=${downgrades}; ${suiteStatus}`,
+    asOf: nowIso,
+    evalGated: false,
+    kind: 'live',
+    ...noActivity,
   };
 }
 
@@ -142,23 +191,35 @@ function citationCoverageDim(reader: MetricsReader, nowIso: string): MriDimensio
   });
 }
 
-/** Cost & latency — live (Part 1 axes). tokens/query off the token counters. */
-function tokensPerQueryDim(reader: MetricsReader, nowIso: string): MriDimension {
-  const synthTotal = sumCounter(reader, 'brain_synthesize_total');
+/**
+ * Tokens/query — live (Part 1 axis). All-AI tokens ÷ TERMINAL synthesize count
+ * (`point.sampleCount`, the per-request denominator — not the double-counting
+ * raw brain_synthesize_total). Like cost, this is an UPPER BOUND: the token
+ * counters carry no per-subsystem label, so non-synthesize AI tokens are
+ * attributed to synthesize requests. Labelled as such, never a per-answer count.
+ */
+function tokensPerQueryDim(
+  reader: MetricsReader,
+  point: PolicyOperatingPoint,
+  nowIso: string,
+): MriDimension {
+  const source =
+    'brain_openai_tokens_total (all-AI: embed+chat across derive/dreams/ingest/synthesize) ÷ terminal synthesize count — UPPER BOUND, not synthesize-only';
   const tokens = sumCounter(reader, 'brain_openai_tokens_total');
-  if (synthTotal <= 0) {
+  if (point.sampleCount <= 0) {
     return pendingCell({
-      source: 'brain_openai_tokens_total ÷ brain_synthesize_total',
-      reason: 'no synthesize traffic in the current window (0 queries) — no rate to report',
+      source,
+      reason:
+        'no terminal synthesize traffic in the current window (0 requests) — no rate to report',
       evalGated: false,
       kind: 'live',
       asOf: nowIso,
     });
   }
   return {
-    value: tokens / synthTotal,
-    unit: 'tokens/query',
-    source: 'brain_openai_tokens_total ÷ brain_synthesize_total',
+    value: tokens / point.sampleCount,
+    unit: 'tokens/query (all-AI upper bound)',
+    source,
     asOf: nowIso,
     evalGated: false,
     kind: 'live',
@@ -169,71 +230,66 @@ function costLatencyDims(
   point: PolicyOperatingPoint,
   nowIso: string,
 ): Record<string, MriDimension> {
+  // Cost is an UPPER BOUND: the token counters are not separable by subsystem,
+  // so global AI spend is divided by the synthesize request count. The cell key,
+  // unit, and source all say so — it is never presented as the per-answer cost.
   const costSource =
-    'brain_openai_tokens_total × assumed price table (tokens exact; USD conversion assumed) ÷ brain_synthesize_total';
+    'all-AI tokens (embed+chat across derive/dreams/ingest/synthesize — NOT synthesize-only; the token counters carry no per-subsystem label) × assumed price table ÷ terminal synthesize count. UPPER BOUND, not the true per-answer cost.';
+  // No per-query latency histogram is emitted on the serving path:
+  // brain_search_duration_seconds is defined in metrics.service.ts but
+  // observeSearchDuration() is never called outside a unit test. Adding a
+  // serving-path histogram is a separate follow-up (this layer is read-only), so
+  // latency renders `pending` with that reason — never a fabricated number.
+  const latencyReason = 'no per-query latency histogram is emitted on the serving path';
   const latencySource =
-    'brain_search_duration_seconds histogram quantile (search-stage; no end-to-end query histogram is emitted)';
+    'per-query latency histogram (brain_search_duration_seconds is defined but never observed on the serving path)';
 
   const cost: MriDimension =
-    point.costPerQuery === null
+    point.costPerQueryUpperBound === null
       ? pendingCell({
           source: costSource,
-          reason: 'no synthesize traffic in the current window (0 queries)',
+          reason: 'no terminal synthesize traffic in the current window (0 requests)',
           evalGated: false,
           kind: 'live',
           asOf: nowIso,
         })
       : {
-          value: point.costPerQuery,
-          unit: 'USD/query',
+          value: point.costPerQueryUpperBound,
+          unit: 'USD/query (all-AI upper bound)',
           source: costSource,
           asOf: nowIso,
           evalGated: false,
           kind: 'live',
         };
 
-  const p50: MriDimension =
-    point.latencyP50 === null
-      ? pendingCell({
-          source: latencySource,
-          reason: 'no search-latency samples in the current window',
-          evalGated: false,
-          kind: 'live',
-          asOf: nowIso,
-        })
-      : {
-          value: point.latencyP50,
-          unit: 'seconds',
-          source: latencySource,
-          asOf: nowIso,
-          evalGated: false,
-          kind: 'live',
-        };
+  const latencyPending = (): MriDimension =>
+    pendingCell({
+      source: latencySource,
+      reason: latencyReason,
+      evalGated: false,
+      kind: 'pending',
+      asOf: nowIso,
+    });
 
-  const p95: MriDimension =
-    point.latencyP95 === null
-      ? pendingCell({
-          source: latencySource,
-          reason: 'no search-latency samples in the current window',
-          evalGated: false,
-          kind: 'live',
-          asOf: nowIso,
-        })
-      : {
-          value: point.latencyP95,
-          unit: 'seconds',
-          source: latencySource,
-          asOf: nowIso,
-          evalGated: false,
-          kind: 'live',
-        };
-
-  return { costPerQueryUsd: cost, latencyP50Seconds: p50, latencyP95Seconds: p95 };
+  return {
+    costPerQueryUpperBoundUsd: cost,
+    latencyP50Seconds: latencyPending(),
+    latencyP95Seconds: latencyPending(),
+  };
 }
 
 export interface BuildMriReportOptions {
   now?: Date;
   operatingPoint?: CollectOperatingPointOptions;
+  /**
+   * Actual premise/belief-distortion DEFENSE state — whether
+   * FOVEA_PLAUSIBILITY_CHECK is enabled. Drives the premise-awareness cell (a
+   * passing MemTrap suite documents EXPOSURES, so suite-pass alone is NOT
+   * premise-awareness). Resolved read-only by the service from
+   * `plausibilityCheckEnabled()`. Defaults to `false` (conservative: an
+   * unknown/off defense never renders a green pass — it renders `exposed`).
+   */
+  plausibilityCheckEnabled?: boolean;
 }
 
 /**
@@ -249,16 +305,19 @@ export function buildMriReport(
   const now = options.now ?? new Date();
   const nowIso = now.toISOString();
   const point = collectOperatingPoint(reader, options.operatingPoint ?? {});
+  const plausibilityCheckEnabled = options.plausibilityCheckEnabled ?? false;
 
   const dimensions: Record<string, MriDimension> = {
+    // Defense posture (reflects the real defense state, not a suite pass) --
+    premiseAwareness: premiseAwarenessDim({ reader, ledger, nowIso, plausibilityCheckEnabled }),
+
     // Structural (suite-backed) ------------------------------------------
-    premiseAwareness: premiseAwarenessDim(reader, ledger, nowIso),
     poisoningResistance: structuralDim(POISONING_SUITE, { ledger, nowIso, preferNumericGap: true }),
     tenantUserIsolation: structuralDim(ISOLATION_SUITE, { ledger, nowIso }),
 
     // Live telemetry -----------------------------------------------------
     citationCoverage: citationCoverageDim(reader, nowIso),
-    tokensPerQuery: tokensPerQueryDim(reader, nowIso),
+    tokensPerQuery: tokensPerQueryDim(reader, point, nowIso),
     ...costLatencyDims(point, nowIso),
 
     // Pending — freshness is blocked on F1 (must land first; not built here)

--- a/src/mri/mri-markdown.ts
+++ b/src/mri/mri-markdown.ts
@@ -23,12 +23,24 @@ function fmtNum(v: number | null, digits = 4): string {
 function operatingPointTable(p: PolicyOperatingPoint): string {
   const rows: Array<[string, string]> = [
     ['flags', p.flags.length ? p.flags.join(', ') : '(baseline)'],
-    ['accuracyProxy (verifier supported-rate — PROXY, not true accuracy)', fmtNum(p.accuracyProxy)],
+    [
+      'accuracyProxy (ok ÷ terminal synthesize — PROXY, not true accuracy)',
+      fmtNum(p.accuracyProxy),
+    ],
     ['ece', p.ece === null ? 'pending-eval (needs labels)' : fmtNum(p.ece)],
-    ['latencyP50 (s)', fmtNum(p.latencyP50)],
-    ['latencyP95 (s)', fmtNum(p.latencyP95)],
-    ['costPerQuery (USD, estimate)', fmtNum(p.costPerQuery)],
-    ['sampleCount (synthesize calls in window)', String(p.sampleCount)],
+    [
+      'latencyP50 (s)',
+      p.latencyP50 === null ? 'pending (no serving-path histogram)' : fmtNum(p.latencyP50),
+    ],
+    [
+      'latencyP95 (s)',
+      p.latencyP95 === null ? 'pending (no serving-path histogram)' : fmtNum(p.latencyP95),
+    ],
+    [
+      'costPerQueryUpperBound (USD, all-AI upper bound — NOT per-answer cost)',
+      fmtNum(p.costPerQueryUpperBound),
+    ],
+    ['sampleCount (terminal synthesize requests in window)', String(p.sampleCount)],
   ];
   return ['| Axis | Value |', '| --- | --- |', ...rows.map(([k, v]) => `| ${k} | ${v} |`)].join(
     '\n',
@@ -71,7 +83,7 @@ export function renderMriMarkdown(report: MriReport, pareto?: ParetoReport): str
     for (const p of pareto.frontier) {
       lines.push(
         `- [${p.flags.join(',') || 'baseline'}] proxy=${fmtNum(p.accuracyProxy)} ` +
-          `$${fmtNum(p.costPerQuery)}/q p95=${fmtNum(p.latencyP95)}s`,
+          `$${fmtNum(p.costPerQueryUpperBound)}/q (upper bound) p95=${fmtNum(p.latencyP95)}s`,
       );
     }
     if (pareto.dominated.length) {

--- a/src/mri/mri.service.ts
+++ b/src/mri/mri.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { MetricsService } from '../metrics/metrics.service';
+import { plausibilityCheckEnabled } from '../common/fovea-flags';
 import { readerFromPromJson, type PromMetricJson } from './metrics-reader';
 import { buildMriReport, type BuildMriReportOptions } from './mri-collectors';
 import { loadSuiteLedger, DEFAULT_LEDGER_PATH } from './suite-status';
@@ -24,12 +25,18 @@ export class MriService {
 
   constructor(private readonly metrics: MetricsService) {}
 
-  /** Build a fresh report from live telemetry + the ledger, persist, and return. */
+  /** Build a fresh report from live telemetry + the ledger, persist, and return.
+   *  Resolves the premise-awareness DEFENSE state (FOVEA_PLAUSIBILITY_CHECK) via
+   *  the common-layer flag reader — a read-only config read, no serving-path
+   *  touch — unless the caller pinned it explicitly (tests). */
   async generate(options: BuildMriReportOptions = {}): Promise<MriReport> {
     const json = (await this.metrics.registry.getMetricsAsJSON()) as unknown as PromMetricJson[];
     const reader = readerFromPromJson(json);
     const ledger = loadSuiteLedger(this.ledgerPath);
-    const report = buildMriReport(reader, ledger, options);
+    const report = buildMriReport(reader, ledger, {
+      ...options,
+      plausibilityCheckEnabled: options.plausibilityCheckEnabled ?? plausibilityCheckEnabled(),
+    });
     this.persist(report);
     return report;
   }

--- a/test/mri-admin.e2e-spec.ts
+++ b/test/mri-admin.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('GET /v1/admin/mri (admin-gated, read-only)', () => {
       .set({ Authorization: `Bearer ${f.apiKey}` });
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('accuracyProxy');
-    expect(res.body).toHaveProperty('costPerQuery');
+    expect(res.body).toHaveProperty('costPerQueryUpperBound');
     expect(res.body).toHaveProperty('sampleCount');
   });
 

--- a/test/mri-aggregator.unit-spec.ts
+++ b/test/mri-aggregator.unit-spec.ts
@@ -73,41 +73,44 @@ describe('buildMriReport — free (live telemetry) dimensions', () => {
     now: new Date('2026-08-24T12:00:00.000Z'),
   });
 
-  it('tokens/query is a real number off the token counters', () => {
+  it('tokens/query is a real number off the token counters (÷ terminal count)', () => {
     const d = report.dimensions.tokensPerQuery!;
-    expect(d.value).toBe(1250); // 125,000 tokens / 100 queries
-    expect(d.unit).toBe('tokens/query');
+    expect(d.value).toBe(1250); // 125,000 tokens / 100 terminal requests
+    expect(d.unit).toBe('tokens/query (all-AI upper bound)');
     expect(d.kind).toBe('live');
     expect(d.evalGated).toBe(false);
   });
 
-  it('cost/query is derived from exact token counts × the price table', () => {
-    const d = report.dimensions.costPerQueryUsd!;
-    // (100000*0.15 + 20000*0.6 + 5000*0.02)/1e6 / 100 queries = 0.000271
+  it('cost/query is an UPPER BOUND off exact token counts × the price table', () => {
+    const d = report.dimensions.costPerQueryUpperBoundUsd!;
+    // (100000*0.15 + 20000*0.6 + 5000*0.02)/1e6 / 100 terminal = 0.000271
     expect(typeof d.value).toBe('number');
     expect(d.value as number).toBeCloseTo(0.000271, 9);
-    expect(d.unit).toBe('USD/query');
+    expect(d.unit).toBe('USD/query (all-AI upper bound)');
+    expect(d.source).toMatch(/UPPER BOUND/);
   });
 
-  it('p50/p95 latency are histogram-quantile numbers', () => {
-    expect(report.dimensions.latencyP50Seconds!.value as number).toBeCloseTo(0.1, 6);
-    expect(report.dimensions.latencyP95Seconds!.value as number).toBeCloseTo(0.40625, 6);
+  it('p50/p95 latency render pending — no serving-path histogram is emitted', () => {
+    for (const key of ['latencyP50Seconds', 'latencyP95Seconds'] as const) {
+      const d = report.dimensions[key]!;
+      expect(d.value).toBe('pending-eval');
+      expect(d.kind).toBe('pending');
+      expect(d.reason).toMatch(/no per-query latency histogram is emitted on the serving path/);
+    }
   });
 
-  it('exposes a live operating point (proxy-accuracy = supported-rate)', () => {
+  it('exposes a live operating point (proxy-accuracy = ok ÷ terminal); latency null', () => {
     const p = report.operatingPoint;
     expect(p.accuracyProxy).toBeCloseTo(0.8, 6);
     expect(p.ece).toBeNull();
     expect(p.sampleCount).toBe(100);
-    expect(p.latencyP95).toBeCloseTo(0.40625, 6);
+    expect(p.latencyP95).toBeNull();
   });
 });
 
 describe('buildMriReport — structural (suite-backed) dimensions', () => {
   it('renders the ledger status for a recorded suite', () => {
     const report = buildMriReport(busyReader(), GREEN_LEDGER, {});
-    expect(report.dimensions.premiseAwareness!.value).toBe('pass');
-    expect(report.dimensions.premiseAwareness!.kind).toBe('structural');
     expect(report.dimensions.tenantUserIsolation!.value).toBe('pass');
     // Poisoning prefers the numeric GAP count (0 = no gaps).
     expect(report.dimensions.poisoningResistance!.value).toBe(0);
@@ -116,19 +119,52 @@ describe('buildMriReport — structural (suite-backed) dimensions', () => {
 
   it('renders `unrecorded` (never a guessed pass) when the ledger is empty', () => {
     const report = buildMriReport(busyReader(), {}, {});
-    for (const key of ['premiseAwareness', 'poisoningResistance', 'tenantUserIsolation'] as const) {
+    for (const key of ['poisoningResistance', 'tenantUserIsolation'] as const) {
       const d = report.dimensions[key]!;
       expect(d.value).toBe('unrecorded');
       expect(d.reason).toMatch(/mri:record-suite/);
     }
   });
+});
 
-  it('notes the FOVEA_PLAUSIBILITY_CHECK counter when present', () => {
-    const withCounter = busyReader({
-      brain_fovea_plausibility_downgrade_total: [{ labels: {}, value: 7 }],
+describe('buildMriReport — premiseAwareness reflects the DEFENSE state, not a suite pass', () => {
+  it('renders `exposed` (never a green pass) when FOVEA_PLAUSIBILITY_CHECK is off', () => {
+    // A GREEN MemTrap suite documents current EXPOSURES (incl. the served
+    // belief-distortion answer). Suite-pass is NOT premise-awareness.
+    const report = buildMriReport(busyReader(), GREEN_LEDGER, {
+      plausibilityCheckEnabled: false,
     });
-    const report = buildMriReport(withCounter, GREEN_LEDGER, {});
-    expect(report.dimensions.premiseAwareness!.source).toMatch(/downgrades=7/);
+    const d = report.dimensions.premiseAwareness!;
+    expect(d.value).toBe('exposed');
+    expect(d.value).not.toBe('pass');
+    expect(d.reason).toMatch(/belief-distortion/);
+    expect(d.reason).toMatch(/not a pass/);
+  });
+
+  it('defaults to `exposed` when the defense state is unknown (conservative)', () => {
+    const d = buildMriReport(busyReader(), GREEN_LEDGER, {}).dimensions.premiseAwareness!;
+    expect(d.value).toBe('exposed');
+  });
+
+  it('renders `defended` + live downgrade count when the defense is on', () => {
+    const withCounter = busyReader({
+      brain_plausibility_downgrade_total: [{ labels: {}, value: 7 }],
+    });
+    const d = buildMriReport(withCounter, GREEN_LEDGER, {
+      plausibilityCheckEnabled: true,
+    }).dimensions.premiseAwareness!;
+    expect(d.value).toBe('defended');
+    expect(d.kind).toBe('live');
+    expect(d.source).toMatch(/downgrades=7/);
+  });
+
+  it('defense on but no downgrades observed → `defended` with an activity note', () => {
+    const d = buildMriReport(busyReader(), GREEN_LEDGER, {
+      plausibilityCheckEnabled: true,
+    }).dimensions.premiseAwareness!;
+    expect(d.value).toBe('defended');
+    expect(d.source).toMatch(/downgrades=0/);
+    expect(d.reason).toMatch(/no supported-answer downgrades/);
   });
 });
 
@@ -180,7 +216,7 @@ describe('buildMriReport — empty window never fabricates a number', () => {
 
   it('live cells render pending (0 queries), not a fake zero', () => {
     expect(report.dimensions.tokensPerQuery!.value).toBe('pending-eval');
-    expect(report.dimensions.costPerQueryUsd!.value).toBe('pending-eval');
+    expect(report.dimensions.costPerQueryUpperBoundUsd!.value).toBe('pending-eval');
     expect(report.dimensions.latencyP95Seconds!.value).toBe('pending-eval');
     expect(report.operatingPoint.accuracyProxy).toBeNull();
     expect(report.operatingPoint.sampleCount).toBe(0);

--- a/test/mri-pareto.unit-spec.ts
+++ b/test/mri-pareto.unit-spec.ts
@@ -22,16 +22,31 @@ function point(over: Partial<PolicyOperatingPoint>): PolicyOperatingPoint {
     ece: null,
     latencyP50: 0.1,
     latencyP95: 0.2,
-    costPerQuery: 0.01,
+    costPerQueryUpperBound: 0.01,
     sampleCount: 100,
     ...over,
   };
 }
 
-const A = point({ flags: ['a'], accuracyProxy: 0.8, latencyP95: 0.2, costPerQuery: 0.01 });
-const B = point({ flags: ['b'], accuracyProxy: 0.7, latencyP95: 0.3, costPerQuery: 0.02 }); // dominated by A
-const C = point({ flags: ['c'], accuracyProxy: 0.9, latencyP95: 0.5, costPerQuery: 0.05 }); // frontier
-const D = point({ flags: ['d'], latencyP95: null, costPerQuery: null }); // missing axes
+const A = point({
+  flags: ['a'],
+  accuracyProxy: 0.8,
+  latencyP95: 0.2,
+  costPerQueryUpperBound: 0.01,
+});
+const B = point({
+  flags: ['b'],
+  accuracyProxy: 0.7,
+  latencyP95: 0.3,
+  costPerQueryUpperBound: 0.02,
+}); // dominated by A
+const C = point({
+  flags: ['c'],
+  accuracyProxy: 0.9,
+  latencyP95: 0.5,
+  costPerQueryUpperBound: 0.05,
+}); // frontier
+const D = point({ flags: ['d'], latencyP95: null, costPerQueryUpperBound: null }); // missing axes
 
 describe('paretoFrontier', () => {
   it('separates frontier, dominated, and insufficient-data points', () => {
@@ -108,21 +123,62 @@ describe('collectOperatingPoint — from a telemetry reader', () => {
     },
   ];
 
-  it('assembles proxy-accuracy, cost, and latency; ece stays null', () => {
+  it('assembles proxy-accuracy (ok ÷ terminal) + cost upper bound; ece null', () => {
     const p = collectOperatingPoint(readerFromPromJson(json), { flags: ['x'] });
     expect(p.flags).toEqual(['x']);
-    expect(p.accuracyProxy).toBeCloseTo(0.8, 6);
+    expect(p.accuracyProxy).toBeCloseTo(0.8, 6); // 80 ok / 100 terminal
     expect(p.ece).toBeNull();
-    expect(p.costPerQuery!).toBeCloseTo(0.000271, 9);
-    expect(p.latencyP50!).toBeCloseTo(0.1, 6);
-    expect(p.latencyP95!).toBeCloseTo(0.40625, 6);
+    expect(p.costPerQueryUpperBound!).toBeCloseTo(0.000271, 9); // all-AI tokens / 100 terminal
     expect(p.sampleCount).toBe(100);
+  });
+
+  it('leaves latency null even when a search histogram is present (serving path emits none)', () => {
+    // brain_search_duration_seconds is in the snapshot, but the serving path
+    // never observes it — so it is not a real per-query latency signal.
+    const p = collectOperatingPoint(readerFromPromJson(json));
+    expect(p.latencyP50).toBeNull();
+    expect(p.latencyP95).toBeNull();
+  });
+
+  it('accuracyProxy denominator is the TERMINAL count — intermediate outcomes excluded', () => {
+    // A single request can bump brain_synthesize_total more than once: the
+    // intermediate generator_truncated / search_loop_refined tags fire alongside
+    // a terminal outcome. Raw total here = 80+20+30+40 = 170; terminal = 100.
+    const withIntermediate: PromMetricJson[] = [
+      {
+        name: 'brain_synthesize_total',
+        type: 'counter',
+        values: [
+          { value: 80, labels: { outcome: 'ok' } },
+          { value: 20, labels: { outcome: 'verifier_failed' } },
+          { value: 30, labels: { outcome: 'search_loop_refined' } }, // intermediate
+          { value: 40, labels: { outcome: 'generator_truncated' } }, // intermediate
+        ],
+      },
+    ];
+    const p = collectOperatingPoint(readerFromPromJson(withIntermediate));
+    expect(p.sampleCount).toBe(100); // terminal only, not 170
+    expect(p.accuracyProxy).toBeCloseTo(0.8, 6); // 80 / 100, not 80 / 170
+  });
+
+  it('accuracyProxy is null (never a wrong number) when no terminal outcomes exist', () => {
+    // Only intermediate outcomes recorded → no per-request denominator derivable.
+    const onlyIntermediate: PromMetricJson[] = [
+      {
+        name: 'brain_synthesize_total',
+        type: 'counter',
+        values: [{ value: 5, labels: { outcome: 'search_loop_refined' } }],
+      },
+    ];
+    const p = collectOperatingPoint(readerFromPromJson(onlyIntermediate));
+    expect(p.sampleCount).toBe(0);
+    expect(p.accuracyProxy).toBeNull();
   });
 
   it('returns nulls (never zeros) for an empty window', () => {
     const p = collectOperatingPoint(readerFromPromJson([]));
     expect(p.accuracyProxy).toBeNull();
-    expect(p.costPerQuery).toBeNull();
+    expect(p.costPerQueryUpperBound).toBeNull();
     expect(p.latencyP95).toBeNull();
     expect(p.sampleCount).toBe(0);
   });

--- a/test/mri-record-suite.unit-spec.ts
+++ b/test/mri-record-suite.unit-spec.ts
@@ -1,0 +1,104 @@
+/**
+ * mri:record-suite recorder — FAIL-CLOSED guarantees (scripts/mri-record-suite.ts).
+ *
+ * A recorded `pass` must correspond to a REAL green run of the REAL canonical
+ * suite. These specs pin the three hardening properties as pure-function unit
+ * tests (no Jest child process spawned):
+ *   - a non-zero Jest exit is never a pass (records `fail`, or refuses);
+ *   - `--files` suite substitution is rejected;
+ *   - a bad `--gap` is rejected.
+ * Importing the script must NOT execute its `main()` — it is guarded by
+ * `require.main === module`, the same idiom as scripts/init-pack.ts.
+ */
+import { parseArgs, decideEntry, MAX_GAP, type JestRun } from '../scripts/mri-record-suite';
+
+const NOW = new Date('2026-08-24T00:00:00.000Z');
+
+describe('parseArgs — fail-closed flag handling', () => {
+  it('rejects a `--files` override of a canonical suite (suite substitution)', () => {
+    expect(() =>
+      parseArgs(['tenant-user-isolation', '--files', 'test/some-other.spec.ts']),
+    ).toThrow(/--files|unsupported flag/);
+  });
+
+  it('rejects any unknown flag (typo guard)', () => {
+    expect(() => parseArgs(['minja-redteam', '--bogus', 'x'])).toThrow(/unknown or unsupported/);
+  });
+
+  it('rejects a negative --gap', () => {
+    expect(() => parseArgs(['minja-redteam', '--gap', '-1'])).toThrow(/non-negative integer/);
+  });
+
+  it('rejects a non-integer --gap', () => {
+    expect(() => parseArgs(['minja-redteam', '--gap', '1.5'])).toThrow(/non-negative integer/);
+    expect(() => parseArgs(['minja-redteam', '--gap', 'abc'])).toThrow(/non-negative integer/);
+  });
+
+  it('rejects an out-of-range --gap', () => {
+    expect(() => parseArgs(['minja-redteam', '--gap', String(MAX_GAP + 1)])).toThrow(
+      /out of range/,
+    );
+  });
+
+  it('accepts a valid key + config + gap', () => {
+    const args = parseArgs(['minja-redteam', '--config', 'test/jest-e2e.json', '--gap', '0']);
+    expect(args).toEqual({ key: 'minja-redteam', config: 'test/jest-e2e.json', gap: 0 });
+  });
+
+  it('requires a suite key (not a flag)', () => {
+    expect(() => parseArgs(['--config', 'x'])).toThrow(/usage/);
+    expect(() => parseArgs([])).toThrow(/usage/);
+  });
+});
+
+describe('decideEntry — a pass is only ever a real green run', () => {
+  const green: JestRun = {
+    exitCode: 0,
+    json: { success: true, numPassedTests: 6, numFailedTests: 0 },
+  };
+
+  it('records a pass for a green run', () => {
+    const entry = decideEntry(green, { now: NOW, commit: 'abc1234' });
+    expect(entry.status).toBe('pass');
+    expect(entry.numPassed).toBe(6);
+    expect(entry.numFailed).toBe(0);
+    expect(entry.commit).toBe('abc1234');
+  });
+
+  it('records FAIL (never pass) on a non-zero Jest exit with real failures', () => {
+    const failed: JestRun = {
+      exitCode: 1,
+      json: { success: false, numPassedTests: 4, numFailedTests: 2 },
+    };
+    const entry = decideEntry(failed, { now: NOW });
+    expect(entry.status).toBe('fail');
+    expect(entry.numFailed).toBe(2);
+    expect(entry.note).toMatch(/exited 1/);
+  });
+
+  it('REFUSES to record a vacuous exit-0 pass that ran zero tests', () => {
+    const noTests: JestRun = {
+      exitCode: 0,
+      json: { success: true, numPassedTests: 0, numFailedTests: 0 },
+    };
+    expect(() => decideEntry(noTests, { now: NOW })).toThrow(/real green run of real tests/);
+  });
+
+  it('REFUSES when Jest crashed (non-zero exit, no tests executed)', () => {
+    const crash: JestRun = {
+      exitCode: 2,
+      json: { success: false, numPassedTests: 0, numFailedTests: 0 },
+    };
+    expect(() => decideEntry(crash, { now: NOW })).toThrow(/no tests executed/);
+  });
+
+  it('REFUSES when the Jest --json output could not be parsed', () => {
+    const unparseable: JestRun = { exitCode: 1, json: null };
+    expect(() => decideEntry(unparseable, { now: NOW })).toThrow(/could not parse/);
+  });
+
+  it('carries a validated gap onto the entry', () => {
+    const entry = decideEntry(green, { now: NOW, gap: 0 });
+    expect(entry.gapCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## fix(mri): honest cells — audit R2 P1 (MRI can't be a release gate yet)

Fixes five semantic bugs that made MRI cells misleading, so a green/valued cell now means what it says. Read-only — no serving code touched.

1. **accuracyProxy denominator.** Was `ok ÷ brain_synthesize_total`, but `countSynthesize` also fires for **intermediate** outcomes (`generator_truncated`, `search_loop_refined`) alongside a terminal one — so a request is double-counted. Now `ok ÷ Σ(TERMINAL outcomes)` (ok, no_results, no_grounded_evidence, low_coverage, verifier_partial/failed, generator_error, verifier_error — verified at their call sites). `null` when no terminal traffic, never a wrong number. `sampleCount`/`tokensPerQuery` use the same per-request denominator.
2. **Cost mis-attribution.** `brain_openai_tokens_total` has no per-subsystem label → not separable to synthesize. Relabeled honestly: `costPerQuery → costPerQueryUpperBound` / `costPerQueryUpperBoundUsd`, unit "USD/query (all-AI upper bound)", source states it over-attributes global AI spend and is NOT the per-answer cost.
3. **Latency reads a metric prod doesn't emit.** `brain_search_duration_seconds` is observed only in a unit test, never on the serving path → p50/p95 render `pending` ("no per-query latency histogram is emitted on the serving path"). No serving code added.
4. **premiseAwareness was a false green.** It was `pass` when the MemTrap shakedown passed — but that suite certifies exposures-as-documented (incl. the served belief-distortion answer). Reframed to the real defense state: `FOVEA_PLAUSIBILITY_CHECK` off → **`exposed`** (never green); on → `defended` + live downgrade count. Also fixed a latent metric-name bug (collector read `brain_fovea_plausibility_downgrade_total`; prod emits `brain_plausibility_downgrade_total`).
5. **Recorder not fail-closed** (`scripts/mri-record-suite.ts`). Now captures the real Jest exit: non-zero → never a pass (records `fail`/refuses); exit-0 with zero tests → refused (vacuous pass). Dropped `--files` (canonical suites pinned to their spec files; unknown flags rejected); `--gap` validated (0…10000).

### Schema
`PolicyOperatingPoint.costPerQuery → costPerQueryUpperBound`; dimension key `costPerQueryUsd → costPerQueryUpperBoundUsd`. `MriReportSchema` updated; contract test green. No `MriDimension` value-type change.

### Tests / gates
MRI unit (pareto/aggregator/record-suite/contract) + new recorder spec; full unit suite 2408 green; MRI admin e2e 4/4 on Docker; typecheck / lint:ci / format:check clean; gate goldens (config-catalog-truth, engine-gates, contracts-admin-mri) green. No serving file touched.

Two serving-side follow-ups remain to upgrade cells from pending: an end-to-end synthesize latency histogram, and a `supported_cited` counter for citation coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
