### PR TITLE
feat(beliefs): read API behind BELIEFS_API_ENABLED

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -123,6 +123,115 @@
         ],
         "type": "object"
       },
+      "BeliefReadResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "beliefId": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "conversationCount": {
+            "type": "number"
+          },
+          "conversationIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "corroborationCount": {
+            "type": "number"
+          },
+          "field": {
+            "type": "string"
+          },
+          "priorValue": {
+            "type": "string"
+          },
+          "promoterVersion": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "number"
+          },
+          "sourceSceneIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "statement": {
+            "type": "string"
+          },
+          "statementSource": {
+            "enum": [
+              "template",
+              "llm"
+            ],
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "supersededBy": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "validFrom": {
+            "type": "string"
+          },
+          "validUntil": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "beliefId",
+          "userId",
+          "subject",
+          "field",
+          "value",
+          "statement",
+          "statementSource",
+          "confidence",
+          "revision",
+          "status",
+          "validFrom",
+          "sourceSceneIds",
+          "conversationIds",
+          "corroborationCount",
+          "conversationCount"
+        ],
+        "type": "object"
+      },
+      "BeliefsListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "beliefs": {
+            "items": {
+              "$ref": "#/components/schemas/BeliefReadResponse"
+            },
+            "type": "array"
+          },
+          "found": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "beliefs",
+          "found"
+        ],
+        "type": "object"
+      },
       "Candidate": {
         "additionalProperties": false,
         "properties": {
@@ -3719,6 +3828,129 @@
         ]
       }
     },
+    "/v1/beliefs": {
+      "get": {
+        "description": "Beliefs the brain currently holds (semantic_belief, promoted from enriched scenes), filtered by exact subject/field key, lifecycle status (default active) and user scope. A user-bound token is pinned to its own user (userId mismatch is 403); M2M keys may scope to any user or list tenant-wide. Page capped at 100 (default 25). 404 until BELIEFS_API_ENABLED=1. Source: src/beliefs/beliefs.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "listBeliefs",
+        "parameters": [
+          {
+            "description": "Free-text subject key (exact match).",
+            "in": "query",
+            "name": "subject",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Free-text field key (exact match).",
+            "in": "query",
+            "name": "field",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "End-user scope key. M2M keys may assert any user; user-bound tokens are pinned to their own.",
+            "in": "query",
+            "name": "userId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Lifecycle filter: `active` (default), `superseded`, `all`.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size (default 25, max 100).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeliefsListResponse"
+                }
+              }
+            },
+            "description": "The visible beliefs."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "List beliefs by their free-text (subject, field) key",
+        "tags": [
+          "Beliefs"
+        ]
+      }
+    },
+    "/v1/beliefs/{id}": {
+      "get": {
+        "description": "One semantic_belief revision as stored: the held value, its rendered statement, confidence, the supersede chain (revision/status/supersededBy/validFrom/validUntil), inline scene provenance (sourceSceneIds) and corroboration counters. Superseded revisions still resolve. Every visibility fence (tenant, fail-closed single-user scope) answers 404 — existence never leaks. 404 until BELIEFS_API_ENABLED=1. Source: src/beliefs/beliefs.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "getBelief",
+        "parameters": [
+          {
+            "description": "Belief record id (`semantic_belief:…`).",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeliefReadResponse"
+                }
+              }
+            },
+            "description": "The belief."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Read one belief revision by id",
+        "tags": [
+          "Beliefs"
+        ]
+      }
+    },
     "/v1/documents/{id}": {
       "get": {
         "description": "Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/documents.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -5101,6 +5333,10 @@
     {
       "description": "Fact-level reads: one fact by id and its grounding episodes — provenance-first memory (\"show me why I remember this\"). Flag: FACTS_API_ENABLED (off → 404); fact retraction stays flag-independent.",
       "name": "Facts"
+    },
+    {
+      "description": "Belief-level reads over the semantic_belief substrate: what the brain currently holds about a free-text (subject, field) key, with its supersede chain and inline scene provenance. Read-only — the scene promotion pass is the only writer. Flag: BELIEFS_API_ENABLED (off → 404).",
+      "name": "Beliefs"
     },
     {
       "description": "Per-user surfaces: the rolling user profile assembled from user-scoped memory. Flag: USER_PROFILE_API_ENABLED (off → 404).",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -123,6 +123,115 @@
         ],
         "type": "object"
       },
+      "BeliefReadResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "beliefId": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "conversationCount": {
+            "type": "number"
+          },
+          "conversationIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "corroborationCount": {
+            "type": "number"
+          },
+          "field": {
+            "type": "string"
+          },
+          "priorValue": {
+            "type": "string"
+          },
+          "promoterVersion": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "number"
+          },
+          "sourceSceneIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "statement": {
+            "type": "string"
+          },
+          "statementSource": {
+            "enum": [
+              "template",
+              "llm"
+            ],
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "supersededBy": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "validFrom": {
+            "type": "string"
+          },
+          "validUntil": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "beliefId",
+          "userId",
+          "subject",
+          "field",
+          "value",
+          "statement",
+          "statementSource",
+          "confidence",
+          "revision",
+          "status",
+          "validFrom",
+          "sourceSceneIds",
+          "conversationIds",
+          "corroborationCount",
+          "conversationCount"
+        ],
+        "type": "object"
+      },
+      "BeliefsListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "beliefs": {
+            "items": {
+              "$ref": "#/components/schemas/BeliefReadResponse"
+            },
+            "type": "array"
+          },
+          "found": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "beliefs",
+          "found"
+        ],
+        "type": "object"
+      },
       "Candidate": {
         "additionalProperties": false,
         "properties": {
@@ -3719,6 +3828,129 @@
         ]
       }
     },
+    "/v1/beliefs": {
+      "get": {
+        "description": "Beliefs the brain currently holds (semantic_belief, promoted from enriched scenes), filtered by exact subject/field key, lifecycle status (default active) and user scope. A user-bound token is pinned to its own user (userId mismatch is 403); M2M keys may scope to any user or list tenant-wide. Page capped at 100 (default 25). 404 until BELIEFS_API_ENABLED=1. Source: src/beliefs/beliefs.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "listBeliefs",
+        "parameters": [
+          {
+            "description": "Free-text subject key (exact match).",
+            "in": "query",
+            "name": "subject",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Free-text field key (exact match).",
+            "in": "query",
+            "name": "field",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "End-user scope key. M2M keys may assert any user; user-bound tokens are pinned to their own.",
+            "in": "query",
+            "name": "userId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Lifecycle filter: `active` (default), `superseded`, `all`.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size (default 25, max 100).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeliefsListResponse"
+                }
+              }
+            },
+            "description": "The visible beliefs."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "List beliefs by their free-text (subject, field) key",
+        "tags": [
+          "Beliefs"
+        ]
+      }
+    },
+    "/v1/beliefs/{id}": {
+      "get": {
+        "description": "One semantic_belief revision as stored: the held value, its rendered statement, confidence, the supersede chain (revision/status/supersededBy/validFrom/validUntil), inline scene provenance (sourceSceneIds) and corroboration counters. Superseded revisions still resolve. Every visibility fence (tenant, fail-closed single-user scope) answers 404 — existence never leaks. 404 until BELIEFS_API_ENABLED=1. Source: src/beliefs/beliefs.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "getBelief",
+        "parameters": [
+          {
+            "description": "Belief record id (`semantic_belief:…`).",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeliefReadResponse"
+                }
+              }
+            },
+            "description": "The belief."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Read one belief revision by id",
+        "tags": [
+          "Beliefs"
+        ]
+      }
+    },
     "/v1/documents/{id}": {
       "get": {
         "description": "Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/documents.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -5101,6 +5333,10 @@
     {
       "description": "Fact-level reads: one fact by id and its grounding episodes — provenance-first memory (\"show me why I remember this\"). Flag: FACTS_API_ENABLED (off → 404); fact retraction stays flag-independent.",
       "name": "Facts"
+    },
+    {
+      "description": "Belief-level reads over the semantic_belief substrate: what the brain currently holds about a free-text (subject, field) key, with its supersede chain and inline scene provenance. Read-only — the scene promotion pass is the only writer. Flag: BELIEFS_API_ENABLED (off → 404).",
+      "name": "Beliefs"
     },
     {
       "description": "Per-user surfaces: the rolling user profile assembled from user-scoped memory. Flag: USER_PROFILE_API_ENABLED (off → 404).",

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -116,6 +116,10 @@ import {
   FactReadResponseSchema,
 } from '../src/contracts/facts/facts.schema';
 import {
+  BeliefReadResponseSchema,
+  BeliefsListResponseSchema,
+} from '../src/contracts/beliefs/beliefs.schema';
+import {
   ProfileFactSchema,
   ProfileSectionSchema,
   UserProfileResponseSchema,
@@ -212,6 +216,9 @@ const ZOD_COMPONENTS: Record<string, z.ZodType> = {
   FactReadResponse: FactReadResponseSchema,
   FactProvenanceEpisode: FactProvenanceEpisodeSchema,
   FactProvenanceResponse: FactProvenanceResponseSchema,
+  // --- belief reads (src/contracts/beliefs/beliefs.schema.ts)
+  BeliefReadResponse: BeliefReadResponseSchema,
+  BeliefsListResponse: BeliefsListResponseSchema,
   // --- rolling user profile (src/contracts/users/user-profile.schema.ts)
   ProfileFact: ProfileFactSchema,
   ProfileSection: ProfileSectionSchema,
@@ -252,8 +259,7 @@ function generateComponentSchemas(): Json {
   out.FeatureDisabledResponse = {
     type: 'object',
     description:
-      'Answered by every document-pipeline route while ' +
-      'DOCUMENT_INGEST_ENABLED is off.',
+      'Answered by every document-pipeline route while ' + 'DOCUMENT_INGEST_ENABLED is off.',
     properties: {
       error: { type: 'string', const: 'feature_disabled' },
       message: { type: 'string' },
@@ -376,8 +382,7 @@ function registryPaths(): Json {
         tag: 'Registry',
         summary: "One pack's published version history",
         description:
-          'All published versions of a pack, newest first, including ' +
-          'yanked ones (flagged).',
+          'All published versions of a pack, newest first, including ' + 'yanked ones (flagged).',
         scope: 'brain:read',
         parameters: [pathParam('packId', 'The pack id.')],
         responses: {
@@ -403,10 +408,7 @@ function registryPaths(): Json {
           pathParam('version', 'A published version, or `latest`.'),
         ],
         responses: {
-          '200': jsonResponse(
-            'The resolved manifest.',
-            ref('RegistryManifestResponse'),
-          ),
+          '200': jsonResponse('The resolved manifest.', ref('RegistryManifestResponse')),
           ...AUTH_ERRORS,
           '404': errorRef('NotFound'),
         },
@@ -483,9 +485,7 @@ function registryPaths(): Json {
           'is entirely unknown (no profile AND no packs). ' +
           'Source: src/registry/registry.controller.ts.',
         scope: 'brain:read',
-        parameters: [
-          pathParam('publisher', 'The publisher id (trust-store key id).'),
-        ],
+        parameters: [pathParam('publisher', 'The publisher id (trust-store key id).')],
         responses: {
           '200': jsonResponse('The publisher page.', ref('PublisherResponse')),
           ...AUTH_ERRORS,
@@ -582,9 +582,7 @@ function marketplacePaths(): Json {
           "instance's trust store is what ties a company to the " +
           'publisher name (403 otherwise).',
         scope: 'registry:publish',
-        parameters: [
-          pathParam('publisher', 'The publisher id (trust-store key id).'),
-        ],
+        parameters: [pathParam('publisher', 'The publisher id (trust-store key id).')],
         requestBody: jsonBody(ref('UpsertPublisherProfileRequest')),
         responses: {
           '200': jsonResponse('The stored profile.', ref('PublisherProfile')),
@@ -600,7 +598,7 @@ function marketplacePaths(): Json {
         summary: 'Start a hosted checkout for a paid pack',
         description:
           'Creates a billing checkout session for the BUYING tenant ' +
-          '(the caller\'s company is the billing userId). Open ' +
+          "(the caller's company is the billing userId). Open " +
           '`checkoutUrl`, pay, then retry ' +
           'POST /v1/admin/packs/from-registry — the 402 hint on that ' +
           'route points here. Answers 400 for a free pack or while the ' +
@@ -691,9 +689,7 @@ function packsAdminPaths(): Json {
         operationId: 'uninstallDomainPack',
         tag: 'Domain Packs',
         summary: 'Uninstall a pack from this tenant',
-        description:
-          "Deprecates the pack's predicates; facts extracted with them " +
-          'survive.',
+        description: "Deprecates the pack's predicates; facts extracted with them " + 'survive.',
         scope: 'brain:admin',
         parameters: [pathParam('packId', 'The installed pack id.')],
         responses: {
@@ -753,10 +749,7 @@ function documentsPaths(): Json {
         requestBody: jsonBody(ref('IngestDocumentRequest')),
         responses: {
           '201': jsonResponse('Ingest outcome — shape follows the requested `mode`.', {
-            oneOf: [
-              ref('IngestDocumentSyncResponse'),
-              ref('IngestDocumentAsyncResponse'),
-            ],
+            oneOf: [ref('IngestDocumentSyncResponse'), ref('IngestDocumentAsyncResponse')],
           }),
           '400': errorRef('BadRequest'),
           '429': errorRef('TooManyRequests'),
@@ -769,9 +762,7 @@ function documentsPaths(): Json {
         operationId: 'getDocument',
         tag: 'Documents',
         summary: 'Read a document header and its indexer runs',
-        description:
-          `${FLAG_NOTE} ` +
-          'Source: src/documents/documents.controller.ts.',
+        description: `${FLAG_NOTE} ` + 'Source: src/documents/documents.controller.ts.',
         scope: 'brain:read',
         parameters: [
           pathParam('id', 'The document id.'),
@@ -855,10 +846,7 @@ function sourcesPaths(): Json {
           'Source: src/sources/public-sources.controller.ts.',
         scope: 'brain:read',
         parameters: [
-          queryParam(
-            'domain',
-            'Capture this domain’s learned rate per source (`domainTrust`).',
-          ),
+          queryParam('domain', 'Capture this domain’s learned rate per source (`domainTrust`).'),
           queryParam('type', 'Only sources declared with this type.', {
             type: 'string',
             enum: [...SOURCE_TYPES],
@@ -876,10 +864,7 @@ function sourcesPaths(): Json {
           queryParam('offset', 'Page offset.', { type: 'integer' }),
         ],
         responses: {
-          '200': jsonResponse(
-            'The reputation catalogue page.',
-            ref('PublicSourcesListResponse'),
-          ),
+          '200': jsonResponse('The reputation catalogue page.', ref('PublicSourcesListResponse')),
           '400': errorRef('BadRequest'),
           ...AUTH_ERRORS,
         },
@@ -898,16 +883,10 @@ function sourcesPaths(): Json {
           'MCP tool serves.',
         scope: 'brain:read',
         parameters: [
-          pathParam(
-            'sourceKey',
-            'Source key, `vertical:recorder` (e.g. `rent:tenant_bot`).',
-          ),
+          pathParam('sourceKey', 'Source key, `vertical:recorder` (e.g. `rent:tenant_bot`).'),
         ],
         responses: {
-          '200': jsonResponse(
-            'The source reputation detail.',
-            ref('PublicSourceDetailResponse'),
-          ),
+          '200': jsonResponse('The source reputation detail.', ref('PublicSourceDetailResponse')),
           ...AUTH_ERRORS,
           '404': errorRef('NotFound'),
         },
@@ -952,10 +931,7 @@ function driverPaths(): Json {
           queryParam('limit', 'Page size (max 200, default 50).', {
             type: 'integer',
           }),
-          queryParam(
-            'cursor',
-            'Opaque keyset cursor from the previous page (`nextCursor`).',
-          ),
+          queryParam('cursor', 'Opaque keyset cursor from the previous page (`nextCursor`).'),
         ],
         responses: {
           '200': jsonResponse('One page of episodes.', ref('EpisodesListResponse')),
@@ -1022,15 +998,10 @@ function driverPaths(): Json {
         operationId: 'listEpisodeSubscriptions',
         tag: 'Episodes',
         summary: 'List registered webhook endpoints',
-        description:
-          'Secrets are never included. 404 until ' +
-          'EPISODE_SUBSCRIPTIONS_ENABLED=1.',
+        description: 'Secrets are never included. 404 until ' + 'EPISODE_SUBSCRIPTIONS_ENABLED=1.',
         scope: 'brain:read',
         responses: {
-          '200': jsonResponse(
-            'Registered endpoints.',
-            ref('EpisodeSubscriptionsListResponse'),
-          ),
+          '200': jsonResponse('Registered endpoints.', ref('EpisodeSubscriptionsListResponse')),
           ...DRIVER_404,
         },
       }),
@@ -1042,9 +1013,7 @@ function driverPaths(): Json {
         summary: 'Delete a webhook endpoint',
         description: '404 until EPISODE_SUBSCRIPTIONS_ENABLED=1.',
         scope: 'brain:admin',
-        parameters: [
-          pathParam('id', 'The episode_subscription record id.'),
-        ],
+        parameters: [pathParam('id', 'The episode_subscription record id.')],
         responses: {
           '200': jsonResponse(
             'Whether a subscription was deleted.',
@@ -1069,10 +1038,7 @@ function driverPaths(): Json {
           'src/admin/projections.controller.ts.',
         scope: 'brain:read',
         responses: {
-          '200': jsonResponse(
-            'Derived worlds + read pin.',
-            ref('ProjectionsListResponse'),
-          ),
+          '200': jsonResponse('Derived worlds + read pin.', ref('ProjectionsListResponse')),
           ...DRIVER_404,
         },
       }),
@@ -1089,9 +1055,7 @@ function driverPaths(): Json {
           'live read pin (`activate`). Rewriting the pinned world needs ' +
           '`force`. 404 until PROJECTIONS_API_ENABLED=1.',
         scope: 'brain:admin',
-        parameters: [
-          pathParam('name', 'The projection name (v1: `facts`).'),
-        ],
+        parameters: [pathParam('name', 'The projection name (v1: `facts`).')],
         requestBody: {
           required: false,
           content: {
@@ -1099,10 +1063,7 @@ function driverPaths(): Json {
           },
         },
         responses: {
-          '200': jsonResponse(
-            'The batch result.',
-            ref('RebuildProjectionResponse'),
-          ),
+          '200': jsonResponse('The batch result.', ref('RebuildProjectionResponse')),
           '400': errorRef('BadRequest'),
           ...DRIVER_404,
         },
@@ -1113,9 +1074,9 @@ function driverPaths(): Json {
 
 /**
  * Memory read surface: fact-by-id + provenance ("show me why I
- * remember this") and the rolling user profile. Dark behind
- * default-off flags with 404 (an absent surface is indistinguishable
- * from a disabled one).
+ * remember this"), belief reads (semantic_belief) and the rolling user
+ * profile. Dark behind default-off flags with 404 (an absent surface
+ * is indistinguishable from a disabled one).
  */
 function memoryReadPaths(): Json {
   return {
@@ -1152,10 +1113,65 @@ function memoryReadPaths(): Json {
         scope: 'brain:read',
         parameters: [pathParam('id', 'Fact record id (`knowledge_fact:…`).')],
         responses: {
-          '200': jsonResponse(
-            'The grounding episodes.',
-            ref('FactProvenanceResponse'),
+          '200': jsonResponse('The grounding episodes.', ref('FactProvenanceResponse')),
+          ...DRIVER_404,
+        },
+      }),
+    },
+    '/v1/beliefs': {
+      get: operation({
+        operationId: 'listBeliefs',
+        tag: 'Beliefs',
+        summary: 'List beliefs by their free-text (subject, field) key',
+        description:
+          'Beliefs the brain currently holds (semantic_belief, promoted ' +
+          'from enriched scenes), filtered by exact subject/field key, ' +
+          'lifecycle status (default active) and user scope. A ' +
+          'user-bound token is pinned to its own user (userId mismatch ' +
+          'is 403); M2M keys may scope to any user or list tenant-wide. ' +
+          'Page capped at 100 (default 25). 404 until ' +
+          'BELIEFS_API_ENABLED=1. Source: ' +
+          'src/beliefs/beliefs.controller.ts.',
+        scope: 'brain:read',
+        parameters: [
+          queryParam('subject', 'Free-text subject key (exact match).'),
+          queryParam('field', 'Free-text field key (exact match).'),
+          queryParam(
+            'userId',
+            'End-user scope key. M2M keys may assert any user; ' +
+              'user-bound tokens are pinned to their own.',
           ),
+          queryParam('status', 'Lifecycle filter: `active` (default), `superseded`, `all`.'),
+          queryParam('limit', 'Page size (default 25, max 100).', {
+            type: 'integer',
+          }),
+        ],
+        responses: {
+          '200': jsonResponse('The visible beliefs.', ref('BeliefsListResponse')),
+          '400': errorRef('BadRequest'),
+          ...DRIVER_404,
+        },
+      }),
+    },
+    '/v1/beliefs/{id}': {
+      get: operation({
+        operationId: 'getBelief',
+        tag: 'Beliefs',
+        summary: 'Read one belief revision by id',
+        description:
+          'One semantic_belief revision as stored: the held value, its ' +
+          'rendered statement, confidence, the supersede chain ' +
+          '(revision/status/supersededBy/validFrom/validUntil), inline ' +
+          'scene provenance (sourceSceneIds) and corroboration ' +
+          'counters. Superseded revisions still resolve. Every ' +
+          'visibility fence (tenant, fail-closed single-user scope) ' +
+          'answers 404 — existence never leaks. 404 until ' +
+          'BELIEFS_API_ENABLED=1. Source: ' +
+          'src/beliefs/beliefs.controller.ts.',
+        scope: 'brain:read',
+        parameters: [pathParam('id', 'Belief record id (`semantic_belief:…`).')],
+        responses: {
+          '200': jsonResponse('The belief.', ref('BeliefReadResponse')),
           ...DRIVER_404,
         },
       }),
@@ -1179,16 +1195,10 @@ function memoryReadPaths(): Json {
           queryParam('maxFacts', 'Global fact budget (default 60, max 200).', {
             type: 'integer',
           }),
-          queryParam(
-            'lang',
-            'Soft locale filter (facts in this language or unmarked).',
-          ),
+          queryParam('lang', 'Soft locale filter (facts in this language or unmarked).'),
         ],
         responses: {
-          '200': jsonResponse(
-            'The assembled profile.',
-            ref('UserProfileResponse'),
-          ),
+          '200': jsonResponse('The assembled profile.', ref('UserProfileResponse')),
           '400': errorRef('BadRequest'),
           ...DRIVER_404,
         },
@@ -1315,8 +1325,7 @@ function sortKeysDeep(value: unknown): unknown {
 }
 
 function errorResponses(): Json {
-  const err = (description: string): Json =>
-    jsonResponse(description, ref('ErrorResponse'));
+  const err = (description: string): Json => jsonResponse(description, ref('ErrorResponse'));
   return {
     BadRequest: err('Validation failed.'),
     Unauthorized: err('Missing or unknown bearer key.'),
@@ -1340,9 +1349,9 @@ function errorResponses(): Json {
 }
 
 export function buildOpenApiDocument(): Json {
-  const pkg = JSON.parse(
-    readFileSync(join(__dirname, '..', 'package.json'), 'utf8'),
-  ) as { version: string };
+  const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8')) as {
+    version: string;
+  };
 
   const document: Json = {
     openapi: '3.1.0',
@@ -1377,14 +1386,12 @@ export function buildOpenApiDocument(): Json {
       {
         name: 'Registry',
         description:
-          'Discovery reads over the global Domain Pack registry ' +
-          '(shared across all tenants).',
+          'Discovery reads over the global Domain Pack registry ' + '(shared across all tenants).',
       },
       {
         name: 'Registry publishing',
         description:
-          'Publisher-facing writes to the global registry ' +
-          '(scope `registry:publish`).',
+          'Publisher-facing writes to the global registry ' + '(scope `registry:publish`).',
       },
       {
         name: 'Marketplace',
@@ -1445,6 +1452,15 @@ export function buildOpenApiDocument(): Json {
           'provenance-first memory ("show me why I remember this"). ' +
           'Flag: FACTS_API_ENABLED (off → 404); fact retraction stays ' +
           'flag-independent.',
+      },
+      {
+        name: 'Beliefs',
+        description:
+          'Belief-level reads over the semantic_belief substrate: what ' +
+          'the brain currently holds about a free-text (subject, field) ' +
+          'key, with its supersede chain and inline scene provenance. ' +
+          'Read-only — the scene promotion pass is the only writer. ' +
+          'Flag: BELIEFS_API_ENABLED (off → 404).',
       },
       {
         name: 'Users',
@@ -1542,12 +1558,8 @@ function main(): void {
   const body = JSON.stringify(document, null, 2) + '\n';
   for (const outPath of OUT_PATHS) writeFileSync(outPath, body, 'utf8');
   const paths = Object.keys(document.paths as Json).length;
-  const schemas = Object.keys(
-    (document.components as Json).schemas as Json,
-  ).length;
-  process.stdout.write(
-    `wrote ${OUT_PATHS.length} copies (${paths} paths, ${schemas} schemas)\n`,
-  );
+  const schemas = Object.keys((document.components as Json).schemas as Json).length;
+  process.stdout.write(`wrote ${OUT_PATHS.length} copies (${paths} paths, ${schemas} schemas)\n`);
 }
 
 if (require.main === module) main();

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -2129,6 +2129,17 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Fact read + provenance API ("show me why I remember this"): GET /v1/facts/:id serves the fact as stored (aspect/statement/confidence/validFrom, source attribution, retracted flag, derivedVersion) and GET /v1/facts/:id/provenance serves its verbatim grounding turns (source.episodeIds via the shared episode read port, text capped at 600 chars). Every miss is a 404 — tenant fence, fail-closed user scope (another user\'s fact is indistinguishable from absent), registry-backed row policy on scope-fenced predicates; episode text respects brain:read_pii. POST /v1/facts/:id/retract is deliberately NOT gated by this flag (write/GDPR path). Off (default) → read routes answer 404.',
   },
   {
+    key: 'BELIEFS_API_ENABLED',
+    category: 'pipeline',
+    // Read at call time (BeliefsController.assertEnabled) — never
+    // captured in a constructor — so a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Belief read API (Belief-B): GET /v1/beliefs/:id serves one semantic_belief revision as stored (free-text subject/field key, value/priorValue, statement, confidence, revision/status/supersededBy supersede chain, validFrom/validUntil, inline sourceSceneIds provenance, corroboration counters, promoterVersion) and GET /v1/beliefs lists by subject/field/status/userId with a capped page (default 25, max 100). Read-only — the Belief-A promotion pass (SCENES_BELIEF_PROMOTION) stays the only writer. Every miss is a 404 — tenant fence + fail-closed single-user scope (#387: a belief is always one user's; a user-bound token sees only its own, an unstamped row serves to no one); beliefs carry no piiClass and no registry predicate, so no PII/row-policy fence applies. Off (default) → routes answer 404.",
+  },
+  {
     key: 'PROVENANCE_SUMMARY_EPISODE_STAMP',
     category: 'pipeline',
     defaultValue: '0',

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { EpisodesModule } from './episodes/episodes.module';
 import { MultiHopModule } from './multi-hop/multi-hop.module';
 import { AgentQaModule } from './agent-qa/agent-qa.module';
 import { FactsModule } from './facts/facts.module';
+import { BeliefsModule } from './beliefs/beliefs.module';
 import { EntitiesModule } from './entities/entities.module';
 import { ArtifactsModule } from './artifacts/artifacts.module';
 import { McpModule } from './mcp/mcp.module';
@@ -88,6 +89,7 @@ import { MriModule } from './mri/mri.module';
     MultiHopModule,
     AgentQaModule,
     FactsModule,
+    BeliefsModule,
     EntitiesModule,
     ArtifactsModule,
     FeedbackModule,

--- a/src/beliefs/beliefs.controller.ts
+++ b/src/beliefs/beliefs.controller.ts
@@ -1,0 +1,112 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import { PolicyAction } from '../policy/action-registry';
+import { envFlagEnabled } from '../common/env-validation';
+import { AuthenticatedRequest } from '../auth/api-key.types';
+import {
+  BELIEF_STATUS_FILTERS,
+  BELIEFS_LIST_DEFAULT,
+  BELIEFS_LIST_MAX,
+  BeliefsService,
+  type BeliefReadResult,
+  type BeliefsListResult,
+  type BeliefStatusFilter,
+} from './beliefs.service';
+
+/**
+ * Belief read API (Belief-B): the semantic_belief substrate (migration
+ * 0120) as a read-only contract — what the brain currently HOLDS about a
+ * free-text (subject, field) key, with its supersede chain and inline
+ * scene provenance. Read-only by design: the ONLY writer stays the
+ * Belief-A promotion pass; GDPR erasure runs through the forget
+ * cascades, so no retract verb exists here (unlike /v1/facts).
+ *
+ * Deliberately minimal v1 surface:
+ *  - NO provenance endpoint yet — a get_fact_provenance-style walk
+ *    (sourceSceneIds -> scene members -> verbatim turns through the
+ *    PII-fenced episode read port) is future work;
+ *  - NO memory_support edge exposure (supportEdges stays internal);
+ *  - NO MCP twins yet — surface parity with the fact read tools is a
+ *    follow-up PR.
+ */
+
+interface BeliefListQuery {
+  /** Free-text subject key (exact match). */
+  subject?: string;
+  /** Free-text field key (exact match). */
+  field?: string;
+  /** End-user scope key — M2M may assert any; user-bound tokens are
+   *  pinned to their own user (mismatch = 403). */
+  userId?: string;
+  /** Lifecycle filter: active (default) | superseded | all. */
+  status?: string;
+  limit?: string;
+}
+
+@Controller('v1/beliefs')
+@UseGuards(ApiKeyGuard)
+export class BeliefsController {
+  constructor(private readonly beliefs: BeliefsService) {}
+
+  /**
+   * Read-surface gate (BELIEFS_API_ENABLED, default off → 404 —
+   * indistinguishable from an absent route; the FACTS_API_ENABLED /
+   * EPISODES_API_ENABLED idiom). Read at call time so a flip is
+   * runtime-mutable.
+   */
+  private assertEnabled(): void {
+    if (!envFlagEnabled(process.env.BELIEFS_API_ENABLED)) {
+      throw new NotFoundException();
+    }
+  }
+
+  /** List beliefs by the free-text (subject, field) key, page-capped. */
+  @Get()
+  @RequireScopes('brain:read')
+  @PolicyAction('list_beliefs')
+  async list(
+    @Req() req: AuthenticatedRequest,
+    @Query() q: BeliefListQuery,
+  ): Promise<BeliefsListResult> {
+    this.assertEnabled();
+    const limitRaw = q.limit !== undefined ? parseInt(q.limit, 10) : BELIEFS_LIST_DEFAULT;
+    if (!Number.isFinite(limitRaw) || limitRaw < 1) {
+      throw new BadRequestException(`limit must be 1..${BELIEFS_LIST_MAX}`);
+    }
+    const status = q.status ?? 'active';
+    if (!(BELIEF_STATUS_FILTERS as readonly string[]).includes(status)) {
+      throw new BadRequestException(`status must be one of ${BELIEF_STATUS_FILTERS.join(', ')}`);
+    }
+    return this.beliefs.listBeliefs({
+      companyId: req.brainAuth.companyId,
+      scopes: req.brainAuth.scopes,
+      subject: q.subject,
+      field: q.field,
+      userId: q.userId,
+      status: status as BeliefStatusFilter,
+      limit: Math.min(limitRaw, BELIEFS_LIST_MAX),
+    });
+  }
+
+  /** One belief revision — "what do you currently hold, and since when". */
+  @Get(':id')
+  @RequireScopes('brain:read')
+  @PolicyAction('get_belief')
+  async get(@Req() req: AuthenticatedRequest, @Param('id') id: string): Promise<BeliefReadResult> {
+    this.assertEnabled();
+    return this.beliefs.getBelief({
+      companyId: req.brainAuth.companyId,
+      beliefId: id,
+      scopes: req.brainAuth.scopes,
+    });
+  }
+}

--- a/src/beliefs/beliefs.module.ts
+++ b/src/beliefs/beliefs.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { BeliefsController } from './beliefs.controller';
+import { BeliefsService } from './beliefs.service';
+
+@Module({
+  controllers: [BeliefsController],
+  providers: [BeliefsService],
+  exports: [BeliefsService],
+})
+export class BeliefsModule {}

--- a/src/beliefs/beliefs.service.ts
+++ b/src/beliefs/beliefs.service.ts
@@ -1,0 +1,276 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { SurrealService, queryRows } from '../db/surreal.service';
+import { BrainScope } from '../auth/api-key.types';
+import { pinUserScope } from '../auth/user-scope';
+
+/**
+ * Belief read surface (Belief-B, BELIEFS_API_ENABLED — default off →
+ * 404): read-only serving of the semantic_belief substrate (migration
+ * 0120) the Belief-A promotion pass writes. Mirrors the FactsService
+ * read idiom (getFact / listByPredicate) — every visibility miss is a
+ * 404, never a 403, so existence never leaks.
+ *
+ * Fences (getBelief; the list pushes the same verdict into WHERE and
+ * re-applies it in JS):
+ *  - tenant: withScopedCompany pins the per-tenant database — a foreign
+ *    tenant's belief id simply is not present here;
+ *  - user scope: a belief ALWAYS carries the single-user scope its
+ *    promotion stamped (#387 fail-closed fence — never tenant-global).
+ *    Via pinUserScope, a user-bound token sees only its OWN beliefs;
+ *    an M2M credential sees the whole tenant. A row whose userId stamp
+ *    is missing/blank (out-of-contract) is invisible to EVERYONE —
+ *    fail-closed, the same doctrine the promotion applies on write.
+ *
+ * No PII fence: semantic_belief carries no piiClass column (0120) —
+ * statements are distilled state, not verbatim turns; the raw text
+ * stays behind the episode read port's brain:read_pii gate.
+ *
+ * No row policy: beliefs are keyed by FREE-TEXT (subject, field), not
+ * by registry predicates — the predicate-scope fence has nothing to
+ * key on (the 0120 SemanticBelief/Claim separation).
+ */
+
+/** Page caps of GET /v1/beliefs (the episodes-list idiom). */
+export const BELIEFS_LIST_MAX = 100;
+export const BELIEFS_LIST_DEFAULT = 25;
+
+/** Lifecycle filter values GET /v1/beliefs accepts (default 'active'). */
+export const BELIEF_STATUS_FILTERS = ['active', 'superseded', 'all'] as const;
+export type BeliefStatusFilter = (typeof BELIEF_STATUS_FILTERS)[number];
+
+/** Wire shape of GET /v1/beliefs/:id (and each list member). */
+export interface BeliefReadResult {
+  beliefId: string;
+  userId: string;
+  subject: string;
+  field: string;
+  value: string;
+  priorValue?: string;
+  statement: string;
+  statementSource: 'template' | 'llm';
+  confidence: number;
+  revision: number;
+  status: string;
+  supersededBy?: string;
+  validFrom: string;
+  validUntil?: string;
+  sourceSceneIds: string[];
+  conversationIds: string[];
+  corroborationCount: number;
+  conversationCount: number;
+  promoterVersion?: string;
+}
+
+/** Wire shape of GET /v1/beliefs. */
+export interface BeliefsListResult {
+  beliefs: BeliefReadResult[];
+  found: number;
+}
+
+/** Row shape the read queries select (values validated in JS). */
+export interface BeliefReadRow {
+  id: unknown;
+  userId?: unknown;
+  subject?: unknown;
+  field?: unknown;
+  value?: unknown;
+  priorValue?: unknown;
+  statement?: unknown;
+  statementSource?: unknown;
+  confidence?: unknown;
+  revision?: unknown;
+  status?: unknown;
+  supersededBy?: unknown;
+  validFrom?: unknown;
+  validUntil?: unknown;
+  sourceSceneIds?: unknown;
+  conversationIds?: unknown;
+  corroborationCount?: unknown;
+  conversationCount?: unknown;
+  promoterVersion?: unknown;
+}
+
+/**
+ * The user-scope fence of the belief read path as a pure verdict
+ * (the factVisible idiom). scopeUserId is pinUserScope(undefined):
+ * undefined = M2M/tenant-wide, else the token's one user. Fail-closed:
+ * a row without a well-formed single-user stamp — which the promotion
+ * never writes (#387) — is visible to NO caller, M2M included.
+ */
+export function beliefVisible(
+  belief: Pick<BeliefReadRow, 'userId'>,
+  scopeUserId: string | undefined,
+): boolean {
+  const owner =
+    typeof belief.userId === 'string' && belief.userId.length > 0 ? belief.userId : null;
+  if (owner === null) return false;
+  return scopeUserId === undefined || owner === scopeUserId;
+}
+
+const SELECT_COLUMNS = `id, userId, subject, field, value, priorValue,
+              statement, statementSource, confidence, revision, status,
+              supersededBy, validFrom, validUntil, sourceSceneIds,
+              conversationIds, corroborationCount, conversationCount,
+              promoterVersion`;
+
+interface BeliefReadOptions {
+  companyId: string;
+  beliefId: string;
+  scopes: readonly BrainScope[];
+}
+
+export interface BeliefListOptions {
+  companyId: string;
+  scopes: readonly BrainScope[];
+  /** Free-text subject key filter (exact match). */
+  subject?: string | undefined;
+  /** Free-text field key filter (exact match). */
+  field?: string | undefined;
+  /**
+   * Caller-asserted user scope — pinned via pinUserScope: an M2M key
+   * may scope to any user (or omit for tenant-wide), a user-bound
+   * token is pinned to its own user (mismatch = 403, the platform-wide
+   * pin idiom).
+   */
+  userId?: string | undefined;
+  /** Lifecycle filter, already validated ('active' default). */
+  status: BeliefStatusFilter;
+  /** Page size, already clamped to 1..BELIEFS_LIST_MAX. */
+  limit: number;
+}
+
+@Injectable()
+export class BeliefsService {
+  constructor(private readonly surreal: SurrealService) {}
+
+  /**
+   * GET /v1/beliefs/:id — one belief revision as stored. Superseded
+   * revisions still resolve (status/supersededBy/validUntil tell the
+   * story) — only visibility fences turn into 404s, and any miss is
+   * the same 404 ("absent" and "fenced" are indistinguishable).
+   */
+  async getBelief(opts: BeliefReadOptions): Promise<BeliefReadResult> {
+    return this.surreal.withScopedCompany(opts.companyId, opts.scopes, async (db) => {
+      const tail = this.normalizeBeliefId(opts.beliefId);
+      const rows = await queryRows<BeliefReadRow>(
+        db,
+        `SELECT ${SELECT_COLUMNS}
+           FROM type::record('semantic_belief', $rid) LIMIT 1`,
+        { rid: tail },
+      );
+      const belief = rows[0];
+      if (!belief || !beliefVisible(belief, pinUserScope(undefined))) {
+        throw new NotFoundException(`Belief ${opts.beliefId} not found`);
+      }
+      return toWire(belief);
+    });
+  }
+
+  /**
+   * GET /v1/beliefs — list by the free-text (subject, field) key.
+   * The user fence is pushed into WHERE (index-backed belief_user_idx;
+   * WHERE on secondary-indexed fields is safe for SELECT — only DELETE
+   * hits the 3.2.4 planner no-op) so LIMIT never starves the page, and
+   * re-applied in JS fail-closed (out-of-contract rows never serve).
+   */
+  async listBeliefs(opts: BeliefListOptions): Promise<BeliefsListResult> {
+    const scopeUserId = pinUserScope(opts.userId);
+    return this.surreal.withScopedCompany(opts.companyId, opts.scopes, async (db) => {
+      const clauses: string[] = [];
+      const params: Record<string, unknown> = {};
+      if (scopeUserId !== undefined) {
+        clauses.push('userId = $u');
+        params.u = scopeUserId;
+      } else {
+        // The fail-closed leg of beliefVisible, pushed into WHERE: an
+        // out-of-contract blank stamp must not occupy page slots either
+        // (the F1 lesson — a fence applied after LIMIT starves the
+        // page). userId is TYPE string (0120), so blank is the only
+        // DB-representable out-of-contract shape.
+        clauses.push(`userId != ''`);
+      }
+      if (opts.subject !== undefined) {
+        clauses.push('subject = $s');
+        params.s = opts.subject;
+      }
+      if (opts.field !== undefined) {
+        clauses.push('field = $f');
+        params.f = opts.field;
+      }
+      if (opts.status !== 'all') {
+        clauses.push('status = $st');
+        params.st = opts.status;
+      }
+      const where = clauses.length > 0 ? ` WHERE ${clauses.join(' AND ')}` : '';
+      const rows = await queryRows<BeliefReadRow>(
+        db,
+        `SELECT ${SELECT_COLUMNS}
+           FROM semantic_belief${where}
+          ORDER BY userId ASC, subject ASC, field ASC, revision DESC
+          LIMIT ${opts.limit}`,
+        params,
+      );
+      const beliefs = rows.filter((r) => beliefVisible(r, scopeUserId)).map(toWire);
+      return { beliefs, found: beliefs.length };
+    });
+  }
+
+  /** Accept either `<id>` or `semantic_belief:<id>` as the path param. */
+  private normalizeBeliefId(raw: string): string {
+    return raw.startsWith('semantic_belief:') ? raw.slice('semantic_belief:'.length) : raw;
+  }
+}
+
+/** Wire mapping — record ids stringified, datetimes normalized to ISO. */
+function toWire(row: BeliefReadRow): BeliefReadResult {
+  const str = (v: unknown): string | undefined =>
+    typeof v === 'string' && v.length > 0 ? v : undefined;
+  const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+  const strings = (v: unknown): string[] => (Array.isArray(v) ? v.map(String) : []);
+  return {
+    beliefId: String(row.id),
+    userId: String(row.userId ?? ''),
+    subject: String(row.subject ?? ''),
+    field: String(row.field ?? ''),
+    value: String(row.value ?? ''),
+    ...(str(row.priorValue) !== undefined ? { priorValue: str(row.priorValue)! } : {}),
+    statement: String(row.statement ?? ''),
+    // Closed enum by schema assert (0120); anything off-contract reports
+    // the deterministic fold, never a fabricated 'llm' attribution.
+    statementSource: row.statementSource === 'llm' ? 'llm' : 'template',
+    confidence: num(row.confidence),
+    revision: num(row.revision),
+    status: String(row.status ?? 'active'),
+    ...(row.supersededBy !== undefined && row.supersededBy !== null
+      ? { supersededBy: String(row.supersededBy) }
+      : {}),
+    validFrom: toIso(row.validFrom),
+    ...(row.validUntil !== undefined && row.validUntil !== null
+      ? { validUntil: toIso(row.validUntil) }
+      : {}),
+    sourceSceneIds: strings(row.sourceSceneIds),
+    conversationIds: strings(row.conversationIds),
+    corroborationCount: num(row.corroborationCount),
+    conversationCount: num(row.conversationCount),
+    ...(str(row.promoterVersion) !== undefined
+      ? { promoterVersion: str(row.promoterVersion)! }
+      : {}),
+  };
+}
+
+function toIso(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return new Date(value).toISOString();
+  // SurrealDB SDK datetime columns decode to the SDK's own DateTime
+  // class — duck-type on toISOString (the FactsService toIso lesson:
+  // falling through to "now" silently serves request time).
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { toISOString?: unknown }).toISOString === 'function'
+  ) {
+    return (value as { toISOString: () => string }).toISOString();
+  }
+  return new Date(0).toISOString();
+}

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -614,6 +614,10 @@ const KNOWN_BOOLEAN_FLAGS = [
   // Fact read + provenance API: GET /v1/facts/:id and /:id/provenance
   // (grounding episodes). The retract write path stays ungated (GDPR).
   'FACTS_API_ENABLED',
+  // Belief read API (Belief-B): GET /v1/beliefs and /v1/beliefs/:id over
+  // the semantic_belief substrate (0120). Read-only — the promotion pass
+  // stays the only writer. Default off → routes 404.
+  'BELIEFS_API_ENABLED',
   // Raw-substrate driver v1 surface 3: projections registry API + rebuild verb.
   'PROJECTIONS_API_ENABLED',
   // Raw-substrate driver v1 surface 4: new-episode webhook push (watermark

--- a/src/contracts/beliefs/beliefs.schema.ts
+++ b/src/contracts/beliefs/beliefs.schema.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+
+/**
+ * Wire contracts for the belief read API (Belief-B: GET /v1/beliefs/:id,
+ * GET /v1/beliefs — BELIEFS_API_ENABLED, default off → 404). Serves the
+ * semantic_belief substrate (migration 0120) written by the Belief-A
+ * promotion pass. Runtime parity with the service result types is
+ * pinned by test/contracts-beliefs.unit-spec.ts.
+ */
+
+export const BeliefReadResponseSchema = z.object({
+  beliefId: z.string(),
+  /**
+   * The single-user scope the promotion stamped (#387 fence: a belief
+   * always inherits its scenes' one user — never tenant-global).
+   */
+  userId: z.string(),
+  /** FREE-TEXT (subject, field) key from scene stateDeltas — deliberately
+   *  NOT entity-resolved (the 0120 SemanticBelief/Claim separation). */
+  subject: z.string(),
+  field: z.string(),
+  /** The held value. */
+  value: z.string(),
+  /** The value this revision displaced; absent on an unknown prior. */
+  priorValue: z.string().optional(),
+  /** Rendered statement ('template' fold or optional 'llm' phrasing). */
+  statement: z.string(),
+  statementSource: z.enum(['template', 'llm']),
+  confidence: z.number(),
+  /** Supersede-chain position (revision N+1 displaces N, never in-place). */
+  revision: z.number(),
+  /** Bitemporal lifecycle (the 0047 vocabulary subset): 'active' or
+   *  'superseded'. String, not enum — additive-friendly on widening. */
+  status: z.string(),
+  /** Record id of the displacing revision; absent while active. */
+  supersededBy: z.string().optional(),
+  validFrom: z.string(),
+  validUntil: z.string().optional(),
+  /** Inline canonical provenance: the promoted scene record ids. */
+  sourceSceneIds: z.array(z.string()),
+  /** Distinct conversations behind those scenes. */
+  conversationIds: z.array(z.string()),
+  /** Corroboration counters (in-place updatable by contract). */
+  corroborationCount: z.number(),
+  conversationCount: z.number(),
+  /** Readable promoter|world composite stamped by the promotion pass. */
+  promoterVersion: z.string().optional(),
+});
+
+export const BeliefsListResponseSchema = z.object({
+  /** Beliefs visible to the caller after every fence, page-capped. */
+  beliefs: z.array(BeliefReadResponseSchema),
+  /** Rows returned (NOT a total count — the page size after fencing). */
+  found: z.number(),
+});
+
+export type BeliefReadResponse = z.infer<typeof BeliefReadResponseSchema>;
+export type BeliefsListResponse = z.infer<typeof BeliefsListResponseSchema>;

--- a/src/policy/action-registry.ts
+++ b/src/policy/action-registry.ts
@@ -46,6 +46,11 @@ export const ACTIONS: Record<string, ActionSpec> = {
     family: 'mcp_read',
     title: 'Fact provenance (grounding episodes)',
   },
+  // Belief read API (Belief-B, semantic_belief substrate). Tool-shaped
+  // names for the same reason as get_fact: the future MCP twins reuse
+  // these actions (surface parity follow-up).
+  get_belief: { kind: 'read', family: 'mcp_read', title: 'Get belief' },
+  list_beliefs: { kind: 'read', family: 'mcp_read', title: 'List beliefs' },
   summarize_entity: { kind: 'read', family: 'mcp_read', title: 'Summarize entity' },
   detect_contradiction: { kind: 'read', family: 'mcp_read', title: 'Detect contradiction' },
   why: { kind: 'read', family: 'mcp_read', title: 'Code-memory why' },

--- a/test/beliefs-api.e2e-spec.ts
+++ b/test/beliefs-api.e2e-spec.ts
@@ -1,0 +1,282 @@
+/**
+ * Belief-B e2e on real SurrealDB: the read API over semantic_belief
+ * (GET /v1/beliefs/:id + GET /v1/beliefs, BELIEFS_API_ENABLED).
+ *
+ * Pins:
+ *  - default-off → BOTH routes 404 byte-identically (the FACTS_API
+ *    idiom: an absent surface is indistinguishable from a disabled one);
+ *  - visibility fences: user-bound tokens see only their OWN beliefs
+ *    (another user's id is a 404, the list silently narrows), a
+ *    caller-asserted userId mismatch is a 403 (pinUserScope), and an
+ *    out-of-contract row (blank userId stamp) serves to NO ONE — M2M
+ *    included, fail-closed;
+ *  - list caps + filters: subject/field exact match, status default
+ *    'active', limit clamp/validation;
+ *  - wire contract: live responses parse against the zod schemas.
+ *
+ * Belief rows are seeded directly in the DB (the belief-promotion
+ * entity-forget precedent): the promotion pass has its own suite; the
+ * read path serves rows regardless of who wrote them.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import {
+  BeliefReadResponseSchema,
+  BeliefsListResponseSchema,
+} from '../src/contracts/beliefs/beliefs.schema';
+
+const USER = 'belief_reader_u1';
+const OTHER_USER = 'belief_reader_u2';
+
+describe('beliefs read API (e2e)', () => {
+  let f: AppFixture;
+  const m2m = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const userToken = () => ({ Authorization: `Bearer ${f.extraApiKeys[0]}` });
+
+  const savedFlag = process.env.BELIEFS_API_ENABLED;
+
+  const db = <T>(
+    fn: (d: { query: <Q>(sql: string, p?: Record<string, unknown>) => Promise<Q> }) => Promise<T>,
+  ): Promise<T> => f.app.get(SurrealService).withCompany(f.companyId, fn);
+
+  const seedBelief = async (opts: {
+    tail: string;
+    user: string;
+    subject: string;
+    field: string;
+    value: string;
+    revision: number;
+    status: 'active' | 'superseded';
+    priorValue?: string;
+    supersededBy?: string;
+    validUntil?: string;
+  }): Promise<void> => {
+    await db(async (d) => {
+      await d.query(
+        `CREATE type::record('semantic_belief', $tail) CONTENT {
+           userId: $user, subject: $subject, field: $field, value: $value,
+           ${opts.priorValue !== undefined ? 'priorValue: $prior,' : ''}
+           ${opts.supersededBy !== undefined ? `supersededBy: type::record('semantic_belief', $sup),` : ''}
+           ${opts.validUntil !== undefined ? 'validUntil: <datetime>$until,' : ''}
+           statement: $stmt, statementSource: 'template',
+           confidence: 0.85, revision: $revision, status: $status,
+           validFrom: <datetime>'2026-03-01T10:00:00.000Z',
+           sourceSceneIds: [memory_episode:seed_scene],
+           conversationIds: ['proj:c1'], corroborationCount: 1,
+           conversationCount: 1,
+           promoterVersion: 'belief-promotion-v1|scene-segmenter-v1'
+         }`,
+        {
+          tail: opts.tail,
+          user: opts.user,
+          subject: opts.subject,
+          field: opts.field,
+          value: opts.value,
+          stmt: `${opts.subject} — ${opts.field}: ${opts.value}`,
+          revision: opts.revision,
+          status: opts.status,
+          ...(opts.priorValue !== undefined ? { prior: opts.priorValue } : {}),
+          ...(opts.supersededBy !== undefined ? { sup: opts.supersededBy } : {}),
+          ...(opts.validUntil !== undefined ? { until: opts.validUntil } : {}),
+        },
+      );
+    });
+  };
+
+  beforeAll(async () => {
+    delete process.env.BELIEFS_API_ENABLED;
+    f = await createApp({
+      companyId: 'co_beliefs_api_e2e',
+      extraKeys: [{ scopes: ['brain:read'], userId: USER }],
+    });
+
+    // USER's home.city supersede chain (rev1 superseded -> rev2 active).
+    await seedBelief({
+      tail: 'b_city_r1',
+      user: USER,
+      subject: 'mika',
+      field: 'home.city',
+      value: 'lisbon',
+      revision: 1,
+      status: 'superseded',
+      supersededBy: 'b_city_r2',
+      validUntil: '2026-03-05T10:00:00.000Z',
+    });
+    await seedBelief({
+      tail: 'b_city_r2',
+      user: USER,
+      subject: 'mika',
+      field: 'home.city',
+      value: 'porto',
+      revision: 2,
+      status: 'active',
+      priorValue: 'lisbon',
+    });
+    await seedBelief({
+      tail: 'b_coffee',
+      user: USER,
+      subject: 'mika',
+      field: 'coffee.pref',
+      value: 'espresso',
+      revision: 1,
+      status: 'active',
+    });
+    // Another user's belief — invisible to USER's token.
+    await seedBelief({
+      tail: 'b_other',
+      user: OTHER_USER,
+      subject: 'other',
+      field: 'pet',
+      value: 'dog',
+      revision: 1,
+      status: 'active',
+    });
+    // Out-of-contract stamp (blank userId — the promotion never writes
+    // this, #387): must serve to NO caller, fail-closed.
+    await seedBelief({
+      tail: 'b_corrupt',
+      user: '',
+      subject: 'ghost',
+      field: 'x',
+      value: 'y',
+      revision: 1,
+      status: 'active',
+    });
+  }, 120000);
+
+  afterAll(async () => {
+    if (savedFlag === undefined) delete process.env.BELIEFS_API_ENABLED;
+    else process.env.BELIEFS_API_ENABLED = savedFlag;
+    if (f) await f.close();
+  });
+
+  it('default off → both routes 404, even for a fully-scoped M2M key', async () => {
+    expect((await f.http.get('/v1/beliefs/b_city_r2').set(m2m())).status).toBe(404);
+    expect((await f.http.get('/v1/beliefs').set(m2m())).status).toBe(404);
+  });
+
+  it('serves one belief by id (bare tail AND full record form), wire-contract-clean', async () => {
+    process.env.BELIEFS_API_ENABLED = '1';
+    const res = await f.http.get('/v1/beliefs/semantic_belief:b_city_r2').set(m2m());
+    expect(res.status).toBe(200);
+    expect(BeliefReadResponseSchema.safeParse(res.body).success).toBe(true);
+    expect(res.body).toMatchObject({
+      beliefId: 'semantic_belief:b_city_r2',
+      userId: USER,
+      subject: 'mika',
+      field: 'home.city',
+      value: 'porto',
+      priorValue: 'lisbon',
+      statement: 'mika — home.city: porto',
+      statementSource: 'template',
+      confidence: 0.85,
+      revision: 2,
+      status: 'active',
+      validFrom: '2026-03-01T10:00:00.000Z',
+      sourceSceneIds: ['memory_episode:seed_scene'],
+      conversationIds: ['proj:c1'],
+      corroborationCount: 1,
+      conversationCount: 1,
+      promoterVersion: 'belief-promotion-v1|scene-segmenter-v1',
+    });
+    expect(res.body.supersededBy).toBeUndefined();
+    expect(res.body.validUntil).toBeUndefined();
+
+    const bare = await f.http.get('/v1/beliefs/b_city_r2').set(m2m());
+    expect(bare.status).toBe(200);
+    expect(bare.body).toEqual(res.body);
+  });
+
+  it('a superseded revision still resolves, with its chain stamps', async () => {
+    const res = await f.http.get('/v1/beliefs/b_city_r1').set(m2m());
+    expect(res.status).toBe(200);
+    expect(BeliefReadResponseSchema.safeParse(res.body).success).toBe(true);
+    expect(res.body).toMatchObject({
+      status: 'superseded',
+      supersededBy: 'semantic_belief:b_city_r2',
+      validUntil: '2026-03-05T10:00:00.000Z',
+    });
+  });
+
+  it('a missing id is the same 404 as a fenced one', async () => {
+    expect((await f.http.get('/v1/beliefs/nope_never_existed').set(m2m())).status).toBe(404);
+  });
+
+  it("user fence by id: own belief serves, another user's is 404, corrupt is 404 for everyone", async () => {
+    expect((await f.http.get('/v1/beliefs/b_coffee').set(userToken())).status).toBe(200);
+    expect((await f.http.get('/v1/beliefs/b_other').set(userToken())).status).toBe(404);
+    // Fail-closed: blank stamp serves to NO caller, M2M included.
+    expect((await f.http.get('/v1/beliefs/b_corrupt').set(userToken())).status).toBe(404);
+    expect((await f.http.get('/v1/beliefs/b_corrupt').set(m2m())).status).toBe(404);
+  });
+
+  it('list (M2M, defaults): active rows only, corrupt row never serves', async () => {
+    const res = await f.http.get('/v1/beliefs').set(m2m());
+    expect(res.status).toBe(200);
+    expect(BeliefsListResponseSchema.safeParse(res.body).success).toBe(true);
+    const ids = res.body.beliefs.map((b: { beliefId: string }) => b.beliefId);
+    // Deterministic order: userId ASC, subject ASC, field ASC, rev DESC.
+    expect(ids).toEqual([
+      'semantic_belief:b_coffee',
+      'semantic_belief:b_city_r2',
+      'semantic_belief:b_other',
+    ]);
+    expect(res.body.found).toBe(3);
+  });
+
+  it('list filters: subject+field exact match, status=all / superseded, userId scope', async () => {
+    const keyed = await f.http
+      .get('/v1/beliefs?subject=mika&field=home.city&status=all')
+      .set(m2m());
+    expect(keyed.status).toBe(200);
+    expect(keyed.body.beliefs.map((b: { revision: number }) => b.revision)).toEqual([2, 1]);
+
+    const superseded = await f.http.get('/v1/beliefs?status=superseded').set(m2m());
+    expect(superseded.body.beliefs.map((b: { beliefId: string }) => b.beliefId)).toEqual([
+      'semantic_belief:b_city_r1',
+    ]);
+
+    const scoped = await f.http.get(`/v1/beliefs?userId=${OTHER_USER}`).set(m2m());
+    expect(scoped.body.beliefs.map((b: { beliefId: string }) => b.beliefId)).toEqual([
+      'semantic_belief:b_other',
+    ]);
+  });
+
+  it('list user fence: a user-bound token sees only its own; asserting another user is 403', async () => {
+    const res = await f.http.get('/v1/beliefs').set(userToken());
+    expect(res.status).toBe(200);
+    expect(res.body.beliefs.map((b: { beliefId: string }) => b.beliefId)).toEqual([
+      'semantic_belief:b_coffee',
+      'semantic_belief:b_city_r2',
+    ]);
+    // pinUserScope: an explicit mismatching assertion is a 403 (the
+    // platform-wide pin idiom — distinct from the 404 row fence).
+    expect((await f.http.get(`/v1/beliefs?userId=${OTHER_USER}`).set(userToken())).status).toBe(
+      403,
+    );
+    // Asserting the OWN user is a no-op pass-through.
+    expect((await f.http.get(`/v1/beliefs?userId=${USER}`).set(userToken())).status).toBe(200);
+  });
+
+  it('list caps: limit honored, invalid limits 400, oversize clamped not erred', async () => {
+    const one = await f.http.get('/v1/beliefs?limit=1').set(m2m());
+    expect(one.status).toBe(200);
+    expect(one.body.beliefs).toHaveLength(1);
+    expect(one.body.found).toBe(1);
+
+    expect((await f.http.get('/v1/beliefs?limit=0').set(m2m())).status).toBe(400);
+    expect((await f.http.get('/v1/beliefs?limit=-5').set(m2m())).status).toBe(400);
+    expect((await f.http.get('/v1/beliefs?limit=abc').set(m2m())).status).toBe(400);
+    expect((await f.http.get('/v1/beliefs?status=bogus').set(m2m())).status).toBe(400);
+    // Above the cap clamps (100) rather than erring.
+    expect((await f.http.get('/v1/beliefs?limit=99999').set(m2m())).status).toBe(200);
+  });
+
+  it('flag flip back off → 404 again (runtime-mutable, no restart)', async () => {
+    delete process.env.BELIEFS_API_ENABLED;
+    expect((await f.http.get('/v1/beliefs/b_city_r2').set(m2m())).status).toBe(404);
+    expect((await f.http.get('/v1/beliefs').set(m2m())).status).toBe(404);
+    process.env.BELIEFS_API_ENABLED = '1';
+  });
+});

--- a/test/beliefs-visibility.unit-spec.ts
+++ b/test/beliefs-visibility.unit-spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure-verdict unit coverage of the belief read fence (the factVisible
+ * idiom): beliefVisible is the ONE visibility implementation both
+ * GET /v1/beliefs/:id and the list's JS re-filter apply — pinned here so
+ * the fail-closed semantics can never drift silently.
+ */
+import {
+  beliefVisible,
+  BELIEFS_LIST_DEFAULT,
+  BELIEFS_LIST_MAX,
+} from '../src/beliefs/beliefs.service';
+
+describe('beliefVisible (fail-closed single-user fence)', () => {
+  it('M2M (no pinned user) sees any well-stamped belief', () => {
+    expect(beliefVisible({ userId: 'u1' }, undefined)).toBe(true);
+    expect(beliefVisible({ userId: 'u2' }, undefined)).toBe(true);
+  });
+
+  it('a user-bound token sees only its OWN beliefs', () => {
+    expect(beliefVisible({ userId: 'u1' }, 'u1')).toBe(true);
+    expect(beliefVisible({ userId: 'u2' }, 'u1')).toBe(false);
+  });
+
+  it('an out-of-contract stamp is invisible to EVERYONE — M2M included', () => {
+    // The promotion never writes these (#387 fence); if such a row ever
+    // exists it must serve to no caller, fail-closed.
+    for (const userId of ['', undefined, null, 42, ['u1']]) {
+      expect(beliefVisible({ userId }, undefined)).toBe(false);
+      expect(beliefVisible({ userId }, 'u1')).toBe(false);
+    }
+  });
+});
+
+describe('belief list caps', () => {
+  it('pins the page constants the controller clamps against', () => {
+    expect(BELIEFS_LIST_DEFAULT).toBe(25);
+    expect(BELIEFS_LIST_MAX).toBe(100);
+  });
+});

--- a/test/contracts-beliefs.unit-spec.ts
+++ b/test/contracts-beliefs.unit-spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Wire-contract drift guard for GET /v1/beliefs/:id and
+ * GET /v1/beliefs (the contracts-facts idiom).
+ *
+ * Fully-populated samples are typed against the SERVICE result
+ * interfaces (compile-time parity), then parsed against the zod wire
+ * contracts (runtime parity), then pinned key-for-key — a field added
+ * to one side without the other fails loudly.
+ */
+import {
+  BeliefReadResponseSchema,
+  BeliefsListResponseSchema,
+} from '../src/contracts/beliefs/beliefs.schema';
+import type { BeliefReadResult, BeliefsListResult } from '../src/beliefs/beliefs.service';
+
+const expectKeys = (shape: Record<string, unknown>, sample: Record<string, unknown>) =>
+  expect(Object.keys(shape).sort()).toEqual(Object.keys(sample).sort());
+
+const fullBelief: Required<BeliefReadResult> = {
+  beliefId: 'semantic_belief:abc',
+  userId: 'user-1',
+  subject: 'mika',
+  field: 'home.city',
+  value: 'porto',
+  priorValue: 'lisbon',
+  statement: 'mika — home.city: porto (was: lisbon)',
+  statementSource: 'template',
+  confidence: 0.85,
+  revision: 2,
+  status: 'active',
+  supersededBy: 'semantic_belief:def',
+  validFrom: '2026-03-05T10:00:00.000Z',
+  validUntil: '2026-03-09T10:00:00.000Z',
+  sourceSceneIds: ['memory_episode:sb'],
+  conversationIds: ['proj:c3'],
+  corroborationCount: 1,
+  conversationCount: 1,
+  promoterVersion: 'belief-promotion-v1|scene-segmenter-v1',
+};
+
+const fullList: Required<BeliefsListResult> = {
+  beliefs: [fullBelief],
+  found: 1,
+};
+
+describe('beliefs wire contracts', () => {
+  it('BeliefReadResponseSchema parses a fully-populated service result', () => {
+    expect(BeliefReadResponseSchema.safeParse(fullBelief).success).toBe(true);
+  });
+
+  it('BeliefReadResponseSchema parses the minimal shape (optionals absent)', () => {
+    const { priorValue, supersededBy, validUntil, promoterVersion, ...minimal } = fullBelief;
+    void priorValue;
+    void supersededBy;
+    void validUntil;
+    void promoterVersion;
+    expect(BeliefReadResponseSchema.safeParse(minimal).success).toBe(true);
+  });
+
+  it('BeliefReadResponseSchema covers every service field — both directions', () => {
+    expectKeys(BeliefReadResponseSchema.shape, fullBelief);
+  });
+
+  it('BeliefsListResponseSchema parses a fully-populated list result', () => {
+    expect(BeliefsListResponseSchema.safeParse(fullList).success).toBe(true);
+  });
+
+  it('BeliefsListResponseSchema covers every list field — both directions', () => {
+    expectKeys(BeliefsListResponseSchema.shape, fullList);
+  });
+});

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -38,6 +38,8 @@ const PLATFORM_OPERATIONS: Array<[string, string]> = [
   ['/v1/admin/packs/{packId}/eval', 'post'],
   ['/v1/facts/{id}', 'get'],
   ['/v1/facts/{id}/provenance', 'get'],
+  ['/v1/beliefs', 'get'],
+  ['/v1/beliefs/{id}', 'get'],
   ['/v1/users/{userId}/profile', 'get'],
   ['/v1/ingest/document', 'post'],
   ['/v1/documents/{id}', 'get'],


### PR DESCRIPTION
## What

Belief-B: a read-only API over the `semantic_belief` substrate (migration 0120, written by the Belief-A promotion pass, #405) — mirroring the `FACTS_API_ENABLED` idiom end to end.

- **`GET /v1/beliefs/:id`** — one belief revision as stored: `value`/`priorValue`, `statement` + `statementSource`, `confidence`, the supersede chain (`revision`/`status`/`supersededBy`/`validFrom`/`validUntil`), inline `sourceSceneIds` provenance, corroboration counters, `promoterVersion`. Accepts bare tail or full `semantic_belief:` form. Superseded revisions still resolve — only visibility fences turn into 404s, and any miss is the same 404 (existence never leaks).
- **`GET /v1/beliefs`** — list by the free-text `(subject, field)` key with `status` filter (`active` default / `superseded` / `all`) and `userId` scope; page capped at **100** (default **25**), deterministic order (`userId, subject, field ASC, revision DESC`).
- **Flag**: `BELIEFS_API_ENABLED` (KNOWN_BOOLEAN_FLAGS + config catalog, category `pipeline`), default off → both routes 404 byte-identically (indistinguishable from an absent surface), read at call time so a flip is runtime-mutable.

## Fence chain (the getFact equivalent, adapted to what 0120 actually stamps)

- **Tenant**: `withScopedCompany` pins the per-tenant database.
- **User scope, fail-closed**: a belief ALWAYS carries the single-user scope its promotion stamped (#387 — never tenant-global). Via `pinUserScope`, a user-bound token sees only its OWN beliefs (another user's id is a 404; an asserted mismatching `userId` query param is a 403, the platform-wide pin idiom); M2M sees the tenant. A row with an out-of-contract blank stamp serves to **no one**, M2M included — pinned by unit + e2e.
- **No PII / row-policy fence by construction**: `semantic_belief` carries no `piiClass` column (statements are distilled state, not verbatim turns — raw text stays behind the episode read port's `brain:read_pii` gate) and no registry predicate exists for free-text keys, so those fences have nothing to key on. Documented in the service header.
- The list pushes the full fence into `WHERE` (index-backed) and re-applies it in JS. The e2e caught a live page-starvation bug in the first cut (out-of-contract row occupying the only `LIMIT 1` slot — the F1 LIMIT-before-fence lesson); the fix moves the fail-closed leg into the query.

## Contracts / OpenAPI

- `src/contracts/beliefs/beliefs.schema.ts` (zod, additive) + `test/contracts-beliefs.unit-spec.ts` parity pin (compile-time + runtime + key-for-key, the contracts-facts idiom).
- `pnpm openapi:build` regenerated — **both** committed copies (`docs/openapi.json`, `brain-landing/public/openapi.json`); new `Beliefs` tag; drift-gate operation list updated.
- Policy actions `get_belief` / `list_beliefs` registered tool-shaped (the `get_fact` convention) so the future MCP twins reuse them.

## Deliberately NOT in this PR

- **No MCP tools** — surface parity with the fact read tools is a follow-up PR.
- **No provenance endpoint / supportEdges exposure** — a `get_fact_provenance`-style walk (`sourceSceneIds` → scene members → verbatim turns through the PII-fenced episode read port) is future work, noted in the controller docblock.
- **No write/retract verb** — the promotion pass stays the only writer; GDPR erasure runs through the existing forget cascades.

## Verification

- `pnpm typecheck` clean; `pnpm lint:ci` 0 warnings; prettier clean.
- Unit: **332 suites / 3450 tests** pass (includes the new contracts + fence specs and the openapi drift gate).
- e2e (real SurrealDB testcontainer): new `beliefs-api` suite (11 tests: off→404 pin both routes, wire-contract-clean reads, supersede chain, id/list user fences, 403 pin mismatch, caps/400s, runtime flag flip) + `belief-promotion` suite still green — 16/16; adjacent `mcp-fact-tools` / `grounding-status` / `abac-action-gate` 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB