### PR TITLE
feat(fovea): evidence-capability verdict gate + outcome telemetry modality dimensions (0113)

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -541,6 +541,18 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Fovea serving-integrity: L3 evidence citations — the L3 escalation transcript renders per-turn [episode:...] headers and transcript-grounded claims are cited as {episodeId, quote} pairs, resolved into span-verified evidence citations over the stored turn text (episodeId-only when the quote cannot be verified; episodeIds not rendered into the transcript are dropped). An episode-cited answer satisfies FOVEA_REQUIRE_CITATIONS; the answer cache still never admits an episode-only-cited answer. Off = L3 prompt/schema/transcript byte-identical, no evidenceCitations emitted.',
   },
+  {
+    key: 'FOVEA_EVIDENCE_CAPABILITY',
+    category: 'calibration',
+    // Read at call time (fovea-flags.evidenceCapabilityEnabled) on the
+    // finalizeAndAdmit gate-resolution seam — never captured in a
+    // constructor — so a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Fovea serving-integrity: evidence-capability verdict gate (0113). A `supported` answer citing a fact whose predicate declares requiredEvidenceCapability != 'text' (knowledge_predicate column; absent = text = unconstrained) is DOWNGRADED to an abstain with reason 'evidence_capability_unmet' unless cited evidence of that capability exists. v1 is fail-closed abstain-or-pass plumbing: every citation today is text, so claims requiring visual/audio/document_region evidence can no longer verify on text alone — confirmation arrives with the media verifiers (M-track). Off = no registry lookup, byte-identical serving.",
+  },
   // ── Scenes (Brain v2) ──
   {
     key: 'SCENES_SEGMENTATION_ENABLED',

--- a/src/ai/predicate-registry-internals/db-mapping.ts
+++ b/src/ai/predicate-registry-internals/db-mapping.ts
@@ -43,6 +43,9 @@ export function serializeForInsert(p: PredicateDefinition): Record<string, unkno
       : {}),
     piiClass: p.piiClass,
     ...(p.requiresScope ? { requiresScope: p.requiresScope } : {}),
+    ...(p.requiredEvidenceCapability
+      ? { requiredEvidenceCapability: p.requiredEvidenceCapability }
+      : {}),
     ...(p.parentPredicateId ? { parentPredicateId: p.parentPredicateId } : {}),
     ...(p.subjectClasses ? { subjectClasses: p.subjectClasses } : {}),
     ...(p.allowedValues ? { allowedValues: p.allowedValues } : {}),
@@ -52,7 +55,23 @@ export function serializeForInsert(p: PredicateDefinition): Record<string, unkno
   };
 }
 
+/**
+ * 0113: the DB column is an open option<string>; the TS union is the
+ * closed contract. Unknown/legacy values map to ABSENT = 'text' =
+ * unconstrained — deliberately fail-open: a malformed row value must
+ * degrade to today's behavior, never turn the verdict gate into a
+ * tenant-wide abstain storm.
+ */
+function evidenceCapabilityOf(
+  value: unknown,
+): PredicateDefinition['requiredEvidenceCapability'] | undefined {
+  return value === 'text' || value === 'visual' || value === 'audio' || value === 'document_region'
+    ? value
+    : undefined;
+}
+
 export function deserializeFromRow(row: Record<string, unknown>): PredicateDefinition {
+  const requiredEvidenceCapability = evidenceCapabilityOf(row.requiredEvidenceCapability);
   return {
     predicateId: String(row.predicateId),
     displayLabel: String(row.displayLabel ?? row.predicateId),
@@ -62,6 +81,7 @@ export function deserializeFromRow(row: Record<string, unknown>): PredicateDefin
     decayHalfLifeDays: typeof row.decayHalfLifeDays === 'number' ? row.decayHalfLifeDays : null,
     piiClass: row.piiClass as PiiClass,
     ...(row.requiresScope ? { requiresScope: String(row.requiresScope) } : {}),
+    ...(requiredEvidenceCapability ? { requiredEvidenceCapability } : {}),
     ...(row.parentPredicateId ? { parentPredicateId: String(row.parentPredicateId) } : {}),
     ...(Array.isArray(row.subjectClasses)
       ? { subjectClasses: row.subjectClasses as string[] }

--- a/src/ai/predicate-registry-internals/types.ts
+++ b/src/ai/predicate-registry-internals/types.ts
@@ -4,6 +4,8 @@
  * type-only without dragging in NestJS DI.
  */
 
+import type { EvidenceCapability } from '../../synthesize/synthesize.types';
+
 export type Semantics = 'append_only' | 'single_active' | 'bitemporal';
 export type PiiClass = 'none' | 'identifier' | 'behavioral' | 'text' | 'sensitive';
 export type PredicateStatus = 'active' | 'proposed' | 'aliased' | 'deprecated';
@@ -24,6 +26,16 @@ export interface PredicateDefinition {
   decayHalfLifeDays: number | null;
   piiClass: PiiClass;
   requiresScope?: string;
+  /**
+   * 0113 (FOVEA_EVIDENCE_CAPABILITY): the evidence capability a claim
+   * under this predicate REQUIRES to verify — absent = 'text' =
+   * unconstrained (every CORE seed). A verdict-gate policy, not an
+   * extractor concern: deliberately NOT folded into computeHash (the
+   * extractor cache key, db-mapping.ts) — serving picks up an operator
+   * edit via the snapshot TTL, and an extraction made against the old
+   * value is still valid.
+   */
+  requiredEvidenceCapability?: EvidenceCapability;
   parentPredicateId?: string;
   subjectClasses?: string[];
   allowedValues?: string[];

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -895,6 +895,15 @@ const KNOWN_BOOLEAN_FLAGS = [
   // evidenceCitations emitted. Outside ENGINE_PREFIX by design (the FOVEA_
   // family sits off the flag budget).
   'FOVEA_L3_EPISODE_CITATIONS',
+  // Fovea serving-integrity: evidence-capability gate (0113) — a `supported`
+  // answer citing a fact whose predicate requires a NON-TEXT evidence
+  // capability (requiredEvidenceCapability on knowledge_predicate) abstains
+  // (reason 'evidence_capability_unmet') unless cited evidence of that
+  // capability exists. v1 is abstain-or-pass plumbing — every citation today
+  // is text; media verifiers arrive with the M-track. Off = no registry
+  // lookup, byte-identical serving. Outside ENGINE_PREFIX by design (the
+  // FOVEA_ family sits off the flag budget).
+  'FOVEA_EVIDENCE_CAPABILITY',
   // Evidence plane (Brain v2 gap #5): summary-producing writers
   // (promotion, compaction rollups, recompose rewrites, arc/aggregate
   // composers) stamp the union of member source.episodeIds onto the

--- a/src/common/fovea-flags.ts
+++ b/src/common/fovea-flags.ts
@@ -186,6 +186,38 @@ export function l3EpisodeCitationsEnabled(): boolean {
 }
 
 /**
+ * Fovea serving-integrity family — evidence-capability gate master flag —
+ * FOVEA_EVIDENCE_CAPABILITY.
+ *
+ * WHAT IT CHANGES: closes the modality gap in the verifier's supported
+ * serve. A predicate can declare (0113 knowledge_predicate column
+ * `requiredEvidenceCapability`, threaded through PredicatePolicy) that its
+ * claims verify only against non-text evidence — a whiteboard photo, a call
+ * recording, a contract region. When on, the finalizeAndAdmit gate-resolution
+ * (resolveEvidenceCapability, beside resolveAnswerIntegrity) computes the
+ * required capability over a `supported` answer's cited facts (max over
+ * citations — any non-text requirement wins) and DOWNGRADES the answer to an
+ * abstain (reason 'evidence_capability_unmet') unless cited evidence of that
+ * capability exists.
+ *
+ * HONEST v1 BOUND: no media verifier exists yet — every citation today is
+ * text (fact lines + L3 episode spans), so the cited-capability set is
+ * always {'text'} and the check can only ABSTAIN (required non-text) or PASS
+ * (required text). It is fail-closed plumbing: claims requiring visual/audio
+ * evidence can no longer verify on text alone; CONFIRMATION of such claims
+ * arrives with the media verifiers (the M-track fragment mapping populates
+ * per-citation capabilities and VerifyRequest.capabilityEvidenceLines).
+ *
+ * SAFETY: the env read lives here in the common layer, NOT inside the engine
+ * dirs (engine-gates S5.2). Read at call time so a flip is runtime-mutable.
+ * Default off ⇒ the resolver returns {} — no registry lookup, no verdict
+ * param — serving byte-identical (the answer-integrity precedent).
+ */
+export function evidenceCapabilityEnabled(): boolean {
+  return envFlagEnabled(process.env.FOVEA_EVIDENCE_CAPABILITY);
+}
+
+/**
  * Multilingual Tier 5 master flag — MULTILINGUAL_CALIBRATION.
  *
  * When on, the §4.2 per-class focus calibrator (focus-signal.ts) gains a

--- a/src/db/migrations/0113_outcome_dimensions.surql
+++ b/src/db/migrations/0113_outcome_dimensions.surql
@@ -1,0 +1,45 @@
+-- 0113_outcome_dimensions — outcome-telemetry modality dimensions (Part 1)
+-- + the per-predicate evidence-capability requirement (Part 2), Brain v2.1.
+--
+-- NUMBERING NOTE: 0108-0112 are claimed by in-flight sibling PRs of the
+-- same wave; this migration deliberately takes 0113. The migrator applies
+-- by numeric order and tracks per-id, so the gap is harmless whether the
+-- siblings land before or after this one.
+--
+-- Part 1 — memory_outcome gains two OPTIONAL dimensions:
+--   * modality           — which evidence modality the outcome concerns
+--                          ('text' | 'visual' | 'audio' | 'document_region');
+--   * representationKind — free-form representation tag within the modality
+--                          (e.g. 'caption', 'ocr_text', 'frame_embedding').
+-- NONE = legacy/text: every pre-0113 row and every text-path writer.
+--
+-- TOP-LEVEL COLUMNS, NOT meta KEYS — two 0107 contracts force this:
+--   * meta is CONTENT-FREE by contract (record ids / verdict strings only,
+--     0107 header) and is deliberately shapeless (FLEXIBLE) — a queryable
+--     dimension does not belong in it;
+--   * the writer's dedupe key IGNORES meta entirely
+--     (memory-outcome.service.ts dedupeOutcomeEvents) — a dimension buried
+--     in meta would be invisible to event partitioning, so two outcomes of
+--     the same event on different modalities would collapse into one row.
+--
+-- memory_outcome_stat is UNTOUCHED: the rollup stays UNIQUE-per-subject.
+-- Per-modality stat columns are deliberately DEFERRED — no scorer consumes
+-- them yet, and the raw rows retain full dimensionality, so a per-modality
+-- rollup can be introduced later without loss (it would be maintained
+-- forward by the writer, like 0107 — never recomputed from pruned raw).
+
+DEFINE FIELD IF NOT EXISTS modality ON memory_outcome TYPE option<string>
+  ASSERT $value = NONE OR $value INSIDE ['text', 'visual', 'audio', 'document_region'];
+DEFINE FIELD IF NOT EXISTS representationKind ON memory_outcome TYPE option<string>;
+
+-- Part 2 — verifier evidence-capability check (FOVEA_EVIDENCE_CAPABILITY):
+-- the per-predicate REQUIREMENT column. A predicate whose claims can only
+-- be verified against non-text evidence (a whiteboard photo, a call
+-- recording, a contract region) declares it here; the finalize-time gate
+-- reads it through the registry snapshot. Absent (NONE) = 'text' =
+-- unconstrained — every CORE seed predicate and every pre-0113 row.
+-- Open option<string> (not an ASSERT enum) on purpose: the closed union
+-- lives in TS (EvidenceCapability, synthesize.types.ts) and the registry
+-- row mapping drops unknown values to unconstrained — a malformed row must
+-- degrade to today's behavior, never abstain-storm a tenant.
+DEFINE FIELD IF NOT EXISTS requiredEvidenceCapability ON knowledge_predicate TYPE option<string>;

--- a/src/ingest/conflict-resolver.ts
+++ b/src/ingest/conflict-resolver.ts
@@ -45,6 +45,7 @@
  */
 
 import { CORE_PREDICATES } from '../ai/predicate-registry.service';
+import type { EvidenceCapability } from '../synthesize/synthesize.types';
 
 export type Semantics = 'append_only' | 'single_active' | 'bitemporal';
 
@@ -88,6 +89,14 @@ export interface PredicatePolicy {
   decayHalfLifeDays: number | null; // null = never decay
   piiClass: 'none' | 'identifier' | 'behavioral' | 'text' | 'sensitive';
   requiresScope?: 'brain:read_pii';
+  /**
+   * 0113 (FOVEA_EVIDENCE_CAPABILITY): the evidence capability claims
+   * under this predicate REQUIRE to verify. Absent = 'text' =
+   * unconstrained — every CORE seed predicate carries no value (all
+   * text); only tenant registry rows (knowledge_predicate column) set
+   * it. Consumed by the verdict-side evidence-capability gate.
+   */
+  requiredEvidenceCapability?: EvidenceCapability;
 }
 
 export const DEFAULT_POLICY: PredicatePolicy = {
@@ -119,6 +128,11 @@ export function policyFor(predicate: string): PredicatePolicy {
     decayHalfLifeDays: seed.decayHalfLifeDays,
     piiClass: seed.piiClass,
     ...(seed.requiresScope ? { requiresScope: seed.requiresScope as 'brain:read_pii' } : {}),
+    // 0113: no CORE seed sets it (all text) — threaded for shape parity
+    // with the registry rows so a future seed value is not silently lost.
+    ...(seed.requiredEvidenceCapability
+      ? { requiredEvidenceCapability: seed.requiredEvidenceCapability }
+      : {}),
   };
 }
 
@@ -136,6 +150,9 @@ export const PREDICATE_POLICIES: Record<string, PredicatePolicy> = Object.fromEn
       decayHalfLifeDays: p.decayHalfLifeDays,
       piiClass: p.piiClass,
       ...(p.requiresScope ? { requiresScope: p.requiresScope as 'brain:read_pii' } : {}),
+      ...(p.requiredEvidenceCapability
+        ? { requiredEvidenceCapability: p.requiredEvidenceCapability }
+        : {}),
     } as PredicatePolicy,
   ]),
 );

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -313,6 +313,23 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // Evidence-capability verdict gate (FOVEA_EVIDENCE_CAPABILITY, 0113):
+  //   checked    — the gate resolved the required capability over a
+  //                supported answer's cited facts (fires once per resolved
+  //                check, pass or downgrade — the denominator)
+  //   downgraded — a supported answer was abstained because its required
+  //                NON-TEXT capability had no cited evidence (reason
+  //                'evidence_capability_unmet' on the wire)
+  // Counted only when the flag is on. The synthesize outcome series stays
+  // stable (the downgrade still tags 'low_coverage' there, the Part A/C
+  // idiom) — this separate series carries the capability-specific signal.
+  readonly evidenceCapabilityCount = new Counter({
+    name: 'brain_evidence_capability_total',
+    help: 'Evidence-capability verdict gate outcomes (FOVEA_EVIDENCE_CAPABILITY)',
+    labelNames: ['outcome'] as const,
+    registers: [this.registry],
+  });
+
   // Optics §4.3 (docs/roadmap/fovea-optics-2026-08.md §4.3): the
   // lens-suppression governor's per-request outcome —
   //   suppressed     — a confident class match removed ≥1 active lane
@@ -734,6 +751,10 @@ export class MetricsService implements OnModuleInit {
 
   countCitationGuardAbstain(): void {
     this.citationGuardAbstainCount.inc();
+  }
+
+  countEvidenceCapability(outcome: 'checked' | 'downgraded'): void {
+    this.evidenceCapabilityCount.inc({ outcome } as LabelValues<'outcome'>);
   }
 
   countLensSuppression(

--- a/src/outcomes/memory-outcome.service.ts
+++ b/src/outcomes/memory-outcome.service.ts
@@ -45,12 +45,35 @@ export type OutcomeCounter =
   | 'rejectedCount'
   | 'contradictedCount';
 
+/**
+ * 0113 dimension: which evidence modality the outcome concerns. Mirrors
+ * the `EvidenceCapability` union (synthesize.types.ts) value-for-value —
+ * duplicated here as its own name so this substrate layer never imports
+ * from the engine dirs it serves. Absent = legacy/text (the migration's
+ * NONE contract).
+ */
+export type OutcomeModality = 'text' | 'visual' | 'audio' | 'document_region';
+
 export interface OutcomeEventInput {
   subjectKind: OutcomeSubjectKind;
   /** Full record id string, e.g. 'knowledge_fact:abc'. */
   subjectId: string;
   event: OutcomeEventName;
   actor?: string | undefined;
+  /**
+   * 0113: evidence modality of the outcome. A TOP-LEVEL column, not a
+   * meta key — meta is content-free ids-only AND the dedupe key ignores
+   * meta, so a meta-buried dimension would be invisible to partitioning
+   * (see the 0113 migration header). Absent = legacy/text. No writer in
+   * the text pipeline stamps it yet — the media paths (sibling PRs) do.
+   */
+  modality?: OutcomeModality | undefined;
+  /**
+   * 0113: free-form representation tag within the modality (e.g.
+   * 'caption', 'ocr_text', 'frame_embedding'). Same top-level-column
+   * rationale as `modality`; absent = legacy.
+   */
+  representationKind?: string | undefined;
   /** CONTENT-FREE: ids / verdict strings only — never fact text. */
   meta?: Record<string, unknown> | undefined;
 }
@@ -91,14 +114,21 @@ const AUTO_STAT: Partial<
 };
 
 /**
- * Dedupe on (subjectKind, subjectId, event, actor) then cap. Pure and
- * exported for the unit spec.
+ * Dedupe on (subjectKind, subjectId, event, actor, modality,
+ * representationKind) then cap. Pure and exported for the unit spec.
+ *
+ * 0113: the two dimension components extend the key so the SAME event on
+ * DIFFERENT modalities stays two rows. Every existing (text-path) writer
+ * passes neither field, so its key gains a constant `||` suffix —
+ * partitioning identical to pre-0113, pinned by the unit spec.
  */
 export function dedupeOutcomeEvents(events: OutcomeEventInput[]): OutcomeEventInput[] {
   const seen = new Set<string>();
   const out: OutcomeEventInput[] = [];
   for (const ev of events) {
-    const key = `${ev.subjectKind}|${ev.subjectId}|${ev.event}|${ev.actor ?? ''}`;
+    const key =
+      `${ev.subjectKind}|${ev.subjectId}|${ev.event}|${ev.actor ?? ''}` +
+      `|${ev.modality ?? ''}|${ev.representationKind ?? ''}`;
     if (seen.has(key)) continue;
     seen.add(key);
     out.push(ev);
@@ -218,6 +248,13 @@ export class MemoryOutcomeService {
       // undefined → dropped from the payload → NONE (option<...> rejects NULL).
       ...(ev.actor !== undefined ? { actor: ev.actor } : {}),
       ...(opts.requestId !== undefined ? { requestId: opts.requestId } : {}),
+      // 0113 dimensions ride the raw row only. The rollup (statRows below)
+      // stays UNIQUE-per-subject with NO per-modality columns — deliberate:
+      // no scorer consumes a per-modality stat yet, and the raw rows retain
+      // full dimensionality, so a modality rollup can be added later
+      // without loss. Existing writers pass neither → row byte-identical.
+      ...(ev.modality !== undefined ? { modality: ev.modality } : {}),
+      ...(ev.representationKind !== undefined ? { representationKind: ev.representationKind } : {}),
       ...(ev.meta !== undefined ? { meta: ev.meta } : {}),
     }));
 

--- a/src/synthesize/answer-integrity.ts
+++ b/src/synthesize/answer-integrity.ts
@@ -2,10 +2,16 @@ import type OpenAI from 'openai';
 import type { MetricsService } from '../metrics/metrics.service';
 import type { Semaphore } from '../common/semaphore';
 import type { AnswerCacheBeginResult } from '../answer-cache/answer-cache.service';
+import type { PredicateRegistryService } from '../ai/predicate-registry.service';
 import type { RetrievalProfile } from '../search/retrieval-profile';
 import type { SynthesizeDto } from './dto/synthesize.dto';
-import { plausibilityCheckEnabled, requireCitationsEnabled } from '../common/fovea-flags';
+import {
+  evidenceCapabilityEnabled,
+  plausibilityCheckEnabled,
+  requireCitationsEnabled,
+} from '../common/fovea-flags';
 import type { Citation } from './fact-index';
+import type { EvidenceCapability, EvidenceCitation } from './synthesize.types';
 import { runPlausibilityJudge, type VerifierOutput } from './verifier';
 
 /**
@@ -49,10 +55,13 @@ export interface FinalizeContext {
 }
 
 /**
- * Resolve the Part A + Part C gate flags for finalizeVerdict. Returns an empty
- * object — no LLM call — unless the caller supplied dto+profile AND the verdict
- * is `supported`. Both the primary serve and the L3 flip supply dto+profile, so
- * both are gated. Part C (FOVEA_REQUIRE_CITATIONS) is a pure flag; Part A
+ * Resolve the Part A + Part C gate flags for finalizeVerdict, plus the
+ * evidence-capability flag (FOVEA_EVIDENCE_CAPABILITY, 0113 — composed from
+ * resolveEvidenceCapability below so finalizeAndAdmit keeps ONE gate call).
+ * Returns an empty object — no LLM call, no registry lookup — on a
+ * non-supported verdict; A + C additionally require dto+profile. Both the
+ * primary serve and the L3 flip supply dto+profile, so both are gated. Part C
+ * (FOVEA_REQUIRE_CITATIONS) is a pure flag; Part A
  * (FOVEA_PLAUSIBILITY_CHECK) runs ONE extra LLM plausibility judge over the
  * cited premises (see resolvePlausibilityDowngrade). The auditor model is
  * profile.verifierModel || the synthesis model.
@@ -80,12 +89,40 @@ export async function resolveAnswerIntegrity(
   input: {
     ctx: FinalizeContext;
     verdict: VerifierOutput;
-    args: { answer: string; citations: Citation[] };
+    args: {
+      answer: string;
+      citations: Citation[];
+      evidenceCitations?: EvidenceCitation[] | undefined;
+    };
     defaultModel: string;
+    /**
+     * Evidence-capability gate (FOVEA_EVIDENCE_CAPABILITY, 0113): the
+     * per-predicate policy source, threaded from the service's @Optional
+     * injection. Absent (trimmed fixtures) ⇒ the capability arm is a
+     * guarded no-op, like an off flag.
+     */
+    registry?: Pick<PredicateRegistryService, 'rowPolicyLookup'> | undefined;
   },
-): Promise<{ plausibilityDowngrade?: boolean; requireCitations?: boolean }> {
+): Promise<{
+  plausibilityDowngrade?: boolean;
+  requireCitations?: boolean;
+  evidenceCapabilityUnmet?: boolean;
+}> {
   const { ctx } = input;
-  if (!ctx.dto || !ctx.profile || input.verdict.verdict !== 'supported') return {};
+  if (input.verdict.verdict !== 'supported') return {};
+  // The capability arm needs only companyId + registry (both serving
+  // paths carry dto/profile/companyId anyway; bare-cache callers lack
+  // companyId and no-op inside the resolver).
+  const capability = await resolveEvidenceCapability(
+    { registry: input.registry, metrics: deps.metrics, logger: deps.logger },
+    {
+      ctx,
+      verdict: input.verdict,
+      citations: input.args.citations,
+      evidenceCitations: input.args.evidenceCitations,
+    },
+  );
+  if (!ctx.dto || !ctx.profile) return capability;
   const requireCitations = requireCitationsEnabled();
   const plausibilityDowngrade = await resolvePlausibilityDowngrade(deps, {
     query: ctx.dto.query,
@@ -94,6 +131,7 @@ export async function resolveAnswerIntegrity(
     model: ctx.profile.verifierModel || ctx.model || input.defaultModel,
   });
   return {
+    ...capability,
     ...(plausibilityDowngrade ? { plausibilityDowngrade } : {}),
     ...(requireCitations ? { requireCitations } : {}),
   };
@@ -111,6 +149,97 @@ export async function resolveAnswerIntegrity(
  * citations are verbatim-verified mechanically by anchorQuote and carry no
  * premise to audit.
  */
+/**
+ * Evidence-capability gate deps (FOVEA_EVIDENCE_CAPABILITY, 0113). The
+ * registry arrives @Optional from the service — absent (trimmed unit
+ * fixtures) ⇒ the resolver is a guarded no-op, like an off flag.
+ */
+export interface EvidenceCapabilityDeps {
+  registry?: Pick<PredicateRegistryService, 'rowPolicyLookup'> | undefined;
+  metrics?: Pick<MetricsService, 'countEvidenceCapability'> | undefined;
+  logger: { warn(message: string): void };
+}
+
+/**
+ * "max over cited facts": severity order for the required-capability fold.
+ * 'text' is the floor (unconstrained); ANY non-text requirement outranks
+ * it and forces the gate. The relative order among non-text kinds is a
+ * deterministic tie-break only — with today's all-text cited set every
+ * non-text requirement abstains identically; the order starts mattering
+ * once the M-track fragment mapping supplies non-text cited capabilities.
+ */
+const CAPABILITY_RANK: Record<EvidenceCapability, number> = {
+  text: 0,
+  visual: 1,
+  audio: 2,
+  document_region: 3,
+};
+
+/**
+ * Resolve the evidence-capability gate flag for finalizeVerdict — the
+ * resolveAnswerIntegrity sibling in the finalizeAndAdmit gate-resolution.
+ * Flag off ⇒ {} with NO registry lookup (byte-identical, the
+ * answer-integrity precedent); likewise for a non-supported verdict, a
+ * bare-cache caller (no companyId), a trimmed fixture (no registry), or
+ * zero cited facts (Part C owns the uncited case).
+ *
+ * Flag on: ONE snapshot-warm (rowPolicyLookup — TTL-cached, herd-deduped)
+ * then sync per-citation lookups against the tenant registry — no per-fact
+ * IO. required = max over the cited facts' predicate policies (any
+ * non-text wins); the cited-capability set today is always {'text'}
+ * (facts + episode spans are text), so the check can only abstain or
+ * pass. A lookup failure FAILS SAFE to today's behavior (no gate) and is
+ * logged — a registry hiccup must not abstain a grounded answer.
+ */
+export async function resolveEvidenceCapability(
+  deps: EvidenceCapabilityDeps,
+  input: {
+    ctx: FinalizeContext;
+    verdict: VerifierOutput;
+    citations: Citation[];
+    evidenceCitations?: EvidenceCitation[] | undefined;
+  },
+): Promise<{ evidenceCapabilityUnmet?: boolean }> {
+  if (!evidenceCapabilityEnabled()) return {};
+  const { ctx, verdict, citations } = input;
+  if (verdict.verdict !== 'supported') return {};
+  if (!ctx.companyId || !deps.registry || citations.length === 0) return {};
+  try {
+    const policyFor = await deps.registry.rowPolicyLookup(ctx.companyId);
+    const required = citations.reduce<EvidenceCapability>((acc, c) => {
+      const cap = policyFor(c.predicate).requiredEvidenceCapability ?? 'text';
+      return CAPABILITY_RANK[cap] > CAPABILITY_RANK[acc] ? cap : acc;
+    }, 'text');
+    deps.metrics?.countEvidenceCapability('checked');
+    if (required === 'text') return {};
+    if (citedCapabilities(input.evidenceCitations).has(required)) return {};
+    return { evidenceCapabilityUnmet: true };
+  } catch (e) {
+    deps.logger.warn(
+      `evidence-capability resolution failed; serving ungated: ${(e as Error).message}`,
+    );
+    return {};
+  }
+}
+
+/**
+ * The capabilities the answer's cited evidence actually carries.
+ *
+ * SEAM (M-track fragment mapping): today EVERY citation is text — fact
+ * citations are extracted text lines and EvidenceCitation is an
+ * episode/span over stored turn TEXT — so this is the constant {'text'}
+ * and the gate is honestly abstain-or-pass. The M-track sibling maps
+ * media fragments into citations carrying their own capability kind;
+ * it extends THIS function (and populates
+ * VerifyRequest.capabilityEvidenceLines) — nothing else in the gate
+ * changes.
+ */
+function citedCapabilities(
+  _evidenceCitations: EvidenceCitation[] | undefined,
+): Set<EvidenceCapability> {
+  return new Set<EvidenceCapability>(['text']);
+}
+
 async function resolvePlausibilityDowngrade(
   deps: AnswerIntegrityDeps,
   input: { query: string; answer: string; citations: Citation[]; model: string },

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -32,6 +32,7 @@ import { laneProbeDto, type LaneId } from './answer-router';
 import { getActiveRetrievalProfile, type RetrievalProfile } from '../search/retrieval-profile';
 import { buildFactIndex } from './fact-index';
 import { resolveAnswerIntegrity, type FinalizeContext } from './answer-integrity';
+import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { applyFactSuffixes } from './update-story';
 import { buildDateMathLines } from './date-math';
 export { buildFactIndex } from './fact-index';
@@ -135,6 +136,10 @@ export class SynthesizeService {
     @Optional() private readonly laneClassifier?: MultilingualLaneClassifierService,
     // 0107 outcome writer — @Optional so positional unit fixtures stay valid.
     @Optional() private readonly outcomes?: MemoryOutcomeService,
+    // 0113 evidence-capability gate: per-predicate policy source (AiModule
+    // is @Global, so this resolves in every app composition). @Optional so
+    // positional unit fixtures stay valid — absent ⇒ the resolver no-ops.
+    @Optional() private readonly predicateRegistry?: PredicateRegistryService,
   ) {
     this.openai = createOpenAiClientOrThrow(this.configService);
     this.defaultModel = this.configService.get<string>(
@@ -676,9 +681,14 @@ export class SynthesizeService {
     // 0107: cited facts were USED; a supported verdict ⇒ VERIFIED use.
     // Both serving paths (primary + L3 flip) land here with companyId.
     emitAnswerUse(this.outcomes, { companyId: ctx.companyId, citations: args.citations, verdict });
+    // The gate-resolution also folds in the evidence-capability flag
+    // (FOVEA_EVIDENCE_CAPABILITY, 0113 — resolveEvidenceCapability, the
+    // resolveAnswerIntegrity sibling in answer-integrity.ts): does the
+    // supported answer's cited predicate set REQUIRE non-text evidence no
+    // citation carries? Flag off / no registry ⇒ absent ⇒ byte-identical.
     const gate = await resolveAnswerIntegrity(
       { openai: this.openai, metrics: this.metrics, logger: this.logger, limiter: this.limiter },
-      { ctx, verdict, args, defaultModel: this.defaultModel },
+      { ctx, verdict, args, defaultModel: this.defaultModel, registry: this.predicateRegistry },
     );
     const final = this.finalizeVerdict({
       verdict: verdict.verdict,

--- a/src/synthesize/synthesize.types.ts
+++ b/src/synthesize/synthesize.types.ts
@@ -16,10 +16,32 @@ export type SynthesisReason =
   | 'no_grounded_evidence'
   /** V9 §4: the memory-coverage abstention path fired. */
   | 'low_coverage'
+  /**
+   * Evidence-capability gate (FOVEA_EVIDENCE_CAPABILITY, 0113): a
+   * `supported` answer cites a fact whose predicate REQUIRES a non-text
+   * evidence capability, and no cited evidence of that capability
+   * exists. A DISTINCT reason from 'low_coverage' on purpose: the
+   * caller's remedy is different — "attach/verify the picture", not
+   * "the memory doesn't know".
+   */
+  | 'evidence_capability_unmet'
   | 'verifier_failed'
   | 'verifier_partial'
   | 'generator_error'
   | 'verifier_error';
+
+/**
+ * Evidence-capability axis (0113): what KIND of evidence a claim can be
+ * verified against. Per-predicate requirement source:
+ * PredicatePolicy.requiredEvidenceCapability (absent = 'text' =
+ * unconstrained). The verdict-side gate (FOVEA_EVIDENCE_CAPABILITY)
+ * compares a supported answer's required capability — max over its cited
+ * facts — against the capabilities its cited evidence actually carries.
+ * Today every citation is text (facts + episode spans), so the check can
+ * only abstain or pass — no media verifier exists yet (honest v1 bound;
+ * the M-track fragment mapping adds non-text cited capabilities).
+ */
+export type EvidenceCapability = 'text' | 'visual' | 'audio' | 'document_region';
 
 /** Prompt/completion cost of one LLM call, surfaced for token accounting. */
 export interface TokenUsage {

--- a/src/synthesize/verdict.ts
+++ b/src/synthesize/verdict.ts
@@ -30,6 +30,7 @@ export interface VerdictDeps {
         | 'countAbstainPath'
         | 'countPlausibilityDowngrade'
         | 'countCitationGuardAbstain'
+        | 'countEvidenceCapability'
       >
     | undefined;
   logger?: { debug(message: string): void } | undefined;
@@ -60,7 +61,7 @@ export interface AbstainAdaptiveGate {
  * ok path.
  *
  * Verifier answer-integrity arm (default-off, resolved by the service and
- * passed in — this function stays pure): two orthogonal downgrades on the
+ * passed in — this function stays pure): three orthogonal downgrades on the
  * supported serve-path, each byte-identical to today when its input is
  * absent/false.
  *  - Part A `plausibilityDowngrade` (FOVEA_PLAUSIBILITY_CHECK): the
@@ -70,6 +71,10 @@ export interface AbstainAdaptiveGate {
  *  - Part C `requireCitations` (FOVEA_REQUIRE_CITATIONS): a supported answer
  *    carrying ZERO citations (audit F2(b)) is abstained rather than served as
  *    an uncited "supported" answer.
+ *  - `evidenceCapabilityUnmet` (FOVEA_EVIDENCE_CAPABILITY, 0113): a cited
+ *    fact's predicate REQUIRES non-text evidence and none is cited — the
+ *    supported verdict rests on the wrong KIND of evidence; abstain under
+ *    reason 'evidence_capability_unmet'.
  */
 export function finalizeVerdict(
   deps: VerdictDeps,
@@ -84,6 +89,7 @@ export function finalizeVerdict(
     abstention,
     plausibilityDowngrade,
     requireCitations,
+    evidenceCapabilityUnmet,
     evidenceCitations,
   }: {
     verdict: 'supported' | 'partial' | 'unsupported';
@@ -98,6 +104,14 @@ export function finalizeVerdict(
     plausibilityDowngrade?: boolean | undefined;
     /** Part C: abstain a supported answer with zero citations. */
     requireCitations?: boolean | undefined;
+    /**
+     * Evidence-capability gate (FOVEA_EVIDENCE_CAPABILITY, 0113):
+     * resolved by the service (resolveEvidenceCapability) — true when the
+     * supported answer's cited facts REQUIRE a non-text evidence
+     * capability and no cited evidence of that capability exists.
+     * Absent/false ⇒ byte-identical (flag off resolves to {}).
+     */
+    evidenceCapabilityUnmet?: boolean | undefined;
     /**
      * L3 evidence citations (FOVEA_L3_EPISODE_CITATIONS): episode-level
      * references for transcript-grounded claims, supplied ONLY by the L3
@@ -156,6 +170,28 @@ export function finalizeVerdict(
         {
           answer: NOT_IN_MEMORY_ANSWER,
           reason: 'low_coverage',
+          citations: [],
+          results,
+        },
+        decisionLog,
+      );
+    }
+    // Evidence-capability gate (FOVEA_EVIDENCE_CAPABILITY, 0113) — the
+    // FOURTH sequential downgrade on the supported serve: a cited fact's
+    // predicate requires non-text evidence and none is cited, so the
+    // "supported" verdict rests on the WRONG KIND of evidence — abstain,
+    // fail-closed, under its own reason (the caller's remedy is "attach /
+    // verify the picture", not "the memory doesn't know"). The synthesize
+    // OUTCOME series keeps the stable 'low_coverage' tag (the Part A/C
+    // idiom — no new outcome value); the dedicated capability series
+    // carries the specific signal. Absent/false ⇒ byte-identical.
+    if (evidenceCapabilityUnmet) {
+      deps.metrics?.countSynthesize('low_coverage');
+      deps.metrics?.countEvidenceCapability('downgraded');
+      return attachDecisionLog(
+        {
+          answer: NOT_IN_MEMORY_ANSWER,
+          reason: 'evidence_capability_unmet',
           citations: [],
           results,
         },

--- a/src/synthesize/verifier.ts
+++ b/src/synthesize/verifier.ts
@@ -96,6 +96,17 @@ export interface VerifyRequest {
   /** V13 (profile.dateMath): the computed date table the generator
    *  saw — weekday/gap claims grounded in it must not be flagged. */
   dateMathLines?: string[] | undefined;
+  /**
+   * Evidence-capability arm (FOVEA_EVIDENCE_CAPABILITY, 0113) — SEAM,
+   * nothing populates it yet: rendered lines of NON-TEXT evidence the
+   * generator was allowed to answer from, each prefixed
+   * `[capability:<kind>]` (e.g. `[capability:visual] whiteboard photo:
+   * …`). Composed as its own section in the auditor prompt ONLY when
+   * non-empty — absent/empty ⇒ the prompt is byte-identical. The
+   * M-track fragment mapping starts supplying it alongside per-citation
+   * capabilities (answer-integrity.ts citedCapabilities).
+   */
+  capabilityEvidenceLines?: string[] | undefined;
   model: string;
 }
 
@@ -108,6 +119,7 @@ function buildVerifierUserMessage({
   insightLines,
   timelineEvidence,
   dateMathLines,
+  capabilityEvidenceLines,
 }: {
   query: string;
   answer: string;
@@ -116,6 +128,7 @@ function buildVerifierUserMessage({
   insightLines?: string[] | undefined;
   timelineEvidence?: boolean | undefined;
   dateMathLines?: string[] | undefined;
+  capabilityEvidenceLines?: string[] | undefined;
 }): string {
   const sections = [`Source facts:\n${factLines.join('\n')}`];
   if (transcriptLines && transcriptLines.length > 0) {
@@ -131,6 +144,14 @@ function buildVerifierUserMessage({
     sections.push(
       `Computed date table (derived in code from the fact date stamps — weekday and gap claims grounded in it are valid support):\n` +
         dateMathLines.join('\n'),
+    );
+  }
+  // Evidence-capability section (0113 seam) — only when non-empty, so
+  // every text-path audit prompt stays byte-identical.
+  if (capabilityEvidenceLines && capabilityEvidenceLines.length > 0) {
+    sections.push(
+      `Non-text evidence (each line tagged [capability:<kind>] — equally valid support for claims of that kind):\n` +
+        capabilityEvidenceLines.join('\n'),
     );
   }
   return `Query: ${query}\n\nAnswer:\n${answer}\n\n${sections.join('\n\n')}`;

--- a/test/answer-integrity.unit-spec.ts
+++ b/test/answer-integrity.unit-spec.ts
@@ -51,6 +51,7 @@ function fakeDeps(): DepsCapture {
         countCitationGuardAbstain: () => {
           counts.citationGuards++;
         },
+        countEvidenceCapability: () => {},
       },
     },
   };

--- a/test/evidence-capability.unit-spec.ts
+++ b/test/evidence-capability.unit-spec.ts
@@ -1,0 +1,366 @@
+/**
+ * Evidence-capability verdict gate (FOVEA_EVIDENCE_CAPABILITY, 0113) —
+ * unit coverage for every pure seam of the track:
+ *
+ *  - finalizeVerdict fourth-branch matrix: unmet → abstain under the NEW
+ *    reason 'evidence_capability_unmet'; no-rule → pass; gate absent
+ *    (flag off) → byte-identical verdict object;
+ *  - resolveEvidenceCapability: flag gating, the max-over-citations fold,
+ *    the honest v1 bound (cited capabilities are always {'text'}), and
+ *    the fail-safe on registry errors;
+ *  - policy threading: knowledge_predicate row → PredicateDefinition →
+ *    PredicatePolicy (db-mapping round-trip, unknown values dropped);
+ *  - verifier prompt composer: capabilityEvidenceLines render as their
+ *    own section only when non-empty (absent → byte-identical prompt).
+ */
+import { finalizeVerdict } from '../src/synthesize/verdict';
+import { resolveEvidenceCapability } from '../src/synthesize/answer-integrity';
+import type { FinalizeContext } from '../src/synthesize/answer-integrity';
+import { NOT_IN_MEMORY_ANSWER } from '../src/synthesize/abstention';
+import { runVerifier, type VerifierOutput } from '../src/synthesize/verifier';
+import type { Citation } from '../src/synthesize/fact-index';
+import type { SearchHit } from '../src/search/search.service';
+import {
+  deserializeFromRow,
+  serializeForInsert,
+} from '../src/ai/predicate-registry-internals/db-mapping';
+import type { PredicateDefinition } from '../src/ai/predicate-registry-internals/types';
+import { policyFor } from '../src/ingest/conflict-resolver';
+import type OpenAI from 'openai';
+
+const cite = (predicate: string, factId = `knowledge_fact:${predicate}`): Citation => ({
+  factId,
+  entityId: 'knowledge_entity:e',
+  canonicalName: 'ops room',
+  predicate,
+  object: 'the evacuation plan is pinned on the whiteboard',
+});
+const RESULTS: SearchHit[] = [];
+
+interface DepsCapture {
+  deps: Parameters<typeof finalizeVerdict>[0];
+  synth: string[];
+  capability: string[];
+}
+function fakeDeps(): DepsCapture {
+  const synth: string[] = [];
+  const capability: string[] = [];
+  return {
+    synth,
+    capability,
+    deps: {
+      metrics: {
+        countSynthesize: ((o: string) => synth.push(o)) as never,
+        countAbstainPath: () => {},
+        countPlausibilityDowngrade: () => {},
+        countCitationGuardAbstain: () => {},
+        countEvidenceCapability: ((o: string) => capability.push(o)) as never,
+      },
+    },
+  };
+}
+
+// ── finalizeVerdict — the fourth sequential downgrade ───────────────
+describe('finalizeVerdict — evidence-capability branch', () => {
+  it('supported + unmet → abstains under the NEW reason, citations dropped, downgraded counted', () => {
+    const { deps, synth, capability } = fakeDeps();
+    const r = finalizeVerdict(deps, {
+      verdict: 'supported',
+      answer: 'The plan is on the whiteboard.',
+      citations: [cite('whiteboard_layout')],
+      results: RESULTS,
+      guardrails: 'strict',
+      evidenceCapabilityUnmet: true,
+    });
+    expect(r.answer).toBe(NOT_IN_MEMORY_ANSWER);
+    expect(r.reason).toBe('evidence_capability_unmet');
+    expect(r.citations).toEqual([]);
+    // Outcome series stays on the stable abstain tag; the NEW series
+    // carries the specific signal (the Part A/C idiom).
+    expect(synth).toEqual(['low_coverage']);
+    expect(capability).toEqual(['downgraded']);
+  });
+
+  it('supported + gate false → serves unchanged', () => {
+    const { deps, synth, capability } = fakeDeps();
+    const r = finalizeVerdict(deps, {
+      verdict: 'supported',
+      answer: 'A text-verifiable answer.',
+      citations: [cite('status')],
+      results: RESULTS,
+      guardrails: 'strict',
+      evidenceCapabilityUnmet: false,
+    });
+    expect(r.answer).toBe('A text-verifiable answer.');
+    expect(r.reason).toBeUndefined();
+    expect(synth).toEqual(['ok']);
+    expect(capability).toEqual([]);
+  });
+
+  it('gate absent (flag off resolves to {}) → byte-identical to the reference serve', () => {
+    const ref = finalizeVerdict(fakeDeps().deps, {
+      verdict: 'supported',
+      answer: 'A text-verifiable answer.',
+      citations: [cite('status')],
+      results: RESULTS,
+      guardrails: 'strict',
+    });
+    const { deps, capability } = fakeDeps();
+    const out = finalizeVerdict(deps, {
+      verdict: 'supported',
+      answer: 'A text-verifiable answer.',
+      citations: [cite('status')],
+      results: RESULTS,
+      guardrails: 'strict',
+      // evidenceCapabilityUnmet omitted — the flag-off shape.
+    });
+    expect(out).toEqual(ref);
+    expect(capability).toEqual([]);
+  });
+
+  it('is the FOURTH branch: plausibility (earlier) wins and keeps ITS reason', () => {
+    const { deps, capability } = fakeDeps();
+    const r = finalizeVerdict(deps, {
+      verdict: 'supported',
+      answer: 'A distorted answer.',
+      citations: [cite('whiteboard_layout')],
+      results: RESULTS,
+      guardrails: 'strict',
+      plausibilityDowngrade: true,
+      evidenceCapabilityUnmet: true,
+    });
+    expect(r.answer).toBe(NOT_IN_MEMORY_ANSWER);
+    expect(r.reason).toBe('low_coverage');
+    // The later capability branch never ran.
+    expect(capability).toEqual([]);
+  });
+});
+
+// ── resolveEvidenceCapability — the gate resolution ─────────────────
+describe('resolveEvidenceCapability', () => {
+  const SUPPORTED: VerifierOutput = { verdict: 'supported' };
+  const ctx: FinalizeContext = { cache: undefined, companyId: 'co_cap' };
+
+  function registryOf(
+    byPredicate: Record<string, PredicateDefinition['requiredEvidenceCapability']>,
+    calls?: string[],
+  ) {
+    return {
+      rowPolicyLookup: async (companyId: string) => {
+        calls?.push(companyId);
+        return (predicate: string): PredicateDefinition => ({
+          predicateId: predicate,
+          displayLabel: predicate,
+          description: '',
+          datatype: 'string',
+          semantics: 'append_only',
+          decayHalfLifeDays: null,
+          piiClass: 'none',
+          status: 'active',
+          createdBy: 'system',
+          ...(byPredicate[predicate] ? { requiredEvidenceCapability: byPredicate[predicate] } : {}),
+        });
+      },
+    };
+  }
+
+  function capDeps(
+    registry: ReturnType<typeof registryOf> | undefined,
+    counted: string[] = [],
+    warned: string[] = [],
+  ) {
+    return {
+      registry,
+      metrics: { countEvidenceCapability: ((o: string) => counted.push(o)) as never },
+      logger: { warn: (m: string) => warned.push(m) },
+    };
+  }
+
+  beforeEach(() => {
+    process.env.FOVEA_EVIDENCE_CAPABILITY = '1';
+  });
+  afterEach(() => {
+    delete process.env.FOVEA_EVIDENCE_CAPABILITY;
+  });
+
+  it('flag off → {} with NO registry lookup (byte-identical)', async () => {
+    delete process.env.FOVEA_EVIDENCE_CAPABILITY;
+    const calls: string[] = [];
+    const out = await resolveEvidenceCapability(
+      capDeps(registryOf({ whiteboard_layout: 'visual' }, calls)),
+      { ctx, verdict: SUPPORTED, citations: [cite('whiteboard_layout')] },
+    );
+    expect(out).toEqual({});
+    expect(calls).toEqual([]);
+  });
+
+  it('required visual + text-only citations → unmet (the honest v1 bound: abstain-or-pass)', async () => {
+    const counted: string[] = [];
+    const out = await resolveEvidenceCapability(
+      capDeps(registryOf({ whiteboard_layout: 'visual' }), counted),
+      { ctx, verdict: SUPPORTED, citations: [cite('whiteboard_layout')] },
+    );
+    expect(out).toEqual({ evidenceCapabilityUnmet: true });
+    expect(counted).toEqual(['checked']);
+  });
+
+  it('no rule on any cited predicate (absent = text = unconstrained) → passes', async () => {
+    const counted: string[] = [];
+    const out = await resolveEvidenceCapability(capDeps(registryOf({}), counted), {
+      ctx,
+      verdict: SUPPORTED,
+      citations: [cite('status'), cite('preference')],
+    });
+    expect(out).toEqual({});
+    expect(counted).toEqual(['checked']);
+  });
+
+  it('required = max over cited facts: one text + one visual → any non-text wins', async () => {
+    const out = await resolveEvidenceCapability(
+      capDeps(registryOf({ whiteboard_layout: 'visual', status: 'text' })),
+      { ctx, verdict: SUPPORTED, citations: [cite('status'), cite('whiteboard_layout')] },
+    );
+    expect(out).toEqual({ evidenceCapabilityUnmet: true });
+  });
+
+  it('non-supported verdict / no companyId / no registry / no citations → {} without a lookup', async () => {
+    const calls: string[] = [];
+    const registry = registryOf({ whiteboard_layout: 'visual' }, calls);
+    const partial: VerifierOutput = { verdict: 'partial' };
+    expect(
+      await resolveEvidenceCapability(capDeps(registry), {
+        ctx,
+        verdict: partial,
+        citations: [cite('whiteboard_layout')],
+      }),
+    ).toEqual({});
+    expect(
+      await resolveEvidenceCapability(capDeps(registry), {
+        ctx: { cache: undefined },
+        verdict: SUPPORTED,
+        citations: [cite('whiteboard_layout')],
+      }),
+    ).toEqual({});
+    expect(
+      await resolveEvidenceCapability(capDeps(undefined), {
+        ctx,
+        verdict: SUPPORTED,
+        citations: [cite('whiteboard_layout')],
+      }),
+    ).toEqual({});
+    expect(
+      await resolveEvidenceCapability(capDeps(registry), {
+        ctx,
+        verdict: SUPPORTED,
+        citations: [],
+      }),
+    ).toEqual({});
+    expect(calls).toEqual([]);
+  });
+
+  it('registry failure FAILS SAFE to today (no gate) and warns', async () => {
+    const warned: string[] = [];
+    const broken = {
+      rowPolicyLookup: async () => {
+        throw new Error('snapshot load exploded');
+      },
+    };
+    const out = await resolveEvidenceCapability(capDeps(broken, [], warned), {
+      ctx,
+      verdict: SUPPORTED,
+      citations: [cite('whiteboard_layout')],
+    });
+    expect(out).toEqual({});
+    expect(warned.join(' ')).toContain('snapshot load exploded');
+  });
+});
+
+// ── policy threading: registry row → PredicatePolicy field ──────────
+describe('requiredEvidenceCapability threading (0113 row → policy)', () => {
+  const baseRow = {
+    predicateId: 'whiteboard_layout',
+    displayLabel: 'whiteboard layout',
+    description: 'd',
+    datatype: 'string',
+    semantics: 'append_only',
+    piiClass: 'none',
+    status: 'active',
+    createdBy: 'admin',
+  };
+
+  it('deserializeFromRow threads a valid value', () => {
+    const def = deserializeFromRow({ ...baseRow, requiredEvidenceCapability: 'visual' });
+    expect(def.requiredEvidenceCapability).toBe('visual');
+  });
+
+  it('deserializeFromRow drops unknown/legacy values to ABSENT (= text = unconstrained)', () => {
+    expect(
+      deserializeFromRow({ ...baseRow, requiredEvidenceCapability: 'hologram' })
+        .requiredEvidenceCapability,
+    ).toBeUndefined();
+    expect(deserializeFromRow(baseRow).requiredEvidenceCapability).toBeUndefined();
+  });
+
+  it('serializeForInsert round-trips the field and OMITS it when absent (option<> NONE contract)', () => {
+    const def = deserializeFromRow({ ...baseRow, requiredEvidenceCapability: 'audio' });
+    expect(serializeForInsert(def)).toMatchObject({ requiredEvidenceCapability: 'audio' });
+    const bare = deserializeFromRow(baseRow);
+    expect('requiredEvidenceCapability' in serializeForInsert(bare)).toBe(false);
+  });
+
+  it('CORE seeds carry no value — the legacy policyFor maps them unconstrained', () => {
+    expect(policyFor('status').requiredEvidenceCapability).toBeUndefined();
+    expect(policyFor('preference').requiredEvidenceCapability).toBeUndefined();
+  });
+});
+
+// ── verifier prompt composer: capabilityEvidenceLines section ───────
+describe('buildVerifierUserMessage — capabilityEvidenceLines (seam)', () => {
+  function capturingOpenAi(users: string[]): OpenAI {
+    return {
+      chat: {
+        completions: {
+          create: async (req: { messages: Array<{ role: string; content: string }> }) => {
+            users.push(req.messages.find((m) => m.role === 'user')?.content ?? '');
+            return {
+              choices: [
+                {
+                  message: {
+                    content: JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+                  },
+                },
+              ],
+            };
+          },
+        },
+      },
+    } as unknown as OpenAI;
+  }
+
+  const BASE = {
+    query: 'where is the evacuation plan?',
+    answer: 'On the whiteboard.',
+    factLines: ['[knowledge_fact:f1] ops room — whiteboard_layout: evacuation plan pinned'],
+    model: 'gpt-test',
+  };
+
+  it('absent / empty → the prompt is byte-identical (no section)', async () => {
+    const users: string[] = [];
+    await runVerifier({ ...BASE, openai: capturingOpenAi(users) });
+    await runVerifier({ ...BASE, capabilityEvidenceLines: [], openai: capturingOpenAi(users) });
+    expect(users[1]).toBe(users[0]);
+    expect(users[0]).not.toContain('[capability:');
+  });
+
+  it('non-empty → its own section with the [capability:<kind>] lines', async () => {
+    const users: string[] = [];
+    const lines = [
+      '[capability:visual] whiteboard photo: evacuation plan, north stairwell circled',
+    ];
+    await runVerifier({ ...BASE, capabilityEvidenceLines: lines, openai: capturingOpenAi(users) });
+    expect(users[0]).toContain('Non-text evidence');
+    expect(users[0]).toContain(lines[0]);
+    // The base sections are untouched by the addition.
+    expect(users[0]).toContain('Source facts:');
+  });
+});

--- a/test/fovea-adaptive-abstain.unit-spec.ts
+++ b/test/fovea-adaptive-abstain.unit-spec.ts
@@ -75,6 +75,7 @@ function fakeDeps(): DepsCapture {
         countAbstainPath: (p: 'adaptive' | 'static') => paths.push(p),
         countPlausibilityDowngrade: () => {},
         countCitationGuardAbstain: () => {},
+        countEvidenceCapability: () => {},
       },
       logger: { debug: () => {} },
     },

--- a/test/fovea-evidence-capability.e2e-spec.ts
+++ b/test/fovea-evidence-capability.e2e-spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Evidence-capability verdict gate e2e (FOVEA_EVIDENCE_CAPABILITY, 0113)
+ * over a real SurrealDB (testcontainer). A tenant predicate declares
+ * requiredEvidenceCapability='visual' on its knowledge_predicate row; a
+ * supported answer citing a fact under that predicate must then ABSTAIN
+ * with the NEW reason 'evidence_capability_unmet' — the honest v1 bound:
+ * every citation today is text, so a non-text requirement can never be
+ * met (fail-closed plumbing; media verifiers arrive with the M-track).
+ * Flag off ⇒ the same scripted calls serve exactly as today.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSynthesizeOpenAi } from './test-doubles';
+import { MetricsService } from '../src/metrics/metrics.service';
+import { PredicateRegistryService } from '../src/ai/predicate-registry.service';
+import { SurrealService } from '../src/db/surreal.service';
+
+describe('Fovea evidence-capability gate e2e', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const savedEnv: Record<string, string | undefined> = {};
+
+  let visualFactId: string;
+
+  const FACT_OBJECT = 'the evacuation plan is pinned on the ops-room whiteboard';
+  const QUERY = 'where is the evacuation plan pinned';
+  const ANSWER = 'On the ops-room whiteboard.';
+  const VERIFY_SUPPORTED = JSON.stringify({ verdict: 'supported', unsupportedClaims: [] });
+
+  const synth = (body: Record<string, unknown>) =>
+    f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ limit: 5, ...body });
+
+  async function capabilityCounter(outcome: 'checked' | 'downgraded'): Promise<number> {
+    const { body } = await f.app.get(MetricsService).serialize();
+    const m = body.match(
+      new RegExp(`^brain_evidence_capability_total\\{outcome="${outcome}"\\} (\\d+)`, 'm'),
+    );
+    return m ? parseInt(m[1]!, 10) : 0;
+  }
+
+  beforeAll(async () => {
+    // Pin abstention off so a thin-evidence query never pre-abstains before
+    // generation — keeps the gen+verify call sequence deterministic.
+    for (const [k, v] of Object.entries({ RETRIEVAL_ABSTENTION_CALIBRATION: 'off' })) {
+      savedEnv[k] = process.env[k];
+      process.env[k] = v;
+    }
+    delete process.env.FOVEA_EVIDENCE_CAPABILITY;
+    f = await createApp({ companyId: 'co_evidence_capability_e2e' });
+
+    const r = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'ops_room' },
+        // 'status' is a CORE predicate (active in every tenant registry) —
+        // the fact lands under it deterministically (no canonicalize roll).
+        predicate: 'status',
+        object: FACT_OBJECT,
+        validFrom: new Date('2026-05-01').toISOString(),
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+        userId: 'u_cap',
+      });
+    expect([200, 201]).toContain(r.status);
+    visualFactId = r.body.factId as string;
+    expect(visualFactId).toBeTruthy();
+
+    // Operator declares the requirement on the TENANT registry row (0113
+    // column; no admin API in this PR — plumbing only), then invalidates
+    // the snapshot cache so the gate sees it immediately.
+    const surreal = f.app.get(SurrealService);
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `UPDATE knowledge_predicate SET requiredEvidenceCapability = 'visual',
+           updatedAt = time::now()
+         WHERE predicateId = 'status'`,
+      );
+    });
+    f.app.get(PredicateRegistryService).invalidate(f.companyId);
+  });
+
+  afterEach(() => {
+    delete process.env.FOVEA_EVIDENCE_CAPABILITY;
+  });
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (f) await f.close();
+  });
+
+  it("flag ON: a supported answer citing a visual-required predicate abstains with 'evidence_capability_unmet'", async () => {
+    process.env.FOVEA_EVIDENCE_CAPABILITY = '1';
+    const beforeDown = await capabilityCounter('downgraded');
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer: ANSWER, citedFactIds: [visualFactId] }),
+      VERIFY_SUPPORTED,
+    ]);
+    const res = await synth({ query: QUERY, userId: 'u_cap' });
+    expect(res.status).toBe(201);
+    // Downgraded, fail-closed — text citations cannot satisfy 'visual'.
+    expect(res.body.answer).not.toBe(ANSWER);
+    expect(res.body.reason).toBe('evidence_capability_unmet');
+    expect(res.body.citations ?? []).toEqual([]);
+    // No extra LLM call — the gate is a registry lookup, not a judge:
+    // exactly gen + verify.
+    expect(state.calls.length).toBe(2);
+    expect(await capabilityCounter('downgraded')).toBe(beforeDown + 1);
+    expect(await capabilityCounter('checked')).toBeGreaterThanOrEqual(1);
+  });
+
+  it('flag OFF: the same scripted calls serve exactly as today (byte-identical)', async () => {
+    // FOVEA_EVIDENCE_CAPABILITY unset (afterEach cleared it).
+    const beforeDown = await capabilityCounter('downgraded');
+    const beforeChecked = await capabilityCounter('checked');
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer: ANSWER, citedFactIds: [visualFactId] }),
+      VERIFY_SUPPORTED,
+    ]);
+    const res = await synth({ query: QUERY, userId: 'u_cap' });
+    expect(res.status).toBe(201);
+    expect(res.body.answer).toBe(ANSWER);
+    expect(res.body.reason).toBeUndefined();
+    expect(res.body.citations?.map((c: { factId: string }) => c.factId)).toContain(visualFactId);
+    expect(state.calls.length).toBe(2);
+    // Neither series moved — the resolver never ran.
+    expect(await capabilityCounter('downgraded')).toBe(beforeDown);
+    expect(await capabilityCounter('checked')).toBe(beforeChecked);
+  });
+});

--- a/test/memory-outcome.e2e-spec.ts
+++ b/test/memory-outcome.e2e-spec.ts
@@ -15,11 +15,15 @@
  */
 import { AppFixture, createApp } from './app-fixture';
 import { SurrealService } from '../src/db/surreal.service';
+import { MemoryOutcomeService } from '../src/outcomes/memory-outcome.service';
 
 interface OutcomeRow {
   event: string;
   actor?: string;
   meta?: Record<string, unknown>;
+  /** 0113 dimensions — NONE (absent) on every legacy/text row. */
+  modality?: string;
+  representationKind?: string;
 }
 
 interface StatRow {
@@ -54,7 +58,7 @@ describe('memory_outcome — outcome telemetry recording and cascade', () => {
     const surreal = f.app.get(SurrealService);
     return surreal.withCompany(f.companyId, async (db) => {
       const [rows] = await db.query<[OutcomeRow[]]>(
-        `SELECT event, actor, meta FROM memory_outcome
+        `SELECT event, actor, meta, modality, representationKind FROM memory_outcome
           WHERE subjectId = type::record('knowledge_fact', $tail)
           ${event ? 'AND event = $event' : ''}`,
         { tail: tail(factId), ...(event ? { event } : {}) },
@@ -312,6 +316,59 @@ describe('memory_outcome — outcome telemetry recording and cascade', () => {
       delete process.env.RETRIEVAL_VERIFIED_USE_RANKING;
       delete process.env.SEARCH_VERIFIED_USE_BETA;
     }
+  });
+
+  it('(g) 0113: a stamped outcome row round-trips modality and dies in the GDPR sweep', async () => {
+    const { factId } = await ingestFact(
+      'outcome_modality_subj',
+      'name',
+      'Outcome Modality Subject',
+    );
+    // No text-path writer stamps the dimensions yet (media paths arrive in
+    // sibling PRs) — drive the ONE write seam directly, as those writers will.
+    f.app.get(MemoryOutcomeService).recordOutcomes({
+      companyId: f.companyId,
+      events: [
+        {
+          subjectKind: 'fact',
+          subjectId: factId,
+          event: 'used_in_answer',
+          modality: 'visual',
+          representationKind: 'caption',
+        },
+      ],
+    });
+    const rows = await waitFor(
+      () => rawRows(factId, 'used_in_answer'),
+      (r) => r.length >= 1,
+    );
+    expect(rows).toHaveLength(1);
+    // Top-level columns round-trip (NOT meta keys — the 0113 contract).
+    expect(rows[0]).toMatchObject({ modality: 'visual', representationKind: 'caption' });
+    expect(rows[0]!.meta).toBeUndefined();
+    // The rollup folded the counter with no per-modality column.
+    const stat = await waitFor(
+      () => statFor(factId),
+      (s) => (s?.usedCount ?? 0) >= 1,
+    );
+    expect(stat!.usedCount).toBe(1);
+
+    // GDPR entity-forget still sweeps the dimensioned rows.
+    const surreal = f.app.get(SurrealService);
+    const entityId = await surreal.withCompany(f.companyId, async (db) => {
+      const [r] = await db.query<[Array<{ entityId: unknown }>]>(
+        `SELECT entityId FROM type::record('knowledge_fact', $tail)`,
+        { tail: tail(factId) },
+      );
+      return String((r as Array<{ entityId: unknown }>)?.[0]?.entityId);
+    });
+    const forget = await f.http
+      .post(`/v1/entities/${encodeURIComponent(entityId)}/forget`)
+      .set(auth())
+      .send({ reason: 'gdpr_request', requestId: 'req-outcome-modality' });
+    expect([200, 201]).toContain(forget.status);
+    expect(await rawRows(factId)).toHaveLength(0);
+    expect(await statFor(factId)).toBeNull();
   });
 
   it('(e) master off ⇒ zero rows written (byte-identical)', async () => {

--- a/test/memory-outcome.unit-spec.ts
+++ b/test/memory-outcome.unit-spec.ts
@@ -190,6 +190,111 @@ describe('MemoryOutcomeService.recordOutcomes', () => {
       { counter: 'selectedCount', delta: 1 },
     ]);
   });
+
+  // ── 0113 modality dimensions ──────────────────────────────────────
+  describe('0113 modality dimensions', () => {
+    it('dedupe partitioning pin: legacy (no-dimension) events partition exactly as before', () => {
+      // Same legacy pair that deduped to 1 pre-0113 — the appended
+      // constant `||` key suffix must not change the partitioning.
+      expect(
+        dedupeOutcomeEvents([
+          ev('knowledge_fact:a', 'used_in_answer'),
+          ev('knowledge_fact:a', 'used_in_answer'),
+        ]),
+      ).toHaveLength(1);
+      // Distinct actors still partition.
+      expect(
+        dedupeOutcomeEvents([
+          ev('knowledge_fact:a', 'user_confirmed', { actor: 'k1' }),
+          ev('knowledge_fact:a', 'user_confirmed', { actor: 'k2' }),
+        ]),
+      ).toHaveLength(2);
+    });
+
+    it('dedupe: modality/representationKind SPLIT otherwise-identical events', () => {
+      // Same event on different modalities = two rows.
+      expect(
+        dedupeOutcomeEvents([
+          ev('knowledge_fact:a', 'used_in_answer', { modality: 'visual' }),
+          ev('knowledge_fact:a', 'used_in_answer', { modality: 'audio' }),
+        ]),
+      ).toHaveLength(2);
+      // Dimensioned vs legacy (absent = legacy/text) = two rows.
+      expect(
+        dedupeOutcomeEvents([
+          ev('knowledge_fact:a', 'used_in_answer', { modality: 'visual' }),
+          ev('knowledge_fact:a', 'used_in_answer'),
+        ]),
+      ).toHaveLength(2);
+      // Same modality, different representationKind = two rows.
+      expect(
+        dedupeOutcomeEvents([
+          ev('knowledge_fact:a', 'used_in_answer', {
+            modality: 'visual',
+            representationKind: 'caption',
+          }),
+          ev('knowledge_fact:a', 'used_in_answer', {
+            modality: 'visual',
+            representationKind: 'ocr_text',
+          }),
+        ]),
+      ).toHaveLength(2);
+      // True duplicates (same dimensions) still collapse.
+      expect(
+        dedupeOutcomeEvents([
+          ev('knowledge_fact:a', 'used_in_answer', { modality: 'visual' }),
+          ev('knowledge_fact:a', 'used_in_answer', { modality: 'visual' }),
+        ]),
+      ).toHaveLength(1);
+    });
+
+    it('INSERT row for an existing (no-dimension) writer is byte-identical — no new keys', async () => {
+      const captured: CapturedQuery[] = [];
+      const svc = new MemoryOutcomeService(makeSurreal(captured));
+      svc.recordOutcomes({
+        companyId: 'co_x',
+        events: [ev('knowledge_fact:a', 'used_in_answer', { actor: 'k1' })],
+        requestId: 'req-1',
+      });
+      await flush();
+      const rows = captured[0]!.params.rows as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(1);
+      // The EXACT pre-0113 key set — modality/representationKind absent
+      // (undefined → dropped → NONE), so legacy writers stay byte-identical.
+      expect(Object.keys(rows[0]!).sort()).toEqual([
+        'actor',
+        'createdAt',
+        'event',
+        'requestId',
+        'subjectId',
+        'subjectKind',
+      ]);
+    });
+
+    it('a dimensioned event threads modality + representationKind onto the raw row (rollup untouched)', async () => {
+      const captured: CapturedQuery[] = [];
+      const svc = new MemoryOutcomeService(makeSurreal(captured));
+      svc.recordOutcomes({
+        companyId: 'co_x',
+        events: [
+          ev('knowledge_fact:a', 'used_in_answer', {
+            modality: 'visual',
+            representationKind: 'caption',
+          }),
+        ],
+      });
+      await flush();
+      const rows = captured[0]!.params.rows as Array<Record<string, unknown>>;
+      expect(rows[0]).toMatchObject({ modality: 'visual', representationKind: 'caption' });
+      // The rollup stays UNIQUE-per-subject with NO per-modality columns
+      // (deliberately deferred — no scorer consumes them; raw rows retain
+      // full dimensionality).
+      const statRows = captured[0]!.params.statRows as Array<Record<string, unknown>>;
+      expect(statRows).toHaveLength(1);
+      expect(Object.keys(statRows[0]!)).not.toContain('modality');
+      expect(Object.keys(statRows[0]!)).not.toContain('representationKind');
+    });
+  });
 });
 
 describe('OutcomePruneService', () => {


### PR DESCRIPTION
## Summary

Two default-off, byte-identical tracks of Brain v2.1 in one migration (0113):

**Verifier evidence-capability gate (`FOVEA_EVIDENCE_CAPABILITY`, default off).** Claims requiring visual/audio evidence can no longer verify on text alone — fail-closed plumbing; confirmation of such claims arrives with the media verifiers later. A predicate declares `requiredEvidenceCapability` (new `knowledge_predicate` column, threaded through `PredicateDefinition`/`PredicatePolicy`; absent = `'text'` = unconstrained, all CORE seeds carry no value). When the flag is on, the `finalizeAndAdmit` gate-resolution (`resolveEvidenceCapability`, beside `resolveAnswerIntegrity`) computes required = max over the supported answer's cited facts (any non-text wins) via ONE snapshot-warmed `rowPolicyLookup` — no per-fact IO — and `finalizeVerdict` gains the FOURTH sequential supported-arm downgrade: unmet ⇒ `NOT_IN_MEMORY` abstain under the NEW reason `evidence_capability_unmet` (citations `[]`, never cache-admitted).

**Outcome telemetry modality dimensions.** `memory_outcome` gains optional top-level `modality` (ASSERTed to `text|visual|audio|document_region`) + `representationKind` — top-level columns, NOT meta keys, because meta is content-free ids-only by contract AND the dedupe key ignores meta. `OutcomeEventInput` carries both; the dedupe key appends them, so existing writers get a constant `||` suffix — **dedupe semantics for existing writers untouched** (pinned by unit spec) — while media writers (sibling PRs) partition per modality. The rollup stays UNIQUE-per-subject; per-modality stat columns deliberately deferred (no scorer consumes them; raw rows retain full dimensionality). No writer stamps the fields in this PR ⇒ byte-identical.

## The honest v1 bound

The gate can only **abstain or pass** — no VLM/media verifier exists in this PR. Every citation today is text (fact lines + L3 episode spans), so the cited-capability set is the constant `{'text'}`: a non-text requirement always abstains; a text requirement always passes through. This is stated in the flag doc, the resolver, and the catalog entry.

## Marked seams (M-track fragment mapping)

- `citedCapabilities()` in `answer-integrity.ts` — the constant `{'text'}` the M-track extends with per-citation capability kinds.
- `VerifyRequest.capabilityEvidenceLines` — `[capability:<kind>]`-prefixed lines composed as their own verifier-prompt section only when non-empty (absent ⇒ byte-identical prompt); nothing populates it yet.

## Notes

- **Migration numbering:** 0108–0112 are claimed by in-flight sibling PRs of this wave; this PR deliberately takes **0113**. The migrator applies numeric order and tracks per-id, so the gap is safe in either landing order.
- Metrics: `brain_evidence_capability_total{outcome=checked|downgraded}` + `countEvidenceCapability` helper. The synthesize outcome series stays stable (`low_coverage` tag on the downgrade — the Part A/C idiom); the wire reason is the precise `evidence_capability_unmet`.
- Registry row mapping drops unknown column values to unconstrained (a malformed row degrades to today's behavior, never an abstain storm); a registry lookup failure fails safe to an ungated serve (logged).
- No admin API for the new predicate column in this PR — operators set the row directly (the e2e does the same); flag registered in `env-validation` + admin config catalog.

## Test plan

- **Unit (2957/2957 green):** dedupe-key partitioning pin (legacy identical; modality/representationKind split); INSERT row key-set byte-identity for an existing writer; `finalizeVerdict` fourth-branch matrix (unmet → abstain w/ new reason; false → pass; gate absent → deep-equal byte-identical; plausibility precedence); `resolveEvidenceCapability` (flag off ⇒ no lookup; max-over-citations; fail-safe on registry error; no-op without companyId/registry/citations); row → policy threading incl. unknown-value drop + serialize round-trip; verifier prompt composer with/without `capabilityEvidenceLines`.
- **e2e (40/40 green over `memory-outcome|fovea|l3|verdict|synthesize`):** stamped outcome rows round-trip modality as top-level columns and die in the GDPR entity-forget sweep; a tenant predicate with `requiredEvidenceCapability='visual'` + flag on ⇒ synthesize abstains with `evidence_capability_unmet` (scripted gen/verifier via `mockSynthesizeOpenAi`, no extra LLM call, counter moves); flag off ⇒ identical scripted calls serve as today.
- `pnpm typecheck`, `pnpm lint:ci` (`--max-warnings 0`, incl. the 800-line god-file gate), `prettier --check` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB