### PR TITLE
feat(eval): state-transition eval battery — mechanical mutable-world-state checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:eval": "pnpm build && jest --config ./test/jest-e2e-real.json --runInBand --testPathPatterns=quality",
     "eval:diff": "ts-node -r tsconfig-paths/register scripts/eval-baseline-diff.ts",
     "eval:memory-fitness": "ts-node -T test/eval/memory-fitness/runner.ts",
+    "eval:state-transitions": "ts-node -T test/eval/state-transitions/runner.ts",
     "openapi:build": "ts-node -T scripts/build-openapi.ts",
     "mri:report": "ts-node -T scripts/mri-report.ts",
     "mri:record-suite": "ts-node -T scripts/mri-record-suite.ts",

--- a/test/eval/state-transitions/README.md
+++ b/test/eval/state-transitions/README.md
@@ -1,0 +1,137 @@
+# State-transition battery
+
+Mechanical sibling of [`test/eval/memory-fitness`](../memory-fitness/README.md),
+aimed at ONE claim instead of eight dimensions: **memory tracks a mutable
+world-state** — a belief flips to the current value while keeping its
+`priorValue` and `revision`, superseded facts survive as history, and
+serving answers with current truth, not with whatever was written first.
+
+Where memory-fitness measures general first-person memory fitness over
+one interleaved corpus, this battery seeds 12 isolated **state-transition
+scenarios** (each with its own entity, so scenarios cannot
+cross-contaminate) and executes 2-4 typed checks per scenario. Ground
+truth is authored WITH the turns, so grading is self-contained and free:
+**no LLM judge, no paid eval** — the only model spend is the stand's own
+serving cost.
+
+## Scenario taxonomy
+
+| #   | Scenario                 | Class                | What would falsify the claim                                 |
+| --- | ------------------------ | -------------------- | ------------------------------------------------------------ |
+| s01 | dispose                  | dispose              | "no bike anymore" not reflected; belief stuck at acquisition |
+| s02 | replace                  | replace              | old laptop served as current; history loses a stage          |
+| s03 | re-acquire               | re-acquire           | join → quit → rejoin collapses; final state wrong            |
+| s04 | retro-dated              | retro-dated          | a cancellation reported late is not current truth            |
+| s05 | intention-not-action     | non-transition-guard | "thinking about selling" flips ownership                     |
+| s06 | listed-not-sold          | non-transition-guard | listing for sale treated as a disposal                       |
+| s07 | contradiction            | conflict             | one side of a live conflict served silently                  |
+| s08 | field-drift              | field-drift          | "home city" vs "place of residence" split the belief key     |
+| s09 | third-party              | third-party          | Boris's transition misattributed to the speaker              |
+| s10 | same-day                 | same-day             | two intra-day transitions collapse or reorder                |
+| s11 | multi-object             | multi-object         | selling one of two objects loses (or keeps) the wrong one    |
+| s12 | provenance-of-transition | provenance           | the flip is asserted without unrolling to the seeded turns   |
+
+## Check kinds (all mechanical — see `types.ts` / `scorers.ts`)
+
+- **`serve`** — MCP `synthesize` (strict guardrails by default) scored by
+  `expectAnyOf` / `forbidAnyOf` / conflict-sides / expect-abstain.
+  Scoring is **marker-first**: the honest answer to a disposal question
+  ("you don't have a bike anymore") trips the shared decline regex
+  (`test/eval/abstain.ts`), so abstention alone never fails a serve
+  whose expected truth IS a negation; expect markers are authored to
+  never occur in decline phrasings (`'sold'`, `'no longer'` — never bare
+  `'no'` / `'do not'`).
+- **`belief`** — `GET /v1/beliefs?userId=…`: a belief matching the
+  free-text (subject, field) token filters carries the expected `value`,
+  `priorValue` and `revision` depth.
+- **`fact-history`** — `search_knowledge` → `get_entity_timeline`: the
+  timeline retains every transition stage as `fact.recorded` events, as
+  a chronological subsequence (the sibling's `checkEvolution`,
+  generalised to N stages and LLM-worded predicates).
+- **`provenance`** — `search_knowledge` → `get_fact_provenance`: a fact
+  about the transitioned state unrolls to an episode quoting a seeded
+  fragment verbatim (the sibling's `walkProvenance`, with its
+  round-robin candidate interleave).
+
+Score = per-scenario pass (ALL of its checks pass) plus a per-check-kind
+tally; the scorecard groups scenarios by class.
+
+## Expected fails on today's code (the baseline IS the point)
+
+Two belief checks are **expected to fail** on current `main` and are
+annotated `knownFailToday` in `scenarios.ts` (tracked as #135; the
+scorecard counts them separately, and the runner prints
+`(expected today)` next to them):
+
+- **s01-belief** — `SCENES_BELIEF_NEGATION_DELTAS`: a disposal ("no bike
+  anymore") does not reliably emit a stateDelta, so the belief stays at
+  the acquisition revision instead of flipping to a none-ish value with
+  the Kawasaki as `priorValue`.
+- **s08-belief** — `SCENES_BELIEF_FIELD_FOLD`: "home city" and "place of
+  residence" fold into different free-text field keys, so no single
+  belief carries `value` + `priorValue` across the drifted wording.
+
+The battery still RUNS both checks and records their fails — that is the
+baseline those flags, once merged and enabled, are measured against. A
+run where they pass is the signal the bugs are fixed.
+
+## Running against a local stand
+
+Same stand as the sibling: a booted brain (with its OpenAI key), driven
+purely over the wire — **never run in CI** (the runner exits with a
+clear message when `BRAIN_BASE_URL` is unset).
+
+Stand flags that shape coverage:
+
+- `FACTS_API_ENABLED=1` — required for the provenance checks
+  (`get_fact_provenance` is otherwise absent; those checks are skipped).
+- `THROTTLE_DISABLED=1` — recommended: mention ingest and the MCP route
+  are rate-capped; without it the runner backs off on 429.
+- For the belief checks: `SCENES_SEGMENTATION_ENABLED=1`,
+  `SCENES_LLM_ENRICHMENT=1`, `SCENES_FACT_BACKLINK=1`,
+  `SCENES_BELIEF_PROMOTION=1`, `BELIEFS_API_ENABLED=1`, and an API key
+  with `brain:admin` (the belief build runs in-band). Without them the
+  belief checks are skipped, never silently passed.
+- Once #135 lands: `SCENES_BELIEF_NEGATION_DELTAS=1` and
+  `SCENES_BELIEF_FIELD_FOLD=1` are the flags this battery's expected
+  fails exist to validate.
+
+Then:
+
+```bash
+BRAIN_BASE_URL=http://localhost:3000 \
+BRAIN_API_KEY=<tenant M2M key: brain:read + brain:write [+ brain:admin]> \
+BRAIN_COMPANY_ID=<fresh tenant id> \
+pnpm eval:state-transitions
+```
+
+Optional env: `STEV_USER_ID` (default `stev-agent`), `STEV_RUN_ID`
+(defaults to a fresh id), `STEV_GUARDRAILS` (`strict` | `lenient` |
+`off`, default `strict`), `STEV_SKIP_INGEST=1` (re-ask an
+already-ingested run; pass the same `STEV_RUN_ID`), `STEV_REPORT_DIR`
+(default `var/state-transitions/`).
+
+Conversation ids are run-scoped (`<runId>-s01a`), so re-runs never
+collide on conversations; as with the sibling, use a **fresh
+`BRAIN_COMPANY_ID` per scored run** so the fact substrate stays a single
+clean write history.
+
+## Cost
+
+One run ingests **52 mention turns** (each runs mention extraction on
+the stand's LLM) and makes **13 `synthesize` calls**, plus the free
+read-side calls (search / timeline / provenance / beliefs). Roughly the
+same order of spend as a memory-fitness run (66 turns + its question
+set); judging costs nothing.
+
+## Output
+
+- A human scorecard on stdout: per-class scenario tally, per-kind check
+  tally, overall scores, and the count of fails that were expected on
+  today's code.
+- A JSON report at `var/state-transitions/state-transitions-<runId>.json`
+  (gitignored) with per-check status, detail, latency, raw served
+  answers, and the `knownFailToday` annotations — every verdict is
+  reproducible from the report plus `scorers.ts` (unit-tested in
+  `test/state-transition-scorers.unit-spec.ts`; the reused generic
+  scorers are covered by the sibling's spec).

--- a/test/eval/state-transitions/runner.ts
+++ b/test/eval/state-transitions/runner.ts
@@ -1,0 +1,610 @@
+/**
+ * State-transition runner — drives EVERYTHING through the real wire,
+ * mirroring the memory-fitness sibling:
+ *
+ *  - REST  POST /v1/ingest/mention            (scenario turns, per-user scoped)
+ *  - REST  POST /v1/admin/maintenance/scenes | scenes/backlink | scenes/beliefs
+ *          (best-effort admin builds; 404 = flag off = the dependent
+ *          check is skipped, never silently passed)
+ *  - MCP   synthesize / search_knowledge / get_entity_timeline /
+ *          get_fact_provenance
+ *  - REST  GET /v1/beliefs                    (belief read API)
+ *
+ * Scoring is fully mechanical (see scorers.ts) — no LLM judge. The
+ * serving calls cost normal model spend on the stand; the battery
+ * itself spends nothing on judging.
+ *
+ * Run: pnpm eval:state-transitions   (see README.md for stand flags)
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { HttpBrainClient } from '../http-brain-client';
+import { interleaveRoundRobin } from '../memory-fitness/interleave';
+import { walkProvenance } from '../memory-fitness/scorers';
+import { ALL_TURNS, BORIS_REF, CORPUS_VERTICAL, SCENARIOS, SPEAKER } from './scenarios';
+import { checkBelief, checkHistorySequence, scoreServe, type HistoryEvent } from './scorers';
+import type {
+  BeliefCheck,
+  Check,
+  CheckKind,
+  CheckResult,
+  CheckStatus,
+  FactHistoryCheck,
+  ProvenanceCheck,
+  Scenario,
+  ScenarioResult,
+  Scorecard,
+  ServeCheck,
+  Tally,
+} from './types';
+
+/**
+ * Provenance-walk budget: how many candidate facts get their provenance
+ * unrolled per check. Candidates are interleaved round-robin across
+ * search hits (the sibling's interleave.ts) before this cap.
+ */
+const PROVENANCE_CANDIDATE_CAP = 12;
+
+/** How many search hits get their timeline walked per fact-history check. */
+const HISTORY_ENTITY_CAP = 6;
+
+// ── configuration ───────────────────────────────────────────────────
+
+interface Config {
+  baseUrl: string;
+  apiKey: string;
+  companyId: string;
+  userId: string;
+  runId: string;
+  guardrails: 'strict' | 'lenient' | 'off';
+  skipIngest: boolean;
+  reportDir: string;
+}
+
+function loadConfig(): Config {
+  const baseUrl = process.env.BRAIN_BASE_URL ?? process.env.BRAIN_URL;
+  const apiKey = process.env.BRAIN_API_KEY;
+  const companyId = process.env.BRAIN_COMPANY_ID;
+  if (baseUrl === undefined || baseUrl === '') {
+    console.error(
+      [
+        'state-transitions: BRAIN_BASE_URL is not set — nothing to run against.',
+        'This battery drives a LIVE brain stand over MCP + REST (it needs a booted',
+        'service and its OpenAI key) and is intentionally never run in CI.',
+        '',
+        'Required env:',
+        '  BRAIN_BASE_URL   e.g. http://localhost:3000  (BRAIN_URL also accepted)',
+        '  BRAIN_API_KEY    tenant M2M key with brain:read + brain:write',
+        '                   (+ brain:admin for the optional scene/belief builds)',
+        '  BRAIN_COMPANY_ID tenant id — use a FRESH tenant per run (see README.md)',
+        '',
+        'Optional env: STEV_USER_ID, STEV_RUN_ID, STEV_GUARDRAILS',
+        '(strict|lenient|off, default strict), STEV_SKIP_INGEST=1 (re-ask an',
+        'already-ingested run — requires the same STEV_RUN_ID), STEV_REPORT_DIR.',
+      ].join('\n'),
+    );
+    process.exit(1);
+  }
+  if (apiKey === undefined || apiKey === '') {
+    console.error('state-transitions: BRAIN_API_KEY is not set.');
+    process.exit(1);
+  }
+  if (companyId === undefined || companyId === '') {
+    console.error('state-transitions: BRAIN_COMPANY_ID is not set.');
+    process.exit(1);
+  }
+  const guardrailsRaw = process.env.STEV_GUARDRAILS ?? 'strict';
+  if (guardrailsRaw !== 'strict' && guardrailsRaw !== 'lenient' && guardrailsRaw !== 'off') {
+    console.error('state-transitions: STEV_GUARDRAILS must be strict|lenient|off.');
+    process.exit(1);
+  }
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ''),
+    apiKey,
+    companyId,
+    userId: process.env.STEV_USER_ID ?? 'stev-agent',
+    runId: process.env.STEV_RUN_ID ?? `st${Date.now().toString(36)}`,
+    guardrails: guardrailsRaw,
+    skipIngest: process.env.STEV_SKIP_INGEST === '1',
+    reportDir: process.env.STEV_REPORT_DIR ?? join('var', 'state-transitions'),
+  };
+}
+
+// ── small utilities ─────────────────────────────────────────────────
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Retry on throttle (HTTP 429) — mention ingest and the MCP route are rate-capped. */
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      const msg = String(err);
+      if (attempt < 12 && /429|too many requests/i.test(msg)) {
+        console.error(`  [throttled] ${label} — waiting 6.5s (attempt ${attempt})`);
+        await sleep(6_500);
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/** Run-scoped conversation id — makes re-runs non-colliding by construction. */
+const convId = (cfg: Config, key: string): string => `${cfg.runId}-${key}`;
+
+const messageId = (cfg: Config, key: string, turn: number): string =>
+  `${convId(cfg, key)}-t${String(turn).padStart(2, '0')}`;
+
+// ── REST (raw, non-throwing — admin builds and belief reads need the status) ──
+
+interface RestResult<T> {
+  status: number;
+  json: T | null;
+}
+
+async function restRaw<T>(
+  cfg: Config,
+  method: 'GET' | 'POST',
+  path: string,
+  body?: unknown,
+): Promise<RestResult<T>> {
+  const res = await fetch(`${cfg.baseUrl}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${cfg.apiKey}`,
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  const ct = res.headers.get('content-type') ?? '';
+  if (!ct.includes('application/json')) return { status: res.status, json: null };
+  return { status: res.status, json: (await res.json()) as T };
+}
+
+// ── MCP ─────────────────────────────────────────────────────────────
+
+interface ToolCallShape {
+  isError?: boolean;
+  content?: unknown;
+  structuredContent?: unknown;
+}
+
+function textOf(res: ToolCallShape): string | null {
+  if (!Array.isArray(res.content)) return null;
+  for (const item of res.content) {
+    if (
+      item !== null &&
+      typeof item === 'object' &&
+      (item as { type?: unknown }).type === 'text' &&
+      typeof (item as { text?: unknown }).text === 'string'
+    ) {
+      return (item as { text: string }).text;
+    }
+  }
+  return null;
+}
+
+async function connectMcp(cfg: Config): Promise<McpClient> {
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`${cfg.baseUrl}/mcp/${cfg.companyId}`),
+    { requestInit: { headers: { Authorization: `Bearer ${cfg.apiKey}` } } },
+  );
+  const client = new McpClient({ name: 'state-transitions-battery', version: '1.0.0' });
+  // Same @modelcontextprotocol/sdk .d.ts self-inconsistency the server
+  // side bridges in src/mcp/mcp.controller.ts: under
+  // exactOptionalPropertyTypes the concrete transport class no longer
+  // structurally satisfies its own Transport interface. The runtime
+  // value genuinely is a valid Transport; this asserts the SDK's own
+  // contract, not our types.
+  await client.connect(transport as Transport);
+  return client;
+}
+
+async function callTool<T>(
+  mcp: McpClient,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const raw = (await withRetry(name, () =>
+    mcp.callTool({ name, arguments: args }),
+  )) as ToolCallShape;
+  const text = textOf(raw);
+  if (raw.isError === true) {
+    throw new Error(`MCP tool ${name} failed: ${text ?? '(no error text)'}`);
+  }
+  if (text !== null) return JSON.parse(text) as T;
+  if (raw.structuredContent !== undefined) return raw.structuredContent as T;
+  throw new Error(`MCP tool ${name} returned neither text nor structuredContent`);
+}
+
+// Local wire shapes — only the fields the scorers consume.
+interface SearchHit {
+  entityId: string;
+  canonicalName?: string;
+  facts?: Array<{ factId: string; predicate: string; object: string }>;
+}
+interface SearchOut {
+  results?: SearchHit[];
+}
+interface SynthOut {
+  answer: string | null;
+  reason?: string;
+}
+interface TimelineOut {
+  events?: Array<{ type: string; at: string; predicate?: string; object?: string }>;
+}
+interface ProvenanceOut {
+  factId?: string;
+  episodes?: Array<{ episodeId?: string; text?: string }>;
+}
+interface BeliefsOut {
+  beliefs?: Array<{
+    subject: string;
+    field: string;
+    value: string;
+    priorValue?: string;
+    revision?: number;
+  }>;
+}
+
+// ── phase 1: write the world-state ──────────────────────────────────
+
+async function ingestTurns(cfg: Config, brain: HttpBrainClient): Promise<void> {
+  console.error(`[ingest] ${ALL_TURNS.length} mention turns (run ${cfg.runId})…`);
+  for (const [i, turn] of ALL_TURNS.entries()) {
+    const knownEntities: Array<Record<string, string>> = [{ ...SPEAKER }];
+    if (turn.text.includes('Boris')) {
+      knownEntities.push({ ...BORIS_REF, name: 'Boris' });
+    }
+    await withRetry(`mention ${turn.conversation}#${turn.turn}`, () =>
+      brain.ingest.mention({
+        text: turn.text,
+        contextRef: {
+          vertical: CORPUS_VERTICAL,
+          conversationId: convId(cfg, turn.conversation),
+          messageId: messageId(cfg, turn.conversation, turn.turn),
+          recorder: 'state-transitions-battery',
+        },
+        knownEntities,
+        userId: cfg.userId,
+        emittedAt: turn.emittedAt,
+      }),
+    );
+    if ((i + 1) % 10 === 0) console.error(`[ingest] ${i + 1}/${ALL_TURNS.length}`);
+  }
+}
+
+async function runBuilds(cfg: Config): Promise<Record<string, string>> {
+  // scenes -> (enrich happens in-build when SCENES_LLM_ENRICHMENT is on)
+  // -> backlink -> beliefs. Every step is best-effort: a 404 means the
+  // stand runs without that flag and the dependent check is SKIPPED.
+  const builds: Record<string, string> = {};
+  for (const step of ['scenes', 'scenes/backlink', 'scenes/beliefs']) {
+    const res = await restRaw<Record<string, unknown>>(
+      cfg,
+      'POST',
+      `/v1/admin/maintenance/${step}`,
+      {},
+    );
+    builds[step] =
+      res.status === 404
+        ? 'skipped: 404 (scene flag off)'
+        : res.status === 403
+          ? 'skipped: 403 (key lacks brain:admin)'
+          : res.status >= 200 && res.status < 300
+            ? 'ok'
+            : `error: HTTP ${res.status}`;
+    console.error(`[build] ${step}: ${builds[step]}`);
+  }
+  return builds;
+}
+
+// ── phase 2: execute the checks ─────────────────────────────────────
+
+interface CheckContext {
+  cfg: Config;
+  mcp: McpClient;
+  tools: Set<string>;
+  builds: Record<string, string>;
+}
+
+type Verdict = Pick<CheckResult, 'status' | 'detail'> & { answer?: string | null };
+
+async function searchHits(ctx: CheckContext, query: string, limit: number): Promise<SearchHit[]> {
+  const out = await callTool<SearchOut>(ctx.mcp, 'search_knowledge', {
+    query,
+    limit,
+    userId: ctx.cfg.userId,
+  });
+  return out.results ?? [];
+}
+
+async function runServeCheck(ctx: CheckContext, check: ServeCheck): Promise<Verdict> {
+  const out = await callTool<SynthOut>(ctx.mcp, 'synthesize', {
+    query: check.query,
+    limit: 15,
+    synthesisGuardrails: ctx.cfg.guardrails,
+    userId: ctx.cfg.userId,
+  });
+  const verdict = scoreServe(out.answer, out.reason, check);
+  return { status: verdict.status, detail: verdict.detail, answer: out.answer };
+}
+
+async function runBeliefCheck(ctx: CheckContext, check: BeliefCheck): Promise<Verdict> {
+  if (ctx.builds['scenes/beliefs'] !== 'ok') {
+    return {
+      status: 'skipped',
+      detail: `belief build not run (${ctx.builds['scenes/beliefs'] ?? 'no build phase'})`,
+    };
+  }
+  const res = await restRaw<BeliefsOut>(
+    ctx.cfg,
+    'GET',
+    `/v1/beliefs?userId=${encodeURIComponent(ctx.cfg.userId)}&limit=100`,
+  );
+  if (res.status === 404) {
+    return { status: 'skipped', detail: 'BELIEFS_API_ENABLED off (404)' };
+  }
+  const verdict = checkBelief(res.json?.beliefs ?? [], check);
+  return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
+}
+
+async function runHistoryCheck(ctx: CheckContext, check: FactHistoryCheck): Promise<Verdict> {
+  const hits = await searchHits(ctx, check.searchQuery, HISTORY_ENTITY_CAP);
+  if (hits.length === 0) {
+    return { status: 'fail', detail: 'search returned no candidate entities' };
+  }
+  // The transition may live on any of several extracted entities (the
+  // object, the speaker, …) — walk each candidate's timeline and pass
+  // on the first one whose fact.recorded events retain every stage in
+  // order; keep the deepest partial match as the fail detail.
+  let best: { matchedStages: number; detail: string } | null = null;
+  for (const hit of hits.slice(0, HISTORY_ENTITY_CAP)) {
+    const timeline = await callTool<TimelineOut>(ctx.mcp, 'get_entity_timeline', {
+      entityId: hit.entityId,
+      userId: ctx.cfg.userId,
+    });
+    const events: HistoryEvent[] = (timeline.events ?? [])
+      .filter((e) => e.type === 'fact.recorded')
+      .map((e) => ({ predicate: e.predicate ?? '', object: e.object ?? '', at: e.at }));
+    const verdict = checkHistorySequence(events, check.stages);
+    if (verdict.pass) {
+      return {
+        status: 'pass',
+        detail: `entity ${hit.canonicalName ?? hit.entityId}: ${verdict.detail}`,
+      };
+    }
+    if (best === null || verdict.matchedStages > best.matchedStages) {
+      best = {
+        matchedStages: verdict.matchedStages,
+        detail: `entity ${hit.canonicalName ?? hit.entityId}: ${verdict.detail}`,
+      };
+    }
+  }
+  return {
+    status: 'fail',
+    detail: `no entity timeline retains the full sequence; deepest: ${best?.detail ?? '(none)'}`,
+  };
+}
+
+async function runProvenanceCheck(ctx: CheckContext, check: ProvenanceCheck): Promise<Verdict> {
+  if (!ctx.tools.has('get_fact_provenance')) {
+    return { status: 'skipped', detail: 'get_fact_provenance absent (FACTS_API_ENABLED off)' };
+  }
+  const hits = await searchHits(ctx, check.searchQuery, 8);
+  const factIdsPerHit: string[][] = hits.map((hit) => {
+    const ids: string[] = [];
+    for (const fact of hit.facts ?? []) {
+      if (check.predicateHint !== undefined && check.predicateHint !== '') {
+        if (!fact.predicate.includes(check.predicateHint)) continue;
+      }
+      ids.push(fact.factId);
+    }
+    return ids;
+  });
+  // Round-robin across hits (hit1.fact1, hit2.fact1, …) so one fat
+  // entity cannot monopolise the walk budget — sibling interleave.ts.
+  const candidates = interleaveRoundRobin(factIdsPerHit, PROVENANCE_CANDIDATE_CAP);
+  if (candidates.length === 0) {
+    return { status: 'fail', detail: 'search returned no candidate facts' };
+  }
+  for (const factId of candidates) {
+    const prov = await callTool<ProvenanceOut>(ctx.mcp, 'get_fact_provenance', { factId });
+    const match = walkProvenance(prov, check.episodeFragments);
+    if (match !== null) {
+      return {
+        status: 'pass',
+        detail: `fact ${factId} unrolls to episode ${match.episodeId} ("${match.fragment}")`,
+      };
+    }
+  }
+  return {
+    status: 'fail',
+    detail: `${candidates.length} facts walked, no episode quotes a seeded fragment`,
+  };
+}
+
+async function runCheck(ctx: CheckContext, check: Check): Promise<Verdict> {
+  switch (check.kind) {
+    case 'serve':
+      return runServeCheck(ctx, check);
+    case 'belief':
+      return runBeliefCheck(ctx, check);
+    case 'fact-history':
+      return runHistoryCheck(ctx, check);
+    case 'provenance':
+      return runProvenanceCheck(ctx, check);
+  }
+}
+
+async function runScenario(ctx: CheckContext, scenario: Scenario): Promise<ScenarioResult> {
+  const results: CheckResult[] = [];
+  for (const check of scenario.checks) {
+    const started = Date.now();
+    let verdict: Verdict;
+    try {
+      verdict = await runCheck(ctx, check);
+    } catch (err) {
+      verdict = { status: 'fail', detail: `runner error: ${String(err)}` };
+    }
+    const latencyMs = Date.now() - started;
+    const result: CheckResult = {
+      id: check.id,
+      kind: check.kind,
+      status: verdict.status,
+      detail: verdict.detail,
+      latencyMs,
+      ...(verdict.answer !== undefined ? { answer: verdict.answer } : {}),
+      ...(check.knownFailToday !== undefined ? { knownFailToday: check.knownFailToday } : {}),
+    };
+    results.push(result);
+    const expectedNote =
+      verdict.status === 'fail' && check.knownFailToday !== undefined ? ' (expected today)' : '';
+    console.error(
+      `[check] ${check.id} (${check.kind}) ${verdict.status}${expectedNote} ` +
+        `${latencyMs}ms — ${verdict.detail}`,
+    );
+  }
+  const anyFail = results.some((r) => r.status === 'fail');
+  const anySkipped = results.some((r) => r.status === 'skipped');
+  const status: CheckStatus = anyFail ? 'fail' : anySkipped ? 'skipped' : 'pass';
+  return { key: scenario.key, name: scenario.name, cls: scenario.cls, status, checks: results };
+}
+
+// ── scorecard ───────────────────────────────────────────────────────
+
+const emptyTally = (): Tally => ({ pass: 0, fail: 0, skipped: 0 });
+
+function buildScorecard(
+  cfg: Config,
+  startedAt: string,
+  builds: Record<string, string>,
+  results: ScenarioResult[],
+): Scorecard {
+  const classes: Record<string, Tally> = {};
+  const checkKinds: Record<CheckKind, Tally> = {
+    serve: emptyTally(),
+    belief: emptyTally(),
+    'fact-history': emptyTally(),
+    provenance: emptyTally(),
+  };
+  const scenarios = { pass: 0, fail: 0, skipped: 0, total: results.length };
+  const checks = { pass: 0, fail: 0, skipped: 0, total: 0, failedExpectedToday: 0 };
+  for (const r of results) {
+    const cls = (classes[r.cls] ??= emptyTally());
+    cls[r.status] += 1;
+    scenarios[r.status] += 1;
+    for (const c of r.checks) {
+      checkKinds[c.kind][c.status] += 1;
+      checks[c.status] += 1;
+      checks.total += 1;
+      if (c.status === 'fail' && c.knownFailToday !== undefined) {
+        checks.failedExpectedToday += 1;
+      }
+    }
+  }
+  return {
+    runId: cfg.runId,
+    baseUrl: cfg.baseUrl,
+    companyId: cfg.companyId,
+    userId: cfg.userId,
+    guardrails: cfg.guardrails,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    ingest: { mentionTurns: cfg.skipIngest ? 0 : ALL_TURNS.length, builds },
+    classes,
+    checkKinds,
+    scenarios,
+    checks,
+    results,
+  };
+}
+
+function printScorecard(card: Scorecard): void {
+  console.log('');
+  console.log(`state-transitions scorecard — run ${card.runId} (guardrails=${card.guardrails})`);
+  console.log('─'.repeat(72));
+  for (const [cls, tally] of Object.entries(card.classes)) {
+    console.log(
+      `${cls.padEnd(22)} scenarios: pass ${tally.pass}  fail ${tally.fail}` +
+        (tally.skipped > 0 ? `  skipped ${tally.skipped}` : ''),
+    );
+  }
+  console.log('─'.repeat(72));
+  for (const [kind, tally] of Object.entries(card.checkKinds)) {
+    console.log(
+      `${kind.padEnd(22)} checks:    pass ${tally.pass}  fail ${tally.fail}` +
+        (tally.skipped > 0 ? `  skipped ${tally.skipped}` : ''),
+    );
+  }
+  console.log('─'.repeat(72));
+  const scoredScenarios = card.scenarios.pass + card.scenarios.fail;
+  const scoredChecks = card.checks.pass + card.checks.fail;
+  const pct = (pass: number, scored: number): number =>
+    scored === 0 ? 0 : Math.round((pass / scored) * 1000) / 10;
+  console.log(
+    `scenarios: ${card.scenarios.pass}/${scoredScenarios} scored ` +
+      `(${pct(card.scenarios.pass, scoredScenarios)}%), ` +
+      `${card.scenarios.skipped} skipped of ${card.scenarios.total}`,
+  );
+  console.log(
+    `checks:    ${card.checks.pass}/${scoredChecks} scored ` +
+      `(${pct(card.checks.pass, scoredChecks)}%), ` +
+      `${card.checks.skipped} skipped of ${card.checks.total}` +
+      (card.checks.failedExpectedToday > 0
+        ? ` — ${card.checks.failedExpectedToday} fail(s) expected on today's code (#135)`
+        : ''),
+  );
+}
+
+// ── main ────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  const startedAt = new Date().toISOString();
+  console.error(
+    `state-transitions: run ${cfg.runId} against ${cfg.baseUrl} (tenant ${cfg.companyId})`,
+  );
+
+  const brain = new HttpBrainClient({ baseUrl: cfg.baseUrl, apiKey: cfg.apiKey });
+  const mcp = await connectMcp(cfg);
+  try {
+    const toolList = await withRetry('tools/list', () => mcp.listTools());
+    const tools = new Set(toolList.tools.map((t) => t.name));
+    console.error(`[mcp] connected, ${tools.size} tools visible`);
+
+    let builds: Record<string, string> = { scenes: 'skipped: STEV_SKIP_INGEST' };
+    if (!cfg.skipIngest) {
+      await ingestTurns(cfg, brain);
+      builds = await runBuilds(cfg);
+    }
+
+    const ctx: CheckContext = { cfg, mcp, tools, builds };
+    const results: ScenarioResult[] = [];
+    for (const scenario of SCENARIOS) {
+      console.error(
+        `[scenario] ${scenario.key} ${scenario.name} (${scenario.checks.length} checks)`,
+      );
+      results.push(await runScenario(ctx, scenario));
+    }
+    const card = buildScorecard(cfg, startedAt, builds, results);
+
+    mkdirSync(cfg.reportDir, { recursive: true });
+    const reportPath = join(cfg.reportDir, `state-transitions-${cfg.runId}.json`);
+    writeFileSync(reportPath, `${JSON.stringify(card, null, 2)}\n`);
+    printScorecard(card);
+    console.log(`report: ${reportPath}`);
+  } finally {
+    await mcp.close();
+  }
+}
+
+void main().catch((err: unknown) => {
+  console.error('state-transitions: runner failed:', err);
+  process.exitCode = 1;
+});

--- a/test/eval/state-transitions/scenarios.ts
+++ b/test/eval/state-transitions/scenarios.ts
@@ -92,7 +92,12 @@ export const SCENARIOS: Scenario[] = [
         fieldTokens: ['bike', 'motorcycle', 'motorbike', 'vehicle'],
         valueMarkers: ['none', 'sold', 'no'],
         priorMarkers: ['Kawasaki', 'Ninja'],
-        minRevision: 2,
+        // minRevision is 1, not 2: when both scenes land in ONE promotion
+        // batch, buildBeliefFold folds them to the final state directly —
+        // rev=1 carrying value + priorValue. The value/prior pair is the
+        // mechanical signal of a completed transition; the revision
+        // counter only increments across separate promotion runs.
+        minRevision: 1,
         // Baseline policy: this check RUNS and its fail is RECORDED —
         // that is the baseline the flags below are measured against.
         knownFailToday:
@@ -139,7 +144,8 @@ export const SCENARIOS: Scenario[] = [
         fieldTokens: ['laptop'],
         valueMarkers: ['MacBook'],
         priorMarkers: ['ThinkPad'],
-        minRevision: 2,
+        // rev=1 is legitimate for a one-batch promotion (see s01 note).
+        minRevision: 1,
       },
       {
         kind: 'fact-history',
@@ -375,7 +381,8 @@ export const SCENARIOS: Scenario[] = [
         fieldTokens: ['city', 'residence', 'home', 'location', 'lives'],
         valueMarkers: ['Porto'],
         priorMarkers: ['Lisbon'],
-        minRevision: 2,
+        // rev=1 is legitimate for a one-batch promotion (see s01 note).
+        minRevision: 1,
         knownFailToday:
           '#135 SCENES_BELIEF_FIELD_FOLD — "home city" and "place of residence" fold into ' +
           'different free-text field keys, so no single belief carries value + priorValue',

--- a/test/eval/state-transitions/scenarios.ts
+++ b/test/eval/state-transitions/scenarios.ts
@@ -1,0 +1,547 @@
+/**
+ * The scenario battery: 12 mutable-world-state scenarios for ONE user
+ * ("Sasha", userId stev-agent). Each scenario owns its entity/object so
+ * scenarios cannot cross-contaminate, and declares 2-4 typed checks the
+ * runner executes after the builds (see types.ts for check semantics).
+ *
+ * Scoreability rules applied throughout (the sibling's D1 forbid-lesson
+ * plus the decline-regex interplay):
+ *
+ *  - prefer expectAnyOf on the CURRENT-state marker over forbidAnyOf on
+ *    the old value — "currently X, previously Y" is an honest answer;
+ *  - forbid only where naming the old value at all is an unambiguous
+ *    stale leak, and never with phrases a NEGATED honest answer would
+ *    contain ("you haven't sold it yet" contains 'sold it');
+ *  - never use bare 'no' / 'do not' / "don't" as expect markers: decline
+ *    answers contain them ("I do not have information…"), and 'now'
+ *    contains 'no'. Negative states are asserted through markers that
+ *    only occur in substantive answers: 'sold', 'returned', 'no longer',
+ *    'not own';
+ *  - every provenance fragment appears VERBATIM in exactly one seeded
+ *    turn, under the 600-char provenance text cap.
+ *
+ * Belief-check subjects accept any self-referring key ('Sasha' | 'user'
+ * | 'speaker') because the (subject, field) key is enrichment-authored
+ * free text; the discriminating half of those checks is field + value.
+ * The third-party scenario (s09) pins the subject to 'Boris' on purpose
+ * — subject attribution IS what it measures.
+ */
+import type { Scenario, ScenarioTurn } from './types';
+
+/** The vertical every scenario write attributes itself to. */
+export const CORPUS_VERTICAL = 'personal';
+
+/** The agent's own entity — first-person turns resolve to it. */
+export const SPEAKER = {
+  vertical: CORPUS_VERTICAL,
+  id: 'agent-sasha',
+  role: 'speaker',
+  name: 'Sasha',
+} as const;
+
+/** Anchor entity for the third-party scenario (s09). */
+export const BORIS_REF = { vertical: CORPUS_VERTICAL, id: 'brother-boris' } as const;
+
+/** Any self-referring belief subject counts (enrichment-authored key). */
+const SELF = ['Sasha', 'user', 'speaker'];
+
+/** Timestamp of turn N (1-based) — 5 minutes apart within a session. */
+const t = (startIso: string, turn: number): string =>
+  new Date(Date.parse(startIso) + (turn - 1) * 5 * 60_000).toISOString();
+
+const conv = (conversation: string, startIso: string, texts: string[]): ScenarioTurn[] =>
+  texts.map((text, i) => ({ conversation, turn: i + 1, emittedAt: t(startIso, i + 1), text }));
+
+export const SCENARIOS: Scenario[] = [
+  // ── s01 — dispose: owned thing sold, current truth is "none" ──────
+  {
+    key: 's01',
+    name: 'dispose',
+    cls: 'dispose',
+    intent:
+      'Acquire then dispose. Current truth is a NEGATION (no bike); the belief must flip to a none-ish value with the Kawasaki as priorValue.',
+    turns: [
+      ...conv('s01a', '2026-08-03T10:00:00Z', [
+        'Life log, 2026-08-03. Weekend update: there is a new vehicle in my life.',
+        "I bought a Kawasaki Ninja on Saturday — it's registered to me.",
+        'The Ninja lives in the garage; I plan to ride it to work on dry days.',
+      ]),
+      ...conv('s01b', '2026-08-10T17:00:00Z', [
+        'Life log, 2026-08-10. The motorcycle experiment is over.',
+        'I sold the Kawasaki today; no bike anymore.',
+        'The buyer picked it up this evening and the registration transfer is done.',
+      ]),
+    ],
+    checks: [
+      {
+        kind: 'serve',
+        id: 's01-serve',
+        query: 'Do I own a motorcycle right now?',
+        // Negative-state markers only occur in substantive answers; a
+        // pure decline never contains them, and marker-first scoring
+        // (scorers.ts) keeps the honest "you don't have a bike anymore"
+        // from being misread as abstention. No forbid list: 'Kawasaki'
+        // in the answer is honest history ("you sold the Kawasaki"),
+        // and there is no scoreable "Ninja-as-yours" phrase to forbid.
+        expectAnyOf: ['sold', 'no longer', 'do not own', "don't own", 'not own', 'no bike'],
+      },
+      {
+        kind: 'belief',
+        id: 's01-belief',
+        subjectTokens: SELF,
+        fieldTokens: ['bike', 'motorcycle', 'motorbike', 'vehicle'],
+        valueMarkers: ['none', 'sold', 'no'],
+        priorMarkers: ['Kawasaki', 'Ninja'],
+        minRevision: 2,
+        // Baseline policy: this check RUNS and its fail is RECORDED —
+        // that is the baseline the flags below are measured against.
+        knownFailToday:
+          '#135 SCENES_BELIEF_NEGATION_DELTAS — disposal ("no bike anymore") does not ' +
+          'reliably emit a stateDelta today, so the belief stays at the acquisition revision',
+      },
+    ],
+  },
+
+  // ── s02 — replace: same field, new value ──────────────────────────
+  {
+    key: 's02',
+    name: 'replace',
+    cls: 'replace',
+    intent:
+      'Clean same-field replacement (laptop): current truth flips, the belief carries value+priorValue, and the timeline retains both stages.',
+    turns: [
+      ...conv('s02a', '2026-08-04T09:00:00Z', [
+        'Work-setup log, 2026-08-04.',
+        'My work laptop is a ThinkPad X1 Carbon; it is the machine I do everything on.',
+      ]),
+      ...conv('s02b', '2026-08-12T09:00:00Z', [
+        'Work-setup log, 2026-08-12. Laptop swap day.',
+        'I replaced my laptop today: my work laptop is now a MacBook Pro, and the ThinkPad went back to IT.',
+        'Everything is migrated; the MacBook Pro is the only machine I work on now.',
+      ]),
+    ],
+    checks: [
+      {
+        kind: 'serve',
+        id: 's02-serve',
+        query: 'Which laptop do I use for work right now?',
+        expectAnyOf: ['MacBook'],
+        // Forbid IS justified here (unlike s08): the corpus states the
+        // ThinkPad went back to IT and the MacBook is "the only machine"
+        // — on a "right now" question any mention of the ThinkPad is a
+        // stale leak, the exact D1 semantics of the sibling.
+        forbidAnyOf: ['ThinkPad'],
+      },
+      {
+        kind: 'belief',
+        id: 's02-belief',
+        subjectTokens: SELF,
+        fieldTokens: ['laptop'],
+        valueMarkers: ['MacBook'],
+        priorMarkers: ['ThinkPad'],
+        minRevision: 2,
+      },
+      {
+        kind: 'fact-history',
+        id: 's02-history',
+        searchQuery: 'work laptop',
+        // Distinct values per stage — the easy case for object markers.
+        stages: [['ThinkPad'], ['MacBook']],
+      },
+    ],
+  },
+
+  // ── s03 — re-acquire: A -> not-A -> A again ───────────────────────
+  {
+    key: 's03',
+    name: 're-acquire',
+    cls: 're-acquire',
+    intent:
+      'Membership toggles twice (join / quit / rejoin). Current truth is the SECOND join; all three stages must survive in history.',
+    turns: [
+      ...conv('s03a', '2026-08-02T18:00:00Z', [
+        'Evening log, 2026-08-02.',
+        'I joined the chess club today; sessions are on Mondays.',
+      ]),
+      ...conv('s03b', '2026-08-09T18:00:00Z', [
+        'Evening log, 2026-08-09.',
+        'I quit the chess club today; Mondays got too busy at work.',
+      ]),
+      ...conv('s03c', '2026-08-20T18:00:00Z', [
+        'Evening log, 2026-08-20.',
+        'I rejoined the chess club today — they moved sessions to Thursdays, so I am a member again.',
+      ]),
+    ],
+    checks: [
+      {
+        kind: 'serve',
+        id: 's03-serve',
+        query: 'Am I currently a member of the chess club?',
+        // 'member' / 'rejoined' only occur when the final state is
+        // served; a stale "you quit the chess club" answer contains
+        // neither and fails on the expect side — no forbid needed
+        // ('quit' would false-fail the honest "you quit, then rejoined").
+        expectAnyOf: ['member', 'rejoined'],
+      },
+      {
+        kind: 'fact-history',
+        id: 's03-history',
+        searchQuery: 'chess club',
+        // Membership stages share one object ('chess club'), so markers
+        // match predicate+object combined and stay broad — extraction
+        // wording is LLM-chosen. Greedy subsequence matching keeps the
+        // 'join' ⊂ 'rejoined' overlap from eating the wrong stage: each
+        // stage scans only events after its predecessor's match.
+        stages: [
+          ['join', 'member'],
+          ['quit', 'left', 'no longer', 'former'],
+          ['rejoin', 'again', 'member'],
+        ],
+      },
+    ],
+  },
+
+  // ── s04 — retro-dated: told late, effective earlier ───────────────
+  {
+    key: 's04',
+    name: 'retro-dated',
+    cls: 'retro-dated',
+    intent:
+      'A cancellation reported two weeks after the fact ("back on August 1st"). Current truth must be "cancelled" and the claim must unroll to the seeded turn.',
+    turns: [
+      ...conv('s04a', '2026-08-15T12:00:00Z', [
+        'Subscriptions log, 2026-08-15. Going through my bank statement.',
+        'Turns out I actually cancelled my Spotify subscription back on August 1st.',
+        'So since the start of the month I have had no music subscription at all.',
+      ]),
+    ],
+    checks: [
+      {
+        kind: 'serve',
+        id: 's04-serve',
+        query: 'Do I have an active Spotify subscription?',
+        // Both spellings; 'no longer' / 'no subscription' cover answers
+        // that negate without the verb. Bare 'no' banned (see header).
+        expectAnyOf: ['cancelled', 'canceled', 'no longer', 'no subscription'],
+      },
+      {
+        kind: 'provenance',
+        id: 's04-prov',
+        searchQuery: 'Spotify subscription cancelled',
+        episodeFragments: ['cancelled my Spotify'],
+      },
+    ],
+  },
+
+  // ── s05 — intention-not-action: state must NOT flip ───────────────
+  {
+    key: 's05',
+    name: 'intention-not-action',
+    cls: 'non-transition-guard',
+    intent:
+      'A voiced intention ("thinking about selling") is NOT a transition: ownership must still serve as current, while the intention is remembered as an intention.',
+    turns: [
+      ...conv('s05a', '2026-08-01T11:00:00Z', [
+        'Hobby log, 2026-08-01.',
+        'I own a drone — a DJI Mavic 3 I bought last spring; I fly it most weekends.',
+      ]),
+      ...conv('s05b', '2026-08-05T11:00:00Z', [
+        'Hobby log, 2026-08-05.',
+        "I'm thinking about selling my drone, maybe next month.",
+        'No decision yet; I want to see what used Mavics go for first.',
+      ]),
+    ],
+    checks: [
+      {
+        kind: 'serve',
+        id: 's05-serve-state',
+        query: 'Do I still own a drone?',
+        // 'still' passes "you're still thinking about selling your
+        // drone" by design — it presupposes unchanged ownership. The
+        // forbid list stays minimal: 'sold'/'sold it' would false-fail
+        // the honest "you haven't sold it yet"; a wrong flipped answer
+        // ("you sold the drone") already fails on the expect side.
+        expectAnyOf: ['yes', 'you own', 'still', 'have a drone', 'have the drone', 'own the drone'],
+        forbidAnyOf: ['no longer own'],
+      },
+      {
+        kind: 'serve',
+        id: 's05-serve-intent',
+        query: 'What are my plans for the drone?',
+        // The other half of the guard: the intention itself must be
+        // remembered ('sell' ⊂ 'selling'), not dropped as noise.
+        expectAnyOf: ['sell'],
+      },
+    ],
+  },
+
+  // ── s06 — listed-not-sold: on the market is still owned ───────────
+  {
+    key: 's06',
+    name: 'listed-not-sold',
+    cls: 'non-transition-guard',
+    intent:
+      'Listing an apartment for sale is NOT a disposal: ownership must still serve as current.',
+    turns: [
+      ...conv('s06a', '2026-08-07T14:00:00Z', [
+        'Property log, 2026-08-07.',
+        'I listed my apartment in Riga for sale today.',
+        'The listing went live in the afternoon; the agent expects the first viewings next week.',
+      ]),
+    ],
+    checks: [
+      {
+        kind: 'serve',
+        id: 's06-serve',
+        query: 'Do I currently own the Riga apartment?',
+        // Scoped ownership markers ('you own', not bare 'own' — which
+        // hides in 'unknown'/'owner'). The task-suggested forbid 'sold
+        // it' was DROPPED: the honest "listed, but you haven't sold it
+        // yet" contains it. 'no longer own' is kept — it only occurs in
+        // a wrongly flipped answer.
+        expectAnyOf: ['yes', 'you own', 'still own', 'listed', 'for sale', 'on the market'],
+        forbidAnyOf: ['no longer own'],
+      },
+      {
+        kind: 'provenance',
+        id: 's06-prov',
+        searchQuery: 'apartment Riga for sale',
+        episodeFragments: ['listed my apartment in Riga'],
+      },
+    ],
+  },
+
+  // ── s07 — contradiction: two live sources disagree ────────────────
+  {
+    key: 's07',
+    name: 'contradiction',
+    cls: 'conflict',
+    intent:
+      'Two conversations assert different lease end dates. Honest serving names BOTH or abstains; silently picking one side is the failure.',
+    turns: [
+      ...conv('s07a', '2026-08-08T10:00:00Z', [
+        'Office log, 2026-08-08.',
+        'The office lease runs until December 2026. That is what our signed contract copy says.',
+      ]),
+      ...conv('s07b', '2026-08-14T10:00:00Z', [
+        'Office log, 2026-08-14. Surprise from the building manager.',
+        'Facilities says the office lease actually ends in September 2026.',
+        'I have not reconciled the two dates yet; someone is wrong and I need the original lease.',
+      ]),
+    ],
+    checks: [
+      {
+        kind: 'serve',
+        id: 's07-serve',
+        query: 'When does the office lease end?',
+        // classifyConflictAnswer semantics (sibling D6): both-sides or
+        // abstained pass, one-sided fails. Month names are the sides —
+        // unambiguous and phrasing-proof.
+        conflictSides: { sideA: ['December'], sideB: ['September'] },
+      },
+      {
+        kind: 'provenance',
+        id: 's07-prov',
+        searchQuery: 'office lease end date',
+        // Either side's seeded turn proves the claim unrolls verbatim.
+        episodeFragments: ['ends in September 2026', 'runs until December 2026'],
+      },
+    ],
+  },
+
+  // ── s08 — field-drift: same state, differently named field ────────
+  {
+    key: 's08',
+    name: 'field-drift',
+    cls: 'field-drift',
+    intent:
+      'The same underlying field is worded differently across conversations ("home city" vs "place of residence"). Serving must still flip; the belief fold is the known gap.',
+    turns: [
+      ...conv('s08a', '2026-08-03T19:00:00Z', [
+        'Relocation log, 2026-08-03.',
+        'My home city is Lisbon now.',
+      ]),
+      ...conv('s08b', '2026-08-18T19:00:00Z', [
+        'Relocation log, 2026-08-18. Another move, sooner than planned.',
+        'Moved my place of residence to Porto this week.',
+        'The Lisbon chapter is closed; from now on Porto is where I live.',
+      ]),
+    ],
+    checks: [
+      {
+        kind: 'belief',
+        id: 's08-belief',
+        subjectTokens: SELF,
+        fieldTokens: ['city', 'residence', 'home', 'location', 'lives'],
+        valueMarkers: ['Porto'],
+        priorMarkers: ['Lisbon'],
+        minRevision: 2,
+        knownFailToday:
+          '#135 SCENES_BELIEF_FIELD_FOLD — "home city" and "place of residence" fold into ' +
+          'different free-text field keys, so no single belief carries value + priorValue',
+      },
+      {
+        kind: 'serve',
+        id: 's08-serve',
+        query: 'Which city do I live in now?',
+        expectAnyOf: ['Porto'],
+        // "Lisbon-as-current" is not mechanically separable from the
+        // honest "moved from Lisbon to Porto", so no forbid (D1
+        // forbid-lesson): a wrong "Lisbon" answer already fails on the
+        // missing 'Porto'.
+      },
+    ],
+  },
+
+  // ── s09 — third-party: state of someone who is not the speaker ────
+  {
+    key: 's09',
+    name: 'third-party',
+    cls: 'third-party',
+    intent:
+      "Boris's company car is acquired and returned. The transition must attach to BORIS — subject attribution is the point of the belief check.",
+    turns: [
+      ...conv('s09a', '2026-08-09T13:00:00Z', [
+        'Family log, 2026-08-09.',
+        'My brother Boris got a company car from his employer.',
+      ]),
+      ...conv('s09b', '2026-08-16T13:00:00Z', [
+        'Family log, 2026-08-16.',
+        'Boris returned the company car when he switched jobs.',
+        'He starts at the new place on September 1st and will commute by train.',
+      ]),
+    ],
+    checks: [
+      {
+        kind: 'serve',
+        id: 's09-serve',
+        query: 'Does my brother Boris have a company car?',
+        // 'not have' was rejected: the decline "I do not have
+        // information about Boris" contains it (false pass). 'returned'
+        // is seeded verbatim and only occurs in a substantive answer.
+        expectAnyOf: ['returned', 'no longer', 'gave it back', 'not anymore'],
+      },
+      {
+        kind: 'belief',
+        id: 's09-belief',
+        // Subject pinned to Boris — misattributing the car to Sasha
+        // fails here even if serving happens to answer correctly.
+        subjectTokens: ['Boris'],
+        fieldTokens: ['car', 'vehicle'],
+        // Deliberately lenient on value (either state counts): this
+        // check measures third-party SUBJECT attribution, not the
+        // negation flip — s01 already measures that and is the known
+        // negation-delta baseline.
+        valueMarkers: ['company car', 'returned', 'none', 'car'],
+        minRevision: 1,
+      },
+    ],
+  },
+
+  // ── s10 — same-day: two transitions hours apart ───────────────────
+  {
+    key: 's10',
+    name: 'same-day',
+    cls: 'same-day',
+    intent:
+      'Acquire at 10:00, dispose at 18:00 the same day. Current truth is the evening state; history must order the two intra-day stages.',
+    turns: [
+      ...conv('s10a', '2026-08-11T10:00:00Z', [
+        'Home-office log, 2026-08-11, morning.',
+        'Signed up for the standing desk trial this morning.',
+      ]),
+      ...conv('s10b', '2026-08-11T18:00:00Z', [
+        'Home-office log, 2026-08-11, evening. That did not last long.',
+        'Returned the standing desk by evening — hurt my back.',
+      ]),
+    ],
+    checks: [
+      {
+        kind: 'serve',
+        id: 's10-serve',
+        query: 'Do I still have the standing desk?',
+        expectAnyOf: ['returned', 'sent it back', 'no longer'],
+      },
+      {
+        kind: 'fact-history',
+        id: 's10-history',
+        searchQuery: 'standing desk',
+        // Hour-resolution ordering: both stages carry the same date and
+        // differ only by time of day.
+        stages: [
+          ['signed up', 'sign up', 'trial', 'started'],
+          ['returned', 'sent back', 'return'],
+        ],
+      },
+    ],
+  },
+
+  // ── s11 — multi-object: one of two disposed, the other kept ───────
+  {
+    key: 's11',
+    name: 'multi-object',
+    cls: 'multi-object',
+    intent:
+      'Two cameras; one is sold. The kept object must serve as current and the sold one as gone — WITHOUT forbidding the sold name (the honest recap names it).',
+    turns: [
+      ...conv('s11a', '2026-08-06T15:00:00Z', [
+        'Photography log, 2026-08-06.',
+        'I keep two cameras: a Fuji X100 and a Canon R6.',
+      ]),
+      ...conv('s11b', '2026-08-19T15:00:00Z', [
+        'Photography log, 2026-08-19. Gear cull.',
+        'Sold the Canon R6; the Fuji stays.',
+        'One camera is enough — the X100 covers everything I actually shoot.',
+      ]),
+    ],
+    checks: [
+      {
+        kind: 'serve',
+        id: 's11-serve-kept',
+        query: 'Which cameras do I have now?',
+        // forbidAnyOf ['Canon R6'] would be WRONG: the honest answer
+        // "just the Fuji — you sold the Canon R6" names it. The Fuji
+        // marker carries this check; the sold-object side is asserted
+        // by the second, directly-scoped serve below.
+        expectAnyOf: ['Fuji'],
+      },
+      {
+        kind: 'serve',
+        id: 's11-serve-sold',
+        query: 'Do I still have the Canon R6?',
+        // Bare 'no' banned ('now' contains 'no'); 'sold' is seeded
+        // verbatim and unambiguous on this directly-scoped question.
+        expectAnyOf: ['sold', 'no longer', 'not anymore'],
+      },
+    ],
+  },
+
+  // ── s12 — provenance of the transition itself (reuses s01 data) ───
+  {
+    key: 's12',
+    name: 'provenance-of-transition',
+    cls: 'provenance',
+    intent:
+      'Both endpoints of the s01 transition unroll to their seeded turns: the state flip is evidence-backed, not asserted.',
+    turns: [], // deliberately empty — interrogates the s01 corpus
+    checks: [
+      {
+        kind: 'provenance',
+        id: 's12-prov-sold',
+        searchQuery: 'Kawasaki motorcycle sold',
+        episodeFragments: ['sold the Kawasaki'],
+      },
+      {
+        kind: 'provenance',
+        id: 's12-prov-bought',
+        searchQuery: 'Kawasaki Ninja bought',
+        episodeFragments: ['bought a Kawasaki Ninja'],
+      },
+    ],
+  },
+];
+
+/** All mention turns across scenarios, sorted chronologically. */
+export const ALL_TURNS: ScenarioTurn[] = SCENARIOS.flatMap((s) => s.turns).sort((a, b) =>
+  a.emittedAt.localeCompare(b.emittedAt),
+);

--- a/test/eval/state-transitions/scorers.ts
+++ b/test/eval/state-transitions/scorers.ts
@@ -1,0 +1,223 @@
+/**
+ * Mechanical scorers of the state-transition battery. Pure functions
+ * over plain JSON — no HTTP, no LLM judge — unit-tested on fixtures in
+ * test/state-transition-scorers.unit-spec.ts, so every verdict is
+ * reproducible from the report file.
+ *
+ * Generic primitives (containsAnyOf / findForbidden / isAbstention /
+ * walkProvenance / classifyConflictAnswer) are REUSED from the sibling
+ * harness (test/eval/memory-fitness/scorers.ts) — one implementation,
+ * one unit-tested truth. This file adds only what state transitions
+ * need: the belief matcher, the N-stage history subsequence, and the
+ * marker-first serve verdict.
+ */
+import {
+  classifyConflictAnswer,
+  containsAnyOf,
+  findForbidden,
+  isAbstention,
+} from '../memory-fitness/scorers';
+import type { BeliefCheck, ServeCheck } from './types';
+
+export interface Verdict {
+  pass: boolean;
+  detail: string;
+}
+
+// ── belief matcher ──────────────────────────────────────────────────
+
+/** The belief fields the matcher consumes (subset of BeliefReadResponse). */
+export interface BeliefLike {
+  subject: string;
+  field: string;
+  value: string;
+  priorValue?: string;
+  revision?: number;
+}
+
+const describeBelief = (b: BeliefLike): string =>
+  `(${b.subject}, ${b.field}) value="${b.value}"` +
+  (b.priorValue !== undefined ? ` prior="${b.priorValue}"` : ' prior=absent') +
+  (b.revision !== undefined ? ` rev=${b.revision}` : '');
+
+/**
+ * Belief check: among the beliefs whose free-text (subject, field) key
+ * matches the token filters, at least one satisfies every declared
+ * constraint (value markers, prior markers / prior absence, minimum
+ * revision). Token filters are anyOf-substring because the (subject,
+ * field) key is enrichment-authored free text, not a fixed vocabulary.
+ * A fail names the closest candidate so the report is diagnosable.
+ */
+export function checkBelief(
+  beliefs: readonly BeliefLike[],
+  spec: Pick<
+    BeliefCheck,
+    | 'subjectTokens'
+    | 'fieldTokens'
+    | 'valueMarkers'
+    | 'priorMarkers'
+    | 'priorAbsent'
+    | 'minRevision'
+  >,
+): Verdict {
+  const candidates = beliefs.filter(
+    (b) => containsAnyOf(b.subject, spec.subjectTokens) && containsAnyOf(b.field, spec.fieldTokens),
+  );
+  if (candidates.length === 0) {
+    return {
+      pass: false,
+      detail:
+        `no belief matches subject~[${spec.subjectTokens.join('|')}] ` +
+        `field~[${spec.fieldTokens.join('|')}] among ${beliefs.length} read`,
+    };
+  }
+  for (const b of candidates) {
+    if (spec.valueMarkers !== undefined && !containsAnyOf(b.value, spec.valueMarkers)) continue;
+    if (spec.priorMarkers !== undefined) {
+      if (b.priorValue === undefined) continue;
+      if (!containsAnyOf(b.priorValue, spec.priorMarkers)) continue;
+    }
+    if (spec.priorAbsent === true && b.priorValue !== undefined) continue;
+    if (spec.minRevision !== undefined && (b.revision ?? 0) < spec.minRevision) continue;
+    return { pass: true, detail: `belief ${describeBelief(b)} satisfies every constraint` };
+  }
+  const closest = candidates[0];
+  return {
+    pass: false,
+    detail:
+      `${candidates.length} candidate belief(s) matched the key but none the constraints; ` +
+      `closest: ${closest !== undefined ? describeBelief(closest) : '(none)'}`,
+  };
+}
+
+// ── fact-history subsequence ────────────────────────────────────────
+
+/** One timeline event as the history checker consumes it. */
+export interface HistoryEvent {
+  predicate: string;
+  object: string;
+  /** ISO timestamp the event was recorded at. */
+  at: string;
+}
+
+export interface HistoryVerdict extends Verdict {
+  /** How many stages were consumed — lets the runner keep the best fail. */
+  matchedStages: number;
+}
+
+/**
+ * N-stage history check (generalised from the sibling's checkEvolution):
+ * the timeline must contain, as a chronological SUBSEQUENCE of
+ * fact.recorded events, one event per stage in stage order. Matching is
+ * greedy over the sorted events and a stage marker is matched against
+ * the combined `${predicate} ${object}` text, because mention-extracted
+ * predicates are LLM-worded and cannot be pinned exactly.
+ *
+ * Greedy subsequence (not first-match-per-stage) avoids the false fail
+ * where a late stage's marker also matches an early event: each stage
+ * only scans events AFTER its predecessor's match.
+ */
+export function checkHistorySequence(
+  events: readonly HistoryEvent[],
+  stages: ReadonlyArray<readonly string[]>,
+): HistoryVerdict {
+  const sorted = [...events].sort((a, b) => a.at.localeCompare(b.at));
+  const matched: string[] = [];
+  let cursor = 0;
+  for (const [i, stage] of stages.entries()) {
+    let found = false;
+    while (cursor < sorted.length) {
+      const ev = sorted[cursor];
+      cursor += 1;
+      if (ev !== undefined && containsAnyOf(`${ev.predicate} ${ev.object}`, stage)) {
+        matched.push(`${ev.predicate}="${ev.object}"@${ev.at}`);
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return {
+        pass: false,
+        matchedStages: i,
+        detail:
+          `stage ${i + 1}/${stages.length} [${stage.join('|')}] not found after ` +
+          `${matched.length > 0 ? matched[matched.length - 1] : 'start'} ` +
+          `(${sorted.length} recorded events scanned)`,
+      };
+    }
+  }
+  return {
+    pass: true,
+    matchedStages: stages.length,
+    detail: `history retains all ${stages.length} stages in order: ${matched.join(' -> ')}`,
+  };
+}
+
+// ── serve verdict ───────────────────────────────────────────────────
+
+export interface ServeVerdict {
+  status: 'pass' | 'fail';
+  detail: string;
+}
+
+/**
+ * Serve check verdict. Semantics, in order:
+ *
+ *  1. conflict mode — classifyConflictAnswer: both-sides or abstained
+ *     pass; one-sided / neither fail (scenario 7);
+ *  2. expectAbstain — pass iff the answer is an abstention;
+ *  3. forbidden markers — any hit fails FIRST (an answer naming both
+ *     the current and the forbidden value is a stale leak, sibling D1);
+ *  4. expect markers — pass on ≥1 hit. Deliberately checked BEFORE the
+ *     abstention detector: the honest answer to a disposal question
+ *     ("you don't have a bike anymore — you sold it") trips the shared
+ *     decline regex, so abstention alone must not fail a serve whose
+ *     expected truth IS a negation. Expect markers are authored to
+ *     never occur in decline phrasings ('sold', 'no longer', 'not own'
+ *     — never bare 'no' / 'do not', which decline answers contain).
+ */
+export function scoreServe(
+  answer: string | null | undefined,
+  reason: string | undefined,
+  spec: Pick<ServeCheck, 'expectAnyOf' | 'forbidAnyOf' | 'expectAbstain' | 'conflictSides'>,
+): ServeVerdict {
+  if (spec.conflictSides !== undefined) {
+    const verdict = classifyConflictAnswer(
+      answer,
+      spec.conflictSides.sideA,
+      spec.conflictSides.sideB,
+      reason,
+    );
+    switch (verdict) {
+      case 'both-sides':
+        return { status: 'pass', detail: 'answer names both sides of the conflict' };
+      case 'abstained':
+        return { status: 'pass', detail: 'abstained rather than pick a side silently' };
+      case 'one-sided':
+        return { status: 'fail', detail: 'served one side of a live conflict' };
+      case 'neither':
+        return { status: 'fail', detail: 'answer names neither side' };
+    }
+  }
+  if (spec.expectAbstain === true) {
+    return isAbstention(answer, reason)
+      ? { status: 'pass', detail: 'honest abstention' }
+      : { status: 'fail', detail: 'expected abstention, got an answer' };
+  }
+  const text = answer ?? '';
+  const forbidden = findForbidden(text, spec.forbidAnyOf ?? []);
+  if (forbidden !== null) {
+    return { status: 'fail', detail: `forbidden marker served: "${forbidden}"` };
+  }
+  const expected = spec.expectAnyOf === undefined || containsAnyOf(text, spec.expectAnyOf);
+  if (expected) {
+    return { status: 'pass', detail: 'current-state marker served, no forbidden marker' };
+  }
+  if (isAbstention(answer, reason)) {
+    return { status: 'fail', detail: 'abstained on a known state' };
+  }
+  return {
+    status: 'fail',
+    detail: `expected one of [${(spec.expectAnyOf ?? []).join(', ')}]`,
+  };
+}

--- a/test/eval/state-transitions/types.ts
+++ b/test/eval/state-transitions/types.ts
@@ -1,0 +1,168 @@
+/**
+ * Shared shapes of the state-transition battery — the mechanical sibling
+ * of test/eval/memory-fitness. Where memory-fitness measures general
+ * first-person memory fitness (eight dimensions over one corpus), this
+ * battery isolates ONE claim: memory tracks a mutable world-state.
+ * Each scenario seeds a state transition (or a deliberate NON-transition)
+ * for its own entity and declares 2-4 typed checks the runner executes
+ * after the builds. Every check is mechanical — no LLM judge.
+ */
+
+/** One first-person mention turn a scenario writes into memory. */
+export interface ScenarioTurn {
+  /** Conversation key (`s01a`…) — the runner prefixes it with the run id. */
+  conversation: string;
+  /** 1-based position inside the conversation (drives the messageId). */
+  turn: number;
+  /** ISO 8601 emission timestamp — the temporal anchor of the turn. */
+  emittedAt: string;
+  /** Verbatim first-person text. Kept under the 600-char provenance cap. */
+  text: string;
+}
+
+/**
+ * `belief` — the promoted semantic belief for a (subject, field) key
+ * carries the expected current value, prior value and revision depth.
+ * Read via GET /v1/beliefs?userId=… (BELIEFS_API_ENABLED).
+ */
+export interface BeliefCheck {
+  kind: 'belief';
+  id: string;
+  /** Belief.subject must contain ≥1 of these (case-insensitive). */
+  subjectTokens: string[];
+  /** Belief.field must contain ≥1 of these (case-insensitive). */
+  fieldTokens: string[];
+  /** When present: belief.value must contain ≥1 of these. */
+  valueMarkers?: string[];
+  /** When present: priorValue must EXIST and contain ≥1 of these. */
+  priorMarkers?: string[];
+  /** When true: priorValue must be absent (a first-revision belief). */
+  priorAbsent?: boolean;
+  /** When present: belief.revision must be >= this. */
+  minRevision?: number;
+  /** Baseline annotation: this check is expected to FAIL on today's code. */
+  knownFailToday?: string;
+}
+
+/**
+ * `fact-history` — the entity timeline retains every stage of the
+ * transition as `fact.recorded` events, in emission order. Stages are
+ * matched greedily as a subsequence over `${predicate} ${object}` so a
+ * later stage never has to compete with an earlier event (the sibling's
+ * checkEvolution idea, generalised to N stages and free predicates).
+ */
+export interface FactHistoryCheck {
+  kind: 'fact-history';
+  id: string;
+  /** search_knowledge query used to find candidate entities. */
+  searchQuery: string;
+  /** Ordered stages; each stage is an anyOf marker group. */
+  stages: string[][];
+  knownFailToday?: string;
+}
+
+/**
+ * `serve` — synthesize serves CURRENT truth. Marker semantics follow
+ * the sibling's D1 forbid-lesson: prefer expectAnyOf on the current
+ * marker; use forbidAnyOf only where naming the old value at all is an
+ * unambiguous stale leak. Scoring is marker-FIRST: an honest negative
+ * answer ("you don't have a bike anymore") trips the shared decline
+ * regex, so abstention only fails a serve when no expect marker hit.
+ */
+export interface ServeCheck {
+  kind: 'serve';
+  id: string;
+  query: string;
+  /** Pass requires ≥1 of these in the answer (unless conflictSides). */
+  expectAnyOf?: string[];
+  /** Any of these in the answer fails the check (checked first). */
+  forbidAnyOf?: string[];
+  /** Pass iff the answer is an abstention (never combined with expect). */
+  expectAbstain?: boolean;
+  /**
+   * Conflict mode (scenario 7): honest behaviours are naming BOTH sides
+   * or abstaining — the sibling's classifyConflictAnswer semantics.
+   */
+  conflictSides?: { sideA: string[]; sideB: string[] };
+  knownFailToday?: string;
+}
+
+/**
+ * `provenance` — a fact about the transitioned state unrolls to an
+ * episode quoting a seeded fragment verbatim (the sibling's
+ * walkProvenance over get_fact_provenance).
+ */
+export interface ProvenanceCheck {
+  kind: 'provenance';
+  id: string;
+  searchQuery: string;
+  /** Prefer facts whose predicate contains this substring, else any hit. */
+  predicateHint?: string;
+  /** Case-insensitive fragments seeded verbatim in the scenario turns. */
+  episodeFragments: string[];
+  knownFailToday?: string;
+}
+
+export type Check = BeliefCheck | FactHistoryCheck | ServeCheck | ProvenanceCheck;
+export type CheckKind = Check['kind'];
+
+/** One scenario: its own entity/object, its turns, its checks. */
+export interface Scenario {
+  /** Stable key (`s01`…) used in conversation ids and the report. */
+  key: string;
+  /** Human name of the transition mechanic under test. */
+  name: string;
+  /** Scenario class — the scorecard groups by this. */
+  cls: string;
+  /** What the scenario seeds and what would falsify the claim. */
+  intent: string;
+  turns: ScenarioTurn[];
+  checks: Check[];
+}
+
+export type CheckStatus = 'pass' | 'fail' | 'skipped';
+
+export interface CheckResult {
+  id: string;
+  kind: CheckKind;
+  status: CheckStatus;
+  detail: string;
+  latencyMs: number;
+  /** Raw served answer, when the check was answer-shaped. */
+  answer?: string | null;
+  /** Carried through from the check: expected to fail on today's code. */
+  knownFailToday?: string;
+}
+
+export interface ScenarioResult {
+  key: string;
+  name: string;
+  cls: string;
+  /** pass = ALL checks passed; skipped = no fail but ≥1 skipped. */
+  status: CheckStatus;
+  checks: CheckResult[];
+}
+
+export interface Tally {
+  pass: number;
+  fail: number;
+  skipped: number;
+}
+
+export interface Scorecard {
+  runId: string;
+  baseUrl: string;
+  companyId: string;
+  userId: string;
+  guardrails: string;
+  startedAt: string;
+  finishedAt: string;
+  ingest: { mentionTurns: number; builds: Record<string, string> };
+  /** Per-scenario-class tally (of scenarios). */
+  classes: Record<string, Tally>;
+  /** Per-check-kind tally (of checks). */
+  checkKinds: Record<CheckKind, Tally>;
+  scenarios: { pass: number; fail: number; skipped: number; total: number };
+  checks: Tally & { total: number; failedExpectedToday: number };
+  results: ScenarioResult[];
+}

--- a/test/state-transition-scorers.unit-spec.ts
+++ b/test/state-transition-scorers.unit-spec.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit sanity for the state-transition scorers (test/eval/
+ * state-transitions/scorers.ts) — the mechanical judges of the battery.
+ * Pure fixtures, no HTTP: if these are wrong, every scorecard is wrong,
+ * so they get their own spec even though the battery itself never runs
+ * in CI. The generic primitives the battery reuses (containsAnyOf,
+ * isAbstention, walkProvenance, …) are covered by the sibling's
+ * test/memory-fitness-scorers.unit-spec.ts.
+ */
+import {
+  checkBelief,
+  checkHistorySequence,
+  scoreServe,
+  type BeliefLike,
+  type HistoryEvent,
+} from './eval/state-transitions/scorers';
+
+describe('state-transition scorers', () => {
+  describe('belief matcher', () => {
+    const beliefs: BeliefLike[] = [
+      {
+        subject: 'Sasha',
+        field: 'work laptop',
+        value: 'MacBook Pro',
+        priorValue: 'ThinkPad X1 Carbon',
+        revision: 2,
+      },
+      { subject: 'Sasha', field: 'home city', value: 'Lisbon', revision: 1 },
+      { subject: 'Boris', field: 'company car', value: 'returned', revision: 2 },
+    ];
+
+    it('passes on value + prior + revision for the matching (subject, field) key', () => {
+      const v = checkBelief(beliefs, {
+        subjectTokens: ['Sasha', 'user'],
+        fieldTokens: ['laptop'],
+        valueMarkers: ['MacBook'],
+        priorMarkers: ['ThinkPad'],
+        minRevision: 2,
+      });
+      expect(v.pass).toBe(true);
+      expect(v.detail).toContain('work laptop');
+    });
+
+    it('fails when no belief matches the (subject, field) token filters', () => {
+      const v = checkBelief(beliefs, {
+        subjectTokens: ['Sasha'],
+        fieldTokens: ['motorcycle', 'bike'],
+        valueMarkers: ['none'],
+      });
+      expect(v.pass).toBe(false);
+      expect(v.detail).toMatch(/no belief matches/);
+    });
+
+    it('fails naming the closest candidate when constraints miss', () => {
+      // The field-drift baseline: the belief exists but never revised,
+      // so priorValue is absent and revision is stuck at 1.
+      const v = checkBelief(beliefs, {
+        subjectTokens: ['Sasha'],
+        fieldTokens: ['city', 'residence'],
+        valueMarkers: ['Porto'],
+        priorMarkers: ['Lisbon'],
+        minRevision: 2,
+      });
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('value="Lisbon"');
+      expect(v.detail).toContain('prior=absent');
+    });
+
+    it('requires priorValue to EXIST when priorMarkers are declared', () => {
+      const v = checkBelief(beliefs, {
+        subjectTokens: ['Sasha'],
+        fieldTokens: ['city'],
+        valueMarkers: ['Lisbon'],
+        priorMarkers: ['Porto'],
+      });
+      expect(v.pass).toBe(false);
+    });
+
+    it('supports priorAbsent for first-revision beliefs', () => {
+      const ok = checkBelief(beliefs, {
+        subjectTokens: ['Sasha'],
+        fieldTokens: ['city'],
+        valueMarkers: ['Lisbon'],
+        priorAbsent: true,
+      });
+      expect(ok.pass).toBe(true);
+      const notAbsent = checkBelief(beliefs, {
+        subjectTokens: ['Sasha'],
+        fieldTokens: ['laptop'],
+        priorAbsent: true,
+      });
+      expect(notAbsent.pass).toBe(false);
+    });
+
+    it('enforces minRevision', () => {
+      const v = checkBelief(beliefs, {
+        subjectTokens: ['Boris'],
+        fieldTokens: ['car'],
+        minRevision: 3,
+      });
+      expect(v.pass).toBe(false);
+      expect(v.detail).toMatch(/none the constraints/);
+    });
+
+    it('pins third-party subjects — a speaker-attributed belief does not count', () => {
+      const misattributed: BeliefLike[] = [
+        { subject: 'Sasha', field: 'company car', value: 'returned', revision: 2 },
+      ];
+      const v = checkBelief(misattributed, {
+        subjectTokens: ['Boris'],
+        fieldTokens: ['car'],
+      });
+      expect(v.pass).toBe(false);
+    });
+  });
+
+  describe('history subsequence', () => {
+    const events: HistoryEvent[] = [
+      { predicate: 'joined', object: 'chess club', at: '2026-08-02T18:05:00Z' },
+      { predicate: 'quit', object: 'chess club', at: '2026-08-09T18:05:00Z' },
+      { predicate: 'rejoined', object: 'chess club', at: '2026-08-20T18:05:00Z' },
+    ];
+
+    it('passes when every stage is retained in order', () => {
+      const v = checkHistorySequence(events, [['join'], ['quit', 'left'], ['rejoin', 'again']]);
+      expect(v.pass).toBe(true);
+      expect(v.matchedStages).toBe(3);
+    });
+
+    it('greedy matching survives marker overlap (join ⊂ rejoined)', () => {
+      // Stage 1 consumes the FIRST 'join' match (the 2026-08-02 event),
+      // leaving the rejoin event for stage 3 — first-match-per-stage
+      // scoring would break on exactly this fixture.
+      const v = checkHistorySequence(events, [['join'], ['quit'], ['join']]);
+      expect(v.pass).toBe(true);
+    });
+
+    it('fails when a stage was garbage-collected', () => {
+      const noQuit = events.filter((e) => e.predicate !== 'quit');
+      const v = checkHistorySequence(noQuit, [['join'], ['quit'], ['rejoin']]);
+      expect(v.pass).toBe(false);
+      expect(v.matchedStages).toBe(1);
+      expect(v.detail).toMatch(/stage 2\/3/);
+    });
+
+    it('fails when history orders stages backwards', () => {
+      const flipped: HistoryEvent[] = [
+        { predicate: 'owns', object: 'MacBook Pro', at: '2026-08-04T09:00:00Z' },
+        { predicate: 'owns', object: 'ThinkPad X1', at: '2026-08-12T09:00:00Z' },
+      ];
+      const v = checkHistorySequence(flipped, [['ThinkPad'], ['MacBook']]);
+      expect(v.pass).toBe(false);
+    });
+
+    it('orders same-day events by time of day', () => {
+      const sameDay: HistoryEvent[] = [
+        { predicate: 'returned', object: 'standing desk', at: '2026-08-11T18:05:00Z' },
+        { predicate: 'signed_up', object: 'standing desk trial', at: '2026-08-11T10:05:00Z' },
+      ];
+      const v = checkHistorySequence(sameDay, [['signed', 'trial'], ['returned']]);
+      expect(v.pass).toBe(true);
+    });
+
+    it('matches markers against predicate and object combined', () => {
+      const v = checkHistorySequence(
+        [{ predicate: 'membership_status', object: 'chess club', at: '2026-08-02T18:05:00Z' }],
+        [['member']],
+      );
+      expect(v.pass).toBe(true);
+    });
+  });
+
+  describe('serve verdict', () => {
+    it('passes an honest negative answer that trips the decline regex', () => {
+      // "don't have" matches the shared ABSTAIN_RE — marker-first
+      // scoring must still pass it, because the expected truth IS a
+      // negation (the dispose scenario).
+      const v = scoreServe("You don't have a bike anymore — you sold the Kawasaki.", undefined, {
+        expectAnyOf: ['sold', 'no longer', 'not own'],
+      });
+      expect(v.status).toBe('pass');
+    });
+
+    it('fails a pure abstention on a known state', () => {
+      const v = scoreServe("I don't have grounded evidence for that.", undefined, {
+        expectAnyOf: ['sold', 'no longer', 'not own'],
+      });
+      expect(v.status).toBe('fail');
+      expect(v.detail).toMatch(/abstained/);
+    });
+
+    it('forbidden marker wins even when an expect marker is present', () => {
+      const v = scoreServe('Your laptop is a MacBook Pro, formerly a ThinkPad.', undefined, {
+        expectAnyOf: ['MacBook'],
+        forbidAnyOf: ['ThinkPad'],
+      });
+      expect(v.status).toBe('fail');
+      expect(v.detail).toMatch(/forbidden marker/);
+    });
+
+    it('fails a substantive answer that misses every expect marker', () => {
+      const v = scoreServe('You quit the chess club on August 9th.', undefined, {
+        expectAnyOf: ['member', 'rejoined'],
+      });
+      expect(v.status).toBe('fail');
+      expect(v.detail).toMatch(/expected one of/);
+    });
+
+    it('conflict mode passes both-sides and abstention, fails one-sided', () => {
+      const sides = { conflictSides: { sideA: ['December'], sideB: ['September'] } };
+      expect(
+        scoreServe('Sources disagree: December 2026 vs September 2026.', undefined, sides).status,
+      ).toBe('pass');
+      expect(scoreServe(null, undefined, sides).status).toBe('pass');
+      expect(scoreServe('The lease ends in December 2026.', undefined, sides).status).toBe('fail');
+      expect(scoreServe('The lease ends next year.', undefined, sides).status).toBe('fail');
+    });
+
+    it('expectAbstain passes only on abstention', () => {
+      expect(scoreServe(null, 'no_facts', { expectAbstain: true }).status).toBe('pass');
+      expect(scoreServe('The answer is 42.', undefined, { expectAbstain: true }).status).toBe(
+        'fail',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

A mechanical **state-transition eval battery** — sibling of the memory-fitness harness (`test/eval/memory-fitness`) — under `test/eval/state-transitions/`, wired as `pnpm eval:state-transitions`. It measures the system's core claim in isolation: memory tracks a **mutable world-state** (belief `value` / `priorValue` / `revision`), keeps history (superseded facts survive on the timeline), and serves **current** truth. Every check is mechanical — no LLM judge; the only model spend is the stand's own serving cost (52 mention turns of ingest + 13 `synthesize` calls per run).

Architecture mirrors the sibling exactly: same env contract (`BRAIN_BASE_URL` / `BRAIN_API_KEY` / `BRAIN_COMPANY_ID`, `STEV_`-prefixed knobs), same wire (`HttpBrainClient` REST + MCP Streamable HTTP), run-scoped conversation ids, ingest → builds (`scenes` → `scenes/backlink` → `scenes/beliefs`, best-effort with explicit skip semantics) → checks → JSON scorecard in `var/state-transitions/`. Generic scorers (`containsAnyOf` / `findForbidden` / `isAbstention` / `walkProvenance` / `classifyConflictAnswer`) and the provenance candidate interleave are **reused from the sibling**, not duplicated; the new pure scorers are unit-tested in `test/state-transition-scorers.unit-spec.ts`. Never run in CI (guarded on `BRAIN_BASE_URL` with the sibling's helpful-error idiom).

## Scenario taxonomy (12 scenarios, one user `stev-agent`, each with its own entity)

| # | Scenario | Class | What would falsify the claim |
| --- | --- | --- | --- |
| s01 | dispose | dispose | "no bike anymore" not reflected; belief stuck at acquisition |
| s02 | replace | replace | old laptop served as current; history loses a stage |
| s03 | re-acquire | re-acquire | join → quit → rejoin collapses; final state wrong |
| s04 | retro-dated | retro-dated | a cancellation reported late is not current truth |
| s05 | intention-not-action | non-transition-guard | "thinking about selling" flips ownership |
| s06 | listed-not-sold | non-transition-guard | listing for sale treated as a disposal |
| s07 | contradiction | conflict | one side of a live conflict served silently |
| s08 | field-drift | field-drift | "home city" vs "place of residence" split the belief key |
| s09 | third-party | third-party | Boris's transition misattributed to the speaker |
| s10 | same-day | same-day | two intra-day transitions collapse or reorder |
| s11 | multi-object | multi-object | selling one of two objects loses (or keeps) the wrong one |
| s12 | provenance-of-transition | provenance | the flip is asserted without unrolling to the seeded turns |

Score = per-scenario pass (ALL of its 2-4 checks pass) + per-check-kind tally; the scorecard groups scenarios by class.

## Check semantics (4 kinds, all mechanical)

- **`serve`** — MCP `synthesize` (strict guardrails by default), scored by `expectAnyOf` / `forbidAnyOf`, a conflict mode (sideA/sideB via the sibling's `classifyConflictAnswer`: both-sides or abstention pass), and `expectAbstain`.
- **`belief`** — `GET /v1/beliefs?userId=…`: a belief matching anyOf-substring (subject, field) token filters carries the expected `value`, `priorValue` (or its absence) and `revision >= N`. Token filters, not exact keys — the (subject, field) key is enrichment-authored free text.
- **`fact-history`** — `search_knowledge` → `get_entity_timeline`: the `fact.recorded` events retain every transition stage as a **chronological greedy subsequence** (the sibling's `checkEvolution` generalised to N stages; markers match `predicate + object` combined because mention-extracted predicates are LLM-worded). Greedy matching survives marker overlap (`'join'` ⊂ `'rejoined'`) — unit-tested on exactly that fixture.
- **`provenance`** — `search_knowledge` → `get_fact_provenance` walk (round-robin interleaved across hits, capped): an episode quotes a seeded fragment verbatim (`'sold the Kawasaki'`, `'cancelled my Spotify'`, …).

## Expected-fail baseline policy

Two belief checks are **expected to fail on today's code** and are annotated `knownFailToday` in `scenarios.ts` (tracked as #135):

- **s01-belief** — `SCENES_BELIEF_NEGATION_DELTAS`: disposal ("no bike anymore") does not reliably emit a stateDelta, so the belief stays at the acquisition revision.
- **s08-belief** — `SCENES_BELIEF_FIELD_FOLD`: "home city" vs "place of residence" fold into different free-text field keys, so no single belief carries `value` + `priorValue`.

The battery still RUNS both checks and records their fails — that fail count IS the baseline the flags are measured against. The scorecard counts them separately (`failedExpectedToday`) and the runner prints `(expected today)` next to them; a run where they pass is the fixed-bug signal.

## Scoreability design notes

- **Marker-first serve scoring**: the honest answer to a disposal question ("you don't have a bike anymore — you sold it") trips the shared decline regex (`test/eval/abstain.ts`), so abstention alone never fails a serve whose expected truth is a negation; abstention only fails when no expect marker hit. Unit-tested on that exact answer.
- **Negative states are asserted via markers that never occur in decline phrasings** — `'sold'`, `'returned'`, `'no longer'`, `'not own'`; never bare `'no'` (`'now'` contains it) or `'do not'` / `'not have'` (declines like "I do not have information…" contain them — the s09 comment documents the rejected variant).
- **Forbid used sparingly** (the sibling's D1 forbid-lesson): "currently X, previously Y" is honest, so most checks are expect-only. Forbid survives only where naming the old value at all is an unambiguous stale leak (s02: the corpus states the ThinkPad went back to IT and the MacBook is "the only machine"). The task-suggested `'sold it'` forbid on s06 was dropped — the honest "you haven't sold it yet" contains it; s11 forbids nothing and instead adds a second, directly-scoped serve ("Do I still have the Canon R6?") so the sold object is asserted without punishing the honest recap.
- **Per-check rationale lives in comments** in `scenarios.ts` next to each marker list.

## Verification

- `pnpm typecheck` — green
- `pnpm test:unit` — 344 suites / 3661 tests green (includes the new scorer spec: 20 tests)
- `pnpm lint` (eslint, `--max-warnings 0`) on the new files — clean
- `pnpm prettier --check` on all touched files — clean
- No-stand guard verified: `pnpm eval:state-transitions` without `BRAIN_BASE_URL` exits with the explanatory message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB