### PR TITLE
feat(beliefs): wire BELIEFS_FACT_DAMPING — demote fact lines contradicted by current beliefs

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -190,7 +190,7 @@ The first serving path over `semantic_belief`: an extra evidence lane in
 |---|---|---|
 | `BELIEFS_SERVING_LANE` | `0` | Serve beliefs in synthesize: BM25 over `semantic_belief.statement` (0126), top-3, rendered into the evidence set; the generator may cite them via `citedBeliefIds`, which resolve through the rendered-set fence into belief-arm `evidenceCitations` (`beliefId` + rendered excerpt). Fail-closed single-user scope: no `userId` → no query, `active` + visibility re-check per belief. |
 | `BELIEFS_LANE_DATE_DISAMBIGUATION` | `0` | Render belief lines as `belief current since <day>` instead of `as of <day>` — a belief line's date is the belief REVISION's `validFrom`, not the event date. ONE render site, so generator, verifier, and fragment-zoom re-verify read identical lines. No-op without the serving lane. |
-| `BELIEFS_FACT_DAMPING` | `0` | Declared in the catalog but not read by any code path yet; boot validation warns when it is set without the serving lane. |
+| `BELIEFS_FACT_DAMPING` | `0` | Suffix (`(superseded by current belief: <field> = <value>)`) and stably demote fact lines that a lane-matched CURRENT belief contradicts — same (subject, field) key as the fact's (canonicalName, predicate) after trim/case normalization, different value; equal values and belief lines untouched. ONE computation feeds generator, verifier, and fragment-zoom re-verify; outcomes on `brain_belief_damping_total`. No-op without the serving lane's matched beliefs (boot validation warns on the inconsistent pair). |
 
 ### `FOVEA_*` — focus calibration + serving integrity
 

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -2301,7 +2301,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: true,
     isBooleanFlag: true,
     description:
-      'Belief-aware fact damping (PR-B; the resolver ships with the lane, the damping pass lands in the follow-up PR — until then NOTHING reads this flag): prompt-side suffix + stable demotion of fact lines that a matched current belief contradicts, applied to the SAME lines generator and verifier read. Requires BELIEFS_SERVING_LANE (a no-op without the lane’s matched beliefs — boot validation warns on the inconsistent pair). Off (default) → byte-identical.',
+      'Belief-aware fact damping (PR-B, the serving-lane companion pass): after the update-story/grounding-quote suffix maps, the prompt-side pass suffixes " (superseded by current belief: <field> = <value>)" onto — and STABLY demotes below the non-contradicted lines (a stable partition, never a re-sort) — every fact line that a lane-matched CURRENT belief contradicts: same free-text (subject, field) key as the fact’s (canonicalName, predicate) after trim/case normalization with a DIFFERENT normalized value (equal value ⇒ untouched; conservative exact matching, never fuzzy; belief lines themselves untouched). ONE canonical computation feeds the generator, the verifier and the fragment-zoom re-verify (three-consumer parity by construction); the V13 refine round re-applies the pass to its refined evidence against the same matched beliefs. Outcomes land on brain_belief_damping_total{outcome}. Requires BELIEFS_SERVING_LANE (a no-op without the lane’s matched beliefs — boot validation warns on the inconsistent pair). Off (default) → byte-identical.',
   },
   {
     key: 'BELIEFS_LANE_DATE_DISAMBIGUATION',

--- a/src/common/beliefs-flags.ts
+++ b/src/common/beliefs-flags.ts
@@ -27,17 +27,25 @@ export function beliefServingLaneEnabled(): boolean {
 }
 
 /**
- * Belief-aware fact damping — BELIEFS_FACT_DAMPING (PR-B; resolver stub
- * shipped with the lane so the config catalog, boot validation and the
- * inconsistent-pair WARN cover the family from day one).
+ * Belief-aware fact damping — BELIEFS_FACT_DAMPING (PR-B; the serving
+ * lane's companion pass, belief-damping.ts).
  *
  * When on (AND the serving lane is on — a no-op without the lane's
  * matched beliefs; env-validation warns on the inconsistent pair), the
- * prompt-side damping pass suffixes and demotes fact lines that a
- * matched current belief contradicts. NOTHING reads this resolver yet:
- * the damping module lands in the follow-up PR. Read at call time
- * (runtime-mutable); common layer per engine-gates S5.2. Default off ⇒
- * byte-identical.
+ * prompt-side damping pass suffixes (` (superseded by current belief:
+ * <field> = <value>)`) and stably demotes fact lines that a matched
+ * current belief contradicts: same free-text (subject, field) key as
+ * the fact's (canonicalName, predicate) after trim/case normalization,
+ * DIFFERENT normalized value (equal value ⇒ untouched; never fuzzy).
+ * Applied at the ONE canonical promptFactLines computation — round 1
+ * and the V13 refine round — so the generator, the verifier and the
+ * fragment-zoom re-verify read the SAME damped lines (three-consumer
+ * parity by construction; the BELIEFS_LANE_DATE_DISAMBIGUATION
+ * pattern). Belief lines themselves are untouched. Resolved ONCE per
+ * request by the orchestrator beside beliefServingLaneEnabled() (the
+ * single-resolution idiom); outcomes land on
+ * brain_belief_damping_total. Read at call time (runtime-mutable);
+ * common layer per engine-gates S5.2. Default off ⇒ byte-identical.
  */
 export function beliefFactDampingEnabled(): boolean {
   return envFlagEnabled(process.env.BELIEFS_FACT_DAMPING);

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -703,9 +703,11 @@ const KNOWN_BOOLEAN_FLAGS = [
   // as a current-state prompt section + belief-arm citations (0126;
   // repeals the 0120 shadow doctrine behind this default-off flag).
   'BELIEFS_SERVING_LANE',
-  // Belief-aware fact damping (PR-B — the resolver stub ships with the
-  // lane; nothing reads it until the damping pass lands). Requires
-  // BELIEFS_SERVING_LANE (inconsistent-pair WARN below).
+  // Belief-aware fact damping (PR-B, belief-damping.ts): suffix +
+  // stable demotion of fact lines a lane-matched current belief
+  // contradicts, applied at the one canonical promptFactLines
+  // computation. Requires BELIEFS_SERVING_LANE (inconsistent-pair WARN
+  // below).
   'BELIEFS_FACT_DAMPING',
   // Belief-lane date disambiguation (memory-fitness D4): the lane
   // renders ", belief current since <day>" instead of ", as of <day>"

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -302,6 +302,24 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // BELIEFS_FACT_DAMPING: what the prompt-side damping pass did per
+  // evaluation (belief-damping.ts — the beliefCitationCount sibling):
+  //   damped — one increment PER fact line suffixed + demoted because a
+  //            lane-matched CURRENT belief covers its (subject, field)
+  //            with a different value (per-entry counting, the
+  //            countBeliefCitation idiom)
+  //   clean  — the pass evaluated (flag on AND matched beliefs present)
+  //            but no fact line contradicted a matched belief
+  // Emitted only when the pass actually evaluates — flag off, lane off,
+  // or no matched beliefs put nothing on the path. A V13-refined
+  // request evaluates the pass once per generation round.
+  readonly beliefDampingCount = new Counter({
+    name: 'brain_belief_damping_total',
+    help: 'Belief-aware fact-damping outcomes (BELIEFS_FACT_DAMPING)',
+    labelNames: ['outcome'] as const,
+    registers: [this.registry],
+  });
+
   // MM-zoom PR3 (FOVEA_FRAGMENT_ZOOM): what the ONE bounded zoom step did
   // per evaluation —
   //   flipped   — the re-verify over the fuller derived text passed →
@@ -812,6 +830,12 @@ export class MetricsService implements OnModuleInit {
   countBeliefCitation(outcome: 'cited' | 'dropped_unknown', n = 1): void {
     if (n > 0) {
       this.beliefCitationCount.inc({ outcome } as LabelValues<'outcome'>, n);
+    }
+  }
+
+  countBeliefDamping(outcome: 'damped' | 'clean', n = 1): void {
+    if (n > 0) {
+      this.beliefDampingCount.inc({ outcome } as LabelValues<'outcome'>, n);
     }
   }
 

--- a/src/synthesize/belief-damping.ts
+++ b/src/synthesize/belief-damping.ts
@@ -1,0 +1,141 @@
+import type { CitableBelief } from './belief-citations';
+import type { Citation } from './fact-index';
+
+/**
+ * Belief-aware fact damping (BELIEFS_FACT_DAMPING, PR-B — the serving
+ * lane's companion pass). Pure: no IO, no DI, no env — the update-story
+ * module's contract, one seam over.
+ *
+ * WHAT IT DOES: after the fact-line suffix maps apply, the pass marks
+ * and demotes every fact line that a lane-matched CURRENT belief
+ * contradicts, so a superseded fact stops outranking the current state
+ * it lost to. A contradicted line gets
+ *   (a) the deterministic suffix
+ *       ` (superseded by current belief: <field> = <value>)`, and
+ *   (b) a STABLE demotion — moved after the non-contradicted lines,
+ *       preserving relative order within each group (a stable
+ *       partition, never a re-sort by any score).
+ * Belief lines themselves are untouched — this pass only ever sees the
+ * fact section.
+ *
+ * CONTRADICTION SEMANTICS (deliberately conservative — never fuzzy):
+ * a matched belief covers a fact line when, after trim + lowercase
+ * normalization, belief.subject equals the fact's canonicalName AND
+ * belief.field equals the fact's predicate; the line is CONTRADICTED
+ * only when the normalized values then DIFFER (equal value ⇒ the fact
+ * agrees with the current state ⇒ untouched). Subject matching rides
+ * the lane's existing free-text (subject, field) key — no entity
+ * resolution, no similarity.
+ *
+ * THREE-CONSUMER PARITY BY CONSTRUCTION (the
+ * BELIEFS_LANE_DATE_DISAMBIGUATION pattern): the pass runs at the ONE
+ * canonical promptFactLines computation — immediately after
+ * applyFactSuffixes, in both the round-1 site and the V13 refine-round
+ * site — so the generator, the verifier and the fragment-zoom
+ * re-verify all read the SAME damped lines (the L3 escalation reads
+ * them too). The damping suffix therefore renders LAST on the line,
+ * after the update-story and grounding-quote suffixes.
+ *
+ * FENCE: `beliefsById` is the lane's rendered-set map — ONLY beliefs
+ * actually rendered into the prompt's current-state section (rows that
+ * already passed the lane's tenant → scoped-user → active →
+ * beliefVisible stack). Damping keys off it, so with the serving lane
+ * off (or an unscoped request, or nothing matched) there ARE no
+ * matched beliefs and the pass is a structural no-op — exactly the
+ * boot-validation WARN's inconsistent-pair semantics.
+ *
+ * ORDERING CAVEAT (deliberate): demotion runs AFTER the profile's
+ * chronological fact ordering, so a damped line leaves its
+ * chronological slot — that is the point: the contradicted assertion
+ * yields prompt position to lines the current state does not dispute.
+ */
+
+/** Metrics port (keeps this module pure — the belief-citations idiom). */
+export interface BeliefDampingMetrics {
+  countBeliefDamping(outcome: 'damped' | 'clean', n?: number): void;
+}
+
+/** Trim + lowercase — the ONLY normalization the pass applies. */
+function norm(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+/** (subject, field) → belief key; NUL-joined so a '|' inside a free-text
+ *  key can never alias two different keys onto one map slot. */
+function beliefKey(subject: string, field: string): string {
+  return `${norm(subject)}\u0000${norm(field)}`;
+}
+
+/**
+ * Apply the damping pass to the finalized prompt fact lines.
+ *
+ * `enabled` is the caller-resolved BELIEFS_FACT_DAMPING (the
+ * single-resolution idiom — resolved ONCE per request by the
+ * orchestrator; this module reads no env). Disabled, or no matched
+ * beliefs, or no contradiction ⇒ the returned array carries the exact
+ * input strings in the exact input order (byte-identical prompts).
+ *
+ * Lines resolve to facts through the `[<factId>] ` prefix (the
+ * appendUpdateStories idiom) against the caller's factIndex; a line
+ * with no parsable prefix or no index entry is never damped.
+ *
+ * Metrics (emitted only when the pass actually evaluates — flag on AND
+ * matched beliefs present; nothing on the path otherwise): `damped`
+ * counts once PER demoted line (the countBeliefCitation per-entry
+ * idiom), `clean` once per evaluation that demoted nothing. A refined
+ * request (V13 search loop) evaluates the pass once per round.
+ */
+export function applyBeliefFactDamping(opts: {
+  enabled: boolean;
+  factLines: readonly string[];
+  factIndex: ReadonlyMap<string, Citation>;
+  beliefsById: ReadonlyMap<string, CitableBelief> | undefined;
+  metrics?: BeliefDampingMetrics | undefined;
+}): string[] {
+  const { enabled, factLines, factIndex, beliefsById, metrics } = opts;
+  if (!enabled || !beliefsById || beliefsById.size === 0) return [...factLines];
+  // The lane dedupes by exact (subject, field); after normalization two
+  // case-variant keys could collide — first rendered belief wins.
+  const byKey = new Map<string, CitableBelief>();
+  for (const belief of beliefsById.values()) {
+    const key = beliefKey(belief.subject, belief.field);
+    if (!byKey.has(key)) byKey.set(key, belief);
+  }
+  const kept: string[] = [];
+  const damped: string[] = [];
+  for (const line of factLines) {
+    const belief = contradictingBelief(line, factIndex, byKey);
+    if (belief) {
+      damped.push(
+        `${line} (superseded by current belief: ${belief.field.trim()} = ${belief.value.trim()})`,
+      );
+    } else {
+      kept.push(line);
+    }
+  }
+  if (damped.length === 0) {
+    metrics?.countBeliefDamping('clean');
+    return kept;
+  }
+  metrics?.countBeliefDamping('damped', damped.length);
+  // Stable partition: both groups preserve their relative input order.
+  return [...kept, ...damped];
+}
+
+/** The matched belief that contradicts this fact line, or null: same
+ *  normalized (subject=canonicalName, field=predicate) key, DIFFERENT
+ *  normalized value. Unparsable/unindexed lines never dampen. */
+function contradictingBelief(
+  line: string,
+  factIndex: ReadonlyMap<string, Citation>,
+  byKey: ReadonlyMap<string, CitableBelief>,
+): CitableBelief | null {
+  if (!line.startsWith('[')) return null;
+  const close = line.indexOf(']');
+  if (close <= 1) return null;
+  const fact = factIndex.get(line.slice(1, close));
+  if (!fact) return null;
+  const belief = byKey.get(beliefKey(fact.canonicalName, fact.predicate));
+  if (!belief) return null;
+  return norm(belief.value) !== norm(fact.object) ? belief : null;
+}

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -32,9 +32,11 @@ import { fragmentCitationsEnabled } from '../common/evidence-flags';
 import {
   beliefServingLaneEnabled,
   beliefLaneDateDisambiguationEnabled,
+  beliefFactDampingEnabled,
 } from '../common/beliefs-flags';
 import { resolveAndCountFragmentCitations } from './fragment-citations';
-import { resolveAndCountBeliefCitations } from './belief-citations';
+import { resolveAndCountBeliefCitations, type CitableBelief } from './belief-citations';
+import { applyBeliefFactDamping } from './belief-damping';
 import { verifyAndZoom } from './fragment-zoom-seam';
 import { FragmentLaneService } from './fragment-lane.service';
 import { resolveAnswerIntegrity, type FinalizeContext } from './answer-integrity';
@@ -354,7 +356,25 @@ export class SynthesizeService {
     // suffix maps land on the SAME lines the generator and the
     // verifier read (prompt-side only; citations and ranking
     // untouched).
-    let promptFactLines = applyFactSuffixes(prepared.factLines, [updateStories, groundingQuotes]);
+    //
+    // BELIEFS_FACT_DAMPING (PR-B), resolved ONCE per request (the
+    // beliefServingLaneEnabled single-resolution idiom — the refine
+    // round reuses this resolution): after the suffix maps, the damping
+    // pass suffixes + stably demotes fact lines a lane-matched CURRENT
+    // belief contradicts. It keys off beliefsById — the lane's
+    // rendered-set fence — so lane-off / unscoped / nothing-matched is
+    // a structural no-op, and the ONE promptFactLines computation feeds
+    // the generator, the verifier, the fragment-zoom re-verify and L3
+    // alike (three-consumer parity by construction). Off ⇒
+    // byte-identical lines.
+    const factDamping = beliefFactDampingEnabled();
+    let promptFactLines = applyBeliefFactDamping({
+      enabled: factDamping,
+      factLines: applyFactSuffixes(prepared.factLines, [updateStories, groundingQuotes]),
+      factIndex,
+      beliefsById,
+      metrics: this.metrics,
+    });
 
     // V13 answer-side frames, both profile-gated and both pure:
     // the computed date table (generator and verifier read the same
@@ -385,6 +405,12 @@ export class SynthesizeService {
       prepareOpts,
       updateStories,
       groundingQuotes,
+      // BELIEFS_FACT_DAMPING: the per-request resolution + the lane's
+      // rendered-set fence map, so the refine round damps its refined
+      // fact lines against the SAME matched beliefs (the lane never
+      // re-runs on round 2).
+      factDamping,
+      beliefsById,
       results,
       factIndex,
       promptFactLines,
@@ -880,6 +906,14 @@ export class SynthesizeService {
     /** Multiworld §10 facts-as-keys: quotes for the ROUND-1 top facts —
      *  refined-in facts stand without quotes (unmatched lines pass). */
     groundingQuotes?: Map<string, string> | undefined;
+    /** BELIEFS_FACT_DAMPING, resolved ONCE per request by the
+     *  orchestrator (the single-resolution idiom — no second env read
+     *  here): round 2 damps its refined fact lines identically. */
+    factDamping?: boolean | undefined;
+    /** The lane's rendered-set belief fence map (ROUND-1 matched
+     *  beliefs — the lane never re-runs): refined-in facts face the
+     *  same current-state record the round-1 lines were damped by. */
+    beliefsById?: ReadonlyMap<string, CitableBelief> | undefined;
     shapeInstruction?: string | undefined;
     collected: {
       transcriptLines: string[];
@@ -924,10 +958,20 @@ export class SynthesizeService {
       const union = applyEvidenceUnion(args.evidence, probe.results, profile.extraEvidenceCap);
       const prepared = this.prepareEvidence(union, args.prepareOpts);
       if ('empty' in prepared) return null;
-      const promptFactLines = applyFactSuffixes(prepared.factLines, [
-        args.updateStories,
-        args.groundingQuotes,
-      ]);
+      // The refine-round instance of the ONE canonical promptFactLines
+      // computation (see the round-1 site): suffix maps first, then the
+      // BELIEFS_FACT_DAMPING pass over the refined evidence set —
+      // damping off / no matched beliefs ⇒ byte-identical lines.
+      const promptFactLines = applyBeliefFactDamping({
+        enabled: args.factDamping === true,
+        factLines: applyFactSuffixes(prepared.factLines, [
+          args.updateStories,
+          args.groundingQuotes,
+        ]),
+        factIndex: prepared.factIndex,
+        beliefsById: args.beliefsById,
+        metrics: this.metrics,
+      });
       const dateMathLines = profile.dateMath ? buildDateMathLines(prepared.results) : undefined;
       const generated = await withSpan('synthesize.generate_refined', () =>
         this.limiter.run(() =>

--- a/test/belief-damping.unit-spec.ts
+++ b/test/belief-damping.unit-spec.ts
@@ -1,0 +1,256 @@
+/**
+ * Belief-aware fact damping (BELIEFS_FACT_DAMPING) — the pure pass
+ * (belief-damping.ts, the belief-citations.unit-spec sibling):
+ *
+ *  - contradicted line: deterministic suffix + STABLE demotion after
+ *    the non-contradicted lines (a stable partition, never a re-sort);
+ *  - conservative semantics: same normalized (subject=canonicalName,
+ *    field=predicate) key AND a different normalized value — equal
+ *    values, unmatched keys, unparsable/unindexed lines all pass
+ *    through untouched;
+ *  - trim/case normalization on subject, field and value matching;
+ *  - disabled / no matched beliefs ⇒ byte-identical output (exact
+ *    string equality pinned) and NOTHING on the metrics path;
+ *  - metric emission: `damped` per demoted line, `clean` per
+ *    no-contradiction evaluation.
+ */
+import {
+  applyBeliefFactDamping,
+  type BeliefDampingMetrics,
+} from '../src/synthesize/belief-damping';
+import type { CitableBelief } from '../src/synthesize/belief-citations';
+import type { Citation } from '../src/synthesize/fact-index';
+
+const citation = (factId: string, over: Partial<Citation> = {}): Citation => ({
+  factId,
+  entityId: 'entity:alice',
+  canonicalName: 'Alice',
+  predicate: 'city',
+  object: 'Paris',
+  ...over,
+});
+
+const belief = (over: Partial<CitableBelief> = {}): CitableBelief => ({
+  beliefId: 'semantic_belief:b1',
+  subject: 'Alice',
+  field: 'city',
+  value: 'Berlin',
+  excerpt: 'Alice — city: Berlin (was: Paris)',
+  ...over,
+});
+
+const asMap = (...cs: Citation[]): Map<string, Citation> => new Map(cs.map((c) => [c.factId, c]));
+
+const beliefSet = (...bs: CitableBelief[]): Map<string, CitableBelief> =>
+  new Map(bs.map((b) => [b.beliefId, b]));
+
+const recordingMetrics = (): BeliefDampingMetrics & {
+  calls: Array<[string, number | undefined]>;
+} => {
+  const calls: Array<[string, number | undefined]> = [];
+  return { calls, countBeliefDamping: (outcome, n) => calls.push([outcome, n]) };
+};
+
+describe('applyBeliefFactDamping — suffix + stable demotion', () => {
+  it('a contradicted line gets the deterministic suffix and demotes after the clean lines', () => {
+    const lines = [
+      '[fact:1] Alice (person) — city: Paris (as of 2026-01-01)',
+      '[fact:2] Bob (person) — role: engineer',
+    ];
+    const out = applyBeliefFactDamping({
+      enabled: true,
+      factLines: lines,
+      factIndex: asMap(
+        citation('fact:1'),
+        citation('fact:2', { canonicalName: 'Bob', predicate: 'role', object: 'engineer' }),
+      ),
+      beliefsById: beliefSet(belief()),
+    });
+    expect(out).toEqual([
+      '[fact:2] Bob (person) — role: engineer',
+      '[fact:1] Alice (person) — city: Paris (as of 2026-01-01) (superseded by current belief: city = Berlin)',
+    ]);
+  });
+
+  it('demotion is a stable partition — both groups keep their relative input order', () => {
+    const lines = [
+      '[fact:1] Alice (person) — city: Paris',
+      '[fact:2] Bob (person) — role: engineer',
+      '[fact:3] Alice (person) — team: Search',
+      '[fact:4] Carol (person) — city: Rome',
+    ];
+    const out = applyBeliefFactDamping({
+      enabled: true,
+      factLines: lines,
+      factIndex: asMap(
+        citation('fact:1'),
+        citation('fact:2', { canonicalName: 'Bob', predicate: 'role', object: 'engineer' }),
+        citation('fact:3', { predicate: 'team', object: 'Search' }),
+        citation('fact:4', { canonicalName: 'Carol', predicate: 'city', object: 'Rome' }),
+      ),
+      beliefsById: beliefSet(
+        belief(),
+        belief({ beliefId: 'semantic_belief:b2', subject: 'Carol', value: 'Madrid' }),
+      ),
+    });
+    // Clean lines first (2 before 3), damped lines after (1 before 4) —
+    // never re-sorted by any score.
+    expect(out.map((l) => l.slice(0, 8))).toEqual(['[fact:2]', '[fact:3]', '[fact:1]', '[fact:4]']);
+    expect(out[2]).toContain('(superseded by current belief: city = Berlin)');
+    expect(out[3]).toContain('(superseded by current belief: city = Madrid)');
+  });
+
+  it('a fact asserting the SAME value as the belief is untouched (agreement, not contradiction)', () => {
+    const lines = ['[fact:1] Alice (person) — city: Berlin'];
+    const out = applyBeliefFactDamping({
+      enabled: true,
+      factLines: lines,
+      factIndex: asMap(citation('fact:1', { object: 'Berlin' })),
+      beliefsById: beliefSet(belief()),
+    });
+    expect(out).toEqual(lines);
+  });
+
+  it('value equality is judged after trim/case normalization — "  BERLIN " agrees with "berlin"', () => {
+    const lines = ['[fact:1] Alice (person) — city: berlin'];
+    const out = applyBeliefFactDamping({
+      enabled: true,
+      factLines: lines,
+      factIndex: asMap(citation('fact:1', { object: 'berlin' })),
+      beliefsById: beliefSet(belief({ value: '  BERLIN ' })),
+    });
+    expect(out).toEqual(lines);
+  });
+
+  it('subject/field matching normalizes trim + case — never fuzzier than that', () => {
+    const lines = ['[fact:1] Alice (person) — city: Paris'];
+    const out = applyBeliefFactDamping({
+      enabled: true,
+      factLines: lines,
+      factIndex: asMap(citation('fact:1')),
+      beliefsById: beliefSet(belief({ subject: '  ALICE ', field: 'City ' })),
+    });
+    expect(out).toEqual([
+      '[fact:1] Alice (person) — city: Paris (superseded by current belief: City = Berlin)',
+    ]);
+    // A near-miss subject ("Alice B.") is NOT a match — conservative by design.
+    const nearMiss = applyBeliefFactDamping({
+      enabled: true,
+      factLines: lines,
+      factIndex: asMap(citation('fact:1')),
+      beliefsById: beliefSet(belief({ subject: 'Alice B.' })),
+    });
+    expect(nearMiss).toEqual(lines);
+  });
+
+  it('no belief covers the (subject, field) key ⇒ every line passes untouched', () => {
+    const lines = ['[fact:1] Alice (person) — city: Paris'];
+    const out = applyBeliefFactDamping({
+      enabled: true,
+      factLines: lines,
+      factIndex: asMap(citation('fact:1')),
+      beliefsById: beliefSet(belief({ field: 'employer', value: 'ACME' })),
+    });
+    expect(out).toEqual(lines);
+  });
+
+  it('unparsable prefixes and unindexed factIds never dampen', () => {
+    const lines = [
+      'no prefix at all — city: Paris',
+      '[] empty header',
+      '[fact:unknown] Alice (person) — city: Paris',
+    ];
+    const out = applyBeliefFactDamping({
+      enabled: true,
+      factLines: lines,
+      factIndex: asMap(citation('fact:1')),
+      beliefsById: beliefSet(belief()),
+    });
+    expect(out).toEqual(lines);
+  });
+});
+
+describe('applyBeliefFactDamping — the byte-identical off-paths', () => {
+  const lines = [
+    '[fact:1] Alice (person) — city: Paris (as of 2026-01-01)',
+    '[fact:2] Bob (person) — role: engineer',
+  ];
+  const index = asMap(
+    citation('fact:1'),
+    citation('fact:2', { canonicalName: 'Bob', predicate: 'role', object: 'engineer' }),
+  );
+
+  it('enabled: false ⇒ exact same strings in the exact same order, no metric', () => {
+    const metrics = recordingMetrics();
+    const out = applyBeliefFactDamping({
+      enabled: false,
+      factLines: lines,
+      factIndex: index,
+      beliefsById: beliefSet(belief()),
+      metrics,
+    });
+    expect(out).toEqual(lines);
+    // Byte-identical: the very same string instances, untouched.
+    out.forEach((l, i) => expect(l).toBe(lines[i]));
+    expect(metrics.calls).toEqual([]);
+  });
+
+  it('serving lane off (beliefsById undefined) ⇒ structural no-op, no metric', () => {
+    const metrics = recordingMetrics();
+    const out = applyBeliefFactDamping({
+      enabled: true,
+      factLines: lines,
+      factIndex: index,
+      beliefsById: undefined,
+      metrics,
+    });
+    expect(out).toEqual(lines);
+    out.forEach((l, i) => expect(l).toBe(lines[i]));
+    expect(metrics.calls).toEqual([]);
+  });
+
+  it('lane on but nothing matched (empty fence map) ⇒ same no-op', () => {
+    const metrics = recordingMetrics();
+    const out = applyBeliefFactDamping({
+      enabled: true,
+      factLines: lines,
+      factIndex: index,
+      beliefsById: new Map(),
+      metrics,
+    });
+    expect(out).toEqual(lines);
+    expect(metrics.calls).toEqual([]);
+  });
+});
+
+describe('applyBeliefFactDamping — metric emission', () => {
+  it('damped counts once per demoted line', () => {
+    const metrics = recordingMetrics();
+    applyBeliefFactDamping({
+      enabled: true,
+      factLines: ['[fact:1] Alice (person) — city: Paris', '[fact:4] Carol (person) — city: Rome'],
+      factIndex: asMap(
+        citation('fact:1'),
+        citation('fact:4', { canonicalName: 'Carol', predicate: 'city', object: 'Rome' }),
+      ),
+      beliefsById: beliefSet(
+        belief(),
+        belief({ beliefId: 'semantic_belief:b2', subject: 'Carol', value: 'Madrid' }),
+      ),
+      metrics,
+    });
+    expect(metrics.calls).toEqual([['damped', 2]]);
+  });
+
+  it('clean counts once when the pass ran but nothing contradicted', () => {
+    const metrics = recordingMetrics();
+    applyBeliefFactDamping({
+      enabled: true,
+      factLines: ['[fact:1] Alice (person) — city: Berlin'],
+      factIndex: asMap(citation('fact:1', { object: 'Berlin' })),
+      beliefsById: beliefSet(belief()),
+      metrics,
+    });
+    expect(metrics.calls).toEqual([['clean', undefined]]);
+  });
+});


### PR DESCRIPTION
## What

Wires the declared-but-dead `BELIEFS_FACT_DAMPING` flag (PR-B — the follow-up the resolver stub promised): when it is on and the serving lane rendered matched beliefs, the new prompt-side damping pass suffixes and stably demotes fact lines that a matched CURRENT belief contradicts, so a superseded fact stops outranking the current state it lost to.

## How

**New pure module `src/synthesize/belief-damping.ts`** (no IO, no DI, no env — the update-story contract):

- **Contradiction semantics (conservative, never fuzzy):** a fact line is contradicted when a lane-matched belief covers the same key — belief `(subject, field)` equals the fact's `(canonicalName, predicate)` after trim + lowercase normalization — and the normalized values DIFFER. Equal value ⇒ untouched (agreement). Subject matching rides the lane's existing free-text key; no entity resolution, no similarity.
- **Effect on a contradicted line:** the deterministic suffix `` ` (superseded by current belief: <field> = <value>)` `` plus a STABLE demotion after the non-contradicted lines — a stable partition preserving relative order within each group, never a re-sort by any score. Belief lines themselves are untouched.
- **Fence:** the pass keys off `beliefsById`, the lane's rendered-set fence map (rows that already passed tenant → scoped-user → active → beliefVisible). Serving lane off / unscoped request / nothing matched ⇒ no matched beliefs ⇒ structural no-op — exactly the boot-validation WARN's inconsistent-pair semantics.

**Three-consumer parity by construction** (the `BELIEFS_LANE_DATE_DISAMBIGUATION` pattern): the pass runs at the ONE canonical `promptFactLines` computation — immediately after `applyFactSuffixes`, at both the round-1 site and the V13 refine-round site in `synthesize.service.ts` — so the generator, the verifier, and the fragment-zoom re-verify (and L3 escalation) all read the SAME damped lines. The flag is resolved ONCE per request by the orchestrator beside `beliefServingLaneEnabled()` (single-resolution idiom; the env read stays in `common/beliefs-flags.ts` per engine-gates S5.2), and the refine round reuses that resolution plus the round-1 fence map (the lane never re-runs on round 2).

**Telemetry:** `brain_belief_damping_total{outcome}` — `damped` once per demoted line (the belief-citation per-entry idiom), `clean` once per evaluation that demoted nothing; nothing on the path when the pass does not evaluate.

**Docs/catalog:** the config-catalog description, the env-validation KNOWN-flag note, the resolver docblock, and the `docs/operations.md` flag row now describe the live behavior (the "nothing reads this flag yet" sentences are gone).

## Off-path guarantees

- Flag off ⇒ byte-identical prompts and behavior (pinned by exact string-instance equality in the unit spec).
- Damping on, serving lane off ⇒ no matched beliefs ⇒ no-op (boot validation already WARNs on the pair).
- Runtime-mutable: read at call time, never captured in a constructor.

## Tests

New `test/belief-damping.unit-spec.ts` (12 tests): contradicted line suffixed + demoted; stable partition order across multiple damped/kept lines; equal value untouched; trim/case normalization on subject/field/value (and a near-miss subject NOT matching); no covering belief ⇒ untouched; unparsable/unindexed lines never dampen; flag off ⇒ byte-identical (exact same string instances, no metric); lane off (`beliefsById` undefined) and empty fence map ⇒ no-op, no metric; `damped` counted per line, `clean` per evaluation.

Ran locally: `pnpm typecheck`, `pnpm lint:ci`, `pnpm format:check`, `pnpm build`, and the full unit suite (350 suites / 3799 tests, snapshots included) — all green with the flag off, so existing prompt pins are unchanged.

## Notes for review

- Deliberate ordering caveat (documented in the module): demotion runs after the profile's chronological fact ordering, so a damped line leaves its chronological slot — that is the point of the pass.
- Prod enablement already pins `BELIEFS_FACT_DAMPING=1` (`.github/workflows/deploy-brain.yml`), so this goes live on merge + deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
