### PR TITLE
fix(auth): deny cross-tenant admin ops without platform scope + gate (P0)

### DIFF
--- a/src/admin/admin-aggregates.controller.ts
+++ b/src/admin/admin-aggregates.controller.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Body, Controller, Post, Req, UseGuards } from '@ne
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 import { ApiKeyService } from '../auth/api-key.service';
+import { resolvePlatformTenant } from '../auth/tenant-scope';
 import { AggregateComposerService, AggregateRunResult } from './aggregate-composer.service';
 import { ArcComposerService, ArcRunResult } from './arc-composer.service';
 
@@ -52,10 +53,9 @@ export class AdminAggregatesController {
     req: AuthenticatedRequest,
     body: { tenant?: string; version?: string },
   ): { tenant: string; version?: string | undefined } {
-    const tenant = body.tenant?.trim() || req.brainAuth.companyId;
-    if (tenant !== req.brainAuth.companyId && !this.apiKeys.knownCompanyIds().includes(tenant)) {
-      throw new BadRequestException(`Unknown tenant '${tenant}' — not a registered tenant`);
-    }
+    const tenant = resolvePlatformTenant(req, body.tenant, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
     const version = body.version?.trim() || undefined;
     if (version && !/^[a-z0-9-]{2,32}$/.test(version)) {
       throw new BadRequestException('version must be a short kebab-case tag (e.g. wd-v2)');

--- a/src/admin/admin-derive.controller.ts
+++ b/src/admin/admin-derive.controller.ts
@@ -11,6 +11,7 @@ import {
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 import { ApiKeyService } from '../auth/api-key.service';
+import { resolvePlatformTenant } from '../auth/tenant-scope';
 import {
   WindowDeriverService,
   DeriveRunResult,
@@ -68,10 +69,9 @@ export class AdminDeriveController {
       force?: boolean;
     } = {},
   ): Promise<DeriveRunResult> {
-    const tenant = body.tenant?.trim() || req.brainAuth.companyId;
-    if (tenant !== req.brainAuth.companyId && !this.apiKeys.knownCompanyIds().includes(tenant)) {
-      throw new BadRequestException(`Unknown tenant '${tenant}' — not a registered tenant`);
-    }
+    const tenant = resolvePlatformTenant(req, body.tenant, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
     const version = body.version?.trim() || WINDOW_DERIVER_VERSION;
     if (!/^[a-z0-9-]{2,32}$/.test(version)) {
       throw new BadRequestException('version must be a short kebab-case tag (e.g. wd-v2)');
@@ -113,10 +113,9 @@ export class AdminDeriveController {
     @Req() req: AuthenticatedRequest,
     @Body() body: { tenant?: string; keep?: string[] } = {},
   ): Promise<{ deleted: Record<string, number>; kept: string[] }> {
-    const tenant = body.tenant?.trim() || req.brainAuth.companyId;
-    if (tenant !== req.brainAuth.companyId && !this.apiKeys.knownCompanyIds().includes(tenant)) {
-      throw new BadRequestException(`Unknown tenant '${tenant}' — not a registered tenant`);
-    }
+    const tenant = resolvePlatformTenant(req, body.tenant, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
     const keep = (body.keep ?? []).filter(
       (v) => typeof v === 'string' && /^[a-z0-9-]{2,32}$/.test(v),
     );

--- a/src/admin/admin-hnsw.controller.ts
+++ b/src/admin/admin-hnsw.controller.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Body, Controller, Post, Req, UseGuards } from '@ne
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 import { ApiKeyService } from '../auth/api-key.service';
+import { resolvePlatformTenant } from '../auth/tenant-scope';
 import { HnswMaintenanceService, HnswMaintenanceResult } from './hnsw-maintenance.service';
 
 /**
@@ -28,10 +29,9 @@ export class AdminHnswController {
     if (action !== 'create' && action !== 'drop') {
       throw new BadRequestException(`action must be 'create' or 'drop'`);
     }
-    const tenant = body.tenant?.trim() || req.brainAuth.companyId;
-    if (tenant !== req.brainAuth.companyId && !this.apiKeys.knownCompanyIds().includes(tenant)) {
-      throw new BadRequestException(`Unknown tenant '${tenant}' — not a registered tenant`);
-    }
+    const tenant = resolvePlatformTenant(req, body.tenant, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
     return this.hnsw.apply(tenant, action);
   }
 }

--- a/src/admin/admin-infra.controller.ts
+++ b/src/admin/admin-infra.controller.ts
@@ -56,8 +56,8 @@ export class AdminInfraController {
    */
   @Get('migrations')
   @RequireScopes('brain:admin')
-  async migrations(): Promise<MigrationsResponse> {
-    return this.adminInfra.migrationsAudit();
+  async migrations(@Req() req: AuthenticatedRequest): Promise<MigrationsResponse> {
+    return this.adminInfra.migrationsAudit(req);
   }
 
   @Get('throttler')

--- a/src/admin/admin-infra.service.ts
+++ b/src/admin/admin-infra.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { SurrealService, queryRows } from '../db/surreal.service';
 import { ApiKeyService } from '../auth/api-key.service';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { resolvePlatformTenantScope } from '../auth/tenant-scope';
 import type { MigrationsResponse } from '../contracts/admin/migrations.schema';
 
 /**
@@ -31,9 +33,14 @@ export class AdminInfraService {
    * migration the others have). A tenant whose schema_migrations read
    * throws is reported as fully pending rather than failing the audit.
    */
-  async migrationsAudit(): Promise<MigrationsResponse> {
+  async migrationsAudit(req: AuthenticatedRequest): Promise<MigrationsResponse> {
     const manifest = await this.surreal.migrator.loadManifest();
-    const tenants = this.apiKeys.knownCompanyIds();
+    // Tenant isolation: a plain brain:admin audits only its own tenant's
+    // schema state (and never enumerates the tenant roster); a platform
+    // operator (scope + gate) keeps the cross-tenant drift audit.
+    const tenants = resolvePlatformTenantScope(req, undefined, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
     const perTenant: Array<{
       companyId: string;
       applied: string[];

--- a/src/admin/admin-jobs.controller.ts
+++ b/src/admin/admin-jobs.controller.ts
@@ -26,6 +26,11 @@ import { CalibrationRefitService } from '../ai/calibration/calibration-refit.ser
 import { CompactionService } from '../compaction/compaction.service';
 import { ChangefeedConsumerService } from '../audit/changefeed-consumer.service';
 import { ApiKeyService } from '../auth/api-key.service';
+import {
+  resolvePlatformTenant,
+  platformTenantCapable,
+  resolvePlatformTenantScope,
+} from '../auth/tenant-scope';
 import { ConfigService } from '@nestjs/config';
 import { HttpCode } from '@nestjs/common';
 import { ReindexEmbeddingsService } from '../ai/embedder/reindex-embeddings.service';
@@ -84,10 +89,11 @@ export class AdminJobsController {
     private readonly config: ConfigService,
   ) {}
 
-  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Query binding, cannot be folded into an options object without breaking Nest param resolution
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get('jobs')
   @RequireScopes('brain:admin')
   async listJobs(
+    @Req() req: AuthenticatedRequest,
     @Query('jobType') jobType?: string,
     @Query('status') status?: string,
     @Query('since') since?: string,
@@ -98,7 +104,21 @@ export class AdminJobsController {
     const jobTypeVal = (jobType?.trim() as JobType) || undefined;
     const statusVal = (status?.trim() as JobStatus) || undefined;
     const sinceVal = since?.trim() || undefined;
-    const companyIdVal = companyId?.trim() || undefined;
+    // Tenant isolation: a caller-supplied companyId resolves through the
+    // platform gate (own tenant always ok; a foreign one is a 403 without
+    // brain:platform_admin + gate). Omitted → a platform operator lists
+    // every tenant's jobs; a plain brain:admin sees only its own tenant.
+    const requestedCompany = companyId?.trim();
+    let companyIdVal: string | undefined;
+    if (requestedCompany) {
+      companyIdVal = resolvePlatformTenant(req, requestedCompany, {
+        knownTenants: () => this.apiKeys.knownCompanyIds(),
+      });
+    } else if (platformTenantCapable(req.brainAuth.scopes)) {
+      companyIdVal = undefined;
+    } else {
+      companyIdVal = req.brainAuth.companyId;
+    }
     const limitVal =
       parsedLimit !== undefined && Number.isFinite(parsedLimit) ? parsedLimit : undefined;
     const rows = await this.jobs.list({
@@ -114,8 +134,9 @@ export class AdminJobsController {
   @Get('jobs/:runId')
   @RequireScopes('brain:admin')
   async getJob(@Req() req: AuthenticatedRequest, @Param('runId') runId: string): Promise<JobRow> {
-    // Try caller's company first; admins may also query across tenants
-    // via the explicit companyId query string on /jobs list endpoint.
+    // Scoped to the caller's own tenant: a job belonging to another tenant
+    // reads as not-found. Cross-tenant reach is the platform-operator path
+    // only (brain:platform_admin + gate), never plain brain:admin.
     const row = await this.jobs.get(runId, req.brainAuth.companyId);
     if (!row) throw new NotFoundException(`Job ${runId} not found`);
     return row satisfies JobRow;
@@ -257,13 +278,20 @@ export class AdminJobsController {
     @Req() req: AuthenticatedRequest,
     @Body() body: { companyId?: string } = {},
   ): AcceptedCompactionResponse {
-    const known = this.apiKeys.knownCompanyIds();
-    if (body.companyId && !known.includes(body.companyId)) {
-      throw new BadRequestException(
-        `Unknown companyId '${body.companyId}' — not a registered tenant`,
-      );
-    }
-    const target = body.companyId ? [body.companyId] : known;
+    // Tenant isolation: a specific companyId resolves through the platform
+    // gate (own tenant always ok; a foreign one is a 403 without the
+    // platform scope + gate). Omitted → a platform operator fans out over
+    // every tenant; a plain brain:admin compacts only its own tenant.
+    const requested = body.companyId?.trim();
+    const target = requested
+      ? [
+          resolvePlatformTenant(req, requested, {
+            knownTenants: () => this.apiKeys.knownCompanyIds(),
+          }),
+        ]
+      : platformTenantCapable(req.brainAuth.scopes)
+        ? this.apiKeys.knownCompanyIds()
+        : [req.brainAuth.companyId];
     void (async () => {
       for (const companyId of target) {
         try {
@@ -275,7 +303,6 @@ export class AdminJobsController {
         }
       }
     })();
-    void req;
     return {
       accepted: true,
       jobType: 'compaction',
@@ -314,12 +341,26 @@ export class AdminJobsController {
     @Body()
     body: { tenant?: string; dryRun?: boolean; maxFacts?: number } = {},
   ): Promise<AcceptedReindexResponse> {
-    const tenants = this.apiKeys.knownCompanyIds();
-    const tenantFilter = body.tenant?.trim();
-    if (tenantFilter && !tenants.includes(tenantFilter)) {
-      throw new BadRequestException(`Unknown tenant '${tenantFilter}' — not a registered tenant`);
+    // Tenant isolation: a specific tenant resolves through the platform
+    // gate (own tenant always ok; a foreign one is a 403 without the
+    // platform scope + gate). Omitted → a platform operator re-embeds
+    // every tenant (reindexTenant undefined); a plain brain:admin
+    // re-embeds only its own tenant. hostTenant carries the job row.
+    const requested = body.tenant?.trim();
+    let reindexTenant: string | undefined;
+    let hostTenant: string | undefined;
+    if (requested) {
+      reindexTenant = resolvePlatformTenant(req, requested, {
+        knownTenants: () => this.apiKeys.knownCompanyIds(),
+      });
+      hostTenant = reindexTenant;
+    } else if (platformTenantCapable(req.brainAuth.scopes)) {
+      reindexTenant = undefined;
+      hostTenant = this.apiKeys.knownCompanyIds()[0];
+    } else {
+      reindexTenant = req.brainAuth.companyId;
+      hostTenant = req.brainAuth.companyId;
     }
-    const hostTenant = tenantFilter || tenants[0];
     if (!hostTenant) {
       throw new BadRequestException('No registered tenant to reindex');
     }
@@ -329,14 +370,13 @@ export class AdminJobsController {
       triggeredBy: 'manual',
       triggeredByActor: req.brainAuth.companyId,
       initialProgress: {
-        tenantFilter: body.tenant?.trim() ?? null,
+        tenantFilter: reindexTenant ?? null,
         dryRun: body.dryRun === true,
         maxFacts: body.maxFacts ?? null,
       },
     });
     void (async () => {
       try {
-        const reindexTenant = body.tenant?.trim() || undefined;
         const result = await this.reindex.run({
           ...(reindexTenant !== undefined ? { tenant: reindexTenant } : {}),
           dryRun: body.dryRun === true,
@@ -383,8 +423,13 @@ export class AdminJobsController {
       : body.vertical
         ? all.filter((s) => s.vertical === body.vertical).map((s) => s.id)
         : all.map((s) => s.id);
-    const tenants = this.apiKeys.knownCompanyIds();
-    const hostTenant = tenants[0];
+    // Tenant isolation: a plain brain:admin books the batch job under its
+    // own tenant; a platform operator may host it on the first registered
+    // tenant. The scenarios themselves run against synthetic scratch
+    // tenants — hostTenant only carries the job_run bookkeeping row.
+    const hostTenant = platformTenantCapable(req.brainAuth.scopes)
+      ? this.apiKeys.knownCompanyIds()[0]
+      : req.brainAuth.companyId;
     if (!hostTenant) {
       throw new BadRequestException('No registered tenant to run scenarios');
     }
@@ -450,18 +495,30 @@ export class AdminJobsController {
   }
 
   /**
-   * Per-run emit drill for Dreams. Returns the emit rows the
-   * specified run produced (identity_link / resolution / summary).
-   * If no runId is given, returns the most recent successful run's
-   * emits across known tenants.
+   * Per-run emit drill for Dreams. Returns the emit rows the specified
+   * run produced (identity_link / resolution / summary). Tenant-scoped:
+   * a caller-supplied companyId resolves through the platform gate (own
+   * tenant always ok; a foreign one is a 403 without brain:platform_admin
+   * + gate). Omitted → a platform operator scans every tenant; a plain
+   * brain:admin sees only its own tenant's emits.
    */
   @Get('dreams/runs/:runId/emits')
   @RequireScopes('brain:admin')
   async dreamEmits(
+    @Req() req: AuthenticatedRequest,
     @Param('runId') runId: string,
     @Query('companyId') companyIdQ?: string,
   ): Promise<DreamsEmitsResponse> {
-    const tenants = companyIdQ ? [companyIdQ] : this.apiKeys.knownCompanyIds();
+    const requestedCompany = companyIdQ?.trim();
+    const tenants: readonly string[] = requestedCompany
+      ? [
+          resolvePlatformTenant(req, requestedCompany, {
+            knownTenants: () => this.apiKeys.knownCompanyIds(),
+          }),
+        ]
+      : platformTenantCapable(req.brainAuth.scopes)
+        ? this.apiKeys.knownCompanyIds()
+        : [req.brainAuth.companyId];
     const emits: Array<Record<string, unknown>> = [];
     for (const companyId of tenants) {
       try {
@@ -494,10 +551,16 @@ export class AdminJobsController {
    */
   @Get('dreams/summary')
   @RequireScopes('brain:admin')
-  async dreamsSummary(): Promise<DreamsSummaryResponse> {
+  async dreamsSummary(@Req() req: AuthenticatedRequest): Promise<DreamsSummaryResponse> {
+    // Tenant isolation: a plain brain:admin sees only its own tenant's
+    // dreams runs + aggregates; a platform operator keeps the all-tenant
+    // rollup.
     const runs = await this.jobs.list({
       jobType: 'dreams',
       limit: 100,
+      ...(platformTenantCapable(req.brainAuth.scopes)
+        ? {}
+        : { companyId: req.brainAuth.companyId }),
     });
     let identityLinks = 0;
     let resolutions = 0;
@@ -540,10 +603,17 @@ export class AdminJobsController {
    */
   @Get('leases')
   @RequireScopes('brain:admin')
-  async leases(): Promise<LeasesResponse> {
+  async leases(@Req() req: AuthenticatedRequest): Promise<LeasesResponse> {
+    // Tenant isolation: the active-claim scan is tenant-scoped data — a
+    // plain brain:admin sees only its own tenant's claims; a platform
+    // operator keeps the all-tenant cockpit. Leader leases + pod identity
+    // are cluster-orchestration state (no tenant dimension), shown as-is.
+    const claimTenants = platformTenantCapable(req.brainAuth.scopes)
+      ? this.apiKeys.knownCompanyIds()
+      : [req.brainAuth.companyId];
     const [leaderLeases, activeClaims] = await Promise.all([
       this.leaderLease.list(),
-      this.claim.listActiveClaims(this.apiKeys.knownCompanyIds()),
+      this.claim.listActiveClaims(claimTenants),
     ]);
     const now = Date.now();
     const queueMode = (this.config.get<string>('JOBS_QUEUE_MODE', 'enqueue') ?? 'enqueue') as
@@ -583,12 +653,22 @@ export class AdminJobsController {
 
   @Get('changefeed/state')
   @RequireScopes('brain:admin')
-  async changefeedState(): Promise<ChangefeedStateResponse> {
+  async changefeedState(@Req() req: AuthenticatedRequest): Promise<ChangefeedStateResponse> {
     // stats() is synchronous (a plain snapshot getter); only cursorState() is
     // async — so read stats() directly and await the one Promise rather than
     // wrapping a non-Thenable in Promise.all.
     const stats = this.changefeed.stats();
-    const cursors = await this.changefeed.cursorState();
+    const allCursors = await this.changefeed.cursorState();
+    // Tenant isolation: the per-tenant cursors are scoped to the caller —
+    // a plain brain:admin sees only its own tenant's watermarks; a
+    // platform operator (scope + gate) keeps the all-tenant view. stats
+    // are process-wide consumer counters (no tenant dimension), shown as-is.
+    const scope = new Set(
+      resolvePlatformTenantScope(req, undefined, {
+        knownTenants: () => this.apiKeys.knownCompanyIds(),
+      }),
+    );
+    const cursors = allCursors.filter((c) => scope.has(c.companyId));
     // sources is readonly string[] on the service to keep callers from
     // mutating the constant; on the wire it's just an array.
     return {

--- a/src/admin/admin-ops.controller.ts
+++ b/src/admin/admin-ops.controller.ts
@@ -43,20 +43,25 @@ export class AdminOpsController {
 
   // ── Dead-letter ───────────────────────────────────────────
 
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get('dlq')
   @RequireScopes('brain:admin')
   async dlq(
+    @Req() req: AuthenticatedRequest,
     @Query('companyId') companyId?: string,
     @Query('reason') reason?: string,
     @Query('limit') limit?: string,
   ): Promise<DlqResponse> {
     const parsed = limit ? parseInt(limit, 10) : undefined;
     return {
-      rows: await this.admin.listDeadLetter({
-        companyId: companyId?.trim() || undefined,
-        reason: reason?.trim() || undefined,
-        limit: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined,
-      }),
+      rows: await this.admin.listDeadLetter(
+        {
+          companyId: companyId?.trim() || undefined,
+          reason: reason?.trim() || undefined,
+          limit: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined,
+        },
+        req,
+      ),
     } satisfies DlqResponse;
   }
 
@@ -76,6 +81,7 @@ export class AdminOpsController {
   @Get('forgotten')
   @RequireScopes('brain:admin')
   async forgotten(
+    @Req() req: AuthenticatedRequest,
     @Query('companyId') companyId?: string,
     @Query('reason') reason?: string,
     @Query('since') since?: string,
@@ -83,12 +89,15 @@ export class AdminOpsController {
   ): Promise<ForgottenResponse> {
     const parsed = limit ? parseInt(limit, 10) : undefined;
     return {
-      rows: await this.admin.listForgotten({
-        companyId: companyId?.trim() || undefined,
-        reason: reason?.trim() || undefined,
-        since: since?.trim() || undefined,
-        limit: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined,
-      }),
+      rows: await this.admin.listForgotten(
+        {
+          companyId: companyId?.trim() || undefined,
+          reason: reason?.trim() || undefined,
+          since: since?.trim() || undefined,
+          limit: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined,
+        },
+        req,
+      ),
     } satisfies ForgottenResponse;
   }
 
@@ -100,18 +109,23 @@ export class AdminOpsController {
    * Note: payload contains only entityIdHash + counts + reason + ts.
    * The actual entity data is gone; that's the whole point.
    */
+  // eslint-disable-next-line max-params -- decorated HTTP route handler; each param is a @Req/@Res/@Query binding, cannot be folded into an options object without breaking Nest param resolution
   @Get('forgotten/export')
   @RequireScopes('brain:admin')
   async forgottenExport(
+    @Req() req: AuthenticatedRequest,
     @Res() res: Response,
     @Query('companyId') companyId?: string,
     @Query('since') since?: string,
   ) {
-    const rows = await this.admin.listForgotten({
-      companyId: companyId?.trim() || undefined,
-      since: since?.trim() || undefined,
-      limit: 2000,
-    });
+    const rows = await this.admin.listForgotten(
+      {
+        companyId: companyId?.trim() || undefined,
+        since: since?.trim() || undefined,
+        limit: 2000,
+      },
+      req,
+    );
     const manifest = {
       generatedAt: new Date().toISOString(),
       filter: {
@@ -141,9 +155,9 @@ export class AdminOpsController {
 
   @Get('pii')
   @RequireScopes('brain:admin', 'brain:read_pii')
-  async piiInventory(): Promise<PiiInventoryResponse> {
+  async piiInventory(@Req() req: AuthenticatedRequest): Promise<PiiInventoryResponse> {
     return {
-      rows: await this.admin.listPiiInventory(),
+      rows: await this.admin.listPiiInventory(req),
     } satisfies PiiInventoryResponse;
   }
 
@@ -159,15 +173,17 @@ export class AdminOpsController {
     @Query('since') since?: string,
     @Query('limit') limit?: string,
   ): Promise<OperatorActionsResponse> {
-    void req; // reserved for future per-key scoping
     const parsed = limit ? parseInt(limit, 10) : undefined;
     return {
-      rows: await this.actions.list({
-        actor: actor?.trim() || undefined,
-        pathPrefix: pathPrefix?.trim() || undefined,
-        since: since?.trim() || undefined,
-        limit: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined,
-      }),
+      rows: await this.actions.list(
+        {
+          actor: actor?.trim() || undefined,
+          pathPrefix: pathPrefix?.trim() || undefined,
+          since: since?.trim() || undefined,
+          limit: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined,
+        },
+        req,
+      ),
     } satisfies OperatorActionsResponse;
   }
 }

--- a/src/admin/admin-segments.controller.ts
+++ b/src/admin/admin-segments.controller.ts
@@ -1,7 +1,8 @@
-import { BadRequestException, Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 import { ApiKeyService } from '../auth/api-key.service';
+import { resolvePlatformTenant } from '../auth/tenant-scope';
 import { SegmentComposerService, SegmentRunResult } from './segment-composer.service';
 
 /**
@@ -24,10 +25,9 @@ export class AdminSegmentsController {
     @Req() req: AuthenticatedRequest,
     @Body() body: { tenant?: string } = {},
   ): Promise<SegmentRunResult> {
-    const tenant = body.tenant?.trim() || req.brainAuth.companyId;
-    if (tenant !== req.brainAuth.companyId && !this.apiKeys.knownCompanyIds().includes(tenant)) {
-      throw new BadRequestException(`Unknown tenant '${tenant}' — not a registered tenant`);
-    }
+    const tenant = resolvePlatformTenant(req, body.tenant, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
     return this.composer.run(tenant);
   }
 }

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -72,8 +72,8 @@ export class AdminController {
 
   @Get('overview')
   @RequireScopes('brain:admin')
-  async overview(): Promise<OverviewResponse> {
-    return (await this.admin.buildOverview()) satisfies OverviewResponse;
+  async overview(@Req() req: AuthenticatedRequest): Promise<OverviewResponse> {
+    return (await this.admin.buildOverview(req)) satisfies OverviewResponse;
   }
 
   /**
@@ -89,6 +89,7 @@ export class AdminController {
   @Get('audit')
   @RequireScopes('brain:admin')
   async audit(
+    @Req() req: AuthenticatedRequest,
     @Query('companyId') companyId?: string,
     @Query('source') source?: string,
     @Query('op') op?: string,
@@ -97,14 +98,17 @@ export class AdminController {
     @Query('limit') limit?: string,
   ): Promise<AuditPageResponse> {
     const parsedLimit = limit ? parseInt(limit, 10) : undefined;
-    const page = await this.admin.listAuditEvents({
-      companyId: companyId?.trim() || undefined,
-      source: source?.trim() || undefined,
-      op: op?.trim() || undefined,
-      since: since?.trim() || undefined,
-      before: before?.trim() || undefined,
-      limit: parsedLimit !== undefined && Number.isFinite(parsedLimit) ? parsedLimit : undefined,
-    });
+    const page = await this.admin.listAuditEvents(
+      {
+        companyId: companyId?.trim() || undefined,
+        source: source?.trim() || undefined,
+        op: op?.trim() || undefined,
+        since: since?.trim() || undefined,
+        before: before?.trim() || undefined,
+        limit: parsedLimit !== undefined && Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+      },
+      req,
+    );
     return page satisfies AuditPageResponse;
   }
 

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ApiKeyService } from '../auth/api-key.service';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { resolvePlatformTenantScope } from '../auth/tenant-scope';
 import { SurrealService, queryRows } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { mapWithLimit } from '../common/parallel';
@@ -196,9 +198,14 @@ export class AdminService {
     private readonly metrics: MetricsService,
   ) {}
 
-  async buildOverview(): Promise<AdminOverview> {
+  async buildOverview(req: AuthenticatedRequest): Promise<AdminOverview> {
     const dbOk = await this.surreal.ping().catch(() => false);
-    const tenants = this.apiKeys.knownCompanyIds();
+    // Tenant isolation: a plain brain:admin sees only its own tenant in
+    // the overview; a platform operator (scope + gate) keeps the
+    // all-tenant console.
+    const tenants = resolvePlatformTenantScope(req, undefined, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
     const metricsSnapshot = await this.snapshotMetrics();
 
     const rows: AdminTenantRow[] = [];
@@ -447,12 +454,17 @@ export class AdminService {
    * Full DLQ listing with filter + pagination. Used by /admin/dlq
    * page; the overview already shows last 20.
    */
-  async listDeadLetter(filter: {
-    companyId?: string | undefined;
-    reason?: string | undefined;
-    limit?: number | undefined;
-  }): Promise<AdminDeadLetterRow[]> {
-    const tenants = filter.companyId ? [filter.companyId] : this.apiKeys.knownCompanyIds();
+  async listDeadLetter(
+    filter: {
+      companyId?: string | undefined;
+      reason?: string | undefined;
+      limit?: number | undefined;
+    },
+    req: AuthenticatedRequest,
+  ): Promise<AdminDeadLetterRow[]> {
+    const tenants = resolvePlatformTenantScope(req, filter.companyId, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
     const limit = Math.min(Math.max(filter.limit ?? 200, 1), 1000);
     const out: AdminDeadLetterRow[] = [];
     const where: string[] = [];
@@ -517,13 +529,18 @@ export class AdminService {
    * Full forgotten-entities list with filter. Used by /admin/forgotten
    * page; also drives the GDPR export endpoint.
    */
-  async listForgotten(filter: {
-    companyId?: string | undefined;
-    reason?: string | undefined;
-    since?: string | undefined;
-    limit?: number | undefined;
-  }): Promise<AdminForgottenRow[]> {
-    const tenants = filter.companyId ? [filter.companyId] : this.apiKeys.knownCompanyIds();
+  async listForgotten(
+    filter: {
+      companyId?: string | undefined;
+      reason?: string | undefined;
+      since?: string | undefined;
+      limit?: number | undefined;
+    },
+    req: AuthenticatedRequest,
+  ): Promise<AdminForgottenRow[]> {
+    const tenants = resolvePlatformTenantScope(req, filter.companyId, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
     const limit = Math.min(Math.max(filter.limit ?? 200, 1), 2000);
     const where: string[] = [];
     const params: Record<string, unknown> = {};
@@ -575,7 +592,7 @@ export class AdminService {
    * operator sees "how many sensitive rows do we hold for tenant X?"
    * Drives the /admin/pii page.
    */
-  async listPiiInventory(): Promise<
+  async listPiiInventory(req: AuthenticatedRequest): Promise<
     Array<{
       companyId: string;
       predicate: string;
@@ -585,7 +602,9 @@ export class AdminService {
       retractedCount: number;
     }>
   > {
-    const tenants = this.apiKeys.knownCompanyIds();
+    const tenants = resolvePlatformTenantScope(req, undefined, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
     const out: Array<{
       companyId: string;
       predicate: string;
@@ -654,9 +673,11 @@ export class AdminService {
    * window, hard limit (capped at 500). Always returns events sorted
    * desc by ts. Also returns aggregate totals for chart drawing.
    */
-  async listAuditEvents(q: AuditQuery): Promise<AuditPage> {
+  async listAuditEvents(q: AuditQuery, req: AuthenticatedRequest): Promise<AuditPage> {
     const limit = Math.min(Math.max(q.limit ?? 100, 1), 500);
-    const tenants = q.companyId ? [q.companyId] : this.apiKeys.knownCompanyIds();
+    const tenants = resolvePlatformTenantScope(req, q.companyId, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
     const events: AuditEventRow[] = [];
     const totalsBySource: Record<string, number> = {};
     const totalsByOp: Record<string, number> = {};

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1628,7 +1628,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: true,
     isBooleanFlag: true,
     description:
-      'Allow an admin-scoped key to address another tenant via the X-Brain-Tenant header (slug-validated). Built for eval harnesses needing per-question tenant isolation (LongMemEval/BEAM: one haystack per tenant) without minting hundreds of keys. Never enable in multi-tenant prod without a policy review.',
+      'Unlock the platform-operator cross-tenant path: a key holding the dedicated brain:platform_admin scope may address a tenant other than its own — via the X-Brain-Tenant header (guard) or a tenant/companyId body/query field on admin endpoints (resolvePlatformTenant). BOTH the scope and this gate are required; with either missing, a plain brain:admin key can only ever operate on its own tenant (a foreign tenant is a 403). Built for eval harnesses needing per-question tenant isolation (LongMemEval/BEAM: one haystack per tenant) without minting hundreds of keys. Never enable in multi-tenant prod without a policy review.',
   },
   {
     key: 'INGEST_EPISODE_ONLY',

--- a/src/admin/operator-action.service.ts
+++ b/src/admin/operator-action.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ApiKeyService } from '../auth/api-key.service';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { resolvePlatformTenantScope } from '../auth/tenant-scope';
 import { SurrealService, queryRows } from '../db/surreal.service';
 
 export interface OperatorActionRow {
@@ -55,14 +57,23 @@ export class OperatorActionService {
     });
   }
 
-  async list(filter: {
-    actor?: string | undefined;
-    pathPrefix?: string | undefined;
-    since?: string | undefined;
-    limit?: number | undefined;
-  }): Promise<OperatorActionRow[]> {
+  async list(
+    filter: {
+      actor?: string | undefined;
+      pathPrefix?: string | undefined;
+      since?: string | undefined;
+      limit?: number | undefined;
+    },
+    req: AuthenticatedRequest,
+  ): Promise<OperatorActionRow[]> {
     if (!this.surreal || !this.apiKeys) return [];
-    const tenants = filter.actor ? [filter.actor] : this.apiKeys.knownCompanyIds();
+    // Tenant isolation: `actor` narrows to one tenant's action log; a
+    // plain brain:admin is confined to its own tenant, a platform
+    // operator (scope + gate) spans all.
+    const apiKeys = this.apiKeys;
+    const tenants = resolvePlatformTenantScope(req, filter.actor, {
+      knownTenants: () => apiKeys.knownCompanyIds(),
+    });
     const limit = Math.min(Math.max(filter.limit ?? 200, 1), 1000);
     const where: string[] = [];
     const params: Record<string, unknown> = {};

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -15,15 +15,21 @@ import { getRequestContext } from '../common/request-context';
 import { resourceMetadataUrl } from './resource-metadata';
 import { BrainScope, AuthenticatedRequest, ApiKeyRecord } from './api-key.types';
 import { envFlagEnabled } from '../common/env-validation';
+import { PLATFORM_TENANT_SCOPE } from './tenant-scope';
 import { resolveRetrievalProfileFor } from '../search/retrieval-profile';
 
 /**
- * Tenant override (BRAIN_TENANT_OVERRIDE_ENABLED, default off): an
- * admin-scoped key may address another tenant via X-Brain-Tenant — the
- * per-call pinning the sink interfaces anticipated. Built for eval
+ * Tenant override (BRAIN_TENANT_OVERRIDE_ENABLED, default off): a
+ * PLATFORM-operator key may address another tenant via X-Brain-Tenant —
+ * the per-call pinning the sink interfaces anticipated. Built for eval
  * harnesses that need per-question tenant isolation (e.g. LongMemEval:
  * one haystack per question) without minting hundreds of keys; never
  * enable in multi-tenant prod without a policy review.
+ *
+ * Reaching another tenant requires the dedicated `brain:platform_admin`
+ * scope (NOT plain `brain:admin`) AND the gate — the same two-key rule
+ * the body/query path enforces via resolvePlatformTenant(). A plain
+ * `brain:admin` key can never cross tenants through this header.
  */
 function resolveTenantOverride(
   record: ApiKeyRecord,
@@ -36,7 +42,7 @@ function resolveTenantOverride(
   const allowed =
     requested !== '' &&
     requested !== record.companyId &&
-    record.scopes.includes('brain:admin') &&
+    record.scopes.includes(PLATFORM_TENANT_SCOPE) &&
     /^[a-z0-9_-]{2,64}$/.test(requested);
   return allowed ? requested : record.companyId;
 }

--- a/src/auth/api-key.types.ts
+++ b/src/auth/api-key.types.ts
@@ -3,6 +3,13 @@ export type BrainScope =
   | 'brain:write'
   | 'brain:admin'
   | 'brain:read_pii'
+  // Cross-tenant (company-level) operator authority — distinct from and
+  // strictly HIGHER than brain:admin ("operate MY tenant"). Required for
+  // any admin op that addresses a tenant other than the credential's own
+  // (with BRAIN_TENANT_OVERRIDE_ENABLED). Hosting-operator only: granted
+  // via env-key config like registry:curate, deliberately NOT added to
+  // the jwks VALID_SCOPES set (never mintable through the token path).
+  | 'brain:platform_admin'
   // Publish/yank in the GLOBAL pack registry — distinct from brain:admin
   // ("operate my tenant") because it mutates the catalogue shared across all
   // tenants. Discovery reads use brain:read; installing from the registry into

--- a/src/auth/tenant-scope.ts
+++ b/src/auth/tenant-scope.ts
@@ -1,0 +1,118 @@
+/**
+ * Cross-tenant (company-level) scope pinning — the platform analogue of
+ * pinUserScope() (per-user, user-scope.ts). Where pinUserScope keeps a
+ * user-bound token inside one user's slice of a tenant, this keeps an
+ * admin-scoped key inside its OWN tenant.
+ *
+ * The tenant target of an admin operation is caller-asserted (a `tenant`
+ * body/query field, or the X-Brain-Tenant header). A `brain:admin`
+ * credential holds authority over ITS tenant only — it must never reach
+ * another registered tenant just because that tenant exists. Reaching a
+ * DIFFERENT tenant is a distinct, higher capability: it requires BOTH
+ *
+ *   1. the dedicated `brain:platform_admin` scope on the credential, AND
+ *   2. the BRAIN_TENANT_OVERRIDE_ENABLED env gate (default off).
+ *
+ * Both are required; either alone denies. With the gate off, or without
+ * the platform scope, an admin caller can ONLY ever operate on
+ * req.brainAuth.companyId — a `tenant` naming another company is a 403,
+ * never silently honored (the tenant-isolation bypass this closes).
+ *
+ * Pure module — importable from controllers and the guard alike. Reads
+ * the gate off process.env per call (runtime-mutable, matching the
+ * catalog), via the sanctioned envFlagEnabled parser.
+ */
+
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { envFlagEnabled } from '../common/env-validation';
+import type { AuthenticatedRequest, BrainScope } from './api-key.types';
+
+/**
+ * Cross-tenant is a separate capability from tenant-local `brain:admin`.
+ * Granted per hosting-operator integration via env-key config — like
+ * `registry:curate`, deliberately NOT part of the jwks VALID_SCOPES set
+ * (never mintable through the normal token path).
+ */
+export const PLATFORM_TENANT_SCOPE: BrainScope = 'brain:platform_admin';
+
+/** The env gate that unlocks the platform-operator cross-tenant path. */
+export function tenantOverrideEnabled(): boolean {
+  return envFlagEnabled(process.env.BRAIN_TENANT_OVERRIDE_ENABLED);
+}
+
+/**
+ * True ONLY when this credential may address a tenant other than its own:
+ * it carries the platform scope AND the gate is on. Both required.
+ */
+export function platformTenantCapable(scopes: readonly BrainScope[]): boolean {
+  return tenantOverrideEnabled() && scopes.includes(PLATFORM_TENANT_SCOPE);
+}
+
+export interface ResolvePlatformTenantOptions {
+  /**
+   * Registered tenants — a foreign target must be one of these. Supplied
+   * as a thunk so it is only evaluated on the (rare) sanctioned
+   * cross-tenant path, never on the hot own-tenant path.
+   */
+  knownTenants?: () => readonly string[];
+}
+
+/**
+ * Resolve the effective tenant for an admin request.
+ *
+ *  - No tenant requested, or the requested tenant equals the caller's own
+ *    → the caller's own companyId (pre-existing behavior, byte-identical).
+ *  - A DIFFERENT tenant requested → DENY (403 ForbiddenException) unless
+ *    the caller is platform-capable (platform scope + gate). On the
+ *    sanctioned path an unknown tenant is still a 400.
+ *
+ * This is the ONE place cross-tenant is decided; controllers must not
+ * re-implement the check.
+ */
+export function resolvePlatformTenant(
+  req: AuthenticatedRequest,
+  requested: string | undefined,
+  opts: ResolvePlatformTenantOptions = {},
+): string {
+  const own = req.brainAuth.companyId;
+  const target = requested?.trim();
+  if (!target || target === own) return own;
+
+  // A different tenant is asked for: cross-tenant capability required.
+  if (!platformTenantCapable(req.brainAuth.scopes)) {
+    throw new ForbiddenException(
+      'Cross-tenant access denied: addressing a tenant other than your own ' +
+        'requires the brain:platform_admin scope and BRAIN_TENANT_OVERRIDE_ENABLED',
+    );
+  }
+
+  const known = opts.knownTenants?.() ?? [];
+  if (!known.includes(target)) {
+    throw new BadRequestException(`Unknown tenant '${target}' — not a registered tenant`);
+  }
+  return target;
+}
+
+/**
+ * The set of tenants an admin READ may span — the aggregate-read analogue
+ * of resolvePlatformTenant. A plain brain:admin is confined to its own
+ * tenant; a platform operator (scope + gate) spans every registered
+ * tenant. An optional caller-supplied `requested` narrows to that single
+ * tenant through resolvePlatformTenant (own ok; a foreign tenant is a 403
+ * without the platform capability, then a 400 if unknown).
+ *
+ * Use this wherever a handler/service would otherwise fan a read out over
+ * apiKeys.knownCompanyIds() and return the result to the caller, so a
+ * plain admin never observes another tenant's data or activity.
+ */
+export function resolvePlatformTenantScope(
+  req: AuthenticatedRequest,
+  requested: string | undefined,
+  opts: ResolvePlatformTenantOptions = {},
+): readonly string[] {
+  const target = requested?.trim();
+  if (target) return [resolvePlatformTenant(req, target, opts)];
+  return platformTenantCapable(req.brainAuth.scopes)
+    ? (opts.knownTenants?.() ?? [req.brainAuth.companyId])
+    : [req.brainAuth.companyId];
+}

--- a/src/strategy/strategy-admin.controller.ts
+++ b/src/strategy/strategy-admin.controller.ts
@@ -14,6 +14,7 @@ import {
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 import { ApiKeyService } from '../auth/api-key.service';
+import { resolvePlatformTenant } from '../auth/tenant-scope';
 import {
   StrategyMemoryService,
   type StrategyItem,
@@ -81,14 +82,9 @@ export class StrategyAdminController {
   }
 
   private resolveTenant(req: AuthenticatedRequest, tenant?: string): string {
-    const resolved = tenant?.trim() || req.brainAuth.companyId;
-    if (
-      resolved !== req.brainAuth.companyId &&
-      !this.apiKeys.knownCompanyIds().includes(resolved)
-    ) {
-      throw new BadRequestException(`Unknown tenant '${resolved}' — not a registered tenant`);
-    }
-    return resolved;
+    return resolvePlatformTenant(req, tenant, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
   }
 
   @Post('distill')

--- a/test/admin-tenant-isolation.unit-spec.ts
+++ b/test/admin-tenant-isolation.unit-spec.ts
@@ -1,0 +1,410 @@
+/**
+ * Release blocker (P0 tenant-isolation bypass): admin controllers used to
+ * resolve the target tenant from the request body/query and accept ANY
+ * registered tenant, so a `brain:admin` key scoped to tenant A could pass
+ * `tenant = B` and run privileged ops (derive/GC, drop HNSW, mutate
+ * strategies, compaction, reindex) on tenant B. The fix centralizes tenant
+ * resolution in resolvePlatformTenant(): a foreign tenant is a 403 unless
+ * the caller holds the dedicated brain:platform_admin scope AND
+ * BRAIN_TENANT_OVERRIDE_ENABLED is on. This pins the default-deny and the
+ * sanctioned platform path for every affected endpoint.
+ */
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import type { AuthenticatedRequest, BrainScope } from '../src/auth/api-key.types';
+import {
+  resolvePlatformTenant,
+  resolvePlatformTenantScope,
+  platformTenantCapable,
+  PLATFORM_TENANT_SCOPE,
+} from '../src/auth/tenant-scope';
+import { AdminDeriveController } from '../src/admin/admin-derive.controller';
+import { AdminHnswController } from '../src/admin/admin-hnsw.controller';
+import { AdminSegmentsController } from '../src/admin/admin-segments.controller';
+import { AdminAggregatesController } from '../src/admin/admin-aggregates.controller';
+import { StrategyAdminController } from '../src/strategy/strategy-admin.controller';
+import { AdminJobsController } from '../src/admin/admin-jobs.controller';
+
+const KNOWN = ['tenant-a', 'tenant-b'];
+const apiKeys = { knownCompanyIds: () => KNOWN } as never;
+const ADMIN: BrainScope[] = ['brain:admin'];
+const PLATFORM: BrainScope[] = ['brain:admin', PLATFORM_TENANT_SCOPE];
+
+function req(scopes: BrainScope[], companyId = 'tenant-a'): AuthenticatedRequest {
+  return { brainAuth: { companyId, scopes, keyHash: 'h' } } as unknown as AuthenticatedRequest;
+}
+
+function gateOn(): void {
+  process.env.BRAIN_TENANT_OVERRIDE_ENABLED = '1';
+}
+
+const OLD_GATE = process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+afterEach(() => {
+  if (OLD_GATE === undefined) delete process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+  else process.env.BRAIN_TENANT_OVERRIDE_ENABLED = OLD_GATE;
+});
+
+describe('resolvePlatformTenant — cross-tenant is default-deny (P0)', () => {
+  const opts = { knownTenants: () => KNOWN };
+
+  it('no tenant requested → own tenant', () => {
+    expect(resolvePlatformTenant(req(ADMIN), undefined, opts)).toBe('tenant-a');
+  });
+  it('own tenant echoed back → own tenant', () => {
+    expect(resolvePlatformTenant(req(ADMIN), 'tenant-a', opts)).toBe('tenant-a');
+  });
+  it('whitespace-only tenant → own tenant', () => {
+    expect(resolvePlatformTenant(req(ADMIN), '   ', opts)).toBe('tenant-a');
+  });
+  it('foreign tenant, plain brain:admin, gate off → 403', () => {
+    expect(() => resolvePlatformTenant(req(ADMIN), 'tenant-b', opts)).toThrow(ForbiddenException);
+  });
+  it('foreign tenant, platform scope, gate OFF → 403 (gate required)', () => {
+    expect(() => resolvePlatformTenant(req(PLATFORM), 'tenant-b', opts)).toThrow(
+      ForbiddenException,
+    );
+  });
+  it('foreign tenant, plain brain:admin, gate ON → 403 (scope required)', () => {
+    gateOn();
+    expect(() => resolvePlatformTenant(req(ADMIN), 'tenant-b', opts)).toThrow(ForbiddenException);
+  });
+  it('foreign KNOWN tenant, platform scope + gate ON → allowed', () => {
+    gateOn();
+    expect(resolvePlatformTenant(req(PLATFORM), 'tenant-b', opts)).toBe('tenant-b');
+  });
+  it('foreign UNKNOWN tenant, platform scope + gate ON → 400', () => {
+    gateOn();
+    expect(() => resolvePlatformTenant(req(PLATFORM), 'ghost', opts)).toThrow(BadRequestException);
+  });
+});
+
+describe('resolvePlatformTenantScope — aggregate reads default to own tenant (P0)', () => {
+  const opts = { knownTenants: () => KNOWN };
+
+  it('no tenant requested, plain brain:admin → own tenant only', () => {
+    expect(resolvePlatformTenantScope(req(ADMIN), undefined, opts)).toEqual(['tenant-a']);
+  });
+  it('no tenant requested, platform scope but gate OFF → own tenant only', () => {
+    expect(resolvePlatformTenantScope(req(PLATFORM), undefined, opts)).toEqual(['tenant-a']);
+  });
+  it('no tenant requested, platform scope + gate ON → all registered tenants', () => {
+    gateOn();
+    expect(resolvePlatformTenantScope(req(PLATFORM), undefined, opts)).toEqual(KNOWN);
+  });
+  it('own tenant requested → own tenant only', () => {
+    expect(resolvePlatformTenantScope(req(ADMIN), 'tenant-a', opts)).toEqual(['tenant-a']);
+  });
+  it('foreign tenant requested, plain brain:admin → 403', () => {
+    expect(() => resolvePlatformTenantScope(req(ADMIN), 'tenant-b', opts)).toThrow(
+      ForbiddenException,
+    );
+  });
+  it('foreign tenant requested, platform scope + gate ON → that tenant', () => {
+    gateOn();
+    expect(resolvePlatformTenantScope(req(PLATFORM), 'tenant-b', opts)).toEqual(['tenant-b']);
+  });
+});
+
+describe('platformTenantCapable', () => {
+  it('false when gate off (even with the scope)', () => {
+    expect(platformTenantCapable(PLATFORM)).toBe(false);
+  });
+  it('false when gate on but scope missing', () => {
+    gateOn();
+    expect(platformTenantCapable(ADMIN)).toBe(false);
+  });
+  it('true only with scope AND gate', () => {
+    gateOn();
+    expect(platformTenantCapable(PLATFORM)).toBe(true);
+  });
+});
+
+describe('AdminDeriveController — tenant isolation (P0)', () => {
+  function make() {
+    const seen: string[] = [];
+    const deriver = {
+      run: async (t: string) => {
+        seen.push(t);
+        return { status: 'ok', failed: 0, skipped: [] };
+      },
+      gc: async (t: string) => {
+        seen.push(t);
+        return { deleted: {}, kept: [] };
+      },
+    };
+    return { ctrl: new AdminDeriveController(deriver as never, apiKeys), seen };
+  }
+
+  it('brain:admin + foreign tenant → 403 (derive run)', async () => {
+    await expect(make().ctrl.run(req(ADMIN), { tenant: 'tenant-b' })).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+  it('brain:admin + foreign tenant → 403 (derive gc)', async () => {
+    await expect(make().ctrl.gc(req(ADMIN), { tenant: 'tenant-b' })).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+  it('own tenant (omitted) → operates on own', async () => {
+    const { ctrl, seen } = make();
+    await ctrl.run(req(ADMIN), {});
+    expect(seen).toEqual(['tenant-a']);
+  });
+  it('platform scope + gate → sanctioned cross-tenant reach', async () => {
+    gateOn();
+    const { ctrl, seen } = make();
+    await ctrl.run(req(PLATFORM), { tenant: 'tenant-b' });
+    expect(seen).toEqual(['tenant-b']);
+  });
+});
+
+describe('AdminHnswController — tenant isolation (P0)', () => {
+  function make() {
+    const seen: string[] = [];
+    const hnsw = {
+      apply: async (t: string) => {
+        seen.push(t);
+        return {};
+      },
+    };
+    return { ctrl: new AdminHnswController(hnsw as never, apiKeys), seen };
+  }
+
+  it('brain:admin + foreign tenant → 403', async () => {
+    await expect(
+      make().ctrl.apply(req(ADMIN), { action: 'create', tenant: 'tenant-b' }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+  it('own tenant → operates on own', async () => {
+    const { ctrl, seen } = make();
+    await ctrl.apply(req(ADMIN), { action: 'create' });
+    expect(seen).toEqual(['tenant-a']);
+  });
+  it('platform scope + gate → sanctioned cross-tenant reach', async () => {
+    gateOn();
+    const { ctrl, seen } = make();
+    await ctrl.apply(req(PLATFORM), { action: 'drop', tenant: 'tenant-b' });
+    expect(seen).toEqual(['tenant-b']);
+  });
+});
+
+describe('AdminSegmentsController — tenant isolation (P0)', () => {
+  function make() {
+    const seen: string[] = [];
+    const composer = {
+      run: async (t: string) => {
+        seen.push(t);
+        return {};
+      },
+    };
+    return { ctrl: new AdminSegmentsController(composer as never, apiKeys), seen };
+  }
+
+  it('brain:admin + foreign tenant → 403', async () => {
+    await expect(make().ctrl.run(req(ADMIN), { tenant: 'tenant-b' })).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+  it('own tenant → operates on own', async () => {
+    const { ctrl, seen } = make();
+    await ctrl.run(req(ADMIN), {});
+    expect(seen).toEqual(['tenant-a']);
+  });
+});
+
+describe('AdminAggregatesController — tenant isolation (P0)', () => {
+  function make() {
+    const seen: string[] = [];
+    const composer = {
+      run: async (t: string) => {
+        seen.push(t);
+        return {};
+      },
+    };
+    const arcs = {
+      run: async (t: string) => {
+        seen.push(t);
+        return {};
+      },
+    };
+    return { ctrl: new AdminAggregatesController(composer as never, arcs as never, apiKeys), seen };
+  }
+
+  it('brain:admin + foreign tenant → 403 (aggregates)', async () => {
+    await expect(make().ctrl.run(req(ADMIN), { tenant: 'tenant-b' })).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+  it('brain:admin + foreign tenant → 403 (arcs)', async () => {
+    await expect(make().ctrl.runArcs(req(ADMIN), { tenant: 'tenant-b' })).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+  it('own tenant → operates on own', async () => {
+    const { ctrl, seen } = make();
+    await ctrl.run(req(ADMIN), {});
+    expect(seen).toEqual(['tenant-a']);
+  });
+});
+
+describe('StrategyAdminController — tenant isolation (P0)', () => {
+  function make() {
+    const seen: string[] = [];
+    const strategies = {
+      isEnabled: () => true,
+      isTrajectoriesEnabled: () => true,
+      list: async (t: string) => {
+        seen.push(t);
+        return [];
+      },
+    };
+    const distiller = {
+      distillFromPostMortems: async (t: string) => {
+        seen.push(t);
+        return {};
+      },
+    };
+    return {
+      ctrl: new StrategyAdminController(strategies as never, distiller as never, apiKeys),
+      seen,
+    };
+  }
+
+  it('brain:admin + foreign tenant → 403 (list)', async () => {
+    await expect(make().ctrl.list(req(ADMIN), { tenant: 'tenant-b' })).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+  it('brain:admin + foreign tenant → 403 (distill, before body validation)', async () => {
+    await expect(make().ctrl.distill(req(ADMIN), { tenant: 'tenant-b' })).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+  it('own tenant → operates on own', async () => {
+    const { ctrl, seen } = make();
+    await ctrl.list(req(ADMIN), {});
+    expect(seen).toEqual(['tenant-a']);
+  });
+  it('platform scope + gate → sanctioned cross-tenant reach', async () => {
+    gateOn();
+    const { ctrl, seen } = make();
+    await ctrl.list(req(PLATFORM), { tenant: 'tenant-b' });
+    expect(seen).toEqual(['tenant-b']);
+  });
+});
+
+describe('AdminJobsController — tenant isolation (P0)', () => {
+  function make() {
+    const seen = {
+      compacted: [] as string[],
+      reindexHost: undefined as string | undefined,
+      tenantFilter: undefined as unknown,
+      emitTenants: [] as string[],
+    };
+    const jobs = {
+      start: async (o: { companyId: string; initialProgress: { tenantFilter: unknown } }) => {
+        seen.reindexHost = o.companyId;
+        seen.tenantFilter = o.initialProgress.tenantFilter;
+        return { runId: 'r1' };
+      },
+      finish: async () => {},
+    };
+    const dreams = {
+      emitsForRun: async (companyId: string) => {
+        seen.emitTenants.push(companyId);
+        return [];
+      },
+    };
+    const compaction = {
+      compactCompany: async (c: string) => {
+        seen.compacted.push(c);
+      },
+    };
+    const reindex = { run: async () => ({}) };
+    const scenarios = { list: () => [], runOne: async () => ({}) };
+    const u = undefined as never;
+    const ctrl = new AdminJobsController(
+      jobs as never, // 0 jobs
+      dreams as never, // 1 dreams
+      u, // 2 calibrationRefit
+      u, // 3 changefeed
+      u, // 4 scheduler
+      apiKeys, // 5 apiKeys
+      reindex as never, // 6 reindex
+      scenarios as never, // 7 scenarios
+      u, // 8 claim
+      u, // 9 leaderLease
+      u, // 10 workerLoop
+      u, // 11 workerPool
+      compaction as never, // 12 compaction
+      u, // 13 config
+    );
+    return { ctrl, seen };
+  }
+
+  it('compaction: brain:admin + foreign companyId → 403', () => {
+    expect(() => make().ctrl.triggerCompaction(req(ADMIN), { companyId: 'tenant-b' })).toThrow(
+      ForbiddenException,
+    );
+  });
+  it('compaction: plain brain:admin omitted → own tenant only (no all-tenant fan-out)', () => {
+    const r = make().ctrl.triggerCompaction(req(ADMIN), {});
+    expect(r.tenants).toEqual(['tenant-a']);
+  });
+  it('compaction: platform scope + gate omitted → fans out over all tenants', () => {
+    gateOn();
+    const r = make().ctrl.triggerCompaction(req(PLATFORM), {});
+    expect(r.tenants).toEqual(KNOWN);
+  });
+  it('compaction: platform scope + gate + foreign → that tenant', () => {
+    gateOn();
+    const r = make().ctrl.triggerCompaction(req(PLATFORM), { companyId: 'tenant-b' });
+    expect(r.tenants).toEqual(['tenant-b']);
+  });
+
+  it('reindex: brain:admin + foreign tenant → 403', async () => {
+    await expect(make().ctrl.triggerReindex(req(ADMIN), { tenant: 'tenant-b' })).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+  it('reindex: plain brain:admin omitted → own tenant only', async () => {
+    const { ctrl, seen } = make();
+    await ctrl.triggerReindex(req(ADMIN), {});
+    expect(seen.tenantFilter).toBe('tenant-a');
+    expect(seen.reindexHost).toBe('tenant-a');
+  });
+  it('reindex: platform scope + gate omitted → all tenants (no filter)', async () => {
+    gateOn();
+    const { ctrl, seen } = make();
+    await ctrl.triggerReindex(req(PLATFORM), {});
+    expect(seen.tenantFilter).toBeNull();
+  });
+
+  it('dreamEmits: brain:admin + foreign companyId → 403', async () => {
+    await expect(make().ctrl.dreamEmits(req(ADMIN), 'run-1', 'tenant-b')).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+  it('dreamEmits: plain brain:admin omitted → own tenant only', async () => {
+    const { ctrl, seen } = make();
+    await ctrl.dreamEmits(req(ADMIN), 'run-1');
+    expect(seen.emitTenants).toEqual(['tenant-a']);
+  });
+  it('dreamEmits: platform scope + gate omitted → scans all tenants', async () => {
+    gateOn();
+    const { ctrl, seen } = make();
+    await ctrl.dreamEmits(req(PLATFORM), 'run-1');
+    expect(seen.emitTenants).toEqual(KNOWN);
+  });
+
+  it('scenariosBatch: plain brain:admin books the job under its own tenant', async () => {
+    const { ctrl, seen } = make();
+    await ctrl.triggerScenariosBatch(req(ADMIN, 'tenant-b'), {});
+    expect(seen.reindexHost).toBe('tenant-b');
+  });
+  it('scenariosBatch: platform scope + gate hosts on the first tenant', async () => {
+    gateOn();
+    const { ctrl, seen } = make();
+    await ctrl.triggerScenariosBatch(req(PLATFORM, 'tenant-b'), {});
+    expect(seen.reindexHost).toBe(KNOWN[0]);
+  });
+});

--- a/test/contracts-admin-audit-page.unit-spec.ts
+++ b/test/contracts-admin-audit-page.unit-spec.ts
@@ -1,41 +1,54 @@
 /**
  * Wire-contract drift guard for GET /v1/admin/audit.
+ *
+ * Also pins that the handler threads the caller request into the service,
+ * where tenant scoping (own-only for a plain admin) is enforced.
  */
 import { AuditPageResponseSchema } from '../src/contracts/admin/audit-page.schema';
-import { makeAdminController } from './helpers/admin-controllers';
+import { makeAdminController, adminReq } from './helpers/admin-controllers';
 import type { AdminController } from '../src/admin/admin.controller';
 import type { AdminService } from '../src/admin/admin.service';
 
-function makeController(): AdminController {
+function makeController(seen?: { req?: unknown }): AdminController {
   const admin = {
-    listAuditEvents: async () => ({
-      events: [
-        {
-          id: 'audit:abc',
-          companyId: 'tenant-a',
-          source: 'knowledge_fact',
-          recordId: 'kf:xyz',
-          op: 'create',
-          ts: new Date().toISOString(),
-          versionstamp: 42,
-          before: null,
-          after: { value: 'x' },
-          consumedBy: 'pod-1',
-        },
-      ],
-      totalsBySource: { knowledge_fact: 1 },
-      totalsByOp: { create: 1 },
-      hourly: [{ hour: '2026-06-22T15', count: 1 }],
-    }),
+    listAuditEvents: async (_q: unknown, req: unknown) => {
+      if (seen) seen.req = req;
+      return {
+        events: [
+          {
+            id: 'audit:abc',
+            companyId: 'tenant-a',
+            source: 'knowledge_fact',
+            recordId: 'kf:xyz',
+            op: 'create',
+            ts: new Date().toISOString(),
+            versionstamp: 42,
+            before: null,
+            after: { value: 'x' },
+            consumedBy: 'pod-1',
+          },
+        ],
+        totalsBySource: { knowledge_fact: 1 },
+        totalsByOp: { create: 1 },
+        hourly: [{ hour: '2026-06-22T15', count: 1 }],
+      };
+    },
   } as unknown as AdminService;
   return makeAdminController({ admin });
 }
 
 describe('AdminController.audit() — wire contract', () => {
   it('matches AuditPageResponseSchema', async () => {
-    const parsed = AuditPageResponseSchema.safeParse(await makeController().audit());
+    const parsed = AuditPageResponseSchema.safeParse(await makeController().audit(adminReq()));
     if (!parsed.success) {
       throw new Error(`audit drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
     }
+  });
+
+  it('threads the caller request into the service (tenant scope enforced there)', async () => {
+    const seen: { req?: unknown } = {};
+    const r = adminReq();
+    await makeController(seen).audit(r);
+    expect(seen.req).toBe(r);
   });
 });

--- a/test/contracts-admin-changefeed-state.unit-spec.ts
+++ b/test/contracts-admin-changefeed-state.unit-spec.ts
@@ -13,7 +13,18 @@
  */
 import { ChangefeedStateResponseSchema } from '../src/contracts/admin/changefeed-state.schema';
 import { AdminJobsController } from '../src/admin/admin-jobs.controller';
+import { adminReq, PLATFORM_SCOPES } from './helpers/admin-controllers';
 import type { ChangefeedConsumerService } from '../src/audit/changefeed-consumer.service';
+import type { ApiKeyService } from '../src/auth/api-key.service';
+
+const KNOWN = ['tenant-a', 'tenant-b'];
+const apiKeys = { knownCompanyIds: () => KNOWN } as unknown as ApiKeyService;
+
+const OLD_GATE = process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+afterEach(() => {
+  if (OLD_GATE === undefined) delete process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+  else process.env.BRAIN_TENANT_OVERRIDE_ENABLED = OLD_GATE;
+});
 
 function makeChangefeed(): ChangefeedConsumerService {
   const SOURCES = ['attribution', 'fact_state'] as const;
@@ -44,7 +55,7 @@ function makeController(changefeed: ChangefeedConsumerService): AdminJobsControl
     undef,
     changefeed,
     undef,
-    undef,
+    apiKeys, // 5 apiKeys
     undef,
     undef,
     undef,
@@ -59,7 +70,9 @@ function makeController(changefeed: ChangefeedConsumerService): AdminJobsControl
 describe('AdminJobsController.changefeedState() — wire contract', () => {
   it('matches ChangefeedStateResponseSchema', async () => {
     const controller = makeController(makeChangefeed());
-    const payload = await controller.changefeedState();
+    // tenant-a caller: both mock cursors belong to tenant-a, so own-scoping
+    // keeps them.
+    const payload = await controller.changefeedState(adminReq(undefined, 'tenant-a'));
     const parsed = ChangefeedStateResponseSchema.safeParse(payload);
     if (!parsed.success) {
       throw new Error(
@@ -90,7 +103,25 @@ describe('AdminJobsController.changefeedState() — wire contract', () => {
       cursorState: async () => [],
     } as unknown as ChangefeedConsumerService;
     const controller = makeController(cold);
-    const parsed = ChangefeedStateResponseSchema.safeParse(await controller.changefeedState());
+    const parsed = ChangefeedStateResponseSchema.safeParse(
+      await controller.changefeedState(adminReq()),
+    );
     expect(parsed.success).toBe(true);
+  });
+});
+
+describe('AdminJobsController.changefeedState() — tenant isolation (P0)', () => {
+  it('plain brain:admin sees only its own tenant cursors', async () => {
+    const controller = makeController(makeChangefeed());
+    // caller is tenant-b; the mock cursors are all tenant-a → filtered out.
+    const payload = await controller.changefeedState(adminReq(undefined, 'tenant-b'));
+    expect(payload.cursors).toHaveLength(0);
+  });
+
+  it('platform scope + gate keeps the all-tenant cursor view', async () => {
+    process.env.BRAIN_TENANT_OVERRIDE_ENABLED = '1';
+    const controller = makeController(makeChangefeed());
+    const payload = await controller.changefeedState(adminReq(PLATFORM_SCOPES, 'tenant-b'));
+    expect(payload.cursors).toHaveLength(2);
   });
 });

--- a/test/contracts-admin-dlq.unit-spec.ts
+++ b/test/contracts-admin-dlq.unit-spec.ts
@@ -1,21 +1,28 @@
 /**
  * Wire-contract drift guard for GET /v1/admin/dlq.
+ *
+ * Also pins that the handler threads the caller request into the service,
+ * where tenant scoping (own-only for a plain admin) is enforced.
  */
 import { DlqResponseSchema } from '../src/contracts/admin/dlq.schema';
 import { AdminOpsController } from '../src/admin/admin-ops.controller';
+import { adminReq } from './helpers/admin-controllers';
 import type { AdminService } from '../src/admin/admin.service';
 
-function makeController(): AdminOpsController {
+function makeController(seen?: { req?: unknown }): AdminOpsController {
   const admin = {
-    listDeadLetter: async () => [
-      {
-        companyId: 'tenant-a',
-        id: 'dlq:1',
-        reason: 'predicate_unknown',
-        rejectedAt: new Date().toISOString(),
-        payload: { subject: 'e:x', predicate: 'unknown', object: 'e:y' },
-      },
-    ],
+    listDeadLetter: async (_filter: unknown, req: unknown) => {
+      if (seen) seen.req = req;
+      return [
+        {
+          companyId: 'tenant-a',
+          id: 'dlq:1',
+          reason: 'predicate_unknown',
+          rejectedAt: new Date().toISOString(),
+          payload: { subject: 'e:x', predicate: 'unknown', object: 'e:y' },
+        },
+      ];
+    },
   } as unknown as AdminService;
   const undef = undefined as unknown as never;
   return new AdminOpsController(admin, undef, undef);
@@ -23,9 +30,16 @@ function makeController(): AdminOpsController {
 
 describe('AdminOpsController.dlq() — wire contract', () => {
   it('matches DlqResponseSchema', async () => {
-    const parsed = DlqResponseSchema.safeParse(await makeController().dlq());
+    const parsed = DlqResponseSchema.safeParse(await makeController().dlq(adminReq()));
     if (!parsed.success) {
       throw new Error(`dlq drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
     }
+  });
+
+  it('threads the caller request into the service (tenant scope enforced there)', async () => {
+    const seen: { req?: unknown } = {};
+    const r = adminReq();
+    await makeController(seen).dlq(r);
+    expect(seen.req).toBe(r);
   });
 });

--- a/test/contracts-admin-dreams-summary.unit-spec.ts
+++ b/test/contracts-admin-dreams-summary.unit-spec.ts
@@ -1,9 +1,28 @@
 /**
  * Wire-contract drift guard for GET /v1/admin/dreams/summary.
+ *
+ * Also pins tenant isolation (P0): a plain brain:admin sees only its own
+ * tenant's dreams runs; a platform operator (brain:platform_admin + gate)
+ * keeps the all-tenant rollup.
  */
 import { DreamsSummaryResponseSchema } from '../src/contracts/admin/dreams-summary.schema';
 import { AdminJobsController } from '../src/admin/admin-jobs.controller';
 import type { JobRunService } from '../src/jobs/job-run.service';
+import type { AuthenticatedRequest, BrainScope } from '../src/auth/api-key.types';
+import { PLATFORM_TENANT_SCOPE } from '../src/auth/tenant-scope';
+
+const ADMIN: BrainScope[] = ['brain:admin'];
+const PLATFORM: BrainScope[] = ['brain:admin', PLATFORM_TENANT_SCOPE];
+
+function req(scopes: BrainScope[], companyId = 'tenant-a'): AuthenticatedRequest {
+  return { brainAuth: { companyId, scopes, keyHash: 'h' } } as unknown as AuthenticatedRequest;
+}
+
+const OLD_GATE = process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+afterEach(() => {
+  if (OLD_GATE === undefined) delete process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+  else process.env.BRAIN_TENANT_OVERRIDE_ENABLED = OLD_GATE;
+});
 
 function makeController(): AdminJobsController {
   const jobs = {
@@ -45,11 +64,61 @@ function makeController(): AdminJobsController {
   );
 }
 
+/** Controller whose jobs.list records the filter it was called with. */
+function capturingController() {
+  const seen: { hasCompanyId: boolean; companyId: string | undefined } = {
+    hasCompanyId: false,
+    companyId: undefined,
+  };
+  const jobs = {
+    list: async (f: { companyId?: string }) => {
+      seen.hasCompanyId = Object.prototype.hasOwnProperty.call(f, 'companyId');
+      seen.companyId = f.companyId;
+      return [];
+    },
+  } as unknown as JobRunService;
+  const undef = undefined as unknown as never;
+  const ctrl = new AdminJobsController(
+    jobs,
+    undef,
+    undef,
+    undef,
+    undef,
+    undef,
+    undef,
+    undef,
+    undef,
+    undef,
+    undef,
+    undef,
+    undef,
+    undef,
+  );
+  return { ctrl, seen };
+}
+
 describe('AdminJobsController.dreamsSummary() — wire contract', () => {
   it('matches DreamsSummaryResponseSchema', async () => {
-    const parsed = DreamsSummaryResponseSchema.safeParse(await makeController().dreamsSummary());
+    const parsed = DreamsSummaryResponseSchema.safeParse(
+      await makeController().dreamsSummary(req(ADMIN)),
+    );
     if (!parsed.success) {
       throw new Error(`dreams/summary drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
     }
+  });
+});
+
+describe('AdminJobsController.dreamsSummary() — tenant isolation (P0)', () => {
+  it('plain brain:admin → own tenant only', async () => {
+    const { ctrl, seen } = capturingController();
+    await ctrl.dreamsSummary(req(ADMIN));
+    expect(seen.companyId).toBe('tenant-a');
+  });
+
+  it('platform scope + gate → all tenants (no companyId filter)', async () => {
+    process.env.BRAIN_TENANT_OVERRIDE_ENABLED = '1';
+    const { ctrl, seen } = capturingController();
+    await ctrl.dreamsSummary(req(PLATFORM));
+    expect(seen.hasCompanyId).toBe(false);
   });
 });

--- a/test/contracts-admin-forgotten.unit-spec.ts
+++ b/test/contracts-admin-forgotten.unit-spec.ts
@@ -1,22 +1,29 @@
 /**
  * Wire-contract drift guard for GET /v1/admin/forgotten.
+ *
+ * Also pins that the handler threads the caller request into the service,
+ * where tenant scoping (own-only for a plain admin) is enforced.
  */
 import { ForgottenResponseSchema } from '../src/contracts/admin/forgotten.schema';
 import { AdminOpsController } from '../src/admin/admin-ops.controller';
+import { adminReq } from './helpers/admin-controllers';
 import type { AdminService } from '../src/admin/admin.service';
 
-function makeController(): AdminOpsController {
+function makeController(seen?: { req?: unknown }): AdminOpsController {
   const admin = {
-    listForgotten: async () => [
-      {
-        companyId: 'tenant-a',
-        entityIdHash: 'sha256:deadbeef',
-        reason: 'dsar:user-request',
-        forgottenAt: new Date().toISOString(),
-        factsDeleted: 12,
-        edgesDeleted: 3,
-      },
-    ],
+    listForgotten: async (_filter: unknown, req: unknown) => {
+      if (seen) seen.req = req;
+      return [
+        {
+          companyId: 'tenant-a',
+          entityIdHash: 'sha256:deadbeef',
+          reason: 'dsar:user-request',
+          forgottenAt: new Date().toISOString(),
+          factsDeleted: 12,
+          edgesDeleted: 3,
+        },
+      ];
+    },
   } as unknown as AdminService;
   const undef = undefined as unknown as never;
   return new AdminOpsController(admin, undef, undef);
@@ -24,9 +31,16 @@ function makeController(): AdminOpsController {
 
 describe('AdminOpsController.forgotten() — wire contract', () => {
   it('matches ForgottenResponseSchema', async () => {
-    const parsed = ForgottenResponseSchema.safeParse(await makeController().forgotten());
+    const parsed = ForgottenResponseSchema.safeParse(await makeController().forgotten(adminReq()));
     if (!parsed.success) {
       throw new Error(`forgotten drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
     }
+  });
+
+  it('threads the caller request into the service (tenant scope enforced there)', async () => {
+    const seen: { req?: unknown } = {};
+    const r = adminReq();
+    await makeController(seen).forgotten(r);
+    expect(seen.req).toBe(r);
   });
 });

--- a/test/contracts-admin-jobs.unit-spec.ts
+++ b/test/contracts-admin-jobs.unit-spec.ts
@@ -10,10 +10,33 @@
  * declared field changes type, this test breaks and the BFF 502s
  * in prod. The intent is to make adding-a-field-to-the-protocol an
  * explicit, two-side change.
+ *
+ * Also pins the tenant isolation of the companyId query (P0): a plain
+ * brain:admin can only ever list its own tenant's jobs; a foreign
+ * companyId is a 403 unless the caller holds brain:platform_admin AND
+ * BRAIN_TENANT_OVERRIDE_ENABLED is on.
  */
+import { ForbiddenException } from '@nestjs/common';
 import { JobsListResponseSchema } from '../src/contracts/admin/jobs.schema';
 import { AdminJobsController } from '../src/admin/admin-jobs.controller';
 import type { JobRunService } from '../src/jobs/job-run.service';
+import type { AuthenticatedRequest, BrainScope } from '../src/auth/api-key.types';
+import { PLATFORM_TENANT_SCOPE } from '../src/auth/tenant-scope';
+
+const KNOWN = ['tenant-a', 'tenant-b'];
+const apiKeys = { knownCompanyIds: () => KNOWN } as never;
+const ADMIN: BrainScope[] = ['brain:admin'];
+const PLATFORM: BrainScope[] = ['brain:admin', PLATFORM_TENANT_SCOPE];
+
+function req(scopes: BrainScope[], companyId = 'tenant-a'): AuthenticatedRequest {
+  return { brainAuth: { companyId, scopes, keyHash: 'h' } } as unknown as AuthenticatedRequest;
+}
+
+const OLD_GATE = process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+afterEach(() => {
+  if (OLD_GATE === undefined) delete process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+  else process.env.BRAIN_TENANT_OVERRIDE_ENABLED = OLD_GATE;
+});
 
 function makeJobs(): JobRunService {
   return {
@@ -61,27 +84,43 @@ function makeJobs(): JobRunService {
 function makeController(jobs: JobRunService): AdminJobsController {
   const undef = undefined as unknown as never;
   return new AdminJobsController(
-    jobs,
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
-    undef,
+    jobs, // 0 jobs
+    undef, // 1 dreams
+    undef, // 2 calibrationRefit
+    undef, // 3 changefeed
+    undef, // 4 scheduler
+    apiKeys, // 5 apiKeys
+    undef, // 6 reindex
+    undef, // 7 scenarios
+    undef, // 8 claim
+    undef, // 9 leaderLease
+    undef, // 10 workerLoop
+    undef, // 11 workerPool
+    undef, // 12 compaction
+    undef, // 13 config
   );
+}
+
+/** Jobs mock that captures the filter the controller passes to list(). */
+function capturingController() {
+  const seen: { hasCompanyId: boolean; companyId: string | undefined } = {
+    hasCompanyId: false,
+    companyId: undefined,
+  };
+  const jobs = {
+    list: async (f: { companyId?: string }) => {
+      seen.hasCompanyId = Object.prototype.hasOwnProperty.call(f, 'companyId');
+      seen.companyId = f.companyId;
+      return [];
+    },
+  } as unknown as JobRunService;
+  return { ctrl: makeController(jobs), seen };
 }
 
 describe('AdminJobsController.listJobs() — wire contract', () => {
   it('matches JobsListResponseSchema with mixed-status rows', async () => {
     const controller = makeController(makeJobs());
-    const payload = await controller.listJobs();
+    const payload = await controller.listJobs(req(ADMIN));
     const parsed = JobsListResponseSchema.safeParse(payload);
     if (!parsed.success) {
       throw new Error(
@@ -106,8 +145,43 @@ describe('AdminJobsController.listJobs() — wire contract', () => {
       list: async () => [],
     } as unknown as JobRunService;
     const controller = makeController(empty);
-    const parsed = JobsListResponseSchema.safeParse(await controller.listJobs());
+    const parsed = JobsListResponseSchema.safeParse(await controller.listJobs(req(ADMIN)));
     expect(parsed.success).toBe(true);
     if (parsed.success) expect(parsed.data.jobs).toHaveLength(0);
+  });
+});
+
+describe('AdminJobsController.listJobs() — tenant isolation (P0)', () => {
+  it('plain brain:admin, companyId omitted → own tenant only', async () => {
+    const { ctrl, seen } = capturingController();
+    await ctrl.listJobs(req(ADMIN));
+    expect(seen.companyId).toBe('tenant-a');
+  });
+
+  it('plain brain:admin, foreign companyId → 403', async () => {
+    const { ctrl } = capturingController();
+    await expect(
+      ctrl.listJobs(req(ADMIN), undefined, undefined, undefined, 'tenant-b'),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('platform scope + gate on, foreign companyId → allowed (that tenant)', async () => {
+    process.env.BRAIN_TENANT_OVERRIDE_ENABLED = '1';
+    const { ctrl, seen } = capturingController();
+    await ctrl.listJobs(req(PLATFORM), undefined, undefined, undefined, 'tenant-b');
+    expect(seen.companyId).toBe('tenant-b');
+  });
+
+  it('platform scope + gate on, companyId omitted → all tenants (no filter)', async () => {
+    process.env.BRAIN_TENANT_OVERRIDE_ENABLED = '1';
+    const { ctrl, seen } = capturingController();
+    await ctrl.listJobs(req(PLATFORM));
+    expect(seen.hasCompanyId).toBe(false);
+  });
+
+  it('own companyId echoed back is byte-identical to omitted (own tenant)', async () => {
+    const { ctrl, seen } = capturingController();
+    await ctrl.listJobs(req(ADMIN), undefined, undefined, undefined, 'tenant-a');
+    expect(seen.companyId).toBe('tenant-a');
   });
 });

--- a/test/contracts-admin-leases.unit-spec.ts
+++ b/test/contracts-admin-leases.unit-spec.ts
@@ -19,6 +19,21 @@ import type { JobClaimService } from '../src/jobs/job-claim.service';
 import type { LeaderLeaseService } from '../src/jobs/leader-lease.service';
 import type { WorkerLoopService } from '../src/jobs/worker-loop.service';
 import type { JobWorkerPool } from '../src/jobs/job-worker-pool.service';
+import type { AuthenticatedRequest, BrainScope } from '../src/auth/api-key.types';
+import { PLATFORM_TENANT_SCOPE } from '../src/auth/tenant-scope';
+
+const ADMIN: BrainScope[] = ['brain:admin'];
+const PLATFORM: BrainScope[] = ['brain:admin', PLATFORM_TENANT_SCOPE];
+
+function req(scopes: BrainScope[], companyId = 'tenant-a'): AuthenticatedRequest {
+  return { brainAuth: { companyId, scopes, keyHash: 'h' } } as unknown as AuthenticatedRequest;
+}
+
+const OLD_GATE = process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+afterEach(() => {
+  if (OLD_GATE === undefined) delete process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+  else process.env.BRAIN_TENANT_OVERRIDE_ENABLED = OLD_GATE;
+});
 
 function makeController(): AdminJobsController {
   const claim = {
@@ -90,7 +105,7 @@ function makeController(): AdminJobsController {
 describe('AdminJobsController.leases() — wire contract', () => {
   it('matches LeasesResponseSchema', async () => {
     const controller = makeController();
-    const payload = await controller.leases();
+    const payload = await controller.leases(req(ADMIN));
     const parsed = LeasesResponseSchema.safeParse(payload);
     if (!parsed.success) {
       throw new Error(
@@ -130,7 +145,7 @@ describe('AdminJobsController.leases() — wire contract', () => {
       undefined as never,
       { get: () => 'inline' } as unknown as ConfigService,
     );
-    const payload = await controller.leases();
+    const payload = await controller.leases(req(ADMIN));
     const parsed = LeasesResponseSchema.safeParse(payload);
     expect(parsed.success).toBe(true);
     if (parsed.success) {
@@ -138,5 +153,63 @@ describe('AdminJobsController.leases() — wire contract', () => {
       expect(parsed.data.activeClaims).toHaveLength(0);
       expect(parsed.data.queueMode).toBe('inline');
     }
+  });
+});
+
+/** Controller whose claim.listActiveClaims records the tenant scope it got. */
+function capturingController() {
+  const seen: { tenants: readonly string[] } = { tenants: [] };
+  const claim = {
+    identity: () => 'pod-1#42',
+    listActiveClaims: async (tenants: readonly string[]) => {
+      seen.tenants = tenants;
+      return [];
+    },
+  } as unknown as JobClaimService;
+  const leaderLease = { list: async () => [] } as unknown as LeaderLeaseService;
+  const workerLoop = {
+    leader: () => true,
+    registeredTypes: () => [],
+  } as unknown as WorkerLoopService;
+  const workerPool = {
+    enabled: () => false,
+    stats: () => ({ size: 0, idle: 0, busy: 0, waiters: 0 }),
+  } as unknown as JobWorkerPool;
+  const apiKeys = {
+    knownCompanyIds: () => ['tenant-a', 'tenant-b'],
+  } as unknown as ApiKeyService;
+  const config = { get: () => 'enqueue' } as unknown as ConfigService;
+  const undef = undefined as unknown as never;
+  const ctrl = new AdminJobsController(
+    undef,
+    undef,
+    undef,
+    undef,
+    undef,
+    apiKeys,
+    undef,
+    undef,
+    claim,
+    leaderLease,
+    workerLoop,
+    workerPool,
+    undef,
+    config,
+  );
+  return { ctrl, seen };
+}
+
+describe('AdminJobsController.leases() — tenant isolation (P0)', () => {
+  it('plain brain:admin → own tenant claims only', async () => {
+    const { ctrl, seen } = capturingController();
+    await ctrl.leases(req(ADMIN));
+    expect(seen.tenants).toEqual(['tenant-a']);
+  });
+
+  it('platform scope + gate → all-tenant claim scan', async () => {
+    process.env.BRAIN_TENANT_OVERRIDE_ENABLED = '1';
+    const { ctrl, seen } = capturingController();
+    await ctrl.leases(req(PLATFORM));
+    expect(seen.tenants).toEqual(['tenant-a', 'tenant-b']);
   });
 });

--- a/test/contracts-admin-migrations.unit-spec.ts
+++ b/test/contracts-admin-migrations.unit-spec.ts
@@ -1,8 +1,12 @@
 /**
  * Wire-contract drift guard for GET /v1/admin/migrations.
+ *
+ * Also pins tenant isolation (P0): a plain brain:admin audits only its own
+ * tenant's schema state (never enumerates the roster); a platform operator
+ * (brain:platform_admin + gate) keeps the cross-tenant drift audit.
  */
 import { MigrationsResponseSchema } from '../src/contracts/admin/migrations.schema';
-import { makeAdminInfraController } from './helpers/admin-controllers';
+import { makeAdminInfraController, adminReq, PLATFORM_SCOPES } from './helpers/admin-controllers';
 import type { AdminInfraController } from '../src/admin/admin-infra.controller';
 import { AdminInfraService } from '../src/admin/admin-infra.service';
 import type { SurrealService } from '../src/db/surreal.service';
@@ -27,17 +31,38 @@ function makeController(): AdminInfraController {
     },
   } as unknown as SurrealService;
   const apiKeys = {
-    knownCompanyIds: () => ['tenant-a'],
+    knownCompanyIds: () => ['tenant-a', 'tenant-b'],
   } as unknown as ApiKeyService;
   const adminInfra = new AdminInfraService(surreal, apiKeys);
   return makeAdminInfraController({ adminInfra });
 }
 
+const OLD_GATE = process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+afterEach(() => {
+  if (OLD_GATE === undefined) delete process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
+  else process.env.BRAIN_TENANT_OVERRIDE_ENABLED = OLD_GATE;
+});
+
 describe('AdminInfraController.migrations() — wire contract', () => {
   it('matches MigrationsResponseSchema', async () => {
-    const parsed = MigrationsResponseSchema.safeParse(await makeController().migrations());
+    const parsed = MigrationsResponseSchema.safeParse(
+      await makeController().migrations(adminReq()),
+    );
     if (!parsed.success) {
       throw new Error(`migrations drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
     }
+  });
+});
+
+describe('AdminInfraController.migrations() — tenant isolation (P0)', () => {
+  it('plain brain:admin → own tenant only (roster not enumerated)', async () => {
+    const res = await makeController().migrations(adminReq(undefined, 'tenant-a'));
+    expect(res.perTenant.map((t) => t.companyId)).toEqual(['tenant-a']);
+  });
+
+  it('platform scope + gate → cross-tenant drift audit', async () => {
+    process.env.BRAIN_TENANT_OVERRIDE_ENABLED = '1';
+    const res = await makeController().migrations(adminReq(PLATFORM_SCOPES, 'tenant-a'));
+    expect(res.perTenant.map((t) => t.companyId)).toEqual(['tenant-a', 'tenant-b']);
   });
 });

--- a/test/contracts-admin-overview.unit-spec.ts
+++ b/test/contracts-admin-overview.unit-spec.ts
@@ -1,49 +1,62 @@
 /**
  * Wire-contract drift guard for GET /v1/admin/overview.
  * See contracts-admin-leases for the broader rationale.
+ *
+ * Also pins that the handler threads the caller request into the service,
+ * where tenant scoping (own-only for a plain admin) is enforced.
  */
 import { OverviewResponseSchema } from '../src/contracts/admin/overview.schema';
-import { makeAdminController } from './helpers/admin-controllers';
+import { makeAdminController, adminReq } from './helpers/admin-controllers';
 import type { AdminController } from '../src/admin/admin.controller';
 import type { AdminService } from '../src/admin/admin.service';
 
-function makeController(): AdminController {
+function makeController(seen?: { req?: unknown }): AdminController {
   const admin = {
-    buildOverview: async () => ({
-      generatedAt: new Date().toISOString(),
-      health: { surrealdb: 'ok' as const },
-      totals: {
-        tenants: 2,
-        entities: 100,
-        factsActive: 1234,
-        factsRetracted: 5,
-        deadLetterLast24h: 1,
-        forgottenLast24h: 0,
-      },
-      metrics: {
-        ingestFactsTotal: 9000,
-        ingestFactsByOutcome: { accepted: 9000 },
-        searchCallsTotal: 42,
-        dreamsRunsTotal: 7,
-        dreamsEmittedByKind: { identity_link: 3 },
-        retractsTotal: 0,
-        forgetsTotal: 0,
-        openaiCallsTotal: 0,
-        openaiTokensTotal: 0,
-      },
-      tenants: [{ companyId: 'tenant-a', entities: 50, factsActive: 600, factsRetracted: 5 }],
-      recentDeadLetter: [],
-      recentForgotten: [],
-    }),
+    buildOverview: async (req: unknown) => {
+      if (seen) seen.req = req;
+      return {
+        generatedAt: new Date().toISOString(),
+        health: { surrealdb: 'ok' as const },
+        totals: {
+          tenants: 2,
+          entities: 100,
+          factsActive: 1234,
+          factsRetracted: 5,
+          deadLetterLast24h: 1,
+          forgottenLast24h: 0,
+        },
+        metrics: {
+          ingestFactsTotal: 9000,
+          ingestFactsByOutcome: { accepted: 9000 },
+          searchCallsTotal: 42,
+          dreamsRunsTotal: 7,
+          dreamsEmittedByKind: { identity_link: 3 },
+          retractsTotal: 0,
+          forgetsTotal: 0,
+          openaiCallsTotal: 0,
+          openaiTokensTotal: 0,
+        },
+        tenants: [{ companyId: 'tenant-a', entities: 50, factsActive: 600, factsRetracted: 5 }],
+        recentDeadLetter: [],
+        recentForgotten: [],
+      };
+    },
   } as unknown as AdminService;
   return makeAdminController({ admin });
 }
 
 describe('AdminController.overview() — wire contract', () => {
   it('matches OverviewResponseSchema', async () => {
-    const parsed = OverviewResponseSchema.safeParse(await makeController().overview());
+    const parsed = OverviewResponseSchema.safeParse(await makeController().overview(adminReq()));
     if (!parsed.success) {
       throw new Error(`overview drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
     }
+  });
+
+  it('threads the caller request into the service (tenant scope enforced there)', async () => {
+    const seen: { req?: unknown } = {};
+    const r = adminReq();
+    await makeController(seen).overview(r);
+    expect(seen.req).toBe(r);
   });
 });

--- a/test/contracts-admin-pii.unit-spec.ts
+++ b/test/contracts-admin-pii.unit-spec.ts
@@ -1,22 +1,29 @@
 /**
  * Wire-contract drift guard for GET /v1/admin/pii.
+ *
+ * Also pins that the handler threads the caller request into the service,
+ * where tenant scoping (own-only for a plain admin) is enforced.
  */
 import { PiiInventoryResponseSchema } from '../src/contracts/admin/pii.schema';
 import { AdminOpsController } from '../src/admin/admin-ops.controller';
+import { adminReq } from './helpers/admin-controllers';
 import type { AdminService } from '../src/admin/admin.service';
 
-function makeController(): AdminOpsController {
+function makeController(seen?: { req?: unknown }): AdminOpsController {
   const admin = {
-    listPiiInventory: async () => [
-      {
-        companyId: 'tenant-a',
-        predicate: 'has_email',
-        piiClass: 'identifier',
-        requiresScope: 'brain:read_pii',
-        factCount: 42,
-        retractedCount: 0,
-      },
-    ],
+    listPiiInventory: async (req: unknown) => {
+      if (seen) seen.req = req;
+      return [
+        {
+          companyId: 'tenant-a',
+          predicate: 'has_email',
+          piiClass: 'identifier',
+          requiresScope: 'brain:read_pii',
+          factCount: 42,
+          retractedCount: 0,
+        },
+      ];
+    },
   } as unknown as AdminService;
   const undef = undefined as unknown as never;
   return new AdminOpsController(admin, undef, undef);
@@ -24,9 +31,18 @@ function makeController(): AdminOpsController {
 
 describe('AdminOpsController.piiInventory() — wire contract', () => {
   it('matches PiiInventoryResponseSchema', async () => {
-    const parsed = PiiInventoryResponseSchema.safeParse(await makeController().piiInventory());
+    const parsed = PiiInventoryResponseSchema.safeParse(
+      await makeController().piiInventory(adminReq()),
+    );
     if (!parsed.success) {
       throw new Error(`pii drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
     }
+  });
+
+  it('threads the caller request into the service (tenant scope enforced there)', async () => {
+    const seen: { req?: unknown } = {};
+    const r = adminReq();
+    await makeController(seen).piiInventory(r);
+    expect(seen.req).toBe(r);
   });
 });

--- a/test/helpers/admin-controllers.ts
+++ b/test/helpers/admin-controllers.ts
@@ -12,9 +12,26 @@
  */
 import { AdminController } from '../../src/admin/admin.controller';
 import { AdminInfraController } from '../../src/admin/admin-infra.controller';
+import type { AuthenticatedRequest, BrainScope } from '../../src/auth/api-key.types';
+import { PLATFORM_TENANT_SCOPE } from '../../src/auth/tenant-scope';
 
 const u = undefined as never;
 const as = <T>(v: unknown): T => v as T;
+
+export const ADMIN_SCOPES: BrainScope[] = ['brain:admin'];
+export const PLATFORM_SCOPES: BrainScope[] = ['brain:admin', PLATFORM_TENANT_SCOPE];
+
+/**
+ * A mock authenticated request for admin-controller unit specs. Defaults
+ * to a plain brain:admin key on tenant-a; pass PLATFORM_SCOPES (and turn
+ * BRAIN_TENANT_OVERRIDE_ENABLED on) to exercise the platform-operator path.
+ */
+export function adminReq(
+  scopes: BrainScope[] = ADMIN_SCOPES,
+  companyId = 'tenant-a',
+): AuthenticatedRequest {
+  return { brainAuth: { companyId, scopes, keyHash: 'h' } } as unknown as AuthenticatedRequest;
+}
 
 export interface AdminControllerDeps {
   admin?: unknown;

--- a/test/stats-views.e2e-spec.ts
+++ b/test/stats-views.e2e-spec.ts
@@ -197,7 +197,9 @@ describe('stats views (migration 0088, real SurrealDB)', () => {
   it('admin fan-out reads the same counters from the views', async () => {
     process.env.STATS_VIEWS_ENABLED = '1';
     const live = await liveCounts();
-    const overview = await f.app.get(AdminService).buildOverview();
+    const overview = await f.app.get(AdminService).buildOverview({
+      brainAuth: { companyId: f.companyId, scopes: ['brain:admin'], keyHash: 'h' },
+    } as never);
     const row = overview.tenants.find((t) => t.companyId === f.companyId);
     expect(row).toEqual({
       companyId: f.companyId,


### PR DESCRIPTION
## R3 audit — P0: admin cross-tenant bypass (multi-tenant blocker)

**The auditor's finding:** every admin controller resolved the target tenant from the request body/query and accepted **any** registered tenant. A `brain:admin` key scoped to tenant A could pass `tenant=B` and run privileged ops (derive/GC, drop HNSW, mutate strategies, compaction, reindex) on tenant B — the `knownCompanyIds()`-only checks rejected *unknown* tenants but silently honoured any *other* known one. This is the stated **multi-tenant NO-GO**.

## Fix: centralize tenant resolution
`src/auth/tenant-scope.ts` — the company-level analogue of `pinUserScope`:
- `resolvePlatformTenant(req, requested, opts)` — single-tenant **writes**: own/omitted → own (byte-identical); a different tenant → **403** unless platform-capable, then unknown → 400.
- `resolvePlatformTenantScope(req, requested, opts)` — **read** fan-out set: plain admin → `[own]`; platform → all registered; a caller-supplied tenant narrows through `resolvePlatformTenant`.
- `platformTenantCapable(scopes)` — the shared predicate: **both** the new `brain:platform_admin` scope AND `BRAIN_TENANT_OVERRIDE_ENABLED` (default off) required; either missing → confined to own tenant.

New scope `brain:platform_admin` (`api-key.types.ts`) is env-key-only like `registry:curate`, deliberately **not** in the jwks `VALID_SCOPES` set (never mintable via the token path). The guard's `X-Brain-Tenant` header override now requires that same platform scope (was `brain:admin`), so the platform path is the one and only way across tenants, enforced centrally.

## Scope: the whole request-driven cross-tenant admin surface
The auditor named 3 controllers (derive/hnsw/strategy). A full sweep of every HTTP-reachable `knownCompanyIds()` path found the entire admin cockpit fanned out by design; all closed here so a plain admin never observes another tenant's data or activity:
- **Writes** (foreign → 403): admin-derive (run+gc), admin-hnsw, admin-segments, admin-aggregates, strategy-admin (distill/trajectory/list/patch), admin-jobs (compaction/reindex/scenarios-batch).
- **Reads** (plain admin → own only; platform keeps the all-tenant view): admin-jobs listJobs / dreamEmits / dreamsSummary / leases (active-claim scan) / changefeed-state; admin.controller overview / audit; admin-ops dlq / forgotten / forgotten-export (GDPR manifest) / pii-inventory / operator-actions; admin-infra migrations.

**Deliberately left (correct, not leaks):** cluster/process state with no tenant dimension — `leaderLease.list()`, pod identity, worker-loop/pool stats, process-wide changefeed counters, throttler snapshots, Prometheus/registry/cron views. Background cron/queue/worker `knownCompanyIds()` iterations are unchanged (not HTTP-reachable). The sweep enumerated all 40+ call sites; nothing request-driven remains.

## Behavior
Own-tenant behavior is **byte-identical**; in single-tenant (companyId == the only tenant) every path is unchanged. Cross-tenant is reachable **only** via `brain:platform_admin` + `BRAIN_TENANT_OVERRIDE_ENABLED` — the operator dashboard's existing path once it holds the platform key.

## Verification (exit codes)
- `pnpm typecheck` → 0 · `eslint --max-warnings 0` → 0 · `prettier --check` → 0
- Admin contract/unit + `admin-tenant-isolation` (403 foreign / own-only omitted / platform-scans-all per endpoint + helper semantics) → 33 suites / 126 tests
- FULL unit suite → 273 suites / 2501 tests pass
- Docker e2e `stats-views` (buildOverview over real Surreal) → 12 tests
- No paid evals.

Closes the R3 multi-tenant blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
