### PR TITLE
feat(facts): mention-path conflict formation — competing pairs for extracted contradictions

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1137,6 +1137,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       "Direct-fact conflict semantics. When on, the typed direct ingest path (record_fact / POST /v1/ingest/fact) promotes an unknown-predicate fact — one that resolves to the registry '__default__' append_only fallback — to 'bitemporal', so two direct writes on the same (entity, predicate) slot with contradicting objects form a conflict (close-scored → COMPETING for get_competing_facts, clear winner → SUPERSEDED) instead of both landing INSERTED forever. Mention-extracted bulk and the DEFAULT_FALLBACK policy itself are untouched; known predicates keep their registry semantics. Off (default) = append_only passthrough, byte-identical.",
   },
+  {
+    key: 'CONFLICT_MENTION_FACT_SLOT',
+    category: 'conflict',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Mention-path conflict semantics. When on, a mention/extraction-path fact whose registry policy is 'single_active' — the branch that supersedes unconditionally and can never surface a COMPETING pair — is promoted to 'bitemporal', so two conversations asserting contradictory values of one (userId, entity, predicate) slot form a conflict (close-scored → COMPETING, both sides linked and served; clear winner → SUPERSEDED; equal value from a different origin → CORROBORATED) instead of the second silently replacing the first. Candidates stay per-user scope-local (0055). The append_only open-vocabulary bulk, DEFAULT_FALLBACK, and the direct typed path are untouched. Off (default) = registry passthrough, byte-identical.",
+  },
   // ── ABAC (migrations 0056/0057) ──────────────────────────
   {
     key: 'ABAC_ENABLED',

--- a/src/common/conflict-flags.ts
+++ b/src/common/conflict-flags.ts
@@ -28,3 +28,35 @@ import { envFlagEnabled } from './env-validation';
 export function conflictDirectFactSlotEnabled(): boolean {
   return envFlagEnabled(process.env.CONFLICT_DIRECT_FACT_SLOT);
 }
+
+/**
+ * Mention-path conflict semantics — CONFLICT_MENTION_FACT_SLOT.
+ *
+ * The mention/extraction path resolves a canonicalized predicate to its
+ * registry policy; for a single-value slot that policy is
+ * 'single_active', whose resolver branch supersedes UNCONDITIONALLY
+ * (0085 `$supersede = $semantics = 'single_active' OR …`) and can never
+ * surface a COMPETING pair. Two conversations asserting contradictory
+ * values of one (userId, entity, predicate) slot therefore never form a
+ * conflict — the second assertion silently replaces the first and
+ * serving picks one side (state-transitions s07).
+ *
+ * When on, FactResolverService promotes JUST that combination — mention
+ * path (no recordOutcomeMetric) AND registry semantics 'single_active'
+ * — to 'bitemporal': the SAME conflict-slot doctrine the direct path
+ * uses (close-scored contradictions become COMPETING, both linked; a
+ * clear winner still SUPERSEDES; an equal value from a different origin
+ * CORROBORATES — the fn's exact `object = $object` check, no fuzzier
+ * matching). Candidates stay scope-local (0055: fn::resolve_fact
+ * filters by $user_id), so different users never collide. The
+ * append_only bulk and DEFAULT_FALLBACK are untouched (load-bearing for
+ * open-vocabulary mention extraction), as is the direct typed path. The
+ * env read lives here in the common layer (engine-gates S5.2), read at
+ * call time so a flip is runtime-mutable. Default off ⇒ registry
+ * passthrough, byte-identical. CONFLICT_ sits off the ENGINE flag
+ * budget by design (a resolver-policy knob family — cfg
+ * weights/thresholds — not an engine fork).
+ */
+export function conflictMentionFactSlotEnabled(): boolean {
+  return envFlagEnabled(process.env.CONFLICT_MENTION_FACT_SLOT);
+}

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1407,6 +1407,14 @@ const KNOWN_BOOLEAN_FLAGS = [
   // sits off the ENGINE flag budget by design (resolver-policy knob
   // family, not an engine fork).
   'CONFLICT_DIRECT_FACT_SLOT',
+  // Mention-path sibling: the extraction path promotes a 'single_active'
+  // registry policy (whose resolver branch supersedes unconditionally
+  // and can never form a COMPETING pair) to 'bitemporal' in
+  // FactResolverService, so contradictory slot values from two
+  // conversations COMPETE instead of the second silently replacing the
+  // first. append_only bulk / DEFAULT_FALLBACK / direct path untouched.
+  // Off (default) ⇒ registry passthrough, byte-identical.
+  'CONFLICT_MENTION_FACT_SLOT',
 ];
 
 /**

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -7,7 +7,10 @@ import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { DEFAULT_FALLBACK } from '../ai/predicate-registry-internals/types';
 import { detectLanguage } from '../ai/locale/language-detector';
 import { envFlagEnabled } from '../common/env-validation';
-import { conflictDirectFactSlotEnabled } from '../common/conflict-flags';
+import {
+  conflictDirectFactSlotEnabled,
+  conflictMentionFactSlotEnabled,
+} from '../common/conflict-flags';
 import { supportEdgesEnabled } from '../common/provenance-flags';
 import { buildConflictEdgeRows } from '../common/support-edges';
 import { KeyedMutex } from '../common/keyed-mutex';
@@ -39,6 +42,46 @@ export const VALUE_BEARING_ASPECTS: ReadonlySet<string> = new Set([
 /** Derive-internal semantics choice (V9 §1); pure, exported for tests. */
 export function derivedSemanticsFor(aspect: string, slotSemantics: boolean): DerivedSemantics {
   return slotSemantics && VALUE_BEARING_ASPECTS.has(aspect) ? 'bitemporal_event' : 'append_only';
+}
+
+/**
+ * Shared conflict-slot promotion — the ONE decision point both live
+ * ingest paths flow through (buildResolveCall), so the doctrine cannot
+ * fork per path. Promotion target is always 'bitemporal': the only
+ * semantics whose resolver branch runs the margin doctrine
+ * (close-scored contradictions → COMPETING pair, both linked; clear
+ * winner → SUPERSEDED; equal value from a different origin →
+ * CORROBORATED via the fn's exact `object = $object` check).
+ *
+ *  - direct path (CONFLICT_DIRECT_FACT_SLOT): an UNKNOWN predicate
+ *    (registry '__default__' fallback, append_only) would short-circuit
+ *    the conflict pool to [] — promote it so same-slot direct writes
+ *    can form conflicts. Known predicates keep their registry policy.
+ *  - mention path (CONFLICT_MENTION_FACT_SLOT): a 'single_active'
+ *    policy supersedes UNCONDITIONALLY (0085 $supersede) and can never
+ *    surface a COMPETING pair — promote it so two conversations
+ *    asserting contradictory slot values meet in the conflict pool
+ *    (state-transitions s07). The append_only open-vocabulary bulk and
+ *    DEFAULT_FALLBACK stay untouched (load-bearing for extraction).
+ *
+ * Both flags default off ⇒ registry passthrough, byte-identical.
+ * Deliberately NOT 'single_active' as a target in either direction, and
+ * per-user isolation needs nothing here: fn::resolve_fact's candidate
+ * pool is already scope-local (0055 $user_id filter). Pure decision
+ * (env read lives in src/common/conflict-flags.ts); exported for tests.
+ */
+export function conflictSlotSemantics(
+  policy: { predicateId: string; semantics: string },
+  path: 'direct' | 'mention',
+): string {
+  if (path === 'direct') {
+    return conflictDirectFactSlotEnabled() && policy.predicateId === DEFAULT_FALLBACK.predicateId
+      ? 'bitemporal'
+      : policy.semantics;
+  }
+  return conflictMentionFactSlotEnabled() && policy.semantics === 'single_active'
+    ? 'bitemporal'
+    : policy.semantics;
 }
 
 /**
@@ -244,25 +287,18 @@ export class FactResolverService {
     p: Parameters<FactResolverService['resolve']>[1],
   ): Promise<Parameters<FactResolverService['resolveFactCall']>[1]> {
     const policy = this.predicateRegistry.policyFor(p.companyId, p.predicate);
-    // CONFLICT_DIRECT_FACT_SLOT (default off): on the typed direct path
-    // (recordOutcomeMetric — set ONLY by FactIngestService.ingestFact),
-    // an unknown predicate falls to the registry DEFAULT_FALLBACK
-    // ('__default__', append_only), which short-circuits
-    // fn::resolve_fact's conflict pool to [] — two direct writes on one
-    // (entity, predicate) slot with contradicting objects both landed
-    // INSERTED and no conflict ever formed. Promote JUST that
-    // combination to 'bitemporal' (margin doctrine: close-scored →
-    // COMPETING, clear winner → SUPERSEDED). NOT 'single_active' — its
-    // resolver branch supersedes unconditionally (0085 $supersede) and
-    // can never surface a COMPETING pair. Known predicates keep their
-    // registry policy; the mention path (no recordOutcomeMetric) and
-    // DEFAULT_FALLBACK itself are untouched. Off ⇒ byte-identical.
-    const semantics =
-      conflictDirectFactSlotEnabled() &&
-      p.recordOutcomeMetric === true &&
-      policy.predicateId === DEFAULT_FALLBACK.predicateId
-        ? 'bitemporal'
-        : policy.semantics;
+    // Conflict-slot promotion (CONFLICT_DIRECT_FACT_SLOT /
+    // CONFLICT_MENTION_FACT_SLOT, both default off): the shared helper
+    // routes each path's blind spot into fn::resolve_fact's 'bitemporal'
+    // margin doctrine — see conflictSlotSemantics above. The direct path
+    // is exactly recordOutcomeMetric === true (set ONLY by
+    // FactIngestService.ingestFact); everything else — mention
+    // extraction — is the mention path. Flags off ⇒ registry
+    // passthrough, byte-identical.
+    const semantics = conflictSlotSemantics(
+      policy,
+      p.recordOutcomeMetric === true ? 'direct' : 'mention',
+    );
     const sourceTrust = sourceTrustFor(p.source as Parameters<typeof sourceTrustFor>[0]);
     // Confidence-aware attribution (MULTILINGUAL_LANG_ATTRIBUTION, default
     // off). Off → detectLanguage keeps its Phase-4 `en` fallback and no new

--- a/test/conflict-mention-fact-slot.unit-spec.ts
+++ b/test/conflict-mention-fact-slot.unit-spec.ts
@@ -1,0 +1,194 @@
+import { FactResolverService, conflictSlotSemantics } from '../src/ingest/fact-resolver.service';
+
+/**
+ * CONFLICT_MENTION_FACT_SLOT — semantics promotion at the shared
+ * buildResolveCall seam (conflictSlotSemantics). The mention/extraction
+ * path (no recordOutcomeMetric) promotes a 'single_active' registry
+ * policy — whose fn::resolve_fact branch supersedes UNCONDITIONALLY and
+ * can never surface a COMPETING pair — to 'bitemporal', so two
+ * conversations asserting contradictory values of one (userId, entity,
+ * predicate) slot form a linked competing pair instead of the second
+ * silently replacing the first (state-transitions s07). Pins:
+ *  - flag off → registry passthrough, resolver call byte-identical;
+ *  - flag on + mention + single_active → 'bitemporal', COMPETING pair
+ *    surfaces linked (competingFactIds passthrough);
+ *  - equal value → the fn's exact `object = $object` corroboration is
+ *    what decides sameness (verbatim object binding, CORROBORATED
+ *    passes through — no TS-side fuzzy matching);
+ *  - different users bind their own $user_id (0055 scope-local pool);
+ *  - flag on + direct path → untouched (no leak across paths);
+ *  - flag on + unknown predicate → append_only bulk untouched.
+ */
+describe('FactResolverService — CONFLICT_MENTION_FACT_SLOT promotion', () => {
+  afterEach(() => {
+    delete process.env.CONFLICT_MENTION_FACT_SLOT;
+    delete process.env.CONFLICT_DIRECT_FACT_SLOT;
+  });
+
+  function make(
+    resolveRow: Record<string, unknown> = { factId: 'knowledge_fact:x', outcome: 'INSERTED' },
+  ) {
+    const queries: Array<{ sql: string; params: Record<string, unknown> }> = [];
+    const db = {
+      query: jest.fn(async (sql: string, params: Record<string, unknown>) => {
+        queries.push({ sql, params });
+        return [resolveRow];
+      }),
+    };
+    const factEmbedding = {
+      embed: jest.fn(async () => [0.1]),
+      writeAltEmbeddingIfHype: jest.fn(async () => {}),
+    };
+    // Mirrors PredicateRegistryService.policyFor: a known slot predicate
+    // returns its single_active definition; anything else falls to the
+    // DEFAULT_FALLBACK sentinel ('__default__', append_only).
+    const predicateRegistry = {
+      getSnapshot: jest.fn(async () => ({})),
+      policyFor: jest.fn((_c: string, predicate: string) =>
+        predicate === 'address'
+          ? { predicateId: 'address', semantics: 'single_active' }
+          : { predicateId: '__default__', semantics: 'append_only' },
+      ),
+    };
+    const svc = new FactResolverService(factEmbedding as never, predicateRegistry as never);
+    return { svc, db, queries };
+  }
+
+  function input(
+    predicate: string,
+    opts: { recordOutcomeMetric?: boolean; userId?: string; object?: string } = {},
+  ) {
+    return {
+      companyId: 'co_x',
+      entityId: 'knowledge_entity:e1',
+      predicate,
+      object: opts.object ?? 'lease ends December 2026',
+      confidence: 0.9,
+      validFrom: new Date('2026-08-08T10:00:00Z'),
+      source: {},
+      precomputedEmbedding: [0.1, 0.2],
+      ...(opts.recordOutcomeMetric !== undefined
+        ? { recordOutcomeMetric: opts.recordOutcomeMetric }
+        : {}),
+      ...(opts.userId !== undefined ? { userId: opts.userId } : {}),
+    };
+  }
+
+  const resolveCalls = (queries: Array<{ sql: string; params: Record<string, unknown> }>) =>
+    queries.filter((q) => q.sql.includes('fn::resolve_fact('));
+
+  const semanticsParam = (queries: Array<{ sql: string; params: Record<string, unknown> }>) =>
+    resolveCalls(queries)[0]?.params.semantics;
+
+  it('flag off: mention-path single_active passthrough, resolver call byte-identical', async () => {
+    // Baseline pin: with the flag unset AND with it explicitly '0', the
+    // fn::resolve_fact invocation binds the exact same parameters — the
+    // default-off promise is byte-identical current behavior.
+    const unset = make();
+    const outUnset = await unset.svc.resolve(unset.db as never, input('address'));
+    process.env.CONFLICT_MENTION_FACT_SLOT = '0';
+    const off = make();
+    const outOff = await off.svc.resolve(off.db as never, input('address'));
+
+    expect(outUnset.semantics).toBe('single_active');
+    expect(outOff.semantics).toBe('single_active');
+    expect(semanticsParam(unset.queries)).toBe('single_active');
+    expect(resolveCalls(off.queries)[0]!.params).toEqual(resolveCalls(unset.queries)[0]!.params);
+  });
+
+  it('flag on + mention + single_active: promoted to bitemporal, competing pair surfaces linked', async () => {
+    process.env.CONFLICT_MENTION_FACT_SLOT = '1';
+    const { svc, db, queries } = make({
+      factId: 'knowledge_fact:new',
+      outcome: 'COMPETING',
+      competingFactIds: ['knowledge_fact:prior'],
+    });
+    const out = await svc.resolve(db as never, input('address'));
+    expect(semanticsParam(queries)).toBe('bitemporal');
+    expect(out.semantics).toBe('bitemporal');
+    expect(out.result.outcome).toBe('COMPETING');
+    expect(out.result.competingFactIds).toEqual(['knowledge_fact:prior']);
+  });
+
+  it("flag on: value-sameness is the fn's exact object binding — CORROBORATED passes through", async () => {
+    process.env.CONFLICT_MENTION_FACT_SLOT = '1';
+    const { svc, db, queries } = make({
+      factId: 'knowledge_fact:new',
+      outcome: 'CORROBORATED',
+      corroboratedFactId: 'knowledge_fact:prior',
+    });
+    const out = await svc.resolve(
+      db as never,
+      input('address', { object: 'lease ends December 2026' }),
+    );
+    // The object rides into the fn VERBATIM — sameness stays the fn's
+    // `object = $object` corroboration check, no TS-side fuzzy matching.
+    expect(resolveCalls(queries)[0]!.params.object).toBe('lease ends December 2026');
+    expect(out.result.outcome).toBe('CORROBORATED');
+    expect(out.result.corroboratedFactId).toBe('knowledge_fact:prior');
+  });
+
+  it('flag on: different users bind their own $user_id (0055 scope-local pool, no collision)', async () => {
+    process.env.CONFLICT_MENTION_FACT_SLOT = '1';
+    const { svc, db, queries } = make();
+    await svc.resolve(db as never, input('address', { userId: 'user-a' }));
+    await svc.resolve(db as never, input('address', { userId: 'user-b' }));
+    const calls = resolveCalls(queries);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.params.user_id).toBe('user-a');
+    expect(calls[1]!.params.user_id).toBe('user-b');
+  });
+
+  it('flag on + direct path (recordOutcomeMetric): untouched — no leak across paths', async () => {
+    process.env.CONFLICT_MENTION_FACT_SLOT = '1';
+    const { svc, db, queries } = make();
+    const out = await svc.resolve(db as never, input('address', { recordOutcomeMetric: true }));
+    expect(semanticsParam(queries)).toBe('single_active');
+    expect(out.semantics).toBe('single_active');
+  });
+
+  it('flag on + mention + unknown predicate: append_only open-vocabulary bulk untouched', async () => {
+    process.env.CONFLICT_MENTION_FACT_SLOT = '1';
+    const { svc, db, queries } = make();
+    const out = await svc.resolve(db as never, input('lease_end_date'));
+    expect(semanticsParam(queries)).toBe('append_only');
+    expect(out.semantics).toBe('append_only');
+  });
+
+  describe('conflictSlotSemantics — the shared pure decision', () => {
+    const slot = { predicateId: 'address', semantics: 'single_active' };
+    const fallback = { predicateId: '__default__', semantics: 'append_only' };
+
+    it('both flags off: registry passthrough on both paths', () => {
+      expect(conflictSlotSemantics(slot, 'mention')).toBe('single_active');
+      expect(conflictSlotSemantics(slot, 'direct')).toBe('single_active');
+      expect(conflictSlotSemantics(fallback, 'mention')).toBe('append_only');
+      expect(conflictSlotSemantics(fallback, 'direct')).toBe('append_only');
+    });
+
+    it('mention flag on: only mention-path single_active promotes', () => {
+      process.env.CONFLICT_MENTION_FACT_SLOT = '1';
+      expect(conflictSlotSemantics(slot, 'mention')).toBe('bitemporal');
+      expect(conflictSlotSemantics(fallback, 'mention')).toBe('append_only');
+      expect(conflictSlotSemantics(slot, 'direct')).toBe('single_active');
+      expect(conflictSlotSemantics(fallback, 'direct')).toBe('append_only');
+    });
+
+    it('direct flag on: only direct-path fallback promotes (mention side untouched)', () => {
+      process.env.CONFLICT_DIRECT_FACT_SLOT = '1';
+      expect(conflictSlotSemantics(fallback, 'direct')).toBe('bitemporal');
+      expect(conflictSlotSemantics(slot, 'direct')).toBe('single_active');
+      expect(conflictSlotSemantics(slot, 'mention')).toBe('single_active');
+      expect(conflictSlotSemantics(fallback, 'mention')).toBe('append_only');
+    });
+
+    it('both flags on: each path keeps its own promotion rule', () => {
+      process.env.CONFLICT_DIRECT_FACT_SLOT = '1';
+      process.env.CONFLICT_MENTION_FACT_SLOT = '1';
+      expect(conflictSlotSemantics(fallback, 'direct')).toBe('bitemporal');
+      expect(conflictSlotSemantics(slot, 'mention')).toBe('bitemporal');
+      expect(conflictSlotSemantics(slot, 'direct')).toBe('single_active');
+      expect(conflictSlotSemantics(fallback, 'mention')).toBe('append_only');
+    });
+  });
+});

--- a/test/eval/state-transitions/README.md
+++ b/test/eval/state-transitions/README.md
@@ -58,10 +58,10 @@ tally; the scorecard groups scenarios by class.
 
 ## Expected fails on today's code (the baseline IS the point)
 
-Two belief checks are **expected to fail** on current `main` and are
-annotated `knownFailToday` in `scenarios.ts` (tracked as #135; the
-scorecard counts them separately, and the runner prints
-`(expected today)` next to them):
+Three checks are **expected to fail** on current `main` (default flags)
+and are annotated `knownFailToday` in `scenarios.ts` (the belief pair is
+tracked as #135; the scorecard counts them separately, and the runner
+prints `(expected today)` next to them):
 
 - **s01-belief** — `SCENES_BELIEF_NEGATION_DELTAS`: a disposal ("no bike
   anymore") does not reliably emit a stateDelta, so the belief stays at
@@ -70,10 +70,15 @@ scorecard counts them separately, and the runner prints
 - **s08-belief** — `SCENES_BELIEF_FIELD_FOLD`: "home city" and "place of
   residence" fold into different free-text field keys, so no single
   belief carries `value` + `priorValue` across the drifted wording.
+- **s07-serve** — `CONFLICT_MENTION_FACT_SLOT`: the mention-path slot
+  resolves to `single_active` semantics, which supersedes
+  unconditionally and never forms the COMPETING pair, so serving picks
+  one side of a live contradiction. The flag (default off) promotes the
+  slot to `bitemporal` margin doctrine so the pair competes.
 
-The battery still RUNS both checks and records their fails — that is the
-baseline those flags, once merged and enabled, are measured against. A
-run where they pass is the signal the bugs are fixed.
+The battery still RUNS these checks and records their fails — that is
+the baseline those flags, once merged and enabled, are measured against.
+A run where they pass is the signal the bugs are fixed.
 
 ## Running against a local stand
 
@@ -95,6 +100,13 @@ Stand flags that shape coverage:
 - Once #135 lands: `SCENES_BELIEF_NEGATION_DELTAS=1` and
   `SCENES_BELIEF_FIELD_FOLD=1` are the flags this battery's expected
   fails exist to validate.
+- `CONFLICT_MENTION_FACT_SLOT=1` — the flag the **s07-serve** expected
+  fail exists to validate: mention-path extraction resolves the lease
+  slot to `single_active` semantics, whose resolver branch supersedes
+  unconditionally and never forms the COMPETING pair, so serving picks
+  one side of the contradiction. With the flag on, the slot is promoted
+  to `bitemporal` margin doctrine and the close-scored pair COMPETES
+  (both sides served or an honest abstain).
 
 Then:
 

--- a/test/eval/state-transitions/scenarios.ts
+++ b/test/eval/state-transitions/scenarios.ts
@@ -355,6 +355,11 @@ export const SCENARIOS: Scenario[] = [
         // abstained pass, one-sided fails. Month names are the sides —
         // unambiguous and phrasing-proof.
         conflictSides: { sideA: ['December'], sideB: ['September'] },
+        knownFailToday:
+          'CONFLICT_MENTION_FACT_SLOT — mention-path extraction resolves the slot to ' +
+          'single_active semantics, whose resolver branch supersedes unconditionally and ' +
+          'never forms the COMPETING pair, so serving picks one side; the flag (default ' +
+          'off) promotes the slot to bitemporal margin doctrine',
       },
       {
         kind: 'provenance',


### PR DESCRIPTION
## Problem

The state-transitions eval battery's only deterministic red across 5+ runs: **s07 "conflict"** (`test/eval/state-transitions/scenarios.ts`). Two conversations assert contradictory versions of one fact (a lease end date); the expectation is that the pair ends up `status='competing'` and serving surfaces BOTH sides. Reality: the competing pair never forms for facts arriving via the mention/extraction path.

Root cause: the mention path resolves the slot to its registry **`single_active`** policy, whose `fn::resolve_fact` branch supersedes **unconditionally** (0085 `$supersede = $semantics = 'single_active' OR …`) and can never return COMPETING — the second assertion silently replaces the first, and serving picks one side of a live conflict. `CONFLICT_DIRECT_FACT_SLOT` covered only the sibling blind spot on the typed direct path (unknown-predicate `append_only` short-circuiting the conflict pool to `[]`).

## Fix — `CONFLICT_MENTION_FACT_SLOT` (default off, byte-identical)

- **Shared helper `conflictSlotSemantics`** (`src/ingest/fact-resolver.service.ts`): the one conflict-slot promotion decision both live ingest paths flow through at the `buildResolveCall` seam — the direct path's inline ternary is folded into it rather than cloned. Promotion target is always `'bitemporal'`, the only semantics whose resolver branch runs the margin doctrine: close-scored contradictions → **COMPETING** (both sides `status='competing'`, linked via `competingFactIds`/`conflictTrace`); clear winner → SUPERSEDED; equal value from a different origin → CORROBORATED via the fn's exact `object = $object` check (the same value-sameness the direct path uses — nothing fuzzier invented).
- **Mention rule**: no `recordOutcomeMetric` (i.e. not `FactIngestService.ingestFact`) + registry semantics `single_active` → `'bitemporal'`. Untouched: the `append_only` open-vocabulary bulk, `DEFAULT_FALLBACK` (load-bearing for extraction), the direct typed path, and the derived-batch writer (`resolveDerivedBatch` bypasses `buildResolveCall`).
- **Per-user isolation** needs nothing new: `fn::resolve_fact`'s candidate pool is already scope-local (0055 `$user_id` filter), so different users' slots never collide.
- **No migration, no new SurrealQL** — the existing 0085 fn body performs the pair formation with primary-key-addressed writes; the 3.2.4 indexed-field DELETE/UPDATE-WHERE discipline is not touched.
- **Flag plumbing**: reader in `src/common/conflict-flags.ts` (env read in the common layer only, S5.2; call-time read ⇒ runtime-mutable), config-catalog entry, `KNOWN_BOOLEAN_FLAGS`. `CONFLICT_` stays off the ENGINE flag budget (resolver-policy knob family — `flag-budget.unit-spec.ts` prefix regex).
- **Battery bookkeeping**: `s07-serve` annotated `knownFailToday` naming the flag (the baseline-is-the-point idiom the battery already uses for #135), README's expected-fails and stand-flags sections updated.

## Behavior note (flag on)

With the flag on, a mention-path `single_active` slot takes the margin doctrine end to end: an honest same-slot update whose score gap stays inside `CONFLICT_MARGIN_SUPERSEDE` also lands COMPETING instead of a silent supersede — the same trade the direct-path flag made deliberately (a surfaced conflict is recoverable; a silently-picked side is not). Default off, so nothing changes until a stand/tenant opts in; the next battery run with the flag on is the measurement.

## Tests

`test/conflict-mention-fact-slot.unit-spec.ts` — flag-off byte-identical resolver params (pinned by deep-equal of the `fn::resolve_fact` bindings), promotion to `bitemporal` with linked COMPETING passthrough, verbatim `$object` binding with CORROBORATED passthrough (equal value = corroboration, not conflict), per-user `$user_id` binding, no leak onto the direct path, untouched `append_only` bulk, and the pure decision matrix for both flags including both-on independence.

Full unit suite green: 347 suites / 3839 tests. `pnpm typecheck`, `lint`, `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB