### PR TITLE
fix(db): harden DELETE-WHERE statements against the SurrealDB 3.2.4 compound-index planner no-op

### DIFF
--- a/src/admin/derive-staging.ts
+++ b/src/admin/derive-staging.ts
@@ -311,10 +311,20 @@ export async function promoteStaging(
           `UPDATE knowledge_fact SET derivedVersion = $final
             WHERE derivedVersion = $staging AND source.conversationId = $conv`,
         )
+        // Two-step (LET ids → DELETE $ids) DELIBERATELY: this WHERE pair
+        // is covered by the COMPOUND digest_conv_version_idx
+        // (conversationId, derivedVersion) UNIQUE index — on SurrealDB
+        // 3.2.4 a DELETE planned through a compound index can be a
+        // silent no-op (returns OK, deletes nothing) while the same
+        // WHERE in a SELECT matches fine — the bug class reproduced for
+        // preSweepOutcomeRows (PR #372). A no-op here would collide the
+        // staging→final UPDATE below into the UNIQUE pair and abort the
+        // whole flip.
         .add(
-          `DELETE conversation_digest
-            WHERE derivedVersion = $final AND conversationId = $conv`,
+          `LET $digestIds = (SELECT VALUE id FROM conversation_digest
+            WHERE derivedVersion = $final AND conversationId = $conv)`,
         )
+        .add(`DELETE $digestIds`)
         .add(
           `UPDATE conversation_digest SET derivedVersion = $final
             WHERE derivedVersion = $staging AND conversationId = $conv`,

--- a/src/admin/digest-persist.ts
+++ b/src/admin/digest-persist.ts
@@ -37,11 +37,23 @@ export async function persistDigest({
   // run produced a new one (flag now off, or the fold degraded).
   // Leaving it would serve a narrative inconsistent with the facts
   // that were just rewritten next to it.
-  await db.query(
-    `DELETE conversation_digest
+  //
+  // Two-step (SELECT ids → DELETE $ids) DELIBERATELY: this WHERE pair is
+  // exactly the COMPOUND digest_conv_version_idx (conversationId,
+  // derivedVersion) UNIQUE index — on SurrealDB 3.2.4 a DELETE planned
+  // through a compound index can be a silent no-op (returns OK, deletes
+  // nothing) while the same WHERE in a SELECT matches fine — the bug
+  // class reproduced for preSweepOutcomeRows (PR #372). A no-op here
+  // would collide the CREATE below into the UNIQUE pair. At most one row
+  // by the UNIQUE index, so no batching.
+  const [digestIds] = await db.query<[unknown[]]>(
+    `SELECT VALUE id FROM conversation_digest
       WHERE conversationId = $conv AND derivedVersion = $version`,
     { conv: conversationId, version },
   );
+  if (((digestIds as unknown[]) ?? []).length > 0) {
+    await db.query(`DELETE $ids`, { ids: digestIds });
+  }
   if (digest === null || !digest.trim() || !digestEventAt) return;
   await db.query(
     `CREATE conversation_digest SET

--- a/src/documents/candidate-sweeper.service.ts
+++ b/src/documents/candidate-sweeper.service.ts
@@ -115,10 +115,27 @@ export class CandidateSweeperService implements OnModuleInit {
       let factsFlagged = 0;
       for (const docId of purgeIds) {
         const tail = docId.slice(docId.indexOf(':') + 1);
+        // Two-step batched DELETE-by-ids DELIBERATELY: docId is covered
+        // ONLY by the COMPOUND source_chunk_doc_idx (docId, seq) UNIQUE
+        // index — on SurrealDB 3.2.4 a DELETE planned through a compound
+        // index can be a silent no-op (returns OK, deletes nothing) while
+        // the same WHERE in a SELECT matches fine — the bug class
+        // reproduced for preSweepOutcomeRows (PR #372). Batched with
+        // LIMIT because a large document's chunk count is unbounded.
+        for (;;) {
+          const [, batch] = await db.query<[unknown, unknown[]]>(
+            `LET $ids = (SELECT VALUE id FROM source_chunk
+               WHERE docId = type::record('source_document', $doc)
+               LIMIT 5000);
+             DELETE $ids RETURN BEFORE`,
+            { doc: tail },
+          );
+          // A partial batch means the document's chunks are drained.
+          if (((batch as unknown[]) ?? []).length < 5000) break;
+        }
         await db.query(
-          `DELETE source_chunk WHERE docId = type::record('source_document', $doc);
-           UPDATE type::record('source_document', $doc)
-             SET status = 'purged', hasContent = false;`,
+          `UPDATE type::record('source_document', $doc)
+             SET status = 'purged', hasContent = false`,
           { doc: tail },
         );
         factsFlagged += await markFactsProvenancePurged(db, docId);

--- a/src/documents/document-store.service.ts
+++ b/src/documents/document-store.service.ts
@@ -224,9 +224,24 @@ export class DocumentStoreService {
         { id: idTailOf(docId) },
       );
       if (!existing) return false;
-      await db.query(`DELETE source_chunk WHERE docId = type::record('source_document', $id)`, {
-        id: idTailOf(docId),
-      });
+      // Two-step batched DELETE-by-ids DELIBERATELY: docId is covered
+      // ONLY by the COMPOUND source_chunk_doc_idx (docId, seq) UNIQUE
+      // index — on SurrealDB 3.2.4 a DELETE planned through a compound
+      // index can be a silent no-op (returns OK, deletes nothing) while
+      // the same WHERE in a SELECT matches fine — the bug class
+      // reproduced for preSweepOutcomeRows (PR #372). Batched with LIMIT
+      // because a large document's chunk count is unbounded.
+      for (;;) {
+        const [, batch] = await db.query<[unknown, unknown[]]>(
+          `LET $ids = (SELECT VALUE id FROM source_chunk
+             WHERE docId = type::record('source_document', $id)
+             LIMIT 5000);
+           DELETE $ids RETURN BEFORE`,
+          { id: idTailOf(docId) },
+        );
+        // A partial batch means the document's chunks are drained.
+        if (((batch as unknown[]) ?? []).length < 5000) break;
+      }
       await db.query(
         `UPDATE type::record('source_document', $id)
            SET status = 'purged', hasContent = false`,

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -203,27 +203,17 @@ export class EntityForgetService {
       const episodeRefs = episodeIds.map((id) => new StringRecordId(id));
       const recordIds = [entityIdStr, ...factIds, ...edgeIds];
 
-      // ── Transaction-size guard. Count the two open-ended tables (audit
-      // mirror rows grow with every mutation; segments with every turn) so
-      // the cap reflects the real transaction footprint, then refuse an
-      // oversized single transaction BEFORE mutating anything.
-      const auditCountRow = await queryFirst<{ count: number }>(
-        db,
-        `SELECT count() FROM audit_event WHERE recordId IN $ids GROUP ALL`,
-        { ids: recordIds },
-      );
-      const auditCount = auditCountRow?.count ?? 0;
-      const l0FanOut = await this.countL0FanOut(db, episodeRefs);
-      const txRecordCount = factsDeleted + edgesDeleted + episodeIds.length + l0FanOut + auditCount;
-      if (txRecordCount > this.maxTxRecords) {
-        throw new PayloadTooLargeException(
-          `Entity forget fan-out (${txRecordCount} records) exceeds ` +
-            `FORGET_MAX_TX_RECORDS (${this.maxTxRecords}); refusing to build an ` +
-            `oversized single transaction. Use whole-tenant offboarding ` +
-            `(drop database), raise the cap deliberately, or use the ` +
-            `resumable-chunked erase follow-up.`,
-        );
-      }
+      // Side-table rows to erase BY EXPLICIT ID — see the
+      // preCollectSideTableIds docblock for the 3.2.4 planner contract.
+      const { feedbackIds, artifactIds } = await this.preCollectSideTableIds(db, ref.id);
+
+      // ── Transaction-size guard — see the guardTxRecordCap docblock.
+      await this.guardTxRecordCap(db, {
+        recordIds,
+        episodeRefs,
+        fixedCount:
+          factsDeleted + edgesDeleted + episodeIds.length + feedbackIds.length + artifactIds.length,
+      });
 
       // ── 0107 outcome telemetry: bulk-purge the raw event log OUTSIDE
       // the atomic erase (see preSweepOutcomeRows — content-free by
@@ -250,12 +240,19 @@ export class EntityForgetService {
           .bind('factsDeleted', factsDeleted)
           .bind('edgesDeleted', edgesDeleted)
           .bind('forgottenBy', actorKeyHash ?? 'unknown')
-          .bind('forgottenAt', forgottenAt);
+          .bind('forgottenAt', forgottenAt)
+          .bind('feedbackIds', feedbackIds)
+          .bind('artifactIds', artifactIds);
         tx.add(`LET $ent = type::record('knowledge_entity', $rid)`);
         // fact_usage (0053) + retrieval_feedback (0054) are keyed by fact
         // record — the traversal dies with the facts, so purge first.
+        // fact_usage stays one-step: its factId carries a single-field
+        // UNIQUE index, the verified-working shape on the pinned server.
+        // retrieval_feedback goes BY THE PRE-COLLECTED IDS — its
+        // traversal DELETE is the 3.2.4 planner no-op (see the
+        // pre-collect comment above).
         tx.add(`DELETE fact_usage WHERE factId.entityId = $ent`);
-        tx.add(`DELETE retrieval_feedback WHERE factId.entityId = $ent`);
+        tx.add(`DELETE $feedbackIds`);
         // Scenes (0106): a scene whose membership quotes an erased episode
         // goes whole, with ALL its member rows (mixed-subject scenes lose
         // the scene, other subjects keep their own facts) — members before
@@ -321,8 +318,10 @@ export class EntityForgetService {
           `DELETE debug_trace WHERE companyId = $cid AND string::contains(<string>artifacts, $needle)`,
         );
         // knowledge_artifact: compiled per-entity dossiers carry
-        // name/contact/complaints — entityId-keyed.
-        tx.add(`DELETE knowledge_artifact WHERE entityId = $ent`);
+        // name/contact/complaints — entityId-keyed, erased by the
+        // pre-collected ids (compound-only index coverage — the risky
+        // 3.2.4 planner shape, see the pre-collect comment above).
+        tx.add(`DELETE $artifactIds`);
         // ingest_dead_letter: rejected facts keep payload.{object,entityId}.
         tx.add(`DELETE ingest_dead_letter WHERE payload.entityId = $ent`);
         // entity_external_ref: external subject identifier + pointer.
@@ -461,6 +460,71 @@ export class EntityForgetService {
       );
       // A partial batch means the subject's raw rows are drained.
       if (((batch as unknown[]) ?? []).length < 5000) break;
+    }
+  }
+
+  /**
+   * Side-table rows the erase transaction must delete BY EXPLICIT ID
+   * (same pre-collect contract as recordIds): on SurrealDB 3.2.4 a
+   * DELETE whose WHERE traverses through factId — covered by the
+   * COMPOUND (factId, actor) UNIQUE index — silently matches NOTHING
+   * (returns OK, deletes zero rows) while the same WHERE in a SELECT
+   * matches fine — reproduced 12/12 against the pinned server. Deleting
+   * by explicit ids sidesteps the planner entirely. Same bug class as
+   * preSweepOutcomeRows (PR #372) / scene membership (PR #370).
+   * knowledge_artifact.entityId is covered ONLY by the COMPOUND
+   * (entityId, artifactType) UNIQUE index — same risky shape, hardened
+   * defensively. Collected OUTSIDE the transaction (like every other id
+   * set) so the tx read-set does not grow side-table scans; both tables
+   * are keyed by rows the transaction deletes, so nothing can recreate
+   * them post-commit. Both counts feed the transaction-size guard.
+   */
+  private async preCollectSideTableIds(
+    db: Parameters<Parameters<SurrealService['withCompany']>[1]>[0],
+    rid: string,
+  ): Promise<{ feedbackIds: unknown[]; artifactIds: unknown[] }> {
+    const [feedbackIdRows] = await db.query<[unknown[]]>(
+      `SELECT VALUE id FROM retrieval_feedback WHERE factId.entityId = type::record('knowledge_entity', $rid)`,
+      { rid },
+    );
+    const [artifactIdRows] = await db.query<[unknown[]]>(
+      `SELECT VALUE id FROM knowledge_artifact WHERE entityId = type::record('knowledge_entity', $rid)`,
+      { rid },
+    );
+    return {
+      feedbackIds: (feedbackIdRows as unknown[]) ?? [],
+      artifactIds: (artifactIdRows as unknown[]) ?? [],
+    };
+  }
+
+  /**
+   * Transaction-size guard. Count the two open-ended tables (audit
+   * mirror rows grow with every mutation; L0 fan-out with every turn) on
+   * top of the caller's pre-collected fixed counts so the cap reflects
+   * the real transaction footprint, then refuse an oversized single
+   * transaction BEFORE anything mutates (nothing partially erased —
+   * see the maxTxRecords docblock for the bound-don't-chunk rationale).
+   */
+  private async guardTxRecordCap(
+    db: Parameters<Parameters<SurrealService['withCompany']>[1]>[0],
+    counts: { recordIds: string[]; episodeRefs: StringRecordId[]; fixedCount: number },
+  ): Promise<void> {
+    const auditCountRow = await queryFirst<{ count: number }>(
+      db,
+      `SELECT count() FROM audit_event WHERE recordId IN $ids GROUP ALL`,
+      { ids: counts.recordIds },
+    );
+    const auditCount = auditCountRow?.count ?? 0;
+    const l0FanOut = await this.countL0FanOut(db, counts.episodeRefs);
+    const txRecordCount = counts.fixedCount + l0FanOut + auditCount;
+    if (txRecordCount > this.maxTxRecords) {
+      throw new PayloadTooLargeException(
+        `Entity forget fan-out (${txRecordCount} records) exceeds ` +
+          `FORGET_MAX_TX_RECORDS (${this.maxTxRecords}); refusing to build an ` +
+          `oversized single transaction. Use whole-tenant offboarding ` +
+          `(drop database), raise the cap deliberately, or use the ` +
+          `resumable-chunked erase follow-up.`,
+      );
     }
   }
 }

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -64,12 +64,26 @@ export class UserForgetService {
       const touchedEntityIds = [...new Set(((factEntityRows as unknown[]) ?? []).map(String))];
 
       // Side tables keyed by fact records — traversal needs live facts.
+      // fact_usage stays one-step: its factId carries a single-field
+      // UNIQUE index, the verified-working shape on the pinned server.
       await db.query(`DELETE fact_usage WHERE factId.userId = $u`, {
         u: userId,
       });
-      await db.query(`DELETE retrieval_feedback WHERE factId.userId = $u`, {
-        u: userId,
-      });
+      // Two-step (SELECT ids → DELETE $ids) DELIBERATELY: on SurrealDB
+      // 3.2.4 a DELETE whose WHERE traverses through factId — covered by
+      // the COMPOUND (factId, actor) UNIQUE index — silently matches
+      // NOTHING (returns OK, deletes zero rows) while the same WHERE in
+      // a SELECT matches fine — reproduced 12/12 against the pinned
+      // server. Deleting by explicit ids sidesteps the planner entirely.
+      // Same bug class as preSweepOutcomeRows (PR #372) / scene
+      // membership (PR #370).
+      const [feedbackIds] = await db.query<[unknown[]]>(
+        `SELECT VALUE id FROM retrieval_feedback WHERE factId.userId = $u`,
+        { u: userId },
+      );
+      if (((feedbackIds as unknown[]) ?? []).length > 0) {
+        await db.query(`DELETE $ids`, { ids: feedbackIds });
+      }
       // Outcome telemetry (0107): both tables traverse subjectId into
       // the user's facts — purge while the facts are alive, same as
       // fact_usage above. LET-then-DELETE-by-ids, NOT `DELETE … WHERE`:
@@ -85,17 +99,24 @@ export class UserForgetService {
         { u: userId },
       );
       // Edges touching a personal entity (either endpoint) or stamped
-      // with the scope directly — before the entities go.
-      const [edgesDeletedRows] = await db.query<[Array<{ id?: unknown }>]>(
-        `DELETE knowledge_edge
-          WHERE userId = $u OR in.userId = $u OR out.userId = $u
-          RETURN BEFORE`,
+      // with the scope directly — before the entities go. Same two-step
+      // idiom DEFENSIVELY: the in.userId/out.userId arms traverse record
+      // fields with compound coverage (edge_unique_idx) into the indexed
+      // entity_user_idx — the exact reproduced trigger combination; the
+      // one-step form only works today because the OR keeps the planner
+      // off the index, and that choice is plan-dependent.
+      const [edgeIdRows] = await db.query<[unknown[]]>(
+        `SELECT VALUE id FROM knowledge_edge
+          WHERE userId = $u OR in.userId = $u OR out.userId = $u`,
         { u: userId },
       );
-      const edgeRows = (edgesDeletedRows as Array<{ id?: unknown }>) ?? [];
+      const edgeRecordIds = (edgeIdRows as unknown[]) ?? [];
+      if (edgeRecordIds.length > 0) {
+        await db.query(`DELETE $ids`, { ids: edgeRecordIds });
+      }
       // Edges are mirrored to audit_event (changefeed-drain), so their
       // mirror rows must be purged with the fact/entity ones below.
-      const edgeIds = edgeRows.map((r) => String(r.id)).filter((s) => s && s !== 'undefined');
+      const edgeIds = edgeRecordIds.map(String).filter((s) => s && s !== 'undefined');
       // Dedup refs traverse the entity link — before the entities go.
       await db.query(`DELETE entity_external_ref WHERE entity.userId = $u`, {
         u: userId,
@@ -105,15 +126,23 @@ export class UserForgetService {
       // facts) on next read. Must precede the fact delete: entityId is a
       // record link the artifact carries independently, but doing it here
       // keeps the erasure atomic with the rest of the cascade.
+      // Two-step: knowledge_artifact.entityId is covered ONLY by the
+      // COMPOUND (entityId, artifactType) UNIQUE index — the risky 3.2.4
+      // planner shape (see the retrieval_feedback comment above); the
+      // one-step DELETE passed probes but the failure is plan-dependent,
+      // so it is hardened defensively.
       for (const eid of touchedEntityIds) {
         const tail = eid.startsWith('knowledge_entity:')
           ? eid.slice('knowledge_entity:'.length)
           : eid;
-        await db.query(
-          `DELETE knowledge_artifact
+        const [artifactIds] = await db.query<[unknown[]]>(
+          `SELECT VALUE id FROM knowledge_artifact
              WHERE entityId = type::record('knowledge_entity', $tail)`,
           { tail },
         );
+        if (((artifactIds as unknown[]) ?? []).length > 0) {
+          await db.query(`DELETE $ids`, { ids: artifactIds });
+        }
       }
 
       await db.query(`DELETE knowledge_fact WHERE userId = $u`, { u: userId });
@@ -208,7 +237,7 @@ export class UserForgetService {
         userId,
         factsDeleted: factIds.length,
         entitiesDeleted: entityIds.length,
-        edgesDeleted: edgeRows.length,
+        edgesDeleted: edgeRecordIds.length,
         auditEventsDeleted,
       };
       this.logger.log(

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -153,6 +153,75 @@ describe('0107_memory_outcome indexes', () => {
   });
 });
 
+describe('SurrealDB 3.2.4 DELETE-WHERE planner no-op guards', () => {
+  // Bug class (reproduced against the pinned surrealdb/surrealdb:v3.2.4,
+  // rocksdb, WS driver with CBOR binds AND HTTP /sql): a `DELETE <table>
+  // WHERE <predicate>` can silently match NOTHING (returns OK, deletes
+  // zero rows) while a SELECT with the identical WHERE matches — when the
+  // filtered field's index coverage includes a COMPOUND index, or when
+  // the WHERE traverses a record field into an indexed target field.
+  // Every such statement must use the two-step SELECT-ids → DELETE $ids
+  // idiom (see preSweepOutcomeRows, PR #372). These guards pin the fixed
+  // files so the one-step shapes cannot regress.
+  const SRC = join(__dirname, '..', 'src');
+  const read = (...p: string[]) => readFileSync(join(SRC, ...p), 'utf8');
+
+  it('user-forget: retrieval_feedback / knowledge_edge / knowledge_artifact go by ids', () => {
+    const src = read('entities', 'user-forget.service.ts');
+    // Reproduced no-op: traversal through compound-covered factId.
+    expect(src).not.toMatch(/DELETE retrieval_feedback WHERE/);
+    expect(src).toContain('SELECT VALUE id FROM retrieval_feedback WHERE factId.userId = $u');
+    // Defensive: in.userId/out.userId traverse compound-covered fields.
+    expect(src).not.toMatch(/DELETE knowledge_edge\s+WHERE/);
+    expect(src).toContain('SELECT VALUE id FROM knowledge_edge');
+    // Defensive: entityId covered only by the COMPOUND artifact index.
+    expect(src).not.toMatch(/DELETE knowledge_artifact\s+WHERE/);
+    expect(src).toContain('SELECT VALUE id FROM knowledge_artifact');
+  });
+
+  it('entity-forget tx: retrieval_feedback / knowledge_artifact go by pre-collected ids', () => {
+    const src = read('entities', 'entity-forget.service.ts');
+    expect(src).not.toMatch(/DELETE retrieval_feedback WHERE/);
+    expect(src).toContain(
+      "SELECT VALUE id FROM retrieval_feedback WHERE factId.entityId = type::record('knowledge_entity', $rid)",
+    );
+    expect(src).toContain('DELETE $feedbackIds');
+    expect(src).not.toMatch(/DELETE knowledge_artifact WHERE/);
+    expect(src).toContain(
+      "SELECT VALUE id FROM knowledge_artifact WHERE entityId = type::record('knowledge_entity', $rid)",
+    );
+    expect(src).toContain('DELETE $artifactIds');
+  });
+
+  it('digest writers: no DELETE conversation_digest filtered on the compound pair', () => {
+    // (conversationId, derivedVersion) is exactly digest_conv_version_idx
+    // UNIQUE — the risky compound shape. The version-only DELETEs
+    // (second field of the compound, planner cannot use it) stay.
+    const digestPersist = read('admin', 'digest-persist.ts');
+    expect(digestPersist).not.toMatch(/DELETE conversation_digest\s+WHERE conversationId/);
+    expect(digestPersist).toContain('SELECT VALUE id FROM conversation_digest');
+    const staging = read('admin', 'derive-staging.ts');
+    expect(staging).not.toMatch(
+      /DELETE conversation_digest\s+WHERE derivedVersion = \$final AND conversationId/,
+    );
+    expect(staging).toContain('LET $digestIds = (SELECT VALUE id FROM conversation_digest');
+    expect(staging).toContain('DELETE $digestIds');
+  });
+
+  it('source_chunk purges: no DELETE filtered on compound-only docId', () => {
+    // docId is covered ONLY by source_chunk_doc_idx (docId, seq) UNIQUE.
+    for (const file of [
+      ['documents', 'candidate-sweeper.service.ts'],
+      ['documents', 'document-store.service.ts'],
+    ]) {
+      const src = read(...file);
+      expect(src).not.toMatch(/DELETE source_chunk WHERE/);
+      expect(src).toContain('SELECT VALUE id FROM source_chunk');
+      expect(src).toContain('DELETE $ids RETURN BEFORE');
+    }
+  });
+});
+
 describe('JobRunService.finish ownership guard', () => {
   function mkSurreal(db: { query: (s: string, p?: any) => Promise<any> }) {
     return {

--- a/test/derive-staging.unit-spec.ts
+++ b/test/derive-staging.unit-spec.ts
@@ -289,8 +289,11 @@ describe('derive staging namespace (audit 2026-08-19 P1)', () => {
     // now runs against the FINAL world at flip time.
     expect(flips[0]!.sql).toContain("status = 'superseded'");
     expect(flips[0]!.sql).toContain('supersededBy IN');
-    // Digest slice flips inside the SAME transaction.
-    expect(flips[0]!.sql).toContain('DELETE conversation_digest');
+    // Digest slice flips inside the SAME transaction — via the two-step
+    // LET-ids → DELETE idiom (the WHERE pair is the compound
+    // digest_conv_version_idx, the SurrealDB 3.2.4 planner no-op shape).
+    expect(flips[0]!.sql).toContain('LET $digestIds = (SELECT VALUE id FROM conversation_digest');
+    expect(flips[0]!.sql).toContain('DELETE $digestIds');
     expect(flips[0]!.params?.conv).toBe('conv-1');
   });
 });
@@ -436,10 +439,14 @@ describe('promoteStaging / sweepStagingRows primitives', () => {
       queries[0]!.sql.indexOf('DELETE knowledge_fact'),
     );
     expect(queries[0]!.sql).toContain('source.conversationId = $conv');
-    // Digest slice flips inside the SAME transaction, same scoping.
+    // Digest slice flips inside the SAME transaction, same scoping —
+    // via the two-step LET-ids → DELETE idiom (the WHERE pair is the
+    // compound digest_conv_version_idx, the SurrealDB 3.2.4 planner
+    // no-op shape).
     expect(queries[0]!.sql).toContain(
-      'DELETE conversation_digest\n            WHERE derivedVersion = $final AND conversationId = $conv',
+      'LET $digestIds = (SELECT VALUE id FROM conversation_digest\n            WHERE derivedVersion = $final AND conversationId = $conv)',
     );
+    expect(queries[0]!.sql).toContain('DELETE $digestIds');
   });
 
   it('sweep probes before deleting and scopes to the staging namespace', async () => {

--- a/test/entities-forget.e2e-spec.ts
+++ b/test/entities-forget.e2e-spec.ts
@@ -117,7 +117,28 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
     // including PII fact `object` values. Seed one keyed by the entity's
     // recordId so we can assert the forget cascade purges it.
     const tail = entityId.split(':')[1];
-    await surreal.withCompany(f.companyId, async (db) => {
+    const sideTableIds = await surreal.withCompany(f.companyId, async (db) => {
+      // Side tables keyed by the subject's fact records (fact_usage 0053,
+      // retrieval_feedback 0054). Their ids are captured HERE, before the
+      // forget: after the cascade the factId link dangles, so any
+      // traversal-based count reads 0 even when the rows survived — a
+      // SurrealDB 3.2.4 DELETE planner no-op (see preSweepOutcomeRows,
+      // PR #372) is only observable by asserting on the captured ids.
+      const [usageRows] = await db.query<any[][]>(
+        `CREATE fact_usage CONTENT {
+            factId: type::record('knowledge_fact', $ftail), readCount: 3 } RETURN id`,
+        { ftail: String(subjFactId).split(':')[1] },
+      );
+      const [feedbackRows] = await db.query<any[][]>(
+        `CREATE retrieval_feedback CONTENT {
+            factId: type::record('knowledge_fact', $ftail),
+            verdict: 'helpful', actor: 'reviewer-1',
+            reason: 'secret-pii-value' } RETURN id`,
+        { ftail: String(subjFactId).split(':')[1] },
+      );
+      const capturedIds = [(usageRows as any[])[0]?.id, (feedbackRows as any[])[0]?.id].filter(
+        Boolean,
+      );
       await db.query(
         `CREATE audit_event CONTENT {
             source: 'knowledge_entity',
@@ -165,7 +186,9 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
             spans: [], artifacts: [{ ref: $rid, text: 'secret-pii-value' }] }`,
         { cid: f.companyId, rid: entityId },
       );
+      return capturedIds;
     });
+    expect(sideTableIds.length).toBe(2);
 
     // Forget.
     const r = await f.http
@@ -245,6 +268,16 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
       expect(
         await countWhere(`SELECT id FROM debug_trace WHERE companyId = $cid`, { cid: f.companyId }),
       ).toBe(0);
+
+      // Fact-keyed side tables (fact_usage + retrieval_feedback) must be
+      // gone BY THEIR CAPTURED IDS: a 3.2.4 DELETE planner no-op leaves
+      // the rows in place while every factId-traversal count reads 0
+      // (the facts died, the link dangles) — id-addressed SELECT is the
+      // only assertion the masking cannot hide from.
+      const [sideRows] = await db.query<any[][]>(`SELECT id FROM $ids`, {
+        ids: sideTableIds,
+      });
+      expect((sideRows as any[]).length).toBe(0);
     });
   });
 

--- a/test/user-forget-edge-audit.e2e-spec.ts
+++ b/test/user-forget-edge-audit.e2e-spec.ts
@@ -23,7 +23,7 @@ describe('user-forget purges edge audit_event rows', () => {
 
   it('erases the audit_event mirror of a forgotten user’s edge', async () => {
     const surreal = f.app.get(SurrealService);
-    const edgeId = await surreal.withCompany(f.companyId, async (db) => {
+    const seeded = await surreal.withCompany(f.companyId, async (db) => {
       // A personal entity for user_x and a global one to point at.
       const [personal] = await db.query<[Array<{ id: unknown }>]>(
         `CREATE knowledge_entity SET type='other', canonicalName='Personal X',
@@ -53,8 +53,30 @@ describe('user-forget purges edge audit_event rows', () => {
            op='create', versionstamp=1, consumedBy='test'`,
         { rid: eid },
       );
-      return eid;
+
+      // A personal fact + its retrieval_feedback row: the feedback DELETE
+      // traverses compound-covered factId — the SurrealDB 3.2.4 planner
+      // no-op shape (see preSweepOutcomeRows, PR #372). Capture the ids
+      // BEFORE the forget: afterwards the factId link dangles, so a
+      // traversal count reads 0 whether or not the rows really died.
+      const [fact] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE knowledge_fact SET entityId=$ent, predicate='note', object='secret-pii',
+           confidence=0.9, validFrom=time::now(), userId='user_x',
+           source={ recorder: 'test' } RETURN id`,
+        { ent: new StringRecordId(pid) },
+      );
+      const factId = (fact as Array<{ id: unknown }>)[0]!.id;
+      const [feedback] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE retrieval_feedback SET factId=$f, verdict='helpful', actor='reviewer-1',
+           reason='secret-pii' RETURN id`,
+        { f: factId },
+      );
+      return {
+        edgeId: eid,
+        feedbackId: String((feedback as Array<{ id: unknown }>)[0]!.id),
+      };
     });
+    const edgeId = seeded.edgeId;
 
     const countAudit = () =>
       surreal.withCompany(f.companyId, async (db) => {
@@ -73,5 +95,18 @@ describe('user-forget purges edge audit_event rows', () => {
 
     // The edge's audit mirror is gone with it.
     expect(await countAudit()).toBe(0);
+
+    // The edge row and the fact-keyed feedback row must be gone BY THEIR
+    // CAPTURED IDS — the reported counts and the traversal-based reads
+    // both stay green through a 3.2.4 DELETE planner no-op (the rows
+    // survive with dangling links), so only an id-addressed SELECT can
+    // prove the erase landed.
+    const remaining = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ id: unknown }>]>(`SELECT id FROM $ids`, {
+        ids: [new StringRecordId(edgeId), new StringRecordId(seeded.feedbackId)],
+      });
+      return (rows as Array<{ id: unknown }>).length;
+    });
+    expect(remaining).toBe(0);
   });
 });

--- a/test/window-deriver.unit-spec.ts
+++ b/test/window-deriver.unit-spec.ts
@@ -273,7 +273,11 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
     // namespace — the old digest is DELETED even with the flag off (a
     // stale narrative must not outlive the facts rewritten next to it);
     // nothing is CREATED.
-    expect(off.queries.some((q) => q.sql.includes('DELETE conversation_digest'))).toBe(true);
+    // (Two-step LET-ids → DELETE since the 3.2.4 planner-no-op fix: the
+    // namespace claim is pinned by its id-probe SELECT.)
+    expect(
+      off.queries.some((q) => q.sql.includes('SELECT VALUE id FROM conversation_digest')),
+    ).toBe(true);
     expect(off.queries.some((q) => q.sql.includes('CREATE conversation_digest'))).toBe(false);
 
     process.env.DERIVER_DIGEST = '1';
@@ -283,8 +287,11 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
       const write = on.queries.find((q) => q.sql.includes('CREATE conversation_digest'));
       expect(write).toBeDefined();
       // The DELETE is its own statement now (it must run even when the
-      // fold produces nothing).
-      expect(on.queries.some((q) => q.sql.includes('DELETE conversation_digest'))).toBe(true);
+      // fold produces nothing) — pinned by the two-step id-probe SELECT
+      // (3.2.4 planner-no-op fix).
+      expect(
+        on.queries.some((q) => q.sql.includes('SELECT VALUE id FROM conversation_digest')),
+      ).toBe(true);
       // Digest writes stage like fact writes; the digest flip
       // transaction promotes them alongside the facts.
       expect(String(write?.params?.version).startsWith(`${WINDOW_DERIVER_VERSION}.staging.`)).toBe(


### PR DESCRIPTION
## Summary

P1 correctness sweep of every `DELETE … WHERE` on main against the SurrealDB 3.2.4 indexed-DELETE planner bug (the class behind `preSweepOutcomeRows` in PR #372 and the scene-membership fix in PR #370): a `DELETE <table> WHERE <predicate>` can return OK and delete **nothing** while a `SELECT` with the identical WHERE matches rows.

Every statement in `src/` was inventoried, its index coverage resolved from the migrations, and each distinct shape class probed empirically against a scratch `surrealdb/surrealdb:v3.2.4` (rocksdb, the pinned WS driver with CBOR binds; key repros re-confirmed over HTTP `/sql`), with the real DDL (full migration chain applied), fresh databases per round, and small + 120-row volumes.

**Headline finding: two silent no-ops were live on main, both on GDPR paths.** `DELETE retrieval_feedback WHERE factId.entityId = $ent` (entity forget) and `DELETE retrieval_feedback WHERE factId.userId = $u` (user forget) reproduce the no-op **12/12** against the real schema. Both e2e suites stayed green because nothing seeded `retrieval_feedback` — and after the cascade the `factId` link dangles, so every traversal-based count reads 0 whether or not the rows died. The rows (verdict + free-text `reason`, keyed by the erased subject's facts) survived every erasure.

All hardened statements now use the two-step idiom — `SELECT VALUE id … → DELETE $ids` (standalone) or pre-collected ids bound into the erase transaction — verified working standalone, with bound params, and inside `BEGIN/COMMIT`. Same rows deleted, just reliably; no behavior change otherwise.

## Inventory (every `DELETE … WHERE` in src/) with probe verdicts

Probe legend: *n/n ok* = rounds × {8, 120} rows, fresh DB each, all deleted. No `DELETE`s exist in `.surql` stored functions or `DEFINE EVENT` bodies (checked all migrations), so no new migration is needed.

### Reproduced no-op → fixed

| File | Statement | WHERE shape | Coverage of filtered field | Probe | Action |
|---|---|---|---|---|---|
| `src/entities/entity-forget.service.ts` | `DELETE retrieval_feedback WHERE factId.entityId = $ent` (in tx) | traversal | `factId`: single `retrieval_feedback_fact_idx` **+ compound `(factId, actor)` UNIQUE** | **NO-OP 12/12** | ids pre-collected outside the tx (`preCollectSideTableIds`, same contract as `recordIds`), `DELETE $feedbackIds` inside; counted into the tx-size guard |
| `src/entities/user-forget.service.ts` | `DELETE retrieval_feedback WHERE factId.userId = $u` | traversal | same | **NO-OP 12/12** | two-step SELECT-ids → `DELETE $ids` |

### Passed under probe but compound-covered / trigger-matched → hardened defensively

The failure is plan-dependent (an identical shape occasionally works — confirmed: the minimal 2-index DDL passes while the full production DDL of the same shape no-ops), so compound coverage is treated as risky even where probes passed.

| File | Statement | WHERE shape | Coverage | Probe | Action |
|---|---|---|---|---|---|
| `src/entities/entity-forget.service.ts` | `DELETE knowledge_artifact WHERE entityId = $ent` (in tx) | equality | **compound-ONLY** `(entityId, artifactType)` UNIQUE | 6/6 ok | pre-collected ids → `DELETE $artifactIds` in tx |
| `src/entities/user-forget.service.ts` | `DELETE knowledge_artifact WHERE entityId = type::record(...)` | equality | same | 6/6 ok | two-step per touched entity |
| `src/entities/user-forget.service.ts` | `DELETE knowledge_edge WHERE userId = $u OR in.userId = $u OR out.userId = $u RETURN BEFORE` | OR + traversal | `userId` unindexed; `in`/`out` single idx **+ compound `(in, out, kind)` UNIQUE**; traversal target `entity_user_idx` indexed | 6/6 ok | two-step — the arms match the exact reproduced trigger (compound-covered record field traversing into an indexed target); only the OR keeps the planner off the index today |
| `src/admin/digest-persist.ts` | `DELETE conversation_digest WHERE conversationId = $conv AND derivedVersion = $version` | equality pair | exactly the **compound** `digest_conv_version_idx` UNIQUE (`conversationId` has no single idx) | 6/6 ok | two-step (≤1 row by the UNIQUE pair) |
| `src/admin/derive-staging.ts` (targeted promote, in tx) | `DELETE conversation_digest WHERE derivedVersion = $final AND conversationId = $conv` | equality pair | same compound | 6/6 ok | in-tx `LET $digestIds = (SELECT VALUE id …); DELETE $digestIds` — a no-op here would collide the staging→final UPDATE into the UNIQUE pair and abort the flip |
| `src/documents/candidate-sweeper.service.ts` | `DELETE source_chunk WHERE docId = type::record(...)` | equality | **compound-ONLY** `source_chunk_doc_idx (docId, seq)` UNIQUE | 6/6 ok | two-step batched (`LIMIT 5000` loop — chunk count unbounded) |
| `src/documents/document-store.service.ts` (`purgeContent`) | same | equality | same | 6/6 ok | same batched two-step |

### Verified safe → untouched

| File | Statement | Shape | Coverage | Probe |
|---|---|---|---|---|
| `entity-forget` / `user-forget` | `DELETE fact_usage WHERE factId.entityId = $ent` / `factId.userId = $u` | traversal | `factId` single-field **UNIQUE** only | 6/6 + 6/6 ok (e2e-green path) |
| `entity-forget` (tx) | `DELETE knowledge_fact WHERE entityId = $ent` | equality | **`fact_entity_idx` single-field (0001) exists** + 2 compounds — the "compound-only" premise for this one was wrong; confirmed present via `INFO FOR TABLE` after the full migration chain | 6/6 ok |
| `entity-forget` (tx) | `DELETE knowledge_edge WHERE in = $ent OR out = $ent` | equality OR | `edge_in_idx`/`edge_out_idx` single | 6/6 ok |
| `entity-forget` (tx) | `DELETE episode WHERE id INSIDE $eps` | pk INSIDE | primary key | verified class |
| `entity-forget` (tx) / `user-forget` | `DELETE episode_segment WHERE episodeIds CONTAINSANY $eps` | CONTAINSANY | unindexed array | 6/6 ok |
| `entity-forget` (tx) / `user-forget` | `DELETE audit_event WHERE recordId IN $ids` | IN-list | `audit_event_record_idx` single | 6/6 ok |
| `entity-forget` (tx) | `DELETE dream_emit WHERE subject IN $recordIds OR object IN $recordIds` | IN + OR | unindexed | 6/6 ok |
| `entity-forget` (tx) | `DELETE debug_trace WHERE companyId = $cid AND string::contains(...)` | function pred | unindexed → scan | scan class |
| `entity-forget` (tx) | `DELETE ingest_dead_letter WHERE payload.entityId = $ent` | object field | unindexed | 6/6 ok |
| `entity-forget` (tx) / `user-forget` | `DELETE entity_external_ref WHERE entity = $ent` / `entity.userId = $u` | equality / traversal | `entity_external_ref_ent_idx` single | 6/6 + 6/6 ok |
| `user-forget` | `DELETE knowledge_fact WHERE userId = $u` / `DELETE knowledge_entity WHERE userId = $u` | equality | `fact_user_idx` / `entity_user_idx` single | 6/6 ok (class) |
| `user-forget` | `DELETE episode WHERE userId = $u` / `DELETE episode_segment WHERE userId = $u` | equality | unindexed | 6/6 + 6/6 ok |
| `src/admin/window-deriver.service.ts` | `DELETE knowledge_fact WHERE derivedVersion = $version` (×1) / `+ AND source.conversationId` (×1) | equality (+ nested AND) | `fact_derived_version_idx` single | 6/6 + 6/6 ok |
| `src/admin/window-deriver.service.ts` | `DELETE conversation_digest WHERE derivedVersion = $version` (×2) | equality | second field of the compound — not a usable prefix → scan | 6/6 ok |
| `src/admin/derive-staging.ts` | sweep (`derivedVersion = $version`), orphan sweep (`string::starts_with`), full promote (`derivedVersion = $final`), targeted fact slice (`+ source.conversationId`) | equality / function | single idx (facts) / scan (digests) | 6/6 ok |
| `src/admin/insight-composer-kernel.ts` | `DELETE knowledge_fact WHERE entityId = $eid AND source.recorder = $recorder …` (in tx) | equality + nested AND | `fact_entity_idx` single | 6/6 ok |
| `src/admin/segment-composer.service.ts` | `DELETE episode_segment WHERE conversationId = $conv` (in tx) | equality | `segment_conv_idx` single (+ compound prefix) | 6/6 ok |
| `src/admin/admin.service.ts` | `DELETE ingest_dead_letter WHERE id = $id` | pk equality | primary key | verified class |
| `src/episodes/projection-registry.service.ts` | `DELETE projection WHERE name = $name AND version INSIDE $versions` | equality + INSIDE | unindexed | 6/6 ok |
| `src/communities/community-builder.service.ts` | `DELETE community_member WHERE in = $cid` | equality | `member_in_idx` single (+ compound) | 6/6 ok |
| `src/documents/candidate-store.service.ts` | `DELETE candidate WHERE runId = type::record(...)` (×2) | equality | `candidate_run_idx` single | 6/6 ok |
| `src/documents/candidate-sweeper.service.ts` | `DELETE candidate WHERE status != 'pending' AND decidedAt …` | neq + range | scan (neq unusable) | 6/6 ok |
| `src/policy/policy-store.service.ts` | `DELETE access_policy WHERE name = $name` / `DELETE policy_binding WHERE subject = $subject AND array::len(...) = 0` | equality | single UNIQUE each | verified class |
| `src/policy/policy-decision.sink.ts` | `DELETE policy_decision WHERE ts < time::now() - Nd` | range | `policy_decision_ts_idx` single | 6/6 ok |
| `src/jobs/leader-lease.service.ts` | `DELETE type::record(...) WHERE leaderId = $me` | record-target + pred | direct record fetch, no planner | safe by construction |
| `src/common/trace-buffer.service.ts` | `DELETE $stale.*` | by ids | — | already the safe idiom |

## Tests

- **e2e (`entities-forget`, `user-forget-edge-audit`)**: both now seed `retrieval_feedback` (+ `fact_usage` / the edge row) and assert **zero remaining rows by ids captured before the forget** — the dangling-link masking can no longer hide a no-op. Verified against unfixed src (fixes stashed, strengthened tests kept): **both new assertions fail with exactly one surviving `retrieval_feedback` row each**, proving the tests catch the live bug.
- **unit source-guard** (`test/audit-p1-guards.unit-spec.ts`): grep-style guards ban the one-step `DELETE retrieval_feedback WHERE` / `DELETE knowledge_artifact WHERE` / `DELETE knowledge_edge WHERE` / compound-pair `DELETE conversation_digest WHERE conversationId …` / `DELETE source_chunk WHERE` shapes in the fixed files and pin the two-step markers.
- `derive-staging.unit-spec` / `window-deriver.unit-spec` expectations updated to pin the new idiom (the digest-namespace claim is now pinned by its id-probe SELECT).

## Verification

Rebased onto latest main twice as it advanced (#370 scenes substrate, #371 provenance, #368/0105, #372 outcome telemetry — the last two touch the same forget files). The erase tx now folds this PR's by-ids deletes around #370's scene cascade and #372's outcome pre-sweep; the one-step `DELETE retrieval_feedback WHERE factId.…` shapes those branches inherited from the pre-fix file are replaced by the by-ids forms. Two cohesive helpers were extracted from `forget` (which #370/#372 had grown past the max-lines-per-function budget): `preCollectSideTableIds` (docblock carries the 3.2.4 planner contract) and `guardTxRecordCap` (the pre-mutation transaction-size guard), sitting next to the existing `countL0FanOut`/`preSweepOutcomeRows` helpers.

- `pnpm typecheck` clean.
- `pnpm lint:ci` clean (`--max-warnings 0`).
- Unit: **299 suites / 2873 tests green** (full run, post-rebase onto #372).
- e2e (real SurrealDB 3.2.4 container), post-rebase: `entities-forget`, `user-forget-edge-audit`, `memory-episode`, `fact-usage`, `forget-l0`, `brain` — 27/27 green; `documents-pipeline`, `artifacts-user-scope`, `staleness-event`, `candidate-store-reliability` green earlier (files unchanged since).
- `prettier --check "src/**/*.ts" "test/**/*.ts"` clean.
- Probe harness: ~30 shape classes × {8, 120} rows × 3 rounds each, fresh DB + full migration chain per round; the fixed statements re-verified post-fix (standalone, bound params, in-tx).

One deliberate structural choice: inside the erase transaction the ids are **pre-collected outside** the tx (the file's existing contract for `factIds`/`edgeIds`/`recordIds`) rather than via in-tx `LET (SELECT …)`. The in-tx form is also correct against the planner bug (verified standalone 4/4), but enlarging the tx read-set with side-table scans surfaced optimistic read/write conflicts against concurrent ingest in e2e. Both tables are keyed by rows the same transaction deletes, so nothing can recreate them post-commit; the collected counts also feed the tx-size guard now.

## Upstream (minimal repro for a potential SurrealDB issue — not filed, owner's call)

SurrealDB **3.2.4** (rocksdb; reproduced over both HTTP `/sql` and the WS driver v2.0.8 with CBOR binds). A `DELETE` whose WHERE traverses a record field is a silent no-op when (a) the traversal **target** field on the parent table is indexed and (b) the traversed record field on the child is covered by a **compound** index:

```surql
DEFINE TABLE parent SCHEMAFULL;
DEFINE FIELD userId ON parent TYPE option<string>;
DEFINE INDEX parent_user_idx ON parent FIELDS userId;

DEFINE TABLE child SCHEMAFULL;
DEFINE FIELD ref   ON child TYPE record<parent>;
DEFINE FIELD actor ON child TYPE string;
DEFINE INDEX child_ref_actor_idx ON child FIELDS ref, actor UNIQUE;

CREATE parent:p SET userId = 'u';
CREATE child SET ref = parent:p, actor = 'a';

SELECT count() FROM child WHERE ref.userId = 'u' GROUP ALL; -- [{ count: 1 }]
DELETE child WHERE ref.userId = 'u';                        -- OK
SELECT count() FROM child WHERE ref.userId = 'u' GROUP ALL; -- still [{ count: 1 }]
```

Deterministic single-row, 3/3 rounds. Bisection: drop `parent_user_idx` → deletes fine; replace the compound with a single non-unique index on `ref` → deletes fine. Adding a coexisting single non-unique index on `ref` fixes the *minimal* form but NOT the production table (`retrieval_feedback` with `factId` single idx + `(factId, actor)` UNIQUE + a `createdAt` index no-ops 12/12), i.e. the failure is plan/state-dependent — which is why this PR treats every compound-covered DELETE shape as risky. Related earlier repro in this codebase: compound-only-covered `in` on a RELATION table no-ops for both `in.userId = $u` traversal and direct `in INSIDE $ids` (PR #370). Workaround in all cases: `LET $ids = (SELECT VALUE id FROM … WHERE …); DELETE $ids;`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
