### PR TITLE
feat(outcomes): transactional idempotent writes + decision-context telemetry

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -267,6 +267,33 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Days the raw memory_outcome event log is kept; the 03:41 UTC prune cron deletes older rows. The memory_outcome_stat rollup is never pruned.',
   },
+  {
+    key: 'OUTCOME_TX_WRITES',
+    category: 'audit',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Transactional idempotent outcome writes: raw append + stat fold in ONE BEGIN/COMMIT with deterministic record ids + INSERT IGNORE, an in-tx pre-select gates the stat deltas so a replayed batch folds nothing twice, and an OCC abort gets exactly one retry. Off = the legacy two-statement write shape, byte-identical.',
+  },
+  {
+    key: 'OUTCOME_DECISION_CAPTURE',
+    category: 'audit',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Decision-context telemetry (0119): content-free memory_decision rows at the abstain gate and the L3 escalation trigger, plus the decisionId join columns on memory_outcome / focus_signal_sample and the nightly decision prune leg. Independent master — not coupled to OUTCOME_TELEMETRY_ENABLED.',
+  },
+  {
+    key: 'OUTCOME_DECISION_RETENTION_DAYS',
+    category: 'audit',
+    defaultValue: '30',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Days memory_decision rows are kept; the 03:41 UTC prune cron deletes older rows in bounded batches (third leg, gated on OUTCOME_DECISION_CAPTURE).',
+  },
   // Tool observations (0111) — filed under 'audit' like the 0107 pair
   // (append-only telemetry trail + retention knob).
   {

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -992,6 +992,17 @@ const KNOWN_BOOLEAN_FLAGS = [
   // retrieved rows even with the master on. The retention window knob
   // (OUTCOME_EVENT_RETENTION_DAYS) is an int, not a boolean flag.
   'OUTCOME_RETRIEVED_EVENTS',
+  // Outcome telemetry: transactional idempotent writes — deterministic
+  // record ids + INSERT IGNORE inside ONE BEGIN/COMMIT, in-tx delta
+  // gating, one OCC retry. Off (default) ⇒ the legacy two-statement
+  // write path runs byte-identical (pinned by the unit spec).
+  'OUTCOME_TX_WRITES',
+  // Decision-context telemetry (0119): content-free memory_decision rows
+  // at the abstain/L3 seams + the decisionId join columns + the decision
+  // prune leg. An INDEPENDENT master (the TOOL_OBSERVATIONS_ENABLED
+  // precedent) — not coupled to OUTCOME_TELEMETRY_ENABLED. The retention
+  // knob (OUTCOME_DECISION_RETENTION_DAYS) is an int, not a boolean flag.
+  'OUTCOME_DECISION_CAPTURE',
   // Tool observations master (0111): the per-request MCP build applies
   // the innermost observation wrapper, the pack-tool proxy stamps
   // identity rows, ingest accepts toolObservationRef, the prune leg

--- a/src/common/outcome-flags.ts
+++ b/src/common/outcome-flags.ts
@@ -34,6 +34,42 @@ export function outcomeRetrievedEventsEnabled(): boolean {
   return envFlagEnabled(process.env.OUTCOME_RETRIEVED_EVENTS);
 }
 
+/**
+ * Transactional idempotent outcome writes — OUTCOME_TX_WRITES.
+ *
+ * When on, MemoryOutcomeService takes the atomic branch: deterministic
+ * record ids + INSERT IGNORE inside ONE BEGIN/COMMIT (raw append and
+ * stat fold land together or not at all), an in-tx pre-select gates the
+ * stat deltas so a replayed batch folds NOTHING twice, and an OCC abort
+ * gets exactly one immediate retry. The env read lives here in the
+ * common layer, NOT inside the engine dirs (engine-gates S5.2). Read at
+ * call time so a flip is runtime-mutable. Default off ⇒ the legacy
+ * two-statement write path runs BYTE-IDENTICAL (same SQL strings, same
+ * params keys — pinned by the unit spec).
+ */
+export function outcomeTxWritesEnabled(): boolean {
+  return envFlagEnabled(process.env.OUTCOME_TX_WRITES);
+}
+
+/**
+ * Decision-context telemetry — OUTCOME_DECISION_CAPTURE.
+ *
+ * When on, the synthesize seams write CONTENT-FREE memory_decision rows
+ * (0119) at the abstain gate and the L3 escalation trigger, stamp the
+ * request's primary decisionId onto outcome rows / focus-signal samples,
+ * and the nightly decision prune leg runs. An INDEPENDENT master —
+ * deliberately NOT coupled to OUTCOME_TELEMETRY_ENABLED (the
+ * TOOL_OBSERVATIONS_ENABLED precedent): decision context is useful with
+ * or without the outcome stream. The env read lives here in the common
+ * layer, NOT inside the engine dirs (engine-gates S5.2); engine callers
+ * reach it via the MemoryDecisionService static. Read at call time so a
+ * flip is runtime-mutable. Default off ⇒ no decision row is ever
+ * written and no join column is ever stamped — serving byte-identical.
+ */
+export function outcomeDecisionCaptureEnabled(): boolean {
+  return envFlagEnabled(process.env.OUTCOME_DECISION_CAPTURE);
+}
+
 /** Default raw-event retention window for the nightly prune (days). */
 const DEFAULT_EVENT_RETENTION_DAYS = 30;
 
@@ -51,4 +87,24 @@ export function outcomeEventRetentionDays(): number {
   if (raw === undefined || raw.trim() === '') return DEFAULT_EVENT_RETENTION_DAYS;
   const v = Number(raw);
   return Number.isInteger(v) && v > 0 ? v : DEFAULT_EVENT_RETENTION_DAYS;
+}
+
+/** Default decision-row retention window for the nightly prune (days). */
+const DEFAULT_DECISION_RETENTION_DAYS = 30;
+
+/**
+ * Decision-row retention window — OUTCOME_DECISION_RETENTION_DAYS.
+ *
+ * The nightly prune cron (03:41 UTC, third leg) deletes memory_decision
+ * rows older than this many days — decision context is prunable
+ * telemetry, like the raw outcome log (0107) and tool observations
+ * (0111). A non-boolean knob resolved here in the common layer so
+ * consumers take a resolved number. Must be a positive integer; unset,
+ * blank, or out of range → the 30-day default.
+ */
+export function outcomeDecisionRetentionDays(): number {
+  const raw = process.env.OUTCOME_DECISION_RETENTION_DAYS;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_DECISION_RETENTION_DAYS;
+  const v = Number(raw);
+  return Number.isInteger(v) && v > 0 ? v : DEFAULT_DECISION_RETENTION_DAYS;
 }

--- a/src/db/migrations/0119_decision_telemetry.surql
+++ b/src/db/migrations/0119_decision_telemetry.surql
@@ -1,0 +1,90 @@
+-- 0119_decision_telemetry — decision-context telemetry (memory_decision)
+-- + the decisionId join keys on memory_outcome / focus_signal_sample.
+--
+-- NUMBERING NOTE: 0114-0118 are claimed by in-flight sibling PRs of the
+-- same wave; this migration deliberately takes 0119. The migrator applies
+-- by numeric order and tracks per-id, so the gap is harmless whether the
+-- siblings land before or after this one.
+--
+-- Part 1 — decision join key on the raw outcome log. Outcome rows written
+-- under OUTCOME_DECISION_CAPTURE carry the decisionId of the request's
+-- primary decision, so an outcome (used/verified/confirmed) can be joined
+-- back to the policy decision that produced it. NONE = legacy / capture-off.
+--
+-- IDEMPOTENCY (OUTCOME_TX_WRITES) IS NOT AN INDEX — deliberately. The
+-- transactional writer dedupes replays via DETERMINISTIC RECORD IDS +
+-- INSERT IGNORE (the #92 changefeed idiom: a replayed batch collides on
+-- the PRIMARY KEY and no-ops). A UNIQUE index over a new option<string>
+-- event-key column would NOT be additive-safe: SurrealDB unique indexes
+-- treat NONE as an indexable value, so every pre-existing row (key = NONE)
+-- would collide with every other, and a backfill is out of scope. Record
+-- ids need no index and no backfill: legacy rows keep their random ids,
+-- flag-on rows get `memory_outcome:<sha256-prefix>`.
+--
+-- Part 2 — memory_decision: one CONTENT-FREE row per policy decision the
+-- serving path takes (this PR wires the abstain gate and the L3 escalation
+-- trigger; 'lane_route'/'zoom' reserve the audit's other seams). The row
+-- carries ids / enums / numbers ONLY — never query text, never fact text,
+-- never answer text. That contract (the 0107 rationale verbatim-in-spirit)
+-- is what keeps this table outside the PII reconstruction surface, lets
+-- the GDPR forget services purge it as a bulk telemetry sweep (via the
+-- memory_outcome.decisionId join — decisions carry no subject linkage by
+-- design), and lets the 30-day prune run without provenance ceremony.
+-- observedState is FLEXIBLE but SHAPED by a whitelist in the writer
+-- (shapeDecisionRow): finite signal numbers + a capped queryClass only.
+--
+-- Part 3 — focus_signal_sample gains the same decisionId join key. 0094
+-- is NOT superseded: the admin fit/measure surface stays the sole consumer
+-- of samples; new rows merely gain the join column. NO data migration, no
+-- backfill — pre-0119 rows stay NONE.
+--
+-- NO CHANGEFEED and NO DEFINE EVENT — deliberately (the 0107 rationale):
+-- mirroring telemetry into audit_event would flood the audit trail, and a
+-- DEFINE EVENT on an append-only telemetry table is a write amplifier.
+
+-- Part 1: decision join key on the raw outcome log
+DEFINE FIELD IF NOT EXISTS decisionId ON memory_outcome TYPE option<string>;
+DEFINE INDEX IF NOT EXISTS memory_outcome_decision_idx ON memory_outcome FIELDS decisionId;
+
+-- Part 2: memory_decision
+DEFINE TABLE IF NOT EXISTS memory_decision SCHEMAFULL;
+
+-- decisionId == the record id tail, duplicated as a plain column so the
+-- outcome/focus joins are string joins (no record-id parsing).
+DEFINE FIELD IF NOT EXISTS decisionId    ON memory_decision TYPE string;
+DEFINE FIELD IF NOT EXISTS requestId     ON memory_decision TYPE option<string>;
+-- Kept despite the per-tenant DB (the 0094 precedent): cross-tenant
+-- aggregation later needs the tenant on the row.
+DEFINE FIELD IF NOT EXISTS companyId     ON memory_decision TYPE string;
+DEFINE FIELD IF NOT EXISTS decisionKind  ON memory_decision TYPE string
+  ASSERT $value INSIDE ['l3_escalation', 'abstain', 'lane_route', 'zoom'];
+DEFINE FIELD IF NOT EXISTS policyVersion ON memory_decision TYPE string;
+-- FLEXIBLE but contracted: the writer whitelist admits ONLY
+-- {topScore, coverageScore, retrievalGap, rawConfidence, candidateCount:
+-- finite numbers; queryClass: string ≤64} — everything else is dropped.
+DEFINE FIELD IF NOT EXISTS observedState ON memory_decision TYPE option<object> FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS chosenAction  ON memory_decision TYPE string;
+DEFINE FIELD IF NOT EXISTS actionScore   ON memory_decision TYPE option<float>;
+-- Reserved contract for future stochastic/bandit policies — no writer
+-- stamps it in this PR (no stochastic policy exists).
+DEFINE FIELD IF NOT EXISTS propensity    ON memory_decision TYPE option<float>;
+DEFINE FIELD IF NOT EXISTS alternatives  ON memory_decision TYPE option<array<object>>;
+DEFINE FIELD IF NOT EXISTS alternatives[*].action ON memory_decision TYPE string;
+DEFINE FIELD IF NOT EXISTS alternatives[*].score  ON memory_decision TYPE float;
+DEFINE FIELD IF NOT EXISTS costs                  ON memory_decision TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS costs.latencyMs        ON memory_decision TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS costs.promptTokens     ON memory_decision TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS costs.completionTokens ON memory_decision TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS costs.toolCalls        ON memory_decision TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS createdAt     ON memory_decision TYPE datetime DEFAULT time::now();
+
+-- ALL single-field, ALL non-unique — deliberately. Uniqueness lives in the
+-- record id (deterministic, INSERT IGNORE); a unique decisionId index would
+-- be redundant, and single-field coverage keeps the delete paths (GDPR
+-- join-purge + prune) out of the 3.2.4 compound-planner DELETE no-op class.
+DEFINE INDEX IF NOT EXISTS memory_decision_id_idx      ON memory_decision FIELDS decisionId;
+DEFINE INDEX IF NOT EXISTS memory_decision_created_idx ON memory_decision FIELDS createdAt;
+DEFINE INDEX IF NOT EXISTS memory_decision_request_idx ON memory_decision FIELDS requestId;
+
+-- Part 3: focus-signal join (0094 shape otherwise untouched; no data migration)
+DEFINE FIELD IF NOT EXISTS decisionId ON focus_signal_sample TYPE option<string>;

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -329,6 +329,21 @@ export class EntityForgetService {
         // fact_usage. LET-then-DELETE-by-ids, NOT `DELETE … WHERE`
         // (the 3.2.4 indexed-traversal DELETE bug — see the pre-tx sweep
         // comment above).
+        //
+        // memory_decision (0119) rides the SAME straggler sweep: decision
+        // rows carry NO subject/user linkage by design (content-free
+        // decision context), so they are resolved THROUGH the subject's
+        // straggler outcome rows — collected BEFORE those rows die (the
+        // pre-swept bulk was handled the same way in preSweepOutcomeRows).
+        // Accepted semantics: a decision row shared with another subject's
+        // outcomes dies too — content-free telemetry, prunable at 30d,
+        // over-deletion is the safe direction. Decisions are ≤1-2 rows per
+        // request (bounded), so no dedicated pre-sweep batching is needed
+        // and they stay uncounted in txRecordCount like the rest of the
+        // telemetry. Two-step LET→DELETE mandatory (same planner bug).
+        // Statements live in addDecisionPurgeLeg (max-lines-per-function
+        // gate on forget()).
+        this.addDecisionPurgeLeg(tx);
         tx.add(
           `LET $outIds = (SELECT VALUE id FROM memory_outcome WHERE subjectId.entityId = $ent)`,
         );
@@ -677,11 +692,26 @@ export class EntityForgetService {
    * NOTHING, while the same WHERE in a SELECT matches fine — verified
    * against the pinned server. Deleting by explicit ids sidesteps the
    * planner entirely.
+   *
+   * memory_decision (0119) is purged FIRST, through the same rows:
+   * decision rows carry no subject linkage by design, so the join keys
+   * (memory_outcome.decisionId) must be collected while the subject's
+   * outcome rows are still alive — purging decisions after this sweep
+   * would find nothing to join. Same content-free rationale, same
+   * two-step idiom; bounded by array::distinct over the subject's rows.
    */
   private async preSweepOutcomeRows(
     db: { query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T> },
     rid: string,
   ): Promise<void> {
+    await db.query(
+      `LET $decKeys = array::distinct((SELECT VALUE decisionId FROM memory_outcome
+         WHERE subjectId.entityId = type::record('knowledge_entity', $rid)
+           AND decisionId IS NOT NONE));
+       LET $decIds = (SELECT VALUE id FROM memory_decision WHERE decisionId INSIDE $decKeys);
+       DELETE $decIds;`,
+      { rid },
+    );
     for (;;) {
       const [, batch] = await db.query<[unknown, unknown[]]>(
         `LET $ids = (SELECT VALUE id FROM memory_outcome
@@ -693,6 +723,22 @@ export class EntityForgetService {
       // A partial batch means the subject's raw rows are drained.
       if (((batch as unknown[]) ?? []).length < 5000) break;
     }
+  }
+
+  /**
+   * memory_decision (0119) in-tx straggler leg — the transaction twin of
+   * the preSweepOutcomeRows decision purge above (same join through the
+   * subject's live memory_outcome rows, same two-step LET→DELETE idiom,
+   * same content-free rationale). Split out of forget() for the
+   * max-lines-per-function gate; see the call-site comment for the
+   * shared-decision-row semantics.
+   */
+  private addDecisionPurgeLeg(tx: TxBuilder): void {
+    tx.add(
+      `LET $decKeys = (SELECT VALUE decisionId FROM memory_outcome WHERE subjectId.entityId = $ent AND decisionId IS NOT NONE)`,
+    );
+    tx.add(`LET $decIds = (SELECT VALUE id FROM memory_decision WHERE decisionId INSIDE $decKeys)`);
+    tx.add(`DELETE $decIds`);
   }
 
   /**

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -130,8 +130,20 @@ export class UserForgetService {
       // indexed record field (memory_outcome_subject_idx covers
       // subjectId) silently matches NOTHING, while the same WHERE in a
       // SELECT matches fine — verified against the pinned server.
+      //
+      // memory_decision (0119) goes FIRST: decision rows carry no
+      // subject/user linkage by design (content-free decision context),
+      // so their join keys (memory_outcome.decisionId) must be collected
+      // while the user's outcome rows are still alive. Accepted
+      // semantics: a decision row shared with another subject's outcomes
+      // dies too — content-free telemetry, prunable at 30d, over-deletion
+      // is the safe direction. Same two-step idiom.
       await db.query(
-        `LET $outIds = (SELECT VALUE id FROM memory_outcome WHERE subjectId.userId = $u);
+        `LET $decKeys = array::distinct((SELECT VALUE decisionId FROM memory_outcome
+           WHERE subjectId.userId = $u AND decisionId IS NOT NONE));
+         LET $decIds = (SELECT VALUE id FROM memory_decision WHERE decisionId INSIDE $decKeys);
+         DELETE $decIds;
+         LET $outIds = (SELECT VALUE id FROM memory_outcome WHERE subjectId.userId = $u);
          DELETE $outIds;
          LET $outStatIds = (SELECT VALUE id FROM memory_outcome_stat WHERE subjectId.userId = $u);
          DELETE $outStatIds;`,

--- a/src/mri/economics.ts
+++ b/src/mri/economics.ts
@@ -1,5 +1,5 @@
 import type { MetricsReader } from './metrics-reader';
-import { sumCounter } from './metrics-reader';
+import { histogramQuantile, sumCounter } from './metrics-reader';
 
 /**
  * Part 1 — the economics operating-point + Pareto reporter
@@ -23,17 +23,19 @@ import { sumCounter } from './metrics-reader';
  *     tokens (embed + chat across derive/dreams/ingest/synthesize) by the
  *     synthesize request count — it over-attributes non-synthesize spend. The
  *     field name + labels say so; it is never presented as the true answer cost.
- *   - latency is `null` here: no per-query latency histogram is emitted on the
- *     serving path (brain_search_duration_seconds is defined but its
- *     observe() is never called outside a unit test), so the cell renders
- *     `pending` with that reason rather than a fabricated number.
+ *   - latency is LIVE off `brain_search_duration_seconds`: synthesize()
+ *     observes its wall-clock duration once per request at the serving
+ *     boundary (the audit pt-8 fix — the histogram was defined but never
+ *     observed), and p50/p95 come from `histogramQuantile` over its buckets —
+ *     the Prometheus estimator, an honest bucket interpolation, not a claimed
+ *     exact latency. A window with no samples still yields `null` → the cell
+ *     renders `pending`, never a fabricated number.
  *
  * The reporter renders the Pareto frontier over a set of points and flags
  * the dominated ones (accuracy↑ better, cost↓ better, latency↓ better). The
  * ship-gate is ADVISORY ONLY (§1.3): it REPORTS that a candidate is
  * dominated; it never blocks. Only the accuracy axis is a proxy; cost is an
- * explicit upper bound and latency is pending until a serving-path histogram
- * exists — so a live operating point lands in `insufficientData` until then.
+ * explicit upper bound.
  */
 
 /** USD per 1,000,000 tokens. Assumed list price — the token COUNTS are exact
@@ -71,12 +73,12 @@ export interface PolicyOperatingPoint {
   accuracyProxy: number | null;
   /** Expected Calibration Error. null until a labeled gold set exists. */
   ece: number | null;
-  /** Median query latency in seconds. ALWAYS null today: no per-query latency
-   *  histogram is emitted on the serving path (brain_search_duration_seconds is
-   *  defined but never observed outside a unit test). Kept on the shape so a
-   *  future serving-path histogram fills it without a contract change. */
+  /** Median query latency in seconds — histogram_quantile(0.5) over
+   *  brain_search_duration_seconds (observed once per synthesize() request
+   *  at the serving boundary). null when the window carries no samples —
+   *  never a fabricated zero. */
   latencyP50: number | null;
-  /** p95 query latency in seconds. ALWAYS null today (see latencyP50). */
+  /** p95 query latency in seconds (see latencyP50). */
   latencyP95: number | null;
   /** Estimated USD per query — UPPER BOUND, NOT the true per-answer cost. All-AI
    *  tokens (embed + chat across derive/dreams/ingest/synthesize — the token
@@ -148,8 +150,9 @@ export function terminalSynthesizeCount(reader: MetricsReader): number {
  *   - costPerQueryUpperBound = (all-AI tokens × price) ÷ terminal count. An UPPER
  *     BOUND: the token counters are not separable by subsystem, so global AI
  *     spend is attributed to synthesize requests. NOT the per-answer cost.
- *   - latency stays null: no per-query latency histogram is emitted on the
- *     serving path (see the file header) — the dimension renders `pending`.
+ *   - latencyP50/P95 = histogram_quantile over brain_search_duration_seconds
+ *     (observed once per synthesize() request at the serving boundary); null
+ *     when the window carries no samples (never fabricated).
  *   - ece stays null — no labels here.
  */
 export function collectOperatingPoint(
@@ -182,14 +185,19 @@ export function collectOperatingPoint(
     1_000_000;
   const costPerQueryUpperBound = terminalTotal > 0 ? totalCostUsd / terminalTotal : null;
 
+  // Serving-boundary latency: synthesize() observes once per request.
+  // histogramQuantile returns null on an empty histogram (count 0), and a
+  // missing metric reads as null too — the never-fabricate rule holds.
+  const latencyHist = reader.histogram('brain_search_duration_seconds');
+  const latencyP50 = latencyHist ? histogramQuantile(latencyHist, 0.5) : null;
+  const latencyP95 = latencyHist ? histogramQuantile(latencyHist, 0.95) : null;
+
   return {
     flags,
     accuracyProxy,
     ece: null,
-    // No per-query latency histogram is emitted on the serving path — never a
-    // fabricated number; the cost/latency dims render this as `pending`.
-    latencyP50: null,
-    latencyP95: null,
+    latencyP50,
+    latencyP95,
     costPerQueryUpperBound,
     sampleCount: terminalTotal,
   };

--- a/src/mri/mri-collectors.ts
+++ b/src/mri/mri-collectors.ts
@@ -294,14 +294,13 @@ function costLatencyDims(
   // unit, and source all say so — it is never presented as the per-answer cost.
   const costSource =
     'all-AI tokens (embed+chat across derive/dreams/ingest/synthesize — NOT synthesize-only; the token counters carry no per-subsystem label) × assumed price table ÷ terminal synthesize count. UPPER BOUND, not the true per-answer cost.';
-  // No per-query latency histogram is emitted on the serving path:
-  // brain_search_duration_seconds is defined in metrics.service.ts but
-  // observeSearchDuration() is never called outside a unit test. Adding a
-  // serving-path histogram is a separate follow-up (this layer is read-only), so
-  // latency renders `pending` with that reason — never a fabricated number.
-  const latencyReason = 'no per-query latency histogram is emitted on the serving path';
+  // Latency is LIVE: synthesize() observes brain_search_duration_seconds once
+  // per request at the serving boundary (the audit pt-8 fix), and the operating
+  // point fills p50/p95 via histogram_quantile — an honest bucket-interpolation
+  // estimate. A window with no samples yields null → the cell renders `pending`
+  // with that reason, never a fabricated number.
   const latencySource =
-    'per-query latency histogram (brain_search_duration_seconds is defined but never observed on the serving path)';
+    'histogram_quantile over brain_search_duration_seconds (observed once per synthesize() request at the serving boundary)';
 
   const cost: MriDimension =
     point.costPerQueryUpperBound === null
@@ -321,19 +320,29 @@ function costLatencyDims(
           kind: 'live',
         };
 
-  const latencyPending = (): MriDimension =>
-    pendingCell({
-      source: latencySource,
-      reason: latencyReason,
-      evalGated: false,
-      kind: 'pending',
-      asOf: nowIso,
-    });
+  const latencyCell = (value: number | null): MriDimension =>
+    value === null
+      ? pendingCell({
+          source: latencySource,
+          reason:
+            'no latency samples in the current window (no synthesize request observed the histogram yet)',
+          evalGated: false,
+          kind: 'live',
+          asOf: nowIso,
+        })
+      : {
+          value,
+          unit: 'seconds',
+          source: latencySource,
+          asOf: nowIso,
+          evalGated: false,
+          kind: 'live',
+        };
 
   return {
     costPerQueryUpperBoundUsd: cost,
-    latencyP50Seconds: latencyPending(),
-    latencyP95Seconds: latencyPending(),
+    latencyP50Seconds: latencyCell(point.latencyP50),
+    latencyP95Seconds: latencyCell(point.latencyP95),
   };
 }
 

--- a/src/outcomes/memory-decision.service.ts
+++ b/src/outcomes/memory-decision.service.ts
@@ -1,0 +1,251 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHash, randomUUID } from 'node:crypto';
+import { StringRecordId } from 'surrealdb';
+import { SurrealService } from '../db/surreal.service';
+import { outcomeDecisionCaptureEnabled } from '../common/outcome-flags';
+import {
+  getCorrelationId,
+  getRequestContext,
+  type RequestContext,
+} from '../common/request-context';
+
+/**
+ * MemoryDecisionService — the ONE write seam for memory_decision rows
+ * (migration 0119): decision-context telemetry for the serving path's
+ * policy decisions (this PR: the abstain gate + the L3 escalation
+ * trigger; 'lane_route'/'zoom' reserve the audit's other seams).
+ *
+ * Discipline (the ToolObservationService/MemoryOutcomeService idiom):
+ *   * master-flag guard INSIDE the service (OUTCOME_DECISION_CAPTURE,
+ *     an independent master — deliberately NOT coupled to
+ *     OUTCOME_TELEMETRY_ENABLED, the TOOL_OBSERVATIONS_ENABLED
+ *     precedent) — callers may cheaply check too via the static;
+ *   * fire-and-forget on a fresh ROOT-pool connection; a failure warns,
+ *     NEVER errors or slows the decision it records;
+ *   * deterministic record id + INSERT IGNORE (the #92 idiom): an
+ *     upstream replay recomputes the same id, collides on the primary
+ *     key, and no-ops — replay-safe with NO retry machinery;
+ *   * every stored field is whitelisted/capped by the pure shaper.
+ *
+ * Rows are CONTENT-FREE by contract: ids / enums / numbers only — never
+ * query text, never fact text, never answer text. That keeps the table
+ * outside the PII reconstruction surface; GDPR purges it via the
+ * memory_outcome.decisionId join (decisions carry no subject linkage by
+ * design — see the forget services).
+ */
+
+/** The decision seams 0119 reserves. Only the first two get writers in
+ *  this PR; the enum reserves the audit's other seams. */
+export type DecisionKind = 'l3_escalation' | 'abstain' | 'lane_route' | 'zoom';
+
+/** Cap on the alternatives array (contract-bounded row size). */
+export const DECISION_ALTERNATIVES_CAP = 8;
+
+/** Cap on observedState.queryClass (a LaneId/'default' in practice). */
+export const DECISION_QUERY_CLASS_CAP = 64;
+
+/** Cap on opaque id / enum-ish string fields (requestId, chosenAction,
+ *  policyVersion, alternatives[*].action). */
+export const DECISION_STRING_CAP = 128;
+
+export interface DecisionInput {
+  decisionKind: DecisionKind;
+  /** Which policy produced the decision, e.g. 'static' or
+   *  'adaptive@thr=0.5' — an id-like tag, never free text. */
+  policyVersion: string;
+  /** e.g. 'escalate' / 'skip:<reason>' (l3), 'abstain' / 'proceed'. */
+  chosenAction: string;
+  /** Correlation id override; defaults to the ALS correlation id. */
+  requestId?: string | undefined;
+  /** Signal numbers at decision time — WHITELISTED by the shaper: only
+   *  {topScore, coverageScore, retrievalGap, rawConfidence,
+   *  candidateCount: finite numbers; queryClass: string ≤64} survive. */
+  observedState?: Record<string, unknown> | undefined;
+  /** Calibrated confidence of the chosen action, when one exists. */
+  actionScore?: number | undefined;
+  /** Considered actions with their scores; capped at 8. */
+  alternatives?: ReadonlyArray<{ action: string; score: number }> | undefined;
+  /** Decision-time costs; ints only, absent fields stay NONE. */
+  costs?:
+    | {
+        latencyMs?: number | undefined;
+        promptTokens?: number | undefined;
+        completionTokens?: number | undefined;
+        toolCalls?: number | undefined;
+      }
+    | undefined;
+}
+
+/** Row shape handed to INSERT — exported for the unit spec. */
+export interface DecisionRow {
+  decisionId: string;
+  companyId: string;
+  decisionKind: DecisionKind;
+  policyVersion: string;
+  chosenAction: string;
+  requestId?: string;
+  observedState?: Record<string, number | string>;
+  actionScore?: number;
+  alternatives?: Array<{ action: string; score: number }>;
+  costs?: Record<string, number>;
+}
+
+/**
+ * Per-request, per-kind decision counter (the D5 kindSeq): the id input
+ * is `requestScope|decisionKind|kindSeq`, so a second decision of the
+ * same kind in one request (should not occur at today's seams, but the
+ * contract tolerates it) stays a distinct row while an upstream replay
+ * of the whole request recomputes identical ids. WeakMap keyed on the
+ * ALS context; no context → seq 0 (the randomUUID scope fallback
+ * already makes the call unique).
+ */
+const kindSeqByContext = new WeakMap<RequestContext, Partial<Record<DecisionKind, number>>>();
+
+function nextKindSeq(kind: DecisionKind): number {
+  const ctx = getRequestContext();
+  if (!ctx) return 0;
+  const seqs = kindSeqByContext.get(ctx) ?? {};
+  const seq = seqs[kind] ?? 0;
+  seqs[kind] = seq + 1;
+  kindSeqByContext.set(ctx, seqs);
+  return seq;
+}
+
+/** Deterministic decision id: sha256(requestScope|kind|kindSeq), first
+ *  32 hex chars — hex tail ⇒ unquoted-safe record id (the #92 idiom).
+ *  Pure and exported for the unit spec. */
+export function decisionEventId(requestScope: string, kind: DecisionKind, kindSeq: number): string {
+  return createHash('sha256')
+    .update(`${requestScope}|${kind}|${kindSeq}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+@Injectable()
+export class MemoryDecisionService {
+  private readonly logger = new Logger(MemoryDecisionService.name);
+
+  constructor(private readonly surreal: SurrealService) {}
+
+  /**
+   * Master-flag check, exposed as a static so the engine dirs (S5.2 —
+   * no process.env below the profile boundary) can gate cheaply via the
+   * service class, the MemoryOutcomeService.enabled() idiom.
+   */
+  static enabled(): boolean {
+    return outcomeDecisionCaptureEnabled();
+  }
+
+  /**
+   * Record one decision row — fire-and-forget, replay-safe via the
+   * deterministic id + INSERT IGNORE (no retry by design). Returns the
+   * decisionId (the join key the caller threads onto outcome rows and
+   * focus samples), or undefined when capture is off.
+   */
+  record(companyId: string, input: DecisionInput): string | undefined {
+    if (!outcomeDecisionCaptureEnabled()) return undefined;
+    // Captured SYNCHRONOUSLY — ALS is dead inside the detached promise.
+    const correlated = input.requestId ?? getCorrelationId();
+    const decisionId = decisionEventId(
+      correlated ?? randomUUID(),
+      input.decisionKind,
+      nextKindSeq(input.decisionKind),
+    );
+    const row = shapeDecisionRow(input, { decisionId, companyId, requestId: correlated });
+    void this.surreal
+      .withCompany(companyId, async (db) => {
+        await db.query('INSERT IGNORE INTO memory_decision $row', {
+          row: { id: new StringRecordId(`memory_decision:${decisionId}`), ...row },
+        });
+      })
+      .catch((e: Error) => {
+        this.logger.warn(
+          `decision insert failed (kind=${input.decisionKind}, companyId=${companyId}): ${e.message}`,
+        );
+      });
+    return decisionId;
+  }
+}
+
+const OBSERVED_NUMBER_KEYS = [
+  'topScore',
+  'coverageScore',
+  'retrievalGap',
+  'rawConfidence',
+  'candidateCount',
+] as const;
+
+/** The observedState whitelist: ONLY the contracted signal numbers +
+ *  a capped queryClass survive; everything else is DROPPED (that is what
+ *  keeps the FLEXIBLE column content-free). */
+function whitelistObservedState(
+  state: Record<string, unknown>,
+): Record<string, number | string> | undefined {
+  const out: Record<string, number | string> = {};
+  for (const key of OBSERVED_NUMBER_KEYS) {
+    const v = state[key];
+    if (typeof v === 'number' && Number.isFinite(v)) out[key] = v;
+  }
+  const qc = state['queryClass'];
+  if (typeof qc === 'string' && qc.length > 0) {
+    out['queryClass'] = qc.slice(0, DECISION_QUERY_CLASS_CAP);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+const COST_KEYS = ['latencyMs', 'promptTokens', 'completionTokens', 'toolCalls'] as const;
+
+/** costs.* are int columns — keep only finite non-negative integers. */
+function shapeCosts(
+  costs: NonNullable<DecisionInput['costs']>,
+): Record<string, number> | undefined {
+  const out: Record<string, number> = {};
+  for (const key of COST_KEYS) {
+    const v = costs[key];
+    if (typeof v === 'number' && Number.isFinite(v) && v >= 0) out[key] = Math.round(v);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Pure row shaper — exported for the content-free unit spec. Whitelists
+ * observedState, caps alternatives at 8 (action/score pairs ONLY — any
+ * extra fields are dropped), bounds every string, and keeps only finite
+ * numbers. `propensity` is deliberately never stamped in this PR: no
+ * stochastic policy exists; the 0119 column is the contract for future
+ * bandit work.
+ */
+export function shapeDecisionRow(
+  input: DecisionInput,
+  ctx: { decisionId: string; companyId: string; requestId?: string | undefined },
+): DecisionRow {
+  const row: DecisionRow = {
+    decisionId: ctx.decisionId,
+    companyId: ctx.companyId,
+    decisionKind: input.decisionKind,
+    policyVersion: input.policyVersion.slice(0, DECISION_STRING_CAP),
+    chosenAction: input.chosenAction.slice(0, DECISION_STRING_CAP),
+  };
+  if (ctx.requestId !== undefined) {
+    row.requestId = ctx.requestId.slice(0, DECISION_STRING_CAP);
+  }
+  if (input.observedState !== undefined) {
+    const state = whitelistObservedState(input.observedState);
+    if (state) row.observedState = state;
+  }
+  if (typeof input.actionScore === 'number' && Number.isFinite(input.actionScore)) {
+    row.actionScore = input.actionScore;
+  }
+  if (input.alternatives !== undefined) {
+    const alts = input.alternatives
+      .filter((a) => typeof a.action === 'string' && Number.isFinite(a.score))
+      .slice(0, DECISION_ALTERNATIVES_CAP)
+      .map((a) => ({ action: a.action.slice(0, DECISION_STRING_CAP), score: a.score }));
+    if (alts.length > 0) row.alternatives = alts;
+  }
+  if (input.costs !== undefined) {
+    const costs = shapeCosts(input.costs);
+    if (costs) row.costs = costs;
+  }
+  return row;
+}

--- a/src/outcomes/memory-outcome.service.ts
+++ b/src/outcomes/memory-outcome.service.ts
@@ -1,7 +1,17 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
 import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
-import { outcomeTelemetryEnabled } from '../common/outcome-flags';
+import { isReadConflict } from '../db/surreal-retry';
+import { outcomeTelemetryEnabled, outcomeTxWritesEnabled } from '../common/outcome-flags';
+import {
+  getCorrelationId,
+  getRequestContext,
+  type RequestContext,
+} from '../common/request-context';
+import { AUTO_STAT, buildOutcomeTxPayload, outcomeDedupeKey, runOutcomeTx } from './outcome-tx';
+
+export { outcomeDedupeKey, outcomeEventId } from './outcome-tx';
 
 /**
  * MemoryOutcomeService — the ONE write seam for outcome telemetry
@@ -82,6 +92,16 @@ export interface OutcomeEventInput {
   representationKind?: string | undefined;
   /** CONTENT-FREE: ids / verdict strings only — never fact text. */
   meta?: Record<string, unknown> | undefined;
+  /**
+   * 0119: join key to the memory_decision row this outcome descends from
+   * (the request's primary decision — abstain gate or L3 trigger). A
+   * plain string column (== the decision record-id tail), stamped by the
+   * synthesize emit seam ONLY under OUTCOME_DECISION_CAPTURE; absent =
+   * legacy / capture-off. NOT part of the dedupe key (0113-pinned):
+   * callers stamp one decision per request path, so two same-key events
+   * with different decisionIds do not occur.
+   */
+  decisionId?: string | undefined;
 }
 
 /**
@@ -103,25 +123,11 @@ export interface StatDelta {
 export const OUTCOME_RECORD_CAP = 100;
 
 /**
- * Event → rollup mapping for statDeltas: 'auto'. `retrieved` is
- * DELIBERATELY absent: the raw stream is prunable volume, and readCount
- * already lives on fact_usage (0053) — a retrieved counter here would
- * duplicate it.
- */
-const AUTO_STAT: Partial<
-  Record<OutcomeEventName, { counter: OutcomeCounter; used?: boolean; verified?: boolean }>
-> = {
-  selected_for_context: { counter: 'selectedCount' },
-  used_in_answer: { counter: 'usedCount', used: true },
-  verifier_supported: { counter: 'verifiedUseCount', verified: true },
-  user_confirmed: { counter: 'confirmedCount', verified: true },
-  user_rejected: { counter: 'rejectedCount' },
-  contradicted: { counter: 'contradictedCount' },
-};
-
-/**
  * Dedupe on (subjectKind, subjectId, event, actor, modality,
  * representationKind) then cap. Pure and exported for the unit spec.
+ * The key string lives in outcome-tx.ts (outcomeDedupeKey) because the
+ * OUTCOME_TX_WRITES deterministic event id derives from the SAME key —
+ * one definition, no drift.
  *
  * 0113: the two dimension components extend the key so the SAME event on
  * DIFFERENT modalities stays two rows. Every existing (text-path) writer
@@ -132,9 +138,7 @@ export function dedupeOutcomeEvents(events: OutcomeEventInput[]): OutcomeEventIn
   const seen = new Set<string>();
   const out: OutcomeEventInput[] = [];
   for (const ev of events) {
-    const key =
-      `${ev.subjectKind}|${ev.subjectId}|${ev.event}|${ev.actor ?? ''}` +
-      `|${ev.modality ?? ''}|${ev.representationKind ?? ''}`;
+    const key = outcomeDedupeKey(ev);
     if (seen.has(key)) continue;
     seen.add(key);
     out.push(ev);
@@ -209,6 +213,16 @@ function buildStatRows(deltas: StatDelta[], now: Date): StatRow[] {
   return [...bySubject.values()];
 }
 
+/**
+ * OUTCOME_TX_WRITES batch counter, per request context (D2 batchSeq):
+ * two recordOutcomes calls in ONE request (the search-loop refine case —
+ * identical dedupe keys) get distinct seqs and stay distinct rows
+ * exactly like today. WeakMap keyed on the ALS context object so the
+ * counter dies with the request; no context (cron/jobs) → seq 0, where
+ * the randomUUID request-scope fallback already makes the call unique.
+ */
+const txBatchSeq = new WeakMap<RequestContext, number>();
+
 @Injectable()
 export class MemoryOutcomeService {
   private readonly logger = new Logger(MemoryOutcomeService.name);
@@ -239,6 +253,14 @@ export class MemoryOutcomeService {
     if (!outcomeTelemetryEnabled()) return;
     const now = new Date();
     const events = dedupeOutcomeEvents(opts.events);
+    // OUTCOME_TX_WRITES: the atomic/idempotent branch (outcome-tx.ts).
+    // A SEPARATE branch by design — the flag-off path below stays the
+    // VERBATIM legacy two-statement shape (byte-identity pinned by the
+    // unit spec against literal SQL constants).
+    if (outcomeTxWritesEnabled()) {
+      this.recordOutcomesTx(opts, events, now);
+      return;
+    }
     const deltas =
       opts.statDeltas === undefined || opts.statDeltas === 'auto'
         ? autoStatDeltas(events, now)
@@ -254,6 +276,10 @@ export class MemoryOutcomeService {
       // undefined → dropped from the payload → NONE (option<...> rejects NULL).
       ...(ev.actor !== undefined ? { actor: ev.actor } : {}),
       ...(opts.requestId !== undefined ? { requestId: opts.requestId } : {}),
+      // 0119: decision join key — stamped only when a caller threads it
+      // (OUTCOME_DECISION_CAPTURE emit seams); existing writers pass
+      // nothing → row byte-identical.
+      ...(ev.decisionId !== undefined ? { decisionId: ev.decisionId } : {}),
       // 0113 dimensions ride the raw row only. The rollup (statRows below)
       // stays UNIQUE-per-subject with NO per-modality columns — deliberate:
       // no scorer consumes a per-modality stat yet, and the raw rows retain
@@ -294,6 +320,65 @@ export class MemoryOutcomeService {
     void this.surreal
       .withCompany(opts.companyId, async (db) => {
         await db.query(statements.join(';\n'), params);
+      })
+      .catch((e: Error) => {
+        this.logger.warn(`outcome recording failed for ${opts.companyId}: ${e.message}`);
+      });
+  }
+
+  /**
+   * OUTCOME_TX_WRITES branch: deterministic ids + one BEGIN/COMMIT
+   * (outcome-tx.ts) with a SINGLE immediate retry on the OCC-abort
+   * class only. Request scope + batch seq are captured SYNCHRONOUSLY
+   * before detaching (ALS is dead inside the detached promise); the
+   * payload — ids included — is computed once and reused verbatim by
+   * the retry, so the retry can never mint different ids. The
+   * fire-and-forget contract is unchanged: after the one retry (or on
+   * any non-retriable error) we warn and drop, never throw into the
+   * serving path. Callers untouched.
+   */
+  private recordOutcomesTx(
+    opts: {
+      companyId: string;
+      events: OutcomeEventInput[];
+      requestId?: string | undefined;
+      statDeltas?: 'auto' | StatDelta[] | undefined;
+    },
+    events: OutcomeEventInput[],
+    now: Date,
+  ): void {
+    const ctx = getRequestContext();
+    let batchSeq = 0;
+    if (ctx) {
+      batchSeq = txBatchSeq.get(ctx) ?? 0;
+      txBatchSeq.set(ctx, batchSeq + 1);
+    }
+    // The requestId COLUMN carries only a real correlation id; the id
+    // SCOPE additionally falls back to a random UUID so an uncorrelated
+    // call (cron/jobs) is unique rather than colliding on seq 0.
+    const correlated = opts.requestId ?? getCorrelationId();
+    const payload = buildOutcomeTxPayload({
+      events,
+      statDeltas: opts.statDeltas ?? 'auto',
+      now,
+      requestScope: correlated ?? randomUUID(),
+      batchSeq,
+      requestId: correlated,
+    });
+    if (!payload) return;
+    void this.surreal
+      .withCompany(opts.companyId, async (db) => {
+        try {
+          await runOutcomeTx(db, payload);
+        } catch (e) {
+          // One immediate retry, ONLY for the enriched OCC-abort class
+          // (runTransaction already enriches the bare "failed
+          // transaction" wrapper). No backoff machinery: the racing
+          // committer's row is visible immediately, and the re-run's
+          // pre-select then gates every already-applied delta.
+          if (!isReadConflict(e)) throw e;
+          await runOutcomeTx(db, payload);
+        }
       })
       .catch((e: Error) => {
         this.logger.warn(`outcome recording failed for ${opts.companyId}: ${e.message}`);

--- a/src/outcomes/outcome-prune.service.ts
+++ b/src/outcomes/outcome-prune.service.ts
@@ -2,7 +2,12 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { SurrealService } from '../db/surreal.service';
 import { ApiKeyService } from '../auth/api-key.service';
-import { outcomeEventRetentionDays, outcomeTelemetryEnabled } from '../common/outcome-flags';
+import {
+  outcomeDecisionCaptureEnabled,
+  outcomeDecisionRetentionDays,
+  outcomeEventRetentionDays,
+  outcomeTelemetryEnabled,
+} from '../common/outcome-flags';
 import {
   toolObservationRetentionDays,
   toolObservationsEnabled,
@@ -24,6 +29,15 @@ export const OUTCOME_PRUNE_BATCH_QUERY = `DELETE (SELECT id FROM memory_outcome 
  * guard. Exported for the query-shape unit spec.
  */
 export const TOOL_OBSERVATION_PRUNE_BATCH_QUERY = `DELETE (SELECT id FROM tool_observation WHERE createdAt < $cutoff LIMIT 5000) RETURN BEFORE`;
+
+/**
+ * Same bounded SELECT-ids → DELETE shape for the memory_decision rows
+ * (migration 0119) — its own retention window
+ * (OUTCOME_DECISION_RETENTION_DAYS), same 03:41 cron, shared in-flight
+ * guard, gated on OUTCOME_DECISION_CAPTURE. Exported for the
+ * query-shape unit spec.
+ */
+export const DECISION_PRUNE_BATCH_QUERY = `DELETE (SELECT id FROM memory_decision WHERE createdAt < $cutoff LIMIT 5000) RETURN BEFORE`;
 
 /**
  * OutcomePruneService — retention for the RAW outcome event log
@@ -51,12 +65,14 @@ export class OutcomePruneService {
 
   @Cron('41 3 * * *', { timeZone: 'UTC' })
   async runNightly(): Promise<{ tenants: number; pruned: number }> {
-    // Two independently-flagged legs share the tick + in-flight guard:
-    // memory_outcome (0107, OUTCOME_TELEMETRY_ENABLED) and
-    // tool_observation (0111, TOOL_OBSERVATIONS_ENABLED).
+    // Three independently-flagged legs share the tick + in-flight guard:
+    // memory_outcome (0107, OUTCOME_TELEMETRY_ENABLED), tool_observation
+    // (0111, TOOL_OBSERVATIONS_ENABLED) and memory_decision (0119,
+    // OUTCOME_DECISION_CAPTURE).
     const outcomeLeg = outcomeTelemetryEnabled();
     const observationLeg = toolObservationsEnabled();
-    if (!outcomeLeg && !observationLeg) return { tenants: 0, pruned: 0 };
+    const decisionLeg = outcomeDecisionCaptureEnabled();
+    if (!outcomeLeg && !observationLeg && !decisionLeg) return { tenants: 0, pruned: 0 };
     if (this.running) {
       this.logger.warn('outcome prune still running — skipping this tick');
       return { tenants: 0, pruned: 0 };
@@ -69,6 +85,7 @@ export class OutcomePruneService {
         try {
           if (outcomeLeg) pruned += await this.pruneTenant(companyId);
           if (observationLeg) pruned += await this.pruneToolObservations(companyId);
+          if (decisionLeg) pruned += await this.pruneDecisions(companyId);
         } catch (e) {
           this.logger.warn(`outcome prune for ${companyId} failed: ${(e as Error).message}`);
         }
@@ -90,6 +107,12 @@ export class OutcomePruneService {
   async pruneToolObservations(companyId: string): Promise<number> {
     const cutoff = new Date(Date.now() - toolObservationRetentionDays() * 86_400_000);
     return this.drain(companyId, TOOL_OBSERVATION_PRUNE_BATCH_QUERY, cutoff);
+  }
+
+  /** Same drain for the memory_decision rows (0119). */
+  async pruneDecisions(companyId: string): Promise<number> {
+    const cutoff = new Date(Date.now() - outcomeDecisionRetentionDays() * 86_400_000);
+    return this.drain(companyId, DECISION_PRUNE_BATCH_QUERY, cutoff);
   }
 
   private async drain(companyId: string, query: string, cutoff: Date): Promise<number> {

--- a/src/outcomes/outcome-tx.ts
+++ b/src/outcomes/outcome-tx.ts
@@ -1,0 +1,288 @@
+import { createHash } from 'node:crypto';
+import { StringRecordId, type Surreal } from 'surrealdb';
+import { runTransaction } from '../db/surreal.service';
+import type {
+  OutcomeCounter,
+  OutcomeEventInput,
+  OutcomeEventName,
+  OutcomeSubjectKind,
+  StatDelta,
+} from './memory-outcome.service';
+
+/**
+ * OUTCOME_TX_WRITES — the transactional/idempotent write branch of
+ * MemoryOutcomeService, assembled here as PURE payload builders + one
+ * transaction runner so the service file keeps the legacy branch
+ * verbatim (byte-identity contract) and the unit spec can exercise the
+ * assembly without a datastore.
+ *
+ * Idempotency = deterministic RECORD ids + INSERT IGNORE, NOT a unique
+ * index (see the 0119 header): a replayed batch recomputes the same ids,
+ * collides on the primary key, and no-ops. The stat fold is gated by an
+ * IN-TX pre-select of already-present ids — never by INSERT IGNORE's
+ * return shape (historically unreliable across server versions) — so a
+ * replay folds ZERO deltas and the rollup never double-counts.
+ *
+ * Race safety: two concurrent identical batches both pass the
+ * pre-select and INSERT the same record id → SurrealDB's OCC aborts one
+ * at commit (`isReadConflict` wordings, enriched by runTransaction) →
+ * the caller's single retry re-runs the tx, now sees $existing
+ * populated, and applies 0 deltas. One-tx design = race-correct, not
+ * just replay-correct.
+ */
+
+/** In-tx pre-select: which of this batch's deterministic ids already
+ *  exist (a replay / the loser of a concurrent race after retry). */
+export const OUTCOME_TX_PRESELECT = `LET $existing = (SELECT VALUE id FROM memory_outcome WHERE id INSIDE $rawIds)`;
+
+/** Raw append — rows carry explicit deterministic ids; IGNORE no-ops
+ *  primary-key collisions (the #92 changefeed idiom). */
+export const OUTCOME_TX_RAW_INSERT = `INSERT IGNORE INTO memory_outcome $rows`;
+
+/**
+ * Delta gating: only deltas whose gating raw row is NEW this dispatch
+ * fold into the rollup. A delta with no matching batch event (possible
+ * only for explicit statDeltas shapes) has NO rawId and stays UNGATED —
+ * today's behavior, documented residual: such deltas are not
+ * replay-protected.
+ */
+export const OUTCOME_TX_DELTA_GATE = `LET $newDeltas = (SELECT * FROM $deltas WHERE rawId NOTINSIDE $existing OR rawId IS NONE)`;
+
+/**
+ * Per-delta stat fold. Multiple deltas per subject fold naturally
+ * through ON DUPLICATE KEY UPDATE (first INSERT creates, later ones
+ * fold) — semantics equal to the legacy TS-side aggregation. The
+ * `LET $r = $d.row` hop keeps the INSERT source a plain variable (the
+ * form verified in prod code) rather than a path expression.
+ */
+export const OUTCOME_TX_STAT_FOLD = `FOR $d IN $newDeltas {
+  LET $r = $d.row;
+  INSERT INTO memory_outcome_stat $r
+    ON DUPLICATE KEY UPDATE
+      selectedCount += $input.selectedCount,
+      usedCount += $input.usedCount,
+      verifiedUseCount += $input.verifiedUseCount,
+      confirmedCount += $input.confirmedCount,
+      rejectedCount += $input.rejectedCount,
+      contradictedCount += $input.contradictedCount,
+      lastUsedAt = $input.lastUsedAt ?? lastUsedAt,
+      lastVerifiedUseAt = $input.lastVerifiedUseAt ?? lastVerifiedUseAt,
+      updatedAt = time::now();
+}`;
+
+/** Observability tail: how many raw ids the batch carried and how many
+ *  were already present (replay/race detection in logs, if ever read). */
+export const OUTCOME_TX_RETURN = `RETURN { total: array::len($rawIds), skipped: array::len($existing) }`;
+
+/**
+ * Event → rollup mapping ('auto' statDeltas). `retrieved` is
+ * DELIBERATELY absent: the raw stream is prunable volume, and readCount
+ * already lives on fact_usage (0053) — a retrieved counter here would
+ * duplicate it. Lives here (imported by the service's autoStatDeltas)
+ * so the tx builder and the legacy path share ONE mapping.
+ */
+export const AUTO_STAT: Partial<
+  Record<OutcomeEventName, { counter: OutcomeCounter; used?: boolean; verified?: boolean }>
+> = {
+  selected_for_context: { counter: 'selectedCount' },
+  used_in_answer: { counter: 'usedCount', used: true },
+  verifier_supported: { counter: 'verifiedUseCount', verified: true },
+  user_confirmed: { counter: 'confirmedCount', verified: true },
+  user_rejected: { counter: 'rejectedCount' },
+  contradicted: { counter: 'contradictedCount' },
+};
+
+/**
+ * The 0113-pinned dedupe key (subjectKind|subjectId|event|actor|
+ * modality|representationKind) — UNCHANGED by this PR. Shared by the
+ * service's dedupeOutcomeEvents and the deterministic event-id
+ * derivation below, so the id components can never drift from the
+ * dedupe partitioning.
+ */
+export function outcomeDedupeKey(ev: OutcomeEventInput): string {
+  return (
+    `${ev.subjectKind}|${ev.subjectId}|${ev.event}|${ev.actor ?? ''}` +
+    `|${ev.modality ?? ''}|${ev.representationKind ?? ''}`
+  );
+}
+
+/**
+ * Deterministic event id (D2): sha256(dedupeKey|requestScope|batchSeq),
+ * first 32 hex chars. Hex tail ⇒ unquoted-safe record id (the #92
+ * "numeric/table-name tokens" reasoning). requestScope is the
+ * correlation scope captured synchronously by the service; batchSeq the
+ * per-request monotonic counter, so two recordOutcomes calls in ONE
+ * request (the search-loop refine case: identical dedupe keys) stay
+ * distinct rows exactly like today. Deterministic across an upstream
+ * HTTP replay that reuses x-request-id; always deterministic across the
+ * service's own retry (ids computed once, payload reused).
+ */
+export function outcomeEventId(dedupeKey: string, requestScope: string, batchSeq: number): string {
+  return createHash('sha256')
+    .update(`${dedupeKey}|${requestScope}|${batchSeq}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+/** One per-delta stat row: six counters (one signed non-zero), gated by
+ *  the raw row that produced it (absent rawId = ungated). */
+export interface OutcomeTxDeltaRow {
+  rawId?: StringRecordId;
+  row: {
+    subjectId: StringRecordId;
+    subjectKind: OutcomeSubjectKind;
+    selectedCount: number;
+    usedCount: number;
+    verifiedUseCount: number;
+    confirmedCount: number;
+    rejectedCount: number;
+    contradictedCount: number;
+    lastUsedAt?: Date;
+    lastVerifiedUseAt?: Date;
+    updatedAt: Date;
+  };
+}
+
+/** The bound payload of one transactional dispatch. */
+export interface OutcomeTxPayload {
+  rawIds: StringRecordId[];
+  rows: Array<Record<string, unknown>>;
+  deltas: OutcomeTxDeltaRow[];
+}
+
+/** A StatDelta expanded to the full six-counter row shape. */
+function deltaRow(d: StatDelta, now: Date): OutcomeTxDeltaRow['row'] {
+  const row: OutcomeTxDeltaRow['row'] = {
+    subjectId: new StringRecordId(d.subjectId),
+    subjectKind: d.subjectKind,
+    selectedCount: 0,
+    usedCount: 0,
+    verifiedUseCount: 0,
+    confirmedCount: 0,
+    rejectedCount: 0,
+    contradictedCount: 0,
+    updatedAt: now,
+  };
+  row[d.counter] += d.delta;
+  if (d.lastUsedAt) row.lastUsedAt = d.lastUsedAt;
+  if (d.lastVerifiedUseAt) row.lastVerifiedUseAt = d.lastVerifiedUseAt;
+  return row;
+}
+
+/**
+ * Assemble the transactional payload from an already-deduped batch.
+ * Pure — exported for the unit spec. Delta gating (D3):
+ *   - 'auto' deltas carry the rawId of the event that PRODUCED them
+ *     (1:1 with the AUTO_STAT mapping);
+ *   - explicit signed deltas (feedback) gate on the raw id of the batch
+ *     event with the same (subjectKind, subjectId) — both the −1 and
+ *     the +1 ride the vote's raw row;
+ *   - a delta with no matching event stays ungated (rawId absent).
+ * Returns null when there is nothing to write.
+ */
+/** One raw memory_outcome row with its explicit deterministic id. */
+function eventRow(
+  ev: OutcomeEventInput,
+  rid: StringRecordId,
+  ctx: { now: Date; requestId: string | undefined },
+): Record<string, unknown> {
+  const { now, requestId } = ctx;
+  return {
+    id: rid,
+    subjectKind: ev.subjectKind,
+    subjectId: new StringRecordId(ev.subjectId),
+    event: ev.event,
+    createdAt: now,
+    // undefined → dropped from the payload → NONE (option<...> rejects NULL).
+    ...(ev.actor !== undefined ? { actor: ev.actor } : {}),
+    ...(requestId !== undefined ? { requestId } : {}),
+    ...(ev.decisionId !== undefined ? { decisionId: ev.decisionId } : {}),
+    ...(ev.modality !== undefined ? { modality: ev.modality } : {}),
+    ...(ev.representationKind !== undefined ? { representationKind: ev.representationKind } : {}),
+    ...(ev.meta !== undefined ? { meta: ev.meta } : {}),
+  };
+}
+
+/** The 'auto' delta an event maps to, gated on its own raw id (1:1);
+ *  null for events with no rollup counter (`retrieved`). */
+function autoDeltaFor(
+  ev: OutcomeEventInput,
+  rid: StringRecordId,
+  now: Date,
+): OutcomeTxDeltaRow | null {
+  const spec = AUTO_STAT[ev.event];
+  if (!spec) return null;
+  return {
+    rawId: rid,
+    row: deltaRow(
+      {
+        subjectKind: ev.subjectKind,
+        subjectId: ev.subjectId,
+        counter: spec.counter,
+        delta: 1,
+        ...(spec.used ? { lastUsedAt: now } : {}),
+        ...(spec.verified ? { lastVerifiedUseAt: now } : {}),
+      },
+      now,
+    ),
+  };
+}
+
+export function buildOutcomeTxPayload(args: {
+  events: OutcomeEventInput[];
+  statDeltas: 'auto' | StatDelta[];
+  now: Date;
+  requestScope: string;
+  batchSeq: number;
+  requestId?: string | undefined;
+}): OutcomeTxPayload | null {
+  const { events, statDeltas, now, requestScope, batchSeq, requestId } = args;
+  const rawIds: StringRecordId[] = [];
+  const rows: Array<Record<string, unknown>> = [];
+  const deltas: OutcomeTxDeltaRow[] = [];
+  const idBySubject = new Map<string, StringRecordId>();
+  for (const ev of events) {
+    const hex = outcomeEventId(outcomeDedupeKey(ev), requestScope, batchSeq);
+    const rid = new StringRecordId(`memory_outcome:${hex}`);
+    rawIds.push(rid);
+    const subjectKey = `${ev.subjectKind}|${ev.subjectId}`;
+    if (!idBySubject.has(subjectKey)) idBySubject.set(subjectKey, rid);
+    rows.push(eventRow(ev, rid, { now, requestId }));
+    if (statDeltas === 'auto') {
+      const delta = autoDeltaFor(ev, rid, now);
+      if (delta) deltas.push(delta);
+    }
+  }
+  if (statDeltas !== 'auto') {
+    for (const d of statDeltas) {
+      const rid = idBySubject.get(`${d.subjectKind}|${d.subjectId}`);
+      deltas.push({ ...(rid ? { rawId: rid } : {}), row: deltaRow(d, now) });
+    }
+  }
+  if (rows.length === 0 && deltas.length === 0) return null;
+  return { rawIds, rows, deltas };
+}
+
+/**
+ * ONE BEGIN…COMMIT dispatch of the assembled payload (runTransaction —
+ * the confirmed single-query() idiom; a mid-batch failure rolls the raw
+ * append AND the stat fold back together, closing the 0107 divergence
+ * window where one side landed without the other). The caller owns the
+ * single OCC retry; the payload is reused verbatim so the retry
+ * recomputes nothing.
+ */
+export async function runOutcomeTx(
+  db: Surreal,
+  payload: OutcomeTxPayload,
+): Promise<{ total: number; skipped: number }> {
+  return runTransaction(db, (tx) => {
+    tx.bind('rawIds', payload.rawIds).bind('deltas', payload.deltas);
+    tx.add(OUTCOME_TX_PRESELECT);
+    if (payload.rows.length > 0) {
+      tx.add(OUTCOME_TX_RAW_INSERT).bind('rows', payload.rows);
+    }
+    tx.add(OUTCOME_TX_DELTA_GATE);
+    tx.add(OUTCOME_TX_STAT_FOLD);
+    tx.add(OUTCOME_TX_RETURN);
+  });
+}

--- a/src/outcomes/outcomes.module.ts
+++ b/src/outcomes/outcomes.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { MemoryDecisionService } from './memory-decision.service';
 import { MemoryOutcomeService } from './memory-outcome.service';
 import { OutcomePruneService } from './outcome-prune.service';
 import { ToolObservationService } from './tool-observation.service';
@@ -6,14 +7,20 @@ import { ToolObservationService } from './tool-observation.service';
 /**
  * Outcome telemetry (migration 0107): the append-only memory_outcome
  * event log + the memory_outcome_stat write-path rollup, behind ONE
- * write seam (MemoryOutcomeService) plus the raw-log retention cron
+ * write seam (MemoryOutcomeService), the decision-context writer
+ * (MemoryDecisionService, 0119) plus the telemetry retention cron
  * (OutcomePruneService). Imported by the writer modules (search /
  * synthesize / feedback / ingest-core); every injection there is
  * @Optional so positionally-constructed unit fixtures stay valid.
  * SurrealService and ApiKeyService come from @Global modules.
  */
 @Module({
-  providers: [MemoryOutcomeService, OutcomePruneService, ToolObservationService],
-  exports: [MemoryOutcomeService, ToolObservationService],
+  providers: [
+    MemoryDecisionService,
+    MemoryOutcomeService,
+    OutcomePruneService,
+    ToolObservationService,
+  ],
+  exports: [MemoryDecisionService, MemoryOutcomeService, ToolObservationService],
 })
 export class OutcomesModule {}

--- a/src/synthesize/adaptive-gates.ts
+++ b/src/synthesize/adaptive-gates.ts
@@ -1,0 +1,86 @@
+import { FocusSignalService } from './focus-signal.service';
+import type { SearchHit } from '../search/search.service';
+import type { LaneId } from './answer-router';
+import type { AbstainAdaptiveGate } from './verdict';
+import {
+  buildFocusSignal,
+  calibratedConfidence,
+  hasUsableCalibration,
+  queryClassOf,
+  type FocusSignal,
+  type PerClassCalibration,
+} from './focus-signal';
+
+/**
+ * The two fovea adaptive-gate resolvers (Optics-2 §4.1 / Optics §4.2),
+ * extracted from the synthesize orchestrator (file budget). Semantics
+ * unchanged and load-bearing: each returns its gate ONLY when its flag
+ * is on AND a USABLE model (a class fit from real labeled samples) is
+ * persisted for the tenant; otherwise undefined so the consumer takes
+ * its static path — an unconfigured tenant serves byte-identically. The
+ * env reads live in the common layer (fovea-flags, via the
+ * FocusSignalService statics), never in this engine dir (engine-gates
+ * S5.2). A load failure returns undefined (fail-safe to static).
+ */
+
+interface AdaptiveGateDeps {
+  focusSignal: FocusSignalService | undefined;
+  logger: { warn(message: string): void };
+}
+
+/**
+ * Optics-2 (§4.1) adaptive-L3 inputs: the loaded per-class VERDICT-stage
+ * calibration + escalate threshold, or undefined → the static
+ * coverage-floor L3 path.
+ */
+export async function resolveAdaptiveL3(
+  deps: AdaptiveGateDeps,
+  companyId: string,
+): Promise<{ calibration: PerClassCalibration; threshold: number } | undefined> {
+  if (!deps.focusSignal || !FocusSignalService.adaptiveL3Enabled()) return undefined;
+  try {
+    const calibration = await deps.focusSignal.loadCalibration(companyId);
+    if (!hasUsableCalibration(calibration)) return undefined;
+    return { calibration, threshold: FocusSignalService.adaptiveL3EscalateThreshold() };
+  } catch (e) {
+    deps.logger.warn(
+      `adaptive-L3 calibration load failed; static fallback: ${(e as Error).message}`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Optics §4.2 adaptive-abstention gate: the calibrated PRE-ANSWER
+ * {confidence, threshold} for the coverage-abstention decision, computed
+ * from the SAME per-fact scores the pre-answer capture used with
+ * verdict='none' (fit-shape = apply-shape §4.2) and the loaded
+ * PRE-ANSWER calibration; undefined → the static coverage floor.
+ * `signal` rides along (structurally invisible to the verdict.ts gate
+ * consumer) so the 0119 abstain decision writer reuses the SAME numbers
+ * instead of recomputing.
+ */
+export async function resolveAdaptiveAbstain(
+  deps: AdaptiveGateDeps,
+  companyId: string,
+  args: { results: SearchHit[]; lane: LaneId | null },
+): Promise<(AbstainAdaptiveGate & { signal: FocusSignal }) | undefined> {
+  if (!deps.focusSignal || !FocusSignalService.adaptiveAbstainEnabled()) return undefined;
+  try {
+    const calibration = await deps.focusSignal.loadCalibration(companyId, 'preanswer');
+    if (!hasUsableCalibration(calibration)) return undefined;
+    const factScores = args.results.flatMap((hit) => hit.facts.map((f) => f.score));
+    const signal = buildFocusSignal({
+      queryClass: queryClassOf(args.lane),
+      factScores,
+      verifierVerdict: 'none',
+    });
+    const confidence = calibratedConfidence(calibration, signal);
+    return { confidence, threshold: FocusSignalService.adaptiveAbstainThreshold(), signal };
+  } catch (e) {
+    deps.logger.warn(
+      `adaptive-abstain calibration load failed; static fallback: ${(e as Error).message}`,
+    );
+    return undefined;
+  }
+}

--- a/src/synthesize/answer-integrity.ts
+++ b/src/synthesize/answer-integrity.ts
@@ -53,6 +53,14 @@ export interface FinalizeContext {
    * callers) ⇒ no events, like the empty integrity gate.
    */
   companyId?: string | undefined;
+  /**
+   * 0119: the request's primary decision id (abstain gate or L3
+   * trigger), set ONLY under OUTCOME_DECISION_CAPTURE. finalizeAndAdmit
+   * threads it onto the outcome rows (emitAnswerUse) so an outcome can
+   * be joined back to the decision that produced it. Absent ⇒ rows
+   * byte-identical.
+   */
+  decisionId?: string | undefined;
 }
 
 /**

--- a/src/synthesize/decision-emit.ts
+++ b/src/synthesize/decision-emit.ts
@@ -1,0 +1,130 @@
+import { MemoryDecisionService } from '../outcomes/memory-decision.service';
+import type { SearchHit } from '../search/search.service';
+import type { LaneId } from './answer-router';
+import type { AbstainAdaptiveGate } from './verdict';
+import type { L3DecisionDraft } from './l3-escalation.service';
+import {
+  buildFocusSignal,
+  queryClassOf,
+  rawFocusConfidence,
+  type FocusSignal,
+} from './focus-signal';
+
+/**
+ * Decision-context (0119) emit seams for the synthesize orchestrator,
+ * extracted from the service (file/function budgets) — the outcome-emit
+ * idiom. Every function is a guarded no-op unless the decision writer is
+ * wired AND OUTCOME_DECISION_CAPTURE is on — checked through the service
+ * STATIC so this engine dir takes resolved config only and never reads
+ * the environment directly (engine-gates S5.2). The writer detaches its
+ * insert (root pool, fire-and-forget, INSERT IGNORE on a deterministic
+ * id), so serving never waits on decision telemetry and a telemetry
+ * failure can never fail an answer.
+ */
+
+/**
+ * Mutable per-request decision-capture context. `t0` anchors the
+ * decision rows' costs.latencyMs; `primaryDecisionId` is set by
+ * whichever decision writer fires FIRST in the flow (the abstain gate
+ * evaluates pre-generation, the L3 trigger post-verifier) and is
+ * threaded onto the outcome rows (emitAnswerUse) + the verdict-stage
+ * focus sample. Stays empty unless OUTCOME_DECISION_CAPTURE is on.
+ */
+export interface DecisionContext {
+  t0: number;
+  primaryDecisionId?: string | undefined;
+}
+
+/**
+ * The 'abstain' decision writer, called once per request where the
+ * coverage-abstention gate was LIVE. observedState carries the SAME
+ * buildFocusSignal numbers the adaptive gate computed (threaded via
+ * resolveAdaptiveAbstain's `signal` — recomputed only on the static
+ * path, where no gate ran); alternatives/actionScore exist only on the
+ * adaptive path (the static floor is a rule, not a scored policy).
+ * Claims the primary-decision slot when it is still free.
+ */
+export function captureAbstainDecision(
+  decisions: MemoryDecisionService | undefined,
+  companyId: string,
+  args: {
+    results: SearchHit[];
+    lane: LaneId | null;
+    adaptive?: (AbstainAdaptiveGate & { signal: FocusSignal }) | undefined;
+    abstained: boolean;
+    decisionCtx: DecisionContext;
+  },
+): void {
+  if (!decisions || !MemoryDecisionService.enabled()) return;
+  const factScores = args.results.flatMap((hit) => hit.facts.map((f) => f.score));
+  const signal =
+    args.adaptive?.signal ??
+    buildFocusSignal({
+      queryClass: queryClassOf(args.lane),
+      factScores,
+      verifierVerdict: 'none',
+    });
+  const id = decisions.record(companyId, {
+    decisionKind: 'abstain',
+    policyVersion: args.adaptive ? `adaptive@thr=${args.adaptive.threshold}` : 'static',
+    chosenAction: args.abstained ? 'abstain' : 'proceed',
+    ...(args.adaptive ? { actionScore: args.adaptive.confidence } : {}),
+    observedState: {
+      topScore: signal.topScore,
+      coverageScore: signal.coverageScore,
+      retrievalGap: signal.retrievalGap,
+      rawConfidence: rawFocusConfidence(signal),
+      candidateCount: factScores.length,
+      queryClass: signal.queryClass,
+    },
+    ...(args.adaptive
+      ? {
+          alternatives: [
+            { action: 'abstain', score: args.adaptive.threshold },
+            { action: 'proceed', score: args.adaptive.confidence },
+          ],
+        }
+      : {}),
+    costs: { latencyMs: Date.now() - args.decisionCtx.t0 },
+  });
+  if (id !== undefined) args.decisionCtx.primaryDecisionId ??= id;
+}
+
+/**
+ * Build the L3 onDecision callback (the service invokes it EXACTLY ONCE
+ * per escalate() evaluation — L3EscalateInput.onDecision). Maps the
+ * draft onto a memory_decision row: reason → chosenAction ('escalate' on
+ * 'fire', else 'skip:<reason>'), the adaptive numbers → actionScore /
+ * policyVersion / observedState, and maxSessions → candidateCount (the
+ * ranked-session BUDGET at this seam — see the L3DecisionDraft
+ * docblock). Undefined when capture is off / the writer is absent, so
+ * the L3 input stays byte-identical.
+ */
+export function buildL3DecisionCallback(
+  decisions: MemoryDecisionService | undefined,
+  companyId: string,
+  decisionCtx: DecisionContext,
+): ((draft: L3DecisionDraft) => void) | undefined {
+  if (!decisions || !MemoryDecisionService.enabled()) return undefined;
+  return (draft: L3DecisionDraft) => {
+    const id = decisions.record(companyId, {
+      decisionKind: 'l3_escalation',
+      policyVersion: draft.adaptive ? `adaptive@thr=${draft.adaptive.threshold}` : 'static',
+      chosenAction: draft.reason === 'fire' ? 'escalate' : `skip:${draft.reason}`,
+      ...(draft.adaptive ? { actionScore: draft.adaptive.confidence } : {}),
+      observedState: {
+        ...(draft.adaptive
+          ? {
+              topScore: draft.adaptive.topScore,
+              coverageScore: draft.adaptive.coverageScore,
+              retrievalGap: draft.adaptive.retrievalGap,
+              queryClass: draft.adaptive.queryClass,
+            }
+          : {}),
+        ...(draft.maxSessions !== undefined ? { candidateCount: draft.maxSessions } : {}),
+      },
+      costs: { latencyMs: Date.now() - decisionCtx.t0 },
+    });
+    if (id !== undefined) decisionCtx.primaryDecisionId ??= id;
+  };
+}

--- a/src/synthesize/focus-signal.service.ts
+++ b/src/synthesize/focus-signal.service.ts
@@ -142,6 +142,14 @@ export class FocusSignalService {
       verdict: FocusVerdict;
       lane: LaneId | null;
       query?: string;
+      /**
+       * 0119 join key: the request's primary decision id, threaded by
+       * synthesize ONLY under OUTCOME_DECISION_CAPTURE. Absent (the
+       * default, and always when that flag is off) ⇒ the CREATE is
+       * byte-identical to pre-0119 — 0094's fit/measure surface stays
+       * the sole consumer of samples; new rows merely gain the column.
+       */
+      decisionId?: string | undefined;
     },
     stage: FocusStage = 'verdict',
   ): Promise<void> {
@@ -169,7 +177,7 @@ export class FocusSignalService {
           signal.script = det.script;
         }
       }
-      await this.insertSample(companyId, signal, stage);
+      await this.insertSample(companyId, { sig: signal, stage, decisionId: args.decisionId });
     } catch (e) {
       this.logger.warn(`focus-signal capture failed (${(e as Error).message}); ignored`);
     }
@@ -177,16 +185,18 @@ export class FocusSignalService {
 
   private async insertSample(
     companyId: string,
-    sig: FocusSignal,
-    stage: FocusStage = 'verdict',
+    args: { sig: FocusSignal; stage: FocusStage; decisionId?: string | undefined },
   ): Promise<void> {
+    const { sig, stage, decisionId } = args;
     await this.surreal.withCompany(companyId, async (db) => {
       // Tier 5 language/script columns are appended to the CONTENT only when
       // detected — an omitted optional field stays NONE (not NULL), so
       // `language IS NONE` still selects the global per-class pool. Off ⇒ the
       // clause is empty and the insert is byte-identical to pre-Tier-5.
+      // The 0119 decisionId join key follows the same appended-only idiom.
       const langFields =
         (sig.language ? ', language: $language' : '') + (sig.script ? ', script: $script' : '');
+      const decisionField = decisionId ? ', decisionId: $decisionId' : '';
       await db.query(
         `CREATE focus_signal_sample CONTENT {
             companyId: $companyId,
@@ -198,7 +208,7 @@ export class FocusSignalService {
             verifierVerdict: $verifierVerdict,
             retrievalGap: $retrievalGap,
             rawConfidence: $rawConfidence,
-            correct: NONE${langFields}
+            correct: NONE${langFields}${decisionField}
          }`,
         {
           companyId,
@@ -212,6 +222,7 @@ export class FocusSignalService {
           rawConfidence: rawFocusConfidence(sig),
           ...(sig.language ? { language: sig.language } : {}),
           ...(sig.script ? { script: sig.script } : {}),
+          ...(decisionId ? { decisionId } : {}),
         },
       );
     });

--- a/src/synthesize/l3-escalation.service.ts
+++ b/src/synthesize/l3-escalation.service.ts
@@ -36,11 +36,13 @@ import {
   type L3SessionAnchor,
   type L3AdaptiveGate,
   type L3AnchorSource,
+  type L3TriggerReason,
 } from './l3-escalation';
 import {
   buildFocusSignal,
   calibratedConfidence,
   queryClassOf,
+  type FocusSignal,
   type PerClassCalibration,
 } from './focus-signal';
 
@@ -129,6 +131,48 @@ export interface L3EscalateInput {
    * confidence.
    */
   adaptiveL3?: { calibration: PerClassCalibration; threshold: number } | undefined;
+  /**
+   * 0119 decision-context capture: invoked EXACTLY ONCE per escalate()
+   * evaluation with the trigger outcome + the adaptive-gate numbers (an
+   * optional CALLBACK, deliberately not a 5th constructor dep and not an
+   * env read — this engine dir takes resolved config only, S5.2; the
+   * synthesize orchestrator owns the MemoryDecisionService injection and
+   * builds the callback only when capture is on). Absent ⇒ byte-identical
+   * evaluation. The existing l3_adaptive traceArtifact stays AS WELL —
+   * debug ring and durable telemetry serve different consumers.
+   */
+  onDecision?: ((draft: L3DecisionDraft) => void) | undefined;
+}
+
+/**
+ * What one escalate() evaluation decided — the material the synthesize
+ * orchestrator maps onto a memory_decision row (kind 'l3_escalation').
+ * Mapping contract: `reason` → chosenAction ('escalate' on 'fire', else
+ * 'skip:<reason>'); `adaptive` → actionScore/policyVersion/observedState
+ * signal numbers; `maxSessions` → observedState.candidateCount —
+ * candidateCount is semantically the RANKED-SESSION BUDGET at this seam
+ * (present only when the ladder fired).
+ */
+export interface L3DecisionDraft {
+  /** The l3TriggerDecision result ('fire' | skip_*). */
+  reason: L3TriggerReason;
+  /** Adaptive-gate numbers when a usable model gated the trigger. */
+  adaptive?:
+    | {
+        confidence: number;
+        threshold: number;
+        queryClass: string;
+        topScore: number;
+        coverageScore: number;
+        retrievalGap: number;
+      }
+    | undefined;
+  /** Ranked-session budget of the fired escalation (adaptive-scaled or
+   *  the static profile cap). Absent when the ladder did not fire. */
+  maxSessions?: number | undefined;
+  /** Whether the fired escalation flipped the verdict fail→pass.
+   *  Absent when the ladder did not fire. */
+  flipped?: boolean | undefined;
 }
 
 /** A flipped L3 answer to finalise; null = fall through to abstention. */
@@ -219,18 +263,54 @@ export class L3EscalationService {
       escalated: input.escalated,
       adaptive,
     });
-    if (reason !== 'fire') return null;
+    // 0119 decision draft — completed along the evaluation (maxSessions/
+    // flipped on the fire path) and emitted EXACTLY ONCE per evaluation.
+    const draft: L3DecisionDraft = {
+      reason,
+      ...(adaptive
+        ? {
+            adaptive: {
+              confidence: adaptive.confidence,
+              threshold: adaptive.threshold,
+              queryClass: adaptive.signal.queryClass,
+              topScore: adaptive.signal.topScore,
+              coverageScore: adaptive.signal.coverageScore,
+              retrievalGap: adaptive.signal.retrievalGap,
+            },
+          }
+        : {}),
+    };
+    if (reason !== 'fire') {
+      this.emitDecision(input, draft);
+      return null;
+    }
     // Which sub-condition fired — the observability that tells the operator
     // whether the adaptive optic or the static floor is doing the gating.
     this.metrics?.countL3TriggerPath(adaptive ? 'adaptive' : 'static');
     try {
-      return await this.runEscalation(input, adaptive);
+      const result = await this.runEscalation(input, adaptive, draft);
+      draft.flipped = result !== null;
+      return result;
     } catch (e) {
       // Fail-closed to abstention — the lane must never break synthesis.
+      draft.flipped = false;
       this.logger.warn(
         `L3 escalation failed (companyId=${input.companyId}): ${(e as Error).message}`,
       );
       return null;
+    } finally {
+      this.emitDecision(input, draft);
+    }
+  }
+
+  /** Invoke the optional decision callback, fail-open: telemetry must
+   *  never break the escalation (or the abstention fall-through). */
+  private emitDecision(input: L3EscalateInput, draft: L3DecisionDraft): void {
+    if (!input.onDecision) return;
+    try {
+      input.onDecision(draft);
+    } catch (e) {
+      this.logger.warn(`L3 decision capture failed: ${(e as Error).message}`);
     }
   }
 
@@ -240,10 +320,15 @@ export class L3EscalationService {
    * per-class calibration, and return {confidence, threshold}. Returns
    * undefined when no model was supplied (adaptiveL3 absent) — the static
    * coverage path then runs. Also records the calibrated confidence on the
-   * existing L3 ladder trace for observability. Pure math over pure
-   * helpers (buildFocusSignal / calibratedConfidence); no IO.
+   * existing L3 ladder trace for observability, and carries the built
+   * signal alongside the gate (extra property, structurally invisible to
+   * the L3AdaptiveGate consumers) so the 0119 decision draft reuses the
+   * SAME numbers instead of recomputing. Pure math over pure helpers
+   * (buildFocusSignal / calibratedConfidence); no IO.
    */
-  private resolveAdaptiveGate(input: L3EscalateInput): L3AdaptiveGate | undefined {
+  private resolveAdaptiveGate(
+    input: L3EscalateInput,
+  ): (L3AdaptiveGate & { signal: FocusSignal }) | undefined {
     const a = input.adaptiveL3;
     if (!a) return undefined;
     const factScores: number[] = [];
@@ -264,12 +349,13 @@ export class L3EscalationService {
       topScore: signal.topScore,
       retrievalGap: signal.retrievalGap,
     });
-    return { confidence, threshold: a.threshold };
+    return { confidence, threshold: a.threshold, signal };
   }
 
   private async runEscalation(
     input: L3EscalateInput,
-    adaptive?: L3AdaptiveGate,
+    adaptive: L3AdaptiveGate | undefined,
+    draft: L3DecisionDraft,
   ): Promise<L3EscalateResult | null> {
     const { profile, dto } = input;
     const includePii = input.callerScopes.includes('brain:read_pii');
@@ -317,6 +403,8 @@ export class L3EscalationService {
           maxSessions: profile.l3MaxSessions,
         })
       : profile.l3MaxSessions;
+    // 0119: the ranked-session budget of THIS fired escalation.
+    draft.maxSessions = maxSessions;
     const sessionIds = rankL3Sessions(anchors, {
       max: maxSessions,
       window,

--- a/src/synthesize/minicheck-client.ts
+++ b/src/synthesize/minicheck-client.ts
@@ -7,10 +7,11 @@
  * answer whose text is not consistent with the evidence bundle should
  * decline instead of surfacing.
  *
- * Pure module — no DI, no env reads; the orchestrator passes the
- * endpoint. Errors throw (the caller owns the degrade contract, same
- * as the LLM verifier path).
+ * No DI, no env reads; the orchestrator passes the endpoint. Errors
+ * throw (the caller owns the degrade contract, same as the LLM
+ * verifier path).
  */
+import { withSpan } from '../common/tracing';
 
 export interface MiniCheckRequest {
   /** Ollama base URL, e.g. http://127.0.0.1:11434 */
@@ -23,6 +24,42 @@ export interface MiniCheckRequest {
   claim: string;
   fetchImpl?: typeof fetch;
   signal?: AbortSignal | undefined;
+}
+
+/**
+ * V11 §2 arm (b): the local-NLI judgment mapped onto the verifier
+ * verdict shape, so it falls through the SAME finalizeVerdict gate
+ * (verdict.ts treats 'minicheck' like 'verifier'). The claim is the
+ * whole answer text; the document is the evidence bundle the generator
+ * saw. A refinement candidate from the V10 §5 lesson — decompose the
+ * answer and check the connecting claim separately — is deliberately
+ * NOT in v1 (measure the plain form first). Extracted from the
+ * orchestrator (file budget); the service supplies its span + abort
+ * signal so the call keeps its observability.
+ */
+export async function miniCheckVerdict(
+  cfg: { baseUrl: string; model: string; signal?: AbortSignal | undefined },
+  args: {
+    answer: string;
+    factLines: string[];
+    transcriptLines: string[];
+    insightLines: string[];
+    /** MM-zoom PR2 parity: the media lines the generator saw. */
+    fragmentLines?: string[] | undefined;
+  },
+): Promise<{ verdict: 'supported' | 'unsupported'; unsupportedClaims: string[] }> {
+  const consistent = await withSpan('synthesize.verify', () =>
+    miniCheckConsistent({
+      baseUrl: cfg.baseUrl,
+      model: cfg.model,
+      document: buildMiniCheckDocument(args),
+      claim: args.answer,
+      signal: cfg.signal,
+    }),
+  );
+  return consistent
+    ? { verdict: 'supported', unsupportedClaims: [] }
+    : { verdict: 'unsupported', unsupportedClaims: [args.answer] };
 }
 
 /** True = the claim is consistent with the document (grounded). */
@@ -59,9 +96,10 @@ export async function miniCheckConsistent(req: MiniCheckRequest): Promise<boolea
  * G4 advisory notes are excluded exactly as on the verifier path, and
  * the MM-zoom PR2 media lines join when the fragment lane rendered
  * any). Pure string work, split out of synthesize.service (file-size
- * gate) at the natural seam.
+ * gate) at the natural seam. Not exported: miniCheckVerdict above is
+ * the one consumer (S5.5 dead-export gate).
  */
-export function buildMiniCheckDocument(args: {
+function buildMiniCheckDocument(args: {
   factLines: string[];
   transcriptLines: string[];
   insightLines: string[];

--- a/src/synthesize/outcome-emit.ts
+++ b/src/synthesize/outcome-emit.ts
@@ -65,14 +65,25 @@ export function unverifiedServe(
  */
 export function emitAnswerUse(
   outcomes: MemoryOutcomeService | undefined,
-  opts: { companyId: string | undefined; citations: Citation[]; verdict?: VerifierOutput },
+  opts: {
+    companyId: string | undefined;
+    citations: Citation[];
+    verdict?: VerifierOutput;
+    /**
+     * 0119: the request's primary decision id (abstain gate or L3
+     * trigger), threaded by synthesize ONLY under
+     * OUTCOME_DECISION_CAPTURE — absent ⇒ rows byte-identical.
+     */
+    decisionId?: string | undefined;
+  },
 ): void {
-  const { companyId, citations, verdict } = opts;
+  const { companyId, citations, verdict, decisionId } = opts;
   if (!outcomes || !MemoryOutcomeService.enabled() || companyId === undefined) return;
   const events: OutcomeEventInput[] = citations.map((c) => ({
     subjectKind: 'fact',
     subjectId: c.factId,
     event: 'used_in_answer',
+    ...(decisionId !== undefined ? { decisionId } : {}),
   }));
   if (verdict?.verdict === 'supported') {
     events.push(
@@ -81,6 +92,7 @@ export function emitAnswerUse(
         subjectId: c.factId,
         event: 'verifier_supported',
         meta: { verdict: verdict.verdict },
+        ...(decisionId !== undefined ? { decisionId } : {}),
       })),
     );
   }

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -13,7 +13,6 @@ import { SynthesisGuardrails, SynthesizeDto } from './dto/synthesize.dto';
 import { buildDecisionLog } from './decision-log';
 import { applyConformalGuardrail } from './conformal-guardrail';
 import { coverageAbstention, finalizeVerdict } from './verdict';
-import type { AbstainAdaptiveGate } from './verdict';
 import {
   attachDecisionLog,
   buildGeneratorArgs,
@@ -42,7 +41,7 @@ import { buildDateMathLines } from './date-math';
 export { buildFactIndex } from './fact-index';
 import { runGenerator, type GenerateRequest } from './generator-client';
 import { runVerifier, type VerifierOutput } from './verifier';
-import { buildMiniCheckDocument, miniCheckConsistent } from './minicheck-client';
+import { miniCheckVerdict } from './minicheck-client';
 export { buildGeneratorUserMessage } from './generator-prompt';
 import {
   EvidenceCollectorService,
@@ -51,13 +50,13 @@ import {
 } from './evidence-collector.service';
 import { L3EscalationService } from './l3-escalation.service';
 import { FocusSignalService } from './focus-signal.service';
+import type { FocusVerdict } from './focus-signal';
+import { resolveAdaptiveAbstain, resolveAdaptiveL3 } from './adaptive-gates';
 import {
-  buildFocusSignal,
-  calibratedConfidence,
-  hasUsableCalibration,
-  queryClassOf,
-} from './focus-signal';
-import type { FocusVerdict, PerClassCalibration } from './focus-signal';
+  buildL3DecisionCallback,
+  captureAbstainDecision,
+  type DecisionContext,
+} from './decision-emit';
 import { LensSuppressionService } from './lens-suppression.service';
 import { MultilingualLaneClassifierService } from './multilingual-lane-classifier.service';
 import {
@@ -65,6 +64,7 @@ import {
   type AnswerCacheBeginResult,
 } from '../answer-cache/answer-cache.service';
 import { MemoryOutcomeService } from '../outcomes/memory-outcome.service';
+import { MemoryDecisionService } from '../outcomes/memory-decision.service';
 import { emitAnswerUse, emitSelectedForContext, unverifiedServe } from './outcome-emit';
 import { NOOP_REPORTER, type ProgressReporter } from '../mcp/progress-reporter';
 
@@ -150,6 +150,10 @@ export class SynthesizeService {
     @Optional() private readonly predicateRegistry?: PredicateRegistryService,
     // 0115 ungrounded-support gate: grounding fetch source (grounding-fetch.ts).
     @Optional() private readonly surreal?: SurrealService,
+    // 0119 decision-context writer — @Optional so positional unit
+    // fixtures stay valid; absent (or flag off) ⇒ no decision rows, no
+    // join columns, byte-identical serving.
+    @Optional() private readonly decisions?: MemoryDecisionService,
   ) {
     this.openai = createOpenAiClientOrThrow(this.configService);
     this.defaultModel = this.configService.get<string>(
@@ -185,14 +189,36 @@ export class SynthesizeService {
     this.minicheckModel = this.configService.get<string>('MINICHECK_MODEL', 'bespoke-minicheck');
   }
 
-  async synthesize({
-    companyId,
-    dto,
-    callerScopes,
-    onProgress = NOOP_REPORTER,
-    extraHits,
-    profile = getActiveRetrievalProfile(),
-  }: SynthesizeOptions): Promise<SynthesizeResult> {
+  /**
+   * Public entry — the grounded flow plus the ONE flag-free change of
+   * the 0119 wave: a synthesize-boundary latency observe. The
+   * brain_search_duration_seconds histogram was defined but never
+   * observed on the serving path, so the MRI latency cells rendered
+   * `pending` forever (audit pt-8). A prom histogram observe() has no
+   * serving-path branch and alters no response bytes — metrics-only,
+   * zero behavioral effect — and the `finally` guarantees EXACTLY ONE
+   * observation per request, including error/abstain/cache-hit exits.
+   */
+  async synthesize(opts: SynthesizeOptions): Promise<SynthesizeResult> {
+    const t0 = Date.now();
+    try {
+      return await this.synthesizeGrounded(opts, { t0 });
+    } finally {
+      this.metrics?.observeSearchDuration((Date.now() - t0) / 1000);
+    }
+  }
+
+  private async synthesizeGrounded(
+    {
+      companyId,
+      dto,
+      callerScopes,
+      onProgress = NOOP_REPORTER,
+      extraHits,
+      profile = getActiveRetrievalProfile(),
+    }: SynthesizeOptions,
+    decisionCtx: DecisionContext,
+  ): Promise<SynthesizeResult> {
     // Defence-in-depth clamp. SynthesizeDto.@MaxLength('query', 8000)
     // covers HTTP callers, but multi-hop and admin-demo drive
     // synthesize() with bodies that bypass class-validator. Clamp here
@@ -284,7 +310,7 @@ export class SynthesizeService {
     // V9 §4 coverage abstention + Optics §4.2 pre-answer capture/gate (seam).
     const abstained = await this.maybeCoverageAbstain(
       companyId,
-      { lane, query: dto.query },
+      { lane, query: dto.query, decisionCtx },
       { profile, guardrails, results, explain },
     );
     if (abstained) return abstained;
@@ -382,13 +408,17 @@ export class SynthesizeService {
     let verdict: VerifierOutput;
     try {
       verdict = nliMode
-        ? await this.miniCheckVerdict({
-            answer: generated.answer,
-            factLines: promptFactLines,
-            transcriptLines,
-            insightLines,
-            fragmentLines,
-          })
+        ? await miniCheckVerdict(
+            { baseUrl: this.minicheckUrl, model: this.minicheckModel, signal: getAbortSignal() },
+            {
+              answer: generated.answer,
+              factLines: promptFactLines,
+              transcriptLines,
+              insightLines,
+              // MM-zoom PR2 parity: the media lines the generator saw.
+              fragmentLines,
+            },
+          )
         : await withSpan(
             'synthesize.verify',
             () =>
@@ -445,10 +475,11 @@ export class SynthesizeService {
     }
 
     // Optics-1 focus capture — SERVING-NEUTRAL guarded no-op (see method).
-    // `dto.query` carries the Tier 5 language key onto the verdict sample.
+    // `dto.query` carries the Tier 5 language key onto the verdict sample;
+    // the 0119 primary decision id (if any) joins sample → decision row.
     await this.maybeCaptureFocusSignal(
       companyId,
-      { results, verdict: verdict.verdict, lane },
+      { results, verdict: verdict.verdict, lane, decisionId: decisionCtx.primaryDecisionId },
       dto.query,
     );
 
@@ -461,43 +492,46 @@ export class SynthesizeService {
     // A + C): on no-flip the primary finalizeAndAdmit runs it, and the L3 flip
     // path runs it too (its raw-transcript answer is the most exposed, so the
     // gate is end-to-end).
-    return (
-      (await this.tryL3Escalation({
-        cache,
-        verdict,
-        companyId,
-        callerScopes,
-        dto,
-        profile,
-        lane,
-        model,
-        answerLang,
-        refineAttempted: produced.refined,
-        results,
-        factIndex,
-        promptFactLines,
-        dateMathLines,
-        guardrails,
-        explain,
-      })) ??
-      this.finalizeAndAdmit({ cache, dto, profile, model, companyId }, verdict, {
-        answer: generated.answer,
-        citations,
-        results,
-        guardrails,
-        decisionLog,
-        abstention: profile.abstentionCalibration,
-        // MM-zoom PR2: fragment-arm evidence citations through the
-        // rendered-set fence — spread onto the served result only when
-        // non-empty (finalizeVerdict) and fed to the 0113 capability
-        // gate (citedCapabilities). [] with the flag off ⇒ byte-identical.
-        evidenceCitations: resolveAndCountFragmentCitations({
-          citedFragmentIds: generated.citedFragmentIds,
-          fragmentsById,
-          metrics: this.metrics,
-        }),
-      })
-    );
+    const escalated = await this.tryL3Escalation({
+      cache,
+      verdict,
+      companyId,
+      callerScopes,
+      dto,
+      profile,
+      lane,
+      model,
+      answerLang,
+      refineAttempted: produced.refined,
+      results,
+      factIndex,
+      promptFactLines,
+      dateMathLines,
+      guardrails,
+      explain,
+      decisionCtx,
+    });
+    if (escalated) return escalated;
+    // decisionId read AFTER the L3 evaluation: a skip/no-flip escalation
+    // still minted its decision row, and the primary serve joins to it.
+    const decisionId = decisionCtx.primaryDecisionId;
+    return this.finalizeAndAdmit({ cache, dto, profile, model, companyId, decisionId }, verdict, {
+      answer: generated.answer,
+      citations,
+      results,
+      guardrails,
+      decisionLog,
+      abstention: profile.abstentionCalibration,
+      // MM-zoom PR2: fragment-arm evidence citations through the
+      // rendered-set fence — spread onto the served result only when
+      // non-empty (finalizeVerdict) and fed to the 0113 capability
+      // gate (citedCapabilities). [] with the flag off ⇒ byte-identical.
+      evidenceCitations: resolveAndCountFragmentCitations({
+        citedFragmentIds: generated.citedFragmentIds,
+        fragmentsById,
+        metrics: this.metrics,
+      }),
+    });
   }
 
   /**
@@ -543,7 +577,13 @@ export class SynthesizeService {
    */
   private async maybeCaptureFocusSignal(
     companyId: string,
-    signal: { results: SearchHit[]; verdict: FocusVerdict; lane: LaneId | null },
+    signal: {
+      results: SearchHit[];
+      verdict: FocusVerdict;
+      lane: LaneId | null;
+      /** 0119 join key — present only under OUTCOME_DECISION_CAPTURE. */
+      decisionId?: string | undefined;
+    },
     query: string,
   ): Promise<void> {
     if (!this.focusSignal || !FocusSignalService.captureEnabled()) return;
@@ -577,10 +617,20 @@ export class SynthesizeService {
     dateMathLines?: string[] | undefined;
     guardrails: SynthesisGuardrails;
     explain: boolean;
+    decisionCtx: DecisionContext;
   }): Promise<SynthesizeResult | null> {
-    const { profile, companyId } = args;
+    const { profile, companyId, decisionCtx } = args;
     if (!this.l3 || !profile.l3Escalation) return null;
-    const adaptiveL3 = await this.resolveAdaptiveL3(args.companyId);
+    const adaptiveL3 = await resolveAdaptiveL3(
+      { focusSignal: this.focusSignal, logger: this.logger },
+      args.companyId,
+    );
+    // 0119 decision capture: the service invokes the callback ONCE per
+    // escalate() evaluation (an optional callback — the L3 engine dir
+    // never reads env and never grows a MemoryDecisionService dep, S5.2).
+    // Escalate() awaits before finalize, so a minted id is visible to the
+    // L3-flip finalizeAndAdmit below via decisionCtx.
+    const onDecision = buildL3DecisionCallback(this.decisions, companyId, decisionCtx);
     const l3 = await this.l3.escalate({
       openai: this.openai,
       model: args.model,
@@ -598,6 +648,7 @@ export class SynthesizeService {
       answerLang: args.answerLang,
       dateMathLines: args.dateMathLines,
       ...(adaptiveL3 ? { adaptiveL3 } : {}),
+      ...(onDecision ? { onDecision } : {}),
     });
     if (!l3) return null;
     // Route the L3 supported answer through the SAME answer-integrity gate as
@@ -611,7 +662,14 @@ export class SynthesizeService {
     // → admit(final); a downgraded L3 abstain (reason=low_coverage, citations=[])
     // is rejected by admit()'s existing gate, so it is never cached.
     return this.finalizeAndAdmit(
-      { cache: args.cache, dto: args.dto, profile: args.profile, model: args.model, companyId },
+      {
+        cache: args.cache,
+        dto: args.dto,
+        profile: args.profile,
+        model: args.model,
+        companyId,
+        decisionId: decisionCtx.primaryDecisionId,
+      },
       l3.verdict,
       {
         answer: l3.answer,
@@ -629,73 +687,6 @@ export class SynthesizeService {
         abstention: profile.abstentionCalibration,
       },
     );
-  }
-
-  /**
-   * Optics-2 (§4.1) adaptive-L3 inputs. Returns the loaded per-class
-   * calibration + escalate threshold ONLY when FOVEA_ADAPTIVE_L3 is on AND
-   * a USABLE model (a class fit from real labeled samples) is persisted for
-   * the tenant; otherwise undefined so the L3 lane takes its static
-   * coverage-floor path. This is the load-bearing safety property: flag off
-   * → undefined → static; no/empty/bootstrap model → undefined → static —
-   * an unconfigured tenant serves byte-identically to the pre-Optics-2 L3.
-   * The env reads live in the common layer (fovea-flags, via the
-   * FocusSignalService statics), never in this engine dir (engine-gates
-   * S5.2). A load failure returns undefined (fail-safe to static).
-   */
-  private async resolveAdaptiveL3(
-    companyId: string,
-  ): Promise<{ calibration: PerClassCalibration; threshold: number } | undefined> {
-    if (!this.focusSignal || !FocusSignalService.adaptiveL3Enabled()) return undefined;
-    try {
-      const calibration = await this.focusSignal.loadCalibration(companyId);
-      if (!hasUsableCalibration(calibration)) return undefined;
-      return { calibration, threshold: FocusSignalService.adaptiveL3EscalateThreshold() };
-    } catch (e) {
-      this.logger.warn(
-        `adaptive-L3 calibration load failed; static fallback: ${(e as Error).message}`,
-      );
-      return undefined;
-    }
-  }
-
-  /**
-   * Optics §4.2 adaptive-abstention gate. Returns the calibrated pre-answer
-   * {confidence, threshold} for the coverage-abstention decision ONLY when
-   * FOVEA_ADAPTIVE_ABSTAIN is on AND a USABLE per-class PRE-ANSWER model is
-   * persisted for the tenant; otherwise undefined so the gate takes its
-   * static coverage-floor path. The confidence is computed from the SAME
-   * per-fact scores the pre-answer capture used, with verdict='none' (the
-   * constant that keys the pre-answer stage — fit-shape = apply-shape §4.2)
-   * and the loaded PRE-ANSWER calibration. Load-bearing safety property: flag
-   * off → undefined → static; no/empty/bootstrap model → undefined → static
-   * — an unconfigured tenant serves byte-identically to the static coverage
-   * abstention. The env reads live in the common layer (fovea-flags, via the
-   * FocusSignalService statics), never in this engine dir (engine-gates
-   * S5.2). A load failure returns undefined (fail-safe to static).
-   */
-  private async resolveAdaptiveAbstain(
-    companyId: string,
-    args: { results: SearchHit[]; lane: LaneId | null },
-  ): Promise<AbstainAdaptiveGate | undefined> {
-    if (!this.focusSignal || !FocusSignalService.adaptiveAbstainEnabled()) return undefined;
-    try {
-      const calibration = await this.focusSignal.loadCalibration(companyId, 'preanswer');
-      if (!hasUsableCalibration(calibration)) return undefined;
-      const factScores = args.results.flatMap((hit) => hit.facts.map((f) => f.score));
-      const signal = buildFocusSignal({
-        queryClass: queryClassOf(args.lane),
-        factScores,
-        verifierVerdict: 'none',
-      });
-      const confidence = calibratedConfidence(calibration, signal);
-      return { confidence, threshold: FocusSignalService.adaptiveAbstainThreshold() };
-    } catch (e) {
-      this.logger.warn(
-        `adaptive-abstain calibration load failed; static fallback: ${(e as Error).message}`,
-      );
-      return undefined;
-    }
   }
 
   /**
@@ -720,8 +711,14 @@ export class SynthesizeService {
     args: Omit<Parameters<typeof finalizeVerdict>[1], 'verdict' | 'questionAnswered'>,
   ): Promise<SynthesizeResult> {
     // 0107: cited facts were USED; a supported verdict ⇒ VERIFIED use.
-    // Both serving paths (primary + L3 flip) land here with companyId.
-    emitAnswerUse(this.outcomes, { companyId: ctx.companyId, citations: args.citations, verdict });
+    // Both serving paths (primary + L3 flip) land here with companyId;
+    // the 0119 primary decision id (capture on) joins outcome → decision.
+    emitAnswerUse(this.outcomes, {
+      companyId: ctx.companyId,
+      citations: args.citations,
+      verdict,
+      decisionId: ctx.decisionId,
+    });
     // The gate-resolution also folds in the evidence-capability flag
     // (FOVEA_EVIDENCE_CAPABILITY, 0113 — resolveEvidenceCapability, the
     // resolveAnswerIntegrity sibling in answer-integrity.ts): does the
@@ -959,7 +956,7 @@ export class SynthesizeService {
    */
   private async maybeCoverageAbstain(
     companyId: string,
-    ctx: { lane: LaneId | null; query: string },
+    ctx: { lane: LaneId | null; query: string; decisionCtx?: DecisionContext },
     args: Parameters<typeof coverageAbstention>[1],
   ): Promise<SynthesizeResult | null> {
     const { lane, query } = ctx;
@@ -975,6 +972,9 @@ export class SynthesizeService {
       (guardrails === 'strict' || guardrails === 'lenient');
     if (coverageRegime && this.focusSignal && FocusSignalService.captureEnabled()) {
       // `query` threads the Tier 5 language key into the pre-answer sample.
+      // (No decisionId here by construction: the abstain decision is minted
+      // AFTER the gate below decides — only the verdict-stage sample can
+      // carry the join key.)
       await this.focusSignal.maybeCapture(
         companyId,
         { results, verdict: 'none', lane, query },
@@ -982,9 +982,27 @@ export class SynthesizeService {
       );
     }
     const adaptive = coverageRegime
-      ? await this.resolveAdaptiveAbstain(companyId, { results, lane })
+      ? await resolveAdaptiveAbstain(
+          { focusSignal: this.focusSignal, logger: this.logger },
+          companyId,
+          { results, lane },
+        )
       : undefined;
-    return this.coverageAbstention({ ...args, ...(adaptive ? { adaptive } : {}) });
+    const result = this.coverageAbstention({ ...args, ...(adaptive ? { adaptive } : {}) });
+    // 0119 decision capture: ONE 'abstain' row per request where the gate
+    // was LIVE (coverage regime), recording which action it took. Guarded
+    // no-op unless OUTCOME_DECISION_CAPTURE is on and the writer is wired
+    // (decision-emit.ts); claims the primary-decision slot when free.
+    if (coverageRegime && ctx.decisionCtx) {
+      captureAbstainDecision(this.decisions, companyId, {
+        results,
+        lane,
+        adaptive,
+        abstained: result !== null,
+        decisionCtx: ctx.decisionCtx,
+      });
+    }
+    return result;
   }
 
   /**
@@ -1110,37 +1128,6 @@ export class SynthesizeService {
       logger: this.logger,
       ...args,
     });
-  }
-
-  /**
-   * V11 §2 arm (b): the local-NLI judgment mapped onto the verifier
-   * verdict shape, so it falls through the SAME finalizeVerdict gate
-   * (verdict.ts treats 'minicheck' like 'verifier'). The claim is the
-   * whole answer text; the document is the evidence bundle the
-   * generator saw. A refinement candidate from the V10 §5 lesson —
-   * decompose the answer and check the connecting claim separately —
-   * is deliberately NOT in v1 (measure the plain form first).
-   */
-  private async miniCheckVerdict(args: {
-    answer: string;
-    factLines: string[];
-    transcriptLines: string[];
-    insightLines: string[];
-    /** MM-zoom PR2 parity: the media lines the generator saw. */
-    fragmentLines?: string[] | undefined;
-  }): Promise<VerifierOutput> {
-    const consistent = await withSpan('synthesize.verify', () =>
-      miniCheckConsistent({
-        baseUrl: this.minicheckUrl,
-        model: this.minicheckModel,
-        document: buildMiniCheckDocument(args),
-        claim: args.answer,
-        signal: getAbortSignal(),
-      }),
-    );
-    return consistent
-      ? { verdict: 'supported', unsupportedClaims: [] }
-      : { verdict: 'unsupported', unsupportedClaims: [args.answer] };
   }
 
   private async callVerifier(args: {

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -260,6 +260,103 @@ describe('0111_tool_observation indexes', () => {
   });
 });
 
+describe('0119_decision_telemetry', () => {
+  const sql = readFileSync(join(MIGRATIONS, '0119_decision_telemetry.surql'), 'utf8');
+
+  it.each([
+    ['memory_decision_id_idx', 'memory_decision', 'decisionId'],
+    ['memory_decision_created_idx', 'memory_decision', 'createdAt'],
+    ['memory_decision_request_idx', 'memory_decision', 'requestId'],
+    ['memory_outcome_decision_idx', 'memory_outcome', 'decisionId'],
+  ])('defines %s on %s(%s)', (name, table, fields) => {
+    const re = new RegExp(`DEFINE INDEX IF NOT EXISTS ${name}\\s+ON ${table} FIELDS ${fields};`);
+    expect(sql).toMatch(re);
+  });
+
+  it('adds the decisionId join column to BOTH memory_outcome and focus_signal_sample', () => {
+    expect(sql).toContain('DEFINE FIELD IF NOT EXISTS decisionId ON memory_outcome');
+    expect(sql).toContain('DEFINE FIELD IF NOT EXISTS decisionId ON focus_signal_sample');
+  });
+
+  it('every index is SINGLE-FIELD and NON-UNIQUE (idempotency = record id, 3.2.4 planner rule)', () => {
+    // A UNIQUE index over an option<string> column would collide across
+    // every legacy NONE row (the 0119 header) — uniqueness must stay in
+    // the deterministic record id; compound coverage would put the GDPR
+    // join-purge / prune deletes into the 3.2.4 planner no-op class.
+    const defs = sql.match(/DEFINE INDEX[^;]+;/g) ?? [];
+    expect(defs.length).toBeGreaterThan(0);
+    for (const def of defs) {
+      const fields = /FIELDS ([^;]+);/.exec(def)?.[1] ?? '';
+      expect(fields).not.toContain(',');
+      expect(def).not.toContain('UNIQUE');
+    }
+  });
+
+  it('deliberately defines NO changefeed and NO event', () => {
+    const code = sql
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('--'))
+      .join('\n');
+    expect(code).not.toMatch(/CHANGEFEED/);
+    expect(code).not.toMatch(/DEFINE EVENT/);
+  });
+});
+
+describe('memory_decision GDPR join-purge (0119)', () => {
+  // Decision rows carry NO subject/user linkage by design — both forget
+  // services must resolve them THROUGH the subject's outcome rows
+  // (memory_outcome.decisionId) BEFORE those rows die, with the two-step
+  // LET-select → DELETE-by-ids idiom (the 3.2.4 planner no-op class).
+  const entitySrc = readFileSync(
+    join(__dirname, '..', 'src', 'entities', 'entity-forget.service.ts'),
+    'utf8',
+  );
+  const userSrc = readFileSync(
+    join(__dirname, '..', 'src', 'entities', 'user-forget.service.ts'),
+    'utf8',
+  );
+
+  it('entity-forget: pre-sweep AND in-tx legs collect keys through the outcome join', () => {
+    // Pre-sweep leg (before the bulk outcome purge deletes the join rows).
+    expect(entitySrc).toContain(
+      'LET $decKeys = array::distinct((SELECT VALUE decisionId FROM memory_outcome',
+    );
+    // In-tx straggler leg, keyed on the subject.
+    expect(entitySrc).toContain(
+      'LET $decKeys = (SELECT VALUE decisionId FROM memory_outcome WHERE subjectId.entityId = $ent AND decisionId IS NOT NONE)',
+    );
+    expect(entitySrc).toContain(
+      'LET $decIds = (SELECT VALUE id FROM memory_decision WHERE decisionId INSIDE $decKeys)',
+    );
+    expect(entitySrc).toContain('DELETE $decIds');
+  });
+
+  it('user-forget: decisions go FIRST, through the user-scoped outcome join', () => {
+    expect(userSrc).toContain(
+      'LET $decKeys = array::distinct((SELECT VALUE decisionId FROM memory_outcome',
+    );
+    expect(userSrc).toContain('subjectId.userId = $u AND decisionId IS NOT NONE');
+    expect(userSrc).toContain(
+      'LET $decIds = (SELECT VALUE id FROM memory_decision WHERE decisionId INSIDE $decKeys)',
+    );
+    expect(userSrc).toContain('DELETE $decIds');
+    // Ordering is load-bearing: the join keys must be collected while the
+    // outcome rows are alive — decisions before outcomes in the block.
+    expect(userSrc.indexOf('DELETE $decIds')).toBeLessThan(userSrc.indexOf('DELETE $outIds'));
+  });
+
+  it('no writer uses a one-step DELETE-WHERE on memory_decision', () => {
+    for (const src of [
+      entitySrc,
+      userSrc,
+      readFileSync(join(__dirname, '..', 'src', 'outcomes', 'outcome-prune.service.ts'), 'utf8'),
+      readFileSync(join(__dirname, '..', 'src', 'outcomes', 'memory-decision.service.ts'), 'utf8'),
+    ]) {
+      expect(src).not.toMatch(/DELETE memory_decision\s+WHERE/);
+    }
+  });
+});
+
 describe('0109_evidence_substrate indexes', () => {
   const sql = readFileSync(join(MIGRATIONS, '0109_evidence_substrate.surql'), 'utf8');
 

--- a/test/engine-gates.unit-spec.ts
+++ b/test/engine-gates.unit-spec.ts
@@ -162,6 +162,11 @@ describe('S5.5 — dead exports in the engine dirs', () => {
     // DIRECTLY by the answer-lang-guard unit spec for its precision cases
     // (within-script not adjudicated, proper-noun/numeric-safe, floor).
     'answerLanguageMismatch',
+    // V11 §2 arm (b) low-level NLI call. Consumed inside minicheck-client
+    // (miniCheckVerdict — the orchestrator's seam since the 0119 file-budget
+    // extraction) but pinned DIRECTLY by the minicheck unit spec for its
+    // fetch-level cases (prompt shape, Yes/No parse, error surface).
+    'miniCheckConsistent',
   ]);
   const TESTS = walk(join(ROOT, 'test'))
     .map((f) => readFileSync(f, 'utf8'))

--- a/test/memory-decision.e2e-spec.ts
+++ b/test/memory-decision.e2e-spec.ts
@@ -1,0 +1,298 @@
+/**
+ * Decision-context telemetry e2e (migration 0119, OUTCOME_DECISION_CAPTURE):
+ *   (a) a coverage-abstained /v1/synthesize writes ONE 'abstain' decision
+ *       row (static policy, costs.latencyMs int, content-free);
+ *   (b) a SERVED request (coverage-proceed floors + mocked OpenAI) writes
+ *       a 'proceed' decision; the outcome rows carry its decisionId
+ *       (join), and the verdict-stage focus_signal_sample carries it too;
+ *   (c) GDPR entity-forget purges the decision rows THROUGH the outcome
+ *       join (decisions carry no subject linkage by design);
+ *   (d) user-forget leg — same join purge on the user-scoped slice;
+ *   (e) capture off ⇒ zero decision rows (byte-identical).
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { MemoryOutcomeService } from '../src/outcomes/memory-outcome.service';
+import { MemoryDecisionService } from '../src/outcomes/memory-decision.service';
+import { mockSynthesizeOpenAi } from './test-doubles';
+
+interface DecisionRowWire {
+  decisionId: string;
+  decisionKind: string;
+  chosenAction: string;
+  policyVersion: string;
+  requestId?: string;
+  actionScore?: number;
+  observedState?: Record<string, unknown>;
+  costs?: { latencyMs?: number };
+}
+
+describe('memory_decision — decision-context capture, joins and cascade', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_decision_e2e' });
+    process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+    process.env.OUTCOME_DECISION_CAPTURE = '1';
+  });
+
+  afterAll(async () => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    delete process.env.OUTCOME_DECISION_CAPTURE;
+    delete process.env.RETRIEVAL_ABSTENTION_CALIBRATION;
+    delete process.env.RETRIEVAL_ABSTENTION_MIN_EVIDENCE;
+    delete process.env.RETRIEVAL_ABSTENTION_MIN_SCORE;
+    delete process.env.FOVEA_FOCUS_CAPTURE;
+    if (f) await f.close();
+  });
+
+  const tail = (factId: string) => factId.split(':')[1];
+
+  const decisionRows = async (): Promise<DecisionRowWire[]> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      // createdAt must appear in the selection — the 3.x parser rejects an
+      // ORDER BY over a non-selected idiom.
+      const [rows] = await db.query<[DecisionRowWire[]]>(
+        `SELECT decisionId, decisionKind, chosenAction, policyVersion, requestId,
+                actionScore, observedState, costs, createdAt
+           FROM memory_decision ORDER BY createdAt ASC`,
+      );
+      return (rows as DecisionRowWire[]) ?? [];
+    });
+  };
+
+  const purgeDecisions = async (): Promise<void> => {
+    const surreal = f.app.get(SurrealService);
+    await surreal.withCompany(f.companyId, async (db) => {
+      // Full-table delete (no WHERE) — outside the 3.2.4 planner no-op class.
+      await db.query(`DELETE memory_decision`);
+    });
+  };
+
+  const outcomeRows = async (
+    factId: string,
+  ): Promise<Array<{ event: string; decisionId?: string }>> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ event: string; decisionId?: string }>]>(
+        `SELECT event, decisionId FROM memory_outcome
+          WHERE subjectId = type::record('knowledge_fact', $tail)`,
+        { tail: tail(factId) },
+      );
+      return (rows as Array<{ event: string; decisionId?: string }>) ?? [];
+    });
+  };
+
+  /** Writers are fire-and-forget — poll until the condition holds. */
+  const waitFor = async <T>(probe: () => Promise<T>, ok: (v: T) => boolean): Promise<T> => {
+    let last: T = await probe();
+    for (let i = 0; i < 40 && !ok(last); i++) {
+      await new Promise((r) => setTimeout(r, 100));
+      last = await probe();
+    }
+    return last;
+  };
+
+  const ingestFact = async (
+    entityId: string,
+    object: string,
+    opts: { userId?: string } = {},
+  ): Promise<{ factId: string }> => {
+    const res = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: entityId },
+        predicate: 'name',
+        object,
+        validFrom: '2026-01-01',
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+        ...(opts.userId ? { userId: opts.userId } : {}),
+      });
+    expect([200, 201]).toContain(res.status);
+    return res.body;
+  };
+
+  it('(a) a coverage-abstained synthesize writes ONE static abstain decision', async () => {
+    process.env.RETRIEVAL_ABSTENTION_CALIBRATION = 'coverage';
+    // Default floors: minEvidence 2 — a single-fact evidence set abstains.
+    try {
+      await ingestFact('decision_abstain_subj', 'Decision Abstain Subject');
+      const res = await f.http
+        .post('/v1/synthesize')
+        .set(auth())
+        .send({ query: 'Decision Abstain Subject', limit: 5 });
+      expect(res.status).toBe(201);
+      expect(res.body.reason).toBe('low_coverage');
+
+      const rows = await waitFor(
+        () => decisionRows(),
+        (r) => r.length >= 1,
+      );
+      expect(rows).toHaveLength(1);
+      const d = rows[0]!;
+      expect(d.decisionKind).toBe('abstain');
+      expect(d.chosenAction).toBe('abstain');
+      expect(d.policyVersion).toBe('static');
+      expect(d.decisionId).toMatch(/^[0-9a-f]{32}$/);
+      // The correlation id of the request is stamped (minted by the
+      // middleware when the caller sends none).
+      expect(typeof d.requestId).toBe('string');
+      expect(Number.isInteger(d.costs?.latencyMs)).toBe(true);
+      // Content-free observedState: signal numbers + class only.
+      expect(d.observedState).toMatchObject({ candidateCount: 1 });
+      expect(Object.keys(d.observedState ?? {}).sort()).toEqual(
+        [
+          'candidateCount',
+          'coverageScore',
+          'queryClass',
+          'rawConfidence',
+          'retrievalGap',
+          'topScore',
+        ].sort(),
+      );
+    } finally {
+      delete process.env.RETRIEVAL_ABSTENTION_CALIBRATION;
+      await purgeDecisions();
+    }
+  });
+
+  it('(b) a served request writes a proceed decision; outcomes + focus sample join it', async () => {
+    process.env.RETRIEVAL_ABSTENTION_CALIBRATION = 'coverage';
+    process.env.RETRIEVAL_ABSTENTION_MIN_EVIDENCE = '1';
+    process.env.RETRIEVAL_ABSTENTION_MIN_SCORE = '0';
+    process.env.FOVEA_FOCUS_CAPTURE = '1';
+    try {
+      const { factId } = await ingestFact('decision_serve_subj', 'Decision Serve Subject');
+      mockSynthesizeOpenAi(f.app, [
+        JSON.stringify({ answer: `Served [${factId}].`, citedFactIds: [factId] }),
+        JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+      ]);
+      const res = await f.http
+        .post('/v1/synthesize')
+        .set(auth())
+        .send({ query: 'Decision Serve Subject', limit: 5 });
+      expect(res.status).toBe(201);
+      expect(res.body.answer).toContain('Served');
+
+      const rows = await waitFor(
+        () => decisionRows(),
+        (r) => r.length >= 1,
+      );
+      const proceed = rows.find((r) => r.chosenAction === 'proceed');
+      expect(proceed).toBeDefined();
+      expect(proceed!.decisionKind).toBe('abstain');
+
+      // The outcome rows carry the decisionId join (used + verified).
+      const outcomes = await waitFor(
+        () => outcomeRows(factId),
+        (r) => r.some((x) => x.event === 'used_in_answer'),
+      );
+      const used = outcomes.find((x) => x.event === 'used_in_answer');
+      expect(used?.decisionId).toBe(proceed!.decisionId);
+      const verified = outcomes.find((x) => x.event === 'verifier_supported');
+      expect(verified?.decisionId).toBe(proceed!.decisionId);
+
+      // The verdict-stage focus sample carries the same join key.
+      const surreal = f.app.get(SurrealService);
+      const samples = await waitFor(
+        () =>
+          surreal.withCompany(f.companyId, async (db) => {
+            const [r] = await db.query<[Array<{ stage?: string; decisionId?: string }>]>(
+              `SELECT stage, decisionId FROM focus_signal_sample WHERE decisionId = $d`,
+              { d: proceed!.decisionId },
+            );
+            return (r as Array<{ stage?: string; decisionId?: string }>) ?? [];
+          }),
+        (r) => r.length >= 1,
+      );
+      expect(samples.length).toBeGreaterThanOrEqual(1);
+      expect(samples[0]!.stage).toBe('verdict');
+    } finally {
+      delete process.env.RETRIEVAL_ABSTENTION_CALIBRATION;
+      delete process.env.RETRIEVAL_ABSTENTION_MIN_EVIDENCE;
+      delete process.env.RETRIEVAL_ABSTENTION_MIN_SCORE;
+      delete process.env.FOVEA_FOCUS_CAPTURE;
+    }
+  });
+
+  it('(c) entity-forget purges decision rows through the outcome join', async () => {
+    // Leg (b) left: a proceed decision + outcome rows joining it on the
+    // decision_serve_subj entity. Forget the entity → outcomes AND the
+    // joined decision rows die (over-deletion accepted — content-free).
+    const before = await decisionRows();
+    expect(before.length).toBeGreaterThanOrEqual(1);
+    const surreal = f.app.get(SurrealService);
+    const entityId = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ id: unknown }>]>(
+        `SELECT id FROM knowledge_entity WHERE canonicalName = $n LIMIT 1`,
+        { n: 'decision_serve_subj' },
+      );
+      return String((rows as Array<{ id: unknown }>)?.[0]?.id);
+    });
+    const forget = await f.http
+      .post(`/v1/entities/${encodeURIComponent(entityId)}/forget`)
+      .set(auth())
+      .send({ reason: 'gdpr_request', requestId: 'req-decision-1' });
+    expect([200, 201]).toContain(forget.status);
+    // The proceed decision (joined via the erased subject's outcomes) is gone.
+    const after = await decisionRows();
+    expect(after.find((r) => r.chosenAction === 'proceed')).toBeUndefined();
+    await purgeDecisions();
+  });
+
+  it('(d) user-forget purges the user slice: outcomes + joined decisions', async () => {
+    const { factId } = await ingestFact('decision_user_subj', 'Decision User Subject', {
+      userId: 'user_decision_1',
+    });
+    // Drive the seams the way the emit path does: one decision row, then
+    // outcome events stamped with its id (legacy write path — decisionId
+    // is one more optional column there).
+    const decisionId = f.app.get(MemoryDecisionService).record(f.companyId, {
+      decisionKind: 'abstain',
+      policyVersion: 'static',
+      chosenAction: 'proceed',
+    })!;
+    expect(decisionId).toMatch(/^[0-9a-f]{32}$/);
+    f.app.get(MemoryOutcomeService).recordOutcomes({
+      companyId: f.companyId,
+      events: [{ subjectKind: 'fact', subjectId: factId, event: 'used_in_answer', decisionId }],
+    });
+    await waitFor(
+      () => outcomeRows(factId),
+      (r) => r.length >= 1,
+    );
+    await waitFor(
+      () => decisionRows(),
+      (r) => r.some((x) => x.decisionId === decisionId),
+    );
+
+    const userForget = await f.http.post('/v1/users/user_decision_1/forget').set(auth()).send({});
+    expect([200, 201]).toContain(userForget.status);
+    expect(await outcomeRows(factId)).toHaveLength(0);
+    expect((await decisionRows()).find((r) => r.decisionId === decisionId)).toBeUndefined();
+  });
+
+  it('(e) capture off ⇒ zero decision rows (byte-identical)', async () => {
+    delete process.env.OUTCOME_DECISION_CAPTURE;
+    process.env.RETRIEVAL_ABSTENTION_CALIBRATION = 'coverage';
+    try {
+      await purgeDecisions();
+      await ingestFact('decision_off_subj', 'Decision Off Subject');
+      const res = await f.http
+        .post('/v1/synthesize')
+        .set(auth())
+        .send({ query: 'Decision Off Subject', limit: 5 });
+      expect(res.status).toBe(201);
+      // Fire-and-forget writers: give any (buggy) write time to land.
+      await new Promise((r) => setTimeout(r, 500));
+      expect(await decisionRows()).toHaveLength(0);
+    } finally {
+      process.env.OUTCOME_DECISION_CAPTURE = '1';
+      delete process.env.RETRIEVAL_ABSTENTION_CALIBRATION;
+    }
+  });
+});

--- a/test/memory-decision.unit-spec.ts
+++ b/test/memory-decision.unit-spec.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit coverage for the 0119 decision-context writer:
+ *   * shapeDecisionRow — the observedState WHITELIST (unknown keys and
+ *     non-finite numbers dropped, queryClass capped), the alternatives
+ *     cap (8, action/score pairs only), cost int-bounding, string caps,
+ *     and content-freedom (no free-text field survives the shaper);
+ *   * decisionEventId — deterministic on (scope, kind, seq);
+ *   * MemoryDecisionService.record — master-flag gating, the INSERT
+ *     IGNORE + explicit deterministic record id, id replay semantics
+ *     (fresh context + same correlation id ⇒ same id; same context ⇒
+ *     kind-seq advances), and the fire-and-forget warn-not-throw
+ *     contract.
+ */
+import {
+  DECISION_ALTERNATIVES_CAP,
+  DECISION_QUERY_CLASS_CAP,
+  MemoryDecisionService,
+  decisionEventId,
+  shapeDecisionRow,
+  type DecisionInput,
+} from '../src/outcomes/memory-decision.service';
+import { runWithRequestContext } from '../src/common/request-context';
+import type { SurrealService } from '../src/db/surreal.service';
+
+interface CapturedQuery {
+  sql: string;
+  params: Record<string, unknown>;
+}
+
+function makeSurreal(captured: CapturedQuery[]) {
+  const db = {
+    query: async (sql: string, params: Record<string, unknown> = {}) => {
+      captured.push({ sql, params });
+      return [[]];
+    },
+  };
+  return {
+    withCompany: async <T>(_c: string, fn: (d: typeof db) => Promise<T>) => fn(db),
+  } as unknown as SurrealService;
+}
+
+/** The detached write is fire-and-forget — yield until it lands. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+}
+
+const baseInput: DecisionInput = {
+  decisionKind: 'abstain',
+  policyVersion: 'static',
+  chosenAction: 'abstain',
+};
+
+describe('decisionEventId', () => {
+  it('is deterministic on (scope, kind, seq) and distinct across each component', () => {
+    expect(decisionEventId('scope-1', 'abstain', 0)).toBe(decisionEventId('scope-1', 'abstain', 0));
+    expect(decisionEventId('scope-1', 'abstain', 0)).toMatch(/^[0-9a-f]{32}$/);
+    expect(decisionEventId('scope-1', 'abstain', 0)).not.toBe(
+      decisionEventId('scope-1', 'abstain', 1),
+    );
+    expect(decisionEventId('scope-1', 'abstain', 0)).not.toBe(
+      decisionEventId('scope-1', 'l3_escalation', 0),
+    );
+    expect(decisionEventId('scope-1', 'abstain', 0)).not.toBe(
+      decisionEventId('scope-2', 'abstain', 0),
+    );
+  });
+});
+
+describe('shapeDecisionRow', () => {
+  const ctx = { decisionId: 'd'.repeat(32), companyId: 'co_x' };
+
+  it('whitelists observedState: unknown keys and non-finite numbers are DROPPED', () => {
+    const row = shapeDecisionRow(
+      {
+        ...baseInput,
+        observedState: {
+          topScore: 0.8,
+          coverageScore: 0.5,
+          retrievalGap: 0.2,
+          rawConfidence: 0.6,
+          candidateCount: 7,
+          queryClass: 'temporal',
+          // Everything below must be dropped — the content-free contract.
+          query: 'what is the user password?',
+          answerText: 'free text',
+          nested: { deep: 1 },
+          nan: Number.NaN,
+          inf: Number.POSITIVE_INFINITY,
+        },
+      },
+      ctx,
+    );
+    expect(row.observedState).toEqual({
+      topScore: 0.8,
+      coverageScore: 0.5,
+      retrievalGap: 0.2,
+      rawConfidence: 0.6,
+      candidateCount: 7,
+      queryClass: 'temporal',
+    });
+  });
+
+  it('caps queryClass at 64 chars and drops an all-junk observedState entirely', () => {
+    const long = shapeDecisionRow(
+      { ...baseInput, observedState: { queryClass: 'x'.repeat(200) } },
+      ctx,
+    );
+    expect((long.observedState!.queryClass as string).length).toBe(DECISION_QUERY_CLASS_CAP);
+    const junk = shapeDecisionRow(
+      { ...baseInput, observedState: { free: 'text', other: {} } },
+      ctx,
+    );
+    expect(junk.observedState).toBeUndefined();
+  });
+
+  it('caps alternatives at 8 and keeps ONLY {action, score} pairs', () => {
+    const alts = Array.from({ length: 12 }, (_, i) => ({
+      action: `a${i}`,
+      score: i / 12,
+      // An extra field must not survive into the row.
+      note: 'free text',
+    })) as unknown as Array<{ action: string; score: number }>;
+    const row = shapeDecisionRow({ ...baseInput, alternatives: alts }, ctx);
+    expect(row.alternatives).toHaveLength(DECISION_ALTERNATIVES_CAP);
+    for (const a of row.alternatives!) {
+      expect(Object.keys(a).sort()).toEqual(['action', 'score']);
+    }
+  });
+
+  it('bounds costs to finite non-negative ints and drops the rest', () => {
+    const row = shapeDecisionRow(
+      {
+        ...baseInput,
+        costs: {
+          latencyMs: 123.7,
+          promptTokens: -5,
+          completionTokens: Number.NaN,
+          toolCalls: undefined,
+        },
+      },
+      ctx,
+    );
+    expect(row.costs).toEqual({ latencyMs: 124 });
+  });
+
+  it('drops a non-finite actionScore and never stamps propensity', () => {
+    const row = shapeDecisionRow({ ...baseInput, actionScore: Number.NaN }, ctx);
+    expect(row.actionScore).toBeUndefined();
+    expect(Object.keys(row)).not.toContain('propensity');
+  });
+});
+
+describe('MemoryDecisionService.record', () => {
+  beforeEach(() => {
+    process.env.OUTCOME_DECISION_CAPTURE = '1';
+  });
+  afterAll(() => {
+    delete process.env.OUTCOME_DECISION_CAPTURE;
+  });
+
+  it('is a no-op returning undefined with the flag off', async () => {
+    delete process.env.OUTCOME_DECISION_CAPTURE;
+    const captured: CapturedQuery[] = [];
+    const svc = new MemoryDecisionService(makeSurreal(captured));
+    expect(svc.record('co_x', baseInput)).toBeUndefined();
+    await flush();
+    expect(captured).toEqual([]);
+    expect(MemoryDecisionService.enabled()).toBe(false);
+  });
+
+  it('INSERT IGNOREs one row with the explicit deterministic record id', async () => {
+    const captured: CapturedQuery[] = [];
+    const svc = new MemoryDecisionService(makeSurreal(captured));
+    const id = svc.record('co_x', { ...baseInput, requestId: 'req-1', actionScore: 0.4 });
+    expect(id).toMatch(/^[0-9a-f]{32}$/);
+    await flush();
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toBe('INSERT IGNORE INTO memory_decision $row');
+    const row = captured[0]!.params.row as Record<string, unknown>;
+    expect(String(row.id)).toBe(`memory_decision:${id}`);
+    expect(row.decisionId).toBe(id);
+    expect(row.companyId).toBe('co_x');
+    expect(row.requestId).toBe('req-1');
+    expect(row.actionScore).toBe(0.4);
+  });
+
+  it('replays the SAME id for a fresh context with the same correlation id; kind-seq advances within one context', () => {
+    const svc = new MemoryDecisionService(makeSurreal([]));
+    // Fresh context objects, same correlation id — an upstream replay.
+    const a = runWithRequestContext({ correlationId: 'corr-dec' }, () =>
+      svc.record('co_x', baseInput),
+    );
+    const b = runWithRequestContext({ correlationId: 'corr-dec' }, () =>
+      svc.record('co_x', baseInput),
+    );
+    expect(a).toBe(b);
+    // Same context: a second same-kind decision gets the NEXT seq.
+    const [c, d] = runWithRequestContext({ correlationId: 'corr-dec-2' }, () => [
+      svc.record('co_x', baseInput),
+      svc.record('co_x', baseInput),
+    ]);
+    expect(c).not.toBe(d);
+  });
+
+  it('a write failure warns and never throws into the caller', async () => {
+    const surreal = {
+      withCompany: async () => {
+        throw new Error('boom');
+      },
+    } as unknown as SurrealService;
+    const svc = new MemoryDecisionService(surreal);
+    expect(() => svc.record('co_x', baseInput)).not.toThrow();
+    await flush();
+  });
+});

--- a/test/memory-outcome.e2e-spec.ts
+++ b/test/memory-outcome.e2e-spec.ts
@@ -11,11 +11,20 @@
  *   (e) master off ⇒ zero rows (byte-identical);
  *   (f) verified-use SERVING (read side): with RETRIEVAL_VERIFIED_USE_RANKING
  *       + SEARCH_VERIFIED_USE_BETA the enriched fact's score breakdown
- *       carries the verifiedUse factor; flags off ⇒ no fragment.
+ *       carries the verifiedUse factor; flags off ⇒ no fragment;
+ *   (h/i) OUTCOME_TX_WRITES against the REAL pinned server (this IS the
+ *       SurrealQL semantics verification for the tx branch — INSERT
+ *       IGNORE on deterministic ids, SELECT-from-array-param, FOR loop
+ *       + per-delta ON DUPLICATE fold inside BEGIN/COMMIT): a replayed
+ *       batch changes NOTHING, and a failing batch lands NOTHING.
  */
 import { AppFixture, createApp } from './app-fixture';
 import { SurrealService } from '../src/db/surreal.service';
-import { MemoryOutcomeService } from '../src/outcomes/memory-outcome.service';
+import { runWithRequestContext } from '../src/common/request-context';
+import {
+  MemoryOutcomeService,
+  type OutcomeSubjectKind,
+} from '../src/outcomes/memory-outcome.service';
 
 interface OutcomeRow {
   event: string;
@@ -369,6 +378,83 @@ describe('memory_outcome — outcome telemetry recording and cascade', () => {
     expect([200, 201]).toContain(forget.status);
     expect(await rawRows(factId)).toHaveLength(0);
     expect(await statFor(factId)).toBeNull();
+  });
+
+  it('(h) OUTCOME_TX_WRITES: an upstream replay of the same batch is idempotent (raw + stats)', async () => {
+    process.env.OUTCOME_TX_WRITES = '1';
+    try {
+      const { factId } = await ingestFact('outcome_tx_subj', 'name', 'Outcome Tx Subject');
+      const svc = f.app.get(MemoryOutcomeService);
+      const dispatch = () =>
+        // A FRESH context object with the SAME correlation id per dispatch
+        // (the WeakMap batch-seq restarts) — mirrors an upstream HTTP
+        // replay that reuses x-request-id.
+        runWithRequestContext({ correlationId: 'corr-tx-replay' }, () =>
+          svc.recordOutcomes({
+            companyId: f.companyId,
+            events: [
+              { subjectKind: 'fact', subjectId: factId, event: 'selected_for_context' },
+              { subjectKind: 'fact', subjectId: factId, event: 'used_in_answer' },
+            ],
+          }),
+        );
+      dispatch();
+      const rows1 = await waitFor(
+        () => rawRows(factId),
+        (r) => r.length >= 2,
+      );
+      expect(rows1).toHaveLength(2);
+      const stat1 = await waitFor(
+        () => statFor(factId),
+        (s) => (s?.usedCount ?? 0) >= 1 && (s?.selectedCount ?? 0) >= 1,
+      );
+      expect(stat1).toMatchObject({ selectedCount: 1, usedCount: 1 });
+
+      // Replay: identical deterministic ids → INSERT IGNORE no-ops the raw
+      // rows AND the in-tx pre-select gates every delta — raw count and
+      // ALL SIX counters unchanged.
+      dispatch();
+      await new Promise((r) => setTimeout(r, 700));
+      expect(await rawRows(factId)).toHaveLength(2);
+      expect(await statFor(factId)).toMatchObject({
+        selectedCount: 1,
+        usedCount: 1,
+        verifiedUseCount: 0,
+        confirmedCount: 0,
+        rejectedCount: 0,
+        contradictedCount: 0,
+      });
+    } finally {
+      delete process.env.OUTCOME_TX_WRITES;
+    }
+  });
+
+  it('(i) OUTCOME_TX_WRITES: a failing batch leaves BOTH tables untouched (atomicity)', async () => {
+    process.env.OUTCOME_TX_WRITES = '1';
+    try {
+      const { factId } = await ingestFact('outcome_tx_atomic', 'name', 'Outcome Tx Atomic');
+      const svc = f.app.get(MemoryOutcomeService);
+      runWithRequestContext({ correlationId: 'corr-tx-atomic' }, () =>
+        svc.recordOutcomes({
+          companyId: f.companyId,
+          events: [
+            // subjectKind outside the 0107 ASSERT enum: the raw INSERT
+            // fails → the whole BEGIN/COMMIT aborts → the stat fold this
+            // event maps to (usedCount) must not land either.
+            {
+              subjectKind: 'bogus' as OutcomeSubjectKind,
+              subjectId: factId,
+              event: 'used_in_answer',
+            },
+          ],
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 700));
+      expect(await rawRows(factId)).toHaveLength(0);
+      expect(await statFor(factId)).toBeNull();
+    } finally {
+      delete process.env.OUTCOME_TX_WRITES;
+    }
   });
 
   it('(e) master off ⇒ zero rows written (byte-identical)', async () => {

--- a/test/memory-outcome.unit-spec.ts
+++ b/test/memory-outcome.unit-spec.ts
@@ -3,20 +3,30 @@
  *   * recordOutcomes — master-flag guard, dedupe + cap, the 'auto'
  *     event→counter mapping, explicit signed statDeltas, and the two
  *     batched statements' shape;
+ *   * OUTCOME_TX_WRITES — flag-off BYTE-IDENTITY against literal SQL
+ *     (copied from origin/main, NOT from the implementation constants),
+ *     the deterministic event-id derivation, the one-BEGIN/COMMIT tx
+ *     shape, per-delta gating, and the single-OCC-retry contract;
  *   * OutcomePruneService — batch-loop termination + the prune query
- *     shape (bounded DELETE-subquery with RETURN BEFORE).
+ *     shapes (bounded DELETE-subquery with RETURN BEFORE), incl. the
+ *     0119 memory_decision leg.
  */
 import {
   MemoryOutcomeService,
   OUTCOME_RECORD_CAP,
   autoStatDeltas,
   dedupeOutcomeEvents,
+  outcomeDedupeKey,
+  outcomeEventId,
   type OutcomeEventInput,
 } from '../src/outcomes/memory-outcome.service';
+import { buildOutcomeTxPayload } from '../src/outcomes/outcome-tx';
 import {
+  DECISION_PRUNE_BATCH_QUERY,
   OUTCOME_PRUNE_BATCH_QUERY,
   OutcomePruneService,
 } from '../src/outcomes/outcome-prune.service';
+import { runWithRequestContext } from '../src/common/request-context';
 import type { SurrealService } from '../src/db/surreal.service';
 import type { ApiKeyService } from '../src/auth/api-key.service';
 
@@ -297,6 +307,217 @@ describe('MemoryOutcomeService.recordOutcomes', () => {
   });
 });
 
+// ── OUTCOME_TX_WRITES (0119 wave) ───────────────────────────────────
+describe('OUTCOME_TX_WRITES', () => {
+  beforeEach(() => {
+    process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+  });
+  afterEach(() => {
+    delete process.env.OUTCOME_TX_WRITES;
+  });
+  afterAll(() => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+  });
+
+  // The legacy statements, copied as LITERALS from origin/main —
+  // deliberately NOT imported from the implementation, so a drift in the
+  // off path fails here even if the implementation's own constants
+  // drifted with it.
+  const LEGACY_RAW_SQL = 'INSERT INTO memory_outcome $rows';
+  const LEGACY_STAT_SQL =
+    'INSERT INTO memory_outcome_stat $statRows\n' +
+    '           ON DUPLICATE KEY UPDATE\n' +
+    '             selectedCount += $input.selectedCount,\n' +
+    '             usedCount += $input.usedCount,\n' +
+    '             verifiedUseCount += $input.verifiedUseCount,\n' +
+    '             confirmedCount += $input.confirmedCount,\n' +
+    '             rejectedCount += $input.rejectedCount,\n' +
+    '             contradictedCount += $input.contradictedCount,\n' +
+    '             lastUsedAt = $input.lastUsedAt ?? lastUsedAt,\n' +
+    '             lastVerifiedUseAt = $input.lastVerifiedUseAt ?? lastVerifiedUseAt,\n' +
+    '             updatedAt = time::now()';
+
+  it('flag OFF: the write is byte-identical to the legacy two-statement shape', async () => {
+    const captured: CapturedQuery[] = [];
+    const svc = new MemoryOutcomeService(makeSurreal(captured));
+    svc.recordOutcomes({
+      companyId: 'co_x',
+      events: [ev('knowledge_fact:a', 'used_in_answer', { actor: 'k1' })],
+      requestId: 'req-1',
+    });
+    await flush();
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toBe(`${LEGACY_RAW_SQL};\n${LEGACY_STAT_SQL}`);
+    expect(Object.keys(captured[0]!.params).sort()).toEqual(['rows', 'statRows']);
+    // No tx-only keys leak onto the off-path rows (no id, no decisionId).
+    const row = (captured[0]!.params.rows as Array<Record<string, unknown>>)[0]!;
+    expect(Object.keys(row)).not.toContain('id');
+    expect(Object.keys(row)).not.toContain('decisionId');
+  });
+
+  it('outcomeEventId is deterministic on (key, scope, seq) and distinct across seq', () => {
+    const key = outcomeDedupeKey(ev('knowledge_fact:a', 'used_in_answer'));
+    expect(outcomeEventId(key, 'scope-1', 0)).toBe(outcomeEventId(key, 'scope-1', 0));
+    expect(outcomeEventId(key, 'scope-1', 0)).toMatch(/^[0-9a-f]{32}$/);
+    expect(outcomeEventId(key, 'scope-1', 0)).not.toBe(outcomeEventId(key, 'scope-1', 1));
+    expect(outcomeEventId(key, 'scope-1', 0)).not.toBe(outcomeEventId(key, 'scope-2', 0));
+  });
+
+  it('flag ON: ONE BEGIN/COMMIT query with the pre-select / INSERT IGNORE / gated FOR legs', async () => {
+    process.env.OUTCOME_TX_WRITES = '1';
+    const captured: CapturedQuery[] = [];
+    const svc = new MemoryOutcomeService(makeSurreal(captured));
+    svc.recordOutcomes({
+      companyId: 'co_x',
+      events: [ev('knowledge_fact:a', 'used_in_answer')],
+      requestId: 'req-tx-1',
+    });
+    await flush();
+    expect(captured).toHaveLength(1);
+    const { sql, params } = captured[0]!;
+    expect(sql.startsWith('BEGIN TRANSACTION;\n')).toBe(true);
+    expect(sql).toContain('LET $existing = (SELECT VALUE id FROM memory_outcome');
+    expect(sql).toContain('INSERT IGNORE INTO memory_outcome $rows');
+    expect(sql).toContain('rawId NOTINSIDE $existing OR rawId IS NONE');
+    expect(sql).toContain('FOR $d IN $newDeltas');
+    expect(sql).toContain('ON DUPLICATE KEY UPDATE');
+    expect(sql).toContain('COMMIT TRANSACTION;');
+    expect(Object.keys(params).sort()).toEqual(['deltas', 'rawIds', 'rows']);
+    // Rows carry explicit deterministic ids + the correlation id.
+    const row = (params.rows as Array<Record<string, unknown>>)[0]!;
+    expect(String(row.id)).toMatch(/^memory_outcome:[0-9a-f]{32}$/);
+    expect(row.requestId).toBe('req-tx-1');
+    // Every delta rides its producing event's raw id (the SQL-level
+    // replay guarantee; the true replay assertion is the e2e).
+    const deltas = params.deltas as Array<{ rawId?: unknown }>;
+    expect(deltas).toHaveLength(1);
+    expect(String(deltas[0]!.rawId)).toBe(String(row.id));
+  });
+
+  it('two dispatches of the SAME request replay the SAME ids (fresh context, same correlation id)', async () => {
+    process.env.OUTCOME_TX_WRITES = '1';
+    const idsOf = async (): Promise<string[]> => {
+      const captured: CapturedQuery[] = [];
+      const svc = new MemoryOutcomeService(makeSurreal(captured));
+      // A FRESH context object per dispatch (the WeakMap seq restarts) with
+      // the same correlation id — mirrors an upstream HTTP replay.
+      runWithRequestContext({ correlationId: 'corr-replay' }, () =>
+        svc.recordOutcomes({
+          companyId: 'co_x',
+          events: [ev('knowledge_fact:a', 'used_in_answer')],
+        }),
+      );
+      await flush();
+      return (captured[0]!.params.rawIds as unknown[]).map(String);
+    };
+    expect(await idsOf()).toEqual(await idsOf());
+  });
+
+  it('two batches in ONE request context stay distinct rows (batchSeq)', async () => {
+    process.env.OUTCOME_TX_WRITES = '1';
+    const captured: CapturedQuery[] = [];
+    const svc = new MemoryOutcomeService(makeSurreal(captured));
+    runWithRequestContext({ correlationId: 'corr-two-batches' }, () => {
+      svc.recordOutcomes({
+        companyId: 'co_x',
+        events: [ev('knowledge_fact:a', 'retrieved')],
+      });
+      svc.recordOutcomes({
+        companyId: 'co_x',
+        events: [ev('knowledge_fact:a', 'retrieved')],
+      });
+    });
+    await flush();
+    expect(captured).toHaveLength(2);
+    const first = (captured[0]!.params.rawIds as unknown[]).map(String);
+    const second = (captured[1]!.params.rawIds as unknown[]).map(String);
+    expect(first).not.toEqual(second);
+  });
+
+  it('delta gating: feedback-shaped explicit deltas inherit the matching-subject event id; unmatched stay ungated', () => {
+    const now = new Date();
+    const payload = buildOutcomeTxPayload({
+      events: [ev('knowledge_fact:a', 'user_rejected', { actor: 'k1' })],
+      statDeltas: [
+        // The vote flip: both signed moves ride the vote's raw row.
+        {
+          subjectKind: 'fact',
+          subjectId: 'knowledge_fact:a',
+          counter: 'confirmedCount',
+          delta: -1,
+        },
+        { subjectKind: 'fact', subjectId: 'knowledge_fact:a', counter: 'rejectedCount', delta: 1 },
+        // No event for this subject in the batch → ungated (documented residual).
+        { subjectKind: 'fact', subjectId: 'knowledge_fact:zzz', counter: 'usedCount', delta: 1 },
+      ],
+      now,
+      requestScope: 'scope-gate',
+      batchSeq: 0,
+    })!;
+    expect(payload.rawIds).toHaveLength(1);
+    const eventId = String(payload.rawIds[0]);
+    expect(payload.deltas).toHaveLength(3);
+    expect(String(payload.deltas[0]!.rawId)).toBe(eventId);
+    expect(String(payload.deltas[1]!.rawId)).toBe(eventId);
+    expect(payload.deltas[2]!.rawId).toBeUndefined();
+    // Per-delta rows carry all six counters with ONE signed non-zero move.
+    expect(payload.deltas[0]!.row).toMatchObject({ confirmedCount: -1, rejectedCount: 0 });
+    expect(payload.deltas[1]!.row).toMatchObject({ confirmedCount: 0, rejectedCount: 1 });
+  });
+
+  it("'auto' deltas carry the id of the event that produced them (1:1); `retrieved` maps to none", () => {
+    const now = new Date();
+    const payload = buildOutcomeTxPayload({
+      events: [
+        ev('knowledge_fact:a', 'selected_for_context'),
+        ev('knowledge_fact:a', 'used_in_answer'),
+        ev('knowledge_fact:b', 'retrieved'),
+      ],
+      statDeltas: 'auto',
+      now,
+      requestScope: 'scope-auto',
+      batchSeq: 0,
+    })!;
+    expect(payload.rawIds).toHaveLength(3);
+    expect(payload.deltas).toHaveLength(2); // retrieved → no delta
+    expect(String(payload.deltas[0]!.rawId)).toBe(String(payload.rawIds[0]));
+    expect(String(payload.deltas[1]!.rawId)).toBe(String(payload.rawIds[1]));
+    expect(payload.deltas[0]!.row).toMatchObject({ selectedCount: 1, usedCount: 0 });
+    expect(payload.deltas[1]!.row).toMatchObject({ selectedCount: 0, usedCount: 1 });
+  });
+
+  it('OCC abort → exactly ONE retry; non-retriable error → zero retries (warn only)', async () => {
+    process.env.OUTCOME_TX_WRITES = '1';
+    const runWith = async (firstError: string): Promise<number> => {
+      let calls = 0;
+      const db = {
+        query: async () => {
+          calls += 1;
+          if (calls === 1) throw new Error(firstError);
+          return [];
+        },
+      };
+      const surreal = {
+        withCompany: async <T>(_c: string, fn: (d: typeof db) => Promise<T>) => fn(db),
+      } as unknown as SurrealService;
+      const svc = new MemoryOutcomeService(surreal);
+      svc.recordOutcomes({
+        companyId: 'co_x',
+        events: [ev('knowledge_fact:a', 'used_in_answer')],
+        requestId: 'req-retry',
+      });
+      await flush();
+      return calls;
+    };
+    await expect(
+      runWith(
+        'Failed to commit transaction due to a read or write conflict. This transaction can be retried',
+      ),
+    ).resolves.toBe(2);
+    await expect(runWith('Parse error: unexpected token')).resolves.toBe(1);
+  });
+});
+
 describe('OutcomePruneService', () => {
   beforeEach(() => {
     process.env.OUTCOME_TELEMETRY_ENABLED = '1';
@@ -337,5 +558,26 @@ describe('OutcomePruneService', () => {
     const svc = new OutcomePruneService(makeSurreal(captured, [[], []]), apiKeys(['co_a', 'co_b']));
     expect(await svc.runNightly()).toEqual({ tenants: 2, pruned: 0 });
     expect(captured).toHaveLength(2);
+  });
+
+  it('decision prune leg (0119): bounded DELETE-subquery shape', () => {
+    expect(DECISION_PRUNE_BATCH_QUERY).toBe(
+      'DELETE (SELECT id FROM memory_decision WHERE createdAt < $cutoff LIMIT 5000) RETURN BEFORE',
+    );
+  });
+
+  it('decision leg runs on OUTCOME_DECISION_CAPTURE alone (independent master)', async () => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    process.env.OUTCOME_DECISION_CAPTURE = '1';
+    try {
+      const captured: CapturedQuery[] = [];
+      const svc = new OutcomePruneService(makeSurreal(captured, [[]]), apiKeys(['co_x']));
+      expect(await svc.runNightly()).toEqual({ tenants: 1, pruned: 0 });
+      expect(captured).toHaveLength(1);
+      expect(captured[0]!.sql).toBe(DECISION_PRUNE_BATCH_QUERY);
+      expect(captured[0]!.params.cutoff).toBeInstanceOf(Date);
+    } finally {
+      delete process.env.OUTCOME_DECISION_CAPTURE;
+    }
   });
 });

--- a/test/mri-aggregator.unit-spec.ts
+++ b/test/mri-aggregator.unit-spec.ts
@@ -90,21 +90,26 @@ describe('buildMriReport — free (live telemetry) dimensions', () => {
     expect(d.source).toMatch(/UPPER BOUND/);
   });
 
-  it('p50/p95 latency render pending — no serving-path histogram is emitted', () => {
-    for (const key of ['latencyP50Seconds', 'latencyP95Seconds'] as const) {
-      const d = report.dimensions[key]!;
-      expect(d.value).toBe('pending-eval');
-      expect(d.kind).toBe('pending');
-      expect(d.reason).toMatch(/no per-query latency histogram is emitted on the serving path/);
-    }
+  it('p50/p95 latency are LIVE off the serving-boundary histogram (audit pt-8)', () => {
+    // synthesize() observes brain_search_duration_seconds once per request,
+    // so the cells render histogram_quantile numbers, not `pending`.
+    const p50 = report.dimensions.latencyP50Seconds!;
+    expect(p50.value as number).toBeCloseTo(0.1, 6);
+    expect(p50.kind).toBe('live');
+    expect(p50.unit).toBe('seconds');
+    expect(p50.source).toMatch(/brain_search_duration_seconds/);
+    const p95 = report.dimensions.latencyP95Seconds!;
+    expect(p95.value as number).toBeCloseTo(0.40625, 6);
+    expect(p95.kind).toBe('live');
   });
 
-  it('exposes a live operating point (proxy-accuracy = ok ÷ terminal); latency null', () => {
+  it('exposes a live operating point (proxy-accuracy = ok ÷ terminal) with latency axes', () => {
     const p = report.operatingPoint;
     expect(p.accuracyProxy).toBeCloseTo(0.8, 6);
     expect(p.ece).toBeNull();
     expect(p.sampleCount).toBe(100);
-    expect(p.latencyP95).toBeNull();
+    expect(p.latencyP50).toBeCloseTo(0.1, 6);
+    expect(p.latencyP95).toBeCloseTo(0.40625, 6);
   });
 });
 

--- a/test/mri-pareto.unit-spec.ts
+++ b/test/mri-pareto.unit-spec.ts
@@ -132,10 +132,19 @@ describe('collectOperatingPoint — from a telemetry reader', () => {
     expect(p.sampleCount).toBe(100);
   });
 
-  it('leaves latency null even when a search histogram is present (serving path emits none)', () => {
-    // brain_search_duration_seconds is in the snapshot, but the serving path
-    // never observes it — so it is not a real per-query latency signal.
+  it('fills latency p50/p95 from the serving-boundary histogram (histogram_quantile)', () => {
+    // synthesize() now observes brain_search_duration_seconds once per
+    // request at the serving boundary (audit pt-8), so the operating point
+    // fills the latency axes via histogram_quantile interpolation:
+    //   p50: target 50 → exactly the 0.1 bucket edge;
+    //   p95: target 95 → within [0.25, 0.5): 0.25 + (95−90)/8 · 0.25.
     const p = collectOperatingPoint(readerFromPromJson(json));
+    expect(p.latencyP50).toBeCloseTo(0.1, 6);
+    expect(p.latencyP95).toBeCloseTo(0.40625, 6);
+  });
+
+  it('latency stays null (never fabricated) when the histogram is absent', () => {
+    const p = collectOperatingPoint(readerFromPromJson(json.slice(0, 2)));
     expect(p.latencyP50).toBeNull();
     expect(p.latencyP95).toBeNull();
   });

--- a/test/synthesize-outcome-writers.unit-spec.ts
+++ b/test/synthesize-outcome-writers.unit-spec.ts
@@ -9,15 +9,25 @@
  *     used_in_answer for the served citations — and NEVER
  *     verifier_supported (no verifier ran);
  *   * with the master flag off, nothing is emitted at any seam.
+ *
+ * Plus the 0119 wave seams:
+ *   * the flag-free serving-boundary latency observe — EXACTLY ONE
+ *     observeSearchDuration() per synthesize() call, including the
+ *     no_results and thrown-error exits (the `finally` contract);
+ *   * the OUTCOME_DECISION_CAPTURE abstain writer + primary-decision-id
+ *     threading onto the emitAnswerUse events.
  */
 import { ConfigService } from '@nestjs/config';
 import { SynthesizeService } from '../src/synthesize/synthesize.service';
 import type { SearchService, SearchHit } from '../src/search/search.service';
 import type { SynthesizeDto } from '../src/synthesize/dto/synthesize.dto';
+import type { MetricsService } from '../src/metrics/metrics.service';
+import { getActiveRetrievalProfile } from '../src/search/retrieval-profile';
 import type {
   MemoryOutcomeService,
   OutcomeEventInput,
 } from '../src/outcomes/memory-outcome.service';
+import type { DecisionInput, MemoryDecisionService } from '../src/outcomes/memory-decision.service';
 
 interface RecordedCall {
   companyId: string;
@@ -78,20 +88,40 @@ function stubOpenAI(verdict: string) {
   };
 }
 
-function makeSvc(verdict: string): { svc: SynthesizeService; calls: RecordedCall[] } {
+interface DecisionCall {
+  companyId: string;
+  input: DecisionInput;
+}
+
+function makeSvc(
+  verdict: string,
+  opts: {
+    metrics?: MetricsService | undefined;
+    decisionCalls?: DecisionCall[] | undefined;
+    searchImpl?: (() => Promise<{ results: SearchHit[] }>) | undefined;
+  } = {},
+): { svc: SynthesizeService; calls: RecordedCall[] } {
   const calls: RecordedCall[] = [];
   const outcomes = {
-    recordOutcomes: (opts: RecordedCall) => {
-      calls.push({ companyId: opts.companyId, events: opts.events });
+    recordOutcomes: (o: RecordedCall) => {
+      calls.push({ companyId: o.companyId, events: o.events });
     },
   } as unknown as MemoryOutcomeService;
+  const decisions = opts.decisionCalls
+    ? ({
+        record: (companyId: string, input: DecisionInput) => {
+          opts.decisionCalls!.push({ companyId, input });
+          return 'deadbeefdeadbeefdeadbeefdeadbeef';
+        },
+      } as unknown as MemoryDecisionService)
+    : undefined;
   const search = {
-    search: async () => ({ results: [makeHit('cust_a', 'f1')] }),
+    search: opts.searchImpl ?? (async () => ({ results: [makeHit('cust_a', 'f1')] })),
   } as unknown as SearchService;
   const svc = new SynthesizeService(
     search,
     makeConfig(),
-    undefined, // metrics
+    opts.metrics, // metrics
     undefined, // evidenceCollector
     undefined, // answerCache
     undefined, // l3
@@ -99,6 +129,9 @@ function makeSvc(verdict: string): { svc: SynthesizeService; calls: RecordedCall
     undefined, // lensSuppression
     undefined, // laneClassifier
     outcomes,
+    undefined, // predicateRegistry
+    undefined, // surreal (0115 grounding fetch)
+    decisions,
   );
   (svc as unknown as { openai: unknown }).openai = stubOpenAI(verdict);
   return { svc, calls };
@@ -180,5 +213,148 @@ describe('SynthesizeService — 0107 outcome writer seams', () => {
     });
     expect(out.answer).toBe('Maya [f1].');
     expect(calls).toEqual([]);
+  });
+});
+
+// ── 0119: flag-free serving-boundary latency observe ────────────────
+describe('SynthesizeService — latency observe (flag-free, D8)', () => {
+  function makeMetrics(): { metrics: MetricsService; observed: number[] } {
+    const observed: number[] = [];
+    // A Proxy stub: observeSearchDuration records, every other metric
+    // method is a no-op — so the full serve path (incl. the gen-ai call
+    // wrappers) runs without a real MetricsService.
+    const metrics = new Proxy(
+      {},
+      {
+        get: (_t, prop) =>
+          prop === 'observeSearchDuration' ? (s: number) => observed.push(s) : () => undefined,
+      },
+    ) as unknown as MetricsService;
+    return { metrics, observed };
+  }
+
+  it('observes exactly once on the served (ok) exit', async () => {
+    const { metrics, observed } = makeMetrics();
+    const { svc } = makeSvc('supported', { metrics });
+    await svc.synthesize({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesisGuardrails: 'strict' },
+      callerScopes: ['brain:read'],
+    });
+    expect(observed).toHaveLength(1);
+    expect(observed[0]).toBeGreaterThanOrEqual(0);
+  });
+
+  it('observes exactly once on the no_results early exit', async () => {
+    const { metrics, observed } = makeMetrics();
+    const { svc } = makeSvc('supported', {
+      metrics,
+      searchImpl: async () => ({ results: [] }),
+    });
+    const out = await svc.synthesize({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesisGuardrails: 'strict' },
+      callerScopes: ['brain:read'],
+    });
+    expect(out.reason).toBe('no_results');
+    expect(observed).toHaveLength(1);
+  });
+
+  it('observes exactly once even when the flow throws (finally contract)', async () => {
+    const { metrics, observed } = makeMetrics();
+    const { svc } = makeSvc('supported', {
+      metrics,
+      searchImpl: async () => {
+        throw new Error('search exploded');
+      },
+    });
+    await expect(
+      svc.synthesize({
+        companyId: 'co_x',
+        dto: { ...baseDto, synthesisGuardrails: 'strict' },
+        callerScopes: ['brain:read'],
+      }),
+    ).rejects.toThrow('search exploded');
+    expect(observed).toHaveLength(1);
+  });
+});
+
+// ── 0119: abstain decision writer + primary-id threading ────────────
+describe('SynthesizeService — OUTCOME_DECISION_CAPTURE abstain seam', () => {
+  beforeEach(() => {
+    process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+    process.env.OUTCOME_DECISION_CAPTURE = '1';
+  });
+  afterAll(() => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    delete process.env.OUTCOME_DECISION_CAPTURE;
+  });
+
+  const coverageProfile = (over: Record<string, unknown> = {}) => ({
+    ...getActiveRetrievalProfile(),
+    abstentionCalibration: 'coverage' as const,
+    ...over,
+  });
+
+  it('an abstained request writes ONE static abstain decision (no outcome events)', async () => {
+    const decisionCalls: DecisionCall[] = [];
+    const { svc, calls } = makeSvc('supported', { decisionCalls });
+    // One fact < the default minEvidence floor (2) → coverage abstain.
+    const out = await svc.synthesize({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesisGuardrails: 'strict' },
+      callerScopes: ['brain:read'],
+      profile: coverageProfile({ abstentionMinEvidence: 2 }),
+    });
+    expect(out.reason).toBe('low_coverage');
+    expect(decisionCalls).toHaveLength(1);
+    const d = decisionCalls[0]!;
+    expect(d.companyId).toBe('co_x');
+    expect(d.input.decisionKind).toBe('abstain');
+    expect(d.input.chosenAction).toBe('abstain');
+    expect(d.input.policyVersion).toBe('static');
+    expect(d.input.actionScore).toBeUndefined();
+    expect(d.input.observedState).toMatchObject({ candidateCount: 1 });
+    expect(typeof d.input.costs?.latencyMs).toBe('number');
+    // Abstained pre-generation → no used_in_answer/verifier events.
+    expect(calls.flatMap((c) => c.events)).toEqual([]);
+  });
+
+  it('a proceed decision threads its id onto the emitAnswerUse events', async () => {
+    const decisionCalls: DecisionCall[] = [];
+    const { svc, calls } = makeSvc('supported', { decisionCalls });
+    // Floors that PASS → 'proceed', then the served flow emits outcomes.
+    const out = await svc.synthesize({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesisGuardrails: 'strict' },
+      callerScopes: ['brain:read'],
+      profile: coverageProfile({ abstentionMinEvidence: 1, abstentionMinTopScore: 0 }),
+    });
+    expect(out.answer).toBe('Maya [f1].');
+    expect(decisionCalls).toHaveLength(1);
+    expect(decisionCalls[0]!.input.chosenAction).toBe('proceed');
+    const used = named(calls, 'used_in_answer');
+    expect(used).toHaveLength(1);
+    expect(used[0]!.decisionId).toBe('deadbeefdeadbeefdeadbeefdeadbeef');
+    const verified = named(calls, 'verifier_supported');
+    expect(verified[0]!.decisionId).toBe('deadbeefdeadbeefdeadbeefdeadbeef');
+    // selected_for_context deliberately carries no decision join.
+    expect(named(calls, 'selected_for_context')[0]!.decisionId).toBeUndefined();
+  });
+
+  it('capture flag off: no decision rows, no decisionId on events (byte-identical)', async () => {
+    delete process.env.OUTCOME_DECISION_CAPTURE;
+    const decisionCalls: DecisionCall[] = [];
+    const { svc, calls } = makeSvc('supported', { decisionCalls });
+    await svc.synthesize({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesisGuardrails: 'strict' },
+      callerScopes: ['brain:read'],
+      profile: coverageProfile({ abstentionMinEvidence: 1, abstentionMinTopScore: 0 }),
+    });
+    expect(decisionCalls).toEqual([]);
+    for (const e of calls.flatMap((c) => c.events)) {
+      expect(e.decisionId).toBeUndefined();
+    }
   });
 });

--- a/test/synthesize.unit-spec.ts
+++ b/test/synthesize.unit-spec.ts
@@ -109,6 +109,8 @@ describe('SynthesizeService', () => {
     const outcomes: string[] = [];
     const metrics = {
       countSynthesize: (o: string) => outcomes.push(o),
+      // 0119: the serving-boundary latency observe runs on EVERY exit.
+      observeSearchDuration: () => undefined,
     } as unknown as ConstructorParameters<typeof SynthesizeService>[2];
     const answerCache = {
       begin: async () => ({ hit: cachedResult }),
@@ -134,6 +136,8 @@ describe('SynthesizeService', () => {
     const outcomes: string[] = [];
     const metrics = {
       countSynthesize: (o: string) => outcomes.push(o),
+      // 0119: the serving-boundary latency observe runs on EVERY exit.
+      observeSearchDuration: () => undefined,
     } as unknown as ConstructorParameters<typeof SynthesizeService>[2];
     const cfg = makeConfig({ OPENAI_API_KEY: 'sk-stub' });
     const svc = new SynthesizeService(makeSearch([]), cfg, metrics);


### PR DESCRIPTION
## Summary

Drift-6 of the audit wave: makes the 0107 outcome writes **transactional and idempotent** behind `OUTCOME_TX_WRITES`, adds **decision-context telemetry** (`memory_decision`, migration **0119**) behind `OUTCOME_DECISION_CAPTURE` with writers at the abstain seam and the L3 escalation trigger, closes the **MRI latency axis** with the one flag-free metrics-only observe, and wires the GDPR + retention legs for the new table.

**Migration number: `0119_decision_telemetry.surql`** (0113 was the top of the tree at branch time; 0114–0118 are claimed by in-flight siblings; the header carries the 0113-style NUMBERING NOTE).

## What changed

### Part 1 — transactional idempotent outcome writes (`OUTCOME_TX_WRITES`, default off)
- `src/outcomes/outcome-tx.ts` (new): pure payload builders + one `runTransaction` dispatch. Idempotency = **deterministic record ids + INSERT IGNORE** (the #92 changefeed idiom), NOT a unique index — a unique index over a new `option<string>` column would collide across every legacy NONE row (rationale in the 0119 header).
  - Event id = `sha256(dedupeKey|requestScope|batchSeq)[0..32)`; `dedupeKey` is the untouched 0113-pinned key (one definition shared with `dedupeOutcomeEvents`, so id components can never drift from partitioning); `requestScope` = `opts.requestId ?? getCorrelationId() ?? randomUUID()`, captured synchronously before detaching; `batchSeq` = per-request WeakMap counter, so the search-loop's two `retrieved` batches stay distinct rows exactly like today.
  - Tx shape: in-tx `LET $existing` pre-select → `INSERT IGNORE` (rows carry explicit ids) → delta gate (`rawId NOTINSIDE $existing OR rawId IS NONE`) → per-delta `FOR` fold via `LET $r = $d.row; INSERT ... ON DUPLICATE KEY UPDATE`. Never relies on INSERT IGNORE's return shape. Race-correct, not just replay-correct: concurrent identical batches OCC-abort at commit and the single retry re-runs against a populated `$existing`.
  - Delta gating: 'auto' deltas ride the id of the event that produced them (1:1); feedback's signed ±1 pair rides the vote's raw row; a delta with no matching batch event stays ungated (today's behavior, documented residual).
  - Retry: exactly one immediate retry, only for `isReadConflict` (runTransaction already enriches the bare wrapper). Fire-and-forget contract and all 5 callers untouched.
- `src/outcomes/memory-outcome.service.ts`: flag branch only; the off path is the **verbatim legacy two-statement shape** — the unit spec pins byte-equality of the captured SQL against string literals copied from origin/main (not against the implementation's own constants), and params keys exactly `{rows, statRows}`.

### Part 2 — decision-context telemetry (`OUTCOME_DECISION_CAPTURE`, default off, independent master)
- `0119_decision_telemetry.surql`: `memory_decision` (SCHEMAFULL; `decisionKind` ASSERT `['l3_escalation','abstain','lane_route','zoom']` — only the first two get writers, the enum reserves the audit's other seams; `alternatives[*].action/score` subfield defs — the `[*]` syntax is prod-proven in 0098; `propensity` reserved, never stamped). CONTENT-FREE contract in the header (ids/enums/numbers, never query/fact/answer text — the 0107 GDPR rationale). `decisionId` join columns on `memory_outcome` + `focus_signal_sample` (0094 NOT superseded; no data migration). All indexes single-field, non-unique; no changefeed/DEFINE EVENT.
- `src/outcomes/memory-decision.service.ts` (new, ToolObservationService template): deterministic id `sha256(requestScope|kind|kindSeq)` + INSERT IGNORE, fire-and-forget, no retry; pure exported `shapeDecisionRow` enforces the observedState whitelist (`topScore/coverageScore/retrievalGap/rawConfidence/candidateCount` finite numbers + `queryClass` ≤64), alternatives cap 8 (action/score pairs only), int-bounded costs.
- Writers (`src/synthesize/decision-emit.ts`, the outcome-emit idiom — no env reads in engine dirs, gated via the service static):
  - **abstain**: at the coverage-abstention seam when the gate is live (coverage mode + strict/lenient): `chosenAction 'abstain'|'proceed'`, adaptive path carries `actionScore`/threshold-vs-confidence `alternatives`, observedState reuses the very signal `resolveAdaptiveAbstain` computed (its return now carries `signal` instead of recomputing).
  - **l3_escalation**: `L3EscalateInput.onDecision?: (draft: L3DecisionDraft) => void` — invoked exactly once per `escalate()` evaluation (skip reasons included), fail-open, `traceArtifact` kept as well; `maxSessions` maps to `observedState.candidateCount` (the ranked-session budget at this seam, documented on the draft type). No 5th constructor param on the L3 service.
  - **threading**: first-writer-wins `primaryDecisionId` → `emitAnswerUse` events (both finalize paths + the L3 flip, via `FinalizeContext.decisionId`) and the verdict-stage `focus_signal_sample` (appended-field idiom — absent ⇒ CREATE byte-identical).
- `policyVersion`: `'static'` / `adaptive@thr=<threshold>` — the loaded `PerClassCalibration` does not expose a row version (the brief's anticipated fallback).

### Part 3 — latency axis (flag-free, metrics-only; audit pt-8)
- `synthesize()` observes `brain_search_duration_seconds` exactly once per request in a `finally` (all exits: ok/abstain/no_results/thrown). A histogram observe has no serving-path branch and alters no response bytes.
- `src/mri/economics.ts` fills `latencyP50/P95` via `histogramQuantile` (null when the window has no samples — never fabricated); `src/mri/mri-collectors.ts` renders live cells with the pending fallback + updated reason; stale "ALWAYS null today" docblocks refreshed. Composes with the R3 P1 windowed reader (it already deltas histograms).

### GDPR + retention
- `entity-forget`: decision join-purge in the pre-sweep (before the bulk outcome purge deletes the join rows) **and** the in-tx straggler pair before `DELETE $outIds`; `user-forget`: decisions-first block keyed on `subjectId.userId`. Everywhere the two-step `LET`-select → `DELETE $ids` idiom (3.2.4 planner no-op class); accepted over-deletion semantics documented in both comments; uncounted in txRecordCount like the rest of the telemetry.
- `OutcomePruneService` third leg: `DECISION_PRUNE_BATCH_QUERY`, `OUTCOME_DECISION_RETENTION_DAYS` (default 30), gated on `OUTCOME_DECISION_CAPTURE`, shared tick/in-flight guard.

### Flags / catalog
- `src/common/outcome-flags.ts`: `outcomeTxWritesEnabled()`, `outcomeDecisionCaptureEnabled()`, `outcomeDecisionRetentionDays()`; `KNOWN_BOOLEAN_FLAGS` += `OUTCOME_TX_WRITES`, `OUTCOME_DECISION_CAPTURE`; 3 config-catalog entries under `audit`.

### File-budget extractions (behavior unchanged, no serving diff)
`synthesize.service.ts` sat at ~795/800 counted lines on origin/main, so the wave forced relocations: adaptive-gate resolvers → `src/synthesize/adaptive-gates.ts`; decision seams → `src/synthesize/decision-emit.ts`; `miniCheckVerdict` → `minicheck-client.ts` (span kept); the collector seam → a private method. `miniCheckConsistent` joined the S5.5 TEST_SEAMS golden (its consumer is now in-module; still pinned directly by its unit spec).

## Flag matrix (asserted in tests)
- All new flags off: every SQL statement byte-identical (pinned against literals); no decision rows; no `decisionId` keys anywhere; forget-service new lines run flag-free (no-op on empty tables — the existing 0107 purge-line pattern).
- `OUTCOME_TX_WRITES=1` alone: tx path, ids + requestId stamped, no decision rows.
- `OUTCOME_DECISION_CAPTURE=1` alone: decision rows + `decisionId` on outcome rows via emit threading (rides the legacy write path).
- The latency observe + MRI fill are flag-free by design (metrics-only).

## Deviations from the brief (code-over-brief calls)
1. **entity-forget decision purge**: the brief placed the decision leg only inside the erase tx, but the pre-tx `preSweepOutcomeRows` deletes the subject's outcome rows (the join source) *before* the tx runs — an in-tx-only sweep would miss every decision joined to pre-swept rows. Implemented the join-purge in the pre-sweep as well (honoring the brief's own "COLLECTED BEFORE the outcome rows die"), keeping the in-tx straggler legs as specified.
2. **Static abstain observedState** carries the full focus-signal number set (same whitelist) rather than only `{topScore, candidateCount}` — one uniform shape across static/adaptive, same content-free contract.
3. **Stat fold form**: shipped the brief's documented fallback (`LET $r = $d.row; INSERT ... $r`) rather than the path-expression INSERT — the plain-variable INSERT is the form already verified in prod code; the e2e replay test confirms the whole tx (INSERT IGNORE ids, SELECT-from-array-param, FOR fold) on the real pinned server.
4. **Line-budget relocations** listed above went beyond the brief's file list — forced by `max-lines 800` (the service had ~5 lines of headroom before this PR).

## Verification (local)
- `pnpm typecheck` clean; `pnpm lint:ci` 0 errors 0 warnings; `pnpm format:check` clean.
- Unit: **3140 passed / 313 suites** (full run), incl. new: off-path SQL byte-identity, event-id determinism (replay same ids / batchSeq distinct), tx shape, delta gating, single-OCC-retry, shapeDecisionRow whitelist, prune leg + independent gating, 0119 migration tuples + forget-service source guards, MRI latency live/null cases, latency-observe-once (ok/no_results/throw), abstain-writer + decisionId threading.
- E2E (real SurrealDB v3.2.4, testcontainers): **50 passed / 13 suites** over the touched surfaces (`memory-outcome`, new `memory-decision`, forget, decision-log, fovea, focus, MRI, synthesize) — incl. same-batch-replayed-twice ⇒ identical raw count + all six counters unchanged; type-violating batch ⇒ **both** tables empty (atomicity); abstain + proceed decision rows over HTTP; outcome rows + verdict-stage focus sample joining the proceed decision; both GDPR cascades purging decisions through the join; flags-off legs unchanged.
- Grep-guards: no `DELETE memory_decision WHERE` in `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
