### PR TITLE
fix(facts): open the cosine gate for promoted single_active mention slots

### DIFF
--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -47,6 +47,15 @@ export function derivedSemanticsFor(aspect: string, slotSemantics: boolean): Der
 }
 
 /**
+ * Slot-exact pool floor: cosine's true lower bound, so the resolver's
+ * `cosine(embedding, $embedding) >= $similarity_threshold` gate admits
+ * EVERY embedded row of the slot. Bound as $similarity_threshold only
+ * for promoted mention-path single_active writes (see
+ * conflictSlotResolution below) — never a global threshold change.
+ */
+export const SLOT_EXACT_SIMILARITY_FLOOR = -1;
+
+/**
  * Shared conflict-slot promotion — the ONE decision point both live
  * ingest paths flow through (buildResolveCall), so the doctrine cannot
  * fork per path. Promotion target is always 'bitemporal': the only
@@ -66,24 +75,54 @@ export function derivedSemanticsFor(aspect: string, slotSemantics: boolean): Der
  *    (state-transitions s07). The append_only open-vocabulary bulk and
  *    DEFAULT_FALLBACK stay untouched (load-bearing for extraction).
  *
- * Both flags default off ⇒ registry passthrough, byte-identical.
- * Deliberately NOT 'single_active' as a target in either direction, and
- * per-user isolation needs nothing here: fn::resolve_fact's candidate
- * pool is already scope-local (0055 $user_id filter). Pure decision
- * (env read lives in src/common/conflict-flags.ts); exported for tests.
+ * similarityFloor — the mention-path promotion ALSO opens the
+ * 'bitemporal' pool's cosine gate for exactly those writes
+ * (SLOT_EXACT_SIMILARITY_FLOOR rides into the fn as
+ * $similarity_threshold). The gate exists to establish claim identity
+ * in OPEN slots, but a promoted single_active slot is already
+ * structurally exact — fn::resolve_fact's $candidates SELECT matches
+ * entity, canonical predicate, userId and world — and its registry
+ * semantics declare AT MOST ONE active value, so any two values there
+ * are in collision BY DEFINITION. Left at the shared
+ * CONFLICT_SIMILARITY_THRESHOLD (0.85), contradicting paraphrases of
+ * one attribute ("until December 2026" vs "ends in September 2026",
+ * cosine 0.805 measured live) sit below the gate, the pool empties,
+ * and both land plainly 'active' — the exact silent fork the flag
+ * exists to prevent (state-transitions s07). Note this is strictly
+ * GENTLER than the slot's own registry policy: plain single_active
+ * would take the whole slot as its pool and supersede unconditionally.
+ * The direct-path promotion keeps the gate: its '__default__' slots
+ * are open-vocabulary, where cosine IS the claim-identity signal. The
+ * 0009 interval-overlap gate stays for both (non-overlapping validity
+ * = clean succession, not conflict).
+ *
+ * Both flags default off ⇒ registry passthrough, no floor,
+ * byte-identical. Deliberately NOT 'single_active' as a target in
+ * either direction, and per-user isolation needs nothing here:
+ * fn::resolve_fact's candidate pool is already scope-local (0055
+ * $user_id filter). Pure decision (env read lives in
+ * src/common/conflict-flags.ts); exported for tests.
  */
+export function conflictSlotResolution(
+  policy: { predicateId: string; semantics: string },
+  path: 'direct' | 'mention',
+): { semantics: string; similarityFloor?: number | undefined } {
+  if (path === 'direct') {
+    return conflictDirectFactSlotEnabled() && policy.predicateId === DEFAULT_FALLBACK.predicateId
+      ? { semantics: 'bitemporal' }
+      : { semantics: policy.semantics };
+  }
+  return conflictMentionFactSlotEnabled() && policy.semantics === 'single_active'
+    ? { semantics: 'bitemporal', similarityFloor: SLOT_EXACT_SIMILARITY_FLOOR }
+    : { semantics: policy.semantics };
+}
+
+/** Semantics-only view of conflictSlotResolution (kept for tests/callers). */
 export function conflictSlotSemantics(
   policy: { predicateId: string; semantics: string },
   path: 'direct' | 'mention',
 ): string {
-  if (path === 'direct') {
-    return conflictDirectFactSlotEnabled() && policy.predicateId === DEFAULT_FALLBACK.predicateId
-      ? 'bitemporal'
-      : policy.semantics;
-  }
-  return conflictMentionFactSlotEnabled() && policy.semantics === 'single_active'
-    ? 'bitemporal'
-    : policy.semantics;
+  return conflictSlotResolution(policy, path).semantics;
 }
 
 /**
@@ -365,11 +404,14 @@ export class FactResolverService {
     // Conflict-slot promotion (CONFLICT_DIRECT_FACT_SLOT /
     // CONFLICT_MENTION_FACT_SLOT, both default off): the shared helper
     // routes each path's blind spot into fn::resolve_fact's 'bitemporal'
-    // margin doctrine — see conflictSlotSemantics above. Flags off ⇒
-    // registry passthrough, byte-identical. Composes with
+    // margin doctrine — see conflictSlotResolution above. A mention-path
+    // single_active promotion also carries the slot-exact pool floor
+    // (the cosine gate is redundant for a structurally-exact
+    // single-value slot and starves the collision otherwise). Flags off
+    // ⇒ registry passthrough, no floor, byte-identical. Composes with
     // canonicalization: the canonical slot's registry policy (status →
     // single_active) is what the mention promotion sees.
-    const semantics = conflictSlotSemantics(policy, path);
+    const { semantics, similarityFloor } = conflictSlotResolution(policy, path);
     const sourceTrust = sourceTrustFor(p.source as Parameters<typeof sourceTrustFor>[0]);
     // Confidence-aware attribution (MULTILINGUAL_LANG_ATTRIBUTION, default
     // off). Off → detectLanguage keeps its Phase-4 `en` fallback and no new
@@ -449,6 +491,7 @@ export class FactResolverService {
       source: p.source,
       sourceTrust,
       semantics,
+      similarityFloor,
       lang,
       script,
       langMeta,
@@ -834,6 +877,10 @@ export class FactResolverService {
       source: unknown;
       sourceTrust: number;
       semantics: string;
+      /** Per-call conflict-pool cosine floor (slot-exact promotion — see
+       *  conflictSlotResolution). Undefined ⇒ the shared configured
+       *  CONFLICT_SIMILARITY_THRESHOLD, byte-identical. */
+      similarityFloor?: number | undefined;
       lang?: string | undefined;
       script?: string | undefined;
       /** Attribution metadata (0100), stamped by a follow-up UPDATE; not
@@ -881,7 +928,7 @@ export class FactResolverService {
             source: p.source,
             source_trust: p.sourceTrust,
             semantics: p.semantics,
-            similarity_threshold: this.conflict.similarityThreshold,
+            similarity_threshold: p.similarityFloor ?? this.conflict.similarityThreshold,
             slot_similarity: this.conflict.slotSimilarityThreshold,
             w_confidence: this.conflict.weights.confidence,
             w_source_trust: this.conflict.weights.sourceTrust,

--- a/test/conflict-mention-fact-slot.unit-spec.ts
+++ b/test/conflict-mention-fact-slot.unit-spec.ts
@@ -1,4 +1,9 @@
-import { FactResolverService, conflictSlotSemantics } from '../src/ingest/fact-resolver.service';
+import {
+  FactResolverService,
+  SLOT_EXACT_SIMILARITY_FLOOR,
+  conflictSlotResolution,
+  conflictSlotSemantics,
+} from '../src/ingest/fact-resolver.service';
 
 /**
  * CONFLICT_MENTION_FACT_SLOT — semantics promotion at the shared
@@ -110,6 +115,47 @@ describe('FactResolverService — CONFLICT_MENTION_FACT_SLOT promotion', () => {
     expect(out.result.competingFactIds).toEqual(['knowledge_fact:prior']);
   });
 
+  it('flag on + mention + single_active: binds the slot-exact pool floor as $similarity_threshold', async () => {
+    // The measured s07 failure: contradicting paraphrases of one
+    // single-value attribute ("until December 2026" vs "ends in
+    // September 2026") sit at cosine 0.805 < 0.85, so the promoted
+    // 'bitemporal' pool emptied on the cosine gate and both landed
+    // plainly active. A promoted single_active slot is structurally
+    // exact (entity + canonical predicate + userId + world), so the
+    // promotion opens the gate for exactly these writes.
+    process.env.CONFLICT_MENTION_FACT_SLOT = '1';
+    const { svc, db, queries } = make();
+    await svc.resolve(db as never, input('address'));
+    expect(resolveCalls(queries)[0]!.params.similarity_threshold).toBe(SLOT_EXACT_SIMILARITY_FLOOR);
+  });
+
+  it('flag on + mention + unknown predicate: shared threshold untouched (no floor leak)', async () => {
+    process.env.CONFLICT_MENTION_FACT_SLOT = '1';
+    const { svc, db, queries } = make();
+    await svc.resolve(db as never, input('lease_end_date'));
+    expect(resolveCalls(queries)[0]!.params.similarity_threshold).toBe(0.85);
+  });
+
+  it('direct flag on + direct + __default__: promoted but cosine-gated (open-vocabulary slot)', async () => {
+    // Direct-path promotion targets '__default__' open-vocabulary slots,
+    // where cosine IS the claim-identity signal — the floor must NOT
+    // apply there.
+    process.env.CONFLICT_DIRECT_FACT_SLOT = '1';
+    const { svc, db, queries } = make();
+    const out = await svc.resolve(
+      db as never,
+      input('lease_end_date', { recordOutcomeMetric: true }),
+    );
+    expect(out.semantics).toBe('bitemporal');
+    expect(resolveCalls(queries)[0]!.params.similarity_threshold).toBe(0.85);
+  });
+
+  it('flag off: mention single_active binds the shared configured threshold', async () => {
+    const { svc, db, queries } = make();
+    await svc.resolve(db as never, input('address'));
+    expect(resolveCalls(queries)[0]!.params.similarity_threshold).toBe(0.85);
+  });
+
   it("flag on: value-sameness is the fn's exact object binding — CORROBORATED passes through", async () => {
     process.env.CONFLICT_MENTION_FACT_SLOT = '1';
     const { svc, db, queries } = make({
@@ -189,6 +235,31 @@ describe('FactResolverService — CONFLICT_MENTION_FACT_SLOT promotion', () => {
       expect(conflictSlotSemantics(slot, 'mention')).toBe('bitemporal');
       expect(conflictSlotSemantics(slot, 'direct')).toBe('single_active');
       expect(conflictSlotSemantics(fallback, 'mention')).toBe('append_only');
+    });
+
+    it('similarityFloor: carried ONLY by the mention-path single_active promotion', () => {
+      process.env.CONFLICT_DIRECT_FACT_SLOT = '1';
+      process.env.CONFLICT_MENTION_FACT_SLOT = '1';
+      expect(conflictSlotResolution(slot, 'mention')).toEqual({
+        semantics: 'bitemporal',
+        similarityFloor: SLOT_EXACT_SIMILARITY_FLOOR,
+      });
+      // Direct promotion: open-vocabulary slot, cosine gate stays.
+      expect(conflictSlotResolution(fallback, 'direct')).toEqual({ semantics: 'bitemporal' });
+      // Non-promoted combinations: passthrough, no floor.
+      expect(conflictSlotResolution(fallback, 'mention')).toEqual({ semantics: 'append_only' });
+      expect(conflictSlotResolution(slot, 'direct')).toEqual({ semantics: 'single_active' });
+    });
+
+    it('similarityFloor: flags off ⇒ never set', () => {
+      expect(conflictSlotResolution(slot, 'mention').similarityFloor).toBeUndefined();
+      expect(conflictSlotResolution(fallback, 'direct').similarityFloor).toBeUndefined();
+    });
+
+    it('SLOT_EXACT_SIMILARITY_FLOOR admits the whole cosine range', () => {
+      // cosine ∈ [-1, 1]; the floor must sit at the true lower bound so
+      // `>= floor` can never exclude an embedded slot row.
+      expect(SLOT_EXACT_SIMILARITY_FLOOR).toBe(-1);
     });
   });
 });


### PR DESCRIPTION
## Root cause

`CONFLICT_MENTION_FACT_SLOT` promotes a mention-path `single_active` policy to `'bitemporal'` (`conflictSlotSemantics`, `src/ingest/fact-resolver.service.ts`) so two conversations asserting contradictory values of one slot "meet in the conflict pool" and the margin doctrine can form a COMPETING pair. The promotion target is correct — `'bitemporal'` is the branch that runs the margin doctrine in `fn::resolve_fact` (0085) — but that branch's conflict pool is **cosine-gated**:

```
-- 0085_slot_supersede_pairwise_closure.surql:141-144
(SELECT * FROM $candidates
    WHERE embedding != NONE
      AND vector::similarity::cosine(embedding, $embedding) >= $eff_similarity
      AND fn::intervals_overlap(validFrom, validUntil, $valid_from, $valid_until))
```

with `$eff_similarity = $similarity_threshold` = `CONFLICT_SIMILARITY_THRESHOLD` (0.85 default) for `'bitemporal'`.

That gate was built to establish *claim identity* in **open** slots (genuine `bitemporal` registry predicates admit heterogeneous claims). A promoted `single_active` slot is already **structurally exact** — the `$candidates` SELECT matches entity, canonical predicate (`predicateAlias ?? predicate`), `userId` and world — and its registry semantics declare at most one active value, so any two values there are in collision *by definition*. Contradicting paraphrases of one attribute routinely sit below 0.85, the pool empties, and the second write lands as a plain `INSERTED`: both sides stay `active`, no pair forms — the exact silent fork the flag exists to prevent (state-transitions s07).

### Measured evidence (dogfood stand, scratch SurrealDB, read-only)

Existing s07 pair (tenant `co_fitness4`, user `stev-agent`, entity `knowledge_entity:e77ftt1jx40x0eofdoj1`, slot `status`):

| filter stage | pool |
|---|---|
| `$candidates` (entity + canonical predicate + userId + world + active) | 1 row (`"until December 2026"`) |
| + interval overlap (`fn::intervals_overlap`) | 1 row |
| + `cosine >= 0.85` | **0 rows** ← the pool-emptying filter |

- lease pair cosine: **0.805** (`"status: until December 2026"` vs `"status: ends in September 2026"`) → below the gate → both `active`
- dob pair that *did* form COMPETING (co_fitness5, `"2026-08-09"` vs `"2026-08-20"`): cosine **0.968** → above the gate → pair formed

Both facts carry open validity intervals (validUntil NONE), so the interval gate was not the cause; semantics promotion itself worked (the second write did resolve as `'bitemporal'`).

## Fix

`conflictSlotResolution` (superset of `conflictSlotSemantics`, which remains as a semantics-only view) now returns a per-call `similarityFloor = -1` (cosine's true lower bound) for **exactly** the mention-path `single_active` promotion. `buildResolveCall` threads it through, and `resolveFactCall` binds it as `$similarity_threshold` for that call only.

This is deliberately **not** a global threshold change:

- genuine `bitemporal` registry predicates keep `CONFLICT_SIMILARITY_THRESHOLD` (0.85),
- the direct-path `'__default__'` promotion keeps the gate (open-vocabulary slots — cosine *is* the claim-identity signal there),
- `bitemporal_event` derive keeps `DERIVER_SLOT_SIMILARITY` (0.9),
- the 0009 interval-overlap gate stays for promoted writes too (non-overlapping validity = clean succession, not conflict),
- and the result is strictly *gentler* than the slot's own registry policy — plain `single_active` takes the whole slot as its pool and supersedes unconditionally.

No `fn::resolve_fact` change, no migration. Flags off ⇒ the promotion never fires ⇒ the resolver call is byte-identical (pinned by the existing params-equality test).

## Verification

- `pnpm typecheck`, `pnpm test:unit` (358 suites / 3990 tests), `pnpm format:check` — all green.
- New unit pins: the floor is bound as `$similarity_threshold` only for flag-on + mention + `single_active`; the direct-path promotion and the append_only bulk keep 0.85; flags off keep 0.85; pure-fn pins for `conflictSlotResolution`.
- Live stand (worktree app booted on :3055 against the same scratch SurrealDB, `co_dogfood`, fresh userId):
  - **current main (:3033), userId `s07-diag-1`**: two s07-shaped mention turns ("warehouse lease runs until December 2026" / "actually ends in September 2026") → both facts land `(warehouse lease, status)` **both `active`**, cosine 0.805 — bug reproduced;
  - **this fix (:3055), userId `s07-diag-2`**: same two turns → mutual **COMPETING** pair (margin 0.0 < 0.15, conflictTrace stamped), `/v1/search` shows both sides as `competing`, and `get_competing_facts` returns both facts as one 2-fact `(entity, status)` adjudication group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
