### PR TITLE
feat(evidence): metadata-only evidence asset ingest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -720,8 +720,11 @@ PRIVACY_COMPOSER_USER_SCOPE=1
 # gateway (0125). Orderings: stamp (EVIDENCE_GROUNDING_STAMP) before the
 # ungrounded gates; enable EVIDENCE_QUARANTINE before any external media
 # ingest (off = external origin rejected outright); the raw-read gateway
-# needs EVIDENCE_SIGNED_URL_SECRET (≥32 chars) to mint signed URLs.
+# needs EVIDENCE_SIGNED_URL_SECRET (≥32 chars) to mint signed URLs; the
+# metadata-only ingest route (EVIDENCE_INGEST_ENABLED, off = bare 404)
+# also needs EVIDENCE_SUBSTRATE_ENABLED or every call answers 503.
 #EVIDENCE_SUBSTRATE_ENABLED=0
+#EVIDENCE_INGEST_ENABLED=0
 #EVIDENCE_FS_ROOT=
 #EVIDENCE_MAX_BYTES=1073741824
 #EVIDENCE_PROCESSOR_BROKER=0

--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -71,6 +71,16 @@
         },
         "description": "No such resource in this tenant."
       },
+      "SubstrateDisabled": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "The evidence write seam is off (EVIDENCE_SUBSTRATE_ENABLED) — the route exists but every write is refused. Boot-time env-validation warns about this inconsistent flag pair."
+      },
       "TooManyRequests": {
         "content": {
           "application/json": {
@@ -910,6 +920,157 @@
         ],
         "type": "object"
       },
+      "EvidenceFragmentLocator": {
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "end": {
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991,
+                "type": "integer"
+              },
+              "kind": {
+                "const": "charRange",
+                "type": "string"
+              },
+              "start": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "kind",
+              "start",
+              "end"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "h": {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              "kind": {
+                "const": "pageRegion",
+                "type": "string"
+              },
+              "page": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "w": {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              "x": {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              "y": {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "kind",
+              "page",
+              "x",
+              "y",
+              "w",
+              "h"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "endMs": {
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991,
+                "type": "integer"
+              },
+              "kind": {
+                "const": "timeRange",
+                "type": "string"
+              },
+              "startMs": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "kind",
+              "startMs",
+              "endMs"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "endFrame": {
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991,
+                "type": "integer"
+              },
+              "kind": {
+                "const": "frameRange",
+                "type": "string"
+              },
+              "startFrame": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "kind",
+              "startFrame",
+              "endFrame"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "endMs": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "kind": {
+                "const": "track",
+                "type": "string"
+              },
+              "startMs": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "trackId": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "trackId"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "EvidenceRawUrlResponse": {
         "additionalProperties": false,
         "properties": {
@@ -1541,6 +1702,209 @@
           "runs",
           "committed",
           "counts"
+        ],
+        "type": "object"
+      },
+      "IngestEvidenceAssetRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "byteHash": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "byteLength": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "durationMs": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "fragments": {
+            "items": {
+              "$ref": "#/components/schemas/IngestEvidenceFragment"
+            },
+            "maxItems": 64,
+            "type": "array"
+          },
+          "height": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "mediaType": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "meta": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "modality": {
+            "enum": [
+              "image",
+              "audio",
+              "video",
+              "document",
+              "sensor"
+            ],
+            "type": "string"
+          },
+          "occurredAt": {
+            "type": "string"
+          },
+          "originUri": {
+            "maxLength": 2048,
+            "minLength": 1,
+            "type": "string"
+          },
+          "pageCount": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "piiClasses": {
+            "items": {
+              "enum": [
+                "face",
+                "voice",
+                "biometric",
+                "id_document",
+                "sensitive"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "recorder": {
+            "maxLength": 200,
+            "type": "string"
+          },
+          "retainUntil": {
+            "type": "string"
+          },
+          "scope": {
+            "items": {
+              "maxLength": 200,
+              "type": "string"
+            },
+            "maxItems": 32,
+            "type": "array"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          },
+          "vertical": {
+            "maxLength": 200,
+            "minLength": 1,
+            "type": "string"
+          },
+          "width": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "modality",
+          "mediaType",
+          "byteHash",
+          "byteLength",
+          "occurredAt",
+          "originUri",
+          "vertical"
+        ],
+        "type": "object"
+      },
+      "IngestEvidenceAssetResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "assetId": {
+            "type": "string"
+          },
+          "availability": {
+            "enum": [
+              "hot",
+              "cold",
+              "external",
+              "gone"
+            ],
+            "type": "string"
+          },
+          "deduped": {
+            "type": "boolean"
+          },
+          "fragments": {
+            "items": {
+              "$ref": "#/components/schemas/IngestEvidenceFragmentResult"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "assetId",
+          "availability",
+          "deduped",
+          "fragments"
+        ],
+        "type": "object"
+      },
+      "IngestEvidenceFragment": {
+        "additionalProperties": false,
+        "properties": {
+          "excerpt": {
+            "maxLength": 4000,
+            "minLength": 1,
+            "type": "string"
+          },
+          "label": {
+            "maxLength": 200,
+            "type": "string"
+          },
+          "lang": {
+            "maxLength": 35,
+            "type": "string"
+          },
+          "locator": {
+            "$ref": "#/components/schemas/EvidenceFragmentLocator"
+          },
+          "piiClasses": {
+            "items": {
+              "enum": [
+                "face",
+                "voice",
+                "biometric",
+                "id_document",
+                "sensitive"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "locator"
+        ],
+        "type": "object"
+      },
+      "IngestEvidenceFragmentResult": {
+        "additionalProperties": false,
+        "properties": {
+          "fragmentId": {
+            "type": "string"
+          },
+          "representationId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "fragmentId"
         ],
         "type": "object"
       },
@@ -5030,6 +5394,56 @@
         ]
       }
     },
+    "/v1/ingest/evidence-asset": {
+      "post": {
+        "description": "Registers one multimodal evidence asset header (image / audio / video / document / sensor) plus optional citation-target fragments — WITHOUT transferring bytes. The surface is metadata-only by design (the MM-6 quarantine boundary): `originUri` (a caller-owned location the brain never fetches) is required, `storageRef` is rejected (400), and no upload is accepted, so a fresh registration is always availability `external`. `byteHash` (sha256 of the original bytes) is REQUIRED — the UNIQUE asset identity (migration 0109): same-user re-registration dedupes to the existing asset (`deduped: true`, requested fragments still appended); a different principal hitting a known hash gets a bare 409 without the stored row’s metadata. Fragment locators are validated against the kind→modality matrix BEFORE any row is written — one bad locator fails the whole request. A fragment `excerpt` lands as a caller-asserted `derived_representation` of kind `text` (producerVersion `ingest-excerpt-v1`). Answers a bare 404 until `EVIDENCE_INGEST_ENABLED=1`; answers 503 while `EVIDENCE_SUBSTRATE_ENABLED` is off. Source: src/evidence/evidence-ingest.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "ingestEvidenceAsset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngestEvidenceAssetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestEvidenceAssetResponse"
+                }
+              }
+            },
+            "description": "Registered (or same-user deduped) asset + created fragments."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "503": {
+            "$ref": "#/components/responses/SubstrateDisabled"
+          }
+        },
+        "summary": "Register a multimodal evidence asset (metadata-only)",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
     "/v1/projections": {
       "get": {
         "description": "Every derived world (facts@version, …) with its lifecycle status (building/built/live/residual/failed), watermark, builder identity and stats, plus the process-local read pin (RETRIEVAL_DERIVED_VERSION). A registry row promises a queryable world. 404 until PROJECTIONS_API_ENABLED=1. Source: src/admin/projections.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -5573,7 +5987,7 @@
       "name": "Beliefs"
     },
     {
-      "description": "The raw-evidence read gateway: original observation bytes back out — direct stream, signed short-lived URLs, fragment twins — behind the full deny-overrides gate ladder (scope, ABAC, tenant/availability/quarantine, ownership grants, pack modality consent, media-PII polarity), every attempt audited content-free. Flag: EVIDENCE_RAW_READ_ENABLED (off → 404).",
+      "description": "The multimodal evidence substrate, both directions. IN: the metadata-only ingest surface — register asset headers + citation-target fragments (originUri required, storageRef rejected, no bytes — the MM-6 boundary); flags EVIDENCE_INGEST_ENABLED (off → 404) and EVIDENCE_SUBSTRATE_ENABLED (off → 503). OUT: the raw-evidence read gateway — original observation bytes back out via direct stream, signed short-lived URLs, fragment twins — behind the full deny-overrides gate ladder (scope, ABAC, tenant/availability/quarantine, ownership grants, pack modality consent, media-PII polarity), every attempt audited content-free; flag EVIDENCE_RAW_READ_ENABLED (off → 404).",
       "name": "Evidence"
     },
     {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -71,6 +71,16 @@
         },
         "description": "No such resource in this tenant."
       },
+      "SubstrateDisabled": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "The evidence write seam is off (EVIDENCE_SUBSTRATE_ENABLED) — the route exists but every write is refused. Boot-time env-validation warns about this inconsistent flag pair."
+      },
       "TooManyRequests": {
         "content": {
           "application/json": {
@@ -910,6 +920,157 @@
         ],
         "type": "object"
       },
+      "EvidenceFragmentLocator": {
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "end": {
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991,
+                "type": "integer"
+              },
+              "kind": {
+                "const": "charRange",
+                "type": "string"
+              },
+              "start": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "kind",
+              "start",
+              "end"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "h": {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              "kind": {
+                "const": "pageRegion",
+                "type": "string"
+              },
+              "page": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "w": {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              "x": {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              "y": {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "kind",
+              "page",
+              "x",
+              "y",
+              "w",
+              "h"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "endMs": {
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991,
+                "type": "integer"
+              },
+              "kind": {
+                "const": "timeRange",
+                "type": "string"
+              },
+              "startMs": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "kind",
+              "startMs",
+              "endMs"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "endFrame": {
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991,
+                "type": "integer"
+              },
+              "kind": {
+                "const": "frameRange",
+                "type": "string"
+              },
+              "startFrame": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "kind",
+              "startFrame",
+              "endFrame"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "endMs": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "kind": {
+                "const": "track",
+                "type": "string"
+              },
+              "startMs": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "trackId": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "trackId"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "EvidenceRawUrlResponse": {
         "additionalProperties": false,
         "properties": {
@@ -1541,6 +1702,209 @@
           "runs",
           "committed",
           "counts"
+        ],
+        "type": "object"
+      },
+      "IngestEvidenceAssetRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "byteHash": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "byteLength": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "durationMs": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "fragments": {
+            "items": {
+              "$ref": "#/components/schemas/IngestEvidenceFragment"
+            },
+            "maxItems": 64,
+            "type": "array"
+          },
+          "height": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "mediaType": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "meta": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "modality": {
+            "enum": [
+              "image",
+              "audio",
+              "video",
+              "document",
+              "sensor"
+            ],
+            "type": "string"
+          },
+          "occurredAt": {
+            "type": "string"
+          },
+          "originUri": {
+            "maxLength": 2048,
+            "minLength": 1,
+            "type": "string"
+          },
+          "pageCount": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "piiClasses": {
+            "items": {
+              "enum": [
+                "face",
+                "voice",
+                "biometric",
+                "id_document",
+                "sensitive"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "recorder": {
+            "maxLength": 200,
+            "type": "string"
+          },
+          "retainUntil": {
+            "type": "string"
+          },
+          "scope": {
+            "items": {
+              "maxLength": 200,
+              "type": "string"
+            },
+            "maxItems": 32,
+            "type": "array"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          },
+          "vertical": {
+            "maxLength": 200,
+            "minLength": 1,
+            "type": "string"
+          },
+          "width": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "modality",
+          "mediaType",
+          "byteHash",
+          "byteLength",
+          "occurredAt",
+          "originUri",
+          "vertical"
+        ],
+        "type": "object"
+      },
+      "IngestEvidenceAssetResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "assetId": {
+            "type": "string"
+          },
+          "availability": {
+            "enum": [
+              "hot",
+              "cold",
+              "external",
+              "gone"
+            ],
+            "type": "string"
+          },
+          "deduped": {
+            "type": "boolean"
+          },
+          "fragments": {
+            "items": {
+              "$ref": "#/components/schemas/IngestEvidenceFragmentResult"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "assetId",
+          "availability",
+          "deduped",
+          "fragments"
+        ],
+        "type": "object"
+      },
+      "IngestEvidenceFragment": {
+        "additionalProperties": false,
+        "properties": {
+          "excerpt": {
+            "maxLength": 4000,
+            "minLength": 1,
+            "type": "string"
+          },
+          "label": {
+            "maxLength": 200,
+            "type": "string"
+          },
+          "lang": {
+            "maxLength": 35,
+            "type": "string"
+          },
+          "locator": {
+            "$ref": "#/components/schemas/EvidenceFragmentLocator"
+          },
+          "piiClasses": {
+            "items": {
+              "enum": [
+                "face",
+                "voice",
+                "biometric",
+                "id_document",
+                "sensitive"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "locator"
+        ],
+        "type": "object"
+      },
+      "IngestEvidenceFragmentResult": {
+        "additionalProperties": false,
+        "properties": {
+          "fragmentId": {
+            "type": "string"
+          },
+          "representationId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "fragmentId"
         ],
         "type": "object"
       },
@@ -5030,6 +5394,56 @@
         ]
       }
     },
+    "/v1/ingest/evidence-asset": {
+      "post": {
+        "description": "Registers one multimodal evidence asset header (image / audio / video / document / sensor) plus optional citation-target fragments — WITHOUT transferring bytes. The surface is metadata-only by design (the MM-6 quarantine boundary): `originUri` (a caller-owned location the brain never fetches) is required, `storageRef` is rejected (400), and no upload is accepted, so a fresh registration is always availability `external`. `byteHash` (sha256 of the original bytes) is REQUIRED — the UNIQUE asset identity (migration 0109): same-user re-registration dedupes to the existing asset (`deduped: true`, requested fragments still appended); a different principal hitting a known hash gets a bare 409 without the stored row’s metadata. Fragment locators are validated against the kind→modality matrix BEFORE any row is written — one bad locator fails the whole request. A fragment `excerpt` lands as a caller-asserted `derived_representation` of kind `text` (producerVersion `ingest-excerpt-v1`). Answers a bare 404 until `EVIDENCE_INGEST_ENABLED=1`; answers 503 while `EVIDENCE_SUBSTRATE_ENABLED` is off. Source: src/evidence/evidence-ingest.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "ingestEvidenceAsset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngestEvidenceAssetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestEvidenceAssetResponse"
+                }
+              }
+            },
+            "description": "Registered (or same-user deduped) asset + created fragments."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "503": {
+            "$ref": "#/components/responses/SubstrateDisabled"
+          }
+        },
+        "summary": "Register a multimodal evidence asset (metadata-only)",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
     "/v1/projections": {
       "get": {
         "description": "Every derived world (facts@version, …) with its lifecycle status (building/built/live/residual/failed), watermark, builder identity and stats, plus the process-local read pin (RETRIEVAL_DERIVED_VERSION). A registry row promises a queryable world. 404 until PROJECTIONS_API_ENABLED=1. Source: src/admin/projections.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -5573,7 +5987,7 @@
       "name": "Beliefs"
     },
     {
-      "description": "The raw-evidence read gateway: original observation bytes back out — direct stream, signed short-lived URLs, fragment twins — behind the full deny-overrides gate ladder (scope, ABAC, tenant/availability/quarantine, ownership grants, pack modality consent, media-PII polarity), every attempt audited content-free. Flag: EVIDENCE_RAW_READ_ENABLED (off → 404).",
+      "description": "The multimodal evidence substrate, both directions. IN: the metadata-only ingest surface — register asset headers + citation-target fragments (originUri required, storageRef rejected, no bytes — the MM-6 boundary); flags EVIDENCE_INGEST_ENABLED (off → 404) and EVIDENCE_SUBSTRATE_ENABLED (off → 503). OUT: the raw-evidence read gateway — original observation bytes back out via direct stream, signed short-lived URLs, fragment twins — behind the full deny-overrides gate ladder (scope, ABAC, tenant/availability/quarantine, ownership grants, pack modality consent, media-PII polarity), every attempt audited content-free; flag EVIDENCE_RAW_READ_ENABLED (off → 404).",
       "name": "Evidence"
     },
     {

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -125,6 +125,13 @@ import {
   UserProfileResponseSchema,
 } from '../src/contracts/users/user-profile.schema';
 import { EvidenceRawUrlResponseSchema } from '../src/contracts/evidence/raw.schema';
+import {
+  EvidenceFragmentLocatorSchema,
+  IngestEvidenceAssetRequestSchema,
+  IngestEvidenceAssetResponseSchema,
+  IngestEvidenceFragmentResultSchema,
+  IngestEvidenceFragmentSchema,
+} from '../src/contracts/evidence/evidence-ingest.schema';
 
 type Json = Record<string, unknown>;
 
@@ -226,6 +233,12 @@ const ZOD_COMPONENTS: Record<string, z.ZodType> = {
   UserProfileResponse: UserProfileResponseSchema,
   // --- raw-evidence read gateway (src/contracts/evidence/raw.schema.ts)
   EvidenceRawUrlResponse: EvidenceRawUrlResponseSchema,
+  // --- evidence ingest (src/contracts/evidence/evidence-ingest.schema.ts)
+  EvidenceFragmentLocator: EvidenceFragmentLocatorSchema,
+  IngestEvidenceFragment: IngestEvidenceFragmentSchema,
+  IngestEvidenceAssetRequest: IngestEvidenceAssetRequestSchema,
+  IngestEvidenceFragmentResult: IngestEvidenceFragmentResultSchema,
+  IngestEvidenceAssetResponse: IngestEvidenceAssetResponseSchema,
 };
 
 function generateComponentSchemas(): Json {
@@ -1441,6 +1454,52 @@ function sortKeysDeep(value: unknown): unknown {
   return value;
 }
 
+function evidenceIngestPaths(): Json {
+  return {
+    '/v1/ingest/evidence-asset': {
+      post: operation({
+        operationId: 'ingestEvidenceAsset',
+        tag: 'Evidence',
+        summary: 'Register a multimodal evidence asset (metadata-only)',
+        description:
+          'Registers one multimodal evidence asset header (image / audio ' +
+          '/ video / document / sensor) plus optional citation-target ' +
+          'fragments — WITHOUT transferring bytes. The surface is ' +
+          'metadata-only by design (the MM-6 quarantine boundary): ' +
+          '`originUri` (a caller-owned location the brain never fetches) ' +
+          'is required, `storageRef` is rejected (400), and no upload is ' +
+          'accepted, so a fresh registration is always availability ' +
+          '`external`. `byteHash` (sha256 of the original bytes) is ' +
+          'REQUIRED — the UNIQUE asset identity (migration 0109): ' +
+          'same-user re-registration dedupes to the existing asset ' +
+          '(`deduped: true`, requested fragments still appended); a ' +
+          'different principal hitting a known hash gets a bare 409 ' +
+          'without the stored row’s metadata. Fragment locators are ' +
+          'validated against the kind→modality matrix BEFORE any row is ' +
+          'written — one bad locator fails the whole request. A fragment ' +
+          '`excerpt` lands as a caller-asserted `derived_representation` ' +
+          'of kind `text` (producerVersion `ingest-excerpt-v1`). ' +
+          'Answers a bare 404 until `EVIDENCE_INGEST_ENABLED=1`; answers ' +
+          '503 while `EVIDENCE_SUBSTRATE_ENABLED` is off. ' +
+          'Source: src/evidence/evidence-ingest.controller.ts.',
+        scope: 'brain:write',
+        requestBody: jsonBody(ref('IngestEvidenceAssetRequest')),
+        responses: {
+          '201': jsonResponse(
+            'Registered (or same-user deduped) asset + created fragments.',
+            ref('IngestEvidenceAssetResponse'),
+          ),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+          '409': errorRef('Conflict'),
+          '503': errorRef('SubstrateDisabled'),
+        },
+      }),
+    },
+  };
+}
+
 function errorResponses(): Json {
   const err = (description: string): Json => jsonResponse(description, ref('ErrorResponse'));
   return {
@@ -1456,6 +1515,11 @@ function errorResponses(): Json {
     FeatureDisabled: jsonResponse(
       'The document pipeline is dark (DOCUMENT_INGEST_ENABLED off).',
       ref('FeatureDisabledResponse'),
+    ),
+    SubstrateDisabled: err(
+      'The evidence write seam is off (EVIDENCE_SUBSTRATE_ENABLED) — ' +
+        'the route exists but every write is refused. Boot-time ' +
+        'env-validation warns about this inconsistent flag pair.',
     ),
     BadGateway: err('The billing service rejected the request.'),
     BillingUnavailable: err(
@@ -1582,12 +1646,18 @@ export function buildOpenApiDocument(): Json {
       {
         name: 'Evidence',
         description:
-          'The raw-evidence read gateway: original observation bytes ' +
-          'back out — direct stream, signed short-lived URLs, fragment ' +
-          'twins — behind the full deny-overrides gate ladder (scope, ' +
-          'ABAC, tenant/availability/quarantine, ownership grants, pack ' +
-          'modality consent, media-PII polarity), every attempt audited ' +
-          'content-free. Flag: EVIDENCE_RAW_READ_ENABLED (off → 404).',
+          'The multimodal evidence substrate, both directions. IN: the ' +
+          'metadata-only ingest surface — register asset headers + ' +
+          'citation-target fragments (originUri required, storageRef ' +
+          'rejected, no bytes — the MM-6 boundary); flags ' +
+          'EVIDENCE_INGEST_ENABLED (off → 404) and ' +
+          'EVIDENCE_SUBSTRATE_ENABLED (off → 503). OUT: the raw-evidence ' +
+          'read gateway — original observation bytes back out via direct ' +
+          'stream, signed short-lived URLs, fragment twins — behind the ' +
+          'full deny-overrides gate ladder (scope, ABAC, tenant/' +
+          'availability/quarantine, ownership grants, pack modality ' +
+          'consent, media-PII polarity), every attempt audited ' +
+          'content-free; flag EVIDENCE_RAW_READ_ENABLED (off → 404).',
       },
       {
         name: 'Users',
@@ -1607,6 +1677,7 @@ export function buildOpenApiDocument(): Json {
       ...driverPaths(),
       ...memoryReadPaths(),
       ...evidencePaths(),
+      ...evidenceIngestPaths(),
     },
     webhooks: {
       episodesAvailable: {

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1187,6 +1187,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Master switch for the multimodal evidence substrate writers (evidence_asset / evidence_fragment / derived_representation, migration 0109). Off = EvidenceStoreService refuses every write (503) and no row is ever written; GDPR cascade + retention sweep run regardless so rows written while on stay erasable.',
   },
   {
+    key: 'EVIDENCE_INGEST_ENABLED',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Evidence ingest surface (Brain v2.1 M3): POST /v1/ingest/evidence-asset. Off (default) = the route answers a bare 404 (scenes-surface precedent), byte-identical prod. Metadata-only by design (MM-6 boundary): originUri required, storageRef rejected, no bytes accepted. Requires EVIDENCE_SUBSTRATE_ENABLED — ingest-on/substrate-off answers 503 from the write seam and env-validation warns at boot.',
+  },
+  {
     key: 'EVIDENCE_FS_ROOT',
     category: 'pipeline',
     defaultValue: '',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -260,6 +260,7 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
 
   // ── Evidence plane: claim grounding (Drift-1, migration 0115) ──────
   validateEvidenceGroundingEnv(env, warnings);
+  validateEvidenceIngestEnv(env, warnings);
 
   // ── Evidence plane: processing lifecycle (migration 0121) ──────────
   validateEvidenceProcessingEnv(env, warnings);
@@ -500,6 +501,28 @@ function validateEvidenceRawReadEnv(
       'EVIDENCE_SIGNED_URL_SECRET must be at least 32 characters while ' +
         'EVIDENCE_RAW_READ_ENABLED is on — a short secret makes minted ' +
         'raw-evidence URLs forgeable.',
+    );
+  }
+}
+
+/**
+ * Cross-flag consistency for the evidence ingest surface (Brain v2.1
+ * M3): a WARNING, not an error — the pair is not security-relevant, but
+ * EVIDENCE_INGEST_ENABLED without EVIDENCE_SUBSTRATE_ENABLED means the
+ * route exists while the write seam refuses every call, so EVERY ingest
+ * would be rejected 503. The operator should know before the first
+ * caller bounces.
+ */
+function validateEvidenceIngestEnv(env: NodeJS.ProcessEnv, warnings: string[]): void {
+  if (
+    envFlagEnabled(env.EVIDENCE_INGEST_ENABLED) &&
+    !envFlagEnabled(env.EVIDENCE_SUBSTRATE_ENABLED)
+  ) {
+    warnings.push(
+      'EVIDENCE_INGEST_ENABLED is set while EVIDENCE_SUBSTRATE_ENABLED is not — ' +
+        'the ingest surface is exposed but the evidence write seam refuses every ' +
+        'call; every POST /v1/ingest/evidence-asset will be rejected (503) until ' +
+        'EVIDENCE_SUBSTRATE_ENABLED is turned on.',
     );
   }
 }
@@ -1029,9 +1052,10 @@ const KNOWN_BOOLEAN_FLAGS = [
   // the ENGINE flag budget by design (a substrate builder, not an engine
   // fork). The fs root (EVIDENCE_FS_ROOT) is a string and the size cap
   // (EVIDENCE_MAX_BYTES) an int — not booleans. Reserved for sibling PRs
-  // (not defined yet): EVIDENCE_INGEST_ENABLED. (The scene-links seam
-  // reserved here landed as SCENES_EVIDENCE_LINKS — the writer is a
-  // scene pass, so it keeps the SCENES_ family naming.)
+  // (none left): EVIDENCE_INGEST_ENABLED landed below (PR-C ingest
+  // surface); the scene-links seam reserved here landed as
+  // SCENES_EVIDENCE_LINKS — the writer is a scene pass, so it keeps the
+  // SCENES_ family naming.
   'EVIDENCE_SUBSTRATE_ENABLED',
   // Fragment citations (MM-zoom PR2): generator schema gains
   // citedFragmentIds over the rendered fragment lane; resolved through
@@ -1039,6 +1063,13 @@ const KNOWN_BOOLEAN_FLAGS = [
   // satisfy the 0113 capability gate for non-text. Default off =
   // byte-identical even with the lane on.
   'EVIDENCE_FRAGMENT_CITATIONS',
+  // Evidence ingest surface (Brain v2.1 M3): POST /v1/ingest/evidence-asset.
+  // Default off ⇒ the route answers a bare 404 (scenes-surface precedent)
+  // and prod is byte-identical. Metadata-only (MM-6): originUri required,
+  // no bytes, no storageRef. Requires EVIDENCE_SUBSTRATE_ENABLED to
+  // actually accept writes — validateEvidenceIngestEnv warns on the
+  // inconsistent pair (ingest-on/substrate-off ⇒ every call 503s).
+  'EVIDENCE_INGEST_ENABLED',
   // Claim grounding (Drift-1, migration 0115): write-side post-resolve
   // stamp of knowledge_fact.groundingStatus; fail-closed mention capture
   // (requires EPISODE_SUBSTRATE_ENABLED — validateEvidenceGroundingEnv

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -15,10 +15,11 @@ import { envFlagEnabled } from './env-validation';
  * stay erasable after it is turned off. EVIDENCE_ family sits off the
  * ENGINE flag budget by design (a substrate builder, not an engine fork).
  *
- * Reserved for sibling PRs (NOT defined yet — do not read them):
- * EVIDENCE_SCENE_LINKS (scene↔asset membership).
- * EVIDENCE_FRAGMENT_CITATIONS (MM-zoom PR2) and EVIDENCE_INGEST_ENABLED
- * (PR-C ingest surface) landed below.
+ * Formerly reserved here, all landed: EVIDENCE_FRAGMENT_CITATIONS
+ * (MM-zoom PR2) and EVIDENCE_INGEST_ENABLED (PR-C ingest surface) live
+ * below; the scene↔asset membership seam landed as
+ * SCENES_EVIDENCE_LINKS — the writer is a scene pass, so it keeps the
+ * SCENES_ family naming (see scene-flags.ts).
  */
 export function evidenceSubstrateEnabled(): boolean {
   return envFlagEnabled(process.env.EVIDENCE_SUBSTRATE_ENABLED);

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -16,12 +16,31 @@ import { envFlagEnabled } from './env-validation';
  * ENGINE flag budget by design (a substrate builder, not an engine fork).
  *
  * Reserved for sibling PRs (NOT defined yet — do not read them):
- * EVIDENCE_INGEST_ENABLED (PR-C ingest surface), EVIDENCE_SCENE_LINKS
- * (scene↔asset membership). EVIDENCE_FRAGMENT_CITATIONS landed below
- * (MM-zoom PR2).
+ * EVIDENCE_SCENE_LINKS (scene↔asset membership).
+ * EVIDENCE_FRAGMENT_CITATIONS (MM-zoom PR2) and EVIDENCE_INGEST_ENABLED
+ * (PR-C ingest surface) landed below.
  */
 export function evidenceSubstrateEnabled(): boolean {
   return envFlagEnabled(process.env.EVIDENCE_SUBSTRATE_ENABLED);
+}
+
+/**
+ * Evidence ingest surface (Brain v2.1 M3) — EVIDENCE_INGEST_ENABLED.
+ *
+ * When on, POST /v1/ingest/evidence-asset exists; off (default) the
+ * route answers a bare 404 (the scenes-surface precedent — a dark route
+ * does not advertise itself) and prod stays byte-identical. The surface
+ * is METADATA-ONLY (MM-6 boundary): originUri required, no bytes, no
+ * storageRef — blob-backed registration stays service-level until the
+ * upload/quarantine design lands. Both this flag AND
+ * EVIDENCE_SUBSTRATE_ENABLED must be on for a call to succeed: ingest-on
+ * with substrate-off answers 503 from the write seam and env-validation
+ * warns at boot about the inconsistent pair. Read at call time
+ * (runtime-mutable). Env read lives here in the common layer, NOT inside
+ * the engine dirs (engine-gates S5.2).
+ */
+export function evidenceIngestEnabled(): boolean {
+  return envFlagEnabled(process.env.EVIDENCE_INGEST_ENABLED);
 }
 
 /**

--- a/src/contracts/evidence/evidence-ingest.schema.ts
+++ b/src/contracts/evidence/evidence-ingest.schema.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+import { EVIDENCE_MODALITIES } from '../../common/evidence-taxonomy';
+import { MEDIA_PII_CLASSES, type MediaPiiClass } from '../../common/media-pii';
+
+/**
+ * Wire contracts for the metadata-only evidence ingest surface
+ * (POST /v1/ingest/evidence-asset — EVIDENCE_INGEST_ENABLED, default
+ * off → 404). METADATA-ONLY (MM-6 boundary): `originUri` required,
+ * `storageRef` rejected, no bytes ever cross this surface.
+ *
+ * Runtime truth lives at the write seam (evidence-store.service.ts +
+ * locator.ts): the DTO/pipe layer enforces the same caps and the locator
+ * matrix BEFORE any row is written; these schemas document the wire.
+ */
+
+/** Media PII vocabulary — canonical union in src/common/media-pii.ts. */
+const MediaPiiClassSchema = z.enum([...MEDIA_PII_CLASSES] as [MediaPiiClass, ...MediaPiiClass[]]);
+
+/**
+ * Kind-discriminated "where in the asset" locator, cross-checked against
+ * the parent asset's modality (charRange→document; pageRegion→document |
+ * image, image ⇒ page 0; timeRange/track→audio|video|sensor;
+ * frameRange→video). Mirror of src/evidence/locator.ts.
+ */
+export const EvidenceFragmentLocatorSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('charRange'),
+    start: z.number().int().nonnegative(),
+    end: z.number().int().positive(),
+  }),
+  z.object({
+    kind: z.literal('pageRegion'),
+    page: z.number().int().nonnegative(),
+    x: z.number().min(0).max(1),
+    y: z.number().min(0).max(1),
+    w: z.number().min(0).max(1),
+    h: z.number().min(0).max(1),
+  }),
+  z.object({
+    kind: z.literal('timeRange'),
+    startMs: z.number().int().nonnegative(),
+    endMs: z.number().int().positive(),
+  }),
+  z.object({
+    kind: z.literal('frameRange'),
+    startFrame: z.number().int().nonnegative(),
+    endFrame: z.number().int().positive(),
+  }),
+  z.object({
+    kind: z.literal('track'),
+    trackId: z.string().min(1).max(256),
+    startMs: z.number().int().nonnegative().optional(),
+    endMs: z.number().int().nonnegative().optional(),
+  }),
+]);
+
+export const IngestEvidenceFragmentSchema = z.object({
+  locator: EvidenceFragmentLocatorSchema,
+  /** Human label; PII-redacted then capped server-side. */
+  label: z.string().max(200).optional(),
+  /** Fail-closed polarity: absent = unclassified = blocked; [] = clean. */
+  piiClasses: z.array(MediaPiiClassSchema).optional(),
+  /**
+   * Caller-asserted text excerpt — lands as a derived_representation of
+   * kind 'text' (producerVersion 'ingest-excerpt-v1').
+   */
+  excerpt: z.string().min(1).max(4000).optional(),
+  /** Language of the excerpt (BCP-47). */
+  lang: z.string().max(35).optional(),
+});
+
+export const IngestEvidenceAssetRequestSchema = z.object({
+  modality: z.enum(EVIDENCE_MODALITIES),
+  /** IANA type/subtype (e.g. image/jpeg). */
+  mediaType: z.string().max(255),
+  /**
+   * sha256 hex of the ORIGINAL bytes — REQUIRED: the UNIQUE asset
+   * identity (0109). Same-user re-registration dedupes; a different
+   * principal gets a bare 409.
+   */
+  byteHash: z.string().regex(/^[0-9a-f]{64}$/),
+  /** Declared size in bytes; capped by EVIDENCE_MAX_BYTES. */
+  byteLength: z.number().int().positive(),
+  /** When the observation happened (ISO-8601). */
+  occurredAt: z.string(),
+  /**
+   * Caller-owned external location of the bytes — REQUIRED (metadata-
+   * only surface; a fresh registration is always availability
+   * 'external'). Never fetched by the brain.
+   */
+  originUri: z.string().min(1).max(2048),
+  vertical: z.string().min(1).max(200),
+  /** Per-user scope: invisible to other users, fail-closed reads. */
+  userId: z.string().max(200).optional(),
+  scope: z.array(z.string().max(200)).max(32).optional(),
+  /** Fail-closed polarity: absent = unclassified = blocked; [] = clean. */
+  piiClasses: z.array(MediaPiiClassSchema).optional(),
+  recorder: z.string().max(200).optional(),
+  /** Retention horizon (ISO-8601); past it the asset is tombstoned. */
+  retainUntil: z.string().optional(),
+  meta: z.record(z.string(), z.unknown()).optional(),
+  width: z.number().int().positive().optional(),
+  height: z.number().int().positive().optional(),
+  durationMs: z.number().int().positive().optional(),
+  pageCount: z.number().int().positive().optional(),
+  /** Citation-target fragments; all locators validated before any write. */
+  fragments: z.array(IngestEvidenceFragmentSchema).max(64).optional(),
+});
+
+export const IngestEvidenceFragmentResultSchema = z.object({
+  fragmentId: z.string(),
+  /** Present when the fragment carried an excerpt. */
+  representationId: z.string().optional(),
+});
+
+export const IngestEvidenceAssetResponseSchema = z.object({
+  assetId: z.string(),
+  /**
+   * 'external' for a fresh metadata-only registration; a same-user
+   * dedup returns the EXISTING asset's state, which may be blob-backed.
+   */
+  availability: z.enum(['hot', 'cold', 'external', 'gone']),
+  /** True when byteHash matched this user's existing asset. */
+  deduped: z.boolean(),
+  fragments: z.array(IngestEvidenceFragmentResultSchema),
+});

--- a/src/evidence/dto/ingest-evidence-asset.dto.ts
+++ b/src/evidence/dto/ingest-evidence-asset.dto.ts
@@ -1,0 +1,152 @@
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsIn,
+  IsISO8601,
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { EVIDENCE_MODALITIES, type EvidenceModality } from '../../common/evidence-taxonomy';
+import { MEDIA_PII_CLASSES, type MediaPiiClass } from '../../common/media-pii';
+import { IngestEvidenceFragmentDto } from './ingest-evidence-fragment.dto';
+
+export { IngestEvidenceFragmentDto } from './ingest-evidence-fragment.dto';
+
+/**
+ * Wire shape of POST /v1/ingest/evidence-asset (EVIDENCE_INGEST_ENABLED,
+ * default off → 404). METADATA-ONLY by design (the MM-6 quarantine
+ * boundary): the caller registers what an observation IS and WHERE it
+ * lives (`originUri`, a caller-owned location the brain never fetches) —
+ * never the bytes themselves. `storageRef` is deliberately NOT part of
+ * this contract: the global `forbidNonWhitelisted` pipe rejects it with
+ * 400, so blob-backed registration stays a service-level concern until
+ * the upload/quarantine design lands.
+ *
+ * `byteHash` is REQUIRED — a deliberate narrowing of the "if known"
+ * draft: 0109 makes byteHash the UNIQUE asset identity, so an optional
+ * hash could not be honored without inventing a second identity law.
+ */
+
+/** Fragment caps: a request is a registration, not a bulk import. */
+const FRAGMENTS_MAX = 64;
+/** Opaque pointer, not fetched — bounded against abuse only. */
+const ORIGIN_URI_MAX = 2_048;
+
+export class IngestEvidenceAssetDto {
+  @IsIn(EVIDENCE_MODALITIES)
+  modality!: EvidenceModality;
+
+  /** IANA type/subtype — the exact shape is enforced at the write seam. */
+  @IsString()
+  @MaxLength(255)
+  mediaType!: string;
+
+  /**
+   * sha256 hex of the ORIGINAL bytes — the UNIQUE asset identity (0109).
+   * Required (see the class doc); 64 lowercase hex enforced at the seam.
+   */
+  @IsString()
+  @MaxLength(64)
+  byteHash!: string;
+
+  /** Declared size; capped by EVIDENCE_MAX_BYTES at the write seam. */
+  @IsInt()
+  @Min(1)
+  byteLength!: number;
+
+  /** When the observation happened (ISO-8601). */
+  @IsISO8601()
+  occurredAt!: string;
+
+  /**
+   * Caller-owned external location of the bytes. REQUIRED on this
+   * surface: with no bytes and no storageRef accepted, an asset without
+   * an origin would be unresolvable metadata (availability is always
+   * 'external' for a fresh registration here). Never fetched.
+   */
+  @IsString()
+  @MinLength(1)
+  @MaxLength(ORIGIN_URI_MAX)
+  originUri!: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  vertical!: string;
+
+  /** Per-user scope (0055 discipline): fail-closed reads for others. */
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  userId?: string | undefined;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @MaxLength(200, { each: true })
+  @ArrayMaxSize(32)
+  scope?: string[] | undefined;
+
+  /**
+   * Media PII classes present in the asset (fail-closed polarity:
+   * absent = unclassified = blocked; `[]` = affirmatively clean).
+   */
+  @IsOptional()
+  @IsArray()
+  @IsIn(MEDIA_PII_CLASSES, { each: true })
+  piiClasses?: MediaPiiClass[] | undefined;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  recorder?: string | undefined;
+
+  /** Retention horizon; past it the sweeper tombstones the asset. */
+  @IsOptional()
+  @IsISO8601()
+  retainUntil?: string | undefined;
+
+  @IsOptional()
+  @IsObject()
+  meta?: Record<string, unknown> | undefined;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  width?: number | undefined;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  height?: number | undefined;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  durationMs?: number | undefined;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  pageCount?: number | undefined;
+
+  /**
+   * Citation-target fragments created with the asset. Every locator is
+   * validated against the modality matrix BEFORE the asset row is
+   * written — one bad locator fails the whole request with 400 and
+   * writes nothing.
+   */
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(FRAGMENTS_MAX)
+  @ValidateNested({ each: true })
+  @Type(() => IngestEvidenceFragmentDto)
+  fragments?: IngestEvidenceFragmentDto[] | undefined;
+}

--- a/src/evidence/dto/ingest-evidence-fragment.dto.ts
+++ b/src/evidence/dto/ingest-evidence-fragment.dto.ts
@@ -1,0 +1,58 @@
+import { IsArray, IsIn, IsObject, IsOptional, IsString, MaxLength } from 'class-validator';
+import { MEDIA_PII_CLASSES, type MediaPiiClass } from '../../common/media-pii';
+
+/** Label cap mirrors LABEL_MAX at the write seam (0106 sceneLabel). */
+const LABEL_MAX = 200;
+/** An excerpt is a quotation, not a document. */
+const EXCERPT_MAX = 4_000;
+/** BCP-47 language tags fit well under this (RFC 5646 recommends 35). */
+const LANG_MAX = 35;
+
+/**
+ * One citation-target fragment inside POST /v1/ingest/evidence-asset
+ * (see ingest-evidence-asset.dto.ts for the surface contract).
+ */
+export class IngestEvidenceFragmentDto {
+  /**
+   * Kind-discriminated locator (charRange / pageRegion / timeRange /
+   * frameRange / track). A union — accepted as an opaque object here
+   * (the ingest-fact.dto.ts precedent: @ValidateNested + the
+   * forbidNonWhitelisted pipe strips union members) and shape-checked
+   * against the parent asset's modality by validateLocator BEFORE any
+   * row is written.
+   */
+  @IsObject()
+  locator!: Record<string, unknown>;
+
+  /** Human label; redacted then capped at the write seam. */
+  @IsOptional()
+  @IsString()
+  @MaxLength(LABEL_MAX)
+  label?: string | undefined;
+
+  /**
+   * Media PII classes present IN THIS FRAGMENT (fail-closed polarity:
+   * absent = unclassified = blocked; `[]` = affirmatively clean).
+   */
+  @IsOptional()
+  @IsArray()
+  @IsIn(MEDIA_PII_CLASSES, { each: true })
+  piiClasses?: MediaPiiClass[] | undefined;
+
+  /**
+   * Caller-asserted text excerpt of the fragment (the quoted passage a
+   * charRange points at, a transcript line…). Lands as a
+   * derived_representation of kind 'text' with producerVersion
+   * 'ingest-excerpt-v1' — asserted, not model-derived.
+   */
+  @IsOptional()
+  @IsString()
+  @MaxLength(EXCERPT_MAX)
+  excerpt?: string | undefined;
+
+  /** Language of the excerpt (BCP-47). */
+  @IsOptional()
+  @IsString()
+  @MaxLength(LANG_MAX)
+  lang?: string | undefined;
+}

--- a/src/evidence/evidence-ingest.controller.ts
+++ b/src/evidence/evidence-ingest.controller.ts
@@ -76,6 +76,15 @@ export class EvidenceIngestController {
     if (!evidenceIngestEnabled()) throw new NotFoundException();
     this.validateFragments(body);
     const companyId = req.brainAuth.companyId;
+    // Composition with 0121/0122 (deliberate, not an omission):
+    //  - `origin` stays the default 'internal' — origin means "where the
+    //    BYTES came from", and this surface never takes bytes into
+    //    custody ('external_ingest' + the quarantine seam govern
+    //    byte-backed ingestion, which stays service-level);
+    //  - the initial ownership evidence_grant is created BY registerAsset
+    //    itself (user-owned when userId is present, system-owned
+    //    otherwise; the dedup path re-ensures a live grant) — nothing to
+    //    add here.
     const asset = await this.store.registerAsset(companyId, {
       modality: body.modality,
       mediaType: body.mediaType,

--- a/src/evidence/evidence-ingest.controller.ts
+++ b/src/evidence/evidence-ingest.controller.ts
@@ -1,0 +1,151 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  NotFoundException,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { PolicyAction } from '../policy/action-registry';
+import { evidenceIngestEnabled } from '../common/evidence-flags';
+import { EvidenceStoreService } from './evidence-store.service';
+import { validateLocator } from './locator';
+import { IngestEvidenceAssetDto, IngestEvidenceFragmentDto } from './dto/ingest-evidence-asset.dto';
+
+/**
+ * Producer stamp for caller-asserted fragment excerpts: the "producer"
+ * is this ingest surface relaying the caller's quotation — not a model
+ * (model / modelVersion / promptVersion stay absent on purpose).
+ */
+export const INGEST_EXCERPT_PRODUCER = 'ingest-excerpt-v1';
+
+export interface IngestEvidenceFragmentResult {
+  fragmentId: string;
+  /** Present when the fragment carried an excerpt. */
+  representationId?: string;
+}
+
+export interface IngestEvidenceAssetResult {
+  assetId: string;
+  availability: string;
+  deduped: boolean;
+  fragments: IngestEvidenceFragmentResult[];
+}
+
+/**
+ * POST /v1/ingest/evidence-asset — the HTTP surface of the evidence
+ * substrate (Brain v2.1 M3), METADATA-ONLY by design (the MM-6
+ * quarantine boundary): the caller registers what an observation IS
+ * (modality, mediaType, byteHash identity, dimensions) and WHERE it
+ * lives (`originUri`, never fetched) — no bytes cross this surface and
+ * `storageRef` is rejected by the forbidNonWhitelisted pipe, so a fresh
+ * registration is always availability='external'. Blob-backed
+ * registration stays service-level until the upload/quarantine design
+ * lands.
+ *
+ * Dark behind EVIDENCE_INGEST_ENABLED (default off → bare 404, the
+ * scenes-surface precedent; byte-identical prod). The write seam
+ * additionally requires EVIDENCE_SUBSTRATE_ENABLED (off → 503;
+ * env-validation warns at boot on the inconsistent pair). All flags read
+ * at call time (runtime-mutable).
+ *
+ * Semantics inherited from the ONE write seam (EvidenceStoreService):
+ * same-user re-registration of a known byteHash dedupes
+ * (`deduped: true`) and still appends the requested fragments (0109
+ * deliberately has no UNIQUE (assetId, locator) pair — a retry appends);
+ * a different principal hitting an existing hash gets a bare 409 without
+ * the stored row's metadata (dedup-probe leak stays closed). Every
+ * fragment locator is validated against the kind→modality matrix BEFORE
+ * any row is written — one bad locator fails the whole request.
+ */
+@Controller('v1/ingest')
+@UseGuards(ApiKeyGuard)
+export class EvidenceIngestController {
+  constructor(private readonly store: EvidenceStoreService) {}
+
+  @Post('evidence-asset')
+  @RequireScopes('brain:write')
+  @PolicyAction('rest.ingest.evidence_asset')
+  async ingestEvidenceAsset(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: IngestEvidenceAssetDto,
+  ): Promise<IngestEvidenceAssetResult> {
+    if (!evidenceIngestEnabled()) throw new NotFoundException();
+    this.validateFragments(body);
+    const companyId = req.brainAuth.companyId;
+    const asset = await this.store.registerAsset(companyId, {
+      modality: body.modality,
+      mediaType: body.mediaType,
+      byteHash: body.byteHash,
+      byteLength: body.byteLength,
+      occurredAt: new Date(body.occurredAt),
+      // METADATA-ONLY: originUri, never storageRef (MM-6 boundary).
+      originUri: body.originUri,
+      vertical: body.vertical,
+      userId: body.userId,
+      scope: body.scope,
+      piiClasses: body.piiClasses,
+      recorder: body.recorder,
+      retainUntil: body.retainUntil !== undefined ? new Date(body.retainUntil) : undefined,
+      meta: body.meta,
+      width: body.width,
+      height: body.height,
+      durationMs: body.durationMs,
+      pageCount: body.pageCount,
+    });
+    const fragments: IngestEvidenceFragmentResult[] = [];
+    for (const frag of body.fragments ?? []) {
+      fragments.push(await this.writeFragment(companyId, asset.assetId, frag));
+    }
+    return {
+      assetId: asset.assetId,
+      availability: asset.availability,
+      deduped: asset.deduped,
+      fragments,
+    };
+  }
+
+  /**
+   * Pre-write validation: every locator against the request's modality
+   * (validateLocator is pure — same checker the write seam runs), plus
+   * the excerpt blank-check. Failing HERE means a 400 writes NOTHING —
+   * without it a bad third fragment would leave an asset plus two
+   * fragments behind.
+   */
+  private validateFragments(body: IngestEvidenceAssetDto): void {
+    (body.fragments ?? []).forEach((frag, i) => {
+      const err = validateLocator(body.modality, frag.locator);
+      if (err) throw new BadRequestException(`fragments[${i}].locator: ${err}`);
+      if (frag.excerpt !== undefined && frag.excerpt.trim() === '') {
+        throw new BadRequestException(`fragments[${i}].excerpt must not be blank`);
+      }
+    });
+  }
+
+  /** One fragment row + its optional caller-asserted text excerpt. */
+  private async writeFragment(
+    companyId: string,
+    assetId: string,
+    frag: IngestEvidenceFragmentDto,
+  ): Promise<IngestEvidenceFragmentResult> {
+    const { fragmentId } = await this.store.addFragment(companyId, {
+      assetId,
+      locator: frag.locator,
+      label: frag.label,
+      piiClasses: frag.piiClasses,
+    });
+    if (frag.excerpt === undefined) return { fragmentId };
+    const { representationId } = await this.store.addRepresentation(companyId, {
+      subjectId: fragmentId,
+      subjectKind: 'fragment',
+      kind: 'text',
+      content: frag.excerpt,
+      lang: frag.lang,
+      producerVersion: INGEST_EXCERPT_PRODUCER,
+    });
+    return { fragmentId, representationId };
+  }
+}

--- a/src/evidence/evidence.module.ts
+++ b/src/evidence/evidence.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { EvidenceIngestController } from './evidence-ingest.controller';
 import { EvidenceReadController } from './evidence-read.controller';
 import { EvidenceReadService } from './evidence-read.service';
 import { EvidenceStoreService } from './evidence-store.service';
@@ -25,10 +26,12 @@ import {
  * write seam (EvidenceStoreService) + the blob storage-adapter registry.
  * v1 registers ONE adapter (fs://); an s3-class adapter is a new
  * provider + one more Map entry — consumers resolve by storageRef
- * scheme, never by concrete class. No controller in this PR (the ingest
- * surface is sibling PR-C). Injections into the GDPR / sweeper paths are
- * @Optional so positionally-constructed unit fixtures stay valid.
- * SurrealService comes from the @Global db module.
+ * scheme, never by concrete class. The metadata-only ingest controller
+ * (POST /v1/ingest/evidence-asset, dark behind EVIDENCE_INGEST_ENABLED
+ * → bare 404) is the ONE write-side HTTP surface; the read gateway
+ * below is its bytes-out counterpart. Injections into the GDPR /
+ * sweeper paths are @Optional so positionally-constructed unit
+ * fixtures stay valid. SurrealService comes from the @Global db module.
  *
  * Processing lifecycle (migration 0121): the trusted processor broker
  * (adapter registry array — first match wins at dispatch), the
@@ -47,7 +50,7 @@ import {
  * @Global auth/policy modules.
  */
 @Module({
-  controllers: [EvidenceReadController],
+  controllers: [EvidenceIngestController, EvidenceReadController],
   providers: [
     FsEvidenceStorageAdapter,
     {

--- a/src/evidence/locator.ts
+++ b/src/evidence/locator.ts
@@ -102,8 +102,16 @@ export function validateLocator(modality: string, locator: unknown): string | nu
   }
   const loc = locator as Record<string, unknown>;
   const kind = typeof loc.kind === 'string' ? loc.kind : '';
-  const allowed = KIND_MODALITIES[kind];
-  const validate = SHAPE_VALIDATORS[kind];
+  // OWN-property membership only: a prototype-chain name ('constructor',
+  // '__proto__', 'toString'…) would resolve to an inherited member on
+  // these record literals, pass a bare truthiness guard, and then crash
+  // the unknown-field walk with a TypeError (500 instead of 400). The
+  // kind vocabulary is the records' own keys, nothing else — and the
+  // surface is caller-reachable via POST /v1/ingest/evidence-asset
+  // (CodeQL js/unvalidated-dynamic-method-call).
+  const isKnownKind = Object.prototype.hasOwnProperty.call(SHAPE_VALIDATORS, kind);
+  const allowed = isKnownKind ? KIND_MODALITIES[kind] : undefined;
+  const validate = isKnownKind ? SHAPE_VALIDATORS[kind] : undefined;
   if (!allowed || !validate) return `unknown locator kind '${String(loc.kind)}'`;
   const unknownField = Object.keys(loc).find((field) => !LOCATOR_FIELDS[kind]!.has(field));
   if (unknownField) return `locator kind '${kind}' has unknown field '${unknownField}'`;

--- a/src/evidence/locator.ts
+++ b/src/evidence/locator.ts
@@ -18,14 +18,25 @@ export type FragmentLocator =
   /** A tracked object/channel, optionally time-bounded. */
   | { kind: 'track'; trackId: string; startMs?: number; endMs?: number };
 
+/**
+ * The three kind registries are Maps, NOT record literals, on purpose:
+ * `kind` is caller-controlled (POST /v1/ingest/evidence-asset), and on a
+ * record literal a prototype-chain name ('constructor', '__proto__',
+ * 'toString'…) resolves to an INHERITED member — it passes a truthiness
+ * guard and then crashes the unknown-field walk with a TypeError (500
+ * where a 400 belongs; CodeQL js/unvalidated-dynamic-method-call).
+ * Map.get never walks a prototype chain, so every non-registered name is
+ * simply an unknown kind.
+ */
+
 /** Locator kind → modalities it may target (the cross-check matrix). */
-const KIND_MODALITIES: Record<string, readonly string[]> = {
-  charRange: ['document'],
-  pageRegion: ['document', 'image'],
-  timeRange: ['audio', 'video', 'sensor'],
-  frameRange: ['video'],
-  track: ['audio', 'video', 'sensor'],
-};
+const KIND_MODALITIES = new Map<string, readonly string[]>([
+  ['charRange', ['document']],
+  ['pageRegion', ['document', 'image']],
+  ['timeRange', ['audio', 'video', 'sensor']],
+  ['frameRange', ['video']],
+  ['track', ['audio', 'video', 'sensor']],
+]);
 
 const isInt = (v: unknown): v is number => typeof v === 'number' && Number.isInteger(v);
 const isNum = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
@@ -37,56 +48,70 @@ function rangeError(lo: unknown, hi: unknown, msg: string): string | null {
 }
 
 /** Per-kind shape validators; each returns an error string or null. */
-const SHAPE_VALIDATORS: Record<string, (loc: Record<string, unknown>) => string | null> = {
-  charRange: (loc) =>
-    rangeError(loc.start, loc.end, 'charRange needs int start >= 0 and end > start'),
-  pageRegion: (loc) => {
-    if (!isInt(loc.page) || loc.page < 0) return 'pageRegion needs int page >= 0';
-    for (const k of ['x', 'y', 'w', 'h']) {
-      const v = loc[k];
-      if (!isNum(v) || v < 0 || v > 1) return `pageRegion needs ${k} in [0,1]`;
-    }
-    if ((loc.w as number) === 0 || (loc.h as number) === 0) {
-      return 'pageRegion needs positive w and h';
-    }
-    if ((loc.x as number) + (loc.w as number) > 1) return 'pageRegion x + w must be <= 1';
-    if ((loc.y as number) + (loc.h as number) > 1) return 'pageRegion y + h must be <= 1';
-    return null;
-  },
-  timeRange: (loc) =>
-    rangeError(loc.startMs, loc.endMs, 'timeRange needs int startMs >= 0 and endMs > startMs'),
-  frameRange: (loc) =>
-    rangeError(
-      loc.startFrame,
-      loc.endFrame,
-      'frameRange needs int startFrame >= 0 and endFrame > startFrame',
-    ),
-  track: (loc) => {
-    if (typeof loc.trackId !== 'string' || loc.trackId.length === 0 || loc.trackId.length > 256) {
-      return 'track needs a non-empty trackId (<=256 chars)';
-    }
-    for (const k of ['startMs', 'endMs']) {
-      const v = loc[k];
-      if (v !== undefined && (!isInt(v) || v < 0)) return `track ${k} must be a non-negative int`;
-    }
-    if (
-      isInt(loc.startMs) &&
-      isInt(loc.endMs) &&
-      (loc.endMs as number) <= (loc.startMs as number)
-    ) {
-      return 'track endMs must be greater than startMs';
-    }
-    return null;
-  },
-};
+const SHAPE_VALIDATORS = new Map<string, (loc: Record<string, unknown>) => string | null>([
+  [
+    'charRange',
+    (loc) => rangeError(loc.start, loc.end, 'charRange needs int start >= 0 and end > start'),
+  ],
+  [
+    'pageRegion',
+    (loc) => {
+      if (!isInt(loc.page) || loc.page < 0) return 'pageRegion needs int page >= 0';
+      for (const k of ['x', 'y', 'w', 'h']) {
+        const v = loc[k];
+        if (!isNum(v) || v < 0 || v > 1) return `pageRegion needs ${k} in [0,1]`;
+      }
+      if ((loc.w as number) === 0 || (loc.h as number) === 0) {
+        return 'pageRegion needs positive w and h';
+      }
+      if ((loc.x as number) + (loc.w as number) > 1) return 'pageRegion x + w must be <= 1';
+      if ((loc.y as number) + (loc.h as number) > 1) return 'pageRegion y + h must be <= 1';
+      return null;
+    },
+  ],
+  [
+    'timeRange',
+    (loc) =>
+      rangeError(loc.startMs, loc.endMs, 'timeRange needs int startMs >= 0 and endMs > startMs'),
+  ],
+  [
+    'frameRange',
+    (loc) =>
+      rangeError(
+        loc.startFrame,
+        loc.endFrame,
+        'frameRange needs int startFrame >= 0 and endFrame > startFrame',
+      ),
+  ],
+  [
+    'track',
+    (loc) => {
+      if (typeof loc.trackId !== 'string' || loc.trackId.length === 0 || loc.trackId.length > 256) {
+        return 'track needs a non-empty trackId (<=256 chars)';
+      }
+      for (const k of ['startMs', 'endMs']) {
+        const v = loc[k];
+        if (v !== undefined && (!isInt(v) || v < 0)) return `track ${k} must be a non-negative int`;
+      }
+      if (
+        isInt(loc.startMs) &&
+        isInt(loc.endMs) &&
+        (loc.endMs as number) <= (loc.startMs as number)
+      ) {
+        return 'track endMs must be greater than startMs';
+      }
+      return null;
+    },
+  ],
+]);
 
-const LOCATOR_FIELDS: Record<string, ReadonlySet<string>> = {
-  charRange: new Set(['kind', 'start', 'end']),
-  pageRegion: new Set(['kind', 'page', 'x', 'y', 'w', 'h']),
-  timeRange: new Set(['kind', 'startMs', 'endMs']),
-  frameRange: new Set(['kind', 'startFrame', 'endFrame']),
-  track: new Set(['kind', 'trackId', 'startMs', 'endMs']),
-};
+const LOCATOR_FIELDS = new Map<string, ReadonlySet<string>>([
+  ['charRange', new Set(['kind', 'start', 'end'])],
+  ['pageRegion', new Set(['kind', 'page', 'x', 'y', 'w', 'h'])],
+  ['timeRange', new Set(['kind', 'startMs', 'endMs'])],
+  ['frameRange', new Set(['kind', 'startFrame', 'endFrame'])],
+  ['track', new Set(['kind', 'trackId', 'startMs', 'endMs'])],
+]);
 
 /**
  * Validate a locator against the parent asset's modality. Returns a
@@ -102,18 +127,13 @@ export function validateLocator(modality: string, locator: unknown): string | nu
   }
   const loc = locator as Record<string, unknown>;
   const kind = typeof loc.kind === 'string' ? loc.kind : '';
-  // OWN-property membership only: a prototype-chain name ('constructor',
-  // '__proto__', 'toString'…) would resolve to an inherited member on
-  // these record literals, pass a bare truthiness guard, and then crash
-  // the unknown-field walk with a TypeError (500 instead of 400). The
-  // kind vocabulary is the records' own keys, nothing else — and the
-  // surface is caller-reachable via POST /v1/ingest/evidence-asset
-  // (CodeQL js/unvalidated-dynamic-method-call).
-  const isKnownKind = Object.prototype.hasOwnProperty.call(SHAPE_VALIDATORS, kind);
-  const allowed = isKnownKind ? KIND_MODALITIES[kind] : undefined;
-  const validate = isKnownKind ? SHAPE_VALIDATORS[kind] : undefined;
-  if (!allowed || !validate) return `unknown locator kind '${String(loc.kind)}'`;
-  const unknownField = Object.keys(loc).find((field) => !LOCATOR_FIELDS[kind]!.has(field));
+  // Map.get: no prototype chain, so 'constructor'/'__proto__'/'toString'
+  // read as unknown kinds (see the registry doc comment above).
+  const allowed = KIND_MODALITIES.get(kind);
+  const validate = SHAPE_VALIDATORS.get(kind);
+  const fields = LOCATOR_FIELDS.get(kind);
+  if (!allowed || !validate || !fields) return `unknown locator kind '${String(loc.kind)}'`;
+  const unknownField = Object.keys(loc).find((field) => !fields.has(field));
   if (unknownField) return `locator kind '${kind}' has unknown field '${unknownField}'`;
   if (!allowed.includes(modality)) {
     return `locator kind '${kind}' does not apply to modality '${modality}'`;

--- a/src/policy/action-registry.ts
+++ b/src/policy/action-registry.ts
@@ -83,6 +83,11 @@ export const ACTIONS: Record<string, ActionSpec> = {
   // REST-only actions
   'rest.users.forget': { kind: 'write', family: 'rest', title: 'GDPR user forget' },
   'rest.ingest.mention': { kind: 'write', family: 'rest', title: 'Ingest mention' },
+  'rest.ingest.evidence_asset': {
+    kind: 'write',
+    family: 'rest',
+    title: 'Ingest evidence asset (metadata-only)',
+  },
   'rest.documents.get': { kind: 'read', family: 'rest', title: 'Get document' },
   'rest.documents.candidates': { kind: 'read', family: 'rest', title: 'List candidates' },
   'rest.documents.commit': { kind: 'write', family: 'rest', title: 'Commit candidates' },

--- a/test/env-validation.unit-spec.ts
+++ b/test/env-validation.unit-spec.ts
@@ -285,3 +285,39 @@ describe('validateEnv — evidence grounding pair (Drift-1, warn never throw)', 
     ).toBe(false);
   });
 });
+
+describe('validateEnv — evidence ingest pair (M3, warn never throw)', () => {
+  const warnSpy = () => jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+  afterEach(() => jest.restoreAllMocks());
+
+  it('warns when EVIDENCE_INGEST_ENABLED is set without EVIDENCE_SUBSTRATE_ENABLED', () => {
+    const warn = warnSpy();
+    const env = baseProdEnv();
+    env.EVIDENCE_INGEST_ENABLED = '1';
+    expect(() => validateEnv(env)).not.toThrow();
+    expect(
+      warn.mock.calls.some(([m]) =>
+        String(m).includes('the evidence write seam refuses every call'),
+      ),
+    ).toBe(true);
+  });
+
+  it('no pair warning when both flags are on', () => {
+    const warn = warnSpy();
+    const env = baseProdEnv();
+    env.EVIDENCE_INGEST_ENABLED = '1';
+    env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    expect(() => validateEnv(env)).not.toThrow();
+    expect(
+      warn.mock.calls.some(([m]) => String(m).includes('EVIDENCE_INGEST_ENABLED is set')),
+    ).toBe(false);
+  });
+
+  it('no pair warning when neither flag is set', () => {
+    const warn = warnSpy();
+    expect(() => validateEnv(baseProdEnv())).not.toThrow();
+    expect(
+      warn.mock.calls.some(([m]) => String(m).includes('EVIDENCE_INGEST_ENABLED is set')),
+    ).toBe(false);
+  });
+});

--- a/test/evidence-ingest.e2e-spec.ts
+++ b/test/evidence-ingest.e2e-spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Evidence ingest surface e2e (Brain v2.1 M3, PR-C):
+ * POST /v1/ingest/evidence-asset.
+ *
+ *  - default-off pin: both flags off → bare 404; substrate-on/ingest-off
+ *    → still 404 (the surface flag is THE gate, scenes precedent);
+ *  - ingest-on/substrate-off → 503 from the write seam, no rows;
+ *  - metadata-only boundary (MM-6): storageRef rejected by the
+ *    forbidNonWhitelisted pipe, originUri + byteHash required;
+ *  - locator matrix pre-validation is ATOMIC — one bad locator = 400
+ *    and NO asset row written;
+ *  - excerpts land as derived_representation kind 'text' with
+ *    producerVersion 'ingest-excerpt-v1';
+ *  - same-user re-registration dedupes + appends fragments; a different
+ *    principal gets a bare 409 that leaks no stored metadata;
+ *  - brain:write scope required (403 for read-only keys).
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+const COMPANY = 'co_evidence_ingest_e2e';
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+const HASH_C = 'c'.repeat(64);
+const HASH_D = 'd'.repeat(64);
+
+const baseBody = () => ({
+  modality: 'document',
+  mediaType: 'application/pdf',
+  byteHash: HASH_A,
+  byteLength: 12_345,
+  occurredAt: '2026-03-01T10:00:00.000Z',
+  originUri: 'https://files.example.com/contracts/q1.pdf',
+  vertical: 'proj',
+  userId: 'evidence_ingest_user',
+});
+
+describe('evidence ingest surface (e2e)', () => {
+  let f: AppFixture;
+  let readOnlyKey: string;
+  const auth = (key?: string) => ({ Authorization: `Bearer ${key ?? f.apiKey}` });
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    saved.EVIDENCE_SUBSTRATE_ENABLED = process.env.EVIDENCE_SUBSTRATE_ENABLED;
+    saved.EVIDENCE_INGEST_ENABLED = process.env.EVIDENCE_INGEST_ENABLED;
+    delete process.env.EVIDENCE_SUBSTRATE_ENABLED;
+    delete process.env.EVIDENCE_INGEST_ENABLED;
+    f = await createApp({
+      companyId: COMPANY,
+      extraKeys: [{ scopes: ['brain:read'] }],
+    });
+    readOnlyKey = f.extraApiKeys[0]!;
+  });
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (f) await f.close();
+  });
+
+  const countRows = async (table: string): Promise<number> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM ${table} GROUP ALL`,
+      );
+      return (rows as Array<{ n: number }>)?.[0]?.n ?? 0;
+    });
+  };
+
+  const post = (body: Record<string, unknown>, key?: string) =>
+    f.http.post('/v1/ingest/evidence-asset').set(auth(key)).send(body);
+
+  it('answers a bare 404 while EVIDENCE_INGEST_ENABLED is off — even with the substrate on', async () => {
+    await post(baseBody()).expect(404);
+    process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    await post(baseBody()).expect(404);
+    delete process.env.EVIDENCE_SUBSTRATE_ENABLED;
+    expect(await countRows('evidence_asset')).toBe(0);
+  });
+
+  it('answers 503 from the write seam when ingest is on but the substrate is off', async () => {
+    process.env.EVIDENCE_INGEST_ENABLED = '1';
+    const res = await post(baseBody()).expect(503);
+    expect(JSON.stringify(res.body)).toContain('EVIDENCE_SUBSTRATE_ENABLED');
+    expect(await countRows('evidence_asset')).toBe(0);
+  });
+
+  it('registers a metadata-only asset with fragments; excerpts land as text representations', async () => {
+    process.env.EVIDENCE_INGEST_ENABLED = '1';
+    process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    const res = await post({
+      ...baseBody(),
+      pageCount: 12,
+      piiClasses: [],
+      fragments: [
+        {
+          locator: { kind: 'charRange', start: 100, end: 180 },
+          label: 'termination clause',
+          excerpt: 'Either party may terminate with 30 days notice.',
+          lang: 'en',
+        },
+        { locator: { kind: 'pageRegion', page: 3, x: 0.1, y: 0.2, w: 0.5, h: 0.3 } },
+      ],
+    }).expect(201);
+
+    expect(res.body.assetId).toContain('evidence_asset:');
+    expect(res.body.availability).toBe('external');
+    expect(res.body.deduped).toBe(false);
+    expect(res.body.fragments).toHaveLength(2);
+    expect(res.body.fragments[0].fragmentId).toContain('evidence_fragment:');
+    expect(res.body.fragments[0].representationId).toContain('derived_representation:');
+    expect(res.body.fragments[1].representationId).toBeUndefined();
+
+    expect(await countRows('evidence_asset')).toBe(1);
+    expect(await countRows('evidence_fragment')).toBe(2);
+    expect(await countRows('derived_representation')).toBe(1);
+
+    const surreal = f.app.get(SurrealService);
+    const repr = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<Record<string, unknown>>]>(
+        `SELECT kind, content, producerVersion, lang, subjectKind FROM derived_representation LIMIT 1`,
+      );
+      return (rows as Array<Record<string, unknown>>)[0];
+    });
+    expect(repr).toMatchObject({
+      kind: 'text',
+      content: 'Either party may terminate with 30 days notice.',
+      producerVersion: 'ingest-excerpt-v1',
+      lang: 'en',
+      subjectKind: 'fragment',
+    });
+  });
+
+  it('rejects storageRef — the metadata-only MM-6 boundary', async () => {
+    const res = await post({
+      ...baseBody(),
+      byteHash: HASH_B,
+      storageRef: 'fs://co_evidence_ingest_e2e/bb/' + HASH_B,
+    }).expect(400);
+    expect(JSON.stringify(res.body.message)).toContain('storageRef should not exist');
+    expect(await countRows('evidence_asset')).toBe(1);
+  });
+
+  it('requires originUri and byteHash', async () => {
+    const { originUri, ...noOrigin } = { ...baseBody(), byteHash: HASH_B };
+    void originUri;
+    await post(noOrigin).expect(400);
+    const { byteHash, ...noHash } = baseBody();
+    void byteHash;
+    await post(noHash).expect(400);
+    expect(await countRows('evidence_asset')).toBe(1);
+  });
+
+  it('one bad locator fails the whole request atomically — no asset row written', async () => {
+    const res = await post({
+      ...baseBody(),
+      byteHash: HASH_B,
+      fragments: [
+        { locator: { kind: 'charRange', start: 0, end: 10 } },
+        { locator: { kind: 'frameRange', startFrame: 0, endFrame: 10 } }, // video-only kind
+      ],
+    }).expect(400);
+    expect(JSON.stringify(res.body.message)).toContain('fragments[1].locator');
+    expect(await countRows('evidence_asset')).toBe(1);
+    expect(await countRows('evidence_fragment')).toBe(2);
+  });
+
+  it('rejects unknown modalities and unknown media PII classes (taxonomy-strict)', async () => {
+    await post({ ...baseBody(), byteHash: HASH_B, modality: 'hologram' }).expect(400);
+    await post({ ...baseBody(), byteHash: HASH_B, piiClasses: ['shoe_size'] }).expect(400);
+    expect(await countRows('evidence_asset')).toBe(1);
+  });
+
+  it('same-user re-registration dedupes and appends the requested fragments', async () => {
+    const res = await post({
+      ...baseBody(),
+      fragments: [{ locator: { kind: 'charRange', start: 200, end: 240 } }],
+    }).expect(201);
+    expect(res.body.deduped).toBe(true);
+    expect(await countRows('evidence_asset')).toBe(1);
+    expect(await countRows('evidence_fragment')).toBe(3);
+  });
+
+  it('a different principal hitting a known byteHash gets a bare 409 without stored metadata', async () => {
+    const res = await post({ ...baseBody(), userId: 'someone_else' }).expect(409);
+    const wire = JSON.stringify(res.body);
+    expect(wire).not.toContain('files.example.com');
+    expect(wire).not.toContain('evidence_ingest_user');
+  });
+
+  it('requires brain:write (403 for a read-only key)', async () => {
+    await post({ ...baseBody(), byteHash: HASH_C }, readOnlyKey).expect(403);
+  });
+
+  it('flag flip back off returns the surface to a bare 404 (runtime-mutable)', async () => {
+    delete process.env.EVIDENCE_INGEST_ENABLED;
+    await post({ ...baseBody(), byteHash: HASH_D }).expect(404);
+    delete process.env.EVIDENCE_SUBSTRATE_ENABLED;
+  });
+});

--- a/test/evidence-ingest.e2e-spec.ts
+++ b/test/evidence-ingest.e2e-spec.ts
@@ -176,6 +176,16 @@ describe('evidence ingest surface (e2e)', () => {
     expect(await countRows('evidence_asset')).toBe(1);
   });
 
+  it('a prototype-chain locator kind is a clean 400, not a 500', async () => {
+    const res = await post({
+      ...baseBody(),
+      byteHash: HASH_B,
+      fragments: [{ locator: { kind: 'constructor' } }],
+    }).expect(400);
+    expect(JSON.stringify(res.body.message)).toContain('unknown locator kind');
+    expect(await countRows('evidence_asset')).toBe(1);
+  });
+
   it('same-user re-registration dedupes and appends the requested fragments', async () => {
     const res = await post({
       ...baseBody(),

--- a/test/evidence-locator.unit-spec.ts
+++ b/test/evidence-locator.unit-spec.ts
@@ -46,6 +46,15 @@ describe('validateLocator — shapes and edges', () => {
     expect(validateLocator('image', {})).toMatch(/unknown locator kind/);
   });
 
+  it('treats prototype-chain names as unknown kinds — never a thrown TypeError', () => {
+    // On a record literal these resolve to INHERITED members and would
+    // pass a bare truthiness guard, then crash the unknown-field walk
+    // (500 instead of 400) — caller-reachable via the ingest surface.
+    for (const kind of ['constructor', '__proto__', 'toString', 'hasOwnProperty', 'valueOf']) {
+      expect(validateLocator('document', { kind })).toMatch(/unknown locator kind/);
+    }
+  });
+
   it('rejects non-objects', () => {
     expect(validateLocator('image', null)).toMatch(/must be an object/);
     expect(validateLocator('image', [charRange])).toMatch(/must be an object/);

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -42,6 +42,7 @@ const PLATFORM_OPERATIONS: Array<[string, string]> = [
   ['/v1/beliefs/{id}', 'get'],
   ['/v1/users/{userId}/profile', 'get'],
   ['/v1/ingest/document', 'post'],
+  ['/v1/ingest/evidence-asset', 'post'],
   ['/v1/documents/{id}', 'get'],
   ['/v1/documents/{id}/candidates', 'get'],
   ['/v1/documents/{id}/candidates', 'post'],


### PR DESCRIPTION
## Summary

Brain v2.1 M3 (batch-2 PR-C): the ONE HTTP surface of the evidence substrate — `POST /v1/ingest/evidence-asset`, metadata-only by design, dark behind a new `EVIDENCE_INGEST_ENABLED` flag (default off → bare 404, byte-identical prod).

## What it does

- **`POST /v1/ingest/evidence-asset`** (`brain:write`, policy action `rest.ingest.evidence_asset`) registers one multimodal asset header (image / audio / video / document / sensor) plus optional citation-target fragments through the existing write seam (`EvidenceStoreService` — no second write path).
- **Metadata-only (the MM-6 quarantine boundary)**: `originUri` is REQUIRED, `storageRef` is rejected (the global `forbidNonWhitelisted` pipe — 400 `property storageRef should not exist`), and no bytes cross the surface. A fresh registration is therefore always `availability: 'external'`. Blob-backed registration stays service-level until the upload/quarantine design lands.
- **Fragments** are validated against the `validateLocator` kind→modality matrix (charRange→document; pageRegion→document|image with page 0 for images; timeRange/track→audio|video|sensor; frameRange→video) **before any row is written** — one bad locator fails the whole request with 400 and writes nothing.
- **Excerpts**: a fragment may carry a caller-asserted text `excerpt` (+ optional `lang`); it lands as a `derived_representation` of kind `'text'` with `producerVersion: 'ingest-excerpt-v1'` — asserted, not model-derived (`model`/`modelVersion`/`promptVersion` stay absent).
- **Dedup semantics inherited from the seam**: same-user re-registration of a known `byteHash` returns `deduped: true` and still appends the requested fragments (0109 deliberately has no UNIQUE `(assetId, locator)` pair — a retry appends); a different principal hitting a known hash gets a bare 409 that leaks none of the stored row's metadata (dedup-probe leak stays closed).
- **Boot warning**: `validateEvidenceIngestEnv` warns (never throws) on the ingest-on/substrate-off pair — the route would exist while every call 503s.
- **Grant-free**: `evidence_grant` (MM-4) has not landed; this PR takes no dependency on it.

## ⚠️ Deliberate narrowing — flagged for review

The design draft said `byteHash` **"if known"**. This PR makes it **REQUIRED**: migration 0109 defines `byteHash` as the UNIQUE asset identity (`evidence_asset_hash_idx`), so an optional hash could not be honored without inventing a second identity law for hashless rows (and silently breaking dedup + the 1:1 row↔blob invariant). If a hashless registration tier is genuinely needed, it should be its own design, not a nullable column.

## Flags & plumbing

- `EVIDENCE_INGEST_ENABLED` — defined in `src/common/evidence-flags.ts` (was pre-reserved there in comments), added to `KNOWN_BOOLEAN_FLAGS` and the operator config catalog (`runtimeMutable`, read at call time). Off → bare 404 (the scenes-surface precedent), pinned by e2e.
- Requires `EVIDENCE_SUBSTRATE_ENABLED` to actually write — 503 from the seam otherwise (pinned by e2e + boot warning).
- `EVIDENCE_` family stays off the ENGINE flag budget (substrate builder, not an engine fork).

## OpenAPI

- New zod wire contracts `src/contracts/evidence/evidence-ingest.schema.ts` (locator union mirrors `src/evidence/locator.ts`; PII vocabulary imported from `src/common/media-pii.ts`).
- New `Evidence` tag + `/v1/ingest/evidence-asset` path + dedicated `SubstrateDisabled` 503 response component in `scripts/build-openapi.ts`; **both committed copies regenerated** (`docs/openapi.json` + `brain-landing/public/openapi.json`, 36 paths / 84 schemas); drift-gate allowlist updated.

## Drive-by hardening (surfaced by CodeQL on this PR)

Making `validateLocator` caller-reachable surfaced a latent bug in the pre-existing checker (`js/unvalidated-dynamic-method-call`, high): a prototype-chain locator `kind` (`'constructor'`, `'__proto__'`, `'toString'`…) resolved to an inherited member on the record literals, passed the truthiness guard, and the unknown-field walk then threw a TypeError — a caller-triggerable 500 where a 400 belongs. Kind membership is now an explicit own-property check; pinned by unit (5 prototype names) and e2e (clean 400, no rows written).

## Verification

- `tsc --noEmit` clean; `lint:ci` clean (`--max-warnings 0`); prettier clean.
- Unit: **319 suites / 3223 tests green** (includes the openapi drift gate rebuilt against the committed copies, config-catalog truth gates, flag budget, and 3 new env-validation warning-pair tests).
- Targeted e2e (`evidence-ingest` + `evidence-substrate`): flag-off 404 pin (also substrate-on/ingest-off), ingest-on/substrate-off 503, metadata-only rejections (storageRef / missing originUri / missing byteHash), locator-matrix atomicity (bad locator → 400, no rows), excerpt → `derived_representation kind:'text'` row asserted in DB, same-user dedup + fragment append, cross-user bare 409 (no metadata leak), 403 for read-only keys, runtime flag flip back to 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
