### PR TITLE
feat(telemetry): append-only memory outcome events + write-path rollup (0107)

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -229,6 +229,35 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: false,
     isBooleanFlag: false,
   },
+  // Outcome telemetry (0107) — filed under 'audit' (the nearest existing
+  // category for an append-only event trail + its retention knob).
+  {
+    key: 'OUTCOME_TELEMETRY_ENABLED',
+    category: 'audit',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Master switch for outcome telemetry (0107): writers append memory_outcome events + fold the memory_outcome_stat rollup; nightly raw-log prune runs.',
+  },
+  {
+    key: 'OUTCOME_RETRIEVED_EVENTS',
+    category: 'audit',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Extra gate on the high-volume `retrieved` outcome stream (one event per surfaced fact per search) on top of OUTCOME_TELEMETRY_ENABLED.',
+  },
+  {
+    key: 'OUTCOME_EVENT_RETENTION_DAYS',
+    category: 'audit',
+    defaultValue: '30',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Days the raw memory_outcome event log is kept; the 03:41 UTC prune cron deletes older rows. The memory_outcome_stat rollup is never pruned.',
+  },
   // ── Router ────────────────────────────────────────────────
   {
     key: 'CHAT_ROUTE_CACHE_ENABLED',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -744,6 +744,18 @@ const KNOWN_BOOLEAN_FLAGS = [
   // segmenter is session-gap + max-turns only (embedder-free). The
   // cosine floor (SCENES_TOPIC_MIN_COSINE) is a float, not a boolean.
   'SCENES_TOPIC_BOUNDARY',
+  // Outcome telemetry master (0107): writers append memory_outcome rows
+  // + fold memory_outcome_stat counters; the nightly raw-log prune runs.
+  // Default off = byte-identical (every writer is a guarded no-op).
+  // OUTCOME_ prefix sits outside ENGINE_PREFIX by design — measurement
+  // substrate, not an engine fork — so it is off the flag budget, like
+  // the FOVEA_ family.
+  'OUTCOME_TELEMETRY_ENABLED',
+  // Outcome telemetry: extra gate on the high-volume `retrieved` writer
+  // (one event per surfaced fact per search). Off (default) ⇒ no
+  // retrieved rows even with the master on. The retention window knob
+  // (OUTCOME_EVENT_RETENTION_DAYS) is an int, not a boolean flag.
+  'OUTCOME_RETRIEVED_EVENTS',
   // Fovea optics (Optics-1, docs/roadmap/fovea-optics-2026-08.md): capture
   // the focus signal at the synthesize verdict point + expose the admin
   // fit/measure surface. SERVING-NEUTRAL — nothing consumes the calibrated

--- a/src/common/outcome-flags.ts
+++ b/src/common/outcome-flags.ts
@@ -1,0 +1,54 @@
+import { envFlagEnabled } from './env-validation';
+
+/**
+ * Outcome telemetry (0107) master flag — OUTCOME_TELEMETRY_ENABLED.
+ *
+ * When on, the writers (search `retrieved`, synthesize selected/used/
+ * verifier-supported, ingest contradicted, feedback confirmed/rejected)
+ * append rows to memory_outcome and fold counter deltas into
+ * memory_outcome_stat, and the nightly prune cron runs. The env read
+ * lives here in the common layer, NOT inside the engine dirs
+ * (src/search/ and src/synthesize/ take resolved config only —
+ * engine-gates S5.2); engine callers reach it via the
+ * MemoryOutcomeService static. Read at call time so a flip is
+ * runtime-mutable (no restart). Default off ⇒ every writer is a guarded
+ * no-op and the cron returns immediately — serving byte-identical.
+ */
+export function outcomeTelemetryEnabled(): boolean {
+  return envFlagEnabled(process.env.OUTCOME_TELEMETRY_ENABLED);
+}
+
+/**
+ * Outcome telemetry `retrieved` stream gate — OUTCOME_RETRIEVED_EVENTS.
+ *
+ * An EXTRA gate on top of the master flag for the one writer whose
+ * volume is unbounded by anything smaller than search traffic itself:
+ * one event per surfaced fact per search (same id list fact_usage
+ * stamps). The env read lives here in the common layer, NOT inside the
+ * engine dirs (engine-gates S5.2). Read at call time so a flip is
+ * runtime-mutable. Default off ⇒ even with the master on, searches
+ * write no `retrieved` rows — operators opt into the raw stream
+ * separately from the low-volume outcome writers.
+ */
+export function outcomeRetrievedEventsEnabled(): boolean {
+  return envFlagEnabled(process.env.OUTCOME_RETRIEVED_EVENTS);
+}
+
+/** Default raw-event retention window for the nightly prune (days). */
+const DEFAULT_EVENT_RETENTION_DAYS = 30;
+
+/**
+ * Raw-event retention window — OUTCOME_EVENT_RETENTION_DAYS.
+ *
+ * The nightly prune cron deletes memory_outcome rows older than this
+ * many days (the rollup table is never pruned — it survives raw-row
+ * retention by design, see 0107). A non-boolean knob resolved here in
+ * the common layer so consumers take a resolved number. Must be a
+ * positive integer; unset, blank, or out of range → the 30-day default.
+ */
+export function outcomeEventRetentionDays(): number {
+  const raw = process.env.OUTCOME_EVENT_RETENTION_DAYS;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_EVENT_RETENTION_DAYS;
+  const v = Number(raw);
+  return Number.isInteger(v) && v > 0 ? v : DEFAULT_EVENT_RETENTION_DAYS;
+}

--- a/src/db/migrations/0107_memory_outcome.surql
+++ b/src/db/migrations/0107_memory_outcome.surql
@@ -1,0 +1,80 @@
+-- 0107_memory_outcome — append-only outcome telemetry, storage side.
+--
+-- fact_usage (0053) records that search SURFACED a fact; nothing records
+-- what happened AFTER — whether the fact was selected into a prompt,
+-- cited in an answer, verified as supporting it, confirmed/rejected by a
+-- consumer, or contradicted by later ingest. This pair is the outcome
+-- substrate the verified-use ranking work will read:
+--   * memory_outcome      — the append-only raw event log;
+--   * memory_outcome_stat — a per-subject rollup maintained on the write
+--     path (one indexed row per subject — the ranking currency).
+--
+-- A SEPARATE table pair, not fields on knowledge_fact: the 0053
+-- rationale carries over verbatim —
+--   * "knowledge_fact sits on a CHANGEFEED mirrored into audit_event —
+--     per-search counter bumps would flood the audit trail;"
+--   * "knowledge_artifact has a DEFINE EVENT that marks artifacts dirty
+--     on ANY fact change — usage stamps would recompile artifacts for
+--     nothing;"
+--   * "the ingest path serializes fact writes per (entity, predicate)
+--     through a KeyedMutex — read-path writes must not contend there."
+-- Telemetry must touch none of those surfaces.
+--
+-- Why the rollup is a normal write-path table and NOT a 0088 computed
+-- view: lastVerifiedUseAt is a MAX — non-invertible, an incremental view
+-- cannot process a raw-row DELETE — and the retention cron PRUNES raw
+-- rows, which would decrement any incremental count view. The rollup
+-- must SURVIVE raw-row pruning, so the writer maintains it directly
+-- (INSERT … ON DUPLICATE KEY UPDATE over the UNIQUE subjectId index)
+-- and it is never recomputed from the raw table.
+--
+-- Growth bounds:
+--   * memory_outcome ≤ event volume × OUTCOME_EVENT_RETENTION_DAYS —
+--     the nightly prune cron (03:41 UTC) deletes older rows in bounded
+--     batches; writers cap events per request;
+--   * memory_outcome_stat ≤ 1 row per subject (UNIQUE subjectId).
+--
+-- NO CHANGEFEED and NO DEFINE EVENT — deliberately. Mirroring telemetry
+-- into audit_event would reintroduce exactly the flood 0053 avoided, and
+-- a DEFINE EVENT on a high-volume append table is a write amplifier.
+--
+-- meta is CONTENT-FREE by contract: record ids / verdict strings only,
+-- NEVER fact text. That is what lets the GDPR entity-forget bulk-purge
+-- run OUTSIDE the atomic erase transaction (an aborted erase merely
+-- deleted telemetry early) and keeps these tables out of the PII
+-- reconstruction surface.
+
+DEFINE TABLE IF NOT EXISTS memory_outcome SCHEMAFULL;
+
+DEFINE FIELD IF NOT EXISTS subjectKind ON memory_outcome TYPE string
+  ASSERT $value INSIDE ['fact', 'episode', 'belief', 'evidence'];
+-- Untyped record — generic over subject tables, still traversable
+-- (subjectId.userId / subjectId.entityId in the GDPR cascades).
+DEFINE FIELD IF NOT EXISTS subjectId   ON memory_outcome TYPE record;
+DEFINE FIELD IF NOT EXISTS event       ON memory_outcome TYPE string
+  ASSERT $value INSIDE ['retrieved', 'selected_for_context', 'used_in_answer',
+    'verifier_supported', 'user_confirmed', 'user_rejected', 'contradicted'];
+DEFINE FIELD IF NOT EXISTS actor       ON memory_outcome TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS requestId   ON memory_outcome TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS createdAt   ON memory_outcome TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS meta        ON memory_outcome TYPE option<object> FLEXIBLE;
+
+DEFINE INDEX IF NOT EXISTS memory_outcome_subject_idx ON memory_outcome FIELDS subjectId, event;
+DEFINE INDEX IF NOT EXISTS memory_outcome_created_idx ON memory_outcome FIELDS createdAt;
+
+DEFINE TABLE IF NOT EXISTS memory_outcome_stat SCHEMAFULL;
+
+DEFINE FIELD IF NOT EXISTS subjectId         ON memory_outcome_stat TYPE record;
+DEFINE FIELD IF NOT EXISTS subjectKind       ON memory_outcome_stat TYPE string
+  ASSERT $value INSIDE ['fact', 'episode', 'belief', 'evidence'];
+DEFINE FIELD IF NOT EXISTS selectedCount     ON memory_outcome_stat TYPE int DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS usedCount         ON memory_outcome_stat TYPE int DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS verifiedUseCount  ON memory_outcome_stat TYPE int DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS confirmedCount    ON memory_outcome_stat TYPE int DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS rejectedCount     ON memory_outcome_stat TYPE int DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS contradictedCount ON memory_outcome_stat TYPE int DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS lastUsedAt        ON memory_outcome_stat TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS lastVerifiedUseAt ON memory_outcome_stat TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS updatedAt         ON memory_outcome_stat TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX IF NOT EXISTS memory_outcome_stat_subject_idx ON memory_outcome_stat FIELDS subjectId UNIQUE;

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -225,6 +225,12 @@ export class EntityForgetService {
         );
       }
 
+      // ── 0107 outcome telemetry: bulk-purge the raw event log OUTSIDE
+      // the atomic erase (see preSweepOutcomeRows — content-free by
+      // contract, deliberately uncounted in txRecordCount like
+      // fact_usage, so FORGET_MAX_TX_RECORDS never trips on telemetry).
+      await this.preSweepOutcomeRows(db, ref.id);
+
       // ── Atomic erase. Everything below commits together or rolls back
       // together (single BEGIN/COMMIT). Ordering inside the transaction is
       // for readability only — the commit is atomic — but we keep the
@@ -274,6 +280,20 @@ export class EntityForgetService {
         );
         tx.add(`DELETE $sceneMemberIds`);
         tx.add(`LET $scenesDel = (DELETE memory_episode WHERE id INSIDE $sceneIds RETURN BEFORE)`);
+        // 0107 outcome telemetry: stragglers written after the pre-tx
+        // bulk sweep, plus the one-row-per-subject rollup (small enough
+        // to live inside the tx). Uncounted in txRecordCount, like
+        // fact_usage. LET-then-DELETE-by-ids, NOT `DELETE … WHERE`
+        // (the 3.2.4 indexed-traversal DELETE bug — see the pre-tx sweep
+        // comment above).
+        tx.add(
+          `LET $outIds = (SELECT VALUE id FROM memory_outcome WHERE subjectId.entityId = $ent)`,
+        );
+        tx.add(`DELETE $outIds`);
+        tx.add(
+          `LET $outStatIds = (SELECT VALUE id FROM memory_outcome_stat WHERE subjectId.entityId = $ent)`,
+        );
+        tx.add(`DELETE $outStatIds`);
         // L0: a segment that quotes an erased episode goes with it; segments
         // before episodes to keep the dependency order.
         tx.add(
@@ -409,5 +429,38 @@ export class EntityForgetService {
     );
     const sceneCount = new Set(sceneIdRows.map((r) => String(r.in))).size;
     return (segCountRow?.count ?? 0) + (sceneMemberCountRow?.count ?? 0) + sceneCount;
+  }
+
+  /**
+   * 0107 outcome telemetry pre-sweep: bulk-purge the subject's raw
+   * memory_outcome rows OUTSIDE the atomic erase, in bounded batches, so
+   * a telemetry-heavy subject can't inflate the erase transaction. Safe
+   * outside the tx because meta is CONTENT-FREE by contract (ids /
+   * verdict strings only, never fact text): an erase that aborts after
+   * this merely deleted telemetry early. The in-tx DELETEs catch
+   * stragglers written between this sweep and the commit.
+   *
+   * Two-step (SELECT ids → DELETE $ids) DELIBERATELY: on SurrealDB 3.2.4
+   * a DELETE whose WHERE traverses through an indexed record field
+   * (memory_outcome_subject_idx covers subjectId) silently matches
+   * NOTHING, while the same WHERE in a SELECT matches fine — verified
+   * against the pinned server. Deleting by explicit ids sidesteps the
+   * planner entirely.
+   */
+  private async preSweepOutcomeRows(
+    db: { query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T> },
+    rid: string,
+  ): Promise<void> {
+    for (;;) {
+      const [, batch] = await db.query<[unknown, unknown[]]>(
+        `LET $ids = (SELECT VALUE id FROM memory_outcome
+           WHERE subjectId.entityId = type::record('knowledge_entity', $rid)
+           LIMIT 5000);
+         DELETE $ids RETURN BEFORE`,
+        { rid },
+      );
+      // A partial batch means the subject's raw rows are drained.
+      if (((batch as unknown[]) ?? []).length < 5000) break;
+    }
   }
 }

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -70,6 +70,20 @@ export class UserForgetService {
       await db.query(`DELETE retrieval_feedback WHERE factId.userId = $u`, {
         u: userId,
       });
+      // Outcome telemetry (0107): both tables traverse subjectId into
+      // the user's facts — purge while the facts are alive, same as
+      // fact_usage above. LET-then-DELETE-by-ids, NOT `DELETE … WHERE`:
+      // on SurrealDB 3.2.4 a DELETE whose WHERE traverses through an
+      // indexed record field (memory_outcome_subject_idx covers
+      // subjectId) silently matches NOTHING, while the same WHERE in a
+      // SELECT matches fine — verified against the pinned server.
+      await db.query(
+        `LET $outIds = (SELECT VALUE id FROM memory_outcome WHERE subjectId.userId = $u);
+         DELETE $outIds;
+         LET $outStatIds = (SELECT VALUE id FROM memory_outcome_stat WHERE subjectId.userId = $u);
+         DELETE $outStatIds;`,
+        { u: userId },
+      );
       // Edges touching a personal entity (either endpoint) or stamped
       // with the scope directly — before the entities go.
       const [edgesDeletedRows] = await db.query<[Array<{ id?: unknown }>]>(

--- a/src/feedback/feedback.module.ts
+++ b/src/feedback/feedback.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { OutcomesModule } from '../outcomes/outcomes.module';
 import { FeedbackController } from './feedback.controller';
 import { FeedbackService } from './feedback.service';
 
 @Module({
+  // OutcomesModule supplies the 0107 confirmed/rejected outcome writer.
+  imports: [OutcomesModule],
   controllers: [FeedbackController],
   providers: [FeedbackService],
   exports: [FeedbackService],

--- a/src/feedback/feedback.service.ts
+++ b/src/feedback/feedback.service.ts
@@ -3,6 +3,12 @@ import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { idTailOf } from '../ingest/ingest-utils';
+import {
+  MemoryOutcomeService,
+  type OutcomeCounter,
+  type OutcomeEventInput,
+  type StatDelta,
+} from '../outcomes/memory-outcome.service';
 
 /**
  * FeedbackService — the write side of the retrieval feedback loop
@@ -28,6 +34,23 @@ export interface RecordFeedbackResult {
   replaced: boolean;
 }
 
+/**
+ * 0107 outcome mapping. 'not_helpful' maps to NO event and NO counter
+ * on purpose — relevance ≠ correctness, the same reasoning that keeps
+ * it out of source trust (0054:15-17): an irrelevant retrieval says
+ * nothing about whether the fact itself is right.
+ */
+const OUTCOME_EVENT: Record<FeedbackVerdict, OutcomeEventInput['event'] | null> = {
+  helpful: 'user_confirmed',
+  incorrect: 'user_rejected',
+  not_helpful: null,
+};
+const OUTCOME_BUCKET: Record<FeedbackVerdict, OutcomeCounter | null> = {
+  helpful: 'confirmedCount',
+  incorrect: 'rejectedCount',
+  not_helpful: null,
+};
+
 @Injectable()
 export class FeedbackService {
   private readonly logger = new Logger(FeedbackService.name);
@@ -35,6 +58,7 @@ export class FeedbackService {
   constructor(
     private readonly surreal: SurrealService,
     @Optional() private readonly metrics?: MetricsService,
+    @Optional() private readonly outcomes?: MemoryOutcomeService,
   ) {}
 
   async record(p: {
@@ -56,11 +80,14 @@ export class FeedbackService {
       const fact = new StringRecordId(`knowledge_fact:${idTailOf(p.factId)}`);
       // One standing vote per (fact, actor): the UNIQUE index routes a
       // repeat into the UPDATE branch — verdict replaced, not stacked.
-      const [existing] = await db.query<[Array<{ id: unknown }>]>(
-        `SELECT id FROM retrieval_feedback WHERE factId = $fact AND actor = $actor`,
+      // The prior verdict is read alongside so the 0107 rollup can move
+      // the replaced vote out of its old bucket (−1 old / +1 new).
+      const [existing] = await db.query<[Array<{ id: unknown; verdict: FeedbackVerdict }>]>(
+        `SELECT id, verdict FROM retrieval_feedback WHERE factId = $fact AND actor = $actor`,
         { fact, actor: p.actor },
       );
-      const replaced = ((existing as Array<{ id: unknown }>) ?? []).length > 0;
+      const prior = ((existing as Array<{ id: unknown; verdict: FeedbackVerdict }>) ?? [])[0];
+      const replaced = prior !== undefined;
       await db.query(
         `INSERT INTO retrieval_feedback {
            factId: $fact, verdict: $verdict, actor: $actor,
@@ -76,10 +103,55 @@ export class FeedbackService {
         },
       );
       this.metrics?.countFeedback(p.verdict);
+      this.emitOutcome(p.companyId, String(fact), p.verdict, prior?.verdict, p.actor);
       this.logger.log(
         `feedback ${p.companyId}: ${String(fact)} ${p.verdict}${replaced ? ' (replaced)' : ''}`,
       );
       return { factId: String(fact), verdict: p.verdict, replaced };
     });
+  }
+
+  /**
+   * Outcome telemetry (0107) — detached inside the service, guarded
+   * no-op when unwired or flag-off. RAW event: every helpful/incorrect
+   * vote appends one row (an audit trail of votes, including repeats).
+   * ROLLUP: explicit signed deltas mirror the 0054 one-standing-vote
+   * semantics — a NEW vote is +1 on its bucket; a REPLACED vote is −1
+   * on the old bucket and +1 on the new one, so a same-verdict repeat
+   * nets zero and the counters always reflect standing votes, never
+   * vote volume.
+   */
+  // eslint-disable-next-line max-params -- one 0107 emit seam; a params object would just rename the five values
+  private emitOutcome(
+    companyId: string,
+    factId: string,
+    verdict: FeedbackVerdict,
+    priorVerdict: FeedbackVerdict | undefined,
+    actor: string,
+  ): void {
+    if (!this.outcomes || !MemoryOutcomeService.enabled()) return;
+    const events: OutcomeEventInput[] = [];
+    const eventName = OUTCOME_EVENT[verdict];
+    if (eventName) {
+      events.push({ subjectKind: 'fact', subjectId: factId, event: eventName, actor });
+    }
+    const newBucket = OUTCOME_BUCKET[verdict];
+    const oldBucket = priorVerdict !== undefined ? OUTCOME_BUCKET[priorVerdict] : null;
+    const statDeltas: StatDelta[] = [];
+    if (oldBucket && oldBucket !== newBucket) {
+      statDeltas.push({ subjectKind: 'fact', subjectId: factId, counter: oldBucket, delta: -1 });
+    }
+    if (newBucket && oldBucket !== newBucket) {
+      statDeltas.push({
+        subjectKind: 'fact',
+        subjectId: factId,
+        counter: newBucket,
+        delta: 1,
+        // A confirmation is a verified use — same 'auto' semantics.
+        ...(newBucket === 'confirmedCount' ? { lastVerifiedUseAt: new Date() } : {}),
+      });
+    }
+    if (events.length === 0 && statDeltas.length === 0) return;
+    this.outcomes.recordOutcomes({ companyId, events, statDeltas });
   }
 }

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -10,6 +10,7 @@ import { KeyedMutex } from '../common/keyed-mutex';
 import { ConflictConfig, type DerivedSemantics, type ResolveOutcome } from './conflict-resolver';
 import { idTailOf, sourceTrustFor } from './ingest-utils';
 import { FactEmbeddingService } from './fact-embedding.service';
+import { MemoryOutcomeService, type OutcomeEventInput } from '../outcomes/memory-outcome.service';
 
 /**
  * V9 §1 — aspect classes for the derived-world lifecycle. The deriver's
@@ -71,10 +72,14 @@ export class FactResolverService {
   private readonly resolveLock = new KeyedMutex();
   private readonly conflict: ConflictConfig;
 
+  // Fourth dep is the optional 0107 outcome-telemetry writer; @Optional
+  // so positionally-constructed unit tests stay three-argument.
+  // eslint-disable-next-line max-params
   constructor(
     private readonly factEmbedding: FactEmbeddingService,
     private readonly predicateRegistry: PredicateRegistryService,
     @Optional() private readonly metrics?: MetricsService,
+    @Optional() private readonly outcomes?: MemoryOutcomeService,
   ) {
     this.conflict = {
       similarityThreshold: this.cfgNum('CONFLICT_SIMILARITY_THRESHOLD', 0.85),
@@ -322,6 +327,46 @@ export class FactResolverService {
     if (p.recordOutcomeMetric && outcome) {
       this.metrics?.countIngestFact(String(outcome));
     }
+    this.emitConflictOutcomes(p.companyId, result);
+  }
+
+  /** 0107 cap — bounds a pathological conflict fan-out. */
+  private static readonly CONFLICT_OUTCOME_CAP = 20;
+
+  /**
+   * Outcome telemetry (0107): a resolver SUPERSEDED verdict is a
+   * `contradicted` outcome for each standing fact the new one displaced;
+   * a COMPETING verdict marks every party to the standoff — the standing
+   * competitors AND the new fact. Runs in the shared post-call tail,
+   * i.e. AFTER resolveFactCall returned — never inside the KeyedMutex
+   * critical section — and the service detaches the write onto the root
+   * pool (a telemetry failure warns, never fails the ingest). Guarded
+   * no-op when the module isn't wired or the master flag is off. meta is
+   * CONTENT-FREE: the winning fact id only.
+   */
+  private emitConflictOutcomes(companyId: string, result: ResolveOutcome): void {
+    if (!this.outcomes || !MemoryOutcomeService.enabled()) return;
+    const outcome = String(result?.outcome ?? '');
+    const newFactId = result?.factId ? String(result.factId) : undefined;
+    let subjects: string[] = [];
+    if (outcome === 'SUPERSEDED') {
+      subjects = ((result?.supersededFactIds as unknown[]) ?? []).map(String);
+    } else if (outcome === 'COMPETING') {
+      subjects = [
+        ...((result?.competingFactIds as unknown[]) ?? []).map(String),
+        ...(newFactId ? [newFactId] : []),
+      ];
+    }
+    if (subjects.length === 0) return;
+    const events: OutcomeEventInput[] = subjects
+      .slice(0, FactResolverService.CONFLICT_OUTCOME_CAP)
+      .map((id) => ({
+        subjectKind: 'fact' as const,
+        subjectId: id,
+        event: 'contradicted' as const,
+        ...(newFactId && id !== newFactId ? { meta: { byFactId: newFactId } } : {}),
+      }));
+    this.outcomes.recordOutcomes({ companyId, events });
   }
 
   /**

--- a/src/ingest/ingest-core.module.ts
+++ b/src/ingest/ingest-core.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { OutcomesModule } from '../outcomes/outcomes.module';
 import { EntityResolverService } from './entity-resolver.service';
 import { EntityUpsertService } from './entity-upsert.service';
 import { FactEmbeddingService } from './fact-embedding.service';
@@ -13,6 +14,9 @@ import { FactResolverService } from './fact-resolver.service';
  * mention-via-document wrapper) without an import cycle.
  */
 @Module({
+  // OutcomesModule supplies the 0107 contradicted-outcome writer the
+  // fact resolver emits from its post-call tail (@Optional injection).
+  imports: [OutcomesModule],
   providers: [
     EntityResolverService,
     EntityUpsertService,

--- a/src/outcomes/memory-outcome.service.ts
+++ b/src/outcomes/memory-outcome.service.ts
@@ -1,0 +1,259 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { StringRecordId } from 'surrealdb';
+import { SurrealService } from '../db/surreal.service';
+import { outcomeTelemetryEnabled } from '../common/outcome-flags';
+
+/**
+ * MemoryOutcomeService — the ONE write seam for outcome telemetry
+ * (memory_outcome + memory_outcome_stat, migration 0107).
+ *
+ * Every writer (search `retrieved`, synthesize selected/used/verifier,
+ * ingest contradicted, feedback confirmed/rejected) hands this service a
+ * batch of events; it appends the raw rows and folds the corresponding
+ * counter deltas into the per-subject rollup in ONE detached round-trip.
+ *
+ * Discipline (the fact_usage/usage.ts idiom, 0053):
+ *   * master-flag guard INSIDE the service — callers may cheaply check
+ *     too, but flag-off is a no-op here regardless;
+ *   * fire-and-forget on a fresh ROOT-pool connection (the caller's
+ *     scoped connection returns to the pool when the request ends — a
+ *     detached write must not borrow it); a failure warns, never errors
+ *     or slows the serving path;
+ *   * dedupe + cap per call bounds the write amplification.
+ *
+ * meta is CONTENT-FREE by contract: record ids / verdict strings only,
+ * never fact text (see the 0107 header for why that is load-bearing).
+ */
+
+export type OutcomeSubjectKind = 'fact' | 'episode' | 'belief' | 'evidence';
+
+export type OutcomeEventName =
+  | 'retrieved'
+  | 'selected_for_context'
+  | 'used_in_answer'
+  | 'verifier_supported'
+  | 'user_confirmed'
+  | 'user_rejected'
+  | 'contradicted';
+
+/** Rollup counters a stat delta may target (0107 columns). */
+export type OutcomeCounter =
+  | 'selectedCount'
+  | 'usedCount'
+  | 'verifiedUseCount'
+  | 'confirmedCount'
+  | 'rejectedCount'
+  | 'contradictedCount';
+
+export interface OutcomeEventInput {
+  subjectKind: OutcomeSubjectKind;
+  /** Full record id string, e.g. 'knowledge_fact:abc'. */
+  subjectId: string;
+  event: OutcomeEventName;
+  actor?: string | undefined;
+  /** CONTENT-FREE: ids / verdict strings only — never fact text. */
+  meta?: Record<string, unknown> | undefined;
+}
+
+/**
+ * One signed counter move on the rollup. Explicit deltas exist for the
+ * verdict-replacement writers (feedback): a replaced vote is −1 on the
+ * old bucket and +1 on the new one — a shape the event→counter 'auto'
+ * mapping cannot express.
+ */
+export interface StatDelta {
+  subjectKind: OutcomeSubjectKind;
+  subjectId: string;
+  counter: OutcomeCounter;
+  delta: number;
+  lastUsedAt?: Date | undefined;
+  lastVerifiedUseAt?: Date | undefined;
+}
+
+/** Max events recorded per call — bounds the write amplification (usage.ts RECORD_CAP idiom). */
+export const OUTCOME_RECORD_CAP = 100;
+
+/**
+ * Event → rollup mapping for statDeltas: 'auto'. `retrieved` is
+ * DELIBERATELY absent: the raw stream is prunable volume, and readCount
+ * already lives on fact_usage (0053) — a retrieved counter here would
+ * duplicate it.
+ */
+const AUTO_STAT: Partial<
+  Record<OutcomeEventName, { counter: OutcomeCounter; used?: boolean; verified?: boolean }>
+> = {
+  selected_for_context: { counter: 'selectedCount' },
+  used_in_answer: { counter: 'usedCount', used: true },
+  verifier_supported: { counter: 'verifiedUseCount', verified: true },
+  user_confirmed: { counter: 'confirmedCount', verified: true },
+  user_rejected: { counter: 'rejectedCount' },
+  contradicted: { counter: 'contradictedCount' },
+};
+
+/**
+ * Dedupe on (subjectKind, subjectId, event, actor) then cap. Pure and
+ * exported for the unit spec.
+ */
+export function dedupeOutcomeEvents(events: OutcomeEventInput[]): OutcomeEventInput[] {
+  const seen = new Set<string>();
+  const out: OutcomeEventInput[] = [];
+  for (const ev of events) {
+    const key = `${ev.subjectKind}|${ev.subjectId}|${ev.event}|${ev.actor ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(ev);
+    if (out.length >= OUTCOME_RECORD_CAP) break;
+  }
+  return out;
+}
+
+/** The 'auto' event→counter mapping. Pure and exported for the unit spec. */
+export function autoStatDeltas(events: OutcomeEventInput[], now: Date): StatDelta[] {
+  const deltas: StatDelta[] = [];
+  for (const ev of events) {
+    const spec = AUTO_STAT[ev.event];
+    if (!spec) continue;
+    deltas.push({
+      subjectKind: ev.subjectKind,
+      subjectId: ev.subjectId,
+      counter: spec.counter,
+      delta: 1,
+      ...(spec.used ? { lastUsedAt: now } : {}),
+      ...(spec.verified ? { lastVerifiedUseAt: now } : {}),
+    });
+  }
+  return deltas;
+}
+
+/** One aggregated rollup row per subject, ready for the batched INSERT. */
+interface StatRow {
+  subjectId: StringRecordId;
+  subjectKind: OutcomeSubjectKind;
+  selectedCount: number;
+  usedCount: number;
+  verifiedUseCount: number;
+  confirmedCount: number;
+  rejectedCount: number;
+  contradictedCount: number;
+  lastUsedAt?: Date;
+  lastVerifiedUseAt?: Date;
+  updatedAt: Date;
+}
+
+/** Aggregate deltas per subject into insertable rollup rows. */
+function buildStatRows(deltas: StatDelta[], now: Date): StatRow[] {
+  const bySubject = new Map<string, StatRow>();
+  for (const d of deltas) {
+    let row = bySubject.get(d.subjectId);
+    if (!row) {
+      row = {
+        subjectId: new StringRecordId(d.subjectId),
+        subjectKind: d.subjectKind,
+        selectedCount: 0,
+        usedCount: 0,
+        verifiedUseCount: 0,
+        confirmedCount: 0,
+        rejectedCount: 0,
+        contradictedCount: 0,
+        updatedAt: now,
+      };
+      bySubject.set(d.subjectId, row);
+    }
+    row[d.counter] += d.delta;
+    if (d.lastUsedAt && (!row.lastUsedAt || d.lastUsedAt > row.lastUsedAt)) {
+      row.lastUsedAt = d.lastUsedAt;
+    }
+    if (
+      d.lastVerifiedUseAt &&
+      (!row.lastVerifiedUseAt || d.lastVerifiedUseAt > row.lastVerifiedUseAt)
+    ) {
+      row.lastVerifiedUseAt = d.lastVerifiedUseAt;
+    }
+  }
+  return [...bySubject.values()];
+}
+
+@Injectable()
+export class MemoryOutcomeService {
+  private readonly logger = new Logger(MemoryOutcomeService.name);
+
+  constructor(private readonly surreal: SurrealService) {}
+
+  /**
+   * Master-flag check, exposed as a static so the engine dirs (S5.2 —
+   * no process.env below the profile boundary) can gate cheaply via the
+   * service class, the FocusSignalService.captureEnabled() idiom.
+   */
+  static enabled(): boolean {
+    return outcomeTelemetryEnabled();
+  }
+
+  /**
+   * Append raw outcome events and fold the matching rollup deltas —
+   * fire-and-forget. `statDeltas` defaults to 'auto' (the per-event
+   * mapping above); pass an explicit array for signed replacement
+   * semantics (feedback), or when raw events and counter moves diverge.
+   */
+  recordOutcomes(opts: {
+    companyId: string;
+    events: OutcomeEventInput[];
+    requestId?: string | undefined;
+    statDeltas?: 'auto' | StatDelta[] | undefined;
+  }): void {
+    if (!outcomeTelemetryEnabled()) return;
+    const now = new Date();
+    const events = dedupeOutcomeEvents(opts.events);
+    const deltas =
+      opts.statDeltas === undefined || opts.statDeltas === 'auto'
+        ? autoStatDeltas(events, now)
+        : opts.statDeltas;
+    const statRows = buildStatRows(deltas, now);
+    if (events.length === 0 && statRows.length === 0) return;
+
+    const rows = events.map((ev) => ({
+      subjectKind: ev.subjectKind,
+      subjectId: new StringRecordId(ev.subjectId),
+      event: ev.event,
+      createdAt: now,
+      // undefined → dropped from the payload → NONE (option<...> rejects NULL).
+      ...(ev.actor !== undefined ? { actor: ev.actor } : {}),
+      ...(opts.requestId !== undefined ? { requestId: opts.requestId } : {}),
+      ...(ev.meta !== undefined ? { meta: ev.meta } : {}),
+    }));
+
+    // Two batched statements, one detached round-trip on the ROOT pool
+    // (usage.ts:98-99 idiom). The rollup rides the UNIQUE subjectId
+    // index: first sight INSERTs the row, every later one folds the
+    // per-row deltas in via $input (verified against SurrealDB 3.2.4);
+    // the `?? column` coalesce keeps a timestamp the batch didn't carry.
+    const statements: string[] = [];
+    const params: Record<string, unknown> = {};
+    if (rows.length > 0) {
+      statements.push('INSERT INTO memory_outcome $rows');
+      params.rows = rows;
+    }
+    if (statRows.length > 0) {
+      statements.push(
+        `INSERT INTO memory_outcome_stat $statRows
+           ON DUPLICATE KEY UPDATE
+             selectedCount += $input.selectedCount,
+             usedCount += $input.usedCount,
+             verifiedUseCount += $input.verifiedUseCount,
+             confirmedCount += $input.confirmedCount,
+             rejectedCount += $input.rejectedCount,
+             contradictedCount += $input.contradictedCount,
+             lastUsedAt = $input.lastUsedAt ?? lastUsedAt,
+             lastVerifiedUseAt = $input.lastVerifiedUseAt ?? lastVerifiedUseAt,
+             updatedAt = time::now()`,
+      );
+      params.statRows = statRows;
+    }
+    void this.surreal
+      .withCompany(opts.companyId, async (db) => {
+        await db.query(statements.join(';\n'), params);
+      })
+      .catch((e: Error) => {
+        this.logger.warn(`outcome recording failed for ${opts.companyId}: ${e.message}`);
+      });
+  }
+}

--- a/src/outcomes/outcome-prune.service.ts
+++ b/src/outcomes/outcome-prune.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { SurrealService } from '../db/surreal.service';
+import { ApiKeyService } from '../auth/api-key.service';
+import { outcomeEventRetentionDays, outcomeTelemetryEnabled } from '../common/outcome-flags';
+
+/**
+ * One bounded prune batch: delete the oldest raw rows past the cutoff,
+ * ≤ 5000 per round so a long-unpruned tenant never builds one huge
+ * write transaction. RETURN BEFORE hands back the deleted rows, so the
+ * loop can tell a full batch (go again) from the final partial one.
+ * Exported for the query-shape unit spec.
+ */
+export const OUTCOME_PRUNE_BATCH_QUERY = `DELETE (SELECT id FROM memory_outcome WHERE createdAt < $cutoff LIMIT 5000) RETURN BEFORE`;
+
+/**
+ * OutcomePruneService — retention for the RAW outcome event log
+ * (memory_outcome, migration 0107). The rollup (memory_outcome_stat) is
+ * deliberately never pruned: it is the compact per-subject currency that
+ * SURVIVES raw retention — that asymmetry is why the rollup is a
+ * write-path table and not a 0088 computed view (see the 0107 header).
+ *
+ * Nightly at 03:41 UTC — offset from the 03:xx cron neighbourhood
+ * (compaction 03:17, memory-quality 03:35, calibration refit 03:42) —
+ * gated on the master flag, with an in-flight guard so an overlapping
+ * tick never doubles the work. Tenant roster comes from
+ * ApiKeyService.knownCompanyIds(), the same way the compaction cron
+ * enumerates tenants.
+ */
+@Injectable()
+export class OutcomePruneService {
+  private readonly logger = new Logger(OutcomePruneService.name);
+  private running = false;
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly apiKeys: ApiKeyService,
+  ) {}
+
+  @Cron('41 3 * * *', { timeZone: 'UTC' })
+  async runNightly(): Promise<{ tenants: number; pruned: number }> {
+    if (!outcomeTelemetryEnabled()) return { tenants: 0, pruned: 0 };
+    if (this.running) {
+      this.logger.warn('outcome prune still running — skipping this tick');
+      return { tenants: 0, pruned: 0 };
+    }
+    this.running = true;
+    try {
+      const tenants = this.apiKeys.knownCompanyIds();
+      let pruned = 0;
+      for (const companyId of tenants) {
+        try {
+          pruned += await this.pruneTenant(companyId);
+        } catch (e) {
+          this.logger.warn(`outcome prune for ${companyId} failed: ${(e as Error).message}`);
+        }
+      }
+      this.logger.log(`outcome prune: ${pruned} row(s) across ${tenants.length} tenant(s)`);
+      return { tenants: tenants.length, pruned };
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /** Batched delete-until-empty of raw rows older than the retention window. */
+  async pruneTenant(companyId: string): Promise<number> {
+    const cutoff = new Date(Date.now() - outcomeEventRetentionDays() * 86_400_000);
+    return this.surreal.withCompany(companyId, async (db) => {
+      let total = 0;
+      for (;;) {
+        const [batch] = await db.query<[unknown[]]>(OUTCOME_PRUNE_BATCH_QUERY, { cutoff });
+        const n = ((batch as unknown[]) ?? []).length;
+        total += n;
+        // A partial batch means the cutoff range is drained.
+        if (n < 5000) break;
+      }
+      return total;
+    });
+  }
+}

--- a/src/outcomes/outcomes.module.ts
+++ b/src/outcomes/outcomes.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { MemoryOutcomeService } from './memory-outcome.service';
+import { OutcomePruneService } from './outcome-prune.service';
+
+/**
+ * Outcome telemetry (migration 0107): the append-only memory_outcome
+ * event log + the memory_outcome_stat write-path rollup, behind ONE
+ * write seam (MemoryOutcomeService) plus the raw-log retention cron
+ * (OutcomePruneService). Imported by the writer modules (search /
+ * synthesize / feedback / ingest-core); every injection there is
+ * @Optional so positionally-constructed unit fixtures stay valid.
+ * SurrealService and ApiKeyService come from @Global modules.
+ */
+@Module({
+  providers: [MemoryOutcomeService, OutcomePruneService],
+  exports: [MemoryOutcomeService],
+})
+export class OutcomesModule {}

--- a/src/search/search.module.ts
+++ b/src/search/search.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { EpisodesModule } from '../episodes/episodes.module';
+import { OutcomesModule } from '../outcomes/outcomes.module';
 import { SearchController } from './search.controller';
 import { SearchService } from './search.service';
 import { SearchRetrievalService } from './search-retrieval.service';
@@ -8,7 +9,8 @@ import { SearchRerankService } from './search-rerank.service';
 @Module({
   // EpisodesModule supplies ReadPinService — the per-tenant derived-world
   // pin the read path resolves before building its WHERE (audit W2).
-  imports: [EpisodesModule],
+  // OutcomesModule supplies the 0107 `retrieved` outcome writer.
+  imports: [EpisodesModule, OutcomesModule],
   controllers: [SearchController],
   providers: [SearchService, SearchRetrievalService, SearchRerankService],
   exports: [SearchService],

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -43,6 +43,8 @@ import { PipelineContext } from './pipeline-context';
 import { ReadPinService } from '../episodes/read-pin.service';
 import { getActiveRetrievalProfile, resolveSearchTuning } from './retrieval-profile';
 import { JobWorkerPool } from '../jobs/job-worker-pool.service';
+import { MemoryOutcomeService } from '../outcomes/memory-outcome.service';
+import { outcomeRetrievedEventsEnabled } from '../common/outcome-flags';
 
 export type { SearchHit } from './search.types';
 export type { GraphRetrieveHit } from './internals/graph-retrieve';
@@ -109,6 +111,10 @@ export class SearchService {
     // MULTILINGUAL_LANG_ATTRIBUTION is on). Optional so positional unit
     // constructions omit it.
     @Optional() private readonly metrics?: MetricsService,
+    // Eighth: outcome telemetry (0107) `retrieved` writer — optional so
+    // positional unit constructions omit it; double-gated at the call
+    // site (OUTCOME_RETRIEVED_EVENTS) and inside the service (master).
+    @Optional() private readonly outcomes?: MemoryOutcomeService,
   ) {}
 
   /**
@@ -400,6 +406,24 @@ export class SearchService {
         logger: this.logger,
         companyId,
         factIds: out.results.flatMap((h) => (h.facts ?? []).map((f) => f.factId)),
+      });
+    }
+    // Outcome telemetry (0107, default off): the raw `retrieved` stream
+    // for the same surfaced-fact list. DOUBLE-gated — the dedicated
+    // OUTCOME_RETRIEVED_EVENTS gate here (this is the highest-volume
+    // writer of the family) on top of the master flag inside the
+    // service. The fact_usage stamp above is UNTOUCHED (compat):
+    // readCount keeps feeding decay/G8 ranking regardless.
+    if (this.outcomes && outcomeRetrievedEventsEnabled()) {
+      this.outcomes.recordOutcomes({
+        companyId,
+        events: out.results.flatMap((h) =>
+          (h.facts ?? []).map((f) => ({
+            subjectKind: 'fact' as const,
+            subjectId: f.factId,
+            event: 'retrieved' as const,
+          })),
+        ),
       });
     }
     return out;

--- a/src/synthesize/answer-integrity.ts
+++ b/src/synthesize/answer-integrity.ts
@@ -39,6 +39,13 @@ export interface FinalizeContext {
   dto?: SynthesizeDto | undefined;
   profile?: RetrievalProfile | undefined;
   model?: string | undefined;
+  /**
+   * Tenant for the 0107 outcome-telemetry writer inside finalizeAndAdmit
+   * (used_in_answer / verifier_supported). Both serving paths — the
+   * primary serve and the L3 flip — carry it; absent (bare-cache
+   * callers) ⇒ no events, like the empty integrity gate.
+   */
+  companyId?: string | undefined;
 }
 
 /**

--- a/src/synthesize/outcome-emit.ts
+++ b/src/synthesize/outcome-emit.ts
@@ -1,0 +1,89 @@
+import { MemoryOutcomeService, type OutcomeEventInput } from '../outcomes/memory-outcome.service';
+import type { Citation } from './fact-index';
+import type { VerifierOutput } from './verifier';
+import { unverifiedReturn, type VerdictDeps } from './verdict';
+import type { SynthesizeResult } from './synthesize.types';
+
+/**
+ * Outcome telemetry (0107) emit seams for the synthesize orchestrator,
+ * extracted from the service (file/function budgets). Every function is
+ * a guarded no-op unless the outcomes module is wired AND the master
+ * flag is on — checked through the service STATIC so this engine dir
+ * takes resolved config only and never reads the environment directly
+ * (engine-gates S5.2, the FocusSignalService.captureEnabled() idiom).
+ * The service detaches the write (root pool, fire-and-forget), so
+ * serving never waits on telemetry, and a telemetry failure can never
+ * fail an answer.
+ */
+
+/**
+ * The facts that made the FINAL prompt evidence set (post search-loop
+ * refine) were selected for context — emitted once per request, at the
+ * one point the set is final.
+ */
+export function emitSelectedForContext(
+  outcomes: MemoryOutcomeService | undefined,
+  companyId: string,
+  factIds: Iterable<string>,
+): void {
+  if (!outcomes || !MemoryOutcomeService.enabled()) return;
+  const events: OutcomeEventInput[] = [...factIds].map((id) => ({
+    subjectKind: 'fact',
+    subjectId: id,
+    event: 'selected_for_context',
+  }));
+  if (events.length === 0) return;
+  outcomes.recordOutcomes({ companyId, events });
+}
+
+/**
+ * The unverifiedReturn exit (verdict.ts) plus its 0107 emission, one
+ * seam: guardrails 'off'/'answer' serve citations with NO verifier —
+ * that counts as use, never as verified use (no verifier_supported by
+ * design), and the refusal exit carries citations: [] → zero events.
+ * Null falls through to the verifier path exactly as before.
+ */
+export function unverifiedServe(
+  deps: VerdictDeps & { outcomes?: MemoryOutcomeService | undefined },
+  companyId: string,
+  args: Parameters<typeof unverifiedReturn>[1],
+): SynthesizeResult | null {
+  const result = unverifiedReturn(deps, args);
+  if (result) emitAnswerUse(deps.outcomes, { companyId, citations: result.citations });
+  return result;
+}
+
+/**
+ * The cited facts were used in the answer; on a `supported` verdict the
+ * same ids additionally count as VERIFIED use (meta carries the verdict
+ * string only — content-free). Called from BOTH finalizeAndAdmit
+ * serving paths (primary + L3 flip) with the verdict, and from the
+ * unverifiedReturn exit WITHOUT one — guardrails off/'answer' serve
+ * citations with no verifier, which counts as use, never as verified
+ * use. `companyId` is optional because bare-cache finalize callers may
+ * not carry it — absent ⇒ no events.
+ */
+export function emitAnswerUse(
+  outcomes: MemoryOutcomeService | undefined,
+  opts: { companyId: string | undefined; citations: Citation[]; verdict?: VerifierOutput },
+): void {
+  const { companyId, citations, verdict } = opts;
+  if (!outcomes || !MemoryOutcomeService.enabled() || companyId === undefined) return;
+  const events: OutcomeEventInput[] = citations.map((c) => ({
+    subjectKind: 'fact',
+    subjectId: c.factId,
+    event: 'used_in_answer',
+  }));
+  if (verdict?.verdict === 'supported') {
+    events.push(
+      ...citations.map((c): OutcomeEventInput => ({
+        subjectKind: 'fact',
+        subjectId: c.factId,
+        event: 'verifier_supported',
+        meta: { verdict: verdict.verdict },
+      })),
+    );
+  }
+  if (events.length === 0) return;
+  outcomes.recordOutcomes({ companyId, events });
+}

--- a/src/synthesize/synthesize.module.ts
+++ b/src/synthesize/synthesize.module.ts
@@ -3,6 +3,7 @@ import { SearchModule } from '../search/search.module';
 import { EpisodesModule } from '../episodes/episodes.module';
 import { AnswerCacheModule } from '../answer-cache/answer-cache.module';
 import { StrategyModule } from '../strategy/strategy.module';
+import { OutcomesModule } from '../outcomes/outcomes.module';
 import { SynthesizeController } from './synthesize.controller';
 import { FocusAdminController } from './focus-admin.controller';
 import { LensAdminController } from './lens-admin.controller';
@@ -21,7 +22,7 @@ import { EvidenceCollectorService } from './evidence-collector.service';
 import { L3EscalationService } from './l3-escalation.service';
 
 @Module({
-  imports: [SearchModule, EpisodesModule, AnswerCacheModule, StrategyModule],
+  imports: [SearchModule, EpisodesModule, AnswerCacheModule, StrategyModule, OutcomesModule],
   controllers: [SynthesizeController, FocusAdminController, LensAdminController],
   providers: [
     SynthesizeService,

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -12,7 +12,7 @@ import { MetricsService } from '../metrics/metrics.service';
 import { SynthesisGuardrails, SynthesizeDto } from './dto/synthesize.dto';
 import { buildDecisionLog } from './decision-log';
 import { applyConformalGuardrail } from './conformal-guardrail';
-import { coverageAbstention, finalizeVerdict, unverifiedReturn } from './verdict';
+import { coverageAbstention, finalizeVerdict } from './verdict';
 import type { AbstainAdaptiveGate } from './verdict';
 import {
   attachDecisionLog,
@@ -55,6 +55,8 @@ import {
   AnswerCacheService,
   type AnswerCacheBeginResult,
 } from '../answer-cache/answer-cache.service';
+import { MemoryOutcomeService } from '../outcomes/memory-outcome.service';
+import { emitAnswerUse, emitSelectedForContext, unverifiedServe } from './outcome-emit';
 import { NOOP_REPORTER, type ProgressReporter } from '../mcp/progress-reporter';
 
 export interface SynthesizeOptions {
@@ -131,6 +133,8 @@ export class SynthesizeService {
     @Optional() private readonly focusSignal?: FocusSignalService,
     @Optional() private readonly lensSuppression?: LensSuppressionService,
     @Optional() private readonly laneClassifier?: MultilingualLaneClassifierService,
+    // 0107 outcome writer — @Optional so positional unit fixtures stay valid.
+    @Optional() private readonly outcomes?: MemoryOutcomeService,
   ) {
     this.openai = createOpenAiClientOrThrow(this.configService);
     this.defaultModel = this.configService.get<string>(
@@ -360,13 +364,11 @@ export class SynthesizeService {
     const citedSet = new Set(citations.map((c) => c.factId));
     const decisionLog = explain ? buildDecisionLog(results, citedSet) : undefined;
 
-    const unverified = this.unverifiedReturn({
-      guardrails,
-      generated,
-      citations,
-      results,
-      decisionLog,
-    });
+    const unverified = unverifiedServe(
+      { metrics: this.metrics, outcomes: this.outcomes },
+      companyId,
+      { guardrails, generated, citations, results, decisionLog },
+    );
     if (unverified) return unverified;
 
     onProgress({ stage: 'verify', message: 'verifier checking claim grounding' });
@@ -476,7 +478,7 @@ export class SynthesizeService {
         guardrails,
         explain,
       })) ??
-      this.finalizeAndAdmit({ cache, dto, profile, model }, verdict, {
+      this.finalizeAndAdmit({ cache, dto, profile, model, companyId }, verdict, {
         answer: generated.answer,
         citations,
         results,
@@ -530,7 +532,7 @@ export class SynthesizeService {
     guardrails: SynthesisGuardrails;
     explain: boolean;
   }): Promise<SynthesizeResult | null> {
-    const { profile } = args;
+    const { profile, companyId } = args;
     if (!this.l3 || !profile.l3Escalation) return null;
     const adaptiveL3 = await this.resolveAdaptiveL3(args.companyId);
     const l3 = await this.l3.escalate({
@@ -563,7 +565,7 @@ export class SynthesizeService {
     // → admit(final); a downgraded L3 abstain (reason=low_coverage, citations=[])
     // is rejected by admit()'s existing gate, so it is never cached.
     return this.finalizeAndAdmit(
-      { cache: args.cache, dto: args.dto, profile: args.profile, model: args.model },
+      { cache: args.cache, dto: args.dto, profile: args.profile, model: args.model, companyId },
       l3.verdict,
       {
         answer: l3.answer,
@@ -666,6 +668,9 @@ export class SynthesizeService {
     verdict: VerifierOutput,
     args: Omit<Parameters<typeof finalizeVerdict>[1], 'verdict' | 'questionAnswered'>,
   ): Promise<SynthesizeResult> {
+    // 0107: cited facts were USED; a supported verdict ⇒ VERIFIED use.
+    // Both serving paths (primary + L3 flip) land here with companyId.
+    emitAnswerUse(this.outcomes, { companyId: ctx.companyId, citations: args.citations, verdict });
     const gate = await resolveAnswerIntegrity(
       { openai: this.openai, metrics: this.metrics, logger: this.logger, limiter: this.limiter },
       { ctx, verdict, args, defaultModel: this.defaultModel },
@@ -773,6 +778,9 @@ export class SynthesizeService {
           generated,
           refined: false,
         };
+    // 0107: the FINAL evidence set (post-refine) was selected for
+    // context — once per request, at the point the set is final.
+    emitSelectedForContext(this.outcomes, args.companyId, round.factIndex.keys());
     // Tier 5 answer-language guard — no-op unless on AND the final answer's
     // language mismatches; then the corrected regeneration replaces `generated`.
     const corrected = await enforceAnswerLanguage(
@@ -887,10 +895,6 @@ export class SynthesizeService {
   // the call sites and the spec bindings unchanged.
   private finalizeVerdict(args: Parameters<typeof finalizeVerdict>[1]): SynthesizeResult {
     return finalizeVerdict({ metrics: this.metrics }, args);
-  }
-
-  private unverifiedReturn(args: Parameters<typeof unverifiedReturn>[1]): SynthesizeResult | null {
-    return unverifiedReturn({ metrics: this.metrics }, args);
   }
 
   private coverageAbstention(

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -123,6 +123,36 @@ describe('entity-forget scenes cascade (0106)', () => {
   });
 });
 
+describe('0107_memory_outcome indexes', () => {
+  const sql = readFileSync(join(MIGRATIONS, '0107_memory_outcome.surql'), 'utf8');
+
+  it.each([
+    ['memory_outcome_subject_idx', 'memory_outcome', 'subjectId, event'],
+    ['memory_outcome_created_idx', 'memory_outcome', 'createdAt'],
+  ])('defines %s on %s(%s)', (name, table, fields) => {
+    const re = new RegExp(`DEFINE INDEX IF NOT EXISTS ${name}\\s+ON ${table} FIELDS ${fields};`);
+    expect(sql).toMatch(re);
+  });
+
+  it('pins the rollup to one row per subject (UNIQUE subjectId)', () => {
+    expect(sql).toMatch(
+      /DEFINE INDEX IF NOT EXISTS memory_outcome_stat_subject_idx\s+ON memory_outcome_stat FIELDS subjectId UNIQUE;/,
+    );
+  });
+
+  it('deliberately defines NO changefeed and NO event on either table', () => {
+    // The 0053 separation rationale: telemetry must not feed the audit
+    // mirror or any dirty-marking event. The header EXPLAINS the absence
+    // in prose, so judge only non-comment lines.
+    const code = sql
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('--'))
+      .join('\n');
+    expect(code).not.toMatch(/CHANGEFEED/);
+    expect(code).not.toMatch(/DEFINE EVENT/);
+  });
+});
+
 describe('JobRunService.finish ownership guard', () => {
   function mkSurreal(db: { query: (s: string, p?: any) => Promise<any> }) {
     return {

--- a/test/forget-l0-cascade.unit-spec.ts
+++ b/test/forget-l0-cascade.unit-spec.ts
@@ -209,9 +209,19 @@ describe('entity forget → atomicity contract (R4)', () => {
     // write that could survive a rolled-back erase.
     expect(tx!.sql).toContain('CREATE forgotten_entity');
     // No DELETE / tombstone CREATE was issued as a standalone statement
-    // outside the transaction.
+    // outside the transaction — with ONE documented exception: the 0107
+    // outcome-telemetry pre-sweep (memory_outcome) deliberately runs
+    // outside the atomic unit. Telemetry meta is content-free by
+    // contract, so an aborted erase merely deleted telemetry early (see
+    // EntityForgetService), and the sweep keeps a telemetry-heavy
+    // subject from inflating the erase transaction.
     expect(
-      queries.some((q) => !q.sql.includes('BEGIN TRANSACTION') && q.sql.includes('DELETE')),
+      queries.some(
+        (q) =>
+          !q.sql.includes('BEGIN TRANSACTION') &&
+          q.sql.includes('DELETE') &&
+          !q.sql.includes('memory_outcome'),
+      ),
     ).toBe(false);
   });
 });

--- a/test/memory-outcome.e2e-spec.ts
+++ b/test/memory-outcome.e2e-spec.ts
@@ -1,0 +1,289 @@
+/**
+ * Outcome telemetry e2e (migration 0107): with OUTCOME_TELEMETRY_ENABLED
+ * the writers append memory_outcome rows and fold memory_outcome_stat
+ * counters (fire-and-forget — assertions poll):
+ *   (a) feedback helpful/repeat/flip — raw rows accumulate, the rollup
+ *       tracks STANDING votes (replace = −1 old / +1 new, repeat nets 0);
+ *   (b) a superseding ingest marks the LOSER contradicted;
+ *   (c) OUTCOME_RETRIEVED_EVENTS adds the raw retrieved stream while
+ *       fact_usage.readCount still increments (compat pin);
+ *   (d) GDPR entity-forget + user-forget cascade BOTH tables;
+ *   (e) master off ⇒ zero rows (byte-identical).
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+interface OutcomeRow {
+  event: string;
+  actor?: string;
+  meta?: Record<string, unknown>;
+}
+
+interface StatRow {
+  selectedCount: number;
+  usedCount: number;
+  verifiedUseCount: number;
+  confirmedCount: number;
+  rejectedCount: number;
+  contradictedCount: number;
+  lastVerifiedUseAt?: string;
+}
+
+describe('memory_outcome — outcome telemetry recording and cascade', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_outcome_e2e' });
+    process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+  });
+
+  afterAll(async () => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    delete process.env.OUTCOME_RETRIEVED_EVENTS;
+    delete process.env.SEARCH_USAGE_RECORDING_ENABLED;
+    if (f) await f.close();
+  });
+
+  const tail = (factId: string) => factId.split(':')[1];
+
+  const rawRows = async (factId: string, event?: string): Promise<OutcomeRow[]> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[OutcomeRow[]]>(
+        `SELECT event, actor, meta FROM memory_outcome
+          WHERE subjectId = type::record('knowledge_fact', $tail)
+          ${event ? 'AND event = $event' : ''}`,
+        { tail: tail(factId), ...(event ? { event } : {}) },
+      );
+      return (rows as OutcomeRow[]) ?? [];
+    });
+  };
+
+  const statFor = async (factId: string): Promise<StatRow | null> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[StatRow[]]>(
+        `SELECT * FROM memory_outcome_stat
+          WHERE subjectId = type::record('knowledge_fact', $tail)`,
+        { tail: tail(factId) },
+      );
+      return (rows as StatRow[])?.[0] ?? null;
+    });
+  };
+
+  /** Writers are fire-and-forget — poll until the condition holds. */
+  const waitFor = async <T>(probe: () => Promise<T>, ok: (v: T) => boolean): Promise<T> => {
+    let last: T = await probe();
+    for (let i = 0; i < 40 && !ok(last); i++) {
+      await new Promise((r) => setTimeout(r, 100));
+      last = await probe();
+    }
+    return last;
+  };
+
+  const ingestFact = async (
+    entityId: string,
+    predicate: string,
+    object: string,
+    opts: { validFrom?: string; confidence?: number; userId?: string } = {},
+  ): Promise<{ factId: string; outcome: string; supersededFactIds?: string[] }> => {
+    const res = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: entityId },
+        predicate,
+        object,
+        validFrom: opts.validFrom ?? '2026-01-01',
+        confidence: opts.confidence ?? 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+        ...(opts.userId ? { userId: opts.userId } : {}),
+      });
+    expect([200, 201]).toContain(res.status);
+    return res.body;
+  };
+
+  const vote = async (factId: string, verdict: string) => {
+    const res = await f.http.post('/v1/feedback').set(auth()).send({ factId, verdict });
+    expect([200, 201]).toContain(res.status);
+  };
+
+  it('(a) feedback: raw rows accumulate, the rollup tracks standing votes', async () => {
+    const { factId } = await ingestFact('outcome_vote_subj', 'name', 'Outcome Vote Subject');
+
+    // First helpful vote → one raw user_confirmed + confirmedCount 1.
+    await vote(factId, 'helpful');
+    const confirmed1 = await waitFor(
+      () => rawRows(factId, 'user_confirmed'),
+      (r) => r.length >= 1,
+    );
+    expect(confirmed1).toHaveLength(1);
+    // actor = the caller key hash, never free-form.
+    expect(confirmed1[0]!.actor).toMatch(/^sha256:/);
+    const stat1 = await waitFor(
+      () => statFor(factId),
+      (s) => (s?.confirmedCount ?? 0) >= 1,
+    );
+    expect(stat1).toMatchObject({ confirmedCount: 1, rejectedCount: 0 });
+    expect(stat1!.lastVerifiedUseAt).toBeTruthy();
+
+    // Repeat helpful → SECOND raw row (audit trail), stat NETS to 1.
+    await vote(factId, 'helpful');
+    const confirmed2 = await waitFor(
+      () => rawRows(factId, 'user_confirmed'),
+      (r) => r.length >= 2,
+    );
+    expect(confirmed2).toHaveLength(2);
+    expect((await statFor(factId))!.confirmedCount).toBe(1);
+
+    // Flip to incorrect → −1 confirmed / +1 rejected (standing vote moves).
+    await vote(factId, 'incorrect');
+    const rejected = await waitFor(
+      () => rawRows(factId, 'user_rejected'),
+      (r) => r.length >= 1,
+    );
+    expect(rejected).toHaveLength(1);
+    const statFlipped = await waitFor(
+      () => statFor(factId),
+      (s) => (s?.rejectedCount ?? 0) >= 1 && (s?.confirmedCount ?? 1) === 0,
+    );
+    expect(statFlipped).toMatchObject({ confirmedCount: 0, rejectedCount: 1 });
+  });
+
+  it('(b) a superseding ingest marks the loser contradicted', async () => {
+    const first = await ingestFact('outcome_conflict', 'tier', 'standard', {
+      validFrom: '2026-01-01',
+      confidence: 0.7,
+    });
+    expect(first.outcome).toBe('INSERTED');
+    const winner = await ingestFact('outcome_conflict', 'tier', 'gold', {
+      validFrom: '2026-04-01',
+      confidence: 0.95,
+    });
+    expect(winner.outcome).toBe('SUPERSEDED');
+    expect(winner.supersededFactIds).toContain(first.factId);
+
+    const contradicted = await waitFor(
+      () => rawRows(first.factId, 'contradicted'),
+      (r) => r.length >= 1,
+    );
+    expect(contradicted).toHaveLength(1);
+    // meta is content-free: the winning fact id only.
+    expect(contradicted[0]!.meta).toMatchObject({ byFactId: winner.factId });
+    const stat = await waitFor(
+      () => statFor(first.factId),
+      (s) => (s?.contradictedCount ?? 0) >= 1,
+    );
+    expect(stat!.contradictedCount).toBe(1);
+    // The WINNER of a supersede is not contradicted.
+    expect(await rawRows(winner.factId, 'contradicted')).toHaveLength(0);
+  });
+
+  it('(c) retrieved stream is double-gated AND fact_usage keeps incrementing (compat pin)', async () => {
+    process.env.SEARCH_USAGE_RECORDING_ENABLED = '1';
+    process.env.OUTCOME_RETRIEVED_EVENTS = '1';
+    try {
+      const { factId } = await ingestFact('outcome_probe', 'name', 'Outcome Probe Tenant');
+      const search = await f.http
+        .post('/v1/search')
+        .set(auth())
+        .send({ query: 'Outcome Probe Tenant', limit: 5 });
+      expect(search.status).toBe(201);
+      expect(search.body.results.length).toBeGreaterThan(0);
+
+      const retrieved = await waitFor(
+        () => rawRows(factId, 'retrieved'),
+        (r) => r.length >= 1,
+      );
+      expect(retrieved.length).toBeGreaterThanOrEqual(1);
+      // retrieved is raw-stream only: NO rollup counter for it.
+      expect((await statFor(factId))?.contradictedCount ?? 0).toBe(0);
+
+      // Compat pin: the 0053 fact_usage stamp is untouched by 0107.
+      const surreal = f.app.get(SurrealService);
+      const usage = await waitFor(
+        () =>
+          surreal.withCompany(f.companyId, async (db) => {
+            const [rows] = await db.query<[Array<{ readCount: number }>]>(
+              `SELECT readCount FROM fact_usage
+                WHERE factId = type::record('knowledge_fact', $tail)`,
+              { tail: tail(factId) },
+            );
+            return (rows as Array<{ readCount: number }>)?.[0] ?? null;
+          }),
+        (u) => (u?.readCount ?? 0) >= 1,
+      );
+      expect(usage!.readCount).toBeGreaterThanOrEqual(1);
+    } finally {
+      delete process.env.SEARCH_USAGE_RECORDING_ENABLED;
+      delete process.env.OUTCOME_RETRIEVED_EVENTS;
+    }
+  });
+
+  it('(d) GDPR: entity-forget and user-forget cascade both tables', async () => {
+    // Entity leg — seed outcome rows via a vote, then erase the entity.
+    const { factId } = await ingestFact('outcome_forget_subj', 'name', 'Outcome Forget Subject');
+    await vote(factId, 'helpful');
+    await waitFor(
+      () => statFor(factId),
+      (s) => (s?.confirmedCount ?? 0) >= 1,
+    );
+
+    const surreal = f.app.get(SurrealService);
+    const entityId = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ entityId: unknown }>]>(
+        `SELECT entityId FROM type::record('knowledge_fact', $tail)`,
+        { tail: tail(factId) },
+      );
+      return String((rows as Array<{ entityId: unknown }>)?.[0]?.entityId);
+    });
+    const forget = await f.http
+      .post(`/v1/entities/${encodeURIComponent(entityId)}/forget`)
+      .set(auth())
+      .send({ reason: 'gdpr_request', requestId: 'req-outcome-1' });
+    expect([200, 201]).toContain(forget.status);
+    expect(await rawRows(factId)).toHaveLength(0);
+    expect(await statFor(factId)).toBeNull();
+
+    // User leg — a user-scoped fact's telemetry dies with the user slice.
+    const userFact = await ingestFact('outcome_user_subj', 'name', 'Outcome User Subject', {
+      userId: 'user_outcome_1',
+    });
+    await vote(userFact.factId, 'helpful');
+    await waitFor(
+      () => statFor(userFact.factId),
+      (s) => (s?.confirmedCount ?? 0) >= 1,
+    );
+
+    const userForget = await f.http.post('/v1/users/user_outcome_1/forget').set(auth()).send({});
+    expect([200, 201]).toContain(userForget.status);
+    expect(await rawRows(userFact.factId)).toHaveLength(0);
+    expect(await statFor(userFact.factId)).toBeNull();
+  });
+
+  it('(e) master off ⇒ zero rows written (byte-identical)', async () => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    try {
+      const { factId } = await ingestFact('outcome_off_subj', 'name', 'Outcome Off Subject');
+      await vote(factId, 'helpful');
+      // Supersede path too — no contradicted rows either.
+      const off1 = await ingestFact('outcome_off_conflict', 'tier', 'standard', {
+        validFrom: '2026-01-01',
+        confidence: 0.7,
+      });
+      await ingestFact('outcome_off_conflict', 'tier', 'gold', {
+        validFrom: '2026-04-01',
+        confidence: 0.95,
+      });
+      // Fire-and-forget writers: give any (buggy) write time to land.
+      await new Promise((r) => setTimeout(r, 500));
+      expect(await rawRows(factId)).toHaveLength(0);
+      expect(await statFor(factId)).toBeNull();
+      expect(await rawRows(off1.factId)).toHaveLength(0);
+      expect(await statFor(off1.factId)).toBeNull();
+    } finally {
+      process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+    }
+  });
+});

--- a/test/memory-outcome.unit-spec.ts
+++ b/test/memory-outcome.unit-spec.ts
@@ -1,0 +1,236 @@
+/**
+ * Unit coverage for the 0107 outcome-telemetry write seam:
+ *   * recordOutcomes — master-flag guard, dedupe + cap, the 'auto'
+ *     event→counter mapping, explicit signed statDeltas, and the two
+ *     batched statements' shape;
+ *   * OutcomePruneService — batch-loop termination + the prune query
+ *     shape (bounded DELETE-subquery with RETURN BEFORE).
+ */
+import {
+  MemoryOutcomeService,
+  OUTCOME_RECORD_CAP,
+  autoStatDeltas,
+  dedupeOutcomeEvents,
+  type OutcomeEventInput,
+} from '../src/outcomes/memory-outcome.service';
+import {
+  OUTCOME_PRUNE_BATCH_QUERY,
+  OutcomePruneService,
+} from '../src/outcomes/outcome-prune.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { ApiKeyService } from '../src/auth/api-key.service';
+
+interface CapturedQuery {
+  sql: string;
+  params: Record<string, unknown>;
+}
+
+function makeSurreal(captured: CapturedQuery[], results: unknown[][] = []) {
+  let call = 0;
+  const db = {
+    query: async (sql: string, params: Record<string, unknown> = {}) => {
+      captured.push({ sql, params });
+      return [results[call++] ?? []];
+    },
+  };
+  return {
+    withCompany: async <T>(_c: string, fn: (d: typeof db) => Promise<T>) => fn(db),
+  } as unknown as SurrealService;
+}
+
+/** The detached write is fire-and-forget — yield until it lands. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+}
+
+const ev = (
+  subjectId: string,
+  event: OutcomeEventInput['event'],
+  extra: Partial<OutcomeEventInput> = {},
+): OutcomeEventInput => ({ subjectKind: 'fact', subjectId, event, ...extra });
+
+describe('MemoryOutcomeService.recordOutcomes', () => {
+  beforeEach(() => {
+    process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+  });
+  afterAll(() => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+  });
+
+  it('is a no-op with the master flag off (byte-identical)', async () => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    const captured: CapturedQuery[] = [];
+    const svc = new MemoryOutcomeService(makeSurreal(captured));
+    svc.recordOutcomes({ companyId: 'co_x', events: [ev('knowledge_fact:a', 'used_in_answer')] });
+    await flush();
+    expect(captured).toEqual([]);
+    expect(MemoryOutcomeService.enabled()).toBe(false);
+  });
+
+  it("'auto' maps each event to its counter — and `retrieved` to NO stat row", async () => {
+    const captured: CapturedQuery[] = [];
+    const svc = new MemoryOutcomeService(makeSurreal(captured));
+    svc.recordOutcomes({
+      companyId: 'co_x',
+      events: [
+        ev('knowledge_fact:a', 'selected_for_context'),
+        ev('knowledge_fact:a', 'used_in_answer'),
+        ev('knowledge_fact:a', 'verifier_supported'),
+        ev('knowledge_fact:b', 'user_confirmed'),
+        ev('knowledge_fact:b', 'user_rejected'),
+        ev('knowledge_fact:c', 'contradicted'),
+        ev('knowledge_fact:d', 'retrieved'),
+      ],
+    });
+    await flush();
+    expect(captured).toHaveLength(1);
+    const { sql, params } = captured[0]!;
+    // Two batched statements in one round-trip.
+    expect(sql).toContain('INSERT INTO memory_outcome $rows');
+    expect(sql).toContain('INSERT INTO memory_outcome_stat $statRows');
+    expect(sql).toContain('ON DUPLICATE KEY UPDATE');
+    const rows = params.rows as Array<{ subjectId: unknown; event: string }>;
+    expect(rows).toHaveLength(7);
+    const statRows = params.statRows as Array<Record<string, unknown>>;
+    const byId = new Map(statRows.map((r) => [String(r.subjectId), r]));
+    // fact:d only carried `retrieved` → no rollup row at all.
+    expect(byId.has('knowledge_fact:d')).toBe(false);
+    expect(byId.get('knowledge_fact:a')).toMatchObject({
+      selectedCount: 1,
+      usedCount: 1,
+      verifiedUseCount: 1,
+      confirmedCount: 0,
+    });
+    expect((byId.get('knowledge_fact:a') as { lastUsedAt?: Date }).lastUsedAt).toBeInstanceOf(Date);
+    expect(
+      (byId.get('knowledge_fact:a') as { lastVerifiedUseAt?: Date }).lastVerifiedUseAt,
+    ).toBeInstanceOf(Date);
+    expect(byId.get('knowledge_fact:b')).toMatchObject({ confirmedCount: 1, rejectedCount: 1 });
+    // user_confirmed counts as a verified use.
+    expect(
+      (byId.get('knowledge_fact:b') as { lastVerifiedUseAt?: Date }).lastVerifiedUseAt,
+    ).toBeInstanceOf(Date);
+    expect(byId.get('knowledge_fact:c')).toMatchObject({ contradictedCount: 1 });
+  });
+
+  it('dedupes on (kind, subject, event, actor) and caps at OUTCOME_RECORD_CAP', async () => {
+    const dup = [
+      ev('knowledge_fact:a', 'used_in_answer'),
+      ev('knowledge_fact:a', 'used_in_answer'),
+    ];
+    expect(dedupeOutcomeEvents(dup)).toHaveLength(1);
+    // Distinct actors are NOT dupes (feedback: one row per voting key).
+    expect(
+      dedupeOutcomeEvents([
+        ev('knowledge_fact:a', 'user_confirmed', { actor: 'k1' }),
+        ev('knowledge_fact:a', 'user_confirmed', { actor: 'k2' }),
+      ]),
+    ).toHaveLength(2);
+    const many = Array.from({ length: OUTCOME_RECORD_CAP + 50 }, (_, i) =>
+      ev(`knowledge_fact:f${i}`, 'retrieved'),
+    );
+    expect(dedupeOutcomeEvents(many)).toHaveLength(OUTCOME_RECORD_CAP);
+
+    const captured: CapturedQuery[] = [];
+    const svc = new MemoryOutcomeService(makeSurreal(captured));
+    svc.recordOutcomes({ companyId: 'co_x', events: many });
+    await flush();
+    expect((captured[0]!.params.rows as unknown[]).length).toBe(OUTCOME_RECORD_CAP);
+  });
+
+  it('explicit signed statDeltas aggregate per subject (replace = −1 old / +1 new)', async () => {
+    const captured: CapturedQuery[] = [];
+    const svc = new MemoryOutcomeService(makeSurreal(captured));
+    svc.recordOutcomes({
+      companyId: 'co_x',
+      events: [ev('knowledge_fact:a', 'user_rejected', { actor: 'k1' })],
+      statDeltas: [
+        {
+          subjectKind: 'fact',
+          subjectId: 'knowledge_fact:a',
+          counter: 'confirmedCount',
+          delta: -1,
+        },
+        { subjectKind: 'fact', subjectId: 'knowledge_fact:a', counter: 'rejectedCount', delta: 1 },
+      ],
+    });
+    await flush();
+    const statRows = captured[0]!.params.statRows as Array<Record<string, unknown>>;
+    expect(statRows).toHaveLength(1);
+    expect(statRows[0]).toMatchObject({ confirmedCount: -1, rejectedCount: 1, usedCount: 0 });
+  });
+
+  it('emits only the stat statement when events are empty but deltas move', async () => {
+    const captured: CapturedQuery[] = [];
+    const svc = new MemoryOutcomeService(makeSurreal(captured));
+    // A helpful → not_helpful flip: no raw event, standing vote leaves
+    // its bucket.
+    svc.recordOutcomes({
+      companyId: 'co_x',
+      events: [],
+      statDeltas: [
+        {
+          subjectKind: 'fact',
+          subjectId: 'knowledge_fact:a',
+          counter: 'confirmedCount',
+          delta: -1,
+        },
+      ],
+    });
+    await flush();
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).not.toContain('INSERT INTO memory_outcome $rows');
+    expect(captured[0]!.sql).toContain('INSERT INTO memory_outcome_stat');
+  });
+
+  it("the 'auto' mapping helper leaves `retrieved` unmapped", () => {
+    const now = new Date();
+    expect(autoStatDeltas([ev('knowledge_fact:a', 'retrieved')], now)).toEqual([]);
+    expect(autoStatDeltas([ev('knowledge_fact:a', 'selected_for_context')], now)).toMatchObject([
+      { counter: 'selectedCount', delta: 1 },
+    ]);
+  });
+});
+
+describe('OutcomePruneService', () => {
+  beforeEach(() => {
+    process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+  });
+  afterAll(() => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+  });
+
+  const apiKeys = (ids: string[]) => ({ knownCompanyIds: () => ids }) as unknown as ApiKeyService;
+
+  it('prune query is the bounded DELETE-subquery shape', () => {
+    expect(OUTCOME_PRUNE_BATCH_QUERY).toBe(
+      'DELETE (SELECT id FROM memory_outcome WHERE createdAt < $cutoff LIMIT 5000) RETURN BEFORE',
+    );
+  });
+
+  it('loops full batches and stops on the partial one', async () => {
+    const captured: CapturedQuery[] = [];
+    const surreal = makeSurreal(captured, [new Array(5000).fill({}), new Array(3).fill({})]);
+    const svc = new OutcomePruneService(surreal, apiKeys(['co_x']));
+    const total = await svc.pruneTenant('co_x');
+    expect(total).toBe(5003);
+    expect(captured).toHaveLength(2);
+    expect(captured.every((c) => c.sql === OUTCOME_PRUNE_BATCH_QUERY)).toBe(true);
+    expect(captured[0]!.params.cutoff).toBeInstanceOf(Date);
+  });
+
+  it('runNightly is gated on the master flag', async () => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    const captured: CapturedQuery[] = [];
+    const svc = new OutcomePruneService(makeSurreal(captured), apiKeys(['co_x']));
+    expect(await svc.runNightly()).toEqual({ tenants: 0, pruned: 0 });
+    expect(captured).toEqual([]);
+  });
+
+  it('runNightly walks the tenant roster when on', async () => {
+    const captured: CapturedQuery[] = [];
+    const svc = new OutcomePruneService(makeSurreal(captured, [[], []]), apiKeys(['co_a', 'co_b']));
+    expect(await svc.runNightly()).toEqual({ tenants: 2, pruned: 0 });
+    expect(captured).toHaveLength(2);
+  });
+});

--- a/test/synthesize-outcome-writers.unit-spec.ts
+++ b/test/synthesize-outcome-writers.unit-spec.ts
@@ -1,0 +1,184 @@
+/**
+ * 0107 outcome-telemetry writer seams inside SynthesizeService, driven
+ * with a mocked MemoryOutcomeService (no DB, no OpenAI):
+ *   * selected_for_context fires once, after produceAnswer returns, for
+ *     the FINAL factIndex keys;
+ *   * used_in_answer + verifier_supported (meta { verdict }) fire in
+ *     finalizeAndAdmit on a supported strict verdict;
+ *   * the unverifiedReturn exit ('answer'/'off' guardrails) emits
+ *     used_in_answer for the served citations — and NEVER
+ *     verifier_supported (no verifier ran);
+ *   * with the master flag off, nothing is emitted at any seam.
+ */
+import { ConfigService } from '@nestjs/config';
+import { SynthesizeService } from '../src/synthesize/synthesize.service';
+import type { SearchService, SearchHit } from '../src/search/search.service';
+import type { SynthesizeDto } from '../src/synthesize/dto/synthesize.dto';
+import type {
+  MemoryOutcomeService,
+  OutcomeEventInput,
+} from '../src/outcomes/memory-outcome.service';
+
+interface RecordedCall {
+  companyId: string;
+  events: OutcomeEventInput[];
+}
+
+function makeHit(entityId: string, factId: string): SearchHit {
+  return {
+    entityId,
+    entityType: 'customer',
+    canonicalName: entityId,
+    externalRefs: {},
+    facts: [
+      {
+        factId,
+        predicate: 'name',
+        object: 'Maya',
+        confidence: 0.9,
+        validFrom: '2026-01-01T00:00:00Z',
+        status: 'active',
+        score: 0.5,
+      },
+    ],
+    score: 0.5,
+  } as SearchHit;
+}
+
+function makeConfig(): ConfigService {
+  return {
+    get: <T>(_k: string, dflt?: T) => dflt as T,
+    getOrThrow: <T>() => 'sk-stub' as unknown as T,
+  } as unknown as ConfigService;
+}
+
+/** Generator answers with a citation; the verifier (system prompt names
+ *  the auditor role) returns the requested verdict. */
+function stubOpenAI(verdict: string) {
+  return {
+    chat: {
+      completions: {
+        create: async (req: { messages: Array<{ role: string; content: string }> }) => {
+          const isVerifier = req.messages[0]!.content.includes('auditor');
+          return {
+            choices: [
+              {
+                message: {
+                  content: isVerifier
+                    ? JSON.stringify({ verdict })
+                    : JSON.stringify({ answer: 'Maya [f1].', citedFactIds: ['f1'] }),
+                },
+                finish_reason: 'stop',
+              },
+            ],
+          };
+        },
+      },
+    },
+  };
+}
+
+function makeSvc(verdict: string): { svc: SynthesizeService; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const outcomes = {
+    recordOutcomes: (opts: RecordedCall) => {
+      calls.push({ companyId: opts.companyId, events: opts.events });
+    },
+  } as unknown as MemoryOutcomeService;
+  const search = {
+    search: async () => ({ results: [makeHit('cust_a', 'f1')] }),
+  } as unknown as SearchService;
+  const svc = new SynthesizeService(
+    search,
+    makeConfig(),
+    undefined, // metrics
+    undefined, // evidenceCollector
+    undefined, // answerCache
+    undefined, // l3
+    undefined, // focusSignal
+    undefined, // lensSuppression
+    undefined, // laneClassifier
+    outcomes,
+  );
+  (svc as unknown as { openai: unknown }).openai = stubOpenAI(verdict);
+  return { svc, calls };
+}
+
+const eventsOf = (calls: RecordedCall[]) => calls.flatMap((c) => c.events);
+const named = (calls: RecordedCall[], event: string) =>
+  eventsOf(calls).filter((e) => e.event === event);
+
+const baseDto: SynthesizeDto = { query: 'what is her name?' };
+
+describe('SynthesizeService — 0107 outcome writer seams', () => {
+  beforeEach(() => {
+    process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+  });
+  afterAll(() => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+  });
+
+  it('strict + supported: selected_for_context, then used_in_answer + verifier_supported', async () => {
+    const { svc, calls } = makeSvc('supported');
+    const out = await svc.synthesize({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesisGuardrails: 'strict' },
+      callerScopes: ['brain:read'],
+    });
+    expect(out.answer).toBe('Maya [f1].');
+
+    const selected = named(calls, 'selected_for_context');
+    expect(selected).toHaveLength(1);
+    expect(selected[0]).toMatchObject({ subjectKind: 'fact', subjectId: 'f1' });
+
+    const used = named(calls, 'used_in_answer');
+    expect(used).toHaveLength(1);
+    expect(used[0]).toMatchObject({ subjectId: 'f1' });
+
+    const verified = named(calls, 'verifier_supported');
+    expect(verified).toHaveLength(1);
+    expect(verified[0]).toMatchObject({ subjectId: 'f1', meta: { verdict: 'supported' } });
+
+    expect(calls.every((c) => c.companyId === 'co_x')).toBe(true);
+  });
+
+  it('strict + unsupported: used_in_answer still recorded at the finalize seam, NO verifier_supported', async () => {
+    const { svc, calls } = makeSvc('unsupported');
+    await svc.synthesize({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesisGuardrails: 'strict' },
+      callerScopes: ['brain:read'],
+    });
+    expect(named(calls, 'selected_for_context')).toHaveLength(1);
+    expect(named(calls, 'used_in_answer')).toHaveLength(1);
+    expect(named(calls, 'verifier_supported')).toHaveLength(0);
+  });
+
+  it("'answer' guardrails (unverifiedReturn exit): used_in_answer, never verifier_supported", async () => {
+    const { svc, calls } = makeSvc('supported');
+    const out = await svc.synthesize({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesisGuardrails: 'answer' },
+      callerScopes: ['brain:read'],
+    });
+    expect(out.answer).toBe('Maya [f1].');
+    expect(named(calls, 'selected_for_context')).toHaveLength(1);
+    const used = named(calls, 'used_in_answer');
+    expect(used).toHaveLength(1);
+    expect(used[0]).toMatchObject({ subjectId: 'f1' });
+    // No verifier ran — a use is never a VERIFIED use on this exit.
+    expect(named(calls, 'verifier_supported')).toHaveLength(0);
+  });
+
+  it('master flag off: no seam emits anything (byte-identical)', async () => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    const { svc, calls } = makeSvc('supported');
+    const out = await svc.synthesize({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesisGuardrails: 'strict' },
+      callerScopes: ['brain:read'],
+    });
+    expect(out.answer).toBe('Maya [f1].');
+    expect(calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Groundwork for roadmap gap #7: today `fact_usage` (0053) counts only that search **surfaced** a fact — nothing records what happened after. This PR adds the outcome substrate the verified-use ranking PR will read: an append-only `memory_outcome` event log plus a `memory_outcome_stat` per-subject rollup maintained on the write path, migration `0107`, behind one write seam (`MemoryOutcomeService`).

Everything is **default-off** behind `OUTCOME_TELEMETRY_ENABLED` (byte-identical when off — every writer is a guarded no-op, the prune cron returns immediately). No LLM calls anywhere.

## Design

- **Separate tables, not fields on `knowledge_fact`** — the 0053 rationale carries over verbatim (quoted in the migration header): the fact table sits on a CHANGEFEED mirrored into `audit_event`, `knowledge_artifact` has a dirty-marking `DEFINE EVENT`, and ingest serializes fact writes through a KeyedMutex. Telemetry touches none of those surfaces; 0107 deliberately defines **no CHANGEFEED and no EVENT** (pinned by a unit gate).
- **Rollup is a write-path table, NOT a 0088 computed view** — `lastVerifiedUseAt` is a max (non-invertible), and retention-pruning raw rows would decrement any incremental view. The rollup must *survive* raw pruning, so the writer maintains it via `INSERT ... ON DUPLICATE KEY UPDATE` with per-row `$input` deltas over the UNIQUE `subjectId` index (idiom verified against SurrealDB 3.2.4, incl. signed deltas and omitted-timestamp coalesce).
- **Growth bounds** — raw <= event volume x `OUTCOME_EVENT_RETENTION_DAYS` (nightly 03:41 UTC prune, 5000-row batches, in-flight guard, compaction-style tenant roster); stat <= 1 row/subject. Writers dedupe + cap 100 events/call (the `usage.ts` RECORD_CAP idiom); writes are detached on the root pool (fire-and-forget, warn on failure).
- **`meta` is content-free by contract** — record ids / verdict strings only, never fact text. That contract is what lets the entity-forget pre-sweep run outside the erase transaction.

## Writers

| Writer | Event(s) | Rollup effect | Gate |
|---|---|---|---|
| `search.service.ts` (next to `recordFactUsage`) | `retrieved` per surfaced fact | none (raw stream only; readCount already lives on `fact_usage`) | `OUTCOME_RETRIEVED_EVENTS` **and** master |
| `synthesize` (`produceAnswer` final round) | `selected_for_context` for final factIndex keys | `selectedCount` | master |
| `synthesize` (`finalizeAndAdmit`, both primary and L3-flip paths via `FinalizeContext.companyId`) | `used_in_answer` for cited facts; `verifier_supported` (meta `{verdict}`) when supported | `usedCount`+`lastUsedAt`; `verifiedUseCount`+`lastVerifiedUseAt` | master |
| `synthesize` (`unverifiedServe` exit — guardrails `off`/`answer`) | `used_in_answer` (no verifier ran -> never a verified use) | `usedCount`+`lastUsedAt` | master |
| `fact-resolver` (post-call tail, outside the KeyedMutex) | `contradicted` on SUPERSEDED losers (meta `{byFactId}`) / all COMPETING parties incl. the new fact; cap 20 | `contradictedCount` | master |
| `feedback.service.ts` | `helpful`->`user_confirmed`, `incorrect`->`user_rejected`; actor = caller key hash | explicit signed deltas: new vote +1; replaced vote -1 old / +1 new (same-verdict repeat nets zero — counters track STANDING votes, raw rows keep the full vote trail) | master |

**`not_helpful` decision (flagged for owner):** it maps to **no event and no counter** — relevance is not correctness, the same reasoning that keeps it out of source trust (0054:15-17). A standing `helpful` vote replaced by `not_helpful` still decrements `confirmedCount` (the confirmation is withdrawn). Say the word if you want a dedicated relevance counter instead.

## GDPR

- **user-forget**: both tables purged right after the `fact_usage` deletes, while the facts (and their `subjectId.userId` traversal) are alive.
- **entity-forget**: bounded pre-sweep of raw rows **outside** the erase transaction (content-free meta => an aborted erase merely deleted telemetry early — documented), plus straggler + rollup deletes **inside** the tx next to the `fact_usage` line. `txRecordCount` deliberately unchanged (uncounted like `fact_usage`), so `FORGET_MAX_TX_RECORDS` never trips on telemetry. The R4 atomicity unit pin gained a documented carve-out for the pre-sweep.
- **SurrealDB 3.2.4 finding**: a `DELETE` whose WHERE traverses through an indexed record field (`memory_outcome_subject_idx` covers `subjectId`) silently matches **nothing**, while the same WHERE in a `SELECT` matches fine — reproduced against the pinned server (rocksdb). All GDPR deletes therefore use `LET $ids = (SELECT VALUE id ...); DELETE $ids` (verified working; caught by the e2e before the fix).

## Flags

`OUTCOME_TELEMETRY_ENABLED` (master, bool), `OUTCOME_RETRIEVED_EVENTS` (extra gate on the high-volume writer, bool), `OUTCOME_EVENT_RETENTION_DAYS` (int, default 30). Booleans registered in `KNOWN_BOOLEAN_FLAGS`; all three in `CONFIG_CATALOG` under **`audit`** (no `telemetry` category exists — `audit` is the nearest: append-only event trail + retention knob; adding a new `ConfigCategory` felt out of scope). The `OUTCOME_` prefix sits outside `ENGINE_PREFIX` by design (measurement substrate, not an engine fork) — confirmed against the flag-budget spec, which passes with no golden change. Engine dirs never read env (S5.2): synthesize/search gate through the `MemoryOutcomeService.enabled()` static / common-layer helpers.

## Safety

- Default-off => byte-identical: pinned by unit (`recordOutcomes` no-op, no synthesize seam emits) and e2e (feedback + supersede + search with master off => zero rows in both tables).
- `fact_usage` compat pinned: the 0053 stamp is untouched and the e2e asserts `readCount` still increments alongside the `retrieved` stream.
- All injections `@Optional()` — existing positionally-constructed unit fixtures stay valid.

## Test plan

- `test/memory-outcome.e2e-spec.ts` (5): feedback raw-trail + standing-vote rollup (repeat nets, flip moves buckets); superseding ingest -> `contradicted` on the loser with `meta.byFactId`; retrieved stream + `fact_usage` compat pin; entity-forget + user-forget cascade both tables; master-off => zero rows.
- `test/memory-outcome.unit-spec.ts` (10): flag guard, 'auto' mapping (retrieved unmapped), dedupe + cap, signed delta aggregation, stat-only statement, prune query shape + batch-loop termination + cron gating.
- `test/synthesize-outcome-writers.unit-spec.ts` (4): mocked `MemoryOutcomeService`; selected/used/verifier_supported at the right seams incl. the `unverifiedServe` exit; flag-off emits nothing.
- `test/audit-p1-guards.unit-spec.ts`: 0107 index tuples + UNIQUE rollup pin + no-CHANGEFEED/no-EVENT pin.
- Full verification: `pnpm typecheck` clean; unit suite 297 suites / 2805 tests green; targeted e2e (memory-outcome + fact-usage + forget suites) green; `prettier --check` clean over `src/**` and `test/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
