### PR TITLE
feat(multilingual): hierarchical per-language calibration + answer-language guard (Tier 5, default-off)

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -575,6 +575,30 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Typed conflict detection: detectEvidenceConflicts compares NORMALIZED TYPED VALUES (numbers/booleans, digit-script- and case-folded, locale number parsing) instead of surface strings, so a cross-lingual numeric/boolean disagreement on a typed slot ("70 kg" vs "75 kg") is caught even on derived rows without a COMPETING status, and cosmetic differences (digit script, case) no longer false-flag. Presentation of already-flagged COMPETING facts only — never the write-side adjudicator; model-based multilingual NLI (semantic string equivalence like "tea" ≡ "чай") is deliberately deferred (needs a model). Resolved into the RetrievalProfile. Off (default) → byte-identical string-equality behavior.',
   },
+  // ── Multilingual (Tier 5, migration 0103) ───────────
+  {
+    key: 'MULTILINGUAL_CALIBRATION',
+    category: 'pipeline',
+    // Read at fit / load time via fovea-flags.multilingualCalibrationEnabled()
+    // (a per-call function body const, never constructor-captured) — a flip
+    // takes effect on the next fit/load without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Hierarchical per-language focus calibration: the §4.2 per-class isotonic calibrator (focus-signal.ts) gains a LANGUAGE key with an exact (class × language) → (class × script/family) → (class) → global fallback, fitting a per-language / per-script map only when the bucket clears the same min-sample floor (so a sparse language never earns a noisy calibrator and degrades up the hierarchy). Focus-signal capture stamps the detected query language + script on each sample (migration 0103 optional columns). Serving-neutral — nothing on the answer path reads the calibration yet (Optics-2/3). Off (default) → the language dimension is never written or consulted and the global per-class calibration is byte-identical.',
+  },
+  {
+    key: 'MULTILINGUAL_ANSWER_GUARD',
+    category: 'pipeline',
+    // Resolved into the RetrievalProfile (answerLangGuard) by
+    // resolveRetrievalProfile — read per request, never constructor-captured.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Answer-language guard: the answer-language target follows a strict fallback ORDER — explicit answerLang → user/session locale (dto.queryLang) → confidently-detected query language (Tier 1 confidence floor) → no forced language — so on mixed retrieval the FACTS never decide the answer language. After generation the answer's own language is detected and, on a cross-script mismatch with the target, ONE bounded corrective regeneration runs with a reinforced language directive (temperature already 0); a still-mismatched answer is flagged (metrics) and served best-effort. Resolved into the RetrievalProfile. Off (default) → resolveAnswerLang byte-identical and no output-language check runs.",
+  },
   {
     key: 'INGEST_CONFUSABLES_CHECK',
     category: 'pipeline',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -813,6 +813,25 @@ const KNOWN_BOOLEAN_FLAGS = [
   // (multilingualConflict). Default off ⇒ byte-identical string-equality.
   // MULTILINGUAL_ family, off the ENGINE flag budget.
   'MULTILINGUAL_CONFLICT',
+  // Multilingual Tier 5 (migration 0103). Hierarchical per-language focus
+  // calibration: the §4.2 per-class isotonic calibrator gains a LANGUAGE key
+  // with an exact (class × language) → (class × script/family) → (class)
+  // fallback, and the focus-signal capture stamps the detected query
+  // language/script per sample. Read at fit/load time via fovea-flags
+  // (multilingualCalibrationEnabled). Serving-neutral (nothing on the answer
+  // path reads the calibration yet). Default off ⇒ language dimension never
+  // written or consulted; global per-class calibration byte-identical.
+  // MULTILINGUAL_ family, off the ENGINE flag budget.
+  'MULTILINGUAL_CALIBRATION',
+  // Multilingual Tier 5. Answer-language guard: the answer target follows a
+  // strict fallback order (explicit answerLang → session locale → confidently-
+  // detected query language → no forced language) so the facts never pick the
+  // answer language, and the generated answer's own language is checked against
+  // that target with ONE bounded corrective regeneration on a cross-script
+  // mismatch. Resolved into the RetrievalProfile (answerLangGuard). Default off
+  // ⇒ resolveAnswerLang byte-identical, no output-language check.
+  // MULTILINGUAL_ family, off the ENGINE flag budget.
+  'MULTILINGUAL_ANSWER_GUARD',
   // Multilingual Tier 2 (migration 0101). The embedding-space family stamps
   // + guards the (model, dim, norm) space a vector lives in so flipping the
   // embedder can't silently mix vector spaces. All default off; each is a

--- a/src/common/fovea-flags.ts
+++ b/src/common/fovea-flags.ts
@@ -153,3 +153,21 @@ export function plausibilityCheckEnabled(): boolean {
 export function requireCitationsEnabled(): boolean {
   return envFlagEnabled(process.env.FOVEA_REQUIRE_CITATIONS);
 }
+
+/**
+ * Multilingual Tier 5 master flag — MULTILINGUAL_CALIBRATION.
+ *
+ * When on, the §4.2 per-class focus calibrator (focus-signal.ts) gains a
+ * hierarchical LANGUAGE key: it fits + applies (class × language) →
+ * (class × script/family) → (class) → 'default' maps, and the focus-signal
+ * capture path records the detected query language/script on each sample
+ * (migration 0103 columns). The env read lives here in the common layer,
+ * NOT inside the engine dirs (engine-gates S5.2), and is read at fit / load
+ * time so a flip is runtime-mutable. Default off ⇒ the language dimension is
+ * never written or consulted and the global per-class calibration is
+ * BYTE-IDENTICAL to pre-Tier-5. Serving-neutral like the rest of the focus
+ * surface (nothing on the answer path reads the calibration yet).
+ */
+export function multilingualCalibrationEnabled(): boolean {
+  return envFlagEnabled(process.env.MULTILINGUAL_CALIBRATION);
+}

--- a/src/contracts/admin/retrieval-profile.schema.ts
+++ b/src/contracts/admin/retrieval-profile.schema.ts
@@ -23,6 +23,7 @@ export const RetrievalProfileWireSchema = z.object({
   cjkSegmentation: z.boolean(),
   multilingualLaneRouting: z.boolean(),
   multilingualConflict: z.boolean(),
+  answerLangGuard: z.boolean(),
   scanHnswEf: z.number().int(),
   scanHnswOverfetch: z.number().int(),
   dateAnchoring: z.enum(['none', 'session_date', 'absolute']),

--- a/src/db/migrations/0103_focus_calibration_language.surql
+++ b/src/db/migrations/0103_focus_calibration_language.surql
@@ -1,0 +1,47 @@
+-- 0103: hierarchical per-language focus calibration (multilingual Tier 5).
+-- Companion to docs/roadmap/fovea-optics-2026-08.md §4.2 and
+-- docs/roadmap/multilingual-2026-08.md.
+--
+-- WHY a language/script dimension. The §4.2 per-class isotonic calibrator
+-- (0094/0095) keys the raw→P(correct) map by queryClass (routed LaneId) and
+-- stage. The genre law that motivated per-class calibration has a
+-- multilingual analogue: the raw focus confidence is systematically
+-- mis-scaled across languages/scripts (a retrieval "coverage" that reads as
+-- 0.7 on a Latin query does not mean the same P(correct) on a Cyrillic /
+-- CJK one). Tier 5 adds a LANGUAGE key with a HIERARCHICAL fallback —
+-- exact (class × language) → (class × script/family) → (class) global —
+-- so a well-sampled language gets its own calibrator while a sparse one
+-- falls back up the ladder (min-sample floor in fitPerClass) and never gets
+-- a noisy per-language map.
+--
+-- ADDITIVE + OPTIONAL by construction (the 0094/0095/0102 posture): two new
+-- OPTIONAL columns on each of the two focus tables, no default, no
+-- migrate-time data mutation. Every existing row keeps language = NONE and
+-- script = NONE — i.e. the global-per-class population — so with
+-- MULTILINGUAL_CALIBRATION off the fit / load / apply path is BYTE-IDENTICAL
+-- to pre-0103 (the readers add `AND language IS NONE AND script IS NONE`
+-- when the flag is off, matching exactly these NONE rows). Every statement
+-- is IF NOT EXISTS / REMOVE-then-DEFINE, so the migration is OVERWRITE-safe
+-- and re-runnable.
+
+-- ── focus_signal_sample: the query language/script the sample was captured
+--    under (detected from the query at capture time, only when the Tier 5
+--    flag is on). NONE ⇒ the sample belongs to the global per-class pool. ──
+DEFINE FIELD IF NOT EXISTS language ON focus_signal_sample TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS script   ON focus_signal_sample TYPE option<string>;
+
+-- ── focus_calibration: the language/script the fitted map calibrates. A
+--    (class × language) row carries language set + script NONE; a
+--    (class × script) row carries script set + language NONE; the global
+--    per-class row carries both NONE (byte-identical to pre-0103). ──
+DEFINE FIELD IF NOT EXISTS language ON focus_calibration TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS script   ON focus_calibration TYPE option<string>;
+
+-- The version counter is now scoped per (queryClass, language, script,
+-- stage): a (class × ru) map versions independently of the (class × Cyrl)
+-- map and of the global (class) map. Extend the key index to carry both new
+-- dimensions so the max-version-per-key read stays index-served.
+-- (Non-unique — the reader picks max(version) per key.)
+REMOVE INDEX IF EXISTS focus_calibration_key_idx ON focus_calibration;
+DEFINE INDEX IF NOT EXISTS focus_calibration_key_idx ON focus_calibration
+    FIELDS queryClass, language, script, stage, version;

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -630,6 +630,12 @@ export class MetricsService implements OnModuleInit {
       // V13 constrained search loop: the one refine round ran (the
       // final outcome is still counted separately by the exits above).
       | 'search_loop_refined'
+      // Multilingual Tier 5 (answer-language guard): an output-language
+      // mismatch triggered the ONE corrective regeneration.
+      | 'answer_lang_retry'
+      // Tier 5: the answer was STILL not in the target language after that
+      // retry (the bounded "then flag" — served best-effort).
+      | 'answer_lang_unresolved'
       | 'verifier_error',
   ): void {
     this.synthesizeCount.inc({ outcome } as LabelValues<'outcome'>);

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -287,6 +287,17 @@ export interface RetrievalProfile {
    * adjudicator. Off (default) ⇒ byte-identical string-equality behavior.
    */
   multilingualConflict: boolean;
+  /**
+   * Multilingual Tier 5 (MULTILINGUAL_ANSWER_GUARD). When ON, the answer-
+   * language target follows a strict fallback ORDER — explicit answerLang →
+   * user/session locale (dto.queryLang) → confidently-detected query language
+   * (Tier 1 confidence floor) → no forced language — so the retrieved FACTS
+   * never decide the answer language; and after generation the answer's own
+   * language is checked against that target, with ONE bounded corrective
+   * regeneration on a cross-script mismatch (then flagged). Off (default) ⇒
+   * `resolveAnswerLang` is byte-identical and no output-language check runs.
+   */
+  answerLangGuard: boolean;
   /** HNSW ef candidate-list size for the scan legs (clamped up to the
    *  overfetched k at query time — ef below k is never useful). */
   scanHnswEf: number;
@@ -660,6 +671,7 @@ function resolveForGenre(genre: RetrievalGenre, env: NodeJS.ProcessEnv): Retriev
     cjkSegmentation: envFlagEnabled(env.MULTILINGUAL_CJK_SEGMENTATION),
     multilingualLaneRouting: envFlagEnabled(env.MULTILINGUAL_LANE_ROUTING),
     multilingualConflict: envFlagEnabled(env.MULTILINGUAL_CONFLICT),
+    answerLangGuard: envFlagEnabled(env.MULTILINGUAL_ANSWER_GUARD),
     scanHnswEf: positiveIntEnv(env, 'RETRIEVAL_SCAN_HNSW_EF', 400),
     scanHnswOverfetch: positiveIntEnv(env, 'RETRIEVAL_SCAN_HNSW_OVERFETCH', 4),
     dateAnchoring:
@@ -860,6 +872,7 @@ export function resolveRetrievalProfileFor(
     'cjkSegmentation',
     'multilingualLaneRouting',
     'multilingualConflict',
+    'answerLangGuard',
   ] as const) {
     if (typeof o[key] === 'boolean') merged[key] = o[key] as boolean;
   }

--- a/src/synthesize/focus-signal.service.ts
+++ b/src/synthesize/focus-signal.service.ts
@@ -6,15 +6,19 @@ import {
   adaptiveL3Enabled,
   adaptiveL3EscalateThreshold,
   focusCaptureEnabled,
+  multilingualCalibrationEnabled,
 } from '../common/fovea-flags';
 import { SurrealService } from '../db/surreal.service';
+import { detectLanguage } from '../ai/locale/language-detector';
 import type { SearchHit } from '../search/search.types';
 import type { LaneId } from './answer-router';
 import {
   buildFocusSignal,
   calibratedConfidence as calibratedConfidenceOf,
+  calibrationKey,
   computeReliability,
   fitPerClass,
+  parseCalibrationKey,
   queryClassOf,
   rawFocusConfidence,
   type FocusOutcomeSample,
@@ -36,6 +40,38 @@ const FOCUS_STAGES: readonly FocusStage[] = ['verdict', 'preanswer'];
  */
 function stagePredicate(stage: FocusStage): string {
   return stage === 'verdict' ? "(stage = 'verdict' OR stage IS NONE)" : "stage = 'preanswer'";
+}
+
+/**
+ * Build the WHERE fragment + params that select EXACTLY one calibration key's
+ * (queryClass, language, script) tuple — an absent dimension matches `IS NONE`
+ * so a bare per-class row is never confused with a (class × language) row when
+ * bumping the version counter (Tier 5). queryClass is a typed LaneId/'default';
+ * language/script are ISO codes — all inlined via bound params.
+ */
+function calibrationKeyPredicate(parts: {
+  queryClass: string;
+  language?: string | undefined;
+  script?: string | undefined;
+}): {
+  where: string;
+  params: Record<string, unknown>;
+} {
+  const clauses = ['queryClass = $q'];
+  const params: Record<string, unknown> = { q: parts.queryClass };
+  if (parts.language) {
+    clauses.push('language = $language');
+    params.language = parts.language;
+  } else {
+    clauses.push('language IS NONE');
+  }
+  if (parts.script) {
+    clauses.push('script = $script');
+    params.script = parts.script;
+  } else {
+    clauses.push('script IS NONE');
+  }
+  return { where: clauses.join(' AND '), params };
 }
 
 /**
@@ -101,7 +137,12 @@ export class FocusSignalService {
    */
   async maybeCapture(
     companyId: string,
-    args: { results: readonly SearchHit[]; verdict: FocusVerdict; lane: LaneId | null },
+    args: {
+      results: readonly SearchHit[];
+      verdict: FocusVerdict;
+      lane: LaneId | null;
+      query?: string;
+    },
     stage: FocusStage = 'verdict',
   ): Promise<void> {
     if (!FocusSignalService.captureEnabled()) return;
@@ -115,6 +156,19 @@ export class FocusSignalService {
         factScores,
         verifierVerdict: args.verdict,
       });
+      // Tier 5 (MULTILINGUAL_CALIBRATION): stamp the detected QUERY language +
+      // script so the hierarchical calibrator can key on them. Detected with
+      // attribution OFF so the bucket label is deterministic and independent
+      // of MULTILINGUAL_LANG_ATTRIBUTION; 'und' leaves the pair unset (the
+      // sample stays in the global per-class pool). Off ⇒ never stamped, so
+      // every sample is language-NONE and the fit/apply path is byte-identical.
+      if (multilingualCalibrationEnabled() && args.query) {
+        const det = detectLanguage(args.query, false);
+        if (det.language !== 'und') {
+          signal.language = det.language;
+          signal.script = det.script;
+        }
+      }
       await this.insertSample(companyId, signal, stage);
     } catch (e) {
       this.logger.warn(`focus-signal capture failed (${(e as Error).message}); ignored`);
@@ -127,6 +181,12 @@ export class FocusSignalService {
     stage: FocusStage = 'verdict',
   ): Promise<void> {
     await this.surreal.withCompany(companyId, async (db) => {
+      // Tier 5 language/script columns are appended to the CONTENT only when
+      // detected — an omitted optional field stays NONE (not NULL), so
+      // `language IS NONE` still selects the global per-class pool. Off ⇒ the
+      // clause is empty and the insert is byte-identical to pre-Tier-5.
+      const langFields =
+        (sig.language ? ', language: $language' : '') + (sig.script ? ', script: $script' : '');
       await db.query(
         `CREATE focus_signal_sample CONTENT {
             companyId: $companyId,
@@ -138,7 +198,7 @@ export class FocusSignalService {
             verifierVerdict: $verifierVerdict,
             retrievalGap: $retrievalGap,
             rawConfidence: $rawConfidence,
-            correct: NONE
+            correct: NONE${langFields}
          }`,
         {
           companyId,
@@ -150,6 +210,8 @@ export class FocusSignalService {
           verifierVerdict: sig.verifierVerdict,
           retrievalGap: sig.retrievalGap,
           rawConfidence: rawFocusConfidence(sig),
+          ...(sig.language ? { language: sig.language } : {}),
+          ...(sig.script ? { script: sig.script } : {}),
         },
       );
     });
@@ -204,15 +266,20 @@ export class FocusSignalService {
             verifierVerdict: string;
             retrievalGap: number;
             correct: number;
+            language: string | null;
+            script: string | null;
           }>,
         ]
       >(
         `SELECT queryClass, topScore, coverageScore, verifierVerdict,
-                retrievalGap, correct
+                retrievalGap, correct, language, script
             FROM focus_signal_sample
             WHERE correct IS NOT NONE AND ${stagePredicate(stage)}
             LIMIT 100000`,
       );
+      // language/script are carried through (NONE ⇒ global pool); fitPerClass
+      // only groups on them when byLanguage is on (Tier 5), so loading them
+      // unconditionally is flag-agnostic and harmless when off.
       return (rows ?? []).map((r) => ({
         queryClass: r.queryClass,
         topScore: r.topScore,
@@ -220,6 +287,8 @@ export class FocusSignalService {
         verifierVerdict: normalizeVerdict(r.verifierVerdict),
         retrievalGap: r.retrievalGap,
         correct: r.correct === 1 ? 1 : 0,
+        ...(r.language ? { language: r.language } : {}),
+        ...(r.script ? { script: r.script } : {}),
       }));
     });
   }
@@ -243,11 +312,12 @@ export class FocusSignalService {
       sampleCount: number;
       stage: FocusStage;
     }> = [];
+    const byLanguage = multilingualCalibrationEnabled();
     for (const stage of FOCUS_STAGES) {
       const samples = await this.loadLabeledSamples(companyId, stage);
       total += samples.length;
       if (samples.length === 0) continue;
-      const cal = fitPerClass(samples);
+      const cal = fitPerClass(samples, { byLanguage });
       const persisted = await this.persistCalibration(companyId, cal, stage);
       for (const p of persisted) classes.push({ ...p, stage });
     }
@@ -261,15 +331,26 @@ export class FocusSignalService {
   ): Promise<Array<{ queryClass: string; bins: number; sampleCount: number }>> {
     return this.surreal.withCompany(companyId, async (db) => {
       const out: Array<{ queryClass: string; bins: number; sampleCount: number }> = [];
-      for (const [queryClass, map] of Object.entries(cal)) {
-        // Version counter is per (queryClass, stage) — a verdict 'default'
-        // and a preanswer 'default' map advance independently.
+      for (const [key, map] of Object.entries(cal)) {
+        // Decode the calibration key back into its columns (Tier 5): a bare
+        // key → { queryClass } (language/script NONE, byte-identical to
+        // pre-0103); a hierarchical key → the (class × language|script) tuple.
+        const parts = parseCalibrationKey(key);
+        // Version counter is per (queryClass, language, script, stage) — a
+        // (class × ru), a (class × Cyrl) and the global (class) map each
+        // advance independently, as do the verdict/preanswer stages.
+        const keyPred = calibrationKeyPredicate(parts);
         const [latest] = await db.query<[Array<{ version: number }>]>(
           `SELECT version FROM focus_calibration
-              WHERE queryClass = $q AND stage = $stage ORDER BY version DESC LIMIT 1`,
-          { q: queryClass, stage },
+              WHERE ${keyPred.where} AND stage = $stage ORDER BY version DESC LIMIT 1`,
+          { ...keyPred.params, stage },
         );
         const next = Array.isArray(latest) && latest[0]?.version ? latest[0].version + 1 : 1;
+        // Optional columns appended only when set — an omitted one stays NONE,
+        // so a bare per-class row is byte-identical to pre-0103.
+        const langFields =
+          (parts.language ? ', language: $language' : '') +
+          (parts.script ? ', script: $script' : '');
         await db.query(
           `CREATE focus_calibration CONTENT {
               queryClass: $q,
@@ -277,18 +358,20 @@ export class FocusSignalService {
               thresholds: $t,
               values: $v,
               sampleCount: $sc,
-              version: $version
+              version: $version${langFields}
            }`,
           {
-            q: queryClass,
+            q: parts.queryClass,
             stage,
             t: map.thresholds,
             v: map.values,
             sc: map.sampleCount,
             version: next,
+            ...(parts.language ? { language: parts.language } : {}),
+            ...(parts.script ? { script: parts.script } : {}),
           },
         );
-        out.push({ queryClass, bins: map.thresholds.length, sampleCount: map.sampleCount });
+        out.push({ queryClass: key, bins: map.thresholds.length, sampleCount: map.sampleCount });
       }
       return out;
     });
@@ -296,15 +379,24 @@ export class FocusSignalService {
 
   /**
    * Load the latest persisted per-class calibration for one STAGE (max
-   * version per class). `stage` defaults to 'verdict' so Optics-2's stage-
-   * less `loadCalibration(companyId)` call resolves the verdict calibrator
+   * version per key). `stage` defaults to 'verdict' so Optics-2's stage-less
+   * `loadCalibration(companyId)` call resolves the verdict calibrator
    * byte-identically; NONE-stage rows (pre-0095) are read as verdict.
+   *
+   * Tier 5 (MULTILINGUAL_CALIBRATION): when the flag is on, the (class ×
+   * language) and (class × script) rows are ALSO loaded and re-keyed with
+   * `calibrationKey`, so the hierarchical lookup in `calibratedConfidence`
+   * can resolve them. When OFF the query adds `language IS NONE AND script IS
+   * NONE`, selecting ONLY the global per-class rows (every pre-0103 row, plus
+   * any bare row a later fit wrote) — byte-identical to the pre-Tier-5 load.
    */
   async loadCalibration(
     companyId: string,
     stage: FocusStage = 'verdict',
   ): Promise<PerClassCalibration> {
+    const byLanguage = multilingualCalibrationEnabled();
     return this.surreal.withCompany(companyId, async (db) => {
+      const langClause = byLanguage ? '' : ' AND language IS NONE AND script IS NONE';
       const [rows] = await db.query<
         [
           Array<{
@@ -313,20 +405,29 @@ export class FocusSignalService {
             values: number[];
             sampleCount: number;
             version: number;
+            language: string | null;
+            script: string | null;
           }>,
         ]
       >(
-        `SELECT queryClass, thresholds, values, sampleCount, version
+        `SELECT queryClass, thresholds, values, sampleCount, version, language, script
             FROM focus_calibration
-            WHERE ${stagePredicate(stage)}
+            WHERE ${stagePredicate(stage)}${langClause}
             ORDER BY version DESC`,
       );
       const cal: PerClassCalibration = {};
       for (const r of rows ?? []) {
-        // First row per class wins (rows are version-desc ordered).
-        if (cal[r.queryClass]) continue;
+        // Re-key on the full (class, language, script) tuple; a bare row
+        // yields the plain queryClass key. First row per key wins (rows are
+        // version-desc ordered).
+        const key = calibrationKey({
+          queryClass: r.queryClass,
+          ...(r.language ? { language: r.language } : {}),
+          ...(r.script ? { script: r.script } : {}),
+        });
+        if (cal[key]) continue;
         if (!Array.isArray(r.thresholds) || !Array.isArray(r.values)) continue;
-        cal[r.queryClass] = {
+        cal[key] = {
           thresholds: r.thresholds,
           values: r.values,
           sampleCount: r.sampleCount,
@@ -353,10 +454,12 @@ export class FocusSignalService {
   }
 
   /** Apply the latest persisted calibration to a live signal — provided for
-   *  Optics-2/3 (NOT called on the serving path in this PR). */
+   *  Optics-2/3 (NOT called on the serving path in this PR). Threads the Tier 5
+   *  hierarchy flag so the (class × language|script) lookup matches the load. */
   async calibrate(companyId: string, sig: FocusSignal): Promise<number> {
+    const byLanguage = multilingualCalibrationEnabled();
     const cal = await this.loadCalibration(companyId);
-    return calibratedConfidenceOf(cal, sig);
+    return calibratedConfidenceOf(cal, sig, { byLanguage });
   }
 
   /** List recent samples (id + class + label state) so the harness can

--- a/src/synthesize/focus-signal.ts
+++ b/src/synthesize/focus-signal.ts
@@ -79,6 +79,18 @@ export interface FocusSignal {
    *  gap means the top hit stands out (a distinctive, confident retrieval);
    *  a flat distribution (small gap) means ambiguous evidence. In [0,1]. */
   retrievalGap: number;
+  /**
+   * Multilingual Tier 5 (MULTILINGUAL_CALIBRATION, migration 0103). The
+   * detected QUERY language (ISO 639-1) and script (ISO 15924) the sample
+   * was captured under — the language key of the hierarchical calibrator
+   * (see `calibrationKey` / `fitPerClass` / `calibratedConfidence`).
+   * UNDEFINED ⇒ the sample belongs to the global per-class pool (the
+   * pre-Tier-5 population); the whole language dimension is consulted only
+   * when the caller opts in via the `byLanguage` option, so an undefined
+   * pair is byte-identical to the per-class-only behaviour.
+   */
+  language?: string | undefined;
+  script?: string | undefined;
 }
 
 /** A captured signal paired with its observed outcome (1 = the answer was
@@ -105,6 +117,56 @@ export const MIN_CLASS_SAMPLES = 30;
 
 /** The shared/fallback calibration-class key. */
 export const DEFAULT_CLASS = 'default';
+
+// ── Hierarchical calibration key (multilingual Tier 5) ─────────────
+//
+// The per-class calibration Record is keyed by a single string so it can
+// keep reusing ONE flat `Record<string, CalibrationMap>` and the ONE PAV
+// primitive — no parallel calibrator. A bare `queryClass` is the global
+// per-class key (byte-identical to pre-Tier-5). The language and script
+// dimensions are encoded as suffixes on that same key, so the whole
+// exact→family→global hierarchy lives in the same Record and persists
+// through the same versioned-row path (the migration 0103 language/script
+// columns are just the decoded parts of the key). The separator is the
+// ASCII unit separator (control U+001F) — never present in a LaneId (the
+// only queryClass source) nor in an ISO 639-1 / 15924 code.
+const KEY_SEP = String.fromCharCode(0x1f);
+const LANG_TAG = 'lang=';
+const SCRIPT_TAG = 'script=';
+
+/** The decoded parts of a calibration key. */
+export interface CalibrationKeyParts {
+  queryClass: string;
+  /** ISO 639-1 language — the (class × language) tier. */
+  language?: string | undefined;
+  /** ISO 15924 script — the (class × script/family) tier. */
+  script?: string | undefined;
+}
+
+/**
+ * Encode a calibration key. `language` takes precedence over `script` (a
+ * key names exactly ONE tier); a bare queryClass (both absent) is the
+ * global per-class key, encoded exactly as the queryClass string so it is
+ * byte-identical to the pre-Tier-5 key.
+ */
+export function calibrationKey(parts: CalibrationKeyParts): string {
+  if (parts.language) return `${parts.queryClass}${KEY_SEP}${LANG_TAG}${parts.language}`;
+  if (parts.script) return `${parts.queryClass}${KEY_SEP}${SCRIPT_TAG}${parts.script}`;
+  return parts.queryClass;
+}
+
+/** Inverse of `calibrationKey` — split a stored key back into its parts so
+ *  the persistence layer can write the (queryClass, language, script)
+ *  columns (migration 0103). A bare key → { queryClass }. */
+export function parseCalibrationKey(key: string): CalibrationKeyParts {
+  const sep = key.indexOf(KEY_SEP);
+  if (sep === -1) return { queryClass: key };
+  const queryClass = key.slice(0, sep);
+  const tail = key.slice(sep + KEY_SEP.length);
+  if (tail.startsWith(LANG_TAG)) return { queryClass, language: tail.slice(LANG_TAG.length) };
+  if (tail.startsWith(SCRIPT_TAG)) return { queryClass, script: tail.slice(SCRIPT_TAG.length) };
+  return { queryClass };
+}
 
 // ── Raw signal ─────────────────────────────────────────────────────
 
@@ -195,6 +257,22 @@ export function queryClassOf(laneId: LaneId | null | undefined): string {
 // ── Per-class calibration (reuses isotonic.ts) ─────────────────────
 
 /**
+ * Fit options. `byLanguage` (multilingual Tier 5, MULTILINGUAL_CALIBRATION)
+ * additionally fits the hierarchical (class × language) and (class × script)
+ * tiers; OFF (default) ⇒ the per-class-only fit, byte-identical to pre-Tier-5.
+ */
+export interface FitOptions {
+  byLanguage?: boolean | undefined;
+}
+
+/** Accumulate a labeled sample into a keyed bucket map. */
+function pushPair(buckets: Map<string, CalibrationPair[]>, key: string, pair: CalibrationPair) {
+  const bucket = buckets.get(key);
+  if (bucket) bucket.push(pair);
+  else buckets.set(key, [pair]);
+}
+
+/**
  * Fit one isotonic calibration map per query-class from labeled samples,
  * mapping rawFocusConfidence → P(correct). Grouping is by `queryClass`.
  *
@@ -207,10 +285,23 @@ export function queryClassOf(laneId: LaneId | null | undefined): string {
  *     to 'default'. A missed per-class fit therefore degrades to the pooled
  *     prior, never to nothing.
  *
+ * Multilingual Tier 5 (`opts.byLanguage`): ALSO fit a (class × language) and
+ * a (class × script) map for every populated (class, language) / (class,
+ * script) bucket that clears the SAME MIN_CLASS_SAMPLES floor — so a sparse
+ * language never earns a noisy per-language calibrator and falls back up the
+ * hierarchy (`calibratedConfidence`). These extra maps are keyed with
+ * `calibrationKey`; the per-class and global maps keep their bare keys, so
+ * with the option OFF the output is byte-identical.
+ *
  * Reuses `fitIsotonic` (the PAV primitive) throughout — no new regression.
  */
-export function fitPerClass(samples: readonly FocusOutcomeSample[]): PerClassCalibration {
+export function fitPerClass(
+  samples: readonly FocusOutcomeSample[],
+  opts: FitOptions = {},
+): PerClassCalibration {
   const byClass = new Map<string, CalibrationPair[]>();
+  const byLang = new Map<string, CalibrationPair[]>();
+  const byScript = new Map<string, CalibrationPair[]>();
   const all: CalibrationPair[] = [];
   for (const s of samples) {
     const pair: CalibrationPair = {
@@ -218,27 +309,70 @@ export function fitPerClass(samples: readonly FocusOutcomeSample[]): PerClassCal
       correctness: s.correct,
     };
     all.push(pair);
-    const bucket = byClass.get(s.queryClass);
-    if (bucket) bucket.push(pair);
-    else byClass.set(s.queryClass, [pair]);
+    pushPair(byClass, s.queryClass, pair);
+    if (opts.byLanguage) {
+      if (s.language)
+        pushPair(byLang, calibrationKey({ queryClass: s.queryClass, language: s.language }), pair);
+      if (s.script)
+        pushPair(byScript, calibrationKey({ queryClass: s.queryClass, script: s.script }), pair);
+    }
   }
   const out: PerClassCalibration = { [DEFAULT_CLASS]: fitIsotonic(all) };
   for (const [cls, pairs] of byClass) {
     if (cls === DEFAULT_CLASS) continue; // the shared map already covers it
     if (pairs.length >= MIN_CLASS_SAMPLES) out[cls] = fitIsotonic(pairs);
   }
+  // Tier 5 hierarchical tiers — same min-sample floor; keys never collide
+  // with the bare per-class keys above (they carry the KEY_SEP suffix).
+  for (const [key, pairs] of byLang) {
+    if (pairs.length >= MIN_CLASS_SAMPLES) out[key] = fitIsotonic(pairs);
+  }
+  for (const [key, pairs] of byScript) {
+    if (pairs.length >= MIN_CLASS_SAMPLES) out[key] = fitIsotonic(pairs);
+  }
   return out;
 }
 
 /**
- * Apply the calibrated map for a signal's class to its raw confidence.
- * Uses the class's own map when present, else the shared 'default' map,
- * else (empty calibration) the raw value unchanged.
+ * Apply the calibrated map for a signal to its raw confidence.
+ *
+ * Per-class only (default): the class's own map when present, else the shared
+ * 'default' map, else (empty calibration) the raw value unchanged.
+ *
+ * Multilingual Tier 5 (`opts.byLanguage`): a HIERARCHICAL fallback — exact
+ * (class × language) → (class × script/family) → (class) → 'default' → raw.
+ * The first tier that has a fitted map wins, so a well-sampled language uses
+ * its own calibrator and a sparse one degrades up the ladder to the pooled
+ * prior. With the option OFF the language/script tiers are never consulted,
+ * so the lookup is byte-identical to the per-class-only path.
  */
-export function calibratedConfidence(cal: PerClassCalibration, sig: FocusSignal): number {
+export function calibratedConfidence(
+  cal: PerClassCalibration,
+  sig: FocusSignal,
+  opts: FitOptions = {},
+): number {
   const raw = rawFocusConfidence(sig);
-  const map = cal[sig.queryClass] ?? cal[DEFAULT_CLASS];
+  const map = resolveCalibrationMap(cal, sig, opts);
   return map ? applyMap(map, raw) : raw;
+}
+
+/** The map a signal resolves to under the hierarchy (or undefined). */
+function resolveCalibrationMap(
+  cal: PerClassCalibration,
+  sig: FocusSignal,
+  opts: FitOptions,
+): CalibrationMap | undefined {
+  if (opts.byLanguage) {
+    if (sig.language) {
+      const m = cal[calibrationKey({ queryClass: sig.queryClass, language: sig.language })];
+      if (m) return m;
+    }
+    if (sig.script) {
+      const m = cal[calibrationKey({ queryClass: sig.queryClass, script: sig.script })];
+      if (m) return m;
+    }
+  }
+  return cal[sig.queryClass] ?? cal[DEFAULT_CLASS];
 }
 
 /**

--- a/src/synthesize/generator-client.ts
+++ b/src/synthesize/generator-client.ts
@@ -65,6 +65,9 @@ export interface GenerateRequest {
   arcInsights?: boolean | undefined;
   model: string;
   answerLang: string | null;
+  /** Tier 5: reinforce the language directive on the corrective regeneration
+   *  after an output-language mismatch (answer-language guard). */
+  answerLangStrict?: boolean | undefined;
   neverAbstain?: boolean | undefined;
   /** ISO date the answer should treat as "today" (SYNTHESIZE_DATE_CONTEXT). */
   dateContext?: string | undefined;

--- a/src/synthesize/generator-prompt.ts
+++ b/src/synthesize/generator-prompt.ts
@@ -28,6 +28,7 @@ export function buildGeneratorUserMessage({
   dateArbitratedConflicts,
   arcInsights,
   answerLang,
+  answerLangStrict,
   dateContext,
   lane,
   instructions,
@@ -76,6 +77,13 @@ export function buildGeneratorUserMessage({
    */
   arcInsights?: boolean | undefined;
   answerLang: string | null;
+  /**
+   * Tier 5 answer-language guard: reinforce the language directive on the ONE
+   * corrective regeneration after an output-language mismatch. Off/undefined =
+   * the normal directive, byte-identical. Only meaningful when answerLang is
+   * set (a forced target).
+   */
+  answerLangStrict?: boolean | undefined;
   dateContext?: string | undefined;
   /** T1 typed dispatch: lane-specific answer instruction. */
   lane?: LaneId | null | undefined;
@@ -110,7 +118,9 @@ export function buildGeneratorUserMessage({
   strategyNotes?: string[] | undefined;
 }): string {
   const langInstruction = answerLang
-    ? `\n\nLanguage policy: write your answer in ${answerLang} (ISO 639-1). Keep citation spans in their original language.`
+    ? answerLangStrict
+      ? `\n\nLanguage policy (STRICT): You MUST write the ENTIRE answer in ${answerLang} (ISO 639-1) and in NO other language — a previous attempt answered in the wrong language. Translate all prose into ${answerLang}; keep only citation spans and proper nouns in their original language.`
+      : `\n\nLanguage policy: write your answer in ${answerLang} (ISO 639-1). Keep citation spans in their original language.`
     : '';
   const dateInstruction = dateContext
     ? `Today: ${dateContext}. Facts carry date stamps like (as of YYYY-MM-DD). Resolve relative time expressions ("last week", "next month") against the stamp of the fact that states them, and answer "when" questions with a specific date or period, using simple date arithmetic when needed.\n` +

--- a/src/synthesize/synthesize.helpers.ts
+++ b/src/synthesize/synthesize.helpers.ts
@@ -1,5 +1,5 @@
 import type { SearchHit } from '../search/search.service';
-import { detectLanguage } from '../ai/locale/language-detector';
+import { detectLanguage, type ScriptCode } from '../ai/locale/language-detector';
 import type { LaneId, RetrievalProfile } from '../search/retrieval-profile';
 import { routeLane, detectEvidenceConflicts } from './answer-router';
 import type { MultilingualLaneClassifierService } from './multilingual-lane-classifier.service';
@@ -11,6 +11,8 @@ import type { Citation } from './fact-index';
 import type { GeneratorOutput, SynthesizeResult } from './synthesize.types';
 import { buildDateMathLines } from './date-math';
 import { detectAnswerShape, shapeInstructionFor } from './answer-shape';
+import { resolvePromptFrames } from './evidence-gates';
+import type { GenerateRequest } from './generator-client';
 import type { MetricsService } from '../metrics/metrics.service';
 
 /**
@@ -41,7 +43,7 @@ export async function resolveRoutedLane(
  * Evidence-conflict detection, threaded with the Tier 4 typed-compare flag
  * (MULTILINGUAL_CONFLICT). Off ⇒ byte-identical surface-string comparison.
  */
-export function evidenceConflicts(
+function evidenceConflicts(
   results: SearchHit[],
   profile: RetrievalProfile,
 ): Array<{ factIds: string[]; label: string }> {
@@ -120,9 +122,73 @@ export function buildSecondaryDto(
   } as SearchDto;
 }
 
+/**
+ * Assemble the generator-client request from the query-invariant context
+ * (profile/lane/model/answerLang/collected sections) plus the per-round
+ * evidence (`o`). ONE builder for round-1, the refine round, and the Tier 5
+ * answer-language retry, so those calls cannot drift; the only per-round
+ * differences are the evidence lines, the conflict set (derived from
+ * `o.results`), and the two optional switches (`allowRefine`, `answerLangStrict`).
+ * Pure — no `this`, no IO; field VALUES match the historical inline calls
+ * (order is irrelevant, the client destructures by name) so the assembled
+ * prompt is byte-identical.
+ */
+export function buildGeneratorArgs(
+  ctx: {
+    dto: SynthesizeDto;
+    profile: RetrievalProfile;
+    lane: LaneId | null;
+    model: string;
+    answerLang: string | null;
+    guardrails: SynthesisGuardrails;
+    shapeInstruction?: string | undefined;
+    collected: {
+      transcriptLines: string[];
+      insightLines: string[];
+      instructions?: string[] | undefined;
+      timelineEvidence: boolean;
+      strategyNotes?: string[] | undefined;
+    };
+  },
+  o: {
+    results: SearchHit[];
+    promptFactLines: string[];
+    dateMathLines?: string[] | undefined;
+    allowRefine?: boolean | undefined;
+    answerLangStrict?: boolean | undefined;
+  },
+): Omit<GenerateRequest, 'openai' | 'metrics' | 'logger'> {
+  const { profile, dto, collected } = ctx;
+  return {
+    query: dto.query,
+    factLines: o.promptFactLines,
+    transcriptLines: collected.transcriptLines,
+    insightLines: collected.insightLines,
+    timelineEvidence: collected.timelineEvidence,
+    // V10 frame switches — resolved once by the kernel, not inline.
+    ...resolvePromptFrames(profile, collected.timelineEvidence),
+    model: ctx.model,
+    answerLang: ctx.answerLang,
+    neverAbstain: ctx.guardrails === 'answer',
+    // Date context anchors "today"; the temporal lane forces it from asOf.
+    dateContext: resolveLaneDateContext(profile, ctx.lane, dto.asOf),
+    lane: ctx.lane,
+    enumStrict: profile.enumStrict,
+    instructions: collected.instructions,
+    // T3: evidence-conditional conflict pairs (from THIS round's results).
+    conflicts: evidenceConflicts(o.results, profile),
+    dateMathLines: o.dateMathLines,
+    shapeInstruction: ctx.shapeInstruction,
+    // G4 strategy lane: advisory notes, GENERATOR-ONLY (parity exception).
+    strategyNotes: collected.strategyNotes,
+    ...(o.allowRefine !== undefined ? { allowRefine: o.allowRefine } : {}),
+    ...(o.answerLangStrict ? { answerLangStrict: true } : {}),
+  };
+}
+
 /** Temporal lane forces the Today anchor from asOf; others follow the
  *  profile's dateAnchoring. */
-export function resolveLaneDateContext(
+function resolveLaneDateContext(
   profile: RetrievalProfile,
   lane: LaneId | null,
   asOf: string | undefined,
@@ -221,16 +287,134 @@ export function attachDecisionLog(
 }
 
 /**
- * Detect the answer language: explicit DTO value wins, else the pure
- * detector on the query; `null` when the detector is undecided so the
- * caller can omit the language instruction from the prompt entirely
- * (the generator's own multilingual default is correct enough for
- * the `und` case).
+ * Confidence floor for treating a detected language as the answer target
+ * (Tier 5 answer-language guard). The Tier 1 detector reports `confidence`
+ * ∈ [0,1] — the dominant-script fraction (non-Latin) or the stopword
+ * fraction (Latin). Below this floor the query language is too weakly
+ * signalled to force, so the guard declines to `no forced language` (the
+ * generator's own multilingual default). Also the floor below which a
+ * DETECTED ANSWER language is not trusted enough to call a mismatch.
  */
-export function resolveAnswerLang(dto: SynthesizeDto): string | null {
+const ANSWER_LANG_MIN_CONFIDENCE = 0.3;
+
+/** Normalise a locale hint to a bare ISO 639-1 code, or null if unusable. */
+function normalizeLangCode(x: string | undefined): string | null {
+  if (!x) return null;
+  const code = x.trim().toLowerCase().slice(0, 2);
+  return /^[a-z]{2}$/.test(code) ? code : null;
+}
+
+/**
+ * Detect the answer language.
+ *
+ * Default (guard off / no profile) — BYTE-IDENTICAL to the historical
+ * behaviour: explicit DTO value wins, else the pure detector on the query;
+ * `null` when the detector is undecided (`und`) so the caller omits the
+ * language instruction and the generator's own multilingual default applies.
+ *
+ * Tier 5 (profile.answerLangGuard, MULTILINGUAL_ANSWER_GUARD) — a strict
+ * fallback ORDER so the retrieved FACTS never decide the answer language:
+ *   1. explicit `answerLang`,
+ *   2. the user/session locale (dto.queryLang),
+ *   3. a CONFIDENTLY-detected query language (Tier 1 confidence ≥ floor),
+ *   4. `null` — no forced language.
+ */
+export function resolveAnswerLang(
+  dto: SynthesizeDto,
+  profile?: { answerLangGuard?: boolean } | undefined,
+): string | null {
   if (dto.answerLang) return dto.answerLang;
+  if (profile?.answerLangGuard) {
+    const locale = normalizeLangCode(dto.queryLang);
+    if (locale) return locale;
+    const r = detectLanguage(dto.query);
+    return r.language !== 'und' && r.confidence >= ANSWER_LANG_MIN_CONFIDENCE ? r.language : null;
+  }
   const r = detectLanguage(dto.query);
   return r.language === 'und' ? null : r.language;
+}
+
+/** Canonical ISO 15924 script for an ISO 639-1 target language. Non-Latin
+ *  targets each map to their one script by the Tier 1 detector's convention;
+ *  everything else is Latin. */
+function scriptForLang(lang: string): ScriptCode {
+  switch (lang.slice(0, 2).toLowerCase()) {
+    case 'ru':
+      return 'Cyrl';
+    case 'zh':
+      return 'Hani';
+    case 'ja':
+      return 'Hira';
+    case 'ko':
+      return 'Hang';
+    case 'ar':
+      return 'Arab';
+    case 'hi':
+      return 'Deva';
+    default:
+      return 'Latn';
+  }
+}
+
+/**
+ * Whether a generated `answer` is in the wrong language for `targetLang`
+ * (Tier 5 output-language check). Deliberately CROSS-SCRIPT only: a Latin
+ * answer to a Cyrillic/CJK/Arabic/Devanagari target (and vice-versa) is the
+ * high-precision, high-value failure the detector catches reliably. Within-
+ * script disambiguation (e.g. Spanish vs English) is NOT adjudicated — short-
+ * answer Latin stopword scoring is too noisy (see language-detector.ts), and
+ * a false mismatch would waste a corrective LLM call. Undetermined (`und`) or
+ * low-confidence detections are never a mismatch, so proper-noun-only / numeric
+ * answers ("Paris", "42") in any target are left alone.
+ */
+export function answerLanguageMismatch(
+  answer: string,
+  targetLang: string,
+  minConfidence: number = ANSWER_LANG_MIN_CONFIDENCE,
+): boolean {
+  if (!answer.trim()) return false;
+  // Attribution OFF: a deterministic label independent of
+  // MULTILINGUAL_LANG_ATTRIBUTION — this check is about the SCRIPT.
+  const det = detectLanguage(answer, false);
+  if (det.language === 'und' || det.script === 'Zyyy') return false;
+  if (det.confidence < minConfidence) return false;
+  return det.script !== scriptForLang(targetLang);
+}
+
+/**
+ * Tier 5 output-language guard (the decision + bounded retry, side of the
+ * generator call the orchestrator owns via `regenerate`). Returns the
+ * CORRECTED answer when a cross-script mismatch was found and a regeneration
+ * ran, or `null` when nothing should change (guard off / no forced target /
+ * no mismatch / retry threw) — the caller then keeps the original. Bounded to
+ * ONE retry: a still-mismatched retry is flagged (metrics + log) and returned
+ * best-effort. Pure control-flow — the LLM call is injected.
+ */
+export async function enforceAnswerLanguage(
+  deps: { metrics?: MetricsService | undefined; logger: { warn(message: string): void } },
+  ctx: { guard: boolean; target: string | null; answer: string | null | undefined },
+  regenerate: () => Promise<GeneratorOutput>,
+): Promise<GeneratorOutput | null> {
+  const { guard, target, answer } = ctx;
+  if (!guard || !target || !answer || !answerLanguageMismatch(answer, target)) return null;
+  deps.metrics?.countSynthesize('answer_lang_retry');
+  try {
+    const retry = await regenerate();
+    if (answerLanguageMismatch(retry.answer, target)) {
+      // Bounded: one retry, then flag — the retry (reinforced directive) is the
+      // best-effort attempt, so it is still returned.
+      deps.metrics?.countSynthesize('answer_lang_unresolved');
+      deps.logger.warn(
+        `answer-language guard: answer still not in target '${target}' after one retry`,
+      );
+    }
+    return retry;
+  } catch (err) {
+    deps.logger.warn(
+      `answer-language retry failed (${(err as Error).message}); keeping the original answer`,
+    );
+    return null;
+  }
 }
 
 /**

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -16,17 +16,17 @@ import { coverageAbstention, finalizeVerdict, unverifiedReturn } from './verdict
 import type { AbstainAdaptiveGate } from './verdict';
 import {
   attachDecisionLog,
+  buildGeneratorArgs,
   buildSecondaryDto,
-  evidenceConflicts,
+  enforceAnswerLanguage,
   resolveAnswerFrames,
   resolveAnswerLang,
   resolveCitations,
-  resolveLaneDateContext,
   resolveRoutedLane,
   serveCacheHit,
   verifierErrorResult,
 } from './synthesize.helpers';
-import { resolvePromptFrames, wantsTimelineEvidence } from './evidence-gates';
+import { wantsTimelineEvidence } from './evidence-gates';
 import { applyEvidenceUnion } from './evidence-union';
 import { laneProbeDto, type LaneId } from './answer-router';
 import { getActiveRetrievalProfile, type RetrievalProfile } from '../search/retrieval-profile';
@@ -267,12 +267,11 @@ export class SynthesizeService {
     let { results, factIndex } = prepared;
 
     // V9 §4 coverage abstention + Optics §4.2 pre-answer capture/gate (seam).
-    const abstained = await this.maybeCoverageAbstain(companyId, lane, {
-      profile,
-      guardrails,
-      results,
-      explain,
-    });
+    const abstained = await this.maybeCoverageAbstain(
+      companyId,
+      { lane, query: dto.query },
+      { profile, guardrails, results, explain },
+    );
     if (abstained) return abstained;
 
     // Every non-fact prompt section — transcript quotes, insights,
@@ -318,15 +317,11 @@ export class SynthesizeService {
     const shapeInstruction = frames.shapeInstruction;
     let dateMathLines = frames.dateMathLines;
 
-    // Phase 4.C — resolve the answer language. Explicit DTO wins;
-    // otherwise we detect from the query (so a Russian question gets
-    // a Russian answer by default without the caller having to opt in).
-    const answerLang = resolveAnswerLang(dto);
+    // Phase 4.C answer language; Tier 5 (profile.answerLangGuard) applies the
+    // strict fallback order so the facts never decide it (off ⇒ byte-identical).
+    const answerLang = resolveAnswerLang(dto, profile);
 
-    onProgress({
-      stage: 'generate',
-      message: `LLM grounding answer over ${factIndex.size} facts`,
-    });
+    onProgress({ stage: 'generate', message: `LLM grounding answer over ${factIndex.size} facts` });
     // Generation + the V13 constrained refine round, one seam: a
     // 'failed' result is the generator_error early-return; otherwise
     // the tuple is whichever round answered last.
@@ -446,7 +441,12 @@ export class SynthesizeService {
     }
 
     // Optics-1 focus capture — SERVING-NEUTRAL guarded no-op (see method).
-    await this.maybeCaptureFocusSignal(companyId, { results, verdict: verdict.verdict, lane });
+    // `dto.query` carries the Tier 5 language key onto the verdict sample.
+    await this.maybeCaptureFocusSignal(
+      companyId,
+      { results, verdict: verdict.verdict, lane },
+      dto.query,
+    );
 
     // G2 L3 escalation — the pre-abstention seam. On a verifier-fail with
     // an anchoring session it escalates ONCE to full-raw-session context
@@ -496,9 +496,10 @@ export class SynthesizeService {
   private async maybeCaptureFocusSignal(
     companyId: string,
     signal: { results: SearchHit[]; verdict: FocusVerdict; lane: LaneId | null },
+    query: string,
   ): Promise<void> {
     if (!this.focusSignal || !FocusSignalService.captureEnabled()) return;
-    await this.focusSignal.maybeCapture(companyId, signal);
+    await this.focusSignal.maybeCapture(companyId, { ...signal, query });
   }
 
   /**
@@ -727,49 +728,22 @@ export class SynthesizeService {
         refined: boolean;
       }
   > {
-    const { profile, dto, collected } = args;
+    const { profile } = args;
     let generated: GeneratorOutput;
     try {
       generated = await withSpan(
         'synthesize.generate',
         () =>
           this.limiter.run(() =>
-            this.callGenerator({
-              query: dto.query,
-              factLines: args.promptFactLines,
-              transcriptLines: collected.transcriptLines,
-              insightLines: collected.insightLines,
-              timelineEvidence: collected.timelineEvidence,
-              // V10 frame switches — resolved once by the kernel
-              // (evidence-gates.resolvePromptFrames), not inline.
-              ...resolvePromptFrames(profile, collected.timelineEvidence),
-              model: args.model,
-              answerLang: args.answerLang,
-              neverAbstain: args.guardrails === 'answer',
-              // Date context (SYNTHESIZE_DATE_CONTEXT): anchor "today"
-              // for the generator so relative/when questions resolve
-              // against the facts' date stamps instead of guessing.
-              // The temporal lane FORCES the anchor from asOf even when
-              // the profile disables anchoring — elapsed annotations are
-              // meaningless without a stated "today".
-              dateContext: resolveLaneDateContext(profile, args.lane, dto.asOf),
-              lane: args.lane,
-              // §8 item 3: enumeration scope discipline.
-              enumStrict: profile.enumStrict,
-              // T7: standing instructions in their own section.
-              instructions: collected.instructions,
-              // T3: evidence-conditional — fires on write-side COMPETING
-              // facts regardless of what the question looks like.
-              conflicts: evidenceConflicts(args.results, profile),
-              dateMathLines: args.dateMathLines,
-              shapeInstruction: args.shapeInstruction,
-              // G4 strategy lane: advisory notes, GENERATOR-ONLY — the
-              // documented exception to the W5 #22 evidence-parity
-              // invariant (advice, not evidence; see verifier.ts).
-              strategyNotes: collected.strategyNotes,
-              // V13 search loop: round 1 exposes the refine affordance.
-              allowRefine: profile.searchLoop,
-            }),
+            this.callGenerator(
+              // Round 1 exposes the V13 refine affordance (allowRefine).
+              buildGeneratorArgs(args, {
+                results: args.results,
+                promptFactLines: args.promptFactLines,
+                dateMathLines: args.dateMathLines,
+                allowRefine: profile.searchLoop,
+              }),
+            ),
           ),
         { 'synthesize.facts': args.factIndex.size },
       );
@@ -789,7 +763,7 @@ export class SynthesizeService {
       };
     }
     const second = await this.refineRound({ ...args, generated });
-    return second
+    const round = second
       ? { ...second, refined: true }
       : {
           results: args.results,
@@ -799,6 +773,26 @@ export class SynthesizeService {
           generated,
           refined: false,
         };
+    // Tier 5 answer-language guard — no-op unless on AND the final answer's
+    // language mismatches; then the corrected regeneration replaces `generated`.
+    const corrected = await enforceAnswerLanguage(
+      { metrics: this.metrics, logger: this.logger },
+      { guard: profile.answerLangGuard, target: args.answerLang, answer: round.generated.answer },
+      () =>
+        withSpan('synthesize.generate_lang_retry', () =>
+          this.limiter.run(() =>
+            this.callGenerator(
+              buildGeneratorArgs(args, {
+                results: round.results,
+                promptFactLines: round.promptFactLines,
+                dateMathLines: round.dateMathLines,
+                answerLangStrict: true,
+              }),
+            ),
+          ),
+        ),
+    );
+    return corrected ? { ...round, generated: corrected } : round;
   }
 
   /**
@@ -842,7 +836,7 @@ export class SynthesizeService {
     dateMathLines?: string[] | undefined;
     generated: GeneratorOutput;
   } | null> {
-    const { profile, dto, collected } = args;
+    const { profile, dto } = args;
     const refineQuery = args.generated.refineQuery?.trim();
     if (!profile.searchLoop || !refineQuery || refineQuery === dto.query) return null;
     try {
@@ -866,25 +860,10 @@ export class SynthesizeService {
       const dateMathLines = profile.dateMath ? buildDateMathLines(prepared.results) : undefined;
       const generated = await withSpan('synthesize.generate_refined', () =>
         this.limiter.run(() =>
-          this.callGenerator({
-            query: dto.query,
-            factLines: promptFactLines,
-            transcriptLines: collected.transcriptLines,
-            insightLines: collected.insightLines,
-            timelineEvidence: collected.timelineEvidence,
-            ...resolvePromptFrames(profile, collected.timelineEvidence),
-            model: args.model,
-            answerLang: args.answerLang,
-            neverAbstain: args.guardrails === 'answer',
-            dateContext: resolveLaneDateContext(profile, args.lane, dto.asOf),
-            lane: args.lane,
-            enumStrict: profile.enumStrict,
-            instructions: collected.instructions,
-            conflicts: evidenceConflicts(prepared.results, profile),
-            dateMathLines,
-            shapeInstruction: args.shapeInstruction,
-            strategyNotes: collected.strategyNotes,
-          }),
+          // The round-2 call omits allowRefine — the one-round cap is structural.
+          this.callGenerator(
+            buildGeneratorArgs(args, { results: prepared.results, promptFactLines, dateMathLines }),
+          ),
         ),
       );
       this.metrics?.countSynthesize('search_loop_refined');
@@ -931,9 +910,10 @@ export class SynthesizeService {
    */
   private async maybeCoverageAbstain(
     companyId: string,
-    lane: LaneId | null,
+    ctx: { lane: LaneId | null; query: string },
     args: Parameters<typeof coverageAbstention>[1],
   ): Promise<SynthesizeResult | null> {
+    const { lane, query } = ctx;
     const { profile, guardrails, results } = args;
     // The pre-answer focus capture + the adaptive gate BOTH apply only in the
     // regime where coverage-abstention actually runs (coverage mode, strict/
@@ -945,9 +925,10 @@ export class SynthesizeService {
       profile.abstentionCalibration === 'coverage' &&
       (guardrails === 'strict' || guardrails === 'lenient');
     if (coverageRegime && this.focusSignal && FocusSignalService.captureEnabled()) {
+      // `query` threads the Tier 5 language key into the pre-answer sample.
       await this.focusSignal.maybeCapture(
         companyId,
-        { results, verdict: 'none', lane },
+        { results, verdict: 'none', lane, query },
         'preanswer',
       );
     }

--- a/test/answer-lang-guard.unit-spec.ts
+++ b/test/answer-lang-guard.unit-spec.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit spec — multilingual Tier 5 answer-language guard (pure helpers).
+ *
+ * Covers the two pure pieces of the guard:
+ *   - resolveAnswerLang: the OFF path is byte-identical to the historical
+ *     explicit→detect→null behaviour; the ON path follows the strict fallback
+ *     ORDER explicit → session locale → confidently-detected query language →
+ *     no forced language (so the FACTS never decide the answer language).
+ *   - answerLanguageMismatch: the output-language check — cross-script only,
+ *     confidence-gated, und/proper-noun/numeric-safe.
+ *
+ * The service-level ONE-shot corrective regeneration is an integration
+ * concern (it re-calls the LLM) and is exercised end-to-end elsewhere; the
+ * OFF-path no-op is guaranteed here structurally — answerLanguageMismatch is
+ * only ever consulted when profile.answerLangGuard is on.
+ */
+import {
+  answerLanguageMismatch,
+  enforceAnswerLanguage,
+  resolveAnswerLang,
+} from '../src/synthesize/synthesize.helpers';
+import type { SynthesizeDto } from '../src/synthesize/dto/synthesize.dto';
+import type { GeneratorOutput } from '../src/synthesize/synthesize.types';
+
+const dto = (fields: Partial<SynthesizeDto> & { query: string }): SynthesizeDto =>
+  fields as SynthesizeDto;
+
+const RU = 'Привет, как у тебя дела сегодня вечером';
+const EN = 'the user lives in paris and works as an engineer at the company';
+// A Latin query with a single stopword hit ⇒ detected en at confidence 0.2
+// (< the 0.3 floor), independent of MULTILINGUAL_LANG_ATTRIBUTION (bestScore
+// is > 0, so attribution never forces `und`).
+const LOW_CONF_LATIN = 'zzz the qqq www eee';
+
+describe('resolveAnswerLang — OFF (byte-identical historical behaviour)', () => {
+  it('explicit answerLang always wins', () => {
+    expect(resolveAnswerLang(dto({ query: RU, answerLang: 'de' }))).toBe('de');
+  });
+
+  it('detects the query language when no explicit value', () => {
+    expect(resolveAnswerLang(dto({ query: RU }))).toBe('ru');
+  });
+
+  it('returns null when the detector is undecided (und)', () => {
+    expect(resolveAnswerLang(dto({ query: '42 42 42' }))).toBeNull();
+  });
+
+  it('returns a LOW-confidence detection unchanged (no confidence gate off)', () => {
+    // The whole point of contrast with the guard: off, any non-und wins.
+    expect(resolveAnswerLang(dto({ query: LOW_CONF_LATIN }))).toBe('en');
+  });
+
+  it('ignores a session locale when the guard is off', () => {
+    expect(resolveAnswerLang(dto({ query: RU, queryLang: 'en' }))).toBe('ru');
+  });
+});
+
+describe('resolveAnswerLang — ON (Tier 5 fallback ordering)', () => {
+  // The guard flag lives on the resolved RetrievalProfile; the session locale
+  // is dto.queryLang.
+  const on = { answerLangGuard: true };
+
+  it('1) explicit answerLang wins over everything', () => {
+    expect(resolveAnswerLang(dto({ query: RU, answerLang: 'de', queryLang: 'fr' }), on)).toBe('de');
+  });
+
+  it('2) session locale (dto.queryLang) beats a confident query detection', () => {
+    expect(resolveAnswerLang(dto({ query: RU, queryLang: 'en' }), on)).toBe('en');
+  });
+
+  it('2) session locale is normalised (case + region tag stripped)', () => {
+    expect(resolveAnswerLang(dto({ query: RU, queryLang: 'EN-US' }), on)).toBe('en');
+    expect(resolveAnswerLang(dto({ query: RU, queryLang: 'pt_BR' }), on)).toBe('pt');
+  });
+
+  it('2) an unusable session locale falls through to detection', () => {
+    expect(resolveAnswerLang(dto({ query: RU, queryLang: '123' }), on)).toBe('ru');
+    expect(resolveAnswerLang(dto({ query: RU, queryLang: '' }), on)).toBe('ru');
+  });
+
+  it('3) a CONFIDENT query detection is used when no explicit / no locale', () => {
+    expect(resolveAnswerLang(dto({ query: RU }), on)).toBe('ru');
+  });
+
+  it('4) a LOW-confidence detection forces NO language (null)', () => {
+    expect(resolveAnswerLang(dto({ query: LOW_CONF_LATIN }), on)).toBeNull();
+  });
+
+  it('4) an undecided query forces no language (null)', () => {
+    expect(resolveAnswerLang(dto({ query: '42 42 42' }), on)).toBeNull();
+  });
+});
+
+describe('answerLanguageMismatch — output-language check (cross-script)', () => {
+  it('flags a Latin answer against a Cyrillic target', () => {
+    expect(answerLanguageMismatch(EN, 'ru')).toBe(true);
+  });
+
+  it('flags a Cyrillic answer against a Latin target', () => {
+    expect(answerLanguageMismatch(RU, 'en')).toBe(true);
+  });
+
+  it('does NOT flag a matching-script answer', () => {
+    expect(answerLanguageMismatch(RU, 'ru')).toBe(false);
+    expect(answerLanguageMismatch(EN, 'en')).toBe(false);
+  });
+
+  it('does NOT adjudicate within-script (es answer vs en target)', () => {
+    const ES = 'el usuario vive en la ciudad de madrid con su familia y su perro';
+    expect(answerLanguageMismatch(ES, 'en')).toBe(false);
+  });
+
+  it('is safe on proper-noun / numeric / empty answers (und or low-confidence)', () => {
+    expect(answerLanguageMismatch('Paris', 'ru')).toBe(false);
+    expect(answerLanguageMismatch('42', 'ru')).toBe(false);
+    expect(answerLanguageMismatch('', 'ru')).toBe(false);
+    expect(answerLanguageMismatch('   ', 'ru')).toBe(false);
+  });
+
+  it('maps region-tagged / cased targets to their canonical script', () => {
+    expect(answerLanguageMismatch(EN, 'RU-ru')).toBe(true);
+    expect(answerLanguageMismatch(RU, 'EN')).toBe(true);
+  });
+
+  it('respects the confidence floor', () => {
+    // A single-stopword Latin string is below the default floor ⇒ not a
+    // mismatch even against a Cyrillic target; forcing the floor to 0 makes
+    // it one.
+    expect(answerLanguageMismatch(LOW_CONF_LATIN, 'ru')).toBe(false);
+    expect(answerLanguageMismatch(LOW_CONF_LATIN, 'ru', 0)).toBe(true);
+  });
+});
+
+describe('enforceAnswerLanguage — bounded corrective retry', () => {
+  const gen = (answer: string): GeneratorOutput => ({ answer, citedFactIds: [] });
+  const makeDeps = () => {
+    const countSynthesize = jest.fn();
+    const warn = jest.fn();
+    return {
+      deps: { metrics: { countSynthesize } as never, logger: { warn } },
+      countSynthesize,
+      warn,
+    };
+  };
+
+  it('OFF (guard false) is a no-op — never regenerates, returns null', async () => {
+    const { deps, countSynthesize } = makeDeps();
+    const regenerate = jest.fn(async () => gen(RU));
+    const out = await enforceAnswerLanguage(
+      deps,
+      { guard: false, target: 'ru', answer: EN },
+      regenerate,
+    );
+    expect(out).toBeNull();
+    expect(regenerate).not.toHaveBeenCalled();
+    expect(countSynthesize).not.toHaveBeenCalled();
+  });
+
+  it('no forced target ⇒ no-op', async () => {
+    const { deps } = makeDeps();
+    const regenerate = jest.fn(async () => gen(RU));
+    expect(
+      await enforceAnswerLanguage(deps, { guard: true, target: null, answer: EN }, regenerate),
+    ).toBeNull();
+    expect(regenerate).not.toHaveBeenCalled();
+  });
+
+  it('a matching-language answer ⇒ no-op (no retry)', async () => {
+    const { deps, countSynthesize } = makeDeps();
+    const regenerate = jest.fn(async () => gen(RU));
+    expect(
+      await enforceAnswerLanguage(deps, { guard: true, target: 'ru', answer: RU }, regenerate),
+    ).toBeNull();
+    expect(regenerate).not.toHaveBeenCalled();
+    expect(countSynthesize).not.toHaveBeenCalled();
+  });
+
+  it('a mismatch regenerates ONCE and returns the corrected answer', async () => {
+    const { deps, countSynthesize, warn } = makeDeps();
+    const corrected = gen(RU);
+    const regenerate = jest.fn(async () => corrected);
+    const out = await enforceAnswerLanguage(
+      deps,
+      { guard: true, target: 'ru', answer: EN },
+      regenerate,
+    );
+    expect(out).toBe(corrected);
+    expect(regenerate).toHaveBeenCalledTimes(1);
+    expect(countSynthesize).toHaveBeenCalledWith('answer_lang_retry');
+    expect(countSynthesize).not.toHaveBeenCalledWith('answer_lang_unresolved');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('a STILL-wrong retry is flagged and returned best-effort (bounded: one retry)', async () => {
+    const { deps, countSynthesize, warn } = makeDeps();
+    const stillWrong = gen(EN);
+    const regenerate = jest.fn(async () => stillWrong);
+    const out = await enforceAnswerLanguage(
+      deps,
+      { guard: true, target: 'ru', answer: EN },
+      regenerate,
+    );
+    expect(out).toBe(stillWrong);
+    expect(regenerate).toHaveBeenCalledTimes(1); // never twice
+    expect(countSynthesize).toHaveBeenCalledWith('answer_lang_retry');
+    expect(countSynthesize).toHaveBeenCalledWith('answer_lang_unresolved');
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('a regeneration failure keeps the original (returns null) and logs', async () => {
+    const { deps, warn } = makeDeps();
+    const regenerate = jest.fn(async () => {
+      throw new Error('boom');
+    });
+    const out = await enforceAnswerLanguage(
+      deps,
+      { guard: true, target: 'ru', answer: EN },
+      regenerate,
+    );
+    expect(out).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/engine-gates.unit-spec.ts
+++ b/test/engine-gates.unit-spec.ts
@@ -157,6 +157,11 @@ describe('S5.5 — dead exports in the engine dirs', () => {
     // focus-signal unit spec; no serving consumer yet (Optics-2/3).
     'MIN_CLASS_SAMPLES',
     'DEFAULT_CLASS',
+    // Multilingual Tier 5 — the pure cross-script output-language check.
+    // Consumed inside synthesize.helpers (enforceAnswerLanguage) but pinned
+    // DIRECTLY by the answer-lang-guard unit spec for its precision cases
+    // (within-script not adjudicated, proper-noun/numeric-safe, floor).
+    'answerLanguageMismatch',
   ]);
   const TESTS = walk(join(ROOT, 'test'))
     .map((f) => readFileSync(f, 'utf8'))

--- a/test/focus-signal.e2e-spec.ts
+++ b/test/focus-signal.e2e-spec.ts
@@ -184,4 +184,75 @@ describe('Fovea Optics-1 — focus-signal capture + calibration surface', () => 
     expect(res.status).toBe(201);
     expect(res.body.updated).toBe(1);
   });
+
+  // Multilingual Tier 5 (migration 0103): prove the language/script columns
+  // round-trip on a real SurrealDB — the part unit tests can't cover (the
+  // `language IS NONE` predicate, the conditional CONTENT, the composite-key
+  // load). Off (default flag) the calibration is the global per-class one;
+  // ON, the fit persists (class × language) / (class × script) rows and the
+  // 0103 columns read back with the values written.
+  it('rounds-trips the 0103 language/script columns through fit + persist', async () => {
+    process.env.FOVEA_FOCUS_CAPTURE = '1';
+    process.env.MULTILINGUAL_CALIBRATION = '1';
+    try {
+      // Seed a well-sampled (class=default × ru/Cyrl) cell — enough to clear
+      // the per-language min-sample floor (MIN_CLASS_SAMPLES = 30).
+      await surreal.withCompany(f.companyId, async (db) => {
+        for (let i = 0; i < 34; i++) {
+          const x = (i + 0.5) / 34;
+          await db.query(
+            `CREATE focus_signal_sample CONTENT {
+                companyId: $c, sampleId: $s, queryClass: 'default',
+                stage: 'verdict', topScore: $x, coverageScore: $x, retrievalGap: $x,
+                verifierVerdict: 'none', rawConfidence: $r, correct: $correct,
+                language: 'ru', script: 'Cyrl'
+             }`,
+            { c: f.companyId, s: randomUUID(), x, r: 0.65 * x, correct: x > 0.5 ? 1 : 0 },
+          );
+        }
+      });
+
+      const fit = await f.http.post('/v1/admin/focus/fit').set(auth()).send({});
+      expect(fit.status).toBe(201);
+
+      // The persisted rows carry the 0103 columns: a (class × language) row
+      // (language='ru', script NONE) and a (class × script) row (script='Cyrl',
+      // language NONE), alongside the bare global-per-class rows.
+      const cal = await surreal.withCompany(f.companyId, async (db) => {
+        const [rows] = await db.query<
+          [
+            Array<{
+              queryClass: string;
+              language: string | null;
+              script: string | null;
+              thresholds: number[];
+              values: number[];
+            }>,
+          ]
+        >('SELECT queryClass, language, script, thresholds, values FROM focus_calibration');
+        return rows ?? [];
+      });
+      const langRow = cal.find((r) => r.language === 'ru');
+      expect(langRow).toBeDefined();
+      expect(langRow!.script == null).toBe(true);
+      expect(Array.isArray(langRow!.thresholds)).toBe(true);
+      expect(langRow!.thresholds.length).toBe(langRow!.values.length);
+
+      const scriptRow = cal.find((r) => r.script === 'Cyrl');
+      expect(scriptRow).toBeDefined();
+      expect(scriptRow!.language == null).toBe(true);
+
+      // `language IS NONE AND script IS NONE` still selects the global rows —
+      // the off-path (byte-identical) read.
+      const globalRows = await surreal.withCompany(f.companyId, async (db) => {
+        const [rows] = await db.query<[Array<{ queryClass: string }>]>(
+          'SELECT queryClass FROM focus_calibration WHERE language IS NONE AND script IS NONE',
+        );
+        return rows ?? [];
+      });
+      expect(globalRows.some((r) => r.queryClass === 'default')).toBe(true);
+    } finally {
+      delete process.env.MULTILINGUAL_CALIBRATION;
+    }
+  });
 });

--- a/test/focus-signal.unit-spec.ts
+++ b/test/focus-signal.unit-spec.ts
@@ -10,10 +10,12 @@ import { applyMap } from '../src/ai/calibration/isotonic';
 import {
   buildFocusSignal,
   calibratedConfidence,
+  calibrationKey,
   computeReliability,
   DEFAULT_CLASS,
   fitPerClass,
   MIN_CLASS_SAMPLES,
+  parseCalibrationKey,
   queryClassOf,
   rawFocusConfidence,
   type FocusOutcomeSample,
@@ -186,6 +188,160 @@ describe('fitPerClass + calibratedConfidence', () => {
     const c = calibratedConfidence(cal, temporalSig);
     expect(c).toBeGreaterThanOrEqual(0);
     expect(c).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('hierarchical per-language calibration (Tier 5)', () => {
+  /** Labeled samples for a (class, language, script) cell whose raw→correct
+   *  shape is deliberately DIFFERENT per language so a per-language map is
+   *  distinguishable from the pooled one. `flip` inverts the correctness so
+   *  the ru cell calibrates to the OPPOSITE of the en cell. */
+  function langSamples(
+    queryClass: string,
+    language: string,
+    script: string,
+    n: number,
+    flip = false,
+  ): FocusOutcomeSample[] {
+    const out: FocusOutcomeSample[] = [];
+    for (let i = 0; i < n; i++) {
+      const p = (i + 0.5) / n;
+      const correct = (flip ? p < 0.5 : p > 0.5) ? 1 : 0;
+      out.push({ ...signalWithRaw(p, queryClass), language, script, correct });
+    }
+    return out;
+  }
+
+  it('round-trips a calibration key through encode/decode', () => {
+    expect(parseCalibrationKey(calibrationKey({ queryClass: 'temporal' }))).toEqual({
+      queryClass: 'temporal',
+    });
+    expect(parseCalibrationKey(calibrationKey({ queryClass: 'temporal', language: 'ru' }))).toEqual(
+      { queryClass: 'temporal', language: 'ru' },
+    );
+    expect(parseCalibrationKey(calibrationKey({ queryClass: 'temporal', script: 'Cyrl' }))).toEqual(
+      { queryClass: 'temporal', script: 'Cyrl' },
+    );
+    // A bare key is byte-identical to the plain queryClass string.
+    expect(calibrationKey({ queryClass: 'temporal' })).toBe('temporal');
+  });
+
+  it('OFF (default): language-bearing samples produce NO language keys — byte-identical', () => {
+    const samples = [
+      ...langSamples('temporal', 'ru', 'Cyrl', MIN_CLASS_SAMPLES + 5),
+      ...langSamples('temporal', 'en', 'Latn', MIN_CLASS_SAMPLES + 5),
+    ];
+    const cal = fitPerClass(samples); // no opts ⇒ per-class only
+    // Only bare keys exist — no KEY_SEP-suffixed language/script entries.
+    expect(Object.keys(cal).sort()).toEqual([DEFAULT_CLASS, 'temporal']);
+    // And calibratedConfidence (no opts) ignores language entirely.
+    const ruSig: FocusSignal = {
+      ...signalWithRaw(0.8, 'temporal'),
+      language: 'ru',
+      script: 'Cyrl',
+    };
+    expect(calibratedConfidence(cal, ruSig)).toBeCloseTo(
+      applyMap(cal['temporal']!, rawFocusConfidence(ruSig)),
+      10,
+    );
+  });
+
+  it('ON: fits (class × language) and (class × script) maps above the floor', () => {
+    const samples = [
+      ...langSamples('temporal', 'ru', 'Cyrl', MIN_CLASS_SAMPLES + 5),
+      ...langSamples('temporal', 'en', 'Latn', MIN_CLASS_SAMPLES + 5),
+    ];
+    const cal = fitPerClass(samples, { byLanguage: true });
+    expect(cal[calibrationKey({ queryClass: 'temporal', language: 'ru' })]).toBeDefined();
+    expect(cal[calibrationKey({ queryClass: 'temporal', language: 'en' })]).toBeDefined();
+    expect(cal[calibrationKey({ queryClass: 'temporal', script: 'Cyrl' })]).toBeDefined();
+    expect(cal[calibrationKey({ queryClass: 'temporal', script: 'Latn' })]).toBeDefined();
+    // The bare per-class + global maps still exist.
+    expect(cal['temporal']).toBeDefined();
+    expect(cal[DEFAULT_CLASS]).toBeDefined();
+  });
+
+  it('ON: a sparse language earns NO own map and falls back up the hierarchy', () => {
+    const samples = [
+      ...langSamples('temporal', 'ru', 'Cyrl', MIN_CLASS_SAMPLES + 5),
+      ...langSamples('temporal', 'fr', 'Latn', 5), // below floor
+    ];
+    const cal = fitPerClass(samples, { byLanguage: true });
+    // fr got too few → no (class × fr) map.
+    expect(cal[calibrationKey({ queryClass: 'temporal', language: 'fr' })]).toBeUndefined();
+    // A fr signal resolves down the ladder to (class × Latn) — fr is Latin,
+    // and the Latin script bucket (ru is Cyrl) is exactly the fr samples, so
+    // it may or may not clear the floor; either way it never throws and
+    // returns a value in [0,1].
+    const frSig: FocusSignal = {
+      ...signalWithRaw(0.8, 'temporal'),
+      language: 'fr',
+      script: 'Latn',
+    };
+    const c = calibratedConfidence(cal, frSig, { byLanguage: true });
+    expect(c).toBeGreaterThanOrEqual(0);
+    expect(c).toBeLessThanOrEqual(1);
+  });
+
+  it('ON: calibratedConfidence prefers language → script → class → default', () => {
+    // ru calibrates OPPOSITE to en so the per-language map is observably chosen.
+    const samples = [
+      ...langSamples('temporal', 'ru', 'Cyrl', MIN_CLASS_SAMPLES + 20, true),
+      ...langSamples('temporal', 'en', 'Latn', MIN_CLASS_SAMPLES + 20, false),
+    ];
+    const cal = fitPerClass(samples, { byLanguage: true });
+
+    const ruSig: FocusSignal = {
+      ...signalWithRaw(0.8, 'temporal'),
+      language: 'ru',
+      script: 'Cyrl',
+    };
+    // The (class × ru) map is the FIRST tier and must be the one applied.
+    expect(calibratedConfidence(cal, ruSig, { byLanguage: true })).toBeCloseTo(
+      applyMap(
+        cal[calibrationKey({ queryClass: 'temporal', language: 'ru' })]!,
+        rawFocusConfidence(ruSig),
+      ),
+      10,
+    );
+
+    // A language with no own map but a known script → the (class × script) tier.
+    const cyrlOnly: FocusSignal = {
+      ...signalWithRaw(0.8, 'temporal'),
+      language: 'uk', // no (temporal × uk) map fitted
+      script: 'Cyrl',
+    };
+    expect(calibratedConfidence(cal, cyrlOnly, { byLanguage: true })).toBeCloseTo(
+      applyMap(
+        cal[calibrationKey({ queryClass: 'temporal', script: 'Cyrl' })]!,
+        rawFocusConfidence(cyrlOnly),
+      ),
+      10,
+    );
+
+    // No language/script on the signal → the plain per-class map (tier 3).
+    const bare: FocusSignal = signalWithRaw(0.8, 'temporal');
+    expect(calibratedConfidence(cal, bare, { byLanguage: true })).toBeCloseTo(
+      applyMap(cal['temporal']!, rawFocusConfidence(bare)),
+      10,
+    );
+  });
+
+  it('ON without any fitted language maps is byte-identical to the per-class path', () => {
+    // Samples carry NO language ⇒ byLanguage produces no language keys, so the
+    // hierarchical lookup falls straight through to the per-class map.
+    const samples: FocusOutcomeSample[] = [];
+    for (let i = 0; i < MIN_CLASS_SAMPLES + 5; i++) {
+      const p = (i + 0.5) / (MIN_CLASS_SAMPLES + 5);
+      samples.push({ ...signalWithRaw(p, 'temporal'), correct: p > 0.5 ? 1 : 0 });
+    }
+    const calOn = fitPerClass(samples, { byLanguage: true });
+    const calOff = fitPerClass(samples);
+    expect(Object.keys(calOn).sort()).toEqual(Object.keys(calOff).sort());
+    const sig = signalWithRaw(0.7, 'temporal');
+    expect(calibratedConfidence(calOn, sig, { byLanguage: true })).toBe(
+      calibratedConfidence(calOff, sig),
+    );
   });
 });
 

--- a/test/genre-presets.unit-spec.ts
+++ b/test/genre-presets.unit-spec.ts
@@ -170,6 +170,7 @@ describe('genre presets — full effective profile per genre (snapshot)', () => 
     cjkSegmentation: false,
     multilingualLaneRouting: false,
     multilingualConflict: false,
+    answerLangGuard: false,
     scanHnswEf: 400,
     scanHnswOverfetch: 4,
     dateAnchoring: 'absolute',


### PR DESCRIPTION
## Multilingual program — Tier 5 (final): hierarchical per-language calibration + answer-language guard

The last tier. **Everything default-off; prod byte-identical when off** (off-path tests). No heavy deps, no paid eval.

### 1. Hierarchical per-language calibration (`MULTILINGUAL_CALIBRATION`)
Extends the fovea §4.2 per-class isotonic calibrator (`focus-signal.ts`) with a **language key** and a **hierarchical fallback**: exact `(class × language)` → `(class × script/family)` → `(class)` global. Reuses the **one PAV primitive** and one flat `Record` via composite keys (`calibrationKey`/`parseCalibrationKey`) — **no parallel calibrator**. A per-language/per-script bucket earns its own map only above the existing `MIN_CLASS_SAMPLES` floor, so a sparse language degrades gracefully up the ladder. The service threads the detected query language/script through capture/fit/persist/load. Serving-neutral (matches the current fovea posture — Tier 5 adds the language dimension to the fit/measure surface; Optics-2/3 consume it later).

### 2. Answer-language guard (`MULTILINGUAL_ANSWER_GUARD`)
- `resolveAnswerLang` fallback order: explicit `answerLang` → session locale (`dto.queryLang`) → **confidently-detected** query language (Tier 1 confidence) → **no forced language**. Facts never decide the answer language.
- `enforceAnswerLanguage`: a **cross-script** output-language check after generation with exactly **one bounded corrective regeneration** (reinforced strict directive), then a metrics flag + best-effort serve. Within-Latin (es-vs-en) is deliberately not adjudicated (short-answer Latin detection is too noisy); und/low-confidence/proper-noun/numeric answers are safe.

### Migration `0103_focus_calibration_language.surql`
Additive, OVERWRITE-safe optional `language`/`script` columns on `focus_signal_sample` + `focus_calibration`; version-key index extended. Pre-0103 rows read NONE and readers add `language IS NONE AND script IS NONE` → **byte-identical** global per-class path when off.

### Flags & goldens
Both flags in `env-validation.ts` + `config-catalog.data.ts` (MULTILINGUAL_ family, off the ENGINE budget). `answerLangGuard` resolved into `RetrievalProfile` + wire schema + mergeProfileOverrides + genre-presets snapshot.

### Verification (all green)
- `tsc` → 0 · `eslint --max-warnings 0` → 0 · `prettier --check` → 0
- Full unit suite: **294 suites / 2766 tests** (new `answer-lang-guard` + extended `focus-signal`; engine-gates S5.5 satisfied)
- `focus-signal.e2e` on loco-321: **6/6** incl. migration 0103 applied on real Surreal, `language`/`script` round-trip through fit/persist/load
- No paid eval.

### Engineering note
Extracted `buildGeneratorArgs` (shared byte-identically by round-1/refine/retry) + `enforceAnswerLanguage` into `synthesize.helpers.ts` to keep `synthesize.service.ts` under the 800-line god-file gate and `synthesize()` ≤200.

Multilingual stays **experimental** — nothing flipped on. This completes the Tier 0–5 multilingual program (all default-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
