### PR TITLE
feat(scenes): memory_episode shadow substrate — versioned scene segmentation over raw episodes (0106)

### DIFF
--- a/src/admin/admin-scenes.controller.ts
+++ b/src/admin/admin-scenes.controller.ts
@@ -1,0 +1,39 @@
+import { Body, Controller, NotFoundException, Post, Req, UseGuards } from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { AuthenticatedRequest } from '../auth/api-key.types';
+import { ApiKeyService } from '../auth/api-key.service';
+import { resolvePlatformTenant } from '../auth/tenant-scope';
+import { sceneSegmentationEnabled } from '../common/scene-flags';
+import { SceneComposerService, SceneRunResult } from './scene-composer.service';
+
+/**
+ * Explicit trigger for the Brain v2 scene composer (shadow memory_episode
+ * substrate, migration 0106). LLM-free; embedding cost only when
+ * SCENES_TOPIC_BOUNDARY is on. Idempotent per (conversation ×
+ * segmenterVersion) — atomic delete-then-insert swap. Flag off ⇒ the
+ * route 404s (SCENES_SEGMENTATION_ENABLED, read at call time).
+ */
+@Controller('v1/admin')
+@UseGuards(ApiKeyGuard)
+export class AdminScenesController {
+  constructor(
+    private readonly composer: SceneComposerService,
+    private readonly apiKeys: ApiKeyService,
+  ) {}
+
+  @Post('maintenance/scenes')
+  @RequireScopes('brain:admin')
+  async run(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { tenant?: string; conversationId?: string } = {},
+  ): Promise<SceneRunResult> {
+    if (!sceneSegmentationEnabled()) throw new NotFoundException();
+    const tenant = resolvePlatformTenant(req, body.tenant, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
+    return this.composer.run(
+      tenant,
+      body.conversationId !== undefined ? { conversationId: body.conversationId } : {},
+    );
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -43,6 +43,8 @@ import { ProjectionsController } from './projections.controller';
 import { WindowDeriverService } from './window-deriver.service';
 import { AdminSegmentsController } from './admin-segments.controller';
 import { SegmentComposerService } from './segment-composer.service';
+import { AdminScenesController } from './admin-scenes.controller';
+import { SceneComposerService } from './scene-composer.service';
 import { HnswMaintenanceService } from './hnsw-maintenance.service';
 import { CodeMemoryModule } from '../code-memory/code-memory.module';
 import { RegistryModule } from '../registry/registry.module';
@@ -109,6 +111,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     AdminAggregatesController,
     AdminDeriveController,
     AdminSegmentsController,
+    AdminScenesController,
     ProjectionsController,
   ],
   providers: [
@@ -118,6 +121,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     ArcComposerService,
     WindowDeriverService,
     SegmentComposerService,
+    SceneComposerService,
     AdminInfraService,
     HealthComponentsService,
     LiveSnapshotService,

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -491,6 +491,53 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Fovea optics (verifier answer-integrity arm, Part C): treat a `supported` verdict whose answer carries ZERO citations as low_coverage/abstain instead of serving an uncited "supported" answer (audit F2(b)). LIVE-behavior change when enabled — prod answers can shift, so default off until the owner enables + validates. Off = byte-identical serving.',
   },
+  // ── Scenes (Brain v2) ──
+  {
+    key: 'SCENES_SEGMENTATION_ENABLED',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneSegmentationEnabled) by the
+    // admin controller 404 guard + the composer's defensive early return
+    // — never captured in a constructor — so a flip takes effect without
+    // restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Scenes shadow substrate (Brain v2 PR1, migration 0106): enable the batch scene composer + POST /v1/admin/maintenance/scenes. Shadow — no serving path reads memory_episode. Off = route 404s, no scene row is ever written, byte-identical prod.',
+  },
+  {
+    key: 'SCENES_TOPIC_BOUNDARY',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneTopicBoundaryEnabled) per
+    // composer run — never captured in a constructor — runtime-mutable.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Scenes: within-session topic-boundary refinement — ONE embedding batch per conversation (the surface’s only paid step; no LLM anywhere) and a cosine split below SCENES_TOPIC_MIN_COSINE. Off = session-gap + max-turns segmentation only, embedder-free.',
+  },
+  {
+    key: 'SCENES_TOPIC_MIN_COSINE',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneTopicMinCosine) per composer
+    // run — never captured in a constructor — runtime-mutable.
+    defaultValue: '0.55',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Scenes: split between turns when cosine(mean of the last 3 member embeddings, next turn) < this floor, in [-1,1]. Ignored unless SCENES_TOPIC_BOUNDARY is on. Default 0.55.',
+  },
+  {
+    key: 'SCENES_MAX_TURNS',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneMaxTurns) per composer run —
+    // never captured in a constructor — runtime-mutable.
+    defaultValue: '40',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Scenes: force a scene boundary once a scene reaches this many turns, regardless of topic continuity. Positive integer; default 40.',
+  },
   // ── Multilingual (Tier 1, migration 0100) ───────────
   {
     key: 'MULTILINGUAL_LANG_ATTRIBUTION',

--- a/src/admin/config-inspector.service.ts
+++ b/src/admin/config-inspector.service.ts
@@ -13,6 +13,7 @@ export type ConfigCategory =
   | 'search'
   | 'multihop'
   | 'calibration'
+  | 'scenes'
   | 'conflict'
   | 'cost'
   | 'throttle'

--- a/src/admin/scene-composer.service.ts
+++ b/src/admin/scene-composer.service.ts
@@ -214,13 +214,25 @@ export class SceneComposerService {
     // previous set or the new one, never neither, and other segmenter
     // versions are untouched. No graph-arrow syntax anywhere (0106 note):
     // in/out are filtered as plain record fields.
+    //
+    // Member delete is two-step (SELECT ids → DELETE $ids) DELIBERATELY:
+    // on SurrealDB 3.2.4 a DELETE whose WHERE filters on `in` — covered
+    // only by the COMPOUND scene_member_uq index — can silently match
+    // NOTHING, while the same WHERE in a SELECT matches fine — verified
+    // against the pinned server. Deleting by explicit ids sidesteps the
+    // planner entirely (same bug class as preSweepOutcomeRows, PR #372).
+    // A silent no-op here would abort the whole swap on the UNIQUE
+    // (in, out) index at re-insert time.
     await runTransaction(db as unknown as Surreal, (tx) =>
       tx
         .add(
           `LET $scenes = (SELECT VALUE id FROM memory_episode
              WHERE conversationIds CONTAINS $conv AND segmenterVersion = $v)`,
         )
-        .add(`DELETE memory_episode_member WHERE in INSIDE $scenes`)
+        .add(
+          `LET $oldMemberIds = (SELECT VALUE id FROM memory_episode_member WHERE in INSIDE $scenes)`,
+        )
+        .add(`DELETE $oldMemberIds`)
         .add(`DELETE memory_episode WHERE id INSIDE $scenes`)
         .add(`INSERT INTO memory_episode $sceneRows`)
         .add(`INSERT RELATION INTO memory_episode_member $memberRows`)

--- a/src/admin/scene-composer.service.ts
+++ b/src/admin/scene-composer.service.ts
@@ -1,0 +1,242 @@
+import { createHash } from 'node:crypto';
+import { Injectable, Logger } from '@nestjs/common';
+import { RecordId, StringRecordId, type Surreal } from 'surrealdb';
+import { SurrealService, runTransaction } from '../db/surreal.service';
+import { FactEmbeddingService } from '../ingest/fact-embedding.service';
+import { EpisodeReadStoreService } from '../episodes/episode-read-store.service';
+import { ProjectionRegistryService } from '../episodes/projection-registry.service';
+import { scopeForUser } from '../auth/scope-tags';
+import { segmentSessions } from '../episodes/session-window';
+import {
+  sceneMaxTurns,
+  sceneSegmentationEnabled,
+  sceneTopicBoundaryEnabled,
+  sceneTopicMinCosine,
+} from '../common/scene-flags';
+import {
+  detectSceneBoundaries,
+  foldSceneScope,
+  meanVector,
+  renderSceneGist,
+  renderSceneLabel,
+  scoreSceneDeterministic,
+  type SceneTurnRow,
+} from './scene-segmentation';
+
+/**
+ * Scene composer (Brain v2 PR1): batch-derives the SHADOW memory_episode
+ * substrate (migration 0106) — versioned scenes over the immutable L0
+ * episode substrate — plus memory_episode_member rows binding each scene
+ * to its exact member turns. Mirrors SegmentComposerService: LLM-free
+ * (the only paid step is ONE optional embedding batch per conversation,
+ * and only when SCENES_TOPIC_BOUNDARY is on), idempotent per
+ * (conversation × segmenterVersion), and atomic — the paid batch runs
+ * BEFORE any delete, then the old scene set of THIS segmenter version is
+ * swapped for the new one in a single transaction. Other segmenter
+ * versions' scenes are untouched, so competing segmenters coexist.
+ *
+ * SHADOW GUARANTEE: this service writes ONLY memory_episode /
+ * memory_episode_member / projection rows. Nothing on the serving path
+ * reads them — prod behavior is byte-identical whether it runs or not.
+ * Lifecycle is recorded in the projection registry ('scenes'); a scene
+ * world is only ever 'built', NEVER 'live' — there is no reader to flip.
+ */
+export const SCENE_RECORDER = 'scene-composer-v1';
+export const SEGMENTER_VERSION = 'scene-segmenter-v1';
+/** sceneLabel budget enforced in code (the 0106 header's ≤200 contract). */
+const SCENE_LABEL_MAX = 200;
+
+export interface SceneRunResult {
+  conversations: number;
+  scenes: number;
+  skipped: Array<{ conversationId: string; reason: string }>;
+}
+
+@Injectable()
+export class SceneComposerService {
+  private readonly logger = new Logger(SceneComposerService.name);
+
+  // Fourth dep is the projection-registry ledger (observes the lifecycle,
+  // never fails it — every registry write degrades to a warning).
+  // eslint-disable-next-line max-params
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly embedding: FactEmbeddingService,
+    private readonly episodes: EpisodeReadStoreService,
+    private readonly registry: ProjectionRegistryService,
+  ) {}
+
+  async run(companyId: string, opts: { conversationId?: string } = {}): Promise<SceneRunResult> {
+    const result: SceneRunResult = { conversations: 0, scenes: 0, skipped: [] };
+    // Defense in depth: the controller already 404s with the flag off; a
+    // programmatic caller must not write shadow rows past a disabled flag.
+    if (!sceneSegmentationEnabled()) return result;
+    // One generation stamp per run (0081 idiom): every row written by this
+    // rebuild carries it, so a partially-failed run is observable
+    // (conversations still on the old generation = swaps that never landed).
+    const generation = new Date().toISOString();
+    await this.registry.begin({
+      companyId,
+      name: 'scenes',
+      version: SEGMENTER_VERSION,
+      builder: SCENE_RECORDER,
+    });
+    try {
+      await this.surreal.withCompany(companyId, async (db) => {
+        const convs = await this.episodes.conversationCounts(db);
+        for (const conv of convs) {
+          const conversationId = conv.conversationId;
+          // Targeted rebuild: one conversation should not force a full
+          // tenant re-run (and vice versa).
+          if (opts.conversationId && conversationId !== opts.conversationId) continue;
+          try {
+            await this.composeConversation({ db, conversationId, result, generation });
+            result.conversations += 1;
+          } catch (e) {
+            result.skipped.push({ conversationId, reason: (e as Error).message });
+            this.logger.warn(`scene compose failed for ${conversationId}: ${(e as Error).message}`);
+          }
+        }
+      });
+    } catch (e) {
+      await this.registry.fail({ companyId, name: 'scenes', version: SEGMENTER_VERSION });
+      throw e;
+    }
+    // 'built', never 'live': the scene world has no serving reader to
+    // promote to — activation semantics arrive with the first read lane.
+    await this.registry.complete({
+      companyId,
+      name: 'scenes',
+      version: SEGMENTER_VERSION,
+      live: false,
+      stats: {
+        conversations: result.conversations,
+        scenes: result.scenes,
+        skipped: result.skipped.length,
+      },
+    });
+    return result;
+  }
+
+  private async composeConversation({
+    db,
+    conversationId,
+    result,
+    generation,
+  }: {
+    db: { query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T> };
+    conversationId: string;
+    result: SceneRunResult;
+    generation: string;
+  }): Promise<void> {
+    const turns = (await this.episodes.conversationTurnsRaw(db, conversationId)) as SceneTurnRow[];
+    if (turns.length === 0) return;
+
+    // Paid step BEFORE any delete (segment-composer rule): an embedding
+    // failure leaves the old scene set intact instead of an emptied
+    // conversation. ONE batch per conversation, and only when the topic
+    // boundary is on — the default segmenter is embedder-free.
+    let vectors: number[][] | undefined;
+    if (sceneTopicBoundaryEnabled()) {
+      vectors = await this.embedding.embedMany(turns.map((t) => t.text));
+    }
+
+    // Session boundaries first (shared 60-min gap rule), then the
+    // within-session detector. Sessions partition `turns` in order, so a
+    // running offset maps each session onto its embedding slice.
+    const boundaryOpts = { minCosine: sceneTopicMinCosine(), maxTurns: sceneMaxTurns() };
+    const scenes: SceneTurnRow[][] = [];
+    let offset = 0;
+    for (const session of segmentSessions(turns) as SceneTurnRow[][]) {
+      const sessionVecs = vectors?.slice(offset, offset + session.length);
+      offset += session.length;
+      scenes.push(...detectSceneBoundaries(session, sessionVecs, boundaryOpts));
+    }
+    if (scenes.length === 0) return;
+
+    // Build scene + member rows. Scene record ids are deterministic over
+    // (conversation, segmenterVersion, index) so a rebuild replaces the
+    // same identities. gistEmbedding is deliberately NOT written in v1 —
+    // it is the gist TEXT's vector, not the member-turn centroid we
+    // compute for novelty; the PR2 encoder pass backfills it.
+    const priorCentroids: number[][] = [];
+    const sceneRows: Array<Record<string, unknown>> = [];
+    const memberRows: Array<Record<string, unknown>> = [];
+    let sceneOffset = 0;
+    for (const [index, scene] of scenes.entries()) {
+      const sceneVecs = (vectors?.slice(sceneOffset, sceneOffset + scene.length) ?? []).filter(
+        (v): v is number[] => Array.isArray(v),
+      );
+      sceneOffset += scene.length;
+      const centroid = sceneVecs.length > 0 ? meanVector(sceneVecs) : undefined;
+      const memoryValue = scoreSceneDeterministic(centroid, priorCentroids, scene);
+      if (centroid) priorCentroids.push(centroid);
+      const fold = foldSceneScope(scene);
+      const first = scene[0]!; // scenes are non-empty by construction
+      const last = scene[scene.length - 1]!;
+      const sceneId = new RecordId('memory_episode', this.sceneIdTail(conversationId, index));
+      sceneRows.push({
+        id: sceneId,
+        // Scope/PII fold — same rule as segment-composer :147-160: pii is
+        // the member union; userId only when single-user; a mixed-user
+        // scene stays tenant-global (scopeForUser(undefined) = []).
+        piiClass: fold.piiClass,
+        userId: fold.userId,
+        scope: scopeForUser(fold.userId),
+        sceneLabel: renderSceneLabel(scene).slice(0, SCENE_LABEL_MAX),
+        conversationIds: [conversationId],
+        occurredFrom: new Date(first.occurredAt as string),
+        occurredTo: new Date(last.occurredAt as string),
+        gist: renderSceneGist(scene),
+        memoryValue,
+        // The deterministic segmenter is exact about its own rule — the
+        // knob for "how sure was the boundary model" arrives with a
+        // learned segmenter.
+        confidence: 1,
+        segmenterVersion: SEGMENTER_VERSION,
+        generation,
+        source: { recorder: SCENE_RECORDER },
+      });
+      for (const [ord, turn] of scene.entries()) {
+        memberRows.push({
+          in: sceneId,
+          out: new StringRecordId(String(turn.id)),
+          role: 'core',
+          ord,
+          relevance: 1,
+          segmenterVersion: SEGMENTER_VERSION,
+        });
+      }
+    }
+
+    // Atomic swap per (conversation × segmenterVersion): old scene set of
+    // THIS version out, new set in, one transaction — readers see the
+    // previous set or the new one, never neither, and other segmenter
+    // versions are untouched. No graph-arrow syntax anywhere (0106 note):
+    // in/out are filtered as plain record fields.
+    await runTransaction(db as unknown as Surreal, (tx) =>
+      tx
+        .add(
+          `LET $scenes = (SELECT VALUE id FROM memory_episode
+             WHERE conversationIds CONTAINS $conv AND segmenterVersion = $v)`,
+        )
+        .add(`DELETE memory_episode_member WHERE in INSIDE $scenes`)
+        .add(`DELETE memory_episode WHERE id INSIDE $scenes`)
+        .add(`INSERT INTO memory_episode $sceneRows`)
+        .add(`INSERT RELATION INTO memory_episode_member $memberRows`)
+        .bind('conv', conversationId)
+        .bind('v', SEGMENTER_VERSION)
+        .bind('sceneRows', sceneRows)
+        .bind('memberRows', memberRows),
+    );
+    result.scenes += sceneRows.length;
+  }
+
+  /** Deterministic scene id tail over (conversation, version, index). */
+  private sceneIdTail(conversationId: string, index: number): string {
+    return createHash('sha256')
+      .update(`${conversationId}|${SEGMENTER_VERSION}|${index}`)
+      .digest('hex')
+      .slice(0, 24);
+  }
+}

--- a/src/admin/scene-segmentation.ts
+++ b/src/admin/scene-segmentation.ts
@@ -1,0 +1,233 @@
+import { cosineSimilarity } from '../common/vector-math';
+import type { EpisodeRow } from '../episodes/session-window';
+
+/**
+ * Pure scene segmentation + deterministic rendering/scoring for the
+ * Brain v2 shadow Scenes substrate (memory_episode, migration 0106).
+ *
+ * No NestJS, no DB, no env reads — mirrors session-window.ts: the
+ * composer (scene-composer.service.ts) resolves flags/knobs and passes
+ * plain values in. Sessions come PRE-SPLIT via segmentSessions (the
+ * shared 60-min-gap convention) — `detectSceneBoundaries` works WITHIN
+ * one session; the session gap itself is therefore always a scene
+ * boundary by construction. Everything here is deterministic: the same
+ * turns (and the same embeddings, when provided) always produce the
+ * same scenes, gists, labels, and scores.
+ */
+
+/** Member turn shape — the raw L0 read row (piiClass rides for folding). */
+export interface SceneTurnRow extends EpisodeRow {
+  piiClass?: string[];
+}
+
+/** Options for the within-session boundary detector. */
+export interface SceneBoundaryOpts {
+  /** Split when cosine(mean of last 3 turns, next turn) < this floor. */
+  minCosine: number;
+  /** Force a boundary once a scene reaches this many turns. */
+  maxTurns: number;
+}
+
+/** Trailing-context width for the topic-boundary cosine test. */
+const TOPIC_TAIL_TURNS = 3;
+/** A cosine split never leaves a scene shorter than this. */
+const MIN_SCENE_TURNS = 2;
+
+/** Element-wise mean of equal-length vectors ([] for empty input). */
+export function meanVector(vectors: number[][]): number[] {
+  if (vectors.length === 0) return [];
+  const dim = vectors[0]!.length;
+  const out = new Array<number>(dim).fill(0);
+  for (const v of vectors) {
+    for (let i = 0; i < dim && i < v.length; i++) out[i]! += v[i]!;
+  }
+  for (let i = 0; i < dim; i++) out[i]! /= vectors.length;
+  return out;
+}
+
+/**
+ * Pure: split ONE session's time-ordered turns into scenes.
+ *
+ *  - Without embeddings: a single scene, force-split at maxTurns — the
+ *    session gap (handled upstream by segmentSessions) is the only
+ *    semantic boundary the embedder-free mode knows.
+ *  - With embeddings (parallel to `turns`, entries may be missing):
+ *    additionally split between turn i-1 and i when cosine(mean of the
+ *    last TOPIC_TAIL_TURNS turns' embeddings, embedding[i]) < minCosine,
+ *    never leaving a scene shorter than MIN_SCENE_TURNS.
+ *  - Always force-split at maxTurns, embeddings or not.
+ */
+export function detectSceneBoundaries<T extends SceneTurnRow>(
+  sessionTurns: T[],
+  embeddings: Array<number[] | undefined> | undefined,
+  opts: SceneBoundaryOpts,
+): T[][] {
+  if (sessionTurns.length === 0) return [];
+  const maxTurns = Math.max(1, Math.floor(opts.maxTurns));
+  const scenes: T[][] = [];
+  let current: T[] = [sessionTurns[0]!];
+  let currentStart = 0;
+  for (let i = 1; i < sessionTurns.length; i++) {
+    let boundary = false;
+    if (current.length >= maxTurns) {
+      boundary = true;
+    } else if (embeddings && current.length >= MIN_SCENE_TURNS) {
+      const tailFrom = Math.max(currentStart, i - TOPIC_TAIL_TURNS);
+      const tail: number[][] = [];
+      for (let j = tailFrom; j < i; j++) {
+        const v = embeddings[j];
+        if (v) tail.push(v);
+      }
+      const next = embeddings[i];
+      if (tail.length > 0 && next) {
+        boundary = cosineSimilarity(meanVector(tail), next) < opts.minCosine;
+      }
+    }
+    if (boundary) {
+      scenes.push(current);
+      current = [];
+      currentStart = i;
+    }
+    current.push(sessionTurns[i]!);
+  }
+  scenes.push(current);
+  return scenes;
+}
+
+/**
+ * Assistant-role detection: case-insensitive speaker SUFFIX, matching the
+ * assistant-lane convention (retrieval-profile.ts assistantLaneMatch —
+ * harness speakers are `<convSlug>__<role>`). A scene of only assistant
+ * turns falls back to its first turn.
+ */
+function isAssistantSpeaker(speaker: string | undefined): boolean {
+  return (speaker ?? '').toLowerCase().endsWith('assistant');
+}
+
+function firstNonAssistant<T extends SceneTurnRow>(turns: T[]): T {
+  return turns.find((t) => !isAssistantSpeaker(t.speaker)) ?? turns[0]!;
+}
+
+/** Deterministic trim: collapse whitespace runs, cut at `max` chars. */
+function trimTo(text: string, max: number): string {
+  return text.replace(/\s+/g, ' ').trim().slice(0, max);
+}
+
+const OPENER_CLOSER_CHARS = 160;
+const LABEL_CHARS = 80;
+
+function isoOf(occurredAt: string | Date): string {
+  return occurredAt instanceof Date ? occurredAt.toISOString() : new Date(occurredAt).toISOString();
+}
+
+/**
+ * Canonical deterministic scene gist TEXT:
+ *   `<YYYY-MM-DD HH:mm>–<HH:mm> · <speakers> · <N> turns — opens: "…" — closes: "…"`
+ * UTC timestamps; speakers are distinct, in order of first appearance.
+ * PII-safe by construction — member turns are already redacted at capture
+ * (0073), and the gist only ever quotes member text verbatim.
+ */
+export function renderSceneGist(turns: SceneTurnRow[]): string {
+  const first = turns[0]!;
+  const last = turns[turns.length - 1]!;
+  const fromIso = isoOf(first.occurredAt);
+  const toIso = isoOf(last.occurredAt);
+  const speakers = [...new Set(turns.map((t) => t.speaker ?? 'unknown'))].join(', ');
+  const opens = trimTo(firstNonAssistant(turns).text, OPENER_CLOSER_CHARS);
+  const closes = trimTo(last.text, OPENER_CLOSER_CHARS);
+  return (
+    `${fromIso.slice(0, 10)} ${fromIso.slice(11, 16)}–${toIso.slice(11, 16)} · ` +
+    `${speakers} · ${turns.length} turns — opens: "${opens}" — closes: "${closes}"`
+  );
+}
+
+/** Deterministic scene label: first non-assistant turn, trimmed to 80. */
+export function renderSceneLabel(turns: SceneTurnRow[]): string {
+  return trimTo(firstNonAssistant(turns).text, LABEL_CHARS);
+}
+
+/** Version stamp of the deterministic scorer below. */
+export const SCENE_SCORER_VERSION = 'scene-scorer-v0';
+
+/** Partial per-dimension memory value (migration 0106 memoryValue). */
+export interface SceneMemoryValue {
+  novelty?: number;
+  contradiction?: number;
+  stateChange?: number;
+  identity?: number;
+  explicitness?: number;
+  estimatedUtility?: number;
+  scorerVersion: string;
+  scoredAt: Date;
+}
+
+/**
+ * First-person-declarative markers for the explicitness dimension — a
+ * deliberately small, documented v0 heuristic (English + Russian). Two
+ * patterns because `\b` is ASCII-only and never fires around Cyrillic:
+ * the second uses explicit non-letter guards instead of word boundaries.
+ */
+const FIRST_PERSON_PATTERNS: readonly RegExp[] = [
+  /\b(i|i'm|i've|i'd|my|mine|me)\b/i,
+  /(?:^|[^а-яё])(я|мне|меня|мой|моя|моё|мои|нам|наш)(?=[^а-яё]|$)/i,
+];
+
+/**
+ * Deterministic (LLM-free) partial memory-value scoring:
+ *  - novelty: 1 − max cosine(scene centroid, prior scene centroids) —
+ *    computed ONLY when the centroid exists (i.e. embeddings ran); with
+ *    no priors the scene is maximally novel (1).
+ *  - explicitness: fraction of member turns carrying a first-person
+ *    declarative marker (FIRST_PERSON_PATTERNS).
+ *  - every other dimension stays undefined until a paid scorer exists.
+ * Stamps scorerVersion + scoredAt so mixed-scorer worlds stay auditable.
+ */
+export function scoreSceneDeterministic(
+  sceneCentroid: number[] | undefined,
+  priorCentroids: number[][],
+  turns: SceneTurnRow[],
+): SceneMemoryValue {
+  const value: SceneMemoryValue = {
+    scorerVersion: SCENE_SCORER_VERSION,
+    scoredAt: new Date(),
+  };
+  if (sceneCentroid && sceneCentroid.length > 0) {
+    let maxSim = 0;
+    for (const prior of priorCentroids) {
+      const sim = cosineSimilarity(sceneCentroid, prior);
+      if (sim > maxSim) maxSim = sim;
+    }
+    value.novelty = 1 - maxSim;
+  }
+  if (turns.length > 0) {
+    const matching = turns.filter((t) =>
+      FIRST_PERSON_PATTERNS.some((re) => re.test(t.text)),
+    ).length;
+    value.explicitness = matching / turns.length;
+  }
+  return value;
+}
+
+/** Scope/PII fold of one scene's member turns (segment-composer rule). */
+export interface SceneScopeFold {
+  piiClass: string[] | undefined;
+  userId: string | undefined;
+  userIds: string[];
+}
+
+/**
+ * Pure: fold the member turns' piiClass/userId into the scene stamp —
+ * the SAME rule as the L0 segment composer (segment-composer.service.ts
+ * :147-160): piiClass is the union of member tags; userId is stamped only
+ * when the whole scene is ONE user's; a mixed-user scene stays
+ * tenant-global (userId undefined ⇒ scopeForUser yields []).
+ */
+export function foldSceneScope(turns: SceneTurnRow[]): SceneScopeFold {
+  const pii = [...new Set(turns.flatMap((t) => t.piiClass ?? []))];
+  const userIds = [...new Set(turns.map((t) => t.userId).filter((u): u is string => !!u))];
+  return {
+    piiClass: pii.length > 0 ? pii : undefined,
+    userId: userIds.length === 1 ? userIds[0] : undefined,
+    userIds,
+  };
+}

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -228,6 +228,12 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // ── Worker-loop concurrency (per-jobType poller) ────────────────────
   validateWorkerConcurrencyEnv(env, errors);
 
+  // ── Scenes shadow substrate (Brain v2 PR1, migration 0106) ─────────
+  // The composer clamps bad values to defaults at read time; boot
+  // validation catches the typo before it silently reads as a default.
+  positiveInt(env, 'SCENES_MAX_TURNS', errors);
+  floatInRange(env, 'SCENES_TOPIC_MIN_COSINE', -1, 1, errors);
+
   // ── Retrieval profile (per-tenant genre configuration) ─────────────
   validateRetrievalProfileEnv(env, errors);
 
@@ -726,6 +732,18 @@ const KNOWN_BOOLEAN_FLAGS = [
   // master. Default off ⇒ no trajectory column is written or selected
   // and the capture endpoint 404s (byte-identical to pre-0098).
   'STRATEGY_TRAJECTORIES_ENABLED',
+  // Scenes shadow substrate (Brain v2 PR1, migration 0106): the batch
+  // scene composer + its admin trigger. Default off ⇒ no memory_episode
+  // row is ever written and the admin route 404s (byte-identical prod;
+  // shadow even when on — no serving path reads the tables). SCENES_
+  // family sits off the ENGINE flag budget by design (a shadow-substrate
+  // builder, not an engine fork).
+  'SCENES_SEGMENTATION_ENABLED',
+  // Scenes: within-session topic-boundary refinement — one embedding
+  // batch per conversation, the surface's only paid step. Off ⇒ the
+  // segmenter is session-gap + max-turns only (embedder-free). The
+  // cosine floor (SCENES_TOPIC_MIN_COSINE) is a float, not a boolean.
+  'SCENES_TOPIC_BOUNDARY',
   // Fovea optics (Optics-1, docs/roadmap/fovea-optics-2026-08.md): capture
   // the focus signal at the synthesize verdict point + expose the admin
   // fit/measure surface. SERVING-NEUTRAL — nothing consumes the calibrated
@@ -1032,5 +1050,22 @@ function nonNegativeFloat(env: NodeJS.ProcessEnv, name: string, errors: string[]
   const n = Number(v);
   if (!Number.isFinite(n) || n < 0) {
     errors.push(`${name} must be a non-negative number`);
+  }
+}
+
+/** Bounded float knob (e.g. a cosine floor, which may be negative). */
+// eslint-disable-next-line max-params -- validator helper family shape + explicit bounds
+function floatInRange(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  min: number,
+  max: number,
+  errors: string[],
+): void {
+  const v = env[name];
+  if (v === undefined) return;
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < min || n > max) {
+    errors.push(`${name} must be a number in [${min}, ${max}]`);
   }
 }

--- a/src/common/scene-flags.ts
+++ b/src/common/scene-flags.ts
@@ -1,0 +1,71 @@
+import { envFlagEnabled } from './env-validation';
+
+/**
+ * Scenes (Brain v2 PR1) master flag — SCENES_SEGMENTATION_ENABLED.
+ *
+ * When on, the admin scene-composer surface (POST
+ * /v1/admin/maintenance/scenes) batch-derives the shadow memory_episode
+ * substrate (migration 0106) from raw L0 episodes. The env read lives here
+ * in the common layer, NOT inside the engine dirs (engine-gates S5.2).
+ * Read at call time so a flip is runtime-mutable (no restart). Default off
+ * ⇒ the admin route 404s and NO memory_episode row is ever written —
+ * byte-identical prod (shadow substrate: nothing on the serving path reads
+ * these tables even when on). SCENES_ family sits off the ENGINE flag
+ * budget by design (a shadow-substrate builder, not an engine fork).
+ */
+export function sceneSegmentationEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_SEGMENTATION_ENABLED);
+}
+
+/**
+ * Scenes topic-boundary flag — SCENES_TOPIC_BOUNDARY.
+ *
+ * When on, the composer spends ONE embedding batch per conversation (its
+ * only paid step — no LLM anywhere in v1) and the segmenter additionally
+ * splits WITHIN a session where cosine(mean of the last 3 turns, next
+ * turn) drops below the SCENES_TOPIC_MIN_COSINE floor. The env read lives
+ * here in the common layer, NOT inside the engine dirs (engine-gates
+ * S5.2). Read at call time so a flip is runtime-mutable. Default off ⇒
+ * session-gap + max-turns segmentation only, embedder-free — and with the
+ * master flag off the whole surface is byte-identical prod.
+ */
+export function sceneTopicBoundaryEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_TOPIC_BOUNDARY);
+}
+
+/** Default cosine floor for the topic-boundary split (Brain v2 PR1). */
+const DEFAULT_TOPIC_MIN_COSINE = 0.55;
+
+/**
+ * Topic-boundary cosine floor (SCENES_TOPIC_MIN_COSINE): split between
+ * turns when cosine(mean of the last 3 member embeddings, next turn's
+ * embedding) < this value. A non-boolean knob resolved here in the common
+ * layer so the segmenter takes a resolved number (engine-gates S5.2); read
+ * at call time so a change is runtime-mutable. Cosine lives in [-1,1], so
+ * the full range is accepted; unset, blank, or out of range → the 0.55
+ * default. Ignored unless SCENES_TOPIC_BOUNDARY is on.
+ */
+export function sceneTopicMinCosine(): number {
+  const raw = process.env.SCENES_TOPIC_MIN_COSINE;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_TOPIC_MIN_COSINE;
+  const v = Number(raw);
+  return Number.isFinite(v) && v >= -1 && v <= 1 ? v : DEFAULT_TOPIC_MIN_COSINE;
+}
+
+/** Default hard cap on turns per scene (Brain v2 PR1). */
+const DEFAULT_MAX_TURNS = 40;
+
+/**
+ * Scene size cap (SCENES_MAX_TURNS): force a boundary once a scene reaches
+ * this many turns, regardless of topic continuity — a bound on gist length
+ * and on the eventual consolidation unit. A non-boolean knob resolved here
+ * in the common layer so the segmenter takes a resolved number
+ * (engine-gates S5.2); read at call time so a change is runtime-mutable.
+ * Must be a positive integer; unset, blank, or invalid → the 40 default.
+ */
+export function sceneMaxTurns(): number {
+  const raw = process.env.SCENES_MAX_TURNS;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_MAX_TURNS;
+  const v = Number(raw);
+  return Number.isInteger(v) && v > 0 ? v : DEFAULT_MAX_TURNS;
+}

--- a/src/contracts/admin/config.schema.ts
+++ b/src/contracts/admin/config.schema.ts
@@ -18,6 +18,7 @@ const ConfigCategorySchema = z.enum([
   'search',
   'multihop',
   'calibration',
+  'scenes',
   'conflict',
   'cost',
   'throttle',

--- a/src/db/migrations/0106_memory_episode.surql
+++ b/src/db/migrations/0106_memory_episode.surql
@@ -1,0 +1,149 @@
+-- 0106: memory_episode — the shadow Scenes substrate (Brain v2 PR1,
+-- episodic-plane primitive).
+--
+-- WHY. Brain v2 frames memory as three planes: the RAW plane (verbatim
+-- `episode` turns, 0073), the SEMANTIC plane (derived `knowledge_fact`
+-- propositions), and — missing until now — the EPISODIC plane: coherent
+-- multi-turn SCENES that sit between them. A scene is a versioned, derived
+-- grouping of contiguous raw turns within one session (session-gap first,
+-- optional topic-boundary refinement), carrying a deterministic gist, a
+-- per-dimension memory-value assessment, and typed membership edges back to
+-- the exact turns it covers. Facts answer "what is true"; scenes answer
+-- "what happened, together, when" — the unit that summarization,
+-- consolidation, and dual-trace style retrieval want and that neither raw
+-- turns (too granular) nor positional `episode_segment` windows (fixed
+-- stride, no semantic boundary, no value model) provide.
+--
+-- SHADOW. Nothing on the serving path reads these tables. The composer
+-- (scene-composer.service.ts, SCENES_SEGMENTATION_ENABLED, default off)
+-- writes only memory_episode / memory_episode_member / projection rows —
+-- prod behavior is byte-identical with the flag off, and remains
+-- serving-identical with it on. Derived state: rebuildable from `episode`
+-- at any time (delete-by-conversation-and-version then reinsert), so
+-- removal is DROP both tables + delete the composer — no reader to migrate.
+--
+-- NAMING NOTES.
+--  * `residual` was REJECTED as a field name for the unexpected-details
+--    payload: it is already the projection lifecycle status
+--    (contracts/episodes/driver.schema.ts PROJECTION_STATUSES), and scenes
+--    register in that same projection ledger — one word, two meanings in
+--    one subsystem is a trap. The field is `unexpectedDetails`.
+--  * memoryValue is a VECTOR of per-dimension scores (novelty,
+--    contradiction, stateChange, identity, explicitness, estimatedUtility),
+--    NOT a single surprise scalar: the dimensions are consumed
+--    independently by consolidation policy (PR2+), and collapsing them at
+--    write time would bake one weighting into stored data. Every dimension
+--    is optional — the deterministic v0 scorer fills only what it can
+--    compute without an LLM; the rest stays NONE until a paid scorer runs.
+--
+-- ALTERNATIVES CONSIDERED.
+--  * Reusing episode_segment (0075): rejected — segments are positional
+--    sliding windows keyed (conversationId, seq) with no boundary
+--    semantics, no versioned segmenter, no value model, and a UNIQUE key
+--    that cannot host overlapping scene generations side by side.
+--  * A sessionId column on `episode`: rejected in 0073 (sessionization is
+--    a derivation-time concern) and still rejected here — scenes are one
+--    of many possible segmentations, hence versioned rows in their own
+--    table, keyed by segmenterVersion so competing segmenters coexist.
+--
+-- NO CHANGEFEED on either table, deliberately (same GDPR reasoning as
+-- 0073): scenes quote-derive from verbatim turns, and a 30-day INCLUDE
+-- ORIGINAL feed would keep forgotten scene gists readable after a GDPR
+-- delete. Rebuild scheduling is the admin trigger + projection registry,
+-- not a feed.
+
+DEFINE TABLE IF NOT EXISTS memory_episode SCHEMAFULL;
+
+-- Per-user scope (0055 model) + scope tags (0093) + PII classes, folded
+-- from the member turns exactly like episode_segment: userId only when the
+-- whole scene is one user's; a mixed-user scene stays tenant-global.
+DEFINE FIELD IF NOT EXISTS userId ON memory_episode TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS scope ON memory_episode TYPE array<string> DEFAULT [];
+DEFINE FIELD IF NOT EXISTS piiClass ON memory_episode TYPE option<array<string>>;
+
+-- Deterministic label (first non-assistant turn, trimmed; ≤200 enforced in
+-- code — the segmenter emits ≤80 today, the cap leaves LLM labels room).
+DEFINE FIELD IF NOT EXISTS sceneLabel ON memory_episode TYPE string;
+DEFINE FIELD IF NOT EXISTS conversationIds ON memory_episode TYPE array<string>;
+DEFINE FIELD IF NOT EXISTS occurredFrom ON memory_episode TYPE datetime;
+DEFINE FIELD IF NOT EXISTS occurredTo ON memory_episode TYPE datetime;
+DEFINE FIELD IF NOT EXISTS recordedAt ON memory_episode TYPE datetime DEFAULT time::now();
+
+-- Canonical gist TEXT (deterministic render in v1; PII-safe by
+-- construction — member turns are already redacted at capture).
+DEFINE FIELD IF NOT EXISTS gist ON memory_episode TYPE string;
+DEFINE FIELD IF NOT EXISTS gistEmbedding ON memory_episode TYPE option<array<float>>;
+
+-- Semantic backlinks into the knowledge graph (PR2 fills these).
+DEFINE FIELD IF NOT EXISTS entityIds ON memory_episode TYPE option<array<record<knowledge_entity>>>;
+DEFINE FIELD IF NOT EXISTS relationIds ON memory_episode TYPE option<array<record<knowledge_edge>>>;
+
+-- Per-dimension memory value (see NAMING NOTES above — a vector, not a
+-- surprise scalar). Every dimension optional; the scorer stamps its own
+-- version + time so mixed-scorer worlds stay auditable.
+DEFINE FIELD IF NOT EXISTS memoryValue ON memory_episode TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS memoryValue.novelty ON memory_episode TYPE option<float>;
+DEFINE FIELD IF NOT EXISTS memoryValue.contradiction ON memory_episode TYPE option<float>;
+DEFINE FIELD IF NOT EXISTS memoryValue.stateChange ON memory_episode TYPE option<float>;
+DEFINE FIELD IF NOT EXISTS memoryValue.identity ON memory_episode TYPE option<float>;
+DEFINE FIELD IF NOT EXISTS memoryValue.explicitness ON memory_episode TYPE option<float>;
+DEFINE FIELD IF NOT EXISTS memoryValue.estimatedUtility ON memory_episode TYPE option<float>;
+DEFINE FIELD IF NOT EXISTS memoryValue.scorerVersion ON memory_episode TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS memoryValue.scoredAt ON memory_episode TYPE option<datetime>;
+
+DEFINE FIELD IF NOT EXISTS confidence ON memory_episode TYPE float
+  ASSERT $value >= 0 AND $value <= 1;
+
+-- Surprise payload (NOT `residual` — see NAMING NOTES).
+DEFINE FIELD IF NOT EXISTS unexpectedDetails ON memory_episode TYPE option<array<string>>;
+
+-- State-delta capture for the world-model plane (PR3+); FLEXIBLE because
+-- the delta shape is scorer-owned, not schema-owned yet.
+DEFINE FIELD IF NOT EXISTS stateDeltas ON memory_episode TYPE option<array<object>> FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS baselineRef ON memory_episode TYPE option<object> FLEXIBLE;
+
+-- Versioning: competing segmenters coexist keyed by segmenterVersion; one
+-- generation stamp per rebuild run (0081 idiom) makes partial runs visible.
+DEFINE FIELD IF NOT EXISTS segmenterVersion ON memory_episode TYPE string;
+DEFINE FIELD IF NOT EXISTS encoderVersion ON memory_episode TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS gistPromptVersion ON memory_episode TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS generation ON memory_episode TYPE string;
+DEFINE FIELD IF NOT EXISTS source ON memory_episode TYPE object FLEXIBLE;
+
+-- Consolidation trail (PR2+): facts distilled out of this scene.
+DEFINE FIELD IF NOT EXISTS consolidatedInto ON memory_episode TYPE option<array<record<knowledge_fact>>>;
+
+DEFINE INDEX IF NOT EXISTS scene_version_idx ON memory_episode FIELDS segmenterVersion;
+DEFINE INDEX IF NOT EXISTS scene_conv_idx ON memory_episode FIELDS conversationIds;
+DEFINE INDEX IF NOT EXISTS scene_user_idx ON memory_episode FIELDS userId;
+DEFINE INDEX IF NOT EXISTS scene_time_idx ON memory_episode FIELDS occurredFrom;
+
+-- Same lowercase-only analyzer contract as episode_text (0073) /
+-- segment_text (0075): snowball stemming would mangle non-Latin scripts,
+-- and scene gists quote multilingual verbatim dialogue.
+DEFINE ANALYZER IF NOT EXISTS scene_gist TOKENIZERS class FILTERS lowercase;
+DEFINE INDEX IF NOT EXISTS scene_gist_search ON memory_episode
+  FIELDS gist FULLTEXT ANALYZER scene_gist BM25;
+
+-- Typed membership: scene -> member turn. A RELATION table so graph
+-- tooling sees it, but QUERIES MUST NOT use graph-arrow syntax (plain
+-- `WHERE in/out` reads only) — the composer and both GDPR cascades filter
+-- on in/out as ordinary record fields, so a plain SCHEMAFULL table with
+-- explicit in/out record fields would behave identically.
+DEFINE TABLE IF NOT EXISTS memory_episode_member
+  SCHEMAFULL TYPE RELATION FROM memory_episode TO episode;
+
+DEFINE FIELD IF NOT EXISTS role ON memory_episode_member TYPE string
+  ASSERT $value INSIDE ['core', 'context', 'boundary'];
+DEFINE FIELD IF NOT EXISTS ord ON memory_episode_member TYPE int;
+DEFINE FIELD IF NOT EXISTS relevance ON memory_episode_member TYPE float
+  ASSERT $value >= 0 AND $value <= 1;
+DEFINE FIELD IF NOT EXISTS segmenterVersion ON memory_episode_member TYPE string;
+DEFINE FIELD IF NOT EXISTS createdAt ON memory_episode_member TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX IF NOT EXISTS scene_member_uq ON memory_episode_member FIELDS in, out UNIQUE;
+DEFINE INDEX IF NOT EXISTS scene_member_out_idx ON memory_episode_member FIELDS out;
+DEFINE INDEX IF NOT EXISTS scene_member_ver_idx ON memory_episode_member FIELDS segmenterVersion;
+
+-- GDPR tombstone counter (0080 idiom): scenes erased by an entity forget.
+DEFINE FIELD IF NOT EXISTS scenesDeleted ON forgotten_entity TYPE option<int>;

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -257,10 +257,22 @@ export class EntityForgetService {
         // facts may keep stale source.memoryEpisodeIds strings after this,
         // the same class as stale source.episodeIds — repaired by the PR2
         // backlink re-run, not chased here.
+        //
+        // Two-step (SELECT ids → DELETE $ids) DELIBERATELY: on SurrealDB
+        // 3.2.4 a DELETE whose WHERE filters on `in` — covered only by
+        // the COMPOUND scene_member_uq index — silently matches NOTHING
+        // (even a direct `in INSIDE $ids` form; a traversal through it
+        // fails the same way), while the same WHERE in a SELECT matches
+        // fine — verified against the pinned server. Deleting by explicit
+        // ids sidesteps the planner entirely. Same bug class as
+        // preSweepOutcomeRows (PR #372).
         tx.add(
           `LET $sceneIds = (SELECT VALUE in FROM memory_episode_member WHERE out INSIDE $eps)`,
         );
-        tx.add(`DELETE memory_episode_member WHERE in INSIDE $sceneIds`);
+        tx.add(
+          `LET $sceneMemberIds = (SELECT VALUE id FROM memory_episode_member WHERE in INSIDE $sceneIds)`,
+        );
+        tx.add(`DELETE $sceneMemberIds`);
         tx.add(`LET $scenesDel = (DELETE memory_episode WHERE id INSIDE $sceneIds RETURN BEFORE)`);
         // L0: a segment that quotes an erased episode goes with it; segments
         // before episodes to keep the dependency order.

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -213,17 +213,8 @@ export class EntityForgetService {
         { ids: recordIds },
       );
       const auditCount = auditCountRow?.count ?? 0;
-      let segmentCount = 0;
-      if (episodeRefs.length > 0) {
-        const segCountRow = await queryFirst<{ count: number }>(
-          db,
-          `SELECT count() FROM episode_segment WHERE episodeIds CONTAINSANY $eps GROUP ALL`,
-          { eps: episodeRefs },
-        );
-        segmentCount = segCountRow?.count ?? 0;
-      }
-      const txRecordCount =
-        factsDeleted + edgesDeleted + episodeIds.length + segmentCount + auditCount;
+      const l0FanOut = await this.countL0FanOut(db, episodeRefs);
+      const txRecordCount = factsDeleted + edgesDeleted + episodeIds.length + l0FanOut + auditCount;
       if (txRecordCount > this.maxTxRecords) {
         throw new PayloadTooLargeException(
           `Entity forget fan-out (${txRecordCount} records) exceeds ` +
@@ -259,6 +250,18 @@ export class EntityForgetService {
         // record — the traversal dies with the facts, so purge first.
         tx.add(`DELETE fact_usage WHERE factId.entityId = $ent`);
         tx.add(`DELETE retrieval_feedback WHERE factId.entityId = $ent`);
+        // Scenes (0106): a scene whose membership quotes an erased episode
+        // goes whole, with ALL its member rows (mixed-subject scenes lose
+        // the scene, other subjects keep their own facts) — members before
+        // scenes, scenes before the episodes they quote. NOTE: surviving
+        // facts may keep stale source.memoryEpisodeIds strings after this,
+        // the same class as stale source.episodeIds — repaired by the PR2
+        // backlink re-run, not chased here.
+        tx.add(
+          `LET $sceneIds = (SELECT VALUE in FROM memory_episode_member WHERE out INSIDE $eps)`,
+        );
+        tx.add(`DELETE memory_episode_member WHERE in INSIDE $sceneIds`);
+        tx.add(`LET $scenesDel = (DELETE memory_episode WHERE id INSIDE $sceneIds RETURN BEFORE)`);
         // L0: a segment that quotes an erased episode goes with it; segments
         // before episodes to keep the dependency order.
         tx.add(
@@ -305,6 +308,7 @@ export class EntityForgetService {
             auditEventsDeleted: array::len($audit),
             episodesDeleted: array::len($epsDel),
             segmentsDeleted: array::len($segs),
+            scenesDeleted: array::len($scenesDel),
             forgottenBy: $forgottenBy,
             forgottenAt: $forgottenAt
           } RETURN AFTER)`);
@@ -362,5 +366,36 @@ export class EntityForgetService {
     }
 
     return result;
+  }
+
+  /**
+   * L0 fan-out of the erase for the transaction-size guard: segments that
+   * quote the dying episodes (audit W1 #13) PLUS — scenes, 0106 — the
+   * membership rows of those episodes and the distinct scene rows they
+   * resolve to. All of these join the same single transaction, so they
+   * count toward FORGET_MAX_TX_RECORDS BEFORE any mutation.
+   */
+  private async countL0FanOut(
+    db: Parameters<Parameters<SurrealService['withCompany']>[1]>[0],
+    episodeRefs: StringRecordId[],
+  ): Promise<number> {
+    if (episodeRefs.length === 0) return 0;
+    const segCountRow = await queryFirst<{ count: number }>(
+      db,
+      `SELECT count() FROM episode_segment WHERE episodeIds CONTAINSANY $eps GROUP ALL`,
+      { eps: episodeRefs },
+    );
+    const sceneMemberCountRow = await queryFirst<{ count: number }>(
+      db,
+      `SELECT count() FROM memory_episode_member WHERE out INSIDE $eps GROUP ALL`,
+      { eps: episodeRefs },
+    );
+    const sceneIdRows = await queryRows<{ in: unknown }>(
+      db,
+      `SELECT in FROM memory_episode_member WHERE out INSIDE $eps`,
+      { eps: episodeRefs },
+    );
+    const sceneCount = new Set(sceneIdRows.map((r) => String(r.in))).size;
+    return (segCountRow?.count ?? 0) + (sceneMemberCountRow?.count ?? 0) + sceneCount;
   }
 }

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -129,6 +129,34 @@ export class UserForgetService {
       }
       await db.query(`DELETE episode_segment WHERE userId = $u`, { u: userId });
 
+      // Scenes (0106, same finding-#13 class as segments): membership rows
+      // traverse in.userId, so they go FIRST while their scene rows are
+      // still alive. A user-scoped scene's members are all that user's by
+      // the fold rule, so this clears them completely.
+      await db.query(`DELETE memory_episode_member WHERE in.userId = $u`, { u: userId });
+      // Mixed-user scenes carry no userId stamp — resolve them BY
+      // REFERENCE through the membership of the just-deleted episodes
+      // (the `out` link keeps its record id after the episode row died).
+      // Erasure wins over retention: a scene quoting an erased turn goes
+      // whole, exactly like a mixed-user segment.
+      if (deletedEpisodeRefs.length > 0) {
+        const [sceneIdRows] = await db.query<[unknown[]]>(
+          `SELECT VALUE in FROM memory_episode_member WHERE out INSIDE $eps`,
+          { eps: deletedEpisodeRefs },
+        );
+        const sceneIds = [...new Set(((sceneIdRows as unknown[]) ?? []).map(String))].map(
+          (id) => new StringRecordId(id),
+        );
+        await db.query(
+          `DELETE memory_episode_member WHERE in INSIDE $sceneIds OR out INSIDE $eps`,
+          { sceneIds, eps: deletedEpisodeRefs },
+        );
+        if (sceneIds.length > 0) {
+          await db.query(`DELETE memory_episode WHERE id INSIDE $sceneIds`, { sceneIds });
+        }
+      }
+      await db.query(`DELETE memory_episode WHERE userId = $u`, { u: userId });
+
       // Purge the materialised audit mirror (same contract as entity
       // forget): recordId is the full `table:id` string. The changefeed
       // consumer's PII redaction covers any still-unconsumed lag.

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -133,12 +133,28 @@ export class UserForgetService {
       // traverse in.userId, so they go FIRST while their scene rows are
       // still alive. A user-scoped scene's members are all that user's by
       // the fold rule, so this clears them completely.
-      await db.query(`DELETE memory_episode_member WHERE in.userId = $u`, { u: userId });
+      //
+      // Two-step (SELECT ids → DELETE $ids) DELIBERATELY: on SurrealDB
+      // 3.2.4 a DELETE whose WHERE traverses through an indexed record
+      // field silently matches NOTHING, while the same WHERE in a SELECT
+      // matches fine — verified against the pinned server, and for `in`
+      // (covered only by the COMPOUND scene_member_uq index) even a
+      // direct `in INSIDE $ids` DELETE no-ops. Deleting by explicit ids
+      // sidesteps the planner entirely. Same bug class as PR #372's
+      // preSweepOutcomeRows in entity-forget.service.ts.
+      const [ownMemberIds] = await db.query<[unknown[]]>(
+        `SELECT VALUE id FROM memory_episode_member WHERE in.userId = $u`,
+        { u: userId },
+      );
+      if (((ownMemberIds as unknown[]) ?? []).length > 0) {
+        await db.query(`DELETE $ids`, { ids: ownMemberIds });
+      }
       // Mixed-user scenes carry no userId stamp — resolve them BY
       // REFERENCE through the membership of the just-deleted episodes
       // (the `out` link keeps its record id after the episode row died).
       // Erasure wins over retention: a scene quoting an erased turn goes
-      // whole, exactly like a mixed-user segment.
+      // whole, exactly like a mixed-user segment. Same two-step idiom:
+      // the `in INSIDE` leg of a DELETE is dead on 3.2.4 (see above).
       if (deletedEpisodeRefs.length > 0) {
         const [sceneIdRows] = await db.query<[unknown[]]>(
           `SELECT VALUE in FROM memory_episode_member WHERE out INSIDE $eps`,
@@ -147,10 +163,13 @@ export class UserForgetService {
         const sceneIds = [...new Set(((sceneIdRows as unknown[]) ?? []).map(String))].map(
           (id) => new StringRecordId(id),
         );
-        await db.query(
-          `DELETE memory_episode_member WHERE in INSIDE $sceneIds OR out INSIDE $eps`,
+        const [refMemberIds] = await db.query<[unknown[]]>(
+          `SELECT VALUE id FROM memory_episode_member WHERE in INSIDE $sceneIds OR out INSIDE $eps`,
           { sceneIds, eps: deletedEpisodeRefs },
         );
+        if (((refMemberIds as unknown[]) ?? []).length > 0) {
+          await db.query(`DELETE $ids`, { ids: refMemberIds });
+        }
         if (sceneIds.length > 0) {
           await db.query(`DELETE memory_episode WHERE id INSIDE $sceneIds`, { sceneIds });
         }

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -57,6 +57,49 @@ describe('0059_perf_indexes', () => {
   });
 });
 
+describe('0106_memory_episode indexes', () => {
+  const sql = readFileSync(join(MIGRATIONS, '0106_memory_episode.surql'), 'utf8');
+
+  it.each([
+    ['scene_version_idx', 'memory_episode', 'segmenterVersion'],
+    ['scene_conv_idx', 'memory_episode', 'conversationIds'],
+    ['scene_user_idx', 'memory_episode', 'userId'],
+    ['scene_time_idx', 'memory_episode', 'occurredFrom'],
+    ['scene_member_uq', 'memory_episode_member', 'in, out UNIQUE'],
+    ['scene_member_out_idx', 'memory_episode_member', 'out'],
+    ['scene_member_ver_idx', 'memory_episode_member', 'segmenterVersion'],
+  ])('defines %s on %s(%s)', (name, table, fields) => {
+    expect(sql).toContain(`DEFINE INDEX IF NOT EXISTS ${name} ON ${table} FIELDS ${fields};`);
+  });
+
+  it('defines the BM25 gist index with the lowercase-only analyzer', () => {
+    expect(sql).toContain(
+      'DEFINE ANALYZER IF NOT EXISTS scene_gist TOKENIZERS class FILTERS lowercase;',
+    );
+    expect(sql).toMatch(
+      /DEFINE INDEX IF NOT EXISTS scene_gist_search ON memory_episode\s+FIELDS gist FULLTEXT ANALYZER scene_gist BM25;/,
+    );
+  });
+});
+
+describe('entity-forget scenes cascade (0106)', () => {
+  // Source-regex guard, same spirit as the index tuples above: the atomic
+  // erase transaction must take scene membership AND scene rows with the
+  // episodes it deletes — dropping either line reopens the GDPR hole that
+  // audit W1 #13 closed for segments.
+  const src = readFileSync(
+    join(__dirname, '..', 'src', 'entities', 'entity-forget.service.ts'),
+    'utf8',
+  );
+
+  it('the erase transaction deletes scene membership and scenes', () => {
+    expect(src).toContain('DELETE memory_episode_member WHERE in INSIDE $sceneIds');
+    expect(src).toContain('DELETE memory_episode WHERE id INSIDE $sceneIds');
+    // Scene resolution must come from membership of the dying episodes.
+    expect(src).toContain('SELECT VALUE in FROM memory_episode_member WHERE out INSIDE $eps');
+  });
+});
+
 describe('JobRunService.finish ownership guard', () => {
   function mkSurreal(db: { query: (s: string, p?: any) => Promise<any> }) {
     return {

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -93,10 +93,33 @@ describe('entity-forget scenes cascade (0106)', () => {
   );
 
   it('the erase transaction deletes scene membership and scenes', () => {
-    expect(src).toContain('DELETE memory_episode_member WHERE in INSIDE $sceneIds');
+    // Two-step (SELECT ids → DELETE $ids): on SurrealDB 3.2.4 a DELETE
+    // whose WHERE filters on `in` (compound scene_member_uq coverage)
+    // silently matches NOTHING — the membership erase must go by ids.
+    expect(src).toContain(
+      'LET $sceneMemberIds = (SELECT VALUE id FROM memory_episode_member WHERE in INSIDE $sceneIds)',
+    );
+    expect(src).toContain('DELETE $sceneMemberIds');
     expect(src).toContain('DELETE memory_episode WHERE id INSIDE $sceneIds');
     // Scene resolution must come from membership of the dying episodes.
     expect(src).toContain('SELECT VALUE in FROM memory_episode_member WHERE out INSIDE $eps');
+  });
+
+  it('no writer uses the 3.2.4-broken DELETE-on-`in` shape', () => {
+    // Regression guard for the silent-no-op class: `DELETE
+    // memory_episode_member WHERE in ...` (traversal OR direct INSIDE)
+    // matches nothing on the pinned server because `in` is covered only
+    // by the COMPOUND scene_member_uq index. Every membership delete
+    // must be the two-step SELECT-ids → DELETE $ids idiom.
+    const files = [
+      join(__dirname, '..', 'src', 'entities', 'entity-forget.service.ts'),
+      join(__dirname, '..', 'src', 'entities', 'user-forget.service.ts'),
+      join(__dirname, '..', 'src', 'admin', 'scene-composer.service.ts'),
+    ];
+    for (const file of files) {
+      const text = readFileSync(file, 'utf8');
+      expect(text).not.toMatch(/DELETE memory_episode_member WHERE in[\s.]/);
+    }
   });
 });
 

--- a/test/memory-episode.e2e-spec.ts
+++ b/test/memory-episode.e2e-spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Brain v2 shadow Scenes substrate e2e (migration 0106): flag gate (off →
+ * 404, no rows), scene derivation over episode-only ingest (two sessions →
+ * two scenes with contiguous core membership, gist, version + generation
+ * stamps, a 'built' projection row), idempotent re-run on a fresh
+ * generation, and the user-forget GDPR cascade taking scenes + members.
+ * Embedder-free path (SCENES_TOPIC_BOUNDARY stays off) — no paid calls.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+const CONV = 'proj:scenes';
+const USER = 'scene_user';
+
+interface SceneRow {
+  id: unknown;
+  gist: string;
+  sceneLabel: string;
+  segmenterVersion: string;
+  generation: string;
+  userId?: string;
+  scope: string[];
+}
+
+describe('memory_episode — shadow scenes substrate (e2e)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const saved: Record<string, string | undefined> = {};
+  beforeAll(async () => {
+    for (const k of ['EPISODE_SUBSTRATE_ENABLED', 'INGEST_EPISODE_ONLY']) {
+      saved[k] = process.env[k];
+      process.env[k] = '1';
+    }
+    saved.SCENES_SEGMENTATION_ENABLED = process.env.SCENES_SEGMENTATION_ENABLED;
+    delete process.env.SCENES_SEGMENTATION_ENABLED;
+    f = await createApp({ companyId: 'co_scenes_e2e' });
+    // One conversation, two sessions: 3 turns, then a >60-min gap, then 2.
+    const turns = [
+      { t: '2026-02-01T10:00:00.000Z', text: 'I started planning the Lisbon trip.' },
+      { t: '2026-02-01T10:05:00.000Z', text: 'Comparing flights for next month.' },
+      { t: '2026-02-01T10:10:00.000Z', text: 'Booked the morning one.' },
+      { t: '2026-02-01T12:00:00.000Z', text: 'Back to it — now the hotel.' },
+      { t: '2026-02-01T12:05:00.000Z', text: 'Found a place near the river.' },
+    ];
+    for (const [i, turn] of turns.entries()) {
+      const res = await f.http
+        .post('/v1/ingest/mention')
+        .set(auth())
+        .send({
+          text: turn.text,
+          contextRef: { vertical: 'proj', conversationId: CONV, messageId: `sc${i}` },
+          knownEntities: [{ vertical: 'proj', id: 'mika', role: 'speaker', name: 'mika' }],
+          userId: USER,
+          emittedAt: turn.t,
+        });
+      expect(res.status).toBe(201);
+    }
+  });
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (f) await f.close();
+  });
+
+  const scenesInDb = async (): Promise<SceneRow[]> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[SceneRow[]]>(
+        `SELECT * FROM memory_episode ORDER BY occurredFrom ASC`,
+      );
+      return rows ?? [];
+    });
+  };
+
+  const membersOf = async (sceneId: unknown): Promise<Array<{ ord: number; role: string }>> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ ord: number; role: string }>]>(
+        `SELECT ord, role FROM memory_episode_member WHERE in = $scene ORDER BY ord ASC`,
+        { scene: sceneId },
+      );
+      return rows ?? [];
+    });
+  };
+
+  /** Deletes are synchronous but poll anyway — cheap and future-proof. */
+  const waitForSceneCount = async (expected: number): Promise<SceneRow[]> => {
+    for (let i = 0; i < 40; i++) {
+      const rows = await scenesInDb();
+      if (rows.length === expected) return rows;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    return scenesInDb();
+  };
+
+  it('404s with the flag off and writes nothing', async () => {
+    const res = await f.http.post('/v1/admin/maintenance/scenes').set(auth()).send({});
+    expect(res.status).toBe(404);
+    expect(await scenesInDb()).toHaveLength(0);
+  });
+
+  it('derives two scenes with core membership, stamps, and a built projection row', async () => {
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    const res = await f.http.post('/v1/admin/maintenance/scenes').set(auth()).send({});
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ conversations: 1, scenes: 2 });
+
+    const scenes = await scenesInDb();
+    expect(scenes).toHaveLength(2);
+    for (const scene of scenes) {
+      expect(scene.gist.length).toBeGreaterThan(0);
+      expect(scene.segmenterVersion).toBe('scene-segmenter-v1');
+      expect(scene.generation).toBeDefined();
+      // Single-user conversation → per-user scope folded onto the scene.
+      expect(scene.userId).toBe(USER);
+      expect(scene.scope).toEqual([`user:${USER}`]);
+    }
+    const first = await membersOf(scenes[0]!.id);
+    expect(first.map((m) => m.ord)).toEqual([0, 1, 2]);
+    expect(first.every((m) => m.role === 'core')).toBe(true);
+    expect((await membersOf(scenes[1]!.id)).map((m) => m.ord)).toEqual([0, 1]);
+
+    const surreal = f.app.get(SurrealService);
+    const projection = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ status: string }>]>(
+        `SELECT status FROM projection WHERE name = 'scenes'`,
+      );
+      return rows ?? [];
+    });
+    expect(projection).toHaveLength(1);
+    expect(projection[0]!.status).toBe('built');
+  });
+
+  it('re-runs idempotently onto a fresh generation', async () => {
+    const before = await scenesInDb();
+    const res = await f.http.post('/v1/admin/maintenance/scenes').set(auth()).send({});
+    expect(res.status).toBe(201);
+    expect(res.body.scenes).toBe(2);
+    const after = await scenesInDb();
+    expect(after).toHaveLength(before.length);
+    expect(after[0]!.generation).not.toBe(before[0]!.generation);
+  });
+
+  it('user forget cascades over scenes and membership', async () => {
+    const forget = await f.http.post(`/v1/users/${USER}/forget`).set(auth()).send({});
+    expect([200, 201]).toContain(forget.status);
+    expect(await waitForSceneCount(0)).toHaveLength(0);
+    const surreal = f.app.get(SurrealService);
+    const members = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM memory_episode_member GROUP ALL`,
+      );
+      return (rows ?? [])[0]?.n ?? 0;
+    });
+    expect(members).toBe(0);
+  });
+});

--- a/test/memory-episode.e2e-spec.ts
+++ b/test/memory-episode.e2e-spec.ts
@@ -147,16 +147,40 @@ describe('memory_episode — shadow scenes substrate (e2e)', () => {
   });
 
   it('user forget cascades over scenes and membership', async () => {
+    // Capture the user's scene ids BEFORE the forget so the membership
+    // assertion below targets exactly those scenes by id — it must not
+    // pass by way of the by-reference (out INSIDE deleted-episodes)
+    // sweep alone masking a silently no-oped membership delete (the
+    // 3.2.4 compound-index DELETE bug the cascade works around).
+    const before = await scenesInDb();
+    expect(before.length).toBeGreaterThan(0);
+    const sceneIds = before.map((s) => s.id);
+
     const forget = await f.http.post(`/v1/users/${USER}/forget`).set(auth()).send({});
     expect([200, 201]).toContain(forget.status);
     expect(await waitForSceneCount(0)).toHaveLength(0);
+
     const surreal = f.app.get(SurrealService);
-    const members = await surreal.withCompany(f.companyId, async (db) => {
-      const [rows] = await db.query<[Array<{ n: number }>]>(
+    const counts = await surreal.withCompany(f.companyId, async (db) => {
+      const [forScenes] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM memory_episode_member WHERE in INSIDE $sceneIds GROUP ALL`,
+        { sceneIds },
+      );
+      const [total] = await db.query<[Array<{ n: number }>]>(
         `SELECT count() AS n FROM memory_episode_member GROUP ALL`,
       );
-      return (rows ?? [])[0]?.n ?? 0;
+      const [userScenes] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM memory_episode WHERE userId = $u GROUP ALL`,
+        { u: USER },
+      );
+      return {
+        membersForScenes: (forScenes ?? [])[0]?.n ?? 0,
+        membersTotal: (total ?? [])[0]?.n ?? 0,
+        userScenes: (userScenes ?? [])[0]?.n ?? 0,
+      };
     });
-    expect(members).toBe(0);
+    expect(counts.membersForScenes).toBe(0);
+    expect(counts.membersTotal).toBe(0);
+    expect(counts.userScenes).toBe(0);
   });
 });

--- a/test/scene-segmentation.unit-spec.ts
+++ b/test/scene-segmentation.unit-spec.ts
@@ -1,0 +1,213 @@
+/**
+ * Pure-function tests for the Brain v2 scene segmenter
+ * (src/admin/scene-segmentation.ts): boundary detection (session gap via
+ * the shared segmentSessions, cosine topic split, min scene size,
+ * max-turns force split, determinism), the deterministic gist/label
+ * renders, the deterministic memory-value scorer, and the scope/PII fold
+ * (segment-composer :147-160 rule).
+ */
+import {
+  detectSceneBoundaries,
+  foldSceneScope,
+  meanVector,
+  renderSceneGist,
+  renderSceneLabel,
+  scoreSceneDeterministic,
+  SCENE_SCORER_VERSION,
+  type SceneTurnRow,
+} from '../src/admin/scene-segmentation';
+import { segmentSessions } from '../src/episodes/session-window';
+
+let seq = 0;
+function turn(over: Partial<SceneTurnRow> & { text: string }): SceneTurnRow {
+  seq += 1;
+  return {
+    id: `episode:t${seq}`,
+    speaker: 'mika',
+    occurredAt: '2026-01-01T10:00:00.000Z',
+    ...over,
+  };
+}
+
+const at = (iso: string, text: string, over: Partial<SceneTurnRow> = {}) =>
+  turn({ occurredAt: iso, text, ...over });
+
+const OPTS = { minCosine: 0.55, maxTurns: 40 };
+
+describe('detectSceneBoundaries', () => {
+  it('session gap always splits (via segmentSessions), each session is one scene', () => {
+    const turns = [
+      at('2026-01-01T10:00:00.000Z', 'planning the trip'),
+      at('2026-01-01T10:05:00.000Z', 'looking at flights'),
+      at('2026-01-01T10:10:00.000Z', 'found a good one'),
+      // > 60 min inactivity gap ⇒ a new session, hence a scene boundary.
+      at('2026-01-01T12:00:00.000Z', 'back from lunch'),
+      at('2026-01-01T12:05:00.000Z', 'booking the hotel'),
+    ];
+    const sessions = segmentSessions(turns) as SceneTurnRow[][];
+    expect(sessions).toHaveLength(2);
+    const scenes = sessions.flatMap((s) => detectSceneBoundaries(s, undefined, OPTS));
+    expect(scenes.map((s) => s.length)).toEqual([3, 2]);
+    expect(scenes[0]![0]!.text).toBe('planning the trip');
+    expect(scenes[1]![0]!.text).toBe('back from lunch');
+  });
+
+  it('splits within a session when cosine drops below the floor', () => {
+    const session = [
+      at('2026-01-01T10:00:00.000Z', 'a1'),
+      at('2026-01-01T10:01:00.000Z', 'a2'),
+      at('2026-01-01T10:02:00.000Z', 'a3'),
+      at('2026-01-01T10:03:00.000Z', 'b1'),
+      at('2026-01-01T10:04:00.000Z', 'b2'),
+      at('2026-01-01T10:05:00.000Z', 'b3'),
+    ];
+    // Topic A on one axis, topic B orthogonal: cos(mean(a), b1) = 0 < 0.55.
+    const embeddings = [
+      [1, 0],
+      [1, 0],
+      [1, 0],
+      [0, 1],
+      [0, 1],
+      [0, 1],
+    ];
+    const scenes = detectSceneBoundaries(session, embeddings, OPTS);
+    expect(scenes.map((s) => s.map((t) => t.text))).toEqual([
+      ['a1', 'a2', 'a3'],
+      ['b1', 'b2', 'b3'],
+    ]);
+  });
+
+  it('never cosine-splits a scene below the 2-turn minimum', () => {
+    const session = [at('2026-01-01T10:00:00.000Z', 'a1'), at('2026-01-01T10:01:00.000Z', 'b1')];
+    // Orthogonal from the very first pair — still one scene of two.
+    const scenes = detectSceneBoundaries(
+      session,
+      [
+        [1, 0],
+        [0, 1],
+      ],
+      OPTS,
+    );
+    expect(scenes).toHaveLength(1);
+    expect(scenes[0]).toHaveLength(2);
+  });
+
+  it('force-splits at maxTurns even without embeddings', () => {
+    const session = Array.from({ length: 5 }, (_, i) => at(`2026-01-01T10:0${i}:00.000Z`, `t${i}`));
+    const scenes = detectSceneBoundaries(session, undefined, { minCosine: 0.55, maxTurns: 2 });
+    expect(scenes.map((s) => s.length)).toEqual([2, 2, 1]);
+  });
+
+  it('is deterministic', () => {
+    const session = Array.from({ length: 7 }, (_, i) => at(`2026-01-01T10:0${i}:00.000Z`, `t${i}`));
+    const embeddings = session.map((_, i) => (i < 4 ? [1, 0] : [0, 1]));
+    const a = detectSceneBoundaries(session, embeddings, OPTS);
+    const b = detectSceneBoundaries(session, embeddings, OPTS);
+    expect(a).toEqual(b);
+  });
+});
+
+describe('renderSceneGist / renderSceneLabel', () => {
+  const scene = [
+    at('2026-03-05T09:30:00.000Z', 'I moved to Lisbon last week', { speaker: 'mika' }),
+    at('2026-03-05T09:31:00.000Z', 'Congrats! How is the flat?', { speaker: 'chat__assistant' }),
+    at('2026-03-05T09:40:00.000Z', 'Small but sunny', { speaker: 'mika' }),
+  ];
+
+  it('renders the canonical gist text', () => {
+    expect(renderSceneGist(scene)).toBe(
+      '2026-03-05 09:30–09:40 · mika, chat__assistant · 3 turns — ' +
+        'opens: "I moved to Lisbon last week" — closes: "Small but sunny"',
+    );
+  });
+
+  it('truncates opener/closer to 160 chars deterministically', () => {
+    const long = 'x'.repeat(500);
+    const gist = renderSceneGist([at('2026-03-05T09:30:00.000Z', long)]);
+    const quoted = /opens: "([^"]*)"/.exec(gist)![1]!;
+    expect(quoted).toHaveLength(160);
+  });
+
+  it('labels from the first NON-assistant turn, trimmed to 80', () => {
+    const assistantFirst = [
+      at('2026-03-05T09:30:00.000Z', 'Here is your daily summary', { speaker: 'chat__assistant' }),
+      at('2026-03-05T09:31:00.000Z', `Thanks! ${'y'.repeat(200)}`, { speaker: 'mika' }),
+    ];
+    const label = renderSceneLabel(assistantFirst);
+    expect(label.startsWith('Thanks!')).toBe(true);
+    expect(label).toHaveLength(80);
+    // All-assistant scene falls back to its first turn.
+    expect(renderSceneLabel([assistantFirst[0]!])).toBe('Here is your daily summary');
+  });
+});
+
+describe('scoreSceneDeterministic', () => {
+  it('novelty = 1 − max cosine to prior centroids; absent without embeddings', () => {
+    const turns = [at('2026-01-01T10:00:00.000Z', 'hello world')];
+    const scored = scoreSceneDeterministic(
+      [0, 1],
+      [
+        [1, 0],
+        [0, 1],
+      ],
+      turns,
+    );
+    expect(scored.novelty).toBeCloseTo(0, 5); // identical prior exists
+    const novel = scoreSceneDeterministic([0, 1], [[1, 0]], turns);
+    expect(novel.novelty).toBeCloseTo(1, 5); // orthogonal to every prior
+    const firstScene = scoreSceneDeterministic([0, 1], [], turns);
+    expect(firstScene.novelty).toBeCloseTo(1, 5); // no priors = maximally novel
+    expect(scoreSceneDeterministic(undefined, [], turns).novelty).toBeUndefined();
+  });
+
+  it('explicitness = fraction of first-person-declarative turns (en + ru)', () => {
+    const turns = [
+      at('2026-01-01T10:00:00.000Z', 'I moved to Lisbon'),
+      at('2026-01-01T10:01:00.000Z', 'я люблю кофе'),
+      at('2026-01-01T10:02:00.000Z', 'the weather held up'),
+      at('2026-01-01T10:03:00.000Z', 'sounds great'),
+    ];
+    expect(scoreSceneDeterministic(undefined, [], turns).explicitness).toBeCloseTo(0.5, 5);
+  });
+
+  it('stamps version + scoredAt and leaves unscored dims undefined', () => {
+    const scored = scoreSceneDeterministic(undefined, [], [at('2026-01-01T10:00:00.000Z', 'hi')]);
+    expect(scored.scorerVersion).toBe(SCENE_SCORER_VERSION);
+    expect(scored.scoredAt).toBeInstanceOf(Date);
+    expect(scored.contradiction).toBeUndefined();
+    expect(scored.stateChange).toBeUndefined();
+    expect(scored.identity).toBeUndefined();
+    expect(scored.estimatedUtility).toBeUndefined();
+  });
+
+  it('meanVector averages element-wise', () => {
+    expect(
+      meanVector([
+        [1, 0],
+        [0, 1],
+      ]),
+    ).toEqual([0.5, 0.5]);
+    expect(meanVector([])).toEqual([]);
+  });
+});
+
+describe('foldSceneScope (segment-composer :147-160 rule)', () => {
+  it('single-user scene: userId stamped, pii unioned', () => {
+    const fold = foldSceneScope([
+      at('2026-01-01T10:00:00.000Z', 'a', { userId: 'u1', piiClass: ['email'] }),
+      at('2026-01-01T10:01:00.000Z', 'b', { userId: 'u1', piiClass: ['phone', 'email'] }),
+    ]);
+    expect(fold.userId).toBe('u1');
+    expect(fold.piiClass).toEqual(['email', 'phone']);
+  });
+
+  it('mixed-user scene stays tenant-global; clean scene has no pii', () => {
+    const fold = foldSceneScope([
+      at('2026-01-01T10:00:00.000Z', 'a', { userId: 'u1' }),
+      at('2026-01-01T10:01:00.000Z', 'b', { userId: 'u2' }),
+    ]);
+    expect(fold.userId).toBeUndefined();
+    expect(fold.userIds).toEqual(['u1', 'u2']);
+    expect(fold.piiClass).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Brain v2 PR1: the **episodic-plane primitive** between raw episodes (L0, 0073) and derived facts — coherent multi-turn SCENES with deterministic gists, typed membership back to the exact turns, and a per-dimension memory-value vector. **Shadow substrate**: no serving path reads `memory_episode` — the composer writes only `memory_episode` / `memory_episode_member` / `projection` rows, so prod is byte-identical with the flag off and serving-identical with it on. No LLM calls anywhere (deterministic v1; one optional embedding batch per conversation via the existing embedder, only under `SCENES_TOPIC_BOUNDARY`).

## What's in

- **Migration `0106_memory_episode.surql`**: `memory_episode` (SCHEMAFULL; scope/PII fold columns, deterministic gist + BM25 lowercase-only analyzer per the 0073/0075 multilingual contract, `memoryValue` as a per-dimension vector — deliberately not a surprise scalar, `unexpectedDetails` — `residual` rejected as a name, it's the projection lifecycle status in `contracts/episodes/driver.schema.ts`) + `memory_episode_member` (`TYPE RELATION FROM memory_episode TO episode`, role/ord/relevance, UNIQUE `(in,out)`; queries never use graph-arrow syntax) + `scenesDeleted` tombstone counter on `forgotten_entity`. Every statement `IF NOT EXISTS`. **No changefeed by design** (GDPR, same as 0073). `TYPE … FLEXIBLE` ordering verified against a live SurrealDB 3.2.4, as was `INSERT RELATION` with explicit in/out.
- **Flags `src/common/scene-flags.ts`** (fovea-flags idiom, call-time reads, runtime-mutable): `SCENES_SEGMENTATION_ENABLED` (master), `SCENES_TOPIC_BOUNDARY`, `SCENES_TOPIC_MIN_COSINE` (default 0.55, clamped to [-1,1]), `SCENES_MAX_TURNS` (default 40, positive int). Booleans registered in `KNOWN_BOOLEAN_FLAGS`; both knobs boot-validated; all four in `CONFIG_CATALOG` under a new `scenes` category.
- **Segmenter `src/admin/scene-segmentation.ts`** (pure, no NestJS): session-gap boundaries via the shared `segmentSessions`; optional cosine topic split (mean of last 3 turns vs next, 2-turn minimum scene); max-turns force split; canonical gist/label renders (PII-safe by construction — member turns are redacted at capture); deterministic v0 scorer (novelty from centroids + first-person explicitness; all other dimensions stay unset); scope/PII fold extracted as a pure helper (segment-composer :147-160 rule).
- **Composer `src/admin/scene-composer.service.ts`**: mirrors `SegmentComposerService` — paid-step-first (embedding batch before any delete), atomic swap per (conversation × segmenterVersion) in ONE transaction, deterministic scene record ids, generation stamp per run (0081 idiom), projection-registry `begin` / `complete` (**'built', never 'live'**) / `fail`.
- **Controller `src/admin/admin-scenes.controller.ts`**: `POST /v1/admin/maintenance/scenes` `{tenant?, conversationId?}`, `brain:admin`, platform-tenant resolution; flag off ⇒ 404.
- **GDPR**: `user-forget` (sequential path) and `entity-forget` (single transaction) both cascade scene membership + scene rows with the episodes they quote — members before scenes, scenes before episodes; entity forget counts the scene fan-out toward `FORGET_MAX_TX_RECORDS` **before** mutating and stamps `scenesDeleted` into the tombstone. Surviving facts may keep stale `source.memoryEpisodeIds` strings — same class as stale `source.episodeIds`, repaired by the PR2 backlink re-run (documented in code).

## Safety

- **Default off, byte-identical prod**: flag off ⇒ admin route 404s, composer early-returns, zero rows written. Even on, nothing on the serving path reads the new tables.
- **No changefeed** on either table (GDPR — forgotten gists must not stay readable via a feed).
- **Deliberate flag-family choice**: `SCENES_` sits **outside** the ENGINE flag-budget prefix regex — a shadow-substrate builder, not an engine fork (same reasoning as the `FOVEA_` / `MULTILINGUAL_` families). Confirmed: the flag-budget gate passes with **no golden change**.
- GDPR cascades are guarded by source-regex tests so the erase transaction cannot silently lose the scene deletes.

## Test plan

- [x] `pnpm typecheck` clean
- [x] Full unit suite: 296 suites / 2810 tests green (includes flag-budget, engine-gates, config-catalog-truth, audit-p1-guards)
- [x] New `test/scene-segmentation.unit-spec.ts`: boundaries (gap/cosine/min-size/max-turns/determinism), gist/label renders + truncation, deterministic scorer, scope/PII fold
- [x] `test/audit-p1-guards.unit-spec.ts`: it.each tuples for every 0106 index + BM25 analyzer + entity-forget scene-cascade source guard
- [x] `test/memory-episode.e2e-spec.ts` (real SurrealDB 3.2.4 via testcontainers): flag off ⇒ 404 + empty table; two-session conversation ⇒ 2 scenes with contiguous core membership, stamps, 'built' projection row; idempotent re-run on a fresh generation; user-forget cascade
- [x] `prettier --check` clean on src + test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB