### PR TITLE
docs(roadmap): brain v2.1 wave + multi-vector design

### DIFF
--- a/docs/roadmap/brain-v21-2026-08.md
+++ b/docs/roadmap/brain-v21-2026-08.md
@@ -1,0 +1,165 @@
+# Brain v2.1 — the multimodal Evidence Plane wave (2026-08)
+
+Companion to [brain-v2-2026-08.md](brain-v2-2026-08.md) (the three-plane program this
+extends), [multi-vector-2026-08.md](multi-vector-2026-08.md) (the retrieval design cut
+from this wave), and [privacy-user-fence-2026-08.md](privacy-user-fence-2026-08.md) (the
+drift-2 operator runbook). The thesis: **v2 built the three-plane skeleton for text; v2.1
+extends the Evidence plane beyond text, closes the audited integrity drifts, gives the
+Semantic plane a first-class belief substrate, and refreshes the MCP consumer surface —
+everything default-off and byte-identical when off, measurement still parked.**
+
+## 1. Three-plane recap, one wave later
+
+| Plane        | v2 state (see brain-v2 §1)                                     | What v2.1 adds                                                                                                                                   |
+| ------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Evidence** | Text turns + positional windows (`episode`, `episode_segment`) | Non-text observations: `evidence_asset` / `evidence_fragment` / `derived_representation` (0109), tool observations (0111), blob GC outbox (0114) |
+| **Episodic** | `memory_episode` scenes (0106) + enrichment                    | Fingerprinted reconstruction versions, enrichment as an immutable revision (0118), mixed-user scope fencing (0117)                               |
+| **Semantic** | Facts/summaries/graph; "SemanticBelief stays facts-shaped"     | Grounding status on claims (0115), typed support graph (0116, in flight), the Belief track's `semantic_belief` table (~0120, queued)             |
+
+The serving doctrine is unchanged: L0–L3 are resolution levels, foveation chooses the
+level per query, and every claim must unroll to an observation. v2.1's addition to the
+doctrine: **a caption is an index into an observation, never a replacement for it** — and
+claims that require visual/audio evidence can no longer verify on text alone
+(`resolveEvidenceCapability`, `src/synthesize/answer-integrity.ts:213`).
+
+## 2. Shipped (merged to main, chronological)
+
+| PR   | Migration | What                                                                                                                                                               |
+| ---- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| #381 | —         | `memoryModel` manifest section — packs declare HOW their domain perceives memory (scenes, states, attention, verification, retention); contract-first, no consumer |
+| #382 | 0109      | Multimodal evidence substrate: assets / fragments / derived representations, fs:// storage adapter, GDPR + retention legs; bytes never in the DB                   |
+| #383 | 0113      | Evidence-capability verdict gate (`evidence_capability_unmet` abstain) + modality dimensions on outcome telemetry                                                  |
+| #380 | 0112      | Media/biometric consent tier: `brain:read_media` scope (env-key only), pack modality consent checksum, fail-closed media PII gate (`src/common/media-pii.ts:52`)   |
+| #385 | 0111      | Tool observations — content-free digest anchors for tool calls; ingest can cite `tool_observation` as a provenance hop in `source.evidence[]`                      |
+| #390 | —         | Red-main unblock: 30-min build-test timeout, modality-only `memoryModel` acceptance, pack-install OCC retry                                                        |
+| #384 | 0108      | GDPR cascade through source documents / chunks / candidates / indexer runs — closes the erasure gap the forget e2es never seeded                                   |
+| #392 | 0114      | Port of the sibling-session multimodal contract: typed `modalities`/`processors`/`rawEvidence` manifest fields, blob-GC outbox, lifecycle hardening                |
+| #388 | 0115      | Drift-1: `groundingStatus` on claims (`src/common/grounding-status.ts:26`) — fail-closed capture, promotion + strict-serving gates                                 |
+| #387 | 0117      | Drift-2: mixed-user derived rows carry `userIds` and fail closed behind the `PRIVACY_` fence; backfill endpoint                                                    |
+| #386 | 0118      | Drift-3/3b/4: config-fingerprinted segmenter versions (`src/admin/scene-version.ts:62`), enrichment as immutable revision, exact-match swap delete                 |
+| #393 | —         | MCP surface refresh: `get_fact` / `get_fact_provenance` tools, `toolObservationRef` on `ingest_document`, connector shim 0.2.0 (resources + sampling passthrough)  |
+
+The wave's one incident: main went red mid-wave (build-test exceeding the old CI timeout,
+plus #381's validator rejecting the modality-only manifests the consent tier installs, plus
+a pack-install OCC flake) — #390 is the fix and the reason it gets a table row.
+
+## 3. In flight
+
+| PR / branch                          | Migration | What                                                                                                      |
+| ------------------------------------ | --------- | --------------------------------------------------------------------------------------------------------- |
+| #389 `feat/provenance-support-edges` | 0116      | Drift-5: typed `memory_support` edges (supported_by / contradicted_by / derived_from) + closure-walk read |
+| #391 `feat/decision-telemetry`       | 0119      | Drift-6: transactional idempotent outcome writes + `memory_decision` context capture + MRI latency axis   |
+| `feat/pack-memory-projections`       | 0110      | Batch-2 P2 — pack scene/state_delta candidates (§6)                                                       |
+| `feat/attention-hints`               | —         | Batch-2 P4 — ordering-only attention hints (§6)                                                           |
+| `feat/evidence-metadata-ingest`      | —         | Batch-2 M-PR-C — metadata-only evidence ingest endpoint (§6)                                              |
+| `feat/evidence-processing-lifecycle` | ~0121     | MM-1 + MM-5 + MM-6 in one PR (§4)                                                                         |
+| `feat/evidence-grants`               | ~0122     | MM-4 asset/ownership split (§4)                                                                           |
+| `feat/fragment-lane`                 | ~0124     | MM-2 PR2 (§4)                                                                                             |
+
+Migration numbers marked `~` are reservations under the wave's numbering convention
+(numeric order, gaps tolerated, header notes name the siblings).
+
+## 4. The MM tracks — multimodal program
+
+**MM-1 — Trusted processor broker.** Packs may only _declare_ processing capability
+requests (`memoryModel.processors`: id, modality, produces — typed since #392; no code,
+model, prompt, or endpoint ever rides a manifest,
+`src/ai/domain-packs/validate-memory-model.ts`); the platform executes ASR/OCR/vision
+through a `ProcessorAdapter` registry, the same trust shape as the storage adapter
+registry. Builds `processing_run` (~0121) so every derived representation names the run
+that produced it. In flight on `feat/evidence-processing-lifecycle`.
+
+**MM-2 — M-track retrieval: fragment lane → fragment citations → verifier zoom.** Three
+staged PRs. First a retrieval lane over derived text representations (fragments become
+candidates, the text-proxy option A of the multi-vector doc). Then fragment-level
+citations: `citedCapabilities()` (`src/synthesize/answer-integrity.ts:257`) stops being
+the constant `{'text'}` and the #383 verdict gate gets real inputs, so visual-evidence
+claims can _pass_, not only abstain. Then verifier-controlled zoom — the verifier may
+request a deeper read of a cited fragment before ruling. Scene↔evidence links ride
+`memory_support` kind `reconstructed_from`, the enum slot #389 reserves with no writer.
+PR2 in flight on `feat/fragment-lane` (~0124).
+
+**MM-3 — Single raw-read gateway.** Exactly one controller ever serves raw evidence
+bytes, behind a fixed gate ladder: tenant → grant → ABAC → modality consent
+(`gateRawEvidence`, `src/mcp/raw-evidence-gate.ts:33`, gaining its first production call
+site) → media PII (`mediaPiiGate`) → stream-or-signed-URL. Every read lands in an
+`evidence_access` audit table (~0123). Queued behind MM-4 — serving bytes before ownership
+is settled would harden the wrong model.
+
+**MM-4 — Asset/ownership split.** An `evidence_grant` table (~0122) separates
+content-addressed immutable assets from per-owner grants: the same bytes may be granted to
+many owners, and GDPR deletes content only when zero live grants remain. This replaces the
+v1 stopgap posture (#382's bare 409 on a foreign dedup probe, asset dies with its one
+user) with real multi-owner semantics. In flight on `feat/evidence-grants`.
+
+**MM-5 — Idempotent processing runs + version lineage.** Deterministic run ids + INSERT
+IGNORE (the #391 outcome-tx idiom) make processor re-runs replay-safe, and
+`producedByRun` / `supersededBy` on `derived_representation` turn representation history
+into an auditable lineage instead of delete-by-version-and-reinsert being the only record.
+Rides MM-1's PR.
+
+**MM-6 — External-ingest safety seams.** `quarantineStatus` lifecycle on assets, a
+`ScanHook` stub, size caps, and storage-adapter extension points for KMS and signed URLs —
+the seams that real scanners, S3, and KMS plug into later without touching row shapes. The
+real integrations are §7 not-yet items. Rides MM-1's PR.
+
+## 5. The Belief track
+
+Two PRs, queued behind #389 (the support edges are its provenance substrate). The v2
+decision "SemanticBelief stays facts-shaped" (brain-v2 §4) expires: consolidation needs a
+place to put _what the tenant currently believes_ that is not one more summary fact.
+
+**PR1 — `semantic_belief` (~0120).** Bitemporal vocabulary (valid-time vs recorded-time)
+plus an explicit revision chain: a belief is never edited in place — a new revision
+supersedes the old, so "what did we believe on date X" stays answerable forever.
+
+**PR2 — scene→belief promotion (`SCENES_BELIEF_PROMOTION`).** Folds enriched scenes of
+the current fingerprinted segmenter version (#386's effective-version machinery) into
+beliefs, with a corroboration floor (`SCENES_BELIEF_MIN_SCENES` — distinct scenes, the
+#377 promotion-floor precedent), a conflict guard (contested folds abort loudly, never
+average), and optional LLM synthesis behind `SCENES_BELIEF_LLM_SYNTHESIS`. Consumed scenes
+get `consolidatedInto` + a `baselineRef` (`{belief, revision, value, stampedAt}`) so a
+scene knows which belief absorbed it and at which revision. Belief provenance rides
+`memory_support` `derived_from` / `contradicted_by` edges. Read API `GET /v1/beliefs/:id`
+behind `BELIEFS_API_ENABLED`. Serving lanes are deliberately deferred to MM-2 consumption
+— a belief that cannot cite fragments would be one more ungrounded summary.
+
+## 6. Batch-2 items
+
+- **P2 — pack memory projections** (`feat/pack-memory-projections`, migration 0110 — the
+  long-reserved number finally lands): candidate kinds gain `scene` and `state_delta`, the
+  candidate redaction path is rewritten default-deny, and a `SceneCandidateWriterService`
+  writes _shadow_ scenes under a `pack:<packId>+<fp>` namespace — pack worlds coexist with
+  core worlds via the #386 fingerprint idiom and stay candidates, never truth (#381's
+  law). Behind `PACK_MEMORY_PROJECTIONS_ENABLED`.
+- **P4 — attention hints** (`feat/attention-hints`): `FOVEA_ATTENTION_HINTS` turns pack
+  `attentionHints` into an ordering-only `hintBoost` inside anchor-source merging —
+  reorder, never admit or exclude, so a hint can waste attention but cannot smuggle a row
+  past a fence.
+- **M-PR-C — metadata evidence ingest** (`feat/evidence-metadata-ingest`):
+  `POST /v1/ingest/evidence-asset` behind `EVIDENCE_INGEST_ENABLED` (the flag #382
+  reserved in comments) — metadata-only registration, `byteHash` required, no raw bytes on
+  this endpoint. Uploading bytes remains the storage adapter's private business.
+- **PR-D — this doc pair** (the v2.1 roadmap + the multi-vector design).
+
+## 7. Deliberately NOT in v2.1
+
+| Item                         | Why deferred                                                                                                                                    |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Real ASR/OCR/vision adapters | MM-1 ships the broker with no production adapter; interpretation quality is a measurement question and the paid-eval program is parked          |
+| S3/KMS storage adapter       | `fs://` is the only registered scheme; the adapter contract (`belongsToTenant`, put/head/delete) is the extension point — a new scheme, no rows |
+| Malware scanning             | MM-6 ships `ScanHook` as a stub; a real scanner is an ops dependency, not a code seam                                                           |
+| MCP raw-read tool            | `gateRawEvidence` exists (#380) and MM-3 gives it a REST caller; exposing raw bytes over MCP waits until the gateway has proven the gate ladder |
+| RL / learned meta-controller | Unchanged from v2 §4 — deterministic policies first; #391's decision capture is the training data being collected                               |
+| Neural Field layer           | Unchanged from v2 §4 — research layer, not a product dependency                                                                                 |
+| Genre-preset default flip    | #295's measured defaults per `RETRIEVAL_GENRE` stay opt-in; default flips require strict-currency confirmation once the eval budget returns     |
+
+## 8. Measurement posture
+
+Identical to v2 §5: nothing in this wave flips a default or claims a quality number. What
+the wave buys for free is structural — erasure that actually cascades (0108), scope fences
+on derived rows (0117), claims that carry their grounding (0115), scenes whose versions
+tell the truth about their config (0118), and a consumer surface (#393) that exposes the
+trust story end-to-end. When the paid-eval budget returns, the fragment lane, belief
+promotion, and attention hints are measured like every other lever: strict-currency,
+ablation-mined, confirmed on the full pack before any default flip.

--- a/docs/roadmap/multi-vector-2026-08.md
+++ b/docs/roadmap/multi-vector-2026-08.md
@@ -1,0 +1,132 @@
+# Multi-vector memory — per-modality embedding spaces (2026-08)
+
+Design for the retrieval half of the multimodal Evidence Plane: how non-text observations
+get dense representations, which embedding spaces those live in, what it costs, and why
+this is **deliberately a design doc and not a build** (§6). Companion to
+[brain-v21-2026-08.md](brain-v21-2026-08.md) (the v2.1 wave this belongs to) and
+[multilingual-2026-08.md](multilingual-2026-08.md) (whose Tier 2 built the space machinery
+this design reuses wholesale). The one-line thesis: **a modality is just another embedding
+space, and 0101 already knows how to name, stamp, fence, and migrate spaces — so
+multi-vector memory is a registry and a lane, not a substrate.**
+
+## 1. What already exists (each verified on main)
+
+| Piece                                                                                     | Where                                                                       | What it gives this design                                                       |
+| ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Canonical space id `provider:model:dim:norm`                                              | `src/ai/embedder/embedding-space.ts:54`                                     | One naming scheme for every space, text or not                                  |
+| `spacesCompatible` / `describeSpaceIncompatibility`                                       | `src/ai/embedder/embedding-space.ts:107`                                    | A guard that refuses cross-space compares instead of silently scoring noise     |
+| Per-row `embeddingSpaceId` on all embedding-bearing tables + per-tenant cutover state     | `src/db/migrations/0101_embedding_space.surql` (state table at `:88`)       | Row-level space provenance; dual-write + atomic cutover protocol                |
+| `EMBEDDING_TABLES` inventory                                                              | `src/ai/embedder/embedding-space.ts:143`                                    | The single list the reindex sweep walks                                         |
+| `EmbedderService.activeSpaceId()` (+ the `FactEmbeddingService` facade)                   | `src/ai/embedder.service.ts:279`, `src/ingest/fact-embedding.service.ts:30` | The active-space resolver every writer already consults                         |
+| `derived_representation` with `kind='embedding'`, `embeddingSpaceId`, and a vector column | `src/db/migrations/0109_evidence_substrate.surql:175,181,186`               | The storage seat — reserved in 0109 precisely so this design needs no migration |
+| The dense-leg read shape (`vector::distance::knn()` projection)                           | `src/search/internals/legs.ts:142`                                          | The KNN idiom any new lane copies verbatim                                      |
+
+Two spaces ship today, both text: `openai:text-embedding-3-small:1536:l2` and
+`bge-m3:Xenova/bge-m3:1024:l2`. A tenant is wholly in one space at query time — never
+mixed — and the 0109 `embedding` column on `derived_representation` is **write-dead**: the
+migration comment names this doc as the unlock.
+
+## 2. The design: one space per modality, fenced by 0101
+
+The single-active-space assumption relaxes to a per-tenant **modality map**
+(`modality → embeddingSpaceId`, modalities from `EVIDENCE_MODALITIES`,
+`src/common/evidence-taxonomy.ts:8`). Nothing else changes shape:
+
+- **Naming.** A CLIP-class image space is just a new canonical id (e.g.
+  `clip:ViT-L-14:768:l2`); an audio-embedding space likewise. No new descriptor format.
+- **State.** `embedding_space_state` today models one `activeSpace` plus one migration
+  `targetSpace` (0101). The modality map extends that row with additive `option<>` fields —
+  the same table, the same dual-write/cut-over protocol per modality.
+- **Storage.** Non-text vectors live in `derived_representation` rows (`kind='embedding'`,
+  `subjectKind` asset|fragment), each stamped with its space. Heterogeneous dims coexist in
+  one table because every compare is fenced by `spacesCompatible` — a wrong-space candidate
+  is dropped, never scored.
+- **Retrieval.** One dense leg per targeted modality: the query embeds through that space's
+  query tower, the leg runs the standard KNN projection, and legs fuse by RRF exactly like
+  today's lanes. The retrieval profile decides the fan-out per query class — no new config
+  surface.
+- **Versioning.** A representation producer re-run deletes its own `producerVersion` rows
+  and reinserts (the 0106 segmenter idiom, already in 0109); scene fingerprints already
+  embed the active space id into effective versions (`src/admin/scene-version.ts:62`), so a
+  space flip forces re-derivation instead of silently mixing worlds.
+
+Three candidate architectures, ranked:
+
+| Option                    | Shape                                                                                | Verdict                     |
+| ------------------------- | ------------------------------------------------------------------------------------ | --------------------------- |
+| **A. Text-proxy**         | Captions / OCR / ASR text embedded in the EXISTING text space — zero new spaces      | **v1 — the bar to beat**    |
+| **B. Joint dual-encoder** | CLIP-class shared space per modality pair; text queries embed through the text tower | v2 candidate, measured vs A |
+| **C. Late interaction**   | N token/patch vectors per fragment + MaxSim                                          | Parked (§4)                 |
+
+## 3. Why option A is the bar
+
+The substrate already produces text derived representations (`caption`/`ocr`/`asr` kinds,
+0109), and embedding them rides the entire existing dense stack: same embedder, same
+space, same reindex sweep, same HNSW legs, zero new query cost — it is just more text.
+Our lever history also says selection, not representation, dominates misses (the ablation
+mining in the research program), so the class option B uniquely fixes — queries where the
+text proxy is _lossy_ ("what color was the chart", speaker identity from voice) — is real
+but unmeasured. Doctrine: **A ships with the fragment retrieval lane (MM-2); B is built
+only when a paid eval shows the proxy-lossy class matters in a consumer workload.**
+
+## 4. Late interaction (option C) — recorded and parked
+
+What it buys: sub-fragment precision — MaxSim over token/patch vectors finds the sentence
+inside a page or the region inside a frame without pre-cutting finer fragments. Why it is
+parked:
+
+- **Storage shape.** N vectors per row does not fit `option<array<float>>`; it needs
+  per-vector rows or nested arrays plus custom scoring — and SurrealDB has no native
+  MaxSim, so scoring runs TS-side over candidate sets, the exact full-scan class the
+  `vector::distance::knn()` idiom exists to avoid.
+- **Index cost.** HNSW entries multiply by the per-fragment vector count (32–128×); the
+  cost model (§5) puts a 100k-fragment tenant at tens of GB of vectors alone.
+- **Cheaper substitute.** Fragments are already locators (charRange / pageRegion /
+  timeRange) — cutting finer fragments where precision matters buys most of the win inside
+  the single-vector model.
+
+Bar to revisit: a live fragment lane whose pooled vectors measurably fail on
+span-precision questions.
+
+## 5. Cost model (estimates, f64 array storage)
+
+| Configuration                                      | Per-fragment vector payload  | 100k fragments | Query-side delta                       |
+| -------------------------------------------------- | ---------------------------- | -------------- | -------------------------------------- |
+| A. Text-proxy (reuses text space, 1536-dim)        | ~12 KB (rides existing rows) | ~1.2 GB        | none (existing lanes)                  |
+| B. One joint space, 768-dim, 1 vector/fragment     | ~6 KB                        | ~0.6 GB        | +1 embed + 1 KNN leg per modality      |
+| C. Late interaction, 768-dim × 64 vectors/fragment | ~0.4 MB                      | ~40 GB         | +1 embed + candidate fetch + TS MaxSim |
+
+Production cost: option A rides the embed budget already paid for facts and segments;
+option B needs a self-hosted tower (the bge-m3 ONNX worker precedent) or a paid API call
+per asset; option C multiplies B's production cost by the vector count. Index memory adds
+one HNSW index per (table, space) — linear in rows, dominated by the vector payload above.
+GDPR is free everywhere: vectors ride `derived_representation` rows, which already die in
+the evidence cascade.
+
+## 6. Why NOT built yet
+
+1. **No producer.** No real ASR/OCR/vision adapter exists — MM-1 ships the broker seam,
+   and real adapters are on the v2.1 not-yet list. An image space with nothing embedded is
+   dead weight.
+2. **No consumer.** No serving path reads the 0109 tables (the substrate's pinned shadow
+   guarantee); the fragment lane is MM-2, in flight. A lane-less space cannot even be
+   mis-measured.
+3. **Measurement is parked.** The paid-eval program is frozen, and §3's A-vs-B question is
+   precisely a measurement question. Building B before it can be scored strict-currency
+   would violate the house rule that levers are measured before they earn defaults.
+4. **Multi-active-space state is a small but real build.** Extending
+   `embedding_space_state` to a modality map touches the cutover protocol; not worth
+   landing ahead of the first non-text space that would use it.
+5. **The reserved seat is the plan working as intended.** 0109 pre-paid the schema
+   (`embedding` + `embeddingSpaceId` on `derived_representation`) so that when this design
+   builds, it is flags + a registry entry — no migration, no backfill.
+
+## 7. Build shape when it lands
+
+A `MULTI_VECTOR_`-free build: the registry rides the existing `EMBEDDING_` family
+(`EMBEDDING_MODALITY_SPACES` naming the map, default off), the lane rides MM-2's fragment
+lane flag, and `EMBEDDING_TABLES` gains a `derived_representation` entry only if a plain
+re-embed producer exists — modality vectors otherwise re-derive through their own producer,
+the `community_node` precedent already documented at
+`src/ai/embedder/embedding-space.ts:137`. Serving guards reuse `spacesCompatible`
+verbatim; the migration count is zero.


### PR DESCRIPTION
## Summary

PR-D of the batch-2 wave — two roadmap docs, no code changes.

### `docs/roadmap/brain-v21-2026-08.md` — the v2.1 wave roadmap

- **Three-plane recap** one wave later: what v2.1 added to the Evidence / Episodic / Semantic planes on top of `docs/roadmap/brain-v2-2026-08.md`, plus the wave's doctrine addition ("a caption is an index into an observation, never a replacement for it").
- **Shipped table** (chronological): #381 memoryModel manifest, #382 evidence substrate (0109), #383 evidence-capability gate + outcome modality dims (0113), #380 consent tier (0112), #385 tool observations (0111), #390 red-main unblock, #384 GDPR document cascade (0108), #392 multimodal contract port + blob GC (0114), #388 grounding status (0115), #387 mixed-user fence (0117), #386 scene version fingerprints (0118), #393 MCP surface refresh.
- **In-flight table**: #389 (0116), #391 (0119), and the batch-2 / MM-track branches with their reserved migration numbers.
- **MM-1..MM-6 track summaries**: trusted processor broker, M-track retrieval (fragment lane → citations → verifier zoom), single raw-read gateway, asset/ownership split, idempotent processing runs + lineage, external-ingest safety seams.
- **Belief track**: `semantic_belief` (~0120, bitemporal + revision chain) and `SCENES_BELIEF_PROMOTION` with corroboration floor / conflict guard / baselineRef stamping; serving deferred to MM-2.
- **Batch-2 items** (P2 pack projections 0110, P4 attention hints, M-PR-C metadata ingest, PR-D itself) and an **explicit not-yet list** (real ASR/OCR/vision adapters, S3/KMS, malware scanning, MCP raw-read tool, RL controller, Neural Field, the #295 genre-preset default flip).

### `docs/roadmap/multi-vector-2026-08.md` — per-modality embedding spaces design

- Reuses the 0101 `embeddingSpaceId` machinery wholesale (canonical `provider:model:dim:norm` ids, `spacesCompatible` fencing, per-tenant `embedding_space_state`); the design is "a registry and a lane, not a substrate".
- Ranks three architectures: text-proxy (v1, the bar to beat), joint dual-encoder (CLIP-class, measured against the proxy), late interaction (recorded and parked with the storage/index/MaxSim cost argument).
- Cost model with storage/query estimates per option, and the honest **why-not-built-yet list**: no producer, no consumer lane until MM-2, paid-eval program parked, and the 0109 write-dead `embedding` column deliberately pre-paid the schema so the eventual build needs zero migrations.

## Verification

- `prettier --check` clean on both new files (repo `format:check` scopes to `src`/`test` TS only, so the docs were checked directly).
- Every `file.ts:line` reference verified against origin/main before writing (embedding-space.ts:54/107/143, embedder.service.ts:279, fact-embedding.service.ts:30, 0101/0109 migration lines, legs.ts:142, scene-version.ts:62, answer-integrity.ts:213/257, raw-evidence-gate.ts:33, media-pii.ts:52, evidence-taxonomy.ts:8, grounding-status.ts:26).
- `git diff --stat`: 2 files, docs only — no code, no config, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
