### PR TITLE
fix(beliefs): supersede foldable-field orphan beliefs on promotion

### DIFF
--- a/src/admin/belief-field-fold.ts
+++ b/src/admin/belief-field-fold.ts
@@ -1,0 +1,226 @@
+import type { Logger } from '@nestjs/common';
+import { StringRecordId } from 'surrealdb';
+import type { BeliefDb, BeliefPromotionResult, FoldedBelief } from './belief-promotion.service';
+
+/**
+ * Belief field-fold machinery (#135 seam 2, SCENES_BELIEF_FIELD_FOLD):
+ * the deterministic lexical rule that decides when two free-text field
+ * names denote the same attribute (fieldsFold / resolveFieldFold — the
+ * incoming-name router the promotion fold calls BEFORE the group key is
+ * built), and the ORPHAN ABSORB sweep that retires beliefs already
+ * stored under a foldable VARIANT of a canonical field. Split out of
+ * belief-promotion.service.ts (the god-file ceiling); the service
+ * re-exports the public helpers, so the import surface is unchanged.
+ */
+
+const str = (v: unknown): string => (typeof v === 'string' ? v.trim() : '');
+
+/**
+ * Generic-modifier stoplist for the field-fold rule (#135 seam 2): the
+ * ONLY extra tokens a longer field name may carry and still fold onto a
+ * shorter one. Deliberately tiny and conservative — 'car ownership'
+ * folds onto 'car' (ownership is generic), 'car registration' does NOT
+ * (registration names a DIFFERENT attribute), and 'queue backend' does
+ * NOT fold onto 'queue' (backend is specific) — a known limitation we
+ * accept over the false-fold risk.
+ */
+export const FIELD_FOLD_GENERIC_TOKENS: ReadonlySet<string> = new Set([
+  'ownership',
+  'status',
+  'state',
+  'current',
+  'of',
+  'the',
+]);
+
+/** Normalize a free-text field name: lowercase, strip punctuation, tokenize. */
+function fieldTokens(field: string): Set<string> {
+  return new Set(
+    field
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+      .split(/\s+/)
+      .filter((t) => t !== ''),
+  );
+}
+
+/**
+ * Pure (#135 seam 2): may these two free-text field names denote the
+ * same attribute? True ONLY when one token SET is a subset of the other
+ * AND every extra token of the longer name is a generic modifier from
+ * FIELD_FOLD_GENERIC_TOKENS. Deterministic and lexical — NO embeddings,
+ * NO LLM, no stemming ('deploy' ≠ 'deployment' — accepted limitation).
+ */
+export function fieldsFold(a: string, b: string): boolean {
+  const ta = fieldTokens(a);
+  const tb = fieldTokens(b);
+  if (ta.size === 0 || tb.size === 0) return false;
+  const [small, large] = ta.size <= tb.size ? [ta, tb] : [tb, ta];
+  for (const t of small) if (!large.has(t)) return false;
+  for (const t of large) if (!small.has(t) && !FIELD_FOLD_GENERIC_TOKENS.has(t)) return false;
+  return true;
+}
+
+/**
+ * Pure (#135 seam 2): resolve an incoming field name against the known
+ * fields of the same (userId, subject). An exact string match short-
+ * circuits (already the canonical name); exactly ONE foldable candidate
+ * folds — the EXISTING name wins (stability); MORE than one is
+ * ambiguous — fold NOTHING, keep the incoming name (the caller warns
+ * loudly: skip loudly, never flip-flop).
+ */
+export function resolveFieldFold(
+  incoming: string,
+  knownFields: readonly string[],
+): { field: string; folded: boolean; ambiguous: boolean; candidates: string[] } {
+  const distinct = [...new Set(knownFields)];
+  if (distinct.includes(incoming)) {
+    return { field: incoming, folded: false, ambiguous: false, candidates: [] };
+  }
+  const candidates = distinct.filter((existing) => fieldsFold(incoming, existing));
+  if (candidates.length === 1) {
+    return { field: candidates[0]!, folded: true, ambiguous: false, candidates };
+  }
+  if (candidates.length > 1) {
+    return { field: incoming, folded: false, ambiguous: true, candidates };
+  }
+  return { field: incoming, folded: false, ambiguous: false, candidates: [] };
+}
+
+/** Active sibling row read by the orphan sweep (fold on only). */
+interface ActiveSiblingBeliefRow {
+  id: unknown;
+  field: unknown;
+  value: unknown;
+  priorValue?: unknown;
+  revision?: unknown;
+  validFrom?: unknown;
+}
+
+/**
+ * ORPHAN ABSORB (#135 seam 2 follow-up, SCENES_BELIEF_FIELD_FOLD —
+ * called ONLY with the flag on; off = zero extra queries, byte-
+ * identical). After a canonical (userId, subject, field) upsert,
+ * supersede ACTIVE beliefs of the same (userId, subject) whose field
+ * folds to the canonical one but is stored under a variant name —
+ * leftovers of earlier batches the incoming-name fold can never retire,
+ * which otherwise keep serving a stale value next to the canonical
+ * belief (the s08 field-drift eval).
+ *
+ * MARK, NEVER DELETE: serving and the read API only read
+ * status='active', the row keeps its provenance (sourceSceneIds), the
+ * scenes' consolidatedInto refs stay resolvable, and the GDPR cascades
+ * erase by userId regardless of status — so the supersede stamp is the
+ * minimal mechanism that stops serving (a DELETE would destroy the
+ * audit trail for no additional correctness). No contradicted_by /
+ * derived_from edges: absorption is key deduplication, not a value
+ * contradiction or derivation — supersededBy is the canonical trail.
+ *
+ * 3.2.4 PLANNER DISCIPLINE (the 0093/0120 idiom): the sweep is one
+ * plain SELECT (reads are safe — only DELETE/UPDATE WHERE over indexed
+ * fields hit the silent-no-op planner class) and every write is
+ * primary-key addressed (UPDATE $id) — immune by construction.
+ *
+ * DETERMINISTIC + IDEMPOTENT: the canonical belief always wins with its
+ * OWN value (an orphan's valid-time recency does not rescue it — naming
+ * canon beats recency, deterministically); an absorbed orphan's value
+ * contributes ONLY as priorValue and only when the canonical row has
+ * none. A superseded orphan leaves both the serving set and the fold-
+ * candidate set, so a re-run finds nothing to absorb and a re-coined
+ * variant name simply folds onto the canonical field — one-way
+ * convergence, never flip-flop. Fields in runGroupKeys (the CURRENT
+ * run's folded + conflict groups) are live attribute names and are
+ * never absorbed — parallel groups the fold deliberately kept must not
+ * be eaten by upsert order. Orphans spanning MORE than one distinct
+ * field are skipped loudly (the resolveFieldFold ambiguity doctrine:
+ * fieldsFold is not transitive, so merging both would equate fields the
+ * rule holds distinct).
+ */
+export async function absorbFoldableOrphans({
+  db,
+  belief,
+  runGroupKeys,
+  result,
+  logger,
+}: {
+  db: BeliefDb;
+  belief: FoldedBelief;
+  runGroupKeys: ReadonlySet<string>;
+  result: BeliefPromotionResult;
+  logger: Logger;
+}): Promise<void> {
+  const [rows] = await db.query<[ActiveSiblingBeliefRow[]]>(
+    `SELECT id, field, value, priorValue, revision, validFrom
+       FROM semantic_belief
+      WHERE userId = $u AND subject = $s AND status = 'active'`,
+    { u: belief.userId, s: belief.subject },
+  );
+  const actives = rows ?? [];
+  // The canonical head this group just upserted. Absent only in a
+  // pathological replay window (INSERT IGNORE collided with an already
+  // superseded id) — nothing to absorb INTO, so do nothing.
+  const canonical = actives.find((r) => str(r.field) === belief.field);
+  if (canonical === undefined) return;
+  const revisionOf = (r: ActiveSiblingBeliefRow): number =>
+    typeof r.revision === 'number' && Number.isFinite(r.revision) ? r.revision : 0;
+  const orphans = actives
+    .filter((r) => {
+      const variant = str(r.field);
+      return (
+        variant !== '' &&
+        variant !== belief.field &&
+        // Same-run groups are LIVE attribute names — never absorbed.
+        !runGroupKeys.has(`${belief.userId}\x00${belief.subject}\x00${variant}`) &&
+        fieldsFold(variant, belief.field)
+      );
+    })
+    // Chain head first (highest revision) — the priorValue donor; the
+    // id tiebreak keeps the order total for equal revisions.
+    .sort((a, b) => revisionOf(b) - revisionOf(a) || String(a.id).localeCompare(String(b.id)));
+  if (orphans.length === 0) return;
+
+  const orphanFields = [...new Set(orphans.map((r) => str(r.field)))].sort();
+  if (orphanFields.length > 1) {
+    result.fieldOrphanAmbiguous += 1;
+    logger.warn(
+      `belief promotion orphan-absorb ambiguity: (${belief.subject}, ${belief.field}) for ` +
+        `user ${belief.userId} has ${orphanFields.length} distinct foldable variant fields ` +
+        `[${orphanFields.join(' | ')}] — NOT absorbed (skip loudly, never flip-flop)`,
+    );
+    return;
+  }
+
+  const canonicalId = String(canonical.id);
+  for (const orphan of orphans) {
+    await db.query(
+      `UPDATE $id SET status = 'superseded', supersededBy = $winner,
+                      validUntil = $until, updatedAt = time::now()`,
+      {
+        id: new StringRecordId(String(orphan.id)),
+        winner: new StringRecordId(canonicalId),
+        until: canonical.validFrom,
+      },
+    );
+    result.fieldOrphansAbsorbed += 1;
+    logger.warn(
+      `belief promotion orphan absorb: belief (${belief.subject}, '${str(orphan.field)}') ` +
+        `revision ${revisionOf(orphan)} superseded into canonical field '${belief.field}' ` +
+        `for user ${belief.userId} — SCENES_BELIEF_FIELD_FOLD`,
+    );
+  }
+
+  // priorValue backfill — the ONLY way an orphan's value survives: when
+  // the canonical row has no prior of its own, the absorbed chain
+  // head's value becomes it (never when equal to the canonical value —
+  // a self-prior is meaningless). The statement is NOT rewritten (the
+  // 0120 doctrine: never in-place for value/statement).
+  if (str(canonical.priorValue) === '') {
+    const donorValue = str(orphans[0]!.value);
+    if (donorValue !== '' && donorValue !== str(canonical.value)) {
+      await db.query(`UPDATE $id SET priorValue = $prior, updatedAt = time::now()`, {
+        id: new StringRecordId(canonicalId),
+        prior: donorValue,
+      });
+    }
+  }
+}

--- a/src/admin/belief-promotion.service.ts
+++ b/src/admin/belief-promotion.service.ts
@@ -14,7 +14,12 @@ import {
 } from '../common/scene-flags';
 import { supportEdgesEnabled } from '../common/provenance-flags';
 import { buildSupportEdgeBatches } from '../common/support-edges';
+import { absorbFoldableOrphans, resolveFieldFold } from './belief-field-fold';
 import { SceneVersionService } from './scene-version';
+
+// The lexical fold rule lives in belief-field-fold.ts (god-file split);
+// re-exported here so the historical import surface is unchanged.
+export { FIELD_FOLD_GENERIC_TOKENS, fieldsFold, resolveFieldFold } from './belief-field-fold';
 
 /**
  * Belief promotion (Belief-A, SCENES_BELIEF_PROMOTION — default off):
@@ -56,6 +61,16 @@ import { SceneVersionService } from './scene-version';
  * BEFORE the group key is built, so negation + fold compose. The
  * EXISTING name wins (stability); more than one match folds NOTHING and
  * warns loudly (the skip-loudly, never-flip-flop doctrine).
+ *
+ * ORPHAN ABSORB (#135 seam 2 follow-up, same flag): the fold only
+ * routes INCOMING names — it cannot retire a belief already stored
+ * under a foldable VARIANT of the group's canonical field (an earlier
+ * batch's leftover), which keeps serving its stale value next to the
+ * canonical belief (the s08 field-drift eval: "Lisbon" kept answering
+ * after "Porto" won). After every canonical upsert such orphans are
+ * stamped superseded — the full doctrine (mark-never-DELETE rationale,
+ * priorValue backfill, same-run fence, ambiguity skip, idempotence)
+ * lives on absorbFoldableOrphans in belief-field-fold.ts.
  *
  * CONFLICT GUARD (built-in, no flag): a group whose latest timestamp is
  * shared by two DIFFERENT values has no deterministic winner — the whole
@@ -225,78 +240,6 @@ export interface BeliefFoldOptions {
 }
 
 const str = (v: unknown): string => (typeof v === 'string' ? v.trim() : '');
-
-/**
- * Generic-modifier stoplist for the field-fold rule (#135 seam 2): the
- * ONLY extra tokens a longer field name may carry and still fold onto a
- * shorter one. Deliberately tiny and conservative — 'car ownership'
- * folds onto 'car' (ownership is generic), 'car registration' does NOT
- * (registration names a DIFFERENT attribute), and 'queue backend' does
- * NOT fold onto 'queue' (backend is specific) — a known limitation we
- * accept over the false-fold risk.
- */
-export const FIELD_FOLD_GENERIC_TOKENS: ReadonlySet<string> = new Set([
-  'ownership',
-  'status',
-  'state',
-  'current',
-  'of',
-  'the',
-]);
-
-/** Normalize a free-text field name: lowercase, strip punctuation, tokenize. */
-function fieldTokens(field: string): Set<string> {
-  return new Set(
-    field
-      .toLowerCase()
-      .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
-      .split(/\s+/)
-      .filter((t) => t !== ''),
-  );
-}
-
-/**
- * Pure (#135 seam 2): may these two free-text field names denote the
- * same attribute? True ONLY when one token SET is a subset of the other
- * AND every extra token of the longer name is a generic modifier from
- * FIELD_FOLD_GENERIC_TOKENS. Deterministic and lexical — NO embeddings,
- * NO LLM, no stemming ('deploy' ≠ 'deployment' — accepted limitation).
- */
-export function fieldsFold(a: string, b: string): boolean {
-  const ta = fieldTokens(a);
-  const tb = fieldTokens(b);
-  if (ta.size === 0 || tb.size === 0) return false;
-  const [small, large] = ta.size <= tb.size ? [ta, tb] : [tb, ta];
-  for (const t of small) if (!large.has(t)) return false;
-  for (const t of large) if (!small.has(t) && !FIELD_FOLD_GENERIC_TOKENS.has(t)) return false;
-  return true;
-}
-
-/**
- * Pure (#135 seam 2): resolve an incoming field name against the known
- * fields of the same (userId, subject). An exact string match short-
- * circuits (already the canonical name); exactly ONE foldable candidate
- * folds — the EXISTING name wins (stability); MORE than one is
- * ambiguous — fold NOTHING, keep the incoming name (the caller warns
- * loudly: skip loudly, never flip-flop).
- */
-export function resolveFieldFold(
-  incoming: string,
-  knownFields: readonly string[],
-): { field: string; folded: boolean; ambiguous: boolean; candidates: string[] } {
-  const distinct = [...new Set(knownFields)];
-  if (distinct.includes(incoming)) {
-    return { field: incoming, folded: false, ambiguous: false, candidates: [] };
-  }
-  const candidates = distinct.filter((existing) => fieldsFold(incoming, existing));
-  if (candidates.length === 1) {
-    return { field: candidates[0]!, folded: true, ambiguous: false, candidates };
-  }
-  if (candidates.length > 1) {
-    return { field: incoming, folded: false, ambiguous: true, candidates };
-  }
-  return { field: incoming, folded: false, ambiguous: false, candidates: [] };
-}
 
 /**
  * Pure: a delta's landing value, or null when it holds nothing
@@ -600,6 +543,10 @@ export interface BeliefPromotionResult {
   fieldFolds: number;
   /** Field names left UNfolded because >1 existing field matched. */
   fieldFoldAmbiguous: number;
+  /** Foldable-variant orphan beliefs superseded into the canonical one. */
+  fieldOrphansAbsorbed: number;
+  /** Orphan sweeps skipped: >1 distinct foldable field (never merged). */
+  fieldOrphanAmbiguous: number;
   /** Groups below the SCENES_BELIEF_MIN_SCENES conversation floor. */
   skippedFloor: number;
   /** Groups whose winner was not newer than the active belief (stale). */
@@ -621,7 +568,7 @@ interface ActiveBeliefRow {
   conversationIds?: unknown;
 }
 
-interface BeliefDb {
+export interface BeliefDb {
   query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T>;
 }
 
@@ -668,6 +615,8 @@ export class BeliefPromotionService {
       skippedConflict: 0,
       fieldFolds: 0,
       fieldFoldAmbiguous: 0,
+      fieldOrphansAbsorbed: 0,
+      fieldOrphanAmbiguous: 0,
       skippedFloor: 0,
       skippedStale: 0,
       beliefsCreated: 0,
@@ -772,6 +721,15 @@ export class BeliefPromotionService {
         );
       }
 
+      // ORPHAN ABSORB fence: every (userId, subject, field) the CURRENT
+      // run still folds to — including conflict-skipped groups — is a
+      // live attribute name; the sweep must never eat a parallel group
+      // the fold deliberately kept (upsert order would otherwise decide
+      // which sibling survives).
+      const runGroupKeys = new Set<string>(
+        [...folded, ...conflicts].map((g) => `${g.userId}\x00${g.subject}\x00${g.field}`),
+      );
+
       for (const belief of folded) {
         if (floor > 0 && belief.conversationIds.length < floor) {
           result.skippedFloor += 1;
@@ -782,6 +740,9 @@ export class BeliefPromotionService {
           continue;
         }
         await this.upsertBelief({ db, belief, promoterVersion, edgesOn, result });
+        if (fieldFoldOn) {
+          await absorbFoldableOrphans({ db, belief, runGroupKeys, result, logger: this.logger });
+        }
       }
     });
     this.logger.log(
@@ -790,6 +751,8 @@ export class BeliefPromotionService {
         `over ${result.eligibleScenes}/${result.scenes} scene(s) ` +
         `(mixedUser=${result.skippedMixedUser} conflict=${result.skippedConflict} ` +
         `fieldFolds=${result.fieldFolds} foldAmbiguous=${result.fieldFoldAmbiguous} ` +
+        `orphansAbsorbed=${result.fieldOrphansAbsorbed} ` +
+        `orphanAmbiguous=${result.fieldOrphanAmbiguous} ` +
         `floor=${result.skippedFloor} stale=${result.skippedStale} edges=${result.supportEdges})`,
     );
     return result;

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -778,7 +778,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: true,
     isBooleanFlag: true,
     description:
-      'Belief promotion field fold (#135 seam 2): deterministically fold an enricher-re-coined field name onto an existing one for the same (userId, subject) — token-set subset whose extra tokens are all generic modifiers (ownership/status/state/current/of/the); the EXISTING name wins, and more than one match folds nothing and warns loudly (skip loudly, never flip-flop). NO embeddings, NO LLM. Off = exact-string (subject, field) grouping and zero extra queries — byte-identical fold output.',
+      'Belief promotion field fold (#135 seam 2): deterministically fold an enricher-re-coined field name onto an existing one for the same (userId, subject) — token-set subset whose extra tokens are all generic modifiers (ownership/status/state/current/of/the); the EXISTING name wins, and more than one match folds nothing and warns loudly (skip loudly, never flip-flop). NO embeddings, NO LLM. Also absorbs orphans: after each canonical upsert, ACTIVE beliefs of the same (userId, subject) stored under a foldable VARIANT of the canonical field (earlier-batch leftovers the incoming-name fold can never retire) are stamped superseded so they stop serving stale values; the canonical belief keeps its own value, the orphan value backfills priorValue only when the canonical has none, and more than one distinct variant field skips loudly. Off = exact-string (subject, field) grouping and zero extra queries — byte-identical fold output.',
   },
   {
     key: 'SCENES_EVIDENCE_LINKS',

--- a/test/belief-promotion.unit-spec.ts
+++ b/test/belief-promotion.unit-spec.ts
@@ -441,6 +441,384 @@ describe('foldBeliefGroups: field fold (#135 seam 2)', () => {
   });
 });
 
+describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', () => {
+  /** One semantic_belief row as the fake store holds it. */
+  interface FakeBeliefRow {
+    id: string;
+    userId: string;
+    subject: string;
+    field: string;
+    value: string;
+    priorValue?: string;
+    revision: number;
+    status: string;
+    supersededBy?: string;
+    validFrom: unknown;
+    validUntil?: unknown;
+    sourceSceneIds: string[];
+    conversationIds: string[];
+  }
+
+  /**
+   * Minimal stateful SurrealDB double for the promotion pass: routes the
+   * service's exact SQL shapes onto an in-memory semantic_belief store
+   * (scene stamps are no-ops — pinned by their own e2e). Stateful on
+   * purpose: the idempotency test re-runs the SAME world.
+   */
+  class FakeBeliefDb {
+    rows: FakeBeliefRow[] = [];
+    sceneHeads: PromotableSceneHead[] = [];
+    sql: string[] = [];
+
+    async query(sqlText: string, params: Record<string, unknown> = {}): Promise<unknown> {
+      this.sql.push(sqlText);
+      const p = params;
+      if (sqlText.includes('FROM memory_episode') && sqlText.includes('stateDeltas')) {
+        return [this.sceneHeads];
+      }
+      if (sqlText.includes('SELECT userId, subject, field FROM semantic_belief')) {
+        return [
+          this.rows
+            .filter((r) => r.status === 'active' && (p.userIds as string[]).includes(r.userId))
+            .map(({ userId, subject, field }) => ({ userId, subject, field })),
+        ];
+      }
+      if (sqlText.includes('field = $f')) {
+        return [
+          this.rows
+            .filter(
+              (r) =>
+                r.status === 'active' && r.userId === p.u && r.subject === p.s && r.field === p.f,
+            )
+            .sort((a, b) => b.revision - a.revision)
+            .map((r) => ({ ...r })),
+        ];
+      }
+      if (sqlText.includes('SELECT id, field, value, priorValue, revision, validFrom')) {
+        return [
+          this.rows
+            .filter((r) => r.status === 'active' && r.userId === p.u && r.subject === p.s)
+            .map((r) => ({ ...r })),
+        ];
+      }
+      if (sqlText.startsWith('INSERT IGNORE INTO semantic_belief')) {
+        for (const raw of p.rows as Array<Record<string, unknown>>) {
+          const id = String(raw.id);
+          if (this.rows.some((r) => r.id === id)) continue;
+          this.rows.push({
+            id,
+            userId: String(raw.userId),
+            subject: String(raw.subject),
+            field: String(raw.field),
+            value: String(raw.value),
+            ...(raw.priorValue !== undefined ? { priorValue: String(raw.priorValue) } : {}),
+            revision: raw.revision as number,
+            status: String(raw.status),
+            validFrom: raw.validFrom,
+            sourceSceneIds: (raw.sourceSceneIds as unknown[]).map(String),
+            conversationIds: [...(raw.conversationIds as string[])],
+          });
+        }
+        return [];
+      }
+      if (sqlText.includes(`SET status = 'superseded'`)) {
+        const row = this.byId(String(p.id));
+        row.status = 'superseded';
+        row.supersededBy = String(p.winner ?? p.new);
+        row.validUntil = p.until;
+        return [];
+      }
+      if (sqlText.includes('SET priorValue = $prior')) {
+        this.byId(String(p.id)).priorValue = String(p.prior);
+        return [];
+      }
+      if (sqlText.includes('SET sourceSceneIds')) {
+        const row = this.byId(String(p.id));
+        row.sourceSceneIds = (p.scenes as unknown[]).map(String);
+        row.conversationIds = [...(p.convs as string[])];
+        return [];
+      }
+      if (sqlText.includes('UPDATE memory_episode')) return [];
+      throw new Error(`FakeBeliefDb: unhandled SQL: ${sqlText}`);
+    }
+
+    private byId(id: string): FakeBeliefRow {
+      const row = this.rows.find((r) => r.id === id);
+      if (row === undefined) throw new Error(`FakeBeliefDb: no row ${id}`);
+      return row;
+    }
+
+    active(field: string, subject = 'Sasha', userId = 'u1'): FakeBeliefRow | undefined {
+      return this.rows.find(
+        (r) =>
+          r.status === 'active' &&
+          r.userId === userId &&
+          r.subject === subject &&
+          r.field === field,
+      );
+    }
+  }
+
+  function makeRunService(db: FakeBeliefDb): BeliefPromotionService {
+    const surreal = {
+      withCompany: async <T>(_c: string, fn: (d: unknown) => Promise<T>) => fn(db),
+    } as unknown as SurrealService;
+    const versions = {
+      resolve: () => ({ version: 'scene-segmenter-v1' }),
+    } as unknown as SceneVersionService;
+    const config = { get: (_key: string, def?: string) => def } as unknown as ConfigService;
+    return new BeliefPromotionService(surreal, config, versions);
+  }
+
+  /** The s08 measured end-state: canonical + foldable-variant orphan. */
+  const belief = (over: Partial<FakeBeliefRow> & { id: string; field: string }): FakeBeliefRow => ({
+    userId: 'u1',
+    subject: 'Sasha',
+    value: 'Lisbon',
+    revision: 1,
+    status: 'active',
+    validFrom: '2026-08-03T19:00:00.000Z',
+    sourceSceneIds: ['memory_episode:sa'],
+    conversationIds: ['conv:a'],
+    ...over,
+  });
+
+  const canonicalRow = (over: Partial<FakeBeliefRow> = {}): FakeBeliefRow =>
+    belief({
+      id: 'semantic_belief:canon1',
+      field: 'location',
+      value: 'Porto',
+      priorValue: 'Lisbon',
+      validFrom: '2026-08-18T19:00:00.000Z',
+      sourceSceneIds: ['memory_episode:sb'],
+      conversationIds: ['conv:b'],
+      ...over,
+    });
+
+  const orphanRow = (over: Partial<FakeBeliefRow> = {}): FakeBeliefRow =>
+    belief({ id: 'semantic_belief:orphan1', field: 'current location', ...over });
+
+  /** Re-promotion of the canonical scene (the repair-on-next-run shape). */
+  const canonicalScene = (): PromotableSceneHead =>
+    scene({
+      id: 'memory_episode:sb',
+      conversationIds: ['conv:b'],
+      occurredTo: '2026-08-18T19:00:00.000Z',
+      stateDeltas: [{ subject: 'Sasha', field: 'location', from: 'Lisbon', to: 'Porto' }],
+    });
+
+  const saved: Record<string, string | undefined> = {};
+  const KEYS = [
+    'SCENES_BELIEF_PROMOTION',
+    'SCENES_BELIEF_FIELD_FOLD',
+    'SCENES_BELIEF_NEGATION_DELTAS',
+    'SCENES_BELIEF_LLM_SYNTHESIS',
+    'SCENES_BELIEF_MIN_SCENES',
+    'PROVENANCE_SUPPORT_EDGES',
+  ];
+  beforeEach(() => {
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.SCENES_BELIEF_PROMOTION = '1';
+    process.env.SCENES_BELIEF_FIELD_FOLD = '1';
+  });
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('absorbs a foldable-variant orphan: superseded into the canonical belief, which keeps its own value', async () => {
+    const db = new FakeBeliefDb();
+    db.rows = [canonicalRow(), orphanRow()];
+    db.sceneHeads = [canonicalScene()];
+
+    const res = await makeRunService(db).run('co_test');
+    expect(res.fieldOrphansAbsorbed).toBe(1);
+    expect(res.fieldOrphanAmbiguous).toBe(0);
+
+    const orphan = db.rows.find((r) => r.id === 'semantic_belief:orphan1')!;
+    expect(orphan.status).toBe('superseded');
+    expect(orphan.supersededBy).toBe('semantic_belief:canon1');
+    expect(orphan.validUntil).toBe('2026-08-18T19:00:00.000Z'); // canonical validFrom
+    expect(orphan.value).toBe('Lisbon'); // value untouched — mark, never rewrite
+
+    const canonical = db.rows.find((r) => r.id === 'semantic_belief:canon1')!;
+    expect(canonical).toMatchObject({
+      status: 'active',
+      field: 'location',
+      value: 'Porto', // the canonical belief wins with its OWN value
+      priorValue: 'Lisbon',
+      revision: 1,
+    });
+    // The orphan can no longer serve: no active row under the variant name.
+    expect(db.active('current location')).toBeUndefined();
+    // priorValue already present — the backfill UPDATE never fires.
+    expect(db.sql.some((s) => s.includes('SET priorValue'))).toBe(false);
+  });
+
+  it('backfills priorValue from the absorbed orphan ONLY when the canonical belief has none', async () => {
+    const db = new FakeBeliefDb();
+    const canonical = canonicalRow();
+    delete canonical.priorValue;
+    db.rows = [canonical, orphanRow()];
+    db.sceneHeads = [
+      scene({
+        id: 'memory_episode:sb',
+        conversationIds: ['conv:b'],
+        occurredTo: '2026-08-18T19:00:00.000Z',
+        // No `from` on the delta — the canonical belief lands prior-less.
+        stateDeltas: [{ subject: 'Sasha', field: 'location', from: '', to: 'Porto' }],
+      }),
+    ];
+
+    const res = await makeRunService(db).run('co_test');
+    expect(res.fieldOrphansAbsorbed).toBe(1);
+    expect(db.rows.find((r) => r.id === 'semantic_belief:canon1')).toMatchObject({
+      value: 'Porto', // own value always wins…
+      priorValue: 'Lisbon', // …the orphan contributes ONLY the prior
+      status: 'active',
+    });
+  });
+
+  it('no backfill when the orphan value equals the canonical value (a self-prior is meaningless)', async () => {
+    const db = new FakeBeliefDb();
+    const canonical = canonicalRow();
+    delete canonical.priorValue;
+    db.rows = [canonical, orphanRow({ value: 'Porto' })];
+    db.sceneHeads = [canonicalScene()];
+
+    const res = await makeRunService(db).run('co_test');
+    expect(res.fieldOrphansAbsorbed).toBe(1);
+    const head = db.rows.find((r) => r.id === 'semantic_belief:canon1')!;
+    expect(head.priorValue).toBeUndefined();
+    expect(db.sql.some((s) => s.includes('SET priorValue'))).toBe(false);
+  });
+
+  it('re-run is idempotent: the absorbed orphan stays superseded and nothing flip-flops', async () => {
+    const db = new FakeBeliefDb();
+    db.rows = [canonicalRow(), orphanRow()];
+    db.sceneHeads = [canonicalScene()];
+    const svc = makeRunService(db);
+
+    const first = await svc.run('co_test');
+    expect(first.fieldOrphansAbsorbed).toBe(1);
+    const after = JSON.parse(JSON.stringify(db.rows)) as FakeBeliefRow[];
+
+    const second = await svc.run('co_test');
+    expect(second.fieldOrphansAbsorbed).toBe(0);
+    expect(second.fieldOrphanAmbiguous).toBe(0);
+    expect(second).toMatchObject({ beliefsCreated: 0, beliefsRevised: 0 });
+    expect(db.rows).toEqual(after); // byte-identical world — converged
+  });
+
+  it('never absorbs across a different subject or a different user', async () => {
+    const db = new FakeBeliefDb();
+    db.rows = [
+      canonicalRow(),
+      orphanRow(),
+      belief({ id: 'semantic_belief:boris1', field: 'current location', subject: 'Boris' }),
+      belief({ id: 'semantic_belief:u2row1', field: 'current location', userId: 'u2' }),
+    ];
+    db.sceneHeads = [canonicalScene()];
+
+    const res = await makeRunService(db).run('co_test');
+    expect(res.fieldOrphansAbsorbed).toBe(1); // ONLY (u1, Sasha)'s variant
+    expect(db.active('current location', 'Boris')).toBeDefined();
+    expect(db.active('current location', 'Sasha', 'u2')).toBeDefined();
+  });
+
+  it('flag off: no sweep query, the orphan keeps serving, counters stay zero (byte-identical)', async () => {
+    delete process.env.SCENES_BELIEF_FIELD_FOLD;
+    const db = new FakeBeliefDb();
+    db.rows = [canonicalRow(), orphanRow()];
+    db.sceneHeads = [canonicalScene()];
+
+    const res = await makeRunService(db).run('co_test');
+    expect(res.fieldOrphansAbsorbed).toBe(0);
+    expect(res.fieldOrphanAmbiguous).toBe(0);
+    expect(db.active('current location')).toBeDefined(); // untouched
+    // Zero fold/sweep queries — the historical query set exactly.
+    expect(db.sql.some((s) => s.includes('SELECT userId, subject, field'))).toBe(false);
+    expect(db.sql.some((s) => s.includes('priorValue, revision, validFrom'))).toBe(false);
+  });
+
+  it('ambiguity guard: two distinct foldable variant fields absorb NOTHING, loudly', async () => {
+    const db = new FakeBeliefDb();
+    db.rows = [
+      belief({
+        id: 'semantic_belief:own1',
+        subject: 'Mikhail',
+        field: 'car ownership',
+        value: 'Jeep',
+      }),
+      belief({
+        id: 'semantic_belief:stat1',
+        subject: 'Mikhail',
+        field: 'car status',
+        value: 'broken',
+      }),
+    ];
+    db.sceneHeads = [
+      scene({
+        id: 'memory_episode:sc',
+        conversationIds: ['conv:c'],
+        occurredTo: '2026-08-20T10:00:00.000Z',
+        stateDeltas: [{ subject: 'Mikhail', field: 'car', from: '', to: 'BMW' }],
+      }),
+    ];
+
+    const res = await makeRunService(db).run('co_test');
+    // Fold-time ambiguity kept the incoming name as a parallel group…
+    expect(res.fieldFoldAmbiguous).toBe(1);
+    expect(res.beliefsCreated).toBe(1);
+    // …and the sweep refuses to merge fields the rule holds distinct.
+    expect(res.fieldOrphanAmbiguous).toBe(1);
+    expect(res.fieldOrphansAbsorbed).toBe(0);
+    expect(db.active('car ownership', 'Mikhail')).toBeDefined();
+    expect(db.active('car status', 'Mikhail')).toBeDefined();
+    expect(db.active('car', 'Mikhail')).toMatchObject({ value: 'BMW' });
+  });
+
+  it('same-run parallel groups never eat each other (the run-group fence)', async () => {
+    const db = new FakeBeliefDb();
+    db.rows = [
+      belief({ id: 'semantic_belief:car1', subject: 'Mikhail', field: 'car', value: 'BMW' }),
+      belief({
+        id: 'semantic_belief:own1',
+        subject: 'Mikhail',
+        field: 'car ownership',
+        value: 'Jeep',
+      }),
+    ];
+    db.sceneHeads = [
+      scene({
+        id: 'memory_episode:sc1',
+        conversationIds: ['conv:c'],
+        occurredTo: '2026-08-20T10:00:00.000Z',
+        stateDeltas: [{ subject: 'Mikhail', field: 'car', from: '', to: 'BMW' }],
+      }),
+      scene({
+        id: 'memory_episode:sc2',
+        conversationIds: ['conv:d'],
+        occurredTo: '2026-08-20T11:00:00.000Z',
+        stateDeltas: [{ subject: 'Mikhail', field: 'car ownership', from: '', to: 'Jeep' }],
+      }),
+    ];
+
+    const res = await makeRunService(db).run('co_test');
+    // Both incoming names exact-match their existing chains: two live
+    // groups this run — each is fenced from the other's sweep.
+    expect(res.fieldOrphansAbsorbed).toBe(0);
+    expect(res.fieldOrphanAmbiguous).toBe(0);
+    expect(db.active('car', 'Mikhail')).toBeDefined();
+    expect(db.active('car ownership', 'Mikhail')).toBeDefined();
+  });
+});
+
 describe('deterministic helpers', () => {
   it('renderBeliefStatement: template with and without a prior value', () => {
     expect(
@@ -611,6 +989,8 @@ describe('OFF-state hard guarantee (byte-identical prod)', () => {
       skippedConflict: 0,
       fieldFolds: 0,
       fieldFoldAmbiguous: 0,
+      fieldOrphansAbsorbed: 0,
+      fieldOrphanAmbiguous: 0,
       skippedFloor: 0,
       skippedStale: 0,
       beliefsCreated: 0,


### PR DESCRIPTION
## The bug (measured, live)

The state-transition eval battery (`test/eval/state-transitions/`, scenario **s08 field-drift**) with `SCENES_BELIEF_FIELD_FOLD=1`:

- **s08-belief PASSES**: the fold correctly produced the canonical belief `(Sasha, location) value="Porto" prior="Lisbon" rev=1`.
- **s08-serve FAILS**: serving answered *"Sasha's home city is Lisbon [semantic_belief:…]"* — from an **older belief of the same (userId, subject) stored under an unfolded foldable variant of the canonical field** (created by an earlier promotion batch, before the newer batch folded onto the canonical name).

Root cause: the field fold (`resolveFieldFold`, called from `foldDeltaField` in `src/admin/belief-promotion.service.ts`) only routes **incoming** delta field names onto existing ones. It has no mechanism to retire a belief row that already sits on a foldable variant of the canonical field — pre-flag parallels, or an ambiguity-kept name that later batches folded past. That orphan stays `status='active'`, and both the serving lane (`belief-lane.service.ts` — `status = 'active'` only) and `GET /v1/beliefs` (default `status=active`) keep serving its stale value next to the canonical belief.

## The fix

New `absorbFoldableOrphans` (`src/admin/belief-field-fold.ts`), called after every canonical `(userId, subject, field)` upsert — **only when `SCENES_BELIEF_FIELD_FOLD` is on**:

- Finds ACTIVE beliefs of the same `(userId, subject)` whose field `fieldsFold`s to the canonical field but differs from it, and stamps them `status='superseded'` + `supersededBy` + `validUntil` (= canonical `validFrom`).
- **Mark, never DELETE** — the minimal correct mechanism: serving and the read API only read `status='active'`, so the stamp fully stops serving; the row keeps its provenance (`sourceSceneIds`), scenes' `consolidatedInto` refs stay resolvable, and the GDPR cascades already erase by `userId` regardless of status.
- **The canonical belief wins with its own value**; an absorbed orphan's value contributes **only** as `priorValue`, and only when the canonical row has none (never as a self-prior).
- **Same-run fence**: fields that are folded or conflict groups of the current run are live attribute names — never absorbed, so parallel groups the fold deliberately kept cannot be eaten by upsert order.
- **Ambiguity guard**: more than one distinct foldable variant field absorbs nothing, loudly (`fieldsFold` is not transitive — merging both would equate fields the rule holds distinct). Mirrors the `resolveFieldFold` doctrine.
- **Deterministic + idempotent**: a superseded orphan leaves both the serving set and the fold-candidate set (`existingFields` reads active rows only), so re-runs converge one-way — never flip-flop; a later re-coined variant name simply folds onto the canonical field.
- **SurrealDB 3.2.4 planner discipline** (the 0093/0120 idiom): the sweep is one plain SELECT (reads are safe) and every write is primary-key addressed (`UPDATE $id`) — immune by construction to the compound-index `DELETE/UPDATE WHERE` silent-zero-rows planner class.
- **No migration**: 0120 already carries the supersede vocabulary (`status`/`supersededBy`/`validUntil`).
- **Flag off = byte-identical**: zero extra queries, new counters stay 0.

House-rules split: the file was at the 800-code-line ESLint ceiling, so the lexical fold rule (`FIELD_FOLD_GENERIC_TOKENS` / `fieldsFold` / `resolveFieldFold`) moved to `belief-field-fold.ts` together with the sweep; `belief-promotion.service.ts` re-exports them, keeping the import surface unchanged. New observability counters `fieldOrphansAbsorbed` / `fieldOrphanAmbiguous` ride `BeliefPromotionResult` and the pass log line; the `SCENES_BELIEF_FIELD_FOLD` config-catalog description documents the behavior.

On the live stand the next beliefs build heals the measured s08 orphan (canonical group corroborates as a no-op, the variant row is absorbed) — s08-serve then answers "Porto".

## Tests

`test/belief-promotion.unit-spec.ts` — new run()-level battery over a stateful SurrealDB fake (52 tests total in the suite):

- orphan absorbed when fold is on: superseded into the canonical belief, which keeps its own value; no active row remains under the variant name
- `priorValue` backfill only when the canonical belief lacks one
- no backfill when the orphan value equals the canonical value
- idempotent re-run: zero absorbs the second time, byte-identical world
- no supersede across different subjects or users
- flag off: no sweep/fold queries, orphan untouched, counters zero
- ambiguity guard: two distinct foldable variants absorb nothing, loudly
- same-run parallel groups never eat each other (run-group fence)

Local verification: `pnpm typecheck` ✓, `pnpm lint:ci` ✓, `pnpm format:check` ✓, full unit suite ✓ (349 suites, 3795 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB