### PR TITLE
fix(extractor): rate-limit phrasing in literal harvest + ownership fewshot for code_memory

### DIFF
--- a/src/ai/domain-packs/code-memory.pack.ts
+++ b/src/ai/domain-packs/code-memory.pack.ts
@@ -11,7 +11,7 @@ import { composePredicateId, type DomainPackManifest } from './manifest';
  */
 export const CODE_MEMORY_PACK: DomainPackManifest = {
   id: 'code_memory',
-  version: '0.4.0',
+  version: '0.4.1',
   description:
     'Non-derivable engineering "why" of a codebase — decisions, rationale, invariants, gotchas, ownership, flag/config defaults, dependency pins, and decision supersession anchored to code, with a domain extraction profile and memory model.',
   // Retro-declaration, documentation-true: code-memory has ALWAYS been an
@@ -157,7 +157,9 @@ flag/config (code_memory__default_value), pinned dependency versions
 (code_memory__depends_on_version), and decision supersession
 (code_memory__superseded_by). Copy identifiers, paths, versions, and values
 VERBATIM — "3.2.4" not "the current version", "EXTRACTOR_LITERAL_HARVEST"
-not "the harvest flag".`,
+not "the harvest flag". Ownership INVERTS the surface grammar: in
+"NAME owns PATH", the owned module/path is the fact's SUBJECT (a code
+anchor) and the person or team is the VALUE of code_memory__owns.`,
     fewShot: [
       {
         text: 'We decided to resolve all facts through one gateway in src/ingest/fact-resolver.service.ts because 21 positional args drifted between call-sites.',
@@ -174,6 +176,13 @@ not "the harvest flag".`,
       {
         text: 'Our decision to cache answers per request in src/answers/cache.ts was superseded by caching per tenant.',
         note: "code anchor 'src/answers/cache.ts' → code_memory__superseded_by='caching per tenant' (the old decided fact stays in history).",
+      },
+      // 0.4.1: dedicated ownership example (k13 battery finding) — the
+      // person-first phrasing with a repo qualifier and an "including …"
+      // enumeration tail, which the compound example above did not cover.
+      {
+        text: 'Dmitri owns src/billing in ledger-core, including the invoice worker and the dunning cron.',
+        note: "ownership inverts the sentence: the owned module 'src/billing' is the SUBJECT (a code anchor), the person is the value → code_memory__owns='Dmitri'. The 'including …' tail stays inside that one fact — no extra owns fact per sub-component.",
       },
     ],
   },

--- a/src/ai/extractor-internals/literal-harvest.ts
+++ b/src/ai/extractor-internals/literal-harvest.ts
@@ -44,6 +44,22 @@ const PORT_LIST_ITEM =
 const RATE_LIMIT =
   /\b(\d[\d.,]*)\s*(?:requests?|calls?|req|rps)\s*(?:per|\/)\s*(?:second|minute|hour|sec|min|hr)\b/gi;
 
+/**
+ * The cue-gated rate forms the main rule cannot see (k07 code-memory
+ * battery finding — additions only, the main rule is untouched): a
+ * number joined straight to a TIME unit with no request noun between
+ * (`at 120 per minute`, `to 300/min`) or a compact rate token
+ * (`850 rps`, `120 qps`). These fire ONLY when the sentence carries
+ * explicit rate-limit vocabulary (RATE_LIMIT_CUE) — "the line moved at
+ * 120 per minute" is casual prose, not a limit. `rpm` is deliberately
+ * absent: outside software prose it reads as revolutions per minute.
+ */
+const RATE_LIMIT_CUED =
+  /\b(\d[\d.,]*)\s*(?:(?:per|\/)\s*(?:second|minute|hour|sec|min|hr)|rps|qps)\b/gi;
+
+/** Explicit rate-limit vocabulary that admits a RATE_LIMIT_CUED match. */
+const RATE_LIMIT_CUE = /\b(?:rate[\s-]?limit(?:s|ed|ing)?|throttl(?:e|es|ed|ing)|quota)\b/i;
+
 /** `HTTP 429` — an explicit protocol status code. */
 const HTTP_STATUS = /\bHTTP\s+([1-5]\d{2})\b/g;
 
@@ -173,6 +189,12 @@ function collectMatches(input: string, sentences: SentenceSpan[]): HarvestMatch[
 
   for (const m of input.matchAll(RATE_LIMIT)) {
     // The full phrase verbatim WITH units — "50" alone is not a limit.
+    out.push({ predicate: 'rate_limit', object: m[0], valueSpan: m[0], index: m.index });
+  }
+  for (const m of input.matchAll(RATE_LIMIT_CUED)) {
+    // Unit-noun-less / compact rate forms only count inside a sentence
+    // that says it IS a limit (throttle / rate-limit / quota).
+    if (!RATE_LIMIT_CUE.test(sentenceAt(sentences, m.index).text)) continue;
     out.push({ predicate: 'rate_limit', object: m[0], valueSpan: m[0], index: m.index });
   }
   for (const m of input.matchAll(PORT_STATEMENT)) {

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -408,6 +408,24 @@ describe('code-memory pack', () => {
     expect(profile?.fewShot?.length ?? 0).toBeGreaterThanOrEqual(3);
   });
 
+  // 0.4.1 (k13 battery finding): ownership phrasing must be covered by a
+  // DEDICATED few-shot — person-first "NAME owns PATH" with an
+  // enumeration tail — and the guidance must spell out the
+  // subject/value inversion, so open-vocab extraction canonicalizes
+  // ownership turns into code_memory__owns instead of coining.
+  it('covers ownership phrasing: dedicated fewShot + inversion guidance', () => {
+    const profile = CODE_MEMORY_PACK.extractionProfile;
+    const ownershipExamples = (profile?.fewShot ?? []).filter((ex) =>
+      ex.note.includes('code_memory__owns'),
+    );
+    // The dedicated example plus the original compound one.
+    expect(ownershipExamples.length).toBeGreaterThanOrEqual(2);
+    expect(
+      ownershipExamples.some((ex) => /\bowns src\/\S+ in \S+, including\b/.test(ex.text)),
+    ).toBe(true);
+    expect(profile?.guidance).toContain('the VALUE of code_memory__owns');
+  });
+
   it('declares the perception contract: three lifecycles, hints, one recency rule', () => {
     const mm = CODE_MEMORY_PACK.memoryModel;
     expect(mm?.stateModels?.map((m) => m.id).sort()).toEqual([

--- a/test/literal-harvest.unit-spec.ts
+++ b/test/literal-harvest.unit-spec.ts
@@ -104,6 +104,70 @@ describe('harvestLiterals — positive table (verbatim corpus turns)', () => {
   });
 });
 
+describe('harvestLiterals — k07 rate-limit phrasing table (code-memory battery)', () => {
+  // VERBATIM corpus turn from test/eval/code-memory/corpus.ts (the k07
+  // rate_limit want) — pins that the deterministic lane produces the
+  // fact for this exact phrasing whenever it runs with a grounded
+  // entity, so a battery miss localizes upstream of the regex lane.
+  const THROTTLE_TURN = 'acme-api throttles /v1/webhooks at 120 requests per minute.';
+
+  it('corpus phrasing: "throttles … at 120 requests per minute" → rate_limit', () => {
+    const facts = harvest(THROTTLE_TURN, [ent('acme-api')], null);
+    const rate = byPredicate(facts, 'rate_limit');
+    expect(rate).toHaveLength(1);
+    expect(rate[0]!.object).toBe('120 requests per minute');
+    expect(rate[0]!.entityIndex).toBe(0);
+    // The cue-gated addition must not double-fire next to the main rule.
+    expect(facts).toHaveLength(1);
+  });
+
+  it('held-out: cue-gated bare form "rate-limits … at 60 per minute"', () => {
+    const facts = harvest(
+      'acme-api rate-limits /v1/events at 60 per minute.',
+      [ent('acme-api')],
+      null,
+    );
+    expect(byPredicate(facts, 'rate_limit').map((f) => f.object)).toEqual(['60 per minute']);
+  });
+
+  it('held-out: cue-gated slash form "throttled to 300/min"', () => {
+    const facts = harvest(
+      'The acme-api webhook route is throttled to 300/min in staging.',
+      [ent('acme-api')],
+      null,
+    );
+    expect(byPredicate(facts, 'rate_limit').map((f) => f.object)).toEqual(['300/min']);
+  });
+
+  it('held-out: cue-gated compact unit "quota … is 850 rps"', () => {
+    const facts = harvest('The ingest quota for acme-api is 850 rps.', [ent('acme-api')], null);
+    expect(byPredicate(facts, 'rate_limit').map((f) => f.object)).toEqual(['850 rps']);
+  });
+
+  it('negative: "120 users" never becomes a rate limit, even beside a throttle cue', () => {
+    const facts = harvest(
+      'acme-api throttles onboarding; 120 users hit the waitlist.',
+      [ent('acme-api')],
+      null,
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('negative: cue-less "120 per minute" prose stays out', () => {
+    const facts = harvest(
+      'The acme-api conveyor demo moved 120 per minute all day.',
+      [ent('acme-api')],
+      null,
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('negative: rpm stays out even with a cue (revolutions ambiguity)', () => {
+    const facts = harvest('We throttle the acme-api fans at 1200 rpm.', [ent('acme-api')], null);
+    expect(facts).toEqual([]);
+  });
+});
+
 describe('harvestLiterals — negative table', () => {
   const NOTHING: Array<[string, string]> = [
     ['casual duration', 'we met three minutes apart'],


### PR DESCRIPTION
Fixes the two measured findings from the first live run (cmmtpdjjnk) of the code-memory eval battery (`pnpm eval:code-memory`).

## k07 literal-harvest: no `rate_limit` fact for the 120-req/min turn

**Diagnosis.** The corpus turn is `acme-api throttles /v1/webhooks at 120 requests per minute.` The existing `RATE_LIMIT` regex *does* match that literal (`120 requests per minute`) in isolation — verified against the exact bytes of both files, and `harvestLiterals` emits the fact when given a grounded `acme-api` entity. So the live miss was not a raw regex miss; the residual failure mode sits upstream of the regex lane (the lane runs only after LLM entity extraction: a safe-exit zero-entity extraction on this terse turn skips the mention as `no_entities`, and the local-replay `trySkip` path returns before the harvest seam). That is now pinned: a verbatim-corpus unit test asserts the lane produces the fact, so if k07's `rate_limit` want fails again with this spec green, the cause localizes upstream, not in the pattern set.

**Hardening (additions only).** The lane could not see adjacent real-world rate phrasings, so a new cue-gated rule `RATE_LIMIT_CUED` is added — it admits unit-noun-less rates (`at 120 per minute`, `to 300/min`) and compact units (`850 rps` / `qps`) **only** when the sentence carries explicit rate-limit vocabulary (`throttle*` / `rate-limit*` / `quota`), mirroring the lane's existing `NAMING_PREFIX_CUE` design. `rpm` is deliberately excluded (revolutions-per-minute ambiguity). Every existing pattern is byte-identical.

**Tests.** New spec table: the verbatim corpus phrasing harvests; three held-out phrasings harvest (`rate-limits … at 60 per minute`, `throttled to 300/min`, `quota … is 850 rps`); negatives pinned: `120 users` beside a throttle cue, cue-less `120 per minute` prose, and cued `1200 rpm` all produce nothing; plus a no-double-fire assertion next to the main rule.

## k13 serve-owner: ownership never canonicalized into `code_memory__owns`

The pack's only ownership few-shot was a compound example (`… and mikefluff owns src/fovea`) with ownership as a secondary clause, so the corpus shape — `Priya owns src/gateway in acme-api, including the webhook dispatcher and the queue relay.` (person-first subject, repo qualifier, enumeration tail, and the subject/value **inversion**: the owned module is the fact's subject, the person is the value) — was uncovered. Fix, minimal:

- a dedicated ownership few-shot with exactly that shape (same-shape, different names — the eval sentence itself is deliberately **not** taught, so k13 stays a measurement, not a memorization);
- one guidance sentence spelling out the inversion (`in "NAME owns PATH", the owned module/path is the fact's SUBJECT … the person or team is the VALUE of code_memory__owns`);
- pack PATCH bump `0.4.0 → 0.4.1`. Manifest stays zod-valid; the corpus `gap040` helper and the external-candidates e2e reference `CODE_MEMORY_PACK.version` dynamically, so nothing drifts.

k10 (path-vs-symbol entity dedup) is intentionally untouched — separate design item.

## Verification

- `pnpm typecheck` — clean
- literal-harvest / domain-pack / code-memory-scorers suites — green
- full `pnpm test:unit` — 351 suites, 3890 tests, all green
- `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB