### PR TITLE
feat(multilingual): embeddingSpaceId + zero-downtime space migration protocol (Tier 2, default-off)

### DIFF
--- a/src/admin/admin-embedding-space.controller.ts
+++ b/src/admin/admin-embedding-space.controller.ts
@@ -1,0 +1,89 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { AuthenticatedRequest } from '../auth/api-key.types';
+import { ApiKeyService } from '../auth/api-key.service';
+import { resolvePlatformTenant } from '../auth/tenant-scope';
+import {
+  EmbeddingSpaceService,
+  type EmbeddingSpaceState,
+} from '../ai/embedder/embedding-space.service';
+
+/**
+ * Admin surface for the zero-downtime embedding-space migration protocol
+ * (multilingual Tier 2). Every mutating operation is gated at the service
+ * layer (EMBEDDING_SPACE_DUAL_WRITE / EMBEDDING_SPACE_ACTIVE) AND scoped to
+ * brain:admin, resolving the target tenant through the same platform-tenant
+ * guard the HNSW maintenance surface uses. With the flags off these
+ * endpoints refuse (400) rather than mutate — so the surface is inert by
+ * default and cannot shift serving behaviour.
+ *
+ * Recommended order: begin → reindex (POST /v1/admin/reindex/embeddings
+ * ?allTables=true) → cutover.
+ */
+@Controller('v1/admin/embedding-space')
+@UseGuards(ApiKeyGuard)
+export class AdminEmbeddingSpaceController {
+  constructor(
+    private readonly spaces: EmbeddingSpaceService,
+    private readonly apiKeys: ApiKeyService,
+  ) {}
+
+  private tenant(req: AuthenticatedRequest, requested?: string): string {
+    return resolvePlatformTenant(req, requested, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
+  }
+
+  /** Current per-tenant space state (active / target / phase). Read-only. */
+  @Get('status')
+  @RequireScopes('brain:admin')
+  async status(
+    @Req() req: AuthenticatedRequest,
+    @Query('tenant') tenant?: string,
+  ): Promise<EmbeddingSpaceState> {
+    return this.spaces.getState(this.tenant(req, tenant));
+  }
+
+  /** Phase 1 — arm shadow dual-write into the target space. */
+  @Post('begin')
+  @RequireScopes('brain:admin')
+  async begin(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { targetSpace?: string; tenant?: string } = {},
+  ): Promise<EmbeddingSpaceState> {
+    const target = body.targetSpace?.trim();
+    if (!target) throw new BadRequestException('targetSpace is required');
+    return this.spaces.beginMigration(this.tenant(req, body.tenant), target);
+  }
+
+  /** Phase 3 — atomic per-tenant cutover to the target space. */
+  @Post('cutover')
+  @RequireScopes('brain:admin')
+  async cutover(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { targetSpace?: string; tenant?: string } = {},
+  ): Promise<EmbeddingSpaceState> {
+    const target = body.targetSpace?.trim();
+    if (!target) throw new BadRequestException('targetSpace is required');
+    return this.spaces.cutover(this.tenant(req, body.tenant), target);
+  }
+
+  /** Abort an in-flight migration (clears target + dual-write). */
+  @Post('abort')
+  @RequireScopes('brain:admin')
+  async abort(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { tenant?: string } = {},
+  ): Promise<EmbeddingSpaceState> {
+    return this.spaces.abortMigration(this.tenant(req, body.tenant));
+  }
+}

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -162,25 +162,27 @@ export class AdminController {
    *   POST /v1/admin/reindex/embeddings?dryRun=true
    *
    * Query params:
-   *   tenant   — limit to a single companyId (default: every known)
-   *   dryRun   — when "true" count rows but write nothing
-   *   maxFacts — hard cap on facts processed across all tenants
+   *   tenant    — limit to a single companyId (default: every known)
+   *   dryRun    — when "true" count rows but write nothing
+   *   maxFacts  — hard cap on facts processed across all tenants
+   *   allTables — when "true" ALSO sweep entity / predicate / episode /
+   *               segment / strategy_memory (Tier 2). Default (absent) =
+   *               the historical knowledge_fact-only reindex.
    */
   @Post('reindex/embeddings')
   @RequireScopes('brain:admin')
   async reindexEmbeddings(
-    @Query('tenant') tenant?: string,
-    @Query('dryRun') dryRun?: string,
-    @Query('maxFacts') maxFacts?: string,
+    @Query() q: { tenant?: string; dryRun?: string; maxFacts?: string; allTables?: string } = {},
   ): Promise<ReindexRunResponse> {
-    const parsedMaxFacts = maxFacts ? parseInt(maxFacts, 10) : undefined;
-    const reindexTenant = tenant?.trim() || undefined;
+    const parsedMaxFacts = q.maxFacts ? parseInt(q.maxFacts, 10) : undefined;
+    const reindexTenant = q.tenant?.trim() || undefined;
     const reindexMaxFacts =
       parsedMaxFacts !== undefined && Number.isFinite(parsedMaxFacts) ? parsedMaxFacts : undefined;
     return (await this.reindex.run({
       ...(reindexTenant !== undefined ? { tenant: reindexTenant } : {}),
-      dryRun: dryRun === 'true',
+      dryRun: q.dryRun === 'true',
       ...(reindexMaxFacts !== undefined ? { maxFacts: reindexMaxFacts } : {}),
+      ...(q.allTables === 'true' ? { allTables: true } : {}),
     })) satisfies ReindexRunResponse;
   }
 

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -34,6 +34,7 @@ import { AdminPolicyDecisionsController } from './admin-policy-decisions.control
 import { AdminKeysController } from './admin-keys.controller';
 import { AdminCodeMemoryController } from './admin-code-memory.controller';
 import { AdminHnswController } from './admin-hnsw.controller';
+import { AdminEmbeddingSpaceController } from './admin-embedding-space.controller';
 import { AdminAggregatesController } from './admin-aggregates.controller';
 import { AggregateComposerService } from './aggregate-composer.service';
 import { ArcComposerService } from './arc-composer.service';
@@ -104,6 +105,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     AdminKeysController,
     AdminCodeMemoryController,
     AdminHnswController,
+    AdminEmbeddingSpaceController,
     AdminAggregatesController,
     AdminDeriveController,
     AdminSegmentsController,

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -516,6 +516,48 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Soft same-language filter: replaces the hard `lang = q OR lang IS NONE` exclusion at both read sites (search where-builder + user-profile) with a same-language RANKING boost — a cross-lingual fact is demoted, never hidden. In search it is gated on a high-confidence detected query language (an explicit dto.queryLang / caller-supplied profile lang counts as confident); below the confidence floor no boost AND no exclusion. Off (default) → the hard filter is byte-identical.',
   },
+  // ── Embedding space (Tier 2, migration 0101) ────────
+  {
+    key: 'EMBEDDING_SPACE_TRACKING',
+    category: 'embedder',
+    // Read at call time inside the reindex engine (spaceStampId), never
+    // constructor-captured — a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Stamp `embeddingSpaceId` (canonical `provider:model:dim:norm`, e.g. openai:text-embedding-3-small:1536:l2) on the active reindex rewrite so each row declares which vector space it lives in. Off (default) → the reindex UPDATE is the pre-Tier-2 `SET embedding = $embedding` and the column is never written — byte-identical.',
+  },
+  {
+    key: 'EMBEDDING_SPACE_STRICT',
+    category: 'embedder',
+    // Read per-call in EmbedderService.serveProvider(), not the constructor.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Strict-space serving guard: when on, EmbedderService refuses (503) to serve a query embedded in a space INCOMPATIBLE (different dim / model / norm) with the primary configured space — the warmup-window failover from bge-m3 (1024) to the OpenAI fallback (1536) is the canonical case — instead of silently cross-space-comparing against the target rows. Off (default) → the existing warmup failover is byte-identical.',
+  },
+  {
+    key: 'EMBEDDING_SPACE_DUAL_WRITE',
+    category: 'embedder',
+    // Read per-call in EmbeddingSpaceService, not the constructor.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Zero-downtime migration phase 1: arm shadow dual-write so a begun migration keeps the target space warm (new writes produced in BOTH the active and target space) while the reindex backfills history. Off (default) → no target-space write is armed and beginMigration refuses.',
+  },
+  {
+    key: 'EMBEDDING_SPACE_ACTIVE',
+    category: 'embedder',
+    // Read per-call in EmbeddingSpaceService, not the constructor.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Zero-downtime migration phase 3: per-tenant active-space selection + ATOMIC cutover. When on, reads resolve the tenant’s active space from embedding_space_state and the admin cutover flips it all-or-nothing after reindex. Off (default) → reads use the current provider space and the cutover surface refuses — byte-identical serving.',
+  },
   // ── Cost ────────────────────────────────────────────
   {
     key: 'COST_CHAT_PROMPT_USD_PER_MTOK',

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -22,6 +22,7 @@ import { CalibrationRefitQueueService } from './calibration/calibration-refit-qu
 import { CalibrationRefitJobService } from './calibration/calibration-refit-job.service';
 import { ReindexEmbeddingsService } from './embedder/reindex-embeddings.service';
 import { ReindexEngineService } from './embedder/reindex-engine.service';
+import { EmbeddingSpaceService } from './embedder/embedding-space.service';
 import { EntityJudgeService } from './entity-judge.service';
 
 @Global()
@@ -72,6 +73,7 @@ import { EntityJudgeService } from './entity-judge.service';
     CalibrationRefitService,
     ReindexEngineService,
     ReindexEmbeddingsService,
+    EmbeddingSpaceService,
     EntityJudgeService,
   ],
   exports: [
@@ -91,6 +93,7 @@ import { EntityJudgeService } from './entity-judge.service';
     CalibrationService,
     CalibrationRefitService,
     ReindexEmbeddingsService,
+    EmbeddingSpaceService,
     EntityJudgeService,
   ],
 })

--- a/src/ai/embedder.service.ts
+++ b/src/ai/embedder.service.ts
@@ -1,4 +1,11 @@
-import { Injectable, Logger, OnModuleDestroy, OnModuleInit, Optional } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+  Optional,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHash } from 'node:crypto';
 import { LRUCache } from '../common/lru-cache';
@@ -9,6 +16,12 @@ import { createOpenAiClientOrThrow } from './openai-client';
 import { OpenAIEmbedderProvider } from './embedder/openai-embedder.provider';
 import { BgeM3EmbedderProvider } from './embedder/bge-m3-embedder.provider';
 import { envFlagEnabled } from '../common/env-validation';
