### PR TITLE
feat(mcp): fact read tools, tool-observation ref on ingest_document, full-capability connector shim

### DIFF
--- a/clients/brain-mcp/README.md
+++ b/clients/brain-mcp/README.md
@@ -18,8 +18,19 @@ harness ──stdio──▶ brain-mcp ──HTTP + Bearer──▶ https://brai
 ```
 
 It is a **transparent passthrough** — it does not rename or curate tools.
-`tools/list` and `tools/call` are forwarded verbatim, so the harness sees
-exactly the surface the key unlocks (read → 15 tools, +write → 20, +admin → 21).
+Forwarded verbatim (as of v0.2.0):
+
+- `tools/list` / `tools/call` — the harness sees exactly the tool surface
+  the key unlocks (read / +write / +admin; flag-gated tools appear only
+  when the server has them enabled).
+- `resources/list`, `resources/templates/list`, `resources/read` — brain's
+  `brain://entity/<id>` and `brain://entity/<id>/timeline` resources are
+  visible and readable through the bridge.
+- **Sampling, in reverse**: brain's `sampling/createMessage` requests are
+  forwarded to the harness, so `summarize_entity` with
+  `styleHint='client_llm'` uses the **harness's** model. If the harness
+  does not advertise the `sampling` capability, the request fails cleanly
+  and brain falls back to its local template (the pre-0.2.0 behavior).
 
 ## Configuration
 

--- a/clients/brain-mcp/package.json
+++ b/clients/brain-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inite/brain-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "First-party stdio MCP connector for the INITE Brain service. Lets stdio-only harnesses that can't attach auth headers (e.g. openclaw, Goose 1.x) use brain as long-term memory by transparently proxying every scoped tool over Streamable HTTP with Bearer auth. Harnesses with native remote MCP (Hermes, Claude Desktop, Cursor) connect directly by URL instead.",
   "author": "INITE",
   "license": "AGPL-3.0-or-later",

--- a/clients/brain-mcp/src/bridge.ts
+++ b/clients/brain-mcp/src/bridge.ts
@@ -1,0 +1,137 @@
+/**
+ * Bridge wiring for @inite/brain-mcp — the downstream (harness-facing)
+ * MCP server, the request passthroughs, and the sampling
+ * reverse-passthrough. Split out of index.ts so the wiring can be
+ * imported by tests without executing the CLI entrypoint.
+ *
+ * Surface map (v0.2.0):
+ *   harness → bridge → brain:  tools/list, tools/call, resources/list,
+ *                              resources/templates/list, resources/read
+ *   brain → bridge → harness:  sampling/createMessage
+ *
+ * Everything is forwarded verbatim — no curation, no renaming, no field
+ * filtering. The bridge advertises downstream exactly the capabilities
+ * the upstream brain advertised (tools always; resources when brain has
+ * them), and advertises `sampling` upstream so brain's
+ * summarize_entity(styleHint='client_llm') can reach the harness's LLM.
+ * If the harness itself never advertised sampling, the forwarded request
+ * fails with a clear MCP error and brain falls back to its local
+ * template — the same behavior as before the bridge supported sampling.
+ */
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  CallToolRequestSchema,
+  CreateMessageRequestSchema,
+  ErrorCode,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ListToolsRequestSchema,
+  McpError,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
+
+export interface BridgeServerOptions {
+  /** Connected upstream client (brain over Streamable HTTP + Bearer). */
+  upstream: Client;
+  /** Capabilities the upstream advertised during initialize. */
+  upstreamCapabilities: ServerCapabilities;
+  /** Downstream server identity shown to the harness. */
+  name: string;
+  version: string;
+}
+
+/**
+ * Mirror of the upstream capabilities the bridge re-advertises to the
+ * harness: tools always (brain's baseline surface), resources only when
+ * the upstream actually has them — the MCP SDK rejects registering a
+ * resources handler on a server that never declared the capability, so
+ * the mirror and the handler set must agree.
+ *
+ * NOT mirrored: `sampling` is a client-side capability (it belongs in
+ * the bridge's upstream initialize, not here), and server capabilities
+ * brain doesn't advertise (prompts, logging) stay un-mirrored so the
+ * bridge never promises what the upstream can't serve.
+ */
+export function downstreamCapabilities(upstream: ServerCapabilities): ServerCapabilities {
+  return {
+    tools: upstream.tools ?? {},
+    ...(upstream.resources !== undefined ? { resources: upstream.resources } : {}),
+  };
+}
+
+/**
+ * Build the harness-facing stdio server: transparent passthrough of the
+ * tool surface, plus the resource surface when the upstream advertises
+ * one (brain exposes brain://entity/{id} and .../timeline as resource
+ * TEMPLATES, so resources/templates/list is the discovery call that
+ * makes them visible; resources/list stays a passthrough for
+ * completeness and future concrete resources). Pagination cursors and
+ * request params are forwarded verbatim in both directions.
+ */
+export function createBridgeServer({
+  upstream,
+  upstreamCapabilities,
+  name,
+  version,
+}: BridgeServerOptions): Server {
+  const capabilities = downstreamCapabilities(upstreamCapabilities);
+  const server = new Server({ name, version }, { capabilities });
+
+  server.setRequestHandler(ListToolsRequestSchema, async (request) =>
+    upstream.listTools(request.params),
+  );
+  server.setRequestHandler(CallToolRequestSchema, async (request) =>
+    upstream.callTool(request.params),
+  );
+
+  if (capabilities.resources !== undefined) {
+    server.setRequestHandler(ListResourcesRequestSchema, async (request) =>
+      upstream.listResources(request.params),
+    );
+    server.setRequestHandler(ListResourceTemplatesRequestSchema, async (request) =>
+      upstream.listResourceTemplates(request.params),
+    );
+    server.setRequestHandler(ReadResourceRequestSchema, async (request) =>
+      upstream.readResource(request.params),
+    );
+  }
+
+  return server;
+}
+
+/**
+ * Reverse passthrough: brain (upstream server) may request
+ * sampling/createMessage from its client — that client is this bridge,
+ * so the request is forwarded DOWN to the harness, whose LLM answers.
+ * The upstream Client must have been constructed with
+ * `capabilities: { sampling: {} }` for this handler to register (the
+ * SDK asserts declared capabilities), and because MCP has no capability
+ * renegotiation the bridge advertises sampling upstream BEFORE it can
+ * know whether the harness supports it. When the harness never
+ * advertised sampling, the forwarded request fails with a clear MCP
+ * error; brain catches sampling errors and falls back to its local
+ * template, which is exactly the pre-bridge behavior.
+ */
+export function registerSamplingPassthrough({
+  upstream,
+  server,
+  log = () => undefined,
+}: {
+  upstream: Client;
+  server: Server;
+  log?: (...args: unknown[]) => void;
+}): void {
+  upstream.setRequestHandler(CreateMessageRequestSchema, async (request) => {
+    const clientCapabilities = server.getClientCapabilities();
+    if (!clientCapabilities?.sampling) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        'downstream harness does not advertise sampling — brain will fall back to its local template',
+      );
+    }
+    log('forwarding sampling/createMessage to the downstream harness');
+    return server.createMessage(request.params);
+  });
+}

--- a/clients/brain-mcp/src/index.ts
+++ b/clients/brain-mcp/src/index.ts
@@ -12,8 +12,13 @@
  *   harness ──stdio──▶ brain-mcp ──HTTP+Bearer──▶ https://brain.inite.ai/mcp/<company>
  *
  * It is a thin, transparent passthrough — it does NOT curate or rename tools.
- * `tools/list` and `tools/call` are forwarded verbatim, so the harness sees
- * exactly the surface the API key unlocks (read / write / admin).
+ * `tools/list`, `tools/call`, and the resource surface (`resources/list`,
+ * `resources/templates/list`, `resources/read` — brain://entity/… lives
+ * there) are forwarded verbatim, so the harness sees exactly the surface
+ * the API key unlocks (read / write / admin). Sampling is bridged the
+ * other way: brain's sampling/createMessage requests are forwarded to the
+ * harness so summarize_entity(styleHint='client_llm') can use ITS model.
+ * See bridge.ts for the wiring.
  *
  * Config is entirely via environment (harnesses pass `env` to the subprocess):
  *   BRAIN_API_KEY      (required)  e.g. brain_xxxxx
@@ -26,15 +31,11 @@
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
+import { createBridgeServer, registerSamplingPassthrough } from './bridge.js';
 
 const PKG_NAME = '@inite/brain-mcp';
-const PKG_VERSION = '0.1.0';
+const PKG_VERSION = '0.2.0';
 const DEFAULT_BASE_URL = 'https://brain.inite.ai';
 const COMPANY_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
 
@@ -93,9 +94,15 @@ function resolveConfig(): Resolved {
 }
 
 async function connectUpstream({ url, apiKey }: Resolved): Promise<Client> {
+  // `sampling` is declared upstream unconditionally: MCP has no
+  // capability renegotiation, and the harness's own capabilities are
+  // only known after the stdio side connects (which needs the upstream
+  // capabilities first, to mirror them). If the harness turns out not
+  // to support sampling, the forwarded request errors cleanly and brain
+  // falls back to its local template — see registerSamplingPassthrough.
   const client = new Client(
     { name: PKG_NAME, version: PKG_VERSION },
-    { capabilities: {} },
+    { capabilities: { sampling: {} } },
   );
 
   const transport = new StreamableHTTPClientTransport(new URL(url), {
@@ -136,22 +143,19 @@ async function main(): Promise<void> {
       `(capabilities: ${Object.keys(upstreamCaps).join(', ') || 'none'})`,
   );
 
-  // Downstream server faces the harness over stdio. We only advertise the
-  // capabilities the upstream actually has; brain is tools-only today, but
-  // this keeps the bridge honest if that grows.
-  const server = new Server(
-    { name: 'brain', version: upstreamInfo?.version ?? PKG_VERSION },
-    { capabilities: { tools: upstreamCaps.tools ?? {} } },
-  );
-
-  // Transparent passthrough — forward verbatim, including pagination cursors.
-  server.setRequestHandler(ListToolsRequestSchema, async (request) => {
-    return upstream.listTools(request.params);
+  // Downstream server faces the harness over stdio. It advertises the
+  // capabilities the upstream actually has (tools + resources) and
+  // forwards every surface verbatim, including pagination cursors.
+  const server = createBridgeServer({
+    upstream,
+    upstreamCapabilities: upstreamCaps,
+    name: 'brain',
+    version: upstreamInfo?.version ?? PKG_VERSION,
   });
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    return upstream.callTool(request.params);
-  });
+  // Reverse direction: brain's sampling/createMessage requests reach the
+  // harness's LLM (summarize_entity styleHint='client_llm').
+  registerSamplingPassthrough({ upstream, server, log });
 
   // If the remote connection drops, take the bridge down so the harness
   // surfaces it instead of silently serving a dead proxy.

--- a/src/mcp/read-tools.ts
+++ b/src/mcp/read-tools.ts
@@ -1,5 +1,6 @@
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { envFlagEnabled } from '../common/env-validation';
 import type { SearchService } from '../search/search.service';
 import type { EntitiesService } from '../entities/entities.service';
 import type { FactsService } from '../facts/facts.service';
@@ -514,6 +515,19 @@ function registerEntityReadTools({
 
   registerDetectContradictionTool({ server, companyId, scopes, deps });
 
+  // ── get_fact / get_fact_provenance ────────────────────────────────
+  // Registered only when the REST fact-read surface is switched on —
+  // same conditional-registration idiom as ingest_document (agents
+  // shouldn't see a tool that answers 404). The REST twin 404s behind
+  // FACTS_API_ENABLED "indistinguishable from an absent route"; the MCP
+  // analogue of an absent route is an absent tool (tools/list omits it,
+  // a blind tools/call gets the SDK's standard unknown-tool error).
+  // buildServer runs per request, so a flag flip applies on the next
+  // request — exactly like the REST gate.
+  if (envFlagEnabled(process.env.FACTS_API_ENABLED)) {
+    registerFactReadTools({ server, companyId, scopes, deps });
+  }
+
   // ── find_related_entities ─────────────────────────────────────────
   server.registerTool(
     'find_related_entities',
@@ -544,6 +558,68 @@ function registerEntityReadTools({
         kind: args.kind,
         scopes,
         asOf: args.asOf,
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
+        structuredContent: asStructuredContent(out),
+      };
+    },
+  );
+}
+
+/**
+ * Fact-level read surface (FACTS_API_ENABLED): the MCP twins of
+ * GET /v1/facts/:id and GET /v1/facts/:id/provenance, delegating to the
+ * same FactsService methods — one implementation of every visibility
+ * fence (tenant pin, user scope, row policy; each an absence, never a
+ * 403). Tool names equal the registry action ids (get_fact /
+ * get_fact_provenance, both kind 'read'), so the ABAC + RFC 9396 grant
+ * gates govern them exactly as they govern the REST routes.
+ */
+function registerFactReadTools({
+  server,
+  companyId,
+  scopes,
+  deps,
+}: RegisterReadToolsOptions): void {
+  server.registerTool(
+    'get_fact',
+    {
+      title: 'Get one fact by id',
+      description:
+        'Read a single fact as stored — predicate (aspect), object (statement), confidence, validity window, source attribution (vertical / recorder / conversationId), and lifecycle state. Retracted facts still resolve (retracted: true) — "why did I stop remembering this" is part of the trust story; only visibility fences turn into not-found. groundingStatus (grounded | ungrounded) appears on facts stamped by the claim-grounding plane (EVIDENCE_GROUNDING_STAMP); legacy rows carry no key. Same shape as GET /v1/facts/:id. Use after search_knowledge / record_fact when you hold a factId and need the full trust record behind it.',
+      inputSchema: {
+        factId: z.string().describe('Fact id (knowledge_fact:...) or short id'),
+      },
+    },
+    async (args) => {
+      const out = await deps.facts.getFact({
+        companyId,
+        factId: args.factId,
+        scopes,
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],
+        structuredContent: asStructuredContent(out),
+      };
+    },
+  );
+
+  server.registerTool(
+    'get_fact_provenance',
+    {
+      title: 'Show why a fact is remembered (grounding provenance)',
+      description:
+        'Return the grounding provenance behind one fact: the verbatim conversation turns it was derived from (episodes, chronological, with char-span quotes when the deriver stamped them). When the server runs with the recursive-closure flag the response additionally carries derivedFacts + closure (the transitive derivedFrom support graph); a plain deployment returns episodes only — the response is a passthrough of GET /v1/facts/:id/provenance, no field filtering. Traversal depth is a server-side policy (flag + caps), not a caller knob. Use to audit a surprising fact before trusting or retracting it.',
+      inputSchema: {
+        factId: z.string().describe('Fact id (knowledge_fact:...) or short id'),
+      },
+    },
+    async (args) => {
+      const out = await deps.facts.getProvenance({
+        companyId,
+        factId: args.factId,
+        scopes,
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],

--- a/src/mcp/write-tools.ts
+++ b/src/mcp/write-tools.ts
@@ -442,6 +442,13 @@ function registerIngestDocumentTool({
           .describe(
             "'general' (default) = generalist union pass only; 'auto' = also route relevant installed domain packs (server must have DOCUMENT_MULTI_INDEXER_ENABLED)",
           ),
+        toolObservationRef: z
+          .string()
+          .max(160)
+          .optional()
+          .describe(
+            'Provenance hop back to the tool result this document was derived from: tool_observation:<id> (migration 0111). Honored only under TOOL_OBSERVATIONS_ENABLED — validated against this tenant\'s own observation rows, stored on the document header, and folded into every committed fact\'s source.evidence[] as a "tool_observation" entry. Closes the tool result → document → fact loop.',
+          ),
       },
     },
     async (args) => {
@@ -463,6 +470,9 @@ function registerIngestDocumentTool({
         contextRef: { vertical: args.vertical, recorder },
         ...(args.storeContent !== undefined ? { storeContent: args.storeContent } : {}),
         indexers: args.indexers ?? 'general',
+        ...(args.toolObservationRef !== undefined
+          ? { toolObservationRef: args.toolObservationRef }
+          : {}),
         mode: 'sync',
       });
       return {

--- a/test/brain-mcp-bridge.unit-spec.ts
+++ b/test/brain-mcp-bridge.unit-spec.ts
@@ -1,0 +1,237 @@
+/**
+ * Smoke coverage for the @inite/brain-mcp connector bridge (v0.2.0) —
+ * the wiring in clients/brain-mcp/src/bridge.ts, exercised against a
+ * REAL MCP client over an in-memory transport (the SDK's linked-pair
+ * test idiom), with the upstream brain stubbed:
+ *
+ *  - capability mirror: tools always, resources only when the upstream
+ *    advertises them (a bridge must never promise what brain can't serve);
+ *  - tools/list + tools/call forward params verbatim;
+ *  - resources/templates/list + resources/read passthrough — the surface
+ *    that made brain://entity/... visible through the bridge;
+ *  - a tools-only upstream registers NO resource handlers (the harness
+ *    gets the standard capability error, not a hang);
+ *  - sampling reverse-passthrough: brain's sampling/createMessage is
+ *    forwarded to the downstream harness when it advertises sampling,
+ *    and fails with a clean McpError when it doesn't (brain's sampling
+ *    path catches errors and falls back to its local template).
+ *
+ * The bridge package has no test toolchain of its own; its source is
+ * plain SDK wiring with no relative imports, so the repo suite smokes it
+ * directly against the repo's SDK install.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { CreateMessageRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  createBridgeServer,
+  downstreamCapabilities,
+  registerSamplingPassthrough,
+} from '../clients/brain-mcp/src/bridge';
+
+type SamplingHandler = (request: {
+  method: 'sampling/createMessage';
+  params: Record<string, unknown>;
+}) => Promise<unknown>;
+
+function stubUpstream() {
+  const calls: Record<string, unknown[]> = {};
+  const record = (name: string, arg: unknown) => (calls[name] ??= []).push(arg);
+  let samplingHandler: SamplingHandler | undefined;
+  const upstream = {
+    listTools: async (params?: unknown) => {
+      record('listTools', params);
+      return {
+        tools: [
+          {
+            name: 'search_knowledge',
+            description: 'stub',
+            inputSchema: { type: 'object' as const },
+          },
+        ],
+      };
+    },
+    callTool: async (params: unknown) => {
+      record('callTool', params);
+      return { content: [{ type: 'text' as const, text: 'called' }] };
+    },
+    listResources: async (params?: unknown) => {
+      record('listResources', params);
+      return { resources: [] };
+    },
+    listResourceTemplates: async (params?: unknown) => {
+      record('listResourceTemplates', params);
+      return {
+        resourceTemplates: [
+          { uriTemplate: 'brain://entity/{entityId}', name: 'entity-profile' },
+          { uriTemplate: 'brain://entity/{entityId}/timeline', name: 'entity-timeline' },
+        ],
+      };
+    },
+    readResource: async (params: { uri: string }) => {
+      record('readResource', params);
+      return {
+        contents: [{ uri: params.uri, mimeType: 'application/json', text: '{"stub":true}' }],
+      };
+    },
+    setRequestHandler: (_schema: unknown, handler: SamplingHandler) => {
+      samplingHandler = handler;
+    },
+  };
+  return { upstream, calls, getSamplingHandler: () => samplingHandler };
+}
+
+async function connectHarness(
+  server: Server,
+  capabilities: Record<string, unknown> = {},
+): Promise<Client> {
+  const client = new Client({ name: 'harness', version: '1.0.0' }, { capabilities });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return client;
+}
+
+describe('brain-mcp bridge — capability mirror', () => {
+  it('mirrors tools always and resources only when the upstream has them', () => {
+    expect(downstreamCapabilities({ tools: { listChanged: true } })).toEqual({
+      tools: { listChanged: true },
+    });
+    expect(downstreamCapabilities({ tools: {}, resources: { subscribe: false } })).toEqual({
+      tools: {},
+      resources: { subscribe: false },
+    });
+    // No tools advertised upstream (never the case for brain, but the
+    // mirror must not invent undefined) → empty tools object, no resources.
+    expect(downstreamCapabilities({})).toEqual({ tools: {} });
+  });
+});
+
+describe('brain-mcp bridge — passthrough over a real MCP wire', () => {
+  it('forwards tools/list, tools/call, resources/templates/list, resources/read verbatim', async () => {
+    const { upstream, calls } = stubUpstream();
+    const server = createBridgeServer({
+      upstream: upstream as never,
+      upstreamCapabilities: { tools: {}, resources: {} },
+      name: 'brain',
+      version: '9.9.9',
+    });
+    const client = await connectHarness(server);
+    try {
+      const tools = await client.listTools();
+      expect(tools.tools.map((t) => t.name)).toEqual(['search_knowledge']);
+
+      const result = await client.callTool({
+        name: 'search_knowledge',
+        arguments: { query: 'acme' },
+      });
+      expect(result.content).toEqual([{ type: 'text', text: 'called' }]);
+      // Params reach the upstream verbatim — no curation, no renaming.
+      expect(calls['callTool']![0]).toMatchObject({
+        name: 'search_knowledge',
+        arguments: { query: 'acme' },
+      });
+
+      const templates = await client.listResourceTemplates();
+      expect(templates.resourceTemplates.map((t) => t.uriTemplate)).toEqual([
+        'brain://entity/{entityId}',
+        'brain://entity/{entityId}/timeline',
+      ]);
+
+      const read = await client.readResource({ uri: 'brain://entity/e1' });
+      expect(read.contents[0]).toMatchObject({ uri: 'brain://entity/e1' });
+      expect(calls['readResource']![0]).toMatchObject({ uri: 'brain://entity/e1' });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('a tools-only upstream registers no resource surface downstream', async () => {
+    const { upstream } = stubUpstream();
+    const server = createBridgeServer({
+      upstream: upstream as never,
+      upstreamCapabilities: { tools: {} },
+      name: 'brain',
+      version: '9.9.9',
+    });
+    const client = await connectHarness(server);
+    try {
+      // No handler registered → the bridge answers with the protocol's
+      // standard method-not-found error (never a hang, never a forward
+      // to an upstream that would reject it anyway).
+      await expect(client.listResources()).rejects.toThrow(/Method not found|resources/);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});
+
+describe('brain-mcp bridge — sampling reverse-passthrough', () => {
+  it('forwards sampling/createMessage to a harness that advertises sampling', async () => {
+    const { upstream, getSamplingHandler } = stubUpstream();
+    const server = createBridgeServer({
+      upstream: upstream as never,
+      upstreamCapabilities: { tools: {} },
+      name: 'brain',
+      version: '9.9.9',
+    });
+    registerSamplingPassthrough({ upstream: upstream as never, server });
+    const handler = getSamplingHandler();
+    expect(handler).toBeDefined();
+
+    const client = new Client(
+      { name: 'harness', version: '1.0.0' },
+      { capabilities: { sampling: {} } },
+    );
+    client.setRequestHandler(CreateMessageRequestSchema, async () => ({
+      model: 'harness-model',
+      role: 'assistant' as const,
+      content: { type: 'text' as const, text: 'one-line briefing from the harness LLM' },
+    }));
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    try {
+      const out = (await handler!({
+        method: 'sampling/createMessage',
+        params: {
+          messages: [{ role: 'user', content: { type: 'text', text: 'summarize acme' } }],
+          maxTokens: 32,
+        },
+      })) as { model: string; content: { text: string } };
+      expect(out.model).toBe('harness-model');
+      expect(out.content.text).toContain('briefing');
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('fails with a clean McpError when the harness lacks sampling (brain then falls back)', async () => {
+    const { upstream, getSamplingHandler } = stubUpstream();
+    const server = createBridgeServer({
+      upstream: upstream as never,
+      upstreamCapabilities: { tools: {} },
+      name: 'brain',
+      version: '9.9.9',
+    });
+    registerSamplingPassthrough({ upstream: upstream as never, server });
+    const client = await connectHarness(server); // no sampling capability
+    try {
+      // Assert on the error's wire shape, not instanceof: when the shim
+      // package has its own node_modules the bridge resolves ITS copy of
+      // the SDK, and cross-realm class identity would flake while the
+      // JSON-RPC behavior stays identical.
+      await expect(
+        getSamplingHandler()!({
+          method: 'sampling/createMessage',
+          params: { messages: [], maxTokens: 8 },
+        }),
+      ).rejects.toThrow(/does not advertise sampling/);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/test/mcp-fact-tools.e2e-spec.ts
+++ b/test/mcp-fact-tools.e2e-spec.ts
@@ -1,0 +1,169 @@
+/**
+ * MCP fact read tools — end-to-end on a real DB.
+ *
+ * The 0115 trust loop over MCP: record_fact with evidence[] (under
+ * EVIDENCE_GROUNDING_STAMP=1) → get_fact shows groundingStatus →
+ * get_fact_provenance returns the passthrough provenance shape. Plus
+ * gating parity with REST: FACTS_API_ENABLED off removes the tools from
+ * tools/list and a blind tools/call errors — the MCP twin of the
+ * controller's 404 ("indistinguishable from an absent route") — and the
+ * per-request server build means the flag flips without a restart,
+ * exactly like the REST gate.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+
+describe('MCP get_fact / get_fact_provenance (e2e)', () => {
+  let f: AppFixture;
+  const SAVED = {
+    factsApi: process.env.FACTS_API_ENABLED,
+    stamp: process.env.EVIDENCE_GROUNDING_STAMP,
+  };
+
+  beforeAll(async () => {
+    process.env.FACTS_API_ENABLED = '1';
+    process.env.EVIDENCE_GROUNDING_STAMP = '1';
+    f = await createApp({ companyId: 'co_mcp_fact_tools_e2e' });
+  }, 120_000);
+
+  afterAll(async () => {
+    if (SAVED.factsApi === undefined) delete process.env.FACTS_API_ENABLED;
+    else process.env.FACTS_API_ENABLED = SAVED.factsApi;
+    if (SAVED.stamp === undefined) delete process.env.EVIDENCE_GROUNDING_STAMP;
+    else process.env.EVIDENCE_GROUNDING_STAMP = SAVED.stamp;
+    if (f) await f.close();
+  });
+
+  // ── JSON-RPC over the stateless Streamable HTTP endpoint ──────────
+  function parseSse(text: string): any {
+    const events: any[] = [];
+    for (const line of text.split('\n')) {
+      if (line.startsWith('data: ')) events.push(JSON.parse(line.slice(6)));
+    }
+    return events[events.length - 1];
+  }
+
+  async function rpc(body: Record<string, unknown>): Promise<any> {
+    const res = await f.http
+      .post(`/mcp/${f.companyId}`)
+      .set({
+        Authorization: `Bearer ${f.apiKey}`,
+        Accept: 'application/json, text/event-stream',
+      })
+      .send(body);
+    expect(res.status).toBe(200);
+    const ct = String(res.headers['content-type'] ?? '');
+    if (ct.includes('text/event-stream')) {
+      return parseSse(res.text ?? res.body.toString());
+    }
+    return res.body;
+  }
+
+  const toolsList = async (): Promise<string[]> => {
+    const out = await rpc({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+    return (out.result?.tools ?? []).map((t: { name: string }) => t.name);
+  };
+
+  const toolCall = async (name: string, args: Record<string, unknown>): Promise<any> => {
+    return rpc({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    });
+  };
+
+  let factId = '';
+
+  it('tools/list shows get_fact + get_fact_provenance under FACTS_API_ENABLED', async () => {
+    const names = await toolsList();
+    expect(names).toContain('get_fact');
+    expect(names).toContain('get_fact_provenance');
+  });
+
+  it('record_fact with evidence[] → get_fact shows groundingStatus grounded', async () => {
+    const recorded = await toolCall('record_fact', {
+      entityRef: { vertical: 'rent', id: 'cust_mcp_fact_1' },
+      predicate: 'complained_about',
+      object: 'observation recorded over MCP',
+      validFrom: '2026-04-01T00:00:00.000Z',
+      confidence: 0.7,
+      sourceVertical: 'rent',
+      evidence: [{ kind: 'message', ref: 'msg_mcp_ev_1' }],
+    });
+    expect(recorded.result.isError).toBeFalsy();
+    expect(recorded.result.structuredContent.outcome).toBe('INSERTED');
+    factId = recorded.result.structuredContent.factId;
+    expect(typeof factId).toBe('string');
+
+    const read = await toolCall('get_fact', { factId });
+    expect(read.result.isError).toBeFalsy();
+    const fact = read.result.structuredContent;
+    expect(fact.factId).toBe(factId);
+    expect(fact.aspect).toBe('complained_about');
+    expect(fact.statement).toBe('observation recorded over MCP');
+    expect(fact.retracted).toBe(false);
+    // The evidence[] pointer marked the claim grounded at ingest; the
+    // MCP read surfaces the stamp exactly as GET /v1/facts/:id does.
+    expect(fact.groundingStatus).toBe('grounded');
+  });
+
+  it('get_fact matches the REST twin byte-for-byte (same service, same fences)', async () => {
+    const mcp = await toolCall('get_fact', { factId });
+    const rest = await f.http
+      .get(`/v1/facts/${encodeURIComponent(factId)}`)
+      .set({ Authorization: `Bearer ${f.apiKey}` });
+    expect(rest.status).toBe(200);
+    expect(mcp.result.structuredContent).toEqual(rest.body);
+  });
+
+  it('get_fact_provenance returns the passthrough provenance shape', async () => {
+    const out = await toolCall('get_fact_provenance', { factId });
+    expect(out.result.isError).toBeFalsy();
+    const prov = out.result.structuredContent;
+    expect(prov.factId).toBe(factId);
+    // Evidence-grounded fact, no derivation episodes: empty list, and no
+    // closure keys (PROVENANCE_RECURSIVE_CLOSURE off → byte-identical).
+    expect(Array.isArray(prov.episodes)).toBe(true);
+    expect(prov.episodes).toEqual([]);
+    expect('derivedFacts' in prov).toBe(false);
+  });
+
+  it('an unknown factId surfaces the REST-parity not-found error, not a raw DB error', async () => {
+    const out = await toolCall('get_fact', { factId: 'knowledge_fact:does_not_exist' });
+    // The NotFoundException (HttpException < 500) passes the MCP error
+    // wrapper unchanged — the deliberate client-facing class — and the
+    // SDK folds a thrown handler error into an isError tool result. A
+    // raw Surreal message (record ids, index names) must never appear.
+    expect(out.result.isError).toBe(true);
+    const text = String(out.result.content?.[0]?.text ?? '');
+    expect(text).toContain('not found');
+    expect(text.toLowerCase()).not.toContain('surreal');
+  });
+
+  it('FACTS_API_ENABLED off → tools vanish from tools/list and a blind call errors', async () => {
+    delete process.env.FACTS_API_ENABLED;
+    try {
+      const names = await toolsList();
+      expect(names).not.toContain('get_fact');
+      expect(names).not.toContain('get_fact_provenance');
+      // Baseline read tools are untouched by the flag.
+      expect(names).toContain('search_knowledge');
+
+      // The SDK folds its unknown-tool McpError into an isError tool
+      // result ("MCP error -32602: Tool get_fact not found") — the
+      // absent-tool refusal, never a successful read.
+      const out = await toolCall('get_fact', { factId });
+      expect(out.result.isError).toBe(true);
+      expect(String(out.result.content?.[0]?.text ?? '')).toContain('not found');
+
+      // REST twin at the same instant: 404 behind the same flag.
+      const rest = await f.http
+        .get(`/v1/facts/${encodeURIComponent(factId)}`)
+        .set({ Authorization: `Bearer ${f.apiKey}` });
+      expect(rest.status).toBe(404);
+    } finally {
+      process.env.FACTS_API_ENABLED = '1';
+    }
+  });
+});

--- a/test/mcp-tools.unit-spec.ts
+++ b/test/mcp-tools.unit-spec.ts
@@ -21,6 +21,7 @@
  * it for the test only — production code never touches it.
  */
 import { McpService } from '../src/mcp/mcp.service';
+import { ACTIONS } from '../src/policy/action-registry';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { BrainScope } from '../src/auth/api-key.types';
 
@@ -142,6 +143,46 @@ describe('McpService.buildServer — scope-gated tool surface', () => {
     expect(names).toContain('entity-timeline');
   });
 
+  it('does NOT register get_fact / get_fact_provenance with FACTS_API_ENABLED off (default)', async () => {
+    // Gating parity with REST: facts.controller 404s the GET routes when
+    // the flag is off ("indistinguishable from an absent route"); the MCP
+    // twin of an absent route is an absent tool.
+    const names = toolNames(await buildWithScopes(['brain:read']));
+    expect(names).not.toContain('get_fact');
+    expect(names).not.toContain('get_fact_provenance');
+  });
+
+  it('registers get_fact / get_fact_provenance under FACTS_API_ENABLED with a factId input', async () => {
+    const prev = process.env.FACTS_API_ENABLED;
+    process.env.FACTS_API_ENABLED = '1';
+    try {
+      const server = await buildWithScopes(['brain:read']);
+      const names = toolNames(server);
+      expect(names).toContain('get_fact');
+      expect(names).toContain('get_fact_provenance');
+      const internals = server as unknown as {
+        _registeredTools: Record<string, { inputSchema?: { shape?: object } }>;
+      };
+      for (const t of ['get_fact', 'get_fact_provenance']) {
+        expect(Object.keys(internals._registeredTools[t]!.inputSchema?.shape ?? {})).toEqual([
+          'factId',
+        ]);
+      }
+    } finally {
+      if (prev === undefined) delete process.env.FACTS_API_ENABLED;
+      else process.env.FACTS_API_ENABLED = prev;
+    }
+  });
+
+  it('get_fact / get_fact_provenance tool names map to read actions in the policy registry', () => {
+    // The ABAC tool gate and the RFC 9396 grant gate both resolve a tool
+    // by NAME through ACTIONS — name-equality with the registry entry IS
+    // the wiring. Both must be read-kind (grant macro 'read' covers them;
+    // any policy over the REST route governs the MCP tool identically).
+    expect(ACTIONS['get_fact']).toMatchObject({ kind: 'read' });
+    expect(ACTIONS['get_fact_provenance']).toMatchObject({ kind: 'read' });
+  });
+
   it('ingest_document exposes the indexers param (REST parity: auto routes packs)', async () => {
     const prev = process.env.DOCUMENT_INGEST_ENABLED;
     process.env.DOCUMENT_INGEST_ENABLED = '1';
@@ -197,7 +238,179 @@ describe('McpService.health — unauthenticated probe payload', () => {
     // exactly what it doesn't have permission to call.
     expect(health.tools).not.toContain('record_fact');
     expect(health.tools).not.toContain('forget_entity');
+    // Flag-gated read tools stay OFF the probe too: HEALTH_TOOLS is the
+    // always-present read baseline, and get_fact / get_fact_provenance
+    // exist only under FACTS_API_ENABLED (default off) — listing them
+    // would make the probe advertise tools a default deployment lacks.
+    expect(health.tools).not.toContain('get_fact');
+    expect(health.tools).not.toContain('get_fact_provenance');
     expect(health.embedder).toBe('openai:text-embedding-3-small (1536d)');
+  });
+});
+
+describe('get_fact / get_fact_provenance — delegation to FactsService', () => {
+  // detect_contradiction-style delegation: the tool is a thin seam over
+  // the SAME service method the REST route calls, forwarding the tenant
+  // pin and the caller's scope set (every visibility fence lives in
+  // FactsService; omitting scopes would skip the row-policy filter).
+  async function buildFactHandlers(factsStub: object): Promise<{
+    handlers: Record<string, (args: Record<string, unknown>) => Promise<unknown>>;
+    scopes: BrainScope[];
+  }> {
+    const handlers: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {};
+    const fakeServer = {
+      registerTool: (
+        name: string,
+        _meta: unknown,
+        cb: (args: Record<string, unknown>) => Promise<unknown>,
+      ) => {
+        handlers[name] = cb;
+      },
+      registerResource: () => ({ remove: () => undefined }),
+    };
+    const scopes: BrainScope[] = ['brain:read'];
+    const { registerReadTools } = await import('../src/mcp/read-tools');
+    registerReadTools({
+      server: fakeServer as never,
+      companyId: 'co_test',
+      scopes,
+      deps: {
+        search: {} as never,
+        entities: {} as never,
+        facts: factsStub as never,
+        multiHop: {} as never,
+        synth: {} as never,
+        memoryDiff: {} as never,
+        predictor: {} as never,
+        summarizer: {} as never,
+        embedderDescription: () => 'stub-embedder',
+      },
+    });
+    return { handlers, scopes };
+  }
+
+  const prevFlag = process.env.FACTS_API_ENABLED;
+  beforeAll(() => {
+    process.env.FACTS_API_ENABLED = '1';
+  });
+  afterAll(() => {
+    if (prevFlag === undefined) delete process.env.FACTS_API_ENABLED;
+    else process.env.FACTS_API_ENABLED = prevFlag;
+  });
+
+  it('get_fact forwards {companyId, factId, scopes} and returns the service result verbatim', async () => {
+    const captured: unknown[] = [];
+    const serviceResult = {
+      factId: 'knowledge_fact:f1',
+      aspect: 'status',
+      statement: 'active',
+      confidence: 0.9,
+      validFrom: '2026-01-01T00:00:00.000Z',
+      retracted: false,
+      groundingStatus: 'grounded',
+    };
+    const { handlers, scopes } = await buildFactHandlers({
+      getFact: async (o: unknown) => {
+        captured.push(o);
+        return serviceResult;
+      },
+    });
+    const out = (await handlers['get_fact']!({ factId: 'f1' })) as {
+      structuredContent: unknown;
+    };
+    expect(captured).toEqual([{ companyId: 'co_test', factId: 'f1', scopes }]);
+    // Passthrough — no field filtering; groundingStatus rides through.
+    expect(out.structuredContent).toEqual(serviceResult);
+  });
+
+  it('get_fact_provenance forwards {companyId, factId, scopes} and passes the shape through', async () => {
+    const captured: unknown[] = [];
+    const serviceResult = {
+      factId: 'knowledge_fact:f1',
+      episodes: [],
+      derivedFacts: [
+        { factId: 'knowledge_fact:f0', predicate: 'status', depth: 1, status: 'active' },
+      ],
+      closure: { depth: 1, factCount: 1, truncated: false, filtered: false },
+    };
+    const { handlers, scopes } = await buildFactHandlers({
+      getProvenance: async (o: unknown) => {
+        captured.push(o);
+        return serviceResult;
+      },
+    });
+    const out = (await handlers['get_fact_provenance']!({ factId: 'f1' })) as {
+      structuredContent: unknown;
+    };
+    expect(captured).toEqual([{ companyId: 'co_test', factId: 'f1', scopes }]);
+    // Passthrough — recursive-closure fields (derivedFacts / closure)
+    // ride the service response untouched as server-side flags land.
+    expect(out.structuredContent).toEqual(serviceResult);
+  });
+});
+
+describe('ingest_document — toolObservationRef plumbing (0111 loop over MCP)', () => {
+  it('passes toolObservationRef through to DocumentIngestService, and omits it when absent', async () => {
+    const prev = process.env.DOCUMENT_INGEST_ENABLED;
+    process.env.DOCUMENT_INGEST_ENABLED = '1';
+    try {
+      const captured: Array<Record<string, unknown>> = [];
+      const handlers: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {};
+      const configs: Record<string, { inputSchema?: Record<string, unknown> }> = {};
+      const fakeServer = {
+        registerTool: (
+          name: string,
+          config: { inputSchema?: Record<string, unknown> },
+          cb: (args: Record<string, unknown>) => Promise<unknown>,
+        ) => {
+          handlers[name] = cb;
+          configs[name] = config;
+        },
+      };
+      const { registerWriteTools } = await import('../src/mcp/write-tools');
+      registerWriteTools({
+        server: fakeServer as never,
+        companyId: 'co_test',
+        scopes: ['brain:read', 'brain:write'],
+        deps: {
+          ingest: {} as never,
+          facts: {} as never,
+          procedural: {} as never,
+          documents: {
+            ingestDocument: async (_companyId: string, dto: Record<string, unknown>) => {
+              captured.push(dto);
+              return { documentId: 'document:d1', outcome: 'INGESTED' };
+            },
+          } as never,
+        },
+      });
+
+      // The MCP input schema advertises the field (the DTO accepted it
+      // all along — the schema was the missing half of the 0111 loop).
+      expect(Object.keys(configs['ingest_document']!.inputSchema ?? {})).toContain(
+        'toolObservationRef',
+      );
+
+      const base = {
+        kind: 'chat',
+        text: 'tool result body',
+        occurredAt: '2026-08-01T00:00:00.000Z',
+        vertical: 'agent',
+      };
+      await handlers['ingest_document']!({
+        ...base,
+        toolObservationRef: 'tool_observation:obs1',
+      });
+      expect(captured[0]!['toolObservationRef']).toBe('tool_observation:obs1');
+
+      await handlers['ingest_document']!(base);
+      // Absent must stay ABSENT (exactOptionalPropertyTypes discipline):
+      // the service treats the key's presence as the 0111 opt-in.
+      expect('toolObservationRef' in captured[1]!).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.DOCUMENT_INGEST_ENABLED;
+      else process.env.DOCUMENT_INGEST_ENABLED = prev;
+    }
   });
 });
 


### PR DESCRIPTION
## Why

An MCP-surface audit found the consumer surface lagging the engine: the fact-level trust story (fact read + provenance, claim grounding) was REST-only, the 0111 tool-observation loop couldn't be closed over MCP, and the stdio connector shim hid brain's resources and silently degraded client-LLM sampling. This PR closes the code gaps (docs/skills follow in a separate PR).

## What

### 1. New read tool `get_fact` (brain:read, behind `FACTS_API_ENABLED`)

`{factId}` → thin delegation to `FactsService.getFact` — the same method behind `GET /v1/facts/:id`, so the two surfaces can never disagree on visibility (tenant pin, user scope, row policy — each an absence, never a 403) and `groundingStatus` rides through when stamped (0115).

**Gating choice, justified:** conditional registration (the `ingest_document` idiom — "agents shouldn't see a tool that answers 503") rather than an always-registered tool that errors when off. The REST gate 404s *"indistinguishable from an absent route"*; the MCP analogue of an absent route is an absent tool — `tools/list` omits it and a blind `tools/call` gets the SDK's standard unknown-tool error. `buildServer` runs per request, so a flag flip applies on the next request, exactly like REST. The e2e pins this parity (flag off → tool vanishes AND the REST twin 404s in the same breath).

**ABAC:** the tool name equals the pre-existing `get_fact` action id in `src/policy/action-registry.ts` (kind `read`, family `mcp_read`) — verified by test — so the ABAC tool gate and the RFC 9396 grant gate govern it with zero policy changes, and any policy over the REST route governs the MCP tool identically.

### 2. New read tool `get_fact_provenance` (brain:read, same gate)

`{factId}` → `FactsService.getProvenance` passthrough, no field filtering: `episodes` today; `derivedFacts` + `closure` ride the service response wherever `PROVENANCE_RECURSIVE_CLOSURE` lands, with zero MCP changes.

**Deviation from the brief, justified:** no `depth?` input. `FactsService.getProvenance` takes `{companyId, factId, scopes}` only — traversal depth is a server-side policy (flag + internal caps), not a service parameter. A dead `depth` schema field would advertise caller control that doesn't exist; when the service grows a depth option, the passthrough gains it in the same change.

### 3. `ingest_document` gains `toolObservationRef?` (≤160 chars)

The DTO accepted it all along (`ingest-document.dto.ts`); the MCP input schema + plumbing were the missing half. Omitted-when-absent (the service treats key presence as the 0111 opt-in). This closes the tool result → document → fact loop over MCP: an agent's tool observation can now be named as the provenance hop behind an ingested document, and every committed fact folds it into `source.evidence[]` as a `tool_observation` entry.

### 4. Connector shim `@inite/brain-mcp` 0.1.0 → 0.2.0 — full-capability passthrough

New `bridge.ts` (split from `index.ts` so tests can import the wiring without executing the CLI):

- **Resources: feasible, implemented.** `resources/list`, `resources/templates/list`, `resources/read` forwarded verbatim; the resources capability is mirrored downstream only when the upstream advertises it (the SDK rejects handlers on undeclared capabilities, so mirror and handler set must agree). `resources/templates/list` is the call that actually makes `brain://entity/{entityId}` (+`/timeline`) discoverable — brain exposes them as resource *templates*.
- **Sampling: feasible, implemented (reverse direction).** The bridge now advertises `sampling` to brain and forwards brain's `sampling/createMessage` requests down to the harness, so `summarize_entity(styleHint='client_llm')` uses the harness's model through the bridge. Caveat, documented in the README: MCP has no capability renegotiation and the upstream connects first, so `sampling` is declared upstream unconditionally; when the harness never advertised sampling the forwarded request fails with a clean MCP error and brain falls back to its local template — byte-identical outcome to pre-0.2.0, minus the silence.
- **No SDK bump needed:** everything used (resource client calls, `Server.createMessage`, `getClientCapabilities`) exists within the pinned `^1.29.0` range (resolves 1.30.0, same as the server repo).
- README "transparent passthrough" claim now enumerates the actual forwarded surface; version 0.2.0.

### 5. `HEALTH_TOOLS` — deliberately NOT extended

Its contract is the *always-present* read baseline for the unauthenticated probe. `get_fact`/`get_fact_provenance` are flag-gated default-off; listing them would make the probe advertise tools a default deployment doesn't have. Pinned by a unit assertion with the reasoning in-line.

## Default-behavior note (deliberate)

With all flags at defaults the surface is byte-identical — the new tools don't register (flag off), `toolObservationRef` is optional-and-absent, and the shim is a separately-versioned client package. The one additive visible change: **under `FACTS_API_ENABLED=1`** (already-opted-in tenants), `tools/list` grows the two read tools. That listing growth is the point of the PR and follows the precedent that grounding inputs on `record_fact` set (additive listing changes are not flag-doubled).

## Tests

- `test/mcp-tools.unit-spec.ts` (+7): registration gating parity both ways, input-schema pin (`factId` only), ACTIONS registry mapping (both kind `read`), delegation capture (`{companyId, factId, scopes}` forwarded; result passthrough verbatim incl. `groundingStatus` / closure fields), `toolObservationRef` present/absent plumbing + schema exposure, HEALTH_TOOLS exclusion pin.
- `test/brain-mcp-bridge.unit-spec.ts` (new, 5): the bridge against a **real MCP client** over the SDK's in-memory linked-pair transport — capability mirror, verbatim tool+resource round-trips, tools-only upstream registers no resource surface, sampling forward (harness with sampling answers brain's request), sampling-less harness gets a clean error.
- `test/mcp-fact-tools.e2e-spec.ts` (new, 6, real SurrealDB): `record_fact` with `evidence[]` under `EVIDENCE_GROUNDING_STAMP=1` → `get_fact` shows `groundingStatus: grounded` and is byte-equal to the REST twin → `get_fact_provenance` passthrough shape → not-found stays the REST-parity error (no raw DB leak) → flag-off vanish + REST 404 in the same instant.

## Verification

- `pnpm typecheck` (tsconfig.spec.json, src + test + the imported shim sources) — clean
- `pnpm lint:ci` — clean (0 warnings)
- unit: full suite **3219/3219** green (includes the 12 new/extended MCP assertions)
- e2e (targeted, real SurrealDB): `mcp-health` + `pack-mcp-tools` + `mcp-fact-tools` — **17/17**
- shim: `tsc -p clients/brain-mcp/tsconfig.json --noEmit` clean
- `prettier` clean on touched `src/**` + `test/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
