### PR TITLE
feat(packs): industry packs 0.2.0 — memoryModel, eval fixtures for all six domains

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -305,10 +305,9 @@ contract**: how this domain perceives and episodizes memory. It turns a
 pack from a vocabulary into a domain *projection*: the pack declares HOW
 to look, never WHAT is true. The contract is validated, stored, cached,
 exposed read-only on the admin surface, and read by five live core
-consumers (listed below). No first-party pack in `packs/` declares a
-`memoryModel` section yet — the contract and its consumers are ahead of
-the catalogue; the builtin `code_memory` pack declares one as of 0.4.0
-(the reference declaration).
+consumers (listed below). The builtin `code_memory` pack declares one as
+of 0.4.0 (the reference declaration), and every first-party industry
+pack in `packs/` declares one as of 0.2.0 (see the library table below).
 
 The semantic plane has five optional arrays. The Evidence Plane adds
 three declarative capabilities. A present section must declare at least
@@ -607,16 +606,17 @@ ABAC deny rule.
 Beyond the builtin `code_memory`, brain ships a library of DISTRIBUTABLE
 industry packs (installed per-tenant, published to the registry via
 `pnpm registry:seed`) — each a complete ontology with predicates +
-`extractionProfile` + `evalFixtures`, not a stub:
+`extractionProfile` + `evalFixtures` + `memoryModel` (as of 0.2.0), not
+a stub:
 
-| pack | domain | predicates (namespaced `<id>__*`) |
-|---|---|---|
-| `real_estate` | property | zoned_as, valued_at, listed_at, encumbered_by, tenure_type, built_in |
-| `fintech` | financial-services regulation | regulated_by, licensed_as, complies_with, capital_requirement, settlement_period |
-| `medical` | clinical pharmacology (drugs, not patients) | treats, dosed_at, administered_via, interacts_with, contraindicated_with |
-| `legal` | contracts | governed_by, party_to, obligation, effective_from, terminates_on |
-| `insurance` | insurance policies | covers, coverage_limit, premium, deductible, excludes |
-| `hr` | HR / recruiting (roles, not PII) | requires_skill, seniority, compensation, employment_type, work_location |
+| pack | domain | predicates (namespaced `<id>__*`) | memoryModel lifecycles |
+|---|---|---|---|
+| `real_estate` | property | zoned_as, valued_at, listed_at, encumbered_by, tenure_type, built_in | listing, tenancy, permit |
+| `fintech` | financial-services regulation | regulated_by, licensed_as, complies_with, capital_requirement, settlement_period | license, certification, enforcement |
+| `medical` | clinical pharmacology (drugs, not patients) | treats, dosed_at, administered_via, interacts_with, contraindicated_with | prescription, approval |
+| `legal` | contracts | governed_by, party_to, obligation, effective_from, terminates_on | matter, agreement, obligation |
+| `insurance` | insurance policies | covers, coverage_limit, premium, deductible, excludes | policy, claim |
+| `hr` | HR / recruiting (roles, not PII) | requires_skill, seniority, compensation, employment_type, work_location | position, employee |
 
 Sources: `src/ai/domain-packs/*.pack.ts` (the `FIRST_PARTY_PACKS` list) →
 committed JSON in `packs/*.pack.json` (drift-guarded by

--- a/packs/fintech.pack.json
+++ b/packs/fintech.pack.json
@@ -1,7 +1,7 @@
 {
   "id": "fintech",
-  "version": "0.1.0",
-  "description": "Financial-services regulation ontology — regulators, licenses, compliance standards, capital, and settlement of institutions/products, with a domain extraction profile.",
+  "version": "0.2.0",
+  "description": "Financial-services regulation ontology — regulators, licenses, compliance standards, capital, and settlement of institutions/products, with a domain extraction profile and memory model.",
   "predicates": [
     {
       "localId": "regulated_by",
@@ -71,6 +71,245 @@
       }
     ]
   },
+  "memoryModel": {
+    "sceneSchemas": [
+      {
+        "id": "audit_review",
+        "description": "A compliance audit or regulatory examination: an auditor or regulator reviews the institution and findings are discussed.",
+        "cues": [
+          "audit",
+          "examination",
+          "regulator visit",
+          "findings"
+        ]
+      },
+      {
+        "id": "regulatory_filing",
+        "description": "A regulatory filing or reporting event: the institution submits returns, disclosures, or capital reports to its regulator.",
+        "cues": [
+          "filing",
+          "submitted",
+          "annual return",
+          "disclosure"
+        ]
+      }
+    ],
+    "stateModels": [
+      {
+        "id": "license_lifecycle",
+        "subjectType": "license",
+        "states": [
+          "applied",
+          "granted",
+          "suspended",
+          "revoked",
+          "surrendered"
+        ],
+        "transitions": [
+          {
+            "from": "applied",
+            "to": "granted"
+          },
+          {
+            "from": "granted",
+            "to": "suspended"
+          },
+          {
+            "from": "suspended",
+            "to": "granted"
+          },
+          {
+            "from": "granted",
+            "to": "revoked"
+          },
+          {
+            "from": "suspended",
+            "to": "revoked"
+          },
+          {
+            "from": "granted",
+            "to": "surrendered"
+          }
+        ]
+      },
+      {
+        "id": "certification_lifecycle",
+        "subjectType": "compliance_certification",
+        "states": [
+          "in_assessment",
+          "certified",
+          "lapsed",
+          "withdrawn"
+        ],
+        "transitions": [
+          {
+            "from": "in_assessment",
+            "to": "certified"
+          },
+          {
+            "from": "certified",
+            "to": "lapsed"
+          },
+          {
+            "from": "lapsed",
+            "to": "in_assessment"
+          },
+          {
+            "from": "certified",
+            "to": "withdrawn"
+          }
+        ]
+      },
+      {
+        "id": "enforcement_lifecycle",
+        "subjectType": "enforcement_action",
+        "states": [
+          "opened",
+          "remediation_ordered",
+          "settled",
+          "closed"
+        ],
+        "transitions": [
+          {
+            "from": "opened",
+            "to": "remediation_ordered"
+          },
+          {
+            "from": "remediation_ordered",
+            "to": "settled"
+          },
+          {
+            "from": "opened",
+            "to": "settled"
+          },
+          {
+            "from": "settled",
+            "to": "closed"
+          },
+          {
+            "from": "opened",
+            "to": "closed"
+          }
+        ]
+      }
+    ],
+    "attentionHints": [
+      {
+        "cue": "regulated by",
+        "prefer": [
+          "regulated_by"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "license",
+        "prefer": [
+          "licensed_as"
+        ],
+        "zoom": [
+          "facts",
+          "episodes"
+        ],
+        "weight": 0.7
+      },
+      {
+        "cue": "compliant",
+        "prefer": [
+          "complies_with"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "capital",
+        "prefer": [
+          "capital_requirement"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "settlement",
+        "prefer": [
+          "settlement_period"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "revoked",
+        "prefer": [
+          "licensed_as",
+          "regulated_by"
+        ],
+        "zoom": [
+          "episodes",
+          "facts"
+        ],
+        "weight": 0.7
+      },
+      {
+        "cue": "audit",
+        "prefer": [
+          "complies_with"
+        ],
+        "zoom": [
+          "audit_review",
+          "episodes"
+        ],
+        "weight": 0.6
+      }
+    ],
+    "verificationRules": [
+      {
+        "claimPattern": "licensed",
+        "requires": "recency_check"
+      },
+      {
+        "claimPattern": "settlement",
+        "requires": "recency_check"
+      }
+    ],
+    "retentionHints": [
+      {
+        "predicateOrScene": "regulated_by",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "licensed_as",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "complies_with",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "capital_requirement",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "settlement_period",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "audit_review",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "regulatory_filing",
+        "hint": "standard"
+      }
+    ]
+  },
   "evalFixtures": [
     {
       "id": "regulator",
@@ -107,6 +346,49 @@
           {
             "predicate": "settlement_period",
             "objectIncludes": "T+2"
+          }
+        ]
+      }
+    },
+    {
+      "id": "license",
+      "description": "the license type is captured verbatim",
+      "text": "Acme Pay is licensed as an EMI.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "licensed_as",
+            "objectIncludes": "EMI"
+          }
+        ]
+      }
+    },
+    {
+      "id": "capital",
+      "description": "a capital requirement is captured with its currency",
+      "text": "The fund must hold €5M in own funds.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "capital_requirement",
+            "objectIncludes": "€5M"
+          }
+        ]
+      }
+    },
+    {
+      "id": "license-and-regulator",
+      "description": "a compound registration sentence yields both facts",
+      "text": "Nova Securities is a registered broker-dealer under SEC oversight.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "licensed_as",
+            "objectIncludes": "broker-dealer"
+          },
+          {
+            "predicate": "regulated_by",
+            "objectIncludes": "SEC"
           }
         ]
       }

--- a/packs/hr.pack.json
+++ b/packs/hr.pack.json
@@ -1,7 +1,7 @@
 {
   "id": "hr",
-  "version": "0.1.0",
-  "description": "HR / recruiting ontology — required skills, seniority, compensation, employment type, and work location of roles, with a domain extraction profile.",
+  "version": "0.2.0",
+  "description": "HR / recruiting ontology — required skills, seniority, compensation, employment type, and work location of roles, with a domain extraction profile and memory model.",
   "predicates": [
     {
       "localId": "requires_skill",
@@ -67,6 +67,241 @@
       }
     ]
   },
+  "memoryModel": {
+    "sceneSchemas": [
+      {
+        "id": "interview_debrief",
+        "description": "An interview or debrief for a role: interviewers discuss how a candidate met the role requirements.",
+        "cues": [
+          "interview",
+          "debrief",
+          "panel",
+          "scorecard"
+        ]
+      },
+      {
+        "id": "offer_stage",
+        "description": "An offer-stage conversation: compensation, start date, and terms for a role are negotiated.",
+        "cues": [
+          "offer",
+          "counteroffer",
+          "start date",
+          "signed the offer"
+        ]
+      }
+    ],
+    "stateModels": [
+      {
+        "id": "position_lifecycle",
+        "subjectType": "position",
+        "states": [
+          "opened",
+          "sourcing",
+          "interviewing",
+          "offer_extended",
+          "filled",
+          "vacated"
+        ],
+        "transitions": [
+          {
+            "from": "opened",
+            "to": "sourcing"
+          },
+          {
+            "from": "sourcing",
+            "to": "interviewing"
+          },
+          {
+            "from": "interviewing",
+            "to": "offer_extended"
+          },
+          {
+            "from": "offer_extended",
+            "to": "filled"
+          },
+          {
+            "from": "offer_extended",
+            "to": "interviewing"
+          },
+          {
+            "from": "filled",
+            "to": "vacated"
+          },
+          {
+            "from": "vacated",
+            "to": "sourcing"
+          }
+        ]
+      },
+      {
+        "id": "employee_lifecycle",
+        "subjectType": "employee",
+        "states": [
+          "hired",
+          "onboarded",
+          "promoted",
+          "on_leave",
+          "offboarded"
+        ],
+        "transitions": [
+          {
+            "from": "hired",
+            "to": "onboarded"
+          },
+          {
+            "from": "onboarded",
+            "to": "promoted"
+          },
+          {
+            "from": "promoted",
+            "to": "promoted"
+          },
+          {
+            "from": "onboarded",
+            "to": "on_leave"
+          },
+          {
+            "from": "on_leave",
+            "to": "onboarded"
+          },
+          {
+            "from": "onboarded",
+            "to": "offboarded"
+          },
+          {
+            "from": "promoted",
+            "to": "offboarded"
+          },
+          {
+            "from": "on_leave",
+            "to": "offboarded"
+          }
+        ]
+      }
+    ],
+    "attentionHints": [
+      {
+        "cue": "requires",
+        "prefer": [
+          "requires_skill"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.5
+      },
+      {
+        "cue": "must know",
+        "prefer": [
+          "requires_skill"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "senior",
+        "prefer": [
+          "seniority"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.5
+      },
+      {
+        "cue": "salary",
+        "prefer": [
+          "compensation"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.7
+      },
+      {
+        "cue": "comp band",
+        "prefer": [
+          "compensation"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "remote",
+        "prefer": [
+          "work_location"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "hybrid",
+        "prefer": [
+          "work_location"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.5
+      },
+      {
+        "cue": "full-time",
+        "prefer": [
+          "employment_type"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.5
+      }
+    ],
+    "verificationRules": [
+      {
+        "claimPattern": "comp",
+        "requires": "recency_check"
+      },
+      {
+        "claimPattern": "remote",
+        "requires": "recency_check"
+      }
+    ],
+    "retentionHints": [
+      {
+        "predicateOrScene": "employment_type",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "seniority",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "requires_skill",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "compensation",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "work_location",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "offer_stage",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "interview_debrief",
+        "hint": "ephemeral"
+      }
+    ]
+  },
   "evalFixtures": [
     {
       "id": "skill",
@@ -103,6 +338,32 @@
           {
             "predicate": "work_location",
             "objectIncludes": "remote"
+          }
+        ]
+      }
+    },
+    {
+      "id": "seniority",
+      "description": "the seniority level is captured",
+      "text": "This is a Senior-level role.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "seniority",
+            "objectIncludes": "Senior"
+          }
+        ]
+      }
+    },
+    {
+      "id": "employment-type",
+      "description": "the employment type is captured",
+      "text": "The role is full-time.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "employment_type",
+            "objectIncludes": "full-time"
           }
         ]
       }

--- a/packs/insurance.pack.json
+++ b/packs/insurance.pack.json
@@ -1,7 +1,7 @@
 {
   "id": "insurance",
-  "version": "0.1.0",
-  "description": "Insurance ontology — coverage, limits, premiums, deductibles, and exclusions of policies, with a domain extraction profile.",
+  "version": "0.2.0",
+  "description": "Insurance ontology — coverage, limits, premiums, deductibles, and exclusions of policies, with a domain extraction profile and memory model.",
   "predicates": [
     {
       "localId": "covers",
@@ -67,6 +67,230 @@
       }
     ]
   },
+  "memoryModel": {
+    "sceneSchemas": [
+      {
+        "id": "claim_intake",
+        "description": "A claim intake: a loss event is reported against a policy and first notice of loss details are captured.",
+        "cues": [
+          "claim",
+          "first notice of loss",
+          "loss reported",
+          "incident"
+        ]
+      },
+      {
+        "id": "renewal_review",
+        "description": "A policy renewal or re-quote: terms, premium, and coverage of an existing policy are reassessed.",
+        "cues": [
+          "renewal",
+          "requote",
+          "premium change",
+          "rate increase"
+        ]
+      }
+    ],
+    "stateModels": [
+      {
+        "id": "policy_lifecycle",
+        "subjectType": "policy",
+        "states": [
+          "quoted",
+          "bound",
+          "renewed",
+          "lapsed",
+          "cancelled"
+        ],
+        "transitions": [
+          {
+            "from": "quoted",
+            "to": "bound"
+          },
+          {
+            "from": "bound",
+            "to": "renewed"
+          },
+          {
+            "from": "renewed",
+            "to": "renewed"
+          },
+          {
+            "from": "bound",
+            "to": "lapsed"
+          },
+          {
+            "from": "renewed",
+            "to": "lapsed"
+          },
+          {
+            "from": "bound",
+            "to": "cancelled"
+          },
+          {
+            "from": "renewed",
+            "to": "cancelled"
+          },
+          {
+            "from": "lapsed",
+            "to": "bound"
+          }
+        ]
+      },
+      {
+        "id": "claim_lifecycle",
+        "subjectType": "claim",
+        "states": [
+          "reported",
+          "assessed",
+          "approved",
+          "denied",
+          "paid",
+          "closed"
+        ],
+        "transitions": [
+          {
+            "from": "reported",
+            "to": "assessed"
+          },
+          {
+            "from": "assessed",
+            "to": "approved"
+          },
+          {
+            "from": "assessed",
+            "to": "denied"
+          },
+          {
+            "from": "approved",
+            "to": "paid"
+          },
+          {
+            "from": "paid",
+            "to": "closed"
+          },
+          {
+            "from": "denied",
+            "to": "closed"
+          }
+        ]
+      }
+    ],
+    "attentionHints": [
+      {
+        "cue": "covers",
+        "prefer": [
+          "covers"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "excluded",
+        "prefer": [
+          "excludes"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.7
+      },
+      {
+        "cue": "deductible",
+        "prefer": [
+          "deductible"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "excess",
+        "prefer": [
+          "deductible"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.5
+      },
+      {
+        "cue": "premium",
+        "prefer": [
+          "premium"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "sum insured",
+        "prefer": [
+          "coverage_limit"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "claim",
+        "prefer": [
+          "covers",
+          "excludes",
+          "deductible"
+        ],
+        "zoom": [
+          "claim_intake",
+          "episodes"
+        ],
+        "weight": 0.7
+      }
+    ],
+    "verificationRules": [
+      {
+        "claimPattern": "premium",
+        "requires": "recency_check"
+      },
+      {
+        "claimPattern": "cover",
+        "requires": "recency_check"
+      }
+    ],
+    "retentionHints": [
+      {
+        "predicateOrScene": "covers",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "excludes",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "coverage_limit",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "premium",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "deductible",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "claim_intake",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "renewal_review",
+        "hint": "standard"
+      }
+    ]
+  },
   "evalFixtures": [
     {
       "id": "coverage",
@@ -103,6 +327,32 @@
           {
             "predicate": "excludes",
             "objectIncludes": "Flood"
+          }
+        ]
+      }
+    },
+    {
+      "id": "limit",
+      "description": "the coverage limit is captured verbatim with currency",
+      "text": "The policy has a coverage limit of $1,000,000.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "coverage_limit",
+            "objectIncludes": "$1,000,000"
+          }
+        ]
+      }
+    },
+    {
+      "id": "premium",
+      "description": "the premium is captured verbatim",
+      "text": "The annual premium is $1,200.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "premium",
+            "objectIncludes": "$1,200"
           }
         ]
       }

--- a/packs/legal.pack.json
+++ b/packs/legal.pack.json
@@ -1,7 +1,7 @@
 {
   "id": "legal",
-  "version": "0.1.0",
-  "description": "Legal / contracts ontology — governing law, parties, obligations, and term of agreements, with a domain extraction profile.",
+  "version": "0.2.0",
+  "description": "Legal / contracts ontology — governing law, parties, obligations, and term of agreements, with a domain extraction profile and memory model.",
   "predicates": [
     {
       "localId": "governed_by",
@@ -71,6 +71,245 @@
       }
     ]
   },
+  "memoryModel": {
+    "sceneSchemas": [
+      {
+        "id": "negotiation_session",
+        "description": "A contract negotiation session: terms, redlines, and concessions on an agreement are discussed between the parties.",
+        "cues": [
+          "redline",
+          "negotiation",
+          "counterparty",
+          "term sheet"
+        ]
+      },
+      {
+        "id": "execution",
+        "description": "An execution event: an agreement is signed, countersigned, or comes into force.",
+        "cues": [
+          "signed",
+          "executed",
+          "countersigned",
+          "came into force"
+        ]
+      }
+    ],
+    "stateModels": [
+      {
+        "id": "matter_lifecycle",
+        "subjectType": "matter",
+        "states": [
+          "opened",
+          "discovery",
+          "settled",
+          "judged",
+          "closed"
+        ],
+        "transitions": [
+          {
+            "from": "opened",
+            "to": "discovery"
+          },
+          {
+            "from": "discovery",
+            "to": "settled"
+          },
+          {
+            "from": "discovery",
+            "to": "judged"
+          },
+          {
+            "from": "opened",
+            "to": "settled"
+          },
+          {
+            "from": "settled",
+            "to": "closed"
+          },
+          {
+            "from": "judged",
+            "to": "closed"
+          }
+        ]
+      },
+      {
+        "id": "agreement_lifecycle",
+        "subjectType": "agreement",
+        "states": [
+          "drafted",
+          "negotiated",
+          "executed",
+          "effective",
+          "terminated",
+          "expired"
+        ],
+        "transitions": [
+          {
+            "from": "drafted",
+            "to": "negotiated"
+          },
+          {
+            "from": "negotiated",
+            "to": "executed"
+          },
+          {
+            "from": "drafted",
+            "to": "executed"
+          },
+          {
+            "from": "executed",
+            "to": "effective"
+          },
+          {
+            "from": "effective",
+            "to": "terminated"
+          },
+          {
+            "from": "effective",
+            "to": "expired"
+          }
+        ]
+      },
+      {
+        "id": "obligation_lifecycle",
+        "subjectType": "obligation",
+        "states": [
+          "owed",
+          "performed",
+          "waived",
+          "breached"
+        ],
+        "transitions": [
+          {
+            "from": "owed",
+            "to": "performed"
+          },
+          {
+            "from": "owed",
+            "to": "waived"
+          },
+          {
+            "from": "owed",
+            "to": "breached"
+          }
+        ]
+      }
+    ],
+    "attentionHints": [
+      {
+        "cue": "governed by",
+        "prefer": [
+          "governed_by"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "party",
+        "prefer": [
+          "party_to"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.5
+      },
+      {
+        "cue": "shall",
+        "prefer": [
+          "obligation"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "effective",
+        "prefer": [
+          "effective_from"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "terminates",
+        "prefer": [
+          "terminates_on"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.7
+      },
+      {
+        "cue": "notice period",
+        "prefer": [
+          "terminates_on"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "breach",
+        "prefer": [
+          "obligation",
+          "terminates_on"
+        ],
+        "zoom": [
+          "episodes",
+          "facts"
+        ],
+        "weight": 0.7
+      }
+    ],
+    "verificationRules": [
+      {
+        "claimPattern": "terminat",
+        "requires": "recency_check"
+      },
+      {
+        "claimPattern": "effective",
+        "requires": "recency_check"
+      }
+    ],
+    "retentionHints": [
+      {
+        "predicateOrScene": "governed_by",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "party_to",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "effective_from",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "terminates_on",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "obligation",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "execution",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "negotiation_session",
+        "hint": "ephemeral"
+      }
+    ]
+  },
   "evalFixtures": [
     {
       "id": "governing-law",
@@ -107,6 +346,32 @@
           {
             "predicate": "effective_from",
             "objectIncludes": "1 January 2026"
+          }
+        ]
+      }
+    },
+    {
+      "id": "party",
+      "description": "a named party to the agreement is captured",
+      "text": "This Agreement is between Acme Corp and Beta LLC.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "party_to",
+            "objectIncludes": "Acme Corp"
+          }
+        ]
+      }
+    },
+    {
+      "id": "termination",
+      "description": "the termination condition is captured verbatim",
+      "text": "The contract terminates on 90 days written notice.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "terminates_on",
+            "objectIncludes": "90 days"
           }
         ]
       }

--- a/packs/medical.pack.json
+++ b/packs/medical.pack.json
@@ -1,7 +1,7 @@
 {
   "id": "medical",
-  "version": "0.1.0",
-  "description": "Clinical pharmacology ontology — indications, dosing, routes, interactions, and contraindications of drugs/treatments, with a domain extraction profile.",
+  "version": "0.2.0",
+  "description": "Clinical pharmacology ontology — indications, dosing, routes, interactions, and contraindications of drugs/treatments, with a domain extraction profile and memory model.",
   "predicates": [
     {
       "localId": "treats",
@@ -71,6 +71,218 @@
       }
     ]
   },
+  "memoryModel": {
+    "sceneSchemas": [
+      {
+        "id": "medication_review",
+        "description": "A medication review or reconciliation: current drugs, doses, and interactions of a treatment plan are checked and adjusted.",
+        "cues": [
+          "medication review",
+          "reconciliation",
+          "dose adjusted",
+          "titration"
+        ]
+      },
+      {
+        "id": "adverse_event",
+        "description": "An adverse event or safety report: a suspected reaction, interaction, or harm involving a drug is described.",
+        "cues": [
+          "adverse event",
+          "side effect",
+          "reaction",
+          "pharmacovigilance"
+        ]
+      }
+    ],
+    "stateModels": [
+      {
+        "id": "prescription_lifecycle",
+        "subjectType": "prescription",
+        "states": [
+          "started",
+          "dose_changed",
+          "paused",
+          "discontinued"
+        ],
+        "transitions": [
+          {
+            "from": "started",
+            "to": "dose_changed"
+          },
+          {
+            "from": "dose_changed",
+            "to": "dose_changed"
+          },
+          {
+            "from": "started",
+            "to": "paused"
+          },
+          {
+            "from": "dose_changed",
+            "to": "paused"
+          },
+          {
+            "from": "paused",
+            "to": "started"
+          },
+          {
+            "from": "started",
+            "to": "discontinued"
+          },
+          {
+            "from": "dose_changed",
+            "to": "discontinued"
+          },
+          {
+            "from": "paused",
+            "to": "discontinued"
+          }
+        ]
+      },
+      {
+        "id": "approval_lifecycle",
+        "subjectType": "drug",
+        "states": [
+          "investigational",
+          "approved",
+          "restricted",
+          "withdrawn"
+        ],
+        "transitions": [
+          {
+            "from": "investigational",
+            "to": "approved"
+          },
+          {
+            "from": "approved",
+            "to": "restricted"
+          },
+          {
+            "from": "approved",
+            "to": "withdrawn"
+          },
+          {
+            "from": "restricted",
+            "to": "withdrawn"
+          }
+        ]
+      }
+    ],
+    "attentionHints": [
+      {
+        "cue": "indicated for",
+        "prefer": [
+          "treats"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "dose",
+        "prefer": [
+          "dosed_at"
+        ],
+        "zoom": [
+          "facts",
+          "episodes"
+        ],
+        "weight": 0.7
+      },
+      {
+        "cue": "mg",
+        "prefer": [
+          "dosed_at"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "interacts",
+        "prefer": [
+          "interacts_with"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.7
+      },
+      {
+        "cue": "contraindicated",
+        "prefer": [
+          "contraindicated_with"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.7
+      },
+      {
+        "cue": "route",
+        "prefer": [
+          "administered_via"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.5
+      },
+      {
+        "cue": "titrated",
+        "prefer": [
+          "dosed_at"
+        ],
+        "zoom": [
+          "medication_review",
+          "facts"
+        ],
+        "weight": 0.6
+      }
+    ],
+    "verificationRules": [
+      {
+        "claimPattern": "dose",
+        "requires": "recency_check"
+      },
+      {
+        "claimPattern": "contraindicated",
+        "requires": "corroboration"
+      }
+    ],
+    "retentionHints": [
+      {
+        "predicateOrScene": "treats",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "interacts_with",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "contraindicated_with",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "dosed_at",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "administered_via",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "adverse_event",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "medication_review",
+        "hint": "standard"
+      }
+    ]
+  },
   "evalFixtures": [
     {
       "id": "indication",
@@ -107,6 +319,49 @@
           {
             "predicate": "contraindicated_with",
             "objectIncludes": "pregnancy"
+          }
+        ]
+      }
+    },
+    {
+      "id": "route",
+      "description": "the route of administration is captured",
+      "text": "Ceftriaxone is administered via intravenous infusion.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "administered_via",
+            "objectIncludes": "intravenous"
+          }
+        ]
+      }
+    },
+    {
+      "id": "interaction",
+      "description": "an interacting agent is captured",
+      "text": "Warfarin interacts with aspirin.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "interacts_with",
+            "objectIncludes": "aspirin"
+          }
+        ]
+      }
+    },
+    {
+      "id": "dose-and-route",
+      "description": "a compound dosing sentence yields both facts",
+      "text": "Metformin is dosed at 500 mg twice daily, taken orally.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "dosed_at",
+            "objectIncludes": "500 mg"
+          },
+          {
+            "predicate": "administered_via",
+            "objectIncludes": "oral"
           }
         ]
       }

--- a/packs/real-estate.pack.json
+++ b/packs/real-estate.pack.json
@@ -1,7 +1,7 @@
 {
   "id": "real_estate",
-  "version": "0.1.0",
-  "description": "Real-estate ontology — zoning, valuation, encumbrances, tenure, and construction of properties/parcels, with a domain extraction profile.",
+  "version": "0.2.0",
+  "description": "Real-estate ontology — zoning, valuation, encumbrances, tenure, and construction of properties/parcels, with a domain extraction profile and memory model.",
   "predicates": [
     {
       "localId": "zoned_as",
@@ -81,6 +81,246 @@
       }
     ]
   },
+  "memoryModel": {
+    "sceneSchemas": [
+      {
+        "id": "viewing",
+        "description": "A property viewing or open house: prospective buyers or tenants inspect the property and reactions are recorded.",
+        "cues": [
+          "viewing",
+          "open house",
+          "walkthrough",
+          "showed the property"
+        ]
+      },
+      {
+        "id": "closing",
+        "description": "A transaction closing: contracts are exchanged, funds settle, and title transfers on a property deal.",
+        "cues": [
+          "closing",
+          "completion",
+          "exchanged contracts",
+          "title transfer",
+          "escrow"
+        ]
+      }
+    ],
+    "stateModels": [
+      {
+        "id": "listing_lifecycle",
+        "subjectType": "listing",
+        "states": [
+          "listed",
+          "under_offer",
+          "sold",
+          "withdrawn"
+        ],
+        "transitions": [
+          {
+            "from": "listed",
+            "to": "under_offer"
+          },
+          {
+            "from": "under_offer",
+            "to": "listed"
+          },
+          {
+            "from": "under_offer",
+            "to": "sold"
+          },
+          {
+            "from": "listed",
+            "to": "withdrawn"
+          },
+          {
+            "from": "withdrawn",
+            "to": "listed"
+          }
+        ]
+      },
+      {
+        "id": "tenancy_lifecycle",
+        "subjectType": "tenancy",
+        "states": [
+          "advertised",
+          "let",
+          "notice_given",
+          "vacated"
+        ],
+        "transitions": [
+          {
+            "from": "advertised",
+            "to": "let"
+          },
+          {
+            "from": "let",
+            "to": "notice_given"
+          },
+          {
+            "from": "notice_given",
+            "to": "vacated"
+          },
+          {
+            "from": "vacated",
+            "to": "advertised"
+          }
+        ]
+      },
+      {
+        "id": "permit_lifecycle",
+        "subjectType": "planning_permit",
+        "states": [
+          "applied",
+          "granted",
+          "refused",
+          "expired"
+        ],
+        "transitions": [
+          {
+            "from": "applied",
+            "to": "granted"
+          },
+          {
+            "from": "applied",
+            "to": "refused"
+          },
+          {
+            "from": "granted",
+            "to": "expired"
+          }
+        ]
+      }
+    ],
+    "attentionHints": [
+      {
+        "cue": "zoned",
+        "prefer": [
+          "zoned_as"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "appraised",
+        "prefer": [
+          "valued_at"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "asking price",
+        "prefer": [
+          "listed_at",
+          "valued_at"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "lien",
+        "prefer": [
+          "encumbered_by"
+        ],
+        "zoom": [
+          "facts",
+          "episodes"
+        ],
+        "weight": 0.7
+      },
+      {
+        "cue": "easement",
+        "prefer": [
+          "encumbered_by"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "leasehold",
+        "prefer": [
+          "tenure_type"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.5
+      },
+      {
+        "cue": "under offer",
+        "prefer": [
+          "listed_at"
+        ],
+        "zoom": [
+          "episodes",
+          "facts"
+        ],
+        "weight": 0.6
+      },
+      {
+        "cue": "built in",
+        "prefer": [
+          "built_in"
+        ],
+        "zoom": [
+          "facts"
+        ],
+        "weight": 0.4
+      }
+    ],
+    "verificationRules": [
+      {
+        "claimPattern": "listed at",
+        "requires": "recency_check"
+      },
+      {
+        "claimPattern": "appraised",
+        "requires": "recency_check"
+      }
+    ],
+    "retentionHints": [
+      {
+        "predicateOrScene": "tenure_type",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "built_in",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "encumbered_by",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "zoned_as",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "valued_at",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "listed_at",
+        "hint": "standard"
+      },
+      {
+        "predicateOrScene": "closing",
+        "hint": "durable"
+      },
+      {
+        "predicateOrScene": "viewing",
+        "hint": "ephemeral"
+      }
+    ]
+  },
   "evalFixtures": [
     {
       "id": "zoning",
@@ -117,6 +357,45 @@
           {
             "predicate": "tenure_type",
             "objectIncludes": "leasehold"
+          }
+        ]
+      }
+    },
+    {
+      "id": "listing-price",
+      "description": "the asking price is captured verbatim",
+      "text": "The warehouse is listed at $1.5M.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "listed_at",
+            "objectIncludes": "$1.5M"
+          }
+        ]
+      }
+    },
+    {
+      "id": "encumbrance",
+      "description": "an encumbrance on the property is captured",
+      "text": "The property at 12 Elm St carries a mortgage held by First National.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "encumbered_by",
+            "objectIncludes": "mortgage"
+          }
+        ]
+      }
+    },
+    {
+      "id": "construction-year",
+      "description": "the construction year is captured verbatim",
+      "text": "The house at 8 Oak Ave was built in 1998.",
+      "expect": {
+        "facts": [
+          {
+            "predicate": "built_in",
+            "objectIncludes": "1998"
           }
         ]
       }

--- a/src/ai/domain-packs/fintech.pack.ts
+++ b/src/ai/domain-packs/fintech.pack.ts
@@ -5,14 +5,16 @@ import type { DomainPackManifest } from './manifest';
  * real-estate (and unlike the builtin code-memory), a DISTRIBUTABLE pack —
  * installed per-tenant from `packs/fintech.pack.json` via `pnpm pack:install`,
  * NOT in BUILTIN_PACKS, so its domain predicates don't seed into unrelated
- * tenants. Ships an extractionProfile + eval fixtures so it's a complete,
- * self-verifying ontology, not a stub. Bump `version` to ship an update.
+ * tenants. Ships an extractionProfile + eval fixtures + memoryModel (license /
+ * certification / enforcement lifecycles, attention + retention hints, recency
+ * rules for license and settlement claims) so it's a complete, self-verifying
+ * ontology, not a stub. Bump `version` to ship an update.
  */
 export const FINTECH_PACK: DomainPackManifest = {
   id: 'fintech',
-  version: '0.1.0',
+  version: '0.2.0',
   description:
-    'Financial-services regulation ontology — regulators, licenses, compliance standards, capital, and settlement of institutions/products, with a domain extraction profile.',
+    'Financial-services regulation ontology — regulators, licenses, compliance standards, capital, and settlement of institutions/products, with a domain extraction profile and memory model.',
   predicates: [
     {
       localId: 'regulated_by',
@@ -106,6 +108,92 @@ named entity, ALSO emit an edge (Institution —regulated_by→ Authority).`,
       },
     ],
   },
+  // The domain perception contract (docs/domain-packs.md). Declarative data
+  // only — consumed by MemoryModelReaderService for installed tenants.
+  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  memoryModel: {
+    sceneSchemas: [
+      {
+        id: 'audit_review',
+        description:
+          'A compliance audit or regulatory examination: an auditor or regulator reviews the institution and findings are discussed.',
+        cues: ['audit', 'examination', 'regulator visit', 'findings'],
+      },
+      {
+        id: 'regulatory_filing',
+        description:
+          'A regulatory filing or reporting event: the institution submits returns, disclosures, or capital reports to its regulator.',
+        cues: ['filing', 'submitted', 'annual return', 'disclosure'],
+      },
+    ],
+    stateModels: [
+      {
+        id: 'license_lifecycle',
+        subjectType: 'license',
+        states: ['applied', 'granted', 'suspended', 'revoked', 'surrendered'],
+        transitions: [
+          { from: 'applied', to: 'granted' },
+          { from: 'granted', to: 'suspended' },
+          { from: 'suspended', to: 'granted' },
+          { from: 'granted', to: 'revoked' },
+          { from: 'suspended', to: 'revoked' },
+          { from: 'granted', to: 'surrendered' },
+        ],
+      },
+      {
+        id: 'certification_lifecycle',
+        subjectType: 'compliance_certification',
+        states: ['in_assessment', 'certified', 'lapsed', 'withdrawn'],
+        transitions: [
+          { from: 'in_assessment', to: 'certified' },
+          { from: 'certified', to: 'lapsed' },
+          { from: 'lapsed', to: 'in_assessment' },
+          { from: 'certified', to: 'withdrawn' },
+        ],
+      },
+      {
+        id: 'enforcement_lifecycle',
+        subjectType: 'enforcement_action',
+        states: ['opened', 'remediation_ordered', 'settled', 'closed'],
+        transitions: [
+          { from: 'opened', to: 'remediation_ordered' },
+          { from: 'remediation_ordered', to: 'settled' },
+          { from: 'opened', to: 'settled' },
+          { from: 'settled', to: 'closed' },
+          { from: 'opened', to: 'closed' },
+        ],
+      },
+    ],
+    attentionHints: [
+      { cue: 'regulated by', prefer: ['regulated_by'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'license', prefer: ['licensed_as'], zoom: ['facts', 'episodes'], weight: 0.7 },
+      { cue: 'compliant', prefer: ['complies_with'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'capital', prefer: ['capital_requirement'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'settlement', prefer: ['settlement_period'], zoom: ['facts'], weight: 0.6 },
+      {
+        cue: 'revoked',
+        prefer: ['licensed_as', 'regulated_by'],
+        zoom: ['episodes', 'facts'],
+        weight: 0.7,
+      },
+      { cue: 'audit', prefer: ['complies_with'], zoom: ['audit_review', 'episodes'], weight: 0.6 },
+    ],
+    // License status and settlement conventions go stale (EMI licenses get
+    // revoked; markets migrate T+2 to T+1) — serve them recency-checked.
+    verificationRules: [
+      { claimPattern: 'licensed', requires: 'recency_check' },
+      { claimPattern: 'settlement', requires: 'recency_check' },
+    ],
+    retentionHints: [
+      { predicateOrScene: 'regulated_by', hint: 'durable' },
+      { predicateOrScene: 'licensed_as', hint: 'durable' },
+      { predicateOrScene: 'complies_with', hint: 'durable' },
+      { predicateOrScene: 'capital_requirement', hint: 'durable' },
+      { predicateOrScene: 'settlement_period', hint: 'standard' },
+      { predicateOrScene: 'audit_review', hint: 'durable' },
+      { predicateOrScene: 'regulatory_filing', hint: 'standard' },
+    ],
+  },
   evalFixtures: [
     {
       id: 'regulator',
@@ -124,6 +212,29 @@ named entity, ALSO emit an edge (Institution —regulated_by→ Authority).`,
       description: 'the settlement window is captured verbatim',
       text: 'Equity trades settle T+2.',
       expect: { facts: [{ predicate: 'settlement_period', objectIncludes: 'T+2' }] },
+    },
+    {
+      id: 'license',
+      description: 'the license type is captured verbatim',
+      text: 'Acme Pay is licensed as an EMI.',
+      expect: { facts: [{ predicate: 'licensed_as', objectIncludes: 'EMI' }] },
+    },
+    {
+      id: 'capital',
+      description: 'a capital requirement is captured with its currency',
+      text: 'The fund must hold €5M in own funds.',
+      expect: { facts: [{ predicate: 'capital_requirement', objectIncludes: '€5M' }] },
+    },
+    {
+      id: 'license-and-regulator',
+      description: 'a compound registration sentence yields both facts',
+      text: 'Nova Securities is a registered broker-dealer under SEC oversight.',
+      expect: {
+        facts: [
+          { predicate: 'licensed_as', objectIncludes: 'broker-dealer' },
+          { predicate: 'regulated_by', objectIncludes: 'SEC' },
+        ],
+      },
     },
   ],
 };

--- a/src/ai/domain-packs/hr.pack.ts
+++ b/src/ai/domain-packs/hr.pack.ts
@@ -4,13 +4,15 @@ import type { DomainPackManifest } from './manifest';
  * Industry Domain Pack: HR / recruiting. DISTRIBUTABLE (installed per-tenant from
  * `packs/hr.pack.json`, NOT in BUILTIN_PACKS). Captures role/candidate ontology —
  * required skills, seniority, compensation, employment type, location policy.
- * Scoped to ROLES/REQUISITIONS, not individual PII. Bump `version` to update.
+ * Scoped to ROLES/REQUISITIONS, not individual PII — the memoryModel's
+ * position / employee lifecycles are generic vocabulary about subjects of
+ * those types, never person records. Bump `version` to update.
  */
 export const HR_PACK: DomainPackManifest = {
   id: 'hr',
-  version: '0.1.0',
+  version: '0.2.0',
   description:
-    'HR / recruiting ontology — required skills, seniority, compensation, employment type, and work location of roles, with a domain extraction profile.',
+    'HR / recruiting ontology — required skills, seniority, compensation, employment type, and work location of roles, with a domain extraction profile and memory model.',
   predicates: [
     {
       localId: 'requires_skill',
@@ -95,6 +97,81 @@ the SUBJECT entity. Prefer the hr__* predicates for required skills
       },
     ],
   },
+  // The domain perception contract (docs/domain-packs.md). Declarative data
+  // only — consumed by MemoryModelReaderService for installed tenants.
+  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  memoryModel: {
+    sceneSchemas: [
+      {
+        id: 'interview_debrief',
+        description:
+          'An interview or debrief for a role: interviewers discuss how a candidate met the role requirements.',
+        cues: ['interview', 'debrief', 'panel', 'scorecard'],
+      },
+      {
+        id: 'offer_stage',
+        description:
+          'An offer-stage conversation: compensation, start date, and terms for a role are negotiated.',
+        cues: ['offer', 'counteroffer', 'start date', 'signed the offer'],
+      },
+    ],
+    stateModels: [
+      {
+        id: 'position_lifecycle',
+        subjectType: 'position',
+        states: ['opened', 'sourcing', 'interviewing', 'offer_extended', 'filled', 'vacated'],
+        transitions: [
+          { from: 'opened', to: 'sourcing' },
+          { from: 'sourcing', to: 'interviewing' },
+          { from: 'interviewing', to: 'offer_extended' },
+          { from: 'offer_extended', to: 'filled' },
+          { from: 'offer_extended', to: 'interviewing' },
+          { from: 'filled', to: 'vacated' },
+          { from: 'vacated', to: 'sourcing' },
+        ],
+      },
+      {
+        id: 'employee_lifecycle',
+        subjectType: 'employee',
+        states: ['hired', 'onboarded', 'promoted', 'on_leave', 'offboarded'],
+        transitions: [
+          { from: 'hired', to: 'onboarded' },
+          { from: 'onboarded', to: 'promoted' },
+          { from: 'promoted', to: 'promoted' },
+          { from: 'onboarded', to: 'on_leave' },
+          { from: 'on_leave', to: 'onboarded' },
+          { from: 'onboarded', to: 'offboarded' },
+          { from: 'promoted', to: 'offboarded' },
+          { from: 'on_leave', to: 'offboarded' },
+        ],
+      },
+    ],
+    attentionHints: [
+      { cue: 'requires', prefer: ['requires_skill'], zoom: ['facts'], weight: 0.5 },
+      { cue: 'must know', prefer: ['requires_skill'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'senior', prefer: ['seniority'], zoom: ['facts'], weight: 0.5 },
+      { cue: 'salary', prefer: ['compensation'], zoom: ['facts'], weight: 0.7 },
+      { cue: 'comp band', prefer: ['compensation'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'remote', prefer: ['work_location'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'hybrid', prefer: ['work_location'], zoom: ['facts'], weight: 0.5 },
+      { cue: 'full-time', prefer: ['employment_type'], zoom: ['facts'], weight: 0.5 },
+    ],
+    // Comp bands are rebenchmarked and location policies flip — serve
+    // compensation and remote-policy claims recency-checked.
+    verificationRules: [
+      { claimPattern: 'comp', requires: 'recency_check' },
+      { claimPattern: 'remote', requires: 'recency_check' },
+    ],
+    retentionHints: [
+      { predicateOrScene: 'employment_type', hint: 'durable' },
+      { predicateOrScene: 'seniority', hint: 'durable' },
+      { predicateOrScene: 'requires_skill', hint: 'standard' },
+      { predicateOrScene: 'compensation', hint: 'standard' },
+      { predicateOrScene: 'work_location', hint: 'standard' },
+      { predicateOrScene: 'offer_stage', hint: 'standard' },
+      { predicateOrScene: 'interview_debrief', hint: 'ephemeral' },
+    ],
+  },
   evalFixtures: [
     {
       id: 'skill',
@@ -113,6 +190,18 @@ the SUBJECT entity. Prefer the hr__* predicates for required skills
       description: 'the work-location policy is captured',
       text: 'This position is fully remote.',
       expect: { facts: [{ predicate: 'work_location', objectIncludes: 'remote' }] },
+    },
+    {
+      id: 'seniority',
+      description: 'the seniority level is captured',
+      text: 'This is a Senior-level role.',
+      expect: { facts: [{ predicate: 'seniority', objectIncludes: 'Senior' }] },
+    },
+    {
+      id: 'employment-type',
+      description: 'the employment type is captured',
+      text: 'The role is full-time.',
+      expect: { facts: [{ predicate: 'employment_type', objectIncludes: 'full-time' }] },
     },
   ],
 };

--- a/src/ai/domain-packs/index.ts
+++ b/src/ai/domain-packs/index.ts
@@ -1,7 +1,7 @@
 import { CORE_PREDICATES } from '../predicate-registry-internals/core-seed';
 import type { PredicateDefinition } from '../predicate-registry-internals/types';
 import type { DomainPackManifest } from './manifest';
-import { assembleSeed } from './validate';
+import { assembleSeed, validatePack } from './validate';
 import { CODE_MEMORY_PACK } from './code-memory.pack';
 
 /**
@@ -60,3 +60,9 @@ export const FIRST_PARTY_PACKS: DomainPackManifest[] = [
   INSURANCE_PACK,
   HR_PACK,
 ];
+
+// Every distributable manifest is validated at module load too (builtins get
+// this via assembleSeed above): a malformed industry pack — including its
+// memoryModel section — fails the boot/test run here, not a tenant install
+// later.
+for (const pack of FIRST_PARTY_PACKS) validatePack(pack);

--- a/src/ai/domain-packs/insurance.pack.ts
+++ b/src/ai/domain-packs/insurance.pack.ts
@@ -4,13 +4,15 @@ import type { DomainPackManifest } from './manifest';
  * Industry Domain Pack: insurance. DISTRIBUTABLE (installed per-tenant from
  * `packs/insurance.pack.json`, NOT in BUILTIN_PACKS). Captures policy ontology —
  * coverage, limits, premiums, deductibles, exclusions — with an extractionProfile
- * + eval fixtures. Bump `version` to ship an update.
+ * + eval fixtures + memoryModel (policy / claim lifecycles, attention +
+ * retention hints, recency rules for premium and coverage claims). Bump
+ * `version` to ship an update.
  */
 export const INSURANCE_PACK: DomainPackManifest = {
   id: 'insurance',
-  version: '0.1.0',
+  version: '0.2.0',
   description:
-    'Insurance ontology — coverage, limits, premiums, deductibles, and exclusions of policies, with a domain extraction profile.',
+    'Insurance ontology — coverage, limits, premiums, deductibles, and exclusions of policies, with a domain extraction profile and memory model.',
   predicates: [
     {
       localId: 'covers',
@@ -97,6 +99,84 @@ what it EXCLUDES.`,
       },
     ],
   },
+  // The domain perception contract (docs/domain-packs.md). Declarative data
+  // only — consumed by MemoryModelReaderService for installed tenants.
+  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  memoryModel: {
+    sceneSchemas: [
+      {
+        id: 'claim_intake',
+        description:
+          'A claim intake: a loss event is reported against a policy and first notice of loss details are captured.',
+        cues: ['claim', 'first notice of loss', 'loss reported', 'incident'],
+      },
+      {
+        id: 'renewal_review',
+        description:
+          'A policy renewal or re-quote: terms, premium, and coverage of an existing policy are reassessed.',
+        cues: ['renewal', 'requote', 'premium change', 'rate increase'],
+      },
+    ],
+    stateModels: [
+      {
+        id: 'policy_lifecycle',
+        subjectType: 'policy',
+        states: ['quoted', 'bound', 'renewed', 'lapsed', 'cancelled'],
+        transitions: [
+          { from: 'quoted', to: 'bound' },
+          { from: 'bound', to: 'renewed' },
+          { from: 'renewed', to: 'renewed' },
+          { from: 'bound', to: 'lapsed' },
+          { from: 'renewed', to: 'lapsed' },
+          { from: 'bound', to: 'cancelled' },
+          { from: 'renewed', to: 'cancelled' },
+          { from: 'lapsed', to: 'bound' },
+        ],
+      },
+      {
+        id: 'claim_lifecycle',
+        subjectType: 'claim',
+        states: ['reported', 'assessed', 'approved', 'denied', 'paid', 'closed'],
+        transitions: [
+          { from: 'reported', to: 'assessed' },
+          { from: 'assessed', to: 'approved' },
+          { from: 'assessed', to: 'denied' },
+          { from: 'approved', to: 'paid' },
+          { from: 'paid', to: 'closed' },
+          { from: 'denied', to: 'closed' },
+        ],
+      },
+    ],
+    attentionHints: [
+      { cue: 'covers', prefer: ['covers'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'excluded', prefer: ['excludes'], zoom: ['facts'], weight: 0.7 },
+      { cue: 'deductible', prefer: ['deductible'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'excess', prefer: ['deductible'], zoom: ['facts'], weight: 0.5 },
+      { cue: 'premium', prefer: ['premium'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'sum insured', prefer: ['coverage_limit'], zoom: ['facts'], weight: 0.6 },
+      {
+        cue: 'claim',
+        prefer: ['covers', 'excludes', 'deductible'],
+        zoom: ['claim_intake', 'episodes'],
+        weight: 0.7,
+      },
+    ],
+    // Premiums and coverage terms are repriced and rewritten at every
+    // renewal — serve both recency-checked.
+    verificationRules: [
+      { claimPattern: 'premium', requires: 'recency_check' },
+      { claimPattern: 'cover', requires: 'recency_check' },
+    ],
+    retentionHints: [
+      { predicateOrScene: 'covers', hint: 'durable' },
+      { predicateOrScene: 'excludes', hint: 'durable' },
+      { predicateOrScene: 'coverage_limit', hint: 'durable' },
+      { predicateOrScene: 'premium', hint: 'standard' },
+      { predicateOrScene: 'deductible', hint: 'standard' },
+      { predicateOrScene: 'claim_intake', hint: 'durable' },
+      { predicateOrScene: 'renewal_review', hint: 'standard' },
+    ],
+  },
   evalFixtures: [
     {
       id: 'coverage',
@@ -115,6 +195,18 @@ what it EXCLUDES.`,
       description: 'an exclusion is captured',
       text: 'Flood is excluded from this policy.',
       expect: { facts: [{ predicate: 'excludes', objectIncludes: 'Flood' }] },
+    },
+    {
+      id: 'limit',
+      description: 'the coverage limit is captured verbatim with currency',
+      text: 'The policy has a coverage limit of $1,000,000.',
+      expect: { facts: [{ predicate: 'coverage_limit', objectIncludes: '$1,000,000' }] },
+    },
+    {
+      id: 'premium',
+      description: 'the premium is captured verbatim',
+      text: 'The annual premium is $1,200.',
+      expect: { facts: [{ predicate: 'premium', objectIncludes: '$1,200' }] },
     },
   ],
 };

--- a/src/ai/domain-packs/legal.pack.ts
+++ b/src/ai/domain-packs/legal.pack.ts
@@ -4,13 +4,15 @@ import type { DomainPackManifest } from './manifest';
  * Industry Domain Pack: legal / contracts. A DISTRIBUTABLE pack (installed
  * per-tenant from `packs/legal.pack.json`, NOT in BUILTIN_PACKS). Captures the
  * ontology of agreements — governing law, parties, obligations, and term — with
- * an extractionProfile + eval fixtures. Bump `version` to ship an update.
+ * an extractionProfile + eval fixtures + memoryModel (matter / agreement /
+ * obligation lifecycles, attention + retention hints, recency rules for
+ * termination and effective-date claims). Bump `version` to ship an update.
  */
 export const LEGAL_PACK: DomainPackManifest = {
   id: 'legal',
-  version: '0.1.0',
+  version: '0.2.0',
   description:
-    'Legal / contracts ontology — governing law, parties, obligations, and term of agreements, with a domain extraction profile.',
+    'Legal / contracts ontology — governing law, parties, obligations, and term of agreements, with a domain extraction profile and memory model.',
   predicates: [
     {
       localId: 'governed_by',
@@ -102,6 +104,92 @@ an agreement, emit an edge between them in addition to the party facts.`,
       },
     ],
   },
+  // The domain perception contract (docs/domain-packs.md). Declarative data
+  // only — consumed by MemoryModelReaderService for installed tenants.
+  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  memoryModel: {
+    sceneSchemas: [
+      {
+        id: 'negotiation_session',
+        description:
+          'A contract negotiation session: terms, redlines, and concessions on an agreement are discussed between the parties.',
+        cues: ['redline', 'negotiation', 'counterparty', 'term sheet'],
+      },
+      {
+        id: 'execution',
+        description:
+          'An execution event: an agreement is signed, countersigned, or comes into force.',
+        cues: ['signed', 'executed', 'countersigned', 'came into force'],
+      },
+    ],
+    stateModels: [
+      {
+        id: 'matter_lifecycle',
+        subjectType: 'matter',
+        states: ['opened', 'discovery', 'settled', 'judged', 'closed'],
+        transitions: [
+          { from: 'opened', to: 'discovery' },
+          { from: 'discovery', to: 'settled' },
+          { from: 'discovery', to: 'judged' },
+          { from: 'opened', to: 'settled' },
+          { from: 'settled', to: 'closed' },
+          { from: 'judged', to: 'closed' },
+        ],
+      },
+      {
+        id: 'agreement_lifecycle',
+        subjectType: 'agreement',
+        states: ['drafted', 'negotiated', 'executed', 'effective', 'terminated', 'expired'],
+        transitions: [
+          { from: 'drafted', to: 'negotiated' },
+          { from: 'negotiated', to: 'executed' },
+          { from: 'drafted', to: 'executed' },
+          { from: 'executed', to: 'effective' },
+          { from: 'effective', to: 'terminated' },
+          { from: 'effective', to: 'expired' },
+        ],
+      },
+      {
+        id: 'obligation_lifecycle',
+        subjectType: 'obligation',
+        states: ['owed', 'performed', 'waived', 'breached'],
+        transitions: [
+          { from: 'owed', to: 'performed' },
+          { from: 'owed', to: 'waived' },
+          { from: 'owed', to: 'breached' },
+        ],
+      },
+    ],
+    attentionHints: [
+      { cue: 'governed by', prefer: ['governed_by'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'party', prefer: ['party_to'], zoom: ['facts'], weight: 0.5 },
+      { cue: 'shall', prefer: ['obligation'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'effective', prefer: ['effective_from'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'terminates', prefer: ['terminates_on'], zoom: ['facts'], weight: 0.7 },
+      { cue: 'notice period', prefer: ['terminates_on'], zoom: ['facts'], weight: 0.6 },
+      {
+        cue: 'breach',
+        prefer: ['obligation', 'terminates_on'],
+        zoom: ['episodes', 'facts'],
+        weight: 0.7,
+      },
+    ],
+    // Term claims go stale as contracts renew, terminate, or are amended —
+    // serve termination and effective-date claims recency-checked.
+    verificationRules: [
+      { claimPattern: 'terminat', requires: 'recency_check' },
+      { claimPattern: 'effective', requires: 'recency_check' },
+    ],
+    retentionHints: [
+      { predicateOrScene: 'governed_by', hint: 'durable' },
+      { predicateOrScene: 'party_to', hint: 'durable' },
+      { predicateOrScene: 'effective_from', hint: 'durable' },
+      { predicateOrScene: 'terminates_on', hint: 'durable' },
+      { predicateOrScene: 'obligation', hint: 'standard' },
+      { predicateOrScene: 'execution', hint: 'durable' },
+      { predicateOrScene: 'negotiation_session', hint: 'ephemeral' },
+    ],
+  },
   evalFixtures: [
     {
       id: 'governing-law',
@@ -120,6 +208,18 @@ an agreement, emit an edge between them in addition to the party facts.`,
       description: 'the effective date is captured',
       text: 'This Agreement is effective 1 January 2026.',
       expect: { facts: [{ predicate: 'effective_from', objectIncludes: '1 January 2026' }] },
+    },
+    {
+      id: 'party',
+      description: 'a named party to the agreement is captured',
+      text: 'This Agreement is between Acme Corp and Beta LLC.',
+      expect: { facts: [{ predicate: 'party_to', objectIncludes: 'Acme Corp' }] },
+    },
+    {
+      id: 'termination',
+      description: 'the termination condition is captured verbatim',
+      text: 'The contract terminates on 90 days written notice.',
+      expect: { facts: [{ predicate: 'terminates_on', objectIncludes: '90 days' }] },
     },
   ],
 };

--- a/src/ai/domain-packs/medical.pack.ts
+++ b/src/ai/domain-packs/medical.pack.ts
@@ -5,13 +5,16 @@ import type { DomainPackManifest } from './manifest';
  * (installed per-tenant from `packs/medical.pack.json`, NOT in BUILTIN_PACKS).
  * Scoped to DRUG / TREATMENT ontology (indications, dosing, interactions,
  * contraindications) — not patient records — so its predicates are piiClass
- * 'none'. Ships an extractionProfile + eval fixtures. Bump `version` to update.
+ * 'none'. Ships an extractionProfile + eval fixtures + memoryModel
+ * (prescription / approval lifecycles, attention + retention hints, a recency
+ * rule for dosage claims and a corroboration rule for contraindications).
+ * Bump `version` to update.
  */
 export const MEDICAL_PACK: DomainPackManifest = {
   id: 'medical',
-  version: '0.1.0',
+  version: '0.2.0',
   description:
-    'Clinical pharmacology ontology — indications, dosing, routes, interactions, and contraindications of drugs/treatments, with a domain extraction profile.',
+    'Clinical pharmacology ontology — indications, dosing, routes, interactions, and contraindications of drugs/treatments, with a domain extraction profile and memory model.',
   predicates: [
     {
       localId: 'treats',
@@ -103,6 +106,82 @@ pack captures drug ontology, not clinical records.`,
       },
     ],
   },
+  // The domain perception contract (docs/domain-packs.md). Declarative data
+  // only — consumed by MemoryModelReaderService for installed tenants.
+  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  memoryModel: {
+    sceneSchemas: [
+      {
+        id: 'medication_review',
+        description:
+          'A medication review or reconciliation: current drugs, doses, and interactions of a treatment plan are checked and adjusted.',
+        cues: ['medication review', 'reconciliation', 'dose adjusted', 'titration'],
+      },
+      {
+        id: 'adverse_event',
+        description:
+          'An adverse event or safety report: a suspected reaction, interaction, or harm involving a drug is described.',
+        cues: ['adverse event', 'side effect', 'reaction', 'pharmacovigilance'],
+      },
+    ],
+    stateModels: [
+      {
+        id: 'prescription_lifecycle',
+        subjectType: 'prescription',
+        states: ['started', 'dose_changed', 'paused', 'discontinued'],
+        transitions: [
+          { from: 'started', to: 'dose_changed' },
+          { from: 'dose_changed', to: 'dose_changed' },
+          { from: 'started', to: 'paused' },
+          { from: 'dose_changed', to: 'paused' },
+          { from: 'paused', to: 'started' },
+          { from: 'started', to: 'discontinued' },
+          { from: 'dose_changed', to: 'discontinued' },
+          { from: 'paused', to: 'discontinued' },
+        ],
+      },
+      {
+        id: 'approval_lifecycle',
+        subjectType: 'drug',
+        states: ['investigational', 'approved', 'restricted', 'withdrawn'],
+        transitions: [
+          { from: 'investigational', to: 'approved' },
+          { from: 'approved', to: 'restricted' },
+          { from: 'approved', to: 'withdrawn' },
+          { from: 'restricted', to: 'withdrawn' },
+        ],
+      },
+    ],
+    attentionHints: [
+      { cue: 'indicated for', prefer: ['treats'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'dose', prefer: ['dosed_at'], zoom: ['facts', 'episodes'], weight: 0.7 },
+      { cue: 'mg', prefer: ['dosed_at'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'interacts', prefer: ['interacts_with'], zoom: ['facts'], weight: 0.7 },
+      { cue: 'contraindicated', prefer: ['contraindicated_with'], zoom: ['facts'], weight: 0.7 },
+      { cue: 'route', prefer: ['administered_via'], zoom: ['facts'], weight: 0.5 },
+      {
+        cue: 'titrated',
+        prefer: ['dosed_at'],
+        zoom: ['medication_review', 'facts'],
+        weight: 0.6,
+      },
+    ],
+    // Dosage claims must not serve stale (doses get titrated and superseded);
+    // contraindication claims are safety-critical — want a second source.
+    verificationRules: [
+      { claimPattern: 'dose', requires: 'recency_check' },
+      { claimPattern: 'contraindicated', requires: 'corroboration' },
+    ],
+    retentionHints: [
+      { predicateOrScene: 'treats', hint: 'durable' },
+      { predicateOrScene: 'interacts_with', hint: 'durable' },
+      { predicateOrScene: 'contraindicated_with', hint: 'durable' },
+      { predicateOrScene: 'dosed_at', hint: 'standard' },
+      { predicateOrScene: 'administered_via', hint: 'standard' },
+      { predicateOrScene: 'adverse_event', hint: 'durable' },
+      { predicateOrScene: 'medication_review', hint: 'standard' },
+    ],
+  },
   evalFixtures: [
     {
       id: 'indication',
@@ -122,6 +201,29 @@ pack captures drug ontology, not clinical records.`,
       text: 'Isotretinoin is contraindicated in pregnancy.',
       expect: {
         facts: [{ predicate: 'contraindicated_with', objectIncludes: 'pregnancy' }],
+      },
+    },
+    {
+      id: 'route',
+      description: 'the route of administration is captured',
+      text: 'Ceftriaxone is administered via intravenous infusion.',
+      expect: { facts: [{ predicate: 'administered_via', objectIncludes: 'intravenous' }] },
+    },
+    {
+      id: 'interaction',
+      description: 'an interacting agent is captured',
+      text: 'Warfarin interacts with aspirin.',
+      expect: { facts: [{ predicate: 'interacts_with', objectIncludes: 'aspirin' }] },
+    },
+    {
+      id: 'dose-and-route',
+      description: 'a compound dosing sentence yields both facts',
+      text: 'Metformin is dosed at 500 mg twice daily, taken orally.',
+      expect: {
+        facts: [
+          { predicate: 'dosed_at', objectIncludes: '500 mg' },
+          { predicate: 'administered_via', objectIncludes: 'oral' },
+        ],
       },
     },
   ],

--- a/src/ai/domain-packs/real-estate.pack.ts
+++ b/src/ai/domain-packs/real-estate.pack.ts
@@ -14,13 +14,18 @@ import type { DomainPackManifest } from './manifest';
  * end-to-end: a community pack contributes both ontology AND extraction tuning
  * without a core change or redeploy.
  *
+ * As of 0.2.0 it also ships a `memoryModel` (listing / tenancy / permit
+ * lifecycles, attention + retention hints, recency rules for asking-price and
+ * appraisal claims) — the domain perception contract consumed by
+ * MemoryModelReaderService for installed tenants.
+ *
  * Bump `version` to ship an updated real-estate ontology / profile.
  */
 export const REAL_ESTATE_PACK: DomainPackManifest = {
   id: 'real_estate',
-  version: '0.1.0',
+  version: '0.2.0',
   description:
-    'Real-estate ontology — zoning, valuation, encumbrances, tenure, and construction of properties/parcels, with a domain extraction profile.',
+    'Real-estate ontology — zoning, valuation, encumbrances, tenure, and construction of properties/parcels, with a domain extraction profile and memory model.',
   predicates: [
     {
       localId: 'zoned_as',
@@ -127,6 +132,85 @@ encumbrance, ALSO emit an edge to that party (e.g. Property —held_by→ Bank).
       },
     ],
   },
+  // The domain perception contract (docs/domain-packs.md). Declarative data
+  // only — consumed by MemoryModelReaderService for installed tenants.
+  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  memoryModel: {
+    sceneSchemas: [
+      {
+        id: 'viewing',
+        description:
+          'A property viewing or open house: prospective buyers or tenants inspect the property and reactions are recorded.',
+        cues: ['viewing', 'open house', 'walkthrough', 'showed the property'],
+      },
+      {
+        id: 'closing',
+        description:
+          'A transaction closing: contracts are exchanged, funds settle, and title transfers on a property deal.',
+        cues: ['closing', 'completion', 'exchanged contracts', 'title transfer', 'escrow'],
+      },
+    ],
+    stateModels: [
+      {
+        id: 'listing_lifecycle',
+        subjectType: 'listing',
+        states: ['listed', 'under_offer', 'sold', 'withdrawn'],
+        transitions: [
+          { from: 'listed', to: 'under_offer' },
+          { from: 'under_offer', to: 'listed' },
+          { from: 'under_offer', to: 'sold' },
+          { from: 'listed', to: 'withdrawn' },
+          { from: 'withdrawn', to: 'listed' },
+        ],
+      },
+      {
+        id: 'tenancy_lifecycle',
+        subjectType: 'tenancy',
+        states: ['advertised', 'let', 'notice_given', 'vacated'],
+        transitions: [
+          { from: 'advertised', to: 'let' },
+          { from: 'let', to: 'notice_given' },
+          { from: 'notice_given', to: 'vacated' },
+          { from: 'vacated', to: 'advertised' },
+        ],
+      },
+      {
+        id: 'permit_lifecycle',
+        subjectType: 'planning_permit',
+        states: ['applied', 'granted', 'refused', 'expired'],
+        transitions: [
+          { from: 'applied', to: 'granted' },
+          { from: 'applied', to: 'refused' },
+          { from: 'granted', to: 'expired' },
+        ],
+      },
+    ],
+    attentionHints: [
+      { cue: 'zoned', prefer: ['zoned_as'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'appraised', prefer: ['valued_at'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'asking price', prefer: ['listed_at', 'valued_at'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'lien', prefer: ['encumbered_by'], zoom: ['facts', 'episodes'], weight: 0.7 },
+      { cue: 'easement', prefer: ['encumbered_by'], zoom: ['facts'], weight: 0.6 },
+      { cue: 'leasehold', prefer: ['tenure_type'], zoom: ['facts'], weight: 0.5 },
+      { cue: 'under offer', prefer: ['listed_at'], zoom: ['episodes', 'facts'], weight: 0.6 },
+      { cue: 'built in', prefer: ['built_in'], zoom: ['facts'], weight: 0.4 },
+    ],
+    // Asking prices move and appraisals expire — serve both recency-checked.
+    verificationRules: [
+      { claimPattern: 'listed at', requires: 'recency_check' },
+      { claimPattern: 'appraised', requires: 'recency_check' },
+    ],
+    retentionHints: [
+      { predicateOrScene: 'tenure_type', hint: 'durable' },
+      { predicateOrScene: 'built_in', hint: 'durable' },
+      { predicateOrScene: 'encumbered_by', hint: 'durable' },
+      { predicateOrScene: 'zoned_as', hint: 'durable' },
+      { predicateOrScene: 'valued_at', hint: 'standard' },
+      { predicateOrScene: 'listed_at', hint: 'standard' },
+      { predicateOrScene: 'closing', hint: 'durable' },
+      { predicateOrScene: 'viewing', hint: 'ephemeral' },
+    ],
+  },
   evalFixtures: [
     {
       id: 'zoning',
@@ -145,6 +229,24 @@ encumbrance, ALSO emit an edge to that party (e.g. Property —held_by→ Bank).
       description: 'ownership tenure is captured',
       text: 'Unit 4B is held on a leasehold basis.',
       expect: { facts: [{ predicate: 'tenure_type', objectIncludes: 'leasehold' }] },
+    },
+    {
+      id: 'listing-price',
+      description: 'the asking price is captured verbatim',
+      text: 'The warehouse is listed at $1.5M.',
+      expect: { facts: [{ predicate: 'listed_at', objectIncludes: '$1.5M' }] },
+    },
+    {
+      id: 'encumbrance',
+      description: 'an encumbrance on the property is captured',
+      text: 'The property at 12 Elm St carries a mortgage held by First National.',
+      expect: { facts: [{ predicate: 'encumbered_by', objectIncludes: 'mortgage' }] },
+    },
+    {
+      id: 'construction-year',
+      description: 'the construction year is captured verbatim',
+      text: 'The house at 8 Oak Ave was built in 1998.',
+      expect: { facts: [{ predicate: 'built_in', objectIncludes: '1998' }] },
     },
   ],
 };

--- a/test/eval/domain-packs/runner.ts
+++ b/test/eval/domain-packs/runner.ts
@@ -345,7 +345,11 @@ async function ensurePackSetup(cfg: Config): Promise<Record<string, string>> {
   const installed = list.json?.installed ?? [];
   for (const pack of [FINTECH_PACK, MEDICAL_PACK]) {
     const already = installed.find((p) => p.packId === pack.id);
-    if (already !== undefined) {
+    // Skip only on an exact version match: the install check (corpus
+    // wantsPacksInstalled) pins the LOCAL manifest version, so a stand
+    // holding an older install must be upgraded (install upsert = upgrade),
+    // not skipped — otherwise every manifest bump strands the battery.
+    if (already !== undefined && already.version === pack.version) {
       setup[pack.id] = `already installed v${already.version}`;
       console.error(`[setup] ${pack.id}: ${setup[pack.id]}`);
       continue;


### PR DESCRIPTION
## What

All six first-party industry packs — `real_estate`, `fintech`, `medical`, `legal`, `insurance`, `hr` — move from the frozen 0.1.0 shape (predicates + `extractionProfile` only) to **0.2.0**, catching up with the manifest contract as it stands after the `memoryModel` wave (#381): every pack now ships a domain perception contract and a fuller eval-fixture set, validated at module load exactly like the builtin `code_memory` (0.4.1), which served as the reference for shapes and tone.

### memoryModel per pack (all text-only — zero consent surface)

| pack | stateModels (lifecycles) | scenes | attentionHints | verificationRules |
|---|---|---|---|---|
| `real_estate` | listing (listed→under_offer→sold/withdrawn), tenancy (advertised→let→notice_given→vacated), permit (applied→granted/refused→expired) | viewing, closing | 8 | `listed at` + `appraised` → recency_check |
| `fintech` | license (applied→granted→suspended/revoked/surrendered), certification (in_assessment→certified→lapsed/withdrawn), enforcement (opened→remediation_ordered→settled→closed) | audit_review, regulatory_filing | 7 | `licensed` + `settlement` → recency_check |
| `medical` | prescription (started→dose_changed→paused→discontinued), approval (investigational→approved→restricted/withdrawn) | medication_review, adverse_event | 7 | `dose` → recency_check, `contraindicated` → corroboration |
| `legal` | matter (opened→discovery→settled/judged→closed), agreement (drafted→negotiated→executed→effective→terminated/expired), obligation (owed→performed/waived/breached) | negotiation_session, execution | 7 | `terminat` + `effective` → recency_check |
| `insurance` | policy (quoted→bound→renewed→lapsed/cancelled), claim (reported→assessed→approved/denied→paid→closed) | claim_intake, renewal_review | 7 | `premium` + `cover` → recency_check |
| `hr` | position (opened→sourcing→interviewing→offer_extended→filled→vacated), employee (hired→onboarded→promoted/on_leave→offboarded) | interview_debrief, offer_stage | 8 | `comp` + `remote` → recency_check |

Every `attentionHints.prefer` references only the pack's own predicate localIds, every zoom target is an own scene id or a fixed literal, and retentionHints split durable identity/compliance facts (tenure, regulator, contraindications, governing law, exclusions, employment type) from operational churn (asking price, settlement convention, dose, obligations, premium, comp) — with `ephemeral` used where it genuinely fits (viewings, negotiation sessions, interview debriefs). Everything passes `validateMemoryModel`'s anti-DSL and referential fences.

### evalFixtures

Extended from 3 to 5–6 per pack, following the `code_memory` fixture shape — **additions only**: every previously shipped fixture id/text/expectation is byte-identical, and each pack now covers every one of its predicates (plus one compound fixture each for fintech and medical).

### Guard-rails kept

- **Eval battery**: the fintech/medical predicate sets read via `packPredicate` are unchanged (no member lost, no semantics changed). One battery-side fix rode along: phase-0 (`ensurePackSetup`) previously skipped install when the pack was present at *any* version, while the install check pins the *local manifest* version — after this bump that would have stranded the battery on stands holding 0.1.0. It now upgrades on version mismatch (install upsert = upgrade, self-healing via registry republish).
- **Manifest validation**: `FIRST_PARTY_PACKS` are now validated at module load in `src/ai/domain-packs/index.ts` (builtins already got this via `assembleSeed`); a malformed industry manifest fails the boot/test run, not a tenant install.
- **JSON artifacts**: `packs/*.pack.json` regenerated from the TS constants; the drift guards (`test/industry-packs.unit-spec.ts`, `test/real-estate-pack.unit-spec.ts`) pass.
- **Docs**: `docs/domain-packs.md` pack table gains a `memoryModel lifecycles` column; the "no first-party pack declares a memoryModel yet" note is retired.

### Deliberately NOT added (and why)

- **`mcpTools`**: the machinery is real (PackToolsReaderService + `MCP_PACK_TOOLS_ENABLED` + `acceptMcpTools` on both `/v1/admin/packs` and `/from-registry`), but declaring tools makes *every* install/upgrade of these packs consent-gated (`mcpConsentRequired` → 400 without `acceptMcpTools: true`), and none of the packs' existing install surfaces can grant that consent today: `pnpm pack:install` has no consent flag, the eval battery's phase-0 installer doesn't pass one, and the e2e installs don't either. Shipping tools now would hard-break every current install flow for a surface that is default-off — that belongs in a dedicated increment that first teaches the CLI/runner to consent.
- **`seedDocuments`**: the channel is live (`pack_seed_ingest`), but these packs are ontology, not content — their facts should come from tenant data. Canned industry prose would inject invented "knowledge" into tenant graphs and burn install-time LLM ingestion for no retrieval benefit. Skipped as dead weight.

### Verification

- `pnpm typecheck` — clean
- `pnpm format:check` — clean
- eslint over every touched file — clean
- full `pnpm test:unit` (worktree jest overrides) — **3940/3940 passed**, including all 12 pack suites (181 tests: manifest validity, JSON drift guards, memory-model validation, scorers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
