### PR TITLE
fix(beliefs): disambiguate the belief-lane date token from event-date stamps (BELIEFS_LANE_DATE_DISAMBIGUATION)

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -2261,6 +2261,17 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Belief-aware fact damping (PR-B; the resolver ships with the lane, the damping pass lands in the follow-up PR — until then NOTHING reads this flag): prompt-side suffix + stable demotion of fact lines that a matched current belief contradicts, applied to the SAME lines generator and verifier read. Requires BELIEFS_SERVING_LANE (a no-op without the lane’s matched beliefs — boot validation warns on the inconsistent pair). Off (default) → byte-identical.',
   },
   {
+    key: 'BELIEFS_LANE_DATE_DISAMBIGUATION',
+    category: 'pipeline',
+    // Read at call time (common/beliefs-flags.ts) — never captured in a
+    // constructor — so a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Belief-lane date disambiguation (memory-fitness D4: the generator’s date block teaches "(as of YYYY-MM-DD)" as an answer-bearing EVENT-date stamp, but a belief line’s day is the belief REVISION’s validFrom — so "when did X happen" questions served the revision date instead of the event fact’s date). When on, BeliefLaneService renders ", belief current since <day>" in place of ", as of <day>" — ONE render site, so the generator, the verifier and the fragment-zoom re-verify all read the same disambiguated lines (three-consumer parity by construction) — and both generator belief-section header variants state that a belief-line date is when the belief last changed, never the asked-about event’s date (take event dates from the facts). A no-op without BELIEFS_SERVING_LANE (no lane → no belief lines). Off (default) → byte-identical lines and prompts.',
+  },
+  {
     key: 'PROVENANCE_SUMMARY_EPISODE_STAMP',
     category: 'pipeline',
     defaultValue: '0',

--- a/src/common/beliefs-flags.ts
+++ b/src/common/beliefs-flags.ts
@@ -42,3 +42,28 @@ export function beliefServingLaneEnabled(): boolean {
 export function beliefFactDampingEnabled(): boolean {
   return envFlagEnabled(process.env.BELIEFS_FACT_DAMPING);
 }
+
+/**
+ * Belief-lane date disambiguation — BELIEFS_LANE_DATE_DISAMBIGUATION
+ * (memory-fitness D4: the lane's `as of <day>` token is the same shape
+ * the generator's date block teaches as an answer-bearing EVENT-date
+ * stamp, but a belief's day is the belief REVISION's validFrom — so
+ * "when did X happen" questions served the revision date instead of the
+ * event fact's date).
+ *
+ * When on (AND the serving lane is on — a no-op without rendered belief
+ * lines), BeliefLaneService renders `, belief current since <day>` in
+ * place of `, as of <day>` (ONE render site feeds the generator, the
+ * verifier and the fragment-zoom re-verify — three-consumer parity by
+ * construction) and the generator's belief-section header states that a
+ * belief-line date is when the belief last changed, never the date of
+ * the asked-about event. Resolved ONCE per request by the orchestrator
+ * beside beliefServingLaneEnabled() (the single-resolution idiom); the
+ * env read lives here in the common layer, NOT inside the engine dirs
+ * (engine-gates S5.2). Read at call time so a flip is runtime-mutable
+ * (no restart). Default off ⇒ byte-identical lines and prompts.
+ * BELIEFS_ family sits off the ENGINE flag budget by design.
+ */
+export function beliefLaneDateDisambiguationEnabled(): boolean {
+  return envFlagEnabled(process.env.BELIEFS_LANE_DATE_DISAMBIGUATION);
+}

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -707,6 +707,12 @@ const KNOWN_BOOLEAN_FLAGS = [
   // lane; nothing reads it until the damping pass lands). Requires
   // BELIEFS_SERVING_LANE (inconsistent-pair WARN below).
   'BELIEFS_FACT_DAMPING',
+  // Belief-lane date disambiguation (memory-fitness D4): the lane
+  // renders ", belief current since <day>" instead of ", as of <day>"
+  // (which the generator's date block teaches as an EVENT-date stamp —
+  // a belief's day is the REVISION's validFrom) and the generator's
+  // belief header scopes the date. No-op without BELIEFS_SERVING_LANE.
+  'BELIEFS_LANE_DATE_DISAMBIGUATION',
   // Raw-substrate driver v1 surface 3: projections registry API + rebuild verb.
   'PROJECTIONS_API_ENABLED',
   // Raw-substrate driver v1 surface 4: new-episode webhook push (watermark

--- a/src/synthesize/belief-lane.service.ts
+++ b/src/synthesize/belief-lane.service.ts
@@ -104,6 +104,13 @@ export class BeliefLaneService {
     /** Scope key of the asking end-user; omitted → the lane is EMPTY
      *  (fence 2 — scoped-user-only, see the class doc). */
     userId?: string | undefined;
+    /** BELIEFS_LANE_DATE_DISAMBIGUATION, resolved ONCE by the caller
+     *  (the beliefServingLaneEnabled idiom — this service reads no
+     *  env): render `, belief current since <day>` instead of
+     *  `, as of <day>` so the belief REVISION's validFrom cannot be
+     *  misread as the asked-about event's date (memory-fitness D4).
+     *  Off/absent ⇒ byte-identical lines. */
+    dateDisambiguation?: boolean | undefined;
   }): Promise<BeliefLaneResult> {
     // Fence 2 (D4): an unscoped request serves NO beliefs — checked
     // before any IO so the off-path issues zero queries.
@@ -153,7 +160,7 @@ export class BeliefLaneService {
         return rrfFuse([dense ?? [], bm25 ?? []]);
       });
       if (fused.length === 0) return EMPTY_RESULT;
-      return this.render(fused, userId);
+      return this.render(fused, userId, opts.dateDisambiguation === true);
     } catch (e) {
       // Fence 6: degrade to an empty section, never fail the answer.
       this.logger.warn(`belief lane failed (companyId=${opts.companyId}): ${(e as Error).message}`);
@@ -167,12 +174,25 @@ export class BeliefLaneService {
    * so this is defense in depth), validFrom-ascending, capped at
    * BELIEF_LANE_TOP_K. Line shape:
    *   `[semantic_belief:...] (<subject> — <field>, rev <revision>, as of <day>) <statement>`
+   * — or, under BELIEFS_LANE_DATE_DISAMBIGUATION (memory-fitness D4:
+   * the `as of` token is the shape the generator's date block teaches
+   * as an EVENT-date stamp, while a belief's day is the REVISION's
+   * validFrom):
+   *   `[semantic_belief:...] (<subject> — <field>, rev <revision>, belief current since <day>) <statement>`
+   * The no-day branch is identical in both modes. This is the ONE
+   * render site — the generator, the verifier and the fragment-zoom
+   * re-verify all read these same lines (three-consumer parity by
+   * construction).
    * The id header renders UNCONDITIONALLY — belief citations ride the
    * master flag (no separate switch; see belief-citations.ts). Fence 4
    * (beliefVisible) re-applies here fail-closed: an out-of-contract row
    * the SQL fence let through never renders.
    */
-  private render(fused: BeliefLaneRow[], userId: string): BeliefLaneResult {
+  private render(
+    fused: BeliefLaneRow[],
+    userId: string,
+    dateDisambiguation: boolean,
+  ): BeliefLaneResult {
     const byKey = new Map<string, BeliefLaneRow>();
     for (const row of fused) {
       // Fence 4: JS re-check of the user fence (the read-API doctrine).
@@ -191,9 +211,15 @@ export class BeliefLaneService {
       const beliefId = String(row.id);
       const excerpt = String(row.statement).slice(0, BELIEF_EXCERPT_MAX_CHARS);
       const day = isoDay(row.validFrom);
+      // D4 date-token disambiguation: `as of` reads as an event-date
+      // stamp downstream; the flagged variant names what the day IS —
+      // the revision's validFrom (flag off ⇒ byte-identical).
+      const dayToken = day
+        ? `, ${dateDisambiguation ? 'belief current since' : 'as of'} ${day}`
+        : '';
       lines.push(
         `[${beliefId}] (${String(row.subject ?? '')} — ${String(row.field ?? '')}, ` +
-          `rev ${String(row.revision ?? 1)}${day ? `, as of ${day}` : ''}) ${excerpt}`,
+          `rev ${String(row.revision ?? 1)}${dayToken}) ${excerpt}`,
       );
       byId.set(beliefId, {
         beliefId,

--- a/src/synthesize/evidence-collector.service.ts
+++ b/src/synthesize/evidence-collector.service.ts
@@ -145,6 +145,14 @@ export interface CollectedEvidence {
    */
   beliefsById?: ReadonlyMap<string, CitableBelief> | undefined;
   /**
+   * BELIEFS_LANE_DATE_DISAMBIGUATION echo (memory-fitness D4): the
+   * caller-resolved flag, carried back so the generator's belief-section
+   * header keys off the SAME per-request resolution that shaped the
+   * rendered lines' date token (the single-resolution idiom — no second
+   * env read downstream). false/undefined ⇒ byte-identical header.
+   */
+  beliefDateDisambiguation?: boolean | undefined;
+  /**
    * G4 strategy lane: rendered advisory notes (k≤2, default 1) from
    * the separate strategy_memory store; undefined when the lane is off
    * the profile or read-side serving is disabled.
@@ -187,6 +195,7 @@ export function emptyCollectedEvidence(
     fragmentZoom: [],
     beliefLines: [],
     beliefsById: undefined,
+    beliefDateDisambiguation: undefined,
   };
 }
 
@@ -236,6 +245,10 @@ export class EvidenceCollectorService {
     /** BELIEFS_SERVING_LANE, resolved ONCE by the caller (the
      *  fragmentCitations precedent) — this service reads no env. */
     beliefLane?: boolean | undefined;
+    /** BELIEFS_LANE_DATE_DISAMBIGUATION, resolved ONCE by the caller
+     *  beside beliefLane — shapes the lane's rendered date token and is
+     *  echoed on CollectedEvidence for the generator header. */
+    beliefDateDisambiguation?: boolean | undefined;
   }): Promise<CollectedEvidence> {
     const { profile, query } = opts;
     const timelineEvidence = wantsTimelineEvidence(profile, query);
@@ -288,6 +301,7 @@ export class EvidenceCollectorService {
       fragmentZoom: fragmentEvidence.zoom,
       beliefLines: beliefEvidence.lines,
       beliefsById: beliefEvidence.byId.size > 0 ? beliefEvidence.byId : undefined,
+      beliefDateDisambiguation: opts.beliefDateDisambiguation,
     };
   }
 
@@ -300,11 +314,13 @@ export class EvidenceCollectorService {
    */
   private async collectBeliefEvidence({
     beliefLane,
+    beliefDateDisambiguation,
     companyId,
     query,
     userId,
   }: {
     beliefLane?: boolean | undefined;
+    beliefDateDisambiguation?: boolean | undefined;
     companyId: string;
     query: string;
     userId?: string | undefined;
@@ -312,7 +328,13 @@ export class EvidenceCollectorService {
     const empty = { lines: [], byId: new Map<string, CitableBelief>() };
     if (beliefLane !== true || !this.beliefLane) return empty;
     if (getAbortSignal()?.aborted) return empty;
-    return this.beliefLane.beliefLines({ companyId, query, userId });
+    return this.beliefLane.beliefLines({
+      companyId,
+      query,
+      userId,
+      // D4 date-token disambiguation — caller-resolved with the lane flag.
+      dateDisambiguation: beliefDateDisambiguation,
+    });
   }
 
   /**

--- a/src/synthesize/generator-client.ts
+++ b/src/synthesize/generator-client.ts
@@ -110,6 +110,15 @@ export interface GenerateRequest {
    */
   beliefCitations?: boolean | undefined;
   /**
+   * BELIEFS_LANE_DATE_DISAMBIGUATION (memory-fitness D4): the belief
+   * section header gains the date-scoping clause (a belief-line date is
+   * when the belief last changed, never the asked-about event's date) —
+   * resolved once per request beside the lane flag and matching the
+   * lane's `belief current since` token. Effective only when
+   * beliefLines are non-empty (no section ⇒ byte-identical prompt).
+   */
+  beliefDateDisambiguation?: boolean | undefined;
+  /**
    * MM-zoom PR2 (profile.fragmentLane): rendered media-evidence lines,
    * their own section — the verifier reads the same lines
    * (capabilityEvidenceLines, evidence parity).

--- a/src/synthesize/generator-prompt.ts
+++ b/src/synthesize/generator-prompt.ts
@@ -39,6 +39,7 @@ export function buildGeneratorUserMessage({
   strategyNotes,
   beliefLines,
   beliefCitations,
+  beliefDateDisambiguation,
   fragmentLines,
   fragmentCitations,
 }: {
@@ -138,6 +139,17 @@ export function buildGeneratorUserMessage({
    */
   beliefCitations?: boolean | undefined;
   /**
+   * BELIEFS_LANE_DATE_DISAMBIGUATION (memory-fitness D4): both belief
+   * section header variants gain the date-scoping clause — the date on
+   * a belief line is the belief REVISION's validFrom (when the belief
+   * last changed), never the date of the asked-about event, so "when
+   * did X happen" questions must take the date from the facts. Matches
+   * the lane's `belief current since` line token (one per-request
+   * resolution, echoed through CollectedEvidence). Off/undefined = the
+   * historical headers, byte-identical.
+   */
+  beliefDateDisambiguation?: boolean | undefined;
+  /**
    * MM-zoom PR2 (profile.fragmentLane): rendered media-evidence lines —
    * `[capability:<kind>]`-tagged derived-representation excerpts of
    * registered media observations — their own section. The verifier
@@ -200,7 +212,7 @@ export function buildGeneratorUserMessage({
     insightLines && insightLines.length > 0
       ? `\n\n${insightHeader}\n${insightLines.join('\n')}`
       : '';
-  const beliefSection = renderBeliefSection(beliefLines, beliefCitations);
+  const beliefSection = renderBeliefSection(beliefLines, beliefCitations, beliefDateDisambiguation);
   const fragmentSection = renderFragmentSection(fragmentLines, fragmentCitations);
   const dateMathSection =
     dateMathLines && dateMathLines.length > 0
@@ -225,11 +237,24 @@ export function buildGeneratorUserMessage({
  *  generator-client.ts BELIEF_ABSTENTION_ADDENDUM). */
 const BELIEF_EVIDENCE_ONLY_CLAUSE =
   ' These lines ADD evidence — they never relax the base evidence rules: when NEITHER a belief line NOR the facts/transcript cover the question, follow the base instructions for an unanswerable question unchanged';
-function renderBeliefSection(beliefLines?: string[], beliefCitations?: boolean): string {
+/** BELIEFS_LANE_DATE_DISAMBIGUATION (memory-fitness D4) header clause —
+ *  appended to BOTH variants when the flag is on (the
+ *  BELIEF_EVIDENCE_ONLY_CLAUSE split-constant idiom; flag off ⇒
+ *  byte-identical). The date block above teaches "(as of YYYY-MM-DD)"
+ *  as an answer-bearing EVENT-date stamp; a belief line's day is the
+ *  belief REVISION's validFrom, so the header must scope it. */
+const BELIEF_DATE_DISAMBIGUATION_CLAUSE =
+  ". The date on a belief line is when the belief last changed — never the date of the event being asked about; for 'when did X happen' questions take the date from the facts";
+function renderBeliefSection(
+  beliefLines?: string[],
+  beliefCitations?: boolean,
+  beliefDateDisambiguation?: boolean,
+): string {
   if (!beliefLines || beliefLines.length === 0) return '';
+  const dateClause = beliefDateDisambiguation ? BELIEF_DATE_DISAMBIGUATION_CLAUSE : '';
   const header = beliefCitations
-    ? `Current-state record (distilled beliefs — each line states what is CURRENTLY true for its subject/field and supersedes any older or conflicting fact above; each line is headed by its [semantic_belief:...] id. For questions asking the CURRENT state, prefer these lines ONLY when one covers the asked subject/field; when a claim rests on one, copy its id EXACTLY into citedBeliefIds. For questions about history, sequence, or why something changed, use the facts and transcript instead; cite factIds for fact-grounded claims as before.${BELIEF_EVIDENCE_ONLY_CLAUSE}):`
-    : `Current-state record (distilled beliefs — each line states what is CURRENTLY true for its subject/field and supersedes any older or conflicting fact above. For questions asking the CURRENT state, prefer these lines ONLY when one covers the asked subject/field; for questions about history, sequence, or why something changed, use the facts and transcript instead; cite factIds only.${BELIEF_EVIDENCE_ONLY_CLAUSE}):`;
+    ? `Current-state record (distilled beliefs — each line states what is CURRENTLY true for its subject/field and supersedes any older or conflicting fact above; each line is headed by its [semantic_belief:...] id. For questions asking the CURRENT state, prefer these lines ONLY when one covers the asked subject/field; when a claim rests on one, copy its id EXACTLY into citedBeliefIds. For questions about history, sequence, or why something changed, use the facts and transcript instead; cite factIds for fact-grounded claims as before.${BELIEF_EVIDENCE_ONLY_CLAUSE}${dateClause}):`
+    : `Current-state record (distilled beliefs — each line states what is CURRENTLY true for its subject/field and supersedes any older or conflicting fact above. For questions asking the CURRENT state, prefer these lines ONLY when one covers the asked subject/field; for questions about history, sequence, or why something changed, use the facts and transcript instead; cite factIds only.${BELIEF_EVIDENCE_ONLY_CLAUSE}${dateClause}):`;
   return `\n\n${header}\n${beliefLines.join('\n')}`;
 }
 

--- a/src/synthesize/synthesize.helpers.ts
+++ b/src/synthesize/synthesize.helpers.ts
@@ -156,6 +156,8 @@ export function buildGeneratorArgs(
       beliefLines?: string[] | undefined;
       /** Belief-citation affordance (rides the master flag), resolved once. */
       beliefCitations?: boolean | undefined;
+      /** BELIEFS_LANE_DATE_DISAMBIGUATION echo (D4), resolved once. */
+      beliefDateDisambiguation?: boolean | undefined;
     };
   },
   o: {
@@ -197,6 +199,10 @@ export function buildGeneratorArgs(
     // affordance — carried identically by both rounds too.
     beliefLines: collected.beliefLines,
     beliefCitations: collected.beliefCitations,
+    // BELIEFS_LANE_DATE_DISAMBIGUATION (D4): the belief-header date
+    // scoping clause rides the same per-request resolution as the
+    // lane's rendered token.
+    beliefDateDisambiguation: collected.beliefDateDisambiguation,
     ...(o.allowRefine !== undefined ? { allowRefine: o.allowRefine } : {}),
     ...(o.answerLangStrict ? { answerLangStrict: true } : {}),
   };

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -29,7 +29,10 @@ import { runLaneProbe } from './lane-probe';
 import { getActiveRetrievalProfile, type RetrievalProfile } from '../search/retrieval-profile';
 import { buildFactIndex } from './fact-index';
 import { fragmentCitationsEnabled } from '../common/evidence-flags';
-import { beliefServingLaneEnabled } from '../common/beliefs-flags';
+import {
+  beliefServingLaneEnabled,
+  beliefLaneDateDisambiguationEnabled,
+} from '../common/beliefs-flags';
 import { resolveAndCountFragmentCitations } from './fragment-citations';
 import { resolveAndCountBeliefCitations } from './belief-citations';
 import { verifyAndZoom } from './fragment-zoom-seam';
@@ -550,6 +553,10 @@ export class SynthesizeService {
       // generator affordance and the resolver all key off the resulting
       // fence map (populated ⟺ flag on AND beliefs rendered).
       beliefLane: beliefServingLaneEnabled(),
+      // BELIEFS_LANE_DATE_DISAMBIGUATION, resolved ONCE beside the lane
+      // flag: the lane's rendered date token and the generator's belief
+      // header key off the same resolution (echoed on CollectedEvidence).
+      beliefDateDisambiguation: beliefLaneDateDisambiguationEnabled(),
     });
   }
 
@@ -889,6 +896,9 @@ export class SynthesizeService {
        *  carries them identically too. */
       beliefLines?: string[] | undefined;
       beliefCitations?: boolean | undefined;
+      /** BELIEFS_LANE_DATE_DISAMBIGUATION echo — the belief-section
+       *  header rides the same per-request resolution in both rounds. */
+      beliefDateDisambiguation?: boolean | undefined;
     };
   }): Promise<{
     results: SearchHit[];

--- a/test/belief-lane.unit-spec.ts
+++ b/test/belief-lane.unit-spec.ts
@@ -207,6 +207,65 @@ describe('BeliefLaneService — render + degrade', () => {
   });
 });
 
+describe('BeliefLaneService — date-token disambiguation (BELIEFS_LANE_DATE_DISAMBIGUATION)', () => {
+  it('flag off (absent or explicit false) ⇒ the historical `, as of <day>` token, byte-identical', async () => {
+    const { surreal } = surrealOf({ bm25Rows: [row({})] });
+    const svc = new BeliefLaneService(surreal, embedderOk);
+    const absent = await svc.beliefLines(baseOpts);
+    const explicit = await svc.beliefLines({ ...baseOpts, dateDisambiguation: false });
+    expect(absent.lines).toEqual([
+      '[semantic_belief:b1] (inventory service — database, rev 2, as of 2026-08-01) ' +
+        'inventory service — database: SurrealDB (was: PostgreSQL)',
+    ]);
+    expect(explicit.lines).toEqual(absent.lines);
+  });
+
+  it('flag on ⇒ `, belief current since <day>` replaces the `as of` token (D4: the day is the REVISION’s validFrom, not an event date)', async () => {
+    const { surreal } = surrealOf({ bm25Rows: [row({})] });
+    const out = await new BeliefLaneService(surreal, embedderOk).beliefLines({
+      ...baseOpts,
+      dateDisambiguation: true,
+    });
+    expect(out.lines).toEqual([
+      '[semantic_belief:b1] (inventory service — database, rev 2, belief current since 2026-08-01) ' +
+        'inventory service — database: SurrealDB (was: PostgreSQL)',
+    ]);
+    expect(out.lines[0]).not.toContain(', as of ');
+  });
+
+  it('no-day branch is unchanged in BOTH modes (no date token at all)', async () => {
+    const noDay = row({ validFrom: undefined as unknown as string });
+    const expected =
+      '[semantic_belief:b1] (inventory service — database, rev 2) ' +
+      'inventory service — database: SurrealDB (was: PostgreSQL)';
+    const { surreal: sOff } = surrealOf({ bm25Rows: [noDay] });
+    const off = await new BeliefLaneService(sOff, embedderOk).beliefLines(baseOpts);
+    const { surreal: sOn } = surrealOf({ bm25Rows: [noDay] });
+    const on = await new BeliefLaneService(sOn, embedderOk).beliefLines({
+      ...baseOpts,
+      dateDisambiguation: true,
+    });
+    expect(off.lines).toEqual([expected]);
+    expect(on.lines).toEqual([expected]);
+  });
+
+  it('byId citation fence is untouched by the flag (keys on beliefId, not the rendered string)', async () => {
+    const { surreal } = surrealOf({ bm25Rows: [row({})] });
+    const out = await new BeliefLaneService(surreal, embedderOk).beliefLines({
+      ...baseOpts,
+      dateDisambiguation: true,
+    });
+    expect(out.byId.get('semantic_belief:b1')).toEqual({
+      beliefId: 'semantic_belief:b1',
+      subject: 'inventory service',
+      field: 'database',
+      value: 'SurrealDB',
+      excerpt: 'inventory service — database: SurrealDB (was: PostgreSQL)',
+      occurredAt: '2026-08-01T00:00:00.000Z',
+    });
+  });
+});
+
 describe('EvidenceCollectorService — belief lane gating', () => {
   const noSearch = { search: async () => ({ results: [] }) } as unknown as SearchService;
 
@@ -288,5 +347,24 @@ describe('EvidenceCollectorService — belief lane gating', () => {
     const out = await collectorWith(undefined).collect(collectArgs(true));
     expect(out.beliefLines).toEqual([]);
     expect(out.beliefsById).toBeUndefined();
+  });
+
+  it('beliefDateDisambiguation (caller-resolved) reaches the lane and is echoed on CollectedEvidence', async () => {
+    const seen: Array<boolean | undefined> = [];
+    const lane = {
+      beliefLines: async (o: { dateDisambiguation?: boolean | undefined }) => {
+        seen.push(o.dateDisambiguation);
+        return { lines: [], byId: new Map() };
+      },
+    } as unknown as BeliefLaneService;
+    const on = await collectorWith(lane).collect({
+      ...collectArgs(true),
+      beliefDateDisambiguation: true,
+    });
+    expect(seen).toEqual([true]);
+    expect(on.beliefDateDisambiguation).toBe(true);
+    const off = await collectorWith(lane).collect(collectArgs(true));
+    expect(seen).toEqual([true, undefined]);
+    expect(off.beliefDateDisambiguation).toBeUndefined();
   });
 });

--- a/test/synthesize.unit-spec.ts
+++ b/test/synthesize.unit-spec.ts
@@ -607,6 +607,60 @@ describe('buildGeneratorUserMessage — belief section (BELIEFS_SERVING_LANE sea
       expect(out).not.toContain('prefer these lines;');
     }
   });
+
+  // BELIEFS_LANE_DATE_DISAMBIGUATION (memory-fitness D4): a belief
+  // line's date is the REVISION's validFrom, which the date block's
+  // "(as of YYYY-MM-DD)" teaching otherwise reads as an event date.
+  const DATE_SCOPING_CLAUSE =
+    "The date on a belief line is when the belief last changed — never the date of the event being asked about; for 'when did X happen' questions take the date from the facts";
+
+  it('date disambiguation OFF (absent / false / undefined) ⇒ BYTE-IDENTICAL headers, no date-scoping clause', () => {
+    const line = '[semantic_belief:b1] (s — f, rev 1, as of 2026-04-15) s';
+    const base = buildGeneratorUserMessage({ ...BASE, beliefLines: [line], beliefCitations: true });
+    expect(
+      buildGeneratorUserMessage({
+        ...BASE,
+        beliefLines: [line],
+        beliefCitations: true,
+        beliefDateDisambiguation: false,
+      }),
+    ).toBe(base);
+    expect(
+      buildGeneratorUserMessage({
+        ...BASE,
+        beliefLines: [line],
+        beliefCitations: true,
+        beliefDateDisambiguation: undefined,
+      }),
+    ).toBe(base);
+    expect(base).not.toContain(DATE_SCOPING_CLAUSE);
+  });
+
+  it('date disambiguation ON ⇒ BOTH header variants carry the date-scoping clause', () => {
+    const line = '[semantic_belief:b1] (s — f, rev 1, belief current since 2026-04-15) s';
+    const cited = buildGeneratorUserMessage({
+      ...BASE,
+      beliefLines: [line],
+      beliefCitations: true,
+      beliefDateDisambiguation: true,
+    });
+    const plain = buildGeneratorUserMessage({
+      ...BASE,
+      beliefLines: [line],
+      beliefDateDisambiguation: true,
+    });
+    for (const out of [cited, plain]) {
+      expect(out).toContain(DATE_SCOPING_CLAUSE);
+      // The clause composes with (never replaces) the D5 abstention
+      // discipline — both survive in the same header.
+      expect(out).toContain('prefer these lines ONLY when one covers the asked subject/field');
+      expect(out).toContain('These lines ADD evidence');
+    }
+    // The variant split is untouched: only the cited header instructs
+    // citedBeliefIds mirroring.
+    expect(cited).toContain('citedBeliefIds');
+    expect(plain).not.toContain('citedBeliefIds');
+  });
 });
 
 describe('buildVerifierUserMessage — beliefLines (BELIEFS_SERVING_LANE seam)', () => {


### PR DESCRIPTION
## Mechanism (confirmed against memory-fitness run reports)

D4 regressed 4/4 → 2/4 when `BELIEFS_SERVING_LANE` came on. The chain:

1. The generator's date block (`generator-prompt.ts`) teaches that `(as of YYYY-MM-DD)` tokens are **answer-bearing date stamps** for "when" questions — correct for fact lines (`fact-index.ts` renders ` (as of ${from})` with the fact's event-time validFrom).
2. Belief lines reuse the same token shape: `[beliefId] (subject — field, rev N, as of ${day}) ...` — but a belief's `as of` day is the belief **revision's** validFrom (when the current value was last promoted), not the date of the asked-about event.
3. The belief section header says the lines "supersede any older or conflicting fact above", amplifying the misread.
4. The lane has no relevance floor (disjunctive `or_terms` BM25 leg, top-3 unconditional), so non-covering belief lines with wrongly-scoped dates routinely land on "when" questions.

Net effect: "When did the ledger-sync project kick off?" answered with the belief revision's date (2026-04-15) instead of the kickoff fact's date (2026-03-02).

### Why D1 went up while D4 went down

The same token that hurts "when did X happen" questions is what helps current-state questions: for D1 ("what is X now"), a dated current-state line is exactly the right evidence, and the supersede framing is correct there. The lane's date token is only *mis-scoped* when the question asks about an event's date — the revision date then masquerades as the event date. The fix therefore renames what the day **is** (`belief current since`) instead of removing it, keeping the D1 value while cutting off the D4 misread.

## Change — flag `BELIEFS_LANE_DATE_DISAMBIGUATION` (default off)

- **`BeliefLaneService.render()`**: `, as of ${day}` → `, belief current since ${day}` when the flag is on; the no-day branch is unchanged in both modes.
- **Generator belief-section headers** (BOTH variants — cited and plain): append the date-scoping clause — *"The date on a belief line is when the belief last changed — never the date of the event being asked about; for 'when did X happen' questions take the date from the facts"* — via the split-constant idiom (`BELIEF_EVIDENCE_ONLY_CLAUSE` / `BELIEF_ABSTENTION_ADDENDUM` precedent).
- **Flag helper** `beliefLaneDateDisambiguationEnabled()` beside its siblings in `common/beliefs-flags.ts` (call-time `envFlagEnabled`, runtime-mutable), registered in `KNOWN_BOOLEAN_FLAGS` and the admin config catalog. `BELIEFS_` prefix — off the ENGINE flag budget.

## Three-consumer parity

The rendered belief lines feed the generator, the verifier, and the fragment-zoom re-verify (both `VerifyRequest` build sites in `fragment-zoom-seam.ts`). All three read the same `collected.beliefLines`, produced by the **one** render site in `BeliefLaneService.render()` — verified by grep that nobody re-renders belief lines elsewhere — so the token change reaches all three by construction. The flag is resolved ONCE per request beside `beliefServingLaneEnabled()` in `collectSections` and echoed through `CollectedEvidence`, so the line token and the header clause ride the same resolution (the lane itself still reads no env). The `byId` citation fence keys on `beliefId`, not the rendered string — untouched.

## Flag-off byte-identity

Off (default) ⇒ byte-identical lines, prompts and serving — pinned by unit tests:
- render: off (absent/explicit false) reproduces today's `, as of <day>` line byte-exactly; on emits `, belief current since <day>`; no-day branch identical in both modes; `byId` unchanged.
- prompt: off (absent/false/undefined) headers byte-identical, clause absent; on carries the clause in BOTH variants, composing with (not replacing) the #412/#413 abstention discipline.
- collector: caller-resolved flag reaches the lane and echoes on `CollectedEvidence`.

## Deliberately NOT in this PR

`BELIEFS_LANE_COVERAGE_GATE` (relevance floor for the lane) — deferred until this fix is measured in isolation.

## Verification

- `pnpm typecheck` clean; `pnpm test:unit` 339 suites / 3616 tests green; `pnpm prettier --check` clean on all touched files; eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB