### PR TITLE
fix(extractor): deterministic flag-default harvest - k08 flag-transition was an LLM-redraw lottery

### DIFF
--- a/src/ai/domain-packs/code-memory.pack.ts
+++ b/src/ai/domain-packs/code-memory.pack.ts
@@ -356,6 +356,21 @@ export function codeMemoryPredicateId(kind: CodeMemoryKind): string {
 /** The set of namespaced code-memory predicate ids (for filtering reads). */
 export const CODE_MEMORY_PREDICATE_IDS: string[] = CODE_MEMORY_KINDS.map(codeMemoryPredicateId);
 
+/**
+ * Namespaced id of the flag/config default slot
+ * (`code_memory__default_value`), exported for the literal-harvest
+ * flag-default rule. The deterministic producer MUST emit the SAME
+ * predicate id the extraction profile teaches the LLM: two different
+ * ids for one slot would defeat the (entity, predicate, object) dedup
+ * between the lanes and split the single_active revision history
+ * across two predicates. Guarded by a unit test against manifest
+ * drift (the localId leaving the pack).
+ */
+export const CODE_MEMORY_DEFAULT_VALUE_PREDICATE = composePredicateId(
+  CODE_MEMORY_PACK.id,
+  'default_value',
+);
+
 /** Strip the pack prefix from a namespaced id → the local kind (for display). */
 export function codeMemoryKindOf(predicateId: string): string {
   const prefix = `${CODE_MEMORY_PACK.id}__`;

--- a/src/ai/extractor-internals/literal-harvest.ts
+++ b/src/ai/extractor-internals/literal-harvest.ts
@@ -1,5 +1,6 @@
 import type { ExtractedEntity, ExtractedFact } from './types';
 import { normalizeForGrounding } from './grounding';
+import { CODE_MEMORY_DEFAULT_VALUE_PREDICATE } from '../domain-packs/code-memory.pack';
 
 /**
  * Deterministic literal-harvest lane (EXTRACTOR_LITERAL_HARVEST,
@@ -73,8 +74,14 @@ const NAMING_PREFIX_TOKEN = /\b([A-Z][A-Z0-9]{1,15}_)\b/g;
  */
 const NAMING_PREFIX_CUE = /\b(?:prefix(?:ed)?|convention|naming|named)\b/i;
 
-/** `LSYNC_REPLAY_ENABLED` — an ALL_CAPS underscore identifier. */
-const ALL_CAPS_IDENTIFIER = /\b([A-Z][A-Z0-9]{2,}_[A-Z0-9_]{2,})\b/g;
+/** `LSYNC_REPLAY_ENABLED` — an ALL_CAPS underscore identifier. One
+ *  source, two compilations: the global rule scan below and the
+ *  per-sentence subject probe of the flag-default rule (a fresh
+ *  non-global instance so the probe can never perturb the global
+ *  regex's lastIndex mid-scan). */
+const ALL_CAPS_IDENTIFIER_SOURCE = String.raw`\b([A-Z][A-Z0-9]{2,}_[A-Z0-9_]{2,})\b`;
+const ALL_CAPS_IDENTIFIER = new RegExp(ALL_CAPS_IDENTIFIER_SOURCE, 'g');
+const ALL_CAPS_SUBJECT_PROBE = new RegExp(ALL_CAPS_IDENTIFIER_SOURCE);
 
 /**
  * `LSYNC.payouts.*` — a dotted subject / glob. The terminator is a
@@ -110,6 +117,78 @@ const CAMEL_ASSIGN_AFTER = /^\s*=/;
 
 /** camelCase cue B: the immediately preceding word is an idiom verb/noun. */
 const CAMEL_CUE_BEFORE = /\b(?:carries|uses|set|key)\s*[:=]?\s*$/i;
+
+/**
+ * Clause boundary shared by the deterministic lanes: comma, semicolon,
+ * colon, sentence punctuation, em/en dash, a SPACED ascii dash (an
+ * intra-word hyphen as in "ledger-sync" must not split), and the
+ * subordinators. Moved here from state-verb-harvest (which imports it
+ * back) so the dependency direction stays state-verb → literal; the
+ * flag-default guard below clips its pre-window with the SAME boundary
+ * the sibling lane's guards use.
+ */
+export const CLAUSE_BOUNDARY_SOURCE = String.raw`[,;:.!?—–]|\s--?\s|\s(?:because|when|so|but)\s`;
+const FLAG_DEFAULT_CLAUSE_BOUNDARY = new RegExp(CLAUSE_BOUNDARY_SOURCE, 'gi');
+
+/**
+ * `default stays 0` / `default is now 1` / `defaults to 0` — an
+ * explicit flag/config DEFAULT assertion (k08 code-memory battery
+ * finding — additions only, every existing rule untouched). The
+ * measured lottery: the flag story's two stages had NO deterministic
+ * producer — the state-verb lane binds "we enabled FLAG" to a person
+ * or the speaker (absent on agent-recorded turns, so the match drops),
+ * and the LLM redraw sometimes lands the stage as a `decided`
+ * paraphrase and sometimes as the typed default only. This rule makes
+ * the TYPED emission deterministic: verb forms are present-state only
+ * ("defaulted to" — a historical default — never matches by
+ * construction) and the captured value must be value-shaped (a number
+ * or an on/off/true/false/enabled/disabled state word), so "the
+ * default is the same as prod" harvests nothing.
+ */
+const FLAG_DEFAULT =
+  /\bdefaults?\s+(?:is\s+(?:now\s+)?|stays?\s+(?:at\s+)?|remains?\s+(?:at\s+)?|becomes?\s+|to\s+|at\s+)(\d[\w.-]*|true|false|on|off|enabled|disabled|null|none)\b/gi;
+
+/**
+ * Pre-cue guard for the flag-default rule: negation, hypotheticals,
+ * futures, intentions and conditionals within the 6 tokens before the
+ * match (clipped to the match's own clause) mean the asserted default
+ * is NOT the current one — "we should probably default to 1" and
+ * "if the default stays 0" must not write the typed slot. Same failure
+ * direction as the state lane's guards: over-guarding costs a missing
+ * fact, never a wrong one.
+ */
+const FLAG_DEFAULT_GUARD =
+  /\b(?:not|never|no longer|won't|wouldn't|shouldn't|should|will|would|might|may|could|plan to|planning to|considering|thinking about|thinking of|want to|wants to|hoping to|going to|about to|used to|previously|formerly|intend|intends|propose[ds]?|if|unless|whether|assuming|suppose)\b/i;
+
+/** Guard window: tokens inspected before the match (same clause). */
+const FLAG_DEFAULT_GUARD_WINDOW_TOKENS = 6;
+
+/**
+ * True when the guard window before the flag-default match carries a
+ * guard term — the state lane's guardedBefore idiom (clause-clipped
+ * window, typographic apostrophes folded) applied to this rule's own
+ * term list.
+ */
+function flagDefaultGuardedBefore(
+  input: string,
+  sentenceStart: number,
+  matchStart: number,
+): boolean {
+  const pre = input.slice(sentenceStart, matchStart);
+  let clauseFrom = 0;
+  for (const b of pre.matchAll(FLAG_DEFAULT_CLAUSE_BOUNDARY)) {
+    clauseFrom = b.index + b[0].length;
+  }
+  const window = pre
+    .slice(clauseFrom)
+    .replace(/’/g, "'")
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+    .slice(-FLAG_DEFAULT_GUARD_WINDOW_TOKENS)
+    .join(' ');
+  return window.length > 0 && FLAG_DEFAULT_GUARD.test(window);
+}
 
 /**
  * Duration-limit pattern (`30s delay`, `15 minutes`, `30 days`) —
@@ -200,6 +279,15 @@ interface HarvestMatch {
   valueSpan: string;
   /** Match start offset — drives sentence/clause attribution. */
   index: number;
+  /**
+   * Subject-directed binding (flag-default rule only): the fact is
+   * ABOUT this identifier token, never about whichever entity happens
+   * to lead the sentence. Binding resolves the token against the
+   * entity list (minting it on the no-entity path) and DROPS the match
+   * when it cannot — a flag default bound to the project or the
+   * speaker would be a wrong fact, not a weaker one.
+   */
+  subjectToken?: string;
 }
 
 /** The predicates whose match token IS the subject (identifier-class). */
@@ -320,6 +408,30 @@ function collectMatches(input: string, sentences: SentenceSpan[]): HarvestMatch[
     if (!followedByAssign && !precededByCue) continue;
     out.push({ predicate: 'identifier', object: m[0], valueSpan: m[0], index: m.index });
   }
+  for (const m of input.matchAll(FLAG_DEFAULT)) {
+    const sentence = sentenceAt(sentences, m.index);
+    // Cue: an ALL_CAPS identifier must co-occur in the SAME sentence —
+    // a flag default is a fact about the FLAG; a prose default with no
+    // identifier subject ("the timeout default is 10000") stays with
+    // the LLM path. A fresh non-global probe, so the global identifier
+    // rule's iteration state is never perturbed.
+    const subject = ALL_CAPS_SUBJECT_PROBE.exec(sentence.text)?.[1];
+    if (subject === undefined) continue;
+    if (flagDefaultGuardedBefore(input, sentence.start, m.index)) continue;
+    // The namespaced pack predicate ON PURPOSE (not a coined bare
+    // `default_value`): the builtin code_memory extraction profile
+    // already teaches the LLM this exact id, so only the SAME id lets
+    // the (entity, predicate, object) dedup collapse the two producers
+    // into one fact and keeps the slot's single_active revision
+    // history on one predicate.
+    out.push({
+      predicate: CODE_MEMORY_DEFAULT_VALUE_PREDICATE,
+      object: m[1] as string,
+      valueSpan: m[0],
+      index: m.index,
+      subjectToken: subject,
+    });
+  }
   // NOTE: DURATION_LIMIT_PATTERN is deliberately NOT collected — see
   // its doc comment. The rule ships dark until measured.
 
@@ -379,14 +491,34 @@ export function harvestLiterals(args: HarvestLiteralsArgs): ExtractedFact[] {
   for (const m of collectMatches(trimmed, sentences)) {
     if (harvested.length >= LITERAL_HARVEST_CAP) break;
     const sentence = sentenceAt(sentences, m.index);
-    // Minting runs the same priority bindEntity encodes — a sentence-
-    // grounded subject beats the speaker — so the speaker fallback is
-    // withheld from the first pass and re-applied only after minting
-    // found no subject shape in the sentence.
-    let entityIndex = bindEntity(entities, sentence.text, mintSubjects ? null : speakerEntityIndex);
-    if (entityIndex === null && mintSubjects) {
-      const token = IDENTIFIER_CLASS.has(m.predicate) ? m.object : firstSubjectToken(sentence.text);
-      entityIndex = token !== null ? resolveOrMintSubject(entities, token) : speakerEntityIndex;
+    // Subject-directed matches (flag-default rule) bind to the match's
+    // own identifier token: resolve it against the working list, mint
+    // it on the no-entity path, and otherwise drop the match honestly
+    // (see HarvestMatch.subjectToken).
+    let entityIndex: number | null;
+    if (m.subjectToken !== undefined) {
+      const normalizedSubject = normalizeForGrounding(m.subjectToken);
+      const existing = entities.findIndex(
+        (e) => normalizeForGrounding(e.name) === normalizedSubject,
+      );
+      entityIndex =
+        existing !== -1
+          ? existing
+          : mintSubjects
+            ? resolveOrMintSubject(entities, m.subjectToken)
+            : null;
+    } else {
+      // Minting runs the same priority bindEntity encodes — a sentence-
+      // grounded subject beats the speaker — so the speaker fallback is
+      // withheld from the first pass and re-applied only after minting
+      // found no subject shape in the sentence.
+      entityIndex = bindEntity(entities, sentence.text, mintSubjects ? null : speakerEntityIndex);
+      if (entityIndex === null && mintSubjects) {
+        const token = IDENTIFIER_CLASS.has(m.predicate)
+          ? m.object
+          : firstSubjectToken(sentence.text);
+        entityIndex = token !== null ? resolveOrMintSubject(entities, token) : speakerEntityIndex;
+      }
     }
     if (entityIndex === null) continue;
     const key = `${entityIndex}\u0000${m.predicate}\u0000${normalizeForGrounding(m.object)}`;

--- a/src/ai/extractor-internals/literal-harvest.ts
+++ b/src/ai/extractor-internals/literal-harvest.ts
@@ -478,6 +478,37 @@ export interface HarvestLiteralsArgs {
  * skipped. Returns ONLY the new facts, capped at LITERAL_HARVEST_CAP,
  * for the caller to union.
  */
+/**
+ * Entity binding for one harvest match — pulled out of harvestLiterals
+ * verbatim (cognitive-complexity gate). Subject-directed matches
+ * (flag-default rule) bind to the match's own identifier token: resolve
+ * it against the working list, mint it on the no-entity path, and
+ * otherwise drop the match honestly (see HarvestMatch.subjectToken).
+ * Undirected matches run bindEntity's priority — a sentence-grounded
+ * subject beats the speaker — so the speaker fallback is withheld from
+ * the first pass and re-applied only after minting found no subject
+ * shape in the sentence.
+ */
+function bindHarvestSubject(args: {
+  m: HarvestMatch;
+  sentenceText: string;
+  entities: HarvestLiteralsArgs['entities'];
+  speakerEntityIndex: number | null;
+  mintSubjects: boolean;
+}): number | null {
+  const { m, sentenceText, entities, speakerEntityIndex, mintSubjects } = args;
+  if (m.subjectToken !== undefined) {
+    const normalizedSubject = normalizeForGrounding(m.subjectToken);
+    const existing = entities.findIndex((e) => normalizeForGrounding(e.name) === normalizedSubject);
+    if (existing !== -1) return existing;
+    return mintSubjects ? resolveOrMintSubject(entities, m.subjectToken) : null;
+  }
+  const bound = bindEntity(entities, sentenceText, mintSubjects ? null : speakerEntityIndex);
+  if (bound !== null || !mintSubjects) return bound;
+  const token = IDENTIFIER_CLASS.has(m.predicate) ? m.object : firstSubjectToken(sentenceText);
+  return token !== null ? resolveOrMintSubject(entities, token) : speakerEntityIndex;
+}
+
 export function harvestLiterals(args: HarvestLiteralsArgs): ExtractedFact[] {
   const { trimmed, entities, speakerEntityIndex, existingFacts = [], mintSubjects = false } = args;
   if (!trimmed || (entities.length === 0 && !mintSubjects)) return [];
@@ -491,35 +522,13 @@ export function harvestLiterals(args: HarvestLiteralsArgs): ExtractedFact[] {
   for (const m of collectMatches(trimmed, sentences)) {
     if (harvested.length >= LITERAL_HARVEST_CAP) break;
     const sentence = sentenceAt(sentences, m.index);
-    // Subject-directed matches (flag-default rule) bind to the match's
-    // own identifier token: resolve it against the working list, mint
-    // it on the no-entity path, and otherwise drop the match honestly
-    // (see HarvestMatch.subjectToken).
-    let entityIndex: number | null;
-    if (m.subjectToken !== undefined) {
-      const normalizedSubject = normalizeForGrounding(m.subjectToken);
-      const existing = entities.findIndex(
-        (e) => normalizeForGrounding(e.name) === normalizedSubject,
-      );
-      entityIndex =
-        existing !== -1
-          ? existing
-          : mintSubjects
-            ? resolveOrMintSubject(entities, m.subjectToken)
-            : null;
-    } else {
-      // Minting runs the same priority bindEntity encodes — a sentence-
-      // grounded subject beats the speaker — so the speaker fallback is
-      // withheld from the first pass and re-applied only after minting
-      // found no subject shape in the sentence.
-      entityIndex = bindEntity(entities, sentence.text, mintSubjects ? null : speakerEntityIndex);
-      if (entityIndex === null && mintSubjects) {
-        const token = IDENTIFIER_CLASS.has(m.predicate)
-          ? m.object
-          : firstSubjectToken(sentence.text);
-        entityIndex = token !== null ? resolveOrMintSubject(entities, token) : speakerEntityIndex;
-      }
-    }
+    const entityIndex = bindHarvestSubject({
+      m,
+      sentenceText: sentence.text,
+      entities,
+      speakerEntityIndex,
+      mintSubjects,
+    });
     if (entityIndex === null) continue;
     const key = `${entityIndex}\u0000${m.predicate}\u0000${normalizeForGrounding(m.object)}`;
     if (seen.has(key)) continue;

--- a/src/ai/extractor-internals/state-verb-harvest.ts
+++ b/src/ai/extractor-internals/state-verb-harvest.ts
@@ -1,6 +1,6 @@
 import type { ExtractedEntity, ExtractedFact } from './types';
 import { normalizeForGrounding } from './grounding';
-import { sentenceAt, sentenceSpans } from './literal-harvest';
+import { CLAUSE_BOUNDARY_SOURCE, sentenceAt, sentenceSpans } from './literal-harvest';
 
 /**
  * Deterministic state-verb harvest lane (EXTRACTOR_STATE_VERB_HARVEST)
@@ -161,9 +161,10 @@ const TRANSITION_VERB = new RegExp(`\\b(?:${ALL_VERBS.join('|')})\\b`, 'gi');
  * "ledger-sync" must not split), and the subordinators. The colon is a
  * deliberate addition to the design's boundary list — the corpus's own
  * replace turn pivots on one ("I replaced my laptop today: …") and an
- * unbounded capture would drag the next clause into the span.
+ * unbounded capture would drag the next clause into the span. The
+ * source string lives in literal-harvest (shared with its flag-default
+ * guard) so the two lanes clip clauses identically.
  */
-const CLAUSE_BOUNDARY_SOURCE = String.raw`[,;:.!?—–]|\s--?\s|\s(?:because|when|so|but)\s`;
 /** Global form — backward scan for the LAST boundary before the verb. */
 const CLAUSE_BOUNDARY_ALL = new RegExp(CLAUSE_BOUNDARY_SOURCE, 'gi');
 /** Non-global form — forward search for the FIRST boundary after it. */

--- a/test/eval/code-memory/corpus.ts
+++ b/test/eval/code-memory/corpus.ts
@@ -98,13 +98,16 @@ export const PROFILE_GAP =
   'lands and extraction consults it.';
 
 /** Gap annotation for the flag-transition history check. */
-export const LEXICON_GAP =
-  'The state-verb lexicon gains coding transition verbs ("enabled", "merged", ' +
-  '"reverted", …) in a parallel PR, and EXTRACTOR_STATE_VERB_HARVEST must be ' +
-  'ON at the stand; even then, holder binding routes "we enabled FLAG" to the ' +
-  'AGENT entity rather than the flag entity (known lexicon-lane limitation), ' +
-  'so both stages landing on ONE timeline is unmeasured. A fail is the ' +
-  'recorded gap; a pass is the signal the transition story closed.';
+export const FLAG_TRANSITION_GAP =
+  'Diagnosed 2026-09 (k08 lottery): the state-verb lane binds "we enabled ' +
+  'FLAG" to a person-or-speaker holder — absent on agent-recorded turns, so ' +
+  'the match DROPS — and the LLM redraw sometimes lands a stage as a decided ' +
+  'paraphrase carrying the prose markers and sometimes as the typed ' +
+  'code_memory__default_value only. The stages therefore accept BOTH surface ' +
+  'forms; the deterministic producer of the typed form is the literal-harvest ' +
+  'flag-default rule, so EXTRACTOR_LITERAL_HARVEST must be ON at the stand ' +
+  'for the check to hold every run. A fail with the lane off is the recorded ' +
+  'gap; a fail with it on is a regression.';
 
 /** Real (today) namespaced ids — drift-guarded. */
 export const CM = {
@@ -378,13 +381,19 @@ export function buildChecks(runId = ''): Check[] {
       cls: 'transition',
       intent:
         'ONE entity timeline retains the flag story in order: introduced dark ' +
-        '(ships disabled, default 0) then enabled (default 1).',
+        '(ships disabled, default 0) then enabled (default 1). Each stage ' +
+        'accepts the verbatim prose form (an LLM decided/state paraphrase) OR ' +
+        'the typed form — the predicate+object surface of the single_active ' +
+        'code_memory__default_value slot the pack doctrine routes flag ' +
+        "defaults into (matched against the timeline event's " +
+        '"predicate object" string, so "default_value 0" hits the typed ' +
+        'fact and never a corpus turn).',
       searchQuery: 'ACME_RETRY_QUEUE flag default',
       stages: [
-        ['ships disabled', 'default stays 0'],
-        ['enabled ACME_RETRY_QUEUE', 'default is now 1'],
+        ['ships disabled', 'default stays 0', 'default_value 0'],
+        ['enabled ACME_RETRY_QUEUE', 'default is now 1', 'default_value 1'],
       ],
-      expectedUnknown: LEXICON_GAP,
+      expectedUnknown: FLAG_TRANSITION_GAP,
     },
 
     // ── supersession, mechanically (MCP write path) ───────────────────

--- a/test/literal-harvest.unit-spec.ts
+++ b/test/literal-harvest.unit-spec.ts
@@ -14,6 +14,12 @@ import {
 import { isGroundedSpan, normalizeForGrounding } from '../src/ai/extractor-internals/grounding';
 import type { ExtractedEntity, ExtractedFact } from '../src/ai/extractor-internals/types';
 import { ExtractorRunnerService } from '../src/ai/extractor-runner.service';
+import {
+  CODE_MEMORY_DEFAULT_VALUE_PREDICATE,
+  CODE_MEMORY_PACK,
+} from '../src/ai/domain-packs/code-memory.pack';
+import { buildChecks } from './eval/code-memory/corpus';
+import { checkHistorySequence } from './eval/state-transitions/scorers';
 
 const ent = (name: string, type: ExtractedEntity['type'] = 'project'): ExtractedEntity => ({
   name,
@@ -165,6 +171,172 @@ describe('harvestLiterals — k07 rate-limit phrasing table (code-memory battery
   it('negative: rpm stays out even with a cue (revolutions ambiguity)', () => {
     const facts = harvest('We throttle the acme-api fans at 1200 rpm.', [ent('acme-api')], null);
     expect(facts).toEqual([]);
+  });
+});
+
+describe('harvestLiterals — k08 flag-default rule (code-memory battery)', () => {
+  // VERBATIM corpus turns from test/eval/code-memory/corpus.ts (the k08
+  // flag-transition stages). Diagnosed lottery (2026-09, 6-attempt
+  // controlled repro on the dogfood stand): the two stages had NO
+  // deterministic producer — the state-verb lane drops "we enabled
+  // FLAG" when no person/speaker holder exists (agent-recorded turns),
+  // and the LLM redraw only sometimes parrots the prose markers into a
+  // decided fact. This rule pins the TYPED emission.
+  const FLAG_T1 =
+    'We introduced the ACME_RETRY_QUEUE flag in acme-api; it ships disabled and its ' +
+    'default stays 0 until the queue is proven.';
+  const FLAG_T2 =
+    'We enabled ACME_RETRY_QUEUE in prod today; its default is now 1 for every acme-api tenant.';
+  const flagEntities = (): ExtractedEntity[] => [ent('ACME_RETRY_QUEUE', 'other'), ent('acme-api')];
+
+  it('derives the namespaced predicate from the live builtin manifest', () => {
+    expect(CODE_MEMORY_DEFAULT_VALUE_PREDICATE).toBe('code_memory__default_value');
+    expect(CODE_MEMORY_PACK.predicates.some((p) => p.localId === 'default_value')).toBe(true);
+  });
+
+  it('corpus stage 1: "default stays 0" → default_value "0" ON the flag entity', () => {
+    const facts = harvest(FLAG_T1, flagEntities(), null);
+    const dv = byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE);
+    expect(dv).toHaveLength(1);
+    expect(dv[0]!.object).toBe('0');
+    expect(dv[0]!.valueSpan).toBe('default stays 0');
+    // Subject-directed binding: the flag, never the leading project.
+    expect(dv[0]!.entityIndex).toBe(0);
+    // The identifier rule still fires; nothing else does.
+    expect(byPredicate(facts, 'identifier').map((f) => f.object)).toEqual(['ACME_RETRY_QUEUE']);
+    expect(facts).toHaveLength(2);
+  });
+
+  it('corpus stage 2: "default is now 1" → default_value "1" ON the flag entity', () => {
+    const facts = harvest(FLAG_T2, flagEntities(), null);
+    const dv = byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE);
+    expect(dv).toHaveLength(1);
+    expect(dv[0]!.object).toBe('1');
+    expect(dv[0]!.valueSpan).toBe('default is now 1');
+    expect(dv[0]!.entityIndex).toBe(0);
+  });
+
+  it('LOCKSTEP: the harvested pair satisfies the k08 stage sequence on one timeline', () => {
+    const k08 = buildChecks().find((c) => c.id === 'k08-flag-transition');
+    if (k08?.kind !== 'flag-transition') throw new Error('k08 shape changed');
+    const events = [
+      ...harvest(FLAG_T1, flagEntities(), null).map((f) => ({
+        predicate: f.predicate,
+        object: f.object,
+        at: '2026-09-01T15:00:00Z',
+      })),
+      ...harvest(FLAG_T2, flagEntities(), null).map((f) => ({
+        predicate: f.predicate,
+        object: f.object,
+        at: '2026-09-01T15:20:00Z',
+      })),
+    ];
+    const verdict = checkHistorySequence(events, k08.stages);
+    expect(verdict.pass).toBe(true);
+  });
+
+  it('held-out: the pack few-shot phrasing "defaults to 0" harvests the typed slot', () => {
+    const facts = harvest(
+      'EXTRACTOR_LITERAL_HARVEST defaults to 0 in production.',
+      [ent('EXTRACTOR_LITERAL_HARVEST', 'other')],
+      null,
+    );
+    const dv = byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE);
+    expect(dv.map((f) => f.object)).toEqual(['0']);
+  });
+
+  it('held-out: state-word value "remains off"', () => {
+    const facts = harvest(
+      'The FOO_BAR_MODE default remains off for now.',
+      [ent('FOO_BAR_MODE', 'other')],
+      null,
+    );
+    expect(byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE).map((f) => f.object)).toEqual([
+      'off',
+    ]);
+  });
+
+  it('negative: no ALL_CAPS identifier in the sentence → the prose default stays out', () => {
+    const facts = harvest('The timeout default is 10000 in acme-api.', [ent('acme-api')], null);
+    expect(byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE)).toEqual([]);
+  });
+
+  it('negative: hypothetical is guarded ("should … default at 1")', () => {
+    const facts = harvest(
+      'We should probably keep the ACME_STRICT_MODE default at 1 next quarter.',
+      [ent('ACME_STRICT_MODE', 'other')],
+      null,
+    );
+    expect(byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE)).toEqual([]);
+  });
+
+  it('negative: conditional is guarded ("If the … default stays 0")', () => {
+    const facts = harvest(
+      'If the ACME_RETRY_QUEUE default stays 0, we bail out of the rollout.',
+      [ent('ACME_RETRY_QUEUE', 'other')],
+      null,
+    );
+    expect(byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE)).toEqual([]);
+  });
+
+  it('negative: historical "defaulted to 0" never matches by construction', () => {
+    const facts = harvest(
+      'The ACME_RETRY_QUEUE flag defaulted to 0 last year.',
+      [ent('ACME_RETRY_QUEUE', 'other')],
+      null,
+    );
+    expect(byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE)).toEqual([]);
+  });
+
+  it('negative: a non-value object stays out ("default is the same as prod")', () => {
+    const facts = harvest(
+      'The ACME_RETRY_QUEUE default is the same as prod.',
+      [ent('ACME_RETRY_QUEUE', 'other')],
+      null,
+    );
+    expect(byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE)).toEqual([]);
+  });
+
+  it('dedup: an LLM-emitted default_value on the flag suppresses the harvest twin', () => {
+    const existing: ExtractedFact[] = [
+      {
+        entityIndex: 0,
+        predicate: CODE_MEMORY_DEFAULT_VALUE_PREDICATE,
+        object: '0',
+        confidence: 0.9,
+        valueSpan: '0',
+      },
+    ];
+    const facts = harvest(FLAG_T1, flagEntities(), null, existing);
+    expect(byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE)).toEqual([]);
+  });
+
+  it('honest drop: identifier absent from the entity list and minting off → no default fact', () => {
+    const facts = harvest(FLAG_T1, [ent('acme-api')], null);
+    expect(byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE)).toEqual([]);
+  });
+
+  it('mint path: a no-entity turn mints the flag and binds the default to it', () => {
+    const entities: ExtractedEntity[] = [];
+    const facts = harvestLiterals({
+      trimmed: FLAG_T1,
+      entities,
+      speakerEntityIndex: null,
+      mintSubjects: true,
+    });
+    const dv = byPredicate(facts, CODE_MEMORY_DEFAULT_VALUE_PREDICATE);
+    expect(dv).toHaveLength(1);
+    expect(entities[dv[0]!.entityIndex]).toEqual({ name: 'ACME_RETRY_QUEUE', type: 'other' });
+  });
+
+  it('every flag-default valueSpan passes the grounding gate by construction', () => {
+    for (const text of [FLAG_T1, FLAG_T2]) {
+      for (const f of harvest(text, flagEntities(), null)) {
+        expect(
+          isGroundedSpan(normalizeForGrounding(text), normalizeForGrounding(f.valueSpan!)),
+        ).toBe(true);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## The lottery, measured

k08 (flag-transition: `ACME_RETRY_QUEUE` timeline must retain *introduced dark → enabled* in order) passed 2/5 battery runs on the stand. A controlled repro — only the two flag turns, 6 fresh userIds per round, facts read straight from the scratch SurrealDB — tabulated what every attempt actually produced:

| attempt (pre-fix, :3033) | T1 facts on `ACME_RETRY_QUEUE` | T2 facts on `ACME_RETRY_QUEUE` | k08 stage1 | k08 stage2 |
|---|---|---|---|---|
| 1–6 (identical) | `identifier`, `code_memory__default_value="0"`, `code_memory__decided="ships disabled"` | `code_memory__default_value="1"` ×2, `identifier` | hit via `decided="ships disabled"` | **MISS** — no fact carries "enabled ACME_RETRY_QUEUE" / "default is now 1" |

A fresh boot rolled a NEW LLM draw: `decided="disabled"` instead of `"ships disabled"` — the run-5-style stage-1 miss, live. The redraw trigger between battery runs is the extraction cache key: open-vocab coinage bumps the predicate-vocab hash, invalidating the (text, tenant, vocab) entry, so each battery run redraws the LLM.

## Root cause

**Neither k08 stage had a deterministic producer; the check could only see LLM prose parroting.**

- Hypothesis (d) confirmed, harsher than predicted: the state-verb lane's `bindStateHolder` wants a person-or-speaker holder; the battery ingests with `knownEntities: []`, so "we enabled ACME_RETRY_QUEUE" produces **nothing** (not even an agent-bound fact).
- Hypothesis (a) confirmed: every draw lands the **typed** story — `code_memory__default_value` `0 → 1` on the flag entity, exactly the slot the pack doctrine mandates — but the k08 markers matched corpus prose only, so the check missed the very facts that told the story. Whether a draw *also* parrots "ships disabled" / "enabled ACME_RETRY_QUEUE…" into a `decided` fact is the lottery.
- Hypotheses (b)/(c) refuted: no zero-fact turns, no entity variants — everything lands on ONE `ACME_RETRY_QUEUE` entity.

## Fix (both halves honest)

**Harvest side** — `literal-harvest` gains a cue-gated `FLAG_DEFAULT` rule under the lane's existing `EXTRACTOR_LITERAL_HARVEST` flag (additions only, default off, no new ENGINE flag — same precedent as the k07 `RATE_LIMIT_CUED` addition):

- fires only when an explicit default assertion (`default stays 0`, `default is now 1`, `defaults to 0`, `remains off`, …) co-occurs with an ALL_CAPS identifier in the same sentence;
- present-state verb forms only (`defaulted to` never matches), value-shaped captures only (`is the same as prod` never matches), clause-clipped pre-cue guard for negation/hypotheticals/conditionals (`should … default at 1`, `if the … default stays 0` harvest nothing);
- **subject-directed binding**: the fact binds to the identifier entity (minted on the no-entity path), and drops honestly when it can't — a flag default bound to the project or speaker would be a wrong fact, not a weaker one.

**Namespacing** — the rule deliberately emits the pack-namespaced `code_memory__default_value` (sourced from the pack module, drift-guarded by unit test), not a bare coined `default_value`: the builtin code_memory extraction profile already teaches the LLM this exact id, so only the same id lets the `(entity, predicate, object)` dedup collapse the two producers into one fact and keeps the slot's `single_active` revision history on one predicate. A bare twin would have split the slot across two ids and double-served defaults.

**Check side** — k08's stages now additionally accept the typed surface (`default_value 0` / `default_value 1`, matched against the timeline event's `"predicate object"` string — a form that occurs in no corpus turn, so the scoreability invariants hold; the "never restates the OLD value" spec still passes). The gap annotation (`FLAG_TRANSITION_GAP`) now records the diagnosed mechanics: with the lane off a fail is the recorded gap, with it on a fail is a regression. A unit **lockstep test** pins that the harvested pair from the two verbatim corpus turns satisfies the k08 stage sequence.

The clause-boundary regex source moves to `literal-harvest` (state-verb imports it back — dependency direction unchanged) so both lanes clip guard windows identically; behavior-neutral.

## Live verification (worktree boot on :3058, dogfood env, :3033/loco-321 untouched)

- Controlled repro, 5/5 fresh userIds: both stages retained in order on the `ACME_RETRY_QUEUE` timeline every attempt (`default_value="0" → default_value="1"`), including a draw whose `decided` fact would have missed the old prose markers.
- Full `pnpm eval:code-memory` against :3058: **k08 pass** — `entity ACME_RETRY_QUEUE: history retains all 2 stages in order`. Two full runs, k08 passed in both.
- Honest residuals, out of scope and pre-existing: k10 cross-entity failed identically in both runs (symbol-phrasing fact not on the path entity — the alias-resolution seam, no `default` cue involved); k12 serve failed in one of two runs on answer wording ("stays 0" quoted while narrating the history) — gap-gated finding by design.

Gates: `pnpm typecheck` ✓, full `pnpm test:unit` (360 suites / 4021 tests) ✓, `pnpm format:check` ✓, flag-budget golden untouched (no new flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
