### PR TITLE
feat(facts): slot canonicalization — cross-predicate contradictions meet in one slot

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1146,6 +1146,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       "Mention-path conflict semantics. When on, a mention/extraction-path fact whose registry policy is 'single_active' — the branch that supersedes unconditionally and can never surface a COMPETING pair — is promoted to 'bitemporal', so two conversations asserting contradictory values of one (userId, entity, predicate) slot form a conflict (close-scored → COMPETING, both sides linked and served; clear winner → SUPERSEDED; equal value from a different origin → CORROBORATED) instead of the second silently replacing the first. Candidates stay per-user scope-local (0055). The append_only open-vocabulary bulk, DEFAULT_FALLBACK, and the direct typed path are untouched. Off (default) = registry passthrough, byte-identical.",
   },
+  {
+    key: 'CONFLICT_SLOT_CANONICALIZATION',
+    category: 'conflict',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Write-side slot canonicalization. The conflict machinery pairs only identical (userId, entity, predicate) slots, but the extractor legitimately splits one contradicted attribute across two predicates — 'lease runs until December 2026' is a duration phrase (duration_limit, append_only) while 'lease ends in September 2026' is a lifecycle claim (status, single_active) — so no collision structurally exists and CONFLICT_MENTION_FACT_SLOT is starved (state-transitions s07). When on, a mention-path fact whose predicate sits in a small declared alias table (duration_limit → status) AND whose object carries an explicit calendar anchor (full month name + 4-digit year, or an ISO date) resolves in the canonical single-value slot instead, re-embedded with the canonical slot text, so both arms of the contradiction meet in one slot and the normal single_active/bitemporal machinery adjudicates (with CONFLICT_MENTION_FACT_SLOT also on: close-scored → COMPETING, both sides served). Purely deterministic (static table + regex, no DB read, no fuzzy matching, no LLM), order-free and idempotent. Bare unit durations ('30 days' — the technical-literal harvest bulk), facts with an EDC predicateAlias, the direct typed path, and every other predicate are untouched. Off (default) = extracted-predicate passthrough, byte-identical. Requires re-ingest to affect existing rows.",
+  },
   // ── ABAC (migrations 0056/0057) ──────────────────────────
   {
     key: 'ABAC_ENABLED',

--- a/src/common/conflict-flags.ts
+++ b/src/common/conflict-flags.ts
@@ -60,3 +60,37 @@ export function conflictDirectFactSlotEnabled(): boolean {
 export function conflictMentionFactSlotEnabled(): boolean {
   return envFlagEnabled(process.env.CONFLICT_MENTION_FACT_SLOT);
 }
+
+/**
+ * Write-side slot canonicalization — CONFLICT_SLOT_CANONICALIZATION.
+ *
+ * The conflict machinery pairs only identical (userId, entity,
+ * predicate) slots, but the extractor legitimately splits ONE
+ * contradicted attribute across two predicates: "lease runs until
+ * December 2026" is a duration phrase (duration_limit, append_only
+ * harvest predicate) while "lease ends in September 2026" is a
+ * lifecycle claim (status, single_active) — so no collision
+ * structurally exists and CONFLICT_MENTION_FACT_SLOT is starved
+ * (state-transitions s07, measured live).
+ *
+ * When on, FactResolverService routes a mention-path fact whose
+ * predicate sits in a SMALL DECLARED alias table (duration_limit →
+ * status) AND whose object carries an explicit calendar anchor (full
+ * month name + 4-digit year, or an ISO date — a lease-end/deadline
+ * claim, never a bare unit duration like "30 days") into the canonical
+ * single-value slot, so both arms of the contradiction meet in one
+ * (userId, entity, predicate) slot and the normal single_active /
+ * bitemporal machinery sees the collision. Purely deterministic (static
+ * table + regex — no DB read, no fuzzy matching, no LLM), order-free
+ * and idempotent: both arms map to the same slot regardless of arrival
+ * order. The direct typed path (caller states its slot), the harvest
+ * bulk without calendar anchors, and every other predicate are
+ * untouched. The env read lives here in the common layer (engine-gates
+ * S5.2), read at call time so a flip is runtime-mutable. Default off ⇒
+ * extracted-predicate passthrough, byte-identical. CONFLICT_ sits off
+ * the ENGINE flag budget by design (a resolver-policy knob family, not
+ * an engine fork).
+ */
+export function conflictSlotCanonicalizationEnabled(): boolean {
+  return envFlagEnabled(process.env.CONFLICT_SLOT_CANONICALIZATION);
+}

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1421,6 +1421,18 @@ const KNOWN_BOOLEAN_FLAGS = [
   // first. append_only bulk / DEFAULT_FALLBACK / direct path untouched.
   // Off (default) ⇒ registry passthrough, byte-identical.
   'CONFLICT_MENTION_FACT_SLOT',
+  // Write-side slot canonicalization: a mention-path fact whose
+  // predicate has a declared canonical alias (duration_limit → status)
+  // AND whose object carries an explicit calendar anchor (full month
+  // name + year, or ISO date) resolves in the canonical single-value
+  // slot, so cross-predicate contradictions about one attribute meet in
+  // one (userId, entity, predicate) slot and the normal
+  // single_active/bitemporal machinery sees the collision. Static
+  // table + regex — no DB read, no fuzzy matching. Bare unit durations
+  // ("30 days"), the direct typed path, and every other predicate are
+  // untouched. Off (default) ⇒ extracted-predicate passthrough,
+  // byte-identical.
+  'CONFLICT_SLOT_CANONICALIZATION',
 ];
 
 /**

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -10,6 +10,7 @@ import { envFlagEnabled } from '../common/env-validation';
 import {
   conflictDirectFactSlotEnabled,
   conflictMentionFactSlotEnabled,
+  conflictSlotCanonicalizationEnabled,
 } from '../common/conflict-flags';
 import { supportEdgesEnabled } from '../common/provenance-flags';
 import { buildConflictEdgeRows } from '../common/support-edges';
@@ -83,6 +84,65 @@ export function conflictSlotSemantics(
   return conflictMentionFactSlotEnabled() && policy.semantics === 'single_active'
     ? 'bitemporal'
     : policy.semantics;
+}
+
+/**
+ * Slot-canonicalization alias table (CONFLICT_SLOT_CANONICALIZATION):
+ * predicate pairs the extractor legitimately splits ONE attribute
+ * across. Value = the CANONICAL slot — deliberately the single-value
+ * (single_active) member of the pair, because that is the slot whose
+ * collisions the conflict machinery adjudicates (and which
+ * CONFLICT_MENTION_FACT_SLOT promotes to the bitemporal margin
+ * doctrine). Keep this table SMALL and declared: every entry is a
+ * deliberate ontology statement, not a similarity guess.
+ */
+export const SLOT_CANONICAL_ALIASES: ReadonlyMap<string, string> = new Map([
+  // "runs until December 2026" (a duration phrase → duration_limit,
+  // append_only) vs "ends in September 2026" (a lifecycle claim →
+  // status, single_active): same attribute, two slots (s07).
+  ['duration_limit', 'status'],
+]);
+
+/**
+ * Deterministic same-attribute gate for slot canonicalization: the
+ * object must carry an EXPLICIT calendar anchor — a full month name
+ * followed (optionally via a day) by a 4-digit year, or an ISO date.
+ * A calendar-anchored "duration" ("until December 2026") is a
+ * deadline/lifecycle claim about the entity; a bare unit duration
+ * ("30 days", "5 minutes" — the technical-literal harvest bulk) is not
+ * and must stay in its append_only slot. Full month names only —
+ * abbreviations miss conservatively (no reroute), never false-hit.
+ */
+const CALENDAR_ANCHOR_RE =
+  /\b(?:january|february|march|april|may|june|july|august|september|october|november|december)\b(?:\s+\d{1,2}(?:st|nd|rd|th)?,?)?\s+\d{4}\b|\b\d{4}-\d{2}-\d{2}\b/i;
+
+/**
+ * Write-side slot canonicalization (CONFLICT_SLOT_CANONICALIZATION,
+ * default off) — the canonical slot a fact should resolve in, or
+ * undefined for the extracted-predicate passthrough. Applies ONLY when
+ * ALL of:
+ *  - mention path (the direct typed path stated its slot on purpose);
+ *  - the flag is on;
+ *  - no predicateAlias is set (an EDC coinage already has a canon —
+ *    0082 owns that mapping, never clobber it);
+ *  - the predicate has a declared canonical alias (table above);
+ *  - the object passes the calendar-anchor gate.
+ * Static table + regex — no DB read, no fuzzy matching, no LLM — so the
+ * mapping is order-free and idempotent: BOTH arms of a cross-predicate
+ * contradiction land in the canonical slot regardless of arrival order,
+ * and the normal single_active/bitemporal machinery
+ * (conflictSlotSemantics above) sees the collision. Pure decision (env
+ * read lives in src/common/conflict-flags.ts); exported for tests.
+ */
+export function canonicalSlotFor(
+  p: { predicate: string; predicateAlias?: string | undefined; object: string },
+  path: 'direct' | 'mention',
+): string | undefined {
+  if (path !== 'mention' || !conflictSlotCanonicalizationEnabled()) return undefined;
+  if (p.predicateAlias !== undefined) return undefined;
+  const canonical = SLOT_CANONICAL_ALIASES.get(p.predicate);
+  if (canonical === undefined) return undefined;
+  return CALENDAR_ANCHOR_RE.test(p.object) ? canonical : undefined;
 }
 
 /**
@@ -289,19 +349,27 @@ export class FactResolverService {
   private async buildResolveCall(
     p: Parameters<FactResolverService['resolve']>[1],
   ): Promise<Parameters<FactResolverService['resolveFactCall']>[1]> {
-    const policy = this.predicateRegistry.policyFor(p.companyId, p.predicate);
+    // The direct path is exactly recordOutcomeMetric === true (set ONLY
+    // by FactIngestService.ingestFact); everything else — mention
+    // extraction — is the mention path.
+    const path = p.recordOutcomeMetric === true ? 'direct' : 'mention';
+    // Slot canonicalization (CONFLICT_SLOT_CANONICALIZATION, default
+    // off): a mention-path fact whose predicate has a declared canonical
+    // alias AND whose object carries an explicit calendar anchor
+    // resolves in the canonical slot — see canonicalSlotFor above.
+    // Undefined (flag off, or any guard) ⇒ extracted-predicate
+    // passthrough, byte-identical.
+    const canonicalSlot = canonicalSlotFor(p, path);
+    const predicate = canonicalSlot ?? p.predicate;
+    const policy = this.predicateRegistry.policyFor(p.companyId, predicate);
     // Conflict-slot promotion (CONFLICT_DIRECT_FACT_SLOT /
     // CONFLICT_MENTION_FACT_SLOT, both default off): the shared helper
     // routes each path's blind spot into fn::resolve_fact's 'bitemporal'
-    // margin doctrine — see conflictSlotSemantics above. The direct path
-    // is exactly recordOutcomeMetric === true (set ONLY by
-    // FactIngestService.ingestFact); everything else — mention
-    // extraction — is the mention path. Flags off ⇒ registry
-    // passthrough, byte-identical.
-    const semantics = conflictSlotSemantics(
-      policy,
-      p.recordOutcomeMetric === true ? 'direct' : 'mention',
-    );
+    // margin doctrine — see conflictSlotSemantics above. Flags off ⇒
+    // registry passthrough, byte-identical. Composes with
+    // canonicalization: the canonical slot's registry policy (status →
+    // single_active) is what the mention promotion sees.
+    const semantics = conflictSlotSemantics(policy, path);
     const sourceTrust = sourceTrustFor(p.source as Parameters<typeof sourceTrustFor>[0]);
     // Confidence-aware attribution (MULTILINGUAL_LANG_ATTRIBUTION, default
     // off). Off → detectLanguage keeps its Phase-4 `en` fallback and no new
@@ -354,13 +422,23 @@ export class FactResolverService {
         detectorVersion: detLang.detectorVersion,
       });
     }
+    // Canonicalized facts are re-embedded with the CANONICAL slot text
+    // (ignoring the caller's precomputed vector, which was built from
+    // the extracted predicate): the stored embedding must match the
+    // stored slot so the bitemporal cosine gate compares like-with-like
+    // — the exact vector the fact would carry had the extractor chosen
+    // the canonical slot. Deterministic (same embedder space, LRU-cached).
     const embedding =
-      p.precomputedEmbedding ??
-      (await this.factEmbedding.embed(p.embeddingText ?? factIndexText(p.predicate, p.object)));
+      canonicalSlot !== undefined
+        ? await this.factEmbedding.embed(factIndexText(predicate, p.object))
+        : (p.precomputedEmbedding ??
+          (await this.factEmbedding.embed(
+            p.embeddingText ?? factIndexText(p.predicate, p.object),
+          )));
     return {
       companyId: p.companyId,
       entityId: p.entityId,
-      predicate: p.predicate,
+      predicate,
       predicateAlias: p.predicateAlias,
       object: p.object,
       objectMeta: p.objectMeta,

--- a/test/conflict-slot-canonicalization.unit-spec.ts
+++ b/test/conflict-slot-canonicalization.unit-spec.ts
@@ -1,0 +1,266 @@
+import { FactResolverService, canonicalSlotFor } from '../src/ingest/fact-resolver.service';
+
+/**
+ * CONFLICT_SLOT_CANONICALIZATION — write-side slot canonicalization at
+ * the shared buildResolveCall seam (canonicalSlotFor). The conflict
+ * machinery pairs only identical (userId, entity, predicate), but the
+ * extractor splits one contradicted attribute across two predicates
+ * (state-transitions s07, measured live): "runs until December 2026"
+ * lands as (office lease, duration_limit) — an append_only harvest
+ * predicate — while "ends in September 2026" lands as (office lease,
+ * status), so no collision structurally exists and
+ * CONFLICT_MENTION_FACT_SLOT is starved. The flag routes the
+ * calendar-anchored duration_limit arm into the canonical status slot
+ * at write time (static declared alias table + calendar-anchor regex —
+ * no DB read, no fuzzy matching, no LLM), so both arms meet in ONE slot
+ * and the normal single_active/bitemporal machinery adjudicates. Pins:
+ *  - flag off (unset AND '0') → extracted-predicate passthrough, the
+ *    resolver call byte-identical;
+ *  - flag on: the EXACT s07 shapes meet in one slot — both arms bind
+ *    predicate 'status' regardless of arrival order, the rerouted arm
+ *    is re-embedded with the canonical slot text, and with
+ *    CONFLICT_MENTION_FACT_SLOT also on both bind semantics
+ *    'bitemporal' (COMPETING passthrough);
+ *  - non-contradicting different predicates untouched: a bare unit
+ *    duration ("30 days") stays in append_only duration_limit;
+ *  - other predicates, the direct typed path, and facts carrying an
+ *    EDC predicateAlias (0082 canon) are untouched;
+ *  - different entities bind their own $eid — pool separation stays
+ *    the fn's entityId filter, canonicalization never crosses entities.
+ */
+describe('FactResolverService — CONFLICT_SLOT_CANONICALIZATION', () => {
+  afterEach(() => {
+    delete process.env.CONFLICT_SLOT_CANONICALIZATION;
+    delete process.env.CONFLICT_MENTION_FACT_SLOT;
+    delete process.env.CONFLICT_DIRECT_FACT_SLOT;
+  });
+
+  function make(
+    resolveRow: Record<string, unknown> = { factId: 'knowledge_fact:x', outcome: 'INSERTED' },
+  ) {
+    const queries: Array<{ sql: string; params: Record<string, unknown> }> = [];
+    const db = {
+      query: jest.fn(async (sql: string, params: Record<string, unknown>) => {
+        queries.push({ sql, params });
+        return [resolveRow];
+      }),
+    };
+    const factEmbedding = {
+      embed: jest.fn(async () => [0.5]),
+      writeAltEmbeddingIfHype: jest.fn(async () => {}),
+    };
+    // Mirrors PredicateRegistryService.policyFor over the CORE seed: the
+    // two s07 slots return their seed policies; anything else falls to
+    // the DEFAULT_FALLBACK sentinel ('__default__', append_only).
+    const predicateRegistry = {
+      getSnapshot: jest.fn(async () => ({})),
+      policyFor: jest.fn((_c: string, predicate: string) => {
+        if (predicate === 'status') return { predicateId: 'status', semantics: 'single_active' };
+        if (predicate === 'duration_limit')
+          return { predicateId: 'duration_limit', semantics: 'append_only' };
+        return { predicateId: '__default__', semantics: 'append_only' };
+      }),
+    };
+    const svc = new FactResolverService(factEmbedding as never, predicateRegistry as never);
+    return { svc, db, queries, factEmbedding };
+  }
+
+  /** The two s07 arms exactly as measured live on the stand. */
+  const DECEMBER_ARM = { predicate: 'duration_limit', object: 'until December 2026' };
+  const SEPTEMBER_ARM = { predicate: 'status', object: 'ends in September 2026' };
+
+  function input(
+    f: { predicate: string; object: string },
+    opts: {
+      recordOutcomeMetric?: boolean;
+      userId?: string;
+      entityId?: string;
+      predicateAlias?: string;
+    } = {},
+  ) {
+    return {
+      companyId: 'co_x',
+      entityId: opts.entityId ?? 'knowledge_entity:office-lease',
+      predicate: f.predicate,
+      object: f.object,
+      confidence: 0.9,
+      validFrom: new Date('2026-08-08T10:00:00Z'),
+      source: {},
+      precomputedEmbedding: [0.1, 0.2],
+      ...(opts.recordOutcomeMetric !== undefined
+        ? { recordOutcomeMetric: opts.recordOutcomeMetric }
+        : {}),
+      ...(opts.userId !== undefined ? { userId: opts.userId } : {}),
+      ...(opts.predicateAlias !== undefined ? { predicateAlias: opts.predicateAlias } : {}),
+    };
+  }
+
+  const resolveCalls = (queries: Array<{ sql: string; params: Record<string, unknown> }>) =>
+    queries.filter((q) => q.sql.includes('fn::resolve_fact('));
+
+  it('flag off: extracted-predicate passthrough, resolver call byte-identical', async () => {
+    // Baseline pin: with the flag unset AND with it explicitly '0', the
+    // fn::resolve_fact invocation binds the exact same parameters — the
+    // default-off promise is byte-identical current behavior.
+    const unset = make();
+    const outUnset = await unset.svc.resolve(unset.db as never, input(DECEMBER_ARM));
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '0';
+    const off = make();
+    const outOff = await off.svc.resolve(off.db as never, input(DECEMBER_ARM));
+
+    for (const run of [unset, off]) {
+      const params = resolveCalls(run.queries)[0]!.params;
+      expect(params.predicate).toBe('duration_limit');
+      expect(params.semantics).toBe('append_only');
+      // The caller's precomputed vector rides through untouched.
+      expect(params.embedding).toEqual([0.1, 0.2]);
+      expect(run.factEmbedding.embed).not.toHaveBeenCalled();
+    }
+    expect(outUnset.semantics).toBe('append_only');
+    expect(outOff.semantics).toBe('append_only');
+    expect(resolveCalls(off.queries)[0]!.params).toEqual(resolveCalls(unset.queries)[0]!.params);
+  });
+
+  it('flag on: the exact s07 shapes meet in ONE slot regardless of arrival order', async () => {
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+    const { svc, db, queries, factEmbedding } = make();
+    // December arm first (as on the stand: conv s07a precedes s07b).
+    await svc.resolve(db as never, input(DECEMBER_ARM));
+    await svc.resolve(db as never, input(SEPTEMBER_ARM));
+    const calls = resolveCalls(queries);
+    expect(calls).toHaveLength(2);
+    // Both arms bind the canonical slot — the collision now exists.
+    expect(calls[0]!.params.predicate).toBe('status');
+    expect(calls[1]!.params.predicate).toBe('status');
+    // The rerouted arm is re-embedded with the CANONICAL slot text (the
+    // vector it would carry had the extractor chosen status), so the
+    // bitemporal cosine gate compares like-with-like; the native arm
+    // keeps its precomputed vector.
+    expect(factEmbedding.embed).toHaveBeenCalledTimes(1);
+    expect(factEmbedding.embed).toHaveBeenCalledWith('status: until December 2026');
+    expect(calls[0]!.params.embedding).toEqual([0.5]);
+    expect(calls[1]!.params.embedding).toEqual([0.1, 0.2]);
+    // Objects ride into the fn VERBATIM — no value rewriting.
+    expect(calls[0]!.params.object).toBe('until December 2026');
+    expect(calls[1]!.params.object).toBe('ends in September 2026');
+  });
+
+  it('flag on alone: canonical slot takes its registry policy (single_active)', async () => {
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+    const { svc, db, queries } = make();
+    const out = await svc.resolve(db as never, input(DECEMBER_ARM));
+    expect(resolveCalls(queries)[0]!.params.semantics).toBe('single_active');
+    expect(out.semantics).toBe('single_active');
+  });
+
+  it('flag on + CONFLICT_MENTION_FACT_SLOT: composes into the bitemporal margin doctrine, COMPETING pair linked', async () => {
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+    process.env.CONFLICT_MENTION_FACT_SLOT = '1';
+    const { svc, db, queries } = make({
+      factId: 'knowledge_fact:new',
+      outcome: 'COMPETING',
+      competingFactIds: ['knowledge_fact:prior'],
+    });
+    const out = await svc.resolve(db as never, input(DECEMBER_ARM));
+    expect(resolveCalls(queries)[0]!.params.semantics).toBe('bitemporal');
+    expect(out.semantics).toBe('bitemporal');
+    expect(out.result.outcome).toBe('COMPETING');
+    expect(out.result.competingFactIds).toEqual(['knowledge_fact:prior']);
+  });
+
+  it('flag on + bare unit duration ("30 days"): non-contradicting harvest bulk untouched', async () => {
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+    const { svc, db, queries, factEmbedding } = make();
+    const out = await svc.resolve(
+      db as never,
+      input({ predicate: 'duration_limit', object: '30 days' }),
+    );
+    const params = resolveCalls(queries)[0]!.params;
+    expect(params.predicate).toBe('duration_limit');
+    expect(params.semantics).toBe('append_only');
+    expect(params.embedding).toEqual([0.1, 0.2]);
+    expect(factEmbedding.embed).not.toHaveBeenCalled();
+    expect(out.semantics).toBe('append_only');
+  });
+
+  it('flag on + predicates outside the declared table: untouched even with a calendar anchor', async () => {
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+    const { svc, db, queries } = make();
+    await svc.resolve(
+      db as never,
+      input({ predicate: 'preference', object: 'until December 2026' }),
+    );
+    await svc.resolve(
+      db as never,
+      input({ predicate: 'lease_end_date', object: 'ends in September 2026' }),
+    );
+    const calls = resolveCalls(queries);
+    expect(calls[0]!.params.predicate).toBe('preference');
+    expect(calls[1]!.params.predicate).toBe('lease_end_date');
+  });
+
+  it('flag on + direct path (recordOutcomeMetric): untouched — the caller stated its slot', async () => {
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+    const { svc, db, queries } = make();
+    const out = await svc.resolve(db as never, input(DECEMBER_ARM, { recordOutcomeMetric: true }));
+    expect(resolveCalls(queries)[0]!.params.predicate).toBe('duration_limit');
+    expect(out.semantics).toBe('append_only');
+  });
+
+  it('flag on + EDC predicateAlias present: 0082 owns the canon, never clobbered', async () => {
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+    const { svc, db, queries } = make();
+    await svc.resolve(db as never, input(DECEMBER_ARM, { predicateAlias: 'contract_term' }));
+    const params = resolveCalls(queries)[0]!.params;
+    expect(params.predicate).toBe('duration_limit');
+    expect(params.predicate_alias).toBe('contract_term');
+  });
+
+  it('flag on + different entities: each binds its own $eid — no cross-entity collision', async () => {
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+    const { svc, db, queries } = make();
+    await svc.resolve(db as never, input(DECEMBER_ARM, { entityId: 'knowledge_entity:lease-a' }));
+    await svc.resolve(db as never, input(SEPTEMBER_ARM, { entityId: 'knowledge_entity:lease-b' }));
+    const calls = resolveCalls(queries);
+    expect(calls[0]!.params.eid).toBe('lease-a');
+    expect(calls[1]!.params.eid).toBe('lease-b');
+  });
+
+  describe('canonicalSlotFor — the pure decision', () => {
+    it('flag off: undefined for every shape', () => {
+      expect(canonicalSlotFor(DECEMBER_ARM, 'mention')).toBeUndefined();
+      expect(canonicalSlotFor(SEPTEMBER_ARM, 'mention')).toBeUndefined();
+    });
+
+    it('flag on: reroutes exactly the calendar-anchored declared-table shapes, mention path only', () => {
+      process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+      // The s07 duration arm reroutes; the status arm is already native
+      // (identity — not in the table, no rewrite needed).
+      expect(canonicalSlotFor(DECEMBER_ARM, 'mention')).toBe('status');
+      expect(canonicalSlotFor(SEPTEMBER_ARM, 'mention')).toBeUndefined();
+      // Calendar-anchor variants.
+      expect(
+        canonicalSlotFor({ predicate: 'duration_limit', object: 'December 15, 2026' }, 'mention'),
+      ).toBe('status');
+      expect(
+        canonicalSlotFor({ predicate: 'duration_limit', object: 'through 2026-09-30' }, 'mention'),
+      ).toBe('status');
+      // Conservative misses: unit durations, month without a year,
+      // abbreviations — no reroute.
+      expect(
+        canonicalSlotFor({ predicate: 'duration_limit', object: '30 days' }, 'mention'),
+      ).toBeUndefined();
+      expect(
+        canonicalSlotFor({ predicate: 'duration_limit', object: 'ends in September' }, 'mention'),
+      ).toBeUndefined();
+      expect(
+        canonicalSlotFor({ predicate: 'duration_limit', object: 'until Dec 2026' }, 'mention'),
+      ).toBeUndefined();
+      // Direct path and alias-carrying facts never reroute.
+      expect(canonicalSlotFor(DECEMBER_ARM, 'direct')).toBeUndefined();
+      expect(
+        canonicalSlotFor({ ...DECEMBER_ARM, predicateAlias: 'contract_term' }, 'mention'),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/test/eval/state-transitions/README.md
+++ b/test/eval/state-transitions/README.md
@@ -70,11 +70,16 @@ prints `(expected today)` next to them):
 - **s08-belief** — `SCENES_BELIEF_FIELD_FOLD`: "home city" and "place of
   residence" fold into different free-text field keys, so no single
   belief carries `value` + `priorValue` across the drifted wording.
-- **s07-serve** — `CONFLICT_MENTION_FACT_SLOT`: the mention-path slot
-  resolves to `single_active` semantics, which supersedes
-  unconditionally and never forms the COMPETING pair, so serving picks
-  one side of a live contradiction. The flag (default off) promotes the
-  slot to `bitemporal` margin doctrine so the pair competes.
+- **s07-serve** — `CONFLICT_SLOT_CANONICALIZATION`: the two arms extract
+  into DIFFERENT slots on one entity — `(office lease, status)` = "ends
+  in September 2026" vs `(office lease, duration_limit)` = "until
+  December 2026" (measured live) — and the conflict machinery pairs only
+  identical `(userId, entity, predicate)`, so even with
+  `CONFLICT_MENTION_FACT_SLOT` on no collision structurally exists. The
+  flag (default off) routes the calendar-anchored `duration_limit` arm
+  into the canonical `status` slot at write time so the pair meets in
+  one slot and the `bitemporal` margin doctrine (which
+  `CONFLICT_MENTION_FACT_SLOT` applies there) can compete it.
 
 The battery still RUNS these checks and records their fails — that is
 the baseline those flags, once merged and enabled, are measured against.

--- a/test/eval/state-transitions/scenarios.ts
+++ b/test/eval/state-transitions/scenarios.ts
@@ -356,10 +356,12 @@ export const SCENARIOS: Scenario[] = [
         // unambiguous and phrasing-proof.
         conflictSides: { sideA: ['December'], sideB: ['September'] },
         knownFailToday:
-          'CONFLICT_MENTION_FACT_SLOT — mention-path extraction resolves the slot to ' +
-          'single_active semantics, whose resolver branch supersedes unconditionally and ' +
-          'never forms the COMPETING pair, so serving picks one side; the flag (default ' +
-          'off) promotes the slot to bitemporal margin doctrine',
+          'CONFLICT_SLOT_CANONICALIZATION — the arms extract into DIFFERENT slots on one ' +
+          'entity ((office lease, status) vs (office lease, duration_limit)), and the ' +
+          'conflict machinery pairs only identical (userId, entity, predicate), so even ' +
+          'with CONFLICT_MENTION_FACT_SLOT on no collision structurally exists; the flag ' +
+          '(default off) routes the calendar-anchored duration_limit arm into the status ' +
+          'slot at write time so the bitemporal margin doctrine sees the collision',
       },
       {
         kind: 'provenance',


### PR DESCRIPTION
## Problem

State-transitions **s07** (contradiction: two live sources disagree about the office lease end date) is the last deterministic red of the battery. Measured live with all flags on, including `CONFLICT_MENTION_FACT_SLOT` (#444): the two arms extract into **different slots on the same entity** — `(office lease, status) = "ends in September 2026"` vs `(office lease, duration_limit) = "until December 2026"`. The conflict machinery (`fn::resolve_fact`, 0085) pools candidates only over identical `(userId, entity, predicate)`, and `duration_limit` is an `append_only` harvest predicate (#423) whose pool is `[]` by definition — so **no collision structurally exists**. #444 is correct but starved of same-slot collisions; serving silently picks one side.

## Design decision: write-side (a), not serve-side (b)

Both candidate designs were evaluated in the code:

**(a) Write-side slot canonicalization** — shipped. One seam: `buildResolveCall` in `FactResolverService`, the exact decision point #444 already lives at (both mention persist paths — per-fact and batched — flow through it; the derived-world batch does not, by design). A mention-path fact whose predicate sits in a **small declared alias table** (`duration_limit → status`) AND whose object carries an **explicit calendar anchor** (full month name + 4-digit year, or an ISO date) resolves in the canonical single-value slot. Static table + regex: no DB read, no fuzzy matching, no LLM, **order-free and idempotent** — both arms map to the same slot whichever conversation arrives first. The canonicalized fact is re-embedded with the canonical slot text (`status: until December 2026`), so the bitemporal cosine gate compares like-with-like — the exact vector the fact would carry had the extractor chosen the canonical slot. Downstream needs zero changes: the registry policy of the canonical slot (`status`, `single_active`) is what `conflictSlotSemantics` (#444) sees, the margin doctrine forms the COMPETING pair, and the existing serve-side render (`detectEvidenceConflicts` → "Conflict pairs (write-side COMPETING)" in the generator prompt) names both sides.

**(b) Serve-side cross-predicate surfacing** — rejected for blast radius. `detectEvidenceConflicts` is slot-keyed (`entityId::predicate`); cross-predicate surfacing would require regrouping evidence by entity, a value-typed mutual-contradiction test, and a score-proximity heuristic **per query at serve time** — duplicating conflict doctrine in a second place, touching every serve, and still never forming the write-side COMPETING pair (so `get_competing_facts`, outcome telemetry (0107), and support edges (0116) would all stay blind to the contradiction). Design (a) is one pure function plus three wired lines; the honest deterministic same-attribute test exists (declared pair + calendar anchor), so per the task's preference (a) wins.

## What changed

- `src/ingest/fact-resolver.service.ts` — `SLOT_CANONICAL_ALIASES` (one entry: `duration_limit → status`), `CALENDAR_ANCHOR_RE` (full month names + 4-digit year, optional day, or ISO date — bare unit durations like `"30 days"` never match), and pure exported `canonicalSlotFor()`; `buildResolveCall` uses the canonical slot for policy lookup, the `$predicate` binding, and (canonicalized facts only) a re-embed with the canonical slot text. The KeyedMutex lock key and the 0085 candidate pool follow automatically.
- `src/common/conflict-flags.ts` — `conflictSlotCanonicalizationEnabled()` (`CONFLICT_SLOT_CANONICALIZATION`, CONFLICT_ family, env read in the common layer per S5.2, call-time read so a flip is runtime-mutable).
- `src/common/env-validation.ts` — `KNOWN_BOOLEAN_FLAGS` entry.
- `src/admin/config-catalog.data.ts` — catalog entry (category `conflict`, default `'0'`, runtime-mutable, boolean).
- `test/eval/state-transitions/scenarios.ts` + `README.md` — s07's `knownFailToday` now names `CONFLICT_SLOT_CANONICALIZATION` (the #135 idiom).
- `test/conflict-slot-canonicalization.unit-spec.ts` — new spec (9 resolver tests + pure-decision tests).

## Guardrails (all pinned in the unit spec)

- **Flag off (unset AND `'0'`): byte-identical** — the `fn::resolve_fact` invocation binds the exact same parameters, precomputed embedding untouched.
- **The exact s07 shapes pass**: both arms bind `predicate = 'status'` regardless of arrival order; the rerouted arm re-embeds as `status: until December 2026`; with `CONFLICT_MENTION_FACT_SLOT` also on, both bind `semantics = 'bitemporal'` and the COMPETING pair passes through linked.
- **Non-contradicting different predicates untouched**: `("30 days", duration_limit)` stays `append_only` with its precomputed vector; predicates outside the declared table never reroute even with a calendar anchor.
- **Different entities untouched**: each resolve binds its own `$eid` — pool separation stays the fn's `entityId` filter.
- **Direct typed path untouched** (the caller stated its slot); **EDC `predicateAlias` facts untouched** (0082 owns that canon); month-without-year and abbreviations miss conservatively.

## Constraints honored

- No new migration; no SurrealQL touched at all (no DELETE/UPDATE-WHERE anywhere near the 0093 quirk — the only new write behavior is a different `$predicate` binding into the existing `fn::resolve_fact`).
- Deterministic and idempotent: static table + regex; re-ingest maps identically.
- One seam, no hybrid: serve-side rendering is reached only through the write-side COMPETING pair it already consumes.

## Gates

- `pnpm typecheck` — clean
- `pnpm test:unit` — 355 suites / 3951 tests green (includes the new spec and the #444 sibling)
- `pnpm format:check` — clean
- `eslint --max-warnings 0` over changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB