### PR TITLE
test(ci): cap e2e worker concurrency + recycle on memory to stop SIGABRT flake

### DIFF
--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,9 +1,5 @@
 {
-  "moduleFileExtensions": [
-    "js",
-    "json",
-    "ts"
-  ],
+  "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": "..",
   "testEnvironment": "node",
   "testRegex": "test/.*\\.e2e-spec\\.ts$",
@@ -12,16 +8,13 @@
   },
   "testTimeout": 120000,
   "forceExit": true,
+  "maxWorkers": "50%",
+  "workerIdleMemoryLimit": "1GB",
   "globalSetup": "<rootDir>/test/global-setup.ts",
   "globalTeardown": "<rootDir>/test/global-teardown.ts",
   "moduleNameMapper": {
     "^@/(.*)$": "<rootDir>/src/$1"
   },
-  "testPathIgnorePatterns": [
-    "/node_modules/",
-    "/.claude/worktrees/"
-  ],
-  "modulePathIgnorePatterns": [
-    "/.claude/worktrees/"
-  ]
+  "testPathIgnorePatterns": ["/node_modules/", "/.claude/worktrees/"],
+  "modulePathIgnorePatterns": ["/.claude/worktrees/"]
 }


### PR DESCRIPTION
## test(ci): deterministic-green e2e (audit R2 — two consecutive green runs)

The full e2e run intermittently fails a suite with `a jest worker process was terminated ... signal=SIGABRT` / "Test suite failed to run" while **every test in it passed** (a run reporting e.g. `425/425 tests passed` but `1 suite failed`). Root cause: each e2e suite boots a Nest app + a SurrealDB testcontainer + native worker modules (bge-m3 embedder, cross-encoder); at jest's default worker count the heavy full-stack suites (`fovea-cascade`, `memtrap-shakedown`, `memory-injection`) run concurrently and spike the `ubuntu-latest` runner (4 vCPU / 16 GB) past its RAM → the OS OOM-kills a worker.

### Fix (`test/jest-e2e.json`)
- `maxWorkers: "50%"` — halves the number of concurrent testcontainers so the peak fits the runner.
- `workerIdleMemoryLimit: "1GB"` — recycles a worker before it accumulates too much heap across suites.

No test logic changed; the suites themselves already pass. This removes the resource-pressure source so the full e2e is deterministically green — the audit's pre-tag requirement (two consecutive fully-green E2E runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)