### PR TITLE
feat(fovea): verifier-controlled fragment zoom — one bounded re-verify step

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
       "ip-address": "^10.3.1",
       "@opentelemetry/core": "^2.8.0",
       "@opentelemetry/propagator-jaeger": "^2.9.0",
-      "fast-uri": "^3.1.5",
+      "fast-uri": "^3.1.6",
       "body-parser": "^2.3.0",
       "form-data": "^4.0.6",
       "tmp": "^0.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   ip-address: ^10.3.1
   '@opentelemetry/core': ^2.8.0
   '@opentelemetry/propagator-jaeger': ^2.9.0
-  fast-uri: ^3.1.5
+  fast-uri: ^3.1.6
   body-parser: ^2.3.0
   form-data: ^4.0.6
   tmp: ^0.2.6
@@ -2894,8 +2894,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -7124,14 +7124,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8100,7 +8100,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fb-watchman@2.0.2:
     dependencies:

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1277,6 +1277,29 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       "Evidence plane, fragment citations (MM-zoom PR2): with the fragment lane rendering media evidence (RETRIEVAL_FRAGMENT_LANE), each rendered line carries its [evidence_fragment:...] header and the generator schema gains citedFragmentIds; emitted ids resolve through the rendered-set fence (the FOVEA_L3_EPISODE_CITATIONS idiom: an id not rendered into the prompt is dropped and counted, never surfaced; the citation's excerpt is the RENDERED excerpt, never generator text; dedupe; cap 16) into fragment-arm evidenceCitations carrying assetId + capability. Those citations let the FOVEA_EVIDENCE_CAPABILITY gate PASS for non-text requirements when a matching-modality fragment is cited. Off (default) → no header, no schema field, no resolver — byte-identical even with the lane on.",
   },
   {
+    key: 'FOVEA_FRAGMENT_ZOOM',
+    category: 'pipeline',
+    // Read at call time (fovea-flags fragmentZoomEnabled) on the
+    // synthesize post-verifier seam — never captured in a constructor —
+    // so a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Evidence plane, fragment zoom (MM-zoom PR3): ONE monotone bounded zoom step at the post-verifier seam. On a verifier-fail with a rendered fragment line truncated by the lane's 600-char excerpt cap, fetch the fuller DERIVED TEXT of the same derived_representation rows (cited fragments first, ≤2 fragments, per-fragment chars capped by FOVEA_FRAGMENT_ZOOM_MAX_CHARS) through the lane's own fence stack (tenant → consent → asset-join user fence → media PII → availability), and RE-VERIFY ONLY — the answer is never regenerated. A flipped verdict serves through the normal finalize path (and the L3 ladder then skips on verdict-ok); no flip or any error falls through to the existing downgrade unchanged. Raw bytes stay exclusively behind EVIDENCE_RAW_READ_ENABLED. Runs before/independent of L3, at most once per request. Off (default) → the verifier runs exactly once and no extra read happens — byte-identical.",
+  },
+  {
+    key: 'FOVEA_FRAGMENT_ZOOM_MAX_CHARS',
+    category: 'pipeline',
+    // Read at call time (fovea-flags fragmentZoomMaxChars) per zoom
+    // step; runtime-mutable.
+    defaultValue: '4000',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      "Evidence plane, fragment zoom (MM-zoom PR3): per-fragment ceiling on the fuller derived text one zoom step may hand the re-verifier. A positive integer ≤ 100000; unset/blank/out-of-range → 4000. Values at or below the lane's 600-char excerpt cap make no candidate deeper — the step then skips (safe, just useless). Ignored unless FOVEA_FRAGMENT_ZOOM is on.",
+  },
+  {
     key: 'EVIDENCE_RAW_READ_ENABLED',
     category: 'pipeline',
     defaultValue: '0',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1138,6 +1138,20 @@ const KNOWN_BOOLEAN_FLAGS = [
   // lookup, byte-identical serving. Outside ENGINE_PREFIX by design (the
   // FOVEA_ family sits off the flag budget).
   'FOVEA_EVIDENCE_CAPABILITY',
+  // Fovea serving-integrity: fragment zoom (MM-zoom PR3) — ONE monotone
+  // bounded zoom step at the post-verifier seam: on a verifier-fail with a
+  // rendered fragment line TRUNCATED by the lane's 600-char excerpt cap,
+  // fetch the fuller DERIVED TEXT of the same derived_representation rows
+  // (≤2 fragments, per-fragment chars capped by the int knob
+  // FOVEA_FRAGMENT_ZOOM_MAX_CHARS — not a boolean flag) through the lane's
+  // own fence stack, and RE-VERIFY ONLY (never regenerate). A flipped
+  // verdict serves; anything else (or any error) falls through to the
+  // static downgrade unchanged. Raw bytes stay behind the
+  // EVIDENCE_RAW_READ_ENABLED gateway — zoom cannot reach them. Default
+  // off = verifier runs exactly once, no extra read, byte-identical
+  // serving. Outside ENGINE_PREFIX by design (the FOVEA_ family sits off
+  // the flag budget).
+  'FOVEA_FRAGMENT_ZOOM',
   // Fovea optics: attention-hints anchor boost — on a fired L3 escalation
   // with fact anchors, the installed packs' memoryModel.attentionHints are
   // resolved against the query (case-folded literal cue match) and anchors

--- a/src/common/fovea-flags.ts
+++ b/src/common/fovea-flags.ts
@@ -239,6 +239,64 @@ export function attentionHintsEnabled(): boolean {
 }
 
 /**
+ * Fovea serving-integrity family — fragment-zoom master flag —
+ * FOVEA_FRAGMENT_ZOOM (MM-zoom PR3).
+ *
+ * WHAT IT CHANGES: ONE monotone bounded zoom step at the post-verifier
+ * seam (the adaptive-L3 ladder idiom — single-shot, capped, fail-safe to
+ * static). When the verifier verdict fails (not supported, or
+ * supported-but-not-answering under topic coverage) AND at least one
+ * RENDERED fragment line was TRUNCATED by the lane's 600-char excerpt
+ * cap, the service fetches the FULLER derived TEXT of the same
+ * derived_representation rows — capped per fragment by
+ * FOVEA_FRAGMENT_ZOOM_MAX_CHARS, at most FRAGMENT_ZOOM_MAX_FRAGMENTS
+ * fragments, through the SAME fence stack the lane applied — and
+ * RE-VERIFIES ONLY (never regenerates) against the enriched evidence
+ * document. A flipped verdict serves through the normal finalize path;
+ * anything else falls through to the existing downgrade path unchanged.
+ *
+ * DERIVED TEXT ONLY — NEVER RAW BYTES: zoom widens the auditor's view of
+ * derived_representation.content (captions / OCR / ASR text renders).
+ * Original media bytes stay exclusively behind the raw-read gateway
+ * (EVIDENCE_RAW_READ_ENABLED, EvidenceReadService — gate ladder, grants,
+ * signed URLs, access audit); the zoom step can never reach them.
+ *
+ * SAFETY: one step max, before and independent of L3 escalation; any
+ * error degrades to the static (pre-zoom) behavior. The env read lives
+ * here in the common layer, NOT inside the engine dirs (engine-gates
+ * S5.2). Read at call time so a flip is runtime-mutable. Default off ⇒
+ * the verifier runs exactly once and no extra read happens —
+ * byte-identical serving.
+ */
+export function fragmentZoomEnabled(): boolean {
+  return envFlagEnabled(process.env.FOVEA_FRAGMENT_ZOOM);
+}
+
+/** Default per-fragment char cap on the zoomed derived text. */
+const DEFAULT_FRAGMENT_ZOOM_MAX_CHARS = 4000;
+/** Sanity ceiling on the knob (keeps a fat OCR from blowing the audit
+ *  prompt); values above it fall back to the default. */
+const FRAGMENT_ZOOM_MAX_CHARS_CEILING = 100_000;
+
+/**
+ * MM-zoom PR3 char-cap knob (FOVEA_FRAGMENT_ZOOM_MAX_CHARS): the
+ * per-fragment ceiling on the fuller derived text a zoom step may hand
+ * the re-verifier. A non-boolean knob resolved here in the common layer
+ * so the engine dirs take a resolved number. Must be a positive integer
+ * ≤ 100000; unset, blank, or out of range → the 4000 default. A value
+ * at or below the lane's 600-char excerpt cap makes no candidate
+ * "deeper" and the zoom step skips — safe, just useless.
+ */
+export function fragmentZoomMaxChars(): number {
+  const raw = process.env.FOVEA_FRAGMENT_ZOOM_MAX_CHARS;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_FRAGMENT_ZOOM_MAX_CHARS;
+  const v = Number(raw);
+  return Number.isInteger(v) && v > 0 && v <= FRAGMENT_ZOOM_MAX_CHARS_CEILING
+    ? v
+    : DEFAULT_FRAGMENT_ZOOM_MAX_CHARS;
+}
+
+/**
  * Multilingual Tier 5 master flag — MULTILINGUAL_CALIBRATION.
  *
  * When on, the §4.2 per-class focus calibrator (focus-signal.ts) gains a

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -286,6 +286,23 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // MM-zoom PR3 (FOVEA_FRAGMENT_ZOOM): what the ONE bounded zoom step did
+  // per evaluation —
+  //   flipped   — the re-verify over the fuller derived text passed →
+  //               the answer served
+  //   unchanged — the re-verify still failed → the normal downgrade ran
+  //   skipped   — the step evaluated (flag on, verdict failed) but had
+  //               nothing to zoom (no truncated rendered fragment / no
+  //               deeper text fetched)
+  //   error     — any failure inside the step (degraded to static)
+  // Emitted only when the flag is on (nothing on the path when off).
+  readonly fragmentZoomCount = new Counter({
+    name: 'brain_fragment_zoom_total',
+    help: 'Fragment zoom step outcomes (FOVEA_FRAGMENT_ZOOM)',
+    labelNames: ['outcome'] as const,
+    registers: [this.registry],
+  });
+
   // Optics §4.2 (docs/roadmap/fovea-optics-2026-08.md §4.2): which sub-
   // condition fired the pre-generation memory-coverage ABSTAIN decision —
   //   adaptive — the calibrated-pre-answer-confidence floor
@@ -774,6 +791,10 @@ export class MetricsService implements OnModuleInit {
     if (n > 0) {
       this.fragmentCitationCount.inc({ outcome } as LabelValues<'outcome'>, n);
     }
+  }
+
+  countFragmentZoom(outcome: 'flipped' | 'unchanged' | 'skipped' | 'error'): void {
+    this.fragmentZoomCount.inc({ outcome } as LabelValues<'outcome'>);
   }
 
   countAbstainPath(path: 'adaptive' | 'static'): void {

--- a/src/outcomes/memory-decision.service.ts
+++ b/src/outcomes/memory-decision.service.ts
@@ -12,8 +12,9 @@ import {
 /**
  * MemoryDecisionService — the ONE write seam for memory_decision rows
  * (migration 0119): decision-context telemetry for the serving path's
- * policy decisions (this PR: the abstain gate + the L3 escalation
- * trigger; 'lane_route'/'zoom' reserve the audit's other seams).
+ * policy decisions (the abstain gate, the L3 escalation trigger, and —
+ * MM-zoom PR3 — the fragment-zoom step; 'lane_route' reserves the
+ * audit's remaining seam).
  *
  * Discipline (the ToolObservationService/MemoryOutcomeService idiom):
  *   * master-flag guard INSIDE the service (OUTCOME_DECISION_CAPTURE,
@@ -34,8 +35,9 @@ import {
  * design — see the forget services).
  */
 
-/** The decision seams 0119 reserves. Only the first two get writers in
- *  this PR; the enum reserves the audit's other seams. */
+/** The decision seams 0119 reserves. 'l3_escalation'/'abstain' got their
+ *  writers with 0119, 'zoom' with MM-zoom PR3 (decision-emit.ts
+ *  captureZoomDecision); 'lane_route' still reserves its seam. */
 export type DecisionKind = 'l3_escalation' | 'abstain' | 'lane_route' | 'zoom';
 
 /** Cap on the alternatives array (contract-bounded row size). */

--- a/src/synthesize/decision-emit.ts
+++ b/src/synthesize/decision-emit.ts
@@ -3,6 +3,7 @@ import type { SearchHit } from '../search/search.service';
 import type { LaneId } from './answer-router';
 import type { AbstainAdaptiveGate } from './verdict';
 import type { L3DecisionDraft } from './l3-escalation.service';
+import { FRAGMENT_ZOOM_MAX_FRAGMENTS, type FragmentZoomResult } from './fragment-zoom';
 import {
   buildFocusSignal,
   queryClassOf,
@@ -127,4 +128,37 @@ export function buildL3DecisionCallback(
     });
     if (id !== undefined) decisionCtx.primaryDecisionId ??= id;
   };
+}
+
+/**
+ * The 'zoom' decision writer (FOVEA_FRAGMENT_ZOOM, MM-zoom PR3), called
+ * once per EVALUATED zoom step — flag on and the primary verdict failed
+ * (mirrors the metric: no row when the step never gated). chosenAction
+ * carries the outcome directly ('zoom:flipped' / 'zoom:unchanged' /
+ * 'skip:no_deeper' / 'error'); observedState.candidateCount is the
+ * TRUNCATED-candidate count at this seam (the L3 maxSessions precedent:
+ * candidateCount is the seam's budget-relevant count). Content-free by
+ * the 0119 contract; claims the primary-decision slot when free.
+ */
+export function captureZoomDecision(
+  decisions: MemoryDecisionService | undefined,
+  companyId: string,
+  args: { result: FragmentZoomResult; decisionCtx: DecisionContext },
+): void {
+  if (!decisions || !MemoryDecisionService.enabled()) return;
+  const { result } = args;
+  const chosenAction =
+    result.outcome === 'flipped' || result.outcome === 'unchanged'
+      ? `zoom:${result.outcome}`
+      : result.outcome === 'skipped'
+        ? 'skip:no_deeper'
+        : 'error';
+  const id = decisions.record(companyId, {
+    decisionKind: 'zoom',
+    policyVersion: `static@cap=${FRAGMENT_ZOOM_MAX_FRAGMENTS}`,
+    chosenAction,
+    observedState: { candidateCount: result.candidateCount },
+    costs: { latencyMs: Date.now() - args.decisionCtx.t0 },
+  });
+  if (id !== undefined) args.decisionCtx.primaryDecisionId ??= id;
 }

--- a/src/synthesize/evidence-collector.service.ts
+++ b/src/synthesize/evidence-collector.service.ts
@@ -22,6 +22,7 @@ import { UpdateStoryService } from './update-story.service';
 import { DigestLaneService } from './digest-lane.service';
 import { FragmentLaneService } from './fragment-lane.service';
 import type { CitableFragment } from './fragment-citations';
+import type { ZoomCandidate } from './fragment-zoom';
 import type { CoverageScanTuning } from './scan-leg';
 
 /** Grounding anchors the raw-window lane expands (top evidence order). */
@@ -115,6 +116,13 @@ export interface CollectedEvidence {
    */
   fragmentsById?: ReadonlyMap<string, CitableFragment> | undefined;
   /**
+   * Zoom affordances for EXACTLY the fragments in fragmentLines
+   * (FOVEA_FRAGMENT_ZOOM, MM-zoom PR3) — recorded by the lane at render
+   * time, no IO. Consumed only by the flag-gated zoom step in the
+   * orchestrator; empty when the lane rendered nothing.
+   */
+  fragmentZoom: ZoomCandidate[];
+  /**
    * G4 strategy lane: rendered advisory notes (k≤2, default 1) from
    * the separate strategy_memory store; undefined when the lane is off
    * the profile or read-side serving is disabled.
@@ -154,6 +162,7 @@ export function emptyCollectedEvidence(
     strategyNotes: undefined,
     fragmentLines: [],
     fragmentsById: undefined,
+    fragmentZoom: [],
   };
 }
 
@@ -246,6 +255,7 @@ export class EvidenceCollectorService {
       strategyNotes,
       fragmentLines: fragmentEvidence.lines,
       fragmentsById: fragmentEvidence.byId.size > 0 ? fragmentEvidence.byId : undefined,
+      fragmentZoom: fragmentEvidence.zoom,
     };
   }
 
@@ -269,8 +279,12 @@ export class EvidenceCollectorService {
     callerScopes: string[];
     userId?: string | undefined;
     fragmentCitations?: boolean | undefined;
-  }): Promise<{ lines: string[]; byId: ReadonlyMap<string, CitableFragment> }> {
-    const empty = { lines: [], byId: new Map<string, CitableFragment>() };
+  }): Promise<{
+    lines: string[];
+    byId: ReadonlyMap<string, CitableFragment>;
+    zoom: ZoomCandidate[];
+  }> {
+    const empty = { lines: [], byId: new Map<string, CitableFragment>(), zoom: [] };
     if (!profile.fragmentLane || !this.fragmentLane) return empty;
     if (getAbortSignal()?.aborted) return empty;
     return this.fragmentLane.fragmentLines({

--- a/src/synthesize/fragment-lane.service.ts
+++ b/src/synthesize/fragment-lane.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { mediaPiiGate } from '../common/media-pii';
@@ -6,6 +7,7 @@ import { capabilityForModality } from '../common/evidence-taxonomy';
 import { hasCurrentModalityConsent, type ModalityConsentRow } from '../ai/domain-packs';
 import { rrfFuse } from './segment-lane.service';
 import type { CitableFragment } from './fragment-citations';
+import type { ZoomCandidate } from './fragment-zoom';
 
 /** Fragment lines per prompt (design constant, MM-zoom PR2 —
  *  deliberately NOT an env knob until the lane is measured). */
@@ -37,9 +39,18 @@ export interface FragmentLaneResult {
    * off: no headers rendered, nothing citable).
    */
   byId: Map<string, CitableFragment>;
+  /**
+   * Zoom affordances for EXACTLY the fragments rendered into `lines`
+   * (FOVEA_FRAGMENT_ZOOM, MM-zoom PR3) — which derived_representation
+   * row each line excerpted and whether the 600-char cap truncated it.
+   * Pure bookkeeping over rows already in memory: populated
+   * unconditionally (no IO, no rendered-byte change); consumed only by
+   * the flag-gated zoom step.
+   */
+  zoom: ZoomCandidate[];
 }
 
-const EMPTY_RESULT: FragmentLaneResult = { lines: [], byId: new Map() };
+const EMPTY_RESULT: FragmentLaneResult = { lines: [], byId: new Map(), zoom: [] };
 
 /**
  * Fragment retrieval lane (MM-zoom PR2, profile.fragmentLane /
@@ -97,17 +108,7 @@ export class FragmentLaneService {
     withIds: boolean;
   }): Promise<FragmentLaneResult> {
     const fetchK = Math.max(FRAGMENT_LANE_TOP_K * 3, 12);
-    // Fence 3: the fragment's own piiClasses, through the record link.
-    const piiGate = mediaPiiGate(opts.callerScopes, 'subjectId.piiClasses');
-    // Fence 2: asset-join user fence (single-owner 0055 gate — see class doc).
-    const userFence =
-      opts.userId === undefined
-        ? { clause: 'AND subjectId.assetId.userId IS NONE', params: {} }
-        : {
-            clause:
-              'AND (subjectId.assetId.userId IS NONE OR subjectId.assetId.userId = $scopeUserId)',
-            params: { scopeUserId: opts.userId },
-          };
+    const { piiGate, userFence } = this.rowFences(opts.callerScopes, opts.userId);
     try {
       // Fence 4 (0112): tenant-level consent — absent/stale ⇒ EMPTY.
       const consented = await this.surreal.withCompany(opts.companyId, async (db) => {
@@ -178,7 +179,9 @@ export class FragmentLaneService {
    * with the `[<fragmentId>]` header only under `withIds` (the L3
    * episode-header idiom — flag off renders byte-identical lines with
    * no citable surface). The capability tag leads every line — the
-   * VerifyRequest.capabilityEvidenceLines contract.
+   * VerifyRequest.capabilityEvidenceLines contract. Each kept row also
+   * records its ZoomCandidate (which repr row the excerpt came from +
+   * whether the cap truncated it) — bookkeeping only, no byte change.
    */
   private render(fused: FragmentReprRow[], withIds: boolean): FragmentLaneResult {
     const byFragment = new Map<string, FragmentReprRow>();
@@ -194,16 +197,25 @@ export class FragmentLaneService {
     );
     const lines: string[] = [];
     const byId = new Map<string, CitableFragment>();
+    const zoom: ZoomCandidate[] = [];
     for (const [fragmentId, row] of kept) {
       const modality = String(row.modality ?? 'unknown');
       const capability = capabilityForModality(modality);
-      const excerpt = String(row.content).slice(0, FRAGMENT_EXCERPT_MAX_CHARS);
+      const content = String(row.content);
+      const excerpt = content.slice(0, FRAGMENT_EXCERPT_MAX_CHARS);
       const day = isoDay(row.occurredAt);
-      const base =
+      const linePrefix =
         `[capability:${capability}] ` +
         (withIds ? `[${fragmentId}] ` : '') +
-        `(${modality} ${String(row.kind ?? 'text')}${day ? `, ${day}` : ''}) ${excerpt}`;
-      lines.push(base);
+        `(${modality} ${String(row.kind ?? 'text')}${day ? `, ${day}` : ''}) `;
+      zoom.push({
+        fragmentId,
+        reprId: String(row.id ?? ''),
+        lineIndex: lines.length,
+        linePrefix,
+        truncated: content.length > FRAGMENT_EXCERPT_MAX_CHARS,
+      });
+      lines.push(linePrefix + excerpt);
       if (withIds) {
         byId.set(fragmentId, {
           fragmentId,
@@ -214,7 +226,75 @@ export class FragmentLaneService {
         });
       }
     }
-    return { lines, byId };
+    return { lines, byId, zoom };
+  }
+
+  /**
+   * Fuller derived TEXT for the given derived_representation rows — the
+   * FOVEA_FRAGMENT_ZOOM read (MM-zoom PR3). Re-applies the lane's OWN
+   * fence stack per read (defense in depth — the rows passed it seconds
+   * ago in the same request, but rows can change): tenant (withCompany),
+   * 0112 modality consent, asset-join user fence, media PII, and
+   * availability. Content is capped at `maxChars` per row. DERIVED TEXT
+   * ONLY: this reads derived_representation.content — original media
+   * bytes stay exclusively behind the raw-read gateway
+   * (EVIDENCE_RAW_READ_ENABLED, EvidenceReadService). Errors PROPAGATE:
+   * the zoom runner (fragment-zoom.ts) owns the fail-safe-to-static
+   * catch and the 'error' outcome count.
+   */
+  async fullerTexts(opts: {
+    companyId: string;
+    reprIds: string[];
+    maxChars: number;
+    callerScopes: string[];
+    userId?: string | undefined;
+  }): Promise<Map<string, string>> {
+    if (opts.reprIds.length === 0) return new Map();
+    const { piiGate, userFence } = this.rowFences(opts.callerScopes, opts.userId);
+    const rows = await this.surreal.withCompany(opts.companyId, async (db) => {
+      const [consentRows] = await db.query<[ModalityConsentRow[]]>(
+        `SELECT manifest, acceptedModalities, acceptedModalitiesChecksum FROM domain_pack`,
+      );
+      if (!hasCurrentModalityConsent(consentRows ?? [])) return [];
+      const [reprRows] = await db.query<[Array<{ id?: unknown; content?: unknown }>]>(
+        `SELECT id, content FROM derived_representation
+            WHERE id INSIDE $ids AND subjectKind = 'fragment'
+            ${userFence.clause}
+            ${piiGate}
+            AND subjectId.assetId.availability != 'gone'`,
+        { ids: opts.reprIds.map((id) => new StringRecordId(id)), ...userFence.params },
+      );
+      return reprRows ?? [];
+    });
+    const out = new Map<string, string>();
+    for (const row of rows) {
+      if (typeof row.content !== 'string') continue;
+      out.set(String(row.id ?? ''), row.content.slice(0, opts.maxChars));
+    }
+    return out;
+  }
+
+  /** The lane's row-level fences (2: asset-join user fence, 3: media
+   *  PII), shared verbatim by the retrieval read and the zoom read. */
+  private rowFences(
+    callerScopes: string[],
+    userId: string | undefined,
+  ): {
+    piiGate: string;
+    userFence: { clause: string; params: Record<string, string> };
+  } {
+    // Fence 3: the fragment's own piiClasses, through the record link.
+    const piiGate = mediaPiiGate(callerScopes, 'subjectId.piiClasses');
+    // Fence 2: asset-join user fence (single-owner 0055 gate — see class doc).
+    const userFence =
+      userId === undefined
+        ? { clause: 'AND subjectId.assetId.userId IS NONE', params: {} }
+        : {
+            clause:
+              'AND (subjectId.assetId.userId IS NONE OR subjectId.assetId.userId = $scopeUserId)',
+            params: { scopeUserId: userId },
+          };
+    return { piiGate, userFence };
   }
 }
 

--- a/src/synthesize/fragment-zoom-seam.ts
+++ b/src/synthesize/fragment-zoom-seam.ts
@@ -1,0 +1,309 @@
+import type OpenAI from 'openai';
+import type { MetricsService } from '../metrics/metrics.service';
+import type { MemoryDecisionService } from '../outcomes/memory-decision.service';
+import type { SynthesisGuardrails, SynthesizeDto } from './dto/synthesize.dto';
+import type { RetrievalProfile } from '../search/retrieval-profile';
+import type { SearchHit } from '../search/search.service';
+import type { GeneratorOutput, SynthesizeResult } from './synthesize.types';
+import type { Citation } from './fact-index';
+import { fragmentZoomEnabled, fragmentZoomMaxChars } from '../common/fovea-flags';
+import { withSpan } from '../common/tracing';
+import { getAbortSignal } from '../common/request-context';
+import { runVerifier, type VerifierOutput } from './verifier';
+import { miniCheckVerdict } from './minicheck-client';
+import { verifierErrorResult } from './synthesize.helpers';
+import { verifierPasses } from './l3-escalation';
+import { runFragmentZoom, type ZoomCandidate } from './fragment-zoom';
+import { captureZoomDecision, type DecisionContext } from './decision-emit';
+
+/**
+ * The corrective-VERIFIER stage + the MM-zoom PR3 fragment-zoom step
+ * (FOVEA_FRAGMENT_ZOOM), one module behind one seam — extracted WHOLE
+ * from synthesize.service.ts (file/function budgets, the
+ * resolveAnswerIntegrity deps idiom). Deliberately one module: the
+ * primary audit and the zoom re-verify build their VerifyRequest side by
+ * side here, so the "same audit, only the fragment lines enriched"
+ * parity holds by construction, not by convention.
+ *
+ * verifyAndZoom = the stage: run the primary verifier (LLM judge, or the
+ * local NLI when abstention='minicheck' in lenient mode — V11 §2 arm b),
+ * fail to the historical verifier_error result on a throw, hand the
+ * PRE-zoom verdict to the caller's onPrimaryVerdict callback (the
+ * Optics-1 focus capture — the sample must see the primary verdict,
+ * fit-shape discipline), then apply the zoom step.
+ *
+ * tryFragmentZoom = the step. Gates, in order: flag on (read via the
+ * common-layer resolver — no direct env read), LLM-verifier path only
+ * (an NLI verdict is not the judge the zoom re-runs — skip ⇒ static),
+ * the fenced reader wired, and the primary verdict FAILED the shared
+ * flip test (verifierPasses — the L3 fail notion). Then ONE bounded
+ * zoom (fragment-zoom.ts): fetch fuller DERIVED TEXT of the truncated
+ * rendered fragments through the lane's own fence stack — NEVER raw
+ * bytes; those stay exclusively behind the EVIDENCE_RAW_READ_ENABLED
+ * gateway (EvidenceReadService) — and RE-VERIFY ONLY. The answer is
+ * NEVER regenerated.
+ *
+ * The step returns the FLIPPED verdict or null. Every failure path —
+ * including the wrapper's own guard — returns null: the zoom can only
+ * ADD a flipped serve, never lose the static downgrade. One step by
+ * construction: the flow is linear and a flipped verdict passes the very
+ * gate that triggers zooming.
+ */
+
+/** The fenced fuller-text reader (FragmentLaneService.fullerTexts
+ *  satisfies this structurally — a port, not an import, so this module
+ *  never depends on the lane service). */
+export interface FragmentZoomFetchPort {
+  fullerTexts(opts: {
+    companyId: string;
+    reprIds: string[];
+    maxChars: number;
+    callerScopes: string[];
+    userId?: string | undefined;
+  }): Promise<Map<string, string>>;
+}
+
+export interface FragmentZoomSeamDeps {
+  openai: OpenAI;
+  metrics?: MetricsService | undefined;
+  logger: { warn(message: string): void };
+  limiter: { run<T>(fn: () => Promise<T>): Promise<T> };
+  fragmentLane?: FragmentZoomFetchPort | undefined;
+  decisions?: MemoryDecisionService | undefined;
+  /** The local NLI endpoint for abstention='minicheck' (V11 §2 arm b). */
+  minicheck: { baseUrl: string; model: string };
+}
+
+/** The per-request serving context — the orchestrator's cacheArgs
+ *  bundle, passed as-is. */
+export interface VerifyStageCtx {
+  companyId: string;
+  dto: SynthesizeDto;
+  callerScopes: string[];
+  profile: RetrievalProfile;
+  model: string;
+  guardrails: SynthesisGuardrails;
+}
+
+export interface VerifyStageArgs {
+  ctx: VerifyStageCtx;
+  generated: GeneratorOutput;
+  /** The collector's rendered sections (evidence parity: generator,
+   *  primary audit and zoom re-verify all read the same lines). */
+  collected: {
+    fragmentLines: string[];
+    fragmentZoom: ZoomCandidate[];
+    transcriptLines: string[];
+    insightLines: string[];
+    timelineEvidence: boolean;
+  };
+  promptFactLines: string[];
+  dateMathLines?: string[] | undefined;
+  citations: Citation[];
+  results: SearchHit[];
+  decisionLog: Parameters<typeof verifierErrorResult>[0]['decisionLog'];
+  /** factIndex.size — the synthesize.verify span attribute. */
+  factCount: number;
+  decisionCtx: DecisionContext;
+  /** Invoked with the PRE-zoom verdict (the focus-capture hook). */
+  onPrimaryVerdict: (verdict: VerifierOutput) => Promise<void>;
+}
+
+/**
+ * The stage: primary verify → verifier_error exit on a throw →
+ * onPrimaryVerdict → the zoom step. Moved verbatim from
+ * synthesize.service.ts (see the module docblock); with
+ * FOVEA_FRAGMENT_ZOOM off the returned verdict IS the primary verdict —
+ * byte-identical serving.
+ */
+export async function verifyAndZoom(
+  deps: FragmentZoomSeamDeps,
+  args: VerifyStageArgs,
+): Promise<{ verdict: VerifierOutput } | { failed: SynthesizeResult }> {
+  const { ctx, collected, generated } = args;
+  const { dto, profile, model, guardrails } = ctx;
+  // V11 §2 arm (b): lenient 'minicheck' delegates the judgment to the
+  // local NLI; the verdict falls through to the SAME finalizeVerdict
+  // gate (verdict.ts treats the mode like 'verifier'). A throw lands in
+  // the shared verifier_error catch.
+  const nliMode = guardrails === 'lenient' && profile.abstentionCalibration === 'minicheck';
+  let verdict: VerifierOutput;
+  try {
+    verdict = nliMode
+      ? await miniCheckVerdict(
+          {
+            baseUrl: deps.minicheck.baseUrl,
+            model: deps.minicheck.model,
+            signal: getAbortSignal(),
+          },
+          {
+            answer: generated.answer,
+            factLines: args.promptFactLines,
+            transcriptLines: collected.transcriptLines,
+            insightLines: collected.insightLines,
+            // MM-zoom PR2 parity: the media lines the generator saw.
+            fragmentLines: collected.fragmentLines,
+          },
+        )
+      : await withSpan(
+          'synthesize.verify',
+          () =>
+            deps.limiter.run(() =>
+              runVerifier({
+                openai: deps.openai,
+                metrics: deps.metrics,
+                query: dto.query,
+                answer: generated.answer,
+                factLines: args.promptFactLines,
+                // Audit W5 #22: the verifier used to see ONLY factLines,
+                // so an answer correctly built from transcript quotes or
+                // the computed interval table had claims present in no
+                // fact line — strict mode dropped correct answers, and
+                // lenient/answer shipped quoted L0 content with zero
+                // faithfulness scoring. It now audits against the same
+                // evidence the generator was given.
+                transcriptLines: collected.transcriptLines,
+                insightLines: collected.insightLines,
+                // W5 #22 parity for the mention record (V9 §2 closes the
+                // V8 gap): the auditor sees the same MENTION RECORD
+                // framing the generator saw — the collector computed it
+                // exactly once for both.
+                timelineEvidence: collected.timelineEvidence,
+                // V10 §5: topic-coverage audit (relationship-claim
+                // strictness + the questionAnswered judgment).
+                topicCoverage: profile.verifierTopicCoverage,
+                // V13 date-table parity: the auditor sees the same
+                // computed table the generator saw.
+                dateMathLines: args.dateMathLines,
+                // MM-zoom PR2 parity: the same media lines the
+                // generator saw (the 0113 capabilityEvidenceLines seam).
+                capabilityEvidenceLines: collected.fragmentLines,
+                // G4 strategyNotes are DELIBERATELY absent — the one
+                // documented exception to the W5 #22 parity invariant:
+                // advisory strategy notes are guidance, not evidence,
+                // and must never make an unsupported claim verify as
+                // supported (see verifier.ts + CollectedEvidence).
+                // V11 §2 arm (a): the audit may run on a stronger judge
+                // than the generator; empty override = same model.
+                model: profile.verifierModel || model,
+              }),
+            ),
+          { 'synthesize.facts': args.factCount },
+        );
+  } catch (err) {
+    deps.logger.warn(`Synthesize verifier failed: ${(err as Error).message}`);
+    deps.metrics?.countSynthesize('verifier_error');
+    return {
+      failed: verifierErrorResult({
+        guardrails,
+        answer: generated.answer,
+        citations: args.citations,
+        results: args.results,
+        decisionLog: args.decisionLog,
+      }),
+    };
+  }
+  // Optics-1 focus capture — the sample sees the PRE-zoom verdict.
+  await args.onPrimaryVerdict(verdict);
+  // MM-zoom PR3: the ONE bounded zoom step; null ⇒ the primary verdict
+  // stands and every downstream byte matches the pre-zoom flow.
+  const zoomed = await tryFragmentZoom(deps, {
+    ctx,
+    nliMode,
+    verdict,
+    generated,
+    collected,
+    promptFactLines: args.promptFactLines,
+    dateMathLines: args.dateMathLines,
+    decisionCtx: args.decisionCtx,
+  });
+  return { verdict: zoomed ?? verdict };
+}
+
+interface FragmentZoomSeamArgs {
+  /** The per-request serving context (the cacheArgs bundle). */
+  ctx: VerifyStageCtx;
+  /** True when the verdict came from the local NLI judge (minicheck). */
+  nliMode: boolean;
+  verdict: VerifierOutput;
+  generated: GeneratorOutput;
+  /** The collector's rendered sections (evidence parity: the re-verify
+   *  reuses them verbatim, only the fragment lines are enriched). */
+  collected: {
+    fragmentLines: string[];
+    fragmentZoom: ZoomCandidate[];
+    transcriptLines: string[];
+    insightLines: string[];
+    timelineEvidence: boolean;
+  };
+  promptFactLines: string[];
+  dateMathLines?: string[] | undefined;
+  decisionCtx: DecisionContext;
+}
+
+async function tryFragmentZoom(
+  deps: FragmentZoomSeamDeps,
+  args: FragmentZoomSeamArgs,
+): Promise<VerifierOutput | null> {
+  const { collected } = args;
+  const { companyId, dto, callerScopes, profile, model } = args.ctx;
+  if (!fragmentZoomEnabled()) return null;
+  if (args.nliMode || !deps.fragmentLane) return null;
+  if (verifierPasses(args.verdict, profile.verifierTopicCoverage)) return null;
+  try {
+    const fragmentLane = deps.fragmentLane;
+    const userId = dto.userId || undefined;
+    const result = await runFragmentZoom(
+      {
+        fetchFullerTexts: (reprIds, maxChars) =>
+          fragmentLane.fullerTexts({
+            companyId,
+            reprIds,
+            maxChars,
+            callerScopes,
+            userId,
+          }),
+        // Re-verify ONLY: the SAME audit request as the primary verifier
+        // call, with the zoomed lines standing in for the rendered
+        // fragment lines (every other section untouched).
+        reverify: (zoomedLines) =>
+          deps.limiter.run(() =>
+            runVerifier({
+              openai: deps.openai,
+              metrics: deps.metrics,
+              query: dto.query,
+              answer: args.generated.answer,
+              factLines: args.promptFactLines,
+              transcriptLines: collected.transcriptLines,
+              insightLines: collected.insightLines,
+              timelineEvidence: collected.timelineEvidence,
+              topicCoverage: profile.verifierTopicCoverage,
+              dateMathLines: args.dateMathLines,
+              capabilityEvidenceLines: zoomedLines,
+              model: profile.verifierModel || model,
+            }),
+          ),
+        metrics: deps.metrics,
+        warn: (m) => deps.logger.warn(`${m} (companyId=${companyId})`),
+      },
+      {
+        topicCoverage: profile.verifierTopicCoverage,
+        fragmentLines: collected.fragmentLines,
+        candidates: collected.fragmentZoom,
+        citedFragmentIds: args.generated.citedFragmentIds ?? [],
+        maxChars: fragmentZoomMaxChars(),
+      },
+    );
+    // 0119 decision capture — once per EVALUATED step (mirrors the
+    // metric); guarded no-op unless OUTCOME_DECISION_CAPTURE is on.
+    captureZoomDecision(deps.decisions, companyId, {
+      result,
+      decisionCtx: args.decisionCtx,
+    });
+    return result.verdict ?? null;
+  } catch (e) {
+    // Fail-safe to static: zoom must never break the serve/downgrade.
+    deps.logger.warn(`fragment zoom seam failed (companyId=${companyId}): ${(e as Error).message}`);
+    return null;
+  }
+}

--- a/src/synthesize/fragment-zoom.ts
+++ b/src/synthesize/fragment-zoom.ts
@@ -1,0 +1,205 @@
+import type { VerifierOutput } from './verifier';
+import { verifierPasses } from './l3-escalation';
+
+/**
+ * Verifier-controlled fragment zoom (FOVEA_FRAGMENT_ZOOM, MM-zoom PR3)
+ * — the pure decision core + the IO-injected runner. No DI, no env: the
+ * orchestrator resolves the flag/knob in the common layer and supplies
+ * the two IO ports (fetch fuller derived text, re-verify), the
+ * l3-escalation.ts split idiom.
+ *
+ * THE ONE STEP: when the primary verifier verdict FAILS and at least one
+ * RENDERED fragment line was TRUNCATED by the lane's 600-char excerpt
+ * cap (ZoomCandidate.truncated — recorded at render time, no extra
+ * read), fetch the fuller text of the SAME derived_representation rows
+ * (≤ maxChars each, ≤ FRAGMENT_ZOOM_MAX_FRAGMENTS fragments, cited
+ * fragments first) and re-run the SAME verifier over the enriched
+ * evidence document. The ANSWER is never regenerated: a flip means the
+ * already-served answer was grounded in text the excerpt cap had hidden
+ * from the auditor. No flip (or any failure) returns null and the
+ * caller's downgrade path runs byte-identically.
+ *
+ * DERIVED TEXT ONLY — NEVER RAW BYTES: the zoom reads
+ * derived_representation.content through the lane's own fence stack
+ * (FragmentLaneService.fullerTexts). Original media bytes stay
+ * exclusively behind the raw-read gateway (EVIDENCE_RAW_READ_ENABLED,
+ * EvidenceReadService); this module cannot name them.
+ *
+ * MONOTONE + BOUNDED + FAIL-SAFE (the adaptive-L3 ladder shape): the
+ * flow is linear so the step runs at most once per request; the fetch is
+ * bounded by the fragment cap × char cap; every error path counts
+ * 'error' and returns null — the zoom can only ADD a flipped verdict,
+ * never lose the static behavior.
+ */
+
+/** Ceiling on fragments zoomed per step (design constant, deliberately
+ *  NOT an env knob until the step is measured — the lane top-K idiom). */
+export const FRAGMENT_ZOOM_MAX_FRAGMENTS = 2;
+
+/**
+ * One rendered fragment line's zoom affordance, recorded by the lane at
+ * render time (fragment-lane.service.ts render()) — pure bookkeeping
+ * over rows already in memory, no IO and no rendered-byte change.
+ */
+export interface ZoomCandidate {
+  /** evidence_fragment record id (the citedFragmentIds join key). */
+  fragmentId: string;
+  /** The derived_representation row whose content the line excerpted —
+   *  the row the zoom re-reads for its fuller text. */
+  reprId: string;
+  /** Index of the fragment's line within the lane's rendered lines. */
+  lineIndex: number;
+  /** Everything before the excerpt on the rendered line — the zoomed
+   *  line is linePrefix + fullerText, format-identical to the lane's. */
+  linePrefix: string;
+  /** Whether the excerpt cap actually truncated the content — the
+   *  "deeper representation available" trigger bit. */
+  truncated: boolean;
+}
+
+/** Per-step outcomes (the brain_fragment_zoom_total label values). */
+export type FragmentZoomOutcome = 'flipped' | 'unchanged' | 'skipped' | 'error';
+
+/** Metrics port (keeps this module pure — the fragment-citations idiom). */
+export interface FragmentZoomMetrics {
+  countFragmentZoom(outcome: FragmentZoomOutcome): void;
+}
+
+/**
+ * Select the fragments to zoom: truncated candidates only, CITED ones
+ * first (the generator named them — the likeliest support site), rendered
+ * order within each group, deduped by fragmentId, capped. Pure.
+ */
+export function selectZoomFragments(
+  candidates: ReadonlyArray<ZoomCandidate>,
+  citedFragmentIds: ReadonlyArray<string>,
+  cap: number = FRAGMENT_ZOOM_MAX_FRAGMENTS,
+): ZoomCandidate[] {
+  const cited = new Set(citedFragmentIds);
+  const truncated = candidates.filter((c) => c.truncated);
+  const seen = new Set<string>();
+  const picked: ZoomCandidate[] = [];
+  for (const group of [
+    truncated.filter((c) => cited.has(c.fragmentId)),
+    truncated.filter((c) => !cited.has(c.fragmentId)),
+  ]) {
+    for (const c of group) {
+      if (picked.length >= cap) return picked;
+      if (seen.has(c.fragmentId)) continue;
+      seen.add(c.fragmentId);
+      picked.push(c);
+    }
+  }
+  return picked;
+}
+
+/**
+ * Rebuild the evidence lines with the zoomed fragments' fuller text —
+ * linePrefix + fullerText at the candidate's own index, every other line
+ * byte-identical. A stale candidate (index out of range or prefix
+ * mismatch — cannot happen when lane and candidates come from the same
+ * render, but the fence is cheap) leaves its line untouched. Pure.
+ */
+export function buildZoomedLines(
+  lines: ReadonlyArray<string>,
+  zoomed: ReadonlyArray<{ candidate: ZoomCandidate; fullerText: string }>,
+): string[] {
+  const out = [...lines];
+  for (const { candidate, fullerText } of zoomed) {
+    const current = out[candidate.lineIndex];
+    if (current === undefined || !current.startsWith(candidate.linePrefix)) continue;
+    out[candidate.lineIndex] = candidate.linePrefix + fullerText;
+  }
+  return out;
+}
+
+/** The two IO ports + observability the runner needs. */
+export interface FragmentZoomDeps {
+  /** Fetch fuller derived TEXT (≤ maxChars each) for the given
+   *  derived_representation ids, through the lane's fence stack. */
+  fetchFullerTexts(reprIds: string[], maxChars: number): Promise<Map<string, string>>;
+  /** Re-run the SAME verifier with the enriched evidence lines standing
+   *  in for the rendered fragment lines — everything else identical. */
+  reverify(zoomedLines: string[]): Promise<VerifierOutput>;
+  metrics?: FragmentZoomMetrics | undefined;
+  warn(message: string): void;
+}
+
+export interface FragmentZoomArgs {
+  /** profile.verifierTopicCoverage — the shared flip-test knob. */
+  topicCoverage: boolean;
+  /** The lane's rendered fragment lines (the verifier's
+   *  capabilityEvidenceLines section). */
+  fragmentLines: ReadonlyArray<string>;
+  /** Zoom affordances for EXACTLY the rendered fragments. */
+  candidates: ReadonlyArray<ZoomCandidate>;
+  /** The generator's cited fragment ids (selection preference). */
+  citedFragmentIds: ReadonlyArray<string>;
+  /** Resolved FOVEA_FRAGMENT_ZOOM_MAX_CHARS. */
+  maxChars: number;
+}
+
+/** What one zoom evaluation decided — the material captureZoomDecision
+ *  maps onto a memory_decision row (kind 'zoom'). */
+export interface FragmentZoomResult {
+  outcome: FragmentZoomOutcome;
+  /** Truncated candidates available to the step. */
+  candidateCount: number;
+  /** Fragments actually zoomed into the re-verify (0 on skip/error). */
+  zoomedCount: number;
+  /** The flipped verdict — present ONLY on outcome 'flipped'. */
+  verdict?: VerifierOutput | undefined;
+}
+
+/**
+ * Run the ONE zoom step. Called by the orchestrator ONLY when
+ * FOVEA_FRAGMENT_ZOOM is on AND the primary verdict already FAILED the
+ * shared flip test (both gates stay in the caller — this module reads no
+ * env, and a passing verdict never reaches it, so 'skipped' always means
+ * "failed verdict with nothing to zoom"). Returns the evaluation result;
+ * only outcome 'flipped' carries a verdict for the caller to serve.
+ * Every error path degrades to 'error' + no verdict — the caller's
+ * static behavior.
+ */
+export async function runFragmentZoom(
+  deps: FragmentZoomDeps,
+  args: FragmentZoomArgs,
+): Promise<FragmentZoomResult> {
+  const candidateCount = args.candidates.filter((c) => c.truncated).length;
+  const done = (outcome: FragmentZoomOutcome, zoomedCount = 0, verdict?: VerifierOutput) => {
+    deps.metrics?.countFragmentZoom(outcome);
+    return { outcome, candidateCount, zoomedCount, verdict };
+  };
+  try {
+    // Trigger residue: at least one truncated rendered fragment (the
+    // failed-verdict gate already ran in the caller). Nothing to zoom
+    // ⇒ skip.
+    const picked = selectZoomFragments(args.candidates, args.citedFragmentIds);
+    if (picked.length === 0) return done('skipped');
+    const fuller = await deps.fetchFullerTexts(
+      picked.map((c) => c.reprId),
+      args.maxChars,
+    );
+    // Deeper only: a fetch that returned nothing longer than the rendered
+    // excerpt (row shrank / vanished / knob below the excerpt cap) skips.
+    const zoomed = picked.flatMap((candidate) => {
+      const fullerText = fuller.get(candidate.reprId);
+      const line = args.fragmentLines[candidate.lineIndex];
+      const excerptLength = line === undefined ? 0 : line.length - candidate.linePrefix.length;
+      return fullerText !== undefined && fullerText.length > excerptLength
+        ? [{ candidate, fullerText }]
+        : [];
+    });
+    if (zoomed.length === 0) return done('skipped');
+    const zoomedLines = buildZoomedLines(args.fragmentLines, zoomed);
+    // Re-verify ONLY — the answer is never regenerated.
+    const verdict = await deps.reverify(zoomedLines);
+    return verifierPasses(verdict, args.topicCoverage)
+      ? done('flipped', zoomed.length, verdict)
+      : done('unchanged', zoomed.length);
+  } catch (e) {
+    // Fail-safe to static: the step must never break the serve/downgrade.
+    deps.warn(`fragment zoom failed: ${(e as Error).message}`);
+    return done('error');
+  }
+}

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -6,7 +6,6 @@ import { SearchService, SearchHit } from '../search/search.service';
 import { Semaphore } from '../common/semaphore';
 import { withSpan } from '../common/tracing';
 import { clampLlmInputText } from '../common/input-limits';
-import { getAbortSignal } from '../common/request-context';
 import { pinUserScope } from '../auth/user-scope';
 import { MetricsService } from '../metrics/metrics.service';
 import { SynthesisGuardrails, SynthesizeDto } from './dto/synthesize.dto';
@@ -23,7 +22,6 @@ import {
   resolveCitations,
   resolveRoutedLane,
   serveCacheHit,
-  verifierErrorResult,
 } from './synthesize.helpers';
 import { applyEvidenceUnion } from './evidence-union';
 import type { LaneId } from './answer-router';
@@ -32,6 +30,8 @@ import { getActiveRetrievalProfile, type RetrievalProfile } from '../search/retr
 import { buildFactIndex } from './fact-index';
 import { fragmentCitationsEnabled } from '../common/evidence-flags';
 import { resolveAndCountFragmentCitations } from './fragment-citations';
+import { verifyAndZoom } from './fragment-zoom-seam';
+import { FragmentLaneService } from './fragment-lane.service';
 import { resolveAnswerIntegrity, type FinalizeContext } from './answer-integrity';
 import { makeGroundingFetchPort } from './grounding-fetch';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
@@ -40,8 +40,7 @@ import { applyFactSuffixes } from './update-story';
 import { buildDateMathLines } from './date-math';
 export { buildFactIndex } from './fact-index';
 import { runGenerator, type GenerateRequest } from './generator-client';
-import { runVerifier, type VerifierOutput } from './verifier';
-import { miniCheckVerdict } from './minicheck-client';
+import type { VerifierOutput } from './verifier';
 export { buildGeneratorUserMessage } from './generator-prompt';
 import {
   EvidenceCollectorService,
@@ -154,6 +153,10 @@ export class SynthesizeService {
     // fixtures stay valid; absent (or flag off) ⇒ no decision rows, no
     // join columns, byte-identical serving.
     @Optional() private readonly decisions?: MemoryDecisionService,
+    // MM-zoom PR3 (FOVEA_FRAGMENT_ZOOM): the fenced fuller-text read for
+    // the zoom step. @Optional so positional unit fixtures stay valid —
+    // absent ⇒ the zoom seam no-ops (static behavior).
+    @Optional() private readonly fragmentLane?: FragmentLaneService,
   ) {
     this.openai = createOpenAiClientOrThrow(this.configService);
     this.defaultModel = this.configService.get<string>(
@@ -329,9 +332,9 @@ export class SynthesizeService {
       factIds: [...factIndex.keys()],
       evidence,
     });
-    const { transcriptLines, insightLines, timelineEvidence, fragmentLines, fragmentsById } =
-      collected;
-    const { updateStories, groundingQuotes } = collected;
+    // The other rendered sections stay on `collected` — the verify stage
+    // (verifyAndZoom) and produceAnswer read them from there directly.
+    const { fragmentsById, updateStories, groundingQuotes } = collected;
 
     // V10 §2 update stories + multiworld §10 grounding quotes: both
     // suffix maps land on the SAME lines the generator and the
@@ -396,92 +399,45 @@ export class SynthesizeService {
     if (unverified) return unverified;
 
     onProgress({ stage: 'verify', message: 'verifier checking claim grounding' });
-    // Verifier — the corrective guardrail. Runs in strict and
-    // lenient modes. Strict gates the answer behind a 'supported'
+    // Verifier — the corrective guardrail — plus the MM-zoom PR3
+    // fragment-zoom step (FOVEA_FRAGMENT_ZOOM), ONE stage behind one
+    // seam (fragment-zoom-seam.ts, moved whole for the size gates: the
+    // primary audit and the zoom re-verify build their VerifyRequest in
+    // one module, so evidence parity between them holds by
+    // construction). Strict gates the answer behind a 'supported'
     // verdict; lenient surfaces the verdict but returns the answer
-    // either way.
-    // V11 §2 arm (b): lenient 'minicheck' delegates the judgment to
-    // the local NLI; the verdict falls through to the SAME
-    // finalizeVerdict gate below (verdict.ts treats the mode like
-    // 'verifier'). A throw lands in the shared verifier_error catch.
-    const nliMode = guardrails === 'lenient' && profile.abstentionCalibration === 'minicheck';
-    let verdict: VerifierOutput;
-    try {
-      verdict = nliMode
-        ? await miniCheckVerdict(
-            { baseUrl: this.minicheckUrl, model: this.minicheckModel, signal: getAbortSignal() },
-            {
-              answer: generated.answer,
-              factLines: promptFactLines,
-              transcriptLines,
-              insightLines,
-              // MM-zoom PR2 parity: the media lines the generator saw.
-              fragmentLines,
-            },
-          )
-        : await withSpan(
-            'synthesize.verify',
-            () =>
-              this.limiter.run(() =>
-                this.callVerifier({
-                  query: dto.query,
-                  answer: generated.answer,
-                  factLines: promptFactLines,
-                  // Audit W5 #22: the verifier used to see ONLY factLines,
-                  // so an answer correctly built from transcript quotes or
-                  // the computed interval table had claims present in no
-                  // fact line — strict mode dropped correct answers, and
-                  // lenient/answer shipped quoted L0 content with zero
-                  // faithfulness scoring. It now audits against the same
-                  // evidence the generator was given.
-                  transcriptLines,
-                  insightLines,
-                  // W5 #22 parity for the mention record (V9 §2 closes the
-                  // V8 gap): the auditor sees the same MENTION RECORD
-                  // framing the generator saw — the collector computed it
-                  // exactly once for both.
-                  timelineEvidence,
-                  // V10 §5: topic-coverage audit (relationship-claim
-                  // strictness + the questionAnswered judgment).
-                  topicCoverage: profile.verifierTopicCoverage,
-                  // V13 date-table parity: the auditor sees the same
-                  // computed table the generator saw.
-                  dateMathLines,
-                  // MM-zoom PR2 parity: the same media lines the
-                  // generator saw (the 0113 capabilityEvidenceLines seam).
-                  capabilityEvidenceLines: fragmentLines,
-                  // G4 strategyNotes are DELIBERATELY absent — the one
-                  // documented exception to the W5 #22 parity invariant:
-                  // advisory strategy notes are guidance, not evidence,
-                  // and must never make an unsupported claim verify as
-                  // supported (see verifier.ts + CollectedEvidence).
-                  // V11 §2 arm (a): the audit may run on a stronger judge
-                  // than the generator; empty override = same model.
-                  model: profile.verifierModel || model,
-                }),
-              ),
-            { 'synthesize.facts': factIndex.size },
-          );
-    } catch (err) {
-      this.logger.warn(`Synthesize verifier failed: ${(err as Error).message}`);
-      this.metrics?.countSynthesize('verifier_error');
-      return verifierErrorResult({
-        guardrails,
-        answer: generated.answer,
-        citations,
-        results,
-        decisionLog,
-      });
-    }
-
-    // Optics-1 focus capture — SERVING-NEUTRAL guarded no-op (see method).
-    // `dto.query` carries the Tier 5 language key onto the verdict sample;
-    // the 0119 primary decision id (if any) joins sample → decision row.
-    await this.maybeCaptureFocusSignal(
-      companyId,
-      { results, verdict: verdict.verdict, lane, decisionId: decisionCtx.primaryDecisionId },
-      dto.query,
-    );
+    // either way; 'minicheck' delegates to the local NLI. A verifier
+    // throw returns the historical verifier_error result. On a
+    // zoom flip the returned verdict is the RE-verified one — the L3
+    // trigger below then reads 'skip_verdict_ok' and the normal
+    // supported serve runs; otherwise (and always with the flag off)
+    // it is the primary verdict, byte for byte.
+    //
+    // Optics-1 focus capture rides the onPrimaryVerdict callback so the
+    // sample sees the PRE-zoom verdict (fit-shape discipline; see
+    // maybeCaptureFocusSignal — SERVING-NEUTRAL guarded no-op).
+    // `dto.query` carries the Tier 5 language key onto the verdict
+    // sample; the 0119 primary decision id joins sample → decision row.
+    const verified = await verifyAndZoom(this.verifyDeps(), {
+      ctx: cacheArgs,
+      generated,
+      collected,
+      promptFactLines,
+      dateMathLines,
+      citations,
+      results,
+      decisionLog,
+      factCount: factIndex.size,
+      decisionCtx,
+      onPrimaryVerdict: (v) =>
+        this.maybeCaptureFocusSignal(
+          companyId,
+          { results, verdict: v.verdict, lane, decisionId: decisionCtx.primaryDecisionId },
+          dto.query,
+        ),
+    });
+    if ('failed' in verified) return verified.failed;
+    const { verdict } = verified;
 
     // G2 L3 escalation — the pre-abstention seam. On a verifier-fail with
     // an anchoring session it escalates ONCE to full-raw-session context
@@ -687,6 +643,21 @@ export class SynthesizeService {
         abstention: profile.abstentionCalibration,
       },
     );
+  }
+
+  /** The verify-stage ports, bundled once (fragment-zoom-seam.ts owns
+   *  the primary audit + the MM-zoom PR3 step; this service only lends
+   *  its ports — the resolveAnswerIntegrity deps idiom). */
+  private verifyDeps() {
+    return {
+      openai: this.openai,
+      metrics: this.metrics,
+      logger: this.logger,
+      limiter: this.limiter,
+      fragmentLane: this.fragmentLane,
+      decisions: this.decisions,
+      minicheck: { baseUrl: this.minicheckUrl, model: this.minicheckModel },
+    };
   }
 
   /**
@@ -1116,8 +1087,9 @@ export class SynthesizeService {
 
   /**
    * Thin adapter over the generator client (V10 architecture pass) —
-   * same seam as callVerifier/runVerifier: the orchestrator supplies
-   * its client/metrics/logger, the module owns the call.
+   * the orchestrator supplies its client/metrics/logger, the module owns
+   * the call. (The verifier twin moved into fragment-zoom-seam.ts with
+   * the verify stage — verifyAndZoom calls runVerifier directly.)
    */
   private async callGenerator(
     args: Omit<GenerateRequest, 'openai' | 'metrics' | 'logger'>,
@@ -1126,26 +1098,6 @@ export class SynthesizeService {
       openai: this.openai,
       metrics: this.metrics,
       logger: this.logger,
-      ...args,
-    });
-  }
-
-  private async callVerifier(args: {
-    query: string;
-    answer: string;
-    factLines: string[];
-    transcriptLines?: string[] | undefined;
-    insightLines?: string[] | undefined;
-    timelineEvidence?: boolean | undefined;
-    topicCoverage?: boolean | undefined;
-    dateMathLines?: string[] | undefined;
-    /** MM-zoom PR2: the fragment lane's rendered media lines (parity). */
-    capabilityEvidenceLines?: string[] | undefined;
-    model: string;
-  }): Promise<VerifierOutput> {
-    return runVerifier({
-      openai: this.openai,
-      metrics: this.metrics,
       ...args,
     });
   }

--- a/test/engine-gates.unit-spec.ts
+++ b/test/engine-gates.unit-spec.ts
@@ -167,6 +167,12 @@ describe('S5.5 — dead exports in the engine dirs', () => {
     // extraction) but pinned DIRECTLY by the minicheck unit spec for its
     // fetch-level cases (prompt shape, Yes/No parse, error surface).
     'miniCheckConsistent',
+    // MM-zoom PR3 (FOVEA_FRAGMENT_ZOOM) pure decision seams. Consumed
+    // inside fragment-zoom.ts (runFragmentZoom) but pinned DIRECTLY by the
+    // fragment-zoom unit spec for their precision cases (cited-first /
+    // truncated-only / cap selection; the substitution prefix fence).
+    'selectZoomFragments',
+    'buildZoomedLines',
   ]);
   const TESTS = walk(join(ROOT, 'test'))
     .map((f) => readFileSync(f, 'utf8'))

--- a/test/fragment-zoom.e2e-spec.ts
+++ b/test/fragment-zoom.e2e-spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Fragment zoom e2e (FOVEA_FRAGMENT_ZOOM, MM-zoom PR3) over a real
+ * SurrealDB (testcontainer). NO paid call — the OpenAI client is the
+ * scripted stub (mockSynthesizeOpenAi), the fragment-lane e2e idiom.
+ *
+ * Substrate: one tenant with a consented media pack and ONE clean
+ * fragment whose derived caption is LONGER than the lane's 600-char
+ * excerpt cap — the grounding detail lives in the TAIL the cap hides
+ * from the primary audit.
+ *
+ * Pins:
+ *   1. CONTROL (lane on, zoom OFF): a verifier-fail abstains exactly as
+ *      today — TWO LLM calls (generate + verify), no extra read, the
+ *      byte-identity contract;
+ *   2. FLIP: zoom ON, primary verdict unsupported → ONE re-verify whose
+ *      prompt carries the fuller derived text (the tail), verdict flips,
+ *      the SAME generated answer serves (never regenerated — exactly one
+ *      generator call);
+ *   3. UNCHANGED + BOUNDED: the re-verify fails too → the static
+ *      verifier_failed abstain, and EXACTLY three LLM calls total — the
+ *      monotone single step never re-zooms.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSynthesizeOpenAi } from './test-doubles';
+import { SurrealService } from '../src/db/surreal.service';
+import {
+  declaredModalitySection,
+  modalitiesChecksum,
+  type DomainPackManifest,
+} from '../src/ai/domain-packs';
+
+const FLAG_KEYS = ['RETRIEVAL_FRAGMENT_LANE', 'FOVEA_FRAGMENT_ZOOM'] as const;
+
+describe('Fragment zoom e2e', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const savedEnv: Record<string, string | undefined> = {};
+
+  let factId: string;
+
+  // The excerpt head lexically matches the query (BM25 leg); the TAIL —
+  // beyond the 600-char cap — holds the detail only the zoom can show
+  // the auditor.
+  const CAPTION_HEAD = 'whiteboard photo: the evacuation plan pinned in the ops room. ';
+  const CAPTION_TAIL = 'The plan names the north stairwell as the primary evacuation route.';
+  const CAPTION =
+    CAPTION_HEAD + 'detail '.repeat(Math.ceil((601 - CAPTION_HEAD.length) / 7)) + CAPTION_TAIL;
+  const QUERY = 'evacuation plan pinned';
+  const ANSWER = 'Take the north stairwell.';
+  const GEN = JSON.stringify({ answer: ANSWER, citedFactIds: [] });
+  const VERIFY_SUPPORTED = JSON.stringify({ verdict: 'supported', unsupportedClaims: [] });
+  const VERIFY_UNSUPPORTED = JSON.stringify({
+    verdict: 'unsupported',
+    unsupportedClaims: [ANSWER],
+  });
+
+  const MANIFEST = {
+    memoryModel: { modalities: ['text', 'image'] },
+  } as unknown as DomainPackManifest;
+
+  const synth = (body: Record<string, unknown>) =>
+    f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ limit: 5, ...body });
+
+  beforeAll(async () => {
+    expect(CAPTION.length).toBeGreaterThan(600);
+    for (const k of [...FLAG_KEYS, 'RETRIEVAL_ABSTENTION_CALIBRATION']) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    // Pin abstention off so a thin-evidence query never pre-abstains
+    // before generation (the fragment-lane e2e discipline).
+    process.env.RETRIEVAL_ABSTENTION_CALIBRATION = 'off';
+    f = await createApp({ companyId: 'co_fragment_zoom_e2e' });
+
+    // One fact so retrieval yields evidence (the generator needs a
+    // non-empty fact set to run at all).
+    const r = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'ops_room' },
+        predicate: 'status',
+        object: 'the evacuation plan is pinned on the ops-room whiteboard',
+        validFrom: new Date('2026-05-01').toISOString(),
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+        userId: 'u_zoom',
+      });
+    expect([200, 201]).toContain(r.status);
+    factId = r.body.factId as string;
+    expect(factId).toBeTruthy();
+
+    const surreal = f.app.get(SurrealService);
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `CREATE domain_pack CONTENT {
+           packId: 'media_pack_zoom_e2e', version: '1.0.0',
+           manifest: $manifest,
+           acceptedModalities: true,
+           acceptedModalitiesChecksum: $checksum
+         }`,
+        { manifest: MANIFEST, checksum: modalitiesChecksum(declaredModalitySection(MANIFEST)) },
+      );
+      const [asset] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE evidence_asset CONTENT {
+           modality: 'image', mediaType: 'image/jpeg',
+           byteHash: 'e2e-zoom-hash', byteLength: 100,
+           occurredAt: d'2026-05-01T00:00:00Z', availability: 'hot',
+           piiClasses: [], vertical: 'rent'
+         }`,
+      );
+      const [frag] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE evidence_fragment CONTENT {
+           assetId: $assetId, locator: { kind: 'pageRegion' }, piiClasses: []
+         }`,
+        { assetId: asset?.[0]?.id },
+      );
+      await db.query(
+        `CREATE derived_representation CONTENT {
+           subjectId: $subjectId, subjectKind: 'fragment', kind: 'caption',
+           content: $content, producerVersion: 'e2e-1'
+         }`,
+        { subjectId: frag?.[0]?.id, content: CAPTION },
+      );
+    });
+  });
+
+  afterEach(() => {
+    for (const k of FLAG_KEYS) delete process.env[k];
+  });
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (f) await f.close();
+  });
+
+  it('CONTROL — zoom off: a verifier-fail abstains as today, TWO calls, no extra read', async () => {
+    process.env.RETRIEVAL_FRAGMENT_LANE = '1';
+    const state = mockSynthesizeOpenAi(f.app, [GEN, VERIFY_UNSUPPORTED]);
+    const res = await synth({ query: QUERY, userId: 'u_zoom' });
+    expect(res.status).toBe(201);
+    expect(res.body.answer).toBeNull();
+    expect(res.body.reason).toBe('verifier_failed');
+    // Byte-identity pin: the verifier ran EXACTLY once — no zoom call.
+    expect(state.calls.length).toBe(2);
+    // The primary audit saw the capped excerpt: head yes, tail no.
+    expect(state.calls[1]!.user).toContain(CAPTION_HEAD.trim());
+    expect(state.calls[1]!.user).not.toContain(CAPTION_TAIL);
+  });
+
+  it('FLIP — zoom on: ONE re-verify over the fuller text, the SAME answer serves', async () => {
+    process.env.RETRIEVAL_FRAGMENT_LANE = '1';
+    process.env.FOVEA_FRAGMENT_ZOOM = '1';
+    const state = mockSynthesizeOpenAi(f.app, [GEN, VERIFY_UNSUPPORTED, VERIFY_SUPPORTED]);
+    const res = await synth({ query: QUERY, userId: 'u_zoom' });
+    expect(res.status).toBe(201);
+    // Served on the flip — the generator's own answer, never regenerated.
+    expect(res.body.answer).toBe(ANSWER);
+    expect(res.body.reason).toBeUndefined();
+    expect(state.calls.length).toBe(3);
+    // Exactly ONE generator call (call 0); calls 1+2 are audits.
+    expect(state.calls[0]!.user).toContain('Query:');
+    // The primary audit saw only the capped excerpt …
+    expect(state.calls[1]!.user).not.toContain(CAPTION_TAIL);
+    // … the zoom re-verify saw the fuller derived text, same section.
+    expect(state.calls[2]!.user).toContain('Non-text evidence');
+    expect(state.calls[2]!.user).toContain(CAPTION_TAIL);
+    // Re-verify ONLY: the audit request, not a generation (same answer).
+    expect(state.calls[2]!.user).toContain(ANSWER);
+  });
+
+  it('UNCHANGED + BOUNDED — a failing re-verify falls through to the static abstain, EXACTLY three calls', async () => {
+    process.env.RETRIEVAL_FRAGMENT_LANE = '1';
+    process.env.FOVEA_FRAGMENT_ZOOM = '1';
+    // The queue's last response repeats — a second zoom step would still
+    // see 'unsupported'; the call COUNT is the single-step pin.
+    const state = mockSynthesizeOpenAi(f.app, [GEN, VERIFY_UNSUPPORTED, VERIFY_UNSUPPORTED]);
+    const res = await synth({ query: QUERY, userId: 'u_zoom' });
+    expect(res.status).toBe(201);
+    // The downgrade path is unchanged — the CONTROL result, byte for byte.
+    expect(res.body.answer).toBeNull();
+    expect(res.body.reason).toBe('verifier_failed');
+    // Monotone single step: generate + verify + ONE zoom re-verify.
+    expect(state.calls.length).toBe(3);
+  });
+});

--- a/test/fragment-zoom.unit-spec.ts
+++ b/test/fragment-zoom.unit-spec.ts
@@ -1,0 +1,269 @@
+/**
+ * Fragment zoom (FOVEA_FRAGMENT_ZOOM, MM-zoom PR3) — the pure seams +
+ * the IO-injected runner with stub ports (NO paid call anywhere):
+ *
+ *  - selectZoomFragments: truncated-only, cited-first, rendered order,
+ *    dedupe, the FRAGMENT_ZOOM_MAX_FRAGMENTS cap;
+ *  - buildZoomedLines: in-place fuller-text substitution, every other
+ *    line byte-identical, the stale-candidate prefix fence;
+ *  - runFragmentZoom: the bounded single step — flip serves the new
+ *    verdict, no-flip/skip/error return none; the re-verifier runs AT
+ *    MOST ONCE; every error degrades to 'error' (fail-safe to static);
+ *  - fragmentZoomMaxChars: the knob's validation envelope.
+ */
+import {
+  buildZoomedLines,
+  FRAGMENT_ZOOM_MAX_FRAGMENTS,
+  runFragmentZoom,
+  selectZoomFragments,
+  type FragmentZoomDeps,
+  type FragmentZoomOutcome,
+  type ZoomCandidate,
+} from '../src/synthesize/fragment-zoom';
+import { fragmentZoomMaxChars } from '../src/common/fovea-flags';
+import type { VerifierOutput } from '../src/synthesize/verifier';
+
+const cand = (n: number, over: Partial<ZoomCandidate> = {}): ZoomCandidate => ({
+  fragmentId: `evidence_fragment:f${n}`,
+  reprId: `derived_representation:r${n}`,
+  lineIndex: n,
+  linePrefix: `[capability:visual] (image caption) `,
+  truncated: true,
+  ...over,
+});
+
+const SUPPORTED: VerifierOutput = { verdict: 'supported', unsupportedClaims: [] };
+const PARTIAL: VerifierOutput = { verdict: 'partial', unsupportedClaims: ['x'] };
+
+/** Stub deps recording every port call; reverify scripted per test. */
+function stubDeps(opts: {
+  fuller?: Map<string, string>;
+  reverify?: VerifierOutput;
+  fetchThrows?: boolean;
+  reverifyThrows?: boolean;
+}) {
+  const calls = {
+    fetches: [] as Array<{ reprIds: string[]; maxChars: number }>,
+    reverifies: [] as string[][],
+    outcomes: [] as FragmentZoomOutcome[],
+    warns: [] as string[],
+  };
+  const deps: FragmentZoomDeps = {
+    fetchFullerTexts: (reprIds, maxChars) => {
+      calls.fetches.push({ reprIds, maxChars });
+      if (opts.fetchThrows) return Promise.reject(new Error('fetch boom'));
+      return Promise.resolve(opts.fuller ?? new Map());
+    },
+    reverify: (zoomedLines) => {
+      calls.reverifies.push(zoomedLines);
+      if (opts.reverifyThrows) return Promise.reject(new Error('verify boom'));
+      return Promise.resolve(opts.reverify ?? SUPPORTED);
+    },
+    metrics: { countFragmentZoom: (outcome) => calls.outcomes.push(outcome) },
+    warn: (m) => calls.warns.push(m),
+  };
+  return { deps, calls };
+}
+
+describe('selectZoomFragments — bounded, cited-first, truncated-only', () => {
+  it('keeps only truncated candidates, in rendered order', () => {
+    const picked = selectZoomFragments(
+      [cand(0, { truncated: false }), cand(1), cand(2, { truncated: false }), cand(3)],
+      [],
+    );
+    expect(picked.map((c) => c.fragmentId)).toEqual([
+      'evidence_fragment:f1',
+      'evidence_fragment:f3',
+    ]);
+  });
+
+  it('cited fragments come FIRST, then rendered order fills the cap', () => {
+    const picked = selectZoomFragments([cand(0), cand(1), cand(2)], ['evidence_fragment:f2']);
+    expect(picked.map((c) => c.fragmentId)).toEqual([
+      'evidence_fragment:f2',
+      'evidence_fragment:f0',
+    ]);
+  });
+
+  it(`caps at FRAGMENT_ZOOM_MAX_FRAGMENTS (${FRAGMENT_ZOOM_MAX_FRAGMENTS}) and dedupes by fragmentId`, () => {
+    const picked = selectZoomFragments(
+      [cand(0), cand(0), cand(1), cand(2), cand(3)],
+      ['evidence_fragment:f0'],
+    );
+    expect(picked).toHaveLength(FRAGMENT_ZOOM_MAX_FRAGMENTS);
+    expect(new Set(picked.map((c) => c.fragmentId)).size).toBe(FRAGMENT_ZOOM_MAX_FRAGMENTS);
+  });
+});
+
+describe('buildZoomedLines — substitution fence', () => {
+  const lines = ['[capability:visual] (image caption) short', 'untouched line'];
+
+  it('replaces ONLY the candidate line, prefix preserved, others byte-identical', () => {
+    const out = buildZoomedLines(lines, [
+      {
+        candidate: cand(0, { lineIndex: 0 }),
+        fullerText: 'short plus the rest of the derived text',
+      },
+    ]);
+    expect(out[0]).toBe(
+      '[capability:visual] (image caption) short plus the rest of the derived text',
+    );
+    expect(out[1]).toBe(lines[1]);
+    // Pure: the input array is never mutated.
+    expect(lines[0]).toContain(') short');
+  });
+
+  it('a stale candidate (prefix mismatch / index out of range) leaves lines untouched', () => {
+    const out = buildZoomedLines(lines, [
+      { candidate: cand(0, { lineIndex: 0, linePrefix: '[capability:audio] ' }), fullerText: 'x' },
+      { candidate: cand(9, { lineIndex: 9 }), fullerText: 'y' },
+    ]);
+    expect(out).toEqual(lines);
+  });
+});
+
+describe('runFragmentZoom — the ONE bounded step', () => {
+  const FULLER = 'short caption plus the tail the 600-char cap had hidden from the auditor';
+  const args = (over: Partial<Parameters<typeof runFragmentZoom>[1]> = {}) => ({
+    topicCoverage: false,
+    fragmentLines: ['[capability:visual] (image caption) short caption'],
+    candidates: [cand(0, { lineIndex: 0 })],
+    citedFragmentIds: [],
+    maxChars: 4000,
+    ...over,
+  });
+
+  it('flip: fetches ≤2 fragments, re-verifies ONCE over the enriched line, returns the verdict', async () => {
+    const { deps, calls } = stubDeps({
+      fuller: new Map([['derived_representation:r0', FULLER]]),
+      reverify: SUPPORTED,
+    });
+    const result = await runFragmentZoom(deps, args());
+    expect(result.outcome).toBe('flipped');
+    expect(result.verdict).toEqual(SUPPORTED);
+    expect(result.zoomedCount).toBe(1);
+    expect(calls.fetches).toEqual([{ reprIds: ['derived_representation:r0'], maxChars: 4000 }]);
+    // Re-verify ONLY, exactly once, over the enriched evidence document.
+    expect(calls.reverifies).toHaveLength(1);
+    expect(calls.reverifies[0]![0]).toBe(`[capability:visual] (image caption) ${FULLER}`);
+    expect(calls.outcomes).toEqual(['flipped']);
+  });
+
+  it('no flip: the still-failing re-verdict is NOT returned — the caller keeps the static path', async () => {
+    const { deps, calls } = stubDeps({
+      fuller: new Map([['derived_representation:r0', FULLER]]),
+      reverify: PARTIAL,
+    });
+    const result = await runFragmentZoom(deps, args());
+    expect(result.outcome).toBe('unchanged');
+    expect(result.verdict).toBeUndefined();
+    expect(calls.reverifies).toHaveLength(1);
+    expect(calls.outcomes).toEqual(['unchanged']);
+  });
+
+  it('topic coverage: supported-but-not-answering is NOT a flip (the shared verifierPasses test)', async () => {
+    const { deps } = stubDeps({
+      fuller: new Map([['derived_representation:r0', FULLER]]),
+      reverify: { verdict: 'supported', unsupportedClaims: [], questionAnswered: false },
+    });
+    const result = await runFragmentZoom(deps, args({ topicCoverage: true }));
+    expect(result.outcome).toBe('unchanged');
+    expect(result.verdict).toBeUndefined();
+  });
+
+  it('skip: no truncated candidate ⇒ no fetch, no re-verify', async () => {
+    const { deps, calls } = stubDeps({});
+    const result = await runFragmentZoom(
+      deps,
+      args({ candidates: [cand(0, { lineIndex: 0, truncated: false })] }),
+    );
+    expect(result.outcome).toBe('skipped');
+    expect(calls.fetches).toHaveLength(0);
+    expect(calls.reverifies).toHaveLength(0);
+  });
+
+  it('skip: fetched text no deeper than the rendered excerpt ⇒ no re-verify', async () => {
+    const { deps, calls } = stubDeps({
+      fuller: new Map([['derived_representation:r0', 'short']]),
+    });
+    const result = await runFragmentZoom(deps, args());
+    expect(result.outcome).toBe('skipped');
+    expect(calls.reverifies).toHaveLength(0);
+  });
+
+  it('bounded: 3 truncated candidates fetch exactly the 2-fragment cap, one re-verify', async () => {
+    const { deps, calls } = stubDeps({
+      fuller: new Map([
+        ['derived_representation:r0', FULLER],
+        ['derived_representation:r1', FULLER],
+      ]),
+      reverify: PARTIAL,
+    });
+    await runFragmentZoom(
+      deps,
+      args({
+        fragmentLines: ['l0 short', 'l1 short', 'l2 short'],
+        candidates: [
+          cand(0, { lineIndex: 0, linePrefix: 'l0 ' }),
+          cand(1, { lineIndex: 1, linePrefix: 'l1 ' }),
+          cand(2, { lineIndex: 2, linePrefix: 'l2 ' }),
+        ],
+      }),
+    );
+    expect(calls.fetches[0]!.reprIds).toEqual([
+      'derived_representation:r0',
+      'derived_representation:r1',
+    ]);
+    expect(calls.reverifies).toHaveLength(1);
+  });
+
+  it('error in the fetch degrades to static: outcome error, warn, no verdict, no re-verify', async () => {
+    const { deps, calls } = stubDeps({ fetchThrows: true });
+    const result = await runFragmentZoom(deps, args());
+    expect(result.outcome).toBe('error');
+    expect(result.verdict).toBeUndefined();
+    expect(calls.reverifies).toHaveLength(0);
+    expect(calls.warns).toHaveLength(1);
+    expect(calls.outcomes).toEqual(['error']);
+  });
+
+  it('error in the re-verify degrades to static too', async () => {
+    const { deps, calls } = stubDeps({
+      fuller: new Map([['derived_representation:r0', FULLER]]),
+      reverifyThrows: true,
+    });
+    const result = await runFragmentZoom(deps, args());
+    expect(result.outcome).toBe('error');
+    expect(result.verdict).toBeUndefined();
+    expect(calls.warns).toHaveLength(1);
+  });
+});
+
+describe('fragmentZoomMaxChars — the knob envelope', () => {
+  const KEY = 'FOVEA_FRAGMENT_ZOOM_MAX_CHARS';
+  let saved: string | undefined;
+  beforeAll(() => {
+    saved = process.env[KEY];
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env[KEY];
+    else process.env[KEY] = saved;
+  });
+
+  it('unset/blank/invalid/out-of-range → the 4000 default; a valid int is honored', () => {
+    delete process.env[KEY];
+    expect(fragmentZoomMaxChars()).toBe(4000);
+    process.env[KEY] = '  ';
+    expect(fragmentZoomMaxChars()).toBe(4000);
+    process.env[KEY] = 'nope';
+    expect(fragmentZoomMaxChars()).toBe(4000);
+    process.env[KEY] = '0';
+    expect(fragmentZoomMaxChars()).toBe(4000);
+    process.env[KEY] = '2.5';
+    expect(fragmentZoomMaxChars()).toBe(4000);
+    process.env[KEY] = '100001';
+    expect(fragmentZoomMaxChars()).toBe(4000);
+    process.env[KEY] = '8000';
+    expect(fragmentZoomMaxChars()).toBe(8000);
+  });
+});

--- a/test/synthesize-verification.unit-spec.ts
+++ b/test/synthesize-verification.unit-spec.ts
@@ -1,8 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { SynthesizeService } from '../src/synthesize/synthesize.service';
+import { runVerifier } from '../src/synthesize/verifier';
 import type { SearchService } from '../src/search/search.service';
 import type { ConfigService } from '@nestjs/config';
+import type OpenAI from 'openai';
 
 /**
  * Audit W5 (engine-architecture-audit-2026-08.md #22/#24/#26):
@@ -79,21 +81,38 @@ const HITS = [
   },
 ] as never;
 
+/** Scripted auditor client for the runVerifier prompt-composition pins
+ *  (the callVerifier adapter moved into fragment-zoom-seam.ts with the
+ *  verify stage — verifyAndZoom now calls runVerifier directly, so the
+ *  W5 #22 bundle shape is pinned at the module seam). */
+function stubAuditor(captured: Captured[]): OpenAI {
+  return {
+    chat: {
+      completions: {
+        create: async (req: { messages: Array<{ role: string; content: string }> }) => {
+          captured.push({
+            system: req.messages[0]!.content,
+            user: req.messages[1]!.content,
+          });
+          return {
+            choices: [
+              {
+                message: { content: JSON.stringify({ verdict: 'supported' }) },
+                finish_reason: 'stop',
+              },
+            ],
+          };
+        },
+      },
+    },
+  } as unknown as OpenAI;
+}
+
 describe('verifier sees the whole evidence bundle (W5 #22)', () => {
   it('transcript quotes reach the auditor prompt', async () => {
     const captured: Captured[] = [];
-    const svc = makeService({
-      generatorContent: JSON.stringify({
-        answer: 'You suggested a token bucket [knowledge_fact:f1]',
-        citedFactIds: ['knowledge_fact:f1'],
-      }),
-      captured,
-    });
-    await (
-      svc as unknown as {
-        callVerifier(a: Record<string, unknown>): Promise<unknown>;
-      }
-    ).callVerifier({
+    await runVerifier({
+      openai: stubAuditor(captured),
       query: 'What did you suggest?',
       answer: 'You suggested a token bucket',
       factLines: ['[knowledge_fact:f1] activities: …'],
@@ -109,12 +128,8 @@ describe('verifier sees the whole evidence bundle (W5 #22)', () => {
 
   it('without quotes the prompt is the facts-only shape (no empty sections)', async () => {
     const captured: Captured[] = [];
-    const svc = makeService({ generatorContent: '{}', captured });
-    await (
-      svc as unknown as {
-        callVerifier(a: Record<string, unknown>): Promise<unknown>;
-      }
-    ).callVerifier({
+    await runVerifier({
+      openai: stubAuditor(captured),
       query: 'q',
       answer: 'a',
       factLines: ['[knowledge_fact:f1] x'],


### PR DESCRIPTION
## What

`FOVEA_FRAGMENT_ZOOM` (default **off**): ONE monotone, bounded, fail-safe zoom step at the post-verifier seam — the adaptive-L3 ladder shape, one lane over.

**Trigger** — the primary verifier verdict FAILS the shared flip test (`verifierPasses`: not `supported`, or supported-but-not-answering under topic coverage) AND at least one RENDERED fragment line was TRUNCATED by the lane's 600-char excerpt cap (`ZoomCandidate.truncated`, recorded at render time — no probe read).

**Action** — fetch the fuller **derived TEXT** of the same `derived_representation` rows: cited fragments first, at most `FRAGMENT_ZOOM_MAX_FRAGMENTS = 2`, per-fragment chars capped by the int knob `FOVEA_FRAGMENT_ZOOM_MAX_CHARS` (default 4000), through the lane's own fence stack re-applied per read (tenant → 0112 modality consent → asset-join user fence → media PII → availability). **Never raw bytes** — original media stays exclusively behind the `EVIDENCE_RAW_READ_ENABLED` gateway (#408); the zoom step cannot name it, stated in the docblocks.

**Re-verify ONLY** — the same audit request as the primary verifier call with only `capabilityEvidenceLines` enriched; the answer is never regenerated. A flipped verdict serves through the normal finalize path (the L3 trigger then reads `skip_verdict_ok`); no flip — or ANY error — falls through to the existing downgrade path unchanged. Zoom runs before and independent of L3 escalation, at most once per request (linear flow; a flipped verdict passes the very gate that triggers zooming).

## How

- **`src/synthesize/fragment-zoom.ts`** (new) — the pure step: truncated-only / cited-first / capped selection, prefix-fenced line substitution, deeper-only check, the IO-injected bounded runner (fetch + single re-verify ports), per-outcome metrics.
- **`src/synthesize/fragment-zoom-seam.ts`** (new) — the verify STAGE, moved whole from `synthesize.service.ts` (file/function size gates; the `resolveAnswerIntegrity` deps idiom): primary verify (LLM judge or minicheck NLI) → `verifier_error` exit → `onPrimaryVerdict` focus-capture hook (the sample sees the PRE-zoom verdict) → the zoom step. Deliberately one module: the primary audit and the zoom re-verify build their `VerifyRequest` side by side, so evidence parity holds by construction. The NLI/minicheck path skips zoom (a MiniCheck verdict is not the judge the zoom re-runs).
- **`fragment-lane.service.ts`** — `ZoomCandidate` bookkeeping in `render()` (pure, rendered bytes untouched) + the fenced `fullerTexts` read; `rowFences` extracted so retrieval and zoom share the fence text verbatim.
- **Decision telemetry (#391)** — `captureZoomDecision` (decision-emit.ts): `decisionKind: 'zoom'` is **already in the 0119 ASSERT** (`['l3_escalation','abstain','lane_route','zoom']`) and the TS union — **no migration**. One content-free row per EVALUATED step (`zoom:flipped` / `zoom:unchanged` / `skip:no_deeper` / `error`, `candidateCount`, latency); claims the primary-decision slot when free.
- **Metrics** — `brain_fragment_zoom_total{outcome=flipped|unchanged|skipped|error}`.
- **Flag plumbing** — `fovea-flags.ts` (call-time env reads, runtime-mutable), `KNOWN_BOOLEAN_FLAGS`, config catalog (boolean flag + int knob; `FOVEA_` family sits off the engine flag budget as before).

## Byte-identity when off (pinned)

- Verifier runs exactly ONCE, no extra read — e2e CONTROL pins the 2-call count and the `verifier_failed` abstain with the substrate fully populated.
- The lane's rendered lines are byte-identical (`ZoomCandidate` is bookkeeping over rows already in memory).
- The verify-stage move is verbatim (same calls, same spans, same catch); with the flag off the returned verdict IS the primary verdict.

## Tests (no paid eval — scripted verifier stubs throughout)

- `test/fragment-zoom.unit-spec.ts` — selection (truncated-only, cited-first, cap 2, dedupe), substitution prefix fence, runner flip/unchanged/skip/deeper-only/error, bounded single re-verify, knob envelope.
- `test/fragment-zoom.e2e-spec.ts` (real SurrealDB testcontainer) — CONTROL off byte-identity (2 calls), FLIP (3 calls; the re-verify prompt carries the tail beyond the 600-char cap; the SAME generated answer serves — one generator call), UNCHANGED + BOUNDED (static abstain, exactly 3 calls — no re-zoom).
- Adjusted: `engine-gates` TEST_SEAMS gains the two pure zoom seams; `synthesize-verification` W5 #22 prompt pins retargeted at `runVerifier` (the `callVerifier` adapter moved into the seam module with the stage).

## Verification

- `pnpm typecheck` — clean
- `pnpm lint:ci` — clean (0 warnings)
- Unit: **336 suites / 3546 tests passing** (full suite)
- Targeted e2e (fragment-zoom, fragment-lane, fovea-evidence-capability, fovea-answer-integrity, l3-escalation, fovea-adaptive-l3, answer-cache, answer-lang, decision-log): all passing
- Prettier: clean

## Rider: supply-chain gate unblock (separate commit)

Four high advisories against transitive `fast-uri` (<3.1.6 — host confusion / SSRF) landed in the advisory DB **after** main's last green CI run and turned the required supply-chain job red for every PR. The second commit bumps the existing `pnpm.overrides` CVE floor `fast-uri: ^3.1.5 → ^3.1.6` (patched) — lockfile-only, no direct dependency touched; `pnpm audit --audit-level=high` is clean again. Unrelated to the feature; split out as its own `chore(deps)` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
