### PR TITLE
feat(packs): code_memory 0.4.0 — extractionProfile, ontology, memoryModel, eval fixtures

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -151,7 +151,12 @@ pack (seeded into every tenant, like `code_memory`) is a code change:
 
 `code_memory` (`src/ai/domain-packs/code-memory.pack.ts`) — the non-derivable
 engineering "why" of a codebase: `decided`, `because`, `invariant`, `gotcha`,
-anchored to code anchors. See `docs/roadmap/code-memory-domain.md`.
+plus (0.4.0) `owns`, `default_value`, `depends_on_version`, `superseded_by`,
+anchored to code anchors. Ships a self-scoping `extractionProfile` (a builtin
+profile reaches every tenant's prompt, so it fences itself to software-work
+inputs), eval fixtures, and a `memoryModel` (flag/dependency/change
+lifecycles, attention + retention hints, a recency rule for default-value
+claims). See `docs/roadmap/code-memory-domain.md`.
 
 ## Distribution + integrity
 
@@ -302,7 +307,8 @@ to look, never WHAT is true. The contract is validated, stored, cached,
 exposed read-only on the admin surface, and read by five live core
 consumers (listed below). No first-party pack in `packs/` declares a
 `memoryModel` section yet — the contract and its consumers are ahead of
-the catalogue.
+the catalogue; the builtin `code_memory` pack declares one as of 0.4.0
+(the reference declaration).
 
 The semantic plane has five optional arrays. The Evidence Plane adds
 three declarative capabilities. A present section must declare at least

--- a/src/ai/domain-packs/code-memory.pack.ts
+++ b/src/ai/domain-packs/code-memory.pack.ts
@@ -11,9 +11,9 @@ import { composePredicateId, type DomainPackManifest } from './manifest';
  */
 export const CODE_MEMORY_PACK: DomainPackManifest = {
   id: 'code_memory',
-  version: '0.2.0',
+  version: '0.4.0',
   description:
-    'Non-derivable engineering "why" of a codebase — decisions, rationale, invariants, gotchas anchored to code.',
+    'Non-derivable engineering "why" of a codebase — decisions, rationale, invariants, gotchas, ownership, flag/config defaults, dependency pins, and decision supersession anchored to code, with a domain extraction profile and memory model.',
   // Retro-declaration, documentation-true: code-memory has ALWAYS been an
   // external indexer — its capture pipeline runs where the code lives
   // (raw source never leaves the machine) and posts typed facts. No
@@ -72,12 +72,239 @@ VALUE  one gotcha per fact (multi-valued)`,
       piiClass: 'none',
       status: 'active',
     },
+    // ── 0.4.0 ontology increment (dogfood gaps: ownership, flag/config
+    //    defaults, dependency pins, decision supersession) ─────────────
+    {
+      localId: 'owns',
+      displayLabel: 'owned by',
+      description: `TYPE   subject is a code anchor (module/service/area); value is the owner
+ADMIT  text assigns ownership or responsibility for the subject to a
+       person or team ("mikefluff owns src/fovea", "the platform team
+       owns the ingest service")
+VALUE  the owning person/team, verbatim ("mikefluff", "platform team")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'default_value',
+      displayLabel: 'default value',
+      description: `TYPE   subject is a flag/config identifier entity; value is its current default
+ADMIT  text states the current default of a feature flag, env var, or
+       config setting ("EXTRACTOR_LITERAL_HARVEST defaults to 0",
+       "the timeout default is 10000"). Revisioned: a new default
+       supersedes the old one; history is retained
+NOT FOR the value a caller passes at one call-site — only the DEFAULT
+VALUE  the default value, verbatim ("0", "1", "10000")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'depends_on_version',
+      displayLabel: 'depends on version',
+      description: `TYPE   subject is a dependency (library/service/tool) entity; value is
+       the version currently pinned or in use
+ADMIT  text states the version a dependency is pinned at or running
+       ("prod SurrealDB is 3.2.4", "bumped jest to 30"). Revisioned:
+       a bump supersedes the old pin; history is retained
+VALUE  the version, verbatim ("3.2.4", "30")`,
+      datatype: 'string',
+      semantics: 'single_active',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+    {
+      localId: 'superseded_by',
+      displayLabel: 'superseded by',
+      description: `TYPE   subject is a code anchor whose earlier decision was replaced;
+       value names what replaced it
+ADMIT  text states that a decision/approach for this code location was
+       superseded, replaced, or abandoned in favour of another ("the
+       opt-out was replaced by the always-on integrity gate")
+VALUE  the superseding decision statement, one per fact (multi-valued —
+       the supersession trail is history, never silently overwritten)`,
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'none',
+      status: 'active',
+    },
+  ],
+  // CAUTION: code_memory is a BUILTIN — this profile is injected into EVERY
+  // tenant's extraction prompt (predicate-registry loadFresh assembles builtin
+  // profiles unconditionally). It is therefore SELF-SCOPING: the first lines
+  // fence it to software-work inputs and tell the extractor to contribute
+  // nothing anywhere else.
+  extractionProfile: {
+    guidance: `Apply this profile ONLY when the input discusses software work —
+code, repositories, modules, services, feature flags, env vars, deploys,
+dependencies, or engineering decisions. For any other domain this profile
+contributes NOTHING. When it applies: identifier-shaped subjects become their
+OWN entities — an ALL_CAPS flag or env var ("EXTRACTOR_LITERAL_HARVEST"), a
+file or module path ("src/ingest/fact-resolver.service.ts"), a dotted symbol
+or package name is the SUBJECT of its facts, NEVER the speaker who mentions
+it. Prefer the code_memory__* predicates for the engineering "why":
+decisions (code_memory__decided), their rationale (code_memory__because),
+constraints (code_memory__invariant), pitfalls (code_memory__gotcha),
+module/service ownership (code_memory__owns), the current default of a
+flag/config (code_memory__default_value), pinned dependency versions
+(code_memory__depends_on_version), and decision supersession
+(code_memory__superseded_by). Copy identifiers, paths, versions, and values
+VERBATIM — "3.2.4" not "the current version", "EXTRACTOR_LITERAL_HARVEST"
+not "the harvest flag".`,
+    fewShot: [
+      {
+        text: 'We decided to resolve all facts through one gateway in src/ingest/fact-resolver.service.ts because 21 positional args drifted between call-sites.',
+        note: "code anchor 'src/ingest/fact-resolver.service.ts' → code_memory__decided='resolve all facts through one gateway', code_memory__because='21 positional args drifted between call-sites'.",
+      },
+      {
+        text: 'EXTRACTOR_LITERAL_HARVEST defaults to 0 in production.',
+        note: "flag entity 'EXTRACTOR_LITERAL_HARVEST' (the identifier is the SUBJECT, not the speaker) → code_memory__default_value='0'.",
+      },
+      {
+        text: 'Prod SurrealDB is pinned at 3.2.4, and mikefluff owns src/fovea.',
+        note: "dependency 'SurrealDB' → code_memory__depends_on_version='3.2.4'; module 'src/fovea' → code_memory__owns='mikefluff'.",
+      },
+      {
+        text: 'Our decision to cache answers per request in src/answers/cache.ts was superseded by caching per tenant.',
+        note: "code anchor 'src/answers/cache.ts' → code_memory__superseded_by='caching per tenant' (the old decided fact stays in history).",
+      },
+    ],
+  },
+  // The domain perception contract (docs/domain-packs.md). Declarative data
+  // only; consumable once the memory-model reader unions builtin manifests.
+  // Text-only — no modalities/processors/rawEvidence, so no consent surface.
+  memoryModel: {
+    sceneSchemas: [
+      {
+        id: 'change_session',
+        description:
+          'A focused engineering change: a flag flip, dependency bump, merge, revert, deploy, or rollback discussed or performed.',
+        cues: ['merged', 'reverted', 'deployed', 'rolled back', 'flipped', 'bumped'],
+      },
+    ],
+    stateModels: [
+      {
+        id: 'flag_lifecycle',
+        subjectType: 'feature_flag',
+        states: ['declared', 'enabled', 'deprecated', 'removed'],
+        transitions: [
+          { from: 'declared', to: 'enabled' },
+          { from: 'enabled', to: 'deprecated' },
+          { from: 'enabled', to: 'removed' },
+          { from: 'deprecated', to: 'removed' },
+        ],
+      },
+      {
+        id: 'dependency_lifecycle',
+        subjectType: 'dependency',
+        states: ['added', 'bumped', 'removed'],
+        transitions: [
+          { from: 'added', to: 'bumped' },
+          { from: 'bumped', to: 'bumped' },
+          { from: 'added', to: 'removed' },
+          { from: 'bumped', to: 'removed' },
+        ],
+      },
+      {
+        id: 'change_lifecycle',
+        subjectType: 'change',
+        states: ['proposed', 'merged', 'reverted'],
+        transitions: [
+          { from: 'proposed', to: 'merged' },
+          { from: 'merged', to: 'reverted' },
+          { from: 'reverted', to: 'merged' },
+        ],
+      },
+    ],
+    attentionHints: [
+      { cue: 'gotcha', prefer: ['gotcha'], zoom: ['facts', 'episodes'], weight: 0.7 },
+      { cue: 'invariant', prefer: ['invariant'], zoom: ['facts'], weight: 0.7 },
+      { cue: 'default', prefer: ['default_value'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'flag', prefer: ['default_value', 'gotcha'], zoom: ['facts'], weight: 0.5 },
+      {
+        cue: 'because',
+        prefer: ['because', 'decided'],
+        zoom: ['facts', 'episodes'],
+        weight: 0.6,
+      },
+      { cue: 'who owns', prefer: ['owns'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'version', prefer: ['depends_on_version'], zoom: ['facts'], weight: 0.5 },
+    ],
+    // The dogfood north-star claim class: "what is the current default of X"
+    // must not serve stale — a default_value claim deserves a recency check.
+    verificationRules: [{ claimPattern: 'default', requires: 'recency_check' }],
+    retentionHints: [
+      { predicateOrScene: 'decided', hint: 'durable' },
+      { predicateOrScene: 'invariant', hint: 'durable' },
+      { predicateOrScene: 'gotcha', hint: 'durable' },
+      { predicateOrScene: 'superseded_by', hint: 'durable' },
+      { predicateOrScene: 'because', hint: 'standard' },
+      { predicateOrScene: 'owns', hint: 'standard' },
+      { predicateOrScene: 'default_value', hint: 'standard' },
+      { predicateOrScene: 'depends_on_version', hint: 'standard' },
+      { predicateOrScene: 'change_session', hint: 'standard' },
+    ],
+  },
+  // Scored by POST /v1/admin/packs/code_memory/eval (resolves the builtin
+  // manifest in-process) — one fixture per new predicate + the classic
+  // decision/rationale and gotcha shapes.
+  evalFixtures: [
+    {
+      id: 'decision_rationale',
+      description: 'a decision and its rationale are extracted onto the code anchor',
+      text: 'We decided to resolve all facts through one gateway in src/ingest/fact-resolver.service.ts because 21 positional args drifted between call-sites.',
+      expect: {
+        facts: [
+          { predicate: 'decided', objectIncludes: 'gateway' },
+          { predicate: 'because', objectIncludes: 'drifted' },
+        ],
+      },
+    },
+    {
+      id: 'gotcha',
+      description: 'a pitfall warning is captured',
+      text: 'Gotcha: pnpm test -- --testPathPattern does not work in this repo; use --testPathPatterns.',
+      expect: { facts: [{ predicate: 'gotcha', objectIncludes: 'testPathPattern' }] },
+    },
+    {
+      id: 'flag_default',
+      description: 'the current default of a feature flag is captured on the flag entity',
+      text: 'The feature flag EXTRACTOR_LITERAL_HARVEST defaults to 0.',
+      expect: { facts: [{ predicate: 'default_value', objectIncludes: '0' }] },
+    },
+    {
+      id: 'dependency_version',
+      description: 'a pinned dependency version is captured verbatim',
+      text: 'Production SurrealDB is pinned at 3.2.4.',
+      expect: { facts: [{ predicate: 'depends_on_version', objectIncludes: '3.2.4' }] },
+    },
+    {
+      id: 'ownership',
+      description: 'module ownership is captured',
+      text: 'mikefluff owns the src/fovea module.',
+      expect: { facts: [{ predicate: 'owns', objectIncludes: 'mikefluff' }] },
+    },
+    {
+      id: 'supersession',
+      description: 'a decision supersession link is captured',
+      text: 'Our decision to cache answers per request in src/answers/cache.ts was superseded by caching per tenant.',
+      expect: { facts: [{ predicate: 'superseded_by', objectIncludes: 'per tenant' }] },
+    },
   ],
 };
 
 /** The pack-local kinds, in author order. The ergonomic surface for the MCP
  *  `record_decision` tool + the capture pipeline (callers pass `decided`, not
- *  the namespaced id). */
+ *  the namespaced id). Deliberately the decision-journal SUBSET of the pack's
+ *  predicates: the 0.4.0 additions (owns/default_value/depends_on_version/
+ *  superseded_by) arrive via the extraction path, not `record_decision`. */
 export const CODE_MEMORY_KINDS = ['decided', 'because', 'invariant', 'gotcha'] as const;
 export type CodeMemoryKind = (typeof CODE_MEMORY_KINDS)[number];
 

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -373,4 +373,72 @@ describe('code-memory pack', () => {
     // core predicates still present
     expect(ids).toContain('name');
   });
+
+  // ── 0.4.0: extractionProfile + ontology increment + memoryModel ────
+  it('seeds the 0.4.0 ontology increment alongside the original four kinds', () => {
+    const ids = SEED_PREDICATES.map((p) => p.predicateId);
+    for (const local of ['owns', 'default_value', 'depends_on_version', 'superseded_by']) {
+      expect(ids).toContain(`code_memory__${local}`);
+    }
+    // The original decision-journal kinds are untouched.
+    for (const local of ['decided', 'because', 'invariant', 'gotcha']) {
+      expect(ids).toContain(`code_memory__${local}`);
+    }
+  });
+
+  it('revisioned vs trail semantics: defaults/pins/ownership supersede, supersession appends', () => {
+    const byLocal = new Map(CODE_MEMORY_PACK.predicates.map((p) => [p.localId, p]));
+    expect(byLocal.get('default_value')?.semantics).toBe('single_active');
+    expect(byLocal.get('depends_on_version')?.semantics).toBe('single_active');
+    expect(byLocal.get('owns')?.semantics).toBe('single_active');
+    expect(byLocal.get('superseded_by')?.semantics).toBe('append_only');
+    // The originals keep the semantics they shipped with.
+    expect(byLocal.get('decided')?.semantics).toBe('single_active');
+    expect(byLocal.get('because')?.semantics).toBe('append_only');
+    expect(byLocal.get('invariant')?.semantics).toBe('single_active');
+    expect(byLocal.get('gotcha')?.semantics).toBe('append_only');
+  });
+
+  it('ships a SELF-SCOPING extractionProfile (builtin = injected into every tenant)', () => {
+    const profile = CODE_MEMORY_PACK.extractionProfile;
+    expect(profile?.guidance).toContain('ONLY when the input discusses software work');
+    expect(profile?.guidance).toContain('contributes NOTHING');
+    // Identifier-shaped subjects become their own entities, never the speaker.
+    expect(profile?.guidance).toContain('NEVER the speaker');
+    expect(profile?.fewShot?.length ?? 0).toBeGreaterThanOrEqual(3);
+  });
+
+  it('declares the perception contract: three lifecycles, hints, one recency rule', () => {
+    const mm = CODE_MEMORY_PACK.memoryModel;
+    expect(mm?.stateModels?.map((m) => m.id).sort()).toEqual([
+      'change_lifecycle',
+      'dependency_lifecycle',
+      'flag_lifecycle',
+    ]);
+    const flag = mm?.stateModels?.find((m) => m.id === 'flag_lifecycle');
+    expect(flag?.states).toEqual(['declared', 'enabled', 'deprecated', 'removed']);
+    expect(mm?.attentionHints?.length ?? 0).toBeGreaterThanOrEqual(5);
+    expect(mm?.verificationRules).toEqual([{ claimPattern: 'default', requires: 'recency_check' }]);
+    expect(mm?.retentionHints?.some((h) => h.predicateOrScene === 'gotcha')).toBe(true);
+    // Text-only: no consent-tier declarations.
+    expect(mm?.modalities).toBeUndefined();
+    expect(mm?.processors).toBeUndefined();
+    expect(mm?.rawEvidence).toBeUndefined();
+  });
+
+  it('eval fixtures cover every 0.4.0 predicate and resolve against declared localIds', () => {
+    const locals = new Set(CODE_MEMORY_PACK.predicates.map((p) => p.localId));
+    const fixtures = CODE_MEMORY_PACK.evalFixtures ?? [];
+    expect(fixtures.length).toBeGreaterThanOrEqual(4);
+    const asserted = new Set<string>();
+    for (const f of fixtures) {
+      for (const want of f.expect.facts ?? []) {
+        expect(locals.has(want.predicate)).toBe(true);
+        asserted.add(want.predicate);
+      }
+    }
+    for (const local of ['owns', 'default_value', 'depends_on_version', 'superseded_by']) {
+      expect(asserted.has(local)).toBe(true);
+    }
+  });
 });

--- a/test/external-candidates.e2e-spec.ts
+++ b/test/external-candidates.e2e-spec.ts
@@ -7,6 +7,7 @@
  * run-ledger 409 on duplicate submission, and the settled commit.
  */
 import { AppFixture, createApp } from './app-fixture';
+import { CODE_MEMORY_PACK } from '../src/ai/domain-packs';
 
 describe('external candidates (e2e)', () => {
   let f: AppFixture;
@@ -130,8 +131,9 @@ describe('external candidates (e2e)', () => {
       .set(auth())
       .send(submission()); // no packVersion in the body
     expect(r.status).toBe(201);
-    // The response echoes the resolved installed version…
-    expect(r.body.packVersion).toBe('0.2.0');
+    // The response echoes the resolved installed version (the builtin
+    // manifest's — referenced, not hardcoded, so version bumps don't drift).
+    expect(r.body.packVersion).toBe(CODE_MEMORY_PACK.version);
 
     // …and the PERSISTED candidate provenance must match it, not the '0'
     // fallback the omitted-packVersion path used to stamp.
@@ -146,7 +148,7 @@ describe('external candidates (e2e)', () => {
       return ((rows as Array<{ v: unknown }>) ?? []).map((x) => String(x.v));
     });
     expect(versions.length).toBeGreaterThan(0);
-    for (const v of versions) expect(v).toBe('0.2.0');
+    for (const v of versions) expect(v).toBe(CODE_MEMORY_PACK.version);
   });
 
   it('rejects predicates outside the indexer namespace', async () => {


### PR DESCRIPTION
Completes the builtin code_memory pack against the pack standard it is supposed to reference: it was the only pack without an `extractionProfile`, shipped no `evalFixtures` for the already-live `POST /v1/admin/packs/code_memory/eval` surface, declared no `memoryModel`, and its ontology (frozen since 0.1.0) could not represent flag defaults, dependency pins, ownership, or decision supersession. Bump 0.2.0 → 0.4.0. Manifest content only — no reader, extractor, or consumer code changes.

## 1. extractionProfile — self-scoping by design

A builtin profile is injected into EVERY tenant's extraction prompt (`PredicateRegistryService.loadFresh` assembles builtin profiles unconditionally), so the guidance opens by fencing itself: apply ONLY when the input discusses software work; contribute NOTHING elsewhere. It teaches the extractor that identifier-shaped subjects — ALL_CAPS flags/env vars, file/module paths, dotted symbols — become their OWN entities (the identifier is the SUBJECT, never the speaker), addressing the literal-harvest mis-binding where "I flipped EXTRACTOR_LITERAL_HARVEST to on" attached the identifier to the agent. Shape mirrors the fintech/medical profiles (guidance + 4 fewShot).

## 2. Ontology increment (namespaced `code_memory__`)

| predicate | semantics | represents |
| --- | --- | --- |
| `owns` | single_active | module/service ownership (subject = the code anchor, value = owner) |
| `default_value` | single_active | current default of a flag/config — revisioned: a new default supersedes, history retained |
| `depends_on_version` | single_active | dependency pinned at a version (subject = the dependency entity) |
| `superseded_by` | append_only | decision supersession trail — never silently overwritten |

`decided`/`because`/`invariant`/`gotcha` are untouched. `CODE_MEMORY_KINDS` deliberately stays the decision-journal subset (the `record_decision` MCP surface); the new predicates arrive via the extraction path.

## 3. memoryModel — the #381 perception contract (text-only, no consent surface)

- **stateModels**: `flag_lifecycle` (declared→enabled→deprecated→removed), `dependency_lifecycle` (added→bumped→removed, self-transition for repeated bumps), `change_lifecycle` (proposed→merged→reverted, reverted→merged for re-lands).
- **sceneSchemas**: one `change_session` schema (cues: merged/reverted/deployed/rolled back/flipped/bumped) — state-delta candidates must ride a scene, so without at least one schema the stateModels would be structurally unstageable.
- **attentionHints**: cues `gotcha`/`invariant`/`default`/`flag`/`because`/`who owns`/`version` preferring the pack's own predicates, zooming facts/episodes.
- **retentionHints**: durable for the why-facts (decided/invariant/gotcha/superseded_by), standard for operational facts (because/owns/default_value/depends_on_version) and the scene.
- **verificationRules**: one recency rule — `default_value`-class claims (`claimPattern: "default"`) deserve a `recency_check` before serving; the dogfood north-star question ("what is the current default of X") must not serve stale.
- No `modalities`/`processors`/`rawEvidence` — text-only stays consent-free.

Everything validates against `validateMemoryModel` (referential fences, anti-DSL, caps) via `validatePack`, which `assembleSeed` runs at module load — an invalid manifest fails the boot.

## 4. evalFixtures

6 fixtures — one per new predicate plus the classic decision+rationale and gotcha shapes. `POST /v1/admin/packs/code_memory/eval` already resolves builtin manifests in-process (`PackEvalService.resolveManifest`), so this endpoint goes from empty-report to scoring 6 cases. Fixtures run only on that operator-triggered endpoint (paid extractor calls) — never in CI.

## Relationship to the reader-union PR

Merges independently (manifest content alone), but the `memoryModel` only becomes VISIBLE to consumers once the sibling reader-union PR (`MemoryModelReaderService` unions `BUILTIN_PACKS`) is merged.

## What changes live at deploy (current prod enablement, deploy-brain.yml)

Honest accounting, assuming both PRs merged:

- **Default-on, not flag-gated**: the 4 new predicate cards seed into every tenant's closed vocabulary at bootstrap, and the extractionProfile joins every tenant's extraction prompt (this is exactly how the builtin-profile plumbing is designed to work; the profile is self-scoping). These are the two real behavior changes at deploy.
- **`FOVEA_ATTENTION_HINTS=1` (ON in prod)**: the attentionHints go live — queries containing the cues get a tie-break-only boost toward `code_memory__*` anchors in L3 escalation (ordering-only; can never add/drop/filter an anchor).
- **`PACK_MEMORY_PROJECTIONS_ENABLED=1` (ON in prod)**: scene/state_delta staging becomes structurally possible for code_memory through the external-candidates API, but nothing exercises it yet — the capture pipeline posts `/v1/ingest/fact` and never stages candidates. Armed, dormant.
- **Raw-evidence gate / processor broker**: no `rawEvidence`/`processors` declared — no change.
- **verificationRules / retentionHints / stateModels**: declarative; no consumer acts on them for this pack today beyond the projection fences above.
- `EXTRACTOR_STATE_VERB_HARVEST=1` landed in the prod enablement block via #436 while this PR was in flight — orthogonal to this PR (that lane emits core `state_change` facts; the pack's stateModels are declarative vocabulary, not a harvest trigger).

Test fallout fixed here: `test/external-candidates.e2e-spec.ts` hardcoded the builtin's version (`'0.2.0'`) in its provenance-stamp assertions — now references `CODE_MEMORY_PACK.version`. Docs: the reference-pack section and the "no pack declares a memoryModel" note in `docs/domain-packs.md` are brought up to date.

## Tests

- `test/domain-pack.unit-spec.ts`: 0.4.0 seed coverage, semantics matrix (revisioned vs trail), self-scoping profile assertions, perception-contract shape, fixture↔predicate parity.
- `pnpm typecheck`, `pnpm format:check`, `pnpm lint:ci`, `pnpm build`, full `pnpm test:unit` (349 suites / 3792 tests), socket suite — all green locally.
- Pack-related e2e (domain-pack-install, code-memory, code-memory-eval, code-memory-anchor, pack-memory-projections, real-estate-pack, external-candidates, indexer-work — 53 tests) green locally against an ephemeral SurrealDB 3.2.4 container.
- Combined with the reader-union branch (local merge): full unit 3799 tests + the same e2e set all green — the two PRs are safe in either merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
