### PR TITLE
feat(provenance): summary episode stamping + bounded recursive support-closure (Evidence plane)

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -844,6 +844,57 @@
       "FactProvenanceResponse": {
         "additionalProperties": false,
         "properties": {
+          "closure": {
+            "additionalProperties": false,
+            "properties": {
+              "depth": {
+                "type": "number"
+              },
+              "factCount": {
+                "type": "number"
+              },
+              "filtered": {
+                "type": "boolean"
+              },
+              "truncated": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "depth",
+              "factCount",
+              "truncated",
+              "filtered"
+            ],
+            "type": "object"
+          },
+          "derivedFacts": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "depth": {
+                  "type": "number"
+                },
+                "factId": {
+                  "type": "string"
+                },
+                "predicate": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "factId",
+                "predicate",
+                "depth",
+                "status"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "episodes": {
             "items": {
               "$ref": "#/components/schemas/FactProvenanceEpisode"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -844,6 +844,57 @@
       "FactProvenanceResponse": {
         "additionalProperties": false,
         "properties": {
+          "closure": {
+            "additionalProperties": false,
+            "properties": {
+              "depth": {
+                "type": "number"
+              },
+              "factCount": {
+                "type": "number"
+              },
+              "filtered": {
+                "type": "boolean"
+              },
+              "truncated": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "depth",
+              "factCount",
+              "truncated",
+              "filtered"
+            ],
+            "type": "object"
+          },
+          "derivedFacts": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "depth": {
+                  "type": "number"
+                },
+                "factId": {
+                  "type": "string"
+                },
+                "predicate": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "factId",
+                "predicate",
+                "depth",
+                "status"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "episodes": {
             "items": {
               "$ref": "#/components/schemas/FactProvenanceEpisode"

--- a/src/admin/aggregate-composer.service.ts
+++ b/src/admin/aggregate-composer.service.ts
@@ -5,6 +5,8 @@ import { StringRecordId } from 'surrealdb';
 import { createOpenAiClientOrThrow } from '../ai/openai-client';
 import { SurrealService } from '../db/surreal.service';
 import { FactEmbeddingService } from '../ingest/fact-embedding.service';
+import { summaryEpisodeStampEnabled } from '../common/provenance-flags';
+import { unionEpisodeIds } from '../common/episode-ids';
 import { runInsightComposer, type InsightComposerSpec } from './insight-composer-kernel';
 
 /**
@@ -91,13 +93,23 @@ export class AggregateComposerService {
         .toLowerCase()
         .replace(/[^a-z0-9_]+/g, '_')
         .slice(0, 40);
+      // Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP): union of the
+      // proposal members' grounding stamps (window-deriver idiom,
+      // capped 64). Flag off → empty union → source byte-identical.
+      const episodeIds = summaryEpisodeStampEnabled()
+        ? unionEpisodeIds(agg.members.map((m) => ctx.facts[m]!.episodeIds))
+        : [];
       return {
         entityId: ctx.entityId,
         predicate: `aggregate_${slug}`,
         object: agg.proposition,
         confidence: 0.9,
         validFrom: new Date(),
-        source: { vertical: 'aggregate', recorder: AGGREGATE_RECORDER },
+        source: {
+          vertical: 'aggregate',
+          recorder: AGGREGATE_RECORDER,
+          ...(episodeIds.length ? { episodeIds } : {}),
+        },
         status: 'active',
         embedding: ctx.vector,
         derivedFrom: agg.members.map(

--- a/src/admin/arc-composer.service.ts
+++ b/src/admin/arc-composer.service.ts
@@ -5,6 +5,8 @@ import { StringRecordId } from 'surrealdb';
 import { createOpenAiClientOrThrow } from '../ai/openai-client';
 import { SurrealService } from '../db/surreal.service';
 import { FactEmbeddingService } from '../ingest/fact-embedding.service';
+import { summaryEpisodeStampEnabled } from '../common/provenance-flags';
+import { unionEpisodeIds } from '../common/episode-ids';
 import { AGGREGATE_RECORDER } from './aggregate-composer.service';
 import {
   factDay,
@@ -132,13 +134,23 @@ export class ArcComposerService {
         .toLowerCase()
         .replace(/[^a-z0-9_]+/g, '_')
         .slice(0, 28);
+      // Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP): union of the
+      // proposal members' grounding stamps (window-deriver idiom,
+      // capped 64). Flag off → empty union → source byte-identical.
+      const episodeIds = summaryEpisodeStampEnabled()
+        ? unionEpisodeIds(arc.members.map((m) => ctx.facts[m]!.episodeIds))
+        : [];
       return {
         entityId: ctx.entityId,
         predicate: `summary_arc_${slug}`,
         object: arc.narrative.slice(0, ARC_NARRATIVE_CHAR_CAP),
         confidence: 0.9,
         validFrom: arcValidFrom(arc, ctx.facts),
-        source: { vertical: 'arc', recorder: ARC_RECORDER },
+        source: {
+          vertical: 'arc',
+          recorder: ARC_RECORDER,
+          ...(episodeIds.length ? { episodeIds } : {}),
+        },
         status: 'active',
         embedding: ctx.vector,
         derivedFrom: arc.members.map(

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1693,6 +1693,51 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Fact read + provenance API ("show me why I remember this"): GET /v1/facts/:id serves the fact as stored (aspect/statement/confidence/validFrom, source attribution, retracted flag, derivedVersion) and GET /v1/facts/:id/provenance serves its verbatim grounding turns (source.episodeIds via the shared episode read port, text capped at 600 chars). Every miss is a 404 — tenant fence, fail-closed user scope (another user\'s fact is indistinguishable from absent), registry-backed row policy on scope-fenced predicates; episode text respects brain:read_pii. POST /v1/facts/:id/retract is deliberately NOT gated by this flag (write/GDPR path). Off (default) → read routes answer 404.',
   },
   {
+    key: 'PROVENANCE_SUMMARY_EPISODE_STAMP',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Evidence plane, write side (Brain v2 gap #5): every summary-producing writer — promotion runner, compaction rollups, recompose rewrites, arc/aggregate composers — stamps the union of its members' source.episodeIds onto the summary row's source (window-deriver idiom: 'episode:'-prefixed, deduped, member order preserved, capped at 64), so a summary keeps a direct line to the verbatim turns behind its members. No backfill: the recursive closure reads member stamps through derivedFrom, and recompose re-stamps incrementally as summaries recompute. Off (default) → every summary write is byte-identical (no episodeIds key, no SET fragment).",
+  },
+  {
+    key: 'PROVENANCE_RECURSIVE_CLOSURE',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Evidence plane, read side (Brain v2 gap #6): GET /v1/facts/:id/provenance of a fact WITH derivedFrom walks the support graph breadth-first (bounded by PROVENANCE_CLOSURE_MAX_DEPTH/_FACTS/_EPISODES) and serves the union of grounding episodes across the closure plus optional derivedFacts (factId/predicate/depth/status — compacted/retracted members still witness, status reported not hidden) and closure ({depth, factCount, truncated, filtered}) fields. Every member passes the same fences as the root (user scope, scope tags, row policy); an invisible member is a SILENT drop marked filtered:true — the root keeps its exact 404 semantics. Off (default) → the one-hop response is byte-identical (optional fields absent).',
+  },
+  {
+    key: 'PROVENANCE_CLOSURE_MAX_DEPTH',
+    category: 'pipeline',
+    defaultValue: '5',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Depth cap of the PROVENANCE_RECURSIVE_CLOSURE walk — max derivedFrom hops from the root (root = 0). Clamped to 1..10; unset/invalid → 5. Unvisited children past the cap mark the closure truncated.',
+  },
+  {
+    key: 'PROVENANCE_CLOSURE_MAX_FACTS',
+    category: 'pipeline',
+    defaultValue: '256',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Fact budget of the PROVENANCE_RECURSIVE_CLOSURE walk — total supporting facts admitted across all depths. Clamped to 1..1024; unset/invalid → 256. Children past the cap mark the closure truncated (fan-out cap).',
+  },
+  {
+    key: 'PROVENANCE_CLOSURE_MAX_EPISODES',
+    category: 'pipeline',
+    defaultValue: '200',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Episode budget of the PROVENANCE_RECURSIVE_CLOSURE walk — distinct grounding episodes harvested across the closure. Clamped to 1..500; unset/invalid → 200. Ids past the cap mark the closure truncated.',
+  },
+  {
     key: 'PROJECTIONS_API_ENABLED',
     category: 'pipeline',
     defaultValue: '0',

--- a/src/admin/insight-composer-kernel.ts
+++ b/src/admin/insight-composer-kernel.ts
@@ -31,6 +31,12 @@ export interface FactRowLite {
   predicate: string;
   object: string;
   validFrom?: string | Date;
+  /**
+   * `source.episodeIds AS episodeIds` — the member's grounding stamp
+   * (FLEXIBLE source, shape never guaranteed). Consumed by the
+   * composers' buildRow under PROVENANCE_SUMMARY_EPISODE_STAMP.
+   */
+  episodeIds?: unknown;
 }
 
 /**
@@ -159,7 +165,8 @@ async function composeEntity<P>(
   );
   const name = entity?.canonicalName ?? entityId;
   const [facts] = await db.query<[FactRowLite[]]>(
-    `SELECT id, predicate, object, validFrom FROM knowledge_fact
+    `SELECT id, predicate, object, validFrom, source.episodeIds AS episodeIds
+       FROM knowledge_fact
       WHERE entityId = $eid AND status = 'active'
         ${spec.sourceExclusionSql}
         ${versionClause}

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -770,6 +770,22 @@ const KNOWN_BOOLEAN_FLAGS = [
   // default off. Outside ENGINE_PREFIX by design (the FOVEA_ family sits off
   // the flag budget).
   'FOVEA_REQUIRE_CITATIONS',
+  // Evidence plane (Brain v2 gap #5): summary-producing writers
+  // (promotion, compaction rollups, recompose rewrites, arc/aggregate
+  // composers) stamp the union of member source.episodeIds onto the
+  // summary's source (window-deriver idiom, capped 64). Default off ⇒
+  // every summary write byte-identical. Outside ENGINE_PREFIX by design
+  // (the PROVENANCE_ family is a provenance surface, not an engine
+  // fork — sits off the flag budget like FOVEA_/MULTILINGUAL_).
+  'PROVENANCE_SUMMARY_EPISODE_STAMP',
+  // Evidence plane (Brain v2 gap #6): GET /v1/facts/:id/provenance runs
+  // a bounded recursive derivedFrom closure and serves the episode union
+  // + derivedFacts/closure fields. Member fences silently drop
+  // (filtered marker); root 404 semantics unchanged. Default off ⇒
+  // response byte-identical. The depth/fact/episode caps
+  // (PROVENANCE_CLOSURE_MAX_*) are integer knobs, not boolean flags.
+  // Outside ENGINE_PREFIX by design — off the flag budget.
+  'PROVENANCE_RECURSIVE_CLOSURE',
   // Multilingual Tier 1 (migration 0100). Confidence-aware attribution:
   // the detector returns `und` (not `en`) for short/stopword-less objects
   // and the resolver stamps langConfidence/langSource/detectorVersion/

--- a/src/common/episode-ids.ts
+++ b/src/common/episode-ids.ts
@@ -1,0 +1,22 @@
+/**
+ * The ONE episode-grounding union idiom (window-deriver.service.ts:876,
+ * replicated verbatim by every summary stamper of the evidence plane):
+ * union of the members' `source.episodeIds`, each value String()-coerced
+ * and filtered to the 'episode:' record prefix (source is FLEXIBLE —
+ * shapes are never guaranteed), deduped with member order preserved
+ * (Set insertion order), capped at 64.
+ *
+ * Pure module — importable from the compaction runners, the admin
+ * composers, and the provenance walker alike.
+ */
+export function unionEpisodeIds(memberEpisodeIds: readonly unknown[]): string[] {
+  const out = new Set<string>();
+  for (const list of memberEpisodeIds) {
+    if (!Array.isArray(list)) continue;
+    for (const raw of list) {
+      const id = String(raw);
+      if (id.startsWith('episode:')) out.add(id);
+    }
+  }
+  return [...out].slice(0, 64);
+}

--- a/src/common/provenance-flags.ts
+++ b/src/common/provenance-flags.ts
@@ -1,0 +1,92 @@
+import { envFlagEnabled } from './env-validation';
+
+/**
+ * Evidence plane — summary episode stamping master flag —
+ * PROVENANCE_SUMMARY_EPISODE_STAMP.
+ *
+ * When on, every summary-producing writer (promotion runner, compaction
+ * rollups, recompose rewrites, arc/aggregate composers) stamps the union
+ * of its members' `source.episodeIds` onto the summary row's source —
+ * the window-deriver idiom (window-deriver.service.ts:876): strings
+ * filtered to the 'episode:' prefix, deduped, member order preserved,
+ * capped at 64 — so a summary keeps a direct line to the verbatim turns
+ * behind its members instead of breaking the evidence chain at
+ * promotion. The env read lives here in the common layer, NOT inside the
+ * engine dirs (engine-gates S5.2). Read at call time so a flip is
+ * runtime-mutable. Default off ⇒ every summary write is byte-identical
+ * to today's rows (no episodeIds key is ever added, no SET fragment is
+ * ever emitted).
+ */
+export function summaryEpisodeStampEnabled(): boolean {
+  return envFlagEnabled(process.env.PROVENANCE_SUMMARY_EPISODE_STAMP);
+}
+
+/**
+ * Evidence plane — recursive support-closure master flag —
+ * PROVENANCE_RECURSIVE_CLOSURE.
+ *
+ * When on, GET /v1/facts/:id/provenance of a fact WITH `derivedFrom`
+ * runs a bounded BFS over the derivedFrom graph (provenance-closure.ts)
+ * and serves the union of grounding episodes across the closure plus the
+ * optional `derivedFacts` / `closure` result fields. Every member row
+ * passes the SAME per-row fences as the root (user scope, scope tags,
+ * row policy) — an invisible member is a SILENT drop (`filtered: true`),
+ * never an error, while the root keeps its exact 404 semantics. The env
+ * read lives here in the common layer, NOT inside the engine dirs
+ * (engine-gates S5.2). Read at call time so a flip is runtime-mutable.
+ * Default off ⇒ the provenance response is byte-identical to today's
+ * one-hop shape (the optional fields are absent, not empty).
+ */
+export function recursiveClosureEnabled(): boolean {
+  return envFlagEnabled(process.env.PROVENANCE_RECURSIVE_CLOSURE);
+}
+
+/** Closure walk caps — defaults + clamp bounds (see the knobs below). */
+const DEFAULT_CLOSURE_MAX_DEPTH = 5;
+const DEFAULT_CLOSURE_MAX_FACTS = 256;
+const DEFAULT_CLOSURE_MAX_EPISODES = 200;
+
+/** Integer knob: unset/blank/non-numeric → default; else clamped. */
+function intKnob(raw: string | undefined, dflt: number, range: [min: number, max: number]): number {
+  if (raw === undefined || raw.trim() === '') return dflt;
+  const v = Math.floor(Number(raw));
+  if (!Number.isFinite(v)) return dflt;
+  return Math.min(range[1], Math.max(range[0], v));
+}
+
+/**
+ * Closure depth cap (PROVENANCE_CLOSURE_MAX_DEPTH): the BFS stops after
+ * this many derivedFrom hops from the root; unvisited children beyond it
+ * report `truncated`. A non-boolean knob resolved here in the common
+ * layer so the walker takes a resolved number. Default 5, clamped to
+ * 1..10; unset, blank, or non-numeric → the default.
+ */
+export function closureMaxDepth(): number {
+  return intKnob(process.env.PROVENANCE_CLOSURE_MAX_DEPTH, DEFAULT_CLOSURE_MAX_DEPTH, [1, 10]);
+}
+
+/**
+ * Closure fact budget (PROVENANCE_CLOSURE_MAX_FACTS): total supporting
+ * facts the walk may admit across all depths; children beyond it report
+ * `truncated` (fan-out cap). A non-boolean knob resolved here in the
+ * common layer so the walker takes a resolved number. Default 256,
+ * clamped to 1..1024; unset, blank, or non-numeric → the default.
+ */
+export function closureMaxFacts(): number {
+  return intKnob(process.env.PROVENANCE_CLOSURE_MAX_FACTS, DEFAULT_CLOSURE_MAX_FACTS, [1, 1024]);
+}
+
+/**
+ * Closure episode budget (PROVENANCE_CLOSURE_MAX_EPISODES): distinct
+ * grounding episodes harvested across the walk; ids beyond it report
+ * `truncated`. A non-boolean knob resolved here in the common layer so
+ * the walker takes a resolved number. Default 200, clamped to 1..500;
+ * unset, blank, or non-numeric → the default.
+ */
+export function closureMaxEpisodes(): number {
+  return intKnob(
+    process.env.PROVENANCE_CLOSURE_MAX_EPISODES,
+    DEFAULT_CLOSURE_MAX_EPISODES,
+    [1, 500],
+  );
+}

--- a/src/compaction/compaction-runner.service.ts
+++ b/src/compaction/compaction-runner.service.ts
@@ -7,6 +7,8 @@ import { ReadPinService } from '../episodes/read-pin.service';
 import { ConcatSummaryGenerator, FactToSummarize, SummaryGenerator } from './summary-generator';
 import { CandidateFactRow, CompactionStats, SUMMARY_GENERATOR } from './compaction.types';
 import { envFlagEnabled } from '../common/env-validation';
+import { summaryEpisodeStampEnabled } from '../common/provenance-flags';
+import { unionEpisodeIds } from '../common/episode-ids';
 
 /**
  * CompactionRunnerService — the retention engine.
@@ -105,7 +107,8 @@ export class CompactionRunnerService {
       // tenant dominating the cron — anything past that gets compacted
       // on the next cycle.
       const [factRows] = await db.query<[CandidateFactRow[]]>(
-        `SELECT id, entityId, predicate, object, validFrom, validUntil, confidence, userId
+        `SELECT id, entityId, predicate, object, validFrom, validUntil, confidence, userId,
+                source.episodeIds AS eps
            FROM knowledge_fact
            WHERE status != 'compacted'
              AND embedding != NONE
@@ -201,6 +204,13 @@ export class CompactionRunnerService {
       const latest = last.validUntil ?? last.validFrom;
       const meanConfidence = sorted.reduce((acc, g) => acc + g.confidence, 0) / sorted.length;
 
+      // Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP): union of the
+      // members' grounding stamps, member order, capped 64. Flag off →
+      // empty union → source byte-identical to today's.
+      const episodeIds = summaryEpisodeStampEnabled()
+        ? unionEpisodeIds(sorted.map((g) => g.eps))
+        : [];
+
       await dbCreate(db, 'knowledge_fact', {
         entityId: first.entityId,
         predicate: `summary_${first.predicate}`,
@@ -208,7 +218,10 @@ export class CompactionRunnerService {
         confidence: meanConfidence,
         validFrom: earliest,
         validUntil: latest,
-        source: { kind: 'compaction-summary' },
+        source: {
+          kind: 'compaction-summary',
+          ...(episodeIds.length ? { episodeIds } : {}),
+        },
         derivedFrom: sorted.map((g) => g.id),
         status: 'active',
         // The summary belongs to the same world as the facts it replaces

--- a/src/compaction/compaction.types.ts
+++ b/src/compaction/compaction.types.ts
@@ -27,4 +27,6 @@ export interface CandidateFactRow {
   confidence: number;
   /** Per-user scope (0055); NONE/undefined = tenant-global. */
   userId?: string | null;
+  /** `source.episodeIds AS eps` — grounding stamp of the member (FLEXIBLE). */
+  eps?: unknown;
 }

--- a/src/compaction/promotion-runner.service.ts
+++ b/src/compaction/promotion-runner.service.ts
@@ -7,6 +7,8 @@ import { PREDICATE_POLICIES } from '../ingest/conflict-resolver';
 import { ConcatSummaryGenerator, FactToSummarize, SummaryGenerator } from './summary-generator';
 import { SUMMARY_GENERATOR } from './compaction.types';
 import { envFlagEnabled } from '../common/env-validation';
+import { summaryEpisodeStampEnabled } from '../common/provenance-flags';
+import { unionEpisodeIds } from '../common/episode-ids';
 
 /**
  * PromotionRunnerService — episodic→semantic promotion.
@@ -55,6 +57,8 @@ interface PromotableRow {
   validUntil?: string | null;
   confidence: number;
   userId?: string | null;
+  /** `source.episodeIds AS eps` — grounding stamp of the member (FLEXIBLE). */
+  eps?: unknown;
 }
 
 @Injectable()
@@ -170,7 +174,8 @@ export class PromotionRunnerService {
   ): Promise<number> {
     const scopeClause = group.userId ? 'AND userId = $scopeUser' : 'AND userId IS NONE';
     const [rows] = (await db.query(
-      `SELECT id, entityId, predicate, object, validFrom, validUntil, confidence, userId
+      `SELECT id, entityId, predicate, object, validFrom, validUntil, confidence, userId,
+              source.episodeIds AS eps
        FROM knowledge_fact
        WHERE entityId = $entity AND predicate = $predicate
          AND status = 'active' AND retractedAt IS NONE
@@ -222,6 +227,14 @@ export class PromotionRunnerService {
     const earliest = first.validFrom;
     const meanConfidence = members.reduce((acc, m) => acc + m.confidence, 0) / members.length;
 
+    // Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP): the summary
+    // carries the union of its members' grounding stamps (window-deriver
+    // idiom, capped 64). Flag off → empty union → the source object is
+    // byte-identical to today's `{ kind: 'promotion' }`.
+    const episodeIds = summaryEpisodeStampEnabled()
+      ? unionEpisodeIds(members.map((m) => m.eps))
+      : [];
+
     await dbCreate(db, 'knowledge_fact', {
       entityId: first.entityId,
       predicate: `summary_${group.predicate}`,
@@ -229,7 +242,7 @@ export class PromotionRunnerService {
       confidence: meanConfidence,
       validFrom: earliest,
       validUntil: last.validUntil ?? last.validFrom,
-      source: { kind: 'promotion' },
+      source: { kind: 'promotion', ...(episodeIds.length ? { episodeIds } : {}) },
       derivedFrom: members.map((m) => m.id),
       status: 'active',
       ...(group.userId ? { userId: group.userId } : {}),

--- a/src/compaction/recompose.service.ts
+++ b/src/compaction/recompose.service.ts
@@ -9,6 +9,8 @@ import { WorkerLoopService } from '../jobs/worker-loop.service';
 import { SUMMARY_GENERATOR } from './compaction.types';
 import { changefeedRow } from '../db/changefeed-row';
 import type { SummaryGenerator, FactToSummarize } from './summary-generator';
+import { summaryEpisodeStampEnabled } from '../common/provenance-flags';
+import { unionEpisodeIds } from '../common/episode-ids';
 
 /** Changefeed cursor key — distinct from the audit drain's per-table keys. */
 const CURSOR = 'recompose:knowledge_fact';
@@ -58,7 +60,12 @@ interface FactRow {
   validUntil?: unknown;
   retractedAt?: unknown;
   supersededBy?: unknown;
+  /** `source.episodeIds AS eps` — grounding stamp of the parent (FLEXIBLE). */
+  eps?: unknown;
 }
+
+/** A live parent as fed to the generator, carrying its grounding stamp. */
+type RecomposeParent = FactToSummarize & { eps?: unknown };
 
 /**
  * RecomposeService — Phase 1 of docs/roadmap/cascade-recompose-2026-07.md.
@@ -239,16 +246,16 @@ export class RecomposeService implements OnModuleInit {
    * at status='compacted' is NORMAL — that is what compaction does to its
    * sources — so it counts as surviving.
    */
-  private async currentParents(db: Surreal, recorded: unknown[]): Promise<FactToSummarize[]> {
+  private async currentParents(db: Surreal, recorded: unknown[]): Promise<RecomposeParent[]> {
     if (recorded.length === 0) return [];
     const rows = await queryRows<FactRow>(
       db,
       `SELECT id, predicate, object, confidence, validFrom, validUntil,
-              retractedAt, supersededBy
+              retractedAt, supersededBy, source.episodeIds AS eps
          FROM knowledge_fact WHERE id INSIDE $ids`,
       { ids: recorded.map((r) => new StringRecordId(String(r))) },
     );
-    const out: FactToSummarize[] = [];
+    const out: RecomposeParent[] = [];
     for (const row of rows) {
       const live = await this.followSupersedes(db, row);
       if (!live || live.retractedAt) continue;
@@ -259,6 +266,7 @@ export class RecomposeService implements OnModuleInit {
         validFrom: isoOf(live.validFrom),
         validUntil: live.validUntil ? isoOf(live.validUntil) : undefined,
         confidence: Number(live.confidence ?? 0),
+        eps: live.eps,
       });
     }
     // Chronological, matching how compaction built the summary originally.
@@ -272,7 +280,7 @@ export class RecomposeService implements OnModuleInit {
       const next = await queryRows<FactRow>(
         db,
         `SELECT id, predicate, object, confidence, validFrom, validUntil,
-                retractedAt, supersededBy
+                retractedAt, supersededBy, source.episodeIds AS eps
            FROM knowledge_fact WHERE id = $id`,
         { id: new StringRecordId(String(current.supersededBy)) },
       );
@@ -287,7 +295,7 @@ export class RecomposeService implements OnModuleInit {
   private async rewrite(
     db: Surreal,
     summaryId: string,
-    parents: FactToSummarize[],
+    parents: RecomposeParent[],
   ): Promise<boolean> {
     const text = await this.summaryGenerator.generate(parents);
     if (!text) return false;
@@ -295,12 +303,28 @@ export class RecomposeService implements OnModuleInit {
     const last = parents[parents.length - 1];
     if (!first || !last) return false; // no parents to recompose from
     const meanConfidence = parents.reduce((acc, p) => acc + p.confidence, 0) / parents.length;
+    // Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP): re-stamp the
+    // union of the CURRENT parents' grounding stamps in the same UPDATE
+    // (incremental re-stamp — this is why stamping needs no backfill
+    // pass). The SET fragment is emitted ONLY when the flag is on, so
+    // flag off produces today's exact statement; an empty union under
+    // the flag clears a possibly-stale field with NONE rather than
+    // leaving it behind.
+    const stamp = summaryEpisodeStampEnabled();
+    const episodeIds = stamp ? unionEpisodeIds(parents.map((p) => p.eps)) : [];
+    const episodeIdsSet = stamp
+      ? episodeIds.length > 0
+        ? `,
+         source.episodeIds = $episodeIds`
+        : `,
+         source.episodeIds = NONE`
+      : '';
     await db.query(
       `UPDATE $id SET
          object = $object, confidence = $confidence,
          validFrom = <datetime>$validFrom,
          validUntil = <datetime>$validUntil,
-         derivedFrom = $derivedFrom,
+         derivedFrom = $derivedFrom${episodeIdsSet},
          staleAt = NONE, staleReason = NONE`,
       {
         id: new StringRecordId(summaryId),
@@ -312,6 +336,7 @@ export class RecomposeService implements OnModuleInit {
         // no longer what this summary is derived from, and leaving the old id
         // would make the next invalidation pass chase a dead row.
         derivedFrom: parents.map((p) => new StringRecordId(p.factId)),
+        ...(episodeIds.length > 0 ? { episodeIds } : {}),
       },
     );
     return true;

--- a/src/contracts/facts/facts.schema.ts
+++ b/src/contracts/facts/facts.schema.ts
@@ -55,6 +55,38 @@ export const FactProvenanceResponseSchema = z.object({
   factId: z.string(),
   /** Grounding turns (source.episodeIds), chronological. */
   episodes: z.array(FactProvenanceEpisodeSchema),
+  /**
+   * Recursive support closure (PROVENANCE_RECURSIVE_CLOSURE, default
+   * off): the facts this fact was derived from, transitively, with
+   * their derivedFrom distance and lifecycle status (compacted /
+   * retracted members still witness — status is reported, not hidden).
+   * Absent (not empty) when the flag is off or the fact has no
+   * derivedFrom → backward-compatible.
+   */
+  derivedFacts: z
+    .array(
+      z.object({
+        factId: z.string(),
+        predicate: z.string(),
+        depth: z.number(),
+        status: z.string(),
+      }),
+    )
+    .optional(),
+  /**
+   * Closure walk summary: deepest hop reached, supporting-fact count,
+   * whether a depth/fan-out/episode cap truncated the walk, and whether
+   * a visibility fence silently dropped ≥1 member. Absent with the flag
+   * off → backward-compatible.
+   */
+  closure: z
+    .object({
+      depth: z.number(),
+      factCount: z.number(),
+      truncated: z.boolean(),
+      filtered: z.boolean(),
+    })
+    .optional(),
 });
 
 export type FactReadResponse = z.infer<typeof FactReadResponseSchema>;

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -5,17 +5,33 @@ import {
   NotFoundException,
   Optional,
 } from '@nestjs/common';
-import { Surreal } from 'surrealdb';
+import { StringRecordId, Surreal } from 'surrealdb';
 import { SurrealService, dbMerge, queryFirst, queryRows } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
-import { EpisodeReadStoreService } from '../episodes/episode-read-store.service';
+import { EpisodeReadStoreService, EpisodeQuoteRow } from '../episodes/episode-read-store.service';
 import { RetractFactDto } from './dto/retract.dto';
 import { BrainScope } from '../auth/api-key.types';
 import { pinUserScope } from '../auth/user-scope';
-import { principalScopeTags, scopeTagsEnabled, visibleUnderScope } from '../auth/scope-visibility';
-import { makeRowPolicyFilter, type PolicyFilterableRow } from '../policy/row-filter';
+import {
+  principalScopeTags,
+  scopeTagsEnabled,
+  visibleUnderScope,
+  type PrincipalScope,
+} from '../auth/scope-visibility';
+import {
+  makeRowPolicyFilter,
+  type PolicyFilterableRow,
+  type RowPolicyFilter,
+} from '../policy/row-filter';
 import { activeFactWhere } from '../entities/entity-read.helpers';
+import {
+  closureMaxDepth,
+  closureMaxEpisodes,
+  closureMaxFacts,
+  recursiveClosureEnabled,
+} from '../common/provenance-flags';
+import { indexCharSpans, walkProvenanceClosure, type ProvenanceSpan } from './provenance-closure';
 
 /**
  * Predicate-class allowlist that requires `brain:admin` for retract,
@@ -89,42 +105,6 @@ export interface RetractOptions {
  */
 const PROVENANCE_TEXT_CHAR_CAP = 600;
 
-/**
- * Defensive read of source.charSpans (G3 — written by the derive row
- * builder, but `source` is FLEXIBLE so shapes are never guaranteed).
- * Keeps the first well-formed span per episode; malformed entries are
- * ignored. Only {start, end, exact} go on the wire — prefix/suffix are
- * re-anchoring context for the store, not the API.
- */
-function indexCharSpans(
-  charSpans: unknown,
-): Map<string, { start: number; end: number; exact: string }> {
-  const byEpisode = new Map<string, { start: number; end: number; exact: string }>();
-  if (!Array.isArray(charSpans)) return byEpisode;
-  for (const raw of charSpans) {
-    const s = raw as {
-      episodeId?: unknown;
-      start?: unknown;
-      end?: unknown;
-      exact?: unknown;
-    };
-    if (
-      typeof s?.episodeId === 'string' &&
-      typeof s.start === 'number' &&
-      typeof s.end === 'number' &&
-      typeof s.exact === 'string' &&
-      !byEpisode.has(s.episodeId)
-    ) {
-      byEpisode.set(s.episodeId, {
-        start: s.start,
-        end: s.end,
-        exact: s.exact,
-      });
-    }
-  }
-  return byEpisode;
-}
-
 /** Wire shape of GET /v1/facts/:id. */
 export interface FactReadResult {
   factId: string;
@@ -164,11 +144,44 @@ export interface FactProvenanceEpisode {
   textTruncated?: boolean;
 }
 
+/**
+ * One supporting fact of the recursive closure
+ * (PROVENANCE_RECURSIVE_CLOSURE): what the root was derived from,
+ * transitively, with its derivedFrom distance and lifecycle status
+ * (compacted/retracted members still witness — status is reported,
+ * never hidden).
+ */
+export interface FactProvenanceDerivedFact {
+  factId: string;
+  predicate: string;
+  depth: number;
+  status: string;
+}
+
+/** Closure walk summary (PROVENANCE_RECURSIVE_CLOSURE). */
+export interface FactProvenanceClosure {
+  /** Deepest derivedFrom hop reached (root = 0). */
+  depth: number;
+  /** Supporting facts in the closure (root excluded). */
+  factCount: number;
+  /** True when a depth / fan-out / episode cap cut the walk short. */
+  truncated: boolean;
+  /** True when ≥1 member was silently dropped by a visibility fence. */
+  filtered: boolean;
+}
+
 /** Wire shape of GET /v1/facts/:id/provenance. */
 export interface FactProvenanceResult {
   factId: string;
   /** Grounding turns (source.episodeIds), chronological. */
   episodes: FactProvenanceEpisode[];
+  /**
+   * Recursive support closure (PROVENANCE_RECURSIVE_CLOSURE) — absent
+   * (not empty) when the flag is off or the root has no derivedFrom, so
+   * the default response stays byte-identical.
+   */
+  derivedFacts?: FactProvenanceDerivedFact[];
+  closure?: FactProvenanceClosure;
 }
 
 interface FactReadOptions {
@@ -178,7 +191,7 @@ interface FactReadOptions {
 }
 
 /** Row shape loadVisibleFact selects (superset of PolicyFilterableRow). */
-interface FactReadRow extends PolicyFilterableRow {
+export interface FactReadRow extends PolicyFilterableRow {
   id: unknown;
   object?: unknown;
   confidence?: unknown;
@@ -188,6 +201,54 @@ interface FactReadRow extends PolicyFilterableRow {
   derivedVersion?: unknown;
   /** Scope-tag AND-set (migration 0093); absent/empty = tenant-global. */
   scope?: unknown;
+  /** Provenance edges — the closure walk's frontier (option<array>). */
+  derivedFrom?: unknown;
+}
+
+/**
+ * The per-row read fences of loadVisibleFact, resolved once per request
+ * so the closure walk can apply the SAME verdict to every member row
+ * without rebuilding the policy filter per depth.
+ */
+export interface FactVisibilityGates {
+  /** pinUserScope(undefined) — undefined = M2M/tenant-wide. */
+  scopeUserId: string | undefined;
+  /** principalScopeTags() when SCOPE_TAGS_ENABLED; null ⇒ fence inert. */
+  principalTags: PrincipalScope | null;
+  /** Registry-backed scope fence + ABAC verdict (surface 'fact_read'). */
+  rowPolicy: Pick<RowPolicyFilter, 'filter'>;
+}
+
+/**
+ * The fence chain of the fact read path as a pure verdict — user scope
+ * (0055), scope tags (G6), then the registry-backed row policy, in the
+ * exact order loadVisibleFact has always applied them. No throwing: the
+ * root caller turns `false` into its 404, the closure walk turns it into
+ * a silent member drop.
+ */
+export function factVisible(fact: FactReadRow, gates: FactVisibilityGates): boolean {
+  // User scope (0055): another user's fact is invisible.
+  if (
+    gates.scopeUserId !== undefined &&
+    typeof fact.userId === 'string' &&
+    fact.userId.length > 0 &&
+    fact.userId !== gates.scopeUserId
+  ) {
+    return false;
+  }
+  // G6 scope-tag fence (SCOPE_TAGS_ENABLED) — ADDED alongside the
+  // userId ownership check above, never replacing it. Composed as an
+  // extra AND, it can only narrow visibility. Inert when the flag is
+  // off (principalTags null). See scope-visibility.ts.
+  if (gates.principalTags !== null) {
+    const recordScope = Array.isArray(fact.scope)
+      ? (fact.scope as unknown[]).map((t) => String(t))
+      : [];
+    if (!visibleUnderScope(recordScope, gates.principalTags)) return false;
+  }
+  // Registry-backed row policy (scope fence + ABAC) — same seam as the
+  // audit-fixed fact lanes under src/synthesize/.
+  return gates.rowPolicy.filter(fact);
 }
 
 export interface ListCompetingResult {
@@ -301,6 +362,16 @@ export class FactsService {
   async getProvenance(opts: FactReadOptions): Promise<FactProvenanceResult> {
     return this.surreal.withScopedCompany(opts.companyId, opts.scopes, async (db) => {
       const fact = await this.loadVisibleFact(db, opts);
+      // Recursive closure (PROVENANCE_RECURSIVE_CLOSURE) only for a root
+      // that HAS derivedFrom — flag off, or a leaf fact, takes the
+      // one-hop path below byte-identically (no optional fields).
+      if (
+        recursiveClosureEnabled() &&
+        Array.isArray(fact.derivedFrom) &&
+        fact.derivedFrom.length > 0
+      ) {
+        return this.provenanceWithClosure(db, opts, fact);
+      }
       const source = (fact.source ?? {}) as {
         episodeIds?: unknown;
         charSpans?: unknown;
@@ -320,37 +391,143 @@ export class FactsService {
             : pinUserScope(undefined),
         db,
       });
-      const episodes = rows
-        .slice()
-        .sort(
-          (a, b) =>
-            new Date(toIso(a.occurredAt)).getTime() - new Date(toIso(b.occurredAt)).getTime(),
-        )
-        .map((r): FactProvenanceEpisode => {
-          // G3: attach the fact's stored char span for this turn.
-          // textTruncated rides along because span offsets reference
-          // the FULL stored episode text, not the capped `text` view.
-          // Span-less episodes keep the pre-G3 shape byte-identical.
-          const span = spanByEpisode.get(String(r.id));
-          return {
-            episodeId: String(r.id),
-            ...(r.conversationId !== undefined ? { conversationId: r.conversationId } : {}),
-            ...(r.speaker !== undefined ? { speaker: r.speaker } : {}),
-            occurredAt: toIso(r.occurredAt),
-            text:
-              r.text.length > PROVENANCE_TEXT_CHAR_CAP
-                ? `${r.text.slice(0, PROVENANCE_TEXT_CHAR_CAP - 1)}…`
-                : r.text,
-            ...(span
-              ? {
-                  span,
-                  textTruncated: r.text.length > PROVENANCE_TEXT_CHAR_CAP,
-                }
-              : {}),
-          };
-        });
+      const episodes = this.mapProvenanceEpisodes(rows, spanByEpisode);
       return { factId: String(fact.id), episodes };
     });
+  }
+
+  /**
+   * PROVENANCE_RECURSIVE_CLOSURE read path: bounded BFS over the root's
+   * derivedFrom graph inside the ONE existing scoped connection. The
+   * fence gates are resolved ONCE (scope pin, scope tags, one row-policy
+   * filter for the whole walk — surface 'fact_read', finish() after) and
+   * applied to every member via the same `factVisible` verdict as the
+   * root; an invisible member is a silent drop (`filtered`), never an
+   * error. Episode fetches group per owning user — a member fact's own
+   * userId keys its turns (generalizing the root rule: '' falls back to
+   * the caller's pinned scope) — each group one PII-fenced byIds read.
+   */
+  private async provenanceWithClosure(
+    db: Surreal,
+    opts: FactReadOptions,
+    root: FactReadRow,
+  ): Promise<FactProvenanceResult> {
+    const scopeUserId = pinUserScope(undefined);
+    const principalTags = scopeTagsEnabled() ? principalScopeTags() : null;
+    const rowPolicy = makeRowPolicyFilter({
+      callerScopes: opts.scopes,
+      surface: 'fact_read',
+      policyLookup: await this.predicateRegistry?.rowPolicyLookup(opts.companyId),
+    });
+    const gates: FactVisibilityGates = { scopeUserId, principalTags, rowPolicy };
+    const closure = await walkProvenanceClosure<FactReadRow>({
+      root,
+      caps: {
+        maxDepth: closureMaxDepth(),
+        maxFacts: closureMaxFacts(),
+        maxEpisodes: closureMaxEpisodes(),
+      },
+      visible: (f) => factVisible(f, gates),
+      fetchByIds: async (ids) => {
+        // NO status filter — compacted/retracted members still witness;
+        // status is REPORTED on the wire, not hidden.
+        const [rows] = await db.query<[FactReadRow[]]>(
+          `SELECT id, predicate, object, confidence, validFrom, validUntil,
+                  recordedAt, retractedAt, status, source, userId, scope,
+                  derivedVersion, trustSnapshot, corroboration, derivedFrom
+             FROM knowledge_fact WHERE id INSIDE $ids`,
+          { ids: ids.map((id) => new StringRecordId(id)) },
+        );
+        return rows ?? [];
+      },
+    });
+    rowPolicy.finish();
+
+    // Episode fetch grouped per owning user ('' → the caller's pinned
+    // scope; else that fact's user — the caller already passed the
+    // fact-level gate for that member).
+    const includePii = opts.scopes.includes('brain:read_pii');
+    const byOwner = new Map<string, string[]>();
+    for (const [episodeId, owner] of closure.episodes) {
+      const group = byOwner.get(owner);
+      if (group) group.push(episodeId);
+      else byOwner.set(owner, [episodeId]);
+    }
+    const rows: EpisodeQuoteRow[] = [];
+    for (const [owner, ids] of byOwner) {
+      rows.push(
+        ...(await this.episodes.byIds({
+          companyId: opts.companyId,
+          ids,
+          includePii,
+          userId: owner === '' ? scopeUserId : owner,
+          db,
+        })),
+      );
+    }
+    const episodes = this.mapProvenanceEpisodes(rows, closure.spans);
+
+    const truncated =
+      closure.truncated.depth || closure.truncated.fanout || closure.truncated.episodes;
+    this.metrics?.countProvenanceClosure(
+      truncated ? 'truncated' : closure.closureFacts.length === 0 ? 'empty' : 'resolved',
+    );
+    return {
+      factId: String(root.id),
+      episodes,
+      derivedFacts: closure.closureFacts.map(({ fact, depth }) => ({
+        factId: String(fact.id),
+        predicate: String(fact.predicate),
+        depth,
+        status: String(fact.status ?? 'active'),
+      })),
+      closure: {
+        depth: closure.closureFacts.reduce((acc, c) => Math.max(acc, c.depth), 0),
+        factCount: closure.closureFacts.length,
+        truncated,
+        filtered: closure.filtered,
+      },
+    };
+  }
+
+  /**
+   * Chronological sort + wire mapping of provenance episode rows —
+   * shared by the one-hop path and the closure path so the per-episode
+   * shape (PROVENANCE_TEXT_CHAR_CAP, G3 span attachment) has ONE
+   * implementation.
+   */
+  private mapProvenanceEpisodes(
+    rows: EpisodeQuoteRow[],
+    spanByEpisode: Map<string, ProvenanceSpan>,
+  ): FactProvenanceEpisode[] {
+    return rows
+      .slice()
+      .sort(
+        (a, b) => new Date(toIso(a.occurredAt)).getTime() - new Date(toIso(b.occurredAt)).getTime(),
+      )
+      .map((r): FactProvenanceEpisode => {
+        // G3: attach the fact's stored char span for this turn.
+        // textTruncated rides along because span offsets reference
+        // the FULL stored episode text, not the capped `text` view.
+        // Span-less episodes keep the pre-G3 shape byte-identical.
+        const span = spanByEpisode.get(String(r.id));
+        return {
+          episodeId: String(r.id),
+          ...(r.conversationId !== undefined ? { conversationId: r.conversationId } : {}),
+          ...(r.speaker !== undefined ? { speaker: r.speaker } : {}),
+          occurredAt: toIso(r.occurredAt),
+          text:
+            r.text.length > PROVENANCE_TEXT_CHAR_CAP
+              ? `${r.text.slice(0, PROVENANCE_TEXT_CHAR_CAP - 1)}…`
+              : r.text,
+          ...(span
+            ? {
+                span,
+                textTruncated: r.text.length > PROVENANCE_TEXT_CHAR_CAP,
+              }
+            : {}),
+        };
+      });
   }
 
   /**
@@ -364,44 +541,28 @@ export class FactsService {
     const [rows] = await db.query<[FactReadRow[]]>(
       `SELECT id, predicate, object, confidence, validFrom, validUntil,
               recordedAt, retractedAt, status, source, userId, scope,
-              derivedVersion, trustSnapshot, corroboration
+              derivedVersion, trustSnapshot, corroboration, derivedFrom
          FROM type::record('knowledge_fact', $rid) LIMIT 1`,
       { rid: ref.id },
     );
     const notFound = () => new NotFoundException(`Fact ${opts.factId} not found`);
     const fact = rows?.[0];
     if (!fact) throw notFound();
-    // User scope (0055): 404, not 403 — don't leak existence.
-    const scopeUserId = pinUserScope(undefined);
-    if (
-      scopeUserId !== undefined &&
-      typeof fact.userId === 'string' &&
-      fact.userId.length > 0 &&
-      fact.userId !== scopeUserId
-    ) {
-      throw notFound();
-    }
-    // G6 scope-tag fence (SCOPE_TAGS_ENABLED) — ADDED alongside the
-    // userId ownership check above, never replacing it. Composed as an
-    // extra AND, it can only narrow visibility; a row hidden here (an
-    // unparseable or non-matching scope tag) is a 404 exactly like the
-    // userId miss. Inert when the flag is off. See scope-visibility.ts.
-    if (scopeTagsEnabled()) {
-      const recordScope = Array.isArray(fact.scope)
-        ? (fact.scope as unknown[]).map((t) => String(t))
-        : [];
-      if (!visibleUnderScope(recordScope, principalScopeTags())) {
-        throw notFound();
-      }
-    }
-    // Registry-backed row policy (scope fence + ABAC) — same seam as the
-    // audit-fixed fact lanes under src/synthesize/.
+    // The fence chain lives in factVisible (shared with the closure
+    // walk); ANY miss is the same 404 — user scope (0055) and scope tags
+    // (G6) 404 rather than 403 so existence never leaks, and a row-
+    // policy-fenced predicate is simply absent to callers without the
+    // scope.
     const rowPolicy = makeRowPolicyFilter({
       callerScopes: opts.scopes,
       surface: 'fact_read',
       policyLookup: await this.predicateRegistry?.rowPolicyLookup(opts.companyId),
     });
-    const visible = rowPolicy.filter(fact);
+    const visible = factVisible(fact, {
+      scopeUserId: pinUserScope(undefined),
+      principalTags: scopeTagsEnabled() ? principalScopeTags() : null,
+      rowPolicy,
+    });
     rowPolicy.finish();
     if (!visible) throw notFound();
     return fact;
@@ -822,5 +983,18 @@ function toIso(value: unknown): string {
   if (value instanceof Date) return value.toISOString();
   if (typeof value === 'string') return value;
   if (typeof value === 'number') return new Date(value).toISOString();
+  // SurrealDB SDK 2.x decodes datetime columns to its own DateTime class
+  // (NOT a native Date — String()/JSON already yield the ISO form).
+  // Duck-type on toISOString so live rows don't fall through to the
+  // "now" fallback below, which silently served the REQUEST time as
+  // occurredAt/validFrom and broke chronological provenance ordering
+  // (caught by the closure e2e against a real SurrealDB).
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { toISOString?: unknown }).toISOString === 'function'
+  ) {
+    return (value as { toISOString: () => string }).toISOString();
+  }
   return new Date().toISOString();
 }

--- a/src/facts/provenance-closure.ts
+++ b/src/facts/provenance-closure.ts
@@ -1,0 +1,219 @@
+/**
+ * Bounded recursive provenance closure (evidence plane, PR gap #6).
+ *
+ * Promotion/compaction/composers replace member facts with summary rows
+ * whose `derivedFrom` points at the (now hidden) members — one-hop
+ * provenance dead-ends at the summary. This walker follows `derivedFrom`
+ * breadth-first from an ALREADY-FENCED root, harvesting each depth's
+ * grounding stamps (`source.episodeIds` + `source.charSpans`), so the
+ * provenance surface can serve the union of verbatim turns behind the
+ * whole support closure.
+ *
+ * Pure module, unit-testable with a stubbed db: the caller supplies the
+ * batched row fetch and the per-row visibility verdict. Fence semantics
+ * are the caller's (facts.service `factVisible`): an invisible member is
+ * a SILENT drop (`filtered`), never an error — and its subtree is
+ * dropped with it, because evidence reachable only through a fenced fact
+ * is evidence the caller may not see.
+ *
+ * Status is deliberately NOT filtered: compacted/retracted members still
+ * witness what a summary was derived from — status is REPORTED on the
+ * wire, not hidden.
+ */
+
+/** Wire span shape — {start, end, exact} only (G3). */
+export interface ProvenanceSpan {
+  start: number;
+  end: number;
+  exact: string;
+}
+
+/**
+ * Defensive read of source.charSpans (G3 — written by the derive row
+ * builder, but `source` is FLEXIBLE so shapes are never guaranteed).
+ * Keeps the first well-formed span per episode; malformed entries are
+ * ignored. Only {start, end, exact} go on the wire — prefix/suffix are
+ * re-anchoring context for the store, not the API.
+ */
+export function indexCharSpans(charSpans: unknown): Map<string, ProvenanceSpan> {
+  const byEpisode = new Map<string, ProvenanceSpan>();
+  if (!Array.isArray(charSpans)) return byEpisode;
+  for (const raw of charSpans) {
+    const s = raw as {
+      episodeId?: unknown;
+      start?: unknown;
+      end?: unknown;
+      exact?: unknown;
+    };
+    if (
+      typeof s?.episodeId === 'string' &&
+      typeof s.start === 'number' &&
+      typeof s.end === 'number' &&
+      typeof s.exact === 'string' &&
+      !byEpisode.has(s.episodeId)
+    ) {
+      byEpisode.set(s.episodeId, {
+        start: s.start,
+        end: s.end,
+        exact: s.exact,
+      });
+    }
+  }
+  return byEpisode;
+}
+
+/** The minimal row shape the walk reads. FactReadRow satisfies it. */
+export interface ClosureFactRow {
+  id: unknown;
+  predicate?: unknown;
+  status?: unknown;
+  userId?: unknown;
+  source?: unknown;
+  derivedFrom?: unknown;
+}
+
+export interface ProvenanceClosureCaps {
+  /** Max derivedFrom hops from the root (root = depth 0). */
+  maxDepth: number;
+  /** Total supporting facts admitted across the whole walk. */
+  maxFacts: number;
+  /** Distinct grounding episodes harvested across the whole walk. */
+  maxEpisodes: number;
+}
+
+export interface ProvenanceClosureResult<Row extends ClosureFactRow> {
+  /** Visible supporting facts, BFS order, root excluded (depth ≥ 1). */
+  closureFacts: Array<{ fact: Row; depth: number }>;
+  /**
+   * episodeId → contributing fact's userId ('' = tenant-global).
+   * Insertion-ordered (BFS order, root's stamps first); the first
+   * contributing fact wins the ownership key.
+   */
+  episodes: Map<string, string>;
+  /** episodeId → first-wins char span across the walk (root first). */
+  spans: Map<string, ProvenanceSpan>;
+  truncated: { depth: boolean; fanout: boolean; episodes: boolean };
+  /** True when ≥1 member row was silently dropped by the fence. */
+  filtered: boolean;
+}
+
+/** Mutable walk bookkeeping shared by the per-depth helpers. */
+interface WalkState {
+  visited: Set<string>;
+  episodes: Map<string, string>;
+  spans: Map<string, ProvenanceSpan>;
+  truncated: { depth: boolean; fanout: boolean; episodes: boolean };
+  /** Fact budget consumed — children admitted across the whole walk. */
+  admitted: number;
+}
+
+/**
+ * Harvest one fact's grounding stamps into the walk state: 'episode:'-
+ * prefixed ids (String()-coerced, deduped, episode-budget capped) keyed
+ * to the fact's userId ('' = tenant-global), and first-wins char spans.
+ */
+function harvestGrounding(fact: ClosureFactRow, caps: ProvenanceClosureCaps, s: WalkState): void {
+  const source = (fact.source ?? {}) as { episodeIds?: unknown; charSpans?: unknown };
+  const owner = typeof fact.userId === 'string' && fact.userId.length > 0 ? fact.userId : '';
+  if (Array.isArray(source.episodeIds)) {
+    for (const raw of source.episodeIds) {
+      const id = String(raw);
+      if (!id.startsWith('episode:') || s.episodes.has(id)) continue;
+      if (s.episodes.size >= caps.maxEpisodes) {
+        s.truncated.episodes = true;
+        continue;
+      }
+      s.episodes.set(id, owner);
+    }
+  }
+  for (const [episodeId, span] of indexCharSpans(source.charSpans)) {
+    if (!s.spans.has(episodeId)) s.spans.set(episodeId, span);
+  }
+}
+
+/**
+ * The frontier's next generation: union of derivedFrom minus visited,
+ * String()-normalized, capped by the walk-wide fact budget (fanout).
+ */
+function collectChildren(
+  frontier: readonly ClosureFactRow[],
+  caps: ProvenanceClosureCaps,
+  s: WalkState,
+): string[] {
+  const children: string[] = [];
+  for (const fact of frontier) {
+    if (!Array.isArray(fact.derivedFrom)) continue;
+    for (const raw of fact.derivedFrom) {
+      const id = String(raw);
+      if (s.visited.has(id)) continue;
+      if (s.admitted >= caps.maxFacts) {
+        s.truncated.fanout = true;
+        continue;
+      }
+      s.visited.add(id);
+      s.admitted += 1;
+      children.push(id);
+    }
+  }
+  return children;
+}
+
+/**
+ * BFS over `derivedFrom` from an already-fenced root. One batched fetch
+ * per depth (`WHERE id INSIDE $ids` — the caller's query carries NO
+ * status filter); record-id shapes are String()-normalized throughout,
+ * so RecordId objects and plain strings key the visited set identically
+ * (which is also what terminates cycles — each id is admitted once).
+ */
+export async function walkProvenanceClosure<Row extends ClosureFactRow>(opts: {
+  root: Row;
+  caps: ProvenanceClosureCaps;
+  /** Per-row fence verdict (user scope / scope tags / row policy). */
+  visible: (fact: Row) => boolean;
+  /** ONE batched SELECT of loadVisibleFact's column set — no status filter. */
+  fetchByIds: (ids: string[]) => Promise<Row[]>;
+}): Promise<ProvenanceClosureResult<Row>> {
+  const { caps } = opts;
+  const state: WalkState = {
+    visited: new Set<string>([String(opts.root.id)]),
+    episodes: new Map<string, string>(),
+    spans: new Map<string, ProvenanceSpan>(),
+    truncated: { depth: false, fanout: false, episodes: false },
+    admitted: 0,
+  };
+  const closureFacts: Array<{ fact: Row; depth: number }> = [];
+  let filtered = false;
+  let frontier: Row[] = [opts.root];
+  let depth = 0;
+
+  while (frontier.length > 0) {
+    // 1. Harvest this depth's grounding stamps. A member without
+    //    episodeIds still contributes its children below.
+    for (const fact of frontier) harvestGrounding(fact, caps, state);
+
+    // 2. Next generation, minus visited, fact-budget capped.
+    const children = collectChildren(frontier, caps, state);
+    if (children.length === 0) break;
+    if (depth >= caps.maxDepth) {
+      // Unvisited children remain past the depth cap.
+      state.truncated.depth = true;
+      break;
+    }
+
+    // 3. Fetch + fence. Invisible member = silent drop, subtree included.
+    const rows = await opts.fetchByIds(children);
+    const visibleRows = rows.filter((row) => opts.visible(row));
+    if (visibleRows.length < rows.length) filtered = true;
+    depth += 1;
+    for (const row of visibleRows) closureFacts.push({ fact: row, depth });
+    frontier = visibleRows;
+  }
+
+  return {
+    closureFacts,
+    episodes: state.episodes,
+    spans: state.spans,
+    truncated: state.truncated,
+    filtered,
+  };
+}

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -335,6 +335,20 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // Evidence plane (PROVENANCE_RECURSIVE_CLOSURE): one recursive
+  // support-closure walk over derivedFrom per provenance read —
+  //   resolved  — walk completed inside every cap, ≥1 supporting fact
+  //   truncated — a depth / fan-out / episode cap cut the walk short
+  //               (partial closure still served)
+  //   empty     — walk ran but no visible supporting fact remained
+  //               (dangling derivedFrom, or every member fenced)
+  readonly provenanceClosureCount = new Counter({
+    name: 'brain_provenance_closure_total',
+    help: 'Recursive provenance closure walks by outcome',
+    labelNames: ['outcome'] as const,
+    registers: [this.registry],
+  });
+
   readonly forgets = new Counter({
     name: 'brain_forget_total',
     help: 'Number of entity forgets (cascade)',
@@ -700,6 +714,10 @@ export class MetricsService implements OnModuleInit {
 
   countRetract(): void {
     this.retracts.inc();
+  }
+
+  countProvenanceClosure(outcome: 'resolved' | 'truncated' | 'empty'): void {
+    this.provenanceClosureCount.inc({ outcome } as LabelValues<'outcome'>);
   }
 
   countForget(): void {

--- a/test/aggregate-composer.unit-spec.ts
+++ b/test/aggregate-composer.unit-spec.ts
@@ -8,7 +8,13 @@ import type { FactEmbeddingService } from '../src/ingest/fact-embedding.service'
 
 function makeSvc(opts: {
   tops: Array<{ entityId: string; n: number }>;
-  facts: Array<{ id: string; predicate: string; object: string; validFrom: string }>;
+  facts: Array<{
+    id: string;
+    predicate: string;
+    object: string;
+    validFrom: string;
+    episodeIds?: string[];
+  }>;
   llm: unknown;
 }): {
   svc: AggregateComposerService;
@@ -177,5 +183,67 @@ describe('AggregateComposerService (Lane C v1)', () => {
     const res = await svc.run('co_x');
     expect(res.entities).toBe(0);
     expect(res.skipped).toEqual([{ entityId: 'knowledge_entity:mel', reason: 'llm down' }]);
+  });
+});
+
+/**
+ * Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP): an aggregate row's
+ * source gains the union of its members' grounding stamps —
+ * window-deriver idiom (member order, deduped, capped 64). Off
+ * (default) the written source deep-equals today's exactly.
+ */
+describe('AggregateComposerService — summary episode stamping', () => {
+  const saved = process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+    else process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = saved;
+  });
+
+  const STAMPED_FACTS = FACTS.map((f, i) => ({
+    ...f,
+    episodeIds: [`episode:e${i}`, 'episode:shared'],
+  }));
+  const LLM = {
+    aggregates: [
+      {
+        aspect: 'pets',
+        proposition: "Melanie's pets: cat Bailey and a dog.",
+        members: [1, 0],
+      },
+    ],
+  };
+
+  it('flag OFF (default): written source deep-equals today’s', async () => {
+    delete process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+    const { svc, queries } = makeSvc({
+      tops: [{ entityId: 'knowledge_entity:mel', n: 5 }],
+      facts: STAMPED_FACTS,
+      llm: LLM,
+    });
+    await svc.run('co_x');
+    const swap = queries.find((q) => q.sql.includes('INSERT INTO knowledge_fact'));
+    const rows = swap?.params?.rows as Array<Record<string, unknown>>;
+    expect(rows[0]!.source).toEqual({
+      vertical: 'aggregate',
+      recorder: AGGREGATE_RECORDER,
+    });
+  });
+
+  it('flag ON: source carries the member union — member order, deduped, capped 64', async () => {
+    process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = '1';
+    const { svc, queries } = makeSvc({
+      tops: [{ entityId: 'knowledge_entity:mel', n: 5 }],
+      facts: STAMPED_FACTS,
+      llm: LLM,
+    });
+    await svc.run('co_x');
+    const swap = queries.find((q) => q.sql.includes('INSERT INTO knowledge_fact'));
+    const rows = swap?.params?.rows as Array<Record<string, unknown>>;
+    // Proposal member order [1, 0]; 'shared' deduped on first sight.
+    expect((rows[0]!.source as Record<string, unknown>).episodeIds).toEqual([
+      'episode:e1',
+      'episode:shared',
+      'episode:e0',
+    ]);
   });
 });

--- a/test/arc-composer.unit-spec.ts
+++ b/test/arc-composer.unit-spec.ts
@@ -25,6 +25,7 @@ function makeSvc(opts: {
     predicate: string;
     object: string;
     validFrom: string;
+    episodeIds?: string[];
   }>;
   llm: unknown;
 }): {
@@ -226,5 +227,92 @@ describe('ArcComposerService (V9 §3)', () => {
     const res = await svc.run('co_x');
     expect(res.entities).toBe(0);
     expect(res.skipped).toEqual([{ entityId: 'knowledge_entity:mel', reason: 'llm down' }]);
+  });
+});
+
+/**
+ * Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP): an arc row's source
+ * gains the union of its members' grounding stamps — window-deriver
+ * idiom (member order, deduped, capped 64). Off (default) the written
+ * source deep-equals today's exactly.
+ */
+describe('ArcComposerService — summary episode stamping', () => {
+  const saved = process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+    else process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = saved;
+  });
+
+  const STAMPED_FACTS = FACTS.map((f, i) => ({
+    ...f,
+    episodeIds: [`episode:e${i}`, 'episode:shared'],
+  }));
+  const LLM = {
+    arcs: [
+      {
+        topic: 'move',
+        narrative: 'Planned in March; chose Austin in May.',
+        members: [1, 0],
+      },
+    ],
+  };
+
+  it('flag OFF (default): written source deep-equals today’s', async () => {
+    delete process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+    const { svc, queries } = makeSvc({
+      tops: [{ entityId: 'knowledge_entity:mel', n: 5 }],
+      facts: STAMPED_FACTS,
+      llm: LLM,
+    });
+    await svc.run('co_x');
+    const swap = queries.find((q) => q.sql.includes('INSERT INTO knowledge_fact'));
+    const rows = swap?.params?.rows as Array<Record<string, unknown>>;
+    expect(rows[0]!.source).toEqual({ vertical: 'arc', recorder: ARC_RECORDER });
+  });
+
+  it('flag ON: source carries the member union — member order, deduped, capped 64', async () => {
+    process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = '1';
+    const { svc, queries } = makeSvc({
+      tops: [{ entityId: 'knowledge_entity:mel', n: 5 }],
+      facts: STAMPED_FACTS,
+      llm: LLM,
+    });
+    await svc.run('co_x');
+    const swap = queries.find((q) => q.sql.includes('INSERT INTO knowledge_fact'));
+    const rows = swap?.params?.rows as Array<Record<string, unknown>>;
+    // Proposal member order [1, 0]; 'shared' deduped on first sight.
+    expect((rows[0]!.source as Record<string, unknown>).episodeIds).toEqual([
+      'episode:e1',
+      'episode:shared',
+      'episode:e0',
+    ]);
+  });
+
+  it('flag ON: the union is capped at 64', async () => {
+    process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = '1';
+    const wide = FACTS.map((f, i) => ({
+      ...f,
+      episodeIds: Array.from({ length: 40 }, (_, j) => `episode:f${i}_${j}`),
+    }));
+    const { svc, queries } = makeSvc({
+      tops: [{ entityId: 'knowledge_entity:mel', n: 5 }],
+      facts: wide,
+      llm: LLM,
+    });
+    await svc.run('co_x');
+    const swap = queries.find((q) => q.sql.includes('INSERT INTO knowledge_fact'));
+    const rows = swap?.params?.rows as Array<Record<string, unknown>>;
+    expect((rows[0]!.source as Record<string, unknown>).episodeIds).toHaveLength(64);
+  });
+
+  it('the source SELECT carries the grounding stamp column', async () => {
+    const { svc, queries } = makeSvc({
+      tops: [{ entityId: 'knowledge_entity:mel', n: 5 }],
+      facts: STAMPED_FACTS,
+      llm: { arcs: [] },
+    });
+    await svc.run('co_x');
+    const src = queries.find((q) => q.sql.includes('SELECT id, predicate'));
+    expect(src?.sql).toContain('source.episodeIds AS episodeIds');
   });
 });

--- a/test/compaction.unit-spec.ts
+++ b/test/compaction.unit-spec.ts
@@ -1,10 +1,14 @@
 /**
  * Unit-test for CompactionService. Mocks SurrealService, ApiKeyService,
  * and the SummaryGenerator to verify retention math, multi-tenant fan-out,
- * error isolation, and the optional summary leg.
+ * error isolation, and the optional summary leg — plus the evidence-plane
+ * episode stamping of compaction AND promotion summaries
+ * (PROVENANCE_SUMMARY_EPISODE_STAMP; both runners live in src/compaction).
  */
 import { ConfigService } from '@nestjs/config';
 import { CompactionRunnerService } from '../src/compaction/compaction-runner.service';
+import { PromotionRunnerService } from '../src/compaction/promotion-runner.service';
+import type { EmbedderService } from '../src/ai/embedder.service';
 import type { FactToSummarize, SummaryGenerator } from '../src/compaction/summary-generator';
 import type { SurrealService } from '../src/db/surreal.service';
 
@@ -33,6 +37,8 @@ interface CandidateRow {
   validFrom: string;
   validUntil?: string;
   confidence: number;
+  /** `source.episodeIds AS eps` — grounding stamp of the member. */
+  eps?: string[];
 }
 
 interface TenantSeed {
@@ -296,6 +302,202 @@ describe('CompactionService — summary mode (COMPACTION_SUMMARIES=true)', () =>
     expect(stats!.summariesCreated).toBe(0);
     expect(gen.calls).toHaveLength(0);
     expect(created).toHaveLength(0);
+  });
+});
+
+/**
+ * Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP): a compaction
+ * rollup's source gains the union of its members' grounding stamps
+ * (window-deriver idiom — member order, deduped, capped 64). Off
+ * (default) the written source deep-equals today's exactly.
+ */
+describe('CompactionRunnerService — summary episode stamping', () => {
+  const saved = process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+    else process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = saved;
+  });
+
+  const stampedRows = () =>
+    rows([
+      {
+        id: 'fact:1',
+        predicate: 'tier',
+        object: 'gold',
+        validFrom: '2025-01-01T00:00:00Z',
+        eps: ['episode:e1', 'episode:shared'],
+      },
+      {
+        id: 'fact:2',
+        predicate: 'tier',
+        object: 'platinum',
+        validFrom: '2025-04-01T00:00:00Z',
+        eps: ['episode:shared', 'episode:e2'],
+      },
+    ]);
+
+  const makeRunner = (surreal: SurrealService) =>
+    new CompactionRunnerService(
+      surreal,
+      new StubConfig({ COMPACTION_SUMMARIES: 'true' }) as unknown as ConfigService,
+      { generate: async () => 'S' },
+    );
+
+  it('flag OFF (default): written source deep-equals today’s', async () => {
+    delete process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+    const { surreal, created } = makeFakeSurreal({ co_a: { rows: stampedRows() } });
+    await makeRunner(surreal).compactAll(['co_a']);
+    expect(created).toHaveLength(1);
+    expect(created[0]!.payload.source).toEqual({ kind: 'compaction-summary' });
+  });
+
+  it('flag ON: source carries the member union — member order, deduped', async () => {
+    process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = '1';
+    const { surreal, created } = makeFakeSurreal({ co_a: { rows: stampedRows() } });
+    await makeRunner(surreal).compactAll(['co_a']);
+    expect(created).toHaveLength(1);
+    expect(created[0]!.payload.source).toEqual({
+      kind: 'compaction-summary',
+      episodeIds: ['episode:e1', 'episode:shared', 'episode:e2'],
+    });
+  });
+
+  it('flag ON: members without stamps yield today’s source (no empty key)', async () => {
+    process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = '1';
+    const { surreal, created } = makeFakeSurreal({
+      co_a: {
+        rows: rows([
+          { id: 'fact:1', predicate: 'tier', object: 'gold' },
+          { id: 'fact:2', predicate: 'tier', object: 'platinum' },
+        ]),
+      },
+    });
+    await makeRunner(surreal).compactAll(['co_a']);
+    expect(created[0]!.payload.source).toEqual({ kind: 'compaction-summary' });
+  });
+
+  it('the candidate SELECT carries the grounding stamp column', async () => {
+    const { surreal, calls } = makeFakeSurreal({ co_a: { rows: [] } });
+    await makeRunner(surreal).compactAll(['co_a']);
+    const select = calls[0]!.calls.find((c) => c.sql.includes('SELECT id, entityId'))!;
+    expect(select.sql).toContain('source.episodeIds AS eps');
+  });
+});
+
+/**
+ * Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP) on the promotion
+ * runner: the episodic→semantic summary carries the union of the folded
+ * members' grounding stamps. Off (default) the written source
+ * deep-equals today's `{ kind: 'promotion' }` exactly.
+ */
+describe('PromotionRunnerService — summary episode stamping', () => {
+  const saved = process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+    else process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = saved;
+  });
+
+  interface PromotableSeed {
+    id: string;
+    object: string;
+    validFrom: string;
+    eps?: string[];
+  }
+
+  function makePromotionStack(seeds: PromotableSeed[]) {
+    const calls: QueryCall[] = [];
+    const created: Array<Record<string, unknown>> = [];
+    const fakeDb = {
+      async query<R>(sql: string, params?: Record<string, unknown>): Promise<R> {
+        calls.push({ sql, params });
+        if (sql.includes('GROUP BY entityId, predicate, userId')) {
+          return [
+            [{ entityId: 'knowledge_entity:e1', predicate: 'said', n: seeds.length }],
+          ] as unknown as R;
+        }
+        if (sql.includes('WHERE entityId = $entity AND predicate = $predicate')) {
+          return [
+            seeds.map((s) => ({
+              id: s.id,
+              entityId: 'knowledge_entity:e1',
+              predicate: 'said',
+              object: s.object,
+              validFrom: s.validFrom,
+              confidence: 0.9,
+              ...(s.eps ? { eps: s.eps } : {}),
+            })),
+          ] as unknown as R;
+        }
+        if (sql.startsWith('CREATE type::table($t)')) {
+          created.push(params!.d as Record<string, unknown>);
+          return [[{ id: 'knowledge_fact:summary1' }]] as unknown as R;
+        }
+        return [[]] as unknown as R;
+      },
+    };
+    const surreal = {
+      withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>) => fn(fakeDb),
+    } as unknown as SurrealService;
+    const embedder = { embed: async () => [1, 0] } as unknown as EmbedderService;
+    const runner = new PromotionRunnerService(
+      surreal,
+      new StubConfig({
+        COMPACTION_PROMOTION_ENABLED: '1',
+        COMPACTION_PROMOTION_MIN_GROUP: '2',
+      }) as unknown as ConfigService,
+      embedder,
+      { generate: async () => 'promoted summary' },
+    );
+    return { runner, calls, created };
+  }
+
+  // 'said' is a seed append_only predicate — the only class promotion folds.
+  const SEEDS: PromotableSeed[] = [
+    {
+      id: 'knowledge_fact:s1',
+      object: 'old remark 1',
+      validFrom: '2025-01-01T00:00:00Z',
+      eps: ['episode:e1', 'episode:shared'],
+    },
+    {
+      id: 'knowledge_fact:s2',
+      object: 'old remark 2',
+      validFrom: '2025-02-01T00:00:00Z',
+      eps: ['episode:shared', 'episode:e2'],
+    },
+  ];
+
+  it('flag OFF (default): written source deep-equals today’s { kind: promotion }', async () => {
+    delete process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+    const { runner, created } = makePromotionStack(SEEDS);
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(1);
+    expect(created).toHaveLength(1);
+    expect(created[0]!.source).toEqual({ kind: 'promotion' });
+  });
+
+  it('flag ON: source carries the member union — member order, deduped', async () => {
+    process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = '1';
+    const { runner, created } = makePromotionStack(SEEDS);
+    await runner.promoteCompany('co_a');
+    expect(created[0]!.source).toEqual({
+      kind: 'promotion',
+      episodeIds: ['episode:e1', 'episode:shared', 'episode:e2'],
+    });
+  });
+
+  it('flag ON: unstamped members yield today’s source (no empty key)', async () => {
+    process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = '1';
+    const { runner, created } = makePromotionStack(SEEDS.map(({ eps: _eps, ...s }) => s));
+    await runner.promoteCompany('co_a');
+    expect(created[0]!.source).toEqual({ kind: 'promotion' });
+  });
+
+  it('the member SELECT carries the grounding stamp column', async () => {
+    const { runner, calls } = makePromotionStack(SEEDS);
+    await runner.promoteCompany('co_a');
+    const select = calls.find((c) => c.sql.includes('WHERE entityId = $entity'))!;
+    expect(select.sql).toContain('source.episodeIds AS eps');
   });
 });
 

--- a/test/contracts-facts.unit-spec.ts
+++ b/test/contracts-facts.unit-spec.ts
@@ -18,6 +18,9 @@ import type {
   FactReadResult,
 } from '../src/facts/facts.service';
 
+const expectKeys = (shape: Record<string, unknown>, sample: Record<string, unknown>) =>
+  expect(Object.keys(shape).sort()).toEqual(Object.keys(sample).sort());
+
 const fullFact: Required<FactReadResult> = {
   factId: 'knowledge_fact:abc',
   aspect: 'residence',
@@ -44,9 +47,20 @@ const fullEpisode: Required<FactProvenanceEpisode> = {
   textTruncated: false,
 };
 
-const fullProvenance: FactProvenanceResult = {
+const fullProvenance: Required<FactProvenanceResult> = {
   factId: 'knowledge_fact:abc',
   episodes: [fullEpisode],
+  // PROVENANCE_RECURSIVE_CLOSURE optionals — absent when the flag is
+  // off; the fully-populated sample pins the on-shape both ways.
+  derivedFacts: [
+    {
+      factId: 'knowledge_fact:member1',
+      predicate: 'residence',
+      depth: 1,
+      status: 'compacted',
+    },
+  ],
+  closure: { depth: 1, factCount: 1, truncated: false, filtered: false },
 };
 
 describe('facts wire contracts', () => {
@@ -64,9 +78,19 @@ describe('facts wire contracts', () => {
     expect(parsed.success).toBe(true);
   });
 
+  it('FactProvenanceResponseSchema parses the flag-off shape (optionals absent)', () => {
+    const parsed = FactProvenanceResponseSchema.safeParse({
+      factId: 'knowledge_fact:abc',
+      episodes: [fullEpisode],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('FactProvenanceResponseSchema covers every response field — both directions', () => {
+    expectKeys(FactProvenanceResponseSchema.shape, fullProvenance);
+  });
+
   it('FactProvenanceEpisodeSchema covers every episode field — both directions', () => {
-    expect(Object.keys(FactProvenanceEpisodeSchema.shape).sort()).toEqual(
-      Object.keys(fullEpisode).sort(),
-    );
+    expectKeys(FactProvenanceEpisodeSchema.shape, fullEpisode);
   });
 });

--- a/test/fact-provenance-closure.e2e-spec.ts
+++ b/test/fact-provenance-closure.e2e-spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Evidence plane e2e (PROVENANCE_RECURSIVE_CLOSURE, real SurrealDB):
+ * the recursive support closure of GET /v1/facts/:id/provenance against
+ * the REAL fences — (1) the root 404 on a cross-user read is unchanged,
+ * (2) a fenced MEMBER of a tenant-global summary is a silent drop with
+ * `filtered: true` (never an error), (3) the PII gate on closure
+ * episodes follows brain:read_pii exactly like the one-hop path.
+ */
+import { StringRecordId } from 'surrealdb';
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+describe('fact provenance closure (real SurrealDB)', () => {
+  let f: AppFixture;
+  let summaryId = '';
+  let userAFactId = '';
+  const m2mAuth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const userBAuth = () => ({ Authorization: `Bearer ${f.extraApiKeys[0]}` });
+  const noPiiAuth = () => ({ Authorization: `Bearer ${f.extraApiKeys[1]}` });
+
+  beforeAll(async () => {
+    process.env.FACTS_API_ENABLED = '1';
+    process.env.PROVENANCE_RECURSIVE_CLOSURE = '1';
+    f = await createApp({
+      companyId: 'co_prov_closure_e2e',
+      extraKeys: [
+        // A user-B-bound read token (cross-user fences).
+        { scopes: ['brain:read'], userId: 'user-b' },
+        // An M2M read token WITHOUT brain:read_pii (PII gate).
+        { scopes: ['brain:read'] },
+      ],
+    });
+
+    const surreal = f.app.get(SurrealService);
+    await surreal.withCompany(f.companyId, async (db) => {
+      const [entRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE knowledge_entity CONTENT {
+           type: 'customer', canonicalName: 'Closure Subject'
+         }`,
+      );
+      const entityId = entRows[0]!.id;
+
+      // Three grounding turns: tenant-global, user-A-scoped, PII-classed.
+      await db.query(`INSERT INTO episode $rows`, {
+        rows: [
+          {
+            kind: 'turn',
+            conversationId: 'conv_closure',
+            messageId: 'm1',
+            speaker: 'user',
+            text: 'global remark about the lease',
+            occurredAt: new Date('2026-07-01T10:00:00Z'),
+            source: {},
+          },
+          {
+            kind: 'turn',
+            conversationId: 'conv_closure',
+            messageId: 'm2',
+            speaker: 'user',
+            text: 'user-a private remark',
+            occurredAt: new Date('2026-07-02T10:00:00Z'),
+            userId: 'user-a',
+            source: {},
+          },
+          {
+            kind: 'turn',
+            conversationId: 'conv_closure',
+            messageId: 'm3',
+            speaker: 'user',
+            text: 'my phone number is 555-0100',
+            occurredAt: new Date('2026-07-03T10:00:00Z'),
+            piiClass: ['contact'],
+            source: {},
+          },
+        ],
+      });
+      const [epRows] = await db.query<[Array<{ id: unknown; messageId: string }>]>(
+        // 3.x: the ORDER BY idiom must appear in the selection.
+        `SELECT id, messageId, occurredAt FROM episode ORDER BY occurredAt ASC`,
+      );
+      const epId = (msg: string) => String(epRows.find((e) => e.messageId === msg)!.id);
+
+      // Promotion-shaped members (status 'compacted', each stamped) —
+      // m2's member is user-A's; m3's member cites the PII turn.
+      const createFact = async (fields: Record<string, unknown>): Promise<string> => {
+        const [rows] = await db.query<[Array<{ id: unknown }>]>(
+          `CREATE knowledge_fact CONTENT $fields`,
+          {
+            fields: {
+              entityId,
+              confidence: 0.9,
+              validFrom: new Date('2026-07-01T00:00:00Z'),
+              ...fields,
+            },
+          },
+        );
+        return String(rows[0]!.id);
+      };
+      const member1 = await createFact({
+        predicate: 'said',
+        object: 'global remark about the lease',
+        status: 'compacted',
+        source: { kind: 'fact', episodeIds: [epId('m1')] },
+      });
+      const member2 = await createFact({
+        predicate: 'said',
+        object: 'user-a private remark',
+        status: 'compacted',
+        userId: 'user-a',
+        source: { kind: 'fact', episodeIds: [epId('m2')] },
+      });
+      const member3 = await createFact({
+        predicate: 'said',
+        object: 'shared a phone number',
+        status: 'compacted',
+        source: { kind: 'fact', episodeIds: [epId('m3')] },
+      });
+      summaryId = await createFact({
+        predicate: 'summary_said',
+        object: 'Talked about the lease and shared contact details.',
+        status: 'active',
+        source: { kind: 'promotion' },
+        // 3.x does not coerce string↔record — record-id params required.
+        derivedFrom: [member1, member2, member3].map((id) => new StringRecordId(id)),
+      });
+      // A user-A-owned root for the cross-user 404.
+      userAFactId = await createFact({
+        predicate: 'preference',
+        object: 'prefers morning viewings',
+        status: 'active',
+        userId: 'user-a',
+        source: { kind: 'fact', episodeIds: [epId('m2')] },
+      });
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    delete process.env.FACTS_API_ENABLED;
+    delete process.env.PROVENANCE_RECURSIVE_CLOSURE;
+    if (f) await f.close();
+  });
+
+  it("cross-user ROOT is still a 404 (user-B key on user-A's fact — closure changes nothing)", async () => {
+    const res = await f.http
+      .get(`/v1/facts/${encodeURIComponent(userAFactId)}/provenance`)
+      .set(userBAuth());
+    expect(res.status).toBe(404);
+  });
+
+  it('member fence is a SILENT drop: M2M sees the member episodes, user-B sees them dropped + filtered', async () => {
+    // M2M with read_pii: full closure — all three members, all three turns.
+    const m2m = await f.http
+      .get(`/v1/facts/${encodeURIComponent(summaryId)}/provenance`)
+      .set(m2mAuth());
+    expect(m2m.status).toBe(200);
+    expect(m2m.body.episodes.map((e: { text: string }) => e.text)).toEqual([
+      'global remark about the lease',
+      'user-a private remark',
+      'my phone number is 555-0100',
+    ]);
+    expect(m2m.body.derivedFacts).toHaveLength(3);
+    expect(
+      m2m.body.derivedFacts.every(
+        (d: { status: string; depth: number }) => d.status === 'compacted' && d.depth === 1,
+      ),
+    ).toBe(true);
+    expect(m2m.body.closure).toEqual({
+      depth: 1,
+      factCount: 3,
+      truncated: false,
+      filtered: false,
+    });
+
+    // User-B: the user-A member is silently dropped (filtered marker, no
+    // error); the PII turn is fenced by the missing brain:read_pii.
+    const userB = await f.http
+      .get(`/v1/facts/${encodeURIComponent(summaryId)}/provenance`)
+      .set(userBAuth());
+    expect(userB.status).toBe(200);
+    expect(userB.body.episodes.map((e: { text: string }) => e.text)).toEqual([
+      'global remark about the lease',
+    ]);
+    expect(userB.body.closure.filtered).toBe(true);
+    expect(userB.body.closure.factCount).toBe(2); // member2 dropped
+    expect(userB.body.derivedFacts).toHaveLength(2);
+  });
+
+  it('PII episode is invisible without brain:read_pii and served with it', async () => {
+    const noPii = await f.http
+      .get(`/v1/facts/${encodeURIComponent(summaryId)}/provenance`)
+      .set(noPiiAuth());
+    expect(noPii.status).toBe(200);
+    // M2M (no user fence) sees the user-A member's turn — only the
+    // PII-classed turn is gone; the member row itself stays visible.
+    expect(noPii.body.episodes.map((e: { text: string }) => e.text)).toEqual([
+      'global remark about the lease',
+      'user-a private remark',
+    ]);
+    expect(noPii.body.closure).toEqual({
+      depth: 1,
+      factCount: 3,
+      truncated: false,
+      filtered: false,
+    });
+
+    const withPii = await f.http
+      .get(`/v1/facts/${encodeURIComponent(summaryId)}/provenance`)
+      .set(m2mAuth());
+    expect(withPii.body.episodes).toHaveLength(3);
+  });
+});

--- a/test/fact-provenance.unit-spec.ts
+++ b/test/fact-provenance.unit-spec.ts
@@ -44,6 +44,13 @@ function makeStack(opts: {
         );
         return [rows];
       }
+      // Closure walk: ONE batched member SELECT per depth.
+      if (sql.includes('FROM knowledge_fact WHERE id INSIDE $ids')) {
+        const wanted = ((params?.ids as unknown[]) ?? []).map(ridOf);
+        return [
+          (opts.factsByCompany[companyId] ?? []).filter((f) => wanted.includes(String(f.id))),
+        ];
+      }
       if (sql.includes('FROM episode')) {
         const wanted = ((params?.ids as unknown[]) ?? []).map(ridOf);
         let rows = (opts.episodesByCompany?.[companyId] ?? []).filter((e) =>
@@ -390,6 +397,183 @@ describe('GET /v1/facts/:id/provenance — grounding episodes', () => {
       scopes: READ_PII,
     });
     expect(withScope.episodes.map((e) => e.episodeId)).toEqual(['episode:e1', 'episode:e3']);
+  });
+});
+
+/**
+ * Evidence plane: PROVENANCE_RECURSIVE_CLOSURE. Off (default) the
+ * provenance response is byte-identical to the one-hop shape — the
+ * promotion-summary golden below pins today's empty-episodes response.
+ * On, a summary's provenance walks derivedFrom and serves the member
+ * episode union + derivedFacts + closure; a fenced member is a SILENT
+ * drop marked filtered:true, and the root keeps its 404 semantics.
+ */
+describe('PROVENANCE_RECURSIVE_CLOSURE — recursive support closure', () => {
+  const saved = process.env.PROVENANCE_RECURSIVE_CLOSURE;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.PROVENANCE_RECURSIVE_CLOSURE;
+    else process.env.PROVENANCE_RECURSIVE_CLOSURE = saved;
+  });
+
+  // Promotion-style members: folded to 'compacted', each carrying its
+  // own grounding stamp. m1 carries the LATER episode — the response
+  // must still be chronological.
+  const MEMBER_1: Row = {
+    id: 'knowledge_fact:m1',
+    predicate: 'said',
+    object: 'remark about routes',
+    status: 'compacted',
+    source: { kind: 'fact', episodeIds: ['episode:e2'] },
+  };
+  const MEMBER_2: Row = {
+    id: 'knowledge_fact:m2',
+    predicate: 'said',
+    object: 'remark about hiking',
+    status: 'compacted',
+    source: { kind: 'fact', episodeIds: ['episode:e1'] },
+  };
+  const SUMMARY: Row = {
+    id: 'knowledge_fact:sum1',
+    predicate: 'summary_said',
+    object: '[2026-07-01] said: … | [2026-07-02] said: …',
+    confidence: 0.9,
+    validFrom: '2026-08-01T00:00:00.000Z',
+    status: 'active',
+    source: { kind: 'promotion' },
+    derivedFrom: ['knowledge_fact:m1', 'knowledge_fact:m2'],
+  };
+
+  it('flag OFF (default): promotion-summary response is byte-identical — GOLDEN empty episodes', async () => {
+    delete process.env.PROVENANCE_RECURSIVE_CLOSURE;
+    const { svc } = makeStack({
+      factsByCompany: { co_a: [SUMMARY, MEMBER_1, MEMBER_2] },
+      episodesByCompany: { co_a: EPISODES },
+    });
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'sum1',
+      scopes: READ,
+    });
+    // GOLDEN: today's exact shape — an unstamped summary serves an empty
+    // list; no derivedFacts/closure keys exist.
+    expect(res).toEqual({ factId: 'knowledge_fact:sum1', episodes: [] });
+  });
+
+  it('flag OFF: a leaf fact keeps its exact one-hop shape (no optional keys)', async () => {
+    delete process.env.PROVENANCE_RECURSIVE_CLOSURE;
+    const { svc } = makeStack({
+      factsByCompany: { co_a: [FACT_GLOBAL] },
+      episodesByCompany: { co_a: EPISODES },
+    });
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    expect(Object.keys(res).sort()).toEqual(['episodes', 'factId']);
+    expect(res.episodes.map((e) => e.episodeId)).toEqual(['episode:e1', 'episode:e2']);
+  });
+
+  it('flag ON: a leaf (no derivedFrom) still takes the one-hop path byte-identically', async () => {
+    process.env.PROVENANCE_RECURSIVE_CLOSURE = '1';
+    const { svc } = makeStack({
+      factsByCompany: { co_a: [FACT_GLOBAL] },
+      episodesByCompany: { co_a: EPISODES },
+    });
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    expect(Object.keys(res).sort()).toEqual(['episodes', 'factId']);
+  });
+
+  it('flag ON: summary serves the member episode union chronologically + derivedFacts + closure', async () => {
+    process.env.PROVENANCE_RECURSIVE_CLOSURE = '1';
+    const { svc } = makeStack({
+      factsByCompany: { co_a: [SUMMARY, MEMBER_1, MEMBER_2] },
+      episodesByCompany: { co_a: EPISODES },
+    });
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'sum1',
+      scopes: READ,
+    });
+    expect(res.factId).toBe('knowledge_fact:sum1');
+    // m1 stamped the later turn — the union is still chronological.
+    expect(res.episodes.map((e) => e.episodeId)).toEqual(['episode:e1', 'episode:e2']);
+    // Members are REPORTED with their lifecycle status, never hidden.
+    expect(res.derivedFacts).toEqual([
+      { factId: 'knowledge_fact:m1', predicate: 'said', depth: 1, status: 'compacted' },
+      { factId: 'knowledge_fact:m2', predicate: 'said', depth: 1, status: 'compacted' },
+    ]);
+    expect(res.closure).toEqual({
+      depth: 1,
+      factCount: 2,
+      truncated: false,
+      filtered: false,
+    });
+  });
+
+  it("flag ON: another user's member is a SILENT drop — filtered:true, no error", async () => {
+    process.env.PROVENANCE_RECURSIVE_CLOSURE = '1';
+    const { svc } = makeStack({
+      factsByCompany: {
+        co_a: [SUMMARY, { ...MEMBER_1, userId: 'u2' }, MEMBER_2],
+      },
+      episodesByCompany: { co_a: EPISODES },
+    });
+    await runWithRequestContext({ correlationId: 'test', authUserId: 'u1' }, async () => {
+      const res = await svc.getProvenance({
+        companyId: 'co_a',
+        factId: 'sum1',
+        scopes: READ,
+      });
+      // u2's member (and its episode) never surfaces; the walk reports it.
+      expect(res.episodes.map((e) => e.episodeId)).toEqual(['episode:e1']);
+      expect(res.derivedFacts).toEqual([
+        { factId: 'knowledge_fact:m2', predicate: 'said', depth: 1, status: 'compacted' },
+      ]);
+      expect(res.closure).toEqual({
+        depth: 1,
+        factCount: 1,
+        truncated: false,
+        filtered: true,
+      });
+    });
+  });
+
+  it("flag ON: a user-scoped member's episodes are fetched under THAT user's scope", async () => {
+    process.env.PROVENANCE_RECURSIVE_CLOSURE = '1';
+    const userEpisode: Row = {
+      id: 'episode:eu',
+      conversationId: 'conv-1',
+      speaker: 'Caroline',
+      text: 'my private remark',
+      occurredAt: '2026-07-03T10:00:00.000Z',
+      userId: 'u2',
+    };
+    const { svc, queries } = makeStack({
+      factsByCompany: {
+        co_a: [
+          { ...SUMMARY, derivedFrom: ['knowledge_fact:m1', 'knowledge_fact:m2'] },
+          { ...MEMBER_1, userId: 'u2', source: { kind: 'fact', episodeIds: ['episode:eu'] } },
+          MEMBER_2,
+        ],
+      },
+      episodesByCompany: { co_a: [...EPISODES, userEpisode] },
+    });
+    // M2M caller: sees the u2 member; its episode fetch must be keyed to
+    // u2 (the generalized :317-320 rule), the global group to no user.
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'sum1',
+      scopes: READ,
+    });
+    expect(res.episodes.map((e) => e.episodeId)).toEqual(['episode:e1', 'episode:eu']);
+    const episodeQueries = queries.filter((q) => q.sql.includes('FROM episode'));
+    const scoped = episodeQueries.find((q) => q.sql.includes('userId = $scopeUserId'));
+    expect(scoped?.params?.scopeUserId).toBe('u2');
   });
 });
 

--- a/test/provenance-closure.unit-spec.ts
+++ b/test/provenance-closure.unit-spec.ts
@@ -1,0 +1,290 @@
+import {
+  walkProvenanceClosure,
+  indexCharSpans,
+  type ClosureFactRow,
+} from '../src/facts/provenance-closure';
+
+/**
+ * Bounded BFS provenance walker (evidence plane, PROVENANCE_RECURSIVE_
+ * CLOSURE). Pure module — the db is a stubbed fetchByIds over an
+ * in-memory row map; the fence is a stubbed visible() verdict. These
+ * pin the cap semantics (depth / fan-out / episodes, each with its own
+ * truncated marker), cycle termination, first-wins span merging,
+ * String() record-id normalization, and the status-is-reported-not-
+ * hidden rule for compacted/retracted members.
+ */
+
+type Row = ClosureFactRow & Record<string, unknown>;
+
+const CAPS = { maxDepth: 5, maxFacts: 256, maxEpisodes: 200 };
+
+function fact(
+  id: string,
+  opts: {
+    derivedFrom?: unknown[];
+    episodeIds?: unknown[];
+    charSpans?: unknown[];
+    userId?: string;
+    status?: string;
+    source?: false;
+  } = {},
+): Row {
+  return {
+    id: `knowledge_fact:${id}`,
+    predicate: 'preference',
+    status: opts.status ?? 'active',
+    ...(opts.userId ? { userId: opts.userId } : {}),
+    ...(opts.source === false
+      ? {}
+      : {
+          source: {
+            kind: 'fact',
+            ...(opts.episodeIds ? { episodeIds: opts.episodeIds } : {}),
+            ...(opts.charSpans ? { charSpans: opts.charSpans } : {}),
+          },
+        }),
+    ...(opts.derivedFrom ? { derivedFrom: opts.derivedFrom } : {}),
+  };
+}
+
+function makeDb(rows: Row[]): {
+  fetchByIds: (ids: string[]) => Promise<Row[]>;
+  batches: string[][];
+} {
+  const byId = new Map(rows.map((r) => [String(r.id), r]));
+  const batches: string[][] = [];
+  return {
+    batches,
+    fetchByIds: async (ids: string[]) => {
+      batches.push(ids);
+      return ids.map((id) => byId.get(id)).filter((r): r is Row => r !== undefined);
+    },
+  };
+}
+
+const allVisible = () => true;
+
+describe('walkProvenanceClosure — caps', () => {
+  it('depth cap: a chain deeper than maxDepth stops with truncated.depth', async () => {
+    // root → c1 → c2 → c3 → c4 (maxDepth 2 ⇒ c1, c2 in; c3 unvisited).
+    const rows = [
+      fact('c1', { derivedFrom: ['knowledge_fact:c2'], episodeIds: ['episode:e1'] }),
+      fact('c2', { derivedFrom: ['knowledge_fact:c3'], episodeIds: ['episode:e2'] }),
+      fact('c3', { derivedFrom: ['knowledge_fact:c4'] }),
+      fact('c4', {}),
+    ];
+    const db = makeDb(rows);
+    const out = await walkProvenanceClosure({
+      root: fact('root', { derivedFrom: ['knowledge_fact:c1'], episodeIds: ['episode:e0'] }),
+      caps: { ...CAPS, maxDepth: 2 },
+      visible: allVisible,
+      fetchByIds: db.fetchByIds,
+    });
+    expect(out.closureFacts.map((c) => [String(c.fact.id), c.depth])).toEqual([
+      ['knowledge_fact:c1', 1],
+      ['knowledge_fact:c2', 2],
+    ]);
+    expect(out.truncated).toEqual({ depth: true, fanout: false, episodes: false });
+    // Root's stamps harvested first, then each depth's.
+    expect([...out.episodes.keys()]).toEqual(['episode:e0', 'episode:e1', 'episode:e2']);
+    expect(out.filtered).toBe(false);
+  });
+
+  it('fan-out cap: a star wider than maxFacts truncates with truncated.fanout', async () => {
+    const children = Array.from({ length: 6 }, (_, i) => `knowledge_fact:c${i}`);
+    const db = makeDb(children.map((id) => fact(id.split(':')[1]!)));
+    const out = await walkProvenanceClosure({
+      root: fact('root', { derivedFrom: children }),
+      caps: { ...CAPS, maxFacts: 4 },
+      visible: allVisible,
+      fetchByIds: db.fetchByIds,
+    });
+    expect(out.closureFacts).toHaveLength(4);
+    expect(out.truncated.fanout).toBe(true);
+    expect(out.truncated.depth).toBe(false);
+    expect(db.batches).toEqual([children.slice(0, 4)]);
+  });
+
+  it('episode cap: harvesting stops at maxEpisodes with truncated.episodes', async () => {
+    const out = await walkProvenanceClosure({
+      root: fact('root', {
+        derivedFrom: ['knowledge_fact:c1'],
+        episodeIds: ['episode:e1', 'episode:e2'],
+      }),
+      caps: { ...CAPS, maxEpisodes: 3 },
+      visible: allVisible,
+      fetchByIds: makeDb([fact('c1', { episodeIds: ['episode:e2', 'episode:e3', 'episode:e4'] })])
+        .fetchByIds,
+    });
+    // e1, e2 from the root; e2 deduped; e3 fills the cap; e4 truncated.
+    expect([...out.episodes.keys()]).toEqual(['episode:e1', 'episode:e2', 'episode:e3']);
+    expect(out.truncated.episodes).toBe(true);
+  });
+});
+
+describe('walkProvenanceClosure — graph shapes', () => {
+  it('cycle A↔B terminates, each node visited exactly once', async () => {
+    const db = makeDb([
+      fact('b', { derivedFrom: ['knowledge_fact:a'], episodeIds: ['episode:eb'] }),
+    ]);
+    const out = await walkProvenanceClosure({
+      root: fact('a', { derivedFrom: ['knowledge_fact:b'], episodeIds: ['episode:ea'] }),
+      caps: CAPS,
+      visible: allVisible,
+      fetchByIds: db.fetchByIds,
+    });
+    expect(out.closureFacts.map((c) => String(c.fact.id))).toEqual(['knowledge_fact:b']);
+    expect(db.batches).toEqual([['knowledge_fact:b']]); // a never re-fetched
+    expect(out.truncated).toEqual({ depth: false, fanout: false, episodes: false });
+  });
+
+  it('String-normalizes record-id shapes (RecordId-like objects and strings key identically)', async () => {
+    // derivedFrom carries a RecordId-like object whose String() form is
+    // the same id a later frontier references as a plain string.
+    const ridLike = { toString: () => 'knowledge_fact:c1' };
+    const db = makeDb([fact('c1', { derivedFrom: [ridLike] })]);
+    const out = await walkProvenanceClosure({
+      root: fact('root', { derivedFrom: [ridLike, 'knowledge_fact:c1'] }),
+      caps: CAPS,
+      visible: allVisible,
+      fetchByIds: db.fetchByIds,
+    });
+    // One admission despite two shapes; c1's self-reference already visited.
+    expect(db.batches).toEqual([['knowledge_fact:c1']]);
+    expect(out.closureFacts).toHaveLength(1);
+  });
+
+  it('a member without episodeIds still contributes its children', async () => {
+    const db = makeDb([
+      fact('mid', { derivedFrom: ['knowledge_fact:leaf'], source: false }),
+      fact('leaf', { episodeIds: ['episode:deep'] }),
+    ]);
+    const out = await walkProvenanceClosure({
+      root: fact('root', { derivedFrom: ['knowledge_fact:mid'] }),
+      caps: CAPS,
+      visible: allVisible,
+      fetchByIds: db.fetchByIds,
+    });
+    expect(out.closureFacts.map((c) => String(c.fact.id))).toEqual([
+      'knowledge_fact:mid',
+      'knowledge_fact:leaf',
+    ]);
+    expect([...out.episodes.keys()]).toEqual(['episode:deep']);
+  });
+
+  it('compacted/retracted members contribute; status is reported, not hidden', async () => {
+    const db = makeDb([
+      fact('m1', { status: 'compacted', episodeIds: ['episode:e1'] }),
+      fact('m2', { status: 'retracted', episodeIds: ['episode:e2'] }),
+    ]);
+    const out = await walkProvenanceClosure({
+      root: fact('root', { derivedFrom: ['knowledge_fact:m1', 'knowledge_fact:m2'] }),
+      caps: CAPS,
+      visible: allVisible,
+      fetchByIds: db.fetchByIds,
+    });
+    expect(out.closureFacts.map((c) => String(c.fact.status))).toEqual(['compacted', 'retracted']);
+    expect([...out.episodes.keys()]).toEqual(['episode:e1', 'episode:e2']);
+    expect(out.filtered).toBe(false);
+  });
+
+  it('an invisible member is silently dropped (subtree included) and sets filtered', async () => {
+    const db = makeDb([
+      fact('visible', { episodeIds: ['episode:ok'] }),
+      fact('hidden', {
+        userId: 'someone-else',
+        episodeIds: ['episode:secret'],
+        derivedFrom: ['knowledge_fact:behind'],
+      }),
+      fact('behind', { episodeIds: ['episode:behind'] }),
+    ]);
+    const out = await walkProvenanceClosure({
+      root: fact('root', {
+        derivedFrom: ['knowledge_fact:visible', 'knowledge_fact:hidden'],
+      }),
+      caps: CAPS,
+      visible: (f) => f.userId === undefined,
+      fetchByIds: db.fetchByIds,
+    });
+    expect(out.filtered).toBe(true);
+    expect(out.closureFacts.map((c) => String(c.fact.id))).toEqual(['knowledge_fact:visible']);
+    // The fenced member's episodes AND its subtree never surface.
+    expect([...out.episodes.keys()]).toEqual(['episode:ok']);
+    expect(db.batches).toHaveLength(1);
+  });
+});
+
+describe('walkProvenanceClosure — episode ownership + spans', () => {
+  it("episodes map to the CONTRIBUTING fact's userId ('' = tenant-global), first-wins", async () => {
+    const db = makeDb([
+      fact('mine', { userId: 'user-a', episodeIds: ['episode:shared', 'episode:a-only'] }),
+    ]);
+    const out = await walkProvenanceClosure({
+      root: fact('root', {
+        derivedFrom: ['knowledge_fact:mine'],
+        episodeIds: ['episode:shared'],
+      }),
+      caps: CAPS,
+      visible: allVisible,
+      fetchByIds: db.fetchByIds,
+    });
+    // 'shared' first seen on the tenant-global root — ownership sticks.
+    expect(out.episodes.get('episode:shared')).toBe('');
+    expect(out.episodes.get('episode:a-only')).toBe('user-a');
+  });
+
+  it('charSpans merge first-wins per episode across the walk (root first)', async () => {
+    const rootSpan = { episodeId: 'episode:e1', start: 0, end: 4, exact: 'root' };
+    const memberSpan = { episodeId: 'episode:e1', start: 9, end: 15, exact: 'member' };
+    const otherSpan = { episodeId: 'episode:e2', start: 1, end: 3, exact: 'ok' };
+    const db = makeDb([
+      fact('m', {
+        episodeIds: ['episode:e2'],
+        charSpans: [memberSpan, otherSpan],
+      }),
+    ]);
+    const out = await walkProvenanceClosure({
+      root: fact('root', {
+        derivedFrom: ['knowledge_fact:m'],
+        episodeIds: ['episode:e1'],
+        charSpans: [rootSpan],
+      }),
+      caps: CAPS,
+      visible: allVisible,
+      fetchByIds: db.fetchByIds,
+    });
+    expect(out.spans.get('episode:e1')).toEqual({ start: 0, end: 4, exact: 'root' });
+    expect(out.spans.get('episode:e2')).toEqual({ start: 1, end: 3, exact: 'ok' });
+  });
+
+  it("harvest filters non-'episode:' ids and String()-coerces values", async () => {
+    const out = await walkProvenanceClosure({
+      root: fact('root', {
+        episodeIds: ['episode:good', 'document:bad', { toString: () => 'episode:obj' }],
+      }),
+      caps: CAPS,
+      visible: allVisible,
+      fetchByIds: makeDb([]).fetchByIds,
+    });
+    expect([...out.episodes.keys()]).toEqual(['episode:good', 'episode:obj']);
+    expect(out.closureFacts).toEqual([]);
+  });
+});
+
+describe('indexCharSpans (shared helper)', () => {
+  it('keeps the first well-formed span per episode and drops malformed entries', () => {
+    const map = indexCharSpans([
+      { episodeId: 'episode:e1', start: 1, end: 2, exact: 'a' },
+      { episodeId: 'episode:e1', start: 3, end: 4, exact: 'b' }, // dup: first wins
+      { episodeId: 'episode:e2', exact: 'missing-offsets' }, // malformed
+      'not-an-object',
+    ]);
+    expect(map.get('episode:e1')).toEqual({ start: 1, end: 2, exact: 'a' });
+    expect(map.has('episode:e2')).toBe(false);
+  });
+
+  it('tolerates a non-array input (FLEXIBLE source)', () => {
+    expect(indexCharSpans(undefined).size).toBe(0);
+    expect(indexCharSpans({ episodeId: 'episode:e1' }).size).toBe(0);
+  });
+});

--- a/test/recompose.unit-spec.ts
+++ b/test/recompose.unit-spec.ts
@@ -264,4 +264,103 @@ describe('RecomposeService', () => {
       expect(generator.generate).not.toHaveBeenCalled();
     });
   });
+
+  /**
+   * Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP): the rewrite
+   * re-stamps source.episodeIds from the CURRENT parents' union in the
+   * same UPDATE — the incremental path that makes a backfill pass
+   * unnecessary. Flag off must produce today's EXACT statement (golden
+   * below); an empty union under the flag clears the field with NONE.
+   */
+  describe('rewrite — summary episode re-stamping', () => {
+    const saved = process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+    afterEach(() => {
+      if (saved === undefined) delete process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+      else process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = saved;
+    });
+
+    const staleSummary = {
+      id: 'knowledge_fact:sum1',
+      predicate: 'summary_lives_in',
+      derivedFrom: ['knowledge_fact:p1', 'knowledge_fact:p2'],
+      staleAt: '2023-06-01T00:00:00Z',
+    };
+    const stampedParents = {
+      'knowledge_fact:p1': parent('knowledge_fact:p1', 'Berlin', {
+        eps: ['episode:e1', 'episode:shared'],
+      }),
+      'knowledge_fact:p2': parent('knowledge_fact:p2', 'Dublin', {
+        validFrom: '2023-02-01T00:00:00Z',
+        eps: ['episode:shared', 'episode:e2'],
+      }),
+    };
+
+    it("flag OFF (default): today's EXACT statement — golden, no episodeIds fragment", async () => {
+      delete process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
+      const { svc, queries } = make({ stale: [staleSummary], parents: stampedParents });
+      await svc.recompute('co_x');
+      const write = queries.find((q) => q.sql.includes('staleAt = NONE'));
+      expect(write!.sql).toBe(
+        `UPDATE $id SET
+         object = $object, confidence = $confidence,
+         validFrom = <datetime>$validFrom,
+         validUntil = <datetime>$validUntil,
+         derivedFrom = $derivedFrom,
+         staleAt = NONE, staleReason = NONE`,
+      );
+      expect(write!.params.episodeIds).toBeUndefined();
+    });
+
+    it('flag ON: re-stamps the union of the CURRENT parents (chronological parent order)', async () => {
+      process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = '1';
+      const { svc, queries } = make({ stale: [staleSummary], parents: stampedParents });
+      await svc.recompute('co_x');
+      const write = queries.find((q) => q.sql.includes('staleAt = NONE'));
+      expect(write!.sql).toContain('source.episodeIds = $episodeIds');
+      // Parents are fed chronologically (p1 2023-01 before p2 2023-02);
+      // the union follows that order, 'shared' deduped on first sight.
+      expect(write!.params.episodeIds).toEqual(['episode:e1', 'episode:shared', 'episode:e2']);
+    });
+
+    it('flag ON: follows supersededBy — the stamp comes from the LIVE parent', async () => {
+      process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = '1';
+      const { svc, queries } = make({
+        stale: [{ ...staleSummary, derivedFrom: ['knowledge_fact:p1'] }],
+        parents: {
+          'knowledge_fact:p1': parent('knowledge_fact:p1', 'old', {
+            supersededBy: 'knowledge_fact:p1v2',
+            eps: ['episode:stale'],
+          }),
+          'knowledge_fact:p1v2': parent('knowledge_fact:p1v2', 'new', {
+            eps: ['episode:current'],
+          }),
+        },
+      });
+      await svc.recompute('co_x');
+      const write = queries.find((q) => q.sql.includes('staleAt = NONE'));
+      expect(write!.params.episodeIds).toEqual(['episode:current']);
+    });
+
+    it('flag ON, unstamped parents: the fragment clears the field with NONE', async () => {
+      process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = '1';
+      const { svc, queries } = make({
+        stale: [staleSummary],
+        parents: {
+          'knowledge_fact:p1': parent('knowledge_fact:p1', 'Berlin'),
+          'knowledge_fact:p2': parent('knowledge_fact:p2', 'Dublin'),
+        },
+      });
+      await svc.recompute('co_x');
+      const write = queries.find((q) => q.sql.includes('staleAt = NONE'));
+      expect(write!.sql).toContain('source.episodeIds = NONE');
+      expect(write!.params.episodeIds).toBeUndefined();
+    });
+
+    it('the parent SELECTs carry the grounding stamp column', async () => {
+      const { svc, queries } = make({ stale: [staleSummary], parents: stampedParents });
+      await svc.recompute('co_x');
+      const batch = queries.find((q) => q.sql.includes('WHERE id INSIDE $ids'));
+      expect(batch!.sql).toContain('source.episodeIds AS eps');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

PR3 of the Brain v2 wave — the Evidence plane, closing gaps #5/#6 of the Brain v2 review: provenance today is **one-hop** (`GET /v1/facts/:id/provenance` reads only the root's own `source.episodeIds`), and **promotion breaks the evidence chain** — when promotion/compaction fold members into a summary, the summary carries no grounding stamp and its provenance dead-ends at an empty episode list, even though every member still carries its stamp behind `derivedFrom`.

Two default-off flags fix both ends of the chain:

- `PROVENANCE_SUMMARY_EPISODE_STAMP` — write side: summaries carry the union of their members' episode stamps.
- `PROVENANCE_RECURSIVE_CLOSURE` — read side: provenance walks `derivedFrom` and serves the union of grounding episodes across the whole support closure.

Both flags (plus the three closure cap knobs `PROVENANCE_CLOSURE_MAX_DEPTH`/`_FACTS`/`_EPISODES`, clamped 1..10 / 1..1024 / 1..500) are catalogued in `CONFIG_CATALOG` and the booleans in `KNOWN_BOOLEAN_FLAGS`. The `PROVENANCE_` prefix is a deliberate flag family **outside** the `ENGINE_PREFIX` flag budget (like `FOVEA_`/`MULTILINGUAL_`): a provenance surface, not an engine fork — `test/flag-budget.unit-spec.ts` confirms.

## Write side (`PROVENANCE_SUMMARY_EPISODE_STAMP`)

One idiom everywhere — the window-deriver union (`window-deriver.service.ts:876`), extracted to `src/common/episode-ids.ts`: member `source.episodeIds` String()-coerced, filtered to the `episode:` prefix, deduped with member order preserved, `.slice(0, 64)`.

- **promotion-runner** `promoteGroup`: member SELECT gains `source.episodeIds AS eps`; summary source becomes `{ kind: 'promotion', ...(episodeIds.length ? { episodeIds } : {}) }`.
- **compaction-runner** summary create: same on `{ kind: 'compaction-summary' }`.
- **recompose** rewrite: parent SELECTs gain `eps`; under the flag the UPDATE re-stamps `source.episodeIds` with the recomputed union (empty union clears with `NONE`). The SET fragment is emitted **only when the flag is on** — flag off produces today's exact statement, golden-pinned in the unit spec.
- **insight-composer kernel**: fact SELECT gains `source.episodeIds AS episodeIds` (`FactRowLite` extended); **arc** and **aggregate** composers union over proposal members into their source objects under the flag.

**No backfill pass, by design**: the read-side walker reaches the members' own stamps through `derivedFrom` regardless of whether the summary was ever stamped, and recompose re-stamps incrementally as summaries recompute — stamping converges without a migration.

## Read side (`PROVENANCE_RECURSIVE_CLOSURE`)

New `src/facts/provenance-closure.ts`: a pure, bounded BFS walker (unit-testable with a stubbed db). Per depth: harvest frontier grounding stamps (episode ids keyed to the contributing fact's user, first-wins `charSpans` merge), collect `derivedFrom` children minus visited (String()-normalized record ids — this is also what terminates cycles), ONE batched `SELECT ... WHERE id INSIDE $ids` with **no status filter** — compacted/retracted members still witness; status is *reported* (`derivedFacts[].status`), never hidden. Truncation is tracked per cap (depth / fan-out / episodes).

`facts.service` wiring:
- The per-row fence chain of `loadVisibleFact` is extracted into a pure `factVisible(fact, gates)` (user-scope pin → scope tags → row policy, same order, no throwing). `loadVisibleFact` keeps its exact current root 404 semantics.
- The walk runs inside the ONE existing `withScopedCompany` connection; the row-policy filter (surface `fact_read`) and the scope pin are resolved ONCE for the whole walk.
- Episode fetches group per owning user: `''` (tenant-global contributor) → the caller's pinned scope; else that fact's userId — generalizing the existing one-hop rule.
- Result gains optional `derivedFacts` (`factId`/`predicate`/`depth`/`status`) and `closure` (`depth`/`factCount`/`truncated`/`filtered`) — **absent** when the flag is off or the root has no `derivedFrom`, so the default JSON is byte-identical. Contracts mirrored in `FactProvenanceResponseSchema`; both `openapi.json` copies regenerated.
- Metric: `brain_provenance_closure_total{outcome=resolved|truncated|empty}`.

## Fence semantics

- Root behavior is **unchanged**: every root fence miss is the same 404 (existence never leaks) — golden-pinned and re-verified e2e.
- A fenced **member** is a **silent drop** (its subtree with it): the response stays 200, the drop is visible only as `closure.filtered: true`. Evidence reachable only through a fact the caller may not see is evidence the caller may not see.
- PII: closure episode fetches ride the shared episode read port, so `brain:read_pii` gates member turns exactly like the one-hop path.

## Drive-by fix (caught by the new real-DB e2e)

`toIso` in `facts.service` fell through to its `new Date()` ("now") fallback for real rows: the surrealdb 2.x SDK decodes datetime columns to its custom `DateTime` class, **not** a native `Date`, so live provenance responses served the request time as `occurredAt` and the chronological sort was inert. `toIso` now duck-types on `toISOString`. (Everything else that formats SDK datetimes uses `String()`-based helpers, which already produced the ISO form.)

## Safety

- Both flags default **off**; off ⇒ byte-identical writes (composer/compaction/promotion goldens deep-equal today's source objects; recompose pins today's exact UPDATE statement) and byte-identical provenance JSON (goldens for a leaf fact and a promotion-style summary).
- No migrations, no paid LLM calls, no read-path changes outside the two flags.
- Promotion-gate work (corroboration floor) lands separately in a later PR and reads the same member fields this PR stamps.

## Test plan

- `test/provenance-closure.unit-spec.ts` (new, 13 tests): depth cap (chain → `truncated.depth`), fan-out cap (star), cycle A↔B terminates with each node visited once, episode cap, span first-wins, String normalization of record-id shapes, member without `episodeIds` still contributes children, compacted/retracted members contribute with status reported, invisible member silently dropped + `filtered`.
- `test/fact-provenance.unit-spec.ts` (+6): flag-off goldens (leaf + promotion summary byte-identical), flag-on union chronological + `derivedFacts` + `closure`, silent member drop under a user-bound token, member-scoped episode fetch keyed to the member's user.
- Composer stamping units extended in `arc-composer` / `aggregate-composer` / `compaction` (incl. a new `PromotionRunnerService` describe) / `recompose` specs: flag off → written source deep-equals today's; flag on → union present, member order, capped 64; recompose exact-SQL golden + NONE-clear + supersede-following stamp.
- `test/fact-provenance-closure.e2e-spec.ts` (new, real SurrealDB, 3 tests): cross-user root 404 unchanged; member fence silent-drop (M2M sees member episodes, user-B sees them dropped + `filtered: true`, no error); PII episode invisible without `brain:read_pii`, served with it.
- Verified: `pnpm typecheck` clean; full unit suite 296 suites / 2827 tests green; `test:e2e --testPathPatterns fact-provenance` 3/3 green; `prettier --check` clean; eslint clean on all touched files; `flag-budget` gate green; both `openapi.json` copies regenerated and committed (drift gate green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB