### PR TITLE
feat(eval): variation axis for the state-transitions battery — paraphrase and RU corpora

### DIFF
--- a/src/ai/extractor-internals/state-verb-harvest.ts
+++ b/src/ai/extractor-internals/state-verb-harvest.ts
@@ -141,6 +141,16 @@ const ALL_VERBS = [...ACQUIRE_VERBS, ...DISPOSE_VERBS, ...CHANGE_VERBS, ...CODIN
   (a, b) => b.length - a.length,
 );
 
+/**
+ * The full lexicon, exported READ-ONLY for the state-transition
+ * battery's paraphrase-variant honesty pin (test/state-transition-
+ * corpus.unit-spec.ts): the paraphrase corpus exists to measure what
+ * the transition CLASSIFIER catches when this lexicon sees nothing, so
+ * the unit test asserts no paraphrase turn contains any of these verbs
+ * — against the real list, not a drifting copy.
+ */
+export const STATE_VERB_LEXICON: readonly string[] = ALL_VERBS;
+
 /** Word-boundary-matched, case-insensitive alternation over the lexicon. */
 const TRANSITION_VERB = new RegExp(`\\b(?:${ALL_VERBS.join('|')})\\b`, 'gi');
 

--- a/test/eval/state-transitions/README.md
+++ b/test/eval/state-transitions/README.md
@@ -56,6 +56,44 @@ serving cost.
 Score = per-scenario pass (ALL of its checks pass) plus a per-check-kind
 tally; the scorecard groups scenarios by class.
 
+## Variation axis (`STEV_VARIANT`)
+
+The corpus has three phrasings of the SAME 12 scenarios — same
+conversations, same turn counts, same timestamps, same checks
+(`variants.ts`, unit-pinned in `test/state-transition-corpus.unit-spec.ts`):
+
+- **`default`** — the original corpus, byte-identical (the builder
+  returns the `SCENARIOS` array itself).
+- **`paraphrase`** — same facts phrased WITHOUT any verb of the
+  deterministic state-verb lexicon (`EXTRACTOR_STATE_VERB_HARVEST`;
+  pinned against the exported `STATE_VERB_LEXICON`): "parted with the
+  Kawasaki" for sold, "walked away from the chess club" for quit,
+  "sent the standing desk back" for returned. Only the transition
+  classifier lane (`EXTRACTOR_TRANSITION_CLASSIFIER`: morphology +
+  BGE-M3 prototypes) and the LLM extractor can catch these transitions.
+- **`ru`** — faithful Russian phrasings («продал», «вернул»,
+  «вступил», «записался», …; person names go Cyrillic, brand names
+  stay Latin the way Russian text writes them), exercising the RU
+  prototype path of the classifier and the RU candidate matcher's
+  sentence-scoped guards — including the documented deliberate-miss
+  class («Я продал Kawasaki сегодня; байка больше нет.» is ONE guarded
+  span, because the RU guard is sentence-scoped and `sentenceSpans`
+  splits only before Latin uppercase).
+
+Check expectations stay the same across variants: nothing is removed,
+marker lists only gain language/phrasing alternates a correct answer
+would legitimately echo (a served «вернул» is as correct as
+'returned'), and provenance fragments are re-authored to quote the
+variant's own turns verbatim. The honest framing: **variants measure
+extraction ROBUSTNESS across phrasings and languages, not pass/fail
+parity** — a paraphrase or RU run scoring below default is a
+measurement of where the classifier/LLM lanes go blind, not a battery
+regression, and the deltas between the three scorecards are the
+deliverable.
+
+Use a fresh run (fresh salted user) per variant; comparing variants on
+one tenant is fine because runs are user-scoped and hermetic.
+
 ## Expected fails on today's code (the baseline IS the point)
 
 Three checks are **expected to fail** on current `main` (default flags)
@@ -122,10 +160,12 @@ BRAIN_COMPANY_ID=<fresh tenant id> \
 pnpm eval:state-transitions
 ```
 
-Optional env: `STEV_USER_ID` (default `stev-agent`), `STEV_RUN_ID`
-(defaults to a fresh id), `STEV_GUARDRAILS` (`strict` | `lenient` |
-`off`, default `strict`), `STEV_SKIP_INGEST=1` (re-ask an
-already-ingested run; pass the same `STEV_RUN_ID`), `STEV_REPORT_DIR`
+Optional env: `STEV_VARIANT` (`default` | `paraphrase` | `ru`, default
+`default` — see the variation axis above), `STEV_USER_ID` (default
+`stev-agent-<runId>`, run-salted per #457), `STEV_RUN_ID` (defaults to
+a fresh id), `STEV_GUARDRAILS` (`strict` | `lenient` | `off`, default
+`strict`), `STEV_SKIP_INGEST=1` (re-ask an already-ingested run; pass
+the same `STEV_RUN_ID` AND the same `STEV_VARIANT`), `STEV_REPORT_DIR`
 (default `var/state-transitions/`).
 
 Conversation ids are run-scoped (`<runId>-s01a`), so re-runs never

--- a/test/eval/state-transitions/runner.ts
+++ b/test/eval/state-transitions/runner.ts
@@ -24,7 +24,8 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { HttpBrainClient } from '../http-brain-client';
 import { interleaveRoundRobin } from '../memory-fitness/interleave';
 import { walkProvenance } from '../memory-fitness/scorers';
-import { ALL_TURNS, BORIS_REF, CORPUS_VERTICAL, SCENARIOS, SPEAKER } from './scenarios';
+import { BORIS_REF, CORPUS_VERTICAL, SPEAKER } from './scenarios';
+import { allTurnsOf, buildScenarios, parseVariant, type StevVariant } from './variants';
 import { checkBelief, checkHistorySequence, scoreServe, type HistoryEvent } from './scorers';
 import type {
   BeliefCheck,
@@ -36,6 +37,7 @@ import type {
   ProvenanceCheck,
   Scenario,
   ScenarioResult,
+  ScenarioTurn,
   Scorecard,
   ServeCheck,
   Tally,
@@ -59,6 +61,7 @@ interface Config {
   companyId: string;
   userId: string;
   runId: string;
+  variant: StevVariant;
   guardrails: 'strict' | 'lenient' | 'off';
   skipIngest: boolean;
   reportDir: string;
@@ -81,9 +84,11 @@ function loadConfig(): Config {
         '                   (+ brain:admin for the optional scene/belief builds)',
         '  BRAIN_COMPANY_ID tenant id — use a FRESH tenant per run (see README.md)',
         '',
-        'Optional env: STEV_USER_ID, STEV_RUN_ID, STEV_GUARDRAILS',
+        'Optional env: STEV_VARIANT (default|paraphrase|ru — corpus variation',
+        'axis, see variants.ts), STEV_USER_ID, STEV_RUN_ID, STEV_GUARDRAILS',
         '(strict|lenient|off, default strict), STEV_SKIP_INGEST=1 (re-ask an',
-        'already-ingested run — requires the same STEV_RUN_ID), STEV_REPORT_DIR.',
+        'already-ingested run — requires the same STEV_RUN_ID and STEV_VARIANT),',
+        'STEV_REPORT_DIR.',
       ].join('\n'),
     );
     process.exit(1);
@@ -99,6 +104,11 @@ function loadConfig(): Config {
   const guardrailsRaw = process.env.STEV_GUARDRAILS ?? 'strict';
   if (guardrailsRaw !== 'strict' && guardrailsRaw !== 'lenient' && guardrailsRaw !== 'off') {
     console.error('state-transitions: STEV_GUARDRAILS must be strict|lenient|off.');
+    process.exit(1);
+  }
+  const variant = parseVariant(process.env.STEV_VARIANT);
+  if (variant === null) {
+    console.error('state-transitions: STEV_VARIANT must be default|paraphrase|ru.');
     process.exit(1);
   }
   // Run-scoped default user (the #456 hermeticity doctrine): a FIXED
@@ -117,6 +127,7 @@ function loadConfig(): Config {
     companyId,
     userId: process.env.STEV_USER_ID ?? `stev-agent-${runId}`,
     runId,
+    variant,
     guardrails: guardrailsRaw,
     skipIngest: process.env.STEV_SKIP_INGEST === '1',
     reportDir: process.env.STEV_REPORT_DIR ?? join('var', 'state-transitions'),
@@ -264,11 +275,18 @@ interface BeliefsOut {
 
 // ── phase 1: write the world-state ──────────────────────────────────
 
-async function ingestTurns(cfg: Config, brain: HttpBrainClient): Promise<void> {
-  console.error(`[ingest] ${ALL_TURNS.length} mention turns (run ${cfg.runId})…`);
-  for (const [i, turn] of ALL_TURNS.entries()) {
+async function ingestTurns(
+  cfg: Config,
+  brain: HttpBrainClient,
+  turns: readonly ScenarioTurn[],
+): Promise<void> {
+  console.error(
+    `[ingest] ${turns.length} mention turns (run ${cfg.runId}, variant ${cfg.variant})…`,
+  );
+  for (const [i, turn] of turns.entries()) {
     const knownEntities: Array<Record<string, string>> = [{ ...SPEAKER }];
-    if (turn.text.includes('Boris')) {
+    // Both spellings — the RU corpus writes the brother's name «Борис».
+    if (turn.text.includes('Boris') || turn.text.includes('Борис')) {
       knownEntities.push({ ...BORIS_REF, name: 'Boris' });
     }
     await withRetry(`mention ${turn.conversation}#${turn.turn}`, () =>
@@ -285,7 +303,7 @@ async function ingestTurns(cfg: Config, brain: HttpBrainClient): Promise<void> {
         emittedAt: turn.emittedAt,
       }),
     );
-    if ((i + 1) % 10 === 0) console.error(`[ingest] ${i + 1}/${ALL_TURNS.length}`);
+    if ((i + 1) % 10 === 0) console.error(`[ingest] ${i + 1}/${turns.length}`);
   }
 }
 
@@ -495,6 +513,7 @@ function buildScorecard(
   startedAt: string,
   builds: Record<string, string>,
   results: ScenarioResult[],
+  mentionTurns: number,
 ): Scorecard {
   const classes: Record<string, Tally> = {};
   const checkKinds: Record<CheckKind, Tally> = {
@@ -520,13 +539,14 @@ function buildScorecard(
   }
   return {
     runId: cfg.runId,
+    variant: cfg.variant,
     baseUrl: cfg.baseUrl,
     companyId: cfg.companyId,
     userId: cfg.userId,
     guardrails: cfg.guardrails,
     startedAt,
     finishedAt: new Date().toISOString(),
-    ingest: { mentionTurns: cfg.skipIngest ? 0 : ALL_TURNS.length, builds },
+    ingest: { mentionTurns: cfg.skipIngest ? 0 : mentionTurns, builds },
     classes,
     checkKinds,
     scenarios,
@@ -537,7 +557,10 @@ function buildScorecard(
 
 function printScorecard(card: Scorecard): void {
   console.log('');
-  console.log(`state-transitions scorecard — run ${card.runId} (guardrails=${card.guardrails})`);
+  console.log(
+    `state-transitions scorecard — run ${card.runId} ` +
+      `(variant=${card.variant}, guardrails=${card.guardrails})`,
+  );
   console.log('─'.repeat(72));
   for (const [cls, tally] of Object.entries(card.classes)) {
     console.log(
@@ -578,9 +601,12 @@ async function main(): Promise<void> {
   const cfg = loadConfig();
   const startedAt = new Date().toISOString();
   console.error(
-    `state-transitions: run ${cfg.runId} against ${cfg.baseUrl} (tenant ${cfg.companyId})`,
+    `state-transitions: run ${cfg.runId} (variant ${cfg.variant}) ` +
+      `against ${cfg.baseUrl} (tenant ${cfg.companyId})`,
   );
 
+  const scenarios = buildScenarios(cfg.variant);
+  const turns = allTurnsOf(scenarios);
   const brain = new HttpBrainClient({ baseUrl: cfg.baseUrl, apiKey: cfg.apiKey });
   const mcp = await connectMcp(cfg);
   try {
@@ -590,19 +616,19 @@ async function main(): Promise<void> {
 
     let builds: Record<string, string> = { scenes: 'skipped: STEV_SKIP_INGEST' };
     if (!cfg.skipIngest) {
-      await ingestTurns(cfg, brain);
+      await ingestTurns(cfg, brain, turns);
       builds = await runBuilds(cfg);
     }
 
     const ctx: CheckContext = { cfg, mcp, tools, builds };
     const results: ScenarioResult[] = [];
-    for (const scenario of SCENARIOS) {
+    for (const scenario of scenarios) {
       console.error(
         `[scenario] ${scenario.key} ${scenario.name} (${scenario.checks.length} checks)`,
       );
       results.push(await runScenario(ctx, scenario));
     }
-    const card = buildScorecard(cfg, startedAt, builds, results);
+    const card = buildScorecard(cfg, startedAt, builds, results, turns.length);
 
     mkdirSync(cfg.reportDir, { recursive: true });
     const reportPath = join(cfg.reportDir, `state-transitions-${cfg.runId}.json`);

--- a/test/eval/state-transitions/types.ts
+++ b/test/eval/state-transitions/types.ts
@@ -151,6 +151,8 @@ export interface Tally {
 
 export interface Scorecard {
   runId: string;
+  /** Corpus variant of the run: default | paraphrase | ru (variants.ts). */
+  variant: string;
   baseUrl: string;
   companyId: string;
   userId: string;

--- a/test/eval/state-transitions/variants.ts
+++ b/test/eval/state-transitions/variants.ts
@@ -1,0 +1,606 @@
+/**
+ * Variation axis of the state-transition battery (STEV_VARIANT):
+ * the SAME 12 scenarios, the SAME checks, three phrasings of the corpus.
+ *
+ *  - `default`    — the original corpus, byte-identical (buildScenarios
+ *    returns the SCENARIOS array itself; pinned by unit test).
+ *  - `paraphrase` — same facts, phrased WITHOUT any verb of the
+ *    deterministic state-verb lexicon (src/ai/extractor-internals/
+ *    state-verb-harvest.ts — pinned against the exported
+ *    STATE_VERB_LEXICON by unit test), so only the transition
+ *    classifier lane (morphology + BGE-M3 prototypes) and the LLM
+ *    extractor can catch the transitions ("parted with the Kawasaki"
+ *    for sold, "walked away from the chess club" for quit, …).
+ *  - `ru`         — faithful Russian phrasings of the same facts
+ *    (speakers/entities keep their names; brand names stay Latin, the
+ *    way Russian text actually writes them), exercising the RU
+ *    prototype path of the classifier («продал», «вернул», «вступил»,
+ *    «записался», …) and the RU candidate matcher's sentence-scoped
+ *    guards.
+ *
+ * Variants measure ROBUSTNESS, not pass/fail parity — see README.md.
+ *
+ * Overlay semantics (enforced by applyScenario / unit-tested):
+ *
+ *  - turn overlays REPLACE the text of a conversation's turns 1:1 —
+ *    same conversation ids, same turn counts, same timestamps, so the
+ *    ingest structure is identical across variants;
+ *  - check overlays only EXTEND marker lists (expectAnyOf, conflict
+ *    sides, history stages, belief tokens) with alternates the variant
+ *    corpus makes legitimate — a served answer echoing «вернул» is as
+ *    correct as one echoing 'returned'. Nothing is removed: every
+ *    default marker stays, forbid lists stay, check ids/kinds/counts
+ *    stay. The ONE replacement is provenance episodeFragments, which
+ *    MUST quote the variant's seeded turns verbatim to mean anything —
+ *    the builder refuses a variant that leaves them stale.
+ */
+import type {
+  BeliefCheck,
+  Check,
+  FactHistoryCheck,
+  ProvenanceCheck,
+  Scenario,
+  ScenarioTurn,
+  ServeCheck,
+} from './types';
+import { SCENARIOS } from './scenarios';
+
+export type StevVariant = 'default' | 'paraphrase' | 'ru';
+
+export const STEV_VARIANTS: readonly StevVariant[] = ['default', 'paraphrase', 'ru'];
+
+export function parseVariant(raw: string | undefined): StevVariant | null {
+  if (raw === undefined || raw === '') return 'default';
+  return (STEV_VARIANTS as readonly string[]).includes(raw) ? (raw as StevVariant) : null;
+}
+
+/** Per-check marker extensions / provenance replacement (see header). */
+interface CheckOverlay {
+  /** serve: appended to expectAnyOf. */
+  expectExtra?: string[];
+  /** serve conflict mode: appended to the respective side. */
+  sideAExtra?: string[];
+  sideBExtra?: string[];
+  /** provenance: REPLACES episodeFragments (verbatim in variant turns). */
+  fragments?: string[];
+  /** fact-history: per-stage appended markers, aligned to stages. */
+  stagesExtra?: string[][];
+  /** belief: appended token/marker alternates. */
+  subjectExtra?: string[];
+  fieldExtra?: string[];
+  valueExtra?: string[];
+  priorExtra?: string[];
+}
+
+interface ScenarioOverlay {
+  /** conversation id -> replacement texts for ALL its turns, in order. */
+  turns?: Record<string, string[]>;
+  /** check id -> marker overlay. */
+  checks?: Record<string, CheckOverlay>;
+}
+
+type VariantOverlay = Record<string, ScenarioOverlay>;
+
+/** RU alternates for the self-referring belief subject (see scenarios.ts SELF). */
+const SELF_RU = ['Саша', 'пользовател'];
+
+// ── paraphrase corpus ───────────────────────────────────────────────
+// Rule: rephrase every turn that carried a transition (or any lexicon
+// verb); scaffold turns stay byte-identical to the default corpus so
+// deltas attribute to the transition phrasing, not to corpus drift.
+const PARAPHRASE: VariantOverlay = {
+  s01: {
+    turns: {
+      s01a: [
+        'Life log, 2026-08-03. Weekend update: there is a new vehicle in my life.',
+        "I picked up a Kawasaki Ninja on Saturday — it's registered to me.",
+        'The Ninja lives in the garage; I plan to ride it to work on dry days.',
+      ],
+      s01b: [
+        'Life log, 2026-08-10. The motorcycle experiment is over.',
+        'I parted with the Kawasaki today; no bike anymore.',
+        'The buyer picked it up this evening and the registration transfer is done.',
+      ],
+    },
+    checks: {
+      's01-serve': { expectExtra: ['parted with'] },
+    },
+  },
+  s02: {
+    turns: {
+      s02b: [
+        'Work-setup log, 2026-08-12. Laptop swap day.',
+        'I swapped my laptop today: my work laptop is now a MacBook Pro, and the ThinkPad went back to IT.',
+        'Everything is carried over; the MacBook Pro is the only machine I work on now.',
+      ],
+    },
+  },
+  s03: {
+    turns: {
+      s03a: [
+        'Evening log, 2026-08-02.',
+        'I became a member of the chess club today; sessions are on Mondays.',
+      ],
+      s03b: [
+        'Evening log, 2026-08-09.',
+        'I walked away from the chess club today; Mondays became too busy at work.',
+      ],
+      s03c: [
+        'Evening log, 2026-08-20.',
+        'I came back to the chess club today — they shifted sessions to Thursdays, so I am a member again.',
+      ],
+    },
+    checks: {
+      's03-serve': { expectExtra: ['came back'] },
+      's03-history': { stagesExtra: [[], ['walked away'], ['came back']] },
+    },
+  },
+  s04: {
+    turns: {
+      s04a: [
+        'Subscriptions log, 2026-08-15. Going through my bank statement.',
+        'Turns out I actually pulled the plug on my Spotify subscription back on August 1st.',
+        'So since the start of the month I have had no music subscription at all.',
+      ],
+    },
+    checks: {
+      's04-serve': { expectExtra: ['pulled the plug'] },
+      's04-prov': { fragments: ['pulled the plug on my Spotify'] },
+    },
+  },
+  s05: {
+    turns: {
+      s05a: [
+        'Hobby log, 2026-08-01.',
+        'I own a drone — a DJI Mavic 3 from last spring; I fly it most weekends.',
+      ],
+      s05b: [
+        'Hobby log, 2026-08-05.',
+        "I'm toying with the idea of parting with my drone, maybe next month.",
+        'No decision yet; I want to see what used Mavics go for first.',
+      ],
+    },
+    checks: {
+      's05-serve-intent': { expectExtra: ['part with', 'parting with', 'let go', 'letting go'] },
+    },
+  },
+  s06: {
+    turns: {
+      s06a: [
+        'Property log, 2026-08-07.',
+        'I put my apartment in Riga on the market today.',
+        'The listing went live in the afternoon; the agent expects the first viewings next week.',
+      ],
+    },
+    checks: {
+      's06-prov': { fragments: ['put my apartment in Riga on the market'] },
+    },
+  },
+  s07: {
+    turns: {
+      s07a: [
+        'Office log, 2026-08-08.',
+        'The office lease is good through December 2026. That is what our signed contract copy says.',
+      ],
+      s07b: [
+        'Office log, 2026-08-14. Surprise from the building manager.',
+        'Facilities says the office lease actually wraps up in September 2026.',
+        'I have not reconciled the two dates yet; someone is wrong and I need the original lease.',
+      ],
+    },
+    checks: {
+      's07-prov': { fragments: ['wraps up in September 2026', 'good through December 2026'] },
+    },
+  },
+  s08: {
+    turns: {
+      s08b: [
+        'Relocation log, 2026-08-18. Another move, sooner than planned.',
+        'My place of residence shifted to Porto this week.',
+        'The Lisbon chapter is over; from now on Porto is where I live.',
+      ],
+    },
+  },
+  s09: {
+    turns: {
+      s09a: [
+        'Family log, 2026-08-09.',
+        'My brother Boris was given a company car by his employer.',
+      ],
+      s09b: [
+        'Family log, 2026-08-16.',
+        'Boris handed the company car back when he changed employers.',
+        'He starts at the new place on September 1st and will commute by train.',
+      ],
+    },
+    checks: {
+      's09-serve': { expectExtra: ['handed'] },
+    },
+  },
+  s10: {
+    turns: {
+      s10a: [
+        'Home-office log, 2026-08-11, morning.',
+        'Put my name down for the standing desk trial this morning.',
+      ],
+      s10b: [
+        'Home-office log, 2026-08-11, evening. That did not last long.',
+        'Sent the standing desk back by evening — hurt my back.',
+      ],
+    },
+    checks: {
+      's10-serve': { expectExtra: ['sent'] },
+      's10-history': { stagesExtra: [[], ['sent']] },
+    },
+  },
+  s11: {
+    turns: {
+      s11b: [
+        'Photography log, 2026-08-19. Gear cull.',
+        'The Canon R6 went to a new owner today; the Fuji stays.',
+        'One camera is enough — the X100 covers everything I actually shoot.',
+      ],
+    },
+    checks: {
+      's11-serve-sold': { expectExtra: ['new owner'] },
+    },
+  },
+  s12: {
+    checks: {
+      's12-prov-sold': { fragments: ['parted with the Kawasaki'] },
+      's12-prov-bought': { fragments: ['picked up a Kawasaki Ninja'] },
+    },
+  },
+};
+
+// ── Russian corpus ──────────────────────────────────────────────────
+// Faithful phrasings, fully translated (a half-EN corpus would measure
+// code-switching, not the RU path). Person names go Cyrillic the way
+// Russian text writes them («Борис»); brand/product names stay Latin
+// (Kawasaki Ninja, ThinkPad, Spotify …) — also the way Russian text
+// writes them, and it keeps the brand-marker checks language-neutral.
+// Known consequences measured, not papered over: the RU candidate
+// guard is sentence-scoped and sentenceSpans splits only before
+// Latin-uppercase, so «Я продал Kawasaki сегодня; байка больше нет.»
+// is ONE guarded span (the documented deliberate-miss class).
+const RUSSIAN: VariantOverlay = {
+  s01: {
+    turns: {
+      s01a: [
+        'Жизненный дневник, 2026-08-03. Итоги выходных: в моей жизни появился новый транспорт.',
+        'Я купил Kawasaki Ninja в субботу — он зарегистрирован на меня.',
+        'Ninja живёт в гараже; планирую ездить на нём на работу в сухие дни.',
+      ],
+      s01b: [
+        'Жизненный дневник, 2026-08-10. Мотоциклетный эксперимент окончен.',
+        'Я продал Kawasaki сегодня; байка больше нет.',
+        'Покупатель забрал его вечером, и переоформление документов завершено.',
+      ],
+    },
+    checks: {
+      's01-serve': { expectExtra: ['продал', 'больше нет'] },
+      's01-belief': {
+        subjectExtra: SELF_RU,
+        fieldExtra: ['мотоцикл', 'байк', 'транспорт'],
+        valueExtra: ['нет', 'продал', 'продан'],
+        priorExtra: ['Кавасаки'],
+      },
+    },
+  },
+  s02: {
+    turns: {
+      s02a: [
+        'Дневник рабочего сетапа, 2026-08-04.',
+        'Мой рабочий ноутбук — ThinkPad X1 Carbon; это машина, на которой я делаю всё.',
+      ],
+      s02b: [
+        'Дневник рабочего сетапа, 2026-08-12. День замены ноутбука.',
+        'Я заменил ноутбук сегодня: мой рабочий ноутбук теперь MacBook Pro, а ThinkPad вернулся в IT-отдел.',
+        'Всё перенесено; MacBook Pro — единственная машина, на которой я теперь работаю.',
+      ],
+    },
+    checks: {
+      's02-belief': { subjectExtra: SELF_RU, fieldExtra: ['ноутбук'] },
+    },
+  },
+  s03: {
+    turns: {
+      s03a: [
+        'Вечерний дневник, 2026-08-02.',
+        'Я вступил в шахматный клуб сегодня; занятия по понедельникам.',
+      ],
+      s03b: [
+        'Вечерний дневник, 2026-08-09.',
+        'Я вышел из шахматного клуба сегодня; понедельники стали слишком загруженными на работе.',
+      ],
+      s03c: [
+        'Вечерний дневник, 2026-08-20.',
+        'Я снова вступил в шахматный клуб сегодня — занятия перенесли на четверг, так что я опять член клуба.',
+      ],
+    },
+    checks: {
+      's03-serve': { expectExtra: ['член', 'снова'] },
+      's03-history': {
+        stagesExtra: [
+          ['вступил', 'член'],
+          ['вышел', 'покинул'],
+          ['снова', 'опять'],
+        ],
+      },
+    },
+  },
+  s04: {
+    turns: {
+      s04a: [
+        'Дневник подписок, 2026-08-15. Разбираю банковскую выписку.',
+        'Оказывается, я на самом деле отменил подписку на Spotify ещё 1 августа.',
+        'Так что с начала месяца у меня вообще нет музыкальной подписки.',
+      ],
+    },
+    checks: {
+      's04-serve': { expectExtra: ['отмен'] },
+      's04-prov': { fragments: ['отменил подписку на Spotify'] },
+    },
+  },
+  s05: {
+    turns: {
+      s05a: [
+        'Дневник хобби, 2026-08-01.',
+        'У меня есть дрон — DJI Mavic 3, купленный прошлой весной; летаю на нём почти каждые выходные.',
+      ],
+      s05b: [
+        'Дневник хобби, 2026-08-05.',
+        'Я подумываю продать дрон, может быть, в следующем месяце.',
+        'Решения пока нет; сначала хочу посмотреть, почём уходят подержанные Мавики.',
+      ],
+    },
+    checks: {
+      's05-serve-state': { expectExtra: ['есть дрон', 'владе'] },
+      's05-serve-intent': { expectExtra: ['продать', 'продаж'] },
+    },
+  },
+  s06: {
+    turns: {
+      s06a: [
+        'Дневник недвижимости, 2026-08-07.',
+        'Я выставил свою квартиру в Риге на продажу сегодня.',
+        'Объявление появилось днём; агент ждёт первые просмотры на следующей неделе.',
+      ],
+    },
+    checks: {
+      's06-serve': { expectExtra: ['выставил', 'на продажу', 'владе'] },
+      's06-prov': { fragments: ['выставил свою квартиру в Риге'] },
+    },
+  },
+  s07: {
+    turns: {
+      s07a: [
+        'Офисный дневник, 2026-08-08.',
+        'Аренда офиса действует до декабря 2026 года. Так написано в нашей подписанной копии договора.',
+      ],
+      s07b: [
+        'Офисный дневник, 2026-08-14. Сюрприз от управляющего зданием.',
+        'Отдел эксплуатации говорит, что аренда офиса на самом деле заканчивается в сентябре 2026 года.',
+        'Я ещё не сверил эти две даты; кто-то ошибается, и мне нужен оригинал договора.',
+      ],
+    },
+    checks: {
+      's07-serve': { sideAExtra: ['декабр'], sideBExtra: ['сентябр'] },
+      's07-prov': {
+        fragments: ['заканчивается в сентябре 2026', 'действует до декабря 2026'],
+      },
+    },
+  },
+  s08: {
+    turns: {
+      s08a: ['Дневник переезда, 2026-08-03.', 'Мой домашний город теперь Лиссабон.'],
+      s08b: [
+        'Дневник переезда, 2026-08-18. Ещё один переезд, раньше, чем планировалось.',
+        'Моё место жительства переехало в Порту на этой неделе.',
+        'Лиссабонская глава закрыта; отныне я живу в Порту.',
+      ],
+    },
+    checks: {
+      's08-belief': {
+        subjectExtra: SELF_RU,
+        fieldExtra: ['город', 'жительств', 'дом'],
+        valueExtra: ['Порту'],
+        priorExtra: ['Лиссабон'],
+      },
+      's08-serve': { expectExtra: ['Порту'] },
+    },
+  },
+  s09: {
+    turns: {
+      s09a: [
+        'Семейный дневник, 2026-08-09.',
+        'Мой брат Борис получил служебную машину от работодателя.',
+      ],
+      s09b: [
+        'Семейный дневник, 2026-08-16.',
+        'Борис вернул служебную машину, когда сменил работу.',
+        'Он выходит на новое место 1 сентября и будет ездить на работу на поезде.',
+      ],
+    },
+    checks: {
+      's09-serve': { expectExtra: ['вернул'] },
+      's09-belief': {
+        subjectExtra: ['Борис'],
+        fieldExtra: ['машин', 'автомобил'],
+        valueExtra: ['вернул', 'служебн', 'машин'],
+      },
+    },
+  },
+  s10: {
+    turns: {
+      s10a: [
+        'Дневник домашнего офиса, 2026-08-11, утро.',
+        'Записался на пробу стоячего стола этим утром.',
+      ],
+      s10b: [
+        'Дневник домашнего офиса, 2026-08-11, вечер. Это продлилось недолго.',
+        'Вернул стоячий стол к вечеру — заболела спина.',
+      ],
+    },
+    checks: {
+      's10-serve': { expectExtra: ['вернул'] },
+      's10-history': { stagesExtra: [['записался', 'проб'], ['вернул']] },
+    },
+  },
+  s11: {
+    turns: {
+      s11a: ['Фотодневник, 2026-08-06.', 'У меня две камеры: Fuji X100 и Canon R6.'],
+      s11b: [
+        'Фотодневник, 2026-08-19. Чистка техники.',
+        'Продал Canon R6 сегодня; Fuji остаётся.',
+        'Одной камеры достаточно — X100 закрывает всё, что я реально снимаю.',
+      ],
+    },
+    checks: {
+      's11-serve-sold': { expectExtra: ['продал', 'продан'] },
+    },
+  },
+  s12: {
+    checks: {
+      's12-prov-sold': { fragments: ['продал Kawasaki'] },
+      's12-prov-bought': { fragments: ['купил Kawasaki Ninja'] },
+    },
+  },
+};
+
+const OVERLAYS: Record<Exclude<StevVariant, 'default'>, VariantOverlay> = {
+  paraphrase: PARAPHRASE,
+  ru: RUSSIAN,
+};
+
+// ── builder ─────────────────────────────────────────────────────────
+
+function fail(scenario: string, msg: string): never {
+  throw new Error(`state-transitions variant overlay (${scenario}): ${msg}`);
+}
+
+function applyTurns(s: Scenario, overlay: ScenarioOverlay): ScenarioTurn[] {
+  const byConv = new Map<string, number>();
+  for (const t of s.turns) byConv.set(t.conversation, (byConv.get(t.conversation) ?? 0) + 1);
+  for (const [conv, texts] of Object.entries(overlay.turns ?? {})) {
+    const count = byConv.get(conv);
+    if (count === undefined) fail(s.key, `overlay names unknown conversation "${conv}"`);
+    if (count !== texts.length) {
+      fail(s.key, `conversation "${conv}" has ${count} turns, overlay provides ${texts.length}`);
+    }
+  }
+  return s.turns.map((t) => ({
+    ...t,
+    text: overlay.turns?.[t.conversation]?.[t.turn - 1] ?? t.text,
+  }));
+}
+
+function extend(base: readonly string[] | undefined, extra: string[] | undefined): string[] {
+  return [...(base ?? []), ...(extra ?? [])];
+}
+
+function applyServe(s: Scenario, check: ServeCheck, o: CheckOverlay): ServeCheck {
+  if (o.expectExtra !== undefined && check.expectAnyOf === undefined) {
+    fail(s.key, `${check.id}: expectExtra on a check with no expectAnyOf`);
+  }
+  if ((o.sideAExtra !== undefined || o.sideBExtra !== undefined) && !check.conflictSides) {
+    fail(s.key, `${check.id}: conflict-side extras on a non-conflict check`);
+  }
+  return {
+    ...check,
+    ...(check.expectAnyOf !== undefined
+      ? { expectAnyOf: extend(check.expectAnyOf, o.expectExtra) }
+      : {}),
+    ...(check.conflictSides !== undefined
+      ? {
+          conflictSides: {
+            sideA: extend(check.conflictSides.sideA, o.sideAExtra),
+            sideB: extend(check.conflictSides.sideB, o.sideBExtra),
+          },
+        }
+      : {}),
+  };
+}
+
+function applyHistory(s: Scenario, check: FactHistoryCheck, o: CheckOverlay): FactHistoryCheck {
+  if (o.stagesExtra === undefined) return { ...check };
+  if (o.stagesExtra.length !== check.stages.length) {
+    fail(
+      s.key,
+      `${check.id}: stagesExtra has ${o.stagesExtra.length} entries for ${check.stages.length} stages`,
+    );
+  }
+  return {
+    ...check,
+    stages: check.stages.map((stage, i) => extend(stage, o.stagesExtra?.[i])),
+  };
+}
+
+function applyBelief(check: BeliefCheck, o: CheckOverlay): BeliefCheck {
+  return {
+    ...check,
+    subjectTokens: extend(check.subjectTokens, o.subjectExtra),
+    fieldTokens: extend(check.fieldTokens, o.fieldExtra),
+    ...(check.valueMarkers !== undefined
+      ? { valueMarkers: extend(check.valueMarkers, o.valueExtra) }
+      : {}),
+    ...(check.priorMarkers !== undefined
+      ? { priorMarkers: extend(check.priorMarkers, o.priorExtra) }
+      : {}),
+  };
+}
+
+function applyProvenance(s: Scenario, check: ProvenanceCheck, o: CheckOverlay): ProvenanceCheck {
+  // A variant corpus rewrites the seeded turns, so stale fragments can
+  // no longer be quoted verbatim — the overlay MUST replace them.
+  if (o.fragments === undefined || o.fragments.length === 0) {
+    fail(s.key, `${check.id}: provenance check without replacement fragments`);
+  }
+  return { ...check, episodeFragments: o.fragments };
+}
+
+function applyCheck(s: Scenario, check: Check, o: CheckOverlay | undefined): Check {
+  if (check.kind === 'provenance') {
+    // Provenance fragments are corpus text — always variant-authored.
+    return applyProvenance(s, check, o ?? {});
+  }
+  if (o === undefined) return check;
+  switch (check.kind) {
+    case 'serve':
+      return applyServe(s, check, o);
+    case 'fact-history':
+      return applyHistory(s, check, o);
+    case 'belief':
+      return applyBelief(check, o);
+  }
+}
+
+function applyScenario(s: Scenario, overlay: ScenarioOverlay | undefined): Scenario {
+  const o = overlay ?? {};
+  const checkIds = new Set(s.checks.map((c) => c.id));
+  for (const id of Object.keys(o.checks ?? {})) {
+    if (!checkIds.has(id)) fail(s.key, `overlay names unknown check "${id}"`);
+  }
+  return {
+    ...s,
+    turns: applyTurns(s, o),
+    checks: s.checks.map((c) => applyCheck(s, c, o.checks?.[c.id])),
+  };
+}
+
+/**
+ * The corpus builder. `default` returns the SCENARIOS array ITSELF —
+ * byte-identical current corpus by construction (unit-pinned); the
+ * other variants overlay turn texts and marker extensions per the
+ * header contract, validating overlay/corpus alignment as they build.
+ */
+export function buildScenarios(variant: StevVariant): Scenario[] {
+  if (variant === 'default') return SCENARIOS;
+  const overlay = OVERLAYS[variant];
+  return SCENARIOS.map((s) => applyScenario(s, overlay[s.key]));
+}
+
+/** All mention turns of a built corpus, sorted chronologically. */
+export function allTurnsOf(scenarios: readonly Scenario[]): ScenarioTurn[] {
+  return scenarios.flatMap((s) => s.turns).sort((a, b) => a.emittedAt.localeCompare(b.emittedAt));
+}

--- a/test/state-transition-corpus.unit-spec.ts
+++ b/test/state-transition-corpus.unit-spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Corpus-builder contract for the state-transition battery's variation
+ * axis (test/eval/state-transitions/variants.ts). Four pins:
+ *
+ *  1. default identity — buildScenarios('default') IS the current
+ *     corpus, byte-identical (same reference AND same serialized
+ *     bytes), so the axis can never drift the baseline;
+ *  2. structural parity — every variant keeps every scenario, every
+ *     check (id, kind, count), every conversation/turn/timestamp; only
+ *     turn TEXT differs. No scenario loses checks, no marker list
+ *     loses a default marker (except provenance fragments, which are
+ *     corpus text and are REPLACED — pinned verbatim below);
+ *  3. paraphrase honesty — the paraphrase corpus contains NO verb of
+ *     the deterministic state-verb lexicon (asserted against the REAL
+ *     exported STATE_VERB_LEXICON, not a copy), so a paraphrase pass
+ *     can only come from the transition classifier or the LLM lane;
+ *  4. ru honesty — every RU turn actually carries Cyrillic, and every
+ *     variant's provenance fragments are verbatim substrings of that
+ *     variant's seeded turns (a fragment that quotes nothing measures
+ *     nothing).
+ */
+import { STATE_VERB_LEXICON } from '../src/ai/extractor-internals/state-verb-harvest';
+import { SCENARIOS } from './eval/state-transitions/scenarios';
+import {
+  allTurnsOf,
+  buildScenarios,
+  parseVariant,
+  STEV_VARIANTS,
+  type StevVariant,
+} from './eval/state-transitions/variants';
+import type { Check } from './eval/state-transitions/types';
+
+const VARIANTS: readonly StevVariant[] = STEV_VARIANTS;
+const NON_DEFAULT = VARIANTS.filter((v) => v !== 'default');
+
+/** The default-marker lists a variant must never shrink. */
+function markerLists(check: Check): Record<string, readonly string[] | undefined> {
+  switch (check.kind) {
+    case 'serve':
+      return {
+        expectAnyOf: check.expectAnyOf,
+        forbidAnyOf: check.forbidAnyOf,
+        sideA: check.conflictSides?.sideA,
+        sideB: check.conflictSides?.sideB,
+      };
+    case 'belief':
+      return {
+        subjectTokens: check.subjectTokens,
+        fieldTokens: check.fieldTokens,
+        valueMarkers: check.valueMarkers,
+        priorMarkers: check.priorMarkers,
+      };
+    case 'fact-history':
+      return Object.fromEntries(check.stages.map((s, i) => [`stage${i}`, s]));
+    case 'provenance':
+      // Fragments are corpus text — replaced per variant, pinned by the
+      // verbatim test below instead of the superset rule.
+      return {};
+  }
+}
+
+describe('state-transition corpus builder (variation axis)', () => {
+  it('parses the variant env value strictly', () => {
+    expect(parseVariant(undefined)).toBe('default');
+    expect(parseVariant('')).toBe('default');
+    expect(parseVariant('default')).toBe('default');
+    expect(parseVariant('paraphrase')).toBe('paraphrase');
+    expect(parseVariant('ru')).toBe('ru');
+    expect(parseVariant('RU')).toBeNull();
+    expect(parseVariant('russian')).toBeNull();
+  });
+
+  it('default is the current corpus, byte-identical', () => {
+    const built = buildScenarios('default');
+    expect(built).toBe(SCENARIOS);
+    expect(JSON.stringify(built)).toBe(JSON.stringify(SCENARIOS));
+  });
+
+  it.each(NON_DEFAULT)('%s keeps every scenario and every check (id, kind, order)', (variant) => {
+    const built = buildScenarios(variant);
+    expect(built.map((s) => s.key)).toEqual(SCENARIOS.map((s) => s.key));
+    for (const [i, scenario] of built.entries()) {
+      const base = SCENARIOS[i];
+      if (base === undefined) throw new Error('scenario count changed');
+      expect(scenario.checks.map((c) => `${c.id}:${c.kind}`)).toEqual(
+        base.checks.map((c) => `${c.id}:${c.kind}`),
+      );
+    }
+  });
+
+  it.each(NON_DEFAULT)('%s keeps the ingest structure — only turn text differs', (variant) => {
+    const built = buildScenarios(variant);
+    for (const [i, scenario] of built.entries()) {
+      const base = SCENARIOS[i];
+      if (base === undefined) throw new Error('scenario count changed');
+      expect(scenario.turns.map((t) => `${t.conversation}#${t.turn}@${t.emittedAt}`)).toEqual(
+        base.turns.map((t) => `${t.conversation}#${t.turn}@${t.emittedAt}`),
+      );
+    }
+    // Same total corpus size in every variant (52 turns today).
+    expect(allTurnsOf(built).length).toBe(allTurnsOf(SCENARIOS).length);
+  });
+
+  it.each(NON_DEFAULT)('%s never drops a default marker from any check', (variant) => {
+    const built = buildScenarios(variant);
+    for (const [i, scenario] of built.entries()) {
+      const base = SCENARIOS[i];
+      if (base === undefined) throw new Error('scenario count changed');
+      for (const [j, check] of scenario.checks.entries()) {
+        const baseCheck = base.checks[j];
+        if (baseCheck === undefined) throw new Error('check count changed');
+        const baseLists = markerLists(baseCheck);
+        const builtLists = markerLists(check);
+        for (const [name, baseList] of Object.entries(baseLists)) {
+          if (baseList === undefined) {
+            expect(builtLists[name]).toBeUndefined();
+            continue;
+          }
+          for (const marker of baseList) {
+            expect(builtLists[name]).toContain(marker);
+          }
+        }
+      }
+    }
+  });
+
+  it('paraphrase corpus contains NO state-verb-lexicon verb (classifier-only by construction)', () => {
+    const lexicon = new RegExp(
+      `\\b(?:${[...STATE_VERB_LEXICON].sort((a, b) => b.length - a.length).join('|')})\\b`,
+      'i',
+    );
+    for (const turn of allTurnsOf(buildScenarios('paraphrase'))) {
+      const hit = lexicon.exec(turn.text);
+      expect(
+        hit === null ? null : `${turn.conversation}#${turn.turn} contains lexicon verb "${hit[0]}"`,
+      ).toBeNull();
+    }
+  });
+
+  it('ru corpus is actually Russian — every turn carries Cyrillic', () => {
+    for (const turn of allTurnsOf(buildScenarios('ru'))) {
+      expect(/[а-яё]/i.test(turn.text)).toBe(true);
+    }
+  });
+
+  it.each(VARIANTS)(
+    '%s provenance fragments quote a seeded turn of the SAME variant verbatim',
+    (variant) => {
+      const built = buildScenarios(variant);
+      const texts = allTurnsOf(built).map((t) => t.text);
+      for (const scenario of built) {
+        for (const check of scenario.checks) {
+          if (check.kind !== 'provenance') continue;
+          expect(check.episodeFragments.length).toBeGreaterThan(0);
+          for (const fragment of check.episodeFragments) {
+            const carrier = texts.find((t) => t.includes(fragment));
+            expect(
+              carrier === undefined ? `${check.id}: fragment "${fragment}" quotes no turn` : 'ok',
+            ).toBe('ok');
+          }
+        }
+      }
+    },
+  );
+
+  it('variant serve checks stay honest — no bare negation markers were introduced', () => {
+    // The scenarios.ts header rule: decline answers contain 'no' /
+    // 'do not', and 'now' contains 'no' — a variant extension must not
+    // smuggle them in as expect markers.
+    const banned = new Set(['no', 'not', 'do not', "don't", 'нет', 'не']);
+    for (const variant of NON_DEFAULT) {
+      for (const scenario of buildScenarios(variant)) {
+        for (const check of scenario.checks) {
+          if (check.kind !== 'serve' || check.expectAnyOf === undefined) continue;
+          for (const marker of check.expectAnyOf) {
+            expect(banned.has(marker.toLowerCase())).toBe(false);
+          }
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds the long-queued **variation axis** to the state-transitions battery: `STEV_VARIANT=default|paraphrase|ru` — the same 12 scenarios and the same checks over three phrasings of the corpus — and reports the first live measurement of all three, including the **first live run of the transition classifier's RU path** (#446).

- **`default`** — byte-identical current corpus (`buildScenarios('default')` returns the `SCENARIOS` array itself; unit-pinned).
- **`paraphrase`** — same facts phrased **without any verb of the state-verb lexicon** ("parted with the Kawasaki", "walked away from the chess club", "sent the standing desk back"), so only the transition-classifier lane (morphology + BGE-M3 prototypes) and the LLM extractor can catch the transitions. Pinned live: the paraphrase run produced **zero** 0.95-confidence (lexicon-lane) `state_change` facts, and a unit test asserts the corpus against the newly exported `STATE_VERB_LEXICON`.
- **`ru`** — faithful Russian phrasings («продал», «вернул», «вступил», «записался»; people Cyrillic, brands Latin), exercising the RU prototype path and the RU candidate matcher's sentence-scoped guards.

Check expectations stay the same: marker lists only **gain** language/phrasing alternates a correct answer would legitimately echo; forbid lists, check ids/kinds/counts are untouched; provenance fragments are re-authored to quote the variant's own turns verbatim (builder-enforced). Unit spec pins default identity, structural parity, no-marker-loss, paraphrase lexicon-invisibility, RU Cyrillic coverage, verbatim fragments, and the no-bare-negation-marker rule. README documents the axis and the honest framing: **variants measure robustness, not pass/fail parity**.

## Live measurement (dogfood stand, all extraction/scene/belief flags on, fresh salted user per run)

| scenario (class) | default | paraphrase | ru |
|---|---|---|---|
| s01 dispose | PASS | PASS | PASS |
| s02 replace | FAIL (history) | FAIL (history) | FAIL (history) |
| s03 re-acquire | PASS | PASS | **FAIL** (history) |
| s04 retro-dated | PASS | PASS | PASS |
| s05 intention-guard | FAIL (serve) | FAIL (serve) | **PASS** |
| s06 listed-not-sold | PASS | PASS | PASS |
| s07 contradiction | FAIL* (serve) | **PASS** | FAIL* (serve) |
| s08 field-drift | FAIL (serve) | **PASS** | **PASS** |
| s09 third-party | PASS | PASS | **FAIL** (serve) |
| s10 same-day | PASS | **FAIL** (history) | **FAIL** (serve+history) |
| s11 multi-object | PASS | **FAIL** (serve) | PASS |
| s12 provenance | PASS | PASS | PASS |
| **scenarios** | **8/12** | **8/12** | **7/12** |
| **checks** | **21/25 (84%)** | **21/25 (84%)** | **19/25 (76%)** |

\* = `knownFailToday` (conflict slot canonicalization).

Runs: `stmtqie5su` (default), `stmtqimpqu` (paraphrase), `stmtqirszw` (ru); reports in `var/state-transitions/` (gitignored), all serve answers embedded. Single-shot runs — serve checks ride LLM synthesis, so ±1 check of noise is expected (s08-serve abstained in default but passed in both variants).

## Where the classifier caught it (state_change provenance by confidence lane: 0.95 lexicon / 0.85 classifier / ~0.9 LLM)

- **default**: 11 lexicon + 21 LLM facts, classifier 0 (every transition sentence already claimed — the defer-to-lexicon contract working as designed).
- **paraphrase**: **0 lexicon** (honesty pin held live), **4 classifier catches** — "I became a member of the chess club today", "I walked away from the chess club today", "I came back to the chess club today", and the out-of-lexicon **passive** "My brother Boris was given a company car by his employer" — plus 20 LLM facts ("parted with the Kawasaki", "pulled the plug on my Spotify…", "handed the company car back", "swapped my laptop").
- **ru**: **1 classifier catch** — «Моё место жительства переехало в Порту на этой неделе» (the first live RU prototype-path emission; it is what turned s08 field-drift green). The LLM lane natively carried most RU transitions as RU-object `state_change` facts («продал Kawasaki», «вышел из шахматного клуба», «отменил подписку на Spotify», …).

## Where extraction went blind

1. **RU same-day dispose is fully lost (s10)**: «Вернул стоячий стол к вечеру — заболела спина.» produced no transition fact from any lane (the RU candidate exists — no guard fires — so the classifier saw it and rejected it; the LLM emitted only `interacted_with`). Serving answered with the stale morning state ("signed up for the standing desk trial"). In paraphrase, the same dispose ("Sent the standing desk back") also left no timeline fact, but the **scene/belief lane** caught it (`standing desk status: acquired → returned`) and rescued serving — the fact substrate and the belief substrate now measurably disagree in coverage.
2. **RU third-party transition is blind (s09)**: «Борис вернул служебную машину, когда сменил работу» yielded no `state_change` for the car — the LLM claimed the sentence with the subordinate «сменил работу» fact, and the sentence-scoped defer rule then hid the main-clause «вернул» from the classifier (clause-vs-sentence composition gap). Serve answered "Boris has interacted with a company car" (fail); the belief lane again knew better (`Boris, company car: returned`).
3. **Object identity dies in subject-position phrasings (s11 paraphrase)**: "The Canon R6 went to a new owner today" extracted as bare "went to a new owner" `state_change` facts bound to the holder — the Canon fell out of the object, and the fragment then leaked into the **drone** question's answer ("The drone went to a new owner", s05 fail). One phrasing, two scenario failures.
4. **RU re-acquire loses «снова» (s03)**: the rejoin normalized to «вступил в шахматный клуб» — byte-identical to the first join — so the timeline cannot show the third stage even though it retains three events; serving still answered "member" correctly.
5. **Cross-variant constants**: s02-history (replace timeline split across `ThinkPad`/`MacBook` entities) fails identically in all three variants — corpus-phrasing-independent, a substrate bug, not a robustness gap. Provenance held 5/5 in **every** variant, including RU fragments — the evidence plane is phrasing- and language-robust. All 4 belief checks passed in all three variants (the #135 flags are on on this stand).
6. **Known marker-scoring limit, recorded honestly**: RU s06-serve passed on the 'for sale' marker while the answer text wrongly asserted the apartment was already sold (cross-scenario fusion with the s01 buyer). The report keeps the full answer; tightening s06's forbid list is a follow-up for the default corpus, not a variant concern.

## Gates

- `pnpm typecheck` clean, `pnpm format:check` clean, full `pnpm test:unit`: 361 suites / 4020 tests green (includes the new 14-test corpus spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
