### PR TITLE
feat(eval): first-person memory fitness harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:e2e:jobs": "jest --config ./test/jest-e2e-real.json --runInBand --testPathPatterns=jobs.real",
     "test:eval": "pnpm build && jest --config ./test/jest-e2e-real.json --runInBand --testPathPatterns=quality",
     "eval:diff": "ts-node -r tsconfig-paths/register scripts/eval-baseline-diff.ts",
+    "eval:memory-fitness": "ts-node -T test/eval/memory-fitness/runner.ts",
     "openapi:build": "ts-node -T scripts/build-openapi.ts",
     "mri:report": "ts-node -T scripts/mri-report.ts",
     "mri:record-suite": "ts-node -T scripts/mri-record-suite.ts",

--- a/test/eval/memory-fitness/README.md
+++ b/test/eval/memory-fitness/README.md
@@ -1,0 +1,119 @@
+# Memory-fitness harness
+
+First-person memory fitness for the brain: **imagine the brain is YOUR
+memory and you write into it — the most eloquent test is whether it
+works as memory.** This harness is not benchmark-QA over synthetic
+diaries. It writes one engineering agent's OWN working knowledge through
+the real wire (MCP Streamable HTTP + REST), then asks the questions the
+same agent would genuinely ask weeks later, and scores mechanically.
+
+Ground truth is authored WITH the corpus (`corpus.ts` and `questions.ts`
+are written together), so grading is self-contained and free: **no LLM
+judge, no paid eval**. The only model spend is the stand's own normal
+serving cost (mention extraction on ingest, synthesis on questions).
+
+## The eight dimensions
+
+| Dim | Name                      | What it measures                                                                                                           | Mechanical check                                                                 |
+| --- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| D1  | State currency            | A revised decision serves the CURRENT value, and the stale value does not leak                                             | expected substring present, forbidden (stale) substring absent                   |
+| D2  | Evolution history         | Superseded state is retained, not garbage-collected: old + new both in history, in order                                   | entity timeline (and, optionally, promoted belief `value` + `priorValue`)        |
+| D3  | Provenance unrollability  | A served claim unrolls to ≥1 verbatim episode quoting the seeded turn                                                      | `get_fact_provenance` walk, substring match against corpus fragments             |
+| D4  | Temporal anchors          | Dated decisions come back with their dates                                                                                 | date matcher over common phrasings of the expected `yyyy-mm-dd`                  |
+| D5  | Absence honesty           | Never-written topics yield abstention, not confabulation                                                                   | `answer === null` or the shared decline regex (`test/eval/abstain.ts`)           |
+| D6  | Conflict surfacing        | Two disagreeing sources are surfaced, not silently collapsed to one                                                        | `get_competing_facts` lists both sides; the served answer names both or abstains |
+| D7  | Cross-session integration | Questions answerable only by joining two conversations                                                                     | `search_multi_hop` (fallback `synthesize`), expected substring                   |
+| D8  | Self-utility replay       | Questions phrased exactly as a returning agent asks them ("what idiom do we use for X and why", "which numbers are taken") | key-phrase presence                                                              |
+
+## The corpus
+
+`corpus.ts` seeds 66 first-person mention-turns across 5 conversations
+(2026-03-02 … 2026-04-02) for one primary user: an engineering agent
+("Argus") building `ledger-sync`. Engineered into the text:
+
+- **four revision chains** — queue backend (Redis Streams → NATS
+  JetStream), retry policy (fixed 3×30s → exponential backoff cap 5),
+  pilot launch (2026-04-15 → 2026-05-06), deploy target (Fly.io → AWS
+  ECS Fargate);
+- **stable facts** — repo, ports 8443/9464/8081, staging namespace,
+  flag prefix, dashboard name, Meridian sandbox rate limit;
+- **one contradiction pair** — Meridian payout cutoff: Priya says
+  17:00 UTC, Meridian docs v2.3 say 16:30 UTC (deliberately left
+  unresolved);
+- **temporal anchors** — every decision carries its date in the text;
+- **cross-conversation entities** — Meridian, Priya, `ls-staging`;
+- **grounding mix** — 12 direct `record_fact` calls carrying both
+  `evidence[]` and `conversationId`, 3 deliberately ungrounded.
+
+## Running against a local stand
+
+The harness needs a booted brain (with its OpenAI key) and drives it
+purely over the wire — it is **never run in CI** (the runner exits with
+a clear message when `BRAIN_BASE_URL` is unset).
+
+Stand flags that shape coverage:
+
+- `FACTS_API_ENABLED=1` — required for D3 (`get_fact` /
+  `get_fact_provenance` tools are otherwise absent; D3 is then skipped).
+- `THROTTLE_DISABLED=1` — recommended: mention ingest is capped at
+  10/min and the MCP route at 30/min; without the flag the runner
+  backs off on 429 and a run takes much longer.
+- Optional, for the D2 belief leg: `SCENES_SEGMENTATION_ENABLED=1`,
+  `SCENES_LLM_ENRICHMENT=1`, `SCENES_FACT_BACKLINK=1`,
+  `SCENES_BELIEF_PROMOTION=1`, `BELIEFS_API_ENABLED=1`, and an API key
+  with `brain:admin` (enrich runs in-build during the scenes pass).
+  Without them the belief question is skipped, never silently passed.
+
+Then:
+
+```bash
+BRAIN_BASE_URL=http://localhost:3000 \
+BRAIN_API_KEY=<tenant M2M key: brain:read + brain:write [+ brain:admin]> \
+BRAIN_COMPANY_ID=<fresh tenant id> \
+pnpm eval:memory-fitness
+```
+
+Optional env: `MEMFIT_USER_ID` (default `memfit-agent`),
+`MEMFIT_RUN_ID` (defaults to a fresh id), `MEMFIT_GUARDRAILS`
+(`strict` | `lenient` | `off`, default `strict` — strict is the honest
+test: the brain must ground what it serves), `MEMFIT_SKIP_INGEST=1`
+(re-ask an already-ingested run; pass the same `MEMFIT_RUN_ID`),
+`MEMFIT_REPORT_DIR` (default `var/memory-fitness/`).
+
+### Idempotent re-runs
+
+Every conversation id is prefixed with the run id, so re-runs never
+collide on conversations. Facts, however, accumulate per tenant: a
+second full run re-asserts the same facts into the same graph (the
+conflict resolver dedups/supersedes, so scores usually hold, but the
+substrate is no longer a single clean write history). **Recommended:
+a fresh `BRAIN_COMPANY_ID` per scored run** — the tenant is the
+namespace, and it is operator-supplied on purpose. To re-ask questions
+without re-writing, use `MEMFIT_SKIP_INGEST=1` with the original
+`MEMFIT_RUN_ID`.
+
+## Output
+
+- A human scorecard on stdout: per-dimension pass/fail/skipped, overall
+  score over the scored (non-skipped) questions, median/max per-question
+  latency.
+- A JSON report at `var/memory-fitness/memory-fitness-<runId>.json`
+  (gitignored) with per-question status, detail, wall-clock latency,
+  and the raw served answers — every verdict is reproducible from the
+  report plus `scorers.ts`.
+
+`skipped` is an explicit verdict, reserved for stand preconditions the
+run could not satisfy (flag off, missing scope) — a skipped question is
+reported, never counted as a pass.
+
+## Self-graded philosophy
+
+The corpus and the expectations are one artifact: whoever writes the
+memory writes the answer key. That keeps grading mechanical
+(substring / date / regex / chain-walk — see `scorers.ts`, unit-tested
+in `test/memory-fitness-scorers.unit-spec.ts`) and free of judge bias:
+no paid judge, no rubric drift, and any scoring dispute is settled by
+reading the seeded turn the expectation points at. The trade-off is
+narrowness — this harness measures whether the brain works as ONE
+agent's memory on an authored history; it complements, not replaces,
+the benchmark axes under `test/eval/`.

