### PR TITLE
feat(multilingual): language-agnostic lane classifier + locale-time decomposition + typed conflict detection (Tier 4, default-off)

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -540,6 +540,41 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'CJK segmentation for the mention-scan topic: segment the topic with the Intl.Segmenter built-in (ICU-backed word boundaries — no new dependency) so CJK / other non-space-delimited scripts yield real terms instead of being split to nothing by the ASCII/Cyrillic character class. Resolved into the RetrievalProfile and threaded to the mention-scan lane. Off (default) → the legacy split — byte-identical.',
   },
+  // ── Multilingual (Tier 4) ───────────────────────────
+  {
+    key: 'MULTILINGUAL_LANE_ROUTING',
+    category: 'pipeline',
+    // Resolved into the RetrievalProfile (multilingualLaneRouting) by
+    // resolveRetrievalProfile — read per request, never constructor-captured.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Language-agnostic lane classifier: a nearest-centroid classifier over a small in-repo multilingual exemplar set (reusing the shared cosine primitive) AUGMENTS the English-regex answer router for queries it returns null/generic for, so a non-English temporal/enumeration/preference/summary question can still reach its typed lane. Abstain-safe (a low-confidence or ambiguous match declines to the generic path) and only ever ADDS a route where the regex router found none. Resolved into the RetrievalProfile and threaded to the synthesize boundary. Off (default) → the regex router is byte-identical.',
+  },
+  {
+    key: 'MULTILINGUAL_TEMPORAL',
+    category: 'pipeline',
+    // Read per-call on the ingest path (MentionPersistService.persistFacts via
+    // process.env), never constructor-captured — a flip takes effect on the
+    // next ingest without restart (re-ingest to backfill).
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Locale-time decomposition for event-time extraction: (1) ar/hi/ko relative-expression recognition (chrono has no parser for those scripts — they otherwise fall to the English parser and silently miss), (2) locale-aware digit parsing (native ٣/५ digits), and (3) the atUtcMidnight day-shift fix — a relative event ("yesterday", "3 days ago") near a UTC day boundary is anchored to the speaker’s LOCAL calendar day via the session timezone (dto.timezone), then stored as language-neutral ISO-8601. An unknown timezone degrades to UTC-day behavior (never rejects the ingest). Off (default) → byte-identical UTC-day chrono behavior.',
+  },
+  {
+    key: 'MULTILINGUAL_CONFLICT',
+    category: 'pipeline',
+    // Resolved into the RetrievalProfile (multilingualConflict) by
+    // resolveRetrievalProfile — read per request, never constructor-captured.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Typed conflict detection: detectEvidenceConflicts compares NORMALIZED TYPED VALUES (numbers/booleans, digit-script- and case-folded, locale number parsing) instead of surface strings, so a cross-lingual numeric/boolean disagreement on a typed slot ("70 kg" vs "75 kg") is caught even on derived rows without a COMPETING status, and cosmetic differences (digit script, case) no longer false-flag. Presentation of already-flagged COMPETING facts only — never the write-side adjudicator; model-based multilingual NLI (semantic string equivalence like "tea" ≡ "чай") is deliberately deferred (needs a model). Resolved into the RetrievalProfile. Off (default) → byte-identical string-equality behavior.',
+  },
   {
     key: 'INGEST_CONFUSABLES_CHECK',
     category: 'pipeline',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -790,6 +790,29 @@ const KNOWN_BOOLEAN_FLAGS = [
   // Default off ⇒ the legacy split (byte-identical). MULTILINGUAL_ family,
   // off the ENGINE flag budget.
   'MULTILINGUAL_CJK_SEGMENTATION',
+  // Multilingual Tier 4. Language-agnostic lane classifier: a nearest-centroid
+  // classifier (multilingual exemplar centroids, shared cosine primitive)
+  // AUGMENTS the English-regex answer router for queries it returns
+  // null/generic for — abstain-safe. Resolved into the RetrievalProfile
+  // (multilingualLaneRouting) and threaded to the synthesize boundary. Default
+  // off ⇒ the regex router is byte-identical. MULTILINGUAL_ family, off the
+  // ENGINE flag budget.
+  'MULTILINGUAL_LANE_ROUTING',
+  // Multilingual Tier 4. Locale-time decomposition: ar/hi/ko relative-
+  // expression recognition (chrono has no parser for them), locale-aware digit
+  // parsing, and the atUtcMidnight day-shift fix (anchors a relative event to
+  // the speaker's LOCAL calendar day via dto.timezone). Read on the ingest
+  // path (mention-persist); re-ingest to apply. Default off ⇒ byte-identical
+  // UTC-day chrono behavior. MULTILINGUAL_ family, off the ENGINE flag budget.
+  'MULTILINGUAL_TEMPORAL',
+  // Multilingual Tier 4. Typed conflict detection: detectEvidenceConflicts
+  // compares normalized TYPED values (numbers/booleans, digit-script/case
+  // folded) instead of surface strings, catching cross-lingual value conflicts
+  // on typed slots. Presentation of already-COMPETING facts only, never the
+  // write-side adjudicator. Resolved into the RetrievalProfile
+  // (multilingualConflict). Default off ⇒ byte-identical string-equality.
+  // MULTILINGUAL_ family, off the ENGINE flag budget.
+  'MULTILINGUAL_CONFLICT',
   // Multilingual Tier 2 (migration 0101). The embedding-space family stamps
   // + guards the (model, dim, norm) space a vector lives in so flipping the
   // embedder can't silently mix vector spaces. All default off; each is a

--- a/src/common/locale-digits.ts
+++ b/src/common/locale-digits.ts
@@ -1,0 +1,56 @@
+/**
+ * Locale digit normalization — map non-ASCII decimal digits to 0-9.
+ *
+ * Multilingual Tier 4 shared primitive. Arabic-Indic (٠-٩), Extended
+ * Arabic-Indic / Persian-Urdu (۰-۹) and Devanagari (०-९) digits are the
+ * high-value scripts for the ar / fa / ur / hi relative-time parser
+ * (event-time) and the typed-value conflict comparison (answer-router):
+ * a native-digit "٣ أيام" / "५ दिन" must reduce to "3" / "5" before any
+ * numeric match. ASCII digits pass through untouched, so on ASCII input
+ * this is a no-op (byte-identical).
+ *
+ * Deliberately small — only the digit ranges the Tier 4 parsers exercise.
+ * Other decimal scripts (Bengali, Thai, …) can be added when a consumer
+ * needs them; Intl has no built-in "digits → ASCII" so a table is the
+ * dependency-free way (no new npm dep).
+ */
+
+/** [base codepoint of the '0' digit, script label] for each supported set. */
+const DIGIT_BASES: ReadonlyArray<readonly [number, string]> = [
+  [0x0660, 'arabic-indic'], // ٠١٢٣٤٥٦٧٨٩
+  [0x06f0, 'extended-arabic-indic'], // ۰۱۲۳۴۵۶۷۸۹ (Persian / Urdu)
+  [0x0966, 'devanagari'], // ०१२३४५६७८९
+];
+
+/** True when the string carries any non-ASCII decimal digit we normalize. */
+export function hasNonAsciiDigits(text: string): boolean {
+  for (const ch of text) {
+    const code = ch.codePointAt(0) ?? 0;
+    for (const [base] of DIGIT_BASES) {
+      if (code >= base && code <= base + 9) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Replace every supported non-ASCII decimal digit with its ASCII 0-9
+ * equivalent, position-preserving. ASCII-only input returns the same
+ * characters (a cheap early-out keeps the common path allocation-free).
+ */
+export function normalizeDigits(text: string): string {
+  if (!text || !hasNonAsciiDigits(text)) return text;
+  let out = '';
+  for (const ch of text) {
+    const code = ch.codePointAt(0) ?? 0;
+    let mapped = ch;
+    for (const [base] of DIGIT_BASES) {
+      if (code >= base && code <= base + 9) {
+        mapped = String.fromCharCode(0x30 + (code - base));
+        break;
+      }
+    }
+    out += mapped;
+  }
+  return out;
+}

--- a/src/contracts/admin/retrieval-profile.schema.ts
+++ b/src/contracts/admin/retrieval-profile.schema.ts
@@ -21,6 +21,8 @@ export const RetrievalProfileWireSchema = z.object({
   coverageScanMode: z.enum(['brute', 'hnsw']),
   coverageLexMode: z.enum(['phrase', 'or_terms']),
   cjkSegmentation: z.boolean(),
+  multilingualLaneRouting: z.boolean(),
+  multilingualConflict: z.boolean(),
   scanHnswEf: z.number().int(),
   scanHnswOverfetch: z.number().int(),
   dateAnchoring: z.enum(['none', 'session_date', 'absolute']),

--- a/src/ingest/dto/ingest-mention.dto.ts
+++ b/src/ingest/dto/ingest-mention.dto.ts
@@ -68,4 +68,17 @@ export class IngestMentionDto {
 
   @IsISO8601()
   emittedAt!: string;
+
+  /**
+   * IANA timezone of the speaker's session (e.g. 'Asia/Tokyo'). Multilingual
+   * Tier 4 (MULTILINGUAL_TEMPORAL): when event-time extraction resolves a
+   * relative expression ("yesterday", "3 days ago"), this anchors it to the
+   * speaker's LOCAL calendar day so a message near a UTC day boundary isn't
+   * shifted. Ignored when MULTILINGUAL_TEMPORAL is off or the zone is unknown
+   * (falls back to UTC-day behavior — never rejects the ingest).
+   */
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  timezone?: string | undefined;
 }

--- a/src/ingest/event-time.ts
+++ b/src/ingest/event-time.ts
@@ -25,6 +25,7 @@
  */
 import * as chrono from 'chrono-node';
 import { detectLanguage } from '../ai/locale/language-detector';
+import { normalizeDigits } from '../common/locale-digits';
 
 /** Sanity window: an event referenced in conversation is in the past, and we
  *  won't trust a resolved date more than this far back (guards a stray parse). */
@@ -79,10 +80,194 @@ export interface EventTime {
 export interface ResolveEventTimeOptions {
   /** ISO-639-1 language of the clause. When omitted it is auto-detected. */
   lang?: string;
+  /**
+   * Multilingual Tier 4 (MULTILINGUAL_TEMPORAL). When true, three otherwise-
+   * conflated concerns turn on together: (1) ar/hi/ko relative-expression
+   * recognition (chrono has no parser for them — they otherwise fall to the
+   * English parser and silently miss), (2) locale-aware digit parsing (native
+   * ٣ / ५ digits in those expressions), and (3) — when `timeZone` is also set
+   * — the day-shift fix below. Absent / false ⇒ byte-identical legacy
+   * behavior (the caller passes nothing, so the default path is unchanged).
+   */
+  localeTime?: boolean;
+  /**
+   * IANA timezone of the speaker's session (e.g. 'Asia/Tokyo'). Only consulted
+   * when `localeTime` is true. Fixes the atUtcMidnight day-shift: a message
+   * emitted near a UTC day boundary is anchored to the speaker's LOCAL calendar
+   * day, so "yesterday" resolves against the day they actually saw, not the UTC
+   * day. An unknown/invalid zone degrades to the UTC-day behavior (never
+   * throws). The stored date stays language-neutral ISO-8601 (UTC-midnight of
+   * the resolved calendar day).
+   */
+  timeZone?: string;
 }
 
 function atUtcMidnight(d: Date): Date {
   return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+/** The speaker's LOCAL calendar Y/M/D for an instant, via Intl (ICU tz DB —
+ *  no new dep). Independent of the HOST timezone. Null on an unknown zone. */
+function localeYmd(date: Date, timeZone: string): { y: number; m: number; d: number } | null {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(date);
+    const pick = (t: string): number => Number(parts.find((p) => p.type === t)?.value);
+    const y = pick('year');
+    const m = pick('month');
+    const d = pick('day');
+    if (![y, m, d].every(Number.isFinite)) return null;
+    return { y, m: m - 1, d };
+  } catch {
+    return null; // RangeError on an invalid IANA zone → UTC-day fallback.
+  }
+}
+
+/** UTC-midnight of the speaker's LOCAL calendar day (the language-neutral
+ *  storage slot). Falls back to the UTC-day midnight on an unknown zone. */
+function atLocaleMidnight(date: Date, timeZone: string): Date {
+  const p = localeYmd(date, timeZone);
+  return p ? new Date(Date.UTC(p.y, p.m, p.d)) : atUtcMidnight(date);
+}
+
+/** UTC-NOON of the speaker's local calendar day — the chrono reference under a
+ *  timezone. Noon is used so relative math ("yesterday", "3 weeks ago") is
+ *  anchored on the correct local day AND is host-timezone-independent: 12:00Z
+ *  falls on the same calendar day in every realistic host zone, so chrono's
+ *  day component is stable regardless of where the process runs. Falls back to
+ *  the raw instant on an unknown zone (byte-identical). */
+function localeNoonUtc(date: Date, timeZone: string): Date {
+  const p = localeYmd(date, timeZone);
+  return p ? new Date(Date.UTC(p.y, p.m, p.d, 12)) : date;
+}
+
+type RelUnit = 'day' | 'week' | 'month' | 'year';
+
+/**
+ * Per-language relative-expression grammar for scripts chrono has NO parser
+ * for (Arabic, Hindi/Devanagari, Korean). Digits are ASCII-normalized before
+ * matching, so native ٣ / ५ work. Deliberately covers the high-frequency
+ * conversational forms (today / yesterday / day-before, "N <unit> ago", "last
+ * <unit>"); dual/spelled-out numbers and calendar-name dates are DEFERRED to
+ * chrono coverage (a future chrono locale) — this closes the silent
+ * English-fallback gap, it is not a full NL date grammar.
+ *
+ * NOTE on ambiguity: Hindi कल = yesterday OR tomorrow and परसों = day-before
+ * OR day-after; event-time is past-biased ("occurred" is behind us), so both
+ * resolve to the PAST reading, consistent with chrono's forwardDate:false.
+ */
+interface RelGrammar {
+  fixed: ReadonlyArray<readonly [RegExp, number]>; // phrase → day offset (<0 = past)
+  lastUnit: ReadonlyArray<readonly [RegExp, RelUnit]>; // "last <unit>" → subtract 1
+  ago: ReadonlyArray<readonly [RegExp, RelUnit]>; // capture-group-1 = N, subtract N units
+}
+
+const REL_GRAMMARS: Partial<Record<string, RelGrammar>> = {
+  ko: {
+    fixed: [
+      [/그저께|그제/u, -2],
+      [/어제/u, -1],
+      [/오늘/u, 0],
+    ],
+    lastUnit: [
+      [/지난\s*주/u, 'week'],
+      [/지난\s*달/u, 'month'],
+      [/작년|지난\s*해/u, 'year'],
+    ],
+    ago: [
+      [/(\d+)\s*일\s*전/u, 'day'],
+      [/(\d+)\s*주\s*전/u, 'week'],
+      [/(\d+)\s*(?:개월|달)\s*전/u, 'month'],
+      [/(\d+)\s*년\s*전/u, 'year'],
+    ],
+  },
+  hi: {
+    // Devanagari doesn't delimit suffixes with spaces, so the bare day-words
+    // are guarded by script boundaries (कल = yesterday must not match inside
+    // कलम "pen" / कला "art"). Longer phrases below carry their own context.
+    fixed: [
+      [/(?<![ऀ-ॿ])परसों(?![ऀ-ॿ])/u, -2],
+      [/(?<![ऀ-ॿ])कल(?![ऀ-ॿ])/u, -1],
+      [/(?<![ऀ-ॿ])आज(?![ऀ-ॿ])/u, 0],
+    ],
+    lastUnit: [
+      [/पिछले\s*(?:हफ्ते|सप्ताह)/u, 'week'],
+      [/पिछले\s*महीने/u, 'month'],
+      [/पिछले\s*(?:साल|वर्ष)/u, 'year'],
+    ],
+    ago: [
+      [/(\d+)\s*दिन\s*पहले/u, 'day'],
+      [/(\d+)\s*(?:हफ्ते|सप्ताह)\s*पहले/u, 'week'],
+      [/(\d+)\s*(?:महीने|माह)\s*पहले/u, 'month'],
+      [/(\d+)\s*(?:साल|वर्ष)\s*पहले/u, 'year'],
+    ],
+  },
+  ar: {
+    fixed: [
+      [/أول\s*أمس|أمس\s*الأول|قبل\s*يومين/u, -2],
+      [/أمس|البارحة/u, -1],
+      [/اليوم/u, 0],
+    ],
+    lastUnit: [
+      [/الأسبوع\s*الماضي/u, 'week'],
+      [/الشهر\s*الماضي/u, 'month'],
+      [/العام\s*الماضي|السنة\s*الماضية/u, 'year'],
+    ],
+    ago: [
+      [/(?:قبل|منذ)\s*(\d+)\s*(?:يوم|أيام|يوما|يومًا|يوماً)/u, 'day'],
+      [/(?:قبل|منذ)\s*(\d+)\s*(?:أسبوع|أسابيع|أسبوعا|أسبوعًا)/u, 'week'],
+      [/(?:قبل|منذ)\s*(\d+)\s*(?:شهر|أشهر|شهور|شهرا|شهرًا)/u, 'month'],
+      [/(?:قبل|منذ)\s*(\d+)\s*(?:سنة|سنوات|سنين|عام|أعوام|عاما|عامًا)/u, 'year'],
+    ],
+  },
+};
+
+/** Subtract N whole units from a UTC-midnight anchor (calendar-correct for
+ *  month/year via the UTC setters). */
+function subtractUnits(anchor: Date, n: number, unit: RelUnit): Date {
+  const d = new Date(anchor.getTime());
+  if (unit === 'day') d.setUTCDate(d.getUTCDate() - n);
+  else if (unit === 'week') d.setUTCDate(d.getUTCDate() - n * 7);
+  else if (unit === 'month') d.setUTCMonth(d.getUTCMonth() - n);
+  else d.setUTCFullYear(d.getUTCFullYear() - n);
+  return d;
+}
+
+/**
+ * Resolve an ar/hi/ko relative expression against a local-day anchor, or null.
+ * Precedence: explicit "N <unit> ago" (most specific) → fixed day phrases →
+ * "last <unit>". Returns UTC-midnight of the resolved calendar day.
+ */
+function parseRelativeGrammar(
+  lang: string,
+  clause: string,
+  anchor: Date,
+): { date: Date; expr: string } | null {
+  const g = REL_GRAMMARS[lang];
+  if (!g) return null;
+  const text = normalizeDigits(clause);
+  for (const [re, unit] of g.ago) {
+    const m = text.match(re);
+    if (m?.[1]) {
+      const n = parseInt(m[1], 10);
+      if (Number.isFinite(n) && n > 0) {
+        return { date: subtractUnits(anchor, n, unit), expr: m[0] };
+      }
+    }
+  }
+  for (const [re, days] of g.fixed) {
+    const m = text.match(re);
+    if (m) return { date: subtractUnits(anchor, -days, 'day'), expr: m[0] };
+  }
+  for (const [re, unit] of g.lastUnit) {
+    const m = text.match(re);
+    if (m) return { date: subtractUnits(anchor, 1, unit), expr: m[0] };
+  }
+  return null;
 }
 
 /**
@@ -98,9 +283,29 @@ export function resolveEventTime(
   if (!clause || !clause.trim()) return null;
   const anchorRaw = anchorIso instanceof Date ? anchorIso : new Date(anchorIso);
   if (Number.isNaN(anchorRaw.getTime())) return null;
-  const anchor = atUtcMidnight(anchorRaw);
+
+  // Locale-time decomposition (MULTILINGUAL_TEMPORAL). Off ⇒ the legacy
+  // UTC-day anchor and raw chrono reference — byte-identical. On with a
+  // timeZone ⇒ the anchor is the speaker's LOCAL calendar day (day-shift fix)
+  // and chrono resolves against local-day noon (host-tz-independent).
+  const localeOn = opts.localeTime === true;
+  const tz = localeOn && opts.timeZone ? opts.timeZone : undefined;
+  const anchor = tz ? atLocaleMidnight(anchorRaw, tz) : atUtcMidnight(anchorRaw);
+  const chronoRef = tz ? localeNoonUtc(anchorRaw, tz) : anchorRaw;
 
   const lang = opts.lang ?? (detectLanguage(clause).language || 'und');
+
+  // ar/hi/ko relative expressions — scripts chrono has no parser for, which
+  // otherwise fall through to the English parser and silently miss. Gated by
+  // localeTime so the off path is unchanged.
+  if (localeOn) {
+    const rel = parseRelativeGrammar(lang, clause, anchor);
+    if (rel) {
+      const clamped = clampPast(rel.date, anchor);
+      if (clamped) return { date: clamped, expr: rel.expr };
+    }
+  }
+
   const langKey = PARSERS[lang] ? lang : 'en';
 
   // chrono first (relative expressions, multilingual), English as a secondary
@@ -108,8 +313,8 @@ export function resolveEventTime(
   const primary = PARSERS[langKey];
   const english = PARSERS.en;
   const hit =
-    (primary ? parseWith(primary, clause, anchorRaw) : null) ??
-    (langKey !== 'en' && english ? parseWith(english, clause, anchorRaw) : null);
+    (primary ? parseWith(primary, clause, chronoRef) : null) ??
+    (langKey !== 'en' && english ? parseWith(english, clause, chronoRef) : null);
   if (hit) {
     const clamped = clampPast(hit.date, anchor);
     if (clamped) return { date: clamped, expr: hit.expr };

--- a/src/ingest/mention-persist.service.ts
+++ b/src/ingest/mention-persist.service.ts
@@ -25,6 +25,27 @@ export interface MentionPersistResult {
   extractedEdgeIds: string[];
 }
 
+/** Resolved event-time knobs for a mention, computed once per persist. */
+interface EventTimeResolveOpts {
+  /** INGEST_EVENT_TIME_EXTRACTION — resolve occurrence dates at all. */
+  on: boolean;
+  /** MULTILINGUAL_TEMPORAL — ar/hi/ko relative expressions + day-shift fix. */
+  localeTime: boolean;
+  /** IANA session timezone (dto.timezone), only used when localeTime. */
+  timeZone?: string;
+}
+
+/** Read the event-time flags for this mention. The MULTILINGUAL_TEMPORAL
+ *  branch is a separable concern (locale-time decomposition); when off, the
+ *  resolver is called exactly as before (byte-identical). */
+function resolveEventTimeOpts(dto: IngestMentionDto): EventTimeResolveOpts {
+  return {
+    on: envFlagEnabled(process.env.INGEST_EVENT_TIME_EXTRACTION),
+    localeTime: envFlagEnabled(process.env.MULTILINGUAL_TEMPORAL),
+    ...(dto.timezone ? { timeZone: dto.timezone } : {}),
+  };
+}
+
 /**
  * Persistence stage of mention ingest, run INSIDE the db session: resolve each
  * extracted entity, write each extracted fact through FactResolverService
@@ -156,15 +177,15 @@ export class MentionPersistService {
   ): Promise<string[]> {
     const { companyId, dto, extraction, source, factEmbeddings, entityIds } = p;
     const factIds: string[] = [];
-    const eventTimeOn = envFlagEnabled(process.env.INGEST_EVENT_TIME_EXTRACTION);
+    const timeOpts = resolveEventTimeOpts(dto);
     if (envFlagEnabled(process.env.INGEST_BATCH_FACTS)) {
-      return this.persistFactsBatched(db, p, eventTimeOn);
+      return this.persistFactsBatched(db, p, timeOpts);
     }
     for (let i = 0; i < extraction.facts.length; i++) {
       const f = extraction.facts[i]!;
       const eid = entityIds[f.entityIndex];
       if (!eid) continue;
-      const validFrom = this.factValidFrom(f, dto, eventTimeOn);
+      const validFrom = this.factValidFrom(f, dto, timeOpts);
       const factId = await traceSpan(
         'ingest.fact.upsert',
         () =>
@@ -199,9 +220,20 @@ export class MentionPersistService {
   private factValidFrom(
     f: { predicate: string; clause?: string | undefined },
     dto: IngestMentionDto,
-    eventTimeOn: boolean,
+    timeOpts: EventTimeResolveOpts,
   ): Date {
-    const event = eventTimeOn ? resolveEventTime(f.clause, dto.emittedAt) : null;
+    const event = timeOpts.on
+      ? resolveEventTime(
+          f.clause,
+          dto.emittedAt,
+          // MULTILINGUAL_TEMPORAL off ⇒ no options object at all (byte-identical
+          // to the historical no-opts call). On ⇒ locale-time decomposition
+          // (ar/hi/ko relative expressions + the session-timezone day-shift fix).
+          timeOpts.localeTime
+            ? { localeTime: true, ...(timeOpts.timeZone ? { timeZone: timeOpts.timeZone } : {}) }
+            : {},
+        )
+      : null;
     if (!event) return new Date(dto.emittedAt);
     traceArtifact('ingest.fact.event_time', {
       predicate: f.predicate,
@@ -229,7 +261,7 @@ export class MentionPersistService {
       factEmbeddings: number[][];
       entityIds: string[];
     },
-    eventTimeOn: boolean,
+    timeOpts: EventTimeResolveOpts,
   ): Promise<string[]> {
     const { companyId, dto, extraction, source, factEmbeddings, entityIds } = p;
     const specs: Array<{
@@ -249,7 +281,7 @@ export class MentionPersistService {
           predicateAlias: f.predicateAlias,
           object: f.object,
           confidence: f.confidence,
-          validFrom: this.factValidFrom(f, dto, eventTimeOn),
+          validFrom: this.factValidFrom(f, dto, timeOpts),
           source,
           entropy: typeof f.extractionEntropy === 'number' ? f.extractionEntropy : undefined,
           precomputedEmbedding: factEmbeddings[i],

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -268,6 +268,25 @@ export interface RetrievalProfile {
    * boundary) and threaded to the mention-scan lane.
    */
   cjkSegmentation: boolean;
+  /**
+   * Multilingual Tier 4 (MULTILINGUAL_LANE_ROUTING). When ON, a language-
+   * agnostic nearest-centroid classifier augments the English-regex answer
+   * router for queries it returns null/generic for — a non-English temporal /
+   * enumeration / preference / summary question can still reach its typed
+   * lane. Abstain-safe (low confidence ⇒ the generic path). Off (default) ⇒
+   * the regex router is byte-identical. Resolved here (the one env-reading
+   * module below the boundary) and threaded to the synthesize boundary.
+   */
+  multilingualLaneRouting: boolean;
+  /**
+   * Multilingual Tier 4 (MULTILINGUAL_CONFLICT). When ON, detectEvidenceConflicts
+   * compares NORMALIZED TYPED VALUES (numbers/booleans, digit-script- and
+   * case-folded) instead of surface strings, so cross-lingual VALUE conflicts
+   * on typed slots are caught and cosmetic differences don't false-flag.
+   * Presentation of already-COMPETING facts only — never the write-side
+   * adjudicator. Off (default) ⇒ byte-identical string-equality behavior.
+   */
+  multilingualConflict: boolean;
   /** HNSW ef candidate-list size for the scan legs (clamped up to the
    *  overfetched k at query time — ef below k is never useful). */
   scanHnswEf: number;
@@ -636,9 +655,11 @@ function resolveForGenre(genre: RetrievalGenre, env: NodeJS.ProcessEnv): Retriev
       enumEnv(env, 'RETRIEVAL_COVERAGE_SCAN_MODE', ['brute', 'hnsw'] as const) ?? 'brute',
     coverageLexMode:
       enumEnv(env, 'RETRIEVAL_COVERAGE_LEX_MODE', ['phrase', 'or_terms'] as const) ?? 'phrase',
-    // Cross-cutting locale flag (MULTILINGUAL_ family, off the RETRIEVAL_
+    // Cross-cutting locale flags (MULTILINGUAL_ family, off the RETRIEVAL_
     // budget); resolved directly from env here, no genre preset.
     cjkSegmentation: envFlagEnabled(env.MULTILINGUAL_CJK_SEGMENTATION),
+    multilingualLaneRouting: envFlagEnabled(env.MULTILINGUAL_LANE_ROUTING),
+    multilingualConflict: envFlagEnabled(env.MULTILINGUAL_CONFLICT),
     scanHnswEf: positiveIntEnv(env, 'RETRIEVAL_SCAN_HNSW_EF', 400),
     scanHnswOverfetch: positiveIntEnv(env, 'RETRIEVAL_SCAN_HNSW_OVERFETCH', 4),
     dateAnchoring:
@@ -837,6 +858,8 @@ export function resolveRetrievalProfileFor(
     'assistantLane',
     'factsAsKeys',
     'cjkSegmentation',
+    'multilingualLaneRouting',
+    'multilingualConflict',
   ] as const) {
     if (typeof o[key] === 'boolean') merged[key] = o[key] as boolean;
   }

--- a/src/synthesize/answer-router.ts
+++ b/src/synthesize/answer-router.ts
@@ -1,5 +1,6 @@
 import type { SearchHit } from '../search/search.service';
 import type { LaneId, RetrievalProfile } from '../search/retrieval-profile';
+import { normalizeDigits } from '../common/locale-digits';
 
 /**
  * Typed Answer Dispatch (docs/roadmap/typed-answer-dispatch-2026-07.md):
@@ -505,6 +506,99 @@ export function formatElapsed(validFromIso: string | undefined, asOfIso: string)
 }
 
 /**
+ * Multilingual Tier 4 typed-value normalization. Reduce a surface object to a
+ * language-agnostic TYPED value so cross-lingual VALUE conflicts on typed
+ * slots are comparable and cosmetic differences (digit script, case,
+ * diacritics, thousands separators) don't read as conflicts.
+ *
+ * Deliberately FREE / rule-based — model-based multilingual NLI (that would
+ * resolve semantic string equivalence like "tea" ≡ "чай") needs a model and
+ * is DEFERRED (see MULTILINGUAL_CONFLICT note). So typed comparison catches
+ * numeric and boolean disagreement across languages; free-text strings only
+ * collapse on formatting, never on translation.
+ */
+type TypedValue =
+  | { kind: 'boolean'; bool: boolean }
+  | { kind: 'number'; magnitude: number; unit: string }
+  | { kind: 'string'; str: string };
+
+const BOOL_TRUE_RE = /^(?:yes|yeah|true|да|sí|si|oui|ja|sim|はい|예|네|نعم|हाँ|हां)$/;
+const BOOL_FALSE_RE = /^(?:no|nope|false|нет|non|nein|não|nao|いいえ|아니(?:요|오)?|لا|नहीं)$/;
+
+/** Parse a locale-formatted number: handles both "1,000.50" (en) and
+ *  "1.000,50" (de) grouping/decimal conventions. Null when no digits. */
+function parseLocaleNumber(s: string): number | null {
+  if (!/\d/.test(s)) return null;
+  let x = s.replace(/[^\d.,-]/g, '');
+  const hasDot = x.includes('.');
+  const hasComma = x.includes(',');
+  if (hasDot && hasComma) {
+    // The LAST separator is the decimal mark; the other groups thousands.
+    x =
+      x.lastIndexOf(',') > x.lastIndexOf('.')
+        ? x.replace(/\./g, '').replace(',', '.')
+        : x.replace(/,/g, '');
+  } else if (hasComma) {
+    x = x.replace(',', '.'); // lone comma = decimal
+  }
+  const n = Number(x);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** First number in the value + the unit token IMMEDIATELY adjacent to it
+ *  (trailing "kg"/"%"/"°c" or a leading currency symbol) — NOT every letter in
+ *  the phrase, so "weighs 70 kg" and "весит 75 kg" share the unit "kg". */
+const NUM_UNIT_RE = /(-?[\d.,]*\d)\s*([a-z°%µ‰]{1,8})?/u;
+const LEADING_CURRENCY_RE = /([$€£¥₽₹])\s*-?[\d.,]*\d/u;
+
+function normalizeTypedValue(object: string): TypedValue {
+  const norm = normalizeDigits(object).normalize('NFC').trim().toLowerCase();
+  if (BOOL_TRUE_RE.test(norm)) return { kind: 'boolean', bool: true };
+  if (BOOL_FALSE_RE.test(norm)) return { kind: 'boolean', bool: false };
+  const m = norm.match(NUM_UNIT_RE);
+  if (m) {
+    const magnitude = parseLocaleNumber(m[1]!);
+    if (magnitude !== null) {
+      // A shared unit with a different magnitude is a conflict; a different
+      // unit is left alone (no unit conversion — conservative, avoids false
+      // positives across kg/lb, °c/°f, …).
+      const unit = m[2] ?? norm.match(LEADING_CURRENCY_RE)?.[1] ?? '';
+      return { kind: 'number', magnitude, unit };
+    }
+  }
+  const str = norm
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/\s+/g, ' ');
+  return { kind: 'string', str };
+}
+
+function typedKey(v: TypedValue): string {
+  if (v.kind === 'boolean') return `b:${v.bool}`;
+  if (v.kind === 'number') return `n:${v.magnitude}:${v.unit}`;
+  return `s:${v.str}`;
+}
+
+/** A typed conflict = two facts that disagree on a NUMBER (same unit) or a
+ *  BOOLEAN. Free-text disagreement is NOT a typed conflict here (needs NLI). */
+function hasTypedConflict(objects: string[]): boolean {
+  const vals = objects.map(normalizeTypedValue);
+  const bools = new Set(
+    vals.filter((v) => v.kind === 'boolean').map((v) => (v as { bool: boolean }).bool),
+  );
+  if (bools.size >= 2) return true;
+  const byUnit = new Map<string, Set<number>>();
+  for (const v of vals) {
+    if (v.kind !== 'number') continue;
+    const set = byUnit.get(v.unit) ?? new Set<number>();
+    set.add(v.magnitude);
+    byUnit.set(v.unit, set);
+  }
+  for (const set of byUnit.values()) if (set.size >= 2) return true;
+  return false;
+}
+
+/**
  * T3: detect write-side-adjudicated conflicts inside the retrieved
  * evidence. Conservative by design: a slot counts as conflicted ONLY
  * when its facts disagree on the object AND at least one carries the
@@ -512,10 +606,20 @@ export function formatElapsed(validFromIso: string | undefined, asOfIso: string)
  * ordinary multi-value slots (works_at, likes, …) never trigger. Pure,
  * exported for tests. `lanes` is the profile's active set — the
  * contradiction lane must be live for the notice to render.
+ *
+ * Multilingual Tier 4 (`typedCompare`, MULTILINGUAL_CONFLICT): compare
+ * NORMALIZED TYPED VALUES rather than surface strings. This is presentation
+ * of already-COMPETING facts, NOT the write-side adjudicator — it decides
+ * which slots to SURFACE. On ⇒ (a) formatting-only differences (digit script,
+ * case, diacritics) no longer read as two objects, and (b) a numeric/boolean
+ * disagreement is flagged even on derived rows without a COMPETING status or a
+ * negation polarity split (the cross-lingual "70 kg" vs "75 kg" case).
+ * Off (default) ⇒ byte-identical surface-string behavior.
  */
 export function detectEvidenceConflicts(
   results: SearchHit[],
   lanes: ReadonlySet<LaneId>,
+  typedCompare = false,
 ): Array<{ factIds: string[]; label: string }> {
   if (!lanes.has('contradiction')) return [];
   const bySlot = new Map<
@@ -536,8 +640,14 @@ export function detectEvidenceConflicts(
   }
   const conflicts: Array<{ factIds: string[]; label: string }> = [];
   for (const [slot, facts] of bySlot) {
-    const objects = new Set(facts.map((f) => f.object));
-    if (objects.size < 2) continue;
+    const objects = facts.map((f) => f.object);
+    // Distinctness: typed comparison collapses formatting-equivalent values
+    // (so a slot with one true value in two scripts is NOT "two objects");
+    // off = raw surface distinctness (byte-identical).
+    const distinct = typedCompare
+      ? new Set(objects.map((o) => typedKey(normalizeTypedValue(o))))
+      : new Set(objects);
+    if (distinct.size < 2) continue;
     const hasCompeting = facts.some((f) => (f.status ?? '').toUpperCase() === 'COMPETING');
     // Second tier for DERIVED worlds: the window deriver batch-INSERTs
     // propositions past the conflict predictor, so contradictions sit as
@@ -547,7 +657,10 @@ export function detectEvidenceConflicts(
     // slots: two affirmative objects share polarity.
     const negated = facts.filter((f) => NEGATION_RE.test(f.object));
     const polaritySplit = negated.length > 0 && negated.length < facts.length;
-    if (hasCompeting || polaritySplit) {
+    // Third tier (typedCompare only): a numeric/boolean disagreement that
+    // neither COMPETING status nor English negation would catch.
+    const typedSplit = typedCompare && hasTypedConflict(objects);
+    if (hasCompeting || polaritySplit || typedSplit) {
       conflicts.push({
         factIds: facts.map((f) => f.factId),
         label: slot.split('::')[1] ?? slot,

--- a/src/synthesize/multilingual-lane-classifier.service.ts
+++ b/src/synthesize/multilingual-lane-classifier.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { EmbedderService } from '../ai/embedder.service';
+import type { LaneId } from '../search/retrieval-profile';
+import {
+  buildLaneCentroids,
+  classifyLane,
+  CLASSIFIER_LANES,
+  LANE_CLASSIFIER_MIN_COSINE,
+  LANE_CLASSIFIER_MIN_MARGIN,
+  LANE_EXEMPLARS,
+  type ClassifierLane,
+  type LaneClassifierModel,
+} from './multilingual-lane-classifier';
+
+/**
+ * MultilingualLaneClassifierService — the embedder + cache shell around the
+ * pure lane classifier (multilingual-lane-classifier.ts). Mirrors the
+ * lens-suppression service split: the DECISION is pure; the service owns only
+ * the embedder call and the centroid cache.
+ *
+ * Nothing here reads env: the master flag is resolved into the profile
+ * (RetrievalProfile.multilingualLaneRouting) at the retrieval-profile
+ * boundary and checked by the caller (SynthesizeService) BEFORE this service
+ * is invoked, keeping the synthesize dir env-free (engine-gates S5.2). The
+ * embedder is @Optional so positionally-constructed unit tests stay as-is;
+ * absent embedder ⇒ augmentLane returns null (byte-identical to the unrouted
+ * generic path).
+ */
+@Injectable()
+export class MultilingualLaneClassifierService {
+  private readonly logger = new Logger(MultilingualLaneClassifierService.name);
+
+  /** Centroids are keyed by embedding dimension so a provider swap that
+   *  changes the space rebuilds instead of cosine-comparing across spaces. */
+  private cached: { key: string; model: LaneClassifierModel } | undefined;
+  private building: Promise<LaneClassifierModel> | undefined;
+
+  constructor(@Optional() private readonly embedder?: EmbedderService) {}
+
+  /**
+   * Propose a routable lane for a query the regex router missed, or null.
+   * Any failure (embedder absent, embed error, empty model, abstain) resolves
+   * to null so the caller keeps the generic path — byte-identical to today.
+   */
+  async augmentLane(query: string, activeLanes: ReadonlySet<LaneId>): Promise<LaneId | null> {
+    if (!this.embedder || !query.trim()) return null;
+    try {
+      const model = await this.centroids();
+      if (model.length === 0) return null;
+      const queryEmbedding = await this.embedder.embed(query);
+      const decision = classifyLane({
+        model,
+        queryEmbedding,
+        activeLanes,
+        minCosine: LANE_CLASSIFIER_MIN_COSINE,
+        minMargin: LANE_CLASSIFIER_MIN_MARGIN,
+      });
+      if (decision.lane) {
+        this.logger.debug(
+          `multilingual lane classifier: routed=${decision.lane} ` +
+            `cos=${decision.ranked[0]?.cosine.toFixed(3)}`,
+        );
+      }
+      return decision.lane;
+    } catch (e) {
+      this.logger.warn(
+        `multilingual lane classifier failed; generic path: ${(e as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  /** Build (once) + cache the per-lane centroids from the embedded exemplar
+   *  set. Concurrent first calls share one in-flight build. */
+  private async centroids(): Promise<LaneClassifierModel> {
+    const key = String(this.embedder!.getDimensions());
+    if (this.cached?.key === key) return this.cached.model;
+    if (this.building) return this.building;
+    this.building = this.buildCentroids(key);
+    try {
+      return await this.building;
+    } finally {
+      this.building = undefined;
+    }
+  }
+
+  private async buildCentroids(key: string): Promise<LaneClassifierModel> {
+    const byLane = new Map<ClassifierLane, number[][]>();
+    for (const lane of CLASSIFIER_LANES) {
+      byLane.set(lane, await this.embedder!.embedMany([...LANE_EXEMPLARS[lane]]));
+    }
+    const model = buildLaneCentroids(byLane);
+    this.cached = { key, model };
+    return model;
+  }
+}

--- a/src/synthesize/multilingual-lane-classifier.ts
+++ b/src/synthesize/multilingual-lane-classifier.ts
@@ -1,0 +1,232 @@
+/**
+ * Multilingual lane classifier (MULTILINGUAL_LANE_ROUTING) — Tier 4.
+ *
+ * A SEPARATE, language-agnostic multi-label classifier that AUGMENTS the
+ * English-regex router (answer-router.ts) for the queries it returns
+ * null/generic for. It is NOT the lens-suppression model: that governor is
+ * subtractive (removes lanes from an active set); this one is a positive
+ * nearest-centroid MATCH that proposes ONE lane for an otherwise-unrouted
+ * query. It reuses only the shared cosine PRIMITIVE (common/vector-math),
+ * exactly as lens-suppression does — same primitive, different model.
+ *
+ * The centroids are seeded from a small in-repo labeled exemplar set
+ * (LANE_EXEMPLARS), embedded once at classify time and cached by the
+ * service — no paid training data, no migration, no DB. Multilingual
+ * embedders (OpenAI text-embedding-3-*, BGE-M3) place a non-English query
+ * near its same-lane exemplars regardless of language, so the regex router's
+ * blind spot (its lexicons are English) is covered without per-language
+ * rules.
+ *
+ * Abstain-first by construction: a nearest match below the cosine floor, an
+ * ambiguous top-2 (margin below the floor), an empty/dimension-mismatched
+ * model, or an empty query embedding all return `null` — the generic path,
+ * i.e. today's behavior. It can therefore only ADD a route where the regex
+ * router found none; it never overrides a regex hit (the caller only invokes
+ * it on a null route) and never emits an inactive or non-routable lane.
+ *
+ * Pure module — no DI, no IO, no env. The service (…​.service.ts) owns the
+ * embedder call + centroid cache; the flag is resolved in retrieval-profile
+ * (profile.multilingualLaneRouting) and checked at the synthesize boundary.
+ */
+
+import type { LaneId } from '../search/retrieval-profile';
+import { cosineSimilarity } from '../common/vector-math';
+
+/**
+ * The lanes the classifier may propose — exactly the QUERY-ROUTABLE lanes of
+ * the registry (those with a `detect` lexicon). The evidence-conditional
+ * lanes (contradiction / recency / instruction / strategy) are never routed
+ * from the query text, so the classifier must never emit them. `ordering` is
+ * folded into `enumeration` in the registry (ENUMERATION_PATTERNS ⊇
+ * ORDERING_PATTERNS), so it is not a separate class here.
+ */
+export const CLASSIFIER_LANES = [
+  'temporal',
+  'enumeration',
+  'preference',
+  'summary',
+] as const satisfies readonly LaneId[];
+
+export type ClassifierLane = (typeof CLASSIFIER_LANES)[number];
+
+/**
+ * In-repo labeled exemplar set — short, natural queries per lane across the
+ * Tier 1-3 target languages (en, ru, es, fr, de, pt, it, zh, ja, ko, ar,
+ * hi). Deliberately small and paraphrase-diverse: the centroid is a mean, so
+ * a handful of on-topic phrasings per language localizes the lane well
+ * without paid data. Add exemplars here — no migration, no retraining.
+ */
+export const LANE_EXEMPLARS: Record<ClassifierLane, readonly string[]> = {
+  temporal: [
+    'how long ago did I start learning the piano',
+    'when did I move to Berlin',
+    'how many days since I quit smoking',
+    'сколько времени прошло с моего переезда',
+    'когда я в последний раз был у врача',
+    'combien de temps depuis mon déménagement',
+    'quand ai-je commencé ce travail',
+    'vor wie langer zeit habe ich angefangen',
+    'hace cuánto tiempo empecé a correr',
+    'há quanto tempo eu moro aqui',
+    'da quanto tempo lavoro qui',
+    '我上次去看医生是多久以前',
+    'ピアノを始めてからどれくらい経ちましたか',
+    '내가 이사한 지 얼마나 됐어',
+    'منذ متى بدأت تعلم اللغة',
+    'मैंने कितने दिन पहले शुरू किया था',
+  ],
+  enumeration: [
+    'list all the cities I have visited',
+    'how many books did I read this year',
+    'name every project I worked on',
+    'перечисли все места, где я был',
+    'сколько всего курсов я прошёл',
+    'liste tous les restaurants que j’ai aimés',
+    'combien de fois suis-je allé à la gym',
+    'zähle alle länder auf die ich besucht habe',
+    'enumera todos los libros que leí',
+    'quantos filmes eu assisti',
+    'elenca tutti i corsi che ho seguito',
+    '列出我去过的所有城市',
+    '私が訪れた都市をすべて挙げて',
+    '내가 방문한 도시를 모두 나열해줘',
+    'اذكر كل الأماكن التي زرتها',
+    'मैंने कौन कौन सी किताबें पढ़ीं सब बताओ',
+  ],
+  preference: [
+    'what restaurant should I try tonight',
+    'can you recommend a book for me',
+    'suggest a movie I would enjoy',
+    'что мне посмотреть сегодня вечером',
+    'посоветуй мне ресторан',
+    'peux-tu me recommander un livre',
+    'que devrais-je cuisiner ce soir',
+    'welches buch solltest du mir empfehlen',
+    'qué película me recomiendas',
+    'o que você me recomenda para o jantar',
+    'cosa mi consigli di guardare',
+    '给我推荐一本书',
+    'おすすめの映画を教えて',
+    '나에게 어울리는 책 추천해줘',
+    'بماذا تنصحني أن أشاهد الليلة',
+    'मुझे कौन सी फिल्म देखनी चाहिए सुझाव दो',
+  ],
+  summary: [
+    'summarize how my fitness has progressed',
+    'give me an overview of my career so far',
+    'how has my relationship with my sister evolved',
+    'подведи итог моего года',
+    'как менялось моё здоровье со временем',
+    'résume l’évolution de mon projet',
+    'donne-moi un aperçu de mes progrès',
+    'fasse meine fortschritte zusammen',
+    'resume cómo ha evolucionado mi carrera',
+    'faça um resumo do meu progresso',
+    'riassumi come è andato il mio anno',
+    '总结一下我这一年的变化',
+    '私のキャリアのこれまでを要約して',
+    '내 경력이 어떻게 발전했는지 요약해줘',
+    'لخّص لي تطوّر مسيرتي المهنية',
+    'मेरी प्रगति का सारांश दो',
+  ],
+};
+
+/** One fitted lane class: the mean of its embedded exemplars. */
+export interface LaneCentroid {
+  lane: ClassifierLane;
+  centroid: number[];
+  /** Exemplars that fed the centroid (0 ⇒ unusable, skipped). */
+  sampleCount: number;
+}
+
+export type LaneClassifierModel = readonly LaneCentroid[];
+
+/** Classifier outcome (control flow + telemetry label). */
+export type LaneClassifyOutcome =
+  'classified' | 'abstain_no_model' | 'abstain_low_confidence' | 'abstain_ambiguous';
+
+export interface LaneClassification {
+  /** The proposed lane, or null for every abstain outcome. */
+  lane: ClassifierLane | null;
+  outcome: LaneClassifyOutcome;
+  /** Active-and-routable lanes ranked by cosine (desc); [] for no_model. */
+  ranked: ReadonlyArray<{ lane: ClassifierLane; cosine: number }>;
+}
+
+/**
+ * Conservative, UNVALIDATED defaults (default-off feature; abstain-safe, so
+ * erring high just declines more often → today's behavior). The cosine floor
+ * rejects unrelated queries; the margin floor declines an ambiguous top-2
+ * rather than guess between two near-tied lanes.
+ */
+export const LANE_CLASSIFIER_MIN_COSINE = 0.3;
+export const LANE_CLASSIFIER_MIN_MARGIN = 0.02;
+
+/**
+ * Build per-lane centroids (mean vector) from embedded exemplars. Cosine
+ * normalizes magnitude, so the un-normalized mean is a fine centroid. A lane
+ * with no non-empty exemplar embedding is dropped (sampleCount 0).
+ */
+export function buildLaneCentroids(
+  embeddingsByLane: ReadonlyMap<ClassifierLane, number[][]>,
+): LaneClassifierModel {
+  const out: LaneCentroid[] = [];
+  for (const lane of CLASSIFIER_LANES) {
+    const vecs = (embeddingsByLane.get(lane) ?? []).filter((v) => v.length > 0);
+    if (vecs.length === 0) continue;
+    const dim = vecs[0]!.length;
+    const sum = new Array<number>(dim).fill(0);
+    let counted = 0;
+    for (const v of vecs) {
+      if (v.length !== dim) continue; // never average across dimensions
+      for (let i = 0; i < dim; i++) sum[i]! += v[i]!;
+      counted++;
+    }
+    if (counted === 0) continue;
+    out.push({
+      lane,
+      centroid: sum.map((s) => s / counted),
+      sampleCount: counted,
+    });
+  }
+  return out;
+}
+
+/**
+ * The pure classification decision. Nearest-centroid over the classes that
+ * are BOTH active (in `activeLanes`) and dimension-compatible with the query
+ * embedding. Abstains (lane: null) on an empty/incompatible model, a nearest
+ * cosine below `minCosine`, or a top-2 margin below `minMargin`. Never emits
+ * a lane outside `activeLanes` or outside CLASSIFIER_LANES.
+ */
+export function classifyLane(args: {
+  model: LaneClassifierModel;
+  queryEmbedding: number[];
+  activeLanes: ReadonlySet<LaneId>;
+  minCosine: number;
+  minMargin: number;
+}): LaneClassification {
+  const { model, queryEmbedding, activeLanes, minCosine, minMargin } = args;
+  if (queryEmbedding.length === 0) {
+    return { lane: null, outcome: 'abstain_no_model', ranked: [] };
+  }
+  const usable = model.filter(
+    (c) =>
+      c.sampleCount > 0 && c.centroid.length === queryEmbedding.length && activeLanes.has(c.lane),
+  );
+  if (usable.length === 0) {
+    return { lane: null, outcome: 'abstain_no_model', ranked: [] };
+  }
+  const ranked = usable
+    .map((c) => ({ lane: c.lane, cosine: cosineSimilarity(queryEmbedding, c.centroid) }))
+    .sort((a, b) => b.cosine - a.cosine);
+  const top = ranked[0]!;
+  if (top.cosine < minCosine) {
+    return { lane: null, outcome: 'abstain_low_confidence', ranked };
+  }
+  const second = ranked[1];
+  if (second && top.cosine - second.cosine < minMargin) {
+    return { lane: null, outcome: 'abstain_ambiguous', ranked };
+  }
+  return { lane: top.lane, outcome: 'classified', ranked };
+}

--- a/src/synthesize/synthesize.helpers.ts
+++ b/src/synthesize/synthesize.helpers.ts
@@ -1,6 +1,8 @@
 import type { SearchHit } from '../search/search.service';
 import { detectLanguage } from '../ai/locale/language-detector';
 import type { LaneId, RetrievalProfile } from '../search/retrieval-profile';
+import { routeLane, detectEvidenceConflicts } from './answer-router';
+import type { MultilingualLaneClassifierService } from './multilingual-lane-classifier.service';
 import type { SynthesisGuardrails, SynthesizeDto } from './dto/synthesize.dto';
 import type { SearchDto } from '../search/dto/search.dto';
 import type { DecisionLogEntry } from './decision-log';
@@ -17,6 +19,34 @@ import type { MetricsService } from '../metrics/metrics.service';
  * the service over 800). No IO, no DI; type-only imports back into the
  * service module, so there is no runtime cycle.
  */
+
+/**
+ * Route a query to a typed lane. Multilingual Tier 4 (MULTILINGUAL_LANE_ROUTING):
+ * when the English-regex router MISSES (null) and the flag is on, a language-
+ * agnostic nearest-centroid classifier proposes a lane for a non-English query
+ * — abstain-safe (low confidence ⇒ null ⇒ the generic path). Flag off /
+ * classifier absent ⇒ the regex route, byte-identical.
+ */
+export async function resolveRoutedLane(
+  profile: RetrievalProfile,
+  query: string,
+  classifier?: MultilingualLaneClassifierService,
+): Promise<LaneId | null> {
+  const lane = routeLane(profile, query);
+  if (lane !== null || !profile.multilingualLaneRouting || !classifier) return lane;
+  return classifier.augmentLane(query, profile.lanes);
+}
+
+/**
+ * Evidence-conflict detection, threaded with the Tier 4 typed-compare flag
+ * (MULTILINGUAL_CONFLICT). Off ⇒ byte-identical surface-string comparison.
+ */
+export function evidenceConflicts(
+  results: SearchHit[],
+  profile: RetrievalProfile,
+): Array<{ factIds: string[]; label: string }> {
+  return detectEvidenceConflicts(results, profile.lanes, profile.multilingualConflict);
+}
 
 /**
  * Serve an answer-cache hit — and count it as the terminal `ok` it is. admit()

--- a/src/synthesize/synthesize.module.ts
+++ b/src/synthesize/synthesize.module.ts
@@ -9,6 +9,7 @@ import { LensAdminController } from './lens-admin.controller';
 import { SynthesizeService } from './synthesize.service';
 import { FocusSignalService } from './focus-signal.service';
 import { LensSuppressionService } from './lens-suppression.service';
+import { MultilingualLaneClassifierService } from './multilingual-lane-classifier.service';
 import { EpisodeLaneService } from './episode-lane.service';
 import { SegmentLaneService } from './segment-lane.service';
 import { InsightLaneService } from './insight-lane.service';
@@ -26,6 +27,7 @@ import { L3EscalationService } from './l3-escalation.service';
     SynthesizeService,
     FocusSignalService,
     LensSuppressionService,
+    MultilingualLaneClassifierService,
     EvidenceCollectorService,
     EpisodeLaneService,
     SegmentLaneService,

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -17,17 +17,18 @@ import type { AbstainAdaptiveGate } from './verdict';
 import {
   attachDecisionLog,
   buildSecondaryDto,
+  evidenceConflicts,
   resolveAnswerFrames,
   resolveAnswerLang,
   resolveCitations,
   resolveLaneDateContext,
+  resolveRoutedLane,
   serveCacheHit,
   verifierErrorResult,
 } from './synthesize.helpers';
 import { resolvePromptFrames, wantsTimelineEvidence } from './evidence-gates';
 import { applyEvidenceUnion } from './evidence-union';
-import { routeLane, laneProbeDto, detectEvidenceConflicts, type LaneId } from './answer-router';
-export { detectEvidenceConflicts } from './answer-router';
+import { laneProbeDto, type LaneId } from './answer-router';
 import { getActiveRetrievalProfile, type RetrievalProfile } from '../search/retrieval-profile';
 import { buildFactIndex } from './fact-index';
 import { resolveAnswerIntegrity, type FinalizeContext } from './answer-integrity';
@@ -49,6 +50,7 @@ import {
 } from './focus-signal';
 import type { FocusVerdict, PerClassCalibration } from './focus-signal';
 import { LensSuppressionService } from './lens-suppression.service';
+import { MultilingualLaneClassifierService } from './multilingual-lane-classifier.service';
 import {
   AnswerCacheService,
   type AnswerCacheBeginResult,
@@ -128,6 +130,7 @@ export class SynthesizeService {
     @Optional() private readonly l3?: L3EscalationService,
     @Optional() private readonly focusSignal?: FocusSignalService,
     @Optional() private readonly lensSuppression?: LensSuppressionService,
+    @Optional() private readonly laneClassifier?: MultilingualLaneClassifierService,
   ) {
     this.openai = createOpenAiClientOrThrow(this.configService);
     this.defaultModel = this.configService.get<string>(
@@ -210,8 +213,11 @@ export class SynthesizeService {
 
     // Typed dispatch: lane detection is lexical and free, so it runs
     // before retrieval — the preference lane adds a deterministic
-    // second probe that similarity search would never surface.
-    const lane: LaneId | null = routeLane(profile, dto.query);
+    // second probe that similarity search would never surface. Multilingual
+    // Tier 4: a null regex route is augmented by the language-agnostic
+    // classifier when MULTILINGUAL_LANE_ROUTING is on (abstain-safe, off =
+    // byte-identical). See resolveRoutedLane.
+    const lane: LaneId | null = await resolveRoutedLane(profile, dto.query, this.laneClassifier);
 
     onProgress({ stage: 'search', message: 'hybrid retrieval' });
     const searchResult = await withSpan(
@@ -754,7 +760,7 @@ export class SynthesizeService {
               instructions: collected.instructions,
               // T3: evidence-conditional — fires on write-side COMPETING
               // facts regardless of what the question looks like.
-              conflicts: detectEvidenceConflicts(args.results, profile.lanes),
+              conflicts: evidenceConflicts(args.results, profile),
               dateMathLines: args.dateMathLines,
               shapeInstruction: args.shapeInstruction,
               // G4 strategy lane: advisory notes, GENERATOR-ONLY — the
@@ -838,9 +844,7 @@ export class SynthesizeService {
   } | null> {
     const { profile, dto, collected } = args;
     const refineQuery = args.generated.refineQuery?.trim();
-    if (!profile.searchLoop || !refineQuery || refineQuery === dto.query) {
-      return null;
-    }
+    if (!profile.searchLoop || !refineQuery || refineQuery === dto.query) return null;
     try {
       // Audit 2026-08-19 P1: the refined retrieval inherits the FULL
       // caller filter contract (anchors, floors, mode, user scope) —
@@ -876,7 +880,7 @@ export class SynthesizeService {
             lane: args.lane,
             enumStrict: profile.enumStrict,
             instructions: collected.instructions,
-            conflicts: detectEvidenceConflicts(prepared.results, profile.lanes),
+            conflicts: evidenceConflicts(prepared.results, profile),
             dateMathLines,
             shapeInstruction: args.shapeInstruction,
             strategyNotes: collected.strategyNotes,
@@ -981,8 +985,7 @@ export class SynthesizeService {
     baseHits: SearchHit[];
   }): Promise<SearchHit[]> {
     const probeDto = laneProbeDto(profile, lane, { query: dto.query, baseHits });
-    if (!probeDto) return [];
-    if (getAbortSignal()?.aborted) return [];
+    if (!probeDto || getAbortSignal()?.aborted) return [];
     try {
       // Audit 2026-08-19 P1: the probe inherits the caller's full
       // filter contract; the lane supplies only its query and limit.

--- a/test/answer-router.unit-spec.ts
+++ b/test/answer-router.unit-spec.ts
@@ -18,6 +18,7 @@ import {
   TEMPORAL_LANE_INSTRUCTION,
   ENUMERATION_LANE_INSTRUCTION,
   LANE_REGISTRY,
+  detectEvidenceConflicts,
 } from '../src/synthesize/answer-router';
 import {
   resolveRetrievalProfile,
@@ -33,11 +34,7 @@ function profileWith(over: Partial<RetrievalProfile> = {}): RetrievalProfile {
     ...over,
   };
 }
-import {
-  buildGeneratorUserMessage,
-  buildFactIndex,
-  detectEvidenceConflicts,
-} from '../src/synthesize/synthesize.service';
+import { buildGeneratorUserMessage, buildFactIndex } from '../src/synthesize/synthesize.service';
 import { CONTRADICTION_NOTE_INSTRUCTION } from '../src/synthesize/answer-router';
 import type { SearchHit } from '../src/search/search.types';
 

--- a/test/genre-presets.unit-spec.ts
+++ b/test/genre-presets.unit-spec.ts
@@ -168,6 +168,8 @@ describe('genre presets — full effective profile per genre (snapshot)', () => 
     coverageScanMode: 'brute',
     coverageLexMode: 'phrase',
     cjkSegmentation: false,
+    multilingualLaneRouting: false,
+    multilingualConflict: false,
     scanHnswEf: 400,
     scanHnswOverfetch: 4,
     dateAnchoring: 'absolute',

--- a/test/locale-time-decomposition.unit-spec.ts
+++ b/test/locale-time-decomposition.unit-spec.ts
@@ -1,0 +1,131 @@
+import { resolveEventTime } from '../src/ingest/event-time';
+
+/**
+ * Multilingual Tier 4 — locale-time decomposition (MULTILINGUAL_TEMPORAL).
+ * Three separable concerns behind opts.localeTime: (1) ar/hi/ko relative-
+ * expression recognition (chrono has no parser for them), (2) native-digit
+ * parsing, and (3) the atUtcMidnight day-shift fix via a session timezone.
+ * Off (no opts / localeTime:false) MUST be byte-identical to the legacy path.
+ *
+ * Anchors use a fixed instant; the ar/hi/ko + day-shift assertions resolve
+ * against the pure local-calendar-day anchor (Intl-based, host-timezone
+ * independent), so they hold on any CI machine.
+ */
+describe('locale-time decomposition', () => {
+  const ref = '2023-05-08T13:56:00Z'; // Monday, midday UTC
+  const ymd = (e: { date: Date } | null) => (e ? e.date.toISOString().slice(0, 10) : null);
+
+  describe('byte-identical when off (no opts ≡ localeTime:false)', () => {
+    const cases: Array<[string, string]> = [
+      ['went to the support group yesterday', 'en'],
+      ['ходил в группу вчера', 'ru'],
+      ['signed up 3 weeks ago', 'en'],
+      ['practicing art since 2016', 'en'],
+      ['I ran 2000 meters', 'en'],
+    ];
+    it.each(cases)('%s (%s) resolves identically with localeTime:false', (clause, lang) => {
+      const legacy = resolveEventTime(clause, ref, { lang });
+      const off = resolveEventTime(clause, ref, { lang, localeTime: false });
+      expect(ymd(off)).toEqual(ymd(legacy));
+    });
+    it('a Korean clause silently misses when off (the gap Tier 4 closes)', () => {
+      // chrono has no ko parser → English fallback → no date.
+      expect(resolveEventTime('어제 병원에 갔다', ref, { lang: 'ko' })).toBeNull();
+    });
+  });
+
+  describe('Korean relative expressions (localeTime on)', () => {
+    const t = (clause: string) =>
+      ymd(resolveEventTime(clause, ref, { lang: 'ko', localeTime: true }));
+    it('어제 → minus one day', () => expect(t('어제 병원에 갔다')).toBe('2023-05-07'));
+    it('그저께 → minus two days', () => expect(t('그저께 갔었어')).toBe('2023-05-06'));
+    it('3일 전 → minus three days', () => expect(t('3일 전에 만났다')).toBe('2023-05-05'));
+    it('지난주 → minus one week', () => expect(t('지난주에 시작했다')).toBe('2023-05-01'));
+    it('작년 → prior year', () =>
+      expect(
+        resolveEventTime('작년에 이사했다', ref, {
+          lang: 'ko',
+          localeTime: true,
+        })?.date.getUTCFullYear(),
+      ).toBe(2022));
+    it('5년 전 → five years back', () =>
+      expect(
+        resolveEventTime('5년 전에 졸업했다', ref, {
+          lang: 'ko',
+          localeTime: true,
+        })?.date.getUTCFullYear(),
+      ).toBe(2018));
+  });
+
+  describe('Hindi relative expressions (localeTime on)', () => {
+    const t = (clause: string) =>
+      ymd(resolveEventTime(clause, ref, { lang: 'hi', localeTime: true }));
+    it('कल → minus one day', () => expect(t('मैं कल गया था')).toBe('2023-05-07'));
+    it('5 दिन पहले → minus five days', () => expect(t('5 दिन पहले हुआ')).toBe('2023-05-03'));
+    it('पिछले साल → prior year', () =>
+      expect(
+        resolveEventTime('पिछले साल शुरू किया', ref, {
+          lang: 'hi',
+          localeTime: true,
+        })?.date.getUTCFullYear(),
+      ).toBe(2022));
+    it('does not match कल inside कलम (script boundary guard)', () =>
+      expect(t('मैंने कलम खरीदी')).toBeNull());
+  });
+
+  describe('Arabic relative expressions + native digits (localeTime on)', () => {
+    const t = (clause: string) =>
+      ymd(resolveEventTime(clause, ref, { lang: 'ar', localeTime: true }));
+    it('أمس → minus one day', () => expect(t('ذهبت أمس')).toBe('2023-05-07'));
+    it('منذ ٣ أيام (Arabic-Indic digits) → minus three days', () =>
+      expect(t('حدث منذ ٣ أيام')).toBe('2023-05-05'));
+    it('قبل 3 أسابيع → minus three weeks', () => expect(t('قبل 3 أسابيع')).toBe('2023-04-17'));
+    it('العام الماضي → prior year', () =>
+      expect(
+        resolveEventTime('العام الماضي انتقلت', ref, {
+          lang: 'ar',
+          localeTime: true,
+        })?.date.getUTCFullYear(),
+      ).toBe(2022));
+  });
+
+  describe('day-shift fix (atUtcMidnight → speaker local calendar day)', () => {
+    // 2023-05-07T15:30Z is 2023-05-08 00:30 in Tokyo — the speaker's local
+    // "today" is the 8th, so "yesterday" is the 7th, NOT the UTC-day 6th.
+    const boundary = '2023-05-07T15:30:00Z';
+    const ko = (clause: string, o: { timeZone?: string }) =>
+      ymd(resolveEventTime(clause, boundary, { lang: 'ko', localeTime: true, ...o }));
+
+    it('without a timezone: anchors to the UTC day (어제 → 05-06)', () => {
+      expect(ko('어제', {})).toBe('2023-05-06');
+    });
+    it('with the session timezone: anchors to the local day (어제 → 05-07)', () => {
+      expect(ko('어제', { timeZone: 'Asia/Tokyo' })).toBe('2023-05-07');
+    });
+    it('English "yesterday" is day-shift-corrected under a timezone too', () => {
+      expect(
+        ymd(
+          resolveEventTime('went there yesterday', boundary, {
+            lang: 'en',
+            localeTime: true,
+            timeZone: 'Asia/Tokyo',
+          }),
+        ),
+      ).toBe('2023-05-07');
+    });
+    it('an unknown timezone degrades to UTC-day behavior (never throws)', () => {
+      expect(ko('어제', { timeZone: 'Not/AZone' })).toBe('2023-05-06');
+    });
+  });
+
+  describe('past-only + lookback still enforced under localeTime', () => {
+    it('clamps an absurd lookback (30년 전) to null', () => {
+      expect(resolveEventTime('30년 전', ref, { lang: 'ko', localeTime: true })).toBeNull();
+    });
+    it('a stative Korean clause with no temporal expression → null', () => {
+      expect(
+        resolveEventTime('나는 개발자입니다', ref, { lang: 'ko', localeTime: true }),
+      ).toBeNull();
+    });
+  });
+});

--- a/test/multilingual-conflict.unit-spec.ts
+++ b/test/multilingual-conflict.unit-spec.ts
@@ -1,0 +1,136 @@
+import { detectEvidenceConflicts } from '../src/synthesize/answer-router';
+import { ALL_LANES, resolveRetrievalProfile } from '../src/search/retrieval-profile';
+import type { SearchHit } from '../src/search/search.service';
+
+/**
+ * Multilingual Tier 4 — typed conflict detection (MULTILINGUAL_CONFLICT).
+ * With typedCompare OFF (default) the detector is byte-identical surface-string
+ * equality; ON it compares normalized TYPED values so cross-lingual numeric /
+ * boolean disagreements are caught and cosmetic differences (digit script,
+ * case, number locale) don't false-flag. It never adjudicates — it only decides
+ * which slots to surface. LLM/NLI string-equivalence ("tea" ≡ "чай") is deferred.
+ */
+const LANES = new Set(ALL_LANES);
+
+const hitWith = (facts: Array<Record<string, unknown>>): SearchHit =>
+  ({
+    entityId: 'e1',
+    entityType: 'person',
+    canonicalName: 'n',
+    externalRefs: {},
+    score: 1,
+    facts: facts.map((f, i) => ({
+      factId: `knowledge_fact:f${i}`,
+      confidence: 0.7,
+      score: 1,
+      status: 'active',
+      ...f,
+    })),
+  }) as unknown as SearchHit;
+
+const labels = (c: Array<{ label: string }>) => c.map((x) => x.label);
+
+describe('detectEvidenceConflicts — typedCompare OFF (byte-identical)', () => {
+  it('a numeric disagreement without COMPETING/polarity is NOT flagged (legacy)', () => {
+    const hit = hitWith([
+      { predicate: 'weight', object: 'weighs 70 kg' },
+      { predicate: 'weight', object: 'весит 75 kg' },
+    ]);
+    expect(detectEvidenceConflicts([hit], LANES)).toEqual([]);
+    // explicit false is identical to the default (no drift).
+    expect(detectEvidenceConflicts([hit], LANES, false)).toEqual([]);
+  });
+  it('still flags COMPETING and polarity splits exactly as before', () => {
+    const competing = hitWith([
+      { predicate: 'has_key', object: 'yes', status: 'active' },
+      { predicate: 'has_key', object: 'no', status: 'COMPETING' },
+    ]);
+    expect(detectEvidenceConflicts([competing], LANES)).toHaveLength(1);
+  });
+});
+
+describe('detectEvidenceConflicts — typedCompare ON', () => {
+  it('catches a cross-lingual NUMERIC conflict on a typed slot (same unit)', () => {
+    const hit = hitWith([
+      { predicate: 'weight', object: 'weighs 70 kg' },
+      { predicate: 'weight', object: 'весит 75 kg' },
+    ]);
+    const c = detectEvidenceConflicts([hit], LANES, true);
+    expect(c).toHaveLength(1);
+    expect(labels(c)).toEqual(['weight']);
+  });
+  it('catches a BOOLEAN conflict across languages (yes vs нет)', () => {
+    const hit = hitWith([
+      { predicate: 'vaccinated', object: 'Yes' },
+      { predicate: 'vaccinated', object: 'нет' },
+    ]);
+    expect(detectEvidenceConflicts([hit], LANES, true)).toHaveLength(1);
+  });
+  it('does NOT flag equal values that differ only in DIGIT SCRIPT (no false positive)', () => {
+    // Arabic-Indic ٧٠ == 70; even with a COMPETING marker they normalize to one
+    // typed value, so the slot is not a conflict.
+    const hit = hitWith([
+      { predicate: 'weight', object: '٧٠ kg', status: 'COMPETING' },
+      { predicate: 'weight', object: '70 kg', status: 'active' },
+    ]);
+    expect(detectEvidenceConflicts([hit], LANES, true)).toEqual([]);
+  });
+  it('parses locale number formats (de 1.000,50 == en 1000.5) → not a conflict', () => {
+    const same = hitWith([
+      { predicate: 'salary', object: '1.000,50' },
+      { predicate: 'salary', object: '1000.5' },
+    ]);
+    expect(detectEvidenceConflicts([same], LANES, true)).toEqual([]);
+    const diff = hitWith([
+      { predicate: 'salary', object: '1.000,50' },
+      { predicate: 'salary', object: '1.500,50' },
+    ]);
+    expect(detectEvidenceConflicts([diff], LANES, true)).toHaveLength(1);
+  });
+  it('does NOT over-flag free-text strings (cross-lingual equivalence deferred to NLI)', () => {
+    // "tea"/"чай" are the same drink, but we cannot know that without a model;
+    // typed comparison must not invent a numeric/boolean conflict from strings.
+    const hit = hitWith([
+      { predicate: 'favorite_drink', object: 'tea' },
+      { predicate: 'favorite_drink', object: 'чай' },
+    ]);
+    expect(detectEvidenceConflicts([hit], LANES, true)).toEqual([]);
+  });
+  it('still surfaces a genuine COMPETING string conflict when typedCompare is on', () => {
+    const hit = hitWith([
+      { predicate: 'favorite_drink', object: 'tea', status: 'active' },
+      { predicate: 'favorite_drink', object: 'coffee', status: 'COMPETING' },
+    ]);
+    expect(detectEvidenceConflicts([hit], LANES, true)).toHaveLength(1);
+  });
+  it('does not fire when a different unit could mean an equivalent value (conservative)', () => {
+    // 70 kg vs 154 lb — no unit conversion (deferred); different unit tokens
+    // are left alone rather than risk a false positive.
+    const hit = hitWith([
+      { predicate: 'weight', object: '70 kg' },
+      { predicate: 'weight', object: '154 lb' },
+    ]);
+    expect(detectEvidenceConflicts([hit], LANES, true)).toEqual([]);
+  });
+  it('respects the lane gate even with typedCompare on', () => {
+    const hit = hitWith([
+      { predicate: 'weight', object: '70 kg' },
+      { predicate: 'weight', object: '75 kg' },
+    ]);
+    expect(detectEvidenceConflicts([hit], new Set(), true)).toEqual([]);
+  });
+});
+
+describe('MULTILINGUAL_CONFLICT → RetrievalProfile.multilingualConflict', () => {
+  it('defaults off and round-trips through the profile resolver', () => {
+    expect(resolveRetrievalProfile({} as NodeJS.ProcessEnv).multilingualConflict).toBe(false);
+    expect(
+      resolveRetrievalProfile({ MULTILINGUAL_CONFLICT: '1' } as NodeJS.ProcessEnv)
+        .multilingualConflict,
+    ).toBe(true);
+    expect(
+      resolveRetrievalProfile({ MULTILINGUAL_CONFLICT: '0' } as NodeJS.ProcessEnv)
+        .multilingualConflict,
+    ).toBe(false);
+  });
+});

--- a/test/multilingual-lane-classifier.unit-spec.ts
+++ b/test/multilingual-lane-classifier.unit-spec.ts
@@ -1,0 +1,164 @@
+import {
+  buildLaneCentroids,
+  classifyLane,
+  CLASSIFIER_LANES,
+  LANE_EXEMPLARS,
+  LANE_CLASSIFIER_MIN_COSINE,
+  LANE_CLASSIFIER_MIN_MARGIN,
+  type ClassifierLane,
+  type LaneClassifierModel,
+} from '../src/synthesize/multilingual-lane-classifier';
+import { ALL_LANES, resolveRetrievalProfile, type LaneId } from '../src/search/retrieval-profile';
+
+/**
+ * Multilingual Tier 4 — the pure language-agnostic lane classifier
+ * (MULTILINGUAL_LANE_ROUTING). Synthetic embeddings only: the pure decision
+ * takes precomputed vectors, so abstain/classify/margin logic is tested
+ * without an embedder. The off-path (byte-identical regex routing) is pinned
+ * by the profile default + the genre-presets snapshot; here we prove the
+ * decision itself is abstain-safe and never emits an inactive / non-routable
+ * lane.
+ */
+
+/** Standard basis vector e_i in `dims` dimensions. */
+const basis = (i: number, dims = 5): number[] => {
+  const v = new Array<number>(dims).fill(0);
+  v[i] = 1;
+  return v;
+};
+
+/** Orthonormal 4-lane model in `dims`≥4 dims; lanes live in dims 0..3, so a
+ *  query with weight in dim 4 can score arbitrarily low against all of them. */
+const model = (dims = 5): LaneClassifierModel => [
+  { lane: 'temporal', centroid: basis(0, dims), sampleCount: 3 },
+  { lane: 'enumeration', centroid: basis(1, dims), sampleCount: 3 },
+  { lane: 'preference', centroid: basis(2, dims), sampleCount: 3 },
+  { lane: 'summary', centroid: basis(3, dims), sampleCount: 3 },
+];
+
+const ALL = new Set<LaneId>(ALL_LANES);
+const classify = (q: number[], active: ReadonlySet<LaneId> = ALL, m = model()) =>
+  classifyLane({
+    model: m,
+    queryEmbedding: q,
+    activeLanes: active,
+    minCosine: LANE_CLASSIFIER_MIN_COSINE,
+    minMargin: LANE_CLASSIFIER_MIN_MARGIN,
+  });
+
+describe('CLASSIFIER_LANES — only query-routable lanes', () => {
+  it('excludes the evidence-conditional lanes (never routed from query text)', () => {
+    for (const forbidden of ['contradiction', 'recency', 'instruction', 'strategy'] as const) {
+      expect(CLASSIFIER_LANES).not.toContain(forbidden);
+    }
+  });
+  it('every classifier lane is a real LaneId with exemplars in many languages', () => {
+    for (const lane of CLASSIFIER_LANES) {
+      expect(ALL_LANES).toContain(lane);
+      // A handful of paraphrases across languages — enough for a mean centroid.
+      expect(LANE_EXEMPLARS[lane].length).toBeGreaterThanOrEqual(8);
+    }
+  });
+});
+
+describe('buildLaneCentroids', () => {
+  it('averages exemplar embeddings per lane and drops empty lanes', () => {
+    const by = new Map<ClassifierLane, number[][]>([
+      [
+        'temporal',
+        [
+          [2, 0, 0],
+          [0, 2, 0],
+        ],
+      ],
+      ['enumeration', []], // no usable exemplars → dropped
+    ]);
+    const built = buildLaneCentroids(by);
+    expect(built.map((c) => c.lane)).toEqual(['temporal']);
+    expect(built[0]!.centroid).toEqual([1, 1, 0]); // componentwise mean
+    expect(built[0]!.sampleCount).toBe(2);
+  });
+  it('never averages across mismatched dimensions', () => {
+    const by = new Map<ClassifierLane, number[][]>([
+      [
+        'temporal',
+        [
+          [1, 0],
+          [9, 9, 9], // wrong dim — skipped
+        ],
+      ],
+    ]);
+    const built = buildLaneCentroids(by);
+    expect(built[0]!.centroid).toEqual([1, 0]);
+    expect(built[0]!.sampleCount).toBe(1);
+  });
+});
+
+describe('classifyLane — confident match', () => {
+  it('routes a query nearest one centroid to that lane', () => {
+    const d = classify(basis(0)); // pure temporal direction
+    expect(d.lane).toBe('temporal');
+    expect(d.outcome).toBe('classified');
+    expect(d.ranked[0]!.lane).toBe('temporal');
+  });
+  it('routes to the second lane when it dominates', () => {
+    expect(classify(basis(2)).lane).toBe('preference');
+  });
+});
+
+describe('classifyLane — abstain outcomes (abstain-safe)', () => {
+  it('abstains (low confidence) below the cosine floor', () => {
+    // Mostly in dim 4 where no centroid lives → best cosine ≈ 0.1.
+    const d = classify([0.1, 0, 0, 0, 1]);
+    expect(d.lane).toBeNull();
+    expect(d.outcome).toBe('abstain_low_confidence');
+  });
+  it('abstains (ambiguous) when the top two are within the margin', () => {
+    const d = classify([1, 1, 0, 0, 0]); // equidistant temporal/enumeration
+    expect(d.lane).toBeNull();
+    expect(d.outcome).toBe('abstain_ambiguous');
+  });
+  it('abstains (no model) on an empty model', () => {
+    expect(classify(basis(0), ALL, []).outcome).toBe('abstain_no_model');
+  });
+  it('abstains (no model) on a dimension mismatch', () => {
+    const d = classify([1, 0, 0], ALL, model(5)); // query dim 3 vs centroid dim 5
+    expect(d.outcome).toBe('abstain_no_model');
+    expect(d.lane).toBeNull();
+  });
+  it('abstains on an empty query embedding', () => {
+    expect(classify([]).outcome).toBe('abstain_no_model');
+  });
+});
+
+describe('classifyLane — respects the active lane set', () => {
+  it('never emits a lane outside activeLanes', () => {
+    // temporal is the nearest but not active; the only active routable lane
+    // (enumeration) is orthogonal ⇒ below the floor ⇒ abstain, not a wrong route.
+    const active = new Set<LaneId>(['enumeration', 'contradiction']);
+    const d = classify(basis(0), active);
+    expect(d.lane).not.toBe('temporal');
+    expect(d.lane).toBeNull();
+    expect(d.ranked.every((r) => active.has(r.lane))).toBe(true);
+  });
+  it('routes to the nearest ACTIVE lane when it clears the floor', () => {
+    const active = new Set<LaneId>(['enumeration', 'summary']);
+    expect(classify(basis(1), active).lane).toBe('enumeration');
+  });
+});
+
+describe('MULTILINGUAL_LANE_ROUTING → RetrievalProfile.multilingualLaneRouting', () => {
+  it('defaults off and round-trips through the profile resolver', () => {
+    expect(resolveRetrievalProfile({} as NodeJS.ProcessEnv).multilingualLaneRouting).toBe(false);
+    expect(
+      resolveRetrievalProfile({
+        MULTILINGUAL_LANE_ROUTING: '1',
+      } as NodeJS.ProcessEnv).multilingualLaneRouting,
+    ).toBe(true);
+    expect(
+      resolveRetrievalProfile({
+        MULTILINGUAL_LANE_ROUTING: '0',
+      } as NodeJS.ProcessEnv).multilingualLaneRouting,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Multilingual program — Tier 4: language-agnostic lane classifier + locale-time decomposition + typed conflict detection

Fifth tier. **Everything default-off; prod byte-identical when off** (off-path tests). No new deps (`Intl`/`chrono`), no migration (pure functions + a profile field + an in-memory-cached classifier), no paid eval.

### Verified before building
- `lens-suppression.ts` is subtractive (`effectiveLanes ⊆ activeLanes`) → reused only the cosine PRIMITIVE (`common/vector-math` `cosineSimilarity`), **not** the suppression model.
- `answer-router.ts`: routable lane set (temporal/enumeration/preference/summary; ordering folds into enumeration) + `detectEvidenceConflicts` (~:516, string-equality + polarity fallback).
- `event-time.ts`: `atUtcMidnight` (:84 day-shift), `PARSERS`, ar/hi/ko → English chrono.

### Built (each behind a default-off flag)
1. **Language-agnostic lane classifier** (`MULTILINGUAL_LANE_ROUTING`) — new pure `multilingual-lane-classifier.ts` (nearest-centroid over a small multilingual exemplar set; abstain outcomes `no_model`/`low_confidence`/`ambiguous`) + a service (embedder + centroid cache). Wired in `synthesize.helpers.ts::resolveRoutedLane` as a **fallback only when the English-regex router returns null** and the flag is on. OFF → regex router byte-identical. Flag resolved in `retrieval-profile.ts` (synthesize boundary stays env-free, mirroring Tier 3).
2. **Locale-time decomposition** (`MULTILINGUAL_TEMPORAL`) — fixes the day-shift: `atLocaleMidnight(tz)` + chrono resolves against `localeNoonUtc` (UTC-noon of the speaker's local day, Intl-based, host-TZ-independent) when a session timezone is present; a data-driven ar/hi/ko relative-expression grammar + native-digit `normalizeDigits` (new `common/locale-digits.ts`). Read ingest-side (`mention-persist.service.ts`) via a new optional `IngestMentionDto.timezone`. OFF → byte-identical.
3. **Typed conflict detection** (`MULTILINGUAL_CONFLICT`) — `detectEvidenceConflicts(..., typedCompare)`: when on, normalizes to typed values (locale number parse, unit-adjacent token, boolean, digit/case/diacritic fold) and flags numeric/boolean disagreement even on derived rows while collapsing cosmetic-only differences. OFF → byte-identical string-equality. (This path presents already-flagged COMPETING facts — not the write-side adjudicator.)

### Flags & goldens
3 flags in `KNOWN_BOOLEAN_FLAGS` + `CONFIG_CATALOG`; two are profile fields (`multilingualLaneRouting`, `multilingualConflict`) in `retrieval-profile.ts` + wire schema + genre-presets snapshot. `MULTILINGUAL_` family off the ENGINE flag-budget by design → no golden edit. **No migration** (0102 remains the highest).

### Verification (all green)
- `tsc` → 0 · `eslint --max-warnings 0` → 0 · `prettier --check` → 0 (lane/conflict orchestration relocated into `synthesize.helpers.ts` to keep the service file ≤800 lines under the god-file ceiling)
- Full unit suite: **293 suites / 2735 tests** (new lane off/on/abstain, locale-time + day-shift + digits, typed-conflict off/on + gate goldens flag-budget/config-catalog-truth/genre-presets/contracts-admin-retrieval-profile)
- No paid eval.

### Deferred (documented)
Non-Gregorian calendars (Hijri/Jalali/令和/Buddhist+543 — need more than `Intl`); LLM/model-based multilingual NLI for free-text cross-lingual equivalence ("tea" ≡ "чай" — needs a model = paid/native dep). The free typed-value comparison ships now.

Multilingual stays **experimental** — nothing flipped on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
