### PR TITLE
feat(consent): media/biometric consent tier — read_media scope, pack modality consent, fail-closed media PII gate

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -1371,6 +1371,9 @@
           "acceptMcpTools": {
             "type": "boolean"
           },
+          "acceptModalities": {
+            "type": "boolean"
+          },
           "packId": {
             "type": "string"
           },
@@ -1387,6 +1390,9 @@
         "additionalProperties": false,
         "properties": {
           "acceptMcpTools": {
+            "type": "boolean"
+          },
+          "acceptModalities": {
             "type": "boolean"
           },
           "expectedChecksum": {

--- a/docs/mcp-pack-tools.md
+++ b/docs/mcp-pack-tools.md
@@ -105,6 +105,37 @@ Consent is stored with a sha256 checksum of the canonical-JSON
 The MCP reader only ever registers tools whose stored consent checksum
 matches the stored section — a row edited out-of-band serves nothing.
 
+## Modality consent (media/biometric tier)
+
+The same consent shape covers a pack's **non-text modality declaration**
+(image/audio/video processing and any raw-evidence serving capability,
+migration 0112). Installing a pack that declares non-text modalities
+fails with 400 unless the request carries `acceptModalities: true` —
+on both install routes, exactly like `acceptMcpTools`.
+
+ONE checksum (canonical-JSON sha256) covers the whole media section:
+the declared non-text modalities **plus** any raw-evidence capability
+declaration. Any change to either is a single re-consent trigger; an
+upgrade that leaves the section byte-identical carries consent over; an
+upgrade that drops it clears the stored consent. No manifest declares
+modalities today, so the gate is inert by construction for every
+existing pack.
+
+Two further gates stack on top of consent (deny-overrides — every layer
+must pass):
+
+- **Raw-evidence per-call gate** (`src/mcp/raw-evidence-gate.ts`): a
+  future pack tool that serves raw media evidence must call
+  `gateRawEvidence` per served fragment — pack declares the capability,
+  stored consent checksum is current, and the fragment passes the media
+  PII gate.
+- **Media PII gate** (`src/common/media-pii.ts`): media rows carry
+  `piiClasses` with INVERTED polarity vs the text `piiClass` fence —
+  absence (unclassified) is **blocked**, only the affirmatively-clean
+  empty array is open, and non-empty classes require the env-key-only
+  `brain:read_media` scope (deliberately stricter than, and never
+  conflated with, `brain:read_pii`; never mintable via jwks).
+
 ## Query tools
 
 Query tools are served entirely by Brain. The input schemas are fixed

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1371,6 +1371,9 @@
           "acceptMcpTools": {
             "type": "boolean"
           },
+          "acceptModalities": {
+            "type": "boolean"
+          },
           "packId": {
             "type": "string"
           },
@@ -1387,6 +1390,9 @@
         "additionalProperties": false,
         "properties": {
           "acceptMcpTools": {
+            "type": "boolean"
+          },
+          "acceptModalities": {
             "type": "boolean"
           },
           "expectedChecksum": {

--- a/src/admin/admin-packs.controller.ts
+++ b/src/admin/admin-packs.controller.ts
@@ -59,11 +59,14 @@ export class AdminPacksController {
       expectedChecksum?: string;
       /** Consent to the manifest's mcpTools section (docs/mcp-pack-tools.md). */
       acceptMcpTools?: boolean;
+      /** Consent to declared non-text modalities (docs/mcp-pack-tools.md). */
+      acceptModalities?: boolean;
     },
   ): Promise<InstallPackResponse> {
     return this.packs.install(req.brainAuth.companyId, body?.manifest, {
       expectedChecksum: body?.expectedChecksum,
       acceptMcpTools: body?.acceptMcpTools,
+      acceptModalities: body?.acceptModalities,
     });
   }
 
@@ -76,7 +79,12 @@ export class AdminPacksController {
   async installFromRegistry(
     @Req() req: AuthenticatedRequest,
     @Body()
-    body: { packId: string; version?: string; acceptMcpTools?: boolean },
+    body: {
+      packId: string;
+      version?: string;
+      acceptMcpTools?: boolean;
+      acceptModalities?: boolean;
+    },
   ): Promise<InstallPackResponse> {
     const { manifest, checksum } = await this.registry.resolveForInstall({
       packId: body?.packId,
@@ -86,6 +94,7 @@ export class AdminPacksController {
     return this.packs.install(req.brainAuth.companyId, manifest, {
       expectedChecksum: checksum,
       acceptMcpTools: body?.acceptMcpTools,
+      acceptModalities: body?.acceptModalities,
     });
   }
 

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -25,9 +25,12 @@ import {
   composePredicateId,
   diffPackUpgrade,
   DomainPackError,
+  declaredModalitySection,
   externalMcpTools,
   mcpConsentRequired,
   mcpToolsChecksum,
+  modalitiesChecksum,
+  modalityConsentRequired,
   packChecksum,
   validatePack,
   type DomainPackManifest,
@@ -61,6 +64,8 @@ interface DomainPackRow {
   installId?: unknown;
   acceptedMcpTools?: unknown;
   acceptedMcpToolsChecksum?: unknown;
+  acceptedModalities?: unknown;
+  acceptedModalitiesChecksum?: unknown;
 }
 
 /** `listInstalled` projection of `domain_pack`. */
@@ -160,6 +165,9 @@ export class DomainPackInstallService {
     opts: {
       expectedChecksum?: string | undefined;
       acceptMcpTools?: boolean | undefined;
+      /** Consent to the manifest's declared non-text modalities /
+       *  raw-evidence capability (0112) — see modality-consent.ts. */
+      acceptModalities?: boolean | undefined;
     } = {},
   ): Promise<{
     packId: string;
@@ -237,11 +245,21 @@ export class DomainPackInstallService {
     const mcpSet = mcpChecksum
       ? `, acceptedMcpTools = true, acceptedMcpToolsChecksum = $mcpChecksum`
       : `, acceptedMcpTools = NONE, acceptedMcpToolsChecksum = NONE`;
+    // Modality consent (0112) — same mold as the 0068 fields above: one
+    // checksum over the whole media section (non-text modalities +
+    // raw-evidence capability), stamped when declared, cleared when an
+    // upgrade drops the section. Inert for every manifest that declares
+    // no non-text modalities (all of them today).
+    const modalitySection = declaredModalitySection(manifest);
+    const modalityChecksum = modalitiesChecksum(modalitySection);
+    const modalitySet = modalityChecksum
+      ? `, acceptedModalities = true, acceptedModalitiesChecksum = $modalityChecksum`
+      : `, acceptedModalities = NONE, acceptedModalitiesChecksum = NONE`;
     let mintedInstallId: string | undefined;
     const seeded = await this.surreal.withCompany(companyId, async (db) => {
       const existing = await queryRows<DomainPackRow>(
         db,
-        `SELECT id, version, manifest, webhookSecret, installId, acceptedMcpTools, acceptedMcpToolsChecksum FROM domain_pack WHERE packId = $packId LIMIT 1`,
+        `SELECT id, version, manifest, webhookSecret, installId, acceptedMcpTools, acceptedMcpToolsChecksum, acceptedModalities, acceptedModalitiesChecksum FROM domain_pack WHERE packId = $packId LIMIT 1`,
         { packId: manifest.id },
       );
       const row = existing[0];
@@ -252,6 +270,17 @@ export class DomainPackInstallService {
         priorChecksum: row?.acceptedMcpToolsChecksum ? String(row.acceptedMcpToolsChecksum) : null,
       });
       if (consentMessage) throw new BadRequestException(consentMessage);
+      const modalityMessage = modalityConsentRequired({
+        packId: manifest.id,
+        version: manifest.version,
+        declared: modalitySection,
+        accepted: opts.acceptModalities,
+        priorAccepted: row?.acceptedModalities === true,
+        priorChecksum: row?.acceptedModalitiesChecksum
+          ? String(row.acceptedModalitiesChecksum)
+          : null,
+      });
+      if (modalityMessage) throw new BadRequestException(modalityMessage);
       // installId (0068) — the opaque per-install identity external tool
       // endpoints see instead of companyId. Minted once, kept forever.
       if (externalTools.length > 0 && !row?.installId) {
@@ -264,7 +293,14 @@ export class DomainPackInstallService {
           manifest,
           checksum,
           newIds,
-          mint: { wantsWebhook, mintedInstallId, mcpChecksum, mcpSet },
+          mint: {
+            wantsWebhook,
+            mintedInstallId,
+            mcpChecksum,
+            mcpSet,
+            modalityChecksum,
+            modalitySet,
+          },
         });
       } else {
         if (wantsWebhook) {
@@ -283,6 +319,12 @@ export class DomainPackInstallService {
               ? {
                   acceptedMcpTools: true,
                   acceptedMcpToolsChecksum: mcpChecksum,
+                }
+              : {}),
+            ...(modalityChecksum
+              ? {
+                  acceptedModalities: true,
+                  acceptedModalitiesChecksum: modalityChecksum,
                 }
               : {}),
           },
@@ -332,6 +374,8 @@ export class DomainPackInstallService {
       mintedInstallId?: string | undefined;
       mcpChecksum: string | null;
       mcpSet: string;
+      modalityChecksum: string | null;
+      modalitySet: string;
     };
   }): Promise<string | undefined> {
     const { db, row, manifest, checksum, newIds, mint } = opts;
@@ -354,7 +398,7 @@ export class DomainPackInstallService {
     await db.query(
       `UPDATE $id SET version = $version, manifest = $manifest, checksum = $checksum, status = 'active', updatedAt = time::now()${
         mintedSecret ? ', webhookSecret = $webhookSecret' : ''
-      }${mint.mintedInstallId ? ', installId = $installId' : ''}${mint.mcpSet}`,
+      }${mint.mintedInstallId ? ', installId = $installId' : ''}${mint.mcpSet}${mint.modalitySet}`,
       {
         id: row.id,
         version: manifest.version,
@@ -363,6 +407,7 @@ export class DomainPackInstallService {
         ...(mintedSecret ? { webhookSecret: mintedSecret } : {}),
         ...(mint.mintedInstallId ? { installId: mint.mintedInstallId } : {}),
         ...(mint.mcpChecksum ? { mcpChecksum: mint.mcpChecksum } : {}),
+        ...(mint.modalityChecksum ? { modalityChecksum: mint.modalityChecksum } : {}),
       },
     );
     // Reinstall/upgrade: uninstall DEPRECATED this pack's predicates and

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -26,6 +26,7 @@ export * from './validate';
 export * from './upgrade-diff';
 export * from './checksum';
 export * from './mcp-consent';
+export * from './modality-consent';
 export * from './signature';
 export * from './semver';
 export * from './eval-fixture';

--- a/src/ai/domain-packs/modality-consent.ts
+++ b/src/ai/domain-packs/modality-consent.ts
@@ -1,0 +1,126 @@
+import { createHash } from 'node:crypto';
+import { canonicalJson } from './checksum';
+import type { DomainPackManifest } from './manifest';
+
+/**
+ * Install-time consent for pack-declared NON-TEXT modality processing
+ * (media/biometric tier, migration 0112 — the modality sibling of the
+ * 0068 mcpTools consent in ./mcp-consent.ts).
+ *
+ * A pack that declares image/audio/video processing changes what the
+ * tenant's memory substrate DOES with raw media (classification, storage,
+ * possibly serving raw evidence back out) — that must be an explicit
+ * operator decision, not a side effect of installing an ontology. ONE
+ * checksum covers the whole media section (declared non-text modalities +
+ * any raw-evidence capability declaration): any change to either is a
+ * single re-consent trigger; a byte-identical section carries prior
+ * consent over.
+ *
+ * Pure helpers — DomainPackInstallService owns the DB row and maps the
+ * returned message to a 400.
+ */
+
+/** The manifest's media section, as consented to (checksum input). */
+export interface ModalityConsentSection {
+  /** Declared non-text modality entries, verbatim from the manifest. */
+  modalities: unknown[];
+  /** Raw-evidence capability declaration, verbatim; absent when none. */
+  rawEvidence?: unknown;
+}
+
+/** Modality entry shapes the defensive probe understands. */
+type ModalityEntry = string | { kind?: unknown; type?: unknown; modality?: unknown };
+
+function modalityName(entry: ModalityEntry): string | null {
+  if (typeof entry === 'string') return entry;
+  if (entry && typeof entry === 'object') {
+    const name = entry.kind ?? entry.type ?? entry.modality;
+    if (typeof name === 'string') return name;
+  }
+  return null;
+}
+
+/**
+ * THE documented accessor for the manifest's modality declaration —
+ * bind-point for the P-track manifest field.
+ *
+ * The typed manifest does not carry the field yet (it arrives with a
+ * sibling P-track PR), so this probes defensively:
+ * `manifest.memoryModel.modalities` first, `manifest.memoryModel
+ * .processors` as the fallback spelling, and `manifest.memoryModel
+ * .rawEvidence` for the raw-evidence capability. When the typed field
+ * lands, ONLY this function changes (one line per probe) — every
+ * consumer (install enforcement, raw-evidence gate, tests) reads the
+ * declaration through here.
+ *
+ * Returns null when the pack declares nothing beyond text (the inert
+ * case — every existing pack), else the section that gets checksummed:
+ * declared NON-TEXT modality entries verbatim plus the raw-evidence
+ * declaration, so a change to either re-triggers consent.
+ */
+export function declaredModalitySection(
+  manifest: DomainPackManifest,
+): ModalityConsentSection | null {
+  const memoryModel = (
+    manifest as {
+      memoryModel?: { modalities?: unknown; processors?: unknown; rawEvidence?: unknown };
+    }
+  ).memoryModel;
+  if (!memoryModel || typeof memoryModel !== 'object') return null;
+  const declared = memoryModel.modalities ?? memoryModel.processors;
+  const nonText = Array.isArray(declared)
+    ? (declared as ModalityEntry[]).filter((m) => modalityName(m) !== 'text')
+    : [];
+  const rawEvidence = memoryModel.rawEvidence;
+  if (nonText.length === 0 && rawEvidence === undefined) return null;
+  return { modalities: nonText, ...(rawEvidence !== undefined ? { rawEvidence } : {}) };
+}
+
+/** The manifest's raw-evidence capability declaration, or null when the
+ *  pack does not declare it (raw serving denied — see
+ *  src/mcp/raw-evidence-gate.ts). Same bind-point discipline as
+ *  {@link declaredModalitySection}. */
+export function rawEvidenceCapability(manifest: DomainPackManifest): unknown {
+  return declaredModalitySection(manifest)?.rawEvidence ?? null;
+}
+
+/** sha256 hex of the canonical media section; null when absent. Takes the
+ *  section as an ARGUMENT (not the manifest) so the exact manifest field
+ *  name can land later without touching the checksum. */
+export function modalitiesChecksum(section: ModalityConsentSection | null): string | null {
+  if (!section) return null;
+  return createHash('sha256').update(canonicalJson(section)).digest('hex');
+}
+
+/**
+ * Decide whether this install/upgrade needs the `acceptModalities` flag —
+ * mirrors mcpConsentRequired: re-consent on checksum change, carry-over
+ * when the stored checksum matches. Returns the client-facing refusal
+ * message (listing what the operator would accept), or null when consent
+ * is granted or not required.
+ */
+export function modalityConsentRequired(opts: {
+  packId: string;
+  version: string;
+  /** From {@link declaredModalitySection} — null = nothing declared. */
+  declared: ModalityConsentSection | null;
+  accepted: boolean | undefined;
+  /** Prior row state — pass false/null on a fresh install. */
+  priorAccepted: boolean;
+  priorChecksum: string | null;
+}): string | null {
+  const checksum = modalitiesChecksum(opts.declared);
+  if (!checksum || !opts.declared) return null; // nothing declared — inert
+  if (opts.accepted === true) return null;
+  if (opts.priorAccepted && opts.priorChecksum === checksum) return null;
+  const names = opts.declared.modalities
+    .map((m) => modalityName(m as ModalityEntry) ?? JSON.stringify(m))
+    .join(', ');
+  const rawNote =
+    opts.declared.rawEvidence !== undefined ? '; declares the raw-evidence capability' : '';
+  return (
+    `pack "${opts.packId}" v${opts.version} declares non-text modality ` +
+    `processing (${names || 'none'})${rawNote}. ` +
+    `Review the declaration and repeat the install with acceptModalities: true.`
+  );
+}

--- a/src/auth/api-key.types.ts
+++ b/src/auth/api-key.types.ts
@@ -3,6 +3,17 @@ export type BrainScope =
   | 'brain:write'
   | 'brain:admin'
   | 'brain:read_pii'
+  // Media/biometric evidence access (faces, voices, ID documents — see
+  // src/common/media-pii.ts). A STRICTER regime than brain:read_pii, not
+  // an extension of it: read_pii opens text rows whose piiClass is set,
+  // read_media opens media rows whose piiClasses gate would otherwise
+  // fail closed (unclassified AND classified states). Deliberately a NEW
+  // scope rather than reusing read_pii — conflating the tiers would
+  // silently grant every existing read_pii holder biometric access.
+  // Hosting-operator only: granted via env-key config like
+  // brain:platform_admin, deliberately NOT added to the jwks
+  // VALID_SCOPES set (never mintable through the token path).
+  | 'brain:read_media'
   // Cross-tenant (company-level) operator authority — distinct from and
   // strictly HIGHER than brain:admin ("operate MY tenant"). Required for
   // any admin op that addresses a tenant other than the credential's own

--- a/src/common/media-pii.ts
+++ b/src/common/media-pii.ts
@@ -1,0 +1,68 @@
+/**
+ * Media/biometric PII tier — the fail-closed gate for media evidence rows
+ * (Brain v2.1 consent tier).
+ *
+ * POLARITY FLIP vs the text gate. Text predicates carry a single
+ * `piiClass` where absence means "nothing sensitive here": the row fence
+ * is `AND piiClass IS NONE` (see src/search/internals/segment-leg.ts /
+ * insight-leg.ts) — an UNCLASSIFIED text row is open. Media evidence
+ * inverts that: a photo or audio clip that nobody has classified may
+ * contain faces, voices, or ID documents, so absence of classification
+ * must mean CLOSED. Media rows therefore carry
+ * `piiClasses: option<array<string>>` with three distinct states:
+ *
+ *   - NONE / absent  → unclassified            → BLOCKED (fail closed)
+ *   - `[]`           → affirmatively clean     → open
+ *   - non-empty      → classified sensitive    → blocked without scope
+ *
+ * The only value that opens a row to an unscoped caller is the EMPTY
+ * ARRAY — an affirmative "a classifier looked and found nothing". The
+ * `brain:read_media` scope (env-key-only, stricter than brain:read_pii —
+ * see src/auth/api-key.types.ts) opens all three states.
+ *
+ * Canonical vocabulary note: this union is THE source of truth for media
+ * PII classes. The evidence substrate's migrations (evidence_asset /
+ * evidence_fragment, in-flight sibling PR) pin their ASSERT vocabulary to
+ * these values; if they drift at rebase time, this file wins. A unit test
+ * (test/media-consent.unit-spec.ts) pins the two against each other once
+ * the migration exists.
+ */
+
+export type MediaPiiClass = 'face' | 'voice' | 'biometric' | 'id_document' | 'sensitive';
+
+/** Runtime mirror of the MediaPiiClass union — for ASSERT-vocabulary pins
+ *  and classifiers that enumerate the classes. */
+export const MEDIA_PII_CLASSES: readonly MediaPiiClass[] = [
+  'face',
+  'voice',
+  'biometric',
+  'id_document',
+  'sensitive',
+];
+
+/**
+ * Row-fence SQL fragment for media evidence tables. Returns `''` when the
+ * caller holds `brain:read_media` (no fence — the scope sees every state,
+ * including unclassified), else ` AND piiClasses = []` — which in
+ * SurrealQL is true ONLY for the affirmatively-clean empty array:
+ * NONE/absent (unclassified) and non-empty (classified) rows both fail
+ * the equality, so absence stays closed. Interpolate after a WHERE that
+ * already pins tenant/user scope, mirroring the text `piiGate` call sites.
+ */
+export function mediaPiiGate(callerScopes: readonly string[]): string {
+  return callerScopes.includes('brain:read_media') ? '' : ' AND piiClasses = []';
+}
+
+/**
+ * JS-side twin of {@link mediaPiiGate} for per-item decisions (rows
+ * already in hand, e.g. the raw-evidence per-call gate in
+ * src/mcp/raw-evidence-gate.ts). Same polarity table:
+ * scope → allowed; `[]` → allowed; NONE/undefined or non-empty → denied.
+ */
+export function mediaPiiAllowed(
+  piiClasses: readonly string[] | null | undefined,
+  callerScopes: readonly string[],
+): boolean {
+  if (callerScopes.includes('brain:read_media')) return true;
+  return Array.isArray(piiClasses) && piiClasses.length === 0;
+}

--- a/src/contracts/admin/packs.schema.ts
+++ b/src/contracts/admin/packs.schema.ts
@@ -34,6 +34,12 @@ export const InstallPackRequestSchema = z.object({
    *  non-empty, unless a prior install already accepted the identical
    *  section — an upgrade that CHANGES it re-requires the flag. */
   acceptMcpTools: z.boolean().optional(),
+  /** Explicit consent to the manifest's declared non-text modalities and
+   *  raw-evidence capability (media/biometric tier, 0112). Required (400
+   *  otherwise) whenever the manifest declares non-text modality
+   *  processing, unless a prior install already accepted the identical
+   *  media section — an upgrade that CHANGES it re-requires the flag. */
+  acceptModalities: z.boolean().optional(),
 });
 
 export const InstallFromRegistryRequestSchema = z.object({
@@ -42,6 +48,8 @@ export const InstallFromRegistryRequestSchema = z.object({
   version: z.string().optional(),
   /** See InstallPackRequest.acceptMcpTools — same consent gate. */
   acceptMcpTools: z.boolean().optional(),
+  /** See InstallPackRequest.acceptModalities — same consent gate. */
+  acceptModalities: z.boolean().optional(),
 });
 
 export const InstallPackResponseSchema = z.object({

--- a/src/db/migrations/0112_pack_modality_consent.surql
+++ b/src/db/migrations/0112_pack_modality_consent.surql
@@ -1,0 +1,11 @@
+-- 0112_pack_modality_consent — install-time consent for pack-declared
+-- non-text modality processing (media/biometric tier, Brain v2.1). Mirrors
+-- the 0068 mcpTools consent fields: ONE checksum covers the whole media
+-- section of the manifest (declared non-text modalities + any raw-evidence
+-- capability declaration), so ANY change to that section is a single
+-- re-consent trigger; an upgrade that leaves it byte-identical carries the
+-- stored consent over. See src/ai/domain-packs/modality-consent.ts.
+-- (0108-0111 are claimed by in-flight sibling PRs; this file deliberately
+-- takes 0112 — the gap closes as those PRs merge.)
+DEFINE FIELD IF NOT EXISTS acceptedModalities ON domain_pack TYPE option<bool>;
+DEFINE FIELD IF NOT EXISTS acceptedModalitiesChecksum ON domain_pack TYPE option<string>;

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -211,6 +211,11 @@ export class McpService {
    * Applied AFTER the policy gate, and removals are independent, so
    * deny-overrides holds: a policy deny removes a tool the grant
    * allows, and a grant omission removes a tool the policy allows.
+   *
+   * Registration gates end here. A future pack tool that SERVES raw
+   * media evidence must additionally call gateRawEvidence
+   * (./raw-evidence-gate.ts) per served fragment — same deny-overrides
+   * discipline, applied per call rather than per registration.
    */
   private applyGrantToolGate(
     server: McpServer,

--- a/src/mcp/raw-evidence-gate.ts
+++ b/src/mcp/raw-evidence-gate.ts
@@ -1,0 +1,69 @@
+import type { DomainPackManifest } from '../ai/domain-packs';
+import { declaredModalitySection, modalitiesChecksum } from '../ai/domain-packs';
+import { mediaPiiAllowed } from '../common/media-pii';
+
+/**
+ * Per-call gate for pack tools that would serve RAW media evidence
+ * (media/biometric tier, Brain v2.1).
+ *
+ * NO tool currently serves raw evidence — this is the guard the future
+ * surface MUST call, once per served fragment, before returning bytes or
+ * a signed URL. The intended call site is the pack-tool handler layer in
+ * mcp.service.ts, alongside the deny-overrides tool gates
+ * (applyPolicyToolGate / applyGrantToolGate): those decide whether a tool
+ * is REGISTERED; this decides whether one CALL may serve one fragment.
+ * Kept in its own module so the pending tool-observation wrapper PR in
+ * mcp.service.ts rebases cleanly around it.
+ *
+ * Deny-overrides — ALL of the following must hold, checked in order,
+ * first failure wins:
+ *   (a) the pack manifest declares the raw-evidence capability
+ *       (declaredModalitySection().rawEvidence — see modality-consent.ts);
+ *   (b) the tenant's stored consent is current: acceptedModalities === true
+ *       AND the stored checksum equals the checksum of the CURRENT
+ *       manifest's media section (a row edited out-of-band, or consent
+ *       recorded for an older declaration, serves nothing);
+ *   (c) the fragment passes the media PII gate (src/common/media-pii.ts):
+ *       unclassified (NONE) blocked, non-empty blocked without
+ *       brain:read_media, only `[]` (affirmatively clean) or the scope
+ *       opens it.
+ */
+export type RawEvidenceDecision = { allowed: true } | { allowed: false; reason: string };
+
+export function gateRawEvidence(opts: {
+  manifest: DomainPackManifest;
+  /** Stored consent row state (domain_pack.acceptedModalities, 0112). */
+  acceptedModalities: boolean;
+  acceptedModalitiesChecksum: string | null;
+  callerScopes: readonly string[];
+  /** The fragment's piiClasses column — pass exactly what the row holds
+   *  (undefined/null = unclassified). */
+  fragmentPiiClasses: readonly string[] | null | undefined;
+}): RawEvidenceDecision {
+  const section = declaredModalitySection(opts.manifest);
+  if (!section || section.rawEvidence === undefined) {
+    return {
+      allowed: false,
+      reason: `pack "${opts.manifest.id}" does not declare the raw-evidence capability`,
+    };
+  }
+  const currentChecksum = modalitiesChecksum(section);
+  if (opts.acceptedModalities !== true || opts.acceptedModalitiesChecksum !== currentChecksum) {
+    return {
+      allowed: false,
+      reason:
+        `pack "${opts.manifest.id}" has no current modality consent ` +
+        `(re-install with acceptModalities: true)`,
+    };
+  }
+  if (!mediaPiiAllowed(opts.fragmentPiiClasses, opts.callerScopes)) {
+    return {
+      allowed: false,
+      reason:
+        opts.fragmentPiiClasses == null
+          ? 'fragment is unclassified for media PII (fail closed)'
+          : 'fragment carries media PII classes and the caller lacks brain:read_media',
+    };
+  }
+  return { allowed: true };
+}

--- a/test/media-consent.unit-spec.ts
+++ b/test/media-consent.unit-spec.ts
@@ -1,0 +1,291 @@
+/**
+ * Media/biometric consent tier (Brain v2.1) — unit coverage:
+ *  - media PII gate polarity (NONE blocked / [] open / class blocked /
+ *    scope opens) — the deliberate flip vs the text `piiClass IS NONE`;
+ *  - modality consent checksum matrix (fresh / carry-over / changed /
+ *    removed), mirroring mcpConsentRequired semantics;
+ *  - PIN: brain:read_media is OMITTED from jwks VALID_SCOPES (env-key
+ *    only, never mintable) while env-key parsing accepts it;
+ *  - PIN (conditional): the MediaPiiClass union matches the evidence
+ *    substrate migration's ASSERT vocabulary once that migration lands;
+ *  - raw-evidence per-call gate deny-overrides ladder.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ConfigService } from '@nestjs/config';
+import { ApiKeyService } from '../src/auth/api-key.service';
+import { MEDIA_PII_CLASSES, mediaPiiAllowed, mediaPiiGate } from '../src/common/media-pii';
+import {
+  declaredModalitySection,
+  modalitiesChecksum,
+  modalityConsentRequired,
+  rawEvidenceCapability,
+  type DomainPackManifest,
+} from '../src/ai/domain-packs';
+import { gateRawEvidence } from '../src/mcp/raw-evidence-gate';
+
+const READ_MEDIA = ['brain:read', 'brain:read_media'];
+const PLAIN = ['brain:read', 'brain:read_pii'];
+
+describe('mediaPiiGate — fail-closed polarity (flip vs text piiClass)', () => {
+  it('without brain:read_media the fence admits ONLY affirmatively-clean rows', () => {
+    expect(mediaPiiGate(PLAIN)).toBe(' AND piiClasses = []');
+  });
+
+  it('brain:read_media removes the fence entirely (sees unclassified + classified)', () => {
+    expect(mediaPiiGate(READ_MEDIA)).toBe('');
+  });
+
+  it('read_pii does NOT open media rows — the tiers are not conflated', () => {
+    expect(mediaPiiGate(['brain:read_pii'])).toBe(' AND piiClasses = []');
+  });
+
+  // JS twin — same table the SQL fragment enforces.
+  it.each([
+    // [piiClasses, scopes, allowed]
+    [undefined, PLAIN, false], // NONE = unclassified → BLOCKED
+    [null, PLAIN, false], // NONE = unclassified → BLOCKED
+    [[], PLAIN, true], // [] = affirmatively clean → open
+    [['face'], PLAIN, false], // classified → blocked without scope
+    [['face'], READ_MEDIA, true], // scope opens classified
+    [undefined, READ_MEDIA, true], // scope opens unclassified (no fence)
+    [[], READ_MEDIA, true],
+  ] as const)('mediaPiiAllowed(%j, %j) === %j', (piiClasses, scopes, allowed) => {
+    expect(mediaPiiAllowed(piiClasses as string[] | null | undefined, [...scopes])).toBe(allowed);
+  });
+});
+
+const manifest = (memoryModel?: Record<string, unknown>): DomainPackManifest =>
+  ({
+    id: 'media_pack',
+    version: '1.0.0',
+    description: 'Synthetic media pack (unit).',
+    predicates: [],
+    ...(memoryModel ? { memoryModel } : {}),
+  }) as unknown as DomainPackManifest;
+
+describe('declaredModalitySection — the defensive manifest probe', () => {
+  it('returns null when nothing is declared (every existing pack — inert)', () => {
+    expect(declaredModalitySection(manifest())).toBeNull();
+  });
+
+  it('returns null for a text-only declaration', () => {
+    expect(declaredModalitySection(manifest({ modalities: ['text'] }))).toBeNull();
+  });
+
+  it('keeps non-text entries and drops text', () => {
+    const s = declaredModalitySection(manifest({ modalities: ['text', 'image', 'audio'] }));
+    expect(s).toEqual({ modalities: ['image', 'audio'] });
+  });
+
+  it('accepts the processors spelling and object entries', () => {
+    const s = declaredModalitySection(
+      manifest({ processors: [{ kind: 'text' }, { kind: 'image', model: 'x' }] }),
+    );
+    expect(s?.modalities).toEqual([{ kind: 'image', model: 'x' }]);
+  });
+
+  it('a raw-evidence declaration alone makes the section non-null', () => {
+    const s = declaredModalitySection(manifest({ rawEvidence: { serve: true } }));
+    expect(s).toEqual({ modalities: [], rawEvidence: { serve: true } });
+    expect(rawEvidenceCapability(manifest({ rawEvidence: { serve: true } }))).toEqual({
+      serve: true,
+    });
+    expect(rawEvidenceCapability(manifest({ modalities: ['image'] }))).toBeNull();
+  });
+});
+
+describe('modalityConsentRequired — checksum matrix', () => {
+  const declared = declaredModalitySection(
+    manifest({ modalities: ['image'], rawEvidence: { serve: true } }),
+  );
+  const chk = modalitiesChecksum(declared);
+  const base = { packId: 'media_pack', version: '1.0.0', declared };
+
+  it('checksum is null iff nothing is declared', () => {
+    expect(modalitiesChecksum(null)).toBeNull();
+    expect(chk).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('fresh install: declared without the flag → refusal naming the flag + modalities', () => {
+    const msg = modalityConsentRequired({
+      ...base,
+      accepted: undefined,
+      priorAccepted: false,
+      priorChecksum: null,
+    });
+    expect(msg).toContain('acceptModalities');
+    expect(msg).toContain('image');
+    expect(msg).toContain('raw-evidence');
+  });
+
+  it('fresh install: flag grants consent', () => {
+    expect(
+      modalityConsentRequired({
+        ...base,
+        accepted: true,
+        priorAccepted: false,
+        priorChecksum: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('carry-over: identical section needs no flag on upgrade', () => {
+    expect(
+      modalityConsentRequired({
+        ...base,
+        accepted: undefined,
+        priorAccepted: true,
+        priorChecksum: chk,
+      }),
+    ).toBeNull();
+  });
+
+  it('changed: a different stored checksum re-requires the flag (single trigger)', () => {
+    const changed = declaredModalitySection(manifest({ modalities: ['image', 'audio'] }));
+    expect(modalitiesChecksum(changed)).not.toBe(chk);
+    const msg = modalityConsentRequired({
+      ...base,
+      declared: changed,
+      accepted: undefined,
+      priorAccepted: true,
+      priorChecksum: chk,
+    });
+    expect(msg).toContain('acceptModalities');
+  });
+
+  it('removed: a manifest that drops the section needs no consent', () => {
+    expect(
+      modalityConsentRequired({
+        packId: 'media_pack',
+        version: '2.0.0',
+        declared: null,
+        accepted: undefined,
+        priorAccepted: true,
+        priorChecksum: chk,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('brain:read_media scope — env-key only, never jwks-mintable', () => {
+  it('PIN: jwks VALID_SCOPES omits brain:read_media (and still holds read_pii)', () => {
+    const src = readFileSync(join(__dirname, '../src/auth/jwks.service.ts'), 'utf8');
+    const block = /const VALID_SCOPES[\s\S]*?\]\);/.exec(src)?.[0];
+    expect(block).toBeDefined();
+    expect(block).toContain("'brain:read_pii'");
+    // The deliberate omission: media/biometric is a stricter regime than
+    // read_pii; adding it here would make it mintable through the token
+    // path and conflate the tiers. Env-key/introspection grants only.
+    expect(block).not.toContain('brain:read_media');
+  });
+
+  it('env-key parsing (BRAIN_API_KEYS) accepts the scope', () => {
+    const keyHash = ApiKeyService.hash('media-unit-key');
+    const config = {
+      get: () =>
+        JSON.stringify([
+          { keyHash, companyId: 'co_media_unit', scopes: ['brain:read', 'brain:read_media'] },
+        ]),
+    } as unknown as ConfigService;
+    const svc = new ApiKeyService(config);
+    svc.onModuleInit();
+    const rec = svc.resolve('media-unit-key');
+    expect(rec?.scopes).toContain('brain:read_media');
+  });
+});
+
+describe('MediaPiiClass union vs evidence-substrate migration vocabulary (conditional pin)', () => {
+  // The evidence substrate (evidence_asset / evidence_fragment) lands in a
+  // sibling PR whose migrations ASSERT a piiClasses vocabulary matching
+  // MEDIA_PII_CLASSES. Until it merges there is nothing to pin — skip
+  // gracefully; once a migration mentioning both an evidence table and
+  // piiClasses exists, this test locks the two vocabularies together
+  // (src/common/media-pii.ts is canonical on drift).
+  const migrationsDir = join(__dirname, '../src/db/migrations');
+  const evidenceMigration = readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.surql'))
+    .map((f) => ({ f, text: readFileSync(join(migrationsDir, f), 'utf8') }))
+    .find(({ text }) => /evidence_(asset|fragment)/.test(text) && text.includes('piiClasses'));
+
+  (evidenceMigration ? it : it.skip)('migration ASSERT vocabulary === MediaPiiClass union', () => {
+    const { text } = evidenceMigration as { f: string; text: string };
+    const assertStmt = /piiClasses[^;]*ASSERT[^;]*;/s.exec(text)?.[0] ?? '';
+    const vocab = [...assertStmt.matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+    expect(new Set(vocab)).toEqual(new Set(MEDIA_PII_CLASSES));
+  });
+});
+
+describe('gateRawEvidence — deny-overrides ladder', () => {
+  const rawManifest = manifest({ modalities: ['image'], rawEvidence: { serve: true } });
+  const currentChk = modalitiesChecksum(declaredModalitySection(rawManifest));
+  const consented = {
+    manifest: rawManifest,
+    acceptedModalities: true,
+    acceptedModalitiesChecksum: currentChk,
+  };
+
+  it('(a) denies when the pack declares no raw-evidence capability', () => {
+    const d = gateRawEvidence({
+      manifest: manifest({ modalities: ['image'] }),
+      acceptedModalities: true,
+      acceptedModalitiesChecksum: modalitiesChecksum(
+        declaredModalitySection(manifest({ modalities: ['image'] })),
+      ),
+      callerScopes: READ_MEDIA,
+      fragmentPiiClasses: [],
+    });
+    expect(d).toEqual({ allowed: false, reason: expect.stringContaining('raw-evidence') });
+  });
+
+  it('(b) denies without consent, and on a stale checksum', () => {
+    for (const row of [
+      { acceptedModalities: false, acceptedModalitiesChecksum: currentChk },
+      { acceptedModalities: true, acceptedModalitiesChecksum: 'deadbeef' },
+      { acceptedModalities: true, acceptedModalitiesChecksum: null },
+    ]) {
+      const d = gateRawEvidence({
+        manifest: rawManifest,
+        ...row,
+        callerScopes: READ_MEDIA,
+        fragmentPiiClasses: [],
+      });
+      expect(d.allowed).toBe(false);
+      if (!d.allowed) expect(d.reason).toContain('consent');
+    }
+  });
+
+  it('(c) fragment gate: unclassified and classified both deny without the scope', () => {
+    const unclassified = gateRawEvidence({
+      ...consented,
+      callerScopes: PLAIN,
+      fragmentPiiClasses: undefined,
+    });
+    expect(unclassified).toEqual({
+      allowed: false,
+      reason: expect.stringContaining('unclassified'),
+    });
+    const classified = gateRawEvidence({
+      ...consented,
+      callerScopes: PLAIN,
+      fragmentPiiClasses: ['face'],
+    });
+    expect(classified).toEqual({
+      allowed: false,
+      reason: expect.stringContaining('brain:read_media'),
+    });
+  });
+
+  it('allows affirmatively-clean fragments, and classified ones for the scope', () => {
+    expect(gateRawEvidence({ ...consented, callerScopes: PLAIN, fragmentPiiClasses: [] })).toEqual({
+      allowed: true,
+    });
+    expect(
+      gateRawEvidence({
+        ...consented,
+        callerScopes: READ_MEDIA,
+        fragmentPiiClasses: ['face', 'voice'],
+      }),
+    ).toEqual({ allowed: true });
+  });
+});

--- a/test/pack-modality-consent.e2e-spec.ts
+++ b/test/pack-modality-consent.e2e-spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Modality consent tier (0112) — lean install-flow e2e: a manifest that
+ * declares non-text modalities (via the defensive accessor's documented
+ * shape, `memoryModel.modalities` + `memoryModel.rawEvidence`) is
+ * rejected without acceptModalities, installs with it, carries consent
+ * over on a byte-identical re-install, and re-requires the flag when the
+ * media section changes. A modality-free manifest stays byte-identical
+ * to the pre-0112 path (inert by construction).
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+
+describe('pack modality consent (e2e)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const predicate = {
+    localId: 'media_note',
+    displayLabel: 'media note',
+    description: 'TYPE subject is a person; value is a note about a media item',
+    datatype: 'string',
+    semantics: 'append_only',
+    decayHalfLifeDays: null,
+    piiClass: 'none',
+    status: 'active',
+  };
+
+  const manifest = (over: Record<string, unknown> = {}) => ({
+    id: 'media_modality',
+    version: '1.0.0',
+    description: 'Modality consent test pack (e2e).',
+    predicates: [predicate],
+    // The defensive accessor's documented probe shape — see
+    // src/ai/domain-packs/modality-consent.ts declaredModalitySection().
+    memoryModel: { modalities: ['text', 'image'], rawEvidence: { serve: true } },
+    ...over,
+  });
+
+  beforeAll(async () => {
+    f = await createApp({
+      companyId: 'co_pack_modality_e2e',
+      scopes: ['brain:read', 'brain:write', 'brain:admin'],
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('rejects a modality-declaring manifest without acceptModalities (naming the modalities)', async () => {
+    const r = await f.http.post('/v1/admin/packs').set(auth()).send({ manifest: manifest() });
+    expect(r.status).toBe(400);
+    const msg = JSON.stringify(r.body);
+    expect(msg).toContain('acceptModalities');
+    expect(msg).toContain('image');
+    expect(msg).toContain('raw-evidence');
+  });
+
+  it('installs with acceptModalities: true', async () => {
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: manifest(), acceptModalities: true });
+    expect([200, 201]).toContain(r.status);
+    expect(r.body.packId).toBe('media_modality');
+  });
+
+  it('carries consent over on an upgrade with an identical media section', async () => {
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: manifest({ version: '1.0.1' }) });
+    expect([200, 201]).toContain(r.status);
+  });
+
+  it('re-requires the flag when the media section changes, then accepts it', async () => {
+    const changed = manifest({
+      version: '1.1.0',
+      memoryModel: { modalities: ['text', 'image', 'audio'], rawEvidence: { serve: true } },
+    });
+    const denied = await f.http.post('/v1/admin/packs').set(auth()).send({ manifest: changed });
+    expect(denied.status).toBe(400);
+    expect(JSON.stringify(denied.body)).toContain('acceptModalities');
+
+    const ok = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: changed, acceptModalities: true });
+    expect([200, 201]).toContain(ok.status);
+  });
+
+  it('a modality-free manifest installs without the flag (inert path)', async () => {
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({
+        manifest: {
+          id: 'media_plain',
+          version: '1.0.0',
+          description: 'Modality-free control pack (e2e).',
+          predicates: [predicate],
+        },
+      });
+    expect([200, 201]).toContain(r.status);
+  });
+});


### PR DESCRIPTION
## Design center: the polarity flip

The text PII fence treats absence as clean: `AND piiClass IS NONE` opens every unclassified row. Media evidence must invert that — an unclassified photo or audio clip may contain faces, voices, or ID documents, so **absence of classification means closed**. Media rows carry `piiClasses: option<array<string>>` with three distinct states:

| `piiClasses` | meaning | unscoped caller |
|---|---|---|
| `NONE` / absent | unclassified | **BLOCKED** (fail closed) |
| `[]` | affirmatively clean — a classifier looked and found nothing | open |
| non-empty | classified sensitive | blocked without `brain:read_media` |

`mediaPiiGate(callerScopes)` (src/common/media-pii.ts) emits the row fence (`''` with the scope, ` AND piiClasses = []` without — the equality is true only for the empty array, so both NONE and non-empty stay closed), with `mediaPiiAllowed` as its JS twin for per-item decisions.

## Why a NEW env-key-only scope, not read_pii

Biometric/media is a **stricter regime** than `brain:read_pii`, not an extension of it. Reusing read_pii would silently grant every existing read_pii holder biometric access the day media evidence lands. `brain:read_media` is therefore:

- a separate member of the BrainScope union, documented platform_admin-style;
- deliberately **NOT** added to jwks `VALID_SCOPES` — never mintable through the token path; env-key/introspection grants only. The omission is **pinned by a unit test**, so adding it later is a conscious act, not drift.

## Single-checksum consent model (0112, 0068 mold)

`domain_pack` gains `acceptedModalities` + `acceptedModalitiesChecksum`. ONE canonical-JSON sha256 covers the whole media section — declared non-text modalities **plus** any raw-evidence capability declaration — so any change to either is a single re-consent trigger:

- fresh install declaring non-text modalities → 400 without `acceptModalities: true` (both install routes; refusal names the modalities);
- upgrade with a byte-identical section → consent carries over;
- changed section → re-requires the flag; dropped section → stored consent cleared.

`modalityConsentRequired` mirrors `mcpConsentRequired` exactly; enforcement sits beside the MCP consent block in `DomainPackInstallService.install()`.

On top of consent, `src/mcp/raw-evidence-gate.ts` ships the per-call deny-overrides guard the future raw-evidence tool surface must call per served fragment: capability declared → stored consent checksum current → fragment passes the media PII gate. No tool serves raw evidence today; the intended call site is documented next to the registration gates in mcp.service.ts (whose diff is a doc pointer only).

## Inert by construction (why no feature flag)

No current manifest declares modalities, so `declaredModalitySection()` returns null for every existing pack and the install path is **byte-identical** to before — verified by the e2e inert-path case. A flag would only add a second way to be off.

## Coordination notes

- **evidence-substrate sibling PR**: creates `evidence_asset`/`evidence_fragment` with this `piiClasses` shape and an ASSERT vocabulary matching the `MediaPiiClass` union. **This PR's union is canonical on drift.** A conditional unit test pins union vs migration vocabulary and skips gracefully until that migration merges.
- **P-track sibling PR (manifest field)**: the manifest is probed defensively through `declaredModalitySection()` (`memoryModel.modalities`, `memoryModel.processors` fallback, `memoryModel.rawEvidence`) — the documented single bind point; when the typed field lands, only that accessor changes.
- **tool-observation sibling PR**: touches mcp.service.ts — this PR keeps its diff to a comment pointer for clean rebases.
- **Migration numbering**: 0108–0111 are claimed by in-flight siblings; this PR takes **0112** (noted in the file header; the gap closes as those merge).

## Verification

- `pnpm typecheck` clean; `pnpm lint:ci` clean (0 warnings); `prettier --check src+test` clean
- `pnpm test:unit`: 304 suites, 2964 passed, 1 skipped (the conditional vocabulary pin)
- `pnpm test:e2e --testPathPatterns "domain-pack|pack"`: 8 suites, 59 passed (incl. new pack-modality-consent.e2e-spec.ts: reject/accept/carry-over/re-consent/inert)
- `pnpm openapi:build` regenerated both committed copies (only `acceptModalities` added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