--- a/test/eval/memory-fitness/corpus.ts
+++ b/test/eval/memory-fitness/corpus.ts
@@ -1,0 +1,307 @@
+/**
+ * First-person seeded corpus: the working memory of one engineering
+ * agent ("Argus") building the `ledger-sync` payment-reconciliation
+ * service. Everything is written in the first person because the brain
+ * under test IS this agent's memory — the corpus is what the agent
+ * chose to remember, and questions.ts asks what the same agent would
+ * ask weeks later.
+ *
+ * Engineered content (ground truth authored WITH the corpus):
+ *  - four revision chains (decision made, then changed):
+ *      A queue backend   : Redis Streams (03-02)  -> NATS JetStream (03-18)
+ *      B retry policy    : fixed 3x30s   (03-10)  -> exp backoff cap 5 (03-18)
+ *      C pilot launch    : 2026-04-15    (03-02)  -> 2026-05-06 (03-18)
+ *      D deploy target   : Fly.io        (03-02)  -> AWS ECS Fargate (03-25)
+ *  - stable facts: repo, ports (8443 / 9464 / 8081), staging namespace,
+ *    flag prefix, dashboard name, Meridian sandbox rate limit;
+ *  - one contradiction pair (two sources disagree): Meridian payout
+ *    cutoff — Priya says 17:00 UTC, Meridian docs v2.3 say 16:30 UTC;
+ *  - temporal anchors: every decision carries its date in the text;
+ *  - entities spanning conversations: Meridian (c1, c2, c4, c5),
+ *    Priya (c1, c2, c5), ls-staging (c1, c2, c5);
+ *  - grounding mix in DIRECT_FACTS: 12 record_fact calls with
+ *    evidence[] + conversationId, 3 deliberately ungrounded.
+ *
+ * Turns stay under ~550 chars so the provenance text cap (600 chars)
+ * never truncates a seeded fragment away.
+ */
+import type { CorpusTurn, DirectFact } from './types';
+
+/** The vertical every corpus write attributes itself to. */
+export const CORPUS_VERTICAL = 'engineering';
+
+/** The agent's own entity — first-person turns resolve to it. */
+export const SPEAKER = {
+  vertical: CORPUS_VERTICAL,
+  id: 'agent-argus',
+  role: 'speaker',
+  name: 'Argus',
+} as const;
+
+/** Anchor entities attached to turns that mention them. */
+export const LEDGER_SYNC_REF = { vertical: CORPUS_VERTICAL, id: 'ledger-sync' } as const;
+export const MERIDIAN_REF = { vertical: CORPUS_VERTICAL, id: 'meridian' } as const;
+
+/** Timestamp of turn N (1-based) — 5 minutes apart within a session. */
+const t = (startIso: string, turn: number): string =>
+  new Date(Date.parse(startIso) + (turn - 1) * 5 * 60_000).toISOString();
+
+const conv = (conversation: string, startIso: string, texts: string[]): CorpusTurn[] =>
+  texts.map((text, i) => ({
+    conversation,
+    turn: i + 1,
+    emittedAt: t(startIso, i + 1),
+    text,
+  }));
+
+// ── c1 — kickoff, 2026-03-02 ────────────────────────────────────────
+const C1 = conv('c1', '2026-03-02T09:00:00Z', [
+  'Kickoff log, 2026-03-02. I am starting ledger-sync, our payment-reconciliation worker. This memory is my source of truth for decisions on this project.',
+  'The repository for ledger-sync is acme/ledger-sync on GitHub. All code and runbooks live there.',
+  'Runtime decision: ledger-sync runs on Node 22 with TypeScript, package manager is pnpm.',
+  'I picked port 8443 for the ledger-sync HTTP service. That is the port the service listens on everywhere: local, staging, production.',
+  'Decision (2026-03-02): the job queue backend for ledger-sync is Redis Streams. Rationale: we already operate Redis and the team knows it.',
+  'Decision (2026-03-02): we deploy ledger-sync to Fly.io for the pilot. Cheap, fast to iterate.',
+  'The staging namespace for ledger-sync is ls-staging. Every pre-production experiment goes there, never to prod.',
+  'Decision (2026-03-02): the pilot launch date for ledger-sync is 2026-04-15. That is the commitment I gave the payments team.',
+  'Context: ledger-sync reconciles payouts against Meridian, the upstream bank API vendor. Meridian is the only external dependency of the pilot.',
+  'Convention: all ledger-sync configuration comes from environment variables validated at boot. No config files in the image.',
+  'Priya owns the Meridian integration on our side. Anything about Meridian contracts or credentials goes through Priya.',
+  'Idiom: I record every decision as a dated log entry in this memory, and when I change a decision I write the new one with its date instead of editing the old.',
+  'Kickoff done. Next session: triage of the duplicate payout report from the pilot ledger.',
+]);
+
+// ── c2 — bug hunt, 2026-03-10 ───────────────────────────────────────
+const C2 = conv('c2', '2026-03-10T10:00:00Z', [
+  'Bug-hunt log, 2026-03-10. Today I am chasing the duplicate payout bug in ledger-sync: one payout went out twice.',
+  'Symptom: payout PA-1077 was paid twice on 2026-03-08. The ledger shows two identical transfers three minutes apart.',
+  'Root cause found (2026-03-10): the retry handler re-enqueued payout jobs without an idempotency key, so a timed-out job ran twice. The duplicate payout was our own retry, not Meridian.',
+  'Fix idiom (2026-03-10): every enqueue in ledger-sync now carries idempotencyKey = sha256(payoutId + attemptDate). The worker drops any job whose key it has already processed.',
+  'Decision (2026-03-10): the retry policy for ledger-sync jobs is fixed — 3 retries with a 30s delay between attempts.',
+  'For the record: ledger-sync calls the Meridian payouts API to fetch payout status. That integration is the hot path of the service.',
+  'Constraint: the Meridian sandbox rate limit is 50 requests per minute. Exceeding it returns HTTP 429 and poisons the test run.',
+  'Priya told me today that the Meridian payout cutoff is 17:00 UTC — payouts submitted after that settle the next banking day.',
+  'I wrote a regression test that replays the double-enqueue: it fails without the idempotency key and passes with it.',
+  'Postmortem note: the duplicate payout was a missing-idempotency bug in our retry path. Meridian behaved correctly throughout.',
+  'Rule for future me: never retry a non-idempotent enqueue without an idempotency key. This is exactly how PA-1077 double-paid.',
+  'Shipped the idempotency fix in commit 9f31c2d to acme/ledger-sync.',
+  'Verified the fix in ls-staging: replayed the PA-1077 scenario, exactly one transfer went out.',
+  'Bug-hunt done. The retry policy itself still feels crude; revisiting it at the architecture review.',
+]);
+
+// ── c3 — architecture revision, 2026-03-18 ──────────────────────────
+const C3 = conv('c3', '2026-03-18T09:30:00Z', [
+  'Architecture-review log, 2026-03-18. Several kickoff decisions do not survive contact with reality; I am revising them today.',
+  'Decision (2026-03-18): the job queue backend for ledger-sync is now NATS JetStream. We need message replay and cross-region consumer groups, and JetStream gives us both.',
+  'This supersedes my 2026-03-02 decision to use Redis Streams as the queue backend. Redis Streams is no longer the queue.',
+  'Migration plan: dual-run the old and new queue until the end of the month, then cut over. No big-bang switch.',
+  'Decision (2026-03-18): the retry policy for ledger-sync is now exponential backoff with full jitter, capped at 5 attempts. This replaces the fixed 3-retries-30s policy from 2026-03-10.',
+  'Rationale for the retry change: fixed 30s retries synchronized into a thundering herd against the Meridian sandbox and tripped its rate limit.',
+  'Decision (2026-03-18): the pilot launch date for ledger-sync moves from 2026-04-15 to 2026-05-06. The JetStream migration needs the extra three weeks.',
+  'I told the payments team about the new 2026-05-06 launch date today; they signed off.',
+  'A big win of JetStream: we can finally build replay tooling — re-consume any stream from a point in time. That was impossible to do cleanly before.',
+  'Convention: JetStream subjects for ledger-sync are named LSYNC.payouts.* — one subject per payout state transition.',
+  'Action item: update the runbooks in acme/ledger-sync for the new queue and retry policy.',
+  'Risk: the team has not run JetStream in production before. I scheduled a pairing session with the platform team for next week.',
+  'Recap of 2026-03-18: queue backend is NATS JetStream, retries are exponential backoff capped at 5 attempts, pilot launch is 2026-05-06.',
+]);
+
+// ── c4 — ops and conventions, 2026-03-25 ────────────────────────────
+const C4 = conv('c4', '2026-03-25T14:00:00Z', [
+  'Ops log, 2026-03-25. Today is about observability, conventions, and the deployment target for ledger-sync.',
+  'The Prometheus metrics endpoint of ledger-sync listens on port 9464.',
+  'Our Grafana dashboard for the service is called "LedgerSync Ops". Latency, queue depth, and payout lag live there.',
+  'Convention: every ledger-sync feature flag is prefixed LSYNC_ — for example LSYNC_REPLAY_ENABLED. No unprefixed flags.',
+  'The internal admin console of ledger-sync listens on port 8081. It is never exposed publicly.',
+  'Ports taken by ledger-sync so far: 8443 for the HTTP service, 9464 for metrics, 8081 for the admin console. Pick something else for anything new.',
+  'Decision (2026-03-25): ledger-sync deploys to AWS ECS Fargate instead of Fly.io. We need VPC peering with Meridian and the compliance team wants everything inside our AWS account. This replaces the 2026-03-02 Fly.io decision.',
+  'Discrepancy found: the Meridian API docs v2.3 state the payout cutoff is 16:30 UTC. That contradicts what Priya was told (17:00 UTC). I need to resolve this with Meridian support before launch.',
+  'Alerting rule: page the on-call when payout lag exceeds 15 minutes.',
+  'Log retention for ledger-sync is 30 days in Loki.',
+  'Now that we are on ECS, secrets move to AWS SSM Parameter Store. Nothing secret in task definitions.',
+  'The JetStream cluster in ls-staging runs 3 nodes. Good enough for the pilot load test.',
+  'Ops session done. Next: integration week with the replay tooling.',
+]);
+
+// ── c5 — integration week, 2026-04-02 ───────────────────────────────
+const C5 = conv('c5', '2026-04-02T11:00:00Z', [
+  'Integration log, 2026-04-02. Replay tooling and the outbox work land this week.',
+  'Shipped the replay CLI: `pnpm replay --from <iso>` re-consumes the payout stream from our queue backend starting at that timestamp.',
+  'Idiom (2026-04-02): ledger-sync emits domain events through an outbox table — write the event in the same transaction as the state change, and a relay publishes it. We never dual-write to the queue. This idiom exists because of the duplicate-payout postmortem.',
+  'The outbox relay drains to the queue every 2 seconds. Lag beyond that shows up on the LedgerSync Ops dashboard.',
+  'Rotated the Meridian sandbox credentials today; the new ones are in SSM under /lsync/meridian/sandbox.',
+  'The PA-1077 double-payout regression test is green on the new queue backend too. The idempotency key protects the JetStream path exactly as it did before.',
+  'Staging dry-run of the pilot passed in ls-staging on 2026-04-01: zero duplicate transfers, payout lag under 4 minutes.',
+  'Launch check: we are on track for the 2026-05-06 pilot launch.',
+  'Updated the README and runbooks in acme/ledger-sync with the replay CLI and the outbox idiom.',
+  'Priya verified the Meridian integration against ECS staging today. Credentials, VPC peering, and payout status polling all work.',
+  'The outbox relay reuses the enqueue idiom: idempotencyKey = sha256(payoutId + attemptDate), so replayed events cannot double-pay.',
+  'Note to future me: the Meridian payout cutoff discrepancy (Priya: 17:00 UTC vs docs v2.3: 16:30 UTC) is still unresolved. Chase Meridian support before launch.',
+  'Integration week done. Remaining before launch: load test at 2x pilot volume and the cutoff resolution.',
+]);
+
+/** All mention turns, chronological. */
+export const CORPUS_TURNS: CorpusTurn[] = [...C1, ...C2, ...C3, ...C4, ...C5];
+
+/**
+ * Direct record_fact calls — the agent distilling its own log into
+ * structured memory. 12 grounded (evidence[] + conversationId), 3
+ * deliberately ungrounded (no evidence, no conversation) so the
+ * grounding plane has both classes to stamp.
+ *
+ * Ordered chronologically by validFrom so revision chains replay the
+ * way the agent lived them (old value recorded before its successor).
+ */
+export const DIRECT_FACTS: DirectFact[] = [
+  {
+    key: 'queue-v1',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'queue_backend',
+    object: 'Redis Streams',
+    validFrom: '2026-03-02T09:20:00Z',
+    confidence: 0.9,
+    conversation: 'c1',
+    evidence: [{ kind: 'conversation', ref: 'c1', note: 'kickoff decision log' }],
+  },
+  {
+    key: 'deploy-v1',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'deploy_target',
+    object: 'Fly.io',
+    validFrom: '2026-03-02T09:25:00Z',
+    confidence: 0.9,
+    conversation: 'c1',
+    evidence: [{ kind: 'conversation', ref: 'c1', note: 'kickoff decision log' }],
+  },
+  {
+    key: 'launch-v1',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'pilot_launch_date',
+    object: '2026-04-15',
+    validFrom: '2026-03-02T09:35:00Z',
+    confidence: 0.9,
+    conversation: 'c1',
+    evidence: [{ kind: 'conversation', ref: 'c1', note: 'commitment to the payments team' }],
+  },
+  {
+    key: 'service-port',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'service_port',
+    object: '8443',
+    validFrom: '2026-03-02T09:15:00Z',
+    confidence: 0.95,
+    conversation: 'c1',
+    evidence: [{ kind: 'message', ref: 'c1:t04', note: 'port decision turn' }],
+  },
+  {
+    key: 'repo',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'repository',
+    object: 'acme/ledger-sync',
+    validFrom: '2026-03-02T09:05:00Z',
+    confidence: 0.95,
+    conversation: 'c1',
+    evidence: [{ kind: 'url', ref: 'https://github.com/acme/ledger-sync', note: 'repository' }],
+  },
+  {
+    key: 'retry-v1',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'retry_policy',
+    object: 'fixed: 3 retries with 30s delay',
+    validFrom: '2026-03-10T10:20:00Z',
+    confidence: 0.9,
+    conversation: 'c2',
+    evidence: [{ kind: 'message', ref: 'c2:t05', note: 'retry policy decision turn' }],
+  },
+  {
+    key: 'cutoff-priya',
+    entityRef: MERIDIAN_REF,
+    predicate: 'payout_cutoff',
+    object: '17:00 UTC',
+    validFrom: '2026-03-10T10:35:00Z',
+    confidence: 0.7,
+    conversation: 'c2',
+    evidence: [{ kind: 'message', ref: 'c2:t08', note: 'Priya, relayed from Meridian onboarding' }],
+  },
+  {
+    key: 'queue-v2',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'queue_backend',
+    object: 'NATS JetStream',
+    validFrom: '2026-03-18T09:35:00Z',
+    confidence: 0.9,
+    conversation: 'c3',
+    evidence: [{ kind: 'conversation', ref: 'c3', note: 'architecture revision session' }],
+  },
+  {
+    key: 'retry-v2',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'retry_policy',
+    object: 'exponential backoff with full jitter, max 5 attempts',
+    validFrom: '2026-03-18T09:50:00Z',
+    confidence: 0.9,
+    conversation: 'c3',
+    evidence: [{ kind: 'message', ref: 'c3:t05', note: 'retry revision turn' }],
+  },
+  {
+    key: 'launch-v2',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'pilot_launch_date',
+    object: '2026-05-06',
+    validFrom: '2026-03-18T10:00:00Z',
+    confidence: 0.9,
+    conversation: 'c3',
+    evidence: [{ kind: 'conversation', ref: 'c3', note: 'launch slip, payments team signed off' }],
+  },
+  {
+    key: 'deploy-v2',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'deploy_target',
+    object: 'AWS ECS Fargate',
+    validFrom: '2026-03-25T14:30:00Z',
+    confidence: 0.9,
+    conversation: 'c4',
+    evidence: [{ kind: 'message', ref: 'c4:t07', note: 'deploy revision turn' }],
+  },
+  {
+    key: 'cutoff-docs',
+    entityRef: MERIDIAN_REF,
+    predicate: 'payout_cutoff',
+    object: '16:30 UTC',
+    validFrom: '2026-03-25T14:35:00Z',
+    confidence: 0.7,
+    conversation: 'c4',
+    evidence: [
+      {
+        kind: 'document',
+        ref: 'meridian-api-docs-v2.3',
+        note: 'Meridian API docs v2.3, settlement',
+      },
+    ],
+  },
+  // ── deliberately ungrounded (no evidence, no conversationId) ──────
+  {
+    key: 'dashboard-ungrounded',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'grafana_dashboard',
+    object: 'LedgerSync Ops',
+    validFrom: '2026-03-25T14:10:00Z',
+    confidence: 0.8,
+  },
+  {
+    key: 'flag-prefix-ungrounded',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'feature_flag_prefix',
+    object: 'LSYNC_',
+    validFrom: '2026-03-25T14:15:00Z',
+    confidence: 0.8,
+  },
+  {
+    key: 'admin-port-ungrounded',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'admin_console_port',
+    object: '8081',
+    validFrom: '2026-03-25T14:20:00Z',
+    confidence: 0.8,
+  },
+];

--- a/test/eval/memory-fitness/questions.ts
+++ b/test/eval/memory-fitness/questions.ts
@@ -1,0 +1,257 @@
+/**
+ * The question set — what the SAME agent would genuinely ask its memory
+ * weeks later, with expectations authored together with the corpus so
+ * every check is mechanical. One block per fitness dimension (D1-D8);
+ * see README.md for what each dimension measures and why.
+ */
+import type { Question } from './types';
+
+export const QUESTIONS: Question[] = [
+  // ── D1 — state currency: current value served, stale value absent ──
+  {
+    id: 'd1-queue',
+    dimension: 'D1',
+    kind: 'currency',
+    prompt: 'What is the current job queue backend for ledger-sync?',
+    expectAnyOf: ['JetStream', 'NATS'],
+    forbidAnyOf: ['Redis'],
+  },
+  {
+    id: 'd1-retry',
+    dimension: 'D1',
+    kind: 'currency',
+    prompt: 'What retry policy does ledger-sync use for jobs right now?',
+    expectAnyOf: ['exponential'],
+    forbidAnyOf: ['fixed', '30s delay', '30 second'],
+  },
+  {
+    id: 'd1-launch',
+    dimension: 'D1',
+    kind: 'currency',
+    prompt: 'When is the ledger-sync pilot launching?',
+    expectAnyOf: ['2026-05-06', 'May 6', '6 May'],
+    forbidAnyOf: ['2026-04-15', 'April 15', '15 April'],
+  },
+  {
+    id: 'd1-deploy',
+    dimension: 'D1',
+    kind: 'currency',
+    prompt: 'Where does ledger-sync deploy to?',
+    expectAnyOf: ['ECS', 'Fargate'],
+    forbidAnyOf: ['Fly.io'],
+  },
+
+  // ── D2 — evolution history: old + new both retained, ordered ──────
+  {
+    id: 'd2-queue',
+    dimension: 'D2',
+    kind: 'evolution',
+    prompt: 'How has the ledger-sync queue backend decision evolved?',
+    entityQuery: 'ledger-sync queue backend',
+    predicate: 'queue_backend',
+    oldMarkers: ['Redis Streams'],
+    newMarkers: ['JetStream'],
+  },
+  {
+    id: 'd2-retry',
+    dimension: 'D2',
+    kind: 'evolution',
+    prompt: 'How has the ledger-sync retry policy evolved?',
+    entityQuery: 'ledger-sync retry policy',
+    predicate: 'retry_policy',
+    oldMarkers: ['fixed'],
+    newMarkers: ['exponential'],
+  },
+  {
+    id: 'd2-launch',
+    dimension: 'D2',
+    kind: 'evolution',
+    prompt: 'How has the ledger-sync pilot launch date moved?',
+    entityQuery: 'ledger-sync pilot launch date',
+    predicate: 'pilot_launch_date',
+    oldMarkers: ['2026-04-15'],
+    newMarkers: ['2026-05-06'],
+  },
+  {
+    id: 'd2-beliefs',
+    dimension: 'D2',
+    kind: 'belief-evolution',
+    prompt: 'Does the promoted belief about the queue backend carry its prior value?',
+    valueMarkers: ['JetStream', 'NATS'],
+    priorMarkers: ['Redis'],
+  },
+
+  // ── D3 — provenance unrollability: claim -> episode -> seeded turn ─
+  {
+    id: 'd3-idempotency',
+    dimension: 'D3',
+    kind: 'provenance',
+    prompt: 'Provenance of the duplicate-payout root cause reaches the bug-hunt turn.',
+    searchQuery: 'duplicate payout root cause idempotency key retry',
+    predicateHint: '',
+    episodeFragments: ['idempotency'],
+  },
+  {
+    id: 'd3-ratelimit',
+    dimension: 'D3',
+    kind: 'provenance',
+    prompt: 'Provenance of the Meridian sandbox rate limit reaches the constraint turn.',
+    searchQuery: 'Meridian sandbox rate limit requests per minute',
+    predicateHint: '',
+    episodeFragments: ['50 requests per minute'],
+  },
+  {
+    id: 'd3-outbox',
+    dimension: 'D3',
+    kind: 'provenance',
+    prompt: 'Provenance of the outbox idiom reaches the integration-week turn.',
+    searchQuery: 'outbox table domain events dual-write',
+    predicateHint: '',
+    episodeFragments: ['outbox'],
+  },
+
+  // ── D4 — temporal anchors: dated decisions come back dated ────────
+  {
+    id: 'd4-nats-date',
+    dimension: 'D4',
+    kind: 'temporal',
+    prompt: 'When did we decide to switch the ledger-sync queue to NATS JetStream?',
+    expectDate: '2026-03-18',
+  },
+  {
+    id: 'd4-rootcause-date',
+    dimension: 'D4',
+    kind: 'temporal',
+    prompt: 'When did we find the root cause of the duplicate payout bug?',
+    expectDate: '2026-03-10',
+  },
+  {
+    id: 'd4-kickoff-date',
+    dimension: 'D4',
+    kind: 'temporal',
+    prompt: 'When did the ledger-sync project kick off?',
+    expectDate: '2026-03-02',
+  },
+  {
+    id: 'd4-launch-date',
+    dimension: 'D4',
+    kind: 'temporal',
+    prompt: 'What is the current pilot launch date for ledger-sync?',
+    expectDate: '2026-05-06',
+  },
+
+  // ── D5 — absence honesty: never-written topics must abstain ───────
+  {
+    id: 'd5-warehouse',
+    dimension: 'D5',
+    kind: 'absence',
+    prompt: 'What database does the ledger-sync analytics warehouse use?',
+  },
+  {
+    id: 'd5-oncall',
+    dimension: 'D5',
+    kind: 'absence',
+    prompt: 'Who leads the on-call rotation for ledger-sync?',
+  },
+  {
+    id: 'd5-mobile',
+    dimension: 'D5',
+    kind: 'absence',
+    prompt: 'What did we decide about the ledger-sync mobile client SDK?',
+  },
+  {
+    id: 'd5-sla',
+    dimension: 'D5',
+    kind: 'absence',
+    prompt: "What is Meridian's production API latency SLA?",
+  },
+  {
+    id: 'd5-postgres',
+    dimension: 'D5',
+    kind: 'absence',
+    prompt: 'Which Postgres version does ledger-sync run in production?',
+  },
+
+  // ── D6 — conflict surfacing: both sides of the cutoff disagreement ─
+  {
+    id: 'd6-competing-api',
+    dimension: 'D6',
+    kind: 'conflict-api',
+    prompt: 'The competing-facts API lists both payout-cutoff sources for Meridian.',
+    entityQuery: 'Meridian payout cutoff',
+    predicate: 'payout_cutoff',
+    sideA: ['17:00'],
+    sideB: ['16:30'],
+  },
+  {
+    id: 'd6-answer',
+    dimension: 'D6',
+    kind: 'conflict-answer',
+    prompt: "What is Meridian's payout cutoff time?",
+    sideA: ['17:00'],
+    sideB: ['16:30'],
+  },
+
+  // ── D7 — cross-session integration: join two conversations ────────
+  {
+    id: 'd7-port',
+    dimension: 'D7',
+    kind: 'integration',
+    prompt: 'What port does the service that talks to the Meridian API listen on?',
+    expectAnyOf: ['8443'],
+  },
+  {
+    id: 'd7-replay',
+    dimension: 'D7',
+    kind: 'integration',
+    prompt: 'Which queue backend does the replay CLI re-consume the payout stream from?',
+    expectAnyOf: ['JetStream', 'NATS'],
+  },
+  {
+    id: 'd7-vendor',
+    dimension: 'D7',
+    kind: 'integration',
+    prompt: 'Which vendor API does the service launching on 2026-05-06 integrate with?',
+    expectAnyOf: ['Meridian'],
+  },
+
+  // ── D8 — self-utility replay: asked exactly as a returning agent ──
+  {
+    id: 'd8-enqueue-idiom',
+    dimension: 'D8',
+    kind: 'replay',
+    prompt: 'What idiom do we use for enqueueing jobs in ledger-sync, and why?',
+    keyPhrases: [
+      ['idempotencyKey', 'idempotency key', 'idempotency'],
+      ['duplicate', 'double'],
+    ],
+  },
+  {
+    id: 'd8-ports-taken',
+    dimension: 'D8',
+    kind: 'replay',
+    prompt: 'Which ports are already taken on the ledger-sync deployment?',
+    keyPhrases: ['8443', '9464', '8081'],
+  },
+  {
+    id: 'd8-flag-prefix',
+    dimension: 'D8',
+    kind: 'replay',
+    prompt: 'What is the naming convention for ledger-sync feature flags?',
+    keyPhrases: ['LSYNC_'],
+  },
+  {
+    id: 'd8-events-pattern',
+    dimension: 'D8',
+    kind: 'replay',
+    prompt: 'How should I emit domain events from the database — what is our pattern?',
+    keyPhrases: ['outbox'],
+  },
+  {
+    id: 'd8-ratelimit',
+    dimension: 'D8',
+    kind: 'replay',
+    prompt: 'What Meridian sandbox rate limit do I need to respect?',
+    keyPhrases: ['50'],
+  },
+];

--- a/test/eval/memory-fitness/runner.ts
+++ b/test/eval/memory-fitness/runner.ts
@@ -1,0 +1,716 @@
+/**
+ * Memory-fitness runner — drives EVERYTHING through the real wire:
+ *
+ *  - REST  POST /v1/ingest/mention            (corpus turns, per-user scoped)
+ *  - MCP   record_fact                        (direct facts, grounding mix)
+ *  - REST  POST /v1/admin/maintenance/scenes | scenes/backlink | scenes/beliefs
+ *          (best-effort admin builds; enrich runs in-build when
+ *          SCENES_LLM_ENRICHMENT is on; 404 = flag off = the dependent
+ *          question is skipped, never silently passed)
+ *  - MCP   synthesize / search_knowledge / search_multi_hop /
+ *          get_entity_timeline / get_fact_provenance / get_competing_facts
+ *  - REST  GET /v1/beliefs                    (belief read API)
+ *
+ * Scoring is fully mechanical (see scorers.ts) — no LLM judge. The
+ * serving calls cost normal model spend on the stand; the harness
+ * itself spends nothing on judging.
+ *
+ * Run: pnpm eval:memory-fitness   (see README.md for stand flags)
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { HttpBrainClient } from '../http-brain-client';
+import {
+  CORPUS_TURNS,
+  CORPUS_VERTICAL,
+  DIRECT_FACTS,
+  LEDGER_SYNC_REF,
+  MERIDIAN_REF,
+  SPEAKER,
+} from './corpus';
+import { QUESTIONS } from './questions';
+import {
+  checkEvolution,
+  classifyConflictAnswer,
+  containsAnyOf,
+  findForbidden,
+  isAbstention,
+  matchesDate,
+  missingKeyPhrases,
+  walkProvenance,
+  type EvolutionEvent,
+} from './scorers';
+import type { DimensionTally, Dimension, Question, QuestionResult, Scorecard } from './types';
+
+// ── configuration ───────────────────────────────────────────────────
+
+interface Config {
+  baseUrl: string;
+  apiKey: string;
+  companyId: string;
+  userId: string;
+  runId: string;
+  guardrails: 'strict' | 'lenient' | 'off';
+  skipIngest: boolean;
+  reportDir: string;
+}
+
+function loadConfig(): Config {
+  const baseUrl = process.env.BRAIN_BASE_URL ?? process.env.BRAIN_URL;
+  const apiKey = process.env.BRAIN_API_KEY;
+  const companyId = process.env.BRAIN_COMPANY_ID;
+  if (baseUrl === undefined || baseUrl === '') {
+    console.error(
+      [
+        'memory-fitness: BRAIN_BASE_URL is not set — nothing to run against.',
+        'This harness drives a LIVE brain stand over MCP + REST (it needs a booted',
+        'service and its OpenAI key) and is intentionally never run in CI.',
+        '',
+        'Required env:',
+        '  BRAIN_BASE_URL   e.g. http://localhost:3000  (BRAIN_URL also accepted)',
+        '  BRAIN_API_KEY    tenant M2M key with brain:read + brain:write',
+        '                   (+ brain:admin for the optional scene/belief builds)',
+        '  BRAIN_COMPANY_ID tenant id — use a FRESH tenant per run (see README.md)',
+        '',
+        'Optional env: MEMFIT_USER_ID, MEMFIT_RUN_ID, MEMFIT_GUARDRAILS',
+        '(strict|lenient|off, default strict), MEMFIT_SKIP_INGEST=1 (re-ask an',
+        'already-ingested run — requires the same MEMFIT_RUN_ID), MEMFIT_REPORT_DIR.',
+      ].join('\n'),
+    );
+    process.exit(1);
+  }
+  if (apiKey === undefined || apiKey === '') {
+    console.error('memory-fitness: BRAIN_API_KEY is not set.');
+    process.exit(1);
+  }
+  if (companyId === undefined || companyId === '') {
+    console.error('memory-fitness: BRAIN_COMPANY_ID is not set.');
+    process.exit(1);
+  }
+  const guardrailsRaw = process.env.MEMFIT_GUARDRAILS ?? 'strict';
+  if (guardrailsRaw !== 'strict' && guardrailsRaw !== 'lenient' && guardrailsRaw !== 'off') {
+    console.error(`memory-fitness: MEMFIT_GUARDRAILS must be strict|lenient|off.`);
+    process.exit(1);
+  }
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ''),
+    apiKey,
+    companyId,
+    userId: process.env.MEMFIT_USER_ID ?? 'memfit-agent',
+    runId: process.env.MEMFIT_RUN_ID ?? `mf${Date.now().toString(36)}`,
+    guardrails: guardrailsRaw,
+    skipIngest: process.env.MEMFIT_SKIP_INGEST === '1',
+    reportDir: process.env.MEMFIT_REPORT_DIR ?? join('var', 'memory-fitness'),
+  };
+}
+
+// ── small utilities ─────────────────────────────────────────────────
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Retry on throttle (HTTP 429) — mention ingest and the MCP route are rate-capped. */
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      const msg = String(err);
+      if (attempt < 12 && /429|too many requests/i.test(msg)) {
+        console.error(`  [throttled] ${label} — waiting 6.5s (attempt ${attempt})`);
+        await sleep(6_500);
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/** Run-scoped conversation id — makes re-runs non-colliding by construction. */
+const convId = (cfg: Config, key: string): string => `${cfg.runId}-${key}`;
+
+const messageId = (cfg: Config, key: string, turn: number): string =>
+  `${convId(cfg, key)}-t${String(turn).padStart(2, '0')}`;
+
+/** Expand corpus-local evidence refs (`c3`, `c2:t08`) to run-scoped ids. */
+function expandEvidenceRef(cfg: Config, kind: string, ref: string): string {
+  if (kind === 'conversation' && /^c\d$/.test(ref)) return convId(cfg, ref);
+  const m = /^(c\d):t(\d+)$/.exec(ref);
+  if (kind === 'message' && m !== null && m[1] !== undefined && m[2] !== undefined) {
+    return messageId(cfg, m[1], Number(m[2]));
+  }
+  return ref;
+}
+
+// ── REST (raw, non-throwing — admin builds and belief reads need the status) ──
+
+interface RestResult<T> {
+  status: number;
+  json: T | null;
+}
+
+async function restRaw<T>(
+  cfg: Config,
+  method: 'GET' | 'POST',
+  path: string,
+  body?: unknown,
+): Promise<RestResult<T>> {
+  const res = await fetch(`${cfg.baseUrl}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${cfg.apiKey}`,
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  const ct = res.headers.get('content-type') ?? '';
+  if (!ct.includes('application/json')) return { status: res.status, json: null };
+  return { status: res.status, json: (await res.json()) as T };
+}
+
+// ── MCP ─────────────────────────────────────────────────────────────
+
+interface ToolCallShape {
+  isError?: boolean;
+  content?: unknown;
+  structuredContent?: unknown;
+}
+
+function textOf(res: ToolCallShape): string | null {
+  if (!Array.isArray(res.content)) return null;
+  for (const item of res.content) {
+    if (
+      item !== null &&
+      typeof item === 'object' &&
+      (item as { type?: unknown }).type === 'text' &&
+      typeof (item as { text?: unknown }).text === 'string'
+    ) {
+      return (item as { text: string }).text;
+    }
+  }
+  return null;
+}
+
+async function connectMcp(cfg: Config): Promise<McpClient> {
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`${cfg.baseUrl}/mcp/${cfg.companyId}`),
+    { requestInit: { headers: { Authorization: `Bearer ${cfg.apiKey}` } } },
+  );
+  const client = new McpClient({ name: 'memory-fitness-harness', version: '1.0.0' });
+  // Same @modelcontextprotocol/sdk .d.ts self-inconsistency the server
+  // side bridges in src/mcp/mcp.controller.ts: under
+  // exactOptionalPropertyTypes the concrete transport class no longer
+  // structurally satisfies its own Transport interface. The runtime
+  // value genuinely is a valid Transport; this asserts the SDK's own
+  // contract, not our types.
+  await client.connect(transport as Transport);
+  return client;
+}
+
+async function callTool<T>(
+  mcp: McpClient,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const raw = (await withRetry(name, () =>
+    mcp.callTool({ name, arguments: args }),
+  )) as ToolCallShape;
+  const text = textOf(raw);
+  if (raw.isError === true) {
+    throw new Error(`MCP tool ${name} failed: ${text ?? '(no error text)'}`);
+  }
+  if (text !== null) return JSON.parse(text) as T;
+  if (raw.structuredContent !== undefined) return raw.structuredContent as T;
+  throw new Error(`MCP tool ${name} returned neither text nor structuredContent`);
+}
+
+// Local wire shapes — only the fields the scorers consume.
+interface SearchHit {
+  entityId: string;
+  canonicalName?: string;
+  facts?: Array<{ factId: string; predicate: string; object: string }>;
+}
+interface SearchOut {
+  results?: SearchHit[];
+}
+interface SynthOut {
+  answer: string | null;
+  reason?: string;
+}
+interface MultiHopOut {
+  synthesis?: { answer: string | null; reason?: string };
+}
+interface TimelineOut {
+  events?: Array<{ type: string; at: string; predicate?: string; object?: string }>;
+}
+interface CompetingOut {
+  groups?: Array<{ predicate: string; facts?: Array<{ object: string }> }>;
+}
+interface ProvenanceOut {
+  factId?: string;
+  episodes?: Array<{ episodeId?: string; text?: string }>;
+}
+interface BeliefsOut {
+  beliefs?: Array<{ subject: string; field: string; value: string; priorValue?: string }>;
+}
+interface RecordFactOut {
+  factId: string | null;
+  outcome?: string;
+}
+
+// ── phase 1: write the agent's memory ───────────────────────────────
+
+async function ingestCorpus(cfg: Config, brain: HttpBrainClient): Promise<void> {
+  console.error(`[ingest] ${CORPUS_TURNS.length} mention turns (run ${cfg.runId})…`);
+  for (const [i, turn] of CORPUS_TURNS.entries()) {
+    const knownEntities: Array<Record<string, string>> = [
+      { ...SPEAKER },
+      { ...LEDGER_SYNC_REF, name: 'ledger-sync' },
+    ];
+    if (turn.text.includes('Meridian')) {
+      knownEntities.push({ ...MERIDIAN_REF, name: 'Meridian' });
+    }
+    await withRetry(`mention ${turn.conversation}#${turn.turn}`, () =>
+      brain.ingest.mention({
+        text: turn.text,
+        contextRef: {
+          vertical: CORPUS_VERTICAL,
+          conversationId: convId(cfg, turn.conversation),
+          messageId: messageId(cfg, turn.conversation, turn.turn),
+          recorder: 'memory-fitness-harness',
+        },
+        knownEntities,
+        userId: cfg.userId,
+        emittedAt: turn.emittedAt,
+      }),
+    );
+    if ((i + 1) % 10 === 0) console.error(`[ingest] ${i + 1}/${CORPUS_TURNS.length}`);
+  }
+}
+
+async function recordDirectFacts(cfg: Config, mcp: McpClient): Promise<void> {
+  console.error(`[record] ${DIRECT_FACTS.length} direct record_fact calls…`);
+  for (const fact of DIRECT_FACTS) {
+    const args: Record<string, unknown> = {
+      entityRef: fact.entityRef,
+      predicate: fact.predicate,
+      object: fact.object,
+      validFrom: fact.validFrom,
+      sourceVertical: CORPUS_VERTICAL,
+      userId: cfg.userId,
+    };
+    if (fact.validUntil !== undefined) args.validUntil = fact.validUntil;
+    if (fact.confidence !== undefined) args.confidence = fact.confidence;
+    if (fact.conversation !== undefined) args.conversationId = convId(cfg, fact.conversation);
+    if (fact.evidence !== undefined) {
+      args.evidence = fact.evidence.map((ev) => ({
+        kind: ev.kind,
+        ref: expandEvidenceRef(cfg, ev.kind, ev.ref),
+        ...(ev.note !== undefined ? { note: ev.note } : {}),
+      }));
+    }
+    const out = await callTool<RecordFactOut>(mcp, 'record_fact', args);
+    console.error(`[record] ${fact.key}: ${out.outcome ?? 'ok'}`);
+  }
+}
+
+async function runBuilds(cfg: Config): Promise<Record<string, string>> {
+  // scenes -> (enrich happens in-build when SCENES_LLM_ENRICHMENT is on)
+  // -> backlink -> beliefs. Every step is best-effort: a 404 means the
+  // stand runs without that flag and the dependent question is SKIPPED.
+  const builds: Record<string, string> = {};
+  for (const step of ['scenes', 'scenes/backlink', 'scenes/beliefs']) {
+    const res = await restRaw<Record<string, unknown>>(
+      cfg,
+      'POST',
+      `/v1/admin/maintenance/${step}`,
+      {},
+    );
+    builds[step] =
+      res.status === 404
+        ? 'skipped: 404 (scene flag off)'
+        : res.status === 403
+          ? 'skipped: 403 (key lacks brain:admin)'
+          : res.status >= 200 && res.status < 300
+            ? 'ok'
+            : `error: HTTP ${res.status}`;
+    console.error(`[build] ${step}: ${builds[step]}`);
+  }
+  return builds;
+}
+
+// ── phase 2: ask and score ──────────────────────────────────────────
+
+interface AskContext {
+  cfg: Config;
+  mcp: McpClient;
+  tools: Set<string>;
+  builds: Record<string, string>;
+}
+
+async function synthesizeAnswer(ctx: AskContext, query: string): Promise<SynthOut> {
+  return callTool<SynthOut>(ctx.mcp, 'synthesize', {
+    query,
+    limit: 15,
+    synthesisGuardrails: ctx.cfg.guardrails,
+    userId: ctx.cfg.userId,
+  });
+}
+
+async function searchHits(ctx: AskContext, query: string, limit: number): Promise<SearchHit[]> {
+  const out = await callTool<SearchOut>(ctx.mcp, 'search_knowledge', {
+    query,
+    limit,
+    userId: ctx.cfg.userId,
+  });
+  return out.results ?? [];
+}
+
+/** Resolve the entity that carries `predicate`, else best-name match. */
+async function resolveEntityId(
+  ctx: AskContext,
+  query: string,
+  predicate?: string,
+): Promise<string | null> {
+  const hits = await searchHits(ctx, query, 10);
+  if (predicate !== undefined) {
+    const withPredicate = hits.find((h) => (h.facts ?? []).some((f) => f.predicate === predicate));
+    if (withPredicate !== undefined) return withPredicate.entityId;
+  }
+  return hits[0]?.entityId ?? null;
+}
+
+type Verdict = Pick<QuestionResult, 'status' | 'detail'> & { answer?: string | null };
+
+async function askOne(ctx: AskContext, q: Question): Promise<Verdict> {
+  switch (q.kind) {
+    case 'currency': {
+      const out = await synthesizeAnswer(ctx, q.prompt);
+      if (isAbstention(out.answer, out.reason)) {
+        return { status: 'fail', detail: 'abstained on a known value', answer: out.answer };
+      }
+      const answer = out.answer ?? '';
+      const stale = findForbidden(answer, q.forbidAnyOf);
+      if (stale !== null) {
+        return { status: 'fail', detail: `stale value served: "${stale}"`, answer };
+      }
+      return containsAnyOf(answer, q.expectAnyOf)
+        ? { status: 'pass', detail: 'current value served, stale value absent', answer }
+        : { status: 'fail', detail: `expected one of [${q.expectAnyOf.join(', ')}]`, answer };
+    }
+    case 'evolution': {
+      const entityId = await resolveEntityId(ctx, q.entityQuery, q.predicate);
+      if (entityId === null) return { status: 'fail', detail: 'entity not found via search' };
+      const timeline = await callTool<TimelineOut>(ctx.mcp, 'get_entity_timeline', { entityId });
+      const events: EvolutionEvent[] = (timeline.events ?? [])
+        .filter((e) => e.type === 'fact.recorded')
+        .map((e) => ({ predicate: e.predicate ?? '', object: e.object ?? '', at: e.at }));
+      const verdict = checkEvolution(events, q.predicate, q.oldMarkers, q.newMarkers);
+      return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
+    }
+    case 'belief-evolution': {
+      if (ctx.builds['scenes/beliefs'] !== 'ok') {
+        return {
+          status: 'skipped',
+          detail: `belief build not run (${ctx.builds['scenes/beliefs'] ?? 'no build phase'})`,
+        };
+      }
+      const res = await restRaw<BeliefsOut>(
+        ctx.cfg,
+        'GET',
+        `/v1/beliefs?userId=${encodeURIComponent(ctx.cfg.userId)}&limit=50`,
+      );
+      if (res.status === 404) {
+        return { status: 'skipped', detail: 'BELIEFS_API_ENABLED off (404)' };
+      }
+      const beliefs = res.json?.beliefs ?? [];
+      const match = beliefs.find(
+        (b) =>
+          containsAnyOf(b.value, q.valueMarkers) &&
+          b.priorValue !== undefined &&
+          containsAnyOf(b.priorValue, q.priorMarkers),
+      );
+      return match !== undefined
+        ? {
+            status: 'pass',
+            detail: `belief (${match.subject}, ${match.field}) holds value + priorValue`,
+          }
+        : { status: 'fail', detail: `no belief carries value+priorValue (${beliefs.length} read)` };
+    }
+    case 'provenance': {
+      if (!ctx.tools.has('get_fact_provenance')) {
+        return { status: 'skipped', detail: 'get_fact_provenance absent (FACTS_API_ENABLED off)' };
+      }
+      const hits = await searchHits(ctx, q.searchQuery, 8);
+      const factIds: string[] = [];
+      for (const hit of hits) {
+        for (const fact of hit.facts ?? []) {
+          if (q.predicateHint !== undefined && q.predicateHint !== '') {
+            if (!fact.predicate.includes(q.predicateHint)) continue;
+          }
+          factIds.push(fact.factId);
+        }
+      }
+      const candidates = factIds.slice(0, 6);
+      if (candidates.length === 0) {
+        return { status: 'fail', detail: 'search returned no candidate facts' };
+      }
+      for (const factId of candidates) {
+        const prov = await callTool<ProvenanceOut>(ctx.mcp, 'get_fact_provenance', { factId });
+        const match = walkProvenance(prov, q.episodeFragments);
+        if (match !== null) {
+          return {
+            status: 'pass',
+            detail: `fact ${factId} unrolls to episode ${match.episodeId} ("${match.fragment}")`,
+          };
+        }
+      }
+      return {
+        status: 'fail',
+        detail: `${candidates.length} facts walked, no episode quotes a seeded fragment`,
+      };
+    }
+    case 'temporal': {
+      const out = await synthesizeAnswer(ctx, q.prompt);
+      if (isAbstention(out.answer, out.reason)) {
+        return { status: 'fail', detail: 'abstained on a dated decision', answer: out.answer };
+      }
+      const answer = out.answer ?? '';
+      return matchesDate(answer, q.expectDate)
+        ? { status: 'pass', detail: `date ${q.expectDate} served`, answer }
+        : { status: 'fail', detail: `expected date ${q.expectDate}`, answer };
+    }
+    case 'absence': {
+      const out = await synthesizeAnswer(ctx, q.prompt);
+      return isAbstention(out.answer, out.reason)
+        ? { status: 'pass', detail: 'honest abstention on never-written topic', answer: out.answer }
+        : { status: 'fail', detail: 'confabulated an answer', answer: out.answer };
+    }
+    case 'conflict-api': {
+      const entityId = await resolveEntityId(ctx, q.entityQuery, q.predicate);
+      if (entityId === null) return { status: 'fail', detail: 'entity not found via search' };
+      const out = await callTool<CompetingOut>(ctx.mcp, 'get_competing_facts', {
+        entityId,
+        predicate: q.predicate,
+      });
+      const group = (out.groups ?? []).find((g) => g.predicate === q.predicate);
+      const objects = (group?.facts ?? []).map((f) => f.object).join(' | ');
+      const hasA = containsAnyOf(objects, q.sideA);
+      const hasB = containsAnyOf(objects, q.sideB);
+      if (hasA && hasB) {
+        return { status: 'pass', detail: `both sides competing: [${objects}]` };
+      }
+      return {
+        status: 'fail',
+        detail:
+          group === undefined
+            ? 'no competing group for the predicate (conflict auto-resolved?)'
+            : `competing group lists only [${objects}]`,
+      };
+    }
+    case 'conflict-answer': {
+      const out = await synthesizeAnswer(ctx, q.prompt);
+      const verdict = classifyConflictAnswer(out.answer, q.sideA, q.sideB, out.reason);
+      switch (verdict) {
+        case 'both-sides':
+          return { status: 'pass', detail: 'answer names both sides', answer: out.answer };
+        case 'abstained':
+          return {
+            status: 'pass',
+            detail: 'abstained rather than pick a side silently',
+            answer: out.answer,
+          };
+        case 'one-sided':
+          return {
+            status: 'fail',
+            detail: 'served one side of a live conflict',
+            answer: out.answer,
+          };
+        case 'neither':
+          return { status: 'fail', detail: 'answer names neither side', answer: out.answer };
+      }
+      break;
+    }
+    case 'integration': {
+      let answer: string | null;
+      let reason: string | undefined;
+      if (ctx.tools.has('search_multi_hop')) {
+        const out = await callTool<MultiHopOut>(ctx.mcp, 'search_multi_hop', {
+          query: q.prompt,
+          synthesize: true,
+          synthesisGuardrails: ctx.cfg.guardrails,
+          userId: ctx.cfg.userId,
+        });
+        answer = out.synthesis?.answer ?? null;
+        reason = out.synthesis?.reason;
+      } else {
+        const out = await synthesizeAnswer(ctx, q.prompt);
+        answer = out.answer;
+        reason = out.reason;
+      }
+      if (isAbstention(answer, reason)) {
+        return { status: 'fail', detail: 'abstained on a cross-session join', answer };
+      }
+      return containsAnyOf(answer ?? '', q.expectAnyOf)
+        ? { status: 'pass', detail: 'joined across conversations', answer }
+        : { status: 'fail', detail: `expected one of [${q.expectAnyOf.join(', ')}]`, answer };
+    }
+    case 'replay': {
+      const out = await synthesizeAnswer(ctx, q.prompt);
+      if (isAbstention(out.answer, out.reason)) {
+        return { status: 'fail', detail: 'abstained on working knowledge', answer: out.answer };
+      }
+      const missing = missingKeyPhrases(out.answer ?? '', q.keyPhrases);
+      return missing.length === 0
+        ? { status: 'pass', detail: 'all key phrases present', answer: out.answer }
+        : { status: 'fail', detail: `missing: ${missing.join('; ')}`, answer: out.answer };
+    }
+  }
+  return { status: 'fail', detail: 'unreachable question kind' };
+}
+
+async function askAll(ctx: AskContext): Promise<QuestionResult[]> {
+  const results: QuestionResult[] = [];
+  for (const q of QUESTIONS) {
+    const started = Date.now();
+    let verdict: Verdict;
+    try {
+      verdict = await askOne(ctx, q);
+    } catch (err) {
+      verdict = { status: 'fail', detail: `runner error: ${String(err)}` };
+    }
+    const latencyMs = Date.now() - started;
+    const result: QuestionResult = {
+      id: q.id,
+      dimension: q.dimension,
+      prompt: q.prompt,
+      status: verdict.status,
+      detail: verdict.detail,
+      latencyMs,
+      ...(verdict.answer !== undefined ? { answer: verdict.answer } : {}),
+    };
+    results.push(result);
+    console.error(
+      `[ask] ${q.id} (${q.dimension}) ${verdict.status} ${latencyMs}ms — ${verdict.detail}`,
+    );
+  }
+  return results;
+}
+
+// ── scorecard ───────────────────────────────────────────────────────
+
+const DIMENSION_LABELS: Record<Dimension, string> = {
+  D1: 'state currency',
+  D2: 'evolution history',
+  D3: 'provenance unrollability',
+  D4: 'temporal anchors',
+  D5: 'absence honesty',
+  D6: 'conflict surfacing',
+  D7: 'cross-session integration',
+  D8: 'self-utility replay',
+};
+
+function buildScorecard(
+  cfg: Config,
+  startedAt: string,
+  builds: Record<string, string>,
+  questions: QuestionResult[],
+): Scorecard {
+  const dimensions = {} as Record<Dimension, DimensionTally>;
+  for (const d of Object.keys(DIMENSION_LABELS) as Dimension[]) {
+    dimensions[d] = { pass: 0, fail: 0, skipped: 0 };
+  }
+  const overall = { pass: 0, fail: 0, skipped: 0, total: questions.length };
+  for (const r of questions) {
+    const bucket = r.status === 'pass' ? 'pass' : r.status === 'fail' ? 'fail' : 'skipped';
+    dimensions[r.dimension][bucket] += 1;
+    overall[bucket] += 1;
+  }
+  return {
+    runId: cfg.runId,
+    baseUrl: cfg.baseUrl,
+    companyId: cfg.companyId,
+    userId: cfg.userId,
+    guardrails: cfg.guardrails,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    ingest: {
+      mentionTurns: cfg.skipIngest ? 0 : CORPUS_TURNS.length,
+      directFacts: cfg.skipIngest ? 0 : DIRECT_FACTS.length,
+      builds,
+    },
+    dimensions,
+    overall,
+    questions,
+  };
+}
+
+function printScorecard(card: Scorecard): void {
+  console.log('');
+  console.log(`memory-fitness scorecard — run ${card.runId} (guardrails=${card.guardrails})`);
+  console.log('─'.repeat(72));
+  for (const d of Object.keys(DIMENSION_LABELS) as Dimension[]) {
+    const t = card.dimensions[d];
+    const label = DIMENSION_LABELS[d];
+    console.log(
+      `${d}  ${label.padEnd(26)} pass ${t.pass}  fail ${t.fail}` +
+        (t.skipped > 0 ? `  skipped ${t.skipped}` : ''),
+    );
+  }
+  console.log('─'.repeat(72));
+  const scored = card.overall.pass + card.overall.fail;
+  const pct = scored === 0 ? 0 : Math.round((card.overall.pass / scored) * 1000) / 10;
+  console.log(
+    `overall: ${card.overall.pass}/${scored} scored (${pct}%), ` +
+      `${card.overall.skipped} skipped of ${card.overall.total}`,
+  );
+  const latencies = card.questions.map((q) => q.latencyMs).sort((a, b) => a - b);
+  const mid = latencies[Math.floor(latencies.length / 2)];
+  const max = latencies[latencies.length - 1];
+  if (mid !== undefined && max !== undefined) {
+    console.log(`latency: median ${mid}ms, max ${max}ms per question`);
+  }
+}
+
+// ── main ────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  const startedAt = new Date().toISOString();
+  console.error(
+    `memory-fitness: run ${cfg.runId} against ${cfg.baseUrl} (tenant ${cfg.companyId})`,
+  );
+
+  const brain = new HttpBrainClient({ baseUrl: cfg.baseUrl, apiKey: cfg.apiKey });
+  const mcp = await connectMcp(cfg);
+  try {
+    const toolList = await withRetry('tools/list', () => mcp.listTools());
+    const tools = new Set(toolList.tools.map((t) => t.name));
+    console.error(`[mcp] connected, ${tools.size} tools visible`);
+
+    let builds: Record<string, string> = { scenes: 'skipped: MEMFIT_SKIP_INGEST' };
+    if (!cfg.skipIngest) {
+      await ingestCorpus(cfg, brain);
+      await recordDirectFacts(cfg, mcp);
+      builds = await runBuilds(cfg);
+    }
+
+    const questions = await askAll({ cfg, mcp, tools, builds });
+    const card = buildScorecard(cfg, startedAt, builds, questions);
+
+    mkdirSync(cfg.reportDir, { recursive: true });
+    const reportPath = join(cfg.reportDir, `memory-fitness-${cfg.runId}.json`);
+    writeFileSync(reportPath, `${JSON.stringify(card, null, 2)}\n`);
+    printScorecard(card);
+    console.log(`report: ${reportPath}`);
+  } finally {
+    await mcp.close();
+  }
+}
+
+void main().catch((err: unknown) => {
+  console.error('memory-fitness: runner failed:', err);
+  process.exitCode = 1;
+});

--- a/test/eval/memory-fitness/scorers.ts
+++ b/test/eval/memory-fitness/scorers.ts
@@ -1,0 +1,197 @@
+/**
+ * Mechanical scorers of the memory-fitness harness. Pure functions over
+ * plain JSON — no HTTP, no LLM judge — so they are unit-testable on
+ * fixtures (test/memory-fitness-scorers.unit-spec.ts) and every verdict
+ * is reproducible from the report file.
+ */
+import { ABSTAIN_RE } from '../abstain';
+
+const norm = (s: string): string => s.toLowerCase();
+
+/** Case-insensitive: does `text` contain at least one of `needles`? */
+export function containsAnyOf(text: string, needles: readonly string[]): boolean {
+  const t = norm(text);
+  return needles.some((n) => t.includes(norm(n)));
+}
+
+/** Case-insensitive: first forbidden needle present in `text`, else null. */
+export function findForbidden(text: string, needles: readonly string[]): string | null {
+  const t = norm(text);
+  for (const n of needles) {
+    if (t.includes(norm(n))) return n;
+  }
+  return null;
+}
+
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const;
+
+/**
+ * Accepted phrasings of a `yyyy-mm-dd` date. Substring-matched, so
+ * "March 18" also covers "March 18th" and "March 18, 2026".
+ */
+export function dateVariants(iso: string): string[] {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (!m) throw new Error(`dateVariants: expected yyyy-mm-dd, got "${iso}"`);
+  const [, year, month, day] = m;
+  if (year === undefined || month === undefined || day === undefined) {
+    throw new Error(`dateVariants: unparseable "${iso}"`);
+  }
+  const monthName = MONTHS[Number(month) - 1];
+  if (monthName === undefined) throw new Error(`dateVariants: bad month in "${iso}"`);
+  const shortMonth = monthName.slice(0, 3);
+  const bareDay = String(Number(day));
+  return [
+    iso,
+    `${year}/${month}/${day}`,
+    `${monthName} ${bareDay}`,
+    `${bareDay} ${monthName}`,
+    `${shortMonth} ${bareDay}`,
+    `${bareDay} ${shortMonth}`,
+  ];
+}
+
+/** Does the answer name the expected `yyyy-mm-dd` date in any phrasing? */
+export function matchesDate(text: string, iso: string): boolean {
+  return containsAnyOf(text, dateVariants(iso));
+}
+
+/**
+ * Abstention detector: a null/empty answer, or the shared decline
+ * regex (test/eval/abstain.ts — covers the brain's own guardrail
+ * sentinel), or an explicit abstain reason.
+ */
+export function isAbstention(answer: string | null | undefined, reason?: string): boolean {
+  if (answer === null || answer === undefined) return true;
+  if (answer.trim().length === 0) return true;
+  if (ABSTAIN_RE.test(answer)) return true;
+  return reason !== undefined && /abstain|no_facts|unsupported|partial/i.test(reason);
+}
+
+/** Minimal provenance shape the walker needs (mirrors FactProvenanceResult). */
+export interface ProvenanceLike {
+  factId?: string;
+  episodes?: Array<{ episodeId?: string; text?: string }>;
+}
+
+export interface ProvenanceMatch {
+  episodeId: string;
+  fragment: string;
+}
+
+/**
+ * Provenance walker: does any grounding episode's verbatim text contain
+ * one of the seeded corpus fragments? Returns the first match, so a
+ * pass names the exact episode + fragment in the report.
+ */
+export function walkProvenance(
+  prov: ProvenanceLike,
+  fragments: readonly string[],
+): ProvenanceMatch | null {
+  const episodes = prov.episodes ?? [];
+  for (const ep of episodes) {
+    const text = ep.text;
+    if (typeof text !== 'string') continue;
+    for (const fragment of fragments) {
+      if (norm(text).includes(norm(fragment))) {
+        return { episodeId: ep.episodeId ?? '(unknown episode)', fragment };
+      }
+    }
+  }
+  return null;
+}
+
+/** One timeline event as the evolution checker consumes it. */
+export interface EvolutionEvent {
+  predicate: string;
+  object: string;
+  /** ISO timestamp the event was recorded/valid at. */
+  at: string;
+}
+
+export interface EvolutionVerdict {
+  pass: boolean;
+  detail: string;
+}
+
+/**
+ * Evolution checker: within one predicate's history, the old value and
+ * the new value are BOTH retained, and the old one precedes the new
+ * one. A memory that garbage-collects superseded state fails here even
+ * when D1 passes.
+ */
+export function checkEvolution(
+  events: readonly EvolutionEvent[],
+  predicate: string,
+  oldMarkers: readonly string[],
+  newMarkers: readonly string[],
+): EvolutionVerdict {
+  const relevant = events.filter((e) => e.predicate === predicate);
+  const firstOld = relevant.find((e) => containsAnyOf(e.object, oldMarkers));
+  const firstNew = relevant.find((e) => containsAnyOf(e.object, newMarkers));
+  if (!firstOld && !firstNew) {
+    return { pass: false, detail: `no ${predicate} events matched either value` };
+  }
+  if (!firstOld) return { pass: false, detail: 'old value missing from history' };
+  if (!firstNew) return { pass: false, detail: 'new value missing from history' };
+  if (Date.parse(firstOld.at) > Date.parse(firstNew.at)) {
+    return { pass: false, detail: 'history orders the new value before the old one' };
+  }
+  return {
+    pass: true,
+    detail: `history retains "${firstOld.object}" -> "${firstNew.object}" in order`,
+  };
+}
+
+/**
+ * Key-phrase scorer (D8): every group must be satisfied; a plain string
+ * is a required substring, an array is an any-of group. Returns the
+ * missing groups (empty = pass).
+ */
+export function missingKeyPhrases(
+  text: string,
+  groups: ReadonlyArray<string | string[]>,
+): string[] {
+  const missing: string[] = [];
+  for (const group of groups) {
+    const alternatives = Array.isArray(group) ? group : [group];
+    if (!containsAnyOf(text, alternatives)) {
+      missing.push(alternatives.join(' | '));
+    }
+  }
+  return missing;
+}
+
+export type ConflictAnswerVerdict = 'both-sides' | 'abstained' | 'one-sided' | 'neither';
+
+/**
+ * Conflict-answer classifier (D6): with two live contradictory sources
+ * the honest behaviours are naming both sides or abstaining; silently
+ * serving exactly one side is the failure being measured.
+ */
+export function classifyConflictAnswer(
+  answer: string | null | undefined,
+  sideA: readonly string[],
+  sideB: readonly string[],
+  reason?: string,
+): ConflictAnswerVerdict {
+  if (isAbstention(answer, reason)) return 'abstained';
+  const text = answer ?? '';
+  const hasA = containsAnyOf(text, sideA);
+  const hasB = containsAnyOf(text, sideB);
+  if (hasA && hasB) return 'both-sides';
+  if (hasA || hasB) return 'one-sided';
+  return 'neither';
+}

--- a/test/eval/memory-fitness/types.ts
+++ b/test/eval/memory-fitness/types.ts
@@ -1,0 +1,189 @@
+/**
+ * Shared shapes of the memory-fitness harness.
+ *
+ * The harness treats the brain as the FIRST-PERSON memory of one
+ * engineering agent: the corpus is what the agent wrote into its own
+ * memory, the questions are what the same agent would genuinely ask
+ * later, and every expectation is authored together with the corpus so
+ * scoring stays mechanical (no LLM judge).
+ */
+
+/** One first-person mention turn the agent writes into its memory. */
+export interface CorpusTurn {
+  /** Conversation key (`c1`..`c5`) — the runner prefixes it with the run id. */
+  conversation: string;
+  /** 1-based position inside the conversation (drives the messageId). */
+  turn: number;
+  /** ISO 8601 emission timestamp — the temporal anchor of the turn. */
+  emittedAt: string;
+  /** Verbatim first-person text. Kept under the 600-char provenance cap. */
+  text: string;
+}
+
+/** Evidence pointer accepted by the `record_fact` MCP tool. */
+export interface DirectFactEvidence {
+  kind: 'event' | 'message' | 'conversation' | 'url' | 'document' | 'commit' | 'other';
+  ref: string;
+  note?: string;
+}
+
+/** One direct `record_fact` call (the grounding-mix half of the corpus). */
+export interface DirectFact {
+  /** Stable key for logs and the report file. */
+  key: string;
+  entityRef: { vertical: string; id: string };
+  predicate: string;
+  object: string;
+  /** ISO 8601 datetime. */
+  validFrom: string;
+  validUntil?: string;
+  confidence?: number;
+  /**
+   * Conversation key this fact was observed in — the runner expands it
+   * to the run-scoped conversationId (grounds the claim). Absent on the
+   * deliberately ungrounded facts.
+   */
+  conversation?: string;
+  /** Typed evidence pointers; absent on the deliberately ungrounded facts. */
+  evidence?: DirectFactEvidence[];
+}
+
+export type Dimension = 'D1' | 'D2' | 'D3' | 'D4' | 'D5' | 'D6' | 'D7' | 'D8';
+
+interface QuestionBase {
+  id: string;
+  dimension: Dimension;
+  /** The question exactly as the returning agent would ask it. */
+  prompt: string;
+}
+
+/** D1 — state currency: current value served, stale value absent. */
+export interface CurrencyQuestion extends QuestionBase {
+  kind: 'currency';
+  /** Answer passes when it contains at least one of these. */
+  expectAnyOf: string[];
+  /** Answer fails when it contains any of these (the stale value). */
+  forbidAnyOf: string[];
+}
+
+/** D2 — evolution history via the entity timeline (old + new, ordered). */
+export interface EvolutionQuestion extends QuestionBase {
+  kind: 'evolution';
+  /** search_knowledge query used to resolve the entity. */
+  entityQuery: string;
+  predicate: string;
+  /** Markers of the earlier value (anyOf). */
+  oldMarkers: string[];
+  /** Markers of the later value (anyOf). */
+  newMarkers: string[];
+}
+
+/** D2 (belief leg) — the promoted belief carries value + priorValue. */
+export interface BeliefEvolutionQuestion extends QuestionBase {
+  kind: 'belief-evolution';
+  /** Markers the CURRENT belief value must match (anyOf). */
+  valueMarkers: string[];
+  /** Markers the priorValue must match (anyOf). */
+  priorMarkers: string[];
+}
+
+/** D3 — provenance unrollability: a served fact unrolls to a seeded turn. */
+export interface ProvenanceQuestion extends QuestionBase {
+  kind: 'provenance';
+  searchQuery: string;
+  /** Prefer facts whose predicate contains this substring, else any hit. */
+  predicateHint?: string;
+  /**
+   * Case-insensitive fragments seeded in the corpus turns; the walk
+   * passes when ≥1 provenance episode's text matches ≥1 fragment.
+   */
+  episodeFragments: string[];
+}
+
+/** D4 — temporal anchor: the served answer names the expected date. */
+export interface TemporalQuestion extends QuestionBase {
+  kind: 'temporal';
+  /** Expected date as `yyyy-mm-dd`; the scorer accepts common phrasings. */
+  expectDate: string;
+}
+
+/** D5 — absence honesty: never-written topic must yield abstention. */
+export interface AbsenceQuestion extends QuestionBase {
+  kind: 'absence';
+}
+
+/** D6 — conflict surfacing via the competing-facts API. */
+export interface ConflictApiQuestion extends QuestionBase {
+  kind: 'conflict-api';
+  entityQuery: string;
+  predicate: string;
+  sideA: string[];
+  sideB: string[];
+}
+
+/** D6 — conflict surfacing in the served answer. */
+export interface ConflictAnswerQuestion extends QuestionBase {
+  kind: 'conflict-answer';
+  sideA: string[];
+  sideB: string[];
+}
+
+/** D7 — cross-session integration (joins two conversations). */
+export interface IntegrationQuestion extends QuestionBase {
+  kind: 'integration';
+  expectAnyOf: string[];
+}
+
+/** D8 — self-utility replay, scored by key-phrase presence. */
+export interface ReplayQuestion extends QuestionBase {
+  kind: 'replay';
+  /**
+   * Every group must be satisfied; a string is a required substring, a
+   * string[] is an any-of group.
+   */
+  keyPhrases: Array<string | string[]>;
+}
+
+export type Question =
+  | CurrencyQuestion
+  | EvolutionQuestion
+  | BeliefEvolutionQuestion
+  | ProvenanceQuestion
+  | TemporalQuestion
+  | AbsenceQuestion
+  | ConflictApiQuestion
+  | ConflictAnswerQuestion
+  | IntegrationQuestion
+  | ReplayQuestion;
+
+/** Per-question outcome in the scorecard / JSON report. */
+export interface QuestionResult {
+  id: string;
+  dimension: Dimension;
+  prompt: string;
+  status: 'pass' | 'fail' | 'skipped';
+  detail: string;
+  latencyMs: number;
+  /** Raw served answer, when the question was answer-shaped. */
+  answer?: string | null;
+}
+
+export interface DimensionTally {
+  pass: number;
+  fail: number;
+  skipped: number;
+}
+
+export interface Scorecard {
+  runId: string;
+  baseUrl: string;
+  companyId: string;
+  userId: string;
+  guardrails: string;
+  startedAt: string;
+  finishedAt: string;
+  ingest: { mentionTurns: number; directFacts: number; builds: Record<string, string> };
+  dimensions: Record<Dimension, DimensionTally>;
+  overall: DimensionTally & { total: number };
+  questions: QuestionResult[];
+}

--- a/test/memory-fitness-scorers.unit-spec.ts
+++ b/test/memory-fitness-scorers.unit-spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit sanity for the memory-fitness scorers (test/eval/memory-fitness/
+ * scorers.ts) — the mechanical judges of the harness. Pure fixtures, no
+ * HTTP: if these are wrong, every scorecard is wrong, so they get their
+ * own spec even though the harness itself never runs in CI.
+ */
+import {
+  checkEvolution,
+  classifyConflictAnswer,
+  containsAnyOf,
+  dateVariants,
+  findForbidden,
+  isAbstention,
+  matchesDate,
+  missingKeyPhrases,
+  walkProvenance,
+} from './eval/memory-fitness/scorers';
+
+describe('memory-fitness scorers', () => {
+  describe('containsAnyOf / findForbidden', () => {
+    it('matches case-insensitively', () => {
+      expect(containsAnyOf('We moved to NATS JetStream.', ['jetstream'])).toBe(true);
+      expect(containsAnyOf('We moved to NATS JetStream.', ['Redis'])).toBe(false);
+    });
+
+    it('names the first forbidden needle present', () => {
+      expect(findForbidden('The queue is Redis Streams.', ['Redis'])).toBe('Redis');
+      expect(findForbidden('The queue is NATS.', ['Redis'])).toBeNull();
+    });
+  });
+
+  describe('date matcher', () => {
+    it('builds the accepted phrasings of an ISO date', () => {
+      expect(dateVariants('2026-03-18')).toEqual([
+        '2026-03-18',
+        '2026/03/18',
+        'March 18',
+        '18 March',
+        'Mar 18',
+        '18 Mar',
+      ]);
+    });
+
+    it('accepts common phrasings, including ordinal suffixes via substring', () => {
+      expect(matchesDate('We decided on 2026-03-18.', '2026-03-18')).toBe(true);
+      expect(matchesDate('Decided on March 18th, 2026.', '2026-03-18')).toBe(true);
+      expect(matchesDate('It happened on 18 March.', '2026-03-18')).toBe(true);
+      expect(matchesDate('Launch slipped to May 6.', '2026-05-06')).toBe(true);
+    });
+
+    it('rejects other dates', () => {
+      expect(matchesDate('We decided on 2026-04-15.', '2026-03-18')).toBe(false);
+      expect(matchesDate('No date here at all.', '2026-03-18')).toBe(false);
+    });
+
+    it('throws on a non yyyy-mm-dd expectation', () => {
+      expect(() => dateVariants('March 18')).toThrow(/yyyy-mm-dd/);
+    });
+  });
+
+  describe('abstention detector', () => {
+    it('treats null / empty answers as abstention', () => {
+      expect(isAbstention(null)).toBe(true);
+      expect(isAbstention(undefined)).toBe(true);
+      expect(isAbstention('   ')).toBe(true);
+    });
+
+    it('recognizes decline phrasings including the guardrail sentinel', () => {
+      expect(isAbstention("I don't have grounded evidence for that.")).toBe(true);
+      expect(isAbstention('There is no record of an on-call lead.')).toBe(true);
+      expect(isAbstention('I cannot determine the SLA from memory.')).toBe(true);
+    });
+
+    it('recognizes an abstain reason on a null-ish serving', () => {
+      expect(isAbstention('some text', 'no_facts')).toBe(true);
+    });
+
+    it('does not flag a substantive answer', () => {
+      expect(isAbstention('The service listens on port 8443.')).toBe(false);
+    });
+  });
+
+  describe('provenance walker', () => {
+    const prov = {
+      factId: 'knowledge_fact:abc',
+      episodes: [
+        { episodeId: 'memory_episode:e1', text: 'Kickoff log, 2026-03-02. Starting ledger-sync.' },
+        {
+          episodeId: 'memory_episode:e2',
+          text: 'every enqueue now carries idempotencyKey = sha256(payoutId + attemptDate)',
+        },
+      ],
+    };
+
+    it('finds the episode quoting a seeded fragment', () => {
+      expect(walkProvenance(prov, ['idempotency'])).toEqual({
+        episodeId: 'memory_episode:e2',
+        fragment: 'idempotency',
+      });
+    });
+
+    it('returns null when no episode quotes a fragment', () => {
+      expect(walkProvenance(prov, ['outbox'])).toBeNull();
+    });
+
+    it('handles empty / malformed provenance without throwing', () => {
+      expect(walkProvenance({}, ['idempotency'])).toBeNull();
+      expect(walkProvenance({ episodes: [{ episodeId: 'e3' }] }, ['idempotency'])).toBeNull();
+    });
+  });
+
+  describe('evolution checker', () => {
+    const events = [
+      { predicate: 'queue_backend', object: 'Redis Streams', at: '2026-03-02T09:20:00Z' },
+      { predicate: 'service_port', object: '8443', at: '2026-03-02T09:15:00Z' },
+      { predicate: 'queue_backend', object: 'NATS JetStream', at: '2026-03-18T09:35:00Z' },
+    ];
+
+    it('passes when both values are retained in order', () => {
+      const v = checkEvolution(events, 'queue_backend', ['Redis Streams'], ['JetStream']);
+      expect(v.pass).toBe(true);
+    });
+
+    it('fails when the old value was garbage-collected', () => {
+      const onlyNew = events.filter((e) => e.object !== 'Redis Streams');
+      const v = checkEvolution(onlyNew, 'queue_backend', ['Redis Streams'], ['JetStream']);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toMatch(/old value missing/);
+    });
+
+    it('fails when history orders new before old', () => {
+      const flipped = [
+        { predicate: 'queue_backend', object: 'NATS JetStream', at: '2026-03-01T00:00:00Z' },
+        { predicate: 'queue_backend', object: 'Redis Streams', at: '2026-03-18T00:00:00Z' },
+      ];
+      const v = checkEvolution(flipped, 'queue_backend', ['Redis Streams'], ['JetStream']);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toMatch(/orders/);
+    });
+
+    it('fails distinctly when the predicate has no matching events', () => {
+      const v = checkEvolution(events, 'retry_policy', ['fixed'], ['exponential']);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toMatch(/no retry_policy events/);
+    });
+  });
+
+  describe('key-phrase scorer', () => {
+    it('satisfies plain strings and any-of groups', () => {
+      const text = 'Ports 8443 and 9464 are taken; use the idempotency key idiom.';
+      expect(missingKeyPhrases(text, ['8443', ['idempotencyKey', 'idempotency key']])).toEqual([]);
+    });
+
+    it('reports each unsatisfied group', () => {
+      expect(missingKeyPhrases('Nothing useful.', ['8443', ['a', 'b']])).toEqual(['8443', 'a | b']);
+    });
+  });
+
+  describe('conflict-answer classifier', () => {
+    it('classifies all four behaviours', () => {
+      expect(
+        classifyConflictAnswer('Sources disagree: 17:00 UTC vs 16:30 UTC.', ['17:00'], ['16:30']),
+      ).toBe('both-sides');
+      expect(classifyConflictAnswer('The cutoff is 17:00 UTC.', ['17:00'], ['16:30'])).toBe(
+        'one-sided',
+      );
+      expect(classifyConflictAnswer(null, ['17:00'], ['16:30'])).toBe('abstained');
+      expect(classifyConflictAnswer('The cutoff is noon.', ['17:00'], ['16:30'])).toBe('neither');
+    });
+  });
+});


### PR DESCRIPTION
## What

A self-graded **memory-fitness harness** under `test/eval/memory-fitness/`. The framing: the brain is an agent's OWN memory — the most eloquent test is whether it works as memory. The harness writes one engineering agent's working knowledge through the real wire (MCP Streamable HTTP + REST), then asks the 30 questions the same agent would genuinely ask weeks later, and scores mechanically. Ground truth is authored WITH the corpus — **no LLM judge, no paid eval**; serving calls cost normal model spend only.

## The corpus (`corpus.ts`)

66 first-person mention turns across 5 conversations (2026-03-02…04-02) for one primary user, engineered to contain:

- **4 revision chains** — queue backend (Redis Streams → NATS JetStream), retry policy (fixed 3×30s → exponential backoff cap 5), pilot launch (2026-04-15 → 2026-05-06), deploy target (Fly.io → AWS ECS);
- **stable facts** (repo, ports, namespaces, conventions), **a two-source contradiction pair** (payout cutoff 17:00 vs 16:30 UTC), **dated decisions**, **entities spanning conversations**;
- **grounding mix**: 12 direct `record_fact` calls with `evidence[]` + `conversationId`, 3 deliberately ungrounded.

## The questions (`questions.ts`) — eight dimensions

| Dim | Measures | Check |
| --- | --- | --- |
| D1 | state currency | current value present, stale value forbidden |
| D2 | evolution history | timeline retains old + new in order (+ optional belief `value`/`priorValue` leg) |
| D3 | provenance unrollability | `get_fact_provenance` reaches an episode quoting the seeded turn |
| D4 | temporal anchors | expected date strings (variant-tolerant matcher) |
| D5 | absence honesty | never-written topics → abstention, not confabulation |
| D6 | conflict surfacing | competing-facts API lists both sides / answer names both or abstains |
| D7 | cross-session integration | answerable only by joining two conversations (`search_multi_hop`) |
| D8 | self-utility replay | returning-agent phrasing, key-phrase presence |

## The runner (`runner.ts`)

Everything over the real wire: MCP (`record_fact`, `search_knowledge`, `synthesize`, `search_multi_hop`, `get_entity_timeline`, `get_fact`/`get_fact_provenance`, `get_competing_facts`) + REST (`/v1/ingest/mention`, `/v1/admin/maintenance/scenes` → backlink → beliefs with enrich in-build, `/v1/beliefs`). Config via `BRAIN_BASE_URL` (`BRAIN_URL` accepted), `BRAIN_API_KEY`, `BRAIN_COMPANY_ID`. Outputs a per-dimension scorecard + per-question wall-clock latency + a JSON report under `var/` (gitignored). Run-scoped conversation ids make re-runs non-colliding; a fresh tenant per scored run is the documented recommendation (`MEMFIT_SKIP_INGEST=1` re-asks an existing run).

Stand preconditions degrade honestly: `FACTS_API_ENABLED` off → D3 **skipped** (tool absent by design), scene/belief flags off or no `brain:admin` → belief leg **skipped** — skipped is an explicit verdict, never a silent pass. Throttle-aware (429 backoff; `THROTTLE_DISABLED=1` recommended on the stand).

## CI

The harness never runs in CI: the runner exits 1 with a clear message when `BRAIN_BASE_URL` is unset. What CI does run is the scorer unit spec (`test/memory-fitness-scorers.unit-spec.ts`, 20 tests — date matcher, abstention detector on the shared `ABSTAIN_RE`, provenance walker on fixture JSON, evolution/order checker, conflict classifier).

## Verification

- `pnpm typecheck` green (tsconfig.spec covers `test/eval/memory-fitness/`)
- `pnpm lint:ci` green (0 warnings), `pnpm format:check` green
- unit spec 20/20
- no-env invocation prints the required-env message and exits 1

## How to run against a local stand

```bash
BRAIN_BASE_URL=http://localhost:3000 \
BRAIN_API_KEY=<tenant M2M key: brain:read + brain:write [+ brain:admin]> \
BRAIN_COMPANY_ID=<fresh tenant id> \
pnpm eval:memory-fitness
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB