### PR TITLE
feat(provenance): PROVENANCE_EPISODE_NEIGHBOURS — sibling-turn widening of the one-hop provenance read (default off)

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -1103,6 +1103,10 @@
           "occurredAt": {
             "type": "string"
           },
+          "relation": {
+            "const": "neighbour",
+            "type": "string"
+          },
           "span": {
             "additionalProperties": false,
             "properties": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1103,6 +1103,10 @@
           "occurredAt": {
             "type": "string"
           },
+          "relation": {
+            "const": "neighbour",
+            "type": "string"
+          },
           "span": {
             "additionalProperties": false,
             "properties": {

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -2324,6 +2324,24 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Typed support graph, read side (Drift-5): the provenance closure walk (PROVENANCE_RECURSIVE_CLOSURE) additionally follows derived_from edges as children (same visited set, same depth/fact/episode caps) and returns the supported_by/contradicted_by/derived_from edges it crossed in a new optional supportEdges response field; a root with typed edges but an empty derivedFrom array now walks too. Members pass the same per-row fences; edge targets are classified via EvidenceRef prefixes. Off (default) → the walk and the provenance response are byte-identical (field absent, not empty).',
   },
   {
+    key: 'PROVENANCE_EPISODE_NEIGHBOURS',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Evidence plane, read side: the one-hop GET /v1/facts/:id/provenance read widens to the ±radius sibling turns of the SAME conversation around each primary grounding turn (radius = PROVENANCE_EPISODE_NEIGHBOUR_RADIUS, clamped 1..3) — a mention-extracted fact stamps exactly ONE turn, so a verbatim constraint in the neighbouring paraphrased turn is otherwise unreachable from the fact. Neighbours are fetched through the shared episode read port with the IDENTICAL fences as the primary fetch (PII gate + fail-closed user pin keyed to the same userId + scope-tag fence) and carry relation:'neighbour' on the wire; primary episodes keep their exact shape and always serve — neighbours only fill the remaining PROVENANCE_CLOSURE_MAX_EPISODES budget, admitted chronologically. Off (default) → no window query is issued and the response is byte-identical (no relation key).",
+  },
+  {
+    key: 'PROVENANCE_EPISODE_NEIGHBOUR_RADIUS',
+    category: 'pipeline',
+    defaultValue: '1',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Sibling-turn radius of the PROVENANCE_EPISODE_NEIGHBOURS widening — turns fetched BEFORE and AFTER each primary grounding turn within the same conversation. Clamped to 1..3; unset/invalid → 1. The served union stays bounded by PROVENANCE_CLOSURE_MAX_EPISODES regardless of the radius.',
+  },
+  {
     key: 'PROJECTIONS_API_ENABLED',
     category: 'pipeline',
     defaultValue: '0',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1251,6 +1251,16 @@ const KNOWN_BOOLEAN_FLAGS = [
   // response byte-identical (field absent). Outside ENGINE_PREFIX by
   // design — off the flag budget.
   'PROVENANCE_SUPPORT_GRAPH_READ',
+  // Evidence plane: the one-hop GET /v1/facts/:id/provenance read
+  // widens to the ±radius sibling turns of the same conversation around
+  // each primary grounding turn (radius =
+  // PROVENANCE_EPISODE_NEIGHBOUR_RADIUS, an integer knob clamped 1..3;
+  // union capped by PROVENANCE_CLOSURE_MAX_EPISODES). Neighbours pass
+  // the identical episode read fences as the primary fetch and carry
+  // relation:'neighbour'. Default off ⇒ response byte-identical.
+  // Outside ENGINE_PREFIX by design — the PROVENANCE_ family sits off
+  // the flag budget.
+  'PROVENANCE_EPISODE_NEIGHBOURS',
   // Multilingual Tier 1 (migration 0100). Confidence-aware attribution:
   // the detector returns `und` (not `en`) for short/stopword-less objects
   // and the resolver stamps langConfidence/langSource/detectorVersion/

--- a/src/common/provenance-flags.ts
+++ b/src/common/provenance-flags.ts
@@ -42,6 +42,32 @@ export function recursiveClosureEnabled(): boolean {
 }
 
 /**
+ * Evidence plane — episode-neighbour widening —
+ * PROVENANCE_EPISODE_NEIGHBOURS.
+ *
+ * When on, the one-hop GET /v1/facts/:id/provenance read additionally
+ * serves the ±radius sibling turns of the SAME conversation around each
+ * primary grounding turn (radius = PROVENANCE_EPISODE_NEIGHBOUR_RADIUS,
+ * clamped 1..3). A mention-extracted fact stamps exactly the ONE turn it
+ * was extracted from; when the verbatim constraint lives in the
+ * neighbouring paraphrased turn, the walk could never reach it — this
+ * widening exposes the surrounding turns WITHOUT changing the grounding
+ * stamp. Neighbours go through the identical episode read fences as the
+ * primary fetch (PII gate + fail-closed user pin, same userId key) and
+ * carry `relation: 'neighbour'` on the wire; primary episodes keep
+ * their exact shape. The union is capped by closureMaxEpisodes() —
+ * primaries always serve, neighbours only fill the remaining budget.
+ * The env read lives here in the common layer, NOT inside the engine
+ * dirs (engine-gates S5.2). Read at call time so a flip is
+ * runtime-mutable. Default off ⇒ the provenance response is
+ * byte-identical (no relation key ever appears, no window query is
+ * ever issued).
+ */
+export function episodeNeighboursEnabled(): boolean {
+  return envFlagEnabled(process.env.PROVENANCE_EPISODE_NEIGHBOURS);
+}
+
+/**
  * Typed support graph — write side — PROVENANCE_SUPPORT_EDGES.
  *
  * When on, the three writer families emit canonical memory_support
@@ -129,4 +155,20 @@ export function closureMaxEpisodes(): number {
     DEFAULT_CLOSURE_MAX_EPISODES,
     [1, 500],
   );
+}
+
+/** Neighbour-widening radius default (see the knob below). */
+const DEFAULT_NEIGHBOUR_RADIUS = 1;
+
+/**
+ * Episode-neighbour radius (PROVENANCE_EPISODE_NEIGHBOUR_RADIUS): how
+ * many sibling turns BEFORE and AFTER each primary grounding turn the
+ * PROVENANCE_EPISODE_NEIGHBOURS widening fetches from the same
+ * conversation. A non-boolean knob resolved here in the common layer so
+ * the read path takes a resolved number. Default 1, clamped to 1..3;
+ * unset, blank, or non-numeric → the default. Total served episodes
+ * stay bounded by closureMaxEpisodes() regardless of the radius.
+ */
+export function episodeNeighbourRadius(): number {
+  return intKnob(process.env.PROVENANCE_EPISODE_NEIGHBOUR_RADIUS, DEFAULT_NEIGHBOUR_RADIUS, [1, 3]);
 }

--- a/src/contracts/facts/facts.schema.ts
+++ b/src/contracts/facts/facts.schema.ts
@@ -57,6 +57,15 @@ export const FactProvenanceEpisodeSchema = z.object({
   /** Present with `span`: true when `text` was truncated by the server
    *  cap — span offsets reference the FULL stored text. */
   textTruncated: z.boolean().optional(),
+  /**
+   * PROVENANCE_EPISODE_NEIGHBOURS (default off): 'neighbour' marks a
+   * ±radius sibling turn of the same conversation served around a
+   * primary grounding turn (radius = PROVENANCE_EPISODE_NEIGHBOUR_RADIUS,
+   * clamped 1..3). Absent = a primary grounding turn (source.episodeIds)
+   * — primaries keep their exact pre-flag shape. Optional →
+   * backward-compatible.
+   */
+  relation: z.literal('neighbour').optional(),
 });
 
 export const FactProvenanceResponseSchema = z.object({

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -29,6 +29,8 @@ import {
   closureMaxDepth,
   closureMaxEpisodes,
   closureMaxFacts,
+  episodeNeighbourRadius,
+  episodeNeighboursEnabled,
   recursiveClosureEnabled,
   supportGraphReadEnabled,
 } from '../common/provenance-flags';
@@ -159,6 +161,13 @@ export interface FactProvenanceEpisode {
   /** Present with `span`: true when `text` was truncated by the cap —
    *  span offsets reference the FULL stored text, not the capped view. */
   textTruncated?: boolean;
+  /**
+   * PROVENANCE_EPISODE_NEIGHBOURS (default off): 'neighbour' marks a
+   * ±radius sibling turn of the same conversation served around a
+   * primary grounding turn. Absent = a primary grounding turn
+   * (source.episodeIds) — primaries keep their exact pre-flag shape.
+   */
+  relation?: 'neighbour';
 }
 
 /**
@@ -414,19 +423,104 @@ export class FactsService {
         ? [...new Set(source.episodeIds.map(String).filter((e) => e.startsWith('episode:')))]
         : [];
       if (ids.length === 0) return { factId: String(fact.id), episodes: [] };
+      const includePii = opts.scopes.includes('brain:read_pii');
+      const episodeUserId =
+        typeof fact.userId === 'string' && fact.userId.length > 0
+          ? fact.userId
+          : pinUserScope(undefined);
       const rows = await this.episodes.byIds({
         companyId: opts.companyId,
         ids,
-        includePii: opts.scopes.includes('brain:read_pii'),
-        userId:
-          typeof fact.userId === 'string' && fact.userId.length > 0
-            ? fact.userId
-            : pinUserScope(undefined),
+        includePii,
+        userId: episodeUserId,
         db,
       });
-      const episodes = this.mapProvenanceEpisodes(rows, spanByEpisode);
+      // PROVENANCE_EPISODE_NEIGHBOURS (default off): widen to the
+      // ±radius sibling turns of the SAME conversation around each
+      // primary grounding turn — a mention-extracted fact stamps exactly
+      // ONE turn, so a verbatim constraint in the neighbouring
+      // paraphrased turn is otherwise unreachable. Neighbours ride the
+      // identical fences as the primary fetch (see
+      // fetchEpisodeNeighbours) and carry relation:'neighbour'. Flag off
+      // ⇒ no window query, no relation key — byte-identical.
+      let neighbourIds: Set<string> | undefined;
+      let allRows = rows;
+      if (episodeNeighboursEnabled()) {
+        const neighbours = await this.fetchEpisodeNeighbours({
+          db,
+          companyId: opts.companyId,
+          primaries: rows,
+          includePii,
+          userId: episodeUserId,
+        });
+        if (neighbours.length > 0) {
+          neighbourIds = new Set(neighbours.map((n) => String(n.id)));
+          allRows = [...rows, ...neighbours];
+        }
+      }
+      const episodes = this.mapProvenanceEpisodes(allRows, spanByEpisode, neighbourIds);
       return { factId: String(fact.id), episodes };
     });
+  }
+
+  /**
+   * PROVENANCE_EPISODE_NEIGHBOURS widening: the ±radius sibling turns
+   * of the same conversation around each primary grounding turn.
+   *
+   * SECURITY — this is a read widening on the evidence surface, so every
+   * neighbour fetch goes through the SHARED episode read port
+   * (windowAround), which composes the identical fences the primary
+   * byIds fetch uses: the one PII-fence implementation, the fail-closed
+   * user pin keyed to the SAME userId as the primary fetch (the fact's
+   * owner, else the caller's pinned scope), and the G6 scope-tag fence.
+   * A neighbour turn recorded by another user is dropped by that SQL
+   * fence and never surfaces.
+   *
+   * Caps: radius clamped 1..3 (episodeNeighbourRadius); the served
+   * union stays ≤ closureMaxEpisodes() — primaries always serve,
+   * neighbours only fill the remaining budget, admitted chronologically
+   * (then by id) so the cut is deterministic.
+   */
+  private async fetchEpisodeNeighbours(args: {
+    db: Surreal;
+    companyId: string;
+    primaries: EpisodeQuoteRow[];
+    includePii: boolean;
+    userId: string | undefined;
+  }): Promise<EpisodeQuoteRow[]> {
+    const primaryIds = new Set(args.primaries.map((r) => String(r.id)));
+    const budget = closureMaxEpisodes() - primaryIds.size;
+    if (budget <= 0) return [];
+    const radius = episodeNeighbourRadius();
+    const seen = new Set<string>();
+    const neighbours: EpisodeQuoteRow[] = [];
+    for (const primary of args.primaries) {
+      // The conversation fence comes from the FENCED primary row itself;
+      // a turn without one has no siblings to widen to.
+      if (primary.conversationId === undefined || primary.conversationId === '') continue;
+      const win = await this.episodes.windowAround({
+        companyId: args.companyId,
+        conversationId: primary.conversationId,
+        centerIso: toIso(primary.occurredAt),
+        span: radius,
+        includePii: args.includePii,
+        ...(args.userId !== undefined ? { userId: args.userId } : {}),
+        db: args.db,
+      });
+      for (const row of win) {
+        const id = String(row.id);
+        if (primaryIds.has(id) || seen.has(id)) continue;
+        seen.add(id);
+        neighbours.push(row);
+      }
+    }
+    return neighbours
+      .sort((a, b) => {
+        const dt =
+          new Date(toIso(a.occurredAt)).getTime() - new Date(toIso(b.occurredAt)).getTime();
+        return dt !== 0 ? dt : String(a.id).localeCompare(String(b.id));
+      })
+      .slice(0, budget);
   }
 
   /**
@@ -572,11 +666,14 @@ export class FactsService {
    * Chronological sort + wire mapping of provenance episode rows —
    * shared by the one-hop path and the closure path so the per-episode
    * shape (PROVENANCE_TEXT_CHAR_CAP, G3 span attachment) has ONE
-   * implementation.
+   * implementation. `neighbourIds` (PROVENANCE_EPISODE_NEIGHBOURS)
+   * marks the sibling turns with relation:'neighbour'; omitted (every
+   * other caller) the shape is byte-identical.
    */
   private mapProvenanceEpisodes(
     rows: EpisodeQuoteRow[],
     spanByEpisode: Map<string, ProvenanceSpan>,
+    neighbourIds?: Set<string>,
   ): FactProvenanceEpisode[] {
     return rows
       .slice()
@@ -604,6 +701,9 @@ export class FactsService {
                 textTruncated: r.text.length > PROVENANCE_TEXT_CHAR_CAP,
               }
             : {}),
+          // PROVENANCE_EPISODE_NEIGHBOURS: sibling turns carry the
+          // marker; primary grounding turns keep their exact shape.
+          ...(neighbourIds?.has(String(r.id)) ? { relation: 'neighbour' as const } : {}),
         };
       });
   }

--- a/test/contracts-facts.unit-spec.ts
+++ b/test/contracts-facts.unit-spec.ts
@@ -47,6 +47,10 @@ const fullEpisode: Required<FactProvenanceEpisode> = {
   // G3: code-point offsets over the NFC-normalized FULL stored text.
   span: { start: 2, end: 22, exact: 'moved to Lisbon last' },
   textTruncated: false,
+  // PROVENANCE_EPISODE_NEIGHBOURS: sibling-turn marker — absent on
+  // primary grounding turns (and on the whole response with the flag
+  // off).
+  relation: 'neighbour',
 };
 
 const fullProvenance: Required<FactProvenanceResult> = {

--- a/test/eval/memory-fitness/interleave.ts
+++ b/test/eval/memory-fitness/interleave.ts
@@ -1,0 +1,25 @@
+/**
+ * Round-robin candidate interleave for the memory-fitness provenance
+ * walk (runner.ts, d3): candidates used to be flattened hit-major then
+ * sliced, so one fat entity (many facts on the first hit) monopolised
+ * the whole walk budget and the fact holding the seeded fragment —
+ * often on hit 2 or 3 — never got walked. Interleaving takes the first
+ * fact of EVERY hit, then the second of every hit, and so on
+ * (hit1.fact1, hit2.fact1, hit3.fact1, hit1.fact2, …) before the cap,
+ * so the budget spreads across entities.
+ *
+ * Pure and harness-only — no server behavior involved.
+ */
+export function interleaveRoundRobin<T>(lists: ReadonlyArray<readonly T[]>, cap: number): T[] {
+  const out: T[] = [];
+  if (cap <= 0) return out;
+  const longest = lists.reduce((max, list) => Math.max(max, list.length), 0);
+  for (let rank = 0; rank < longest; rank++) {
+    for (const list of lists) {
+      if (rank >= list.length) continue;
+      out.push(list[rank] as T);
+      if (out.length >= cap) return out;
+    }
+  }
+  return out;
+}

--- a/test/eval/memory-fitness/runner.ts
+++ b/test/eval/memory-fitness/runner.ts
@@ -31,6 +31,7 @@ import {
   MERIDIAN_REF,
   SPEAKER,
 } from './corpus';
+import { interleaveRoundRobin } from './interleave';
 import { QUESTIONS } from './questions';
 import {
   checkEvolution,
@@ -44,6 +45,13 @@ import {
   type EvolutionEvent,
 } from './scorers';
 import type { DimensionTally, Dimension, Question, QuestionResult, Scorecard } from './types';
+
+/**
+ * Provenance-walk budget (d3): how many candidate facts get their
+ * provenance unrolled per question. Candidates are interleaved
+ * round-robin across search hits (interleave.ts) before this cap.
+ */
+const PROVENANCE_CANDIDATE_CAP = 12;
 
 // ── configuration ───────────────────────────────────────────────────
 
@@ -444,16 +452,19 @@ async function askOne(ctx: AskContext, q: Question): Promise<Verdict> {
         return { status: 'skipped', detail: 'get_fact_provenance absent (FACTS_API_ENABLED off)' };
       }
       const hits = await searchHits(ctx, q.searchQuery, 8);
-      const factIds: string[] = [];
-      for (const hit of hits) {
+      const factIdsPerHit: string[][] = hits.map((hit) => {
+        const ids: string[] = [];
         for (const fact of hit.facts ?? []) {
           if (q.predicateHint !== undefined && q.predicateHint !== '') {
             if (!fact.predicate.includes(q.predicateHint)) continue;
           }
-          factIds.push(fact.factId);
+          ids.push(fact.factId);
         }
-      }
-      const candidates = factIds.slice(0, 6);
+        return ids;
+      });
+      // Round-robin across hits (hit1.fact1, hit2.fact1, …) so one fat
+      // entity cannot monopolise the walk budget — see interleave.ts.
+      const candidates = interleaveRoundRobin(factIdsPerHit, PROVENANCE_CANDIDATE_CAP);
       if (candidates.length === 0) {
         return { status: 'fail', detail: 'search returned no candidate facts' };
       }

--- a/test/fact-provenance.unit-spec.ts
+++ b/test/fact-provenance.unit-spec.ts
@@ -51,6 +51,40 @@ function makeStack(opts: {
           (opts.factsByCompany[companyId] ?? []).filter((f) => wanted.includes(String(f.id))),
         ];
       }
+      // windowAround (PROVENANCE_EPISODE_NEIGHBOURS): the two bounded
+      // conversation-window reads. Like the byIds branch below, the
+      // PII/user gates are applied from the SQL the REAL
+      // EpisodeReadStoreService composed — these tests pin the actual
+      // fence strings, not a re-implementation.
+      if (sql.includes('FROM episode') && sql.includes('conversationId = $conv')) {
+        const centerMs = new Date(params?.c as Date).getTime();
+        const before = sql.includes('occurredAt <= $c');
+        const limit = Number(/LIMIT (\d+)/.exec(sql)?.[1] ?? 1000);
+        let rows = (opts.episodesByCompany?.[companyId] ?? []).filter(
+          (e) => e.conversationId === params?.conv,
+        );
+        rows = rows.filter((e) => {
+          const t = new Date(String(e.occurredAt)).getTime();
+          return before ? t <= centerMs : t > centerMs;
+        });
+        if (sql.includes('piiClass IS NONE')) {
+          rows = rows.filter((e) => e.piiClass === undefined);
+        }
+        if (sql.includes('userId = $scopeUserId')) {
+          rows = rows.filter((e) => e.userId === undefined || e.userId === params?.scopeUserId);
+        } else {
+          rows = rows.filter((e) => e.userId === undefined);
+        }
+        rows = rows
+          .slice()
+          .sort((a, b) => {
+            const d =
+              new Date(String(a.occurredAt)).getTime() - new Date(String(b.occurredAt)).getTime();
+            return before ? -d : d;
+          })
+          .slice(0, limit);
+        return [rows];
+      }
       if (sql.includes('FROM episode')) {
         const wanted = ((params?.ids as unknown[]) ?? []).map(ridOf);
         let rows = (opts.episodesByCompany?.[companyId] ?? []).filter((e) =>
@@ -574,6 +608,236 @@ describe('PROVENANCE_RECURSIVE_CLOSURE — recursive support closure', () => {
     const episodeQueries = queries.filter((q) => q.sql.includes('FROM episode'));
     const scoped = episodeQueries.find((q) => q.sql.includes('userId = $scopeUserId'));
     expect(scoped?.params?.scopeUserId).toBe('u2');
+  });
+});
+
+/**
+ * PROVENANCE_EPISODE_NEIGHBOURS: the one-hop provenance read widens to
+ * the ±radius sibling turns of the SAME conversation around each
+ * primary grounding turn. Off (default) the response is byte-identical
+ * — the golden below pins today's exact full shape. On, neighbours are
+ * fetched through the REAL EpisodeReadStoreService.windowAround (the
+ * stub applies the gate strings that service composed), carry
+ * relation:'neighbour', and the union is capped by
+ * PROVENANCE_CLOSURE_MAX_EPISODES.
+ */
+describe('PROVENANCE_EPISODE_NEIGHBOURS — sibling-turn widening', () => {
+  const SAVED_KEYS = [
+    'PROVENANCE_EPISODE_NEIGHBOURS',
+    'PROVENANCE_EPISODE_NEIGHBOUR_RADIUS',
+    'PROVENANCE_CLOSURE_MAX_EPISODES',
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const k of SAVED_KEYS) saved[k] = process.env[k];
+  });
+  afterEach(() => {
+    for (const k of SAVED_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  // conv-1 timeline: n0 (the verbatim constraint) … e1 (primary,
+  // paraphrase) … n1 … e2 (primary) … n2. The fact stamps ONLY e1+e2 —
+  // exactly the d3-ratelimit failure: the seeded fragment lives in n0.
+  const N0: Row = {
+    id: 'episode:n0',
+    conversationId: 'conv-1',
+    speaker: 'Ops',
+    text: 'Heads up: the gateway hard limit is 50 requests per minute.',
+    occurredAt: '2026-07-01T09:00:00.000Z',
+  };
+  const N1: Row = {
+    id: 'episode:n1',
+    conversationId: 'conv-1',
+    speaker: 'Caroline',
+    text: 'Noted, I will keep our poller under that.',
+    occurredAt: '2026-07-01T11:00:00.000Z',
+  };
+  const N2: Row = {
+    id: 'episode:n2',
+    conversationId: 'conv-1',
+    speaker: 'Melanie',
+    text: 'Trip planning continues tomorrow.',
+    occurredAt: '2026-07-02T11:00:00.000Z',
+  };
+  const NEIGHBOUR_CORPUS: Row[] = [N0, EPISODES[0]!, N1, EPISODES[1]!, N2];
+
+  it('flag OFF (default): GOLDEN — the full response is byte-identical, no window query issued', async () => {
+    delete process.env.PROVENANCE_EPISODE_NEIGHBOURS;
+    const { svc, queries } = makeStack({
+      factsByCompany: { co_a: [FACT_GLOBAL] },
+      episodesByCompany: { co_a: NEIGHBOUR_CORPUS },
+    });
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    // GOLDEN: the exact pre-flag response — primaries only, no
+    // relation key anywhere, e2 text capped at 600 chars.
+    expect(res).toEqual({
+      factId: 'knowledge_fact:f1',
+      episodes: [
+        {
+          episodeId: 'episode:e1',
+          conversationId: 'conv-1',
+          speaker: 'Caroline',
+          occurredAt: '2026-07-01T10:00:00.000Z',
+          text: 'I love hiking, we should plan a trip!',
+        },
+        {
+          episodeId: 'episode:e2',
+          conversationId: 'conv-1',
+          speaker: 'Melanie',
+          occurredAt: '2026-07-02T10:00:00.000Z',
+          text: `${LONG_TEXT.slice(0, 599)}…`,
+        },
+      ],
+    });
+    expect(queries.some((q) => q.sql.includes('conversationId = $conv'))).toBe(false);
+  });
+
+  it('flag ON: ±1 siblings are served chronologically, labelled relation:neighbour; primaries keep their shape', async () => {
+    process.env.PROVENANCE_EPISODE_NEIGHBOURS = '1';
+    const { svc } = makeStack({
+      factsByCompany: { co_a: [FACT_GLOBAL] },
+      episodesByCompany: { co_a: NEIGHBOUR_CORPUS },
+    });
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    expect(res.episodes.map((e) => e.episodeId)).toEqual([
+      'episode:n0',
+      'episode:e1',
+      'episode:n1',
+      'episode:e2',
+      'episode:n2',
+    ]);
+    // The turn holding the verbatim constraint is now reachable…
+    expect(res.episodes[0]).toEqual({
+      episodeId: 'episode:n0',
+      conversationId: 'conv-1',
+      speaker: 'Ops',
+      occurredAt: '2026-07-01T09:00:00.000Z',
+      text: 'Heads up: the gateway hard limit is 50 requests per minute.',
+      relation: 'neighbour',
+    });
+    // …every sibling carries the marker, and primaries keep their
+    // exact primary shape (no relation key).
+    for (const ep of res.episodes) {
+      if (ep.episodeId.startsWith('episode:n')) expect(ep.relation).toBe('neighbour');
+      else expect(ep).not.toHaveProperty('relation');
+    }
+  });
+
+  it('flag ON: the union is capped by PROVENANCE_CLOSURE_MAX_EPISODES — primaries always serve, neighbours fill the rest chronologically', async () => {
+    process.env.PROVENANCE_EPISODE_NEIGHBOURS = '1';
+    process.env.PROVENANCE_CLOSURE_MAX_EPISODES = '3';
+    const { svc } = makeStack({
+      factsByCompany: { co_a: [FACT_GLOBAL] },
+      episodesByCompany: { co_a: NEIGHBOUR_CORPUS },
+    });
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    // 2 primaries + budget for exactly 1 neighbour (the earliest, n0).
+    expect(res.episodes.map((e) => e.episodeId)).toEqual([
+      'episode:n0',
+      'episode:e1',
+      'episode:e2',
+    ]);
+  });
+
+  it('flag ON: the radius knob is clamped to 3 (window LIMITs pin the clamp)', async () => {
+    process.env.PROVENANCE_EPISODE_NEIGHBOURS = '1';
+    process.env.PROVENANCE_EPISODE_NEIGHBOUR_RADIUS = '99';
+    const { svc, queries } = makeStack({
+      factsByCompany: { co_a: [FACT_GLOBAL] },
+      episodesByCompany: { co_a: NEIGHBOUR_CORPUS },
+    });
+    await svc.getProvenance({ companyId: 'co_a', factId: 'f1', scopes: READ });
+    const windows = queries.filter((q) => q.sql.includes('conversationId = $conv'));
+    expect(windows.length).toBeGreaterThan(0);
+    // windowAround issues LIMIT span+1 before / LIMIT span after — a
+    // clamped radius of 3 means LIMIT 4 / LIMIT 3, never 100.
+    for (const w of windows) {
+      const limit = Number(/LIMIT (\d+)/.exec(w.sql)?.[1]);
+      expect(limit).toBeLessThanOrEqual(4);
+    }
+  });
+
+  it("flag ON, SECURITY: another user's sibling and a PII sibling are dropped by the fences the primary fetch uses", async () => {
+    process.env.PROVENANCE_EPISODE_NEIGHBOURS = '1';
+    const { svc, queries } = makeStack({
+      factsByCompany: { co_a: [FACT_GLOBAL] },
+      episodesByCompany: {
+        co_a: [
+          { ...N0, userId: 'u9' }, // foreign user's turn — must NOT leak
+          EPISODES[0]!,
+          { ...N1, piiClass: ['contact'] }, // PII turn, caller lacks read_pii
+          EPISODES[1]!,
+          N2,
+        ],
+      },
+    });
+    // M2M caller, tenant-global fact → the fetch is unscoped
+    // (fail-closed: tenant-global turns only), same as the primary read.
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    expect(res.episodes.map((e) => e.episodeId)).toEqual([
+      'episode:e1',
+      'episode:e2',
+      'episode:n2',
+    ]);
+    // The fence strings of the shared episode read port are ON the
+    // window SQL — identical composition to the byIds primary fetch.
+    const windows = queries.filter((q) => q.sql.includes('conversationId = $conv'));
+    for (const w of windows) {
+      expect(w.sql).toContain('piiClass IS NONE');
+      expect(w.sql).toContain('userId IS NONE');
+    }
+  });
+
+  it("flag ON: a user-scoped fact's sibling fetch is keyed to the FACT's user — that user's turns serve, a third user's never do", async () => {
+    process.env.PROVENANCE_EPISODE_NEIGHBOURS = '1';
+    const { svc, queries } = makeStack({
+      factsByCompany: { co_a: [{ ...FACT_GLOBAL, userId: 'u2' }] },
+      episodesByCompany: {
+        co_a: [
+          { ...N0, userId: 'u9' }, // third user — must NOT leak
+          { ...EPISODES[0]!, userId: 'u2' },
+          { ...N1, userId: 'u2' }, // the fact owner's own sibling turn
+          { ...EPISODES[1]!, userId: 'u2' },
+          N2, // tenant-global sibling
+        ],
+      },
+    });
+    const res = await svc.getProvenance({
+      companyId: 'co_a',
+      factId: 'f1',
+      scopes: READ,
+    });
+    expect(res.episodes.map((e) => e.episodeId)).toEqual([
+      'episode:e1',
+      'episode:n1',
+      'episode:e2',
+      'episode:n2',
+    ]);
+    const windows = queries.filter((q) => q.sql.includes('conversationId = $conv'));
+    expect(windows.length).toBeGreaterThan(0);
+    for (const w of windows) {
+      expect(w.sql).toContain('(userId IS NONE OR userId = $scopeUserId)');
+      expect(w.params?.scopeUserId).toBe('u2');
+    }
   });
 });
 

--- a/test/memory-fitness-interleave.unit-spec.ts
+++ b/test/memory-fitness-interleave.unit-spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit sanity for the memory-fitness candidate interleave
+ * (test/eval/memory-fitness/interleave.ts) — the round-robin flattener
+ * feeding the d3 provenance walk. Pure fixtures, no HTTP; the harness
+ * itself never runs in CI, but the budget-spreading property it relies
+ * on is pinned here.
+ */
+import { interleaveRoundRobin } from './eval/memory-fitness/interleave';
+
+describe('memory-fitness candidate interleave', () => {
+  it('round-robins across hits: first fact of every hit before any second fact', () => {
+    expect(
+      interleaveRoundRobin(
+        [
+          ['a1', 'a2', 'a3'],
+          ['b1', 'b2'],
+          ['c1', 'c2', 'c3'],
+        ],
+        12,
+      ),
+    ).toEqual(['a1', 'b1', 'c1', 'a2', 'b2', 'c2', 'a3', 'c3']);
+  });
+
+  it('a fat first hit cannot monopolise the budget (the d3 failure mode)', () => {
+    const fat = ['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8'];
+    const out = interleaveRoundRobin([fat, ['gold1'], ['gold2']], 6);
+    // Hit-major flatten + slice(0, 6) would have served f1..f6 only.
+    expect(out).toContain('gold1');
+    expect(out).toContain('gold2');
+    expect(out).toEqual(['f1', 'gold1', 'gold2', 'f2', 'f3', 'f4']);
+  });
+
+  it('handles uneven and empty lists', () => {
+    expect(interleaveRoundRobin([[], ['b1'], [], ['d1', 'd2']], 12)).toEqual(['b1', 'd1', 'd2']);
+    expect(interleaveRoundRobin([], 12)).toEqual([]);
+    expect(interleaveRoundRobin([[], []], 12)).toEqual([]);
+  });
+
+  it('enforces the cap mid-round', () => {
+    expect(
+      interleaveRoundRobin(
+        [
+          ['a1', 'a2'],
+          ['b1', 'b2'],
+          ['c1', 'c2'],
+        ],
+        4,
+      ),
+    ).toEqual(['a1', 'b1', 'c1', 'a2']);
+  });
+
+  it('a non-positive cap yields nothing', () => {
+    expect(interleaveRoundRobin([['a1']], 0)).toEqual([]);
+    expect(interleaveRoundRobin([['a1']], -1)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Provenance is one episode deep. A mention-extracted fact stamps `source.episodeIds = [episodeId]` — exactly the ONE turn it was extracted from (`src/ingest/mention-ingest.service.ts`), and `getProvenance` returns exactly those episodes. The recursive closure (`PROVENANCE_RECURSIVE_CLOSURE`) only widens `derivedFrom` chains, which leaf facts don't have. So when a fact was extracted from a paraphrasing turn, the walk can never reach the sibling turn of the same conversation that holds the verbatim constraint — the memory-fitness `d3-ratelimit` failure ("50 requests per minute" exists in exactly one corpus turn, adjacent to the extraction turn). Text truncation was ruled out (`PROVENANCE_TEXT_CHAR_CAP` = 600).

## Change 1 — server: `PROVENANCE_EPISODE_NEIGHBOURS` (default off)

When on, the one-hop `GET /v1/facts/:id/provenance` read additionally serves the ±radius sibling turns of the SAME conversation around each primary grounding turn.

**Mechanism**
- After the primary `episodes.byIds` fetch, each fenced primary row's own `conversationId`/`occurredAt` anchors a `windowAround` read (`span = radius`) on the shared episode read port — no new SurrealQL was written; the existing conversation-fenced method serves.
- Radius = `PROVENANCE_EPISODE_NEIGHBOUR_RADIUS`, an integer knob resolved in `common/provenance-flags.ts` (default 1, clamped 1..3), beside the `PROVENANCE_CLOSURE_MAX_*` caps.
- Neighbours carry `relation: 'neighbour'` on the wire; primary episodes keep their exact shape (no marker). The union is served chronologically, same as today.

**Security fences (read widening on the evidence surface)**
- The neighbour fetch goes through `EpisodeReadStoreService.windowAround`, which composes the IDENTICAL fences as the primary `byIds` fetch: the single PII-fence implementation (`piiClass IS NONE` without `brain:read_pii`), the fail-closed user pin keyed to the SAME userId as the primary fetch (the fact's owner, else the caller's pinned scope), and the G6 scope-tag fence.
- A neighbour turn recorded by another user is dropped by that SQL fence and never surfaces — unit-pinned against the REAL `EpisodeReadStoreService` SQL (the test stub applies the gate strings the service composed, not a re-implementation).

**Caps**
- Radius clamped 1..3 (unset/invalid → 1).
- Total served episodes ≤ the existing `closureMaxEpisodes()` cap (`PROVENANCE_CLOSURE_MAX_EPISODES`): primaries always serve; neighbours only fill the remaining budget, admitted chronologically (then by id) so the cut is deterministic.

**Flag-off byte-identity**
- Off (default): no window query is issued and no `relation` key ever appears — the response is byte-identical. Golden-pinned in `test/fact-provenance.unit-spec.ts` (full-response deep-equal + assertion that no window SQL was issued).

**Contract**
- `FactProvenanceEpisodeSchema` extended with OPTIONAL `relation: z.literal('neighbour')`; parity pin (`test/contracts-facts.unit-spec.ts`) updated both ways; `pnpm openapi:build` regenerated BOTH copies (`docs/openapi.json`, `brain-landing/public/openapi.json`).
- Flag registered in `KNOWN_BOOLEAN_FLAGS` (`src/common/env-validation.ts`) + two catalog entries in `src/admin/config-catalog.data.ts` (bool flag + integer knob). `PROVENANCE_` sits off the engine flag budget by family convention.

## Change 2 — harness: round-robin candidate interleave (test-only, no flag)

This is the confirmation experiment for the diagnosis: in `test/eval/memory-fitness/runner.ts` the provenance-walk candidates were flattened hit-major then sliced to 6, so one fat entity monopolised the walk budget and the fact adjacent to the seeded fragment — often on hit 2 or 3 — never got walked. Candidates are now interleaved round-robin across hits (`hit1.fact1, hit2.fact1, hit3.fact1, hit1.fact2, …`) before slicing, and the cap is raised 6 → 12 (`PROVENANCE_CANDIDATE_CAP`). Scorers untouched. The interleave is a small pure module (`test/eval/memory-fitness/interleave.ts`) with its own unit spec.

## Tests

- `test/fact-provenance.unit-spec.ts`: flag-off golden byte-identity; flag-on neighbour labelling + chronological merge; episode-cap enforcement; radius clamp (pinned via the window SQL LIMITs); fence drops — foreign-user sibling and PII sibling never leak, and a user-scoped fact's sibling fetch is keyed to the fact's user.
- `test/memory-fitness-interleave.unit-spec.ts`: round-robin order, fat-first-hit failure mode, uneven/empty lists, mid-round cap, non-positive cap.
- `pnpm typecheck`, full `pnpm test:unit` (340 suites / 3620 tests), contracts parity, openapi drift gate, prettier — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB