### PR TITLE
feat(ingest): confidence-gate the write-side language stamp

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -829,6 +829,19 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Confidence gate on the HARD same-language search exclusion: the `lang = q OR lang IS NONE` WHERE filter (and its cross-lingual backoff pass) fires only when the detected query language cleared the same high-confidence floor the Tier-1 soft boost trusts. Below the floor — including the detector\'s zero-evidence `en` fallback on stopword-less identifier queries like "acme-api webhooks rate limit" — the pass is single and unfiltered, so a fact mislabeled with another language is never hidden from a query that expressed no language at all (the code-memory k07 miss). An explicit dto.queryLang carries confidence 1 and always filters. Off (default) → any non-`und` detection filters, byte-identical.',
   },
+  {
+    key: 'MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE',
+    category: 'pipeline',
+    // Read per-call on the write paths (langStampConfidenceGateEnabled in
+    // the language detector, consumed by fact-resolver buildResolveCall +
+    // derive-row-builder) — never constructor-captured — so a flip takes
+    // effect on the next ingest/derive without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Write-side mirror of MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE (migration 0127): a language DETECTION below the same shared high-confidence floor (0.5) is NOT stamped as the row\'s authoritative `lang` column — the hard same-language search filter\'s input — so a one-stopword mislabel ("120 requests per minute" → it@0.33 off the lone Italian "per", the k07 write-side root) stops polluting facts for every future lang-aware consumer. Applies to live fact ingest (fact-resolver) and derived rows (derive-row-builder). Only `lang` is withheld: the detected script stays, and on the fact-resolver path the attribution metadata records what the detector said (detectedLang + langConfidence + detectorVersion, langSource=detected) even while MULTILINGUAL_LANG_ATTRIBUTION is off — withholding is never silent. Inherited/explicit language paths are untouched (a weak detection does NOT divert to sourceLang inheritance — that stays strictly for detector-`und` objects). Off (default) → any non-`und` detection stamps, byte-identical.',
+  },
   // ── Multilingual (Tier 3, migration 0102) ───────────
   {
     key: 'MULTILINGUAL_ENTITY_REVERSIBLE',

--- a/src/admin/derive-row-builder.ts
+++ b/src/admin/derive-row-builder.ts
@@ -1,5 +1,9 @@
 import { resolveExtractionProfile } from '../ai/extraction-profile';
-import { detectLanguage } from '../ai/locale/language-detector';
+import {
+  detectLanguage,
+  LANG_HIGH_CONFIDENCE,
+  langStampConfidenceGateEnabled,
+} from '../ai/locale/language-detector';
 import { sourceTrustFor } from '../ingest/ingest-utils';
 import { accumulateLanded, type RollupMember } from './aspect-rollups';
 import { typedAtomKind, type DerivedProposition } from './deriver-client';
@@ -29,6 +33,31 @@ function derivedScopeFields(
     ...(lang !== undefined ? { lang } : {}),
     ...(script !== undefined ? { script } : {}),
     ...(userId !== undefined ? { userId } : {}),
+  };
+}
+
+/**
+ * The derived row's language stamp, write-side-gated
+ * (MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE, default off): derived rows
+ * land in knowledge_fact and feed the same hard same-language search
+ * filter as live facts, so a below-floor detection (the k07 shape: one
+ * stray stopword flips a technical proposition to it@0.33) withholds the
+ * authoritative `lang` here too. Only `lang` is withheld — `script`
+ * comes from character classes (certain even when the language guess is
+ * weak) and stays. Unlike the fact-resolver path, no attribution
+ * metadata is recorded: the derived-batch path builds none by design
+ * (resolveDerivedBatch), and the deriver's own detection is reproducible
+ * from the stored proposition text. Off (default) ⇒ byte-identical.
+ */
+function derivedRowLang(proposition: string): { lang?: string; script?: string } {
+  const det = detectLanguage(proposition);
+  const langGated =
+    det.language !== 'und' &&
+    det.confidence < LANG_HIGH_CONFIDENCE &&
+    langStampConfidenceGateEnabled();
+  return {
+    ...(det.language !== 'und' && !langGated ? { lang: det.language } : {}),
+    ...(det.language !== 'und' ? { script: det.script } : {}),
   };
 }
 
@@ -73,9 +102,9 @@ export function buildDerivedRows({
             // "undated"); sessionDate would re-stamp the removed value.
             new Date(0)
           : sessionDate;
-    const det = detectLanguage(p.proposition);
-    const lang = det.language !== 'und' ? det.language : undefined;
-    const script = det.language !== 'und' ? det.script : undefined;
+    // Detected language/script, write-side stamp gate applied — see
+    // derivedRowLang above.
+    const { lang, script } = derivedRowLang(p.proposition);
     // V8 §4: salience rides in `source` (object FLEXIBLE, passed
     // verbatim through fn::resolve_fact's CREATE) — no schema
     // migration, no resolver-arity change; every read leg already

--- a/src/ai/locale/language-detector.ts
+++ b/src/ai/locale/language-detector.ts
@@ -69,6 +69,40 @@ function attributionEnabled(): boolean {
   return envFlagEnabled(process.env.MULTILINGUAL_LANG_ATTRIBUTION);
 }
 
+/**
+ * The ONE high-confidence floor for trusting a detected language, shared
+ * by every confidence-gated language behaviour so "confident detection"
+ * means one thing across the system:
+ *  - read side: the Tier-1 soft same-language boost and the
+ *    MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE hard-exclusion gate
+ *    (search.service) only trust a query language at/above it;
+ *  - write side: MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE withholds the
+ *    authoritative `lang` stamp for a detection below it (fact-resolver +
+ *    derive-row-builder).
+ * Not a tunable knob — the floor is the contract, and the k07 incident
+ * (a fact stamped `it`@0.33 off the lone stopword "per", then hidden
+ * from an `en`@0 zero-evidence query by the hard filter) is exactly what
+ * splitting it per-site would reintroduce.
+ */
+export const LANG_HIGH_CONFIDENCE = 0.5;
+
+/**
+ * Write-side stamp gate (MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE, default
+ * off) — the mirror of the read-side k07 fix. When ON, a language
+ * DETECTION below LANG_HIGH_CONFIDENCE is not stamped as a row's
+ * authoritative `lang` column (the hard same-language search filter's
+ * input), so a one-stopword mislabel ("120 requests per minute" → it@0.33)
+ * stops polluting rows for every future lang-aware consumer. Only the
+ * `lang` column is withheld — the detected script and the attribution
+ * metadata (what the detector said, at what confidence, by which
+ * detector version) are still recorded, and inherited/explicit language
+ * paths are untouched. Read per-call (the MULTILINGUAL_ ingest-side
+ * idiom — never constructor-captured) so a flip lands without restart.
+ */
+export function langStampConfidenceGateEnabled(): boolean {
+  return envFlagEnabled(process.env.MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE);
+}
+
 // Top-30 stopwords per Latin-script language. Ordered by frequency so
 // short inputs still have a fighting chance. Lowercase only — the
 // tokeniser canonicalises before lookup.

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1339,6 +1339,15 @@ const KNOWN_BOOLEAN_FLAGS = [
   // code-memory k07 miss). Default off ⇒ any non-`und` detection filters,
   // byte-identical. MULTILINGUAL_ family, off the ENGINE flag budget.
   'MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE',
+  // Multilingual Tier 1. Write-side mirror of the hard-filter gate
+  // (migration 0127): a detection below the same shared high-confidence
+  // floor is not stamped as the row's authoritative `lang` (fact-resolver +
+  // derive-row-builder); the detected script and — on the resolver path —
+  // the attribution metadata (detectedLang/langConfidence/detectorVersion)
+  // are still recorded, and inherited/explicit language paths are
+  // untouched. Default off ⇒ any non-`und` detection stamps,
+  // byte-identical. MULTILINGUAL_ family, off the ENGINE flag budget.
+  'MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE',
   // Multilingual Tier 3 (migration 0102). Reversible entity resolution: a
   // weak embedding-only inline-resolution match is NOT auto-merged — it
   // becomes a reviewable entity_merge_log candidate — and every strong

--- a/src/db/migrations/0127_lang_stamp_detected_lang.surql
+++ b/src/db/migrations/0127_lang_stamp_detected_lang.surql
@@ -1,0 +1,21 @@
+-- 0127: write-side language-stamp confidence gate — the withheld label.
+--
+-- WHY. MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE (the write-side mirror of
+-- the 0126-era read fix for the code-memory k07 miss) withholds the
+-- authoritative `lang` column when the detector's confidence sits below
+-- the shared high-confidence floor — the "120 requests per minute" →
+-- it@0.33 mislabel stops polluting rows that every future lang-aware
+-- consumer inherits. Withholding must never be silent: the attribution
+-- stamp (0100) keeps the confidence + detector version, and THIS column
+-- keeps the label itself, so the row still says exactly what the
+-- detector claimed while `lang` stays NONE (= never hard-filtered).
+--
+-- ADDITIVE + OPTIONAL by construction (the 0100 posture): option<...>,
+-- no backfill, nothing writes it unless the gate withholds a detection.
+-- Gate off (default) ⇒ the column is never written — byte-identical.
+
+-- The below-floor detected label the stamp gate kept out of `lang`.
+-- NONE on every ungated row (an ungated detection lives in `lang`
+-- itself; duplicating it here would change the gate-off stamp).
+DEFINE FIELD IF NOT EXISTS detectedLang ON knowledge_fact TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 2;

--- a/src/ingest/episode-store.service.ts
+++ b/src/ingest/episode-store.service.ts
@@ -61,6 +61,12 @@ export class EpisodeStoreService {
         dto.knownEntities?.find((k) => k.role === role);
       const nameOf = (k?: KnownEntity): string | undefined =>
         k ? (k.name ?? `${k.vertical}:${k.id}`) : undefined;
+      // Deliberately NOT behind MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE:
+      // episode.lang is descriptive metadata only — no read surface hard-
+      // filters on it (the gate exists for knowledge_fact.lang, the input
+      // of the search WHERE exclusion), and a full dialogue turn is the
+      // detector's best-case input, not the short-object failure mode.
+      // Revisit if an episode read path ever grows a lang filter.
       const lang = detectLanguage(rawText).language;
       const row = {
         kind: 'turn',

--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -5,7 +5,11 @@ import { scopeForUser } from '../auth/scope-tags';
 import { MetricsService } from '../metrics/metrics.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
 import { DEFAULT_FALLBACK } from '../ai/predicate-registry-internals/types';
-import { detectLanguage } from '../ai/locale/language-detector';
+import {
+  detectLanguage,
+  LANG_HIGH_CONFIDENCE,
+  langStampConfidenceGateEnabled,
+} from '../ai/locale/language-detector';
 import { envFlagEnabled } from '../common/env-validation';
 import {
   conflictDirectFactSlotEnabled,
@@ -197,6 +201,14 @@ interface LangAttributionMeta {
   detectorVersion: string;
   /** Language of the SOURCE turn (distinct from the object's `lang`). */
   sourceLang?: string | undefined;
+  /**
+   * The label the detector produced when the write-side stamp gate
+   * (MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE) withheld it from the
+   * authoritative `lang` column (migration 0127). Set ONLY on gated rows
+   * — an ungated detection lives in `lang` itself, so duplicating it
+   * here would change the gate-off stamp (the byte-identical pin).
+   */
+  detectedLang?: string | undefined;
 }
 
 /**
@@ -421,18 +433,48 @@ export class FactResolverService {
     // inherit the source-turn language onto an undetectable object.
     const attribution = envFlagEnabled(process.env.MULTILINGUAL_LANG_ATTRIBUTION);
     const detLang = detectLanguage(p.object, attribution);
-    let lang: string | undefined = detLang.language !== 'und' ? detLang.language : undefined;
+    const detectedLang: string | undefined =
+      detLang.language !== 'und' ? detLang.language : undefined;
+    // Write-side stamp gate (MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE,
+    // default off) — the mirror of the read-side k07 fix: a detection
+    // below the SAME shared floor the query-side gate trusts is not
+    // stamped as the row's authoritative `lang` (the hard same-language
+    // search filter's input), so "120 requests per minute" → it@0.33 no
+    // longer poisons the row for every future lang-aware consumer. ONLY
+    // the low-confidence 'detected' branch changes: the detected script
+    // and the attribution metadata (incl. detectedLang, 0127) are still
+    // recorded, and a weak detection is NOT license to inherit — the
+    // inherited path stays strictly for detector-`und` objects (which
+    // carry no language signal of their own; a weak detection carries a
+    // weak one, and re-stamping sourceLang over it would trade one guess
+    // for another). Off (default) ⇒ stampGated is always false and every
+    // branch below is byte-identical.
+    const stampGated =
+      detectedLang !== undefined &&
+      detLang.confidence < LANG_HIGH_CONFIDENCE &&
+      langStampConfidenceGateEnabled();
+    let lang: string | undefined = stampGated ? undefined : detectedLang;
     // Script is only ever the detected script — an inherited lang leaves it
-    // NONE (the source turn's script isn't carried on the fact input).
-    const script: string | undefined = detLang.language !== 'und' ? detLang.script : undefined;
+    // NONE (the source turn's script isn't carried on the fact input). The
+    // stamp gate keeps it: script comes from character classes, which are
+    // certain even when the language guess is weak.
+    const script: string | undefined = detectedLang !== undefined ? detLang.script : undefined;
     let langMeta: LangAttributionMeta | undefined;
-    if (attribution) {
-      if (lang) {
+    // The gate never withholds silently: a gated row records what the
+    // detector said (detectedLang + confidence + detectorVersion) even
+    // when attribution is off — withholding an authoritative column while
+    // also dropping the evidence for the decision would be dishonest
+    // telemetry.
+    if (attribution || stampGated) {
+      if (lang !== undefined || stampGated) {
         langMeta = {
           langConfidence: detLang.confidence,
           langSource: 'detected',
           detectorVersion: detLang.detectorVersion,
           sourceLang: p.sourceLang,
+          // Below-floor detection: the withheld label rides in the
+          // attribution metadata (migration 0127) instead of `lang`.
+          ...(stampGated ? { detectedLang } : {}),
         };
       } else if (p.sourceLang) {
         // Undetectable object (short / stopword-less / numeric): inherit
@@ -456,9 +498,13 @@ export class FactResolverService {
           sourceLang: undefined,
         };
       }
+    }
+    if (attribution) {
       // Behaviour-neutral distribution telemetry (surface = 'fact').
+      // A gated row reports the DETECTED language — what the detector
+      // said, not the withheld column — so the distribution stays honest.
       this.metrics?.recordLangAttribution({
-        lang: lang ?? 'und',
+        lang: lang ?? detectedLang ?? 'und',
         source: 'fact',
         confidence: detLang.confidence,
         detectorVersion: detLang.detectorVersion,
@@ -631,12 +677,14 @@ export class FactResolverService {
    * Multilingual Tier 1 (0100): stamp confidence-aware attribution metadata
    * onto the created fact rows via a follow-up UPDATE — the stampFactScope
    * idiom, kept OUT of fn::resolve_fact so the resolver's pinned invariants
-   * are untouched. Only rows whose langMeta is set (attribution on) are
-   * touched, so with the flag off this is a no-op and ingest is
-   * byte-identical. Best-effort: a stamp failure WARNs and never fails the
-   * ingest (the `lang` column proper is already set by the resolver; these
-   * are supplementary provenance fields). `sourceLang` is written only when
-   * known — omitted, not NULLed, matching the omit-when-undefined idiom.
+   * are untouched. Only rows whose langMeta is set (attribution on, or a
+   * write-side stamp-gate withhold — see buildResolveCall) are touched, so
+   * with both flags off this is a no-op and ingest is byte-identical.
+   * Best-effort: a stamp failure WARNs and never fails the ingest (the
+   * `lang` column proper is already set by the resolver; these are
+   * supplementary provenance fields). `sourceLang` / `detectedLang` are
+   * written only when known — omitted, not NULLed, matching the
+   * omit-when-undefined idiom.
    */
   private async stampLangAttribution(
     db: {
@@ -666,6 +714,12 @@ export class FactResolverService {
         if (meta.sourceLang !== undefined) {
           sets.push('sourceLang = $sourceLang');
           params.sourceLang = meta.sourceLang;
+        }
+        // Stamp-gated rows only (MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE,
+        // 0127): the below-floor label the gate kept out of `lang`.
+        if (meta.detectedLang !== undefined) {
+          sets.push('detectedLang = $detectedLang');
+          params.detectedLang = meta.detectedLang;
         }
         await db.query(`UPDATE $id SET ${sets.join(', ')}`, params);
       }

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -2,7 +2,11 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Surreal } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { PredicateRegistryService } from '../ai/predicate-registry.service';
-import { detectLanguage, DETECTOR_VERSION } from '../ai/locale/language-detector';
+import {
+  detectLanguage,
+  DETECTOR_VERSION,
+  LANG_HIGH_CONFIDENCE,
+} from '../ai/locale/language-detector';
 import { MetricsService } from '../metrics/metrics.service';
 import { SearchDto, SearchMode } from './dto/search.dto';
 import { withSpan } from '../common/tracing';
@@ -85,12 +89,15 @@ interface StagedPipeline {
  * is trusted enough to tilt ranking toward same-language facts; below it
  * the boost is withheld (no exclusion either — soft mode never filters).
  * An explicit dto.queryLang is treated as confidence 1, so it always
- * clears the floor. Module-private (not a tunable knob in Tier 1).
+ * clears the floor. Not a tunable knob in Tier 1.
  * MULTILINGUAL_LANG_FILTER_CONFIDENCE_GATE reuses the SAME floor for the
- * hard exclusion (hardLangFilterFor below), so "confident query language"
- * means one thing across both read-side language behaviours.
+ * hard exclusion (hardLangFilterFor below), and the write-side stamp gate
+ * (MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE, fact-resolver) reuses it too,
+ * so "confident detection" means one thing across every language
+ * behaviour — hence the shared LANG_HIGH_CONFIDENCE constant, which lives
+ * with the detector.
  */
-const LANG_QUERY_HIGH_CONFIDENCE = 0.5;
+const LANG_QUERY_HIGH_CONFIDENCE = LANG_HIGH_CONFIDENCE;
 
 /**
  * The hard same-language WHERE exclusion's language, confidence-gated

--- a/test/ingest-lang-stamp-confidence-gate.unit-spec.ts
+++ b/test/ingest-lang-stamp-confidence-gate.unit-spec.ts
@@ -1,0 +1,306 @@
+/**
+ * MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE — confidence gate on the
+ * WRITE-side language stamp (fact-resolver buildResolveCall +
+ * derive-row-builder), the mirror of the read-side k07 fix (#456).
+ *
+ * Measured root being closed: at write time the detector labeled the
+ * object "120 requests per minute" `it` off the lone Italian stopword
+ * "per" (confidence 0.33) and the row was stamped `lang: 'it'` — the
+ * hard `lang = 'en' OR lang IS NONE` search filter then hid it from
+ * English queries, and ANY future lang-aware consumer inherits the same
+ * mislabel. #456 gated the read side; this gates the stamp itself.
+ *
+ * Gate ON ⇒ a DETECTION below the shared high-confidence floor (the same
+ * LANG_HIGH_CONFIDENCE = 0.5 the query-side gate and the Tier-1 soft
+ * boost trust) stamps `lang` NONE while the attribution metadata keeps
+ * what the detector said (detectedLang + langConfidence +
+ * detectorVersion — withholding is never silent). Only the authoritative
+ * `lang` column is withheld: the detected script stays, and the
+ * inherited-language path (sourceLang onto a detector-`und` object) is
+ * untouched — a WEAK detection does not divert to inheritance.
+ * Gate OFF (default) ⇒ any non-`und` detection stamps, byte-identical.
+ */
+import {
+  detectLanguage,
+  DETECTOR_VERSION,
+  LANG_HIGH_CONFIDENCE,
+  langStampConfidenceGateEnabled,
+} from '../src/ai/locale/language-detector';
+import { buildDerivedRows } from '../src/admin/derive-row-builder';
+import { FactResolverService } from '../src/ingest/fact-resolver.service';
+import { MetricsService } from '../src/metrics/metrics.service';
+import type { EpisodeRow } from '../src/episodes/session-window';
+import type { DerivedProposition } from '../src/admin/deriver-client';
+
+const GATE = 'MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE';
+const ATTR = 'MULTILINGUAL_LANG_ATTRIBUTION';
+
+// The measured k07 write-side shape: one Italian stopword, weak evidence.
+const LOW_CONF_OBJECT = '120 requests per minute';
+// en@0.5 — sits exactly ON the floor (inclusive: still stamped).
+const FLOOR_OBJECT = 'The cat sat on the mat';
+
+async function withEnv(
+  pairs: Record<string, string | undefined>,
+  fn: () => void | Promise<void>,
+): Promise<void> {
+  const saved = new Map(Object.keys(pairs).map((k) => [k, process.env[k]]));
+  for (const [k, v] of Object.entries(pairs)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+// ── The shared floor and the flag read ─────────────────────────────────
+
+describe('the shared confidence floor', () => {
+  it('is the one 0.5 floor the read-side gate already trusts', () => {
+    expect(LANG_HIGH_CONFIDENCE).toBe(0.5);
+  });
+
+  it('langStampConfidenceGateEnabled defaults off; env flag flips it (per-call)', async () => {
+    await withEnv({ [GATE]: undefined }, () => {
+      expect(langStampConfidenceGateEnabled()).toBe(false);
+    });
+    await withEnv({ [GATE]: '1' }, () => {
+      expect(langStampConfidenceGateEnabled()).toBe(true);
+    });
+    await withEnv({ [GATE]: '0' }, () => {
+      expect(langStampConfidenceGateEnabled()).toBe(false);
+    });
+  });
+
+  it('the k07 fixture really is a below-floor detection', () => {
+    const det = detectLanguage(LOW_CONF_OBJECT, false);
+    expect(det.language).toBe('it');
+    expect(det.confidence).toBeLessThan(LANG_HIGH_CONFIDENCE);
+  });
+});
+
+// ── Fact resolver (live ingest path) ───────────────────────────────────
+
+describe('FactResolverService — write-side stamp gate', () => {
+  function make(metrics?: MetricsService) {
+    const queries: Array<{ sql: string; params: Record<string, unknown> }> = [];
+    const db = {
+      query: jest.fn(async (sql: string, params: Record<string, unknown>) => {
+        queries.push({ sql, params });
+        if (sql.includes('fn::resolve_fact(')) {
+          return [{ factId: 'knowledge_fact:x1', outcome: 'INSERTED' }];
+        }
+        return [];
+      }),
+    };
+    const factEmbedding = { embed: jest.fn(async () => [0.1]) };
+    const predicateRegistry = {
+      getSnapshot: jest.fn(async () => ({})),
+      policyFor: jest.fn(() => ({ semantics: 'append_only' })),
+    };
+    const svc = new FactResolverService(
+      factEmbedding as never,
+      predicateRegistry as never,
+      metrics,
+    );
+    return { svc, db, queries };
+  }
+
+  const input = (object: string, sourceLang?: string) => ({
+    companyId: 'c',
+    entityId: 'knowledge_entity:e1',
+    predicate: 'rate_limit',
+    object,
+    ...(sourceLang ? { sourceLang } : {}),
+    confidence: 0.9,
+    validFrom: new Date('2026-01-01T00:00:00Z'),
+    source: {},
+    precomputedEmbedding: [0.1],
+  });
+
+  const factCall = (qs: Array<{ sql: string; params: Record<string, unknown> }>) =>
+    qs.find((q) => q.sql.includes('fn::resolve_fact('));
+  const stampCall = (qs: Array<{ sql: string; params: Record<string, unknown> }>) =>
+    qs.find((q) => q.sql.includes('langSource ='));
+
+  it('gate OFF (pin) → the below-floor detection stamps lang as today, no detectedLang', async () => {
+    await withEnv({ [GATE]: undefined, [ATTR]: '1' }, async () => {
+      const { svc, db, queries } = make();
+      await svc.resolve(db as never, input(LOW_CONF_OBJECT));
+      expect(factCall(queries)!.params.lang).toBe('it');
+      expect(factCall(queries)!.params.script).toBe('Latn');
+      const stamp = stampCall(queries)!;
+      expect(stamp.params.langSource).toBe('detected');
+      expect(stamp.sql).not.toContain('detectedLang');
+      expect('detectedLang' in stamp.params).toBe(false);
+    });
+  });
+
+  it('gate OFF + attribution OFF (pin) → Phase-4 stamp, no attribution UPDATE at all', async () => {
+    await withEnv({ [GATE]: undefined, [ATTR]: undefined }, async () => {
+      const { svc, db, queries } = make();
+      await svc.resolve(db as never, input(LOW_CONF_OBJECT));
+      expect(factCall(queries)!.params.lang).toBe('it');
+      expect(stampCall(queries)).toBeUndefined();
+    });
+  });
+
+  it('gate ON → below-floor detection stamps lang NONE, keeps script + full langMeta', async () => {
+    await withEnv({ [GATE]: '1', [ATTR]: '1' }, async () => {
+      const { svc, db, queries } = make();
+      await svc.resolve(db as never, input(LOW_CONF_OBJECT));
+      const call = factCall(queries)!;
+      // Only the authoritative lang column is withheld …
+      expect(call.params.lang).toBeUndefined();
+      // … the detected script stays (character classes are certain even
+      // when the language guess is weak) …
+      expect(call.params.script).toBe('Latn');
+      // … and the metadata stays honest about what the detector said.
+      const stamp = stampCall(queries)!;
+      expect(stamp.params.langSource).toBe('detected');
+      expect(stamp.params.detectedLang).toBe('it');
+      expect(stamp.params.langConfidence).toBeCloseTo(1 / 3, 6);
+      expect(stamp.params.detectorVersion).toBe(DETECTOR_VERSION);
+    });
+  });
+
+  it('gate ON → an at/above-floor detection is stamped exactly as today (floor inclusive)', async () => {
+    await withEnv({ [GATE]: '1', [ATTR]: '1' }, async () => {
+      const { svc, db, queries } = make();
+      await svc.resolve(db as never, input(FLOOR_OBJECT));
+      expect(factCall(queries)!.params.lang).toBe('en');
+      const stamp = stampCall(queries)!;
+      expect(stamp.params.langSource).toBe('detected');
+      expect('detectedLang' in stamp.params).toBe(false);
+    });
+  });
+
+  it('gate ON → the inheritance branch (detector-`und` + sourceLang) is untouched', async () => {
+    await withEnv({ [GATE]: '1', [ATTR]: '1' }, async () => {
+      const { svc, db, queries } = make();
+      await svc.resolve(db as never, input('OK', 'ru'));
+      expect(factCall(queries)!.params.lang).toBe('ru');
+      const stamp = stampCall(queries)!;
+      expect(stamp.params.langSource).toBe('inherited');
+      expect(stamp.params.sourceLang).toBe('ru');
+      expect('detectedLang' in stamp.params).toBe(false);
+    });
+  });
+
+  it('gate ON → a WEAK detection with a sourceLang does NOT divert to inheritance', async () => {
+    await withEnv({ [GATE]: '1', [ATTR]: '1' }, async () => {
+      const { svc, db, queries } = make();
+      await svc.resolve(db as never, input(LOW_CONF_OBJECT, 'ru'));
+      // Withheld, not replaced by the source-turn language — the object
+      // DID carry (weak) signal of its own; re-stamping sourceLang over
+      // it would trade one guess for another.
+      expect(factCall(queries)!.params.lang).toBeUndefined();
+      const stamp = stampCall(queries)!;
+      expect(stamp.params.langSource).toBe('detected');
+      expect(stamp.params.detectedLang).toBe('it');
+      expect(stamp.params.sourceLang).toBe('ru');
+    });
+  });
+
+  it('gate ON + attribution OFF → withholding is never silent (meta still stamped)', async () => {
+    await withEnv({ [GATE]: '1', [ATTR]: undefined }, async () => {
+      const { svc, db, queries } = make();
+      await svc.resolve(db as never, input(LOW_CONF_OBJECT));
+      expect(factCall(queries)!.params.lang).toBeUndefined();
+      const stamp = stampCall(queries)!;
+      expect(stamp.params.langSource).toBe('detected');
+      expect(stamp.params.detectedLang).toBe('it');
+    });
+  });
+
+  it('gate ON + attribution ON → telemetry reports the DETECTED language, not the withheld column', async () => {
+    await withEnv({ [GATE]: '1', [ATTR]: '1' }, async () => {
+      const metrics = new MetricsService();
+      const { svc, db } = make(metrics);
+      await svc.resolve(db as never, input(LOW_CONF_OBJECT));
+      const { body } = await metrics.serialize();
+      expect(body).toMatch(
+        new RegExp(
+          `brain_lang_attribution_total\\{lang="it",source="fact",detectorVersion="${DETECTOR_VERSION}"\\} 1`,
+        ),
+      );
+    });
+  });
+
+  it('gate ON + attribution OFF → an above-floor detection stays byte-identical (no meta)', async () => {
+    await withEnv({ [GATE]: '1', [ATTR]: undefined }, async () => {
+      const { svc, db, queries } = make();
+      await svc.resolve(db as never, input(FLOOR_OBJECT));
+      expect(factCall(queries)!.params.lang).toBe('en');
+      expect(stampCall(queries)).toBeUndefined();
+    });
+  });
+});
+
+// ── Derive row builder (derived-world facts) ───────────────────────────
+
+describe('buildDerivedRows — write-side stamp gate', () => {
+  const SESSION: EpisodeRow[] = [
+    {
+      id: 'episode:t0',
+      speaker: 'Alice',
+      text: 'a turn',
+      occurredAt: '2026-08-01T10:00:00Z',
+    },
+  ] as EpisodeRow[];
+
+  function build(proposition: string) {
+    return buildDerivedRows({
+      resolved: [
+        {
+          p: {
+            subject: 'Alice',
+            aspect: 'work',
+            proposition,
+            occurred_on: null,
+            turns: [0],
+          } as DerivedProposition,
+          entityId: 'knowledge_entity:alice',
+        },
+      ],
+      vectors: [[1, 0]],
+      sessionDate: new Date('2026-08-01T00:00:00Z'),
+      session: SESSION,
+      ns: { final: 'wd-t', staging: 'wd-t.staging' } as never,
+      conversationId: 'conv-1',
+    });
+  }
+
+  it('gate OFF (pin) → the below-floor detection stamps lang as today', async () => {
+    await withEnv({ [GATE]: undefined }, () => {
+      const row = build(LOW_CONF_OBJECT)[0]!;
+      expect(row.lang).toBe('it');
+      expect(row.script).toBe('Latn');
+    });
+  });
+
+  it('gate ON → below-floor detection withholds lang, keeps script', async () => {
+    await withEnv({ [GATE]: '1' }, () => {
+      const row = build(LOW_CONF_OBJECT)[0]!;
+      expect(row.lang).toBeUndefined();
+      expect(row.script).toBe('Latn');
+    });
+  });
+
+  it('gate ON → an at/above-floor detection is stamped as today', async () => {
+    await withEnv({ [GATE]: '1' }, () => {
+      expect(build(FLOOR_OBJECT)[0]!.lang).toBe('en');
+      // Non-Latin scripts detect at block-fraction confidence — far above
+      // the floor — so real cross-lingual rows keep their stamp.
+      const ru = build('Мария работает директором в Акме.')[0]!;
+      expect(ru.lang).toBe('ru');
+      expect(ru.script).toBe('Cyrl');
+    });
+  });
+});


### PR DESCRIPTION
## What

**MULTILINGUAL_LANG_STAMP_CONFIDENCE_GATE** (new, default off, MULTILINGUAL_ family — verified off the ENGINE flag budget regex): the write-side mirror of #456's read fix. When on, a language **detection** below the shared 0.5 high-confidence floor stamps `lang` **NONE** instead of polluting the row with a one-stopword mislabel (`detectLanguage("120 requests per minute")` → `it`@0.33 off the lone Italian "per" — the k07 write-side root).

## Why

#456 gated the READ side (a zero-evidence query language no longer hard-filters), but the row still carried `lang:'it'` — every future lang-aware consumer inherits the mislabel. This closes the source.

## How

- **One shared floor.** `LANG_HIGH_CONFIDENCE = 0.5` extracted to `src/ai/locale/language-detector.ts`; `search.service.ts` now consumes it instead of its own `0.5` literal (`LANG_QUERY_HIGH_CONFIDENCE` aliases it), so "confident detection" means one thing read- and write-side.
- **Only `lang` is withheld.** The detected script stays (character classes are certain even when the language guess is weak). The attribution metadata keeps what the detector said: a new `detectedLang` column (migration **0127**, additive `option<string>`) beside the 0100 `langConfidence`/`langSource`/`detectorVersion` stamp — written even while `MULTILINGUAL_LANG_ATTRIBUTION` is off, so withholding is never silent. Fact-surface telemetry reports the DETECTED language on gated rows.
- **Inheritance untouched.** `sourceLang` inheritance stays strictly for detector-`und` objects; a weak detection does NOT divert to inheritance.
- **Env read** per the family's ingest-side convention: per-call `envFlagEnabled(process.env.…)` via `langStampConfidenceGateEnabled()` in the language detector (never constructor-captured; S5.2 boundary untouched).

## Stamp sites (gated vs left alone)

Gated — both feed the hard `lang = $q OR lang IS NONE` search exclusion over `knowledge_fact`:
- `src/ingest/fact-resolver.service.ts` `buildResolveCall` (live ingest: direct + mention, per-fact and batched paths share the seam);
- `src/admin/derive-row-builder.ts` (derived-world rows; no attribution meta there by design — `resolveDerivedBatch` builds none, and the detection is reproducible from the stored proposition text).

Left alone, deliberately:
- `src/ingest/episode-store.service.ts` — `episode.lang` is descriptive metadata; no read surface hard-filters on it, and a full dialogue turn is the detector's best-case input (documented at the stamp site);
- `src/ingest/event-time.ts`, `src/search/search.service.ts`, `src/synthesize/*` — locale-rule selection and query-side reads, not row stamps.

## Bookkeeping

- config-catalog entry (runtime-mutable, truthfully — per-call read);
- `KNOWN_BOOLEAN_FLAGS` entry in env-validation;
- migration `0127_lang_stamp_detected_lang.surql` (additive, no backfill, gate-off ⇒ never written).

## Tests

New `test/ingest-lang-stamp-confidence-gate.unit-spec.ts` (15 tests): flag off ⇒ byte-identical stamps (pin, both sites); low-confidence detection ⇒ `lang` NONE + script kept + full langMeta incl. `detectedLang`; floor inclusive (en@0.5 still stamps); inheritance branch untouched; weak-detection-with-sourceLang does not divert to inheritance; gate-on/attribution-off still records the withheld label; honest-telemetry metric.

`pnpm typecheck` ✓ · full unit suite 361 suites / 4021 tests ✓ · `pnpm format:check` ✓ · eslint on touched files ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB