### PR TITLE
fix(strategy): active strategies immutable to trajectory capture — candidate revision + unverified evidence ref (R3 P1)

### DIFF
--- a/src/db/migrations/0099_strategy_revision.surql
+++ b/src/db/migrations/0099_strategy_revision.surql
@@ -1,0 +1,33 @@
+-- 0099: strategy_memory candidate-revision pointer + caller-asserted
+-- evidence label — the R3 P1 hardening of G4's capture path (bet #3).
+--
+-- WHY. A distill/trajectory-capture merge (strategy-distill.service.ts
+-- dedupMerge) that targeted an already-serving `active` row used to mutate
+-- it IN PLACE (mergeUpdate never sets `status`), silently changing what
+-- retrieve() serves and bypassing candidate→active review. The fix makes
+-- active rows IMMUTABLE to capture: a merge onto an active row instead
+-- proposes a NEW `candidate` revision that carries the merged content +
+-- experience and points at the active row it supersedes. The active row
+-- stays byte-identical until a human promotes the revision (updateStatus).
+--
+-- ADDITIVE + OPTIONAL by construction (the 0098 posture): every column is
+-- option<...>, so existing rows are unaffected and NO backfill is needed.
+-- A write that omits these fields stores nothing for them. The whole
+-- capture path is gated OFF by STRATEGY_MEMORY_ENABLED at the service
+-- layer — master off ⇒ these columns are never written and never selected,
+-- so serving is byte-identical to pre-0099.
+
+-- The active strategy_memory row this candidate revision proposes to
+-- replace. Stored as the opaque `strategy_memory:<id>` string (the same
+-- shape strategyId already carries end to end — mapStrategyRow does
+-- String(id), idTail parses the string), mirroring 0098's outcomeEvidenceRef
+-- opaque-pointer idiom. Present only on revision candidates; NONE otherwise.
+DEFINE FIELD IF NOT EXISTS supersedesId ON strategy_memory TYPE option<string>;
+
+-- Explicit label that a stored outcomeEvidenceRef (0098) is CALLER-ASSERTED
+-- and UNVERIFIED: there is no tenant evidence table to resolve the opaque
+-- ref against, so it is persisted stamped `false`. The trajectory (and its
+-- ref) is ADVICE, never evidence — it reaches the generator advisory only,
+-- never the verifier bundle or citations (the G4 verifier-parity exception).
+-- This flag makes the "not proof" posture explicit at the row level.
+DEFINE FIELD IF NOT EXISTS outcomeEvidenceVerified ON strategy_memory TYPE option<bool>;

--- a/src/strategy/strategy-distill.service.ts
+++ b/src/strategy/strategy-distill.service.ts
@@ -55,6 +55,13 @@ export interface DistillStats {
   proposed: number;
   added: number;
   updated: number;
+  /**
+   * A merge whose target was an already-serving `active` row: instead of
+   * mutating it in place, a NEW candidate revision was proposed (R3 P1).
+   * The active row is left byte-identical until a human promotes the
+   * revision. Distinct from `updated` (in-place merge of a candidate).
+   */
+  revised: number;
   noop: number;
 }
 
@@ -77,6 +84,12 @@ export interface TrajectoryCaptureStats {
   proposed: number;
   added: number;
   updated: number;
+  /**
+   * The captured trajectory's merge targeted an already-serving `active`
+   * row: a NEW candidate revision was proposed rather than mutating the
+   * live row (R3 P1). The active row stays byte-identical until promotion.
+   */
+  revised: number;
   noop: number;
 }
 
@@ -238,6 +251,7 @@ export class StrategyDistillService {
       proposed: 0,
       added: 0,
       updated: 0,
+      revised: 0,
       noop: 0,
     };
     if (postMortems.length === 0) return stats;
@@ -256,7 +270,8 @@ export class StrategyDistillService {
     }
     this.logger.log(
       `[strategy.distill] companyId=${companyId} postMortems=${stats.postMortems} ` +
-        `proposed=${stats.proposed} added=${stats.added} updated=${stats.updated} noop=${stats.noop}`,
+        `proposed=${stats.proposed} added=${stats.added} updated=${stats.updated} ` +
+        `revised=${stats.revised} noop=${stats.noop}`,
     );
     return stats;
   }
@@ -290,6 +305,7 @@ export class StrategyDistillService {
       proposed: 0,
       added: 0,
       updated: 0,
+      revised: 0,
       noop: 0,
     };
     // Defensive gate: never write trajectory columns when the flag is off
@@ -316,7 +332,7 @@ export class StrategyDistillService {
     this.logger.log(
       `[strategy.trajectory] companyId=${companyId} steps=${stats.steps} ` +
         `proposed=${stats.proposed} added=${stats.added} updated=${stats.updated} ` +
-        `noop=${stats.noop} outcome=${run.outcome}`,
+        `revised=${stats.revised} noop=${stats.noop} outcome=${run.outcome}`,
     );
     return stats;
   }
@@ -464,7 +480,7 @@ export class StrategyDistillService {
     companyId: string,
     item: DistilledItemShape,
     ctx: { evidence: StrategyEvidence; bundle?: TrajectoryBundle | undefined },
-  ): Promise<'added' | 'updated' | 'noop'> {
+  ): Promise<'added' | 'updated' | 'revised' | 'noop'> {
     const neighbors = await this.strategies.findSimilar(
       companyId,
       `${item.title}\n${item.situation}`,
@@ -476,6 +492,16 @@ export class StrategyDistillService {
         : await this.decideMerge(item, neighbors);
     if (decision.action === 'UPDATE' && decision.targetId) {
       const target = neighbors.find((n) => n.strategyId === decision.targetId);
+      // R3 P1 — active rows are IMMUTABLE to capture. A merge that targets an
+      // already-SERVING (`active`) row must NOT mutate it in place: that
+      // would silently change what retrieve() serves, bypassing candidate→
+      // active review. Propose a candidate REVISION instead and leave the
+      // active row byte-identical (a human promotes it via updateStatus).
+      if (target?.status === 'active') {
+        return this.reviseActive(companyId, { item, target, decision, ctx });
+      }
+      // Candidate target (the review buffer, not served): in-place merge is
+      // fine — that is exactly what candidates are for.
       await this.strategies.mergeUpdate(companyId, decision.targetId, {
         strategy: decision.strategy,
         situation: decision.situation,
@@ -489,6 +515,47 @@ export class StrategyDistillService {
       return 'added';
     }
     return 'noop';
+  }
+
+  /**
+   * Active-immutability arm (R3 P1): the merge target is an already-serving
+   * `active` row, so instead of mutating it we create a NEW `candidate`
+   * revision carrying the merged content + the experience bundle, pointing
+   * at the active row it supersedes (supersedesId). The active row is left
+   * untouched until a human promotes the revision (which then deprecates the
+   * superseded active row). A unique-title collision — a revision already
+   * pending, or an exact twin — degrades to NOOP rather than mutating the
+   * active row (the ADD-arm collision idiom).
+   */
+  private async reviseActive(
+    companyId: string,
+    args: {
+      item: DistilledItemShape;
+      target: ScoredStrategyItem;
+      decision: MergeDecision;
+      ctx: { evidence: StrategyEvidence; bundle?: TrajectoryBundle | undefined };
+    },
+  ): Promise<'revised' | 'noop'> {
+    const { item, target, decision, ctx } = args;
+    try {
+      await this.strategies.create(companyId, {
+        title: item.title,
+        situation: decision.situation ?? item.situation,
+        strategy: decision.strategy ?? item.strategy,
+        polarity: item.polarity,
+        status: 'candidate',
+        evidence: mergeEvidence(target.evidence ?? {}, ctx.evidence),
+        supersedesId: target.strategyId,
+        ...bundleFields(ctx.bundle),
+      });
+      return 'revised';
+    } catch (e) {
+      this.logger.warn(
+        `strategy revision skipped (title '${item.title}' supersedes ${target.strategyId}): ` +
+          `${(e as Error).message}`,
+      );
+      return 'noop';
+    }
   }
 
   /** ADD arm; a unique-title collision degrades to NOOP (exact twin). */

--- a/src/strategy/strategy-memory.service.ts
+++ b/src/strategy/strategy-memory.service.ts
@@ -71,6 +71,20 @@ export interface StrategyItem {
   trajectory?: ToolStep[] | undefined;
   verifiedOutcome?: VerifiedOutcome | undefined;
   outcomeEvidenceRef?: string | undefined;
+  /**
+   * Whether the outcomeEvidenceRef was resolved/verified. It is an opaque
+   * caller-asserted pointer with no tenant table to resolve against, so
+   * capture persists it stamped `false` (0099): the ref is a CLAIM, never
+   * proof. Absent on items that carry no ref.
+   */
+  outcomeEvidenceVerified?: boolean | undefined;
+  /**
+   * Revision provenance (0099): when this item is a candidate proposed to
+   * replace an already-serving `active` row (the capture path never mutates
+   * an active row in place), this points at the superseded active row's id.
+   * Absent on ordinary candidates/actives.
+   */
+  supersedesId?: string | undefined;
 }
 
 export interface ScoredStrategyItem extends StrategyItem {
@@ -93,6 +107,13 @@ export interface CreateStrategyArgs {
   trajectory?: ToolStep[] | undefined;
   verifiedOutcome?: VerifiedOutcome | undefined;
   outcomeEvidenceRef?: string | undefined;
+  /**
+   * Revision provenance (0099): set when this item is a candidate proposed
+   * to supersede an already-serving `active` row — capture proposes a
+   * revision rather than mutating the live row in place. The active row it
+   * points at is left byte-identical until a human promotes the revision.
+   */
+  supersedesId?: string | undefined;
 }
 
 /** Retrieval k is hard-capped: k=1 default, 2 absolute max (G4). */
@@ -158,20 +179,27 @@ interface RawStrategyRow {
   scope?: string;
   createdAt?: unknown;
   updatedAt?: unknown;
+  // 0099 revision pointer — selected always (revision is master-gated, not
+  // trajectory-gated: the post-mortem distill path can propose one too).
+  supersedesId?: unknown;
   // 0098 columns — selected ONLY when the trajectories flag is on
   // (TRAJECTORY_ROW_FIELDS), so on the off path they are always absent
   // and the mapper leaves the item byte-identical to pre-0098.
   trajectory?: unknown;
   verifiedOutcome?: unknown;
   outcomeEvidenceRef?: unknown;
+  // 0099 caller-asserted-evidence label — trajectory-gated (written only
+  // alongside outcomeEvidenceRef), so on the off path it is always absent.
+  outcomeEvidenceVerified?: unknown;
 }
 
 const STRATEGY_ROW_FIELDS =
   'id, companyId, title, situation, strategy, polarity, status, ' +
-  'evidence, scope, createdAt, updatedAt';
+  'evidence, scope, createdAt, updatedAt, supersedesId';
 
-/** 0098 additive columns, appended to the SELECT only when serving trajectories. */
-const TRAJECTORY_ROW_FIELDS = 'trajectory, verifiedOutcome, outcomeEvidenceRef';
+/** 0098/0099 additive columns, appended to the SELECT only when serving trajectories. */
+const TRAJECTORY_ROW_FIELDS =
+  'trajectory, verifiedOutcome, outcomeEvidenceRef, outcomeEvidenceVerified';
 
 @Injectable()
 export class StrategyMemoryService {
@@ -250,6 +278,12 @@ export class StrategyMemoryService {
     if (fields.outcomeEvidenceRef !== undefined) {
       cols.push('outcomeEvidenceRef');
       params.outcomeEvidenceRef = fields.outcomeEvidenceRef;
+      // 0099: the ref is an opaque CALLER-ASSERTED pointer with no tenant
+      // table to resolve against — persist it explicitly stamped unverified
+      // so nothing downstream can mistake the claim for proof. Co-written
+      // with the ref (never without one), so it inherits the same gate.
+      cols.push('outcomeEvidenceVerified');
+      params.outcomeEvidenceVerified = false;
     }
     return {
       content: cols.map((c) => `,\n            ${c}: $${c}`).join(''),
@@ -270,6 +304,11 @@ export class StrategyMemoryService {
       // rather than passing null, so the option<string> ASSERT is never
       // handed a NULL it would reject.)
       const traj = this.trajectoryWriteFragment(args);
+      // 0099 revision pointer: master-gated (NOT trajectory-gated), included
+      // only when a supersedesId was supplied — a revision candidate points
+      // at the active row it proposes to replace. Absent otherwise ⇒ the
+      // CONTENT is byte-identical to a non-revision create.
+      const revisionContent = args.supersedesId ? ',\n            supersedesId: $supersedesId' : '';
       const [row] = await db.query<RawStrategyRow[]>(
         `CREATE ONLY strategy_memory CONTENT {
             companyId: $companyId,
@@ -282,7 +321,7 @@ export class StrategyMemoryService {
             embedding: $embedding,
             scope: $scope,
             createdAt: time::now(),
-            updatedAt: time::now()${traj.content}
+            updatedAt: time::now()${revisionContent}${traj.content}
          }`,
         {
           companyId,
@@ -294,6 +333,7 @@ export class StrategyMemoryService {
           evidence: args.evidence ?? {},
           embedding,
           scope: args.scope ?? 'tenant',
+          ...(args.supersedesId ? { supersedesId: args.supersedesId } : {}),
           ...traj.params,
         },
       );
@@ -348,7 +388,32 @@ export class StrategyMemoryService {
       if (!updated) {
         throw new NotFoundException(`Strategy ${strategyIdRaw} not found`);
       }
-      return mapStrategyRow(updated);
+      const item = mapStrategyRow(updated);
+      // 0099 promotion-deprecation: promoting a REVISION candidate (one that
+      // carries a supersedesId) to active deprecates the old active row it
+      // supersedes, so two actives never serve the same slot. Scoped by
+      // companyId and guarded on `status = 'active'` — idempotent, and it
+      // never demotes a row an operator has since re-activated for another
+      // reason. Best-effort: a failure here does not fail the promotion.
+      if (status === 'active' && item.supersedesId) {
+        try {
+          await db.query(
+            `UPDATE type::record('strategy_memory', $supTail)
+               SET status = 'deprecated', updatedAt = time::now()
+               WHERE companyId = $companyId AND status = 'active'`,
+            { supTail: idTail(item.supersedesId), companyId },
+          );
+          this.logger.log(
+            `[strategy.superseded] companyId=${companyId} promoted=${String(updated.id)} ` +
+              `deprecated=${item.supersedesId}`,
+          );
+        } catch (e) {
+          this.logger.warn(
+            `superseded-deprecate ${item.supersedesId} failed: ${(e as Error).message}`,
+          );
+        }
+      }
+      return item;
     });
   }
 
@@ -536,6 +601,16 @@ function mapStrategyRow(r: RawStrategyRow): StrategyItem {
   if (isVerifiedOutcome(r.verifiedOutcome)) item.verifiedOutcome = r.verifiedOutcome;
   if (typeof r.outcomeEvidenceRef === 'string' && r.outcomeEvidenceRef) {
     item.outcomeEvidenceRef = r.outcomeEvidenceRef;
+  }
+  // 0099: caller-asserted-evidence label — only present when a ref was
+  // stored (co-written), so the field pins the ref as an unverified claim.
+  if (typeof r.outcomeEvidenceVerified === 'boolean') {
+    item.outcomeEvidenceVerified = r.outcomeEvidenceVerified;
+  }
+  // 0099: revision pointer — present only on a candidate that supersedes an
+  // active row; absent (NONE → undefined) on ordinary items.
+  if (typeof r.supersedesId === 'string' && r.supersedesId) {
+    item.supersedesId = r.supersedesId;
   }
   return item;
 }

--- a/test/strategy-revision.unit-spec.ts
+++ b/test/strategy-revision.unit-spec.ts
@@ -1,0 +1,213 @@
+/**
+ * R3 P1 — active strategies are IMMUTABLE to distill/trajectory capture.
+ *
+ * The dedup-merge UPDATE arm used to call mergeUpdate() on WHATEVER row the
+ * arbiter chose — including an already-serving `active` row — silently
+ * changing what retrieve() serves and bypassing candidate→active review.
+ * The fix: an `active` merge target is NEVER mutated in place; a new
+ * `candidate` revision is proposed instead (carrying the merged content +
+ * the experience bundle + a supersedesId pointer at the row it supersedes).
+ * A `candidate` target (the review buffer, not served) still merges in place.
+ *
+ * This suite drives StrategyDistillService.distillFromTrajectory through a
+ * STUBBED StrategyMemoryService so the merge target's status is controlled
+ * exactly. (The real stub embedder's near-orthogonal vectors make the live
+ * floor-0 neighbor lookup non-deterministic — the wrong harness for this
+ * branch; the service-level DB guarantees are pinned in the e2e instead.)
+ */
+import { ConfigService } from '@nestjs/config';
+import {
+  StrategyDistillService,
+  type TrajectoryRun,
+} from '../src/strategy/strategy-distill.service';
+import type {
+  CreateStrategyArgs,
+  ScoredStrategyItem,
+  StrategyItem,
+  StrategyMemoryService,
+} from '../src/strategy/strategy-memory.service';
+import type { ApiKeyService } from '../src/auth/api-key.service';
+
+interface MergeCall {
+  id: string;
+  patch: Record<string, unknown>;
+}
+
+/** Stub store: findSimilar returns a scripted neighbor set; create/mergeUpdate record calls. */
+function fakeStrategies(neighbors: ScoredStrategyItem[]) {
+  const createCalls: CreateStrategyArgs[] = [];
+  const mergeCalls: MergeCall[] = [];
+  const svc = {
+    isTrajectoriesEnabled: () => true,
+    findSimilar: async () => neighbors,
+    create: async (_companyId: string, args: CreateStrategyArgs): Promise<StrategyItem> => {
+      createCalls.push(args);
+      return {
+        strategyId: 'strategy_memory:new',
+        companyId: 'c1',
+        title: args.title,
+        situation: args.situation,
+        strategy: args.strategy,
+        polarity: args.polarity,
+        status: args.status ?? 'candidate',
+        evidence: args.evidence ?? {},
+        scope: 'tenant',
+        createdAt: '',
+        updatedAt: '',
+      } as StrategyItem;
+    },
+    mergeUpdate: async (
+      _companyId: string,
+      id: string,
+      patch: Record<string, unknown>,
+    ): Promise<StrategyItem> => {
+      mergeCalls.push({ id, patch });
+      return { strategyId: id } as StrategyItem;
+    },
+  };
+  return { svc: svc as unknown as StrategyMemoryService, createCalls, mergeCalls };
+}
+
+function distillConfig(): ConfigService {
+  const env: Record<string, string> = {
+    OPENAI_API_KEY: 'sk-test',
+    OPENAI_CHAT_MODEL: 'gpt-4o-mini',
+  };
+  return {
+    get: (k: string, d?: string) => env[k] ?? d,
+    getOrThrow: (k: string) => {
+      const v = env[k];
+      if (v === undefined) throw new Error(`missing ${k}`);
+      return v;
+    },
+  } as unknown as ConfigService;
+}
+
+const apiKeysStub = { knownCompanyIds: () => ['c1'] } as unknown as ApiKeyService;
+
+/** Script the distiller's two LLM calls in order: proposal, then merge decision. */
+function mockDistillOpenAi(svc: StrategyDistillService, responses: string[]): void {
+  let calls = 0;
+  const stub = {
+    chat: {
+      completions: {
+        create: async () => {
+          const content = responses[calls] ?? responses[responses.length - 1] ?? '{}';
+          calls++;
+          return { choices: [{ message: { content } }] };
+        },
+      },
+    },
+  };
+  (svc as unknown as { openai: typeof stub }).openai = stub;
+}
+
+const PROPOSAL = JSON.stringify({
+  items: [
+    {
+      title: 'proposed lesson',
+      situation: 'some situation',
+      strategy: 'proposed strategy body',
+      polarity: 'do',
+    },
+  ],
+});
+
+function neighbor(status: StrategyItem['status'], id: string): ScoredStrategyItem {
+  return {
+    strategyId: id,
+    companyId: 'c1',
+    title: 'existing lesson',
+    situation: 'existing situation',
+    strategy: 'existing strategy body',
+    polarity: 'do',
+    status,
+    evidence: { nSupport: 3, nContradict: 0 },
+    scope: 'tenant',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    similarity: 0.9,
+  };
+}
+
+const RUN: TrajectoryRun = {
+  task: 'do the thing',
+  outcome: 'success',
+  outcomeEvidenceRef: 'eval:ref#1',
+  steps: [{ tool: 'lookup', args: { id: 1 }, result: { ok: true }, ok: true }],
+};
+
+function makeDistiller(neighbors: ScoredStrategyItem[]) {
+  const { svc, createCalls, mergeCalls } = fakeStrategies(neighbors);
+  const distiller = new StrategyDistillService(svc, apiKeysStub, distillConfig());
+  return { distiller, createCalls, mergeCalls };
+}
+
+describe('R3 P1 — dedup-merge active-immutability branch', () => {
+  it('active merge target → a NEW candidate revision (supersedesId + bundle); mergeUpdate is NEVER called', async () => {
+    const { distiller, createCalls, mergeCalls } = makeDistiller([
+      neighbor('active', 'strategy_memory:act1'),
+    ]);
+    mockDistillOpenAi(distiller, [
+      PROPOSAL,
+      JSON.stringify({
+        action: 'UPDATE',
+        targetId: 'strategy_memory:act1',
+        strategy: 'MERGED strategy',
+        situation: 'MERGED situation',
+      }),
+    ]);
+    const stats = await distiller.distillFromTrajectory('c1', RUN, 'run-9');
+
+    // The active row is untouched — no in-place merge happened.
+    expect(mergeCalls).toHaveLength(0);
+    // A revision candidate was created instead.
+    expect(createCalls).toHaveLength(1);
+    const rev = createCalls[0]!;
+    expect(rev.status).toBe('candidate');
+    expect(rev.supersedesId).toBe('strategy_memory:act1');
+    expect(rev.strategy).toBe('MERGED strategy');
+    expect(rev.situation).toBe('MERGED situation');
+    // The experience bundle rode along onto the revision.
+    expect(rev.verifiedOutcome).toBe('success');
+    expect(rev.outcomeEvidenceRef).toBe('eval:ref#1');
+    expect(rev.trajectory?.[0]?.tool).toBe('lookup');
+    // Stats honestly report a revision, not an update.
+    expect(stats).toMatchObject({ proposed: 1, added: 0, updated: 0, revised: 1, noop: 0 });
+  });
+
+  it('candidate merge target → in-place mergeUpdate (the review buffer); no revision created', async () => {
+    const { distiller, createCalls, mergeCalls } = makeDistiller([
+      neighbor('candidate', 'strategy_memory:cand1'),
+    ]);
+    mockDistillOpenAi(distiller, [
+      PROPOSAL,
+      JSON.stringify({
+        action: 'UPDATE',
+        targetId: 'strategy_memory:cand1',
+        strategy: 'MERGED strategy',
+        situation: 'MERGED situation',
+      }),
+    ]);
+    const stats = await distiller.distillFromTrajectory('c1', RUN, 'run-9');
+
+    // In-place merge of the candidate — exactly the pre-fix behavior.
+    expect(mergeCalls).toHaveLength(1);
+    expect(mergeCalls[0]!.id).toBe('strategy_memory:cand1');
+    expect(mergeCalls[0]!.patch.strategy).toBe('MERGED strategy');
+    // No revision row for a candidate target.
+    expect(createCalls).toHaveLength(0);
+    expect(stats).toMatchObject({ proposed: 1, added: 0, updated: 1, revised: 0, noop: 0 });
+  });
+
+  it('empty table (no neighbors) → ADD, and never a revision', async () => {
+    const { distiller, createCalls, mergeCalls } = makeDistiller([]);
+    mockDistillOpenAi(distiller, [PROPOSAL]);
+    const stats = await distiller.distillFromTrajectory('c1', RUN);
+    expect(mergeCalls).toHaveLength(0);
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0]!.status).toBe('candidate');
+    expect(createCalls[0]!.supersedesId).toBeUndefined();
+    expect(stats).toMatchObject({ added: 1, updated: 0, revised: 0, noop: 0 });
+  });
+});

--- a/test/strategy-trajectories.e2e-spec.ts
+++ b/test/strategy-trajectories.e2e-spec.ts
@@ -313,3 +313,105 @@ describe('strategy trajectories — all flags ON', () => {
     expect(JSON.stringify(res.body.citations ?? [])).not.toContain('past tool path');
   });
 });
+
+// ── R3 P1. Active rows are IMMUTABLE to capture: revision, not mutation ────
+//
+// The dedup-merge BRANCHING (active target → propose a revision; candidate
+// target → merge in place) is proved deterministically at the unit level in
+// test/strategy-revision.unit-spec.ts (the stub embedder's near-orthogonal
+// vectors make the distiller's floor-0 neighbor lookup non-deterministic, so
+// it is the wrong harness for that branch). Here we pin the SERVICE-LEVEL DB
+// guarantees against the real store: the 0099 columns round-trip, a candidate
+// revision is NOT served until promotion, and promotion deprecates the
+// superseded active row — all via retrieve()'s deterministic 0.4 floor.
+
+describe('strategy trajectories — active rows are immutable to capture (R3 P1)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    clearStrategyEnv();
+    process.env.STRATEGY_MEMORY_ENABLED = '1';
+    process.env.STRATEGY_RETRIEVAL_ENABLED = '1';
+    process.env.STRATEGY_TRAJECTORIES_ENABLED = '1';
+    process.env.SYNTHESIZE_ANSWER_ROUTER_ENABLED = '1';
+    f = await createApp({ companyId: 'co_traj_revision_e2e' });
+  });
+  afterAll(async () => {
+    clearStrategyEnv();
+    if (f) await f.close();
+  });
+
+  it('a candidate revision is NOT served until promotion; supersedesId + unverified evidence label round-trip; promotion deprecates the superseded active row', async () => {
+    const strategy = f.app.get(StrategyMemoryService);
+
+    // The SERVING row: an ACTIVE, trajectory-bearing item whose retrieval key
+    // (title, empty situation) == 'onboarding lookup' (the stub embedder
+    // trims `title\n` to `title`, cosine 1.0 ≥ the 0.4 floor).
+    const ACTIVE_STRATEGY = 'Original active advice: check the profile record first.';
+    const active = await strategy.create(f.companyId, {
+      title: 'onboarding lookup',
+      situation: '',
+      strategy: ACTIVE_STRATEGY,
+      polarity: 'do',
+      status: 'active',
+      trajectory: [{ tool: 'profile_lookup', argsDigest: 'aaaa', resultDigest: 'bbbb', ok: true }],
+      verifiedOutcome: 'success',
+    });
+
+    // A candidate REVISION proposing to replace it — exactly the row the
+    // capture path (reviseActive) persists: merged content + the new
+    // experience, a supersedesId pointer, and a caller-asserted evidence ref.
+    const MERGED_STRATEGY = 'Merged advice: check the profile record, then confirm status.';
+    const revision = await strategy.create(f.companyId, {
+      title: 'onboarding lookup revised',
+      situation: '',
+      strategy: MERGED_STRATEGY,
+      polarity: 'do',
+      status: 'candidate',
+      supersedesId: active.strategyId,
+      trajectory: [{ tool: 'profile_lookup', argsDigest: 'cccc', resultDigest: 'dddd', ok: false }],
+      verifiedOutcome: 'failure',
+      outcomeEvidenceRef: 'eval:run-rev-1#q1',
+    });
+
+    // (1) The 0099 columns round-trip through the real store: the revision
+    // points at the active row it supersedes, and its caller-asserted
+    // evidence ref is persisted LABELED UNVERIFIED (a claim, not proof).
+    const revRead = (await strategy.findSimilar(f.companyId, 'onboarding lookup revised', 5)).find(
+      (i) => i.strategyId === revision.strategyId,
+    )!;
+    expect(revRead.supersedesId).toBe(active.strategyId);
+    expect(revRead.outcomeEvidenceRef).toBe('eval:run-rev-1#q1');
+    expect(revRead.outcomeEvidenceVerified).toBe(false);
+
+    // (2) retrieve() serves the ACTIVE row and NOT the candidate revision —
+    // even though the revision's own key scores 1.0, the status filter keeps
+    // it out until a human promotes it (the load-bearing serving guarantee).
+    expect(
+      (await strategy.retrieve(f.companyId, 'onboarding lookup', 2)).map((s) => s.strategyId),
+    ).toEqual([active.strategyId]);
+    expect(await strategy.retrieve(f.companyId, 'onboarding lookup revised', 2)).toEqual([]);
+
+    // (3) Promotion (candidate→active via PATCH) deprecates the superseded
+    // active row so two actives never serve one slot; the revision now serves.
+    const patch = await f.http
+      .patch(`/v1/admin/strategy/${encodeURIComponent(revision.strategyId)}`)
+      .set(auth())
+      .send({ status: 'active' });
+    expect(patch.status).toBe(200);
+    expect(patch.body.status).toBe('active');
+
+    const oldActive = (await strategy.list(f.companyId)).find(
+      (i) => i.strategyId === active.strategyId,
+    )!;
+    expect(oldActive.status).toBe('deprecated');
+    expect(
+      (await strategy.retrieve(f.companyId, 'onboarding lookup revised', 2)).map(
+        (s) => s.strategyId,
+      ),
+    ).toEqual([revision.strategyId]);
+    // The deprecated old active no longer serves its old key either.
+    expect(await strategy.retrieve(f.companyId, 'onboarding lookup', 2)).toEqual([]);
+  });
+});

--- a/test/strategy-trajectories.unit-spec.ts
+++ b/test/strategy-trajectories.unit-spec.ts
@@ -278,3 +278,123 @@ describe('trajectory read gate (byte-identical serving when off)', () => {
     );
   });
 });
+
+// ── R3 P1: caller-asserted evidence label + revision pointer ──────────────
+
+describe('capture write-path labeling (R3 P1)', () => {
+  const ALL_ON = {
+    STRATEGY_MEMORY_ENABLED: '1',
+    STRATEGY_RETRIEVAL_ENABLED: '1',
+    STRATEGY_TRAJECTORIES_ENABLED: '1',
+  };
+
+  function createStub(calls: QueryCall[], env: Record<string, string> = ALL_ON) {
+    return new StrategyMemoryService(
+      stubSurreal(
+        (sql) => (sql.includes('CREATE ONLY strategy_memory') ? [trajRow()] : [[]]),
+        calls,
+      ),
+      stubEmbedder({}),
+      stubConfig(env),
+    );
+  }
+
+  it('create() stamps outcomeEvidenceVerified=false whenever an outcomeEvidenceRef is written', async () => {
+    const calls: QueryCall[] = [];
+    await createStub(calls).create('c1', {
+      title: 'x',
+      situation: '',
+      strategy: 's',
+      polarity: 'do',
+      outcomeEvidenceRef: 'run:abc',
+      verifiedOutcome: 'success',
+    });
+    const create = calls.find((c) => c.sql.includes('CREATE ONLY strategy_memory'))!;
+    // The opaque caller-asserted ref is co-written with an explicit
+    // "unverified" label so nothing downstream can mistake it for proof.
+    expect(create.sql).toContain('outcomeEvidenceRef: $outcomeEvidenceRef');
+    expect(create.sql).toContain('outcomeEvidenceVerified: $outcomeEvidenceVerified');
+    expect(create.params?.outcomeEvidenceRef).toBe('run:abc');
+    expect(create.params?.outcomeEvidenceVerified).toBe(false);
+  });
+
+  it('create() writes NO evidence label when the flag is off (byte-identical)', async () => {
+    const calls: QueryCall[] = [];
+    await createStub(calls, {
+      STRATEGY_MEMORY_ENABLED: '1',
+      STRATEGY_RETRIEVAL_ENABLED: '1',
+      // STRATEGY_TRAJECTORIES_ENABLED unset → off
+    }).create('c1', {
+      title: 'x',
+      situation: '',
+      strategy: 's',
+      polarity: 'do',
+      outcomeEvidenceRef: 'run:abc',
+    });
+    const create = calls.find((c) => c.sql.includes('CREATE ONLY strategy_memory'))!;
+    expect(create.sql).not.toContain('outcomeEvidenceRef');
+    expect(create.sql).not.toContain('outcomeEvidenceVerified');
+    expect(create.params).not.toHaveProperty('outcomeEvidenceVerified');
+  });
+
+  it('create() writes supersedesId into the CONTENT only for a revision candidate', async () => {
+    const withRev: QueryCall[] = [];
+    await createStub(withRev).create('c1', {
+      title: 'x',
+      situation: '',
+      strategy: 's',
+      polarity: 'do',
+      status: 'candidate',
+      supersedesId: 'strategy_memory:old',
+    });
+    const revCreate = withRev.find((c) => c.sql.includes('CREATE ONLY strategy_memory'))!;
+    expect(revCreate.sql).toContain('supersedesId: $supersedesId');
+    expect(revCreate.params?.supersedesId).toBe('strategy_memory:old');
+
+    // Ordinary (non-revision) create omits it entirely — byte-identical.
+    const noRev: QueryCall[] = [];
+    await createStub(noRev).create('c1', {
+      title: 'x',
+      situation: '',
+      strategy: 's',
+      polarity: 'do',
+    });
+    const plainCreate = noRev.find((c) => c.sql.includes('CREATE ONLY strategy_memory'))!;
+    expect(plainCreate.sql).not.toContain('supersedesId');
+    expect(plainCreate.params).not.toHaveProperty('supersedesId');
+  });
+
+  it('maps supersedesId + outcomeEvidenceVerified through the serving projection', async () => {
+    const svc = new StrategyMemoryService(
+      stubSurreal((sql) =>
+        sql.includes('FROM strategy_memory')
+          ? [[trajRow({ supersedesId: 'strategy_memory:prev', outcomeEvidenceVerified: false })]]
+          : [[]],
+      ),
+      stubEmbedder({ q: [1, 0] }),
+      stubConfig(ALL_ON),
+    );
+    const out = await svc.retrieve('c1', 'q');
+    expect(out[0]!.supersedesId).toBe('strategy_memory:prev');
+    expect(out[0]!.outcomeEvidenceVerified).toBe(false);
+  });
+
+  it('outcomeEvidenceRef is NEVER rendered into the advisory note (advice, not evidence)', () => {
+    const item = {
+      title: 't',
+      situation: 's',
+      strategy: 'strat',
+      polarity: 'do',
+      trajectory: [TRAJ_STEP],
+      verifiedOutcome: 'success',
+      outcomeEvidenceRef: 'eval:run-9#q1',
+      outcomeEvidenceVerified: false,
+    } as unknown as ScoredStrategyItem;
+    const note = renderStrategyNote(item);
+    // The past-tool-path suffix may render, but the ref (a claim) never does.
+    expect(note).toContain('past tool path');
+    expect(note).not.toContain('eval:run-9#q1');
+    expect(note).not.toContain('outcomeEvidence');
+    expect(renderTrajectorySuffix(item)).not.toContain('eval:run-9#q1');
+  });
+});


### PR DESCRIPTION
## R3 audit — P1: trajectory/distill capture mutated an active strategy without review

**Verified bug:** `dedupMerge`'s UPDATE arm (`strategy-distill.service.ts`) found the merge target among `findSimilar`'s results (candidate **and** active) and called `mergeUpdate(...)` **without checking status**. `mergeUpdate` (`strategy-memory.service.ts`) builds its SET from `evidence/updatedAt/strategy/situation/trajectory` and **never sets `status`** — so an `active` (already-serving) target was mutated **in place**. `retrieve()` serves `active`-only, so a trajectory/distill capture silently changed served content, bypassing candidate→active review. The whole capture path is default-off (`STRATEGY_MEMORY_ENABLED` + the trajectory write-fragment gate).

## Fix: active rows are immutable to capture (revision, not in-place mutation)
- **`dedupMerge` UPDATE arm** — if the target is `active`: `reviseActive(...)` creates a **new `candidate` revision** carrying the merged content + experience bundle and a `supersedesId` pointer at the active row; the active row is left **byte-identical**. Returns a new `'revised'` outcome (threaded honestly through `DistillStats`/`TrajectoryCaptureStats` + both log lines). A `candidate` target keeps the existing in-place merge (candidates are the review buffer). A unique-title collision degrades to `noop`, never mutating the active row.
- **Promotion** — `updateStatus`, when promoting a revision candidate (`supersedesId` set) to `active`, deprecates the pointed-to old active row (guarded on `status='active'`, best-effort), so two actives never serve the same slot. (Chose this over a TODO; pinned by e2e.)
- **`outcomeEvidenceRef`** — there is no tenant evidence table to resolve it against, and it is verified to never reach the generator/verifier/citations (only `trajectory`+`verifiedOutcome` render via `renderTrajectorySuffix`). It is now persisted explicitly stamped `outcomeEvidenceVerified: false` — the "advice, not proof" posture made explicit at the row level.
- **Migration `0099_strategy_revision.surql`** (additive, `DEFINE FIELD IF NOT EXISTS`, OVERWRITE-safe, 0098 style): `option<string> supersedesId` + `option<bool> outcomeEvidenceVerified`. Every column optional → no backfill; when the feature is off the columns are never written or selected → **serving byte-identical to pre-0099**.

## Note
The same central `dedupMerge` is shared by the post-mortem distill path, so it too now proposes revisions instead of mutating active rows — a consistent correctness improvement (both default-off).

## Verification (exit codes)
- `pnpm typecheck` → 0 · `eslint --max-warnings 0` → 0 · `prettier --check` → 0
- Unit: strategy suites + goldens (config-catalog-truth, env-validation, engine-gates, flag-budget, gate-kinds-golden, migration-resolver-invariants, contracts-admin-migrations, migrator) → 11 suites / 101 tests
- e2e (Docker SurrealDB 3.2.4, migrations 0001–0099 applied cleanly): 0099 columns round-trip; a candidate revision is **not served** until promotion; promotion deprecates the superseded active row → 3 suites / 14 tests
- No paid evals. Default-off; byte-identical when off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
