### PR TITLE
feat(deploy): enable answer conditioning in prod — broad-question coverage

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -307,6 +307,14 @@ jobs:
           # battery 4/12 -> 8/12 scenarios, checks 84%; held-out
           # adversarial set 18/18; unit 29/29 incl. holder binding) ──
           EXTRACTOR_STATE_VERB_HARVEST=1
+          # ── Answer conditioning (V13 G2 shape instructions; existing
+          # flag, was never enabled — the aggregation shape's coverage
+          # instruction fixes broad-question domain dropout. Measured on
+          # the stand 2026-09-06, flag-off vs flag-on: domain-packs
+          # battery 14/15 -> 15/15, state-transitions 8/12 -> 10/12
+          # scenarios (checks 84% -> 92%), memory-fitness 27/30 ->
+          # 28/30; pointed-question isolation checks unaffected) ──
+          RETRIEVAL_ANSWER_CONDITIONING=1
           EOF
           # The heredoc carries the YAML block's 10-space indent into the
           # file; strip it so every line is a clean KEY=value / #comment


### PR DESCRIPTION
## What

Adds `RETRIEVAL_ANSWER_CONDITIONING=1` to the prod enablement set. The flag (V13 G2 per-shape answer conditioning: chained evidence-first reasoning for why/how shapes, exhaustive facet coverage for aggregation shapes, exact-token verbatim for quote shapes) has existed since the SOTA-gap wave but was never enabled in any environment or genre preset.

## Why

The domain-pack battery's only failure (c12-serve-cross) was diagnosed on the live stand: for "Tell me about Meridian Clinic" **all** facts of both domain groups reached the generator prompt (22 facts < 48 budget, conformal guardrail kept all), but the bare "concise answer" instruction made the model drop the lower-similarity domain group entirely. The `aggregation` answer shape's detector already matches this query verbatim and its coverage instruction is exactly the counterfactual that fixed it.

## Measured (dogfood stand, flag-off vs flag-on, strict guardrails)

| battery | off | on |
|---|---|---|
| domain-packs | 14/15 | **15/15** |
| state-transitions | 8/12 scenarios (checks 84%) | **10/12 (92%)** — s02 replace + s08 field-drift flipped |
| memory-fitness | 27/30 | **28/30** |

Pointed-question isolation checks (c13/c14) unaffected. No code changes — deploy-workflow enablement only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB