### PR TITLE
feat(eval): domain-pack battery — first live exercise of the install→vocab→trace chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eval:diff": "ts-node -r tsconfig-paths/register scripts/eval-baseline-diff.ts",
     "eval:memory-fitness": "ts-node -T test/eval/memory-fitness/runner.ts",
     "eval:state-transitions": "ts-node -T test/eval/state-transitions/runner.ts",
+    "eval:domain-packs": "ts-node -T test/eval/domain-packs/runner.ts",
     "openapi:build": "ts-node -T scripts/build-openapi.ts",
     "mri:report": "ts-node -T scripts/mri-report.ts",
     "mri:record-suite": "ts-node -T scripts/mri-record-suite.ts",

--- a/test/domain-pack-scorers.unit-spec.ts
+++ b/test/domain-pack-scorers.unit-spec.ts
@@ -1,0 +1,346 @@
+/**
+ * Unit sanity for the domain-pack battery scorers (test/eval/
+ * domain-packs/scorers.ts) — the mechanical judges of the battery.
+ * Pure fixtures, no HTTP: if these are wrong, every scorecard is
+ * wrong, so they get their own spec even though the battery itself
+ * never runs in CI. The generic primitives the battery reuses
+ * (containsAnyOf, isAbstention, walkProvenance, checkHistorySequence,
+ * scoreServe, …) are covered by the siblings'
+ * test/memory-fitness-scorers.unit-spec.ts and
+ * test/state-transition-scorers.unit-spec.ts.
+ *
+ * The corpus-integrity block additionally pins the battery's own
+ * scoreability invariants (real pack predicate ids, verbatim
+ * provenance fragments, the 600-char provenance cap).
+ */
+import {
+  ALL_TURNS,
+  CHECKS,
+  FIN,
+  FIN_DOMAIN,
+  FINTECH_PACK,
+  MED,
+  MED_DOMAIN,
+  MEDICAL_PACK,
+  packPredicate,
+} from './eval/domain-packs/corpus';
+import {
+  checkCrossDomainEntity,
+  checkInterleavedDomains,
+  checkPacksInstalled,
+  findExactPredicateFact,
+  findNamespacedTools,
+  inDomain,
+  scoreServeCross,
+  type HitLike,
+  type InstalledPackLike,
+} from './eval/domain-packs/scorers';
+import type { HistoryEvent } from './eval/state-transitions/scorers';
+
+describe('domain-pack scorers', () => {
+  describe('install matcher', () => {
+    const installed: InstalledPackLike[] = [
+      { packId: 'fintech', version: '0.1.0' },
+      { packId: 'medical', version: '0.1.0' },
+      { packId: 'code_memory', version: '0.2.0' },
+    ];
+
+    it('passes when every wanted pack is installed at the wanted version', () => {
+      const v = checkPacksInstalled(installed, [
+        { packId: 'fintech', version: '0.1.0' },
+        { packId: 'medical', version: '0.1.0' },
+      ]);
+      expect(v.pass).toBe(true);
+      expect(v.detail).toContain('fintech@0.1.0');
+    });
+
+    it('fails and names an absent pack', () => {
+      const v = checkPacksInstalled(installed, [{ packId: 'legal', version: '0.1.0' }]);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('legal@0.1.0 (absent)');
+    });
+
+    it('fails and names a version mismatch', () => {
+      const v = checkPacksInstalled(installed, [{ packId: 'fintech', version: '0.2.0' }]);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('installed at v0.1.0');
+    });
+  });
+
+  describe('exact-predicate vocabulary matcher', () => {
+    const hits: HitLike[] = [
+      {
+        entityId: 'e1',
+        canonicalName: 'Meridian Clinic',
+        facts: [
+          { factId: 'f1', predicate: 'fintech__licensed_as', object: 'EMI' },
+          { factId: 'f2', predicate: 'has_license', object: 'EMI license' },
+          { factId: 'f3', predicate: 'medical__treats', object: 'type 2 diabetes' },
+        ],
+      },
+      {
+        entityId: 'e2',
+        canonicalName: 'Dr. Vega',
+        facts: [{ factId: 'f4', predicate: 'works_at', object: 'Meridian Clinic' }],
+      },
+    ];
+
+    it('passes on the exact namespaced predicate with a matching value', () => {
+      const v = findExactPredicateFact(hits, 'fintech__licensed_as', ['EMI']);
+      expect(v.pass).toBe(true);
+      expect(v.detail).toContain('f1');
+      expect(v.detail).toContain('fintech__licensed_as');
+    });
+
+    it('fails and names the coined predicates that swallowed the value', () => {
+      const v = findExactPredicateFact(hits, 'fintech__regulated_by', ['EMI']);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('coined predicate');
+      expect(v.detail).toContain('has_license');
+      // The exact-hit fact of ANOTHER predicate also counts as coinage
+      // evidence for this one — the value landed somewhere else.
+      expect(v.detail).toContain('fintech__licensed_as');
+    });
+
+    it('does not pass on the right predicate with the wrong value', () => {
+      const v = findExactPredicateFact(hits, 'fintech__licensed_as', ['broker-dealer']);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('at all');
+    });
+  });
+
+  describe('domain classifier', () => {
+    it('classifies by namespace prefix regardless of markers', () => {
+      expect(inDomain('fintech__settlement_period', 'weekly', FIN_DOMAIN)).toBe(true);
+    });
+
+    it('classifies by corpus value marker when the predicate is coined', () => {
+      expect(inDomain('settles_in', 'T+1', FIN_DOMAIN)).toBe(true);
+      expect(inDomain('dosage', '850 mg of metformin', MED_DOMAIN)).toBe(true);
+    });
+
+    it('rejects a fact matching neither namespace nor markers', () => {
+      expect(inDomain('founded_in', '2009', FIN_DOMAIN)).toBe(false);
+    });
+  });
+
+  describe('cross-domain entity check', () => {
+    const spec = {
+      entityNameToken: 'meridian',
+      domains: [FIN_DOMAIN, MED_DOMAIN] as [typeof FIN_DOMAIN, typeof MED_DOMAIN],
+      genericMarkers: ['2009', 'Lisbon'],
+    };
+    const clinic = (facts: NonNullable<HitLike['facts']>): HitLike => ({
+      entityId: 'e1',
+      canonicalName: 'Meridian Clinic',
+      facts,
+    });
+    const bothDomainFacts = [
+      { factId: 'f1', predicate: 'licensed_as', object: 'EMI' },
+      { factId: 'f2', predicate: 'medical__treats', object: 'type 2 diabetes' },
+      { factId: 'f3', predicate: 'founded_in', object: '2009' },
+    ];
+
+    it('passes on one entity carrying both domains plus a generic fact', () => {
+      const v = checkCrossDomainEntity([clinic(bothDomainFacts)], spec);
+      expect(v.pass).toBe(true);
+      expect(v.detail).toContain('fintech=1, medical=1, generic=1');
+    });
+
+    it('fails on per-domain entity duplication', () => {
+      const dup: HitLike = {
+        entityId: 'e9',
+        canonicalName: 'Meridian Clinic (payments)',
+        facts: [],
+      };
+      const v = checkCrossDomainEntity([clinic(bothDomainFacts), dup], spec);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('duplicated across 2 hits');
+    });
+
+    it('fails when one domain is missing from the entity', () => {
+      const v = checkCrossDomainEntity(
+        [
+          clinic([
+            { factId: 'f1', predicate: 'licensed_as', object: 'EMI' },
+            { factId: 'f3', predicate: 'founded_in', object: '2009' },
+          ]),
+        ],
+        spec,
+      );
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('medical=0');
+    });
+
+    it('fails when no hit carries the entity name token', () => {
+      const v = checkCrossDomainEntity(
+        [{ entityId: 'e2', canonicalName: 'Dr. Vega', facts: [] }],
+        spec,
+      );
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('no hit named');
+    });
+  });
+
+  describe('timeline interleave check', () => {
+    const ev = (predicate: string, object: string, at: string): HistoryEvent => ({
+      predicate,
+      object,
+      at,
+    });
+
+    it('passes when neither domain sits entirely before the other', () => {
+      const v = checkInterleavedDomains(
+        [
+          ev('licensed_as', 'EMI', '2026-08-31T09:00:00Z'),
+          ev('treats', 'type 2 diabetes', '2026-08-31T14:00:00Z'),
+          ev('complies_with', 'SOC 2', '2026-09-02T11:05:00Z'),
+          ev('administered_via', 'intravenous infusion', '2026-09-02T11:10:00Z'),
+        ],
+        FIN_DOMAIN,
+        MED_DOMAIN,
+      );
+      expect(v.pass).toBe(true);
+      expect(v.detail).toContain('interleave');
+    });
+
+    it('fails when one domain is a single block before the other', () => {
+      const v = checkInterleavedDomains(
+        [
+          ev('licensed_as', 'EMI', '2026-08-31T09:00:00Z'),
+          ev('settles_in', 'T+2', '2026-08-31T09:05:00Z'),
+          ev('treats', 'type 2 diabetes', '2026-09-02T14:00:00Z'),
+        ],
+        FIN_DOMAIN,
+        MED_DOMAIN,
+      );
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('do not interleave');
+    });
+
+    it('fails when a domain is absent from the timeline', () => {
+      const v = checkInterleavedDomains(
+        [ev('licensed_as', 'EMI', '2026-08-31T09:00:00Z')],
+        FIN_DOMAIN,
+        MED_DOMAIN,
+      );
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('lacks a domain');
+    });
+  });
+
+  describe('cross-domain serve verdict', () => {
+    const groups = [
+      ['EMI', 'FCA'],
+      ['diabetes', 'metformin'],
+    ];
+
+    it('passes when the answer carries a marker of every domain group', () => {
+      const v = scoreServeCross(
+        'Meridian Clinic is an FCA-regulated payments provider that also treats type 2 diabetes.',
+        undefined,
+        groups,
+      );
+      expect(v.status).toBe('pass');
+    });
+
+    it('fails and names the missing domain group', () => {
+      const v = scoreServeCross(
+        'Meridian Clinic is an FCA-regulated payments provider.',
+        undefined,
+        groups,
+      );
+      expect(v.status).toBe('fail');
+      expect(v.detail).toContain('diabetes | metformin');
+    });
+
+    it('fails on abstention — the entity is richly known', () => {
+      const v = scoreServeCross(null, 'no_facts', groups);
+      expect(v.status).toBe('fail');
+      expect(v.detail).toContain('abstained');
+    });
+  });
+
+  describe('rogue-tool scan', () => {
+    it('accepts builtin single-underscore tools', () => {
+      expect(
+        findNamespacedTools(['search_knowledge', 'get_entity_timeline', 'synthesize']),
+      ).toEqual([]);
+    });
+
+    it('flags pack-namespaced tools', () => {
+      expect(findNamespacedTools(['search_knowledge', 'fintech__score_risk'])).toEqual([
+        'fintech__score_risk',
+      ]);
+    });
+  });
+});
+
+describe('domain-pack corpus integrity', () => {
+  it('derives every referenced predicate from the real pack manifests', () => {
+    // The corpus builds these through the packPredicate guard, which
+    // throws on manifest drift — this pins the derived ids too.
+    expect(FIN.settlement).toBe('fintech__settlement_period');
+    expect(FIN.licensed).toBe('fintech__licensed_as');
+    expect(MED.treats).toBe('medical__treats');
+    expect(MED.dosed).toBe('medical__dosed_at');
+    expect(() => packPredicate(FINTECH_PACK, 'kyc_status')).toThrow(/not in fintech/);
+    expect(() => packPredicate(MEDICAL_PACK, 'specialty')).toThrow(/not in medical/);
+  });
+
+  it('targets only predicates that exist in the installed manifests', () => {
+    const known = new Set(
+      [FINTECH_PACK, MEDICAL_PACK].flatMap((pack) =>
+        pack.predicates.map((p) => `${pack.id}__${p.localId}`),
+      ),
+    );
+    for (const check of CHECKS) {
+      if (check.kind === 'pack-vocab') {
+        expect(known.has(check.predicate)).toBe(true);
+      }
+    }
+  });
+
+  it('seeds every provenance fragment verbatim in exactly one turn', () => {
+    for (const check of CHECKS) {
+      if (check.kind !== 'trace-provenance') continue;
+      for (const fragment of check.episodeFragments) {
+        const carriers = ALL_TURNS.filter((t) =>
+          t.text.toLowerCase().includes(fragment.toLowerCase()),
+        );
+        expect(carriers).toHaveLength(1);
+      }
+    }
+  });
+
+  it('keeps every turn under the 600-char provenance cap', () => {
+    for (const turn of ALL_TURNS) {
+      expect(turn.text.length).toBeLessThan(600);
+    }
+  });
+
+  it('never restates the OLD transition value in the NEW turn', () => {
+    // Scoreability: the history subsequence and the serve markers must
+    // not cross-match. For each transition check, the last-stage turn
+    // must not contain any first-stage marker.
+    for (const check of CHECKS) {
+      if (check.kind !== 'pack-transition') continue;
+      const [oldStage, newStage] = [check.stages[0], check.stages[check.stages.length - 1]];
+      if (oldStage === undefined || newStage === undefined) continue;
+      const newTurns = ALL_TURNS.filter((t) =>
+        newStage.some((m) => t.text.toLowerCase().includes(m.toLowerCase())),
+      );
+      expect(newTurns.length).toBeGreaterThan(0);
+      for (const turn of newTurns) {
+        for (const marker of oldStage) {
+          expect(turn.text.toLowerCase()).not.toContain(marker.toLowerCase());
+        }
+      }
+    }
+  });
+
+  it('uses unique check ids', () => {
+    const ids = CHECKS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/test/eval/domain-packs/README.md
+++ b/test/eval/domain-packs/README.md
@@ -1,0 +1,149 @@
+# Domain-pack battery
+
+Third mechanical battery, sibling of
+[`test/eval/memory-fitness`](../memory-fitness/README.md) (general
+first-person memory fitness, eight dimensions over one corpus) and
+[`test/eval/state-transitions`](../state-transitions/README.md) (memory
+tracks a mutable world-state). This one isolates a claim neither
+sibling touches: **memory behaves correctly WITH industry Domain Packs
+installed** — the install → vocabulary → trace chain works end to end,
+and ONE entity living in TWO domain ontologies stays a single entity
+whose facts, timeline, and provenance keep their per-domain identity.
+
+It is the **first live exercise of that chain**: the six industry packs
+(`fintech`, `medical`, `legal`, `insurance`, `real_estate`, `hr`) ship
+frozen at v0.1.0 with zero installs anywhere; only the builtin
+`code_memory` pack has ever seeded predicates. The battery installs
+`fintech` + `medical` into a fresh tenant and measures what actually
+happens.
+
+## The multi-domain trace core
+
+One userId (`dp-agent`), one shared subject: **"Meridian Clinic"** — an
+org that is deliberately BOTH a fintech client (its payments arm:
+EMI license, FCA, PCI-DSS, T+2→T+1 settlement) and a medical provider
+(its clinical side: indications, dosing, routes) — plus a person
+"Dr. Vega". Four conversations (~20 turns): one per domain (each ending
+in a transition on a pack predicate), one generic (domain-free), and
+one deliberately MIXED conversation weaving both domains, so the
+entity's timeline genuinely interleaves fintech and medical events in
+time. Predicate ids are **derived from the real pack manifests at build
+time** (`src/ai/domain-packs/{fintech,medical}.pack.ts`) through a
+guard that throws on manifest drift — the corpus can never reference an
+ontology that doesn't exist.
+
+Why one entity in two ontologies: per-domain entity duplication, domain
+cross-contamination in serving, and provenance that loses its domain
+identity are exactly the failures a domain-pack platform can introduce
+— and none of them are visible while every eval corpus lives inside a
+single domain.
+
+## Check battery (all mechanical — see `types.ts` / `scorers.ts`)
+
+| id      | kind             | What would falsify the claim                                                                                                      |
+| ------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| c01     | install          | phase 0 "succeeded" but the packs are not in the installed list                                                                   |
+| c02-c05 | pack-vocab       | domain phrasing coined an open-vocab predicate instead of the exact `fintech__*` / `medical__*` id (baseline finding — see below) |
+| c06-c07 | pack-transition  | T+2→T+1 / 500 mg→850 mg loses a stage or reorders (sibling `checkHistorySequence`)                                                |
+| c08     | cross-entity     | the clinic splits into per-domain entities, or one domain's facts are missing from the single entity                              |
+| c09-c10 | trace-provenance | a fintech/medical fact does not unroll to its OWN domain's seeded turn (sibling `walkProvenance`)                                 |
+| c11     | trace-interleave | the shared timeline lacks a domain, or one domain sits entirely before the other (no genuine interleave)                          |
+| c12     | serve-cross      | "Tell me about Meridian Clinic" serves only one domain (or abstains on a richly-known entity)                                     |
+| c13-c14 | serve-isolation  | a settlement question confabulates doses, a dosing question confabulates fintech values                                           |
+| c15     | no-rogue-tools   | tools/list exposes a `__`-namespaced pack tool although no installed pack declares `mcpTools`                                     |
+
+Scoring reuses the siblings' unit-tested primitives (`containsAnyOf`,
+`isAbstention`, `missingKeyPhrases`, `walkProvenance`,
+`checkHistorySequence`, `scoreServe`) — one implementation, one truth —
+and adds only pack-specific scorers, unit-tested in
+`test/domain-pack-scorers.unit-spec.ts`. **No LLM judge, no paid eval**
+— the only model spend is the stand's own extraction + serving cost
+(~20 mention extractions + 3 synthesize calls, well under $1 per run
+on the default stand models).
+
+## Honest-baseline policy for `pack-vocab`
+
+The four vocabulary checks are annotated `expectedUnknown` (this
+battery's variant of the state-transitions `knownFailToday` idea, for
+an outcome that has _never been measured_ rather than one known to be
+broken): whether mention-path extraction consults an installed pack's
+`extractionProfile` has zero prior observations, and today's likely
+outcome is that it does NOT — extraction coins open-vocab predicates
+(`has_license`) instead of canonicalizing into pack vocabulary
+(`fintech__licensed_as`).
+
+**A fail there is the finding, not a defect of the battery.** The
+runner still executes the checks, the report records the exact coined
+predicates that swallowed each domain value (so the gap is diagnosable
+from the scorecard alone), and the scorecard tallies these fails
+separately (`failedExpectedUnknown`). A run where they pass is the
+signal pack-vocabulary extraction has landed. Everything downstream is
+deliberately vocabulary-independent: the cross-domain checks classify
+facts **namespace-first, corpus-value-marker-fallback**, so they get
+stronger as pack vocabulary adoption grows but stay meaningful before
+it.
+
+Similarly `no-rogue-tools` asserts a NO-OP honestly: no pack today
+declares `mcpTools`, `memoryModel`, or `seedDocuments`, so the correct
+observable is _zero_ `__`-namespaced tools in `tools/list` even with
+packs installed (pack tools surface as `<packId>__<tool>` — the
+`code_memory__decided` naming law). The day a pack ships tools, this
+check flips into a positive assertion (the pack's tools present, no
+one else's).
+
+## Running against a local stand
+
+Same stand as the siblings: a booted brain (with its OpenAI key),
+driven purely over the wire — **never run in CI** (the runner exits
+with a clear message when `BRAIN_BASE_URL` is unset).
+
+Prerequisites beyond the siblings':
+
+- **A FRESH tenant per run** (`BRAIN_COMPANY_ID`) — the battery
+  installs packs into it and asserts entity dedup, both of which a
+  reused tenant contaminates.
+- **The GLOBAL pack registry must hold `fintech` + `medical`** —
+  one-time per environment:
+  `BRAIN_API_KEY=<registry:publish key> pnpm registry:seed -- --brain-url <url>`.
+  Phase 0 installs via `POST /v1/admin/packs/from-registry`; when the
+  registry entry is missing it attempts to republish the LOCAL manifest
+  (checksum-pinned) through `POST /v1/admin/registry/packs`, and when
+  the key cannot publish it **fails with the instruction above** —
+  setup is never silently skipped.
+- The API key needs `brain:read + brain:write + brain:admin`
+  (`registry:publish` too if you want the runner to self-seed the
+  registry).
+
+Stand flags that shape coverage:
+
+- `FACTS_API_ENABLED=1` — required for the trace-provenance checks
+  (`get_fact_provenance` is otherwise absent; those checks are
+  skipped, never silently passed).
+- `THROTTLE_DISABLED=1` — recommended: mention ingest and the MCP
+  route are rate-capped; without it the runner backs off on 429.
+- No scene/belief flags are needed — this battery reads facts,
+  timelines, and provenance straight from mention ingest and runs no
+  admin builds.
+
+Then:
+
+```bash
+BRAIN_BASE_URL=http://localhost:3000 \
+BRAIN_API_KEY=... \
+BRAIN_COMPANY_ID=<fresh tenant> \
+pnpm eval:domain-packs
+```
+
+Knobs (`DPEV_` prefix, mirroring the siblings' `MEMFIT_`/`STEV_`):
+`DPEV_USER_ID` (default `dp-agent`), `DPEV_RUN_ID` (default
+time-derived; conversation ids are run-scoped so re-runs never
+collide), `DPEV_GUARDRAILS` (`strict`|`lenient`|`off`, default
+`strict`), `DPEV_SKIP_INGEST=1` (re-ask an already-ingested run —
+requires the same `DPEV_RUN_ID`), `DPEV_REPORT_DIR` (default
+`var/domain-packs/`).
+
+The JSON scorecard lands in
+`var/domain-packs/domain-packs-<runId>.json` — per-class and
+per-check-kind tallies, the phase-0 setup trail, every verdict with
+its detail (and the raw served answers), so any verdict is
+reproducible from the report file alone.

--- a/test/eval/domain-packs/corpus.ts
+++ b/test/eval/domain-packs/corpus.ts
@@ -1,0 +1,320 @@
+/**
+ * The multi-domain corpus and check battery: ~20 turns about ONE
+ * shared subject — "Meridian Clinic", an org that is BOTH a fintech
+ * client (its payments arm) and a medical provider (its clinical
+ * side) — plus a person "Dr. Vega". One conversation per domain, one
+ * generic (domain-free) conversation, and one deliberately MIXED
+ * conversation weaving both domains, so the entity's timeline
+ * genuinely interleaves fintech and medical events in time.
+ *
+ * Predicate ids are DERIVED from the real pack manifests at build
+ * time (src/ai/domain-packs/{fintech,medical}.pack.ts) through a
+ * guard that throws when a referenced localId leaves the pack — the
+ * corpus can never drift from the ontology it exercises. Turn
+ * phrasing is chosen to hit those predicates' ADMIT rules:
+ * fintech__licensed_as/"licensed as an EMI", medical__dosed_at/"dosed
+ * at 500 mg twice daily", etc.
+ *
+ * Scoreability rules inherited from the siblings:
+ *  - transition turns never restate the OLD value, so the history
+ *    subsequence and the serve markers cannot cross-match;
+ *  - every provenance fragment appears VERBATIM in exactly one turn,
+ *    under the 600-char provenance text cap;
+ *  - serve markers are value-shaped ("T+1", "850 mg") and never occur
+ *    in decline phrasings.
+ */
+import { FINTECH_PACK } from '../../../src/ai/domain-packs/fintech.pack';
+import { MEDICAL_PACK } from '../../../src/ai/domain-packs/medical.pack';
+import type { DomainPackManifest } from '../../../src/ai/domain-packs/manifest';
+import type { Check, CorpusTurn, DomainSpec } from './types';
+
+export { FINTECH_PACK, MEDICAL_PACK };
+
+/** The vertical every corpus write attributes itself to. */
+export const CORPUS_VERTICAL = 'work';
+
+/** The shared subject entity — one org, two domain ontologies. */
+export const MERIDIAN_REF = { vertical: CORPUS_VERTICAL, id: 'org-meridian-clinic' } as const;
+export const MERIDIAN_NAME = 'Meridian Clinic';
+
+/** The person anchor entity. */
+export const VEGA_REF = { vertical: CORPUS_VERTICAL, id: 'person-dr-vega' } as const;
+export const VEGA_NAME = 'Dr. Vega';
+
+/**
+ * Namespaced pack predicate id, guarded against manifest drift: a
+ * localId that leaves the pack makes the corpus refuse to build.
+ */
+export function packPredicate(pack: DomainPackManifest, localId: string): string {
+  if (!pack.predicates.some((p) => p.localId === localId)) {
+    throw new Error(
+      `corpus references ${pack.id}__${localId}, which is not in ${pack.id}@${pack.version}`,
+    );
+  }
+  return `${pack.id}__${localId}`;
+}
+
+/** Real fintech predicate ids (fintech@0.1.0). */
+export const FIN = {
+  licensed: packPredicate(FINTECH_PACK, 'licensed_as'),
+  regulated: packPredicate(FINTECH_PACK, 'regulated_by'),
+  complies: packPredicate(FINTECH_PACK, 'complies_with'),
+  capital: packPredicate(FINTECH_PACK, 'capital_requirement'),
+  settlement: packPredicate(FINTECH_PACK, 'settlement_period'),
+} as const;
+
+/** Real medical predicate ids (medical@0.1.0). */
+export const MED = {
+  treats: packPredicate(MEDICAL_PACK, 'treats'),
+  dosed: packPredicate(MEDICAL_PACK, 'dosed_at'),
+  route: packPredicate(MEDICAL_PACK, 'administered_via'),
+  interacts: packPredicate(MEDICAL_PACK, 'interacts_with'),
+} as const;
+
+/** Timestamp of turn N (1-based) — 5 minutes apart within a session. */
+const t = (startIso: string, turn: number): string =>
+  new Date(Date.parse(startIso) + (turn - 1) * 5 * 60_000).toISOString();
+
+const conv = (conversation: string, startIso: string, texts: string[]): CorpusTurn[] =>
+  texts.map((text, i) => ({ conversation, turn: i + 1, emittedAt: t(startIso, i + 1), text }));
+
+// ── the four conversations ──────────────────────────────────────────
+// fin (day 1 morning) and med (day 1 afternoon) each end in a
+// transition; mix (day 3) adds LATE events of both domains, so
+// neither domain sits entirely before the other on the timeline.
+
+/** Fintech conversation — hits licensed_as / regulated_by /
+ *  complies_with / capital_requirement, then transitions
+ *  settlement_period T+2 → T+1 (single_active). */
+const FIN_TURNS = conv('fin', '2026-08-31T09:00:00Z', [
+  'Meridian Clinic runs its own payments arm and is licensed as an EMI.',
+  "Meridian Clinic's payments arm is regulated by the FCA.",
+  "Meridian Clinic's payment gateway is PCI-DSS compliant.",
+  'Meridian Clinic must hold €2M in own funds as its capital requirement.',
+  "Meridian Clinic's card settlements settle T+2.",
+  "Since this week, Meridian Clinic's card settlements settle T+1.",
+]);
+
+/** Medical conversation — hits treats / administered_via, then
+ *  transitions dosed_at 500 mg → 850 mg (single_active). */
+const MED_TURNS = conv('med', '2026-08-31T14:00:00Z', [
+  'Meridian Clinic treats type 2 diabetes in its outpatient program.',
+  'Dr. Vega runs the infusion unit at Meridian Clinic.',
+  "Meridian Clinic's antibiotic therapy is administered via intravenous infusion.",
+  "Meridian Clinic's standard metformin course is dosed at 500 mg twice daily.",
+  'Meridian Clinic revised its standard metformin course: it is now dosed at 850 mg twice daily.',
+  'Meridian Clinic treats hypertension in its cardiology wing.',
+]);
+
+/** Generic conversation — domain-free turns about the SAME entity. */
+const GEN_TURNS = conv('gen', '2026-09-01T10:00:00Z', [
+  'Meridian Clinic was founded in 2009.',
+  'Meridian Clinic is headquartered in Lisbon.',
+  'Dr. Vega has worked at Meridian Clinic since 2019.',
+  'Dr. Vega specializes in endocrinology.',
+]);
+
+/** Mixed conversation — both domains inside ONE conversation, and the
+ *  LATE event of each domain (the interleave anchors). */
+const MIX_TURNS = conv('mix', '2026-09-02T11:00:00Z', [
+  "Dr. Vega reported that Meridian Clinic's warfarin protocol interacts with aspirin.",
+  "Meridian Clinic's payments arm passed its audit — the gateway complies with SOC 2.",
+  "Meridian Clinic's oncology unit administers rituximab via intravenous infusion.",
+  "Meridian Clinic's payment gateway also meets KYC requirements.",
+]);
+
+export const ALL_TURNS: CorpusTurn[] = [...FIN_TURNS, ...MED_TURNS, ...GEN_TURNS, ...MIX_TURNS];
+
+// ── domain lenses ───────────────────────────────────────────────────
+// Markers are corpus VALUES (regulators, standards, doses, drugs) —
+// never generic words — so a fact matches its domain by content even
+// while extraction still coins open-vocab predicates.
+
+export const FIN_DOMAIN: DomainSpec = {
+  namespace: FINTECH_PACK.id,
+  markers: ['EMI', 'FCA', 'PCI-DSS', 'T+2', 'T+1', 'own funds', 'SOC 2', 'KYC'],
+};
+
+export const MED_DOMAIN: DomainSpec = {
+  namespace: MEDICAL_PACK.id,
+  markers: [
+    'diabetes',
+    'metformin',
+    'hypertension',
+    'intravenous',
+    'infusion',
+    'warfarin',
+    'aspirin',
+    'rituximab',
+  ],
+};
+
+/** Markers of the generic (domain-free) turns. */
+export const GENERIC_MARKERS = ['2009', 'Lisbon', 'founded', 'headquartered'];
+
+// ── the checks ──────────────────────────────────────────────────────
+
+const VOCAB_BASELINE =
+  'Outcome never measured: mention extraction may not consult the installed ' +
+  "pack's extractionProfile on this path yet, so a coined open-vocab " +
+  'predicate here is the baseline finding this battery exists to record.';
+
+export const CHECKS: Check[] = [
+  // ── install ───────────────────────────────────────────────────────
+  {
+    kind: 'install',
+    id: 'c01-install',
+    cls: 'setup',
+    intent: 'Both industry packs are actually installed in the tenant after phase 0.',
+    packs: [
+      { packId: FINTECH_PACK.id, version: FINTECH_PACK.version },
+      { packId: MEDICAL_PACK.id, version: MEDICAL_PACK.version },
+    ],
+  },
+
+  // ── pack-vocab (2 per domain, honest baseline) ────────────────────
+  {
+    kind: 'pack-vocab',
+    id: 'c02-vocab-fin-licensed',
+    cls: 'vocab',
+    intent: `"licensed as an EMI" canonicalizes into ${FIN.licensed}, not a coined predicate.`,
+    searchQuery: 'Meridian Clinic EMI license',
+    predicate: FIN.licensed,
+    valueMarkers: ['EMI'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'c03-vocab-fin-settlement',
+    cls: 'vocab',
+    intent: `the settlement window lands on ${FIN.settlement} with a verbatim T+n value.`,
+    searchQuery: 'Meridian Clinic card settlement period',
+    predicate: FIN.settlement,
+    valueMarkers: ['T+1', 'T+2'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'c04-vocab-med-treats',
+    cls: 'vocab',
+    intent: `a treated condition lands on ${MED.treats} with the verbatim condition.`,
+    searchQuery: 'Meridian Clinic diabetes treatment',
+    predicate: MED.treats,
+    valueMarkers: ['diabetes', 'hypertension'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'c05-vocab-med-dosed',
+    cls: 'vocab',
+    intent: `the metformin dose lands on ${MED.dosed} with the verbatim dose.`,
+    searchQuery: 'Meridian Clinic metformin dose',
+    predicate: MED.dosed,
+    valueMarkers: ['850 mg', '500 mg'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+
+  // ── pack-transition (1 per domain) ────────────────────────────────
+  {
+    kind: 'pack-transition',
+    id: 'c06-transition-fin',
+    cls: 'transition',
+    intent: 'The settlement transition retains T+2 → T+1 as ordered history.',
+    searchQuery: 'Meridian Clinic card settlement',
+    stages: [['T+2'], ['T+1']],
+  },
+  {
+    kind: 'pack-transition',
+    id: 'c07-transition-med',
+    cls: 'transition',
+    intent: 'The dosing transition retains 500 mg → 850 mg as ordered history.',
+    searchQuery: 'Meridian Clinic metformin course',
+    stages: [['500 mg'], ['850 mg']],
+  },
+
+  // ── cross-domain entity ───────────────────────────────────────────
+  {
+    kind: 'cross-entity',
+    id: 'c08-cross-entity',
+    cls: 'cross-domain',
+    intent:
+      'ONE Meridian Clinic entity carries fintech + medical + generic facts — ' +
+      'no per-domain entity duplication.',
+    searchQuery: 'Meridian Clinic',
+    entityNameToken: 'meridian',
+    domains: [FIN_DOMAIN, MED_DOMAIN],
+    genericMarkers: GENERIC_MARKERS,
+  },
+
+  // ── cross-domain trace ────────────────────────────────────────────
+  {
+    kind: 'trace-provenance',
+    id: 'c09-trace-fin',
+    cls: 'trace',
+    intent: "A fintech fact unrolls to the fintech conversation's seeded turn.",
+    searchQuery: 'Meridian Clinic EMI license',
+    objectHint: ['EMI'],
+    episodeFragments: ['licensed as an EMI'],
+  },
+  {
+    kind: 'trace-provenance',
+    id: 'c10-trace-med',
+    cls: 'trace',
+    intent: "A medical fact unrolls to the medical conversation's seeded turn.",
+    searchQuery: 'Meridian Clinic type 2 diabetes',
+    objectHint: ['diabetes'],
+    episodeFragments: ['treats type 2 diabetes'],
+  },
+  {
+    kind: 'trace-interleave',
+    id: 'c11-trace-interleave',
+    cls: 'trace',
+    intent:
+      "The shared entity's timeline holds events of BOTH domains and neither " +
+      'domain sits entirely before the other in time.',
+    searchQuery: 'Meridian Clinic',
+    entityNameToken: 'meridian',
+    domains: [FIN_DOMAIN, MED_DOMAIN],
+  },
+
+  // ── serving ───────────────────────────────────────────────────────
+  {
+    kind: 'serve-cross',
+    id: 'c12-serve-cross',
+    cls: 'serving',
+    intent: 'A broad question about the entity serves facts from BOTH domains.',
+    query: 'Tell me about Meridian Clinic.',
+    requireGroups: [
+      ['EMI', 'FCA', 'PCI-DSS', 'T+1', 'T+2', 'SOC 2', 'KYC', '€2M'],
+      ['diabetes', 'metformin', 'hypertension', 'intravenous', 'warfarin', 'rituximab', '850 mg'],
+    ],
+  },
+  {
+    kind: 'serve-isolation',
+    id: 'c13-isolation-fin',
+    cls: 'serving',
+    intent: 'A fintech question answers from the fintech fact, no medical confabulation.',
+    query: 'What settlement period do Meridian Clinic card settlements use?',
+    expectAnyOf: ['T+1'],
+    forbidAnyOf: ['metformin', '850 mg', '500 mg', 'diabetes', 'warfarin', 'intravenous'],
+  },
+  {
+    kind: 'serve-isolation',
+    id: 'c14-isolation-med',
+    cls: 'serving',
+    intent: 'A medical question answers from the medical fact, no fintech confabulation.',
+    query: "What is the dose of Meridian Clinic's standard metformin course?",
+    expectAnyOf: ['850'],
+    forbidAnyOf: ['T+1', 'T+2', 'EMI', 'FCA', 'PCI-DSS', 'SOC 2', '€2M'],
+  },
+
+  // ── surfaces ──────────────────────────────────────────────────────
+  {
+    kind: 'no-rogue-tools',
+    id: 'c15-no-rogue-tools',
+    cls: 'surfaces',
+    intent:
+      'Neither installed pack declares mcpTools, so tools/list must carry ZERO ' +
+      '__-namespaced pack tools — the no-op is asserted, not assumed.',
+  },
+];

--- a/test/eval/domain-packs/runner.ts
+++ b/test/eval/domain-packs/runner.ts
@@ -1,0 +1,743 @@
+/**
+ * Domain-pack battery runner — drives EVERYTHING through the real
+ * wire, mirroring the memory-fitness / state-transitions siblings:
+ *
+ *  - REST  GET/POST /v1/admin/packs[.../from-registry]
+ *          (phase 0: install fintech + medical into the tenant; a
+ *          missing registry entry is republished from the local
+ *          manifest when the key can, else the runner FAILS with the
+ *          registry:seed instructions — setup is never silently skipped)
+ *  - REST  POST /v1/ingest/mention            (corpus turns, per-user scoped)
+ *  - MCP   tools/list / synthesize / search_knowledge /
+ *          get_entity_timeline / get_fact_provenance
+ *
+ * Scoring is fully mechanical (see scorers.ts) — no LLM judge. The
+ * serving calls cost normal model spend on the stand; the battery
+ * itself spends nothing on judging.
+ *
+ * Run: pnpm eval:domain-packs   (see README.md for stand flags)
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { packChecksum } from '../../../src/ai/domain-packs/checksum';
+import type { DomainPackManifest } from '../../../src/ai/domain-packs/manifest';
+import { HttpBrainClient } from '../http-brain-client';
+import { interleaveRoundRobin } from '../memory-fitness/interleave';
+import { walkProvenance } from '../memory-fitness/scorers';
+import { checkHistorySequence, scoreServe, type HistoryEvent } from '../state-transitions/scorers';
+import {
+  ALL_TURNS,
+  CHECKS,
+  CORPUS_VERTICAL,
+  FINTECH_PACK,
+  MEDICAL_PACK,
+  MERIDIAN_NAME,
+  MERIDIAN_REF,
+  VEGA_NAME,
+  VEGA_REF,
+} from './corpus';
+import {
+  checkCrossDomainEntity,
+  checkInterleavedDomains,
+  checkPacksInstalled,
+  findExactPredicateFact,
+  findNamespacedTools,
+  scoreServeCross,
+  type HitLike,
+  type InstalledPackLike,
+} from './scorers';
+import type {
+  Check,
+  CheckKind,
+  CheckResult,
+  CrossEntityCheck,
+  InstallCheck,
+  PackTransitionCheck,
+  PackVocabCheck,
+  Scorecard,
+  ServeCrossCheck,
+  ServeIsolationCheck,
+  Tally,
+  TraceInterleaveCheck,
+  TraceProvenanceCheck,
+} from './types';
+
+/** Provenance-walk budget per check (sibling round-robin interleave). */
+const PROVENANCE_CANDIDATE_CAP = 12;
+
+/** How many search hits get their timeline walked per transition check. */
+const HISTORY_ENTITY_CAP = 6;
+
+// ── configuration ───────────────────────────────────────────────────
+
+interface Config {
+  baseUrl: string;
+  apiKey: string;
+  companyId: string;
+  userId: string;
+  runId: string;
+  guardrails: 'strict' | 'lenient' | 'off';
+  skipIngest: boolean;
+  reportDir: string;
+}
+
+function loadConfig(): Config {
+  const baseUrl = process.env.BRAIN_BASE_URL ?? process.env.BRAIN_URL;
+  const apiKey = process.env.BRAIN_API_KEY;
+  const companyId = process.env.BRAIN_COMPANY_ID;
+  if (baseUrl === undefined || baseUrl === '') {
+    console.error(
+      [
+        'domain-packs: BRAIN_BASE_URL is not set — nothing to run against.',
+        'This battery drives a LIVE brain stand over MCP + REST (it needs a booted',
+        'service and its OpenAI key) and is intentionally never run in CI.',
+        '',
+        'Required env:',
+        '  BRAIN_BASE_URL   e.g. http://localhost:3000  (BRAIN_URL also accepted)',
+        '  BRAIN_API_KEY    tenant M2M key with brain:read + brain:write + brain:admin',
+        '                   (phase 0 installs the packs through /v1/admin/packs)',
+        '  BRAIN_COMPANY_ID tenant id — use a FRESH tenant per run (see README.md)',
+        '',
+        'Prerequisite: the GLOBAL pack registry must hold fintech + medical',
+        '(one-time: BRAIN_API_KEY=<registry:publish key> pnpm registry:seed -- \\',
+        '  --brain-url <url>). The runner republishes from the local manifests',
+        'when its key can; otherwise it fails with this instruction.',
+        '',
+        'Optional env: DPEV_USER_ID, DPEV_RUN_ID, DPEV_GUARDRAILS',
+        '(strict|lenient|off, default strict), DPEV_SKIP_INGEST=1 (re-ask an',
+        'already-ingested run — requires the same DPEV_RUN_ID), DPEV_REPORT_DIR.',
+      ].join('\n'),
+    );
+    process.exit(1);
+  }
+  if (apiKey === undefined || apiKey === '') {
+    console.error('domain-packs: BRAIN_API_KEY is not set.');
+    process.exit(1);
+  }
+  if (companyId === undefined || companyId === '') {
+    console.error('domain-packs: BRAIN_COMPANY_ID is not set.');
+    process.exit(1);
+  }
+  const guardrailsRaw = process.env.DPEV_GUARDRAILS ?? 'strict';
+  if (guardrailsRaw !== 'strict' && guardrailsRaw !== 'lenient' && guardrailsRaw !== 'off') {
+    console.error('domain-packs: DPEV_GUARDRAILS must be strict|lenient|off.');
+    process.exit(1);
+  }
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ''),
+    apiKey,
+    companyId,
+    userId: process.env.DPEV_USER_ID ?? 'dp-agent',
+    runId: process.env.DPEV_RUN_ID ?? `dp${Date.now().toString(36)}`,
+    guardrails: guardrailsRaw,
+    skipIngest: process.env.DPEV_SKIP_INGEST === '1',
+    reportDir: process.env.DPEV_REPORT_DIR ?? join('var', 'domain-packs'),
+  };
+}
+
+// ── small utilities ─────────────────────────────────────────────────
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Retry on throttle (HTTP 429) — mention ingest and the MCP route are rate-capped. */
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      const msg = String(err);
+      if (attempt < 12 && /429|too many requests/i.test(msg)) {
+        console.error(`  [throttled] ${label} — waiting 6.5s (attempt ${attempt})`);
+        await sleep(6_500);
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/** Run-scoped conversation id — makes re-runs non-colliding by construction. */
+const convId = (cfg: Config, key: string): string => `${cfg.runId}-${key}`;
+
+const messageId = (cfg: Config, key: string, turn: number): string =>
+  `${convId(cfg, key)}-t${String(turn).padStart(2, '0')}`;
+
+// ── REST (raw, non-throwing — the setup phase branches on the status) ──
+
+interface RestResult<T> {
+  status: number;
+  json: T | null;
+}
+
+async function restRaw<T>(
+  cfg: Config,
+  method: 'GET' | 'POST',
+  path: string,
+  body?: unknown,
+): Promise<RestResult<T>> {
+  const res = await fetch(`${cfg.baseUrl}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${cfg.apiKey}`,
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  const ct = res.headers.get('content-type') ?? '';
+  if (!ct.includes('application/json')) return { status: res.status, json: null };
+  return { status: res.status, json: (await res.json()) as T };
+}
+
+// ── MCP ─────────────────────────────────────────────────────────────
+
+interface ToolCallShape {
+  isError?: boolean;
+  content?: unknown;
+  structuredContent?: unknown;
+}
+
+function textOf(res: ToolCallShape): string | null {
+  if (!Array.isArray(res.content)) return null;
+  for (const item of res.content) {
+    if (
+      item !== null &&
+      typeof item === 'object' &&
+      (item as { type?: unknown }).type === 'text' &&
+      typeof (item as { text?: unknown }).text === 'string'
+    ) {
+      return (item as { text: string }).text;
+    }
+  }
+  return null;
+}
+
+async function connectMcp(cfg: Config): Promise<McpClient> {
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`${cfg.baseUrl}/mcp/${cfg.companyId}`),
+    { requestInit: { headers: { Authorization: `Bearer ${cfg.apiKey}` } } },
+  );
+  const client = new McpClient({ name: 'domain-packs-battery', version: '1.0.0' });
+  // Same @modelcontextprotocol/sdk .d.ts self-inconsistency the server
+  // side bridges in src/mcp/mcp.controller.ts: under
+  // exactOptionalPropertyTypes the concrete transport class no longer
+  // structurally satisfies its own Transport interface. The runtime
+  // value genuinely is a valid Transport; this asserts the SDK's own
+  // contract, not our types.
+  await client.connect(transport as Transport);
+  return client;
+}
+
+async function callTool<T>(
+  mcp: McpClient,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const raw = (await withRetry(name, () =>
+    mcp.callTool({ name, arguments: args }),
+  )) as ToolCallShape;
+  const text = textOf(raw);
+  if (raw.isError === true) {
+    throw new Error(`MCP tool ${name} failed: ${text ?? '(no error text)'}`);
+  }
+  if (text !== null) return JSON.parse(text) as T;
+  if (raw.structuredContent !== undefined) return raw.structuredContent as T;
+  throw new Error(`MCP tool ${name} returned neither text nor structuredContent`);
+}
+
+// Local wire shapes — only the fields the scorers consume.
+interface SearchHit {
+  entityId: string;
+  canonicalName?: string;
+  facts?: Array<{ factId: string; predicate: string; object: string }>;
+}
+interface SearchOut {
+  results?: SearchHit[];
+}
+interface SynthOut {
+  answer: string | null;
+  reason?: string;
+}
+interface TimelineOut {
+  events?: Array<{ type: string; at: string; predicate?: string; object?: string }>;
+}
+interface ProvenanceOut {
+  factId?: string;
+  episodes?: Array<{ episodeId?: string; text?: string }>;
+}
+interface PacksListOut {
+  installed?: Array<InstalledPackLike & { predicateCount?: number }>;
+}
+interface InstallOut {
+  packId?: string;
+  version?: string;
+  predicatesSeeded?: number;
+}
+
+// ── phase 0: pack setup (idempotent) ────────────────────────────────
+
+const seedInstruction = (cfg: Config): string =>
+  [
+    'The GLOBAL pack registry does not hold the pack and this key cannot',
+    'publish it. Seed the registry once with a registry:publish key:',
+    `  BRAIN_API_KEY=<registry:publish key> pnpm registry:seed -- --brain-url ${cfg.baseUrl}`,
+    'then re-run pnpm eval:domain-packs.',
+  ].join('\n');
+
+async function installOnePack(cfg: Config, pack: DomainPackManifest): Promise<string> {
+  const fromRegistry = (): Promise<RestResult<InstallOut>> =>
+    restRaw<InstallOut>(cfg, 'POST', '/v1/admin/packs/from-registry', {
+      packId: pack.id,
+      version: pack.version,
+    });
+  let res = await fromRegistry();
+  let republished = false;
+  if (res.status < 200 || res.status >= 300) {
+    // Registry likely empty (fresh stand: zero installs anywhere). Try to
+    // publish the LOCAL manifest through the registry admin route — the
+    // seed script's logic over REST, checksum-pinned.
+    const pub = await restRaw<Record<string, unknown>>(cfg, 'POST', '/v1/admin/registry/packs', {
+      manifest: pack,
+      expectedChecksum: packChecksum(pack),
+    });
+    if (pub.status >= 200 && pub.status < 300) {
+      republished = true;
+      res = await fromRegistry();
+    } else {
+      console.error(
+        `domain-packs: install of ${pack.id}@${pack.version} failed ` +
+          `(from-registry HTTP ${res.status}; registry publish HTTP ${pub.status}).`,
+      );
+      console.error(seedInstruction(cfg));
+      process.exit(1);
+    }
+  }
+  if (res.status < 200 || res.status >= 300) {
+    console.error(
+      `domain-packs: install of ${pack.id}@${pack.version} still failed after ` +
+        `registry publish (HTTP ${res.status}). Fix the stand before running.`,
+    );
+    process.exit(1);
+  }
+  return (
+    `installed v${res.json?.version ?? pack.version} ` +
+    `(predicatesSeeded=${res.json?.predicatesSeeded ?? '?'}` +
+    `${republished ? ', registry-published from local manifest' : ''})`
+  );
+}
+
+async function ensurePackSetup(cfg: Config): Promise<Record<string, string>> {
+  const setup: Record<string, string> = {};
+  const list = await restRaw<PacksListOut>(cfg, 'GET', '/v1/admin/packs');
+  if (list.status === 401 || list.status === 403) {
+    console.error(
+      `domain-packs: GET /v1/admin/packs -> HTTP ${list.status} — the key lacks ` +
+        'brain:admin. Phase 0 installs packs and cannot be skipped.',
+    );
+    process.exit(1);
+  }
+  if (list.status < 200 || list.status >= 300) {
+    console.error(`domain-packs: GET /v1/admin/packs -> HTTP ${list.status}.`);
+    process.exit(1);
+  }
+  const installed = list.json?.installed ?? [];
+  for (const pack of [FINTECH_PACK, MEDICAL_PACK]) {
+    const already = installed.find((p) => p.packId === pack.id);
+    if (already !== undefined) {
+      setup[pack.id] = `already installed v${already.version}`;
+      console.error(`[setup] ${pack.id}: ${setup[pack.id]}`);
+      continue;
+    }
+    setup[pack.id] = await installOnePack(cfg, pack);
+    console.error(`[setup] ${pack.id}: ${setup[pack.id]}`);
+  }
+  return setup;
+}
+
+// ── phase 1: write the corpus ───────────────────────────────────────
+
+async function ingestTurns(cfg: Config, brain: HttpBrainClient): Promise<void> {
+  console.error(`[ingest] ${ALL_TURNS.length} mention turns (run ${cfg.runId})…`);
+  for (const [i, turn] of ALL_TURNS.entries()) {
+    const knownEntities: Array<Record<string, string>> = [];
+    if (turn.text.includes('Meridian')) {
+      knownEntities.push({ ...MERIDIAN_REF, name: MERIDIAN_NAME });
+    }
+    if (turn.text.includes('Vega')) {
+      knownEntities.push({ ...VEGA_REF, name: VEGA_NAME });
+    }
+    await withRetry(`mention ${turn.conversation}#${turn.turn}`, () =>
+      brain.ingest.mention({
+        text: turn.text,
+        contextRef: {
+          vertical: CORPUS_VERTICAL,
+          conversationId: convId(cfg, turn.conversation),
+          messageId: messageId(cfg, turn.conversation, turn.turn),
+          recorder: 'domain-packs-battery',
+        },
+        knownEntities,
+        userId: cfg.userId,
+        emittedAt: turn.emittedAt,
+      }),
+    );
+    if ((i + 1) % 10 === 0) console.error(`[ingest] ${i + 1}/${ALL_TURNS.length}`);
+  }
+}
+
+// ── phase 2: execute the checks ─────────────────────────────────────
+
+interface CheckContext {
+  cfg: Config;
+  mcp: McpClient;
+  tools: Set<string>;
+}
+
+type Verdict = Pick<CheckResult, 'status' | 'detail'> & { answer?: string | null };
+
+async function searchHits(ctx: CheckContext, query: string, limit: number): Promise<SearchHit[]> {
+  const out = await callTool<SearchOut>(ctx.mcp, 'search_knowledge', {
+    query,
+    limit,
+    userId: ctx.cfg.userId,
+  });
+  return out.results ?? [];
+}
+
+async function runInstallCheck(ctx: CheckContext, check: InstallCheck): Promise<Verdict> {
+  const res = await restRaw<PacksListOut>(ctx.cfg, 'GET', '/v1/admin/packs');
+  if (res.status < 200 || res.status >= 300) {
+    return { status: 'fail', detail: `GET /v1/admin/packs -> HTTP ${res.status}` };
+  }
+  const verdict = checkPacksInstalled(res.json?.installed ?? [], check.packs);
+  return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
+}
+
+async function runVocabCheck(ctx: CheckContext, check: PackVocabCheck): Promise<Verdict> {
+  const hits = await searchHits(ctx, check.searchQuery, 8);
+  if (hits.length === 0) {
+    return { status: 'fail', detail: 'search returned no candidate entities' };
+  }
+  const verdict = findExactPredicateFact(hits as HitLike[], check.predicate, check.valueMarkers);
+  return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
+}
+
+async function runTransitionCheck(ctx: CheckContext, check: PackTransitionCheck): Promise<Verdict> {
+  const hits = await searchHits(ctx, check.searchQuery, HISTORY_ENTITY_CAP);
+  if (hits.length === 0) {
+    return { status: 'fail', detail: 'search returned no candidate entities' };
+  }
+  // The transition may live on any of several extracted entities (the
+  // clinic, the course, …) — walk each candidate's timeline and pass on
+  // the first one whose fact.recorded events retain every stage in
+  // order; keep the deepest partial match as the fail detail.
+  let best: { matchedStages: number; detail: string } | null = null;
+  for (const hit of hits.slice(0, HISTORY_ENTITY_CAP)) {
+    const timeline = await callTool<TimelineOut>(ctx.mcp, 'get_entity_timeline', {
+      entityId: hit.entityId,
+      userId: ctx.cfg.userId,
+    });
+    const events: HistoryEvent[] = (timeline.events ?? [])
+      .filter((e) => e.type === 'fact.recorded')
+      .map((e) => ({ predicate: e.predicate ?? '', object: e.object ?? '', at: e.at }));
+    const verdict = checkHistorySequence(events, check.stages);
+    if (verdict.pass) {
+      return {
+        status: 'pass',
+        detail: `entity ${hit.canonicalName ?? hit.entityId}: ${verdict.detail}`,
+      };
+    }
+    if (best === null || verdict.matchedStages > best.matchedStages) {
+      best = {
+        matchedStages: verdict.matchedStages,
+        detail: `entity ${hit.canonicalName ?? hit.entityId}: ${verdict.detail}`,
+      };
+    }
+  }
+  return {
+    status: 'fail',
+    detail: `no entity timeline retains the full sequence; deepest: ${best?.detail ?? '(none)'}`,
+  };
+}
+
+async function runCrossEntityCheck(ctx: CheckContext, check: CrossEntityCheck): Promise<Verdict> {
+  const hits = await searchHits(ctx, check.searchQuery, 10);
+  const verdict = checkCrossDomainEntity(hits as HitLike[], check);
+  return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
+}
+
+async function runTraceProvenanceCheck(
+  ctx: CheckContext,
+  check: TraceProvenanceCheck,
+): Promise<Verdict> {
+  if (!ctx.tools.has('get_fact_provenance')) {
+    return { status: 'skipped', detail: 'get_fact_provenance absent (FACTS_API_ENABLED off)' };
+  }
+  const hits = await searchHits(ctx, check.searchQuery, 8);
+  const factIdsPerHit: string[][] = hits.map((hit) => {
+    const ids: string[] = [];
+    for (const fact of hit.facts ?? []) {
+      if (check.objectHint.length > 0) {
+        const text = `${fact.predicate} ${fact.object}`.toLowerCase();
+        if (!check.objectHint.some((h) => text.includes(h.toLowerCase()))) continue;
+      }
+      ids.push(fact.factId);
+    }
+    return ids;
+  });
+  // Round-robin across hits (hit1.fact1, hit2.fact1, …) so one fat
+  // entity cannot monopolise the walk budget — sibling interleave.ts.
+  const candidates = interleaveRoundRobin(factIdsPerHit, PROVENANCE_CANDIDATE_CAP);
+  if (candidates.length === 0) {
+    return { status: 'fail', detail: 'search returned no candidate facts' };
+  }
+  for (const factId of candidates) {
+    const prov = await callTool<ProvenanceOut>(ctx.mcp, 'get_fact_provenance', { factId });
+    const match = walkProvenance(prov, check.episodeFragments);
+    if (match !== null) {
+      return {
+        status: 'pass',
+        detail: `fact ${factId} unrolls to episode ${match.episodeId} ("${match.fragment}")`,
+      };
+    }
+  }
+  return {
+    status: 'fail',
+    detail: `${candidates.length} facts walked, no episode quotes the domain's seeded fragment`,
+  };
+}
+
+async function runTraceInterleaveCheck(
+  ctx: CheckContext,
+  check: TraceInterleaveCheck,
+): Promise<Verdict> {
+  const hits = await searchHits(ctx, check.searchQuery, 10);
+  const target = hits.find((h) =>
+    (h.canonicalName ?? '').toLowerCase().includes(check.entityNameToken.toLowerCase()),
+  );
+  if (target === undefined) {
+    return {
+      status: 'fail',
+      detail: `no hit named ~"${check.entityNameToken}" among ${hits.length} results`,
+    };
+  }
+  const timeline = await callTool<TimelineOut>(ctx.mcp, 'get_entity_timeline', {
+    entityId: target.entityId,
+    userId: ctx.cfg.userId,
+  });
+  const events: HistoryEvent[] = (timeline.events ?? [])
+    .filter((e) => e.type === 'fact.recorded')
+    .map((e) => ({ predicate: e.predicate ?? '', object: e.object ?? '', at: e.at }));
+  const [a, b] = check.domains;
+  const verdict = checkInterleavedDomains(events, a, b);
+  return {
+    status: verdict.pass ? 'pass' : 'fail',
+    detail: `entity ${target.canonicalName ?? target.entityId}: ${verdict.detail}`,
+  };
+}
+
+async function runServeCrossCheck(ctx: CheckContext, check: ServeCrossCheck): Promise<Verdict> {
+  const out = await callTool<SynthOut>(ctx.mcp, 'synthesize', {
+    query: check.query,
+    limit: 15,
+    synthesisGuardrails: ctx.cfg.guardrails,
+    userId: ctx.cfg.userId,
+  });
+  const verdict = scoreServeCross(out.answer, out.reason, check.requireGroups);
+  return { status: verdict.status, detail: verdict.detail, answer: out.answer };
+}
+
+async function runIsolationCheck(ctx: CheckContext, check: ServeIsolationCheck): Promise<Verdict> {
+  const out = await callTool<SynthOut>(ctx.mcp, 'synthesize', {
+    query: check.query,
+    limit: 15,
+    synthesisGuardrails: ctx.cfg.guardrails,
+    userId: ctx.cfg.userId,
+  });
+  const verdict = scoreServe(out.answer, out.reason, {
+    expectAnyOf: check.expectAnyOf,
+    forbidAnyOf: check.forbidAnyOf,
+  });
+  return { status: verdict.status, detail: verdict.detail, answer: out.answer };
+}
+
+function runNoRogueToolsCheck(ctx: CheckContext): Verdict {
+  const offenders = findNamespacedTools([...ctx.tools]);
+  if (offenders.length === 0) {
+    return {
+      status: 'pass',
+      detail: `tools/list clean: 0 __-namespaced tools among ${ctx.tools.size}`,
+    };
+  }
+  return {
+    status: 'fail',
+    detail: `unexpected pack-namespaced tool(s) exposed: ${offenders.join(', ')}`,
+  };
+}
+
+async function runCheck(ctx: CheckContext, check: Check): Promise<Verdict> {
+  switch (check.kind) {
+    case 'install':
+      return runInstallCheck(ctx, check);
+    case 'pack-vocab':
+      return runVocabCheck(ctx, check);
+    case 'pack-transition':
+      return runTransitionCheck(ctx, check);
+    case 'cross-entity':
+      return runCrossEntityCheck(ctx, check);
+    case 'trace-provenance':
+      return runTraceProvenanceCheck(ctx, check);
+    case 'trace-interleave':
+      return runTraceInterleaveCheck(ctx, check);
+    case 'serve-cross':
+      return runServeCrossCheck(ctx, check);
+    case 'serve-isolation':
+      return runIsolationCheck(ctx, check);
+    case 'no-rogue-tools':
+      return runNoRogueToolsCheck(ctx);
+  }
+}
+
+async function runChecks(ctx: CheckContext): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+  for (const check of CHECKS) {
+    const started = Date.now();
+    let verdict: Verdict;
+    try {
+      verdict = await runCheck(ctx, check);
+    } catch (err) {
+      verdict = { status: 'fail', detail: `runner error: ${String(err)}` };
+    }
+    const latencyMs = Date.now() - started;
+    const expectedUnknown = check.kind === 'pack-vocab' ? check.expectedUnknown : undefined;
+    const result: CheckResult = {
+      id: check.id,
+      kind: check.kind,
+      cls: check.cls,
+      status: verdict.status,
+      detail: verdict.detail,
+      latencyMs,
+      ...(verdict.answer !== undefined ? { answer: verdict.answer } : {}),
+      ...(expectedUnknown !== undefined ? { expectedUnknown } : {}),
+    };
+    results.push(result);
+    const note =
+      verdict.status === 'fail' && expectedUnknown !== undefined ? ' (baseline finding)' : '';
+    console.error(
+      `[check] ${check.id} (${check.kind}) ${verdict.status}${note} ` +
+        `${latencyMs}ms — ${verdict.detail}`,
+    );
+  }
+  return results;
+}
+
+// ── scorecard ───────────────────────────────────────────────────────
+
+const emptyTally = (): Tally => ({ pass: 0, fail: 0, skipped: 0 });
+
+function buildScorecard(
+  cfg: Config,
+  startedAt: string,
+  setup: Record<string, string>,
+  results: CheckResult[],
+): Scorecard {
+  const classes: Record<string, Tally> = {};
+  const checkKinds: Record<CheckKind, Tally> = {
+    install: emptyTally(),
+    'pack-vocab': emptyTally(),
+    'pack-transition': emptyTally(),
+    'cross-entity': emptyTally(),
+    'trace-provenance': emptyTally(),
+    'trace-interleave': emptyTally(),
+    'serve-cross': emptyTally(),
+    'serve-isolation': emptyTally(),
+    'no-rogue-tools': emptyTally(),
+  };
+  const checks = { pass: 0, fail: 0, skipped: 0, total: 0, failedExpectedUnknown: 0 };
+  for (const r of results) {
+    const cls = (classes[r.cls] ??= emptyTally());
+    cls[r.status] += 1;
+    checkKinds[r.kind][r.status] += 1;
+    checks[r.status] += 1;
+    checks.total += 1;
+    if (r.status === 'fail' && r.expectedUnknown !== undefined) {
+      checks.failedExpectedUnknown += 1;
+    }
+  }
+  return {
+    runId: cfg.runId,
+    baseUrl: cfg.baseUrl,
+    companyId: cfg.companyId,
+    userId: cfg.userId,
+    guardrails: cfg.guardrails,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    setup,
+    ingest: { mentionTurns: cfg.skipIngest ? 0 : ALL_TURNS.length },
+    classes,
+    checkKinds,
+    checks,
+    results,
+  };
+}
+
+function printScorecard(card: Scorecard): void {
+  console.log('');
+  console.log(`domain-packs scorecard — run ${card.runId} (guardrails=${card.guardrails})`);
+  console.log('─'.repeat(72));
+  for (const [cls, tally] of Object.entries(card.classes)) {
+    console.log(
+      `${cls.padEnd(22)} checks: pass ${tally.pass}  fail ${tally.fail}` +
+        (tally.skipped > 0 ? `  skipped ${tally.skipped}` : ''),
+    );
+  }
+  console.log('─'.repeat(72));
+  const scored = card.checks.pass + card.checks.fail;
+  const pct = scored === 0 ? 0 : Math.round((card.checks.pass / scored) * 1000) / 10;
+  console.log(
+    `checks: ${card.checks.pass}/${scored} scored (${pct}%), ` +
+      `${card.checks.skipped} skipped of ${card.checks.total}` +
+      (card.checks.failedExpectedUnknown > 0
+        ? ` — ${card.checks.failedExpectedUnknown} fail(s) are the pack-vocab baseline finding`
+        : ''),
+  );
+}
+
+// ── main ────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  const startedAt = new Date().toISOString();
+  console.error(`domain-packs: run ${cfg.runId} against ${cfg.baseUrl} (tenant ${cfg.companyId})`);
+
+  const setup = await ensurePackSetup(cfg);
+
+  const brain = new HttpBrainClient({ baseUrl: cfg.baseUrl, apiKey: cfg.apiKey });
+  const mcp = await connectMcp(cfg);
+  try {
+    const toolList = await withRetry('tools/list', () => mcp.listTools());
+    const tools = new Set(toolList.tools.map((t) => t.name));
+    console.error(`[mcp] connected, ${tools.size} tools visible`);
+
+    if (!cfg.skipIngest) {
+      await ingestTurns(cfg, brain);
+    }
+
+    const results = await runChecks({ cfg, mcp, tools });
+    const card = buildScorecard(cfg, startedAt, setup, results);
+
+    mkdirSync(cfg.reportDir, { recursive: true });
+    const reportPath = join(cfg.reportDir, `domain-packs-${cfg.runId}.json`);
+    writeFileSync(reportPath, `${JSON.stringify(card, null, 2)}\n`);
+    printScorecard(card);
+    console.log(`report: ${reportPath}`);
+  } finally {
+    await mcp.close();
+  }
+}
+
+void main().catch((err: unknown) => {
+  console.error('domain-packs: runner failed:', err);
+  process.exitCode = 1;
+});

--- a/test/eval/domain-packs/scorers.ts
+++ b/test/eval/domain-packs/scorers.ts
@@ -1,0 +1,268 @@
+/**
+ * Mechanical scorers of the domain-pack battery. Pure functions over
+ * plain JSON — no HTTP, no LLM judge — unit-tested on fixtures in
+ * test/domain-pack-scorers.unit-spec.ts, so every verdict is
+ * reproducible from the report file.
+ *
+ * Generic primitives are REUSED from the sibling harnesses — one
+ * implementation, one unit-tested truth: containsAnyOf / isAbstention /
+ * missingKeyPhrases / walkProvenance come from
+ * test/eval/memory-fitness/scorers.ts; checkHistorySequence and
+ * scoreServe from test/eval/state-transitions/scorers.ts. This file
+ * adds only what the domain-pack claims need: the install matcher, the
+ * exact-predicate vocabulary matcher, the cross-domain entity/timeline
+ * classifiers, the all-groups serve verdict, and the rogue-tool scan.
+ */
+import { containsAnyOf, isAbstention, missingKeyPhrases } from '../memory-fitness/scorers';
+import type { HistoryEvent } from '../state-transitions/scorers';
+import type { CrossEntityCheck, DomainSpec } from './types';
+
+export interface Verdict {
+  pass: boolean;
+  detail: string;
+}
+
+// ── install matcher ─────────────────────────────────────────────────
+
+/** The installed-pack fields the matcher consumes (subset of
+ *  InstalledPackSchema — src/contracts/admin/packs.schema.ts). */
+export interface InstalledPackLike {
+  packId: string;
+  version: string;
+}
+
+/** Every wanted pack is present in the installed list at the wanted
+ *  version (a different installed version is named in the fail). */
+export function checkPacksInstalled(
+  installed: readonly InstalledPackLike[],
+  wanted: ReadonlyArray<{ packId: string; version: string }>,
+): Verdict {
+  const missing: string[] = [];
+  const found: string[] = [];
+  for (const want of wanted) {
+    const hit = installed.find((p) => p.packId === want.packId);
+    if (hit === undefined) {
+      missing.push(`${want.packId}@${want.version} (absent)`);
+    } else if (hit.version !== want.version) {
+      missing.push(`${want.packId}@${want.version} (installed at v${hit.version})`);
+    } else {
+      found.push(`${want.packId}@${want.version}`);
+    }
+  }
+  if (missing.length > 0) {
+    return {
+      pass: false,
+      detail: `not installed as expected: ${missing.join(', ')} (installed list has ${installed.length})`,
+    };
+  }
+  return { pass: true, detail: `installed: ${found.join(', ')}` };
+}
+
+// ── pack-vocabulary matcher ─────────────────────────────────────────
+
+/** One search-hit fact as the vocabulary matcher consumes it. */
+export interface FactLike {
+  factId: string;
+  predicate: string;
+  object: string;
+}
+
+/** One search hit as the cross-domain scorers consume it. */
+export interface HitLike {
+  entityId: string;
+  canonicalName?: string;
+  facts?: FactLike[];
+}
+
+/**
+ * Exact-predicate vocabulary check: some fact across the hits carries
+ * EXACTLY the namespaced pack predicate with a matching value. A fail
+ * names the predicates extraction coined instead for the same values —
+ * the diagnosable half of the honest baseline: the report shows WHAT
+ * open vocabulary swallowed the domain phrasing.
+ */
+export function findExactPredicateFact(
+  hits: readonly HitLike[],
+  predicate: string,
+  valueMarkers: readonly string[],
+): Verdict {
+  const coined = new Set<string>();
+  for (const hit of hits) {
+    for (const fact of hit.facts ?? []) {
+      if (!containsAnyOf(fact.object, valueMarkers)) continue;
+      if (fact.predicate === predicate) {
+        return {
+          pass: true,
+          detail:
+            `fact ${fact.factId} on ${hit.canonicalName ?? hit.entityId} carries ` +
+            `${predicate}="${fact.object}"`,
+        };
+      }
+      coined.add(fact.predicate);
+    }
+  }
+  const coinedList = [...coined];
+  return {
+    pass: false,
+    detail:
+      coinedList.length > 0
+        ? `no fact carries ${predicate}; the value landed on coined predicate(s): ` +
+          coinedList.join(', ')
+        : `no fact carries ${predicate} and no fact matches [${valueMarkers.join('|')}] at all`,
+  };
+}
+
+// ── cross-domain classifiers ────────────────────────────────────────
+
+/** A fact (or timeline event) belongs to a domain when its predicate
+ *  carries the pack namespace prefix OR its combined text matches a
+ *  corpus value marker — namespace-first, so the check gets STRONGER
+ *  as pack vocabulary adoption grows, but stays meaningful before it. */
+export function inDomain(predicate: string, object: string, spec: DomainSpec): boolean {
+  if (predicate.startsWith(`${spec.namespace}__`)) return true;
+  return containsAnyOf(`${predicate} ${object}`, spec.markers);
+}
+
+/**
+ * Cross-domain entity check:
+ *  1. exactly ONE hit's canonicalName contains the entity token
+ *     (2+ = per-domain entity duplication, the failure being measured);
+ *  2. that hit carries ≥1 fact of EACH domain and ≥1 generic fact.
+ * The detail always carries the per-bucket counts, so a fail is
+ * diagnosable from the report alone.
+ */
+export function checkCrossDomainEntity(
+  hits: readonly HitLike[],
+  spec: Pick<CrossEntityCheck, 'entityNameToken' | 'domains' | 'genericMarkers'>,
+): Verdict {
+  const named = hits.filter((h) => containsAnyOf(h.canonicalName ?? '', [spec.entityNameToken]));
+  if (named.length === 0) {
+    return {
+      pass: false,
+      detail: `no hit named ~"${spec.entityNameToken}" among ${hits.length} results`,
+    };
+  }
+  if (named.length > 1) {
+    const names = named.map((h) => `"${h.canonicalName ?? h.entityId}"`).join(', ');
+    return {
+      pass: false,
+      detail: `entity duplicated across ${named.length} hits: ${names}`,
+    };
+  }
+  const top = named[0];
+  if (top === undefined) return { pass: false, detail: 'unreachable: no named hit' };
+  const [a, b] = spec.domains;
+  let inA = 0;
+  let inB = 0;
+  let generic = 0;
+  for (const fact of top.facts ?? []) {
+    const isA = inDomain(fact.predicate, fact.object, a);
+    const isB = inDomain(fact.predicate, fact.object, b);
+    if (isA) inA += 1;
+    if (isB) inB += 1;
+    if (!isA && !isB && containsAnyOf(`${fact.predicate} ${fact.object}`, spec.genericMarkers)) {
+      generic += 1;
+    }
+  }
+  const counts =
+    `${a.namespace}=${inA}, ${b.namespace}=${inB}, generic=${generic} ` +
+    `of ${(top.facts ?? []).length} facts on "${top.canonicalName ?? top.entityId}"`;
+  if (inA > 0 && inB > 0 && generic > 0) {
+    return { pass: true, detail: `one entity carries both domains: ${counts}` };
+  }
+  return { pass: false, detail: `domain coverage incomplete: ${counts}` };
+}
+
+/**
+ * Timeline interleave check: fact.recorded events of BOTH domains are
+ * present, and neither domain sits entirely before the other in time —
+ * i.e. each domain's LAST event is later than the other domain's
+ * FIRST event. The corpus seeds late events of both domains in the
+ * mixed conversation, so a correctly-anchored timeline interleaves.
+ */
+export function checkInterleavedDomains(
+  events: readonly HistoryEvent[],
+  a: DomainSpec,
+  b: DomainSpec,
+): Verdict {
+  const inA = events.filter((e) => inDomain(e.predicate, e.object, a));
+  const inB = events.filter((e) => inDomain(e.predicate, e.object, b));
+  if (inA.length === 0 || inB.length === 0) {
+    return {
+      pass: false,
+      detail:
+        `timeline lacks a domain: ${a.namespace}=${inA.length}, ` +
+        `${b.namespace}=${inB.length} of ${events.length} recorded events`,
+    };
+  }
+  const at = (list: readonly HistoryEvent[]): number[] =>
+    list.map((e) => Date.parse(e.at)).filter((n) => !Number.isNaN(n));
+  const timesA = at(inA);
+  const timesB = at(inB);
+  if (timesA.length === 0 || timesB.length === 0) {
+    return { pass: false, detail: 'domain events carry unparseable timestamps' };
+  }
+  const lastAAfterFirstB = Math.max(...timesA) > Math.min(...timesB);
+  const lastBAfterFirstA = Math.max(...timesB) > Math.min(...timesA);
+  if (lastAAfterFirstB && lastBAfterFirstA) {
+    return {
+      pass: true,
+      detail:
+        `${inA.length} ${a.namespace} + ${inB.length} ${b.namespace} events ` +
+        'genuinely interleave in time',
+    };
+  }
+  const blockFirst = lastAAfterFirstB ? b.namespace : a.namespace;
+  return {
+    pass: false,
+    detail:
+      `domains do not interleave: every ${blockFirst} event precedes the ` +
+      `other domain (${a.namespace}=${inA.length}, ${b.namespace}=${inB.length})`,
+  };
+}
+
+// ── serve verdicts ──────────────────────────────────────────────────
+
+export interface ServeVerdict {
+  status: 'pass' | 'fail';
+  detail: string;
+}
+
+/**
+ * Cross-domain serve verdict: the answer must satisfy EVERY marker
+ * group (each group anyOf — the sibling's missingKeyPhrases). An
+ * abstention fails: the entity is richly known, so declining to serve
+ * it is the cross-domain failure being measured, not honesty.
+ */
+export function scoreServeCross(
+  answer: string | null | undefined,
+  reason: string | undefined,
+  requireGroups: ReadonlyArray<string[]>,
+): ServeVerdict {
+  if (isAbstention(answer, reason)) {
+    return { status: 'fail', detail: 'abstained on a richly-known entity' };
+  }
+  const missing = missingKeyPhrases(answer ?? '', requireGroups);
+  if (missing.length === 0) {
+    return {
+      status: 'pass',
+      detail: `answer serves ≥1 marker of all ${requireGroups.length} domains`,
+    };
+  }
+  return {
+    status: 'fail',
+    detail: `answer misses ${missing.length}/${requireGroups.length} domain group(s): ${missing.join('; ')}`,
+  };
+}
+
+// ── rogue-surface scan ──────────────────────────────────────────────
+
+/**
+ * Pack-namespaced tool detector: pack mcpTools surface as
+ * `<packId>__<tool>` (the code_memory__decided naming law), while
+ * every builtin tool uses single underscores. Returns the offenders —
+ * an empty list is the asserted no-op.
+ */
+export function findNamespacedTools(toolNames: readonly string[]): string[] {
+  return toolNames.filter((name) => name.includes('__'));
+}

--- a/test/eval/domain-packs/types.ts
+++ b/test/eval/domain-packs/types.ts
@@ -1,0 +1,198 @@
+/**
+ * Shared shapes of the domain-pack battery — the third mechanical
+ * sibling of test/eval/memory-fitness (general first-person memory
+ * fitness) and test/eval/state-transitions (mutable world-state).
+ * This battery isolates ONE claim: memory behaves correctly WITH
+ * industry Domain Packs installed — the install→vocabulary→trace
+ * chain works end to end, and ONE entity living in TWO domain
+ * ontologies (fintech + medical) stays a single entity whose facts,
+ * timeline and provenance keep their per-domain identity.
+ *
+ * Every check is mechanical — no LLM judge (see scorers.ts).
+ */
+
+/** One mention turn the runner writes into memory. */
+export interface CorpusTurn {
+  /** Conversation key (`fin`…) — the runner prefixes it with the run id. */
+  conversation: string;
+  /** 1-based position inside the conversation (drives the messageId). */
+  turn: number;
+  /** ISO 8601 emission timestamp — the temporal anchor of the turn. */
+  emittedAt: string;
+  /** Verbatim turn text. Kept under the 600-char provenance cap. */
+  text: string;
+}
+
+/** A domain lens: its pack namespace plus corpus value markers. A fact
+ *  belongs to the domain when its predicate carries the `<namespace>__`
+ *  prefix OR its text matches a marker — so the cross-domain checks
+ *  stay meaningful even while extraction still coins open-vocab
+ *  predicates (the pack-vocab baseline finding). */
+export interface DomainSpec {
+  namespace: string;
+  markers: string[];
+}
+
+interface BaseCheck {
+  /** Stable key (`c01-install`…) used in the report. */
+  id: string;
+  /** Check class — the scorecard groups by this. */
+  cls: string;
+  /** What the check asserts and what would falsify it. */
+  intent: string;
+}
+
+/** `install` — GET /v1/admin/packs lists both packs as installed. */
+export interface InstallCheck extends BaseCheck {
+  kind: 'install';
+  packs: Array<{ packId: string; version: string }>;
+}
+
+/**
+ * `pack-vocab` — a searched fact's predicate is the EXACT namespaced
+ * pack predicate (`fintech__settlement_period`), proving domain
+ * phrasing canonicalized into the installed pack's vocabulary instead
+ * of a coined open-vocab predicate. `expectedUnknown` marks the honest
+ * baseline: a fail here is a FINDING (extraction may not consult the
+ * installed pack's extractionProfile on this path yet — the
+ * state-transitions battery's knownFailToday idea, for an outcome that
+ * has never been measured), not a forced green.
+ */
+export interface PackVocabCheck extends BaseCheck {
+  kind: 'pack-vocab';
+  searchQuery: string;
+  /** The exact namespaced predicate id, derived from the pack manifest. */
+  predicate: string;
+  /** The fact's object must contain ≥1 of these (case-insensitive). */
+  valueMarkers: string[];
+  /** Baseline annotation: outcome unknown on today's code; a fail is
+   *  recorded as a finding, tallied separately, never forced green. */
+  expectedUnknown?: string;
+}
+
+/** `pack-transition` — the entity timeline retains old→new on a pack
+ *  predicate as a chronological subsequence (the state-transitions
+ *  battery's checkHistorySequence, reused verbatim). */
+export interface PackTransitionCheck extends BaseCheck {
+  kind: 'pack-transition';
+  searchQuery: string;
+  /** Ordered stages; each stage is an anyOf marker group. */
+  stages: string[][];
+}
+
+/** `cross-entity` — search returns ONE entity (no per-domain
+ *  duplication) carrying facts from BOTH domains plus generic ones. */
+export interface CrossEntityCheck extends BaseCheck {
+  kind: 'cross-entity';
+  searchQuery: string;
+  /** The subject entity's canonicalName must contain this token; hits
+   *  are deduped on it (2+ matching hits = per-domain duplication). */
+  entityNameToken: string;
+  domains: [DomainSpec, DomainSpec];
+  /** Markers of the domain-free corpus turns about the same entity. */
+  genericMarkers: string[];
+}
+
+/** `trace-provenance` — a domain fact of the shared entity unrolls via
+ *  get_fact_provenance to an episode quoting that domain's seeded turn
+ *  verbatim (the memory-fitness walkProvenance, with its round-robin
+ *  candidate interleave). */
+export interface TraceProvenanceCheck extends BaseCheck {
+  kind: 'trace-provenance';
+  searchQuery: string;
+  /** Prefer facts whose object contains ≥1 of these, else any fact. */
+  objectHint: string[];
+  /** Case-insensitive fragments seeded verbatim in exactly one turn. */
+  episodeFragments: string[];
+}
+
+/** `trace-interleave` — the shared entity's timeline holds
+ *  fact.recorded events from BOTH domains and neither domain sits
+ *  entirely before the other in time (a genuine interleave). */
+export interface TraceInterleaveCheck extends BaseCheck {
+  kind: 'trace-interleave';
+  searchQuery: string;
+  entityNameToken: string;
+  domains: [DomainSpec, DomainSpec];
+}
+
+/** `serve-cross` — synthesize over the shared entity cites BOTH
+ *  domains: at least one marker from every group must be served. */
+export interface ServeCrossCheck extends BaseCheck {
+  kind: 'serve-cross';
+  query: string;
+  /** Every group is an anyOf set; ALL groups must be satisfied. */
+  requireGroups: string[][];
+}
+
+/** `serve-isolation` — a domain-specific question answers from ITS
+ *  domain's fact and never confabulates the other domain's values. */
+export interface ServeIsolationCheck extends BaseCheck {
+  kind: 'serve-isolation';
+  query: string;
+  /** Pass requires ≥1 of these in the answer. */
+  expectAnyOf: string[];
+  /** Any of these in the answer fails the check (checked first). */
+  forbidAnyOf: string[];
+}
+
+/** `no-rogue-tools` — MCP tools/list carries ZERO `__`-namespaced pack
+ *  tools. Neither installed pack declares mcpTools, so the no-op is
+ *  ASSERTED, not assumed; this flips to a positive check the day a
+ *  pack ships tools (see README.md). */
+export interface NoRogueToolsCheck extends BaseCheck {
+  kind: 'no-rogue-tools';
+}
+
+export type Check =
+  | InstallCheck
+  | PackVocabCheck
+  | PackTransitionCheck
+  | CrossEntityCheck
+  | TraceProvenanceCheck
+  | TraceInterleaveCheck
+  | ServeCrossCheck
+  | ServeIsolationCheck
+  | NoRogueToolsCheck;
+export type CheckKind = Check['kind'];
+
+export type CheckStatus = 'pass' | 'fail' | 'skipped';
+
+export interface CheckResult {
+  id: string;
+  kind: CheckKind;
+  cls: string;
+  status: CheckStatus;
+  detail: string;
+  latencyMs: number;
+  /** Raw served answer, when the check was answer-shaped. */
+  answer?: string | null;
+  /** Carried through from the check: baseline finding, not regression. */
+  expectedUnknown?: string;
+}
+
+export interface Tally {
+  pass: number;
+  fail: number;
+  skipped: number;
+}
+
+export interface Scorecard {
+  runId: string;
+  baseUrl: string;
+  companyId: string;
+  userId: string;
+  guardrails: string;
+  startedAt: string;
+  finishedAt: string;
+  /** Phase-0 pack setup trail (per pack: already installed / installed /
+   *  registry-published), so a report is reproducible from itself. */
+  setup: Record<string, string>;
+  ingest: { mentionTurns: number };
+  /** Per-check-class tally. */
+  classes: Record<string, Tally>;
+  /** Per-check-kind tally. */
+  checkKinds: Record<CheckKind, Tally>;
+  checks: Tally & { total: number; failedExpectedUnknown: number };
+  results: CheckResult[];
+}


### PR DESCRIPTION
## Context (from the 2026-09-05 pack audit)

The six industry Domain Packs (`real_estate`, `fintech`, `medical`, `legal`, `insurance`, `hr`) ship frozen at **v0.1.0** — each validates, carries 5-6 predicates + an `extractionProfile` + `evalFixtures`, has a checksum-matching JSON twin in `packs/` — and have **zero installs anywhere**. Only the builtin `code_memory` pack has ever seeded predicates. The install → vocabulary → trace chain has never been exercised against a live stand. This PR adds `pnpm eval:domain-packs`, the third mechanical eval battery (sibling of `test/eval/memory-fitness` and `test/eval/state-transitions`), as that first live exercise.

## What it measures

One userId (`dp-agent`), one shared subject entity — **"Meridian Clinic"**, deliberately BOTH a fintech client (payments arm: EMI, FCA, PCI-DSS, T+2→T+1 settlement) and a medical provider (clinical side: indications, dosing, routes) — plus "Dr. Vega". Four conversations (~20 turns): one per domain (each ending in an old→new transition on a `single_active` pack predicate), one generic, one deliberately MIXED, so the entity's timeline genuinely interleaves both domains in time. Predicate ids are derived from the real manifests (`src/ai/domain-packs/{fintech,medical}.pack.ts`) through a build-time guard that throws on manifest drift.

15 mechanical checks across 9 kinds (no LLM judge; details in the README):

| kind | claim |
| --- | --- |
| `install` | phase 0 actually landed both packs in `GET /v1/admin/packs` installed list |
| `pack-vocab` (×4) | domain phrasing canonicalized into the EXACT namespaced predicate (`fintech__licensed_as`), not a coined open-vocab one |
| `pack-transition` (×2) | T+2→T+1 and 500 mg→850 mg survive as ordered timeline history |
| `cross-entity` | ONE entity carries fintech + medical + generic facts — no per-domain duplication |
| `trace-provenance` (×2) | a fintech fact and a medical fact of the SAME entity each unroll to their OWN domain's seeded turn |
| `trace-interleave` | the shared timeline holds both domains and neither sits entirely before the other |
| `serve-cross` | "Tell me about Meridian Clinic" (strict) cites at least one marker from EACH domain |
| `serve-isolation` (×2) | a settlement question never confabulates doses; a dosing question never confabulates fintech values |
| `no-rogue-tools` | tools/list has ZERO `__`-namespaced tools — no pack declares `mcpTools`, so the NO-OP is asserted, not assumed (flips to a positive check when a pack ships tools) |

## Honest-baseline policy

The four `pack-vocab` checks are annotated `expectedUnknown` — this battery's variant of the state-transitions `knownFailToday` idea, for an outcome that has never been measured: whether mention-path extraction consults an installed pack's `extractionProfile` is unobserved, and the likely answer today is NO. A fail there is recorded as a finding (the report names the exact coined predicates that swallowed each domain value) and tallied separately (`failedExpectedUnknown`) — never forced green, never skipped. Everything downstream is vocabulary-independent by design: cross-domain classification is namespace-first with corpus-value-marker fallback, so those checks get stronger as pack vocabulary adoption grows but are meaningful before it.

## Setup semantics (never silently skipped)

Phase 0 installs via `POST /v1/admin/packs/from-registry` (checksum pinned by the registry). When the registry lacks the pack (fresh stand — the audited state), the runner republishes the LOCAL manifest through `POST /v1/admin/registry/packs` (checksum-pinned, the seed script's logic over REST); if the key cannot publish, the runner exits with the actionable instruction (`BRAIN_API_KEY=<registry:publish key> pnpm registry:seed -- --brain-url <url>`).

## Architecture

Mirrors the two siblings exactly: `HttpBrainClient` + MCP client over `/mcp/<companyId>`, `DPEV_`-prefixed env knobs (`DPEV_USER_ID`, `DPEV_RUN_ID`, `DPEV_GUARDRAILS`, `DPEV_SKIP_INGEST`, `DPEV_REPORT_DIR`), run-scoped conversation/message ids, JSON scorecard to `var/domain-packs/`, hard `BRAIN_BASE_URL` guard — intentionally never run in CI. Generic scorers (`containsAnyOf`, `isAbstention`, `missingKeyPhrases`, `walkProvenance`, `checkHistorySequence`, `scoreServe`, round-robin interleave) are reused from the sibling harnesses; only pack-specific scorers are new, all pure and unit-tested (`test/domain-pack-scorers.unit-spec.ts`, 27 tests, including corpus-integrity invariants: real predicate ids, verbatim single-turn provenance fragments, the 600-char cap, no old-value restatement in transition turns).

## Verification

- `pnpm typecheck` green
- `pnpm test:unit` green (347 suites / 3754 tests)
- `pnpm prettier --check` clean on all touched files; eslint clean on the new files
- The battery itself needs a live stand (booted brain + OpenAI key + seeded registry + fresh tenant) and has not been executed in this PR — its first run IS the baseline measurement it exists to record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB