### PR TITLE
feat(compaction): per-tenant retention overrides + promotion corroboration floor + conflict guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -512,6 +512,17 @@ SYNTHESIZE_MIN_CONFIDENCE=0.30
 #COMPACTION_PROMOTION_AGE_DAYS=180
 #COMPACTION_PROMOTION_MIN_GROUP=5
 #COMPACTION_PROMOTION_MAX_GROUPS=20
+# Consolidation gate (Brain v2 PR8). MIN_EPISODES = corroboration floor:
+# minimum DISTINCT evidence contexts (union of member source.episodeIds +
+# source.conversationId) a group must span before folding — five facts from
+# one conversation are one witness, not five; 0 = off. CONFLICT_GUARD: a
+# group with sibling status=competing rows aborts loudly instead of folding.
+#COMPACTION_PROMOTION_MIN_EPISODES=0
+#COMPACTION_PROMOTION_CONFLICT_GUARD=0
+# Per-tenant retention/promotion schedule (JSON: companyId → partial
+# override { hotRetentionDays?, promotionAgeDays?, promotionMinGroup?,
+# promotionMinEpisodes? }); malformed entries fail open to the globals.
+#COMPACTION_TENANT_OVERRIDES=
 # HNSW vector index (opt-in per tenant via POST /v1/admin/maintenance/hnsw).
 # The flag only switches the KNN leg on; tenants without an index fall back
 # to the full scan. OVERFETCH/EF trade recall for speed. Swapping the

--- a/docs/roadmap/brain-v2-resolution-2026-08.md
+++ b/docs/roadmap/brain-v2-resolution-2026-08.md
@@ -1,0 +1,118 @@
+# Brain v2 — Retention as resolution: the tier ladder as SERVING policy (2026-08)
+
+Companion to [brain-v2-2026-08.md](brain-v2-2026-08.md) (the wave doc — this is PR8's
+design note), [memory-research-2026-08.md](memory-research-2026-08.md) (§8-9, the fovea
+cascade this ladder extends downward), and [fovea-optics-2026-08.md](fovea-optics-2026-08.md)
+(the read-side focusing policy; this doc is its storage-side mirror).
+
+The thesis: **retention is not deletion, it is resolution.** A memory's age changes how
+sharply it is _served_, never whether it _exists_. The L0-L3 ladder already states this
+for the read path (the same memory servable as semantic prior, fact index, raw window, or
+full session); the resolution tiers state it for the write/retention path — hot, warm,
+cold, and archive are serving contracts, not lifecycle stages. Nothing in this ladder is
+a delete: GDPR erasure (the forget/tombstone path) is the only mechanism that removes
+content, and it cuts across every tier identically.
+
+## 1. The ladder
+
+| Tier        | Serving contract                                                                                                                                  | Storage state                                                                                                                                                                                                                                                           | Status |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| **hot**     | Full serving: raw windows, episodes, facts, digests — every lane, every ladder rung (L0-L3)                                                       | Facts carry embeddings; episodes/segments servable (`src/search/retrieval-profile.ts:723` rawWindowSpan, `src/synthesize/l3-escalation.service.ts:126`)                                                                                                                 | today  |
+| **warm**    | Summaries serve in place of members; members leave every read surface but stay auditable and provenance-reachable                                 | Today's compacted state reframed: `status='compacted'`, embedding stripped (`src/compaction/compaction-runner.service.ts:147`), hidden by every read lane (`src/search/internals/where-builder.ts:192`), still walkable via `derivedFrom` (provenance closure, PR #371) | today  |
+| **cold**    | Schema + index only: the summary row plus an outcome-stat pointer serve; no BM25 body, no vector — a hit tells you _that_ and _where_, not _what_ | Future: summary + `memory_outcome_stat` pointer (0107), body evicted from the analyzed index                                                                                                                                                                            | future |
+| **archive** | Source pointer only: a stable reference to the evidence origin (export/blob/upstream system); serving requires explicit re-hydration              | Future                                                                                                                                                                                                                                                                  | future |
+
+The tier transitions are the existing compaction/promotion passes — this PR makes their
+schedule per-tenant and their consolidation honest; it does not add a tier column.
+"Which tier a row is in" stays derivable from row state (embedding presence, status,
+index membership), the same way L0-L3 are query-time choices rather than storage types.
+
+## 2. What ships in this PR (the per-tenant schedule + the consolidation gate)
+
+| Piece                                                                    | Where                                                           | Behavior                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `COMPACTION_TENANT_OVERRIDES` parser                                     | `src/compaction/compaction-overrides.ts`                        | JSON env mapping companyId → `{ hotRetentionDays?, promotionAgeDays?, promotionMinGroup?, promotionMinEpisodes? }`; call-time read, fail-open per tenant                                                                                                  |
+| Boot-shape validation                                                    | `src/common/env-validation.ts` (validateCompactionOverridesEnv) | Clones the RETRIEVAL_PROFILE_OVERRIDES shape check but WARNS, never throws — a malformed schedule degrades to the global one                                                                                                                              |
+| Hot-retention override                                                   | `src/compaction/compaction-runner.service.ts:89`                | `override.hotRetentionDays ?? COMPACTION_HOT_RETENTION_DAYS` (default 90)                                                                                                                                                                                 |
+| Promotion schedule override                                              | `src/compaction/promotion-runner.service.ts:119`                | `promotionAgeDays`/`promotionMinGroup` overlay the process defaults (180/5)                                                                                                                                                                               |
+| Corroboration floor (`COMPACTION_PROMOTION_MIN_EPISODES`, default 0=off) | `src/compaction/promotion-runner.service.ts:242`                | A group folds only when its members span ≥ N DISTINCT evidence contexts (union of member `source.episodeIds` + `source.conversationId`) — five facts from one conversation are one witness, not five; below the floor the group is skipped (logger.debug) |
+| Conflict guard (`COMPACTION_PROMOTION_CONFLICT_GUARD`, default off)      | `src/compaction/promotion-runner.service.ts:267`                | Sibling `status='competing'` rows on the same (entity, predicate, user-scope) ABORT the group loudly (logger.warn "contested group NOT promoted") — a contested group must never fold silently into one summary                                           |
+
+Gate order inside `promoteGroup`: corroboration floor → conflict guard → the existing
+summarize/create/compact flow. Everything is default-off/unset: with no env set, every
+query, log line, and written row is byte-identical to today (pinned in
+`test/promotion-gate.unit-spec.ts`).
+
+Why the gate belongs to the resolution story: demotion to warm is LOSSY for serving (the
+members leave the read surface; the summary is the only carrier). A lossy demotion is
+safe only when the summary genuinely consolidates — corroborated across independent
+evidence contexts, and uncontested. The floor and the guard are the two admission checks
+that make "warm" a consolidation, not a compression artifact.
+
+## 3. Strong-cue re-zoom (future, sketch)
+
+The ladder's missing rung: a strong retrieval cue on a warm/cold memory should be able to
+_re-sharpen_ it on demand — the storage-side mirror of L3 escalation.
+
+Sketch (no code in this wave):
+
+- **Trigger**: a warm summary is served as a top-ranked hit N times in a window
+  (`memory_outcome_stat` from PR6 is exactly this counter), or an L3 escalation lands in
+  a conversation whose facts are compacted.
+- **Act**: re-embed the summary's members (embeddings are derived state — the text never
+  left; `embedding = NONE` is reversible by construction) and/or re-run the recompose
+  pass over the group (`src/compaction/recompose.service.ts:171` invalidate → recompute
+  is the existing re-derive machinery to reuse).
+- **Bound**: per-tenant re-zoom budget per run (same shape as
+  `COMPACTION_PROMOTION_MAX_GROUPS`), and a demotion cooldown so a memory cannot
+  oscillate hot↔warm.
+- **Non-goal**: automatic un-compaction on every read — that would make retrieval
+  self-reinforcing again, the exact gap #7 failure mode PR7's verified-use signals exist
+  to close. Re-zoom keys off _verified_ use, never mere retrieval.
+
+## 4. Carve-out: resolution tiers and staleness are orthogonal, permanently
+
+Two mechanisms share the words "old summary" and must never be confused:
+
+- **Staleness (0072/0089) — a CORRECTNESS property.**
+  `src/db/migrations/0072_derived_staleness.surql:49` defines
+  `fn::mark_derived_stale`: when a parent fact is superseded/retracted, the
+  reverse-`derivedFrom` closure gets `staleAt`/`staleReason`, and the recompose pass
+  re-derives the artifact over its surviving parents.
+  `src/db/migrations/0089_staleness_event.surql:80` moves the marking to write time (a
+  four-clause storm-guarded DEFINE EVENT on the status transition); the nightly drain
+  (`src/compaction/recompose.service.ts:171`) stays as the backstop. A stale summary is
+  _possibly wrong_ and keeps serving only until recomputed.
+- **Resolution (this doc) — an ECONOMICS property.** A warm summary is _cheaper_, not
+  suspect. Demotion says nothing about truth; it says the tenant's schedule stopped
+  paying for full resolution.
+
+The carve-out, both directions:
+
+1. **Tier transitions never mark staleness.** Compaction/promotion set
+   `status='compacted'` on members in the same pass that creates their summary — 0089's
+   guard deliberately omits `'compacted'` from its transition vocabulary
+   (`0089_staleness_event.surql:36`, clause 3) precisely so demotion cannot mark every
+   summary stale at birth. Per-tenant schedules and the consolidation gate change _when_
+   and _whether_ that pass runs — they add no new status transitions, so the invariant
+   is untouched by this PR.
+2. **The staleness machinery never changes tiers.** `fn::mark_derived_stale` writes only
+   `staleAt`/`staleReason` (0072:54-62); recompose re-derives content and may retract an
+   orphan whose parents are all gone, but it never sets `status='compacted'`, never
+   strips an embedding for economic reasons, and never consults the retention schedule.
+
+A future cold tier keeps the same contract: eviction from the BM25 index is a serving
+decision and must not touch `staleAt`; a stale cold summary is simply both — cheap AND
+awaiting recompute — and the two flags resolve independently.
+
+## 5. Measurement posture
+
+Parked with the paid-eval budget, like the rest of the wave
+([brain-v2-2026-08.md](brain-v2-2026-08.md) §5). Nothing here flips a default. What the
+PR buys for free: a tenant-shaped retention schedule (an enterprise tenant can hold hot
+at 365d while a trial tenant compacts at 30d — one process), and promotion that cannot
+manufacture false confidence (single-witness groups and contested groups no longer fold).
+When the budget returns, the levers measure like every other lever — strict-currency,
+ablation-mined, full-pack confirm before any default flip; the natural first
+question is whether the corroboration floor changes summary-lane precision on the
+BEAM/LME summary classes.

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -213,6 +213,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: false,
     isBooleanFlag: true,
   },
+  {
+    key: 'COMPACTION_TENANT_OVERRIDES',
+    category: 'compaction',
+    defaultValue: null,
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Per-tenant retention/promotion schedule (Brain v2 PR8, docs/roadmap/brain-v2-resolution-2026-08.md): JSON object mapping companyId → { hotRetentionDays?, promotionAgeDays?, promotionMinGroup?, promotionMinEpisodes? } (positive ints; promotionMinEpisodes ≥ 0). Overrides the process-global COMPACTION_HOT_RETENTION_DAYS / COMPACTION_PROMOTION_AGE_DAYS / COMPACTION_PROMOTION_MIN_GROUP / COMPACTION_PROMOTION_MIN_EPISODES for that tenant only. RETRIEVAL_PROFILE_OVERRIDES idiom: boot-validated shape (warn, never throw), malformed entries fail open to the process defaults per tenant; read at call time, so the cron picks up changes without a restart.',
+  },
   // ── Audit / changefeed ────────────────────────────────────
   {
     key: 'AUDIT_CHANGEFEED_ENABLED',
@@ -2138,6 +2147,24 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     isBooleanFlag: true,
     description:
       'Promote old corroborated append_only fact groups into a durable summary. Bounded by COMPACTION_PROMOTION_MAX_GROUPS per run.',
+  },
+  {
+    key: 'COMPACTION_PROMOTION_MIN_EPISODES',
+    category: 'compaction',
+    defaultValue: '0',
+    runtimeMutable: false,
+    isBooleanFlag: false,
+    description:
+      'Corroboration floor of the promotion consolidation gate (Brain v2 PR8): minimum DISTINCT evidence contexts — union of the member facts’ source.episodeIds and source.conversationId — a group must span before it may fold into a summary. Five facts from one conversation are one witness, not five. 0 (default) = floor off, promotion byte-identical. Per-tenant override via COMPACTION_TENANT_OVERRIDES (promotionMinEpisodes).',
+  },
+  {
+    key: 'COMPACTION_PROMOTION_CONFLICT_GUARD',
+    category: 'compaction',
+    defaultValue: '0',
+    runtimeMutable: false,
+    isBooleanFlag: true,
+    description:
+      'Competing-evidence guard of the promotion consolidation gate (Brain v2 PR8): before folding a group, count sibling status=competing rows on the same (entity, predicate, user-scope); any hit ABORTS the group loudly (logger.warn "contested group NOT promoted") — a contested group must never fold silently into one summary. Off (default) = byte-identical promotion, no extra query.',
   },
   // ── Strategy-memory lane (G4) ────────────────────────────
   {

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -159,6 +159,12 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   positiveInt(env, 'COMPACTION_PROMOTION_AGE_DAYS', errors);
   positiveInt(env, 'COMPACTION_PROMOTION_MIN_GROUP', errors);
   positiveInt(env, 'COMPACTION_PROMOTION_MAX_GROUPS', errors);
+  // Corroboration floor of the promotion consolidation gate (Brain v2
+  // PR8). 0 is meaningful (= floor off, the default), so non-negative.
+  nonNegativeInt(env, 'COMPACTION_PROMOTION_MIN_EPISODES', errors);
+
+  // ── Per-tenant compaction schedule (COMPACTION_TENANT_OVERRIDES) ───
+  validateCompactionOverridesEnv(env, warnings);
 
   // ── HNSW vector leg ────────────────────────────────────────────────
   positiveInt(env, 'SEARCH_HNSW_EF', errors);
@@ -460,6 +466,41 @@ function validateRetrievalProfileEnv(env: NodeJS.ProcessEnv, errors: string[]): 
   }
 }
 
+/**
+ * COMPACTION_TENANT_OVERRIDES — the per-tenant retention/promotion
+ * schedule (Brain v2 PR8). Clones the RETRIEVAL_PROFILE_OVERRIDES shape
+ * check (JSON object mapping companyId → partial override), but WARNS
+ * instead of refusing to start: the parser fails open to the process
+ * defaults per tenant (src/compaction/compaction-overrides.ts), so a
+ * malformed value degrades to today's global schedule rather than
+ * breaking boot. Per-field validation stays lenient in the parser.
+ */
+function validateCompactionOverridesEnv(env: NodeJS.ProcessEnv, warnings: string[]): void {
+  const raw = env.COMPACTION_TENANT_OVERRIDES;
+  if (raw === undefined || raw.trim() === '') return;
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed) ||
+      Object.values(parsed).some((o) => o === null || typeof o !== 'object' || Array.isArray(o))
+    ) {
+      warnings.push(
+        'COMPACTION_TENANT_OVERRIDES must be a JSON object mapping ' +
+          'companyId → partial compaction schedule — ignoring it (every ' +
+          'tenant keeps the process-global retention/promotion defaults).',
+      );
+    }
+  } catch (e) {
+    warnings.push(
+      `COMPACTION_TENANT_OVERRIDES is not valid JSON: ${(e as Error).message} — ` +
+        'ignoring it (every tenant keeps the process-global ' +
+        'retention/promotion defaults).',
+    );
+  }
+}
+
 function validateBodySize(env: NodeJS.ProcessEnv, errors: string[]): void {
   const maxBody = env.MAX_BODY_SIZE;
   if (maxBody !== undefined && !/^\d+(\.\d+)?(b|kb|mb)?$/i.test(maxBody.trim())) {
@@ -654,6 +695,11 @@ const KNOWN_BOOLEAN_FLAGS = [
   'DREAMS_LLM_SUMMARY_ENABLED',
   'COMPACTION_PROMOTION_ENABLED',
   'COMPACTION_SUMMARIES',
+  // Promotion consolidation gate (Brain v2 PR8): a group with sibling
+  // COMPETING rows on the same (entity, predicate, user-scope) is NOT
+  // folded into a summary — it aborts loudly (logger.warn) and stays for
+  // the conflict engine to settle. Default off = byte-identical.
+  'COMPACTION_PROMOTION_CONFLICT_GUARD',
   'INGEST_INLINE_RESOLUTION_ENABLED',
   'INGEST_INLINE_RESOLUTION_HNSW',
   'EXTRACTOR_DROP_SAID',

--- a/src/compaction/compaction-overrides.ts
+++ b/src/compaction/compaction-overrides.ts
@@ -1,0 +1,72 @@
+/**
+ * COMPACTION_TENANT_OVERRIDES — the per-tenant resolution schedule
+ * (Brain v2 PR8, docs/roadmap/brain-v2-resolution-2026-08.md).
+ *
+ * The retention/promotion thresholds were process-global: one
+ * COMPACTION_HOT_RETENTION_DAYS for every tenant, one promotion age /
+ * group floor for every tenant. This JSON env converts them into a
+ * per-tenant schedule, following the RETRIEVAL_PROFILE_OVERRIDES idiom
+ * (JSON object mapping companyId → partial override; malformed entries
+ * fail open to the process defaults PER TENANT, the JSON shape itself is
+ * boot-validated — warn, never throw — in env-validation.ts).
+ *
+ * Read at call time, not boot: compaction sits outside the engine-gates
+ * S5.2 env-read boundary, and a call-time read keeps the schedule
+ * runtime-mutable (the cron picks up a changed env on its next run
+ * without a restart).
+ */
+export interface CompactionTenantOverride {
+  /** Overrides COMPACTION_HOT_RETENTION_DAYS for this tenant (positive int). */
+  hotRetentionDays?: number;
+  /** Overrides COMPACTION_PROMOTION_AGE_DAYS for this tenant (positive int). */
+  promotionAgeDays?: number;
+  /** Overrides COMPACTION_PROMOTION_MIN_GROUP for this tenant (positive int). */
+  promotionMinGroup?: number;
+  /**
+   * Overrides COMPACTION_PROMOTION_MIN_EPISODES for this tenant — the
+   * corroboration floor of the promotion consolidation gate (int ≥ 0;
+   * 0 = floor off).
+   */
+  promotionMinEpisodes?: number;
+}
+
+const POSITIVE_INT_FIELDS = ['hotRetentionDays', 'promotionAgeDays', 'promotionMinGroup'] as const;
+
+function intField(o: Record<string, unknown>, field: string, min: number): number | undefined {
+  const v = o[field];
+  return typeof v === 'number' && Number.isInteger(v) && v >= min ? v : undefined;
+}
+
+/**
+ * The tenant's validated partial override from COMPACTION_TENANT_OVERRIDES,
+ * or {} when the env is absent/malformed or holds no (valid) entry for
+ * this tenant. Field-lenient: an out-of-contract field value is dropped
+ * (that field falls back to the process default) rather than discarding
+ * the tenant's whole entry.
+ */
+export function compactionOverridesFor(
+  companyId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): CompactionTenantOverride {
+  const raw = env.COMPACTION_TENANT_OVERRIDES;
+  if (!raw || !raw.trim()) return {};
+  let overrides: unknown;
+  try {
+    overrides = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (overrides === null || typeof overrides !== 'object' || Array.isArray(overrides)) return {};
+  const entry = (overrides as Record<string, unknown>)[companyId];
+  if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) return {};
+  const o = entry as Record<string, unknown>;
+  const out: CompactionTenantOverride = {};
+  for (const field of POSITIVE_INT_FIELDS) {
+    const v = intField(o, field, 1);
+    if (v !== undefined) out[field] = v;
+  }
+  // 0 is meaningful here (= corroboration floor off for this tenant).
+  const minEpisodes = intField(o, 'promotionMinEpisodes', 0);
+  if (minEpisodes !== undefined) out.promotionMinEpisodes = minEpisodes;
+  return out;
+}

--- a/src/compaction/compaction-runner.service.ts
+++ b/src/compaction/compaction-runner.service.ts
@@ -9,6 +9,7 @@ import { CandidateFactRow, CompactionStats, SUMMARY_GENERATOR } from './compacti
 import { envFlagEnabled } from '../common/env-validation';
 import { summaryEpisodeStampEnabled } from '../common/provenance-flags';
 import { unionEpisodeIds } from '../common/episode-ids';
+import { compactionOverridesFor } from './compaction-overrides';
 
 /**
  * CompactionRunnerService — the retention engine.
@@ -81,12 +82,17 @@ export class CompactionRunnerService {
    *   3. UPDATE old facts: status = 'compacted', embedding = NONE.
    */
   async compactCompany(companyId: string): Promise<CompactionStats> {
+    // Per-tenant resolution schedule (COMPACTION_TENANT_OVERRIDES): a
+    // tenant entry overrides the process-global hot-retention window;
+    // unset = byte-identical to the ctor default.
+    const retentionDays =
+      compactionOverridesFor(companyId).hotRetentionDays ?? this.hotRetentionDays;
     // A Date param serialises as a native SurrealDB datetime. The previous
     // `d$cutoff` cast + ISO-string param was a 2.x idiom — SurrealDB 3.x
     // fails to PARSE it ("Unexpected token `a parameter`"), which made
     // every compaction pass throw (and log-and-skip) since the 3.1.5
     // upgrade. Caught by the promotion e2e reusing the same idiom.
-    const cutoff = new Date(Date.now() - this.hotRetentionDays * 24 * 60 * 60 * 1000);
+    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
 
     // Audit W2 #10: compaction used to be version-BLIND. Under a pinned
     // derived world it flipped that world's facts to status='compacted'

--- a/src/compaction/promotion-runner.service.ts
+++ b/src/compaction/promotion-runner.service.ts
@@ -9,6 +9,7 @@ import { SUMMARY_GENERATOR } from './compaction.types';
 import { envFlagEnabled } from '../common/env-validation';
 import { summaryEpisodeStampEnabled } from '../common/provenance-flags';
 import { unionEpisodeIds } from '../common/episode-ids';
+import { compactionOverridesFor } from './compaction-overrides';
 
 /**
  * PromotionRunnerService — episodic→semantic promotion.
@@ -59,6 +60,19 @@ interface PromotableRow {
   userId?: string | null;
   /** `source.episodeIds AS eps` — grounding stamp of the member (FLEXIBLE). */
   eps?: unknown;
+  /** `source.conversationId AS conversationId` — evidence context of the member (FLEXIBLE). */
+  conversationId?: unknown;
+}
+
+/**
+ * Per-run promotion schedule: the age cutoff plus the effective
+ * thresholds (env defaults overlaid per tenant). One object so the
+ * per-group path stays within the max-params=3 budget.
+ */
+interface PromotionSchedule {
+  cutoff: Date;
+  minGroup: number;
+  minEpisodes: number;
 }
 
 @Injectable()
@@ -68,6 +82,8 @@ export class PromotionRunnerService {
   private readonly ageDays: number;
   private readonly minGroup: number;
   private readonly maxGroups: number;
+  private readonly minEpisodes: number;
+  private readonly conflictGuard: boolean;
   private readonly summaryGenerator: SummaryGenerator;
 
   // Fourth dep is the embedder — promotion summaries replace active
@@ -83,6 +99,11 @@ export class PromotionRunnerService {
     this.ageDays = parseInt(config.get<string>('COMPACTION_PROMOTION_AGE_DAYS', '180'), 10);
     this.minGroup = parseInt(config.get<string>('COMPACTION_PROMOTION_MIN_GROUP', '5'), 10);
     this.maxGroups = parseInt(config.get<string>('COMPACTION_PROMOTION_MAX_GROUPS', '20'), 10);
+    // Consolidation gate (Brain v2 PR8): corroboration floor (0 = off)
+    // + competing-sibling guard. The floor is per-tenant overridable via
+    // the tenant schedule (compaction-overrides.ts); the guard is boolean.
+    this.minEpisodes = parseInt(config.get<string>('COMPACTION_PROMOTION_MIN_EPISODES', '0'), 10);
+    this.conflictGuard = envFlagEnabled(config.get<string>('COMPACTION_PROMOTION_CONFLICT_GUARD'));
     this.summaryGenerator = injectedGenerator ?? new ConcatSummaryGenerator();
   }
 
@@ -97,15 +118,23 @@ export class PromotionRunnerService {
       factsPromoted: 0,
     };
     if (!this.enabled) return stats;
-    // Date param → native datetime; the 2.x `d$param` cast fails to parse
-    // on SurrealDB 3.x (see compactCompany).
-    const cutoff = new Date(Date.now() - this.ageDays * 24 * 60 * 60 * 1000);
+    // Per-tenant resolution schedule (COMPACTION_TENANT_OVERRIDES): a
+    // tenant entry overrides the process defaults; unset = byte-identical.
+    const override = compactionOverridesFor(companyId);
+    const ageDays = override.promotionAgeDays ?? this.ageDays;
+    const schedule: PromotionSchedule = {
+      // Date param → native datetime; the 2.x `d$param` cast fails to
+      // parse on SurrealDB 3.x (see compactCompany).
+      cutoff: new Date(Date.now() - ageDays * 24 * 60 * 60 * 1000),
+      minGroup: override.promotionMinGroup ?? this.minGroup,
+      minEpisodes: override.promotionMinEpisodes ?? this.minEpisodes,
+    };
 
     return this.surreal.withCompany(companyId, async (db) => {
-      const groups = await this.findPromotableGroups(db, cutoff);
+      const groups = await this.findPromotableGroups(db, schedule);
       for (const group of groups.slice(0, this.maxGroups)) {
         try {
-          const promoted = await this.promoteGroup(db, group, cutoff);
+          const promoted = await this.promoteGroup(db, group, schedule);
           if (promoted > 0) {
             stats.groupsPromoted++;
             stats.factsPromoted += promoted;
@@ -133,7 +162,7 @@ export class PromotionRunnerService {
    */
   private async findPromotableGroups(
     db: Surreal,
-    cutoff: Date,
+    schedule: PromotionSchedule,
   ): Promise<Array<{ entityId: unknown; predicate: string; userId?: string | null }>> {
     // User scope (0055) is part of the group key — a user's episodic
     // history folds into THAT user's summary, never a blended one.
@@ -143,7 +172,7 @@ export class PromotionRunnerService {
          AND recordedAt < $cutoff
          AND !string::starts_with(predicate, 'summary_')
        GROUP BY entityId, predicate, userId`,
-      { cutoff },
+      { cutoff: schedule.cutoff },
     )) as [
       Array<{
         entityId: unknown;
@@ -153,7 +182,7 @@ export class PromotionRunnerService {
       }>,
     ];
     return (rows ?? [])
-      .filter((g) => g.n >= this.minGroup)
+      .filter((g) => g.n >= schedule.minGroup)
       .filter((g) => {
         // 0082: SEED lookup, not policyFor — the unknown-predicate
         // fallback is append_only now, but a coined (open-vocabulary)
@@ -166,16 +195,23 @@ export class PromotionRunnerService {
       });
   }
 
-  /** Fold one group's aged tail into a summary fact. Returns count folded. */
+  /**
+   * Fold one group's aged tail into a summary fact. Returns count folded.
+   *
+   * Consolidation gate order (Brain v2 PR8): corroboration floor →
+   * conflict guard → the existing summarize/create/compact flow.
+   */
   private async promoteGroup(
     db: Surreal,
     group: { entityId: unknown; predicate: string; userId?: string | null },
-    cutoff: Date,
+    schedule: PromotionSchedule,
   ): Promise<number> {
     const scopeClause = group.userId ? 'AND userId = $scopeUser' : 'AND userId IS NONE';
+    const scopeParams = group.userId ? { scopeUser: group.userId } : {};
     const [rows] = (await db.query(
       `SELECT id, entityId, predicate, object, validFrom, validUntil, confidence, userId,
-              source.episodeIds AS eps
+              source.episodeIds AS eps,
+              source.conversationId AS conversationId
        FROM knowledge_fact
        WHERE entityId = $entity AND predicate = $predicate
          AND status = 'active' AND retractedAt IS NONE
@@ -185,12 +221,58 @@ export class PromotionRunnerService {
       {
         entity: group.entityId,
         predicate: group.predicate,
-        cutoff,
-        ...(group.userId ? { scopeUser: group.userId } : {}),
+        cutoff: schedule.cutoff,
+        ...scopeParams,
       },
     )) as [PromotableRow[]];
     const members = (rows ?? []) as PromotableRow[];
-    if (members.length < this.minGroup) return 0;
+    if (members.length < schedule.minGroup) return 0;
+
+    // Corroboration floor (COMPACTION_PROMOTION_MIN_EPISODES > 0): a
+    // summary must consolidate INDEPENDENT evidence, so the floor counts
+    // distinct evidence contexts — the union of the members' grounding
+    // episode ids and conversation ids — not member rows. Five facts
+    // from ONE conversation are one witness, not five.
+    if (schedule.minEpisodes > 0) {
+      const distinct = new Set<string>(unionEpisodeIds(members.map((m) => m.eps)));
+      for (const m of members) {
+        if (typeof m.conversationId === 'string' && m.conversationId.length > 0) {
+          distinct.add(m.conversationId);
+        }
+      }
+      if (distinct.size < schedule.minEpisodes) {
+        this.logger.debug(
+          `promotion skipped (corroboration floor): ${String(group.entityId)}/${group.predicate} ` +
+            `distinct=${distinct.size} < ${schedule.minEpisodes}`,
+        );
+        return 0;
+      }
+    }
+
+    // Conflict guard (COMPACTION_PROMOTION_CONFLICT_GUARD): the members
+    // are status='active' by the WHERE above, so the signal for a
+    // contested group is its sibling COMPETING pool — same (entity,
+    // predicate) and the same user scope as the member query. A
+    // contested group must never fold silently into one summary: abort
+    // LOUDLY and leave the rows for the conflict engine to settle.
+    if (this.conflictGuard) {
+      const [countRows] = (await db.query(
+        `SELECT count() AS n FROM knowledge_fact
+         WHERE entityId = $entity AND predicate = $predicate
+           AND status = 'competing' AND retractedAt IS NONE
+           ${scopeClause}
+         GROUP ALL`,
+        { entity: group.entityId, predicate: group.predicate, ...scopeParams },
+      )) as [Array<{ n: number }>];
+      const competing = countRows?.[0]?.n ?? 0;
+      if (competing > 0) {
+        this.logger.warn(
+          `contested group NOT promoted: ${String(group.entityId)}/${group.predicate}, ` +
+            `${competing} competing rows`,
+        );
+        return 0;
+      }
+    }
 
     // The SDK returns datetime columns as Date objects; FactToSummarize
     // (and the concat generator's `.slice`) expect ISO strings.

--- a/test/compaction.unit-spec.ts
+++ b/test/compaction.unit-spec.ts
@@ -159,6 +159,43 @@ describe('CompactionService — mark + drop (default mode)', () => {
     expect(cutoffMs).toBeLessThanOrEqual(after - 30 * 24 * 60 * 60 * 1000);
   });
 
+  it('honours a per-tenant hotRetentionDays override (COMPACTION_TENANT_OVERRIDES)', async () => {
+    const saved = process.env.COMPACTION_TENANT_OVERRIDES;
+    process.env.COMPACTION_TENANT_OVERRIDES = JSON.stringify({
+      co_a: { hotRetentionDays: 30 },
+    });
+    try {
+      const { surreal, calls } = makeFakeSurreal({
+        co_a: { rows: rows([{ id: 'f1' }]) },
+        co_b: { rows: rows([{ id: 'g1' }]) },
+      });
+      const runner = new CompactionRunnerService(
+        surreal,
+        new StubConfig() as unknown as ConfigService, // process default 90d
+      );
+
+      const before = Date.now();
+      await runner.compactCompany('co_a');
+      await runner.compactCompany('co_b');
+      const after = Date.now();
+
+      const cutoffOf = (companyId: string): number => {
+        const tenant = calls.find((c) => c.companyId === companyId)!;
+        const select = tenant.calls.find((c) => c.sql.includes('SELECT id, entityId'))!;
+        return (select.params!.cutoff as Date).getTime();
+      };
+      // co_a follows its 30d override…
+      expect(cutoffOf('co_a')).toBeGreaterThanOrEqual(before - 30 * 24 * 60 * 60 * 1000);
+      expect(cutoffOf('co_a')).toBeLessThanOrEqual(after - 30 * 24 * 60 * 60 * 1000);
+      // …while co_b keeps the process-global 90d default.
+      expect(cutoffOf('co_b')).toBeGreaterThanOrEqual(before - 90 * 24 * 60 * 60 * 1000);
+      expect(cutoffOf('co_b')).toBeLessThanOrEqual(after - 90 * 24 * 60 * 60 * 1000);
+    } finally {
+      if (saved === undefined) delete process.env.COMPACTION_TENANT_OVERRIDES;
+      else process.env.COMPACTION_TENANT_OVERRIDES = saved;
+    }
+  });
+
   it('rejects invalid retention config at construction', () => {
     const surreal = {} as SurrealService;
     expect(

--- a/test/env-validation.unit-spec.ts
+++ b/test/env-validation.unit-spec.ts
@@ -7,6 +7,7 @@
  * app-layer filter is the effective barrier). Production must refuse to
  * start without both creds.
  */
+import { Logger } from '@nestjs/common';
 import { validateEnv } from '../src/common/env-validation';
 
 function baseProdEnv(): NodeJS.ProcessEnv {
@@ -186,6 +187,65 @@ describe('validateEnv — PROCESS_ROLE', () => {
       env.PROCESS_ROLE = role;
       env.JOBS_QUEUE_MODE = 'inline';
       expect(() => validateEnv(env)).toThrow(/JOBS_QUEUE_MODE=enqueue/);
+    }
+  });
+});
+
+/**
+ * COMPACTION_TENANT_OVERRIDES clones the RETRIEVAL_PROFILE_OVERRIDES
+ * shape check (JSON object mapping companyId → object) but WARNS
+ * instead of refusing to start: the parser fails open to the process
+ * defaults per tenant, so a malformed schedule must degrade, not brick
+ * the boot.
+ */
+describe('validateEnv — COMPACTION_TENANT_OVERRIDES (warn, never throw)', () => {
+  const warnSpy = () => jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+  afterEach(() => jest.restoreAllMocks());
+
+  it('accepts a valid schedule object (no warning)', () => {
+    const warn = warnSpy();
+    const env = baseProdEnv();
+    env.COMPACTION_TENANT_OVERRIDES = JSON.stringify({
+      co_a: { hotRetentionDays: 30, promotionMinEpisodes: 2 },
+    });
+    expect(() => validateEnv(env)).not.toThrow();
+    expect(warn.mock.calls.some(([m]) => String(m).includes('COMPACTION_TENANT_OVERRIDES'))).toBe(
+      false,
+    );
+  });
+
+  it('accepts the feature-off default (unset / blank)', () => {
+    const warn = warnSpy();
+    for (const value of [undefined, '', '   ']) {
+      const env = baseProdEnv();
+      if (value !== undefined) env.COMPACTION_TENANT_OVERRIDES = value;
+      expect(() => validateEnv(env)).not.toThrow();
+    }
+    expect(warn.mock.calls.some(([m]) => String(m).includes('COMPACTION_TENANT_OVERRIDES'))).toBe(
+      false,
+    );
+  });
+
+  it('warns (does NOT throw) on invalid JSON', () => {
+    const warn = warnSpy();
+    const env = baseProdEnv();
+    env.COMPACTION_TENANT_OVERRIDES = 'not-json{';
+    expect(() => validateEnv(env)).not.toThrow();
+    expect(warn.mock.calls.some(([m]) => String(m).includes('COMPACTION_TENANT_OVERRIDES'))).toBe(
+      true,
+    );
+  });
+
+  it('warns (does NOT throw) when the value is not an object-of-objects', () => {
+    for (const bad of ['[]', '"co_a"', '{"co_a": 30}', '{"co_a": null}', '{"co_a": [1]}']) {
+      const warn = warnSpy();
+      const env = baseProdEnv();
+      env.COMPACTION_TENANT_OVERRIDES = bad;
+      expect(() => validateEnv(env)).not.toThrow();
+      expect(warn.mock.calls.some(([m]) => String(m).includes('COMPACTION_TENANT_OVERRIDES'))).toBe(
+        true,
+      );
+      jest.restoreAllMocks();
     }
   });
 });

--- a/test/promotion-gate.unit-spec.ts
+++ b/test/promotion-gate.unit-spec.ts
@@ -1,0 +1,293 @@
+/**
+ * Unit-test for the promotion consolidation gate (Brain v2 PR8) on
+ * PromotionRunnerService, plus the per-tenant schedule
+ * (COMPACTION_TENANT_OVERRIDES):
+ *
+ *   - corroboration floor (COMPACTION_PROMOTION_MIN_EPISODES): a group
+ *     folds only when its members span enough DISTINCT evidence contexts
+ *     (union of member source.episodeIds + source.conversationId) — five
+ *     facts from ONE conversation are one witness, not five;
+ *   - conflict guard (COMPACTION_PROMOTION_CONFLICT_GUARD): sibling
+ *     COMPETING rows abort the group loudly;
+ *   - both off/unset → promotion byte-identical to today (pinned);
+ *   - the per-tenant override changes the effective floor.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PromotionRunnerService } from '../src/compaction/promotion-runner.service';
+import type { EmbedderService } from '../src/ai/embedder.service';
+import type { SurrealService } from '../src/db/surreal.service';
+
+class StubConfig {
+  constructor(private readonly map: Record<string, string> = {}) {}
+  get<T = string>(key: string, fallback?: T): T {
+    return (this.map[key] as unknown as T) ?? (fallback as T);
+  }
+  getOrThrow<T = string>(key: string): T {
+    const v = this.map[key];
+    if (v === undefined) throw new Error(`missing ${key}`);
+    return v as unknown as T;
+  }
+}
+
+interface QueryCall {
+  sql: string;
+  params?: Record<string, unknown> | undefined;
+}
+
+interface PromotableSeed {
+  id: string;
+  object: string;
+  validFrom: string;
+  eps?: string[];
+  conversationId?: string;
+}
+
+function makePromotionStack(
+  seeds: PromotableSeed[],
+  config: Record<string, string>,
+  opts: { competingCount?: number } = {},
+) {
+  const calls: QueryCall[] = [];
+  const created: Array<Record<string, unknown>> = [];
+  const fakeDb = {
+    async query<R>(sql: string, params?: Record<string, unknown>): Promise<R> {
+      calls.push({ sql, params });
+      if (sql.includes('GROUP BY entityId, predicate, userId')) {
+        return [
+          [{ entityId: 'knowledge_entity:e1', predicate: 'said', n: seeds.length }],
+        ] as unknown as R;
+      }
+      // The competing-sibling count query ALSO matches the member
+      // SELECT's WHERE prefix — discriminate on the status literal first.
+      if (sql.includes("status = 'competing'")) {
+        return [[{ n: opts.competingCount ?? 0 }]] as unknown as R;
+      }
+      if (sql.includes('WHERE entityId = $entity AND predicate = $predicate')) {
+        return [
+          seeds.map((s) => ({
+            id: s.id,
+            entityId: 'knowledge_entity:e1',
+            predicate: 'said',
+            object: s.object,
+            validFrom: s.validFrom,
+            confidence: 0.9,
+            ...(s.eps ? { eps: s.eps } : {}),
+            ...(s.conversationId ? { conversationId: s.conversationId } : {}),
+          })),
+        ] as unknown as R;
+      }
+      if (sql.startsWith('CREATE type::table($t)')) {
+        created.push(params!.d as Record<string, unknown>);
+        return [[{ id: 'knowledge_fact:summary1' }]] as unknown as R;
+      }
+      return [[]] as unknown as R;
+    },
+  };
+  const surreal = {
+    withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>) => fn(fakeDb),
+  } as unknown as SurrealService;
+  const embedder = { embed: async () => [1, 0] } as unknown as EmbedderService;
+  const runner = new PromotionRunnerService(
+    surreal,
+    new StubConfig({
+      COMPACTION_PROMOTION_ENABLED: '1',
+      COMPACTION_PROMOTION_MIN_GROUP: '2',
+      ...config,
+    }) as unknown as ConfigService,
+    embedder,
+    { generate: async () => 'promoted summary' },
+  );
+  return { runner, calls, created };
+}
+
+// 'said' is a seed append_only predicate — the only class promotion folds.
+// Five aged facts, ALL grounded in the same single conversation.
+const ONE_CONVERSATION: PromotableSeed[] = Array.from({ length: 5 }, (_, i) => ({
+  id: `knowledge_fact:s${i}`,
+  object: `old remark ${i}`,
+  validFrom: `2025-0${i + 1}-01T00:00:00Z`,
+  conversationId: 'conv_1',
+}));
+
+// The same five facts, spanning two conversations (and one episode stamp).
+const TWO_CONVERSATIONS: PromotableSeed[] = ONE_CONVERSATION.map((s, i) => ({
+  ...s,
+  conversationId: i < 3 ? 'conv_1' : 'conv_2',
+  ...(i === 0 ? { eps: ['episode:e1'] } : {}),
+}));
+
+const savedOverrides = process.env.COMPACTION_TENANT_OVERRIDES;
+afterEach(() => {
+  if (savedOverrides === undefined) delete process.env.COMPACTION_TENANT_OVERRIDES;
+  else process.env.COMPACTION_TENANT_OVERRIDES = savedOverrides;
+  jest.restoreAllMocks();
+});
+
+describe('PromotionRunnerService — corroboration floor', () => {
+  it('skips a single-conversation group below the floor (and says so at debug)', async () => {
+    const debug = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+    const { runner, created } = makePromotionStack(ONE_CONVERSATION, {
+      COMPACTION_PROMOTION_MIN_EPISODES: '2',
+    });
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(0);
+    expect(stats.factsPromoted).toBe(0);
+    expect(created).toHaveLength(0);
+    expect(debug).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'promotion skipped (corroboration floor): knowledge_entity:e1/said distinct=1 < 2',
+      ),
+    );
+  });
+
+  it('promotes a group spanning two conversations at floor 2', async () => {
+    const { runner, created } = makePromotionStack(TWO_CONVERSATIONS, {
+      COMPACTION_PROMOTION_MIN_EPISODES: '2',
+    });
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(1);
+    expect(stats.factsPromoted).toBe(5);
+    expect(created).toHaveLength(1);
+    expect(created[0]!.predicate).toBe('summary_said');
+  });
+
+  it('counts episode stamps and conversation ids into ONE distinct-context set', async () => {
+    // One conversation only, but two members carry distinct episode
+    // stamps: contexts = {episode:e1, episode:e2, conv_1} = 3.
+    const seeds = ONE_CONVERSATION.map((s, i) => ({
+      ...s,
+      ...(i === 0 ? { eps: ['episode:e1'] } : {}),
+      ...(i === 1 ? { eps: ['episode:e2'] } : {}),
+    }));
+    const { runner, created } = makePromotionStack(seeds, {
+      COMPACTION_PROMOTION_MIN_EPISODES: '3',
+    });
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(1);
+    expect(created).toHaveLength(1);
+  });
+
+  it('the member SELECT carries the evidence-context column', async () => {
+    const { runner, calls } = makePromotionStack(TWO_CONVERSATIONS, {});
+    await runner.promoteCompany('co_a');
+    const select = calls.find((c) => c.sql.includes('WHERE entityId = $entity'))!;
+    expect(select.sql).toContain('source.conversationId AS conversationId');
+  });
+});
+
+describe('PromotionRunnerService — conflict guard', () => {
+  it('aborts a contested group loudly (competing siblings present)', async () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    const { runner, created } = makePromotionStack(
+      TWO_CONVERSATIONS,
+      { COMPACTION_PROMOTION_CONFLICT_GUARD: '1' },
+      { competingCount: 3 },
+    );
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(0);
+    expect(created).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'contested group NOT promoted: knowledge_entity:e1/said, 3 competing rows',
+      ),
+    );
+  });
+
+  it('promotes an uncontested group with the guard on (count = 0)', async () => {
+    const { runner, created, calls } = makePromotionStack(
+      TWO_CONVERSATIONS,
+      { COMPACTION_PROMOTION_CONFLICT_GUARD: '1' },
+      { competingCount: 0 },
+    );
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(1);
+    expect(created).toHaveLength(1);
+    // The guard issued exactly one count query for the group.
+    expect(calls.filter((c) => c.sql.includes("status = 'competing'"))).toHaveLength(1);
+  });
+});
+
+describe('PromotionRunnerService — gate off/unset is byte-identical (pin)', () => {
+  it('single-conversation group promotes exactly as today; no competing query fires', async () => {
+    const { runner, created, calls } = makePromotionStack(ONE_CONVERSATION, {});
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(1);
+    expect(stats.factsPromoted).toBe(5);
+    expect(created).toHaveLength(1);
+    const summary = created[0]!;
+    expect(summary.predicate).toBe('summary_said');
+    expect(summary.object).toBe('promoted summary');
+    expect(summary.status).toBe('active');
+    expect(summary.source).toEqual({ kind: 'promotion' });
+    expect((summary.derivedFrom as unknown[]).length).toBe(5);
+    // No consolidation-gate query was issued.
+    expect(calls.some((c) => c.sql.includes("status = 'competing'"))).toBe(false);
+  });
+});
+
+describe('PromotionRunnerService — per-tenant schedule (COMPACTION_TENANT_OVERRIDES)', () => {
+  it('the tenant override raises the effective floor for THAT tenant only', async () => {
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+    process.env.COMPACTION_TENANT_OVERRIDES = JSON.stringify({
+      co_a: { promotionMinEpisodes: 2 },
+    });
+    // Env default floor is 0 (off): co_a inherits 2 from its override
+    // and skips the single-witness group…
+    const a = makePromotionStack(ONE_CONVERSATION, {});
+    const statsA = await a.runner.promoteCompany('co_a');
+    expect(statsA.groupsPromoted).toBe(0);
+    expect(a.created).toHaveLength(0);
+    // …while co_b keeps the process default and promotes it.
+    const b = makePromotionStack(ONE_CONVERSATION, {});
+    const statsB = await b.runner.promoteCompany('co_b');
+    expect(statsB.groupsPromoted).toBe(1);
+    expect(b.created).toHaveLength(1);
+  });
+
+  it('the tenant override can LOWER the env floor (override wins over env default)', async () => {
+    process.env.COMPACTION_TENANT_OVERRIDES = JSON.stringify({
+      co_a: { promotionMinEpisodes: 0 },
+    });
+    const { runner, created } = makePromotionStack(ONE_CONVERSATION, {
+      COMPACTION_PROMOTION_MIN_EPISODES: '2',
+    });
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(1);
+    expect(created).toHaveLength(1);
+  });
+
+  it('promotionMinGroup override changes the group-size threshold', async () => {
+    process.env.COMPACTION_TENANT_OVERRIDES = JSON.stringify({
+      co_a: { promotionMinGroup: 6 },
+    });
+    // 5 members < 6 → the group no longer qualifies for co_a.
+    const { runner, created } = makePromotionStack(ONE_CONVERSATION, {});
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(0);
+    expect(created).toHaveLength(0);
+  });
+
+  it('promotionAgeDays override moves the cutoff for that tenant', async () => {
+    process.env.COMPACTION_TENANT_OVERRIDES = JSON.stringify({
+      co_a: { promotionAgeDays: 30 },
+    });
+    const { runner, calls } = makePromotionStack(ONE_CONVERSATION, {});
+    const before = Date.now();
+    await runner.promoteCompany('co_a');
+    const after = Date.now();
+    const select = calls.find((c) => c.sql.includes('GROUP BY entityId'))!;
+    const cutoff = select.params!.cutoff as Date;
+    expect(cutoff).toBeInstanceOf(Date);
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(before - 30 * 24 * 60 * 60 * 1000);
+    expect(cutoff.getTime()).toBeLessThanOrEqual(after - 30 * 24 * 60 * 60 * 1000);
+  });
+
+  it('a malformed overrides env fails open to the process defaults', async () => {
+    process.env.COMPACTION_TENANT_OVERRIDES = 'not-json{';
+    const { runner, created } = makePromotionStack(ONE_CONVERSATION, {});
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(1);
+    expect(created).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Brain v2 PR8 — the final build PR of the wave (`docs/roadmap/brain-v2-2026-08.md` §3): **retention becomes a per-tenant resolution schedule, and promotion becomes consolidation** — a summary must be corroborated across distinct evidence contexts, and contested groups abort loudly instead of folding silently.

- **`COMPACTION_TENANT_OVERRIDES`** (JSON env, cloned from the `RETRIEVAL_PROFILE_OVERRIDES` idiom): `companyId → { hotRetentionDays?, promotionAgeDays?, promotionMinGroup?, promotionMinEpisodes? }`. Parsed at call time in `src/compaction/compaction-overrides.ts` (runtime-mutable — the cron picks up changes without a restart); per-tenant fail-open to the process defaults; boot-shape validation **warns, never throws**. Consumed by `compactCompany` (hot retention) and `promoteCompany` (promotion age / group floor / corroboration floor). Catalog entry + `.env.example` included.
- **Corroboration floor** — `COMPACTION_PROMOTION_MIN_EPISODES` (int, default 0 = off): a group folds into a summary only when its members span enough **distinct evidence contexts** — the union of member `source.episodeIds` (the same field the base branch's episode stamping reads) and `source.conversationId` (newly selected). Five facts from one conversation are one witness, not five. Below the floor the group is skipped with a `logger.debug`.
- **Conflict guard** — `COMPACTION_PROMOTION_CONFLICT_GUARD` (boolean, default off): one count query per group for sibling `status='competing'` rows on the same (entity, predicate, user-scope); any hit **aborts the group loudly** (`logger.warn "contested group NOT promoted"`). Members are `status='active'` by the existing WHERE — the sibling competing pool is the contested-knowledge signal.
- Gate order in `promoteGroup`: floor → conflict guard → the existing summarize/create/compact flow. The summary row shape is untouched (#371 owns episodeIds stamping).

## The doc

`docs/roadmap/brain-v2-resolution-2026-08.md` — the resolution-tier ladder as **serving policy, not existence**: hot (full serving) / warm (today's compacted state reframed: summaries serve, members auditable) / cold (schema + index only, future) / archive (source pointer only, future); the per-tenant schedule + consolidation gate as the tier-transition controls; a strong-cue re-zoom sketch (future); and the explicit carve-out that resolution tiers and the 0072/0089 staleness machinery are orthogonal in both directions. Measurement posture: parked with the paid-eval budget.

## Safety

- Everything is default-off/unset ⇒ **byte-identical**: no env set → same queries (minus one extra SELECT column), same written rows, same logs. Pinned in `test/promotion-gate.unit-spec.ts` (off/unset pin: identical summary payload `{ kind: 'promotion' }`, no competing-count query issued).
- `COMPACTION_` stays off the engine flag budget (compaction is outside the S5.2 engine-gates env-read boundary).
- Malformed `COMPACTION_TENANT_OVERRIDES` degrades to the global schedule (boot warns; parser fails open per tenant) — it can never brick boot or a tenant's compaction.
- No paid LLM calls anywhere.

## Test plan

- `pnpm typecheck` — clean.
- Full unit suite: **297 suites / 2844 tests green** (includes the config-catalog truth gates over the three new catalog entries).
- New `test/promotion-gate.unit-spec.ts`: floor skip (5 facts / 1 conversation, floor 2 → no summary + debug), floor pass (2 conversations → promotes), episode-stamp ∪ conversation-id counting, conflict-guard abort (+warn) and pass-through, off/unset byte-identical pin, per-tenant floor raise AND lower, `promotionMinGroup`/`promotionAgeDays` overrides, malformed-env fail-open.
- `test/env-validation.unit-spec.ts`: `COMPACTION_TENANT_OVERRIDES` shape cases (valid / unset / invalid JSON / non-object-of-objects) — warn, never throw.
- `test/compaction.unit-spec.ts`: per-tenant `hotRetentionDays` override honored (30d for the overridden tenant, 90d for its neighbor).
- Targeted e2e (`--testPathPatterns "promotion|compaction"`) against a real SurrealDB v3.2.4 testcontainer: 2/2 green.
- `prettier --check "src/**/*.ts" "test/**/*.ts"` — clean (doc formatted too).

## Base / retarget plan

Based on `feat/provenance-closure` (#371) because both PRs touch `promotion-runner.service.ts` (the corroboration floor reads the same member `source.episodeIds` field #371 selects). **Retarget to `main` after #371 merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
