### PR TITLE
fix(eval): memory-fitness runner must pass userId to timeline/competing reads

### DIFF
--- a/test/eval/memory-fitness/runner.ts
+++ b/test/eval/memory-fitness/runner.ts
@@ -411,7 +411,10 @@ async function askOne(ctx: AskContext, q: Question): Promise<Verdict> {
     case 'evolution': {
       const entityId = await resolveEntityId(ctx, q.entityQuery, q.predicate);
       if (entityId === null) return { status: 'fail', detail: 'entity not found via search' };
-      const timeline = await callTool<TimelineOut>(ctx.mcp, 'get_entity_timeline', { entityId });
+      const timeline = await callTool<TimelineOut>(ctx.mcp, 'get_entity_timeline', {
+        entityId,
+        userId: ctx.cfg.userId,
+      });
       const events: EvolutionEvent[] = (timeline.events ?? [])
         .filter((e) => e.type === 'fact.recorded')
         .map((e) => ({ predicate: e.predicate ?? '', object: e.object ?? '', at: e.at }));
@@ -505,6 +508,7 @@ async function askOne(ctx: AskContext, q: Question): Promise<Verdict> {
       const out = await callTool<CompetingOut>(ctx.mcp, 'get_competing_facts', {
         entityId,
         predicate: q.predicate,
+        userId: ctx.cfg.userId,
       });
       const group = (out.groups ?? []).find((g) => g.predicate === q.predicate);
       const objects = (group?.facts ?? []).map((f) => f.object).join(' | ');


### PR DESCRIPTION
Run-4 on the fix-wave stand showed the #417 write side works — both `payout_cutoff` facts land as `status='competing'` (the `CONFLICT_DIRECT_FACT_SLOT` promotion fired, no rejects) and both `queue_backend` versions are retained in order — yet D2/D6-api still failed. Root cause: the runner calls `get_entity_timeline` / `get_competing_facts` **without `userId`**, and `READ_SURFACE_USER_SCOPE` only widens the read when the caller asserts a user. Every fact in the corpus is user-scoped, so the tools answered from the empty tenant-global slice.

Fix: pass `ctx.cfg.userId` on both calls — the same first-person identity every other read in the harness (search, synthesize, multi-hop) already asserts. No scorer or corpus changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
