### PR TITLE
fix(ci): unblock build-test — 30-min timeout + modality-only memoryModel acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,12 @@ permissions:
 jobs:
   build-test:
     runs-on: ubuntu-latest
-    # 20, not 15: now that the boot bug is fixed the e2e suite actually
-    # runs to completion (it used to crash instantly), and CI gained the
-    # unit + jobs-real steps. Two testcontainer lifecycles + cold installs
-    # need headroom; forceExit (jest configs) prevents the post-suite hang.
-    timeout-minutes: 20
+    # 30, not 20: the serialized e2e suite (maxWorkers 1, 2026-08 CI-stability
+    # fix) plus the growing suite count runs 18-20+ min on cold runners, and
+    # jobs were dying at exactly 20:00 as spurious "cancelled" conclusions.
+    # Two testcontainer lifecycles + cold installs need headroom; forceExit
+    # (jest configs) prevents the post-suite hang.
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/src/admin/domain-pack-install.service.ts
+++ b/src/admin/domain-pack-install.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import type { Surreal } from 'surrealdb';
 import { SurrealService, queryRows } from '../db/surreal.service';
+import { retryOnUniqueViolation } from '../db/surreal-retry';
 import { JobClaimService } from '../jobs/job-claim.service';
 import { envFlagEnabled } from '../common/env-validation';
 import { EmbedderService } from '../ai/embedder.service';
@@ -273,87 +274,103 @@ export class DomainPackInstallService {
       ? `, acceptedModalities = true, acceptedModalitiesChecksum = $modalityChecksum`
       : `, acceptedModalities = NONE, acceptedModalitiesChecksum = NONE`;
     let mintedInstallId: string | undefined;
-    const seeded = await this.surreal.withCompany(companyId, async (db) => {
-      const existing = await queryRows<DomainPackRow>(
-        db,
-        `SELECT id, version, manifest, webhookSecret, installId, acceptedMcpTools, acceptedMcpToolsChecksum, acceptedModalities, acceptedModalitiesChecksum FROM domain_pack WHERE packId = $packId LIMIT 1`,
-        { packId: manifest.id },
-      );
-      const row = existing[0];
-      const consentMessage = mcpConsentRequired({
-        manifest,
-        acceptMcpTools: opts.acceptMcpTools,
-        priorAccepted: row?.acceptedMcpTools === true,
-        priorChecksum: row?.acceptedMcpToolsChecksum ? String(row.acceptedMcpToolsChecksum) : null,
-      });
-      if (consentMessage) throw new BadRequestException(consentMessage);
-      const modalityMessage = modalityConsentRequired({
-        packId: manifest.id,
-        version: manifest.version,
-        declared: modalitySection,
-        accepted: opts.acceptModalities,
-        priorAccepted: row?.acceptedModalities === true,
-        priorChecksum: row?.acceptedModalitiesChecksum
-          ? String(row.acceptedModalitiesChecksum)
-          : null,
-      });
-      if (modalityMessage) throw new BadRequestException(modalityMessage);
-      // installId (0068) — the opaque per-install identity external tool
-      // endpoints see instead of companyId. Minted once, kept forever.
-      if (externalTools.length > 0 && !row?.installId) {
-        mintedInstallId = randomUUID();
-      }
-      if (row) {
-        mintedSecret = await this.applyPackUpgrade({
+    // Concurrent installs of the same pack both pass the SELECT (no prior
+    // row) and race to CREATE; on the rocksdb backend the loser surfaces
+    // either a unique violation or a commit-time OCC "read or write
+    // conflict" that would otherwise escape as a raw 500 through the
+    // ExceptionsHandler. retryOnUniqueViolation re-runs the closure — the
+    // retry's SELECT sees the winner's row and takes the upgrade path
+    // (same mold as PackRegistryService.publish).
+    const seeded = await this.surreal.withCompany(companyId, (db) =>
+      retryOnUniqueViolation(async () => {
+        // Attempt-scoped state: a retry that now sees the racing
+        // committer's row must not carry a stale minted identity/secret
+        // into the upgrade path (it would overwrite the winner's).
+        mintedSecret = undefined;
+        mintedInstallId = undefined;
+        const existing = await queryRows<DomainPackRow>(
           db,
-          row,
+          `SELECT id, version, manifest, webhookSecret, installId, acceptedMcpTools, acceptedMcpToolsChecksum, acceptedModalities, acceptedModalitiesChecksum FROM domain_pack WHERE packId = $packId LIMIT 1`,
+          { packId: manifest.id },
+        );
+        const row = existing[0];
+        const consentMessage = mcpConsentRequired({
           manifest,
-          checksum,
-          newIds,
-          mint: {
-            wantsWebhook,
-            mintedInstallId,
-            mcpChecksum,
-            mcpSet,
-            modalityChecksum,
-            modalitySet,
-          },
+          acceptMcpTools: opts.acceptMcpTools,
+          priorAccepted: row?.acceptedMcpTools === true,
+          priorChecksum: row?.acceptedMcpToolsChecksum
+            ? String(row.acceptedMcpToolsChecksum)
+            : null,
         });
-      } else {
-        if (wantsWebhook) {
-          mintedSecret = randomBytes(32).toString('hex');
+        if (consentMessage) throw new BadRequestException(consentMessage);
+        const modalityMessage = modalityConsentRequired({
+          packId: manifest.id,
+          version: manifest.version,
+          declared: modalitySection,
+          accepted: opts.acceptModalities,
+          priorAccepted: row?.acceptedModalities === true,
+          priorChecksum: row?.acceptedModalitiesChecksum
+            ? String(row.acceptedModalitiesChecksum)
+            : null,
+        });
+        if (modalityMessage) throw new BadRequestException(modalityMessage);
+        // installId (0068) — the opaque per-install identity external tool
+        // endpoints see instead of companyId. Minted once, kept forever.
+        if (externalTools.length > 0 && !row?.installId) {
+          mintedInstallId = randomUUID();
         }
-        await db.query(`CREATE domain_pack CONTENT $content`, {
-          content: {
-            packId: manifest.id,
-            version: manifest.version,
+        if (row) {
+          mintedSecret = await this.applyPackUpgrade({
+            db,
+            row,
             manifest,
             checksum,
-            status: 'active',
-            ...(mintedSecret ? { webhookSecret: mintedSecret } : {}),
-            ...(mintedInstallId ? { installId: mintedInstallId } : {}),
-            ...(mcpChecksum
-              ? {
-                  acceptedMcpTools: true,
-                  acceptedMcpToolsChecksum: mcpChecksum,
-                }
-              : {}),
-            ...(modalityChecksum
-              ? {
-                  acceptedModalities: true,
-                  acceptedModalitiesChecksum: modalityChecksum,
-                }
-              : {}),
-          },
+            newIds,
+            mint: {
+              wantsWebhook,
+              mintedInstallId,
+              mcpChecksum,
+              mcpSet,
+              modalityChecksum,
+              modalitySet,
+            },
+          });
+        } else {
+          if (wantsWebhook) {
+            mintedSecret = randomBytes(32).toString('hex');
+          }
+          await db.query(`CREATE domain_pack CONTENT $content`, {
+            content: {
+              packId: manifest.id,
+              version: manifest.version,
+              manifest,
+              checksum,
+              status: 'active',
+              ...(mintedSecret ? { webhookSecret: mintedSecret } : {}),
+              ...(mintedInstallId ? { installId: mintedInstallId } : {}),
+              ...(mcpChecksum
+                ? {
+                    acceptedMcpTools: true,
+                    acceptedMcpToolsChecksum: mcpChecksum,
+                  }
+                : {}),
+              ...(modalityChecksum
+                ? {
+                    acceptedModalities: true,
+                    acceptedModalitiesChecksum: modalityChecksum,
+                  }
+                : {}),
+            },
+          });
+        }
+        return seedMissingPredicates({
+          db,
+          predicates,
+          embedder: this.embedder,
+          log: (m) => this.logger.log(`[pack ${manifest.id}] ${m}`),
         });
-      }
-      return seedMissingPredicates({
-        db,
-        predicates,
-        embedder: this.embedder,
-        log: (m) => this.logger.log(`[pack ${manifest.id}] ${m}`),
-      });
-    });
+      }),
+    );
 
     this.registry.invalidate(companyId);
     this.packToolsReader?.invalidate(companyId);

--- a/src/ai/domain-packs/validate-memory-model.ts
+++ b/src/ai/domain-packs/validate-memory-model.ts
@@ -120,6 +120,13 @@ interface MemoryModelShape {
   attentionHints?: unknown;
   verificationRules?: unknown;
   retentionHints?: unknown;
+  /** Modality-era keys (0112 consent tier): accepted as substantive
+   *  sections so a modality-only memoryModel is a valid manifest. Their
+   *  contents are consumed via the documented defensive accessor in
+   *  ./modality-consent.ts (declaredModalitySection); full structural
+   *  validation arrives with the P-track manifest field. */
+  modalities?: unknown;
+  rawEvidence?: unknown;
 }
 
 /**
@@ -139,10 +146,12 @@ export function validateMemoryModel(pack: DomainPackManifest, mm: unknown): void
     model.attentionHints,
     model.verificationRules,
     model.retentionHints,
+    model.modalities,
+    model.rawEvidence,
   ].filter((v) => v !== undefined);
   if (declared.length === 0) {
     throw new DomainPackError(
-      `pack "${pack.id}" memoryModel must declare at least one of sceneSchemas|stateModels|attentionHints|verificationRules|retentionHints (omit the section instead of declaring it empty)`,
+      `pack "${pack.id}" memoryModel must declare at least one of sceneSchemas|stateModels|attentionHints|verificationRules|retentionHints|modalities|rawEvidence (omit the section instead of declaring it empty)`,
     );
   }
   const sceneIds = validateSceneSchemas(pack.id, model.sceneSchemas);


### PR DESCRIPTION
## Why

Two independent build-test blockers, both live on `main`:

1. **Spurious 20:00 cancellations.** `build-test` has been dying with a `cancelled` conclusion at exactly 20:00 elapsed (e.g. run 33021351847: started 22:55:39, cancelled 23:15:55). The job's `timeout-minutes: 20` no longer fits: the 2026-08 CI-stability fix serialized the in-process e2e suite (`maxWorkers: 1`) to kill the native-model OOM flake, and the suite count has kept growing — cold-runner wall time is now 18-20+ minutes, so marginal runs hit the timeout and read like infra cancellations.

2. **`main` itself is red: a #381 × #380 merge collision.** `test/pack-modality-consent.e2e-spec.ts` fails 4/5 tests deterministically. PR #381's memoryModel validator requires at least one substantive section, but its list predates the modality-era keys; PR #380's consent manifests declare `memoryModel: {modalities, rawEvidence}` only, so the emptiness rejection fires before the `acceptModalities` consent logic ever runs. Each PR was green individually — they collided at merge. Full analysis in the PR #389 comment thread.

## What

- `build-test` `timeout-minutes`: 20 → 30, with the comment updated to record the real sizing rationale. No other job budgets touched.
- `validate-memory-model.ts`: accept `modalities` and `rawEvidence` as substantive memoryModel sections. Deliberately a strict subset of the `audit/multimodal-release` validator expansion (which also adds `processors` plus full structural validation), so the later port lands on top without conflict; the sections' contents remain consumed via the documented defensive accessor (`declaredModalitySection`).
- `domain-pack-install.service.ts`: wrap the install write path in `retryOnUniqueViolation`. A CI log line showed a SurrealDB commit-time OCC abort ("read or write conflict; this transaction can be retried") escaping as a raw 500 via the ExceptionsHandler — the install closure runs the classic SELECT-then-CREATE race with no retry while the equivalent registry publish path already wraps it. `mintedSecret`/`mintedInstallId` are reset per attempt so a retry cannot overwrite the racing winner's install identity.

## Verification

- Baseline repro on the unmodified validator: 4 failed / 1 passed, exactly the diagnosed emptiness rejection.
- With the fix: `pack-modality-consent` 5/5; regression sweep over the wrapped install path (`domain-pack-install`, `domain-pack-seed`, `pack-mcp-tools`) — 4 suites, 34/34 tests, real SurrealDB via testcontainers.
- `pack-memory-model` unit suite 19/19; `pnpm typecheck`, `pnpm lint:ci`, and prettier check on touched files all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB