### PR TITLE
feat(packs): builtin memoryModel visibility — reader unions BUILTIN_PACKS declarations

### DIFF
--- a/src/ai/memory-model-reader.service.ts
+++ b/src/ai/memory-model-reader.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { SurrealService, queryRows } from '../db/surreal.service';
 import { LRUCache } from '../common/lru-cache';
 import {
+  BUILTIN_PACKS,
   validateMemoryModel,
   DomainPackError,
   type DomainPackManifest,
@@ -19,14 +20,21 @@ const DEFAULT_TTL_MS = 30_000;
 const CACHE_CAP = 200;
 
 /**
- * Read side of pack-declared memory models: which active packs declare a
- * memoryModel section for this tenant (PackToolsReaderService mold —
- * LRU+TTL cache with in-flight dedupe). Contract-only for now: the
- * perception/episodization consumers arrive in sibling increments and
- * will sit on hot paths, hence the cache from day one. Fail-open to []
- * on read errors — a domain_pack hiccup must not take down a consumer;
- * models reappear on the next load. NO consent gate by design: a
- * memoryModel is declarative data with zero egress (see the decision
+ * Read side of pack-declared memory models: the BUILTIN_PACKS' declared
+ * memoryModels (globally seeded, in-process manifests) unioned with the
+ * active installed packs' declarations for this tenant
+ * (PackToolsReaderService mold — LRU+TTL cache with in-flight dedupe).
+ * The builtin leg mirrors PackEvalService.resolveManifest and the
+ * extraction-profile assembly in PredicateRegistryService.loadFresh:
+ * builtins never pass through install (DomainPackInstallService rejects
+ * their ids), so without this union a builtin's memoryModel would be
+ * invisible to every consumer. Builtins are static for the process
+ * lifetime, so their bindings are assembled once and merged AFTER the
+ * per-tenant cache read — the cache keeps holding exactly the DB-derived
+ * bindings it held before. Fail-open on read errors degrades to
+ * builtins-only — a domain_pack hiccup must not take down a consumer;
+ * installed models reappear on the next load. NO consent gate by design:
+ * a memoryModel is declarative data with zero egress (see the decision
  * note in DomainPackInstallService).
  */
 @Injectable()
@@ -37,10 +45,35 @@ export class MemoryModelReaderService {
     { bindings: PackMemoryModelBinding[]; loadedAt: number }
   >(CACHE_CAP);
   private readonly inFlight = new Map<string, Promise<PackMemoryModelBinding[]>>();
+  /** Lazily assembled once — BUILTIN_PACKS is a module constant. */
+  private builtins?: PackMemoryModelBinding[];
 
   constructor(private readonly surreal: SurrealService) {}
 
   async installedMemoryModels(companyId: string): Promise<PackMemoryModelBinding[]> {
+    const builtins = this.builtinBindings();
+    const stored = await this.storedMemoryModels(companyId);
+    // Fast path — with no builtin declaring a memoryModel (the state of the
+    // world while code_memory declares none) this returns the stored array
+    // untouched: byte-identical to the pre-union behavior.
+    if (builtins.length === 0) return stored;
+    // Precedence: an installed row with a builtin's packId is impossible by
+    // construction (DomainPackInstallService rejects builtin ids at install),
+    // so a duplicate here means a corrupted or hand-written row — the
+    // in-process builtin wins and the row is skipped, loudly.
+    const builtinIds = new Set(builtins.map((b) => b.packId));
+    const deduped = stored.filter((b) => {
+      if (!builtinIds.has(b.packId)) return true;
+      this.logger.warn(
+        `pack ${b.packId}: stored domain_pack row shadows a builtin pack id — skipped (builtin manifest wins)`,
+      );
+      return false;
+    });
+    return [...builtins, ...deduped];
+  }
+
+  /** The per-tenant leg: active domain_pack rows, cached + deduped. */
+  private async storedMemoryModels(companyId: string): Promise<PackMemoryModelBinding[]> {
     const cached = this.cache.get(companyId);
     if (cached && Date.now() - cached.loadedAt < ttlMs()) {
       return cached.bindings;
@@ -54,13 +87,36 @@ export class MemoryModelReaderService {
       })
       .catch((e) => {
         this.logger.warn(
-          `memory model load failed for ${companyId} (${(e as Error).message}) — serving no pack memory models`,
+          `memory model load failed for ${companyId} (${(e as Error).message}) — serving builtin pack memory models only`,
         );
         return [] as PackMemoryModelBinding[];
       })
       .finally(() => this.inFlight.delete(companyId));
     this.inFlight.set(companyId, load);
     return load;
+  }
+
+  /**
+   * The builtin leg: BUILTIN_PACKS manifests → validated bindings, via the
+   * SAME defensive toBinding path stored rows go through. Redundant with the
+   * module-load validation (assembleSeed runs validatePack on every builtin,
+   * failing the boot on a bad manifest) but kept for consistency: nothing
+   * reaches a consumer half-checked, whatever its source.
+   */
+  private builtinBindings(): PackMemoryModelBinding[] {
+    if (this.builtins) return this.builtins;
+    const bindings: PackMemoryModelBinding[] = [];
+    for (const pack of this.builtinSource()) {
+      const binding = this.toBinding({ packId: pack.id, version: pack.version, manifest: pack });
+      if (binding) bindings.push(binding);
+    }
+    this.builtins = bindings;
+    return bindings;
+  }
+
+  /** Static in-process manifest source — an overridable seam for tests. */
+  protected builtinSource(): DomainPackManifest[] {
+    return BUILTIN_PACKS;
   }
 
   /** Called by DomainPackInstallService next to registry.invalidate. */
@@ -86,10 +142,11 @@ export class MemoryModelReaderService {
   }
 
   /**
-   * Row → binding, defensively: the stored section must still pass
+   * Row → binding, defensively: the section must still pass
    * validateMemoryModel — a manifest written by an older/newer server
    * version never reaches a consumer half-checked (PackToolsReaderService
-   * toBinding mold).
+   * toBinding mold). Serves both legs: stored domain_pack rows and the
+   * builtin manifests (shaped into the same row form).
    */
   private toBinding(row: Record<string, unknown>): PackMemoryModelBinding | null {
     const manifest = row.manifest as DomainPackManifest | undefined;
@@ -101,7 +158,7 @@ export class MemoryModelReaderService {
     } catch (e) {
       if (e instanceof DomainPackError) {
         this.logger.warn(
-          `pack ${row.packId}: stored memoryModel failed validation (${e.message}) — skipped`,
+          `pack ${row.packId}: memoryModel failed validation (${e.message}) — skipped`,
         );
         return null;
       }

--- a/test/pack-memory-model.unit-spec.ts
+++ b/test/pack-memory-model.unit-spec.ts
@@ -7,6 +7,7 @@
  */
 import { generateKeyPairSync } from 'node:crypto';
 import {
+  BUILTIN_PACKS,
   diffPackUpgrade,
   packChecksum,
   signPack,
@@ -442,7 +443,14 @@ describe('memoryModel — checksum, signature, upgrade diff', () => {
 
 type Row = { packId: string; version: string; manifest: DomainPackManifest };
 
-function readerWith(rows: () => Promise<Row[]>): {
+/** Reader over a fake DB. `builtins` overrides the builtin manifest source
+ *  (default: none) so these tests stay insulated from what the REAL
+ *  BUILTIN_PACKS declare — code_memory growing a memoryModel must not
+ *  ripple through unrelated expectations here. */
+function readerWith(
+  rows: () => Promise<Row[]>,
+  builtins: DomainPackManifest[] = [],
+): {
   reader: MemoryModelReaderService;
   calls: () => number;
 } {
@@ -456,7 +464,12 @@ function readerWith(rows: () => Promise<Row[]>): {
   const surreal = {
     withCompany: (_companyId: string, fn: (db: unknown) => unknown) => fn(fakeDb),
   } as unknown as SurrealService;
-  return { reader: new MemoryModelReaderService(surreal), calls: () => calls };
+  class TestReader extends MemoryModelReaderService {
+    protected override builtinSource(): DomainPackManifest[] {
+      return builtins;
+    }
+  }
+  return { reader: new TestReader(surreal), calls: () => calls };
 }
 
 describe('MemoryModelReaderService', () => {
@@ -500,5 +513,100 @@ describe('MemoryModelReaderService', () => {
       throw new Error('db down');
     });
     await expect(reader.installedMemoryModels('co3')).resolves.toEqual([]);
+  });
+});
+
+// ── builtin union (PackEvalService.resolveManifest mold) ────────────
+
+describe('MemoryModelReaderService — builtin memoryModel union', () => {
+  const builtinWithMm = (): DomainPackManifest =>
+    manifest({ id: 'fake_builtin', version: '3.0.0', memoryModel: memoryModel() });
+  const builtinWithoutMm = (): DomainPackManifest =>
+    manifest({ id: 'fake_builtin', version: '3.0.0' });
+  const installedRow = (): Row => ({
+    packId: 'realty',
+    version: '1.0.0',
+    manifest: withMm(memoryModel()),
+  });
+
+  it('unions a builtin declaration ahead of installed rows', async () => {
+    const { reader } = readerWith(async () => [installedRow()], [builtinWithMm()]);
+    const bindings = await reader.installedMemoryModels('co1');
+    expect(bindings.map((b) => b.packId)).toEqual(['fake_builtin', 'realty']);
+    expect(bindings[0]).toMatchObject({ packId: 'fake_builtin', packVersion: '3.0.0' });
+    expect(bindings[0]?.memoryModel.attentionHints?.[0]?.cue).toBe('asking price');
+  });
+
+  it('a builtin declaring NO memoryModel contributes nothing — stored result unchanged', async () => {
+    // The live no-op proof: same rows, with and without the memoryModel-less
+    // builtin in the source, produce identical bindings.
+    const { reader: withBuiltin } = readerWith(async () => [installedRow()], [builtinWithoutMm()]);
+    const { reader: without } = readerWith(async () => [installedRow()]);
+    const a = await withBuiltin.installedMemoryModels('co1');
+    const b = await without.installedMemoryModels('co1');
+    expect(a).toEqual(b);
+    expect(a.map((x) => x.packId)).toEqual(['realty']);
+    // And with no installed packs either: empty stays empty.
+    const { reader: empty } = readerWith(async () => [], [builtinWithoutMm()]);
+    await expect(empty.installedMemoryModels('co2')).resolves.toEqual([]);
+  });
+
+  it('degrades to builtins-only when the domain_pack read fails', async () => {
+    const { reader } = readerWith(async () => {
+      throw new Error('db down');
+    }, [builtinWithMm()]);
+    const bindings = await reader.installedMemoryModels('co3');
+    expect(bindings.map((b) => b.packId)).toEqual(['fake_builtin']);
+  });
+
+  it('skips a stored row that shadows a builtin pack id — the in-process manifest wins', async () => {
+    // Impossible by construction (install rejects builtin ids), so a shadow
+    // row is corruption; assert the builtin's version is the one served.
+    const shadow: Row = {
+      packId: 'fake_builtin',
+      version: '9.9.9',
+      manifest: manifest({ id: 'fake_builtin', version: '9.9.9', memoryModel: memoryModel() }),
+    };
+    const { reader } = readerWith(async () => [shadow, installedRow()], [builtinWithMm()]);
+    const bindings = await reader.installedMemoryModels('co4');
+    expect(bindings.map((b) => b.packId)).toEqual(['fake_builtin', 'realty']);
+    expect(bindings[0]?.packVersion).toBe('3.0.0');
+  });
+
+  it('merges builtins OUTSIDE the per-tenant cache: one DB read, invalidate untouched', async () => {
+    const { reader, calls } = readerWith(async () => [installedRow()], [builtinWithMm()]);
+    await reader.installedMemoryModels('co5');
+    const second = await reader.installedMemoryModels('co5');
+    expect(calls()).toBe(1); // stored leg served from cache; builtins static
+    expect(second.map((b) => b.packId)).toEqual(['fake_builtin', 'realty']);
+    reader.invalidate('co5');
+    await reader.installedMemoryModels('co5');
+    expect(calls()).toBe(2);
+  });
+
+  it('defensively skips a builtin whose memoryModel fails validation', async () => {
+    const corrupted = manifest({
+      id: 'fake_builtin',
+      memoryModel: { attentionHints: [{ cue: 'x{{evil}}' }] } as PackMemoryModel,
+    });
+    const { reader } = readerWith(async () => [installedRow()], [corrupted]);
+    const bindings = await reader.installedMemoryModels('co6');
+    expect(bindings.map((b) => b.packId)).toEqual(['realty']);
+  });
+
+  it('with the REAL builtin source, serves exactly the builtins that declare a memoryModel', async () => {
+    // Dynamic expectation so this stays true as builtins evolve (e.g.
+    // code_memory shipping a memoryModel makes it appear here).
+    const surreal = {
+      withCompany: (_companyId: string, fn: (db: unknown) => unknown) =>
+        fn({ query: async () => [[]] }),
+    } as unknown as SurrealService;
+    const reader = new MemoryModelReaderService(surreal);
+    const bindings = await reader.installedMemoryModels('co7');
+    const declared = BUILTIN_PACKS.filter((p) => p.memoryModel !== undefined);
+    expect(bindings.map((b) => b.packId)).toEqual(declared.map((p) => p.id));
+    for (const [i, p] of declared.entries()) {
+      expect(bindings[i]).toMatchObject({ packId: p.id, packVersion: p.version });
+    }
   });
 });


### PR DESCRIPTION
## Problem

All ~5 live memoryModel consumers read through `MemoryModelReaderService` — the fovea L3 attention-hint boost (`src/synthesize/l3-escalation.service.ts`), the scene and state-delta candidate projections (`src/documents/external-candidates.service.ts`), and (via manifests) the raw-evidence gate and processor broker. The reader queried ONLY the tenant `domain_pack` table (`src/ai/memory-model-reader.service.ts` `loadFresh`), while `DomainPackInstallService` rejects installing a builtin pack id. So a builtin pack's `memoryModel` could never be seen by any consumer: builtins have no `domain_pack` row and can never get one.

## Fix

`installedMemoryModels` now unions the validated `memoryModel` declarations of `BUILTIN_PACKS` ahead of the installed-pack rows — the same builtin-manifest resolution pattern `PackEvalService.resolveManifest` and the extraction-profile assembly in `PredicateRegistryService.loadFresh` already use.

- **Static merge, cache untouched.** Builtins are constant for the process lifetime: their bindings are assembled once, lazily, and merged AFTER the per-tenant LRU+TTL cache read. The cache keeps holding exactly the DB-derived bindings it held before; TTL, in-flight dedupe, and `invalidate` are unchanged.
- **Same validation path.** Builtin manifests go through the same defensive `toBinding`/`validateMemoryModel` path stored rows do (redundant with the boot-time `assembleSeed` validation, kept for consistency — nothing reaches a consumer half-checked).
- **Precedence.** An installed row carrying a builtin's pack id is impossible by construction (install rejects builtin ids); if one ever appears it is treated as corruption — skipped with a warning, the in-process manifest wins.
- **Fail-open improves.** A `domain_pack` read failure now degrades to builtins-only instead of `[]` (mirrors the "builtins-only" degradation the extraction-profile reader already has).

## Live no-op today

No builtin declares a `memoryModel` on main (code_memory declares none), so the union is empty and behavior is byte-identical. Proven in the spec: same rows with and without a memoryModel-less builtin in the source produce identical bindings, for tenants with installed packs and with none.

## Tests

- Reader tests insulated from real `BUILTIN_PACKS` content via an overridable `builtinSource()` seam (so a future builtin declaration doesn't ripple through unrelated expectations).
- New cases: union order, builtin-declares-nothing no-op, builtins-only degradation on DB failure, shadow-row dedupe, cache behavior (one DB read, invalidate), invalid-builtin skip, and one dynamic-expectation case against the real builtin source that stays green as builtins evolve.
- `pnpm typecheck`, `pnpm format:check`, full `pnpm test:unit` (349 suites / 3794 tests) green locally.

Unblocks the sibling PR that gives code_memory an actual `memoryModel` (pack 0.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
