### PR TITLE
feat(beliefs): belief-aware serving lane with belief citations

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -2230,6 +2230,28 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       "Belief read API (Belief-B): GET /v1/beliefs/:id serves one semantic_belief revision as stored (free-text subject/field key, value/priorValue, statement, confidence, revision/status/supersededBy supersede chain, validFrom/validUntil, inline sourceSceneIds provenance, corroboration counters, promoterVersion) and GET /v1/beliefs lists by subject/field/status/userId with a capped page (default 25, max 100). Read-only — the Belief-A promotion pass (SCENES_BELIEF_PROMOTION) stays the only writer. Every miss is a 404 — tenant fence + fail-closed single-user scope (#387: a belief is always one user's; a user-bound token sees only its own, an unstamped row serves to no one); beliefs carry no piiClass and no registry predicate, so no PII/row-policy fence applies. Off (default) → routes answer 404.",
   },
   {
+    key: 'BELIEFS_SERVING_LANE',
+    category: 'pipeline',
+    // Read at call time (common/beliefs-flags.ts) — never captured in a
+    // constructor — so a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Belief serving lane (repeals the 0120 shadow doctrine behind this default-off flag): synthesize retrieves the caller's ACTIVE semantic_belief rows matching the query (BM25 over the 0126 statement index + a dense leg that stays empty while embedding is write-dead) and renders them as a current-state prompt section for BOTH generator and verifier; the generator schema gains citedBeliefIds and cited ids resolve through the rendered-set fence into belief-arm evidenceCitations (so a belief-grounded answer passes FOVEA_REQUIRE_CITATIONS and carries unrollable provenance); 0107 outcome rows land under subjectKind 'belief'. SCOPED-USER-ONLY: the lane fires only when synthesize is called with a userId — an unscoped/M2M request serves NO belief lines (stricter than GET /v1/beliefs by design: blending one user's state into an unscoped answer is a cross-user leak). Off (default) → no query, no section, no schema field — prompts and serving byte-identical.",
+  },
+  {
+    key: 'BELIEFS_FACT_DAMPING',
+    category: 'pipeline',
+    // Read at call time (common/beliefs-flags.ts) — never captured in a
+    // constructor — so a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Belief-aware fact damping (PR-B; the resolver ships with the lane, the damping pass lands in the follow-up PR — until then NOTHING reads this flag): prompt-side suffix + stable demotion of fact lines that a matched current belief contradicts, applied to the SAME lines generator and verifier read. Requires BELIEFS_SERVING_LANE (a no-op without the lane’s matched beliefs — boot validation warns on the inconsistent pair). Off (default) → byte-identical.',
+  },
+  {
     key: 'PROVENANCE_SUMMARY_EPISODE_STAMP',
     category: 'pipeline',
     defaultValue: '0',

--- a/src/answer-cache/answer-cache.service.ts
+++ b/src/answer-cache/answer-cache.service.ts
@@ -317,6 +317,11 @@ export class AnswerCacheService {
    * rejected by the gate below. Check-on-read revalidates cited FACT
    * rows against the live substrate and cannot (yet) invalidate episode
    * citations, so caching such an answer would make it uninvalidatable.
+   * The BELIEF arm (BELIEFS_SERVING_LANE) rides the same doctrine: a
+   * belief-only-cited current-state answer has citations.length 0 and
+   * is rejected here too — check-on-read cannot invalidate a belief
+   * citation against the supersede chain, so caching it would serve a
+   * stale current-state answer past the next revision.
    */
   async admit(
     ctx: AnswerCacheStoreContext,

--- a/src/common/beliefs-flags.ts
+++ b/src/common/beliefs-flags.ts
@@ -1,0 +1,44 @@
+import { envFlagEnabled } from './env-validation';
+
+/**
+ * Belief serving lane — BELIEFS_SERVING_LANE.
+ *
+ * When on, the synthesize-side belief lane (BeliefLaneService) retrieves
+ * the caller's ACTIVE semantic_belief rows matching the query (BM25 over
+ * the 0126 statement index + a brute-cosine dense leg that degrades to
+ * empty while the embedding column is write-dead) and renders them as a
+ * current-state prompt section for BOTH the generator and the verifier;
+ * the generator's strict schema gains `citedBeliefIds`, resolved through
+ * the rendered-set fence into belief-arm EvidenceCitations. This repeals
+ * the 0120 shadow doctrine ("nothing on the serving path reads this
+ * table") BEHIND this default-off flag. The lane fires ONLY for a
+ * user-scoped request (dto.userId) — beliefs are single-user rows and an
+ * unscoped answer must never blend one user's state in (stricter than
+ * the read API's M2M tenant read; see BeliefLaneService). The env read
+ * lives here in the common layer, NOT inside the engine dirs
+ * (engine-gates S5.2). Read at call time so a flip is runtime-mutable
+ * (no restart). Default off ⇒ no query, no section, no schema field —
+ * byte-identical prompts and serving. BELIEFS_ family sits off the
+ * ENGINE flag budget by design (a substrate serving switch, not an
+ * engine fork).
+ */
+export function beliefServingLaneEnabled(): boolean {
+  return envFlagEnabled(process.env.BELIEFS_SERVING_LANE);
+}
+
+/**
+ * Belief-aware fact damping — BELIEFS_FACT_DAMPING (PR-B; resolver stub
+ * shipped with the lane so the config catalog, boot validation and the
+ * inconsistent-pair WARN cover the family from day one).
+ *
+ * When on (AND the serving lane is on — a no-op without the lane's
+ * matched beliefs; env-validation warns on the inconsistent pair), the
+ * prompt-side damping pass suffixes and demotes fact lines that a
+ * matched current belief contradicts. NOTHING reads this resolver yet:
+ * the damping module lands in the follow-up PR. Read at call time
+ * (runtime-mutable); common layer per engine-gates S5.2. Default off ⇒
+ * byte-identical.
+ */
+export function beliefFactDampingEnabled(): boolean {
+  return envFlagEnabled(process.env.BELIEFS_FACT_DAMPING);
+}

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -264,6 +264,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // ── Evidence plane: processing lifecycle (migration 0121) ──────────
   validateEvidenceProcessingEnv(env, warnings);
 
+  // ── Belief serving: damping requires the lane ──────────────────────
+  validateBeliefServingEnv(env, warnings);
+
   // ── Evidence plane: raw-read gateway (MM-3, migration 0125) ────────
   validateEvidenceRawReadEnv(env, errors, warnings);
 
@@ -445,6 +448,23 @@ function validateEvidenceProcessingEnv(env: NodeJS.ProcessEnv, warnings: string[
       'EVIDENCE_PROCESSOR_BROKER is set while EVIDENCE_SUBSTRATE_ENABLED is not — ' +
         'the broker writes derived representations through the substrate seam; every ' +
         'dispatch will be rejected (503) until EVIDENCE_SUBSTRATE_ENABLED is turned on.',
+    );
+  }
+}
+
+/**
+ * Belief serving (BELIEFS_SERVING_LANE / BELIEFS_FACT_DAMPING): damping
+ * suffixes fact lines that a matched current belief contradicts — with
+ * the lane off there ARE no matched beliefs, so damping-on-while-lane-off
+ * is a silent no-op (the validateEvidenceProcessingEnv inconsistent-pair
+ * idiom: warn, don't refuse).
+ */
+function validateBeliefServingEnv(env: NodeJS.ProcessEnv, warnings: string[]): void {
+  if (envFlagEnabled(env.BELIEFS_FACT_DAMPING) && !envFlagEnabled(env.BELIEFS_SERVING_LANE)) {
+    warnings.push(
+      'BELIEFS_FACT_DAMPING is set while BELIEFS_SERVING_LANE is not — damping keys off ' +
+        'the serving lane’s matched beliefs, so it is a no-op until BELIEFS_SERVING_LANE ' +
+        'is turned on.',
     );
   }
 }
@@ -656,6 +676,14 @@ const KNOWN_BOOLEAN_FLAGS = [
   // the semantic_belief substrate (0120). Read-only — the promotion pass
   // stays the only writer. Default off → routes 404.
   'BELIEFS_API_ENABLED',
+  // Belief serving lane: synthesize renders the caller's ACTIVE beliefs
+  // as a current-state prompt section + belief-arm citations (0126;
+  // repeals the 0120 shadow doctrine behind this default-off flag).
+  'BELIEFS_SERVING_LANE',
+  // Belief-aware fact damping (PR-B — the resolver stub ships with the
+  // lane; nothing reads it until the damping pass lands). Requires
+  // BELIEFS_SERVING_LANE (inconsistent-pair WARN below).
+  'BELIEFS_FACT_DAMPING',
   // Raw-substrate driver v1 surface 3: projections registry API + rebuild verb.
   'PROJECTIONS_API_ENABLED',
   // Raw-substrate driver v1 surface 4: new-episode webhook push (watermark

--- a/src/db/migrations/0126_belief_serving_search.surql
+++ b/src/db/migrations/0126_belief_serving_search.surql
@@ -1,0 +1,28 @@
+-- 0126: belief serving search — the lexical + (future) dense legs of the
+-- synthesize-side belief lane (BELIEFS_SERVING_LANE, default off).
+--
+-- WHY. 0120 shipped semantic_belief as a shadow substrate: single-field
+-- exact indexes only (userId/subject/status), no FULLTEXT, no embedding —
+-- nothing on the serving path read it. The belief lane retrieves by
+-- QUERY TEXT against the rendered statement (the deterministic template
+-- embeds subject, field, value and prior value), so it needs exactly one
+-- FULLTEXT index. Same lowercase-only analyzer contract as episode_text
+-- (0073) / segment_text (0075) / scene_gist (0106) / fragment_content
+-- (0124): snowball would mangle non-Latin scripts.
+--
+-- embedding is WRITE-DEAD by design (the 0124 precedent): no producer
+-- fills it in this PR; the lane's dense leg is a brute cosine that
+-- degrades to empty by construction until a promotion-side producer
+-- exists. option<> keeps every existing row valid.
+--
+-- SINGLE-FIELD only, deliberately (the 0109/0111/0120 3.2.4 rule); every
+-- deleter of this table already uses the LET $ids = (SELECT VALUE id …);
+-- DELETE $ids; idiom and the audit-p1-guards spec pins the repo-wide
+-- `DELETE semantic_belief WHERE` prohibition — this migration adds no
+-- delete path. No changefeed, no event (0120 GDPR rationale stands).
+
+DEFINE ANALYZER IF NOT EXISTS belief_statement TOKENIZERS class FILTERS lowercase;
+DEFINE INDEX IF NOT EXISTS belief_statement_search ON semantic_belief
+  FIELDS statement FULLTEXT ANALYZER belief_statement BM25;
+
+DEFINE FIELD IF NOT EXISTS embedding ON semantic_belief TYPE option<array<float>>;

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -286,6 +286,22 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // BELIEFS_SERVING_LANE: what happened to each generator-emitted
+  // citedBeliefIds entry in the rendered-set resolver
+  // (belief-citations.ts — the fragmentCitationCount sibling):
+  //   cited           — the generator named a RENDERED belief → a
+  //                     belief-arm citation shipped
+  //   dropped_unknown — the generator named a beliefId NOT rendered
+  //                     into the current-state section (hallucination /
+  //                     probe) → dropped, never surfaced
+  // Emitted only when the flag is on (nothing on the path when off).
+  readonly beliefCitationCount = new Counter({
+    name: 'brain_belief_citation_total',
+    help: 'Belief evidence citation resolution outcomes (BELIEFS_SERVING_LANE)',
+    labelNames: ['outcome'] as const,
+    registers: [this.registry],
+  });
+
   // MM-zoom PR3 (FOVEA_FRAGMENT_ZOOM): what the ONE bounded zoom step did
   // per evaluation —
   //   flipped   — the re-verify over the fuller derived text passed →
@@ -790,6 +806,12 @@ export class MetricsService implements OnModuleInit {
   countFragmentCitation(outcome: 'cited' | 'dropped_unknown', n = 1): void {
     if (n > 0) {
       this.fragmentCitationCount.inc({ outcome } as LabelValues<'outcome'>, n);
+    }
+  }
+
+  countBeliefCitation(outcome: 'cited' | 'dropped_unknown', n = 1): void {
+    if (n > 0) {
+      this.beliefCitationCount.inc({ outcome } as LabelValues<'outcome'>, n);
     }
   }
 

--- a/src/synthesize/belief-citations.ts
+++ b/src/synthesize/belief-citations.ts
@@ -116,10 +116,7 @@ export function resolveAndCountBeliefCitations(opts: {
   metrics?: BeliefCitationMetrics | undefined;
 }): EvidenceCitation[] {
   if (!opts.beliefsById) return [];
-  const { citations, counts } = resolveBeliefCitations(
-    opts.citedBeliefIds ?? [],
-    opts.beliefsById,
-  );
+  const { citations, counts } = resolveBeliefCitations(opts.citedBeliefIds ?? [], opts.beliefsById);
   for (const outcome of ['cited', 'dropped_unknown'] as const) {
     if (counts[outcome] > 0) opts.metrics?.countBeliefCitation(outcome, counts[outcome]);
   }

--- a/src/synthesize/belief-citations.ts
+++ b/src/synthesize/belief-citations.ts
@@ -1,0 +1,138 @@
+import type { EvidenceCitation } from './synthesize.types';
+
+/**
+ * Belief citations (BELIEFS_SERVING_LANE) — the pure resolver that turns
+ * the generator's raw `citedBeliefIds` output into verified belief-arm
+ * EvidenceCitations. No IO, no DI, no env: the caller supplies the
+ * beliefsById map and emits metrics from the returned counts. The
+ * fragment-citations.ts sibling, one lane over. Citations ride the
+ * MASTER flag (no separate switch): the citation is what makes a
+ * belief-grounded answer pass FOVEA_REQUIRE_CITATIONS, and it is the
+ * unrollable provenance handle (sourceSceneIds → scenes → episodes).
+ *
+ * THE ANTI-HALLUCINATION + SECURITY FENCE: `beliefsById` contains ONLY
+ * the beliefs actually rendered into the prompt's current-state section
+ * — rows that already passed the lane's fence stack on their way in
+ * (BeliefLaneService: tenant → scoped-user → status='active' →
+ * beliefVisible re-check). Any beliefId the generator emits that is NOT
+ * in that map is dropped (and counted), so a belief citation can never
+ * name a belief the caller couldn't read, whether the id was
+ * hallucinated or probed.
+ *
+ * RENDERED-EXCERPT-ONLY: the citation's `excerpt` is copied from the
+ * rendered set — the exact (≤600-char) statement excerpt the generator
+ * saw — never generator-authored text, so a wrong or invented quote can
+ * never ship as a citation.
+ */
+
+/** One rendered current-state line's belief, as the resolver may cite it. */
+export interface CitableBelief {
+  /** semantic_belief record id, exactly as rendered in the line header. */
+  beliefId: string;
+  /** Free-text subject key (0120 — deliberately not entity-resolved). */
+  subject: string;
+  /** Free-text field key. */
+  field: string;
+  /** The held current value. */
+  value: string;
+  /** The RENDERED statement excerpt — the only citable text. */
+  excerpt: string;
+  /** ISO validFrom of the active revision, when known. */
+  occurredAt?: string | undefined;
+}
+
+/** Per-citation resolution outcomes (the metric label values). */
+export interface BeliefCitationCounts {
+  /** beliefId was rendered → a belief-arm citation shipped. */
+  cited: number;
+  /** beliefId not in the rendered set (or malformed entry) →
+   *  dropped, never surfaced. */
+  dropped_unknown: number;
+}
+
+/** Ceiling on resolved belief citations per answer (the l3-citations
+ *  EVIDENCE_CITATION_CAP idiom — bounded output). */
+const BELIEF_CITATION_CAP = 16;
+
+/**
+ * Resolve the generator's raw citedBeliefIds against the rendered-set
+ * map. Deduped by beliefId; capped at 16. Input is `unknown[]` by
+ * design — the LLM output is parsed defensively here, not trusted at the
+ * call site (a `{beliefId}` object entry is tolerated alongside the
+ * schema's plain string).
+ */
+export function resolveBeliefCitations(
+  citedBeliefIds: ReadonlyArray<unknown>,
+  beliefsById: ReadonlyMap<string, CitableBelief>,
+): { citations: EvidenceCitation[]; counts: BeliefCitationCounts } {
+  const counts: BeliefCitationCounts = { cited: 0, dropped_unknown: 0 };
+  const citations: EvidenceCitation[] = [];
+  const seen = new Set<string>();
+  for (const raw of citedBeliefIds) {
+    if (citations.length >= BELIEF_CITATION_CAP) break;
+    const beliefId = parseEntry(raw);
+    if (!beliefId) {
+      counts.dropped_unknown += 1;
+      continue;
+    }
+    const belief = beliefsById.get(beliefId);
+    if (!belief) {
+      counts.dropped_unknown += 1;
+      continue;
+    }
+    if (seen.has(beliefId)) continue;
+    seen.add(beliefId);
+    // ONE-OF invariant (EvidenceCitation): the belief arm only — never
+    // an episodeId or a fragmentId on the same citation. No `capability`
+    // stamp either (the episode-arm precedent): a belief line is
+    // distilled TEXT, so it neither satisfies nor triggers the 0113
+    // non-text capability gate (resolveEvidenceCapability sees only the
+    // text baseline).
+    citations.push({
+      beliefId: belief.beliefId,
+      excerpt: belief.excerpt,
+      ...(belief.occurredAt !== undefined ? { occurredAt: belief.occurredAt } : {}),
+    });
+    counts.cited += 1;
+  }
+  return { citations, counts };
+}
+
+/** Metrics port for the counting wrapper (keeps this module pure). */
+export interface BeliefCitationMetrics {
+  countBeliefCitation(outcome: 'cited' | 'dropped_unknown', n?: number): void;
+}
+
+/**
+ * Service-facing wrapper (the resolveAndCountFragmentCitations sibling):
+ * resolve + emit the per-outcome telemetry. An absent fence map means
+ * the flag was off for the request OR nothing was rendered (the map is
+ * only populated by the lane's rendered set) — [] either way, the
+ * byte-identical default path.
+ */
+export function resolveAndCountBeliefCitations(opts: {
+  citedBeliefIds: ReadonlyArray<unknown> | undefined;
+  beliefsById: ReadonlyMap<string, CitableBelief> | undefined;
+  metrics?: BeliefCitationMetrics | undefined;
+}): EvidenceCitation[] {
+  if (!opts.beliefsById) return [];
+  const { citations, counts } = resolveBeliefCitations(
+    opts.citedBeliefIds ?? [],
+    opts.beliefsById,
+  );
+  for (const outcome of ['cited', 'dropped_unknown'] as const) {
+    if (counts[outcome] > 0) opts.metrics?.countBeliefCitation(outcome, counts[outcome]);
+  }
+  return citations;
+}
+
+/** Defensive shape check on one generator-emitted entry; a malformed row
+ *  (no non-empty string id) resolves to null and counts as dropped. */
+function parseEntry(raw: unknown): string | null {
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  if (typeof raw === 'object' && raw !== null) {
+    const id = (raw as { beliefId?: unknown }).beliefId;
+    if (typeof id === 'string' && id.length > 0) return id;
+  }
+  return null;
+}

--- a/src/synthesize/belief-lane.service.ts
+++ b/src/synthesize/belief-lane.service.ts
@@ -1,0 +1,227 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { EmbedderService } from '../ai/embedder.service';
+import { beliefVisible } from '../beliefs/beliefs.service';
+import { rrfFuse } from './segment-lane.service';
+import { buildLexMatchLeg } from './lex-leg';
+import type { CitableBelief } from './belief-citations';
+
+/** Belief lines per prompt (design constant, BELIEFS_SERVING_LANE —
+ *  deliberately NOT an env knob until the lane is measured; the
+ *  FRAGMENT_LANE_TOP_K idiom). */
+const BELIEF_LANE_TOP_K = 3;
+/** Rendered statement cap per line (the 600-char line-cap idiom). */
+const BELIEF_EXCERPT_MAX_CHARS = 600;
+
+/** semantic_belief row columns the lane selects. */
+interface BeliefLaneRow {
+  id: unknown;
+  userId?: unknown;
+  subject?: unknown;
+  field?: unknown;
+  value?: unknown;
+  statement?: unknown;
+  revision?: unknown;
+  validFrom?: Date | string;
+  score?: number;
+}
+
+/** The lane's output: rendered lines + the rendered-set citation fence. */
+export interface BeliefLaneResult {
+  /** One line per (subject, field), validFrom-ascending, headed by the
+   *  `[semantic_belief:...]` id (citations ride the master flag). */
+  lines: string[];
+  /**
+   * beliefId → rendered-belief info for resolveBeliefCitations —
+   * EXACTLY the beliefs rendered into `lines` (the l3-citations
+   * turnsById fence). Empty ⟺ `lines` is empty.
+   */
+  byId: Map<string, CitableBelief>;
+}
+
+const EMPTY_RESULT: BeliefLaneResult = { lines: [], byId: new Map() };
+
+/**
+ * Belief retrieval lane (BELIEFS_SERVING_LANE) — the first serving
+ * surface of the 0120 belief substrate. This lane REPEALS the 0120
+ * shadow doctrine ("nothing on the serving path reads this table")
+ * behind the default-off master flag.
+ *
+ * Retrieves ACTIVE semantic_belief rows on their own BM25+dense merit —
+ * the fragment-lane shape: two legs fused by reciprocal rank. The
+ * lexical leg rides the 0126 lowercase FULLTEXT index over `statement`
+ * (the deterministic template embeds subject, field, value and prior
+ * value, so one index covers the whole key) — composed as the V11 A2
+ * `or_terms` disjunction (buildLexMatchLeg): the matches operator is
+ * AND-semantics over analyzed tokens, so a phrase-shaped `@1@ $query`
+ * leg would require the WHOLE question to appear in a short statement
+ * and (with dense write-dead) leave the lane empty for every natural
+ * question; the bounded per-term disjunction makes a belief mentioning
+ * ANY informative query word a lexical hit, ranked by summed BM25. The
+ * dense leg is a brute cosine over semantic_belief.embedding, which is
+ * WRITE-DEAD in v1 (no producer fills it — 0126 header), so it degrades
+ * to empty by construction until a producer exists; an embedder failure
+ * is caught per-leg and never kills the lexical leg.
+ *
+ * FENCE ORDER (composed per read):
+ *   1. tenant  — SurrealService.withCompany scoping;
+ *   2. user    — SCOPED-USER-ONLY, fail-closed (D4): `userId ===
+ *      undefined` ⇒ the lane is EMPTY, no query issued. DELIBERATE
+ *      TIGHTENING vs GET /v1/beliefs, where an M2M credential reads the
+ *      whole tenant: an explicit admin/API read is auditable, but
+ *      silently blending user A's current-state into an unscoped agent
+ *      ANSWER is a cross-user leak no serving lane allows — and no
+ *      belief is tenant-global (0120 userId TYPE string, never NONE),
+ *      so the platform-wide 0055 unscoped-serves-global rule yields
+ *      nothing here anyway. Scoped: SQL `userId = $u` (index-backed
+ *      belief_user_idx; WHERE on a secondary index is safe for SELECT —
+ *      only DELETE hits the 3.2.4 planner no-op);
+ *   3. status  — only `status = 'active'` rows ever serve (current
+ *      state by construction; the supersede chain guarantees one active
+ *      row per (userId, subject, field));
+ *   4. JS re-check — beliefVisible(row, userId) fail-closed (the
+ *      read-API doctrine: a blank/missing stamp is visible to NO ONE);
+ *   5. dedupe by (subject, field) keeping the best-fused row, cap at
+ *      BELIEF_LANE_TOP_K, sort by validFrom ascending;
+ *   6. any error degrades to an empty section, never fails the answer.
+ *
+ * Same contracts as the sibling lanes: activation comes from the
+ * caller-resolved flag (beliefServingLaneEnabled(), resolved ONCE per
+ * request by the orchestrator) — this service reads no env.
+ */
+@Injectable()
+export class BeliefLaneService {
+  private readonly logger = new Logger(BeliefLaneService.name);
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly embedder: EmbedderService,
+  ) {}
+
+  async beliefLines(opts: {
+    companyId: string;
+    query: string;
+    /** Scope key of the asking end-user; omitted → the lane is EMPTY
+     *  (fence 2 — scoped-user-only, see the class doc). */
+    userId?: string | undefined;
+  }): Promise<BeliefLaneResult> {
+    // Fence 2 (D4): an unscoped request serves NO beliefs — checked
+    // before any IO so the off-path issues zero queries.
+    if (opts.userId === undefined) return EMPTY_RESULT;
+    const userId = opts.userId;
+    const fetchK = Math.max(BELIEF_LANE_TOP_K * 3, 9);
+    try {
+      // Dense leg's query vector — its own degrade: an embedder failure
+      // must not kill the lexical leg.
+      let queryVector: number[] | null = null;
+      try {
+        queryVector = await this.embedder.embed(opts.query);
+      } catch (e) {
+        this.logger.warn(`belief lane dense leg unavailable: ${(e as Error).message}`);
+      }
+
+      // Fences 2/3 compose in the WHERE, in the design order.
+      const where = `userId = $u AND status = 'active'`;
+      const select = `id, userId, subject, field, value, statement, revision, validFrom`;
+      const fused = await this.surreal.withCompany(opts.companyId, async (db) => {
+        const [dense] = queryVector
+          ? await db.query<[BeliefLaneRow[]]>(
+              `SELECT ${select},
+                    vector::similarity::cosine(embedding, $q) AS score
+               FROM semantic_belief
+              WHERE embedding != NONE AND ${where}
+              ORDER BY score DESC
+              LIMIT $k`,
+              { q: queryVector, k: fetchK, u: userId },
+            )
+          : [[] as BeliefLaneRow[]];
+        // The or_terms disjunctive BM25 leg (see the class doc) —
+        // composed per request over the caller's query text.
+        const lex = buildLexMatchLeg({
+          fields: ['statement'],
+          topic: opts.query,
+          mode: 'or_terms',
+        });
+        const [bm25] = await db.query<[BeliefLaneRow[]]>(
+          `SELECT ${select}, ${lex.score} AS score
+               FROM semantic_belief
+              WHERE ${lex.where} AND ${where}
+              ORDER BY score DESC
+              LIMIT $k`,
+          { ...lex.params, k: fetchK, u: userId },
+        );
+        return rrfFuse([dense ?? [], bm25 ?? []]);
+      });
+      if (fused.length === 0) return EMPTY_RESULT;
+      return this.render(fused, userId);
+    } catch (e) {
+      // Fence 6: degrade to an empty section, never fail the answer.
+      this.logger.warn(
+        `belief lane failed (companyId=${opts.companyId}): ${(e as Error).message}`,
+      );
+      return EMPTY_RESULT;
+    }
+  }
+
+  /**
+   * One line per (subject, field) key (the best-fused revision wins —
+   * with the supersede chain there is at most one active row per key,
+   * so this is defense in depth), validFrom-ascending, capped at
+   * BELIEF_LANE_TOP_K. Line shape:
+   *   `[semantic_belief:...] (<subject> — <field>, rev <revision>, as of <day>) <statement>`
+   * The id header renders UNCONDITIONALLY — belief citations ride the
+   * master flag (no separate switch; see belief-citations.ts). Fence 4
+   * (beliefVisible) re-applies here fail-closed: an out-of-contract row
+   * the SQL fence let through never renders.
+   */
+  private render(fused: BeliefLaneRow[], userId: string): BeliefLaneResult {
+    const byKey = new Map<string, BeliefLaneRow>();
+    for (const row of fused) {
+      // Fence 4: JS re-check of the user fence (the read-API doctrine).
+      if (!beliefVisible(row, userId)) continue;
+      const beliefId = row.id === undefined ? '' : String(row.id);
+      const statement = typeof row.statement === 'string' ? row.statement : '';
+      if (!beliefId || !statement.trim()) continue;
+      const key = `${String(row.subject ?? '')}|${String(row.field ?? '')}`;
+      if (!byKey.has(key)) byKey.set(key, row);
+      if (byKey.size >= BELIEF_LANE_TOP_K) break;
+    }
+    const kept = [...byKey.values()].sort((a, b) => toMs(a.validFrom) - toMs(b.validFrom));
+    const lines: string[] = [];
+    const byId = new Map<string, CitableBelief>();
+    for (const row of kept) {
+      const beliefId = String(row.id);
+      const excerpt = String(row.statement).slice(0, BELIEF_EXCERPT_MAX_CHARS);
+      const day = isoDay(row.validFrom);
+      lines.push(
+        `[${beliefId}] (${String(row.subject ?? '')} — ${String(row.field ?? '')}, ` +
+          `rev ${String(row.revision ?? 1)}${day ? `, as of ${day}` : ''}) ${excerpt}`,
+      );
+      byId.set(beliefId, {
+        beliefId,
+        subject: String(row.subject ?? ''),
+        field: String(row.field ?? ''),
+        value: String(row.value ?? ''),
+        excerpt,
+        ...(day ? { occurredAt: isoInstant(row.validFrom) } : {}),
+      });
+    }
+    return { lines, byId };
+  }
+}
+
+function toMs(v: Date | string | undefined): number {
+  if (v === undefined) return 0;
+  const t = v instanceof Date ? v.getTime() : Date.parse(String(v));
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function isoDay(v: Date | string | undefined): string {
+  if (v === undefined) return '';
+  const ms = toMs(v);
+  return ms === 0 ? '' : new Date(ms).toISOString().slice(0, 10);
+}
+
+function isoInstant(v: Date | string | undefined): string {
+  return new Date(toMs(v)).toISOString();
+}

--- a/src/synthesize/belief-lane.service.ts
+++ b/src/synthesize/belief-lane.service.ts
@@ -156,9 +156,7 @@ export class BeliefLaneService {
       return this.render(fused, userId);
     } catch (e) {
       // Fence 6: degrade to an empty section, never fail the answer.
-      this.logger.warn(
-        `belief lane failed (companyId=${opts.companyId}): ${(e as Error).message}`,
-      );
+      this.logger.warn(`belief lane failed (companyId=${opts.companyId}): ${(e as Error).message}`);
       return EMPTY_RESULT;
     }
   }

--- a/src/synthesize/evidence-collector.service.ts
+++ b/src/synthesize/evidence-collector.service.ts
@@ -21,7 +21,9 @@ import { QueryArcService } from './query-arc.service';
 import { UpdateStoryService } from './update-story.service';
 import { DigestLaneService } from './digest-lane.service';
 import { FragmentLaneService } from './fragment-lane.service';
+import { BeliefLaneService } from './belief-lane.service';
 import type { CitableFragment } from './fragment-citations';
+import type { CitableBelief } from './belief-citations';
 import type { ZoomCandidate } from './fragment-zoom';
 import type { CoverageScanTuning } from './scan-leg';
 
@@ -123,6 +125,26 @@ export interface CollectedEvidence {
    */
   fragmentZoom: ZoomCandidate[];
   /**
+   * BELIEFS_SERVING_LANE belief lane: rendered current-state lines —
+   * `[semantic_belief:...]`-headed statement excerpts of the caller's
+   * ACTIVE beliefs matching the query — the prompt's OWN current-state
+   * section. Evidence parity by construction: the generator renders
+   * them as a section and the verifier reads the SAME lines
+   * (VerifyRequest.beliefLines). Deliberately NOT noise-filtered
+   * (bounded at 3 lines by the lane; a relevance cut on so small a
+   * section risks more than it saves — the fragment-lane rationale).
+   * Empty when the flag is off / the lane is unwired / the request is
+   * unscoped (D4) / the lane failed.
+   */
+  beliefLines: string[];
+  /**
+   * The rendered-set citation fence for resolveBeliefCitations
+   * (BELIEFS_SERVING_LANE — citations ride the master flag): beliefId →
+   * rendered-belief info for EXACTLY the beliefs in beliefLines.
+   * undefined when the lane rendered nothing.
+   */
+  beliefsById?: ReadonlyMap<string, CitableBelief> | undefined;
+  /**
    * G4 strategy lane: rendered advisory notes (k≤2, default 1) from
    * the separate strategy_memory store; undefined when the lane is off
    * the profile or read-side serving is disabled.
@@ -163,6 +185,8 @@ export function emptyCollectedEvidence(
     fragmentLines: [],
     fragmentsById: undefined,
     fragmentZoom: [],
+    beliefLines: [],
+    beliefsById: undefined,
   };
 }
 
@@ -186,6 +210,7 @@ export class EvidenceCollectorService {
     @Optional() private readonly crossEncoder?: CrossEncoderService,
     @Optional() private readonly strategyMemory?: StrategyMemoryService,
     @Optional() private readonly fragmentLane?: FragmentLaneService,
+    @Optional() private readonly beliefLane?: BeliefLaneService,
   ) {}
 
   /**
@@ -208,6 +233,9 @@ export class EvidenceCollectorService {
     /** EVIDENCE_FRAGMENT_CITATIONS, resolved ONCE by the caller (the L3
      *  single-resolution idiom) — this service reads no env. */
     fragmentCitations?: boolean | undefined;
+    /** BELIEFS_SERVING_LANE, resolved ONCE by the caller (the
+     *  fragmentCitations precedent) — this service reads no env. */
+    beliefLane?: boolean | undefined;
   }): Promise<CollectedEvidence> {
     const { profile, query } = opts;
     const timelineEvidence = wantsTimelineEvidence(profile, query);
@@ -220,6 +248,7 @@ export class EvidenceCollectorService {
       groundingQuotes,
       strategyNotes,
       fragmentEvidence,
+      beliefEvidence,
     ] = await Promise.all([
       this.collectStandingInstructions(opts),
       this.collectTranscriptLines(opts, timelineEvidence),
@@ -229,6 +258,7 @@ export class EvidenceCollectorService {
       this.collectGroundingQuotes(opts),
       this.collectStrategyNotes(opts),
       this.collectFragmentEvidence(opts),
+      this.collectBeliefEvidence(opts),
     ]);
     // V12 §2: digests merge AHEAD of retrieved insight lines under
     // the same slot — generator, verifier and NLI judge all see them
@@ -256,7 +286,33 @@ export class EvidenceCollectorService {
       fragmentLines: fragmentEvidence.lines,
       fragmentsById: fragmentEvidence.byId.size > 0 ? fragmentEvidence.byId : undefined,
       fragmentZoom: fragmentEvidence.zoom,
+      beliefLines: beliefEvidence.lines,
+      beliefsById: beliefEvidence.byId.size > 0 ? beliefEvidence.byId : undefined,
     };
+  }
+
+  /**
+   * BELIEFS_SERVING_LANE belief lane — gated on the caller-resolved
+   * flag (no env read here — the fragmentCitations precedent); degrades
+   * to an empty section on absence/abort (the lane owns its own error
+   * degrade AND the D4 scoped-user fence: an unscoped request yields
+   * empty inside the lane).
+   */
+  private async collectBeliefEvidence({
+    beliefLane,
+    companyId,
+    query,
+    userId,
+  }: {
+    beliefLane?: boolean | undefined;
+    companyId: string;
+    query: string;
+    userId?: string | undefined;
+  }): Promise<{ lines: string[]; byId: ReadonlyMap<string, CitableBelief> }> {
+    const empty = { lines: [], byId: new Map<string, CitableBelief>() };
+    if (beliefLane !== true || !this.beliefLane) return empty;
+    if (getAbortSignal()?.aborted) return empty;
+    return this.beliefLane.beliefLines({ companyId, query, userId });
   }
 
   /**

--- a/src/synthesize/fragment-zoom-seam.ts
+++ b/src/synthesize/fragment-zoom-seam.ts
@@ -95,6 +95,9 @@ export interface VerifyStageArgs {
     fragmentZoom: ZoomCandidate[];
     transcriptLines: string[];
     insightLines: string[];
+    /** BELIEFS_SERVING_LANE: same parity — both audits read the SAME
+     *  belief lines the generator saw. */
+    beliefLines: string[];
     timelineEvidence: boolean;
   };
   promptFactLines: string[];
@@ -164,6 +167,9 @@ export async function verifyAndZoom(
                 // evidence the generator was given.
                 transcriptLines: collected.transcriptLines,
                 insightLines: collected.insightLines,
+                // BELIEFS_SERVING_LANE parity (W5 #22): the same belief
+                // lines the generator's current-state section rendered.
+                beliefLines: collected.beliefLines,
                 // W5 #22 parity for the mention record (V9 §2 closes the
                 // V8 gap): the auditor sees the same MENTION RECORD
                 // framing the generator saw — the collector computed it
@@ -234,6 +240,8 @@ interface FragmentZoomSeamArgs {
     fragmentZoom: ZoomCandidate[];
     transcriptLines: string[];
     insightLines: string[];
+    /** BELIEFS_SERVING_LANE: carried verbatim into the re-verify. */
+    beliefLines: string[];
     timelineEvidence: boolean;
   };
   promptFactLines: string[];
@@ -276,6 +284,10 @@ async function tryFragmentZoom(
               factLines: args.promptFactLines,
               transcriptLines: collected.transcriptLines,
               insightLines: collected.insightLines,
+              // BELIEFS_SERVING_LANE parity by construction (W5 #22):
+              // the zoom re-verify audits the SAME belief lines as the
+              // primary audit — only the fragment lines are enriched.
+              beliefLines: collected.beliefLines,
               timelineEvidence: collected.timelineEvidence,
               topicCoverage: profile.verifierTopicCoverage,
               dateMathLines: args.dateMathLines,

--- a/src/synthesize/generator-client.ts
+++ b/src/synthesize/generator-client.ts
@@ -96,6 +96,20 @@ export interface GenerateRequest {
    */
   allowRefine?: boolean | undefined;
   /**
+   * BELIEFS_SERVING_LANE: rendered current-state belief lines, their
+   * own section — the verifier reads the same lines
+   * (VerifyRequest.beliefLines, evidence parity).
+   */
+  beliefLines?: string[] | undefined;
+  /**
+   * BELIEFS_SERVING_LANE: expose the belief-citation affordance — the
+   * schema gains `citedBeliefIds` and the system prompt the matching
+   * rule. Effective only when beliefLines are non-empty (no rendered
+   * beliefs ⇒ nothing citable ⇒ prompt and schema byte-identical — the
+   * fragmentAffordance guard).
+   */
+  beliefCitations?: boolean | undefined;
+  /**
    * MM-zoom PR2 (profile.fragmentLane): rendered media-evidence lines,
    * their own section — the verifier reads the same lines
    * (capabilityEvidenceLines, evidence parity).
@@ -122,15 +136,59 @@ const FRAGMENT_CITE_ADDENDUM = `
 
 FRAGMENT CITATIONS: some evidence lines are media-derived and headed by an [evidence_fragment:...] id. When a claim in your answer rests on such a line, copy that id EXACTLY as it appears into the citedFragmentIds array (in addition to any factIds you cite). Cite only ids present in the evidence — never invent one. citedFragmentIds is [] when no media line supports a claim.`;
 
+/** BELIEFS_SERVING_LANE belief-citation affordance — appended when the
+ *  current-state section rendered (citations ride the master flag). */
+const BELIEF_CITE_ADDENDUM = `
+
+BELIEF CITATIONS: some evidence lines are distilled current-state beliefs headed by a [semantic_belief:...] id. When a claim in your answer rests on such a line, copy that id EXACTLY as it appears into the citedBeliefIds array (in addition to any factIds you cite). Cite only ids present in the evidence — never invent one. citedBeliefIds is [] when no belief line supports a claim.`;
+
+/** The strict-JSON answer schema, affordance-conditional fields included
+ *  (extracted from runGenerator for the complexity budget — pure). */
+function buildAnswerSchema(opts: {
+  allowRefine: boolean;
+  fragmentAffordance: boolean;
+  beliefAffordance: boolean;
+}): { schema: Record<string, unknown>; required: string[] } {
+  return {
+    schema: {
+      answer: { type: 'string' },
+      citedFactIds: { type: 'array', items: { type: 'string' } },
+      ...(opts.allowRefine ? { refineQuery: { type: ['string', 'null'] } } : {}),
+      ...(opts.fragmentAffordance
+        ? { citedFragmentIds: { type: 'array', items: { type: 'string' } } }
+        : {}),
+      ...(opts.beliefAffordance
+        ? { citedBeliefIds: { type: 'array', items: { type: 'string' } } }
+        : {}),
+    },
+    required: [
+      'answer',
+      'citedFactIds',
+      ...(opts.allowRefine ? ['refineQuery'] : []),
+      ...(opts.fragmentAffordance ? ['citedFragmentIds'] : []),
+      ...(opts.beliefAffordance ? ['citedBeliefIds'] : []),
+    ],
+  };
+}
+
 export async function runGenerator(req: GenerateRequest): Promise<GeneratorOutput> {
   const { openai, metrics, logger, model, answerLang, neverAbstain } = req;
   // The affordance is real only when fragments actually rendered —
   // flag-on with an empty lane keeps prompt and schema byte-identical.
   const fragmentAffordance = req.fragmentCitations === true && (req.fragmentLines?.length ?? 0) > 0;
+  // Same guard for beliefs: flag-on with an empty lane keeps prompt and
+  // schema byte-identical (BELIEFS_SERVING_LANE).
+  const beliefAffordance = req.beliefCitations === true && (req.beliefLines?.length ?? 0) > 0;
+  const answerSchema = buildAnswerSchema({
+    allowRefine: req.allowRefine === true,
+    fragmentAffordance,
+    beliefAffordance,
+  });
   const systemPrompt =
     (neverAbstain ? GENERATOR_SYSTEM_ANSWER : GENERATOR_SYSTEM) +
     (req.allowRefine ? REFINE_ADDENDUM : '') +
-    (fragmentAffordance ? FRAGMENT_CITE_ADDENDUM : '');
+    (fragmentAffordance ? FRAGMENT_CITE_ADDENDUM : '') +
+    (beliefAffordance ? BELIEF_CITE_ADDENDUM : '');
   const user = buildGeneratorUserMessage(req);
   traceArtifact('synthesize.generator_prompt', {
     system: systemPrompt,
@@ -163,20 +221,8 @@ export async function runGenerator(req: GenerateRequest): Promise<GeneratorOutpu
               schema: {
                 type: 'object',
                 additionalProperties: false,
-                properties: {
-                  answer: { type: 'string' },
-                  citedFactIds: { type: 'array', items: { type: 'string' } },
-                  ...(req.allowRefine ? { refineQuery: { type: ['string', 'null'] } } : {}),
-                  ...(fragmentAffordance
-                    ? { citedFragmentIds: { type: 'array', items: { type: 'string' } } }
-                    : {}),
-                },
-                required: [
-                  'answer',
-                  'citedFactIds',
-                  ...(req.allowRefine ? ['refineQuery'] : []),
-                  ...(fragmentAffordance ? ['citedFragmentIds'] : []),
-                ],
+                properties: answerSchema.schema,
+                required: answerSchema.required,
               },
             },
           },
@@ -187,13 +233,37 @@ export async function runGenerator(req: GenerateRequest): Promise<GeneratorOutpu
   );
   const content = res.choices[0]?.message?.content;
   if (!content) throw new Error('empty generator response');
-  // Audit W5 #24: the exhaustive-list lanes ("a partial list is a wrong
-  // answer") run against a 512-token cap. A truncated strict-JSON body
-  // used to throw here and degrade to `generator_error` — i.e. the
-  // lanes that must enumerate silently ABSTAINED instead of returning
-  // what they had. Say so explicitly in the trace, and salvage the
-  // answer text when the JSON envelope is the only casualty.
-  const finishReason = res.choices[0]?.finish_reason;
+  const parsed = parseGeneratorContent(content, res.choices[0]?.finish_reason, {
+    logger,
+    metrics,
+  });
+  if (res.usage) {
+    parsed.usage = {
+      promptTokens: res.usage.prompt_tokens ?? 0,
+      completionTokens: res.usage.completion_tokens ?? 0,
+    };
+  }
+  traceArtifact('synthesize.generator_output', parsed);
+  return parsed;
+}
+
+/**
+ * Parse + defensively normalize the generator's strict-JSON body
+ * (extracted from runGenerator for the complexity budget).
+ *
+ * Audit W5 #24: the exhaustive-list lanes ("a partial list is a wrong
+ * answer") run against a 512-token cap. A truncated strict-JSON body
+ * used to throw here and degrade to `generator_error` — i.e. the lanes
+ * that must enumerate silently ABSTAINED instead of returning what they
+ * had. Say so explicitly in the trace, and salvage the answer text when
+ * the JSON envelope is the only casualty.
+ */
+function parseGeneratorContent(
+  content: string,
+  finishReason: string | undefined,
+  deps: { logger: GenerateRequest['logger']; metrics: GenerateRequest['metrics'] },
+): GeneratorOutput {
+  const { logger, metrics } = deps;
   let parsed: GeneratorOutput;
   try {
     parsed = JSON.parse(content) as GeneratorOutput;
@@ -220,12 +290,9 @@ export async function runGenerator(req: GenerateRequest): Promise<GeneratorOutpu
   if (parsed.citedFragmentIds !== undefined && !Array.isArray(parsed.citedFragmentIds)) {
     delete parsed.citedFragmentIds;
   }
-  if (res.usage) {
-    parsed.usage = {
-      promptTokens: res.usage.prompt_tokens ?? 0,
-      completionTokens: res.usage.completion_tokens ?? 0,
-    };
+  // Same defensive parse for the belief arm (BELIEFS_SERVING_LANE).
+  if (parsed.citedBeliefIds !== undefined && !Array.isArray(parsed.citedBeliefIds)) {
+    delete parsed.citedBeliefIds;
   }
-  traceArtifact('synthesize.generator_output', parsed);
   return parsed;
 }

--- a/src/synthesize/generator-prompt.ts
+++ b/src/synthesize/generator-prompt.ts
@@ -37,6 +37,8 @@ export function buildGeneratorUserMessage({
   dateMathLines,
   shapeInstruction,
   strategyNotes,
+  beliefLines,
+  beliefCitations,
   fragmentLines,
   fragmentCitations,
 }: {
@@ -119,6 +121,23 @@ export function buildGeneratorUserMessage({
    */
   strategyNotes?: string[] | undefined;
   /**
+   * BELIEFS_SERVING_LANE: rendered current-state belief lines —
+   * `[semantic_belief:...]`-headed statement excerpts of the caller's
+   * ACTIVE beliefs — their own section, between insights and media
+   * (state before media). The verifier reads the SAME lines
+   * (VerifyRequest.beliefLines — evidence parity). Empty/undefined = no
+   * section, byte-identical.
+   */
+  beliefLines?: string[] | undefined;
+  /**
+   * BELIEFS_SERVING_LANE citations variant: the lines carry
+   * [semantic_belief:...] headers and the section header instructs
+   * mirroring cited ids into citedBeliefIds. Off = the cite-factIds-only
+   * header (kept so the header split survives a future flag split — the
+   * fragment-lane precedent; in PR-A the master flag implies citations).
+   */
+  beliefCitations?: boolean | undefined;
+  /**
    * MM-zoom PR2 (profile.fragmentLane): rendered media-evidence lines —
    * `[capability:<kind>]`-tagged derived-representation excerpts of
    * registered media observations — their own section. The verifier
@@ -181,12 +200,25 @@ export function buildGeneratorUserMessage({
     insightLines && insightLines.length > 0
       ? `\n\n${insightHeader}\n${insightLines.join('\n')}`
       : '';
+  const beliefSection = renderBeliefSection(beliefLines, beliefCitations);
   const fragmentSection = renderFragmentSection(fragmentLines, fragmentCitations);
   const dateMathSection =
     dateMathLines && dateMathLines.length > 0
       ? `\n\nDate table (computed from the fact date stamps — trust it over your own arithmetic; gaps are between EVIDENCE dates, not from today):\n${dateMathLines.join('\n')}`
       : '';
-  return `Query: ${query}\n${dateInstruction}${shapeInstruction ?? ''}${laneInstruction}${instructionSection}${conflictSection}\nRetrieved facts:\n${factLines.join('\n')}${transcriptSection}${insightSection}${fragmentSection}${dateMathSection}${renderStrategySection(strategyNotes)}${langInstruction}`;
+  return `Query: ${query}\n${dateInstruction}${shapeInstruction ?? ''}${laneInstruction}${instructionSection}${conflictSection}\nRetrieved facts:\n${factLines.join('\n')}${transcriptSection}${insightSection}${beliefSection}${fragmentSection}${dateMathSection}${renderStrategySection(strategyNotes)}${langInstruction}`;
+}
+
+/** Belief lane (BELIEFS_SERVING_LANE): distilled current-state lines in
+ *  their own section. Empty input = empty string (byte-identical prompt
+ *  without the lane). The citations variant instructs mirroring cited
+ *  [semantic_belief:...] ids into citedBeliefIds. */
+function renderBeliefSection(beliefLines?: string[], beliefCitations?: boolean): string {
+  if (!beliefLines || beliefLines.length === 0) return '';
+  const header = beliefCitations
+    ? 'Current-state record (distilled beliefs — each line states what is CURRENTLY true for its subject/field and supersedes any older or conflicting fact above; each line is headed by its [semantic_belief:...] id. For questions asking the CURRENT state, prefer these lines; when a claim rests on one, copy its id EXACTLY into citedBeliefIds. For questions about history, sequence, or why something changed, use the facts and transcript instead; cite factIds for fact-grounded claims as before):'
+    : 'Current-state record (distilled beliefs — each line states what is CURRENTLY true for its subject/field and supersedes any older or conflicting fact above. For questions asking the CURRENT state, prefer these lines; for questions about history, sequence, or why something changed, use the facts and transcript instead; cite factIds only):';
+  return `\n\n${header}\n${beliefLines.join('\n')}`;
 }
 
 /**

--- a/src/synthesize/outcome-emit.ts
+++ b/src/synthesize/outcome-emit.ts
@@ -153,15 +153,13 @@ export function emitBeliefAnswerUse(
   }));
   if (verdict?.verdict === 'supported') {
     events.push(
-      ...beliefIds.map(
-        (id): OutcomeEventInput => ({
-          subjectKind: 'belief',
-          subjectId: id,
-          event: 'verifier_supported',
-          meta: { verdict: verdict.verdict },
-          ...(decisionId !== undefined ? { decisionId } : {}),
-        }),
-      ),
+      ...beliefIds.map((id): OutcomeEventInput => ({
+        subjectKind: 'belief',
+        subjectId: id,
+        event: 'verifier_supported',
+        meta: { verdict: verdict.verdict },
+        ...(decisionId !== undefined ? { decisionId } : {}),
+      })),
     );
   }
   if (events.length === 0) return;

--- a/src/synthesize/outcome-emit.ts
+++ b/src/synthesize/outcome-emit.ts
@@ -2,7 +2,7 @@ import { MemoryOutcomeService, type OutcomeEventInput } from '../outcomes/memory
 import type { Citation } from './fact-index';
 import type { VerifierOutput } from './verifier';
 import { unverifiedReturn, type VerdictDeps } from './verdict';
-import type { SynthesizeResult } from './synthesize.types';
+import type { EvidenceCitation, SynthesizeResult } from './synthesize.types';
 
 /**
  * Outcome telemetry (0107) emit seams for the synthesize orchestrator,
@@ -94,6 +94,74 @@ export function emitAnswerUse(
         meta: { verdict: verdict.verdict },
         ...(decisionId !== undefined ? { decisionId } : {}),
       })),
+    );
+  }
+  if (events.length === 0) return;
+  outcomes.recordOutcomes({ companyId, events });
+}
+
+/**
+ * BELIEFS_SERVING_LANE (D7): the belief lines rendered into the prompt
+ * were selected for context — emitted once per request, right after the
+ * collector returns (the rendered set is final there: the search-loop
+ * refine never re-runs the belief lane). subjectKind 'belief' rides the
+ * existing 0107 vocabulary — no schema work.
+ */
+export function emitBeliefContext(
+  outcomes: MemoryOutcomeService | undefined,
+  companyId: string,
+  beliefIds: Iterable<string>,
+): void {
+  if (!outcomes || !MemoryOutcomeService.enabled()) return;
+  const events: OutcomeEventInput[] = [...beliefIds].map((id) => ({
+    subjectKind: 'belief',
+    subjectId: id,
+    event: 'selected_for_context',
+  }));
+  if (events.length === 0) return;
+  outcomes.recordOutcomes({ companyId, events });
+}
+
+/**
+ * BELIEFS_SERVING_LANE (D7): the belief-arm evidence citations of a
+ * served answer count as use — `used_in_answer`, plus `verifier_supported`
+ * on a supported verdict, the 0119 decisionId threaded exactly like the
+ * fact arm (emitAnswerUse above). Called from finalizeAndAdmit — BOTH
+ * serving paths land there; the L3 flip carries episode-arm citations
+ * only, so the belief filter yields zero events on that path today.
+ * Non-belief arms (episodeId / fragmentId) are skipped by the filter.
+ */
+export function emitBeliefAnswerUse(
+  outcomes: MemoryOutcomeService | undefined,
+  opts: {
+    companyId: string | undefined;
+    evidenceCitations: EvidenceCitation[] | undefined;
+    verdict?: VerifierOutput;
+    decisionId?: string | undefined;
+  },
+): void {
+  const { companyId, evidenceCitations, verdict, decisionId } = opts;
+  if (!outcomes || !MemoryOutcomeService.enabled() || companyId === undefined) return;
+  const beliefIds = (evidenceCitations ?? [])
+    .map((c) => c.beliefId)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+  const events: OutcomeEventInput[] = beliefIds.map((id) => ({
+    subjectKind: 'belief',
+    subjectId: id,
+    event: 'used_in_answer',
+    ...(decisionId !== undefined ? { decisionId } : {}),
+  }));
+  if (verdict?.verdict === 'supported') {
+    events.push(
+      ...beliefIds.map(
+        (id): OutcomeEventInput => ({
+          subjectKind: 'belief',
+          subjectId: id,
+          event: 'verifier_supported',
+          meta: { verdict: verdict.verdict },
+          ...(decisionId !== undefined ? { decisionId } : {}),
+        }),
+      ),
     );
   }
   if (events.length === 0) return;

--- a/src/synthesize/synthesize.helpers.ts
+++ b/src/synthesize/synthesize.helpers.ts
@@ -152,6 +152,10 @@ export function buildGeneratorArgs(
       fragmentLines?: string[] | undefined;
       /** EVIDENCE_FRAGMENT_CITATIONS, resolved once per request. */
       fragmentCitations?: boolean | undefined;
+      /** BELIEFS_SERVING_LANE: rendered current-state lines (own section). */
+      beliefLines?: string[] | undefined;
+      /** Belief-citation affordance (rides the master flag), resolved once. */
+      beliefCitations?: boolean | undefined;
     };
   },
   o: {
@@ -189,6 +193,10 @@ export function buildGeneratorArgs(
     // both rounds of the search loop carry them identically.
     fragmentLines: collected.fragmentLines,
     fragmentCitations: collected.fragmentCitations,
+    // BELIEFS_SERVING_LANE: current-state lines + the belief-citation
+    // affordance — carried identically by both rounds too.
+    beliefLines: collected.beliefLines,
+    beliefCitations: collected.beliefCitations,
     ...(o.allowRefine !== undefined ? { allowRefine: o.allowRefine } : {}),
     ...(o.answerLangStrict ? { answerLangStrict: true } : {}),
   };

--- a/src/synthesize/synthesize.module.ts
+++ b/src/synthesize/synthesize.module.ts
@@ -19,6 +19,7 @@ import { QueryArcService } from './query-arc.service';
 import { UpdateStoryService } from './update-story.service';
 import { DigestLaneService } from './digest-lane.service';
 import { FragmentLaneService } from './fragment-lane.service';
+import { BeliefLaneService } from './belief-lane.service';
 import { EvidenceCollectorService } from './evidence-collector.service';
 import { L3EscalationService } from './l3-escalation.service';
 import { MemoryModelReaderService } from '../ai/memory-model-reader.service';
@@ -40,6 +41,7 @@ import { MemoryModelReaderService } from '../ai/memory-model-reader.service';
     UpdateStoryService,
     DigestLaneService,
     FragmentLaneService,
+    BeliefLaneService,
     L3EscalationService,
     // FOVEA_ATTENTION_HINTS: the L3 escalation lane's lazy read of pack
     // memory models. A second DI instance beside admin.module's — its

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -29,7 +29,9 @@ import { runLaneProbe } from './lane-probe';
 import { getActiveRetrievalProfile, type RetrievalProfile } from '../search/retrieval-profile';
 import { buildFactIndex } from './fact-index';
 import { fragmentCitationsEnabled } from '../common/evidence-flags';
+import { beliefServingLaneEnabled } from '../common/beliefs-flags';
 import { resolveAndCountFragmentCitations } from './fragment-citations';
+import { resolveAndCountBeliefCitations } from './belief-citations';
 import { verifyAndZoom } from './fragment-zoom-seam';
 import { FragmentLaneService } from './fragment-lane.service';
 import { resolveAnswerIntegrity, type FinalizeContext } from './answer-integrity';
@@ -64,7 +66,13 @@ import {
 } from '../answer-cache/answer-cache.service';
 import { MemoryOutcomeService } from '../outcomes/memory-outcome.service';
 import { MemoryDecisionService } from '../outcomes/memory-decision.service';
-import { emitAnswerUse, emitSelectedForContext, unverifiedServe } from './outcome-emit';
+import {
+  emitAnswerUse,
+  emitBeliefAnswerUse,
+  emitBeliefContext,
+  emitSelectedForContext,
+  unverifiedServe,
+} from './outcome-emit';
 import { NOOP_REPORTER, type ProgressReporter } from '../mcp/progress-reporter';
 
 export interface SynthesizeOptions {
@@ -334,7 +342,10 @@ export class SynthesizeService {
     });
     // The other rendered sections stay on `collected` — the verify stage
     // (verifyAndZoom) and produceAnswer read them from there directly.
-    const { fragmentsById, updateStories, groundingQuotes } = collected;
+    const { fragmentsById, beliefsById, updateStories, groundingQuotes } = collected;
+    // 0107 belief arm (D7): the rendered belief lines were selected for
+    // context — final here (the refine round never re-runs the lane).
+    emitBeliefContext(this.outcomes, companyId, beliefsById?.keys() ?? []);
 
     // V10 §2 update stories + multiworld §10 grounding quotes: both
     // suffix maps land on the SAME lines the generator and the
@@ -381,6 +392,9 @@ export class SynthesizeService {
         // MM-zoom PR2: citation affordance (populated fence map ⟺
         // switch on AND rendered); round 2 carries both.
         fragmentCitations: fragmentsById !== undefined,
+        // BELIEFS_SERVING_LANE: same construction — citations ride the
+        // master flag, so affordance ⟺ the lane rendered anything.
+        beliefCitations: beliefsById !== undefined,
       },
     });
     if ('failed' in produced) return produced.failed;
@@ -478,15 +492,24 @@ export class SynthesizeService {
       guardrails,
       decisionLog,
       abstention: profile.abstentionCalibration,
-      // MM-zoom PR2: fragment-arm evidence citations through the
-      // rendered-set fence — spread onto the served result only when
-      // non-empty (finalizeVerdict) and fed to the 0113 capability
-      // gate (citedCapabilities). [] with the flag off ⇒ byte-identical.
-      evidenceCitations: resolveAndCountFragmentCitations({
-        citedFragmentIds: generated.citedFragmentIds,
-        fragmentsById,
-        metrics: this.metrics,
-      }),
+      // MM-zoom PR2 + BELIEFS_SERVING_LANE: fragment-arm and belief-arm
+      // evidence citations through their rendered-set fences, merged —
+      // spread onto the served result only when non-empty
+      // (finalizeVerdict) and fed to the 0113 capability gate
+      // (citedCapabilities; the belief arm carries no capability stamp).
+      // [] with both flags off ⇒ byte-identical.
+      evidenceCitations: [
+        ...resolveAndCountFragmentCitations({
+          citedFragmentIds: generated.citedFragmentIds,
+          fragmentsById,
+          metrics: this.metrics,
+        }),
+        ...resolveAndCountBeliefCitations({
+          citedBeliefIds: generated.citedBeliefIds,
+          beliefsById,
+          metrics: this.metrics,
+        }),
+      ],
     });
   }
 
@@ -522,6 +545,11 @@ export class SynthesizeService {
       factIds: opts.factIds,
       evidence: opts.evidence,
       fragmentCitations: fragmentCitationsEnabled(),
+      // BELIEFS_SERVING_LANE, resolved ONCE per request (the same
+      // single-resolution idiom): the lane, the rendered headers, the
+      // generator affordance and the resolver all key off the resulting
+      // fence map (populated ⟺ flag on AND beliefs rendered).
+      beliefLane: beliefServingLaneEnabled(),
     });
   }
 
@@ -690,6 +718,14 @@ export class SynthesizeService {
       verdict,
       decisionId: ctx.decisionId,
     });
+    // 0107 belief arm (D7): cited beliefs count as use — and as VERIFIED
+    // use on a supported verdict — with the same decisionId threading.
+    emitBeliefAnswerUse(this.outcomes, {
+      companyId: ctx.companyId,
+      evidenceCitations: args.evidenceCitations,
+      verdict,
+      decisionId: ctx.decisionId,
+    });
     // The gate-resolution also folds in the evidence-capability flag
     // (FOVEA_EVIDENCE_CAPABILITY, 0113 — resolveEvidenceCapability, the
     // resolveAnswerIntegrity sibling in answer-integrity.ts): does the
@@ -849,6 +885,10 @@ export class SynthesizeService {
        *  carries them identically (buildGeneratorArgs reads both). */
       fragmentLines?: string[] | undefined;
       fragmentCitations?: boolean | undefined;
+      /** BELIEFS_SERVING_LANE: belief lines + affordance — round 2
+       *  carries them identically too. */
+      beliefLines?: string[] | undefined;
+      beliefCitations?: boolean | undefined;
     };
   }): Promise<{
     results: SearchHit[];

--- a/src/synthesize/synthesize.types.ts
+++ b/src/synthesize/synthesize.types.ts
@@ -65,9 +65,10 @@ export interface TokenUsage {
 
 /**
  * Non-fact evidence citation — a claim's reference to the stored
- * observation it came from. TWO arms behind a ONE-OF invariant
- * (exactly one of `episodeId` / `fragmentId` is present; resolvers
- * construct only well-formed arms, never both, never neither):
+ * observation it came from. THREE arms behind a ONE-OF invariant
+ * (exactly one of `episodeId` / `fragmentId` / `beliefId` is present;
+ * resolvers construct only well-formed arms, never several, never
+ * none):
  *
  *  - EPISODE arm (FOVEA_L3_EPISODE_CITATIONS): a transcript-grounded
  *    claim's reference to the stored episode turn. `span`, when present,
@@ -86,9 +87,17 @@ export interface TokenUsage {
  *    the generator actually saw (the rendered-set fence of
  *    resolveFragmentCitations — never generator-authored text).
  *
- * Widened ADDITIVELY from the episode-only shape: every pre-existing
- * consumer reads `episodeId?`/`span?` and is untouched by absent
- * fragment fields.
+ *  - BELIEF arm (BELIEFS_SERVING_LANE): a current-state claim's
+ *    reference to the semantic_belief revision it rests on (0120/0126).
+ *    `excerpt` is the RENDERED statement excerpt the generator actually
+ *    saw (resolveBeliefCitations — same rendered-set fence) and
+ *    `occurredAt` its validFrom. NO `capability` stamp (the episode-arm
+ *    precedent): a belief line is distilled text, so it neither
+ *    satisfies nor triggers the 0113 non-text capability gate.
+ *
+ * Widened ADDITIVELY from the episode-only shape (and again for the
+ * belief arm): every pre-existing consumer reads its own arm's fields
+ * and is untouched by absent fields of the other arms.
  */
 export interface EvidenceCitation {
   episodeId?: string;
@@ -99,6 +108,7 @@ export interface EvidenceCitation {
   assetId?: string;
   capability?: EvidenceCapability;
   excerpt?: string;
+  beliefId?: string;
 }
 
 export interface SynthesizeResult {
@@ -158,6 +168,14 @@ export interface GeneratorOutput {
    * resolved defensively via resolveFragmentCitations — never trusted.
    */
   citedFragmentIds?: string[];
+  /**
+   * Belief citations (BELIEFS_SERVING_LANE): the belief ids the
+   * generator grounds current-state claims on, echoed from the rendered
+   * `[semantic_belief:...]` headers. Only present when the call was made
+   * with the belief-citation affordance; resolved defensively via
+   * resolveBeliefCitations — never trusted (the citedFragmentIds idiom).
+   */
+  citedBeliefIds?: string[];
   /** Generator-call usage, when the provider reported it. */
   usage?: TokenUsage;
 }

--- a/src/synthesize/verifier.ts
+++ b/src/synthesize/verifier.ts
@@ -81,6 +81,13 @@ export interface VerifyRequest {
   /** Derived insights (V8 §1) the generator was allowed to answer from. */
   insightLines?: string[] | undefined;
   /**
+   * BELIEFS_SERVING_LANE: the rendered current-state belief lines the
+   * generator saw — evidence parity (W5 #22: belief lines are EVIDENCE,
+   * unlike the advisory strategy notes). Composed as its own section
+   * ONLY when non-empty — absent/empty ⇒ the prompt is byte-identical.
+   */
+  beliefLines?: string[] | undefined;
+  /**
    * V8 §2 / V9 §2: the transcript excerpts were collected as the
    * MENTION RECORD for an ordering question — label them so the auditor
    * treats excerpt sequence as valid support for order claims (the
@@ -118,6 +125,7 @@ function buildVerifierUserMessage({
   factLines,
   transcriptLines,
   insightLines,
+  beliefLines,
   timelineEvidence,
   dateMathLines,
   capabilityEvidenceLines,
@@ -127,6 +135,7 @@ function buildVerifierUserMessage({
   factLines: string[];
   transcriptLines?: string[] | undefined;
   insightLines?: string[] | undefined;
+  beliefLines?: string[] | undefined;
   timelineEvidence?: boolean | undefined;
   dateMathLines?: string[] | undefined;
   capabilityEvidenceLines?: string[] | undefined;
@@ -140,6 +149,14 @@ function buildVerifierUserMessage({
   }
   if (insightLines && insightLines.length > 0) {
     sections.push(`Derived insights (equally valid support):\n` + insightLines.join('\n'));
+  }
+  // Belief section (BELIEFS_SERVING_LANE seam) — only when non-empty,
+  // so every no-lane audit prompt stays byte-identical.
+  if (beliefLines && beliefLines.length > 0) {
+    sections.push(
+      `Current-state record (distilled belief lines — each states the CURRENT value of its subject/field and supersedes older values in the other sections for present-tense claims; equally valid support):\n` +
+        beliefLines.join('\n'),
+    );
   }
   if (dateMathLines && dateMathLines.length > 0) {
     sections.push(

--- a/test/audit-p1-guards.unit-spec.ts
+++ b/test/audit-p1-guards.unit-spec.ts
@@ -1094,6 +1094,62 @@ describe('0117_window_user_scope (mixed-user privacy fence substrate)', () => {
   });
 });
 
+describe('0126_belief_serving_search (belief lane BM25 leg)', () => {
+  const SRC = join(__dirname, '..', 'src');
+  const sql = readFileSync(join(MIGRATIONS, '0126_belief_serving_search.surql'), 'utf8');
+
+  it('defines the BM25 statement index with the lowercase-only analyzer', () => {
+    // The 0073/0075/0106/0124 analyzer contract: lowercase only —
+    // snowball stemming would mangle non-Latin scripts, and belief
+    // statements quote free-text subject/field/value keys.
+    expect(sql).toContain(
+      'DEFINE ANALYZER IF NOT EXISTS belief_statement TOKENIZERS class FILTERS lowercase;',
+    );
+    expect(sql).toMatch(
+      /DEFINE INDEX IF NOT EXISTS belief_statement_search ON semantic_belief\s+FIELDS statement FULLTEXT ANALYZER belief_statement BM25;/,
+    );
+  });
+
+  it('defines the write-dead embedding column as option<array<float>> (the 0124 precedent)', () => {
+    expect(sql).toContain(
+      'DEFINE FIELD IF NOT EXISTS embedding ON semantic_belief TYPE option<array<float>>;',
+    );
+  });
+
+  it.each([['belief_statement_search', 'semantic_belief', 'statement']])(
+    'defines %s on %s(%s) single-field (3.2.4 compound-planner DELETE risk)',
+    (name, table) => {
+      const indexLines = sql
+        .split('\n')
+        .filter((l) => l.trimStart().startsWith('DEFINE INDEX'))
+        .filter((l) => l.includes(name) && l.includes(table));
+      expect(indexLines.length).toBeGreaterThan(0);
+      for (const line of indexLines) {
+        expect(line).not.toMatch(/FIELDS [A-Za-z]+,/);
+      }
+    },
+  );
+
+  it('the belief lane service is covered by the repo-wide DELETE-shape sweep and is itself clean', () => {
+    // The 0120 sweep above walks ALL of src/, so the new serving-path
+    // reader is covered by construction — this pin makes the coverage
+    // EXPLICIT (a moved/renamed file must not silently escape it) and
+    // re-asserts the file adds no delete path at all.
+    const lanePath = join(SRC, 'synthesize', 'belief-lane.service.ts');
+    // Comment lines EXPLAIN the trap (0058-guard idiom) — judge only
+    // code lines.
+    const code = readFileSync(lanePath, 'utf8')
+      .split('\n')
+      .filter((l) => {
+        const t = l.trimStart();
+        return !t.startsWith('--') && !t.startsWith('//') && !t.startsWith('*');
+      })
+      .join('\n');
+    expect(code).not.toMatch(/DELETE semantic_belief\s+WHERE/);
+    expect(code).not.toMatch(/\bDELETE\b/);
+  });
+});
+
 describe('0124_fragment_content_search (fragment lane BM25 leg)', () => {
   const sql = readFileSync(join(MIGRATIONS, '0124_fragment_content_search.surql'), 'utf8');
 

--- a/test/belief-citations.unit-spec.ts
+++ b/test/belief-citations.unit-spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Belief citations (BELIEFS_SERVING_LANE) — the pure seams
+ * (the fragment-citations.unit-spec sibling):
+ *
+ *  - resolveBeliefCitations: the rendered-set fence (unknown ids
+ *    dropped + counted, never surfaced), rendered-excerpt-only, the
+ *    one-of invariant (belief arm only — no episodeId, no fragmentId,
+ *    no capability stamp), dedupe, the cap, and the defensive parse of
+ *    malformed generator entries;
+ *  - resolveAndCountBeliefCitations: absent fence map ⇒ [] (flag off /
+ *    nothing rendered — the byte-identical default path), and the
+ *    per-outcome metric emission.
+ */
+import {
+  resolveBeliefCitations,
+  resolveAndCountBeliefCitations,
+  type CitableBelief,
+} from '../src/synthesize/belief-citations';
+
+const belief = (id: string, over: Partial<CitableBelief> = {}): CitableBelief => ({
+  beliefId: id,
+  subject: 'inventory service',
+  field: 'database',
+  value: 'SurrealDB',
+  excerpt: 'inventory service — database: SurrealDB (was: PostgreSQL)',
+  occurredAt: '2026-08-01T00:00:00.000Z',
+  ...over,
+});
+
+const renderedSet = (...beliefs: CitableBelief[]): Map<string, CitableBelief> =>
+  new Map(beliefs.map((b) => [b.beliefId, b]));
+
+describe('resolveBeliefCitations — the rendered-set fence', () => {
+  it('a rendered id resolves to a belief-arm citation carrying the RENDERED excerpt', () => {
+    const { citations, counts } = resolveBeliefCitations(
+      ['semantic_belief:b1'],
+      renderedSet(belief('semantic_belief:b1')),
+    );
+    expect(citations).toEqual([
+      {
+        beliefId: 'semantic_belief:b1',
+        excerpt: 'inventory service — database: SurrealDB (was: PostgreSQL)',
+        occurredAt: '2026-08-01T00:00:00.000Z',
+      },
+    ]);
+    expect(counts).toEqual({ cited: 1, dropped_unknown: 0 });
+    // ONE-OF invariant: the belief arm never carries the other arms —
+    // and no capability stamp (text baseline only for the 0113 gate).
+    expect(citations[0]!.episodeId).toBeUndefined();
+    expect(citations[0]!.fragmentId).toBeUndefined();
+    expect(citations[0]!.capability).toBeUndefined();
+  });
+
+  it('an id NOT in the rendered set is dropped and counted — never surfaced', () => {
+    const { citations, counts } = resolveBeliefCitations(
+      ['semantic_belief:hallucinated', 'semantic_belief:b1'],
+      renderedSet(belief('semantic_belief:b1')),
+    );
+    expect(citations).toHaveLength(1);
+    expect(citations[0]!.beliefId).toBe('semantic_belief:b1');
+    expect(counts).toEqual({ cited: 1, dropped_unknown: 1 });
+  });
+
+  it('malformed entries (non-string, empty, wrong-key object) are dropped and counted', () => {
+    const { citations, counts } = resolveBeliefCitations(
+      [42, '', null, { other: 'semantic_belief:b1' }, { beliefId: 'semantic_belief:b1' }],
+      renderedSet(belief('semantic_belief:b1')),
+    );
+    // The tolerated {beliefId} object form resolves; the rest drop.
+    expect(citations).toHaveLength(1);
+    expect(counts).toEqual({ cited: 1, dropped_unknown: 4 });
+  });
+
+  it('dedupes by beliefId — a repeated cite ships once and counts once', () => {
+    const { citations, counts } = resolveBeliefCitations(
+      ['semantic_belief:b1', 'semantic_belief:b1'],
+      renderedSet(belief('semantic_belief:b1')),
+    );
+    expect(citations).toHaveLength(1);
+    expect(counts.cited).toBe(1);
+  });
+
+  it('caps resolved citations at 16', () => {
+    const many = Array.from({ length: 20 }, (_, i) => belief(`semantic_belief:b${i}`));
+    const { citations } = resolveBeliefCitations(
+      many.map((b) => b.beliefId),
+      renderedSet(...many),
+    );
+    expect(citations).toHaveLength(16);
+  });
+
+  it('omits occurredAt when the rendered belief has none', () => {
+    const { citations } = resolveBeliefCitations(
+      ['semantic_belief:b1'],
+      renderedSet(belief('semantic_belief:b1', { occurredAt: undefined })),
+    );
+    expect('occurredAt' in citations[0]!).toBe(false);
+  });
+});
+
+describe('resolveAndCountBeliefCitations — the service-facing wrapper', () => {
+  it('absent fence map ⇒ [] (flag off / nothing rendered — byte-identical default)', () => {
+    const counted: Array<[string, number]> = [];
+    const out = resolveAndCountBeliefCitations({
+      citedBeliefIds: ['semantic_belief:b1'],
+      beliefsById: undefined,
+      metrics: { countBeliefCitation: (o, n) => counted.push([o, n ?? 1]) },
+    });
+    expect(out).toEqual([]);
+    expect(counted).toEqual([]);
+  });
+
+  it('emits one metric count per non-zero outcome', () => {
+    const counted: Array<[string, number]> = [];
+    const out = resolveAndCountBeliefCitations({
+      citedBeliefIds: ['semantic_belief:b1', 'semantic_belief:nope', 'semantic_belief:nah'],
+      beliefsById: renderedSet(belief('semantic_belief:b1')),
+      metrics: { countBeliefCitation: (o, n) => counted.push([o, n ?? 1]) },
+    });
+    expect(out).toHaveLength(1);
+    expect(counted).toEqual([
+      ['cited', 1],
+      ['dropped_unknown', 2],
+    ]);
+  });
+
+  it('undefined citedBeliefIds with a populated map ⇒ [] and zero counts', () => {
+    const counted: Array<[string, number]> = [];
+    const out = resolveAndCountBeliefCitations({
+      citedBeliefIds: undefined,
+      beliefsById: renderedSet(belief('semantic_belief:b1')),
+      metrics: { countBeliefCitation: (o, n) => counted.push([o, n ?? 1]) },
+    });
+    expect(out).toEqual([]);
+    expect(counted).toEqual([]);
+  });
+});

--- a/test/belief-lane.unit-spec.ts
+++ b/test/belief-lane.unit-spec.ts
@@ -1,0 +1,292 @@
+/**
+ * Belief retrieval lane (BELIEFS_SERVING_LANE) — unit coverage of the
+ * fence stack and the degrade seams, over a scripted Surreal double
+ * (the fragment-lane.unit-spec sibling):
+ *
+ *  - D4 scoped-user fence: `userId === undefined` ⇒ EMPTY and NO query
+ *    is ever issued (deliberately STRICTER than the read API, where an
+ *    M2M credential reads the whole tenant);
+ *  - WHERE composition: `userId = $u` + `status = 'active'` on both
+ *    legs;
+ *  - beliefVisible JS re-check: an out-of-contract row (blank/missing
+ *    userId stamp) the SQL fence let through never renders;
+ *  - render: one line per (subject, field), `[semantic_belief:...]`
+ *    header, validFrom-ascending, 600-char statement cap, TOP_K = 3,
+ *    byId = exactly the rendered set;
+ *  - degrade: an embedder failure skips the dense leg but keeps BM25;
+ *    a query failure degrades the lane to empty, never a throw;
+ *  - collector gating: caller-resolved flag off (or lane unwired) ⇒ no
+ *    call, empty section.
+ */
+import { BeliefLaneService } from '../src/synthesize/belief-lane.service';
+import { EvidenceCollectorService } from '../src/synthesize/evidence-collector.service';
+import type { SearchService, SearchHit } from '../src/search/search.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { EmbedderService } from '../src/ai/embedder.service';
+import { resolveRetrievalProfile, type RetrievalProfile } from '../src/search/retrieval-profile';
+
+interface BeliefRowFixture {
+  id: string;
+  userId: string;
+  subject: string;
+  field: string;
+  value: string;
+  statement: string;
+  revision: number;
+  validFrom: string;
+  score: number;
+}
+
+const row = (over: Partial<BeliefRowFixture>): BeliefRowFixture => ({
+  id: 'semantic_belief:b1',
+  userId: 'u1',
+  subject: 'inventory service',
+  field: 'database',
+  value: 'SurrealDB',
+  statement: 'inventory service — database: SurrealDB (was: PostgreSQL)',
+  revision: 2,
+  validFrom: '2026-08-01T00:00:00.000Z',
+  score: 1,
+  ...over,
+});
+
+/** Scripted Surreal double: routes by query text, records every call. */
+function surrealOf(opts: {
+  bm25Rows?: BeliefRowFixture[];
+  denseRows?: BeliefRowFixture[];
+  failRetrieval?: boolean;
+}) {
+  const calls: Array<{ sql: string; params: Record<string, unknown> | undefined }> = [];
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      calls.push({ sql, params });
+      if (opts.failRetrieval) throw new Error('boom');
+      if (sql.includes('vector::similarity')) return [opts.denseRows ?? []];
+      if (sql.includes('@1@')) return [opts.bm25Rows ?? []];
+      return [[]];
+    },
+  };
+  const surreal = {
+    withCompany: async (_companyId: string, fn: (d: typeof db) => Promise<unknown>) => fn(db),
+  } as unknown as SurrealService;
+  return { surreal, calls };
+}
+
+const embedderOk = {
+  embed: async () => [0.1, 0.2, 0.3],
+} as unknown as EmbedderService;
+
+const embedderBroken = {
+  embed: async () => {
+    throw new Error('no embedder');
+  },
+} as unknown as EmbedderService;
+
+const baseOpts = {
+  companyId: 'co_belief',
+  query: 'which database are we using for the inventory service?',
+  userId: 'u1' as string | undefined,
+};
+
+describe('BeliefLaneService — D4 scoped-user fence', () => {
+  it('undefined userId ⇒ EMPTY and NO query is ever issued (stricter than the read API)', async () => {
+    const { surreal, calls } = surrealOf({ bm25Rows: [row({})] });
+    const out = await new BeliefLaneService(surreal, embedderOk).beliefLines({
+      ...baseOpts,
+      userId: undefined,
+    });
+    expect(out.lines).toEqual([]);
+    expect(out.byId.size).toBe(0);
+    expect(calls).toEqual([]);
+  });
+
+  it('scoped read: `userId = $u` AND `status = active` on both legs', async () => {
+    const { surreal, calls } = surrealOf({ bm25Rows: [row({})] });
+    await new BeliefLaneService(surreal, embedderOk).beliefLines(baseOpts);
+    const retrievals = calls.filter((c) => c.sql.includes('FROM semantic_belief'));
+    expect(retrievals.length).toBe(2); // dense + BM25
+    for (const c of retrievals) {
+      expect(c.sql).toContain('userId = $u');
+      expect(c.sql).toContain("status = 'active'");
+      expect(c.params).toMatchObject({ u: 'u1' });
+    }
+  });
+
+  it('beliefVisible re-check drops an out-of-contract (blank-stamp) row fail-closed', async () => {
+    const { surreal } = surrealOf({
+      bm25Rows: [
+        row({ id: 'semantic_belief:blank', userId: '' }),
+        row({ id: 'semantic_belief:other', userId: 'u2' }),
+      ],
+    });
+    const out = await new BeliefLaneService(surreal, embedderOk).beliefLines(baseOpts);
+    expect(out.lines).toEqual([]);
+    expect(out.byId.size).toBe(0);
+  });
+});
+
+describe('BeliefLaneService — render + degrade', () => {
+  it('renders id-headed validFrom-ascending lines, one per (subject, field), and fills byId', async () => {
+    const { surreal } = surrealOf({
+      bm25Rows: [
+        row({}),
+        row({
+          id: 'semantic_belief:b2',
+          subject: 'billing service',
+          field: 'queue',
+          value: 'nats',
+          statement: 'billing service — queue: nats',
+          revision: 1,
+          validFrom: '2026-07-01T00:00:00.000Z',
+          score: 0.5,
+        }),
+      ],
+    });
+    const out = await new BeliefLaneService(surreal, embedderOk).beliefLines(baseOpts);
+    expect(out.lines).toEqual([
+      '[semantic_belief:b2] (billing service — queue, rev 1, as of 2026-07-01) ' +
+        'billing service — queue: nats',
+      '[semantic_belief:b1] (inventory service — database, rev 2, as of 2026-08-01) ' +
+        'inventory service — database: SurrealDB (was: PostgreSQL)',
+    ]);
+    expect([...out.byId.keys()].sort()).toEqual(['semantic_belief:b1', 'semantic_belief:b2']);
+    expect(out.byId.get('semantic_belief:b1')).toEqual({
+      beliefId: 'semantic_belief:b1',
+      subject: 'inventory service',
+      field: 'database',
+      value: 'SurrealDB',
+      excerpt: 'inventory service — database: SurrealDB (was: PostgreSQL)',
+      occurredAt: '2026-08-01T00:00:00.000Z',
+    });
+  });
+
+  it('dedupes by (subject, field) keeping the best-fused row', async () => {
+    const { surreal } = surrealOf({
+      bm25Rows: [
+        row({ id: 'semantic_belief:best', score: 2 }),
+        row({ id: 'semantic_belief:worse', score: 1 }),
+      ],
+    });
+    const out = await new BeliefLaneService(surreal, embedderOk).beliefLines(baseOpts);
+    expect(out.lines).toHaveLength(1);
+    expect(out.lines[0]).toContain('[semantic_belief:best]');
+  });
+
+  it('caps at BELIEF_LANE_TOP_K = 3 lines', async () => {
+    const { surreal } = surrealOf({
+      bm25Rows: [1, 2, 3, 4, 5].map((i) =>
+        row({ id: `semantic_belief:b${i}`, field: `f${i}`, score: 6 - i }),
+      ),
+    });
+    const out = await new BeliefLaneService(surreal, embedderOk).beliefLines(baseOpts);
+    expect(out.lines).toHaveLength(3);
+    expect(out.byId.size).toBe(3);
+  });
+
+  it('caps the rendered statement at 600 chars', async () => {
+    const { surreal } = surrealOf({ bm25Rows: [row({ statement: 'x'.repeat(1000) })] });
+    const out = await new BeliefLaneService(surreal, embedderOk).beliefLines(baseOpts);
+    const excerpt = out.byId.get('semantic_belief:b1')!.excerpt;
+    expect(excerpt).toHaveLength(600);
+    expect(out.lines[0]!.endsWith(excerpt)).toBe(true);
+  });
+
+  it('an embedder failure skips the dense leg but keeps the BM25 leg', async () => {
+    const { surreal, calls } = surrealOf({ bm25Rows: [row({})] });
+    const out = await new BeliefLaneService(surreal, embedderBroken).beliefLines(baseOpts);
+    expect(out.lines).toHaveLength(1);
+    expect(calls.some((c) => c.sql.includes('vector::similarity'))).toBe(false);
+    expect(calls.some((c) => c.sql.includes('@1@'))).toBe(true);
+  });
+
+  it('a retrieval failure degrades the lane to empty — never a throw', async () => {
+    const { surreal } = surrealOf({ failRetrieval: true });
+    const out = await new BeliefLaneService(surreal, embedderOk).beliefLines(baseOpts);
+    expect(out.lines).toEqual([]);
+    expect(out.byId.size).toBe(0);
+  });
+});
+
+describe('EvidenceCollectorService — belief lane gating', () => {
+  const noSearch = { search: async () => ({ results: [] }) } as unknown as SearchService;
+
+  function profileWith(over: Partial<RetrievalProfile>): RetrievalProfile {
+    return { ...resolveRetrievalProfile({} as NodeJS.ProcessEnv), ...over } as RetrievalProfile;
+  }
+
+  function collectorWith(lane: BeliefLaneService | undefined) {
+    return new EvidenceCollectorService(
+      noSearch,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      lane,
+    );
+  }
+
+  const collectArgs = (beliefLane?: boolean) => ({
+    profile: profileWith({}),
+    lane: null,
+    companyId: 'co_belief',
+    query: 'which database',
+    callerScopes: [] as string[],
+    factIds: [] as string[],
+    evidence: [] as SearchHit[],
+    userId: 'u1',
+    ...(beliefLane !== undefined ? { beliefLane } : {}),
+  });
+
+  const scriptedLane = (calls: string[]) =>
+    ({
+      beliefLines: async (o: { query: string }) => {
+        calls.push(o.query);
+        return {
+          lines: ['[semantic_belief:b1] (s — f, rev 1) s — f: v'],
+          byId: new Map([
+            [
+              'semantic_belief:b1',
+              {
+                beliefId: 'semantic_belief:b1',
+                subject: 's',
+                field: 'f',
+                value: 'v',
+                excerpt: 's — f: v',
+              },
+            ],
+          ]),
+        };
+      },
+    }) as unknown as BeliefLaneService;
+
+  it('caller-resolved flag off (or absent) ⇒ the lane is never called', async () => {
+    const called: string[] = [];
+    const lane = scriptedLane(called);
+    const off = await collectorWith(lane).collect(collectArgs());
+    expect(off.beliefLines).toEqual([]);
+    expect(off.beliefsById).toBeUndefined();
+    const explicit = await collectorWith(lane).collect(collectArgs(false));
+    expect(explicit.beliefLines).toEqual([]);
+    expect(called).toEqual([]);
+  });
+
+  it('flag on ⇒ lines flow through and beliefsById is the rendered set', async () => {
+    const called: string[] = [];
+    const out = await collectorWith(scriptedLane(called)).collect(collectArgs(true));
+    expect(out.beliefLines).toEqual(['[semantic_belief:b1] (s — f, rev 1) s — f: v']);
+    expect(out.beliefsById?.size).toBe(1);
+    expect(called).toEqual(['which database']);
+  });
+
+  it('lane unwired ⇒ empty section (partial-wiring degrade)', async () => {
+    const out = await collectorWith(undefined).collect(collectArgs(true));
+    expect(out.beliefLines).toEqual([]);
+    expect(out.beliefsById).toBeUndefined();
+  });
+});

--- a/test/belief-serving.e2e-spec.ts
+++ b/test/belief-serving.e2e-spec.ts
@@ -138,10 +138,7 @@ describe('Belief serving lane e2e (the dogfood stale-answer scenario)', () => {
     });
     process.env.SCENES_SEGMENTATION_ENABLED = '1';
     process.env.SCENES_BELIEF_PROMOTION = '1';
-    const promoted = await f.http
-      .post('/v1/admin/maintenance/scenes/beliefs')
-      .set(auth())
-      .send({});
+    const promoted = await f.http.post('/v1/admin/maintenance/scenes/beliefs').set(auth()).send({});
     expect(promoted.status).toBe(201);
     expect(promoted.body).toMatchObject({ beliefsCreated: 1 });
     delete process.env.SCENES_SEGMENTATION_ENABLED;

--- a/test/belief-serving.e2e-spec.ts
+++ b/test/belief-serving.e2e-spec.ts
@@ -1,0 +1,302 @@
+/**
+ * Belief serving lane e2e (BELIEFS_SERVING_LANE) over a real SurrealDB
+ * (testcontainer) — the dogfood acceptance scenario the lane exists for:
+ * the user decided Postgres, then SWITCHED to SurrealDB; free extraction
+ * produced non-colliding claims (both alive — the supersede never
+ * fired), while the belief substrate holds the CORRECT current state.
+ *
+ * Substrate: the EXACT dogfood shape — two alive facts
+ * (`PostgreSQL|code_memory__decided|we will use Postgres as the main
+ * database` + `SurrealDB|interacted_with|SurrealDB`) and one enriched
+ * scene with stateDelta {subject:'inventory service', field:'database',
+ * from:'PostgreSQL', to:'SurrealDB'} for USER, folded by the Belief-A
+ * promotion into an active belief value=SurrealDB.
+ *
+ * Pins:
+ *   1. CONTROL (flag off): the generator prompt carries NO belief
+ *      section and the response no evidenceCitations — today's stale
+ *      serving, byte-identical with the substrate fully populated;
+ *   2. flag ON: the belief line renders for generator AND verifier
+ *      (evidence parity), the scripted generator cites the belief id ⇒
+ *      the served answer says SurrealDB with a belief-arm evidence
+ *      citation whose excerpt IS the rendered statement, and 0107
+ *      memory_outcome rows land under subjectKind='belief'
+ *      (selected_for_context + used_in_answer + verifier_supported);
+ *   3. history non-regression (flag on): the fact lines stay in the
+ *      prompt and the scripted answer covers the PostgreSQL→SurrealDB
+ *      transition — the in-prompt routing never removes fact evidence;
+ *   4. user fence (D4): another user gets NO belief line; an unscoped
+ *      request gets NO belief line (stricter than the read API).
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSynthesizeOpenAi } from './test-doubles';
+import { SurrealService } from '../src/db/surreal.service';
+
+const USER = 'dogfood_u1';
+const OTHER_USER = 'dogfood_u2';
+const QUERY = 'which database are we using for the inventory service?';
+const HISTORY_QUERY = 'how did the database choice for the inventory service change?';
+const STATEMENT = 'inventory service — database: SurrealDB (was: PostgreSQL)';
+const VERIFY_SUPPORTED = JSON.stringify({ verdict: 'supported', unsupportedClaims: [] });
+
+const FLAG_KEYS = ['BELIEFS_SERVING_LANE', 'OUTCOME_TELEMETRY_ENABLED'] as const;
+
+describe('Belief serving lane e2e (the dogfood stale-answer scenario)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const savedEnv: Record<string, string | undefined> = {};
+
+  let pgFactId: string;
+  let beliefId: string;
+
+  const db = <T>(
+    fn: (d: { query: <Q>(sql: string, p?: Record<string, unknown>) => Promise<Q> }) => Promise<T>,
+  ): Promise<T> => f.app.get(SurrealService).withCompany(f.companyId, fn);
+
+  const synth = (body: Record<string, unknown>) =>
+    f.http
+      .post('/v1/synthesize')
+      .set(auth())
+      .send({ limit: 5, ...body });
+
+  /** Outcome writers are fire-and-forget — poll until the rows land. */
+  const waitFor = async <T>(probe: () => Promise<T>, ok: (v: T) => boolean): Promise<T> => {
+    for (let i = 0; i < 40; i++) {
+      const v = await probe();
+      if (ok(v)) return v;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    return probe();
+  };
+
+  beforeAll(async () => {
+    for (const k of [
+      ...FLAG_KEYS,
+      'RETRIEVAL_ABSTENTION_CALIBRATION',
+      'SCENES_SEGMENTATION_ENABLED',
+      'SCENES_BELIEF_PROMOTION',
+    ]) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    // Pin abstention off so a thin-evidence query never pre-abstains
+    // before generation (the 0113 e2e discipline).
+    process.env.RETRIEVAL_ABSTENTION_CALIBRATION = 'off';
+    f = await createApp({ companyId: 'co_belief_serving_e2e' });
+
+    // The dogfood fact pair — non-colliding (entity, predicate) keys, so
+    // fn::resolve_fact never superseded either; BOTH stay alive.
+    // Tenant-global (no userId) so every fence variant below still has
+    // fact evidence to synthesize from.
+    const pg = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'proj', id: 'postgresql' },
+        predicate: 'code_memory__decided',
+        object: 'we will use Postgres as the main database',
+        validFrom: new Date('2026-08-01').toISOString(),
+        confidence: 0.9,
+        source: { vertical: 'proj', recorder: 'bot' },
+      });
+    expect([200, 201]).toContain(pg.status);
+    pgFactId = pg.body.factId as string;
+    expect(pgFactId).toBeTruthy();
+    const sdb = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'proj', id: 'surrealdb' },
+        predicate: 'interacted_with',
+        object: 'SurrealDB is the database now used by the inventory service',
+        validFrom: new Date('2026-08-10').toISOString(),
+        confidence: 0.9,
+        source: { vertical: 'proj', recorder: 'bot' },
+      });
+    expect([200, 201]).toContain(sdb.status);
+
+    // The enriched scene carrying the state delta (the belief-promotion
+    // direct-seed precedent), then the Belief-A fold → active belief.
+    await db(async (d) => {
+      await d.query(
+        `CREATE memory_episode:dogfood1 CONTENT {
+           userId: $u, userIds: [$u], scope: [],
+           sceneLabel: 'db switch', conversationIds: ['proj:c1'],
+           occurredFrom: <datetime>'2026-08-10T10:00:00.000Z',
+           occurredTo: <datetime>'2026-08-10T10:00:00.000Z',
+           gist: 'switched the inventory service database',
+           confidence: 1,
+           stateDeltas: [{ subject: 'inventory service', field: 'database',
+                           from: 'PostgreSQL', to: 'SurrealDB' }],
+           segmenterVersion: 'scene-segmenter-v1', generation: 'seed-gen',
+           source: { recorder: 'test-seed' },
+           enrichmentVersion: 'seed-enrich-v1',
+           enrichedMemoryValue: { explicitness: 0.8 } }`,
+        { u: USER },
+      );
+    });
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    process.env.SCENES_BELIEF_PROMOTION = '1';
+    const promoted = await f.http
+      .post('/v1/admin/maintenance/scenes/beliefs')
+      .set(auth())
+      .send({});
+    expect(promoted.status).toBe(201);
+    expect(promoted.body).toMatchObject({ beliefsCreated: 1 });
+    delete process.env.SCENES_SEGMENTATION_ENABLED;
+    delete process.env.SCENES_BELIEF_PROMOTION;
+
+    const beliefs = await db(async (d) => {
+      const [rows] = await d.query<
+        [Array<{ id: unknown; value: string; status: string; statement: string }>]
+      >(`SELECT id, value, status, statement FROM semantic_belief`);
+      return rows ?? [];
+    });
+    expect(beliefs).toHaveLength(1);
+    expect(beliefs[0]).toMatchObject({ value: 'SurrealDB', status: 'active' });
+    expect(beliefs[0]!.statement).toBe(STATEMENT);
+    beliefId = String(beliefs[0]!.id);
+  }, 120000);
+
+  afterEach(() => {
+    for (const k of FLAG_KEYS) delete process.env[k];
+  });
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (f) await f.close();
+  });
+
+  it('CONTROL — flag off: no belief section, no evidenceCitations, the stale path serves as today', async () => {
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({
+        answer: 'We decided to use Postgres as the main database [' + pgFactId + '].',
+        citedFactIds: [pgFactId],
+      }),
+      VERIFY_SUPPORTED,
+    ]);
+    const res = await synth({ query: QUERY, userId: USER });
+    expect(res.status).toBe(201);
+    expect(res.body.answer).toContain('Postgres');
+    expect(res.body.evidenceCitations).toBeUndefined();
+    expect(state.calls.length).toBe(2);
+    // No belief section, no belief id, no citation affordance — the
+    // substrate is fully populated yet serving is byte-identical.
+    expect(state.calls[0]!.user).not.toContain('Current-state record');
+    expect(state.calls[0]!.user).not.toContain('[semantic_belief:');
+    expect(state.calls[0]!.system).not.toContain('BELIEF CITATIONS');
+    expect(state.calls[1]!.user).not.toContain('Current-state record');
+  });
+
+  it('flag ON: belief line renders for generator AND verifier; cited belief ⇒ SurrealDB answer + belief-arm citation + 0107 rows', async () => {
+    process.env.BELIEFS_SERVING_LANE = '1';
+    process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({
+        answer:
+          'The inventory service now uses SurrealDB [' +
+          beliefId +
+          '] (previously Postgres [' +
+          pgFactId +
+          ']).',
+        citedFactIds: [pgFactId],
+        citedBeliefIds: [beliefId, 'semantic_belief:hallucinated'],
+      }),
+      VERIFY_SUPPORTED,
+    ]);
+    const res = await synth({ query: QUERY, userId: USER });
+    expect(res.status).toBe(201);
+    expect(res.body.answer).toContain('SurrealDB');
+    // The belief-arm evidence citation, through the rendered-set fence
+    // (the hallucinated id dropped): excerpt IS the rendered statement.
+    expect(res.body.evidenceCitations).toHaveLength(1);
+    expect(res.body.evidenceCitations[0]).toMatchObject({
+      beliefId,
+      excerpt: STATEMENT,
+    });
+    // Generator saw the current-state section with the id header and
+    // gained the schema affordance.
+    const genPrompt = state.calls[0]!.user;
+    expect(genPrompt).toContain('Current-state record');
+    expect(genPrompt).toContain(`[${beliefId}]`);
+    expect(genPrompt).toContain(STATEMENT);
+    expect(state.calls[0]!.system).toContain('BELIEF CITATIONS');
+    // Verifier parity (W5 #22): the SAME line arrives as its own section.
+    const verifyPrompt = state.calls[1]!.user;
+    expect(verifyPrompt).toContain('Current-state record (distilled belief lines');
+    expect(verifyPrompt).toContain(STATEMENT);
+    // 0107 telemetry: subjectKind='belief' rows for the rendered set
+    // (selected_for_context) and the cited serve (used_in_answer +
+    // verifier_supported under the scripted supported verdict).
+    const events = await waitFor(
+      () =>
+        db(async (d) => {
+          const [rows] = await d.query<[Array<{ event: string; subjectId: unknown }>]>(
+            `SELECT event, subjectId FROM memory_outcome WHERE subjectKind = 'belief'`,
+          );
+          return rows ?? [];
+        }),
+      (rows) => rows.length >= 3,
+    );
+    const names = events.map((e) => e.event).sort();
+    expect(names).toEqual(['selected_for_context', 'used_in_answer', 'verifier_supported']);
+    for (const e of events) expect(String(e.subjectId)).toBe(beliefId);
+  });
+
+  it('history non-regression (flag ON): fact lines stay in the prompt; the scripted answer covers the transition', async () => {
+    process.env.BELIEFS_SERVING_LANE = '1';
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({
+        answer:
+          'The team first decided on PostgreSQL, then switched the inventory service to ' +
+          'SurrealDB [' +
+          pgFactId +
+          '].',
+        citedFactIds: [pgFactId],
+        citedBeliefIds: [],
+      }),
+      VERIFY_SUPPORTED,
+    ]);
+    const res = await synth({ query: HISTORY_QUERY, userId: USER });
+    expect(res.status).toBe(201);
+    // The answer covers the PostgreSQL→SurrealDB transition.
+    expect(res.body.answer).toContain('PostgreSQL');
+    expect(res.body.answer).toContain('SurrealDB');
+    const genPrompt = state.calls[0]!.user;
+    // The fact record (the update story's raw material) is still there —
+    // the belief section ROUTES in-prompt, it never displaces evidence.
+    expect(genPrompt).toContain('Retrieved facts:');
+    expect(genPrompt).toContain('we will use Postgres as the main database');
+    // The belief section is present and its header routes history
+    // questions to facts + transcript.
+    expect(genPrompt).toContain('Current-state record');
+    expect(genPrompt).toContain('For questions about history');
+  });
+
+  it('user fence (D4): OTHER_USER gets no belief line; an unscoped request gets no belief line', async () => {
+    process.env.BELIEFS_SERVING_LANE = '1';
+    const otherState = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer: 'Postgres [' + pgFactId + '].', citedFactIds: [pgFactId] }),
+      VERIFY_SUPPORTED,
+    ]);
+    const other = await synth({ query: QUERY, userId: OTHER_USER });
+    expect(other.status).toBe(201);
+    expect(otherState.calls[0]!.user).not.toContain('Current-state record');
+    expect(otherState.calls[0]!.user).not.toContain('[semantic_belief:');
+    expect(other.body.evidenceCitations).toBeUndefined();
+
+    const unscopedState = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer: 'Postgres [' + pgFactId + '].', citedFactIds: [pgFactId] }),
+      VERIFY_SUPPORTED,
+    ]);
+    const unscoped = await synth({ query: QUERY });
+    expect(unscoped.status).toBe(201);
+    expect(unscopedState.calls[0]!.user).not.toContain('Current-state record');
+    expect(unscopedState.calls[0]!.user).not.toContain('[semantic_belief:');
+    expect(unscoped.body.evidenceCitations).toBeUndefined();
+  });
+});

--- a/test/synthesize.unit-spec.ts
+++ b/test/synthesize.unit-spec.ts
@@ -1,7 +1,16 @@
 import { ConfigService } from '@nestjs/config';
+import type OpenAI from 'openai';
 import { SynthesizeService, SynthesizeResult } from '../src/synthesize/synthesize.service';
 import type { SearchService, SearchHit } from '../src/search/search.service';
 import type { SynthesizeDto } from '../src/synthesize/dto/synthesize.dto';
+import { buildGeneratorUserMessage } from '../src/synthesize/generator-prompt';
+import { runGenerator } from '../src/synthesize/generator-client';
+import { runVerifier, type VerifierOutput } from '../src/synthesize/verifier';
+import { finalizeVerdict } from '../src/synthesize/verdict';
+import {
+  resolveEvidenceCapability,
+  type FinalizeContext,
+} from '../src/synthesize/answer-integrity';
 
 /**
  * Unit coverage for SynthesizeService — exercises the orchestrator
@@ -527,5 +536,255 @@ describe('SynthesizeService', () => {
     });
     // makeHit pins validFrom = 2026-01-01, no validUntil → "(as of …)".
     expect(prompts[0]).toContain('attended: support group (as of 2026-01-01)');
+  });
+});
+
+// ── BELIEFS_SERVING_LANE seams: byte-identity + gate pins ───────────
+describe('buildGeneratorUserMessage — belief section (BELIEFS_SERVING_LANE seam)', () => {
+  const BASE = {
+    query: 'which database are we using?',
+    factLines: ['[knowledge_fact:f1] PostgreSQL — code_memory__decided: we will use Postgres'],
+    insightLines: ['insight line'],
+    fragmentLines: ['[capability:visual] (image caption) a whiteboard'],
+    answerLang: null,
+  };
+
+  it('beliefLines absent / undefined / [] ⇒ BYTE-IDENTICAL output', () => {
+    const absent = buildGeneratorUserMessage(BASE);
+    const explicit = buildGeneratorUserMessage({ ...BASE, beliefLines: undefined });
+    const empty = buildGeneratorUserMessage({ ...BASE, beliefLines: [], beliefCitations: true });
+    expect(explicit).toBe(absent);
+    expect(empty).toBe(absent);
+    expect(absent).not.toContain('Current-state record');
+  });
+
+  it('non-empty ⇒ own section BETWEEN the insight and fragment sections', () => {
+    const line = '[semantic_belief:b1] (inventory service — database, rev 2) statement';
+    const out = buildGeneratorUserMessage({
+      ...BASE,
+      beliefLines: [line],
+      beliefCitations: true,
+    });
+    expect(out).toContain('Current-state record');
+    expect(out).toContain(line);
+    // The citations variant instructs mirroring ids into citedBeliefIds.
+    expect(out).toContain('citedBeliefIds');
+    const insightAt = out.indexOf('insight line');
+    const beliefAt = out.indexOf('Current-state record');
+    const fragmentAt = out.indexOf('Media evidence');
+    expect(insightAt).toBeGreaterThan(-1);
+    expect(fragmentAt).toBeGreaterThan(-1);
+    expect(beliefAt).toBeGreaterThan(insightAt);
+    expect(beliefAt).toBeLessThan(fragmentAt);
+  });
+
+  it('base (citations-off) variant keeps the cite-factIds-only header', () => {
+    const out = buildGeneratorUserMessage({
+      ...BASE,
+      beliefLines: ['[semantic_belief:b1] (s — f, rev 1) s'],
+    });
+    expect(out).toContain('Current-state record');
+    expect(out).toContain('cite factIds only');
+    expect(out).not.toContain('citedBeliefIds');
+  });
+});
+
+describe('buildVerifierUserMessage — beliefLines (BELIEFS_SERVING_LANE seam)', () => {
+  function capturingOpenAi(users: string[]): OpenAI {
+    return {
+      chat: {
+        completions: {
+          create: async (req: { messages: Array<{ role: string; content: string }> }) => {
+            users.push(req.messages.find((m) => m.role === 'user')?.content ?? '');
+            return {
+              choices: [
+                {
+                  message: {
+                    content: JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+                  },
+                },
+              ],
+            };
+          },
+        },
+      },
+    } as unknown as OpenAI;
+  }
+
+  const BASE = {
+    query: 'which database are we using?',
+    answer: 'SurrealDB.',
+    factLines: ['[knowledge_fact:f1] PostgreSQL — decided'],
+    model: 'gpt-test',
+  };
+
+  it('absent / empty ⇒ the audit prompt is BYTE-IDENTICAL (no section)', async () => {
+    const users: string[] = [];
+    await runVerifier({ ...BASE, openai: capturingOpenAi(users) });
+    await runVerifier({ ...BASE, beliefLines: [], openai: capturingOpenAi(users) });
+    await runVerifier({ ...BASE, beliefLines: undefined, openai: capturingOpenAi(users) });
+    expect(users[1]).toBe(users[0]);
+    expect(users[2]).toBe(users[0]);
+    expect(users[0]).not.toContain('Current-state record');
+  });
+
+  it('non-empty ⇒ its own equally-valid-support section', async () => {
+    const users: string[] = [];
+    const lines = ['[semantic_belief:b1] (inventory service — database, rev 2) statement'];
+    await runVerifier({ ...BASE, beliefLines: lines, openai: capturingOpenAi(users) });
+    expect(users[0]).toContain('Current-state record (distilled belief lines');
+    expect(users[0]).toContain(lines[0]!);
+    // The base sections are untouched by the addition.
+    expect(users[0]).toContain('Source facts:');
+  });
+});
+
+describe('runGenerator — belief-citation affordance (BELIEFS_SERVING_LANE)', () => {
+  function capturingOpenAi(reqs: unknown[], content: string): OpenAI {
+    return {
+      chat: {
+        completions: {
+          create: async (req: unknown) => {
+            reqs.push(req);
+            return { choices: [{ message: { content } }] };
+          },
+        },
+      },
+    } as unknown as OpenAI;
+  }
+
+  const CONTENT = JSON.stringify({ answer: 'SurrealDB.', citedFactIds: [] });
+  const BASE = {
+    query: 'which database?',
+    factLines: ['[knowledge_fact:f1] fact'],
+    model: 'gpt-test',
+    answerLang: null,
+  };
+
+  it('flag ON but empty lane ⇒ prompt AND schema BYTE-IDENTICAL to the base call', async () => {
+    const base: unknown[] = [];
+    await runGenerator({ ...BASE, openai: capturingOpenAi(base, CONTENT) });
+    const emptyLane: unknown[] = [];
+    await runGenerator({
+      ...BASE,
+      beliefCitations: true,
+      beliefLines: [],
+      openai: capturingOpenAi(emptyLane, CONTENT),
+    });
+    expect(JSON.stringify(emptyLane[0])).toBe(JSON.stringify(base[0]));
+    expect(JSON.stringify(base[0])).not.toContain('citedBeliefIds');
+    expect(JSON.stringify(base[0])).not.toContain('BELIEF CITATIONS');
+  });
+
+  it('live affordance ⇒ schema gains citedBeliefIds (properties + required) and the addendum', async () => {
+    const reqs: unknown[] = [];
+    await runGenerator({
+      ...BASE,
+      beliefCitations: true,
+      beliefLines: ['[semantic_belief:b1] (s — f, rev 1) s'],
+      openai: capturingOpenAi(
+        reqs,
+        JSON.stringify({ answer: 'x', citedFactIds: [], citedBeliefIds: [] }),
+      ),
+    });
+    const raw = JSON.stringify(reqs[0]);
+    expect(raw).toContain('citedBeliefIds');
+    expect(raw).toContain('BELIEF CITATIONS');
+    const req = reqs[0] as {
+      response_format: {
+        json_schema: { schema: { properties: Record<string, unknown>; required: string[] } };
+      };
+    };
+    expect(req.response_format.json_schema.schema.properties.citedBeliefIds).toBeDefined();
+    expect(req.response_format.json_schema.schema.required).toContain('citedBeliefIds');
+  });
+
+  it('defensively deletes a non-array citedBeliefIds from the parsed output', async () => {
+    const reqs: unknown[] = [];
+    const out = await runGenerator({
+      ...BASE,
+      beliefCitations: true,
+      beliefLines: ['[semantic_belief:b1] (s — f, rev 1) s'],
+      openai: capturingOpenAi(
+        reqs,
+        JSON.stringify({ answer: 'x', citedFactIds: [], citedBeliefIds: 'not-an-array' }),
+      ),
+    });
+    expect(out.citedBeliefIds).toBeUndefined();
+  });
+});
+
+describe('belief-arm citations and the serving gates (BELIEFS_SERVING_LANE)', () => {
+  const SUPPORTED: VerifierOutput = { verdict: 'supported', unsupportedClaims: [] };
+
+  it('FOVEA_REQUIRE_CITATIONS Part C: a belief-cited answer is NOT whollyUncited — it serves', () => {
+    const beliefCitation = { beliefId: 'semantic_belief:b1', excerpt: 's — f: v' };
+    const served = finalizeVerdict(
+      {},
+      {
+        verdict: 'supported',
+        answer: 'SurrealDB.',
+        citations: [],
+        results: [],
+        guardrails: 'strict',
+        requireCitations: true,
+        evidenceCitations: [beliefCitation],
+      },
+    );
+    expect(served.answer).toBe('SurrealDB.');
+    expect(served.reason).toBeUndefined();
+    expect(served.evidenceCitations).toEqual([beliefCitation]);
+    // Contrast: zero fact citations AND zero evidence citations abstains.
+    const abstained = finalizeVerdict(
+      {},
+      {
+        verdict: 'supported',
+        answer: 'SurrealDB.',
+        citations: [],
+        results: [],
+        guardrails: 'strict',
+        requireCitations: true,
+        evidenceCitations: [],
+      },
+    );
+    expect(abstained.reason).toBe('low_coverage');
+  });
+
+  it('resolveEvidenceCapability: a belief-arm citation carries NO capability — it neither satisfies nor triggers the 0113 gate', async () => {
+    const saved = process.env.FOVEA_EVIDENCE_CAPABILITY;
+    process.env.FOVEA_EVIDENCE_CAPABILITY = '1';
+    try {
+      const deps = {
+        registry: {
+          rowPolicyLookup: async () => () => ({ requiredEvidenceCapability: 'visual' }),
+        } as never,
+        logger: { warn: () => undefined },
+      };
+      const ctx = { cache: undefined, companyId: 'co_x' } as FinalizeContext;
+      const citations = [{ factId: 'knowledge_fact:f1', predicate: 'p', entityId: 'e' } as never];
+      // A visual requirement is NOT satisfied by a belief citation…
+      const unmet = await resolveEvidenceCapability(deps, {
+        ctx,
+        verdict: SUPPORTED,
+        citations,
+        evidenceCitations: [{ beliefId: 'semantic_belief:b1', excerpt: 's' }],
+      });
+      expect(unmet).toEqual({ evidenceCapabilityUnmet: true });
+      // …and a text requirement is not TRIGGERED by one either.
+      const textDeps = {
+        registry: { rowPolicyLookup: async () => () => ({}) } as never,
+        logger: { warn: () => undefined },
+      };
+      const ok = await resolveEvidenceCapability(textDeps, {
+        ctx,
+        verdict: SUPPORTED,
+        citations,
+        evidenceCitations: [{ beliefId: 'semantic_belief:b1', excerpt: 's' }],
+      });
+      expect(ok).toEqual({});
+    } finally {
+      if (saved === undefined) delete process.env.FOVEA_EVIDENCE_CAPABILITY;
+      else process.env.FOVEA_EVIDENCE_CAPABILITY = saved;
+    }
   });
 });


### PR DESCRIPTION
## Motivation — the stale dogfood answer

Dogfood session, 8 turns: the user decides Postgres, then SWITCHES to SurrealDB. Free extraction produced non-colliding (entity, predicate) claims — `PostgreSQL|code_memory__decided|we will use Postgres as the main database` vs `SurrealDB|interacted_with|SurrealDB` — so `fn::resolve_fact` supersede never fired, both claims stayed alive, and synthesize answered the STALE value. Meanwhile the belief substrate (migration 0120, promoted from enriched scene stateDeltas) held the CORRECT current state: `inventory service — database: SurrealDB (was: PostgreSQL)`. Root cause: the 0120 header's own shadow doctrine — "nothing on the serving path reads this table."

This PR repeals that doctrine behind ONE default-off flag, `BELIEFS_SERVING_LANE`. Off ⇒ prompts, schemas and serving are byte-identical (pinned by unit tests).

## What's in

- **Migration `0126_belief_serving_search.surql`** — lowercase-only FULLTEXT BM25 index on `semantic_belief.statement` (the 0073/0075/0106/0124 analyzer contract; the deterministic statement template embeds subject/field/value/prior, so one single-field index covers the whole key) + a write-dead `embedding option<array<float>>` column (the 0124 precedent: the dense leg degrades to empty until a producer exists). Single-field only; no new delete path.
- **Belief lane** (`belief-lane.service.ts`, the fragment-lane sibling): a BM25 leg + a brute-cosine leg fused by `rrfFuse`, `status='active'` only, dedupe by (subject, field), top-K 3 (design constant), 600-char line cap, validFrom-ascending. The lexical leg is composed as the V11 A2 **`or_terms` disjunction** (`buildLexMatchLeg`), not a phrase-shaped `statement @1@ $query`: the matches operator is AND-semantics over analyzed tokens, so the phrase shape would require the whole natural question to appear inside a short statement and — with the dense leg write-dead — leave the lane empty for every real query (caught live by the acceptance e2e). Fences: tenant (`withCompany`) → **scoped-user-only fail-closed** → SQL `userId = $u` → `beliefVisible` JS re-check → any error degrades to an empty section.
- **Prompt seams**: a `Current-state record` section between insights and media for the generator, the SAME lines for the verifier and the zoom re-verify (W5 #22 parity at BOTH VerifyRequest build sites); empty ⇒ byte-identical. In-prompt routing: current-state questions prefer belief lines; history/why questions use facts + transcript (no router/lane-registry change — the history e2e pins the non-regression).
- **Belief citations** (`belief-citations.ts`, the fragment-citations sibling; citations ride the master flag): `citedBeliefIds` schema affordance (only when lines rendered — flag-on-but-empty stays byte-identical), rendered-set anti-hallucination fence (unknown ids dropped + counted), dedupe, cap 16, RENDERED-excerpt-only. `EvidenceCitation` widened ADDITIVELY with the third one-of arm `beliefId`. A belief-cited answer passes `FOVEA_REQUIRE_CITATIONS` (unit pin); the belief arm carries no `capability`, so the 0113 gate is neither satisfied nor triggered by it (unit pin); the answer cache keeps rejecting citation-less answers (comment extended to name the belief arm).
- **Telemetry** (0107 — `subjectKind 'belief'` already in the ASSERT and the TS union, no schema work): rendered → `selected_for_context`; cited on a served answer → `used_in_answer` + `verifier_supported` on a supported verdict, decisionId threaded like the fact arm. New `brain_belief_citation_total` counter.
- **Flags** (`common/beliefs-flags.ts`, S5.2 call-time env reads): `beliefServingLaneEnabled()` + the `beliefFactDampingEnabled()` stub; config-catalog entries next to `BELIEFS_API_ENABLED` (scoped-user requirement, citation arm and byte-identical-off named in the description); both keys in `KNOWN_BOOLEAN_FLAGS`; boot WARN on damping-on-while-lane-off. `BELIEFS_` sits outside the ENGINE flag-budget prefix ⇒ zero golden bumps.

## Deliberately out (PR-B)

`BELIEFS_FACT_DAMPING` behavior — the prompt-side damping/demotion of belief-contradicted fact lines (`belief-damping.ts`). It MUTATES the existing fact section, so it ships and gets measured separately. Only its resolver stub, catalog entry and the inconsistent-pair WARN land here.

## D4 fence tightening (deliberate)

The lane serves ONLY user-scoped requests: `userId === undefined` ⇒ empty, no query. This is STRICTER than `GET /v1/beliefs`, where an M2M credential reads the whole tenant — an explicit API read is auditable, but silently blending user A's current-state into an unscoped agent ANSWER is a cross-user leak no serving lane allows (and no belief is tenant-global, so the 0055 unscoped-serves-global rule yields nothing anyway). Documented in the lane's class doc and the catalog entry.

## Test evidence

- Full unit suite: **3581 passed / 0 failed** (includes new `belief-lane.unit-spec` and `belief-citations.unit-spec`, the 0126 audit-p1-guards tuples + explicit DELETE-sweep coverage of the lane file, and byte-identity pins for generator prompt, generator schema, and verifier prompt — absent/`[]`/flag-on-but-empty all byte-equal).
- Targeted e2e: `belief-serving.e2e-spec.ts` (the exact dogfood shape: control off-path, flag-on serve with belief citation + 0107 belief rows, history non-regression, both D4 fence variants) + the existing `belief-promotion.e2e` and `fragment-lane.e2e` — all green on a real SurrealDB 3.2.4 testcontainer.
- `pnpm typecheck` and `pnpm lint:ci` (max-warnings 0) green; `pnpm openapi:build` ⇒ **zero diff** on docs/openapi.json (synthesize is not in the public spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
