### PR TITLE
docs(roadmap): Brain v2 — Evidence Plane / MemoryEpisode / provenance DAG program

### DIFF
--- a/docs/roadmap/brain-v2-2026-08.md
+++ b/docs/roadmap/brain-v2-2026-08.md
@@ -1,0 +1,157 @@
+# Brain v2 — Evidence Plane, MemoryEpisode, and the provenance DAG (2026-08)
+
+Companion to [memory-research-2026-08.md](memory-research-2026-08.md) (the read/write-side
+research program), [fovea-optics-2026-08.md](fovea-optics-2026-08.md) (adaptive serving
+optics), and [sota-gap-build-2026-08.md](sota-gap-build-2026-08.md) (the G1-G9 wave this
+builds on). Source: an external architecture review triggered by the Nature
+complementary-learning-systems paper (hippocampus/cortex consolidation,
+s41467-026-74357-6), plus a code-level critique verified line-by-line against this repo.
+
+The north star, verbatim from the review:
+
+> Brain does not store truth and does not store conversations. It stores observations,
+> versioned reconstructions of events, and the world model they support. Every
+> interpretation must be unrollable back to an observation.
+
+## 1. The three planes
+
+| Plane | Contents | Today's tables | Property |
+|---|---|---|---|
+| **Evidence** | Raw observations. Proof that something *was said*, never that it *is true*. | `episode` (0073), `episode_segment` (0075) | Immutable-ish, PII-redacted at capture, GDPR-erasable, **no changefeed** |
+| **Episodic** | Versioned reconstructions of events: scenes with gist, state deltas, unpredicted details. | `memory_episode` (**new**, 0106) | Rebuildable projection — a newer segmenter re-derives it without destroying anything |
+| **Semantic** | The consolidated world model: claims, summaries, profiles, graph. | `knowledge_fact`, `knowledge_entity`, `knowledge_edge`, `conversation_digest`, profiles | Every claim unrolls to Evidence via the support DAG |
+
+Glossary mapping (architectural language only — no physical renames):
+
+| Review term | Repo object | Note |
+|---|---|---|
+| EvidenceEvent | `episode` row | One raw message; `kind: 'turn'` hardcoded by the sole writer (`src/ingest/episode-store.service.ts:57`) |
+| EvidenceWindow | `episode_segment` row | Positional verbatim window, WINDOW=4/STRIDE=2 (`src/admin/segment-composer.service.ts:26`) |
+| MemoryEpisode / Scene | `memory_episode` row | New first-class primitive between raw and facts |
+| Claim | `knowledge_fact` row | Facts become an index over episodes, not the memory itself |
+| SemanticBelief | `summary_*` facts, profile, graph | Stays facts-shaped in this wave (no new table) |
+
+L0-L3 are **serving-resolution levels**, not storage types: the same memory is servable as
+semantic prior (L0), episodic index (L1), evidence windows (L2), or full raw sessions (L3).
+Foveation = choosing the resolution per query; the storage architecture stays put.
+
+## 2. Verified gaps (each checked in code before this program was cut)
+
+| # | Gap | Where | Consequence |
+|---|---|---|---|
+| 1 | `episode` is a raw evidence event, not a semantic episode | `src/db/migrations/0073_episode_substrate.surql:32` | The episodic plane has no primitive; "scene" is a ≤200-char string riding `knowledge_fact.source` (`src/admin/derive-row-builder.ts:109`) |
+| 2 | Segmentation is positional, not semantic | `src/db/migrations/0075_episode_segment.surql:14` | The docblock itself names SeCom-style topical segmentation "the v2 upgrade" |
+| 3 | L3 anchors come only from `source.episodeIds` of already-retrieved facts | `src/synthesize/l3-escalation.service.ts:260` | The paradox: L3 is most needed exactly when extraction missed the info — which is when no fact anchor exists (`skipped_no_anchor`) |
+| 4 | L3 transcript claims are exempt from citation | `src/synthesize/l3-escalation.service.ts:114` | Consumers get no stable evidence reference; with `FOVEA_REQUIRE_CITATIONS` such answers abstain (`src/synthesize/answer-integrity.ts:54`) |
+| 5 | Provenance is one hop | `src/facts/facts.service.ts:288` | `derivedFrom` is never walked; the support chain exists physically but the resolver stops at `source.episodeIds` |
+| 6 | Promotion summaries carry no episode ids | `src/compaction/promotion-runner.service.ts:225` | `source: {kind:'promotion'}` + `derivedFrom` only → provenance on a summary returns `episodes: []`, while its members leave the read surface as `status='compacted'` |
+| 7 | Usage is self-reinforcing and decay is not tenant-aware | `src/search/internals/scoring.ts:308` (lastReadAt restarts the decay clock), `:374` (readCount multiplier), `:302` (legacy non-tenant `policyFor` while the per-tenant registry exists) | Retrieval alone extends a memory's life; a wrong memory can keep itself alive |
+
+## 3. The program — 8 build PRs, all default-off
+
+Everything ships flag-gated and byte-identical when off. Feature measurement is deferred
+until the paid-eval budget unfreezes; construction and stub-tested correctness are free.
+
+### PR1 — Scenes substrate (shadow), migration 0106
+`memory_episode` + `memory_episode_member` (many-to-many to raw `episode`, with
+role/ord/relevance — one raw event may belong to several scenes, a scene may span
+conversations). Versioned projection: rows carry `segmenterVersion`, rebuilds are an
+atomic per-conversation swap, versions coexist, runs register in the projection registry.
+The v1 segmenter is deterministic (session-gap boundaries via the shared
+`src/episodes/session-window.ts`, plus optional embedding-cosine topic boundaries — zero
+LLM calls). Gist is canonical deterministic TEXT (codec-drift protection: embeddings are
+derived state, text is the contract). `memoryValue` is a vector of optional dims
+(novelty/contradiction/stateChange/identity/explicitness/estimatedUtility +
+`scorerVersion`/`scoredAt`), never a single surprise scalar — the review's U-shape caveat
+makes a monotone "more surprise → more memory" scalar scientifically doubtful, and a
+versioned vector lets a later scorer re-score without lying about provenance.
+Flags: `SCENES_SEGMENTATION_ENABLED`, `SCENES_TOPIC_BOUNDARY`, `SCENES_TOPIC_MIN_COSINE`,
+`SCENES_MAX_TURNS`. Shadow guarantee: writes only its own tables; no serving path reads them.
+
+### PR2 — Scene enrichment + fact backlink
+`SCENES_LLM_ENRICHMENT`: one stub-injectable structured call per scene (abstractive gist,
+full memoryValue, stateDeltas, unexpectedDetails). `SCENES_FACT_BACKLINK`: idempotent
+batch pass stamping `source.memoryEpisodeIds` onto facts whose grounding intersects a
+scene — facts become pointers into the episodic plane, with no migration (the FLEXIBLE
+`source` idiom, `src/admin/derive-row-builder.ts:150`) and no derive-time ordering
+dependency (a re-segmentation just re-runs the backlink).
+
+### PR3 — Evidence plane: episode stamping + recursive provenance closure
+Write side (`PROVENANCE_SUMMARY_EPISODE_STAMP`): promotion / compaction / recompose /
+arc / aggregate composers stamp the union of member `source.episodeIds` forward (cap 64 —
+the `src/admin/window-deriver.service.ts:876` idiom), closing gap #6 for new rows.
+Read side (`PROVENANCE_RECURSIVE_CLOSURE`): a bounded, cycle-safe walker
+(depth/fan-out/episode caps) that follows `derivedFrom` down to grounded members and
+unions their evidence — with the full fence chain applied per hop (tenant, user-scope,
+scope-tags, row-policy, PII), invisible members silently dropped (never a 404 for the
+caller who could see the root), and `filtered`/`truncated` markers on the response.
+No backfill needed: historical summaries have no stamps, but the walker reaches their
+members' stamps; recompose re-stamps whatever its changefeed touches.
+
+### PR4 — L3 anchor independence
+Three per-tenant retrieval fields, consulted **only when fact anchors are empty** (the
+paradox case): `l3DirectAnchor` (BM25 over raw episodes), `l3SegmentAnchor` (segment-lane
+RRF), `l3TemporalAnchor` (parsed query time range → conversations in range — discovery,
+distinct from the existing rank-only preference). Per-source score normalization feeds the
+unchanged session ranker; ladder monotonicity, token caps, and degrade paths untouched.
+
+### PR5 — L3 evidence citations
+`FOVEA_L3_EPISODE_CITATIONS`: transcript lines gain `[episode:<id>]` headers, the prompt's
+citation exemption (gap #4) is replaced by an instruction to cite the supporting turn, and
+a resolver anchors quoted spans via the existing span machinery
+(`src/admin/span-anchor.ts`, code-point offsets). The load-bearing property: only turns
+actually rendered into the transcript are citable — an L3 citation can never name an
+episode the caller couldn't read. `FOVEA_REQUIRE_CITATIONS` accepts episode-cited answers;
+episode-only-cited answers are deliberately not admitted to the answer cache (check-on-read
+cannot invalidate episode citations yet).
+
+### PR6 — Outcome telemetry substrate, migration 0107
+`memory_outcome` (append-only events: retrieved / selected_for_context / used_in_answer /
+verifier_supported / user_confirmed / user_rejected / contradicted; generic over
+fact/episode/belief/evidence subjects; content-free `meta`) + `memory_outcome_stat`
+(write-path rollup, one row per subject). Writers at the natural seams: search assembly,
+synthesize context selection + citation use + verifier support, ingest supersede/compete,
+feedback (replace-aware, anti-farming parity with `retrieval_feedback`). Separate tables
+for the same reason `fact_usage` is separate (0053: the fact table's changefeed,
+dirty-marking event, and ingest mutex must never see read-path traffic). Raw events are
+retention-pruned; the rollup is bounded at one row per subject.
+
+### PR7 — Verified-use serving reads
+The successor signals to gap #7: `verifiedUseDecay` (decay clock may restart at last
+*verified* use, never at mere retrieval), `verifiedUseRanking` (saturating multiplier over
+verified-use + confirmed counts), `tenantDecayPolicy` (scoring resolves half-lives through
+the per-tenant predicate registry — zero extra IO, the snapshot is already warmed for the
+row fence). Legacy usage flags stay untouched with deprecation notes. The pinned
+regression: a stale fact with a fresh `lastReadAt` but no verified use must score exactly
+like its never-read twin.
+
+### PR8 — Retention as resolution + consolidation gate
+`COMPACTION_TENANT_OVERRIDES` converts the process-global retention/promotion thresholds
+into a per-tenant resolution schedule. Promotion gains a corroboration floor
+(`COMPACTION_PROMOTION_MIN_EPISODES`: distinct evidence contexts, not just fact count —
+five facts from one conversation are one witness) and a competing-evidence guard
+(`COMPACTION_PROMOTION_CONFLICT_GUARD`: a contested group aborts loudly instead of folding
+into one summary). The resolution-tier ladder (hot/warm/cold/archive as serving policy,
+not existence) is specified in `brain-v2-resolution-2026-08.md`.
+
+## 4. What is deliberately NOT in this wave
+
+| Item | Why deferred |
+|---|---|
+| RL / learned meta-controller | The review's own ordering: build deterministic policies first, collect outcome telemetry (PR6), train only after there is data to train on |
+| Neural Field layer | Research layer above this substrate, not a product dependency |
+| `SemanticBelief` as a table | `summary_*` facts + `derivedFrom` already carry the shape; a table adds migration/GDPR/read-path cost with no consumer yet |
+| Cross-conversation scene merge pass | Schema supports it (`conversationIds` is an array; membership is many-to-many); no v1 producer — a later `SCENES_` flag |
+| Fine-tuning consolidation (paper's replay→LoRA) | Catastrophic forgetting, per-memory deletability (GDPR), tenant contamination, rollback cost — the "cortex" stays external semantic state |
+| Answer-cache episode-aware check-on-read | Needed only when L3 flip volume justifies caching episode-cited answers |
+| Stat↔raw reconcile job, actor-distinct verified-use | Follow-ups once telemetry shows drift/farming in practice |
+
+## 5. Measurement posture
+
+The paid-eval program is parked; nothing here flips a default or claims a quality number.
+What the wave buys immediately, for free: a provenance chain that actually reaches raw
+evidence (auditable via the facts API), L3 that can fire without a fact anchor (observable
+via `brain_l3_anchor_source_total`), citations on transcript-grounded answers, and outcome
+telemetry that turns "is this memory earning its keep?" from a guess into a query. When
+the eval budget returns, the scenes/verified-use levers are measured like every other
+lever: strict-currency, ablation-mined, confirmed on the full pack before any default flip.

--- a/docs/roadmap/brain-v2-2026-08.md
+++ b/docs/roadmap/brain-v2-2026-08.md
@@ -15,21 +15,21 @@ The north star, verbatim from the review:
 
 ## 1. The three planes
 
-| Plane | Contents | Today's tables | Property |
-|---|---|---|---|
-| **Evidence** | Raw observations. Proof that something *was said*, never that it *is true*. | `episode` (0073), `episode_segment` (0075) | Immutable-ish, PII-redacted at capture, GDPR-erasable, **no changefeed** |
-| **Episodic** | Versioned reconstructions of events: scenes with gist, state deltas, unpredicted details. | `memory_episode` (**new**, 0106) | Rebuildable projection — a newer segmenter re-derives it without destroying anything |
-| **Semantic** | The consolidated world model: claims, summaries, profiles, graph. | `knowledge_fact`, `knowledge_entity`, `knowledge_edge`, `conversation_digest`, profiles | Every claim unrolls to Evidence via the support DAG |
+| Plane        | Contents                                                                                  | Today's tables                                                                          | Property                                                                             |
+| ------------ | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Evidence** | Raw observations. Proof that something _was said_, never that it _is true_.               | `episode` (0073), `episode_segment` (0075)                                              | Immutable-ish, PII-redacted at capture, GDPR-erasable, **no changefeed**             |
+| **Episodic** | Versioned reconstructions of events: scenes with gist, state deltas, unpredicted details. | `memory_episode` (**new**, 0106)                                                        | Rebuildable projection — a newer segmenter re-derives it without destroying anything |
+| **Semantic** | The consolidated world model: claims, summaries, profiles, graph.                         | `knowledge_fact`, `knowledge_entity`, `knowledge_edge`, `conversation_digest`, profiles | Every claim unrolls to Evidence via the support DAG                                  |
 
 Glossary mapping (architectural language only — no physical renames):
 
-| Review term | Repo object | Note |
-|---|---|---|
-| EvidenceEvent | `episode` row | One raw message; `kind: 'turn'` hardcoded by the sole writer (`src/ingest/episode-store.service.ts:57`) |
-| EvidenceWindow | `episode_segment` row | Positional verbatim window, WINDOW=4/STRIDE=2 (`src/admin/segment-composer.service.ts:26`) |
-| MemoryEpisode / Scene | `memory_episode` row | New first-class primitive between raw and facts |
-| Claim | `knowledge_fact` row | Facts become an index over episodes, not the memory itself |
-| SemanticBelief | `summary_*` facts, profile, graph | Stays facts-shaped in this wave (no new table) |
+| Review term           | Repo object                       | Note                                                                                                    |
+| --------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| EvidenceEvent         | `episode` row                     | One raw message; `kind: 'turn'` hardcoded by the sole writer (`src/ingest/episode-store.service.ts:57`) |
+| EvidenceWindow        | `episode_segment` row             | Positional verbatim window, WINDOW=4/STRIDE=2 (`src/admin/segment-composer.service.ts:26`)              |
+| MemoryEpisode / Scene | `memory_episode` row              | New first-class primitive between raw and facts                                                         |
+| Claim                 | `knowledge_fact` row              | Facts become an index over episodes, not the memory itself                                              |
+| SemanticBelief        | `summary_*` facts, profile, graph | Stays facts-shaped in this wave (no new table)                                                          |
 
 L0-L3 are **serving-resolution levels**, not storage types: the same memory is servable as
 semantic prior (L0), episodic index (L1), evidence windows (L2), or full raw sessions (L3).
@@ -37,15 +37,15 @@ Foveation = choosing the resolution per query; the storage architecture stays pu
 
 ## 2. Verified gaps (each checked in code before this program was cut)
 
-| # | Gap | Where | Consequence |
-|---|---|---|---|
-| 1 | `episode` is a raw evidence event, not a semantic episode | `src/db/migrations/0073_episode_substrate.surql:32` | The episodic plane has no primitive; "scene" is a ≤200-char string riding `knowledge_fact.source` (`src/admin/derive-row-builder.ts:109`) |
-| 2 | Segmentation is positional, not semantic | `src/db/migrations/0075_episode_segment.surql:14` | The docblock itself names SeCom-style topical segmentation "the v2 upgrade" |
-| 3 | L3 anchors come only from `source.episodeIds` of already-retrieved facts | `src/synthesize/l3-escalation.service.ts:260` | The paradox: L3 is most needed exactly when extraction missed the info — which is when no fact anchor exists (`skipped_no_anchor`) |
-| 4 | L3 transcript claims are exempt from citation | `src/synthesize/l3-escalation.service.ts:114` | Consumers get no stable evidence reference; with `FOVEA_REQUIRE_CITATIONS` such answers abstain (`src/synthesize/answer-integrity.ts:54`) |
-| 5 | Provenance is one hop | `src/facts/facts.service.ts:288` | `derivedFrom` is never walked; the support chain exists physically but the resolver stops at `source.episodeIds` |
-| 6 | Promotion summaries carry no episode ids | `src/compaction/promotion-runner.service.ts:225` | `source: {kind:'promotion'}` + `derivedFrom` only → provenance on a summary returns `episodes: []`, while its members leave the read surface as `status='compacted'` |
-| 7 | Usage is self-reinforcing and decay is not tenant-aware | `src/search/internals/scoring.ts:308` (lastReadAt restarts the decay clock), `:374` (readCount multiplier), `:302` (legacy non-tenant `policyFor` while the per-tenant registry exists) | Retrieval alone extends a memory's life; a wrong memory can keep itself alive |
+| #   | Gap                                                                      | Where                                                                                                                                                                                   | Consequence                                                                                                                                                          |
+| --- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `episode` is a raw evidence event, not a semantic episode                | `src/db/migrations/0073_episode_substrate.surql:32`                                                                                                                                     | The episodic plane has no primitive; "scene" is a ≤200-char string riding `knowledge_fact.source` (`src/admin/derive-row-builder.ts:109`)                            |
+| 2   | Segmentation is positional, not semantic                                 | `src/db/migrations/0075_episode_segment.surql:14`                                                                                                                                       | The docblock itself names SeCom-style topical segmentation "the v2 upgrade"                                                                                          |
+| 3   | L3 anchors come only from `source.episodeIds` of already-retrieved facts | `src/synthesize/l3-escalation.service.ts:260`                                                                                                                                           | The paradox: L3 is most needed exactly when extraction missed the info — which is when no fact anchor exists (`skipped_no_anchor`)                                   |
+| 4   | L3 transcript claims are exempt from citation                            | `src/synthesize/l3-escalation.service.ts:114`                                                                                                                                           | Consumers get no stable evidence reference; with `FOVEA_REQUIRE_CITATIONS` such answers abstain (`src/synthesize/answer-integrity.ts:54`)                            |
+| 5   | Provenance is one hop                                                    | `src/facts/facts.service.ts:288`                                                                                                                                                        | `derivedFrom` is never walked; the support chain exists physically but the resolver stops at `source.episodeIds`                                                     |
+| 6   | Promotion summaries carry no episode ids                                 | `src/compaction/promotion-runner.service.ts:225`                                                                                                                                        | `source: {kind:'promotion'}` + `derivedFrom` only → provenance on a summary returns `episodes: []`, while its members leave the read surface as `status='compacted'` |
+| 7   | Usage is self-reinforcing and decay is not tenant-aware                  | `src/search/internals/scoring.ts:308` (lastReadAt restarts the decay clock), `:374` (readCount multiplier), `:302` (legacy non-tenant `policyFor` while the per-tenant registry exists) | Retrieval alone extends a memory's life; a wrong memory can keep itself alive                                                                                        |
 
 ## 3. The program — 8 build PRs, all default-off
 
@@ -53,6 +53,7 @@ Everything ships flag-gated and byte-identical when off. Feature measurement is 
 until the paid-eval budget unfreezes; construction and stub-tested correctness are free.
 
 ### PR1 — Scenes substrate (shadow), migration 0106
+
 `memory_episode` + `memory_episode_member` (many-to-many to raw `episode`, with
 role/ord/relevance — one raw event may belong to several scenes, a scene may span
 conversations). Versioned projection: rows carry `segmenterVersion`, rebuilds are an
@@ -69,6 +70,7 @@ Flags: `SCENES_SEGMENTATION_ENABLED`, `SCENES_TOPIC_BOUNDARY`, `SCENES_TOPIC_MIN
 `SCENES_MAX_TURNS`. Shadow guarantee: writes only its own tables; no serving path reads them.
 
 ### PR2 — Scene enrichment + fact backlink
+
 `SCENES_LLM_ENRICHMENT`: one stub-injectable structured call per scene (abstractive gist,
 full memoryValue, stateDeltas, unexpectedDetails). `SCENES_FACT_BACKLINK`: idempotent
 batch pass stamping `source.memoryEpisodeIds` onto facts whose grounding intersects a
@@ -77,6 +79,7 @@ scene — facts become pointers into the episodic plane, with no migration (the 
 dependency (a re-segmentation just re-runs the backlink).
 
 ### PR3 — Evidence plane: episode stamping + recursive provenance closure
+
 Write side (`PROVENANCE_SUMMARY_EPISODE_STAMP`): promotion / compaction / recompose /
 arc / aggregate composers stamp the union of member `source.episodeIds` forward (cap 64 —
 the `src/admin/window-deriver.service.ts:876` idiom), closing gap #6 for new rows.
@@ -89,6 +92,7 @@ No backfill needed: historical summaries have no stamps, but the walker reaches 
 members' stamps; recompose re-stamps whatever its changefeed touches.
 
 ### PR4 — L3 anchor independence
+
 Three per-tenant retrieval fields, consulted **only when fact anchors are empty** (the
 paradox case): `l3DirectAnchor` (BM25 over raw episodes), `l3SegmentAnchor` (segment-lane
 RRF), `l3TemporalAnchor` (parsed query time range → conversations in range — discovery,
@@ -96,6 +100,7 @@ distinct from the existing rank-only preference). Per-source score normalization
 unchanged session ranker; ladder monotonicity, token caps, and degrade paths untouched.
 
 ### PR5 — L3 evidence citations
+
 `FOVEA_L3_EPISODE_CITATIONS`: transcript lines gain `[episode:<id>]` headers, the prompt's
 citation exemption (gap #4) is replaced by an instruction to cite the supporting turn, and
 a resolver anchors quoted spans via the existing span machinery
@@ -106,6 +111,7 @@ episode-only-cited answers are deliberately not admitted to the answer cache (ch
 cannot invalidate episode citations yet).
 
 ### PR6 — Outcome telemetry substrate, migration 0107
+
 `memory_outcome` (append-only events: retrieved / selected_for_context / used_in_answer /
 verifier_supported / user_confirmed / user_rejected / contradicted; generic over
 fact/episode/belief/evidence subjects; content-free `meta`) + `memory_outcome_stat`
@@ -117,8 +123,9 @@ dirty-marking event, and ingest mutex must never see read-path traffic). Raw eve
 retention-pruned; the rollup is bounded at one row per subject.
 
 ### PR7 — Verified-use serving reads
+
 The successor signals to gap #7: `verifiedUseDecay` (decay clock may restart at last
-*verified* use, never at mere retrieval), `verifiedUseRanking` (saturating multiplier over
+_verified_ use, never at mere retrieval), `verifiedUseRanking` (saturating multiplier over
 verified-use + confirmed counts), `tenantDecayPolicy` (scoring resolves half-lives through
 the per-tenant predicate registry — zero extra IO, the snapshot is already warmed for the
 row fence). Legacy usage flags stay untouched with deprecation notes. The pinned
@@ -126,6 +133,7 @@ regression: a stale fact with a fresh `lastReadAt` but no verified use must scor
 like its never-read twin.
 
 ### PR8 — Retention as resolution + consolidation gate
+
 `COMPACTION_TENANT_OVERRIDES` converts the process-global retention/promotion thresholds
 into a per-tenant resolution schedule. Promotion gains a corroboration floor
 (`COMPACTION_PROMOTION_MIN_EPISODES`: distinct evidence contexts, not just fact count —
@@ -136,15 +144,15 @@ not existence) is specified in `brain-v2-resolution-2026-08.md`.
 
 ## 4. What is deliberately NOT in this wave
 
-| Item | Why deferred |
-|---|---|
-| RL / learned meta-controller | The review's own ordering: build deterministic policies first, collect outcome telemetry (PR6), train only after there is data to train on |
-| Neural Field layer | Research layer above this substrate, not a product dependency |
-| `SemanticBelief` as a table | `summary_*` facts + `derivedFrom` already carry the shape; a table adds migration/GDPR/read-path cost with no consumer yet |
-| Cross-conversation scene merge pass | Schema supports it (`conversationIds` is an array; membership is many-to-many); no v1 producer — a later `SCENES_` flag |
-| Fine-tuning consolidation (paper's replay→LoRA) | Catastrophic forgetting, per-memory deletability (GDPR), tenant contamination, rollback cost — the "cortex" stays external semantic state |
-| Answer-cache episode-aware check-on-read | Needed only when L3 flip volume justifies caching episode-cited answers |
-| Stat↔raw reconcile job, actor-distinct verified-use | Follow-ups once telemetry shows drift/farming in practice |
+| Item                                                | Why deferred                                                                                                                               |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| RL / learned meta-controller                        | The review's own ordering: build deterministic policies first, collect outcome telemetry (PR6), train only after there is data to train on |
+| Neural Field layer                                  | Research layer above this substrate, not a product dependency                                                                              |
+| `SemanticBelief` as a table                         | `summary_*` facts + `derivedFrom` already carry the shape; a table adds migration/GDPR/read-path cost with no consumer yet                 |
+| Cross-conversation scene merge pass                 | Schema supports it (`conversationIds` is an array; membership is many-to-many); no v1 producer — a later `SCENES_` flag                    |
+| Fine-tuning consolidation (paper's replay→LoRA)     | Catastrophic forgetting, per-memory deletability (GDPR), tenant contamination, rollback cost — the "cortex" stays external semantic state  |
+| Answer-cache episode-aware check-on-read            | Needed only when L3 flip volume justifies caching episode-cited answers                                                                    |
+| Stat↔raw reconcile job, actor-distinct verified-use | Follow-ups once telemetry shows drift/farming in practice                                                                                  |
 
 ## 5. Measurement posture
 


### PR DESCRIPTION
## Summary

Roadmap doc for the Brain v2 wave, distilled from an external architecture review (Nature complementary-learning-systems paper + a code-level critique). Every code claim in the review was verified against the repo first; the seven confirmed gaps are tabulated with file:line.

The doc establishes:
- **Three planes** (Evidence / Episodic / Semantic) and the glossary mapping onto existing tables — no physical renames.
- **L0-L3 as serving-resolution levels**, decoupled from storage.
- The **8-PR default-off build program**: scenes substrate (0106) → enrichment+backlink → provenance stamping + recursive closure → L3 anchor independence → L3 evidence citations → outcome telemetry (0107) → verified-use serving reads → retention-as-resolution + consolidation gate.
- **Deliberate deferrals** with reasons: RL meta-controller (telemetry first), Neural Field, SemanticBelief table, fine-tuning consolidation (forgetting/deletability/tenant-contamination), cross-conversation scene merge.

Docs only — no code changes. Measurement stays parked with the paid-eval budget; the wave ships flag-gated and byte-identical off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB