### PR TITLE
feat(fovea): L3 evidence citations — episode-level references for transcript-grounded claims

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -520,6 +520,18 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Fovea optics (verifier answer-integrity arm, Part C): treat a `supported` verdict whose answer carries ZERO citations as low_coverage/abstain instead of serving an uncited "supported" answer (audit F2(b)). LIVE-behavior change when enabled — prod answers can shift, so default off until the owner enables + validates. Off = byte-identical serving.',
   },
+  {
+    key: 'FOVEA_L3_EPISODE_CITATIONS',
+    category: 'calibration',
+    // Read at call time (fovea-flags.l3EpisodeCitationsEnabled) on the L3
+    // escalation seam — never captured in a constructor — so a flip takes
+    // effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Fovea serving-integrity: L3 evidence citations — the L3 escalation transcript renders per-turn [episode:...] headers and transcript-grounded claims are cited as {episodeId, quote} pairs, resolved into span-verified evidence citations over the stored turn text (episodeId-only when the quote cannot be verified; episodeIds not rendered into the transcript are dropped). An episode-cited answer satisfies FOVEA_REQUIRE_CITATIONS; the answer cache still never admits an episode-only-cited answer. Off = L3 prompt/schema/transcript byte-identical, no evidenceCitations emitted.',
+  },
   // ── Scenes (Brain v2) ──
   {
     key: 'SCENES_SEGMENTATION_ENABLED',

--- a/src/answer-cache/answer-cache.service.ts
+++ b/src/answer-cache/answer-cache.service.ts
@@ -310,6 +310,13 @@ export class AnswerCacheService {
    * Abstentions, unverified returns, low_coverage and partial verdicts
    * are never cached — an uncited answer is uninvalidatable, and a
    * non-supported one failed the grounding audit.
+   *
+   * L3 evidence citations (FOVEA_L3_EPISODE_CITATIONS) are DELIBERATELY
+   * not admission-bearing: an episode-only-cited L3 answer (zero fact
+   * citations, ≥1 evidence citation) has citations.length 0 and is
+   * rejected by the gate below. Check-on-read revalidates cited FACT
+   * rows against the live substrate and cannot (yet) invalidate episode
+   * citations, so caching such an answer would make it uninvalidatable.
    */
   async admit(
     ctx: AnswerCacheStoreContext,

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -807,6 +807,16 @@ const KNOWN_BOOLEAN_FLAGS = [
   // default off. Outside ENGINE_PREFIX by design (the FOVEA_ family sits off
   // the flag budget).
   'FOVEA_REQUIRE_CITATIONS',
+  // Fovea serving-integrity: L3 evidence citations — the L3 transcript gains
+  // per-turn [episode:...] headers and transcript-grounded claims are cited
+  // as {episodeId, quote} pairs, resolved into span-verified evidence
+  // citations over the stored turn text (only turns actually rendered into
+  // the transcript are citable; unknown episodeIds dropped). Changes the
+  // FOVEA_REQUIRE_CITATIONS verdict interaction (an episode-cited answer
+  // serves). Off = prompt/schema/transcript byte-identical, no
+  // evidenceCitations emitted. Outside ENGINE_PREFIX by design (the FOVEA_
+  // family sits off the flag budget).
+  'FOVEA_L3_EPISODE_CITATIONS',
   // Evidence plane (Brain v2 gap #5): summary-producing writers
   // (promotion, compaction rollups, recompose rewrites, arc/aggregate
   // composers) stamp the union of member source.episodeIds onto the

--- a/src/common/fovea-flags.ts
+++ b/src/common/fovea-flags.ts
@@ -155,6 +155,37 @@ export function requireCitationsEnabled(): boolean {
 }
 
 /**
+ * Fovea serving-integrity family — L3 evidence citations master flag —
+ * FOVEA_L3_EPISODE_CITATIONS.
+ *
+ * WHAT IT CHANGES: closes the L3 citation exemption ("Claims taken from the
+ * raw transcript need no citation", L3_SYSTEM rule 2). When on, the L3
+ * escalation transcript renders per-turn `[episode:<id>]` headers, the
+ * generator must cite each transcript-grounded claim as an {episodeId, quote}
+ * pair (citedEpisodes, added to the strict JSON schema), and the service
+ * resolves those into span-verified EvidenceCitations over the STORED turn
+ * text (anchorQuote: NFC, code points, fail-safe episodeId-only) — every
+ * served claim becomes unrollable to an observation. Only turns actually
+ * rendered into the transcript are citable: an unknown episodeId is dropped,
+ * so an L3 citation can never name an episode the caller couldn't read.
+ *
+ * VERDICT INTERACTION: changes the FOVEA_REQUIRE_CITATIONS contract — the
+ * zero-citation guard in verdict.ts counts evidence citations too, so an L3
+ * answer carrying zero fact citations but ≥1 evidence citation SERVES under
+ * require-citations instead of abstaining. The answer cache is deliberately
+ * unchanged: an episode-only-cited answer still has citations.length 0 and
+ * is never admitted (check-on-read cannot invalidate episode citations yet).
+ *
+ * SAFETY: the env read lives here in the common layer, NOT inside the engine
+ * dirs (engine-gates S5.2). Read at call time so a flip is runtime-mutable.
+ * Default off ⇒ the L3 prompt, JSON schema, and transcript lines are
+ * byte-identical to before and no evidenceCitations field is ever emitted.
+ */
+export function l3EpisodeCitationsEnabled(): boolean {
+  return envFlagEnabled(process.env.FOVEA_L3_EPISODE_CITATIONS);
+}
+
+/**
  * Multilingual Tier 5 master flag — MULTILINGUAL_CALIBRATION.
  *
  * When on, the §4.2 per-class focus calibrator (focus-signal.ts) gains a

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -250,6 +250,26 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // L3 evidence citations (FOVEA_L3_EPISODE_CITATIONS): per-citation
+  // resolution outcome of the citedEpisodes the L3 generator emitted —
+  //   span_anchored   — the quote verified verbatim against the stored
+  //                     turn text (anchorQuote) → the citation carries a
+  //                     code-point span
+  //   episode_only    — quote absent/ambiguous/unverifiable → the
+  //                     citation degrades to episodeId-only
+  //   dropped_unknown — the generator named an episodeId NOT rendered
+  //                     into the transcript (hallucination / probe) →
+  //                     dropped, never surfaced
+  // Emitted only when the flag is on (nothing on the path when off). A
+  // separate counter — NOT new labels on brain_l3_escalation_total —
+  // keeps the existing outcome series stable (the Optics-2 precedent).
+  readonly l3EpisodeCitationCount = new Counter({
+    name: 'brain_l3_episode_citation_total',
+    help: 'L3 evidence (episode) citation resolution outcomes (FOVEA_L3_EPISODE_CITATIONS)',
+    labelNames: ['outcome'] as const,
+    registers: [this.registry],
+  });
+
   // Optics §4.2 (docs/roadmap/fovea-optics-2026-08.md §4.2): which sub-
   // condition fired the pre-generation memory-coverage ABSTAIN decision —
   //   adaptive — the calibrated-pre-answer-confidence floor
@@ -693,6 +713,15 @@ export class MetricsService implements OnModuleInit {
 
   countL3AnchorSource(source: 'fact' | 'direct' | 'segment' | 'temporal'): void {
     this.l3AnchorSourceCount.inc({ source } as LabelValues<'source'>);
+  }
+
+  countL3EpisodeCitation(
+    outcome: 'span_anchored' | 'episode_only' | 'dropped_unknown',
+    n = 1,
+  ): void {
+    if (n > 0) {
+      this.l3EpisodeCitationCount.inc({ outcome } as LabelValues<'outcome'>, n);
+    }
   }
 
   countAbstainPath(path: 'adaptive' | 'static'): void {

--- a/src/synthesize/answer-integrity.ts
+++ b/src/synthesize/answer-integrity.ts
@@ -57,12 +57,16 @@ export interface FinalizeContext {
  * cited premises (see resolvePlausibilityDowngrade). The auditor model is
  * profile.verifierModel || the synthesis model.
  *
- * Consequence on L3: an L3 answer that grounds on the raw transcript may be
- * UNCITED by design ("claims from transcript need no citation"). With
- * FOVEA_REQUIRE_CITATIONS on, such an answer therefore abstains — the correct
- * end-to-end reading of the citation-bearing promise. An operator enabling
- * require-citations is explicitly opting into "no uncited answers, including
- * L3". (Default-off, so no prod impact.)
+ * Consequence on L3 (with FOVEA_L3_EPISODE_CITATIONS off): an L3 answer that
+ * grounds on the raw transcript may be UNCITED by design ("claims from
+ * transcript need no citation"). With FOVEA_REQUIRE_CITATIONS on, such an
+ * answer therefore abstains — the correct end-to-end reading of the
+ * citation-bearing promise. An operator enabling require-citations is
+ * explicitly opting into "no uncited answers, including L3". With
+ * FOVEA_L3_EPISODE_CITATIONS ALSO on, transcript-grounded claims carry
+ * episode-level evidence citations instead, and the finalizeVerdict guard
+ * counts those: an episode-cited L3 answer SERVES under require-citations
+ * (verdict.ts). (All default-off, so no prod impact.)
  *
  * NOTE on the serving-cost boundary: the judge fires on a `supported` verdict
  * when the flag is on and cited premises exist. In the narrow lenient +
@@ -103,7 +107,9 @@ export async function resolveAnswerIntegrity(
  * premises there is nothing to judge (Part C owns the zero-citation case) →
  * false, no call. A judge error FAILS SAFE to today's behavior (no downgrade)
  * and is logged — a transient LLM error must not turn a grounded answer into
- * an abstain.
+ * an abstain. The judge audits FACT citations only — L3 episode evidence
+ * citations are verbatim-verified mechanically by anchorQuote and carry no
+ * premise to audit.
  */
 async function resolvePlausibilityDowngrade(
   deps: AnswerIntegrityDeps,

--- a/src/synthesize/l3-citations.ts
+++ b/src/synthesize/l3-citations.ts
@@ -1,0 +1,98 @@
+import { anchorQuote } from '../admin/span-anchor';
+import type { EvidenceCitation } from './synthesize.types';
+
+/**
+ * L3 evidence citations (FOVEA_L3_EPISODE_CITATIONS) — the pure resolver
+ * that turns the L3 generator's raw `citedEpisodes` output into verified
+ * EvidenceCitations. No IO, no DI, no env: the service supplies the
+ * turnsById map and emits the metrics from the returned counts.
+ *
+ * THE ANTI-HALLUCINATION + SECURITY FENCE: `turnsById` contains ONLY the
+ * turns actually rendered into the L3 transcript — rows that already
+ * passed the PII/user/scope read gates on their way in
+ * (EpisodeReadStoreService.conversationTurns / windowAround). Any
+ * episodeId the generator emits that is NOT in that map is dropped (and
+ * counted), so an L3 citation can never name an episode the caller
+ * couldn't read, whether the id was hallucinated or probed.
+ *
+ * Quotes are verified mechanically via anchorQuote (NFC, code-point
+ * offsets, fail-safe null): a verifiable quote yields a span citation, an
+ * absent/ambiguous/unverifiable one degrades to an episodeId-only
+ * citation — the fact of grounding survives, a wrong highlight never
+ * ships.
+ */
+
+/** One rendered transcript turn the resolver may cite. */
+export interface CitableTurn {
+  /** The STORED turn text the transcript line was rendered from (the
+   *  text spans anchor against — the span-anchor invariant). */
+  text: string;
+  conversationId?: string | undefined;
+  /** ISO event time of the turn, when known. */
+  occurredAt?: string | undefined;
+}
+
+/** Per-citation resolution outcomes (the metric label values). */
+export interface EpisodeCitationCounts {
+  /** Quote verified verbatim → citation carries a code-point span. */
+  span_anchored: number;
+  /** Quote absent/ambiguous/unverifiable → episodeId-only citation. */
+  episode_only: number;
+  /** episodeId not in the rendered transcript (or malformed entry) →
+   *  dropped, never surfaced. */
+  dropped_unknown: number;
+}
+
+/** Ceiling on resolved evidence citations per L3 answer (mirrors the
+ *  bounded-output idiom of the fact-citation path). */
+const EVIDENCE_CITATION_CAP = 16;
+
+/**
+ * Resolve the generator's raw citedEpisodes against the rendered-turn
+ * map. Deduped by (episodeId, span?.start); capped at 16. Input is
+ * `unknown[]` by design — the LLM output is parsed defensively here, not
+ * trusted at the call site.
+ */
+export function resolveEpisodeCitations(
+  citedEpisodes: ReadonlyArray<unknown>,
+  turnsById: ReadonlyMap<string, CitableTurn>,
+): { citations: EvidenceCitation[]; counts: EpisodeCitationCounts } {
+  const counts: EpisodeCitationCounts = { span_anchored: 0, episode_only: 0, dropped_unknown: 0 };
+  const citations: EvidenceCitation[] = [];
+  const seen = new Set<string>();
+  for (const raw of citedEpisodes) {
+    if (citations.length >= EVIDENCE_CITATION_CAP) break;
+    const entry = parseEntry(raw);
+    if (!entry) {
+      counts.dropped_unknown += 1;
+      continue;
+    }
+    const turn = turnsById.get(entry.episodeId);
+    if (!turn) {
+      counts.dropped_unknown += 1;
+      continue;
+    }
+    const span = anchorQuote(turn.text, entry.quote);
+    const key = `${entry.episodeId}\u0000${span ? span.start : 'none'}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    citations.push({
+      episodeId: entry.episodeId,
+      ...(turn.conversationId !== undefined ? { conversationId: turn.conversationId } : {}),
+      ...(turn.occurredAt !== undefined ? { occurredAt: turn.occurredAt } : {}),
+      ...(span ? { span: { start: span.start, end: span.end, exact: span.exact } } : {}),
+    });
+    counts[span ? 'span_anchored' : 'episode_only'] += 1;
+  }
+  return { citations, counts };
+}
+
+/** Defensive shape check on one generator-emitted entry; a malformed row
+ *  (no string episodeId) resolves to null and counts as dropped. */
+function parseEntry(raw: unknown): { episodeId: string; quote: string } | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const episodeId = (raw as { episodeId?: unknown }).episodeId;
+  if (typeof episodeId !== 'string' || episodeId.length === 0) return null;
+  const quote = (raw as { quote?: unknown }).quote;
+  return { episodeId, quote: typeof quote === 'string' ? quote : '' };
+}

--- a/src/synthesize/l3-escalation.service.ts
+++ b/src/synthesize/l3-escalation.service.ts
@@ -12,10 +12,12 @@ import type { SearchHit } from '../search/search.service';
 import type { RetrievalProfile, LaneId } from '../search/retrieval-profile';
 import { parseQueryTimeRange } from '../search/internals/time-range';
 import type { SynthesizeDto } from './dto/synthesize.dto';
+import { l3EpisodeCitationsEnabled } from '../common/fovea-flags';
 import { runVerifier, type VerifierOutput } from './verifier';
 import { resolveCitations } from './synthesize.helpers';
 import type { Citation } from './fact-index';
-import type { GeneratorOutput } from './synthesize.types';
+import type { EvidenceCitation, GeneratorOutput } from './synthesize.types';
+import { resolveEpisodeCitations, type CitableTurn } from './l3-citations';
 import { SegmentLaneService } from './segment-lane.service';
 import {
   l3TriggerDecision,
@@ -66,11 +68,21 @@ import {
 interface L3Context {
   transcriptLines: string[];
   degraded: boolean;
+  /**
+   * episodeId → rendered-turn info for the evidence-citation resolver.
+   * Populated ONLY when FOVEA_L3_EPISODE_CITATIONS is on; contains
+   * EXACTLY the turns rendered into transcriptLines — the fence set of
+   * resolveEpisodeCitations (only readable, rendered turns are citable).
+   */
+  turnsById: Map<string, CitableTurn>;
 }
 
 /** Minimal turn shape shared by conversationTurns and windowAround rows. */
 interface L3Turn {
   id?: unknown;
+  /** Present on windowAround rows (the degrade path); the full-session
+   *  path carries the conversation on the session wrapper instead. */
+  conversationId?: string;
   speaker?: string;
   text: string;
   occurredAt: Date | string;
@@ -118,16 +130,39 @@ export interface L3EscalateResult {
   verdict: VerifierOutput;
   answer: string;
   citations: Citation[];
+  /** Episode-level evidence citations for transcript-grounded claims
+   *  (FOVEA_L3_EPISODE_CITATIONS); always [] when the flag is off. */
+  evidenceCitations: EvidenceCitation[];
 }
 
-const L3_SYSTEM = `You are an answer synthesizer with access to FULL raw conversation transcripts.
+/**
+ * The L3 system prompt, split around rule 2 so the evidence-citation flag
+ * swaps ONLY the transcript-citation sentence: flag off concatenates to the
+ * historical prompt byte-for-byte (pinned by the L3 e2e), flag on replaces
+ * the exemption with the citedEpisodes instruction.
+ */
+const L3_SYSTEM_HEAD = `You are an answer synthesizer with access to FULL raw conversation transcripts.
 
 The extracted facts did not ground an answer, so you are given the complete raw sessions the relevant facts came from. Read the transcripts as the primary evidence and answer the user's query.
 1. Use ONLY information present in the provided transcripts and facts. Do NOT speculate or use outside knowledge.
-2. When a numbered fact supports a claim, inline its factId in square brackets EXACTLY as it appears (including the "knowledge_fact:" prefix) and mirror it into citedFactIds. Claims taken from the raw transcript need no citation.
+2. When a numbered fact supports a claim, inline its factId in square brackets EXACTLY as it appears (including the "knowledge_fact:" prefix) and mirror it into citedFactIds. `;
+
+/** Rule-2 tail, flag OFF: the historical transcript-citation exemption. */
+const L3_RULE2_EXEMPT = `Claims taken from the raw transcript need no citation.`;
+
+/** Rule-2 tail, flag ON: transcript-grounded claims cite their turn. */
+const L3_RULE2_EPISODE_CITE = `When a claim comes from the raw transcript, cite the supporting turn: add {episodeId, quote} to citedEpisodes — episodeId EXACTLY as it appears in the turn's [episode:...] header, quote a SHORT verbatim excerpt of that turn. When a numbered fact supports a claim, cite its factId as before.`;
+
+const L3_SYSTEM_TAIL = `
 3. If the transcripts do not answer the question, output the exact string "I don't have grounded evidence for that." with citedFactIds set to [].
 
 Output strictly the JSON shape requested by the schema. No preamble, no chain-of-thought.`;
+
+function l3SystemPrompt(episodeCitations: boolean): string {
+  return (
+    L3_SYSTEM_HEAD + (episodeCitations ? L3_RULE2_EPISODE_CITE : L3_RULE2_EXEMPT) + L3_SYSTEM_TAIL
+  );
+}
 
 /** How much wider than the raw-window span the L2 degrade reaches when
  *  full sessions blow the token cap (still bounded, still fenced). */
@@ -274,24 +309,45 @@ export class L3EscalationService {
         this.metrics?.countL3AnchorSource(s.source);
       }
     }
+    // Evidence citations (FOVEA_L3_EPISODE_CITATIONS): resolved ONCE per
+    // escalation so the transcript headers, the prompt/schema, and the
+    // resolver all see the same flag state within one request.
+    const episodeCitations = l3EpisodeCitationsEnabled();
     const ctx = await this.assembleContext(input, {
       sessionIds,
       episodeById,
       includePii,
       userId,
+      episodeCitations,
     });
     if (ctx.transcriptLines.length === 0) return null;
     if (ctx.degraded) this.metrics?.countL3Escalation('over_budget_degraded');
 
-    const generated = await this.generate(input, ctx.transcriptLines);
+    const generated = await this.generate(input, ctx.transcriptLines, episodeCitations);
     const citations = resolveCitations(generated.citedFactIds, generated.answer, input.factIndex);
+    const evidenceCitations = episodeCitations
+      ? this.resolveEvidence(generated.citedEpisodes, ctx.turnsById)
+      : [];
     const verdict = await this.verify(input, generated.answer, ctx);
     if (!verifierPasses(verdict, profile.verifierTopicCoverage)) {
       this.metrics?.countL3Escalation('no_flip');
       return null;
     }
     this.metrics?.countL3Escalation('flipped');
-    return { verdict, answer: generated.answer, citations };
+    return { verdict, answer: generated.answer, citations, evidenceCitations };
+  }
+
+  /** Resolve raw citedEpisodes via the pure fence (l3-citations.ts) and
+   *  emit the per-outcome telemetry. */
+  private resolveEvidence(
+    citedEpisodes: ReadonlyArray<unknown>,
+    turnsById: ReadonlyMap<string, CitableTurn>,
+  ): EvidenceCitation[] {
+    const { citations, counts } = resolveEpisodeCitations(citedEpisodes, turnsById);
+    for (const outcome of ['span_anchored', 'episode_only', 'dropped_unknown'] as const) {
+      if (counts[outcome] > 0) this.metrics?.countL3EpisodeCitation(outcome, counts[outcome]);
+    }
+    return citations;
   }
 
   /**
@@ -518,6 +574,9 @@ export class L3EscalationService {
       episodeById: Map<string, { conversationId: string; atMs?: number | undefined }>;
       includePii: boolean;
       userId?: string | undefined;
+      /** FOVEA_L3_EPISODE_CITATIONS: render [episode:...] turn headers
+       *  and collect the citable-turn map. */
+      episodeCitations: boolean;
     },
   ): Promise<L3Context> {
     const sessions = await Promise.all(
@@ -532,9 +591,13 @@ export class L3EscalationService {
           .then((turns) => ({ conversationId, turns })),
       ),
     );
-    const full = this.renderSessions(sessions);
+    const full = this.renderSessions(sessions, args.episodeCitations);
     if (estimateTokens(full.join('\n')) <= input.profile.l3TokenCap) {
-      return { transcriptLines: full, degraded: false };
+      return {
+        transcriptLines: full,
+        degraded: false,
+        turnsById: args.episodeCitations ? citableTurnsOf(sessions) : new Map(),
+      };
     }
     // Over budget: widen the L2 windows around the anchor turns of the
     // selected sessions (reuse windowAround) rather than truncating.
@@ -564,16 +627,30 @@ export class L3EscalationService {
         if (!byId.has(key)) byId.set(key, row);
       }
     }
+    const windowSessions = [{ conversationId: 'windows', turns: [...byId.values()] }];
     return {
-      transcriptLines: this.renderSessions([
-        { conversationId: 'windows', turns: [...byId.values()] },
-      ]),
+      transcriptLines: this.renderSessions(windowSessions, args.episodeCitations),
       degraded: true,
+      // windowAround rows carry their own conversationId, so the 'windows'
+      // pseudo-session name never reaches a citation.
+      turnsById: args.episodeCitations
+        ? citableTurnsOf(windowSessions.map((s) => ({ ...s, conversationId: undefined })))
+        : new Map(),
     };
   }
 
-  /** One fenced section per session, chronological dated turns. */
-  private renderSessions(sessions: Array<{ conversationId: string; turns: L3Turn[] }>): string[] {
+  /**
+   * One fenced section per session, chronological dated turns. With
+   * `episodeHeaders` (FOVEA_L3_EPISODE_CITATIONS) each turn line is
+   * prefixed with its `[episode:<id>]` header — the id the generator must
+   * echo into citedEpisodes — on BOTH the full-session and the degrade
+   * (windowAround) renders; a rare id-less row falls back to the plain
+   * line (uncitable but still evidence). Off ⇒ byte-identical lines.
+   */
+  private renderSessions(
+    sessions: Array<{ conversationId: string; turns: L3Turn[] }>,
+    episodeHeaders: boolean,
+  ): string[] {
     const lines: string[] = [];
     for (const s of sessions) {
       if (s.turns.length === 0) continue;
@@ -585,18 +662,23 @@ export class L3EscalationService {
         const day = String(
           t.occurredAt instanceof Date ? t.occurredAt.toISOString() : t.occurredAt,
         ).slice(0, 10);
-        lines.push(`[${day}] ${t.speaker ?? 'unknown'}: ${t.text}`);
+        const base = `[${day}] ${t.speaker ?? 'unknown'}: ${t.text}`;
+        lines.push(episodeHeaders && t.id !== undefined ? `[${String(t.id)}] ${base}` : base);
       }
     }
     return lines;
   }
 
   /** The ONE large-context generation. chatCallParams owns the token
-   *  policy (reasoningCap for the large context); no hand-rolled params. */
+   *  policy (reasoningCap for the large context); no hand-rolled params.
+   *  `episodeCitations` (FOVEA_L3_EPISODE_CITATIONS) swaps rule 2 of the
+   *  system prompt and adds `citedEpisodes` to the strict schema; off ⇒
+   *  prompt and schema byte-identical (pinned by the L3 e2e). */
   private async generate(
     input: L3EscalateInput,
     transcriptLines: string[],
-  ): Promise<GeneratorOutput> {
+    episodeCitations: boolean,
+  ): Promise<GeneratorOutput & { citedEpisodes: unknown[] }> {
     const sections = [
       `Full conversation transcripts:\n${transcriptLines.join('\n')}`,
       `Extracted facts (cite by factId when one supports a claim):\n${input.factLines.join('\n')}`,
@@ -606,8 +688,9 @@ export class L3EscalationService {
     }
     const langLine = input.answerLang ? `\n\nAnswer in ${input.answerLang}.` : '';
     const user = `Query: ${input.dto.query}\n\n${sections.join('\n\n')}${langLine}`;
+    const system = l3SystemPrompt(episodeCitations);
     traceArtifact('synthesize.l3_prompt', {
-      system: L3_SYSTEM,
+      system,
       user,
       model: input.model,
     });
@@ -624,7 +707,7 @@ export class L3EscalationService {
           {
             model: input.model,
             messages: [
-              { role: 'system', content: L3_SYSTEM },
+              { role: 'system', content: system },
               { role: 'user', content: user },
             ],
             response_format: {
@@ -638,8 +721,26 @@ export class L3EscalationService {
                   properties: {
                     answer: { type: 'string' },
                     citedFactIds: { type: 'array', items: { type: 'string' } },
+                    ...(episodeCitations
+                      ? {
+                          citedEpisodes: {
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                              additionalProperties: false,
+                              properties: {
+                                episodeId: { type: 'string' },
+                                quote: { type: 'string' },
+                              },
+                              required: ['episodeId', 'quote'],
+                            },
+                          },
+                        }
+                      : {}),
                   },
-                  required: ['answer', 'citedFactIds'],
+                  required: episodeCitations
+                    ? ['answer', 'citedFactIds', 'citedEpisodes']
+                    : ['answer', 'citedFactIds'],
                 },
               },
             },
@@ -656,13 +757,18 @@ export class L3EscalationService {
     );
     const content = res.choices[0]?.message?.content;
     if (!content) throw new Error('empty L3 generator response');
-    const parsed = JSON.parse(content) as GeneratorOutput;
+    const parsed = JSON.parse(content) as GeneratorOutput & { citedEpisodes?: unknown };
     if (typeof parsed.answer !== 'string') {
       throw new Error('L3 generator returned non-string answer');
     }
     if (!Array.isArray(parsed.citedFactIds)) parsed.citedFactIds = [];
     traceArtifact('synthesize.l3_output', parsed);
-    return parsed;
+    // Defensive parse: a non-array (or flag-off) citedEpisodes is [].
+    return {
+      ...parsed,
+      citedEpisodes:
+        episodeCitations && Array.isArray(parsed.citedEpisodes) ? parsed.citedEpisodes : [],
+    };
   }
 
   /** Re-run the SAME verifier over the L3 answer against the session
@@ -690,4 +796,32 @@ function toMs(v: Date | string | undefined): number | undefined {
   if (v === undefined) return undefined;
   const t = v instanceof Date ? v.getTime() : Date.parse(String(v));
   return Number.isNaN(t) ? undefined : t;
+}
+
+/**
+ * Collect the citable-turn map from EXACTLY the sessions renderSessions
+ * rendered — the anti-hallucination fence set of resolveEpisodeCitations
+ * (a turn absent here was never shown to the generator and can never be
+ * cited). Per-row conversationId (windowAround rows) wins over the
+ * session wrapper's; id-less rows are uncitable and skipped.
+ */
+function citableTurnsOf(
+  sessions: Array<{ conversationId: string | undefined; turns: L3Turn[] }>,
+): Map<string, CitableTurn> {
+  const map = new Map<string, CitableTurn>();
+  for (const s of sessions) {
+    for (const t of s.turns) {
+      if (t.id === undefined) continue;
+      const key = String(t.id);
+      if (map.has(key)) continue;
+      const conversationId = t.conversationId ?? s.conversationId;
+      const atMs = toMs(t.occurredAt);
+      map.set(key, {
+        text: t.text,
+        ...(conversationId !== undefined ? { conversationId } : {}),
+        ...(atMs !== undefined ? { occurredAt: new Date(atMs).toISOString() } : {}),
+      });
+    }
+  }
+  return map;
 }

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -570,6 +570,11 @@ export class SynthesizeService {
       {
         answer: l3.answer,
         citations: l3.citations,
+        // L3 evidence citations (FOVEA_L3_EPISODE_CITATIONS): episode-level
+        // refs for transcript-grounded claims — [] when the flag is off, so
+        // finalizeVerdict never spreads the field. The primary serve path
+        // passes nothing here.
+        evidenceCitations: l3.evidenceCitations,
         results: args.results,
         guardrails: args.guardrails,
         decisionLog: args.explain

--- a/src/synthesize/synthesize.types.ts
+++ b/src/synthesize/synthesize.types.ts
@@ -27,11 +27,38 @@ export interface TokenUsage {
   completionTokens: number;
 }
 
+/**
+ * L3 evidence citation (FOVEA_L3_EPISODE_CITATIONS): a transcript-grounded
+ * claim's reference to the stored episode turn it came from. `span`, when
+ * present, is a W3C-style VERIFIED span over the NFC-normalized STORED turn
+ * text, measured in Unicode code points — the span-anchor contract
+ * (src/admin/span-anchor.ts): `start` inclusive, `end` exclusive, `exact`
+ * the verified verbatim quote. An absent span = episodeId-only citation
+ * (the quote was missing, absent from the turn, or ambiguous — fail-safe,
+ * never a guessed highlight).
+ */
+export interface EvidenceCitation {
+  episodeId: string;
+  conversationId?: string;
+  occurredAt?: string;
+  span?: { start: number; end: number; exact: string };
+}
+
 export interface SynthesizeResult {
   answer: string | null;
   reason?: SynthesisReason;
   citations: Citation[];
   results: SearchHit[];
+  /**
+   * L3 evidence citations (FOVEA_L3_EPISODE_CITATIONS): episode-level
+   * references for the transcript-grounded claims of an L3-escalated
+   * answer. A SEPARATE array from `citations` — consumers of fact
+   * citations (answer-cache admit, multi-hop, agent-qa) read `c.factId`
+   * and must never see episode refs there. Present ONLY on a served L3
+   * answer that resolved ≥1 evidence citation; absent otherwise (and
+   * always absent when the flag is off).
+   */
+  evidenceCitations?: EvidenceCitation[];
   /**
    * Populated only when the request was made with `explain: true`. One
    * entry per retrieved fact, with score breakdown, retrieval-stage

--- a/src/synthesize/verdict.ts
+++ b/src/synthesize/verdict.ts
@@ -6,7 +6,12 @@ import { buildDecisionLog, type DecisionLogEntry } from './decision-log';
 import { assessMemoryCoverage, NOT_IN_MEMORY_ANSWER } from './abstention';
 import { attachDecisionLog } from './synthesize.helpers';
 import type { Citation } from './fact-index';
-import type { GeneratorOutput, SynthesisReason, SynthesizeResult } from './synthesize.types';
+import type {
+  EvidenceCitation,
+  GeneratorOutput,
+  SynthesisReason,
+  SynthesizeResult,
+} from './synthesize.types';
 
 /**
  * Verdict → response shaping, split out of synthesize.service.ts (the
@@ -79,6 +84,7 @@ export function finalizeVerdict(
     abstention,
     plausibilityDowngrade,
     requireCitations,
+    evidenceCitations,
   }: {
     verdict: 'supported' | 'partial' | 'unsupported';
     questionAnswered?: boolean | undefined;
@@ -92,6 +98,15 @@ export function finalizeVerdict(
     plausibilityDowngrade?: boolean | undefined;
     /** Part C: abstain a supported answer with zero citations. */
     requireCitations?: boolean | undefined;
+    /**
+     * L3 evidence citations (FOVEA_L3_EPISODE_CITATIONS): episode-level
+     * references for transcript-grounded claims, supplied ONLY by the L3
+     * flip path (the primary serve passes nothing). The Part C guard
+     * counts them as citations — an episode-cited answer serves — and the
+     * supported ok-path spreads them onto the served result when
+     * non-empty. Abstain/downgrade branches never carry them.
+     */
+    evidenceCitations?: EvidenceCitation[] | undefined;
   },
 ): SynthesizeResult {
   if (verdict === 'supported') {
@@ -130,8 +145,11 @@ export function finalizeVerdict(
     }
     // Part C (FOVEA_REQUIRE_CITATIONS): a supported answer with zero
     // citations breaks the citation-bearing promise (audit F2(b)) — abstain
-    // rather than serve an uncited "supported" answer. Off ⇒ byte-identical.
-    if (requireCitations && citations.length === 0) {
+    // rather than serve an uncited "supported" answer. An L3 answer whose
+    // transcript-grounded claims carry evidence citations
+    // (FOVEA_L3_EPISODE_CITATIONS) IS cited — it serves. Off ⇒
+    // byte-identical.
+    if (requireCitations && whollyUncited(citations, evidenceCitations)) {
       deps.metrics?.countSynthesize('low_coverage');
       deps.metrics?.countCitationGuardAbstain();
       return attachDecisionLog(
@@ -145,7 +163,12 @@ export function finalizeVerdict(
       );
     }
     deps.metrics?.countSynthesize('ok');
-    return attachDecisionLog({ answer, citations, results }, decisionLog);
+    // Evidence citations ride ONLY the supported serve (spread when
+    // non-empty); every abstain/downgrade shape above omits them.
+    return attachDecisionLog(
+      { answer, citations, results, ...evidenceField(evidenceCitations) },
+      decisionLog,
+    );
   }
   // V9 §4 'verifier' abstention: the verifier's verdict IS the
   // coverage signal — an unsupported/partial answer means the memory
@@ -172,6 +195,25 @@ export function finalizeVerdict(
   }
   // strict — fail closed.
   return attachDecisionLog({ answer: null, reason, citations: [], results }, decisionLog);
+}
+
+/** Part C predicate: zero fact citations AND zero evidence citations —
+ *  the wholly-uncited state the require-citations guard abstains. */
+function whollyUncited(
+  citations: Citation[],
+  evidenceCitations: EvidenceCitation[] | undefined,
+): boolean {
+  return (
+    citations.length === 0 && (evidenceCitations === undefined || evidenceCitations.length === 0)
+  );
+}
+
+/** The served-shape fragment: evidence citations spread only when
+ *  non-empty (an empty/absent array emits NO field). */
+function evidenceField(evidenceCitations: EvidenceCitation[] | undefined): {
+  evidenceCitations?: EvidenceCitation[];
+} {
+  return evidenceCitations && evidenceCitations.length > 0 ? { evidenceCitations } : {};
 }
 
 /**

--- a/test/answer-cache.unit-spec.ts
+++ b/test/answer-cache.unit-spec.ts
@@ -686,6 +686,19 @@ describe('AnswerCacheService.admit — admission rules', () => {
     ['abstention (null answer)', { ...grounded, answer: null }, 'supported'],
     ['reason-tagged return (low_coverage)', { ...grounded, reason: 'low_coverage' }, 'supported'],
     ['zero citations', { ...grounded, citations: [] }, 'supported'],
+    // FOVEA_L3_EPISODE_CITATIONS: an episode-only-cited L3 answer (zero
+    // FACT citations) is DELIBERATELY not admitted — check-on-read cannot
+    // invalidate episode citations, so caching it would be
+    // uninvalidatable (see admit()'s docblock).
+    [
+      'episode-only-cited (evidence citations, zero fact citations)',
+      {
+        ...grounded,
+        citations: [],
+        evidenceCitations: [{ episodeId: 'episode:ep1', conversationId: 'conv1' }],
+      },
+      'supported',
+    ],
   ] as Array<[string, SynthesizeResult, 'supported' | 'partial' | 'unsupported']>)(
     'never caches: %s',
     async (_name, result, verdict) => {

--- a/test/answer-integrity.unit-spec.ts
+++ b/test/answer-integrity.unit-spec.ts
@@ -187,6 +187,88 @@ describe('finalizeVerdict — Part C require-citations guard', () => {
   });
 });
 
+// ── L3 evidence citations × the require-citations guard ─────────────
+describe('finalizeVerdict — evidence citations (FOVEA_L3_EPISODE_CITATIONS)', () => {
+  const EVIDENCE = [
+    {
+      episodeId: 'episode:ep1',
+      conversationId: 'conv1',
+      span: { start: 0, end: 4, exact: 'safe' },
+    },
+  ];
+
+  it('requireCitations + zero fact citations + ≥1 evidence citation → SERVES, evidenceCitations on the result', () => {
+    const { deps, synth, counts } = fakeDeps();
+    const r = finalizeVerdict(deps, {
+      verdict: 'supported',
+      answer: 'A transcript-grounded answer.',
+      citations: [],
+      results: RESULTS,
+      guardrails: 'strict',
+      requireCitations: true,
+      evidenceCitations: EVIDENCE,
+    });
+    expect(r.answer).toBe('A transcript-grounded answer.');
+    expect(r.reason).toBeUndefined();
+    expect(r.evidenceCitations).toEqual(EVIDENCE);
+    expect(synth).toEqual(['ok']);
+    expect(counts.citationGuards).toBe(0);
+  });
+
+  it('requireCitations + zero of BOTH → abstains, and the abstain carries no evidenceCitations', () => {
+    const { deps, counts } = fakeDeps();
+    const r = finalizeVerdict(deps, {
+      verdict: 'supported',
+      answer: 'An uncited answer.',
+      citations: [],
+      results: RESULTS,
+      guardrails: 'strict',
+      requireCitations: true,
+      evidenceCitations: [],
+    });
+    expect(r.answer).toBe(NOT_IN_MEMORY_ANSWER);
+    expect(r.reason).toBe('low_coverage');
+    expect(r.evidenceCitations).toBeUndefined();
+    expect(counts.citationGuards).toBe(1);
+  });
+
+  it('plausibility downgrade never leaks evidenceCitations onto the abstain', () => {
+    const { deps } = fakeDeps();
+    const r = finalizeVerdict(deps, {
+      verdict: 'supported',
+      answer: 'A distorted answer.',
+      citations: [CITE],
+      results: RESULTS,
+      guardrails: 'strict',
+      plausibilityDowngrade: true,
+      evidenceCitations: EVIDENCE,
+    });
+    expect(r.answer).toBe(NOT_IN_MEMORY_ANSWER);
+    expect(r.evidenceCitations).toBeUndefined();
+  });
+
+  it('no evidence citations supplied (the primary path) → byte-identical serve, no field emitted', () => {
+    const { deps } = fakeDeps();
+    const ref = finalizeVerdict(fakeDeps().deps, {
+      verdict: 'supported',
+      answer: 'A cited answer.',
+      citations: [CITE],
+      results: RESULTS,
+      guardrails: 'strict',
+    });
+    const out = finalizeVerdict(deps, {
+      verdict: 'supported',
+      answer: 'A cited answer.',
+      citations: [CITE],
+      results: RESULTS,
+      guardrails: 'strict',
+      evidenceCitations: [],
+    });
+    expect(out).toEqual(ref);
+    expect('evidenceCitations' in out).toBe(false);
+  });
+});
+
 // ── the judge itself: parse + cost contract ─────────────────────────
 describe('runPlausibilityJudge — parse + one-call cost', () => {
   const base = {

--- a/test/l3-citations.unit-spec.ts
+++ b/test/l3-citations.unit-spec.ts
@@ -1,0 +1,125 @@
+/**
+ * L3 evidence citations (FOVEA_L3_EPISODE_CITATIONS) — the pure resolver
+ * (src/synthesize/l3-citations.ts). No IO, no flags: the fence property
+ * (only rendered turns are citable), the span-anchor contract (NFC,
+ * code-point offsets, fail-safe episodeId-only), dedupe, and the cap.
+ */
+import { resolveEpisodeCitations, type CitableTurn } from '../src/synthesize/l3-citations';
+
+const TURNS: ReadonlyMap<string, CitableTurn> = new Map([
+  [
+    'episode:ep1',
+    {
+      text: 'my tier is sapphire, confirmed last week',
+      conversationId: 'conv1',
+      occurredAt: '2026-04-01T10:00:00.000Z',
+    },
+  ],
+  ['episode:ep2', { text: 'twice twice — the word repeats', conversationId: 'conv1' }],
+]);
+
+describe('resolveEpisodeCitations — fence, spans, dedupe, cap', () => {
+  it('drops an episodeId not in the rendered-turn map (the anti-hallucination fence) and counts it', () => {
+    const { citations, counts } = resolveEpisodeCitations(
+      [
+        { episodeId: 'episode:ghost', quote: 'anything' },
+        { episodeId: 'episode:ep1', quote: 'tier is sapphire' },
+      ],
+      TURNS,
+    );
+    expect(citations.map((c) => c.episodeId)).toEqual(['episode:ep1']);
+    expect(counts.dropped_unknown).toBe(1);
+    expect(counts.span_anchored).toBe(1);
+  });
+
+  it('counts malformed entries (no string episodeId) as dropped', () => {
+    const { citations, counts } = resolveEpisodeCitations(
+      [null, 42, { quote: 'no id' }, { episodeId: '' }],
+      TURNS,
+    );
+    expect(citations).toEqual([]);
+    expect(counts.dropped_unknown).toBe(4);
+  });
+
+  it('anchors a verifiable quote → span with code-point offsets over the NFC text', () => {
+    const { citations } = resolveEpisodeCitations(
+      [{ episodeId: 'episode:ep1', quote: 'tier is sapphire' }],
+      TURNS,
+    );
+    expect(citations).toEqual([
+      {
+        episodeId: 'episode:ep1',
+        conversationId: 'conv1',
+        occurredAt: '2026-04-01T10:00:00.000Z',
+        span: { start: 3, end: 19, exact: 'tier is sapphire' },
+      },
+    ]);
+  });
+
+  it('offsets are CODE POINTS, not UTF-16 units (astral chars count once)', () => {
+    const turns = new Map<string, CitableTurn>([
+      ['episode:astral', { text: '𝄞𝄞 note: the clef sings' }],
+    ]);
+    const { citations } = resolveEpisodeCitations(
+      [{ episodeId: 'episode:astral', quote: 'the clef' }],
+      turns,
+    );
+    // '𝄞𝄞 note: ' = 9 code points (each 𝄞 is ONE position, 2 UTF-16 units).
+    expect(citations[0]?.span).toEqual({ start: 9, end: 17, exact: 'the clef' });
+  });
+
+  it('ambiguous quote (2+ occurrences) → episodeId-only citation, counted episode_only', () => {
+    const { citations, counts } = resolveEpisodeCitations(
+      [{ episodeId: 'episode:ep2', quote: 'twice' }],
+      TURNS,
+    );
+    expect(citations).toEqual([{ episodeId: 'episode:ep2', conversationId: 'conv1' }]);
+    expect(counts.episode_only).toBe(1);
+    expect(counts.span_anchored).toBe(0);
+  });
+
+  it('absent/empty quote → episodeId-only citation (fail-safe, never a guessed span)', () => {
+    const { citations, counts } = resolveEpisodeCitations(
+      [
+        { episodeId: 'episode:ep1', quote: 'not in the turn at all' },
+        { episodeId: 'episode:ep2', quote: '' },
+      ],
+      TURNS,
+    );
+    expect(citations.every((c) => c.span === undefined)).toBe(true);
+    expect(counts.episode_only).toBe(2);
+  });
+
+  it('dedupes by (episodeId, span?.start): same span once, distinct spans kept', () => {
+    const { citations, counts } = resolveEpisodeCitations(
+      [
+        { episodeId: 'episode:ep1', quote: 'tier is sapphire' },
+        { episodeId: 'episode:ep1', quote: 'tier is sapphire' }, // same span → dropped
+        { episodeId: 'episode:ep1', quote: 'confirmed last week' }, // other span → kept
+        { episodeId: 'episode:ep1', quote: 'not present' }, // episodeId-only
+        { episodeId: 'episode:ep1', quote: 'also not present' }, // dup episodeId-only → dropped
+      ],
+      TURNS,
+    );
+    expect(citations).toHaveLength(3);
+    expect(counts.span_anchored).toBe(2);
+    expect(counts.episode_only).toBe(1);
+  });
+
+  it('caps the resolved citations at 16', () => {
+    const turns = new Map<string, CitableTurn>(
+      Array.from({ length: 25 }, (_, i): [string, CitableTurn] => [
+        `episode:e${i}`,
+        { text: `turn number ${i} content` },
+      ]),
+    );
+    const { citations } = resolveEpisodeCitations(
+      Array.from({ length: 25 }, (_, i) => ({
+        episodeId: `episode:e${i}`,
+        quote: `turn number ${i}`,
+      })),
+      turns,
+    );
+    expect(citations).toHaveLength(16);
+  });
+});

--- a/test/l3-escalation.e2e-spec.ts
+++ b/test/l3-escalation.e2e-spec.ts
@@ -74,6 +74,15 @@ describe('G2 L3 escalation e2e', () => {
     return m ? parseInt(m[1]!, 10) : 0;
   }
 
+  async function episodeCitationCount(app: AppFixture, outcome: string): Promise<number> {
+    const metrics = app.app.get(MetricsService);
+    const { body } = await metrics.serialize();
+    const m = body.match(
+      new RegExp(`brain_l3_episode_citation_total\\{outcome="${outcome}"\\} (\\d+)`),
+    );
+    return m ? parseInt(m[1]!, 10) : 0;
+  }
+
   // A flipping L3 re-verification (supported + answering).
   const L3_VERIFY_PASS = JSON.stringify({
     verdict: 'supported',
@@ -224,6 +233,7 @@ describe('G2 L3 escalation e2e', () => {
   afterEach(() => {
     delete process.env.FOVEA_PLAUSIBILITY_CHECK;
     delete process.env.FOVEA_REQUIRE_CITATIONS;
+    delete process.env.FOVEA_L3_EPISODE_CITATIONS;
     delete process.env.RETRIEVAL_L3_DIRECT_ANCHOR;
     delete process.env.RETRIEVAL_L3_SEGMENT_ANCHOR;
     delete process.env.RETRIEVAL_L3_TEMPORAL_ANCHOR;
@@ -236,6 +246,7 @@ describe('G2 L3 escalation e2e', () => {
     delete process.env.RETRIEVAL_L3_TEMPORAL_ANCHOR;
     delete process.env.FOVEA_PLAUSIBILITY_CHECK;
     delete process.env.FOVEA_REQUIRE_CITATIONS;
+    delete process.env.FOVEA_L3_EPISODE_CITATIONS;
     if (f) await f.close();
     if (f2) await f2.close();
   });
@@ -493,5 +504,163 @@ describe('G2 L3 escalation e2e', () => {
     expect(state.calls[2]!.user).not.toContain('conv_l3_direct');
     expect(await l3Count(f2, 'fired')).toBe(firedBefore + 1);
     expect(await anchorSourceCount(f2, 'temporal')).toBe(temporalBefore + 1);
+  });
+
+  // ── L3 evidence citations (FOVEA_L3_EPISODE_CITATIONS) ────────────
+  // Gap #4: rule 2's transcript-citation exemption. Flag on, transcript-
+  // grounded claims cite {episodeId, quote} pairs resolved into
+  // span-verified evidence citations; flag off is pinned byte-identical.
+
+  // The historical L3 system prompt, pinned byte-for-byte: any flag-off
+  // drift in the prompt (rule 2's exemption included) fails here.
+  const L3_SYSTEM_PINNED = `You are an answer synthesizer with access to FULL raw conversation transcripts.
+
+The extracted facts did not ground an answer, so you are given the complete raw sessions the relevant facts came from. Read the transcripts as the primary evidence and answer the user's query.
+1. Use ONLY information present in the provided transcripts and facts. Do NOT speculate or use outside knowledge.
+2. When a numbered fact supports a claim, inline its factId in square brackets EXACTLY as it appears (including the "knowledge_fact:" prefix) and mirror it into citedFactIds. Claims taken from the raw transcript need no citation.
+3. If the transcripts do not answer the question, output the exact string "I don't have grounded evidence for that." with citedFactIds set to [].
+
+Output strictly the JSON shape requested by the schema. No preamble, no chain-of-thought.`;
+
+  /** The captured L3 request, narrowed to prompt + schema assertions. */
+  interface CapturedL3Request {
+    response_format: { json_schema: { schema: unknown } };
+  }
+
+  it('episode-citations flag OFF → L3 prompt + schema + transcript lines byte-identical (pinned)', async () => {
+    process.env.RETRIEVAL_L3_ESCALATION = '1';
+    const state = mockSynthesizeOpenAi(f.app, [
+      R1_GEN,
+      R1_VERIFY,
+      JSON.stringify({ answer: L3_ANSWER, citedFactIds: [anchoredFactId] }),
+      L3_VERIFY_PASS,
+    ]);
+    const res = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: ANCHOR_QUERY, limit: 5 });
+    expect(res.status).toBe(201);
+    expect(res.body.answer).toBe(L3_ANSWER);
+    // No evidenceCitations field is ever emitted with the flag off.
+    expect(res.body.evidenceCitations).toBeUndefined();
+    // The system prompt is the historical one, byte-for-byte.
+    expect(state.calls[2]!.system).toBe(L3_SYSTEM_PINNED);
+    // The strict JSON schema is the historical two-field shape.
+    const req = state.calls[2]!.request as CapturedL3Request;
+    expect(req.response_format.json_schema.schema).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        answer: { type: 'string' },
+        citedFactIds: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['answer', 'citedFactIds'],
+    });
+    // And the transcript lines carry no [episode:...] headers.
+    expect(state.calls[2]!.user).not.toContain('[episode:');
+  });
+
+  it('flag ON → [episode:...] headers; citedEpisodes → evidenceCitations end-to-end; hallucinated id never surfaces', async () => {
+    process.env.RETRIEVAL_L3_ESCALATION = '1';
+    process.env.FOVEA_L3_EPISODE_CITATIONS = '1';
+    const spanBefore = await episodeCitationCount(f, 'span_anchored');
+    const droppedBefore = await episodeCitationCount(f, 'dropped_unknown');
+    const quote = `My tier is ${ANCHOR_OBJECT}`;
+    const state = mockSynthesizeOpenAi(f.app, [
+      R1_GEN,
+      R1_VERIFY,
+      JSON.stringify({
+        answer: L3_ANSWER,
+        citedFactIds: [anchoredFactId],
+        citedEpisodes: [
+          { episodeId: 'episode:l3ep1', quote },
+          // A hallucinated id — never rendered into the transcript, must
+          // be dropped by the fence and never surface in the response.
+          { episodeId: 'episode:ghost_l3', quote: 'anything' },
+        ],
+      }),
+      L3_VERIFY_PASS,
+    ]);
+    const res = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: ANCHOR_QUERY, limit: 5 });
+    expect(res.status).toBe(201);
+    expect(res.body.answer).toBe(L3_ANSWER);
+    // The transcript lines carry the per-turn episode headers.
+    expect(state.calls[2]!.user).toContain('[episode:l3ep1]');
+    expect(state.calls[2]!.user).toContain('[episode:l3ep2]');
+    // The fact citation is untouched; the evidence citation resolved with
+    // a verified code-point span over the stored turn text.
+    expect(res.body.citations.map((c: { factId: string }) => c.factId)).toContain(anchoredFactId);
+    expect(res.body.evidenceCitations).toEqual([
+      {
+        episodeId: 'episode:l3ep1',
+        conversationId: 'conv_l3',
+        occurredAt: '2026-04-01T10:00:00.000Z',
+        span: { start: 0, end: [...quote].length, exact: quote },
+      },
+    ]);
+    expect(JSON.stringify(res.body)).not.toContain('ghost_l3');
+    expect(await episodeCitationCount(f, 'span_anchored')).toBe(spanBefore + 1);
+    expect(await episodeCitationCount(f, 'dropped_unknown')).toBe(droppedBefore + 1);
+  });
+
+  it('FOVEA_REQUIRE_CITATIONS + zero fact citations + ≥1 evidence citation → SERVES', async () => {
+    process.env.RETRIEVAL_L3_ESCALATION = '1';
+    process.env.FOVEA_L3_EPISODE_CITATIONS = '1';
+    process.env.FOVEA_REQUIRE_CITATIONS = '1';
+    const guardBefore = await counter(f, 'brain_citation_guard_abstain_total');
+    const quote = `you are on ${ANCHOR_OBJECT}`;
+    const state = mockSynthesizeOpenAi(f.app, [
+      R1_GEN,
+      R1_VERIFY,
+      JSON.stringify({
+        answer: L3_ANSWER,
+        citedFactIds: [] as string[],
+        citedEpisodes: [{ episodeId: 'episode:l3ep2', quote }],
+      }),
+      L3_VERIFY_PASS,
+    ]);
+    const res = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: ANCHOR_QUERY, limit: 5 });
+    expect(res.status).toBe(201);
+    // Episode-cited ⇒ the require-citations guard counts it as cited.
+    expect(res.body.answer).toBe(L3_ANSWER);
+    expect(res.body.reason).toBeUndefined();
+    expect(res.body.citations).toEqual([]);
+    expect(res.body.evidenceCitations).toHaveLength(1);
+    expect(res.body.evidenceCitations[0].episodeId).toBe('episode:l3ep2');
+    expect(state.calls.length).toBe(4);
+    expect(await counter(f, 'brain_citation_guard_abstain_total')).toBe(guardBefore);
+  });
+
+  it('FOVEA_REQUIRE_CITATIONS + zero of BOTH → abstains, and the abstain carries no evidenceCitations', async () => {
+    process.env.RETRIEVAL_L3_ESCALATION = '1';
+    process.env.FOVEA_L3_EPISODE_CITATIONS = '1';
+    process.env.FOVEA_REQUIRE_CITATIONS = '1';
+    const guardBefore = await counter(f, 'brain_citation_guard_abstain_total');
+    mockSynthesizeOpenAi(f.app, [
+      R1_GEN,
+      R1_VERIFY,
+      JSON.stringify({
+        answer: L3_ANSWER,
+        citedFactIds: [] as string[],
+        citedEpisodes: [] as Array<{ episodeId: string; quote: string }>,
+      }),
+      L3_VERIFY_PASS,
+    ]);
+    const res = await f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ query: ANCHOR_QUERY, limit: 5 });
+    expect(res.status).toBe(201);
+    expect(res.body.answer).not.toBe(L3_ANSWER);
+    expect(res.body.reason).toBe('low_coverage');
+    expect(res.body.citations ?? []).toEqual([]);
+    expect(res.body.evidenceCitations).toBeUndefined();
+    expect(await counter(f, 'brain_citation_guard_abstain_total')).toBe(guardBefore + 1);
   });
 });

--- a/test/l3-escalation.unit-spec.ts
+++ b/test/l3-escalation.unit-spec.ts
@@ -348,6 +348,8 @@ interface Mocks {
   outcomes: string[];
   triggerPaths: string[];
   anchorSources: string[];
+  /** One entry per counted episode-citation outcome (n expanded). */
+  episodeCitationOutcomes: string[];
   windowAroundCalls: number;
   conversationTurnsCalls: number;
   searchTextCalls: number;
@@ -355,21 +357,24 @@ interface Mocks {
   segmentAnchorCalls: number;
 }
 
-function fakeOpenAi(responses: string[]): OpenAI {
+function fakeOpenAi(responses: string[], captured?: unknown[]): OpenAI {
   let i = 0;
   return {
     chat: {
       completions: {
-        create: async () => ({
-          id: 'stub',
-          choices: [
-            {
-              message: {
-                content: responses[i++] ?? responses[responses.length - 1],
+        create: async (req: unknown) => {
+          captured?.push(req);
+          return {
+            id: 'stub',
+            choices: [
+              {
+                message: {
+                  content: responses[i++] ?? responses[responses.length - 1],
+                },
               },
-            },
-          ],
-        }),
+            ],
+          };
+        },
       },
     },
   } as unknown as OpenAI;
@@ -397,7 +402,13 @@ function makeService(opts: {
     string,
     Array<{ id: string; speaker: string; text: string; occurredAt: string }>
   >;
-  windowTurns?: Array<{ id: string; speaker: string; text: string; occurredAt: string }>;
+  windowTurns?: Array<{
+    id: string;
+    conversationId?: string;
+    speaker: string;
+    text: string;
+    occurredAt: string;
+  }>;
   /** Rows the direct-anchor BM25 probe (episodes.searchText) returns. */
   searchTextRows?: Array<{
     id: string;
@@ -416,6 +427,7 @@ function makeService(opts: {
     outcomes: [],
     triggerPaths: [],
     anchorSources: [],
+    episodeCitationOutcomes: [],
     windowAroundCalls: 0,
     conversationTurnsCalls: 0,
     searchTextCalls: 0,
@@ -449,6 +461,9 @@ function makeService(opts: {
     countL3Escalation: (o: string) => mocks.outcomes.push(o),
     countL3TriggerPath: (p: string) => mocks.triggerPaths.push(p),
     countL3AnchorSource: (s: string) => mocks.anchorSources.push(s),
+    countL3EpisodeCitation: (o: string, n = 1) => {
+      for (let k = 0; k < n; k++) mocks.episodeCitationOutcomes.push(o);
+    },
     recordOpenAiCall: () => {},
   } as unknown as MetricsService;
   const segments = opts.segmentAnchors
@@ -953,5 +968,162 @@ describe('L3EscalationService — auxiliary anchor sources', () => {
       expect(mocks.conversationsInRangeCalls).toBe(1);
       expect(mocks.anchorSources).toEqual(['temporal']);
     }
+  });
+});
+
+// ── service: L3 evidence citations (FOVEA_L3_EPISODE_CITATIONS) ─────
+describe('L3EscalationService — evidence citations', () => {
+  afterEach(() => {
+    delete process.env.FOVEA_L3_EPISODE_CITATIONS;
+  });
+
+  /** The captured L3 generator request, narrowed for assertions. */
+  interface CapturedL3Request {
+    messages: Array<{ role: string; content: string }>;
+    response_format: {
+      json_schema: { schema: { properties: Record<string, unknown>; required: string[] } };
+    };
+  }
+
+  const oneTurnSetup = () => ({
+    factEps: [{ id: FACT_ID, eps: ['episode:ep1'] }],
+    episodesByIds: [
+      { id: 'episode:ep1', conversationId: 'conv1', occurredAt: '2026-04-01T00:00:00Z' },
+    ],
+    sessionTurns: {
+      conv1: [
+        {
+          id: 'episode:ep1',
+          speaker: 'user',
+          text: 'my tier is sapphire',
+          occurredAt: '2026-04-01T00:00:00Z',
+        },
+      ],
+    },
+  });
+
+  it('flag OFF (default) → evidenceCitations [], and prompt/schema/lines byte-identical', async () => {
+    const captured: unknown[] = [];
+    const { service } = makeService(oneTurnSetup());
+    const openai = fakeOpenAi(
+      [
+        JSON.stringify({ answer: 'The tier is sapphire.', citedFactIds: [FACT_ID] }),
+        JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+      ],
+      captured,
+    );
+    const out = await service.escalate(baseInput(openai, makeProfile({})));
+    expect(out?.evidenceCitations).toEqual([]);
+    const req = captured[0] as CapturedL3Request;
+    // Rule 2 keeps the historical transcript-citation exemption verbatim.
+    expect(req.messages[0]!.content).toContain(
+      'Claims taken from the raw transcript need no citation.',
+    );
+    expect(req.messages[0]!.content).not.toContain('citedEpisodes');
+    // The strict schema is exactly the historical two-field shape.
+    expect(req.response_format.json_schema.schema.properties).toEqual({
+      answer: { type: 'string' },
+      citedFactIds: { type: 'array', items: { type: 'string' } },
+    });
+    expect(req.response_format.json_schema.schema.required).toEqual(['answer', 'citedFactIds']);
+    // Transcript lines carry no [episode:...] headers.
+    expect(req.messages[1]!.content).toContain('[2026-04-01] user: my tier is sapphire');
+    expect(req.messages[1]!.content).not.toContain('[episode:');
+  });
+
+  it('flag ON → [episode:...] headers, citedEpisodes in schema+required, spans resolved, hallucinated id dropped', async () => {
+    process.env.FOVEA_L3_EPISODE_CITATIONS = '1';
+    const captured: unknown[] = [];
+    const { service, mocks } = makeService(oneTurnSetup());
+    const openai = fakeOpenAi(
+      [
+        JSON.stringify({
+          answer: 'The tier is sapphire.',
+          citedFactIds: [],
+          citedEpisodes: [
+            { episodeId: 'episode:ep1', quote: 'tier is sapphire' },
+            { episodeId: 'episode:hallucinated', quote: 'anything at all' },
+          ],
+        }),
+        JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+      ],
+      captured,
+    );
+    const out = await service.escalate(baseInput(openai, makeProfile({})));
+    const req = captured[0] as CapturedL3Request;
+    // The transcript line now carries its stable episode header.
+    expect(req.messages[1]!.content).toContain(
+      '[episode:ep1] [2026-04-01] user: my tier is sapphire',
+    );
+    // Rule 2 swapped to the citedEpisodes instruction; schema gained the
+    // field in properties AND required (strict mode).
+    expect(req.messages[0]!.content).toContain('citedEpisodes');
+    expect(req.messages[0]!.content).not.toContain('need no citation');
+    expect(req.response_format.json_schema.schema.properties).toHaveProperty('citedEpisodes');
+    expect(req.response_format.json_schema.schema.required).toEqual([
+      'answer',
+      'citedFactIds',
+      'citedEpisodes',
+    ]);
+    // The known turn resolves to a span-anchored citation; the
+    // hallucinated id never surfaces (dropped + counted).
+    expect(out?.evidenceCitations).toEqual([
+      {
+        episodeId: 'episode:ep1',
+        conversationId: 'conv1',
+        occurredAt: '2026-04-01T00:00:00.000Z',
+        span: { start: 3, end: 19, exact: 'tier is sapphire' },
+      },
+    ]);
+    expect(mocks.episodeCitationOutcomes.sort()).toEqual(['dropped_unknown', 'span_anchored']);
+  });
+
+  it('flag ON, over-budget degrade → windowAround lines carry the SAME headers and stay citable', async () => {
+    process.env.FOVEA_L3_EPISODE_CITATIONS = '1';
+    const captured: unknown[] = [];
+    const bigText = 'x'.repeat(2000);
+    const { service, mocks } = makeService({
+      factEps: [{ id: FACT_ID, eps: ['episode:ep1'] }],
+      episodesByIds: [
+        { id: 'episode:ep1', conversationId: 'conv1', occurredAt: '2026-04-01T00:00:00Z' },
+      ],
+      sessionTurns: {
+        conv1: [
+          { id: 'episode:ep1', speaker: 'user', text: bigText, occurredAt: '2026-04-01T00:00:00Z' },
+        ],
+      },
+      windowTurns: [
+        {
+          id: 'episode:epw',
+          conversationId: 'conv1',
+          speaker: 'user',
+          text: 'tier is sapphire',
+          occurredAt: '2026-04-01T00:00:00Z',
+        },
+      ],
+    });
+    const openai = fakeOpenAi(
+      [
+        JSON.stringify({
+          answer: 'sapphire',
+          citedFactIds: [],
+          citedEpisodes: [{ episodeId: 'episode:epw', quote: 'sapphire' }],
+        }),
+        JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+      ],
+      captured,
+    );
+    const out = await service.escalate(baseInput(openai, makeProfile({ l3TokenCap: 10 })));
+    expect(mocks.outcomes).toEqual(['fired', 'over_budget_degraded', 'flipped']);
+    const req = captured[0] as CapturedL3Request;
+    expect(req.messages[1]!.content).toContain('[episode:epw] [2026-04-01] user: tier is sapphire');
+    expect(out?.evidenceCitations).toEqual([
+      {
+        episodeId: 'episode:epw',
+        conversationId: 'conv1',
+        occurredAt: '2026-04-01T00:00:00.000Z',
+        span: { start: 8, end: 16, exact: 'sapphire' },
+      },
+    ]);
   });
 });

--- a/test/test-doubles.ts
+++ b/test/test-doubles.ts
@@ -101,6 +101,11 @@ export interface OpenAiMockState {
     system: string;
     user: string;
     response: string;
+    /** The full raw request payload (messages + response_format + params)
+     *  — lets byte-identity tests pin the prompt AND the JSON schema the
+     *  service actually sent (e.g. the L3 evidence-citations flag-off
+     *  pin). */
+    request: unknown;
   }>;
 }
 
@@ -124,7 +129,7 @@ export function mockSynthesizeOpenAi(app: INestApplication, responses: string[])
           const user = req.messages.find((m) => m.role === 'user')?.content ?? '';
           const idx = state.calls.length;
           const content = responses[idx] ?? responses[responses.length - 1] ?? '{}';
-          state.calls.push({ system, user, response: content });
+          state.calls.push({ system, user, response: content, request: req });
           return { choices: [{ message: { content } }] };
         },
       },


### PR DESCRIPTION
## Summary

PR5 of the Brain v2 wave. Closes **gap #4: the L3 citation exemption**. `L3_SYSTEM` rule 2 said verbatim *"Claims taken from the raw transcript need no citation."* — so an L3 answer grounded on raw transcript evidence served with no reference trail, breaking the Evidence-plane contract that **every served claim must be unrollable to an observation**. This PR gives transcript-grounded claims stable episode references, behind `FOVEA_L3_EPISODE_CITATIONS` (default off).

When the flag is on:

- **Transcript headers**: `renderSessions` prefixes every L3 transcript line with its `[episode:<id>]` header — on the full-session render AND the over-budget `windowAround` degrade path identically.
- **Prompt + schema**: `L3_SYSTEM` is split into a shared base with two rule-2 variants; flag-on replaces the exemption sentence with a `citedEpisodes` instruction ({episodeId, quote} pairs, episodeId exactly as it appears in the header). The strict JSON schema gains `citedEpisodes: [{episodeId, quote}]` in `properties` AND `required`; parsed defensively (`Array.isArray` fallback `[]`).
- **Resolution** (new pure `src/synthesize/l3-citations.ts`): `resolveEpisodeCitations` anchors each quote against the STORED turn text via the existing `anchorQuote` (NFC, code-point offsets, W3C-style spans); an unverifiable/ambiguous quote degrades to an episodeId-only citation. Deduped by (episodeId, span start), capped at 16.
- **Result surface**: `SynthesizeResult` gains an OPTIONAL `evidenceCitations?: EvidenceCitation[]` — a SEPARATE array, never unioned into `Citation`, so every `c.factId` consumer (answer-cache admit, multi-hop, agent-qa) is untouched. Synthesize is not in the OpenAPI contracts (verified: `src/contracts/` has no synthesize schema); the HTTP/MCP surface passes the result object through additively.

## The anti-hallucination fence

Only turns **actually rendered into the transcript** are citable: the resolver's `turnsById` map is built from exactly the rows the fenced episode reads returned (`conversationTurns` / `windowAround`, which already enforce the PII / user-scope / scope-tag gates). Any episodeId the generator emits outside that set is dropped and counted (`dropped_unknown`) — an L3 citation can never name an episode the caller couldn't read, whether hallucinated or probed.

## REQUIRE_CITATIONS interaction

`finalizeVerdict`'s Part C guard becomes *"abstain only when fact citations AND evidence citations are both empty"*: an episode-cited transcript-grounded L3 answer now SERVES under `FOVEA_REQUIRE_CITATIONS` instead of abstaining (the previously documented consequence in `answer-integrity.ts:54-58`, now conditional on this flag being off). `evidenceCitations` are spread onto the supported serve only when non-empty; abstain/downgrade shapes never carry them. The plausibility judge (Part A) keeps auditing fact citations only — episode quotes are verbatim-verified mechanically by `anchorQuote` and carry no premise to audit.

## Cache non-admission (deliberate)

`answer-cache.admit` is unchanged: an episode-only-cited answer has `citations.length === 0` and is rejected by the existing gate. Check-on-read revalidates cited FACT rows against the live substrate and cannot (yet) invalidate episode citations, so caching such an answer would make it uninvalidatable. Documented in `admit()`'s docblock and pinned by a unit row in the never-caches table.

## Observability

`brain_l3_episode_citation_total{outcome=span_anchored|episode_only|dropped_unknown}` + `MetricsService.countL3EpisodeCitation` — a separate counter (the Optics-2 precedent), keeping `brain_l3_escalation_total`'s outcome series stable.

## Safety

- Default off; **flag-off is byte-identical and pinned**: the L3 e2e asserts the exact historical system prompt string, the exact two-field JSON schema, and header-free transcript lines against the captured mock request (`mockSynthesizeOpenAi` now records the raw request payload).
- The flag read lives in `src/common/fovea-flags.ts` (engine-gates S5.2), read once per escalation, runtime-mutable; registered in `KNOWN_BOOLEAN_FLAGS` + `CONFIG_CATALOG` (fovea section). FOVEA_ family sits off the engine flag budget.
- No paid LLM calls in tests (scripted mocks only).

## Test plan

- `test/l3-citations.unit-spec.ts` (new): unknown-id drop + count, span anchoring with code-point offsets (astral-char case), ambiguous/absent quote → episodeId-only, dedupe by (episodeId, span start), cap 16, malformed entries.
- `test/l3-escalation.unit-spec.ts`: flag OFF → captured generator request prompt/schema/lines identical (no `[episode:` headers, two-field schema); flag ON → headers + `citedEpisodes` in schema+required, evidenceCitations end-to-end, hallucinated id dropped + metric; degrade path renders the same headers and stays citable.
- `test/l3-escalation.e2e-spec.ts`: flag-off byte-identity PINNED (full system-prompt literal + schema deep-equal); flag-on end-to-end over real SurrealDB (headers, span-verified citation with conversationId/occurredAt, hallucinated id never in the response body, metrics); `FOVEA_REQUIRE_CITATIONS=1` + zero fact citations + ≥1 evidence citation → SERVES; zero of both → abstains with no `evidenceCitations` on the abstain.
- `test/answer-integrity.unit-spec.ts`: guard matrix incl. no-leak on plausibility downgrade and byte-identical primary serve.
- `test/answer-cache.unit-spec.ts`: episode-only-cited supported answer never admitted.

Verification: `pnpm typecheck` clean; full unit suite 296 suites / 2812 tests green; e2e `--testPathPatterns "l3"` 14/14 green + adjacent suites (`fovea-answer-integrity`, `fovea-adaptive-l3`, `answer-cache`) green; `prettier --check "src/**/*.ts" "test/**/*.ts"` clean; eslint clean on touched files.

## Base branch

Based on `feat/l3-anchor-independence` (PR #373, L3 anchor independence) — **retarget to `main` after #373 merges**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB