### PR TITLE
fix(seo): route catalogue equity to the parent, and unstick server.json version

### DIFF
--- a/brain-landing/__tests__/parent-link.test.ts
+++ b/brain-landing/__tests__/parent-link.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { PARENT, organizationSchema } from '@/lib/seo'
+import { LANGS, getMessages } from '@/lib/i18n'
+
+/**
+ * Brain must link to the company that makes it, with an anchor a crawler
+ * follows.
+ *
+ * The relationship was already declared twice — `parentOrganization` and
+ * `sameAs` in the JSON-LD — and linked zero times. JSON-LD asserts a
+ * relationship; it does not carry one. Meanwhile every MCP catalogue that
+ * lists this server points at brain.inite.ai, so the only earned links the
+ * family has were arriving here and stopping: inite.ai's own external profile
+ * came to two donors, both of them listings of *this* server.
+ *
+ * The footer anchor is the edge that fixes it, and this is the gate that keeps
+ * it from being refactored away.
+ *
+ * Scope note: the suite runs on `environment: 'node'` with no DOM, so the
+ * component itself cannot be rendered here. The first two cases are real unit
+ * assertions on the schema builder; the third reads the component source, and
+ * is written that way on purpose rather than pretending to be a render.
+ *
+ * Proof it bites: delete the `<a href={PARENT.url}>` block from Footer.tsx.
+ */
+
+const FOOTER = readFileSync(join(__dirname, '..', 'components', 'Footer.tsx'), 'utf-8')
+
+describe('the parent link', () => {
+  it('is the same address the schema claims as parent', () => {
+    const org = organizationSchema() as Record<string, any>
+    expect(org.parentOrganization.url).toBe(PARENT.url)
+    expect(org.parentOrganization['@id']).toBe(`${PARENT.url}/#organization`)
+    expect(org.sameAs).toContain(PARENT.url)
+  })
+
+  it('points somewhere outside this site', () => {
+    expect(PARENT.url).toMatch(/^https:\/\//)
+    expect(PARENT.url).not.toContain('brain.')
+  })
+
+  it('is rendered by the footer, out of that one constant', () => {
+    expect(FOOTER).toContain("from '../lib/seo'")
+    expect(FOOTER).toMatch(/href=\{PARENT\.url\}/)
+    // Not a hardcoded second copy of the address.
+    expect(FOOTER).not.toContain('https://inite.ai')
+  })
+
+  it('has copy in every locale', () => {
+    for (const lang of LANGS) {
+      const maker = getMessages(lang).footer.maker
+      expect(String(maker ?? '').trim().length, `${lang} footer.maker`).toBeGreaterThan(0)
+    }
+  })
+})

--- a/brain-landing/components/Footer.tsx
+++ b/brain-landing/components/Footer.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { getMessages, type Lang } from '../lib/i18n'
-import { REPO } from '../lib/seo'
+import { PARENT, REPO } from '../lib/seo'
 
 interface Props {
   lang: Lang
@@ -76,6 +76,19 @@ export function Footer({ lang }: Props) {
           </div>
           <p className="mt-3 text-[12px] leading-relaxed text-[var(--text-faint)] max-w-[14rem]">
             {f.tagline}
+          </p>
+          {/* The only crawlable edge from Brain to the company that makes it.
+              See lib/seo.ts PARENT: the relationship was asserted in JSON-LD
+              and never linked, so every catalogue listing landed here and
+              stopped. */}
+          <p className="mt-3 text-[12px] text-[var(--text-faint)]">
+            {f.maker}{' '}
+            <a
+              href={PARENT.url}
+              className="text-[var(--text-muted)] underline underline-offset-2 hover:text-[var(--text)]"
+            >
+              {PARENT.name}
+            </a>
           </p>
         </div>
 

--- a/brain-landing/lib/seo.ts
+++ b/brain-landing/lib/seo.ts
@@ -9,6 +9,25 @@ export const SITE_URL = 'https://brain.inite.ai'
 export const REPO = 'inite-ai/inite-brain-service'
 export const GITHUB_URL = `https://github.com/${REPO}`
 
+/**
+ * The company Brain belongs to.
+ *
+ * It was declared twice and linked zero times: `organizationSchema` asserts
+ * `parentOrganization` and lists inite.ai under `sameAs`, and neither is a
+ * hyperlink. JSON-LD states a relationship; it does not carry one. Every MCP
+ * catalogue that lists this server (pulsemcp, mcphq, mcp-marketplace,
+ * roninforge) points at brain.inite.ai, and from here nothing pointed on — the
+ * whole family's earned links dead-ended on a subdomain.
+ *
+ * The footer link below is the only crawlable edge from Brain to the parent,
+ * and this constant is the one place its address lives.
+ */
+export const PARENT = {
+  name: 'INITE',
+  legalName: 'inite LLC',
+  url: 'https://inite.ai',
+} as const
+
 export const ORG = {
   name: 'INITE Brain',
   url: SITE_URL,
@@ -49,17 +68,17 @@ export function organizationSchema(): Json {
     description: ORG.description,
     sameAs: [
       ...ORG.sameAs,
-      'https://inite.ai',
+      PARENT.url,
       'https://www.linkedin.com/company/inite-ai/',
       'https://t.me/initeai',
       'https://github.com/inite-ai',
     ],
     parentOrganization: {
       '@type': 'Organization',
-      '@id': 'https://inite.ai/#organization',
-      name: 'INITE',
-      legalName: 'inite LLC',
-      url: 'https://inite.ai',
+      '@id': `${PARENT.url}/#organization`,
+      name: PARENT.name,
+      legalName: PARENT.legalName,
+      url: PARENT.url,
     },
   }
 }

--- a/brain-landing/locales/en/common.json
+++ b/brain-landing/locales/en/common.json
@@ -240,6 +240,7 @@
   },
   "footer": {
     "tagline": "Open-source bitemporal knowledge graph for AI agents. A system of insight, not a system of record.",
+    "maker": "A project by",
     "columns": {
       "product": {
         "title": "Product",

--- a/brain-landing/locales/ru/common.json
+++ b/brain-landing/locales/ru/common.json
@@ -240,6 +240,7 @@
   },
   "footer": {
     "tagline": "Open-source битемпоральный граф знаний для AI-агентов. System of insight, не system of record.",
+    "maker": "Проект компании",
     "columns": {
       "product": {
         "title": "Продукт",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,11 @@
           "type": "json",
           "path": "docs/openapi.json",
           "jsonpath": "$.info.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.inite-ai/inite-brain-service",
   "title": "Inite Brain",
   "description": "Open-source bitemporal memory layer for LLM agents — knowledge graph with conflict resolution.",
-  "version": "0.1.0",
+  "version": "2.1.0",
   "websiteUrl": "https://brain.inite.ai",
   "repository": {
     "url": "https://github.com/inite-ai/inite-brain-service",

--- a/test/server-json-version.unit-spec.ts
+++ b/test/server-json-version.unit-spec.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 /**
  * `server.json` is the file the MCP registry publishes and every downstream
@@ -15,20 +15,20 @@ import { join } from 'node:path'
  * Proof it bites: set `version` in `server.json` back to `0.1.0`.
  */
 
-const root = join(__dirname, '..')
-const read = (p: string) => JSON.parse(readFileSync(join(root, p), 'utf-8'))
+const root = join(__dirname, '..');
+const read = (p: string) => JSON.parse(readFileSync(join(root, p), 'utf-8'));
 
 describe('server.json', () => {
   it('publishes the package version', () => {
-    expect(read('server.json').version).toBe(read('package.json').version)
-  })
+    expect(read('server.json').version).toBe(read('package.json').version);
+  });
 
   it('is carried by release-please, so it cannot drift again', () => {
     const extra = read('release-please-config.json').packages['.']['extra-files'] as Array<{
-      path: string
-      jsonpath: string
-    }>
-    expect(extra.map((e) => e.path)).toContain('server.json')
-    expect(extra.find((e) => e.path === 'server.json')?.jsonpath).toBe('$.version')
-  })
-})
+      path: string;
+      jsonpath: string;
+    }>;
+    expect(extra.map((e) => e.path)).toContain('server.json');
+    expect(extra.find((e) => e.path === 'server.json')?.jsonpath).toBe('$.version');
+  });
+});

--- a/test/server-json-version.unit-spec.ts
+++ b/test/server-json-version.unit-spec.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * `server.json` is the file the MCP registry publishes and every downstream
+ * catalogue reads — pulsemcp, glama, smithery, mcp.so, mcphq all render its
+ * `version`.
+ *
+ * It said `0.1.0` while the package was at `2.1.0`, because release-please
+ * carried `docs/openapi.json` in `extra-files` and never carried this one. So
+ * the public listings advertised a pre-release of a service two majors past it,
+ * and nothing failed when they drifted — the same shape as the OpenAPI drift
+ * that `openapi-doc.unit-spec.ts` exists to catch.
+ *
+ * Proof it bites: set `version` in `server.json` back to `0.1.0`.
+ */
+
+const root = join(__dirname, '..')
+const read = (p: string) => JSON.parse(readFileSync(join(root, p), 'utf-8'))
+
+describe('server.json', () => {
+  it('publishes the package version', () => {
+    expect(read('server.json').version).toBe(read('package.json').version)
+  })
+
+  it('is carried by release-please, so it cannot drift again', () => {
+    const extra = read('release-please-config.json').packages['.']['extra-files'] as Array<{
+      path: string
+      jsonpath: string
+    }>
+    expect(extra.map((e) => e.path)).toContain('server.json')
+    expect(extra.find((e) => e.path === 'server.json')?.jsonpath).toBe('$.version')
+  })
+})


### PR DESCRIPTION
## Что нашлось

Разбор ссылочного профиля inite.ai (DataForSEO, 05.09.2026) дал такую картину:

```
доменов-доноров            127
  своя сеть inite.*         13   868 из 1225 ссылок
  внешних                  114
  из них со страниц с весом   2   ← pulsemcp.com и mcphq.ai
```

Оба «настоящих» донора — листинги **этого** сервера. Сюда же ведут `mcp-marketplace.io` и `roninforge.org`. То есть единственное, что заработало семейству ссылки без единого письма, — подача MCP-сервера в каталоги.

**А отсюда не вело никуда.** Родство было объявлено дважды и не связано ни разу: `organizationSchema` объявляет `parentOrganization` и держит `inite.ai` в `sameAs`. JSON-LD утверждает связь, но не переносит её — вес идёт по якорям. Подвал рендерится на всех 171 странице и ссылки на компанию не имел.

## Что сделано

**Ссылка на родителя.** `PARENT` в `lib/seo.ts` — единственное место, где живёт адрес; схема теперь читает его оттуда вместо второй копии. Подвал рендерит якорь «INITE» после «A project by» / «Проект компании».

**Версия в `server.json`.** Файл объявлял `0.1.0` при `2.1.0` в пакете. Это то, что публикует реестр MCP и читают все каталоги: pulsemcp, glama, smithery, mcp.so, mcphq показывали предрелиз сервиса, ушедшего на два мажора вперёд. Причина — release-please нёс `docs/openapi.json` в `extra-files`, а этот файл нет. Добавлен туда же.

## Сторожа

| тест | ловит | доказательство |
|---|---|---|
| `brain-landing/__tests__/parent-link.test.ts` | схема и проводка в компоненте | убрать `href={PARENT.url}` из Footer |
| `test/server-json-version.unit-spec.ts` | расхождение версий и выпадение из release-please | вернуть `0.1.0` |

Оба проверены возвратом дефекта.

Оговорка по третьему случаю первого теста: в наборе `environment: 'node'`, DOM нет, компонент отрендерить нечем. Первые два случая — настоящие юнит-проверки схемы; третий читает исходник и помечен как проверка исходника, а не выдаёт себя за рендер.

## Гейты

`tsc` · 38 тестов лендинга · 2 корневых · сборка 171 страницы. Ссылка проверена в собранном HTML обеих локалей: dofollow, якорь «INITE».

Контекст и остальные семь вен: `.planning/backlinks-2026-09.md` в initeai-landing (PR #111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014U8o8AqEtZq9DMGBzScu16