### PR TITLE
docs: refresh prose docs against current main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,10 @@ strict binary judge, own full-context baseline, paired stats, held-out split
 ([docs/eval-protocol.md](docs/eval-protocol.md)). Do not quote numbers from
 other systems' self-reported benchmarks as comparable — most published
 memory scores use lenient judges and are inflated; ours are deliberately
-hard to inflate.
+hard to inflate. The in-repo memory-fitness numbers come from the
+mechanical, judge-free battery (`pnpm eval:memory-fitness`,
+`pnpm eval:state-transitions` — see
+[docs/eval-methodology.md](docs/eval-methodology.md)).
 
 ## More
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -50,19 +50,25 @@ deploy:
 |---|---|---|
 | `DOCKERHUB_USERNAME` | docker login | shared with other inite services |
 | `DOCKERHUB_TOKEN` | docker login | — |
-| `INITE_SHARED_PAT` | second checkout | optional — falls back to `github.token` if same-org |
+| `INITE_SHARED_PAT` | `ci.yml` second checkout | optional — CI workflow only, not read by `deploy-brain.yml`; falls back to `github.token` if same-org |
 | `BRAIN_SURREAL_USER` | brain SURREALDB_USERNAME | root user for the shared inite-surrealdb |
 | `BRAIN_SURREAL_PASS` | brain SURREALDB_PASSWORD | — |
 | `BRAIN_SURREAL_SCOPED_PASS` | brain SURREALDB_SCOPED_PASS | password for `brain_caller` user. Brain auto-overwrites the placeholder password from migration 0005 with this secret on each ensureSchema cycle. |
 | `BRAIN_OPENAI_API_KEY` | OPENAI_API_KEY | embeddings + extraction + faithfulness verifier |
 | `BRAIN_FORGET_HMAC_KEY` | FORGET_HMAC_KEY | ≥32 chars; used to mint opaque tombstone markers on GDPR forget |
+| `BRAIN_EVIDENCE_URL_SECRET` | EVIDENCE_SIGNED_URL_SECRET (via the enablement env file) | ≥32 chars; signs evidence raw-serving URLs |
+| `BRAIN_BILLING_API_KEY` | BILLING_SERVICE_API_KEY | marketplace billing client credential |
 
-Optional (off by default in workflow, opt in per-feature):
-- `BRAIN_COHERE_API_KEY` — cross-encoder reranker
+Optional feature env vars **not currently wired in `deploy-brain.yml`** —
+setting these as repo secrets alone is inert; to enable one, add the
+secret AND the corresponding env line to the workflow's compose /
+enablement blocks (env-var semantics in [operations.md](operations.md)):
+
+- `AUTH_SERVICE_INTROSPECTION_CLIENT_ID/SECRET` — auth-service `ik_…` API-key resolution (RFC 7662). Provision the `brain-service` client with `register-brain-clients` in the auth repo first.
+- `AUTH_SSF_POLL_URL` — CAEP revocation stream (create a poll stream in the auth admin → Shared Signals); revoked IdP sessions then die within the poll interval instead of at token expiry.
+- `THROTTLE_TIER_MULTIPLIERS` — per-plan rate-limit multipliers, e.g. `{"plan:pro":2}`.
+- `COHERE_API_KEY` — cross-encoder reranker.
 - `BRAIN_API_KEYS` — static `[{keyHash, companyId, scopes}]` JSON; only if you need a non-JWT fallback path. NODE_ENV=production + a remote verifier (JWKS/introspection) rejects static keys, so leaving this empty is correct.
-- `BRAIN_AUTH_INTROSPECTION_CLIENT_ID/SECRET` → `AUTH_SERVICE_INTROSPECTION_CLIENT_ID/SECRET` — enables auth-service `ik_…` API-key resolution (RFC 7662). Provision the `brain-service` client with `register-brain-clients` in the auth repo first.
-- `BRAIN_AUTH_SSF_POLL_URL` → `AUTH_SSF_POLL_URL` — CAEP revocation stream (create a poll stream in the auth admin → Shared Signals); revoked IdP sessions then die here within the poll interval instead of at token expiry.
-- `BRAIN_THROTTLE_TIER_MULTIPLIERS` → `THROTTLE_TIER_MULTIPLIERS` — per-plan rate-limit multipliers, e.g. `{"plan:pro":2}`.
 
 ## DNS
 
@@ -104,15 +110,39 @@ restart is **not zero-downtime** — single replica today; brain in-flight
 requests get aborted on swap. Acceptable for current traffic; revisit
 when caller volume warrants.
 
+## Where the container's env comes from
+
+The running container reads its environment from TWO places, both
+written by the deploy workflow on every deploy:
+
+- the `environment:` block of the generated
+  `/opt/projects/inite-brain-service/docker-compose.yml` — secrets,
+  infrastructure settings, and a few pinned overrides;
+- `/opt/projects/inite-brain-service/enablement.env`, written by the
+  workflow's **"Write enablement env file"** step and referenced from
+  the compose file via `env_file:` — the full feature-flag enablement
+  block.
+
+Compose precedence: on a key collision `environment:` **wins** over
+`env_file`, so a pinned value in the compose block overrides the
+enablement file. The flag block lives in a separate file because
+embedding ~190 flag lines in the compose heredoc pushed the workflow's
+run script past GitHub's **21k max-expression-length limit** — a
+failure mode worth knowing: the run then fails with **zero jobs** and
+only a "workflow file issue" annotation, no logs at all. If a deploy
+run shows no jobs, suspect run-script size before anything else.
+
 ## Operational dispatch actions
 
 The workflow accepts three actions via `workflow_dispatch.inputs.action`:
 
 - `deploy` (default) — full build + push + deploy.
 - `restart` — skip build, restart the running container against the same
-  image. Use for env-var rotations after editing `docker-compose.yml` on
-  the droplet (rare — normal env changes go through workflow re-run).
-- `logs` — print last 200 lines of the container log. Faster than SSH.
+  image. Use for env-var rotations after editing `docker-compose.yml` or
+  `enablement.env` on the droplet (rare — normal env changes go through
+  the workflow, which rewrites both files).
+- `logs` — print last 200 lines of the container log
+  (`gh workflow run deploy-brain.yml -f action=logs`). Faster than SSH.
 
 ## Health check
 
@@ -174,6 +204,22 @@ see [`monitoring/README.md`](../monitoring/README.md) and
 - `auth.inite.ai` JWKS endpoint is reachable from the droplet. The
   ApiKeyGuard refuses to start in NODE_ENV=production without a valid
   JWKS load (defense-in-depth).
+- `AUTH_SERVICE_ISSUER` equals the auth-service's REAL `iss` claim —
+  **`https://auth-api.inite.ai`**, NOT `https://auth.inite.ai` (the
+  host the JWKS document is fetched from). A mismatch rejects EVERY
+  JWKS-verified token as "Invalid credentials" while everything else
+  looks healthy. Diagnose with
+  `gh workflow run deploy-brain.yml -f action=logs`, then grep the
+  output for `[JwksService]`: the boot line prints `issuer=…` and each
+  rejection logs `JWT verification failed: …`.
+- Flipping `PRIVACY_SEGMENT_USER_FENCE` on a deployment with existing
+  data follows the order **migrate → backfill → flip**: deploy (0117
+  applies lazily per tenant), then run
+  `POST /v1/admin/maintenance/segments/backfill-user-ids` per tenant
+  (`brain:admin`; body `{ tenant, maxRows? }`), then enable the flag.
+  Scenes are not covered by the backfill — re-run
+  `POST /v1/admin/maintenance/scenes` instead. Details:
+  [operations.md](operations.md) § `PRIVACY_*`.
 - Migration `0005_pii_permissions.surql` defines `brain_caller` with a
   static placeholder password (DDL doesn't bind to runtime variables).
   Right after the migration lands, brain runs

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,13 +34,14 @@ with one row per document.
 | [Source reputation & trust](source-reputation.md) | Domain-scoped trust, corroboration, feedback loop, trust in ranking. |
 | [ABAC access policies](abac.md) | Per-key policy sets: action gating + row-level read filtering, rollout runbook. |
 | [Document pipeline](document-pipeline.md) | Source → Indexer → Candidates → Brain: composable indexers, staged candidates, origin-keyed corroboration, re-indexing, external indexers, seed documents. |
+| [Extraction harvest lanes](extraction-harvest-lanes.md) | Deterministic post-LLM harvest: literal facts, state-verb transitions with holder binding, and the (unwired) language-agnostic transition classifier. |
 | [Fact provenance API](fact-provenance-api.md) | `GET /v1/facts/:id` + `/provenance` — the fact and the verbatim turns it came from ("show me why I remember this"). Flag-gated, ownership-fenced. |
 | [User profile API](user-profile-api.md) | `GET /v1/users/:userId/profile` — deterministic, prompt-ready assembly of one user's own memory (strict user scope). Flag-gated. |
 ## Measure it
 
 | Doc | Purpose |
 |---|---|
-| [Eval methodology](eval-methodology.md) | The public strict-eval statement: strict-judge protocol, measured judge inflation, lenient-vs-strict conversion factors, our numbers with CIs. |
+| [Eval methodology](eval-methodology.md) | The public strict-eval statement: strict-judge protocol, measured judge inflation, lenient-vs-strict conversion factors, our numbers with CIs — plus the mechanical judge-free battery (`eval:memory-fitness`, `eval:state-transitions`). |
 | [Eval protocol](eval-protocol.md) | The full three-axis protocol (LoCoMo / LongMemEval / BEAM): harness design and per-axis rules. |
 | [Eval harness](eval.md) | Production-gate retrieval + lifecycle eval. Load your CRM via JSON or Wikidata. |
 | [LoCoMo benchmark](locomo.md) | Long-term conversational memory eval — apples-to-apples vs Mem0 / Zep / MemGPT. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -259,9 +259,10 @@ SurrealDB:
 - **CPU-bound dispatch** — handlers can opt in via `register(jobType,
   handler, { cpuBound: true, workerModule: '…' })` to be routed
   through `JobWorkerPool` — a fixed-size `node:worker_threads` pool.
-  Default `JOB_WORKER_POOL_SIZE=0` (disabled — no current handler is
-  cpuBound; BGE-M3 already owns its own worker, every other handler
-  is IO-bound). Scaffolding ships for future heavy work. Phase K1.
+  Code default `JOB_WORKER_POOL_SIZE=2`; the prod compose and
+  `PROCESS_ROLE=api` pin it to `0` (no current handler is cpuBound;
+  BGE-M3 already owns its own worker, every other handler is
+  IO-bound). Scaffolding ships for future heavy work. Phase K1.
 - **Tracing** — Enqueue → OTel PRODUCER span (`jobs.enqueue`,
   `messaging.system=surrealdb`, traceparent injected into the row).
   Dispatch → CONSUMER span (`jobs.process <jobType>`) linked as a

--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -298,9 +298,11 @@ signature verification, security model: [mcp-pack-tools.md](mcp-pack-tools.md).
 A pack MAY ship a `memoryModel` section — the **domain perception
 contract**: how this domain perceives and episodizes memory. It turns a
 pack from a vocabulary into a domain *projection*: the pack declares HOW
-to look, never WHAT is true. The section is contract-only today
-(validated, stored, cached, exposed read-only on the admin surface);
-the perception/episodization consumers arrive in sibling increments.
+to look, never WHAT is true. The contract is validated, stored, cached,
+exposed read-only on the admin surface, and read by five live core
+consumers (listed below). No first-party pack in `packs/` declares a
+`memoryModel` section yet — the contract and its consumers are ahead of
+the catalogue.
 
 The semantic plane has five optional arrays. The Evidence Plane adds
 three declarative capabilities. A present section must declare at least
@@ -346,6 +348,35 @@ The whole section rides the signed/checksummed manifest; an upgrade that
 changes it flips `memoryModelChanged` and invalidates the
 `MemoryModelReaderService` cache.
 
+### Live consumers
+
+Consumers read installed models through `MemoryModelReaderService`
+(`src/ai/memory-model-reader.service.ts` — per-tenant LRU + 30s TTL,
+fail-open to "no models"), except where a fail-open cache would be a
+security hole:
+
+- **Episodic candidate projections**
+  (`src/documents/external-candidates.service.ts`) — an indexer pack may
+  stage `scene` / `state_delta` candidates only against its OWN declared
+  `sceneSchemas` / `stateModels` ids; a pack with no memoryModel cannot
+  stage episodic candidates at all.
+- **L3 attention boost** (`src/synthesize/l3-escalation.service.ts`) —
+  under `FOVEA_ATTENTION_HINTS`, installed packs' `attentionHints` bias
+  which memories the L3 escalation pass prefers and how deep it zooms.
+- **Processor capability matching**
+  (`src/evidence/processor-broker.service.ts`) — a pack's declared
+  `processors` (input `modality` + derived `produces`) select which
+  derived representations the trusted core broker computes.
+- **Processor dispatch gate**
+  (`src/evidence/processing/dispatch-gate.ts`) — dispatch is refused
+  unless the pack declared a processor whose modality matches the asset
+  and whose `produces` includes the requested capability.
+- **Raw-evidence serving** (`src/evidence/evidence-read.service.ts`) —
+  raw bytes serve only when the manifest declares
+  `rawEvidence: { serve: true }`. This gate reads the stored manifest
+  directly, NOT the fail-open cache: after a consent withdrawal a stale
+  cache entry must not keep serving, so a read failure denies.
+
 ## The registry (global catalogue)
 
 Packs are published to and installed from a **global registry** — a shared,
@@ -377,8 +408,13 @@ Surface:
 - **Install from registry** (`brain:admin`): `POST /v1/admin/packs/from-registry
   {packId, version?}` — resolves latest-non-yanked (or a pin) and installs via
   the normal path, pinning the registry checksum.
-- **Browse** (public, no auth): `GET /registry/ui` — a server-rendered HTML
-  catalogue of published packs (ids, versions, keywords, install hint).
+- **Browse** (public, no auth): `GET /registry/ui` (+
+  `GET /registry/ui/publisher/:publisher`) — a server-rendered HTML
+  catalogue of published packs (ids, versions, keywords, install hint),
+  served by `src/registry/registry-ui.controller.ts`. Deliberately
+  unguarded: the catalogue is public metadata and a browser can't send a
+  Bearer token. Prod edge routing for `/registry` is wired in PR #433
+  (before it, the public catalogue 404'd at the proxy).
 
 CLI:
 

--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -149,6 +149,38 @@ methodology. We are happy to run partner systems through this harness
 and/or re-run ours through theirs; under matched protocols, deltas are
 meaningful — absolute numbers alone are not.
 
+## 6. The mechanical eval battery (judge-free)
+
+Alongside the judged benchmark axes, an in-repo battery family measures
+memory fitness **mechanically**: ground truth is authored WITH the
+corpus, so there is no LLM judge and no paid eval — the only model
+spend is the stand's own normal serving cost.
+
+- **`pnpm eval:memory-fitness`** (`test/eval/memory-fitness/`) — 30
+  questions over an authored 66-turn corpus (5 conversations, one
+  primary user, 4 revision chains + 1 contradiction pair), scored on
+  8 dimensions: D1 state currency, D2 evolution history, D3 provenance
+  unrollability, D4 temporal anchors, D5 absence honesty, D6 conflict
+  surfacing, D7 cross-session integration, D8 self-utility replay.
+- **`pnpm eval:state-transitions`** (`test/eval/state-transitions/`) —
+  12 isolated mutable-world-state scenarios (dispose, replace,
+  re-acquire, retro-dated, intention-vs-action, listed-not-sold,
+  contradiction, field drift, third-party, same-day, multi-object,
+  provenance-of-transition), each with 2–4 typed checks
+  (`serve` / `belief` / `history` / `prov`). Serve scoring is
+  marker-first: an honest decline never fails a serve check by itself.
+- **`eval:domain-packs`** — a pack-conformance battery in the same
+  family, landing in a separate in-flight PR.
+
+Methodology: each battery runs against a **fresh tenant per run**
+(`BRAIN_COMPANY_ID` is operator-supplied; every scenario seeds its own
+entities, so scenarios cannot cross-contaminate within a run). The
+**same-memory re-ask** (`MEMFIT_SKIP_INGEST=1` / `STEV_SKIP_INGEST=1`
+with the original run id) re-asks an already-ingested run without
+re-writing — separating the *extraction lottery* (what a fresh ingest
+happens to capture) from *read-side* regressions over the same stored
+memory. Both runners' READMEs carry the full env contract.
+
 ## See also
 
 - [eval-protocol.md](eval-protocol.md) — the full three-axis protocol

--- a/docs/extraction-harvest-lanes.md
+++ b/docs/extraction-harvest-lanes.md
@@ -1,0 +1,71 @@
+# Deterministic extraction harvest lanes
+
+LLM extraction has a recall lottery: the same turn can yield a fact on
+one run and miss it on the next. The harvest lanes close that gap for
+two fact classes where determinism is possible — **technical literals**
+and **completed state transitions**. Each lane runs AFTER the LLM
+extractor's denoise pass and UNIONs extra mention candidates into the
+same downstream pipeline (same attribution, dedup, conflict
+resolution). No lane adds an LLM call; all are default-off flags in the
+[config catalog](operations.md#extractor_--deterministic-harvest-lanes).
+
+## Literal harvest (`EXTRACTOR_LITERAL_HARVEST`)
+
+`src/ai/extractor-internals/literal-harvest.ts` — regex rules over the
+turn text emit mention candidates for five technical-literal core
+predicates:
+
+| Predicate       | Catches                                           |
+| --------------- | ------------------------------------------------- |
+| `rate_limit`    | request/rate ceilings ("100 req/s per key")       |
+| `service_port`  | service ↔ port bindings                           |
+| `http_status`   | endpoint ↔ status-code behavior                   |
+| `naming_prefix` | naming conventions ("all queues prefixed `evt_`") |
+| `identifier`    | opaque ids, codes, keys                           |
+
+A sixth technical-literal predicate, `duration_limit`, is seeded as an
+LLM extraction slot only: its harvest regex ships in the module but is
+deliberately excluded from the active rule list as the over-firing rule
+of the family. The lane caps at 6 candidates per turn; attribution is
+by clause overlap with a speaker fallback.
+
+## State-verb harvest (`EXTRACTOR_STATE_VERB_HARVEST`)
+
+`src/ai/extractor-internals/state-verb-harvest.ts` — a lexicon of
+past-tense/completed state verbs (sold, quit, adopted, moved…) emits
+`state_change` facts (append-only predicate, confidence 0.95, cap
+6/turn).
+
+**Holder binding law**: the fact binds to the person whose state
+changed — a PERSON entity named in the sentence when present, else the
+speaker — and NEVER to the transitioned object. "Anna sold the bike"
+is a state change OF ANNA (the bike is inside the harvested span);
+binding it to the bike scatters one person's transitions across object
+entities and makes the timeline unreadable. Intention forms
+("is planning to sell", "listed the bike") are deliberately outside the
+lexicon: an intention is not a completed transition.
+
+## Transition classifier (`EXTRACTOR_TRANSITION_CLASSIFIER`)
+
+Module only — NOT wired into the extraction pipeline in this release;
+the flag is an availability gate, and thresholds are exported defaults
+pending stand calibration. Two pure stages:
+
+1. **Morphology** (`src/ai/extractor-internals/transition-morphology.ts`)
+   — compromise-based English morphology finds past-tense,
+   non-negated, non-hypothetical verb clauses with a complement.
+2. **Semantics** (`src/ai/extractor-internals/transition-classifier.ts`)
+   — max-cosine against a fixed EN + RU prototype bank
+   (BGE-M3 embeddings carry the language-agnosticism), classifying
+   `completed_acquire | completed_dispose | completed_change |
+intention | unrelated`.
+
+## See also
+
+- [Operations](operations.md#extractor_--deterministic-harvest-lanes) —
+  the `EXTRACTOR_*` flag table (all default-off).
+- [Data model](data-model.md) — predicate vocabulary + conflict
+  resolution the harvested facts flow into.
+- [Eval methodology](eval-methodology.md) — the mechanical battery
+  (`eval:memory-fitness`, `eval:state-transitions`) that measures what
+  these lanes fix.

--- a/docs/fact-provenance-api.md
+++ b/docs/fact-provenance-api.md
@@ -142,7 +142,7 @@ the row exists.
 ## Example
 
 ```bash
-export BRAIN_KEY=sk_...
+export BRAIN_KEY=brain_...
 curl -s -H "Authorization: Bearer $BRAIN_KEY" \
   https://brain.example.com/v1/facts/f1 | jq .
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -40,6 +40,8 @@ the operator's reference for running Brain.
 | `CONFLICT_*` | per spec | Override the resolution weights at runtime; defaults match `core/capabilities/knowledge.yaml`. |
 | `MULTI_HOP_PLANNER_MODEL` | `OPENAI_CHAT_MODEL` | Override the chat model for the multi-hop planner LLM call. |
 | `MULTI_HOP_PLANNER_CONCURRENCY` | `4` | Max in-flight planner calls. |
+| `AUTH_SERVICE_JWKS_URL` | unset | Enables JWKS-based verification of user JWTs (unset = static keys only, dev). In prod the JWKS document lives at `https://auth.inite.ai/.well-known/jwks.json`. |
+| `AUTH_SERVICE_ISSUER` | unset | Expected `iss` claim for JWKS-verified JWTs; production refuses to boot with JWKS on and this unset. MUST equal the auth-service's REAL issuer — `https://auth-api.inite.ai` in prod, NOT the `auth.inite.ai` host the JWKS document is fetched from. A mismatch rejects EVERY JWT as "Invalid credentials"; grep the boot log for `[JwksService]` `issuer=` to confirm the running value. |
 | `AUTH_SERVICE_INTROSPECTION_CLIENT_ID` / `_SECRET` | unset | Enables RFC 7662 resolution of auth-service `ik_…` API keys (brain-service M2M client credentials). |
 | `AUTH_SERVICE_INTROSPECTION_URL` | `AUTH_SERVICE_URL`+`/v1/oauth/introspect` | Endpoint override. |
 | `AUTH_SSF_POLL_URL` | unset | CAEP revocation stream poll endpoint (RFC 8936); enables the deny-list that rejects IdP-revoked tokens before `exp`. `AUTH_SSF_CLIENT_ID/SECRET` default to the introspection client; `AUTH_SSF_POLL_SCOPE` default `admin`; `AUTH_SSF_POLL_INTERVAL_MS` default `30000`. |
@@ -154,8 +156,11 @@ off, external-origin registration is refused entirely.
 
 ### `SCENES_*` — scene substrate + belief promotion (Brain v2)
 
-All shadow: no serving path reads `memory_episode` / `semantic_belief`
-(the beliefs READ API is its own flag, `BELIEFS_API_ENABLED`).
+Construction is shadow: these flags build the episodic/belief substrate
+without touching serving. Serving FROM `semantic_belief` is its own
+opt-in lane — see [`BELIEFS_*`](#beliefs_--belief-serving-lane-0126)
+below (the beliefs READ API is also its own flag,
+`BELIEFS_API_ENABLED`).
 
 | Flag | Default | Purpose |
 |---|---|---|
@@ -169,10 +174,23 @@ All shadow: no serving path reads `memory_episode` / `semantic_belief`
 | `SCENES_BELIEF_PROMOTION` | `0` | Belief promotion (Belief-A, 0120): fold ENRICHED scenes into `semantic_belief` supersede-chain revisions via `…/scenes/beliefs`. |
 | `SCENES_BELIEF_MIN_SCENES` | `0` | Corroboration floor: promote a (subject, field) only when the winning value spans at least this many DISTINCT conversations (0 = off). |
 | `SCENES_BELIEF_LLM_SYNTHESIS` | `0` | ONE LLM call per belief create/revise to phrase the statement; any failure degrades to the deterministic template. |
+| `SCENES_BELIEF_NEGATION_DELTAS` | `0` | Fold state REMOVALS (sold / quit / ended): a stateDelta with empty `to` + non-empty `from` becomes a belief contribution with the sentinel value `none` (`priorValue` = the removed state). Both-ends-empty deltas stay dropped. |
+| `SCENES_BELIEF_FIELD_FOLD` | `0` | Deterministic field-name folding: an enricher-re-coined field name folds onto an existing `(userId, subject)` field when its extra tokens are all generic modifiers; the EXISTING name wins; more than one match folds nothing and warns loudly. No embeddings, no LLM. |
 
 Order: master flag → compose → (`SCENES_LLM_ENRICHMENT` → enrich) →
 (`SCENES_BELIEF_PROMOTION` → beliefs). Enrichment is a prerequisite for
 promotion — the belief fold reads enriched fields only.
+
+### `BELIEFS_*` — belief serving lane (0126)
+
+The first serving path over `semantic_belief`: an extra evidence lane in
+`/v1/synthesize` alongside the fact lanes.
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `BELIEFS_SERVING_LANE` | `0` | Serve beliefs in synthesize: BM25 over `semantic_belief.statement` (0126), top-3, rendered into the evidence set; the generator may cite them via `citedBeliefIds`, which resolve through the rendered-set fence into belief-arm `evidenceCitations` (`beliefId` + rendered excerpt). Fail-closed single-user scope: no `userId` → no query, `active` + visibility re-check per belief. |
+| `BELIEFS_LANE_DATE_DISAMBIGUATION` | `0` | Render belief lines as `belief current since <day>` instead of `as of <day>` — a belief line's date is the belief REVISION's `validFrom`, not the event date. ONE render site, so generator, verifier, and fragment-zoom re-verify read identical lines. No-op without the serving lane. |
+| `BELIEFS_FACT_DAMPING` | `0` | Declared in the catalog but not read by any code path yet; boot validation warns when it is set without the serving lane. |
 
 ### `FOVEA_*` — focus calibration + serving integrity
 
@@ -217,6 +235,19 @@ segment-serving mode is on, cross-user verbatim disclosure is possible.
 | `OUTCOME_TX_WRITES` | `0` | Transactional idempotent outcome writes (one BEGIN/COMMIT, deterministic ids, replay folds nothing twice). |
 | `OUTCOME_DECISION_CAPTURE` | `0` | Content-free `memory_decision` rows at the abstain gate + L3 trigger (0119); independent master, not coupled to `OUTCOME_TELEMETRY_ENABLED`. |
 | `OUTCOME_DECISION_RETENTION_DAYS` | `30` | Decision-row retention (03:41 UTC prune, gated on the capture flag). |
+
+### `EXTRACTOR_*` — deterministic harvest lanes
+
+Regex/lexicon lanes that run after the LLM extractor's denoise pass and
+UNION extra mention candidates into the same pipeline — deterministic,
+zero additional LLM calls. Prose reference:
+[extraction-harvest-lanes.md](extraction-harvest-lanes.md).
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `EXTRACTOR_LITERAL_HARVEST` | `0` | Literal-fact harvest (`src/ai/extractor-internals/literal-harvest.ts`): regex rules emit `rate_limit`, `service_port`, `http_status`, `naming_prefix`, `identifier` mention candidates (cap 6/turn; attribution by clause overlap with speaker fallback). The sixth technical-literal core predicate, `duration_limit`, is seeded as an LLM slot only — its harvest rule ships disabled (the over-firing rule of the family). |
+| `EXTRACTOR_STATE_VERB_HARVEST` | `0` | State-verb harvest (`src/ai/extractor-internals/state-verb-harvest.ts`): a past-tense/completed state-verb lexicon emits `state_change` facts (confidence 0.95, cap 6/turn). The fact binds to the state HOLDER — a person entity named in the sentence, else the speaker — never to the transitioned object. |
+| `EXTRACTOR_TRANSITION_CLASSIFIER` | `0` | Availability gate ONLY in this release: the language-agnostic transition classifier (compromise morphology stage + BGE-M3 EN/RU prototype bank — `transition-morphology.ts` + `transition-classifier.ts`) exists as a standalone module but is NOT wired into the extraction pipeline yet; thresholds are exported defaults pending stand calibration. |
 
 Related read-surface flags documented in [api.md](api.md):
 `FACTS_API_ENABLED` (fact read + provenance, also registers the MCP
@@ -335,7 +366,12 @@ The genre-dependent retrieval dimensions are NOT feature flags — they
 are per-tenant configuration, resolved once per request into a
 `RetrievalProfile` object (the platform directive 2026-08-03 replaced
 the old per-lane flag forks with this surface). Env sets the boot
-default; `RETRIEVAL_PROFILE_OVERRIDES` overlays per tenant.
+default; `RETRIEVAL_PROFILE_OVERRIDES` overlays per tenant. Resolution
+order per key: explicit env var → the `RETRIEVAL_GENRE` preset
+(`src/search/genre-presets.ts`; the genre defaults to `assistant_chat`)
+→ the code fallback — so for an unset var the EFFECTIVE default is the
+`assistant_chat` preset value, not necessarily the code fallback listed
+below.
 
 | Key | Default | What it does |
 |---|---|---|
@@ -343,7 +379,7 @@ default; `RETRIEVAL_PROFILE_OVERRIDES` overlays per tenant.
 | `RETRIEVAL_VERBATIM_EVIDENCE` | `shape_conditioned` | How verbatim L0 evidence reaches answers: `off` (facts only), `shape_conditioned` (episode quotes + provenance excerpts only when the question asks for conversational content — the engine default), `always` (all verbatim lanes unconditionally as a prompt appendix; the diary-genre profile), `fused` (segments become scored, reranked, citable SearchHits inside the search pipeline instead of an appendix), `routed` (per-query dispatch: verbatim-shaped questions take the fused path, everything else stays shape_conditioned). |
 | `RETRIEVAL_INSIGHT_EVIDENCE` | `off` | How derived insight rows (aspect aggregates + `summary_*` promotion/compaction summaries) reach answers: `off` (they ride the fact legs as ordinary rows), `routed` (fact legs exclude them; summarization/enumeration-routed questions retrieve them as their own dense+BM25 fused pool under a separate prompt slot — `INSIGHT_TOP_K`, not the fact budget). |
 | `RETRIEVAL_TIMELINE_EVIDENCE` | `off` | `routed`: ordering/sequence-shaped questions (the order-lexicon) also get the chronological segment appendix — the occurredAt-ordered mention record. Event-time extraction collapses a session's mentions onto one `validFrom` date, so mention order is unrecoverable from facts alone. Skipped when the query's resolved verbatim mode is `fused`. `scan`: the mention record is built by the topic-scan lane instead of the top-K appendix — topic phrase extracted from the question, the segment record scanned per session (BM25+embedding against the TOPIC), one dated line per session-mention in occurredAt order; coverage bounded by session count, not top-K. |
-| `RETRIEVAL_ABSTENTION_CALIBRATION` | `off` | `coverage`: in strict/lenient guardrails, evidence must clear the coverage floor (best fact score ≥ `RETRIEVAL_ABSTENTION_MIN_SCORE`, default 0.35; fact count ≥ `RETRIEVAL_ABSTENTION_MIN_EVIDENCE`, default 2) before generation — below it synthesize returns an explicit not-in-my-memory answer (reason `low_coverage`). Note: retrieval-level floors cannot detect answer-absence on topically-adjacent questions (measured non-discriminative) — use for genuinely off-topic traffic. `verifier`: answer-level coverage — in lenient guardrails an unsupported/partial verifier verdict returns the explicit decline instead of ungrounded text (no extra LLM cost). `answer` guardrails are always exempt (caller-level never-abstain contract). |
+| `RETRIEVAL_ABSTENTION_CALIBRATION` | `verifier` (effective — set by the default `assistant_chat` genre preset in `src/search/genre-presets.ts`; the bare-code fallback is `off`) | `coverage`: in strict/lenient guardrails, evidence must clear the coverage floor (best fact score ≥ `RETRIEVAL_ABSTENTION_MIN_SCORE`, default 0.35; fact count ≥ `RETRIEVAL_ABSTENTION_MIN_EVIDENCE`, default 2) before generation — below it synthesize returns an explicit not-in-my-memory answer (reason `low_coverage`). Note: retrieval-level floors cannot detect answer-absence on topically-adjacent questions (measured non-discriminative) — use for genuinely off-topic traffic. `verifier`: answer-level coverage — in lenient guardrails an unsupported/partial verifier verdict returns the explicit decline instead of ungrounded text (no extra LLM cost). `answer` guardrails are always exempt (caller-level never-abstain contract). |
 | `RETRIEVAL_SALIENCE_SCORING` | off | Fold the deriver-stamped `source.salience` (0-3, written under `DERIVER_SALIENCE_STAMP`) into ranking — weights [0.8, 1.0, 1.1, 1.25] per grade. Unstamped rows sit on the neutral grade and are unaffected. Enable only against a salience-stamped derived world. |
 | `RETRIEVAL_DATE_ANCHORING` | `absolute` | How the generator's "today" anchors: `none` (session-date-convention golds, e.g. the LoCoMo eval profile), `session_date` (only when the caller sends `asOf`), `absolute` (asOf, else wall clock). |
 | `RETRIEVAL_TEMPORAL_MODE` | `filter` | How an explicit `asOf` shapes retrieval: `filter` (strict bitemporal point-in-time closure), `overlap_boost` (the validity gate is relaxed; facts outside the interval survive with an exponential distance decay on their score — a slightly-wrong asOf degrades results instead of emptying them). |


### PR DESCRIPTION
Documentation refresh: audit of `docs/` + `README.md` + `AGENTS.md` against current main (`416a1cc`). Every claim below was verified against code (file paths, flag names, endpoint paths). `docs/roadmap/` untouched (dated historical briefs). Docs-only — `paths-ignore` skips the deploy.

## What changed

| Doc | What was stale | What it says now |
|---|---|---|
| `docs/domain-packs.md` | memoryModel section claimed "contract-only today … consumers arrive in sibling increments" — false, five consumers are live. Registry UI browse bullet lacked the controller path / publisher route / routing status. | New **Live consumers** subsection: episodic candidate projections (`external-candidates.service.ts`), L3 attention boost (`l3-escalation.service.ts` under `FOVEA_ATTENTION_HINTS`), processor capability matching (`processor-broker.service.ts`), dispatch gate (`dispatch-gate.ts`), raw-evidence serving (`evidence-read.service.ts`, deliberately NOT via the fail-open cache). States plainly that no first-party pack in `packs/` declares a memoryModel yet. Browse bullet now names `registry-ui.controller.ts`, the `/registry/ui/publisher/:publisher` route, and the prod edge-routing fix (PR #433). |
| `docs/operations.md` | "All shadow: no serving path reads `memory_episode` / `semantic_belief`" — repealed by `BELIEFS_SERVING_LANE`. Missing flags: `SCENES_BELIEF_NEGATION_DELTAS`, `SCENES_BELIEF_FIELD_FOLD`, `BELIEFS_SERVING_LANE`, `BELIEFS_LANE_DATE_DISAMBIGUATION`, `BELIEFS_FACT_DAMPING`, all three `EXTRACTOR_*` lanes, `AUTH_SERVICE_JWKS_URL` / `AUTH_SERVICE_ISSUER`. `RETRIEVAL_ABSTENTION_CALIBRATION` default listed as `off` (effective default is `verifier` via the `assistant_chat` genre preset). | Corrected SCENES intro; new `BELIEFS_*` (0126 serving lane) and `EXTRACTOR_*` (deterministic harvest lanes) flag-family subsections; JWKS/issuer env rows including the auth-api vs auth host distinction; abstention-calibration default corrected; retrieval-profile section now documents the env → genre-preset → code-fallback resolution order. |
| `docs/DEPLOY.md` | No mention that flags come from TWO places (compose `environment:` + `enablement.env`) or of the GitHub 21k expression-limit failure mode. `restart` bullet pointed only at `docker-compose.yml`. Secrets table omitted `BRAIN_EVIDENCE_URL_SECRET` and `BRAIN_BILLING_API_KEY` (both consumed by `deploy-brain.yml`), mislabeled `INITE_SHARED_PAT` as a deploy secret (it's `ci.yml`-only), and listed four "optional" secrets the workflow does not read at all. No issuer runbook, no segment-fence backfill order. | New **Where the container's env comes from** section (env_file + precedence + the zero-job "workflow file issue" failure mode). Secrets table completed and corrected; unwired optional vars explicitly labeled inert-until-wired. New invariants: `AUTH_SERVICE_ISSUER` = `https://auth-api.inite.ai` (not `auth.inite.ai`) with the `action=logs` → `[JwksService]` diagnosis path, and the `PRIVACY_SEGMENT_USER_FENCE` migrate → backfill (`POST /v1/admin/maintenance/segments/backfill-user-ids`) → flip sequence. |
| `docs/eval-methodology.md` | The mechanical battery family did not exist in the doc. | New section 6: `pnpm eval:memory-fitness` (8 dimensions D1–D8, 30 questions, no LLM judge), `pnpm eval:state-transitions` (12 scenarios, typed `serve`/`belief`/`history`/`prov` checks, marker-first serve scoring), `eval:domain-packs` noted as landing in a separate in-flight PR; fresh-tenant-per-run + skip-ingest same-memory re-ask methodology (extraction lottery vs read-side isolation). |
| `docs/extraction-harvest-lanes.md` (new) | Harvest lanes had no prose home. | `EXTRACTOR_LITERAL_HARVEST` (five harvested predicates; `duration_limit` seeded but harvest-disabled), `EXTRACTOR_STATE_VERB_HARVEST` (`state_change`, holder-binding law — binds to the person whose state changed, never the object), `EXTRACTOR_TRANSITION_CLASSIFIER` (module-only: compromise morphology + BGE-M3 EN/RU prototype bank, unwired pending calibration). |
| `docs/architecture.md` | "Default `JOB_WORKER_POOL_SIZE=0`" — the code default is `2` (`job-worker-pool.service.ts`); `0` comes only from `PROCESS_ROLE=api` or the prod compose. | Code default 2; api-role/prod pin to 0. |
| `docs/fact-provenance-api.md` | curl example used `BRAIN_KEY=sk_...` (OpenAI prefix). | `brain_...` (the brain key prefix). |
| `docs/README.md` | Index missing the new extraction doc; eval-methodology row predated the battery. | Row added; eval row mentions the judge-free battery. |
| `AGENTS.md` | Honesty-note section did not mention the mechanical batteries that now produce the in-repo memory numbers. | One added sentence pointing at `eval:memory-fitness` / `eval:state-transitions`. |

## Suspicious but NOT changed (unverified or intentional — flagging instead of guessing)

- `RETRIEVAL_SCENE_TRACES`: effective default is ON (`assistant_chat` preset sets `sceneTraces: true`) while `config-catalog.data.ts` and the `env-validation.ts` comment both say off. The new resolution-order note in operations.md covers the mechanism, but the catalog/comment themselves may deserve a code-side fix.
- `operations.md` `JOB_WORKER_POOL_SIZE` row says "`2` (dev) / `0` (prod)" — accurate for the inite-hosted deploy but the prod `0` is a compose choice, not a built-in `NODE_ENV` branch; left as-is.
- `BELIEFS_FACT_DAMPING` is declared in the config catalog but nothing reads it yet — documented as such rather than removed.
- Coverage gap (shipped, catalogued flags with zero prose-doc mentions, not added because their semantics weren't independently verified in this pass): `FOVEA_FRAGMENT_ZOOM` (+`_MAX_CHARS`, missing from the otherwise-complete `FOVEA_*` table), `RETRIEVAL_FRAGMENT_LANE`, `RETRIEVAL_L3_ESCALATION`, `SEARCH_FACT_RERANK`, `LIVE_SUBSCRIPTIONS_ENABLED`, `STATS_VIEWS_ENABLED`, `SCOPE_TAGS_ENABLED`, `STRATEGY_MEMORY_ENABLED`, `AGENT_QA_TOOLS_V2`.
- `eval:domain-packs` does not exist in main yet — mentioned in eval-methodology.md as landing in a separate in-flight PR, per the current plan; drop that bullet if the PR is abandoned.
- `README.md` checked and NOT changed: the `@inite/brain-mcp` JSON registration snippet, the remote `https://brain.inite.ai/mcp/<companyId>` shape, and every referenced `pnpm` script verified current. README makes no skills-bundle-version claim (the 0.4.0 figure lives in `skills/VERSION` + `skills/CHANGELOG.md`).
- `docs/roadmap/*.md` left untouched — nothing found that is actively misleading enough to need a superseded banner (they self-identify as dated briefs and `docs/README.md` labels them historical).

## Formatting note

Bare `prettier --check` fails on `docs/*.md` **on main already** (the repo's formatting authority, `pnpm format:check`, covers only `src`/`test` TypeScript). To keep the diff surgical instead of reformatting whole files, edits match each doc's existing style; the one new file (`docs/extraction-harvest-lanes.md`) is prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
