### PR TITLE
feat(deploy): enable state-verb harvest in prod; clarify scene-traces catalog default

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -303,6 +303,10 @@ jobs:
           EXTRACTOR_LITERAL_HARVEST=1
           SCENES_BELIEF_NEGATION_DELTAS=1
           SCENES_BELIEF_FIELD_FOLD=1
+          # ── State-verb harvest (#429/#431, measured: state-transition
+          # battery 4/12 -> 8/12 scenarios, checks 84%; held-out
+          # adversarial set 18/18; unit 29/29 incl. holder binding) ──
+          EXTRACTOR_STATE_VERB_HARVEST=1
           EOF
           # The heredoc carries the YAML block's 10-space indent into the
           # file; strip it so every line is a clean KEY=value / #comment

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1845,7 +1845,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: true,
     isBooleanFlag: true,
     description:
-      'V13 read side of DERIVER_SCENE_TRACE (profile field sceneTraces): fact lines carry a "(context: …)" suffix from the stamped source.scene, so the generator and verifier see the situational anchor next to the proposition. Unstamped rows render as before; against worlds derived without the stamp the flag is byte-identical off.',
+      'V13 read side of DERIVER_SCENE_TRACE (profile field sceneTraces): fact lines carry a "(context: …)" suffix from the stamped source.scene, so the generator and verifier see the situational anchor next to the proposition. Unstamped rows render as before; against worlds derived without the stamp the flag is byte-identical off. NOTE: defaultValue is the env fallback only — the assistant_chat genre preset (the default RETRIEVAL_GENRE) presets sceneTraces ON, so tenants on that genre render scene traces unless the env pins =0.',
   },
   {
     key: 'DERIVER_TYPED_ATOMS',


### PR DESCRIPTION
## What

Two riders from the measured state-verb wave:

1. **Prod enablement**: `EXTRACTOR_STATE_VERB_HARVEST=1` added to `enablement.env` in the deploy workflow. The lane was merged default-off in #429/#431 and measured on the stand before this rider: state-transition battery 4/12 → 8/12 scenarios (checks 84%), adversarial held-out set 18/18, unit suite 29/29 including the holder-binding regression.
2. **Catalog truth**: the `RETRIEVAL_SCENE_TRACES` catalog description now says explicitly that `defaultValue='0'` is only the env fallback — the `assistant_chat` genre preset (the default `RETRIEVAL_GENRE`, `retrieval-profile.ts:634`) presets `sceneTraces` ON, so the effective default for assistant_chat tenants is on unless the env pins `=0`. Doc-refresh finding; prod already pins `RETRIEVAL_SCENE_TRACES=1` so behavior is unchanged everywhere.

## Verification

- `pnpm typecheck` clean
- `pnpm test:unit -- config-catalog-truth flag-budget` 9/9
- `pnpm format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB