### PR TITLE
fix(extractor): run harvest lanes on no-entity and replay-skip turns

### DIFF
--- a/src/ai/extractor-internals/literal-harvest.ts
+++ b/src/ai/extractor-internals/literal-harvest.ts
@@ -87,6 +87,24 @@ const DOTTED_IDENTIFIER = /\b([A-Z][A-Za-z0-9]*(?:\.[A-Za-z0-9*]+)+)(?![\w*])/g;
 /** `idempotencyKey` — camelCase; only admitted with an assignment/idiom cue. */
 const CAMEL_TOKEN = /\b[a-z]+(?:[A-Z][a-z0-9]+)+\b/g;
 
+/**
+ * Identifier-shaped SUBJECT tokens for the fallback minting path
+ * (no-entity turns only — see HarvestLiteralsArgs.mintSubjects). The
+ * shapes mirror the code-memory extractionProfile's subject doctrine
+ * ("identifier-shaped subjects become their OWN entities — an ALL_CAPS
+ * flag or env var, a file or module path, a dotted symbol or package
+ * name"): ALL_CAPS and dotted reuse the harvest rules above; the two
+ * additions are the slash path (leading slash allowed, first segment
+ * must carry a letter so `300/min` and `2026/03/08` never read as
+ * paths) and the hyphenated package/service slug (`acme-api`,
+ * `ledger-sync`). The FIRST shape by sentence position wins — English
+ * subjects lead their sentence, so position is the deterministic
+ * stand-in for a parse.
+ */
+const SUBJECT_PATH = /(?<![\w.])\/?[\w.-]*[A-Za-z][\w.-]*(?:\/[\w.*-]+)+/g;
+const SUBJECT_SLUG = /\b[a-z][a-z0-9]*(?:-[a-z0-9]+)+\b/g;
+const SUBJECT_SHAPES = [ALL_CAPS_IDENTIFIER, DOTTED_IDENTIFIER, SUBJECT_PATH, SUBJECT_SLUG];
+
 /** camelCase cue A: the token is immediately followed by `=`. */
 const CAMEL_ASSIGN_AFTER = /^\s*=/;
 
@@ -184,6 +202,51 @@ interface HarvestMatch {
   index: number;
 }
 
+/** The predicates whose match token IS the subject (identifier-class). */
+const IDENTIFIER_CLASS = new Set(['identifier', 'naming_prefix']);
+
+/**
+ * The first identifier-shaped subject token of a sentence (by position;
+ * longest match on a tie), or null when the sentence carries none. Only
+ * consulted on the fallback minting path.
+ */
+export function firstSubjectToken(sentenceText: string): string | null {
+  let best: { index: number; token: string } | null = null;
+  for (const shape of SUBJECT_SHAPES) {
+    shape.lastIndex = 0;
+    for (const m of sentenceText.matchAll(shape)) {
+      const token = m[1] ?? m[0];
+      if (
+        !best ||
+        m.index < best.index ||
+        (m.index === best.index && token.length > best.token.length)
+      ) {
+        best = { index: m.index, token };
+      }
+    }
+  }
+  return best?.token ?? null;
+}
+
+/**
+ * Resolve a subject token against the working entity list by normalized
+ * name (the extractor's existing resolution idiom — the same match
+ * resolveSpeakerEntityIndex uses), minting a new `other`-typed entity
+ * when absent. APPENDS to the passed array; returns the bound index.
+ * Deliberately `other`, never a person type — bindStateHolder must not
+ * pick a minted identifier as a state holder. Cross-turn dedup stays
+ * where it lives today: the ingest entity-resolution upsert
+ * (resolveOrCreateNamedEntity) resolves the minted name exactly like an
+ * LLM-emitted one.
+ */
+function resolveOrMintSubject(entities: ExtractedEntity[], token: string): number {
+  const normalized = normalizeForGrounding(token);
+  const existing = entities.findIndex((e) => normalizeForGrounding(e.name) === normalized);
+  if (existing !== -1) return existing;
+  entities.push({ name: token, type: 'other' });
+  return entities.length - 1;
+}
+
 function collectMatches(input: string, sentences: SentenceSpan[]): HarvestMatch[] {
   const out: HarvestMatch[] = [];
 
@@ -266,12 +329,33 @@ function collectMatches(input: string, sentences: SentenceSpan[]): HarvestMatch[
 export interface HarvestLiteralsArgs {
   /** The clamped input text the extraction ran on. */
   trimmed: string;
-  /** The FINAL compacted grounded entity list of the extraction. */
+  /**
+   * The FINAL compacted grounded entity list of the extraction. With
+   * `mintSubjects` on, minted subject entities are APPENDED to this
+   * array (pass a copy if the original must stay untouched).
+   */
   entities: ExtractedEntity[];
   /** Speaker's index in `entities` (resolveSpeakerEntityIndex), or null. */
   speakerEntityIndex: number | null;
   /** The denoised LLM facts — drives dedup against the harvest. */
   existingFacts?: readonly ExtractedFact[];
+  /**
+   * Fallback grounding for the no-entity starvation case (the k07
+   * code-memory battery finding: an LLM extraction that yields zero
+   * entities used to starve this lane entirely, so a turn like
+   * "acme-api throttles /v1/webhooks at 120 requests per minute."
+   * produced NO rate_limit fact). When set, a match that normal
+   * binding cannot ground is bound by minting: an identifier-class
+   * match (identifier / naming_prefix) becomes its OWN subject entity
+   * — the code-memory extractionProfile's doctrine — and any other
+   * match binds to the first identifier-shaped subject token of its
+   * sentence, with the speaker kept as the LAST resort (mirroring
+   * bindEntity's name-in-sentence-over-speaker priority). A sentence
+   * with no subject shape and no speaker still harvests nothing —
+   * minting never invents a subject. Default off: absent, the function
+   * is byte-identical to the pre-mint behavior.
+   */
+  mintSubjects?: boolean;
 }
 
 /**
@@ -283,8 +367,8 @@ export interface HarvestLiteralsArgs {
  * for the caller to union.
  */
 export function harvestLiterals(args: HarvestLiteralsArgs): ExtractedFact[] {
-  const { trimmed, entities, speakerEntityIndex, existingFacts = [] } = args;
-  if (!trimmed || entities.length === 0) return [];
+  const { trimmed, entities, speakerEntityIndex, existingFacts = [], mintSubjects = false } = args;
+  if (!trimmed || (entities.length === 0 && !mintSubjects)) return [];
   const sentences = sentenceSpans(trimmed);
   const seen = new Set(
     existingFacts.map(
@@ -295,7 +379,15 @@ export function harvestLiterals(args: HarvestLiteralsArgs): ExtractedFact[] {
   for (const m of collectMatches(trimmed, sentences)) {
     if (harvested.length >= LITERAL_HARVEST_CAP) break;
     const sentence = sentenceAt(sentences, m.index);
-    const entityIndex = bindEntity(entities, sentence.text, speakerEntityIndex);
+    // Minting runs the same priority bindEntity encodes — a sentence-
+    // grounded subject beats the speaker — so the speaker fallback is
+    // withheld from the first pass and re-applied only after minting
+    // found no subject shape in the sentence.
+    let entityIndex = bindEntity(entities, sentence.text, mintSubjects ? null : speakerEntityIndex);
+    if (entityIndex === null && mintSubjects) {
+      const token = IDENTIFIER_CLASS.has(m.predicate) ? m.object : firstSubjectToken(sentence.text);
+      entityIndex = token !== null ? resolveOrMintSubject(entities, token) : speakerEntityIndex;
+    }
     if (entityIndex === null) continue;
     const key = `${entityIndex}\u0000${m.predicate}\u0000${normalizeForGrounding(m.object)}`;
     if (seen.has(key)) continue;

--- a/src/ai/extractor-runner.service.ts
+++ b/src/ai/extractor-runner.service.ts
@@ -128,7 +128,31 @@ export class ExtractorRunnerService {
     const contextPrefix = buildConversationContext(context ?? {});
 
     const skip = await this.local.trySkip(companyId, trimmed);
-    if (skip) return skip;
+    if (skip) {
+      // Replay-starvation fix: the local-replay path used to return
+      // BEFORE the harvest seam, yet replay patterns deliberately carry
+      // the LLM facts only (persistPatterns excludes harvested rows on
+      // the promise that the deterministic lanes re-derive them "on
+      // every ingest") — so a replayed turn silently lost every
+      // harvested fact. Run the same seam over the replayed result.
+      // All lanes off → the exact trySkip object, byte-identical.
+      const { facts: replayHarvested, entities: replayEntities } = await this.runHarvestLanes({
+        trimmed,
+        entities: skip.entities,
+        existingFacts: skip.facts,
+        context,
+      });
+      if (replayHarvested.length === 0) return skip;
+      traceArtifact('extractor.replay_skip_harvest', {
+        count: replayHarvested.length,
+        facts: replayHarvested.map((f) => ({ predicate: f.predicate, object: f.object })),
+      });
+      return {
+        entities: replayEntities,
+        facts: [...skip.facts, ...replayHarvested],
+        edges: skip.edges,
+      };
+    }
 
     traceArtifact('extractor.vocab', {
       versionHash: snapshot.versionHash,
@@ -426,20 +450,114 @@ export class ExtractorRunnerService {
       });
     }
 
-    // Literal harvest (EXTRACTOR_LITERAL_HARVEST, default off): the
-    // deterministic regex lane for technical literals the closed-vocab
-    // prompt drops (ports, rate limits, HTTP statuses, identifiers,
-    // naming prefixes). Runs AFTER denoise so the denoiser cannot eat
-    // harvested rows; every harvested valueSpan is an exact substring
-    // of the input by construction, so the grounding invariant the gate
-    // above enforces holds for these rows too. Dedup against the
-    // denoised LLM set keeps the union additive-only.
-    const harvested = resolveExtractionProfile().literalHarvest
+    // Deterministic harvest lanes (all default off) — see runHarvestLanes.
+    // Runs AFTER denoise so the denoiser cannot eat harvested rows; every
+    // harvested valueSpan is an exact substring of the input by
+    // construction, so the grounding invariant the gate above enforces
+    // holds for these rows too.
+    const { facts: harvestedFacts, entities: finalEntities } = await this.runHarvestLanes({
+      trimmed,
+      entities,
+      existingFacts: denoised,
+      context,
+    });
+
+    const finalFacts = harvestedFacts.length > 0 ? [...denoised, ...harvestedFacts] : denoised;
+
+    const result: ExtractionResult = { entities: finalEntities, facts: finalFacts, edges };
+    this.local.persistPatterns({
+      companyId,
+      clauses,
+      rawFacts,
+      // Deliberately the LLM facts only: harvested rows are re-derived
+      // deterministically on every ingest, so caching them as replay
+      // patterns would leak flag-on behavior into flag-off replays.
+      facts: denoised,
+      edges,
+    });
+    return result;
+  }
+
+  /**
+   * The deterministic harvest seam, shared by BOTH producers of an
+   * extraction result — assembleResult (the LLM path) and the trySkip
+   * local-replay path in run(). Sequences the three flag-gated lanes:
+   *
+   *  - Literal harvest (EXTRACTOR_LITERAL_HARVEST): the regex lane for
+   *    technical literals the closed-vocab prompt drops (ports, rate
+   *    limits, HTTP statuses, identifiers, naming prefixes). Dedup
+   *    against the existing set keeps the union additive-only.
+   *  - State-verb harvest (EXTRACTOR_STATE_VERB_HARVEST): the past-
+   *    tense transition lexicon (bought/joined/quit/returned/…)
+   *    harvesting completed acquire/dispose/change events as span-
+   *    grounded `state_change` facts, with pre-verb guards so
+   *    intentions ("thinking about selling") never flip state. Dedups
+   *    against BOTH the existing set and the literal harvest.
+   *  - Transition classifier (EXTRACTOR_TRANSITION_CLASSIFIER): the
+   *    semantic generalization — morphology candidates + the BGE-M3
+   *    prototype classifier — landing the SAME state_change shape with
+   *    the SAME holder binding. Runs LAST and receives every prior
+   *    fact, so a sentence the lexicon lane already harvested is
+   *    deferred whole (no double emission). A lane failure (embedder
+   *    down mid-request) costs only its extra recall.
+   *
+   * No-entity starvation fix: when the extraction produced ZERO grounded
+   * entities (the `no_entities` skip shape at the ingest boundary), the
+   * lanes used to be starved — nothing to bind a fact to. Here the seam
+   * mints instead: the speaker entity is minted from the caller-supplied
+   * context (the caller asserted that identity; typed `staff`, the same
+   * type the local NER path assigns a PERSON), and the literal lane may
+   * mint identifier-shaped subject entities per its extractionProfile
+   * doctrine (mintSubjects). The state lanes keep bindStateHolder
+   * semantics untouched: no person entity and no speaker → their
+   * matches skip honestly (debug log below), never mis-bind to a minted
+   * identifier. Minted entities that end up referenced by no harvested
+   * fact are pruned, so a turn that harvests nothing yields the input
+   * entity list unchanged — the `no_entities` skip fires exactly as
+   * before. Minting NEVER runs when the extraction has entities, so
+   * previously-working lanes-on paths are untouched.
+   *
+   * Returns the harvested facts ONLY (for the caller to union) and the
+   * final entity list — the input array itself unless minting added a
+   * referenced entity.
+   */
+  private async runHarvestLanes(args: {
+    trimmed: string;
+    entities: ExtractedEntity[];
+    existingFacts: ExtractedFact[];
+    context?: ConversationContext | undefined;
+  }): Promise<{ facts: ExtractedFact[]; entities: ExtractedEntity[] }> {
+    const { trimmed, entities, existingFacts, context } = args;
+    const profile = resolveExtractionProfile();
+    const anyLane =
+      profile.literalHarvest || profile.stateVerbHarvest || profile.transitionClassifier;
+    if (!anyLane) return { facts: [], entities };
+
+    // Working list the lanes bind against. Minting (no-entity turns
+    // only) appends to it; the referenced tail is folded back below.
+    const working = [...entities];
+    const mint = entities.length === 0;
+    if (mint && context?.speakerName) {
+      working.push({ name: context.speakerName, type: 'staff' });
+    }
+    if (
+      mint &&
+      !context?.speakerName &&
+      (profile.stateVerbHarvest || profile.transitionClassifier)
+    ) {
+      this.logger.debug(
+        'harvest lanes: no entities and no speaker — state-verb/transition matches have no bindable holder and are skipped',
+      );
+    }
+    const speakerEntityIndex = resolveSpeakerEntityIndex(working, context?.speakerName);
+
+    const harvested = profile.literalHarvest
       ? harvestLiterals({
           trimmed,
-          entities,
-          speakerEntityIndex: resolveSpeakerEntityIndex(entities, context?.speakerName),
-          existingFacts: denoised,
+          entities: working,
+          speakerEntityIndex,
+          existingFacts,
+          mintSubjects: mint,
         })
       : [];
     if (harvested.length > 0) {
@@ -449,20 +567,12 @@ export class ExtractorRunnerService {
       });
     }
 
-    // State-verb harvest (EXTRACTOR_STATE_VERB_HARVEST, default off):
-    // the deterministic transition lane — a past-tense lexicon
-    // (bought/joined/quit/returned/…) harvests completed acquire/
-    // dispose/change events as span-grounded `state_change` facts, with
-    // pre-verb guards so intentions ("thinking about selling") never
-    // flip state. Same seam and invariants as the literal lane; it
-    // dedups against BOTH the denoised LLM set and the literal harvest,
-    // so the two lanes compose additively when enabled together.
-    const stateHarvested = resolveExtractionProfile().stateVerbHarvest
+    const stateHarvested = profile.stateVerbHarvest
       ? harvestStateVerbs({
           trimmed,
-          entities,
-          speakerEntityIndex: resolveSpeakerEntityIndex(entities, context?.speakerName),
-          existingFacts: harvested.length > 0 ? [...denoised, ...harvested] : denoised,
+          entities: working,
+          speakerEntityIndex,
+          existingFacts: harvested.length > 0 ? [...existingFacts, ...harvested] : existingFacts,
         })
       : [];
     if (stateHarvested.length > 0) {
@@ -472,28 +582,16 @@ export class ExtractorRunnerService {
       });
     }
 
-    // Transition-classifier harvest (EXTRACTOR_TRANSITION_CLASSIFIER,
-    // default off): the semantic generalization of the state-verb
-    // lexicon lane — compromise morphology (EN) + a bounded RU matcher
-    // propose candidate clauses, the BGE-M3 prototype classifier
-    // accepts completed transitions above the calibrated floor/margin,
-    // and each acceptance lands as the SAME span-grounded state_change
-    // shape with the SAME holder binding. Runs LAST and receives every
-    // prior fact, so a sentence the lexicon lane already harvested is
-    // deferred whole (no double emission) and triples dedup across all
-    // lanes. A lane failure (embedder down mid-request) costs only its
-    // extra recall — the LLM facts and sibling lanes still carry the
-    // turn.
     let transitionHarvested: ExtractedFact[] = [];
-    if (resolveExtractionProfile().transitionClassifier) {
+    if (profile.transitionClassifier) {
       const classifier = this.transitionClassifier();
       if (classifier) {
         try {
           transitionHarvested = await harvestTransitions({
             trimmed,
-            entities,
-            speakerEntityIndex: resolveSpeakerEntityIndex(entities, context?.speakerName),
-            existingFacts: [...denoised, ...harvested, ...stateHarvested],
+            entities: working,
+            speakerEntityIndex,
+            existingFacts: [...existingFacts, ...harvested, ...stateHarvested],
             classifier,
           });
         } catch (e) {
@@ -510,22 +608,33 @@ export class ExtractorRunnerService {
       });
     }
 
-    const finalFacts =
-      harvested.length > 0 || stateHarvested.length > 0 || transitionHarvested.length > 0
-        ? [...denoised, ...harvested, ...stateHarvested, ...transitionHarvested]
-        : denoised;
+    const facts = [...harvested, ...stateHarvested, ...transitionHarvested];
+    if (working.length === entities.length) return { facts, entities };
 
-    const result: ExtractionResult = { entities, facts: finalFacts, edges };
-    this.local.persistPatterns({
-      companyId,
-      clauses,
-      rawFacts,
-      // Deliberately the LLM facts only: harvested rows are re-derived
-      // deterministically on every ingest, so caching them as replay
-      // patterns would leak flag-on behavior into flag-off replays.
-      facts: denoised,
-      edges,
+    // Fold the minted tail back in: keep only minted entities some
+    // harvested fact references (an unreferenced minted speaker must
+    // not turn a no_entities skip into a facts-less persisted mention)
+    // and remap the harvested facts onto the compacted list. Existing
+    // facts only reference the pre-mint range, which never moves.
+    const referenced = new Set(facts.map((f) => f.entityIndex));
+    const finalEntities = [...entities];
+    const remap = new Map<number, number>();
+    working.forEach((e, i) => {
+      if (i < entities.length || !referenced.has(i)) return;
+      remap.set(i, finalEntities.length);
+      finalEntities.push(e);
     });
-    return result;
+    if (finalEntities.length > entities.length) {
+      traceArtifact('extractor.harvest_minted_entities', {
+        count: finalEntities.length - entities.length,
+        names: finalEntities.slice(entities.length).map((e) => e.name),
+      });
+    }
+    return {
+      facts: facts.map((f) =>
+        remap.has(f.entityIndex) ? { ...f, entityIndex: remap.get(f.entityIndex) as number } : f,
+      ),
+      entities: finalEntities.length === entities.length ? entities : finalEntities,
+    };
   }
 }

--- a/test/extractor-harvest-starvation.unit-spec.ts
+++ b/test/extractor-harvest-starvation.unit-spec.ts
@@ -1,0 +1,342 @@
+/**
+ * Harvest-lane starvation fixes (code-memory battery k07, two live
+ * runs): the deterministic lanes used to be starved on exactly the
+ * turns they matter most for —
+ *
+ *  1. a zero-entity LLM extraction reached the harvest seam with an
+ *     empty entity list, every lane bailed, and the ingest boundary
+ *     then skipped the mention as `no_entities` — so "acme-api
+ *     throttles /v1/webhooks at 120 requests per minute." produced NO
+ *     rate_limit fact even though the RATE_LIMIT regex provably
+ *     matches it;
+ *  2. the trySkip local-replay path returned BEFORE the harvest seam,
+ *     while replay patterns deliberately carry the LLM facts only (the
+ *     lanes are promised to "re-derive on every ingest") — a replayed
+ *     turn silently lost every harvested fact.
+ *
+ * The fix is gated by the lanes' own flags (no new flag): with every
+ * lane off, both paths are byte-identical to before.
+ */
+import { harvestLiterals } from '../src/ai/extractor-internals/literal-harvest';
+import type {
+  ExtractedEntity,
+  ExtractedFact,
+  ExtractionResult,
+} from '../src/ai/extractor-internals/types';
+import { ExtractorRunnerService } from '../src/ai/extractor-runner.service';
+
+// VERBATIM corpus turn from test/eval/code-memory/corpus.ts (the k07
+// rate_limit want, the measured miss of both live battery runs).
+const THROTTLE_TURN = 'acme-api throttles /v1/webhooks at 120 requests per minute.';
+
+const FLAGS = [
+  'EXTRACTOR_LITERAL_HARVEST',
+  'EXTRACTOR_STATE_VERB_HARVEST',
+  'EXTRACTOR_TRANSITION_CLASSIFIER',
+  'EXTRACTOR_SKIP_LLM_ENABLED',
+  'EXTRACTOR_DIALOGUE_PROFILE',
+] as const;
+const saved: Record<string, string | undefined> = {};
+beforeAll(() => {
+  for (const flag of FLAGS) saved[flag] = process.env[flag];
+});
+beforeEach(() => {
+  for (const flag of FLAGS) delete process.env[flag];
+});
+afterAll(() => {
+  for (const flag of FLAGS) {
+    if (saved[flag] === undefined) delete process.env[flag];
+    else process.env[flag] = saved[flag];
+  }
+});
+
+// ── Lane level: the mintSubjects fallback grounding path ─────────────
+describe('harvestLiterals — mintSubjects fallback (no-entity turns)', () => {
+  it('k07 throttle turn, zero entities → rate_limit bound to a minted "acme-api" subject', () => {
+    const entities: ExtractedEntity[] = [];
+    const facts = harvestLiterals({
+      trimmed: THROTTLE_TURN,
+      entities,
+      speakerEntityIndex: null,
+      mintSubjects: true,
+    });
+    expect(facts).toHaveLength(1);
+    expect(facts[0]).toMatchObject({
+      predicate: 'rate_limit',
+      object: '120 requests per minute',
+      entityIndex: 0,
+    });
+    // The subject is minted from the sentence's leading identifier-shaped
+    // token (the code-memory extractionProfile doctrine), typed `other`
+    // so bindStateHolder can never pick it as a state holder.
+    expect(entities).toEqual([{ name: 'acme-api', type: 'other' }]);
+  });
+
+  it('identifier-class match becomes its OWN subject entity', () => {
+    const entities: ExtractedEntity[] = [];
+    const facts = harvestLiterals({
+      trimmed: 'ACME_RETRY_QUEUE stays disabled until the backfill lands.',
+      entities,
+      speakerEntityIndex: null,
+      mintSubjects: true,
+    });
+    expect(facts).toHaveLength(1);
+    expect(facts[0]).toMatchObject({
+      predicate: 'identifier',
+      object: 'ACME_RETRY_QUEUE',
+      entityIndex: 0,
+    });
+    expect(entities).toEqual([{ name: 'ACME_RETRY_QUEUE', type: 'other' }]);
+  });
+
+  it('minted sentence subject beats the speaker fallback (bindEntity priority preserved)', () => {
+    const entities: ExtractedEntity[] = [{ name: 'Dev', type: 'staff' }];
+    const facts = harvestLiterals({
+      trimmed: THROTTLE_TURN,
+      entities,
+      speakerEntityIndex: 0,
+      mintSubjects: true,
+    });
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.entityIndex).toBe(1);
+    expect(entities[1]).toEqual({ name: 'acme-api', type: 'other' });
+  });
+
+  it('no subject shape in the sentence → speaker fallback still applies', () => {
+    const entities: ExtractedEntity[] = [{ name: 'Dev', type: 'staff' }];
+    const facts = harvestLiterals({
+      trimmed: 'Exceeding it returns HTTP 429 and poisons the test run.',
+      entities,
+      speakerEntityIndex: 0,
+      mintSubjects: true,
+    });
+    expect(facts).toHaveLength(1);
+    expect(facts[0]).toMatchObject({ predicate: 'http_status', object: '429', entityIndex: 0 });
+    expect(entities).toHaveLength(1); // nothing minted
+  });
+
+  it('no subject shape and no speaker → the match is skipped, never invented', () => {
+    const entities: ExtractedEntity[] = [];
+    const facts = harvestLiterals({
+      trimmed: 'Exceeding it returns HTTP 429 and poisons the test run.',
+      entities,
+      speakerEntityIndex: null,
+      mintSubjects: true,
+    });
+    expect(facts).toEqual([]);
+    expect(entities).toEqual([]);
+  });
+
+  it('a rate token never reads as a path subject ("300/min" must not self-subject)', () => {
+    const entities: ExtractedEntity[] = [];
+    const facts = harvestLiterals({
+      trimmed: 'The route is throttled to 300/min in staging.',
+      entities,
+      speakerEntityIndex: null,
+      mintSubjects: true,
+    });
+    expect(facts).toEqual([]);
+    expect(entities).toEqual([]);
+  });
+
+  it('mintSubjects absent → byte-identical starved behavior (zero entities harvest nothing)', () => {
+    expect(
+      harvestLiterals({ trimmed: THROTTLE_TURN, entities: [], speakerEntityIndex: null }),
+    ).toEqual([]);
+  });
+});
+
+// ── Runner level: both starvation paths through run() ────────────────
+type LlmStub = {
+  composeSystemPrompt: () => string;
+  scPasses: number;
+  callLlm: jest.Mock;
+  modelId: () => string;
+};
+
+const mkLlm = (rawJson: unknown): LlmStub => ({
+  composeSystemPrompt: () => 'system',
+  scPasses: 1,
+  callLlm: jest.fn(async () => rawJson),
+  modelId: () => 'stub-model',
+});
+
+const mkRunner = (
+  llm: LlmStub,
+  trySkipResult: ExtractionResult | null = null,
+): { runner: ExtractorRunnerService; trySkip: jest.Mock } => {
+  const trySkip = jest.fn(async () => trySkipResult);
+  const runner = new ExtractorRunnerService(
+    llm as never,
+    { trySkip, persistPatterns: () => {} } as never,
+    { applyPredicateRefinements: async () => {} } as never,
+  );
+  return { runner, trySkip };
+};
+
+const EMPTY_RAW = { entities: [], clauses: [], facts: [], edges: [] };
+const SNAPSHOT = { versionHash: 'h', active: [] };
+
+describe('run() — the no_entities starvation path (zero-entity LLM extraction)', () => {
+  it('all lanes off → byte-identical empty result (mention still skips as no_entities)', async () => {
+    const { runner } = mkRunner(mkLlm(EMPTY_RAW));
+    const result = await runner.run({
+      trimmed: THROTTLE_TURN,
+      companyId: 'co_test',
+      snapshot: SNAPSHOT,
+    });
+    expect(result).toEqual({ entities: [], facts: [], edges: [] });
+  });
+
+  it('literal lane on → the k07 rate_limit lands on a minted acme-api entity', async () => {
+    process.env['EXTRACTOR_LITERAL_HARVEST'] = '1';
+    const { runner } = mkRunner(mkLlm(EMPTY_RAW));
+    const result = await runner.run({
+      trimmed: THROTTLE_TURN,
+      companyId: 'co_test',
+      snapshot: SNAPSHOT,
+    });
+    expect(result).toEqual({
+      entities: [{ name: 'acme-api', type: 'other' }],
+      facts: [
+        expect.objectContaining({
+          predicate: 'rate_limit',
+          object: '120 requests per minute',
+          entityIndex: 0,
+        }),
+      ],
+      edges: [],
+    });
+  });
+
+  it('state-verb lane on + known speaker → state_change binds to the minted speaker', async () => {
+    process.env['EXTRACTOR_STATE_VERB_HARVEST'] = '1';
+    const { runner } = mkRunner(mkLlm(EMPTY_RAW));
+    const result = await runner.run({
+      trimmed: 'I sold my ThinkPad today.',
+      companyId: 'co_test',
+      snapshot: SNAPSHOT,
+      context: { speakerName: 'Dev' },
+    });
+    // The speaker entity is minted from caller-supplied context (typed
+    // `staff` — the same type the local NER path assigns a PERSON).
+    expect(result).toEqual({
+      entities: [{ name: 'Dev', type: 'staff' }],
+      facts: [
+        expect.objectContaining({
+          predicate: 'state_change',
+          object: 'sold my ThinkPad today',
+          entityIndex: 0,
+        }),
+      ],
+      edges: [],
+    });
+  });
+
+  it('state-verb lane on, NO speaker → honest skip (no holder is ever invented)', async () => {
+    process.env['EXTRACTOR_STATE_VERB_HARVEST'] = '1';
+    const { runner } = mkRunner(mkLlm(EMPTY_RAW));
+    const result = await runner.run({
+      trimmed: 'I sold my ThinkPad today.',
+      companyId: 'co_test',
+      snapshot: SNAPSHOT,
+    });
+    expect(result).toEqual({ entities: [], facts: [], edges: [] });
+  });
+
+  it('a minted speaker no fact references is pruned from the result', async () => {
+    process.env['EXTRACTOR_LITERAL_HARVEST'] = '1';
+    const { runner } = mkRunner(mkLlm(EMPTY_RAW));
+    const result = await runner.run({
+      trimmed: THROTTLE_TURN,
+      companyId: 'co_test',
+      snapshot: SNAPSHOT,
+      context: { speakerName: 'Dev' },
+    });
+    // The rate_limit binds to the sentence subject, not the speaker; a
+    // speaker-only entity list must not turn the no_entities skip into
+    // a facts-less persisted mention.
+    expect(result!.entities).toEqual([{ name: 'acme-api', type: 'other' }]);
+    expect(result!.facts).toEqual([
+      expect.objectContaining({ predicate: 'rate_limit', entityIndex: 0 }),
+    ]);
+  });
+
+  it('turns WITH entities never mint (no duplicate subject, no double harvest)', async () => {
+    process.env['EXTRACTOR_LITERAL_HARVEST'] = '1';
+    const raw = {
+      entities: [{ name: 'acme-api', type: 'project' }],
+      clauses: [],
+      facts: [],
+      edges: [],
+    };
+    const { runner } = mkRunner(mkLlm(raw));
+    const result = await runner.run({
+      trimmed: THROTTLE_TURN,
+      companyId: 'co_test',
+      snapshot: SNAPSHOT,
+    });
+    expect(result!.entities).toEqual([{ name: 'acme-api', type: 'project', canonical: undefined }]);
+    const rateFacts = result!.facts.filter((f: ExtractedFact) => f.predicate === 'rate_limit');
+    expect(rateFacts).toHaveLength(1);
+    expect(rateFacts[0]!.entityIndex).toBe(0);
+  });
+});
+
+describe('run() — the trySkip replay starvation path', () => {
+  const REPLAY_TURN = 'I picked port 8443 for the ledger-sync HTTP service.';
+  const mkReplay = (): ExtractionResult => ({
+    entities: [{ name: 'ledger-sync', type: 'project' }],
+    facts: [{ entityIndex: 0, predicate: 'status', object: 'active', confidence: 0.9 }],
+    edges: [],
+  });
+
+  it('all lanes off → the exact trySkip object is returned, LLM untouched', async () => {
+    const replay = mkReplay();
+    const llm = mkLlm(EMPTY_RAW);
+    const { runner } = mkRunner(llm, replay);
+    const result = await runner.run({
+      trimmed: REPLAY_TURN,
+      companyId: 'co_test',
+      snapshot: SNAPSHOT,
+    });
+    expect(result).toBe(replay); // byte-identical: same reference
+    expect(llm.callLlm).not.toHaveBeenCalled();
+  });
+
+  it('literal lane on → the replayed result gains the harvested service_port', async () => {
+    process.env['EXTRACTOR_LITERAL_HARVEST'] = '1';
+    const replay = mkReplay();
+    const llm = mkLlm(EMPTY_RAW);
+    const { runner } = mkRunner(llm, replay);
+    const result = await runner.run({
+      trimmed: REPLAY_TURN,
+      companyId: 'co_test',
+      snapshot: SNAPSHOT,
+    });
+    expect(llm.callLlm).not.toHaveBeenCalled();
+    expect(result!.entities).toEqual(replay.entities);
+    expect(result!.facts).toEqual([
+      replay.facts[0],
+      expect.objectContaining({ predicate: 'service_port', object: '8443', entityIndex: 0 }),
+    ]);
+    // The replayed object itself is never mutated.
+    expect(replay.facts).toHaveLength(1);
+  });
+
+  it('lane on but every harvest already replayed → the exact trySkip object again', async () => {
+    process.env['EXTRACTOR_LITERAL_HARVEST'] = '1';
+    const replay: ExtractionResult = {
+      entities: [{ name: 'ledger-sync', type: 'project' }],
+      facts: [{ entityIndex: 0, predicate: 'service_port', object: '8443', confidence: 0.95 }],
+      edges: [],
+    };
+    const { runner } = mkRunner(mkLlm(EMPTY_RAW), replay);
+    const result = await runner.run({
+      trimmed: REPLAY_TURN,
+      companyId: 'co_test',
+      snapshot: SNAPSHOT,
+    });
+    expect(result).toBe(replay);
+  });
+});


### PR DESCRIPTION
## The gap

Two live code-memory battery runs plus code reading localized a starvation gap in the deterministic harvest lanes (`EXTRACTOR_LITERAL_HARVEST`, `EXTRACTOR_STATE_VERB_HARVEST`, `EXTRACTOR_TRANSITION_CLASSIFIER`): the k07 turn `acme-api throttles /v1/webhooks at 120 requests per minute.` produced **no** `rate_limit` fact in both runs, even though the `RATE_LIMIT` regex provably matches it. Two paths starved the lanes:

1. **Zero-entity LLM extraction.** The lanes run at the `assembleResult` seam but every lane bails on an empty grounded-entity list (`entities.length === 0`), so the result stays entity-less and mention ingest then skips it as `no_entities`. Terse identifier-heavy turns — exactly where the deterministic lanes matter most — are the turns the LLM most often returns zero entities for.
2. **The `trySkip` local-replay path** returned before the harvest seam. `persistPatterns` deliberately excludes harvested rows from replay patterns *on the promise that the lanes re-derive them deterministically on every ingest* — a promise the replay path broke: replayed turns silently lost every harvested fact. (Verified not-unnecessary: replay patterns are learned from LLM facts only, so no prior extraction has ever attached the harvested rows to a replayed result.)

## The fix (gated by the lanes' own existing flags — no new flag)

- The lane-union block moves out of `assembleResult` into a shared `runHarvestLanes` seam called by **both** producers of an extraction result: `assembleResult` (LLM path) and the `trySkip` replay path in `run()`. All lanes off → both paths byte-identical (the replay path returns the exact `trySkip` object, same reference).
- **Fallback grounding on no-entity turns only** (never when the extraction has entities, so previously-working lanes-on paths are untouched and nothing double-harvests):
  - `harvestLiterals` gains `mintSubjects`: an identifier-class match (`identifier`/`naming_prefix`) becomes its **own** subject entity — the code-memory extractionProfile doctrine ("identifier-shaped subjects become their OWN entities") — and any other match binds to the first identifier-shaped subject token of its sentence (ALL_CAPS / dotted / slash path / hyphenated package slug), with the speaker kept as the last resort, mirroring `bindEntity`'s name-in-sentence-over-speaker priority. Minted subjects are typed `other`, so `bindStateHolder` can never pick one as a state holder. Resolution reuses the extractor's normalized-name idiom (the `resolveSpeakerEntityIndex` match); cross-turn dedup stays where it lives today — the ingest `resolveOrCreateNamedEntity` upsert.
  - The **speaker entity** is minted from caller-supplied context (typed `staff`, the same type the local-NER path assigns a PERSON), so the state-verb/transition lanes keep their `bindStateHolder` semantics unchanged; with no speaker known their matches skip honestly with a debug log rather than mis-bind.
  - Minted entities referenced by no harvested fact are **pruned**, so a turn that harvests nothing still yields the empty entity list and the `no_entities` skip fires exactly as before.
- A sentence with no subject shape and no speaker still harvests nothing — minting never invents a subject (`300/min` is guarded from reading as a path; the shapes require a lettered first segment).

## Tests

New `test/extractor-harvest-starvation.unit-spec.ts` reproduces both starvations end-to-end through `run()`:
- zero-entity LLM stub + literal lane → the k07 `rate_limit` lands on a minted `acme-api` entity;
- state-verb sentence + speaker → `state_change` on the minted speaker; no speaker → honest empty result;
- lanes off → byte-identical empty result / the exact replay object reference;
- replay + lane on → the replayed result gains the harvested fact with **no LLM call**, no mutation of the replayed object, and dedup against already-replayed facts;
- entity-ful turns never mint (no duplicate subject, no double harvest);
- lane-level tables for the minting priority, identifier self-subjecting, and the negative guards.

`pnpm typecheck`, full `test:unit` (354 suites / 3940 tests), `pnpm format:check`, and eslint on the touched files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB