### PR TITLE
feat(facts): deterministic status landing for calendar-anchored artifact lifecycle claims

### DIFF
--- a/src/ingest/fact-resolver.service.ts
+++ b/src/ingest/fact-resolver.service.ts
@@ -140,7 +140,41 @@ export const SLOT_CANONICAL_ALIASES: ReadonlyMap<string, string> = new Map([
   // append_only) vs "ends in September 2026" (a lifecycle claim →
   // status, single_active): same attribute, two slots (s07).
   ['duration_limit', 'status'],
+  // The third observed landing of the SAME attribute (battery run
+  // stmtq22rtp): the extraction lottery can put a lease-end claim into
+  // state_change — an append_only transition-event predicate where no
+  // conflict pair can form BY DESIGN. A calendar-anchored lifecycle
+  // claim about an ARTIFACT is not a transition event; it is the
+  // entity's lifecycle state and belongs in the status slot. Guarded
+  // TWICE on top of the mention-path/alias conditions: the
+  // calendar-anchor gate below, AND the non-person subject gate
+  // (NON_PERSON_GUARDED_ALIASES) — a person's own state_change history
+  // ("quit the chess club", "returned the standing desk") is the
+  // timeline substrate the state-transition lanes exist to build and
+  // must NEVER reroute, whatever dates it mentions.
+  ['state_change', 'status'],
 ]);
+
+/**
+ * Person-typed extraction subjects — exactly the state-holder types the
+ * transition lanes bind state_change facts to (bindStateHolder in
+ * state-verb-harvest.ts: customer | staff, else the speaker, who is
+ * also one of these). Kept in lockstep with that binder on purpose: it
+ * defines what "a person's own lifecycle history" means here.
+ */
+const PERSON_ENTITY_TYPES: ReadonlySet<string> = new Set(['customer', 'staff']);
+
+/**
+ * Alias entries that additionally require a KNOWN non-person subject
+ * (guard (b) of the state_change entry above). Membership is per-entry:
+ * duration_limit is a service/system predicate by its own seed card and
+ * predates this guard — its behaviour is pinned by the live-proven s07
+ * chain and stays calendar-anchor-only. An UNKNOWN subject type (a
+ * caller that does not thread it, e.g. the document commit path) misses
+ * conservatively: no reroute, never a false hit — the same doctrine as
+ * the calendar-anchor regex.
+ */
+const NON_PERSON_GUARDED_ALIASES: ReadonlySet<string> = new Set(['state_change']);
 
 /**
  * Deterministic same-attribute gate for slot canonicalization: the
@@ -165,6 +199,9 @@ const CALENDAR_ANCHOR_RE =
  *  - no predicateAlias is set (an EDC coinage already has a canon —
  *    0082 owns that mapping, never clobber it);
  *  - the predicate has a declared canonical alias (table above);
+ *  - for NON_PERSON_GUARDED_ALIASES entries (state_change): the subject
+ *    entity's extraction type is known and NOT person-typed
+ *    (PERSON_ENTITY_TYPES) — unknown misses conservatively;
  *  - the object passes the calendar-anchor gate.
  * Static table + regex — no DB read, no fuzzy matching, no LLM — so the
  * mapping is order-free and idempotent: BOTH arms of a cross-predicate
@@ -174,13 +211,24 @@ const CALENDAR_ANCHOR_RE =
  * read lives in src/common/conflict-flags.ts); exported for tests.
  */
 export function canonicalSlotFor(
-  p: { predicate: string; predicateAlias?: string | undefined; object: string },
+  p: {
+    predicate: string;
+    predicateAlias?: string | undefined;
+    object: string;
+    entityType?: string | undefined;
+  },
   path: 'direct' | 'mention',
 ): string | undefined {
   if (path !== 'mention' || !conflictSlotCanonicalizationEnabled()) return undefined;
   if (p.predicateAlias !== undefined) return undefined;
   const canonical = SLOT_CANONICAL_ALIASES.get(p.predicate);
   if (canonical === undefined) return undefined;
+  if (
+    NON_PERSON_GUARDED_ALIASES.has(p.predicate) &&
+    (p.entityType === undefined || PERSON_ENTITY_TYPES.has(p.entityType))
+  ) {
+    return undefined;
+  }
   return CALENDAR_ANCHOR_RE.test(p.object) ? canonical : undefined;
 }
 
@@ -275,6 +323,17 @@ export class FactResolverService {
        * no sourceLang stamp — byte-identical.
        */
       sourceLang?: string | undefined;
+      /**
+       * Extraction type of the subject entity (the closed extractor
+       * vocabulary: customer | staff | asset | project | topic |
+       * location | other), when the caller has it — the mention path
+       * resolves entities before facts and threads it through. Read
+       * ONLY by the slot-canonicalization non-person guard
+       * (canonicalSlotFor); absent ⇒ the guarded aliases miss
+       * conservatively (no reroute) and everything else is
+       * byte-identical.
+       */
+      entityType?: string | undefined;
       objectMeta?: object | undefined;
       /** Exact text to embed; defaults to factIndexText(predicate, object)
        *  (the historical `${predicate}: ${object}` unless

--- a/src/ingest/mention-persist.service.ts
+++ b/src/ingest/mention-persist.service.ts
@@ -197,6 +197,9 @@ export class MentionPersistService {
             validFrom,
             precomputedEmbedding: factEmbeddings[i],
             userId: dto.userId,
+            // Subject entity's extraction type — read only by the
+            // slot-canonicalization non-person guard (canonicalSlotFor).
+            entityType: extraction.entities[f.entityIndex]?.type,
           }),
         { predicate: f.predicate, entityId: eid },
       );
@@ -288,6 +291,9 @@ export class MentionPersistService {
           // Audit 2026-08-21 P0: the per-user scope stamps every
           // extracted fact on the batched path too.
           userId: dto.userId,
+          // Subject entity's extraction type — read only by the
+          // slot-canonicalization non-person guard (canonicalSlotFor).
+          entityType: extraction.entities[f.entityIndex]?.type,
         },
       });
     }
@@ -336,6 +342,8 @@ export class MentionPersistService {
       precomputedEmbedding: number[] | undefined;
       /** Per-user scope (audit 2026-08-21 P0) — stamps the fact row. */
       userId?: string | undefined;
+      /** Subject entity's extraction type (slot-canonicalization guard). */
+      entityType?: string | undefined;
     },
   ): Promise<string | null> {
     const { f } = p;
@@ -352,6 +360,7 @@ export class MentionPersistService {
       entropy,
       precomputedEmbedding: p.precomputedEmbedding,
       userId: p.userId,
+      entityType: p.entityType,
     });
     return this.emitFactOutcome(f, result, semantics);
   }

--- a/test/conflict-slot-canonicalization.unit-spec.ts
+++ b/test/conflict-slot-canonicalization.unit-spec.ts
@@ -13,7 +13,15 @@ import { FactResolverService, canonicalSlotFor } from '../src/ingest/fact-resolv
  * calendar-anchored duration_limit arm into the canonical status slot
  * at write time (static declared alias table + calendar-anchor regex —
  * no DB read, no fuzzy matching, no LLM), so both arms meet in ONE slot
- * and the normal single_active/bitemporal machinery adjudicates. Pins:
+ * and the normal single_active/bitemporal machinery adjudicates.
+ *
+ * The state_change entry closes the remaining EXTRACTION LANDING
+ * LOTTERY (run stmtq22rtp): the same two turns can land both arms as
+ * (office lease, state_change) — append_only, no pair by design. A
+ * calendar-anchored lifecycle claim on a KNOWN NON-PERSON subject
+ * reroutes to status too; a person's own state_change history (the
+ * transition lanes' timeline substrate) and unknown-typed subjects
+ * never do. Pins:
  *  - flag off (unset AND '0') → extracted-predicate passthrough, the
  *    resolver call byte-identical;
  *  - flag on: the EXACT s07 shapes meet in one slot — both arms bind
@@ -58,6 +66,8 @@ describe('FactResolverService — CONFLICT_SLOT_CANONICALIZATION', () => {
         if (predicate === 'status') return { predicateId: 'status', semantics: 'single_active' };
         if (predicate === 'duration_limit')
           return { predicateId: 'duration_limit', semantics: 'append_only' };
+        if (predicate === 'state_change')
+          return { predicateId: 'state_change', semantics: 'append_only' };
         return { predicateId: '__default__', semantics: 'append_only' };
       }),
     };
@@ -69,8 +79,25 @@ describe('FactResolverService — CONFLICT_SLOT_CANONICALIZATION', () => {
   const DECEMBER_ARM = { predicate: 'duration_limit', object: 'until December 2026' };
   const SEPTEMBER_ARM = { predicate: 'status', object: 'ends in September 2026' };
 
+  /**
+   * The third observed landing (hermetic battery run stmtq22rtp): the
+   * extraction lottery put BOTH lease arms into state_change on the
+   * office-lease ARTIFACT entity — an append_only predicate where no
+   * conflict pair can form by design.
+   */
+  const DECEMBER_STATE_ARM = {
+    predicate: 'state_change',
+    object: 'runs until December 2026',
+    entityType: 'asset',
+  };
+  const SEPTEMBER_STATE_ARM = {
+    predicate: 'state_change',
+    object: 'ends in September 2026',
+    entityType: 'asset',
+  };
+
   function input(
-    f: { predicate: string; object: string },
+    f: { predicate: string; object: string; entityType?: string },
     opts: {
       recordOutcomeMetric?: boolean;
       userId?: string;
@@ -87,6 +114,7 @@ describe('FactResolverService — CONFLICT_SLOT_CANONICALIZATION', () => {
       validFrom: new Date('2026-08-08T10:00:00Z'),
       source: {},
       precomputedEmbedding: [0.1, 0.2],
+      ...(f.entityType !== undefined ? { entityType: f.entityType } : {}),
       ...(opts.recordOutcomeMetric !== undefined
         ? { recordOutcomeMetric: opts.recordOutcomeMetric }
         : {}),
@@ -216,6 +244,65 @@ describe('FactResolverService — CONFLICT_SLOT_CANONICALIZATION', () => {
     expect(params.predicate_alias).toBe('contract_term');
   });
 
+  it('flag on: a state_change LOTTERY landing on the artifact reroutes into the same canonical slot', async () => {
+    // Battery run stmtq22rtp: the SAME two corpus turns landed both
+    // arms as (office lease, state_change) — append_only, no pair can
+    // form. The fix: calendar-anchored ARTIFACT lifecycle claims land
+    // in status regardless of which predicate the extraction chose.
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+    const { svc, db, queries, factEmbedding } = make();
+    await svc.resolve(db as never, input(DECEMBER_STATE_ARM));
+    await svc.resolve(db as never, input(SEPTEMBER_STATE_ARM));
+    const calls = resolveCalls(queries);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.params.predicate).toBe('status');
+    expect(calls[1]!.params.predicate).toBe('status');
+    // Both rerouted arms are re-embedded with the CANONICAL slot text.
+    expect(factEmbedding.embed).toHaveBeenCalledTimes(2);
+    expect(factEmbedding.embed).toHaveBeenNthCalledWith(1, 'status: runs until December 2026');
+    expect(factEmbedding.embed).toHaveBeenNthCalledWith(2, 'status: ends in September 2026');
+    // Objects ride into the fn VERBATIM — no value rewriting.
+    expect(calls[0]!.params.object).toBe('runs until December 2026');
+    expect(calls[1]!.params.object).toBe('ends in September 2026');
+    // Canonical slot's registry policy applies (single_active).
+    expect(calls[0]!.params.semantics).toBe('single_active');
+  });
+
+  it('flag on: a person-subject state_change with a calendar anchor stays in its slot (service seam)', async () => {
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+    const { svc, db, queries, factEmbedding } = make();
+    const out = await svc.resolve(
+      db as never,
+      input({
+        predicate: 'state_change',
+        object: 'cancelled the lease effective December 2026',
+        entityType: 'customer',
+      }),
+    );
+    const params = resolveCalls(queries)[0]!.params;
+    expect(params.predicate).toBe('state_change');
+    expect(params.semantics).toBe('append_only');
+    expect(params.embedding).toEqual([0.1, 0.2]);
+    expect(factEmbedding.embed).not.toHaveBeenCalled();
+    expect(out.semantics).toBe('append_only');
+  });
+
+  it('flag off: a state_change landing is passthrough byte-identical, entityType inert', async () => {
+    const unset = make();
+    await unset.svc.resolve(unset.db as never, input(DECEMBER_STATE_ARM));
+    process.env.CONFLICT_SLOT_CANONICALIZATION = '0';
+    const off = make();
+    await off.svc.resolve(off.db as never, input(DECEMBER_STATE_ARM));
+    for (const run of [unset, off]) {
+      const params = resolveCalls(run.queries)[0]!.params;
+      expect(params.predicate).toBe('state_change');
+      expect(params.semantics).toBe('append_only');
+      expect(params.embedding).toEqual([0.1, 0.2]);
+      expect(run.factEmbedding.embed).not.toHaveBeenCalled();
+    }
+    expect(resolveCalls(off.queries)[0]!.params).toEqual(resolveCalls(unset.queries)[0]!.params);
+  });
+
   it('flag on + different entities: each binds its own $eid — no cross-entity collision', async () => {
     process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
     const { svc, db, queries } = make();
@@ -260,6 +347,81 @@ describe('FactResolverService — CONFLICT_SLOT_CANONICALIZATION', () => {
       expect(canonicalSlotFor(DECEMBER_ARM, 'direct')).toBeUndefined();
       expect(
         canonicalSlotFor({ ...DECEMBER_ARM, predicateAlias: 'contract_term' }, 'mention'),
+      ).toBeUndefined();
+    });
+
+    it('state_change entry: reroutes ONLY a calendar-anchored claim on a known non-person subject', () => {
+      process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+      // The stmtq22rtp lottery landings — artifact subject, anchored.
+      expect(canonicalSlotFor(DECEMBER_STATE_ARM, 'mention')).toBe('status');
+      expect(canonicalSlotFor(SEPTEMBER_STATE_ARM, 'mention')).toBe('status');
+      // Every non-person extraction type qualifies; person types never do.
+      for (const entityType of ['asset', 'project', 'topic', 'location', 'other']) {
+        expect(canonicalSlotFor({ ...DECEMBER_STATE_ARM, entityType }, 'mention')).toBe('status');
+      }
+      for (const entityType of ['customer', 'staff']) {
+        expect(canonicalSlotFor({ ...DECEMBER_STATE_ARM, entityType }, 'mention')).toBeUndefined();
+      }
+      // UNKNOWN subject type misses conservatively (a caller that does
+      // not thread it — e.g. the document commit path — never reroutes).
+      expect(
+        canonicalSlotFor(
+          { predicate: 'state_change', object: 'runs until December 2026' },
+          'mention',
+        ),
+      ).toBeUndefined();
+      // Direct path stays untouched even for a qualifying shape.
+      expect(canonicalSlotFor(DECEMBER_STATE_ARM, 'direct')).toBeUndefined();
+      // duration_limit keeps its live-proven anchor-only gate: the
+      // non-person guard is per-entry and does NOT spread to it.
+      expect(canonicalSlotFor({ ...DECEMBER_ARM, entityType: 'customer' }, 'mention')).toBe(
+        'status',
+      );
+    });
+
+    it('state_change entry: the battery corpus transition spans never reroute (pinned verbatim)', () => {
+      process.env.CONFLICT_SLOT_CANONICALIZATION = '1';
+      // The EXACT state_change objects the harvest lanes produce from
+      // the s02/s03/s10/s11 corpus turns (verb-phrase spans, verbatim
+      // substrings of scenarios.ts). All bind to the PERSON holder
+      // (bindStateHolder: person in sentence, else speaker), so the
+      // non-person guard alone already excludes them; none carries a
+      // full-month-plus-year or ISO anchor either — the corpus's ISO
+      // dates live only in verb-less log-header sentences the lanes'
+      // clause capture cannot cross into. Belt AND suspenders: assert
+      // no reroute under the person type, and ALSO no anchor match even
+      // if a lottery landing put the same span on a non-person entity.
+      const corpusSpans = [
+        'replaced my laptop today', // s02
+        'joined the chess club today', // s03
+        'quit the chess club today', // s03
+        'rejoined the chess club today', // s03
+        'Signed up for the standing desk trial this morning', // s10
+        'Returned the standing desk by evening', // s10
+        'Sold the Canon R6', // s11
+      ];
+      for (const object of corpusSpans) {
+        expect(
+          canonicalSlotFor(
+            { predicate: 'state_change', object, entityType: 'customer' },
+            'mention',
+          ),
+        ).toBeUndefined();
+        expect(
+          canonicalSlotFor({ predicate: 'state_change', object, entityType: 'asset' }, 'mention'),
+        ).toBeUndefined();
+      }
+      // A person-subject claim WITH an anchor still never reroutes: a
+      // person's own lifecycle history is timeline substrate.
+      expect(
+        canonicalSlotFor(
+          {
+            predicate: 'state_change',
+            object: 'cancelled the gym membership until December 2026',
+            entityType: 'customer',
+          },
+          'mention',
+        ),
       ).toBeUndefined();
     });
   });

--- a/test/eval/state-transitions/README.md
+++ b/test/eval/state-transitions/README.md
@@ -112,6 +112,19 @@ Stand flags that shape coverage:
   one side of the contradiction. With the flag on, the slot is promoted
   to `bitemporal` margin doctrine and the close-scored pair COMPETES
   (both sides served or an honest abstain).
+- `SYNTHESIZE_ANSWER_ROUTER_ENABLED=1` — required for the **s07-serve**
+  PASS half: a formed COMPETING pair renders as the T3 conflict note
+  (the both-sides instruction) only when the contradiction lane is
+  live, and the whole lane set is empty without the router. On a stand
+  without it, serving names one side even when the write side formed
+  the pair perfectly (measured live, runs stmtqi40g4/stmtqijarx vs
+  stmtqiundv).
+- Run-independence gotcha: extraction memoises in an in-process LRU
+  (`EXTRACTOR_CACHE_ENABLED`, default on) keyed on turn text — two
+  battery runs against ONE app boot share every extraction draw, so a
+  landing-lottery outcome from run 1 is FROZEN into run 2. Restart the
+  app (or disable the cache) between runs that must sample the
+  extraction independently.
 
 Then:
 

--- a/test/eval/state-transitions/scenarios.ts
+++ b/test/eval/state-transitions/scenarios.ts
@@ -357,11 +357,13 @@ export const SCENARIOS: Scenario[] = [
         conflictSides: { sideA: ['December'], sideB: ['September'] },
         knownFailToday:
           'CONFLICT_SLOT_CANONICALIZATION — the arms extract into DIFFERENT slots on one ' +
-          'entity ((office lease, status) vs (office lease, duration_limit)), and the ' +
-          'conflict machinery pairs only identical (userId, entity, predicate), so even ' +
-          'with CONFLICT_MENTION_FACT_SLOT on no collision structurally exists; the flag ' +
-          '(default off) routes the calendar-anchored duration_limit arm into the status ' +
-          'slot at write time so the bitemporal margin doctrine sees the collision',
+          'entity ((office lease, status) vs (office lease, duration_limit), and the ' +
+          'landing lottery can also put either arm in (office lease, state_change) — run ' +
+          'stmtq22rtp), and the conflict machinery pairs only identical (userId, entity, ' +
+          'predicate), so even with CONFLICT_MENTION_FACT_SLOT on no collision ' +
+          'structurally exists; the flag (default off) routes every calendar-anchored ' +
+          'artifact lifecycle landing (duration_limit, non-person state_change) into the ' +
+          'status slot at write time so the bitemporal margin doctrine sees the collision',
       },
       {
         kind: 'provenance',

--- a/test/eval/state-transitions/scenarios.ts
+++ b/test/eval/state-transitions/scenarios.ts
@@ -363,7 +363,11 @@ export const SCENARIOS: Scenario[] = [
           'predicate), so even with CONFLICT_MENTION_FACT_SLOT on no collision ' +
           'structurally exists; the flag (default off) routes every calendar-anchored ' +
           'artifact lifecycle landing (duration_limit, non-person state_change) into the ' +
-          'status slot at write time so the bitemporal margin doctrine sees the collision',
+          'status slot at write time so the bitemporal margin doctrine sees the collision. ' +
+          'SERVE SIDE: even with the pair formed, both-sides naming needs the T3 conflict ' +
+          'note, which renders only when the contradiction lane is live — the stand must ' +
+          'run SYNTHESIZE_ANSWER_ROUTER_ENABLED=1 or the lane set is empty and ' +
+          'detectEvidenceConflicts returns [] before looking at the evidence',
       },
       {
         kind: 'provenance',


### PR DESCRIPTION
## Problem

The s07 conflict chain (#450 slot canonicalization + #444/#455 conflict-slot promotion) is live-proven end-to-end — when the two contradicting lease claims land in the `status`/`duration_limit` slots, a `(office lease, status)` COMPETING pair forms. But hermetic battery run `stmtq22rtp` exposed the **extraction landing lottery**: the same two corpus turns can land BOTH arms as `(office lease, state_change)` — an append_only transition-event predicate where no conflict pair can form by design. Which predicate the arms land in varies draw to draw; the machinery only fired on the canonicalizable landings.

## Fix

Extend the declared alias table with `state_change → status`, with TWO guards on top of the existing mention-path/alias conditions:

- **Calendar-anchor gate** (existing `CALENDAR_ANCHOR_RE`): full month + 4-digit year, or ISO date. Verified against the battery corpus: none of the s02/s03/s10/s11 transition spans carries one (`replaced my laptop today`, `joined/quit/rejoined the chess club today`, `Signed up for the standing desk trial this morning`, `Returned the standing desk by evening`, `Sold the Canon R6`) — the corpus's ISO dates live only in verb-less log-header sentences the harvest lanes' clause capture cannot cross into. All pinned verbatim in the unit spec.
- **Non-person subject gate** (new, per-entry): the transition lanes bind `state_change` to PERSON holders exclusively (`bindStateHolder`: `customer` | `staff`, else the speaker), so a person's own lifecycle history never reroutes, whatever dates it mentions. An unknown subject type (a caller that does not thread it, e.g. the document commit path) misses conservatively — no reroute, never a false hit. `duration_limit` keeps its live-proven anchor-only gate; the person guard does not spread to it.

The subject entity's extraction type is threaded minimally: mention persist (per-fact and batched paths) passes `extraction.entities[f.entityIndex].type` into the resolver input, read only by `canonicalSlotFor`. No new flag: gated by the existing `CONFLICT_SLOT_CANONICALIZATION` (default off ⇒ byte-identical, pinned in tests).

## Unit tests

- The stmtq22rtp `state_change` lottery landing reroutes: both arms bind `status`, are re-embedded with the canonical slot text, and compose with `CONFLICT_MENTION_FACT_SLOT` into the bitemporal margin doctrine.
- Every s02/s03/s10/s11 corpus transition span pinned verbatim as no-reroute under person AND asset subject types; person-subject with a calendar anchor never reroutes; unknown subject type never reroutes; direct path untouched; flag-off byte-identical (including `entityType` inertness).

## Live verification (worktree app on :3057, scratch SurrealDB, full dogfood flag set)

Full `pnpm eval:state-transitions` battery, fresh user each run:

| run | config | scenarios | checks | s07-serve | s03/s10/s11 | s02 |
|---|---|---|---|---|---|---|
| stmtqi40g4 | stand as-is | 8/12 | 21/25 | fail (one side) | pass | serve+belief pass, history fail (= baseline) |
| stmtqijarx | stand as-is | 7/12 | 20/25 | fail (one side) | pass | serve+belief pass, history fail (= baseline) |
| stmtqiundv | + `SYNTHESIZE_ANSWER_ROUTER_ENABLED=1` | 9/12 | 22/25 | **pass — names both sides** | pass | serve+belief pass, history fail (= baseline) |

s02-history fails in all three runs AND in the last four baseline runs on main (stmtq22rtp, stmtq1rxni, stmtpzc8gk, stmtpxw49e) — pre-existing, untouched by this change (no anchored `state_change`/`duration_limit` facts are involved in that scenario). The remaining variance (s05/s06/s08 serve abstentions) is baseline-class serving flakiness, orthogonal to the write side.

**Landing determinism, measured at the slot level.** In every run and in 8/8 cache-cold probe ingests of the two s07 conversations (traced with `x-brain-debug`), both lease arms land in the `status` slot; when both bind the office-lease entity the COMPETING pair forms every time:

```
office lease (asset) | status = "until December 2026"     | competing
office lease (asset) | status = "ends in September 2026"  | competing
```

Run 3's serve answer: *"The office lease ends in September 2026 [fact]. However, there is a conflicting statement that the lease is until December 2026 [fact]. Which one is correct?"*

## Findings (documented in the battery README + s07 note)

1. **Serve side requires the router.** Even with the pair perfectly formed, `detectEvidenceConflicts` returns `[]` when the contradiction lane is absent, and the lane set is empty without `SYNTHESIZE_ANSWER_ROUTER_ENABLED=1` — the T3 both-sides note never renders and serving names one side (runs 1/2, and every recent baseline run: the stand has never run with the router). With the router on, s07 passes end-to-end (run 3). Config fix, not code — now pinned in the battery README.
2. **Runs on one app boot are not independent.** Extraction memoises in an in-process LRU keyed on turn text: run 2 inherited run 1's extraction draws verbatim (0ms `ingest.nlu.extract` in the trace). Documented in the README; restart the app between runs that must sample the lottery.
3. **Residual entity-binding lottery (out of scope).** One cold draw (frozen across runs 1–2 by the cache) extracted the December claim as `(Sasha[staff], duration_limit)` with a junk `December 2026` entity — the lease entity was never emitted for that turn, so no slot logic can form the pair (canonicalization deliberately never crosses entities). The pre-existing `duration_limit → status` alias then rerouted it into Sasha's `status` slot, where the promoted single_active pool paired it with an unrelated `(Sasha, status, "work laptop")` fact. 8/8 fresh probes bound the office lease correctly, so the draw is rare; if it becomes a problem, extending the non-person guard to `duration_limit` is the natural next step — deliberately NOT done here to keep the live-proven duration_limit behaviour pinned.

## Gates

- `pnpm typecheck` clean
- `pnpm test:unit`: 360 suites, 4011 tests, all pass
- `pnpm format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