+import {
+  describeSpaceIncompatibility,
+  embeddingSpaceIdFromProviderId,
+  spacesCompatible,
+  type EmbeddingNorm,
+} from './embedder/embedding-space';
 
 /**
  * EmbedderService — thin facade in front of an EmbedderProvider.
@@ -31,6 +44,14 @@ export class EmbedderService implements OnModuleInit, OnModuleDestroy {
   private readonly cache: LRUCache<string, number[]>;
   private readonly primary: EmbedderProvider;
   private readonly fallback: EmbedderProvider | null;
+  /**
+   * The canonical space id of the PRIMARY (configured) provider — the space
+   * a tenant's rows are expected to be in once reindexed. Computed once at
+   * boot from the provider's model+dim+norm; the strict-space guard compares
+   * the serving provider's space against this. Not a boolean flag, so it is
+   * safe to capture in the constructor.
+   */
+  private readonly primarySpaceIdValue: string;
 
   constructor(
     private readonly configService: ConfigService,
@@ -50,6 +71,7 @@ export class EmbedderService implements OnModuleInit, OnModuleDestroy {
       this.fallback = null;
       this.logger.log(`Embedder primary=openai`);
     }
+    this.primarySpaceIdValue = this.spaceIdOf(this.primary);
   }
 
   async onModuleInit(): Promise<void> {
@@ -105,7 +127,7 @@ export class EmbedderService implements OnModuleInit, OnModuleDestroy {
     const trimmed = text.trim();
     if (!trimmed) return new Array(this.getDimensions()).fill(0);
 
-    const provider = this.activeProvider();
+    const provider = this.serveProvider();
     const key = this.cacheKey(provider.providerId, trimmed);
     const hit = this.cache.get(key);
     if (hit) return hit;
@@ -155,7 +177,7 @@ export class EmbedderService implements OnModuleInit, OnModuleDestroy {
    */
   async embedMany(texts: string[]): Promise<number[][]> {
     if (texts.length === 0) return [];
-    const provider = this.activeProvider();
+    const provider = this.serveProvider();
     const out: number[][] = new Array(texts.length);
     const missIdx: number[] = [];
     const missTexts: string[] = [];
@@ -246,6 +268,79 @@ export class EmbedderService implements OnModuleInit, OnModuleDestroy {
     if (this.primary.isReady()) return this.primary;
     if (this.fallback) return this.fallback;
     return this.primary;
+  }
+
+  /**
+   * The canonical space id of the provider that would serve RIGHT NOW.
+   * Used by the reindex sweep to stamp `embeddingSpaceId` on rewritten
+   * rows (behind EMBEDDING_SPACE_TRACKING) so a row declares the space it
+   * was embedded in.
+   */
+  activeSpaceId(): string {
+    return this.spaceIdOf(this.activeProvider());
+  }
+
+  /**
+   * The space id of the PRIMARY (configured) provider — the space a
+   * tenant's rows are expected to be in once reindex completes. Stable for
+   * the life of the process (embedder config is boot-time).
+   */
+  primarySpaceId(): string {
+    return this.primarySpaceIdValue;
+  }
+
+  /**
+   * The serving provider for an actual embed call. Byte-identical to
+   * `activeProvider()` UNLESS EMBEDDING_SPACE_STRICT is on: then a query
+   * that would be embedded in a space INCOMPATIBLE with the primary
+   * (configured) space — the warmup-window failover from bge-m3 (1024) to
+   * the OpenAI fallback (1536) is the canonical case — is refused rather
+   * than silently cross-space-compared against the target rows. Read the
+   * flag per-call so an operator flip takes effect without a restart.
+   */
+  private serveProvider(): EmbedderProvider {
+    const provider = this.activeProvider();
+    if (!envFlagEnabled(this.configService.get<string>('EMBEDDING_SPACE_STRICT'))) {
+      return provider; // default: the existing warmup failover, unchanged
+    }
+    const servingSpace = this.spaceIdOf(provider);
+    if (!spacesCompatible(servingSpace, this.primarySpaceIdValue)) {
+      const reason = describeSpaceIncompatibility(servingSpace, this.primarySpaceIdValue);
+      // 503, not 500: this is transient — the primary provider is warming
+      // up (or has failed warmup); the query is refused ONLY because a
+      // cross-space compare would be meaningless, not because of a bug.
+      throw new ServiceUnavailableException(
+        `embedding space strict-guard: refusing to serve a query in '${servingSpace}' ` +
+          `against rows in '${this.primarySpaceIdValue}' (${reason}). The primary ` +
+          `embedder is not ready; retry once warmup completes or reindex the tenant ` +
+          `into the serving space.`,
+      );
+    }
+    return provider;
+  }
+
+  /**
+   * The canonical embedding-space id of a provider: its providerId
+   * (`vendor:model:dim`) plus normalization. A provider whose id is not the
+   * expected three-part shape (e.g. a test stub) falls back to its raw
+   * providerId, which is only ever compatible with a byte-identical id — so
+   * the guard never guesses a cross-space compare is safe.
+   */
+  private spaceIdOf(provider: EmbedderProvider): string {
+    return (
+      embeddingSpaceIdFromProviderId(provider.providerId, this.normOf(provider)) ??
+      provider.providerId
+    );
+  }
+
+  /**
+   * Output normalization of a provider. Both shipped providers emit unit
+   * vectors (OpenAI by API contract; bge-m3 via `normalize:true`), so `l2`
+   * is the house default. A genuinely non-normalized provider must be a
+   * DISTINCT space, so it would override this before shipping.
+   */
+  private normOf(_provider: EmbedderProvider): EmbeddingNorm {
+    return 'l2';
   }
 
   private buildOpenAIProvider(): OpenAIEmbedderProvider {

--- a/src/ai/embedder/embedding-space.service.ts
+++ b/src/ai/embedder/embedding-space.service.ts
@@ -1,0 +1,228 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SurrealService } from '../../db/surreal.service';
+import { EmbedderService } from '../embedder.service';
+import { envFlagEnabled } from '../../common/env-validation';
+
+/**
+ * EmbeddingSpaceService — the per-tenant zero-downtime migration protocol
+ * (multilingual Tier 2, migration 0101).
+ *
+ * A tenant's rows live in ONE embedding space at query time — never mixed.
+ * Moving a tenant from space A → space B without downtime is a three-phase
+ * choreography, each phase gated OFF by default:
+ *
+ *   1. begin  (EMBEDDING_SPACE_DUAL_WRITE) — arm shadow dual-write: new
+ *      writes are produced in BOTH the active space and the target space so
+ *      the target is kept warm while the reindex backfills history.
+ *   2. reindex — POST /v1/admin/reindex/embeddings?allTables=true rewrites
+ *      every historical vector into the target space (stamping
+ *      embeddingSpaceId under EMBEDDING_SPACE_TRACKING).
+ *   3. cutover (EMBEDDING_SPACE_ACTIVE) — an ATOMIC single-statement flip of
+ *      the tenant's active space to the target, after the reindex completes.
+ *      Reads switch wholly to the target space; there is never a window where
+ *      a query is compared against a half-migrated corpus.
+ *
+ * State lives in a singleton row `embedding_space_state:current` per tenant
+ * DB. Absent / unset ⇒ the tenant is wholly in the CURRENT provider space
+ * (the legacy/implicit space) — so with every flag off, `activeSpaceFor`
+ * returns the provider's own space and serving is byte-identical to
+ * pre-Tier-2.
+ *
+ * SCOPE NOTE (honest bound): the atomic per-tenant state machine + resolver
+ * are fully built and tested here. Wiring the shadow dual-write into every
+ * live ingest/derive write site, and the active-space WHERE filter into
+ * every search leg, is the remaining mechanical surface — it reuses
+ * `activeSpaceFor` / `targetSpaceFor` exactly as the reindex sweep reuses
+ * `EmbedderService.activeSpaceId()`. That per-site wiring is deferred (it
+ * touches many hot paths) and called out in the Tier-2 report.
+ */
+
+export type MigrationPhase = 'idle' | 'dual_write' | 'cut_over';
+
+export interface EmbeddingSpaceState {
+  /** The space reads select for this tenant. */
+  activeSpace: string;
+  /** The space an in-flight migration is moving into (null ⇒ none). */
+  targetSpace: string | null;
+  /** True while shadow dual-write is arming the target space. */
+  dualWrite: boolean;
+  phase: MigrationPhase;
+}
+
+interface StateRow {
+  activeSpace?: string | null;
+  targetSpace?: string | null;
+  dualWrite?: boolean | null;
+  phase?: MigrationPhase | null;
+}
+
+const STATE_ID = 'embedding_space_state:current';
+
+@Injectable()
+export class EmbeddingSpaceService {
+  private readonly logger = new Logger(EmbeddingSpaceService.name);
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly embedder: EmbedderService,
+    private readonly config: ConfigService,
+  ) {}
+
+  /** Master switch for active-space selection + cutover. */
+  private activeEnabled(): boolean {
+    return envFlagEnabled(this.config.get<string>('EMBEDDING_SPACE_ACTIVE'));
+  }
+
+  /** Switch for arming shadow dual-write. */
+  private dualWriteEnabled(): boolean {
+    return envFlagEnabled(this.config.get<string>('EMBEDDING_SPACE_DUAL_WRITE'));
+  }
+
+  /**
+   * The space id the READ path should use for this tenant. When
+   * EMBEDDING_SPACE_ACTIVE is off, or no migration state exists, this is the
+   * current provider's space — byte-identical to pre-Tier-2 serving. A
+   * tenant is WHOLLY in this one space at query time.
+   */
+  async activeSpaceFor(companyId: string): Promise<string> {
+    const fallback = this.embedder.primarySpaceId();
+    if (!this.activeEnabled()) return fallback;
+    const state = await this.readState(companyId);
+    return state?.activeSpace ?? fallback;
+  }
+
+  /**
+   * The dual-write TARGET space for this tenant, or null when no migration
+   * is arming. Null whenever EMBEDDING_SPACE_DUAL_WRITE is off — so the
+   * dual-write write sites are inert by default.
+   */
+  async targetSpaceFor(companyId: string): Promise<string | null> {
+    if (!this.dualWriteEnabled()) return null;
+    const state = await this.readState(companyId);
+    return state?.dualWrite ? (state.targetSpace ?? null) : null;
+  }
+
+  /** The full state, defaulted for reporting. */
+  async getState(companyId: string): Promise<EmbeddingSpaceState> {
+    const fallback = this.embedder.primarySpaceId();
+    const row = await this.readState(companyId);
+    return {
+      activeSpace: row?.activeSpace ?? fallback,
+      targetSpace: row?.targetSpace ?? null,
+      dualWrite: row?.dualWrite ?? false,
+      phase: row?.phase ?? 'idle',
+    };
+  }
+
+  /**
+   * Phase 1 — arm shadow dual-write into `targetSpace`. Gated by
+   * EMBEDDING_SPACE_DUAL_WRITE. Idempotent. The active space is left
+   * untouched (reads keep serving the old space) — only new writes gain a
+   * second, target-space vector once the dual-write write sites consult
+   * `targetSpaceFor`.
+   */
+  async beginMigration(companyId: string, targetSpace: string): Promise<EmbeddingSpaceState> {
+    if (!this.dualWriteEnabled()) {
+      throw new BadRequestException(
+        'EMBEDDING_SPACE_DUAL_WRITE is off — cannot begin a space migration',
+      );
+    }
+    this.assertSpaceId(targetSpace);
+    const active = await this.activeSpaceFor(companyId);
+    if (targetSpace === active) {
+      throw new BadRequestException(
+        `target space '${targetSpace}' equals the active space — nothing to migrate`,
+      );
+    }
+    await this.surreal.withCompany(companyId, async (db) => {
+      await db.query(
+        `UPSERT ${STATE_ID} SET
+           activeSpace = $active, targetSpace = $target,
+           dualWrite = true, phase = 'dual_write', updatedAt = time::now()`,
+        { active, target: targetSpace },
+      );
+    });
+    this.logger.log(`[embedding-space] begin migration ${companyId}: ${active} -> ${targetSpace}`);
+    return this.getState(companyId);
+  }
+
+  /**
+   * Phase 3 — ATOMIC per-tenant cutover. Flips the active space to the
+   * target in a SINGLE UPSERT statement (all-or-nothing) and clears the
+   * dual-write arming. Gated by EMBEDDING_SPACE_ACTIVE. Refuses unless a
+   * migration into `targetSpace` is in flight, so a cutover can only follow
+   * a begin (+ the operator's reindex). After this, reads serve the target
+   * space wholly.
+   */
+  async cutover(companyId: string, targetSpace: string): Promise<EmbeddingSpaceState> {
+    if (!this.activeEnabled()) {
+      throw new BadRequestException(
+        'EMBEDDING_SPACE_ACTIVE is off — per-tenant active-space cutover is disabled',
+      );
+    }
+    this.assertSpaceId(targetSpace);
+    const state = await this.getState(companyId);
+    if (state.targetSpace !== targetSpace) {
+      throw new BadRequestException(
+        `no migration into '${targetSpace}' is in flight for ${companyId} ` +
+          `(current target: ${state.targetSpace ?? 'none'}). Begin a migration and ` +
+          `reindex before cutting over.`,
+      );
+    }
+    await this.surreal.withCompany(companyId, async (db) => {
+      // Single statement ⇒ atomic: no window where activeSpace is set but
+      // targetSpace/dualWrite are stale.
+      await db.query(
+        `UPSERT ${STATE_ID} SET
+           activeSpace = $target, targetSpace = NONE,
+           dualWrite = false, phase = 'cut_over', updatedAt = time::now()`,
+        { target: targetSpace },
+      );
+    });
+    this.logger.log(`[embedding-space] cutover ${companyId} -> ${targetSpace}`);
+    return this.getState(companyId);
+  }
+
+  /**
+   * Abort an in-flight migration — clears the target + dual-write arming,
+   * leaving the active space untouched. Gated by EMBEDDING_SPACE_ACTIVE
+   * (same surface as cutover). Idempotent.
+   */
+  async abortMigration(companyId: string): Promise<EmbeddingSpaceState> {
+    if (!this.activeEnabled()) {
+      throw new BadRequestException('EMBEDDING_SPACE_ACTIVE is off — nothing to abort');
+    }
+    await this.surreal.withCompany(companyId, async (db) => {
+      await db.query(
+        `UPSERT ${STATE_ID} SET
+           targetSpace = NONE, dualWrite = false, phase = 'idle', updatedAt = time::now()`,
+      );
+    });
+    this.logger.log(`[embedding-space] abort migration ${companyId}`);
+    return this.getState(companyId);
+  }
+
+  private async readState(companyId: string): Promise<StateRow | null> {
+    try {
+      return await this.surreal.withCompany(companyId, async (db) => {
+        const [rows] = await db.query<[StateRow[]]>(
+          `SELECT activeSpace, targetSpace, dualWrite, phase FROM ${STATE_ID}`,
+        );
+        return (rows as StateRow[])?.[0] ?? null;
+      });
+    } catch (e) {
+      // A missing table / fresh tenant reads as "no state" ⇒ current space.
+      this.logger.warn(
+        `[embedding-space] state read failed for ${companyId}: ${(e as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  private assertSpaceId(id: string): void {
+    if (typeof id !== 'string' || id.trim().length < 3) {
+      throw new BadRequestException(`invalid embedding space id: '${id}'`);
+    }
+  }
+}

--- a/src/ai/embedder/embedding-space.ts
+++ b/src/ai/embedder/embedding-space.ts
@@ -1,0 +1,152 @@
+/**
+ * Multilingual Tier 2 — canonical embedding-space descriptors.
+ *
+ * An "embedding space" is the (model, dimensionality, normalization) triple
+ * a dense vector was produced under. Two vectors are only comparable
+ * (cosine / dot) when they live in the SAME space; a cross-space compare is
+ * numerically meaningless even when the dimensions happen to match. This
+ * module is the single source of truth for naming a space and testing two
+ * spaces for compatibility. It is PURE (no I/O, no NestJS) so it can be
+ * shared by the embedder service, the reindex engine, the per-tenant
+ * active-space resolver, and the tests without pulling in the DI graph.
+ *
+ * Canonical id shape: `${provider}:${model}:${dim}:${norm}`
+ *   e.g. `openai:text-embedding-3-small:1536:l2`
+ *        `bge-m3:Xenova/bge-m3:1024:l2`
+ *
+ * The id is stamped on rows behind EMBEDDING_SPACE_TRACKING (default off);
+ * a NONE column is interpreted as "the current provider's space" (the
+ * legacy / implicit space), which keeps serving byte-identical when the
+ * flag is off.
+ */
+
+/** How a provider normalizes its output vectors. Both shipped providers
+ *  emit unit vectors (OpenAI by API contract; bge-m3 via `normalize:true`),
+ *  so `l2` is the only value in play today — but the descriptor records it
+ *  explicitly so a future non-normalized provider is a DIFFERENT space
+ *  rather than a silent cross-space compare. */
+export type EmbeddingNorm = 'l2' | 'none';
+
+export interface EmbeddingSpaceConfig {
+  /** Provider vendor, e.g. `openai` | `bge-m3`. */
+  provider: string;
+  /** Model id, e.g. `text-embedding-3-small` | `Xenova/bge-m3`. */
+  model: string;
+  /** Vector dimensionality, e.g. 1536 | 1024. */
+  dim: number;
+  /** Output normalization. */
+  norm: EmbeddingNorm;
+}
+
+export interface ParsedEmbeddingSpace {
+  provider: string;
+  model: string;
+  dim: number;
+  norm: string;
+}
+
+/**
+ * The canonical, stable id for an embedding space. Pure function of its
+ * config — identical config ⇒ identical id, byte-for-byte. Callers MUST go
+ * through this rather than hand-assembling the string, so the format has
+ * exactly one definition.
+ */
+export function embeddingSpaceId(cfg: EmbeddingSpaceConfig): string {
+  return `${cfg.provider}:${cfg.model}:${cfg.dim}:${cfg.norm}`;
+}
+
+/**
+ * Build a space id from a provider's `providerId` (`vendor:model:dim`, as
+ * produced by OpenAIEmbedderProvider / BgeM3EmbedderProvider) plus its
+ * normalization. Splits on the FIRST and LAST colon so a model id that
+ * itself contains a colon still parses (vendor = head, dim = tail, model =
+ * everything between). Returns null when the providerId is not the expected
+ * three-part shape.
+ */
+export function embeddingSpaceIdFromProviderId(
+  providerId: string,
+  norm: EmbeddingNorm,
+): string | null {
+  const firstColon = providerId.indexOf(':');
+  const lastColon = providerId.lastIndexOf(':');
+  if (firstColon === -1 || lastColon === firstColon) return null;
+  const provider = providerId.slice(0, firstColon);
+  const model = providerId.slice(firstColon + 1, lastColon);
+  const dimRaw = providerId.slice(lastColon + 1);
+  const dim = Number.parseInt(dimRaw, 10);
+  if (!provider || !model || !Number.isInteger(dim) || String(dim) !== dimRaw) return null;
+  return embeddingSpaceId({ provider, model, dim, norm });
+}
+
+/** Parse a canonical id back into its parts. Returns null on a malformed id
+ *  (used by the compatibility test to reason about dim / model / norm). */
+export function parseEmbeddingSpaceId(id: string): ParsedEmbeddingSpace | null {
+  const parts = id.split(':');
+  // provider : model : dim : norm — but the model may contain colons, so
+  // pin provider (head), norm (tail), dim (second from tail) and rejoin the
+  // middle as the model.
+  if (parts.length < 4) return null;
+  const provider = parts[0]!;
+  const norm = parts[parts.length - 1]!;
+  const dimRaw = parts[parts.length - 2]!;
+  const model = parts.slice(1, parts.length - 2).join(':');
+  const dim = Number.parseInt(dimRaw, 10);
+  if (!provider || !model || !norm || !Number.isInteger(dim) || String(dim) !== dimRaw) {
+    return null;
+  }
+  return { provider, model, dim, norm };
+}
+
+/**
+ * Are two spaces compatible for a cosine / dot compare? Explicit test: the
+ * spaces must agree on dim, model, provider AND norm. Identical ids are
+ * trivially compatible; otherwise we parse and compare the load-bearing
+ * fields. A malformed (unparseable) id is compatible ONLY with a
+ * byte-identical id — we never guess a comparison is safe.
+ */
+export function spacesCompatible(a: string, b: string): boolean {
+  if (a === b) return true;
+  const pa = parseEmbeddingSpaceId(a);
+  const pb = parseEmbeddingSpaceId(b);
+  if (!pa || !pb) return false;
+  return (
+    pa.provider === pb.provider && pa.model === pb.model && pa.dim === pb.dim && pa.norm === pb.norm
+  );
+}
+
+/** Human-readable reason two spaces are incompatible — for guard errors.
+ *  Returns null when they ARE compatible. */
+export function describeSpaceIncompatibility(a: string, b: string): string | null {
+  if (spacesCompatible(a, b)) return null;
+  const pa = parseEmbeddingSpaceId(a);
+  const pb = parseEmbeddingSpaceId(b);
+  if (!pa || !pb) return `unparseable space id(s): '${a}' vs '${b}'`;
+  const diffs: string[] = [];
+  if (pa.dim !== pb.dim) diffs.push(`dim ${pa.dim}≠${pb.dim}`);
+  if (pa.model !== pb.model) diffs.push(`model ${pa.model}≠${pb.model}`);
+  if (pa.provider !== pb.provider) diffs.push(`provider ${pa.provider}≠${pb.provider}`);
+  if (pa.norm !== pb.norm) diffs.push(`norm ${pa.norm}≠${pb.norm}`);
+  return diffs.join(', ');
+}
+
+/** The column name carrying a row's space descriptor across every
+ *  embedding-bearing table (migration 0101). One name everywhere so the
+ *  stamping SET clauses and read filters stay in lockstep. */
+export const EMBEDDING_SPACE_FIELD = 'embeddingSpaceId';
+
+/**
+ * Every table that stores a dense vector, with the vector column(s) whose
+ * space `embeddingSpaceId` describes. The reindex-all sweep uses the subset
+ * that can be regenerated by a plain re-embed of stored text; community /
+ * procedural vectors are derived by their own passes and are stamped there.
+ */
+export const EMBEDDING_TABLES = [
+  { table: 'knowledge_fact', vectorFields: ['embedding', 'altEmbedding'] },
+  { table: 'knowledge_entity', vectorFields: ['embedding'] },
+  { table: 'knowledge_predicate', vectorFields: ['embedding'] },
+  { table: 'episode', vectorFields: ['embedding'] },
+  { table: 'episode_segment', vectorFields: ['embedding'] },
+  { table: 'strategy_memory', vectorFields: ['embedding'] },
+  { table: 'community_node', vectorFields: ['summaryEmbedding'] },
+  { table: 'procedural_memory', vectorFields: ['triggerEmbedding'] },
+] as const;

--- a/src/ai/embedder/reindex-embeddings.service.ts
+++ b/src/ai/embedder/reindex-embeddings.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ApiKeyService } from '../../auth/api-key.service';
-import { ReindexEngineService } from './reindex-engine.service';
+import { ReindexEngineService, type TableReindexCount } from './reindex-engine.service';
 
 export interface ReindexResult {
   tenantsScanned: number;
@@ -9,6 +9,9 @@ export interface ReindexResult {
   durationMs: number;
   dryRun: boolean;
   provider: string;
+  /** Per-table breakdown, present ONLY when the opt-in all-tables sweep
+   *  ran; absent on the default knowledge_fact-only path. */
+  tables?: TableReindexCount[];
 }
 
 export interface ReindexOptions {
@@ -18,6 +21,12 @@ export interface ReindexOptions {
   dryRun?: boolean;
   /** Cap on facts processed per tenant; protects against runaway batches. */
   maxFacts?: number;
+  /**
+   * Opt-in: also sweep the non-fact embedding tables (entity, predicate,
+   * episode, segment, strategy_memory). Default (undefined/false) = the
+   * historical knowledge_fact-only reindex, byte-identical.
+   */
+  allTables?: boolean;
 }
 
 /**
@@ -53,16 +62,26 @@ export class ReindexEmbeddingsService {
     const maxFacts = opts.maxFacts ?? Number.MAX_SAFE_INTEGER;
     const tenants = opts.tenant ? [opts.tenant] : this.apiKeys.knownCompanyIds();
 
+    const allTables = opts.allTables === true;
     let factsScanned = 0;
     let factsUpdated = 0;
+    // Aggregate the per-table sweep counts across tenants (all-tables only).
+    const tableTotals = new Map<string, TableReindexCount>();
     for (const companyId of tenants) {
       try {
         const tenantResult = await this.engine.reindexTenant(companyId, {
           dryRun,
           remaining: maxFacts - factsScanned,
+          allTables,
         });
         factsScanned += tenantResult.factsScanned;
         factsUpdated += tenantResult.factsUpdated;
+        for (const t of tenantResult.tables ?? []) {
+          const acc = tableTotals.get(t.table) ?? { table: t.table, scanned: 0, updated: 0 };
+          acc.scanned += t.scanned;
+          acc.updated += t.updated;
+          tableTotals.set(t.table, acc);
+        }
         if (factsScanned >= maxFacts) break;
       } catch (e) {
         this.logger.warn(`reindex failed for ${companyId}: ${(e as Error).message}`);
@@ -76,6 +95,7 @@ export class ReindexEmbeddingsService {
       durationMs: Date.now() - started,
       dryRun,
       provider: this.engine.providerId(),
+      ...(allTables ? { tables: [...tableTotals.values()] } : {}),
     };
     this.logger.log(
       `reindex done — provider=${result.provider} tenants=${result.tenantsScanned} scanned=${result.factsScanned} updated=${result.factsUpdated} dryRun=${dryRun}`,

--- a/src/ai/embedder/reindex-engine.service.ts
+++ b/src/ai/embedder/reindex-engine.service.ts
@@ -1,12 +1,113 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import type { Surreal } from 'surrealdb';
 import { SurrealService } from '../../db/surreal.service';
 import { EmbedderService } from '../embedder.service';
+import { envFlagEnabled } from '../../common/env-validation';
+import { EMBEDDING_SPACE_FIELD } from './embedding-space';
 
 interface FactRowForReindex {
   id: { tb: string; id: { String: string } } | string;
   predicate: string;
   object: string;
+}
+
+/** One additional embedding-bearing table the opt-in all-tables sweep can
+ *  re-embed. `text` mirrors the WRITE-path projection so a reindex produces
+ *  the same vector the ingest/derive path would. */
+interface ReindexTableSpec {
+  table: string;
+  /** The column holding the vector (fixed literal, never caller input). */
+  vectorField: string;
+  /** Columns the SELECT must fetch to rebuild the embed text. */
+  select: string;
+  /** Rebuild the embed text from a row; empty string ⇒ skip the row. */
+  text: (row: Record<string, unknown>) => string;
+}
+
+/**
+ * The non-fact tables the sweep covers, each re-embedding from a STORED
+ * text column so the projection cannot drift from a separately-maintained
+ * copy. Sourced from the confirmed write paths:
+ *   - knowledge_entity   — entity-resolver embeds `name: <name>`
+ *   - knowledge_predicate— db-mapping.embeddingTextFor: `<id_ws>: <desc>`
+ *   - episode            — episode.text (embeddings are derived state, not
+ *                          yet backfilled; the != NONE guard makes this a
+ *                          safe no-op until they are)
+ *   - episode_segment    — segment-composer stores the exact embedded `text`
+ *   - strategy_memory    — `<title>\n<situation>` (strategy-memory.service)
+ *
+ * community_node (summaryEmbedding) and procedural_memory (triggerEmbedding)
+ * are intentionally NOT here: their vectors are produced by a summarization
+ * / trigger-derive pass, not a plain re-embed, so they are re-stamped by
+ * their own write paths, not by this sweep.
+ */
+const asStr = (v: unknown): string => (typeof v === 'string' ? v : '');
+const ADDITIONAL_TABLE_SPECS: ReindexTableSpec[] = [
+  {
+    table: 'knowledge_entity',
+    vectorField: 'embedding',
+    select: 'id, name, canonicalName, embedding',
+    text: (r) => {
+      const name = asStr(r.canonicalName) || asStr(r.name);
+      return name ? `name: ${name}` : '';
+    },
+  },
+  {
+    table: 'knowledge_predicate',
+    vectorField: 'embedding',
+    select: 'id, predicateId, description, embedding',
+    text: (r) => {
+      const pid = asStr(r.predicateId);
+      return pid ? `${pid.replace(/_/g, ' ')}: ${asStr(r.description)}` : '';
+    },
+  },
+  {
+    table: 'episode',
+    vectorField: 'embedding',
+    select: 'id, text, embedding',
+    text: (r) => asStr(r.text),
+  },
+  {
+    table: 'episode_segment',
+    vectorField: 'embedding',
+    select: 'id, text, embedding',
+    text: (r) => asStr(r.text),
+  },
+  {
+    table: 'strategy_memory',
+    vectorField: 'embedding',
+    select: 'id, title, situation, embedding',
+    text: (r) => {
+      const title = asStr(r.title);
+      const situation = asStr(r.situation);
+      return title || situation ? `${title}\n${situation}` : '';
+    },
+  },
+];
+
+/** Per-table row of the opt-in all-tables sweep, surfaced for operator audit. */
+export interface TableReindexCount {
+  table: string;
+  scanned: number;
+  updated: number;
+}
+
+export interface ReindexTenantResult {
+  factsScanned: number;
+  factsUpdated: number;
+  /** Present ONLY when the all-tables sweep ran; absent on the default
+   *  knowledge_fact-only path so the response stays byte-identical. */
+  tables?: TableReindexCount[];
+}
+
+/** Per-tenant reindex context — the open DB handle, the tenant id (for log
+ *  lines), and the space stamp (null ⇒ EMBEDDING_SPACE_TRACKING off). Bundled
+ *  so the helpers stay ≤3 params. */
+interface ReindexCtx {
+  db: Surreal;
+  companyId: string;
+  spaceId: string | null;
 }
 
 /**
@@ -18,6 +119,12 @@ interface FactRowForReindex {
  * which delegates here. Splitting the engine out keeps each class's
  * injected-dep list ≤3 and isolates the DB/embedder machinery from the
  * "which tenants" policy.
+ *
+ * Space-tracking (Tier 2): with EMBEDDING_SPACE_TRACKING on, every rewrite
+ * ALSO stamps `embeddingSpaceId` with the active provider's canonical space
+ * so the row declares which space its vector lives in. With the flag off
+ * (default) NO stamp is written and the DEFAULT reindex covers knowledge_fact
+ * ONLY — byte-identical to pre-Tier-2.
  */
 @Injectable()
 export class ReindexEngineService {
@@ -27,9 +134,9 @@ export class ReindexEngineService {
   constructor(
     private readonly surreal: SurrealService,
     private readonly embedder: EmbedderService,
-    config: ConfigService,
+    private readonly config: ConfigService,
   ) {
-    this.batchSize = parseInt(config.get<string>('REINDEX_BATCH_SIZE', '200'), 10);
+    this.batchSize = parseInt(this.config.get<string>('REINDEX_BATCH_SIZE', '200'), 10);
   }
 
   /**
@@ -43,64 +150,192 @@ export class ReindexEngineService {
       : 'unknown';
   }
 
+  /**
+   * Whether to stamp `embeddingSpaceId` on rewrite. Read per-call so an
+   * operator flip takes effect without a restart. Off (default) ⇒ the
+   * UPDATE clause is exactly the pre-Tier-2 `SET embedding = $embedding`.
+   */
+  private spaceStampId(): string | null {
+    if (!envFlagEnabled(this.config.get<string>('EMBEDDING_SPACE_TRACKING'))) return null;
+    return this.embedder.activeSpaceId();
+  }
+
   async reindexTenant(
     companyId: string,
+    opts: { dryRun: boolean; remaining: number; allTables?: boolean },
+  ): Promise<ReindexTenantResult> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const ctx: ReindexCtx = { db, companyId, spaceId: this.spaceStampId() };
+      const factResult = await this.reindexKnowledgeFacts(ctx, opts);
+      if (opts.allTables !== true) return factResult;
+
+      // Opt-in sweep over the remaining embedding-bearing tables. Each is
+      // capped independently by `remaining` (a shared budget would make the
+      // per-table numbers depend on iteration order, which is worse for
+      // operator reasoning).
+      const tables: TableReindexCount[] = [];
+      for (const spec of ADDITIONAL_TABLE_SPECS) {
+        tables.push(await this.reindexGenericTable(ctx, spec, opts));
+      }
+      return { ...factResult, tables };
+    });
+  }
+
+  /**
+   * Rewrite one row's vector. Byte-identical to pre-Tier-2 when
+   * `ctx.spaceId` is null (EMBEDDING_SPACE_TRACKING off): the UPDATE is
+   * `SET <vectorField> = $embedding`, no extra column touched. `vectorField`
+   * is a fixed literal, never caller input.
+   */
+  private async writeVector(
+    ctx: ReindexCtx,
+    vectorField: string,
+    entry: { id: unknown; vector: number[] | undefined },
+  ): Promise<void> {
+    if (ctx.spaceId) {
+      await ctx.db.query(
+        `UPDATE $id SET ${vectorField} = $embedding, ${EMBEDDING_SPACE_FIELD} = $space`,
+        { id: entry.id, embedding: entry.vector, space: ctx.spaceId },
+      );
+    } else {
+      await ctx.db.query(`UPDATE $id SET ${vectorField} = $embedding`, {
+        id: entry.id,
+        embedding: entry.vector,
+      });
+    }
+  }
+
+  /**
+   * knowledge_fact reindex — the DEFAULT path.
+   */
+  private async reindexKnowledgeFacts(
+    ctx: ReindexCtx,
     opts: { dryRun: boolean; remaining: number },
   ): Promise<{ factsScanned: number; factsUpdated: number }> {
-    return this.surreal.withCompany(companyId, async (db) => {
-      let offset = 0;
-      let factsScanned = 0;
-      let factsUpdated = 0;
-      const batch = Math.min(this.batchSize, opts.remaining);
-      // Paginate until either the tenant is empty or we hit the cap.
-      while (factsScanned < opts.remaining) {
-        const [rows] = await db.query<[FactRowForReindex[]]>(
-          `SELECT id, predicate, object
-              FROM knowledge_fact
-              ORDER BY id
-              LIMIT $batch START $offset`,
-          { batch, offset },
-        );
-        const page = (rows as FactRowForReindex[]) ?? [];
-        if (page.length === 0) break;
+    let offset = 0;
+    let factsScanned = 0;
+    let factsUpdated = 0;
+    const batch = Math.min(this.batchSize, opts.remaining);
+    // Paginate until either the tenant is empty or we hit the cap.
+    while (factsScanned < opts.remaining) {
+      const [rows] = await ctx.db.query<[FactRowForReindex[]]>(
+        `SELECT id, predicate, object
+            FROM knowledge_fact
+            ORDER BY id
+            LIMIT $batch START $offset`,
+        { batch, offset },
+      );
+      const page = (rows as FactRowForReindex[]) ?? [];
+      if (page.length === 0) break;
 
-        factsScanned += page.length;
-        if (!opts.dryRun) {
-          // Batch the whole page through one embedMany — the previous
-          // per-row embed() loop paid one HTTP round-trip per fact,
-          // which made reindex unworkable on large tenants (a 100k-row
-          // tenant = 100k sequential calls). embedMany chunks 512 at
-          // a time inside the OpenAI provider.
-          const texts = page.map((row) => `${row.predicate}: ${row.object}`);
-          let embeddings: number[][];
-          try {
-            embeddings = await this.embedder.embedMany(texts);
-          } catch (e) {
-            this.logger.warn(
-              `reindex batch embed failed (${companyId}, page=${page.length}): ${(e as Error).message}`,
-            );
-            // Skip this page entirely; the next outer-loop iteration
-            // advances `offset` by `page.length` so we don't retry-loop.
-            offset += page.length;
-            if (page.length < batch) break;
-            continue;
-          }
-          for (const [i, row] of page.entries()) {
-            try {
-              await db.query(`UPDATE $id SET embedding = $embedding`, {
-                id: row.id,
-                embedding: embeddings[i],
-              });
-              factsUpdated += 1;
-            } catch (e) {
-              this.logger.warn(`reindex row update failed (${companyId}): ${(e as Error).message}`);
-            }
-          }
+      factsScanned += page.length;
+      if (!opts.dryRun) {
+        // Batch the whole page through one embedMany — the previous
+        // per-row embed() loop paid one HTTP round-trip per fact.
+        const texts = page.map((row) => `${row.predicate}: ${row.object}`);
+        const embeddings = await this.embedPageOrNull(texts, `knowledge_fact ${ctx.companyId}`);
+        if (embeddings) {
+          const entries = page.map((row, i) => ({ id: row.id, vector: embeddings[i] }));
+          factsUpdated += await this.writePage(ctx, 'embedding', entries);
         }
-        offset += page.length;
-        if (page.length < batch) break;
       }
-      return { factsScanned, factsUpdated };
-    });
+      offset += page.length;
+      if (page.length < batch) break;
+    }
+    return { factsScanned, factsUpdated };
+  }
+
+  /**
+   * Re-embed one non-fact table (opt-in sweep). Rewrites ONLY rows that
+   * ALREADY carry a vector (`WHERE <vectorField> != NONE`) — the sweep MOVES
+   * existing embeddings into the active space, it never creates embeddings
+   * where the write path left none (so tables whose vectors are unpopulated
+   * derived state are a safe no-op). Stamps `embeddingSpaceId` when tracking
+   * is on. `vectorField`/`table`/`select` are fixed literals from
+   * ADDITIONAL_TABLE_SPECS, never caller input.
+   */
+  private async reindexGenericTable(
+    ctx: ReindexCtx,
+    spec: ReindexTableSpec,
+    opts: { dryRun: boolean; remaining: number },
+  ): Promise<TableReindexCount> {
+    let offset = 0;
+    let scanned = 0;
+    let updated = 0;
+    const batch = Math.min(this.batchSize, opts.remaining);
+    while (scanned < opts.remaining) {
+      const [rows] = await ctx.db.query<[Array<Record<string, unknown>>]>(
+        `SELECT ${spec.select}
+            FROM ${spec.table}
+            WHERE ${spec.vectorField} != NONE
+            ORDER BY id
+            LIMIT $batch START $offset`,
+        { batch, offset },
+      );
+      const page = (rows as Array<Record<string, unknown>>) ?? [];
+      if (page.length === 0) break;
+      scanned += page.length;
+      if (!opts.dryRun) updated += await this.reindexGenericPage(ctx, spec, page);
+      offset += page.length;
+      if (page.length < batch) break;
+    }
+    return { table: spec.table, scanned, updated };
+  }
+
+  /** Re-embed + rewrite one page of a non-fact table. Skips rows with no
+   *  usable source text so a vector is never overwritten with a zero one. */
+  private async reindexGenericPage(
+    ctx: ReindexCtx,
+    spec: ReindexTableSpec,
+    page: Array<Record<string, unknown>>,
+  ): Promise<number> {
+    const kept: Array<Record<string, unknown>> = [];
+    const texts: string[] = [];
+    for (const row of page) {
+      const t = spec.text(row).trim();
+      if (t) {
+        kept.push(row);
+        texts.push(t);
+      }
+    }
+    if (texts.length === 0) return 0;
+    const embeddings = await this.embedPageOrNull(texts, `${spec.table} ${ctx.companyId}`);
+    if (!embeddings) return 0;
+    const entries = kept.map((row, i) => ({ id: row.id, vector: embeddings[i] }));
+    return this.writePage(ctx, spec.vectorField, entries);
+  }
+
+  /** Embed a page, logging + swallowing a batch failure (returns null so the
+   *  caller advances past the page rather than retry-looping). */
+  private async embedPageOrNull(texts: string[], where: string): Promise<number[][] | null> {
+    try {
+      return await this.embedder.embedMany(texts);
+    } catch (e) {
+      this.logger.warn(
+        `reindex batch embed failed (${where}, page=${texts.length}): ${(e as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  /** Write each row's vector, tolerating a per-row failure. Returns the
+   *  number of rows successfully updated. */
+  private async writePage(
+    ctx: ReindexCtx,
+    vectorField: string,
+    entries: Array<{ id: unknown; vector: number[] | undefined }>,
+  ): Promise<number> {
+    let updated = 0;
+    for (const entry of entries) {
+      try {
+        await this.writeVector(ctx, vectorField, entry);
+        updated += 1;
+      } catch (e) {
+        this.logger.warn(
+          `reindex ${vectorField} row update failed (${ctx.companyId}): ${(e as Error).message}`,
+        );
+      }
+    }
+    return updated;
   }
 }

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -769,6 +769,26 @@ const KNOWN_BOOLEAN_FLAGS = [
   // confidence-gated ranking boost (cross-lingual facts demoted, never
   // hidden). Default off ⇒ the hard filter is byte-identical.
   'MULTILINGUAL_SOFT_LANG_FILTER',
+  // Multilingual Tier 2 (migration 0101). The embedding-space family stamps
+  // + guards the (model, dim, norm) space a vector lives in so flipping the
+  // embedder can't silently mix vector spaces. All default off; each is a
+  // cross-cutting embedding concern (EMBEDDING_ prefix), so — like the
+  // MULTILINGUAL_ / FOVEA_ families — it sits OFF the ENGINE flag budget.
+  //
+  // Stamp `embeddingSpaceId` on rewrite (reindex sweep). Off ⇒ no column
+  // written, serving byte-identical.
+  'EMBEDDING_SPACE_TRACKING',
+  // Strict-space serving guard: refuse a query embedded in a space
+  // incompatible with the target rows (no cross-space cosine, no warmup
+  // failover across incompatible dims). Off ⇒ the existing warmup failover
+  // is byte-identical.
+  'EMBEDDING_SPACE_STRICT',
+  // Shadow dual-write: arm a migration to write BOTH the active and the
+  // target space. Off ⇒ no target-space write is armed.
+  'EMBEDDING_SPACE_DUAL_WRITE',
+  // Per-tenant active-space selection + atomic cutover. Off ⇒ reads use the
+  // current provider space and the cutover admin surface refuses.
+  'EMBEDDING_SPACE_ACTIVE',
 ];
 
 /**

--- a/src/contracts/admin/write-responses.schema.ts
+++ b/src/contracts/admin/write-responses.schema.ts
@@ -152,6 +152,18 @@ export const ReindexRunResponseSchema = z.object({
   durationMs: z.number(),
   dryRun: z.boolean(),
   provider: z.string(),
+  // Tier 2: per-table sweep counts, present ONLY when the opt-in
+  // all-tables reindex ran. Absent on the default knowledge_fact-only
+  // path so the response stays byte-identical.
+  tables: z
+    .array(
+      z.object({
+        table: z.string(),
+        scanned: z.number(),
+        updated: z.number(),
+      }),
+    )
+    .optional(),
 });
 
 // ── Scenarios + baselines write responses ────────────────────────

--- a/src/db/migrations/0101_embedding_space.surql
+++ b/src/db/migrations/0101_embedding_space.surql
@@ -1,0 +1,102 @@
+-- 0101: embedding-space provenance (multilingual Tier 2).
+--
+-- WHY. Every table that stores a dense vector stores it in SOME embedding
+-- space — a (model, dimensionality, normalization) triple. Today that
+-- space is IMPLICIT: it is whatever `EMBEDDER_PROVIDER` happened to be
+-- when the row was written. Flipping the embedder (openai 1536 → bge-m3
+-- 1024, or a re-fit of the same model) silently MIXES spaces: a query
+-- embedded in one space gets cosine-compared against rows written in
+-- another, and the numbers are meaningless. `reindex-embeddings` only
+-- rewrites knowledge_fact, so entity / predicate / episode / segment /
+-- strategy vectors are left behind in the old space (hnsw-maintenance.ts
+-- already acknowledges this hole).
+--
+-- Tier 2 makes the space EXPLICIT and per-row. `embeddingSpaceId` is a
+-- canonical descriptor `provider:model:dim:norm`
+-- (e.g. `openai:text-embedding-3-small:1536:l2`). With it, a serving
+-- guard can refuse a cross-space compare, a reindex can stamp the space
+-- it rewrote into, and a zero-downtime migration can dual-write + cut a
+-- tenant over atomically.
+--
+-- ADDITIVE + OPTIONAL by construction (the 0098/0099/0100 posture): every
+-- new column is option<string>, so EXISTING ROWS READ NONE and NO backfill
+-- runs at migrate time. NONE is interpreted by the read path as "the
+-- current provider's space" (the legacy/implicit space) — byte-identical
+-- to pre-0101 behaviour. The write-time stamp is gated OFF by
+-- EMBEDDING_SPACE_TRACKING at the service layer, so with the flag off these
+-- columns are never written and never read. `embedding` / `altEmbedding` /
+-- the per-table vector columns are kept AS-IS; embeddingSpaceId sits beside
+-- them and describes the space they were produced in.
+--
+-- No migration-time data mutation: existing rows are re-stamped only by the
+-- explicit, flag-gated reindex sweep (POST /v1/admin/reindex/embeddings),
+-- never at migrate time.
+
+-- Every embedding-bearing table gets one `embeddingSpaceId`. A single
+-- column per row is correct even for knowledge_fact (which carries both
+-- `embedding` and `altEmbedding`): both are produced by the SAME active
+-- provider in one write, so they share one space descriptor.
+
+-- knowledge_fact — the primary fact vector (`embedding`) + the HyPE
+-- alternate vector (`altEmbedding`), both in the same space.
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON knowledge_fact TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;
+
+-- knowledge_entity — the entity-name/description vector.
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON knowledge_entity TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;
+
+-- knowledge_predicate — the predicate-registry embedding (0012).
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON knowledge_predicate TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;
+
+-- episode — the raw-turn substrate embedding (0073).
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON episode TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;
+
+-- episode_segment — the coverage-scan segment embedding (0075/0081).
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON episode_segment TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;
+
+-- strategy_memory — the experience-lane embedding (0092).
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON strategy_memory TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;
+
+-- community_node — the community-summary embedding (0036). Included for
+-- completeness so the whole vector store can declare its space; the
+-- reindex-all sweep does not regenerate summary vectors (they are derived
+-- from a summarization pass, not a plain re-embed), so this column is
+-- stamped only by a future community re-derive.
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON community_node TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;
+
+-- procedural_memory — the trigger embedding (0035). Same note as
+-- community_node: additive column now, stamped by its own write path later.
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON procedural_memory TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;
+
+-- ── Per-tenant active-space state (zero-downtime migration protocol) ──
+--
+-- The atomic cutover needs a durable, per-tenant record of WHICH space the
+-- tenant currently serves reads from, plus (during a migration) the target
+-- space it is dual-writing into. A single SCHEMAFULL row per tenant DB
+-- (`embedding_space_state:current`) holds it. Unset / absent ⇒ the tenant
+-- is wholly in the current provider's (legacy) space — the resolver
+-- defaults to that, so serving is byte-identical until an operator begins a
+-- migration. All fields optional; the table is inert unless
+-- EMBEDDING_SPACE_ACTIVE is on.
+DEFINE TABLE IF NOT EXISTS embedding_space_state SCHEMAFULL;
+-- The space the read path selects for this tenant (NONE ⇒ current provider
+-- space). A tenant is WHOLLY in one space at query time — never mixed.
+DEFINE FIELD IF NOT EXISTS activeSpace ON embedding_space_state TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;
+-- The space a migration is moving this tenant INTO (dual-write target).
+-- NONE ⇒ no migration in flight.
+DEFINE FIELD IF NOT EXISTS targetSpace ON embedding_space_state TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;
+-- True while shadow dual-write is arming the target space's vectors.
+DEFINE FIELD IF NOT EXISTS dualWrite ON embedding_space_state TYPE bool DEFAULT false;
+-- Audit: when the state last changed and what phase it is in.
+DEFINE FIELD IF NOT EXISTS phase ON embedding_space_state TYPE option<string>
+    ASSERT $value IS NONE OR $value IN ['idle', 'dual_write', 'cut_over'];
+DEFINE FIELD IF NOT EXISTS updatedAt ON embedding_space_state TYPE datetime DEFAULT time::now();

--- a/test/embedder-space-guard.unit-spec.ts
+++ b/test/embedder-space-guard.unit-spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Multilingual Tier 2 — EmbedderService strict-space guard
+ * (EMBEDDING_SPACE_STRICT).
+ *
+ * Proves:
+ *   - OFF (default): the warmup failover from a not-ready bge-m3 primary to
+ *     the OpenAI fallback is BYTE-IDENTICAL to today — embed() serves the
+ *     fallback vector, no throw.
+ *   - ON: the same cross-space failover is REFUSED (503) rather than
+ *     silently cross-space-compared.
+ *   - ON but compatible (primary ready, or openai-only deployment): serves
+ *     normally — the guard only fires on a genuine space mismatch.
+ */
+import { EmbedderService } from '../src/ai/embedder.service';
+import { ServiceUnavailableException } from '@nestjs/common';
+
+interface FakeProvider {
+  providerId: string;
+  getDimensions(): number;
+  isReady(): boolean;
+  embed(t: string): Promise<number[]>;
+  embedMany(t: string[]): Promise<number[][]>;
+}
+
+const bge = (ready: boolean): FakeProvider => ({
+  providerId: 'bge-m3:Xenova/bge-m3:1024',
+  getDimensions: () => 1024,
+  isReady: () => ready,
+  embed: async () => new Array(1024).fill(0.1),
+  embedMany: async (t) => t.map(() => new Array(1024).fill(0.1)),
+});
+
+const openai = (): FakeProvider => ({
+  providerId: 'openai:text-embedding-3-small:1536',
+  getDimensions: () => 1536,
+  isReady: () => true,
+  embed: async () => new Array(1536).fill(0.2),
+  embedMany: async (t) => t.map(() => new Array(1536).fill(0.2)),
+});
+
+function mkSvc(opts: {
+  strict?: string | undefined;
+  primary: FakeProvider;
+  fallback: FakeProvider | null;
+  primarySpaceId: string;
+}): EmbedderService {
+  const config = {
+    get: (k: string, def?: string) => {
+      if (k === 'EMBEDDING_SPACE_STRICT') return opts.strict;
+      if (k === 'OPENAI_API_KEY') return 'sk-test-stub';
+      if (k === 'OPENAI_EMBEDDING_DIMENSIONS') return '1536';
+      if (k === 'EMBEDDING_CACHE_SIZE') return '50';
+      if (k === 'EMBEDDER_PROVIDER') return 'openai';
+      return def;
+    },
+    getOrThrow: () => 'sk-test-stub',
+  } as never;
+  const svc = new EmbedderService(config);
+  (svc as unknown as { primary: FakeProvider }).primary = opts.primary;
+  (svc as unknown as { fallback: FakeProvider | null }).fallback = opts.fallback;
+  (svc as unknown as { primarySpaceIdValue: string }).primarySpaceIdValue = opts.primarySpaceId;
+  return svc;
+}
+
+const BGE_SPACE = 'bge-m3:Xenova/bge-m3:1024:l2';
+const OPENAI_SPACE = 'openai:text-embedding-3-small:1536:l2';
+
+describe('EmbedderService strict-space guard', () => {
+  it('OFF: cross-space warmup failover is byte-identical (serves the fallback)', async () => {
+    const svc = mkSvc({
+      strict: undefined, // flag off
+      primary: bge(false), // not warmed up yet
+      fallback: openai(),
+      primarySpaceId: BGE_SPACE,
+    });
+    const v = await svc.embed('hello');
+    expect(v).toHaveLength(1536); // the OpenAI fallback served, exactly as today
+    const many = await svc.embedMany(['a', 'b']);
+    expect(many).toHaveLength(2);
+    expect(many[0]).toHaveLength(1536);
+  });
+
+  it('ON: refuses the cross-space failover (503), no silent cross-space compare', async () => {
+    const svc = mkSvc({
+      strict: '1',
+      primary: bge(false),
+      fallback: openai(),
+      primarySpaceId: BGE_SPACE,
+    });
+    await expect(svc.embed('hello')).rejects.toBeInstanceOf(ServiceUnavailableException);
+    await expect(svc.embed('hello')).rejects.toThrow(/strict-guard/i);
+    await expect(svc.embedMany(['a'])).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+
+  it('ON but primary READY: serves the primary space (compatible ⇒ no throw)', async () => {
+    const svc = mkSvc({
+      strict: '1',
+      primary: bge(true), // warmed up: active == primary
+      fallback: openai(),
+      primarySpaceId: BGE_SPACE,
+    });
+    const v = await svc.embed('hello');
+    expect(v).toHaveLength(1024); // bge-m3 primary served
+  });
+
+  it('ON with openai-only deployment (no fallback): never fires', async () => {
+    const svc = mkSvc({
+      strict: '1',
+      primary: openai(),
+      fallback: null,
+      primarySpaceId: OPENAI_SPACE,
+    });
+    const v = await svc.embed('hello');
+    expect(v).toHaveLength(1536);
+  });
+
+  it('exposes activeSpaceId / primarySpaceId', () => {
+    const svc = mkSvc({
+      strict: undefined,
+      primary: bge(false),
+      fallback: openai(),
+      primarySpaceId: BGE_SPACE,
+    });
+    expect(svc.primarySpaceId()).toBe(BGE_SPACE);
+    // active = fallback while primary is warming
+    expect(svc.activeSpaceId()).toBe(OPENAI_SPACE);
+  });
+});

--- a/test/embedding-space-service.unit-spec.ts
+++ b/test/embedding-space-service.unit-spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Multilingual Tier 2 — EmbeddingSpaceService (zero-downtime protocol).
+ *
+ * Proves:
+ *   - flags OFF (default): activeSpaceFor returns the current provider space
+ *     with NO db read — byte-identical serving; the mutating ops refuse.
+ *   - begin arms dual-write into the target (gated by DUAL_WRITE).
+ *   - cutover is ATOMIC (a single UPSERT flipping activeSpace ← target and
+ *     clearing the target) and refuses unless that migration is in flight.
+ */
+import { EmbeddingSpaceService } from '../src/ai/embedder/embedding-space.service';
+
+const PROVIDER_SPACE = 'openai:text-embedding-3-small:1536:l2';
+const TARGET_SPACE = 'bge-m3:Xenova/bge-m3:1024:l2';
+
+interface Mutation {
+  sql: string;
+  params: Record<string, unknown> | undefined;
+}
+
+function makeSvc(opts: {
+  active?: string | undefined;
+  dualWrite?: string | undefined;
+  stateRow?: Record<string, unknown> | null | undefined;
+}) {
+  const mutations: Mutation[] = [];
+  let selects = 0;
+  // Mutable state seeded from the initial row so that reads AFTER an UPSERT
+  // reflect the write (the real singleton row behaves this way).
+  let current: Record<string, unknown> | null = opts.stateRow ?? null;
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      if (/UPSERT/.test(sql)) {
+        mutations.push({ sql, params });
+        // Apply the recognizable mutation to the mutable state.
+        if (sql.includes('activeSpace = $target')) {
+          current = {
+            activeSpace: params?.target,
+            targetSpace: null,
+            dualWrite: false,
+            phase: 'cut_over',
+          };
+        } else if (sql.includes('dualWrite = true')) {
+          current = {
+            activeSpace: params?.active,
+            targetSpace: params?.target,
+            dualWrite: true,
+            phase: 'dual_write',
+          };
+        } else {
+          current = { ...(current ?? {}), targetSpace: null, dualWrite: false, phase: 'idle' };
+        }
+        return [[]];
+      }
+      selects += 1; // SELECT FROM embedding_space_state:current
+      return [current ? [current] : []];
+    },
+  };
+  const surreal = {
+    withCompany: async <T>(_c: string, fn: (d: typeof db) => Promise<T>) => fn(db),
+  } as never;
+  const embedder = { primarySpaceId: () => PROVIDER_SPACE } as never;
+  const config = {
+    get: (k: string, def?: string) => {
+      if (k === 'EMBEDDING_SPACE_ACTIVE') return opts.active;
+      if (k === 'EMBEDDING_SPACE_DUAL_WRITE') return opts.dualWrite;
+      return def;
+    },
+  } as never;
+  return {
+    svc: new EmbeddingSpaceService(surreal, embedder, config),
+    mutations,
+    selectCount: () => selects,
+  };
+}
+
+describe('EmbeddingSpaceService — resolver defaults (flags off ⇒ byte-identical)', () => {
+  it('activeSpaceFor returns the provider space with NO db read when ACTIVE is off', async () => {
+    const { svc, selectCount } = makeSvc({ active: undefined });
+    expect(await svc.activeSpaceFor('acme')).toBe(PROVIDER_SPACE);
+    expect(selectCount()).toBe(0);
+  });
+
+  it('targetSpaceFor is null when DUAL_WRITE is off', async () => {
+    const { svc } = makeSvc({
+      dualWrite: undefined,
+      stateRow: { targetSpace: TARGET_SPACE, dualWrite: true },
+    });
+    expect(await svc.targetSpaceFor('acme')).toBeNull();
+  });
+
+  it('activeSpaceFor reads the stored active space when ACTIVE is on', async () => {
+    const { svc } = makeSvc({ active: '1', stateRow: { activeSpace: TARGET_SPACE } });
+    expect(await svc.activeSpaceFor('acme')).toBe(TARGET_SPACE);
+  });
+
+  it('activeSpaceFor falls back to the provider space when no state row exists', async () => {
+    const { svc } = makeSvc({ active: '1', stateRow: null });
+    expect(await svc.activeSpaceFor('acme')).toBe(PROVIDER_SPACE);
+  });
+});
+
+describe('EmbeddingSpaceService — begin migration', () => {
+  it('refuses when DUAL_WRITE is off', async () => {
+    const { svc } = makeSvc({ dualWrite: undefined });
+    await expect(svc.beginMigration('acme', TARGET_SPACE)).rejects.toThrow(
+      /EMBEDDING_SPACE_DUAL_WRITE is off/i,
+    );
+  });
+
+  it('arms dual-write into the target space', async () => {
+    const { svc, mutations } = makeSvc({ dualWrite: '1', active: '1', stateRow: null });
+    await svc.beginMigration('acme', TARGET_SPACE);
+    const upsert = mutations.find((m) => m.sql.includes('dualWrite = true'));
+    expect(upsert).toBeDefined();
+    expect(upsert!.params?.target).toBe(TARGET_SPACE);
+    expect(upsert!.sql).toContain("phase = 'dual_write'");
+  });
+
+  it('refuses to migrate into the already-active space', async () => {
+    const { svc } = makeSvc({ dualWrite: '1', active: undefined });
+    await expect(svc.beginMigration('acme', PROVIDER_SPACE)).rejects.toThrow(
+      /equals the active space/i,
+    );
+  });
+});
+
+describe('EmbeddingSpaceService — atomic cutover', () => {
+  it('refuses when ACTIVE is off', async () => {
+    const { svc } = makeSvc({ active: undefined });
+    await expect(svc.cutover('acme', TARGET_SPACE)).rejects.toThrow(
+      /EMBEDDING_SPACE_ACTIVE is off/i,
+    );
+  });
+
+  it('refuses unless a migration into that target is in flight', async () => {
+    const { svc } = makeSvc({
+      active: '1',
+      stateRow: { activeSpace: PROVIDER_SPACE, targetSpace: null },
+    });
+    await expect(svc.cutover('acme', TARGET_SPACE)).rejects.toThrow(/no migration into/i);
+  });
+
+  it('flips active ← target in a SINGLE atomic UPSERT and clears the target', async () => {
+    const { svc, mutations } = makeSvc({
+      active: '1',
+      stateRow: { activeSpace: PROVIDER_SPACE, targetSpace: TARGET_SPACE, dualWrite: true },
+    });
+    const state = await svc.cutover('acme', TARGET_SPACE);
+    expect(state.activeSpace).toBe(TARGET_SPACE);
+
+    // Exactly one mutation statement — the atomic flip.
+    expect(mutations).toHaveLength(1);
+    const sql = mutations[0]!.sql;
+    expect(sql).toContain('activeSpace = $target');
+    expect(sql).toContain('targetSpace = NONE');
+    expect(sql).toContain('dualWrite = false');
+    expect(mutations[0]!.params?.target).toBe(TARGET_SPACE);
+  });
+});

--- a/test/embedding-space.e2e-spec.ts
+++ b/test/embedding-space.e2e-spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Multilingual Tier 2 e2e — proves against a REAL SurrealDB that:
+ *   - migration 0101 applies on the tenant DB;
+ *   - the `embeddingSpaceId` column round-trips on knowledge_fact;
+ *   - the per-tenant embedding_space_state + ATOMIC cutover round-trip;
+ *   - the reindex sweep stamps `embeddingSpaceId` under EMBEDDING_SPACE_TRACKING.
+ *
+ * The strict-space guard is a property of the REAL EmbedderService, which the
+ * app-fixture replaces with StubEmbedder — so it is proven at the unit level
+ * (embedder-space-guard.unit-spec) against the real serveProvider logic, not
+ * here. No paid eval: the embedder is stubbed and no synthesize/OpenAI call
+ * is made.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { EmbeddingSpaceService } from '../src/ai/embedder/embedding-space.service';
+import { ReindexEmbeddingsService } from '../src/ai/embedder/reindex-embeddings.service';
+
+const OPENAI_SPACE = 'openai:text-embedding-3-small:1536:l2';
+const BGE_SPACE = 'bge-m3:Xenova/bge-m3:1024:l2';
+
+describe('Multilingual Tier 2 — embedding-space e2e (migration 0101)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    for (const k of [
+      'EMBEDDING_SPACE_STRICT',
+      'EMBEDDING_SPACE_TRACKING',
+      'EMBEDDING_SPACE_ACTIVE',
+      'EMBEDDING_SPACE_DUAL_WRITE',
+    ]) {
+      delete process.env[k];
+    }
+    f = await createApp();
+    await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'space_tenant' },
+        predicate: 'status',
+        object: 'active',
+        validFrom: '2026-04-01',
+        source: { vertical: 'rent', eventId: 'auth.profile_updated' },
+      });
+  });
+
+  afterAll(async () => {
+    for (const k of [
+      'EMBEDDING_SPACE_STRICT',
+      'EMBEDDING_SPACE_TRACKING',
+      'EMBEDDING_SPACE_ACTIVE',
+      'EMBEDDING_SPACE_DUAL_WRITE',
+    ]) {
+      delete process.env[k];
+    }
+    if (f) await f.close();
+  });
+
+  it('migration 0101 is applied on the tenant DB', async () => {
+    const surreal = f.app.get(SurrealService);
+    const count = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ migrationId: string }>]>(
+        `SELECT migrationId FROM schema_migrations WHERE migrationId = '0101'`,
+      );
+      return ((rows as Array<{ migrationId: string }>) ?? []).length;
+    });
+    expect(count).toBe(1);
+  });
+
+  it('embeddingSpaceId column round-trips on knowledge_fact', async () => {
+    const surreal = f.app.get(SurrealService);
+    const value = await surreal.withCompany(f.companyId, async (db) => {
+      const [facts] = await db.query<[Array<{ id: unknown }>]>(
+        `SELECT id FROM knowledge_fact LIMIT 1`,
+      );
+      const id = (facts as Array<{ id: unknown }>)[0]?.id;
+      expect(id).toBeTruthy();
+      await db.query(`UPDATE $id SET embeddingSpaceId = $s`, { id, s: OPENAI_SPACE });
+      const [rows] = await db.query<[Array<{ embeddingSpaceId?: string }>]>(
+        `SELECT embeddingSpaceId FROM knowledge_fact WHERE id = $id`,
+        { id },
+      );
+      return (rows as Array<{ embeddingSpaceId?: string }>)[0]?.embeddingSpaceId;
+    });
+    expect(value).toBe(OPENAI_SPACE);
+  });
+
+  it('embedding_space_state + atomic cutover round-trip on a real DB', async () => {
+    process.env.EMBEDDING_SPACE_ACTIVE = '1';
+    process.env.EMBEDDING_SPACE_DUAL_WRITE = '1';
+    try {
+      const spaces = f.app.get(EmbeddingSpaceService);
+      await spaces.beginMigration(f.companyId, BGE_SPACE);
+      const mid = await spaces.getState(f.companyId);
+      expect(mid.targetSpace).toBe(BGE_SPACE);
+      expect(mid.dualWrite).toBe(true);
+
+      const after = await spaces.cutover(f.companyId, BGE_SPACE);
+      expect(after.activeSpace).toBe(BGE_SPACE);
+      expect(after.targetSpace).toBeNull();
+      expect(after.dualWrite).toBe(false);
+      // The resolver now serves the target space wholly.
+      expect(await spaces.activeSpaceFor(f.companyId)).toBe(BGE_SPACE);
+    } finally {
+      delete process.env.EMBEDDING_SPACE_ACTIVE;
+      delete process.env.EMBEDDING_SPACE_DUAL_WRITE;
+    }
+  });
+
+  it('reindex sweep stamps embeddingSpaceId under EMBEDDING_SPACE_TRACKING', async () => {
+    const surreal = f.app.get(SurrealService);
+    // Clear any stamp left by an earlier test so we observe the reindex write.
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(`UPDATE knowledge_fact SET embeddingSpaceId = NONE`);
+    });
+
+    process.env.EMBEDDING_SPACE_TRACKING = '1';
+    try {
+      const reindex = f.app.get(ReindexEmbeddingsService);
+      const res = await reindex.run({ tenant: f.companyId });
+      expect(res.factsUpdated).toBeGreaterThanOrEqual(1);
+    } finally {
+      delete process.env.EMBEDDING_SPACE_TRACKING;
+    }
+
+    const stamped = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ embeddingSpaceId?: string }>]>(
+        `SELECT embeddingSpaceId FROM knowledge_fact WHERE embeddingSpaceId != NONE`,
+      );
+      return (rows as Array<{ embeddingSpaceId?: string }>) ?? [];
+    });
+    expect(stamped.length).toBeGreaterThanOrEqual(1);
+    // StubEmbedder emulates the default OpenAI 1536 space.
+    expect(stamped[0]!.embeddingSpaceId).toBe(OPENAI_SPACE);
+  });
+});

--- a/test/embedding-space.unit-spec.ts
+++ b/test/embedding-space.unit-spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Multilingual Tier 2 — canonical embedding-space helpers.
+ *
+ * Pins the id FORMAT (provider:model:dim:norm) and the EXPLICIT
+ * compatibility test (different dim / model / norm ⇒ incompatible), plus the
+ * providerId → space-id derivation the embedder guard relies on.
+ */
+import {
+  embeddingSpaceId,
+  embeddingSpaceIdFromProviderId,
+  parseEmbeddingSpaceId,
+  spacesCompatible,
+  describeSpaceIncompatibility,
+  EMBEDDING_SPACE_FIELD,
+  EMBEDDING_TABLES,
+} from '../src/ai/embedder/embedding-space';
+
+describe('embeddingSpaceId — canonical descriptor', () => {
+  it('formats provider:model:dim:norm', () => {
+    expect(
+      embeddingSpaceId({
+        provider: 'openai',
+        model: 'text-embedding-3-small',
+        dim: 1536,
+        norm: 'l2',
+      }),
+    ).toBe('openai:text-embedding-3-small:1536:l2');
+    expect(
+      embeddingSpaceId({ provider: 'bge-m3', model: 'Xenova/bge-m3', dim: 1024, norm: 'l2' }),
+    ).toBe('bge-m3:Xenova/bge-m3:1024:l2');
+  });
+
+  it('is a pure function — identical config ⇒ identical id', () => {
+    const cfg = { provider: 'openai', model: 'm', dim: 8, norm: 'l2' } as const;
+    expect(embeddingSpaceId(cfg)).toBe(embeddingSpaceId({ ...cfg }));
+  });
+});
+
+describe('embeddingSpaceIdFromProviderId', () => {
+  it('derives the space id from a vendor:model:dim providerId + norm', () => {
+    expect(embeddingSpaceIdFromProviderId('openai:text-embedding-3-small:1536', 'l2')).toBe(
+      'openai:text-embedding-3-small:1536:l2',
+    );
+    expect(embeddingSpaceIdFromProviderId('bge-m3:Xenova/bge-m3:1024', 'l2')).toBe(
+      'bge-m3:Xenova/bge-m3:1024:l2',
+    );
+  });
+
+  it('returns null for a non-three-part providerId (e.g. a stub)', () => {
+    expect(embeddingSpaceIdFromProviderId('stub', 'l2')).toBeNull();
+    expect(embeddingSpaceIdFromProviderId('vendor:model', 'l2')).toBeNull();
+    expect(embeddingSpaceIdFromProviderId('openai:model:notanumber', 'l2')).toBeNull();
+  });
+});
+
+describe('parseEmbeddingSpaceId', () => {
+  it('round-trips a canonical id (model with a slash)', () => {
+    expect(parseEmbeddingSpaceId('bge-m3:Xenova/bge-m3:1024:l2')).toEqual({
+      provider: 'bge-m3',
+      model: 'Xenova/bge-m3',
+      dim: 1024,
+      norm: 'l2',
+    });
+  });
+
+  it('rejects malformed ids', () => {
+    expect(parseEmbeddingSpaceId('too:short')).toBeNull();
+    expect(parseEmbeddingSpaceId('a:b:notnum:l2')).toBeNull();
+  });
+});
+
+describe('spacesCompatible — the EXPLICIT incompatibility test', () => {
+  const openai = 'openai:text-embedding-3-small:1536:l2';
+  const bge = 'bge-m3:Xenova/bge-m3:1024:l2';
+
+  it('identical ids are compatible', () => {
+    expect(spacesCompatible(openai, openai)).toBe(true);
+  });
+
+  it('different DIM ⇒ incompatible', () => {
+    const other = 'openai:text-embedding-3-small:1024:l2';
+    expect(spacesCompatible(openai, other)).toBe(false);
+    expect(describeSpaceIncompatibility(openai, other)).toContain('dim');
+  });
+
+  it('different MODEL ⇒ incompatible', () => {
+    const other = 'openai:text-embedding-3-large:1536:l2';
+    expect(spacesCompatible(openai, other)).toBe(false);
+    expect(describeSpaceIncompatibility(openai, other)).toContain('model');
+  });
+
+  it('different NORM ⇒ incompatible', () => {
+    const other = 'openai:text-embedding-3-small:1536:none';
+    expect(spacesCompatible(openai, other)).toBe(false);
+    expect(describeSpaceIncompatibility(openai, other)).toContain('norm');
+  });
+
+  it('openai vs bge-m3 are incompatible (provider + model + dim differ)', () => {
+    expect(spacesCompatible(openai, bge)).toBe(false);
+  });
+
+  it('an unparseable id is compatible ONLY with a byte-identical id', () => {
+    expect(spacesCompatible('stub', 'stub')).toBe(true);
+    expect(spacesCompatible('stub', openai)).toBe(false);
+  });
+
+  it('compatible ids ⇒ describeSpaceIncompatibility returns null', () => {
+    expect(describeSpaceIncompatibility(openai, openai)).toBeNull();
+  });
+});
+
+describe('EMBEDDING_TABLES / field constant', () => {
+  it('names the column once', () => {
+    expect(EMBEDDING_SPACE_FIELD).toBe('embeddingSpaceId');
+  });
+
+  it('enumerates every embedding-bearing table with its vector columns', () => {
+    const tables = EMBEDDING_TABLES.map((t) => t.table);
+    expect(tables).toEqual([
+      'knowledge_fact',
+      'knowledge_entity',
+      'knowledge_predicate',
+      'episode',
+      'episode_segment',
+      'strategy_memory',
+      'community_node',
+      'procedural_memory',
+    ]);
+    const fact = EMBEDDING_TABLES.find((t) => t.table === 'knowledge_fact')!;
+    expect(fact.vectorFields).toEqual(['embedding', 'altEmbedding']);
+  });
+});

--- a/test/eval/multilingual/ab-harness.ts
+++ b/test/eval/multilingual/ab-harness.ts
@@ -1,0 +1,163 @@
+/**
+ * Multilingual Tier 2 — embedder A/B harness (SCAFFOLD, no paid scoring).
+ *
+ * Compares several embedding "arms" — OpenAI vs bge-m3 vs bge-m3+reranker —
+ * over the Tier-0 multilingual matrix and lays their metrics side by side so
+ * a space migration can be justified by numbers rather than a hunch. It is
+ * deliberately a scaffold: every arm's model comes from the SAME Tier-0
+ * spend gate (`createMultilingualModel`), so in CI every arm runs on the
+ * deterministic StubModel and NO real / paid embedder call is reachable.
+ * The live path (a real embedder behind each arm) stays inert exactly like
+ * Tier 0's RealModel — its `predict` throws — until it is deliberately built
+ * behind MULTILINGUAL_EVAL_LIVE.
+ *
+ * Each arm carries its canonical `embeddingSpaceId` (Tier 2) purely as
+ * provenance on the comparison — so a report says which vector space each
+ * column was produced in.
+ */
+
+import type { MultilingualCase, MultilingualMatrixReport } from '../../../src/eval/types';
+import { embeddingSpaceId } from '../../../src/ai/embedder/embedding-space';
+import { MultilingualMatrixRunner } from './matrix-runner';
+import {
+  createMultilingualModel,
+  isLiveEvalEnabled,
+  type MultilingualModelEnv,
+  type StubMode,
+} from './model';
+
+export interface AbArm {
+  /** Display name, e.g. `openai` | `bge-m3` | `bge-m3+reranker`. */
+  name: string;
+  /** Canonical embedding-space id of the arm's embedder — provenance only. */
+  spaceId: string;
+  /** Whether this arm also applies a reranker over the retrieved pool. Only
+   *  metadata in the scaffold; the live wiring would route retrieval through
+   *  a cross-encoder before scoring. */
+  reranker?: boolean;
+  /** In the stub/CI path, how this arm's StubModel behaves. Lets a caller
+   *  make the A/B diff visibly non-zero without any real model. */
+  stubMode?: StubMode;
+}
+
+export interface AbArmResult {
+  arm: string;
+  spaceId: string;
+  reranker: boolean;
+  report: MultilingualMatrixReport;
+}
+
+export interface AbMetricRow {
+  metric: string;
+  /** arm name → overall value for that metric (null when N/A). */
+  values: Record<string, number | null>;
+}
+
+export interface AbComparison {
+  generatedAt: string;
+  /** 'stub' in CI; 'real' only under MULTILINGUAL_EVAL_LIVE + a key. */
+  modelKind: 'stub' | 'real';
+  arms: AbArmResult[];
+  /** Overall metric values laid out per arm — the side-by-side table. */
+  overallByMetric: AbMetricRow[];
+}
+
+/**
+ * The three canonical arms of the Tier-2 comparison. Space ids are built via
+ * the pure helper so they stay in lockstep with the serving-side descriptors.
+ */
+export const DEFAULT_AB_ARMS: AbArm[] = [
+  {
+    name: 'openai',
+    spaceId: embeddingSpaceId({
+      provider: 'openai',
+      model: 'text-embedding-3-small',
+      dim: 1536,
+      norm: 'l2',
+    }),
+    stubMode: 'perfect',
+  },
+  {
+    name: 'bge-m3',
+    spaceId: embeddingSpaceId({
+      provider: 'bge-m3',
+      model: 'Xenova/bge-m3',
+      dim: 1024,
+      norm: 'l2',
+    }),
+    stubMode: 'perfect',
+  },
+  {
+    name: 'bge-m3+reranker',
+    spaceId: embeddingSpaceId({
+      provider: 'bge-m3',
+      model: 'Xenova/bge-m3',
+      dim: 1024,
+      norm: 'l2',
+    }),
+    reranker: true,
+    stubMode: 'perfect',
+  },
+];
+
+export class MultilingualAbHarness {
+  constructor(private readonly runner: MultilingualMatrixRunner = new MultilingualMatrixRunner()) {}
+
+  /** True only when a live A/B run is explicitly enabled (never in CI). */
+  isLive(env: MultilingualModelEnv = process.env): boolean {
+    return isLiveEvalEnabled(env);
+  }
+
+  /**
+   * Score every arm over the matrix and lay the overall metrics side by side.
+   * Each arm's model comes from the Tier-0 spend gate, so this is stub-only
+   * in CI. Throws (never bills) if the live flag is set without a key —
+   * inherited straight from `createMultilingualModel`.
+   */
+  run(
+    cases: MultilingualCase[],
+    arms: AbArm[] = DEFAULT_AB_ARMS,
+    env: MultilingualModelEnv = process.env,
+  ): AbComparison {
+    const results: AbArmResult[] = arms.map((arm) => {
+      // Conditional spread: under exactOptionalPropertyTypes an explicit
+      // `mode: undefined` is not assignable to StubModelOptions.
+      const model = createMultilingualModel(env, arm.stubMode ? { mode: arm.stubMode } : {});
+      return {
+        arm: arm.name,
+        spaceId: arm.spaceId,
+        reranker: arm.reranker === true,
+        report: this.runner.run(cases, model),
+      };
+    });
+
+    // Union of metric names across arms (they share the Tier-0 column set,
+    // but union keeps this robust to arm-specific columns later).
+    const metricNames: string[] = [];
+    const seen = new Set<string>();
+    for (const r of results) {
+      for (const cellMetric of r.report.overall) {
+        if (!seen.has(cellMetric.metric)) {
+          seen.add(cellMetric.metric);
+          metricNames.push(cellMetric.metric);
+        }
+      }
+    }
+
+    const overallByMetric: AbMetricRow[] = metricNames.map((metric) => {
+      const values: Record<string, number | null> = {};
+      for (const r of results) {
+        const c = r.report.overall.find((x) => x.metric === metric);
+        values[r.arm] = c ? c.value : null;
+      }
+      return { metric, values };
+    });
+
+    return {
+      generatedAt: new Date().toISOString(),
+      modelKind: results[0]?.report.modelKind ?? 'stub',
+      arms: results,
+      overallByMetric,
+    };
+  }
+}

--- a/test/eval/multilingual/index.ts
+++ b/test/eval/multilingual/index.ts
@@ -5,3 +5,5 @@ export type { MultilingualModel, StubMode, StubModelOptions, MultilingualModelEn
 export { MultilingualMatrixRunner } from './matrix-runner';
 export { MultilingualReporter } from './matrix-reporter';
 export type { SerializedMultilingualReport } from './matrix-reporter';
+export { MultilingualAbHarness, DEFAULT_AB_ARMS } from './ab-harness';
+export type { AbArm, AbArmResult, AbComparison, AbMetricRow } from './ab-harness';

--- a/test/multilingual-ab-harness.unit-spec.ts
+++ b/test/multilingual-ab-harness.unit-spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Multilingual Tier 2 — embedder A/B harness (SCAFFOLD).
+ *
+ * Proves the comparison wiring works AND that no paid call is reachable:
+ *   - default env → every arm runs on the StubModel (modelKind 'stub')
+ *   - the overall metrics are laid side-by-side per arm, tagged with each
+ *     arm's canonical embeddingSpaceId
+ *   - the live gate is inherited from Tier 0: live flag without a key throws
+ *     rather than billing
+ *   - a degraded arm visibly diverges from a perfect arm (scorers wired)
+ */
+import { multilingualMatrix } from '../src/eval/scenarios';
+import { MultilingualAbHarness, DEFAULT_AB_ARMS } from './eval/multilingual/ab-harness';
+
+describe('MultilingualAbHarness — stub-only comparison (no paid eval)', () => {
+  const harness = new MultilingualAbHarness();
+
+  it('default env → all arms are stub, never a live model', () => {
+    const cmp = harness.run(multilingualMatrix, DEFAULT_AB_ARMS, {});
+    expect(cmp.modelKind).toBe('stub');
+    expect(cmp.arms.map((a) => a.arm)).toEqual(['openai', 'bge-m3', 'bge-m3+reranker']);
+    for (const arm of cmp.arms) expect(arm.report.modelKind).toBe('stub');
+  });
+
+  it('tags each arm with its canonical embeddingSpaceId + reranker flag', () => {
+    const cmp = harness.run(multilingualMatrix, DEFAULT_AB_ARMS, {});
+    const byName = new Map(cmp.arms.map((a) => [a.arm, a]));
+    expect(byName.get('openai')!.spaceId).toBe('openai:text-embedding-3-small:1536:l2');
+    expect(byName.get('bge-m3')!.spaceId).toBe('bge-m3:Xenova/bge-m3:1024:l2');
+    expect(byName.get('bge-m3+reranker')!.reranker).toBe(true);
+  });
+
+  it('lays overall metrics side-by-side per arm', () => {
+    const cmp = harness.run(multilingualMatrix, DEFAULT_AB_ARMS, {});
+    const recall = cmp.overallByMetric.find((r) => r.metric === 'recall@1');
+    expect(recall).toBeDefined();
+    expect(Object.keys(recall!.values).sort()).toEqual(['bge-m3', 'bge-m3+reranker', 'openai']);
+    // Perfect-stub arms → recall@1 ≈ 1 for every arm.
+    for (const v of Object.values(recall!.values)) expect(v).toBeCloseTo(1, 6);
+  });
+
+  it('a degraded arm diverges from a perfect arm (scorers actually wired)', () => {
+    const cmp = harness.run(
+      multilingualMatrix,
+      [
+        { name: 'perfect', spaceId: 'openai:m:1536:l2', stubMode: 'perfect' },
+        { name: 'degraded', spaceId: 'bge-m3:m:1024:l2', stubMode: 'degraded' },
+      ],
+      {},
+    );
+    const recall = cmp.overallByMetric.find((r) => r.metric === 'recall@1')!;
+    expect(recall.values.perfect).toBeCloseTo(1, 6);
+    expect(recall.values.degraded).toBe(0);
+  });
+
+  it('inherits the Tier-0 spend gate: live flag without a key throws (never bills)', () => {
+    expect(harness.isLive({})).toBe(false);
+    expect(harness.isLive({ MULTILINGUAL_EVAL_LIVE: '1' })).toBe(true);
+    expect(() =>
+      harness.run(multilingualMatrix, DEFAULT_AB_ARMS, { MULTILINGUAL_EVAL_LIVE: '1' }),
+    ).toThrow(/refusing to construct a live model/i);
+  });
+});

--- a/test/reindex-engine-space.unit-spec.ts
+++ b/test/reindex-engine-space.unit-spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Multilingual Tier 2 — ReindexEngineService.
+ *
+ * Proves:
+ *   - DEFAULT (allTables off, tracking off): only knowledge_fact is
+ *     SELECTed, the UPDATE is the pre-Tier-2 `SET embedding = $embedding`
+ *     (no embeddingSpaceId), and the result carries NO `tables` key. Byte-
+ *     identical to the historical reindex.
+ *   - allTables ON: the non-fact tables are swept and a per-table breakdown
+ *     is returned.
+ *   - EMBEDDING_SPACE_TRACKING ON: every rewrite ALSO stamps
+ *     `embeddingSpaceId = <active space>`.
+ */
+import { ReindexEngineService } from '../src/ai/embedder/reindex-engine.service';
+
+interface QueryCall {
+  sql: string;
+  params: Record<string, unknown> | undefined;
+}
+
+/** Fake Surreal DB — answers the paginated SELECTs from a per-table page and
+ *  records the UPDATE statements so the test can inspect the SET clause. */
+function makeDb(pages: Record<string, Array<Record<string, unknown>>>) {
+  const calls: QueryCall[] = [];
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      calls.push({ sql, params });
+      if (/^\s*UPDATE/.test(sql)) return [[]];
+      // SELECT — first page returns rows, subsequent pages empty.
+      const offset = Number(params?.offset ?? 0);
+      for (const [table, rows] of Object.entries(pages)) {
+        if (sql.includes(`FROM ${table}`)) return [offset === 0 ? rows : []];
+      }
+      return [[]];
+    },
+  };
+  return { db, calls };
+}
+
+const ACTIVE_SPACE = 'openai:text-embedding-3-small:1536:l2';
+
+function makeEngine(opts: {
+  pages: Record<string, Array<Record<string, unknown>>>;
+  tracking?: string;
+}) {
+  const { db, calls } = makeDb(opts.pages);
+  const surreal = {
+    withCompany: async <T>(_c: string, fn: (d: typeof db) => Promise<T>) => fn(db),
+  } as never;
+  const embedder = {
+    embedMany: async (texts: string[]) => texts.map(() => [1, 2, 3]),
+    activeSpaceId: () => ACTIVE_SPACE,
+    cacheStats: () => ({ provider: 'openai:text-embedding-3-small:1536' }),
+  } as never;
+  const config = {
+    get: (k: string, def?: string) => {
+      if (k === 'REINDEX_BATCH_SIZE') return '200';
+      if (k === 'EMBEDDING_SPACE_TRACKING') return opts.tracking;
+      return def;
+    },
+  } as never;
+  return { engine: new ReindexEngineService(surreal, embedder, config), calls };
+}
+
+const FACT_PAGE = [{ id: 'knowledge_fact:1', predicate: 'status', object: 'active' }];
+const ALL_PAGES = {
+  knowledge_fact: FACT_PAGE,
+  knowledge_entity: [{ id: 'knowledge_entity:1', name: 'Alice', canonicalName: 'Alice' }],
+  knowledge_predicate: [
+    { id: 'knowledge_predicate:1', predicateId: 'works_at', description: 'employer' },
+  ],
+  episode: [{ id: 'episode:1', text: 'hello world' }],
+  episode_segment: [{ id: 'episode_segment:1', text: 'segment text' }],
+  strategy_memory: [{ id: 'strategy_memory:1', title: 'T', situation: 'S' }],
+};
+
+describe('ReindexEngineService — default path (byte-identical)', () => {
+  it('reindexes knowledge_fact ONLY and returns no tables key', async () => {
+    const { engine, calls } = makeEngine({ pages: ALL_PAGES });
+    const res = await engine.reindexTenant('acme', { dryRun: false, remaining: 1000 });
+
+    expect(res.factsScanned).toBe(1);
+    expect(res.factsUpdated).toBe(1);
+    expect(res).not.toHaveProperty('tables');
+
+    // No non-fact table was ever SELECTed.
+    const selects = calls.filter((c) => /^\s*SELECT/.test(c.sql));
+    expect(selects.every((c) => c.sql.includes('FROM knowledge_fact'))).toBe(true);
+
+    // The UPDATE is exactly the historical clause — NO embeddingSpaceId.
+    const updates = calls.filter((c) => /^\s*UPDATE/.test(c.sql));
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.sql).toContain('SET embedding = $embedding');
+    expect(updates[0]!.sql).not.toContain('embeddingSpaceId');
+  });
+
+  it('dryRun writes nothing', async () => {
+    const { engine, calls } = makeEngine({ pages: ALL_PAGES });
+    const res = await engine.reindexTenant('acme', { dryRun: true, remaining: 1000 });
+    expect(res.factsScanned).toBe(1);
+    expect(res.factsUpdated).toBe(0);
+    expect(calls.some((c) => /^\s*UPDATE/.test(c.sql))).toBe(false);
+  });
+});
+
+describe('ReindexEngineService — opt-in all-tables sweep', () => {
+  it('sweeps the non-fact tables and returns a per-table breakdown', async () => {
+    const { engine } = makeEngine({ pages: ALL_PAGES });
+    const res = await engine.reindexTenant('acme', {
+      dryRun: false,
+      remaining: 1000,
+      allTables: true,
+    });
+    expect(res.factsUpdated).toBe(1);
+    expect(res.tables).toBeDefined();
+    const tables = (res.tables ?? []).map((t) => t.table);
+    expect(tables).toEqual([
+      'knowledge_entity',
+      'knowledge_predicate',
+      'episode',
+      'episode_segment',
+      'strategy_memory',
+    ]);
+    for (const t of res.tables ?? []) {
+      expect(t.scanned).toBe(1);
+      expect(t.updated).toBe(1);
+    }
+  });
+});
+
+describe('ReindexEngineService — EMBEDDING_SPACE_TRACKING stamping', () => {
+  it('stamps embeddingSpaceId on the knowledge_fact rewrite when tracking is on', async () => {
+    const { engine, calls } = makeEngine({ pages: ALL_PAGES, tracking: '1' });
+    await engine.reindexTenant('acme', { dryRun: false, remaining: 1000 });
+    const update = calls.find((c) => /^\s*UPDATE/.test(c.sql))!;
+    expect(update.sql).toContain('embeddingSpaceId = $space');
+    expect(update.params?.space).toBe(ACTIVE_SPACE);
+  });
+
+  it('stamps embeddingSpaceId across ALL swept tables', async () => {
+    const { engine, calls } = makeEngine({ pages: ALL_PAGES, tracking: '1' });
+    await engine.reindexTenant('acme', { dryRun: false, remaining: 1000, allTables: true });
+    const updates = calls.filter((c) => /^\s*UPDATE/.test(c.sql));
+    expect(updates).toHaveLength(6); // fact + 5 tables
+    for (const u of updates) {
+      expect(u.sql).toContain('embeddingSpaceId = $space');
+      expect(u.params?.space).toBe(ACTIVE_SPACE);
+    }
+  });
+});

--- a/test/test-doubles.ts
+++ b/test/test-doubles.ts
@@ -13,9 +13,20 @@ import { SynthesizeService } from '../src/synthesize/synthesize.service';
  */
 export class StubEmbedder implements Pick<
   EmbedderService,
-  'embed' | 'embedMany' | 'getDimensions'
+  'embed' | 'embedMany' | 'getDimensions' | 'primarySpaceId' | 'activeSpaceId'
 > {
   constructor(private readonly dimensions = 1536) {}
+
+  // Tier 2: the canonical space of the stub's vectors. The stub emulates the
+  // default OpenAI 1536-dim provider, so EmbeddingSpaceService's resolver /
+  // reindex stamp see a coherent `openai:...:l2` descriptor in e2e.
+  primarySpaceId(): string {
+    return `openai:text-embedding-3-small:${this.dimensions}:l2`;
+  }
+
+  activeSpaceId(): string {
+    return this.primarySpaceId();
+  }
 
   async embed(text: string): Promise<number[]> {
     const trimmed = text.trim();


### PR DESCRIPTION
## Multilingual program — Tier 2: embeddingSpaceId + zero-downtime space-migration protocol

Third tier. Fixes the embedding-**space-mixing** hazard that makes flipping the embedder unsafe today. **Everything default-off; prod byte-identical when off** (proven by off-path tests).

### The hazard (verified)
`embedder.service.ts` `activeProvider()` fails over from bge-m3 (1024-dim, warming up) to OpenAI (1536-dim) → a query embeds in a **different space** than the rows it's compared against. `reindex-engine` rewrites only `knowledge_fact`; entity/segment/episode/predicate/strategy embeddings stay in the old space (`hnsw-maintenance.service.ts` acknowledges it). Confirmed **8 embedding-bearing tables**: knowledge_fact (+altEmbedding), knowledge_entity, knowledge_predicate, episode, episode_segment, strategy_memory, community_node, procedural_memory.

### Built (each behind a default-off flag)
1. **Migration `0101_embedding_space.surql`** — additive `option<string> embeddingSpaceId` on all 8 tables (NONE = current/legacy space; no migrate-time mutation) + an `embedding_space_state` singleton (`dualWrite DEFAULT false`) for the cutover state machine.
2. **`embedding-space.ts`** — pure `embeddingSpaceId(provider:model:dim:norm)` + explicit `spacesCompatible()` (different dim/model/norm ⇒ incompatible). Both shipped providers are L2-normalized.
3. **Strict-space guard** (`EMBEDDING_SPACE_STRICT`) in `serveProvider()` — refuses (**503**, transient) a cross-space failover; **off ⇒ `return activeProvider()`, byte-identical** to today's warmup failover.
4. **Reindex-all** — opt-in `?allTables=true` sweep over entity/predicate/episode/segment/strategy_memory (default = knowledge_fact only, unchanged); stamps `embeddingSpaceId` under `EMBEDDING_SPACE_TRACKING`.
5. **Zero-downtime protocol** — `EmbeddingSpaceService` (per-tenant resolver, dual-write arm `EMBEDDING_SPACE_DUAL_WRITE`, **atomic single-UPSERT cutover** `EMBEDDING_SPACE_ACTIVE`) + `admin-embedding-space.controller.ts` (brain:admin, mirrors HNSW idioms).
6. **A/B harness** — `test/eval/multilingual/ab-harness.ts`, StubModel-only through the same `MULTILINGUAL_EVAL_LIVE` spend gate; no paid call reachable.

### Flags & goldens
4 flags in `KNOWN_BOOLEAN_FLAGS` + `CONFIG_CATALOG` (runtimeMutable). `EMBEDDING_` prefix → off the ENGINE flag budget by construction; flag-budget golden untouched, passes.

### Verification (all green)
- `tsc` → 0 · `eslint --max-warnings 0` → 0 · `prettier --check` → 0
- Unit: **287 suites / 2662 tests** (incl. flag-budget, config-catalog-truth, migrator, migration-resolver-invariants, embedder, reindex-engine, hnsw, search legs + 5 new suites: pure helpers, strict guard off/on, reindex default-vs-all + stamping, space-service resolver + atomic cutover, A/B harness)
- e2e (Docker ephemeral, not the eval stand): 4/4 — 0101 applied, `embeddingSpaceId` round-trips, atomic cutover round-trips, reindex stamps under tracking
- No paid eval.

### Deferred (bounded, documented — not silently dropped)
Live-write `embeddingSpaceId` stamping at every ingest/derive site (reindex path stamps now; reuses `activeSpaceId()`); shadow dual-write vector-doubling + active-space WHERE filter at each read leg (state machine/resolver/cutover fully built + tested — per-site wiring is the remaining surface, flagged scaffolded-but-partial); community_node/procedural_memory get the 0101 column but are re-stamped by their own summarize/trigger-derive passes. None affect default-off safety.

Multilingual stays **experimental** — nothing flipped on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
