### PR TITLE
fix(beliefs): belief-lane prompt variant must preserve abstention discipline

### DIFF
--- a/src/synthesize/generator-client.ts
+++ b/src/synthesize/generator-client.ts
@@ -142,6 +142,21 @@ const BELIEF_CITE_ADDENDUM = `
 
 BELIEF CITATIONS: some evidence lines are distilled current-state beliefs headed by a [semantic_belief:...] id. When a claim in your answer rests on such a line, copy that id EXACTLY as it appears into the citedBeliefIds array (in addition to any factIds you cite). Cite only ids present in the evidence — never invent one. citedBeliefIds is [] when no belief line supports a claim.`;
 
+/**
+ * BELIEFS_SERVING_LANE abstention guard (memory-fitness D5): the
+ * current-state preference in the belief section must not weaken the
+ * base evidence-only/abstention discipline — the lane adds evidence,
+ * never permission to answer. The closing sentence mirrors the base
+ * GENERATOR_SYSTEM rule 3 abstention sentence VERBATIM. Appended only
+ * when the belief section actually rendered (flag off / empty lane ⇒
+ * byte-identical system prompt) and only in the default abstaining
+ * mode — never with GENERATOR_SYSTEM_ANSWER, whose always-commit
+ * contract (neverAbstain) is deliberately unchanged.
+ */
+const BELIEF_ABSTENTION_ADDENDUM = `
+
+BELIEF LINES PRESERVE ABSTENTION: the current-state record is ADDITIONAL evidence, not permission to answer beyond the evidence. Prefer a belief line only when one covers the asked subject/field. If neither a belief line nor the facts answer the question, output the exact answer string "I don't have grounded evidence for that." with citedFactIds set to [].`;
+
 /** The strict-JSON answer schema, affordance-conditional fields included
  *  (extracted from runGenerator for the complexity budget — pure). */
 function buildAnswerSchema(opts: {
@@ -179,6 +194,9 @@ export async function runGenerator(req: GenerateRequest): Promise<GeneratorOutpu
   // Same guard for beliefs: flag-on with an empty lane keeps prompt and
   // schema byte-identical (BELIEFS_SERVING_LANE).
   const beliefAffordance = req.beliefCitations === true && (req.beliefLines?.length ?? 0) > 0;
+  // The abstention guard rides the RENDERED section, not the citation
+  // affordance — it must hold even under a future header/flag split.
+  const beliefRendered = (req.beliefLines?.length ?? 0) > 0;
   const answerSchema = buildAnswerSchema({
     allowRefine: req.allowRefine === true,
     fragmentAffordance,
@@ -188,7 +206,8 @@ export async function runGenerator(req: GenerateRequest): Promise<GeneratorOutpu
     (neverAbstain ? GENERATOR_SYSTEM_ANSWER : GENERATOR_SYSTEM) +
     (req.allowRefine ? REFINE_ADDENDUM : '') +
     (fragmentAffordance ? FRAGMENT_CITE_ADDENDUM : '') +
-    (beliefAffordance ? BELIEF_CITE_ADDENDUM : '');
+    (beliefAffordance ? BELIEF_CITE_ADDENDUM : '') +
+    (beliefRendered && !neverAbstain ? BELIEF_ABSTENTION_ADDENDUM : '');
   const user = buildGeneratorUserMessage(req);
   traceArtifact('synthesize.generator_prompt', {
     system: systemPrompt,

--- a/src/synthesize/generator-prompt.ts
+++ b/src/synthesize/generator-prompt.ts
@@ -212,12 +212,24 @@ export function buildGeneratorUserMessage({
 /** Belief lane (BELIEFS_SERVING_LANE): distilled current-state lines in
  *  their own section. Empty input = empty string (byte-identical prompt
  *  without the lane). The citations variant instructs mirroring cited
- *  [semantic_belief:...] ids into citedBeliefIds. */
+ *  [semantic_belief:...] ids into citedBeliefIds.
+ *
+ *  Abstention discipline (memory-fitness D5 regression): the original
+ *  #412 header said "prefer these lines" unconditionally, which read as
+ *  a license to answer current-state questions FROM the belief record
+ *  even when no line covered the asked subject — confabulation on
+ *  never-written questions. The preference is now conditional on a
+ *  covering line, and the header states explicitly that belief lines
+ *  add evidence without relaxing the base unanswerable-question rule
+ *  (the verbatim base abstention sentence is re-asserted system-side in
+ *  generator-client.ts BELIEF_ABSTENTION_ADDENDUM). */
+const BELIEF_EVIDENCE_ONLY_CLAUSE =
+  ' These lines ADD evidence — they never relax the base evidence rules: when NEITHER a belief line NOR the facts/transcript cover the question, follow the base instructions for an unanswerable question unchanged';
 function renderBeliefSection(beliefLines?: string[], beliefCitations?: boolean): string {
   if (!beliefLines || beliefLines.length === 0) return '';
   const header = beliefCitations
-    ? 'Current-state record (distilled beliefs — each line states what is CURRENTLY true for its subject/field and supersedes any older or conflicting fact above; each line is headed by its [semantic_belief:...] id. For questions asking the CURRENT state, prefer these lines; when a claim rests on one, copy its id EXACTLY into citedBeliefIds. For questions about history, sequence, or why something changed, use the facts and transcript instead; cite factIds for fact-grounded claims as before):'
-    : 'Current-state record (distilled beliefs — each line states what is CURRENTLY true for its subject/field and supersedes any older or conflicting fact above. For questions asking the CURRENT state, prefer these lines; for questions about history, sequence, or why something changed, use the facts and transcript instead; cite factIds only):';
+    ? `Current-state record (distilled beliefs — each line states what is CURRENTLY true for its subject/field and supersedes any older or conflicting fact above; each line is headed by its [semantic_belief:...] id. For questions asking the CURRENT state, prefer these lines ONLY when one covers the asked subject/field; when a claim rests on one, copy its id EXACTLY into citedBeliefIds. For questions about history, sequence, or why something changed, use the facts and transcript instead; cite factIds for fact-grounded claims as before.${BELIEF_EVIDENCE_ONLY_CLAUSE}):`
+    : `Current-state record (distilled beliefs — each line states what is CURRENTLY true for its subject/field and supersedes any older or conflicting fact above. For questions asking the CURRENT state, prefer these lines ONLY when one covers the asked subject/field; for questions about history, sequence, or why something changed, use the facts and transcript instead; cite factIds only.${BELIEF_EVIDENCE_ONLY_CLAUSE}):`;
   return `\n\n${header}\n${beliefLines.join('\n')}`;
 }
 

--- a/test/belief-serving.e2e-spec.ts
+++ b/test/belief-serving.e2e-spec.ts
@@ -186,6 +186,7 @@ describe('Belief serving lane e2e (the dogfood stale-answer scenario)', () => {
     expect(state.calls[0]!.user).not.toContain('Current-state record');
     expect(state.calls[0]!.user).not.toContain('[semantic_belief:');
     expect(state.calls[0]!.system).not.toContain('BELIEF CITATIONS');
+    expect(state.calls[0]!.system).not.toContain('BELIEF LINES PRESERVE ABSTENTION');
     expect(state.calls[1]!.user).not.toContain('Current-state record');
   });
 
@@ -222,6 +223,11 @@ describe('Belief serving lane e2e (the dogfood stale-answer scenario)', () => {
     expect(genPrompt).toContain(`[${beliefId}]`);
     expect(genPrompt).toContain(STATEMENT);
     expect(state.calls[0]!.system).toContain('BELIEF CITATIONS');
+    // Abstention discipline (memory-fitness D5): the rendered lane pulls in
+    // the system-side guard mirroring the base abstention rule verbatim,
+    // and the current-state preference is conditional on a covering line.
+    expect(state.calls[0]!.system).toContain('BELIEF LINES PRESERVE ABSTENTION');
+    expect(genPrompt).toContain('ONLY when one covers the asked subject/field');
     // Verifier parity (W5 #22): the SAME line arrives as its own section.
     const verifyPrompt = state.calls[1]!.user;
     expect(verifyPrompt).toContain('Current-state record (distilled belief lines');

--- a/test/synthesize.unit-spec.ts
+++ b/test/synthesize.unit-spec.ts
@@ -587,6 +587,26 @@ describe('buildGeneratorUserMessage — belief section (BELIEFS_SERVING_LANE sea
     expect(out).toContain('cite factIds only');
     expect(out).not.toContain('citedBeliefIds');
   });
+
+  it('abstention discipline (memory-fitness D5): BOTH header variants condition the belief preference and pin the evidence-only clause', () => {
+    const line = '[semantic_belief:b1] (s — f, rev 1) s';
+    const cited = buildGeneratorUserMessage({
+      ...BASE,
+      beliefLines: [line],
+      beliefCitations: true,
+    });
+    const plain = buildGeneratorUserMessage({ ...BASE, beliefLines: [line] });
+    for (const out of [cited, plain]) {
+      // The preference is conditional on a covering line — never a blanket
+      // license to answer current-state questions from the belief record.
+      expect(out).toContain('prefer these lines ONLY when one covers the asked subject/field');
+      // The lane adds evidence without relaxing the base abstention rule.
+      expect(out).toContain(
+        'These lines ADD evidence — they never relax the base evidence rules: when NEITHER a belief line NOR the facts/transcript cover the question, follow the base instructions for an unanswerable question unchanged',
+      );
+      expect(out).not.toContain('prefer these lines;');
+    }
+  });
 });
 
 describe('buildVerifierUserMessage — beliefLines (BELIEFS_SERVING_LANE seam)', () => {
@@ -674,6 +694,52 @@ describe('runGenerator — belief-citation affordance (BELIEFS_SERVING_LANE)', (
     expect(JSON.stringify(emptyLane[0])).toBe(JSON.stringify(base[0]));
     expect(JSON.stringify(base[0])).not.toContain('citedBeliefIds');
     expect(JSON.stringify(base[0])).not.toContain('BELIEF CITATIONS');
+    expect(JSON.stringify(base[0])).not.toContain('BELIEF LINES PRESERVE ABSTENTION');
+  });
+
+  it('rendered lane (default mode) ⇒ the abstention guard mirrors the base rule VERBATIM', async () => {
+    const reqs: unknown[] = [];
+    await runGenerator({
+      ...BASE,
+      beliefCitations: true,
+      beliefLines: ['[semantic_belief:b1] (s — f, rev 1) s'],
+      openai: capturingOpenAi(
+        reqs,
+        JSON.stringify({ answer: 'x', citedFactIds: [], citedBeliefIds: [] }),
+      ),
+    });
+    const system = (
+      reqs[0] as { messages: Array<{ role: string; content: string }> }
+    ).messages.find((m) => m.role === 'system')!.content;
+    expect(system).toContain('BELIEF LINES PRESERVE ABSTENTION');
+    expect(system).toContain('Prefer a belief line only when one covers the asked subject/field.');
+    // Verbatim mirror of the base GENERATOR_SYSTEM rule 3 abstention tail —
+    // the belief lane must not weaken the absence-honesty contract (D5).
+    expect(system).toContain(
+      `If neither a belief line nor the facts answer the question, output the exact answer string "I don't have grounded evidence for that." with citedFactIds set to [].`,
+    );
+    // The base rule itself is still present (the guard adds, never replaces).
+    expect(system).toContain('If the facts do not answer the question');
+  });
+
+  it('neverAbstain mode keeps its always-commit contract — NO abstention guard with the lane rendered', async () => {
+    const reqs: unknown[] = [];
+    await runGenerator({
+      ...BASE,
+      neverAbstain: true,
+      beliefCitations: true,
+      beliefLines: ['[semantic_belief:b1] (s — f, rev 1) s'],
+      openai: capturingOpenAi(
+        reqs,
+        JSON.stringify({ answer: 'x', citedFactIds: [], citedBeliefIds: [] }),
+      ),
+    });
+    const system = (
+      reqs[0] as { messages: Array<{ role: string; content: string }> }
+    ).messages.find((m) => m.role === 'system')!.content;
+    expect(system).toContain('ALWAYS commit to an answer');
+    expect(system).not.toContain('BELIEF LINES PRESERVE ABSTENTION');
+    expect(system).not.toContain("I don't have grounded evidence for that.");
   });
 
   it('live affordance ⇒ schema gains citedBeliefIds (properties + required) and the addendum', async () => {


### PR DESCRIPTION
## Regression

Measured by the memory-fitness harness (PR #411 branch) with `BELIEFS_SERVING_LANE` on:

| Dimension | Baseline | Lane on (#412) |
|---|---|---|
| D1 state-currency | 1/4 | **3/4** (kept) |
| D8 self-utility | 1/5 | **4/5** (kept) |
| D5 absence-honesty | 5/5 | **2/5** (regressed) |

With the lane on, the generator CONFABULATES answers to never-written questions instead of abstaining. Root cause: the #412 belief section header — "For questions asking the CURRENT state, prefer these lines" — reads as an unconditional license to answer current-state questions from the belief record, implicitly weakening the base evidence-only/abstention discipline (`GENERATOR_SYSTEM` rule 3).

## Fix (variant-only, minimal)

Base prompts are untouched — with the flag off (or an empty lane) every prompt is byte-identical, and the existing byte-identity pins stay green.

1. **`src/synthesize/generator-prompt.ts`** — both belief section headers (citations + cite-factIds-only variants):
   - the preference is now conditional: `prefer these lines ONLY when one covers the asked subject/field`;
   - new closing clause: `These lines ADD evidence — they never relax the base evidence rules: when NEITHER a belief line NOR the facts/transcript cover the question, follow the base instructions for an unanswerable question unchanged`.
2. **`src/synthesize/generator-client.ts`** — new `BELIEF_ABSTENTION_ADDENDUM` appended to the system prompt whenever the belief section rendered, mirroring the base abstention sentence VERBATIM: `If neither a belief line nor the facts answer the question, output the exact answer string "I don't have grounded evidence for that." with citedFactIds set to [].`
   - Gated on `!neverAbstain`: the `guardrails='answer'` always-commit contract is deliberately unchanged.
   - Gated on the RENDERED section (not the citation affordance), so the guard survives a future header/flag split.

## Tests

- `test/synthesize.unit-spec.ts`: pins the conditional preference + evidence-only clause in BOTH header variants; pins the verbatim abstention mirror in the system prompt (default mode), its absence in `neverAbstain` mode, and byte-identity of the base/flag-off call (now also asserting the guard is absent).
- `test/belief-serving.e2e-spec.ts`: flag-on run pins the guard + conditional clause in the live prompts; flag-off run pins their absence.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint:ci` — clean (zero warnings)
- `pnpm format:check` — clean
- `pnpm test:unit` — 338 suites / 3584 tests, all green
- Targeted e2e (ephemeral SurrealDB v3.2.4): `belief-serving`, `beliefs-api`, `belief-promotion`, `fovea-answer-integrity`, `fragment-lane`, `answer-lang`, `answer-cache` — 7 suites / 37 tests, all green (the non-belief suites prove the new addendum does not leak into other paths).

D1/D8 gains from #412 are preserved: the belief section, its supersedes semantics, and the citation affordance are unchanged when a covering belief line exists — only the no-coverage posture is restored to the baseline abstention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB