### PR TITLE
fix(mri): honest cells — fail-closed recorder, windowed counters, evidence-gated premise, cache-hit accounting (R3 P1)

### DIFF
--- a/scripts/mri-record-suite.ts
+++ b/scripts/mri-record-suite.ts
@@ -215,7 +215,21 @@ function loadLedger(path: string): SuiteLedger {
   }
 }
 
-function main(): void {
+/**
+ * FAIL-CLOSED process exit code for a recorded entry. A `pass` exits 0; ANY
+ * other recorded status (a real red run recorded as `fail`) exits NON-ZERO so a
+ * CI wrapper (`pnpm mri:record-suite … && …`) never mistakes a recorded red for
+ * success. decideEntry already refuses to write a green on red (it throws, or
+ * records `fail`); this closes the remaining leak — the recorder used to write
+ * the `fail` entry and STILL exit 0, greening a red suite at the process level.
+ */
+export function exitCodeForEntry(entry: SuiteLedgerEntry): number {
+  return entry.status === 'pass' ? 0 : 1;
+}
+
+/** Runs the recorder end-to-end and returns the fail-closed exit code (writes
+ *  the entry — even a `fail` — so the ledger reflects the real last run). */
+function main(): number {
   const args = parseArgs(process.argv.slice(2));
   const spec = ALL_SUITE_SPECS.find((s) => s.key === args.key);
   if (!spec) {
@@ -241,11 +255,19 @@ function main(): void {
   process.stdout.write(
     `recorded ${args.key}: ${entry.status} (${entry.numPassed}/${entry.numFailed}) → ${DEFAULT_LEDGER_PATH}\n`,
   );
+  const code = exitCodeForEntry(entry);
+  if (code !== 0) {
+    process.stderr.write(
+      `✗ mri:record-suite: suite '${args.key}' did NOT pass (status=${entry.status}) — recorded the ` +
+        'red status; failing closed with a non-zero exit\n',
+    );
+  }
+  return code;
 }
 
 if (require.main === module) {
   try {
-    main();
+    process.exit(main());
   } catch (e) {
     process.stderr.write(`✗ mri:record-suite failed: ${(e as Error).message}\n`);
     process.exit(1);

--- a/src/contracts/admin/mri.schema.ts
+++ b/src/contracts/admin/mri.schema.ts
@@ -37,10 +37,20 @@ export const MriDimensionSchema = z.object({
   kind: z.enum(['live', 'structural', 'pending']),
 });
 
+/** The rolling window the LIVE rate cells cover — the counters are deltaed
+ *  against a baseline snapshot so rates are bounded to recent traffic, never the
+ *  whole process lifetime. Optional: absent for a raw (un-windowed) build. */
+export const MriWindowSchema = z.object({
+  startedAt: z.string(),
+  endedAt: z.string(),
+  windowMs: z.number(),
+});
+
 export const MriReportSchema = z.object({
   generatedAt: z.string(),
   dimensions: z.record(z.string(), MriDimensionSchema),
   operatingPoint: PolicyOperatingPointSchema,
+  window: MriWindowSchema.optional(),
 });
 
 export type MriReportContract = z.infer<typeof MriReportSchema>;

--- a/src/mri/mri-collectors.ts
+++ b/src/mri/mri-collectors.ts
@@ -1,6 +1,6 @@
 import type { MetricsReader } from './metrics-reader';
 import { sumCounter } from './metrics-reader';
-import type { MriDimension, MriReport } from './mri.types';
+import type { MriDimension, MriReport, MriWindow } from './mri.types';
 import {
   collectOperatingPoint,
   type CollectOperatingPointOptions,
@@ -61,13 +61,19 @@ function structuralDim(
     };
   }
   const commitRef = entry.commit ? ` @ ${entry.commit}` : '';
-  const gapNote = entry.gapCount !== undefined ? `, gapCount=${entry.gapCount}` : '';
+  const passed = entry.status === 'pass';
+  // gapCount is a HEALTH value only on a PASS. On a failed run a `0` gap reads
+  // as "0 gaps → healthy" — a false green — while the suite that establishes it
+  // actually went red. So the numeric gap (both the reported value AND the
+  // source note) is suppressed unless the run passed; a failed entry renders
+  // its `fail` status instead. (R3 P1: gapCount must be omitted on a red entry.)
+  const gapNote = passed && entry.gapCount !== undefined ? `, gapCount=${entry.gapCount}` : '';
   const countNote =
     entry.numPassed !== undefined || entry.numFailed !== undefined
       ? `, tests ${entry.numPassed ?? 0} passed/${entry.numFailed ?? 0} failed`
       : '';
   const source = `suite ${suiteRef} — status ${entry.status}, recorded ${entry.recordedAt}${commitRef}${gapNote}${countNote}`;
-  if (args.preferNumericGap && entry.gapCount !== undefined) {
+  if (args.preferNumericGap && passed && entry.gapCount !== undefined) {
     return {
       value: entry.gapCount,
       unit: 'gaps',
@@ -97,13 +103,18 @@ function structuralDim(
  * premise-aware". Rendering that as a green `pass` would be a false green.
  *
  * The real defense is FOVEA_PLAUSIBILITY_CHECK (the post-grounding plausibility
- * judge that downgrades an implausible cited premise to an abstain). This cell
- * therefore reflects that flag's state, resolved read-only by the service from
- * `plausibilityCheckEnabled()` and passed in:
+ * judge that downgrades an implausible cited premise to an abstain). But a
+ * flag being ON is NOT evidence the exposure is closed — "the defense code
+ * runs" ≠ "we are premise-aware". So this cell is EVIDENCE-gated, never
+ * flag-gated (R3 P1):
  *   - defense OFF  → `exposed` (never a pass): the documented belief-distortion
  *     answer is live. Backed by the suite that documents the exposure.
- *   - defense ON   → `defended`: report the live downgrade activity from
- *     brain_plausibility_downgrade_total (the metric prod actually emits).
+ *   - defense ON   → `pending-eval` (eval-gated), NOT `defended`: the judge
+ *     runs, but no eval asserts the documented class-4 belief-distortion case
+ *     is actually downgraded with the defense on. The live downgrade count
+ *     (brain_plausibility_downgrade_total) is surfaced as ACTIVITY, not proof.
+ *     A green `defended` is only earned by such eval evidence, which does not
+ *     yet exist.
  */
 function premiseAwarenessDim(args: {
   reader: MetricsReader;
@@ -137,23 +148,25 @@ function premiseAwarenessDim(args: {
     };
   }
 
-  const downgradeSeries = reader.counter('brain_plausibility_downgrade_total');
+  // Flag ON does NOT earn a green `defended`. Report honest-pending (eval-gated):
+  // the plausibility judge runs, but no eval proves the documented belief-
+  // distortion exposure is actually closed. The live downgrade count is
+  // surfaced as ACTIVITY (the judge is firing), never as proof of defense.
   const downgrades = sumCounter(reader, 'brain_plausibility_downgrade_total');
-  const noActivity =
-    downgradeSeries.length === 0
-      ? {
-          reason:
-            'FOVEA_PLAUSIBILITY_CHECK is on but no supported-answer downgrades have been observed ' +
-            'in the current window (brain_plausibility_downgrade_total absent/zero)',
-        }
-      : {};
   return {
-    value: 'defended',
-    source: `FOVEA_PLAUSIBILITY_CHECK ON; brain_plausibility_downgrade_total downgrades=${downgrades}; ${suiteStatus}`,
+    value: 'pending-eval',
+    source:
+      `FOVEA_PLAUSIBILITY_CHECK ON; brain_plausibility_downgrade_total downgrades=${downgrades} ` +
+      `(activity, not proof of defense); ${suiteStatus}`,
     asOf: nowIso,
-    evalGated: false,
-    kind: 'live',
-    ...noActivity,
+    evalGated: true,
+    kind: 'pending',
+    reason:
+      'FOVEA_PLAUSIBILITY_CHECK is enabled, so the post-grounding plausibility judge runs — but ' +
+      'flag-state is not premise-awareness. No eval asserts the documented belief-distortion exposure ' +
+      '(MemTrap shakedown class 4) is actually downgraded with the defense on, so the defense is ' +
+      'enabled-but-UNVERIFIED. Reported pending until such a labeled case exists — never a green ' +
+      '`defended`.',
   };
 }
 
@@ -189,6 +202,52 @@ function citationCoverageDim(reader: MetricsReader, nowIso: string): MriDimensio
     kind: 'live',
     asOf: nowIso,
   });
+}
+
+/**
+ * Freshness — the stale-answer catch rate off the answer-cache invalidation
+ * telemetry. F1 (answer-cache additive-write invalidation, #339) is MERGED, so
+ * this is now a REAL read-only signal rather than the stale "blocked on F1"
+ * pending: of the cache-backed reads (an entry existed), the fraction the
+ * check-on-read invalidated as stale = rejected_stale ÷ (hit + rejected_stale).
+ * A `miss`/`bypass` had no entry to be stale, so it is excluded from the
+ * denominator.
+ *
+ * When the window saw no cache-backed reads — the DEFAULT, since
+ * SYNTHESIZE_ANSWER_CACHE is off so `begin()` short-circuits and emits nothing —
+ * the rate is unobservable and renders honest-pending with that reason, never a
+ * fabricated 0 (which would read as "never stale → healthy").
+ */
+function freshnessDim(reader: MetricsReader, nowIso: string): MriDimension {
+  const series = reader.counter('brain_answer_cache_total');
+  const hit = sumCounter(reader, 'brain_answer_cache_total', { outcome: 'hit' });
+  const rejectedStale = sumCounter(reader, 'brain_answer_cache_total', {
+    outcome: 'rejected_stale',
+  });
+  const reads = hit + rejectedStale;
+  const source =
+    'brain_answer_cache_total{outcome=rejected_stale} ÷ (hit + rejected_stale) — check-on-read ' +
+    'staleness catch rate (F1 additive-write invalidation, #339)';
+  if (series.length === 0 || reads <= 0) {
+    return pendingCell({
+      source,
+      reason:
+        'no answer-cache read traffic in the current window: SYNTHESIZE_ANSWER_CACHE is default-off, ' +
+        'so the cache serves no reads and the stale-answer rate is unobservable. Auto-fills once the ' +
+        'cache is enabled and serves hits / stale-rejections.',
+      evalGated: false,
+      kind: 'live',
+      asOf: nowIso,
+    });
+  }
+  return {
+    value: rejectedStale / reads,
+    unit: 'ratio (stale-rejected ÷ cache-backed reads)',
+    source,
+    asOf: nowIso,
+    evalGated: false,
+    kind: 'live',
+  };
 }
 
 /**
@@ -290,6 +349,13 @@ export interface BuildMriReportOptions {
    * unknown/off defense never renders a green pass — it renders `exposed`).
    */
   plausibilityCheckEnabled?: boolean;
+  /**
+   * The rolling window the LIVE rate cells cover, when the caller (the service)
+   * deltas process-lifetime counters against a baseline snapshot. Embedded in
+   * the report so a consumer sees the numbers are windowed, not lifetime. Absent
+   * for a pure buildMriReport call over a raw reader (unit tests).
+   */
+  window?: MriWindow;
 }
 
 /**
@@ -320,16 +386,9 @@ export function buildMriReport(
     tokensPerQuery: tokensPerQueryDim(reader, point, nowIso),
     ...costLatencyDims(point, nowIso),
 
-    // Pending — freshness is blocked on F1 (must land first; not built here)
-    freshnessStaleAnswerRate: pendingCell({
-      source: 'answer-cache invalidation telemetry (brain_answer_cache_total{rejected_stale})',
-      reason:
-        'blocked on F1 answer-cache additive-write invalidation — the stale-answer rate is only ' +
-        'meaningful once F1 lands; F1 is out of scope for this measurement layer',
-      evalGated: false,
-      kind: 'pending',
-      asOf: nowIso,
-    }),
+    // Freshness — REAL signal now F1 (answer-cache invalidation, #339) is
+    // merged; honest-pending only when there is no cache read traffic.
+    freshnessStaleAnswerRate: freshnessDim(reader, nowIso),
 
     // Pending — eval-gated (need a labeled gold set)
     abstentionCalibration: pendingCell({
@@ -351,5 +410,10 @@ export function buildMriReport(
     }),
   };
 
-  return { generatedAt: nowIso, dimensions, operatingPoint: point };
+  return {
+    generatedAt: nowIso,
+    dimensions,
+    operatingPoint: point,
+    ...(options.window ? { window: options.window } : {}),
+  };
 }

--- a/src/mri/mri-markdown.ts
+++ b/src/mri/mri-markdown.ts
@@ -52,6 +52,14 @@ export function renderMriMarkdown(report: MriReport, pareto?: ParetoReport): str
   lines.push('# Memory Reliability Index (MRI) snapshot');
   lines.push('');
   lines.push(`Generated: ${report.generatedAt}`);
+  if (report.window) {
+    const w = report.window;
+    lines.push('');
+    lines.push(
+      `Live-cell window: ${w.startedAt} → ${w.endedAt} (rolling, ≤ ${Math.round(w.windowMs / 1000)}s). ` +
+        'Rates are deltaed against a baseline snapshot — NOT the process lifetime.',
+    );
+  }
   lines.push('');
   lines.push(
     '> Honest scaffold (measurable-economics-mri-2026-08.md). Every cell is a real value or the ' +

--- a/src/mri/mri-window.ts
+++ b/src/mri/mri-window.ts
@@ -1,0 +1,143 @@
+import type { MetricsReader, PromMetricJson } from './metrics-reader';
+import { readerFromPromJson } from './metrics-reader';
+
+/**
+ * Windowed telemetry for the MRI report (R3 P1).
+ *
+ * Prometheus counters are process-lifetime, MONOTONIC accumulators. Dividing
+ * two of them (e.g. ok / terminal, tokens / requests) yields a rate over the
+ * WHOLE process lifetime -- it silently folds in ancient traffic and drifts as
+ * the process ages, so a "per query" cell means less and less the longer the
+ * process runs. The MRI live cells must instead reflect a bounded RECENT window.
+ *
+ * We window by DELTA over a rolling baseline: keep timestamped snapshots of the
+ * raw counter JSON, and on each report subtract the oldest snapshot still inside
+ * the window from the current one. Counters are monotonic, so the delta is the
+ * traffic that landed IN the window. A series that shrank (process restart /
+ * registry reset) is clamped to its current value (reset-safe). Histograms delta
+ * the same way -- cumulative bucket/sum/count differences are a valid histogram
+ * over the window.
+ *
+ * This layer is READ-ONLY: it only reads snapshots the pipeline already emits;
+ * it never touches the serving path.
+ */
+
+/** A timestamped raw-counter snapshot. */
+export interface CounterSnapshot {
+  /** Epoch milliseconds the snapshot was taken. */
+  at: number;
+  metrics: PromMetricJson[];
+}
+
+/** Default rolling window: 1 hour. A per-query rate over the last hour is
+ *  meaningful for an advisory admin report; older traffic is dropped. */
+export const DEFAULT_MRI_WINDOW_MS = 60 * 60 * 1000;
+
+/** Hard cap on retained snapshots so a pathological tight poll loop cannot grow
+ *  memory without bound. Dropping the oldest only ever SHRINKS the window (never
+ *  lengthens it), which is the safe direction: recent data, never ancient. */
+export const MAX_SNAPSHOTS = 512;
+
+/** Internal map-key field separator. A printable delimiter that cannot appear in
+ *  a Prometheus metric name / series / `k=v` label pair, so keys never collide. */
+const SEP = '||';
+
+function labelKey(labels: Record<string, string | number> | undefined): string {
+  if (!labels) return '';
+  return Object.keys(labels)
+    .sort()
+    .map((k) => `${k}=${String(labels[k])}`)
+    .join(',');
+}
+
+/** Index a snapshot's every value by (metric, series, labels) -> value. */
+function indexSnapshot(metrics: PromMetricJson[]): Map<string, number> {
+  const idx = new Map<string, number>();
+  for (const m of metrics) {
+    for (const v of m.values) {
+      const series = v.metricName ?? m.name;
+      idx.set(`${m.name}${SEP}${series}${SEP}${labelKey(v.labels)}`, v.value);
+    }
+  }
+  return idx;
+}
+
+/**
+ * current - baseline, per (metric, series, labels). A missing baseline series ->
+ * keep current (all of it is in-window). A negative delta (counter reset) ->
+ * clamp to current. `baseline === null` -> pass current through unchanged.
+ */
+export function deltaSnapshots(
+  current: PromMetricJson[],
+  baseline: PromMetricJson[] | null,
+): PromMetricJson[] {
+  if (baseline === null) return current;
+  const base = indexSnapshot(baseline);
+  return current.map((m) => ({
+    ...m,
+    values: m.values.map((v) => {
+      const series = v.metricName ?? m.name;
+      const prev = base.get(`${m.name}${SEP}${series}${SEP}${labelKey(v.labels)}`);
+      const delta = prev === undefined ? v.value : v.value - prev;
+      return { ...v, value: delta < 0 ? v.value : delta };
+    }),
+  }));
+}
+
+/** A windowed reader over the delta between the current snapshot and a baseline. */
+export function windowedReader(
+  current: PromMetricJson[],
+  baseline: PromMetricJson[] | null,
+): MetricsReader {
+  return readerFromPromJson(deltaSnapshots(current, baseline));
+}
+
+/** The window an `observe()` resolved: the baseline to delta against + bounds. */
+export interface WindowResult {
+  /** The baseline snapshot the delta is taken against (never null once
+   *  observed -- the first observation baselines against itself -> span 0). */
+  baseline: CounterSnapshot;
+  startedAt: string;
+  endedAt: string;
+  windowMs: number;
+}
+
+/**
+ * A rolling snapshot ring. `observe(metrics, now)` records the current snapshot,
+ * prunes snapshots older than the window (and beyond MAX_SNAPSHOTS), and returns
+ * the oldest still-retained snapshot as the delta baseline.
+ *
+ * The FIRST observation baselines against itself (window span 0) -- so the report
+ * honestly renders "no traffic in the window yet" rather than a lifetime rate.
+ * Once a poll >= windowMs old exists the window is a true rolling window; if polls
+ * stop for longer than the window, the ring empties and the next poll re-opens a
+ * fresh (empty) window rather than reporting a stale multi-window rate.
+ */
+export class SnapshotWindow {
+  private readonly snapshots: CounterSnapshot[] = [];
+
+  constructor(private readonly windowMs: number = DEFAULT_MRI_WINDOW_MS) {}
+
+  observe(metrics: PromMetricJson[], now: Date): WindowResult {
+    const at = now.getTime();
+    this.snapshots.push({ at, metrics });
+
+    // Drop snapshots older than the window (always keep the current one).
+    const cutoff = at - this.windowMs;
+    while (this.snapshots.length > 1 && this.snapshots[0]!.at < cutoff) {
+      this.snapshots.shift();
+    }
+    // Memory backstop: never retain more than MAX_SNAPSHOTS.
+    while (this.snapshots.length > MAX_SNAPSHOTS) {
+      this.snapshots.shift();
+    }
+
+    const baseline = this.snapshots[0]!;
+    return {
+      baseline,
+      startedAt: new Date(baseline.at).toISOString(),
+      endedAt: now.toISOString(),
+      windowMs: this.windowMs,
+    };
+  }
+}

--- a/src/mri/mri.service.ts
+++ b/src/mri/mri.service.ts
@@ -3,8 +3,9 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { MetricsService } from '../metrics/metrics.service';
 import { plausibilityCheckEnabled } from '../common/fovea-flags';
-import { readerFromPromJson, type PromMetricJson } from './metrics-reader';
+import { type PromMetricJson } from './metrics-reader';
 import { buildMriReport, type BuildMriReportOptions } from './mri-collectors';
+import { SnapshotWindow, windowedReader, DEFAULT_MRI_WINDOW_MS } from './mri-window';
 import { loadSuiteLedger, DEFAULT_LEDGER_PATH } from './suite-status';
 import type { MriReport } from './mri.types';
 
@@ -22,20 +23,29 @@ export class MriService {
   private readonly logger = new Logger(MriService.name);
   private readonly ledgerPath = DEFAULT_LEDGER_PATH;
   private readonly snapshotPath = join('var', 'mri', 'latest.json');
+  /** Rolling snapshot ring: deltas process-lifetime counters against a baseline
+   *  so the LIVE rate cells cover a bounded recent window, not the whole process
+   *  lifetime (R3 P1). Read-only — snapshots the registry the pipeline emits. */
+  private readonly window = new SnapshotWindow(DEFAULT_MRI_WINDOW_MS);
 
   constructor(private readonly metrics: MetricsService) {}
 
   /** Build a fresh report from live telemetry + the ledger, persist, and return.
-   *  Resolves the premise-awareness DEFENSE state (FOVEA_PLAUSIBILITY_CHECK) via
-   *  the common-layer flag reader — a read-only config read, no serving-path
-   *  touch — unless the caller pinned it explicitly (tests). */
+   *  Windows the counters against a rolling baseline so "per query" rates are
+   *  bounded to a recent window. Resolves the premise-awareness DEFENSE state
+   *  (FOVEA_PLAUSIBILITY_CHECK) via the common-layer flag reader — a read-only
+   *  config read, no serving-path touch — unless the caller pinned it (tests). */
   async generate(options: BuildMriReportOptions = {}): Promise<MriReport> {
+    const now = options.now ?? new Date();
     const json = (await this.metrics.registry.getMetricsAsJSON()) as unknown as PromMetricJson[];
-    const reader = readerFromPromJson(json);
+    const win = this.window.observe(json, now);
+    const reader = windowedReader(json, win.baseline.metrics);
     const ledger = loadSuiteLedger(this.ledgerPath);
     const report = buildMriReport(reader, ledger, {
       ...options,
+      now,
       plausibilityCheckEnabled: options.plausibilityCheckEnabled ?? plausibilityCheckEnabled(),
+      window: { startedAt: win.startedAt, endedAt: win.endedAt, windowMs: win.windowMs },
     });
     this.persist(report);
     return report;

--- a/src/mri/mri.types.ts
+++ b/src/mri/mri.types.ts
@@ -33,10 +33,28 @@ export interface MriDimension {
   kind: 'live' | 'structural' | 'pending';
 }
 
+/**
+ * The bounded, rolling window the LIVE rate cells cover. Prometheus counters are
+ * process-lifetime accumulators; the MRI reader deltas them against a baseline
+ * snapshot so "per query" rates reflect only recent traffic, never the whole
+ * process lifetime. `startedAt`..`endedAt` is what the numbers are as-of.
+ */
+export interface MriWindow {
+  /** Window start — the baseline snapshot the delta is taken against (ISO). */
+  startedAt: string;
+  /** Window end — the report's generation time (ISO). */
+  endedAt: string;
+  /** Configured rolling-window bound in milliseconds. */
+  windowMs: number;
+}
+
 export interface MriReport {
   generatedAt: string;
   /** The seven §2 dimensions plus the split cost/latency cells. */
   dimensions: Record<string, MriDimension>;
   /** Part 1 live operating point (proxy-accuracy × cost × latency). */
   operatingPoint: PolicyOperatingPoint;
+  /** The rolling window the LIVE rate cells cover (absent for a pure
+   *  buildMriReport call that does not window — e.g. unit tests). */
+  window?: MriWindow;
 }

--- a/src/synthesize/synthesize.helpers.ts
+++ b/src/synthesize/synthesize.helpers.ts
@@ -9,6 +9,7 @@ import type { Citation } from './fact-index';
 import type { GeneratorOutput, SynthesizeResult } from './synthesize.types';
 import { buildDateMathLines } from './date-math';
 import { detectAnswerShape, shapeInstructionFor } from './answer-shape';
+import type { MetricsService } from '../metrics/metrics.service';
 
 /**
  * Pure helpers of the synthesize orchestrator, split out of
@@ -16,6 +17,23 @@ import { detectAnswerShape, shapeInstructionFor } from './answer-shape';
  * the service over 800). No IO, no DI; type-only imports back into the
  * service module, so there is no runtime cycle.
  */
+
+/**
+ * Serve an answer-cache hit — and count it as the terminal `ok` it is. admit()
+ * only ever caches a verifier-`supported`, cited answer, so a served hit is an
+ * `ok`; recording it in the SAME brain_synthesize_total counter the fresh path
+ * bumps keeps the MRI per-request denominator (terminal synthesize count)
+ * inclusive of cache hits instead of silently dropping them and skewing every
+ * "per query" rate (R3 P1). Read-only accounting: no verdict/serving change, and
+ * the caller only reaches here when the cache is on (off by default).
+ */
+export function serveCacheHit(
+  metrics: MetricsService | undefined,
+  hit: SynthesizeResult,
+): SynthesizeResult {
+  metrics?.countSynthesize('ok');
+  return hit;
+}
 
 /**
  * V13 answer-side frames, both profile-gated and both pure: the

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -21,6 +21,7 @@ import {
   resolveAnswerLang,
   resolveCitations,
   resolveLaneDateContext,
+  serveCacheHit,
   verifierErrorResult,
 } from './synthesize.helpers';
 import { resolvePromptFrames, wantsTimelineEvidence } from './evidence-gates';
@@ -203,7 +204,9 @@ export class SynthesizeService {
     // carries the key context to the admit hook (finalizeAndAdmit).
     const cacheArgs = { companyId, dto, callerScopes, profile, model, guardrails };
     const cache = await this.answerCache?.begin(cacheArgs);
-    if (cache?.hit) return cache.hit;
+    // A served cache hit is a terminal `ok` (admit() only caches supported+cited);
+    // count it so the MRI per-request denominator includes cache hits (R3 P1).
+    if (cache?.hit) return serveCacheHit(this.metrics, cache.hit);
 
     // Typed dispatch: lane detection is lexical and free, so it runs
     // before retrieval — the preference lane adds a deterministic

--- a/test/mri-aggregator.unit-spec.ts
+++ b/test/mri-aggregator.unit-spec.ts
@@ -125,6 +125,25 @@ describe('buildMriReport — structural (suite-backed) dimensions', () => {
       expect(d.reason).toMatch(/mri:record-suite/);
     }
   });
+
+  it('a FAILED poisoning entry renders `fail`, never the gapCount (no "0 gaps → healthy" green)', () => {
+    // R3 P1: a red run with gapCount=0 must NOT render `0 gaps` (reads healthy).
+    const failedLedger: SuiteLedger = {
+      'minja-redteam': {
+        status: 'fail',
+        gapCount: 0,
+        numPassed: 4,
+        numFailed: 2,
+        recordedAt: '2026-08-24T00:00:00.000Z',
+      },
+    };
+    const d = buildMriReport(busyReader(), failedLedger, {}).dimensions.poisoningResistance!;
+    expect(d.value).toBe('fail');
+    expect(d.value).not.toBe(0);
+    expect(d.unit).toBeUndefined();
+    // The misleading "gapCount=0" note is suppressed on a red entry.
+    expect(d.source).not.toMatch(/gapCount=/);
+  });
 });
 
 describe('buildMriReport — premiseAwareness reflects the DEFENSE state, not a suite pass', () => {
@@ -146,36 +165,67 @@ describe('buildMriReport — premiseAwareness reflects the DEFENSE state, not a 
     expect(d.value).toBe('exposed');
   });
 
-  it('renders `defended` + live downgrade count when the defense is on', () => {
+  it('flag ON is NOT a green `defended` — pending-eval with the downgrade count as ACTIVITY', () => {
+    // R3 P1: "the defense code runs" is not evidence the exposure is closed.
+    // With no eval proving the class-4 case is downgraded, the cell is
+    // honest-pending (eval-gated), never `defended`.
     const withCounter = busyReader({
       brain_plausibility_downgrade_total: [{ labels: {}, value: 7 }],
     });
     const d = buildMriReport(withCounter, GREEN_LEDGER, {
       plausibilityCheckEnabled: true,
     }).dimensions.premiseAwareness!;
-    expect(d.value).toBe('defended');
-    expect(d.kind).toBe('live');
+    expect(d.value).toBe('pending-eval');
+    expect(d.value).not.toBe('defended');
+    expect(d.kind).toBe('pending');
+    expect(d.evalGated).toBe(true);
+    // The live downgrade count is surfaced as activity, not proof.
     expect(d.source).toMatch(/downgrades=7/);
+    expect(d.source).toMatch(/not proof/);
+    expect(d.reason).toMatch(/enabled-but-UNVERIFIED|flag-state is not premise-awareness/);
   });
 
-  it('defense on but no downgrades observed → `defended` with an activity note', () => {
+  it('defense on but no downgrades observed → still pending-eval (never `defended`)', () => {
     const d = buildMriReport(busyReader(), GREEN_LEDGER, {
       plausibilityCheckEnabled: true,
     }).dimensions.premiseAwareness!;
-    expect(d.value).toBe('defended');
+    expect(d.value).toBe('pending-eval');
+    expect(d.value).not.toBe('defended');
     expect(d.source).toMatch(/downgrades=0/);
-    expect(d.reason).toMatch(/no supported-answer downgrades/);
+    expect(d.evalGated).toBe(true);
   });
 });
 
 describe('buildMriReport — pending dimensions carry an honest reason', () => {
   const report = buildMriReport(busyReader(), GREEN_LEDGER, {});
 
-  it('freshness is F1-blocked (not built here)', () => {
+  it('freshness renders pending (no cache read traffic) with an ACCURATE reason — not "blocked on F1"', () => {
     const d = report.dimensions.freshnessStaleAnswerRate!;
     expect(d.value).toBe('pending-eval');
-    expect(d.reason).toMatch(/F1 answer-cache/);
-    expect(d.kind).toBe('pending');
+    // Resolves via LIVE telemetry once the cache serves reads (like citation
+    // coverage), so it auto-fills rather than staying feature-gated.
+    expect(d.kind).toBe('live');
+    // F1 is merged (#339); the stale "blocked on F1" reason must be gone.
+    expect(d.reason).not.toMatch(/blocked on F1/);
+    expect(d.reason).toMatch(/no answer-cache read traffic|default-off/);
+    expect(d.source).toMatch(/rejected_stale/);
+  });
+
+  it('freshness auto-fills a LIVE stale-rejection rate once the cache serves reads (F1 #339)', () => {
+    // 10 stale-rejections ÷ (90 hits + 10 stale) = 0.1; miss/bypass excluded.
+    const withCache = busyReader({
+      brain_answer_cache_total: [
+        { labels: { outcome: 'hit' }, value: 90 },
+        { labels: { outcome: 'rejected_stale' }, value: 10 },
+        { labels: { outcome: 'miss' }, value: 5 },
+        { labels: { outcome: 'bypass' }, value: 3 },
+      ],
+    });
+    const d = buildMriReport(withCache, GREEN_LEDGER, {}).dimensions.freshnessStaleAnswerRate!;
+    expect(d.value as number).toBeCloseTo(0.1, 6);
+    expect(d.kind).toBe('live');
+    expect(d.evalGated).toBe(false);
+    expect(d.unit).toMatch(/stale-rejected/);
   });
 
   it('correctness + abstention are eval-gated', () => {

--- a/test/mri-record-suite.unit-spec.ts
+++ b/test/mri-record-suite.unit-spec.ts
@@ -10,7 +10,14 @@
  * Importing the script must NOT execute its `main()` — it is guarded by
  * `require.main === module`, the same idiom as scripts/init-pack.ts.
  */
-import { parseArgs, decideEntry, MAX_GAP, type JestRun } from '../scripts/mri-record-suite';
+import {
+  parseArgs,
+  decideEntry,
+  exitCodeForEntry,
+  MAX_GAP,
+  type JestRun,
+} from '../scripts/mri-record-suite';
+import type { SuiteLedgerEntry } from '../src/mri/suite-status';
 
 const NOW = new Date('2026-08-24T00:00:00.000Z');
 
@@ -100,5 +107,38 @@ describe('decideEntry — a pass is only ever a real green run', () => {
   it('carries a validated gap onto the entry', () => {
     const entry = decideEntry(green, { now: NOW, gap: 0 });
     expect(entry.gapCount).toBe(0);
+  });
+});
+
+describe('exitCodeForEntry — FAIL-CLOSED process exit (R3 P1)', () => {
+  it('exits 0 only for a recorded pass', () => {
+    const pass: SuiteLedgerEntry = {
+      status: 'pass',
+      numPassed: 6,
+      numFailed: 0,
+      recordedAt: NOW.toISOString(),
+    };
+    expect(exitCodeForEntry(pass)).toBe(0);
+  });
+
+  it('exits NON-ZERO on a recorded fail — a red suite never greens the process', () => {
+    const fail: SuiteLedgerEntry = {
+      status: 'fail',
+      numPassed: 4,
+      numFailed: 2,
+      recordedAt: NOW.toISOString(),
+      note: 'jest exited 1',
+    };
+    expect(exitCodeForEntry(fail)).toBe(1);
+    // End-to-end: decideEntry turns a red Jest run into a `fail` entry, and
+    // exitCodeForEntry turns that into a non-zero exit — so the recorder cannot
+    // record `fail` yet exit 0 (the leak #343 left behind).
+    const redRun: JestRun = {
+      exitCode: 1,
+      json: { success: false, numPassedTests: 4, numFailedTests: 2 },
+    };
+    const entry = decideEntry(redRun, { now: NOW });
+    expect(entry.status).toBe('fail');
+    expect(exitCodeForEntry(entry)).toBe(1);
   });
 });

--- a/test/mri-window.unit-spec.ts
+++ b/test/mri-window.unit-spec.ts
@@ -1,0 +1,104 @@
+/**
+ * MRI windowed telemetry (src/mri/mri-window.ts) — R3 P1.
+ *
+ * Prometheus counters are process-lifetime accumulators; a rate off two of them
+ * silently folds in ancient traffic. These specs pin the delta-over-baseline
+ * windowing: the reader reflects only traffic IN the window, resets are
+ * clamped, new series pass through, and a rolling window drops ancient
+ * baselines so an aged process never reports a lifetime rate.
+ */
+import { sumCounter } from '../src/mri/metrics-reader';
+import type { PromMetricJson } from '../src/mri/metrics-reader';
+import { deltaSnapshots, windowedReader, SnapshotWindow } from '../src/mri/mri-window';
+
+function synth(ok: number, tokens?: number): PromMetricJson[] {
+  const out: PromMetricJson[] = [
+    {
+      name: 'brain_synthesize_total',
+      type: 'counter',
+      values: [{ value: ok, labels: { outcome: 'ok' } }],
+    },
+  ];
+  if (tokens !== undefined) {
+    out.push({
+      name: 'brain_openai_tokens_total',
+      type: 'counter',
+      values: [{ value: tokens, labels: { kind: 'chat', type: 'prompt' } }],
+    });
+  }
+  return out;
+}
+
+const okOf = (m: PromMetricJson[]): number =>
+  sumCounter(windowedReader(m, null), 'brain_synthesize_total', { outcome: 'ok' });
+
+describe('deltaSnapshots — current − baseline per (metric, labels)', () => {
+  it('subtracts the baseline so the reader reflects only in-window traffic', () => {
+    const reader = windowedReader(synth(150), synth(100));
+    expect(sumCounter(reader, 'brain_synthesize_total', { outcome: 'ok' })).toBe(50);
+  });
+
+  it('passes current through unchanged when there is no baseline', () => {
+    const delta = deltaSnapshots(synth(150), null);
+    expect(delta).toEqual(synth(150));
+    expect(okOf(delta)).toBe(150);
+  });
+
+  it('clamps a counter that shrank (process restart / registry reset) to current', () => {
+    // baseline ok=200 > current ok=50 → the counter reset; the window is the
+    // current value, never a negative rate.
+    const reader = windowedReader(synth(50), synth(200));
+    expect(sumCounter(reader, 'brain_synthesize_total', { outcome: 'ok' })).toBe(50);
+  });
+
+  it('keeps a series absent from the baseline (all of it is in-window)', () => {
+    const reader = windowedReader(synth(150, 5000), synth(100)); // no tokens at baseline
+    expect(sumCounter(reader, 'brain_synthesize_total', { outcome: 'ok' })).toBe(50);
+    expect(sumCounter(reader, 'brain_openai_tokens_total')).toBe(5000);
+  });
+});
+
+describe('SnapshotWindow — rolling window over process-lifetime counters', () => {
+  const t = (ms: number) => new Date(1_000_000 + ms);
+
+  it('first observation baselines against itself → window span 0, no traffic', () => {
+    const w = new SnapshotWindow(1000);
+    const r = w.observe(synth(100), t(0));
+    expect(r.startedAt).toBe(r.endedAt); // span 0
+    const reader = windowedReader(synth(100), r.baseline.metrics);
+    expect(sumCounter(reader, 'brain_synthesize_total', { outcome: 'ok' })).toBe(0);
+  });
+
+  it('a subsequent poll inside the window reports the delta since the baseline', () => {
+    const w = new SnapshotWindow(1000);
+    w.observe(synth(100), t(0));
+    const r = w.observe(synth(160), t(500));
+    const reader = windowedReader(synth(160), r.baseline.metrics);
+    // baseline is the t0 snapshot (ok=100) → delta 60.
+    expect(sumCounter(reader, 'brain_synthesize_total', { outcome: 'ok' })).toBe(60);
+  });
+
+  it('drops an ANCIENT baseline so an aged process never reports a lifetime rate', () => {
+    const w = new SnapshotWindow(1000);
+    w.observe(synth(100), t(0)); // ancient
+    w.observe(synth(200), t(900)); // still inside window at t=1600? no — see cutoff
+    const r = w.observe(synth(260), t(1600));
+    // cutoff = 1600 − 1000 = 600; t0(0) and t500... here t900 ≥ 600 stays,
+    // t0 is pruned. baseline = t900 snapshot (ok=200) → delta 60, NOT 160.
+    const reader = windowedReader(synth(260), r.baseline.metrics);
+    expect(sumCounter(reader, 'brain_synthesize_total', { outcome: 'ok' })).toBe(60);
+    // the window start advanced past the ancient t0 snapshot
+    expect(new Date(r.startedAt).getTime()).toBe(t(900).getTime());
+  });
+
+  it('re-opens a fresh empty window when polling stops for longer than the window', () => {
+    const w = new SnapshotWindow(1000);
+    w.observe(synth(100), t(0));
+    const r = w.observe(synth(500), t(5000)); // 5s gap ≫ 1s window
+    // Only the current snapshot remains → baseline is itself → delta 0 rather
+    // than a stale multi-window rate.
+    const reader = windowedReader(synth(500), r.baseline.metrics);
+    expect(sumCounter(reader, 'brain_synthesize_total', { outcome: 'ok' })).toBe(0);
+    expect(r.startedAt).toBe(r.endedAt);
+  });
+});

--- a/test/synthesize.unit-spec.ts
+++ b/test/synthesize.unit-spec.ts
@@ -96,6 +96,56 @@ describe('SynthesizeService', () => {
     });
   });
 
+  it('counts a served cache hit as a terminal `ok` so the MRI denominator includes it (R3 P1)', async () => {
+    // A cache hit early-returns BEFORE the fresh path's countSynthesize, so it
+    // used to be excluded from brain_synthesize_total — skewing every "per
+    // query" rate the MRI reader derives from the terminal count. It must be
+    // counted as the terminal `ok` it is (admit() only caches supported+cited).
+    const cachedResult = {
+      answer: 'cached answer',
+      citations: [],
+      results: [],
+    } as unknown as SynthesizeResult;
+    const outcomes: string[] = [];
+    const metrics = {
+      countSynthesize: (o: string) => outcomes.push(o),
+    } as unknown as ConstructorParameters<typeof SynthesizeService>[2];
+    const answerCache = {
+      begin: async () => ({ hit: cachedResult }),
+    } as unknown as ConstructorParameters<typeof SynthesizeService>[4];
+    const cfg = makeConfig({ OPENAI_API_KEY: 'sk-stub' });
+    const svc = new SynthesizeService(makeSearch([]), cfg, metrics, undefined, answerCache);
+
+    const out = await svc.synthesize({
+      companyId: 'co_x',
+      dto: baseDto,
+      callerScopes: ['brain:read'],
+    });
+
+    // Served as-is (no verdict/serving change) …
+    expect(out).toBe(cachedResult);
+    // … and counted exactly once as the terminal `ok`.
+    expect(outcomes).toEqual(['ok']);
+  });
+
+  it('never enters the cache-count branch when the cache is off (default) — byte-identical', async () => {
+    // No answerCache dep → the cache-hit branch is unreachable; the normal
+    // no_results terminal fires exactly once (proves the off path is unchanged).
+    const outcomes: string[] = [];
+    const metrics = {
+      countSynthesize: (o: string) => outcomes.push(o),
+    } as unknown as ConstructorParameters<typeof SynthesizeService>[2];
+    const cfg = makeConfig({ OPENAI_API_KEY: 'sk-stub' });
+    const svc = new SynthesizeService(makeSearch([]), cfg, metrics);
+    const out = await svc.synthesize({
+      companyId: 'co_x',
+      dto: baseDto,
+      callerScopes: ['brain:read'],
+    });
+    expect(out.reason).toBe('no_results');
+    expect(outcomes).toEqual(['no_results']);
+  });
+
   it('returns no_grounded_evidence on the generator sentinel', async () => {
     const search = makeSearch([
       makeHit('cust_a', [{ factId: 'f1', predicate: 'name', object: 'Maya' }]),


### PR DESCRIPTION
## R3 audit — P1: MRI residual false-greens

MRI is a read-only, admin-only, default-off measurement/reporting layer. #343 hardened its semantics; the R3 audit found six residual cells that still read "healthy/defended" without earning it. Each fix makes the cell either **honestly measured** or **explicitly pending with a truthful reason** — never a fake green. Verify-before-fix applied to each.

1. **Recorder fail-closed** (`scripts/mri-record-suite.ts`) — a red Jest run wrote an honest `fail` entry but `main()` still returned exit 0, greening the suite for any `&&` CI wrapper. Added pure `exitCodeForEntry`; a red run now writes the `fail` entry **and** exits non-zero; crash/unparseable/vacuous throw→exit 1 without writing.
2. **gapCount gated on status** (`src/mri/mri-collectors.ts`) — a red poisoning run with `gapCount=0` read as "0 gaps → healthy". Numeric gap now renders only when `entry.status === 'pass'`; a failed entry renders its fail status.
3. **Freshness wired to the real signal** — F1 (#339) is merged; `freshnessDim` now computes `rejected_stale ÷ (hit + rejected_stale)` off `brain_answer_cache_total`, honest-pending with an accurate reason only when there is no cache traffic (default-off).
4. **premiseAwareness evidence-gated** — flag-ON no longer renders `defended`; it renders `pending-eval` and surfaces the live downgrade count as **activity, not proof**. flag-OFF stays `exposed`. Never `defended` without eval evidence.
5. **Windowed counters** (`src/mri/mri-window.ts`, new) — replaces process-lifetime cumulative reads with a rolling 1h baseline delta (`SnapshotWindow`/`deltaSnapshots`), reset-safe (clamped) and dropping ancient baselines. Window bounds embedded in the report + wire schema.
6. **Cache-hit accounting** (`src/synthesize/synthesize.service.ts` + `synthesize.helpers.ts`) — the cache-hit early-return skipped the synthesize counter, excluding served hits from the terminal-count denominator. Now counted as the terminal `ok` it is (admit() only caches supported+cited). The increment lives in a pure `serveCacheHit` helper to respect the file's pre-existing lint caps; **byte-identical when the cache is off (default)**, proven by an added off-path test.

## Serving-path note
The only serving-file touch is finding 6: a call site + a pure accounting helper, no verdict/synthesis change, unreachable when `SYNTHESIZE_ANSWER_CACHE` is off (default) → prod byte-identical.

## Deliberately left honest-pending (truthful reasons)
`correctness`, `abstentionCalibration` (eval-gated, parked paid eval); `latencyP50/P95`, `citationCoverage` (no serving-path histogram / no citation-vs-supported counter — instrumenting would touch the serving path). Unchanged, already honest.

## Verification (exit codes)
- `pnpm typecheck` → 0 · `eslint --max-warnings 0` → 0 · `prettier --check` (13 files) → 0
- Jest: MRI unit suites (`mri-aggregator`, `mri-record-suite`, `mri-window`, `mri-pareto`, `contracts-admin-mri`) + gate goldens + `synthesize.unit-spec` → 11 suites / 115 tests pass
- No new flags/config → catalog + env/catalog goldens untouched and passing. No paid evals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
