### PR TITLE
fix(eval): k10 measures identity — predicate-agnostic markers + invariant slotting fewshot

### DIFF
--- a/src/ai/domain-packs/code-memory.pack.ts
+++ b/src/ai/domain-packs/code-memory.pack.ts
@@ -11,7 +11,7 @@ import { composePredicateId, type DomainPackManifest } from './manifest';
  */
 export const CODE_MEMORY_PACK: DomainPackManifest = {
   id: 'code_memory',
-  version: '0.4.2',
+  version: '0.4.3',
   description:
     'Non-derivable engineering "why" of a codebase — decisions, rationale, invariants, gotchas, ownership, flag/config defaults, dependency pins, and decision supersession anchored to code, with a domain extraction profile and memory model.',
   // Retro-declaration, documentation-true: code-memory has ALWAYS been an
@@ -97,6 +97,10 @@ ADMIT  text states the current default of a feature flag, env var, or
        "the timeout default is 10000"). Revisioned: a new default
        supersedes the old one; history is retained
 NOT FOR the value a caller passes at one call-site — only the DEFAULT
+NOT FOR prose fragments: the value must be value-shaped — a number,
+       boolean, or enum token of a NAMED flag/config. A sentence
+       fragment describing behaviour ("every duration in milliseconds")
+       is never a default; a unit/behaviour rule belongs in invariant
 VALUE  the default value, verbatim ("0", "1", "10000")`,
       datatype: 'string',
       semantics: 'single_active',
@@ -163,7 +167,14 @@ flag/config (code_memory__default_value), pinned dependency versions
 VERBATIM — "3.2.4" not "the current version", "EXTRACTOR_LITERAL_HARVEST"
 not "the harvest flag". Ownership INVERTS the surface grammar: in
 "NAME owns PATH", the owned module/path is the fact's SUBJECT (a code
-anchor) and the person or team is the VALUE of code_memory__owns.`,
+anchor) and the person or team is the VALUE of code_memory__owns.
+code_memory__default_value takes ONLY value-shaped defaults of a NAMED
+flag/config — a number, boolean, or enum token ("0", "true", "strict");
+NEVER a prose fragment: a sentence fragment describing behaviour ("every
+duration in milliseconds") must never become a default_value. A compound
+invariant — one sentence stating a rule and its negation ("X, never Y")
+— is ONE code_memory__invariant fact carrying BOTH clauses verbatim;
+never split its clauses across facts or predicates.`,
     fewShot: [
       {
         text: 'We decided to resolve all facts through one gateway in src/ingest/fact-resolver.service.ts because 21 positional args drifted between call-sites.',
@@ -194,6 +205,14 @@ anchor) and the person or team is the VALUE of code_memory__owns.`,
       {
         text: 'RateLimiter rejects a burst with 429 before the handler runs; it lives in src/gateway/rate-limiter.ts.',
         note: "the symbol 'RateLimiter' and the path 'src/gateway/rate-limiter.ts' are ONE entity — subject is the canonical path 'src/gateway/rate-limiter.ts' (the symbol is the same module, not a second entity) → code_memory__invariant='rejects a burst with 429 before the handler runs'.",
+      },
+      // 0.4.3: compound-invariant slotting (k10 battery finding, run
+      // cmmtq1z412) — a two-clause "X, never Y" invariant was split and
+      // its value-shaped-looking fragment mis-slotted as a config
+      // default. The rule and its negation are ONE invariant fact.
+      {
+        text: 'PaymentNormalizer in ledger-core stores every duration in milliseconds, never seconds.',
+        note: "a compound invariant stays ONE fact, verbatim with BOTH clauses — subject 'PaymentNormalizer' → code_memory__invariant='stores every duration in milliseconds, never seconds'. Do NOT split the clauses into separate facts, and do NOT slot the fragment 'every duration in milliseconds' as code_memory__default_value — a default is the value token ('0', 'true', 'strict') of a named flag/config, never a prose fragment.",
       },
     ],
   },

--- a/test/code-memory-scorers.unit-spec.ts
+++ b/test/code-memory-scorers.unit-spec.ts
@@ -29,10 +29,11 @@ import {
 } from './eval/code-memory/corpus';
 import {
   checkBuiltinPredicates,
-  checkEntityDedup,
+  checkEntityFactGroups,
   checkNoForbiddenFact,
   checkSupersession,
   checkWhyRoundtrip,
+  resolveModuleEntity,
   type PredicateLike,
   type WhyLike,
 } from './eval/code-memory/scorers';
@@ -119,7 +120,7 @@ describe('code-memory scorers', () => {
     });
   });
 
-  describe('path-vs-symbol entity dedup', () => {
+  describe('path-vs-symbol entity identity (resolve + predicate-agnostic scan)', () => {
     const tokens = ['webhook-dispatcher', 'webhookdispatcher', 'webhook dispatcher'];
     const groups = [
       ['dispatch path', 'outbound webhook'],
@@ -134,38 +135,72 @@ describe('code-memory scorers', () => {
       ],
     };
 
-    it('passes on one entity carrying facts from both phrasings', () => {
-      const v = checkEntityDedup([merged], tokens, groups);
+    it('resolves exactly one named entity', () => {
+      const r = resolveModuleEntity([merged], tokens);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.entity.entityId).toBe('e1');
+    });
+
+    it('STRICT uniqueness: per-phrasing duplication fails resolution and names both entities', () => {
+      const dup: HitLike = { entityId: 'e2', canonicalName: 'WebhookDispatcher', facts: [] };
+      const r = resolveModuleEntity([merged, dup], tokens);
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.fail.detail).toContain('split across 2 entities');
+        expect(r.fail.detail).toContain('WebhookDispatcher');
+      }
+    });
+
+    it('fails resolution when no hit carries a module name token', () => {
+      const r = resolveModuleEntity(
+        [{ entityId: 'e9', canonicalName: 'acme-api', facts: [] }],
+        tokens,
+      );
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.fail.detail).toContain('no hit named');
+    });
+
+    it('passes when the entity carries facts from both phrasings', () => {
+      const v = checkEntityFactGroups(
+        'src/gateway/webhook-dispatcher.ts',
+        merged.facts ?? [],
+        groups,
+      );
       expect(v.pass).toBe(true);
       expect(v.detail).toContain('both phrasings');
     });
 
-    it('fails on per-phrasing duplication and names both entities', () => {
-      const dup: HitLike = { entityId: 'e2', canonicalName: 'WebhookDispatcher', facts: [] };
-      const v = checkEntityDedup([merged, dup], tokens, groups);
-      expect(v.pass).toBe(false);
-      expect(v.detail).toContain('split across 2 entities');
-      expect(v.detail).toContain('WebhookDispatcher');
+    it('PREDICATE-AGNOSTIC: a split, mis-slotted fact still proves identity when attached', () => {
+      // The measured k10 failure (run cmmtq1z412): extraction split the
+      // invariant sentence and slotted its fragment as default_value.
+      // Identity is about ATTACHMENT to the one entity — the scan must
+      // count it under ANY predicate; slot quality is k02–k06 scope.
+      const misSlotted = [
+        { predicate: 'code_memory__decided', object: 'one dispatch path instead of six' },
+        { predicate: 'code_memory__default_value', object: 'every line-item amount in cents' },
+        { predicate: 'code_memory__invariant', object: 'never floats' },
+      ];
+      const v = checkEntityFactGroups('src/gateway/webhook-dispatcher.ts', misSlotted, groups);
+      expect(v.pass).toBe(true);
+      expect(v.detail).toContain('[cents|line-item]=1');
     });
 
-    it("fails when one phrasing's facts are missing from the single entity", () => {
-      const onlyPath: HitLike = {
-        ...merged,
-        facts: [{ factId: 'f1', predicate: 'decided', object: 'one dispatch path instead of six' }],
-      };
-      const v = checkEntityDedup([onlyPath], tokens, groups);
+    it('matches a marker landing in the predicate text, not only the object', () => {
+      // A coined predicate can swallow the marker itself ("cents_convention")
+      // while the object carries none — attachment still proves identity.
+      const inPredicate = [
+        { predicate: 'decided', object: 'one dispatch path instead of six' },
+        { predicate: 'cents_convention', object: 'minor units only' },
+      ];
+      const v = checkEntityFactGroups('m', inPredicate, groups);
+      expect(v.pass).toBe(true);
+    });
+
+    it("fails when one phrasing's facts are missing from the full fact set", () => {
+      const onlyPath = [{ predicate: 'decided', object: 'one dispatch path instead of six' }];
+      const v = checkEntityFactGroups('src/gateway/webhook-dispatcher.ts', onlyPath, groups);
       expect(v.pass).toBe(false);
       expect(v.detail).toContain('[cents|line-item]=0');
-    });
-
-    it('fails when no hit carries a module name token', () => {
-      const v = checkEntityDedup(
-        [{ entityId: 'e9', canonicalName: 'acme-api', facts: [] }],
-        tokens,
-        groups,
-      );
-      expect(v.pass).toBe(false);
-      expect(v.detail).toContain('no hit named');
     });
   });
 

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -447,6 +447,36 @@ describe('code-memory pack', () => {
     ).toBe(true);
   });
 
+  // 0.4.3 (k10 battery finding, run cmmtq1z412): a compound "X, never Y"
+  // invariant was split in two and its value-shaped-looking fragment
+  // mis-slotted as code_memory__default_value. The profile must carry a
+  // dedicated few-shot keeping a two-clause invariant ONE fact, and the
+  // guidance + predicate description must confine default_value to
+  // value-shaped defaults (number/boolean/enum token of a NAMED
+  // flag/config) — never prose fragments.
+  it('0.4.3: compound invariant stays ONE fact; default_value is value-shaped only', () => {
+    const profile = CODE_MEMORY_PACK.extractionProfile;
+    // Guidance: default_value confined to value tokens, compound invariants unsplit.
+    expect(profile?.guidance).toContain('ONLY value-shaped defaults');
+    expect(profile?.guidance).toContain('NEVER a prose fragment');
+    expect(profile?.guidance).toContain('never split its clauses');
+    // A dedicated few-shot shows a two-clause invariant landing as ONE
+    // invariant fact with BOTH clauses verbatim, and forbids routing the
+    // value-shaped-looking fragment into default_value.
+    const compound = (profile?.fewShot ?? []).filter(
+      (ex) =>
+        /, never /.test(ex.text) &&
+        ex.note.includes('code_memory__invariant') &&
+        ex.note.includes('NOT') &&
+        ex.note.includes('code_memory__default_value'),
+    );
+    expect(compound.length).toBeGreaterThanOrEqual(1);
+    // The predicate description itself fences out prose fragments.
+    const defaultValue = CODE_MEMORY_PACK.predicates.find((p) => p.localId === 'default_value');
+    expect(defaultValue?.description).toContain('NOT FOR prose fragments');
+    expect(defaultValue?.description).toContain('value-shaped');
+  });
+
   it('declares the perception contract: three lifecycles, hints, one recency rule', () => {
     const mm = CODE_MEMORY_PACK.memoryModel;
     expect(mm?.stateModels?.map((m) => m.id).sort()).toEqual([

--- a/test/eval/code-memory/README.md
+++ b/test/eval/code-memory/README.md
@@ -59,7 +59,7 @@ are unique to one turn; every `ACME_STRICT_MODE` turn is a voiced plan.
 | k07 | literal-harvest   |           | the ALL_CAPS flag / port / rate limit in coding prose produce no `identifier` / `service_port` / `rate_limit`                                     |
 | k08 | flag-transition   | yes       | no single entity timeline retains introduced-dark → enabled in order (needs the coding-verb lexicon; holder binding routes the flip to the agent) |
 | k09 | supersession-asof |           | re-`decided` leaves TWO active decisions, or the old one is unrecoverable at `asOf`, or `asOf` leaks the future                                   |
-| k10 | cross-entity      |           | the module referenced by path vs symbol splits into two entities                                                                                  |
+| k10 | cross-entity      |           | the module referenced by path vs symbol splits into two entities, or a phrasing's facts never attach to the one module (identity only: the marker scan is predicate-agnostic over ALL the entity's facts — slotting is k02-k06 scope) |
 | k11 | trace-provenance  |           | the decision fact does not unroll to the seeded turn's episode verbatim                                                                           |
 | k12 | serve             | yes       | "current default of ACME_RETRY_QUEUE" serves the stale 0/disabled or abstains — the dogfood north-star                                            |
 | k13 | serve             | yes       | "who owns src/gateway" cannot name Priya (ownership has no typed home until 0.4.0 `owns`)                                                         |
@@ -108,7 +108,13 @@ k14 is the deliberate NEGATIVE twin of k08: it must hold today (no
 coding verbs in the lexicon → nothing to guard) and keep holding after
 the lexicon lands (the 6-token pre-verb guards are then what keeps it
 green). k10 (cross-entity) is un-gated on purpose: a fail there is a
-genuine platform finding, not a known gap.
+genuine platform finding, not a known gap. It measures IDENTITY alone —
+the runner resolves the ONE named entity strictly, then scans ALL facts
+ever recorded onto it (`get_entity_timeline` ∪ the hit's top facts)
+predicate-agnostically, so a clause extraction split or mis-slotted
+still counts as long as it is ATTACHED to the module; which predicate a
+clause lands in is scored by the vocab checks (k02-k06), never
+re-punished here.
 
 ## Running against a local stand
 

--- a/test/eval/code-memory/corpus.ts
+++ b/test/eval/code-memory/corpus.ts
@@ -411,7 +411,10 @@ export function buildChecks(runId = ''): Check[] {
       intent:
         `The module referenced by PATH (${m.path}) and by ` +
         `SYMBOL (${m.symbol}) resolves to ONE entity carrying facts seeded by ` +
-        'both phrasings — no per-phrasing duplication.',
+        'both phrasings — no per-phrasing duplication. Identity ONLY: the marker ' +
+        'scan is predicate-agnostic over ALL facts of the resolved entity, so a ' +
+        'clause extraction split or mis-slotted still counts when it is attached ' +
+        'to the one module (slot quality is k02–k06 scope).',
       searchQuery: 'acme-api webhook dispatcher',
       nameTokens: m.nameTokens,
       mustCarryGroups: [

--- a/test/eval/code-memory/runner.ts
+++ b/test/eval/code-memory/runner.ts
@@ -30,10 +30,12 @@ import { findExactPredicateFact, findNamespacedTools, type HitLike } from '../do
 import { buildChecks, buildTurns, CM, CORPUS_VERTICAL } from './corpus';
 import {
   checkBuiltinPredicates,
-  checkEntityDedup,
+  checkEntityFactGroups,
   checkNoForbiddenFact,
   checkSupersession,
   checkWhyRoundtrip,
+  resolveModuleEntity,
+  type FactText,
   type PredicateLike,
   type WhyLike,
 } from './scorers';
@@ -440,7 +442,41 @@ async function runSupersessionCheck(
 
 async function runCrossEntityCheck(ctx: CheckContext, check: CrossEntityCheck): Promise<Verdict2> {
   const hits = await searchHits(ctx, check.searchQuery, 10);
-  const verdict = checkEntityDedup(hits as HitLike[], check.nameTokens, check.mustCarryGroups);
+  const resolution = resolveModuleEntity(hits as HitLike[], check.nameTokens);
+  if (!resolution.ok) {
+    return { status: 'fail', detail: resolution.fail.detail };
+  }
+  const entity = resolution.entity;
+  // k10 measures IDENTITY — both phrasings' facts attached to the ONE
+  // resolved entity. A search hit carries only query-ranked TOP facts,
+  // which under-samples: a fact extraction split off the invariant
+  // sentence (e.g. slotted as default_value) is attached to the module
+  // yet can rank below the hit's fact cap for the module-name query
+  // (measured: run cmmtq1z412 reported [cents|line-item]=0 while the
+  // fact sat on the entity). So the marker scan runs over ALL facts
+  // ever recorded onto the entity (get_entity_timeline — the full
+  // chronological audit), unioned with the hit's facts. Slot quality
+  // is k02–k06's scope, never re-punished here.
+  const timeline = await callTool<TimelineOut>(ctx.mcp, 'get_entity_timeline', {
+    entityId: entity.entityId,
+    userId: ctx.cfg.userId,
+  });
+  const recorded: FactText[] = (timeline.events ?? [])
+    .filter((e) => e.type === 'fact.recorded')
+    .map((e) => ({ predicate: e.predicate ?? '', object: e.object ?? '' }));
+  const seen = new Set<string>();
+  const allFacts: FactText[] = [];
+  for (const fact of [...recorded, ...(entity.facts ?? [])]) {
+    const key = `${fact.predicate} ${fact.object}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    allFacts.push({ predicate: fact.predicate, object: fact.object });
+  }
+  const verdict = checkEntityFactGroups(
+    entity.canonicalName ?? entity.entityId,
+    allFacts,
+    check.mustCarryGroups,
+  );
   return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail };
 }
 

--- a/test/eval/code-memory/scorers.ts
+++ b/test/eval/code-memory/scorers.ts
@@ -12,7 +12,8 @@
  * findNamespacedTools from test/eval/domain-packs/scorers.ts. This
  * file adds only what the code-memory claims need: the builtin-seed
  * matcher, the forbidden-transition scan (intention guard), the
- * path-vs-symbol entity dedup, and the `why` roundtrip/supersession
+ * path-vs-symbol entity identity pair (resolveModuleEntity +
+ * checkEntityFactGroups), and the `why` roundtrip/supersession
  * verdicts.
  */
 import { containsAnyOf } from '../memory-fitness/scorers';
@@ -97,40 +98,67 @@ export function checkNoForbiddenFact(
   };
 }
 
-// ── path-vs-symbol entity dedup ─────────────────────────────────────
+// ── path-vs-symbol entity identity (two-stage) ──────────────────────
+
+/** The predicate+object text of one fact, however it was slotted. */
+export interface FactText {
+  predicate: string;
+  object: string;
+}
+
+/** Stage-1 outcome: the unique module entity, or the fail verdict. */
+export type ModuleResolution = { ok: true; entity: HitLike } | { ok: false; fail: Verdict };
 
 /**
- * Cross-phrasing entity check:
- *  1. exactly ONE hit's canonicalName matches a module name token
- *     (2+ = the path phrasing and the symbol phrasing split into
- *     separate entities — the failure being measured);
- *  2. that one hit carries ≥1 fact per marker group, each group
- *     seeded by a DIFFERENT phrasing's turn.
- * The detail always carries per-group counts, so a fail is
- * diagnosable from the report alone.
+ * Stage 1 of the cross-phrasing identity check — STRICT entity
+ * uniqueness: exactly ONE hit's canonicalName matches a module name
+ * token. Zero = the module never resolved; 2+ = the path phrasing and
+ * the symbol phrasing split into separate entities — the failure being
+ * measured. The caller then gathers the resolved entity's FULL fact
+ * set (a search hit carries only query-ranked top facts) and scores it
+ * with checkEntityFactGroups.
  */
-export function checkEntityDedup(
+export function resolveModuleEntity(
   hits: readonly HitLike[],
   nameTokens: readonly string[],
-  mustCarryGroups: ReadonlyArray<readonly string[]>,
-): Verdict {
+): ModuleResolution {
   const named = hits.filter((h) => containsAnyOf(h.canonicalName ?? '', nameTokens));
-  if (named.length === 0) {
+  const first = named[0];
+  if (first === undefined) {
     return {
-      pass: false,
-      detail: `no hit named ~[${nameTokens.join('|')}] among ${hits.length} results`,
+      ok: false,
+      fail: {
+        pass: false,
+        detail: `no hit named ~[${nameTokens.join('|')}] among ${hits.length} results`,
+      },
     };
   }
   if (named.length > 1) {
     const names = named.map((h) => `"${h.canonicalName ?? h.entityId}"`).join(', ');
     return {
-      pass: false,
-      detail: `module split across ${named.length} entities: ${names}`,
+      ok: false,
+      fail: { pass: false, detail: `module split across ${named.length} entities: ${names}` },
     };
   }
-  const top = named[0];
-  if (top === undefined) return { pass: false, detail: 'unreachable: no named hit' };
-  const facts = top.facts ?? [];
+  return { ok: true, entity: first };
+}
+
+/**
+ * Stage 2 — the PREDICATE-AGNOSTIC marker scan: the resolved entity
+ * carries ≥1 fact per marker group, each group seeded by a DIFFERENT
+ * phrasing's turn. A fact counts for a group whenever the group's
+ * markers appear in its predicate+object text, WHATEVER predicate
+ * extraction slotted the clause into — a split or mis-slotted fact
+ * that is still attached to the ONE resolved entity proves identity
+ * just as well (slot quality is scored by the vocab checks k02–k06,
+ * never here). The detail always carries per-group counts, so a fail
+ * is diagnosable from the report alone.
+ */
+export function checkEntityFactGroups(
+  entityLabel: string,
+  facts: readonly FactText[],
+  mustCarryGroups: ReadonlyArray<readonly string[]>,
+): Verdict {
   const counts: number[] = mustCarryGroups.map(
     (group) => facts.filter((f) => containsAnyOf(`${f.predicate} ${f.object}`, group)).length,
   );
@@ -138,16 +166,12 @@ export function checkEntityDedup(
   if (counts.every((n) => n > 0)) {
     return {
       pass: true,
-      detail:
-        `one entity "${top.canonicalName ?? top.entityId}" carries both phrasings: ` +
-        `${summary} of ${facts.length} facts`,
+      detail: `one entity "${entityLabel}" carries both phrasings: ${summary} of ${facts.length} facts`,
     };
   }
   return {
     pass: false,
-    detail:
-      `entity "${top.canonicalName ?? top.entityId}" misses a phrasing's facts: ` +
-      `${summary} of ${facts.length} facts`,
+    detail: `entity "${entityLabel}" misses a phrasing's facts: ${summary} of ${facts.length} facts`,
   };
 }
 

--- a/test/eval/code-memory/types.ts
+++ b/test/eval/code-memory/types.ts
@@ -104,14 +104,21 @@ export interface SupersessionCheck extends BaseCheck {
 }
 
 /** `cross-entity` — the module referenced by file path AND by symbol
- *  name resolves to ONE entity carrying facts from both phrasings. */
+ *  name resolves to ONE entity carrying facts from both phrasings.
+ *  Measures IDENTITY only: entity uniqueness is strict, but the marker
+ *  scan is predicate-agnostic over ALL facts of the resolved entity
+ *  (search top-facts ∪ timeline), so a split or mis-slotted fact still
+ *  proves identity as long as it is ATTACHED to the one module — slot
+ *  quality is the vocab checks' (k02–k06) scope, never double-punished
+ *  here. */
 export interface CrossEntityCheck extends BaseCheck {
   kind: 'cross-entity';
   searchQuery: string;
   /** A hit belongs to the module when its canonicalName contains ≥1. */
   nameTokens: string[];
   /** Each group is an anyOf set seeded by a DIFFERENT phrasing's turn;
-   *  the single entity must carry ≥1 fact per group. */
+   *  the single entity must carry ≥1 fact per group, under ANY
+   *  predicate (matched against the fact's predicate+object text). */
   mustCarryGroups: string[][];
 }
 


### PR DESCRIPTION
## What happened (measured, run `cmmtq1z412`, hermetic corpus)

The k10 module identity is **SOLVED**: one entity `src/gateway/webhook-dispatcher-<runId>.ts` exists and carries facts seeded by both the PATH and the SYMBOL phrasing. Yet k10 reported `[cents|line-item]=0 of 1 facts` and failed — because extraction SPLIT the compound invariant sentence *"emits every line-item amount in cents, never floats"* into two facts:

- `code_memory__default_value="every line-item amount in cents"` — a mis-slot (that is not a config default), and
- `code_memory__invariant="never floats"`,

and the k10 marker scan only saw the search hit's **query-ranked top facts**, where the split fact never surfaced. k10 was punishing SLOTTING, not identity — and slotting already has its own k-scope.

## Fix 1 — checker honesty: k10 measures IDENTITY

k10's claim is that both phrasings' facts land on ONE module entity. The scan is now predicate-agnostic across ALL facts of the resolved entity:

- `test/eval/code-memory/scorers.ts`: `checkEntityDedup` split into
  - `resolveModuleEntity` — the STRICT entity-uniqueness stage, semantics unchanged (0 named hits = not resolved; 2+ = the split-twins failure, still a hard fail);
  - `checkEntityFactGroups` — the predicate-agnostic marker scan over a caller-supplied full fact set: a fact counts for a marker group under ANY predicate, because attachment to the one module is what proves identity. A split-but-correctly-attached fact no longer fails the check.
- `test/eval/code-memory/runner.ts`: after strict resolution, k10 gathers ALL facts ever recorded onto the entity (`get_entity_timeline` — the full chronological audit — unioned with the hit's top facts, deduped) instead of trusting the hit's capped fact list.
- `corpus.ts` (k10 intent), `types.ts` (`CrossEntityCheck` doc) and the battery README now state the scope explicitly.

**Slot quality is k-scope elsewhere (k02–k06)**: whether the flag default lands in `code_memory__default_value`, the invariant in `code_memory__invariant`, etc. is exactly what the pack-vocab checks measure. k10 no longer double-punishes slotting.

## Fix 2 — pack content: `code_memory` 0.4.2 → 0.4.3

The mis-slot itself is a real extraction defect, fixed where extraction is steered:

- **New fewShot** (compound-invariant slotting): a two-clause "X, never Y" invariant stays ONE `code_memory__invariant` fact verbatim with BOTH clauses, and the value-shaped-looking fragment must NOT be routed into `code_memory__default_value`. The example mirrors the corpus sentence's shape while staying lexically disjoint from the battery's markers (no cents/line-item/floats), so the injected prompt cannot contaminate the measurement.
- **Sharpened `default_value`** (guidance + predicate description): ONLY value-shaped defaults of a NAMED flag/config — a number, boolean, or enum token ("0", "true", "strict") — never prose fragments; a behaviour/unit rule belongs in `invariant`.

## Tests

- `test/code-memory-scorers.unit-spec.ts`: rewritten onto the two-stage API; the measured mis-slot (`default_value="every line-item amount in cents"` + `invariant="never floats"` on the one entity) is the regression fixture and now passes group 2; strict-uniqueness and missing-phrasing fails are pinned unchanged; plus a marker-in-predicate-text case.
- `test/domain-pack.unit-spec.ts`: 0.4.3 block pins the compound-invariant fewShot and the value-shaped-only `default_value` fencing (same pattern as the 0.4.1/0.4.2 battery-finding tests).
- Gates: `pnpm typecheck` clean, full `pnpm test:unit` 4010/4010 (360 suites), `pnpm format:check` clean. Version-referencing tests interpolate the live manifest (`CODE_MEMORY_PACK.version`) — verified no static pins remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
