### PR TITLE
fix(extraction): state_change binds to the state holder, not the transitioned object

### DIFF
--- a/src/ai/extractor-internals/state-verb-harvest.ts
+++ b/src/ai/extractor-internals/state-verb-harvest.ts
@@ -1,6 +1,6 @@
 import type { ExtractedEntity, ExtractedFact } from './types';
 import { normalizeForGrounding } from './grounding';
-import { bindEntity, sentenceAt, sentenceSpans } from './literal-harvest';
+import { sentenceAt, sentenceSpans } from './literal-harvest';
 
 /**
  * Deterministic state-verb harvest lane (EXTRACTOR_STATE_VERB_HARVEST)
@@ -233,6 +233,35 @@ export interface HarvestStateVerbsArgs {
  * output is capped at STATE_VERB_HARVEST_CAP. Returns ONLY the new
  * facts for the caller to union.
  */
+/**
+ * Bind a transition to its STATE HOLDER, not to the transitioned object.
+ *
+ * A state_change is a fact about whoever's world-state changed — the
+ * person who sold/joined/returned — never about the asset or club named
+ * in the clause. The literal lane's `bindEntity` (first name-overlap
+ * win) is wrong here: it scatters a multi-stage transition across
+ * object entities ("chess club" vs "the chess club", "standing desk"
+ * vs "standing desk trial" — live run stmtp52jfw), so no single
+ * timeline retains the sequence. Policy: a PERSON entity (customer |
+ * staff) named in the sentence wins (third-party transitions — "Boris
+ * returned the company car" binds to Boris), else the speaker. Object
+ * entities are deliberately never bound; the object is already inside
+ * the harvested span.
+ */
+function bindStateHolder(
+  entities: ExtractedEntity[],
+  sentenceText: string,
+  speakerEntityIndex: number | null,
+): number | null {
+  const sentenceLower = sentenceText.toLowerCase();
+  for (const [i, e] of entities.entries()) {
+    if (e.type !== 'customer' && e.type !== 'staff') continue;
+    const name = e.name.trim().toLowerCase();
+    if (name && sentenceLower.includes(name)) return i;
+  }
+  return speakerEntityIndex;
+}
+
 export function harvestStateVerbs(args: HarvestStateVerbsArgs): ExtractedFact[] {
   const { trimmed, entities, speakerEntityIndex, existingFacts = [] } = args;
   if (!trimmed || entities.length === 0) return [];
@@ -255,7 +284,7 @@ export function harvestStateVerbs(args: HarvestStateVerbsArgs): ExtractedFact[] 
     // input, so valueSpan === object and the grounding gate passes by
     // construction.
     const span = trimmed.slice(m.index, object.end);
-    const entityIndex = bindEntity(entities, sentence.text, speakerEntityIndex);
+    const entityIndex = bindStateHolder(entities, sentence.text, speakerEntityIndex);
     if (entityIndex === null) continue;
     const key = `${entityIndex}\u0000${STATE_CHANGE_PREDICATE}\u0000${normalizeForGrounding(span)}`;
     if (seen.has(key)) continue;

--- a/test/state-verb-harvest.unit-spec.ts
+++ b/test/state-verb-harvest.unit-spec.ts
@@ -86,12 +86,28 @@ describe('harvestStateVerbs — positive table (verbatim battery turns)', () => 
     expect(facts.map((f) => f.object)).toEqual(['quit the chess club today']);
   });
 
-  it('s09 third-party turn binds to Boris by clause overlap, not the speaker', () => {
-    const entities = [ent('Boris', 'other'), ent('Sasha')];
+  it('s09 third-party turn binds to Boris — a PERSON named in the sentence wins', () => {
+    const entities = [ent('Boris', 'customer'), ent('Sasha')];
     const facts = harvest(S09_RETURN_TURN, entities, resolveSpeakerEntityIndex(entities, 'Sasha'));
     expect(facts).toHaveLength(1);
     expect(facts[0]!.object).toBe('returned the company car');
     expect(facts[0]!.entityIndex).toBe(0);
+  });
+
+  it('object entities never steal the binding — state holder is the speaker', () => {
+    // Live-run regression (stmtp52jfw): "returned the standing desk" bound
+    // to the "standing desk" asset entity, scattering the two stages of a
+    // transition across different timelines. A transition is a fact about
+    // the state HOLDER: non-person entities named in the sentence are
+    // skipped and the fact lands on the speaker.
+    const entities = [ent('standing desk', 'asset'), ent('Sasha')];
+    const facts = harvest(
+      'Returned the standing desk by evening.',
+      entities,
+      resolveSpeakerEntityIndex(entities, 'Sasha'),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.entityIndex).toBe(1);
   });
 });
 


### PR DESCRIPTION
Battery run stmtp52jfw proved the harvest lane fires correctly (19 `state_change` facts, every expected transition present) while fact-history stayed 0/3. DB evidence: the stages of one transition landed on different OBJECT entities — fragmented ones at that (`chess club` vs `the chess club`, `standing desk` vs `standing desk trial`) — so no single entity timeline retained a sequence. `bindEntity`'s first-name-overlap policy is right for literals (a port belongs to the service named next to it) and wrong for transitions.

Fix: state-verb-specific `bindStateHolder` — a PERSON entity (customer | staff) named in the sentence wins (third-party case "Boris returned the company car" keeps binding to Boris), otherwise the speaker; non-person entities are never bound. The transitioned object is already inside the harvested span text, so nothing is lost.

Measurement: battery re-run after merge — s03/s10 (and s02) history checks should finally flip: all stages now land on one holder timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB