### PR TITLE
feat(provenance): typed support graph — memory_support edges + closure walk

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -910,6 +910,34 @@
           },
           "factId": {
             "type": "string"
+          },
+          "supportEdges": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "from": {
+                  "type": "string"
+                },
+                "kind": {
+                  "enum": [
+                    "supported_by",
+                    "contradicted_by",
+                    "derived_from"
+                  ],
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "from",
+                "to"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           }
         },
         "required": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -910,6 +910,34 @@
           },
           "factId": {
             "type": "string"
+          },
+          "supportEdges": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "from": {
+                  "type": "string"
+                },
+                "kind": {
+                  "enum": [
+                    "supported_by",
+                    "contradicted_by",
+                    "derived_from"
+                  ],
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "from",
+                "to"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           }
         },
         "required": [

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -2069,6 +2069,24 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Episode budget of the PROVENANCE_RECURSIVE_CLOSURE walk — distinct grounding episodes harvested across the closure. Clamped to 1..500; unset/invalid → 200. Ids past the cap mark the closure truncated.',
   },
   {
+    key: 'PROVENANCE_SUPPORT_EDGES',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Typed support graph, write side (Drift-5, migration 0116): writers emit canonical memory_support edges — scene-backlink adds fact-supported_by->scene edges alongside the legacy source.memoryEpisodeIds stamps, the conflict resolver records loser-contradicted_by->winner on SUPERSEDED and mutual pairs on COMPETING (capped 20), and promotion/compaction/recompose mirror derivedFrom as summary-derived_from->member edges (recompose deletes-then-reinserts its summary's edges to track rewrites). Idempotent via UNIQUE(in,out,kind) + INSERT RELATION IGNORE. GDPR cascades erase edges regardless of this flag. Off (default) → no edge is ever written, every writer's queries byte-identical.",
+  },
+  {
+    key: 'PROVENANCE_SUPPORT_GRAPH_READ',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Typed support graph, read side (Drift-5): the provenance closure walk (PROVENANCE_RECURSIVE_CLOSURE) additionally follows derived_from edges as children (same visited set, same depth/fact/episode caps) and returns the supported_by/contradicted_by/derived_from edges it crossed in a new optional supportEdges response field; a root with typed edges but an empty derivedFrom array now walks too. Members pass the same per-row fences; edge targets are classified via EvidenceRef prefixes. Off (default) → the walk and the provenance response are byte-identical (field absent, not empty).',
+  },
+  {
     key: 'PROJECTIONS_API_ENABLED',
     category: 'pipeline',
     defaultValue: '0',

--- a/src/admin/scene-backlink.service.ts
+++ b/src/admin/scene-backlink.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { sceneFactBacklinkEnabled } from '../common/scene-flags';
 import { SceneVersionService } from './scene-version';
+import { supportEdgesEnabled } from '../common/provenance-flags';
+import { buildSupportEdgeBatches } from '../common/support-edges';
 
 /**
  * Scene fact backlinker (Brain v2 PR2, SCENES_FACT_BACKLINK — default
@@ -146,6 +149,41 @@ export class SceneBacklinkService {
           );
         }
         result.factsLinked += factIds.length;
+
+        // Typed support graph (PROVENANCE_SUPPORT_EDGES, default off):
+        // fact-supported_by->scene edges IN ADDITION to the string
+        // stamps above (stamps are existing default-on behavior; their
+        // removal is a separate cleanup once the typed reader is
+        // proven). Replay-idempotent: INSERT RELATION IGNORE over
+        // UNIQUE(in, out, kind) — a re-segmentation re-run lands on the
+        // same deterministic scene ids and inserts nothing new. Off ⇒
+        // this whole block is skipped and the query sequence above is
+        // byte-identical. writerVersion follows the SAME effective
+        // version as the sceneLinkVersion stamp above (SceneVersionService,
+        // resolved once per run) — under SCENES_VERSION_FINGERPRINT the
+        // edge names the fingerprinted world that was linked; flag off ⇒
+        // the literal SEGMENTER_VERSION, byte-identical to the pre-#386
+        // stamp.
+        if (supportEdgesEnabled()) {
+          const { batches, skipped } = buildSupportEdgeBatches({
+            kind: 'supported_by',
+            writer: 'scene_backlink',
+            writerVersion: version,
+            pairs: factIds.map((id) => ({ in: String(id), out: String(scene.id) })),
+          });
+          if (skipped > 0) {
+            this.logger.warn(`scene backlink: ${skipped} malformed support-edge pair(s) skipped`);
+          }
+          for (const batch of batches) {
+            await db.query(`INSERT RELATION IGNORE INTO memory_support $rows`, {
+              rows: batch.map((r) => ({
+                ...r,
+                in: new StringRecordId(r.in),
+                out: new StringRecordId(r.out),
+              })),
+            });
+          }
+        }
       }
     });
     this.logger.log(

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1006,6 +1006,20 @@ const KNOWN_BOOLEAN_FLAGS = [
   // (PROVENANCE_CLOSURE_MAX_*) are integer knobs, not boolean flags.
   // Outside ENGINE_PREFIX by design — off the flag budget.
   'PROVENANCE_RECURSIVE_CLOSURE',
+  // Typed support graph, write side (Drift-5, 0116): writers emit
+  // canonical memory_support edges — scene-backlink supported_by
+  // (alongside the legacy stamps), conflict resolver contradicted_by,
+  // promotion/compaction/recompose derived_from mirrors. GDPR cascades
+  // erase edges regardless of this flag. Default off ⇒ no edge written,
+  // every writer byte-identical. Outside ENGINE_PREFIX by design (the
+  // PROVENANCE_ family sits off the flag budget).
+  'PROVENANCE_SUPPORT_EDGES',
+  // Typed support graph, read side (Drift-5): the recursive closure
+  // additionally follows derived_from edges and serves the crossed
+  // edges as the optional supportEdges field. Default off ⇒ walk and
+  // response byte-identical (field absent). Outside ENGINE_PREFIX by
+  // design — off the flag budget.
+  'PROVENANCE_SUPPORT_GRAPH_READ',
   // Multilingual Tier 1 (migration 0100). Confidence-aware attribution:
   // the detector returns `und` (not `en`) for short/stopword-less objects
   // and the resolver stamps langConfidence/langSource/detectorVersion/

--- a/src/common/provenance-flags.ts
+++ b/src/common/provenance-flags.ts
@@ -41,6 +41,46 @@ export function recursiveClosureEnabled(): boolean {
   return envFlagEnabled(process.env.PROVENANCE_RECURSIVE_CLOSURE);
 }
 
+/**
+ * Typed support graph — write side — PROVENANCE_SUPPORT_EDGES.
+ *
+ * When on, the three writer families emit canonical memory_support
+ * edges (0116): scene-backlink adds fact-supported_by->scene edges
+ * ALONGSIDE the legacy source.memoryEpisodeIds stamps, the conflict
+ * resolver records loser-contradicted_by->winner on SUPERSEDED and the
+ * mutual pair on COMPETING (CONFLICT_OUTCOME_CAP idiom), and
+ * promotion/compaction/recompose mirror derivedFrom as
+ * summary-derived_from->member edges (recompose deletes-then-reinserts
+ * its summary's set to track rewrites). Writes are replay-idempotent
+ * (`INSERT RELATION IGNORE` over UNIQUE(in, out, kind)). The GDPR
+ * cascades erase edges REGARDLESS of this flag. The env read lives here
+ * in the common layer, NOT inside the engine dirs (engine-gates S5.2).
+ * Read at call time so a flip is runtime-mutable. Default off ⇒ no edge
+ * is ever written and every writer's query sequence is byte-identical.
+ */
+export function supportEdgesEnabled(): boolean {
+  return envFlagEnabled(process.env.PROVENANCE_SUPPORT_EDGES);
+}
+
+/**
+ * Typed support graph — read side — PROVENANCE_SUPPORT_GRAPH_READ.
+ *
+ * When on, the provenance closure walk (PROVENANCE_RECURSIVE_CLOSURE)
+ * additionally follows derived_from edges as children (same visited
+ * set, same depth/fact/episode caps) and returns the supported_by /
+ * contradicted_by / derived_from edges it crossed in the optional
+ * `supportEdges` response field; a root with typed edges but an EMPTY
+ * derivedFrom array now walks too. Members pass the same per-row
+ * fences; edge targets are classified via the EvidenceRef prefix
+ * vocabulary (support-edges.ts). The env read lives here in the common
+ * layer, NOT inside the engine dirs (engine-gates S5.2). Read at call
+ * time so a flip is runtime-mutable. Default off ⇒ the walk and the
+ * provenance response are byte-identical (field absent, not empty).
+ */
+export function supportGraphReadEnabled(): boolean {
+  return envFlagEnabled(process.env.PROVENANCE_SUPPORT_GRAPH_READ);
+}
+
 /** Closure walk caps — defaults + clamp bounds (see the knobs below). */
 const DEFAULT_CLOSURE_MAX_DEPTH = 5;
 const DEFAULT_CLOSURE_MAX_FACTS = 256;

--- a/src/common/support-edges.ts
+++ b/src/common/support-edges.ts
@@ -1,0 +1,205 @@
+/**
+ * Typed support graph (Drift-5, migration 0116) — the pure edge-row
+ * assembly shared by every memory_support writer and the closure
+ * walker's edge classification. Pure module (episode-ids.ts
+ * discipline): no Nest, no I/O — writers own their db calls
+ * (`INSERT RELATION IGNORE INTO memory_support $rows`, verified
+ * replay-idempotent on the pinned 3.2.4 via UNIQUE(in, out, kind)).
+ *
+ * Direction semantics (`in` = the claim being supported / contradicted
+ * / derived — see the 0116 header):
+ *   * supported_by:    in = knowledge_fact, out = memory_episode (scene)
+ *   * contradicted_by: in = knowledge_fact (loser), out = knowledge_fact
+ *     (winner); COMPETING writes the mutual pair
+ *   * derived_from:    in = summary knowledge_fact, out = member
+ *     knowledge_fact (typed mirror of the untyped derivedFrom array)
+ *   * reconstructed_from: RESERVED — scene membership stays in
+ *     memory_episode_member (0106); NO writer emits it (assertEdgeShape
+ *     rejects it so a stray caller cannot start).
+ */
+import { parseRecordRef } from './evidence-ref';
+
+export const SUPPORT_EDGE_KINDS = [
+  'supported_by',
+  'contradicted_by',
+  'derived_from',
+  'reconstructed_from',
+] as const;
+export type SupportEdgeKind = (typeof SUPPORT_EDGE_KINDS)[number];
+
+/** The kinds a writer may actually emit (reconstructed_from reserved). */
+export const EMITTED_EDGE_KINDS = ['supported_by', 'contradicted_by', 'derived_from'] as const;
+export type EmittedEdgeKind = (typeof EMITTED_EDGE_KINDS)[number];
+
+export function isEmittedEdgeKind(v: string): v is EmittedEdgeKind {
+  return (EMITTED_EDGE_KINDS as readonly string[]).includes(v);
+}
+
+export const SUPPORT_EDGE_WRITERS = [
+  'scene_backlink',
+  'fact_resolver',
+  'promotion_runner',
+  'compaction_runner',
+  'recompose',
+] as const;
+export type SupportEdgeWriter = (typeof SUPPORT_EDGE_WRITERS)[number];
+
+/** Rows per INSERT payload — the unionEvidenceRefs cap idiom. */
+export const SUPPORT_EDGE_CAP = 64;
+
+/** One memory_support row as assembled (record ids as strings — the
+ *  writer converts to StringRecordId at the bind site; 3.x does not
+ *  coerce string↔record). */
+export interface SupportEdgeRow {
+  in: string;
+  out: string;
+  kind: SupportEdgeKind;
+  writer: SupportEdgeWriter;
+  writerVersion?: string;
+}
+
+/**
+ * Classify an edge endpoint by table prefix. EvidenceRef runtime
+ * adoption: evidence-plane prefixes (episode:/evidence_fragment:/
+ * evidence_asset:) dispatch through `parseRecordRef` — its first
+ * runtime caller — so the evidence plane and the support graph share
+ * ONE prefix vocabulary; the two support-graph-native tables are
+ * matched directly. 'unknown' is never a guess.
+ */
+export type SupportTargetClass = 'fact' | 'scene' | 'episode' | 'fragment' | 'asset' | 'unknown';
+
+export function classifySupportTarget(raw: string): SupportTargetClass {
+  const ref = parseRecordRef(raw);
+  if (ref !== null && ref.kind !== 'external') return ref.kind;
+  if (raw.startsWith('knowledge_fact:')) return 'fact';
+  if (raw.startsWith('memory_episode:')) return 'scene';
+  return 'unknown';
+}
+
+/**
+ * Endpoint-table pairing per kind (the TS-side substitute for the
+ * FROM/TO types one polymorphic RELATION table cannot carry — 0116
+ * header). Returns a boolean verdict: writers SKIP invalid rows with a
+ * warn, never throw. reconstructed_from is always false (reserved).
+ */
+export function assertEdgeShape(kind: SupportEdgeKind, inId: string, outId: string): boolean {
+  if (classifySupportTarget(inId) !== 'fact') return false;
+  const out = classifySupportTarget(outId);
+  switch (kind) {
+    case 'supported_by':
+      return out === 'scene';
+    case 'contradicted_by':
+    case 'derived_from':
+      return out === 'fact';
+    case 'reconstructed_from':
+      return false;
+  }
+}
+
+export interface SupportEdgeSpec {
+  kind: SupportEdgeKind;
+  writer: SupportEdgeWriter;
+  writerVersion?: string | undefined;
+  /** Endpoint pairs in emission order (record ids as strings). */
+  pairs: ReadonlyArray<{ in: string; out: string }>;
+}
+
+/**
+ * Assemble edge rows from endpoint pairs: shape-validated
+ * (assertEdgeShape — invalid pairs are counted, not thrown), deduped by
+ * (in, out, kind) with emission order preserved (Set-insertion idiom of
+ * unionEvidenceRefs), capped at SUPPORT_EDGE_CAP per call. Callers with
+ * potentially larger sets use `buildSupportEdgeBatches`.
+ */
+export function buildSupportEdgeRows(spec: SupportEdgeSpec): {
+  rows: SupportEdgeRow[];
+  skipped: number;
+} {
+  const { batches, skipped } = buildSupportEdgeBatches(spec);
+  return { rows: batches[0] ?? [], skipped };
+}
+
+/**
+ * The unbounded-input form: same validation/dedupe as
+ * buildSupportEdgeRows, the deduped set sliced into
+ * SUPPORT_EDGE_CAP-sized INSERT payloads (bounded query payloads, the
+ * FACTS_PER_UPDATE discipline).
+ */
+export function buildSupportEdgeBatches(spec: SupportEdgeSpec): {
+  batches: SupportEdgeRow[][];
+  skipped: number;
+} {
+  const seen = new Set<string>();
+  const rows: SupportEdgeRow[] = [];
+  let skipped = 0;
+  for (const pair of spec.pairs) {
+    if (!assertEdgeShape(spec.kind, pair.in, pair.out)) {
+      skipped += 1;
+      continue;
+    }
+    const key = `${pair.in}\x00${pair.out}\x00${spec.kind}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    rows.push({
+      in: pair.in,
+      out: pair.out,
+      kind: spec.kind,
+      writer: spec.writer,
+      ...(spec.writerVersion !== undefined ? { writerVersion: spec.writerVersion } : {}),
+    });
+  }
+  const batches: SupportEdgeRow[][] = [];
+  for (let i = 0; i < rows.length; i += SUPPORT_EDGE_CAP) {
+    batches.push(rows.slice(i, i + SUPPORT_EDGE_CAP));
+  }
+  return { batches, skipped };
+}
+
+/** The resolver-verdict slice buildConflictEdgeRows reads
+ *  (ResolveOutcome structurally satisfies it). */
+export interface ConflictVerdict {
+  outcome?: unknown;
+  factId?: unknown;
+  supersededFactIds?: unknown;
+  competingFactIds?: unknown;
+}
+
+/**
+ * Conflict verdicts → contradicted_by rows (the emitConflictOutcomes
+ * pairing, decision #4):
+ *   * SUPERSEDED → one edge per displaced fact, in = LOSER,
+ *     out = WINNER ("the old claim is contradicted by the new one");
+ *   * COMPETING → the MUTUAL pair (both directions) between each
+ *     standing competitor and the new fact;
+ *   * every other outcome → no rows.
+ * `cap` bounds a pathological fan-out (the CONFLICT_OUTCOME_CAP idiom —
+ * applied to EDGES here, after dedupe).
+ */
+export function buildConflictEdgeRows(result: ConflictVerdict, cap: number): SupportEdgeRow[] {
+  const outcome = String(result?.outcome ?? '');
+  const newFactId = result?.factId ? String(result.factId) : undefined;
+  if (!newFactId) return [];
+  const pairs: Array<{ in: string; out: string }> = [];
+  if (outcome === 'SUPERSEDED') {
+    for (const raw of asArray(result.supersededFactIds)) {
+      pairs.push({ in: String(raw), out: newFactId });
+    }
+  } else if (outcome === 'COMPETING') {
+    for (const raw of asArray(result.competingFactIds)) {
+      const competitor = String(raw);
+      if (competitor === newFactId) continue;
+      pairs.push({ in: competitor, out: newFactId });
+      pairs.push({ in: newFactId, out: competitor });
+    }
+  }
+  const { rows } = buildSupportEdgeRows({
+    kind: 'contradicted_by',
+    writer: 'fact_resolver',
+    pairs,
+  });
+  return rows.slice(0, cap);
+}
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}

--- a/src/compaction/compaction-runner.service.ts
+++ b/src/compaction/compaction-runner.service.ts
@@ -7,8 +7,9 @@ import { ReadPinService } from '../episodes/read-pin.service';
 import { ConcatSummaryGenerator, FactToSummarize, SummaryGenerator } from './summary-generator';
 import { CandidateFactRow, CompactionStats, SUMMARY_GENERATOR } from './compaction.types';
 import { envFlagEnabled } from '../common/env-validation';
-import { summaryEpisodeStampEnabled } from '../common/provenance-flags';
+import { summaryEpisodeStampEnabled, supportEdgesEnabled } from '../common/provenance-flags';
 import { unionEpisodeIds } from '../common/episode-ids';
+import { insertDerivedFromEdges } from './support-edge-mirror';
 import { compactionOverridesFor } from './compaction-overrides';
 
 /**
@@ -217,7 +218,7 @@ export class CompactionRunnerService {
         ? unionEpisodeIds(sorted.map((g) => g.eps))
         : [];
 
-      await dbCreate(db, 'knowledge_fact', {
+      const summary = await dbCreate(db, 'knowledge_fact', {
         entityId: first.entityId,
         predicate: `summary_${first.predicate}`,
         object: summaryText,
@@ -236,6 +237,24 @@ export class CompactionRunnerService {
         ...(first.userId ? { userId: first.userId } : {}),
       });
       created++;
+
+      // Typed support graph (PROVENANCE_SUPPORT_EDGES, default off):
+      // mirror the EXACT derivedFrom array just written. Best-effort —
+      // a mirror failure warns, never aborts the rollup pass. Off ⇒
+      // block skipped, the write sequence is byte-identical.
+      if (supportEdgesEnabled()) {
+        try {
+          await insertDerivedFromEdges(db, {
+            summaryId: String(summary.id),
+            memberIds: sorted.map((g) => String(g.id)),
+            writer: 'compaction_runner',
+          });
+        } catch (e) {
+          this.logger.warn(
+            `compaction derived_from edge mirror failed (non-fatal): ${(e as Error).message}`,
+          );
+        }
+      }
     }
     return created;
   }

--- a/src/compaction/promotion-runner.service.ts
+++ b/src/compaction/promotion-runner.service.ts
@@ -7,9 +7,10 @@ import { PREDICATE_POLICIES } from '../ingest/conflict-resolver';
 import { ConcatSummaryGenerator, FactToSummarize, SummaryGenerator } from './summary-generator';
 import { SUMMARY_GENERATOR } from './compaction.types';
 import { envFlagEnabled } from '../common/env-validation';
-import { summaryEpisodeStampEnabled } from '../common/provenance-flags';
+import { summaryEpisodeStampEnabled, supportEdgesEnabled } from '../common/provenance-flags';
 import { ungroundedExcludeEnabled } from '../common/evidence-flags';
 import { unionEpisodeIds } from '../common/episode-ids';
+import { insertDerivedFromEdges } from './support-edge-mirror';
 import { compactionOverridesFor } from './compaction-overrides';
 
 /**
@@ -350,7 +351,7 @@ export class PromotionRunnerService {
       ? unionEpisodeIds(members.map((m) => m.eps))
       : [];
 
-    await dbCreate(db, 'knowledge_fact', {
+    const summary = await dbCreate(db, 'knowledge_fact', {
       entityId: first.entityId,
       predicate: `summary_${group.predicate}`,
       object: summaryText,
@@ -364,6 +365,11 @@ export class PromotionRunnerService {
       ...(embedding ? { embedding } : {}),
     });
 
+    await this.mirrorDerivedFromEdges(db, {
+      summaryId: String(summary.id),
+      memberIds: members.map((m) => String(m.id)),
+    });
+
     // Record-id params — 3.x does not coerce string↔record (see
     // compaction-runner).
     const ids = members.map((m) => new StringRecordId(String(m.id)));
@@ -374,6 +380,28 @@ export class PromotionRunnerService {
       { ids },
     );
     return members.length;
+  }
+
+  /**
+   * Typed support graph (PROVENANCE_SUPPORT_EDGES, default off): mirror
+   * the EXACT derivedFrom array just written as
+   * summary-derived_from->member edges. Best-effort — the summary
+   * already landed and the members must still be compacted, so a mirror
+   * failure warns, never aborts. Off ⇒ zero queries, the write sequence
+   * is byte-identical.
+   */
+  private async mirrorDerivedFromEdges(
+    db: Surreal,
+    mirror: { summaryId: string; memberIds: string[] },
+  ): Promise<void> {
+    if (!supportEdgesEnabled()) return;
+    try {
+      await insertDerivedFromEdges(db, { ...mirror, writer: 'promotion_runner' });
+    } catch (e) {
+      this.logger.warn(
+        `promotion derived_from edge mirror failed (non-fatal): ${(e as Error).message}`,
+      );
+    }
   }
 }
 

--- a/src/compaction/recompose.service.ts
+++ b/src/compaction/recompose.service.ts
@@ -9,8 +9,9 @@ import { WorkerLoopService } from '../jobs/worker-loop.service';
 import { SUMMARY_GENERATOR } from './compaction.types';
 import { changefeedRow } from '../db/changefeed-row';
 import type { SummaryGenerator, FactToSummarize } from './summary-generator';
-import { summaryEpisodeStampEnabled } from '../common/provenance-flags';
+import { summaryEpisodeStampEnabled, supportEdgesEnabled } from '../common/provenance-flags';
 import { unionEpisodeIds } from '../common/episode-ids';
+import { replaceDerivedFromEdges } from './support-edge-mirror';
 
 /** Changefeed cursor key — distinct from the audit drain's per-table keys. */
 const CURSOR = 'recompose:knowledge_fact';
@@ -339,6 +340,26 @@ export class RecomposeService implements OnModuleInit {
         ...(episodeIds.length > 0 ? { episodeIds } : {}),
       },
     );
+    // Typed support graph (PROVENANCE_SUPPORT_EDGES, default off): the
+    // UPDATE above REWROTE derivedFrom to the current parents, so the
+    // typed mirror is REPLACED — stale edges deleted (two-step
+    // LET-select-ids → DELETE, mandatory on 3.2.4 — see the mirror
+    // module), then the new set inserted. Best-effort: the summary
+    // rewrite already landed, a mirror failure warns, never aborts.
+    // Off ⇒ block skipped, the statement above is byte-identical.
+    if (supportEdgesEnabled()) {
+      try {
+        await replaceDerivedFromEdges(db, {
+          summaryId,
+          memberIds: parents.map((p) => p.factId),
+          writer: 'recompose',
+        });
+      } catch (e) {
+        this.logger.warn(
+          `recompose derived_from edge mirror failed (non-fatal): ${(e as Error).message}`,
+        );
+      }
+    }
     return true;
   }
 

--- a/src/compaction/support-edge-mirror.ts
+++ b/src/compaction/support-edge-mirror.ts
@@ -1,0 +1,62 @@
+/**
+ * derived_from edge mirror (Drift-5, PROVENANCE_SUPPORT_EDGES) — the
+ * ONE implementation the three summary writers share: promotion and
+ * compaction INSERT the mirror of the exact derivedFrom array they just
+ * wrote; recompose REPLACES its summary's set (delete-then-reinsert)
+ * because it rewrites derivedFrom to the current parents. Callers gate
+ * on supportEdgesEnabled() and wrap with their own warn-never-fail
+ * handling — a failed mirror must not abort a summary write.
+ */
+import { StringRecordId } from 'surrealdb';
+import { buildSupportEdgeBatches, type SupportEdgeWriter } from '../common/support-edges';
+
+interface DbLike {
+  query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T>;
+}
+
+export interface DerivedFromMirror {
+  /** The summary fact (edge `in`), full record id. */
+  summaryId: string;
+  /** The exact derivedFrom array written (edge `out`s), in order. */
+  memberIds: readonly string[];
+  writer: SupportEdgeWriter;
+}
+
+/** Mirror the summary's derivedFrom as edges (replay-idempotent —
+ *  INSERT RELATION IGNORE over UNIQUE(in, out, kind)). */
+export async function insertDerivedFromEdges(db: DbLike, mirror: DerivedFromMirror): Promise<void> {
+  const { batches } = buildSupportEdgeBatches({
+    kind: 'derived_from',
+    writer: mirror.writer,
+    pairs: mirror.memberIds.map((out) => ({ in: mirror.summaryId, out })),
+  });
+  for (const batch of batches) {
+    await db.query(`INSERT RELATION IGNORE INTO memory_support $rows`, {
+      rows: batch.map((r) => ({
+        ...r,
+        in: new StringRecordId(r.in),
+        out: new StringRecordId(r.out),
+      })),
+    });
+  }
+}
+
+/**
+ * Recompose form: derivedFrom was REWRITTEN, so the stale mirror goes
+ * first — two-step LET-select-ids → DELETE $ids, MANDATORY on 3.2.4:
+ * `in` is covered by the COMPOUND support_edge_uq index, and a
+ * `DELETE memory_support WHERE in = …` is the reproduced silent
+ * planner no-op (see the 0116 header) — then the new set is inserted.
+ */
+export async function replaceDerivedFromEdges(
+  db: DbLike,
+  mirror: DerivedFromMirror,
+): Promise<void> {
+  await db.query(
+    `LET $edgeIds = (SELECT VALUE id FROM memory_support
+       WHERE in = $summary AND kind = 'derived_from');
+     DELETE $edgeIds;`,
+    { summary: new StringRecordId(mirror.summaryId) },
+  );
+  await insertDerivedFromEdges(db, mirror);
+}

--- a/src/contracts/facts/facts.schema.ts
+++ b/src/contracts/facts/facts.schema.ts
@@ -95,6 +95,23 @@ export const FactProvenanceResponseSchema = z.object({
       filtered: z.boolean(),
     })
     .optional(),
+  /**
+   * Typed support edges crossed by the walk
+   * (PROVENANCE_SUPPORT_GRAPH_READ, migration 0116): supported_by
+   * (fact -> scene), contradicted_by (loser fact -> winner fact),
+   * derived_from (summary fact -> member fact). `from`/`to` are full
+   * record ids. Absent (not empty) when the read flag is off →
+   * backward-compatible.
+   */
+  supportEdges: z
+    .array(
+      z.object({
+        kind: z.enum(['supported_by', 'contradicted_by', 'derived_from']),
+        from: z.string(),
+        to: z.string(),
+      }),
+    )
+    .optional(),
 });
 
 export type FactReadResponse = z.infer<typeof FactReadResponseSchema>;

--- a/src/db/migrations/0116_memory_support.surql
+++ b/src/db/migrations/0116_memory_support.surql
@@ -1,0 +1,64 @@
+-- 0116: memory_support — the ONE polymorphic typed support-edge table
+-- (Drift-5). Kinds:
+--   * supported_by    (knowledge_fact -> memory_episode): the claim is
+--     grounded in that scene — the typed successor of the write-only
+--     source.memoryEpisodeIds string stamps (scene-backlink keeps
+--     writing the stamps; edges are ADDITIVE, PROVENANCE_SUPPORT_EDGES).
+--   * contradicted_by (knowledge_fact -> knowledge_fact): conflict
+--     standoffs from the resolver — SUPERSEDED writes one edge,
+--     loser -> winner ("the old claim is contradicted by the new one");
+--     COMPETING writes the mutual pair (both directions), capped by the
+--     resolver's CONFLICT_OUTCOME_CAP idiom.
+--   * derived_from    (summary knowledge_fact -> member knowledge_fact):
+--     the typed mirror of the untyped `derivedFrom` array (0001) —
+--     promotion/compaction insert, recompose deletes-then-reinserts its
+--     summary's edges to track derivedFrom rewrites.
+--   * reconstructed_from — RESERVED. Scene -> turn membership stays in
+--     memory_episode_member (0106), the canonical representation; NO
+--     writer emits this kind yet (the enum slot exists so future
+--     non-scene reconstructions — e.g. consolidated summaries — have a
+--     name without a schema change).
+--
+-- Endpoint-table pairing is enforced by the TS writer (assertEdgeShape,
+-- src/common/support-edges.ts): `in`/`out` are DELIBERATELY untyped
+-- records because one relation table cannot carry heterogeneous FROM/TO
+-- types (fact->scene AND fact->fact) on 3.2.4.
+--
+-- 0106 doctrine applies: TYPE RELATION so graph tooling sees it, but
+-- QUERIES MUST NOT use graph-arrow syntax — plain WHERE in/out only.
+-- (The 0106-documented fallback — plain SCHEMAFULL table with explicit
+-- in/out record fields — was NOT needed: RELATION-without-FROM/TO and
+-- `INSERT RELATION IGNORE` were both verified against the pinned
+-- surrealdb/surrealdb:v3.2.4 — IGNORE silently skips a UNIQUE
+-- (in, out, kind) duplicate, so every writer is replay-idempotent.)
+--
+-- GDPR: BOTH forget cascades (user-forget, entity-forget) erase this
+-- table's rows for their subjects UNCONDITIONALLY — rows written while
+-- PROVENANCE_SUPPORT_EDGES was on must stay erasable after it is off
+-- (the EVIDENCE_SUBSTRATE_ENABLED precedent).
+--
+-- No CHANGEFEED and no DEFINE EVENT (the 0053/0107 separation rationale):
+-- provenance edges must not feed the audit mirror or any dirty-marking
+-- event, and an erased subject's edges must not stay readable in a feed.
+DEFINE TABLE IF NOT EXISTS memory_support SCHEMAFULL TYPE RELATION;
+
+DEFINE FIELD IF NOT EXISTS in  ON memory_support TYPE record;
+DEFINE FIELD IF NOT EXISTS out ON memory_support TYPE record;
+DEFINE FIELD IF NOT EXISTS kind ON memory_support TYPE string
+  ASSERT $value INSIDE ['supported_by', 'contradicted_by', 'derived_from', 'reconstructed_from'];
+-- Provenance of the edge itself (which code path asserted it, when).
+DEFINE FIELD IF NOT EXISTS writer ON memory_support TYPE string
+  ASSERT $value INSIDE ['scene_backlink', 'fact_resolver', 'promotion_runner', 'compaction_runner', 'recompose'];
+DEFINE FIELD IF NOT EXISTS writerVersion ON memory_support TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS createdAt ON memory_support TYPE datetime DEFAULT time::now();
+
+-- Dedupe/idempotency + the two read paths (by claim, by target).
+-- NOTE 3.2.4: the compound UNIQUE index puts `in` under the planner bug
+-- class where `DELETE memory_support WHERE in INSIDE $x` is a SILENT
+-- no-op (returns OK, deletes zero rows) while the same WHERE in a
+-- SELECT matches — REPRODUCED against the pinned server on THIS exact
+-- table during this migration's smoke. Every deleter MUST use the
+-- two-step idiom: LET $ids = (SELECT VALUE id ...); DELETE $ids;
+DEFINE INDEX IF NOT EXISTS support_edge_uq  ON memory_support FIELDS in, out, kind UNIQUE;
+DEFINE INDEX IF NOT EXISTS support_out_idx  ON memory_support FIELDS out;
+DEFINE INDEX IF NOT EXISTS support_kind_idx ON memory_support FIELDS kind;

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -279,6 +279,25 @@ export class EntityForgetService {
         );
         tx.add(`DELETE $sceneMemberIds`);
         tx.add(`LET $scenesDel = (DELETE memory_episode WHERE id INSIDE $sceneIds RETURN BEFORE)`);
+        // Typed support graph (0116): every memory_support edge touching
+        // this entity's facts (either endpoint) or a dying scene (edge
+        // target) goes with them. The fact ids MUST be pre-collected
+        // here, BEFORE the `DELETE knowledge_fact WHERE entityId = $ent`
+        // below erases the rows the SELECT traverses. Runs
+        // UNCONDITIONALLY — rows written while PROVENANCE_SUPPORT_EDGES
+        // was on must stay erasable after it is off (the
+        // EVIDENCE_SUBSTRATE_ENABLED precedent). Two-step
+        // (SELECT ids → DELETE $ids) MANDATORY: `in` is covered by the
+        // COMPOUND support_edge_uq index — `DELETE memory_support WHERE
+        // in INSIDE …` is the reproduced 3.2.4 silent planner no-op.
+        // Uncounted in txRecordCount, like fact_usage (bookkeeping
+        // rows, content-free by construction — record ids only).
+        tx.add(`LET $entFactIds = (SELECT VALUE id FROM knowledge_fact WHERE entityId = $ent)`);
+        tx.add(
+          `LET $supIds = (SELECT VALUE id FROM memory_support
+             WHERE in INSIDE $entFactIds OR out INSIDE $entFactIds OR out INSIDE $sceneIds)`,
+        );
+        tx.add(`DELETE $supIds`);
         // 0107 outcome telemetry: stragglers written after the pre-tx
         // bulk sweep, plus the one-row-per-subject rollup (small enough
         // to live inside the tx). Uncounted in txRecordCount, like

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -244,6 +244,16 @@ export class UserForgetService {
       if (((ownMemberIds as unknown[]) ?? []).length > 0) {
         await db.query(`DELETE $ids`, { ids: ownMemberIds });
       }
+      // Typed support graph (0116): every dying scene is a possible
+      // supported_by edge target, so scene ids are collected BEFORE
+      // their rows go (the edge erase below goes by these explicit
+      // ids). User-scoped scenes here; mixed-user scenes join the list
+      // in the by-reference branch below.
+      const [ownSceneIdRows] = await db.query<[unknown[]]>(
+        `SELECT VALUE id FROM memory_episode WHERE userId = $u`,
+        { u: userId },
+      );
+      const supportSceneIds = ((ownSceneIdRows as unknown[]) ?? []).map(String);
       // Mixed-user scenes carry no userId stamp — resolve them BY
       // REFERENCE through the membership of the just-deleted episodes
       // (the `out` link keeps its record id after the episode row died).
@@ -258,6 +268,7 @@ export class UserForgetService {
         const sceneIds = [...new Set(((sceneIdRows as unknown[]) ?? []).map(String))].map(
           (id) => new StringRecordId(id),
         );
+        supportSceneIds.push(...sceneIds.map(String));
         const [refMemberIds] = await db.query<[unknown[]]>(
           `SELECT VALUE id FROM memory_episode_member WHERE in INSIDE $sceneIds OR out INSIDE $eps`,
           { sceneIds, eps: deletedEpisodeRefs },
@@ -270,6 +281,27 @@ export class UserForgetService {
         }
       }
       await db.query(`DELETE memory_episode WHERE userId = $u`, { u: userId });
+
+      // Typed support graph (0116): erase every memory_support edge
+      // touching the user's facts (either endpoint) or a dying scene
+      // (edge target). Runs UNCONDITIONALLY — rows written while
+      // PROVENANCE_SUPPORT_EDGES was on must stay erasable after it is
+      // off (the EVIDENCE_SUBSTRATE_ENABLED precedent). Two-step
+      // (SELECT ids → DELETE $ids) MANDATORY: `in` is covered by the
+      // COMPOUND support_edge_uq index — `DELETE memory_support WHERE
+      // in INSIDE …` is the reproduced 3.2.4 silent planner no-op (OK,
+      // zero rows) while the same WHERE in a SELECT matches fine.
+      const supportSubjects = [...factIds, ...new Set(supportSceneIds)].map(
+        (id) => new StringRecordId(id),
+      );
+      if (supportSubjects.length > 0) {
+        await db.query(
+          `LET $supIds = (SELECT VALUE id FROM memory_support
+             WHERE in INSIDE $subjects OR out INSIDE $subjects);
+           DELETE $supIds;`,
+          { subjects: supportSubjects },
+        );
+      }
 
       // Evidence substrate (0109) — see eraseEvidenceRows.
       const { evidenceAssetsDeleted, evidenceFragmentsDeleted, representationsDeleted } =

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -30,8 +30,15 @@ import {
   closureMaxEpisodes,
   closureMaxFacts,
   recursiveClosureEnabled,
+  supportGraphReadEnabled,
 } from '../common/provenance-flags';
-import { indexCharSpans, walkProvenanceClosure, type ProvenanceSpan } from './provenance-closure';
+import {
+  indexCharSpans,
+  walkProvenanceClosure,
+  type ClosureEdgeRow,
+  type ProvenanceClosureEdge,
+  type ProvenanceSpan,
+} from './provenance-closure';
 
 /**
  * Predicate-class allowlist that requires `brain:admin` for retract,
@@ -189,6 +196,12 @@ export interface FactProvenanceResult {
    */
   derivedFacts?: FactProvenanceDerivedFact[];
   closure?: FactProvenanceClosure;
+  /**
+   * Typed support edges crossed by the walk
+   * (PROVENANCE_SUPPORT_GRAPH_READ, 0116) — absent (not empty) when the
+   * read flag is off, so the default response stays byte-identical.
+   */
+  supportEdges?: ProvenanceClosureEdge[];
 }
 
 interface FactReadOptions {
@@ -380,11 +393,11 @@ export class FactsService {
       // Recursive closure (PROVENANCE_RECURSIVE_CLOSURE) only for a root
       // that HAS derivedFrom — flag off, or a leaf fact, takes the
       // one-hop path below byte-identically (no optional fields).
-      if (
-        recursiveClosureEnabled() &&
-        Array.isArray(fact.derivedFrom) &&
-        fact.derivedFrom.length > 0
-      ) {
+      // PROVENANCE_SUPPORT_GRAPH_READ widens the entry: a root with
+      // typed edges but an EMPTY derivedFrom array walks too (the edge
+      // fetch is what discovers its children).
+      const hasDerivedFrom = Array.isArray(fact.derivedFrom) && fact.derivedFrom.length > 0;
+      if (recursiveClosureEnabled() && (hasDerivedFrom || supportGraphReadEnabled())) {
         return this.provenanceWithClosure(db, opts, fact);
       }
       const source = (fact.source ?? {}) as {
@@ -435,6 +448,12 @@ export class FactsService {
       policyLookup: await this.predicateRegistry?.rowPolicyLookup(opts.companyId),
     });
     const gates: FactVisibilityGates = { scopeUserId, principalTags, rowPolicy };
+    // Typed support graph read (PROVENANCE_SUPPORT_GRAPH_READ): supply
+    // the per-depth edge fetch — ONE batched SELECT over the frontier.
+    // Plain WHERE on `in` (the compound support_edge_uq leading field)
+    // is safe for a SELECT; only DELETE hits the 3.2.4 planner no-op.
+    // Flag off ⇒ no fetchEdges ⇒ the walk is byte-identical.
+    const readEdges = supportGraphReadEnabled();
     const closure = await walkProvenanceClosure<FactReadRow>({
       root,
       caps: {
@@ -455,6 +474,17 @@ export class FactsService {
         );
         return rows ?? [];
       },
+      ...(readEdges
+        ? {
+            fetchEdges: async (ids: string[]) => {
+              const [rows] = await db.query<[ClosureEdgeRow[]]>(
+                `SELECT id, in, out, kind FROM memory_support WHERE in INSIDE $ids`,
+                { ids: ids.map((id) => new StringRecordId(id)) },
+              );
+              return rows ?? [];
+            },
+          }
+        : {}),
     });
     rowPolicy.finish();
 
@@ -502,6 +532,10 @@ export class FactsService {
         truncated,
         filtered: closure.filtered,
       },
+      // Additive and flag-keyed: PRESENT (possibly empty) whenever the
+      // read flag drove the walk, ABSENT otherwise — never an empty
+      // array on the default path.
+      ...(readEdges ? { supportEdges: closure.edges } : {}),
     };
   }
 

--- a/src/facts/provenance-closure.ts
+++ b/src/facts/provenance-closure.ts
@@ -21,11 +21,31 @@
  * wire, not hidden.
  */
 
+import {
+  classifySupportTarget,
+  isEmittedEdgeKind,
+  type EmittedEdgeKind,
+} from '../common/support-edges';
+
 /** Wire span shape — {start, end, exact} only (G3). */
 export interface ProvenanceSpan {
   start: number;
   end: number;
   exact: string;
+}
+
+/** The minimal memory_support row shape the walk reads (0116). */
+export interface ClosureEdgeRow {
+  in: unknown;
+  out: unknown;
+  kind: unknown;
+}
+
+/** One crossed support edge, normalized for the wire. */
+export interface ProvenanceClosureEdge {
+  kind: EmittedEdgeKind;
+  from: string;
+  to: string;
 }
 
 /**
@@ -95,6 +115,14 @@ export interface ProvenanceClosureResult<Row extends ClosureFactRow> {
   truncated: { depth: boolean; fanout: boolean; episodes: boolean };
   /** True when ≥1 member row was silently dropped by the fence. */
   filtered: boolean;
+  /**
+   * Support edges crossed by the walk (PROVENANCE_SUPPORT_GRAPH_READ) —
+   * one batched fetchEdges call per depth over the frontier, deduped by
+   * (kind, from, to), capped by maxFacts (no separate cap knob — the
+   * fact budget bounds the edge surface too; overflow marks
+   * truncated.fanout). Always `[]` when fetchEdges is absent.
+   */
+  edges: ProvenanceClosureEdge[];
 }
 
 /** Mutable walk bookkeeping shared by the per-depth helpers. */
@@ -105,6 +133,9 @@ interface WalkState {
   truncated: { depth: boolean; fanout: boolean; episodes: boolean };
   /** Fact budget consumed — children admitted across the whole walk. */
   admitted: number;
+  edges: ProvenanceClosureEdge[];
+  /** Dedupe keys of `edges` — (kind, from, to). */
+  edgeKeys: Set<string>;
 }
 
 /**
@@ -159,11 +190,72 @@ function collectChildren(
 }
 
 /**
+ * Record this depth's crossed support edges into the walk state —
+ * kind-filtered to the three emitted kinds, String()-normalized,
+ * deduped by (kind, from, to), capped by the fact budget (overflow
+ * marks truncated.fanout) — and return the derived_from targets that
+ * classify as facts (EvidenceRef/table-prefix vocabulary — a non-fact
+ * target is reported as an edge but never walked as a child).
+ */
+function collectEdges(
+  edgeRows: readonly ClosureEdgeRow[],
+  caps: ProvenanceClosureCaps,
+  s: WalkState,
+): string[] {
+  const factTargets: string[] = [];
+  for (const row of edgeRows) {
+    const kind = String(row.kind);
+    if (!isEmittedEdgeKind(kind)) continue;
+    const from = String(row.in);
+    const to = String(row.out);
+    const key = `${kind} ${from} ${to}`;
+    if (s.edgeKeys.has(key)) continue;
+    if (s.edges.length >= caps.maxFacts) {
+      s.truncated.fanout = true;
+      continue;
+    }
+    s.edgeKeys.add(key);
+    s.edges.push({ kind, from, to });
+    if (kind === 'derived_from' && classifySupportTarget(to) === 'fact') factTargets.push(to);
+  }
+  return factTargets;
+}
+
+/** Admit edge-derived children through the SAME visited set + fact
+ *  budget as collectChildren — one budget, one dedupe, one cycle
+ *  terminator for both child sources. */
+function admitEdgeChildren(
+  targets: readonly string[],
+  caps: ProvenanceClosureCaps,
+  s: WalkState,
+): string[] {
+  const children: string[] = [];
+  for (const id of targets) {
+    if (s.visited.has(id)) continue;
+    if (s.admitted >= caps.maxFacts) {
+      s.truncated.fanout = true;
+      continue;
+    }
+    s.visited.add(id);
+    s.admitted += 1;
+    children.push(id);
+  }
+  return children;
+}
+
+/**
  * BFS over `derivedFrom` from an already-fenced root. One batched fetch
  * per depth (`WHERE id INSIDE $ids` — the caller's query carries NO
  * status filter); record-id shapes are String()-normalized throughout,
  * so RecordId objects and plain strings key the visited set identically
  * (which is also what terminates cycles — each id is admitted once).
+ *
+ * Optional `fetchEdges` (PROVENANCE_SUPPORT_GRAPH_READ): one batched
+ * memory_support read per depth over the frontier's ids. derived_from
+ * edge targets join the next generation through the SAME visited set
+ * and fact budget; every crossed edge lands in the `edges` result.
+ * ABSENT ⇒ the walk is byte-identical to the pre-edge behavior
+ * (`edges` stays `[]`, no other field changes).
  */
 export async function walkProvenanceClosure<Row extends ClosureFactRow>(opts: {
   root: Row;
@@ -172,6 +264,8 @@ export async function walkProvenanceClosure<Row extends ClosureFactRow>(opts: {
   visible: (fact: Row) => boolean;
   /** ONE batched SELECT of loadVisibleFact's column set — no status filter. */
   fetchByIds: (ids: string[]) => Promise<Row[]>;
+  /** ONE batched memory_support SELECT per depth (`WHERE in INSIDE $ids`). */
+  fetchEdges?: (ids: string[]) => Promise<ClosureEdgeRow[]>;
 }): Promise<ProvenanceClosureResult<Row>> {
   const { caps } = opts;
   const state: WalkState = {
@@ -180,6 +274,8 @@ export async function walkProvenanceClosure<Row extends ClosureFactRow>(opts: {
     spans: new Map<string, ProvenanceSpan>(),
     truncated: { depth: false, fanout: false, episodes: false },
     admitted: 0,
+    edges: [],
+    edgeKeys: new Set<string>(),
   };
   const closureFacts: Array<{ fact: Row; depth: number }> = [];
   let filtered = false;
@@ -191,8 +287,23 @@ export async function walkProvenanceClosure<Row extends ClosureFactRow>(opts: {
     //    episodeIds still contributes its children below.
     for (const fact of frontier) harvestGrounding(fact, caps, state);
 
-    // 2. Next generation, minus visited, fact-budget capped.
-    const children = collectChildren(frontier, caps, state);
+    // 1b. Crossed support edges (only when the caller supplied the
+    //     fetch — absent ⇒ nothing here runs and the walk is
+    //     byte-identical). The final frontier's edges are collected
+    //     too: this step precedes every break below.
+    let edgeTargets: string[] = [];
+    if (opts.fetchEdges) {
+      const edgeRows = await opts.fetchEdges(frontier.map((f) => String(f.id)));
+      edgeTargets = collectEdges(edgeRows, caps, state);
+    }
+
+    // 2. Next generation, minus visited, fact-budget capped — the
+    //    derivedFrom arrays first (existing admission order), then the
+    //    typed derived_from targets through the same budget.
+    const children = [
+      ...collectChildren(frontier, caps, state),
+      ...admitEdgeChildren(edgeTargets, caps, state),
+    ];
     if (children.length === 0) break;
     if (depth >= caps.maxDepth) {
       // Unvisited children remain past the depth cap.
@@ -215,5 +326,6 @@ export async function walkProvenanceClosure<Row extends ClosureFactRow>(opts: {
     spans: state.spans,
     truncated: state.truncated,
     filtered,
+    edges: state.edges,
   };
 }

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -6,6 +6,8 @@ import { MetricsService } from '../metrics/metrics.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { detectLanguage } from '../ai/locale/language-detector';
 import { envFlagEnabled } from '../common/env-validation';
+import { supportEdgesEnabled } from '../common/provenance-flags';
+import { buildConflictEdgeRows } from '../common/support-edges';
 import { KeyedMutex } from '../common/keyed-mutex';
 import { ConflictConfig, type DerivedSemantics, type ResolveOutcome } from './conflict-resolver';
 import { idTailOf, sourceTrustFor } from './ingest-utils';
@@ -329,6 +331,34 @@ export class FactResolverService {
       this.metrics?.countIngestFact(String(outcome));
     }
     this.emitConflictOutcomes(p.companyId, result);
+    await this.writeConflictSupportEdges(db, result);
+  }
+
+  /**
+   * Typed support graph (PROVENANCE_SUPPORT_EDGES, 0116): mirror a
+   * conflict verdict as contradicted_by edges — SUPERSEDED → one edge
+   * per displaced fact (loser→winner), COMPETING → the mutual pair per
+   * standing competitor — capped by CONFLICT_OUTCOME_CAP (row assembly
+   * in support-edges.ts). Runs in the shared post-call tail, AFTER
+   * resolveFactCall, never inside the KeyedMutex critical section.
+   * Best-effort: warn, never fail the ingest (the emitConflictOutcomes
+   * idiom). Off (default) ⇒ zero queries, byte-identical.
+   */
+  private async writeConflictSupportEdges(db: Surreal, result: ResolveOutcome): Promise<void> {
+    if (!supportEdgesEnabled()) return;
+    const rows = buildConflictEdgeRows(result, FactResolverService.CONFLICT_OUTCOME_CAP);
+    if (rows.length === 0) return;
+    try {
+      await db.query(`INSERT RELATION IGNORE INTO memory_support $rows`, {
+        rows: rows.map((r) => ({
+          ...r,
+          in: new StringRecordId(r.in),
+          out: new StringRecordId(r.out),
+        })),
+      });
+    } catch (e) {
+      this.logger.warn(`conflict support-edge write failed (non-fatal): ${(e as Error).message}`);
+    }
   }
 
   /** 0107 cap — bounds a pathological conflict fan-out. */

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -10,7 +10,7 @@
  * 3. JobRunService.finish() must carry the inline-ownership guard so it
  *    can't clobber a row a queue worker has claimed.
  */
-import { readFileSync } from 'fs';
+import { readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { JobRunService } from '../src/jobs/job-run.service';
 import { DERIVED_REPRESENTATION_KINDS, EVIDENCE_MODALITIES } from '../src/common/evidence-taxonomy';
@@ -439,6 +439,80 @@ describe('SurrealDB 3.2.4 DELETE-WHERE planner no-op guards', () => {
     expect(src).toContain(
       'DELETE (SELECT id FROM tool_observation WHERE createdAt < $cutoff LIMIT 5000) RETURN BEFORE',
     );
+  });
+});
+
+describe('0116_memory_support indexes', () => {
+  const sql = readFileSync(join(MIGRATIONS, '0116_memory_support.surql'), 'utf8');
+
+  it.each([
+    ['support_edge_uq', 'memory_support', 'in, out, kind UNIQUE'],
+    ['support_out_idx', 'memory_support', 'out'],
+    ['support_kind_idx', 'memory_support', 'kind'],
+  ])('defines %s on %s(%s)', (name, table, fields) => {
+    const re = new RegExp(`DEFINE INDEX IF NOT EXISTS ${name}\\s+ON ${table} FIELDS ${fields};`);
+    expect(sql).toMatch(re);
+  });
+
+  it('deliberately defines NO changefeed and NO event', () => {
+    // The 0053/0107 separation rationale: provenance edges must not
+    // feed the audit mirror, and an erased subject's edges must not
+    // stay readable in a feed. The header EXPLAINS the absence in
+    // prose, so judge only non-comment lines.
+    const code = sql
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('--'))
+      .join('\n');
+    expect(code).not.toMatch(/CHANGEFEED/);
+    expect(code).not.toMatch(/DEFINE EVENT/);
+  });
+});
+
+describe('memory_support GDPR cascade + DELETE-shape guards (0116)', () => {
+  const SRC = join(__dirname, '..', 'src');
+
+  it('both forget services erase support edges via the two-step SELECT-ids → DELETE idiom', () => {
+    // The compound support_edge_uq index covers `in` — a
+    // `DELETE memory_support WHERE in INSIDE …` is the REPRODUCED
+    // 3.2.4 silent planner no-op (returns OK, deletes zero rows), so
+    // the cascade must pre-select ids and delete by them. And it must
+    // run UNCONDITIONALLY — rows written while PROVENANCE_SUPPORT_EDGES
+    // was on must stay erasable after it is off.
+    const userForget = readFileSync(join(SRC, 'entities', 'user-forget.service.ts'), 'utf8');
+    expect(userForget).toContain('SELECT VALUE id FROM memory_support');
+    expect(userForget).toContain('DELETE $supIds');
+    const entityForget = readFileSync(join(SRC, 'entities', 'entity-forget.service.ts'), 'utf8');
+    expect(entityForget).toContain('SELECT VALUE id FROM memory_support');
+    expect(entityForget).toContain('DELETE $supIds');
+    // The entity tx must pre-collect fact ids BEFORE the fact delete
+    // erases the rows the subject SELECT enumerates.
+    expect(entityForget).toContain(
+      'LET $entFactIds = (SELECT VALUE id FROM knowledge_fact WHERE entityId = $ent)',
+    );
+  });
+
+  it('NO file in src/ uses the 3.2.4-broken DELETE memory_support WHERE shape', () => {
+    const walk = (dir: string): string[] => {
+      const out: string[] = [];
+      for (const name of readdirSync(dir)) {
+        const p = join(dir, name);
+        if (statSync(p).isDirectory()) out.push(...walk(p));
+        else if (p.endsWith('.ts') || p.endsWith('.surql')) out.push(p);
+      }
+      return out;
+    };
+    for (const file of walk(SRC)) {
+      // Comment lines EXPLAIN the trap (0058-guard idiom) — judge only
+      // code lines.
+      const code = readFileSync(file, 'utf8')
+        .split('\n')
+        .filter((l) => {
+          const t = l.trimStart();
+          return !t.startsWith('--') && !t.startsWith('//') && !t.startsWith('*');
+        })
+        .join('\n');
+      expect(code).not.toMatch(/DELETE memory_support\s+WHERE/);
+    }
   });
 });
 

--- a/test/compaction.unit-spec.ts
+++ b/test/compaction.unit-spec.ts
@@ -538,6 +538,151 @@ describe('PromotionRunnerService — summary episode stamping', () => {
   });
 });
 
+/**
+ * Typed support graph (Drift-5, PROVENANCE_SUPPORT_EDGES): both summary
+ * runners mirror the EXACT derivedFrom array they write as
+ * summary-derived_from->member memory_support edges. Off (default) the
+ * query log carries NO memory_support statement — byte-identical.
+ */
+describe('summary runners — derived_from edge mirror (PROVENANCE_SUPPORT_EDGES)', () => {
+  const saved = process.env.PROVENANCE_SUPPORT_EDGES;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.PROVENANCE_SUPPORT_EDGES;
+    else process.env.PROVENANCE_SUPPORT_EDGES = saved;
+  });
+
+  /** Like makeFakeSurreal, but CREATE returns a knowledge_fact-shaped
+   *  id — the mirror's `in` endpoint must pass assertEdgeShape. */
+  function makeMirrorSurreal(candidates: CandidateRow[]) {
+    const calls: QueryCall[] = [];
+    const fakeDb = {
+      async query<R>(sql: string, params?: Record<string, unknown>): Promise<R> {
+        calls.push({ sql, params });
+        if (sql.includes('GROUP BY entityId, predicate, userId')) {
+          return [
+            [{ entityId: 'knowledge_entity:e1', predicate: 'said', n: candidates.length }],
+          ] as unknown as R;
+        }
+        if (
+          sql.includes('SELECT id, entityId, predicate') ||
+          sql.includes('WHERE entityId = $entity AND predicate = $predicate')
+        ) {
+          return [candidates] as unknown as R;
+        }
+        if (sql.startsWith('CREATE type::table($t)')) {
+          return [[{ ...(params!.d as object), id: 'knowledge_fact:sum1' }]] as unknown as R;
+        }
+        return [[]] as unknown as R;
+      },
+    };
+    const surreal = {
+      withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>) => fn(fakeDb),
+    } as unknown as SurrealService;
+    return { surreal, calls };
+  }
+
+  const supportCalls = (calls: QueryCall[]) =>
+    calls.filter((c) => c.sql.includes('memory_support'));
+  const edgeRows = (call: QueryCall) =>
+    (call.params!.rows as Array<Record<string, unknown>>).map((r) => ({
+      ...r,
+      in: String(r.in),
+      out: String(r.out),
+    }));
+
+  const COMPACTION_SEEDS = rows([
+    { id: 'knowledge_fact:m1', predicate: 'tier', object: 'gold' },
+    { id: 'knowledge_fact:m2', predicate: 'tier', object: 'platinum' },
+  ]);
+
+  it('compaction, flag OFF (default): no memory_support statement in the log', async () => {
+    delete process.env.PROVENANCE_SUPPORT_EDGES;
+    const { surreal, calls } = makeMirrorSurreal(COMPACTION_SEEDS);
+    const runner = new CompactionRunnerService(
+      surreal,
+      new StubConfig({ COMPACTION_SUMMARIES: 'true' }) as unknown as ConfigService,
+      { generate: async () => 'S' },
+    );
+    await runner.compactAll(['co_a']);
+    expect(supportCalls(calls)).toEqual([]);
+  });
+
+  it('compaction, flag ON: the mirror equals the derivedFrom array, element for element', async () => {
+    process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    const { surreal, calls } = makeMirrorSurreal(COMPACTION_SEEDS);
+    const runner = new CompactionRunnerService(
+      surreal,
+      new StubConfig({ COMPACTION_SUMMARIES: 'true' }) as unknown as ConfigService,
+      { generate: async () => 'S' },
+    );
+    await runner.compactAll(['co_a']);
+    const inserts = supportCalls(calls);
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]!.sql).toContain('INSERT RELATION IGNORE INTO memory_support');
+    expect(edgeRows(inserts[0]!)).toEqual([
+      {
+        in: 'knowledge_fact:sum1',
+        out: 'knowledge_fact:m1',
+        kind: 'derived_from',
+        writer: 'compaction_runner',
+      },
+      {
+        in: 'knowledge_fact:sum1',
+        out: 'knowledge_fact:m2',
+        kind: 'derived_from',
+        writer: 'compaction_runner',
+      },
+    ]);
+  });
+
+  const promotionRunner = (surreal: SurrealService) =>
+    new PromotionRunnerService(
+      surreal,
+      new StubConfig({
+        COMPACTION_PROMOTION_ENABLED: '1',
+        COMPACTION_PROMOTION_MIN_GROUP: '2',
+      }) as unknown as ConfigService,
+      { embed: async () => [1, 0] } as unknown as EmbedderService,
+      { generate: async () => 'promoted summary' },
+    );
+
+  const PROMOTION_SEEDS = rows([
+    { id: 'knowledge_fact:s1', predicate: 'said', object: 'old remark 1' },
+    { id: 'knowledge_fact:s2', predicate: 'said', object: 'old remark 2' },
+  ]);
+
+  it('promotion, flag OFF (default): no memory_support statement in the log', async () => {
+    delete process.env.PROVENANCE_SUPPORT_EDGES;
+    const { surreal, calls } = makeMirrorSurreal(PROMOTION_SEEDS);
+    await promotionRunner(surreal).promoteCompany('co_a');
+    expect(supportCalls(calls)).toEqual([]);
+  });
+
+  it('promotion, flag ON: mirror lands after the CREATE, writer promotion_runner', async () => {
+    process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    const { surreal, calls } = makeMirrorSurreal(PROMOTION_SEEDS);
+    await promotionRunner(surreal).promoteCompany('co_a');
+    const createIdx = calls.findIndex((c) => c.sql.startsWith('CREATE type::table($t)'));
+    const insertIdx = calls.findIndex((c) => c.sql.includes('memory_support'));
+    expect(createIdx).toBeGreaterThanOrEqual(0);
+    expect(insertIdx).toBeGreaterThan(createIdx);
+    expect(edgeRows(calls[insertIdx]!)).toEqual([
+      {
+        in: 'knowledge_fact:sum1',
+        out: 'knowledge_fact:s1',
+        kind: 'derived_from',
+        writer: 'promotion_runner',
+      },
+      {
+        in: 'knowledge_fact:sum1',
+        out: 'knowledge_fact:s2',
+        kind: 'derived_from',
+        writer: 'promotion_runner',
+      },
+    ]);
+  });
+});
+
 describe('ConcatSummaryGenerator', () => {
   it('produces a chronological concat with date prefix and predicate', async () => {
     const { ConcatSummaryGenerator } = await import('../src/compaction/summary-generator');

--- a/test/contracts-facts.unit-spec.ts
+++ b/test/contracts-facts.unit-spec.ts
@@ -63,6 +63,13 @@ const fullProvenance: Required<FactProvenanceResult> = {
     },
   ],
   closure: { depth: 1, factCount: 1, truncated: false, filtered: false },
+  // PROVENANCE_SUPPORT_GRAPH_READ optional (0116) — absent when the
+  // read flag is off; the on-shape pins all three emitted kinds.
+  supportEdges: [
+    { kind: 'derived_from', from: 'knowledge_fact:abc', to: 'knowledge_fact:member1' },
+    { kind: 'supported_by', from: 'knowledge_fact:member1', to: 'memory_episode:scene1' },
+    { kind: 'contradicted_by', from: 'knowledge_fact:member1', to: 'knowledge_fact:winner1' },
+  ],
 };
 
 describe('facts wire contracts', () => {

--- a/test/forget-l0-cascade.unit-spec.ts
+++ b/test/forget-l0-cascade.unit-spec.ts
@@ -273,3 +273,46 @@ describe('user forget → segments follow the deleted episodes', () => {
     expect(byUser).toBeDefined();
   });
 });
+
+describe('user forget → memory_support cascade (0116)', () => {
+  const saved = {
+    edges: process.env.PROVENANCE_SUPPORT_EDGES,
+    read: process.env.PROVENANCE_SUPPORT_GRAPH_READ,
+  };
+  afterEach(() => {
+    if (saved.edges === undefined) delete process.env.PROVENANCE_SUPPORT_EDGES;
+    else process.env.PROVENANCE_SUPPORT_EDGES = saved.edges;
+    if (saved.read === undefined) delete process.env.PROVENANCE_SUPPORT_GRAPH_READ;
+    else process.env.PROVENANCE_SUPPORT_GRAPH_READ = saved.read;
+  });
+
+  it('erases support edges by pre-collected subject ids with BOTH flags OFF', async () => {
+    // GDPR runs regardless of flags: rows written while
+    // PROVENANCE_SUPPORT_EDGES was on must stay erasable after off.
+    delete process.env.PROVENANCE_SUPPORT_EDGES;
+    delete process.env.PROVENANCE_SUPPORT_GRAPH_READ;
+    const { db, queries } = makeDb((sql) => {
+      if (sql.includes('SELECT VALUE id FROM knowledge_fact')) return ['knowledge_fact:f1'];
+      if (sql.includes('SELECT VALUE id FROM memory_episode WHERE userId'))
+        return ['memory_episode:s1'];
+      return [];
+    });
+    const surreal = {
+      withCompany: async (_c: string, fn: (d: unknown) => Promise<unknown>) => fn(db),
+    } as unknown as SurrealService;
+    await new UserForgetService(surreal).forgetUser('co_x', 'u1');
+
+    // Two-step (SELECT ids → DELETE $ids): `in` sits under the COMPOUND
+    // support_edge_uq index — the 3.2.4 DELETE-WHERE silent no-op class.
+    const cascade = queries.find(
+      (q) =>
+        q.sql.includes('SELECT VALUE id FROM memory_support') && q.sql.includes('DELETE $supIds'),
+    );
+    expect(cascade).toBeDefined();
+    const subjects = (cascade!.params!.subjects as unknown[]).map(String);
+    expect(subjects).toContain('knowledge_fact:f1');
+    expect(subjects).toContain('memory_episode:s1');
+    // Never the broken one-step shape.
+    expect(queries.some((q) => /DELETE memory_support\s+WHERE/.test(q.sql))).toBe(false);
+  });
+});

--- a/test/provenance-closure.unit-spec.ts
+++ b/test/provenance-closure.unit-spec.ts
@@ -288,3 +288,170 @@ describe('indexCharSpans (shared helper)', () => {
     expect(indexCharSpans({ episodeId: 'episode:e1' }).size).toBe(0);
   });
 });
+
+/**
+ * Typed support graph read (Drift-5, PROVENANCE_SUPPORT_GRAPH_READ):
+ * the optional fetchEdges callback. ABSENT ⇒ the walk is byte-identical
+ * to the pre-edge walker (pinned by deep-equal below AND by every
+ * legacy spec above running unchanged). PRESENT ⇒ derived_from targets
+ * join the generation through the SAME visited set and fact budget,
+ * and every crossed edge lands in `edges`.
+ */
+describe('walkProvenanceClosure — fetchEdges (support graph read)', () => {
+  type EdgeSeed = { in: string; out: string; kind: string };
+
+  function makeEdgeDb(edges: EdgeSeed[]) {
+    const batches: string[][] = [];
+    return {
+      batches,
+      fetchEdges: async (ids: string[]) => {
+        batches.push(ids);
+        return edges.filter((e) => ids.includes(e.in));
+      },
+    };
+  }
+
+  it('fetchEdges ABSENT: result deep-equals the pre-edge shape (edges empty, no other change)', async () => {
+    const rows = [fact('c1', { episodeIds: ['episode:e1'] })];
+    const out = await walkProvenanceClosure({
+      root: fact('root', { derivedFrom: ['knowledge_fact:c1'], episodeIds: ['episode:e0'] }),
+      caps: CAPS,
+      visible: allVisible,
+      fetchByIds: makeDb(rows).fetchByIds,
+    });
+    expect(out.edges).toEqual([]);
+    expect(out.closureFacts.map((c) => String(c.fact.id))).toEqual(['knowledge_fact:c1']);
+    expect([...out.episodes.keys()]).toEqual(['episode:e0', 'episode:e1']);
+    expect(out.truncated).toEqual({ depth: false, fanout: false, episodes: false });
+    expect(out.filtered).toBe(false);
+  });
+
+  it('derived_from edges union targets into the generation (root with EMPTY derivedFrom walks)', async () => {
+    const rows = [fact('c1', { episodeIds: ['episode:e1'] })];
+    const edb = makeEdgeDb([
+      { in: 'knowledge_fact:root', out: 'knowledge_fact:c1', kind: 'derived_from' },
+    ]);
+    const out = await walkProvenanceClosure({
+      root: fact('root', { episodeIds: ['episode:e0'] }),
+      caps: CAPS,
+      visible: allVisible,
+      fetchByIds: makeDb(rows).fetchByIds,
+      fetchEdges: edb.fetchEdges,
+    });
+    expect(out.closureFacts.map((c) => [String(c.fact.id), c.depth])).toEqual([
+      ['knowledge_fact:c1', 1],
+    ]);
+    expect(out.edges).toEqual([
+      { kind: 'derived_from', from: 'knowledge_fact:root', to: 'knowledge_fact:c1' },
+    ]);
+    // Harvest reaches the edge-discovered child too.
+    expect([...out.episodes.keys()]).toEqual(['episode:e0', 'episode:e1']);
+    // One batched edge fetch per depth over the frontier.
+    expect(edb.batches).toEqual([['knowledge_fact:root'], ['knowledge_fact:c1']]);
+  });
+
+  it('edge children pass the SAME visited set (derivedFrom twin deduped) and fact budget', async () => {
+    const rows = [fact('c1', {}), fact('c2', {})];
+    const edb = makeEdgeDb([
+      // c1 arrives via BOTH the array and the edge — admitted once.
+      { in: 'knowledge_fact:root', out: 'knowledge_fact:c1', kind: 'derived_from' },
+      { in: 'knowledge_fact:root', out: 'knowledge_fact:c2', kind: 'derived_from' },
+    ]);
+    const db = makeDb(rows);
+    const out = await walkProvenanceClosure({
+      root: fact('root', { derivedFrom: ['knowledge_fact:c1'] }),
+      caps: { ...CAPS, maxFacts: 2 },
+      visible: allVisible,
+      fetchByIds: db.fetchByIds,
+      fetchEdges: edb.fetchEdges,
+    });
+    expect(db.batches).toEqual([['knowledge_fact:c1', 'knowledge_fact:c2']]);
+    expect(out.closureFacts).toHaveLength(2);
+    expect(out.truncated.fanout).toBe(false);
+  });
+
+  it('fact budget exhausted by edge children → truncated.fanout', async () => {
+    const rows = [fact('c1', {})];
+    const edb = makeEdgeDb([
+      { in: 'knowledge_fact:root', out: 'knowledge_fact:c1', kind: 'derived_from' },
+      { in: 'knowledge_fact:root', out: 'knowledge_fact:c2', kind: 'derived_from' },
+    ]);
+    const out = await walkProvenanceClosure({
+      root: fact('root', {}),
+      caps: { ...CAPS, maxFacts: 1 },
+      visible: allVisible,
+      fetchByIds: makeDb(rows).fetchByIds,
+      fetchEdges: edb.fetchEdges,
+    });
+    expect(out.closureFacts.map((c) => String(c.fact.id))).toEqual(['knowledge_fact:c1']);
+    expect(out.truncated.fanout).toBe(true);
+  });
+
+  it('supported_by / contradicted_by are collected but never walked; non-fact targets never walked', async () => {
+    const edb = makeEdgeDb([
+      { in: 'knowledge_fact:root', out: 'memory_episode:s1', kind: 'supported_by' },
+      { in: 'knowledge_fact:root', out: 'knowledge_fact:rival', kind: 'contradicted_by' },
+      // A derived_from pointing OUTSIDE the fact table: reported, not walked.
+      { in: 'knowledge_fact:root', out: 'episode:e9', kind: 'derived_from' },
+      // Reserved / unknown kinds are dropped entirely.
+      { in: 'knowledge_fact:root', out: 'episode:e1', kind: 'reconstructed_from' },
+      { in: 'knowledge_fact:root', out: 'knowledge_fact:x', kind: 'bogus' },
+    ]);
+    const db = makeDb([]);
+    const out = await walkProvenanceClosure({
+      root: fact('root', {}),
+      caps: CAPS,
+      visible: allVisible,
+      fetchByIds: db.fetchByIds,
+      fetchEdges: edb.fetchEdges,
+    });
+    expect(out.edges).toEqual([
+      { kind: 'supported_by', from: 'knowledge_fact:root', to: 'memory_episode:s1' },
+      { kind: 'contradicted_by', from: 'knowledge_fact:root', to: 'knowledge_fact:rival' },
+      { kind: 'derived_from', from: 'knowledge_fact:root', to: 'episode:e9' },
+    ]);
+    // contradicted_by target is NOT a child; no fact fetch ever fired.
+    expect(db.batches).toEqual([]);
+    expect(out.closureFacts).toEqual([]);
+  });
+
+  it('a cycle via edges terminates (visited set covers edge children)', async () => {
+    const rows = [fact('c1', {})];
+    const edb = makeEdgeDb([
+      { in: 'knowledge_fact:root', out: 'knowledge_fact:c1', kind: 'derived_from' },
+      { in: 'knowledge_fact:c1', out: 'knowledge_fact:root', kind: 'derived_from' },
+    ]);
+    const out = await walkProvenanceClosure({
+      root: fact('root', {}),
+      caps: CAPS,
+      visible: allVisible,
+      fetchByIds: makeDb(rows).fetchByIds,
+      fetchEdges: edb.fetchEdges,
+    });
+    expect(out.closureFacts.map((c) => String(c.fact.id))).toEqual(['knowledge_fact:c1']);
+    // The back-edge is still REPORTED — it just cannot re-admit root.
+    expect(out.edges).toEqual([
+      { kind: 'derived_from', from: 'knowledge_fact:root', to: 'knowledge_fact:c1' },
+      { kind: 'derived_from', from: 'knowledge_fact:c1', to: 'knowledge_fact:root' },
+    ]);
+  });
+
+  it('edge surface shares the fact-budget cap (overflow marks truncated.fanout)', async () => {
+    const edb = makeEdgeDb(
+      Array.from({ length: 4 }, (_, i) => ({
+        in: 'knowledge_fact:root',
+        out: `memory_episode:s${i}`,
+        kind: 'supported_by',
+      })),
+    );
+    const out = await walkProvenanceClosure({
+      root: fact('root', {}),
+      caps: { ...CAPS, maxFacts: 2 },
+      visible: allVisible,
+      fetchByIds: makeDb([]).fetchByIds,
+      fetchEdges: edb.fetchEdges,
+    });
+    expect(out.edges).toHaveLength(2);
+    expect(out.truncated.fanout).toBe(true);
+  });
+});

--- a/test/recompose.unit-spec.ts
+++ b/test/recompose.unit-spec.ts
@@ -363,4 +363,76 @@ describe('RecomposeService', () => {
       expect(batch!.sql).toContain('source.episodeIds AS eps');
     });
   });
+
+  /**
+   * Typed support graph (Drift-5, PROVENANCE_SUPPORT_EDGES): recompose
+   * REWRITES derivedFrom, so its typed mirror is REPLACED — the stale
+   * edges deleted by the two-step LET-select-ids → DELETE idiom
+   * (mandatory: `in` is under the compound support_edge_uq index, the
+   * 3.2.4 DELETE-WHERE planner no-op), then the new set inserted. Off
+   * (default) the query log carries NO memory_support statement.
+   */
+  describe('rewrite — derived_from edge mirror (PROVENANCE_SUPPORT_EDGES)', () => {
+    const saved = process.env.PROVENANCE_SUPPORT_EDGES;
+    afterEach(() => {
+      if (saved === undefined) delete process.env.PROVENANCE_SUPPORT_EDGES;
+      else process.env.PROVENANCE_SUPPORT_EDGES = saved;
+    });
+
+    const staleSummary = {
+      id: 'knowledge_fact:sum1',
+      predicate: 'summary_lives_in',
+      derivedFrom: ['knowledge_fact:p1', 'knowledge_fact:p2'],
+      staleAt: '2023-06-01T00:00:00Z',
+    };
+    const parents = {
+      'knowledge_fact:p1': parent('knowledge_fact:p1', 'Berlin'),
+      'knowledge_fact:p2': parent('knowledge_fact:p2', 'Dublin', {
+        validFrom: '2023-02-01T00:00:00Z',
+      }),
+    };
+
+    it('flag OFF (default): no memory_support statement in the log', async () => {
+      delete process.env.PROVENANCE_SUPPORT_EDGES;
+      const { svc, queries } = make({ stale: [staleSummary], parents });
+      await svc.recompute('co_x');
+      expect(queries.filter((q) => q.sql.includes('memory_support'))).toEqual([]);
+    });
+
+    it('flag ON: two-step delete of the stale mirror, then the re-insert of the CURRENT parents', async () => {
+      process.env.PROVENANCE_SUPPORT_EDGES = '1';
+      const { svc, queries } = make({ stale: [staleSummary], parents });
+      await svc.recompute('co_x');
+      const support = queries.filter((q) => q.sql.includes('memory_support'));
+      expect(support).toHaveLength(2);
+      // 1. The two-step erase — string-pinned: a `DELETE memory_support
+      //    WHERE` here would be the 3.2.4 silent no-op.
+      expect(support[0]!.sql).toContain(`LET $edgeIds = (SELECT VALUE id FROM memory_support`);
+      expect(support[0]!.sql).toContain(`WHERE in = $summary AND kind = 'derived_from'`);
+      expect(support[0]!.sql).toContain('DELETE $edgeIds');
+      expect(String(support[0]!.params.summary)).toBe('knowledge_fact:sum1');
+      // 2. The re-insert mirrors the rewritten derivedFrom (chronological
+      //    parent order), writer 'recompose'.
+      expect(support[1]!.sql).toContain('INSERT RELATION IGNORE INTO memory_support');
+      const rows = (support[1]!.params.rows as Array<Record<string, unknown>>).map((r) => ({
+        ...r,
+        in: String(r.in),
+        out: String(r.out),
+      }));
+      expect(rows).toEqual([
+        {
+          in: 'knowledge_fact:sum1',
+          out: 'knowledge_fact:p1',
+          kind: 'derived_from',
+          writer: 'recompose',
+        },
+        {
+          in: 'knowledge_fact:sum1',
+          out: 'knowledge_fact:p2',
+          kind: 'derived_from',
+          writer: 'recompose',
+        },
+      ]);
+    });
+  });
 });

--- a/test/support-edge-writers.unit-spec.ts
+++ b/test/support-edge-writers.unit-spec.ts
@@ -1,0 +1,244 @@
+/**
+ * Typed support graph writers (Drift-5, PROVENANCE_SUPPORT_EDGES) —
+ * scene-backlink (supported_by) and the conflict resolver
+ * (contradicted_by). Both flag-off cases pin BYTE-IDENTICAL query
+ * sequences (the exact SQL strings issued today); the flag-on cases pin
+ * the INSERT RELATION IGNORE payload shape. The derived_from mirrors of
+ * the three summary writers are covered in compaction.unit-spec.ts /
+ * recompose.unit-spec.ts next to their episode-stamp siblings.
+ */
+import { SceneBacklinkService } from '../src/admin/scene-backlink.service';
+import { SEGMENTER_VERSION } from '../src/admin/scene-segmentation';
+import type { SceneVersionService } from '../src/admin/scene-version';
+import { FactResolverService } from '../src/ingest/fact-resolver.service';
+import type { SurrealService } from '../src/db/surreal.service';
+
+interface QueryCall {
+  sql: string;
+  params?: Record<string, unknown> | undefined;
+}
+
+const SAVED = {
+  edges: process.env.PROVENANCE_SUPPORT_EDGES,
+  backlink: process.env.SCENES_FACT_BACKLINK,
+};
+afterEach(() => {
+  if (SAVED.edges === undefined) delete process.env.PROVENANCE_SUPPORT_EDGES;
+  else process.env.PROVENANCE_SUPPORT_EDGES = SAVED.edges;
+  if (SAVED.backlink === undefined) delete process.env.SCENES_FACT_BACKLINK;
+  else process.env.SCENES_FACT_BACKLINK = SAVED.backlink;
+});
+
+describe('SceneBacklinkService — supported_by edges', () => {
+  function makeStack() {
+    const calls: QueryCall[] = [];
+    const fakeDb = {
+      async query<R>(sql: string, params?: Record<string, unknown>): Promise<R> {
+        calls.push({ sql, params });
+        if (sql.includes('FROM memory_episode WHERE segmenterVersion')) {
+          return [[{ id: 'memory_episode:s1', conversationIds: ['conv1'] }]] as unknown as R;
+        }
+        if (sql.includes('FROM memory_episode_member WHERE in = $scene')) {
+          return [[{ out: 'episode:e1' }, { out: 'episode:e2' }]] as unknown as R;
+        }
+        if (sql.includes('FROM knowledge_fact')) {
+          return [
+            [
+              { id: 'knowledge_fact:f1', episodeIds: ['episode:e1'] },
+              { id: 'knowledge_fact:f2', episodeIds: ['episode:other'] },
+              { id: 'knowledge_fact:f3', episodeIds: ['episode:e2'] },
+            ],
+          ] as unknown as R;
+        }
+        return [[]] as unknown as R;
+      },
+    };
+    const surreal = {
+      withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>) => fn(fakeDb),
+    } as unknown as SurrealService;
+    // Fingerprint flag off in the unit env ⇒ the real service resolves to
+    // the literal SEGMENTER_VERSION; the stub pins that same contract
+    // (scene-enrichment.unit-spec pattern).
+    const fakeVersions = {
+      resolve: () => ({
+        version: SEGMENTER_VERSION,
+        cfg: { topicBoundary: false, minCosine: 0.55, maxTurns: 40, embeddingSpaceId: null },
+      }),
+    } as unknown as SceneVersionService;
+    return { svc: new SceneBacklinkService(surreal, fakeVersions), calls };
+  }
+
+  it('flag OFF (default): the query sequence is byte-identical — no memory_support anywhere', async () => {
+    process.env.SCENES_FACT_BACKLINK = '1';
+    delete process.env.PROVENANCE_SUPPORT_EDGES;
+    const { svc, calls } = makeStack();
+    const result = await svc.run('co_x');
+    expect(result).toEqual({ scenes: 1, factsLinked: 2 });
+    // The exact statement sequence of the pre-edge writer, in order.
+    expect(calls.map((c) => c.sql.split(/\s+/).join(' ').trim())).toEqual([
+      'SELECT id, conversationIds FROM memory_episode WHERE segmenterVersion = $v',
+      'SELECT out FROM memory_episode_member WHERE in = $scene',
+      'SELECT id, source.episodeIds AS episodeIds FROM knowledge_fact WHERE source.conversationId = $conv',
+      'UPDATE knowledge_fact SET source.memoryEpisodeIds = array::union(source.memoryEpisodeIds ?? [], [$sceneId]), source.sceneLinkVersion = $v WHERE id INSIDE $factIds',
+    ]);
+  });
+
+  it('flag ON: INSERT RELATION IGNORE lands AFTER the stamp UPDATE, stamps untouched', async () => {
+    process.env.SCENES_FACT_BACKLINK = '1';
+    process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    const { svc, calls } = makeStack();
+    await svc.run('co_x');
+    const updateIdx = calls.findIndex((c) => c.sql.includes('UPDATE knowledge_fact'));
+    const insertIdx = calls.findIndex((c) =>
+      c.sql.includes('INSERT RELATION IGNORE INTO memory_support'),
+    );
+    expect(updateIdx).toBeGreaterThanOrEqual(0);
+    expect(insertIdx).toBeGreaterThan(updateIdx);
+    const rows = calls[insertIdx]!.params!.rows as Array<Record<string, unknown>>;
+    expect(rows.map((r) => ({ ...r, in: String(r.in), out: String(r.out) }))).toEqual([
+      {
+        in: 'knowledge_fact:f1',
+        out: 'memory_episode:s1',
+        kind: 'supported_by',
+        writer: 'scene_backlink',
+        writerVersion: SEGMENTER_VERSION,
+      },
+      {
+        in: 'knowledge_fact:f3',
+        out: 'memory_episode:s1',
+        kind: 'supported_by',
+        writer: 'scene_backlink',
+        writerVersion: SEGMENTER_VERSION,
+      },
+    ]);
+    // The stamp UPDATE itself is untouched by the flag.
+    expect(calls[updateIdx]!.params!.factIds).toEqual(['knowledge_fact:f1', 'knowledge_fact:f3']);
+  });
+
+  it('master flag off (SCENES_FACT_BACKLINK unset): no queries at all, either way', async () => {
+    delete process.env.SCENES_FACT_BACKLINK;
+    process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    const { svc, calls } = makeStack();
+    const result = await svc.run('co_x');
+    expect(result).toEqual({ scenes: 0, factsLinked: 0 });
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('FactResolverService — contradicted_by edges at the postResolve seam', () => {
+  function makeStack(outcome: Record<string, unknown>) {
+    const calls: QueryCall[] = [];
+    const db = {
+      query: jest.fn(async (sql: string, params?: Record<string, unknown>) => {
+        calls.push({ sql, params });
+        if (sql.includes('fn::resolve_fact')) return [outcome];
+        return [[]];
+      }),
+    };
+    const factEmbedding = {
+      embed: jest.fn(async () => [0.1]),
+      writeAltEmbeddingIfHype: jest.fn(async () => {}),
+    };
+    const predicateRegistry = {
+      getSnapshot: jest.fn(async () => ({})),
+      policyFor: jest.fn(() => ({ semantics: 'single_active' })),
+    };
+    const svc = new FactResolverService(factEmbedding as never, predicateRegistry as never);
+    return { svc, db, calls };
+  }
+
+  const input = {
+    companyId: 'co_x',
+    entityId: 'knowledge_entity:e1',
+    predicate: 'status',
+    object: 'active customer',
+    confidence: 0.9,
+    validFrom: new Date('2026-01-01T00:00:00Z'),
+    source: {},
+    precomputedEmbedding: [0.1, 0.2],
+  };
+
+  const supportCalls = (calls: QueryCall[]) =>
+    calls.filter((c) => c.sql.includes('memory_support'));
+
+  it('flag OFF (default): NO memory_support query on any verdict', async () => {
+    delete process.env.PROVENANCE_SUPPORT_EDGES;
+    const { svc, db, calls } = makeStack({
+      outcome: 'SUPERSEDED',
+      factId: 'knowledge_fact:new',
+      supersededFactIds: ['knowledge_fact:old'],
+    });
+    await svc.resolve(db as never, input);
+    expect(supportCalls(calls)).toEqual([]);
+  });
+
+  it('flag ON, SUPERSEDED: one INSERT, loser → winner', async () => {
+    process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    const { svc, db, calls } = makeStack({
+      outcome: 'SUPERSEDED',
+      factId: 'knowledge_fact:new',
+      supersededFactIds: ['knowledge_fact:old'],
+    });
+    await svc.resolve(db as never, input);
+    const inserts = supportCalls(calls);
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]!.sql).toContain('INSERT RELATION IGNORE INTO memory_support');
+    const rows = inserts[0]!.params!.rows as Array<Record<string, unknown>>;
+    expect(rows.map((r) => ({ ...r, in: String(r.in), out: String(r.out) }))).toEqual([
+      {
+        in: 'knowledge_fact:old',
+        out: 'knowledge_fact:new',
+        kind: 'contradicted_by',
+        writer: 'fact_resolver',
+      },
+    ]);
+  });
+
+  it('flag ON, COMPETING: the mutual pair per standing competitor', async () => {
+    process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    const { svc, db, calls } = makeStack({
+      outcome: 'COMPETING',
+      factId: 'knowledge_fact:new',
+      competingFactIds: ['knowledge_fact:standing'],
+    });
+    await svc.resolve(db as never, input);
+    const rows = supportCalls(calls)[0]!.params!.rows as Array<Record<string, unknown>>;
+    expect(rows.map((r) => [String(r.in), String(r.out)])).toEqual([
+      ['knowledge_fact:standing', 'knowledge_fact:new'],
+      ['knowledge_fact:new', 'knowledge_fact:standing'],
+    ]);
+  });
+
+  it('flag ON, INSERTED/REJECTED: no edge write', async () => {
+    process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    for (const outcome of ['INSERTED', 'REJECTED']) {
+      const { svc, db, calls } = makeStack({ outcome, factId: 'knowledge_fact:new' });
+      await svc.resolve(db as never, input);
+      expect(supportCalls(calls)).toEqual([]);
+    }
+  });
+
+  it('flag ON: an edge-write failure warns, never fails the ingest', async () => {
+    process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    const { svc, db } = makeStack({
+      outcome: 'SUPERSEDED',
+      factId: 'knowledge_fact:new',
+      supersededFactIds: ['knowledge_fact:old'],
+    });
+    db.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('memory_support')) throw new Error('unique index blew up');
+      if (sql.includes('fn::resolve_fact')) {
+        return [
+          {
+            outcome: 'SUPERSEDED',
+            factId: 'knowledge_fact:new',
+            supersededFactIds: ['knowledge_fact:old'],
+          },
+        ];
+      }
+      return [[]];
+    });
+    const { result } = await svc.resolve(db as never, input);
+    expect(result.outcome).toBe('SUPERSEDED');
+  });
+});

--- a/test/support-edges.unit-spec.ts
+++ b/test/support-edges.unit-spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Typed support graph (Drift-5, 0116) — the pure edge-row assembly
+ * module. Pins the endpoint-pairing verdicts (assertEdgeShape,
+ * reconstructed_from reserved), the (in, out, kind) dedupe with
+ * emission order + SUPPORT_EDGE_CAP, the conflict-verdict directions
+ * (SUPERSEDED loser→winner; COMPETING mutual, capped), and the
+ * EvidenceRef runtime adoption (classifySupportTarget dispatches the
+ * evidence-plane prefixes through parseRecordRef).
+ */
+import {
+  SUPPORT_EDGE_CAP,
+  assertEdgeShape,
+  buildConflictEdgeRows,
+  buildSupportEdgeBatches,
+  buildSupportEdgeRows,
+  classifySupportTarget,
+  isEmittedEdgeKind,
+} from '../src/common/support-edges';
+
+describe('classifySupportTarget (EvidenceRef prefix vocabulary)', () => {
+  it.each([
+    ['knowledge_fact:f1', 'fact'],
+    ['memory_episode:s1', 'scene'],
+    // The three parseRecordRef arms — the evidence plane and the
+    // support graph share ONE prefix vocabulary.
+    ['episode:e1', 'episode'],
+    ['evidence_fragment:fr1', 'fragment'],
+    ['evidence_asset:a1', 'asset'],
+    ['knowledge_entity:e1', 'unknown'],
+    ['', 'unknown'],
+  ])('%s → %s', (raw, expected) => {
+    expect(classifySupportTarget(raw)).toBe(expected);
+  });
+});
+
+describe('assertEdgeShape (endpoint pairing per kind)', () => {
+  it('supported_by: fact → scene only', () => {
+    expect(assertEdgeShape('supported_by', 'knowledge_fact:f1', 'memory_episode:s1')).toBe(true);
+    expect(assertEdgeShape('supported_by', 'knowledge_fact:f1', 'knowledge_fact:f2')).toBe(false);
+    expect(assertEdgeShape('supported_by', 'knowledge_fact:f1', 'episode:e1')).toBe(false);
+    expect(assertEdgeShape('supported_by', 'memory_episode:s1', 'memory_episode:s2')).toBe(false);
+  });
+
+  it('contradicted_by / derived_from: fact → fact only', () => {
+    for (const kind of ['contradicted_by', 'derived_from'] as const) {
+      expect(assertEdgeShape(kind, 'knowledge_fact:f1', 'knowledge_fact:f2')).toBe(true);
+      expect(assertEdgeShape(kind, 'knowledge_fact:f1', 'memory_episode:s1')).toBe(false);
+      expect(assertEdgeShape(kind, 'episode:e1', 'knowledge_fact:f2')).toBe(false);
+    }
+  });
+
+  it('reconstructed_from is RESERVED — always rejected (0106 stays canonical)', () => {
+    expect(assertEdgeShape('reconstructed_from', 'knowledge_fact:f1', 'knowledge_fact:f2')).toBe(
+      false,
+    );
+    expect(assertEdgeShape('reconstructed_from', 'memory_episode:s1', 'episode:e1')).toBe(false);
+  });
+
+  it('isEmittedEdgeKind excludes the reserved kind', () => {
+    expect(isEmittedEdgeKind('supported_by')).toBe(true);
+    expect(isEmittedEdgeKind('reconstructed_from')).toBe(false);
+    expect(isEmittedEdgeKind('bogus')).toBe(false);
+  });
+});
+
+describe('buildSupportEdgeRows (dedupe / order / cap / skip)', () => {
+  it('dedupes by (in, out, kind) preserving emission order; counts skipped', () => {
+    const { rows, skipped } = buildSupportEdgeRows({
+      kind: 'derived_from',
+      writer: 'promotion_runner',
+      pairs: [
+        { in: 'knowledge_fact:sum', out: 'knowledge_fact:m2' },
+        { in: 'knowledge_fact:sum', out: 'knowledge_fact:m1' },
+        { in: 'knowledge_fact:sum', out: 'knowledge_fact:m2' }, // dupe
+        { in: 'knowledge_fact:sum', out: 'memory_episode:bad' }, // wrong shape
+      ],
+    });
+    expect(rows.map((r) => r.out)).toEqual(['knowledge_fact:m2', 'knowledge_fact:m1']);
+    expect(rows[0]).toEqual({
+      in: 'knowledge_fact:sum',
+      out: 'knowledge_fact:m2',
+      kind: 'derived_from',
+      writer: 'promotion_runner',
+    });
+    expect(skipped).toBe(1);
+  });
+
+  it('writerVersion is carried only when supplied', () => {
+    const { rows } = buildSupportEdgeRows({
+      kind: 'supported_by',
+      writer: 'scene_backlink',
+      writerVersion: 'seg-v9',
+      pairs: [{ in: 'knowledge_fact:f1', out: 'memory_episode:s1' }],
+    });
+    expect(rows[0]!.writerVersion).toBe('seg-v9');
+  });
+
+  it(`caps a single call at SUPPORT_EDGE_CAP (${SUPPORT_EDGE_CAP})`, () => {
+    const pairs = Array.from({ length: SUPPORT_EDGE_CAP + 10 }, (_, i) => ({
+      in: 'knowledge_fact:sum',
+      out: `knowledge_fact:m${i}`,
+    }));
+    const { rows } = buildSupportEdgeRows({ kind: 'derived_from', writer: 'recompose', pairs });
+    expect(rows).toHaveLength(SUPPORT_EDGE_CAP);
+    expect(rows[0]!.out).toBe('knowledge_fact:m0');
+  });
+
+  it('buildSupportEdgeBatches slices the full deduped set into cap-sized payloads', () => {
+    const pairs = Array.from({ length: SUPPORT_EDGE_CAP + 10 }, (_, i) => ({
+      in: 'knowledge_fact:sum',
+      out: `knowledge_fact:m${i}`,
+    }));
+    const { batches, skipped } = buildSupportEdgeBatches({
+      kind: 'derived_from',
+      writer: 'compaction_runner',
+      pairs: [...pairs, ...pairs], // full duplicate — deduped away
+    });
+    expect(skipped).toBe(0);
+    expect(batches.map((b) => b.length)).toEqual([SUPPORT_EDGE_CAP, 10]);
+    expect(batches[1]![9]!.out).toBe(`knowledge_fact:m${SUPPORT_EDGE_CAP + 9}`);
+  });
+
+  it('nothing valid → zero batches (writers then issue zero queries)', () => {
+    const { batches, skipped } = buildSupportEdgeBatches({
+      kind: 'supported_by',
+      writer: 'scene_backlink',
+      pairs: [{ in: 'knowledge_fact:f1', out: 'episode:not-a-scene' }],
+    });
+    expect(batches).toEqual([]);
+    expect(skipped).toBe(1);
+  });
+});
+
+describe('buildConflictEdgeRows (resolver verdicts → contradicted_by)', () => {
+  const CAP = 20;
+
+  it('SUPERSEDED: one edge per displaced fact, in = LOSER, out = WINNER', () => {
+    const rows = buildConflictEdgeRows(
+      {
+        outcome: 'SUPERSEDED',
+        factId: 'knowledge_fact:winner',
+        supersededFactIds: ['knowledge_fact:loser1', 'knowledge_fact:loser2'],
+      },
+      CAP,
+    );
+    expect(rows).toEqual([
+      {
+        in: 'knowledge_fact:loser1',
+        out: 'knowledge_fact:winner',
+        kind: 'contradicted_by',
+        writer: 'fact_resolver',
+      },
+      {
+        in: 'knowledge_fact:loser2',
+        out: 'knowledge_fact:winner',
+        kind: 'contradicted_by',
+        writer: 'fact_resolver',
+      },
+    ]);
+  });
+
+  it('COMPETING: the MUTUAL pair per standing competitor (new fact excluded as its own rival)', () => {
+    const rows = buildConflictEdgeRows(
+      {
+        outcome: 'COMPETING',
+        factId: 'knowledge_fact:new',
+        competingFactIds: ['knowledge_fact:standing', 'knowledge_fact:new'],
+      },
+      CAP,
+    );
+    expect(rows.map((r) => [r.in, r.out])).toEqual([
+      ['knowledge_fact:standing', 'knowledge_fact:new'],
+      ['knowledge_fact:new', 'knowledge_fact:standing'],
+    ]);
+  });
+
+  it('COMPETING fan-out is capped (the CONFLICT_OUTCOME_CAP idiom, applied to edges)', () => {
+    const rows = buildConflictEdgeRows(
+      {
+        outcome: 'COMPETING',
+        factId: 'knowledge_fact:new',
+        competingFactIds: Array.from({ length: 30 }, (_, i) => `knowledge_fact:c${i}`),
+      },
+      CAP,
+    );
+    expect(rows).toHaveLength(CAP);
+  });
+
+  it.each(['INSERTED', 'CORROBORATED', 'REJECTED', 'SKIPPED'])('%s → no rows', (outcome) => {
+    expect(buildConflictEdgeRows({ outcome, factId: 'knowledge_fact:x' }, CAP)).toEqual([]);
+  });
+
+  it('no factId (nothing to point at) → no rows, even on SUPERSEDED', () => {
+    expect(
+      buildConflictEdgeRows(
+        { outcome: 'SUPERSEDED', factId: null, supersededFactIds: ['knowledge_fact:l'] },
+        CAP,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/test/support-graph.e2e-spec.ts
+++ b/test/support-graph.e2e-spec.ts
@@ -1,0 +1,323 @@
+/**
+ * Typed support graph e2e (Drift-5, real SurrealDB): the 0116
+ * memory_support table end-to-end —
+ *   (1) INSERT RELATION IGNORE is replay-idempotent on the REAL pinned
+ *       server (the scene-backlink writer runs twice, the direct
+ *       derived_from insert replays twice — UNIQUE(in, out, kind)
+ *       dedupes both);
+ *   (2) the conflict resolver records the COMPETING mutual pair;
+ *   (3) GET /v1/facts/:id/provenance with the read flag on serves
+ *       supportEdges, and a root with typed edges but an EMPTY
+ *       derivedFrom array walks;
+ *   (4) read flag off → NO supportEdges key (byte-identical response);
+ *   (5) user-forget erases every edge touching the user's facts —
+ *       with the write flag OFF at forget time (GDPR runs regardless).
+ */
+import { StringRecordId } from 'surrealdb';
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { SceneBacklinkService } from '../src/admin/scene-backlink.service';
+import { SEGMENTER_VERSION } from '../src/admin/scene-segmentation';
+import { FactResolverService } from '../src/ingest/fact-resolver.service';
+import { PredicateRegistryService } from '../src/ai/predicate-registry.service';
+import { UserForgetService } from '../src/entities/user-forget.service';
+
+const FLAG_KEYS = [
+  'FACTS_API_ENABLED',
+  'PROVENANCE_RECURSIVE_CLOSURE',
+  'PROVENANCE_SUPPORT_EDGES',
+  'PROVENANCE_SUPPORT_GRAPH_READ',
+  'SCENES_FACT_BACKLINK',
+] as const;
+const savedEnv = new Map<string, string | undefined>();
+
+describe('typed support graph (real SurrealDB)', () => {
+  let f: AppFixture;
+  let surreal: SurrealService;
+  let entityId = '';
+  let backlinkFactId = '';
+  let sceneId = '';
+  let standingFactId = '';
+  let newFactId = '';
+  let summaryId = '';
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const countEdges = async (where: string, params: Record<string, unknown> = {}) =>
+    surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM memory_support ${where} GROUP ALL`,
+        params,
+      );
+      return rows?.[0]?.n ?? 0;
+    });
+
+  beforeAll(async () => {
+    for (const k of FLAG_KEYS) savedEnv.set(k, process.env[k]);
+    process.env.FACTS_API_ENABLED = '1';
+    process.env.PROVENANCE_RECURSIVE_CLOSURE = '1';
+    process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    process.env.PROVENANCE_SUPPORT_GRAPH_READ = '1';
+    process.env.SCENES_FACT_BACKLINK = '1';
+    f = await createApp({ companyId: 'co_support_graph_e2e' });
+    surreal = f.app.get(SurrealService);
+
+    await surreal.withCompany(f.companyId, async (db) => {
+      const [entRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE knowledge_entity CONTENT { type: 'customer', canonicalName: 'Support Graph Subject' }`,
+      );
+      entityId = String(entRows[0]!.id);
+
+      // Two verbatim turns + one scene over them (composer-shaped rows).
+      const [epRows] = await db.query<[Array<{ id: unknown }>]>(`INSERT INTO episode $rows`, {
+        rows: [
+          {
+            kind: 'turn',
+            conversationId: 'conv_sg',
+            messageId: 'sg1',
+            speaker: 'user',
+            text: 'the lease was renewed in March',
+            occurredAt: new Date('2026-07-01T10:00:00Z'),
+            source: {},
+          },
+          {
+            kind: 'turn',
+            conversationId: 'conv_sg',
+            messageId: 'sg2',
+            speaker: 'assistant',
+            text: 'noted — renewal recorded',
+            occurredAt: new Date('2026-07-01T10:01:00Z'),
+            source: {},
+          },
+        ],
+      });
+      const episodeRefs = (epRows ?? []).map((r) => r.id);
+      const episodeIds = episodeRefs.map(String);
+
+      const [sceneRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE memory_episode CONTENT $scene`,
+        {
+          scene: {
+            sceneLabel: 'lease renewal',
+            conversationIds: ['conv_sg'],
+            occurredFrom: new Date('2026-07-01T10:00:00Z'),
+            occurredTo: new Date('2026-07-01T10:01:00Z'),
+            gist: 'user: the lease was renewed in March',
+            confidence: 0.9,
+            segmenterVersion: SEGMENTER_VERSION,
+            generation: 'gen-e2e',
+            source: {},
+          },
+        },
+      );
+      sceneId = String(sceneRows[0]!.id);
+      await db.query(`INSERT RELATION INTO memory_episode_member $rows`, {
+        rows: episodeRefs.map((out, ord) => ({
+          in: sceneRows[0]!.id,
+          out,
+          role: 'core',
+          ord,
+          relevance: 1,
+          segmenterVersion: SEGMENTER_VERSION,
+        })),
+      });
+
+      // A grounded fact inside the scene's conversation — the backlink
+      // writer stamps it AND (flag on) emits the supported_by edge.
+      const [factRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE knowledge_fact CONTENT $fact`,
+        {
+          fact: {
+            entityId: entRows[0]!.id,
+            predicate: 'said',
+            object: 'the lease was renewed in March',
+            confidence: 0.9,
+            validFrom: new Date('2026-07-01T00:00:00Z'),
+            status: 'active',
+            source: { kind: 'fact', conversationId: 'conv_sg', episodeIds: [episodeIds[0]] },
+          },
+        },
+      );
+      backlinkFactId = String(factRows[0]!.id);
+    });
+  });
+
+  afterAll(async () => {
+    for (const k of FLAG_KEYS) {
+      const v = savedEnv.get(k);
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await f.close();
+  });
+
+  it('scene backlink emits supported_by edges; a re-run inserts NOTHING new (IGNORE proven)', async () => {
+    const backlink = f.app.get(SceneBacklinkService);
+    const first = await backlink.run(f.companyId);
+    expect(first.factsLinked).toBe(1);
+    const afterFirst = await countEdges(`WHERE kind = 'supported_by'`);
+    expect(afterFirst).toBe(1);
+
+    // Replay — same scene ids, same fact: INSERT RELATION IGNORE over
+    // UNIQUE(in, out, kind) must dedupe on the REAL pinned server.
+    await backlink.run(f.companyId);
+    expect(await countEdges(`WHERE kind = 'supported_by'`)).toBe(1);
+
+    const rows = await surreal.withCompany(f.companyId, async (db) => {
+      const [r] = await db.query<[Array<{ in: unknown; out: unknown; writer: string }>]>(
+        `SELECT in, out, writer, writerVersion FROM memory_support WHERE kind = 'supported_by'`,
+      );
+      return r ?? [];
+    });
+    expect(String(rows[0]!.in)).toBe(backlinkFactId);
+    expect(String(rows[0]!.out)).toBe(sceneId);
+    expect(rows[0]!.writer).toBe('scene_backlink');
+  });
+
+  it('a COMPETING resolver verdict records the mutual contradicted_by pair', async () => {
+    // single_active ALWAYS supersedes (the V9 slot doctrine — see
+    // 0085's `$supersede`), so a genuine standoff needs a `bitemporal`
+    // predicate: overlapping validity + cosine-similar values + a score
+    // margin below margin_for_supersede ⇒ COMPETING, deterministically.
+    // No CORE seed is bitemporal — register a tenant predicate.
+    const registry = f.app.get(PredicateRegistryService);
+    await registry.create(f.companyId, {
+      predicateId: 'observed_state',
+      semantics: 'bitemporal',
+      piiClass: 'none',
+    });
+    registry.invalidate(f.companyId);
+
+    const resolver = f.app.get(FactResolverService);
+    const embedding = Array.from({ length: 8 }, (_, i) => (i === 0 ? 1 : 0));
+    const base = {
+      companyId: f.companyId,
+      entityId,
+      predicate: 'observed_state',
+      confidence: 0.9,
+      validFrom: new Date('2026-07-02T00:00:00Z'),
+      source: {},
+      precomputedEmbedding: embedding,
+      userId: 'user-gone',
+    };
+    const first = await surreal.withCompany(f.companyId, (db) =>
+      resolver.resolve(db, { ...base, object: 'gold tier' }),
+    );
+    expect(first.result.outcome).toBe('INSERTED');
+    standingFactId = String(first.result.factId);
+
+    // Identical embedding (similarity 1 ≥ threshold), overlapping
+    // open-ended validity, same confidence/trust/authority and
+    // near-equal recency ⇒ score margin ≈ 0 < margin_for_supersede ⇒
+    // COMPETING.
+    const second = await surreal.withCompany(f.companyId, (db) =>
+      resolver.resolve(db, { ...base, object: 'platinum tier' }),
+    );
+    expect(second.result.outcome).toBe('COMPETING');
+    newFactId = String(second.result.factId);
+
+    const pair = await surreal.withCompany(f.companyId, async (db) => {
+      const [r] = await db.query<[Array<{ in: unknown; out: unknown }>]>(
+        `SELECT in, out FROM memory_support WHERE kind = 'contradicted_by'`,
+      );
+      return (r ?? []).map((e) => [String(e.in), String(e.out)]).sort();
+    });
+    expect(pair).toEqual(
+      [
+        [standingFactId, newFactId],
+        [newFactId, standingFactId],
+      ].sort(),
+    );
+  });
+
+  it('provenance serves supportEdges; a root with EMPTY derivedFrom walks via typed edges', async () => {
+    // A summary WITHOUT a derivedFrom array — only the typed edge
+    // carries the derivation. Insert the edge TWICE: the replay is the
+    // direct db-level INSERT RELATION IGNORE idempotency proof.
+    await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ id: unknown }>]>(`CREATE knowledge_fact CONTENT $f`, {
+        f: {
+          // Record-id param — 3.x does not coerce string↔record.
+          entityId: new StringRecordId(entityId),
+          predicate: 'summary_said',
+          object: 'Lease renewal summarized.',
+          confidence: 0.9,
+          validFrom: new Date('2026-07-03T00:00:00Z'),
+          status: 'active',
+          source: { kind: 'promotion' },
+        },
+      });
+      summaryId = String(rows[0]!.id);
+      for (let i = 0; i < 2; i++) {
+        await db.query(`INSERT RELATION IGNORE INTO memory_support $rows`, {
+          rows: [
+            {
+              in: rows[0]!.id,
+              out: new StringRecordId(backlinkFactId),
+              kind: 'derived_from',
+              writer: 'promotion_runner',
+            },
+          ],
+        });
+      }
+    });
+    expect(await countEdges(`WHERE kind = 'derived_from'`)).toBe(1);
+
+    const res = await f.http
+      .get(`/v1/facts/${encodeURIComponent(summaryId)}/provenance`)
+      .set(auth());
+    expect(res.status).toBe(200);
+    // The edge-discovered child (depth 1) — derivedFrom array is EMPTY.
+    expect(res.body.derivedFacts).toEqual([
+      { factId: backlinkFactId, predicate: 'said', depth: 1, status: 'active' },
+    ]);
+    // Crossed edges: the summary's derived_from + the member's
+    // supported_by (backlink test above).
+    expect(res.body.supportEdges).toEqual(
+      expect.arrayContaining([
+        { kind: 'derived_from', from: summaryId, to: backlinkFactId },
+        { kind: 'supported_by', from: backlinkFactId, to: sceneId },
+      ]),
+    );
+    // Grounding harvested THROUGH the edge-discovered member.
+    expect(res.body.episodes.map((e: { text: string }) => e.text)).toEqual([
+      'the lease was renewed in March',
+    ]);
+  });
+
+  it('read flag OFF: the provenance response has NO supportEdges key (byte-identical)', async () => {
+    process.env.PROVENANCE_SUPPORT_GRAPH_READ = '0';
+    try {
+      const res = await f.http
+        .get(`/v1/facts/${encodeURIComponent(summaryId)}/provenance`)
+        .set(auth());
+      expect(res.status).toBe(200);
+      // Root has an EMPTY derivedFrom array ⇒ without the read flag the
+      // one-hop path serves — no closure fields, no supportEdges.
+      expect(res.body).not.toHaveProperty('supportEdges');
+      expect(res.body).not.toHaveProperty('derivedFacts');
+    } finally {
+      process.env.PROVENANCE_SUPPORT_GRAPH_READ = '1';
+    }
+  });
+
+  it('user-forget erases the user facts’ edges with the write flag OFF (GDPR runs regardless)', async () => {
+    // Fail fast on a cascade from the resolver test — an empty record
+    // id must never reach a query param.
+    expect(standingFactId).not.toBe('');
+    expect(newFactId).not.toBe('');
+    process.env.PROVENANCE_SUPPORT_EDGES = '0';
+    try {
+      await f.app.get(UserForgetService).forgetUser(f.companyId, 'user-gone');
+    } finally {
+      process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    }
+    expect(
+      await countEdges(`WHERE in INSIDE $subjects OR out INSIDE $subjects`, {
+        subjects: [standingFactId, newFactId].map((id) => new StringRecordId(id)),
+      }),
+    ).toBe(0);
+    // The unrelated tenant-global edges survive.
+    expect(await countEdges(`WHERE kind = 'supported_by'`)).toBe(1);
+    expect(await countEdges(`WHERE kind = 'derived_from'`)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Drift-5: canonical typed support edges instead of write-only strings and untyped arrays — ONE polymorphic `SCHEMAFULL TYPE RELATION` table **`memory_support`** (migration **0116**) with `UNIQUE(in, out, kind)`, untyped `record` endpoints (TS-side `assertEdgeShape` enforces pairing), and the 0106 doctrine adopted verbatim (plain `WHERE in/out` reads only, never graph-arrow syntax).

Kinds and directions (`in` = the claim being supported/contradicted/derived):
- `supported_by` — knowledge_fact → memory_episode (scene)
- `contradicted_by` — loser fact → winner fact (SUPERSEDED: one edge; COMPETING: the mutual pair, capped by the CONFLICT_OUTCOME_CAP idiom)
- `derived_from` — summary fact → member fact (typed mirror of the untyped `derivedFrom` array)
- `reconstructed_from` — RESERVED enum slot only; scene→turn membership stays in `memory_episode_member` (0106), no writer emits it

## Flags (both default-off, byte-identical off)

- **`PROVENANCE_SUPPORT_EDGES`** (write): scene-backlink emits fact-`supported_by`->scene edges ALONGSIDE the legacy `source.memoryEpisodeIds` stamps (stamps untouched — removal is a separate cleanup once the typed reader is proven); the conflict resolver records `contradicted_by` at the `postResolve`/`emitConflictOutcomes` seam (outside the KeyedMutex, best-effort warn-never-fail); promotion/compaction insert the `derived_from` mirror of the exact array written; recompose REPLACES its summary's mirror (two-step LET-select-ids → DELETE, then re-insert) because it rewrites `derivedFrom`.
- **`PROVENANCE_SUPPORT_GRAPH_READ`** (read): the provenance closure walk gains an optional `fetchEdges` callback — ONE batched `SELECT … WHERE in INSIDE $ids` per depth. `derived_from` targets join the generation through the SAME visited set and fact budget; crossed edges are served in a new additive-optional `supportEdges` response field; a root with typed edges but an EMPTY `derivedFrom` array now walks. Walker without `fetchEdges` is byte-identical (pinned by the extended unit spec and by every pre-existing closure spec running unchanged).

Both registered in `KNOWN_BOOLEAN_FLAGS` + `CONFIG_CATALOG` (category `pipeline`); neither matches `ENGINE_PREFIX` (PROVENANCE_ family sits off the flag budget).

## Verified against the pinned server (surrealdb 3.2.4)

- `DEFINE TABLE … TYPE RELATION` without FROM/TO works — the 0106-documented plain-table fallback was **not** needed.
- `INSERT RELATION IGNORE INTO memory_support` composes and silently dedupes a UNIQUE(in,out,kind) replay — proven in a direct probe AND in the e2e (the scene-backlink writer re-run inserts nothing; a direct edge replay counts 1).
- The 3.2.4 planner bug was **reproduced live on this exact table** during the smoke: `DELETE memory_support WHERE in INSIDE […]` returned OK and deleted ZERO rows while the same WHERE in a SELECT matched — every deleter uses the mandatory `LET $ids = (SELECT VALUE id …); DELETE $ids;` idiom, and `test/audit-p1-guards.unit-spec.ts` walks all of src/ asserting no `DELETE memory_support WHERE` shape exists (comment lines excluded).

## GDPR (runs regardless of flags)

Both forget services erase `memory_support` rows unconditionally (the EVIDENCE_SUBSTRATE_ENABLED precedent: rows written while the flag was on must stay erasable after off):
- `user-forget`: subjects = the user's fact ids + every dying scene id (own-user scenes pre-collected BEFORE their delete; mixed-user scenes joined from the by-reference branch), one two-step delete.
- `entity-forget`: inside the atomic tx — `$entFactIds` pre-collected BEFORE `DELETE knowledge_fact WHERE entityId = $ent`, subjects = entity fact ids (either endpoint) + `$sceneIds`; uncounted in txRecordCount like fact_usage.

This is the ONLY unconditional behavior change (plus the new empty table from the migration) — argued deliberate per the precedent above.

## EvidenceRef runtime adoption

`parseRecordRef` gains its first runtime callers: `classifySupportTarget` (src/common/support-edges.ts) dispatches the evidence-plane prefixes through it, and the closure walker uses that classification to gate which `derived_from` targets are walkable facts. Deviation from the brief noted below.

## Off-state byte-identity

- Writer specs pin exact query sequences with the flag off (scene-backlink golden statement list; resolver/promotion/compaction/recompose: zero `memory_support` statements).
- Walker result with `fetchEdges` absent deep-equals the pre-change shape on every pre-existing field; `edges` is always `[]` there. Every pre-existing closure/backlink/compaction/recompose spec runs unchanged.
- `FactProvenanceResponse` has no `supportEdges` key with the read flag off (asserted in the e2e); openapi regenerated into BOTH copies (additive optional field only).

## Deviations from the brief (trust-the-code rule)

1. **`unionEvidenceRefs` is not called by the scene-backlink writer.** Its prefix vocabulary (episode:/evidence_fragment:/evidence_asset:) excludes both edge endpoints (knowledge_fact:/memory_episode:), so a literal call would filter every id out. The EvidenceRef adoption is `parseRecordRef` via `classifySupportTarget` (walker + writers' shape checks); the dedupe/order/cap-64 idiom of `unionEvidenceRefs` is replicated in `buildSupportEdgeRows` and documented as such.
2. **Walker result field `edges` is always present (`[]` when `fetchEdges` absent)** per the brief's own item 10; byte-identity is pinned on every pre-existing field. The WIRE field `supportEdges` is strictly flag-keyed (absent when off).
3. **`buildSupportEdgeBatches`** added next to the brief's `buildSupportEdgeRows`: the cap is 64 per INSERT payload, but a scene can match >64 facts — the batched form slices the deduped set so no edge is silently lost; `buildSupportEdgeRows` remains the single-call capped primitive.
4. **`supportEdges` is present-but-empty when the read flag is on and no edges were crossed** (flag-keyed presence, not content-keyed) — still additive-optional on the wire.
5. The three summary writers share `src/compaction/support-edge-mirror.ts` (insert/replace helpers) instead of triplicating the insert loop; the fact-resolver change stays tight (one import line + one private method + one call) to ease rebases against feat/evidence-grounding-status.

## Migration number

`0116_memory_support.surql` — `ls src/db/migrations` confirmed 0114/0115 absent in this tree (reserved by the port PR and drift-1 per coordination), 0116 free.

## Test plan

- Unit: `test/support-edges.unit-spec.ts` (pure module: shapes, dedupe/cap/order, conflict directions incl. mutual COMPETING + cap 20, EvidenceRef classification), `test/support-edge-writers.unit-spec.ts` (scene-backlink golden off-sequence + on-payload; resolver off/on/failure-tolerance), extended `test/provenance-closure.unit-spec.ts` (absent-callback byte-identity, edge children through shared visited/budget, cycle termination, edge cap → truncated.fanout, non-fact targets reported-not-walked), extended `test/compaction.unit-spec.ts` + `test/recompose.unit-spec.ts` (derived_from mirrors on/off; recompose two-step delete string-pinned), extended `test/forget-l0-cascade.unit-spec.ts` (cascade with BOTH flags off), extended `test/audit-p1-guards.unit-spec.ts` (0116 index tuples incl. UNIQUE(in,out,kind), no-changefeed/no-event, GDPR two-step guard, src-wide DELETE-WHERE ban), `test/contracts-facts.unit-spec.ts` parity sample.
- e2e (real SurrealDB): new `test/support-graph.e2e-spec.ts` — backlink writer re-run idempotency (IGNORE proven on the pinned server), resolver COMPETING mutual pair, provenance `supportEdges` + empty-derivedFrom root walking via typed edges, read-flag-off response without the key, user-forget erasure with the write flag OFF; `test/fact-provenance-closure.e2e-spec.ts` re-run untouched (read-flag-off regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
