### PR TITLE
feat(packs): memoryModel manifest section — domain perception contract (validation + storage + reader)

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -538,6 +538,13 @@
             },
             "type": "array"
           },
+          "memoryModel": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "predicates": {
             "items": {
               "additionalProperties": {},
@@ -1472,6 +1479,20 @@
           "installedAt": {
             "type": "string"
           },
+          "memoryModel": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "packId": {
             "type": "string"
           },
@@ -1489,7 +1510,8 @@
           "version",
           "installedAt",
           "predicateCount",
-          "checksum"
+          "checksum",
+          "memoryModel"
         ],
         "type": "object"
       },

--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -293,6 +293,52 @@ Both are flag-gated (`MCP_PACK_TOOLS_ENABLED` master, default off).
 Full reference — manifest fields, consent flow, endpoint protocol with
 signature verification, security model: [mcp-pack-tools.md](mcp-pack-tools.md).
 
+## Memory model (contract)
+
+A pack MAY ship a `memoryModel` section — the **domain perception
+contract**: how this domain perceives and episodizes memory. It turns a
+pack from a vocabulary into a domain *projection*: the pack declares HOW
+to look, never WHAT is true. The section is contract-only today
+(validated, stored, cached, exposed read-only on the admin surface);
+the perception/episodization consumers arrive in sibling increments.
+
+Five optional arrays (a present section must declare at least one
+non-empty array; present-but-empty is rejected):
+
+| Field | What it declares | Caps |
+| --- | --- | --- |
+| `sceneSchemas` | Recurring scene shapes (`id`, `description`, literal `cues`) | ≤ 8 schemas, ≤ 12 cues of 2..64 chars |
+| `stateModels` | Subject-typed lifecycles (`states`, optional `transitions`) | ≤ 8 models, 2..16 states, ≤ 64 transitions |
+| `attentionHints` | Literal `cue` → `prefer` (own predicates), `zoom` (own scenes ∪ `episodes`/`facts`/`scenes`), `weight` (0,1] | ≤ 16 hints, ≤ 8 prefer, ≤ 4 zoom |
+| `verificationRules` | Claim classes needing `human_confirmation` \| `corroboration` \| `recency_check` | ≤ 16 rules, `claimPattern` 2..128 chars |
+| `retentionHints` | ADVISORY `ephemeral`/`standard`/`durable` per own predicate/scene | ≤ 32 hints |
+
+Three laws, enforced by `validateMemoryModel`
+(`src/ai/domain-packs/validate-memory-model.ts`):
+
+- **Candidates, never truth.** Everything a consumer derives from a
+  memoryModel — a scene match, a state transition, an attention bias —
+  is a CANDIDATE for the core pipeline, which may reject it. A pack can
+  bias perception; it can never assert memory.
+- **Anti-DSL.** Every free-text field is plain literal text:
+  length-capped, no control characters, no template/DSL syntax (`{{`,
+  `${`, `<%`, backticks, `|`, `\`). `cues` and `claimPattern` are
+  literal substrings — `claimPattern` additionally rejects the regex
+  metacharacters `[]()*+?^$`. No code, templates, or patterns ever ride
+  a manifest.
+- **Referential fence.** Hints may only reference the pack's OWN
+  namespaces: its predicate `localId`s, its own `sceneSchema` ids, and
+  the fixed zoom literals. Cross-pack or core references are rejected at
+  validation time, mirroring the mcpTools query fence.
+
+No consent flag: unlike `mcpTools`, a memoryModel registers nothing on
+any agent surface and causes zero egress, so install/upgrade proceeds
+without an `accept*` flag (the decision + its boundary are documented in
+`DomainPackInstallService`). It rides the signed/checksummed manifest,
+so integrity and version-immutability cover it with zero new machinery;
+an upgrade that changes the section flips `memoryModelChanged` in the
+upgrade diff and invalidates the `MemoryModelReaderService` cache.
+
 ## The registry (global catalogue)
 
 Packs are published to and installed from a **global registry** — a shared,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -538,6 +538,13 @@
             },
             "type": "array"
           },
+          "memoryModel": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "predicates": {
             "items": {
               "additionalProperties": {},
@@ -1472,6 +1479,20 @@
           "installedAt": {
             "type": "string"
           },
+          "memoryModel": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "packId": {
             "type": "string"
           },
@@ -1489,7 +1510,8 @@
           "version",
           "installedAt",
           "predicateCount",
-          "checksum"
+          "checksum",
+          "memoryModel"
         ],
         "type": "object"
       },

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -53,6 +53,7 @@ import { RegistryModule } from '../registry/registry.module';
 import { IndexersModule } from '../indexers/indexers.module';
 import { McpModule } from '../mcp/mcp.module';
 import { DomainPackInstallService } from './domain-pack-install.service';
+import { MemoryModelReaderService } from '../ai/memory-model-reader.service';
 import { PackEvalService } from './pack-eval.service';
 import { ScenarioRunnerService } from './scenario-runner.service';
 import { ScenarioWriteService } from './scenario-write.service';
@@ -133,6 +134,11 @@ import { ConfigInspectorService } from './config-inspector.service';
     DemoPipelineService,
     DemoChatService,
     DomainPackInstallService,
+    // Read side of pack-declared memoryModel sections (contract-only for
+    // now; perception consumers arrive in sibling increments). Registered
+    // here so DomainPackInstallService can invalidate its cache on
+    // install/upgrade/uninstall.
+    MemoryModelReaderService,
     PackEvalService,
     ScenarioRunnerService,
     // Scenario-runner phase services (max-params split):

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -35,6 +35,7 @@ import {
 } from '../ai/domain-packs';
 import { assertPublicHttpUrl, EgressDeniedError } from '../common/egress-guard';
 import { PackToolsReaderService } from '../mcp/pack-tools-reader.service';
+import { MemoryModelReaderService } from '../ai/memory-model-reader.service';
 
 export interface InstalledPack {
   packId: string;
@@ -42,6 +43,11 @@ export interface InstalledPack {
   installedAt: string;
   predicateCount: number;
   checksum: string | null;
+  /** The stored manifest's memoryModel section (PackMemoryModel —
+   *  docs/domain-packs.md); null when the pack declares none. Read-only
+   *  admin exposure — the list projection otherwise drops the manifest.
+   *  Typed opaquely to match the wire contract (InstalledPackSchema). */
+  memoryModel: Record<string, unknown> | null;
 }
 
 export interface AvailablePack {
@@ -68,7 +74,7 @@ interface InstalledPackRow {
   packId?: unknown;
   version?: unknown;
   installedAt: string | Date;
-  manifest?: { predicates?: unknown };
+  manifest?: { predicates?: unknown; memoryModel?: Record<string, unknown> };
   checksum?: unknown;
 }
 
@@ -94,10 +100,19 @@ export class DomainPackInstallService {
   private readonly logger = new Logger(DomainPackInstallService.name);
   private readonly builtinIds = new Set(BUILTIN_PACKS.map((p) => p.id));
 
-  // The optional 4th/5th deps are hooks — the REINDEX_ON_PACK_INSTALL /
-  // seed-ingest queue enqueues and the MCP pack-tools cache invalidation
-  // — fire-and-forget concerns, not responsibilities worth a wrapper
-  // class.
+  // The optional 4th..6th deps are hooks — the REINDEX_ON_PACK_INSTALL /
+  // seed-ingest queue enqueues and the MCP pack-tools / memory-model
+  // cache invalidations — fire-and-forget concerns, not responsibilities
+  // worth a wrapper class.
+  //
+  // CONSENT DECISION (memoryModel): installing/upgrading a manifest with
+  // a memoryModel section requires NO consent flag. Unlike mcpTools it is
+  // purely declarative data — it registers nothing on any agent surface
+  // and causes zero egress; every proposal derived from it is a candidate
+  // the core pipeline may reject. mcpToolsChecksum stays scoped to the
+  // mcpTools section only. BOUNDARY: any future memoryModel field that
+  // grants the pack READ access (or any other capability) moves under its
+  // own accepted<Section>Checksum consent gate, mcpConsentRequired-style.
   // eslint-disable-next-line max-params
   constructor(
     private readonly surreal: SurrealService,
@@ -105,6 +120,7 @@ export class DomainPackInstallService {
     private readonly registry: PredicateRegistryService,
     @Optional() private readonly claim?: JobClaimService,
     @Optional() private readonly packToolsReader?: PackToolsReaderService,
+    @Optional() private readonly memoryModelReader?: MemoryModelReaderService,
   ) {}
 
   /** Trust store: publisher → PEM public key, from DOMAIN_PACK_TRUSTED_KEYS
@@ -149,6 +165,7 @@ export class DomainPackInstallService {
           installedAt: new Date(r.installedAt).toISOString(),
           predicateCount: Array.isArray(preds) ? preds.length : 0,
           checksum: r.checksum ? String(r.checksum) : null,
+          memoryModel: r.manifest?.memoryModel ?? null,
         };
       });
     });
@@ -298,6 +315,9 @@ export class DomainPackInstallService {
 
     this.registry.invalidate(companyId);
     this.packToolsReader?.invalidate(companyId);
+    // Covers both fresh installs and upgrades whose diff flipped
+    // memoryModelChanged (applyPackUpgrade rewrites the manifest row).
+    this.memoryModelReader?.invalidate(companyId);
     this.logger.log(
       `Installed pack ${manifest.id} v${manifest.version} into ${companyId} (${seeded} predicate(s) seeded)`,
     );
@@ -555,6 +575,7 @@ export class DomainPackInstallService {
 
     this.registry.invalidate(companyId);
     this.packToolsReader?.invalidate(companyId);
+    this.memoryModelReader?.invalidate(companyId);
     this.logger.log(
       `Uninstalled pack ${packId} from ${companyId} (${deprecated} predicate(s) deprecated)`,
     );

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -23,6 +23,7 @@ export const SEED_PREDICATES: PredicateDefinition[] = assembleSeed(CORE_PREDICAT
 
 export * from './manifest';
 export * from './validate';
+export * from './validate-memory-model';
 export * from './upgrade-diff';
 export * from './checksum';
 export * from './mcp-consent';

--- a/src/ai/domain-packs/manifest.ts
+++ b/src/ai/domain-packs/manifest.ts
@@ -100,6 +100,16 @@ export interface DomainPackManifest {
    * consent at install time (`acceptMcpTools`).
    */
   mcpTools?: PackToolSpec[];
+  /**
+   * How this domain PERCEIVES memory (see PackMemoryModel below and
+   * docs/domain-packs.md). Declarative data ONLY — no code, templates, or
+   * patterns; every proposal derived from it is a CANDIDATE the core
+   * pipeline may accept or reject, never truth. Rides inside the manifest,
+   * so checksum + signature cover it automatically (canonical JSON) with
+   * zero new machinery. No consent flag: it is declarative, registers
+   * nothing, and causes zero egress.
+   */
+  memoryModel?: PackMemoryModel;
 }
 
 /** Compose the stored, namespaced predicate id for a pack-local predicate. */
@@ -219,3 +229,99 @@ export interface PackExternalToolSpec {
 }
 
 export type PackToolSpec = PackQueryToolSpec | PackExternalToolSpec;
+
+// ── memoryModel — the domain perception contract (docs/domain-packs.md) ──
+//
+// A pack may declare HOW its domain perceives and episodizes memory:
+// which scene shapes exist, which subjects carry state machines, which
+// cues deserve attention, which claims need verification, and which
+// predicates/scenes are worth keeping. Everything here is DECLARATIVE
+// DATA — no code, no templates, no patterns (cues and claimPattern are
+// literal substrings, NEVER regexes or template syntax). Consumers treat
+// every derived proposal as a CANDIDATE for the core pipeline, never as
+// truth. The section lives inside the signed/checksummed manifest, so
+// integrity + immutability cover it automatically (canonical JSON).
+
+/** Caps for the memoryModel section (validate-memory-model.ts enforces). */
+export const MM_MAX_SCENE_SCHEMAS = 8;
+export const MM_MAX_STATE_MODELS = 8;
+export const MM_MAX_ATTENTION_HINTS = 16;
+export const MM_MAX_STATES = 16;
+export const MM_MAX_TRANSITIONS = 64;
+export const MM_MAX_CUES = 12;
+export const MM_MAX_VERIFICATION_RULES = 16;
+export const MM_MAX_RETENTION_HINTS = 32;
+
+/** A recurring scene shape of the domain ("viewing", "claim_intake", …).
+ *  Cues are literal substrings (2..64 chars) that suggest — never assert —
+ *  the scene; a match yields a scene CANDIDATE only. */
+export interface PackSceneSchema {
+  /** snake_case, no `__`; unique within the pack's memoryModel. */
+  id: string;
+  /** 1..500 chars, plain text. */
+  description: string;
+  /** ≤ MM_MAX_CUES literal substrings, each 2..64 chars. */
+  cues?: string[];
+}
+
+/** One allowed state transition of a PackStateModel. */
+export interface PackStateTransition {
+  /** Must be one of the model's declared states. */
+  from: string;
+  /** Must be one of the model's declared states. */
+  to: string;
+}
+
+/** A subject-typed state machine ("deal: open → under_offer → closed").
+ *  Advisory vocabulary for lifecycle-aware consumers — never a gate. */
+export interface PackStateModel {
+  /** snake_case, no `__`; unique within the pack's memoryModel. */
+  id: string;
+  /** What kind of subject carries this lifecycle. 1..64 chars. */
+  subjectType: string;
+  /** 2..MM_MAX_STATES snake_case states, unique. */
+  states: string[];
+  /** ≤ MM_MAX_TRANSITIONS; both ends must be declared states. */
+  transitions?: PackStateTransition[];
+}
+
+/** "When you see this, look closer": a literal cue that biases retrieval /
+ *  perception toward the pack's own vocabulary. NEVER a pattern. */
+export interface PackAttentionHint {
+  /** Literal substring, 2..64 chars — NEVER a regex or template. */
+  cue: string;
+  /** ≤ 8 of the pack's OWN predicate localIds to prefer. */
+  prefer?: string[];
+  /** ≤ 4 zoom targets: the pack's own sceneSchema ids and/or the fixed
+   *  literals 'episodes' | 'facts' | 'scenes'. */
+  zoom?: string[];
+  /** Bias strength in (0, 1]; default 0.5. */
+  weight?: number;
+}
+
+/** A claim class the domain wants double-checked before it hardens. */
+export interface PackVerificationRule {
+  /** Literal substring (2..128 chars) selecting claims — NOT a pattern;
+   *  absent = the rule applies to all of the pack's claims. */
+  claimPattern?: string;
+  requires: 'human_confirmation' | 'corroboration' | 'recency_check';
+}
+
+/** ADVISORY retention preference for one of the pack's own predicates
+ *  (localId) or sceneSchemas (id). Never overrides core retention/GDPR. */
+export interface PackRetentionHint {
+  /** ∈ own predicate localIds ∪ own sceneSchema ids. */
+  predicateOrScene: string;
+  hint: 'ephemeral' | 'standard' | 'durable';
+}
+
+/** The pack's declared perception of its domain — all five arrays are
+ *  optional, but a present section must declare at least one non-empty
+ *  array (present-but-empty is an authoring error). */
+export interface PackMemoryModel {
+  sceneSchemas?: PackSceneSchema[];
+  stateModels?: PackStateModel[];
+  attentionHints?: PackAttentionHint[];
+  verificationRules?: PackVerificationRule[];
+  retentionHints?: PackRetentionHint[];
+}

--- a/src/ai/domain-packs/upgrade-diff.ts
+++ b/src/ai/domain-packs/upgrade-diff.ts
@@ -1,4 +1,5 @@
 import type { PredicateDefinition } from '../predicate-registry-internals/types';
+import { canonicalJson } from './checksum';
 import { composePredicateId, type DomainPackManifest, type PackPredicate } from './manifest';
 
 /**
@@ -32,6 +33,9 @@ export interface PackUpgradeDiff {
   changed: PredicateDefinition[];
   /** Namespaced ids present in the prior manifest but gone in the new — deprecate. */
   removedIds: string[];
+  /** True when the memoryModel section differs (added, removed, or edited) —
+   *  the install service invalidates the memory-model reader cache on it. */
+  memoryModelChanged: boolean;
 }
 
 function defsDiffer(a: PackPredicate, b: PackPredicate): boolean {
@@ -72,5 +76,10 @@ export function diffPackUpgrade(
     }
   }
 
-  return { changed, removedIds };
+  // Canonical-JSON compare (defsDiffer idiom, but key-order-stable): a
+  // reordered-but-equivalent section is NOT a change; absent === absent.
+  const memoryModelChanged =
+    canonicalJson(prior?.memoryModel ?? null) !== canonicalJson(next.memoryModel ?? null);
+
+  return { changed, removedIds, memoryModelChanged };
 }

--- a/src/ai/domain-packs/validate-memory-model.ts
+++ b/src/ai/domain-packs/validate-memory-model.ts
@@ -1,0 +1,416 @@
+import { DomainPackError } from './validate';
+import {
+  MM_MAX_ATTENTION_HINTS,
+  MM_MAX_CUES,
+  MM_MAX_RETENTION_HINTS,
+  MM_MAX_SCENE_SCHEMAS,
+  MM_MAX_STATES,
+  MM_MAX_STATE_MODELS,
+  MM_MAX_TRANSITIONS,
+  MM_MAX_VERIFICATION_RULES,
+  PACK_NAMESPACE_SEP,
+  type DomainPackManifest,
+  type PackAttentionHint,
+  type PackRetentionHint,
+  type PackSceneSchema,
+  type PackStateModel,
+  type PackVerificationRule,
+} from './manifest';
+
+/**
+ * Validation for the memoryModel manifest section (PackMemoryModel in
+ * manifest.ts — the domain perception contract). Structural + referential
+ * only, and deliberately env-free like the rest of `pnpm pack:validate`.
+ *
+ * Two laws are enforced here, not merely documented:
+ *  - ANTI-DSL: every free-text field is plain literal text. Length-capped,
+ *    no control characters, and no template/DSL syntax (`{{`, `${`, `<%`,
+ *    backticks, `|`, `\`). claimPattern additionally rejects the regex
+ *    metacharacters []()*+?^$ — it is a literal substring, not a pattern.
+ *  - REFERENTIAL FENCE: hints may only reference the pack's OWN namespaces
+ *    (its predicate localIds, its sceneSchema ids, and the fixed zoom
+ *    literals). A pack can never point attention or retention at core or
+ *    another pack's vocabulary.
+ *
+ * Exported: the memory-model reader re-runs it defensively against stored
+ * manifests before serving anything (PackToolsReaderService mold).
+ */
+
+const SNAKE = /^[a-z][a-z0-9_]*$/;
+/** Fixed zoom targets available to every pack alongside its own scenes. */
+const ZOOM_LITERALS = new Set(['episodes', 'facts', 'scenes']);
+const REQUIRES = new Set(['human_confirmation', 'corroboration', 'recency_check']);
+const RETENTION_HINTS = new Set(['ephemeral', 'standard', 'durable']);
+
+const CONTROL_CHARS = /[\u0000-\u001f\u007f]/;
+const DSL_MARKERS = ['{{', '${', '<%', '`', '|', '\\'];
+const REGEX_METACHARS = /[[\]()*+?^$]/;
+
+/** Anti-DSL guard for one free-text field: plain literal text only. */
+function assertLiteralText(opts: {
+  packId: string;
+  field: string;
+  value: unknown;
+  min: number;
+  max: number;
+}): void {
+  const { packId, field, value, min, max } = opts;
+  if (typeof value !== 'string' || value.length < min || value.length > max) {
+    throw new DomainPackError(
+      `pack "${packId}" memoryModel ${field} must be a string of ${min}..${max} characters`,
+    );
+  }
+  if (CONTROL_CHARS.test(value)) {
+    throw new DomainPackError(
+      `pack "${packId}" memoryModel ${field} must not contain control characters`,
+    );
+  }
+  for (const marker of DSL_MARKERS) {
+    if (value.includes(marker)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel ${field} must be plain literal text — "${marker}" is not allowed (no templates, code, or patterns)`,
+      );
+    }
+  }
+}
+
+function assertSnakeId(packId: string, field: string, value: unknown): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    !SNAKE.test(value) ||
+    value.includes(PACK_NAMESPACE_SEP) ||
+    value.length > 64
+  ) {
+    throw new DomainPackError(
+      `pack "${packId}" memoryModel ${field} "${String(value)}" must be snake_case of at most 64 chars and must not contain "${PACK_NAMESPACE_SEP}"`,
+    );
+  }
+}
+
+function assertObjectEntry(packId: string, field: string, value: unknown): void {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new DomainPackError(`pack "${packId}" memoryModel ${field} entries must be objects`);
+  }
+}
+
+/** A present list must be a non-empty array within its cap (mcpTools mold:
+ *  "declare it or omit it" — present-but-empty is an authoring error). */
+function assertPresentList(opts: {
+  packId: string;
+  field: string;
+  value: unknown;
+  cap: number;
+}): asserts opts is { packId: string; field: string; value: unknown[]; cap: number } {
+  const { packId, field, value, cap } = opts;
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new DomainPackError(
+      `pack "${packId}" memoryModel ${field} must be a non-empty array (omit the field instead of declaring it empty)`,
+    );
+  }
+  if (value.length > cap) {
+    throw new DomainPackError(
+      `pack "${packId}" memoryModel declares ${value.length} ${field} — max is ${cap}`,
+    );
+  }
+}
+
+interface MemoryModelShape {
+  sceneSchemas?: unknown;
+  stateModels?: unknown;
+  attentionHints?: unknown;
+  verificationRules?: unknown;
+  retentionHints?: unknown;
+}
+
+/**
+ * Validate a pack's memoryModel section. Referential fences run against
+ * the pack's OWN predicate localIds and the section's own sceneSchema
+ * ids — dispatched from validatePack's optional-section block and re-run
+ * defensively by the memory-model reader on stored manifests.
+ */
+export function validateMemoryModel(pack: DomainPackManifest, mm: unknown): void {
+  if (typeof mm !== 'object' || mm === null || Array.isArray(mm)) {
+    throw new DomainPackError(`pack "${pack.id}" memoryModel must be an object`);
+  }
+  const model = mm as MemoryModelShape;
+  const declared = [
+    model.sceneSchemas,
+    model.stateModels,
+    model.attentionHints,
+    model.verificationRules,
+    model.retentionHints,
+  ].filter((v) => v !== undefined);
+  if (declared.length === 0) {
+    throw new DomainPackError(
+      `pack "${pack.id}" memoryModel must declare at least one of sceneSchemas|stateModels|attentionHints|verificationRules|retentionHints (omit the section instead of declaring it empty)`,
+    );
+  }
+  const sceneIds = validateSceneSchemas(pack.id, model.sceneSchemas);
+  validateStateModels(pack.id, model.stateModels, sceneIds);
+  const predicateLocalIds = new Set(pack.predicates.map((p) => p.localId));
+  validateAttentionHints({
+    packId: pack.id,
+    hints: model.attentionHints,
+    predicateLocalIds,
+    sceneIds,
+  });
+  validateVerificationRules(pack.id, model.verificationRules);
+  validateRetentionHints({
+    packId: pack.id,
+    hints: model.retentionHints,
+    predicateLocalIds,
+    sceneIds,
+  });
+}
+
+/** Returns the declared sceneSchema ids (the zoom/retention namespace). */
+function validateSceneSchemas(packId: string, schemas: unknown): Set<string> {
+  const sceneIds = new Set<string>();
+  if (schemas === undefined) return sceneIds;
+  assertPresentList({ packId, field: 'sceneSchemas', value: schemas, cap: MM_MAX_SCENE_SCHEMAS });
+  for (const entry of schemas as unknown[]) {
+    assertObjectEntry(packId, 'sceneSchemas', entry);
+    const s = entry as Partial<PackSceneSchema>;
+    assertSnakeId(packId, 'sceneSchema id', s.id);
+    if (sceneIds.has(s.id)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel declares duplicate sceneSchema id "${s.id}"`,
+      );
+    }
+    sceneIds.add(s.id);
+    assertLiteralText({
+      packId,
+      field: `sceneSchema "${s.id}" description`,
+      value: s.description,
+      min: 1,
+      max: 500,
+    });
+    if (s.cues === undefined) continue;
+    if (!Array.isArray(s.cues) || s.cues.length === 0 || s.cues.length > MM_MAX_CUES) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel sceneSchema "${s.id}" cues must be 1..${MM_MAX_CUES} strings`,
+      );
+    }
+    for (const cue of s.cues) {
+      assertLiteralText({
+        packId,
+        field: `sceneSchema "${s.id}" cue`,
+        value: cue,
+        min: 2,
+        max: 64,
+      });
+    }
+  }
+  return sceneIds;
+}
+
+function validateStateModels(packId: string, models: unknown, sceneIds: Set<string>): void {
+  if (models === undefined) return;
+  assertPresentList({ packId, field: 'stateModels', value: models, cap: MM_MAX_STATE_MODELS });
+  const ids = new Set<string>();
+  for (const entry of models as unknown[]) {
+    assertObjectEntry(packId, 'stateModels', entry);
+    const m = entry as Partial<PackStateModel>;
+    assertSnakeId(packId, 'stateModel id', m.id);
+    if (ids.has(m.id)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel declares duplicate stateModel id "${m.id}"`,
+      );
+    }
+    // sceneSchema ids and stateModel ids share downstream reference space
+    // (retentionHints, zoom) — a cross-list collision would make a
+    // reference ambiguous, so reject it outright.
+    if (sceneIds.has(m.id)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel stateModel id "${m.id}" collides with a sceneSchema id`,
+      );
+    }
+    ids.add(m.id);
+    assertLiteralText({
+      packId,
+      field: `stateModel "${m.id}" subjectType`,
+      value: m.subjectType,
+      min: 1,
+      max: 64,
+    });
+    validateStates(packId, m);
+  }
+}
+
+/** states (2..16 snake_case unique) + transitions (≤64, both ends ∈ states). */
+function validateStates(packId: string, m: Partial<PackStateModel>): void {
+  const id = String(m.id);
+  if (!Array.isArray(m.states) || m.states.length < 2 || m.states.length > MM_MAX_STATES) {
+    throw new DomainPackError(
+      `pack "${packId}" memoryModel stateModel "${id}" states must be 2..${MM_MAX_STATES} entries`,
+    );
+  }
+  const states = new Set<string>();
+  for (const state of m.states) {
+    assertSnakeId(packId, `stateModel "${id}" state`, state);
+    if (states.has(state)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel stateModel "${id}" declares duplicate state "${state}"`,
+      );
+    }
+    states.add(state);
+  }
+  if (m.transitions === undefined) return;
+  if (!Array.isArray(m.transitions) || m.transitions.length === 0) {
+    throw new DomainPackError(
+      `pack "${packId}" memoryModel stateModel "${id}" transitions must be a non-empty array (omit the field instead)`,
+    );
+  }
+  if (m.transitions.length > MM_MAX_TRANSITIONS) {
+    throw new DomainPackError(
+      `pack "${packId}" memoryModel stateModel "${id}" declares ${m.transitions.length} transitions — max is ${MM_MAX_TRANSITIONS}`,
+    );
+  }
+  for (const t of m.transitions) {
+    assertObjectEntry(packId, `stateModel "${id}" transitions`, t);
+    for (const end of ['from', 'to'] as const) {
+      const v = (t as unknown as Record<string, unknown>)[end];
+      if (typeof v !== 'string' || !states.has(v)) {
+        throw new DomainPackError(
+          `pack "${packId}" memoryModel stateModel "${id}" transition ${end} "${String(v)}" is not a declared state`,
+        );
+      }
+    }
+  }
+}
+
+function validateAttentionHints(opts: {
+  packId: string;
+  hints: unknown;
+  predicateLocalIds: Set<string>;
+  sceneIds: Set<string>;
+}): void {
+  const { packId, hints, predicateLocalIds, sceneIds } = opts;
+  if (hints === undefined) return;
+  assertPresentList({ packId, field: 'attentionHints', value: hints, cap: MM_MAX_ATTENTION_HINTS });
+  const cues = new Set<string>();
+  for (const entry of hints as unknown[]) {
+    assertObjectEntry(packId, 'attentionHints', entry);
+    const h = entry as Partial<PackAttentionHint>;
+    assertLiteralText({ packId, field: 'attentionHint cue', value: h.cue, min: 2, max: 64 });
+    const cue = h.cue as string;
+    if (cues.has(cue)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel declares duplicate attentionHint cue "${cue}"`,
+      );
+    }
+    cues.add(cue);
+    validateHintRefs({ packId, cue, hint: h, predicateLocalIds, sceneIds });
+    if (
+      h.weight !== undefined &&
+      (typeof h.weight !== 'number' || !(h.weight > 0) || h.weight > 1)
+    ) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel attentionHint "${cue}" weight must be a number in (0, 1]`,
+      );
+    }
+  }
+}
+
+/** prefer ⊆ own predicate localIds; zoom ⊆ own sceneSchema ids ∪ literals. */
+function validateHintRefs(opts: {
+  packId: string;
+  cue: string;
+  hint: Partial<PackAttentionHint>;
+  predicateLocalIds: Set<string>;
+  sceneIds: Set<string>;
+}): void {
+  const { packId, cue, hint, predicateLocalIds, sceneIds } = opts;
+  if (hint.prefer !== undefined) {
+    if (!Array.isArray(hint.prefer) || hint.prefer.length === 0 || hint.prefer.length > 8) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel attentionHint "${cue}" prefer must be 1..8 predicate localIds`,
+      );
+    }
+    for (const p of hint.prefer) {
+      if (typeof p !== 'string' || !predicateLocalIds.has(p)) {
+        throw new DomainPackError(
+          `pack "${packId}" memoryModel attentionHint "${cue}" prefer references "${String(p)}", which is not a predicate of this pack`,
+        );
+      }
+    }
+  }
+  if (hint.zoom === undefined) return;
+  if (!Array.isArray(hint.zoom) || hint.zoom.length === 0 || hint.zoom.length > 4) {
+    throw new DomainPackError(
+      `pack "${packId}" memoryModel attentionHint "${cue}" zoom must be 1..4 targets`,
+    );
+  }
+  for (const z of hint.zoom) {
+    if (typeof z !== 'string' || (!ZOOM_LITERALS.has(z) && !sceneIds.has(z))) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel attentionHint "${cue}" zoom target "${String(z)}" must be one of this pack's sceneSchema ids or ${[...ZOOM_LITERALS].join('|')}`,
+      );
+    }
+  }
+}
+
+function validateVerificationRules(packId: string, rules: unknown): void {
+  if (rules === undefined) return;
+  assertPresentList({
+    packId,
+    field: 'verificationRules',
+    value: rules,
+    cap: MM_MAX_VERIFICATION_RULES,
+  });
+  for (const entry of rules as unknown[]) {
+    assertObjectEntry(packId, 'verificationRules', entry);
+    const r = entry as Partial<PackVerificationRule>;
+    if (!REQUIRES.has(r.requires as string)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel verificationRule requires "${String(r.requires)}" must be one of ${[...REQUIRES].join('|')}`,
+      );
+    }
+    if (r.claimPattern === undefined) continue;
+    assertLiteralText({
+      packId,
+      field: 'verificationRule claimPattern',
+      value: r.claimPattern,
+      min: 2,
+      max: 128,
+    });
+    if (REGEX_METACHARS.test(r.claimPattern)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel verificationRule claimPattern "${r.claimPattern}" must be a literal substring, not a pattern — regex metacharacters are not allowed`,
+      );
+    }
+  }
+}
+
+function validateRetentionHints(opts: {
+  packId: string;
+  hints: unknown;
+  predicateLocalIds: Set<string>;
+  sceneIds: Set<string>;
+}): void {
+  const { packId, hints, predicateLocalIds, sceneIds } = opts;
+  if (hints === undefined) return;
+  assertPresentList({ packId, field: 'retentionHints', value: hints, cap: MM_MAX_RETENTION_HINTS });
+  const seen = new Set<string>();
+  for (const entry of hints as unknown[]) {
+    assertObjectEntry(packId, 'retentionHints', entry);
+    const h = entry as Partial<PackRetentionHint>;
+    const ref = h.predicateOrScene;
+    if (typeof ref !== 'string' || (!predicateLocalIds.has(ref) && !sceneIds.has(ref))) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel retentionHint references "${String(ref)}", which is neither a predicate localId nor a sceneSchema id of this pack`,
+      );
+    }
+    if (seen.has(ref)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel declares duplicate retentionHint for "${ref}"`,
+      );
+    }
+    seen.add(ref);
+    if (!RETENTION_HINTS.has(h.hint as string)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel retentionHint "${ref}" hint "${String(h.hint)}" must be one of ${[...RETENTION_HINTS].join('|')}`,
+      );
+    }
+  }
+}

--- a/src/ai/domain-packs/validate.ts
+++ b/src/ai/domain-packs/validate.ts
@@ -8,6 +8,7 @@ import {
   type DomainPackManifest,
   type PackToolParam,
 } from './manifest';
+import { validateMemoryModel } from './validate-memory-model';
 
 /**
  * Validation + assembly for the Domain Pack standard. `validatePack` is what a
@@ -94,6 +95,9 @@ export function validatePack(pack: DomainPackManifest): void {
   }
   if (pack.mcpTools !== undefined) {
     validateMcpTools(pack, pack.mcpTools);
+  }
+  if (pack.memoryModel !== undefined) {
+    validateMemoryModel(pack, pack.memoryModel);
   }
 }
 

--- a/src/ai/memory-model-reader.service.ts
+++ b/src/ai/memory-model-reader.service.ts
@@ -1,0 +1,121 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SurrealService, queryRows } from '../db/surreal.service';
+import { LRUCache } from '../common/lru-cache';
+import {
+  validateMemoryModel,
+  DomainPackError,
+  type DomainPackManifest,
+  type PackMemoryModel,
+} from './domain-packs';
+
+/** One installed pack's declared memory model (perception contract). */
+export interface PackMemoryModelBinding {
+  packId: string;
+  packVersion: string;
+  memoryModel: PackMemoryModel;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+const CACHE_CAP = 200;
+
+/**
+ * Read side of pack-declared memory models: which active packs declare a
+ * memoryModel section for this tenant (PackToolsReaderService mold —
+ * LRU+TTL cache with in-flight dedupe). Contract-only for now: the
+ * perception/episodization consumers arrive in sibling increments and
+ * will sit on hot paths, hence the cache from day one. Fail-open to []
+ * on read errors — a domain_pack hiccup must not take down a consumer;
+ * models reappear on the next load. NO consent gate by design: a
+ * memoryModel is declarative data with zero egress (see the decision
+ * note in DomainPackInstallService).
+ */
+@Injectable()
+export class MemoryModelReaderService {
+  private readonly logger = new Logger(MemoryModelReaderService.name);
+  private readonly cache = new LRUCache<
+    string,
+    { bindings: PackMemoryModelBinding[]; loadedAt: number }
+  >(CACHE_CAP);
+  private readonly inFlight = new Map<string, Promise<PackMemoryModelBinding[]>>();
+
+  constructor(private readonly surreal: SurrealService) {}
+
+  async installedMemoryModels(companyId: string): Promise<PackMemoryModelBinding[]> {
+    const cached = this.cache.get(companyId);
+    if (cached && Date.now() - cached.loadedAt < ttlMs()) {
+      return cached.bindings;
+    }
+    const inFlight = this.inFlight.get(companyId);
+    if (inFlight) return inFlight;
+    const load = this.loadFresh(companyId)
+      .then((bindings) => {
+        this.cache.set(companyId, { bindings, loadedAt: Date.now() });
+        return bindings;
+      })
+      .catch((e) => {
+        this.logger.warn(
+          `memory model load failed for ${companyId} (${(e as Error).message}) — serving no pack memory models`,
+        );
+        return [] as PackMemoryModelBinding[];
+      })
+      .finally(() => this.inFlight.delete(companyId));
+    this.inFlight.set(companyId, load);
+    return load;
+  }
+
+  /** Called by DomainPackInstallService next to registry.invalidate. */
+  invalidate(companyId: string): void {
+    this.cache.delete(companyId);
+  }
+
+  private async loadFresh(companyId: string): Promise<PackMemoryModelBinding[]> {
+    const rows = await this.surreal.withCompany(companyId, (db) =>
+      queryRows<Record<string, unknown>>(
+        db,
+        `SELECT packId, version, manifest
+           FROM domain_pack
+          WHERE status = 'active' AND manifest.memoryModel != NONE`,
+      ),
+    );
+    const bindings: PackMemoryModelBinding[] = [];
+    for (const row of rows) {
+      const binding = this.toBinding(row);
+      if (binding) bindings.push(binding);
+    }
+    return bindings;
+  }
+
+  /**
+   * Row → binding, defensively: the stored section must still pass
+   * validateMemoryModel — a manifest written by an older/newer server
+   * version never reaches a consumer half-checked (PackToolsReaderService
+   * toBinding mold).
+   */
+  private toBinding(row: Record<string, unknown>): PackMemoryModelBinding | null {
+    const manifest = row.manifest as DomainPackManifest | undefined;
+    if (!manifest || manifest.memoryModel === undefined || manifest.memoryModel === null) {
+      return null;
+    }
+    try {
+      validateMemoryModel(manifest, manifest.memoryModel);
+    } catch (e) {
+      if (e instanceof DomainPackError) {
+        this.logger.warn(
+          `pack ${row.packId}: stored memoryModel failed validation (${e.message}) — skipped`,
+        );
+        return null;
+      }
+      throw e;
+    }
+    return {
+      packId: String(row.packId),
+      packVersion: String(row.version),
+      memoryModel: manifest.memoryModel,
+    };
+  }
+}
+
+function ttlMs(): number {
+  const v = Number(process.env.PACK_MEMORY_MODEL_CACHE_TTL_MS);
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_TTL_MS;
+}

--- a/src/contracts/admin/packs.schema.ts
+++ b/src/contracts/admin/packs.schema.ts
@@ -19,6 +19,10 @@ export const InstalledPackSchema = z.object({
   installedAt: z.string(),
   predicateCount: z.number().int().nonnegative(),
   checksum: z.string().nullable(),
+  /** The stored manifest's memoryModel section (PackMemoryModel —
+   *  docs/domain-packs.md); null when the pack declares none. Opaque here
+   *  on purpose; runtime validation is validateMemoryModel. */
+  memoryModel: z.record(z.string(), z.unknown()).nullable(),
 });
 
 export const PacksListResponseSchema = z.object({

--- a/src/contracts/registry/registry.schema.ts
+++ b/src/contracts/registry/registry.schema.ts
@@ -102,6 +102,10 @@ export const DomainPackManifestSchema = z.looseObject({
    *  NO raw JSON Schema passthrough by design; runtime validation is
    *  validateMcpTools on the install/publish path. */
   mcpTools: z.array(z.record(z.string(), z.unknown())).optional(),
+  /** Domain perception contract (PackMemoryModel — docs/domain-packs.md).
+   *  Opaque here on purpose; runtime validation is validateMemoryModel on
+   *  the install/publish path, never this schema. */
+  memoryModel: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const PublishPackRequestSchema = z.object({

--- a/test/contracts-admin-packs.unit-spec.ts
+++ b/test/contracts-admin-packs.unit-spec.ts
@@ -26,6 +26,15 @@ function makeController(): AdminPacksController {
           installedAt: '2026-07-07T00:00:00.000Z',
           predicateCount: 1,
           checksum: 'abc123',
+          memoryModel: null,
+        },
+        {
+          packId: 'realty',
+          version: '1.0.0',
+          installedAt: '2026-07-07T00:00:00.000Z',
+          predicateCount: 1,
+          checksum: 'def456',
+          memoryModel: { sceneSchemas: [{ id: 'viewing', description: 'x' }] },
         },
       ]),
   } as unknown as DomainPackInstallService;

--- a/test/domain-pack-install.e2e-spec.ts
+++ b/test/domain-pack-install.e2e-spec.ts
@@ -226,4 +226,77 @@ describe('/v1/admin/packs — runtime Domain Pack install', () => {
     // Added predicate seeded active.
     expect((byId.get('oncology__regimen') as any)?.status).toBe('active');
   });
+  // ── memoryModel — the domain perception contract (P1, contract-only) ──
+
+  const REALTY_MM_MANIFEST = (version: string, cue: string) => ({
+    id: 'realty_mm',
+    version,
+    description: 'Realty perception test pack (memoryModel e2e).',
+    predicates: [
+      {
+        localId: 'deal_stage',
+        displayLabel: 'deal stage',
+        description: 'TYPE subject is a deal; value is its stage',
+        datatype: 'string',
+        semantics: 'single_active',
+        decayHalfLifeDays: null,
+        piiClass: 'none',
+        status: 'active',
+      },
+    ],
+    memoryModel: {
+      sceneSchemas: [{ id: 'viewing', description: 'A property viewing.', cues: [cue] }],
+      attentionHints: [{ cue: 'asking price', prefer: ['deal_stage'], zoom: ['viewing', 'facts'] }],
+      retentionHints: [{ predicateOrScene: 'deal_stage', hint: 'durable' }],
+    },
+  });
+
+  it('installs a memoryModel-bearing pack (no consent flag needed) and GET returns the section', async () => {
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: REALTY_MM_MANIFEST('1.0.0', 'showed the flat') });
+    expect([200, 201]).toContain(r.status);
+    expect(r.body.packId).toBe('realty_mm');
+
+    const list = await f.http.get('/v1/admin/packs').set(auth());
+    expect(list.status).toBe(200);
+    const installed = list.body.installed.find((p: any) => p.packId === 'realty_mm');
+    expect(installed).toBeDefined();
+    expect(installed.memoryModel).toBeDefined();
+    expect(installed.memoryModel.sceneSchemas[0].id).toBe('viewing');
+    expect(installed.memoryModel.sceneSchemas[0].cues).toEqual(['showed the flat']);
+    // Packs without the section expose null, not a missing key.
+    const medical = list.body.installed.find((p: any) => p.packId === 'medical');
+    expect(medical.memoryModel).toBeNull();
+  });
+
+  it('upgrades with a CHANGED memoryModel section without any re-consent', async () => {
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: REALTY_MM_MANIFEST('1.1.0', 'open house') });
+    expect([200, 201]).toContain(r.status);
+
+    const list = await f.http.get('/v1/admin/packs').set(auth());
+    const installed = list.body.installed.find((p: any) => p.packId === 'realty_mm');
+    expect(installed.version).toBe('1.1.0');
+    expect(installed.memoryModel.sceneSchemas[0].cues).toEqual(['open house']);
+  });
+
+  it('rejects an invalid memoryModel (template syntax in a cue) with 400', async () => {
+    const bad = REALTY_MM_MANIFEST('1.2.0', 'ok cue') as any;
+    bad.memoryModel.attentionHints[0].cue = 'price {{template}}';
+    const r = await f.http.post('/v1/admin/packs').set(auth()).send({ manifest: bad });
+    expect(r.status).toBe(400);
+    expect(r.body.message).toMatch(/plain literal text/);
+  });
+
+  it('rejects a memoryModel referencing a foreign predicate with 400', async () => {
+    const bad = REALTY_MM_MANIFEST('1.2.0', 'ok cue') as any;
+    bad.memoryModel.attentionHints[0].prefer = ['not_our_predicate'];
+    const r = await f.http.post('/v1/admin/packs').set(auth()).send({ manifest: bad });
+    expect(r.status).toBe(400);
+    expect(r.body.message).toMatch(/not a predicate of this pack/);
+  });
 });

--- a/test/pack-memory-model.unit-spec.ts
+++ b/test/pack-memory-model.unit-spec.ts
@@ -1,0 +1,451 @@
+/**
+ * memoryModel manifest section — the domain perception contract
+ * (docs/domain-packs.md): validator matrix (caps, ids, referential
+ * fences, anti-DSL), checksum/signature coverage, upgrade-diff flag, and
+ * the MemoryModelReaderService mold (cache, invalidate, corrupted-section
+ * fail-open).
+ */
+import { generateKeyPairSync } from 'node:crypto';
+import {
+  diffPackUpgrade,
+  packChecksum,
+  signPack,
+  validatePack,
+  validateMemoryModel,
+  verifyPackSignature,
+  DomainPackError,
+  MM_MAX_ATTENTION_HINTS,
+  MM_MAX_RETENTION_HINTS,
+  MM_MAX_SCENE_SCHEMAS,
+  MM_MAX_STATE_MODELS,
+  MM_MAX_VERIFICATION_RULES,
+  type DomainPackManifest,
+  type PackMemoryModel,
+} from '../src/ai/domain-packs';
+import { MemoryModelReaderService } from '../src/ai/memory-model-reader.service';
+import type { SurrealService } from '../src/db/surreal.service';
+
+function manifest(over: Partial<DomainPackManifest> = {}): DomainPackManifest {
+  return {
+    id: 'realty',
+    version: '1.0.0',
+    description: 'real-estate perception test pack',
+    predicates: [
+      {
+        localId: 'deal_stage',
+        displayLabel: 'deal stage',
+        description: 'x',
+        datatype: 'string',
+        semantics: 'single_active',
+        decayHalfLifeDays: null,
+        piiClass: 'none',
+        status: 'active',
+      },
+      {
+        localId: 'asking_price',
+        displayLabel: 'asking price',
+        description: 'x',
+        datatype: 'number',
+        semantics: 'bitemporal',
+        decayHalfLifeDays: null,
+        piiClass: 'none',
+        status: 'active',
+      },
+    ],
+    ...over,
+  };
+}
+
+function memoryModel(over: Partial<PackMemoryModel> = {}): PackMemoryModel {
+  return {
+    sceneSchemas: [
+      { id: 'viewing', description: 'A property viewing.', cues: ['viewing', 'showed the flat'] },
+    ],
+    stateModels: [
+      {
+        id: 'deal_lifecycle',
+        subjectType: 'deal',
+        states: ['open', 'under_offer', 'closed'],
+        transitions: [
+          { from: 'open', to: 'under_offer' },
+          { from: 'under_offer', to: 'closed' },
+        ],
+      },
+    ],
+    attentionHints: [
+      { cue: 'asking price', prefer: ['asking_price'], zoom: ['viewing', 'facts'], weight: 0.7 },
+    ],
+    verificationRules: [{ claimPattern: 'sold for', requires: 'corroboration' }],
+    retentionHints: [
+      { predicateOrScene: 'deal_stage', hint: 'durable' },
+      { predicateOrScene: 'viewing', hint: 'standard' },
+    ],
+    ...over,
+  };
+}
+
+const withMm = (mm: unknown) => manifest({ memoryModel: mm as PackMemoryModel });
+
+describe('validateMemoryModel — the domain perception contract', () => {
+  it('accepts a full, well-formed section via validatePack', () => {
+    expect(() => validatePack(withMm(memoryModel()))).not.toThrow();
+  });
+
+  it('rejects a present-but-empty section (mcpTools mold)', () => {
+    expect(() => validatePack(withMm({}))).toThrow(DomainPackError);
+    expect(() => validatePack(withMm({ sceneSchemas: [] }))).toThrow(/non-empty/);
+    expect(() => validatePack(withMm([]))).toThrow(/must be an object/);
+    expect(() => validatePack(withMm('x'))).toThrow(DomainPackError);
+  });
+
+  it('enforces the per-list caps', () => {
+    const scene = (i: number) => ({ id: `scene_${i}`, description: 'x' });
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        sceneSchemas: Array.from({ length: MM_MAX_SCENE_SCHEMAS + 1 }, (_, i) => scene(i)),
+      }),
+    ).toThrow(/max is 8/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        stateModels: Array.from({ length: MM_MAX_STATE_MODELS + 1 }, (_, i) => ({
+          id: `m_${i}`,
+          subjectType: 'deal',
+          states: ['a', 'b'],
+        })),
+      }),
+    ).toThrow(/max is 8/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        attentionHints: Array.from({ length: MM_MAX_ATTENTION_HINTS + 1 }, (_, i) => ({
+          cue: `cue ${i}`,
+        })),
+      }),
+    ).toThrow(/max is 16/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        verificationRules: Array.from({ length: MM_MAX_VERIFICATION_RULES + 1 }, () => ({
+          requires: 'corroboration',
+        })),
+      }),
+    ).toThrow(/max is 16/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        retentionHints: Array.from({ length: MM_MAX_RETENTION_HINTS + 1 }, () => ({
+          predicateOrScene: 'deal_stage',
+          hint: 'durable',
+        })),
+      }),
+    ).toThrow(/max is 32/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        sceneSchemas: [{ id: 'v', description: 'x', cues: Array.from({ length: 13 }, () => 'aa') }],
+      }),
+    ).toThrow(/cues/);
+  });
+
+  it('enforces snake_case ids without the namespace separator', () => {
+    expect(() =>
+      validateMemoryModel(manifest(), { sceneSchemas: [{ id: 'Viewing', description: 'x' }] }),
+    ).toThrow(/snake_case/);
+    expect(() =>
+      validateMemoryModel(manifest(), { sceneSchemas: [{ id: 'a__b', description: 'x' }] }),
+    ).toThrow(/__/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        stateModels: [{ id: 'ok', subjectType: 'deal', states: ['Open', 'closed'] }],
+      }),
+    ).toThrow(/snake_case/);
+  });
+
+  it('rejects duplicate and cross-list-colliding ids', () => {
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        sceneSchemas: [
+          { id: 'viewing', description: 'x' },
+          { id: 'viewing', description: 'y' },
+        ],
+      }),
+    ).toThrow(/duplicate sceneSchema/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        sceneSchemas: [{ id: 'viewing', description: 'x' }],
+        stateModels: [{ id: 'viewing', subjectType: 'deal', states: ['a', 'b'] }],
+      }),
+    ).toThrow(/collides with a sceneSchema id/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        attentionHints: [{ cue: 'price' }, { cue: 'price' }],
+      }),
+    ).toThrow(/duplicate attentionHint cue/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        retentionHints: [
+          { predicateOrScene: 'deal_stage', hint: 'durable' },
+          { predicateOrScene: 'deal_stage', hint: 'ephemeral' },
+        ],
+      }),
+    ).toThrow(/duplicate retentionHint/);
+  });
+
+  it('fences state transitions to declared states', () => {
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        stateModels: [
+          {
+            id: 'm',
+            subjectType: 'deal',
+            states: ['open', 'closed'],
+            transitions: [{ from: 'open', to: 'ghost' }],
+          },
+        ],
+      }),
+    ).toThrow(/not a declared state/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        stateModels: [{ id: 'm', subjectType: 'deal', states: ['only_one'] }],
+      }),
+    ).toThrow(/2\.\.16/);
+  });
+
+  it('fences attentionHint.prefer to the pack’s OWN predicates (cross-pack reject)', () => {
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        attentionHints: [{ cue: 'price', prefer: ['other_pack_predicate'] }],
+      }),
+    ).toThrow(/not a predicate of this pack/);
+    // A CORE predicate id is just as foreign as another pack's.
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        attentionHints: [{ cue: 'price', prefer: ['works_at'] }],
+      }),
+    ).toThrow(/not a predicate of this pack/);
+  });
+
+  it('fences zoom to own sceneSchemas plus the fixed literals', () => {
+    const withScene = {
+      sceneSchemas: [{ id: 'viewing', description: 'x' }],
+    };
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        ...withScene,
+        attentionHints: [{ cue: 'price', zoom: ['viewing', 'episodes', 'facts', 'scenes'] }],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        attentionHints: [{ cue: 'price', zoom: ['someone_elses_scene'] }],
+      }),
+    ).toThrow(/zoom target/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        attentionHints: [{ cue: 'price', zoom: ['facts', 'facts', 'facts', 'facts', 'facts'] }],
+      }),
+    ).toThrow(/1\.\.4/);
+  });
+
+  it('fences retentionHints to own predicates and scenes', () => {
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        retentionHints: [{ predicateOrScene: 'not_ours', hint: 'durable' }],
+      }),
+    ).toThrow(/neither a predicate localId nor a sceneSchema id/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        retentionHints: [{ predicateOrScene: 'deal_stage', hint: 'forever' }],
+      }),
+    ).toThrow(/ephemeral\|standard\|durable/);
+  });
+
+  it('anti-DSL: rejects template/DSL syntax and control chars in every free-text field', () => {
+    for (const bad of ['{{name}}', 'a${x}b', 'a<%b%>', 'tick`tock', 'a|b', 'a\\b', 'a\u0000b']) {
+      expect(() =>
+        validateMemoryModel(manifest(), {
+          sceneSchemas: [{ id: 'v', description: bad }],
+        }),
+      ).toThrow(DomainPackError);
+      expect(() =>
+        validateMemoryModel(manifest(), {
+          sceneSchemas: [{ id: 'v', description: 'ok', cues: [bad] }],
+        }),
+      ).toThrow(DomainPackError);
+      expect(() => validateMemoryModel(manifest(), { attentionHints: [{ cue: bad }] })).toThrow(
+        DomainPackError,
+      );
+      expect(() =>
+        validateMemoryModel(manifest(), {
+          verificationRules: [{ claimPattern: bad, requires: 'corroboration' }],
+        }),
+      ).toThrow(DomainPackError);
+    }
+    // Length caps: cue 2..64, description 1..500, claimPattern 2..128.
+    expect(() => validateMemoryModel(manifest(), { attentionHints: [{ cue: 'x' }] })).toThrow(
+      /2\.\.64/,
+    );
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        sceneSchemas: [{ id: 'v', description: 'x'.repeat(501) }],
+      }),
+    ).toThrow(/1\.\.500/);
+    expect(() =>
+      validateMemoryModel(manifest(), {
+        verificationRules: [{ claimPattern: 'y'.repeat(129), requires: 'recency_check' }],
+      }),
+    ).toThrow(/2\.\.128/);
+  });
+
+  it('claimPattern additionally rejects regex metacharacters — literal substring, not a pattern', () => {
+    for (const bad of ['a[b]', 'a(b)', 'a*b', 'a+b', 'a?b', '^ab', 'ab$']) {
+      expect(() =>
+        validateMemoryModel(manifest(), {
+          verificationRules: [{ claimPattern: bad, requires: 'human_confirmation' }],
+        }),
+      ).toThrow(/literal substring, not a pattern/);
+    }
+    // The same characters stay legal in cues (they are matched literally
+    // and carry no regex machinery) — only claimPattern gets the extra fence.
+    expect(() =>
+      validateMemoryModel(manifest(), { attentionHints: [{ cue: 'price (asking)' }] }),
+    ).not.toThrow();
+  });
+
+  it('bounds attentionHint.weight to (0, 1]', () => {
+    for (const bad of [0, -0.5, 1.5, NaN, 'high']) {
+      expect(() =>
+        validateMemoryModel(manifest(), { attentionHints: [{ cue: 'price', weight: bad }] }),
+      ).toThrow(/\(0, 1\]/);
+    }
+    expect(() =>
+      validateMemoryModel(manifest(), { attentionHints: [{ cue: 'price', weight: 1 }] }),
+    ).not.toThrow();
+  });
+
+  it('rejects bad requires enum values', () => {
+    expect(() =>
+      validateMemoryModel(manifest(), { verificationRules: [{ requires: 'vibes' }] }),
+    ).toThrow(/human_confirmation\|corroboration\|recency_check/);
+  });
+});
+
+describe('memoryModel — checksum, signature, upgrade diff', () => {
+  it('packChecksum flips when a single cue changes', () => {
+    const a = withMm(memoryModel());
+    const b = withMm(
+      memoryModel({
+        sceneSchemas: [
+          { id: 'viewing', description: 'A property viewing.', cues: ['viewing', 'open house'] },
+        ],
+      }),
+    );
+    expect(packChecksum(a)).not.toBe(packChecksum(b));
+    // Same content = same checksum (canonical JSON, key order irrelevant).
+    expect(packChecksum(withMm(memoryModel()))).toBe(packChecksum(withMm(memoryModel())));
+  });
+
+  it('signature still verifies on a memoryModel-bearing manifest', () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    const pub = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+    const priv = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    const m = { ...withMm(memoryModel()), publisher: 'acme' };
+    const signed = { ...m, signature: signPack(m, priv) };
+    expect(verifyPackSignature(signed, pub)).toBe(true);
+    // The signature covers the section: tampering with one cue breaks it.
+    const tampered = {
+      ...signed,
+      memoryModel: memoryModel({
+        attentionHints: [{ cue: 'tampered cue' }],
+      }),
+    };
+    expect(verifyPackSignature(tampered, pub)).toBe(false);
+  });
+
+  it('diffPackUpgrade.memoryModelChanged flips ONLY on a section change', () => {
+    const prior = withMm(memoryModel());
+    // Identical section → no flip (version bump alone is not a change).
+    expect(
+      diffPackUpgrade('realty', prior, { ...withMm(memoryModel()), version: '1.1.0' })
+        .memoryModelChanged,
+    ).toBe(false);
+    // Both absent → no flip.
+    expect(diffPackUpgrade('realty', manifest(), manifest()).memoryModelChanged).toBe(false);
+    // One cue changed → flip.
+    expect(
+      diffPackUpgrade(
+        'realty',
+        prior,
+        withMm(
+          memoryModel({
+            verificationRules: [{ claimPattern: 'sold for', requires: 'recency_check' }],
+          }),
+        ),
+      ).memoryModelChanged,
+    ).toBe(true);
+    // Added / removed → flip.
+    expect(diffPackUpgrade('realty', manifest(), prior).memoryModelChanged).toBe(true);
+    expect(diffPackUpgrade('realty', prior, manifest()).memoryModelChanged).toBe(true);
+  });
+});
+
+// ── MemoryModelReaderService (PackToolsReaderService mold) ──────────
+
+type Row = { packId: string; version: string; manifest: DomainPackManifest };
+
+function readerWith(rows: () => Promise<Row[]>): {
+  reader: MemoryModelReaderService;
+  calls: () => number;
+} {
+  let calls = 0;
+  const fakeDb = {
+    query: async () => {
+      calls += 1;
+      return [await rows()];
+    },
+  };
+  const surreal = {
+    withCompany: (_companyId: string, fn: (db: unknown) => unknown) => fn(fakeDb),
+  } as unknown as SurrealService;
+  return { reader: new MemoryModelReaderService(surreal), calls: () => calls };
+}
+
+describe('MemoryModelReaderService', () => {
+  const row = (over: Partial<DomainPackManifest> = {}): Row => ({
+    packId: 'realty',
+    version: '1.0.0',
+    manifest: withMm(memoryModel()),
+    ...(Object.keys(over).length
+      ? { manifest: manifest({ memoryModel: memoryModel(), ...over }) }
+      : {}),
+  });
+
+  it('returns bindings for active memoryModel-bearing packs and caches them', async () => {
+    const { reader, calls } = readerWith(async () => [row()]);
+    const first = await reader.installedMemoryModels('co1');
+    expect(first).toHaveLength(1);
+    expect(first[0]).toMatchObject({ packId: 'realty', packVersion: '1.0.0' });
+    expect(first[0]?.memoryModel.sceneSchemas?.[0]?.id).toBe('viewing');
+    await reader.installedMemoryModels('co1');
+    expect(calls()).toBe(1); // second read served from cache
+
+    reader.invalidate('co1');
+    await reader.installedMemoryModels('co1');
+    expect(calls()).toBe(2); // invalidate forces a fresh load
+  });
+
+  it('defensively re-validates stored sections and skips corrupted ones', async () => {
+    const corrupted: Row = {
+      packId: 'broken',
+      version: '2.0.0',
+      manifest: withMm({ attentionHints: [{ cue: 'x{{evil}}' }] }),
+    };
+    const { reader } = readerWith(async () => [corrupted, row()]);
+    const bindings = await reader.installedMemoryModels('co2');
+    expect(bindings).toHaveLength(1);
+    expect(bindings[0]?.packId).toBe('realty'); // good row survives
+  });
+
+  it('fails open to [] on read errors', async () => {
+    const { reader } = readerWith(async () => {
+      throw new Error('db down');
+    });
+    await expect(reader.installedMemoryModels('co3')).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Domain Packs become **domain projections**: a pack may now declare HOW its domain perceives and episodizes memory — never WHAT is true. The new optional `memoryModel` manifest section carries five declarative arrays (`sceneSchemas`, `stateModels`, `attentionHints`, `verificationRules`, `retentionHints`), each capped and validated. This PR is **contract-first**: validation, storage, a cached reader, and read-only admin exposure — **no consumer reads the section yet**; the perception/episodization consumers arrive in sibling PRs. Default-off / zero behavior change.

- `PackMemoryModel` + sub-shapes and `MM_*` caps in `src/ai/domain-packs/manifest.ts`; the section rides the canonical-JSON checksum and ed25519 signature automatically — zero new integrity machinery.
- `validateMemoryModel` (`src/ai/domain-packs/validate-memory-model.ts`), dispatched from `validatePack`'s optional-section block; present-but-empty sections are rejected (mcpTools mold).
- `PackUpgradeDiff.memoryModelChanged` (canonical-JSON compare — flips only on a real section change, key order irrelevant).
- `MemoryModelReaderService` (PackToolsReaderService mold): LRU 200 + 30s TTL + in-flight dedupe + fail-open `[]` + defensive re-validation of stored sections; invalidated by `DomainPackInstallService` on install/upgrade/uninstall next to the existing invalidates.
- Admin read: `GET /v1/admin/packs` `installed[]` now projects the stored `memoryModel` (`null` when absent); wire contracts + OpenAPI (both copies) regenerated.
- `docs/domain-packs.md`: the contract + the **candidates-never-truth law** — every proposal a consumer derives from a memoryModel is a CANDIDATE the core pipeline may reject.

## Guarantees

**Anti-DSL.** Every free-text field is plain literal text: length-capped, no control characters, no template/DSL syntax (`{{`, `${`, `<%`, backticks, `|`, `\`). `cues` and `claimPattern` are literal substrings — `claimPattern` additionally rejects the regex metacharacters `[]()*+?^$`. No code, templates, or patterns ever ride a manifest.

**Referential fence.** Hints may only reference the pack's OWN namespaces: `attentionHint.prefer` ⊆ own predicate localIds, `zoom` ⊆ own sceneSchema ids ∪ the fixed literals (`episodes`/`facts`/`scenes`), transitions ∈ declared states, retention refs ∈ own predicates/scenes. Cross-pack and core references are rejected at validation time, mirroring the mcpTools query fence. Cross-list sceneSchema/stateModel id collisions are rejected too.

## Consent decision

**No consent flag for `memoryModel`.** Unlike `mcpTools` it is purely declarative data — it registers nothing on any agent surface and causes zero egress, so install/upgrade proceeds without an `accept*` flag and `mcpToolsChecksum` stays scoped to the mcpTools section only. **Boundary** (documented in `DomainPackInstallService`): any future memoryModel field that grants the pack READ access — or any other capability — moves under its own `accepted<Section>Checksum` consent gate.

## Test plan

- **Unit** (`test/pack-memory-model.unit-spec.ts`): validator matrix — caps, snake_case ids, `__` reject, per-list uniqueness, cross-list collision, referential fences (incl. cross-pack predicate reject), anti-DSL strings, claimPattern metachars, empty-section reject, weight (0,1] bounds; `packChecksum` flips on a single cue change; signature still verifies on a memoryModel-bearing manifest (and breaks on tamper); `memoryModelChanged` flips only on section change; reader mold — cache hit, invalidate, corrupted-section skip, fail-open `[]`.
- **e2e** (`test/domain-pack-install.e2e-spec.ts`): install a memoryModel-bearing pack (no consent flag) → GET returns the section (and `null` for packs without it) → upgrade with a CHANGED section succeeds without re-consent → invalid sections (template syntax, foreign predicate) → 400.
- Verified: `pnpm typecheck`, `pnpm lint:ci`, full unit suite (2956 passed), pack e2e subset (7 suites / 58 tests), `prettier --check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB