### PR TITLE
feat(evidence): single raw-read gateway — gate ladder, signed URLs, access audit

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -910,6 +910,26 @@
         ],
         "type": "object"
       },
+      "EvidenceRawUrlResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "expiresAt": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "url",
+          "expiresAt"
+        ],
+        "type": "object"
+      },
       "FactProvenanceEpisode": {
         "additionalProperties": false,
         "properties": {
@@ -4395,6 +4415,219 @@
         ]
       }
     },
+    "/v1/evidence/fragments/{fragmentId}/raw": {
+      "get": {
+        "description": "Fragment twin of the asset stream: v1 serves the WHOLE parent asset’s bytes (no locator cropping yet) under the STRICTEST union of the fragment’s and the asset’s piiClasses. Streams the asset’s original bytes after the full gate ladder: brain:read scope, ABAC action `rest.evidence.raw`, tenant fence (availability='hot', quarantine clean-or-absent), at least one live ownership grant (a user-bound key needs the end user’s own), current pack modality consent declaring the raw-evidence capability, and the media-PII polarity (unclassified blocked, `[]` open, non-empty needs `brain:read_media`). Any denial is a bare 404. 404 until EVIDENCE_RAW_READ_ENABLED=1. Source: src/evidence/evidence-read.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "streamEvidenceFragment",
+        "parameters": [
+          {
+            "description": "evidence_fragment record id.",
+            "in": "path",
+            "name": "fragmentId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The original bytes (Content-Type = the registered mediaType), with X-Content-Type-Options: nosniff, Cache-Control: no-store and Content-Disposition: attachment."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Stream a fragment’s evidence bytes (parent asset, v1)",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/evidence/fragments/{fragmentId}/raw-url": {
+      "get": {
+        "description": "Fragment twin of the asset mint (whole parent-asset bytes, strictest piiClasses union). Same gate ladder as the raw stream; on pass answers a short-lived signed URL token (HMAC-SHA256, EVIDENCE_SIGNED_URL_SECRET, TTL EVIDENCE_SIGNED_URL_TTL_SECONDS, default 300 s) redeemable WITHOUT auth at /v1/evidence/redeem/{token}. 503 while the secret is not configured. 404 until EVIDENCE_RAW_READ_ENABLED=1.\n\nRequired scope: `brain:read`.",
+        "operationId": "mintEvidenceFragmentUrl",
+        "parameters": [
+          {
+            "description": "evidence_fragment record id.",
+            "in": "path",
+            "name": "fragmentId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvidenceRawUrlResponse"
+                }
+              }
+            },
+            "description": "The signed URL."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Mint a signed short-lived URL for a fragment’s bytes",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/evidence/redeem/{token}": {
+      "get": {
+        "description": "Unauthenticated by design — the token IS the capability. No ABAC/consent/PII re-run; fail-closed re-checks only: signature, expiry, the token’s own tenant, availability still 'hot', and at least one live grant (revocation backstop). Bad, expired and revoked tokens all answer the same bare 404. 404 until EVIDENCE_RAW_READ_ENABLED=1.",
+        "operationId": "redeemEvidenceUrl",
+        "parameters": [
+          {
+            "description": "The signed token from a raw-url mint.",
+            "in": "path",
+            "name": "token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The original bytes (Content-Type = the registered mediaType), with X-Content-Type-Options: nosniff, Cache-Control: no-store and Content-Disposition: attachment."
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Redeem a signed raw-evidence URL (no auth)",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/evidence/{assetId}/raw": {
+      "get": {
+        "description": "Streams the asset’s original bytes after the full gate ladder: brain:read scope, ABAC action `rest.evidence.raw`, tenant fence (availability='hot', quarantine clean-or-absent), at least one live ownership grant (a user-bound key needs the end user’s own), current pack modality consent declaring the raw-evidence capability, and the media-PII polarity (unclassified blocked, `[]` open, non-empty needs `brain:read_media`). Any denial is a bare 404. 404 until EVIDENCE_RAW_READ_ENABLED=1. Source: src/evidence/evidence-read.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "streamEvidenceAsset",
+        "parameters": [
+          {
+            "description": "evidence_asset record id.",
+            "in": "path",
+            "name": "assetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The original bytes (Content-Type = the registered mediaType), with X-Content-Type-Options: nosniff, Cache-Control: no-store and Content-Disposition: attachment."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Stream an evidence asset’s original bytes",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/evidence/{assetId}/raw-url": {
+      "get": {
+        "description": "Same gate ladder as the raw stream; on pass answers a short-lived signed URL token (HMAC-SHA256, EVIDENCE_SIGNED_URL_SECRET, TTL EVIDENCE_SIGNED_URL_TTL_SECONDS, default 300 s) redeemable WITHOUT auth at /v1/evidence/redeem/{token}. 503 while the secret is not configured. 404 until EVIDENCE_RAW_READ_ENABLED=1.\n\nRequired scope: `brain:read`.",
+        "operationId": "mintEvidenceAssetUrl",
+        "parameters": [
+          {
+            "description": "evidence_asset record id.",
+            "in": "path",
+            "name": "assetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvidenceRawUrlResponse"
+                }
+              }
+            },
+            "description": "The signed URL."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Mint a signed short-lived URL for an asset’s bytes",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
     "/v1/facts/{id}": {
       "get": {
         "description": "The fact itself — what is remembered, where it came from (vertical/recorder/conversation), its validity instant and user scope. Every visibility fence (tenant, user scope, row policy) answers 404 — existence never leaks. 404 until FACTS_API_ENABLED=1. Source: src/facts/facts.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -5337,6 +5570,10 @@
     {
       "description": "Belief-level reads over the semantic_belief substrate: what the brain currently holds about a free-text (subject, field) key, with its supersede chain and inline scene provenance. Read-only — the scene promotion pass is the only writer. Flag: BELIEFS_API_ENABLED (off → 404).",
       "name": "Beliefs"
+    },
+    {
+      "description": "The raw-evidence read gateway: original observation bytes back out — direct stream, signed short-lived URLs, fragment twins — behind the full deny-overrides gate ladder (scope, ABAC, tenant/availability/quarantine, ownership grants, pack modality consent, media-PII polarity), every attempt audited content-free. Flag: EVIDENCE_RAW_READ_ENABLED (off → 404).",
+      "name": "Evidence"
     },
     {
       "description": "Per-user surfaces: the rolling user profile assembled from user-scoped memory. Flag: USER_PROFILE_API_ENABLED (off → 404).",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -910,6 +910,26 @@
         ],
         "type": "object"
       },
+      "EvidenceRawUrlResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "expiresAt": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "url",
+          "expiresAt"
+        ],
+        "type": "object"
+      },
       "FactProvenanceEpisode": {
         "additionalProperties": false,
         "properties": {
@@ -4395,6 +4415,219 @@
         ]
       }
     },
+    "/v1/evidence/fragments/{fragmentId}/raw": {
+      "get": {
+        "description": "Fragment twin of the asset stream: v1 serves the WHOLE parent asset’s bytes (no locator cropping yet) under the STRICTEST union of the fragment’s and the asset’s piiClasses. Streams the asset’s original bytes after the full gate ladder: brain:read scope, ABAC action `rest.evidence.raw`, tenant fence (availability='hot', quarantine clean-or-absent), at least one live ownership grant (a user-bound key needs the end user’s own), current pack modality consent declaring the raw-evidence capability, and the media-PII polarity (unclassified blocked, `[]` open, non-empty needs `brain:read_media`). Any denial is a bare 404. 404 until EVIDENCE_RAW_READ_ENABLED=1. Source: src/evidence/evidence-read.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "streamEvidenceFragment",
+        "parameters": [
+          {
+            "description": "evidence_fragment record id.",
+            "in": "path",
+            "name": "fragmentId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The original bytes (Content-Type = the registered mediaType), with X-Content-Type-Options: nosniff, Cache-Control: no-store and Content-Disposition: attachment."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Stream a fragment’s evidence bytes (parent asset, v1)",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/evidence/fragments/{fragmentId}/raw-url": {
+      "get": {
+        "description": "Fragment twin of the asset mint (whole parent-asset bytes, strictest piiClasses union). Same gate ladder as the raw stream; on pass answers a short-lived signed URL token (HMAC-SHA256, EVIDENCE_SIGNED_URL_SECRET, TTL EVIDENCE_SIGNED_URL_TTL_SECONDS, default 300 s) redeemable WITHOUT auth at /v1/evidence/redeem/{token}. 503 while the secret is not configured. 404 until EVIDENCE_RAW_READ_ENABLED=1.\n\nRequired scope: `brain:read`.",
+        "operationId": "mintEvidenceFragmentUrl",
+        "parameters": [
+          {
+            "description": "evidence_fragment record id.",
+            "in": "path",
+            "name": "fragmentId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvidenceRawUrlResponse"
+                }
+              }
+            },
+            "description": "The signed URL."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Mint a signed short-lived URL for a fragment’s bytes",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/evidence/redeem/{token}": {
+      "get": {
+        "description": "Unauthenticated by design — the token IS the capability. No ABAC/consent/PII re-run; fail-closed re-checks only: signature, expiry, the token’s own tenant, availability still 'hot', and at least one live grant (revocation backstop). Bad, expired and revoked tokens all answer the same bare 404. 404 until EVIDENCE_RAW_READ_ENABLED=1.",
+        "operationId": "redeemEvidenceUrl",
+        "parameters": [
+          {
+            "description": "The signed token from a raw-url mint.",
+            "in": "path",
+            "name": "token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The original bytes (Content-Type = the registered mediaType), with X-Content-Type-Options: nosniff, Cache-Control: no-store and Content-Disposition: attachment."
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Redeem a signed raw-evidence URL (no auth)",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/evidence/{assetId}/raw": {
+      "get": {
+        "description": "Streams the asset’s original bytes after the full gate ladder: brain:read scope, ABAC action `rest.evidence.raw`, tenant fence (availability='hot', quarantine clean-or-absent), at least one live ownership grant (a user-bound key needs the end user’s own), current pack modality consent declaring the raw-evidence capability, and the media-PII polarity (unclassified blocked, `[]` open, non-empty needs `brain:read_media`). Any denial is a bare 404. 404 until EVIDENCE_RAW_READ_ENABLED=1. Source: src/evidence/evidence-read.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "streamEvidenceAsset",
+        "parameters": [
+          {
+            "description": "evidence_asset record id.",
+            "in": "path",
+            "name": "assetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The original bytes (Content-Type = the registered mediaType), with X-Content-Type-Options: nosniff, Cache-Control: no-store and Content-Disposition: attachment."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Stream an evidence asset’s original bytes",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/evidence/{assetId}/raw-url": {
+      "get": {
+        "description": "Same gate ladder as the raw stream; on pass answers a short-lived signed URL token (HMAC-SHA256, EVIDENCE_SIGNED_URL_SECRET, TTL EVIDENCE_SIGNED_URL_TTL_SECONDS, default 300 s) redeemable WITHOUT auth at /v1/evidence/redeem/{token}. 503 while the secret is not configured. 404 until EVIDENCE_RAW_READ_ENABLED=1.\n\nRequired scope: `brain:read`.",
+        "operationId": "mintEvidenceAssetUrl",
+        "parameters": [
+          {
+            "description": "evidence_asset record id.",
+            "in": "path",
+            "name": "assetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvidenceRawUrlResponse"
+                }
+              }
+            },
+            "description": "The signed URL."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "503": {
+            "$ref": "#/components/responses/FeatureDisabled"
+          }
+        },
+        "summary": "Mint a signed short-lived URL for an asset’s bytes",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
     "/v1/facts/{id}": {
       "get": {
         "description": "The fact itself — what is remembered, where it came from (vertical/recorder/conversation), its validity instant and user scope. Every visibility fence (tenant, user scope, row policy) answers 404 — existence never leaks. 404 until FACTS_API_ENABLED=1. Source: src/facts/facts.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -5337,6 +5570,10 @@
     {
       "description": "Belief-level reads over the semantic_belief substrate: what the brain currently holds about a free-text (subject, field) key, with its supersede chain and inline scene provenance. Read-only — the scene promotion pass is the only writer. Flag: BELIEFS_API_ENABLED (off → 404).",
       "name": "Beliefs"
+    },
+    {
+      "description": "The raw-evidence read gateway: original observation bytes back out — direct stream, signed short-lived URLs, fragment twins — behind the full deny-overrides gate ladder (scope, ABAC, tenant/availability/quarantine, ownership grants, pack modality consent, media-PII polarity), every attempt audited content-free. Flag: EVIDENCE_RAW_READ_ENABLED (off → 404).",
+      "name": "Evidence"
     },
     {
       "description": "Per-user surfaces: the rolling user profile assembled from user-scoped memory. Flag: USER_PROFILE_API_ENABLED (off → 404).",

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -124,6 +124,7 @@ import {
   ProfileSectionSchema,
   UserProfileResponseSchema,
 } from '../src/contracts/users/user-profile.schema';
+import { EvidenceRawUrlResponseSchema } from '../src/contracts/evidence/raw.schema';
 
 type Json = Record<string, unknown>;
 
@@ -223,6 +224,8 @@ const ZOD_COMPONENTS: Record<string, z.ZodType> = {
   ProfileFact: ProfileFactSchema,
   ProfileSection: ProfileSectionSchema,
   UserProfileResponse: UserProfileResponseSchema,
+  // --- raw-evidence read gateway (src/contracts/evidence/raw.schema.ts)
+  EvidenceRawUrlResponse: EvidenceRawUrlResponseSchema,
 };
 
 function generateComponentSchemas(): Json {
@@ -1207,6 +1210,120 @@ function memoryReadPaths(): Json {
   };
 }
 
+/**
+ * Raw-evidence read gateway (Brain v2.1 MM-3). The '/v1/episodes
+ * 404-until-flag' precedent: every route (the unauthenticated redeem
+ * included) answers a bare 404 while EVIDENCE_RAW_READ_ENABLED is off,
+ * and every controller-side denial — cross-tenant, no grant, no
+ * consent, PII-blocked, quarantined, bad/expired/revoked token — is the
+ * SAME bare 404 (no existence oracle; outcomes differ only in the
+ * content-free evidence_access audit table, migration 0125).
+ */
+function evidencePaths(): Json {
+  const blobResponse: Json = {
+    description:
+      'The original bytes (Content-Type = the registered mediaType), ' +
+      'with X-Content-Type-Options: nosniff, Cache-Control: no-store ' +
+      'and Content-Disposition: attachment.',
+    content: {
+      'application/octet-stream': { schema: { type: 'string', format: 'binary' } },
+    },
+  };
+  const rawDescription =
+    'Streams the asset’s original bytes after the full gate ladder: ' +
+    'brain:read scope, ABAC action `rest.evidence.raw`, tenant fence ' +
+    "(availability='hot', quarantine clean-or-absent), at least one " +
+    'live ownership grant (a user-bound key needs the end user’s own), ' +
+    'current pack modality consent declaring the raw-evidence ' +
+    'capability, and the media-PII polarity (unclassified blocked, `[]` ' +
+    'open, non-empty needs `brain:read_media`). Any denial is a bare ' +
+    '404. 404 until EVIDENCE_RAW_READ_ENABLED=1. Source: ' +
+    'src/evidence/evidence-read.controller.ts.';
+  const mintDescription =
+    'Same gate ladder as the raw stream; on pass answers a short-lived ' +
+    'signed URL token (HMAC-SHA256, EVIDENCE_SIGNED_URL_SECRET, TTL ' +
+    'EVIDENCE_SIGNED_URL_TTL_SECONDS, default 300 s) redeemable WITHOUT ' +
+    'auth at /v1/evidence/redeem/{token}. 503 while the secret is not ' +
+    'configured. 404 until EVIDENCE_RAW_READ_ENABLED=1.';
+  return {
+    '/v1/evidence/{assetId}/raw': {
+      get: operation({
+        operationId: 'streamEvidenceAsset',
+        tag: 'Evidence',
+        summary: 'Stream an evidence asset’s original bytes',
+        description: rawDescription,
+        scope: 'brain:read',
+        parameters: [pathParam('assetId', 'evidence_asset record id.')],
+        responses: { '200': blobResponse, ...DRIVER_404 },
+      }),
+    },
+    '/v1/evidence/{assetId}/raw-url': {
+      get: operation({
+        operationId: 'mintEvidenceAssetUrl',
+        tag: 'Evidence',
+        summary: 'Mint a signed short-lived URL for an asset’s bytes',
+        description: mintDescription,
+        scope: 'brain:read',
+        parameters: [pathParam('assetId', 'evidence_asset record id.')],
+        responses: {
+          '200': jsonResponse('The signed URL.', ref('EvidenceRawUrlResponse')),
+          '503': errorRef('FeatureDisabled'),
+          ...DRIVER_404,
+        },
+      }),
+    },
+    '/v1/evidence/fragments/{fragmentId}/raw': {
+      get: operation({
+        operationId: 'streamEvidenceFragment',
+        tag: 'Evidence',
+        summary: 'Stream a fragment’s evidence bytes (parent asset, v1)',
+        description:
+          'Fragment twin of the asset stream: v1 serves the WHOLE parent ' +
+          'asset’s bytes (no locator cropping yet) under the STRICTEST ' +
+          'union of the fragment’s and the asset’s piiClasses. ' +
+          rawDescription,
+        scope: 'brain:read',
+        parameters: [pathParam('fragmentId', 'evidence_fragment record id.')],
+        responses: { '200': blobResponse, ...DRIVER_404 },
+      }),
+    },
+    '/v1/evidence/fragments/{fragmentId}/raw-url': {
+      get: operation({
+        operationId: 'mintEvidenceFragmentUrl',
+        tag: 'Evidence',
+        summary: 'Mint a signed short-lived URL for a fragment’s bytes',
+        description:
+          'Fragment twin of the asset mint (whole parent-asset bytes, ' +
+          'strictest piiClasses union). ' +
+          mintDescription,
+        scope: 'brain:read',
+        parameters: [pathParam('fragmentId', 'evidence_fragment record id.')],
+        responses: {
+          '200': jsonResponse('The signed URL.', ref('EvidenceRawUrlResponse')),
+          '503': errorRef('FeatureDisabled'),
+          ...DRIVER_404,
+        },
+      }),
+    },
+    '/v1/evidence/redeem/{token}': {
+      get: {
+        operationId: 'redeemEvidenceUrl',
+        tags: ['Evidence'],
+        summary: 'Redeem a signed raw-evidence URL (no auth)',
+        description:
+          'Unauthenticated by design — the token IS the capability. No ' +
+          'ABAC/consent/PII re-run; fail-closed re-checks only: ' +
+          'signature, expiry, the token’s own tenant, availability ' +
+          "still 'hot', and at least one live grant (revocation " +
+          'backstop). Bad, expired and revoked tokens all answer the ' +
+          'same bare 404. 404 until EVIDENCE_RAW_READ_ENABLED=1.',
+        parameters: [pathParam('token', 'The signed token from a raw-url mint.')],
+        responses: { '200': blobResponse, '404': errorRef('NotFound') },
+      },
+    },
+  };
+}
+
 function indexerWorkPaths(): Json {
   return {
     '/v1/indexer/work': {
@@ -1463,6 +1580,16 @@ export function buildOpenApiDocument(): Json {
           'Flag: BELIEFS_API_ENABLED (off → 404).',
       },
       {
+        name: 'Evidence',
+        description:
+          'The raw-evidence read gateway: original observation bytes ' +
+          'back out — direct stream, signed short-lived URLs, fragment ' +
+          'twins — behind the full deny-overrides gate ladder (scope, ' +
+          'ABAC, tenant/availability/quarantine, ownership grants, pack ' +
+          'modality consent, media-PII polarity), every attempt audited ' +
+          'content-free. Flag: EVIDENCE_RAW_READ_ENABLED (off → 404).',
+      },
+      {
         name: 'Users',
         description:
           'Per-user surfaces: the rolling user profile assembled from ' +
@@ -1479,6 +1606,7 @@ export function buildOpenApiDocument(): Json {
       ...sourcesPaths(),
       ...driverPaths(),
       ...memoryReadPaths(),
+      ...evidencePaths(),
     },
     webhooks: {
       episodesAvailable: {

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1263,6 +1263,33 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       "Evidence plane, fragment citations (MM-zoom PR2): with the fragment lane rendering media evidence (RETRIEVAL_FRAGMENT_LANE), each rendered line carries its [evidence_fragment:...] header and the generator schema gains citedFragmentIds; emitted ids resolve through the rendered-set fence (the FOVEA_L3_EPISODE_CITATIONS idiom: an id not rendered into the prompt is dropped and counted, never surfaced; the citation's excerpt is the RENDERED excerpt, never generator text; dedupe; cap 16) into fragment-arm evidenceCitations carrying assetId + capability. Those citations let the FOVEA_EVIDENCE_CAPABILITY gate PASS for non-text requirements when a matching-modality fragment is cited. Off (default) → no header, no schema field, no resolver — byte-identical even with the lane on.",
   },
+  {
+    key: 'EVIDENCE_RAW_READ_ENABLED',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Raw-read gateway (MM-3, migration 0125): the ONE surface serving original evidence bytes — GET /v1/evidence/{assetId}/raw(-url), the fragment twins (whole parent-asset bytes under the STRICTEST fragment+asset piiClasses union), and the unauthenticated signed-URL redeem. Full deny-overrides gate ladder (scope → tenant/availability/quarantine → live grants → ABAC rest.evidence.raw → modality consent via a direct fail-closed domain_pack read → media-PII polarity → blob head), every attempt recorded content-free in evidence_access. Off (default) = every route answers a bare 404, indistinguishable from absent routes — byte-identical.',
+  },
+  {
+    key: 'EVIDENCE_SIGNED_URL_SECRET',
+    category: 'pipeline',
+    defaultValue: '',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'HMAC-SHA256 secret for minted raw-evidence URL tokens. NO default on purpose — a default would make every deployment mutually forgeable. Boot hard-errors when set shorter than 32 chars while EVIDENCE_RAW_READ_ENABLED is on, and warns when the flag is on without it (streaming works; mint answers 503, redeem 404 until the secret lands).',
+  },
+  {
+    key: 'EVIDENCE_SIGNED_URL_TTL_SECONDS',
+    category: 'pipeline',
+    defaultValue: '300',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Lifetime of a minted raw-evidence URL (default 300 s). Deliberately short: the token is a bearer capability — expiry plus the live-grant re-check at redeem are its only revocation levers.',
+  },
   // ── Document pipeline (migrations 0048–0050) ─────────────
   {
     key: 'DOCUMENT_INGEST_ENABLED',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -264,6 +264,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // ── Evidence plane: processing lifecycle (migration 0121) ──────────
   validateEvidenceProcessingEnv(env, warnings);
 
+  // ── Evidence plane: raw-read gateway (MM-3, migration 0125) ────────
+  validateEvidenceRawReadEnv(env, errors, warnings);
+
   // ── All remaining boolean feature flags ────────────────────────────
   validateBooleanFlags(env, warnings);
 
@@ -442,6 +445,41 @@ function validateEvidenceProcessingEnv(env: NodeJS.ProcessEnv, warnings: string[
       'EVIDENCE_PROCESSOR_BROKER is set while EVIDENCE_SUBSTRATE_ENABLED is not — ' +
         'the broker writes derived representations through the substrate seam; every ' +
         'dispatch will be rejected (503) until EVIDENCE_SUBSTRATE_ENABLED is turned on.',
+    );
+  }
+}
+
+/**
+ * Raw-read gateway (MM-3): the signed-URL secret is a forgery boundary,
+ * so a weak configured value is a hard boot ERROR while the gateway flag
+ * is on (the RETRIEVAL_PROFILE_OVERRIDES boot-rule idiom: reject the
+ * misconfiguration shape outright, don't run degraded). Flag on with NO
+ * secret at all is a WARNING, not an error — streaming works without
+ * one; only the mint/redeem routes refuse (503 mint, 404 redeem) until
+ * the secret lands. The TTL is a positive int like the other numeric
+ * knobs (validated unconditionally at the call site above).
+ */
+function validateEvidenceRawReadEnv(
+  env: NodeJS.ProcessEnv,
+  errors: string[],
+  warnings: string[],
+): void {
+  positiveInt(env, 'EVIDENCE_SIGNED_URL_TTL_SECONDS', errors);
+  if (!envFlagEnabled(env.EVIDENCE_RAW_READ_ENABLED)) return;
+  const secret = env.EVIDENCE_SIGNED_URL_SECRET;
+  if (secret === undefined || secret.trim() === '') {
+    warnings.push(
+      'EVIDENCE_RAW_READ_ENABLED is set without EVIDENCE_SIGNED_URL_SECRET — ' +
+        'raw streaming will serve, but signed-URL mint refuses (503) and ' +
+        'redeem answers 404 until a secret (>= 32 chars) is configured.',
+    );
+    return;
+  }
+  if (secret.length < 32) {
+    errors.push(
+      'EVIDENCE_SIGNED_URL_SECRET must be at least 32 characters while ' +
+        'EVIDENCE_RAW_READ_ENABLED is on — a short secret makes minted ' +
+        'raw-evidence URLs forgeable.',
     );
   }
 }
@@ -980,6 +1018,13 @@ const KNOWN_BOOLEAN_FLAGS = [
   // family sits off the ENGINE flag budget by design (see above).
   'EVIDENCE_PROCESSOR_BROKER',
   'EVIDENCE_QUARANTINE',
+  // Raw-read gateway (MM-3, migration 0125): the single REST surface that
+  // serves original evidence bytes (stream + signed-URL mint/redeem)
+  // behind the full gate ladder. Default off = every route 404s,
+  // byte-identical. The secret/TTL knobs are strings/ints, not booleans
+  // (validateEvidenceRawReadEnv). EVIDENCE_ family sits off the ENGINE
+  // flag budget by design (see above).
+  'EVIDENCE_RAW_READ_ENABLED',
   // Outcome telemetry master (0107): writers append memory_outcome rows
   // + fold memory_outcome_stat counters; the nightly raw-log prune runs.
   // Default off = byte-identical (every writer is a guarded no-op).

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -195,6 +195,60 @@ export function fragmentCitationsEnabled(): boolean {
 }
 
 /**
+ * Raw-read gateway (Brain v2.1 MM-3) — EVIDENCE_RAW_READ_ENABLED.
+ *
+ * When on, EvidenceReadController serves the five raw-evidence routes
+ * (asset/fragment stream + signed-URL mint, and the unauthenticated
+ * redeem) behind the full gate ladder. Default off ⇒ every route answers
+ * a bare 404, indistinguishable from an absent route (the
+ * EPISODES_API_ENABLED idiom) — byte-identical prod. The env read lives
+ * here in the common layer, NOT inside the controller (engine-gates
+ * S5.2); read at call time so a flip is runtime-mutable. EVIDENCE_
+ * family sits off the ENGINE flag budget by design.
+ */
+export function evidenceRawReadEnabled(): boolean {
+  return envFlagEnabled(process.env.EVIDENCE_RAW_READ_ENABLED);
+}
+
+/**
+ * Signed-URL HMAC secret — EVIDENCE_SIGNED_URL_SECRET (non-boolean).
+ *
+ * Keys the HMAC-SHA256 over minted raw-evidence URL tokens. NO default,
+ * deliberately: a default secret would make every deployment's tokens
+ * mutually forgeable. Boot validation (env-validation.ts) hard-errors on
+ * a configured-but-short (<32 chars) secret while EVIDENCE_RAW_READ_ENABLED
+ * is on, and warns when the flag is on with no secret at all (the mint
+ * routes then refuse 503; streaming still works). Read at call time
+ * (runtime-mutable); common layer per engine-gates S5.2.
+ */
+export function evidenceSignedUrlSecret(): string | null {
+  const raw = process.env.EVIDENCE_SIGNED_URL_SECRET;
+  if (raw === undefined || raw.trim() === '') return null;
+  return raw;
+}
+
+/** Default mint TTL: 300 s. (Named WITHOUT the full env-key substring so
+ *  the W6 boot-capture truth gate doesn't mistake this module-scope
+ *  default for a boot-captured read.) */
+const DEFAULT_SIGNED_TTL = 300;
+
+/**
+ * Signed-URL lifetime — EVIDENCE_SIGNED_URL_TTL_SECONDS (non-boolean).
+ *
+ * Seconds a minted raw-evidence URL stays redeemable. Short by default
+ * (300 s): the token is a bearer capability — expiry and the live-grant
+ * re-check at redeem are its only revocation levers. Must be a positive
+ * integer; unset, blank, or invalid → the 300 s default. Read at call
+ * time (runtime-mutable); common layer per engine-gates S5.2.
+ */
+export function evidenceSignedUrlTtlSeconds(): number {
+  const raw = process.env.EVIDENCE_SIGNED_URL_TTL_SECONDS;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_SIGNED_TTL;
+  const v = Number(raw);
+  return Number.isInteger(v) && v > 0 ? v : DEFAULT_SIGNED_TTL;
+}
+
+/**
  * Strict serving — EVIDENCE_UNGROUNDED_SERVING_GATE.
  *
  * When on, a supported verdict batch-checks its cited facts' stored

--- a/src/common/media-pii.ts
+++ b/src/common/media-pii.ts
@@ -72,3 +72,19 @@ export function mediaPiiAllowed(
   if (callerScopes.includes('brain:read_media')) return true;
   return Array.isArray(piiClasses) && piiClasses.length === 0;
 }
+
+/**
+ * STRICTEST union of two media piiClasses states — the raw-read
+ * gateway's fragment twins serve whole parent-asset bytes, so BOTH the
+ * fragment's and the asset's classification constrain the serve. Same
+ * polarity table as above: an unclassified (NONE/absent) side wins
+ * (undefined out — blocked); otherwise the set union — `[]` only when
+ * BOTH sides are affirmatively clean.
+ */
+export function strictestPiiUnion(
+  a: readonly string[] | null | undefined,
+  b: readonly string[] | null | undefined,
+): readonly string[] | undefined {
+  if (!Array.isArray(a) || !Array.isArray(b)) return undefined;
+  return [...new Set([...a, ...b])];
+}

--- a/src/contracts/evidence/raw.schema.ts
+++ b/src/contracts/evidence/raw.schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+/**
+ * Wire contract for the raw-evidence read gateway (Brain v2.1 MM-3,
+ * EVIDENCE_RAW_READ_ENABLED). Only the mint routes answer JSON — the
+ * stream/redeem routes serve the blob itself (documented inline in
+ * scripts/build-openapi.ts, no zod contract for a byte stream).
+ */
+
+/** Answer of GET /v1/evidence/{assetId}/raw-url and its fragment twin. */
+export const EvidenceRawUrlResponseSchema = z.object({
+  /** Opaque signed token — `base64url(payload) + '.' + hmac-sha256-hex`. */
+  token: z.string(),
+  /** Relative redeem path (`/v1/evidence/redeem/{token}`), servable by
+   *  any host that fronts this API — no auth header needed. */
+  url: z.string(),
+  /** ISO instant after which the token redeems as 404. */
+  expiresAt: z.string(),
+});
+export type EvidenceRawUrlResponse = z.infer<typeof EvidenceRawUrlResponseSchema>;

--- a/src/db/migrations/0125_evidence_access.surql
+++ b/src/db/migrations/0125_evidence_access.surql
@@ -1,0 +1,51 @@
+-- 0125: evidence_access — content-free audit trail of the raw-read
+-- gateway (Brain v2.1 MM-3).
+--
+-- WHY. Serving original bytes back out is the highest-sensitivity read
+-- the platform performs; every attempt (served OR denied, stream, mint
+-- and redeem alike) must leave an attributable record. The row is
+-- CONTENT-FREE by construction: subject handles (asset/fragment record
+-- ids as plain strings), the caller's hashed credential, the verb, and
+-- the gate-ladder outcome — never bytes, labels, PII classes, or URLs.
+-- A signed-URL token never lands here either (it would BE a capability).
+--
+-- assetId / fragmentId are STRINGS, not record links, on purpose: an
+-- audit row must not dangle (or vanish via record-link cleanup) when its
+-- subject row dies — erasure of the trail is an explicit GDPR decision,
+-- wired into the two places an asset dies (user-forget cascade and the
+-- retention/quarantine tombstone path), LET/SELECT-ids → DELETE by ids.
+--
+-- outcome is an open vocabulary ('ok' | 'denied_<step>' — 0048 `kind`
+-- doctrine: shape-capped at the write seam, no enum ASSERT), so a new
+-- ladder step never needs a migration.
+--
+-- RENUMBER CAVEAT (0109/0122 precedent): 0119 and 0123 are claimed by
+-- sibling PRs; the migrator orders by filename and tolerates gaps —
+-- 0125 stays 0125 either way; do NOT renumber on rebase.
+
+-- ── evidence_access ───────────────────────────────────────────────────
+
+DEFINE TABLE IF NOT EXISTS evidence_access SCHEMAFULL;
+
+-- Subject handles as strings (see header — deliberately NOT record<>).
+DEFINE FIELD IF NOT EXISTS assetId ON evidence_access TYPE string;
+DEFINE FIELD IF NOT EXISTS fragmentId ON evidence_access TYPE option<string>;
+-- The caller's hashed credential (brainAuth.keyHash; for redeem: the
+-- MINTING key's hash carried inside the verified token payload).
+DEFINE FIELD IF NOT EXISTS keyHash ON evidence_access TYPE string;
+DEFINE FIELD IF NOT EXISTS verb ON evidence_access TYPE string
+  ASSERT $value INSIDE ['stream', 'mint', 'redeem'];
+-- 'ok' or 'denied_<step>' — open vocabulary, code-capped (0048 doctrine).
+DEFINE FIELD IF NOT EXISTS outcome ON evidence_access TYPE string;
+DEFINE FIELD IF NOT EXISTS createdAt ON evidence_access TYPE datetime DEFAULT time::now();
+
+-- Single-field indexes ONLY (the SurrealDB 3.2.4 compound-index
+-- DELETE-planner no-op class — this table sits on the GDPR delete path;
+-- the 0122 evidence_grant reasoning verbatim).
+DEFINE INDEX IF NOT EXISTS evidence_access_asset_idx ON evidence_access FIELDS assetId;
+DEFINE INDEX IF NOT EXISTS evidence_access_key_idx ON evidence_access FIELDS keyHash;
+DEFINE INDEX IF NOT EXISTS evidence_access_created_idx ON evidence_access FIELDS createdAt;
+
+-- NO CHANGEFEED, NO EVENT, deliberately (0122 reasoning): the row names
+-- a hashed principal and a subject handle; a 30-day feed would keep a
+-- GDPR-erased access trail readable after the rows die.

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -541,6 +541,19 @@ export class UserForgetService {
         frags: ((fragsGone as unknown[]) ?? []).length,
         assets: ((assetsGone as unknown[]) ?? []).length,
       };
+      // Access audit (0125): the raw-read trail dies with its asset —
+      // this cascade is one of the two places assets die (the other,
+      // retention/quarantine whole-asset death, carries its own leg in
+      // purgeAssetDependents). evidence_access keys the asset as a plain
+      // STRING (audit rows must not dangle), so match the stringified
+      // ids; SURVIVING shared assets keep their trail — it names the
+      // ACCESSOR's hashed key, not the erased owner. LET-select-ids →
+      // DELETE, the 3.2.4 planner discipline like every leg above.
+      await db.query(
+        `LET $accessIds = (SELECT VALUE id FROM evidence_access WHERE assetId INSIDE $strs);
+         DELETE $accessIds RETURN BEFORE;`,
+        { strs: dyingIds.map(String) },
+      );
     }
     let blobFailures = 0;
     for (const ref of storageRefs) {

--- a/src/evidence/evidence-read.controller.ts
+++ b/src/evidence/evidence-read.controller.ts
@@ -1,0 +1,227 @@
+import {
+  Controller,
+  Get,
+  Inject,
+  Logger,
+  NotFoundException,
+  Param,
+  Req,
+  Res,
+  ServiceUnavailableException,
+  UseGuards,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import {
+  evidenceRawReadEnabled,
+  evidenceSignedUrlSecret,
+  evidenceSignedUrlTtlSeconds,
+} from '../common/evidence-flags';
+import type { EvidenceRawUrlResponse } from '../contracts/evidence/raw.schema';
+import { PolicyAction } from '../policy/action-registry';
+import { EvidenceReadService, type SubjectBlob } from './evidence-read.service';
+import { mintEvidenceToken, verifyEvidenceToken } from './raw-url-token';
+import {
+  EVIDENCE_STORAGE_ADAPTERS,
+  EvidenceStorageRegistry,
+  storageRefScheme,
+} from './storage/storage-adapter';
+
+/** Minimum secret length — mirrored by the boot rule in env-validation. */
+const SECRET_MIN = 32;
+
+/**
+ * EvidenceReadController (Brain v2.1 MM-3) — the ONE raw-read gateway:
+ * every path that turns a stored evidence row back into original bytes
+ * goes through here; nothing else in the codebase may serve a blob.
+ * Transport only — the DB half of the ladder lives in
+ * EvidenceReadService (layer purity: controllers never import src/db).
+ *
+ * Routes (all 404 while EVIDENCE_RAW_READ_ENABLED is off — the
+ * EPISODES_API_ENABLED idiom, indistinguishable from absent routes):
+ *   GET /v1/evidence/:assetId/raw               — stream the blob
+ *   GET /v1/evidence/:assetId/raw-url           — mint a signed URL
+ *   GET /v1/evidence/fragments/:fragmentId/raw      — fragment twin
+ *   GET /v1/evidence/fragments/:fragmentId/raw-url  — fragment twin
+ *   GET /v1/evidence/redeem/:token              — redeem a signed URL
+ * The fragment twins serve WHOLE parent-asset bytes in v1 (no locator
+ * cropping yet) under the STRICTEST union of fragment+asset piiClasses.
+ *
+ * Gate ladder — deny-overrides, first failure wins, every controller-
+ * observable step lands in the content-free evidence_access audit row
+ * (migration 0125):
+ *   (1) ApiKeyGuard + brain:read scope            [guard]
+ *   (4) ABAC action 'rest.evidence.raw'           [guard — see note]
+ *   (2) tenant fence  (3) live grants  (5) modality consent
+ *   (6) media PII     (7) blob head               [EvidenceReadService]
+ * Note on (4): ABAC runs inside ApiKeyGuard (platform architecture —
+ * every route is guard-gated before its handler), so a policy deny is a
+ * 403 BEFORE the audit seam; the ladder's remaining order is exact.
+ * Every deny the ladder decides is a uniform bare 404 — no existence
+ * oracle; outcomes differ only inside the audit row.
+ *
+ * Redeem contract: NO auth / ABAC / consent / PII re-run — the token IS
+ * the capability. Fail-closed re-checks only (EvidenceReadService
+ * .redeemLadder): signature (timing-safe, HERE, before ANY db touch),
+ * expiry, structural tenant pin, availability still hot, ≥1 live grant
+ * (the revocation backstop). Bad/expired/revoked all answer the same
+ * bare 404; the audit row distinguishes (denied_signature is log-only:
+ * an unauthenticated forgery must not write rows into anyone's tenant).
+ */
+@Controller('v1/evidence')
+export class EvidenceReadController {
+  private readonly logger = new Logger(EvidenceReadController.name);
+
+  constructor(
+    private readonly reads: EvidenceReadService,
+    @Inject(EVIDENCE_STORAGE_ADAPTERS)
+    private readonly adapters: EvidenceStorageRegistry,
+  ) {}
+
+  private assertEnabled(): void {
+    if (!evidenceRawReadEnabled()) throw new NotFoundException();
+  }
+
+  // ── Redeem (declared FIRST: '/redeem/raw' must never bind to the
+  //    ':assetId/raw' pattern) — unauthenticated by design. ───────────
+  @Get('redeem/:token')
+  async redeem(@Param('token') token: string, @Res() res: Response): Promise<void> {
+    this.assertEnabled();
+    const secret = evidenceSignedUrlSecret();
+    // No/short secret ⇒ nothing valid was ever minted — uniform 404.
+    if (!secret || secret.length < SECRET_MIN) throw new NotFoundException();
+    const verdict = verifyEvidenceToken(token, secret, Date.now());
+    if (verdict.state === 'invalid') {
+      // Forged/malformed: payload untrusted, so no tenant to audit into.
+      this.logger.warn('raw-evidence redeem denied_signature (unsigned token)');
+      throw new NotFoundException();
+    }
+    const blob = await this.reads.redeemLadder(verdict.payload, verdict.state === 'expired');
+    await this.streamBlob(res, blob);
+  }
+
+  // ── Fragment twins (before ':assetId' so 'fragments' never binds). ──
+  @Get('fragments/:fragmentId/raw')
+  @UseGuards(ApiKeyGuard)
+  @RequireScopes('brain:read')
+  @PolicyAction('rest.evidence.raw')
+  async fragmentRaw(
+    @Req() req: AuthenticatedRequest,
+    @Param('fragmentId') fragmentId: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    this.assertEnabled();
+    const blob = await this.reads.runLadder({ ...ladderAuth(req), fragmentId, verb: 'stream' });
+    await this.streamBlob(res, blob);
+  }
+
+  @Get('fragments/:fragmentId/raw-url')
+  @UseGuards(ApiKeyGuard)
+  @RequireScopes('brain:read')
+  @PolicyAction('rest.evidence.raw')
+  async fragmentRawUrl(
+    @Req() req: AuthenticatedRequest,
+    @Param('fragmentId') fragmentId: string,
+  ): Promise<EvidenceRawUrlResponse> {
+    this.assertEnabled();
+    const blob = await this.reads.runLadder({ ...ladderAuth(req), fragmentId, verb: 'mint' });
+    return this.mintFor(req, blob);
+  }
+
+  // ── Asset routes. ──────────────────────────────────────────────────
+  @Get(':assetId/raw')
+  @UseGuards(ApiKeyGuard)
+  @RequireScopes('brain:read')
+  @PolicyAction('rest.evidence.raw')
+  async assetRaw(
+    @Req() req: AuthenticatedRequest,
+    @Param('assetId') assetId: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    this.assertEnabled();
+    const blob = await this.reads.runLadder({ ...ladderAuth(req), assetId, verb: 'stream' });
+    await this.streamBlob(res, blob);
+  }
+
+  @Get(':assetId/raw-url')
+  @UseGuards(ApiKeyGuard)
+  @RequireScopes('brain:read')
+  @PolicyAction('rest.evidence.raw')
+  async assetRawUrl(
+    @Req() req: AuthenticatedRequest,
+    @Param('assetId') assetId: string,
+  ): Promise<EvidenceRawUrlResponse> {
+    this.assertEnabled();
+    const blob = await this.reads.runLadder({ ...ladderAuth(req), assetId, verb: 'mint' });
+    return this.mintFor(req, blob);
+  }
+
+  /** Mint the signed URL for a ladder-approved subject. 503 (operator
+   *  state, the store-gate class) when the secret is absent/short —
+   *  boot only WARNS on flag-without-secret, so the runtime must refuse
+   *  here; the boot ERROR covers the configured-but-short shape. */
+  private mintFor(req: AuthenticatedRequest, blob: SubjectBlob): EvidenceRawUrlResponse {
+    const secret = evidenceSignedUrlSecret();
+    if (!secret || secret.length < SECRET_MIN) {
+      throw new ServiceUnavailableException(
+        'EVIDENCE_SIGNED_URL_SECRET (>= 32 chars) is required to mint signed URLs',
+      );
+    }
+    const exp = Math.floor(Date.now() / 1000) + evidenceSignedUrlTtlSeconds();
+    const token = mintEvidenceToken(
+      {
+        v: 1,
+        t: req.brainAuth.companyId,
+        a: blob.assetIdStr,
+        ...(blob.fragmentIdStr !== undefined ? { f: blob.fragmentIdStr } : {}),
+        k: req.brainAuth.keyHash,
+        exp,
+      },
+      secret,
+    );
+    return {
+      token,
+      url: `/v1/evidence/redeem/${token}`,
+      expiresAt: new Date(exp * 1000).toISOString(),
+    };
+  }
+
+  /** Stream with the defensive header set: nosniff + no-store (spec) and
+   *  attachment disposition (an API origin must never render evidence
+   *  bytes as a document). mediaType was IANA-shape-validated at
+   *  registration; byteLength was verified against the stored blob. */
+  private async streamBlob(res: Response, blob: SubjectBlob): Promise<void> {
+    const scheme = storageRefScheme(blob.storageRef);
+    const adapter = scheme ? this.adapters.get(scheme) : undefined;
+    if (!adapter) throw new NotFoundException();
+    let stream: NodeJS.ReadableStream;
+    try {
+      stream = await adapter.get(blob.storageRef);
+    } catch (e) {
+      // head() passed inside the ladder — a vanish in between is a race
+      // with GDPR/retention; the uniform 404 stands, the ok-row already
+      // written records the ATTEMPT honestly (no bytes left).
+      this.logger.warn(`raw-evidence blob get failed: ${(e as Error).message}`);
+      throw new NotFoundException();
+    }
+    res.setHeader('Content-Type', blob.mediaType);
+    res.setHeader('Content-Length', String(blob.byteLength));
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('Content-Disposition', 'attachment');
+    stream.pipe(res);
+  }
+}
+
+/** The brainAuth slice the ladder needs — one spreadable object so the
+ *  route handlers stay within the max-params discipline. */
+function ladderAuth(req: AuthenticatedRequest): {
+  companyId: string;
+  scopes: readonly string[];
+  keyHash: string;
+  userId?: string | undefined;
+} {
+  const { companyId, scopes, keyHash, userId } = req.brainAuth;
+  return { companyId, scopes, keyHash, userId };
+}

--- a/src/evidence/evidence-read.service.ts
+++ b/src/evidence/evidence-read.service.ts
@@ -1,0 +1,320 @@
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import type { Surreal } from 'surrealdb';
+import type { DomainPackManifest } from '../ai/domain-packs';
+import { strictestPiiUnion } from '../common/media-pii';
+import { SurrealService, dbCreate, queryFirst, queryRows } from '../db/surreal.service';
+import { idTailOf } from '../ingest/ingest-utils';
+import { gateRawEvidence } from '../mcp/raw-evidence-gate';
+import type { EvidenceTokenPayload } from './raw-url-token';
+import {
+  EVIDENCE_STORAGE_ADAPTERS,
+  EvidenceStorageRegistry,
+  storageRefScheme,
+} from './storage/storage-adapter';
+
+/** Caller-supplied subject handles are audited verbatim — bounded so a
+ *  probe cannot bloat the content-free audit table (0048 cap doctrine). */
+const HANDLE_MAX = 200;
+
+export type AccessVerb = 'stream' | 'mint' | 'redeem';
+
+/** What the gate ladder resolved — enough to stream or mint, no bytes. */
+export interface SubjectBlob {
+  assetIdStr: string;
+  fragmentIdStr?: string | undefined;
+  storageRef: string;
+  mediaType: string;
+  byteLength: number;
+}
+
+interface AssetRow {
+  id: unknown;
+  availability?: string | undefined;
+  quarantineStatus?: string | null | undefined;
+  storageRef?: string | undefined;
+  mediaType?: string | undefined;
+  byteLength?: number | undefined;
+  piiClasses?: string[] | null | undefined;
+}
+
+interface FragmentRow extends AssetRow {
+  fragmentPiiClasses?: string[] | null | undefined;
+  assetIdStr?: string | undefined;
+}
+
+interface ConsentRow {
+  manifest?: unknown;
+  acceptedModalities?: unknown;
+  acceptedModalitiesChecksum?: unknown;
+}
+
+interface AuditKey {
+  assetId: string;
+  fragmentId?: string | undefined;
+  keyHash: string;
+  verb: AccessVerb;
+}
+
+/**
+ * EvidenceReadService — the DB half of the raw-read gateway (MM-3):
+ * the gate-ladder steps that touch rows (tenant fence, live grants,
+ * modality consent, media PII, blob head) plus the content-free
+ * evidence_access audit writes (migration 0125). The controller keeps
+ * transport (routes, token mint/verify, headers, streaming) — layer
+ * purity: controllers never import src/db.
+ *
+ * Ladder semantics (deny-overrides, first failure wins; the numbering
+ * follows the controller's class doc):
+ *   (2) tenant fence — the lookup runs inside withCompany(companyId),
+ *       so a foreign asset is simply not found; availability must be
+ *       'hot' and quarantineStatus clean-or-absent (0121: nothing
+ *       writes a non-clean status while the seam is off, so absent
+ *       reads as legacy-clean)                    → denied_tenant /
+ *       denied_availability
+ *   (3) grants (0122) — ≥1 live row keeps the asset servable at all
+ *       (all-revoked = administratively dead, the redeem backstop
+ *       applied to first-party reads); a USER-BOUND key must ALSO hold
+ *       the end user's own live user-grant (0055)  → denied_grant
+ *   (5) modality consent — gateRawEvidence (its FIRST production call
+ *       site) folded over a DIRECT domain_pack read: deliberately NOT
+ *       the fail-open MemoryModelReaderService cache — raw bytes must
+ *       not serve on a stale cache entry after consent was withdrawn,
+ *       and a read failure must deny, never default. Probed with
+ *       `fragmentPiiClasses: []` so only clauses (a)+(b) decide
+ *                                                  → denied_consent
+ *   (6) media PII — the SAME gate re-run with the row's real classes
+ *       (strictest fragment+asset union on the fragment twins): two
+ *       calls, zero duplicated logic, distinguishable audit outcomes
+ *                                                  → denied_pii
+ *   (7) blob head through the scheme adapter       → denied_blob
+ * Every deny is recorded (best-effort) and surfaced as the SAME bare
+ * 404 — no existence oracle. The 'ok' row is written BEFORE the blob
+ * ref leaves this service and is NOT best-effort: if the audit write
+ * fails, the serve fails — no unaccounted byte ever leaves.
+ */
+@Injectable()
+export class EvidenceReadService {
+  private readonly logger = new Logger(EvidenceReadService.name);
+
+  constructor(
+    private readonly surreal: SurrealService,
+    @Inject(EVIDENCE_STORAGE_ADAPTERS)
+    private readonly adapters: EvidenceStorageRegistry,
+  ) {}
+
+  /** Steps 2/3/5/6/7 for the four authenticated routes. */
+  async runLadder(opts: {
+    companyId: string;
+    scopes: readonly string[];
+    keyHash: string;
+    userId?: string | undefined;
+    assetId?: string | undefined;
+    fragmentId?: string | undefined;
+    verb: AccessVerb;
+  }): Promise<SubjectBlob> {
+    return this.surreal.withCompany(opts.companyId, async (db) => {
+      const row = opts.fragmentId
+        ? await this.loadFragment(db, opts.fragmentId)
+        : await this.loadAsset(db, opts.assetId ?? '');
+      const audit: AuditKey = {
+        assetId: (row?.assetIdStr ?? opts.assetId ?? '').slice(0, HANDLE_MAX),
+        fragmentId: opts.fragmentId?.slice(0, HANDLE_MAX),
+        keyHash: opts.keyHash,
+        verb: opts.verb,
+      };
+      if (!row) throw await this.deny(db, audit, 'denied_tenant');
+      if (!availabilityOk(row)) throw await this.deny(db, audit, 'denied_availability');
+      if (!(await this.grantOk(db, row.id, opts.userId))) {
+        throw await this.deny(db, audit, 'denied_grant');
+      }
+      const consent = await this.consentingManifest(db, opts.scopes);
+      if (!consent) throw await this.deny(db, audit, 'denied_consent');
+      const pii = opts.fragmentId
+        ? strictestPiiUnion(row.fragmentPiiClasses, row.piiClasses)
+        : row.piiClasses;
+      if (!gateRawEvidence({ ...consent, fragmentPiiClasses: pii }).allowed) {
+        throw await this.deny(db, audit, 'denied_pii');
+      }
+      const blob = blobOf(row, audit.assetId, audit.fragmentId);
+      if (!blob || !(await this.blobExists(blob.storageRef))) {
+        throw await this.deny(db, audit, 'denied_blob');
+      }
+      // Accountability before bytes: NOT best-effort (class doc).
+      await dbCreate(db, 'evidence_access', { ...audit, outcome: 'ok' });
+      return blob;
+    });
+  }
+
+  /**
+   * Redeem's fail-closed re-checks — NO auth/ABAC/consent/PII re-run
+   * (the token IS the capability; the controller verified its signature
+   * BEFORE this runs, so the payload — tenant included — is trusted):
+   * expiry, structural tenant pin (lookup inside withCompany(payload.t)),
+   * availability still hot, ≥1 live grant (revocation backstop). All
+   * denials are the same bare 404, distinguished only in the audit row.
+   */
+  async redeemLadder(payload: EvidenceTokenPayload, expired: boolean): Promise<SubjectBlob> {
+    return this.surreal.withCompany(payload.t, async (db) => {
+      const audit: AuditKey = {
+        assetId: payload.a.slice(0, HANDLE_MAX),
+        fragmentId: payload.f?.slice(0, HANDLE_MAX),
+        keyHash: payload.k.slice(0, HANDLE_MAX),
+        verb: 'redeem',
+      };
+      if (expired) throw await this.deny(db, audit, 'denied_expired');
+      const row = await this.loadAsset(db, payload.a);
+      if (!row) throw await this.deny(db, audit, 'denied_tenant');
+      if (!availabilityOk(row)) throw await this.deny(db, audit, 'denied_availability');
+      if (!(await this.grantOk(db, row.id, undefined))) {
+        throw await this.deny(db, audit, 'denied_revoked');
+      }
+      const blob = blobOf(row, audit.assetId, audit.fragmentId);
+      if (!blob || !(await this.blobExists(blob.storageRef))) {
+        throw await this.deny(db, audit, 'denied_blob');
+      }
+      // Accountability before bytes: NOT best-effort (class doc).
+      await dbCreate(db, 'evidence_access', { ...audit, outcome: 'ok' });
+      return blob;
+    });
+  }
+
+  private async loadAsset(db: Surreal, assetId: string): Promise<FragmentRow | null> {
+    const row = await queryFirst<AssetRow>(
+      db,
+      `SELECT id, availability, quarantineStatus, storageRef, mediaType,
+              byteLength, piiClasses
+         FROM type::record('evidence_asset', $tail) LIMIT 1`,
+      { tail: idTailOf(assetId) },
+    );
+    if (!row) return null;
+    return { ...row, assetIdStr: String(row.id) };
+  }
+
+  /** Fragment twin: the PARENT asset's row fields through the record
+   *  link, plus the fragment's own piiClasses for the strictest union. */
+  private async loadFragment(db: Surreal, fragmentId: string): Promise<FragmentRow | null> {
+    const row = await queryFirst<FragmentRow & { asset?: unknown }>(
+      db,
+      `SELECT id, piiClasses AS fragmentPiiClasses, assetId AS asset,
+              assetId.availability AS availability,
+              assetId.quarantineStatus AS quarantineStatus,
+              assetId.storageRef AS storageRef,
+              assetId.mediaType AS mediaType,
+              assetId.byteLength AS byteLength,
+              assetId.piiClasses AS piiClasses
+         FROM type::record('evidence_fragment', $tail) LIMIT 1`,
+      { tail: idTailOf(fragmentId) },
+    );
+    if (!row || row.asset === undefined || row.asset === null) return null;
+    return { ...row, id: row.asset, assetIdStr: String(row.asset) };
+  }
+
+  /** Step 3 currency — see the class doc. */
+  private async grantOk(db: Surreal, asset: unknown, userId: string | undefined): Promise<boolean> {
+    const live = await queryRows<{ ownerKind: string; ownerId: string }>(
+      db,
+      `SELECT ownerKind, ownerId FROM evidence_grant
+        WHERE assetId = $asset AND revokedAt = NONE`,
+      { asset },
+    );
+    if (live.length === 0) return false;
+    if (userId === undefined) return true;
+    return live.some((g) => g.ownerKind === 'user' && g.ownerId === userId);
+  }
+
+  /** Step 5 fold — see the class doc. Returns the consenting pack's
+   *  gate inputs (reused verbatim by the step-6 re-run), or null. */
+  private async consentingManifest(
+    db: Surreal,
+    scopes: readonly string[],
+  ): Promise<{
+    manifest: DomainPackManifest;
+    acceptedModalities: boolean;
+    acceptedModalitiesChecksum: string | null;
+    callerScopes: readonly string[];
+  } | null> {
+    let rows: ConsentRow[];
+    try {
+      const [r] = await db.query<[ConsentRow[]]>(
+        `SELECT manifest, acceptedModalities, acceptedModalitiesChecksum FROM domain_pack`,
+      );
+      rows = r ?? [];
+    } catch (e) {
+      this.logger.warn(`raw-evidence consent read failed (fail closed): ${(e as Error).message}`);
+      return null;
+    }
+    for (const row of rows) {
+      try {
+        if (typeof row.manifest !== 'object' || row.manifest === null) continue;
+        const candidate = {
+          manifest: row.manifest as DomainPackManifest,
+          acceptedModalities: row.acceptedModalities === true,
+          acceptedModalitiesChecksum:
+            typeof row.acceptedModalitiesChecksum === 'string'
+              ? row.acceptedModalitiesChecksum
+              : null,
+          callerScopes: scopes,
+        };
+        if (gateRawEvidence({ ...candidate, fragmentPiiClasses: [] }).allowed) {
+          return candidate;
+        }
+      } catch {
+        // Malformed manifest row — not consent (hasCurrentModalityConsent mold).
+      }
+    }
+    return null;
+  }
+
+  private async blobExists(storageRef: string): Promise<boolean> {
+    try {
+      const scheme = storageRefScheme(storageRef);
+      const adapter = scheme ? this.adapters.get(scheme) : undefined;
+      if (!adapter) return false;
+      return (await adapter.head(storageRef)) !== null;
+    } catch (e) {
+      this.logger.warn(`raw-evidence blob head failed for ${storageRef}: ${(e as Error).message}`);
+      return false;
+    }
+  }
+
+  /** Record a denial (best-effort — a warn must not turn the uniform 404
+   *  into a 500) and hand back the bare 404 the caller throws. */
+  private async deny(db: Surreal, audit: AuditKey, outcome: string): Promise<NotFoundException> {
+    try {
+      await dbCreate(db, 'evidence_access', { ...audit, outcome });
+    } catch (e) {
+      this.logger.warn(`evidence_access denial write failed (${outcome}): ${(e as Error).message}`);
+    }
+    return new NotFoundException();
+  }
+}
+
+/** Step 2 currency — hot + quarantine clean-or-absent (class doc). */
+function availabilityOk(row: AssetRow): boolean {
+  if (row.availability !== 'hot') return false;
+  const q = row.quarantineStatus;
+  return q === undefined || q === null || q === 'clean';
+}
+
+/** Step 7 shape: a servable row must carry a resolvable storageRef +
+ *  the metadata the stream headers need. */
+function blobOf(
+  row: AssetRow,
+  assetIdStr: string,
+  fragmentIdStr: string | undefined,
+): SubjectBlob | null {
+  if (
+    row.storageRef === undefined ||
+    typeof row.mediaType !== 'string' ||
+    typeof row.byteLength !== 'number'
+  ) {
+    return null;
+  }
+  return {
+    assetIdStr,
+    fragmentIdStr,
+    storageRef: row.storageRef,
+    mediaType: row.mediaType,
+    byteLength: row.byteLength,
+  };
+}

--- a/src/evidence/evidence-store.service.ts
+++ b/src/evidence/evidence-store.service.ts
@@ -674,6 +674,23 @@ export class EvidenceStoreService {
       await db.query(`DELETE $ids RETURN BEFORE`, { ids: runIds });
       if (runIds.length < 5000) break;
     }
+    // Access audit (0125): the trail dies with its asset — whole-asset
+    // death here (retention / quarantine rejection / reconciliation) is
+    // one of the two places assets die; the other is the user-forget
+    // cascade, which carries its own leg. evidence_access keys the asset
+    // as a plain STRING (audit rows must not dangle), so match on the
+    // stringified id. Two-step SELECT-ids → DELETE-ids like every leg
+    // above (3.2.4 planner discipline).
+    for (;;) {
+      const accessIds = await queryRows<unknown>(
+        db,
+        `SELECT VALUE id FROM evidence_access WHERE assetId = $assetStr LIMIT 5000`,
+        { assetStr: String(assetId) },
+      );
+      if (accessIds.length === 0) break;
+      await db.query(`DELETE $ids RETURN BEFORE`, { ids: accessIds });
+      if (accessIds.length < 5000) break;
+    }
   }
 
   private async purgeRepresentationBatches(

--- a/src/evidence/evidence.module.ts
+++ b/src/evidence/evidence.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { EvidenceReadController } from './evidence-read.controller';
+import { EvidenceReadService } from './evidence-read.service';
 import { EvidenceStoreService } from './evidence-store.service';
 import { EvidenceProcessorBrokerService } from './processor-broker.service';
 import { EvidenceQuarantineService } from './quarantine.service';
@@ -36,8 +38,16 @@ import {
  * All of it default-off behind EVIDENCE_PROCESSOR_BROKER /
  * EVIDENCE_QUARANTINE; exports exist for tests and future PR-C
  * consumers.
+ *
+ * Raw-read gateway (MM-3, migration 0125): EvidenceReadController is
+ * the ONE surface that serves original bytes back out — stream, signed-
+ * URL mint, and the unauthenticated redeem — behind the full gate
+ * ladder, default-off (EVIDENCE_RAW_READ_ENABLED → every route 404s).
+ * Guard dependencies (ApiKeyGuard / policy gate) resolve from the
+ * @Global auth/policy modules.
  */
 @Module({
+  controllers: [EvidenceReadController],
   providers: [
     FsEvidenceStorageAdapter,
     {
@@ -47,6 +57,7 @@ import {
       inject: [FsEvidenceStorageAdapter],
     },
     EvidenceStoreService,
+    EvidenceReadService,
     TextExtractionPassthroughAdapter,
     ImageMetadataStubAdapter,
     {

--- a/src/evidence/raw-url-token.ts
+++ b/src/evidence/raw-url-token.ts
@@ -1,0 +1,87 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Signed raw-evidence URL token (Brain v2.1 MM-3) — the pure half of
+ * the mint/redeem contract: `base64url(JSON payload) + '.' +
+ * HMAC-SHA256-hex over the base64url payload`, keyed by
+ * EVIDENCE_SIGNED_URL_SECRET. Kept free of Nest/DB imports so both the
+ * controller and the read service (and the unit spec) share one
+ * implementation.
+ */
+
+/** Payload (v1). Field names are single letters on purpose — the token
+ *  rides in a URL path; every byte counts. */
+export interface EvidenceTokenPayload {
+  v: 1;
+  /** companyId — the tenant the redeem is structurally pinned to. */
+  t: string;
+  /** evidence_asset record id (string form). */
+  a: string;
+  /** evidence_fragment record id when minted off the fragment twin. */
+  f?: string;
+  /** keyHash of the MINTING credential — redeem audit attribution. */
+  k: string;
+  /** Expiry, epoch seconds. */
+  exp: number;
+}
+
+export function mintEvidenceToken(payload: EvidenceTokenPayload, secret: string): string {
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const sig = createHmac('sha256', secret).update(body).digest('hex');
+  return `${body}.${sig}`;
+}
+
+export type EvidenceTokenVerdict =
+  /** Malformed or bad signature — the payload is NOT trustworthy. */
+  | { state: 'invalid' }
+  /** Signature checks out but the token is past its exp. */
+  | { state: 'expired'; payload: EvidenceTokenPayload }
+  | { state: 'valid'; payload: EvidenceTokenPayload };
+
+/**
+ * Verify a token. Signature FIRST (timing-safe), shape second, expiry
+ * last — a caller must never act on any field of an unsigned payload
+ * (the redeem route writes audit rows into the payload's tenant, so a
+ * forged tenant must die before any DB touch).
+ */
+export function verifyEvidenceToken(
+  token: string,
+  secret: string,
+  nowMs: number,
+): EvidenceTokenVerdict {
+  const dot = token.indexOf('.');
+  if (dot <= 0 || dot === token.length - 1 || token.indexOf('.', dot + 1) !== -1) {
+    return { state: 'invalid' };
+  }
+  const body = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+  const expected = createHmac('sha256', secret).update(body).digest('hex');
+  const sigBuf = Buffer.from(sig, 'utf8');
+  const expBuf = Buffer.from(expected, 'utf8');
+  if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
+    return { state: 'invalid' };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+  } catch {
+    return { state: 'invalid' };
+  }
+  const p = parsed as Record<string, unknown>;
+  if (
+    p === null ||
+    typeof p !== 'object' ||
+    p.v !== 1 ||
+    typeof p.t !== 'string' ||
+    typeof p.a !== 'string' ||
+    typeof p.k !== 'string' ||
+    (p.f !== undefined && typeof p.f !== 'string') ||
+    typeof p.exp !== 'number' ||
+    !Number.isFinite(p.exp)
+  ) {
+    return { state: 'invalid' };
+  }
+  const payload = parsed as EvidenceTokenPayload;
+  if (payload.exp * 1000 <= nowMs) return { state: 'expired', payload };
+  return { state: 'valid', payload };
+}

--- a/src/policy/action-registry.ts
+++ b/src/policy/action-registry.ts
@@ -143,6 +143,12 @@ export const ACTIONS: Record<string, ActionSpec> = {
     family: 'rest',
     title: 'Create pack checkout session',
   },
+  // Raw-evidence read gateway (MM-3, EVIDENCE_RAW_READ_ENABLED). ONE
+  // action for all four authenticated verbs (asset/fragment × stream/
+  // mint) — a policy that may see the bytes may also mint a short-lived
+  // URL to them; redeem is unauthenticated by design and gated by the
+  // token itself, so it carries no action.
+  'rest.evidence.raw': { kind: 'read', family: 'rest', title: 'Read raw evidence bytes' },
   // Rolling user profile v1 (USER_PROFILE_API_ENABLED). MCP-tool-style
   // name (the get_entity_profile precedent) so a future MCP surface
   // shares the action; REST-only today.

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -518,6 +518,73 @@ describe('0122_evidence_grant indexes', () => {
   });
 });
 
+describe('0125_evidence_access (raw-read gateway audit)', () => {
+  const sql = readFileSync(join(MIGRATIONS, '0125_evidence_access.surql'), 'utf8');
+
+  // ALL single-field, deliberately: the table sits on the GDPR delete
+  // path (rows die with their asset in user-forget AND in the retention/
+  // quarantine tombstone path) — compound coverage would put assetId
+  // under the 3.2.4 compound-planner DELETE no-op (0122 reasoning).
+  it.each([
+    ['evidence_access_asset_idx', 'evidence_access', 'assetId'],
+    ['evidence_access_key_idx', 'evidence_access', 'keyHash'],
+    ['evidence_access_created_idx', 'evidence_access', 'createdAt'],
+  ])('defines %s on %s(%s)', (name, table, fields) => {
+    expect(sql).toContain(`DEFINE INDEX IF NOT EXISTS ${name} ON ${table} FIELDS ${fields};`);
+  });
+
+  it('every index is SINGLE-FIELD (the 3.2.4 planner rule)', () => {
+    const defs = sql.match(/DEFINE INDEX[^;]+;/g) ?? [];
+    expect(defs.length).toBeGreaterThan(0);
+    for (const def of defs) {
+      const fields = /FIELDS ([^;]+);/.exec(def)?.[1] ?? '';
+      expect(fields).not.toContain(',');
+      expect(fields).not.toContain('UNIQUE');
+    }
+  });
+
+  it('subject handles are STRINGS, not record links (rows must not dangle)', () => {
+    expect(sql).toContain('DEFINE FIELD IF NOT EXISTS assetId ON evidence_access TYPE string;');
+    expect(sql).toContain(
+      'DEFINE FIELD IF NOT EXISTS fragmentId ON evidence_access TYPE option<string>;',
+    );
+    expect(sql).not.toMatch(/ON evidence_access TYPE record</);
+  });
+
+  it('deliberately defines NO changefeed and NO event', () => {
+    // The row names a hashed principal + a subject handle; a 30-day feed
+    // would keep a GDPR-erased access trail readable after the rows die
+    // (0122 reasoning). The header EXPLAINS the absence in prose, so
+    // judge only non-comment lines.
+    const code = sql
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('--'))
+      .join('\n');
+    expect(code).not.toMatch(/CHANGEFEED/);
+    expect(code).not.toMatch(/DEFINE EVENT/);
+  });
+
+  it('both asset-death sites carry the evidence_access erase leg', () => {
+    // The trail dies with its asset in BOTH places assets die: the GDPR
+    // user-forget cascade and the retention/quarantine tombstone path
+    // (purgeAssetDependents). Both legs must be the two-step
+    // SELECT-ids → DELETE-ids idiom over the STRING assetId column.
+    const forget = readFileSync(
+      join(__dirname, '..', 'src', 'entities', 'user-forget.service.ts'),
+      'utf8',
+    );
+    expect(forget).toContain(
+      'LET $accessIds = (SELECT VALUE id FROM evidence_access WHERE assetId INSIDE $strs)',
+    );
+    expect(forget).toContain('DELETE $accessIds RETURN BEFORE');
+    const store = readFileSync(
+      join(__dirname, '..', 'src', 'evidence', 'evidence-store.service.ts'),
+      'utf8',
+    );
+    expect(store).toContain('SELECT VALUE id FROM evidence_access WHERE assetId = $assetStr');
+  });
+});
+
 describe('evidence substrate DELETE-shape guards (0109)', () => {
   // The three tables sit on TWO delete paths; every delete must be the
   // two-step SELECT-ids → DELETE $ids idiom (the 3.2.4 planner no-op
@@ -536,6 +603,7 @@ describe('evidence substrate DELETE-shape guards (0109)', () => {
       expect(text).not.toMatch(/DELETE derived_representation WHERE/);
       expect(text).not.toMatch(/DELETE evidence_asset WHERE/);
       expect(text).not.toMatch(/DELETE evidence_grant WHERE/);
+      expect(text).not.toMatch(/DELETE evidence_access WHERE/);
     }
   });
 

--- a/test/evidence-raw-gateway.e2e-spec.ts
+++ b/test/evidence-raw-gateway.e2e-spec.ts
@@ -1,0 +1,465 @@
+/**
+ * Raw-read gateway e2e (MM-3, migration 0125) against a real SurrealDB:
+ * flag-off byte-identical 404 pin, the full gate ladder (tenant fence,
+ * live grants incl. user-bound keys + shared-file semantics, modality
+ * consent flip, media-PII polarity incl. brain:read_media, quarantine),
+ * the fragment twins (whole parent bytes, strictest piiClasses union),
+ * signed-URL mint/redeem (expiry, tamper, revocation backstop, no
+ * consent re-run), and the content-free evidence_access audit trail
+ * dying with its asset in the GDPR user-forget cascade.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { EvidenceStoreService } from '../src/evidence/evidence-store.service';
+import { FsEvidenceStorageAdapter } from '../src/evidence/storage/fs-storage.adapter';
+import { mintEvidenceToken } from '../src/evidence/raw-url-token';
+
+const COMPANY = 'co_evidence_raw_e2e';
+const OTHER_COMPANY = 'co_evidence_raw_other';
+const SECRET = 'raw-gateway-e2e-secret-0123456789abcdef';
+const sha256 = (b: Buffer) => createHash('sha256').update(b).digest('hex');
+
+const PREDICATE = {
+  localId: 'raw_note',
+  displayLabel: 'raw note',
+  description: 'TYPE subject is a person; value is a note about raw serving',
+  datatype: 'string',
+  semantics: 'append_only',
+  decayHalfLifeDays: null,
+  piiClass: 'none',
+  status: 'active',
+};
+
+/** A pack that declares the raw-evidence capability (gateRawEvidence
+ *  clause (a)) — installed with acceptModalities for current consent. */
+const RAW_PACK = {
+  id: 'raw_gateway_pack',
+  version: '1.0.0',
+  description: 'Raw-read gateway e2e pack.',
+  predicates: [PREDICATE],
+  memoryModel: {
+    modalities: ['image'],
+    rawEvidence: { serve: true },
+  },
+};
+
+describe('evidence raw-read gateway (e2e)', () => {
+  let f: AppFixture;
+  let store: EvidenceStoreService;
+  let adapter: FsEvidenceStorageAdapter;
+  let surreal: SurrealService;
+  let fsRoot: string;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const mediaAuth = () => ({ Authorization: `Bearer ${f.extraApiKeys[0]!}` });
+  const u1Auth = () => ({ Authorization: `Bearer ${f.extraApiKeys[1]!}` });
+  const u2Auth = () => ({ Authorization: `Bearer ${f.extraApiKeys[2]!}` });
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    fsRoot = await mkdtemp(join(tmpdir(), 'evidence-raw-e2e-'));
+    for (const k of [
+      'EVIDENCE_SUBSTRATE_ENABLED',
+      'EVIDENCE_RAW_READ_ENABLED',
+      'EVIDENCE_SIGNED_URL_SECRET',
+      'EVIDENCE_SIGNED_URL_TTL_SECONDS',
+      'EVIDENCE_FS_ROOT',
+    ]) {
+      saved[k] = process.env[k];
+    }
+    process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    process.env.EVIDENCE_FS_ROOT = fsRoot;
+    process.env.EVIDENCE_SIGNED_URL_SECRET = SECRET;
+    // The flag stays OFF until the 404 pin below runs (runtime-mutable).
+    delete process.env.EVIDENCE_RAW_READ_ENABLED;
+    delete process.env.EVIDENCE_SIGNED_URL_TTL_SECONDS;
+    f = await createApp({
+      companyId: COMPANY,
+      extraKeys: [
+        { scopes: ['brain:read', 'brain:read_media'] },
+        { scopes: ['brain:read'], userId: 'raw_u1' },
+        { scopes: ['brain:read'], userId: 'raw_u2' },
+      ],
+    });
+    store = f.app.get(EvidenceStoreService);
+    adapter = f.app.get(FsEvidenceStorageAdapter);
+    surreal = f.app.get(SurrealService);
+    const install = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: RAW_PACK, acceptModalities: true });
+    expect([200, 201]).toContain(install.status);
+  });
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await rm(fsRoot, { recursive: true, force: true });
+    if (f) await f.close();
+  });
+
+  const query = async <T>(sql: string, params?: Record<string, unknown>): Promise<T> =>
+    surreal.withCompany(COMPANY, async (db) => {
+      const [rows] = await db.query<[T]>(sql, params);
+      return rows;
+    });
+
+  const registerFsAsset = async (
+    data: Buffer,
+    extra: Partial<Parameters<EvidenceStoreService['registerAsset']>[1]> = {},
+    company = COMPANY,
+  ) => {
+    const byteHash = sha256(data);
+    const { storageRef } = await adapter.put(company, byteHash, data);
+    return store.registerAsset(company, {
+      modality: 'image',
+      mediaType: 'image/jpeg',
+      byteHash,
+      byteLength: data.byteLength,
+      occurredAt: new Date('2026-03-01T10:00:00.000Z'),
+      storageRef,
+      vertical: 'proj',
+      piiClasses: [],
+      ...extra,
+    });
+  };
+
+  const outcomesFor = (assetId: string) =>
+    query<Array<{ verb: string; outcome: string; keyHash: string }>>(
+      `SELECT verb, outcome, keyHash FROM evidence_access WHERE assetId = $a`,
+      { a: assetId },
+    );
+
+  it('flag off: every route answers a bare 404 (byte-identical pin)', async () => {
+    const created = await registerFsAsset(randomBytes(64), { userId: 'raw_off_u' });
+    for (const path of [
+      `/v1/evidence/${created.assetId}/raw`,
+      `/v1/evidence/${created.assetId}/raw-url`,
+      '/v1/evidence/fragments/evidence_fragment:none/raw',
+      '/v1/evidence/fragments/evidence_fragment:none/raw-url',
+      '/v1/evidence/redeem/sometoken',
+    ]) {
+      const res = await f.http.get(path).set(auth());
+      expect(res.status).toBe(404);
+    }
+    // Off = not even an audit row (the controller 404s before the seam).
+    expect(await outcomesFor(created.assetId)).toHaveLength(0);
+  });
+
+  it('flag on: a clean granted asset streams its bytes with the defensive headers', async () => {
+    process.env.EVIDENCE_RAW_READ_ENABLED = '1'; // stays on from here
+    const data = randomBytes(2048);
+    const created = await registerFsAsset(data, { userId: 'raw_stream_u' });
+    const res = await f.http.get(`/v1/evidence/${created.assetId}/raw`).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('image/jpeg');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.headers['content-disposition']).toBe('attachment');
+    expect(Buffer.from(res.body as Buffer).equals(data)).toBe(true);
+    const rows = await outcomesFor(created.assetId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ verb: 'stream', outcome: 'ok' });
+    expect(rows[0]!.keyHash).toMatch(/^sha256:/);
+  });
+
+  it('unauthenticated and unscoped callers never reach the ladder', async () => {
+    const created = await registerFsAsset(randomBytes(70), { userId: 'raw_auth_u' });
+    expect((await f.http.get(`/v1/evidence/${created.assetId}/raw`)).status).toBe(401);
+    expect(await outcomesFor(created.assetId)).toHaveLength(0);
+  });
+
+  it('cross-tenant asset ids answer the same bare 404 (tenant fence)', async () => {
+    const other = await registerFsAsset(randomBytes(96), { userId: 'other_u' }, OTHER_COMPANY);
+    const res = await f.http.get(`/v1/evidence/${other.assetId}/raw`).set(auth());
+    expect(res.status).toBe(404);
+    // The denial is audited in the CALLER's tenant under the probed handle.
+    const rows = await outcomesFor(other.assetId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ verb: 'stream', outcome: 'denied_tenant' });
+  });
+
+  it('no live grant = 404 (revocation kills first-party reads too)', async () => {
+    const created = await registerFsAsset(randomBytes(80), { userId: 'raw_grant_u' });
+    const grants = await store.liveGrants(COMPANY, created.assetId);
+    expect(grants).toHaveLength(1);
+    await store.revokeGrant(COMPANY, grants[0]!.grantId);
+    const denied = await f.http.get(`/v1/evidence/${created.assetId}/raw`).set(auth());
+    expect(denied.status).toBe(404);
+    await store.addGrant(COMPANY, {
+      assetId: created.assetId,
+      ownerKind: 'user',
+      ownerId: 'raw_grant_u',
+    });
+    const ok = await f.http.get(`/v1/evidence/${created.assetId}/raw`).set(auth());
+    expect(ok.status).toBe(200);
+    const outcomes = (await outcomesFor(created.assetId)).map((r) => r.outcome);
+    expect(outcomes).toEqual(expect.arrayContaining(['denied_grant', 'ok']));
+  });
+
+  it('user-bound keys read only their user’s slice; shared-file semantics hold', async () => {
+    const data = randomBytes(512);
+    const created = await registerFsAsset(data, { userId: 'raw_u1' });
+    const path = `/v1/evidence/${created.assetId}/raw`;
+    expect((await f.http.get(path).set(u1Auth())).status).toBe(200);
+    expect((await f.http.get(path).set(u2Auth())).status).toBe(404);
+    await store.addGrant(COMPANY, {
+      assetId: created.assetId,
+      ownerKind: 'user',
+      ownerId: 'raw_u2',
+      purpose: 'share',
+    });
+    expect((await f.http.get(path).set(u2Auth())).status).toBe(200);
+    // Forget the FIRST owner: content survives for the other (0122
+    // exclusive-document semantics on bytes), and so does its trail.
+    const forget = await f.http.post('/v1/users/raw_u1/forget').set(auth()).send({});
+    expect([200, 201]).toContain(forget.status);
+    expect((await f.http.get(path).set(u2Auth())).status).toBe(200);
+    expect((await f.http.get(path).set(u1Auth())).status).toBe(404);
+    expect((await outcomesFor(created.assetId)).length).toBeGreaterThan(0);
+    // Forget the LAST owner: asset dies AND the audit trail dies with it.
+    const last = await f.http.post('/v1/users/raw_u2/forget').set(auth()).send({});
+    expect([200, 201]).toContain(last.status);
+    expect(await store.getAsset(COMPANY, created.assetId)).toBeNull();
+    expect(await outcomesFor(created.assetId)).toHaveLength(0);
+  });
+
+  it('consent flip revokes serving; restore re-opens it', async () => {
+    const created = await registerFsAsset(randomBytes(90), { userId: 'raw_consent_u' });
+    const path = `/v1/evidence/${created.assetId}/raw`;
+    expect((await f.http.get(path).set(auth())).status).toBe(200);
+    const packRows = await query<Array<{ id: unknown; acceptedModalitiesChecksum: string }>>(
+      `SELECT id, acceptedModalitiesChecksum FROM domain_pack WHERE packId = $p`,
+      { p: RAW_PACK.id },
+    );
+    expect(packRows.length).toBeGreaterThan(0);
+    await query(`UPDATE $ids SET acceptedModalitiesChecksum = 'stale'`, {
+      ids: packRows.map((r) => r.id),
+    });
+    try {
+      const denied = await f.http.get(path).set(auth());
+      expect(denied.status).toBe(404);
+    } finally {
+      await query(`UPDATE $ids SET acceptedModalitiesChecksum = $c`, {
+        ids: packRows.map((r) => r.id),
+        c: packRows[0]!.acceptedModalitiesChecksum,
+      });
+    }
+    expect((await f.http.get(path).set(auth())).status).toBe(200);
+    const outcomes = (await outcomesFor(created.assetId)).map((r) => r.outcome);
+    expect(outcomes).toEqual(expect.arrayContaining(['ok', 'denied_consent']));
+  });
+
+  it('media-PII polarity: NONE blocked, [] open, non-empty needs brain:read_media', async () => {
+    const unclassified = await registerFsAsset(randomBytes(64), {
+      userId: 'raw_pii_u',
+      piiClasses: undefined,
+    });
+    const classified = await registerFsAsset(randomBytes(65), {
+      userId: 'raw_pii_u',
+      piiClasses: ['face'],
+    });
+    expect((await f.http.get(`/v1/evidence/${unclassified.assetId}/raw`).set(auth())).status).toBe(
+      404,
+    );
+    expect((await f.http.get(`/v1/evidence/${classified.assetId}/raw`).set(auth())).status).toBe(
+      404,
+    );
+    // brain:read_media (env-key-only scope) opens every state.
+    expect(
+      (await f.http.get(`/v1/evidence/${unclassified.assetId}/raw`).set(mediaAuth())).status,
+    ).toBe(200);
+    expect(
+      (await f.http.get(`/v1/evidence/${classified.assetId}/raw`).set(mediaAuth())).status,
+    ).toBe(200);
+    const outcomes = (await outcomesFor(classified.assetId)).map((r) => r.outcome);
+    expect(outcomes).toEqual(expect.arrayContaining(['denied_pii', 'ok']));
+  });
+
+  it('quarantined and non-hot assets are blocked', async () => {
+    const created = await registerFsAsset(randomBytes(72), { userId: 'raw_quar_u' });
+    const path = `/v1/evidence/${created.assetId}/raw`;
+    const tail = created.assetId.slice(created.assetId.indexOf(':') + 1);
+    await query(
+      `UPDATE type::record('evidence_asset', $tail) SET quarantineStatus = 'quarantined'`,
+      {
+        tail,
+      },
+    );
+    expect((await f.http.get(path).set(auth())).status).toBe(404);
+    await query(`UPDATE type::record('evidence_asset', $tail) SET quarantineStatus = 'clean'`, {
+      tail,
+    });
+    expect((await f.http.get(path).set(auth())).status).toBe(200);
+    // originUri-only registration is availability='external' — never hot.
+    const external = await store.registerAsset(COMPANY, {
+      modality: 'image',
+      mediaType: 'image/png',
+      byteHash: sha256(randomBytes(32)),
+      byteLength: 32,
+      occurredAt: new Date('2026-03-01T10:00:00.000Z'),
+      originUri: 'https://example.com/ext.png',
+      userId: 'raw_quar_u',
+      vertical: 'proj',
+      piiClasses: [],
+    });
+    expect((await f.http.get(`/v1/evidence/${external.assetId}/raw`).set(auth())).status).toBe(404);
+    const outcomes = (await outcomesFor(created.assetId)).map((r) => r.outcome);
+    expect(outcomes).toEqual(expect.arrayContaining(['denied_availability', 'ok']));
+  });
+
+  it('fragment twins serve parent bytes under the STRICTEST piiClasses union', async () => {
+    const data = randomBytes(1024);
+    const created = await registerFsAsset(data, { userId: 'raw_frag_u' });
+    const clean = await store.addFragment(COMPANY, {
+      assetId: created.assetId,
+      locator: { kind: 'pageRegion', page: 0, x: 0.1, y: 0.1, w: 0.4, h: 0.4 },
+      piiClasses: [],
+    });
+    const res = await f.http.get(`/v1/evidence/fragments/${clean.fragmentId}/raw`).set(auth());
+    expect(res.status).toBe(200);
+    expect(Buffer.from(res.body as Buffer).equals(data)).toBe(true);
+    // Fragment classified 'face' + clean asset → union non-empty → scope-gated.
+    const faced = await store.addFragment(COMPANY, {
+      assetId: created.assetId,
+      locator: { kind: 'pageRegion', page: 0, x: 0.5, y: 0.5, w: 0.2, h: 0.2 },
+      piiClasses: ['face'],
+    });
+    expect(
+      (await f.http.get(`/v1/evidence/fragments/${faced.fragmentId}/raw`).set(auth())).status,
+    ).toBe(404);
+    expect(
+      (await f.http.get(`/v1/evidence/fragments/${faced.fragmentId}/raw`).set(mediaAuth())).status,
+    ).toBe(200);
+    // Clean fragment on an UNCLASSIFIED asset → union unclassified → blocked.
+    const unclassifiedAsset = await registerFsAsset(randomBytes(60), {
+      userId: 'raw_frag_u',
+      piiClasses: undefined,
+    });
+    const onUnclassified = await store.addFragment(COMPANY, {
+      assetId: unclassifiedAsset.assetId,
+      locator: { kind: 'pageRegion', page: 0, x: 0, y: 0, w: 1, h: 1 },
+      piiClasses: [],
+    });
+    expect(
+      (await f.http.get(`/v1/evidence/fragments/${onUnclassified.fragmentId}/raw`).set(auth()))
+        .status,
+    ).toBe(404);
+    // Unknown fragment: the same bare 404.
+    expect(
+      (await f.http.get('/v1/evidence/fragments/evidence_fragment:missing/raw').set(auth())).status,
+    ).toBe(404);
+  });
+
+  it('mint → redeem serves the bytes WITHOUT auth; the audit trail carries all three verbs', async () => {
+    const data = randomBytes(256);
+    const created = await registerFsAsset(data, { userId: 'raw_mint_u' });
+    const mint = await f.http.get(`/v1/evidence/${created.assetId}/raw-url`).set(auth());
+    expect(mint.status).toBe(200);
+    const { token, url, expiresAt } = mint.body as {
+      token: string;
+      url: string;
+      expiresAt: string;
+    };
+    expect(url).toBe(`/v1/evidence/redeem/${token}`);
+    expect(Date.parse(expiresAt)).toBeGreaterThan(Date.now());
+    const redeem = await f.http.get(url); // NO auth header, deliberately
+    expect(redeem.status).toBe(200);
+    expect(Buffer.from(redeem.body as Buffer).equals(data)).toBe(true);
+    expect(redeem.headers['cache-control']).toBe('no-store');
+    const rows = await outcomesFor(created.assetId);
+    expect(rows.map((r) => `${r.verb}:${r.outcome}`)).toEqual(
+      expect.arrayContaining(['mint:ok', 'redeem:ok']),
+    );
+  });
+
+  it('expired, tampered and cross-tenant tokens all answer the same bare 404', async () => {
+    const created = await registerFsAsset(randomBytes(128), { userId: 'raw_tok_u' });
+    const expired = mintEvidenceToken(
+      {
+        v: 1,
+        t: COMPANY,
+        a: created.assetId,
+        k: 'sha256:expired-mint',
+        exp: Math.floor(Date.now() / 1000) - 5,
+      },
+      SECRET,
+    );
+    expect((await f.http.get(`/v1/evidence/redeem/${expired}`)).status).toBe(404);
+    const rows = await outcomesFor(created.assetId);
+    expect(rows.map((r) => r.outcome)).toEqual(expect.arrayContaining(['denied_expired']));
+    // Tampered signature: log-only denial — nothing lands in the audit.
+    const good = mintEvidenceToken(
+      {
+        v: 1,
+        t: COMPANY,
+        a: created.assetId,
+        k: 'sha256:tamper-mint',
+        exp: Math.floor(Date.now() / 1000) + 60,
+      },
+      SECRET,
+    );
+    const tampered = `${good.split('.')[0]}.${'0'.repeat(64)}`;
+    expect((await f.http.get(`/v1/evidence/redeem/${tampered}`)).status).toBe(404);
+    // A token structurally pinned to ANOTHER tenant finds nothing there.
+    const foreign = mintEvidenceToken(
+      {
+        v: 1,
+        t: OTHER_COMPANY,
+        a: created.assetId,
+        k: 'sha256:foreign-mint',
+        exp: Math.floor(Date.now() / 1000) + 60,
+      },
+      SECRET,
+    );
+    expect((await f.http.get(`/v1/evidence/redeem/${foreign}`)).status).toBe(404);
+  });
+
+  it('redeem re-checks grants (revocation backstop) but NOT consent', async () => {
+    const created = await registerFsAsset(randomBytes(140), { userId: 'raw_backstop_u' });
+    const mint = await f.http.get(`/v1/evidence/${created.assetId}/raw-url`).set(auth());
+    expect(mint.status).toBe(200);
+    const url = (mint.body as { url: string }).url;
+    // Consent flip mid-TTL: redeem deliberately does NOT re-run consent —
+    // the token is the capability; expiry + grants are the levers.
+    const packRows = await query<Array<{ id: unknown; acceptedModalitiesChecksum: string }>>(
+      `SELECT id, acceptedModalitiesChecksum FROM domain_pack WHERE packId = $p`,
+      { p: RAW_PACK.id },
+    );
+    await query(`UPDATE $ids SET acceptedModalitiesChecksum = 'stale'`, {
+      ids: packRows.map((r) => r.id),
+    });
+    try {
+      expect((await f.http.get(url)).status).toBe(200);
+    } finally {
+      await query(`UPDATE $ids SET acceptedModalitiesChecksum = $c`, {
+        ids: packRows.map((r) => r.id),
+        c: packRows[0]!.acceptedModalitiesChecksum,
+      });
+    }
+    // Revoking the last live grant kills the still-fresh token.
+    const grants = await store.liveGrants(COMPANY, created.assetId);
+    for (const g of grants) await store.revokeGrant(COMPANY, g.grantId);
+    expect((await f.http.get(url)).status).toBe(404);
+    const rows = await outcomesFor(created.assetId);
+    expect(rows.map((r) => r.outcome)).toEqual(expect.arrayContaining(['denied_revoked']));
+  });
+
+  it('mint refuses 503 without the secret; redeem stays a bare 404', async () => {
+    const created = await registerFsAsset(randomBytes(88), { userId: 'raw_nosecret_u' });
+    delete process.env.EVIDENCE_SIGNED_URL_SECRET;
+    try {
+      const mint = await f.http.get(`/v1/evidence/${created.assetId}/raw-url`).set(auth());
+      expect(mint.status).toBe(503);
+      expect((await f.http.get('/v1/evidence/redeem/whatever.sig')).status).toBe(404);
+    } finally {
+      process.env.EVIDENCE_SIGNED_URL_SECRET = SECRET;
+    }
+  });
+});

--- a/test/evidence-raw-token.unit-spec.ts
+++ b/test/evidence-raw-token.unit-spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure helpers of the raw-read gateway (MM-3): the signed-URL token
+ * (mint/verify round-trip, forgery/expiry/shape rejection) and the
+ * strictest fragment+asset piiClasses union. The full ladder is covered
+ * by test/evidence-raw-gateway.e2e-spec.ts against a real SurrealDB.
+ */
+import {
+  EvidenceTokenPayload,
+  mintEvidenceToken,
+  verifyEvidenceToken,
+} from '../src/evidence/raw-url-token';
+import { strictestPiiUnion } from '../src/common/media-pii';
+
+const SECRET = 's'.repeat(32);
+const NOW = 1_760_000_000_000; // arbitrary fixed instant (ms)
+
+const payload = (over: Partial<EvidenceTokenPayload> = {}): EvidenceTokenPayload => ({
+  v: 1,
+  t: 'co_token_unit',
+  a: 'evidence_asset:abc123',
+  k: 'sha256:deadbeef',
+  exp: Math.floor(NOW / 1000) + 300,
+  ...over,
+});
+
+describe('evidence signed-URL token', () => {
+  it('round-trips: mint → verify yields the exact payload', () => {
+    const p = payload({ f: 'evidence_fragment:frag1' });
+    const token = mintEvidenceToken(p, SECRET);
+    // URL-path-safe by construction: base64url + '.' + lowercase hex.
+    expect(token).toMatch(/^[A-Za-z0-9_-]+\.[0-9a-f]{64}$/);
+    const v = verifyEvidenceToken(token, SECRET, NOW);
+    expect(v).toEqual({ state: 'valid', payload: p });
+  });
+
+  it('rejects a tampered payload as invalid (signature, not expiry)', () => {
+    const token = mintEvidenceToken(payload(), SECRET);
+    const [body, sig] = token.split('.') as [string, string];
+    const other = JSON.parse(Buffer.from(body, 'base64url').toString('utf8')) as Record<
+      string,
+      unknown
+    >;
+    other.t = 'co_other_tenant'; // retarget the tenant, keep the old sig
+    const forged = `${Buffer.from(JSON.stringify(other)).toString('base64url')}.${sig}`;
+    expect(verifyEvidenceToken(forged, SECRET, NOW)).toEqual({ state: 'invalid' });
+  });
+
+  it('rejects a token minted under a different secret', () => {
+    const token = mintEvidenceToken(payload(), 'x'.repeat(32));
+    expect(verifyEvidenceToken(token, SECRET, NOW)).toEqual({ state: 'invalid' });
+  });
+
+  it.each([
+    ['no dot', 'nodothere'],
+    ['empty body', '.abc'],
+    ['empty sig', 'abc.'],
+    ['two dots', 'a.b.c'],
+    ['non-json body', `${Buffer.from('not json').toString('base64url')}.x`],
+  ])('malformed token (%s) is invalid, never a throw', (_name, raw) => {
+    expect(verifyEvidenceToken(raw, SECRET, NOW)).toEqual({ state: 'invalid' });
+  });
+
+  it('wrong payload shape is invalid even with a VALID signature', () => {
+    // Signature checks out but v/exp/t are wrong — shape must still deny.
+    const bad = { v: 2, t: 't', a: 'a', k: 'k', exp: 1 } as unknown as EvidenceTokenPayload;
+    const token = mintEvidenceToken(bad, SECRET);
+    expect(verifyEvidenceToken(token, SECRET, NOW)).toEqual({ state: 'invalid' });
+  });
+
+  it('an expired token verifies its signature and reports expired WITH the payload', () => {
+    // The redeem route needs the trusted payload to write the
+    // denied_expired audit row into the right tenant.
+    const p = payload({ exp: Math.floor(NOW / 1000) - 1 });
+    const v = verifyEvidenceToken(mintEvidenceToken(p, SECRET), SECRET, NOW);
+    expect(v).toEqual({ state: 'expired', payload: p });
+  });
+
+  it('exp is compared in seconds against a ms clock (boundary exact)', () => {
+    const exp = Math.floor(NOW / 1000);
+    const token = mintEvidenceToken(payload({ exp }), SECRET);
+    expect(verifyEvidenceToken(token, SECRET, exp * 1000).state).toBe('expired');
+    expect(verifyEvidenceToken(token, SECRET, exp * 1000 - 1).state).toBe('valid');
+  });
+});
+
+describe('strictestPiiUnion (fragment + parent asset)', () => {
+  it('unclassified on EITHER side wins (undefined out — blocked)', () => {
+    expect(strictestPiiUnion(undefined, [])).toBeUndefined();
+    expect(strictestPiiUnion([], null)).toBeUndefined();
+    expect(strictestPiiUnion(null, undefined)).toBeUndefined();
+    expect(strictestPiiUnion(['face'], undefined)).toBeUndefined();
+  });
+
+  it('both affirmatively clean stays clean ([])', () => {
+    expect(strictestPiiUnion([], [])).toEqual([]);
+  });
+
+  it('classified classes union across both sides, deduped', () => {
+    expect(strictestPiiUnion(['face'], [])).toEqual(['face']);
+    expect(strictestPiiUnion([], ['voice'])).toEqual(['voice']);
+    expect(strictestPiiUnion(['face', 'voice'], ['voice', 'id_document'])).toEqual([
+      'face',
+      'voice',
+      'id_document',
+    ]);
+  });
+});

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -60,6 +60,13 @@ const PLATFORM_OPERATIONS: Array<[string, string]> = [
   ['/v1/episodes/subscriptions/{id}', 'delete'],
   ['/v1/projections', 'get'],
   ['/v1/projections/{name}/rebuild', 'post'],
+  // Raw-evidence read gateway (MM-3, EVIDENCE_RAW_READ_ENABLED — 404
+  // until on; redeem is unauthenticated by design, token-gated).
+  ['/v1/evidence/{assetId}/raw', 'get'],
+  ['/v1/evidence/{assetId}/raw-url', 'get'],
+  ['/v1/evidence/fragments/{fragmentId}/raw', 'get'],
+  ['/v1/evidence/fragments/{fragmentId}/raw-url', 'get'],
+  ['/v1/evidence/redeem/{token}', 'get'],
 ];
 
 describe('docs/openapi.json', () => {
@@ -119,7 +126,12 @@ describe('docs/openapi.json', () => {
 
   it('every operation states its required scope and is bearer-secured', () => {
     expect(built.security).toEqual([{ bearerAuth: [] }]);
+    // The ONE deliberately unauthenticated operation: signed-URL redeem
+    // (the token IS the capability — see evidence-read.controller.ts).
+    // Everything else must state its bearer scope.
+    const unauthenticated = new Set(['get /v1/evidence/redeem/{token}']);
     for (const [path, method] of PLATFORM_OPERATIONS) {
+      if (unauthenticated.has(`${method} ${path}`)) continue;
       const op = ((built.paths as Json)[path] as Json)[method] as Json;
       expect(op.description).toMatch(/Required scope: `[a-z_]+:[a-z_]+`/);
     }


### PR DESCRIPTION
## What

Brain v2.1 **MM-3**: the ONE surface that turns stored evidence rows back into original bytes. Default-off behind `EVIDENCE_RAW_READ_ENABLED` — every route answers a bare 404 while off (the `/v1/episodes` 404-until-flag precedent), byte-identical prod.

### Routes (`src/evidence/evidence-read.controller.ts` — transport only; the DB half lives in `EvidenceReadService` per layer purity)

| Route | Behavior |
|---|---|
| `GET /v1/evidence/:assetId/raw` | stream the blob |
| `GET /v1/evidence/:assetId/raw-url` | mint a signed URL |
| `GET /v1/evidence/fragments/:fragmentId/raw` (+`-url`) | fragment twins — v1 serves **whole parent-asset bytes** under the **strictest union** of fragment+asset `piiClasses` (`strictestPiiUnion`, `src/common/media-pii.ts`) |
| `GET /v1/evidence/redeem/:token` | unauthenticated redeem |

### Gate ladder (deny-overrides, first failure wins, each controller-observable step recorded)

1. `ApiKeyGuard` + `brain:read` scope *(guard)*
2. tenant fence — `withCompany` + `availability='hot'` + `quarantineStatus` clean-or-absent (0121)
3. grants (0122) — ≥1 live grant; a **user-bound** key additionally needs the end user's own live grant (0055 pin applied to bytes)
4. ABAC — new action `rest.evidence.raw` *(runs inside the guard — see deviations)*
5. modality consent — **`gateRawEvidence`'s first production call site**, folded over a **direct fail-closed `domain_pack` read** (never the fail-open `MemoryModelReaderService` cache); probed with `piiClasses: []` so only capability+consent decide
6. media PII — the same gate re-run with the real classes (`NONE` blocked, `[]` open, non-empty needs `brain:read_media`) — two calls, zero duplicated logic, distinguishable audit outcomes
7. blob head via the storage adapter → stream (`nosniff`, `no-store`, `attachment`) or mint

Every controller-side denial is the same bare 404 — **no existence oracle**; outcomes differ only inside the audit row.

### Signed URLs

`base64url(JSON{v,t,a,f?,k,exp}) + '.' + HMAC-SHA256-hex` over the payload. Secret `EVIDENCE_SIGNED_URL_SECRET` — boot **error** when configured <32 chars while the flag is on; boot **warn** when the flag is on without it (streaming works; mint 503s, redeem 404s). TTL `EVIDENCE_SIGNED_URL_TTL_SECONDS` (default 300). Redeem re-runs **no** auth/ABAC/consent/PII — fail-closed re-checks only: signature (timing-safe, before any DB touch), expiry, structural tenant pin (`withCompany(payload.t)`), availability still hot, ≥1 live grant (revocation backstop). Bad/expired/revoked → uniform 404, distinguished only in the audit row.

### Audit — `evidence_access`, migration **0125**

Content-free: asset/fragment handles as **strings** (rows must not dangle), `keyHash`, verb (`stream|mint|redeem`), outcome (`ok|denied_<step>`), `createdAt`. Single-field indexes only; no changefeed/event (0122 reasoning). The `ok` row is written **before** bytes leave and is not best-effort — no unaccounted byte ever leaves; denial rows are best-effort. The trail is erased with its asset in **both** asset-death sites — the GDPR user-forget cascade and `purgeAssetDependents` (retention/quarantine/reconciliation) — via LET/SELECT-ids→DELETE, pinned by audit-p1-guards tuples + the DELETE-WHERE negative.

### Scope notes

- **No MCP tool in this PR** — REST-first; MCP exposure comes after dogfood.
- OpenAPI: five paths documented (404-until-flag precedent), `pnpm openapi:build`, both committed copies (`docs/openapi.json`, `brain-landing/public/openapi.json`).
- Flags/envs live in `src/common/evidence-flags.ts` (engine-gates S5.2, runtime-mutable call-time reads) + config-catalog + `KNOWN_BOOLEAN_FLAGS` + boot rules.

## Deviations from the design brief

1. **ABAC step order**: the ladder spec places ABAC as step 4 (after tenant/grant), but ABAC is enforced inside `ApiKeyGuard` for every route (platform architecture) — so it runs with step 1, before the controller body. Deny-overrides semantics keep the final decision identical; the observable differences are that a policy deny is a 403 (not 404) and lands no audit row. The remaining controller-side order is exactly as specified.
2. **`denied_signature` is log-only** (not an audit row): redeem is unauthenticated, and an unverified payload's tenant cannot be trusted — persisting rows keyed by a forged tenant would let anonymous forgeries write into arbitrary tenant DBs. All post-signature denials (expired/tenant/availability/revoked) are persisted and distinguished.
3. **"Both forget services"**: entity-forget deliberately never cascades evidence (0109 doctrine, documented in-code) — assets die in exactly two services: `UserForgetService.eraseEvidenceRows` and `EvidenceStoreService.purgeAssetDependents`. The `evidence_access` leg was added to both asset-death sites, which keeps the "erased with its asset" contract complete.
4. **One controller + one service** instead of a single controller file: `import/no-restricted-paths` forbids controllers importing `src/db`, so the DB half of the ladder lives in `EvidenceReadService`; pure token helpers in `src/evidence/raw-url-token.ts`.
5. Additive hardening beyond spec: `Content-Disposition: attachment` on streams (an API origin must never render evidence bytes as a document).

## Verification

- `pnpm typecheck` — clean
- `pnpm lint:ci` — clean (`--max-warnings 0`)
- Unit: **334 suites / 3521 tests** green (incl. new `evidence-raw-token.unit-spec`, 0125 guard tuples + DELETE-WHERE negatives in `audit-p1-guards`, openapi drift gate)
- Targeted e2e on real SurrealDB v3.2.4 (testcontainers): **`evidence-raw-gateway` (12) + `evidence-grant` + `evidence-processing` = 28 tests** green — off→404 pin, cross-tenant 404, no-grant 404, consent flip revokes (and restore re-opens), PII polarity incl. `brain:read_media`, quarantined + non-hot blocked, fragment strictest-union, mint/redeem incl. expired/tampered/foreign-tenant/revoked tokens, no consent re-run at redeem, shared-file semantics + audit trail dying with its asset
- `prettier` — applied
- Rebased onto `origin/main` after #391 (0119) merged; **migration stays 0125** (0123 remains claimed by open #407)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB