### PR TITLE
feat(deploy): enable mention-path conflict formation + transition classifier in prod

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -315,6 +315,17 @@ jobs:
           # scenarios (checks 84% -> 92%), memory-fitness 27/30 ->
           # 28/30; pointed-question isolation checks unaffected) ──
           RETRIEVAL_ANSWER_CONDITIONING=1
+          # ── Mention-path conflict formation (#444) + transition
+          # classifier (#446, BGE-M3 prototypes calibrated offline:
+          # P=0.906 R=0.879 on 76 labeled items). Measured together on
+          # the stand: state-transition battery 9/12 (checks 88%),
+          # code-memory battery 13/16 — no regression vs the flags-off
+          # runs. Note: s07 stays red for a deeper reason (the two
+          # contradicting arms extract into DIFFERENT slots —
+          # status vs duration_limit — so no single_active collision
+          # exists to pair; slot canonicalization is the follow-up). ──
+          CONFLICT_MENTION_FACT_SLOT=1
+          EXTRACTOR_TRANSITION_CLASSIFIER=1
           EOF
           # The heredoc carries the YAML block's 10-space indent into the
           # file; strip it so every line is a clean KEY=value / #comment


### PR DESCRIPTION
## What

Adds two flags to the prod enablement set, both merged default-off earlier today and measured on the dogfood stand:

1. **`CONFLICT_MENTION_FACT_SLOT=1`** (#444) — mention-path writes for registry `single_active` predicates now route through the same bitemporal margin doctrine as the direct path (close-scored contradiction → COMPETING pair; clear winner → SUPERSEDED; equal value → CORROBORATED) instead of unconditionally superseding.
2. **`EXTRACTOR_TRANSITION_CLASSIFIER=1`** (#446) — the morphology + BGE-M3-prototype transition lane, calibrated offline to **P=0.906 / R=0.879** on 76 labeled corpus items (floor 0.52, margin 0.002); defers to the lexicon lane, intention/negation guards intact, EN+RU.

## Measured (stand, all other prod flags on)

- state-transitions battery: **9/12 scenarios, checks 88%** (baseline range 8-10/12 across today's runs — no regression, non-serve planes 12/12)
- code-memory battery: **13/16** (k13 serve-owner flipped green with #445; stable vs previous run)

## Honest caveat

The battery's s07 conflict scenario stays red for a reason DEEPER than #444: its two contradicting arms extract into **different slots** (`status` vs `duration_limit` on the same entity), so no single_active collision exists for the machinery to pair. Slot/predicate canonicalization at extraction is the documented follow-up; #444 is correct and necessary for true same-slot collisions.

No code changes — deploy-workflow enablement only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB