### PR TITLE
fix(db): re-attach audit CHANGEFEED on 3.x-first tenants (migration 0105)

### DIFF
--- a/src/db/migrations/0105_changefeed_overwrite.surql
+++ b/src/db/migrations/0105_changefeed_overwrite.surql
@@ -1,0 +1,52 @@
+-- 0105_changefeed_overwrite — re-attach the audit CHANGEFEED on the three
+-- knowledge tables for SurrealDB-3.x-first tenants.
+--
+-- WHY: migration 0002 attached `CHANGEFEED 30d INCLUDE ORIGINAL` to
+-- knowledge_entity / knowledge_fact / knowledge_edge via
+-- `DEFINE TABLE IF NOT EXISTS …`. That worked on SurrealDB v2, where the
+-- clause was applied to the already-existing table (see the 0002 header
+-- comment). On SurrealDB 3.x, `DEFINE TABLE IF NOT EXISTS` on a table that
+-- already exists (all three are created by 0001) is a FULL no-op — the
+-- CHANGEFEED clause is silently dropped (verified against the v3.2.4
+-- testcontainer; see test/changefeed-drain.e2e-spec.ts, which had to
+-- re-apply the attribute manually before this migration existed). The
+-- result: any tenant database FIRST created under 3.x has no changefeed on
+-- the audit-consumed tables, and the audit drain
+-- (src/audit/changefeed-drain.service.ts, SOURCES = exactly these three
+-- tables) has nothing to read. Tenants migrated under v2.x carry the feed
+-- and are unaffected by the bug.
+--
+-- WHAT: `DEFINE TABLE OVERWRITE` re-declares the table-level attributes,
+-- CHANGEFEED included. Field definitions, indexes, and data are separate
+-- resources and persist untouched (verified in
+-- test/changefeed-migration.e2e-spec.ts, which also pins that RE-applying
+-- the identical definition preserves existing changefeed history — so
+-- 2.x-migrated tenants that already carry a live feed lose neither history
+-- nor drain cursors when this migration runs). knowledge_artifact (0004)
+-- needs no fix: it is FIRST defined with its CHANGEFEED clause, so the
+-- clause applies on creation even under 3.x.
+--
+-- ALTERNATIVES REJECTED:
+--   * Re-running 0002 — same IF NOT EXISTS no-op, changes nothing.
+--   * A narrow "alter changefeed" form — SurrealDB has no
+--     ALTER TABLE … SET CHANGEFEED; OVERWRITE is the supported way to
+--     change table-level attributes in place.
+--
+-- The table-level statements below mirror 0002 (and 0001 for the RELATION
+-- clause) EXACTLY, with only IF NOT EXISTS → OVERWRITE. If a later
+-- migration ever adds table-level attributes (PERMISSIONS, TYPE changes),
+-- it must be reflected here or supersede this file. As of 0105 the only
+-- table-level attributes on these tables are the ones below (0005's PII
+-- permissions are FIELD-level and unaffected by a table re-define).
+--
+-- REMOVAL: safe to drop only after every tenant database has had this
+-- migration applied once (the ledger guarantees that) — the definition is
+-- then durable in each DB's schema.
+
+DEFINE TABLE OVERWRITE knowledge_entity SCHEMAFULL CHANGEFEED 30d INCLUDE ORIGINAL;
+
+DEFINE TABLE OVERWRITE knowledge_fact SCHEMAFULL CHANGEFEED 30d INCLUDE ORIGINAL;
+
+DEFINE TABLE OVERWRITE knowledge_edge SCHEMAFULL TYPE RELATION
+  IN knowledge_entity OUT knowledge_entity
+  CHANGEFEED 30d INCLUDE ORIGINAL;

--- a/test/changefeed-drain.e2e-spec.ts
+++ b/test/changefeed-drain.e2e-spec.ts
@@ -35,18 +35,12 @@ describe('changefeed drain: create/update/delete + idempotent re-drain', () => {
     const surreal = f.app.get(SurrealService);
     const drain = f.app.get(ChangefeedDrainService);
 
-    // Precondition: ensure the CHANGEFEED is live on knowledge_entity.
-    // migration 0002 declares it via `DEFINE TABLE IF NOT EXISTS … CHANGEFEED`,
-    // but on SurrealDB 3.x that is a NO-OP when 0001 already created the table
-    // (verified: the clause is silently dropped) — so a tenant DB first created
-    // under 3.x, like this ephemeral testcontainer, has no changefeed. Tenants
-    // migrated under v2.x (where IF NOT EXISTS DID apply the clause) still carry
-    // it. OVERWRITE re-applies the table-level attribute; fields/indexes persist.
-    await surreal.withCompany(f.companyId, async (db) => {
-      await db.query(
-        'DEFINE TABLE OVERWRITE knowledge_entity SCHEMAFULL CHANGEFEED 30d INCLUDE ORIGINAL',
-      );
-    });
+    // Precondition: the CHANGEFEED on knowledge_entity is attached by
+    // migration 0105 (DEFINE TABLE OVERWRITE) — 0002's IF NOT EXISTS form is a
+    // no-op on SurrealDB 3.x when 0001 already created the table, so this
+    // 3.x-first testcontainer used to need a manual OVERWRITE here. Relying on
+    // the migration doubles as its integration proof; the migration itself is
+    // pinned in changefeed-migration.e2e-spec.ts.
 
     // Seed CREATE → UPDATE → DELETE on a CHANGEFEED table (each is its own
     // versionstamp). `type` is a STRUCTURAL field, so its post-image value

--- a/test/changefeed-migration.e2e-spec.ts
+++ b/test/changefeed-migration.e2e-spec.ts
@@ -1,0 +1,82 @@
+/**
+ * 0105_changefeed_overwrite — the migration itself, against SurrealDB v3.2.4.
+ *
+ * Premise (verified during R4 #92): `DEFINE TABLE IF NOT EXISTS … CHANGEFEED`
+ * in 0002 is a FULL no-op on SurrealDB 3.x when 0001 already created the
+ * table, so a tenant DB first created under 3.x had no changefeed on the
+ * audit-consumed tables. 0105 re-attaches it via DEFINE TABLE OVERWRITE.
+ * This suite pins:
+ *   1. A freshly-migrated tenant (this testcontainer is 3.x-first by
+ *      construction) has a LIVE changefeed on all three drain sources —
+ *      with no manual OVERWRITE anywhere in the fixture.
+ *   2. Table re-definition did not disturb field machinery: the
+ *      canonicalNameLc VALUE field (0002) still computes on create.
+ *   3. RE-applying the identical OVERWRITE — what a 2.x-migrated tenant
+ *      that already carries the feed experiences when 0105 runs — preserves
+ *      the existing changefeed history, so drain cursors survive.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+const SOURCES = ['knowledge_entity', 'knowledge_fact', 'knowledge_edge'] as const;
+
+describe('0105 changefeed overwrite: live feed on a 3.x-first tenant', () => {
+  let f: AppFixture;
+  let surreal: SurrealService;
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_changefeed_mig_e2e' });
+    surreal = f.app.get(SurrealService);
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  const showChanges = (table: (typeof SOURCES)[number]) =>
+    surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[unknown[]]>(
+        `SHOW CHANGES FOR TABLE ${table} SINCE 0 LIMIT 100`,
+      );
+      return (rows as unknown[]) ?? [];
+    });
+
+  it('all three drain sources have a live changefeed after migrations alone', async () => {
+    // On a table WITHOUT a changefeed SHOW CHANGES throws — before 0105 this
+    // loop only passed if the fixture manually re-applied the attribute.
+    for (const table of SOURCES) {
+      await expect(showChanges(table)).resolves.toBeDefined();
+    }
+  });
+
+  it('re-applying the identical OVERWRITE preserves history and field machinery', async () => {
+    const first = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ canonicalNameLc: unknown }>]>(
+        `CREATE knowledge_entity SET type = 'other', canonicalName = 'MixedCase Feed Probe',
+           externalRefs = {} RETURN canonicalNameLc`,
+      );
+      return (rows as Array<{ canonicalNameLc: unknown }>)[0];
+    });
+    // Field survival: the 0002 VALUE field still computes after the table
+    // re-define (OVERWRITE touches table-level attributes only).
+    expect(first?.canonicalNameLc).toBe('mixedcase feed probe');
+
+    const beforeReapply = (await showChanges('knowledge_entity')).length;
+    expect(beforeReapply).toBeGreaterThanOrEqual(1);
+
+    // The 2.x-migrated-tenant path: the feed is already live and 0105 runs
+    // anyway. History recorded before the re-define must remain readable.
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        'DEFINE TABLE OVERWRITE knowledge_entity SCHEMAFULL CHANGEFEED 30d INCLUDE ORIGINAL',
+      );
+      await db.query(
+        `CREATE knowledge_entity SET type = 'other', canonicalName = 'Post Reapply Probe',
+           externalRefs = {}`,
+      );
+    });
+
+    const afterReapply = (await showChanges('knowledge_entity')).length;
+    expect(afterReapply).toBeGreaterThan(beforeReapply);
+  });
+});


### PR DESCRIPTION
## Summary

R4 follow-up: migration `0002` attached `CHANGEFEED 30d INCLUDE ORIGINAL` to `knowledge_entity` / `knowledge_fact` / `knowledge_edge` via `DEFINE TABLE IF NOT EXISTS`. On SurrealDB 3.x that is a **full no-op** when the table already exists (all three are created by `0001`), so a tenant DB first created under 3.x has **no changefeed** on the audit-drain sources — the drain (`ChangefeedDrainService.SOURCES` = exactly these three tables) has nothing to read. Tenants migrated under v2.x carry the feed and are unaffected.

## Changes

- **`0105_changefeed_overwrite.surql`** — `DEFINE TABLE OVERWRITE` for the three tables, mirroring the 0001/0002 table-level attributes exactly plus the CHANGEFEED clause. Fields/indexes/data are separate resources and persist; 0005's PII permissions are field-level and untouched. `knowledge_artifact` (0004) needs no fix — it is *first* defined with its CHANGEFEED clause, which applies on creation even under 3.x.
- **`test/changefeed-migration.e2e-spec.ts`** (new) — pins against the v3.2.4 testcontainer:
  1. a freshly-migrated 3.x-first tenant has a live feed on all three sources with no manual OVERWRITE anywhere in the fixture;
  2. the 0002 `canonicalNameLc` VALUE field still computes after the re-define (field machinery survives);
  3. re-applying the identical OVERWRITE — the 2.x-migrated-tenant path — **preserves existing changefeed history**, so drain cursors survive the migration.
- **`test/changefeed-drain.e2e-spec.ts`** — the manual `DEFINE TABLE OVERWRITE` precondition is removed; the suite now relies on 0105, doubling as its integration proof.

## Safety

Default-off posture unchanged: only the cron tick of the audit drain is flag-gated (`AUDIT_CHANGEFEED_ENABLED`, default off). The migration itself only re-attaches a table-level attribute that 2.x-era tenants already carry; the history-preservation e2e pins that re-applying it is non-destructive.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:e2e -- --testPathPatterns "changefeed-(migration|drain)"` — 2 suites / 3 tests green locally
- [x] prettier clean on touched test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB