### PR TITLE
fix(gdpr): atomic entity erase via client transaction + idempotent requestId; correct the non-firing DB-fence claim (R4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,14 @@ SURREALDB_SCOPED_POOL_SIZE=8
 # default so `docker compose up` works out of the box; override in real envs.
 FORGET_HMAC_KEY=change-me-to-a-long-random-secret-≥32-chars
 
+# Max records a single entity-forget erase may touch in ONE atomic
+# transaction (facts + edges + episodes + segments + audit-mirror rows).
+# The GDPR erase is all-or-nothing (one BEGIN/COMMIT); an entity with
+# pathological fan-out is refused (413) BEFORE any mutation rather than
+# building an oversized transaction — use whole-tenant offboarding for that
+# case. Default 10000.
+FORGET_MAX_TX_RECORDS=10000
+
 # ── OpenAI (embeddings + extraction) ─────────────────────────────────────
 OPENAI_API_KEY=sk-...
 OPENAI_EMBEDDING_MODEL=text-embedding-3-small

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,10 +89,14 @@ vector leg   lexical leg   (HyPE alt-emb leg)
 - **Bitemporal cutoff is in WHERE** — `validFrom <= asOf < validUntil`
   and `retractedAt IS NONE OR retractedAt > asOf` push down into the
   leg query, no JS post-filter.
-- **PII gating** — DB-level via `PERMISSIONS WHERE $caller_scopes
-  CONTAINS 'brain:read_pii'` on the `object` field of `address` /
-  `dob`. Scoped pool signs in as a non-root editor; scope-less callers
-  get NONE for the value but still see the predicate exists.
+- **PII gating** — enforced at the APPLICATION layer (the policy row/PII
+  filter): scope-less callers still see that a PII-classed predicate
+  (`address` / `dob`) exists, but not its `object` value. A mirrored
+  DB-level `PERMISSIONS WHERE $caller_scopes CONTAINS 'brain:read_pii'`
+  fence is declared on those fields (migrations 0005/0057) but is **inert
+  today** — SurrealDB skips PERMISSIONS for the system `brain_caller` user,
+  so it enforces nothing until callers move to Record Access (future). See
+  [ABAC § DB-level fence status](abac.md#db-level-fence-status-migration-0057).
 
 Full feature-flag matrix → [Operations § Retrieval feature flags](operations.md#retrieval-feature-flags).
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -32,6 +32,7 @@ the operator's reference for running Brain.
 |---|---|---|
 | `PORT` | `3000` | |
 | `NODE_ENV` | unset | Set `production` to enable strict env checks (FORGET_HMAC_KEY required, empty BRAIN_API_KEYS warned). |
+| `FORGET_MAX_TX_RECORDS` | `10000` | Max records a single entity-forget erase may touch in ONE atomic transaction (facts + edges + episodes + segments + audit-mirror rows). The GDPR erase is all-or-nothing (one `BEGIN`/`COMMIT`); an entity whose fan-out exceeds this is refused with `413` **before any mutation** rather than building an oversized transaction that risks the server write-key limit — use whole-tenant offboarding (drop database) for that case, or raise the cap deliberately. |
 | `OPENAI_EMBEDDING_MODEL` | `text-embedding-3-small` | |
 | `OPENAI_EMBEDDING_DIMENSIONS` | `1536` | Must match the schema's HNSW dim if HNSW is later enabled. |
 | `OPENAI_CHAT_MODEL` | `gpt-4o-mini` | Used by `ingest-mention` extraction. |

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -270,13 +270,19 @@ function validateProductionGuards(
     if (isProd) {
       errors.push(
         'SURREALDB_SCOPED_USER and SURREALDB_SCOPED_PASS must BOTH be set in ' +
-          'production — without them withScopedCompany() falls back to the ' +
-          'root pool and the DB-level PII fence (migration 0005) is bypassed.',
+          'production so withScopedCompany() uses the non-root scoped pool ' +
+          'instead of falling back to root. NOTE (R4 audit): the DB-level ' +
+          'PERMISSIONS fence (migration 0005) does not currently fire even ' +
+          'on the scoped pool — SurrealDB skips PERMISSIONS for the system ' +
+          'brain_caller user, so the app-layer filter is the effective PII ' +
+          'barrier; the scoped pool is required for parity/readiness for the ' +
+          'future Record Access fence.',
       );
     } else {
       warnings.push(
-        'SURREALDB_SCOPED_USER/PASS not set — DB-level PII fence inactive ' +
-          '(app-layer policy only). Set both before deploying.',
+        'SURREALDB_SCOPED_USER/PASS not set — running on the root pool ' +
+          '(app-layer policy is the effective PII barrier; the DB-level fence ' +
+          'is inert regardless). Set both before deploying.',
       );
     }
   } else if (env.SURREALDB_SCOPED_PASS?.trim() === SHIPPED_SCOPED_PASS_DEFAULT) {

--- a/src/communities/community.service.ts
+++ b/src/communities/community.service.ts
@@ -114,9 +114,12 @@ export class CommunityService {
 
   /**
    * Caller-facing reads (REST controller, MCP tools) thread scopes and
-   * ride the SCOPED pool so DB-level PERMISSIONS apply — community rows
-   * carry LLM summaries synthesized from facts. Internal consumers
-   * (reranker type hints, builder) stay on the root pool.
+   * ride the SCOPED pool — community rows carry LLM summaries synthesized
+   * from facts. NOTE (R4 audit): the DB-level PERMISSIONS fence does NOT
+   * fire for the system `brain_caller` user; the application-layer filter
+   * is the effective barrier. The scoped pool is kept for the future
+   * Record Access track. Internal consumers (reranker type hints, builder)
+   * stay on the root pool.
    */
   private run<T>(
     companyId: string,

--- a/src/db/migrations/0005_pii_permissions.surql
+++ b/src/db/migrations/0005_pii_permissions.surql
@@ -1,4 +1,20 @@
--- 0005_pii_permissions — DB-level PII enforcement gate.
+-- 0005_pii_permissions — DB-level PII enforcement gate
+-- (PREPARED, NOT EFFECTIVE — read the finding below).
+--
+-- ── FINDING (R4 audit, verified; canary test/abac-db-fence.e2e-spec.ts) ──
+-- This DB-level PII fence DOES NOT FIRE on the current stack. SurrealDB
+-- evaluates table/field PERMISSIONS for RECORD (ACCESS/SCOPE) users only —
+-- it SKIPS them for SYSTEM users, and `brain_caller` is a NAMESPACE-level
+-- EDITOR (a system user). Independently, `LET $caller_scopes` does not
+-- persist across query() boundaries on this driver/server, so the clause
+-- reads it as NONE regardless. The EFFECTIVE PII barrier is the
+-- APPLICATION-LAYER filter (policy/row-filter.ts, entity-read.helpers); it
+-- covers every read surface and is e2e-enforced. A real DB fence requires
+-- Record Access (DEFINE ACCESS … TYPE RECORD WITH JWT) — a future track.
+-- This migration ships the fence ARMED for that day; the 0057 canary fails
+-- loudly if the stack ever starts honoring PERMISSIONS. The historical
+-- framing below is kept for context but is SUPERSEDED by this finding.
+-- See docs/abac.md § DB-level fence status.
 --
 -- Architecture (cf. AGENTS A1 + Pinecone-Nexus governance framing):
 --

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -36,10 +36,16 @@ export {
 export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   private readonly logger = new Logger(SurrealService.name);
   // Two pools — admin (root) and scoped (brain_caller user).
-  // Caller-facing reads route through scopedPool so PERMISSIONS clauses
-  // on PII fields (migration 0005) actually fire. Admin paths
-  // (migration apply, GDPR forget, drop database) use rootPool because
-  // PERMISSIONS would block them and we want infra ops to bypass.
+  // Caller-facing reads route through scopedPool. NOTE (R4 audit): the
+  // DB-level field/table PERMISSIONS fence (migrations 0005/0057) does NOT
+  // currently fire — SurrealDB skips PERMISSIONS for SYSTEM users, and
+  // brain_caller is a NAMESPACE-level EDITOR (a system user); `LET` session
+  // vars also don't persist across query() boundaries. The EFFECTIVE
+  // PII/row barrier is the application-layer filter. The scoped pool is
+  // kept for the future Record Access (DEFINE ACCESS … TYPE RECORD WITH
+  // JWT) track that WILL make PERMISSIONS apply — see withScopedCompany
+  // and docs/abac.md. Admin paths (migration apply, GDPR forget, drop
+  // database) use rootPool (root bypasses PERMISSIONS by design).
   private readonly all: Surreal[] = [];
   private readonly rootIdle: Surreal[] = [];
   private readonly scopedIdle: Surreal[] = [];
@@ -186,10 +192,14 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
     }
 
     // Scoped pool — sign in as `brain_caller` (defined in migration 0005).
-    // Disabled cleanly when the user/password aren't set; falls back to
-    // the root pool for everything (defense-in-depth becomes app-only,
-    // matching pre-0005 behaviour). Production deployments MUST set
-    // SURREALDB_SCOPED_USER + SURREALDB_SCOPED_PASS for DB-level fences.
+    // Disabled cleanly when the user/password aren't set; falls back to the
+    // root pool for everything. NOTE (R4 audit): the DB-level PERMISSIONS
+    // fence does NOT fire even when the scoped pool IS enabled — SurrealDB
+    // skips PERMISSIONS for the system `brain_caller` user, so the
+    // application-layer filter is the effective barrier either way. The
+    // scoped pool is retained for the future Record Access track; set
+    // SURREALDB_SCOPED_USER + SURREALDB_SCOPED_PASS to exercise it. See
+    // docs/abac.md.
     const scopedUser = this.configService.get<string>('SURREALDB_SCOPED_USER');
     const scopedPass = this.configService.get<string>('SURREALDB_SCOPED_PASS');
     if (scopedUser && scopedPass) {
@@ -263,8 +273,10 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
    * The connection is exclusive to this callback for its lifetime.
    *
    * Use this for admin paths: schema apply, GDPR forget, drop database,
-   * compaction, ops scripts. Caller-facing paths must use
-   * `withScopedCompany` so DB-level PII permissions apply.
+   * compaction, ops scripts. Caller-facing paths use `withScopedCompany`
+   * (the application-layer filter is the effective PII/row barrier — the
+   * DB-level PERMISSIONS fence does NOT fire for the system `brain_caller`
+   * user today; see withScopedCompany and docs/abac.md).
    */
   async withCompany<T>(companyId: string, fn: (db: Surreal) => Promise<T>): Promise<T> {
     if (!/^[a-zA-Z0-9_-]+$/.test(companyId)) {
@@ -314,18 +326,29 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
 
   /**
    * Run a callback inside a per-tenant DB scope on a SCOPED connection.
-   * The connection is signed in as `brain_caller` (EDITOR role, not
-   * root), so PERMISSIONS clauses defined on schema fields apply.
+   * The connection is signed in as `brain_caller` (EDITOR role, not root).
    *
-   * Per-request, the service binds the caller's brain scopes to the
-   * SurrealDB session variable `$caller_scopes` via `LET`. PERMISSIONS
-   * clauses on PII-classed predicates check this variable; absence
-   * means PII fields return NONE for `object` while non-PII fields
-   * still return their values.
+   * IMPORTANT (R4 audit — do not claim a barrier that does not exist): the
+   * DB-level field/table PERMISSIONS fence DOES NOT CURRENTLY FIRE on this
+   * connection. `brain_caller` is a NAMESPACE-level system (EDITOR) user,
+   * and SurrealDB evaluates table/field PERMISSIONS for RECORD
+   * (ACCESS/SCOPE) users only — system users bypass them entirely.
+   * Independently, `LET $caller_scopes` / `$caller_policy_deny` do not
+   * persist across query() boundaries on this driver/server, so a later
+   * statement reads them as NONE. The EFFECTIVE PII/row barrier is the
+   * APPLICATION-LAYER filter (policy/row-filter.ts, entity-read.helpers),
+   * which covers every read surface and is e2e-enforced.
    *
-   * If the scoped pool is disabled (env var unset, dev mode without
-   * a non-root user), this falls back to `withCompany` semantics —
-   * defense-in-depth becomes app-layer-only.
+   * The scoped connection and the `$caller_scopes` / `$caller_policy_deny`
+   * `LET` binding below are kept intact so a real DB fence can be switched
+   * on the day callers move to Record Access (DEFINE ACCESS … TYPE RECORD
+   * WITH JWT) — a future track. The 0057 canary
+   * (test/abac-db-fence.e2e-spec.ts) fails loudly if the stack ever starts
+   * honoring PERMISSIONS. See docs/abac.md § DB-level fence status.
+   *
+   * If the scoped pool is disabled (env var unset, dev without a non-root
+   * user), this falls back to `withCompany` semantics — identical effective
+   * enforcement, since the app-layer filter is the gate either way.
    */
   async withScopedCompany<T>(
     companyId: string,
@@ -343,10 +366,12 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
       });
     }
     // ABAC DB fence (migration 0057, flag default off): compile the
-    // request's pushdown-safe deny rules off the AsyncLocalStorage
-    // policy context so the knowledge_fact field PERMISSIONS can null
-    // object/objectMeta for matching rows — defense-in-depth behind
-    // the app-layer row filter.
+    // request's pushdown-safe deny rules off the AsyncLocalStorage policy
+    // context and bind them for the knowledge_fact field PERMISSIONS. NOTE
+    // (R4 audit): this fence is INERT today (PERMISSIONS are skipped for the
+    // system brain_caller user — see the withScopedCompany docstring); the
+    // app-layer row filter is the effective gate. The binding is kept armed
+    // for the future Record Access track.
     const policyDeny = envFlagEnabled(process.env.ABAC_DB_FENCE_ENABLED)
       ? compileDenyPushdown(getPolicyContext())
       : [];

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -585,12 +585,14 @@ export class EntitiesService {
           direction: 'inbound' as const,
         })),
       ];
-      // Defense-in-depth: the DB-level PERMISSIONS fence (migration 0005)
-      // gates knowledge_fact.object, but knowledge_edge has no such fence,
-      // so a scoped caller could otherwise read a PII-classed relation
-      // (edge.kind maps to a predicate). Mirror the timeline scope gate,
-      // then the ABAC row verdict — edges evaluate with predicate = kind,
-      // so predicate/source rules apply to relations too.
+      // PII/row gate for relations. The app-layer filter is the effective
+      // PII barrier on knowledge_fact.object (the DB-level PERMISSIONS fence
+      // of migration 0005 is inert for the system brain_caller user); edges
+      // have no field-level fence at all, so a scoped caller could otherwise
+      // read a PII-classed relation (edge.kind maps to a predicate). Mirror
+      // the timeline scope gate, then the ABAC row verdict — edges evaluate
+      // with predicate = kind, so predicate/source rules apply to relations
+      // too.
       const rowPolicy = makeRowPolicyFilter({
         callerScopes: scopes,
         surface: 'entity_connections',

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -1,11 +1,36 @@
-import { Injectable, Logger, NotFoundException, Optional } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  Optional,
+  PayloadTooLargeException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHmac } from 'node:crypto';
 import { StringRecordId } from 'surrealdb';
-import { SurrealService, dbCreate, queryRows, queryFirst } from '../db/surreal.service';
+import { SurrealService, runTransaction, queryRows, queryFirst } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { normalizeEntityId } from './entity-read.helpers';
 import { ForgetOptions, ForgetResult } from './entities.service';
+
+/** A previously-written tombstone, read back for idempotent-replay. */
+interface ForgottenTombstoneRow {
+  entityIdHash: string;
+  factsDeleted?: number;
+  edgesDeleted?: number;
+  auditEventsDeleted?: number;
+  episodesDeleted?: number;
+  segmentsDeleted?: number;
+  forgottenAt: string | Date;
+}
+
+/** Shape returned by the atomic-erase transaction's trailing RETURN. */
+interface ForgetTxResult {
+  auditEventsDeleted: number;
+  episodesDeleted: number;
+  segmentsDeleted: number;
+  tombstone: { id: unknown; entityIdHash: string } | null;
+}
 
 /**
  * EntityForgetService — the GDPR erasure path.
@@ -17,11 +42,39 @@ import { ForgetOptions, ForgetResult } from './entities.service';
  * and the post-erasure embedder-cache eviction. Split out of
  * EntitiesService so the read path (surreal only) and the erasure path
  * (surreal + hmac config + embedder cache) each keep ≤3 injected deps.
+ *
+ * Atomicity (R4 audit): the erase runs inside ONE client-managed
+ * SurrealDB transaction (`runTransaction`, the confirmed BEGIN/COMMIT
+ * idiom — separate `query('BEGIN')`/`query('COMMIT')` calls do NOT work
+ * on the pinned driver, each is its own scope). Every mutation — subject
+ * rows, derived rows, L0 turns, the audit-mirror scrub, and the
+ * `forgotten_entity` tombstone — commits together or not at all. A
+ * mid-sequence failure rolls back completely, so a retry (keyed on
+ * `requestId`) either finds the finished tombstone and no-ops, or re-runs
+ * the whole erase from a clean slate. Never a partially-erased subject.
+ *
+ * Structural REFERENCE ON DELETE CASCADE/UNSET (SurrealDB record
+ * references) for the derived deps is a documented follow-up — it needs a
+ * schema migration and is intentionally out of scope here.
  */
 @Injectable()
 export class EntityForgetService {
   private readonly logger = new Logger(EntityForgetService.name);
   private readonly forgetHmacKey: string;
+  /**
+   * Transaction-size cap. The atomic erase is a single transaction; an
+   * entity with pathological fan-out (tens of thousands of facts + their
+   * mirrored audit rows) would build an oversized transaction that risks
+   * the server's write-key / transaction limit. We BOUND rather than
+   * chunk: chunk-with-resume would need durable per-chunk progress state
+   * (a schema change, forbidden here) and would reintroduce the very
+   * partial-erase window this fix closes. When the fan-out exceeds the
+   * cap we fail fast BEFORE any mutation (nothing partially erased) and
+   * the operator uses whole-tenant offboarding (dropCompanyDatabase),
+   * raises the cap deliberately, or waits for the resumable-chunked
+   * follow-up. Configurable via FORGET_MAX_TX_RECORDS.
+   */
+  private readonly maxTxRecords: number;
 
   constructor(
     private readonly surreal: SurrealService,
@@ -32,6 +85,8 @@ export class EntityForgetService {
     // a per-process default — safe enough for 0.1.0 walking skeleton, but
     // production deployments MUST set this so tombstones survive restart.
     this.forgetHmacKey = this.configService.get<string>('FORGET_HMAC_KEY') ?? 'inite-brain-default';
+    const cap = parseInt(this.configService.get<string>('FORGET_MAX_TX_RECORDS', '10000'), 10);
+    this.maxTxRecords = Number.isFinite(cap) && cap >= 1 ? cap : 10000;
   }
 
   async forget({
@@ -41,9 +96,50 @@ export class EntityForgetService {
     actorKeyHash,
   }: ForgetOptions): Promise<ForgetResult> {
     const ref = normalizeEntityId(entityIdRaw);
+    // Deterministic over (companyId, ref.full): a retry of the same request
+    // recomputes the identical hash, which — paired with requestId — is how
+    // an idempotent replay is detected below.
+    const entityIdHash =
+      'hmac:' +
+      createHmac('sha256', this.forgetHmacKey).update(`${companyId}/${ref.full}`).digest('hex');
 
     const result = await this.surreal.withCompany(companyId, async (db) => {
-      // Verify exists
+      // ── Idempotent retry (R4). The whole erase is atomic, so a failed or
+      // partial attempt left NO tombstone — only a fully-committed erase is
+      // visible here. A tombstone matching BOTH this requestId AND this
+      // entity hash is a true replay: return the stored result, never
+      // re-erase, never double-error. Matching on the pair (not requestId
+      // alone) means a requestId accidentally reused across DIFFERENT
+      // entities still erases each one.
+      const prior = await queryFirst<ForgottenTombstoneRow>(
+        db,
+        `SELECT entityIdHash, factsDeleted, edgesDeleted, auditEventsDeleted,
+                episodesDeleted, segmentsDeleted, forgottenAt
+           FROM forgotten_entity
+          WHERE requestId = $requestId AND entityIdHash = $hash
+          LIMIT 1`,
+        { requestId: dto.requestId, hash: entityIdHash },
+      );
+      if (prior) {
+        this.logger.warn(
+          `[knowledge.entity.forgotten] idempotent replay companyId=${companyId} ` +
+            `hash=${entityIdHash} requestId=${dto.requestId} — returning stored result`,
+        );
+        return {
+          entityIdHash: prior.entityIdHash,
+          factsDeleted: prior.factsDeleted ?? 0,
+          edgesDeleted: prior.edgesDeleted ?? 0,
+          auditEventsDeleted: prior.auditEventsDeleted ?? 0,
+          episodesDeleted: prior.episodesDeleted ?? 0,
+          segmentsDeleted: prior.segmentsDeleted ?? 0,
+          forgottenAt: new Date(prior.forgottenAt).toISOString(),
+        } satisfies ForgetResult;
+      }
+
+      // Verify exists. After a committed erase the entity is gone AND the
+      // idempotency check above already returned; so reaching here with a
+      // missing entity means it never existed (or was erased under a
+      // different requestId) → 404.
       const entity = await queryFirst<{ id: unknown }>(
         db,
         `SELECT id FROM type::record('knowledge_entity', $rid) LIMIT 1`,
@@ -104,137 +200,137 @@ export class EntityForgetService {
           ),
         ),
       ].filter((id) => id.startsWith('episode:'));
-      let episodesDeleted = 0;
-      let segmentsDeleted = 0;
-      if (episodeIds.length > 0) {
-        const refs = episodeIds.map((id) => new StringRecordId(id));
-        // Segments are a rebuildable projection over the same turns — a
-        // segment that quotes an erased episode must go with it.
-        const segRows = await queryRows<unknown>(
-          db,
-          `DELETE episode_segment WHERE episodeIds CONTAINSANY $eps RETURN BEFORE`,
-          { eps: refs },
-        );
-        segmentsDeleted = segRows.length;
-        const epRows = await queryRows<unknown>(
-          db,
-          `DELETE episode WHERE id INSIDE $eps RETURN BEFORE`,
-          { eps: refs },
-        );
-        episodesDeleted = epRows.length;
-      }
-
-      // Cascade hard-delete. Embedding columns die with the rows.
-      // fact_usage (0053) and retrieval_feedback (0054) rows are keyed by
-      // fact record — resolve their cascade BEFORE the facts go, the
-      // record traversal dies with them.
-      await db.query(
-        `DELETE fact_usage
-         WHERE factId.entityId = type::record('knowledge_entity', $rid)`,
-        { rid: ref.id },
-      );
-      await db.query(
-        `DELETE retrieval_feedback
-         WHERE factId.entityId = type::record('knowledge_entity', $rid)`,
-        { rid: ref.id },
-      );
-      await db.query(
-        `DELETE knowledge_fact
-         WHERE entityId = type::record('knowledge_entity', $rid)`,
-        { rid: ref.id },
-      );
-      await db.query(
-        `DELETE knowledge_edge
-         WHERE in = type::record('knowledge_entity', $rid) OR out = type::record('knowledge_entity', $rid)`,
-        { rid: ref.id },
-      );
-      await db.query(`DELETE type::record('knowledge_entity', $rid)`, { rid: ref.id });
-
-      // Purge the materialised audit_event mirror for every deleted
-      // record (entity + its facts + edges). recordId IN [...] matches
-      // exactly how the consumer wrote them.
-      //
-      // Race note: the changefeed consumer is a lagging cron. If a
-      // CREATE/UPDATE for one of these records is still unconsumed in the
-      // rocksdb CHANGEFEED at forget time, a later tick re-materialises it
-      // into audit_event. The structural defence is consumer-side
-      // redaction of PII value fields in `after` (see
-      // changefeed-consumer redactAfterImage) so re-mirrored rows carry
-      // no raw PII; this purge removes the already-materialised rows.
+      const episodeRefs = episodeIds.map((id) => new StringRecordId(id));
       const recordIds = [entityIdStr, ...factIds, ...edgeIds];
-      const auditDeleted = await queryRows<unknown>(
+
+      // ── Transaction-size guard. Count the two open-ended tables (audit
+      // mirror rows grow with every mutation; segments with every turn) so
+      // the cap reflects the real transaction footprint, then refuse an
+      // oversized single transaction BEFORE mutating anything.
+      const auditCountRow = await queryFirst<{ count: number }>(
         db,
-        `DELETE audit_event WHERE recordId IN $ids RETURN BEFORE`,
+        `SELECT count() FROM audit_event WHERE recordId IN $ids GROUP ALL`,
         { ids: recordIds },
       );
-      const auditEventsDeleted = auditDeleted.length;
+      const auditCount = auditCountRow?.count ?? 0;
+      let segmentCount = 0;
+      if (episodeRefs.length > 0) {
+        const segCountRow = await queryFirst<{ count: number }>(
+          db,
+          `SELECT count() FROM episode_segment WHERE episodeIds CONTAINSANY $eps GROUP ALL`,
+          { eps: episodeRefs },
+        );
+        segmentCount = segCountRow?.count ?? 0;
+      }
+      const txRecordCount =
+        factsDeleted + edgesDeleted + episodeIds.length + segmentCount + auditCount;
+      if (txRecordCount > this.maxTxRecords) {
+        throw new PayloadTooLargeException(
+          `Entity forget fan-out (${txRecordCount} records) exceeds ` +
+            `FORGET_MAX_TX_RECORDS (${this.maxTxRecords}); refusing to build an ` +
+            `oversized single transaction. Use whole-tenant offboarding ` +
+            `(drop database), raise the cap deliberately, or use the ` +
+            `resumable-chunked erase follow-up.`,
+        );
+      }
 
-      // dream_emit: subject/object hold the entity/fact ids the dreams
-      // resolver linked or superseded — purge any referencing the
-      // forgotten records (carries fact-derived `detail`).
-      await db.query(`DELETE dream_emit WHERE subject IN $ids OR object IN $ids`, {
-        ids: recordIds,
-      });
-
-      // debug_trace: per-request blobs (artifacts) can carry the subject's
-      // raw fact text / queries when DEBUG_TRACE_PERSIST is on. Not
-      // entity-keyed, so best-effort: drop this tenant's traces whose
-      // serialised artifacts reference the entity or any deleted fact id.
-      await db.query(
-        `DELETE debug_trace
-           WHERE companyId = $cid
-             AND string::contains(<string>artifacts, $needle)`,
-        { cid: companyId, needle: entityIdStr },
-      );
-
-      // knowledge_artifact: compiled per-entity dossiers (customer_profile,
-      // support_context) carry name/contact/complaints — entityId-keyed.
-      await db.query(
-        `DELETE knowledge_artifact
-           WHERE entityId = type::record('knowledge_entity', $rid)`,
-        { rid: ref.id },
-      );
-
-      // ingest_dead_letter: rejected facts keep payload.{object,entityId}.
-      await db.query(
-        `DELETE ingest_dead_letter
-           WHERE payload.entityId = type::record('knowledge_entity', $rid)`,
-        { rid: ref.id },
-      );
-
-      // entity_external_ref: external subject identifier + pointer.
-      await db.query(
-        `DELETE entity_external_ref
-           WHERE entity = type::record('knowledge_entity', $rid)`,
-        { rid: ref.id },
-      );
-
-      const entityIdHash =
-        'hmac:' +
-        createHmac('sha256', this.forgetHmacKey).update(`${companyId}/${ref.full}`).digest('hex');
-
+      // ── Atomic erase. Everything below commits together or rolls back
+      // together (single BEGIN/COMMIT). Ordering inside the transaction is
+      // for readability only — the commit is atomic — but we keep the
+      // dependency order (segments before the episodes they quote; derived
+      // rows before the facts; audit mirror scrubbed by the pre-collected
+      // record-id list; tombstone last).
       const forgottenAt = new Date();
-      await dbCreate(db, 'forgotten_entity', {
-        entityIdHash,
-        reason: dto.reason,
-        requestId: dto.requestId,
-        factsDeleted,
-        edgesDeleted,
-        auditEventsDeleted,
-        episodesDeleted,
-        segmentsDeleted,
-        // GDPR accountability (Art. 5(2)/30): record WHO performed the
-        // erasure (hashed admin credential), not just that it happened.
-        forgottenBy: actorKeyHash ?? 'unknown',
-        forgottenAt,
+      const txResult = await runTransaction<ForgetTxResult>(db, (tx) => {
+        tx.bind('rid', ref.id)
+          .bind('eps', episodeRefs)
+          .bind('recordIds', recordIds)
+          .bind('cid', companyId)
+          .bind('needle', entityIdStr)
+          .bind('entityIdHash', entityIdHash)
+          .bind('reason', dto.reason)
+          .bind('requestId', dto.requestId)
+          .bind('factsDeleted', factsDeleted)
+          .bind('edgesDeleted', edgesDeleted)
+          .bind('forgottenBy', actorKeyHash ?? 'unknown')
+          .bind('forgottenAt', forgottenAt);
+        tx.add(`LET $ent = type::record('knowledge_entity', $rid)`);
+        // fact_usage (0053) + retrieval_feedback (0054) are keyed by fact
+        // record — the traversal dies with the facts, so purge first.
+        tx.add(`DELETE fact_usage WHERE factId.entityId = $ent`);
+        tx.add(`DELETE retrieval_feedback WHERE factId.entityId = $ent`);
+        // L0: a segment that quotes an erased episode goes with it; segments
+        // before episodes to keep the dependency order.
+        tx.add(
+          `LET $segs = (DELETE episode_segment WHERE episodeIds CONTAINSANY $eps RETURN BEFORE)`,
+        );
+        tx.add(`LET $epsDel = (DELETE episode WHERE id INSIDE $eps RETURN BEFORE)`);
+        // Cascade hard-delete. Embedding columns die with the rows.
+        tx.add(`DELETE knowledge_fact WHERE entityId = $ent`);
+        tx.add(`DELETE knowledge_edge WHERE in = $ent OR out = $ent`);
+        tx.add(`DELETE type::record('knowledge_entity', $rid)`);
+        // Purge the materialised audit_event mirror for every deleted record
+        // (entity + its facts + edges). recordId IN [...] matches how the
+        // consumer wrote them. (Race note: a still-unconsumed changefeed
+        // tick can re-materialise a row after this — the structural defence
+        // is consumer-side PII redaction of `after`; this scrubs the rows
+        // already materialised.)
+        tx.add(`LET $audit = (DELETE audit_event WHERE recordId IN $recordIds RETURN BEFORE)`);
+        // dream_emit: subject/object hold the entity/fact ids the dreams
+        // resolver linked or superseded (carries fact-derived `detail`).
+        tx.add(`DELETE dream_emit WHERE subject IN $recordIds OR object IN $recordIds`);
+        // debug_trace: per-request blobs can carry the subject's raw fact
+        // text / queries when DEBUG_TRACE_PERSIST is on. Not entity-keyed —
+        // drop this tenant's traces whose serialised artifacts reference it.
+        tx.add(
+          `DELETE debug_trace WHERE companyId = $cid AND string::contains(<string>artifacts, $needle)`,
+        );
+        // knowledge_artifact: compiled per-entity dossiers carry
+        // name/contact/complaints — entityId-keyed.
+        tx.add(`DELETE knowledge_artifact WHERE entityId = $ent`);
+        // ingest_dead_letter: rejected facts keep payload.{object,entityId}.
+        tx.add(`DELETE ingest_dead_letter WHERE payload.entityId = $ent`);
+        // entity_external_ref: external subject identifier + pointer.
+        tx.add(`DELETE entity_external_ref WHERE entity = $ent`);
+        // Tombstone — GDPR accountability (Art. 5(2)/30): record WHO
+        // performed the erasure (hashed credential) + requestId so a repeat
+        // is detectable. factsDeleted/edgesDeleted are the pre-collected
+        // counts; the L0 + audit counts come from the RETURN BEFORE lengths.
+        tx.add(`LET $tomb = (CREATE forgotten_entity CONTENT {
+            entityIdHash: $entityIdHash,
+            reason: $reason,
+            requestId: $requestId,
+            factsDeleted: $factsDeleted,
+            edgesDeleted: $edgesDeleted,
+            auditEventsDeleted: array::len($audit),
+            episodesDeleted: array::len($epsDel),
+            segmentsDeleted: array::len($segs),
+            forgottenBy: $forgottenBy,
+            forgottenAt: $forgottenAt
+          } RETURN AFTER)`);
+        tx.add(`RETURN {
+            auditEventsDeleted: array::len($audit),
+            episodesDeleted: array::len($epsDel),
+            segmentsDeleted: array::len($segs),
+            tombstone: $tomb[0]
+          }`);
       });
+
+      // A committed erase always returns its tombstone; its absence means
+      // the transaction didn't land — fail loud rather than report success.
+      if (!txResult?.tombstone) {
+        throw new Error('entity forget: transaction returned no tombstone row');
+      }
+      const auditEventsDeleted = txResult.auditEventsDeleted ?? 0;
+      const episodesDeleted = txResult.episodesDeleted ?? 0;
+      const segmentsDeleted = txResult.segmentsDeleted ?? 0;
 
       this.logger.warn(
         `[knowledge.entity.forgotten] companyId=${companyId} hash=${entityIdHash} ` +
           `factsDeleted=${factsDeleted} edgesDeleted=${edgesDeleted} ` +
           `auditEventsDeleted=${auditEventsDeleted} ` +
           `episodesDeleted=${episodesDeleted} segmentsDeleted=${segmentsDeleted} ` +
-          `reason=${dto.reason} ` +
+          `reason=${dto.reason} requestId=${dto.requestId} ` +
           `by=${actorKeyHash ?? 'unknown'}`,
       );
 
@@ -246,7 +342,7 @@ export class EntityForgetService {
         episodesDeleted,
         segmentsDeleted,
         forgottenAt: forgottenAt.toISOString(),
-      };
+      } satisfies ForgetResult;
     });
 
     // Best-effort: drop the in-process embedder cache so the forgotten

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -626,13 +626,17 @@ export class FactsService {
     opts: {
       predicate?: string;
       asOf?: string;
-      /** Caller's scopes — binds the DB-level PII fence (migration 0005). */
+      /** Caller's scopes — drive the app-layer PII/row filter (the DB-level
+       *  PII fence of migration 0005 is inert for the system brain_caller
+       *  user; see SurrealService.withScopedCompany). */
       callerScopes?: readonly string[];
     } = {},
   ): Promise<ListCompetingResult> {
     // Scoped pool when the caller identifies itself (the MCP path — the
     // only consumer today): competing rows carry raw `object` values, so
-    // they must respect the $caller_scopes PII fence like every other read.
+    // they must respect the PII gate like every other read — enforced by
+    // the app-layer row filter below (the DB-level $caller_scopes fence is
+    // inert for the system brain_caller user).
     const run = <T>(fn: (db: Surreal) => Promise<T>) =>
       opts.callerScopes
         ? this.surreal.withScopedCompany(companyId, opts.callerScopes, fn)

--- a/src/mcp/community-tools.ts
+++ b/src/mcp/community-tools.ts
@@ -15,8 +15,10 @@ export function registerCommunityTools(
   deps: {
     communities: CommunityService;
     /**
-     * Caller scopes — threads the DB-level PII fence through the
-     * scoped pool (community summaries are fact-derived).
+     * Caller scopes — thread the PII/row filter for community reads
+     * (community summaries are fact-derived). NOTE (R4 audit): the
+     * DB-level PII fence is inert for the system brain_caller user; the
+     * app-layer filter is the effective barrier.
      */
     scopes?: readonly string[];
   },

--- a/src/mcp/read-tools.ts
+++ b/src/mcp/read-tools.ts
@@ -533,9 +533,11 @@ function registerEntityReadTools({
       },
     },
     async (args) => {
-      // Pass scopes — without them getConnections signs in with an
-      // empty scope set, bypassing the DB-level PII fence (every other
-      // MCP tool forwards scopes).
+      // Pass scopes — without them getConnections runs with an empty scope
+      // set, which would drop the caller's PII/row entitlements at the
+      // app-layer filter (the effective barrier; the DB-level PII fence is
+      // inert for the system brain_caller user). Every other MCP tool
+      // forwards scopes.
       const out = await deps.entities.getConnections({
         companyId,
         entityIdRaw: args.entityId,

--- a/src/procedural/procedural-memory.service.ts
+++ b/src/procedural/procedural-memory.service.ts
@@ -74,8 +74,10 @@ export class ProceduralMemoryService {
    * 0=urgent).
    */
   async match(companyId: string, args: MatchProcedureArgs): Promise<MatchedProcedure[]> {
-    // Caller-facing reads ride the scoped pool when the caller
-    // identifies itself (MCP path) so DB-level PERMISSIONS apply.
+    // Caller-facing reads ride the scoped pool when the caller identifies
+    // itself (MCP path). NOTE (R4 audit): the DB-level PERMISSIONS fence
+    // does NOT fire for the system `brain_caller` user; access here is
+    // gated at the tool/action level (see below), not by DB PERMISSIONS.
     //
     // No ABAC row-filter here by design: procedures are a curated
     // OPERATOR layer (trigger→action how-tos), not user facts — they

--- a/src/stats/stats.service.ts
+++ b/src/stats/stats.service.ts
@@ -28,7 +28,10 @@ export interface MemoryStats {
 /**
  * StatsService — cheap per-company memory counts for the end-user
  * "Usage" surface. One batched round-trip of COUNT aggregates, run on a
- * scope-bound connection so PII permissions still apply.
+ * scope-bound connection. (NOTE, R4 audit: the DB-level PII PERMISSIONS
+ * fence does not currently fire for the system `brain_caller` user — these
+ * are non-PII aggregate counts so it is immaterial here; the app-layer
+ * filter is the effective PII barrier on value-bearing reads.)
  *
  * Two read paths behind STATS_VIEWS_ENABLED (default off):
  *   - off: live GROUP aggregates + 30s LRU (pre-0088 behavior).

--- a/test/entities-forget.e2e-spec.ts
+++ b/test/entities-forget.e2e-spec.ts
@@ -326,8 +326,7 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
     // The transaction's final `CREATE forgotten_entity` hits the UNIQUE
     // index on entityIdHash and aborts the transaction — the DELETEs that
     // ran earlier in the same transaction must roll back.
-    const key =
-      f.app.get(ConfigService).get<string>('FORGET_HMAC_KEY') ?? 'inite-brain-default';
+    const key = f.app.get(ConfigService).get<string>('FORGET_HMAC_KEY') ?? 'inite-brain-default';
     const hash =
       'hmac:' + createHmac('sha256', key).update(`${f.companyId}/${entityId}`).digest('hex');
     await surreal.withCompany(f.companyId, async (db) => {

--- a/test/entities-forget.e2e-spec.ts
+++ b/test/entities-forget.e2e-spec.ts
@@ -10,7 +10,15 @@
  *   4. Verify the entity + its facts + its edges are gone from the
  *      tenant DB (cascade actually deleted).
  *   5. Verify a `forgotten_entity` tombstone row was written.
+ *
+ * R4 audit adds two more, exercised against the real SurrealDB:
+ *   6. Idempotent retry — re-forget with the same requestId replays the
+ *      stored result and writes no duplicate tombstone.
+ *   7. Atomicity — a mid-transaction failure (a pre-seeded tombstone
+ *      hash-conflict) rolls the whole erase back: nothing partially erased.
  */
+import { ConfigService } from '@nestjs/config';
+import { createHmac } from 'node:crypto';
 import type { AppFixture } from './app-fixture';
 import { createApp } from './app-fixture';
 import { SurrealService } from '../src/db/surreal.service';
@@ -246,5 +254,114 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
       .set(auth())
       .send({ reason: 'gdpr_request', requestId: 'req-2' });
     expect(r.status).toBe(404);
+  });
+
+  // Resolve the knowledge_entity id backing a freshly-ingested fact.
+  const seedEntity = async (extId: string, object: string): Promise<string> => {
+    const fact = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: extId },
+        predicate: 'name',
+        object,
+        validFrom: '2026-01-01',
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+      });
+    expect([200, 201]).toContain(fact.status);
+    const surreal = f.app.get(SurrealService);
+    const entityId = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<any[][]>(
+        `SELECT entityId FROM type::record('knowledge_fact', $tail)`,
+        { tail: String(fact.body.factId).split(':')[1] },
+      );
+      return String((rows as any[])?.[0]?.entityId ?? '');
+    });
+    expect(entityId).toMatch(/^knowledge_entity:/);
+    return entityId;
+  };
+
+  it('idempotent retry: re-forget with the same requestId replays the stored result (no duplicate tombstone)', async () => {
+    const entityId = await seedEntity('idem_subj', 'Idempotent Person');
+    const surreal = f.app.get(SurrealService);
+
+    const r1 = await f.http
+      .post(`/v1/entities/${encodeURIComponent(entityId)}/forget`)
+      .set(auth())
+      .send({ reason: 'gdpr_request', requestId: 'idem-1' });
+    expect([200, 201]).toContain(r1.status);
+    const hash = r1.body.entityIdHash as string;
+    expect(hash).toMatch(/^hmac:[0-9a-f]{64}$/);
+    expect(r1.body.factsDeleted).toBeGreaterThanOrEqual(1);
+
+    // Retry with the SAME requestId — the entity is already gone, so this
+    // must be a no-op replay of the stored result, NOT a 404 or a re-erase.
+    const r2 = await f.http
+      .post(`/v1/entities/${encodeURIComponent(entityId)}/forget`)
+      .set(auth())
+      .send({ reason: 'gdpr_request', requestId: 'idem-1' });
+    expect([200, 201]).toContain(r2.status);
+    expect(r2.body.entityIdHash).toBe(hash);
+    expect(r2.body.factsDeleted).toBe(r1.body.factsDeleted);
+    expect(r2.body.forgottenAt).toBe(r1.body.forgottenAt);
+
+    // Exactly one tombstone for this entity — the replay wrote none.
+    const tombCount = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<any[][]>(
+        `SELECT id FROM forgotten_entity WHERE entityIdHash = $h`,
+        { h: hash },
+      );
+      return (rows as any[]).length;
+    });
+    expect(tombCount).toBe(1);
+  });
+
+  it('atomic erase: a mid-transaction failure rolls the whole erase back (nothing partially erased)', async () => {
+    const entityId = await seedEntity('atomic_subj', 'Atomic Person');
+    const surreal = f.app.get(SurrealService);
+
+    // Compute the tombstone hash the erase will attempt to CREATE, then
+    // PRE-SEED a conflicting tombstone (same hash, DIFFERENT requestId).
+    // The transaction's final `CREATE forgotten_entity` hits the UNIQUE
+    // index on entityIdHash and aborts the transaction — the DELETEs that
+    // ran earlier in the same transaction must roll back.
+    const key =
+      f.app.get(ConfigService).get<string>('FORGET_HMAC_KEY') ?? 'inite-brain-default';
+    const hash =
+      'hmac:' + createHmac('sha256', key).update(`${f.companyId}/${entityId}`).digest('hex');
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `CREATE forgotten_entity CONTENT {
+           entityIdHash: $h, reason: 'operator_request', requestId: 'pre-existing-conflict',
+           factsDeleted: 0, edgesDeleted: 0, auditEventsDeleted: 0,
+           episodesDeleted: 0, segmentsDeleted: 0, forgottenBy: 'seed', forgottenAt: time::now() }`,
+        { h: hash },
+      );
+    });
+
+    // Forget with a DIFFERENT requestId so the idempotency check does not
+    // short-circuit; the erase must reach the failing CREATE and roll back.
+    const r = await f.http
+      .post(`/v1/entities/${encodeURIComponent(entityId)}/forget`)
+      .set(auth())
+      .send({ reason: 'gdpr_request', requestId: 'atomic-test' });
+    expect(r.status).toBeGreaterThanOrEqual(500);
+
+    // Atomicity proof: the subject entity + its fact are STILL PRESENT —
+    // the erase deleted nothing because the transaction rolled back.
+    await surreal.withCompany(f.companyId, async (db) => {
+      const tail = entityId.split(':')[1];
+      const [entRows] = await db.query<any[][]>(
+        `SELECT id FROM type::record('knowledge_entity', $tail)`,
+        { tail },
+      );
+      expect((entRows as any[]).length).toBe(1);
+      const [factRows] = await db.query<any[][]>(
+        `SELECT id FROM knowledge_fact WHERE entityId = type::record('knowledge_entity', $tail)`,
+        { tail },
+      );
+      expect((factRows as any[]).length).toBeGreaterThanOrEqual(1);
+    });
   });
 });

--- a/test/env-validation.unit-spec.ts
+++ b/test/env-validation.unit-spec.ts
@@ -1,8 +1,11 @@
 /**
  * Unit coverage for validateEnv — focuses on the production fail-closed
  * assertion for the scoped DB pool (SURREALDB_SCOPED_USER/PASS). Without
- * those, withScopedCompany() silently falls back to the root pool and the
- * DB-level PII fence is bypassed; production must refuse to start.
+ * those, withScopedCompany() silently falls back to the root pool; the
+ * scoped pool is required in production for parity/readiness (the DB-level
+ * PII fence itself is inert for the system brain_caller user — the
+ * app-layer filter is the effective barrier). Production must refuse to
+ * start without both creds.
  */
 import { validateEnv } from '../src/common/env-validation';
 

--- a/test/forget-l0-cascade.unit-spec.ts
+++ b/test/forget-l0-cascade.unit-spec.ts
@@ -8,13 +8,19 @@ import type { ConfigService } from '@nestjs/config';
  * L1. The verbatim episodes naming the erased subject stayed readable
  * through both L0 lanes and GET /v1/episodes — and a re-derive
  * RESURRECTED the deleted facts from them. These pin the cascade.
+ *
+ * R4 audit: the erase now runs inside ONE client transaction (all the
+ * mutations land in a single BEGIN/COMMIT via `runTransaction`, so the
+ * write-side is one recorded `db.query('BEGIN TRANSACTION; …')` call, not
+ * a sequence of independent DELETEs). These tests pin the cascade AND the
+ * atomic + idempotent contract.
  */
 interface Recorded {
   sql: string;
   params?: Record<string, unknown> | undefined;
 }
 
-function makeDb(rowsFor: (sql: string) => unknown[]): {
+function makeDb(rowsFor: (sql: string) => unknown): {
   db: { query: (sql: string, p?: Record<string, unknown>) => Promise<unknown> };
   queries: Recorded[];
 } {
@@ -24,15 +30,35 @@ function makeDb(rowsFor: (sql: string) => unknown[]): {
     db: {
       query: async (sql: string, params?: Record<string, unknown>) => {
         queries.push({ sql, params });
+        // runTransaction takes the last-1 (or last) slot of the returned
+        // array; every other caller (queryRows/queryFirst) reads slot 0 as
+        // its row array. Wrapping rowsFor(sql) in a single-element array
+        // serves both: slot 0 is the value, and for the tx that value is
+        // the trailing RETURN object.
         return [rowsFor(sql)];
       },
     },
   };
 }
 
-describe('entity forget → L0 cascade', () => {
-  it('deletes the grounding episodes and the segments quoting them', async () => {
+const cfg = () =>
+  ({
+    get: (_k: string, d?: string) => d,
+  }) as unknown as ConfigService;
+
+const txQuery = (queries: Recorded[]) => queries.find((q) => q.sql.includes('BEGIN TRANSACTION'));
+
+describe('entity forget → atomic L0 cascade', () => {
+  it('erases the entity + L0 in one transaction; segments precede episodes; grounding precedes facts', async () => {
     const { db, queries } = makeDb((sql) => {
+      if (sql.includes('BEGIN TRANSACTION'))
+        return {
+          auditEventsDeleted: 0,
+          episodesDeleted: 2,
+          segmentsDeleted: 1,
+          tombstone: { id: 'forgotten_entity:t1', entityIdHash: 'hmac:x' },
+        };
+      if (sql.includes('FROM forgotten_entity')) return []; // no prior tombstone
       if (sql.includes('FROM type::record')) return [{ id: 'knowledge_entity:e' }];
       if (sql.includes('SELECT source.episodeIds AS eps'))
         return [
@@ -40,68 +66,153 @@ describe('entity forget → L0 cascade', () => {
           { eps: ['episode:b'] }, // duplicate — must dedupe
         ];
       if (sql.includes('SELECT id FROM knowledge_fact')) return [{ id: 'knowledge_fact:f1' }];
-      if (sql.includes('DELETE episode_segment')) return [{ id: 'seg:1' }];
-      if (sql.includes('DELETE episode ')) return [{ id: 'episode:a' }, { id: 'episode:b' }];
-      // dbCreate asserts a returned row (tombstone must be observable);
-      // its SQL is the generic `CREATE type::table($t) …` form.
-      if (sql.includes('CREATE type::table')) return [{ id: 'forgotten_entity:t1' }];
       return [];
     });
     const surreal = {
       withCompany: async (_c: string, fn: (d: unknown) => Promise<unknown>) => fn(db),
     } as unknown as SurrealService;
-    const config = {
-      get: (_k: string, d?: string) => d,
-    } as unknown as ConfigService;
-    const svc = new EntityForgetService(surreal, config);
+    const svc = new EntityForgetService(surreal, cfg());
 
     const res = await svc.forget({
       companyId: 'co_x',
       entityIdRaw: 'knowledge_entity:e',
-      dto: { reason: 'gdpr' } as never,
+      dto: { reason: 'gdpr_request', requestId: 'req-1' } as never,
       actorKeyHash: 'admin1',
     });
 
+    expect(res.factsDeleted).toBe(1);
     expect(res.episodesDeleted).toBe(2);
     expect(res.segmentsDeleted).toBe(1);
 
-    const epDelete = queries.find((q) => q.sql.includes('DELETE episode '));
-    expect(epDelete).toBeDefined();
-    // deduped to the two distinct episodes
-    expect((epDelete?.params?.eps as unknown[]).length).toBe(2);
+    // The whole write-side is ONE transaction.
+    const tx = txQuery(queries);
+    expect(tx).toBeDefined();
+    // Deduped to the two distinct episodes, bound as record refs.
+    expect((tx?.params?.eps as unknown[]).length).toBe(2);
 
     // Segments must go BEFORE the episodes they reference (dangling links).
-    const segIdx = queries.findIndex((q) => q.sql.includes('DELETE episode_segment'));
-    const epIdx = queries.findIndex((q) => q.sql.includes('DELETE episode '));
-    expect(segIdx).toBeLessThan(epIdx);
+    const txSql = tx!.sql;
+    expect(txSql.indexOf('DELETE episode_segment')).toBeLessThan(
+      txSql.indexOf('DELETE episode WHERE'),
+    );
 
-    // Grounding episodes must be resolved BEFORE the facts that name them.
+    // Grounding episodes (a pre-transaction read) must be resolved BEFORE the
+    // transaction that deletes the facts naming them.
     const groundIdx = queries.findIndex((q) => q.sql.includes('SELECT source.episodeIds AS eps'));
-    const factDelIdx = queries.findIndex((q) => q.sql.includes('DELETE knowledge_fact'));
-    expect(groundIdx).toBeLessThan(factDelIdx);
+    const txIdx = queries.findIndex((q) => q.sql.includes('BEGIN TRANSACTION'));
+    expect(groundIdx).toBeGreaterThanOrEqual(0);
+    expect(groundIdx).toBeLessThan(txIdx);
+    // The fact DELETE lives inside that same transaction.
+    expect(txSql).toContain('DELETE knowledge_fact');
   });
 
-  it('no grounding episodes → no episode/segment deletes at all', async () => {
+  it('no grounding episodes → transaction runs with an empty episode set (0 L0 deletes)', async () => {
     const { db, queries } = makeDb((sql) => {
+      if (sql.includes('BEGIN TRANSACTION'))
+        return {
+          auditEventsDeleted: 0,
+          episodesDeleted: 0,
+          segmentsDeleted: 0,
+          tombstone: { id: 'forgotten_entity:t1', entityIdHash: 'hmac:x' },
+        };
       if (sql.includes('FROM type::record')) return [{ id: 'knowledge_entity:e' }];
-      if (sql.includes('CREATE type::table')) return [{ id: 'forgotten_entity:t1' }];
       return [];
     });
     const surreal = {
       withCompany: async (_c: string, fn: (d: unknown) => Promise<unknown>) => fn(db),
     } as unknown as SurrealService;
-    const config = {
-      get: (_k: string, d?: string) => d,
-    } as unknown as ConfigService;
-    const res = await new EntityForgetService(surreal, config).forget({
+    const res = await new EntityForgetService(surreal, cfg()).forget({
       companyId: 'co_x',
       entityIdRaw: 'knowledge_entity:e',
-      dto: { reason: 'gdpr' } as never,
+      dto: { reason: 'gdpr_request', requestId: 'req-2' } as never,
       actorKeyHash: 'admin1',
     });
     expect(res.episodesDeleted).toBe(0);
     expect(res.segmentsDeleted).toBe(0);
-    expect(queries.some((q) => q.sql.includes('DELETE episode '))).toBe(false);
+    const tx = txQuery(queries);
+    expect(tx).toBeDefined();
+    expect((tx?.params?.eps as unknown[]).length).toBe(0);
+  });
+});
+
+describe('entity forget → idempotent retry (R4)', () => {
+  it('a prior tombstone for (requestId, entity) is a no-op replay of the stored result', async () => {
+    const { db, queries } = makeDb((sql) => {
+      if (sql.includes('FROM forgotten_entity'))
+        return [
+          {
+            entityIdHash: 'hmac:prior',
+            factsDeleted: 5,
+            edgesDeleted: 2,
+            auditEventsDeleted: 3,
+            episodesDeleted: 1,
+            segmentsDeleted: 4,
+            forgottenAt: '2026-01-01T00:00:00.000Z',
+          },
+        ];
+      return [];
+    });
+    const surreal = {
+      withCompany: async (_c: string, fn: (d: unknown) => Promise<unknown>) => fn(db),
+    } as unknown as SurrealService;
+    const res = await new EntityForgetService(surreal, cfg()).forget({
+      companyId: 'co_x',
+      entityIdRaw: 'knowledge_entity:e',
+      dto: { reason: 'gdpr_request', requestId: 'req-1' } as never,
+      actorKeyHash: 'admin1',
+    });
+
+    // Returns the STORED result verbatim.
+    expect(res.entityIdHash).toBe('hmac:prior');
+    expect(res.factsDeleted).toBe(5);
+    expect(res.edgesDeleted).toBe(2);
+    expect(res.auditEventsDeleted).toBe(3);
+    expect(res.episodesDeleted).toBe(1);
+    expect(res.segmentsDeleted).toBe(4);
+    expect(res.forgottenAt).toBe('2026-01-01T00:00:00.000Z');
+
+    // No re-erase: neither the existence check nor the transaction ran.
+    expect(queries.some((q) => q.sql.includes('BEGIN TRANSACTION'))).toBe(false);
+    expect(queries.some((q) => q.sql.includes('DELETE'))).toBe(false);
+    expect(queries.some((q) => q.sql.includes('type::record'))).toBe(false);
+  });
+});
+
+describe('entity forget → atomicity contract (R4)', () => {
+  it('a transaction failure aborts the erase: the error propagates, no success is reported', async () => {
+    const { db, queries } = makeDb((sql) => {
+      // The single transaction fails (server rolls it back) — the whole
+      // erase must fail loud, never report a partial success.
+      if (sql.includes('BEGIN TRANSACTION'))
+        throw new Error('The query was not executed due to a failed transaction');
+      if (sql.includes('FROM type::record')) return [{ id: 'knowledge_entity:e' }];
+      if (sql.includes('SELECT id FROM knowledge_fact')) return [{ id: 'knowledge_fact:f1' }];
+      return [];
+    });
+    const surreal = {
+      withCompany: async (_c: string, fn: (d: unknown) => Promise<unknown>) => fn(db),
+    } as unknown as SurrealService;
+
+    await expect(
+      new EntityForgetService(surreal, cfg()).forget({
+        companyId: 'co_x',
+        entityIdRaw: 'knowledge_entity:e',
+        dto: { reason: 'gdpr_request', requestId: 'req-1' } as never,
+        actorKeyHash: 'admin1',
+      }),
+    ).rejects.toThrow(/failed transaction/);
+
+    // The transaction WAS attempted (the fix routes the writes through it).
+    const tx = queries.find((q) => q.sql.includes('BEGIN TRANSACTION'));
+    expect(tx).toBeDefined();
+    // The tombstone CREATE is part of that atomic unit — never a separate
+    // write that could survive a rolled-back erase.
+    expect(tx!.sql).toContain('CREATE forgotten_entity');
+    // No DELETE / tombstone CREATE was issued as a standalone statement
+    // outside the transaction.
+    expect(
+      queries.some((q) => !q.sql.includes('BEGIN TRANSACTION') && q.sql.includes('DELETE')),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## R4 audit — atomic GDPR erase + correct the non-firing DB-fence claim

Two findings from the SurrealDB architecture audit. **(A)** is a compliance-correctness fix (release-relevant); **(B)** is doc/comment-only.

### (A) Atomic GDPR erase (`entity-forget.service.ts`)
**Verified:** the erase ran as independent `SELECT`/`DELETE`/`CREATE` inside `withCompany()` (which only does `conn.use()` + `fn(conn)` — no transaction), so a mid-sequence failure could leave a partially-erased subject / deleted data without a `forgotten_entity` tombstone / a surviving audit mirror.

Fix:
- The read phase (existence + id/episode collection) is unchanged; **all deletes + the tombstone now run inside one client-managed transaction** via the **pre-existing `runTransaction`** helper (`surreal.service.ts:773`, `BEGIN…COMMIT` as a single multi-statement query — the only idiom that works on the pinned `surrealdb@2.0.8` driver; separate `query('BEGIN')`/`query('COMMIT')` calls do not).
- **Idempotent `requestId`** keyed on `(requestId, entityIdHash)`: a completed erase replays to the stored tombstone result (never re-erases, never double-errors); a failed attempt leaves no tombstone (atomic), so a retry re-runs cleanly.
- **Transaction-size bounded** (`FORGET_MAX_TX_RECORDS`, default 10000): fan-out over the open-ended tables (audit mirror, segments) is counted and the request **refuses with 413 before any mutation** if it exceeds the cap — chosen over chunk-with-resume, which would need durable progress state (a migration, disallowed here) and reopen the partial-erase window. Documented in `.env.example` + `docs/operations.md`; resumable-chunked erase + `REFERENCE ON DELETE CASCADE` noted as follow-ups.

### (B) Correct the false DB-fence claim (doc/comment only, zero behavior change)
**Verified:** `0057`'s own header + `docs/abac.md` already state the DB-level PERMISSIONS fence "DOES NOT FIRE" for the system `brain_caller` user, yet `withScopedCompany` (~:315) and ~10 other sites still claimed PERMISSIONS apply as an effective barrier. Corrected all of them (`surreal.service.ts`, `0005` header, `docs/architecture.md`, community/stats/procedural/facts/entities services, mcp tools, env-validation messages) to state: the fence does not fire for the system user, **application-layer filters are the effective barrier**, and **Record Access (DEFINE ACCESS … TYPE RECORD WITH JWT)** is the future path. The scoped-connection + `LET` mechanism is left intact for that future work.

### Verification (exit 0)
- `tsc` → 0 · `eslint --max-warnings 0` → 0 · `prettier --check` (src + specs) → 0
- Full unit suite: **294 suites / 2768 tests**; affected specs (forget-l0-cascade incl. new rollback + idempotent tests, env-validation) → 25/25
- **Docker atomicity e2e on loco-321** (throwaway namespace): `entities-forget.e2e-spec` **4/4** — incl. a new atomicity test (seed a tombstone hash-conflict so the transaction's final `CREATE` aborts mid-flight → entity + facts **survive**, nothing partially erased) and an idempotency test (re-forget same `requestId` → same result, one tombstone)
- No paid eval. No migration (only comment edits to already-applied 0005/0057; migrator tracks by filename-id, not content-hash — verified).

Closes R4 finding #4 (GDPR atomicity) and #2 (DB-fence honesty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
