### PR TITLE
fix(deploy): route /registry to the backend — public pack catalog was a prod 404

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -622,7 +622,7 @@ jobs:
                 # /skills.tar.gz, written there by scripts/build-openapi.ts.
                 - "traefik.enable=true"
                 - "traefik.docker.network=traefik-global"
-                - "traefik.http.routers.${{ env.PROJECT_NAME }}.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`))"
+                - "traefik.http.routers.${{ env.PROJECT_NAME }}.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || PathPrefix(\`/registry\`))"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}.priority=200"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}.entrypoints=websecure"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}.tls=true"
@@ -630,7 +630,7 @@ jobs:
                 - "traefik.http.services.${{ env.PROJECT_NAME }}.loadbalancer.server.port=${{ env.PORT }}"
                 - "traefik.http.services.${{ env.PROJECT_NAME }}.loadbalancer.responseForwarding.flushInterval=-1"
                 # http→https redirect for the same backend paths (landing has its own).
-                - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`))"
+                - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.rule=Host(\`${{ env.DOMAIN }}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || PathPrefix(\`/registry\`))"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.priority=200"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.entrypoints=web"
                 - "traefik.http.routers.${{ env.PROJECT_NAME }}-http.middlewares=redirect-to-https"


### PR DESCRIPTION
Pack-subsystem audit finding #2: `RegistryUiController` — the deliberately public, unauthenticated Domain Pack catalog (`/registry/ui`) — is live code, healthy on the stand (200, renders the catalog), but a 404 in prod: the Traefik router only forwards `/v1`, `/mcp`, `/health`, so the route fell through to the landing's Next.js catch-all. One-line change to both routers (https + the http→https redirect twin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB