### PR TITLE
feat(beliefs): semantic belief substrate + scene promotion

### DIFF
--- a/src/admin/admin-scenes.controller.ts
+++ b/src/admin/admin-scenes.controller.ts
@@ -14,6 +14,7 @@ import { AuthenticatedRequest } from '../auth/api-key.types';
 import { ApiKeyService } from '../auth/api-key.service';
 import { resolvePlatformTenant } from '../auth/tenant-scope';
 import {
+  sceneBeliefPromotionEnabled,
   sceneFactBacklinkEnabled,
   sceneLlmEnrichmentEnabled,
   sceneSegmentationEnabled,
@@ -21,6 +22,7 @@ import {
 import { SceneComposerService, SceneRunResult } from './scene-composer.service';
 import { SceneEnricherService, SceneEnrichResult } from './scene-enricher.service';
 import { SceneBacklinkService, SceneBacklinkResult } from './scene-backlink.service';
+import { BeliefPromotionService, BeliefPromotionResult } from './belief-promotion.service';
 
 /** Purge param belt: DB stamps are short version slugs, not free text. */
 // 128 (was 64): pack scene worlds (0110) are versioned
@@ -46,6 +48,12 @@ const SEGMENTER_VERSION_MAX_CHARS = 128;
  *  - POST /scenes/backlink — standalone fact backlink (PR2): idempotent
  *    source.memoryEpisodeIds stamps. 404 unless BOTH the master flag and
  *    SCENES_FACT_BACKLINK are on.
+ *  - POST /scenes/beliefs — belief promotion (Belief-A, migration 0120):
+ *    folds ENRICHED scenes of the current effective segmenter version
+ *    into semantic_belief upserts keyed by free-text (subject, field).
+ *    404 unless BOTH the master flag and SCENES_BELIEF_PROMOTION are on.
+ *    Replay-idempotent (deterministic revision ids + INSERT IGNORE +
+ *    array::union stamps).
  *  - DELETE /scenes/versions/:segmenterVersion — purge one version's
  *    scene world (members → scenes, one transaction) and demote its
  *    projection ledger row to 'residual'. 404 when the master flag is
@@ -64,6 +72,7 @@ export class AdminScenesController {
     private readonly composer: SceneComposerService,
     private readonly enricher: SceneEnricherService,
     private readonly backlinker: SceneBacklinkService,
+    private readonly beliefs: BeliefPromotionService,
     private readonly apiKeys: ApiKeyService,
   ) {}
 
@@ -108,6 +117,24 @@ export class AdminScenesController {
     }
     const tenant = this.resolveTenant(req, body.tenant);
     return this.backlinker.run(
+      tenant,
+      body.conversationId !== undefined ? { conversationId: body.conversationId } : {},
+    );
+  }
+
+  @Post('maintenance/scenes/beliefs')
+  @RequireScopes('brain:admin')
+  async promoteBeliefs(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { tenant?: string; conversationId?: string } = {},
+  ): Promise<BeliefPromotionResult> {
+    // Double-gate idiom: controller 404 here + the service's defensive
+    // early return (off = zero queries, byte-identical prod).
+    if (!sceneSegmentationEnabled() || !sceneBeliefPromotionEnabled()) {
+      throw new NotFoundException();
+    }
+    const tenant = this.resolveTenant(req, body.tenant);
+    return this.beliefs.run(
       tenant,
       body.conversationId !== undefined ? { conversationId: body.conversationId } : {},
     );

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -48,6 +48,7 @@ import { AdminScenesController } from './admin-scenes.controller';
 import { SceneComposerService } from './scene-composer.service';
 import { SceneEnricherService } from './scene-enricher.service';
 import { SceneBacklinkService } from './scene-backlink.service';
+import { BeliefPromotionService } from './belief-promotion.service';
 import { SceneVersionService } from './scene-version';
 import { HnswMaintenanceService } from './hnsw-maintenance.service';
 import { CodeMemoryModule } from '../code-memory/code-memory.module';
@@ -129,6 +130,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     SceneComposerService,
     SceneEnricherService,
     SceneBacklinkService,
+    BeliefPromotionService,
     SceneVersionService,
     AdminInfraService,
     HealthComponentsService,

--- a/src/admin/belief-promotion.service.ts
+++ b/src/admin/belief-promotion.service.ts
@@ -1,0 +1,780 @@
+import { createHash } from 'node:crypto';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type OpenAI from 'openai';
+import { RecordId, StringRecordId } from 'surrealdb';
+import { SurrealService } from '../db/surreal.service';
+import { chatCallParams, createOpenAiClient } from '../ai/openai-client';
+import {
+  sceneBeliefLlmSynthesisEnabled,
+  sceneBeliefMinScenes,
+  sceneBeliefPromotionEnabled,
+} from '../common/scene-flags';
+import { supportEdgesEnabled } from '../common/provenance-flags';
+import { buildSupportEdgeBatches } from '../common/support-edges';
+import { SceneVersionService } from './scene-version';
+
+/**
+ * Belief promotion (Belief-A, SCENES_BELIEF_PROMOTION — default off):
+ * folds ENRICHED scenes of the CURRENT effective segmenter version
+ * (SceneVersionService.resolve, the Drift-3 once-per-run contract) into
+ * the shadow semantic_belief substrate (migration 0120) — the
+ * MemoryEpisode[] -> SemanticBelief distillation. Triggered ONLY from
+ * the scenes admin surface (POST /v1/admin/maintenance/scenes/beliefs).
+ *
+ * FOLD. Each enriched scene's stateDeltas ({subject, field, from, to} —
+ * enrichment-owned, 0118) are grouped by (userId, subject, field) —
+ * free-text keys, deliberately unresolved (the 0120 header's
+ * SemanticBelief/Claim separation). Within a group, contributions are
+ * ordered by scene time (occurredTo, then scene id — deterministic);
+ * the LATEST value wins and earlier values are its history, exactly like
+ * sequential state transitions. gist/memoryValue fold in as provenance
+ * and confidence signal (enrichedMemoryValue.explicitness), never as
+ * keys.
+ *
+ * CONFLICT GUARD (built-in, no flag): a group whose latest timestamp is
+ * shared by two DIFFERENT values has no deterministic winner — the whole
+ * (subject, field) group is SKIPPED LOUDLY with a warn. Same for a
+ * batch whose winner is not newer than the active belief's validFrom
+ * (stale/ambiguous re-promotion — skipped loudly, never flip-flopped).
+ *
+ * REVISIONS: supersede chain in code, NEVER in-place for values. A new
+ * value creates revision N+1 and stamps the old row status='superseded'
+ * + validUntil + supersededBy; in-place UPDATE is allowed ONLY for the
+ * corroboration counters (sourceSceneIds / conversationIds /
+ * corroborationCount / conversationCount / updatedAt). fn::resolve_fact
+ * reuse was REJECTED (claim-specific — 0120 header).
+ *
+ * PROVENANCE: sourceSceneIds is the inline canonical trail (survives
+ * flag-off); when PROVENANCE_SUPPORT_EDGES is on, the pass additionally
+ * mirrors it into memory_support (supported_by belief->scene) and marks
+ * revisions (contradicted_by old->new, derived_from new->old), writer
+ * 'belief_promotion' — INSERT RELATION IGNORE, replay-idempotent.
+ *
+ * SCENE CONTRACTS (0106, finally fulfilled): consumed scenes get
+ * consolidatedInto ∪= [belief] (idempotent array::union; column widened
+ * to generic records in 0120) and — on a revision ONLY — baselineRef =
+ * {belief, revision, value, stampedAt}: the belief revision the delta
+ * was applied against. Revision 1 has no baseline (baselineRef stays
+ * NONE).
+ *
+ * #387 USER FENCE (fail-closed): a belief inherits the SINGLE-user
+ * scope of its scenes. A scene whose userIds (0117) is missing (legacy,
+ * pre-0117), empty (tenant-global), or has more than one member — or
+ * disagrees with the folded userId stamp — is SKIPPED LOUDLY.
+ *
+ * IDEMPOTENT: deterministic record ids over (userId|subject|field|
+ * revision) + INSERT IGNORE + array::union stamps ⇒ a re-run over the
+ * same scene world converges without duplicates; a same-value re-fold
+ * is a pure corroboration no-op.
+ *
+ * OFF = ZERO QUERIES: with SCENES_BELIEF_PROMOTION off the controller
+ * 404s AND this service returns before touching the version resolver or
+ * the database (pinned by unit test) — byte-identical prod.
+ *
+ * TESTABILITY: `openai` is the enricher's stub-injectable idiom — a
+ * plain private field holding only the chat.completions.create surface;
+ * tests swap it for a scripted stub, NO paid call ever happens in CI.
+ * The deterministic template fold works with no client at all.
+ */
+
+/** Promoter identity — composed with the effective scene world below. */
+export const BELIEF_PROMOTER_VERSION = 'belief-promotion-v1';
+
+/**
+ * Pure: the readable promoter|world composite stamped on belief rows and
+ * support edges (the enricher's readable-composite idiom — NOT hashed).
+ */
+export function beliefPromoterVersion(sceneVersion: string): string {
+  return `${BELIEF_PROMOTER_VERSION}|${sceneVersion}`;
+}
+
+/** Belts against runaway payloads (the enricher's cap discipline). */
+const STATEMENT_MAX_CHARS = 500;
+const SYNTHESIS_VISIBLE_CAP = 400;
+
+/** Confidence fold constants: explicitness mean + corroboration bonus. */
+const DEFAULT_EXPLICITNESS = 0.5;
+const CORROBORATION_BONUS = 0.05;
+const CONFIDENCE_CAP = 0.95;
+const CONFIDENCE_FLOOR = 0.05;
+
+export const BELIEF_SYNTHESIS_SYSTEM = `You phrase ONE remembered belief — a (subject, attribute, value) state a user's conversations established — as a single natural sentence. Output strictly the JSON schema: "statement": one concise declarative sentence stating the belief content itself (never meta-language like "the user said"). Include the previous value only when one is given.`;
+
+/** Scene head as selected by the promotion query (validated in JS). */
+export interface PromotableSceneHead {
+  id: unknown;
+  userId?: unknown;
+  userIds?: unknown;
+  conversationIds?: unknown;
+  occurredTo?: unknown;
+  stateDeltas?: unknown;
+  /** enrichedMemoryValue.explicitness projection (confidence signal). */
+  explicitness?: unknown;
+}
+
+/**
+ * Pure: the single user a scene's beliefs may inherit, or null when the
+ * scene must be skipped fail-closed (#387): userIds missing (legacy),
+ * empty (tenant-global), longer than one (mixed group), or disagreeing
+ * with the folded userId stamp.
+ */
+export function sceneSingleUser(scene: PromotableSceneHead): string | null {
+  const userIds = scene.userIds;
+  if (!Array.isArray(userIds) || userIds.length !== 1) return null;
+  const only = userIds[0];
+  if (typeof only !== 'string' || only === '') return null;
+  if (scene.userId !== only) return null;
+  return only;
+}
+
+/** One delta occurrence, normalized for the fold. */
+export interface BeliefContribution {
+  sceneId: string;
+  conversationId: string;
+  /** Scene occurredTo as epoch ms — the fold's ordering axis. */
+  occurredAt: number;
+  value: string;
+  priorValue: string;
+  explicitness: number;
+}
+
+/** One promotable (userId, subject, field) verdict out of the fold. */
+export interface FoldedBelief {
+  userId: string;
+  subject: string;
+  field: string;
+  value: string;
+  /** The winner delta's `from` ('' when unknown). */
+  priorValue: string;
+  validFrom: Date;
+  /** Scenes contributing the WINNING value (distinct, emission order). */
+  sceneIds: string[];
+  /** Distinct conversations behind those scenes — the floor unit. */
+  conversationIds: string[];
+  confidence: number;
+}
+
+export interface BeliefFold {
+  folded: FoldedBelief[];
+  /** Groups the conflict guard refused (ambiguous latest value). */
+  conflicts: Array<{ userId: string; subject: string; field: string; values: string[] }>;
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v.trim() : '');
+
+/**
+ * Pure: group eligible scenes' stateDeltas by (userId, subject, field)
+ * and fold each group to one verdict (latest value wins; scenes ordered
+ * by occurredTo then scene id, so the fold is deterministic). Groups
+ * whose latest timestamp carries two different values are returned as
+ * conflicts (the built-in guard) — never half-promoted.
+ */
+export function foldBeliefGroups(
+  scenes: ReadonlyArray<{ scene: PromotableSceneHead; userId: string }>,
+): BeliefFold {
+  const groups = new Map<
+    string,
+    { userId: string; subject: string; field: string; contributions: BeliefContribution[] }
+  >();
+  for (const { scene, userId } of scenes) {
+    const sceneId = String(scene.id);
+    const conversationId = Array.isArray(scene.conversationIds)
+      ? str(scene.conversationIds[0])
+      : '';
+    // WS-driver datetimes arrive as Date instances; e2e/unit fixtures may
+    // hand ISO strings — accept both, never String(Date) (query_arc lesson).
+    const occurredAt =
+      scene.occurredTo instanceof Date
+        ? scene.occurredTo.getTime()
+        : new Date(String(scene.occurredTo ?? '')).getTime();
+    if (!Number.isFinite(occurredAt)) continue; // unordered scene: unusable
+    const explicitnessRaw = scene.explicitness;
+    const explicitness =
+      typeof explicitnessRaw === 'number' && Number.isFinite(explicitnessRaw)
+        ? Math.min(1, Math.max(0, explicitnessRaw))
+        : DEFAULT_EXPLICITNESS;
+    for (const delta of Array.isArray(scene.stateDeltas) ? scene.stateDeltas : []) {
+      if (typeof delta !== 'object' || delta === null) continue;
+      const d = delta as Record<string, unknown>;
+      const subject = str(d.subject);
+      const field = str(d.field);
+      const value = str(d.to);
+      // A delta without a landing value holds nothing promotable.
+      if (subject === '' || field === '' || value === '') continue;
+      const key = `${userId}\x00${subject}\x00${field}`;
+      let group = groups.get(key);
+      if (!group) {
+        group = { userId, subject, field, contributions: [] };
+        groups.set(key, group);
+      }
+      group.contributions.push({
+        sceneId,
+        conversationId,
+        occurredAt,
+        value,
+        priorValue: str(d.from),
+        explicitness,
+      });
+    }
+  }
+
+  const fold: BeliefFold = { folded: [], conflicts: [] };
+  for (const group of groups.values()) {
+    const ordered = [...group.contributions].sort(
+      (a, b) => a.occurredAt - b.occurredAt || a.sceneId.localeCompare(b.sceneId),
+    );
+    const winner = ordered[ordered.length - 1]!;
+    // Conflict guard: a DIFFERENT value at the winning timestamp means
+    // the batch has no deterministic latest state.
+    const ambiguous = ordered.some(
+      (c) => c.occurredAt === winner.occurredAt && c.value !== winner.value,
+    );
+    if (ambiguous) {
+      fold.conflicts.push({
+        userId: group.userId,
+        subject: group.subject,
+        field: group.field,
+        values: [...new Set(ordered.map((c) => c.value))].sort(),
+      });
+      continue;
+    }
+    const corroborating = ordered.filter((c) => c.value === winner.value);
+    const sceneIds = [...new Set(corroborating.map((c) => c.sceneId))];
+    const conversationIds = [
+      ...new Set(corroborating.map((c) => c.conversationId).filter((c) => c !== '')),
+    ];
+    const meanExplicitness =
+      corroborating.reduce((sum, c) => sum + c.explicitness, 0) / corroborating.length;
+    const confidence = Math.min(
+      CONFIDENCE_CAP,
+      Math.max(
+        CONFIDENCE_FLOOR,
+        meanExplicitness + CORROBORATION_BONUS * Math.max(0, conversationIds.length - 1),
+      ),
+    );
+    fold.folded.push({
+      userId: group.userId,
+      subject: group.subject,
+      field: group.field,
+      value: winner.value,
+      priorValue: winner.priorValue,
+      validFrom: new Date(winner.occurredAt),
+      sceneIds,
+      conversationIds,
+      confidence: Math.round(confidence * 10000) / 10000,
+    });
+  }
+  // Deterministic emission order (stable logs, stable tests).
+  fold.folded.sort(
+    (a, b) =>
+      a.userId.localeCompare(b.userId) ||
+      a.subject.localeCompare(b.subject) ||
+      a.field.localeCompare(b.field),
+  );
+  return fold;
+}
+
+/** Pure: the deterministic statement template (works with no LLM). */
+export function renderBeliefStatement(f: {
+  subject: string;
+  field: string;
+  value: string;
+  priorValue: string;
+}): string {
+  const base = `${f.subject} — ${f.field}: ${f.value}`;
+  const withPrior =
+    f.priorValue !== '' && f.priorValue !== f.value ? `${base} (was: ${f.priorValue})` : base;
+  return withPrior.slice(0, STATEMENT_MAX_CHARS);
+}
+
+/**
+ * Pure: deterministic record-id tail over (userId|subject|field|
+ * revision) — the composer's sceneIdTail idiom. Paired with INSERT
+ * IGNORE it makes every create replay-idempotent, and it enforces
+ * (userId, subject, field, revision) uniqueness in CODE — a compound
+ * UNIQUE index is exactly the 3.2.4 planner trap 0120 avoids.
+ */
+export function beliefIdTail(
+  key: { userId: string; subject: string; field: string },
+  revision: number,
+): string {
+  return createHash('sha256')
+    .update(`${key.userId}\x00${key.subject}\x00${key.field}\x00${revision}`)
+    .digest('hex')
+    .slice(0, 24);
+}
+
+export interface BeliefPromotionResult {
+  /** Enriched scenes of the current version seen by the pass. */
+  scenes: number;
+  /** Scenes that passed the #387 single-user fence into the fold. */
+  eligibleScenes: number;
+  skippedMixedUser: number;
+  /** (subject, field) groups the conflict guard refused. */
+  skippedConflict: number;
+  /** Groups below the SCENES_BELIEF_MIN_SCENES conversation floor. */
+  skippedFloor: number;
+  /** Groups whose winner was not newer than the active belief (stale). */
+  skippedStale: number;
+  beliefsCreated: number;
+  beliefsCorroborated: number;
+  beliefsRevised: number;
+  /** memory_support rows written (0 unless PROVENANCE_SUPPORT_EDGES). */
+  supportEdges: number;
+}
+
+/** Active-belief head read back for the upsert decision. */
+interface ActiveBeliefRow {
+  id: unknown;
+  revision: number;
+  value: string;
+  validFrom: unknown;
+  sourceSceneIds?: unknown;
+  conversationIds?: unknown;
+}
+
+interface BeliefDb {
+  query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T>;
+}
+
+/** The one client surface the synthesis uses (mock-swappable in tests). */
+type ChatCompletionsClient = Pick<OpenAI, 'chat'>;
+
+@Injectable()
+export class BeliefPromotionService {
+  private readonly logger = new Logger(BeliefPromotionService.name);
+  /**
+   * Nullable by contract (createOpenAiClient): no OPENAI_API_KEY ⇒ the
+   * optional synthesis degrades to the template. Tests replace this
+   * field with a scripted stub (mockBeliefSynthesisOpenAi) — the same
+   * seam as SceneEnricherService.openai.
+   */
+  private readonly openai: ChatCompletionsClient | null;
+  private readonly model: string;
+
+  constructor(
+    private readonly surreal: SurrealService,
+    configService: ConfigService,
+    private readonly versions: SceneVersionService,
+  ) {
+    this.openai = createOpenAiClient(configService);
+    this.model = configService.get<string>(
+      'SCENES_BELIEF_MODEL',
+      configService.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini'),
+    );
+  }
+
+  /**
+   * Promote every enriched scene of the CURRENT segmenter version
+   * (optionally one conversation's). Per-group problems degrade to a
+   * loud skip — the pass never throws for one bad group.
+   */
+  async run(
+    companyId: string,
+    opts: { conversationId?: string } = {},
+  ): Promise<BeliefPromotionResult> {
+    const result: BeliefPromotionResult = {
+      scenes: 0,
+      eligibleScenes: 0,
+      skippedMixedUser: 0,
+      skippedConflict: 0,
+      skippedFloor: 0,
+      skippedStale: 0,
+      beliefsCreated: 0,
+      beliefsCorroborated: 0,
+      beliefsRevised: 0,
+      supportEdges: 0,
+    };
+    // Defense in depth: the controller already 404s with the flag off; a
+    // programmatic caller must not write belief rows past a disabled
+    // flag. Off = ZERO queries (returns before the version resolver and
+    // before any db handle) — pinned by unit test.
+    if (!sceneBeliefPromotionEnabled()) return result;
+    // Effective world + knobs resolved ONCE per run (the Drift-3
+    // contract): a mid-run env flip can never mix worlds or floors.
+    const { version } = this.versions.resolve();
+    const promoterVersion = beliefPromoterVersion(version);
+    const floor = sceneBeliefMinScenes();
+    const edgesOn = supportEdgesEnabled();
+    await this.surreal.withCompany(companyId, async (db) => {
+      const [scenes] = await db.query<[PromotableSceneHead[]]>(
+        `SELECT id, userId, userIds, conversationIds, occurredTo, stateDeltas,
+                enrichedMemoryValue.explicitness AS explicitness
+           FROM memory_episode
+          WHERE segmenterVersion = $v AND enrichmentVersion IS NOT NONE` +
+          (opts.conversationId !== undefined ? ` AND conversationIds CONTAINS $conv` : ''),
+        {
+          v: version,
+          ...(opts.conversationId !== undefined ? { conv: opts.conversationId } : {}),
+        },
+      );
+      const eligible: Array<{ scene: PromotableSceneHead; userId: string }> = [];
+      for (const scene of scenes ?? []) {
+        result.scenes += 1;
+        const userId = sceneSingleUser(scene);
+        if (userId === null) {
+          // #387 fail-closed: mixed-user, tenant-global or legacy
+          // (pre-0117 userIds) scenes never feed a belief.
+          result.skippedMixedUser += 1;
+          this.logger.warn(
+            `belief promotion skipped scene ${String(scene.id)}: not single-user ` +
+              `(userIds=${JSON.stringify(scene.userIds ?? null)}) — #387 fence`,
+          );
+          continue;
+        }
+        result.eligibleScenes += 1;
+        eligible.push({ scene, userId });
+      }
+
+      const { folded, conflicts } = foldBeliefGroups(eligible);
+      result.skippedConflict = conflicts.length;
+      for (const c of conflicts) {
+        this.logger.warn(
+          `belief promotion conflict guard: (${c.subject}, ${c.field}) for user ${c.userId} ` +
+            `has irreconcilable in-batch values [${c.values.join(' | ')}] — group skipped`,
+        );
+      }
+
+      for (const belief of folded) {
+        if (floor > 0 && belief.conversationIds.length < floor) {
+          result.skippedFloor += 1;
+          this.logger.debug(
+            `belief promotion floor: (${belief.subject}, ${belief.field}) has ` +
+              `${belief.conversationIds.length} conversation(s) < floor ${floor} — not promoted`,
+          );
+          continue;
+        }
+        await this.upsertBelief({ db, belief, promoterVersion, edgesOn, result });
+      }
+    });
+    this.logger.log(
+      `belief promotion pass: ${result.beliefsCreated} created, ` +
+        `${result.beliefsCorroborated} corroborated, ${result.beliefsRevised} revised ` +
+        `over ${result.eligibleScenes}/${result.scenes} scene(s) ` +
+        `(mixedUser=${result.skippedMixedUser} conflict=${result.skippedConflict} ` +
+        `floor=${result.skippedFloor} stale=${result.skippedStale} edges=${result.supportEdges})`,
+    );
+    return result;
+  }
+
+  /** One (userId, subject, field) verdict: create / corroborate / revise. */
+  private async upsertBelief({
+    db,
+    belief,
+    promoterVersion,
+    edgesOn,
+    result,
+  }: {
+    db: BeliefDb;
+    belief: FoldedBelief;
+    promoterVersion: string;
+    edgesOn: boolean;
+    result: BeliefPromotionResult;
+  }): Promise<void> {
+    const [actives] = await db.query<[ActiveBeliefRow[]]>(
+      `SELECT id, revision, value, validFrom, sourceSceneIds, conversationIds
+         FROM semantic_belief
+        WHERE userId = $u AND subject = $s AND field = $f AND status = 'active'
+        ORDER BY revision DESC`,
+      { u: belief.userId, s: belief.subject, f: belief.field },
+    );
+    const head = (actives ?? [])[0];
+    // Self-heal a crash window (revision created, supersede stamp lost):
+    // every active row below the highest revision is stamped superseded.
+    for (const dangling of (actives ?? []).slice(1)) {
+      this.logger.warn(
+        `belief promotion: repairing dangling active revision ${dangling.revision} ` +
+          `of (${belief.subject}, ${belief.field})`,
+      );
+      await db.query(
+        `UPDATE $id SET status = 'superseded', supersededBy = $winner,
+                        validUntil = $until, updatedAt = time::now()`,
+        {
+          id: new StringRecordId(String(dangling.id)),
+          winner: new StringRecordId(String(head!.id)),
+          until: head!.validFrom,
+        },
+      );
+    }
+
+    if (!head) {
+      await this.createRevision({ db, belief, revision: 1, promoterVersion });
+      await this.stampScenes(db, belief.sceneIds, beliefRecordString(belief, 1));
+      if (edgesOn) {
+        result.supportEdges += await this.writeEdges(db, promoterVersion, [
+          {
+            kind: 'supported_by' as const,
+            pairs: belief.sceneIds.map((s) => ({ in: beliefRecordString(belief, 1), out: s })),
+          },
+        ]);
+      }
+      result.beliefsCreated += 1;
+      return;
+    }
+
+    const headId = String(head.id);
+    // The WS driver returns datetimes as Date instances — never round-trip
+    // through String(Date) (the query_arc lesson).
+    const headValidFrom =
+      head.validFrom instanceof Date
+        ? head.validFrom.getTime()
+        : new Date(String(head.validFrom)).getTime();
+
+    if (head.value === belief.value) {
+      // CORROBORATION — the only in-place update the substrate allows:
+      // counters + provenance union, never value/statement/validFrom.
+      const knownScenes = (Array.isArray(head.sourceSceneIds) ? head.sourceSceneIds : []).map(
+        String,
+      );
+      const knownConvs = (Array.isArray(head.conversationIds) ? head.conversationIds : []).map(
+        String,
+      );
+      const mergedScenes = [...new Set([...knownScenes, ...belief.sceneIds])];
+      const mergedConvs = [...new Set([...knownConvs, ...belief.conversationIds])];
+      const newScenes = belief.sceneIds.filter((s) => !knownScenes.includes(s));
+      if (newScenes.length > 0) {
+        await db.query(
+          `UPDATE $id SET sourceSceneIds = $scenes, conversationIds = $convs,
+                          corroborationCount = $n, conversationCount = $m,
+                          updatedAt = time::now()`,
+          {
+            id: new StringRecordId(headId),
+            scenes: mergedScenes.map((s) => new StringRecordId(s)),
+            convs: mergedConvs,
+            n: mergedScenes.length,
+            m: mergedConvs.length,
+          },
+        );
+        result.beliefsCorroborated += 1;
+      }
+      // Stamps + edges are replay-idempotent (array::union / INSERT
+      // IGNORE) and always re-asserted so a crash between the belief
+      // write and the stamps heals on the next run.
+      await this.stampScenes(db, belief.sceneIds, headId);
+      if (edgesOn) {
+        result.supportEdges += await this.writeEdges(db, promoterVersion, [
+          {
+            kind: 'supported_by' as const,
+            pairs: belief.sceneIds.map((s) => ({ in: headId, out: s })),
+          },
+        ]);
+      }
+      return;
+    }
+
+    // Stale/ambiguous batch: never revise BACKWARD in valid time — a
+    // re-promotion of an older world must not flip-flop the chain.
+    if (!Number.isFinite(headValidFrom) || belief.validFrom.getTime() <= headValidFrom) {
+      result.skippedStale += 1;
+      this.logger.warn(
+        `belief promotion stale guard: (${belief.subject}, ${belief.field}) candidate ` +
+          `'${belief.value}' at ${belief.validFrom.toISOString()} is not newer than the ` +
+          `active revision ${head.revision} ('${head.value}') — group skipped`,
+      );
+      return;
+    }
+
+    // REVISION — supersede chain in code, never in-place: revision N+1
+    // holds the new value; the displaced row gets status/validUntil/
+    // supersededBy stamped. The ACTUAL displaced value beats the delta's
+    // claimed `from` as priorValue.
+    const revision = head.revision + 1;
+    const newId = beliefRecordString(belief, revision);
+    await this.createRevision({
+      db,
+      belief: { ...belief, priorValue: head.value },
+      revision,
+      promoterVersion,
+    });
+    await db.query(
+      `UPDATE $id SET status = 'superseded', supersededBy = $new,
+                      validUntil = $until, updatedAt = time::now()`,
+      {
+        id: new StringRecordId(headId),
+        new: new StringRecordId(newId),
+        until: belief.validFrom,
+      },
+    );
+    await this.stampScenes(db, belief.sceneIds, newId);
+    // The 0106 baselineRef contract: the belief revision the delta was
+    // applied against (NONE for revision 1 — no baseline existed).
+    await db.query(`UPDATE memory_episode SET baselineRef = $baseline WHERE id INSIDE $sceneIds`, {
+      baseline: {
+        belief: headId,
+        revision: head.revision,
+        value: head.value,
+        stampedAt: new Date().toISOString(),
+      },
+      sceneIds: belief.sceneIds.map((s) => new StringRecordId(s)),
+    });
+    if (edgesOn) {
+      result.supportEdges += await this.writeEdges(db, promoterVersion, [
+        // Old belief is contradicted by the new one (the resolver's
+        // loser->winner direction), and the new one derives from it.
+        { kind: 'contradicted_by' as const, pairs: [{ in: headId, out: newId }] },
+        { kind: 'derived_from' as const, pairs: [{ in: newId, out: headId }] },
+        {
+          kind: 'supported_by' as const,
+          pairs: belief.sceneIds.map((s) => ({ in: newId, out: s })),
+        },
+      ]);
+    }
+    result.beliefsRevised += 1;
+  }
+
+  /** INSERT IGNORE one revision row (deterministic id — replay-safe). */
+  private async createRevision({
+    db,
+    belief,
+    revision,
+    promoterVersion,
+  }: {
+    db: BeliefDb;
+    belief: FoldedBelief;
+    revision: number;
+    promoterVersion: string;
+  }): Promise<void> {
+    const statement = await this.composeStatement(belief);
+    await db.query(`INSERT IGNORE INTO semantic_belief $rows`, {
+      rows: [
+        {
+          id: new RecordId('semantic_belief', beliefIdTail(belief, revision)),
+          userId: belief.userId,
+          subject: belief.subject,
+          field: belief.field,
+          value: belief.value,
+          ...(belief.priorValue !== '' ? { priorValue: belief.priorValue } : {}),
+          statement: statement.text,
+          statementSource: statement.source,
+          confidence: belief.confidence,
+          revision,
+          status: 'active',
+          validFrom: belief.validFrom,
+          sourceSceneIds: belief.sceneIds.map((s) => new StringRecordId(s)),
+          conversationIds: belief.conversationIds,
+          corroborationCount: belief.sceneIds.length,
+          conversationCount: belief.conversationIds.length,
+          promoterVersion,
+        },
+      ],
+    });
+  }
+
+  /** consolidatedInto ∪= [belief] on the consumed scenes (idempotent). */
+  private async stampScenes(db: BeliefDb, sceneIds: string[], beliefId: string): Promise<void> {
+    if (sceneIds.length === 0) return;
+    // Primary-key addressed (WHERE id INSIDE explicit list) — immune by
+    // construction to the 3.2.4 secondary-index planner bug class.
+    await db.query(
+      `UPDATE memory_episode
+          SET consolidatedInto = array::union(consolidatedInto ?? [], [$belief])
+        WHERE id INSIDE $sceneIds`,
+      {
+        belief: new StringRecordId(beliefId),
+        sceneIds: sceneIds.map((s) => new StringRecordId(s)),
+      },
+    );
+  }
+
+  /** Shape-validated, deduped, capped, replay-idempotent edge writes. */
+  private async writeEdges(
+    db: BeliefDb,
+    promoterVersion: string,
+    specs: Array<{
+      kind: 'supported_by' | 'contradicted_by' | 'derived_from';
+      pairs: Array<{ in: string; out: string }>;
+    }>,
+  ): Promise<number> {
+    let written = 0;
+    for (const spec of specs) {
+      const { batches, skipped } = buildSupportEdgeBatches({
+        kind: spec.kind,
+        writer: 'belief_promotion',
+        writerVersion: promoterVersion,
+        pairs: spec.pairs,
+      });
+      if (skipped > 0) {
+        this.logger.warn(
+          `belief promotion: ${skipped} malformed ${spec.kind} support-edge pair(s) skipped`,
+        );
+      }
+      for (const batch of batches) {
+        await db.query(`INSERT RELATION IGNORE INTO memory_support $rows`, {
+          rows: batch.map((r) => ({
+            ...r,
+            in: new StringRecordId(r.in),
+            out: new StringRecordId(r.out),
+          })),
+        });
+        written += batch.length;
+      }
+    }
+    return written;
+  }
+
+  /** Statement text: deterministic template, optionally LLM-phrased. */
+  private async composeStatement(
+    belief: FoldedBelief,
+  ): Promise<{ text: string; source: 'template' | 'llm' }> {
+    const template = renderBeliefStatement(belief);
+    if (!sceneBeliefLlmSynthesisEnabled()) return { text: template, source: 'template' };
+    if (!this.openai) {
+      this.logger.warn('belief statement synthesis skipped: no OPENAI_API_KEY configured');
+      return { text: template, source: 'template' };
+    }
+    try {
+      const res = await this.openai.chat.completions.create({
+        model: this.model,
+        ...chatCallParams(this.model, { temperature: 0, visibleCap: SYNTHESIS_VISIBLE_CAP }),
+        messages: [
+          { role: 'system', content: BELIEF_SYNTHESIS_SYSTEM },
+          {
+            role: 'user',
+            content:
+              `subject: ${belief.subject}\nattribute: ${belief.field}\nvalue: ${belief.value}` +
+              (belief.priorValue !== '' && belief.priorValue !== belief.value
+                ? `\nprevious value: ${belief.priorValue}`
+                : ''),
+          },
+        ],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'belief_statement',
+            strict: true,
+            schema: {
+              type: 'object',
+              additionalProperties: false,
+              properties: { statement: { type: 'string' } },
+              required: ['statement'],
+            },
+          },
+        },
+      });
+      const content = res.choices[0]?.message?.content;
+      if (!content) return { text: template, source: 'template' };
+      const parsed: unknown = JSON.parse(content);
+      const raw =
+        typeof parsed === 'object' && parsed !== null
+          ? (parsed as Record<string, unknown>).statement
+          : undefined;
+      const text = typeof raw === 'string' ? raw.replace(/\s+/g, ' ').trim() : '';
+      if (text === '') return { text: template, source: 'template' };
+      return { text: text.slice(0, STATEMENT_MAX_CHARS), source: 'llm' };
+    } catch (e) {
+      // Degrade, never fail: the deterministic fold must not depend on
+      // the optional synthesis (transport error, malformed reply, ...).
+      this.logger.warn(`belief statement synthesis degraded to template: ${(e as Error).message}`);
+      return { text: template, source: 'template' };
+    }
+  }
+}
+
+/** Full record-id string for a folded belief at a given revision. */
+function beliefRecordString(
+  belief: Pick<FoldedBelief, 'userId' | 'subject' | 'field'>,
+  revision: number,
+): string {
+  return `semantic_belief:${beliefIdTail(belief, revision)}`;
+}

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -693,6 +693,41 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Pack memory projections (migration 0110): external candidate submissions may carry scenes/stateDeltas validated against the submitting pack’s manifest memoryModel (sceneSchemas / stateModels), staged as candidate kinds scene/state_delta and projected at commit time into shadow memory_episode rows under segmenterVersion pack:<packId>+<fp> (registry scenes:<packId>; purge via DELETE /scenes/versions/:v). Off = submissions carrying either array are rejected 400, no such candidate row is written, no projection runs — byte-identical. The GDPR forget doc-cascade leg for projected rows runs regardless.',
   },
+  {
+    key: 'SCENES_BELIEF_PROMOTION',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneBeliefPromotionEnabled) by the
+    // admin 404 guard + the promotion service's defensive early return —
+    // never captured in a constructor — so a flip takes effect without
+    // restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Belief promotion (Belief-A, migration 0120): POST /v1/admin/maintenance/scenes/beliefs folds ENRICHED scenes of the current effective segmenter version (stateDeltas/memoryValue/gist, 0118) into the shadow semantic_belief substrate keyed by free-text (subject, field) — supersede-chain revisions, inline sourceSceneIds provenance, consolidatedInto/baselineRef stamps on consumed scenes, optional memory_support mirror under PROVENANCE_SUPPORT_EDGES. Mixed-user/legacy scenes are skipped fail-closed (#387). Off = route 404s, zero queries, no belief row is ever written — byte-identical prod (shadow: no serving path reads the table).',
+  },
+  {
+    key: 'SCENES_BELIEF_MIN_SCENES',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneBeliefMinScenes) once per
+    // promotion run — never captured in a constructor — runtime-mutable.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Belief promotion corroboration floor (#377 promotion-floor idiom): promote a (subject, field) group only when its winning value is corroborated by scenes from at least this many DISTINCT CONVERSATIONS. Non-negative integer; 0 (default) = floor off.',
+  },
+  {
+    key: 'SCENES_BELIEF_LLM_SYNTHESIS',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneBeliefLlmSynthesisEnabled) per
+    // belief write — never captured in a constructor — runtime-mutable.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Belief promotion statement synthesis: ONE structured LLM call per belief create/revise phrasing the statement text (statementSource llm); any failure degrades to the deterministic template — the fold never depends on the model. Off = no LLM call ever runs, every statement is the deterministic template (statementSource template).',
+  },
   // ── Multilingual (Tier 1, migration 0100) ───────────
   {
     key: 'MULTILINGUAL_LANG_ATTRIBUTION',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -245,6 +245,8 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // validation catches the typo before it silently reads as a default.
   positiveInt(env, 'SCENES_MAX_TURNS', errors);
   floatInRange(env, 'SCENES_TOPIC_MIN_COSINE', -1, 1, errors);
+  // Belief promotion floor (Belief-A, migration 0120): 0 = off.
+  nonNegativeInt(env, 'SCENES_BELIEF_MIN_SCENES', errors);
 
   // ── Evidence substrate (Brain v2.1 M1, migration 0109) ─────────────
   // The write seam clamps bad values to the default at read time; boot
@@ -923,6 +925,20 @@ const KNOWN_BOOLEAN_FLAGS = [
   // PACK_ sits off the ENGINE flag budget (shadow-substrate writer, the
   // SCENES_/EVIDENCE_ precedent).
   'PACK_MEMORY_PROJECTIONS_ENABLED',
+  // Belief promotion (Belief-A, migration 0120): fold ENRICHED scenes of
+  // the current effective segmenter version into the shadow
+  // semantic_belief substrate via POST /v1/admin/maintenance/scenes/
+  // beliefs. Default off ⇒ the route 404s and the service returns with
+  // ZERO queries — no semantic_belief row is ever written
+  // (byte-identical prod; shadow even when on — no serving path reads
+  // the table). The corroboration floor (SCENES_BELIEF_MIN_SCENES) is an
+  // int, the model knob (SCENES_BELIEF_MODEL) a string — not booleans.
+  'SCENES_BELIEF_PROMOTION',
+  // Belief statement synthesis (Belief-A): ONE structured LLM call per
+  // belief create/revise to phrase the statement; any failure degrades
+  // to the deterministic template. Default off ⇒ no LLM call ever runs —
+  // every statement is the deterministic template.
+  'SCENES_BELIEF_LLM_SYNTHESIS',
   // Evidence substrate master (Brain v2.1 M1, migration 0109): the
   // EvidenceStoreService writers for evidence_asset / evidence_fragment /
   // derived_representation. Default off ⇒ every writer 503s and no row is

--- a/src/common/scene-flags.ts
+++ b/src/common/scene-flags.ts
@@ -115,6 +115,58 @@ export function sceneVersionFingerprintEnabled(): boolean {
   return envFlagEnabled(process.env.SCENES_VERSION_FINGERPRINT);
 }
 
+/**
+ * Scenes belief-promotion flag — SCENES_BELIEF_PROMOTION (Belief-A).
+ *
+ * When on, the admin promotion surface (POST
+ * /v1/admin/maintenance/scenes/beliefs) folds ENRICHED scenes of the
+ * current effective segmenter version (stateDeltas / memoryValue / gist,
+ * migration 0118) into the shadow semantic_belief substrate (migration
+ * 0120), keyed by free-text (subject, field). The env read lives here in
+ * the common layer, NOT inside the engine dirs (engine-gates S5.2). Read
+ * at call time so a flip is runtime-mutable. Default off ⇒ the admin
+ * route 404s and the promotion service returns without a single query —
+ * NO semantic_belief row is ever written, byte-identical prod (shadow
+ * substrate: no serving path reads the table even when on). SCENES_
+ * family sits off the ENGINE flag budget by design.
+ */
+export function sceneBeliefPromotionEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_BELIEF_PROMOTION);
+}
+
+/**
+ * Scenes belief LLM-synthesis flag — SCENES_BELIEF_LLM_SYNTHESIS
+ * (Belief-A). When on AND an OpenAI key is configured, the promotion
+ * pass makes ONE structured LLM call per belief WRITE (create/revise —
+ * never for a pure corroboration update) to phrase the `statement` text;
+ * any failure degrades to the deterministic template (statementSource
+ * 'template'), never fails the write. The env read lives here in the
+ * common layer (engine-gates S5.2); read at call time so a flip is
+ * runtime-mutable. Default off ⇒ NO LLM call is ever made and every
+ * statement is the deterministic template — the fold works identically.
+ */
+export function sceneBeliefLlmSynthesisEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_BELIEF_LLM_SYNTHESIS);
+}
+
+/**
+ * Belief corroboration floor (SCENES_BELIEF_MIN_SCENES): promote a
+ * (subject, field) group only when its winning value is corroborated by
+ * scenes from at least this many DISTINCT CONVERSATIONS (the #377
+ * promotion-floor idiom; the knob keeps the family's SCENES_ naming —
+ * the unit is distinct conversations, the anti-single-mention lever).
+ * 0 = floor off (default): every folded group promotes. A non-boolean
+ * knob resolved here in the common layer (engine-gates S5.2); read at
+ * call time so a change is runtime-mutable. Must be a non-negative
+ * integer; unset, blank, or invalid → 0.
+ */
+export function sceneBeliefMinScenes(): number {
+  const raw = process.env.SCENES_BELIEF_MIN_SCENES;
+  if (raw === undefined || raw.trim() === '') return 0;
+  const v = Number(raw);
+  return Number.isInteger(v) && v >= 0 ? v : 0;
+}
+
 /** Default hard cap on turns per scene (Brain v2 PR1). */
 const DEFAULT_MAX_TURNS = 40;
 

--- a/src/common/support-edges.ts
+++ b/src/common/support-edges.ts
@@ -41,6 +41,7 @@ export const SUPPORT_EDGE_WRITERS = [
   'promotion_runner',
   'compaction_runner',
   'recompose',
+  'belief_promotion',
 ] as const;
 export type SupportEdgeWriter = (typeof SUPPORT_EDGE_WRITERS)[number];
 
@@ -66,13 +67,15 @@ export interface SupportEdgeRow {
  * ONE prefix vocabulary; the two support-graph-native tables are
  * matched directly. 'unknown' is never a guess.
  */
-export type SupportTargetClass = 'fact' | 'scene' | 'episode' | 'fragment' | 'asset' | 'unknown';
+export type SupportTargetClass =
+  'fact' | 'belief' | 'scene' | 'episode' | 'fragment' | 'asset' | 'unknown';
 
 export function classifySupportTarget(raw: string): SupportTargetClass {
   const ref = parseRecordRef(raw);
   if (ref !== null && ref.kind !== 'external') return ref.kind;
   if (raw.startsWith('knowledge_fact:')) return 'fact';
   if (raw.startsWith('memory_episode:')) return 'scene';
+  if (raw.startsWith('semantic_belief:')) return 'belief';
   return 'unknown';
 }
 
@@ -81,16 +84,23 @@ export function classifySupportTarget(raw: string): SupportTargetClass {
  * FROM/TO types one polymorphic RELATION table cannot carry — 0116
  * header). Returns a boolean verdict: writers SKIP invalid rows with a
  * warn, never throw. reconstructed_from is always false (reserved).
+ *
+ * Belief edges (0120, writer 'belief_promotion') follow the SAME
+ * direction semantics with `in` = semantic_belief: supported_by
+ * belief->scene mirrors the fact rule; contradicted_by / derived_from
+ * pair a belief ONLY with another belief (revision chains never cross
+ * into the claim plane — the SemanticBelief/Claim separation).
  */
 export function assertEdgeShape(kind: SupportEdgeKind, inId: string, outId: string): boolean {
-  if (classifySupportTarget(inId) !== 'fact') return false;
+  const inClass = classifySupportTarget(inId);
+  if (inClass !== 'fact' && inClass !== 'belief') return false;
   const out = classifySupportTarget(outId);
   switch (kind) {
     case 'supported_by':
       return out === 'scene';
     case 'contradicted_by':
     case 'derived_from':
-      return out === 'fact';
+      return out === inClass;
     case 'reconstructed_from':
       return false;
   }

--- a/src/db/migrations/0120_semantic_belief.surql
+++ b/src/db/migrations/0120_semantic_belief.surql
@@ -1,0 +1,131 @@
+-- 0120: semantic_belief — the belief substrate (Belief-A): distilled
+-- (subject, field) = value state promoted out of enriched scenes
+-- (memory_episode stateDeltas, migration 0118), SEPARATE from Claim
+-- (knowledge_fact).
+--
+-- WHY A NEW TABLE. A belief is what the brain currently HOLDS about a
+-- free-text (subject, field) key — folded from one or more scenes — not
+-- a single-source claim about a resolved knowledge_entity. A
+-- beliefKind-on-knowledge_fact discriminator was REJECTED: the fact
+-- table's key fields are record<knowledge_entity> (scene stateDeltas
+-- carry FREE-TEXT subject/field keys, unresolved by design), and a
+-- discriminator would leak beliefs into every serving lane that reads
+-- knowledge_fact. fn::resolve_fact reuse was REJECTED for the same
+-- reason — its conflict machinery is claim-specific (entity-keyed,
+-- source-trust duel semantics).
+--
+-- SHADOW (0106 doctrine). Nothing on the serving path reads this table.
+-- The only writer is the promotion pass (belief-promotion.service.ts,
+-- SCENES_BELIEF_PROMOTION, default off) — prod is byte-identical with
+-- the flag off, and serving-identical with it on (a read API is a later
+-- PR). Derived state: rebuildable from enriched scenes at any time.
+--
+-- BITEMPORAL VOCABULARY. Carries the knowledge_fact vocabulary —
+-- validFrom / validUntil / status / supersededBy — plus an explicit
+-- `revision` int: a value change NEVER updates in place; it creates
+-- revision N+1 and stamps the old row superseded (supersede chain in
+-- code, belief-promotion.service.ts). In-place updates are allowed ONLY
+-- for the corroboration counters (sourceSceneIds / conversationIds /
+-- corroborationCount / conversationCount / updatedAt). The status enum
+-- is the belief-relevant SUBSET of the 0047 fact vocabulary.
+--
+-- PROVENANCE. sourceSceneIds is the INLINE canonical provenance — it
+-- survives PROVENANCE_SUPPORT_EDGES being off; the typed memory_support
+-- edges (supported_by belief->scene, contradicted_by / derived_from
+-- belief->belief, writer 'belief_promotion') are the ADDITIVE mirror,
+-- written only while that flag is on.
+--
+-- INDEXES: single-field ONLY, deliberately (the 0109/0111 rule): any
+-- compound index puts its fields into the 3.2.4 planner class where
+-- `DELETE semantic_belief WHERE <field> ...` silently deletes ZERO rows
+-- (reproduced on memory_support during the 0116 smoke). Every deleter
+-- MUST use the two-step idiom regardless: LET $ids = (SELECT VALUE id
+-- ...); DELETE $ids; — the audit-p1-guards spec pins a repo-wide
+-- `DELETE semantic_belief WHERE` prohibition. (userId, subject, field,
+-- revision) uniqueness is code-enforced via deterministic record ids —
+-- a compound UNIQUE index is exactly the trap being avoided.
+--
+-- NO CHANGEFEED and NO DEFINE EVENT (the 0053/0107 separation
+-- rationale): belief statements quote-derive from scene enrichment, and
+-- an erased user's beliefs must not stay readable in a feed.
+--
+-- GDPR: BOTH forget cascades erase beliefs + their memory_support edges
+-- UNCONDITIONALLY (rows written while SCENES_BELIEF_PROMOTION /
+-- PROVENANCE_SUPPORT_EDGES were on must stay erasable after they are
+-- off — the EVIDENCE_SUBSTRATE_ENABLED precedent). user-forget erases
+-- by userId (a belief always carries the single-user scope of its
+-- scenes — the promotion SKIPS mixed-user/legacy scenes fail-closed,
+-- #387 userIds semantics); entity-forget erases by reference through
+-- the dying scenes (sourceSceneIds).
+
+DEFINE TABLE IF NOT EXISTS semantic_belief SCHEMAFULL;
+
+-- Single-user scope, inherited from the promoted scenes (never NONE:
+-- mixed-user / legacy-userIds scene groups are skipped fail-closed).
+DEFINE FIELD IF NOT EXISTS userId ON semantic_belief TYPE string;
+
+-- FREE-TEXT keys from scene stateDeltas ({subject, field, from, to}) —
+-- deliberately NOT record<knowledge_entity> (see WHY A NEW TABLE).
+DEFINE FIELD IF NOT EXISTS subject ON semantic_belief TYPE string;
+DEFINE FIELD IF NOT EXISTS field ON semantic_belief TYPE string;
+
+-- Value payload: the held value, the value it displaced (the delta's
+-- `from`, '' when unknown), and the rendered statement. statementSource
+-- names the renderer: 'template' (deterministic fold) or 'llm'
+-- (SCENES_BELIEF_LLM_SYNTHESIS — optional, degrade-to-template).
+DEFINE FIELD IF NOT EXISTS value ON semantic_belief TYPE string;
+DEFINE FIELD IF NOT EXISTS priorValue ON semantic_belief TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS statement ON semantic_belief TYPE string;
+DEFINE FIELD IF NOT EXISTS statementSource ON semantic_belief TYPE string
+  ASSERT $value INSIDE ['template', 'llm'];
+
+DEFINE FIELD IF NOT EXISTS confidence ON semantic_belief TYPE float
+  ASSERT $value >= 0 AND $value <= 1;
+
+-- Bitemporal + revision chain (the 0047 vocabulary subset).
+DEFINE FIELD IF NOT EXISTS revision ON semantic_belief TYPE int
+  ASSERT $value >= 1;
+DEFINE FIELD IF NOT EXISTS status ON semantic_belief TYPE string DEFAULT 'active'
+  ASSERT $value INSIDE ['active', 'superseded'];
+DEFINE FIELD IF NOT EXISTS supersededBy ON semantic_belief TYPE option<record<semantic_belief>>;
+DEFINE FIELD IF NOT EXISTS validFrom ON semantic_belief TYPE datetime;
+DEFINE FIELD IF NOT EXISTS validUntil ON semantic_belief TYPE option<datetime>;
+
+-- Inline canonical provenance + corroboration counters. Record refs may
+-- dangle after a scene-world purge (the source.episodeIds precedent) —
+-- the GDPR cascades resolve dying scenes by these stored refs.
+DEFINE FIELD IF NOT EXISTS sourceSceneIds ON semantic_belief TYPE array<record<memory_episode>>;
+DEFINE FIELD IF NOT EXISTS conversationIds ON semantic_belief TYPE array<string>;
+DEFINE FIELD IF NOT EXISTS corroborationCount ON semantic_belief TYPE int DEFAULT 1;
+DEFINE FIELD IF NOT EXISTS conversationCount ON semantic_belief TYPE int DEFAULT 1;
+
+-- Which promoter + which scene world produced this row (the enricher's
+-- readable-composite idiom: promoter version | effective segmenter
+-- version — under SCENES_VERSION_FINGERPRINT the fingerprinted string).
+DEFINE FIELD IF NOT EXISTS promoterVersion ON semantic_belief TYPE string;
+
+DEFINE FIELD IF NOT EXISTS createdAt ON semantic_belief TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS updatedAt ON semantic_belief TYPE datetime DEFAULT time::now();
+
+-- Single-field indexes ONLY — see the header's 3.2.4 planner rationale.
+DEFINE INDEX IF NOT EXISTS belief_user_idx ON semantic_belief FIELDS userId;
+DEFINE INDEX IF NOT EXISTS belief_subject_idx ON semantic_belief FIELDS subject;
+DEFINE INDEX IF NOT EXISTS belief_status_idx ON semantic_belief FIELDS status;
+
+-- Widen the 0116 memory_support writer enum with the promotion pass
+-- (DEFINE FIELD OVERWRITE — the 0047/0105 precedent; existing rows all
+-- carry values inside the widened list, so this is purely additive).
+DEFINE FIELD OVERWRITE writer ON memory_support TYPE string
+  ASSERT $value INSIDE ['scene_backlink', 'fact_resolver', 'promotion_runner', 'compaction_runner', 'recompose', 'belief_promotion'];
+
+-- Fulfil the 0106 consolidation-trail contract: consolidatedInto was
+-- promised to PR2+ as record<knowledge_fact>, but the column was NEVER
+-- written (verified — no writer exists) and beliefs, not facts, are what
+-- scenes consolidate into first. Widen to a generic record array so it
+-- can hold semantic_belief refs (and knowledge_fact refs later) —
+-- OVERWRITE on a never-written column is data-safe by construction.
+DEFINE FIELD OVERWRITE consolidatedInto ON memory_episode TYPE option<array<record>>;
+
+-- GDPR tombstone counter (0080 idiom): beliefs erased by an entity
+-- forget (scene-mediated — see the header's GDPR paragraph).
+DEFINE FIELD IF NOT EXISTS beliefsDeleted ON forgotten_entity TYPE option<int>;

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -66,6 +66,11 @@ export interface ForgetResult {
   episodesDeleted: number;
   /** Rebuildable segment projection rows quoting those turns. */
   segmentsDeleted: number;
+  /**
+   * Semantic beliefs (0120) grounded in scenes dying with those turns —
+   * erased scene-mediated (a belief's sourceSceneIds are the linkage).
+   */
+  beliefsDeleted: number;
   forgottenAt: string;
 }
 

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -32,6 +32,7 @@ interface ForgottenTombstoneRow {
   auditEventsDeleted?: number;
   episodesDeleted?: number;
   segmentsDeleted?: number;
+  beliefsDeleted?: number;
   forgottenAt: string | Date;
 }
 
@@ -40,6 +41,7 @@ interface ForgetTxResult {
   auditEventsDeleted: number;
   episodesDeleted: number;
   segmentsDeleted: number;
+  beliefsDeleted: number;
   tombstone: { id: unknown; entityIdHash: string } | null;
 }
 
@@ -284,6 +286,19 @@ export class EntityForgetService {
           `LET $sceneMemberIds = (SELECT VALUE id FROM memory_episode_member WHERE in INSIDE $sceneIds)`,
         );
         tx.add(`DELETE $sceneMemberIds`);
+        // Semantic beliefs (0120): a belief grounded in a dying scene
+        // goes with it (erasure wins over retention — the mixed-subject
+        // scene rule carries to what was distilled FROM the scene).
+        // sourceSceneIds holds record refs as stored VALUES, so the
+        // match works before or after the scene rows die; collected here
+        // so the belief-side memory_support edges join $supIds below.
+        // Two-step by-ids (0120 pins a repo-wide `DELETE semantic_belief
+        // WHERE` prohibition — the 3.2.4 planner class). Runs
+        // UNCONDITIONALLY (the EVIDENCE_SUBSTRATE_ENABLED precedent).
+        tx.add(
+          `LET $beliefIds = (SELECT VALUE id FROM semantic_belief
+             WHERE sourceSceneIds CONTAINSANY $sceneIds)`,
+        );
         tx.add(`LET $scenesDel = (DELETE memory_episode WHERE id INSIDE $sceneIds RETURN BEFORE)`);
         // Typed support graph (0116): every memory_support edge touching
         // this entity's facts (either endpoint) or a dying scene (edge
@@ -301,9 +316,13 @@ export class EntityForgetService {
         tx.add(`LET $entFactIds = (SELECT VALUE id FROM knowledge_fact WHERE entityId = $ent)`);
         tx.add(
           `LET $supIds = (SELECT VALUE id FROM memory_support
-             WHERE in INSIDE $entFactIds OR out INSIDE $entFactIds OR out INSIDE $sceneIds)`,
+             WHERE in INSIDE $entFactIds OR out INSIDE $entFactIds OR out INSIDE $sceneIds
+                OR in INSIDE $beliefIds OR out INSIDE $beliefIds)`,
         );
         tx.add(`DELETE $supIds`);
+        // Belief rows go AFTER their edges (dependency-order reading; the
+        // pre-collected $beliefIds carry the erase either way).
+        tx.add(`LET $beliefsDel = (DELETE $beliefIds RETURN BEFORE)`);
         // 0107 outcome telemetry: stragglers written after the pre-tx
         // bulk sweep, plus the one-row-per-subject rollup (small enough
         // to live inside the tx). Uncounted in txRecordCount, like
@@ -399,6 +418,7 @@ export class EntityForgetService {
             segmentsDeleted: array::len($segs),
             scenesDeleted: array::len($scenesDel),
             purgedDocScenes: array::len($docScenesDel),
+            beliefsDeleted: array::len($beliefsDel),
             purgedSourceDocs: array::len($docsDel),
             purgedSourceChunks: $purgedSourceChunks,
             purgedCandidates: array::len($candDel) + array::len($sweepDel),
@@ -410,6 +430,7 @@ export class EntityForgetService {
             auditEventsDeleted: array::len($audit),
             episodesDeleted: array::len($epsDel),
             segmentsDeleted: array::len($segs),
+            beliefsDeleted: array::len($beliefsDel),
             tombstone: $tomb[0]
           }`);
       });
@@ -419,28 +440,16 @@ export class EntityForgetService {
       if (!txResult?.tombstone) {
         throw new Error('entity forget: transaction returned no tombstone row');
       }
-      const auditEventsDeleted = txResult.auditEventsDeleted ?? 0;
-      const episodesDeleted = txResult.episodesDeleted ?? 0;
-      const segmentsDeleted = txResult.segmentsDeleted ?? 0;
-
-      this.logger.warn(
-        `[knowledge.entity.forgotten] companyId=${companyId} hash=${entityIdHash} ` +
-          `factsDeleted=${factsDeleted} edgesDeleted=${edgesDeleted} ` +
-          `auditEventsDeleted=${auditEventsDeleted} ` +
-          `episodesDeleted=${episodesDeleted} segmentsDeleted=${segmentsDeleted} ` +
-          `reason=${dto.reason} requestId=${dto.requestId} ` +
-          `by=${actorKeyHash ?? 'unknown'}`,
-      );
-
-      return {
+      return this.finishForgetResult({
+        companyId,
         entityIdHash,
+        dto,
+        actorKeyHash,
         factsDeleted,
         edgesDeleted,
-        auditEventsDeleted,
-        episodesDeleted,
-        segmentsDeleted,
-        forgottenAt: forgottenAt.toISOString(),
-      } satisfies ForgetResult;
+        txResult,
+        forgottenAt,
+      });
     });
 
     // Best-effort: drop the in-process embedder cache so the forgotten
@@ -486,6 +495,58 @@ export class EntityForgetService {
   }
 
   /**
+   * Committed-erase epilogue: fold the transaction's RETURN counters
+   * with the pre-collected ones into the wire result + the audit log
+   * line (extracted from forget() for the function-size budget only —
+   * no behavior of its own).
+   */
+  private finishForgetResult({
+    companyId,
+    entityIdHash,
+    dto,
+    actorKeyHash,
+    factsDeleted,
+    edgesDeleted,
+    txResult,
+    forgottenAt,
+  }: {
+    companyId: string;
+    entityIdHash: string;
+    dto: ForgetOptions['dto'];
+    actorKeyHash: ForgetOptions['actorKeyHash'];
+    factsDeleted: number;
+    edgesDeleted: number;
+    txResult: ForgetTxResult;
+    forgottenAt: Date;
+  }): ForgetResult {
+    const auditEventsDeleted = txResult.auditEventsDeleted ?? 0;
+    const episodesDeleted = txResult.episodesDeleted ?? 0;
+    const segmentsDeleted = txResult.segmentsDeleted ?? 0;
+    const beliefsDeleted = txResult.beliefsDeleted ?? 0;
+
+    this.logger.warn(
+      `[knowledge.entity.forgotten] companyId=${companyId} hash=${entityIdHash} ` +
+        `factsDeleted=${factsDeleted} edgesDeleted=${edgesDeleted} ` +
+        `auditEventsDeleted=${auditEventsDeleted} ` +
+        `episodesDeleted=${episodesDeleted} segmentsDeleted=${segmentsDeleted} ` +
+        `beliefsDeleted=${beliefsDeleted} ` +
+        `reason=${dto.reason} requestId=${dto.requestId} ` +
+        `by=${actorKeyHash ?? 'unknown'}`,
+    );
+
+    return {
+      entityIdHash,
+      factsDeleted,
+      edgesDeleted,
+      auditEventsDeleted,
+      episodesDeleted,
+      segmentsDeleted,
+      beliefsDeleted,
+      forgottenAt: forgottenAt.toISOString(),
+    } satisfies ForgetResult;
+  }
+
+  /**
    * Idempotent retry (R4). The whole erase is atomic, so a failed or
    * partial attempt left NO tombstone — only a fully-committed erase is
    * visible here. A tombstone matching BOTH this requestId AND this
@@ -501,7 +562,7 @@ export class EntityForgetService {
     const prior = await queryFirst<ForgottenTombstoneRow>(
       db,
       `SELECT entityIdHash, factsDeleted, edgesDeleted, auditEventsDeleted,
-              episodesDeleted, segmentsDeleted, forgottenAt
+              episodesDeleted, segmentsDeleted, beliefsDeleted, forgottenAt
          FROM forgotten_entity
         WHERE requestId = $requestId AND entityIdHash = $hash
         LIMIT 1`,
@@ -519,6 +580,7 @@ export class EntityForgetService {
       auditEventsDeleted: prior.auditEventsDeleted ?? 0,
       episodesDeleted: prior.episodesDeleted ?? 0,
       segmentsDeleted: prior.segmentsDeleted ?? 0,
+      beliefsDeleted: prior.beliefsDeleted ?? 0,
       forgottenAt: new Date(prior.forgottenAt).toISOString(),
     } satisfies ForgetResult;
   }
@@ -559,8 +621,11 @@ export class EntityForgetService {
    * L0 fan-out of the erase for the transaction-size guard: segments that
    * quote the dying episodes (audit W1 #13) PLUS — scenes, 0106 — the
    * membership rows of those episodes and the distinct scene rows they
-   * resolve to. All of these join the same single transaction, so they
-   * count toward FORGET_MAX_TX_RECORDS BEFORE any mutation.
+   * resolve to, PLUS — beliefs, 0120 — the semantic_belief rows grounded
+   * in those scenes (content-bearing statement text, so they COUNT,
+   * unlike the exempt content-free bookkeeping tables). All of these
+   * join the same single transaction, so they count toward
+   * FORGET_MAX_TX_RECORDS BEFORE any mutation.
    */
   private async countL0FanOut(
     db: Parameters<Parameters<SurrealService['withCompany']>[1]>[0],
@@ -582,8 +647,19 @@ export class EntityForgetService {
       `SELECT in FROM memory_episode_member WHERE out INSIDE $eps`,
       { eps: episodeRefs },
     );
-    const sceneCount = new Set(sceneIdRows.map((r) => String(r.in))).size;
-    return (segCountRow?.count ?? 0) + (sceneMemberCountRow?.count ?? 0) + sceneCount;
+    const sceneIds = [...new Set(sceneIdRows.map((r) => String(r.in)))];
+    let beliefCount = 0;
+    if (sceneIds.length > 0) {
+      const beliefCountRow = await queryFirst<{ count: number }>(
+        db,
+        `SELECT count() FROM semantic_belief WHERE sourceSceneIds CONTAINSANY $scenes GROUP ALL`,
+        { scenes: sceneIds.map((id) => new StringRecordId(id)) },
+      );
+      beliefCount = beliefCountRow?.count ?? 0;
+    }
+    return (
+      (segCountRow?.count ?? 0) + (sceneMemberCountRow?.count ?? 0) + sceneIds.length + beliefCount
+    );
   }
 
   /**

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -52,6 +52,8 @@ export interface UserForgetResult {
   entitiesDeleted: number;
   edgesDeleted: number;
   auditEventsDeleted: number;
+  /** Semantic beliefs (0120): promoted belief rows erased with the user. */
+  beliefsDeleted: number;
   /** Evidence substrate (0109): content-bearing rows erased with the user. */
   evidenceAssetsDeleted: number;
   evidenceFragmentsDeleted: number;
@@ -282,16 +284,23 @@ export class UserForgetService {
       }
       await db.query(`DELETE memory_episode WHERE userId = $u`, { u: userId });
 
+      // Semantic beliefs (0120): ids pre-collected here so the
+      // belief-side memory_support edges join the subject list below
+      // BEFORE the rows die — see collectBeliefIds.
+      const beliefIds = await this.collectBeliefIds(db, userId, supportSceneIds);
+
       // Typed support graph (0116): erase every memory_support edge
-      // touching the user's facts (either endpoint) or a dying scene
-      // (edge target). Runs UNCONDITIONALLY — rows written while
+      // touching the user's facts (either endpoint), a dying scene
+      // (edge target) or a dying belief (0120 edges: supported_by /
+      // contradicted_by / derived_from with a belief endpoint). Runs
+      // UNCONDITIONALLY — rows written while
       // PROVENANCE_SUPPORT_EDGES was on must stay erasable after it is
       // off (the EVIDENCE_SUBSTRATE_ENABLED precedent). Two-step
       // (SELECT ids → DELETE $ids) MANDATORY: `in` is covered by the
       // COMPOUND support_edge_uq index — `DELETE memory_support WHERE
       // in INSIDE …` is the reproduced 3.2.4 silent planner no-op (OK,
       // zero rows) while the same WHERE in a SELECT matches fine.
-      const supportSubjects = [...factIds, ...new Set(supportSceneIds)].map(
+      const supportSubjects = [...factIds, ...new Set(supportSceneIds), ...beliefIds].map(
         (id) => new StringRecordId(id),
       );
       if (supportSubjects.length > 0) {
@@ -302,6 +311,10 @@ export class UserForgetService {
           { subjects: supportSubjects },
         );
       }
+
+      // Belief rows go AFTER their edges (the edge SELECT above needs no
+      // live row, but the order keeps the dependency reading honest).
+      await this.eraseBeliefRows(db, beliefIds);
 
       // Evidence substrate (0109) — see eraseEvidenceRows.
       const { evidenceAssetsDeleted, evidenceFragmentsDeleted, representationsDeleted } =
@@ -327,6 +340,7 @@ export class UserForgetService {
         entitiesDeleted: entityIds.length,
         edgesDeleted: edgeRecordIds.length,
         auditEventsDeleted,
+        beliefsDeleted: beliefIds.length,
         evidenceAssetsDeleted,
         evidenceFragmentsDeleted,
         representationsDeleted,
@@ -336,11 +350,53 @@ export class UserForgetService {
         purgedIndexerRuns: docRows.indexerRuns,
       };
       this.logger.log(
-        `user forget ${companyId}/${userId}: facts=${result.factsDeleted} entities=${result.entitiesDeleted} edges=${result.edgesDeleted} audit=${result.auditEventsDeleted} ` +
+        `user forget ${companyId}/${userId}: facts=${result.factsDeleted} entities=${result.entitiesDeleted} edges=${result.edgesDeleted} audit=${result.auditEventsDeleted} beliefs=${result.beliefsDeleted} ` +
           `evidenceAssets=${result.evidenceAssetsDeleted} evidenceFragments=${result.evidenceFragmentsDeleted} representations=${result.representationsDeleted} ` +
           `docs=${result.purgedSourceDocs} chunks=${result.purgedSourceChunks} candidates=${result.purgedCandidates} indexerRuns=${result.purgedIndexerRuns}`,
       );
       return result;
+    });
+  }
+
+  /**
+   * Semantic beliefs (0120): a belief ALWAYS carries the single-user
+   * scope of its scenes (the promotion skips mixed-user/legacy scene
+   * groups fail-closed, #387), so the userId leg is the primary erase;
+   * the sourceSceneIds leg defensively catches any belief referencing a
+   * scene dying in this cascade (erasure wins over retention —
+   * CONTAINSANY over an empty ref list matches nothing, so the userId
+   * leg carries a scene-less cascade). Runs UNCONDITIONALLY — rows
+   * written while SCENES_BELIEF_PROMOTION was on must stay erasable
+   * after it is off (the EVIDENCE_SUBSTRATE_ENABLED precedent).
+   */
+  private async collectBeliefIds(
+    db: { query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T> },
+    userId: string,
+    sceneIds: string[],
+  ): Promise<string[]> {
+    const [rows] = await db.query<[unknown[]]>(
+      `SELECT VALUE id FROM semantic_belief
+        WHERE userId = $u OR sourceSceneIds CONTAINSANY $scenes`,
+      {
+        u: userId,
+        scenes: [...new Set(sceneIds)].map((id) => new StringRecordId(id)),
+      },
+    );
+    return ((rows as unknown[]) ?? []).map(String);
+  }
+
+  /**
+   * Two-step leg of the belief erase (0120 pins a repo-wide
+   * `DELETE semantic_belief WHERE` prohibition — the 3.2.4 planner
+   * class): the ids were pre-collected by collectBeliefIds.
+   */
+  private async eraseBeliefRows(
+    db: { query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T> },
+    beliefIds: string[],
+  ): Promise<void> {
+    if (beliefIds.length === 0) return;
+    await db.query(`DELETE $ids`, {
+      ids: beliefIds.map((id) => new StringRecordId(id)),
     });
   }
 

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -686,6 +686,114 @@ describe('JobRunService.finish ownership guard', () => {
   });
 });
 
+describe('0120_semantic_belief (belief substrate)', () => {
+  const sql = readFileSync(join(MIGRATIONS, '0120_semantic_belief.surql'), 'utf8');
+
+  it.each([
+    ['belief_user_idx', 'semantic_belief', 'userId'],
+    ['belief_subject_idx', 'semantic_belief', 'subject'],
+    ['belief_status_idx', 'semantic_belief', 'status'],
+  ])('defines %s on %s(%s)', (name, table, fields) => {
+    expect(sql).toContain(`DEFINE INDEX IF NOT EXISTS ${name} ON ${table} FIELDS ${fields};`);
+  });
+
+  it('every index is SINGLE-FIELD (the 3.2.4 planner rule)', () => {
+    // A compound index would put its fields into the DELETE-WHERE
+    // planner no-op class (reproduced on memory_support during the 0116
+    // smoke) — 0120 commits to single-field indexes only;
+    // (userId, subject, field, revision) uniqueness is code-enforced via
+    // deterministic record ids.
+    const defs = sql.match(/DEFINE INDEX[^;]+;/g) ?? [];
+    expect(defs.length).toBeGreaterThan(0);
+    for (const def of defs) {
+      const fields = /FIELDS ([^;]+);/.exec(def)?.[1] ?? '';
+      expect(fields).not.toContain(',');
+    }
+  });
+
+  it('deliberately defines NO changefeed and NO event', () => {
+    // The 0053/0107 separation rationale: belief statements
+    // quote-derive from scene enrichment, and an erased user's beliefs
+    // must not stay readable in a feed. The header EXPLAINS the absence
+    // in prose, so judge only non-comment lines.
+    const code = sql
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('--'))
+      .join('\n');
+    expect(code).not.toMatch(/CHANGEFEED/);
+    expect(code).not.toMatch(/DEFINE EVENT/);
+  });
+
+  it('widens the 0116 writer enum with belief_promotion via OVERWRITE', () => {
+    expect(sql).toContain('DEFINE FIELD OVERWRITE writer ON memory_support');
+    expect(sql).toMatch(
+      /writer ON memory_support[^;]*'scene_backlink', 'fact_resolver', 'promotion_runner', 'compaction_runner', 'recompose', 'belief_promotion'/s,
+    );
+  });
+
+  it('widens the never-written consolidatedInto column to generic records', () => {
+    expect(sql).toContain(
+      'DEFINE FIELD OVERWRITE consolidatedInto ON memory_episode TYPE option<array<record>>;',
+    );
+  });
+
+  it('stamps the GDPR tombstone counter on forgotten_entity', () => {
+    expect(sql).toContain('DEFINE FIELD IF NOT EXISTS beliefsDeleted ON forgotten_entity');
+  });
+
+  it('carries the bitemporal vocabulary + explicit revision', () => {
+    for (const field of ['validFrom', 'validUntil', 'status', 'supersededBy', 'revision']) {
+      expect(sql).toContain(`DEFINE FIELD IF NOT EXISTS ${field} ON semantic_belief`);
+    }
+  });
+});
+
+describe('semantic_belief GDPR cascade + DELETE-shape guards (0120)', () => {
+  const SRC = join(__dirname, '..', 'src');
+
+  it('both forget services erase beliefs via the two-step SELECT-ids → DELETE idiom, unconditionally', () => {
+    // user-forget: the userId leg is the primary erase (a belief always
+    // carries the single-user scope of its scenes — #387 fail-closed
+    // promotion), plus the defensive dying-scene leg; belief ids join
+    // the memory_support subject list BEFORE the rows die.
+    const userForget = readFileSync(join(SRC, 'entities', 'user-forget.service.ts'), 'utf8');
+    expect(userForget).toContain('SELECT VALUE id FROM semantic_belief');
+    expect(userForget).toContain('sourceSceneIds CONTAINSANY $scenes');
+    // entity-forget: scene-mediated — beliefs grounded in dying scenes
+    // go with them, pre-collected inside the atomic transaction.
+    const entityForget = readFileSync(join(SRC, 'entities', 'entity-forget.service.ts'), 'utf8');
+    expect(entityForget).toContain('LET $beliefIds = (SELECT VALUE id FROM semantic_belief');
+    expect(entityForget).toContain('sourceSceneIds CONTAINSANY $sceneIds');
+    expect(entityForget).toContain('LET $beliefsDel = (DELETE $beliefIds RETURN BEFORE)');
+    // The belief endpoints must join the support-edge subject SELECT.
+    expect(entityForget).toContain('OR in INSIDE $beliefIds OR out INSIDE $beliefIds');
+  });
+
+  it('NO file in src/ uses the 3.2.4-broken DELETE semantic_belief WHERE shape', () => {
+    const walk = (dir: string): string[] => {
+      const out: string[] = [];
+      for (const name of readdirSync(dir)) {
+        const p = join(dir, name);
+        if (statSync(p).isDirectory()) out.push(...walk(p));
+        else if (p.endsWith('.ts') || p.endsWith('.surql')) out.push(p);
+      }
+      return out;
+    };
+    for (const file of walk(SRC)) {
+      // Comment lines EXPLAIN the trap (0058-guard idiom) — judge only
+      // code lines.
+      const code = readFileSync(file, 'utf8')
+        .split('\n')
+        .filter((l) => {
+          const t = l.trimStart();
+          return !t.startsWith('--') && !t.startsWith('//') && !t.startsWith('*');
+        })
+        .join('\n');
+      expect(code).not.toMatch(/DELETE semantic_belief\s+WHERE/);
+    }
+  });
+});
+
 describe('0117_window_user_scope (mixed-user privacy fence substrate)', () => {
   const sql = readFileSync(join(MIGRATIONS, '0117_window_user_scope.surql'), 'utf8');
 

--- a/test/belief-promotion.e2e-spec.ts
+++ b/test/belief-promotion.e2e-spec.ts
@@ -1,0 +1,500 @@
+/**
+ * Belief-A e2e on real SurrealDB: promotion fold (POST
+ * /v1/admin/maintenance/scenes/beliefs), the SCENES_BELIEF_MIN_SCENES
+ * distinct-conversation floor, the built-in conflict guard, the #387
+ * mixed-user/legacy fail-closed skip, supersede-chain revisions (never
+ * in-place for values), consolidatedInto/baselineRef stamps on consumed
+ * scenes, the PROVENANCE_SUPPORT_EDGES mirror (supported_by /
+ * contradicted_by / derived_from, writer belief_promotion), optional
+ * LLM statement synthesis (stubbed — no paid calls), and the GDPR
+ * cascade through BOTH forget services with the beliefsDeleted counter.
+ *
+ * Scene rows are seeded directly in the DB (the facts-list-competing
+ * direct-seed precedent): the composer/enricher have their own suites,
+ * and hand-seeded rows make the fold deterministic — the promotion
+ * consumes enriched columns regardless of who wrote them.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockBeliefSynthesisOpenAi } from './test-doubles';
+import { SurrealService } from '../src/db/surreal.service';
+import { beliefIdTail } from '../src/admin/belief-promotion.service';
+
+const USER = 'belief_u1';
+const OTHER_USER = 'belief_u2';
+
+interface BeliefRow {
+  id: unknown;
+  userId: string;
+  subject: string;
+  field: string;
+  value: string;
+  priorValue?: string;
+  statement: string;
+  statementSource: string;
+  confidence: number;
+  revision: number;
+  status: string;
+  supersededBy?: unknown;
+  validFrom?: unknown;
+  validUntil?: unknown;
+  sourceSceneIds?: unknown[];
+  conversationIds?: string[];
+  corroborationCount?: number;
+  conversationCount?: number;
+  promoterVersion?: string;
+}
+
+describe('belief promotion + GDPR cascade (e2e)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const saved: Record<string, string | undefined> = {};
+  const FLAGS = [
+    'SCENES_SEGMENTATION_ENABLED',
+    'SCENES_BELIEF_PROMOTION',
+    'SCENES_BELIEF_MIN_SCENES',
+    'SCENES_BELIEF_LLM_SYNTHESIS',
+    'PROVENANCE_SUPPORT_EDGES',
+  ];
+
+  const db = <T>(
+    fn: (d: { query: <Q>(sql: string, p?: Record<string, unknown>) => Promise<Q> }) => Promise<T>,
+  ): Promise<T> => f.app.get(SurrealService).withCompany(f.companyId, fn);
+
+  const seedScene = async (opts: {
+    tail: string;
+    conv: string;
+    user?: string;
+    users?: string[];
+    occurredTo: string;
+    deltas: Array<{ subject: string; field: string; from: string; to: string }>;
+    enriched?: boolean;
+  }): Promise<void> => {
+    await db(async (d) => {
+      await d.query(
+        `CREATE type::record('memory_episode', $tail) CONTENT {
+           ${opts.user !== undefined ? 'userId: $user,' : ''}
+           ${opts.users !== undefined ? 'userIds: $users,' : ''}
+           scope: [],
+           sceneLabel: 'seed',
+           conversationIds: [$conv],
+           occurredFrom: <datetime>$to,
+           occurredTo: <datetime>$to,
+           gist: 'seed gist',
+           confidence: 1,
+           stateDeltas: $deltas,
+           segmenterVersion: 'scene-segmenter-v1',
+           generation: 'seed-gen',
+           source: { recorder: 'test-seed' }
+           ${opts.enriched !== false ? `, enrichmentVersion: 'seed-enrich-v1', enrichedMemoryValue: { explicitness: 0.8 }` : ''}
+         }`,
+        {
+          tail: opts.tail,
+          conv: opts.conv,
+          to: opts.occurredTo,
+          deltas: opts.deltas,
+          ...(opts.user !== undefined ? { user: opts.user } : {}),
+          ...(opts.users !== undefined ? { users: opts.users } : {}),
+        },
+      );
+    });
+  };
+
+  const beliefs = (): Promise<BeliefRow[]> =>
+    db(async (d) => {
+      const [rows] = await d.query<[BeliefRow[]]>(
+        `SELECT * FROM semantic_belief ORDER BY subject ASC, field ASC, revision ASC`,
+      );
+      return rows ?? [];
+    });
+
+  const supportRows = (): Promise<
+    Array<{ in: unknown; out: unknown; kind: string; writer: string }>
+  > =>
+    db(async (d) => {
+      const [rows] = await d.query<
+        [Array<{ in: unknown; out: unknown; kind: string; writer: string }>]
+      >(`SELECT in, out, kind, writer FROM memory_support ORDER BY kind ASC`);
+      return rows ?? [];
+    });
+
+  const sceneRow = (
+    tail: string,
+  ): Promise<{ consolidatedInto?: unknown[]; baselineRef?: Record<string, unknown> }> =>
+    db(async (d) => {
+      const [rows] = await d.query<
+        [Array<{ consolidatedInto?: unknown[]; baselineRef?: Record<string, unknown> }>]
+      >(`SELECT consolidatedInto, baselineRef FROM type::record('memory_episode', $tail)`, {
+        tail,
+      });
+      return (rows ?? [])[0] ?? {};
+    });
+
+  const promote = () => f.http.post('/v1/admin/maintenance/scenes/beliefs').set(auth()).send({});
+
+  beforeAll(async () => {
+    for (const k of FLAGS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    f = await createApp({ companyId: 'co_belief_e2e' });
+
+    // Corroborating pair (distinct conversations) + a single-conversation
+    // key (the floor probe) + the skip fixtures.
+    await seedScene({
+      tail: 'sa1',
+      conv: 'proj:c1',
+      user: USER,
+      users: [USER],
+      occurredTo: '2026-03-01T10:00:00.000Z',
+      deltas: [
+        { subject: 'mika', field: 'home.city', from: '', to: 'lisbon' },
+        { subject: 'mika', field: 'coffee.pref', from: '', to: 'espresso' },
+      ],
+    });
+    await seedScene({
+      tail: 'sa2',
+      conv: 'proj:c2',
+      user: USER,
+      users: [USER],
+      occurredTo: '2026-03-02T10:00:00.000Z',
+      deltas: [{ subject: 'mika', field: 'home.city', from: '', to: 'lisbon' }],
+    });
+    // Mixed-user group (#387: skip fail-closed, loudly).
+    await seedScene({
+      tail: 'smixed',
+      conv: 'proj:c1',
+      users: [USER, OTHER_USER],
+      occurredTo: '2026-03-01T11:00:00.000Z',
+      deltas: [{ subject: 'mika', field: 'pet', from: '', to: 'cat' }],
+    });
+    // Legacy pre-0117 row: userId stamped, userIds NEVER written.
+    await seedScene({
+      tail: 'slegacy',
+      conv: 'proj:c1',
+      user: USER,
+      occurredTo: '2026-03-01T11:30:00.000Z',
+      deltas: [{ subject: 'mika', field: 'pet', from: '', to: 'cat' }],
+    });
+    // Irreconcilable in-batch value group: same timestamp, two values.
+    await seedScene({
+      tail: 'sconfa',
+      conv: 'proj:c1',
+      user: USER,
+      users: [USER],
+      occurredTo: '2026-03-01T12:00:00.000Z',
+      deltas: [{ subject: 'mika', field: 'job.title', from: '', to: 'engineer' }],
+    });
+    await seedScene({
+      tail: 'sconfb',
+      conv: 'proj:c2',
+      user: USER,
+      users: [USER],
+      occurredTo: '2026-03-01T12:00:00.000Z',
+      deltas: [{ subject: 'mika', field: 'job.title', from: '', to: 'designer' }],
+    });
+    // Un-enriched control: never consumed (enrichmentVersion is NONE).
+    await seedScene({
+      tail: 'splain',
+      conv: 'proj:c1',
+      user: USER,
+      users: [USER],
+      occurredTo: '2026-03-01T13:00:00.000Z',
+      deltas: [{ subject: 'mika', field: 'drink', from: '', to: 'tea' }],
+      enriched: false,
+    });
+  }, 120000);
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (f) await f.close();
+  });
+
+  it('404-gates both ways and writes NOTHING while off (byte-identical prod)', async () => {
+    // Master on, belief flag off.
+    expect((await promote()).status).toBe(404);
+    // Master off, belief flag on.
+    process.env.SCENES_BELIEF_PROMOTION = '1';
+    delete process.env.SCENES_SEGMENTATION_ENABLED;
+    expect((await promote()).status).toBe(404);
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    delete process.env.SCENES_BELIEF_PROMOTION;
+    expect(await beliefs()).toEqual([]);
+  });
+
+  it('promotes with the distinct-conversation floor: corroborated key in, single-conversation key out', async () => {
+    process.env.SCENES_BELIEF_PROMOTION = '1';
+    process.env.SCENES_BELIEF_MIN_SCENES = '2';
+    const res = await promote();
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      scenes: 6, // enriched scenes only — splain is invisible
+      eligibleScenes: 4,
+      skippedMixedUser: 2, // smixed (mixed group) + slegacy (no userIds)
+      skippedConflict: 1, // job.title: engineer vs designer, same instant
+      skippedFloor: 1, // coffee.pref: 1 conversation < floor 2
+      beliefsCreated: 1, // home.city
+      beliefsCorroborated: 0,
+      beliefsRevised: 0,
+      supportEdges: 0, // PROVENANCE_SUPPORT_EDGES off
+    });
+
+    const rows = await beliefs();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      userId: USER,
+      subject: 'mika',
+      field: 'home.city',
+      value: 'lisbon',
+      statement: 'mika — home.city: lisbon',
+      statementSource: 'template',
+      confidence: 0.85, // mean explicitness 0.8 + 0.05 corroboration bonus
+      revision: 1,
+      status: 'active',
+      conversationIds: ['proj:c1', 'proj:c2'],
+      corroborationCount: 2,
+      conversationCount: 2,
+      promoterVersion: 'belief-promotion-v1|scene-segmenter-v1',
+    });
+    expect(String(rows[0]!.id)).toContain(
+      beliefIdTail({ userId: USER, subject: 'mika', field: 'home.city' }, 1),
+    );
+    expect((rows[0]!.sourceSceneIds ?? []).map(String).sort()).toEqual([
+      'memory_episode:sa1',
+      'memory_episode:sa2',
+    ]);
+
+    // Consumed scenes carry the consolidatedInto stamp; revision 1 has
+    // NO baseline. Skipped groups' scenes stay untouched.
+    const beliefId = String(rows[0]!.id);
+    for (const tail of ['sa1', 'sa2']) {
+      const s = await sceneRow(tail);
+      expect((s.consolidatedInto ?? []).map(String)).toEqual([beliefId]);
+      expect(s.baselineRef).toBeUndefined();
+    }
+    for (const tail of ['smixed', 'slegacy', 'sconfa', 'sconfb', 'splain']) {
+      expect((await sceneRow(tail)).consolidatedInto).toBeUndefined();
+    }
+    expect(await supportRows()).toEqual([]);
+  });
+
+  it('floor off: the single-conversation key promotes (LLM-synthesized statement, stubbed), re-fold is idempotent, edges mirror', async () => {
+    delete process.env.SCENES_BELIEF_MIN_SCENES;
+    process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    process.env.SCENES_BELIEF_LLM_SYNTHESIS = '1';
+    const mock = mockBeliefSynthesisOpenAi(f.app, [
+      JSON.stringify({ statement: 'Mika prefers espresso.' }),
+    ]);
+
+    const res = await promote();
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      skippedMixedUser: 2,
+      skippedConflict: 1,
+      skippedFloor: 0,
+      beliefsCreated: 1, // coffee.pref
+      beliefsCorroborated: 0, // home.city: same value, zero NEW scenes
+      beliefsRevised: 0,
+      supportEdges: 3, // supported_by: coffee->sa1 + home.city->{sa1,sa2}
+    });
+    // ONE call — only the coffee.pref CREATE synthesizes; the home.city
+    // no-op corroboration never calls the model.
+    expect(mock.calls).toHaveLength(1);
+    expect(mock.calls[0]!.user).toContain('coffee.pref');
+
+    const rows = await beliefs();
+    expect(rows).toHaveLength(2);
+    const coffee = rows.find((r) => r.field === 'coffee.pref')!;
+    expect(coffee).toMatchObject({
+      value: 'espresso',
+      statement: 'Mika prefers espresso.',
+      statementSource: 'llm',
+      revision: 1,
+      status: 'active',
+      corroborationCount: 1,
+      conversationCount: 1,
+    });
+
+    const edges = await supportRows();
+    expect(edges).toHaveLength(3);
+    for (const e of edges) {
+      expect(e.kind).toBe('supported_by');
+      expect(e.writer).toBe('belief_promotion');
+      expect(String(e.in)).toContain('semantic_belief:');
+      expect(String(e.out)).toContain('memory_episode:');
+    }
+  });
+
+  it('revises on a new value: supersede chain, baselineRef, contradiction edges — never in-place', async () => {
+    delete process.env.SCENES_BELIEF_LLM_SYNTHESIS;
+    await seedScene({
+      tail: 'sb',
+      conv: 'proj:c3',
+      user: USER,
+      users: [USER],
+      occurredTo: '2026-03-05T10:00:00.000Z',
+      deltas: [{ subject: 'mika', field: 'home.city', from: 'lisbon', to: 'porto' }],
+    });
+
+    const res = await promote();
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ beliefsCreated: 0, beliefsRevised: 1 });
+
+    const rows = await beliefs();
+    const chain = rows.filter((r) => r.field === 'home.city');
+    expect(chain).toHaveLength(2);
+    const [rev1, rev2] = chain;
+    expect(rev1).toMatchObject({ revision: 1, value: 'lisbon', status: 'superseded' });
+    expect(String(rev1!.supersededBy)).toBe(String(rev2!.id));
+    expect(rev1!.validUntil).toBeDefined();
+    expect(rev2).toMatchObject({
+      revision: 2,
+      value: 'porto',
+      priorValue: 'lisbon', // the ACTUAL displaced value
+      statement: 'mika — home.city: porto (was: lisbon)',
+      statementSource: 'template',
+      status: 'active',
+    });
+    expect((rev2!.sourceSceneIds ?? []).map(String)).toEqual(['memory_episode:sb']);
+
+    // The 0106 contracts on the consumed scene: consolidatedInto names
+    // the NEW revision; baselineRef names the revision the delta was
+    // applied AGAINST.
+    const sb = await sceneRow('sb');
+    expect((sb.consolidatedInto ?? []).map(String)).toEqual([String(rev2!.id)]);
+    expect(sb.baselineRef).toMatchObject({
+      belief: String(rev1!.id),
+      revision: 1,
+      value: 'lisbon',
+    });
+    expect(sb.baselineRef!.stampedAt).toBeDefined();
+
+    const edges = await supportRows();
+    const contradiction = edges.filter((e) => e.kind === 'contradicted_by');
+    const derivation = edges.filter((e) => e.kind === 'derived_from');
+    expect(contradiction).toHaveLength(1);
+    expect(String(contradiction[0]!.in)).toBe(String(rev1!.id)); // old ->
+    expect(String(contradiction[0]!.out)).toBe(String(rev2!.id)); // -> new
+    expect(derivation).toHaveLength(1);
+    expect(String(derivation[0]!.in)).toBe(String(rev2!.id)); // new ->
+    expect(String(derivation[0]!.out)).toBe(String(rev1!.id)); // -> old
+
+    // Idempotent re-fold: the winning value now matches revision 2 —
+    // nothing new is created and the chain stays two rows.
+    const rerun = await promote();
+    expect(rerun.status).toBe(201);
+    expect(rerun.body).toMatchObject({
+      beliefsCreated: 0,
+      beliefsCorroborated: 0,
+      beliefsRevised: 0,
+    });
+    expect((await beliefs()).filter((r) => r.field === 'home.city')).toHaveLength(2);
+  });
+
+  it('user-forget erases beliefs + their support edges unconditionally, with the beliefsDeleted counter', async () => {
+    // Flag-independence: rows written while on must die while OFF.
+    delete process.env.SCENES_BELIEF_PROMOTION;
+    delete process.env.PROVENANCE_SUPPORT_EDGES;
+
+    const before = await beliefs();
+    expect(before.length).toBe(3); // home.city rev1+rev2 + coffee.pref
+    const res = await f.http.post(`/v1/users/${USER}/forget`).set(auth()).send({});
+    expect(res.status).toBe(201);
+    expect(res.body.beliefsDeleted).toBe(3);
+
+    expect(await beliefs()).toEqual([]);
+    expect(await supportRows()).toEqual([]);
+  });
+
+  it('entity-forget cascades scene-mediated beliefs (dying episode -> scene -> belief) with the counter', async () => {
+    // Minimal grounding graph: entity -> fact (grounded in one episode)
+    // -> scene membership -> a belief sourced from that scene, plus its
+    // support edge — all seeded directly (the promotion path was proven
+    // above; this leg proves the erase linkage).
+    await db(async (d) => {
+      await d.query(
+        `CREATE knowledge_entity:bf_subj CONTENT {
+           type: 'other', canonicalName: 'BeliefSubject', externalRefs: { proj: 'bf_subj' } }`,
+      );
+      await d.query(
+        `CREATE episode:bf_ep CONTENT {
+           kind: 'turn', messageId: 'bf_m1', text: 'belief grounding turn',
+           occurredAt: <datetime>'2026-03-01T09:00:00.000Z', userId: $u,
+           conversationId: 'proj:c9', source: { vertical: 'proj' } }`,
+        { u: OTHER_USER },
+      );
+      await d.query(
+        `CREATE knowledge_fact:bf_fact CONTENT {
+           entityId: knowledge_entity:bf_subj, predicate: 'note',
+           object: 'grounded note', confidence: 0.9,
+           validFrom: <datetime>'2026-03-01T09:00:00.000Z',
+           source: { vertical: 'derived', recorder: 'test-seed',
+                     conversationId: 'proj:c9', episodeIds: ['episode:bf_ep'] } }`,
+      );
+      await d.query(
+        `CREATE memory_episode:bf_scene CONTENT {
+           userId: $u, userIds: [$u], scope: [], sceneLabel: 'seed',
+           conversationIds: ['proj:c9'],
+           occurredFrom: <datetime>'2026-03-01T09:00:00.000Z',
+           occurredTo: <datetime>'2026-03-01T09:00:00.000Z',
+           gist: 'seed gist', confidence: 1,
+           segmenterVersion: 'scene-segmenter-v1', generation: 'seed-gen',
+           source: { recorder: 'test-seed' } }`,
+        { u: OTHER_USER },
+      );
+      await d.query(
+        `INSERT RELATION INTO memory_episode_member {
+           in: memory_episode:bf_scene, out: episode:bf_ep,
+           role: 'core', ord: 0, relevance: 1,
+           segmenterVersion: 'scene-segmenter-v1' }`,
+      );
+      await d.query(
+        `CREATE semantic_belief:bf_belief CONTENT {
+           userId: $u, subject: 'other', field: 'pet', value: 'dog',
+           statement: 'other — pet: dog', statementSource: 'template',
+           confidence: 0.8, revision: 1, status: 'active',
+           validFrom: <datetime>'2026-03-01T09:00:00.000Z',
+           sourceSceneIds: [memory_episode:bf_scene],
+           conversationIds: ['proj:c9'], corroborationCount: 1,
+           conversationCount: 1,
+           promoterVersion: 'belief-promotion-v1|scene-segmenter-v1' }`,
+        { u: OTHER_USER },
+      );
+      await d.query(
+        `INSERT RELATION INTO memory_support {
+           in: semantic_belief:bf_belief, out: memory_episode:bf_scene,
+           kind: 'supported_by', writer: 'belief_promotion' }`,
+      );
+    });
+
+    const res = await f.http
+      .post('/v1/entities/knowledge_entity:bf_subj/forget')
+      .set(auth())
+      .send({ reason: 'gdpr_request', requestId: 'belief-forget-1' });
+    expect(res.status).toBe(201);
+    expect(res.body.beliefsDeleted).toBe(1);
+
+    expect(await beliefs()).toEqual([]);
+    expect(await supportRows()).toEqual([]);
+    const tomb = await db(async (d) => {
+      const [rows] = await d.query<[Array<{ beliefsDeleted?: number }>]>(
+        `SELECT beliefsDeleted FROM forgotten_entity WHERE requestId = 'belief-forget-1'`,
+      );
+      return (rows ?? [])[0];
+    });
+    expect(tomb?.beliefsDeleted).toBe(1);
+
+    // Idempotent replay carries the stored counter.
+    const replay = await f.http
+      .post('/v1/entities/knowledge_entity:bf_subj/forget')
+      .set(auth())
+      .send({ reason: 'gdpr_request', requestId: 'belief-forget-1' });
+    expect(replay.status).toBe(201);
+    expect(replay.body.beliefsDeleted).toBe(1);
+  });
+});

--- a/test/belief-promotion.unit-spec.ts
+++ b/test/belief-promotion.unit-spec.ts
@@ -1,0 +1,413 @@
+/**
+ * Belief promotion (Belief-A, migration 0120) — the pure fold, the #387
+ * single-user fence, the deterministic id/statement/version helpers, the
+ * belief-aware support-edge shapes, the flag resolvers, and the OFF-state
+ * hard guarantee: with SCENES_BELIEF_PROMOTION off the service returns
+ * before touching the version resolver OR the database (zero queries —
+ * byte-identical prod; the route's 404 is pinned in the e2e).
+ */
+import type { ConfigService } from '@nestjs/config';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { SceneVersionService } from '../src/admin/scene-version';
+import {
+  BELIEF_PROMOTER_VERSION,
+  BeliefPromotionService,
+  beliefIdTail,
+  beliefPromoterVersion,
+  foldBeliefGroups,
+  renderBeliefStatement,
+  sceneSingleUser,
+  type PromotableSceneHead,
+} from '../src/admin/belief-promotion.service';
+import {
+  SUPPORT_EDGE_WRITERS,
+  assertEdgeShape,
+  classifySupportTarget,
+} from '../src/common/support-edges';
+import {
+  sceneBeliefLlmSynthesisEnabled,
+  sceneBeliefMinScenes,
+  sceneBeliefPromotionEnabled,
+} from '../src/common/scene-flags';
+
+const scene = (over: Partial<PromotableSceneHead> & { id: string }): PromotableSceneHead => ({
+  userId: 'u1',
+  userIds: ['u1'],
+  conversationIds: ['conv:a'],
+  occurredTo: '2026-03-01T10:00:00.000Z',
+  stateDeltas: [],
+  explicitness: 0.8,
+  ...over,
+});
+
+const delta = (subject: string, field: string, to: string, from = '') => ({
+  subject,
+  field,
+  from,
+  to,
+});
+
+describe('sceneSingleUser (#387 fail-closed fence)', () => {
+  it('admits exactly the single-user shape', () => {
+    expect(sceneSingleUser(scene({ id: 's1' }))).toBe('u1');
+  });
+
+  it.each([
+    ['mixed group', { userIds: ['u1', 'u2'] }],
+    ['legacy pre-0117 (userIds missing)', { userIds: undefined }],
+    ['tenant-global (userIds empty)', { userIds: [] }],
+    ['userId stamp disagrees with the member set', { userId: 'u2' }],
+    ['userId stamp missing', { userId: undefined }],
+    ['non-string member', { userIds: [42] }],
+  ])('rejects %s', (_name, over) => {
+    expect(sceneSingleUser(scene({ id: 's1', ...over }))).toBeNull();
+  });
+});
+
+describe('foldBeliefGroups', () => {
+  it('folds one delta into one verdict with template-ready fields', () => {
+    const { folded, conflicts } = foldBeliefGroups([
+      {
+        userId: 'u1',
+        scene: scene({
+          id: 'memory_episode:s1',
+          stateDeltas: [delta('mika', 'home.city', 'lisbon')],
+        }),
+      },
+    ]);
+    expect(conflicts).toEqual([]);
+    expect(folded).toHaveLength(1);
+    expect(folded[0]).toMatchObject({
+      userId: 'u1',
+      subject: 'mika',
+      field: 'home.city',
+      value: 'lisbon',
+      priorValue: '',
+      sceneIds: ['memory_episode:s1'],
+      conversationIds: ['conv:a'],
+    });
+    expect(folded[0]!.validFrom.toISOString()).toBe('2026-03-01T10:00:00.000Z');
+  });
+
+  it('latest value wins; earlier values are history, corroboration counts the winning set', () => {
+    const { folded } = foldBeliefGroups([
+      {
+        userId: 'u1',
+        scene: scene({
+          id: 'memory_episode:s1',
+          occurredTo: '2026-03-01T10:00:00.000Z',
+          stateDeltas: [delta('mika', 'home.city', 'porto')],
+        }),
+      },
+      {
+        userId: 'u1',
+        scene: scene({
+          id: 'memory_episode:s2',
+          conversationIds: ['conv:b'],
+          occurredTo: '2026-03-02T10:00:00.000Z',
+          stateDeltas: [delta('mika', 'home.city', 'lisbon', 'porto')],
+        }),
+      },
+      {
+        userId: 'u1',
+        scene: scene({
+          id: 'memory_episode:s3',
+          conversationIds: ['conv:c'],
+          occurredTo: '2026-03-03T10:00:00.000Z',
+          stateDeltas: [delta('mika', 'home.city', 'lisbon')],
+        }),
+      },
+    ]);
+    expect(folded).toHaveLength(1);
+    expect(folded[0]).toMatchObject({
+      value: 'lisbon',
+      priorValue: '',
+      sceneIds: ['memory_episode:s2', 'memory_episode:s3'],
+      conversationIds: ['conv:b', 'conv:c'],
+    });
+    expect(folded[0]!.validFrom.toISOString()).toBe('2026-03-03T10:00:00.000Z');
+  });
+
+  it('conflict guard: two different values at the winning timestamp skip the whole group', () => {
+    const { folded, conflicts } = foldBeliefGroups([
+      {
+        userId: 'u1',
+        scene: scene({
+          id: 'memory_episode:s1',
+          stateDeltas: [delta('mika', 'job.title', 'engineer')],
+        }),
+      },
+      {
+        userId: 'u1',
+        scene: scene({
+          id: 'memory_episode:s2',
+          stateDeltas: [delta('mika', 'job.title', 'designer')],
+        }),
+      },
+    ]);
+    expect(folded).toEqual([]);
+    expect(conflicts).toEqual([
+      { userId: 'u1', subject: 'mika', field: 'job.title', values: ['designer', 'engineer'] },
+    ]);
+  });
+
+  it('groups are per (userId, subject, field) — different users never merge', () => {
+    const { folded, conflicts } = foldBeliefGroups([
+      {
+        userId: 'u1',
+        scene: scene({ id: 'memory_episode:s1', stateDeltas: [delta('mika', 'pet', 'cat')] }),
+      },
+      {
+        userId: 'u2',
+        scene: scene({
+          id: 'memory_episode:s2',
+          userId: 'u2',
+          userIds: ['u2'],
+          stateDeltas: [delta('mika', 'pet', 'dog')],
+        }),
+      },
+    ]);
+    expect(conflicts).toEqual([]);
+    expect(folded.map((f) => [f.userId, f.value])).toEqual([
+      ['u1', 'cat'],
+      ['u2', 'dog'],
+    ]);
+  });
+
+  it('drops deltas without subject/field/landing value and unordered scenes', () => {
+    const { folded } = foldBeliefGroups([
+      {
+        userId: 'u1',
+        scene: scene({
+          id: 'memory_episode:s1',
+          stateDeltas: [
+            delta('', 'field', 'v'),
+            delta('subject', '', 'v'),
+            delta('subject', 'field', ''),
+            'not-an-object',
+          ],
+        }),
+      },
+      {
+        userId: 'u1',
+        scene: scene({
+          id: 'memory_episode:s2',
+          occurredTo: undefined,
+          stateDeltas: [delta('mika', 'pet', 'cat')],
+        }),
+      },
+    ]);
+    expect(folded).toEqual([]);
+  });
+
+  it('confidence = mean explicitness + distinct-conversation bonus, capped', () => {
+    const { folded } = foldBeliefGroups([
+      {
+        userId: 'u1',
+        scene: scene({
+          id: 'memory_episode:s1',
+          explicitness: 0.6,
+          stateDeltas: [delta('mika', 'pet', 'cat')],
+        }),
+      },
+      {
+        userId: 'u1',
+        scene: scene({
+          id: 'memory_episode:s2',
+          conversationIds: ['conv:b'],
+          occurredTo: '2026-03-02T10:00:00.000Z',
+          explicitness: 0.8,
+          stateDeltas: [delta('mika', 'pet', 'cat')],
+        }),
+      },
+    ]);
+    // mean(0.6, 0.8) + 0.05 * (2 distinct conversations - 1) = 0.75
+    expect(folded[0]!.confidence).toBe(0.75);
+    const { folded: capped } = foldBeliefGroups([
+      {
+        userId: 'u1',
+        scene: scene({
+          id: 'memory_episode:s3',
+          explicitness: 0.99,
+          stateDeltas: [delta('mika', 'pet', 'cat')],
+        }),
+      },
+    ]);
+    expect(capped[0]!.confidence).toBe(0.95);
+  });
+});
+
+describe('deterministic helpers', () => {
+  it('renderBeliefStatement: template with and without a prior value', () => {
+    expect(
+      renderBeliefStatement({
+        subject: 'mika',
+        field: 'home.city',
+        value: 'lisbon',
+        priorValue: '',
+      }),
+    ).toBe('mika — home.city: lisbon');
+    expect(
+      renderBeliefStatement({
+        subject: 'mika',
+        field: 'home.city',
+        value: 'lisbon',
+        priorValue: 'porto',
+      }),
+    ).toBe('mika — home.city: lisbon (was: porto)');
+  });
+
+  it('beliefIdTail is deterministic per (user, subject, field, revision)', () => {
+    const key = { userId: 'u1', subject: 'mika', field: 'home.city' };
+    const a = beliefIdTail(key, 1);
+    expect(a).toBe(beliefIdTail(key, 1));
+    expect(a).toHaveLength(24);
+    expect(a).not.toBe(beliefIdTail(key, 2));
+    expect(a).not.toBe(beliefIdTail({ ...key, userId: 'u2' }, 1));
+  });
+
+  it('beliefPromoterVersion is the readable promoter|world composite', () => {
+    expect(beliefPromoterVersion('scene-segmenter-v1')).toBe(
+      `${BELIEF_PROMOTER_VERSION}|scene-segmenter-v1`,
+    );
+  });
+});
+
+describe('support-edge shapes for beliefs (0120)', () => {
+  it('belief_promotion is a registered writer', () => {
+    expect(SUPPORT_EDGE_WRITERS).toContain('belief_promotion');
+  });
+
+  it('classifies the semantic_belief prefix', () => {
+    expect(classifySupportTarget('semantic_belief:abc')).toBe('belief');
+  });
+
+  it('supported_by: belief -> scene only', () => {
+    expect(assertEdgeShape('supported_by', 'semantic_belief:b1', 'memory_episode:s1')).toBe(true);
+    expect(assertEdgeShape('supported_by', 'semantic_belief:b1', 'knowledge_fact:f1')).toBe(false);
+  });
+
+  it('contradicted_by / derived_from: belief pairs only with belief (never the claim plane)', () => {
+    expect(assertEdgeShape('contradicted_by', 'semantic_belief:b1', 'semantic_belief:b2')).toBe(
+      true,
+    );
+    expect(assertEdgeShape('derived_from', 'semantic_belief:b2', 'semantic_belief:b1')).toBe(true);
+    expect(assertEdgeShape('contradicted_by', 'semantic_belief:b1', 'knowledge_fact:f1')).toBe(
+      false,
+    );
+    expect(assertEdgeShape('derived_from', 'knowledge_fact:f1', 'semantic_belief:b1')).toBe(false);
+  });
+
+  it('fact rules are byte-identical to pre-0120', () => {
+    expect(assertEdgeShape('supported_by', 'knowledge_fact:f1', 'memory_episode:s1')).toBe(true);
+    expect(assertEdgeShape('contradicted_by', 'knowledge_fact:f1', 'knowledge_fact:f2')).toBe(true);
+    expect(assertEdgeShape('derived_from', 'knowledge_fact:f1', 'knowledge_fact:f2')).toBe(true);
+    expect(assertEdgeShape('reconstructed_from', 'knowledge_fact:f1', 'memory_episode:s1')).toBe(
+      false,
+    );
+    expect(assertEdgeShape('reconstructed_from', 'semantic_belief:b1', 'memory_episode:s1')).toBe(
+      false,
+    );
+  });
+});
+
+describe('flag resolvers', () => {
+  const saved: Record<string, string | undefined> = {};
+  const KEYS = [
+    'SCENES_BELIEF_PROMOTION',
+    'SCENES_BELIEF_LLM_SYNTHESIS',
+    'SCENES_BELIEF_MIN_SCENES',
+  ];
+  beforeEach(() => {
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('both booleans default off', () => {
+    expect(sceneBeliefPromotionEnabled()).toBe(false);
+    expect(sceneBeliefLlmSynthesisEnabled()).toBe(false);
+    process.env.SCENES_BELIEF_PROMOTION = '1';
+    process.env.SCENES_BELIEF_LLM_SYNTHESIS = '1';
+    expect(sceneBeliefPromotionEnabled()).toBe(true);
+    expect(sceneBeliefLlmSynthesisEnabled()).toBe(true);
+  });
+
+  it('SCENES_BELIEF_MIN_SCENES: non-negative int, 0 = off, invalid -> 0', () => {
+    expect(sceneBeliefMinScenes()).toBe(0);
+    process.env.SCENES_BELIEF_MIN_SCENES = '2';
+    expect(sceneBeliefMinScenes()).toBe(2);
+    process.env.SCENES_BELIEF_MIN_SCENES = '0';
+    expect(sceneBeliefMinScenes()).toBe(0);
+    for (const bad of ['-1', '1.5', 'x', ' ']) {
+      process.env.SCENES_BELIEF_MIN_SCENES = bad;
+      expect(sceneBeliefMinScenes()).toBe(0);
+    }
+  });
+});
+
+describe('OFF-state hard guarantee (byte-identical prod)', () => {
+  const savedFlag = process.env.SCENES_BELIEF_PROMOTION;
+  afterAll(() => {
+    if (savedFlag === undefined) delete process.env.SCENES_BELIEF_PROMOTION;
+    else process.env.SCENES_BELIEF_PROMOTION = savedFlag;
+  });
+
+  function makeService(): BeliefPromotionService {
+    // Every collaborator THROWS on touch: with the flag off the run must
+    // return before resolving the version or opening a db handle.
+    const surreal = {
+      withCompany: () => {
+        throw new Error('withCompany must not be called with the flag off');
+      },
+    } as unknown as SurrealService;
+    const versions = {
+      resolve: () => {
+        throw new Error('SceneVersionService.resolve must not be called with the flag off');
+      },
+    } as unknown as SceneVersionService;
+    const config = {
+      get: (_key: string, def?: string) => def,
+    } as unknown as ConfigService;
+    return new BeliefPromotionService(surreal, config, versions);
+  }
+
+  it('flag off ⇒ zero queries, zero version resolution, all-zero result', async () => {
+    delete process.env.SCENES_BELIEF_PROMOTION;
+    const result = await makeService().run('co_test');
+    expect(result).toEqual({
+      scenes: 0,
+      eligibleScenes: 0,
+      skippedMixedUser: 0,
+      skippedConflict: 0,
+      skippedFloor: 0,
+      skippedStale: 0,
+      beliefsCreated: 0,
+      beliefsCorroborated: 0,
+      beliefsRevised: 0,
+      supportEdges: 0,
+    });
+  });
+
+  it('LLM synthesis default-off: statements are deterministic templates (no client needed)', async () => {
+    const svc = makeService();
+    const composed = await (
+      svc as unknown as {
+        composeStatement: (f: {
+          subject: string;
+          field: string;
+          value: string;
+          priorValue: string;
+        }) => Promise<{ text: string; source: string }>;
+      }
+    ).composeStatement({ subject: 'mika', field: 'pet', value: 'cat', priorValue: '' });
+    expect(composed).toEqual({ text: 'mika — pet: cat', source: 'template' });
+  });
+});

--- a/test/test-doubles.ts
+++ b/test/test-doubles.ts
@@ -5,6 +5,7 @@ import type { ExtractorService, ExtractionResult } from '../src/ai/extractor.ser
 import type { LocalCrossEncoderProvider } from '../src/ai/cross-encoder/local-cross-encoder.provider';
 import { SynthesizeService } from '../src/synthesize/synthesize.service';
 import { SceneEnricherService } from '../src/admin/scene-enricher.service';
+import { BeliefPromotionService } from '../src/admin/belief-promotion.service';
 
 /**
  * Deterministic embedder stub for e2e tests. Same text → same vector;
@@ -200,6 +201,37 @@ export function mockSceneEnricherOpenAi(
 ): OpenAiMockState {
   const state: OpenAiMockState = { calls: [] };
   const svc = app.get(SceneEnricherService);
+  const stub = {
+    chat: {
+      completions: {
+        create: async (req: { messages: Array<{ role: string; content: string }> }) => {
+          const system = req.messages.find((m) => m.role === 'system')?.content ?? '';
+          const user = req.messages.find((m) => m.role === 'user')?.content ?? '';
+          const idx = state.calls.length;
+          const content = responses[idx] ?? responses[responses.length - 1] ?? '{}';
+          state.calls.push({ system, user, response: content, request: req });
+          return { choices: [{ message: { content } }] };
+        },
+      },
+    },
+  };
+  (svc as unknown as { openai: typeof stub }).openai = stub;
+  return state;
+}
+
+/**
+ * Replace the OpenAI client on the running BeliefPromotionService with a
+ * scripted stub — the same seam as `mockSceneEnricherOpenAi` (Belief-A's
+ * optional SCENES_BELIEF_LLM_SYNTHESIS statement phrasing). Each call
+ * drains one response; the last repeats indefinitely. NO paid call is
+ * ever made.
+ */
+export function mockBeliefSynthesisOpenAi(
+  app: INestApplication,
+  responses: string[],
+): OpenAiMockState {
+  const state: OpenAiMockState = { calls: [] };
+  const svc = app.get(BeliefPromotionService);
   const stub = {
     chat: {
       completions: {


### PR DESCRIPTION
## What

Separates **SemanticBelief** from **Claim** and builds the `MemoryEpisode[] -> SemanticBelief` promotion. Scope = substrate + promotion + GDPR; the read API is a later PR.

### Migration `0120_semantic_belief`
- New SCHEMAFULL `semantic_belief` table with **free-text** `subject`/`field` keys taken from scene `stateDeltas` — deliberately NOT `record<knowledge_entity>` (the reason a `beliefKind`-on-`knowledge_fact` discriminator was rejected, along with serving-lane leakage). Follows the 0106 shadow doctrine: **no serving reader**.
- Carries the fact bitemporal vocabulary (`validFrom`/`validUntil`/`status`/`supersededBy` — the 0047 subset) + explicit `revision` int, `statement`/`value` payload, `confidence`, inline `sourceSceneIds` provenance (survives flag-off), corroboration counters, `createdAt`/`updatedAt`.
- **Single-field indexes only** — any compound index puts deletes in the 3.2.4 planner-bug class; `(userId, subject, field, revision)` uniqueness is code-enforced via deterministic record ids + `INSERT IGNORE`. No changefeed, no event.
- Widens the 0116 `memory_support.writer` ASSERT with `belief_promotion` via `DEFINE FIELD OVERWRITE`, widens the never-written `memory_episode.consolidatedInto` to `option<array<record>>`, and adds the `beliefsDeleted` tombstone counter.

### Promotion pass (`SCENES_BELIEF_PROMOTION`, default off, SCENES_ family / off-budget)
- New `POST /v1/admin/maintenance/scenes/beliefs` on `admin-scenes.controller.ts` (double-gate idiom: controller 404 + service guard; **off = zero queries**, pinned by unit test).
- Consumes ENRICHED scenes of the CURRENT effective fingerprinted segmenter version (`SceneVersionService.resolve`, #386); folds `stateDeltas`/`memoryValue`/`gist` into belief upserts keyed by `(subject, field)` — latest value wins by scene time, deterministically.
- `SCENES_BELIEF_MIN_SCENES` int knob = distinct-conversation corroboration floor (#377 promotion-floor idiom, 0 = off).
- Built-in conflict guard (no flag): irreconcilable in-batch value groups (two values at the winning timestamp) skip loudly with a warn; a stale guard refuses backward-in-valid-time revisions.
- Optional `SCENES_BELIEF_LLM_SYNTHESIS` (default off) phrases statement text via the enricher's stub-injectable client idiom; the deterministic template fold works with no client at all.
- Mixed-user / legacy-`userIds` scenes are SKIPPED fail-closed (#387 semantics — a belief inherits the single-user scope of its scenes).

### Revisions — supersede chain in code, NEVER in-place for values
- New value ⇒ revision N+1 created, old row stamped `superseded` + `validUntil` + `supersededBy`. In-place updates allowed ONLY for corroboration counters. `fn::resolve_fact` reuse rejected (claim-specific).
- Contradiction edges under `PROVENANCE_SUPPORT_EDGES`: `contradicted_by` (old→new) + `derived_from` (new→old); `sourceSceneIds` mirrored as `supported_by` (belief→scene). `support-edges.ts` gains the `belief` target class + `belief_promotion` writer; fact rules stay byte-identical.

### Scene contracts fulfilled (0106)
- Consumed scenes stamped with `consolidatedInto` (idempotent `array::union`) and — on revisions only — `baselineRef = {belief, revision, value, stampedAt}` (NONE for revision 1).

### GDPR
- BOTH forget services erase beliefs + their `memory_support` edges UNCONDITIONALLY (evidence-substrate precedent), two-step `LET`-select-ids → `DELETE`; `beliefsDeleted` counter in both reports and the `forgotten_entity` tombstone (idempotent replay carries it).
- `audit-p1-guards` spec pins the 0120 index tuples, the single-field-only rule, the OVERWRITE widenings, and a repo-wide `DELETE semantic_belief WHERE` grep prohibition (the memory_support precedent).

## Flags

All default-off, byte-identical off-state (zero queries; 404 e2e-pinned). Registered in `scene-flags.ts`, `config-catalog.data.ts`, `KNOWN_BOOLEAN_FLAGS` (+ `nonNegativeInt` boot validation for the floor knob).

## Verification

- `pnpm typecheck`, `pnpm lint:ci`, prettier: clean
- Unit: **322 suites / 3333 tests** green (incl. new `belief-promotion.unit-spec.ts` — fold, #387 fence, conflict guard, confidence math, off-state zero-queries pin, belief edge shapes, flag resolvers)
- Targeted e2e on real SurrealDB v3.2.4: **8 suites / 39 tests** green — new `belief-promotion.e2e-spec.ts` (promotion fold, floor, conflict-guard skip, revision supersede + baselineRef/consolidatedInto stamps, support-edge mirror, stubbed LLM synthesis, GDPR cascade through BOTH forgets incl. counters + idempotent replay, mixed-user/legacy skip) plus `entities-forget`, `user-forget-edge-audit`, `support-graph`, `scene-enrichment`, `memory-episode`, `forget-document-cascade`, `evidence-substrate`
- Rebased on latest main; migration slot 0120 confirmed free (0119 is PR #391's)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB