### PR TITLE
feat(extractor): coding-domain verbs in the state-verb harvest lexicon

### DIFF
--- a/src/ai/extractor-internals/state-verb-harvest.ts
+++ b/src/ai/extractor-internals/state-verb-harvest.ts
@@ -88,8 +88,56 @@ const DISPOSE_VERBS = [
  */
 const CHANGE_VERBS = ['moved to', 'switched to', 'renamed to', 'migrated to', 'replaced'];
 
+/**
+ * Coding-domain transition verbs (code-memory dogfood program,
+ * 2026-09): the consumer-life lexicon above harvests nothing from a
+ * coding agent's narration — "we enabled ACME_RETRY_QUEUE in prod",
+ * "merged PR #431", "bumped jest to 30" all died in the closed-vocab
+ * extractor exactly like the consumer transitions did. Additions only;
+ * the existing lexicon, guards and holder binding are untouched.
+ *
+ * Matcher constraints these forms respect BY CONSTRUCTION:
+ *  - completed forms only, so "enabling" / "to deprecate" never match;
+ *  - multi-word entries must be ADJACENT in the input ("rolled back
+ *    the migration" matches; "rolled the migration back" does not —
+ *    split phrasal particles are outside the matcher's model);
+ *  - a verb with an empty object noun phrase harvests nothing, so
+ *    passive / verb-final phrasings ("PR #431 was merged.", "the flag
+ *    was enabled.") produce NO fact rather than a mis-bound one;
+ *  - the object capture stops at any clause-boundary character and
+ *    "." is one, so a dotted value in the object ("upgraded SurrealDB
+ *    to 3.2.4") clips at its first dot ("upgraded SurrealDB to 3") —
+ *    still harvested, still verbatim, just truncated;
+ *  - bare "renamed" / "migrated" coexist with the consumer "renamed
+ *    to" / "migrated to": ALL_VERBS sorts longest-first, so the
+ *    phrasal form still wins whenever it is present.
+ *
+ * Holder binding is inherited unchanged: bindStateHolder routes the
+ * fact to a PERSON entity named in the sentence, else the speaker — so
+ * an active-voice artifact transition ("we enabled FLAG_X") lands on
+ * the AGENT, not on the flag entity. Known limitation, deliberate for
+ * this small PR; the code-memory battery measures it.
+ */
+const CODING_VERBS = [
+  'merged',
+  'reverted',
+  'enabled',
+  'disabled',
+  'deployed',
+  'released',
+  'bumped',
+  'upgraded',
+  'downgraded',
+  'deprecated',
+  'removed',
+  'deleted',
+  'renamed',
+  'migrated',
+  'rolled back',
+];
+
 /** All verbs, longest-first so phrasal forms win over any prefix form. */
-const ALL_VERBS = [...ACQUIRE_VERBS, ...DISPOSE_VERBS, ...CHANGE_VERBS].sort(
+const ALL_VERBS = [...ACQUIRE_VERBS, ...DISPOSE_VERBS, ...CHANGE_VERBS, ...CODING_VERBS].sort(
   (a, b) => b.length - a.length,
 );
 

--- a/test/state-verb-harvest.unit-spec.ts
+++ b/test/state-verb-harvest.unit-spec.ts
@@ -193,6 +193,204 @@ describe('harvestStateVerbs — invariants', () => {
   });
 });
 
+// ── Coding-domain verbs (code-memory dogfood, additions-only) ────────
+// The consumer-life lexicon harvested nothing from a coding agent's
+// narration; these pin the added CODING_VERBS entries — completed
+// forms, adjacent phrasal "rolled back", guards intact, and the
+// holder-binding / passive-subject behaviour DOCUMENTED as-is.
+describe('harvestStateVerbs — coding-domain verbs', () => {
+  const CODING_TABLE: Array<[string, string, string]> = [
+    // [label, turn, expected verbatim span]
+    [
+      'merged',
+      'We merged PR #431 this morning; CI went green after the rerun.',
+      'merged PR #431 this morning',
+    ],
+    [
+      'reverted',
+      'I reverted the queue-relay cutover today.',
+      'reverted the queue-relay cutover today',
+    ],
+    [
+      'enabled',
+      'We enabled EXTRACTOR_STATE_VERB_HARVEST in prod.',
+      'enabled EXTRACTOR_STATE_VERB_HARVEST in prod',
+    ],
+    [
+      'disabled',
+      'We disabled the flaky retry sweep on staging.',
+      'disabled the flaky retry sweep on staging',
+    ],
+    [
+      'deployed',
+      'Deployed the billing service to eu-west yesterday.',
+      'Deployed the billing service to eu-west yesterday',
+    ],
+    [
+      'released',
+      'We released version 24 of the ingest worker.',
+      'released version 24 of the ingest worker',
+    ],
+    ['bumped', 'Bumped jest to 30 across the monorepo.', 'Bumped jest to 30 across the monorepo'],
+    [
+      'upgraded',
+      'We upgraded SurrealDB on staging this morning.',
+      'upgraded SurrealDB on staging this morning',
+    ],
+    [
+      'downgraded',
+      'I downgraded the kernel after the panic.',
+      'downgraded the kernel after the panic',
+    ],
+    [
+      'deprecated',
+      'We deprecated the v1 export endpoint today.',
+      'deprecated the v1 export endpoint today',
+    ],
+    [
+      'removed',
+      'Removed the legacy retry shim from the gateway.',
+      'Removed the legacy retry shim from the gateway',
+    ],
+    [
+      'deleted',
+      'I deleted the stale feature branch this afternoon.',
+      'deleted the stale feature branch this afternoon',
+    ],
+    [
+      'renamed',
+      'We renamed the ingestion module last sprint.',
+      'renamed the ingestion module last sprint',
+    ],
+    [
+      'migrated',
+      'We migrated the changefeed consumers off the polling loop.',
+      'migrated the changefeed consumers off the polling loop',
+    ],
+    [
+      'rolled back',
+      'We rolled back the schema migration overnight.',
+      'rolled back the schema migration overnight',
+    ],
+  ];
+
+  it.each(CODING_TABLE)('%s → exactly one state_change, span pinned', (_label, turn, span) => {
+    const facts = harvest(turn, SASHA, 0);
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.predicate).toBe(STATE_CHANGE_PREDICATE);
+    expect(facts[0]!.object).toBe(span);
+    expect(facts[0]!.valueSpan).toBe(span);
+    expect(facts[0]!.entityIndex).toBe(0);
+    expect(facts[0]!.confidence).toBe(STATE_VERB_HARVEST_CONFIDENCE);
+  });
+
+  // Held-out phrasing per verb group — a second wording the primary
+  // table does not cover, so a lexicon regression cannot hide behind
+  // one memorised sentence shape.
+  const HELD_OUT: Array<[string, string, string]> = [
+    [
+      'vcs (merge/revert)',
+      'Finally merged the long-running auth refactor.',
+      'merged the long-running auth refactor',
+    ],
+    [
+      'flags (enable/disable)',
+      'Disabled ANSWER_CACHE for the eu tenants last night.',
+      'Disabled ANSWER_CACHE for the eu tenants last night',
+    ],
+    [
+      'shipping (deploy/release)',
+      'Released the hotfix to all tenants within the hour.',
+      'Released the hotfix to all tenants within the hour',
+    ],
+    [
+      'versions (bump/up/downgrade)',
+      'Upgraded node to 22 on the runners.',
+      'Upgraded node to 22 on the runners',
+    ],
+    [
+      'retirement (deprecate/remove/delete)',
+      'Deprecated the positional-args constructor in favour of options.',
+      'Deprecated the positional-args constructor in favour of options',
+    ],
+    [
+      'movement (rename/migrate/rollback)',
+      'Rolled back the compaction change after the alert fired.',
+      'Rolled back the compaction change after the alert fired',
+    ],
+  ];
+
+  it.each(HELD_OUT)('held-out %s → harvested with the verbatim span', (_label, turn, span) => {
+    const facts = harvest(turn, SASHA, 0);
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.predicate).toBe(STATE_CHANGE_PREDICATE);
+    expect(facts[0]!.object).toBe(span);
+    expect(facts[0]!.valueSpan).toBe(span);
+  });
+
+  // Guards and completed-form construction hold for the new verbs too.
+  const CODING_NOTHING: Array<[string, string]> = [
+    ['bare-infinitive negation', "We didn't merge the release branch."],
+    ['intention idiom + bare infinitive', 'We are planning to deprecate the v1 endpoint.'],
+    ['negated completion', "We haven't merged PR #431 yet."],
+    ['hypothetical', 'We might revert the cutover if latency regresses.'],
+    ['future phrasal', 'We will roll back the migration tomorrow.'],
+    ['gerund under consideration', 'We are considering disabling the retry sweep.'],
+    ['about-to + bare infinitive', 'We are about to release v2.4.'],
+    ['modal suggestion', 'We should probably enable EXTRACTOR_STATE_VERB_HARVEST.'],
+    // Passive / verb-final: the object noun phrase is empty, so the
+    // matcher harvests NOTHING (no fact at all — never a mis-bound
+    // one). The artifact-subject transition is a known lexicon-lane
+    // limitation; the code-memory battery measures it.
+    ['passive verb-final (PR)', 'PR #431 was merged.'],
+    ['passive verb-final (flag)', 'The flag was enabled.'],
+  ];
+
+  it.each(CODING_NOTHING)('%s → no facts', (_label, text) => {
+    expect(harvest(text, [ent('Sasha'), ent('Priya')], 0)).toEqual([]);
+  });
+
+  it('active-voice artifact transition binds to the SPEAKER, not the artifact', () => {
+    // Pinned limitation: bindStateHolder only binds person entities
+    // (customer | staff); an artifact named in the clause never steals
+    // the binding, so "enabled ACME_RETRY_QUEUE" lands on the agent.
+    const entities = [ent('ACME_RETRY_QUEUE', 'asset'), ent('Sasha')];
+    const facts = harvest(
+      'Enabled ACME_RETRY_QUEUE in prod today.',
+      entities,
+      resolveSpeakerEntityIndex(entities, 'Sasha'),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.entityIndex).toBe(1);
+    expect(facts[0]!.object).toBe('Enabled ACME_RETRY_QUEUE in prod today');
+  });
+
+  it('dotted values clip at the first dot — the clause boundary includes "."', () => {
+    // Known matcher constraint, pinned rather than papered over: the
+    // object capture stops at ANY clause-boundary character, and "."
+    // is one, so a dotted version ("3.2.4") or dotted path inside the
+    // object clips at its first dot. The transition still harvests —
+    // the span is verbatim, just truncated. Loosening the boundary is
+    // out of scope for an additions-only lexicon change.
+    const facts = harvest('We upgraded SurrealDB to 3.2.4 on staging.', SASHA, 0);
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.object).toBe('upgraded SurrealDB to 3');
+    expect(facts[0]!.valueSpan).toBe('upgraded SurrealDB to 3');
+  });
+
+  it('phrasal "rolled back" wins as one entry — the span carries the full phrase', () => {
+    const facts = harvest('We rolled back the schema migration overnight.', SASHA, 0);
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.object.startsWith('rolled back ')).toBe(true);
+  });
+
+  it('consumer "renamed to" still wins over bare "renamed" when adjacent', () => {
+    const facts = harvest('I renamed to my maiden name after the divorce.', SASHA, 0);
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.object).toBe('renamed to my maiden name after the divorce');
+  });
+});
+
 // ── The assembleResult seam ──────────────────────────────────────────
 // The union point sits inside ExtractorRunnerService.assembleResult:
 // off-state must be byte-identical; on-state unions state-verb facts


### PR DESCRIPTION
## What

Adds 15 coding-domain transition verbs to the perfective state-verb harvest lexicon (`src/ai/extractor-internals/state-verb-harvest.ts`), additions-only:

`merged, reverted, enabled, disabled, deployed, released, bumped, upgraded, downgraded, deprecated, removed, deleted, renamed, migrated, rolled back`

The consumer-life lexicon harvested nothing from a coding agent's narration — "we enabled ACME_RETRY_QUEUE in prod", "merged PR #431", "bumped jest to 30" all died in the closed-vocab extractor exactly like the consumer transitions the lane was built for. This is PR-E of the code-memory dogfood program (audit fix list); the eval battery that measures it is a separate PR.

## What is deliberately untouched

- The existing lexicon entries, the 6-token pre-verb intention/negation guards, the clause-boundary set, the object caps, and `bindStateHolder`.

## Matcher constraints found (pinned as tests, not papered over)

- **Completed forms only** — gerunds and bare infinitives never match by construction: "planning to deprecate", "didn't merge", "considering disabling", "about to release" harvest nothing; "haven't merged PR #431 yet" is caught by the pre-verb guard.
- **Multi-word entries must be adjacent** — "rolled back the migration" matches as one entry; the split particle "rolled the migration back" does not (outside the matcher's model, so only the adjacent form was added).
- **Passive / verb-final phrasings harvest NOTHING** — "PR #431 was merged.", "The flag was enabled." leave the object noun phrase empty, so no fact is produced at all (never a mis-bound one).
- **Dotted values clip at the first dot** — the clause boundary includes `.`, so "upgraded SurrealDB to 3.2.4" harvests the verbatim-but-truncated span "upgraded SurrealDB to 3".
- Bare `renamed` / `migrated` coexist with consumer `renamed to` / `migrated to` through the existing longest-first alternation sort (pinned by a test).

## Known limitation (documented, not redesigned)

For code facts the state HOLDER is often an artifact, but `bindStateHolder` binds a person entity (`customer`|`staff`) named in the sentence, else the speaker — so an active-voice artifact transition ("we enabled ACME_RETRY_QUEUE") lands on the **agent's** timeline, not on the flag entity. Redesigning holder binding is out of scope for this small PR; the behaviour is pinned by a unit test and measured by the code-memory eval battery (its flag-transition check is gap-gated on exactly this).

## Prod note

`EXTRACTOR_STATE_VERB_HARVEST` is being enabled in prod by #436, so these lexicon additions change live behavior at deploy time. This is deliberate — part of the code-memory dogfood program.

## Tests

`test/state-verb-harvest.unit-spec.ts` grows 29 → 64, all green: one positive row per new verb, a held-out phrasing per verb group, guard/negation negatives for the new verbs, and the binding/clipping behaviour pins. Full unit suite, `pnpm typecheck` and `pnpm format:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
