### PR TITLE
feat(multilingual): confidence-aware language attribution + soft same-language boost (Tier 1, default-off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -614,6 +614,18 @@ SEARCH_FACT_CENTRIC_BUDGET=48
 #BRAIN_TENANT_OVERRIDE_ENABLED=0
 #INGEST_EPISODE_ONLY=0
 
+# ── Multilingual (Tier 1, migration 0100) ────────────────────────────────
+# Confidence-aware attribution: the detector returns `und` (not `en`) for
+# short/stopword-less objects and the resolver stamps langConfidence /
+# langSource / detectorVersion / sourceLang. Off → Phase-4 `en` fallback,
+# no new columns written (byte-identical). Backfill existing rows with
+# scripts/backfill-lang-attribution.ts (admin-run, never automatic).
+#MULTILINGUAL_LANG_ATTRIBUTION=0
+# Soft same-language filter: the hard `lang = q OR lang IS NONE` exclusion
+# (search where-builder + user-profile) becomes a confidence-gated ranking
+# boost — cross-lingual facts are demoted, never hidden. Off → hard filter.
+#MULTILINGUAL_SOFT_LANG_FILTER=0
+
 # ── Observability ────────────────────────────────────────────────────────
 # Enable the OpenTelemetry SDK + GenAI SemConv attributes on every LLM
 # call. Endpoint defaults to OTEL_EXPORTER_OTLP_ENDPOINT (standard env).

--- a/scripts/backfill-lang-attribution.ts
+++ b/scripts/backfill-lang-attribution.ts
@@ -1,0 +1,181 @@
+/**
+ * backfill-lang-attribution — re-stamp existing knowledge_fact rows with
+ * confidence-aware language attribution (multilingual Tier 1, migration
+ * 0100), under the CURRENT detector version.
+ *
+ * WHY a script, not a migration: migration 0100 is deliberately additive +
+ * data-mutation-free (option<...> columns, no backfill at migrate time —
+ * the 0098/0099 posture). Re-labelling the historical corpus is a separate,
+ * EXPLICIT, admin-triggered operation so a schema apply never rewrites data.
+ *
+ * WHY a script, not an admin endpoint (the scope choice, per the task): a
+ * full POST /v1/admin/... surface (controller + DTO + auth + job + tests)
+ * would balloon this Tier-1 change. This script is the bounded equivalent —
+ * same effect (flag-gated, admin-run, never auto-run), reviewed in one file.
+ *
+ * TODO(multilingual Tier 2): promote to an admin endpoint / background job
+ * with per-tenant progress + resumable cursor persistence, and extend to
+ * stamp `sourceLang` by joining each fact's grounding episode(s)
+ * (source.episodeIds → episode.lang). This script stamps DETECTED labels
+ * only (lang / langConfidence / langSource='detected' / detectorVersion);
+ * it does NOT compute inheritance, because the source-turn language is not
+ * on the fact row.
+ *
+ * FLAG-GATED: refuses to run unless MULTILINGUAL_LANG_ATTRIBUTION is on (so
+ * a backfill can't precede the feature it supports) — override with --force
+ * only when you know the flag will be enabled next.
+ *
+ * IDEMPOTENT: re-running re-derives the same labels from the same objects
+ * under the same detector version, so a second pass is a no-op in effect.
+ *
+ * Usage:
+ *   MULTILINGUAL_LANG_ATTRIBUTION=1 npx tsx scripts/backfill-lang-attribution.ts \
+ *     --url http://127.0.0.1:8000 --user root --pass root \
+ *     --ns brain --tenant <companyId> [--batch 500] [--dry-run] [--force]
+ *
+ * The password may come from SURREAL_PASS instead of argv (argv leaks into
+ * `ps` output on shared stands).
+ *
+ * Exit codes: 0 = completed (or dry-run); 1 = error / refused (flag off
+ * without --force).
+ */
+import { Surreal, StringRecordId } from 'surrealdb';
+import { detectLanguage, DETECTOR_VERSION } from '../src/ai/locale/language-detector';
+import { envFlagEnabled } from '../src/common/env-validation';
+
+interface Args {
+  url: string;
+  user: string;
+  pass: string;
+  ns: string;
+  tenant: string;
+  batch: number;
+  dryRun: boolean;
+  force: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (name: string): string | undefined => {
+    const i = argv.indexOf(`--${name}`);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  const has = (name: string): boolean => argv.includes(`--${name}`);
+  const url = get('url') ?? 'http://127.0.0.1:8000';
+  const user = get('user') ?? 'root';
+  const pass = get('pass') ?? process.env.SURREAL_PASS ?? 'root';
+  const ns = get('ns') ?? 'brain';
+  const tenant = get('tenant');
+  if (!tenant) {
+    console.error('backfill-lang-attribution: --tenant <companyId> is required');
+    process.exit(1);
+  }
+  const batch = Number(get('batch') ?? '500');
+  return {
+    url,
+    user,
+    pass,
+    ns,
+    tenant,
+    batch: Number.isFinite(batch) && batch > 0 ? batch : 500,
+    dryRun: has('dry-run'),
+    force: has('force'),
+  };
+}
+
+interface FactRow {
+  id: unknown;
+  object: string;
+}
+
+/** One detected-attribution stamp for a fact (sourceLang deferred — see TODO). */
+function attributionFor(object: string): {
+  lang: string | null;
+  langConfidence: number;
+  langSource: 'detected';
+  detectorVersion: string;
+} {
+  // Force attribution-aware detection regardless of the ambient flag: the
+  // backfill IS the attribution write, so a short/stopword-less object must
+  // resolve to `und` (null lang), never the legacy `en`.
+  const det = detectLanguage(object, true);
+  return {
+    lang: det.language === 'und' ? null : det.language,
+    langConfidence: det.confidence,
+    langSource: 'detected',
+    detectorVersion: det.detectorVersion,
+  };
+}
+
+async function main(): Promise<void> {
+  const a = parseArgs(process.argv.slice(2));
+
+  if (!a.force && !envFlagEnabled(process.env.MULTILINGUAL_LANG_ATTRIBUTION)) {
+    console.error(
+      'backfill-lang-attribution: refusing — MULTILINGUAL_LANG_ATTRIBUTION is off. ' +
+        'Enable the flag (recommended) or pass --force to backfill ahead of it.',
+    );
+    process.exit(1);
+  }
+
+  const db = new Surreal();
+  await db.connect(a.url);
+  await db.signin({ username: a.user, password: a.pass });
+  await db.use({ namespace: a.ns, database: `co_${a.tenant}` });
+
+  console.info(
+    `backfill-lang-attribution: tenant=${a.tenant} detector=${DETECTOR_VERSION} ` +
+      `batch=${a.batch}${a.dryRun ? ' (dry-run)' : ''}`,
+  );
+
+  let cursor: string | null = null;
+  let scanned = 0;
+  let stamped = 0;
+  for (;;) {
+    // Keyset pagination over the record id — stable under concurrent writes
+    // and index-friendly (no OFFSET blow-up on large corpora).
+    const [rows] = await db.query<[FactRow[]]>(
+      `SELECT id, object FROM knowledge_fact
+        ${cursor ? 'WHERE id > $cursor' : ''}
+        ORDER BY id ASC LIMIT $batch`,
+      { cursor: cursor ? new StringRecordId(cursor) : undefined, batch: a.batch },
+    );
+    if (!rows || rows.length === 0) break;
+
+    for (const r of rows) {
+      scanned += 1;
+      if (typeof r.object !== 'string' || r.object.length === 0) continue;
+      const attr = attributionFor(r.object);
+      if (!a.dryRun) {
+        await db.query(
+          `UPDATE $id SET
+             lang = $lang,
+             langConfidence = $langConfidence,
+             langSource = $langSource,
+             detectorVersion = $detectorVersion`,
+          {
+            id: new StringRecordId(String(r.id)),
+            lang: attr.lang ?? undefined,
+            langConfidence: attr.langConfidence,
+            langSource: attr.langSource,
+            detectorVersion: attr.detectorVersion,
+          },
+        );
+      }
+      stamped += 1;
+    }
+    cursor = String(rows[rows.length - 1]!.id);
+    console.info(`  … scanned ${scanned}, stamped ${stamped}`);
+  }
+
+  console.info(
+    `backfill-lang-attribution: done — scanned ${scanned}, ` +
+      `${a.dryRun ? 'would stamp' : 'stamped'} ${stamped}.`,
+  );
+  await db.close();
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(`backfill-lang-attribution: failed — ${(e as Error).message}`);
+  process.exit(1);
+});

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -491,6 +491,31 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Fovea optics (verifier answer-integrity arm, Part C): treat a `supported` verdict whose answer carries ZERO citations as low_coverage/abstain instead of serving an uncited "supported" answer (audit F2(b)). LIVE-behavior change when enabled — prod answers can shift, so default off until the owner enables + validates. Off = byte-identical serving.',
   },
+  // ── Multilingual (Tier 1, migration 0100) ───────────
+  {
+    key: 'MULTILINGUAL_LANG_ATTRIBUTION',
+    category: 'pipeline',
+    // Read at call time (the language detector, fact-resolver buildResolveCall,
+    // and resolveSearchTuning) — never captured in a constructor — so a flip
+    // takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Confidence-aware language attribution: the pure detector returns `und` (not `en`) for short / stopword-less / numeric objects, and the fact resolver stamps langConfidence + langSource (detected | inherited | explicit) + detectorVersion + sourceLang (the SOURCE turn's language, distinct from the object's own `lang`), inheriting the source-turn language onto an undetectable short object. Behaviour-neutral telemetry (brain_lang_attribution_total / _confidence) is emitted only while on. Off (default) → the Phase-4 `en` fallback and NO new columns written — byte-identical.",
+  },
+  {
+    key: 'MULTILINGUAL_SOFT_LANG_FILTER',
+    category: 'pipeline',
+    // Read at call time (resolveSearchTuning per request, user-profile
+    // getProfile) — never constructor-captured — so a flip takes effect
+    // without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Soft same-language filter: replaces the hard `lang = q OR lang IS NONE` exclusion at both read sites (search where-builder + user-profile) with a same-language RANKING boost — a cross-lingual fact is demoted, never hidden. In search it is gated on a high-confidence detected query language (an explicit dto.queryLang / caller-supplied profile lang counts as confident); below the confidence floor no boost AND no exclusion. Off (default) → the hard filter is byte-identical.',
+  },
   // ── Cost ────────────────────────────────────────────
   {
     key: 'COST_CHAT_PROMPT_USD_PER_MTOK',

--- a/src/ai/locale/language-detector.ts
+++ b/src/ai/locale/language-detector.ts
@@ -28,15 +28,45 @@
  * corpora ever land.
  */
 
+import { envFlagEnabled } from '../../common/env-validation';
+
 export type LanguageCode =
   'en' | 'ru' | 'es' | 'fr' | 'de' | 'pt' | 'it' | 'zh' | 'ja' | 'ko' | 'ar' | 'hi' | 'und';
 
 export type ScriptCode = 'Latn' | 'Cyrl' | 'Hani' | 'Hira' | 'Hang' | 'Arab' | 'Deva' | 'Zyyy';
 
+/**
+ * Version tag of THIS detector — the stopword + Unicode-block scheme.
+ * Stamped onto every DetectedLanguage and persisted (as `detectorVersion`)
+ * by the attribution write path so a re-fit / backfill can be attributed
+ * and telemetry can slice by detector generation. Bump when the scoring
+ * scheme or stopword tables change materially.
+ */
+export const DETECTOR_VERSION = 'stopword-v1';
+
 export interface DetectedLanguage {
   language: LanguageCode;
   script: ScriptCode;
   confidence: number;
+  /** Version of the detector that produced this label (DETECTOR_VERSION). */
+  detectorVersion: string;
+}
+
+/** Stamp the shared detectorVersion onto a result so no call site forgets it. */
+function det(language: LanguageCode, script: ScriptCode, confidence: number): DetectedLanguage {
+  return { language, script, confidence, detectorVersion: DETECTOR_VERSION };
+}
+
+/**
+ * Confidence-aware attribution (MULTILINGUAL_LANG_ATTRIBUTION, default
+ * off). When ON, the Latin stopword path returns `und` (not `en`) for
+ * short / stopword-less / numeric tokens — the honest "undetermined"
+ * label — instead of silently defaulting to English. When OFF the detector
+ * is byte-identical to Phase 4 (the `en` fallback). Read at call time so a
+ * live flip lands immediately; a caller can force the mode for tests.
+ */
+function attributionEnabled(): boolean {
+  return envFlagEnabled(process.env.MULTILINGUAL_LANG_ATTRIBUTION);
 }
 
 // Top-30 stopwords per Latin-script language. Ordered by frequency so
@@ -254,46 +284,49 @@ const STOPWORD_SETS: Map<string, Set<string>> = new Map(
   Object.entries(STOPWORDS_BY_LANG).map(([lang, words]) => [lang, new Set(words)]),
 );
 
-export function detectLanguage(text: string): DetectedLanguage {
+export function detectLanguage(
+  text: string,
+  attribution: boolean = attributionEnabled(),
+): DetectedLanguage {
   const trimmed = text.trim();
   if (!trimmed) {
-    return { language: 'und', script: 'Zyyy', confidence: 0 };
+    return det('und', 'Zyyy', 0);
   }
 
   const blocks = countUnicodeBlocks(trimmed);
   const total = blocks.total;
   if (total === 0) {
-    return { language: 'und', script: 'Zyyy', confidence: 0 };
+    return det('und', 'Zyyy', 0);
   }
 
   // Non-Latin scripts triage. Threshold 0.4 of letters in the script —
   // covers mixed-script input where the substantive content is in the
   // target script and the rest is whitespace, punctuation, or digits.
   if (blocks.cyrillic / total > 0.4) {
-    return { language: 'ru', script: 'Cyrl', confidence: blocks.cyrillic / total };
+    return det('ru', 'Cyrl', blocks.cyrillic / total);
   }
   if (blocks.hangul / total > 0.3) {
-    return { language: 'ko', script: 'Hang', confidence: blocks.hangul / total };
+    return det('ko', 'Hang', blocks.hangul / total);
   }
   if ((blocks.hiragana + blocks.katakana) / total > 0.2) {
     const c = (blocks.hiragana + blocks.katakana + blocks.han) / total;
-    return { language: 'ja', script: 'Hira', confidence: c };
+    return det('ja', 'Hira', c);
   }
   if (blocks.han / total > 0.3) {
-    return { language: 'zh', script: 'Hani', confidence: blocks.han / total };
+    return det('zh', 'Hani', blocks.han / total);
   }
   if (blocks.arabic / total > 0.3) {
-    return { language: 'ar', script: 'Arab', confidence: blocks.arabic / total };
+    return det('ar', 'Arab', blocks.arabic / total);
   }
   if (blocks.devanagari / total > 0.3) {
-    return { language: 'hi', script: 'Deva', confidence: blocks.devanagari / total };
+    return det('hi', 'Deva', blocks.devanagari / total);
   }
 
   // Latin path — stopword scoring.
-  return scoreLatinLanguage(trimmed);
+  return scoreLatinLanguage(trimmed, attribution);
 }
 
-function scoreLatinLanguage(text: string): DetectedLanguage {
+function scoreLatinLanguage(text: string, attribution: boolean): DetectedLanguage {
   const tokens = text
     .toLowerCase()
     .normalize('NFC')
@@ -301,7 +334,7 @@ function scoreLatinLanguage(text: string): DetectedLanguage {
     .filter((t) => t.length > 0);
 
   if (tokens.length === 0) {
-    return { language: 'und', script: 'Latn', confidence: 0 };
+    return det('und', 'Latn', 0);
   }
 
   let bestLang: LanguageCode = 'en';
@@ -315,11 +348,17 @@ function scoreLatinLanguage(text: string): DetectedLanguage {
     }
   }
 
-  return {
-    language: bestLang,
-    script: 'Latn',
-    confidence: bestScore / tokens.length,
-  };
+  // Confidence-aware attribution: with ZERO stopword hits there is no
+  // Latin-language signal at all — a bare `en` label is a systematic
+  // mislabel for numeric / short / code-switched objects. Under the flag
+  // we report `und` (undetermined) so the resolver can inherit the source
+  // language or record low confidence; off → the historical `en` fallback
+  // (byte-identical Phase 4 behaviour).
+  if (attribution && bestScore === 0) {
+    return det('und', 'Latn', 0);
+  }
+
+  return det(bestLang, 'Latn', bestScore / tokens.length);
 }
 
 interface UnicodeBlockCounts {

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -757,6 +757,18 @@ const KNOWN_BOOLEAN_FLAGS = [
   // default off. Outside ENGINE_PREFIX by design (the FOVEA_ family sits off
   // the flag budget).
   'FOVEA_REQUIRE_CITATIONS',
+  // Multilingual Tier 1 (migration 0100). Confidence-aware attribution:
+  // the detector returns `und` (not `en`) for short/stopword-less objects
+  // and the resolver stamps langConfidence/langSource/detectorVersion/
+  // sourceLang. Default off ⇒ Phase-4 `en` fallback, no new fields written.
+  // Outside ENGINE_PREFIX by design (a cross-cutting locale concern, not an
+  // engine fork — sits off the flag budget alongside the FOVEA_ family).
+  'MULTILINGUAL_LANG_ATTRIBUTION',
+  // Multilingual Tier 1. Soft same-language filter: the hard
+  // `lang = q OR lang IS NONE` retrieval/profile exclusion becomes a
+  // confidence-gated ranking boost (cross-lingual facts demoted, never
+  // hidden). Default off ⇒ the hard filter is byte-identical.
+  'MULTILINGUAL_SOFT_LANG_FILTER',
 ];
 
 /**

--- a/src/db/migrations/0100_lang_attribution.surql
+++ b/src/db/migrations/0100_lang_attribution.surql
@@ -1,0 +1,63 @@
+-- 0100: confidence-aware language attribution (multilingual Tier 1).
+--
+-- WHY. Phase-4 tagged each fact with a single `lang` (the stored
+-- `object`'s language = contentLang) and NOTHING else — no confidence,
+-- no record of HOW the label was chosen, and the short-string path
+-- silently defaulted to `en` (scoreLatinLanguage's zero-stopword-hit
+-- fallback). That default is a systematic mislabel for numeric / short /
+-- code-switched objects. Tier 1 makes attribution confidence-aware: the
+-- detector returns `und` (not `en`) for stopword-less input under
+-- MULTILINGUAL_LANG_ATTRIBUTION, and the resolver records the confidence,
+-- the SOURCE of the label, the detector version, and — distinct from the
+-- object's own language — the language of the SOURCE message/turn.
+--
+-- ADDITIVE + OPTIONAL by construction (the 0098/0099 posture): every
+-- column is option<...>, so existing rows are unaffected and NO backfill
+-- is needed. A write that omits these fields stores nothing for them.
+-- The attribution write path is gated OFF by MULTILINGUAL_LANG_ATTRIBUTION
+-- at the service layer — master off ⇒ these columns are never written and
+-- never read, so serving is byte-identical to pre-0100. `lang` is kept
+-- AS-IS (still contentLang); these columns sit beside it.
+--
+-- No migration-time data mutation: existing rows are re-stamped only by
+-- the explicit, flag-gated admin backfill (scripts/backfill-lang-attribution),
+-- never at migrate time.
+
+-- Detector confidence for `lang`, 0..1 (the numeric idiom is float — cf.
+-- 0044 agreementRate, candidate.confidence). NONE on pre-0100 rows and on
+-- any write made while attribution is off.
+DEFINE FIELD IF NOT EXISTS langConfidence ON knowledge_fact TYPE option<float>
+    ASSERT $value IS NONE OR ($value >= 0 AND $value <= 1);
+
+-- HOW the `lang` label was chosen:
+--   detected  — the detector read it off the object text
+--   inherited — the object was too short/stopword-less to detect, so the
+--               SOURCE message/turn language was inherited onto it
+--   explicit  — the caller supplied a known language for the content
+DEFINE FIELD IF NOT EXISTS langSource ON knowledge_fact TYPE option<string>
+    ASSERT $value IS NONE OR $value IN ['detected', 'inherited', 'explicit'];
+
+-- Version tag of the detector that produced the label — lets a re-fit /
+-- backfill be attributed and lets telemetry slice by detector generation.
+DEFINE FIELD IF NOT EXISTS detectorVersion ON knowledge_fact TYPE option<string>;
+
+-- The language of the SOURCE message/turn the fact was extracted from,
+-- DISTINCT from `lang` (the stored object's language = contentLang). A
+-- Russian turn can yield a fact whose object is a short English proper
+-- noun; sourceLang preserves the turn language while `lang` stays the
+-- object's. NONE when the turn language is unknown.
+DEFINE FIELD IF NOT EXISTS sourceLang ON knowledge_fact TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 2;
+
+-- episode (0073) is the other table that stamps `lang` (episode-store
+-- detects it off the raw turn text). Mirror the attribution columns here
+-- for schema parity so a future episode-side backfill has somewhere to
+-- land — sourceLang is omitted because an episode IS the source, so its
+-- own `lang` already carries the source-turn language. Nothing writes
+-- these yet (episode-side attribution stamping is a documented follow-up);
+-- additive + optional, so this is a pure schema widening.
+DEFINE FIELD IF NOT EXISTS langConfidence ON episode TYPE option<float>
+    ASSERT $value IS NONE OR ($value >= 0 AND $value <= 1);
+DEFINE FIELD IF NOT EXISTS langSource ON episode TYPE option<string>
+    ASSERT $value IS NONE OR $value IN ['detected', 'inherited', 'explicit'];
+DEFINE FIELD IF NOT EXISTS detectorVersion ON episode TYPE option<string>;

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -5,6 +5,7 @@ import { scopeForUser } from '../auth/scope-tags';
 import { MetricsService } from '../metrics/metrics.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { detectLanguage } from '../ai/locale/language-detector';
+import { envFlagEnabled } from '../common/env-validation';
 import { KeyedMutex } from '../common/keyed-mutex';
 import { ConflictConfig, type DerivedSemantics, type ResolveOutcome } from './conflict-resolver';
 import { idTailOf, sourceTrustFor } from './ingest-utils';
@@ -32,6 +33,21 @@ export const VALUE_BEARING_ASPECTS: ReadonlySet<string> = new Set([
 /** Derive-internal semantics choice (V9 §1); pure, exported for tests. */
 export function derivedSemanticsFor(aspect: string, slotSemantics: boolean): DerivedSemantics {
   return slotSemantics && VALUE_BEARING_ASPECTS.has(aspect) ? 'bitemporal_event' : 'append_only';
+}
+
+/**
+ * Confidence-aware language-attribution metadata (multilingual Tier 1,
+ * migration 0100). Built ONLY when MULTILINGUAL_LANG_ATTRIBUTION is on and
+ * stamped onto the created fact by a follow-up UPDATE (the stampFactScope
+ * idiom) — kept OUT of fn::resolve_fact so the resolver signature and its
+ * pinned invariants are untouched. Undefined ⇒ no stamp ⇒ byte-identical.
+ */
+interface LangAttributionMeta {
+  langConfidence: number;
+  langSource: 'detected' | 'inherited' | 'explicit';
+  detectorVersion: string;
+  /** Language of the SOURCE turn (distinct from the object's `lang`). */
+  sourceLang?: string | undefined;
 }
 
 /**
@@ -96,6 +112,16 @@ export class FactResolverService {
       predicateAlias?: string | undefined;
       /** The string form stored in `object` and used for locale detection. */
       object: string;
+      /**
+       * Language (ISO 639-1) of the SOURCE message/turn this fact was
+       * extracted from, when the caller knows it. Under
+       * MULTILINGUAL_LANG_ATTRIBUTION it is (a) stamped as `sourceLang`
+       * (distinct from the object's own `lang`) and (b) inherited onto a
+       * short / stopword-less object whose own language can't be detected
+       * (recorded as langSource='inherited'). Absent ⇒ no inheritance and
+       * no sourceLang stamp — byte-identical.
+       */
+      sourceLang?: string | undefined;
       objectMeta?: object | undefined;
       /** Exact text to embed; defaults to `${predicate}: ${object}`. */
       embeddingText?: string | undefined;
@@ -209,9 +235,57 @@ export class FactResolverService {
   ): Promise<Parameters<FactResolverService['resolveFactCall']>[1]> {
     const policy = this.predicateRegistry.policyFor(p.companyId, p.predicate);
     const sourceTrust = sourceTrustFor(p.source as Parameters<typeof sourceTrustFor>[0]);
-    const detLang = detectLanguage(p.object);
-    const lang = detLang.language !== 'und' ? detLang.language : undefined;
-    const script = detLang.language !== 'und' ? detLang.script : undefined;
+    // Confidence-aware attribution (MULTILINGUAL_LANG_ATTRIBUTION, default
+    // off). Off → detectLanguage keeps its Phase-4 `en` fallback and no new
+    // metadata is built, so `lang`/`script` and the whole call are
+    // byte-identical to today. On → the detector returns `und` for
+    // short/stopword-less objects and we record confidence + source, and
+    // inherit the source-turn language onto an undetectable object.
+    const attribution = envFlagEnabled(process.env.MULTILINGUAL_LANG_ATTRIBUTION);
+    const detLang = detectLanguage(p.object, attribution);
+    let lang: string | undefined = detLang.language !== 'und' ? detLang.language : undefined;
+    // Script is only ever the detected script — an inherited lang leaves it
+    // NONE (the source turn's script isn't carried on the fact input).
+    const script: string | undefined = detLang.language !== 'und' ? detLang.script : undefined;
+    let langMeta: LangAttributionMeta | undefined;
+    if (attribution) {
+      if (lang) {
+        langMeta = {
+          langConfidence: detLang.confidence,
+          langSource: 'detected',
+          detectorVersion: detLang.detectorVersion,
+          sourceLang: p.sourceLang,
+        };
+      } else if (p.sourceLang) {
+        // Undetectable object (short / stopword-less / numeric): inherit
+        // the source-message language as the contentLang — justified only
+        // because the object carries no signal of its own. Recorded as
+        // 'inherited'; script stays unknown (left NONE).
+        lang = p.sourceLang;
+        langMeta = {
+          langConfidence: detLang.confidence,
+          langSource: 'inherited',
+          detectorVersion: detLang.detectorVersion,
+          sourceLang: p.sourceLang,
+        };
+      } else {
+        // Undetermined and nothing to inherit — record the low-confidence
+        // `und` decision; `lang` stays NONE.
+        langMeta = {
+          langConfidence: detLang.confidence,
+          langSource: 'detected',
+          detectorVersion: detLang.detectorVersion,
+          sourceLang: undefined,
+        };
+      }
+      // Behaviour-neutral distribution telemetry (surface = 'fact').
+      this.metrics?.recordLangAttribution({
+        lang: lang ?? 'und',
+        source: 'fact',
+        confidence: detLang.confidence,
+        detectorVersion: detLang.detectorVersion,
+      });
+    }
     const embedding =
       p.precomputedEmbedding ??
       (await this.factEmbedding.embed(p.embeddingText ?? `${p.predicate}: ${p.object}`));
@@ -231,6 +305,7 @@ export class FactResolverService {
       semantics: policy.semantics,
       lang,
       script,
+      langMeta,
       entropy: p.entropy,
       userId: p.userId,
       derivedVersion: p.derivedVersion,
@@ -296,6 +371,53 @@ export class FactResolverService {
   }
 
   /**
+   * Multilingual Tier 1 (0100): stamp confidence-aware attribution metadata
+   * onto the created fact rows via a follow-up UPDATE — the stampFactScope
+   * idiom, kept OUT of fn::resolve_fact so the resolver's pinned invariants
+   * are untouched. Only rows whose langMeta is set (attribution on) are
+   * touched, so with the flag off this is a no-op and ingest is
+   * byte-identical. Best-effort: a stamp failure WARNs and never fails the
+   * ingest (the `lang` column proper is already set by the resolver; these
+   * are supplementary provenance fields). `sourceLang` is written only when
+   * known — omitted, not NULLed, matching the omit-when-undefined idiom.
+   */
+  private async stampLangAttribution(
+    db: {
+      query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T>;
+    },
+    items: Array<{ factId: unknown; meta?: LangAttributionMeta | undefined }>,
+  ): Promise<void> {
+    const rows = items.filter(
+      (it): it is { factId: unknown; meta: LangAttributionMeta } =>
+        it.meta !== undefined && it.factId !== undefined && it.factId !== null,
+    );
+    if (rows.length === 0) return;
+    try {
+      for (const { factId, meta } of rows) {
+        const id = new StringRecordId(`knowledge_fact:${idTailOf(String(factId))}`);
+        const sets = [
+          'langConfidence = $langConfidence',
+          'langSource = $langSource',
+          'detectorVersion = $detectorVersion',
+        ];
+        const params: Record<string, unknown> = {
+          id,
+          langConfidence: meta.langConfidence,
+          langSource: meta.langSource,
+          detectorVersion: meta.detectorVersion,
+        };
+        if (meta.sourceLang !== undefined) {
+          sets.push('sourceLang = $sourceLang');
+          params.sourceLang = meta.sourceLang;
+        }
+        await db.query(`UPDATE $id SET ${sets.join(', ')}`, params);
+      }
+    } catch (e) {
+      this.logger.warn(`lang-attribution stamp failed (non-fatal): ${(e as Error).message}`);
+    }
+  }
+
+  /**
    * Resolve a set of append_only facts in ONE round-trip via the stored
    * `fn::resolve_facts` (migration 0071), which maps `fn::resolve_fact` over the
    * array server-side and returns the results in order. Safe without the resolve
@@ -355,6 +477,13 @@ export class FactResolverService {
     await this.stampFactScope(
       db,
       prepared.map((c, k) => ({ userId: c.userId, factId: out[k]?.factId })),
+    );
+    // Multilingual Tier 1: per-fact attribution stamp (0100). No-op for
+    // every fact whose langMeta is undefined (attribution off, or the
+    // derived-batch path which builds no attribution meta) — byte-identical.
+    await this.stampLangAttribution(
+      db,
+      prepared.map((c, k) => ({ factId: out[k]?.factId, meta: c.langMeta })),
     );
     return out;
   }
@@ -481,6 +610,9 @@ export class FactResolverService {
       semantics: string;
       lang?: string | undefined;
       script?: string | undefined;
+      /** Attribution metadata (0100), stamped by a follow-up UPDATE; not
+       *  passed to fn::resolve_fact. Undefined ⇒ no stamp. */
+      langMeta?: LangAttributionMeta | undefined;
       entropy?: number | undefined;
       userId?: string | undefined;
       derivedVersion?: string | undefined;
@@ -545,6 +677,9 @@ export class FactResolverService {
     // Outside the retry closure so a stamp hiccup never re-runs the
     // resolver (which would double-create the fact).
     await this.stampFactScope(db, [{ userId: p.userId, factId: r?.factId }]);
+    // Multilingual Tier 1: stamp attribution metadata (0100). No-op when
+    // langMeta is undefined (attribution off) — byte-identical.
+    await this.stampLangAttribution(db, [{ factId: r?.factId, meta: p.langMeta }]);
     return r;
   }
 

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -301,6 +301,34 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // Language-attribution distribution (multilingual Tier 1,
+  // MULTILINGUAL_LANG_ATTRIBUTION). One series per (detected language ×
+  // surface × detector version) — the Prometheus mirror of the Tier-0
+  // aggregator's byLanguage / bySource / byDetectorVersion rollups
+  // (test/eval/metrics/language-attribution.ts). Labels are bounded:
+  // ~13 languages (incl. 'und') × 4 surfaces × a small detector-version
+  // set; no companyId (unbounded cardinality, same rule as every other
+  // domain counter). Emitted ONLY while attribution is on — off = no
+  // series, byte-identical.
+  //   lang: en|ru|es|…|und   source: query|fact|answer|mention
+  readonly langAttribution = new Counter({
+    name: 'brain_lang_attribution_total',
+    help: 'Language-attribution decisions by detected language, surface, and detector version',
+    labelNames: ['lang', 'source', 'detectorVersion'] as const,
+    registers: [this.registry],
+  });
+
+  // Confidence distribution of the same decisions, per surface — supplies
+  // the aggregator's meanConfidence (via _sum/_count) and lowConfidenceRate
+  // (the cumulative bucket at the 0.7 threshold). Bounded to the 4 surfaces.
+  readonly langAttributionConfidence = new Histogram({
+    name: 'brain_lang_attribution_confidence',
+    help: 'Detector confidence of language-attribution decisions, by surface',
+    labelNames: ['source'] as const,
+    buckets: [0.1, 0.3, 0.5, 0.7, 0.9, 1],
+    registers: [this.registry],
+  });
+
   readonly retracts = new Counter({
     name: 'brain_retract_total',
     help: 'Number of fact retractions',
@@ -637,6 +665,31 @@ export class MetricsService implements OnModuleInit {
     outcome: 'suppressed' | 'no_model' | 'low_confidence' | 'floor_kept' | 'no_op',
   ): void {
     this.lensSuppressionCount.inc({ outcome } as LabelValues<'outcome'>);
+  }
+
+  /**
+   * Record one language-attribution decision (multilingual Tier 1). The
+   * argument is exactly the Tier-0 `LanguageAttributionSample` shape
+   * (src/eval/types.ts), so the emitted series roll up to the same
+   * distribution report the eval aggregator produces. Behaviour-neutral —
+   * callers invoke it only while MULTILINGUAL_LANG_ATTRIBUTION is on, so
+   * with the flag off nothing is emitted and serving is byte-identical.
+   */
+  recordLangAttribution(sample: {
+    lang: string;
+    source: 'query' | 'fact' | 'answer' | 'mention';
+    confidence: number;
+    detectorVersion: string;
+  }): void {
+    this.langAttribution.inc({
+      lang: sample.lang,
+      source: sample.source,
+      detectorVersion: sample.detectorVersion,
+    } as LabelValues<'lang' | 'source' | 'detectorVersion'>);
+    this.langAttributionConfidence.observe(
+      { source: sample.source } as LabelValues<'source'>,
+      sample.confidence,
+    );
   }
 
   countRetract(): void {

--- a/src/search/internals/legs.ts
+++ b/src/search/internals/legs.ts
@@ -82,7 +82,7 @@ export async function runVectorLeg({
       SELECT
         id, entityId, predicate, predicateAlias, object, confidence,
         validFrom, validUntil, recordedAt, retractedAt, status, source,
-        trustSnapshot, corroboration, userId,
+        trustSnapshot, corroboration, userId, lang,
         entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity,
         ${combinedGraphProjection(tuning.combinedVectorGraph, edgeFence)}
         vector::similarity::cosine(embedding, $q) AS simScore
@@ -126,7 +126,7 @@ async function runVectorLegKnn({
   const projection = `
         id, entityId, predicate, predicateAlias, object, confidence,
         validFrom, validUntil, recordedAt, retractedAt, status, source,
-        trustSnapshot, corroboration, userId,
+        trustSnapshot, corroboration, userId, lang,
         entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity`;
   // `<|K,EF|>` takes literals, not params — kOver/ef are validated ints.
   //
@@ -207,7 +207,7 @@ export async function runLexicalLeg({
       SELECT
         id, entityId, predicate, predicateAlias, object, confidence,
         validFrom, validUntil, recordedAt, retractedAt, status, source,
-        trustSnapshot, corroboration, userId,
+        trustSnapshot, corroboration, userId, lang,
         entityId.{id, type, canonicalName, externalRefs, mergedInto} AS entity,
         ${highlightProjection(tuning.highlightEnabled)}
         math::max([search::score(1), search::score(2)]) AS bm25Score

--- a/src/search/internals/scoring.ts
+++ b/src/search/internals/scoring.ts
@@ -112,7 +112,26 @@ export interface ScoreRowsOptions {
    * Defaults to USAGE_SATURATION_DEFAULT.
    */
   usageSaturation?: number;
+  /**
+   * Multilingual Tier 1 same-language boost (MULTILINGUAL_SOFT_LANG_FILTER
+   * + high query-lang confidence). When set, a row whose `lang` equals
+   * `langBoost.lang` is multiplied by `1 + (beta ?? LANG_BOOST_BETA)` — a
+   * pure ranking signal that REPLACES the hard same-language WHERE filter
+   * (the exclusion is dropped in the where-builder under the same gate).
+   * Null/undefined, a row without `lang`, or a different language → factor
+   * exactly 1.0 → byte-identical ranking. Rows with `lang IS NONE`
+   * (pre-Phase-4) are never boosted, so they are neither hidden nor
+   * artificially demoted below a same-language match.
+   */
+  langBoost?: { lang: string; beta?: number } | null;
 }
+
+/**
+ * Default multiplicative strength of the same-language boost — a gentle
+ * nudge (matches the trust/usage β convention: a ranking tilt, never a
+ * gate). Module-private: not a tunable knob in Tier 1.
+ */
+const LANG_BOOST_BETA = 0.15;
 
 /**
  * Default readCount at which the usage squash saturates (~1.0). A read
@@ -245,7 +264,23 @@ export function scoreRows({
   salienceScoring = false,
   usageBeta = 0,
   usageSaturation = USAGE_SATURATION_DEFAULT,
+  langBoost = null,
 }: ScoreRowsOptions): ScoredRow[] {
+  // Multilingual Tier 1 same-language factor: `1 + β` when the row's stored
+  // content language matches the (high-confidence) query language; 1.0
+  // otherwise, for a langless row, or when the boost is off. Returns the
+  // breakdown fragment alongside (empty when the factor is 1.0) so the
+  // per-row map arrow stays under the complexity gate — the usageFactorFor
+  // shape.
+  const langFactorFor = (
+    rowLang: unknown,
+  ): { langFactor: number; langBreakdown: { langBoost: number } | object } => {
+    const langFactor =
+      langBoost && typeof rowLang === 'string' && rowLang === langBoost.lang
+        ? 1 + (langBoost.beta ?? LANG_BOOST_BETA)
+        : 1;
+    return { langFactor, langBreakdown: langFactor !== 1 ? { langBoost: langFactor } : {} };
+  };
   const salienceFactorFor = (source: unknown): number => {
     if (!salienceScoring) return 1;
     const s = (source as { salience?: unknown } | null)?.salience;
@@ -324,6 +359,7 @@ export function scoreRows({
     // strength gate. Either off, or a fact search never surfaced → 1.0 →
     // byte-identical ranking.
     const { usageFactor, usageBreakdown } = usageFactorFor(row, usageBeta, usageSaturation);
+    const { langFactor, langBreakdown } = langFactorFor(row.lang);
     const finalScore =
       row.fusedScore *
       decay *
@@ -335,7 +371,8 @@ export function scoreRows({
       temporalOverlap *
       timeRange *
       salienceFactor *
-      usageFactor;
+      usageFactor *
+      langFactor;
     return {
       row,
       score: finalScore,
@@ -348,6 +385,7 @@ export function scoreRows({
         ...(temporalOverlap !== 1 ? { temporalOverlap } : {}),
         ...(timeRange !== 1 ? { timeRange } : {}),
         ...(salienceFactor !== 1 ? { salience: salienceFactor } : {}),
+        ...langBreakdown,
         ...usageBreakdown,
         factTrust,
         finalScore,

--- a/src/search/internals/types.ts
+++ b/src/search/internals/types.ts
@@ -31,6 +31,14 @@ export interface FactRow {
   predicateAlias?: string;
   object: string;
   confidence: number;
+  /**
+   * Stored content language (ISO 639-1) of the `object`, migration 0020;
+   * projected by the vector + lexical legs so the multilingual Tier-1
+   * same-language ranking boost (scoreRows langBoost) can read it. Absent /
+   * NONE on pre-Phase-4 rows and on legs that don't project it (segment /
+   * insight / graph) — the boost simply never fires for those (factor 1.0).
+   */
+  lang?: string | null;
   validFrom: string;
   validUntil?: string;
   recordedAt: string;
@@ -156,6 +164,13 @@ export interface ScoreBreakdown {
    * period parsed, or the filter is off.
    */
   timeRange?: number;
+  /**
+   * Multilingual Tier 1 same-language ranking boost (`1 + β`) applied when
+   * MULTILINGUAL_SOFT_LANG_FILTER is on with a high-confidence query
+   * language and the fact's `lang` matches it. Omitted when 1.0 — the flag
+   * is off, the languages differ, or the row carries no `lang`.
+   */
+  langBoost?: number;
   /**
    * V8 §4 importance factor from the deriver-stamped source.salience
    * (profile salienceScoring). Omitted when 1.0 — scoring off, an

--- a/src/search/internals/where-builder.ts
+++ b/src/search/internals/where-builder.ts
@@ -21,6 +21,17 @@ export interface BaseWhereOptions {
    * avoids regressing recall while the corpus catches up).
    */
   langFilter?: string | undefined;
+  /**
+   * Multilingual Tier 1 (MULTILINGUAL_SOFT_LANG_FILTER + high query-lang
+   * confidence). When true the hard same-language EXCLUSION below is
+   * DROPPED — other-language rows survive retrieval — and the same-language
+   * preference becomes a RANKING boost applied downstream in the scoring
+   * stage (scoreRows langBoost) instead of an exclusion. Off/undefined ⇒
+   * the hard filter is emitted exactly as today (byte-identical). The
+   * caller (search.service) decides the mode: soft flag on AND the query
+   * language was detected with high confidence.
+   */
+  langBoost?: boolean | undefined;
 }
 
 export interface BuildBaseWhereOptions {
@@ -144,11 +155,16 @@ export function buildBaseWhere({
       return new StringRecordId(`knowledge_entity:${id}`);
     });
   }
-  if (opts.langFilter && !dto.disableLangFilter) {
+  if (opts.langFilter && !dto.disableLangFilter && !opts.langBoost) {
     // Pre-Phase-4 facts have lang IS NONE — keep them visible so
     // back-filling the corpus is a soft migration, not a recall
     // cliff. Recall-critical callers can disable via
     // `disableLangFilter: true`.
+    //
+    // Multilingual Tier 1: under langBoost (MULTILINGUAL_SOFT_LANG_FILTER
+    // + high query-lang confidence) this hard exclusion is SKIPPED — the
+    // same-language preference is applied as a ranking boost in scoring,
+    // never as a filter, so a cross-lingual answer is demoted, not hidden.
     clauses.push(`AND (lang = $langFilter OR lang IS NONE)`);
     params.langFilter = opts.langFilter;
   }

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -900,6 +900,18 @@ export interface SearchTuning {
   hnswOverfetch: number;
   highlightEnabled: boolean;
   edgeExpansion: ExpansionConfig;
+  /**
+   * Multilingual Tier 1. `softLangFilter` (MULTILINGUAL_SOFT_LANG_FILTER)
+   * turns the hard same-language WHERE exclusion into a confidence-gated
+   * ranking boost — the where-builder drops the exclusion and scoreRows
+   * applies the same-language factor, but ONLY when the query language was
+   * detected with high confidence (search.service gates on it).
+   * `langAttribution` (MULTILINGUAL_LANG_ATTRIBUTION) mirrors the detector
+   * flag so the search path can emit query-surface attribution telemetry
+   * only when attribution is on. Both default off ⇒ byte-identical.
+   */
+  softLangFilter: boolean;
+  langAttribution: boolean;
 }
 
 function tuningInt(env: NodeJS.ProcessEnv, name: string, fallback: number): number {
@@ -955,5 +967,7 @@ export function resolveSearchTuning(env: NodeJS.ProcessEnv = process.env): Searc
     hnswOverfetch: tuningInt(env, 'SEARCH_HNSW_OVERFETCH', 4),
     highlightEnabled: envFlagEnabled(env.SEARCH_HIGHLIGHT_ENABLED),
     edgeExpansion: resolveExpansionConfig(env),
+    softLangFilter: envFlagEnabled(env.MULTILINGUAL_SOFT_LANG_FILTER),
+    langAttribution: envFlagEnabled(env.MULTILINGUAL_LANG_ATTRIBUTION),
   };
 }

--- a/src/search/search-retrieval.service.ts
+++ b/src/search/search-retrieval.service.ts
@@ -213,6 +213,12 @@ export class SearchRetrievalService {
        * timeFilter). Null/omitted → factor 1.0, byte-identical.
        */
       queryRange?: QueryTimeRange | null;
+      /**
+       * Multilingual Tier 1 same-language boost (MULTILINGUAL_SOFT_LANG_FILTER
+       * + high query-lang confidence). Null/omitted → factor 1.0,
+       * byte-identical ranking.
+       */
+      langBoost?: { lang: string } | null;
     },
   ): Map<string, EntityBucket> {
     const tuning = opts?.tuning ?? resolveSearchTuning();
@@ -235,6 +241,7 @@ export class SearchRetrievalService {
       // unattached readCount.
       usageBeta: tuning.usageRanking ? tuning.usageBeta : 0,
       usageSaturation: tuning.usageSaturation,
+      langBoost: opts?.langBoost ?? null,
     });
     return bucketByEntity(scored);
   }

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -2,7 +2,8 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Surreal } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
-import { detectLanguage } from '../ai/locale/language-detector';
+import { detectLanguage, DETECTOR_VERSION } from '../ai/locale/language-detector';
+import { MetricsService } from '../metrics/metrics.service';
 import { SearchDto, SearchMode } from './dto/search.dto';
 import { withSpan } from '../common/tracing';
 import { clampLlmInputText } from '../common/input-limits';
@@ -74,6 +75,16 @@ interface StagedPipeline {
   neighboursByEntity: Map<string, Neighbour[]>;
 }
 
+/**
+ * Query-language confidence floor for the multilingual Tier-1 soft boost
+ * (MULTILINGUAL_SOFT_LANG_FILTER). At/above it the detected query language
+ * is trusted enough to tilt ranking toward same-language facts; below it
+ * the boost is withheld (no exclusion either — soft mode never filters).
+ * An explicit dto.queryLang is treated as confidence 1, so it always
+ * clears the floor. Module-private (not a tunable knob in Tier 1).
+ */
+const LANG_QUERY_HIGH_CONFIDENCE = 0.5;
+
 @Injectable()
 export class SearchService {
   private readonly logger = new Logger(SearchService.name);
@@ -93,6 +104,11 @@ export class SearchService {
     // Sixth: the per-tenant derived-world pin (audit W2). Optional so
     // positionally-constructed unit tests fall back to the env default.
     @Optional() private readonly readPin?: ReadPinService,
+    // Seventh: metrics sink for multilingual Tier-1 query-surface
+    // attribution telemetry (behaviour-neutral; emitted only when
+    // MULTILINGUAL_LANG_ATTRIBUTION is on). Optional so positional unit
+    // constructions omit it.
+    @Optional() private readonly metrics?: MetricsService,
   ) {}
 
   /**
@@ -114,17 +130,56 @@ export class SearchService {
   }
 
   /**
-   * Resolve the lang code to push into the WHERE builder. Honour an
-   * explicit dto.queryLang first; otherwise run the pure detector on
-   * the query text. Returns undefined when detection is `und` or the
-   * caller opted out via dto.disableLangFilter, so callers downstream
-   * fall back to the single-pass behaviour.
+   * Resolve the query-language signal — the code AND the detector's
+   * confidence — that drives the locale WHERE filter and the multilingual
+   * Tier-1 soft boost. Honour an explicit dto.queryLang first (treated as
+   * fully confident); otherwise run the pure detector on the query text.
+   * Returns undefined when detection is `und` or the caller opted out via
+   * dto.disableLangFilter, so callers fall back to the single-pass, no-lang
+   * behaviour. The confidence is what MULTILINGUAL_SOFT_LANG_FILTER gates
+   * on: the same-language boost only fires for a high-confidence query
+   * language (a bare `en` fallback carries confidence 0 and never boosts).
    */
-  private resolveLangFilter(dto: SearchDto): string | undefined {
+  private resolveLangSignal(dto: SearchDto): { lang: string; confidence: number } | undefined {
     if (dto.disableLangFilter) return undefined;
-    if (dto.queryLang) return dto.queryLang;
+    if (dto.queryLang) return { lang: dto.queryLang, confidence: 1 };
     const detected = detectLanguage(dto.query);
-    return detected.language === 'und' ? undefined : detected.language;
+    return detected.language === 'und'
+      ? undefined
+      : { lang: detected.language, confidence: detected.confidence };
+  }
+
+  /**
+   * Multilingual Tier 1 read-mode for one request. Resolves the query
+   * language, decides whether MULTILINGUAL_SOFT_LANG_FILTER's boost applies
+   * (soft flag on AND high-confidence query language), and emits the
+   * behaviour-neutral query-surface attribution telemetry (only when
+   * MULTILINGUAL_LANG_ATTRIBUTION is on). Both flags off ⇒ `softBoost`
+   * false, no telemetry ⇒ byte-identical. Extracted from runDbStages to
+   * hold that method under the complexity gate.
+   */
+  private resolveLangMode(ctx: PipelineContext): {
+    langFilter: string | undefined;
+    softBoost: boolean;
+  } {
+    const langSignal = this.resolveLangSignal(ctx.dto);
+    // The boost turns the hard same-language exclusion into a ranking
+    // signal (the where-builder drops the exclusion; scoreRows demotes
+    // cross-lingual rows) — but only for a confidently-detected query
+    // language; below the floor there is neither an exclusion nor a boost.
+    const softBoost =
+      ctx.tuning.softLangFilter &&
+      langSignal !== undefined &&
+      langSignal.confidence >= LANG_QUERY_HIGH_CONFIDENCE;
+    if (ctx.tuning.langAttribution && langSignal) {
+      this.metrics?.recordLangAttribution({
+        lang: langSignal.lang,
+        source: 'query',
+        confidence: langSignal.confidence,
+        detectorVersion: DETECTOR_VERSION,
+      });
+    }
+    return { langFilter: langSignal?.lang, softBoost };
   }
 
   /**
@@ -355,7 +410,7 @@ export class SearchService {
     // (or honour the explicit dto.queryLang) and apply a two-pass
     // filter → cross-lingual backoff strategy. `und` or disabled →
     // single-pass exactly as before.
-    const langFilter = this.resolveLangFilter(ctx.dto);
+    const { langFilter, softBoost } = this.resolveLangMode(ctx);
     const baseWhere = buildBaseWhere({
       dto: ctx.dto,
       asOf: ctx.asOf,
@@ -364,7 +419,7 @@ export class SearchService {
       derivedVersion: ctx.derivedVersion,
       temporalMode: ctx.profile.temporalMode,
       excludeInsightRows: ctx.profile.insightEvidence !== 'off',
-      opts: { langFilter },
+      opts: { langFilter, langBoost: softBoost },
     });
     traceArtifact('search.query', {
       query: ctx.dto.query,
@@ -375,8 +430,11 @@ export class SearchService {
     });
 
     // 1. Retrieval legs (parallel) + fusion, with cross-lingual backoff.
+    // The backoff only exists to recover recall lost to the HARD lang
+    // exclusion; under softBoost there is no exclusion (other-language
+    // rows are already retrieved and merely down-ranked), so skip it.
     const fused = await this.retrieval.runRetrievalStage(db, ctx, baseWhere);
-    if (langFilter && fused.length < ctx.candidateK / 2) {
+    if (langFilter && !softBoost && fused.length < ctx.candidateK / 2) {
       // Capture the first-pass size BEFORE the merge loop mutates `fused`.
       const firstPassCount = fused.length;
       const fallbackWhere = buildBaseWhere({
@@ -487,6 +545,9 @@ export class SearchService {
       tuning: ctx.tuning,
       salienceScoring: ctx.profile.salienceScoring,
       queryRange: ctx.queryRange ?? null,
+      // Multilingual Tier 1: same-language ranking boost, only in softBoost
+      // mode (soft flag on + high-confidence query language). Null → 1.0.
+      langBoost: softBoost && langFilter ? { lang: langFilter } : null,
     });
 
     // 5. Edge expansion (default ON) — graph-walk from top seeds. When the

--- a/src/users/user-profile.service.ts
+++ b/src/users/user-profile.service.ts
@@ -3,6 +3,7 @@ import { SurrealService } from '../db/surreal.service';
 import { ReadPinService, derivedVersionFence } from '../episodes/read-pin.service';
 import { makeRowPolicyFilter, type PolicyFilterableRow } from '../policy/row-filter';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
+import { envFlagEnabled } from '../common/env-validation';
 import {
   PER_ASPECT_CAP,
   type ProfileFactWire,
@@ -192,10 +193,24 @@ export class UserProfileService {
       fetchCap: FETCH_CAP,
       ...fence.params,
     };
+    // Multilingual Tier 1: MULTILINGUAL_SOFT_LANG_FILTER turns the hard
+    // same-language exclusion into a RANKING preference. The caller-supplied
+    // `lang` is an explicit, high-confidence intent, so no separate
+    // confidence gate is applied here (unlike the detected-query search
+    // path). Off (default) → the byte-identical hard filter.
+    let langOrderPrefix = '';
     if (lang) {
-      // Locale filter, soft on unstamped rows (the where-builder idiom).
-      clauses.push(`(lang = $langFilter OR lang IS NONE)`);
-      params.langFilter = lang;
+      if (envFlagEnabled(process.env.MULTILINGUAL_SOFT_LANG_FILTER)) {
+        // Drop the exclusion; prefer same-language facts in the fetch order
+        // (a ranking signal within the FETCH_CAP, never an exclusion) so a
+        // cross-lingual fact is demoted, not hidden.
+        langOrderPrefix = '(lang = $langFilter) DESC, ';
+        params.langFilter = lang;
+      } else {
+        // Locale filter, soft on unstamped rows (the where-builder idiom).
+        clauses.push(`(lang = $langFilter OR lang IS NONE)`);
+        params.langFilter = lang;
+      }
     }
 
     // Predicate scope-fence (the PII gate) + ABAC row verdict — the
@@ -211,7 +226,7 @@ export class UserProfileService {
         `SELECT ${PROFILE_PROJECTION}
              FROM knowledge_fact
             WHERE ${clauses.join('\n              AND ')}
-            ORDER BY validFrom DESC, id ASC
+            ORDER BY ${langOrderPrefix}validFrom DESC, id ASC
             LIMIT $fetchCap`,
         params,
       );

--- a/test/multilingual-lang-attribution.unit-spec.ts
+++ b/test/multilingual-lang-attribution.unit-spec.ts
@@ -1,0 +1,302 @@
+/**
+ * Multilingual Tier 1 — confidence-aware language attribution +
+ * soft same-language boost. BOTH behaviours sit behind default-off flags
+ * (MULTILINGUAL_LANG_ATTRIBUTION, MULTILINGUAL_SOFT_LANG_FILTER); with both
+ * off the detector, the scorer, the where-builder, the user-profile SQL and
+ * the resolver are byte-identical to today — the guardrail these gates pin.
+ */
+import { detectLanguage, DETECTOR_VERSION } from '../src/ai/locale/language-detector';
+import { scoreRows } from '../src/search/internals/scoring';
+import type { FusedRow } from '../src/search/internals/types';
+import { buildBaseWhere } from '../src/search/internals/where-builder';
+import type { SearchDto } from '../src/search/dto/search.dto';
+import { resolveSearchTuning } from '../src/search/retrieval-profile';
+import { MetricsService } from '../src/metrics/metrics.service';
+import { FactResolverService } from '../src/ingest/fact-resolver.service';
+
+const ATTR = 'MULTILINGUAL_LANG_ATTRIBUTION';
+const SOFT = 'MULTILINGUAL_SOFT_LANG_FILTER';
+
+function withEnv(key: string, value: string | undefined, fn: () => void): void {
+  const saved = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  try {
+    fn();
+  } finally {
+    if (saved === undefined) delete process.env[key];
+    else process.env[key] = saved;
+  }
+}
+
+// ── Detector ───────────────────────────────────────────────────────────
+
+describe('detectLanguage — confidence-aware attribution', () => {
+  it('every result carries the detector version constant', () => {
+    expect(detectLanguage('The cat sat on the mat.').detectorVersion).toBe(DETECTOR_VERSION);
+    expect(detectLanguage('').detectorVersion).toBe(DETECTOR_VERSION);
+    expect(detectLanguage('Мария — директор.').detectorVersion).toBe(DETECTOR_VERSION);
+  });
+
+  it('OFF (explicit) → the Phase-4 `en` fallback for stopword-less input', () => {
+    // Short / stopword-less Latin token: no language signal, historic
+    // behaviour defaults to English.
+    expect(detectLanguage('OK', false).language).toBe('en');
+    expect(detectLanguage('Acme Corp', false).language).toBe('en');
+  });
+
+  it('ON (explicit) → `und` (not `en`) for short / stopword-less / numeric', () => {
+    expect(detectLanguage('OK', true).language).toBe('und');
+    expect(detectLanguage('Acme Corp', true).language).toBe('und');
+    // Numeric-only is already `und` under both modes (no letters tokenised).
+    expect(detectLanguage('12345', true).language).toBe('und');
+    expect(detectLanguage('12345', false).language).toBe('und');
+  });
+
+  it('ON keeps a real stopword-bearing sentence classified with confidence', () => {
+    const r = detectLanguage('The quick brown fox jumps over the lazy dog.', true);
+    expect(r.language).toBe('en');
+    expect(r.confidence).toBeGreaterThan(0);
+    // Non-Latin scripts are unaffected by the Latin-path attribution gate.
+    expect(detectLanguage('Мария работает CTO в Acme.', true).language).toBe('ru');
+  });
+
+  it('reads the env flag when no explicit mode is given (off-path byte-identical)', () => {
+    withEnv(ATTR, undefined, () => expect(detectLanguage('OK').language).toBe('en'));
+    withEnv(ATTR, '1', () => expect(detectLanguage('OK').language).toBe('und'));
+    withEnv(ATTR, '0', () => expect(detectLanguage('OK').language).toBe('en'));
+  });
+});
+
+// ── Scoring boost ──────────────────────────────────────────────────────
+
+function fused(lang: string | null): FusedRow {
+  return {
+    id: 'knowledge_fact:x',
+    entityId: 'knowledge_entity:e',
+    predicate: 'work',
+    object: 'test',
+    confidence: 1,
+    lang,
+    validFrom: '2026-01-01T00:00:00Z',
+    recordedAt: '2026-01-15T00:00:00Z',
+    status: 'active',
+    source: {},
+    fusedScore: 1,
+  } as FusedRow;
+}
+
+describe('scoreRows — same-language boost', () => {
+  const now = Date.parse('2026-02-01T00:00:00Z');
+  const score = (lang: string | null, boost: { lang: string } | null): number =>
+    scoreRows({ rows: [fused(lang)], now, langBoost: boost })[0]!.score;
+
+  it('off (langBoost null) → factor exactly 1.0 regardless of row lang', () => {
+    expect(score('en', null)).toBeCloseTo(score('ru', null), 12);
+    expect(score(null, null)).toBeCloseTo(score('en', null), 12);
+  });
+
+  it('on + matching language → gentle multiplicative boost (> baseline)', () => {
+    const baseline = score('en', null);
+    expect(score('en', { lang: 'en' })).toBeCloseTo(baseline * 1.15, 12);
+  });
+
+  it('on + mismatched language or langless row → factor 1.0 (demote, never drop)', () => {
+    const baseline = score('en', null);
+    expect(score('ru', { lang: 'en' })).toBeCloseTo(baseline, 12);
+    expect(score(null, { lang: 'en' })).toBeCloseTo(baseline, 12);
+  });
+
+  it('surfaces the factor in the breakdown only when it bites', () => {
+    const scored = scoreRows({
+      rows: [fused('en'), fused('ru')],
+      now,
+      langBoost: { lang: 'en' },
+    });
+    expect(scored[0]!.breakdown.langBoost).toBeCloseTo(1.15, 12);
+    expect('langBoost' in scored[1]!.breakdown).toBe(false);
+  });
+});
+
+// ── where-builder ──────────────────────────────────────────────────────
+
+const dto = (extra: Partial<SearchDto> = {}): SearchDto => ({ query: 'x', ...extra }) as SearchDto;
+
+describe('buildBaseWhere — soft same-language filter', () => {
+  const base = {
+    dto: dto(),
+    asOf: null,
+    includeRetracted: false,
+    includeContested: false,
+  } as const;
+
+  it('OFF-path is byte-identical: the hard lang exclusion is emitted', () => {
+    const { sql, params } = buildBaseWhere({ ...base, opts: { langFilter: 'en' } });
+    expect(sql).toContain('AND (lang = $langFilter OR lang IS NONE)');
+    expect(params.langFilter).toBe('en');
+  });
+
+  it('langBoost drops the exclusion entirely (ranking signal, not a filter)', () => {
+    const { sql, params } = buildBaseWhere({
+      ...base,
+      opts: { langFilter: 'en', langBoost: true },
+    });
+    expect(sql).not.toContain('lang = $langFilter');
+    expect(params.langFilter).toBeUndefined();
+  });
+
+  it('the rest of the WHERE is unchanged whether or not the exclusion is present', () => {
+    const withFilter = buildBaseWhere({ ...base, opts: { langFilter: 'en' } }).sql;
+    const boosted = buildBaseWhere({ ...base, opts: { langFilter: 'en', langBoost: true } }).sql;
+    // The only difference is the single lang clause line.
+    const strip = (s: string): string =>
+      s
+        .split('\n')
+        .filter((l) => !l.includes('lang = $langFilter'))
+        .join('\n');
+    expect(strip(withFilter)).toBe(strip(boosted));
+  });
+});
+
+// ── Tuning plumbing ────────────────────────────────────────────────────
+
+describe('resolveSearchTuning — multilingual flags', () => {
+  it('both default off', () => {
+    const t = resolveSearchTuning({} as NodeJS.ProcessEnv);
+    expect(t.softLangFilter).toBe(false);
+    expect(t.langAttribution).toBe(false);
+  });
+
+  it('resolve to true when set', () => {
+    const t = resolveSearchTuning({
+      [SOFT]: '1',
+      [ATTR]: 'true',
+    } as unknown as NodeJS.ProcessEnv);
+    expect(t.softLangFilter).toBe(true);
+    expect(t.langAttribution).toBe(true);
+  });
+});
+
+// ── Telemetry ──────────────────────────────────────────────────────────
+
+describe('MetricsService.recordLangAttribution', () => {
+  it('emits the labelled counter and the per-surface confidence histogram', async () => {
+    const metrics = new MetricsService();
+    metrics.recordLangAttribution({
+      lang: 'ru',
+      source: 'fact',
+      confidence: 0.9,
+      detectorVersion: DETECTOR_VERSION,
+    });
+    metrics.recordLangAttribution({
+      lang: 'en',
+      source: 'query',
+      confidence: 0.4,
+      detectorVersion: DETECTOR_VERSION,
+    });
+    const { body } = await metrics.serialize();
+    expect(body).toMatch(
+      new RegExp(
+        `brain_lang_attribution_total\\{lang="ru",source="fact",detectorVersion="${DETECTOR_VERSION}"\\} 1`,
+      ),
+    );
+    expect(body).toContain('brain_lang_attribution_confidence_count{source="fact"} 1');
+    expect(body).toContain('brain_lang_attribution_confidence_count{source="query"} 1');
+  });
+});
+
+// ── Resolver stamping ──────────────────────────────────────────────────
+
+describe('FactResolverService — attribution stamp', () => {
+  function make(metrics?: MetricsService) {
+    const queries: Array<{ sql: string; params: Record<string, unknown> }> = [];
+    const db = {
+      query: jest.fn(async (sql: string, params: Record<string, unknown>) => {
+        queries.push({ sql, params });
+        if (sql.includes('fn::resolve_fact(')) {
+          return [{ factId: 'knowledge_fact:x1', outcome: 'INSERTED' }];
+        }
+        return [];
+      }),
+    };
+    const factEmbedding = { embed: jest.fn(async () => [0.1]) };
+    const predicateRegistry = {
+      getSnapshot: jest.fn(async () => ({})),
+      policyFor: jest.fn(() => ({ semantics: 'append_only' })),
+    };
+    const svc = new FactResolverService(
+      factEmbedding as never,
+      predicateRegistry as never,
+      metrics,
+    );
+    return { svc, db, queries };
+  }
+
+  const input = (object: string, sourceLang?: string) => ({
+    companyId: 'c',
+    entityId: 'knowledge_entity:e1',
+    predicate: 'preference',
+    object,
+    ...(sourceLang ? { sourceLang } : {}),
+    confidence: 0.9,
+    validFrom: new Date('2026-01-01T00:00:00Z'),
+    source: {},
+    precomputedEmbedding: [0.1],
+  });
+
+  const factCall = (qs: Array<{ sql: string; params: Record<string, unknown> }>) =>
+    qs.find((q) => q.sql.includes('fn::resolve_fact('));
+  const stampCall = (qs: Array<{ sql: string; params: Record<string, unknown> }>) =>
+    qs.find((q) => q.sql.includes('langSource ='));
+
+  it('OFF → Phase-4 `en` lang, and no attribution UPDATE (byte-identical)', async () => {
+    await withEnvAsync(ATTR, undefined, async () => {
+      const { svc, db, queries } = make();
+      await svc.resolve(db as never, input('OK', 'ru'));
+      expect(factCall(queries)!.params.lang).toBe('en');
+      expect(stampCall(queries)).toBeUndefined();
+    });
+  });
+
+  it('ON + detectable object → langSource="detected"', async () => {
+    await withEnvAsync(ATTR, '1', async () => {
+      const { svc, db, queries } = make();
+      await svc.resolve(db as never, input('The quick brown fox jumps over the lazy dog'));
+      expect(factCall(queries)!.params.lang).toBe('en');
+      const stamp = stampCall(queries)!;
+      expect(stamp.params.langSource).toBe('detected');
+      expect(stamp.params.detectorVersion).toBe(DETECTOR_VERSION);
+    });
+  });
+
+  it('ON + undetectable object + known sourceLang → inherit it, langSource="inherited"', async () => {
+    await withEnvAsync(ATTR, '1', async () => {
+      const metrics = new MetricsService();
+      const { svc, db, queries } = make(metrics);
+      await svc.resolve(db as never, input('OK', 'ru'));
+      // The short object inherits the source-turn language as its contentLang.
+      expect(factCall(queries)!.params.lang).toBe('ru');
+      const stamp = stampCall(queries)!;
+      expect(stamp.params.langSource).toBe('inherited');
+      expect(stamp.params.sourceLang).toBe('ru');
+      const { body } = await metrics.serialize();
+      expect(body).toContain('source="fact"');
+    });
+  });
+});
+
+async function withEnvAsync(
+  key: string,
+  value: string | undefined,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const saved = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  try {
+    await fn();
+  } finally {
+    if (saved === undefined) delete process.env[key];
+    else process.env[key] = saved;
+  }
+}

--- a/test/user-profile.unit-spec.ts
+++ b/test/user-profile.unit-spec.ts
@@ -132,6 +132,26 @@ describe('UserProfileService — SQL contract', () => {
     await svc2.getProfile({ ...baseOpts });
     expect(capture2[0]!.sql).not.toContain('langFilter');
   });
+
+  it('MULTILINGUAL_SOFT_LANG_FILTER → drops the hard exclusion, orders by lang-match', async () => {
+    const FLAG = 'MULTILINGUAL_SOFT_LANG_FILTER';
+    const saved = process.env[FLAG];
+    process.env[FLAG] = '1';
+    try {
+      const capture: Capture[] = [];
+      const svc = makeService({ rows: [], capture, readPin: null });
+      await svc.getProfile({ ...baseOpts, lang: 'en' });
+      const { sql, params } = capture[0]!;
+      // Soft mode: no WHERE exclusion — the language becomes a ranking
+      // preference in the fetch order (same-language first), never a filter.
+      expect(sql).not.toContain('lang = $langFilter OR lang IS NONE');
+      expect(sql).toContain('ORDER BY (lang = $langFilter) DESC, validFrom DESC, id ASC');
+      expect(params?.langFilter).toBe('en');
+    } finally {
+      if (saved === undefined) delete process.env[FLAG];
+      else process.env[FLAG] = saved;
+    }
+  });
 });
 
 describe('UserProfileService — assembly', () => {


### PR DESCRIPTION
## Multilingual program — Tier 1: confidence-aware language attribution + soft same-language boost

Second tier of the multilingual roadmap. **Two default-off flags; prod byte-identical when both off** (proven by off-path tests). Fixes the Gap 0 / Gap 1 correctness bugs the review flagged.

### `MULTILINGUAL_LANG_ATTRIBUTION` (default off)
- The detector (`language-detector.ts`) returns **`und` (not `en`) for short/stopword-less/numeric Latin input**, and `DetectedLanguage` now carries a real `confidence` + a `DETECTOR_VERSION` constant. Gated at call time (`detectLanguage(text, attribution = attributionEnabled())`) — **OFF is byte-identical to today's `en` fallback**; a caller can force the mode for tests.
- `fact-resolver` stamps `langConfidence` / `langSource` (`detected|inherited|explicit`) / `detectorVersion` / `sourceLang` via a follow-up `UPDATE` (the existing `stampFactScope` idiom — **`fn::resolve_fact` and its pinned invariants are untouched**), inheriting the source-turn language onto an undetectable short object.
- Prometheus `brain_lang_attribution_total{lang,source,detectorVersion}` + `_confidence` histogram, matching the Tier-0 aggregator shape; emitted only while attribution is on.

### `MULTILINGUAL_SOFT_LANG_FILTER` (default off)
- At **both** read sites the hard `AND (lang = $q OR lang IS NONE)` exclusion becomes a same-language **ranking boost** — cross-lingual facts are demoted, never hidden:
  - `search` / `where-builder.ts:147` drops the WHERE clause + backoff and applies a `1+β` (β=0.15) scoring factor in `scoring.ts`, **gated on high query-lang confidence** (threaded via `SearchTuning`, resolved in the single allowlisted env-reader).
  - `user-profile.service.ts:195` drops the exclusion and prepends `(lang = $langFilter) DESC` to the ORDER BY.

### Migration `0100_lang_attribution.surql`
Additive, OVERWRITE-safe `option<...>` columns (`langConfidence` float + range ASSERT, `langSource` enum ASSERT, `detectorVersion`, `sourceLang`) on `knowledge_fact` + `episode`. No migrate-time data mutation; existing rows read NONE. Re-stamping is the explicit **flag-gated admin backfill script** (`scripts/backfill-lang-attribution.ts`) — never auto-runs.

### Flags & goldens
Both flags registered in `KNOWN_BOOLEAN_FLAGS` + `CONFIG_CATALOG` (`runtimeMutable`, call-time reads). `MULTILINGUAL_` is off the ENGINE_PREFIX flag budget by design (cross-cutting locale concern, like the `FOVEA_` family) — goldens unchanged, confirmed passing.

### Verification (exit 0)
- `tsc` → 0 · `eslint --max-warnings 0` → 0 · `prettier --check` → 0
- Full unit suite: **282 suites / 2622 tests pass**; gate goldens + migrator + migration-resolver-invariants green
- **loco-321 (SurrealDB 3.2.1) round-trip**: 0100 columns persist, legacy rows read NONE (no backfill needed), both ASSERTs reject bad values (throwaway namespace)
- No paid eval.

### Deferred (documented)
Backfill as a flag-gated script (admin endpoint → Tier 2); code-switching as dominant single label (per-clause → follow-up); episode-side `sourceLang` backfill (needs source-turn join). Multilingual stays **experimental** — nothing flipped on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
