### PR TITLE
fix(beliefs): belief promotion misses state transitions — negation deltas + field fold (#135)

### DIFF
--- a/src/admin/belief-promotion.service.ts
+++ b/src/admin/belief-promotion.service.ts
@@ -6,8 +6,10 @@ import { RecordId, StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { chatCallParams, createOpenAiClient } from '../ai/openai-client';
 import {
+  sceneBeliefFieldFoldEnabled,
   sceneBeliefLlmSynthesisEnabled,
   sceneBeliefMinScenes,
+  sceneBeliefNegationDeltasEnabled,
   sceneBeliefPromotionEnabled,
 } from '../common/scene-flags';
 import { supportEdgesEnabled } from '../common/provenance-flags';
@@ -31,6 +33,29 @@ import { SceneVersionService } from './scene-version';
  * sequential state transitions. gist/memoryValue fold in as provenance
  * and confidence signal (enrichedMemoryValue.explicitness), never as
  * keys.
+ *
+ * NEGATION DELTAS (#135 seam 1, SCENES_BELIEF_NEGATION_DELTAS — default
+ * off): an empty-`to` delta with a NON-empty `from` is a state REMOVAL
+ * (sold/quit/ended — the owns:true→false transition), historically
+ * dropped by the no-landing-value guard, so the belief plane kept
+ * asserting the removed state forever. With the flag on, such a delta
+ * contributes the canonical sentinel value BELIEF_NEGATION_VALUE
+ * ('none') with priorValue = the delta's `from`; the ordinary supersede
+ * chain below then revises the belief naturally ('none' differs from
+ * the current value). Both-ends-empty deltas stay dropped, flag on or
+ * off — nothing to negate.
+ *
+ * FIELD FOLD (#135 seam 2, SCENES_BELIEF_FIELD_FOLD — default off): the
+ * enricher re-coins free-text field names per scene ('car' vs 'car
+ * ownership'), so exact-string grouping created PARALLEL beliefs
+ * instead of revisions. With the flag on, an incoming field name folds
+ * onto an existing one — existing ACTIVE beliefs of the same (userId,
+ * subject) plus fields already admitted earlier in the same batch —
+ * under the deterministic lexical fieldsFold rule (token-set subset
+ * whose extra tokens are all generic modifiers; NO embeddings, NO LLM)
+ * BEFORE the group key is built, so negation + fold compose. The
+ * EXISTING name wins (stability); more than one match folds NOTHING and
+ * warns loudly (the skip-loudly, never-flip-flop doctrine).
  *
  * CONFLICT GUARD (built-in, no flag): a group whose latest timestamp is
  * shared by two DIFFERENT values has no deterministic winner — the whole
@@ -101,6 +126,23 @@ const CONFIDENCE_FLOOR = 0.05;
 
 export const BELIEF_SYNTHESIS_SYSTEM = `You phrase ONE remembered belief — a (subject, attribute, value) state a user's conversations established — as a single natural sentence. Output strictly the JSON schema: "statement": one concise declarative sentence stating the belief content itself (never meta-language like "the user said"). Include the previous value only when one is given.`;
 
+/**
+ * Canonical negation sentinel (#135 seam 1): the folded value of an
+ * admitted state-REMOVAL delta (empty `to`, non-empty `from`). A plain
+ * string on purpose — it flows through the existing supersede chain,
+ * template and lane render unchanged ('subject — field: none (was:
+ * prior)').
+ */
+export const BELIEF_NEGATION_VALUE = 'none';
+
+/**
+ * SCENES_BELIEF_NEGATION_DELTAS synthesis-prompt clause — appended to
+ * BELIEF_SYNTHESIS_SYSTEM only when the flag is on AND the write
+ * involves the sentinel (the generator-prompt split-constant idiom,
+ * #412/#413/#415: flag off ⇒ byte-identical prompt).
+ */
+export const BELIEF_SYNTHESIS_NEGATION_CLAUSE = ` A value of "${BELIEF_NEGATION_VALUE}" means the subject NO LONGER has the attribute — phrase it as a natural negation (e.g. "no longer has a car"), never as possessing something called "${BELIEF_NEGATION_VALUE}".`;
+
 /** Scene head as selected by the promotion query (validated in JS). */
 export interface PromotableSceneHead {
   id: unknown;
@@ -159,101 +201,300 @@ export interface BeliefFold {
   folded: FoldedBelief[];
   /** Groups the conflict guard refused (ambiguous latest value). */
   conflicts: Array<{ userId: string; subject: string; field: string; values: string[] }>;
+  /** SCENES_BELIEF_FIELD_FOLD: incoming names folded onto existing ones. */
+  fieldFolds: Array<{ userId: string; subject: string; from: string; to: string }>;
+  /** Field-fold ambiguity guard: >1 existing candidates — NOT folded. */
+  fieldFoldAmbiguities: Array<{
+    userId: string;
+    subject: string;
+    field: string;
+    candidates: string[];
+  }>;
+}
+
+/** Fold behavior knobs, resolved ONCE per run (the Drift-3 contract). */
+export interface BeliefFoldOptions {
+  /** SCENES_BELIEF_NEGATION_DELTAS: admit empty-`to` removal deltas. */
+  negationDeltas?: boolean;
+  /**
+   * SCENES_BELIEF_FIELD_FOLD: existing ACTIVE belief field names per
+   * (userId, subject) — key `${userId}\x00${subject}`. Undefined (flag
+   * off) ⇒ exact-string grouping, byte-identical to the historical fold.
+   */
+  existingFields?: ReadonlyMap<string, readonly string[]>;
 }
 
 const str = (v: unknown): string => (typeof v === 'string' ? v.trim() : '');
 
 /**
- * Pure: group eligible scenes' stateDeltas by (userId, subject, field)
- * and fold each group to one verdict (latest value wins; scenes ordered
- * by occurredTo then scene id, so the fold is deterministic). Groups
- * whose latest timestamp carries two different values are returned as
- * conflicts (the built-in guard) — never half-promoted.
+ * Generic-modifier stoplist for the field-fold rule (#135 seam 2): the
+ * ONLY extra tokens a longer field name may carry and still fold onto a
+ * shorter one. Deliberately tiny and conservative — 'car ownership'
+ * folds onto 'car' (ownership is generic), 'car registration' does NOT
+ * (registration names a DIFFERENT attribute), and 'queue backend' does
+ * NOT fold onto 'queue' (backend is specific) — a known limitation we
+ * accept over the false-fold risk.
  */
-export function foldBeliefGroups(
-  scenes: ReadonlyArray<{ scene: PromotableSceneHead; userId: string }>,
-): BeliefFold {
-  const groups = new Map<
-    string,
-    { userId: string; subject: string; field: string; contributions: BeliefContribution[] }
-  >();
-  for (const { scene, userId } of scenes) {
-    const sceneId = String(scene.id);
-    const conversationId = Array.isArray(scene.conversationIds)
-      ? str(scene.conversationIds[0])
-      : '';
-    // WS-driver datetimes arrive as Date instances; e2e/unit fixtures may
-    // hand ISO strings — accept both, never String(Date) (query_arc lesson).
-    const occurredAt =
-      scene.occurredTo instanceof Date
-        ? scene.occurredTo.getTime()
-        : new Date(String(scene.occurredTo ?? '')).getTime();
-    if (!Number.isFinite(occurredAt)) continue; // unordered scene: unusable
-    const explicitnessRaw = scene.explicitness;
-    const explicitness =
-      typeof explicitnessRaw === 'number' && Number.isFinite(explicitnessRaw)
-        ? Math.min(1, Math.max(0, explicitnessRaw))
-        : DEFAULT_EXPLICITNESS;
-    for (const delta of Array.isArray(scene.stateDeltas) ? scene.stateDeltas : []) {
-      if (typeof delta !== 'object' || delta === null) continue;
-      const d = delta as Record<string, unknown>;
-      const subject = str(d.subject);
-      const field = str(d.field);
-      const value = str(d.to);
-      // A delta without a landing value holds nothing promotable.
-      if (subject === '' || field === '' || value === '') continue;
-      const key = `${userId}\x00${subject}\x00${field}`;
-      let group = groups.get(key);
-      if (!group) {
-        group = { userId, subject, field, contributions: [] };
-        groups.set(key, group);
-      }
-      group.contributions.push({
-        sceneId,
-        conversationId,
-        occurredAt,
-        value,
-        priorValue: str(d.from),
-        explicitness,
-      });
-    }
-  }
+export const FIELD_FOLD_GENERIC_TOKENS: ReadonlySet<string> = new Set([
+  'ownership',
+  'status',
+  'state',
+  'current',
+  'of',
+  'the',
+]);
 
-  const fold: BeliefFold = { folded: [], conflicts: [] };
-  for (const group of groups.values()) {
-    const ordered = [...group.contributions].sort(
-      (a, b) => a.occurredAt - b.occurredAt || a.sceneId.localeCompare(b.sceneId),
-    );
-    const winner = ordered[ordered.length - 1]!;
-    // Conflict guard: a DIFFERENT value at the winning timestamp means
-    // the batch has no deterministic latest state.
-    const ambiguous = ordered.some(
-      (c) => c.occurredAt === winner.occurredAt && c.value !== winner.value,
-    );
-    if (ambiguous) {
-      fold.conflicts.push({
+/** Normalize a free-text field name: lowercase, strip punctuation, tokenize. */
+function fieldTokens(field: string): Set<string> {
+  return new Set(
+    field
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+      .split(/\s+/)
+      .filter((t) => t !== ''),
+  );
+}
+
+/**
+ * Pure (#135 seam 2): may these two free-text field names denote the
+ * same attribute? True ONLY when one token SET is a subset of the other
+ * AND every extra token of the longer name is a generic modifier from
+ * FIELD_FOLD_GENERIC_TOKENS. Deterministic and lexical — NO embeddings,
+ * NO LLM, no stemming ('deploy' ≠ 'deployment' — accepted limitation).
+ */
+export function fieldsFold(a: string, b: string): boolean {
+  const ta = fieldTokens(a);
+  const tb = fieldTokens(b);
+  if (ta.size === 0 || tb.size === 0) return false;
+  const [small, large] = ta.size <= tb.size ? [ta, tb] : [tb, ta];
+  for (const t of small) if (!large.has(t)) return false;
+  for (const t of large) if (!small.has(t) && !FIELD_FOLD_GENERIC_TOKENS.has(t)) return false;
+  return true;
+}
+
+/**
+ * Pure (#135 seam 2): resolve an incoming field name against the known
+ * fields of the same (userId, subject). An exact string match short-
+ * circuits (already the canonical name); exactly ONE foldable candidate
+ * folds — the EXISTING name wins (stability); MORE than one is
+ * ambiguous — fold NOTHING, keep the incoming name (the caller warns
+ * loudly: skip loudly, never flip-flop).
+ */
+export function resolveFieldFold(
+  incoming: string,
+  knownFields: readonly string[],
+): { field: string; folded: boolean; ambiguous: boolean; candidates: string[] } {
+  const distinct = [...new Set(knownFields)];
+  if (distinct.includes(incoming)) {
+    return { field: incoming, folded: false, ambiguous: false, candidates: [] };
+  }
+  const candidates = distinct.filter((existing) => fieldsFold(incoming, existing));
+  if (candidates.length === 1) {
+    return { field: candidates[0]!, folded: true, ambiguous: false, candidates };
+  }
+  if (candidates.length > 1) {
+    return { field: incoming, folded: false, ambiguous: true, candidates };
+  }
+  return { field: incoming, folded: false, ambiguous: false, candidates: [] };
+}
+
+/**
+ * Pure: a delta's landing value, or null when it holds nothing
+ * promotable. The historical rule drops every empty-`to` delta; with
+ * negationDeltas on (#135 seam 1) an empty-`to` / non-empty-`from`
+ * delta — a state REMOVAL — lands as the canonical sentinel instead.
+ * Both ends empty stays dropped, flag on or off — nothing to negate.
+ */
+function admitDeltaValue(
+  d: Record<string, unknown>,
+  negationDeltas: boolean,
+): { value: string; priorValue: string } | null {
+  const priorValue = str(d.from);
+  const value = str(d.to);
+  if (value !== '') return { value, priorValue };
+  if (negationDeltas && priorValue !== '') return { value: BELIEF_NEGATION_VALUE, priorValue };
+  return null;
+}
+
+/** Mutable fold-state threaded through the per-delta field resolution. */
+interface FieldFoldState {
+  /** Fields already admitted this batch, per (userId, subject) — the
+   *  intra-batch fold candidates (first-seen order, deterministic for a
+   *  given scene order). */
+  batchFields: Map<string, string[]>;
+  fieldFolds: Map<string, BeliefFold['fieldFolds'][number]>;
+  fieldFoldAmbiguities: Map<string, BeliefFold['fieldFoldAmbiguities'][number]>;
+}
+
+/**
+ * #135 seam 2: fold one delta's field BEFORE the group key is built, so
+ * negation + fold compose. Candidates: existing ACTIVE belief fields of
+ * this (userId, subject) ∪ fields already admitted earlier in this
+ * batch (so a two-scene create+negate batch converges to ONE group).
+ * Returns the group field name and records folds/ambiguities in state.
+ */
+function foldDeltaField(
+  { userId, subject, field }: { userId: string; subject: string; field: string },
+  existingFields: ReadonlyMap<string, readonly string[]>,
+  state: FieldFoldState,
+): string {
+  const subjectKey = `${userId}\x00${subject}`;
+  const known = [
+    ...(existingFields.get(subjectKey) ?? []),
+    ...(state.batchFields.get(subjectKey) ?? []),
+  ];
+  const resolved = resolveFieldFold(field, known);
+  let groupField = field;
+  if (resolved.ambiguous) {
+    state.fieldFoldAmbiguities.set(`${subjectKey}\x00${field}`, {
+      userId,
+      subject,
+      field,
+      candidates: resolved.candidates,
+    });
+  } else if (resolved.folded) {
+    state.fieldFolds.set(`${subjectKey}\x00${field}`, {
+      userId,
+      subject,
+      from: field,
+      to: resolved.field,
+    });
+    groupField = resolved.field;
+  }
+  const seen = state.batchFields.get(subjectKey);
+  if (seen === undefined) state.batchFields.set(subjectKey, [groupField]);
+  else if (!seen.includes(groupField)) seen.push(groupField);
+  return groupField;
+}
+
+type BeliefGroups = Map<
+  string,
+  { userId: string; subject: string; field: string; contributions: BeliefContribution[] }
+>;
+
+/** Scene-head fields the fold consumes, parsed defensively. */
+interface SceneFoldContext {
+  sceneId: string;
+  conversationId: string;
+  occurredAt: number;
+  explicitness: number;
+}
+
+/** Pure: parse one scene's head for the fold; null = unusable (unordered). */
+function sceneFoldContext(scene: PromotableSceneHead): SceneFoldContext | null {
+  const sceneId = String(scene.id);
+  const conversationId = Array.isArray(scene.conversationIds) ? str(scene.conversationIds[0]) : '';
+  // WS-driver datetimes arrive as Date instances; e2e/unit fixtures may
+  // hand ISO strings — accept both, never String(Date) (query_arc lesson).
+  const occurredAt =
+    scene.occurredTo instanceof Date
+      ? scene.occurredTo.getTime()
+      : new Date(String(scene.occurredTo ?? '')).getTime();
+  if (!Number.isFinite(occurredAt)) return null;
+  const explicitnessRaw = scene.explicitness;
+  const explicitness =
+    typeof explicitnessRaw === 'number' && Number.isFinite(explicitnessRaw)
+      ? Math.min(1, Math.max(0, explicitnessRaw))
+      : DEFAULT_EXPLICITNESS;
+  return { sceneId, conversationId, occurredAt, explicitness };
+}
+
+/**
+ * Pure (mutates groups/foldState): admit one scene's stateDeltas into
+ * their (userId, subject, field) groups — subject/field presence guard,
+ * value admission (admitDeltaValue, #135 seam 1), field folding
+ * (foldDeltaField, #135 seam 2) BEFORE the group key is built.
+ */
+function collectSceneDeltas({
+  scene,
+  userId,
+  head,
+  opts,
+  foldState,
+  groups,
+}: {
+  scene: PromotableSceneHead;
+  userId: string;
+  head: SceneFoldContext;
+  opts: BeliefFoldOptions;
+  foldState: FieldFoldState;
+  groups: BeliefGroups;
+}): void {
+  for (const delta of Array.isArray(scene.stateDeltas) ? scene.stateDeltas : []) {
+    if (typeof delta !== 'object' || delta === null) continue;
+    const d = delta as Record<string, unknown>;
+    const subject = str(d.subject);
+    const rawField = str(d.field);
+    if (subject === '' || rawField === '') continue;
+    const admitted = admitDeltaValue(d, opts.negationDeltas === true);
+    if (admitted === null) continue;
+    const field =
+      opts.existingFields !== undefined
+        ? foldDeltaField({ userId, subject, field: rawField }, opts.existingFields, foldState)
+        : rawField;
+    const key = `${userId}\x00${subject}\x00${field}`;
+    let group = groups.get(key);
+    if (!group) {
+      group = { userId, subject, field, contributions: [] };
+      groups.set(key, group);
+    }
+    group.contributions.push({
+      sceneId: head.sceneId,
+      conversationId: head.conversationId,
+      occurredAt: head.occurredAt,
+      value: admitted.value,
+      priorValue: admitted.priorValue,
+      explicitness: head.explicitness,
+    });
+  }
+}
+
+/**
+ * Pure: one (userId, subject, field) group's verdict — the latest value
+ * wins (contributions ordered by occurredAt then scene id, so the fold
+ * is deterministic); a DIFFERENT value at the winning timestamp means
+ * the batch has no deterministic latest state and the whole group is a
+ * conflict (the built-in guard) — never half-promoted.
+ */
+function foldGroupVerdict(group: {
+  userId: string;
+  subject: string;
+  field: string;
+  contributions: BeliefContribution[];
+}): { conflict: BeliefFold['conflicts'][number] } | { folded: FoldedBelief } {
+  const ordered = [...group.contributions].sort(
+    (a, b) => a.occurredAt - b.occurredAt || a.sceneId.localeCompare(b.sceneId),
+  );
+  const winner = ordered[ordered.length - 1]!;
+  const ambiguous = ordered.some(
+    (c) => c.occurredAt === winner.occurredAt && c.value !== winner.value,
+  );
+  if (ambiguous) {
+    return {
+      conflict: {
         userId: group.userId,
         subject: group.subject,
         field: group.field,
         values: [...new Set(ordered.map((c) => c.value))].sort(),
-      });
-      continue;
-    }
-    const corroborating = ordered.filter((c) => c.value === winner.value);
-    const sceneIds = [...new Set(corroborating.map((c) => c.sceneId))];
-    const conversationIds = [
-      ...new Set(corroborating.map((c) => c.conversationId).filter((c) => c !== '')),
-    ];
-    const meanExplicitness =
-      corroborating.reduce((sum, c) => sum + c.explicitness, 0) / corroborating.length;
-    const confidence = Math.min(
-      CONFIDENCE_CAP,
-      Math.max(
-        CONFIDENCE_FLOOR,
-        meanExplicitness + CORROBORATION_BONUS * Math.max(0, conversationIds.length - 1),
-      ),
-    );
-    fold.folded.push({
+      },
+    };
+  }
+  const corroborating = ordered.filter((c) => c.value === winner.value);
+  const sceneIds = [...new Set(corroborating.map((c) => c.sceneId))];
+  const conversationIds = [
+    ...new Set(corroborating.map((c) => c.conversationId).filter((c) => c !== '')),
+  ];
+  const meanExplicitness =
+    corroborating.reduce((sum, c) => sum + c.explicitness, 0) / corroborating.length;
+  const confidence = Math.min(
+    CONFIDENCE_CAP,
+    Math.max(
+      CONFIDENCE_FLOOR,
+      meanExplicitness + CORROBORATION_BONUS * Math.max(0, conversationIds.length - 1),
+    ),
+  );
+  return {
+    folded: {
       userId: group.userId,
       subject: group.subject,
       field: group.field,
@@ -263,7 +504,49 @@ export function foldBeliefGroups(
       sceneIds,
       conversationIds,
       confidence: Math.round(confidence * 10000) / 10000,
-    });
+    },
+  };
+}
+
+/**
+ * Pure: group eligible scenes' stateDeltas by (userId, subject, field)
+ * and fold each group to one verdict via foldGroupVerdict (latest value
+ * wins; deterministic ordering). Groups whose latest timestamp carries
+ * two different values are returned as conflicts (the built-in guard) —
+ * never half-promoted.
+ *
+ * With opts.negationDeltas (#135 seam 1) an empty-`to` / non-empty-
+ * `from` delta contributes BELIEF_NEGATION_VALUE instead of being
+ * dropped (admitDeltaValue); with opts.existingFields (#135 seam 2)
+ * each admitted delta's field runs through foldDeltaField BEFORE the
+ * group key is built. No opts ⇒ byte-identical to the historical fold.
+ */
+export function foldBeliefGroups(
+  scenes: ReadonlyArray<{ scene: PromotableSceneHead; userId: string }>,
+  opts: BeliefFoldOptions = {},
+): BeliefFold {
+  const groups: BeliefGroups = new Map();
+  const foldState: FieldFoldState = {
+    batchFields: new Map(),
+    fieldFolds: new Map(),
+    fieldFoldAmbiguities: new Map(),
+  };
+  for (const { scene, userId } of scenes) {
+    const head = sceneFoldContext(scene);
+    if (head === null) continue; // unordered scene: unusable
+    collectSceneDeltas({ scene, userId, head, opts, foldState, groups });
+  }
+
+  const fold: BeliefFold = {
+    folded: [],
+    conflicts: [],
+    fieldFolds: [...foldState.fieldFolds.values()],
+    fieldFoldAmbiguities: [...foldState.fieldFoldAmbiguities.values()],
+  };
+  for (const group of groups.values()) {
+    const verdict = foldGroupVerdict(group);
+    if ('conflict' in verdict) fold.conflicts.push(verdict.conflict);
+    else fold.folded.push(verdict.folded);
   }
   // Deterministic emission order (stable logs, stable tests).
   fold.folded.sort(
@@ -313,6 +596,10 @@ export interface BeliefPromotionResult {
   skippedMixedUser: number;
   /** (subject, field) groups the conflict guard refused. */
   skippedConflict: number;
+  /** Field names folded onto an existing one (SCENES_BELIEF_FIELD_FOLD). */
+  fieldFolds: number;
+  /** Field names left UNfolded because >1 existing field matched. */
+  fieldFoldAmbiguous: number;
   /** Groups below the SCENES_BELIEF_MIN_SCENES conversation floor. */
   skippedFloor: number;
   /** Groups whose winner was not newer than the active belief (stale). */
@@ -379,6 +666,8 @@ export class BeliefPromotionService {
       eligibleScenes: 0,
       skippedMixedUser: 0,
       skippedConflict: 0,
+      fieldFolds: 0,
+      fieldFoldAmbiguous: 0,
       skippedFloor: 0,
       skippedStale: 0,
       beliefsCreated: 0,
@@ -397,6 +686,8 @@ export class BeliefPromotionService {
     const promoterVersion = beliefPromoterVersion(version);
     const floor = sceneBeliefMinScenes();
     const edgesOn = supportEdgesEnabled();
+    const negationDeltas = sceneBeliefNegationDeltasEnabled();
+    const fieldFoldOn = sceneBeliefFieldFoldEnabled();
     await this.surreal.withCompany(companyId, async (db) => {
       const [scenes] = await db.query<[PromotableSceneHead[]]>(
         `SELECT id, userId, userIds, conversationIds, occurredTo, stateDeltas,
@@ -427,12 +718,57 @@ export class BeliefPromotionService {
         eligible.push({ scene, userId });
       }
 
-      const { folded, conflicts } = foldBeliefGroups(eligible);
+      // #135 seam 2: fold candidates are the existing ACTIVE belief
+      // field names per (userId, subject) — one plain SELECT (safe on
+      // the 3.2.4 planner; the DELETE-WHERE trap does not apply to
+      // reads). Flag off ⇒ zero extra queries.
+      let existingFields: Map<string, string[]> | undefined;
+      if (fieldFoldOn && eligible.length > 0) {
+        const userIds = [...new Set(eligible.map((e) => e.userId))];
+        const [rows] = await db.query<
+          [Array<{ userId: unknown; subject: unknown; field: unknown }>]
+        >(
+          `SELECT userId, subject, field FROM semantic_belief
+            WHERE status = 'active' AND userId INSIDE $userIds`,
+          { userIds },
+        );
+        existingFields = new Map();
+        for (const row of rows ?? []) {
+          const u = str(row.userId);
+          const s = str(row.subject);
+          const fieldName = str(row.field);
+          if (u === '' || s === '' || fieldName === '') continue;
+          const key = `${u}\x00${s}`;
+          const list = existingFields.get(key);
+          if (list === undefined) existingFields.set(key, [fieldName]);
+          else if (!list.includes(fieldName)) list.push(fieldName);
+        }
+      }
+
+      const { folded, conflicts, fieldFolds, fieldFoldAmbiguities } = foldBeliefGroups(eligible, {
+        negationDeltas,
+        ...(existingFields !== undefined ? { existingFields } : {}),
+      });
       result.skippedConflict = conflicts.length;
+      result.fieldFolds = fieldFolds.length;
+      result.fieldFoldAmbiguous = fieldFoldAmbiguities.length;
       for (const c of conflicts) {
         this.logger.warn(
           `belief promotion conflict guard: (${c.subject}, ${c.field}) for user ${c.userId} ` +
             `has irreconcilable in-batch values [${c.values.join(' | ')}] — group skipped`,
+        );
+      }
+      for (const ff of fieldFolds) {
+        this.logger.log(
+          `belief promotion field fold: '${ff.from}' folded onto existing field '${ff.to}' ` +
+            `for subject ${ff.subject} (user ${ff.userId}) — SCENES_BELIEF_FIELD_FOLD`,
+        );
+      }
+      for (const amb of fieldFoldAmbiguities) {
+        this.logger.warn(
+          `belief promotion field-fold ambiguity: '${amb.field}' for subject ${amb.subject} ` +
+            `(user ${amb.userId}) matches ${amb.candidates.length} existing fields ` +
+            `[${amb.candidates.join(' | ')}] — NOT folded (skip loudly, never flip-flop)`,
         );
       }
 
@@ -453,6 +789,7 @@ export class BeliefPromotionService {
         `${result.beliefsCorroborated} corroborated, ${result.beliefsRevised} revised ` +
         `over ${result.eligibleScenes}/${result.scenes} scene(s) ` +
         `(mixedUser=${result.skippedMixedUser} conflict=${result.skippedConflict} ` +
+        `fieldFolds=${result.fieldFolds} foldAmbiguous=${result.fieldFoldAmbiguous} ` +
         `floor=${result.skippedFloor} stale=${result.skippedStale} edges=${result.supportEdges})`,
     );
     return result;
@@ -723,12 +1060,20 @@ export class BeliefPromotionService {
       this.logger.warn('belief statement synthesis skipped: no OPENAI_API_KEY configured');
       return { text: template, source: 'template' };
     }
+    // #135 seam 1: the negation clause joins the system prompt only when
+    // the flag is on AND the write involves the sentinel (split-constant
+    // idiom — flag off, or a non-negation belief, is byte-identical).
+    const system =
+      sceneBeliefNegationDeltasEnabled() &&
+      (belief.value === BELIEF_NEGATION_VALUE || belief.priorValue === BELIEF_NEGATION_VALUE)
+        ? BELIEF_SYNTHESIS_SYSTEM + BELIEF_SYNTHESIS_NEGATION_CLAUSE
+        : BELIEF_SYNTHESIS_SYSTEM;
     try {
       const res = await this.openai.chat.completions.create({
         model: this.model,
         ...chatCallParams(this.model, { temperature: 0, visibleCap: SYNTHESIS_VISIBLE_CAP }),
         messages: [
-          { role: 'system', content: BELIEF_SYNTHESIS_SYSTEM },
+          { role: 'system', content: system },
           {
             role: 'user',
             content:

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -756,6 +756,31 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Belief promotion statement synthesis: ONE structured LLM call per belief create/revise phrasing the statement text (statementSource llm); any failure degrades to the deterministic template — the fold never depends on the model. Off = no LLM call ever runs, every statement is the deterministic template (statementSource template).',
   },
   {
+    key: 'SCENES_BELIEF_NEGATION_DELTAS',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneBeliefNegationDeltasEnabled)
+    // once per promotion run for the fold + per belief write for the
+    // synthesis-prompt clause — never captured in a constructor — so a
+    // flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Belief promotion negation deltas (#135 seam 1): admit a stateDelta with empty `to` and NON-empty `from` — a state REMOVAL (sold/quit/ended, the owns:true→false transition) — as a fold contribution with the canonical sentinel value none and priorValue = the delta’s from; the ordinary supersede chain then revises the belief (none vs the current value). Deltas with both ends empty stay dropped. Off = empty-to deltas are dropped exactly as before — byte-identical fold output and synthesis prompt.',
+  },
+  {
+    key: 'SCENES_BELIEF_FIELD_FOLD',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneBeliefFieldFoldEnabled) once
+    // per promotion run — never captured in a constructor — so a flip
+    // takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Belief promotion field fold (#135 seam 2): deterministically fold an enricher-re-coined field name onto an existing one for the same (userId, subject) — token-set subset whose extra tokens are all generic modifiers (ownership/status/state/current/of/the); the EXISTING name wins, and more than one match folds nothing and warns loudly (skip loudly, never flip-flop). NO embeddings, NO LLM. Off = exact-string (subject, field) grouping and zero extra queries — byte-identical fold output.',
+  },
+  {
     key: 'SCENES_EVIDENCE_LINKS',
     category: 'scenes',
     // Read at call time (scene-flags.sceneEvidenceLinksEnabled) by the

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1044,6 +1044,20 @@ const KNOWN_BOOLEAN_FLAGS = [
   // to the deterministic template. Default off ⇒ no LLM call ever runs —
   // every statement is the deterministic template.
   'SCENES_BELIEF_LLM_SYNTHESIS',
+  // Belief negation deltas (#135 seam 1): the promotion fold admits an
+  // empty-`to` / non-empty-`from` stateDelta — a state removal — as the
+  // canonical sentinel value 'none' with priorValue = the delta's
+  // `from`, so the supersede chain revises the belief instead of
+  // silently keeping the stale assertion. Default off ⇒ empty-`to`
+  // deltas are dropped exactly as before — byte-identical fold output.
+  'SCENES_BELIEF_NEGATION_DELTAS',
+  // Belief field fold (#135 seam 2): deterministic lexical folding of
+  // enricher-re-coined field names ('car ownership' → existing 'car')
+  // at promotion time — token-set subset whose extra tokens are all
+  // generic modifiers; the existing name wins, ambiguity (>1 match)
+  // folds nothing and warns loudly. NO embeddings, NO LLM. Default off
+  // ⇒ exact-string grouping, zero extra queries — byte-identical.
+  'SCENES_BELIEF_FIELD_FOLD',
   // Scene evidence links (MM-zoom PR1, migration 0123): typed
   // scene-reconstructed_from->evidence_fragment|evidence_asset edges in
   // memory_support from the union of member episodes' source.evidenceRefs

--- a/src/common/scene-flags.ts
+++ b/src/common/scene-flags.ts
@@ -172,6 +172,45 @@ export function sceneBeliefLlmSynthesisEnabled(): boolean {
 }
 
 /**
+ * Scenes belief negation-deltas flag — SCENES_BELIEF_NEGATION_DELTAS
+ * (#135 seam 1). When on, the promotion fold ADMITS a stateDelta whose
+ * `to` is empty but whose `from` is NON-empty — a state REMOVAL
+ * (sold/quit/ended, the owns:true→false transition) — as a contribution
+ * carrying the canonical negation sentinel value 'none'
+ * (BELIEF_NEGATION_VALUE) with priorValue = the delta's `from`; the
+ * ordinary supersede chain then revises the belief naturally ('none' vs
+ * the current value). A delta with BOTH ends empty stays dropped —
+ * nothing to negate. The env read lives here in the common layer, NOT
+ * inside the engine dirs (engine-gates S5.2). Read at call time so a
+ * flip is runtime-mutable. Default off ⇒ empty-`to` deltas are dropped
+ * exactly as before — byte-identical fold output and prompts.
+ */
+export function sceneBeliefNegationDeltasEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_BELIEF_NEGATION_DELTAS);
+}
+
+/**
+ * Scenes belief field-fold flag — SCENES_BELIEF_FIELD_FOLD (#135 seam
+ * 2). The LLM enricher re-coins free-text field names per scene ('car'
+ * vs 'car ownership'), so exact-string (subject, field) grouping lands
+ * follow-up deltas in a fresh group and creates a PARALLEL belief
+ * instead of revising the existing one. When on, the promotion pass
+ * folds an incoming field name onto an existing one (existing ACTIVE
+ * beliefs of the same (userId, subject) + fields already admitted in
+ * the same batch) under a deterministic lexical rule — token-set subset
+ * whose extra tokens are all generic modifiers (fieldsFold — NO
+ * embeddings, NO LLM); the EXISTING name wins (stability), and more
+ * than one match folds NOTHING and warns loudly (the skip-loudly,
+ * never-flip-flop doctrine). The env read lives here in the common
+ * layer, NOT inside the engine dirs (engine-gates S5.2). Read at call
+ * time so a flip is runtime-mutable. Default off ⇒ exact-string
+ * grouping and zero extra queries — byte-identical fold output.
+ */
+export function sceneBeliefFieldFoldEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_BELIEF_FIELD_FOLD);
+}
+
+/**
  * Belief corroboration floor (SCENES_BELIEF_MIN_SCENES): promote a
  * (subject, field) group only when its winning value is corroborated by
  * scenes from at least this many DISTINCT CONVERSATIONS (the #377

--- a/test/belief-promotion.e2e-spec.ts
+++ b/test/belief-promotion.e2e-spec.ts
@@ -55,6 +55,8 @@ describe('belief promotion + GDPR cascade (e2e)', () => {
     'SCENES_BELIEF_PROMOTION',
     'SCENES_BELIEF_MIN_SCENES',
     'SCENES_BELIEF_LLM_SYNTHESIS',
+    'SCENES_BELIEF_NEGATION_DELTAS',
+    'SCENES_BELIEF_FIELD_FOLD',
     'PROVENANCE_SUPPORT_EDGES',
   ];
 
@@ -396,16 +398,83 @@ describe('belief promotion + GDPR cascade (e2e)', () => {
     expect((await beliefs()).filter((r) => r.field === 'home.city')).toHaveLength(2);
   });
 
+  it('negation + field fold (#135): an empty-`to` delta under a re-coined field name revises to the sentinel', async () => {
+    process.env.SCENES_BELIEF_NEGATION_DELTAS = '1';
+    process.env.SCENES_BELIEF_FIELD_FOLD = '1';
+
+    // The live Compass shape, scene 1: acquisition — belief created.
+    await seedScene({
+      tail: 'scar1',
+      conv: 'proj:c4',
+      user: USER,
+      users: [USER],
+      occurredTo: '2026-03-06T10:00:00.000Z',
+      deltas: [{ subject: 'Mikhail', field: 'car', from: '', to: 'Jeep Compass' }],
+    });
+    const first = await promote();
+    expect(first.status).toBe(201);
+    expect(first.body).toMatchObject({ beliefsCreated: 1, beliefsRevised: 0, fieldFolds: 0 });
+
+    // Scene 2: state REMOVAL under a RE-COINED field name — historically
+    // this delta vanished at the no-landing-value guard AND would have
+    // keyed a fresh parallel group ('car ownership' ≠ 'car').
+    await seedScene({
+      tail: 'scar2',
+      conv: 'proj:c5',
+      user: USER,
+      users: [USER],
+      occurredTo: '2026-03-07T10:00:00.000Z',
+      deltas: [{ subject: 'Mikhail', field: 'car ownership', from: 'Compass', to: '' }],
+    });
+    const second = await promote();
+    expect(second.status).toBe(201);
+    expect(second.body).toMatchObject({
+      beliefsCreated: 0,
+      beliefsRevised: 1,
+      fieldFolds: 1,
+      fieldFoldAmbiguous: 0,
+    });
+
+    const chain = (await beliefs()).filter((r) => r.subject === 'Mikhail' && r.field === 'car');
+    expect(chain).toHaveLength(2);
+    const [rev1, rev2] = chain;
+    expect(rev1).toMatchObject({ revision: 1, value: 'Jeep Compass', status: 'superseded' });
+    expect(String(rev1!.supersededBy)).toBe(String(rev2!.id));
+    expect(rev2).toMatchObject({
+      revision: 2,
+      value: 'none',
+      priorValue: 'Jeep Compass', // the ACTUAL displaced value beats the delta's 'Compass'
+      statement: 'Mikhail — car: none (was: Jeep Compass)',
+      statementSource: 'template',
+      status: 'active',
+    });
+    // NO parallel 'car ownership' belief exists — the fold won.
+    expect((await beliefs()).filter((r) => r.field === 'car ownership')).toEqual([]);
+
+    // The full revision contract fires for the negation delta too.
+    const scar2 = await sceneRow('scar2');
+    expect((scar2.consolidatedInto ?? []).map(String)).toEqual([String(rev2!.id)]);
+    expect(scar2.baselineRef).toMatchObject({
+      belief: String(rev1!.id),
+      revision: 1,
+      value: 'Jeep Compass',
+    });
+
+    delete process.env.SCENES_BELIEF_NEGATION_DELTAS;
+    delete process.env.SCENES_BELIEF_FIELD_FOLD;
+  });
+
   it('user-forget erases beliefs + their support edges unconditionally, with the beliefsDeleted counter', async () => {
     // Flag-independence: rows written while on must die while OFF.
     delete process.env.SCENES_BELIEF_PROMOTION;
     delete process.env.PROVENANCE_SUPPORT_EDGES;
 
     const before = await beliefs();
-    expect(before.length).toBe(3); // home.city rev1+rev2 + coffee.pref
+    // home.city rev1+rev2 + coffee.pref + car rev1+rev2 (#135 fixture)
+    expect(before.length).toBe(5);
     const res = await f.http.post(`/v1/users/${USER}/forget`).set(auth()).send({});
     expect(res.status).toBe(201);
-    expect(res.body.beliefsDeleted).toBe(3);
+    expect(res.body.beliefsDeleted).toBe(5);
 
     expect(await beliefs()).toEqual([]);
     expect(await supportRows()).toEqual([]);

--- a/test/belief-promotion.unit-spec.ts
+++ b/test/belief-promotion.unit-spec.ts
@@ -10,12 +10,15 @@ import type { ConfigService } from '@nestjs/config';
 import type { SurrealService } from '../src/db/surreal.service';
 import type { SceneVersionService } from '../src/admin/scene-version';
 import {
+  BELIEF_NEGATION_VALUE,
   BELIEF_PROMOTER_VERSION,
   BeliefPromotionService,
   beliefIdTail,
   beliefPromoterVersion,
+  fieldsFold,
   foldBeliefGroups,
   renderBeliefStatement,
+  resolveFieldFold,
   sceneSingleUser,
   type PromotableSceneHead,
 } from '../src/admin/belief-promotion.service';
@@ -25,8 +28,10 @@ import {
   classifySupportTarget,
 } from '../src/common/support-edges';
 import {
+  sceneBeliefFieldFoldEnabled,
   sceneBeliefLlmSynthesisEnabled,
   sceneBeliefMinScenes,
+  sceneBeliefNegationDeltasEnabled,
   sceneBeliefPromotionEnabled,
 } from '../src/common/scene-flags';
 
@@ -237,6 +242,205 @@ describe('foldBeliefGroups', () => {
   });
 });
 
+describe('field fold rule (SCENES_BELIEF_FIELD_FOLD, #135 seam 2)', () => {
+  it.each([
+    // [a, b, folds?] — the #135 decision table, verbatim.
+    ['car', 'car ownership', true], // extra token 'ownership' is generic
+    ['queue backend', 'queue', false], // 'backend' not in the stoplist — conservative
+    ['car', 'career', false], // different tokens entirely
+    ['deploy target', 'deployment target', false], // no stemming: 'deploy' ≠ 'deployment'
+    ['car registration', 'car', false], // registration is a DIFFERENT attribute
+    ['car', 'car', true], // identity
+    ['Car', 'car', true], // normalization: case
+    ['car.status', 'car', true], // normalization: punctuation + generic extra
+  ])('fieldsFold(%p, %p) === %p (symmetric)', (a, b, expected) => {
+    expect(fieldsFold(a as string, b as string)).toBe(expected);
+    expect(fieldsFold(b as string, a as string)).toBe(expected);
+  });
+
+  it('resolveFieldFold: exactly one candidate folds — the EXISTING name wins', () => {
+    expect(resolveFieldFold('car ownership', ['car', 'home.city'])).toEqual({
+      field: 'car',
+      folded: true,
+      ambiguous: false,
+      candidates: ['car'],
+    });
+    // Stability holds in the other direction too: incoming shorter name
+    // folds onto the longer EXISTING one.
+    expect(resolveFieldFold('car', ['car ownership'])).toMatchObject({
+      field: 'car ownership',
+      folded: true,
+    });
+  });
+
+  it('resolveFieldFold: no candidate keeps the incoming name', () => {
+    expect(resolveFieldFold('car registration', ['car'])).toEqual({
+      field: 'car registration',
+      folded: false,
+      ambiguous: false,
+      candidates: [],
+    });
+  });
+
+  it('resolveFieldFold: an exact existing match short-circuits (never re-folded)', () => {
+    // 'car' exists verbatim next to a foldable variant — the exact name
+    // is already canonical; folding it would flip-flop parallel chains.
+    expect(resolveFieldFold('car', ['car', 'car ownership'])).toEqual({
+      field: 'car',
+      folded: false,
+      ambiguous: false,
+      candidates: [],
+    });
+  });
+
+  it('resolveFieldFold: MORE than one match is ambiguous — fold nothing', () => {
+    expect(resolveFieldFold('car', ['car ownership', 'car status'])).toEqual({
+      field: 'car',
+      folded: false,
+      ambiguous: true,
+      candidates: ['car ownership', 'car status'],
+    });
+  });
+});
+
+describe('foldBeliefGroups: negation deltas (#135 seam 1)', () => {
+  const negationScene = scene({
+    id: 'memory_episode:s1',
+    stateDeltas: [{ subject: 'mikhail', field: 'car', from: 'Compass', to: '' }],
+  });
+
+  it('no opts: empty-`to` deltas drop exactly as today (byte-identical)', () => {
+    const withoutOpts = foldBeliefGroups([{ userId: 'u1', scene: negationScene }]);
+    const flagOff = foldBeliefGroups([{ userId: 'u1', scene: negationScene }], {
+      negationDeltas: false,
+    });
+    expect(withoutOpts.folded).toEqual([]);
+    expect(flagOff).toEqual(withoutOpts);
+  });
+
+  it('flag on: empty-`to` + non-empty `from` admits the sentinel, priorValue kept', () => {
+    const { folded, conflicts } = foldBeliefGroups([{ userId: 'u1', scene: negationScene }], {
+      negationDeltas: true,
+    });
+    expect(conflicts).toEqual([]);
+    expect(folded).toHaveLength(1);
+    expect(folded[0]).toMatchObject({
+      subject: 'mikhail',
+      field: 'car',
+      value: BELIEF_NEGATION_VALUE,
+      priorValue: 'Compass',
+    });
+  });
+
+  it('flag on: empty-`to` + empty `from` stays dropped (nothing to negate)', () => {
+    const { folded } = foldBeliefGroups(
+      [
+        {
+          userId: 'u1',
+          scene: scene({
+            id: 'memory_episode:s1',
+            stateDeltas: [{ subject: 'mikhail', field: 'car', from: '', to: '' }],
+          }),
+        },
+      ],
+      { negationDeltas: true },
+    );
+    expect(folded).toEqual([]);
+  });
+});
+
+describe('foldBeliefGroups: field fold (#135 seam 2)', () => {
+  const compassScenes = [
+    {
+      userId: 'u1',
+      scene: scene({
+        id: 'memory_episode:s1',
+        occurredTo: '2026-03-01T10:00:00.000Z',
+        stateDeltas: [{ subject: 'Mikhail', field: 'car', from: '', to: 'Jeep Compass' }],
+      }),
+    },
+    {
+      userId: 'u1',
+      scene: scene({
+        id: 'memory_episode:s2',
+        conversationIds: ['conv:b'],
+        occurredTo: '2026-03-02T10:00:00.000Z',
+        stateDeltas: [{ subject: 'Mikhail', field: 'car ownership', from: 'Compass', to: '' }],
+      }),
+    },
+  ];
+
+  it('flag(s) off: the Compass fixture is byte-identical to today (one group, negation dropped)', () => {
+    const fold = foldBeliefGroups(compassScenes);
+    expect(fold.folded).toHaveLength(1);
+    expect(fold.folded[0]).toMatchObject({ field: 'car', value: 'Jeep Compass' });
+    expect(fold.fieldFolds).toEqual([]);
+    expect(fold.fieldFoldAmbiguities).toEqual([]);
+  });
+
+  it('both flags on: the two-scene Compass batch converges to ONE group with the negation winner', () => {
+    const { folded, conflicts, fieldFolds } = foldBeliefGroups(compassScenes, {
+      negationDeltas: true,
+      existingFields: new Map(),
+    });
+    expect(conflicts).toEqual([]);
+    expect(folded).toHaveLength(1);
+    // 'car ownership' folded onto the batch-seen 'car'; latest wins.
+    expect(folded[0]).toMatchObject({
+      userId: 'u1',
+      subject: 'Mikhail',
+      field: 'car',
+      value: BELIEF_NEGATION_VALUE,
+      priorValue: 'Compass',
+      sceneIds: ['memory_episode:s2'],
+    });
+    expect(fieldFolds).toEqual([
+      { userId: 'u1', subject: 'Mikhail', from: 'car ownership', to: 'car' },
+    ]);
+  });
+
+  it('folds onto an EXISTING belief field from the map (the live two-run shape)', () => {
+    const { folded, fieldFolds } = foldBeliefGroups([compassScenes[1]!], {
+      negationDeltas: true,
+      existingFields: new Map([['u1\x00Mikhail', ['car']]]),
+    });
+    expect(folded).toHaveLength(1);
+    expect(folded[0]).toMatchObject({ field: 'car', value: BELIEF_NEGATION_VALUE });
+    expect(fieldFolds).toEqual([
+      { userId: 'u1', subject: 'Mikhail', from: 'car ownership', to: 'car' },
+    ]);
+  });
+
+  it('ambiguity: two existing fields both matching — no fold, reported loudly', () => {
+    const { folded, fieldFolds, fieldFoldAmbiguities } = foldBeliefGroups(
+      [
+        {
+          userId: 'u1',
+          scene: scene({
+            id: 'memory_episode:s1',
+            stateDeltas: [{ subject: 'Mikhail', field: 'car', from: '', to: 'Jeep Compass' }],
+          }),
+        },
+      ],
+      {
+        existingFields: new Map([['u1\x00Mikhail', ['car ownership', 'car status']]]),
+      },
+    );
+    // The incoming name is KEPT — a parallel group beats a wrong merge.
+    expect(folded).toHaveLength(1);
+    expect(folded[0]).toMatchObject({ field: 'car' });
+    expect(fieldFolds).toEqual([]);
+    expect(fieldFoldAmbiguities).toEqual([
+      {
+        userId: 'u1',
+        subject: 'Mikhail',
+        field: 'car',
+        candidates: ['car ownership', 'car status'],
+      },
+    ]);
+  });
+});
+
 describe('deterministic helpers', () => {
   it('renderBeliefStatement: template with and without a prior value', () => {
     expect(
@@ -255,6 +459,16 @@ describe('deterministic helpers', () => {
         priorValue: 'porto',
       }),
     ).toBe('mika — home.city: lisbon (was: porto)');
+    // #135 seam 1: the sentinel renders through the SAME template — no
+    // special-casing anywhere downstream.
+    expect(
+      renderBeliefStatement({
+        subject: 'Mikhail',
+        field: 'car',
+        value: BELIEF_NEGATION_VALUE,
+        priorValue: 'Jeep Compass',
+      }),
+    ).toBe('Mikhail — car: none (was: Jeep Compass)');
   });
 
   it('beliefIdTail is deterministic per (user, subject, field, revision)', () => {
@@ -317,6 +531,8 @@ describe('flag resolvers', () => {
     'SCENES_BELIEF_PROMOTION',
     'SCENES_BELIEF_LLM_SYNTHESIS',
     'SCENES_BELIEF_MIN_SCENES',
+    'SCENES_BELIEF_NEGATION_DELTAS',
+    'SCENES_BELIEF_FIELD_FOLD',
   ];
   beforeEach(() => {
     for (const k of KEYS) {
@@ -331,13 +547,19 @@ describe('flag resolvers', () => {
     }
   });
 
-  it('both booleans default off', () => {
+  it('all four booleans default off', () => {
     expect(sceneBeliefPromotionEnabled()).toBe(false);
     expect(sceneBeliefLlmSynthesisEnabled()).toBe(false);
+    expect(sceneBeliefNegationDeltasEnabled()).toBe(false);
+    expect(sceneBeliefFieldFoldEnabled()).toBe(false);
     process.env.SCENES_BELIEF_PROMOTION = '1';
     process.env.SCENES_BELIEF_LLM_SYNTHESIS = '1';
+    process.env.SCENES_BELIEF_NEGATION_DELTAS = '1';
+    process.env.SCENES_BELIEF_FIELD_FOLD = '1';
     expect(sceneBeliefPromotionEnabled()).toBe(true);
     expect(sceneBeliefLlmSynthesisEnabled()).toBe(true);
+    expect(sceneBeliefNegationDeltasEnabled()).toBe(true);
+    expect(sceneBeliefFieldFoldEnabled()).toBe(true);
   });
 
   it('SCENES_BELIEF_MIN_SCENES: non-negative int, 0 = off, invalid -> 0', () => {
@@ -387,6 +609,8 @@ describe('OFF-state hard guarantee (byte-identical prod)', () => {
       eligibleScenes: 0,
       skippedMixedUser: 0,
       skippedConflict: 0,
+      fieldFolds: 0,
+      fieldFoldAmbiguous: 0,
       skippedFloor: 0,
       skippedStale: 0,
       beliefsCreated: 0,


### PR DESCRIPTION
## Problem (#135): belief promotion misses state transitions

Live evidence from a Compass scenario on the dogfood stand: scene-1 enrichment produced stateDelta `{subject:'Mikhail', field:'car', from:'', to:'Jeep Compass'}` → belief created; scene-2 produced `{subject:'Mikhail', field:'car ownership', from:'Compass', to:''}` → **no revision formed**. The belief plane still asserted "Mikhail has a Jeep Compass" while the fact plane correctly held the old status superseded. Two independent causes, both fixed here behind two default-off flags.

## Seam 1 — empty-`to` deltas were dropped by design (`SCENES_BELIEF_NEGATION_DELTAS`, default off)

`belief-promotion.service.ts` dropped every delta without a landing value:

```ts
const value = str(d.to);
// A delta without a landing value holds nothing promotable.
if (subject === '' || field === '' || value === '') continue;
```

But an empty-`to` delta with a **non-empty `from`** is a state REMOVAL (sold/quit/ended) — the owns:true→false transition, the most valuable delta class — and it vanished at this guard.

With the flag on, such a delta is admitted with the canonical negation sentinel value `none` (`BELIEF_NEGATION_VALUE`) and `priorValue = str(d.from)`. Downstream nothing changes: the existing supersede chain fires because `none` differs from the current belief value — revision N+1, old row `status='superseded'` + `validUntil` + `supersededBy`, `baselineRef` on the consumed scene. The deterministic template renders `Mikhail — car: none (was: Jeep Compass)` unchanged, and the belief serving lane needs no change. The optional LLM statement synthesis gains ONE sentence in its system prompt teaching the sentinel ("phrase it as a natural negation, never as possessing something called none") — gated by the same flag and applied only to sentinel-involving writes, via the split-constant prompt idiom (#412/#413/#415): flag off is byte-identical.

A delta with **both** ends empty stays dropped, flag on or off — nothing to negate (pinned by unit test).

## Seam 2 — exact-string (subject, field) grouping vs LLM-re-coined field names (`SCENES_BELIEF_FIELD_FOLD`, default off)

The group key was `userId\x00subject\x00field` over free-text field names the enricher re-coins per scene — `'car'` vs `'car ownership'` never collide, so the removal delta would have landed in a fresh group and created a *parallel* belief instead of revising the existing one. No canonicalization existed anywhere.

With the flag on, promotion folds an incoming field name onto a known one **before the group key is built** (so negation + fold compose), purely lexically — no embeddings, no LLM:

- **Fold rule** (`fieldsFold`, exported pure function): normalize (lowercase, trim, strip punctuation), tokenize on whitespace; fold ONLY when one token SET is a subset of the other AND every extra token of the longer name is in a small generic-modifier stoplist `{ownership, status, state, current, of, the}`.
- **Candidates**: existing ACTIVE beliefs of the same (userId, subject) — one plain `SELECT` per run (reads are safe on the 3.2.4 planner; the DELETE-WHERE-on-indexed-field trap does not apply) — plus fields already admitted earlier in the same batch, so a two-scene create+negate batch converges to ONE group.
- **Stability**: on fold, the EXISTING field name wins. An exact string match short-circuits (never re-folded).
- **Ambiguity**: more than one existing match folds NOTHING, keeps the incoming name and warns loudly — the service's "skip loudly, never flip-flop" doctrine.

Decision table (pinned verbatim in unit tests):

| incoming vs existing | verdict |
|---|---|
| `car` vs `car ownership` | fold (extra token `ownership` is generic) |
| `queue backend` vs `queue` | NO fold (`backend` not in the stoplist — conservative) |
| `car` vs `career` | NO fold (different tokens) |
| `deploy target` vs `deployment target` | NO fold (no stemming: `deploy` ≠ `deployment`) |
| `car registration` vs `car` | NO fold (`registration` names a different attribute) |

**Known limitations, accepted deliberately**: the stoplist is conservative — `queue backend`/`queue` and `deployment`/`deploy` do not fold (stemming and a broader modifier list are future work). We chose the false-negative direction: an unfolded parallel belief is recoverable; a wrong merge (`car registration` → `car`) is not.

## The live case, end to end

Both flags on: scene-2's `{field:'car ownership', from:'Compass', to:''}` folds to field `car` and lands as revision 2 of the existing belief — `value='none'`, `priorValue='Jeep Compass'` (the ACTUAL displaced value beats the delta's claimed `from`, the revision writer's established rule), old row superseded. Proven by the new e2e test against real SurrealDB 3.2.4.

## Flags & flag-off byte-identity

- Both flags live in `src/common/scene-flags.ts` (call-time `envFlagEnabled` — runtime-mutable), registered in `KNOWN_BOOLEAN_FLAGS` and the config catalog. `SCENES_` sits outside the engine flag budget — no golden bump.
- `foldBeliefGroups` with no options is byte-identical to the historical fold (pinned by unit test on a fixture containing an empty-`to` delta). Flag off ⇒ zero extra queries, identical grouping, identical synthesis prompt.
- `foldBeliefGroups` was split into `admitDeltaValue` / `foldDeltaField` / `sceneFoldContext` / `collectSceneDeltas` / `foldGroupVerdict` to stay inside the lint complexity budgets — pure refactor, same semantics.
- Additive observability: the promotion result (and final log line) gains `fieldFolds` / `fieldFoldAmbiguous` counters (0 with the flags off).

## Tests

- Fold-rule table test on the exported pure `fieldsFold` + `resolveFieldFold` (stability, no-candidate, exact-match short-circuit, ambiguity).
- `foldBeliefGroups`: no-opts byte-identity on an empty-`to` fixture; negation admission (`none`, priorValue kept); both-empty stays dropped; Compass-shaped two-scene fixture → ONE group on the folded field with the negation winner; DB-existing fold; ambiguity → no fold + reported.
- e2e (real SurrealDB 3.2.4): the full Compass scenario across two promotion runs — create, then folded negation revision 2 with supersede chain, `consolidatedInto` and `baselineRef` stamps, and no parallel `car ownership` belief; GDPR forget counts updated for the new fixture rows.

Local verification: `pnpm typecheck` clean, `pnpm test:unit` 343 suites / 3679 tests green, belief-promotion e2e 7/7 green, `eslint --max-warnings 0` and `prettier --check` clean on all touched files. Rebased on `main` after #423 (keep-both in `env-validation.ts` / `config-catalog.data.ts` verified).

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
