### PR TITLE
feat(scenes): LLM enrichment + fact backlink + version purge

### DIFF
--- a/src/admin/admin-scenes.controller.ts
+++ b/src/admin/admin-scenes.controller.ts
@@ -1,23 +1,60 @@
-import { Body, Controller, NotFoundException, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  NotFoundException,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import { AuthenticatedRequest } from '../auth/api-key.types';
 import { ApiKeyService } from '../auth/api-key.service';
 import { resolvePlatformTenant } from '../auth/tenant-scope';
-import { sceneSegmentationEnabled } from '../common/scene-flags';
+import {
+  sceneFactBacklinkEnabled,
+  sceneLlmEnrichmentEnabled,
+  sceneSegmentationEnabled,
+} from '../common/scene-flags';
 import { SceneComposerService, SceneRunResult } from './scene-composer.service';
+import { SceneEnricherService, SceneEnrichResult } from './scene-enricher.service';
+import { SceneBacklinkService, SceneBacklinkResult } from './scene-backlink.service';
+
+/** Purge param belt: DB stamps are short version slugs, not free text. */
+const SEGMENTER_VERSION_MAX_CHARS = 64;
 
 /**
- * Explicit trigger for the Brain v2 scene composer (shadow memory_episode
- * substrate, migration 0106). LLM-free; embedding cost only when
- * SCENES_TOPIC_BOUNDARY is on. Idempotent per (conversation ×
- * segmenterVersion) — atomic delete-then-insert swap. Flag off ⇒ the
- * route 404s (SCENES_SEGMENTATION_ENABLED, read at call time).
+ * Explicit triggers for the Brain v2 scene surface (shadow memory_episode
+ * substrate, migration 0106):
+ *
+ *  - POST /scenes — the PR1 composer (LLM-free; embedding cost only when
+ *    SCENES_TOPIC_BOUNDARY is on). Idempotent per (conversation ×
+ *    segmenterVersion) — atomic delete-then-insert swap. When the PR2
+ *    flags are on it also runs the enrichment/backlink passes after the
+ *    swap.
+ *  - POST /scenes/enrich — standalone re-enrichment (PR2): ONE structured
+ *    LLM call per scene of the current segmenter version. 404 unless BOTH
+ *    the master flag and SCENES_LLM_ENRICHMENT are on.
+ *  - POST /scenes/backlink — standalone fact backlink (PR2): idempotent
+ *    source.memoryEpisodeIds stamps. 404 unless BOTH the master flag and
+ *    SCENES_FACT_BACKLINK are on.
+ *  - DELETE /scenes/versions/:segmenterVersion — purge one version's
+ *    scene world (members → scenes, one transaction) and demote its
+ *    projection ledger row to 'residual'. 404 when the master flag is
+ *    off.
+ *
+ * All flags are read at call time (runtime-mutable).
  */
 @Controller('v1/admin')
 @UseGuards(ApiKeyGuard)
 export class AdminScenesController {
+  // eslint-disable-next-line max-params
   constructor(
     private readonly composer: SceneComposerService,
+    private readonly enricher: SceneEnricherService,
+    private readonly backlinker: SceneBacklinkService,
     private readonly apiKeys: ApiKeyService,
   ) {}
 
@@ -28,12 +65,67 @@ export class AdminScenesController {
     @Body() body: { tenant?: string; conversationId?: string } = {},
   ): Promise<SceneRunResult> {
     if (!sceneSegmentationEnabled()) throw new NotFoundException();
-    const tenant = resolvePlatformTenant(req, body.tenant, {
-      knownTenants: () => this.apiKeys.knownCompanyIds(),
-    });
+    const tenant = this.resolveTenant(req, body.tenant);
     return this.composer.run(
       tenant,
       body.conversationId !== undefined ? { conversationId: body.conversationId } : {},
     );
+  }
+
+  @Post('maintenance/scenes/enrich')
+  @RequireScopes('brain:admin')
+  async enrich(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { tenant?: string; conversationId?: string } = {},
+  ): Promise<SceneEnrichResult> {
+    if (!sceneSegmentationEnabled() || !sceneLlmEnrichmentEnabled()) {
+      throw new NotFoundException();
+    }
+    const tenant = this.resolveTenant(req, body.tenant);
+    return this.enricher.enrich(
+      tenant,
+      body.conversationId !== undefined ? { conversationId: body.conversationId } : {},
+    );
+  }
+
+  @Post('maintenance/scenes/backlink')
+  @RequireScopes('brain:admin')
+  async backlink(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { tenant?: string; conversationId?: string } = {},
+  ): Promise<SceneBacklinkResult> {
+    if (!sceneSegmentationEnabled() || !sceneFactBacklinkEnabled()) {
+      throw new NotFoundException();
+    }
+    const tenant = this.resolveTenant(req, body.tenant);
+    return this.backlinker.run(
+      tenant,
+      body.conversationId !== undefined ? { conversationId: body.conversationId } : {},
+    );
+  }
+
+  @Delete('maintenance/scenes/versions/:segmenterVersion')
+  @RequireScopes('brain:admin')
+  async purgeVersion(
+    @Req() req: AuthenticatedRequest,
+    @Param('segmenterVersion') segmenterVersion: string,
+    @Body() body: { tenant?: string } = {},
+  ): Promise<{ scenes: number; members: number }> {
+    if (!sceneSegmentationEnabled()) throw new NotFoundException();
+    const version = (segmenterVersion ?? '').trim();
+    if (version === '' || version.length > SEGMENTER_VERSION_MAX_CHARS) {
+      throw new BadRequestException(
+        `segmenterVersion must be non-empty and at most ${SEGMENTER_VERSION_MAX_CHARS} characters`,
+      );
+    }
+    const tenant = this.resolveTenant(req, body.tenant);
+    return this.composer.purgeVersion(tenant, version);
+  }
+
+  /** ONE tenant-resolution seam for every scene verb (0104 cache facade). */
+  private resolveTenant(req: AuthenticatedRequest, requested: string | undefined): string {
+    return resolvePlatformTenant(req, requested, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
   }
 }

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -45,6 +45,8 @@ import { AdminSegmentsController } from './admin-segments.controller';
 import { SegmentComposerService } from './segment-composer.service';
 import { AdminScenesController } from './admin-scenes.controller';
 import { SceneComposerService } from './scene-composer.service';
+import { SceneEnricherService } from './scene-enricher.service';
+import { SceneBacklinkService } from './scene-backlink.service';
 import { HnswMaintenanceService } from './hnsw-maintenance.service';
 import { CodeMemoryModule } from '../code-memory/code-memory.module';
 import { RegistryModule } from '../registry/registry.module';
@@ -122,6 +124,8 @@ import { ConfigInspectorService } from './config-inspector.service';
     WindowDeriverService,
     SegmentComposerService,
     SceneComposerService,
+    SceneEnricherService,
+    SceneBacklinkService,
     AdminInfraService,
     HealthComponentsService,
     LiveSnapshotService,

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -588,6 +588,32 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Scenes: force a scene boundary once a scene reaches this many turns, regardless of topic continuity. Positive integer; default 40.',
   },
+  {
+    key: 'SCENES_LLM_ENRICHMENT',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneLlmEnrichmentEnabled) by the
+    // admin 404 guard, the enricher's defensive early return and the
+    // composer's post-swap hook — never captured in a constructor — so a
+    // flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Scenes LLM enrichment (Brain v2 PR2): after the composer swap (and via POST /v1/admin/maintenance/scenes/enrich), ONE structured LLM call per scene of the current segmenter version — abstractive gist replaces the deterministic one, full memoryValue vector (scorerVersion scene-scorer-llm-v1), stateDeltas, unexpectedDetails, gistPromptVersion scene-gist-v1. Degrade-never-fail per scene. Off = no LLM call ever runs, enrich route 404s, byte-identical to PR1.',
+  },
+  {
+    key: 'SCENES_FACT_BACKLINK',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneFactBacklinkEnabled) by the
+    // admin 404 guard, the backlink service's defensive early return and
+    // the composer's post-run hook — never captured in a constructor — so
+    // a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Scenes fact backlink (Brain v2 PR2): stamp knowledge_fact rows whose source.episodeIds intersect a scene’s membership with source.memoryEpisodeIds (idempotent array::union) + source.sceneLinkVersion — facts become pointers into the episodic plane. FLEXIBLE source ride, no migration; nothing on the serving path reads the keys (additively visible where `source` is already returned). Off = no fact row is ever touched, backlink route 404s.',
+  },
   // ── Multilingual (Tier 1, migration 0100) ───────────
   {
     key: 'MULTILINGUAL_LANG_ATTRIBUTION',

--- a/src/admin/scene-backlink.service.ts
+++ b/src/admin/scene-backlink.service.ts
@@ -1,0 +1,146 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { sceneFactBacklinkEnabled } from '../common/scene-flags';
+import { SEGMENTER_VERSION } from './scene-segmentation';
+
+/**
+ * Scene fact backlinker (Brain v2 PR2, SCENES_FACT_BACKLINK — default
+ * off): stamps each knowledge_fact whose grounding turns fall inside a
+ * scene with a pointer to that scene — facts become entries into the
+ * episodic plane. For every memory_episode of the CURRENT segmenter
+ * version it intersects (IN JS — `source` is FLEXIBLE, unindexed) the
+ * fact's source.episodeIds strings with the scene's member episode ids,
+ * then stamps the matches:
+ *
+ *   source.memoryEpisodeIds ∪= [scene id]   (array::union — idempotent)
+ *   source.sceneLinkVersion  = <segmenter version>
+ *
+ * FLEXIBLE-source ride, no migration. Idempotent and re-runnable after a
+ * re-segmentation (scene record ids are deterministic per (conversation,
+ * version, index), so a rebuild re-links onto the same identities; the
+ * GDPR cascades may leave stale pointer strings behind — a re-run is the
+ * documented repair, see entity-forget.service.ts).
+ *
+ * SERVING STAYS BYTE-IDENTICAL: nothing reads source.memoryEpisodeIds.
+ * The keys are merely VISIBLE wherever `source` is already returned
+ * verbatim (facts read/provenance API) — additive payload, no behavior.
+ *
+ * UPDATE targets an explicit id list (`WHERE id INSIDE $factIds`) —
+ * primary-key addressed, immune by construction to the 3.2.4 planner bug
+ * class where a mutation filtered on a compound-index-covered field
+ * silently no-ops (scene-composer swap comment; PR #372).
+ */
+
+/** Cap on fact ids per UPDATE statement (bounded query payloads). */
+const FACTS_PER_UPDATE = 200;
+
+/** Minimal fact head for the intersection: id + grounding turn strings. */
+export interface BacklinkFactHead {
+  id: unknown;
+  /** source.episodeIds as selected — unknown until validated in JS. */
+  episodeIds?: unknown;
+}
+
+/**
+ * Pure: the fact ids whose source.episodeIds intersect the scene's member
+ * episode ids. Non-array / non-string entries are ignored (FLEXIBLE
+ * `source` guarantees nothing about the shape).
+ */
+export function matchFactsToScene(
+  facts: readonly BacklinkFactHead[],
+  memberEpisodeIds: ReadonlySet<string>,
+): unknown[] {
+  const out: unknown[] = [];
+  for (const fact of facts) {
+    if (!Array.isArray(fact.episodeIds)) continue;
+    if (fact.episodeIds.some((e) => typeof e === 'string' && memberEpisodeIds.has(e))) {
+      out.push(fact.id);
+    }
+  }
+  return out;
+}
+
+export interface SceneBacklinkResult {
+  scenes: number;
+  factsLinked: number;
+}
+
+@Injectable()
+export class SceneBacklinkService {
+  private readonly logger = new Logger(SceneBacklinkService.name);
+
+  constructor(private readonly surreal: SurrealService) {}
+
+  async run(
+    companyId: string,
+    opts: { conversationId?: string } = {},
+  ): Promise<SceneBacklinkResult> {
+    const result: SceneBacklinkResult = { scenes: 0, factsLinked: 0 };
+    // Defense in depth: the controller already 404s with the flag off; a
+    // programmatic caller must not stamp fact rows past a disabled flag.
+    if (!sceneFactBacklinkEnabled()) return result;
+    await this.surreal.withCompany(companyId, async (db) => {
+      const [scenes] = await db.query<[Array<{ id: unknown; conversationIds: string[] }>]>(
+        `SELECT id, conversationIds FROM memory_episode WHERE segmenterVersion = $v` +
+          (opts.conversationId !== undefined ? ` AND conversationIds CONTAINS $conv` : ''),
+        {
+          v: SEGMENTER_VERSION,
+          ...(opts.conversationId !== undefined ? { conv: opts.conversationId } : {}),
+        },
+      );
+      // One fact read per conversation, shared across its scenes. The
+      // `source.conversationId = $conv` filter walks the table (FLEXIBLE
+      // source has no index) — acceptable for a batch admin pass, and the
+      // cache keeps it to one walk per conversation per run.
+      const factCache = new Map<string, BacklinkFactHead[]>();
+      for (const scene of scenes ?? []) {
+        result.scenes += 1;
+        const [members] = await db.query<[Array<{ out: unknown }>]>(
+          `SELECT out FROM memory_episode_member WHERE in = $scene`,
+          { scene: scene.id },
+        );
+        const memberEpisodeIds = new Set((members ?? []).map((m) => String(m.out)));
+        if (memberEpisodeIds.size === 0) continue;
+
+        // Dedupe across the (today always length-1) conversation list.
+        const matched = new Map<string, unknown>();
+        for (const conversationId of scene.conversationIds) {
+          let facts = factCache.get(conversationId);
+          if (!facts) {
+            const [rows] = await db.query<[BacklinkFactHead[]]>(
+              `SELECT id, source.episodeIds AS episodeIds FROM knowledge_fact
+                WHERE source.conversationId = $conv`,
+              { conv: conversationId },
+            );
+            facts = rows ?? [];
+            factCache.set(conversationId, facts);
+          }
+          for (const id of matchFactsToScene(facts, memberEpisodeIds)) {
+            matched.set(String(id), id);
+          }
+        }
+        if (matched.size === 0) continue;
+
+        const factIds = [...matched.values()];
+        for (let i = 0; i < factIds.length; i += FACTS_PER_UPDATE) {
+          await db.query(
+            `UPDATE knowledge_fact SET
+               source.memoryEpisodeIds = array::union(source.memoryEpisodeIds ?? [], [$sceneId]),
+               source.sceneLinkVersion = $v
+             WHERE id INSIDE $factIds`,
+            {
+              sceneId: String(scene.id),
+              v: SEGMENTER_VERSION,
+              factIds: factIds.slice(i, i + FACTS_PER_UPDATE),
+            },
+          );
+        }
+        result.factsLinked += factIds.length;
+      }
+    });
+    this.logger.log(
+      `scene backlink pass: ${result.factsLinked} fact(s) linked over ${result.scenes} scene(s)`,
+    );
+    return result;
+  }
+}

--- a/src/admin/scene-composer.service.ts
+++ b/src/admin/scene-composer.service.ts
@@ -8,12 +8,15 @@ import { ProjectionRegistryService } from '../episodes/projection-registry.servi
 import { scopeForUser } from '../auth/scope-tags';
 import { segmentSessions } from '../episodes/session-window';
 import {
+  sceneFactBacklinkEnabled,
+  sceneLlmEnrichmentEnabled,
   sceneMaxTurns,
   sceneSegmentationEnabled,
   sceneTopicBoundaryEnabled,
   sceneTopicMinCosine,
 } from '../common/scene-flags';
 import {
+  SEGMENTER_VERSION,
   detectSceneBoundaries,
   foldSceneScope,
   meanVector,
@@ -22,6 +25,8 @@ import {
   scoreSceneDeterministic,
   type SceneTurnRow,
 } from './scene-segmentation';
+import { SceneEnricherService } from './scene-enricher.service';
+import { SceneBacklinkService } from './scene-backlink.service';
 
 /**
  * Scene composer (Brain v2 PR1): batch-derives the SHADOW memory_episode
@@ -42,7 +47,10 @@ import {
  * world is only ever 'built', NEVER 'live' — there is no reader to flip.
  */
 export const SCENE_RECORDER = 'scene-composer-v1';
-export const SEGMENTER_VERSION = 'scene-segmenter-v1';
+// PR2: the version stamp moved to the pure segmentation module so the
+// enricher/backlinker can name the current world without a module cycle;
+// re-exported here for API continuity.
+export { SEGMENTER_VERSION };
 /** sceneLabel budget enforced in code (the 0106 header's ≤200 contract). */
 const SCENE_LABEL_MAX = 200;
 
@@ -57,13 +65,16 @@ export class SceneComposerService {
   private readonly logger = new Logger(SceneComposerService.name);
 
   // Fourth dep is the projection-registry ledger (observes the lifecycle,
-  // never fails it — every registry write degrades to a warning).
+  // never fails it — every registry write degrades to a warning); the PR2
+  // enricher/backlinker are the optional flag-gated post-swap passes.
   // eslint-disable-next-line max-params
   constructor(
     private readonly surreal: SurrealService,
     private readonly embedding: FactEmbeddingService,
     private readonly episodes: EpisodeReadStoreService,
     private readonly registry: ProjectionRegistryService,
+    private readonly enricher: SceneEnricherService,
+    private readonly backlinker: SceneBacklinkService,
   ) {}
 
   async run(companyId: string, opts: { conversationId?: string } = {}): Promise<SceneRunResult> {
@@ -115,7 +126,64 @@ export class SceneComposerService {
         skipped: result.skipped.length,
       },
     });
+    // PR2 post-swap passes, both flag-gated (default off) and both
+    // degrade-never-fail: the swap has landed and its result must not be
+    // retracted by an optional pass. The enricher/backlinker re-check
+    // their own flags too — these outer guards just skip the no-op calls.
+    if (sceneLlmEnrichmentEnabled()) {
+      try {
+        const enrich = await this.enricher.enrich(companyId, opts);
+        this.logger.log(
+          `scene enrichment pass: ${enrich.enriched}/${enrich.scenes} enriched, ${enrich.failed} degraded`,
+        );
+      } catch (e) {
+        this.logger.warn(`scene enrichment pass failed: ${(e as Error).message}`);
+      }
+    }
+    if (sceneFactBacklinkEnabled()) {
+      try {
+        await this.backlinker.run(companyId, opts);
+      } catch (e) {
+        this.logger.warn(`scene backlink pass failed: ${(e as Error).message}`);
+      }
+    }
     return result;
+  }
+
+  /**
+   * Purge ONE segmenter version's scene world: members then scenes, one
+   * transaction, then demote the projection ledger row to 'residual' (the
+   * row records that the world existed and is no longer queryable; the
+   * builder stamp survives for audit — deleting the row is the gc path,
+   * not the purge path).
+   *
+   * Both deletes go through LET-selected explicit id lists. scene_version_idx
+   * and scene_member_ver_idx are SINGLE-field indexes — an equality DELETE
+   * should be safe — but memory_episode_member is ALSO covered by the
+   * compound scene_member_uq whose planner interaction is exactly the
+   * 3.2.4 silent-no-op bug (see the swap comment above), so both use the
+   * id-list idiom for defensive consistency.
+   */
+  async purgeVersion(
+    companyId: string,
+    segmenterVersion: string,
+  ): Promise<{ scenes: number; members: number }> {
+    const purged = await this.surreal.withCompany(companyId, (db) =>
+      runTransaction<{ scenes: number; members: number }>(db, (tx) =>
+        tx
+          .add(
+            `LET $memberIds = (SELECT VALUE id FROM memory_episode_member
+               WHERE segmenterVersion = $v)`,
+          )
+          .add(`DELETE $memberIds`)
+          .add(`LET $sceneIds = (SELECT VALUE id FROM memory_episode WHERE segmenterVersion = $v)`)
+          .add(`DELETE $sceneIds`)
+          .add(`RETURN { scenes: array::len($sceneIds), members: array::len($memberIds) }`)
+          .bind('v', segmenterVersion),
+      ),
+    );
+    await this.registry.markResidual({ companyId, name: 'scenes', version: segmenterVersion });
+    return purged ?? { scenes: 0, members: 0 };
   }
 
   private async composeConversation({

--- a/src/admin/scene-enricher.service.ts
+++ b/src/admin/scene-enricher.service.ts
@@ -1,0 +1,362 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type OpenAI from 'openai';
+import { SurrealService } from '../db/surreal.service';
+import { EpisodeReadStoreService, type EpisodeDb } from '../episodes/episode-read-store.service';
+import { chatCallParams, createOpenAiClient } from '../ai/openai-client';
+import { sceneLlmEnrichmentEnabled } from '../common/scene-flags';
+import { SEGMENTER_VERSION, type SceneTurnRow } from './scene-segmentation';
+
+/**
+ * Scene LLM enricher (Brain v2 PR2, SCENES_LLM_ENRICHMENT — default off):
+ * the optional pass AFTER the composer's atomic swap. For each scene of
+ * the CURRENT segmenter version it makes ONE structured LLM call (strict
+ * JSON schema, same call idiom as deriver-client) and updates the scene
+ * row: abstractive gist replaces the deterministic render, the FULL
+ * memoryValue vector lands under scorerVersion 'scene-scorer-llm-v1',
+ * plus stateDeltas / unexpectedDetails and the gistPromptVersion stamp.
+ *
+ * DEGRADE, NEVER FAIL: a transport error or an off-contract reply for one
+ * scene logs a warning and leaves THAT scene untouched (it keeps its
+ * deterministic gist/score); the pass continues. The OpenAI client is the
+ * NULLABLE variant — no key means the whole pass is skipped with a
+ * warning, mirroring how feature-gated callers treat "no key" as
+ * feature-off (openai-client.ts).
+ *
+ * TESTABILITY: `openai` is a plain private field holding only the
+ * `chat.completions.create` surface the service uses — tests swap it for
+ * a scripted stub exactly like mockSynthesizeOpenAi (test-doubles.ts), so
+ * NO paid call ever happens in CI.
+ *
+ * entityMentions is parsed and validated but deliberately NOT persisted:
+ * the 0106 column for entity links is entityIds — RECORD refs to
+ * knowledge_entity — and resolving free-text mentions into records is a
+ * separate (PR3) pass; storing raw strings where records are promised
+ * would poison that column's contract.
+ */
+
+/** Stamp on memoryValue written by this enricher (0106 scorerVersion). */
+export const SCENE_SCORER_LLM_VERSION = 'scene-scorer-llm-v1';
+/** Stamp on the scene row for the prompt below (0106 gistPromptVersion). */
+export const SCENE_GIST_PROMPT_VERSION = 'scene-gist-v1';
+
+export const SCENE_ENRICHMENT_SYSTEM = `You analyze ONE scene — a contiguous span of turns from a conversation — and produce its memory encoding. Output strictly the JSON schema:
+- "gist": 1-3 sentences, abstractive — what happened in this scene, who did what, with the concrete names, dates, numbers and decisions. State the content itself, never meta-language ("the user discussed" is always wrong).
+- "memoryValue": how much this scene matters for long-term memory; every dimension is a number in [0,1]:
+  - "novelty": how much genuinely new information appears;
+  - "contradiction": how strongly it contradicts or revises what was previously established;
+  - "stateChange": how much durable state changed (decisions made, plans fixed, purchases, moves);
+  - "identity": how identity-central the content is (job, family, health, home, long-term goals);
+  - "explicitness": how explicitly the durable content is stated rather than implied;
+  - "estimatedUtility": overall likelihood this scene will be needed to answer a future question.
+- "stateDeltas": durable state transitions the scene states, each {"subject", "field", "from", "to"} — subject is who/what changed, field is the changed attribute, from/to are the values (use "" for an unknown prior value). Empty array when none.
+- "unexpectedDetails": short concrete details that are surprising or memorable but do not fit the gist. Empty array when none.
+- "entityMentions": distinct people, places and things named in the scene. Empty array when none.`;
+
+/** Per-dimension keys of the memoryValue vector (0106 order). */
+const MEMORY_DIMS = [
+  'novelty',
+  'contradiction',
+  'stateChange',
+  'identity',
+  'explicitness',
+  'estimatedUtility',
+] as const;
+
+/** Caps on reply payloads — belts against a runaway model, not budgets. */
+const GIST_MAX_CHARS = 2000;
+const DELTAS_MAX = 20;
+const DELTA_FIELD_MAX_CHARS = 200;
+const DETAILS_MAX = 20;
+const DETAIL_MAX_CHARS = 300;
+const MENTIONS_MAX = 50;
+const MENTION_MAX_CHARS = 120;
+/** Transcript render caps: per-line text + visible completion budget. */
+const TURN_TEXT_MAX_CHARS = 600;
+const ENRICH_VISIBLE_CAP = 2000;
+
+export interface SceneMemoryValueLlm {
+  novelty: number;
+  contradiction: number;
+  stateChange: number;
+  identity: number;
+  explicitness: number;
+  estimatedUtility: number;
+}
+
+export interface SceneEnrichment {
+  gist: string;
+  memoryValue: SceneMemoryValueLlm;
+  stateDeltas: Array<{ subject: string; field: string; from: string; to: string }>;
+  unexpectedDetails: string[];
+  entityMentions: string[];
+}
+
+const clamp01 = (v: number): number => Math.min(1, Math.max(0, v));
+
+/**
+ * Pure: parse + validate ONE enrichment reply. Returns null on ANY
+ * malformed shape (bad JSON, empty gist, a non-numeric dimension) — the
+ * caller treats null as "leave the scene untouched". Numeric dimensions
+ * are clamped into [0,1]; arrays are capped and their strings trimmed so
+ * an off-rubric model cannot bloat the row.
+ */
+export function parseSceneEnrichment(content: string): SceneEnrichment | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  if (typeof raw !== 'object' || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.gist !== 'string' || obj.gist.trim() === '') return null;
+  const gist = obj.gist.replace(/\s+/g, ' ').trim().slice(0, GIST_MAX_CHARS);
+
+  const mvRaw = obj.memoryValue;
+  if (typeof mvRaw !== 'object' || mvRaw === null) return null;
+  const memoryValue = {} as SceneMemoryValueLlm;
+  for (const dim of MEMORY_DIMS) {
+    const v = (mvRaw as Record<string, unknown>)[dim];
+    if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+    memoryValue[dim] = clamp01(v);
+  }
+
+  const str = (v: unknown, max: number): string =>
+    typeof v === 'string' ? v.trim().slice(0, max) : '';
+  const stateDeltas = (Array.isArray(obj.stateDeltas) ? obj.stateDeltas : [])
+    .filter((d): d is Record<string, unknown> => typeof d === 'object' && d !== null)
+    .slice(0, DELTAS_MAX)
+    .map((d) => ({
+      subject: str(d.subject, DELTA_FIELD_MAX_CHARS),
+      field: str(d.field, DELTA_FIELD_MAX_CHARS),
+      from: str(d.from, DELTA_FIELD_MAX_CHARS),
+      to: str(d.to, DELTA_FIELD_MAX_CHARS),
+    }))
+    .filter((d) => d.subject !== '' && d.field !== '');
+  const strings = (v: unknown, maxItems: number, maxChars: number): string[] =>
+    (Array.isArray(v) ? v : [])
+      .filter((s): s is string => typeof s === 'string' && s.trim() !== '')
+      .slice(0, maxItems)
+      .map((s) => s.trim().slice(0, maxChars));
+
+  return {
+    gist,
+    memoryValue,
+    stateDeltas,
+    unexpectedDetails: strings(obj.unexpectedDetails, DETAILS_MAX, DETAIL_MAX_CHARS),
+    entityMentions: strings(obj.entityMentions, MENTIONS_MAX, MENTION_MAX_CHARS),
+  };
+}
+
+export interface SceneEnrichResult {
+  scenes: number;
+  enriched: number;
+  failed: number;
+}
+
+interface SceneHead {
+  id: unknown;
+  conversationIds: string[];
+}
+
+/** The one client surface the enricher uses (mock-swappable in tests). */
+type ChatCompletionsClient = Pick<OpenAI, 'chat'>;
+
+@Injectable()
+export class SceneEnricherService {
+  private readonly logger = new Logger(SceneEnricherService.name);
+  /**
+   * Nullable by contract (createOpenAiClient): no OPENAI_API_KEY ⇒ the
+   * whole pass skips with a warning. Tests replace this field with a
+   * scripted stub (mockSceneEnricherOpenAi) — the same seam as
+   * SynthesizeService.openai.
+   */
+  private readonly openai: ChatCompletionsClient | null;
+  private readonly model: string;
+
+  constructor(
+    private readonly surreal: SurrealService,
+    configService: ConfigService,
+    private readonly episodes: EpisodeReadStoreService,
+  ) {
+    this.openai = createOpenAiClient(configService);
+    this.model = configService.get<string>(
+      'SCENES_ENRICH_MODEL',
+      configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),
+    );
+  }
+
+  /**
+   * Enrich every scene of the CURRENT segmenter version (optionally one
+   * conversation's). Never throws for a single scene — per-scene errors
+   * degrade to a warning and the scene keeps its deterministic gist.
+   */
+  async enrich(
+    companyId: string,
+    opts: { conversationId?: string } = {},
+  ): Promise<SceneEnrichResult> {
+    const result: SceneEnrichResult = { scenes: 0, enriched: 0, failed: 0 };
+    // Defense in depth: the controller already 404s with the flag off; a
+    // programmatic caller must not spend LLM calls past a disabled flag.
+    if (!sceneLlmEnrichmentEnabled()) return result;
+    if (!this.openai) {
+      this.logger.warn('scene enrichment skipped: no OPENAI_API_KEY configured');
+      return result;
+    }
+    await this.surreal.withCompany(companyId, async (db) => {
+      const [scenes] = await db.query<[SceneHead[]]>(
+        `SELECT id, conversationIds FROM memory_episode WHERE segmenterVersion = $v` +
+          (opts.conversationId !== undefined ? ` AND conversationIds CONTAINS $conv` : ''),
+        {
+          v: SEGMENTER_VERSION,
+          ...(opts.conversationId !== undefined ? { conv: opts.conversationId } : {}),
+        },
+      );
+      // One raw-turn read per conversation, shared across its scenes.
+      const turnCache = new Map<string, Map<string, SceneTurnRow>>();
+      for (const scene of scenes ?? []) {
+        result.scenes += 1;
+        try {
+          const ok = await this.enrichScene({ db, scene, turnCache });
+          if (ok) result.enriched += 1;
+          else result.failed += 1;
+        } catch (e) {
+          result.failed += 1;
+          this.logger.warn(
+            `scene enrichment failed for ${String(scene.id)}: ${(e as Error).message}`,
+          );
+        }
+      }
+    });
+    return result;
+  }
+
+  /** One scene: transcript → ONE structured call → validated UPDATE. */
+  private async enrichScene({
+    db,
+    scene,
+    turnCache,
+  }: {
+    db: EpisodeDb;
+    scene: SceneHead;
+    turnCache: Map<string, Map<string, SceneTurnRow>>;
+  }): Promise<boolean> {
+    const conversationId = scene.conversationIds[0];
+    if (conversationId === undefined) return false;
+    let turnsById = turnCache.get(conversationId);
+    if (!turnsById) {
+      const turns = (await this.episodes.conversationTurnsRaw(
+        db,
+        conversationId,
+      )) as SceneTurnRow[];
+      turnsById = new Map(turns.map((t) => [String(t.id), t]));
+      turnCache.set(conversationId, turnsById);
+    }
+    // Plain WHERE in = $scene SELECT — safe on 3.2.4 (only DELETE trips
+    // the compound-index planner bug; see scene-composer's swap comment).
+    const [members] = await db.query<[Array<{ out: unknown; ord: number }>]>(
+      `SELECT out, ord FROM memory_episode_member WHERE in = $scene ORDER BY ord ASC`,
+      { scene: scene.id },
+    );
+    const memberTurns = (members ?? [])
+      .map((m) => turnsById.get(String(m.out)))
+      .filter((t): t is SceneTurnRow => t !== undefined);
+    if (memberTurns.length === 0) {
+      this.logger.warn(`scene enrichment skipped ${String(scene.id)}: no member turns readable`);
+      return false;
+    }
+
+    const transcript = memberTurns
+      .map((t) => {
+        const iso = new Date(t.occurredAt as string).toISOString();
+        const stamp = `${iso.slice(0, 10)} ${iso.slice(11, 16)}`;
+        return `(${stamp}) ${t.speaker ?? 'unknown'}: ${t.text.slice(0, TURN_TEXT_MAX_CHARS)}`;
+      })
+      .join('\n');
+    const enrichment = await this.callModel(transcript);
+    if (!enrichment) {
+      this.logger.warn(
+        `scene enrichment reply malformed for ${String(scene.id)} — scene keeps its deterministic gist`,
+      );
+      return false;
+    }
+
+    // Single-record UPDATE by bound id — primary-key addressed, immune to
+    // the 3.2.4 secondary-index planner bug by construction.
+    await db.query(
+      `UPDATE $scene SET
+         gist = $gist,
+         gistPromptVersion = $gistPromptVersion,
+         memoryValue = $memoryValue,
+         stateDeltas = $stateDeltas,
+         unexpectedDetails = $unexpectedDetails`,
+      {
+        scene: scene.id,
+        gist: enrichment.gist,
+        gistPromptVersion: SCENE_GIST_PROMPT_VERSION,
+        memoryValue: {
+          ...enrichment.memoryValue,
+          scorerVersion: SCENE_SCORER_LLM_VERSION,
+          scoredAt: new Date(),
+        },
+        stateDeltas: enrichment.stateDeltas,
+        unexpectedDetails: enrichment.unexpectedDetails,
+      },
+    );
+    return true;
+  }
+
+  /** ONE strict-schema chat call (deriver-client idiom); null = degrade. */
+  private async callModel(transcript: string): Promise<SceneEnrichment | null> {
+    const res = await this.openai!.chat.completions.create({
+      model: this.model,
+      ...chatCallParams(this.model, { temperature: 0, visibleCap: ENRICH_VISIBLE_CAP }),
+      messages: [
+        { role: 'system', content: SCENE_ENRICHMENT_SYSTEM },
+        { role: 'user', content: `Scene transcript:\n${transcript}` },
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'scene_enrichment',
+          strict: true,
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              gist: { type: 'string' },
+              memoryValue: {
+                type: 'object',
+                additionalProperties: false,
+                properties: Object.fromEntries(MEMORY_DIMS.map((d) => [d, { type: 'number' }])),
+                required: [...MEMORY_DIMS],
+              },
+              stateDeltas: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: {
+                    subject: { type: 'string' },
+                    field: { type: 'string' },
+                    from: { type: 'string' },
+                    to: { type: 'string' },
+                  },
+                  required: ['subject', 'field', 'from', 'to'],
+                },
+              },
+              unexpectedDetails: { type: 'array', items: { type: 'string' } },
+              entityMentions: { type: 'array', items: { type: 'string' } },
+            },
+            required: ['gist', 'memoryValue', 'stateDeltas', 'unexpectedDetails', 'entityMentions'],
+          },
+        },
+      },
+    });
+    const content = res.choices[0]?.message?.content;
+    if (!content) return null;
+    return parseSceneEnrichment(content);
+  }
+}

--- a/src/admin/scene-segmentation.ts
+++ b/src/admin/scene-segmentation.ts
@@ -15,6 +15,14 @@ import type { EpisodeRow } from '../episodes/session-window';
  * same scenes, gists, labels, and scores.
  */
 
+/**
+ * Version stamp of the CURRENT deterministic segmenter. Lives in this
+ * pure module (PR2) so the composer, the LLM enricher and the fact
+ * backlinker can all name "the current scene world" without importing
+ * each other — the composer re-exports it for API continuity.
+ */
+export const SEGMENTER_VERSION = 'scene-segmenter-v1';
+
 /** Member turn shape — the raw L0 read row (piiClass rides for folding). */
 export interface SceneTurnRow extends EpisodeRow {
   piiClass?: string[];

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -813,6 +813,22 @@ const KNOWN_BOOLEAN_FLAGS = [
   // segmenter is session-gap + max-turns only (embedder-free). The
   // cosine floor (SCENES_TOPIC_MIN_COSINE) is a float, not a boolean.
   'SCENES_TOPIC_BOUNDARY',
+  // Scenes LLM enrichment (Brain v2 PR2): the optional post-swap pass —
+  // ONE structured LLM call per scene replacing the deterministic gist
+  // with an abstractive one and filling the full memoryValue vector +
+  // stateDeltas/unexpectedDetails ('scene-scorer-llm-v1'). Default off ⇒
+  // no LLM call ever runs, scenes keep the deterministic gist/score and
+  // the enrich admin route 404s — byte-identical to PR1. The model knob
+  // (SCENES_ENRICH_MODEL) is a string, not a boolean.
+  'SCENES_LLM_ENRICHMENT',
+  // Scenes fact backlink (Brain v2 PR2): stamp knowledge_fact rows whose
+  // source.episodeIds intersect a scene's membership with
+  // source.memoryEpisodeIds + source.sceneLinkVersion (idempotent union,
+  // FLEXIBLE source — no migration). Nothing on the serving path reads
+  // the keys; they are only VISIBLE where `source` is already returned
+  // verbatim (facts read/provenance API) — additive. Default off ⇒ no
+  // fact row is ever touched and the backlink admin route 404s.
+  'SCENES_FACT_BACKLINK',
   // Outcome telemetry master (0107): writers append memory_outcome rows
   // + fold memory_outcome_stat counters; the nightly raw-log prune runs.
   // Default off = byte-identical (every writer is a guarded no-op).

--- a/src/common/scene-flags.ts
+++ b/src/common/scene-flags.ts
@@ -52,6 +52,45 @@ export function sceneTopicMinCosine(): number {
   return Number.isFinite(v) && v >= -1 && v <= 1 ? v : DEFAULT_TOPIC_MIN_COSINE;
 }
 
+/**
+ * Scenes LLM enrichment flag — SCENES_LLM_ENRICHMENT (Brain v2 PR2).
+ *
+ * When on, an OPTIONAL pass runs AFTER the composer's atomic swap (and is
+ * also triggerable standalone via POST /v1/admin/maintenance/scenes/enrich):
+ * ONE structured LLM call per scene of the current segmenter version,
+ * replacing the deterministic gist with an abstractive one and filling the
+ * FULL memoryValue vector (scorerVersion 'scene-scorer-llm-v1'), stateDeltas
+ * and unexpectedDetails. The env read lives here in the common layer, NOT
+ * inside the engine dirs (engine-gates S5.2). Read at call time so a flip is
+ * runtime-mutable. Default off ⇒ NO LLM call is ever made and scenes keep
+ * their deterministic gist/score — byte-identical to PR1 behavior. Enrichment
+ * degrades, never fails: a bad reply for one scene logs a warning and leaves
+ * that scene untouched.
+ */
+export function sceneLlmEnrichmentEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_LLM_ENRICHMENT);
+}
+
+/**
+ * Scenes fact-backlink flag — SCENES_FACT_BACKLINK (Brain v2 PR2).
+ *
+ * When on, a batch pass (end of the composer run + standalone POST
+ * /v1/admin/maintenance/scenes/backlink) stamps each knowledge_fact whose
+ * source.episodeIds intersect a scene's membership with
+ * source.memoryEpisodeIds (idempotent array::union) + source.sceneLinkVersion
+ * — facts become pointers into the episodic plane. FLEXIBLE `source` ride, no
+ * migration. The env read lives here in the common layer, NOT inside the
+ * engine dirs (engine-gates S5.2). Read at call time so a flip is
+ * runtime-mutable. Default off ⇒ no fact row is ever touched. Serving stays
+ * byte-identical even when on — nothing READS source.memoryEpisodeIds; the
+ * keys are merely visible wherever `source` is already returned verbatim
+ * (facts read/provenance API) — an additive payload change, not a behavioral
+ * one.
+ */
+export function sceneFactBacklinkEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_FACT_BACKLINK);
+}
+
 /** Default hard cap on turns per scene (Brain v2 PR1). */
 const DEFAULT_MAX_TURNS = 40;
 

--- a/src/episodes/projection-registry.service.ts
+++ b/src/episodes/projection-registry.service.ts
@@ -94,6 +94,23 @@ export class ProjectionRegistryService {
     });
   }
 
+  /**
+   * Demote (name, version) to 'residual' WITHOUT deleting the row — the
+   * verb for a PURGED world (Brain v2 scenes version purge): the ledger
+   * keeps who built it and when, while 'residual' says it is no longer
+   * queryable. UPDATE (not UPSERT) on the array-literal id: a version
+   * that never registered stays absent rather than gaining a ghost row.
+   */
+  async markResidual(opts: { companyId: string; name: string; version: string }): Promise<void> {
+    await this.safely('markResidual', opts.companyId, async (db) => {
+      await db.query(
+        `UPDATE projection:[$name, $version]
+           SET status = 'residual', finishedAt = time::now()`,
+        { name: opts.name, version: opts.version },
+      );
+    });
+  }
+
   /** Reaped worlds lose their rows — a row promises a queryable world. */
   async dropVersions(opts: { companyId: string; name: string; versions: string[] }): Promise<void> {
     if (opts.versions.length === 0) return;

--- a/test/scene-enrichment.e2e-spec.ts
+++ b/test/scene-enrichment.e2e-spec.ts
@@ -1,0 +1,272 @@
+/**
+ * Brain v2 PR2 e2e: LLM enrichment (stubbed model — no paid calls),
+ * fact backlink (idempotent source.memoryEpisodeIds stamps), and version
+ * purge (rows gone + projection ledger row demoted to 'residual').
+ * Mirrors memory-episode.e2e-spec.ts: episode-only ingest, embedder-free
+ * segmentation (SCENES_TOPIC_BOUNDARY stays off), flags flipped via
+ * process.env after boot and restored in afterAll.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSceneEnricherOpenAi } from './test-doubles';
+import { SurrealService } from '../src/db/surreal.service';
+
+const CONV = 'proj:scene-enrich';
+const USER = 'scene2_user';
+
+interface SceneRow {
+  id: unknown;
+  gist: string;
+  gistPromptVersion?: string;
+  memoryValue?: Record<string, unknown>;
+  stateDeltas?: Array<Record<string, unknown>>;
+  unexpectedDetails?: string[];
+}
+
+const ENRICHMENT_REPLY = JSON.stringify({
+  gist: 'Mika planned the Lisbon trip: compared flights and booked the morning one.',
+  memoryValue: {
+    novelty: 0.8,
+    contradiction: 0,
+    stateChange: 0.6,
+    identity: 0.2,
+    explicitness: 0.9,
+    estimatedUtility: 0.7,
+  },
+  stateDeltas: [{ subject: 'mika', field: 'trip.flight', from: '', to: 'booked' }],
+  unexpectedDetails: ['booked the morning flight'],
+  entityMentions: ['Mika', 'Lisbon'],
+});
+
+describe('scene enrichment + fact backlink + version purge (e2e)', () => {
+  let f: AppFixture;
+  let episodeIds: string[] = [];
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const saved: Record<string, string | undefined> = {};
+  beforeAll(async () => {
+    for (const k of ['EPISODE_SUBSTRATE_ENABLED', 'INGEST_EPISODE_ONLY']) {
+      saved[k] = process.env[k];
+      process.env[k] = '1';
+    }
+    // Master on for the whole suite; the PR2 flags start OFF so each `it`
+    // proves its own 404 gate before flipping its flag on.
+    saved.SCENES_SEGMENTATION_ENABLED = process.env.SCENES_SEGMENTATION_ENABLED;
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    for (const k of ['SCENES_LLM_ENRICHMENT', 'SCENES_FACT_BACKLINK']) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    f = await createApp({ companyId: 'co_scene_enrich_e2e' });
+
+    // One conversation, two sessions: 3 turns, then a >60-min gap, then 2.
+    const turns = [
+      { t: '2026-02-01T10:00:00.000Z', text: 'I started planning the Lisbon trip.' },
+      { t: '2026-02-01T10:05:00.000Z', text: 'Comparing flights for next month.' },
+      { t: '2026-02-01T10:10:00.000Z', text: 'Booked the morning one.' },
+      { t: '2026-02-01T12:00:00.000Z', text: 'Back to it — now the hotel.' },
+      { t: '2026-02-01T12:05:00.000Z', text: 'Found a place near the river.' },
+    ];
+    for (const [i, turn] of turns.entries()) {
+      const res = await f.http
+        .post('/v1/ingest/mention')
+        .set(auth())
+        .send({
+          text: turn.text,
+          contextRef: { vertical: 'proj', conversationId: CONV, messageId: `se${i}` },
+          knownEntities: [{ vertical: 'proj', id: 'mika', role: 'speaker', name: 'mika' }],
+          userId: USER,
+          emittedAt: turn.t,
+        });
+      expect(res.status).toBe(201);
+    }
+
+    // Seed facts the backlink pass will (and will not) match: factA is
+    // grounded in the first session's opening turn; factB belongs to a
+    // DIFFERENT conversation — the control that must stay unstamped.
+    // Direct DB seed mirrors facts-list-competing.e2e-spec.ts — the
+    // derive path is a paid LLM call this suite must not make.
+    const surreal = f.app.get(SurrealService);
+    episodeIds = await surreal.withCompany(f.companyId, async (db) => {
+      const [eps] = await db.query<[Array<{ id: unknown }>]>(
+        `SELECT id, occurredAt FROM episode WHERE conversationId = $conv ORDER BY occurredAt ASC`,
+        { conv: CONV },
+      );
+      const ids = (eps ?? []).map((e) => String(e.id));
+      expect(ids).toHaveLength(5);
+      await db.query(
+        `CREATE knowledge_entity:se_subj CONTENT {
+           type: 'other',
+           canonicalName: 'Mika',
+           externalRefs: { proj: 'mika' }
+         }`,
+      );
+      await db.query(
+        `CREATE knowledge_fact:se_a CONTENT {
+           entityId: knowledge_entity:se_subj,
+           predicate: 'travel',
+           object: 'Mika is planning a Lisbon trip.',
+           confidence: 0.85,
+           validFrom: $vf,
+           source: { vertical: 'derived', recorder: 'test-seed', conversationId: $conv,
+                     episodeIds: [$ep0] }
+         }`,
+        { vf: new Date('2026-02-01'), conv: CONV, ep0: ids[0] },
+      );
+      await db.query(
+        `CREATE knowledge_fact:se_b CONTENT {
+           entityId: knowledge_entity:se_subj,
+           predicate: 'travel',
+           object: 'Control fact from another conversation.',
+           confidence: 0.85,
+           validFrom: $vf,
+           source: { vertical: 'derived', recorder: 'test-seed', conversationId: 'proj:other',
+                     episodeIds: [$ep0] }
+         }`,
+        { vf: new Date('2026-02-01'), ep0: ids[0] },
+      );
+      return ids;
+    });
+
+    // Build the scene world once (PR2 flags are still off ⇒ the composer
+    // runs pure PR1: deterministic gists, no LLM, no fact stamps).
+    const run = await f.http.post('/v1/admin/maintenance/scenes').set(auth()).send({});
+    expect(run.status).toBe(201);
+    expect(run.body).toMatchObject({ conversations: 1, scenes: 2 });
+  });
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (f) await f.close();
+  });
+
+  const scenesInDb = async (): Promise<SceneRow[]> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[SceneRow[]]>(
+        `SELECT * FROM memory_episode ORDER BY occurredFrom ASC`,
+      );
+      return rows ?? [];
+    });
+  };
+
+  const factSource = async (factId: string): Promise<Record<string, unknown>> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ source: Record<string, unknown> }>]>(
+        `SELECT source FROM ${factId}`,
+      );
+      return (rows ?? [])[0]?.source ?? {};
+    });
+  };
+
+  it('enriches scenes via the stubbed model: gist replaced, full memoryValue, version stamps', async () => {
+    // Deterministic world before enrichment (flag off ⇒ 404, gist intact).
+    const before = await scenesInDb();
+    expect(before).toHaveLength(2);
+    for (const scene of before) {
+      expect(scene.gist).toContain('opens:'); // PR1 deterministic render
+      expect(scene.gistPromptVersion).toBeUndefined();
+    }
+    const gated = await f.http.post('/v1/admin/maintenance/scenes/enrich').set(auth()).send({});
+    expect(gated.status).toBe(404);
+
+    process.env.SCENES_LLM_ENRICHMENT = '1';
+    const mock = mockSceneEnricherOpenAi(f.app, [ENRICHMENT_REPLY]);
+    const res = await f.http.post('/v1/admin/maintenance/scenes/enrich').set(auth()).send({});
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ scenes: 2, enriched: 2, failed: 0 });
+    expect(mock.calls).toHaveLength(2);
+    // The scene transcripts (not the deterministic gists) are what the
+    // model saw — one call per scene, in unspecified scene order.
+    const prompts = mock.calls.map((c) => c.user).join('\n===\n');
+    expect(prompts).toContain('Lisbon trip');
+    expect(prompts).toContain('near the river');
+
+    const after = await scenesInDb();
+    for (const scene of after) {
+      expect(scene.gist).toBe(
+        'Mika planned the Lisbon trip: compared flights and booked the morning one.',
+      );
+      expect(scene.gistPromptVersion).toBe('scene-gist-v1');
+      expect(scene.memoryValue).toMatchObject({
+        novelty: 0.8,
+        contradiction: 0,
+        stateChange: 0.6,
+        identity: 0.2,
+        explicitness: 0.9,
+        estimatedUtility: 0.7,
+        scorerVersion: 'scene-scorer-llm-v1',
+      });
+      expect(scene.memoryValue!.scoredAt).toBeDefined();
+      expect(scene.stateDeltas).toEqual([
+        { subject: 'mika', field: 'trip.flight', from: '', to: 'booked' },
+      ]);
+      expect(scene.unexpectedDetails).toEqual(['booked the morning flight']);
+    }
+  });
+
+  it('backlinks facts idempotently: pointer stamped once, control fact untouched', async () => {
+    const gated = await f.http.post('/v1/admin/maintenance/scenes/backlink').set(auth()).send({});
+    expect(gated.status).toBe(404);
+
+    process.env.SCENES_FACT_BACKLINK = '1';
+    const res = await f.http.post('/v1/admin/maintenance/scenes/backlink').set(auth()).send({});
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ scenes: 2, factsLinked: 1 });
+
+    const scenes = await scenesInDb();
+    const firstSceneId = String(scenes[0]!.id); // covers the first session (ep0)
+    const linked = await factSource('knowledge_fact:se_a');
+    expect(linked.memoryEpisodeIds).toEqual([firstSceneId]);
+    expect(linked.sceneLinkVersion).toBe('scene-segmenter-v1');
+    expect(linked.episodeIds).toEqual([episodeIds[0]]); // grounding untouched
+    const control = await factSource('knowledge_fact:se_b');
+    expect(control.memoryEpisodeIds).toBeUndefined();
+
+    // Re-run: array::union keeps the pointer set duplicate-free.
+    const rerun = await f.http.post('/v1/admin/maintenance/scenes/backlink').set(auth()).send({});
+    expect(rerun.status).toBe(201);
+    expect((await factSource('knowledge_fact:se_a')).memoryEpisodeIds).toEqual([firstSceneId]);
+  });
+
+  it('purges the segmenter version: rows gone, registry row residual', async () => {
+    const tooLong = await f.http
+      .delete(`/v1/admin/maintenance/scenes/versions/${'x'.repeat(65)}`)
+      .set(auth())
+      .send({});
+    expect(tooLong.status).toBe(400);
+
+    const res = await f.http
+      .delete('/v1/admin/maintenance/scenes/versions/scene-segmenter-v1')
+      .set(auth())
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ scenes: 2, members: 5 });
+
+    const surreal = f.app.get(SurrealService);
+    const counts = await surreal.withCompany(f.companyId, async (db) => {
+      const [scenes] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM memory_episode GROUP ALL`,
+      );
+      const [members] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM memory_episode_member GROUP ALL`,
+      );
+      const [projection] = await db.query<[Array<{ status: string }>]>(
+        `SELECT status FROM projection WHERE name = 'scenes'`,
+      );
+      return {
+        scenes: (scenes ?? [])[0]?.n ?? 0,
+        members: (members ?? [])[0]?.n ?? 0,
+        projection: projection ?? [],
+      };
+    });
+    expect(counts.scenes).toBe(0);
+    expect(counts.members).toBe(0);
+    expect(counts.projection).toHaveLength(1);
+    expect(counts.projection[0]!.status).toBe('residual');
+  });
+});

--- a/test/scene-enrichment.unit-spec.ts
+++ b/test/scene-enrichment.unit-spec.ts
@@ -1,0 +1,199 @@
+/**
+ * Brain v2 PR2 unit tests: the scene-enrichment reply parser (malformed →
+ * null; well-formed → clamped/capped), the pure backlink intersection, and
+ * the enricher service's degrade contract exercised against a scripted
+ * provider stub — a malformed reply leaves the scene row untouched and
+ * warns; a well-formed reply updates the row with the
+ * 'scene-scorer-llm-v1' / 'scene-gist-v1' stamps. No network, no Nest, no
+ * paid calls.
+ */
+import type { ConfigService } from '@nestjs/config';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { EpisodeReadStoreService } from '../src/episodes/episode-read-store.service';
+import {
+  parseSceneEnrichment,
+  SceneEnricherService,
+  SCENE_GIST_PROMPT_VERSION,
+  SCENE_SCORER_LLM_VERSION,
+} from '../src/admin/scene-enricher.service';
+import { matchFactsToScene } from '../src/admin/scene-backlink.service';
+
+const WELL_FORMED = {
+  gist: 'Mika planned the Lisbon trip and booked the morning flight.',
+  memoryValue: {
+    novelty: 0.8,
+    contradiction: 0,
+    stateChange: 0.6,
+    identity: 0.2,
+    explicitness: 0.9,
+    estimatedUtility: 0.7,
+  },
+  stateDeltas: [{ subject: 'mika', field: 'trip.flight', from: '', to: 'booked' }],
+  unexpectedDetails: ['chose the morning slot despite hating mornings'],
+  entityMentions: ['Mika', 'Lisbon'],
+};
+
+describe('parseSceneEnrichment', () => {
+  it('rejects malformed payloads', () => {
+    expect(parseSceneEnrichment('not json at all')).toBeNull();
+    expect(parseSceneEnrichment('[]')).toBeNull();
+    expect(parseSceneEnrichment(JSON.stringify({ ...WELL_FORMED, gist: '  ' }))).toBeNull();
+    expect(parseSceneEnrichment(JSON.stringify({ gist: 'x' }))).toBeNull(); // no memoryValue
+    expect(
+      parseSceneEnrichment(
+        JSON.stringify({
+          ...WELL_FORMED,
+          memoryValue: { ...WELL_FORMED.memoryValue, novelty: 'high' },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('parses a well-formed reply, clamping dimensions into [0,1]', () => {
+    const parsed = parseSceneEnrichment(
+      JSON.stringify({
+        ...WELL_FORMED,
+        memoryValue: { ...WELL_FORMED.memoryValue, novelty: 1.7, contradiction: -0.4 },
+      }),
+    );
+    expect(parsed).not.toBeNull();
+    expect(parsed!.gist).toBe(WELL_FORMED.gist);
+    expect(parsed!.memoryValue.novelty).toBe(1);
+    expect(parsed!.memoryValue.contradiction).toBe(0);
+    expect(parsed!.memoryValue.estimatedUtility).toBeCloseTo(0.7);
+    expect(parsed!.stateDeltas).toEqual(WELL_FORMED.stateDeltas);
+    expect(parsed!.unexpectedDetails).toEqual(WELL_FORMED.unexpectedDetails);
+    expect(parsed!.entityMentions).toEqual(WELL_FORMED.entityMentions);
+  });
+
+  it('drops off-shape delta/detail entries instead of failing the reply', () => {
+    const parsed = parseSceneEnrichment(
+      JSON.stringify({
+        ...WELL_FORMED,
+        stateDeltas: [
+          { subject: 'mika', field: 'city', from: 'Riga', to: 'Lisbon' },
+          { subject: '', field: 'ghost', from: '', to: '' }, // no subject → dropped
+          'not-an-object',
+        ],
+        unexpectedDetails: ['kept', 42, '  '],
+      }),
+    );
+    expect(parsed!.stateDeltas).toEqual([
+      { subject: 'mika', field: 'city', from: 'Riga', to: 'Lisbon' },
+    ]);
+    expect(parsed!.unexpectedDetails).toEqual(['kept']);
+  });
+});
+
+describe('matchFactsToScene', () => {
+  it('returns exactly the facts whose episodeIds intersect the membership', () => {
+    const members = new Set(['episode:a', 'episode:b']);
+    const matched = matchFactsToScene(
+      [
+        { id: 'knowledge_fact:1', episodeIds: ['episode:a', 'episode:z'] },
+        { id: 'knowledge_fact:2', episodeIds: ['episode:z'] },
+        { id: 'knowledge_fact:3', episodeIds: 'episode:a' }, // non-array → ignored
+        { id: 'knowledge_fact:4' }, // absent → ignored
+        { id: 'knowledge_fact:5', episodeIds: [42, 'episode:b'] },
+      ],
+      members,
+    );
+    expect(matched).toEqual(['knowledge_fact:1', 'knowledge_fact:5']);
+  });
+});
+
+describe('SceneEnricherService degrade contract (scripted provider)', () => {
+  const savedFlag = process.env.SCENES_LLM_ENRICHMENT;
+  beforeAll(() => {
+    process.env.SCENES_LLM_ENRICHMENT = '1';
+  });
+  afterAll(() => {
+    if (savedFlag === undefined) delete process.env.SCENES_LLM_ENRICHMENT;
+    else process.env.SCENES_LLM_ENRICHMENT = savedFlag;
+  });
+
+  interface Captured {
+    updates: Array<Record<string, unknown>>;
+  }
+
+  function build(reply: string): { svc: SceneEnricherService; captured: Captured } {
+    const captured: Captured = { updates: [] };
+    const fakeDb = {
+      query: async (sql: string, params?: Record<string, unknown>) => {
+        if (sql.includes('FROM memory_episode WHERE')) {
+          return [[{ id: 'memory_episode:s1', conversationIds: ['conv'] }]];
+        }
+        if (sql.includes('FROM memory_episode_member')) {
+          return [[{ out: 'episode:e1', ord: 0 }]];
+        }
+        if (sql.includes('UPDATE $scene')) {
+          captured.updates.push(params ?? {});
+          return [[]];
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      },
+    };
+    const fakeSurreal = {
+      withCompany: (_c: string, fn: (db: unknown) => Promise<unknown>) => fn(fakeDb),
+    } as unknown as SurrealService;
+    const fakeConfig = { get: (_k: string, d?: unknown) => d } as unknown as ConfigService;
+    const fakeEpisodes = {
+      conversationTurnsRaw: async () => [
+        {
+          id: 'episode:e1',
+          speaker: 'mika',
+          text: 'I booked the morning flight to Lisbon.',
+          occurredAt: '2026-02-01T10:00:00.000Z',
+        },
+      ],
+    } as unknown as EpisodeReadStoreService;
+    const svc = new SceneEnricherService(fakeSurreal, fakeConfig, fakeEpisodes);
+    (svc as unknown as { openai: unknown }).openai = {
+      chat: {
+        completions: {
+          create: async () => ({ choices: [{ message: { content: reply } }] }),
+        },
+      },
+    };
+    return { svc, captured };
+  }
+
+  it('leaves the scene untouched and warns on a malformed reply', async () => {
+    const { svc, captured } = build('{"gist": 12}');
+    const warn = jest
+      .spyOn((svc as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn')
+      .mockImplementation(() => undefined);
+    const result = await svc.enrich('co_test');
+    expect(result).toEqual({ scenes: 1, enriched: 0, failed: 1 });
+    expect(captured.updates).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('malformed'));
+  });
+
+  it('updates the row with the scorer + prompt version stamps on a well-formed reply', async () => {
+    const { svc, captured } = build(JSON.stringify(WELL_FORMED));
+    const result = await svc.enrich('co_test');
+    expect(result).toEqual({ scenes: 1, enriched: 1, failed: 0 });
+    expect(captured.updates).toHaveLength(1);
+    const update = captured.updates[0]!;
+    expect(update.gist).toBe(WELL_FORMED.gist);
+    expect(update.gistPromptVersion).toBe(SCENE_GIST_PROMPT_VERSION);
+    const mv = update.memoryValue as Record<string, unknown>;
+    expect(mv.scorerVersion).toBe(SCENE_SCORER_LLM_VERSION);
+    expect(mv.scoredAt).toBeInstanceOf(Date);
+    expect(mv.novelty).toBeCloseTo(0.8);
+    expect(update.stateDeltas).toEqual(WELL_FORMED.stateDeltas);
+    expect(update.unexpectedDetails).toEqual(WELL_FORMED.unexpectedDetails);
+  });
+
+  it('is a no-op with the flag off', async () => {
+    delete process.env.SCENES_LLM_ENRICHMENT;
+    try {
+      const { svc, captured } = build(JSON.stringify(WELL_FORMED));
+      const result = await svc.enrich('co_test');
+      expect(result).toEqual({ scenes: 0, enriched: 0, failed: 0 });
+      expect(captured.updates).toHaveLength(0);
+    } finally {
+      process.env.SCENES_LLM_ENRICHMENT = '1';
+    }
+  });
+});

--- a/test/test-doubles.ts
+++ b/test/test-doubles.ts
@@ -4,6 +4,7 @@ import type { EmbedderService } from '../src/ai/embedder.service';
 import type { ExtractorService, ExtractionResult } from '../src/ai/extractor.service';
 import type { LocalCrossEncoderProvider } from '../src/ai/cross-encoder/local-cross-encoder.provider';
 import { SynthesizeService } from '../src/synthesize/synthesize.service';
+import { SceneEnricherService } from '../src/admin/scene-enricher.service';
 
 /**
  * Deterministic embedder stub for e2e tests. Same text → same vector;
@@ -167,6 +168,38 @@ export interface OpenAiMockState {
 export function mockSynthesizeOpenAi(app: INestApplication, responses: string[]): OpenAiMockState {
   const state: OpenAiMockState = { calls: [] };
   const svc = app.get(SynthesizeService);
+  const stub = {
+    chat: {
+      completions: {
+        create: async (req: { messages: Array<{ role: string; content: string }> }) => {
+          const system = req.messages.find((m) => m.role === 'system')?.content ?? '';
+          const user = req.messages.find((m) => m.role === 'user')?.content ?? '';
+          const idx = state.calls.length;
+          const content = responses[idx] ?? responses[responses.length - 1] ?? '{}';
+          state.calls.push({ system, user, response: content, request: req });
+          return { choices: [{ message: { content } }] };
+        },
+      },
+    },
+  };
+  (svc as unknown as { openai: typeof stub }).openai = stub;
+  return state;
+}
+
+/**
+ * Replace the OpenAI client on the running SceneEnricherService with a
+ * scripted stub — the same seam as `mockSynthesizeOpenAi` (the enricher's
+ * `openai` field is the one admin-side LLM surface of the Brain v2 scene
+ * pass). Each call drains one response; the last repeats indefinitely, so
+ * a multi-scene pass can share a single scripted reply. NO paid call is
+ * ever made.
+ */
+export function mockSceneEnricherOpenAi(
+  app: INestApplication,
+  responses: string[],
+): OpenAiMockState {
+  const state: OpenAiMockState = { calls: [] };
+  const svc = app.get(SceneEnricherService);
   const stub = {
     chat: {
       completions: {


### PR DESCRIPTION
## Summary

PR2 of the Brain v2 wave, based on #370 (**will be retargeted to `main` after #370 merges** — the diff currently shows only this PR's changes on top of the PR1 substrate).

Scenes gain their paid encoding and the semantic plane gains pointers into the episodic plane:

- **LLM enrichment** (`SCENES_LLM_ENRICHMENT`): an optional pass after the composer's atomic swap — ONE structured LLM call per scene of the current segmenter version (strict JSON schema, deriver-client call idiom, model via `SCENES_ENRICH_MODEL` → `OPENAI_CHAT_MODEL`). The scene row gets an **abstractive gist** (replacing the deterministic render), the **full `memoryValue` vector** stamped `scorerVersion: 'scene-scorer-llm-v1'` + `scoredAt`, `stateDeltas`, `unexpectedDetails`, and `gistPromptVersion: 'scene-gist-v1'`. Degrade-never-fail: a malformed reply or transport error on one scene logs a warning and leaves that scene on its deterministic gist. `entityMentions` is parsed/validated but deliberately not persisted — 0106's `entityIds` promises `knowledge_entity` record refs; mention→record resolution is a later pass. Standalone re-enrichment: `POST /v1/admin/maintenance/scenes/enrich {tenant?, conversationId?}` (404 unless master AND enrichment flags are on).
- **Fact backlink** (`SCENES_FACT_BACKLINK`): per scene of the current version, the fact's `source.episodeIds` strings are JS-intersected with the scene's member episode ids (one `knowledge_fact` read per conversation, cached; `source` is FLEXIBLE and unindexed — a planner never sees it). Matches are stamped in batches by explicit id list: `source.memoryEpisodeIds = array::union(source.memoryEpisodeIds ?? [], [scene])` + `source.sceneLinkVersion` — **idempotent** and re-runnable after re-segmentation (also the documented repair for stale pointers left by GDPR cascades). No migration (FLEXIBLE source ride). Standalone: `POST /v1/admin/maintenance/scenes/backlink` (404 unless master AND backlink flags are on). Both passes also auto-run at the end of a composer run when their flags are on, wrapped so an optional pass can never retract a landed swap.
- **Version purge**: `DELETE /v1/admin/maintenance/scenes/versions/:segmenterVersion` (404 when master off; param validated non-empty ≤64 chars) — members then scenes deleted in one transaction via the LET-select-ids → `DELETE $ids` idiom (defensive against the SurrealDB 3.2.4 silent-no-op planner bug on the compound-uq-covered member table; scene deletes use the same idiom for consistency), then the projection ledger row is demoted to `'residual'` via a new narrow `ProjectionRegistryService.markResidual` verb (UPDATE, not UPSERT — a never-registered version gains no ghost row).

`SEGMENTER_VERSION` moved to the pure `scene-segmentation.ts` module (re-exported from the composer) so the new services can name the current scene world without a module cycle.

## Flags

| Flag | Default | Effect when on |
| --- | --- | --- |
| `SCENES_LLM_ENRICHMENT` | off | post-swap enrichment pass + `/scenes/enrich` route |
| `SCENES_FACT_BACKLINK` | off | post-run backlink pass + `/scenes/backlink` route |
| `SCENES_ENRICH_MODEL` | `OPENAI_CHAT_MODEL` (→ `gpt-4o-mini`) | enricher model override (string knob, same idiom as `WINDOW_DERIVER_MODEL`) |

Both booleans are registered in `KNOWN_BOOLEAN_FLAGS` and `CONFIG_CATALOG` (category `scenes`), read at call time (runtime-mutable), and pass the catalog truth gates.

## Additive `source` keys note

Serving stays byte-identical: **nothing reads** `source.memoryEpisodeIds` / `source.sceneLinkVersion`. The keys do become *visible* in payloads that already return the fact `source` object verbatim (facts read/provenance API) — an additive payload change, not a behavioral one.

## Safety

- Default-off everywhere; with the flags off no LLM call is ever made, no fact row is ever touched, and behavior is byte-identical to PR1.
- **No paid calls in CI**: the enricher's OpenAI client is stub-injected in tests (`mockSceneEnricherOpenAi`, the same seam as `mockSynthesizeOpenAi`); the e2e segmentation path stays embedder-free (`SCENES_TOPIC_BOUNDARY` off). No key → the pass skips with a warning (nullable `createOpenAiClient`).
- All mutations that could meet the 3.2.4 compound-index planner bug go through explicit id lists (`DELETE $ids`, `UPDATE … WHERE id INSIDE $factIds`, single-record `UPDATE $scene`).

## Test plan

- `pnpm typecheck` — clean.
- `pnpm test:unit` — 297 suites / 2818 tests green, including new `test/scene-enrichment.unit-spec.ts` (reply parser accept/reject/clamp/cap, pure backlink intersection, enricher degrade contract against a scripted stub: malformed → scene untouched + warn; well-formed → row updated with the scorer/prompt version stamps; flag off → no-op) and the config-catalog truth/flag-budget gates.
- `pnpm test:e2e -- --testPathPatterns "memory-episode|scene"` — 2 suites / 7 tests green against ephemeral SurrealDB 3.2.4: new `test/scene-enrichment.e2e-spec.ts` (stubbed enrichment incl. 404 gate and deterministic-gist-before assertion; idempotent backlink with a cross-conversation control fact staying unstamped; purge → rows gone, registry row `residual`) plus the untouched PR1 `memory-episode` suite.
- `prettier --check "src/**/*.ts" "test/**/*.ts"` — clean; changed files eslint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
