### PR TITLE
fix(deploy): AUTH_SERVICE_ISSUER must match the auth-service's real iss (auth-api host)

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -378,8 +378,13 @@ jobs:
                 - AUTH_SERVICE_AUDIENCE=brain
                 # Required: JwksService refuses to boot in production when JWKS
                 # is enabled without an issuer (else the `iss` claim is not
-                # validated). Must match the `iss` auth-service signs with.
-                - AUTH_SERVICE_ISSUER=https://auth.inite.ai
+                # validated). Must match the `iss` auth-service signs with —
+                # which is the API host (auth-api), NOT the login UI host:
+                # https://auth.inite.ai/.well-known/openid-configuration
+                # reports issuer=https://auth-api.inite.ai. The old value
+                # made brain reject EVERY JWKS-verified token with
+                # 'unexpected "iss" claim value' (admin BFF data plane 401).
+                - AUTH_SERVICE_ISSUER=https://auth-api.inite.ai
                 # GDPR forget HMAC — opaque tombstone marker.
                 - FORGET_HMAC_KEY=${{ secrets.BRAIN_FORGET_HMAC_KEY }}
                 # Search retrieval features — eval-validated ON config.


### PR DESCRIPTION
Every admin-BFF call to brain was 401ing with "Invalid credentials". Prod logs (via the deploy workflow's `logs` action) show the exact reason:

```
DEBUG [JwksService] JWT verification failed: unexpected "iss" claim value
```

The auth-service's OIDC discovery reports `issuer=https://auth-api.inite.ai` (the API host), while brain pinned `AUTH_SERVICE_ISSUER=https://auth.inite.ai` (the login-UI host). Every JWKS-verified token — the admin BFF's client_credentials token and identity-exchange tokens alike — failed the issuer check, making the whole admin data plane (and any JWT consumer) dead against prod. Long-standing config drift, surfaced today while running the post-enablement segments backfill through the admin BFF.

One env line + comment; JWKS URL and audience unchanged. After deploy, `/api/admin/proxy/*` resolves and the backfill can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB