### PR TITLE
feat(eval): code-memory battery — coding-agent corpus with pack vocab, transitions and serving checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eval:memory-fitness": "ts-node -T test/eval/memory-fitness/runner.ts",
     "eval:state-transitions": "ts-node -T test/eval/state-transitions/runner.ts",
     "eval:domain-packs": "ts-node -T test/eval/domain-packs/runner.ts",
+    "eval:code-memory": "ts-node -T test/eval/code-memory/runner.ts",
     "openapi:build": "ts-node -T scripts/build-openapi.ts",
     "mri:report": "ts-node -T scripts/mri-report.ts",
     "mri:record-suite": "ts-node -T scripts/mri-record-suite.ts",

--- a/test/code-memory-scorers.unit-spec.ts
+++ b/test/code-memory-scorers.unit-spec.ts
@@ -1,0 +1,365 @@
+/**
+ * Unit sanity for the code-memory battery scorers (test/eval/
+ * code-memory/scorers.ts) — the mechanical judges of the battery.
+ * Pure fixtures, no HTTP: if these are wrong, every scorecard is
+ * wrong, so they get their own spec even though the battery itself
+ * never runs in CI. The generic primitives the battery reuses
+ * (containsAnyOf, isAbstention, walkProvenance, checkHistorySequence,
+ * scoreServe, findExactPredicateFact, findNamespacedTools, …) are
+ * covered by the siblings' test/memory-fitness-scorers.unit-spec.ts,
+ * test/state-transition-scorers.unit-spec.ts and
+ * test/domain-pack-scorers.unit-spec.ts.
+ *
+ * The corpus-integrity block additionally pins the battery's own
+ * scoreability invariants — including the HONESTY POLICY: every check
+ * that targets a predicate the live builtin manifest does not declare
+ * yet MUST carry a gap annotation (`expectedUnknown`), so the battery
+ * can never hardcode green ahead of the parallel PRs.
+ */
+import type { HitLike } from './eval/domain-packs/scorers';
+import {
+  ALL_TURNS,
+  CHECKS,
+  CM,
+  CM_040,
+  CODE_MEMORY_PACK,
+  currentPredicate,
+  gap040,
+  packHasPredicate,
+} from './eval/code-memory/corpus';
+import {
+  checkBuiltinPredicates,
+  checkEntityDedup,
+  checkNoForbiddenFact,
+  checkSupersession,
+  checkWhyRoundtrip,
+  type PredicateLike,
+  type WhyLike,
+} from './eval/code-memory/scorers';
+
+describe('code-memory scorers', () => {
+  describe('builtin-seed matcher', () => {
+    const seeded: PredicateLike[] = [
+      { predicateId: 'code_memory__decided', status: 'active' },
+      { predicateId: 'code_memory__because', status: 'active' },
+      { predicateId: 'code_memory__invariant', status: 'active' },
+      { predicateId: 'code_memory__gotcha', status: 'active' },
+      { predicateId: 'identifier', status: 'active' },
+    ];
+
+    it('passes when every required predicate is present and active', () => {
+      const v = checkBuiltinPredicates(seeded, ['code_memory__decided', 'code_memory__gotcha']);
+      expect(v.pass).toBe(true);
+      expect(v.detail).toContain('without install');
+    });
+
+    it('fails and names a missing predicate', () => {
+      const v = checkBuiltinPredicates(seeded, ['code_memory__owns']);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('code_memory__owns');
+    });
+
+    it('fails on a non-active status and names it', () => {
+      const v = checkBuiltinPredicates(
+        [{ predicateId: 'code_memory__decided', status: 'deprecated' }],
+        ['code_memory__decided'],
+      );
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('code_memory__decided (deprecated)');
+    });
+  });
+
+  describe('forbidden-transition scan (intention guard)', () => {
+    const hits: HitLike[] = [
+      {
+        entityId: 'e1',
+        canonicalName: 'ACME_STRICT_MODE',
+        facts: [
+          { factId: 'f1', predicate: 'identifier', object: 'ACME_STRICT_MODE' },
+          { factId: 'f2', predicate: 'status', object: 'not enabled anywhere' },
+        ],
+      },
+      {
+        entityId: 'e2',
+        canonicalName: 'cm-agent',
+        facts: [{ factId: 'f3', predicate: 'state_change', object: 'merged PR #212 in acme-api' }],
+      },
+    ];
+
+    it('passes when no state_change fact names the guarded flag', () => {
+      const v = checkNoForbiddenFact(hits, 'state_change', ['ACME_STRICT_MODE']);
+      expect(v.pass).toBe(true);
+      expect(v.detail).toContain('3 facts scanned');
+    });
+
+    it('fails and names the offending fact when a voiced plan flipped state', () => {
+      const flipped: HitLike[] = [
+        ...hits,
+        {
+          entityId: 'e3',
+          canonicalName: 'cm-agent',
+          facts: [
+            {
+              factId: 'f9',
+              predicate: 'state_change',
+              object: 'enabled ACME_STRICT_MODE next quarter',
+            },
+          ],
+        },
+      ];
+      const v = checkNoForbiddenFact(flipped, 'state_change', ['ACME_STRICT_MODE']);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('f9');
+      expect(v.detail).toContain('voiced plan flipped state');
+    });
+
+    it('only the exact predicate counts — an identifier fact naming the flag is fine', () => {
+      const v = checkNoForbiddenFact(hits, 'state_change', ['ACME_STRICT_MODE', 'anywhere']);
+      expect(v.pass).toBe(true);
+    });
+  });
+
+  describe('path-vs-symbol entity dedup', () => {
+    const tokens = ['webhook-dispatcher', 'webhookdispatcher', 'webhook dispatcher'];
+    const groups = [
+      ['dispatch path', 'outbound webhook'],
+      ['cents', 'line-item'],
+    ];
+    const merged: HitLike = {
+      entityId: 'e1',
+      canonicalName: 'src/gateway/webhook-dispatcher.ts',
+      facts: [
+        { factId: 'f1', predicate: 'decided', object: 'one dispatch path instead of six' },
+        { factId: 'f2', predicate: 'emits', object: 'line-item amounts in cents' },
+      ],
+    };
+
+    it('passes on one entity carrying facts from both phrasings', () => {
+      const v = checkEntityDedup([merged], tokens, groups);
+      expect(v.pass).toBe(true);
+      expect(v.detail).toContain('both phrasings');
+    });
+
+    it('fails on per-phrasing duplication and names both entities', () => {
+      const dup: HitLike = { entityId: 'e2', canonicalName: 'WebhookDispatcher', facts: [] };
+      const v = checkEntityDedup([merged, dup], tokens, groups);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('split across 2 entities');
+      expect(v.detail).toContain('WebhookDispatcher');
+    });
+
+    it("fails when one phrasing's facts are missing from the single entity", () => {
+      const onlyPath: HitLike = {
+        ...merged,
+        facts: [{ factId: 'f1', predicate: 'decided', object: 'one dispatch path instead of six' }],
+      };
+      const v = checkEntityDedup([onlyPath], tokens, groups);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('[cents|line-item]=0');
+    });
+
+    it('fails when no hit carries a module name token', () => {
+      const v = checkEntityDedup(
+        [{ entityId: 'e9', canonicalName: 'acme-api', facts: [] }],
+        tokens,
+        groups,
+      );
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('no hit named');
+    });
+  });
+
+  describe('why roundtrip verdict', () => {
+    const out: WhyLike = {
+      found: 2,
+      memory: [
+        { kind: 'decided', text: 'Cap the replay window at 48 hours' },
+        { kind: 'gotcha', text: 'longer windows re-deliver' },
+      ],
+    };
+
+    it('passes on the recorded kind with matching text', () => {
+      const v = checkWhyRoundtrip(out, 'decided', ['48 hours']);
+      expect(v.pass).toBe(true);
+      expect(v.detail).toContain('48 hours');
+    });
+
+    it('fails on found:0', () => {
+      const v = checkWhyRoundtrip({ found: 0, memory: [] }, 'decided', ['48 hours']);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('found:0');
+    });
+
+    it('fails when the text lands under the wrong kind', () => {
+      const v = checkWhyRoundtrip(out, 'invariant', ['48 hours']);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('no invariant entry');
+    });
+  });
+
+  describe('supersession verdict', () => {
+    const OLD = ['in-process'];
+    const NEW = ['managed queue relay'];
+    const nowGood: WhyLike = {
+      found: 1,
+      memory: [{ kind: 'decided', text: 'Route retries through the managed queue relay.' }],
+    };
+    const asOfGood: WhyLike = {
+      found: 1,
+      memory: [{ kind: 'decided', text: 'Route retries through the in-process queue.' }],
+    };
+
+    it('passes when now serves ONE new decision and asOf recalls the old one', () => {
+      const v = checkSupersession(nowGood, asOfGood, 'decided', OLD, NEW);
+      expect(v.pass).toBe(true);
+      expect(v.detail).toContain('supersession holds');
+    });
+
+    it('fails when TWO decisions are active now (single_active broken)', () => {
+      const twoActive: WhyLike = {
+        found: 2,
+        memory: [
+          { kind: 'decided', text: 'Route retries through the in-process queue.' },
+          { kind: 'decided', text: 'Route retries through the managed queue relay.' },
+        ],
+      };
+      const v = checkSupersession(twoActive, asOfGood, 'decided', OLD, NEW);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('got 2');
+    });
+
+    it('fails when the active decision is still the old one', () => {
+      const v = checkSupersession(asOfGood, asOfGood, 'decided', OLD, NEW);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('not the new decision');
+    });
+
+    it('fails when the superseded decision is unrecoverable at asOf', () => {
+      const v = checkSupersession(nowGood, { found: 0, memory: [] }, 'decided', OLD, NEW);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('unrecoverable at asOf');
+    });
+
+    it('fails when asOf leaks the future decision', () => {
+      const leaky: WhyLike = {
+        found: 2,
+        memory: [
+          { kind: 'decided', text: 'Route retries through the in-process queue.' },
+          { kind: 'decided', text: 'Route retries through the managed queue relay.' },
+        ],
+      };
+      const v = checkSupersession(nowGood, leaky, 'decided', OLD, NEW);
+      expect(v.pass).toBe(false);
+      expect(v.detail).toContain('FUTURE');
+    });
+  });
+});
+
+describe('code-memory corpus integrity', () => {
+  it('derives current predicate ids from the real builtin manifest', () => {
+    expect(CM.decided).toBe('code_memory__decided');
+    expect(CM.because).toBe('code_memory__because');
+    expect(CM.invariant).toBe('code_memory__invariant');
+    expect(CM.gotcha).toBe('code_memory__gotcha');
+    expect(() => currentPredicate('surely_not_a_predicate')).toThrow(/not in code_memory/);
+  });
+
+  it('HONESTY POLICY: every check on a predicate the manifest does not declare is gap-gated', () => {
+    // The battery must never hardcode green ahead of the pack 0.4.0
+    // ontology increment: a pack-vocab check whose predicate is not in
+    // the LIVE manifest must carry expectedUnknown. Version-agnostic:
+    // when 0.4.0 lands, the ids join the manifest and this invariant
+    // holds vacuously for them.
+    const declared = new Set(
+      CODE_MEMORY_PACK.predicates.map((p) => `${CODE_MEMORY_PACK.id}__${p.localId}`),
+    );
+    for (const check of CHECKS) {
+      if (check.kind !== 'pack-vocab') continue;
+      if (!declared.has(check.predicate)) {
+        expect(check.expectedUnknown).toBeDefined();
+        expect(check.expectedUnknown).toContain('0.4.0');
+      }
+    }
+  });
+
+  it('gap040 self-softens once the manifest declares the predicate', () => {
+    // For an id the manifest declares TODAY the annotation is already
+    // the never-measured baseline; for one it never will declare, the
+    // annotation says the check cannot pass yet. This is what flips
+    // the 0.4.0-gated checks to plain findings without an edit here.
+    expect(packHasPredicate('decided')).toBe(true);
+    expect(gap040('decided', 'x')).toMatch(/^Outcome never measured/);
+    expect(gap040('surely_not_a_predicate', 'x')).toContain('does not declare');
+    expect(CM_040.defaultValue).toBe('code_memory__default_value');
+    expect(CM_040.owns).toBe('code_memory__owns');
+  });
+
+  it('gap-gates exactly the checks that depend on unlanded work', () => {
+    const gated = CHECKS.filter((c) => c.expectedUnknown !== undefined).map((c) => c.id);
+    expect(gated).toEqual([
+      'k02-vocab-decided',
+      'k03-vocab-invariant',
+      'k04-vocab-gotcha',
+      'k05-vocab-default-value',
+      'k06-vocab-depends-on-version',
+      'k08-flag-transition',
+      'k12-serve-current-default',
+      'k13-serve-owner',
+    ]);
+  });
+
+  it('seeds every provenance fragment verbatim in exactly one turn', () => {
+    for (const check of CHECKS) {
+      if (check.kind !== 'trace-provenance') continue;
+      for (const fragment of check.episodeFragments) {
+        const carriers = ALL_TURNS.filter((t) =>
+          t.text.toLowerCase().includes(fragment.toLowerCase()),
+        );
+        expect(carriers).toHaveLength(1);
+      }
+    }
+  });
+
+  it('keeps every turn under the 600-char provenance cap', () => {
+    for (const turn of ALL_TURNS) {
+      expect(turn.text.length).toBeLessThan(600);
+    }
+  });
+
+  it('never restates the OLD flag value in the NEW transition turn', () => {
+    for (const check of CHECKS) {
+      if (check.kind !== 'flag-transition') continue;
+      const [oldStage, newStage] = [check.stages[0], check.stages[check.stages.length - 1]];
+      if (oldStage === undefined || newStage === undefined) continue;
+      const newTurns = ALL_TURNS.filter((t) =>
+        newStage.some((m) => t.text.toLowerCase().includes(m.toLowerCase())),
+      );
+      expect(newTurns.length).toBeGreaterThan(0);
+      for (const turn of newTurns) {
+        for (const marker of oldStage) {
+          expect(turn.text.toLowerCase()).not.toContain(marker.toLowerCase());
+        }
+      }
+    }
+  });
+
+  it('keeps the numeric literal markers unique to one turn each', () => {
+    for (const marker of ['9187', '120']) {
+      const carriers = ALL_TURNS.filter((t) => t.text.includes(marker));
+      expect(carriers).toHaveLength(1);
+    }
+  });
+
+  it('every ACME_STRICT_MODE turn is a voiced plan, never a completed transition', () => {
+    const turns = ALL_TURNS.filter((t) => t.text.includes('ACME_STRICT_MODE'));
+    expect(turns.length).toBeGreaterThan(0);
+    for (const turn of turns) {
+      expect(/should probably|have not/.test(turn.text)).toBe(true);
+    }
+  });
+
+  it('uses unique check ids', () => {
+    const ids = CHECKS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/test/eval/code-memory/README.md
+++ b/test/eval/code-memory/README.md
@@ -1,0 +1,158 @@
+# Code-memory battery
+
+Fourth mechanical battery, sibling of
+[`test/eval/memory-fitness`](../memory-fitness/README.md) (general
+first-person memory fitness),
+[`test/eval/state-transitions`](../state-transitions/README.md) (memory
+tracks a mutable world-state) and
+[`test/eval/domain-packs`](../domain-packs/README.md) (memory with
+installed industry packs). This one isolates the dogfood claim: **a
+coding agent's turns about its own repo become recallable, current,
+provenance-clean code memory.**
+
+Two things make it different from the domain-pack sibling:
+
+- **The pack under test is BUILTIN.** `code_memory` is never installed —
+  bootstrap seeds its predicates into every tenant and the install path
+  REJECTS the builtin id by design (`domain-pack-install.service.ts`),
+  so phase 0 performs **no install**: it reads `GET /v1/admin/predicates`
+  and check `k01` asserts the four namespaced predicates are active.
+  The absence of an install step is itself under test.
+- **The battery is findings-first by construction.** Half the checks
+  measure gaps the code-memory audit ranked (no extractionProfile, the
+  0.4.0 ontology increment, coding transition verbs, artifact holder
+  binding) — they are annotated `expectedUnknown` and their fails are
+  the recorded gaps, never regressions. See the honesty policy below.
+
+## The corpus
+
+One userId (`cm-agent`), ~20 turns of realistic coding-agent narration
+about a FICTIONAL repo, **"acme-api"**, in four conversations:
+
+| conversation | seeds                                                                                                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `decision`   | a dispatch decision + its rationale, an invariant (zod schemas), a gotcha (dry-run takes the schema lock), then a SUPERSEDING decision                                         |
+| `flags`      | `ACME_RETRY_QUEUE` introduced dark (default 0), the literal lane's prose (port 9187, 120 req/min), the SYMBOL phrasing of the shared module, then the flag enabled (default 1) |
+| `deps`       | `redis-client` pinned 1.2.0 → bumped 2.0.0, module ownership (Priya owns src/gateway), a gotcha bound to the new version, a second pinned dep                                  |
+| `mixed`      | PR #212 merged then REVERTED, two voiced-plan turns about `ACME_STRICT_MODE` that must NOT flip state, a postmortem line                                                       |
+
+One module — `src/gateway/webhook-dispatcher.ts` aka
+`WebhookDispatcher` — is referenced by PATH in one conversation and by
+SYMBOL in another, so entity identity is measured, not assumed (the
+runner deliberately passes NO `knownEntities` hints).
+
+Scoreability rules inherited from the siblings: transition turns never
+restate the old value; provenance fragments appear verbatim in exactly
+one turn under the 600-char cap; numeric literal markers (9187, 120)
+are unique to one turn; every `ACME_STRICT_MODE` turn is a voiced plan.
+
+## Check battery (all mechanical — see `types.ts` / `scorers.ts`)
+
+| id  | kind              | gap-gated | What would falsify the claim                                                                                                                      |
+| --- | ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| k01 | builtin-vocab     |           | the builtin `code_memory__*` predicates are NOT active in a fresh tenant (bootstrap seeding broken)                                               |
+| k02 | pack-vocab        | yes       | the dispatch decision coins an open-vocab predicate instead of `code_memory__decided`                                                             |
+| k03 | pack-vocab        | yes       | the zod invariant misses `code_memory__invariant`                                                                                                 |
+| k04 | pack-vocab        | yes       | the dry-run trap misses `code_memory__gotcha`                                                                                                     |
+| k05 | pack-vocab        | yes       | the flag default has no typed `code_memory__default_value` home (arrives with pack 0.4.0)                                                         |
+| k06 | pack-vocab        | yes       | the dependency bump has no typed `code_memory__depends_on_version` home (arrives with pack 0.4.0)                                                 |
+| k07 | literal-harvest   |           | the ALL_CAPS flag / port / rate limit in coding prose produce no `identifier` / `service_port` / `rate_limit`                                     |
+| k08 | flag-transition   | yes       | no single entity timeline retains introduced-dark → enabled in order (needs the coding-verb lexicon; holder binding routes the flip to the agent) |
+| k09 | supersession-asof |           | re-`decided` leaves TWO active decisions, or the old one is unrecoverable at `asOf`, or `asOf` leaks the future                                   |
+| k10 | cross-entity      |           | the module referenced by path vs symbol splits into two entities                                                                                  |
+| k11 | trace-provenance  |           | the decision fact does not unroll to the seeded turn's episode verbatim                                                                           |
+| k12 | serve             | yes       | "current default of ACME_RETRY_QUEUE" serves the stale 0/disabled or abstains — the dogfood north-star                                            |
+| k13 | serve             | yes       | "who owns src/gateway" cannot name Priya (ownership has no typed home until 0.4.0 `owns`)                                                         |
+| k14 | intention-guard   |           | a voiced plan produced a completed `state_change` naming `ACME_STRICT_MODE` — must stay green before AND after the coding-verb lexicon lands      |
+| k15 | mcp-roundtrip     |           | `record_decision` → `why` on a fresh anchor does not round-trip                                                                                   |
+| k16 | no-rogue-tools    |           | tools/list exposes a `__`-namespaced pack tool (the code-memory tools are core single-underscore names)                                           |
+
+Scoring reuses the siblings' unit-tested primitives (`containsAnyOf`,
+`isAbstention`, `walkProvenance`, `checkHistorySequence`, `scoreServe`,
+`findExactPredicateFact`, `findNamespacedTools`,
+`interleaveRoundRobin`) — one implementation, one truth — and adds only
+the code-memory scorers, unit-tested in
+`test/code-memory-scorers.unit-spec.ts`. **No LLM judge, no paid eval**
+— the only model spend is the stand's own extraction + serving cost
+(~20 mention extractions + 2 synthesize calls per run).
+
+## Honest-baseline policy (`expectedUnknown`)
+
+The domain-pack battery's pattern, extended: a check whose outcome
+depends on work that has not landed carries an `expectedUnknown`
+annotation. The runner still EXECUTES it, the report records the exact
+failure shape (e.g. which coined predicates swallowed the value), the
+scorecard tallies these fails separately (`failedExpectedUnknown`) and
+prints the gap-gated id list — **a fail there is the finding, a pass is
+the measured signal the parallel PR landed.** The gates:
+
+- **k02-k04** — `code_memory` ships no `extractionProfile` (the only
+  pack without one), so mention-path phrasing has never canonicalized
+  into its vocabulary. Flips when the pack 0.3.0 extraction-profile PR
+  lands.
+- **k05, k06, k12, k13** — target the pack **0.4.0** ontology increment
+  (`default_value`, `depends_on_version`, `owns`; `superseded_by` is
+  exercised mechanically by k09's single_active semantics instead of a
+  vocab check). The annotation is COMPUTED from the live manifest
+  (`gap040` in `corpus.ts`): while the predicate is absent the check
+  says it cannot pass yet; the moment 0.4.0 merges, the annotation
+  self-softens to "never measured" with no edit here. The unit spec
+  pins the invariant that a check on an undeclared predicate is always
+  gap-gated — the battery cannot hardcode green.
+- **k08** — needs the coding-verb state-verb lexicon (parallel PR) AND
+  `EXTRACTOR_STATE_VERB_HARVEST=1` at the stand; even then, holder
+  binding routes "we enabled FLAG" to the AGENT entity, so the full
+  story landing on one timeline is unmeasured.
+
+k14 is the deliberate NEGATIVE twin of k08: it must hold today (no
+coding verbs in the lexicon → nothing to guard) and keep holding after
+the lexicon lands (the 6-token pre-verb guards are then what keeps it
+green). k10 (cross-entity) is un-gated on purpose: a fail there is a
+genuine platform finding, not a known gap.
+
+## Running against a local stand
+
+Same stand as the siblings: a booted brain (with its OpenAI key),
+driven purely over the wire — **never run in CI** (the runner exits
+with a clear message when `BRAIN_BASE_URL` is unset).
+
+- **A FRESH tenant per run** (`BRAIN_COMPANY_ID`) — the battery asserts
+  entity dedup and reads whole timelines; a reused tenant contaminates
+  both.
+- **No registry seeding, no pack install** — `code_memory` is builtin.
+  Do NOT try to install it; the install endpoint rejects builtin ids.
+- The API key needs `brain:read + brain:write + brain:admin`
+  (`admin` for the phase-0 predicates read; `write` for
+  `record_decision` — without it k09/k15 are skipped, never passed).
+
+Stand flags that shape coverage:
+
+- `EXTRACTOR_LITERAL_HARVEST=1` — required for k07 (ON in prod).
+- `EXTRACTOR_STATE_VERB_HARVEST=1` — shapes k08/k14 (the transition
+  lane; k14 must stay green with it on or off).
+- `FACTS_API_ENABLED=1` — required for k11 (`get_fact_provenance` is
+  otherwise absent; the check is skipped, never silently passed).
+- `THROTTLE_DISABLED=1` — recommended; the runner backs off on 429
+  otherwise.
+
+Then:
+
+```bash
+BRAIN_BASE_URL=http://localhost:3000 \
+BRAIN_API_KEY=... \
+BRAIN_COMPANY_ID=<fresh tenant> \
+pnpm eval:code-memory
+```
+
+Knobs (`CMEV_` prefix, mirroring the siblings' `MEMFIT_` / `STEV_` /
+`DPEV_`): `CMEV_USER_ID` (default `cm-agent`), `CMEV_RUN_ID` (default
+time-derived; conversation ids and MCP anchors are run-scoped so
+re-runs never collide), `CMEV_GUARDRAILS` (`strict`|`lenient`|`off`,
+default `strict`), `CMEV_SKIP_INGEST=1` (re-ask an already-ingested
+run — requires the same `CMEV_RUN_ID`), `CMEV_REPORT_DIR` (default
+`var/code-memory/`).
+
+The JSON scorecard lands in `var/code-memory/code-memory-<runId>.json`
+— per-class and per-check-kind tallies, the phase-0 setup trail, the
+gap-gated id list, every verdict with its detail (and the raw served
+answers), so any verdict is reproducible from the report file alone.

--- a/test/eval/code-memory/corpus.ts
+++ b/test/eval/code-memory/corpus.ts
@@ -1,0 +1,417 @@
+/**
+ * The coding-agent corpus and check battery: ~20 turns of realistic
+ * coding-agent narration about a FICTIONAL repo, "acme-api" — a
+ * decision superseded, a flag introduced dark then enabled, a
+ * dependency pinned then bumped, ownership, a gotcha bound to a
+ * version, a PR merged then reverted, and voiced plans that must NOT
+ * become transitions. One module ("webhook-dispatcher") is referenced
+ * BOTH by file path and by symbol name, so entity identity is
+ * measured, not assumed.
+ *
+ * Current predicate ids are DERIVED from the real builtin manifest
+ * (src/ai/domain-packs/code-memory.pack.ts) through a guard that
+ * throws when a referenced localId leaves the pack. Ids arriving with
+ * the pack 0.4.0 ontology increment (owns / default_value /
+ * depends_on_version / superseded_by) are composed through a helper
+ * that READS the live manifest: while they are absent the check
+ * carries a gap annotation (`expectedUnknown`) saying it cannot pass
+ * yet; the moment 0.4.0 lands, the annotation softens to
+ * "never measured" automatically — the battery never hardcodes green.
+ *
+ * Scoreability rules inherited from the siblings:
+ *  - transition turns never restate the OLD value, so history
+ *    subsequences and serve markers cannot cross-match;
+ *  - every provenance fragment appears VERBATIM in exactly one turn,
+ *    under the 600-char provenance text cap;
+ *  - serve markers are value-shaped and never occur in decline
+ *    phrasings; numeric markers (9187, 120) are unique to one turn.
+ */
+import { CODE_MEMORY_PACK } from '../../../src/ai/domain-packs/code-memory.pack';
+import { composePredicateId } from '../../../src/ai/domain-packs/manifest';
+import { STATE_CHANGE_PREDICATE } from '../../../src/ai/extractor-internals/state-verb-harvest';
+import type { Check, CorpusTurn } from './types';
+
+export { CODE_MEMORY_PACK };
+
+/** The vertical every corpus mention attributes itself to. */
+export const CORPUS_VERTICAL = 'work';
+
+/**
+ * Namespaced id of a predicate the pack declares TODAY, guarded
+ * against manifest drift: a localId that leaves the pack makes the
+ * corpus refuse to build (the domain-pack battery's packPredicate).
+ */
+export function currentPredicate(localId: string): string {
+  if (!CODE_MEMORY_PACK.predicates.some((p) => p.localId === localId)) {
+    throw new Error(
+      `corpus references code_memory__${localId}, which is not in ` +
+        `code_memory@${CODE_MEMORY_PACK.version}`,
+    );
+  }
+  return composePredicateId(CODE_MEMORY_PACK.id, localId);
+}
+
+/** Is `localId` declared by the live builtin manifest? */
+export function packHasPredicate(localId: string): boolean {
+  return CODE_MEMORY_PACK.predicates.some((p) => p.localId === localId);
+}
+
+/**
+ * Namespaced id of a predicate EXPECTED from the pack 0.4.0 ontology
+ * increment. Unlike currentPredicate this never throws: the id is
+ * composed either way, and `gap040` (below) supplies the honest
+ * annotation for the period the predicate does not exist.
+ */
+export function plannedPredicate(localId: string): string {
+  return composePredicateId(CODE_MEMORY_PACK.id, localId);
+}
+
+/**
+ * Gap annotation for a check that targets a 0.4.0 predicate. While
+ * the manifest does not declare it, the check CANNOT pass and says
+ * so; once 0.4.0 lands the annotation self-softens to the
+ * never-measured baseline (extraction consulting the pack vocabulary
+ * still has zero observations) — computed from the LIVE manifest, so
+ * no edit here is needed when the parallel PR merges.
+ */
+export function gap040(localId: string, alsoUnknown: string): string {
+  if (packHasPredicate(localId)) {
+    return `Outcome never measured: ${alsoUnknown}`;
+  }
+  return (
+    `code_memory@${CODE_MEMORY_PACK.version} does not declare "${localId}" — ` +
+    `it arrives with the pack 0.4.0 ontology increment, so this check cannot ` +
+    `pass today and its fail is the recorded gap. Also unmeasured: ${alsoUnknown}`
+  );
+}
+
+/** Baseline annotation for the 4 predicates that DO exist today. */
+export const PROFILE_GAP =
+  'code_memory ships no extractionProfile (the only pack without one — audit ' +
+  'gap #2), so mention-path phrasing has never canonicalized into ' +
+  'code_memory__* vocabulary; a coined open-vocab predicate here is the ' +
+  'baseline finding. Flips green when the extraction-profile PR (pack 0.3.0) ' +
+  'lands and extraction consults it.';
+
+/** Gap annotation for the flag-transition history check. */
+export const LEXICON_GAP =
+  'The state-verb lexicon gains coding transition verbs ("enabled", "merged", ' +
+  '"reverted", …) in a parallel PR, and EXTRACTOR_STATE_VERB_HARVEST must be ' +
+  'ON at the stand; even then, holder binding routes "we enabled FLAG" to the ' +
+  'AGENT entity rather than the flag entity (known lexicon-lane limitation), ' +
+  'so both stages landing on ONE timeline is unmeasured. A fail is the ' +
+  'recorded gap; a pass is the signal the transition story closed.';
+
+/** Real (today) namespaced ids — drift-guarded. */
+export const CM = {
+  decided: currentPredicate('decided'),
+  because: currentPredicate('because'),
+  invariant: currentPredicate('invariant'),
+  gotcha: currentPredicate('gotcha'),
+} as const;
+
+/** Planned (pack 0.4.0) namespaced ids — composed, never guarded. */
+export const CM_040 = {
+  owns: plannedPredicate('owns'),
+  defaultValue: plannedPredicate('default_value'),
+  dependsOnVersion: plannedPredicate('depends_on_version'),
+  supersededBy: plannedPredicate('superseded_by'),
+} as const;
+
+/** Timestamp of turn N (1-based) — 5 minutes apart within a session. */
+const t = (startIso: string, turn: number): string =>
+  new Date(Date.parse(startIso) + (turn - 1) * 5 * 60_000).toISOString();
+
+const conv = (conversation: string, startIso: string, texts: string[]): CorpusTurn[] =>
+  texts.map((text, i) => ({ conversation, turn: i + 1, emittedAt: t(startIso, i + 1), text }));
+
+// ── the four conversations ──────────────────────────────────────────
+
+/** Decision conversation — decision + rationale + invariant + gotcha,
+ *  then a superseding decision on the same subject. */
+const DECISION_TURNS = conv('decision', '2026-09-01T09:00:00Z', [
+  'We decided to route every outbound webhook in acme-api through ' +
+    'src/gateway/webhook-dispatcher.ts — one dispatch path instead of six ad-hoc fetch calls.',
+  'The reason: retry and signing logic had drifted between the six webhook call-sites, ' +
+    'and two of them never signed payloads at all.',
+  'Invariant for acme-api: every route handler must validate its body with the shared ' +
+    'zod schema from src/gateway/schemas.ts, or the contract tests fail.',
+  'Gotcha in acme-api: pnpm run migrate --dry-run still acquires the schema lock, ' +
+    'so a dry run can deadlock a live deploy.',
+  'Update: we walked the single-dispatcher decision back — outbound webhooks in acme-api ' +
+    'now go through the managed queue relay in src/gateway/queue-relay.ts.',
+]);
+
+/** Flags conversation — a flag introduced dark (default 0), the
+ *  literal lane's identifier / port / rate-limit prose, the SYMBOL
+ *  phrasing of the shared module, then the flag enablement (0→1). */
+const FLAGS_TURNS = conv('flags', '2026-09-01T15:00:00Z', [
+  'We introduced the ACME_RETRY_QUEUE flag in acme-api; it ships disabled and its ' +
+    'default stays 0 until the queue is proven.',
+  'The gateway metrics endpoint in acme-api listens on port 9187.',
+  'acme-api throttles /v1/webhooks at 120 requests per minute.',
+  'WebhookDispatcher in acme-api emits every line-item amount in cents, never floats.',
+  'We enabled ACME_RETRY_QUEUE in prod today; its default is now 1 for every acme-api tenant.',
+]);
+
+/** Deps conversation — a pin, the bump (1.2.0 → 2.0.0), ownership,
+ *  a gotcha bound to the new version, and a second pinned dep. */
+const DEPS_TURNS = conv('deps', '2026-09-02T10:00:00Z', [
+  'acme-api pins redis-client at 1.2.0; the pin lives in the root package.json.',
+  'We bumped redis-client to 2.0.0 in acme-api — the new cluster API is required by ' +
+    'the retry queue.',
+  'Priya owns src/gateway in acme-api, including the webhook dispatcher and the queue relay.',
+  'Gotcha with redis-client 2.0.0 in acme-api: SCAN cursors are strings now, and comparing ' +
+    'them to zero makes the loop silently never terminate.',
+  'The staging database for acme-api is SurrealDB 3.2.4, pinned in docker-compose.staging.yml.',
+]);
+
+/** Mixed conversation — a merge then its revert, TWO voiced-plan
+ *  turns that must NOT flip state, and a postmortem line. */
+const MIXED_TURNS = conv('mixed', '2026-09-03T11:00:00Z', [
+  'We merged PR #212 in acme-api — it lands the queue-relay cutover for outbound webhooks.',
+  'We reverted PR #212 this morning; the cutover doubled webhook latency for the EU tenants.',
+  'We should probably enable ACME_STRICT_MODE for acme-api next quarter; nobody has ' +
+    'measured the blast radius yet.',
+  'For the record, we have not enabled ACME_STRICT_MODE anywhere in acme-api.',
+  'Postmortem for Friday: the acme-api worker pool ran out of file descriptors because ' +
+    'orphan webhook sockets piled up unclosed.',
+]);
+
+export const ALL_TURNS: CorpusTurn[] = [
+  ...DECISION_TURNS,
+  ...FLAGS_TURNS,
+  ...DEPS_TURNS,
+  ...MIXED_TURNS,
+];
+
+// ── the checks ──────────────────────────────────────────────────────
+
+export const CHECKS: Check[] = [
+  // ── setup: the builtin seeding path itself ────────────────────────
+  {
+    kind: 'builtin-vocab',
+    id: 'k01-builtin-seeded',
+    cls: 'setup',
+    intent:
+      'The builtin code_memory predicates are active in the tenant WITHOUT any ' +
+      'install (bootstrap seeding; the install path rejects the builtin id by design).',
+    requiredPredicates: [CM.decided, CM.because, CM.invariant, CM.gotcha],
+  },
+
+  // ── pack-vocab, today's ontology (honest baseline: no profile) ────
+  {
+    kind: 'pack-vocab',
+    id: 'k02-vocab-decided',
+    cls: 'vocab',
+    intent: `The dispatch decision canonicalizes into ${CM.decided}, not a coined predicate.`,
+    searchQuery: 'acme-api outbound webhook dispatch decision',
+    predicate: CM.decided,
+    valueMarkers: ['dispatch'],
+    expectedUnknown: PROFILE_GAP,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'k03-vocab-invariant',
+    cls: 'vocab',
+    intent: `The zod-schema rule lands on ${CM.invariant} with the verbatim constraint.`,
+    searchQuery: 'acme-api route handler body validation invariant',
+    predicate: CM.invariant,
+    valueMarkers: ['zod'],
+    expectedUnknown: PROFILE_GAP,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'k04-vocab-gotcha',
+    cls: 'vocab',
+    intent: `The dry-run deadlock trap lands on ${CM.gotcha}.`,
+    searchQuery: 'acme-api migrate dry run schema lock',
+    predicate: CM.gotcha,
+    valueMarkers: ['schema lock'],
+    expectedUnknown: PROFILE_GAP,
+  },
+
+  // ── pack-vocab, the 0.4.0 ontology increment (gap-gated) ──────────
+  {
+    kind: 'pack-vocab',
+    id: 'k05-vocab-default-value',
+    cls: 'vocab',
+    intent: `The flag default lands on ${CM_040.defaultValue} as a typed single_active value.`,
+    searchQuery: 'ACME_RETRY_QUEUE default value',
+    predicate: CM_040.defaultValue,
+    valueMarkers: ['0', '1'],
+    expectedUnknown: gap040(
+      'default_value',
+      'whether extraction routes flag-default phrasing into the typed predicate.',
+    ),
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'k06-vocab-depends-on-version',
+    cls: 'vocab',
+    intent: `The redis-client bump lands on ${CM_040.dependsOnVersion} with the new version.`,
+    searchQuery: 'acme-api redis-client version',
+    predicate: CM_040.dependsOnVersion,
+    valueMarkers: ['2.0.0'],
+    expectedUnknown: gap040(
+      'depends_on_version',
+      'whether extraction routes dependency-version phrasing into the typed predicate.',
+    ),
+  },
+
+  // ── literal lane fit inside coding prose ──────────────────────────
+  {
+    kind: 'literal-harvest',
+    id: 'k07-literal-harvest',
+    cls: 'harvest',
+    intent:
+      'The deterministic literal lane (EXTRACTOR_LITERAL_HARVEST, ON at the stand) ' +
+      'produces its core facts from identifier-heavy coding prose: the ALL_CAPS flag, ' +
+      'the metrics port and the route rate limit each land as a typed literal fact.',
+    wants: [
+      {
+        searchQuery: 'ACME_RETRY_QUEUE flag',
+        predicate: 'identifier',
+        valueMarkers: ['ACME_RETRY_QUEUE'],
+      },
+      {
+        searchQuery: 'acme-api gateway metrics port',
+        predicate: 'service_port',
+        valueMarkers: ['9187'],
+      },
+      {
+        searchQuery: 'acme-api webhooks rate limit',
+        predicate: 'rate_limit',
+        valueMarkers: ['120'],
+      },
+    ],
+  },
+
+  // ── the flag 0→1 transition as ordered history ────────────────────
+  {
+    kind: 'flag-transition',
+    id: 'k08-flag-transition',
+    cls: 'transition',
+    intent:
+      'ONE entity timeline retains the flag story in order: introduced dark ' +
+      '(ships disabled, default 0) then enabled (default 1).',
+    searchQuery: 'ACME_RETRY_QUEUE flag default',
+    stages: [
+      ['ships disabled', 'default stays 0'],
+      ['enabled ACME_RETRY_QUEUE', 'default is now 1'],
+    ],
+    expectedUnknown: LEXICON_GAP,
+  },
+
+  // ── supersession, mechanically (MCP write path) ───────────────────
+  {
+    kind: 'supersession-asof',
+    id: 'k09-supersession-asof',
+    cls: 'mcp',
+    intent:
+      'Re-recording a `decided` on one anchor SUPERSEDES: `why` now serves exactly ' +
+      'ONE active decision (the new one), and `why` at an asOf between the writes ' +
+      'still recalls the old one — and not yet the new one (bitemporal).',
+    anchor: 'acme-api/src/gateway/queue-relay.ts',
+    oldText: 'Route webhook retries through the in-process queue.',
+    newText: 'Route webhook retries through the managed queue relay.',
+    oldMarkers: ['in-process'],
+    newMarkers: ['managed queue relay'],
+  },
+
+  // ── entity identity across phrasings ──────────────────────────────
+  {
+    kind: 'cross-entity',
+    id: 'k10-cross-entity',
+    cls: 'identity',
+    intent:
+      'The module referenced by PATH (src/gateway/webhook-dispatcher.ts) and by ' +
+      'SYMBOL (WebhookDispatcher) resolves to ONE entity carrying facts seeded by ' +
+      'both phrasings — no per-phrasing duplication.',
+    searchQuery: 'acme-api webhook dispatcher',
+    nameTokens: ['webhook-dispatcher', 'webhookdispatcher', 'webhook dispatcher'],
+    mustCarryGroups: [
+      ['dispatch path', 'outbound webhook'],
+      ['cents', 'line-item'],
+    ],
+  },
+
+  // ── provenance ────────────────────────────────────────────────────
+  {
+    kind: 'trace-provenance',
+    id: 'k11-trace-provenance',
+    cls: 'trace',
+    intent: "A dispatch-decision fact unrolls to the seeded decision turn's episode verbatim.",
+    searchQuery: 'acme-api outbound webhook dispatch decision',
+    objectHint: ['dispatch', 'webhook'],
+    episodeFragments: ['one dispatch path instead of six'],
+  },
+
+  // ── serving ───────────────────────────────────────────────────────
+  {
+    kind: 'serve',
+    id: 'k12-serve-current-default',
+    cls: 'serving',
+    intent:
+      'The dogfood north-star question — "what is the current default of X" — serves ' +
+      'the NEW value and never the stale one.',
+    query: 'What is the current default of ACME_RETRY_QUEUE in acme-api?',
+    expectAnyOf: ['now 1', 'is 1', 'to 1', 'default of 1', 'enabled'],
+    forbidAnyOf: ['default is 0', 'defaults to 0', 'stays 0', 'still 0', 'disabled'],
+    expectedUnknown: gap040(
+      'default_value',
+      'whether "current default" serves correctly without a typed single_active home.',
+    ),
+  },
+  {
+    kind: 'serve',
+    id: 'k13-serve-owner',
+    cls: 'serving',
+    intent: 'Module-ownership serving: "who owns src/gateway" names the owner.',
+    query: 'Who owns src/gateway in acme-api?',
+    expectAnyOf: ['Priya'],
+    forbidAnyOf: [],
+    expectedUnknown: gap040(
+      'owns',
+      'whether ownership phrasing survives open-vocab extraction well enough to serve.',
+    ),
+  },
+
+  // ── the intention guard must hold ─────────────────────────────────
+  {
+    kind: 'intention-guard',
+    id: 'k14-intention-guard',
+    cls: 'guard',
+    intent:
+      'The voiced-plan turns ("should probably enable", "have not enabled") must NOT ' +
+      'produce a completed state transition for ACME_STRICT_MODE — this must stay ' +
+      'green BOTH before and after the coding-verb lexicon lands (the 6-token guards ' +
+      'are what keep it green after).',
+    searchQuery: 'ACME_STRICT_MODE',
+    forbidPredicate: STATE_CHANGE_PREDICATE,
+    forbidObjectMarkers: ['ACME_STRICT_MODE'],
+  },
+
+  // ── MCP round-trip ────────────────────────────────────────────────
+  {
+    kind: 'mcp-roundtrip',
+    id: 'k15-mcp-roundtrip',
+    cls: 'mcp',
+    intent: 'record_decision → why on a fresh anchor round-trips (found>0, right kind, text).',
+    anchor: 'acme-api/src/ingest/replay-window.ts',
+    recordKind: 'decided',
+    text: 'Cap the replay window at 48 hours; longer windows re-deliver acknowledged webhooks.',
+    textMarkers: ['48 hours', 'replay window'],
+  },
+
+  // ── surfaces ──────────────────────────────────────────────────────
+  {
+    kind: 'no-rogue-tools',
+    id: 'k16-no-rogue-tools',
+    cls: 'surfaces',
+    intent:
+      'The code-memory tools (why / recall_decisions / record_decision) are core ' +
+      'single-underscore names and no pack declares mcpTools, so tools/list must ' +
+      'carry ZERO __-namespaced pack tools — asserted, not assumed.',
+  },
+];

--- a/test/eval/code-memory/runner.ts
+++ b/test/eval/code-memory/runner.ts
@@ -1,0 +1,731 @@
+/**
+ * Code-memory battery runner — drives EVERYTHING through the real
+ * wire, mirroring the memory-fitness / state-transitions /
+ * domain-packs siblings:
+ *
+ *  - REST  GET /v1/admin/predicates      (phase 0: assert the BUILTIN
+ *          code_memory predicates are seeded — the pack is builtin, so
+ *          there is NO install; the install path rejects the builtin
+ *          id by design and this runner never calls it)
+ *  - REST  POST /v1/ingest/mention       (corpus turns, per-user scoped)
+ *  - MCP   tools/list / search_knowledge / get_entity_timeline /
+ *          get_fact_provenance / synthesize / why / record_decision
+ *
+ * Scoring is fully mechanical (see scorers.ts) — no LLM judge. The
+ * serving calls cost normal model spend on the stand; the battery
+ * itself spends nothing on judging.
+ *
+ * Run: pnpm eval:code-memory   (see README.md for stand flags)
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { HttpBrainClient } from '../http-brain-client';
+import { interleaveRoundRobin } from '../memory-fitness/interleave';
+import { walkProvenance } from '../memory-fitness/scorers';
+import { checkHistorySequence, scoreServe, type HistoryEvent } from '../state-transitions/scorers';
+import { findExactPredicateFact, findNamespacedTools, type HitLike } from '../domain-packs/scorers';
+import { ALL_TURNS, CHECKS, CM, CORPUS_VERTICAL } from './corpus';
+import {
+  checkBuiltinPredicates,
+  checkEntityDedup,
+  checkNoForbiddenFact,
+  checkSupersession,
+  checkWhyRoundtrip,
+  type PredicateLike,
+  type WhyLike,
+} from './scorers';
+import type {
+  BuiltinVocabCheck,
+  Check,
+  CheckKind,
+  CheckResult,
+  CrossEntityCheck,
+  FlagTransitionCheck,
+  IntentionGuardCheck,
+  LiteralHarvestCheck,
+  McpRoundtripCheck,
+  PackVocabCheck,
+  Scorecard,
+  ServeCheck,
+  SupersessionCheck,
+  Tally,
+  TraceProvenanceCheck,
+} from './types';
+
+/** Provenance-walk budget per check (sibling round-robin interleave). */
+const PROVENANCE_CANDIDATE_CAP = 12;
+
+/** How many search hits get their timeline walked per transition check. */
+const HISTORY_ENTITY_CAP = 6;
+
+/** Wall-clock gap around the supersession asOf cursor (ms). */
+const SUPERSESSION_GAP_MS = 2_000;
+
+// ── configuration ───────────────────────────────────────────────────
+
+interface Config {
+  baseUrl: string;
+  apiKey: string;
+  companyId: string;
+  userId: string;
+  runId: string;
+  guardrails: 'strict' | 'lenient' | 'off';
+  skipIngest: boolean;
+  reportDir: string;
+}
+
+function loadConfig(): Config {
+  const baseUrl = process.env.BRAIN_BASE_URL ?? process.env.BRAIN_URL;
+  const apiKey = process.env.BRAIN_API_KEY;
+  const companyId = process.env.BRAIN_COMPANY_ID;
+  if (baseUrl === undefined || baseUrl === '') {
+    console.error(
+      [
+        'code-memory: BRAIN_BASE_URL is not set — nothing to run against.',
+        'This battery drives a LIVE brain stand over MCP + REST (it needs a booted',
+        'service and its OpenAI key) and is intentionally never run in CI.',
+        '',
+        'Required env:',
+        '  BRAIN_BASE_URL   e.g. http://localhost:3000  (BRAIN_URL also accepted)',
+        '  BRAIN_API_KEY    tenant M2M key with brain:read + brain:write + brain:admin',
+        '                   (phase 0 reads /v1/admin/predicates; record_decision',
+        '                   needs brain:write)',
+        '  BRAIN_COMPANY_ID tenant id — use a FRESH tenant per run (see README.md)',
+        '',
+        'NOTE: code_memory is a BUILTIN pack — its predicates are seeded into every',
+        'tenant at bootstrap and the install path REJECTS the builtin id, so this',
+        'runner performs no install (that absence is itself under test: k01).',
+        '',
+        'Optional env: CMEV_USER_ID, CMEV_RUN_ID, CMEV_GUARDRAILS',
+        '(strict|lenient|off, default strict), CMEV_SKIP_INGEST=1 (re-ask an',
+        'already-ingested run — requires the same CMEV_RUN_ID), CMEV_REPORT_DIR.',
+      ].join('\n'),
+    );
+    process.exit(1);
+  }
+  if (apiKey === undefined || apiKey === '') {
+    console.error('code-memory: BRAIN_API_KEY is not set.');
+    process.exit(1);
+  }
+  if (companyId === undefined || companyId === '') {
+    console.error('code-memory: BRAIN_COMPANY_ID is not set.');
+    process.exit(1);
+  }
+  const guardrailsRaw = process.env.CMEV_GUARDRAILS ?? 'strict';
+  if (guardrailsRaw !== 'strict' && guardrailsRaw !== 'lenient' && guardrailsRaw !== 'off') {
+    console.error('code-memory: CMEV_GUARDRAILS must be strict|lenient|off.');
+    process.exit(1);
+  }
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ''),
+    apiKey,
+    companyId,
+    userId: process.env.CMEV_USER_ID ?? 'cm-agent',
+    runId: process.env.CMEV_RUN_ID ?? `cm${Date.now().toString(36)}`,
+    guardrails: guardrailsRaw,
+    skipIngest: process.env.CMEV_SKIP_INGEST === '1',
+    reportDir: process.env.CMEV_REPORT_DIR ?? join('var', 'code-memory'),
+  };
+}
+
+// ── small utilities ─────────────────────────────────────────────────
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Retry on throttle (HTTP 429) — mention ingest and the MCP route are rate-capped. */
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      const msg = String(err);
+      if (attempt < 12 && /429|too many requests/i.test(msg)) {
+        console.error(`  [throttled] ${label} — waiting 6.5s (attempt ${attempt})`);
+        await sleep(6_500);
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/** Run-scoped conversation id — makes re-runs non-colliding by construction. */
+const convId = (cfg: Config, key: string): string => `${cfg.runId}-${key}`;
+
+const messageId = (cfg: Config, key: string, turn: number): string =>
+  `${convId(cfg, key)}-t${String(turn).padStart(2, '0')}`;
+
+/** Run-scoped code anchor — MCP writes never collide across runs. */
+const saltedAnchor = (cfg: Config, anchor: string): string => `${cfg.runId}:${anchor}`;
+
+// ── REST (raw, non-throwing — phase 0 branches on the status) ───────
+
+interface RestResult<T> {
+  status: number;
+  json: T | null;
+}
+
+async function restRaw<T>(cfg: Config, method: 'GET', path: string): Promise<RestResult<T>> {
+  const res = await fetch(`${cfg.baseUrl}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${cfg.apiKey}`,
+    },
+  });
+  const ct = res.headers.get('content-type') ?? '';
+  if (!ct.includes('application/json')) return { status: res.status, json: null };
+  return { status: res.status, json: (await res.json()) as T };
+}
+
+// ── MCP ─────────────────────────────────────────────────────────────
+
+interface ToolCallShape {
+  isError?: boolean;
+  content?: unknown;
+  structuredContent?: unknown;
+}
+
+function textOf(res: ToolCallShape): string | null {
+  if (!Array.isArray(res.content)) return null;
+  for (const item of res.content) {
+    if (
+      item !== null &&
+      typeof item === 'object' &&
+      (item as { type?: unknown }).type === 'text' &&
+      typeof (item as { text?: unknown }).text === 'string'
+    ) {
+      return (item as { text: string }).text;
+    }
+  }
+  return null;
+}
+
+async function connectMcp(cfg: Config): Promise<McpClient> {
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`${cfg.baseUrl}/mcp/${cfg.companyId}`),
+    { requestInit: { headers: { Authorization: `Bearer ${cfg.apiKey}` } } },
+  );
+  const client = new McpClient({ name: 'code-memory-battery', version: '1.0.0' });
+  // Same @modelcontextprotocol/sdk .d.ts self-inconsistency the server
+  // side bridges in src/mcp/mcp.controller.ts: under
+  // exactOptionalPropertyTypes the concrete transport class no longer
+  // structurally satisfies its own Transport interface. The runtime
+  // value genuinely is a valid Transport; this asserts the SDK's own
+  // contract, not our types.
+  await client.connect(transport as Transport);
+  return client;
+}
+
+async function callTool<T>(
+  mcp: McpClient,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const raw = (await withRetry(name, () =>
+    mcp.callTool({ name, arguments: args }),
+  )) as ToolCallShape;
+  const text = textOf(raw);
+  if (raw.isError === true) {
+    throw new Error(`MCP tool ${name} failed: ${text ?? '(no error text)'}`);
+  }
+  if (text !== null) return JSON.parse(text) as T;
+  if (raw.structuredContent !== undefined) return raw.structuredContent as T;
+  throw new Error(`MCP tool ${name} returned neither text nor structuredContent`);
+}
+
+// Local wire shapes — only the fields the scorers consume.
+interface SearchHit {
+  entityId: string;
+  canonicalName?: string;
+  facts?: Array<{ factId: string; predicate: string; object: string }>;
+}
+interface SearchOut {
+  results?: SearchHit[];
+}
+interface SynthOut {
+  answer: string | null;
+  reason?: string;
+}
+interface TimelineOut {
+  events?: Array<{ type: string; at: string; predicate?: string; object?: string }>;
+}
+interface ProvenanceOut {
+  factId?: string;
+  episodes?: Array<{ episodeId?: string; text?: string }>;
+}
+interface PredicatesOut {
+  predicates?: PredicateLike[];
+}
+interface WhyOut {
+  symbol?: string;
+  found?: number;
+  memory?: Array<{ kind?: string; text?: string; status?: string }>;
+}
+
+const asWhyLike = (out: WhyOut): WhyLike => ({
+  found: out.found ?? 0,
+  memory: (out.memory ?? []).map((m) => ({ kind: m.kind ?? '', text: m.text ?? '' })),
+});
+
+// ── phase 0: builtin-predicate read (NO install — builtin by design) ─
+
+async function readTenantPredicates(cfg: Config): Promise<PredicateLike[]> {
+  const res = await restRaw<PredicatesOut>(cfg, 'GET', '/v1/admin/predicates');
+  if (res.status === 401 || res.status === 403) {
+    console.error(
+      `code-memory: GET /v1/admin/predicates -> HTTP ${res.status} — the key lacks ` +
+        'brain:admin. Phase 0 asserts the builtin seeding and cannot be skipped.',
+    );
+    process.exit(1);
+  }
+  if (res.status < 200 || res.status >= 300) {
+    console.error(`code-memory: GET /v1/admin/predicates -> HTTP ${res.status}.`);
+    process.exit(1);
+  }
+  return res.json?.predicates ?? [];
+}
+
+// ── phase 1: write the corpus ───────────────────────────────────────
+
+async function ingestTurns(cfg: Config, brain: HttpBrainClient): Promise<void> {
+  console.error(`[ingest] ${ALL_TURNS.length} mention turns (run ${cfg.runId})…`);
+  for (const [i, turn] of ALL_TURNS.entries()) {
+    // Deliberately NO knownEntities hints: the cross-entity check (k10)
+    // measures whether the path and the symbol phrasing resolve to one
+    // entity WITHOUT being told — hints would rig the measurement.
+    await withRetry(`mention ${turn.conversation}#${turn.turn}`, () =>
+      brain.ingest.mention({
+        text: turn.text,
+        contextRef: {
+          vertical: CORPUS_VERTICAL,
+          conversationId: convId(cfg, turn.conversation),
+          messageId: messageId(cfg, turn.conversation, turn.turn),
+          recorder: 'code-memory-battery',
+        },
+        knownEntities: [],
+        userId: cfg.userId,
+        emittedAt: turn.emittedAt,
+      }),
+    );
+    if ((i + 1) % 10 === 0) console.error(`[ingest] ${i + 1}/${ALL_TURNS.length}`);
+  }
+}
+
+// ── phase 2: execute the checks ─────────────────────────────────────
+
+interface CheckContext {
+  cfg: Config;
+  mcp: McpClient;
+  tools: Set<string>;
+  tenantPredicates: PredicateLike[];
+}
+
+type Verdict2 = Pick<CheckResult, 'status' | 'detail'> & { answer?: string | null };
+
+async function searchHits(ctx: CheckContext, query: string, limit: number): Promise<SearchHit[]> {
+  const out = await callTool<SearchOut>(ctx.mcp, 'search_knowledge', {
+    query,
+    limit,
+    userId: ctx.cfg.userId,
+  });
+  return out.results ?? [];
+}
+
+function runBuiltinVocabCheck(ctx: CheckContext, check: BuiltinVocabCheck): Verdict2 {
+  const verdict = checkBuiltinPredicates(ctx.tenantPredicates, check.requiredPredicates);
+  return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
+}
+
+async function runVocabCheck(ctx: CheckContext, check: PackVocabCheck): Promise<Verdict2> {
+  const hits = await searchHits(ctx, check.searchQuery, 8);
+  if (hits.length === 0) {
+    return { status: 'fail', detail: 'search returned no candidate entities' };
+  }
+  const verdict = findExactPredicateFact(hits as HitLike[], check.predicate, check.valueMarkers);
+  return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
+}
+
+async function runLiteralHarvestCheck(
+  ctx: CheckContext,
+  check: LiteralHarvestCheck,
+): Promise<Verdict2> {
+  const parts: string[] = [];
+  let allPass = true;
+  for (const want of check.wants) {
+    const hits = await searchHits(ctx, want.searchQuery, 8);
+    const verdict = findExactPredicateFact(hits as HitLike[], want.predicate, want.valueMarkers);
+    if (!verdict.pass) allPass = false;
+    parts.push(`${want.predicate}: ${verdict.pass ? 'found' : verdict.detail}`);
+  }
+  return { status: allPass ? 'pass' : 'fail', detail: parts.join(' | ') };
+}
+
+async function runFlagTransitionCheck(
+  ctx: CheckContext,
+  check: FlagTransitionCheck,
+): Promise<Verdict2> {
+  const hits = await searchHits(ctx, check.searchQuery, HISTORY_ENTITY_CAP);
+  if (hits.length === 0) {
+    return { status: 'fail', detail: 'search returned no candidate entities' };
+  }
+  // The two stages may live on the flag entity, the agent entity (the
+  // state-verb lane binds transitions to the state HOLDER) or another
+  // extraction-chosen subject — walk each candidate's timeline and
+  // pass on the first retaining every stage in order; keep the deepest
+  // partial as the fail detail.
+  let best: { matchedStages: number; detail: string } | null = null;
+  for (const hit of hits.slice(0, HISTORY_ENTITY_CAP)) {
+    const timeline = await callTool<TimelineOut>(ctx.mcp, 'get_entity_timeline', {
+      entityId: hit.entityId,
+      userId: ctx.cfg.userId,
+    });
+    const events: HistoryEvent[] = (timeline.events ?? [])
+      .filter((e) => e.type === 'fact.recorded')
+      .map((e) => ({ predicate: e.predicate ?? '', object: e.object ?? '', at: e.at }));
+    const verdict = checkHistorySequence(events, check.stages);
+    if (verdict.pass) {
+      return {
+        status: 'pass',
+        detail: `entity ${hit.canonicalName ?? hit.entityId}: ${verdict.detail}`,
+      };
+    }
+    if (best === null || verdict.matchedStages > best.matchedStages) {
+      best = {
+        matchedStages: verdict.matchedStages,
+        detail: `entity ${hit.canonicalName ?? hit.entityId}: ${verdict.detail}`,
+      };
+    }
+  }
+  return {
+    status: 'fail',
+    detail: `no entity timeline retains the full flag story; deepest: ${best?.detail ?? '(none)'}`,
+  };
+}
+
+async function runSupersessionCheck(
+  ctx: CheckContext,
+  check: SupersessionCheck,
+): Promise<Verdict2> {
+  if (!ctx.tools.has('record_decision')) {
+    return { status: 'skipped', detail: 'record_decision absent (key lacks brain:write?)' };
+  }
+  const symbol = saltedAnchor(ctx.cfg, check.anchor);
+  await callTool(ctx.mcp, 'record_decision', {
+    symbol,
+    kind: 'decided',
+    text: check.oldText,
+  });
+  await sleep(SUPERSESSION_GAP_MS);
+  const cursor = new Date().toISOString();
+  await sleep(SUPERSESSION_GAP_MS);
+  await callTool(ctx.mcp, 'record_decision', {
+    symbol,
+    kind: 'decided',
+    text: check.newText,
+  });
+  const now = asWhyLike(await callTool<WhyOut>(ctx.mcp, 'why', { symbol }));
+  const atAsOf = asWhyLike(await callTool<WhyOut>(ctx.mcp, 'why', { symbol, asOf: cursor }));
+  const verdict = checkSupersession(now, atAsOf, 'decided', check.oldMarkers, check.newMarkers);
+  return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
+}
+
+async function runCrossEntityCheck(ctx: CheckContext, check: CrossEntityCheck): Promise<Verdict2> {
+  const hits = await searchHits(ctx, check.searchQuery, 10);
+  const verdict = checkEntityDedup(hits as HitLike[], check.nameTokens, check.mustCarryGroups);
+  return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
+}
+
+async function runTraceProvenanceCheck(
+  ctx: CheckContext,
+  check: TraceProvenanceCheck,
+): Promise<Verdict2> {
+  if (!ctx.tools.has('get_fact_provenance')) {
+    return { status: 'skipped', detail: 'get_fact_provenance absent (FACTS_API_ENABLED off)' };
+  }
+  const hits = await searchHits(ctx, check.searchQuery, 8);
+  const factIdsPerHit: string[][] = hits.map((hit) => {
+    const ids: string[] = [];
+    for (const fact of hit.facts ?? []) {
+      if (check.objectHint.length > 0) {
+        const text = `${fact.predicate} ${fact.object}`.toLowerCase();
+        if (!check.objectHint.some((h) => text.includes(h.toLowerCase()))) continue;
+      }
+      ids.push(fact.factId);
+    }
+    return ids;
+  });
+  // Round-robin across hits so one fat entity cannot monopolise the
+  // walk budget — sibling interleave.ts.
+  const candidates = interleaveRoundRobin(factIdsPerHit, PROVENANCE_CANDIDATE_CAP);
+  if (candidates.length === 0) {
+    return { status: 'fail', detail: 'search returned no candidate facts' };
+  }
+  for (const factId of candidates) {
+    const prov = await callTool<ProvenanceOut>(ctx.mcp, 'get_fact_provenance', { factId });
+    const match = walkProvenance(prov, check.episodeFragments);
+    if (match !== null) {
+      return {
+        status: 'pass',
+        detail: `fact ${factId} unrolls to episode ${match.episodeId} ("${match.fragment}")`,
+      };
+    }
+  }
+  return {
+    status: 'fail',
+    detail: `${candidates.length} facts walked, no episode quotes the seeded fragment`,
+  };
+}
+
+async function runServeCheck(ctx: CheckContext, check: ServeCheck): Promise<Verdict2> {
+  const out = await callTool<SynthOut>(ctx.mcp, 'synthesize', {
+    query: check.query,
+    limit: 15,
+    synthesisGuardrails: ctx.cfg.guardrails,
+    userId: ctx.cfg.userId,
+  });
+  const verdict = scoreServe(out.answer, out.reason, {
+    expectAnyOf: check.expectAnyOf,
+    forbidAnyOf: check.forbidAnyOf,
+  });
+  return { status: verdict.status, detail: verdict.detail, answer: out.answer };
+}
+
+async function runIntentionGuardCheck(
+  ctx: CheckContext,
+  check: IntentionGuardCheck,
+): Promise<Verdict2> {
+  const hits = await searchHits(ctx, check.searchQuery, 10);
+  const verdict = checkNoForbiddenFact(
+    hits as HitLike[],
+    check.forbidPredicate,
+    check.forbidObjectMarkers,
+  );
+  return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
+}
+
+async function runMcpRoundtripCheck(
+  ctx: CheckContext,
+  check: McpRoundtripCheck,
+): Promise<Verdict2> {
+  if (!ctx.tools.has('record_decision')) {
+    return { status: 'skipped', detail: 'record_decision absent (key lacks brain:write?)' };
+  }
+  const symbol = saltedAnchor(ctx.cfg, check.anchor);
+  await callTool(ctx.mcp, 'record_decision', {
+    symbol,
+    kind: check.recordKind,
+    text: check.text,
+  });
+  const out = asWhyLike(await callTool<WhyOut>(ctx.mcp, 'why', { symbol }));
+  const verdict = checkWhyRoundtrip(out, check.recordKind, check.textMarkers);
+  return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
+}
+
+function runNoRogueToolsCheck(ctx: CheckContext): Verdict2 {
+  const offenders = findNamespacedTools([...ctx.tools]);
+  if (offenders.length === 0) {
+    return {
+      status: 'pass',
+      detail: `tools/list clean: 0 __-namespaced tools among ${ctx.tools.size}`,
+    };
+  }
+  return {
+    status: 'fail',
+    detail: `unexpected pack-namespaced tool(s) exposed: ${offenders.join(', ')}`,
+  };
+}
+
+async function runCheck(ctx: CheckContext, check: Check): Promise<Verdict2> {
+  switch (check.kind) {
+    case 'builtin-vocab':
+      return runBuiltinVocabCheck(ctx, check);
+    case 'pack-vocab':
+      return runVocabCheck(ctx, check);
+    case 'literal-harvest':
+      return runLiteralHarvestCheck(ctx, check);
+    case 'flag-transition':
+      return runFlagTransitionCheck(ctx, check);
+    case 'supersession-asof':
+      return runSupersessionCheck(ctx, check);
+    case 'cross-entity':
+      return runCrossEntityCheck(ctx, check);
+    case 'trace-provenance':
+      return runTraceProvenanceCheck(ctx, check);
+    case 'serve':
+      return runServeCheck(ctx, check);
+    case 'intention-guard':
+      return runIntentionGuardCheck(ctx, check);
+    case 'mcp-roundtrip':
+      return runMcpRoundtripCheck(ctx, check);
+    case 'no-rogue-tools':
+      return runNoRogueToolsCheck(ctx);
+  }
+}
+
+async function runChecks(ctx: CheckContext): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+  for (const check of CHECKS) {
+    const started = Date.now();
+    let verdict: Verdict2;
+    try {
+      verdict = await runCheck(ctx, check);
+    } catch (err) {
+      verdict = { status: 'fail', detail: `runner error: ${String(err)}` };
+    }
+    const latencyMs = Date.now() - started;
+    const result: CheckResult = {
+      id: check.id,
+      kind: check.kind,
+      cls: check.cls,
+      status: verdict.status,
+      detail: verdict.detail,
+      latencyMs,
+      ...(verdict.answer !== undefined ? { answer: verdict.answer } : {}),
+      ...(check.expectedUnknown !== undefined ? { expectedUnknown: check.expectedUnknown } : {}),
+    };
+    results.push(result);
+    const note =
+      verdict.status === 'fail' && check.expectedUnknown !== undefined
+        ? ' (gap-gated finding)'
+        : '';
+    console.error(
+      `[check] ${check.id} (${check.kind}) ${verdict.status}${note} ` +
+        `${latencyMs}ms — ${verdict.detail}`,
+    );
+  }
+  return results;
+}
+
+// ── scorecard ───────────────────────────────────────────────────────
+
+const emptyTally = (): Tally => ({ pass: 0, fail: 0, skipped: 0 });
+
+function buildScorecard(
+  cfg: Config,
+  startedAt: string,
+  setup: Record<string, string>,
+  results: CheckResult[],
+): Scorecard {
+  const classes: Record<string, Tally> = {};
+  const checkKinds: Record<CheckKind, Tally> = {
+    'builtin-vocab': emptyTally(),
+    'pack-vocab': emptyTally(),
+    'literal-harvest': emptyTally(),
+    'flag-transition': emptyTally(),
+    'supersession-asof': emptyTally(),
+    'cross-entity': emptyTally(),
+    'trace-provenance': emptyTally(),
+    serve: emptyTally(),
+    'intention-guard': emptyTally(),
+    'mcp-roundtrip': emptyTally(),
+    'no-rogue-tools': emptyTally(),
+  };
+  const checks = { pass: 0, fail: 0, skipped: 0, total: 0, failedExpectedUnknown: 0 };
+  for (const r of results) {
+    const cls = (classes[r.cls] ??= emptyTally());
+    cls[r.status] += 1;
+    checkKinds[r.kind][r.status] += 1;
+    checks[r.status] += 1;
+    checks.total += 1;
+    if (r.status === 'fail' && r.expectedUnknown !== undefined) {
+      checks.failedExpectedUnknown += 1;
+    }
+  }
+  return {
+    runId: cfg.runId,
+    baseUrl: cfg.baseUrl,
+    companyId: cfg.companyId,
+    userId: cfg.userId,
+    guardrails: cfg.guardrails,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    setup,
+    ingest: { mentionTurns: cfg.skipIngest ? 0 : ALL_TURNS.length },
+    classes,
+    checkKinds,
+    checks,
+    gapGatedChecks: CHECKS.filter((c) => c.expectedUnknown !== undefined).map((c) => c.id),
+    results,
+  };
+}
+
+function printScorecard(card: Scorecard): void {
+  console.log('');
+  console.log(`code-memory scorecard — run ${card.runId} (guardrails=${card.guardrails})`);
+  console.log('─'.repeat(72));
+  for (const [cls, tally] of Object.entries(card.classes)) {
+    console.log(
+      `${cls.padEnd(22)} checks: pass ${tally.pass}  fail ${tally.fail}` +
+        (tally.skipped > 0 ? `  skipped ${tally.skipped}` : ''),
+    );
+  }
+  console.log('─'.repeat(72));
+  const scored = card.checks.pass + card.checks.fail;
+  const pct = scored === 0 ? 0 : Math.round((card.checks.pass / scored) * 1000) / 10;
+  console.log(
+    `checks: ${card.checks.pass}/${scored} scored (${pct}%), ` +
+      `${card.checks.skipped} skipped of ${card.checks.total}` +
+      (card.checks.failedExpectedUnknown > 0
+        ? ` — ${card.checks.failedExpectedUnknown} fail(s) are gap-gated findings, not regressions`
+        : ''),
+  );
+  console.log(
+    `gap-gated (expectedUnknown): ${card.gapGatedChecks.join(', ')} — a fail there is ` +
+      'the recorded gap; a pass is the measured signal the parallel PR landed.',
+  );
+}
+
+// ── main ────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  const startedAt = new Date().toISOString();
+  console.error(`code-memory: run ${cfg.runId} against ${cfg.baseUrl} (tenant ${cfg.companyId})`);
+
+  // Phase 0: read the tenant predicate registry. NO pack install — the
+  // pack is builtin (seeded at bootstrap; install rejects the id), and
+  // k01 scores the seeding itself.
+  const tenantPredicates = await readTenantPredicates(cfg);
+  const present = Object.values(CM).filter((id) =>
+    tenantPredicates.some((p) => p.predicateId === id),
+  ).length;
+  const setup: Record<string, string> = {
+    code_memory:
+      `builtin — no install performed (install rejects builtin ids by design); ` +
+      `${present}/${Object.values(CM).length} namespaced predicates visible in ` +
+      `${tenantPredicates.length} registry rows`,
+  };
+  console.error(`[setup] ${setup['code_memory']}`);
+
+  const brain = new HttpBrainClient({ baseUrl: cfg.baseUrl, apiKey: cfg.apiKey });
+  const mcp = await connectMcp(cfg);
+  try {
+    const toolList = await withRetry('tools/list', () => mcp.listTools());
+    const tools = new Set(toolList.tools.map((t) => t.name));
+    console.error(`[mcp] connected, ${tools.size} tools visible`);
+
+    if (!cfg.skipIngest) {
+      await ingestTurns(cfg, brain);
+    }
+
+    const results = await runChecks({ cfg, mcp, tools, tenantPredicates });
+    const card = buildScorecard(cfg, startedAt, setup, results);
+
+    mkdirSync(cfg.reportDir, { recursive: true });
+    const reportPath = join(cfg.reportDir, `code-memory-${cfg.runId}.json`);
+    writeFileSync(reportPath, `${JSON.stringify(card, null, 2)}\n`);
+    printScorecard(card);
+    console.log(`report: ${reportPath}`);
+  } finally {
+    await mcp.close();
+  }
+}
+
+void main().catch((err: unknown) => {
+  console.error('code-memory: runner failed:', err);
+  process.exitCode = 1;
+});

--- a/test/eval/code-memory/scorers.ts
+++ b/test/eval/code-memory/scorers.ts
@@ -1,0 +1,235 @@
+/**
+ * Mechanical scorers of the code-memory battery. Pure functions over
+ * plain JSON — no HTTP, no LLM judge — unit-tested on fixtures in
+ * test/code-memory-scorers.unit-spec.ts, so every verdict is
+ * reproducible from the report file.
+ *
+ * Generic primitives are REUSED from the sibling harnesses — one
+ * implementation, one unit-tested truth: containsAnyOf / isAbstention /
+ * walkProvenance from test/eval/memory-fitness/scorers.ts;
+ * checkHistorySequence and scoreServe from
+ * test/eval/state-transitions/scorers.ts; findExactPredicateFact and
+ * findNamespacedTools from test/eval/domain-packs/scorers.ts. This
+ * file adds only what the code-memory claims need: the builtin-seed
+ * matcher, the forbidden-transition scan (intention guard), the
+ * path-vs-symbol entity dedup, and the `why` roundtrip/supersession
+ * verdicts.
+ */
+import { containsAnyOf } from '../memory-fitness/scorers';
+import type { HitLike } from '../domain-packs/scorers';
+
+export interface Verdict {
+  pass: boolean;
+  detail: string;
+}
+
+// ── builtin-seed matcher ────────────────────────────────────────────
+
+/** The predicate fields the matcher consumes (subset of the
+ *  GET /v1/admin/predicates row — src/contracts/admin/predicates.schema.ts). */
+export interface PredicateLike {
+  predicateId: string;
+  status: string;
+}
+
+/**
+ * Every required namespaced predicate is present AND active in the
+ * tenant's registry — with the builtin pack this must hold WITHOUT
+ * any install (bootstrap seeding is the surface under test).
+ */
+export function checkBuiltinPredicates(
+  predicates: readonly PredicateLike[],
+  required: readonly string[],
+): Verdict {
+  const byId = new Map(predicates.map((p) => [p.predicateId, p.status]));
+  const missing: string[] = [];
+  const inactive: string[] = [];
+  for (const id of required) {
+    const status = byId.get(id);
+    if (status === undefined) missing.push(id);
+    else if (status !== 'active') inactive.push(`${id} (${status})`);
+  }
+  if (missing.length > 0 || inactive.length > 0) {
+    return {
+      pass: false,
+      detail:
+        `builtin seeding incomplete — missing: [${missing.join(', ')}], ` +
+        `non-active: [${inactive.join(', ')}] of ${predicates.length} registry rows`,
+    };
+  }
+  return {
+    pass: true,
+    detail: `all ${required.length} builtin predicates active without install`,
+  };
+}
+
+// ── forbidden-transition scan (intention guard) ─────────────────────
+
+/**
+ * Intention-guard verdict: NO fact across the hits may carry the
+ * forbidden predicate with an object matching a marker — a voiced
+ * plan ("we should probably enable X") that produced a completed
+ * `state_change` is the exact failure the pre-verb guards exist to
+ * prevent. Pass is the ABSENCE; a fail names the offending fact.
+ */
+export function checkNoForbiddenFact(
+  hits: readonly HitLike[],
+  predicate: string,
+  objectMarkers: readonly string[],
+): Verdict {
+  let scanned = 0;
+  for (const hit of hits) {
+    for (const fact of hit.facts ?? []) {
+      scanned += 1;
+      if (fact.predicate !== predicate) continue;
+      if (!containsAnyOf(fact.object, objectMarkers)) continue;
+      return {
+        pass: false,
+        detail:
+          `voiced plan flipped state: fact ${fact.factId} on ` +
+          `"${hit.canonicalName ?? hit.entityId}" carries ${predicate}="${fact.object}"`,
+      };
+    }
+  }
+  return {
+    pass: true,
+    detail: `no ${predicate} fact matches [${objectMarkers.join('|')}] across ${scanned} facts scanned`,
+  };
+}
+
+// ── path-vs-symbol entity dedup ─────────────────────────────────────
+
+/**
+ * Cross-phrasing entity check:
+ *  1. exactly ONE hit's canonicalName matches a module name token
+ *     (2+ = the path phrasing and the symbol phrasing split into
+ *     separate entities — the failure being measured);
+ *  2. that one hit carries ≥1 fact per marker group, each group
+ *     seeded by a DIFFERENT phrasing's turn.
+ * The detail always carries per-group counts, so a fail is
+ * diagnosable from the report alone.
+ */
+export function checkEntityDedup(
+  hits: readonly HitLike[],
+  nameTokens: readonly string[],
+  mustCarryGroups: ReadonlyArray<readonly string[]>,
+): Verdict {
+  const named = hits.filter((h) => containsAnyOf(h.canonicalName ?? '', nameTokens));
+  if (named.length === 0) {
+    return {
+      pass: false,
+      detail: `no hit named ~[${nameTokens.join('|')}] among ${hits.length} results`,
+    };
+  }
+  if (named.length > 1) {
+    const names = named.map((h) => `"${h.canonicalName ?? h.entityId}"`).join(', ');
+    return {
+      pass: false,
+      detail: `module split across ${named.length} entities: ${names}`,
+    };
+  }
+  const top = named[0];
+  if (top === undefined) return { pass: false, detail: 'unreachable: no named hit' };
+  const facts = top.facts ?? [];
+  const counts: number[] = mustCarryGroups.map(
+    (group) => facts.filter((f) => containsAnyOf(`${f.predicate} ${f.object}`, group)).length,
+  );
+  const summary = counts.map((n, i) => `[${(mustCarryGroups[i] ?? []).join('|')}]=${n}`).join(', ');
+  if (counts.every((n) => n > 0)) {
+    return {
+      pass: true,
+      detail:
+        `one entity "${top.canonicalName ?? top.entityId}" carries both phrasings: ` +
+        `${summary} of ${facts.length} facts`,
+    };
+  }
+  return {
+    pass: false,
+    detail:
+      `entity "${top.canonicalName ?? top.entityId}" misses a phrasing's facts: ` +
+      `${summary} of ${facts.length} facts`,
+  };
+}
+
+// ── `why` verdicts (roundtrip + supersession) ───────────────────────
+
+/** The `why` tool output fields the verdicts consume. */
+export interface WhyLike {
+  found: number;
+  memory: Array<{ kind: string; text: string }>;
+}
+
+/** record_decision → why roundtrip: ≥1 memory entry of the recorded
+ *  kind whose text matches a marker. */
+export function checkWhyRoundtrip(
+  out: WhyLike,
+  kind: string,
+  textMarkers: readonly string[],
+): Verdict {
+  if (out.found === 0 || out.memory.length === 0) {
+    return { pass: false, detail: 'why returned found:0 — the write did not round-trip' };
+  }
+  const hit = out.memory.find((m) => m.kind === kind && containsAnyOf(m.text, textMarkers));
+  if (hit !== undefined) {
+    return { pass: true, detail: `why serves ${kind}="${hit.text}"` };
+  }
+  const kinds = out.memory.map((m) => `${m.kind}="${m.text}"`).join('; ');
+  return {
+    pass: false,
+    detail: `no ${kind} entry matches [${textMarkers.join('|')}]; memory: ${kinds}`,
+  };
+}
+
+/**
+ * Supersession verdict over two `why` reads of ONE anchor:
+ *  - NOW: exactly one entry of the kind is active, it matches the NEW
+ *    text and not the old one (two active = single_active broken;
+ *    old text active = supersession did not happen);
+ *  - asOf (a cursor between the two writes): the OLD text is
+ *    recallable and the NEW one is not known yet (bitemporal).
+ */
+export function checkSupersession(
+  now: WhyLike,
+  atAsOf: WhyLike,
+  kind: string,
+  oldMarkers: readonly string[],
+  newMarkers: readonly string[],
+): Verdict {
+  const nowKind = now.memory.filter((m) => m.kind === kind);
+  if (nowKind.length !== 1) {
+    return {
+      pass: false,
+      detail:
+        `expected exactly 1 active ${kind} now, got ${nowKind.length}: ` +
+        nowKind.map((m) => `"${m.text}"`).join('; '),
+    };
+  }
+  const active = nowKind[0];
+  if (active === undefined) return { pass: false, detail: 'unreachable: no active entry' };
+  if (!containsAnyOf(active.text, newMarkers)) {
+    return { pass: false, detail: `active ${kind} is not the new decision: "${active.text}"` };
+  }
+  if (containsAnyOf(active.text, oldMarkers)) {
+    return { pass: false, detail: `active ${kind} still carries the old value: "${active.text}"` };
+  }
+  const oldAtAsOf = atAsOf.memory.find((m) => m.kind === kind && containsAnyOf(m.text, oldMarkers));
+  if (oldAtAsOf === undefined) {
+    return {
+      pass: false,
+      detail: `the superseded ${kind} is unrecoverable at asOf (found ${atAsOf.found})`,
+    };
+  }
+  const newAtAsOf = atAsOf.memory.find((m) => m.kind === kind && containsAnyOf(m.text, newMarkers));
+  if (newAtAsOf !== undefined) {
+    return {
+      pass: false,
+      detail: `asOf leaks the FUTURE decision: "${newAtAsOf.text}" was not known at the cursor`,
+    };
+  }
+  return {
+    pass: true,
+    detail:
+      `one active ${kind} ("${active.text}"), old one recallable at asOf ` +
+      `("${oldAtAsOf.text}") and the new one unknown there — supersession holds`,
+  };
+}

--- a/test/eval/code-memory/types.ts
+++ b/test/eval/code-memory/types.ts
@@ -1,0 +1,227 @@
+/**
+ * Shared shapes of the code-memory battery — the fourth mechanical
+ * sibling of test/eval/memory-fitness (general first-person memory
+ * fitness), test/eval/state-transitions (mutable world-state) and
+ * test/eval/domain-packs (installed industry packs). This battery
+ * isolates ONE claim: **a coding agent's turns about its own repo
+ * become recallable, current, provenance-clean code memory** — with
+ * the BUILTIN `code_memory` pack, which is never installed (bootstrap
+ * seeds its predicates into every tenant), so the battery also asserts
+ * the builtin seeding path itself.
+ *
+ * Every check is mechanical — no LLM judge (see scorers.ts).
+ */
+
+/** One mention turn the runner writes into memory. */
+export interface CorpusTurn {
+  /** Conversation key (`decision`…) — the runner prefixes it with the run id. */
+  conversation: string;
+  /** 1-based position inside the conversation (drives the messageId). */
+  turn: number;
+  /** ISO 8601 emission timestamp — the temporal anchor of the turn. */
+  emittedAt: string;
+  /** Verbatim turn text. Kept under the 600-char provenance cap. */
+  text: string;
+}
+
+interface BaseCheck {
+  /** Stable key (`k01-builtin-vocab`…) used in the report. */
+  id: string;
+  /** Check class — the scorecard groups by this. */
+  cls: string;
+  /** What the check asserts and what would falsify it. */
+  intent: string;
+  /**
+   * Honest-baseline annotation (the domain-pack battery's
+   * `expectedUnknown` pattern): the outcome depends on work that has
+   * not landed (the pack 0.4.0 ontology increment, the coding-verb
+   * state-verb lexicon reaching the stand, an extractionProfile for
+   * code_memory) or has simply never been measured. The runner still
+   * EXECUTES the check — a fail is recorded as a finding and tallied
+   * separately (`failedExpectedUnknown`), never forced green; the run
+   * where it passes is the measured signal that the gap closed.
+   */
+  expectedUnknown?: string;
+}
+
+/** `builtin-vocab` — the builtin pack's namespaced predicates are
+ *  active in the tenant WITHOUT any install (bootstrap seeding). */
+export interface BuiltinVocabCheck extends BaseCheck {
+  kind: 'builtin-vocab';
+  /** Namespaced predicate ids that must be listed as active. */
+  requiredPredicates: string[];
+}
+
+/** `pack-vocab` — a searched fact's predicate is the EXACT namespaced
+ *  code_memory predicate (same shape as the domain-pack battery's
+ *  check). For predicates arriving with pack 0.4.0 the corpus computes
+ *  the gap annotation from the live manifest, so the check flips to a
+ *  plain assertion the moment the ontology increment lands. */
+export interface PackVocabCheck extends BaseCheck {
+  kind: 'pack-vocab';
+  searchQuery: string;
+  /** The exact namespaced predicate id (`code_memory__decided`…). */
+  predicate: string;
+  /** The fact's object must contain ≥1 of these (case-insensitive). */
+  valueMarkers: string[];
+}
+
+/** `literal-harvest` — the deterministic literal lane produces its
+ *  CORE facts (identifier / service_port / rate_limit) from
+ *  identifier-heavy coding prose. Every want must be found. */
+export interface LiteralHarvestCheck extends BaseCheck {
+  kind: 'literal-harvest';
+  wants: Array<{
+    searchQuery: string;
+    /** Exact core predicate id (`service_port`…). */
+    predicate: string;
+    valueMarkers: string[];
+  }>;
+}
+
+/** `flag-transition` — the flag's 0→1 story is retained as ordered
+ *  history on ONE entity's timeline (the state-transitions battery's
+ *  checkHistorySequence, reused verbatim). */
+export interface FlagTransitionCheck extends BaseCheck {
+  kind: 'flag-transition';
+  searchQuery: string;
+  /** Ordered stages; each stage is an anyOf marker group. */
+  stages: string[][];
+}
+
+/** `supersession-asof` — MCP record_decision re-record on one anchor:
+ *  `why` now shows exactly ONE active decision (the new one), and
+ *  `why` at an asOf between the two writes still recalls the OLD one
+ *  (bitemporal supersession, the single_active law). */
+export interface SupersessionCheck extends BaseCheck {
+  kind: 'supersession-asof';
+  /** Anchor symbol — the runner salts it with the run id. */
+  anchor: string;
+  oldText: string;
+  newText: string;
+  oldMarkers: string[];
+  newMarkers: string[];
+}
+
+/** `cross-entity` — the module referenced by file path AND by symbol
+ *  name resolves to ONE entity carrying facts from both phrasings. */
+export interface CrossEntityCheck extends BaseCheck {
+  kind: 'cross-entity';
+  searchQuery: string;
+  /** A hit belongs to the module when its canonicalName contains ≥1. */
+  nameTokens: string[];
+  /** Each group is an anyOf set seeded by a DIFFERENT phrasing's turn;
+   *  the single entity must carry ≥1 fact per group. */
+  mustCarryGroups: string[][];
+}
+
+/** `trace-provenance` — a code fact unrolls via get_fact_provenance to
+ *  an episode quoting the seeded turn verbatim (memory-fitness
+ *  walkProvenance + round-robin candidate interleave). */
+export interface TraceProvenanceCheck extends BaseCheck {
+  kind: 'trace-provenance';
+  searchQuery: string;
+  /** Prefer facts whose object contains ≥1 of these, else any fact. */
+  objectHint: string[];
+  /** Case-insensitive fragments seeded verbatim in exactly one turn. */
+  episodeFragments: string[];
+}
+
+/** `serve` — synthesize answers a serving question with the current
+ *  value and without the forbidden (stale/foreign) markers (the
+ *  state-transitions scoreServe, reused verbatim). */
+export interface ServeCheck extends BaseCheck {
+  kind: 'serve';
+  query: string;
+  expectAnyOf: string[];
+  forbidAnyOf: string[];
+}
+
+/** `intention-guard` — the voiced-plan turns ("we should probably
+ *  enable X", "we haven't enabled X") must NOT have produced a
+ *  completed state transition anywhere. */
+export interface IntentionGuardCheck extends BaseCheck {
+  kind: 'intention-guard';
+  searchQuery: string;
+  /** The forbidden fact: this exact predicate… */
+  forbidPredicate: string;
+  /** …with an object matching ≥1 of these markers. */
+  forbidObjectMarkers: string[];
+}
+
+/** `mcp-roundtrip` — record_decision → why on a fresh anchor
+ *  round-trips (found>0, right kind, verbatim text). */
+export interface McpRoundtripCheck extends BaseCheck {
+  kind: 'mcp-roundtrip';
+  /** Anchor symbol — the runner salts it with the run id. */
+  anchor: string;
+  recordKind: string;
+  text: string;
+  textMarkers: string[];
+}
+
+/** `no-rogue-tools` — tools/list carries ZERO `__`-namespaced pack
+ *  tools: the code-memory tools (`why` / `recall_decisions` /
+ *  `record_decision`) are core-hardcoded single-underscore names, and
+ *  no pack declares mcpTools today (domain-pack battery law). */
+export interface NoRogueToolsCheck extends BaseCheck {
+  kind: 'no-rogue-tools';
+}
+
+export type Check =
+  | BuiltinVocabCheck
+  | PackVocabCheck
+  | LiteralHarvestCheck
+  | FlagTransitionCheck
+  | SupersessionCheck
+  | CrossEntityCheck
+  | TraceProvenanceCheck
+  | ServeCheck
+  | IntentionGuardCheck
+  | McpRoundtripCheck
+  | NoRogueToolsCheck;
+export type CheckKind = Check['kind'];
+
+export type CheckStatus = 'pass' | 'fail' | 'skipped';
+
+export interface CheckResult {
+  id: string;
+  kind: CheckKind;
+  cls: string;
+  status: CheckStatus;
+  detail: string;
+  latencyMs: number;
+  /** Raw served answer, when the check was answer-shaped. */
+  answer?: string | null;
+  /** Carried through from the check: gap-gated finding, not regression. */
+  expectedUnknown?: string;
+}
+
+export interface Tally {
+  pass: number;
+  fail: number;
+  skipped: number;
+}
+
+export interface Scorecard {
+  runId: string;
+  baseUrl: string;
+  companyId: string;
+  userId: string;
+  guardrails: string;
+  startedAt: string;
+  finishedAt: string;
+  /** Phase-0 trail (builtin predicate presence — no install happens;
+   *  the builtin id is REJECTED by the install path by design). */
+  setup: Record<string, string>;
+  ingest: { mentionTurns: number };
+  /** Per-check-class tally. */
+  classes: Record<string, Tally>;
+  /** Per-check-kind tally. */
+  checkKinds: Record<CheckKind, Tally>;
+  checks: Tally & { total: number; failedExpectedUnknown: number };
+  /** The ids of gap-gated checks (expectedUnknown), pass or fail — so
+   *  the report states its own honesty policy. */
+  gapGatedChecks: string[];
+  results: CheckResult[];
+}


### PR DESCRIPTION
## What

`test/eval/code-memory/` — the fourth mechanical eval battery (sibling of memory-fitness / state-transitions / domain-packs), isolating the dogfood claim: **a coding agent's turns about its own repo become recallable, current, provenance-clean code memory.** PR-F of the code-memory audit fix list. New script: `pnpm eval:code-memory`.

Modeled closely on the domain-packs battery (`CMEV_` env knobs mirroring `DPEV_`, MCP tool transport, run-id-salted conversations *and* MCP anchors, 429 backoff, honest JSON scorecard to `var/code-memory/`) — with two deliberate differences:

- **No install phase.** `code_memory` is BUILTIN: bootstrap seeds its predicates into every tenant and the install path rejects the builtin id by design. Phase 0 reads `GET /v1/admin/predicates` and check k01 asserts the four namespaced predicates are active — the absence of an install step is itself under test.
- **Findings-first by construction** — half the checks measure audit-ranked gaps and are gap-gated (below).

## Corpus (20 turns, fictional repo "acme-api")

| conversation | seeds |
| --- | --- |
| `decision` | dispatch decision + rationale, invariant (zod schemas), gotcha (dry-run takes the schema lock), then a SUPERSEDING decision |
| `flags` | `ACME_RETRY_QUEUE` introduced dark (default 0), literal-lane prose (port 9187, 120 req/min), the SYMBOL phrasing of the shared module, then the flag enabled (default 1) |
| `deps` | `redis-client` pinned 1.2.0 → bumped 2.0.0, ownership (Priya owns src/gateway), a gotcha bound to the new version |
| `mixed` | PR #212 merged then REVERTED, two voiced-plan turns about `ACME_STRICT_MODE` that must NOT flip state, a postmortem line |

One module — `src/gateway/webhook-dispatcher.ts` aka `WebhookDispatcher` — is referenced by PATH in one conversation and by SYMBOL in another; the runner passes **no `knownEntities` hints**, so entity identity is measured, not rigged.

## Checks (k01..k16)

| id | kind | gap-gated |
| --- | --- | --- |
| k01 | builtin predicates seeded without install | |
| k02-k04 | pack-vocab: decided / invariant / gotcha | yes — no extractionProfile today (pack 0.3.0 PR) |
| k05-k06 | pack-vocab: `default_value` / `depends_on_version` | yes — arrive with pack 0.4.0 |
| k07 | literal-harvest fit (identifier / service_port / rate_limit in coding prose) | |
| k08 | flag 0→1 transition as ordered history | yes — needs the coding-verb lexicon (#437) + holder binding routes the flip to the agent |
| k09 | MCP supersession: one active `decided` now, old one recallable at `asOf`, future not leaked | |
| k10 | path-vs-symbol cross-entity dedup | |
| k11 | trace-provenance: decision fact unrolls to the seeded episode verbatim | |
| k12 | serve: "current default of ACME_RETRY_QUEUE" (north-star) | yes — no typed `default_value` home until 0.4.0 |
| k13 | serve: "who owns src/gateway" | yes — no typed `owns` home until 0.4.0 |
| k14 | intention-guard negative: voiced plans never produce a `state_change` — must stay green before AND after #437 | |
| k15 | `record_decision` → `why` MCP roundtrip | |
| k16 | no-rogue-tools (zero `__`-namespaced tools) | |

(`superseded_by` from 0.4.0 is exercised mechanically by k09's single_active semantics rather than a vocab check.)

## Honesty policy (never hardcode green)

The domain-packs `expectedUnknown` pattern, extended: 8 checks are gap-gated on unlanded work; the runner **executes them anyway**, records the exact failure shape (e.g. which coined predicates swallowed each value), tallies their fails separately (`failedExpectedUnknown`) and prints the gap-gated id list in the scorecard. The 0.4.0 gates are **computed from the live manifest** (`gap040` in corpus.ts): while a predicate is undeclared the annotation says the check cannot pass yet; the moment the ontology increment merges, it self-softens to "never measured" with no edit here. A unit test pins the invariant that a check on an undeclared predicate is always gated.

## Cost / CI

No LLM judge, no paid eval — the battery runs against a live stand via `BRAIN_BASE_URL`/`BRAIN_API_KEY` at eval time and never runs in CI (clear exit message when unset). The CI-facing surface is the scorer unit spec `test/code-memory-scorers.unit-spec.ts` (28 tests) plus corpus-integrity invariants (verbatim provenance fragments, 600-char cap, no old-value restatement, unique numeric markers, unique ids, the honesty-policy invariant).

## Tests

Scorer unit spec green; full unit suite 350 suites / 3815 tests green; `pnpm typecheck`, `pnpm format:check`, eslint on the new files all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
