### PR TITLE
feat(scenes): evidence links — reconstructed_from edges to fragments and assets

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -1033,7 +1033,8 @@
                   "enum": [
                     "supported_by",
                     "contradicted_by",
-                    "derived_from"
+                    "derived_from",
+                    "reconstructed_from"
                   ],
                   "type": "string"
                 },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1033,7 +1033,8 @@
                   "enum": [
                     "supported_by",
                     "contradicted_by",
-                    "derived_from"
+                    "derived_from",
+                    "reconstructed_from"
                   ],
                   "type": "string"
                 },

--- a/src/admin/admin-scenes.controller.ts
+++ b/src/admin/admin-scenes.controller.ts
@@ -15,6 +15,7 @@ import { ApiKeyService } from '../auth/api-key.service';
 import { resolvePlatformTenant } from '../auth/tenant-scope';
 import {
   sceneBeliefPromotionEnabled,
+  sceneEvidenceLinksEnabled,
   sceneFactBacklinkEnabled,
   sceneLlmEnrichmentEnabled,
   sceneSegmentationEnabled,
@@ -23,6 +24,10 @@ import { SceneComposerService, SceneRunResult } from './scene-composer.service';
 import { SceneEnricherService, SceneEnrichResult } from './scene-enricher.service';
 import { SceneBacklinkService, SceneBacklinkResult } from './scene-backlink.service';
 import { BeliefPromotionService, BeliefPromotionResult } from './belief-promotion.service';
+import {
+  SceneEvidenceLinkerService,
+  SceneEvidenceLinkResult,
+} from './scene-evidence-linker.service';
 
 /** Purge param belt: DB stamps are short version slugs, not free text. */
 // 128 (was 64): pack scene worlds (0110) are versioned
@@ -48,6 +53,12 @@ const SEGMENTER_VERSION_MAX_CHARS = 128;
  *  - POST /scenes/backlink — standalone fact backlink (PR2): idempotent
  *    source.memoryEpisodeIds stamps. 404 unless BOTH the master flag and
  *    SCENES_FACT_BACKLINK are on.
+ *  - POST /scenes/evidence-links — scene evidence linker (MM-zoom PR1,
+ *    migration 0123): typed scene-reconstructed_from->evidence edges
+ *    from member episodes' source.evidenceRefs. 404 unless BOTH the
+ *    master flag and SCENES_EVIDENCE_LINKS are on. Replay-idempotent
+ *    (INSERT RELATION IGNORE over UNIQUE(in, out, kind)); a world
+ *    without evidence refs is a graceful no-op.
  *  - POST /scenes/beliefs — belief promotion (Belief-A, migration 0120):
  *    folds ENRICHED scenes of the current effective segmenter version
  *    into semantic_belief upserts keyed by free-text (subject, field).
@@ -73,6 +84,7 @@ export class AdminScenesController {
     private readonly enricher: SceneEnricherService,
     private readonly backlinker: SceneBacklinkService,
     private readonly beliefs: BeliefPromotionService,
+    private readonly evidenceLinker: SceneEvidenceLinkerService,
     private readonly apiKeys: ApiKeyService,
   ) {}
 
@@ -117,6 +129,24 @@ export class AdminScenesController {
     }
     const tenant = this.resolveTenant(req, body.tenant);
     return this.backlinker.run(
+      tenant,
+      body.conversationId !== undefined ? { conversationId: body.conversationId } : {},
+    );
+  }
+
+  @Post('maintenance/scenes/evidence-links')
+  @RequireScopes('brain:admin')
+  async evidenceLinks(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { tenant?: string; conversationId?: string } = {},
+  ): Promise<SceneEvidenceLinkResult> {
+    // Double-gate idiom: controller 404 here + the service's defensive
+    // early return (off = zero queries, byte-identical prod).
+    if (!sceneSegmentationEnabled() || !sceneEvidenceLinksEnabled()) {
+      throw new NotFoundException();
+    }
+    const tenant = this.resolveTenant(req, body.tenant);
+    return this.evidenceLinker.run(
       tenant,
       body.conversationId !== undefined ? { conversationId: body.conversationId } : {},
     );

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -49,6 +49,7 @@ import { SceneComposerService } from './scene-composer.service';
 import { SceneEnricherService } from './scene-enricher.service';
 import { SceneBacklinkService } from './scene-backlink.service';
 import { BeliefPromotionService } from './belief-promotion.service';
+import { SceneEvidenceLinkerService } from './scene-evidence-linker.service';
 import { SceneVersionService } from './scene-version';
 import { HnswMaintenanceService } from './hnsw-maintenance.service';
 import { CodeMemoryModule } from '../code-memory/code-memory.module';
@@ -131,6 +132,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     SceneEnricherService,
     SceneBacklinkService,
     BeliefPromotionService,
+    SceneEvidenceLinkerService,
     SceneVersionService,
     AdminInfraService,
     HealthComponentsService,

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -755,6 +755,19 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Belief promotion statement synthesis: ONE structured LLM call per belief create/revise phrasing the statement text (statementSource llm); any failure degrades to the deterministic template — the fold never depends on the model. Off = no LLM call ever runs, every statement is the deterministic template (statementSource template).',
   },
+  {
+    key: 'SCENES_EVIDENCE_LINKS',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneEvidenceLinksEnabled) by the
+    // admin 404 guard, the linker's defensive early return and the
+    // composer's post-swap hook — never captured in a constructor — so a
+    // flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Scene evidence links (MM-zoom PR1, migration 0123): after the composer swap (and via POST /v1/admin/maintenance/scenes/evidence-links), write typed scene-reconstructed_from->evidence_fragment|evidence_asset memory_support edges from the union of member episodes source.evidenceRefs — scenes become zoomable into the multimodal evidence substrate (0109). Replay-idempotent (INSERT RELATION IGNORE over UNIQUE(in,out,kind)); a world without evidence refs is a graceful no-op. Off = no edge is ever written, route 404s, composer hook skipped — byte-identical prod. GDPR cascades erase the edges regardless.',
+  },
   // ── Multilingual (Tier 1, migration 0100) ───────────
   {
     key: 'MULTILINGUAL_LANG_ATTRIBUTION',

--- a/src/admin/scene-composer.service.ts
+++ b/src/admin/scene-composer.service.ts
@@ -8,6 +8,7 @@ import { ProjectionRegistryService } from '../episodes/projection-registry.servi
 import { scopeForUser } from '../auth/scope-tags';
 import { segmentSessions } from '../episodes/session-window';
 import {
+  sceneEvidenceLinksEnabled,
   sceneFactBacklinkEnabled,
   sceneLlmEnrichmentEnabled,
   sceneSegmentationEnabled,
@@ -26,6 +27,7 @@ import {
 import { SceneVersionService } from './scene-version';
 import { SceneEnricherService } from './scene-enricher.service';
 import { SceneBacklinkService } from './scene-backlink.service';
+import { SceneEvidenceLinkerService } from './scene-evidence-linker.service';
 
 /**
  * Scene composer (Brain v2 PR1): batch-derives the SHADOW memory_episode
@@ -75,6 +77,7 @@ export class SceneComposerService {
     private readonly registry: ProjectionRegistryService,
     private readonly enricher: SceneEnricherService,
     private readonly backlinker: SceneBacklinkService,
+    private readonly evidenceLinker: SceneEvidenceLinkerService,
     private readonly versions: SceneVersionService,
   ) {}
 
@@ -158,6 +161,13 @@ export class SceneComposerService {
         await this.backlinker.run(companyId, opts);
       } catch (e) {
         this.logger.warn(`scene backlink pass failed: ${(e as Error).message}`);
+      }
+    }
+    if (sceneEvidenceLinksEnabled()) {
+      try {
+        await this.evidenceLinker.run(companyId, opts);
+      } catch (e) {
+        this.logger.warn(`scene evidence links pass failed: ${(e as Error).message}`);
       }
     }
     return result;

--- a/src/admin/scene-evidence-linker.service.ts
+++ b/src/admin/scene-evidence-linker.service.ts
@@ -1,0 +1,145 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { StringRecordId } from 'surrealdb';
+import { SurrealService } from '../db/surreal.service';
+import { sceneEvidenceLinksEnabled } from '../common/scene-flags';
+import { SceneVersionService } from './scene-version';
+import { unionEvidenceRefs } from '../common/evidence-ref';
+import { buildSupportEdgeBatches, classifySupportTarget } from '../common/support-edges';
+
+/**
+ * Scene evidence linker (MM-zoom PR1, SCENES_EVIDENCE_LINKS — default
+ * off): writes typed scene-reconstructed_from->evidence edges into
+ * memory_support (0116, kind activated by 0123) so a scene becomes
+ * zoomable into the multimodal evidence substrate (0109). For every
+ * memory_episode of the CURRENT effective segmenter version it unions
+ * the member episodes' `source.evidenceRefs` (unionEvidenceRefs — the
+ * FLEXIBLE-source discipline: shapes are never guaranteed), keeps the
+ * evidence_fragment/evidence_asset refs, and inserts one edge per
+ * (scene, ref) pair:
+ *
+ *   scene -reconstructed_from-> evidence_fragment | evidence_asset
+ *   (writer 'scene_evidence_linker', writerVersion = the effective
+ *   segmenter version, resolved once per run — SceneVersionService)
+ *
+ * Replay-idempotent by construction: INSERT RELATION IGNORE over
+ * UNIQUE(in, out, kind) — a re-run (or a re-segmentation re-run onto
+ * the same deterministic scene ids) inserts nothing new. Episodes
+ * carrying NO evidence refs are a GRACEFUL NO-OP (zero writes) — the
+ * metadata-ingest path is the producer of source.evidenceRefs and may
+ * not have run for this tenant. Scene -> turn membership stays in
+ * memory_episode_member (0106); this pass never touches it.
+ *
+ * GDPR: both forget cascades erase these edges UNCONDITIONALLY (the
+ * dying-scene `in` legs and the dying-evidence `out` leg) — rows
+ * written while SCENES_EVIDENCE_LINKS was on must stay erasable after
+ * it is off (the EVIDENCE_SUBSTRATE_ENABLED precedent).
+ */
+
+/** Minimal scene head the pass reads. */
+interface LinkerSceneRow {
+  id: unknown;
+}
+
+/**
+ * Pure: member episodes' evidence-ref lists -> deduped edge targets.
+ * unionEvidenceRefs handles the FLEXIBLE-source coercion (String(),
+ * known record prefixes only, member order preserved, capped at 64);
+ * the filter keeps the two linkable classes — 'episode:' refs are
+ * membership-plane pointers, not reconstruction evidence.
+ */
+export function evidenceLinkTargets(memberRefLists: readonly unknown[]): string[] {
+  return unionEvidenceRefs(memberRefLists).filter((ref) => {
+    const cls = classifySupportTarget(ref);
+    return cls === 'fragment' || cls === 'asset';
+  });
+}
+
+export interface SceneEvidenceLinkResult {
+  /** Scenes of the current effective version examined. */
+  scenes: number;
+  /** Scenes that produced at least one edge row this run. */
+  scenesLinked: number;
+  /** Edge rows written across all scenes (post-dedupe, pre-IGNORE). */
+  edges: number;
+}
+
+@Injectable()
+export class SceneEvidenceLinkerService {
+  private readonly logger = new Logger(SceneEvidenceLinkerService.name);
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly versions: SceneVersionService,
+  ) {}
+
+  async run(
+    companyId: string,
+    opts: { conversationId?: string } = {},
+  ): Promise<SceneEvidenceLinkResult> {
+    const result: SceneEvidenceLinkResult = { scenes: 0, scenesLinked: 0, edges: 0 };
+    // Defense in depth: the controller already 404s with the flag off; a
+    // programmatic caller must not write edges past a disabled flag.
+    if (!sceneEvidenceLinksEnabled()) return result;
+    // Effective version resolved ONCE per run (the backlink discipline):
+    // the scene selection and the writerVersion stamp name ONE world.
+    const { version } = this.versions.resolve();
+    await this.surreal.withCompany(companyId, async (db) => {
+      const [scenes] = await db.query<[LinkerSceneRow[]]>(
+        `SELECT id FROM memory_episode WHERE segmenterVersion = $v` +
+          (opts.conversationId !== undefined ? ` AND conversationIds CONTAINS $conv` : ''),
+        {
+          v: version,
+          ...(opts.conversationId !== undefined ? { conv: opts.conversationId } : {}),
+        },
+      );
+      for (const scene of scenes ?? []) {
+        result.scenes += 1;
+        const [members] = await db.query<[Array<{ out: unknown }>]>(
+          `SELECT out FROM memory_episode_member WHERE in = $scene`,
+          { scene: scene.id },
+        );
+        const memberRefs = (members ?? []).map((m) => m.out);
+        if (memberRefs.length === 0) continue;
+        // One batched read of the members' evidence-ref lists. SELECT
+        // VALUE of a missing FLEXIBLE key yields NONE per row —
+        // unionEvidenceRefs skips every non-array, so an episode world
+        // without a metadata-ingest producer is a graceful no-op.
+        const [refLists] = await db.query<[unknown[]]>(
+          `SELECT VALUE source.evidenceRefs FROM episode WHERE id INSIDE $eps`,
+          { eps: memberRefs },
+        );
+        const targets = evidenceLinkTargets((refLists ?? []) as unknown[]);
+        if (targets.length === 0) continue;
+        const { batches, skipped } = buildSupportEdgeBatches({
+          kind: 'reconstructed_from',
+          writer: 'scene_evidence_linker',
+          writerVersion: version,
+          pairs: targets.map((out) => ({ in: String(scene.id), out })),
+        });
+        if (skipped > 0) {
+          this.logger.warn(`scene evidence links: ${skipped} malformed edge pair(s) skipped`);
+        }
+        let written = 0;
+        for (const batch of batches) {
+          await db.query(`INSERT RELATION IGNORE INTO memory_support $rows`, {
+            rows: batch.map((r) => ({
+              ...r,
+              in: new StringRecordId(r.in),
+              out: new StringRecordId(r.out),
+            })),
+          });
+          written += batch.length;
+        }
+        if (written > 0) {
+          result.scenesLinked += 1;
+          result.edges += written;
+        }
+      }
+    });
+    this.logger.log(
+      `scene evidence links pass: ${result.edges} edge(s) over ` +
+        `${result.scenesLinked}/${result.scenes} scene(s)`,
+    );
+    return result;
+  }
+}

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -943,6 +943,17 @@ const KNOWN_BOOLEAN_FLAGS = [
   // to the deterministic template. Default off ⇒ no LLM call ever runs —
   // every statement is the deterministic template.
   'SCENES_BELIEF_LLM_SYNTHESIS',
+  // Scene evidence links (MM-zoom PR1, migration 0123): typed
+  // scene-reconstructed_from->evidence_fragment|evidence_asset edges in
+  // memory_support from the union of member episodes' source.evidenceRefs
+  // (end of the composer run + POST /v1/admin/maintenance/scenes/
+  // evidence-links). Replay-idempotent (INSERT RELATION IGNORE over
+  // UNIQUE(in, out, kind)); a world without evidence refs is a graceful
+  // no-op. Default off ⇒ no edge is ever written, the route 404s and the
+  // composer hook is skipped — byte-identical prod. The GDPR cascades
+  // erase the edges regardless — rows written while on must stay
+  // erasable.
+  'SCENES_EVIDENCE_LINKS',
   // Evidence substrate master (Brain v2.1 M1, migration 0109): the
   // EvidenceStoreService writers for evidence_asset / evidence_fragment /
   // derived_representation. Default off ⇒ every writer 503s and no row is
@@ -952,7 +963,9 @@ const KNOWN_BOOLEAN_FLAGS = [
   // the ENGINE flag budget by design (a substrate builder, not an engine
   // fork). The fs root (EVIDENCE_FS_ROOT) is a string and the size cap
   // (EVIDENCE_MAX_BYTES) an int — not booleans. Reserved for sibling PRs
-  // (not defined yet): EVIDENCE_INGEST_ENABLED / EVIDENCE_SCENE_LINKS.
+  // (not defined yet): EVIDENCE_INGEST_ENABLED. (The scene-links seam
+  // reserved here landed as SCENES_EVIDENCE_LINKS — the writer is a
+  // scene pass, so it keeps the SCENES_ family naming.)
   'EVIDENCE_SUBSTRATE_ENABLED',
   // Fragment citations (MM-zoom PR2): generator schema gains
   // citedFragmentIds over the rendered fragment lane; resolved through

--- a/src/common/scene-flags.ts
+++ b/src/common/scene-flags.ts
@@ -92,6 +92,28 @@ export function sceneFactBacklinkEnabled(): boolean {
 }
 
 /**
+ * Scene evidence-links flag — SCENES_EVIDENCE_LINKS (MM-zoom PR1).
+ *
+ * When on, a batch pass (end of the composer run + standalone POST
+ * /v1/admin/maintenance/scenes/evidence-links) writes typed
+ * scene-reconstructed_from->evidence_fragment|evidence_asset edges into
+ * memory_support (0116; the reserved kind activated by 0123) from the
+ * union of member episodes' source.evidenceRefs — scenes become zoomable
+ * into the multimodal evidence substrate (0109). Replay-idempotent
+ * (INSERT RELATION IGNORE over UNIQUE(in, out, kind)); episodes without
+ * evidence refs are a graceful no-op (the metadata-ingest path is the
+ * producer). The env read lives here in the common layer, NOT inside the
+ * engine dirs (engine-gates S5.2). Read at call time so a flip is
+ * runtime-mutable. Default off ⇒ no edge is ever written, the admin
+ * route 404s and the composer's post-swap hook is skipped —
+ * byte-identical prod. The GDPR cascades erase the edges REGARDLESS of
+ * this flag (the EVIDENCE_SUBSTRATE_ENABLED precedent).
+ */
+export function sceneEvidenceLinksEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_EVIDENCE_LINKS);
+}
+
+/**
  * Scenes version-fingerprint flag — SCENES_VERSION_FINGERPRINT (Drift-3).
  *
  * When on, SceneVersionService resolves the EFFECTIVE segmenter version as

--- a/src/common/support-edges.ts
+++ b/src/common/support-edges.ts
@@ -13,9 +13,12 @@
  *     (winner); COMPETING writes the mutual pair
  *   * derived_from:    in = summary knowledge_fact, out = member
  *     knowledge_fact (typed mirror of the untyped derivedFrom array)
- *   * reconstructed_from: RESERVED — scene membership stays in
- *     memory_episode_member (0106); NO writer emits it (assertEdgeShape
- *     rejects it so a stray caller cannot start).
+ *   * reconstructed_from: in = memory_episode (scene), out =
+ *     evidence_fragment | evidence_asset — the scene is reconstructed
+ *     from that piece of recorded evidence (MM-zoom PR1, kind activated
+ *     by 0123, writer scene_evidence_linker). Scene -> turn membership
+ *     STAYS in memory_episode_member (0106) — this kind names
+ *     evidence-plane reconstruction sources, NOT membership.
  */
 import { parseRecordRef } from './evidence-ref';
 
@@ -27,7 +30,14 @@ export const SUPPORT_EDGE_KINDS = [
 ] as const;
 export type SupportEdgeKind = (typeof SUPPORT_EDGE_KINDS)[number];
 
-/** The kinds a writer may actually emit (reconstructed_from reserved). */
+/**
+ * The kinds the closure WALK crosses mid-walk (fact/belief-rooted
+ * frontier fetches). reconstructed_from is deliberately NOT here even
+ * though the linker writes it: its `in` is a scene, so it can never
+ * appear in a frontier fetch — the provenance reader harvests it in a
+ * dedicated POST-walk fetch over the crossed scenes instead
+ * (provenance-closure.ts, normalizeReconstructedEdges).
+ */
 export const EMITTED_EDGE_KINDS = ['supported_by', 'contradicted_by', 'derived_from'] as const;
 export type EmittedEdgeKind = (typeof EMITTED_EDGE_KINDS)[number];
 
@@ -42,6 +52,7 @@ export const SUPPORT_EDGE_WRITERS = [
   'compaction_runner',
   'recompose',
   'belief_promotion',
+  'scene_evidence_linker',
 ] as const;
 export type SupportEdgeWriter = (typeof SUPPORT_EDGE_WRITERS)[number];
 
@@ -83,26 +94,30 @@ export function classifySupportTarget(raw: string): SupportTargetClass {
  * Endpoint-table pairing per kind (the TS-side substitute for the
  * FROM/TO types one polymorphic RELATION table cannot carry — 0116
  * header). Returns a boolean verdict: writers SKIP invalid rows with a
- * warn, never throw. reconstructed_from is always false (reserved).
+ * warn, never throw.
  *
  * Belief edges (0120, writer 'belief_promotion') follow the SAME
  * direction semantics with `in` = semantic_belief: supported_by
  * belief->scene mirrors the fact rule; contradicted_by / derived_from
  * pair a belief ONLY with another belief (revision chains never cross
  * into the claim plane — the SemanticBelief/Claim separation).
+ *
+ * reconstructed_from (0123) is the ONE kind rooted in the episodic
+ * plane: in = scene, out = fragment | asset — every other pairing stays
+ * rejected, and the three claim-plane kinds keep their exact pre-0123
+ * verdicts (in must classify fact/belief; pinned in the unit spec).
  */
 export function assertEdgeShape(kind: SupportEdgeKind, inId: string, outId: string): boolean {
   const inClass = classifySupportTarget(inId);
-  if (inClass !== 'fact' && inClass !== 'belief') return false;
   const out = classifySupportTarget(outId);
   switch (kind) {
     case 'supported_by':
-      return out === 'scene';
+      return (inClass === 'fact' || inClass === 'belief') && out === 'scene';
     case 'contradicted_by':
     case 'derived_from':
-      return out === inClass;
+      return (inClass === 'fact' || inClass === 'belief') && out === inClass;
     case 'reconstructed_from':
-      return false;
+      return inClass === 'scene' && (out === 'fragment' || out === 'asset');
   }
 }
 

--- a/src/contracts/facts/facts.schema.ts
+++ b/src/contracts/facts/facts.schema.ts
@@ -99,14 +99,16 @@ export const FactProvenanceResponseSchema = z.object({
    * Typed support edges crossed by the walk
    * (PROVENANCE_SUPPORT_GRAPH_READ, migration 0116): supported_by
    * (fact -> scene), contradicted_by (loser fact -> winner fact),
-   * derived_from (summary fact -> member fact). `from`/`to` are full
-   * record ids. Absent (not empty) when the read flag is off →
-   * backward-compatible.
+   * derived_from (summary fact -> member fact), plus the post-walk
+   * scene-evidence zoom edges — reconstructed_from (scene ->
+   * evidence_fragment | evidence_asset, migration 0123) for every scene
+   * a crossed supported_by edge named. `from`/`to` are full record ids.
+   * Absent (not empty) when the read flag is off → backward-compatible.
    */
   supportEdges: z
     .array(
       z.object({
-        kind: z.enum(['supported_by', 'contradicted_by', 'derived_from']),
+        kind: z.enum(['supported_by', 'contradicted_by', 'derived_from', 'reconstructed_from']),
         from: z.string(),
         to: z.string(),
       }),

--- a/src/db/migrations/0123_scene_evidence_links.surql
+++ b/src/db/migrations/0123_scene_evidence_links.surql
@@ -1,0 +1,34 @@
+-- 0123: scene evidence links (MM-zoom PR1) — activate the RESERVED
+-- reconstructed_from kind on memory_support (0116):
+--   * reconstructed_from (memory_episode scene -> evidence_fragment |
+--     evidence_asset): the scene is RECONSTRUCTED FROM that piece of
+--     recorded evidence — the typed zoom path from an episodic scene
+--     down into the multimodal evidence substrate (0109). Written by the
+--     scene-evidence linker pass (scene-evidence-linker.service.ts,
+--     SCENES_EVIDENCE_LINKS, default off) from the union of member
+--     episodes' source.evidenceRefs (unionEvidenceRefs, filtered to the
+--     fragment/asset prefixes). Endpoint pairing is enforced by the TS
+--     writer (assertEdgeShape, src/common/support-edges.ts) — in/out
+--     stay DELIBERATELY untyped records (the 0116 header rationale).
+--   * Scene -> turn membership STAYS in memory_episode_member (0106),
+--     the canonical representation — this kind names evidence-plane
+--     reconstruction sources, NOT membership.
+--
+-- No table or index change: UNIQUE(in, out, kind) (support_edge_uq)
+-- already dedupes the new kind, so INSERT RELATION IGNORE keeps the
+-- linker replay-idempotent; support_out_idx / support_kind_idx already
+-- serve the new read paths. The 0106 doctrine applies unchanged: plain
+-- WHERE in/out only, no graph-arrow syntax, and every deleter uses the
+-- LET-select-ids -> DELETE idiom (the reproduced 3.2.4 planner no-op on
+-- the compound-indexed `in`).
+--
+-- GDPR: BOTH forget cascades erase these edges UNCONDITIONALLY — the
+-- dying-scene (in) legs and the dying-evidence (out) leg land with this
+-- PR (user-forget.service.ts / entity-forget.service.ts).
+--
+-- Widen the 0116 memory_support writer enum with the linker pass
+-- (DEFINE FIELD OVERWRITE — the 0120 precedent; ASSERT is not additive,
+-- the full list must be restated. Existing rows all carry values inside
+-- the widened list, so this is purely additive).
+DEFINE FIELD OVERWRITE writer ON memory_support TYPE string
+  ASSERT $value INSIDE ['scene_backlink', 'fact_resolver', 'promotion_runner', 'compaction_runner', 'recompose', 'belief_promotion', 'scene_evidence_linker'];

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -301,9 +301,11 @@ export class EntityForgetService {
         );
         tx.add(`LET $scenesDel = (DELETE memory_episode WHERE id INSIDE $sceneIds RETURN BEFORE)`);
         // Typed support graph (0116): every memory_support edge touching
-        // this entity's facts (either endpoint) or a dying scene (edge
-        // target) goes with them. The fact ids MUST be pre-collected
-        // here, BEFORE the `DELETE knowledge_fact WHERE entityId = $ent`
+        // this entity's facts (either endpoint) or a dying scene (EITHER
+        // endpoint — supported_by names a scene as `out`; the 0123
+        // scene-evidence zoom edges name it as `in`) goes with them. The
+        // fact ids MUST be pre-collected here, BEFORE the
+        // `DELETE knowledge_fact WHERE entityId = $ent`
         // below erases the rows the SELECT traverses. Runs
         // UNCONDITIONALLY — rows written while PROVENANCE_SUPPORT_EDGES
         // was on must stay erasable after it is off (the
@@ -316,7 +318,8 @@ export class EntityForgetService {
         tx.add(`LET $entFactIds = (SELECT VALUE id FROM knowledge_fact WHERE entityId = $ent)`);
         tx.add(
           `LET $supIds = (SELECT VALUE id FROM memory_support
-             WHERE in INSIDE $entFactIds OR out INSIDE $entFactIds OR out INSIDE $sceneIds
+             WHERE in INSIDE $entFactIds OR out INSIDE $entFactIds
+                OR in INSIDE $sceneIds OR out INSIDE $sceneIds
                 OR in INSIDE $beliefIds OR out INSIDE $beliefIds)`,
         );
         tx.add(`DELETE $supIds`);

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -507,6 +507,14 @@ export class UserForgetService {
     // repr/frag legs; reprs-before-frags stays exactly as is. Runs on
     // SURVIVING shared assets stay too: lineage is asset-scoped, like
     // the fragments it produced.
+    // Scene-evidence zoom edges (0123): a dying asset/fragment is a
+    // possible reconstructed_from edge TARGET whose scene may SURVIVE
+    // this cascade (a scene without this user's turns can still
+    // reference this user's evidence), so the out-side leg runs here,
+    // keyed on the same pre-collected dying ids, BEFORE the endpoint
+    // rows die. Two-step LET-select-ids → DELETE (the 0116 planner
+    // no-op idiom); runs UNCONDITIONALLY (the
+    // EVIDENCE_SUBSTRATE_ENABLED precedent).
     let deleted = { reprs: 0, frags: 0, assets: 0 };
     let storageRefs: string[] = [];
     if (dyingIds.length > 0) {
@@ -521,14 +529,29 @@ export class UserForgetService {
           rows: storageRefs.map((storageRef) => ({ storageRef, reason: 'user_forget' })),
         });
       }
-      const [, , , , , reprsGone, fragsGone, , assetsGone] = await db.query<
-        [unknown, unknown, unknown, unknown, unknown[], unknown[], unknown[], unknown[], unknown[]]
+      const [, , , , , , , reprsGone, fragsGone, , assetsGone] = await db.query<
+        [
+          unknown,
+          unknown,
+          unknown,
+          unknown,
+          unknown,
+          unknown[],
+          unknown[],
+          unknown[],
+          unknown[],
+          unknown[],
+          unknown[],
+        ]
       >(
         `LET $fragIds = (SELECT VALUE id FROM evidence_fragment WHERE assetId INSIDE $assetIds);
          LET $reprIds = (SELECT VALUE id FROM derived_representation
            WHERE subjectId INSIDE $assetIds OR subjectId INSIDE $fragIds);
          LET $residualGrantIds = (SELECT VALUE id FROM evidence_grant WHERE assetId INSIDE $assetIds);
          LET $runIds = (SELECT VALUE id FROM processing_run WHERE assetId INSIDE $assetIds);
+         LET $supEvIds = (SELECT VALUE id FROM memory_support
+           WHERE out INSIDE $assetIds OR out INSIDE $fragIds);
+         DELETE $supEvIds;
          DELETE $runIds RETURN BEFORE;
          DELETE $reprIds RETURN BEFORE;
          DELETE $fragIds RETURN BEFORE;

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -33,11 +33,14 @@ import {
   supportGraphReadEnabled,
 } from '../common/provenance-flags';
 import {
+  collectSceneTargets,
   indexCharSpans,
+  normalizeReconstructedEdges,
   walkProvenanceClosure,
   type ClosureEdgeRow,
   type ProvenanceClosureEdge,
   type ProvenanceSpan,
+  type ReconstructedSupportEdge,
 } from './provenance-closure';
 
 /**
@@ -200,8 +203,10 @@ export interface FactProvenanceResult {
    * Typed support edges crossed by the walk
    * (PROVENANCE_SUPPORT_GRAPH_READ, 0116) — absent (not empty) when the
    * read flag is off, so the default response stays byte-identical.
+   * Includes the post-walk scene-evidence zoom edges (reconstructed_from,
+   * 0123) for every scene a crossed supported_by edge named.
    */
-  supportEdges?: ProvenanceClosureEdge[];
+  supportEdges?: Array<ProvenanceClosureEdge | ReconstructedSupportEdge>;
 }
 
 interface FactReadOptions {
@@ -454,13 +459,14 @@ export class FactsService {
     // is safe for a SELECT; only DELETE hits the 3.2.4 planner no-op.
     // Flag off ⇒ no fetchEdges ⇒ the walk is byte-identical.
     const readEdges = supportGraphReadEnabled();
+    const caps = {
+      maxDepth: closureMaxDepth(),
+      maxFacts: closureMaxFacts(),
+      maxEpisodes: closureMaxEpisodes(),
+    };
     const closure = await walkProvenanceClosure<FactReadRow>({
       root,
-      caps: {
-        maxDepth: closureMaxDepth(),
-        maxFacts: closureMaxFacts(),
-        maxEpisodes: closureMaxEpisodes(),
-      },
+      caps,
       visible: (f) => factVisible(f, gates),
       fetchByIds: async (ids) => {
         // NO status filter — compacted/retracted members still witness;
@@ -487,6 +493,28 @@ export class FactsService {
         : {}),
     });
     rowPolicy.finish();
+
+    // Scene-evidence zoom (reconstructed_from, 0123 — MM-zoom PR1): ONE
+    // post-walk batched fetch over the scenes the crossed supported_by
+    // edges named. Keyed on the SAME read flag as the walk's edge fetch;
+    // edges are record-id-only rows (content-free by construction — the
+    // 0116 doctrine), the same exposure class as the crossed supported_by
+    // targets. Plain WHERE on `in` is SELECT-safe (only DELETE hits the
+    // 3.2.4 planner no-op). Flag off ⇒ no fetch, and with no scenes
+    // crossed (or no zoom edges written) the appended set is empty — the
+    // supportEdges array is byte-identical to the pre-0123 shape.
+    let reconstructed: ReconstructedSupportEdge[] = [];
+    if (readEdges) {
+      const sceneIds = collectSceneTargets(closure.edges);
+      if (sceneIds.length > 0) {
+        const [edgeRows] = await db.query<[ClosureEdgeRow[]]>(
+          `SELECT in, out, kind FROM memory_support
+            WHERE kind = 'reconstructed_from' AND in INSIDE $ids`,
+          { ids: sceneIds.map((id) => new StringRecordId(id)) },
+        );
+        reconstructed = normalizeReconstructedEdges(edgeRows ?? [], caps.maxFacts);
+      }
+    }
 
     // Episode fetch grouped per owning user ('' → the caller's pinned
     // scope; else that fact's user — the caller already passed the
@@ -534,8 +562,9 @@ export class FactsService {
       },
       // Additive and flag-keyed: PRESENT (possibly empty) whenever the
       // read flag drove the walk, ABSENT otherwise — never an empty
-      // array on the default path.
-      ...(readEdges ? { supportEdges: closure.edges } : {}),
+      // array on the default path. Crossed edges first (walk order),
+      // then the post-walk scene-evidence zoom edges.
+      ...(readEdges ? { supportEdges: [...closure.edges, ...reconstructed] } : {}),
     };
   }
 

--- a/src/facts/provenance-closure.ts
+++ b/src/facts/provenance-closure.ts
@@ -49,6 +49,62 @@ export interface ProvenanceClosureEdge {
 }
 
 /**
+ * One scene-evidence zoom edge, normalized for the wire (MM-zoom PR1,
+ * 0123): scene -reconstructed_from-> evidence_fragment | evidence_asset.
+ * Harvested by a dedicated POST-walk fetch — its `in` is a scene, so it
+ * can never surface in the walk's fact/belief-rooted frontier fetches.
+ */
+export interface ReconstructedSupportEdge {
+  kind: 'reconstructed_from';
+  from: string;
+  to: string;
+}
+
+/**
+ * The scenes named by the walk's crossed supported_by edges — the
+ * post-walk reconstructed_from fetch keys on exactly these (deduped,
+ * crossing order preserved). Pure; targets are already String()s.
+ */
+export function collectSceneTargets(edges: readonly ProvenanceClosureEdge[]): string[] {
+  const out = new Set<string>();
+  for (const edge of edges) {
+    if (edge.kind === 'supported_by' && classifySupportTarget(edge.to) === 'scene') {
+      out.add(edge.to);
+    }
+  }
+  return [...out];
+}
+
+/**
+ * Defensive normalization of the post-walk reconstructed_from rows —
+ * kind-filtered, endpoint-classified (scene -> fragment|asset ONLY, the
+ * assertEdgeShape pairing — a foreign row shape is dropped, never a
+ * guess), String()-normalized, deduped by (from, to), capped (the
+ * walker's maxFacts budget — same bound the crossed-edge surface obeys).
+ */
+export function normalizeReconstructedEdges(
+  rows: readonly ClosureEdgeRow[],
+  cap: number,
+): ReconstructedSupportEdge[] {
+  const seen = new Set<string>();
+  const out: ReconstructedSupportEdge[] = [];
+  for (const row of rows) {
+    if (String(row.kind) !== 'reconstructed_from') continue;
+    const from = String(row.in);
+    const to = String(row.out);
+    const target = classifySupportTarget(to);
+    if (classifySupportTarget(from) !== 'scene') continue;
+    if (target !== 'fragment' && target !== 'asset') continue;
+    const key = `${from} ${to}`;
+    if (seen.has(key)) continue;
+    if (out.length >= cap) break;
+    seen.add(key);
+    out.push({ kind: 'reconstructed_from', from, to });
+  }
+  return out;
+}
+
+/**
  * Defensive read of source.charSpans (G3 — written by the derive row
  * builder, but `source` is FLEXIBLE so shapes are never guaranteed).
  * Keeps the first well-formed span per episode; malformed entries are

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -807,6 +807,21 @@ describe('memory_support GDPR cascade + DELETE-shape guards (0116)', () => {
     );
   });
 
+  it('the 0123 scene-evidence zoom direction is covered on BOTH sides of the cascade', () => {
+    // reconstructed_from edges carry the scene as `in` and the evidence
+    // row as `out` — a dying scene must kill the edge from the in side
+    // (entity-forget names scenes on BOTH endpoints), and a dying
+    // asset/fragment whose scene SURVIVES must kill it from the out
+    // side (user-forget's evidence leg, same LET-select-ids → DELETE
+    // idiom, unconditional).
+    const entityForget = readFileSync(join(SRC, 'entities', 'entity-forget.service.ts'), 'utf8');
+    expect(entityForget).toContain('OR in INSIDE $sceneIds OR out INSIDE $sceneIds');
+    const userForget = readFileSync(join(SRC, 'entities', 'user-forget.service.ts'), 'utf8');
+    expect(userForget).toContain('LET $supEvIds = (SELECT VALUE id FROM memory_support');
+    expect(userForget).toContain('WHERE out INSIDE $assetIds OR out INSIDE $fragIds');
+    expect(userForget).toContain('DELETE $supEvIds');
+  });
+
   it('NO file in src/ uses the 3.2.4-broken DELETE memory_support WHERE shape', () => {
     const walk = (dir: string): string[] => {
       const out: string[] = [];
@@ -967,6 +982,30 @@ describe('semantic_belief GDPR cascade + DELETE-shape guards (0120)', () => {
         .join('\n');
       expect(code).not.toMatch(/DELETE semantic_belief\s+WHERE/);
     }
+  });
+});
+
+describe('0123_scene_evidence_links (reconstructed_from activation)', () => {
+  const sql = readFileSync(join(MIGRATIONS, '0123_scene_evidence_links.surql'), 'utf8');
+
+  it('widens the 0116 writer enum with scene_evidence_linker via OVERWRITE (full list restated)', () => {
+    expect(sql).toContain('DEFINE FIELD OVERWRITE writer ON memory_support');
+    expect(sql).toMatch(
+      /writer ON memory_support[^;]*'scene_backlink', 'fact_resolver', 'promotion_runner', 'compaction_runner', 'recompose', 'belief_promotion', 'scene_evidence_linker'/s,
+    );
+  });
+
+  it('defines NO new table, index, changefeed or event (the 0116 surface is reused as-is)', () => {
+    // UNIQUE(in, out, kind) + support_out_idx/support_kind_idx already
+    // serve the new kind; the 0116 no-feed doctrine applies unchanged.
+    const code = sql
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('--'))
+      .join('\n');
+    expect(code).not.toMatch(/DEFINE TABLE/);
+    expect(code).not.toMatch(/DEFINE INDEX/);
+    expect(code).not.toMatch(/CHANGEFEED/);
+    expect(code).not.toMatch(/DEFINE EVENT/);
   });
 });
 

--- a/test/provenance-closure.unit-spec.ts
+++ b/test/provenance-closure.unit-spec.ts
@@ -1,4 +1,6 @@
 import {
+  collectSceneTargets,
+  normalizeReconstructedEdges,
   walkProvenanceClosure,
   indexCharSpans,
   type ClosureFactRow,
@@ -453,5 +455,43 @@ describe('walkProvenanceClosure — fetchEdges (support graph read)', () => {
     });
     expect(out.edges).toHaveLength(2);
     expect(out.truncated.fanout).toBe(true);
+  });
+});
+
+describe('scene-evidence zoom helpers (reconstructed_from post-walk fetch, 0123)', () => {
+  it('collectSceneTargets: supported_by scene targets only, deduped, crossing order kept', () => {
+    expect(
+      collectSceneTargets([
+        { kind: 'supported_by', from: 'knowledge_fact:f1', to: 'memory_episode:s2' },
+        { kind: 'derived_from', from: 'knowledge_fact:f1', to: 'knowledge_fact:f2' },
+        { kind: 'supported_by', from: 'knowledge_fact:f2', to: 'memory_episode:s1' },
+        { kind: 'supported_by', from: 'knowledge_fact:f3', to: 'memory_episode:s2' }, // dupe
+        // A belief-rooted supported_by names a scene too — same harvest.
+        { kind: 'supported_by', from: 'semantic_belief:b1', to: 'memory_episode:s3' },
+        // Non-scene target never harvested (defensive — the writer
+        // rejects this shape, but rows are FLEXIBLE-sourced).
+        { kind: 'supported_by', from: 'knowledge_fact:f4', to: 'episode:e1' },
+      ]),
+    ).toEqual(['memory_episode:s2', 'memory_episode:s1', 'memory_episode:s3']);
+    expect(collectSceneTargets([])).toEqual([]);
+  });
+
+  it('normalizeReconstructedEdges: kind + endpoint-class filtered, deduped, capped', () => {
+    const rows = [
+      { in: 'memory_episode:s1', out: 'evidence_fragment:fr1', kind: 'reconstructed_from' },
+      { in: 'memory_episode:s1', out: 'evidence_asset:a1', kind: 'reconstructed_from' },
+      { in: 'memory_episode:s1', out: 'evidence_fragment:fr1', kind: 'reconstructed_from' }, // dupe
+      { in: 'memory_episode:s1', out: 'episode:e1', kind: 'reconstructed_from' }, // wrong out class
+      { in: 'knowledge_fact:f1', out: 'evidence_asset:a2', kind: 'reconstructed_from' }, // wrong in class
+      { in: 'memory_episode:s1', out: 'memory_episode:s2', kind: 'supported_by' }, // wrong kind
+    ];
+    expect(normalizeReconstructedEdges(rows, 10)).toEqual([
+      { kind: 'reconstructed_from', from: 'memory_episode:s1', to: 'evidence_fragment:fr1' },
+      { kind: 'reconstructed_from', from: 'memory_episode:s1', to: 'evidence_asset:a1' },
+    ]);
+    expect(normalizeReconstructedEdges(rows, 1)).toEqual([
+      { kind: 'reconstructed_from', from: 'memory_episode:s1', to: 'evidence_fragment:fr1' },
+    ]);
+    expect(normalizeReconstructedEdges([], 10)).toEqual([]);
   });
 });

--- a/test/scene-evidence-linker.unit-spec.ts
+++ b/test/scene-evidence-linker.unit-spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Scene evidence linker (MM-zoom PR1, SCENES_EVIDENCE_LINKS —
+ * reconstructed_from edges scene → fragment|asset, 0123). Pins the
+ * flag-off zero-query guarantee, the graceful no-op when member
+ * episodes carry no evidence refs (the metadata-ingest producer may not
+ * have run), the INSERT RELATION IGNORE payload shape (writer
+ * scene_evidence_linker, writerVersion = the effective segmenter
+ * version), and the pure ref filter (evidenceLinkTargets — fragment/
+ * asset classes only, 'episode:' membership refs excluded).
+ */
+import {
+  SceneEvidenceLinkerService,
+  evidenceLinkTargets,
+} from '../src/admin/scene-evidence-linker.service';
+import { SEGMENTER_VERSION } from '../src/admin/scene-segmentation';
+import type { SceneVersionService } from '../src/admin/scene-version';
+import type { SurrealService } from '../src/db/surreal.service';
+
+interface QueryCall {
+  sql: string;
+  params?: Record<string, unknown> | undefined;
+}
+
+const SAVED = { links: process.env.SCENES_EVIDENCE_LINKS };
+afterEach(() => {
+  if (SAVED.links === undefined) delete process.env.SCENES_EVIDENCE_LINKS;
+  else process.env.SCENES_EVIDENCE_LINKS = SAVED.links;
+});
+
+describe('evidenceLinkTargets (pure ref filter)', () => {
+  it('keeps fragment/asset refs, drops episode/membership refs and malformed lists', () => {
+    expect(
+      evidenceLinkTargets([
+        ['evidence_fragment:fr1', 'episode:e1', 'evidence_asset:a1'],
+        'not-a-list',
+        null,
+        ['evidence_fragment:fr1', 'knowledge_fact:f1', 42],
+      ]),
+    ).toEqual(['evidence_fragment:fr1', 'evidence_asset:a1']);
+    expect(evidenceLinkTargets([])).toEqual([]);
+    expect(evidenceLinkTargets([undefined, {}])).toEqual([]);
+  });
+});
+
+describe('SceneEvidenceLinkerService — reconstructed_from edges', () => {
+  function makeStack(refLists: unknown[]) {
+    const calls: QueryCall[] = [];
+    const fakeDb = {
+      async query<R>(sql: string, params?: Record<string, unknown>): Promise<R> {
+        calls.push({ sql, params });
+        if (sql.includes('FROM memory_episode WHERE segmenterVersion')) {
+          return [[{ id: 'memory_episode:s1' }]] as unknown as R;
+        }
+        if (sql.includes('FROM memory_episode_member WHERE in = $scene')) {
+          return [[{ out: 'episode:e1' }, { out: 'episode:e2' }]] as unknown as R;
+        }
+        if (sql.includes('SELECT VALUE source.evidenceRefs FROM episode')) {
+          return [refLists] as unknown as R;
+        }
+        return [[]] as unknown as R;
+      },
+    };
+    const surreal = {
+      withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>) => fn(fakeDb),
+    } as unknown as SurrealService;
+    // Fingerprint flag off in the unit env ⇒ the real service resolves to
+    // the literal SEGMENTER_VERSION; the stub pins that same contract
+    // (support-edge-writers.unit-spec pattern).
+    const fakeVersions = {
+      resolve: () => ({
+        version: SEGMENTER_VERSION,
+        cfg: { topicBoundary: false, minCosine: 0.55, maxTurns: 40, embeddingSpaceId: null },
+      }),
+    } as unknown as SceneVersionService;
+    return { svc: new SceneEvidenceLinkerService(surreal, fakeVersions), calls };
+  }
+
+  it('flag OFF (default): ZERO queries — byte-identical prod', async () => {
+    delete process.env.SCENES_EVIDENCE_LINKS;
+    const { svc, calls } = makeStack([]);
+    const result = await svc.run('co_x');
+    expect(result).toEqual({ scenes: 0, scenesLinked: 0, edges: 0 });
+    expect(calls).toEqual([]);
+  });
+
+  it('flag ON, refs present: INSERT RELATION IGNORE with scene→fragment/asset rows only', async () => {
+    process.env.SCENES_EVIDENCE_LINKS = '1';
+    const { svc, calls } = makeStack([
+      ['evidence_fragment:fr1', 'episode:e1'],
+      ['evidence_asset:a1', 'evidence_fragment:fr1'], // dupe deduped
+    ]);
+    const result = await svc.run('co_x');
+    expect(result).toEqual({ scenes: 1, scenesLinked: 1, edges: 2 });
+    const insert = calls.find((c) => c.sql.includes('INSERT RELATION IGNORE INTO memory_support'));
+    expect(insert).toBeDefined();
+    const rows = insert!.params!.rows as Array<Record<string, unknown>>;
+    expect(rows.map((r) => ({ ...r, in: String(r.in), out: String(r.out) }))).toEqual([
+      {
+        in: 'memory_episode:s1',
+        out: 'evidence_fragment:fr1',
+        kind: 'reconstructed_from',
+        writer: 'scene_evidence_linker',
+        writerVersion: SEGMENTER_VERSION,
+      },
+      {
+        in: 'memory_episode:s1',
+        out: 'evidence_asset:a1',
+        kind: 'reconstructed_from',
+        writer: 'scene_evidence_linker',
+        writerVersion: SEGMENTER_VERSION,
+      },
+    ]);
+  });
+
+  it('flag ON, NO evidence refs anywhere: graceful no-op — reads happen, ZERO writes', async () => {
+    process.env.SCENES_EVIDENCE_LINKS = '1';
+    // SELECT VALUE of a missing FLEXIBLE key yields NONE per row.
+    const { svc, calls } = makeStack([undefined, undefined]);
+    const result = await svc.run('co_x');
+    expect(result).toEqual({ scenes: 1, scenesLinked: 0, edges: 0 });
+    expect(calls.some((c) => c.sql.includes('INSERT'))).toBe(false);
+    expect(calls.some((c) => c.sql.includes('UPDATE'))).toBe(false);
+    expect(calls.some((c) => c.sql.includes('DELETE'))).toBe(false);
+  });
+
+  it('conversationId opt narrows the scene SELECT (the backlink filter shape)', async () => {
+    process.env.SCENES_EVIDENCE_LINKS = '1';
+    const { svc, calls } = makeStack([]);
+    await svc.run('co_x', { conversationId: 'conv1' });
+    expect(calls[0]!.sql).toContain('AND conversationIds CONTAINS $conv');
+    expect(calls[0]!.params).toMatchObject({ conv: 'conv1' });
+  });
+});

--- a/test/scene-evidence-links.e2e-spec.ts
+++ b/test/scene-evidence-links.e2e-spec.ts
@@ -1,0 +1,272 @@
+/**
+ * Scene evidence links e2e (MM-zoom PR1, real SurrealDB): the 0123
+ * reconstructed_from activation end-to-end —
+ *   (1) the linker writes scene→fragment/asset edges from member
+ *       episodes' source.evidenceRefs and a re-run inserts NOTHING new
+ *       (INSERT RELATION IGNORE proven on the REAL pinned server);
+ *   (2) GET /v1/facts/:id/provenance with the read flag on serves the
+ *       post-walk reconstructed_from edges next to the crossed
+ *       supported_by edge;
+ *   (3) read flag off → NO supportEdges key (byte-identical response);
+ *   (4) linker flag off → zero writes on the real path (defensive
+ *       return, not just the controller 404);
+ *   (5) user-forget of the EVIDENCE OWNER — whose turns/facts/scenes
+ *       all survive — erases the reconstructed_from edges from the out
+ *       side (the 0123 GDPR leg), leaving the scene and its
+ *       supported_by edge intact. Runs with the linker flag OFF (GDPR
+ *       runs regardless).
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { SceneBacklinkService } from '../src/admin/scene-backlink.service';
+import { SceneEvidenceLinkerService } from '../src/admin/scene-evidence-linker.service';
+import { SEGMENTER_VERSION } from '../src/admin/scene-segmentation';
+import { UserForgetService } from '../src/entities/user-forget.service';
+
+const FLAG_KEYS = [
+  'FACTS_API_ENABLED',
+  'PROVENANCE_RECURSIVE_CLOSURE',
+  'PROVENANCE_SUPPORT_EDGES',
+  'PROVENANCE_SUPPORT_GRAPH_READ',
+  'SCENES_FACT_BACKLINK',
+  'SCENES_EVIDENCE_LINKS',
+] as const;
+const savedEnv = new Map<string, string | undefined>();
+
+describe('scene evidence links (real SurrealDB)', () => {
+  let f: AppFixture;
+  let surreal: SurrealService;
+  let sceneId = '';
+  let assetId = '';
+  let fragmentId = '';
+  let backlinkFactId = '';
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const countEdges = async (where: string, params: Record<string, unknown> = {}) =>
+    surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM memory_support ${where} GROUP ALL`,
+        params,
+      );
+      return rows?.[0]?.n ?? 0;
+    });
+
+  beforeAll(async () => {
+    for (const k of FLAG_KEYS) savedEnv.set(k, process.env[k]);
+    process.env.FACTS_API_ENABLED = '1';
+    process.env.PROVENANCE_RECURSIVE_CLOSURE = '1';
+    process.env.PROVENANCE_SUPPORT_EDGES = '1';
+    process.env.PROVENANCE_SUPPORT_GRAPH_READ = '1';
+    process.env.SCENES_FACT_BACKLINK = '1';
+    process.env.SCENES_EVIDENCE_LINKS = '1';
+    f = await createApp({ companyId: 'co_scene_evidence_links_e2e' });
+    surreal = f.app.get(SurrealService);
+
+    await surreal.withCompany(f.companyId, async (db) => {
+      // Evidence rows owned by 'user-evd' — the forget subject whose
+      // TURNS do not exist (the scene must survive their forget).
+      const [assetRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE evidence_asset CONTENT {
+           modality: 'image', mediaType: 'image/jpeg',
+           byteHash: 'sel-e2e-hash', byteLength: 128,
+           occurredAt: d'2026-07-01T09:00:00Z', availability: 'hot',
+           piiClasses: [], vertical: 'rent', userId: 'user-evd'
+         }`,
+      );
+      assetId = String(assetRows[0]!.id);
+      const [fragRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE evidence_fragment CONTENT {
+           assetId: $assetId, locator: { kind: 'pageRegion' }, piiClasses: []
+         }`,
+        { assetId: assetRows[0]!.id },
+      );
+      fragmentId = String(fragRows[0]!.id);
+
+      // Two tenant-global turns; the SEEDED evidence refs are the
+      // producer stand-in (the metadata-ingest path is not wired to
+      // episodes yet — the linker's contract is the FLEXIBLE key).
+      // The 'episode:' decoy pins the membership-ref exclusion.
+      const [epRows] = await db.query<[Array<{ id: unknown }>]>(`INSERT INTO episode $rows`, {
+        rows: [
+          {
+            kind: 'turn',
+            conversationId: 'conv_sel',
+            messageId: 'sel1',
+            speaker: 'user',
+            text: 'here is the signed lease scan',
+            occurredAt: new Date('2026-07-01T10:00:00Z'),
+            source: { evidenceRefs: [fragmentId, 'episode:decoy'] },
+          },
+          {
+            kind: 'turn',
+            conversationId: 'conv_sel',
+            messageId: 'sel2',
+            speaker: 'assistant',
+            text: 'scan received and filed',
+            occurredAt: new Date('2026-07-01T10:01:00Z'),
+            source: { evidenceRefs: [assetId] },
+          },
+        ],
+      });
+      const episodeRefs = (epRows ?? []).map((r) => r.id);
+      const episodeIds = episodeRefs.map(String);
+
+      const [sceneRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE memory_episode CONTENT $scene`,
+        {
+          scene: {
+            sceneLabel: 'lease scan intake',
+            conversationIds: ['conv_sel'],
+            occurredFrom: new Date('2026-07-01T10:00:00Z'),
+            occurredTo: new Date('2026-07-01T10:01:00Z'),
+            gist: 'user: here is the signed lease scan',
+            confidence: 0.9,
+            segmenterVersion: SEGMENTER_VERSION,
+            generation: 'gen-e2e',
+            source: {},
+          },
+        },
+      );
+      sceneId = String(sceneRows[0]!.id);
+      await db.query(`INSERT RELATION INTO memory_episode_member $rows`, {
+        rows: episodeRefs.map((out, ord) => ({
+          in: sceneRows[0]!.id,
+          out,
+          role: 'core',
+          ord,
+          relevance: 1,
+          segmenterVersion: SEGMENTER_VERSION,
+        })),
+      });
+
+      // A grounded fact in the scene's conversation — the backlink
+      // writer emits the fact-supported_by->scene edge the provenance
+      // walk crosses to reach the scene.
+      const [entRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE knowledge_entity CONTENT { type: 'customer', canonicalName: 'Scene Evidence Subject' }`,
+      );
+      const [factRows] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE knowledge_fact CONTENT $fact`,
+        {
+          fact: {
+            entityId: entRows[0]!.id,
+            predicate: 'said',
+            object: 'here is the signed lease scan',
+            confidence: 0.9,
+            validFrom: new Date('2026-07-01T00:00:00Z'),
+            status: 'active',
+            source: { kind: 'fact', conversationId: 'conv_sel', episodeIds: [episodeIds[0]] },
+          },
+        },
+      );
+      backlinkFactId = String(factRows[0]!.id);
+    });
+  });
+
+  afterAll(async () => {
+    for (const k of FLAG_KEYS) {
+      const v = savedEnv.get(k);
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await f.close();
+  });
+
+  it('linker writes scene→fragment/asset edges; a re-run inserts NOTHING new (IGNORE proven)', async () => {
+    const linker = f.app.get(SceneEvidenceLinkerService);
+    const first = await linker.run(f.companyId);
+    expect(first).toEqual({ scenes: 1, scenesLinked: 1, edges: 2 });
+    expect(await countEdges(`WHERE kind = 'reconstructed_from'`)).toBe(2);
+
+    // Replay — same deterministic scene id, same refs: INSERT RELATION
+    // IGNORE over UNIQUE(in, out, kind) must dedupe on the REAL server.
+    await linker.run(f.companyId);
+    expect(await countEdges(`WHERE kind = 'reconstructed_from'`)).toBe(2);
+
+    const rows = await surreal.withCompany(f.companyId, async (db) => {
+      const [r] = await db.query<
+        [Array<{ in: unknown; out: unknown; writer: string; writerVersion: string }>]
+      >(`SELECT in, out, writer, writerVersion FROM memory_support
+           WHERE kind = 'reconstructed_from' ORDER BY out`);
+      return r ?? [];
+    });
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(String(row.in)).toBe(sceneId);
+      expect(row.writer).toBe('scene_evidence_linker');
+      expect(row.writerVersion).toBe(SEGMENTER_VERSION);
+    }
+    expect(rows.map((r) => String(r.out)).sort()).toEqual([assetId, fragmentId].sort());
+  });
+
+  it('provenance serves the post-walk reconstructed_from edges next to the crossed supported_by', async () => {
+    // The backlink writer emits the fact→scene edge the walk crosses.
+    const backlink = f.app.get(SceneBacklinkService);
+    const linked = await backlink.run(f.companyId);
+    expect(linked.factsLinked).toBe(1);
+
+    const res = await f.http
+      .get(`/v1/facts/${encodeURIComponent(backlinkFactId)}/provenance`)
+      .set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.supportEdges).toEqual(
+      expect.arrayContaining([
+        { kind: 'supported_by', from: backlinkFactId, to: sceneId },
+        { kind: 'reconstructed_from', from: sceneId, to: fragmentId },
+        { kind: 'reconstructed_from', from: sceneId, to: assetId },
+      ]),
+    );
+    // The zoom edges never leak into the fact-closure surfaces.
+    expect(res.body.derivedFacts).toEqual([]);
+  });
+
+  it('read flag OFF: the provenance response has NO supportEdges key (byte-identical)', async () => {
+    process.env.PROVENANCE_SUPPORT_GRAPH_READ = '0';
+    try {
+      const res = await f.http
+        .get(`/v1/facts/${encodeURIComponent(backlinkFactId)}/provenance`)
+        .set(auth());
+      expect(res.status).toBe(200);
+      expect(res.body).not.toHaveProperty('supportEdges');
+    } finally {
+      process.env.PROVENANCE_SUPPORT_GRAPH_READ = '1';
+    }
+  });
+
+  it('linker flag OFF: zero result and NO new writes on the real path (defensive return)', async () => {
+    process.env.SCENES_EVIDENCE_LINKS = '0';
+    try {
+      const result = await f.app.get(SceneEvidenceLinkerService).run(f.companyId);
+      expect(result).toEqual({ scenes: 0, scenesLinked: 0, edges: 0 });
+    } finally {
+      process.env.SCENES_EVIDENCE_LINKS = '1';
+    }
+    expect(await countEdges(`WHERE kind = 'reconstructed_from'`)).toBe(2);
+  });
+
+  it('user-forget of the evidence owner erases the zoom edges from the OUT side; the scene survives', async () => {
+    // 'user-evd' owns ONLY the evidence rows — no turns, no facts, no
+    // scenes — so the main support-edge erase has no subjects and the
+    // scene must survive. The dying asset/fragment endpoints alone must
+    // take the reconstructed_from edges with them (the 0123 out-side
+    // leg in eraseEvidenceRows), with the linker flag OFF (GDPR runs
+    // regardless of the write flag).
+    process.env.SCENES_EVIDENCE_LINKS = '0';
+    try {
+      await f.app.get(UserForgetService).forgetUser(f.companyId, 'user-evd');
+    } finally {
+      process.env.SCENES_EVIDENCE_LINKS = '1';
+    }
+    await surreal.withCompany(f.companyId, async (db) => {
+      const [assets] = await db.query<[unknown[]]>(`SELECT id FROM evidence_asset`);
+      const [frags] = await db.query<[unknown[]]>(`SELECT id FROM evidence_fragment`);
+      const [scenes] = await db.query<[unknown[]]>(`SELECT id FROM memory_episode`);
+      expect(assets ?? []).toHaveLength(0);
+      expect(frags ?? []).toHaveLength(0);
+      expect(scenes ?? []).toHaveLength(1);
+    });
+    expect(await countEdges(`WHERE kind = 'reconstructed_from'`)).toBe(0);
+    // The claim-plane edge to the surviving scene is untouched.
+    expect(await countEdges(`WHERE kind = 'supported_by'`)).toBe(1);
+  });
+});

--- a/test/segment-user-fence.unit-spec.ts
+++ b/test/segment-user-fence.unit-spec.ts
@@ -12,6 +12,7 @@ import type { FactEmbeddingService } from '../src/ingest/fact-embedding.service'
 import type { ProjectionRegistryService } from '../src/episodes/projection-registry.service';
 import type { SceneEnricherService } from '../src/admin/scene-enricher.service';
 import type { SceneBacklinkService } from '../src/admin/scene-backlink.service';
+import type { SceneEvidenceLinkerService } from '../src/admin/scene-evidence-linker.service';
 import type { SceneVersionService } from '../src/admin/scene-version';
 
 /**
@@ -326,6 +327,9 @@ describe('scene composer persists fold.userIds (0117 write side)', () => {
         enrich: async () => ({ scenes: 0, enriched: 0, failed: 0 }),
       } as unknown as SceneEnricherService,
       { run: async () => undefined } as unknown as SceneBacklinkService,
+      {
+        run: async () => ({ scenes: 0, scenesLinked: 0, edges: 0 }),
+      } as unknown as SceneEvidenceLinkerService,
       // Neutral version world: fingerprint off (default), literal PR2
       // version — this spec pins the userIds fold, not scene identity.
       {

--- a/test/support-edges.unit-spec.ts
+++ b/test/support-edges.unit-spec.ts
@@ -1,11 +1,13 @@
 /**
  * Typed support graph (Drift-5, 0116) — the pure edge-row assembly
- * module. Pins the endpoint-pairing verdicts (assertEdgeShape,
- * reconstructed_from reserved), the (in, out, kind) dedupe with
- * emission order + SUPPORT_EDGE_CAP, the conflict-verdict directions
- * (SUPERSEDED loser→winner; COMPETING mutual, capped), and the
- * EvidenceRef runtime adoption (classifySupportTarget dispatches the
- * evidence-plane prefixes through parseRecordRef).
+ * module. Pins the endpoint-pairing verdicts (assertEdgeShape —
+ * reconstructed_from activated by 0123 as scene → fragment|asset, the
+ * three claim-plane kinds byte-identical to their pre-0123 verdicts),
+ * the (in, out, kind) dedupe with emission order + SUPPORT_EDGE_CAP,
+ * the conflict-verdict directions (SUPERSEDED loser→winner; COMPETING
+ * mutual, capped), and the EvidenceRef runtime adoption
+ * (classifySupportTarget dispatches the evidence-plane prefixes through
+ * parseRecordRef).
  */
 import {
   SUPPORT_EDGE_CAP,
@@ -49,14 +51,40 @@ describe('assertEdgeShape (endpoint pairing per kind)', () => {
     }
   });
 
-  it('reconstructed_from is RESERVED — always rejected (0106 stays canonical)', () => {
+  it('reconstructed_from (0123): scene → fragment|asset only', () => {
+    expect(
+      assertEdgeShape('reconstructed_from', 'memory_episode:s1', 'evidence_fragment:fr1'),
+    ).toBe(true);
+    expect(assertEdgeShape('reconstructed_from', 'memory_episode:s1', 'evidence_asset:a1')).toBe(
+      true,
+    );
+    // Membership stays in memory_episode_member — a turn episode is NOT
+    // a reconstruction source.
+    expect(assertEdgeShape('reconstructed_from', 'memory_episode:s1', 'episode:e1')).toBe(false);
+    expect(assertEdgeShape('reconstructed_from', 'memory_episode:s1', 'memory_episode:s2')).toBe(
+      false,
+    );
+    // Only the episodic plane roots this kind.
+    expect(assertEdgeShape('reconstructed_from', 'knowledge_fact:f1', 'evidence_asset:a1')).toBe(
+      false,
+    );
     expect(assertEdgeShape('reconstructed_from', 'knowledge_fact:f1', 'knowledge_fact:f2')).toBe(
       false,
     );
-    expect(assertEdgeShape('reconstructed_from', 'memory_episode:s1', 'episode:e1')).toBe(false);
   });
 
-  it('isEmittedEdgeKind excludes the reserved kind', () => {
+  it('the claim-plane kinds keep their pre-0123 verdicts with a scene/evidence in (byte-identity pin)', () => {
+    // The 0123 restructure moved the in-class gate INTO the switch —
+    // these pin that nothing changed for the three walk kinds.
+    expect(assertEdgeShape('supported_by', 'memory_episode:s1', 'memory_episode:s2')).toBe(false);
+    expect(assertEdgeShape('supported_by', 'evidence_asset:a1', 'memory_episode:s1')).toBe(false);
+    for (const kind of ['contradicted_by', 'derived_from'] as const) {
+      expect(assertEdgeShape(kind, 'memory_episode:s1', 'knowledge_fact:f1')).toBe(false);
+      expect(assertEdgeShape(kind, 'evidence_fragment:fr1', 'evidence_fragment:fr2')).toBe(false);
+    }
+  });
+
+  it('isEmittedEdgeKind excludes reconstructed_from (post-walk fetch, never a frontier kind)', () => {
     expect(isEmittedEdgeKind('supported_by')).toBe(true);
     expect(isEmittedEdgeKind('reconstructed_from')).toBe(false);
     expect(isEmittedEdgeKind('bogus')).toBe(false);


### PR DESCRIPTION
## What

MM-2 stage 1: scenes gain typed evidence provenance — `reconstructed_from` edges in `memory_support` from `memory_episode` scenes to `evidence_fragment` / `evidence_asset` records.

- Migration `0123`: widens the `memory_support.writer` ASSERT with `scene_evidence_linker` (OVERWRITE, additive).
- Linker pass behind `SCENES_EVIDENCE_LINKS` (default-off): harvests member episodes' `source.evidenceRefs` via the previously unused `unionEvidenceRefs` seam and writes edges idempotently (`INSERT RELATION IGNORE`, UNIQUE(in,out,kind)). Graceful no-op when episodes carry no evidence refs (today's default; the metadata-ingest path #400 is the producer).
- `assertEdgeShape` extended to allow scene→fragment/asset for `reconstructed_from`; all other kind pairings byte-identical (pinned).
- Provenance-closure harvest (behind existing `PROVENANCE_SUPPORT_GRAPH_READ`) appends reconstructed_from edges for harvested scenes into the existing `supportEdges` response array — flows through the `get_fact_provenance` MCP passthrough automatically.
- GDPR: edge cleanup covered by the existing memory_support cascades; pinned by test.

Default-off byte-identical; full verify green locally (typecheck, lint:ci, unit, targeted e2e, prettier). Built across several agent restarts (transient API errors); the final push is the fully verified tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
