### PR TITLE
fix(facts): per-user scope on timeline/competing reads + direct-fact conflict formation

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1103,6 +1103,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: false,
     isBooleanFlag: false,
   },
+  {
+    key: 'CONFLICT_DIRECT_FACT_SLOT',
+    category: 'conflict',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Direct-fact conflict semantics. When on, the typed direct ingest path (record_fact / POST /v1/ingest/fact) promotes an unknown-predicate fact — one that resolves to the registry '__default__' append_only fallback — to 'bitemporal', so two direct writes on the same (entity, predicate) slot with contradicting objects form a conflict (close-scored → COMPETING for get_competing_facts, clear winner → SUPERSEDED) instead of both landing INSERTED forever. Mention-extracted bulk and the DEFAULT_FALLBACK policy itself are untouched; known predicates keep their registry semantics. Off (default) = append_only passthrough, byte-identical.",
+  },
   // ── ABAC (migrations 0056/0057) ──────────────────────────
   {
     key: 'ABAC_ENABLED',
@@ -1148,6 +1157,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     isBooleanFlag: true,
     description:
       'Per-member user-scope fence for verbatim windows (migration 0117). Mixed-user episode_segment windows fold userId=NONE (tenant-global), so the legacy gate served an A+B window — verbatim text included — to EVERY user-scoped caller in the tenant. When on, all four segment read seams (segment lane transcript + anchors, fused search leg, mention scan) admit a user-scoped caller to a userId-NONE window only when its persisted userIds member set is [] (purely global) or CONTAINS the caller (window membership: co-present verbatim is re-disclosure, not disclosure). Tenant-global (M2M) callers unchanged. WARNING: OFF + any segment-serving mode ON (verbatimEvidence/timelineEvidence/l3SegmentAnchor, e.g. RETRIEVAL_GENRE=dialogue or SEARCH_SEGMENT_LANE_ENABLED) = cross-user verbatim disclosure. FAIL-CLOSED on legacy rows: userIds IS NONE (pre-0117) is hidden from user-scoped callers — run POST /v1/admin/maintenance/segments/backfill-user-ids once per tenant BEFORE the first enable on an existing deployment (order: migrate → backfill → flip). Default off in code for byte-identity only; will default ON in a future release.',
+  },
+  {
+    key: 'READ_SURFACE_USER_SCOPE',
+    category: 'auth',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Per-user read scope on the two read surfaces that predate migration 0055 and hardcode `userId IS NONE`: the entity timeline (GET /v1/entities/:id/timeline, get_entity_timeline) and the competing-facts listing (get_competing_facts). When on and the caller supplies a userId (pinned to a user-bound token’s end-user via pinUserScope — 403 on mismatch), the fence widens to the search-lane union `(userId IS NONE OR userId = $scopeUserId)`: tenant-global rows plus that one user’s personal ones, never a third user’s. Off (default) — or on with no userId — keeps the exact historical tenant-global-only clause, byte-identical.',
   },
   {
     key: 'PRIVACY_COMPOSER_USER_SCOPE',

--- a/src/common/conflict-flags.ts
+++ b/src/common/conflict-flags.ts
@@ -1,0 +1,30 @@
+import { envFlagEnabled } from './env-validation';
+
+/**
+ * Direct-fact conflict semantics — CONFLICT_DIRECT_FACT_SLOT.
+ *
+ * A predicate absent from the registry resolves to DEFAULT_FALLBACK
+ * (`__default__`, semantics 'append_only') — correct for the
+ * open-vocabulary mention bulk, but on the TYPED direct path
+ * (record_fact / POST /v1/ingest/fact) it short-circuits
+ * fn::resolve_fact's conflict pool to `[]`: two direct writes with the
+ * same (entity, predicate) and contradicting objects both land
+ * INSERTED and no conflict is ever formed or surfaced.
+ *
+ * When on, FactResolverService promotes JUST that combination — direct
+ * path (recordOutcomeMetric) AND registry-default predicate — to
+ * 'bitemporal': the margin doctrine, i.e. close-scored contradictions
+ * become COMPETING and a clear winner SUPERSEDES. Deliberately NOT
+ * 'single_active': its resolver branch supersedes unconditionally
+ * (0085 `$supersede = $semantics = 'single_active' OR …`) and can
+ * never surface a COMPETING pair. DEFAULT_FALLBACK itself is untouched
+ * (load-bearing for mention extraction), as is every known predicate's
+ * registry policy. The env read lives here in the common layer
+ * (engine-gates S5.2), read at call time so a flip is runtime-mutable.
+ * Default off ⇒ append_only passthrough, byte-identical. CONFLICT_
+ * sits off the ENGINE flag budget by design (a resolver-policy knob
+ * family — cfg weights/thresholds — not an engine fork).
+ */
+export function conflictDirectFactSlotEnabled(): boolean {
+  return envFlagEnabled(process.env.CONFLICT_DIRECT_FACT_SLOT);
+}

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1339,6 +1339,23 @@ const KNOWN_BOOLEAN_FLAGS = [
   // Per-tenant active-space selection + atomic cutover. Off ⇒ reads use the
   // current provider space and the cutover admin surface refuses.
   'EMBEDDING_SPACE_ACTIVE',
+  // Per-user read scope on the two pre-0055 read surfaces (entity
+  // timeline + competing facts): on + userId, the hardcoded
+  // `userId IS NONE` fence widens to `(userId IS NONE OR userId =
+  // $scopeUserId)` with the caller-asserted id pinned to a user-bound
+  // token's end-user (pinUserScope). Off (default) ⇒ the historical
+  // clause, byte-identical. READ_ sits off the ENGINE flag budget by
+  // design (an authz read fence, not an engine fork).
+  'READ_SURFACE_USER_SCOPE',
+  // Direct-fact conflict semantics: the typed ingest path promotes an
+  // unknown-predicate (registry '__default__' fallback) fact from
+  // append_only to 'bitemporal' in FactResolverService so same-slot
+  // direct writes can SUPERSEDE/COMPETE instead of always INSERTED.
+  // Mention-path bulk and DEFAULT_FALLBACK itself untouched. Off
+  // (default) ⇒ append_only passthrough, byte-identical. CONFLICT_
+  // sits off the ENGINE flag budget by design (resolver-policy knob
+  // family, not an engine fork).
+  'CONFLICT_DIRECT_FACT_SLOT',
 ];
 
 /**

--- a/src/common/read-scope-flags.ts
+++ b/src/common/read-scope-flags.ts
@@ -1,0 +1,28 @@
+import { envFlagEnabled } from './env-validation';
+
+/**
+ * Per-user read scope on the pre-0055 read surfaces —
+ * READ_SURFACE_USER_SCOPE.
+ *
+ * Two read surfaces predate migration 0055's per-user scope and pinned
+ * a hardcoded `userId IS NONE` fence: the entity timeline
+ * (EntitiesService.getTimeline) and the competing-facts listing
+ * (FactsService.listCompeting). Every user-scoped fact was therefore
+ * invisible to both — a per-user deployment saw an empty evolution
+ * history and an empty adjudication queue no matter what it wrote.
+ *
+ * When on AND the caller supplies a userId (pinned to a user-bound
+ * token's end-user via pinUserScope, the ingestFact idiom — a user
+ * token cannot read another user's slice), the fence widens to the
+ * search-lane union: `(userId IS NONE OR userId = $scopeUserId)` —
+ * tenant-global rows PLUS that one user's rows, never a third user's.
+ * The env read lives here in the common layer, NOT inside the read
+ * services (engine-gates S5.2). Read at call time so a flip is
+ * runtime-mutable (no restart). Default off — or on with no userId —
+ * keeps the exact historical `userId IS NONE` clause, byte-identical.
+ * READ_ sits off the ENGINE flag budget by design (an authz read
+ * fence, not an engine fork).
+ */
+export function readSurfaceUserScopeEnabled(): boolean {
+  return envFlagEnabled(process.env.READ_SURFACE_USER_SCOPE);
+}

--- a/src/entities/entities.controller.ts
+++ b/src/entities/entities.controller.ts
@@ -60,6 +60,7 @@ export class EntitiesController {
     @Query('since') since?: string,
     @Query('until') until?: string,
     @Query('recordedAt') recordedAt?: string,
+    @Query('userId') userId?: string,
   ) {
     return this.entities.getTimeline({
       companyId: req.brainAuth.companyId,
@@ -67,6 +68,9 @@ export class EntitiesController {
       sinceRaw: since,
       untilRaw: until,
       recordedAtRaw: recordedAt,
+      // Per-user scope (READ_SURFACE_USER_SCOPE gated; pinned to a
+      // user-bound token's end-user inside the service).
+      userId,
       scopes: req.brainAuth.scopes,
     });
   }

--- a/src/entities/entities.service.ts
+++ b/src/entities/entities.service.ts
@@ -7,6 +7,8 @@ import { BrainScope } from '../auth/api-key.types';
 import { EntityForgetService } from './entity-forget.service';
 import { normalizeEntityId, blockedPredicates, activeFactWhere } from './entity-read.helpers';
 import { makeRowPolicyFilter, PolicyFilterableRow } from '../policy/row-filter';
+import { readSurfaceUserScopeEnabled } from '../common/read-scope-flags';
+import { pinUserScope } from '../auth/user-scope';
 
 // Centralised SELECT-clause field lists. Adding a new field to a table
 // touches one place here, not every read site. The strings below are
@@ -101,6 +103,14 @@ export interface GetTimelineOptions {
    * Distinct from `until`, which is an audit paging window over rows.
    */
   recordedAtRaw?: string | undefined;
+  /**
+   * Per-user memory scope (0055), READ_SURFACE_USER_SCOPE gated.
+   * Caller-asserted; pinned to a user-bound token's end-user via
+   * pinUserScope. Flag on + userId → events over tenant-global facts
+   * PLUS this user's personal ones; otherwise the historical
+   * tenant-global-only fence, byte-identical.
+   */
+  userId?: string | undefined;
   scopes: BrainScope[];
 }
 
@@ -430,20 +440,35 @@ export class EntitiesService {
     sinceRaw,
     untilRaw,
     recordedAtRaw,
+    userId,
     scopes,
   }: GetTimelineOptions): Promise<{ entityId: string; events: TimelineEvent[] }> {
     const ref = normalizeEntityId(entityIdRaw);
     const since = sinceRaw ? new Date(sinceRaw) : null;
     const until = untilRaw ? new Date(untilRaw) : null;
     const txAt = recordedAtRaw ? new Date(recordedAtRaw) : null;
+    // READ_SURFACE_USER_SCOPE (default off): this surface predates the
+    // 0055 per-user scope and pinned `userId IS NONE`, so a personal
+    // fact never produced a timeline event. Flag on → the
+    // caller-asserted userId is pinned to a user-bound token's end-user
+    // (the ingestFact idiom — 403 on mismatch, defaulted when omitted)
+    // and the fence widens to the search-lane union below. Off — or on
+    // with no userId in play — keeps the exact historical clause.
+    const scopeUserId = readSurfaceUserScopeEnabled() ? pinUserScope(userId) : undefined;
 
     return this.surreal.withScopedCompany(companyId, scopes, async (db) => {
       // Range pushdown — recordedAt window is part of the WHERE so
       // long-lived entities don't pay for full timeline materialisation
       // on every query. The composite (entityId, status, recordedAt)
       // index covers the entityId+range combination directly.
-      const clauses = [`entityId = type::record('knowledge_entity', $rid)`, `userId IS NONE`];
+      const clauses = [`entityId = type::record('knowledge_entity', $rid)`];
       const params: Record<string, unknown> = { rid: ref.id };
+      if (scopeUserId !== undefined) {
+        clauses.push(`(userId IS NONE OR userId = $scopeUserId)`);
+        params.scopeUserId = scopeUserId;
+      } else {
+        clauses.push(`userId IS NONE`);
+      }
       if (since) {
         clauses.push(`recordedAt >= $since`);
         params.since = since;

--- a/src/facts/facts.service.ts
+++ b/src/facts/facts.service.ts
@@ -32,6 +32,7 @@ import {
   recursiveClosureEnabled,
   supportGraphReadEnabled,
 } from '../common/provenance-flags';
+import { readSurfaceUserScopeEnabled } from '../common/read-scope-flags';
 import {
   collectSceneTargets,
   indexCharSpans,
@@ -866,6 +867,12 @@ export class FactsService {
     opts: {
       predicate?: string;
       asOf?: string;
+      /** Per-user memory scope (0055), READ_SURFACE_USER_SCOPE gated.
+       *  Caller-asserted; pinned to a user-bound token's end-user via
+       *  pinUserScope. Flag on + userId → groups over tenant-global
+       *  rows PLUS this user's personal ones; otherwise the historical
+       *  tenant-global-only fence, byte-identical. */
+      userId?: string;
       /** Caller's scopes — drive the app-layer PII/row filter (the DB-level
        *  PII fence of migration 0005 is inert for the system brain_caller
        *  user; see SurrealService.withScopedCompany). */
@@ -881,17 +888,27 @@ export class FactsService {
       opts.callerScopes
         ? this.surreal.withScopedCompany(companyId, opts.callerScopes, fn)
         : this.surreal.withCompany(companyId, fn);
+    // READ_SURFACE_USER_SCOPE (default off): this surface predates the
+    // 0055 per-user scope and pinned `userId IS NONE`, so a user-scoped
+    // COMPETING pair was invisible to adjudication. Flag on → the
+    // caller-asserted userId is pinned to a user-bound token's end-user
+    // (the ingestFact idiom — 403 on mismatch, defaulted when omitted)
+    // and the fence widens to the search-lane union below. Off — or on
+    // with no userId in play — keeps the exact historical clause.
+    const scopeUserId = readSurfaceUserScopeEnabled() ? pinUserScope(opts.userId) : undefined;
     return run(async (db) => {
       const ref = this.normalizeEntityId(entityIdRaw);
       const asOf = opts.asOf ? new Date(opts.asOf) : null;
 
-      const clauses = [
-        `entityId = type::record('knowledge_entity', $rid)`,
-        `status = 'competing'`,
-        // User scope (0055): competing adjudication is tenant-global v1.
-        `userId IS NONE`,
-      ];
+      const clauses = [`entityId = type::record('knowledge_entity', $rid)`, `status = 'competing'`];
       const params: Record<string, unknown> = { rid: ref.id };
+      if (scopeUserId !== undefined) {
+        clauses.push(`(userId IS NONE OR userId = $scopeUserId)`);
+        params.scopeUserId = scopeUserId;
+      } else {
+        // User scope (0055): competing adjudication is tenant-global v1.
+        clauses.push(`userId IS NONE`);
+      }
       if (opts.predicate) {
         clauses.push(`predicate = $predicate`);
         params.predicate = opts.predicate;

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -4,8 +4,10 @@ import { queryRows, retryOnUniqueViolation } from '../db/surreal.service';
 import { scopeForUser } from '../auth/scope-tags';
 import { MetricsService } from '../metrics/metrics.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
+import { DEFAULT_FALLBACK } from '../ai/predicate-registry-internals/types';
 import { detectLanguage } from '../ai/locale/language-detector';
 import { envFlagEnabled } from '../common/env-validation';
+import { conflictDirectFactSlotEnabled } from '../common/conflict-flags';
 import { supportEdgesEnabled } from '../common/provenance-flags';
 import { buildConflictEdgeRows } from '../common/support-edges';
 import { KeyedMutex } from '../common/keyed-mutex';
@@ -242,6 +244,25 @@ export class FactResolverService {
     p: Parameters<FactResolverService['resolve']>[1],
   ): Promise<Parameters<FactResolverService['resolveFactCall']>[1]> {
     const policy = this.predicateRegistry.policyFor(p.companyId, p.predicate);
+    // CONFLICT_DIRECT_FACT_SLOT (default off): on the typed direct path
+    // (recordOutcomeMetric — set ONLY by FactIngestService.ingestFact),
+    // an unknown predicate falls to the registry DEFAULT_FALLBACK
+    // ('__default__', append_only), which short-circuits
+    // fn::resolve_fact's conflict pool to [] — two direct writes on one
+    // (entity, predicate) slot with contradicting objects both landed
+    // INSERTED and no conflict ever formed. Promote JUST that
+    // combination to 'bitemporal' (margin doctrine: close-scored →
+    // COMPETING, clear winner → SUPERSEDED). NOT 'single_active' — its
+    // resolver branch supersedes unconditionally (0085 $supersede) and
+    // can never surface a COMPETING pair. Known predicates keep their
+    // registry policy; the mention path (no recordOutcomeMetric) and
+    // DEFAULT_FALLBACK itself are untouched. Off ⇒ byte-identical.
+    const semantics =
+      conflictDirectFactSlotEnabled() &&
+      p.recordOutcomeMetric === true &&
+      policy.predicateId === DEFAULT_FALLBACK.predicateId
+        ? 'bitemporal'
+        : policy.semantics;
     const sourceTrust = sourceTrustFor(p.source as Parameters<typeof sourceTrustFor>[0]);
     // Confidence-aware attribution (MULTILINGUAL_LANG_ATTRIBUTION, default
     // off). Off → detectLanguage keeps its Phase-4 `en` fallback and no new
@@ -310,7 +331,7 @@ export class FactResolverService {
       validUntil: p.validUntil,
       source: p.source,
       sourceTrust,
-      semantics: policy.semantics,
+      semantics,
       lang,
       script,
       langMeta,

--- a/src/mcp/read-tools.ts
+++ b/src/mcp/read-tools.ts
@@ -407,6 +407,13 @@ function registerEntityReadTools({
         entityId: z.string(),
         since: z.string().datetime().optional(),
         until: z.string().datetime().optional(),
+        userId: z
+          .string()
+          .max(200)
+          .optional()
+          .describe(
+            "Per-user memory scope: results include tenant-global facts plus this user's personal ones; omit for tenant-global only (fail-closed)",
+          ),
       },
     },
     async (args) => {
@@ -415,6 +422,7 @@ function registerEntityReadTools({
         entityIdRaw: args.entityId,
         sinceRaw: args.since,
         untilRaw: args.until,
+        ...(args.userId !== undefined ? { userId: args.userId } : {}),
         scopes,
       });
       return {
@@ -498,12 +506,20 @@ function registerEntityReadTools({
           .datetime()
           .optional()
           .describe('Show what was competing at this ISO 8601 moment'),
+        userId: z
+          .string()
+          .max(200)
+          .optional()
+          .describe(
+            "Per-user memory scope: preflight a user-scoped record_fact against tenant-global priors PLUS this user's personal ones. Omit for tenant-global candidates (matches record_fact's userId)",
+          ),
       },
     },
     async (args) => {
       const out = await deps.facts.listCompeting(companyId, args.entityId, {
         ...(args.predicate !== undefined ? { predicate: args.predicate } : {}),
         ...(args.asOf !== undefined ? { asOf: args.asOf } : {}),
+        ...(args.userId !== undefined ? { userId: args.userId } : {}),
         callerScopes: scopes,
       });
       return {

--- a/test/conflict-direct-fact-slot.unit-spec.ts
+++ b/test/conflict-direct-fact-slot.unit-spec.ts
@@ -1,0 +1,96 @@
+import { FactResolverService } from '../src/ingest/fact-resolver.service';
+
+/**
+ * CONFLICT_DIRECT_FACT_SLOT — semantics promotion at the
+ * buildResolveCall seam. The typed direct path (recordOutcomeMetric,
+ * set only by FactIngestService.ingestFact) promotes an
+ * unknown-predicate fact (registry '__default__' fallback, semantics
+ * append_only) to 'bitemporal' so same-slot direct writes can form
+ * conflicts. Pins:
+ *  - flag off → append_only passthrough (byte-identical);
+ *  - flag on + direct + unknown predicate → 'bitemporal';
+ *  - flag on + KNOWN predicate → registry policy untouched;
+ *  - flag on + mention path (no recordOutcomeMetric) → untouched.
+ */
+describe('FactResolverService — CONFLICT_DIRECT_FACT_SLOT promotion', () => {
+  afterEach(() => {
+    delete process.env.CONFLICT_DIRECT_FACT_SLOT;
+  });
+
+  function make() {
+    const queries: Array<{ sql: string; params: Record<string, unknown> }> = [];
+    const db = {
+      query: jest.fn(async (sql: string, params: Record<string, unknown>) => {
+        queries.push({ sql, params });
+        return [{ factId: 'knowledge_fact:x', outcome: 'INSERTED' }];
+      }),
+    };
+    const factEmbedding = {
+      embed: jest.fn(async () => [0.1]),
+      writeAltEmbeddingIfHype: jest.fn(async () => {}),
+    };
+    // Mirrors PredicateRegistryService.policyFor: a known predicate
+    // returns its own definition; anything else falls to the
+    // DEFAULT_FALLBACK sentinel ('__default__', append_only).
+    const predicateRegistry = {
+      getSnapshot: jest.fn(async () => ({})),
+      policyFor: jest.fn((_c: string, predicate: string) =>
+        predicate === 'status'
+          ? { predicateId: 'status', semantics: 'single_active' }
+          : { predicateId: '__default__', semantics: 'append_only' },
+      ),
+    };
+    const svc = new FactResolverService(factEmbedding as never, predicateRegistry as never);
+    return { svc, db, queries };
+  }
+
+  function input(predicate: string, recordOutcomeMetric?: boolean) {
+    return {
+      companyId: 'co_x',
+      entityId: 'knowledge_entity:e1',
+      predicate,
+      object: '17:00',
+      confidence: 0.9,
+      validFrom: new Date('2026-01-01T00:00:00Z'),
+      source: {},
+      precomputedEmbedding: [0.1, 0.2],
+      ...(recordOutcomeMetric !== undefined ? { recordOutcomeMetric } : {}),
+    };
+  }
+
+  const semanticsParam = (queries: Array<{ sql: string; params: Record<string, unknown> }>) => {
+    const call = queries.find((q) => q.sql.includes('fn::resolve_fact('));
+    return call?.params.semantics;
+  };
+
+  it('flag off: direct-path unknown predicate stays append_only (byte-identical)', async () => {
+    const { svc, db, queries } = make();
+    const out = await svc.resolve(db as never, input('payout_cutoff', true));
+    expect(semanticsParam(queries)).toBe('append_only');
+    expect(out.semantics).toBe('append_only');
+  });
+
+  it('flag on + direct path + unknown predicate: promoted to bitemporal', async () => {
+    process.env.CONFLICT_DIRECT_FACT_SLOT = '1';
+    const { svc, db, queries } = make();
+    const out = await svc.resolve(db as never, input('payout_cutoff', true));
+    expect(semanticsParam(queries)).toBe('bitemporal');
+    expect(out.semantics).toBe('bitemporal');
+  });
+
+  it('flag on + KNOWN predicate: registry policy untouched', async () => {
+    process.env.CONFLICT_DIRECT_FACT_SLOT = '1';
+    const { svc, db, queries } = make();
+    const out = await svc.resolve(db as never, input('status', true));
+    expect(semanticsParam(queries)).toBe('single_active');
+    expect(out.semantics).toBe('single_active');
+  });
+
+  it('flag on + mention path (no recordOutcomeMetric): untouched', async () => {
+    process.env.CONFLICT_DIRECT_FACT_SLOT = '1';
+    const { svc, db, queries } = make();
+    const out = await svc.resolve(db as never, input('payout_cutoff'));
+    expect(semanticsParam(queries)).toBe('append_only');
+    expect(out.semantics).toBe('append_only');
+  });
+});

--- a/test/facts-list-competing.e2e-spec.ts
+++ b/test/facts-list-competing.e2e-spec.ts
@@ -8,6 +8,9 @@
  *   - the active fact is excluded
  *   - filtering by predicate narrows the result
  *   - asOf < competing.recordedAt excludes the pair
+ *   - READ_SURFACE_USER_SCOPE: user-scoped competing rows are invisible
+ *     with the flag off (byte-identical pre-flag behavior) and join the
+ *     result as the tenant-global∪user union with flag on + userId
  *
  * Direct DB seed instead of the ingest path because forcing the
  * conflict resolver into COMPETING requires similarity tuning that
@@ -84,6 +87,36 @@ describe('FactsService.listCompeting — groups competing pairs by predicate', (
          }`,
         { eid: ENT_ID, vf: new Date('2026-01-01'), ra: now },
       );
+
+      // A USER-SCOPED competing pair (0055) on a different predicate —
+      // invisible pre-flag (hardcoded `userId IS NONE`), part of the
+      // union under READ_SURFACE_USER_SCOPE + userId.
+      for (const [tail, object, recorder] of [
+        ['lc_u_a', 'monthly', 'bot_u1'],
+        ['lc_u_b', 'annual', 'bot_u2'],
+      ] as const) {
+        await db.query(
+          `CREATE type::record('knowledge_fact', $fid) CONTENT {
+              entityId: type::record('knowledge_entity', $eid),
+              predicate: 'plan',
+              object: $object,
+              confidence: 0.7,
+              validFrom: $vf,
+              recordedAt: $ra,
+              status: 'competing',
+              userId: 'u_lc',
+              source: { vertical: 'rent', recorder: $recorder }
+           }`,
+          {
+            fid: tail,
+            eid: ENT_ID,
+            object,
+            recorder,
+            vf: new Date('2026-01-01'),
+            ra: new Date(now.getTime() - 1_500),
+          },
+        );
+      }
     });
   });
 
@@ -133,5 +166,43 @@ describe('FactsService.listCompeting — groups competing pairs by predicate', (
     const b = await facts.listCompeting(f.companyId, ENT_FULL);
     expect(a.groups.length).toBe(b.groups.length);
     expect(a.entityId).toBe(b.entityId);
+  });
+
+  describe('READ_SURFACE_USER_SCOPE (per-user competing visibility)', () => {
+    afterEach(() => {
+      delete process.env.READ_SURFACE_USER_SCOPE;
+    });
+
+    it('flag off: user-scoped rows stay invisible even when a userId is passed', async () => {
+      const facts = f.app.get(FactsService);
+      const out = await facts.listCompeting(f.companyId, ENT_ID, { userId: 'u_lc' });
+      // Byte-identical pre-flag behavior — only the tenant-global group.
+      expect(out.groups.map((g) => g.predicate)).toEqual(['status']);
+    });
+
+    it('flag on + userId: tenant-global ∪ user union returns both groups', async () => {
+      process.env.READ_SURFACE_USER_SCOPE = '1';
+      const facts = f.app.get(FactsService);
+      const out = await facts.listCompeting(f.companyId, ENT_ID, { userId: 'u_lc' });
+      const byPredicate = new Map(out.groups.map((g) => [g.predicate, g]));
+      expect([...byPredicate.keys()].sort()).toEqual(['plan', 'status']);
+      const plan = byPredicate.get('plan')!;
+      expect(plan.facts).toHaveLength(2);
+      expect(plan.facts.map((x) => x.object).sort()).toEqual(['annual', 'monthly']);
+    });
+
+    it('flag on without userId: fail-closed to tenant-global only', async () => {
+      process.env.READ_SURFACE_USER_SCOPE = '1';
+      const facts = f.app.get(FactsService);
+      const out = await facts.listCompeting(f.companyId, ENT_ID);
+      expect(out.groups.map((g) => g.predicate)).toEqual(['status']);
+    });
+
+    it("flag on + ANOTHER user's id: the first user's rows stay invisible", async () => {
+      process.env.READ_SURFACE_USER_SCOPE = '1';
+      const facts = f.app.get(FactsService);
+      const out = await facts.listCompeting(f.companyId, ENT_ID, { userId: 'u_other' });
+      expect(out.groups.map((g) => g.predicate)).toEqual(['status']);
+    });
   });
 });

--- a/test/read-surface-user-scope.unit-spec.ts
+++ b/test/read-surface-user-scope.unit-spec.ts
@@ -1,0 +1,175 @@
+import { ForbiddenException } from '@nestjs/common';
+import { EntitiesService } from '../src/entities/entities.service';
+import { FactsService } from '../src/facts/facts.service';
+import { runWithRequestContext } from '../src/common/request-context';
+import type { BrainScope } from '../src/auth/api-key.types';
+
+/**
+ * READ_SURFACE_USER_SCOPE — the per-user read fence on the two surfaces
+ * that predate migration 0055 and hardcoded `userId IS NONE`:
+ * EntitiesService.getTimeline and FactsService.listCompeting.
+ *
+ * Pins, at the query-builder seam:
+ *  - flag OFF → the WHERE clause is BYTE-IDENTICAL to the historical
+ *    one (`userId IS NONE`, same position), even when a userId is
+ *    passed — and no new 403 path exists;
+ *  - flag ON + userId → the fence widens to the search-lane union
+ *    `(userId IS NONE OR userId = $scopeUserId)` with the id bound;
+ *  - flag ON without a userId → historical clause (fail-closed);
+ *  - flag ON + user-bound token → pinUserScope applies (mismatch 403,
+ *    omitted userId defaults to the token's end-user).
+ */
+describe('READ_SURFACE_USER_SCOPE read fence', () => {
+  const scopes: BrainScope[] = ['brain:read'];
+  type Captured = { sql: string; params: Record<string, unknown> };
+
+  afterEach(() => {
+    delete process.env.READ_SURFACE_USER_SCOPE;
+  });
+
+  // ── EntitiesService.getTimeline ───────────────────────────────────
+  function makeEntities() {
+    const captured: Captured[] = [];
+    const db = {
+      query: async (sql: string, params: Record<string, unknown>) => {
+        captured.push({ sql, params });
+        return [[]];
+      },
+    };
+    const surreal = {
+      withScopedCompany: jest.fn(
+        async (_companyId: string, _scopes: BrainScope[], fn: (db: unknown) => Promise<unknown>) =>
+          fn(db),
+      ),
+    } as never;
+    const svc = new EntitiesService(surreal, undefined as never);
+    return { svc, captured };
+  }
+
+  const timeline = (
+    svc: EntitiesService,
+    userId?: string,
+  ): Promise<{ entityId: string; events: unknown[] }> =>
+    svc.getTimeline({
+      companyId: 'co_x',
+      entityIdRaw: 'e1',
+      sinceRaw: undefined,
+      untilRaw: undefined,
+      userId,
+      scopes,
+    });
+
+  it('timeline, flag off: historical clause byte-identical, userId ignored', async () => {
+    const { svc, captured } = makeEntities();
+    await timeline(svc, 'user-42');
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toContain(
+      `entityId = type::record('knowledge_entity', $rid) AND userId IS NONE`,
+    );
+    expect(captured[0]!.sql).not.toContain('$scopeUserId');
+    expect(captured[0]!.params).not.toHaveProperty('scopeUserId');
+  });
+
+  it('timeline, flag on + userId: union clause with the id bound', async () => {
+    process.env.READ_SURFACE_USER_SCOPE = '1';
+    const { svc, captured } = makeEntities();
+    await timeline(svc, 'user-42');
+    expect(captured[0]!.sql).toContain(
+      `entityId = type::record('knowledge_entity', $rid) AND (userId IS NONE OR userId = $scopeUserId)`,
+    );
+    expect(captured[0]!.params.scopeUserId).toBe('user-42');
+  });
+
+  it('timeline, flag on without userId: fail-closed historical clause', async () => {
+    process.env.READ_SURFACE_USER_SCOPE = '1';
+    const { svc, captured } = makeEntities();
+    await timeline(svc);
+    expect(captured[0]!.sql).toContain('AND userId IS NONE');
+    expect(captured[0]!.sql).not.toContain('$scopeUserId');
+  });
+
+  it('timeline, flag on + user-bound token: pin fences the asserted id', async () => {
+    process.env.READ_SURFACE_USER_SCOPE = '1';
+    await runWithRequestContext({ correlationId: 't', authUserId: 'user-42' }, async () => {
+      // Mismatching assertion → 403 (another user's slice).
+      const { svc } = makeEntities();
+      await expect(timeline(svc, 'user-OTHER')).rejects.toThrow(ForbiddenException);
+      // Omitted userId defaults to the token's end-user.
+      const second = makeEntities();
+      await timeline(second.svc);
+      expect(second.captured[0]!.params.scopeUserId).toBe('user-42');
+    });
+  });
+
+  it('timeline, flag off + user-bound token mismatch: no new 403 path', async () => {
+    await runWithRequestContext({ correlationId: 't', authUserId: 'user-42' }, async () => {
+      const { svc, captured } = makeEntities();
+      await timeline(svc, 'user-OTHER'); // ignored, not rejected
+      expect(captured[0]!.sql).toContain('AND userId IS NONE');
+    });
+  });
+
+  // ── FactsService.listCompeting ────────────────────────────────────
+  function makeFacts() {
+    const captured: Captured[] = [];
+    const db = {
+      query: async (sql: string, params: Record<string, unknown>) => {
+        captured.push({ sql, params });
+        return [[]];
+      },
+    };
+    const surreal = {
+      withCompany: jest.fn(async (_companyId: string, fn: (db: unknown) => Promise<unknown>) =>
+        fn(db),
+      ),
+      withScopedCompany: jest.fn(
+        async (
+          _companyId: string,
+          _scopes: readonly string[],
+          fn: (db: unknown) => Promise<unknown>,
+        ) => fn(db),
+      ),
+    } as never;
+    const svc = new FactsService(surreal, undefined as never);
+    return { svc, captured };
+  }
+
+  it('competing, flag off: historical clause byte-identical, userId ignored', async () => {
+    const { svc, captured } = makeFacts();
+    await svc.listCompeting('co_x', 'e1', { userId: 'user-42' });
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toContain(`status = 'competing' AND userId IS NONE`);
+    expect(captured[0]!.sql).not.toContain('$scopeUserId');
+    expect(captured[0]!.params).not.toHaveProperty('scopeUserId');
+  });
+
+  it('competing, flag on + userId: union clause with the id bound', async () => {
+    process.env.READ_SURFACE_USER_SCOPE = '1';
+    const { svc, captured } = makeFacts();
+    await svc.listCompeting('co_x', 'e1', { userId: 'user-42' });
+    expect(captured[0]!.sql).toContain(
+      `status = 'competing' AND (userId IS NONE OR userId = $scopeUserId)`,
+    );
+    expect(captured[0]!.params.scopeUserId).toBe('user-42');
+  });
+
+  it('competing, flag on without userId: fail-closed historical clause', async () => {
+    process.env.READ_SURFACE_USER_SCOPE = '1';
+    const { svc, captured } = makeFacts();
+    await svc.listCompeting('co_x', 'e1');
+    expect(captured[0]!.sql).toContain(`status = 'competing' AND userId IS NONE`);
+  });
+
+  it('competing, flag on + user-bound token: pin fences the asserted id', async () => {
+    process.env.READ_SURFACE_USER_SCOPE = '1';
+    await runWithRequestContext({ correlationId: 't', authUserId: 'user-42' }, async () => {
+      const { svc } = makeFacts();
+      await expect(svc.listCompeting('co_x', 'e1', { userId: 'user-OTHER' })).rejects.toThrow(
+        ForbiddenException,
+      );
+      const second = makeFacts();
+      await second.svc.listCompeting('co_x', 'e1');
+      expect(second.captured[0]!.params.scopeUserId).toBe('user-42');
+    });
+  });
+});


### PR DESCRIPTION
## Root causes (three, all default-off)

### 1. Entity timeline ignores per-user facts
`src/entities/entities.service.ts` — `getTimeline` hardcodes `userId IS NONE` in its WHERE clause (was line 445). The surface predates migration 0055's per-user scope, so a user-scoped fact **never** produces a timeline event: a per-user deployment sees an empty evolution history no matter what it writes.

### 2. Competing-facts listing ignores per-user facts
`src/facts/facts.service.ts` — `listCompeting` has the same hardcoded `userId IS NONE` fence (was lines 888–893), so a user-scoped COMPETING pair is invisible to adjudication (`get_competing_facts` returns nothing).

### 3. Direct-fact path never forms conflicts
`src/ai/predicate-registry-internals/types.ts:133-149` — an unknown predicate resolves to `DEFAULT_FALLBACK` (`__default__`, semantics `append_only`), and in `fn::resolve_fact` append_only short-circuits the conflict pool to `$competing = []` (migration 0085, lines 136–137) → outcome is always INSERTED. Two `record_fact` calls with the same `(entity, predicate)` and contradicting objects can never become COMPETING or SUPERSEDED.

## Fix

**Flag `READ_SURFACE_USER_SCOPE`** (changes 1+2, one shared fence idiom; helper in new `src/common/read-scope-flags.ts`, call-time env read per S5.2):
- When ON and a `userId` is in play, the fence widens to the search-lane union `(userId IS NONE OR userId = $scopeUserId)` — tenant-global rows plus that one user's, never a third user's.
- The caller-asserted `userId` goes through `pinUserScope()` at the service entry (the `ingestFact` idiom, `src/ingest/fact-ingest.service.ts:42`): a user-bound token 403s on a mismatching assertion and defaults to its own end-user when omitted; M2M passes through.
- `userId` is threaded from the `get_entity_timeline` and `get_competing_facts` MCP schemas (describe texts copied verbatim from `search_knowledge` / `detect_contradiction`) and from the REST timeline route (`@Query('userId')`).
- **Flag off — or on with no userId — the WHERE clause is byte-identical to the historical one** (same clause string, same position; pinned by unit tests). No new 403 path exists with the flag off. `makeRowPolicyFilter` untouched on both surfaces. `getProfile` and the freshness probe are deliberately out of scope.

**Flag `CONFLICT_DIRECT_FACT_SLOT`** (change 3; helper in new `src/common/conflict-flags.ts`):
- In `FactResolverService.buildResolveCall`, when ON **and** this is the typed direct path (`recordOutcomeMetric === true` — set only by `FactIngestService.ingestFact`) **and** the predicate resolves to the registry default (`policyFor(...).predicateId === DEFAULT_FALLBACK.predicateId`), semantics is promoted from `append_only` to **`bitemporal`**.
- `DEFAULT_FALLBACK` itself is untouched (load-bearing for the open-vocabulary mention bulk); known predicates keep their registry policy; the mention path is untouched.

## Decision: `bitemporal`, not `single_active` (deviation from plan, per its own verification clause)

The plan proposed `single_active` on the claim that it "takes the whole candidate pool with no cosine gate and no reject path, so close-scored contradictions become COMPETING and clear winners supersede" — and instructed verifying that claim against the migration before coding. Verification against **0085** (`src/db/migrations/0085_slot_supersede_pairwise_closure.surql`, the live `fn::resolve_fact` definition — 0084's body carried forward):

- Line 403–406: `LET $supersede = $semantics = 'single_active' OR …` — **single_active supersedes unconditionally**. It can never return COMPETING; a same-slot disagreement instantly closes the incumbents (last-write-wins), which fails D6 outright and is riskier than append_only (a bad direct write would erase good facts).
- The claim's *correct* half describes **`bitemporal`**: the margin doctrine (line 406 → COMPETING branch at 449–468) leaves close-scored contradictions COMPETING and lets a clear winner (margin ≥ `CONFLICT_MARGIN_SUPERSEDE`, default 0.15) supersede.
- No branch surfaces COMPETING without a reject gate. `bitemporal`'s reject gate (lines 97–103) is quantifiably a non-issue for direct writes: `$new_score = 0.3·confidence + 0.4·sourceTrust + 0.2·1.0 + 0.1·authority` — at the direct path's default confidence 0.7 the score is ≥ 0.41 even at zero source trust/authority, vs the 0.30 default threshold. Only an explicitly very-low-confidence write (< ~1/3 with an untrusted source) can be rejected, and it is **not silent**: the caller receives `outcome: REJECTED, reason: low_score` in the `IngestResult`, plus an `ingest_dead_letter` row.

So the promotion target is `bitemporal` — the only branch that closes D6 ("get_competing_facts lists both sides").

## Flags & registration
- Both registered in `KNOWN_BOOLEAN_FLAGS` (`src/common/env-validation.ts`) and the config catalog (`src/admin/config-catalog.data.ts`; `auth` / `conflict` categories, runtime-mutable).
- `READ_` / `CONFLICT_` do not match the ENGINE flag-budget regex `^(SEARCH|SYNTHESIZE|MULTI_HOP|EXTRACTOR|EXTRACTION|INGEST|EPISODE|EPISODES|DERIVER|AGENT_QA)_` — the flag-budget gate passes without golden edits.

## Tests
- `test/read-surface-user-scope.unit-spec.ts` — pins, at the query-builder seam of both services: flag-off byte-identical clause (userId ignored, no 403), flag-on union clause + bound param, flag-on fail-closed without userId, and the pinUserScope fence (mismatch 403 / omitted-defaults) for user-bound tokens.
- `test/conflict-direct-fact-slot.unit-spec.ts` — resolver promotion: flag off → append_only passthrough; flag on + direct + unknown → `bitemporal`; flag on + known predicate → registry policy untouched; flag on + mention path → untouched.
- `test/facts-list-competing.e2e-spec.ts` (extended, real SurrealDB 3.2.4 via testcontainers) — a user-scoped competing pair: invisible with the flag off even when userId is passed; tenant-global ∪ user union with flag on + userId; fail-closed without userId; another user's id sees nothing. (Seeded directly rather than via `record_fact`, per the spec's own precedent — forcing the resolver into COMPETING is not deterministic under the stub embedder; the record_fact→COMPETING semantics is covered by the resolver unit spec.)

## Verification
- `pnpm typecheck` green; `pnpm test:unit` green (341 suites / 3622 tests, includes the flag-budget and OpenAPI drift gates); touched e2e specs green locally against the ephemeral SurrealDB container (`facts-list-competing`, `entity-recorded-at`, `user-scope`).
- `pnpm prettier --check` clean on every touched file; eslint clean.

Closes memory-fitness harness dimensions **D2** (evolution history — timeline now sees user-scoped fact + supersede events) and **D6** (conflict surfacing — direct facts form COMPETING pairs and `get_competing_facts` can see them under the user scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB