### PR TITLE
fix(search): confidence-gate the hard lang filter (k07) + hermetic code-memory k10 corpus

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -818,6 +818,17 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Soft same-language filter: replaces the hard `lang = q OR lang IS NONE` exclusion at both read sites (search where-builder + user-profile) with a same-language RANKING boost — a cross-lingual fact is demoted, never hidden. In search it is gated on a high-confidence detected query language (an explicit dto.queryLang / caller-supplied profile lang counts as confident); below the confidence floor no boost AND no exclusion. Off (default) → the hard filter is byte-identical.',
   },
+  {
+    key: 'MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE',
+    category: 'pipeline',
+    // Read at call time (resolveSearchTuning per request) — never
+    // constructor-captured — so a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Confidence gate on the HARD same-language search exclusion: the `lang = q OR lang IS NONE` WHERE filter (and its cross-lingual backoff pass) fires only when the detected query language cleared the same high-confidence floor the Tier-1 soft boost trusts. Below the floor — including the detector\'s zero-evidence `en` fallback on stopword-less identifier queries like "acme-api webhooks rate limit" — the pass is single and unfiltered, so a fact mislabeled with another language is never hidden from a query that expressed no language at all (the code-memory k07 miss). An explicit dto.queryLang carries confidence 1 and always filters. Off (default) → any non-`und` detection filters, byte-identical.',
+  },
   // ── Multilingual (Tier 3, migration 0102) ───────────
   {
     key: 'MULTILINGUAL_ENTITY_REVERSIBLE',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1332,6 +1332,13 @@ const KNOWN_BOOLEAN_FLAGS = [
   // confidence-gated ranking boost (cross-lingual facts demoted, never
   // hidden). Default off ⇒ the hard filter is byte-identical.
   'MULTILINGUAL_SOFT_LANG_FILTER',
+  // Multilingual Tier 1. Confidence gate on the HARD same-language search
+  // exclusion: a query language below the high-confidence floor (incl. the
+  // zero-evidence `en` fallback on stopword-less identifier queries) runs a
+  // single unfiltered pass instead of excluding other-language facts (the
+  // code-memory k07 miss). Default off ⇒ any non-`und` detection filters,
+  // byte-identical. MULTILINGUAL_ family, off the ENGINE flag budget.
+  'MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE',
   // Multilingual Tier 3 (migration 0102). Reversible entity resolution: a
   // weak embedding-only inline-resolution match is NOT auto-merged — it
   // becomes a reviewable entity_merge_log candidate — and every strong

--- a/src/search/retrieval-profile.ts
+++ b/src/search/retrieval-profile.ts
@@ -1047,9 +1047,18 @@ export interface SearchTuning {
    * `langAttribution` (MULTILINGUAL_LANG_ATTRIBUTION) mirrors the detector
    * flag so the search path can emit query-surface attribution telemetry
    * only when attribution is on. Both default off ⇒ byte-identical.
+   *
+   * `langFilterConfidenceGate` (MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE)
+   * gates the HARD same-language exclusion on the same high-confidence
+   * floor the soft boost already uses: a query whose language was only
+   * the detector's zero-evidence `en` fallback (or any below-floor
+   * detection) runs a single unfiltered pass instead of excluding
+   * other-language facts. Default off ⇒ the hard filter fires on any
+   * non-`und` detection, byte-identical.
    */
   softLangFilter: boolean;
   langAttribution: boolean;
+  langFilterConfidenceGate: boolean;
 }
 
 function tuningInt(env: NodeJS.ProcessEnv, name: string, fallback: number): number {
@@ -1109,5 +1118,6 @@ export function resolveSearchTuning(env: NodeJS.ProcessEnv = process.env): Searc
     edgeExpansion: resolveExpansionConfig(env),
     softLangFilter: envFlagEnabled(env.MULTILINGUAL_SOFT_LANG_FILTER),
     langAttribution: envFlagEnabled(env.MULTILINGUAL_LANG_ATTRIBUTION),
+    langFilterConfidenceGate: envFlagEnabled(env.MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE),
   };
 }

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -86,8 +86,42 @@ interface StagedPipeline {
  * the boost is withheld (no exclusion either — soft mode never filters).
  * An explicit dto.queryLang is treated as confidence 1, so it always
  * clears the floor. Module-private (not a tunable knob in Tier 1).
+ * MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE reuses the SAME floor for the
+ * hard exclusion (hardLangFilterFor below), so "confident query language"
+ * means one thing across both read-side language behaviours.
  */
 const LANG_QUERY_HIGH_CONFIDENCE = 0.5;
+
+/**
+ * The hard same-language WHERE exclusion's language, confidence-gated
+ * (MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE, default off). Pure and
+ * exported for tests.
+ *
+ * The measured miss (code-memory battery k07): the identifier-soup query
+ * "acme-api webhooks rate limit" carries ZERO stopword evidence, so the
+ * detector's Phase-4 fallback labels it `en` with confidence 0 — and the
+ * hard `lang = 'en' OR lang IS NONE` exclusion then hid a fact whose
+ * object "120 requests per minute" had been stamped `it` at write time
+ * (the lone Italian stopword "per", confidence 0.33). The fact ranked
+ * #1 by cosine and was EXCLUDED by language — on a query that expressed
+ * no language at all.
+ *
+ * Gate ON: the hard exclusion (and its cross-lingual backoff pass) fires
+ * only when the query language cleared LANG_QUERY_HIGH_CONFIDENCE — the
+ * same floor the Tier-1 soft boost already trusts. Below it the pass is
+ * single and unfiltered: with no real evidence of the query's language,
+ * excluding facts by language is a recall bug, not a locale feature. An
+ * explicit dto.queryLang carries confidence 1 and always filters.
+ * Off (default) → any non-`und` detection filters, byte-identical.
+ */
+export function hardLangFilterFor(
+  langSignal: { lang: string; confidence: number } | undefined,
+  gateEnabled: boolean,
+): string | undefined {
+  if (!langSignal) return undefined;
+  if (gateEnabled && langSignal.confidence < LANG_QUERY_HIGH_CONFIDENCE) return undefined;
+  return langSignal.lang;
+}
 
 @Injectable()
 export class SearchService {
@@ -194,7 +228,14 @@ export class SearchService {
         detectorVersion: DETECTOR_VERSION,
       });
     }
-    return { langFilter: langSignal?.lang, softBoost };
+    // Hard-exclusion gate (MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE): a
+    // below-floor query-language signal never hard-filters — see
+    // hardLangFilterFor. softBoost is unaffected (it already requires the
+    // same floor).
+    return {
+      langFilter: hardLangFilterFor(langSignal, ctx.tuning.langFilterConfidenceGate),
+      softBoost,
+    };
   }
 
   /**

--- a/test/code-memory-corpus-hermetic.unit-spec.ts
+++ b/test/code-memory-corpus-hermetic.unit-spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Run-scoped module identity for the code-memory battery corpus
+ * (test/eval/code-memory/corpus.ts moduleIdentity / buildTurns /
+ * buildChecks) — the k10 hermeticity fix.
+ *
+ * Measured failure being pinned: knowledge entities are tenant-GLOBAL
+ * while battery facts are per-run user-scoped, so with a STATIC module
+ * name every rerun re-resolved the path/symbol phrasings onto whatever
+ * entities the FIRST run minted. On the dogfood stand, runs
+ * cm-dogfood-1..3 executed on pre-#453 code and minted the
+ * `src/gateway/webhook-dispatcher.ts` / `WebhookDispatcher` twin pair;
+ * run cm-dogfood-4 (INGEST_CODE_ALIAS_RESOLUTION=1) then reused BOTH
+ * twins via the step-2 exact-name match and re-measured the stale
+ * split — while a fresh-tenant repro of the same two phrasings
+ * resolved to ONE entity. Run-scoping the module name makes each run
+ * measure its own resolution.
+ *
+ * The spec pins three contracts:
+ *  1. back-compat: no runId ⇒ the historical static corpus,
+ *     byte-identical (ALL_TURNS / CHECKS keep meaning what they meant);
+ *  2. round-trip: the run-scoped path and symbol stay derivable from
+ *     each other through the REAL product helpers (code-alias.ts), in
+ *     BOTH directions the resolver uses;
+ *  3. lockstep: turns and the k10 check agree on the names.
+ */
+import { pathNeedlesForSymbol, symbolAliasForPath } from '../src/ingest/code-alias';
+import {
+  ALL_TURNS,
+  buildChecks,
+  buildTurns,
+  CHECKS,
+  moduleIdentity,
+  moduleRunSlug,
+} from './eval/code-memory/corpus';
+
+describe('moduleRunSlug', () => {
+  it('lowercases and strips non-alphanumerics', () => {
+    expect(moduleRunSlug('cmmtpzlspw')).toBe('cmmtpzlspw');
+    expect(moduleRunSlug('Run_7-KQ')).toBe('run7kq');
+  });
+
+  it('prefixes a digit-leading slug so it stays a valid symbol hump', () => {
+    expect(moduleRunSlug('42ab')).toBe('r42ab');
+  });
+
+  it('empty in, empty out (the unscoped legacy identity)', () => {
+    expect(moduleRunSlug('')).toBe('');
+    expect(moduleRunSlug('__--__')).toBe('');
+  });
+});
+
+describe('moduleIdentity', () => {
+  it('unscoped identity is the historical static one, byte-identical', () => {
+    const m = moduleIdentity('');
+    expect(m.path).toBe('src/gateway/webhook-dispatcher.ts');
+    expect(m.symbol).toBe('WebhookDispatcher');
+    expect(m.nameTokens).toEqual(['webhook-dispatcher', 'webhookdispatcher', 'webhook dispatcher']);
+  });
+
+  it('run-scoped path derives the run-scoped symbol via the REAL product helper', () => {
+    const m = moduleIdentity('cmmtpzlspw');
+    expect(m.path).toBe('src/gateway/webhook-dispatcher-cmmtpzlspw.ts');
+    expect(m.symbol).toBe('WebhookDispatcherCmmtpzlspw');
+    // Forward direction (path → symbol): what creation-time alias
+    // seeding and reuseSymbolEntityForPath derive.
+    expect(symbolAliasForPath(m.path)).toBe(m.symbol);
+    // Reverse direction (symbol → path): reusePathEntityForSymbol scans
+    // needles with string::contains(canonicalNameLc, needle) — the
+    // kebab needle must be a substring of the run-scoped path.
+    const needles = pathNeedlesForSymbol(m.symbol);
+    expect(needles).toContain(m.basename);
+    expect(m.path.includes(m.basename)).toBe(true);
+  });
+
+  it('run-scoped nameTokens name THIS run only (no generic natural-language token)', () => {
+    const m = moduleIdentity('cmmtpzlspw');
+    expect(m.nameTokens).toEqual(['webhook-dispatcher-cmmtpzlspw', 'webhookdispatchercmmtpzlspw']);
+  });
+});
+
+describe('buildTurns / buildChecks lockstep', () => {
+  it('no runId ⇒ the exported static corpus, deep-equal', () => {
+    expect(buildTurns()).toEqual(ALL_TURNS);
+    expect(buildChecks()).toEqual(CHECKS);
+  });
+
+  it('run-scoped turns carry the module by PATH (decision#1) and SYMBOL (flags#4)', () => {
+    const m = moduleIdentity('cmmtpzlspw');
+    const turns = buildTurns('cmmtpzlspw');
+    const decision1 = turns.find((t) => t.conversation === 'decision' && t.turn === 1);
+    const flags4 = turns.find((t) => t.conversation === 'flags' && t.turn === 4);
+    expect(decision1?.text).toContain(m.path);
+    expect(flags4?.text.startsWith(m.symbol)).toBe(true);
+    // The static names must NOT leak into a scoped corpus — that would
+    // resolve onto the legacy twins again.
+    expect(decision1?.text).not.toContain('webhook-dispatcher.ts');
+    expect(flags4?.text).not.toContain('WebhookDispatcher ');
+  });
+
+  it('the k10 check names the same run-scoped module as the turns', () => {
+    const m = moduleIdentity('cmmtpzlspw');
+    const k10 = buildChecks('cmmtpzlspw').find((c) => c.id === 'k10-cross-entity');
+    expect(k10?.kind).toBe('cross-entity');
+    if (k10?.kind !== 'cross-entity') throw new Error('k10 shape changed');
+    expect(k10.nameTokens).toEqual(m.nameTokens);
+    expect(k10.intent).toContain(m.path);
+    expect(k10.intent).toContain(m.symbol);
+    // The phrasing groups stay the corpus invariants, untouched.
+    expect(k10.mustCarryGroups).toEqual([
+      ['dispatch path', 'outbound webhook'],
+      ['cents', 'line-item'],
+    ]);
+  });
+
+  it('only the module-bearing turns differ from the static corpus', () => {
+    const scoped = buildTurns('cmmtpzlspw');
+    const differing = scoped.filter((t, i) => t.text !== ALL_TURNS[i]?.text);
+    expect(differing.map((t) => `${t.conversation}#${t.turn}`)).toEqual(['decision#1', 'flags#4']);
+  });
+});

--- a/test/engine-gates.unit-spec.ts
+++ b/test/engine-gates.unit-spec.ts
@@ -173,6 +173,12 @@ describe('S5.5 — dead exports in the engine dirs', () => {
     // truncated-only / cap selection; the substitution prefix fence).
     'selectZoomFragments',
     'buildZoomedLines',
+    // MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE (code-memory k07) pure
+    // decision seam. Consumed inside search.service (resolveLangMode) but
+    // pinned DIRECTLY by the lang-filter-confidence-gate unit spec for its
+    // precision cases (gate off byte-identical; floor inclusive; the
+    // measured zero-evidence-query regression shape).
+    'hardLangFilterFor',
   ]);
   const TESTS = walk(join(ROOT, 'test'))
     .map((f) => readFileSync(f, 'utf8'))

--- a/test/eval/code-memory/corpus.ts
+++ b/test/eval/code-memory/corpus.ts
@@ -6,7 +6,10 @@
  * version, a PR merged then reverted, and voiced plans that must NOT
  * become transitions. One module ("webhook-dispatcher") is referenced
  * BOTH by file path and by symbol name, so entity identity is
- * measured, not assumed.
+ * measured, not assumed. That module's name is RUN-SCOPED
+ * (moduleIdentity): entities are tenant-global, so a static name would
+ * make every rerun re-measure the twins the FIRST run minted instead
+ * of its own resolution — buildTurns/buildChecks take the run id.
  *
  * Current predicate ids are DERIVED from the real builtin manifest
  * (src/ai/domain-packs/code-memory.pack.ts) through a guard that
@@ -29,6 +32,7 @@
 import { CODE_MEMORY_PACK } from '../../../src/ai/domain-packs/code-memory.pack';
 import { composePredicateId } from '../../../src/ai/domain-packs/manifest';
 import { STATE_CHANGE_PREDICATE } from '../../../src/ai/extractor-internals/state-verb-harvest';
+import { symbolAliasForPath } from '../../../src/ingest/code-alias';
 import type { Check, CorpusTurn } from './types';
 
 export { CODE_MEMORY_PACK };
@@ -118,6 +122,71 @@ export const CM_040 = {
   supersededBy: plannedPredicate('superseded_by'),
 } as const;
 
+// ── run-scoped module identity (k10 hermeticity) ────────────────────
+
+/**
+ * The dual-phrasing module (path + symbol), RUN-SCOPED.
+ *
+ * Why: knowledge entities are tenant-GLOBAL while corpus facts are
+ * per-run user-scoped. With a static module name, run N's path/symbol
+ * turns resolve onto whatever entities run 1 minted — so a twin pair
+ * created before INGEST_CODE_ALIAS_RESOLUTION existed poisons every
+ * later run's k10 measurement (measured live: runs cm-dogfood-1..3 on
+ * pre-#453 code minted the `src/gateway/webhook-dispatcher.ts` /
+ * `WebhookDispatcher` twins; run cm-dogfood-4, flags ON, reused BOTH via
+ * the step-2 exact-name match and re-measured the stale split). The
+ * battery already namespaces conversations per run; the module identity
+ * follows the same principle, so each run measures ITS OWN resolution.
+ *
+ * The symbol is derived through the REAL product helper
+ * (symbolAliasForPath), so the corpus can never drift from the
+ * convention the resolver implements — a slug the helper cannot derive
+ * makes the corpus refuse to build.
+ */
+export interface ModuleIdentity {
+  /** File-path phrasing, e.g. "src/gateway/webhook-dispatcher-r7kq.ts". */
+  path: string;
+  /** Symbol phrasing, e.g. "WebhookDispatcherR7kq". */
+  symbol: string;
+  /** Kebab basename without extension. */
+  basename: string;
+  /** canonicalName needles for the k10 check (lowercased match). */
+  nameTokens: string[];
+}
+
+/**
+ * Sanitize a run id into a slug usable as a kebab-case basename part
+ * AND a PascalCase hump: lowercase alphanumerics, letter-first
+ * (digit-leading ids get an `r` prefix). Empty in → empty out.
+ */
+export function moduleRunSlug(runId: string): string {
+  const slug = runId.toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (slug === '') return '';
+  return /^[a-z]/.test(slug) ? slug : `r${slug}`;
+}
+
+export function moduleIdentity(runId = ''): ModuleIdentity {
+  const slug = moduleRunSlug(runId);
+  const basename = slug === '' ? 'webhook-dispatcher' : `webhook-dispatcher-${slug}`;
+  const path = `src/gateway/${basename}.ts`;
+  const symbol = symbolAliasForPath(path);
+  if (symbol === null) {
+    throw new Error(`corpus module path "${path}" derives no symbol — bad run slug "${slug}"`);
+  }
+  return {
+    path,
+    symbol,
+    basename,
+    // Run-scoped tokens name THIS run's module only. The unscoped
+    // fallback keeps the historical natural-language token so the
+    // static exports stay byte-identical.
+    nameTokens:
+      slug === ''
+        ? [basename, symbol.toLowerCase(), 'webhook dispatcher']
+        : [basename, symbol.toLowerCase()],
+  };
+}
+
 /** Timestamp of turn N (1-based) — 5 minutes apart within a session. */
 const t = (startIso: string, turn: number): string =>
   new Date(Date.parse(startIso) + (turn - 1) * 5 * 60_000).toISOString();
@@ -128,31 +197,35 @@ const conv = (conversation: string, startIso: string, texts: string[]): CorpusTu
 // ── the four conversations ──────────────────────────────────────────
 
 /** Decision conversation — decision + rationale + invariant + gotcha,
- *  then a superseding decision on the same subject. */
-const DECISION_TURNS = conv('decision', '2026-09-01T09:00:00Z', [
-  'We decided to route every outbound webhook in acme-api through ' +
-    'src/gateway/webhook-dispatcher.ts — one dispatch path instead of six ad-hoc fetch calls.',
-  'The reason: retry and signing logic had drifted between the six webhook call-sites, ' +
-    'and two of them never signed payloads at all.',
-  'Invariant for acme-api: every route handler must validate its body with the shared ' +
-    'zod schema from src/gateway/schemas.ts, or the contract tests fail.',
-  'Gotcha in acme-api: pnpm run migrate --dry-run still acquires the schema lock, ' +
-    'so a dry run can deadlock a live deploy.',
-  'Update: we walked the single-dispatcher decision back — outbound webhooks in acme-api ' +
-    'now go through the managed queue relay in src/gateway/queue-relay.ts.',
-]);
+ *  then a superseding decision on the same subject. The dual-phrasing
+ *  module appears here by PATH (run-scoped — see moduleIdentity). */
+const decisionTurns = (m: ModuleIdentity): CorpusTurn[] =>
+  conv('decision', '2026-09-01T09:00:00Z', [
+    'We decided to route every outbound webhook in acme-api through ' +
+      `${m.path} — one dispatch path instead of six ad-hoc fetch calls.`,
+    'The reason: retry and signing logic had drifted between the six webhook call-sites, ' +
+      'and two of them never signed payloads at all.',
+    'Invariant for acme-api: every route handler must validate its body with the shared ' +
+      'zod schema from src/gateway/schemas.ts, or the contract tests fail.',
+    'Gotcha in acme-api: pnpm run migrate --dry-run still acquires the schema lock, ' +
+      'so a dry run can deadlock a live deploy.',
+    'Update: we walked the single-dispatcher decision back — outbound webhooks in acme-api ' +
+      'now go through the managed queue relay in src/gateway/queue-relay.ts.',
+  ]);
 
 /** Flags conversation — a flag introduced dark (default 0), the
  *  literal lane's identifier / port / rate-limit prose, the SYMBOL
- *  phrasing of the shared module, then the flag enablement (0→1). */
-const FLAGS_TURNS = conv('flags', '2026-09-01T15:00:00Z', [
-  'We introduced the ACME_RETRY_QUEUE flag in acme-api; it ships disabled and its ' +
-    'default stays 0 until the queue is proven.',
-  'The gateway metrics endpoint in acme-api listens on port 9187.',
-  'acme-api throttles /v1/webhooks at 120 requests per minute.',
-  'WebhookDispatcher in acme-api emits every line-item amount in cents, never floats.',
-  'We enabled ACME_RETRY_QUEUE in prod today; its default is now 1 for every acme-api tenant.',
-]);
+ *  phrasing of the shared module (run-scoped), then the flag
+ *  enablement (0→1). */
+const flagsTurns = (m: ModuleIdentity): CorpusTurn[] =>
+  conv('flags', '2026-09-01T15:00:00Z', [
+    'We introduced the ACME_RETRY_QUEUE flag in acme-api; it ships disabled and its ' +
+      'default stays 0 until the queue is proven.',
+    'The gateway metrics endpoint in acme-api listens on port 9187.',
+    'acme-api throttles /v1/webhooks at 120 requests per minute.',
+    `${m.symbol} in acme-api emits every line-item amount in cents, never floats.`,
+    'We enabled ACME_RETRY_QUEUE in prod today; its default is now 1 for every acme-api tenant.',
+  ]);
 
 /** Deps conversation — a pin, the bump (1.2.0 → 2.0.0), ownership,
  *  a gotcha bound to the new version, and a second pinned dep. */
@@ -178,240 +251,255 @@ const MIXED_TURNS = conv('mixed', '2026-09-03T11:00:00Z', [
     'orphan webhook sockets piled up unclosed.',
 ]);
 
-export const ALL_TURNS: CorpusTurn[] = [
-  ...DECISION_TURNS,
-  ...FLAGS_TURNS,
-  ...DEPS_TURNS,
-  ...MIXED_TURNS,
-];
+/**
+ * The corpus turns, run-scoped: the dual-phrasing module carries the
+ * run's slug so k10 measures THIS run's entity resolution instead of
+ * re-measuring whatever twins an earlier (possibly pre-flag) run left
+ * in the tenant-global entity space. No runId → the historical static
+ * texts, byte-identical (unit-test surface).
+ */
+export function buildTurns(runId = ''): CorpusTurn[] {
+  const m = moduleIdentity(runId);
+  return [...decisionTurns(m), ...flagsTurns(m), ...DEPS_TURNS, ...MIXED_TURNS];
+}
+
+/** Back-compat static corpus (unscoped module names). */
+export const ALL_TURNS: CorpusTurn[] = buildTurns();
 
 // ── the checks ──────────────────────────────────────────────────────
 
-export const CHECKS: Check[] = [
-  // ── setup: the builtin seeding path itself ────────────────────────
-  {
-    kind: 'builtin-vocab',
-    id: 'k01-builtin-seeded',
-    cls: 'setup',
-    intent:
-      'The builtin code_memory predicates are active in the tenant WITHOUT any ' +
-      'install (bootstrap seeding; the install path rejects the builtin id by design).',
-    requiredPredicates: [CM.decided, CM.because, CM.invariant, CM.gotcha],
-  },
+/** The check battery, run-scoped in lockstep with buildTurns. */
+export function buildChecks(runId = ''): Check[] {
+  const m = moduleIdentity(runId);
+  return [
+    // ── setup: the builtin seeding path itself ────────────────────────
+    {
+      kind: 'builtin-vocab',
+      id: 'k01-builtin-seeded',
+      cls: 'setup',
+      intent:
+        'The builtin code_memory predicates are active in the tenant WITHOUT any ' +
+        'install (bootstrap seeding; the install path rejects the builtin id by design).',
+      requiredPredicates: [CM.decided, CM.because, CM.invariant, CM.gotcha],
+    },
 
-  // ── pack-vocab, today's ontology (honest baseline: no profile) ────
-  {
-    kind: 'pack-vocab',
-    id: 'k02-vocab-decided',
-    cls: 'vocab',
-    intent: `The dispatch decision canonicalizes into ${CM.decided}, not a coined predicate.`,
-    searchQuery: 'acme-api outbound webhook dispatch decision',
-    predicate: CM.decided,
-    valueMarkers: ['dispatch'],
-    expectedUnknown: PROFILE_GAP,
-  },
-  {
-    kind: 'pack-vocab',
-    id: 'k03-vocab-invariant',
-    cls: 'vocab',
-    intent: `The zod-schema rule lands on ${CM.invariant} with the verbatim constraint.`,
-    searchQuery: 'acme-api route handler body validation invariant',
-    predicate: CM.invariant,
-    valueMarkers: ['zod'],
-    expectedUnknown: PROFILE_GAP,
-  },
-  {
-    kind: 'pack-vocab',
-    id: 'k04-vocab-gotcha',
-    cls: 'vocab',
-    intent: `The dry-run deadlock trap lands on ${CM.gotcha}.`,
-    searchQuery: 'acme-api migrate dry run schema lock',
-    predicate: CM.gotcha,
-    valueMarkers: ['schema lock'],
-    expectedUnknown: PROFILE_GAP,
-  },
+    // ── pack-vocab, today's ontology (honest baseline: no profile) ────
+    {
+      kind: 'pack-vocab',
+      id: 'k02-vocab-decided',
+      cls: 'vocab',
+      intent: `The dispatch decision canonicalizes into ${CM.decided}, not a coined predicate.`,
+      searchQuery: 'acme-api outbound webhook dispatch decision',
+      predicate: CM.decided,
+      valueMarkers: ['dispatch'],
+      expectedUnknown: PROFILE_GAP,
+    },
+    {
+      kind: 'pack-vocab',
+      id: 'k03-vocab-invariant',
+      cls: 'vocab',
+      intent: `The zod-schema rule lands on ${CM.invariant} with the verbatim constraint.`,
+      searchQuery: 'acme-api route handler body validation invariant',
+      predicate: CM.invariant,
+      valueMarkers: ['zod'],
+      expectedUnknown: PROFILE_GAP,
+    },
+    {
+      kind: 'pack-vocab',
+      id: 'k04-vocab-gotcha',
+      cls: 'vocab',
+      intent: `The dry-run deadlock trap lands on ${CM.gotcha}.`,
+      searchQuery: 'acme-api migrate dry run schema lock',
+      predicate: CM.gotcha,
+      valueMarkers: ['schema lock'],
+      expectedUnknown: PROFILE_GAP,
+    },
 
-  // ── pack-vocab, the 0.4.0 ontology increment (gap-gated) ──────────
-  {
-    kind: 'pack-vocab',
-    id: 'k05-vocab-default-value',
-    cls: 'vocab',
-    intent: `The flag default lands on ${CM_040.defaultValue} as a typed single_active value.`,
-    searchQuery: 'ACME_RETRY_QUEUE default value',
-    predicate: CM_040.defaultValue,
-    valueMarkers: ['0', '1'],
-    expectedUnknown: gap040(
-      'default_value',
-      'whether extraction routes flag-default phrasing into the typed predicate.',
-    ),
-  },
-  {
-    kind: 'pack-vocab',
-    id: 'k06-vocab-depends-on-version',
-    cls: 'vocab',
-    intent: `The redis-client bump lands on ${CM_040.dependsOnVersion} with the new version.`,
-    searchQuery: 'acme-api redis-client version',
-    predicate: CM_040.dependsOnVersion,
-    valueMarkers: ['2.0.0'],
-    expectedUnknown: gap040(
-      'depends_on_version',
-      'whether extraction routes dependency-version phrasing into the typed predicate.',
-    ),
-  },
+    // ── pack-vocab, the 0.4.0 ontology increment (gap-gated) ──────────
+    {
+      kind: 'pack-vocab',
+      id: 'k05-vocab-default-value',
+      cls: 'vocab',
+      intent: `The flag default lands on ${CM_040.defaultValue} as a typed single_active value.`,
+      searchQuery: 'ACME_RETRY_QUEUE default value',
+      predicate: CM_040.defaultValue,
+      valueMarkers: ['0', '1'],
+      expectedUnknown: gap040(
+        'default_value',
+        'whether extraction routes flag-default phrasing into the typed predicate.',
+      ),
+    },
+    {
+      kind: 'pack-vocab',
+      id: 'k06-vocab-depends-on-version',
+      cls: 'vocab',
+      intent: `The redis-client bump lands on ${CM_040.dependsOnVersion} with the new version.`,
+      searchQuery: 'acme-api redis-client version',
+      predicate: CM_040.dependsOnVersion,
+      valueMarkers: ['2.0.0'],
+      expectedUnknown: gap040(
+        'depends_on_version',
+        'whether extraction routes dependency-version phrasing into the typed predicate.',
+      ),
+    },
 
-  // ── literal lane fit inside coding prose ──────────────────────────
-  {
-    kind: 'literal-harvest',
-    id: 'k07-literal-harvest',
-    cls: 'harvest',
-    intent:
-      'The deterministic literal lane (EXTRACTOR_LITERAL_HARVEST, ON at the stand) ' +
-      'produces its core facts from identifier-heavy coding prose: the ALL_CAPS flag, ' +
-      'the metrics port and the route rate limit each land as a typed literal fact.',
-    wants: [
-      {
-        searchQuery: 'ACME_RETRY_QUEUE flag',
-        predicate: 'identifier',
-        valueMarkers: ['ACME_RETRY_QUEUE'],
-      },
-      {
-        searchQuery: 'acme-api gateway metrics port',
-        predicate: 'service_port',
-        valueMarkers: ['9187'],
-      },
-      {
-        searchQuery: 'acme-api webhooks rate limit',
-        predicate: 'rate_limit',
-        valueMarkers: ['120'],
-      },
-    ],
-  },
+    // ── literal lane fit inside coding prose ──────────────────────────
+    {
+      kind: 'literal-harvest',
+      id: 'k07-literal-harvest',
+      cls: 'harvest',
+      intent:
+        'The deterministic literal lane (EXTRACTOR_LITERAL_HARVEST, ON at the stand) ' +
+        'produces its core facts from identifier-heavy coding prose: the ALL_CAPS flag, ' +
+        'the metrics port and the route rate limit each land as a typed literal fact.',
+      wants: [
+        {
+          searchQuery: 'ACME_RETRY_QUEUE flag',
+          predicate: 'identifier',
+          valueMarkers: ['ACME_RETRY_QUEUE'],
+        },
+        {
+          searchQuery: 'acme-api gateway metrics port',
+          predicate: 'service_port',
+          valueMarkers: ['9187'],
+        },
+        {
+          searchQuery: 'acme-api webhooks rate limit',
+          predicate: 'rate_limit',
+          valueMarkers: ['120'],
+        },
+      ],
+    },
 
-  // ── the flag 0→1 transition as ordered history ────────────────────
-  {
-    kind: 'flag-transition',
-    id: 'k08-flag-transition',
-    cls: 'transition',
-    intent:
-      'ONE entity timeline retains the flag story in order: introduced dark ' +
-      '(ships disabled, default 0) then enabled (default 1).',
-    searchQuery: 'ACME_RETRY_QUEUE flag default',
-    stages: [
-      ['ships disabled', 'default stays 0'],
-      ['enabled ACME_RETRY_QUEUE', 'default is now 1'],
-    ],
-    expectedUnknown: LEXICON_GAP,
-  },
+    // ── the flag 0→1 transition as ordered history ────────────────────
+    {
+      kind: 'flag-transition',
+      id: 'k08-flag-transition',
+      cls: 'transition',
+      intent:
+        'ONE entity timeline retains the flag story in order: introduced dark ' +
+        '(ships disabled, default 0) then enabled (default 1).',
+      searchQuery: 'ACME_RETRY_QUEUE flag default',
+      stages: [
+        ['ships disabled', 'default stays 0'],
+        ['enabled ACME_RETRY_QUEUE', 'default is now 1'],
+      ],
+      expectedUnknown: LEXICON_GAP,
+    },
 
-  // ── supersession, mechanically (MCP write path) ───────────────────
-  {
-    kind: 'supersession-asof',
-    id: 'k09-supersession-asof',
-    cls: 'mcp',
-    intent:
-      'Re-recording a `decided` on one anchor SUPERSEDES: `why` now serves exactly ' +
-      'ONE active decision (the new one), and `why` at an asOf between the writes ' +
-      'still recalls the old one — and not yet the new one (bitemporal).',
-    anchor: 'acme-api/src/gateway/queue-relay.ts',
-    oldText: 'Route webhook retries through the in-process queue.',
-    newText: 'Route webhook retries through the managed queue relay.',
-    oldMarkers: ['in-process'],
-    newMarkers: ['managed queue relay'],
-  },
+    // ── supersession, mechanically (MCP write path) ───────────────────
+    {
+      kind: 'supersession-asof',
+      id: 'k09-supersession-asof',
+      cls: 'mcp',
+      intent:
+        'Re-recording a `decided` on one anchor SUPERSEDES: `why` now serves exactly ' +
+        'ONE active decision (the new one), and `why` at an asOf between the writes ' +
+        'still recalls the old one — and not yet the new one (bitemporal).',
+      anchor: 'acme-api/src/gateway/queue-relay.ts',
+      oldText: 'Route webhook retries through the in-process queue.',
+      newText: 'Route webhook retries through the managed queue relay.',
+      oldMarkers: ['in-process'],
+      newMarkers: ['managed queue relay'],
+    },
 
-  // ── entity identity across phrasings ──────────────────────────────
-  {
-    kind: 'cross-entity',
-    id: 'k10-cross-entity',
-    cls: 'identity',
-    intent:
-      'The module referenced by PATH (src/gateway/webhook-dispatcher.ts) and by ' +
-      'SYMBOL (WebhookDispatcher) resolves to ONE entity carrying facts seeded by ' +
-      'both phrasings — no per-phrasing duplication.',
-    searchQuery: 'acme-api webhook dispatcher',
-    nameTokens: ['webhook-dispatcher', 'webhookdispatcher', 'webhook dispatcher'],
-    mustCarryGroups: [
-      ['dispatch path', 'outbound webhook'],
-      ['cents', 'line-item'],
-    ],
-  },
+    // ── entity identity across phrasings ──────────────────────────────
+    {
+      kind: 'cross-entity',
+      id: 'k10-cross-entity',
+      cls: 'identity',
+      intent:
+        `The module referenced by PATH (${m.path}) and by ` +
+        `SYMBOL (${m.symbol}) resolves to ONE entity carrying facts seeded by ` +
+        'both phrasings — no per-phrasing duplication.',
+      searchQuery: 'acme-api webhook dispatcher',
+      nameTokens: m.nameTokens,
+      mustCarryGroups: [
+        ['dispatch path', 'outbound webhook'],
+        ['cents', 'line-item'],
+      ],
+    },
 
-  // ── provenance ────────────────────────────────────────────────────
-  {
-    kind: 'trace-provenance',
-    id: 'k11-trace-provenance',
-    cls: 'trace',
-    intent: "A dispatch-decision fact unrolls to the seeded decision turn's episode verbatim.",
-    searchQuery: 'acme-api outbound webhook dispatch decision',
-    objectHint: ['dispatch', 'webhook'],
-    episodeFragments: ['one dispatch path instead of six'],
-  },
+    // ── provenance ────────────────────────────────────────────────────
+    {
+      kind: 'trace-provenance',
+      id: 'k11-trace-provenance',
+      cls: 'trace',
+      intent: "A dispatch-decision fact unrolls to the seeded decision turn's episode verbatim.",
+      searchQuery: 'acme-api outbound webhook dispatch decision',
+      objectHint: ['dispatch', 'webhook'],
+      episodeFragments: ['one dispatch path instead of six'],
+    },
 
-  // ── serving ───────────────────────────────────────────────────────
-  {
-    kind: 'serve',
-    id: 'k12-serve-current-default',
-    cls: 'serving',
-    intent:
-      'The dogfood north-star question — "what is the current default of X" — serves ' +
-      'the NEW value and never the stale one.',
-    query: 'What is the current default of ACME_RETRY_QUEUE in acme-api?',
-    expectAnyOf: ['now 1', 'is 1', 'to 1', 'default of 1', 'enabled'],
-    forbidAnyOf: ['default is 0', 'defaults to 0', 'stays 0', 'still 0', 'disabled'],
-    expectedUnknown: gap040(
-      'default_value',
-      'whether "current default" serves correctly without a typed single_active home.',
-    ),
-  },
-  {
-    kind: 'serve',
-    id: 'k13-serve-owner',
-    cls: 'serving',
-    intent: 'Module-ownership serving: "who owns src/gateway" names the owner.',
-    query: 'Who owns src/gateway in acme-api?',
-    expectAnyOf: ['Priya'],
-    forbidAnyOf: [],
-    expectedUnknown: gap040(
-      'owns',
-      'whether ownership phrasing survives open-vocab extraction well enough to serve.',
-    ),
-  },
+    // ── serving ───────────────────────────────────────────────────────
+    {
+      kind: 'serve',
+      id: 'k12-serve-current-default',
+      cls: 'serving',
+      intent:
+        'The dogfood north-star question — "what is the current default of X" — serves ' +
+        'the NEW value and never the stale one.',
+      query: 'What is the current default of ACME_RETRY_QUEUE in acme-api?',
+      expectAnyOf: ['now 1', 'is 1', 'to 1', 'default of 1', 'enabled'],
+      forbidAnyOf: ['default is 0', 'defaults to 0', 'stays 0', 'still 0', 'disabled'],
+      expectedUnknown: gap040(
+        'default_value',
+        'whether "current default" serves correctly without a typed single_active home.',
+      ),
+    },
+    {
+      kind: 'serve',
+      id: 'k13-serve-owner',
+      cls: 'serving',
+      intent: 'Module-ownership serving: "who owns src/gateway" names the owner.',
+      query: 'Who owns src/gateway in acme-api?',
+      expectAnyOf: ['Priya'],
+      forbidAnyOf: [],
+      expectedUnknown: gap040(
+        'owns',
+        'whether ownership phrasing survives open-vocab extraction well enough to serve.',
+      ),
+    },
 
-  // ── the intention guard must hold ─────────────────────────────────
-  {
-    kind: 'intention-guard',
-    id: 'k14-intention-guard',
-    cls: 'guard',
-    intent:
-      'The voiced-plan turns ("should probably enable", "have not enabled") must NOT ' +
-      'produce a completed state transition for ACME_STRICT_MODE — this must stay ' +
-      'green BOTH before and after the coding-verb lexicon lands (the 6-token guards ' +
-      'are what keep it green after).',
-    searchQuery: 'ACME_STRICT_MODE',
-    forbidPredicate: STATE_CHANGE_PREDICATE,
-    forbidObjectMarkers: ['ACME_STRICT_MODE'],
-  },
+    // ── the intention guard must hold ─────────────────────────────────
+    {
+      kind: 'intention-guard',
+      id: 'k14-intention-guard',
+      cls: 'guard',
+      intent:
+        'The voiced-plan turns ("should probably enable", "have not enabled") must NOT ' +
+        'produce a completed state transition for ACME_STRICT_MODE — this must stay ' +
+        'green BOTH before and after the coding-verb lexicon lands (the 6-token guards ' +
+        'are what keep it green after).',
+      searchQuery: 'ACME_STRICT_MODE',
+      forbidPredicate: STATE_CHANGE_PREDICATE,
+      forbidObjectMarkers: ['ACME_STRICT_MODE'],
+    },
 
-  // ── MCP round-trip ────────────────────────────────────────────────
-  {
-    kind: 'mcp-roundtrip',
-    id: 'k15-mcp-roundtrip',
-    cls: 'mcp',
-    intent: 'record_decision → why on a fresh anchor round-trips (found>0, right kind, text).',
-    anchor: 'acme-api/src/ingest/replay-window.ts',
-    recordKind: 'decided',
-    text: 'Cap the replay window at 48 hours; longer windows re-deliver acknowledged webhooks.',
-    textMarkers: ['48 hours', 'replay window'],
-  },
+    // ── MCP round-trip ────────────────────────────────────────────────
+    {
+      kind: 'mcp-roundtrip',
+      id: 'k15-mcp-roundtrip',
+      cls: 'mcp',
+      intent: 'record_decision → why on a fresh anchor round-trips (found>0, right kind, text).',
+      anchor: 'acme-api/src/ingest/replay-window.ts',
+      recordKind: 'decided',
+      text: 'Cap the replay window at 48 hours; longer windows re-deliver acknowledged webhooks.',
+      textMarkers: ['48 hours', 'replay window'],
+    },
 
-  // ── surfaces ──────────────────────────────────────────────────────
-  {
-    kind: 'no-rogue-tools',
-    id: 'k16-no-rogue-tools',
-    cls: 'surfaces',
-    intent:
-      'The code-memory tools (why / recall_decisions / record_decision) are core ' +
-      'single-underscore names and no pack declares mcpTools, so tools/list must ' +
-      'carry ZERO __-namespaced pack tools — asserted, not assumed.',
-  },
-];
+    // ── surfaces ──────────────────────────────────────────────────────
+    {
+      kind: 'no-rogue-tools',
+      id: 'k16-no-rogue-tools',
+      cls: 'surfaces',
+      intent:
+        'The code-memory tools (why / recall_decisions / record_decision) are core ' +
+        'single-underscore names and no pack declares mcpTools, so tools/list must ' +
+        'carry ZERO __-namespaced pack tools — asserted, not assumed.',
+    },
+  ];
+}
+
+/** Back-compat static battery (unscoped module names). */
+export const CHECKS: Check[] = buildChecks();

--- a/test/eval/code-memory/runner.ts
+++ b/test/eval/code-memory/runner.ts
@@ -27,7 +27,7 @@ import { interleaveRoundRobin } from '../memory-fitness/interleave';
 import { walkProvenance } from '../memory-fitness/scorers';
 import { checkHistorySequence, scoreServe, type HistoryEvent } from '../state-transitions/scorers';
 import { findExactPredicateFact, findNamespacedTools, type HitLike } from '../domain-packs/scorers';
-import { ALL_TURNS, CHECKS, CM, CORPUS_VERTICAL } from './corpus';
+import { buildChecks, buildTurns, CM, CORPUS_VERTICAL } from './corpus';
 import {
   checkBuiltinPredicates,
   checkEntityDedup,
@@ -292,8 +292,13 @@ async function readTenantPredicates(cfg: Config): Promise<PredicateLike[]> {
 // ── phase 1: write the corpus ───────────────────────────────────────
 
 async function ingestTurns(cfg: Config, brain: HttpBrainClient): Promise<void> {
-  console.error(`[ingest] ${ALL_TURNS.length} mention turns (run ${cfg.runId})…`);
-  for (const [i, turn] of ALL_TURNS.entries()) {
+  // Run-scoped corpus: the dual-phrasing module's name carries the run
+  // id, so k10 measures THIS run's path/symbol resolution instead of
+  // re-attaching facts to twins an earlier run minted (entities are
+  // tenant-global; only facts are per-user).
+  const turns = buildTurns(cfg.runId);
+  console.error(`[ingest] ${turns.length} mention turns (run ${cfg.runId})…`);
+  for (const [i, turn] of turns.entries()) {
     // Deliberately NO knownEntities hints: the cross-entity check (k10)
     // measures whether the path and the symbol phrasing resolve to one
     // entity WITHOUT being told — hints would rig the measurement.
@@ -311,7 +316,7 @@ async function ingestTurns(cfg: Config, brain: HttpBrainClient): Promise<void> {
         emittedAt: turn.emittedAt,
       }),
     );
-    if ((i + 1) % 10 === 0) console.error(`[ingest] ${i + 1}/${ALL_TURNS.length}`);
+    if ((i + 1) % 10 === 0) console.error(`[ingest] ${i + 1}/${turns.length}`);
   }
 }
 
@@ -568,7 +573,7 @@ async function runCheck(ctx: CheckContext, check: Check): Promise<Verdict2> {
 
 async function runChecks(ctx: CheckContext): Promise<CheckResult[]> {
   const results: CheckResult[] = [];
-  for (const check of CHECKS) {
+  for (const check of buildChecks(ctx.cfg.runId)) {
     const started = Date.now();
     let verdict: Verdict2;
     try {
@@ -644,11 +649,13 @@ function buildScorecard(
     startedAt,
     finishedAt: new Date().toISOString(),
     setup,
-    ingest: { mentionTurns: cfg.skipIngest ? 0 : ALL_TURNS.length },
+    ingest: { mentionTurns: cfg.skipIngest ? 0 : buildTurns(cfg.runId).length },
     classes,
     checkKinds,
     checks,
-    gapGatedChecks: CHECKS.filter((c) => c.expectedUnknown !== undefined).map((c) => c.id),
+    gapGatedChecks: buildChecks(cfg.runId)
+      .filter((c) => c.expectedUnknown !== undefined)
+      .map((c) => c.id),
     results,
   };
 }

--- a/test/search-lang-filter-confidence-gate.unit-spec.ts
+++ b/test/search-lang-filter-confidence-gate.unit-spec.ts
@@ -1,0 +1,79 @@
+/**
+ * MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE — confidence gate on the
+ * hard same-language search exclusion (search.service hardLangFilterFor
+ * + retrieval-profile tuning resolution).
+ *
+ * Measured failure being pinned (code-memory battery k07): the scorer
+ * query "acme-api webhooks rate limit" carries ZERO stopword evidence,
+ * so the detector's Phase-4 fallback labels it `en` with confidence 0 —
+ * and the hard `lang = 'en' OR lang IS NONE` exclusion then hid the
+ * `rate_limit: 120 requests per minute` fact, which had been stamped
+ * `it` at write time off the lone Italian stopword "per" (confidence
+ * 0.33). The fact ranked #1 by raw cosine (the INGEST_PREDICATE_INDEX_TEXT
+ * humanized embedding worked) and was excluded purely by language — on a
+ * query that expressed no language at all. Verified live: the same
+ * search with `disableLangFilter: true` served both rate_limit facts.
+ *
+ * Gate ON ⇒ the hard exclusion requires the SAME high-confidence floor
+ * the Tier-1 soft boost trusts (0.5); below it the pass is single and
+ * unfiltered. Gate OFF (default) ⇒ any non-`und` detection filters —
+ * byte-identical legacy behaviour.
+ */
+import { detectLanguage } from '../src/ai/locale/language-detector';
+import { resolveSearchTuning } from '../src/search/retrieval-profile';
+import { hardLangFilterFor } from '../src/search/search.service';
+
+describe('hardLangFilterFor', () => {
+  it('no signal ⇒ no filter, gate irrelevant', () => {
+    expect(hardLangFilterFor(undefined, false)).toBeUndefined();
+    expect(hardLangFilterFor(undefined, true)).toBeUndefined();
+  });
+
+  it('gate OFF ⇒ any non-und signal filters (legacy, byte-identical)', () => {
+    expect(hardLangFilterFor({ lang: 'en', confidence: 0 }, false)).toBe('en');
+    expect(hardLangFilterFor({ lang: 'it', confidence: 0.2 }, false)).toBe('it');
+  });
+
+  it('gate ON ⇒ a below-floor signal never hard-filters', () => {
+    expect(hardLangFilterFor({ lang: 'en', confidence: 0 }, true)).toBeUndefined();
+    expect(hardLangFilterFor({ lang: 'it', confidence: 0.49 }, true)).toBeUndefined();
+  });
+
+  it('gate ON ⇒ a confident signal still filters (floor 0.5, inclusive)', () => {
+    expect(hardLangFilterFor({ lang: 'en', confidence: 0.5 }, true)).toBe('en');
+    // Explicit dto.queryLang is resolved at confidence 1 upstream — it
+    // always clears the gate.
+    expect(hardLangFilterFor({ lang: 'ru', confidence: 1 }, true)).toBe('ru');
+  });
+
+  it('k07 regression shape: the measured query/fact pair stops mis-excluding', () => {
+    // The scorer query has no stopword evidence: Phase-4 fallback en@0.
+    const query = detectLanguage('acme-api webhooks rate limit', false);
+    expect(query.language).toBe('en');
+    expect(query.confidence).toBe(0);
+    // The write side stamped the fact `it` off one stopword ("per") —
+    // the mislabel that made the en-filter a recall bug.
+    const fact = detectLanguage('120 requests per minute', false);
+    expect(fact.language).toBe('it');
+    expect(fact.confidence).toBeLessThan(0.5);
+    // Legacy: the zero-evidence query hard-filters to en and hides the
+    // it-labeled fact. Gated: no filter — the fact stays retrievable.
+    expect(hardLangFilterFor({ lang: query.language, confidence: query.confidence }, false)).toBe(
+      'en',
+    );
+    expect(
+      hardLangFilterFor({ lang: query.language, confidence: query.confidence }, true),
+    ).toBeUndefined();
+  });
+});
+
+describe('resolveSearchTuning.langFilterConfidenceGate', () => {
+  it('defaults off; env flag flips it', () => {
+    expect(resolveSearchTuning({} as NodeJS.ProcessEnv).langFilterConfidenceGate).toBe(false);
+    expect(
+      resolveSearchTuning({
+        MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE: '1',
+      } as NodeJS.ProcessEnv).langFilterConfidenceGate,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Live diagnosis + fix for the two measured code-memory-battery residuals (run `cm-dogfood-4`, tenant `co_stev4`, all flags on). Both root causes turned out different from the working hypotheses — details and live proof below.

## Finding 2 / k07 — rate_limit facts exist, scorer query serves zero

**What was ruled out first (measured, not assumed):**
- The `INGEST_PREDICATE_INDEX_TEXT` embedding is correct on the harvest lane: the stored vector of the evidence fact is **byte-identical** (cosine 1.000000, max elementwise diff 0) to a fresh embedding of `rate_limit: 120 requests per minute — rate limit`, and cosine 0.9309 to the flag-off text — no fifth embed site bypasses `factIndexText`.
- Ranking is not the loss either: the two rate_limit facts rank **#1–2 by raw cosine** for the exact scorer query `acme-api webhooks rate limit` across all of the user's facts.

**Root cause — the hard same-language WHERE exclusion** (`where-builder.ts:158-170`, driven by `search.service.ts` `resolveLangMode`):
- Write side: `detectLanguage("120 requests per minute")` → **`it` @ 0.33** — the lone Italian stopword `per` out of 3 letter-tokens (`fact-resolver.service.ts:381`; the row carries `lang: "it"`).
- Read side: `acme-api webhooks rate limit` has **zero** stopword hits → Phase-4 fallback **`en` @ confidence 0** (`language-detector.ts` `scoreLatinLanguage`), and the hard `lang = 'en' OR lang IS NONE` filter fires regardless of confidence — excluding the it-stamped facts from every retrieval leg.
- Corroboration: the object-words control query `throttle webhooks requests per minute` surfaced the facts precisely because its own `per` flips the query detection to `it`.
- Live proof: the same search with the DTO's `disableLangFilter: true` escape hatch serves both facts; BM25 additionally can't reach them (`@1@` AND-semantics with entity-context words absent from the predicate+object haystack — known trait, untouched, the vector leg covers it).

**Fix (default-off `MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE`):** the hard exclusion (and its cross-lingual backoff pass) fires only when the query language cleared `LANG_QUERY_HIGH_CONFIDENCE` (0.5) — the same floor the Tier-1 soft boost already trusts. Below it the pass is single and unfiltered: with no evidence of the query's language, excluding facts by language is a recall bug, not a locale feature. Explicit `dto.queryLang` counts as confidence 1 and always filters. Flag off ⇒ byte-identical. The write-side `it`@0.33 stamp itself is documented but deliberately left to the multilingual T0-T5 calibration track; the gate makes the mislabel non-hiding for evidence-free queries. Monolingual tenants (facts `en`/`NONE`) see no behavior change either way.

## Finding 1 / k10 — path + symbol still two entities

**The hypothesized bypassed creation path does not exist — #453 works.** Fresh-tenant repro (co_stev2, current stand app, flags on): the path turn mints ONE entity born with `aliases: [path, "WebhookDispatcher"]` (creation-time seeding, `entity-upsert.service.ts:441`), and the symbol turn reuses it via step-2's `aliases CONTAINS` match — one entity, both facts.

**Actual root cause — battery non-hermeticity on a shared tenant:** knowledge entities are tenant-global; battery facts are per-run user-scoped; the corpus module name was static. Evidence from co_stev4: the twins were created 05:31–05:32Z by run `cm-dogfood-1`, and the stand's code copy only received `code-alias.ts` at 15:00Z (file mtimes) — runs 1–3 ran **pre-#453 code**. Run-4 (15:49Z, flags on, new code) then had each phrasing exact-match its stale twin in step 2 and re-attached its facts to the old split. #453 is creation-time reuse only **by design** (retroactive merge belongs to the dreams dedup), so pre-flag twins poison every later run's measurement forever.

**Fix:** run-scope the dual-phrasing module identity (`moduleIdentity` / `buildTurns` / `buildChecks` take the run id), mirroring the battery's existing per-run conversation namespacing — each run measures its own resolution. The symbol is derived through the real `symbolAliasForPath`, so the corpus can never drift from the resolver's convention; run-scoped k10 `nameTokens` name only this run's module. No runId ⇒ the historical static corpus byte-identical.

**Live proof on a deliberately poisoned tenant** (co_stev2 already holding the unscoped module entity + alias): the run-scoped turns resolved to exactly ONE fresh entity `src/gateway/webhook-dispatcher-k10verif1.ts` with `aliases: [path, WebhookDispatcherK10verif1]`, carrying the dispatch-path `decided` fact AND the cents `invariant`; the k10 scorer shape via `/v1/search` reports 1 named module entity, group1=1, group2=1.

## Verification
- `pnpm typecheck` clean; full unit suite 360/360 suites, 3999 tests green; `pnpm format:check` clean.
- New specs: `test/search-lang-filter-confidence-gate.unit-spec.ts` (gate off byte-identical, floor inclusive, the measured zero-evidence regression pinned against the real detector), `test/code-memory-corpus-hermetic.unit-spec.ts` (back-compat deep-equal, both derivation directions via the real code-alias helpers, turn/check lockstep).
- Live: worktree app booted on :3056 against the stand DB — k07's exact scorer query for `cm-dogfood-4` on the evidence tenant now serves both rate_limit facts (no re-ingest needed); k10 verified as above. The :3033 app and loco-321 were not touched.

To enable at the stand: add `MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE=1` and restart when convenient; the k10 fix needs no flag (next battery run picks up the run-scoped corpus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB