### PR TITLE
feat(deploy): enable memory-fitness fix-wave flags in prod

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -291,6 +291,12 @@ jobs:
           # ── Packs / MCP / QA ──
           MCP_PACK_EXTERNAL_TOOLS_ENABLED=1
           AGENT_QA_TOOLS_V2=1
+          # ── Memory-fitness fix wave (#415-#417, measured on the stand:
+          # same-memory re-ask 16/30 -> 20/29; D2 timeline 3/3, D6 2/2) ──
+          READ_SURFACE_USER_SCOPE=1
+          CONFLICT_DIRECT_FACT_SLOT=1
+          BELIEFS_LANE_DATE_DISAMBIGUATION=1
+          PROVENANCE_EPISODE_NEIGHBOURS=1
           EOF
           # The heredoc carries the YAML block's 10-space indent into the
           # file; strip it so every line is a clean KEY=value / #comment


### PR DESCRIPTION
Flips the four flags built in #415/#416/#417, after measurement on the dogfood stand.

**Same-memory A/B** (identical tenant, re-asked with the userId-fixed runner from #419): **16/30 → 20/29**.

- `READ_SURFACE_USER_SCOPE` — D2 evolution history 3/3: `get_entity_timeline` now retains and orders old → new per predicate for user-scoped facts.
- `CONFLICT_DIRECT_FACT_SLOT` — D6 2/2: both payout-cutoff writes land as `status='competing'` (verified in the DB), `get_competing_facts` lists both sides, and the synthesized answer names both sides with the discrepancy called out.
- `BELIEFS_LANE_DATE_DISAMBIGUATION` — no D5 regression (4/5 in both runs on this tenant); belief-revision dates no longer masquerade as event dates.
- `PROVENANCE_EPISODE_NEIGHBOURS` — no regression. The remaining d3-ratelimit miss on this tenant is extraction-side (the "50 requests per minute" literal never became a fact at all — the belief plane caught it, the fact extractor dropped it), which read-side widening cannot fix; that lever is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB