### PR TITLE
feat(deploy): enable literal-harvest and belief-transition flags in prod

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -297,6 +297,12 @@ jobs:
           CONFLICT_DIRECT_FACT_SLOT=1
           BELIEFS_LANE_DATE_DISAMBIGUATION=1
           PROVENANCE_EPISODE_NEIGHBOURS=1
+          # ── Literal harvest + belief transitions (#423/#426, measured:
+          # memory-fitness 70% -> 90% with the harvest lane; Compass
+          # acceptance green — negation revision + field fold) ──
+          EXTRACTOR_LITERAL_HARVEST=1
+          SCENES_BELIEF_NEGATION_DELTAS=1
+          SCENES_BELIEF_FIELD_FOLD=1
           EOF
           # The heredoc carries the YAML block's 10-space indent into the
           # file; strip it so every line is a clean KEY=value / #comment


### PR DESCRIPTION
Flips three flags, all measured on the dogfood stand:

- **`EXTRACTOR_LITERAL_HARVEST`** (#423) — fresh-tenant memory-fitness run: **21/30 (70%) → 27/30 (90%)**. D8 self-utility 5/5 (ports, LSYNC_ prefix, idempotency idiom, rate limit all served), D3 provenance 3/3 (the "50 requests per minute" fact now exists and unrolls to its verbatim turn), D2 4/4, D4 4/4, D6 2/2.
- **`SCENES_BELIEF_NEGATION_DELTAS` + `SCENES_BELIEF_FIELD_FOLD`** (#426) — Compass acceptance on a fresh tenant: the sell transition now produces `(Mikhail — car ownership) = 'none', prior='Compass'`, statement "Mikhail no longer has a car", served with both fact and belief citations. Field-name drift (`car` vs `car ownership`) folds (fieldFolds: 1, no ambiguity).

Remaining harness tails (d1-deploy metric tension, d5-mobile confabulation, d7-port flake) are tracked separately; the state-transition battery (#425) lands next as the regression harness for this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB