### PR TITLE
feat(evidence): multimodal evidence substrate — assets, fragments, derived representations (0109)

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1004,6 +1004,34 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Effective-meta union: a corroborated fact inherits its confirming documents’ meta for DENY evaluation (union = most restrictive).',
   },
+  // ── Evidence plane (Brain v2.1) ──
+  {
+    key: 'EVIDENCE_SUBSTRATE_ENABLED',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Master switch for the multimodal evidence substrate writers (evidence_asset / evidence_fragment / derived_representation, migration 0109). Off = EvidenceStoreService refuses every write (503) and no row is ever written; GDPR cascade + retention sweep run regardless so rows written while on stay erasable.',
+  },
+  {
+    key: 'EVIDENCE_FS_ROOT',
+    category: 'pipeline',
+    defaultValue: '',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Directory root for the fs:// evidence storage adapter (<root>/<companyId>/<hash[0..1]>/<hash>). NO default on purpose — unset means the adapter throws a clear unconfigured error instead of silently accumulating tenant media in an unmanaged path.',
+  },
+  {
+    key: 'EVIDENCE_MAX_BYTES',
+    category: 'pipeline',
+    defaultValue: '1073741824',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Sanity cap on the DECLARED byteLength of a registered evidence asset (default 1 GiB). A claim bound, not a transfer limit — this release ships no upload endpoint.',
+  },
   // ── Document pipeline (migrations 0048–0050) ─────────────
   {
     key: 'DOCUMENT_INGEST_ENABLED',

--- a/src/ai/embedder/embedding-space.ts
+++ b/src/ai/embedder/embedding-space.ts
@@ -146,6 +146,9 @@ export const EMBEDDING_TABLES = [
   { table: 'knowledge_predicate', vectorFields: ['embedding'] },
   { table: 'episode', vectorFields: ['embedding'] },
   { table: 'episode_segment', vectorFields: ['embedding'] },
+  // 0106 landed after 0101 — without this entry the reindex-all sweep
+  // silently skipped scene gist vectors (space column added in 0109).
+  { table: 'memory_episode', vectorFields: ['gistEmbedding'] },
   { table: 'strategy_memory', vectorFields: ['embedding'] },
   { table: 'community_node', vectorFields: ['summaryEmbedding'] },
   { table: 'procedural_memory', vectorFields: ['triggerEmbedding'] },

--- a/src/ai/embedder/reindex-engine.service.ts
+++ b/src/ai/embedder/reindex-engine.service.ts
@@ -35,6 +35,9 @@ interface ReindexTableSpec {
  *                          yet backfilled; the != NONE guard makes this a
  *                          safe no-op until they are)
  *   - episode_segment    — segment-composer stores the exact embedded `text`
+ *   - memory_episode     — scene gist (0106; gistEmbedding is unpopulated
+ *                          derived state today — the != NONE guard makes
+ *                          this a safe no-op until a scorer fills it)
  *   - strategy_memory    — `<title>\n<situation>` (strategy-memory.service)
  *
  * community_node (summaryEmbedding) and procedural_memory (triggerEmbedding)
@@ -73,6 +76,16 @@ const ADDITIONAL_TABLE_SPECS: ReindexTableSpec[] = [
     vectorField: 'embedding',
     select: 'id, text, embedding',
     text: (r) => asStr(r.text),
+  },
+  {
+    // Scenes (0106): the deterministic gist IS the embedded text (the
+    // composer embeds `gist` verbatim when it fills gistEmbedding). The
+    // `!= NONE` guard makes this a safe no-op while gist vectors remain
+    // unpopulated derived state.
+    table: 'memory_episode',
+    vectorField: 'gistEmbedding',
+    select: 'id, gist, gistEmbedding',
+    text: (r) => asStr(r.gist),
   },
   {
     table: 'strategy_memory',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -246,6 +246,11 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   positiveInt(env, 'SCENES_MAX_TURNS', errors);
   floatInRange(env, 'SCENES_TOPIC_MIN_COSINE', -1, 1, errors);
 
+  // ── Evidence substrate (Brain v2.1 M1, migration 0109) ─────────────
+  // The write seam clamps bad values to the default at read time; boot
+  // validation catches the typo before it silently reads as a default.
+  positiveInt(env, 'EVIDENCE_MAX_BYTES', errors);
+
   // ── Retrieval profile (per-tenant genre configuration) ─────────────
   validateRetrievalProfileEnv(env, errors);
 
@@ -829,6 +834,18 @@ const KNOWN_BOOLEAN_FLAGS = [
   // verbatim (facts read/provenance API) — additive. Default off ⇒ no
   // fact row is ever touched and the backlink admin route 404s.
   'SCENES_FACT_BACKLINK',
+  // Evidence substrate master (Brain v2.1 M1, migration 0109): the
+  // EvidenceStoreService writers for evidence_asset / evidence_fragment /
+  // derived_representation. Default off ⇒ every writer 503s and no row is
+  // ever written (byte-identical prod; no serving path reads the tables
+  // even when on). The GDPR cascade + retention sweep run regardless —
+  // rows written while on must stay erasable. EVIDENCE_ family sits off
+  // the ENGINE flag budget by design (a substrate builder, not an engine
+  // fork). The fs root (EVIDENCE_FS_ROOT) is a string and the size cap
+  // (EVIDENCE_MAX_BYTES) an int — not booleans. Reserved for sibling PRs
+  // (not defined yet): EVIDENCE_INGEST_ENABLED / EVIDENCE_SCENE_LINKS /
+  // EVIDENCE_FRAGMENT_CITATIONS.
+  'EVIDENCE_SUBSTRATE_ENABLED',
   // Outcome telemetry master (0107): writers append memory_outcome rows
   // + fold memory_outcome_stat counters; the nightly raw-log prune runs.
   // Default off = byte-identical (every writer is a guarded no-op).

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -1,0 +1,63 @@
+import { envFlagEnabled } from './env-validation';
+
+/**
+ * Evidence substrate (Brain v2.1 M1) master flag —
+ * EVIDENCE_SUBSTRATE_ENABLED.
+ *
+ * When on, EvidenceStoreService accepts writes to the three 0109 tables
+ * (evidence_asset / evidence_fragment / derived_representation). The env
+ * read lives here in the common layer, NOT inside the engine dirs
+ * (engine-gates S5.2). Read at call time so a flip is runtime-mutable (no
+ * restart). Default off ⇒ every writer refuses and NO row is ever written
+ * — byte-identical prod (shadow substrate: nothing on the serving path
+ * reads these tables even when on). The GDPR cascade and the retention
+ * sweep run REGARDLESS of this flag — rows written while it was on must
+ * stay erasable after it is turned off. EVIDENCE_ family sits off the
+ * ENGINE flag budget by design (a substrate builder, not an engine fork).
+ *
+ * Reserved for sibling PRs (NOT defined yet — do not read them):
+ * EVIDENCE_INGEST_ENABLED (PR-C ingest surface), EVIDENCE_SCENE_LINKS
+ * (scene↔asset membership), EVIDENCE_FRAGMENT_CITATIONS (answer-path
+ * fragment citations).
+ */
+export function evidenceSubstrateEnabled(): boolean {
+  return envFlagEnabled(process.env.EVIDENCE_SUBSTRATE_ENABLED);
+}
+
+/**
+ * Filesystem storage-adapter root — EVIDENCE_FS_ROOT (non-boolean).
+ *
+ * The directory the fs:// adapter stores content-addressed blobs under
+ * (<root>/<companyId>/<hash[0..1]>/<hash>). NO default, deliberately: a
+ * default path would silently accumulate tenant media in an unmanaged
+ * location — unset ⇒ adapter methods throw a clear unconfigured error
+ * instead. Resolved here in the common layer (engine-gates S5.2); read
+ * at call time so a change is runtime-mutable.
+ */
+export function evidenceFsRoot(): string | null {
+  const raw = process.env.EVIDENCE_FS_ROOT;
+  if (raw === undefined || raw.trim() === '') return null;
+  return raw.trim();
+}
+
+/** Default declared-byteLength sanity cap: 1 GiB. (Named WITHOUT the
+ *  full env-key substring so the W6 boot-capture truth gate doesn't
+ *  mistake this module-scope default for a boot-captured read.) */
+const DEFAULT_MAX_BYTES = 1073741824;
+
+/**
+ * Declared-size sanity cap — EVIDENCE_MAX_BYTES (non-boolean).
+ *
+ * registerAsset rejects a declared byteLength above this cap — a bound on
+ * what a caller may claim an observation weighs, NOT a transfer limit
+ * (this PR ships no upload endpoint). A non-boolean knob resolved here in
+ * the common layer so the write seam takes a resolved number (engine-
+ * gates S5.2); read at call time so a change is runtime-mutable. Must be
+ * a positive integer; unset, blank, or invalid → the 1 GiB default.
+ */
+export function evidenceMaxBytes(): number {
+  const raw = process.env.EVIDENCE_MAX_BYTES;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_MAX_BYTES;
+  const v = Number(raw);
+  return Number.isInteger(v) && v > 0 ? v : DEFAULT_MAX_BYTES;
+}

--- a/src/common/evidence-ref.ts
+++ b/src/common/evidence-ref.ts
@@ -1,0 +1,109 @@
+/**
+ * EvidenceRef — the ONE typed pointer shape for "what grounds this claim"
+ * across the evidence plane (Brain v2.1 M1). Pure module (episode-ids.ts
+ * discipline): importable from composers, outcome writers, and the
+ * provenance walker alike, no I/O, no Nest.
+ *
+ * THE "evidence" NAMING MAP (see the 0109 migration header for the long
+ * form):
+ *   * `source.evidence[]` (SourceEvidence, ingest-fact DTO) —
+ *     caller-asserted EXTERNAL provenance, untouched by this module; the
+ *     'external' arm below carries its `kind` vocabulary.
+ *   * memory_outcome.subjectKind = 'evidence' (0107) — binds to
+ *     evidence_asset ids ONLY; a fragment outcome rolls up to its parent
+ *     asset (see outcomeSubjectFor).
+ *   * "evidence plane" docs branding — the episode/segment grounding
+ *     surface; the 'episode' arm is that plane, the asset/fragment arms
+ *     EXTEND it beyond text.
+ */
+import type { SourceEvidence } from '../ingest/dto/ingest-fact.dto';
+
+/** The `source.evidence[].kind` vocabulary (type-level, from the DTO). */
+export type SourceEvidenceKind = SourceEvidence['kind'];
+
+/**
+ * Runtime copy of the kind vocabulary, pinned two ways: `satisfies`
+ * rejects a stray member at compile time, and the exhaustiveness check
+ * below fails to compile if the DTO union gains a kind this list lacks.
+ * (EVIDENCE_KINDS in ingest-utils.ts:100-108 is the unexported runtime
+ * Set on the ingest path; the unit spec pins behavioral sync through
+ * evidenceValidationError.)
+ */
+export const SOURCE_EVIDENCE_KINDS = [
+  'event',
+  'message',
+  'conversation',
+  'url',
+  'document',
+  'commit',
+  'other',
+] as const satisfies readonly SourceEvidenceKind[];
+
+// Compile-time exhaustiveness: a DTO kind missing from the array makes
+// this Exclude non-never and the assignment below stop compiling.
+type MissingKinds = Exclude<SourceEvidenceKind, (typeof SOURCE_EVIDENCE_KINDS)[number]>;
+const _sourceEvidenceKindsExhaustive: MissingKinds extends never ? true : never = true;
+void _sourceEvidenceKindsExhaustive;
+
+export type EvidenceRef =
+  | { kind: 'episode'; episodeId: string; span?: { start: number; end: number; exact: string } }
+  | { kind: 'fragment'; fragmentId: string; assetId?: string }
+  | { kind: 'asset'; assetId: string }
+  | { kind: 'external'; sourceKind: SourceEvidenceKind; ref: string; note?: string };
+
+/**
+ * Dispatch a raw record-id string on its table prefix into a typed ref.
+ * Only the three record-backed arms are parseable — an 'external' ref has
+ * no record id by definition. Anything else (other tables, bare tails,
+ * non-strings coerced upstream) → null, never a guess.
+ */
+export function parseRecordRef(raw: string): EvidenceRef | null {
+  if (raw.startsWith('episode:')) return { kind: 'episode', episodeId: raw };
+  if (raw.startsWith('evidence_fragment:')) return { kind: 'fragment', fragmentId: raw };
+  if (raw.startsWith('evidence_asset:')) return { kind: 'asset', assetId: raw };
+  return null;
+}
+
+/**
+ * The outcome-telemetry binding rule (0107 × 0109): which
+ * memory_outcome subject a ref's outcome events attach to.
+ *   * asset    → subjectKind 'evidence', subjectId = the asset id;
+ *   * fragment → ROLLS UP to its parent asset — needs `assetId` on the
+ *     ref (null without it: better no telemetry than a fragment-keyed
+ *     subject that would split the per-observation signal);
+ *   * episode  → subjectKind 'episode';
+ *   * external → null (nothing brain-owned to key on).
+ */
+export function outcomeSubjectFor(
+  ref: EvidenceRef,
+): { subjectKind: 'evidence' | 'episode'; subjectId: string } | null {
+  switch (ref.kind) {
+    case 'asset':
+      return { subjectKind: 'evidence', subjectId: ref.assetId };
+    case 'fragment':
+      return ref.assetId ? { subjectKind: 'evidence', subjectId: ref.assetId } : null;
+    case 'episode':
+      return { subjectKind: 'episode', subjectId: ref.episodeId };
+    case 'external':
+      return null;
+  }
+}
+
+/**
+ * Union of members' evidence record-id lists — the unionEpisodeIds
+ * (episode-ids.ts) idiom widened to the three evidence-plane prefixes:
+ * each value String()-coerced and filtered to a known record prefix
+ * (lists are FLEXIBLE-sourced — shapes are never guaranteed), deduped
+ * with member order preserved (Set insertion order), capped at 64.
+ */
+export function unionEvidenceRefs(memberRefLists: readonly unknown[]): string[] {
+  const out = new Set<string>();
+  for (const list of memberRefLists) {
+    if (!Array.isArray(list)) continue;
+    for (const raw of list) {
+      const id = String(raw);
+      if (parseRecordRef(id) !== null) out.add(id);
+    }
+  }
+  return [...out].slice(0, 64);
+}

--- a/src/db/migrations/0109_evidence_substrate.surql
+++ b/src/db/migrations/0109_evidence_substrate.surql
@@ -1,0 +1,218 @@
+-- 0109: evidence substrate — the multimodal Evidence Plane storage
+-- primitives (Brain v2.1 M1).
+--
+-- WHY. Memory today is text-first: the RAW plane (episode turns, 0073),
+-- the SEMANTIC plane (knowledge_fact), the EPISODIC plane (memory_episode
+-- scenes, 0106). Observations that arrive as images, audio, video,
+-- documents-as-bytes, or sensor captures have NO first-class identity —
+-- at best a caption string is ingested and the original observation is
+-- lost. This migration adds three tables that give non-text observations
+-- durable identity WITHOUT ever putting bytes in the database:
+--   * evidence_asset          — the ORIGINAL observation's metadata
+--     (modality, hash, dimensions, where the bytes live). One row per
+--     distinct original byte stream.
+--   * evidence_fragment       — the universal CITATION TARGET: a located
+--     region of an asset (a time range, a page region, a frame span, a
+--     char range). Answers cite fragments the way they cite episodes.
+--   * derived_representation  — a RECOMPUTABLE interpretation of an asset
+--     or fragment (caption, ocr, asr, object track, scene graph,
+--     embedding, text render), versioned by producer so re-runs replace
+--     by version, never mutate in place.
+-- The doctrine carried over from 0048 ("Brain must not know what a PDF
+-- is") extends naturally: a caption is an INDEX into an observation,
+-- never a REPLACEMENT for it. Bytes NEVER live in the DB — storageRef is
+-- an adapter-scheme URI ('fs://…') resolved by the storage-adapter
+-- registry, and originUri points at a caller-owned external location.
+--
+-- THE "evidence" NAMING MAP (three prior uses, none of which this
+-- migration changes):
+--   * source.evidence[] (ingest-fact DTO / ingest-utils EVIDENCE_KINDS) —
+--     caller-asserted EXTERNAL provenance pointers stored verbatim inside
+--     knowledge_fact.source. Untouched; an evidence_asset is
+--     brain-registered, content-addressed, and lifecycle-managed, which
+--     source.evidence[] never was.
+--   * memory_outcome.subjectKind = 'evidence' (0107) — outcome telemetry
+--     binds to evidence_asset ids ONLY: a fragment-level outcome rolls up
+--     to its parent asset (the ranking currency is per-observation, and a
+--     per-fragment rollup would fragment the signal). See
+--     outcomeSubjectFor() in src/common/evidence-ref.ts.
+--   * "evidence plane" in the Brain v2 docs branding — the episode +
+--     segment grounding surface. These tables EXTEND that plane beyond
+--     text; they do not rename or replace it.
+--
+-- ALTERNATIVES CONSIDERED.
+--   * Reusing source_document (0048): rejected — source_document stores
+--     NORMALIZED REDACTED TEXT and its contentHash is the hash of that
+--     text; an asset's byteHash is the sha256 of the ORIGINAL bytes,
+--     which the brain never parses. Conflating the two identities would
+--     make "same text, different scan" and "same bytes, different
+--     redactor version" indistinguishable.
+--   * Bytes in the DB (SurrealDB bytes type): rejected — blob lifecycle
+--     (retention, GDPR, tiering) must not ride the row lifecycle, and
+--     multi-GB video in a rocksdb value is an operational trap. The
+--     adapter contract keeps blob storage swappable (fs now; s3-class
+--     later) without touching rows.
+--   * A typed record<...> subjectId on derived_representation: rejected —
+--     a representation targets an asset OR a fragment; the untyped
+--     `record` + subjectKind discriminator is the memory_outcome (0107)
+--     precedent and keeps GDPR traversal uniform.
+--
+-- NO CHANGEFEED on any of the three tables, deliberately (same GDPR
+-- reasoning as 0073/0106/0107): fragments carry human-written labels and
+-- representations carry caption/ocr/asr text derived from personal
+-- observations — a 30-day INCLUDE ORIGINAL feed would keep GDPR-erased
+-- content readable after the rows die. Rebuild scheduling for derived
+-- representations is producerVersion + re-run, not a feed.
+--
+-- RENUMBER CAVEAT: 0108 is claimed by the in-flight GDPR-cascade PR
+-- (forgotten_entity doc counters). If that PR has not merged when this
+-- lands, the migrator orders by filename and tolerates gaps — 0109 stays
+-- 0109 either way; do NOT renumber on rebase.
+
+-- ── evidence_asset ────────────────────────────────────────────────────
+
+DEFINE TABLE IF NOT EXISTS evidence_asset SCHEMAFULL;
+
+DEFINE FIELD IF NOT EXISTS modality ON evidence_asset TYPE string
+  ASSERT $value INSIDE ['image', 'audio', 'video', 'document', 'sensor'];
+-- IANA media type ('image/jpeg', 'application/pdf'…). Open string — new
+-- media types must not need a migration (0048 `kind` precedent); the
+-- shape is code-validated at the write seam (evidence-store.service.ts).
+DEFINE FIELD IF NOT EXISTS mediaType ON evidence_asset TYPE string;
+-- sha256 hex of the ORIGINAL bytes — NOT the 0048 contentHash, which
+-- hashes the normalized REDACTED text of a parsed document. An asset's
+-- identity is the byte stream the brain never parses; the same photo
+-- re-registered dedupes here regardless of any downstream OCR/redaction.
+DEFINE FIELD IF NOT EXISTS byteHash ON evidence_asset TYPE string;
+DEFINE FIELD IF NOT EXISTS byteLength ON evidence_asset TYPE int;
+DEFINE FIELD IF NOT EXISTS width ON evidence_asset TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS height ON evidence_asset TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS durationMs ON evidence_asset TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS pageCount ON evidence_asset TYPE option<int>;
+-- When the observation HAPPENED (0048 occurredAt doctrine: the photo's
+-- capture time, the recording's start) vs when the brain recorded it.
+DEFINE FIELD IF NOT EXISTS occurredAt ON evidence_asset TYPE datetime;
+DEFINE FIELD IF NOT EXISTS recordedAt ON evidence_asset TYPE datetime DEFAULT time::now();
+-- Adapter-scheme URI ('fs://<companyId>/<byteHash>') resolved by the
+-- storage-adapter registry — never a raw filesystem path.
+DEFINE FIELD IF NOT EXISTS storageRef ON evidence_asset TYPE option<string>;
+-- Caller-owned pointer back to where the bytes live externally (0048
+-- originUri doctrine) — the brain never fetches it.
+DEFINE FIELD IF NOT EXISTS originUri ON evidence_asset TYPE option<string>;
+-- 'hot' = adapter-managed blob present; 'cold' = adapter-managed but
+-- offline tier (reserved); 'external' = originUri only; 'gone' = bytes
+-- deleted, header survives as tombstone (0048 'purged' precedent).
+DEFINE FIELD IF NOT EXISTS availability ON evidence_asset TYPE string DEFAULT 'external'
+  ASSERT $value INSIDE ['hot', 'cold', 'external', 'gone'];
+-- Per-user scope (0055 model) + scope tags (0093), like memory_episode.
+DEFINE FIELD IF NOT EXISTS userId ON evidence_asset TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS scope ON evidence_asset TYPE array<string> DEFAULT [];
+-- PII classes present in the OBSERVATION itself. NONE = unclassified →
+-- FAIL-CLOSED: future read gates open only on an affirmatively-clean []
+-- or the media scope; the class vocabulary is owned by the consent tier
+-- (sibling PR) — this ASSERT pins the storage shape, not the policy.
+DEFINE FIELD IF NOT EXISTS piiClasses ON evidence_asset TYPE option<array<string>>
+  ASSERT $value IS NONE OR $value ALLINSIDE ['face', 'voice', 'biometric', 'id_document', 'sensitive'];
+DEFINE FIELD IF NOT EXISTS vertical ON evidence_asset TYPE string;
+-- Who delivered the observation (0048 recorder doctrine).
+DEFINE FIELD IF NOT EXISTS recorder ON evidence_asset TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS retainUntil ON evidence_asset TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS meta ON evidence_asset TYPE option<object> FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS createdAt ON evidence_asset TYPE datetime DEFAULT time::now();
+-- Drive-by (0101 idiom): the sweep-reindexable gist vector on
+-- memory_episode had no space column — defined below with the other
+-- 0101 stragglers; assets themselves carry no vector in v1.
+
+-- ALL single-field indexes, deliberately: on SurrealDB 3.2.4 a DELETE
+-- whose WHERE is planned through a COMPOUND index can silently no-op
+-- (the preSweepOutcomeRows / scene-membership bug class), and these
+-- tables sit on TWO delete paths (GDPR cascade + retention sweep).
+-- byteHash UNIQUE is also the 1:1 row↔blob invariant: one row per byte
+-- stream means deleting a row's blob can never orphan another row's.
+DEFINE INDEX IF NOT EXISTS evidence_asset_hash_idx ON evidence_asset FIELDS byteHash UNIQUE;
+DEFINE INDEX IF NOT EXISTS evidence_asset_user_idx ON evidence_asset FIELDS userId;
+DEFINE INDEX IF NOT EXISTS evidence_asset_avail_idx ON evidence_asset FIELDS availability;
+DEFINE INDEX IF NOT EXISTS evidence_asset_retain_idx ON evidence_asset FIELDS retainUntil;
+
+-- ── evidence_fragment ─────────────────────────────────────────────────
+
+DEFINE TABLE IF NOT EXISTS evidence_fragment SCHEMAFULL;
+
+-- Typed record link — the GDPR user-forget cascade traverses
+-- assetId.userId, so the target table must be known to the schema.
+DEFINE FIELD IF NOT EXISTS assetId ON evidence_fragment TYPE record<evidence_asset>;
+-- Kind-discriminated locator (charRange / pageRegion / timeRange /
+-- frameRange / track), FLEXIBLE because the shape union is code-owned:
+-- validateLocator() in src/evidence/locator.ts cross-checks kind against
+-- the parent asset's modality at the write seam.
+DEFINE FIELD IF NOT EXISTS locator ON evidence_fragment TYPE object FLEXIBLE;
+-- Human label, ≤200 code-capped and passed through redactPiiWithReport
+-- at write (the 0106 sceneLabel discipline).
+DEFINE FIELD IF NOT EXISTS label ON evidence_fragment TYPE option<string>;
+-- Same shape + fail-closed contract as evidence_asset.piiClasses.
+DEFINE FIELD IF NOT EXISTS piiClasses ON evidence_fragment TYPE option<array<string>>
+  ASSERT $value IS NONE OR $value ALLINSIDE ['face', 'voice', 'biometric', 'id_document', 'sensitive'];
+DEFINE FIELD IF NOT EXISTS createdAt ON evidence_fragment TYPE datetime DEFAULT time::now();
+
+-- Single-field only. NO UNIQUE (assetId, locator) pair index, despite the
+-- natural-key temptation: a compound index would put assetId under the
+-- 3.2.4 compound-planner DELETE no-op (this table is on both delete
+-- paths), and locator is a FLEXIBLE object — dedup belongs to the write
+-- seam, not the planner's key comparison.
+DEFINE INDEX IF NOT EXISTS evidence_fragment_asset_idx ON evidence_fragment FIELDS assetId;
+
+-- ── derived_representation ────────────────────────────────────────────
+
+DEFINE TABLE IF NOT EXISTS derived_representation SCHEMAFULL;
+
+-- Untyped record: the subject is an evidence_asset OR an
+-- evidence_fragment (memory_outcome.subjectId precedent, 0107) —
+-- discriminated by subjectKind, still traversable in the GDPR cascade.
+DEFINE FIELD IF NOT EXISTS subjectId ON derived_representation TYPE record;
+DEFINE FIELD IF NOT EXISTS subjectKind ON derived_representation TYPE string
+  ASSERT $value INSIDE ['asset', 'fragment'];
+DEFINE FIELD IF NOT EXISTS kind ON derived_representation TYPE string
+  ASSERT $value INSIDE ['caption', 'ocr', 'asr', 'object_track', 'scene_graph', 'embedding', 'text'];
+DEFINE FIELD IF NOT EXISTS content ON derived_representation TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS model ON derived_representation TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS modelVersion ON derived_representation TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS promptVersion ON derived_representation TYPE option<string>;
+-- 0101 idiom: which embedding space a stored vector lives in.
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON derived_representation TYPE option<string>
+  ASSERT $value IS NONE OR string::len($value) >= 3;
+-- WRITE-DEAD in v1: no producer fills this yet — the multi-vector design
+-- (per-representation spaces, cross-modal retrieval) is a design doc
+-- away, and the column existing now means no second migration then.
+DEFINE FIELD IF NOT EXISTS embedding ON derived_representation TYPE option<array<float>>;
+DEFINE FIELD IF NOT EXISTS confidence ON derived_representation TYPE option<float>
+  ASSERT $value IS NONE OR ($value >= 0 AND $value <= 1);
+DEFINE FIELD IF NOT EXISTS lang ON derived_representation TYPE option<string>;
+-- segmenterVersion analogue (0106): a producer re-run deletes its own
+-- version's rows then reinserts — representations are recomputable
+-- derived state, never mutated in place.
+DEFINE FIELD IF NOT EXISTS producerVersion ON derived_representation TYPE string;
+DEFINE FIELD IF NOT EXISTS createdAt ON derived_representation TYPE datetime DEFAULT time::now();
+
+-- Single-field only (same 3.2.4 planner rationale as above).
+DEFINE INDEX IF NOT EXISTS derived_repr_subject_idx ON derived_representation FIELDS subjectId;
+DEFINE INDEX IF NOT EXISTS derived_repr_kind_idx ON derived_representation FIELDS kind;
+DEFINE INDEX IF NOT EXISTS derived_repr_ver_idx ON derived_representation FIELDS producerVersion;
+
+-- ── drive-by: memory_episode joins the 0101 space-tracking family ─────
+-- EMBEDDING_TABLES gains memory_episode.gistEmbedding in this PR (0106
+-- landed after 0101, so the reindex sweep silently skipped scene
+-- vectors); the sweep stamps embeddingSpaceId on rewrite when tracking
+-- is on, and SCHEMAFULL would reject the stamp without this column.
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON memory_episode TYPE option<string>
+  ASSERT $value IS NONE OR string::len($value) >= 3;
+
+-- ── GDPR tombstone counters (0080/0106 idiom) ─────────────────────────
+-- Stamped by whichever forget path owns a tombstone row when it erases
+-- evidence rows. NOTE: the ENTITY forget does NOT delete assets — an
+-- asset is a user/tenant-scoped observation, not an entity-scoped claim;
+-- erasing a subject entity removes what the brain BELIEVES about it, not
+-- what a tenant OBSERVED (which may ground other subjects). Assets die
+-- with their user (user-forget cascade) or their tenant (offboarding).
+DEFINE FIELD IF NOT EXISTS evidenceAssetsDeleted ON forgotten_entity TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS evidenceFragmentsDeleted ON forgotten_entity TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS representationsDeleted ON forgotten_entity TYPE option<int>;

--- a/src/documents/candidate-sweeper.service.ts
+++ b/src/documents/candidate-sweeper.service.ts
@@ -7,6 +7,7 @@ import { WorkerLoopService, JobContext } from '../jobs/worker-loop.service';
 import { CandidateStoreService } from './candidate-store.service';
 import { markFactsProvenancePurged } from './document-store.service';
 import { idTailOf as idTail } from '../ingest/ingest-utils';
+import { EvidenceStoreService } from '../evidence/evidence-store.service';
 
 /** count()…GROUP ALL projection — `c` is the group count. */
 interface CountRow {
@@ -39,6 +40,7 @@ export class CandidateSweeperService implements OnModuleInit {
     private readonly candidates: CandidateStoreService,
     @Optional() private readonly workerLoop?: WorkerLoopService,
     @Optional() private readonly claim?: JobClaimService,
+    @Optional() private readonly evidence?: EvidenceStoreService,
   ) {}
 
   onModuleInit(): void {
@@ -83,7 +85,7 @@ export class CandidateSweeperService implements OnModuleInit {
   async sweepTenant(companyId: string): Promise<Record<string, unknown>> {
     const retentionDays = envInt('CANDIDATE_RETENTION_DAYS', 30);
     const pendingTtlDays = envInt('CANDIDATE_PENDING_TTL_DAYS', 7);
-    return this.surreal.withCompany(companyId, async (db) => {
+    const base = await this.surreal.withCompany(companyId, async (db) => {
       const expired = await this.countThen(db, {
         countWhere: `status = 'pending' AND createdAt < time::now() - duration::from_days($days)`,
         mutation: `UPDATE candidate SET status = 'expired',
@@ -145,6 +147,14 @@ export class CandidateSweeperService implements OnModuleInit {
       );
       return { expired, deleted, purgedDocs: purgeIds.length, factsFlagged };
     });
+    // Evidence retention leg (0109): assets past retainUntil lose
+    // fragments/representations/blob and become 'gone' tombstones, plus
+    // the blob-delete reconciliation retry. Owned by the evidence module
+    // (the sweeper stays lifecycle-cron glue) and run on its OWN scoped
+    // connection (never nested inside the closure above); @Optional so
+    // positionally-constructed fixtures stay valid.
+    const evidenceCounts = (await this.evidence?.sweepTenantEvidence(companyId)) ?? {};
+    return { ...base, ...evidenceCounts };
   }
 
   /**

--- a/src/documents/documents.module.ts
+++ b/src/documents/documents.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { AiModule } from '../ai/ai.module';
 import { IngestCoreModule } from '../ingest/ingest-core.module';
 import { IndexersModule } from '../indexers/indexers.module';
+import { EvidenceModule } from '../evidence/evidence.module';
 import { DocumentsController } from './documents.controller';
 import { DocumentsIngestController } from './documents-ingest.controller';
 import { ExternalCandidatesController } from './external-candidates.controller';
@@ -30,7 +31,8 @@ import { MentionViaDocumentService } from './mention-via-document.service';
  * dedicated extraction + relevance routing machinery.
  */
 @Module({
-  imports: [AiModule, IngestCoreModule, IndexersModule],
+  // EvidenceModule: the sweeper's evidence retention/reconciliation leg (0109).
+  imports: [AiModule, IngestCoreModule, IndexersModule, EvidenceModule],
   controllers: [
     DocumentsController,
     DocumentsIngestController,

--- a/src/entities/entities.module.ts
+++ b/src/entities/entities.module.ts
@@ -4,8 +4,11 @@ import { EntitiesService } from './entities.service';
 import { EntityForgetService } from './entity-forget.service';
 import { UserForgetController } from './user-forget.controller';
 import { UserForgetService } from './user-forget.service';
+import { EvidenceModule } from '../evidence/evidence.module';
 
 @Module({
+  // EvidenceModule: user-forget's evidence-blob deletion hook (0109).
+  imports: [EvidenceModule],
   controllers: [EntitiesController, UserForgetController],
   providers: [EntitiesService, EntityForgetService, UserForgetService],
   exports: [EntitiesService],

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -326,6 +326,14 @@ export class EntityForgetService {
         tx.add(`DELETE ingest_dead_letter WHERE payload.entityId = $ent`);
         // entity_external_ref: external subject identifier + pointer.
         tx.add(`DELETE entity_external_ref WHERE entity = $ent`);
+        // evidence_asset / evidence_fragment / derived_representation
+        // (0109) are DELIBERATELY NOT deleted here: an asset is a
+        // user/tenant-scoped OBSERVATION, not an entity-scoped claim —
+        // erasing a subject entity removes what the brain BELIEVES about
+        // it, while the tenant's original observation may ground other
+        // subjects. Assets die with their user (user-forget cascade),
+        // their retainUntil (sweeper), or their tenant (offboarding).
+        // See the 0109 migration header.
         // Tombstone — GDPR accountability (Art. 5(2)/30): record WHO
         // performed the erasure (hashed credential) + requestId so a repeat
         // is detectable. factsDeleted/edgesDeleted are the pre-collected

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
+import { EvidenceStoreService } from '../evidence/evidence-store.service';
 
 /**
  * UserForgetService — GDPR erasure for a per-user memory scope
@@ -32,13 +33,22 @@ export interface UserForgetResult {
   entitiesDeleted: number;
   edgesDeleted: number;
   auditEventsDeleted: number;
+  /** Evidence substrate (0109): content-bearing rows erased with the user. */
+  evidenceAssetsDeleted: number;
+  evidenceFragmentsDeleted: number;
+  representationsDeleted: number;
 }
 
 @Injectable()
 export class UserForgetService {
   private readonly logger = new Logger(UserForgetService.name);
 
-  constructor(private readonly surreal: SurrealService) {}
+  constructor(
+    private readonly surreal: SurrealService,
+    // Blob deletion only — the ROW cascade below runs inline SQL so a
+    // fixture constructed without the evidence module still erases rows.
+    @Optional() private readonly evidence?: EvidenceStoreService,
+  ) {}
 
   async forgetUser(companyId: string, userId: string): Promise<UserForgetResult> {
     return this.surreal.withCompany(companyId, async (db) => {
@@ -219,6 +229,10 @@ export class UserForgetService {
       }
       await db.query(`DELETE memory_episode WHERE userId = $u`, { u: userId });
 
+      // Evidence substrate (0109) — see eraseEvidenceRows.
+      const { evidenceAssetsDeleted, evidenceFragmentsDeleted, representationsDeleted } =
+        await this.eraseEvidenceRows(db, companyId, userId);
+
       // Purge the materialised audit mirror (same contract as entity
       // forget): recordId is the full `table:id` string. The changefeed
       // consumer's PII redaction covers any still-unconsumed lag.
@@ -239,11 +253,72 @@ export class UserForgetService {
         entitiesDeleted: entityIds.length,
         edgesDeleted: edgeRecordIds.length,
         auditEventsDeleted,
+        evidenceAssetsDeleted,
+        evidenceFragmentsDeleted,
+        representationsDeleted,
       };
       this.logger.log(
-        `user forget ${companyId}/${userId}: facts=${result.factsDeleted} entities=${result.entitiesDeleted} edges=${result.edgesDeleted} audit=${result.auditEventsDeleted}`,
+        `user forget ${companyId}/${userId}: facts=${result.factsDeleted} entities=${result.entitiesDeleted} edges=${result.edgesDeleted} audit=${result.auditEventsDeleted} ` +
+          `evidenceAssets=${result.evidenceAssetsDeleted} evidenceFragments=${result.evidenceFragmentsDeleted} representations=${result.representationsDeleted}`,
       );
       return result;
     });
+  }
+
+  /**
+   * Evidence substrate (0109): assets are user/tenant-scoped, so a
+   * user's assets die with them — with their fragments and derived
+   * representations (both content-bearing: labels, captions, OCR/ASR
+   * text). Blob refs are collected BEFORE the rows die (the row is the
+   * only pointer). LET-then-DELETE-by-ids, NOT `DELETE … WHERE`: the
+   * fragment/representation WHEREs traverse indexed record fields — the
+   * reproduced 3.2.4 planner no-op class (see the memory_outcome comment
+   * in forgetUser). Blobs go AFTER the rows (an aborted cascade must not
+   * leave rows pointing at deleted bytes), best-effort: with no row left
+   * to key the sweeper's reconciliation retry, a failed unlink is logged
+   * as an ERROR for manual sweep.
+   */
+  private async eraseEvidenceRows(
+    db: { query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T> },
+    companyId: string,
+    userId: string,
+  ): Promise<{
+    evidenceAssetsDeleted: number;
+    evidenceFragmentsDeleted: number;
+    representationsDeleted: number;
+  }> {
+    const [refRows] = await db.query<[unknown[]]>(
+      `SELECT VALUE storageRef FROM evidence_asset
+        WHERE userId = $u AND storageRef != NONE`,
+      { u: userId },
+    );
+    const storageRefs = ((refRows as unknown[]) ?? []).map(String);
+    const [, , , reprsGone, fragsGone, assetsGone] = await db.query<
+      [unknown, unknown, unknown, unknown[], unknown[], unknown[]]
+    >(
+      `LET $assetIds = (SELECT VALUE id FROM evidence_asset WHERE userId = $u);
+       LET $fragIds = (SELECT VALUE id FROM evidence_fragment WHERE assetId INSIDE $assetIds);
+       LET $reprIds = (SELECT VALUE id FROM derived_representation
+         WHERE subjectId INSIDE $assetIds OR subjectId INSIDE $fragIds);
+       DELETE $reprIds RETURN BEFORE;
+       DELETE $fragIds RETURN BEFORE;
+       DELETE $assetIds RETURN BEFORE;`,
+      { u: userId },
+    );
+    let blobFailures = 0;
+    for (const ref of storageRefs) {
+      const ok = (await this.evidence?.deleteBlobBestEffort(ref)) ?? false;
+      if (!ok) blobFailures++;
+    }
+    if (blobFailures > 0) {
+      this.logger.error(
+        `user forget ${companyId}/${userId}: ${blobFailures}/${storageRefs.length} evidence blob delete(s) failed — bytes may outlive rows, sweep manually`,
+      );
+    }
+    return {
+      evidenceAssetsDeleted: ((assetsGone as unknown[]) ?? []).length,
+      evidenceFragmentsDeleted: ((fragsGone as unknown[]) ?? []).length,
+      representationsDeleted: ((reprsGone as unknown[]) ?? []).length,
+    };
   }
 }

--- a/src/evidence/evidence-store.service.ts
+++ b/src/evidence/evidence-store.service.ts
@@ -1,0 +1,418 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import type { Surreal } from 'surrealdb';
+import {
+  SurrealService,
+  dbCreate,
+  isUniqueViolation,
+  queryFirst,
+  queryRows,
+} from '../db/surreal.service';
+import { evidenceMaxBytes, evidenceSubstrateEnabled } from '../common/evidence-flags';
+import { idTailOf, redactPiiWithReport } from '../ingest/ingest-utils';
+import { validateLocator } from './locator';
+import {
+  EVIDENCE_STORAGE_ADAPTERS,
+  EvidenceStorageRegistry,
+  storageRefScheme,
+} from './storage/storage-adapter';
+import { parseStorageRef } from './storage/fs-storage.adapter';
+
+const HASH_RE = /^[0-9a-f]{64}$/;
+// IANA media-type shape (type "/" subtype over the registered-name
+// charset) — open vocabulary, shape-only (0048 `kind` doctrine).
+const MEDIA_TYPE_RE = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/i;
+const MODALITIES = ['image', 'audio', 'video', 'document', 'sensor'] as const;
+const LABEL_MAX = 200;
+const REPR_KINDS = ['caption', 'ocr', 'asr', 'object_track', 'scene_graph', 'embedding', 'text'];
+
+export type EvidenceModality = (typeof MODALITIES)[number];
+
+export interface RegisterAssetInput {
+  modality: EvidenceModality;
+  mediaType: string;
+  byteHash: string;
+  byteLength: number;
+  occurredAt: Date;
+  storageRef?: string | undefined;
+  originUri?: string | undefined;
+  userId?: string | undefined;
+  scope?: string[] | undefined;
+  piiClasses?: string[] | undefined;
+  vertical: string;
+  recorder?: string | undefined;
+  retainUntil?: Date | undefined;
+  meta?: Record<string, unknown> | undefined;
+  width?: number | undefined;
+  height?: number | undefined;
+  durationMs?: number | undefined;
+  pageCount?: number | undefined;
+}
+
+export interface AddFragmentInput {
+  assetId: string;
+  locator: Record<string, unknown>;
+  label?: string | undefined;
+  piiClasses?: string[] | undefined;
+}
+
+export interface AddRepresentationInput {
+  subjectId: string;
+  subjectKind: 'asset' | 'fragment';
+  kind: string;
+  content?: string | undefined;
+  model?: string | undefined;
+  modelVersion?: string | undefined;
+  promptVersion?: string | undefined;
+  confidence?: number | undefined;
+  lang?: string | undefined;
+  producerVersion: string;
+}
+
+/**
+ * EvidenceStoreService — the ONE write seam of the evidence substrate
+ * (0109): registerAsset / addFragment / addRepresentation plus the GDPR
+ * blob hook and the retention/reconciliation sweep legs. NO HTTP
+ * controller in this PR — the ingest surface is the sibling PR-C; tests
+ * and future PRs call the service directly.
+ *
+ * Every WRITER is gated on EVIDENCE_SUBSTRATE_ENABLED (503 when off — no
+ * row is ever written). The delete-side legs (deleteBlobBestEffort,
+ * sweepTenantEvidence) deliberately run REGARDLESS of the flag: rows and
+ * blobs written while it was on must stay erasable after it is off.
+ */
+@Injectable()
+export class EvidenceStoreService {
+  private readonly logger = new Logger(EvidenceStoreService.name);
+
+  constructor(
+    private readonly surreal: SurrealService,
+    @Inject(EVIDENCE_STORAGE_ADAPTERS)
+    private readonly adapters: EvidenceStorageRegistry,
+  ) {}
+
+  private gate(): void {
+    if (!evidenceSubstrateEnabled()) {
+      throw new ServiceUnavailableException('EVIDENCE_SUBSTRATE_ENABLED is off');
+    }
+  }
+
+  /**
+   * Register one asset. Idempotent over byteHash (UNIQUE): same-user
+   * re-registration returns the existing id with `deduped: true`.
+   * A DIFFERENT user hitting an existing hash gets a bare 409 WITHOUT the
+   * stored row's metadata — otherwise registering probe hashes would leak
+   * whether (and as what) another principal already holds those bytes
+   * (the dedup-probe leak, closed here on purpose).
+   */
+  async registerAsset(
+    companyId: string,
+    input: RegisterAssetInput,
+  ): Promise<{ assetId: string; availability: string; deduped: boolean }> {
+    this.gate();
+    this.validateAssetShape(input);
+    const availability = await this.deriveAvailability(companyId, input);
+    return this.surreal.withCompany(companyId, async (db) => {
+      try {
+        const row = await dbCreate<Record<string, unknown>>(db, 'evidence_asset', {
+          modality: input.modality,
+          mediaType: input.mediaType,
+          byteHash: input.byteHash,
+          byteLength: input.byteLength,
+          width: input.width,
+          height: input.height,
+          durationMs: input.durationMs,
+          pageCount: input.pageCount,
+          occurredAt: input.occurredAt,
+          storageRef: input.storageRef,
+          originUri: input.originUri,
+          availability,
+          userId: input.userId,
+          scope: input.scope ?? [],
+          piiClasses: input.piiClasses,
+          vertical: input.vertical,
+          recorder: input.recorder,
+          retainUntil: input.retainUntil,
+          meta: input.meta,
+        });
+        return { assetId: String(row.id), availability, deduped: false };
+      } catch (err) {
+        if (!isUniqueViolation(err)) throw err;
+        const existing = await queryFirst<{ id: unknown; userId?: string; availability: string }>(
+          db,
+          `SELECT id, userId, availability FROM evidence_asset WHERE byteHash = $h LIMIT 1`,
+          { h: input.byteHash },
+        );
+        if (!existing) throw err;
+        if ((existing.userId ?? undefined) !== (input.userId ?? undefined)) {
+          throw new ConflictException('evidence asset with this byteHash already registered');
+        }
+        return {
+          assetId: String(existing.id),
+          availability: String(existing.availability),
+          deduped: true,
+        };
+      }
+    });
+  }
+
+  /** Shape checks that need no I/O — extracted for max-lines discipline. */
+  private validateAssetShape(input: RegisterAssetInput): void {
+    if (!MODALITIES.includes(input.modality)) {
+      throw new BadRequestException(`invalid modality '${String(input.modality)}'`);
+    }
+    if (!MEDIA_TYPE_RE.test(input.mediaType)) {
+      throw new BadRequestException(`mediaType is not an IANA type/subtype shape`);
+    }
+    if (!HASH_RE.test(input.byteHash)) {
+      throw new BadRequestException('byteHash must be 64 lowercase hex chars (sha256)');
+    }
+    const cap = evidenceMaxBytes();
+    if (!Number.isInteger(input.byteLength) || input.byteLength <= 0 || input.byteLength > cap) {
+      throw new BadRequestException(`byteLength must be a positive int <= ${cap}`);
+    }
+  }
+
+  /**
+   * Availability derivation (the 0109 contract):
+   *   storageRef present → its scheme must resolve to a registered
+   *   adapter AND adapter.head() must find the blob AND the blob's
+   *   byteLength must equal the declared one (else 400) → 'hot';
+   *   else originUri present → 'external'; neither → 400.
+   * For the fs scheme the ref's embedded tenant must be the calling
+   * tenant — a cross-tenant blob reference is a 400, not a dedup.
+   */
+  private async deriveAvailability(companyId: string, input: RegisterAssetInput): Promise<string> {
+    if (input.storageRef) {
+      const scheme = storageRefScheme(input.storageRef);
+      const adapter = scheme ? this.adapters.get(scheme) : undefined;
+      if (!adapter) {
+        throw new BadRequestException(`storageRef scheme '${String(scheme)}' has no adapter`);
+      }
+      if (scheme === 'fs' && parseStorageRef(input.storageRef)?.companyId !== companyId) {
+        throw new BadRequestException('storageRef does not belong to this tenant');
+      }
+      const head = await adapter.head(input.storageRef);
+      if (!head) throw new BadRequestException('storageRef does not resolve to a stored blob');
+      if (head.byteLength !== input.byteLength) {
+        throw new BadRequestException(
+          `declared byteLength ${input.byteLength} != stored ${head.byteLength}`,
+        );
+      }
+      return 'hot';
+    }
+    if (input.originUri) return 'external';
+    throw new BadRequestException('an asset needs storageRef or originUri');
+  }
+
+  /** Add a citation-target fragment to an existing asset. */
+  async addFragment(companyId: string, input: AddFragmentInput): Promise<{ fragmentId: string }> {
+    this.gate();
+    return this.surreal.withCompany(companyId, async (db) => {
+      const asset = await queryFirst<{ id: unknown; modality: string }>(
+        db,
+        `SELECT id, modality FROM type::record('evidence_asset', $tail) LIMIT 1`,
+        { tail: idTailOf(input.assetId) },
+      );
+      if (!asset) throw new NotFoundException(`asset ${input.assetId} not found`);
+      const err = validateLocator(asset.modality, input.locator);
+      if (err) throw new BadRequestException(`invalid locator: ${err}`);
+      // Label rides the 0106 sceneLabel discipline: redact then cap.
+      const label =
+        input.label !== undefined
+          ? redactPiiWithReport(input.label).text.slice(0, LABEL_MAX)
+          : undefined;
+      const row = await dbCreate<Record<string, unknown>>(db, 'evidence_fragment', {
+        assetId: asset.id,
+        locator: input.locator,
+        label,
+        piiClasses: input.piiClasses,
+      });
+      return { fragmentId: String(row.id) };
+    });
+  }
+
+  /** Add one derived representation to an asset or fragment. */
+  async addRepresentation(
+    companyId: string,
+    input: AddRepresentationInput,
+  ): Promise<{ representationId: string }> {
+    this.gate();
+    const expectedPrefix = input.subjectKind === 'asset' ? 'evidence_asset:' : 'evidence_fragment:';
+    if (!input.subjectId.startsWith(expectedPrefix)) {
+      throw new BadRequestException(
+        `subjectId must be a ${expectedPrefix.slice(0, -1)} record for subjectKind '${input.subjectKind}'`,
+      );
+    }
+    if (!REPR_KINDS.includes(input.kind)) {
+      throw new BadRequestException(`invalid representation kind '${input.kind}'`);
+    }
+    if (!input.producerVersion || input.producerVersion.trim() === '') {
+      throw new BadRequestException('producerVersion is required');
+    }
+    return this.surreal.withCompany(companyId, async (db) => {
+      const subject = await queryFirst<{ id: unknown }>(
+        db,
+        input.subjectKind === 'asset'
+          ? `SELECT id FROM type::record('evidence_asset', $tail) LIMIT 1`
+          : `SELECT id FROM type::record('evidence_fragment', $tail) LIMIT 1`,
+        { tail: idTailOf(input.subjectId) },
+      );
+      if (!subject) throw new NotFoundException(`subject ${input.subjectId} not found`);
+      const row = await dbCreate<Record<string, unknown>>(db, 'derived_representation', {
+        subjectId: subject.id,
+        subjectKind: input.subjectKind,
+        kind: input.kind,
+        content: input.content,
+        model: input.model,
+        modelVersion: input.modelVersion,
+        promptVersion: input.promptVersion,
+        confidence: input.confidence,
+        lang: input.lang,
+        producerVersion: input.producerVersion,
+      });
+      return { representationId: String(row.id) };
+    });
+  }
+
+  /** Read one asset row (tests + future PRs). */
+  async getAsset(companyId: string, assetId: string): Promise<Record<string, unknown> | null> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const row = await queryFirst<Record<string, unknown>>(
+        db,
+        `SELECT * FROM type::record('evidence_asset', $tail)`,
+        { tail: idTailOf(assetId) },
+      );
+      return row ?? null;
+    });
+  }
+
+  /**
+   * Delete a blob through its scheme adapter, best-effort: failures are
+   * logged, never thrown — the GDPR row cascade must not abort on a blob
+   * hiccup (the reconciliation sweep retries what this misses). Returns
+   * true when a blob was actually removed.
+   */
+  async deleteBlobBestEffort(storageRef: string): Promise<boolean> {
+    try {
+      const scheme = storageRefScheme(storageRef);
+      const adapter = scheme ? this.adapters.get(scheme) : undefined;
+      if (!adapter) {
+        this.logger.warn(`no adapter for storageRef scheme; blob not deleted: ${storageRef}`);
+        return false;
+      }
+      return await adapter.delete(storageRef);
+    } catch (e) {
+      this.logger.warn(`blob delete failed for ${storageRef}: ${(e as Error).message}`);
+      return false;
+    }
+  }
+
+  /**
+   * Retention + reconciliation legs, called from the nightly candidate
+   * sweeper. Retention: assets past retainUntil lose fragments,
+   * representations, and their blob; the header row survives as a
+   * tombstone (availability='gone', 0048 'purged' precedent). A blob
+   * whose delete FAILS keeps its storageRef so the reconciliation leg —
+   * assets 'gone' with a storageRef still set — retries next run: GDPR
+   * bytes must not outlive their rows just because one unlink failed.
+   */
+  async sweepTenantEvidence(companyId: string): Promise<Record<string, number>> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const expired = await queryRows<{ id: unknown; storageRef?: string }>(
+        db,
+        `SELECT id, storageRef FROM evidence_asset
+          WHERE retainUntil != NONE AND retainUntil < time::now()
+            AND availability != 'gone'`,
+      );
+      let blobsDeleted = 0;
+      for (const asset of expired) {
+        await this.purgeAssetDependents(db, asset.id);
+        const cleared = asset.storageRef ? await this.deleteBlobBestEffort(asset.storageRef) : true;
+        if (asset.storageRef && cleared) blobsDeleted++;
+        // Failed blob delete keeps storageRef for the reconciliation leg.
+        await db.query(
+          cleared
+            ? `UPDATE $id SET availability = 'gone', storageRef = NONE`
+            : `UPDATE $id SET availability = 'gone'`,
+          { id: asset.id },
+        );
+      }
+      const reconciled = await this.reconcileGoneBlobs(db);
+      if (expired.length > 0 || reconciled > 0) {
+        this.logger.log(
+          `evidence sweep ${companyId}: expired=${expired.length} blobs=${blobsDeleted} reconciled=${reconciled}`,
+        );
+      }
+      return {
+        evidenceExpired: expired.length,
+        evidenceBlobsDeleted: blobsDeleted,
+        evidenceBlobsReconciled: reconciled,
+      };
+    });
+  }
+
+  /**
+   * Fragments then representations of one dying asset, LET-batched
+   * (LIMIT 5000 loop) by explicit ids — the 3.2.4 compound/traversal
+   * DELETE-WHERE planner no-op class (preSweepOutcomeRows, PR #372)
+   * makes a one-step DELETE-WHERE on the fragment table untrustworthy.
+   */
+  private async purgeAssetDependents(db: Surreal, assetId: unknown): Promise<void> {
+    for (;;) {
+      const [, , fragBatch, reprBatch] = await db.query<[unknown, unknown, unknown[], unknown[]]>(
+        `LET $fragIds = (SELECT VALUE id FROM evidence_fragment
+           WHERE assetId = $asset LIMIT 5000);
+         LET $reprIds = (SELECT VALUE id FROM derived_representation
+           WHERE subjectId = $asset OR subjectId INSIDE $fragIds LIMIT 5000);
+         DELETE $fragIds RETURN BEFORE;
+         DELETE $reprIds RETURN BEFORE;`,
+        { asset: assetId },
+      );
+      const frags = ((fragBatch as unknown[]) ?? []).length;
+      const reprs = ((reprBatch as unknown[]) ?? []).length;
+      if (frags < 5000 && reprs < 5000) break;
+    }
+  }
+
+  /** Retry blob deletion for 'gone' rows still holding a storageRef. */
+  private async reconcileGoneBlobs(db: Surreal): Promise<number> {
+    const stragglers = await queryRows<{ id: unknown; storageRef: string }>(
+      db,
+      `SELECT id, storageRef FROM evidence_asset
+        WHERE availability = 'gone' AND storageRef != NONE`,
+    );
+    let reconciled = 0;
+    for (const row of stragglers) {
+      // deleteBlobBestEffort returns false when the blob is ALREADY gone
+      // (ENOENT) — the ref is stale either way, so clear it unless the
+      // adapter threw/was missing, in which case exists() still finding
+      // the blob keeps the ref for the next run.
+      const removed = await this.deleteBlobBestEffort(row.storageRef);
+      const stillThere = !removed && (await this.blobStillExists(row.storageRef));
+      if (!stillThere) {
+        await db.query(`UPDATE $id SET storageRef = NONE`, { id: row.id });
+        reconciled++;
+      }
+    }
+    return reconciled;
+  }
+
+  /** exists() through the registry, false on any failure. */
+  private async blobStillExists(storageRef: string): Promise<boolean> {
+    try {
+      const scheme = storageRefScheme(storageRef);
+      const adapter = scheme ? this.adapters.get(scheme) : undefined;
+      return adapter ? await adapter.exists(storageRef) : false;
+    } catch {
+      return true; // unknown state — keep the ref, retry next run
+    }
+  }
+}

--- a/src/evidence/evidence.module.ts
+++ b/src/evidence/evidence.module.ts
@@ -1,0 +1,33 @@
+import { Module } from '@nestjs/common';
+import { EvidenceStoreService } from './evidence-store.service';
+import { FsEvidenceStorageAdapter } from './storage/fs-storage.adapter';
+import {
+  EVIDENCE_STORAGE_ADAPTERS,
+  EvidenceStorageAdapter,
+  EvidenceStorageRegistry,
+} from './storage/storage-adapter';
+
+/**
+ * Evidence substrate (migration 0109): the multimodal Evidence Plane
+ * write seam (EvidenceStoreService) + the blob storage-adapter registry.
+ * v1 registers ONE adapter (fs://); an s3-class adapter is a new
+ * provider + one more Map entry — consumers resolve by storageRef
+ * scheme, never by concrete class. No controller in this PR (the ingest
+ * surface is sibling PR-C). Injections into the GDPR / sweeper paths are
+ * @Optional so positionally-constructed unit fixtures stay valid.
+ * SurrealService comes from the @Global db module.
+ */
+@Module({
+  providers: [
+    FsEvidenceStorageAdapter,
+    {
+      provide: EVIDENCE_STORAGE_ADAPTERS,
+      useFactory: (fs: EvidenceStorageAdapter): EvidenceStorageRegistry =>
+        new Map([[fs.scheme, fs]]),
+      inject: [FsEvidenceStorageAdapter],
+    },
+    EvidenceStoreService,
+  ],
+  exports: [EvidenceStoreService],
+})
+export class EvidenceModule {}

--- a/src/evidence/locator.ts
+++ b/src/evidence/locator.ts
@@ -1,0 +1,99 @@
+/**
+ * FragmentLocator — the kind-discriminated "where in the asset" shape of
+ * evidence_fragment.locator (0109). Pure module: the DB column is
+ * FLEXIBLE, so THIS is the schema — validateLocator() runs at the write
+ * seam (evidence-store.service.ts) and cross-checks the locator kind
+ * against the parent asset's modality.
+ */
+
+export type FragmentLocator =
+  /** Character span in a text-bearing document (code points). */
+  | { kind: 'charRange'; start: number; end: number }
+  /** Page + normalized bounding box (0..1 coords); page 0 for an image. */
+  | { kind: 'pageRegion'; page: number; x: number; y: number; w: number; h: number }
+  /** Time span in a temporal medium. */
+  | { kind: 'timeRange'; startMs: number; endMs: number }
+  /** Frame span in a video. */
+  | { kind: 'frameRange'; startFrame: number; endFrame: number }
+  /** A tracked object/channel, optionally time-bounded. */
+  | { kind: 'track'; trackId: string; startMs?: number; endMs?: number };
+
+/** Locator kind → modalities it may target (the cross-check matrix). */
+const KIND_MODALITIES: Record<string, readonly string[]> = {
+  charRange: ['document'],
+  pageRegion: ['document', 'image'],
+  timeRange: ['audio', 'video', 'sensor'],
+  frameRange: ['video'],
+  track: ['audio', 'video', 'sensor'],
+};
+
+const isInt = (v: unknown): v is number => typeof v === 'number' && Number.isInteger(v);
+const isNum = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
+
+/** An int pair forming a strictly-increasing non-negative range. */
+function rangeError(lo: unknown, hi: unknown, msg: string): string | null {
+  if (!isInt(lo) || !isInt(hi) || lo < 0 || hi <= lo) return msg;
+  return null;
+}
+
+/** Per-kind shape validators; each returns an error string or null. */
+const SHAPE_VALIDATORS: Record<string, (loc: Record<string, unknown>) => string | null> = {
+  charRange: (loc) =>
+    rangeError(loc.start, loc.end, 'charRange needs int start >= 0 and end > start'),
+  pageRegion: (loc) => {
+    if (!isInt(loc.page) || loc.page < 0) return 'pageRegion needs int page >= 0';
+    for (const k of ['x', 'y', 'w', 'h']) {
+      const v = loc[k];
+      if (!isNum(v) || v < 0 || v > 1) return `pageRegion needs ${k} in [0,1]`;
+    }
+    return null;
+  },
+  timeRange: (loc) =>
+    rangeError(loc.startMs, loc.endMs, 'timeRange needs int startMs >= 0 and endMs > startMs'),
+  frameRange: (loc) =>
+    rangeError(
+      loc.startFrame,
+      loc.endFrame,
+      'frameRange needs int startFrame >= 0 and endFrame > startFrame',
+    ),
+  track: (loc) => {
+    if (typeof loc.trackId !== 'string' || loc.trackId.length === 0 || loc.trackId.length > 256) {
+      return 'track needs a non-empty trackId (<=256 chars)';
+    }
+    for (const k of ['startMs', 'endMs']) {
+      const v = loc[k];
+      if (v !== undefined && (!isInt(v) || v < 0)) return `track ${k} must be a non-negative int`;
+    }
+    return null;
+  },
+};
+
+/**
+ * Validate a locator against the parent asset's modality. Returns a
+ * human-readable error string, or null when valid (the
+ * evidenceValidationError idiom — no exceptions from a pure checker).
+ * Matrix: charRange→document; pageRegion→document|image (image ⇒ page
+ * 0); timeRange/track→audio|video|sensor; frameRange→video. An unknown
+ * kind is ALWAYS an error — never stored opaquely.
+ */
+export function validateLocator(modality: string, locator: unknown): string | null {
+  if (locator === null || typeof locator !== 'object' || Array.isArray(locator)) {
+    return 'locator must be an object';
+  }
+  const loc = locator as Record<string, unknown>;
+  const kind = typeof loc.kind === 'string' ? loc.kind : '';
+  const allowed = KIND_MODALITIES[kind];
+  const validate = SHAPE_VALIDATORS[kind];
+  if (!allowed || !validate) return `unknown locator kind '${String(loc.kind)}'`;
+  if (!allowed.includes(modality)) {
+    return `locator kind '${kind}' does not apply to modality '${modality}'`;
+  }
+  const err = validate(loc);
+  if (err) return err;
+  // An image has exactly one "page" — locating page 3 of a JPEG is a
+  // caller bug the FLEXIBLE column would otherwise store silently.
+  if (kind === 'pageRegion' && modality === 'image' && loc.page !== 0) {
+    return 'pageRegion on an image must use page 0';
+  }
+  return null;
+}

--- a/src/evidence/storage/fs-storage.adapter.ts
+++ b/src/evidence/storage/fs-storage.adapter.ts
@@ -1,0 +1,133 @@
+import { Injectable } from '@nestjs/common';
+import { createReadStream } from 'node:fs';
+import { mkdir, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { join, resolve, sep } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { Readable } from 'node:stream';
+import { evidenceFsRoot } from '../../common/evidence-flags';
+import { EvidenceStorageAdapter } from './storage-adapter';
+
+const HASH_RE = /^[0-9a-f]{64}$/;
+// Tenant ids as the fixture/auth layer mints them (co_…): a conservative
+// shape that keeps every path segment traversal-free by construction.
+const TENANT_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+
+/** Parsed, validated pieces of an fs:// storageRef. */
+export interface ParsedFsRef {
+  companyId: string;
+  byteHash: string;
+}
+
+/**
+ * Parse + validate an `fs://<companyId>/<byteHash>` storageRef. Pure and
+ * unit-testable: hash must be 64 lowercase hex chars, the tenant id must
+ * match the conservative shape above — both segments are therefore
+ * incapable of path escape ('..', separators, drive letters all fail the
+ * regexes). Returns null on ANY deviation; callers treat null as a
+ * hard error, never a guess.
+ */
+export function parseStorageRef(storageRef: string): ParsedFsRef | null {
+  const m = /^fs:\/\/([^/]+)\/([^/]+)$/.exec(storageRef);
+  if (!m) return null;
+  const companyId = m[1]!;
+  const byteHash = m[2]!;
+  if (!TENANT_RE.test(companyId) || !HASH_RE.test(byteHash)) return null;
+  return { companyId, byteHash };
+}
+
+/**
+ * FsEvidenceStorageAdapter — the v1 blob store: a local directory tree
+ * under EVIDENCE_FS_ROOT, layout `<root>/<companyId>/<hash[0..1]>/<hash>`
+ * (two-char fan-out keeps per-directory entry counts sane at scale).
+ * storageRef is `fs://<companyId>/<byteHash>` — the ROOT IS NOT part of
+ * the ref, so an operator can relocate the tree by changing the env var
+ * without rewriting rows.
+ *
+ * put() is temp-file-then-rename atomic: a crash mid-write leaves a
+ * `.tmp-…` straggler, never a half-written blob under its content
+ * address. Root unset ⇒ every method throws the clear unconfigured error
+ * (evidence-flags contract) — no silent default path.
+ */
+@Injectable()
+export class FsEvidenceStorageAdapter implements EvidenceStorageAdapter {
+  readonly scheme = 'fs';
+
+  /** Resolved root, or a loud error — never a default path. */
+  private root(): string {
+    const root = evidenceFsRoot();
+    if (!root) {
+      throw new Error(
+        'EVIDENCE_FS_ROOT is not set — the fs evidence storage adapter is ' +
+          'unconfigured. Set EVIDENCE_FS_ROOT to the blob directory root.',
+      );
+    }
+    return resolve(root);
+  }
+
+  /** Absolute blob path for a validated ref; throws on a malformed ref. */
+  private pathFor(storageRef: string): string {
+    const parsed = parseStorageRef(storageRef);
+    if (!parsed) throw new Error(`malformed fs storageRef: ${storageRef}`);
+    const root = this.root();
+    const p = resolve(join(root, parsed.companyId, parsed.byteHash.slice(0, 2), parsed.byteHash));
+    // Defense in depth: the segment regexes already forbid traversal, but
+    // the resolved path must still sit under the root or we refuse.
+    if (!p.startsWith(root + sep)) throw new Error(`fs storageRef escapes root: ${storageRef}`);
+    return p;
+  }
+
+  async put(
+    companyId: string,
+    byteHash: string,
+    data: Buffer,
+  ): Promise<{ storageRef: string; byteLength: number }> {
+    if (!TENANT_RE.test(companyId)) throw new Error(`invalid companyId for fs put: ${companyId}`);
+    if (!HASH_RE.test(byteHash)) throw new Error(`invalid byteHash for fs put: ${byteHash}`);
+    const storageRef = `fs://${companyId}/${byteHash}`;
+    const dest = this.pathFor(storageRef);
+    const existing = await this.head(storageRef);
+    if (existing) return { storageRef, byteLength: existing.byteLength }; // content-addressed no-op
+    const dir = join(dest, '..');
+    await mkdir(dir, { recursive: true });
+    const tmp = join(dir, `.tmp-${randomUUID()}`);
+    try {
+      await writeFile(tmp, data);
+      await rename(tmp, dest); // atomic within one filesystem
+    } catch (e) {
+      await rm(tmp, { force: true });
+      throw e;
+    }
+    return { storageRef, byteLength: data.byteLength };
+  }
+
+  async get(storageRef: string): Promise<Readable> {
+    const p = this.pathFor(storageRef);
+    await stat(p); // throw a clean ENOENT before handing back a stream
+    return createReadStream(p);
+  }
+
+  async head(storageRef: string): Promise<{ byteLength: number } | null> {
+    try {
+      const s = await stat(this.pathFor(storageRef));
+      return { byteLength: s.size };
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw e;
+    }
+  }
+
+  async exists(storageRef: string): Promise<boolean> {
+    return (await this.head(storageRef)) !== null;
+  }
+
+  async delete(storageRef: string): Promise<boolean> {
+    const p = this.pathFor(storageRef);
+    try {
+      await rm(p);
+      return true;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      throw e;
+    }
+  }
+}

--- a/src/evidence/storage/storage-adapter.ts
+++ b/src/evidence/storage/storage-adapter.ts
@@ -1,0 +1,55 @@
+import type { Readable } from 'node:stream';
+
+/**
+ * EvidenceStorageAdapter — the blob-side contract of the evidence
+ * substrate (Brain v2.1 M1). Bytes NEVER live in the DB (0109 doctrine);
+ * an evidence_asset row points at its blob through `storageRef`, an
+ * adapter-scheme URI (`<scheme>://…`) resolved against the registry
+ * below. v1 ships ONE adapter (fs); an s3-class adapter is a new scheme
+ * + registry entry, zero row changes.
+ *
+ * Contract points:
+ *   * put() is CONTENT-ADDRESSED and idempotent: the blob's location is a
+ *     pure function of (companyId, byteHash), so re-putting identical
+ *     bytes lands on the same ref and is a no-op. Paired with the
+ *     evidence_asset_hash_idx UNIQUE row invariant this keeps row↔blob
+ *     1:1 — deleting one row's blob can never orphan another row's.
+ *   * delete() returns whether a blob existed — the GDPR cascade and the
+ *     retention/reconciliation sweeps log honest counts.
+ *   * All methods throw a clear error when the adapter is unconfigured
+ *     (e.g. EVIDENCE_FS_ROOT unset) — fail loud, never a silent default
+ *     path.
+ */
+export interface EvidenceStorageAdapter {
+  /** URI scheme this adapter owns ('fs'). */
+  readonly scheme: string;
+  /** Store bytes content-addressed; idempotent on identical bytes. */
+  put(
+    companyId: string,
+    byteHash: string,
+    data: Buffer,
+  ): Promise<{ storageRef: string; byteLength: number }>;
+  /** Stream the blob back; throws when the ref is invalid or missing. */
+  get(storageRef: string): Promise<Readable>;
+  /** Blob metadata without reading it; null when absent. */
+  head(storageRef: string): Promise<{ byteLength: number } | null>;
+  exists(storageRef: string): Promise<boolean>;
+  /** Remove the blob; true when something was deleted. */
+  delete(storageRef: string): Promise<boolean>;
+}
+
+/**
+ * DI token for the scheme registry: Map<scheme, adapter>, assembled in
+ * evidence.module.ts. Injected (not imported) so tests can hand the
+ * store service an in-memory adapter and future adapters register
+ * without touching consumers.
+ */
+export const EVIDENCE_STORAGE_ADAPTERS = Symbol('EVIDENCE_STORAGE_ADAPTERS');
+
+export type EvidenceStorageRegistry = ReadonlyMap<string, EvidenceStorageAdapter>;
+
+/** Scheme of a storageRef URI ('fs://…' → 'fs'); null when malformed. */
+export function storageRefScheme(storageRef: string): string | null {
+  const m = /^([a-z][a-z0-9+.-]*):\/\//.exec(storageRef);
+  return m ? m[1]! : null;
+}

--- a/src/outcomes/memory-outcome.service.ts
+++ b/src/outcomes/memory-outcome.service.ts
@@ -25,6 +25,12 @@ import { outcomeTelemetryEnabled } from '../common/outcome-flags';
  * never fact text (see the 0107 header for why that is load-bearing).
  */
 
+/**
+ * 'evidence' binds to evidence_asset ids ONLY (0109): a fragment-level
+ * outcome ROLLS UP to its parent asset — the ranking currency is
+ * per-observation, and a per-fragment rollup would split the signal.
+ * outcomeSubjectFor() in src/common/evidence-ref.ts owns the mapping.
+ */
 export type OutcomeSubjectKind = 'fact' | 'episode' | 'belief' | 'evidence';
 
 export type OutcomeEventName =

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -153,6 +153,107 @@ describe('0107_memory_outcome indexes', () => {
   });
 });
 
+describe('0109_evidence_substrate indexes', () => {
+  const sql = readFileSync(join(MIGRATIONS, '0109_evidence_substrate.surql'), 'utf8');
+
+  // ALL single-field, deliberately: compound coverage would put these
+  // tables' delete paths (GDPR cascade + retention sweep) under the
+  // 3.2.4 compound-planner DELETE no-op. byteHash UNIQUE doubles as the
+  // 1:1 row↔blob invariant.
+  it.each([
+    ['evidence_asset_hash_idx', 'evidence_asset', 'byteHash UNIQUE'],
+    ['evidence_asset_user_idx', 'evidence_asset', 'userId'],
+    ['evidence_asset_avail_idx', 'evidence_asset', 'availability'],
+    ['evidence_asset_retain_idx', 'evidence_asset', 'retainUntil'],
+    ['evidence_fragment_asset_idx', 'evidence_fragment', 'assetId'],
+    ['derived_repr_subject_idx', 'derived_representation', 'subjectId'],
+    ['derived_repr_kind_idx', 'derived_representation', 'kind'],
+    ['derived_repr_ver_idx', 'derived_representation', 'producerVersion'],
+  ])('defines %s on %s(%s)', (name, table, fields) => {
+    expect(sql).toContain(`DEFINE INDEX IF NOT EXISTS ${name} ON ${table} FIELDS ${fields};`);
+  });
+
+  it('defines no compound index on any of the three tables', () => {
+    const indexLines = sql
+      .split('\n')
+      .filter((l) => l.trimStart().startsWith('DEFINE INDEX'))
+      .filter((l) => /evidence_asset|evidence_fragment|derived_representation/.test(l));
+    for (const line of indexLines) {
+      // A compound tuple would read `FIELDS a, b` — no comma may follow
+      // the FIELDS clause outside the trailing UNIQUE/; suffix.
+      expect(line).not.toMatch(/FIELDS [A-Za-z]+,/);
+    }
+  });
+
+  it('deliberately defines NO changefeed and NO event on any table', () => {
+    // Same GDPR reasoning as 0073/0106/0107: fragment labels + derived
+    // caption/ocr/asr text must not stay readable in a feed after an
+    // erasure. The header EXPLAINS the absence in prose, so judge only
+    // non-comment lines.
+    const code = sql
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('--'))
+      .join('\n');
+    expect(code).not.toMatch(/CHANGEFEED/);
+    expect(code).not.toMatch(/DEFINE EVENT/);
+  });
+
+  it('stamps the GDPR tombstone counters on forgotten_entity', () => {
+    for (const field of [
+      'evidenceAssetsDeleted',
+      'evidenceFragmentsDeleted',
+      'representationsDeleted',
+    ]) {
+      expect(sql).toContain(`DEFINE FIELD IF NOT EXISTS ${field} ON forgotten_entity`);
+    }
+  });
+});
+
+describe('evidence substrate DELETE-shape guards (0109)', () => {
+  // The three tables sit on TWO delete paths; every delete must be the
+  // two-step SELECT-ids → DELETE $ids idiom (the 3.2.4 planner no-op
+  // class — see the suite below). A `DELETE <evidence table> WHERE`
+  // anywhere in these writers is a regression.
+  const files = [
+    join(__dirname, '..', 'src', 'entities', 'user-forget.service.ts'),
+    join(__dirname, '..', 'src', 'documents', 'candidate-sweeper.service.ts'),
+    join(__dirname, '..', 'src', 'evidence', 'evidence-store.service.ts'),
+  ];
+
+  it('no writer uses a one-step DELETE-WHERE on the evidence tables', () => {
+    for (const file of files) {
+      const text = readFileSync(file, 'utf8');
+      expect(text).not.toMatch(/DELETE evidence_fragment WHERE/);
+      expect(text).not.toMatch(/DELETE derived_representation WHERE/);
+      expect(text).not.toMatch(/DELETE evidence_asset WHERE/);
+    }
+  });
+
+  it('user-forget pre-collects the cascade ids (and blob refs) before deleting', () => {
+    const src = readFileSync(files[0]!, 'utf8');
+    expect(src).toContain(
+      'LET $assetIds = (SELECT VALUE id FROM evidence_asset WHERE userId = $u)',
+    );
+    expect(src).toContain(
+      'LET $fragIds = (SELECT VALUE id FROM evidence_fragment WHERE assetId INSIDE $assetIds)',
+    );
+    expect(src).toContain('LET $reprIds = (SELECT VALUE id FROM derived_representation');
+    expect(src).toContain('DELETE $reprIds RETURN BEFORE');
+    expect(src).toContain('DELETE $fragIds RETURN BEFORE');
+    expect(src).toContain('DELETE $assetIds RETURN BEFORE');
+    // Blob refs must be collected while the rows still exist.
+    expect(src).toContain('SELECT VALUE storageRef FROM evidence_asset');
+  });
+
+  it('the retention sweep pre-collects fragment/representation ids per asset', () => {
+    const src = readFileSync(files[2]!, 'utf8');
+    expect(src).toContain('LET $fragIds = (SELECT VALUE id FROM evidence_fragment');
+    expect(src).toContain('LET $reprIds = (SELECT VALUE id FROM derived_representation');
+    expect(src).toContain('DELETE $fragIds RETURN BEFORE');
+    expect(src).toContain('DELETE $reprIds RETURN BEFORE');
+  });
+});
+
 describe('SurrealDB 3.2.4 DELETE-WHERE planner no-op guards', () => {
   // Bug class (reproduced against the pinned surrealdb/surrealdb:v3.2.4,
   // rocksdb, WS driver with CBOR binds AND HTTP /sql): a `DELETE <table>

--- a/test/embedding-space.unit-spec.ts
+++ b/test/embedding-space.unit-spec.ts
@@ -122,6 +122,7 @@ describe('EMBEDDING_TABLES / field constant', () => {
       'knowledge_predicate',
       'episode',
       'episode_segment',
+      'memory_episode',
       'strategy_memory',
       'community_node',
       'procedural_memory',

--- a/test/evidence-fs-adapter.unit-spec.ts
+++ b/test/evidence-fs-adapter.unit-spec.ts
@@ -1,0 +1,114 @@
+/**
+ * FsEvidenceStorageAdapter (0109): put/get/head/exists/delete round-trip
+ * on a per-test mkdtemp root, content-addressed idempotency, malformed
+ * ref / path-traversal rejection, and the unconfigured (EVIDENCE_FS_ROOT
+ * unset) loud throw.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  FsEvidenceStorageAdapter,
+  parseStorageRef,
+} from '../src/evidence/storage/fs-storage.adapter';
+
+const sha256 = (b: Buffer) => createHash('sha256').update(b).digest('hex');
+
+describe('parseStorageRef', () => {
+  const hash = 'a'.repeat(64);
+
+  it('parses a well-formed fs ref', () => {
+    expect(parseStorageRef(`fs://co_x/${hash}`)).toEqual({
+      companyId: 'co_x',
+      byteHash: hash,
+    });
+  });
+
+  it.each([
+    ['wrong scheme', `s3://co_x/${'a'.repeat(64)}`],
+    ['short hash', 'fs://co_x/abc123'],
+    ['uppercase hash', `fs://co_x/${'A'.repeat(64)}`],
+    ['non-hex hash', `fs://co_x/${'z'.repeat(64)}`],
+    ['traversal tenant', `fs://../${'a'.repeat(64)}`],
+    ['dot tenant', `fs://./${'a'.repeat(64)}`],
+    ['extra segment', `fs://co_x/extra/${'a'.repeat(64)}`],
+    ['tenant with slash encoded shape', `fs://co%2Fx/${'a'.repeat(64)}`],
+    ['empty tenant', `fs:///${'a'.repeat(64)}`],
+  ])('rejects %s', (_label, ref) => {
+    expect(parseStorageRef(ref)).toBeNull();
+  });
+});
+
+describe('FsEvidenceStorageAdapter', () => {
+  let root: string;
+  let adapter: FsEvidenceStorageAdapter;
+  const savedRoot = process.env.EVIDENCE_FS_ROOT;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'evidence-fs-'));
+    process.env.EVIDENCE_FS_ROOT = root;
+    adapter = new FsEvidenceStorageAdapter();
+  });
+
+  afterEach(async () => {
+    if (savedRoot === undefined) delete process.env.EVIDENCE_FS_ROOT;
+    else process.env.EVIDENCE_FS_ROOT = savedRoot;
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('round-trips put → head → get → exists → delete', async () => {
+    const data = randomBytes(1024);
+    const hash = sha256(data);
+    const { storageRef, byteLength } = await adapter.put('co_a', hash, data);
+    expect(storageRef).toBe(`fs://co_a/${hash}`);
+    expect(byteLength).toBe(1024);
+
+    expect(await adapter.head(storageRef)).toEqual({ byteLength: 1024 });
+    expect(await adapter.exists(storageRef)).toBe(true);
+
+    const stream = await adapter.get(storageRef);
+    const chunks: Buffer[] = [];
+    for await (const c of stream) chunks.push(c as Buffer);
+    expect(Buffer.concat(chunks).equals(data)).toBe(true);
+
+    expect(await adapter.delete(storageRef)).toBe(true);
+    expect(await adapter.head(storageRef)).toBeNull();
+    expect(await adapter.exists(storageRef)).toBe(false);
+    // Deleting an absent blob is honest about it.
+    expect(await adapter.delete(storageRef)).toBe(false);
+  });
+
+  it('put is content-addressed idempotent', async () => {
+    const data = randomBytes(64);
+    const hash = sha256(data);
+    const first = await adapter.put('co_a', hash, data);
+    const second = await adapter.put('co_a', hash, data);
+    expect(second.storageRef).toBe(first.storageRef);
+    expect(second.byteLength).toBe(64);
+  });
+
+  it('rejects invalid hash and tenant shapes on put', async () => {
+    await expect(adapter.put('co_a', 'nothex', Buffer.from('x'))).rejects.toThrow(/byteHash/);
+    await expect(adapter.put('../evil', 'a'.repeat(64), Buffer.from('x'))).rejects.toThrow(
+      /companyId/,
+    );
+  });
+
+  it('rejects malformed / traversal refs on every read-side method', async () => {
+    for (const ref of ['fs://co_a/short', `fs://../${'a'.repeat(64)}`, 'not-a-ref']) {
+      await expect(adapter.head(ref)).rejects.toThrow(/malformed fs storageRef/);
+      await expect(adapter.get(ref)).rejects.toThrow(/malformed fs storageRef/);
+      await expect(adapter.delete(ref)).rejects.toThrow(/malformed fs storageRef/);
+    }
+  });
+
+  it('throws the clear unconfigured error when EVIDENCE_FS_ROOT is unset', async () => {
+    delete process.env.EVIDENCE_FS_ROOT;
+    const bare = new FsEvidenceStorageAdapter();
+    const hash = 'a'.repeat(64);
+    await expect(bare.put('co_a', hash, Buffer.from('x'))).rejects.toThrow(/EVIDENCE_FS_ROOT/);
+    await expect(bare.head(`fs://co_a/${hash}`)).rejects.toThrow(/EVIDENCE_FS_ROOT/);
+    await expect(bare.delete(`fs://co_a/${hash}`)).rejects.toThrow(/EVIDENCE_FS_ROOT/);
+  });
+});

--- a/test/evidence-locator.unit-spec.ts
+++ b/test/evidence-locator.unit-spec.ts
@@ -1,0 +1,76 @@
+/**
+ * validateLocator (0109): the kind × modality cross-check matrix, the
+ * per-kind shape checks, the image ⇒ page-0 rule, and the unknown-kind
+ * hard error (a FLEXIBLE column must never store an unvalidated shape).
+ */
+import { validateLocator } from '../src/evidence/locator';
+
+const charRange = { kind: 'charRange', start: 0, end: 10 };
+const pageRegion = { kind: 'pageRegion', page: 0, x: 0.1, y: 0.1, w: 0.5, h: 0.5 };
+const timeRange = { kind: 'timeRange', startMs: 0, endMs: 1500 };
+const frameRange = { kind: 'frameRange', startFrame: 0, endFrame: 24 };
+const track = { kind: 'track', trackId: 'speaker-1' };
+
+describe('validateLocator — kind × modality matrix', () => {
+  const MODALITIES = ['image', 'audio', 'video', 'document', 'sensor'] as const;
+  const ALLOWED: Record<string, readonly string[]> = {
+    charRange: ['document'],
+    pageRegion: ['document', 'image'],
+    timeRange: ['audio', 'video', 'sensor'],
+    frameRange: ['video'],
+    track: ['audio', 'video', 'sensor'],
+  };
+  const LOCATORS: Record<string, Record<string, unknown>> = {
+    charRange,
+    pageRegion,
+    timeRange,
+    frameRange,
+    track,
+  };
+
+  it.each(
+    Object.keys(LOCATORS).flatMap((kind) => MODALITIES.map((m) => [kind, m] as [string, string])),
+  )('%s × %s follows the matrix', (kind, modality) => {
+    const err = validateLocator(modality, LOCATORS[kind]!);
+    if (ALLOWED[kind]!.includes(modality)) {
+      expect(err).toBeNull();
+    } else {
+      expect(err).toMatch(/does not apply/);
+    }
+  });
+});
+
+describe('validateLocator — shapes and edges', () => {
+  it('rejects an unknown kind', () => {
+    expect(validateLocator('image', { kind: 'pixelBlob' })).toMatch(/unknown locator kind/);
+    expect(validateLocator('image', {})).toMatch(/unknown locator kind/);
+  });
+
+  it('rejects non-objects', () => {
+    expect(validateLocator('image', null)).toMatch(/must be an object/);
+    expect(validateLocator('image', [charRange])).toMatch(/must be an object/);
+    expect(validateLocator('image', 'charRange')).toMatch(/must be an object/);
+  });
+
+  it('pageRegion on an image must use page 0', () => {
+    expect(validateLocator('image', { ...pageRegion, page: 3 })).toMatch(/page 0/);
+    expect(validateLocator('document', { ...pageRegion, page: 3 })).toBeNull();
+  });
+
+  it('rejects inverted / negative ranges', () => {
+    expect(validateLocator('document', { kind: 'charRange', start: 5, end: 5 })).toMatch(
+      /end > start/,
+    );
+    expect(validateLocator('audio', { kind: 'timeRange', startMs: -1, endMs: 10 })).toMatch(
+      /startMs/,
+    );
+    expect(validateLocator('video', { kind: 'frameRange', startFrame: 9, endFrame: 3 })).toMatch(
+      /endFrame > startFrame/,
+    );
+  });
+
+  it('rejects out-of-range pageRegion coords and empty trackId', () => {
+    expect(validateLocator('image', { ...pageRegion, w: 1.5 })).toMatch(/w in \[0,1\]/);
+    expect(validateLocator('audio', { kind: 'track', trackId: '' })).toMatch(/trackId/);
+  });
+});

--- a/test/evidence-ref.unit-spec.ts
+++ b/test/evidence-ref.unit-spec.ts
@@ -1,0 +1,100 @@
+/**
+ * evidence-ref (0109 companion): record-prefix parsing, the outcome
+ * binding rule (assets only — fragments roll up), the cap-64 union
+ * idiom, and the runtime pin that SOURCE_EVIDENCE_KINDS stays in sync
+ * with the ingest path's EVIDENCE_KINDS vocabulary.
+ */
+import {
+  SOURCE_EVIDENCE_KINDS,
+  outcomeSubjectFor,
+  parseRecordRef,
+  unionEvidenceRefs,
+} from '../src/common/evidence-ref';
+import { evidenceValidationError } from '../src/ingest/ingest-utils';
+
+describe('parseRecordRef', () => {
+  it('dispatches the three record prefixes into typed refs', () => {
+    expect(parseRecordRef('episode:abc')).toEqual({ kind: 'episode', episodeId: 'episode:abc' });
+    expect(parseRecordRef('evidence_fragment:f1')).toEqual({
+      kind: 'fragment',
+      fragmentId: 'evidence_fragment:f1',
+    });
+    expect(parseRecordRef('evidence_asset:a1')).toEqual({
+      kind: 'asset',
+      assetId: 'evidence_asset:a1',
+    });
+  });
+
+  it('returns null for anything else — never a guess', () => {
+    for (const raw of ['knowledge_fact:x', 'evidence_assetx:1', 'a1', '', 'fs://co/x']) {
+      expect(parseRecordRef(raw)).toBeNull();
+    }
+  });
+});
+
+describe('outcomeSubjectFor (the 0107 binding rule)', () => {
+  it('asset → evidence subject on the asset id', () => {
+    expect(outcomeSubjectFor({ kind: 'asset', assetId: 'evidence_asset:a1' })).toEqual({
+      subjectKind: 'evidence',
+      subjectId: 'evidence_asset:a1',
+    });
+  });
+
+  it('fragment rolls up to the parent asset — null without one', () => {
+    expect(
+      outcomeSubjectFor({
+        kind: 'fragment',
+        fragmentId: 'evidence_fragment:f1',
+        assetId: 'evidence_asset:a1',
+      }),
+    ).toEqual({ subjectKind: 'evidence', subjectId: 'evidence_asset:a1' });
+    expect(outcomeSubjectFor({ kind: 'fragment', fragmentId: 'evidence_fragment:f1' })).toBeNull();
+  });
+
+  it('episode binds as an episode subject; external binds to nothing', () => {
+    expect(outcomeSubjectFor({ kind: 'episode', episodeId: 'episode:e1' })).toEqual({
+      subjectKind: 'episode',
+      subjectId: 'episode:e1',
+    });
+    expect(outcomeSubjectFor({ kind: 'external', sourceKind: 'url', ref: 'https://x' })).toBeNull();
+  });
+});
+
+describe('unionEvidenceRefs (episode-ids idiom, widened)', () => {
+  it('unions, coerces, filters to known prefixes, dedupes in member order', () => {
+    expect(
+      unionEvidenceRefs([
+        ['evidence_asset:a1', 'episode:e1', 'knowledge_fact:x', 42],
+        'not-a-list',
+        ['evidence_fragment:f1', 'evidence_asset:a1'],
+      ]),
+    ).toEqual(['evidence_asset:a1', 'episode:e1', 'evidence_fragment:f1']);
+  });
+
+  it('caps at 64', () => {
+    const many = [Array.from({ length: 100 }, (_, i) => `evidence_asset:a${i}`)];
+    expect(unionEvidenceRefs(many)).toHaveLength(64);
+  });
+});
+
+describe('SOURCE_EVIDENCE_KINDS ↔ ingest EVIDENCE_KINDS sync pin', () => {
+  // EVIDENCE_KINDS (ingest-utils.ts) is an unexported Set, so the pin is
+  // behavioral: every kind the ref module exports must pass the ingest
+  // validator, and a kind it does not export must fail it. The DTO-side
+  // direction is a compile-time exhaustiveness check in evidence-ref.ts.
+  it('every exported kind validates on the ingest path', () => {
+    for (const kind of SOURCE_EVIDENCE_KINDS) {
+      expect(evidenceValidationError([{ kind, ref: 'ref-1' }])).toBeNull();
+    }
+  });
+
+  it('a kind outside the vocabulary fails the ingest validator', () => {
+    expect(evidenceValidationError([{ kind: 'bogus', ref: 'ref-1' }])).toMatch(/kind/);
+  });
+
+  it('the exported list is exactly the 7-value vocabulary', () => {
+    expect([...SOURCE_EVIDENCE_KINDS].sort()).toEqual(
+      ['commit', 'conversation', 'document', 'event', 'message', 'other', 'url'].sort(),
+    );
+  });
+});

--- a/test/evidence-substrate.e2e-spec.ts
+++ b/test/evidence-substrate.e2e-spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Evidence substrate e2e (migration 0109): master-flag gate (off →
+ * writers refuse, no rows), fs-backed registerAsset + fragment +
+ * representation writes, same-user dedupe over the UNIQUE byteHash, the
+ * user-forget GDPR cascade (rows + blob + response counters), and the
+ * sweeper retention leg (retainUntil past → 'gone' tombstone + blob
+ * deleted + dependents purged). Service-level suite — this PR ships no
+ * HTTP evidence surface (sibling PR-C).
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { EvidenceStoreService } from '../src/evidence/evidence-store.service';
+import { FsEvidenceStorageAdapter } from '../src/evidence/storage/fs-storage.adapter';
+import { CandidateSweeperService } from '../src/documents/candidate-sweeper.service';
+
+const COMPANY = 'co_evidence_e2e';
+const USER = 'evidence_user';
+const sha256 = (b: Buffer) => createHash('sha256').update(b).digest('hex');
+
+describe('evidence substrate (e2e)', () => {
+  let f: AppFixture;
+  let store: EvidenceStoreService;
+  let adapter: FsEvidenceStorageAdapter;
+  let fsRoot: string;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    fsRoot = await mkdtemp(join(tmpdir(), 'evidence-e2e-'));
+    saved.EVIDENCE_SUBSTRATE_ENABLED = process.env.EVIDENCE_SUBSTRATE_ENABLED;
+    saved.EVIDENCE_FS_ROOT = process.env.EVIDENCE_FS_ROOT;
+    delete process.env.EVIDENCE_SUBSTRATE_ENABLED;
+    process.env.EVIDENCE_FS_ROOT = fsRoot;
+    f = await createApp({ companyId: COMPANY });
+    store = f.app.get(EvidenceStoreService);
+    adapter = f.app.get(FsEvidenceStorageAdapter);
+  });
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await rm(fsRoot, { recursive: true, force: true });
+    if (f) await f.close();
+  });
+
+  const countRows = async (table: string): Promise<number> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM ${table} GROUP ALL`,
+      );
+      return (rows as Array<{ n: number }>)?.[0]?.n ?? 0;
+    });
+  };
+
+  const registerFsAsset = async (
+    data: Buffer,
+    extra: Partial<Parameters<EvidenceStoreService['registerAsset']>[1]> = {},
+  ) => {
+    const byteHash = sha256(data);
+    const { storageRef } = await adapter.put(COMPANY, byteHash, data);
+    return store.registerAsset(COMPANY, {
+      modality: 'image',
+      mediaType: 'image/jpeg',
+      byteHash,
+      byteLength: data.byteLength,
+      occurredAt: new Date('2026-03-01T10:00:00.000Z'),
+      storageRef,
+      userId: USER,
+      vertical: 'proj',
+      ...extra,
+    });
+  };
+
+  it('refuses every write with the flag off and writes no rows', async () => {
+    await expect(
+      store.registerAsset(COMPANY, {
+        modality: 'image',
+        mediaType: 'image/jpeg',
+        byteHash: 'a'.repeat(64),
+        byteLength: 10,
+        occurredAt: new Date(),
+        originUri: 'https://example.com/x.jpg',
+        vertical: 'proj',
+      }),
+    ).rejects.toThrow(/EVIDENCE_SUBSTRATE_ENABLED/);
+    expect(await countRows('evidence_asset')).toBe(0);
+  });
+
+  it('registers an fs-backed asset with a fragment and a representation, and dedupes', async () => {
+    process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    const data = randomBytes(2048);
+    const created = await registerFsAsset(data);
+    expect(created.deduped).toBe(false);
+    expect(created.availability).toBe('hot');
+
+    const frag = await store.addFragment(COMPANY, {
+      assetId: created.assetId,
+      locator: { kind: 'pageRegion', page: 0, x: 0.1, y: 0.1, w: 0.4, h: 0.4 },
+      label: 'receipt total, mail me at test@example.com',
+    });
+    const repr = await store.addRepresentation(COMPANY, {
+      subjectId: frag.fragmentId,
+      subjectKind: 'fragment',
+      kind: 'caption',
+      content: 'A receipt totalling 42 EUR',
+      producerVersion: 'captioner-test-v1',
+    });
+    expect(repr.representationId).toContain('derived_representation:');
+    expect(await countRows('evidence_asset')).toBe(1);
+    expect(await countRows('evidence_fragment')).toBe(1);
+    expect(await countRows('derived_representation')).toBe(1);
+
+    // Fragment label went through the PII redactor at write.
+    const surreal = f.app.get(SurrealService);
+    const label = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ label: string }>]>(
+        `SELECT label FROM evidence_fragment LIMIT 1`,
+      );
+      return (rows as Array<{ label: string }>)?.[0]?.label ?? '';
+    });
+    expect(label).toContain('[EMAIL]');
+    expect(label).not.toContain('test@example.com');
+
+    // Same-user re-registration dedupes onto the same row.
+    const again = await registerFsAsset(data);
+    expect(again.deduped).toBe(true);
+    expect(again.assetId).toBe(created.assetId);
+    expect(await countRows('evidence_asset')).toBe(1);
+  });
+
+  it('user forget cascades rows, deletes the blob, and reports counters', async () => {
+    const asset = (await store.getAsset(COMPANY, 'nonexistent')) ?? null;
+    expect(asset).toBeNull(); // getters are flag-independent reads
+    const surreal = f.app.get(SurrealService);
+    const storageRef = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ storageRef: string }>]>(
+        `SELECT storageRef FROM evidence_asset LIMIT 1`,
+      );
+      return (rows as Array<{ storageRef: string }>)?.[0]?.storageRef ?? '';
+    });
+    expect(await adapter.exists(storageRef)).toBe(true);
+
+    const forget = await f.http.post(`/v1/users/${USER}/forget`).set(auth()).send({});
+    expect([200, 201]).toContain(forget.status);
+    expect(forget.body).toMatchObject({
+      evidenceAssetsDeleted: 1,
+      evidenceFragmentsDeleted: 1,
+      representationsDeleted: 1,
+    });
+    expect(await countRows('evidence_asset')).toBe(0);
+    expect(await countRows('evidence_fragment')).toBe(0);
+    expect(await countRows('derived_representation')).toBe(0);
+    expect(await adapter.exists(storageRef)).toBe(false);
+  });
+
+  it('the sweeper retention leg tombstones an expired asset and deletes its blob', async () => {
+    const data = randomBytes(512);
+    const created = await registerFsAsset(data, {
+      retainUntil: new Date('2020-01-01T00:00:00.000Z'),
+    });
+    await store.addFragment(COMPANY, {
+      assetId: created.assetId,
+      locator: { kind: 'pageRegion', page: 0, x: 0, y: 0, w: 1, h: 1 },
+    });
+    const storageRef = `fs://${COMPANY}/${sha256(data)}`;
+    expect(await adapter.exists(storageRef)).toBe(true);
+
+    const sweeper = f.app.get(CandidateSweeperService);
+    const result = await sweeper.sweepTenant(COMPANY);
+    expect(result.evidenceExpired).toBe(1);
+    expect(result.evidenceBlobsDeleted).toBe(1);
+
+    const surreal = f.app.get(SurrealService);
+    const row = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<Record<string, unknown>>]>(
+        `SELECT availability, storageRef FROM evidence_asset LIMIT 1`,
+      );
+      return (rows as Array<Record<string, unknown>>)?.[0];
+    });
+    expect(row).toMatchObject({ availability: 'gone' });
+    expect(row!.storageRef ?? null).toBeNull();
+    expect(await countRows('evidence_fragment')).toBe(0);
+    expect(await adapter.exists(storageRef)).toBe(false);
+  });
+});

--- a/test/reindex-engine-space.unit-spec.ts
+++ b/test/reindex-engine-space.unit-spec.ts
@@ -71,6 +71,7 @@ const ALL_PAGES = {
   ],
   episode: [{ id: 'episode:1', text: 'hello world' }],
   episode_segment: [{ id: 'episode_segment:1', text: 'segment text' }],
+  memory_episode: [{ id: 'memory_episode:1', gist: 'scene gist' }],
   strategy_memory: [{ id: 'strategy_memory:1', title: 'T', situation: 'S' }],
 };
 
@@ -119,6 +120,7 @@ describe('ReindexEngineService — opt-in all-tables sweep', () => {
       'knowledge_predicate',
       'episode',
       'episode_segment',
+      'memory_episode',
       'strategy_memory',
     ]);
     for (const t of res.tables ?? []) {
@@ -141,7 +143,7 @@ describe('ReindexEngineService — EMBEDDING_SPACE_TRACKING stamping', () => {
     const { engine, calls } = makeEngine({ pages: ALL_PAGES, tracking: '1' });
     await engine.reindexTenant('acme', { dryRun: false, remaining: 1000, allTables: true });
     const updates = calls.filter((c) => /^\s*UPDATE/.test(c.sql));
-    expect(updates).toHaveLength(6); // fact + 5 tables
+    expect(updates).toHaveLength(7); // fact + 6 tables
     for (const u of updates) {
       expect(u.sql).toContain('embeddingSpaceId = $space');
       expect(u.params?.space).toBe(ACTIVE_SPACE);


### PR DESCRIPTION
## Summary

Brain v2.1 M1 — the Evidence Plane extends beyond text. Until now, observations arriving as images, audio, video, raw documents, or sensor captures had no first-class identity in the brain: at best a caption string was ingested and the original observation was lost. Migration **0109** adds three tables that give non-text observations durable identity — with the standing doctrine that **bytes NEVER live in the DB** and **a caption is an index into an observation, never a replacement for it**:

- **`evidence_asset`** — the original observation's metadata: modality, IANA mediaType (open, code-validated shape), `byteHash` (sha256 of the ORIGINAL bytes — deliberately NOT 0048's redacted-text `contentHash`), dimensions, availability, and where the bytes live (`storageRef` adapter URI or caller-owned `originUri`).
- **`evidence_fragment`** — the universal citation target: a located region of an asset (charRange / pageRegion / timeRange / frameRange / track), kind-discriminated and cross-checked against the parent asset's modality at the write seam. Labels go through the PII redactor and a 200-char cap.
- **`derived_representation`** — a recomputable interpretation of an asset or fragment (caption / ocr / asr / object_track / scene_graph / embedding / text), versioned by `producerVersion` (segmenterVersion analogue: re-runs delete-by-version then reinsert). The `embedding` column is write-dead in v1 (multi-vector design doc pending).

Everything is **default-off and byte-identical when off**: writers 503 behind `EVIDENCE_SUBSTRATE_ENABLED`, no serving path reads these tables even when on, and the GDPR/retention legs run regardless of the flag so rows written while on stay erasable.

## The "evidence" naming map

Three prior uses of the word, none changed by this PR:

| Surface | Meaning | This PR |
|---|---|---|
| `source.evidence[]` (ingest-fact DTO) | caller-asserted EXTERNAL provenance pointers stored verbatim in `knowledge_fact.source` | untouched; `EvidenceRef`'s `external` arm carries its 7-kind vocabulary (compile-time + behavioral sync pins) |
| `memory_outcome.subjectKind='evidence'` (0107) | outcome telemetry subject | binds to `evidence_asset` ids ONLY — fragment outcomes roll up to the parent asset (`outcomeSubjectFor()` in `src/common/evidence-ref.ts`) |
| "evidence plane" docs branding | the episode + segment grounding surface | these tables EXTEND that plane beyond text |

## Storage adapter — v1 cut rationale

`EvidenceStorageAdapter` (put/get/head/exists/delete) with a scheme registry; v1 registers **fs:// only**: layout `<root>/<companyId>/<hash[0..1]>/<hash>` under `EVIDENCE_FS_ROOT` (no default — unset throws a clear unconfigured error), storageRef `fs://<companyId>/<byteHash>` (root not in the ref, so the tree is relocatable), content-addressed idempotent put with temp-file-then-rename atomicity, and a pure `parseStorageRef()` that rejects malformed hashes, bad tenant shapes, and path escapes. **No upload endpoint, no signed URLs** — this PR is a metadata-only posture; the ingest surface is sibling PR-C. An s3-class adapter is a new scheme + one registry entry, zero row changes.

`registerAsset` availability contract: `storageRef` → scheme must resolve to a registered adapter AND `head()` must find the blob AND stored size must equal the declared `byteLength` → `hot`; else `originUri` → `external`; neither → 400. Cross-tenant fs refs → 400. Dedup: same-user re-registration returns `{assetId, deduped: true}`; a **different** user hitting an existing hash gets a bare 409 **without** the stored metadata — the dedup-probe leak is closed deliberately.

## GDPR + retention semantics

- **user-forget** gains an evidence leg: representations → fragments → assets by pre-collected ids (LET-then-DELETE — the SurrealDB 3.2.4 compound/traversal DELETE-WHERE planner no-op class), storageRefs collected BEFORE row death, blobs deleted after rows (best-effort, failures logged as ERROR). Counters (`evidenceAssetsDeleted` / `evidenceFragmentsDeleted` / `representationsDeleted`) are returned in the forget response.
- **entity-forget deliberately does NOT delete assets**: an asset is a user/tenant-scoped OBSERVATION, not an entity-scoped claim — erasing a subject entity removes what the brain believes about it, while the tenant's original observation may ground other subjects. Assets die with their user, their `retainUntil`, or their tenant. Commented in the service and the migration header.
- **Retention** (nightly candidate sweeper, delegated to `EvidenceStoreService.sweepTenantEvidence`): assets past `retainUntil` lose fragments/representations (LET-batched LIMIT-5000 loops) and their blob; the header row survives as an `availability='gone'` tombstone (0048 'purged' precedent). A failed blob delete keeps its `storageRef`, and the **reconciliation leg** (`gone` + storageRef still set → retry delete → clear on success) ships NOW, in this PR — GDPR bytes must not outlive rows because one unlink failed.
- Tombstone counter fields are defined on `forgotten_entity` (0109). Note: the user-forget path returns response counters but writes no tombstone row today (only entity-forget owns tombstones, and it deletes no assets) — the fields are additive and ready for the forget path that will stamp them.

## piiClasses — fail-closed contract

`piiClasses` on assets and fragments: `NONE` = **unclassified → FAIL-CLOSED**. Future read gates open only on an affirmatively-clean `[]` or the media scope. The ASSERT pins the storage shape (`face | voice | biometric | id_document | sensitive`); the vocabulary and enforcement are owned by the consent tier, which arrives in a sibling PR.

## Deliberate flag family (off-budget)

`EVIDENCE_` sits off the engine flag-budget regex by design — a substrate builder, not an engine fork (the SCENES_/OUTCOME_/FOVEA_ precedent). `test/flag-budget.unit-spec.ts` confirms. Defined now: `EVIDENCE_SUBSTRATE_ENABLED` (boolean master), `EVIDENCE_FS_ROOT` (string, no default), `EVIDENCE_MAX_BYTES` (int, 1 GiB default, boot-validated). Reserved in comments only (NOT defined): `EVIDENCE_INGEST_ENABLED`, `EVIDENCE_SCENE_LINKS`, `EVIDENCE_FRAGMENT_CITATIONS`.

## Drive-by fix

`EMBEDDING_TABLES` gains `memory_episode.gistEmbedding` (0106 landed after 0101 — the reindex-all sweep silently skipped scene vectors) with the matching reindex-engine text mapping (`gist`, `!= NONE`-guarded so it is a safe no-op while gist vectors stay unpopulated) and the `embeddingSpaceId` column on `memory_episode` in 0109 (SCHEMAFULL would have rejected the sweep's stamp).

## Migration number

0108 is claimed by the in-flight GDPR-cascade PR (forgotten_entity doc counters), which has **not merged** at time of writing — 0109 keeps its number either way (the migrator orders by filename and tolerates gaps; renumber caveat is in the migration header).

## Test plan

- **Guards** (`audit-p1-guards.unit-spec.ts`): all 8 index tuples of 0109 + no-compound-index sweep; changefeed/event absence (0107 template); DELETE-shape guards over user-forget / candidate-sweeper / evidence-store (no one-step `DELETE <evidence table> WHERE`; pre-collects pinned).
- **Unit**: `evidence-fs-adapter.unit-spec.ts` (mkdtemp per test: round-trip, content-addressed idempotency, hash/tenant/traversal rejects, unconfigured throw, ref parsing); `evidence-ref.unit-spec.ts` (prefix dispatch, outcome binding incl. fragment roll-up, cap-64 union, EVIDENCE_KINDS behavioral sync pin); `evidence-locator.unit-spec.ts` (full kind × modality matrix, shape edges, image ⇒ page 0).
- **E2E** (`evidence-substrate.e2e-spec.ts`, 4 its, `co_evidence_e2e`): flag off → writers refuse + zero rows; fs-backed register + fragment (redacted label) + representation + same-user dedupe; user-forget → rows gone + blob gone + counters; sweeper retention → `gone` tombstone + storageRef cleared + blob deleted.
- **Verification run**: `pnpm typecheck` ✓, `pnpm lint:ci` ✓, `pnpm test:unit` 306 suites / 3006 tests ✓ (flag-budget included), e2e `evidence` 4/4 ✓, `entities-forget|user-forget` 5/5 ✓, `memory-episode|fact-usage` 7/7 ✓, `prettier --check` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
