### PR TITLE
feat(evidence): split immutable assets from ownership grants

### DIFF
--- a/src/db/migrations/0122_evidence_grant.surql
+++ b/src/db/migrations/0122_evidence_grant.surql
@@ -1,0 +1,97 @@
+-- 0122: evidence_grant — ownership/access rows split out of evidence_asset
+-- (Brain v2.1 MM-4).
+--
+-- WHY. evidence_asset_hash_idx (byteHash UNIQUE, 0109) makes the asset row
+-- CONTENT IDENTITY: one row per distinct original byte stream, per tenant
+-- DB. The userId column conflated OWNERSHIP into that identity — two users
+-- (or a pack processor, or the system) holding the same bytes cannot be
+-- represented, and user-forget had to choose between over-deletion (kill
+-- shared content) and under-deletion (keep a user's bytes). The split:
+--   * evidence_asset  — WHAT was observed (immutable, content-addressed);
+--   * evidence_grant  — WHO may hold/serve that observation, one row per
+--     (asset, owner) relationship.
+-- GDPR user-forget hard-deletes the user's grant rows; the asset (rows +
+-- blob, via the 0114 evidence_blob_gc outbox) dies only when NO live grant
+-- remains — otherwise the content survives for its other owners, exactly
+-- the 0108/#384 EXCLUSIVE-document contract applied to bytes. The legacy
+-- userId column is RETAINED as provenance of the REGISTERING user (no
+-- reader changes; scrubbed to NONE by forget when it names the erased
+-- user and the asset survives for other owners).
+--
+-- BACKFILL. The FOR-loop below synthesizes one user grant per
+-- legacy-owned asset, idempotent (grant-less assets only), so pre-0122
+-- rows keep exactly their current owner. Prod tables are empty while
+-- EVIDENCE_SUBSTRATE_ENABLED is off, so this is belt-and-braces — and the
+-- forget cascade ALSO keeps a legacy `userId = $u` leg for any asset the
+-- backfill never saw.
+--
+-- RENUMBER CAVEAT (0109 precedent): 0119-0121 are claimed by in-flight
+-- sibling PRs. The migrator orders by filename and tolerates gaps — 0122
+-- stays 0122 either way; do NOT renumber on rebase.
+
+-- ── evidence_grant ────────────────────────────────────────────────────
+
+DEFINE TABLE IF NOT EXISTS evidence_grant SCHEMAFULL;
+
+-- Typed record link — the GDPR user-forget cascade and the retention
+-- sweep both traverse grants by asset, so the target table must be known
+-- to the schema (evidence_fragment.assetId precedent).
+DEFINE FIELD IF NOT EXISTS assetId ON evidence_grant TYPE record<evidence_asset>;
+DEFINE FIELD IF NOT EXISTS ownerKind ON evidence_grant TYPE string
+  ASSERT $value INSIDE ['user', 'pack', 'system'];
+-- An OWNER HANDLE (user id / pack id / 'system') — never content.
+DEFINE FIELD IF NOT EXISTS ownerId ON evidence_grant TYPE string;
+-- Free-form short purpose tag ('ingest', 'share', 'processor'…) —
+-- open vocabulary, length-capped at the write seam (0048 `kind` doctrine).
+DEFINE FIELD IF NOT EXISTS purpose ON evidence_grant TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS grantedAt ON evidence_grant TYPE datetime DEFAULT time::now();
+-- Administrative revocation keeps the row for audit (revokeGrant); GDPR
+-- user-forget HARD-DELETES the user's rows instead — a revoked grant
+-- still names its owner, which is exactly what erasure must remove.
+DEFINE FIELD IF NOT EXISTS revokedAt ON evidence_grant TYPE option<datetime>;
+
+-- Single-field indexes ONLY (the SurrealDB 3.2.4 compound-index
+-- DELETE-planner no-op class — this table sits on BOTH delete paths:
+-- GDPR user-forget and the retention sweep). NO UNIQUE (assetId,
+-- ownerKind, ownerId) natural key, despite the temptation: a compound
+-- index would put assetId under the planner bug, and dedup belongs to
+-- the write seam (EvidenceStoreService.addGrant) — exactly the
+-- evidence_fragment locator precedent (0109).
+DEFINE INDEX IF NOT EXISTS evidence_grant_asset_idx ON evidence_grant FIELDS assetId;
+DEFINE INDEX IF NOT EXISTS evidence_grant_owner_idx ON evidence_grant FIELDS ownerId;
+DEFINE INDEX IF NOT EXISTS evidence_grant_kind_idx ON evidence_grant FIELDS ownerKind;
+DEFINE INDEX IF NOT EXISTS evidence_grant_revoked_idx ON evidence_grant FIELDS revokedAt;
+
+-- NO CHANGEFEED, NO EVENT, deliberately (0109/0114 reasoning): a grant
+-- row names a principal; a 30-day feed would keep GDPR-erased ownership
+-- readable after the rows die.
+
+-- ── GDPR tombstone counter (0080/0106/0109 idiom) ─────────────────────
+-- option<int>, no DEFAULT: NONE = erased pre-0122. SCHEMAFULL
+-- forgotten_entity silently drops unknown fields without this DEFINE.
+DEFINE FIELD IF NOT EXISTS evidenceGrantsDeleted ON forgotten_entity TYPE option<int>;
+
+-- ── Backfill: one synthetic user grant per legacy-owned asset ─────────
+-- Idempotent: only assets with ZERO grant rows get one, so a re-applied
+-- migration (or a crash-retry mid-file) never duplicates. grantedAt
+-- mirrors the asset's createdAt — the ownership existed since
+-- registration, not since this migration ran.
+--
+-- LET-then-FOR, NOT `FOR $a IN (SELECT …)`: on the pinned SurrealDB
+-- 3.2.4 a FOR whose iterable is an inline SELECT subquery fails with
+-- "Cannot execute statement using value: NONE" (reproduced against
+-- surrealdb/surrealdb:v3.2.4, empty AND populated tables); iterating a
+-- LET-bound variable works — the fn::resolve_fact `FOR $loser IN
+-- $competing` idiom (0021/0022).
+LET $legacyOwned = (SELECT id, userId, createdAt FROM evidence_asset WHERE userId != NONE);
+FOR $a IN $legacyOwned {
+  IF array::len((SELECT VALUE id FROM evidence_grant WHERE assetId = $a.id)) = 0 {
+    CREATE evidence_grant CONTENT {
+      assetId: $a.id,
+      ownerKind: 'user',
+      ownerId: $a.userId,
+      purpose: 'backfill-0122',
+      grantedAt: $a.createdAt
+    };
+  };
+};

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -58,6 +58,8 @@ export interface UserForgetResult {
   evidenceAssetsDeleted: number;
   evidenceFragmentsDeleted: number;
   representationsDeleted: number;
+  /** Ownership rows (0122) hard-deleted — the user's own grants. */
+  evidenceGrantsDeleted: number;
   /** source_document headers fully erased (EXCLUSIVE to this user). */
   purgedSourceDocs: number;
   /** source_chunk rows drained from those exclusive docs. */
@@ -316,9 +318,13 @@ export class UserForgetService {
       // live row, but the order keeps the dependency reading honest).
       await this.eraseBeliefRows(db, beliefIds);
 
-      // Evidence substrate (0109) — see eraseEvidenceRows.
-      const { evidenceAssetsDeleted, evidenceFragmentsDeleted, representationsDeleted } =
-        await this.eraseEvidenceRows(db, companyId, userId);
+      // Evidence substrate (0109/0122) — see eraseEvidenceRows.
+      const {
+        evidenceAssetsDeleted,
+        evidenceFragmentsDeleted,
+        representationsDeleted,
+        evidenceGrantsDeleted,
+      } = await this.eraseEvidenceRows(db, companyId, userId);
 
       // Purge the materialised audit mirror (same contract as entity
       // forget): recordId is the full `table:id` string. The changefeed
@@ -344,6 +350,7 @@ export class UserForgetService {
         evidenceAssetsDeleted,
         evidenceFragmentsDeleted,
         representationsDeleted,
+        evidenceGrantsDeleted,
         purgedSourceDocs: docRows.docs,
         purgedSourceChunks,
         purgedCandidates: docRows.candidates,
@@ -351,7 +358,7 @@ export class UserForgetService {
       };
       this.logger.log(
         `user forget ${companyId}/${userId}: facts=${result.factsDeleted} entities=${result.entitiesDeleted} edges=${result.edgesDeleted} audit=${result.auditEventsDeleted} beliefs=${result.beliefsDeleted} ` +
-          `evidenceAssets=${result.evidenceAssetsDeleted} evidenceFragments=${result.evidenceFragmentsDeleted} representations=${result.representationsDeleted} ` +
+          `evidenceAssets=${result.evidenceAssetsDeleted} evidenceFragments=${result.evidenceFragmentsDeleted} representations=${result.representationsDeleted} evidenceGrants=${result.evidenceGrantsDeleted} ` +
           `docs=${result.purgedSourceDocs} chunks=${result.purgedSourceChunks} candidates=${result.purgedCandidates} indexerRuns=${result.purgedIndexerRuns}`,
       );
       return result;
@@ -401,15 +408,29 @@ export class UserForgetService {
   }
 
   /**
-   * Evidence substrate (0109): assets are user/tenant-scoped, so a
-   * user's assets die with them — with their fragments and derived
-   * representations (both content-bearing: labels, captions, OCR/ASR
-   * text). Blob refs are collected BEFORE the rows die (the row is the
-   * only pointer). LET-then-DELETE-by-ids, NOT `DELETE … WHERE`: the
-   * fragment/representation WHEREs traverse indexed record fields — the
-   * reproduced 3.2.4 planner no-op class (see the memory_outcome comment
-   * in forgetUser). Before those rows disappear, storage refs enter the
-   * durable evidence_blob_gc outbox (0114). Blobs go AFTER the rows (an
+   * Evidence substrate (0109/0122), grant-aware. Ownership lives in
+   * evidence_grant rows; the asset row is content identity (byteHash
+   * UNIQUE). Erasure order:
+   *   1. HARD-DELETE the user's grant rows — live AND revoked, both name
+   *      the erased principal (administrative revokeGrant keeps rows for
+   *      audit; GDPR must not).
+   *   2. Candidate assets = those grants' assets ∪ the legacy
+   *      `userId = $u` stamp (pre-0122-backfill belt-and-braces).
+   *   3. Candidates with ZERO live grants remaining are SOLE-OWNED and
+   *      die exactly like before: blob refs into the durable
+   *      evidence_blob_gc outbox (0114) BEFORE the rows go, then
+   *      representations → fragments → residual (revoked) grant rows →
+   *      assets, then best-effort blob deletes.
+   *   4. Candidates with live grants remaining SURVIVE whole — asset,
+   *      fragments, representations, and blob all stay: they ground the
+   *      other owners' citations. Only the legacy userId stamp is
+   *      scrubbed where it names the erased user — the 0108/#384
+   *      EXCLUSIVE-document semantics applied to bytes, documented in
+   *      the 0122 header.
+   * LET/SELECT-ids-then-DELETE-by-ids everywhere, NOT `DELETE … WHERE`:
+   * the fragment/representation/grant WHEREs traverse indexed record
+   * fields — the reproduced 3.2.4 planner no-op class (see the
+   * memory_outcome comment in forgetUser). Blobs go AFTER the rows (an
    * aborted cascade must not leave rows pointing at deleted bytes): an
    * immediate failure remains queued for the nightly reconciliation pass.
    */
@@ -421,34 +442,94 @@ export class UserForgetService {
     evidenceAssetsDeleted: number;
     evidenceFragmentsDeleted: number;
     representationsDeleted: number;
+    evidenceGrantsDeleted: number;
   }> {
-    const [refRows] = await db.query<[unknown[]]>(
-      `SELECT VALUE storageRef FROM evidence_asset
-        WHERE userId = $u AND storageRef != NONE`,
+    // 1. The user's own grant rows, collected then hard-deleted by ids.
+    const [grantRows] = await db.query<[Array<{ id: unknown; assetId: unknown }>]>(
+      `SELECT id, assetId FROM evidence_grant WHERE ownerKind = 'user' AND ownerId = $u`,
       { u: userId },
     );
-    const storageRefs = [...new Set(((refRows as unknown[]) ?? []).map(String))];
-    if (storageRefs.length > 0) {
-      await db.query(`INSERT INTO evidence_blob_gc $rows`, {
-        rows: storageRefs.map((storageRef) => ({ storageRef, reason: 'user_forget' })),
+    const userGrants = (grantRows as Array<{ id: unknown; assetId: unknown }>) ?? [];
+    if (userGrants.length > 0) {
+      await db.query(`DELETE $ids RETURN BEFORE`, { ids: userGrants.map((g) => g.id) });
+    }
+    // 2. Candidate assets: grant-referenced ∪ legacy-stamped.
+    const [legacyIdRows] = await db.query<[unknown[]]>(
+      `SELECT VALUE id FROM evidence_asset WHERE userId = $u`,
+      { u: userId },
+    );
+    const candidates = new Map<string, unknown>();
+    for (const g of userGrants) candidates.set(String(g.assetId), g.assetId);
+    for (const id of (legacyIdRows as unknown[]) ?? []) candidates.set(String(id), id);
+    const candidateIds = [...candidates.values()];
+    if (candidateIds.length === 0) {
+      return {
+        evidenceAssetsDeleted: 0,
+        evidenceFragmentsDeleted: 0,
+        representationsDeleted: 0,
+        evidenceGrantsDeleted: userGrants.length,
+      };
+    }
+    // 3. Classify: the user's grants are already gone, so any live grant
+    // left on a candidate belongs to ANOTHER owner — that asset survives.
+    const [liveRows] = await db.query<[unknown[]]>(
+      `SELECT VALUE assetId FROM evidence_grant
+        WHERE assetId INSIDE $ids AND revokedAt = NONE`,
+      { ids: candidateIds },
+    );
+    const stillOwned = new Set(((liveRows as unknown[]) ?? []).map(String));
+    const dyingIds = candidateIds.filter((id) => !stillOwned.has(String(id)));
+    const survivorIds = candidateIds.filter((id) => stillOwned.has(String(id)));
+    // 4. Survivors: content survives for other owners; the erased user's
+    // grant and identity stamp are gone — the #384 exclusive-document
+    // semantics applied to bytes. Targeted UPDATE by explicit ids.
+    if (survivorIds.length > 0) {
+      await db.query(`UPDATE $ids SET userId = NONE WHERE userId = $u`, {
+        ids: survivorIds,
+        u: userId,
       });
     }
-    // Processing runs (0121) key off assetId only — no ordering hazard
-    // with the repr/frag legs; reprs-before-frags stays exactly as is.
-    const [, , , , , reprsGone, fragsGone, assetsGone] = await db.query<
-      [unknown, unknown, unknown, unknown, unknown[], unknown[], unknown[], unknown[]]
-    >(
-      `LET $assetIds = (SELECT VALUE id FROM evidence_asset WHERE userId = $u);
-       LET $fragIds = (SELECT VALUE id FROM evidence_fragment WHERE assetId INSIDE $assetIds);
-       LET $reprIds = (SELECT VALUE id FROM derived_representation
-         WHERE subjectId INSIDE $assetIds OR subjectId INSIDE $fragIds);
-       LET $runIds = (SELECT VALUE id FROM processing_run WHERE assetId INSIDE $assetIds);
-       DELETE $runIds RETURN BEFORE;
-       DELETE $reprIds RETURN BEFORE;
-       DELETE $fragIds RETURN BEFORE;
-       DELETE $assetIds RETURN BEFORE;`,
-      { u: userId },
-    );
+    // 5. Sole-owned assets die exactly like pre-0122: refs first (the
+    // row is the only pointer), then rows, then blobs. Processing runs
+    // (0121) key off assetId only — no ordering hazard with the
+    // repr/frag legs; reprs-before-frags stays exactly as is. Runs on
+    // SURVIVING shared assets stay too: lineage is asset-scoped, like
+    // the fragments it produced.
+    let deleted = { reprs: 0, frags: 0, assets: 0 };
+    let storageRefs: string[] = [];
+    if (dyingIds.length > 0) {
+      const [refRows] = await db.query<[unknown[]]>(
+        `SELECT VALUE storageRef FROM evidence_asset
+          WHERE id INSIDE $ids AND storageRef != NONE`,
+        { ids: dyingIds },
+      );
+      storageRefs = [...new Set(((refRows as unknown[]) ?? []).map(String))];
+      if (storageRefs.length > 0) {
+        await db.query(`INSERT INTO evidence_blob_gc $rows`, {
+          rows: storageRefs.map((storageRef) => ({ storageRef, reason: 'user_forget' })),
+        });
+      }
+      const [, , , , , reprsGone, fragsGone, , assetsGone] = await db.query<
+        [unknown, unknown, unknown, unknown, unknown[], unknown[], unknown[], unknown[], unknown[]]
+      >(
+        `LET $fragIds = (SELECT VALUE id FROM evidence_fragment WHERE assetId INSIDE $assetIds);
+         LET $reprIds = (SELECT VALUE id FROM derived_representation
+           WHERE subjectId INSIDE $assetIds OR subjectId INSIDE $fragIds);
+         LET $residualGrantIds = (SELECT VALUE id FROM evidence_grant WHERE assetId INSIDE $assetIds);
+         LET $runIds = (SELECT VALUE id FROM processing_run WHERE assetId INSIDE $assetIds);
+         DELETE $runIds RETURN BEFORE;
+         DELETE $reprIds RETURN BEFORE;
+         DELETE $fragIds RETURN BEFORE;
+         DELETE $residualGrantIds RETURN BEFORE;
+         DELETE $assetIds RETURN BEFORE;`,
+        { assetIds: dyingIds },
+      );
+      deleted = {
+        reprs: ((reprsGone as unknown[]) ?? []).length,
+        frags: ((fragsGone as unknown[]) ?? []).length,
+        assets: ((assetsGone as unknown[]) ?? []).length,
+      };
+    }
     let blobFailures = 0;
     for (const ref of storageRefs) {
       const ok = (await this.evidence?.deleteBlobBestEffort(ref)) ?? false;
@@ -470,9 +551,10 @@ export class UserForgetService {
       );
     }
     return {
-      evidenceAssetsDeleted: ((assetsGone as unknown[]) ?? []).length,
-      evidenceFragmentsDeleted: ((fragsGone as unknown[]) ?? []).length,
-      representationsDeleted: ((reprsGone as unknown[]) ?? []).length,
+      evidenceAssetsDeleted: deleted.assets,
+      evidenceFragmentsDeleted: deleted.frags,
+      representationsDeleted: deleted.reprs,
+      evidenceGrantsDeleted: userGrants.length,
     };
   }
 }

--- a/src/evidence/evidence-store.service.ts
+++ b/src/evidence/evidence-store.service.ts
@@ -39,8 +39,14 @@ const HASH_RE = /^[0-9a-f]{64}$/;
 // charset) — open vocabulary, shape-only (0048 `kind` doctrine).
 const MEDIA_TYPE_RE = /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/i;
 const LABEL_MAX = 200;
+// Purpose is a short machine tag ('ingest', 'share', 'processor'…) — open
+// vocabulary, code-capped (the 0048 `kind` doctrine; DB stores option<string>).
+const PURPOSE_MAX = 64;
 const MODALITIES = new Set<string>(EVIDENCE_MODALITIES);
 const REPR_KINDS = new Set<string>(DERIVED_REPRESENTATION_KINDS);
+export const EVIDENCE_GRANT_OWNER_KINDS = ['user', 'pack', 'system'] as const;
+export type EvidenceGrantOwnerKind = (typeof EVIDENCE_GRANT_OWNER_KINDS)[number];
+const GRANT_OWNER_KINDS = new Set<string>(EVIDENCE_GRANT_OWNER_KINDS);
 
 export type { DerivedRepresentationKind, EvidenceModality } from '../common/evidence-taxonomy';
 
@@ -74,6 +80,21 @@ export interface AddFragmentInput {
   locator: Record<string, unknown>;
   label?: string | undefined;
   piiClasses?: string[] | undefined;
+}
+
+export interface AddGrantInput {
+  assetId: string;
+  ownerKind: EvidenceGrantOwnerKind;
+  ownerId: string;
+  purpose?: string | undefined;
+}
+
+export interface EvidenceGrantRow {
+  grantId: string;
+  ownerKind: string;
+  ownerId: string;
+  purpose?: string | undefined;
+  grantedAt: Date;
 }
 
 export interface AddRepresentationInput {
@@ -125,7 +146,16 @@ export class EvidenceStoreService {
    * A DIFFERENT user hitting an existing hash gets a bare 409 WITHOUT the
    * stored row's metadata — otherwise registering probe hashes would leak
    * whether (and as what) another principal already holds those bytes
-   * (the dedup-probe leak, closed here on purpose).
+   * (the dedup-probe leak, closed here on purpose). Sharing is an
+   * explicit addGrant() by an authorized caller, never a side effect of
+   * hash-collision probing.
+   *
+   * Ownership (0122): the asset row is content identity; the initial
+   * OWNERSHIP row is a synthetic evidence_grant — user-owned when userId
+   * is present, system-owned otherwise. The legacy userId column keeps
+   * being stamped as registering-user provenance (additive; no reader
+   * changes). The dedup path re-ensures a live grant so a re-register
+   * after an administrative revoke restores ownership idempotently.
    */
   async registerAsset(
     companyId: string,
@@ -135,6 +165,9 @@ export class EvidenceStoreService {
     this.validateAssetShape(input);
     const quarantineStatus = this.quarantineStampFor(input.origin);
     const availability = await this.deriveAvailability(companyId, input);
+    const owner: { ownerKind: EvidenceGrantOwnerKind; ownerId: string } = input.userId
+      ? { ownerKind: 'user', ownerId: input.userId }
+      : { ownerKind: 'system', ownerId: 'system' };
     return this.surreal.withCompany(companyId, async (db) => {
       try {
         const row = await dbCreate<Record<string, unknown>>(db, 'evidence_asset', {
@@ -161,6 +194,10 @@ export class EvidenceStoreService {
           // the off-state row must be byte-identical (0121).
           ...(quarantineStatus !== undefined ? { quarantineStatus } : {}),
         });
+        // A failure between the two creates leaves an asset without a
+        // grant row — covered by the forget cascade's legacy userId leg
+        // and repaired by the next same-user re-register (ensure below).
+        await this.ensureLiveGrant(db, { assetId: row.id, ...owner, purpose: 'ingest' });
         return { assetId: String(row.id), availability, deduped: false };
       } catch (err) {
         if (!isUniqueViolation(err)) throw err;
@@ -173,6 +210,7 @@ export class EvidenceStoreService {
         if ((existing.userId ?? undefined) !== (input.userId ?? undefined)) {
           throw new ConflictException('evidence asset with this byteHash already registered');
         }
+        await this.ensureLiveGrant(db, { assetId: existing.id, ...owner, purpose: 'ingest' });
         return {
           assetId: String(existing.id),
           availability: String(existing.availability),
@@ -200,6 +238,122 @@ export class EvidenceStoreService {
       return undefined;
     }
     return origin === 'external_ingest' ? 'quarantined' : 'clean';
+  }
+
+  /**
+   * Idempotent write seam for ownership rows: an existing LIVE
+   * (revokedAt = NONE) grant for the (asset, ownerKind, ownerId) triple
+   * is returned as-is — dedup lives HERE, not in a UNIQUE compound index
+   * (the 3.2.4 planner rule; see the 0122 header). Works on an open db
+   * handle so registerAsset can call it inside its own withCompany
+   * closure.
+   */
+  private async ensureLiveGrant(
+    db: Surreal,
+    grant: { assetId: unknown; ownerKind: string; ownerId: string; purpose?: string | undefined },
+  ): Promise<{ grantId: string; created: boolean }> {
+    const existing = await queryFirst<{ id: unknown }>(
+      db,
+      `SELECT id FROM evidence_grant
+        WHERE assetId = $asset AND ownerKind = $kind AND ownerId = $owner
+          AND revokedAt = NONE
+        LIMIT 1`,
+      { asset: grant.assetId, kind: grant.ownerKind, owner: grant.ownerId },
+    );
+    if (existing) return { grantId: String(existing.id), created: false };
+    const row = await dbCreate<Record<string, unknown>>(db, 'evidence_grant', {
+      assetId: grant.assetId,
+      ownerKind: grant.ownerKind,
+      ownerId: grant.ownerId,
+      purpose: grant.purpose,
+    });
+    return { grantId: String(row.id), created: true };
+  }
+
+  /**
+   * Grant an owner access to an existing asset (0122). Service-only —
+   * this PR ships NO HTTP sharing surface; callers are authorized code
+   * paths (and future PRs), never a hash-probing client.
+   */
+  async addGrant(
+    companyId: string,
+    input: AddGrantInput,
+  ): Promise<{ grantId: string; created: boolean }> {
+    this.gate();
+    if (!GRANT_OWNER_KINDS.has(input.ownerKind)) {
+      throw new BadRequestException(`invalid ownerKind '${String(input.ownerKind)}'`);
+    }
+    if (!input.ownerId || input.ownerId.trim() === '') {
+      throw new BadRequestException('ownerId is required');
+    }
+    if (input.purpose !== undefined && input.purpose.length > PURPOSE_MAX) {
+      throw new BadRequestException(`purpose must be <= ${PURPOSE_MAX} chars`);
+    }
+    return this.surreal.withCompany(companyId, async (db) => {
+      const asset = await queryFirst<{ id: unknown; availability: string }>(
+        db,
+        `SELECT id, availability
+           FROM type::record('evidence_asset', $tail) LIMIT 1`,
+        { tail: idTailOf(input.assetId) },
+      );
+      if (!asset) throw new NotFoundException(`asset ${input.assetId} not found`);
+      if (asset.availability === 'gone') {
+        throw new ConflictException(`asset ${input.assetId} is no longer available`);
+      }
+      return this.ensureLiveGrant(db, {
+        assetId: asset.id,
+        ownerKind: input.ownerKind,
+        ownerId: input.ownerId,
+        purpose: input.purpose,
+      });
+    });
+  }
+
+  /**
+   * Administrative revocation: stamps revokedAt and KEEPS the row for
+   * audit. GDPR user-forget does NOT use this — it hard-deletes (a
+   * revoked grant still names its owner). Idempotent: an already-revoked
+   * grant keeps its original timestamp.
+   */
+  async revokeGrant(companyId: string, grantId: string): Promise<{ grantId: string }> {
+    this.gate();
+    return this.surreal.withCompany(companyId, async (db) => {
+      const grant = await queryFirst<{ id: unknown; revokedAt?: unknown }>(
+        db,
+        `SELECT id, revokedAt FROM type::record('evidence_grant', $tail) LIMIT 1`,
+        { tail: idTailOf(grantId) },
+      );
+      if (!grant) throw new NotFoundException(`grant ${grantId} not found`);
+      if (grant.revokedAt === undefined || grant.revokedAt === null) {
+        await db.query(`UPDATE $id SET revokedAt = time::now()`, { id: grant.id });
+      }
+      return { grantId: String(grant.id) };
+    });
+  }
+
+  /** Live (unrevoked) grants of one asset — PR-2's gate ladder currency. */
+  async liveGrants(companyId: string, assetId: string): Promise<EvidenceGrantRow[]> {
+    return this.surreal.withCompany(companyId, async (db) => {
+      const rows = await queryRows<{
+        id: unknown;
+        ownerKind: string;
+        ownerId: string;
+        purpose?: string;
+        grantedAt: Date;
+      }>(
+        db,
+        `SELECT id, ownerKind, ownerId, purpose, grantedAt FROM evidence_grant
+          WHERE assetId = type::record('evidence_asset', $tail) AND revokedAt = NONE`,
+        { tail: idTailOf(assetId) },
+      );
+      return rows.map((r) => ({
+        grantId: String(r.id),
+        ownerKind: r.ownerKind,
+        ownerId: r.ownerId,
+        purpose: r.purpose,
+        grantedAt: r.grantedAt,
+      }));
+    });
   }
 
   /** Shape checks that need no I/O — extracted for max-lines discipline. */
@@ -476,6 +630,10 @@ export class EvidenceStoreService {
    * become undiscoverable orphans after the first batch. The two-step
    * SELECT-ids → DELETE-ids shape also avoids SurrealDB 3.2.4's
    * compound/traversal DELETE-WHERE planner no-op class.
+   *
+   * Grants (0122) go last: retention/reconciliation death is WHOLE-ASSET
+   * death — every ownership row (live or revoked) dies with the content
+   * it granted, unlike user-forget which removes one owner at a time.
    */
   private async purgeAssetDependents(db: Surreal, assetId: unknown): Promise<void> {
     await this.purgeRepresentationBatches(db, `subjectId = $asset`, { asset: assetId });
@@ -491,6 +649,16 @@ export class EvidenceStoreService {
       });
       await db.query(`DELETE $ids RETURN BEFORE`, { ids: fragIds });
       if (fragIds.length < 5000) break;
+    }
+    for (;;) {
+      const grantIds = await queryRows<unknown>(
+        db,
+        `SELECT VALUE id FROM evidence_grant WHERE assetId = $asset LIMIT 5000`,
+        { asset: assetId },
+      );
+      if (grantIds.length === 0) break;
+      await db.query(`DELETE $ids RETURN BEFORE`, { ids: grantIds });
+      if (grantIds.length < 5000) break;
     }
     // Processing runs (0121) go LAST: run rows are discoverable via
     // assetId, which survives as the tombstone header, so batch

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -353,6 +353,74 @@ describe('0114 evidence blob-GC outbox', () => {
   });
 });
 
+describe('0122_evidence_grant indexes', () => {
+  const sql = readFileSync(join(MIGRATIONS, '0122_evidence_grant.surql'), 'utf8');
+
+  // ALL single-field, deliberately: this table sits on BOTH delete paths
+  // (GDPR user-forget + retention sweep), and compound coverage would put
+  // assetId under the 3.2.4 compound-planner DELETE no-op. No UNIQUE
+  // (assetId, ownerKind, ownerId) natural key — dedup lives at the write
+  // seam (EvidenceStoreService.addGrant), the 0109 fragment precedent.
+  it.each([
+    ['evidence_grant_asset_idx', 'evidence_grant', 'assetId'],
+    ['evidence_grant_owner_idx', 'evidence_grant', 'ownerId'],
+    ['evidence_grant_kind_idx', 'evidence_grant', 'ownerKind'],
+    ['evidence_grant_revoked_idx', 'evidence_grant', 'revokedAt'],
+  ])('defines %s on %s(%s)', (name, table, fields) => {
+    expect(sql).toContain(`DEFINE INDEX IF NOT EXISTS ${name} ON ${table} FIELDS ${fields};`);
+  });
+
+  it('every index is SINGLE-FIELD (the 3.2.4 planner rule)', () => {
+    const defs = sql.match(/DEFINE INDEX[^;]+;/g) ?? [];
+    expect(defs.length).toBeGreaterThan(0);
+    for (const def of defs) {
+      const fields = /FIELDS ([^;]+);/.exec(def)?.[1] ?? '';
+      expect(fields).not.toContain(',');
+      expect(fields).not.toContain('UNIQUE');
+    }
+  });
+
+  it('deliberately defines NO changefeed and NO event', () => {
+    // A grant row names a principal; a 30-day feed would keep GDPR-erased
+    // ownership readable after the rows die (0109/0114 reasoning). The
+    // header EXPLAINS the absence in prose, so judge only non-comment
+    // lines.
+    const code = sql
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('--'))
+      .join('\n');
+    expect(code).not.toMatch(/CHANGEFEED/);
+    expect(code).not.toMatch(/DEFINE EVENT/);
+  });
+
+  it('stamps the GDPR tombstone counter on forgotten_entity', () => {
+    expect(sql).toContain('DEFINE FIELD IF NOT EXISTS evidenceGrantsDeleted ON forgotten_entity');
+  });
+
+  it('backfills legacy-owned assets idempotently (grant-less assets only)', () => {
+    // The FOR-loop must guard each CREATE on the asset having ZERO grant
+    // rows — a re-applied migration (or crash-retry) must not duplicate.
+    // LET-then-FOR: on the pinned 3.2.4 a FOR over an inline SELECT
+    // subquery fails ("Cannot execute statement using value: NONE");
+    // iterating a LET-bound variable is the working fn::resolve_fact
+    // idiom.
+    expect(sql).toContain(
+      'LET $legacyOwned = (SELECT id, userId, createdAt FROM evidence_asset WHERE userId != NONE);',
+    );
+    expect(sql).toContain('FOR $a IN $legacyOwned {');
+    // The header EXPLAINS the broken shape in prose — judge only code.
+    const code = sql
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('--'))
+      .join('\n');
+    expect(code).not.toMatch(/FOR \$a IN \(SELECT/);
+    expect(sql).toMatch(
+      /IF array::len\(\(SELECT VALUE id FROM evidence_grant WHERE assetId = \$a\.id\)\) = 0/,
+    );
+    expect(sql).toContain("ownerKind: 'user'");
+  });
+});
+
 describe('evidence substrate DELETE-shape guards (0109)', () => {
   // The three tables sit on TWO delete paths; every delete must be the
   // two-step SELECT-ids → DELETE $ids idiom (the 3.2.4 planner no-op
@@ -370,29 +438,40 @@ describe('evidence substrate DELETE-shape guards (0109)', () => {
       expect(text).not.toMatch(/DELETE evidence_fragment WHERE/);
       expect(text).not.toMatch(/DELETE derived_representation WHERE/);
       expect(text).not.toMatch(/DELETE evidence_asset WHERE/);
+      expect(text).not.toMatch(/DELETE evidence_grant WHERE/);
     }
   });
 
   it('user-forget pre-collects the cascade ids (and blob refs) before deleting', () => {
     const src = readFileSync(files[0]!, 'utf8');
+    // 0122 grant-aware shape: the user's grant rows and the legacy
+    // userId-stamped assets are collected in JS, classified by remaining
+    // live grants, and only the SOLE-OWNED ids are bound as $assetIds.
     expect(src).toContain(
-      'LET $assetIds = (SELECT VALUE id FROM evidence_asset WHERE userId = $u)',
+      "SELECT id, assetId FROM evidence_grant WHERE ownerKind = 'user' AND ownerId = $u",
     );
+    expect(src).toContain('SELECT VALUE id FROM evidence_asset WHERE userId = $u');
     expect(src).toContain(
       'LET $fragIds = (SELECT VALUE id FROM evidence_fragment WHERE assetId INSIDE $assetIds)',
     );
     expect(src).toContain('LET $reprIds = (SELECT VALUE id FROM derived_representation');
+    expect(src).toContain(
+      'LET $residualGrantIds = (SELECT VALUE id FROM evidence_grant WHERE assetId INSIDE $assetIds)',
+    );
     expect(src).toContain('DELETE $reprIds RETURN BEFORE');
     expect(src).toContain('DELETE $fragIds RETURN BEFORE');
+    expect(src).toContain('DELETE $residualGrantIds RETURN BEFORE');
     expect(src).toContain('DELETE $assetIds RETURN BEFORE');
     // Blob refs must be collected while the rows still exist.
     expect(src).toContain('SELECT VALUE storageRef FROM evidence_asset');
   });
 
-  it('the retention sweep pre-collects fragment/representation ids per asset', () => {
+  it('the retention sweep pre-collects fragment/representation/grant ids per asset', () => {
     const src = readFileSync(files[2]!, 'utf8');
     expect(src).toContain('SELECT VALUE id FROM evidence_fragment WHERE assetId = $asset');
     expect(src).toContain('SELECT VALUE id FROM derived_representation WHERE ${where} LIMIT 5000');
+    // 0122: retention death is whole-asset death — grants go too.
+    expect(src).toContain('SELECT VALUE id FROM evidence_grant WHERE assetId = $asset');
     expect(src).toContain('await db.query(`DELETE $ids RETURN BEFORE`, { ids });');
     const fragmentReprs = src.indexOf(
       'await this.purgeRepresentationBatches(db, `subjectId INSIDE $subjects`',

--- a/test/evidence-grant.e2e-spec.ts
+++ b/test/evidence-grant.e2e-spec.ts
@@ -1,0 +1,292 @@
+/**
+ * Evidence ownership grants e2e (migration 0122, MM-4): registerAsset
+ * synthesizes the initial grant, the same-user dedup path keeps ONE live
+ * grant, cross-user re-register stays a bare 409 (dedup-probe closure),
+ * addGrant/revokeGrant/liveGrants seam behavior, the grant-aware GDPR
+ * user-forget (shared assets survive minus the erased owner; sole-owned
+ * die rows+blob), the pre-backfill legacy leg, and 0122 backfill
+ * idempotence. Service-level like evidence-substrate.e2e-spec — this PR
+ * ships no HTTP grant surface.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { EvidenceStoreService } from '../src/evidence/evidence-store.service';
+import { FsEvidenceStorageAdapter } from '../src/evidence/storage/fs-storage.adapter';
+
+const COMPANY = 'co_evidence_grant_e2e';
+const sha256 = (b: Buffer) => createHash('sha256').update(b).digest('hex');
+
+describe('evidence grants (e2e)', () => {
+  let f: AppFixture;
+  let store: EvidenceStoreService;
+  let adapter: FsEvidenceStorageAdapter;
+  let surreal: SurrealService;
+  let fsRoot: string;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    fsRoot = await mkdtemp(join(tmpdir(), 'evidence-grant-e2e-'));
+    saved.EVIDENCE_SUBSTRATE_ENABLED = process.env.EVIDENCE_SUBSTRATE_ENABLED;
+    saved.EVIDENCE_FS_ROOT = process.env.EVIDENCE_FS_ROOT;
+    process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    process.env.EVIDENCE_FS_ROOT = fsRoot;
+    f = await createApp({ companyId: COMPANY });
+    store = f.app.get(EvidenceStoreService);
+    adapter = f.app.get(FsEvidenceStorageAdapter);
+    surreal = f.app.get(SurrealService);
+  });
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await rm(fsRoot, { recursive: true, force: true });
+    if (f) await f.close();
+  });
+
+  const query = async <T>(sql: string, params?: Record<string, unknown>): Promise<T> =>
+    surreal.withCompany(COMPANY, async (db) => {
+      const [rows] = await db.query<[T]>(sql, params);
+      return rows;
+    });
+
+  const grantsFor = (assetId: string) =>
+    query<Array<{ id: unknown; ownerKind: string; ownerId: string; revokedAt?: unknown }>>(
+      `SELECT id, ownerKind, ownerId, revokedAt FROM evidence_grant
+        WHERE assetId = type::record('evidence_asset', $tail)`,
+      { tail: assetId.slice(assetId.indexOf(':') + 1) },
+    );
+
+  const countRows = async (table: string): Promise<number> => {
+    const rows = await query<Array<{ n: number }>>(`SELECT count() AS n FROM ${table} GROUP ALL`);
+    return rows?.[0]?.n ?? 0;
+  };
+
+  const registerFsAsset = async (
+    data: Buffer,
+    extra: Partial<Parameters<EvidenceStoreService['registerAsset']>[1]> = {},
+  ) => {
+    const byteHash = sha256(data);
+    const { storageRef } = await adapter.put(COMPANY, byteHash, data);
+    return store.registerAsset(COMPANY, {
+      modality: 'image',
+      mediaType: 'image/jpeg',
+      byteHash,
+      byteLength: data.byteLength,
+      occurredAt: new Date('2026-03-01T10:00:00.000Z'),
+      storageRef,
+      userId: 'grant_u1',
+      vertical: 'proj',
+      ...extra,
+    });
+  };
+
+  it('registerAsset synthesizes the initial user grant; dedup keeps ONE live grant', async () => {
+    const data = randomBytes(1024);
+    const created = await registerFsAsset(data);
+    expect(created.deduped).toBe(false);
+    let grants = await grantsFor(created.assetId);
+    expect(grants).toHaveLength(1);
+    expect(grants[0]).toMatchObject({ ownerKind: 'user', ownerId: 'grant_u1' });
+
+    const again = await registerFsAsset(data);
+    expect(again.deduped).toBe(true);
+    expect(again.assetId).toBe(created.assetId);
+    grants = await grantsFor(created.assetId);
+    expect(grants).toHaveLength(1);
+  });
+
+  it('cross-user re-register stays a bare 409 and grants nothing to the prober', async () => {
+    const data = randomBytes(1024);
+    const created = await registerFsAsset(data, { userId: 'grant_owner' });
+    await expect(registerFsAsset(data, { userId: 'grant_prober' })).rejects.toThrow(
+      'evidence asset with this byteHash already registered',
+    );
+    const grants = await grantsFor(created.assetId);
+    expect(grants).toHaveLength(1);
+    expect(grants[0]!.ownerId).toBe('grant_owner');
+  });
+
+  it('a userId-less registration is system-owned', async () => {
+    const created = await store.registerAsset(COMPANY, {
+      modality: 'image',
+      mediaType: 'image/png',
+      byteHash: sha256(randomBytes(64)),
+      byteLength: 64,
+      occurredAt: new Date('2026-03-01T10:00:00.000Z'),
+      originUri: 'https://example.com/sys.png',
+      vertical: 'proj',
+    });
+    const grants = await grantsFor(created.assetId);
+    expect(grants).toHaveLength(1);
+    expect(grants[0]).toMatchObject({ ownerKind: 'system', ownerId: 'system' });
+  });
+
+  it('addGrant is idempotent over live triples; revokeGrant keeps the audit row', async () => {
+    const created = await registerFsAsset(randomBytes(700), { userId: 'grant_u2' });
+    const first = await store.addGrant(COMPANY, {
+      assetId: created.assetId,
+      ownerKind: 'pack',
+      ownerId: 'pack_alpha',
+      purpose: 'processor',
+    });
+    expect(first.created).toBe(true);
+    const dup = await store.addGrant(COMPANY, {
+      assetId: created.assetId,
+      ownerKind: 'pack',
+      ownerId: 'pack_alpha',
+    });
+    expect(dup).toEqual({ grantId: first.grantId, created: false });
+    expect(await store.liveGrants(COMPANY, created.assetId)).toHaveLength(2);
+
+    await store.revokeGrant(COMPANY, first.grantId);
+    const live = await store.liveGrants(COMPANY, created.assetId);
+    expect(live).toHaveLength(1);
+    expect(live[0]!.ownerId).toBe('grant_u2');
+    // The revoked row survives for audit; a fresh addGrant creates a new
+    // LIVE row instead of resurrecting it.
+    expect(await grantsFor(created.assetId)).toHaveLength(2);
+    const again = await store.addGrant(COMPANY, {
+      assetId: created.assetId,
+      ownerKind: 'pack',
+      ownerId: 'pack_alpha',
+    });
+    expect(again.created).toBe(true);
+    expect(await grantsFor(created.assetId)).toHaveLength(3);
+  });
+
+  it('addGrant refuses unknown assets, gone assets, and the write-gate off', async () => {
+    await expect(
+      store.addGrant(COMPANY, {
+        assetId: 'evidence_asset:missing',
+        ownerKind: 'user',
+        ownerId: 'nobody',
+      }),
+    ).rejects.toThrow(/not found/);
+
+    const created = await registerFsAsset(randomBytes(80), { userId: 'grant_u3' });
+    await query(`UPDATE type::record('evidence_asset', $tail) SET availability = 'gone'`, {
+      tail: created.assetId.slice(created.assetId.indexOf(':') + 1),
+    });
+    await expect(
+      store.addGrant(COMPANY, {
+        assetId: created.assetId,
+        ownerKind: 'user',
+        ownerId: 'late_owner',
+      }),
+    ).rejects.toThrow(/no longer available/);
+
+    delete process.env.EVIDENCE_SUBSTRATE_ENABLED;
+    try {
+      await expect(
+        store.addGrant(COMPANY, {
+          assetId: created.assetId,
+          ownerKind: 'user',
+          ownerId: 'anyone',
+        }),
+      ).rejects.toThrow(/EVIDENCE_SUBSTRATE_ENABLED/);
+    } finally {
+      process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    }
+  });
+
+  it('forget of ONE owner of a shared asset removes the grant, keeps content for the other', async () => {
+    const data = randomBytes(2048);
+    const created = await registerFsAsset(data, { userId: 'share_u1' });
+    const storageRef = `fs://${COMPANY}/${sha256(data)}`;
+    await store.addFragment(COMPANY, {
+      assetId: created.assetId,
+      locator: { kind: 'pageRegion', page: 0, x: 0.1, y: 0.1, w: 0.4, h: 0.4 },
+      label: 'shared receipt',
+    });
+    await store.addGrant(COMPANY, {
+      assetId: created.assetId,
+      ownerKind: 'user',
+      ownerId: 'share_u2',
+      purpose: 'share',
+    });
+
+    const forget = await f.http.post('/v1/users/share_u1/forget').set(auth()).send({});
+    expect([200, 201]).toContain(forget.status);
+    expect(forget.body).toMatchObject({
+      evidenceGrantsDeleted: 1,
+      evidenceAssetsDeleted: 0,
+      evidenceFragmentsDeleted: 0,
+      representationsDeleted: 0,
+    });
+    // Content survives for the other owner; the erased user's grant and
+    // identity stamp are gone (#384 exclusive-document semantics on bytes).
+    const asset = await store.getAsset(COMPANY, created.assetId);
+    expect(asset).not.toBeNull();
+    expect(asset!.userId ?? null).toBeNull();
+    expect(await adapter.exists(storageRef)).toBe(true);
+    expect(await countRows('evidence_blob_gc')).toBe(0);
+    const live = await store.liveGrants(COMPANY, created.assetId);
+    expect(live).toHaveLength(1);
+    expect(live[0]!.ownerId).toBe('share_u2');
+
+    // The LAST owner's forget kills rows and blob exactly like sole-owned.
+    const last = await f.http.post('/v1/users/share_u2/forget').set(auth()).send({});
+    expect([200, 201]).toContain(last.status);
+    expect(last.body).toMatchObject({
+      evidenceGrantsDeleted: 1,
+      evidenceAssetsDeleted: 1,
+      evidenceFragmentsDeleted: 1,
+    });
+    expect(await store.getAsset(COMPANY, created.assetId)).toBeNull();
+    expect(await grantsFor(created.assetId)).toHaveLength(0);
+    expect(await adapter.exists(storageRef)).toBe(false);
+    expect(await countRows('evidence_blob_gc')).toBe(0);
+  });
+
+  it('legacy leg: a userId-stamped asset with ZERO grant rows still dies on forget', async () => {
+    const data = randomBytes(640);
+    const created = await registerFsAsset(data, { userId: 'legacy_u' });
+    const storageRef = `fs://${COMPANY}/${sha256(data)}`;
+    // Simulate a pre-0122 row: strip the synthetic grant.
+    const ids = await query<unknown[]>(
+      `SELECT VALUE id FROM evidence_grant
+        WHERE assetId = type::record('evidence_asset', $tail)`,
+      { tail: created.assetId.slice(created.assetId.indexOf(':') + 1) },
+    );
+    await query(`DELETE $ids`, { ids });
+    expect(await grantsFor(created.assetId)).toHaveLength(0);
+
+    const forget = await f.http.post('/v1/users/legacy_u/forget').set(auth()).send({});
+    expect([200, 201]).toContain(forget.status);
+    expect(forget.body).toMatchObject({ evidenceAssetsDeleted: 1, evidenceGrantsDeleted: 0 });
+    expect(await store.getAsset(COMPANY, created.assetId)).toBeNull();
+    expect(await adapter.exists(storageRef)).toBe(false);
+  });
+
+  it('the 0122 backfill is idempotent: applying it twice yields exactly one grant', async () => {
+    const created = await registerFsAsset(randomBytes(96), { userId: 'backfill_u' });
+    const tail = created.assetId.slice(created.assetId.indexOf(':') + 1);
+    const ids = await query<unknown[]>(
+      `SELECT VALUE id FROM evidence_grant
+        WHERE assetId = type::record('evidence_asset', $tail)`,
+      { tail },
+    );
+    await query(`DELETE $ids`, { ids });
+
+    const migration = readFileSync(
+      join(__dirname, '..', 'src', 'db', 'migrations', '0122_evidence_grant.surql'),
+      'utf8',
+    );
+    await surreal.withCompany(COMPANY, async (db) => {
+      await db.query(migration);
+      await db.query(migration);
+    });
+    const grants = await grantsFor(created.assetId);
+    expect(grants).toHaveLength(1);
+    expect(grants[0]).toMatchObject({ ownerKind: 'user', ownerId: 'backfill_u' });
+  });
+});


### PR DESCRIPTION
## What

PR-1 of the MM-access cluster (MM-4): ownership moves out of `evidence_asset` into a new `evidence_grant` table. The asset row stays immutable content identity (`byteHash` UNIQUE, 0109); a grant row is WHO may hold/serve the observation. Additive substrate — existing flows are byte-identical with the flag off.

## Migration `0122_evidence_grant.surql`

- `assetId record<evidence_asset>`, `ownerKind user|pack|system`, `ownerId`, `purpose option<string>` (code-capped 64), `grantedAt`, `revokedAt option<datetime>`.
- **Single-field indexes only** (`assetId` / `ownerId` / `ownerKind` / `revokedAt`) — the table sits on both delete paths and the SurrealDB 3.2.4 compound-index DELETE planner silently no-ops. No UNIQUE natural key: dedup lives at the write seam (`addGrant`), the 0109 fragment precedent. No changefeed/event (grant rows name principals).
- Idempotent in-migration **backfill**: one synthetic user grant per legacy-owned asset (`purpose: 'backfill-0122'`, `grantedAt` = the asset's `createdAt`), guarded on zero existing grant rows. The legacy `userId` column is **retained** as registering-user provenance — no reader changes.
- Numbering: `ls src/db/migrations` at build time tops out at 0118 with 0119–0121 sibling-reserved, so 0122 is the lowest free number — matching the brief. Migrator orders by filename and tolerates gaps; do not renumber on rebase.
- `evidenceGrantsDeleted option<int>` tombstone counter field on `forgotten_entity` (0080/0106/0109 idiom).

## Write seam (`EvidenceStoreService`)

- `registerAsset` creates the initial grant in the same `withCompany` closure (user-owned when `userId` present, else `system`/`system`). Same-user dedup path re-ensures a live grant before returning `{deduped:true}`. A **different** user hitting an existing hash keeps the **bare 409** without metadata — the dedup-probe leak stays closed; sharing is an explicit `addGrant` by authorized code, never a probe side effect. **No HTTP sharing surface in this PR.**
- `addGrant` (gated writer; idempotent: an existing LIVE triple returns its id), `revokeGrant` (stamps `revokedAt`, keeps the row for audit — GDPR forget hard-deletes instead), `liveGrants` (ungated read; PR-2's gate-ladder currency).
- Retention sweep: `purgeAssetDependents` now also purges grant rows (batched SELECT-ids→DELETE) — retention death is whole-asset death.

## Grant-aware GDPR user-forget (`eraseEvidenceRows`)

1. Hard-delete the user's grant rows (live AND revoked — both name the principal); count → `evidenceGrantsDeleted` (new additive field in `UserForgetResult` + log line).
2. Candidate assets = those grants' assets ∪ legacy `userId = $u` stamp (pre-backfill belt-and-braces).
3. Zero live grants remaining → sole-owned → dies exactly like before: blob refs into the 0114 `evidence_blob_gc` outbox BEFORE row deletes, then representations → fragments → residual (revoked) grants → assets, then best-effort blob deletes with gc drain.
4. Live grants remain → asset, fragments, representations, and blob all SURVIVE (they ground the other owners' citations); only the legacy `userId` stamp is scrubbed where it names the erased user — the 0108/#384 exclusive-document semantics applied to bytes, documented in the migration header and service comments.

All deletes are the two-step SELECT-ids→DELETE idiom (3.2.4 planner rule); `audit-p1-guards` pins the 0122 index tuples, the no-compound guard, the new cascade shape, and adds `evidence_grant` to the DELETE-WHERE negatives.

## Found while building (reproduced against surrealdb/surrealdb:v3.2.4)

`FOR $a IN (SELECT …) { … }` — a FOR whose iterable is an **inline SELECT subquery** — fails with `Cannot execute statement using value: NONE` (empty and populated tables alike). Iterating a LET-bound variable works, so the backfill uses LET-then-FOR (the `fn::resolve_fact` `FOR $loser IN $competing` idiom). Documented in the migration header and pinned by the guard spec.

## Deviations from the brief

- Backfill reshaped to LET-then-FOR (above) — the brief's sketch used the inline-subquery form, which does not execute on the pinned server.
- The `audit-p1-guards` pin `LET $assetIds = (SELECT VALUE id FROM evidence_asset WHERE userId = $u)` is replaced: dying-asset ids are now classified in JS and bound as `$assetIds`; the legacy select is retained verbatim and pinned alongside the grant-collection shapes.
- `evidenceGrantsDeleted` counts the user's OWN grant rows (the brief's step-2 count); residual revoked grants deleted with a dying asset are cascade hygiene, uncounted.
- No tombstone-stamp code change: user-forget writes no `forgotten_entity` row today (the 0109 counters are defined-but-unstamped); 0122 defines the field for parity per the sketch.
- `migration-resolver-invariants` checked: it pins `fn::resolve_fact` only — no table registry to update.
- `purpose` over 64 chars is a 400, not a silent slice (machine tag, not prose).
- No OpenAPI change: the forget response is not part of the hand-written platform doc; the new field is additive JSON.

## Not in this PR

- PR-2 (MM-3 raw-read gateway, `evidence_access` audit table, migration 0123) follows after this merges.
- **No MCP raw-read tool** in either PR — the gateway is REST-first; MCP exposure is an explicit follow-up once the REST surface is dogfooded.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint:ci` (`--max-warnings 0`) — clean; `pnpm format:check` — clean
- `pnpm test:unit` — 319/319 suites, 3227/3227 tests
- Targeted e2e (testcontainers, surrealdb/surrealdb:v3.2.4, rocksdb): `evidence-grant` (new, 8 tests: initial/dedup grant, bare-409 probe, system owner, addGrant/revoke idempotence, shared-asset forget both legs, legacy zero-grant leg, backfill idempotence), `evidence-substrate`, `forget-document-cascade`, `user-forget-edge-audit`, `entities-forget` — 5/5 suites, 25 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
