### PR TITLE
feat(evidence): fragment-bearing processor outputs + representation embeddings

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1357,6 +1357,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       "External-ingest quarantine seam (migration 0121): registerAsset stamps evidence_asset.quarantineStatus ('clean' internal / 'quarantined' external_ingest) and scan transitions may run; the broker refuses non-clean assets. Off (default) = the field is NEVER written (rows byte-identical), quarantine transitions 503, and origin:'external_ingest' is rejected 503 — fail closed.",
   },
   {
+    key: 'EVIDENCE_FRAGMENT_EMBEDDINGS',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Representation embeddings: the ONE write seam (addRepresentation) embeds a representation\'s TEXT content when its writer asks for it and stores the vector plus its embeddingSpaceId in derived_representation — the producer the 0109 "WRITE-DEAD" embedding column has been waiting for, and therefore the fragment lane\'s dense leg (empty by construction while the column is null). The processing run caps how many outputs it asks to embed per run, so a many-output run cannot fan out unbounded model calls. Off (default) = the embedder is never called and neither key is written — byte-identical rows. An embedding failure is soft: the row lands without a vector and the run still succeeds.',
+  },
+  {
     key: 'EVIDENCE_DERIVED_MAX_BYTES',
     category: 'pipeline',
     defaultValue: '1048576',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1149,6 +1149,13 @@ const KNOWN_BOOLEAN_FLAGS = [
   // family sits off the ENGINE flag budget by design (see above).
   'EVIDENCE_PROCESSOR_BROKER',
   'EVIDENCE_QUARANTINE',
+  // Representation embeddings: the write-side producer for
+  // derived_representation.embedding (WRITE-DEAD since 0109), which is
+  // what the fragment lane's dense leg reads. Off (default) = the
+  // embedder is never called and neither embedding nor embeddingSpaceId
+  // is written — byte-identical rows. EVIDENCE_ family sits off the
+  // ENGINE flag budget by design (see above).
+  'EVIDENCE_FRAGMENT_EMBEDDINGS',
   // Raw-read gateway (MM-3, migration 0125): the single REST surface that
   // serves original evidence bytes (stream + signed-URL mint/redeem)
   // behind the full gate ladder. Default off = every route 404s,

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -269,6 +269,29 @@ export function evidenceSignedUrlTtlSeconds(): number {
 }
 
 /**
+ * Representation embeddings — EVIDENCE_FRAGMENT_EMBEDDINGS.
+ *
+ * When on, the ONE write seam (EvidenceStoreService.addRepresentation)
+ * embeds the TEXT content of a representation whose writer asked for it
+ * (`embedContent`) and stores the vector in
+ * `derived_representation.embedding` together with its
+ * `embeddingSpaceId` — the producer the 0109 column has been waiting
+ * for ("WRITE-DEAD in v1"), and therefore the fragment lane's dense leg,
+ * which degrades to empty by construction while the column is null.
+ *
+ * Off (default) ⇒ the embedder is NEVER called and NEITHER key is
+ * written — the row is byte-identical to today's. An embedding failure
+ * is soft: the row is written without the vector and the caller's
+ * processing run still succeeds (a model hiccup must not lose derived
+ * text). Read at call time (runtime-mutable); common layer per
+ * engine-gates S5.2. EVIDENCE_ family sits off the ENGINE flag budget by
+ * design (a substrate builder, not an engine fork).
+ */
+export function fragmentEmbeddingsEnabled(): boolean {
+  return envFlagEnabled(process.env.EVIDENCE_FRAGMENT_EMBEDDINGS);
+}
+
+/**
  * Strict serving — EVIDENCE_UNGROUNDED_SERVING_GATE.
  *
  * When on, a supported verdict batch-checks its cited facts' stored

--- a/src/evidence/evidence-store.service.ts
+++ b/src/evidence/evidence-store.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import {
   BadRequestException,
   ConflictException,
@@ -5,6 +6,7 @@ import {
   Injectable,
   Logger,
   NotFoundException,
+  Optional,
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { StringRecordId, type Surreal } from 'surrealdb';
@@ -15,10 +17,12 @@ import {
   queryFirst,
   queryRows,
 } from '../db/surreal.service';
+import { EmbedderService } from '../ai/embedder.service';
 import {
   evidenceMaxBytes,
   evidenceQuarantineEnabled,
   evidenceSubstrateEnabled,
+  fragmentEmbeddingsEnabled,
 } from '../common/evidence-flags';
 import {
   DERIVED_REPRESENTATION_KINDS,
@@ -47,6 +51,12 @@ const REPR_KINDS = new Set<string>(DERIVED_REPRESENTATION_KINDS);
 export const EVIDENCE_GRANT_OWNER_KINDS = ['user', 'pack', 'system'] as const;
 export type EvidenceGrantOwnerKind = (typeof EVIDENCE_GRANT_OWNER_KINDS)[number];
 const GRANT_OWNER_KINDS = new Set<string>(EVIDENCE_GRANT_OWNER_KINDS);
+/** Leading window of representation content handed to the embedder. A
+ *  derived representation may legitimately be a megabyte of extracted
+ *  document text (EVIDENCE_DERIVED_MAX_BYTES), which no embedding model
+ *  accepts — and the leading window is what one retrieval vector can
+ *  represent anyway. */
+const EMBED_TEXT_MAX_CHARS = 8000;
 
 export type { DerivedRepresentationKind, EvidenceModality } from '../common/evidence-taxonomy';
 
@@ -80,6 +90,23 @@ export interface AddFragmentInput {
   locator: Record<string, unknown>;
   label?: string | undefined;
   piiClasses?: string[] | undefined;
+  /** Canonical identity of the located span (locatorDedupKey). Present ⇒
+   *  the fragment takes a DETERMINISTIC record id and the write is
+   *  INSERT IGNORE, so a re-run over the same span reuses the row
+   *  instead of multiplying citation targets. See addFragment. */
+  dedupKey?: string | undefined;
+  /**
+   * Take the parent ASSET's media classification when `piiClasses` is
+   * not given — for fragments that no classifier ever looked at on their
+   * own (processor outputs). CONSERVATIVE in every state: an
+   * unclassified asset yields an unclassified (fail-closed, unservable)
+   * fragment, a classified one propagates its classes, and only an
+   * affirmatively-clean `[]` asset yields a fragment the media-PII fence
+   * opens. A derived span is never cleaner than the asset it came from.
+   * Absent/false ⇒ today's behaviour (no classification unless the
+   * caller asserts one).
+   */
+  inheritAssetPii?: boolean | undefined;
 }
 
 export interface AddGrantInput {
@@ -110,6 +137,12 @@ export interface AddRepresentationInput {
   producerVersion: string;
   /** Lineage back to the processing_run that produced this row (0121). */
   producedByRun?: string | undefined;
+  /** Ask the seam to embed this row's TEXT content and store the vector
+   *  (EVIDENCE_FRAGMENT_EMBEDDINGS). The WRITER decides which rows are
+   *  worth a model call — it owns the per-run budget; the flag decides
+   *  whether any call happens at all. Off/absent ⇒ neither `embedding`
+   *  nor `embeddingSpaceId` is written. */
+  embedContent?: boolean | undefined;
 }
 
 /**
@@ -132,6 +165,11 @@ export class EvidenceStoreService {
     private readonly surreal: SurrealService,
     @Inject(EVIDENCE_STORAGE_ADAPTERS)
     private readonly adapters: EvidenceStorageRegistry,
+    /** Dense-leg producer for derived_representation.embedding.
+     *  @Optional (the module-doc idiom): positionally-constructed unit
+     *  fixtures stay valid and the write path degrades to today's
+     *  vector-less rows when no embedder is wired. */
+    @Optional() private readonly embedder?: EmbedderService,
   ) {}
 
   private gate(): void {
@@ -406,13 +444,39 @@ export class EvidenceStoreService {
     throw new BadRequestException('an asset needs storageRef or originUri');
   }
 
-  /** Add a citation-target fragment to an existing asset. */
-  async addFragment(companyId: string, input: AddFragmentInput): Promise<{ fragmentId: string }> {
+  /**
+   * Add a citation-target fragment to an existing asset.
+   *
+   * DEDUP (`dedupKey` — the processor-output path): when present the row
+   * takes a DETERMINISTIC record id, sha256(assetTail | dedupKey), and
+   * the write is INSERT IGNORE — the #92 processing_run idiom:
+   * primary-key-addressed, so re-running a processor over the same span
+   * REUSES the fragment instead of multiplying citation targets, with no
+   * SELECT-then-CREATE race and no compound index (0109 header: locator
+   * is FLEXIBLE and this table sits on two delete paths, so dedup
+   * belongs to the write seam, not the planner's key comparison).
+   *
+   * The key is the LOCATOR's identity, NOT the processor's: the same
+   * region found by OCR v1 and v2 is the same region of the world, so
+   * both generations' representations hang off the ONE fragment and the
+   * supersede pass pairs them. Without a dedupKey the row keeps its
+   * random id and today's CREATE — the caller-driven ingest path is
+   * untouched.
+   */
+  async addFragment(
+    companyId: string,
+    input: AddFragmentInput,
+  ): Promise<{ fragmentId: string; created: boolean }> {
     this.gate();
     return this.surreal.withCompany(companyId, async (db) => {
-      const asset = await queryFirst<{ id: unknown; modality: string; availability: string }>(
+      const asset = await queryFirst<{
+        id: unknown;
+        modality: string;
+        availability: string;
+        piiClasses?: string[];
+      }>(
         db,
-        `SELECT id, modality, availability
+        `SELECT id, modality, availability, piiClasses
            FROM type::record('evidence_asset', $tail) LIMIT 1`,
         { tail: idTailOf(input.assetId) },
       );
@@ -427,14 +491,50 @@ export class EvidenceStoreService {
         input.label !== undefined
           ? redactPiiWithReport(input.label).text.slice(0, LABEL_MAX)
           : undefined;
+      const piiClasses =
+        input.piiClasses ?? (input.inheritAssetPii === true ? asset.piiClasses : undefined);
+      if (input.dedupKey !== undefined) {
+        return this.insertDedupedFragment(db, asset.id, { ...input, label, piiClasses });
+      }
       const row = await dbCreate<Record<string, unknown>>(db, 'evidence_fragment', {
         assetId: asset.id,
         locator: input.locator,
         label,
-        piiClasses: input.piiClasses,
+        piiClasses,
       });
-      return { fragmentId: String(row.id) };
+      return { fragmentId: String(row.id), created: true };
     });
+  }
+
+  /**
+   * Deterministic-id INSERT IGNORE leg of addFragment (see its doc).
+   * Keys are OMITTED rather than undefined-valued: an INSERT row is
+   * serialized verbatim, unlike the CONTENT path's dbCreate.
+   */
+  private async insertDedupedFragment(
+    db: Surreal,
+    assetId: unknown,
+    frag: AddFragmentInput & { label?: string | undefined },
+  ): Promise<{ fragmentId: string; created: boolean }> {
+    const tail = createHash('sha256')
+      .update(`asset=${idTailOf(String(assetId))}|loc=${String(frag.dedupKey)}`)
+      .digest('hex')
+      .slice(0, 32);
+    const fragmentId = `evidence_fragment:${tail}`;
+    const inserted = await queryRows<{ id: unknown }>(
+      db,
+      `INSERT IGNORE INTO evidence_fragment $row`,
+      {
+        row: {
+          id: new StringRecordId(fragmentId),
+          assetId,
+          locator: frag.locator,
+          ...(frag.label !== undefined ? { label: frag.label } : {}),
+          ...(frag.piiClasses !== undefined ? { piiClasses: frag.piiClasses } : {}),
+        },
+      },
+    );
+    return { fragmentId, created: inserted.length > 0 };
   }
 
   /** Add one derived representation to an asset or fragment. */
@@ -472,6 +572,7 @@ export class EvidenceStoreService {
       if (subject.availability === 'gone') {
         throw new ConflictException(`subject ${input.subjectId} belongs to unavailable evidence`);
       }
+      const dense = await this.embeddingFor(input);
       const row = await dbCreate<Record<string, unknown>>(db, 'derived_representation', {
         subjectId: subject.id,
         subjectKind: input.subjectKind,
@@ -487,9 +588,39 @@ export class EvidenceStoreService {
         ...(input.producedByRun !== undefined
           ? { producedByRun: new StringRecordId(input.producedByRun) }
           : {}),
+        ...dense,
       });
       return { representationId: String(row.id) };
     });
+  }
+
+  /**
+   * The dense-leg producer for derived_representation.embedding
+   * (EVIDENCE_FRAGMENT_EMBEDDINGS) — the column 0109 defined WRITE-DEAD
+   * and the fragment lane's dense leg reads. Returns the EXTRA ROW KEYS:
+   * `{}` when the flag is off, the writer did not ask, the row carries
+   * no non-blank text, no embedder is wired, or the model call failed —
+   * so the off-state row is byte-identical. Vector and space id are
+   * written TOGETHER or not at all (the 0101 idiom: a vector whose space
+   * is unknown cannot be compared to anything).
+   *
+   * SOFT-FAIL by design: derived text is the durable artefact and the
+   * vector is a recomputable index over it, so an embedder hiccup costs
+   * the vector — never the row, and never the processing run that wrote
+   * it. The flag is checked FIRST: off means the embedder is not so much
+   * as touched.
+   */
+  private async embeddingFor(input: AddRepresentationInput): Promise<Record<string, unknown>> {
+    if (input.embedContent !== true || !fragmentEmbeddingsEnabled()) return {};
+    const content = input.content ?? '';
+    if (content.trim() === '' || !this.embedder) return {};
+    try {
+      const embedding = await this.embedder.embed(content.slice(0, EMBED_TEXT_MAX_CHARS));
+      return { embedding, embeddingSpaceId: this.embedder.activeSpaceId() };
+    } catch (e) {
+      this.logger.warn(`representation embedding skipped: ${(e as Error).message}`);
+      return {};
+    }
   }
 
   /** Read one asset row (tests + future PRs). */

--- a/src/evidence/locator.ts
+++ b/src/evidence/locator.ts
@@ -114,6 +114,30 @@ const LOCATOR_FIELDS = new Map<string, ReadonlySet<string>>([
 ]);
 
 /**
+ * Canonical identity string of a locator — the fragment write seam's
+ * dedup key (0109: "dedup belongs to the write seam, not the planner's
+ * key comparison" — locator is a FLEXIBLE object, and a UNIQUE
+ * (assetId, locator) index would put assetId under the 3.2.4 compound-
+ * planner DELETE no-op on a table that sits on two delete paths).
+ *
+ * Shape follows the #386 fingerprint idiom already used for processing
+ * runs: a `|`-joined `key=value` string, NOT JSON — key order is fixed
+ * by SORTING so two objects describing the same span produce the same
+ * key whatever order their fields were built in. Numbers ride through
+ * String() (the same span always yields the same literal because
+ * locators are validated ints, plus pageRegion's [0,1] floats which the
+ * caller reproduces bit-for-bit on a re-run of the same processor).
+ *
+ * Pure: no validation, no I/O. Callers validate first (validateLocator).
+ */
+export function locatorDedupKey(locator: Record<string, unknown>): string {
+  return Object.keys(locator)
+    .sort()
+    .map((k) => `${k}=${String(locator[k])}`)
+    .join('|');
+}
+
+/**
  * Validate a locator against the parent asset's modality. Returns a
  * human-readable error string, or null when valid (the
  * evidenceValidationError idiom — no exceptions from a pure checker).

--- a/src/evidence/processing/processing-run.service.ts
+++ b/src/evidence/processing/processing-run.service.ts
@@ -5,6 +5,7 @@ import { evidenceDerivedMaxBytes } from '../../common/evidence-flags';
 import type { DerivedRepresentationKind } from '../../common/evidence-taxonomy';
 import { idTailOf, redactPiiWithReport } from '../../ingest/ingest-utils';
 import { EvidenceStoreService } from '../evidence-store.service';
+import { locatorDedupKey } from '../locator';
 import {
   EVIDENCE_STORAGE_ADAPTERS,
   type EvidenceStorageRegistry,
@@ -13,6 +14,24 @@ import type { ProcessorAdapter, ProcessorInput, ProcessorOutput } from './proces
 import { processingRunIdTail, processorConfigFingerprint } from './processor-fingerprint';
 
 const ERROR_MAX = 500;
+/**
+ * How many text-bearing outputs of ONE run may ask the write seam for an
+ * embedding. A region-wise OCR pass over a 400-page PDF legitimately
+ * emits thousands of outputs; without a cap a single dispatch would fan
+ * out thousands of model calls. The first 32 are the ones a retrieval
+ * vector buys anything for (the lane renders 4 lines), the rest land as
+ * text-only rows that the BM25 leg still serves — and a later run under
+ * a bumped version re-offers them. Deliberately NOT an env knob until
+ * the dense leg is measured (the FRAGMENT_LANE_TOP_K precedent).
+ */
+const EMBED_OUTPUTS_PER_RUN_MAX = 32;
+
+/** Subjects a run's outputs were attached to, plus the written rows. */
+interface WriteOutcome {
+  representationIds: string[];
+  /** Distinct record ids (asset + any fragments) — the supersede scope. */
+  subjectIds: unknown[];
+}
 
 export interface ExecuteRunOpts {
   /** The loaded evidence_asset row's record id (RecordId, not string). */
@@ -85,9 +104,14 @@ export class ProcessingRunService {
       return { runId, capability: adapter.capability, status: 'failed', representationIds: [] };
     }
     try {
-      const representationIds = await this.writeOutputs(companyId, { runId, opts, outputs });
-      await this.completeRun(companyId, { runId, opts, representationIds });
-      return { runId, capability: adapter.capability, status: 'succeeded', representationIds };
+      const written = await this.writeOutputs(companyId, { runId, opts, outputs });
+      await this.completeRun(companyId, { runId, opts, written });
+      return {
+        runId,
+        capability: adapter.capability,
+        status: 'succeeded',
+        representationIds: written.representationIds,
+      };
     } catch (e) {
       await this.failRun(companyId, runId, e);
       return { runId, capability: adapter.capability, status: 'failed', representationIds: [] };
@@ -169,38 +193,102 @@ export class ProcessingRunService {
     }
   }
 
-  /** Write outputs through the ONE write seam, with lineage. */
+  /**
+   * Write outputs through the ONE write seam, with lineage.
+   *
+   * FRAGMENT-BEARING (the point of this pass): a locator-bearing output
+   * is anchored to the evidence_fragment for its span and stored with
+   * `subjectKind: 'fragment'` — the ONLY shape the serving fragment lane
+   * can return, since that lane filters `subjectKind = 'fragment'`. A
+   * locator-less output keeps today's asset-level row, byte-identical:
+   * an adapter that describes the whole asset says so by emitting no
+   * locator, and nothing about its rows changes.
+   *
+   * EMBEDDINGS: text-bearing outputs ask the seam for a vector, capped
+   * at EMBED_OUTPUTS_PER_RUN_MAX per run (the seam decides whether any
+   * model call actually happens — EVIDENCE_FRAGMENT_EMBEDDINGS). The
+   * budget lives HERE because a run is the unit that can fan out.
+   */
   private async writeOutputs(
     companyId: string,
     write: { runId: string; opts: ExecuteRunOpts; outputs: ProcessorOutput[] },
-  ): Promise<string[]> {
+  ): Promise<WriteOutcome> {
     const representationIds: string[] = [];
+    // The asset is ALWAYS a supersede subject (see completeRun) — a run
+    // that moves from asset-level to fragment-level outputs must still
+    // retire the generation it replaces.
+    const subjects = new Map<string, unknown>([
+      [String(write.opts.assetRecordId), write.opts.assetRecordId],
+    ]);
+    let embedBudget = EMBED_OUTPUTS_PER_RUN_MAX;
     for (const output of write.outputs) {
+      const subject = await this.subjectFor(companyId, write.opts, output);
+      if (subject.kind === 'fragment') subjects.set(subject.id, new StringRecordId(subject.id));
+      const embedContent = (output.content ?? '').trim() !== '' && embedBudget > 0;
+      if (embedContent) embedBudget--;
       const { representationId } = await this.store.addRepresentation(companyId, {
-        subjectId: String(write.opts.assetRecordId),
-        subjectKind: 'asset',
+        subjectId: subject.id,
+        subjectKind: subject.kind,
         kind: output.kind,
         content: output.content,
         confidence: output.confidence,
         lang: output.lang,
         producerVersion: write.opts.adapter.version,
         producedByRun: write.runId,
+        embedContent,
       });
       representationIds.push(representationId);
     }
-    return representationIds;
+    return { representationIds, subjectIds: [...subjects.values()] };
+  }
+
+  /**
+   * The subject one output hangs off. A locator names a sub-asset span,
+   * so the fragment for it is created ONCE and reused on every re-run:
+   * the dedup key is the LOCATOR's identity (not the processor's), so a
+   * bumped adapter version re-detecting the same region attaches its new
+   * representation to the SAME citation target instead of forking a
+   * second one. The fragment inherits the asset's media classification
+   * — a processor is not a PII classifier, and a derived span is never
+   * cleaner than the asset it came from.
+   */
+  private async subjectFor(
+    companyId: string,
+    opts: ExecuteRunOpts,
+    output: ProcessorOutput,
+  ): Promise<{ id: string; kind: 'asset' | 'fragment' }> {
+    const assetId = String(opts.assetRecordId);
+    if (output.locator === undefined) return { id: assetId, kind: 'asset' };
+    const locator = { ...output.locator } as Record<string, unknown>;
+    const { fragmentId } = await this.store.addFragment(companyId, {
+      assetId,
+      locator,
+      label: output.label,
+      dedupKey: locatorDedupKey(locator),
+      inheritAssetPii: true,
+    });
+    return { id: fragmentId, kind: 'fragment' };
   }
 
   /**
    * Mark the run succeeded, then the supersede pass — two-step
    * SELECT-ids → UPDATE $ids (the LET→DELETE id-resolution discipline;
    * 3.2.4 planner class):
-   *   * old representations of this (asset, kind) generation point at the
-   *     new run's FIRST output of that kind (0059 supersededBy precedent;
-   *     one-to-many pairing documented here: ALL old rows point at that
-   *     one replacement). Skipped when the run produced no outputs —
-   *     there is nothing to point at, and the old generation stays
-   *     current.
+   *   * old representations of this (subject, kind) generation point at
+   *     the new run's FIRST output of that kind (0059 supersededBy
+   *     precedent; one-to-many pairing documented here: ALL old rows
+   *     point at that one replacement). Skipped when the run produced no
+   *     outputs — there is nothing to point at, and the old generation
+   *     stays current. The SUBJECT SET is the asset plus every fragment
+   *     this run attached to (`subjectId INSIDE`, the
+   *     purgeRepresentationBatches shape): a locator-less run has the
+   *     asset alone and behaves exactly as before, while a fragment-
+   *     bearing one retires both the asset-level generation it replaces
+   *     and the previous generation on each span it re-detected. A
+   *     fragment whose span the new generation NO LONGER finds keeps its
+   *     old representation — there is no replacement to point it at, and
+   *     inventing one would attach another span's text to it; it dies
+   *     with its asset, or is retired when a later run re-detects it.
    *   * old succeeded runs of the same (asset, capability) flip to
    *     'superseded'.
    * Reprocessing NEVER deletes representations — GC owns removal
@@ -210,11 +298,11 @@ export class ProcessingRunService {
    */
   private async completeRun(
     companyId: string,
-    done: { runId: string; opts: ExecuteRunOpts; representationIds: string[] },
+    done: { runId: string; opts: ExecuteRunOpts; written: WriteOutcome },
   ): Promise<void> {
     const capability = done.opts.adapter.capability;
     const runRef = new StringRecordId(done.runId);
-    const outputRefs = done.representationIds.map((rid) => new StringRecordId(rid));
+    const outputRefs = done.written.representationIds.map((rid) => new StringRecordId(rid));
     await this.surreal.withCompany(companyId, async (db) => {
       await db.query(
         `UPDATE $id SET status = 'succeeded', finishedAt = time::now(), outputs = $outputs`,
@@ -226,9 +314,9 @@ export class ProcessingRunService {
         const oldReprIds = await queryRows<unknown>(
           db,
           `SELECT VALUE id FROM derived_representation
-            WHERE subjectId = $asset AND kind = $cap
+            WHERE subjectId INSIDE $subjects AND kind = $cap
               AND supersededBy IS NONE AND id NOT IN $newIds`,
-          { asset: done.opts.assetRecordId, cap: capability, newIds: outputRefs },
+          { subjects: done.written.subjectIds, cap: capability, newIds: outputRefs },
         );
         if (oldReprIds.length > 0) {
           await db.query(`UPDATE $ids SET supersededBy = $winner`, {

--- a/src/evidence/processing/processor-adapter.ts
+++ b/src/evidence/processing/processor-adapter.ts
@@ -1,5 +1,6 @@
 import type { Readable } from 'node:stream';
 import type { DerivedRepresentationKind, EvidenceModality } from '../../common/evidence-taxonomy';
+import type { FragmentLocator } from '../locator';
 
 /**
  * ProcessorAdapter — the platform-side contract of the trusted processor
@@ -42,6 +43,26 @@ export interface ProcessorOutput {
   content?: string | undefined;
   confidence?: number | undefined;
   lang?: string | undefined;
+  /**
+   * WHERE IN THE ASSET this output describes — a page region, a time
+   * range, a char span (the 0109 FragmentLocator union, validated
+   * against the asset's modality at the write seam).
+   *
+   * Present ⇒ writeOutputs creates (or REUSES, by locator identity) the
+   * evidence_fragment for that span FIRST and attaches the
+   * representation to it (`subjectKind: 'fragment'`). That is the ONLY
+   * shape the serving fragment lane can return — the lane filters
+   * `subjectKind = 'fragment'`, so an asset-level row is invisible to
+   * retrieval however good the adapter is.
+   *
+   * Absent ⇒ today's asset-level row, byte-identical: an adapter that
+   * genuinely describes the WHOLE asset (the text passthrough) states
+   * that by emitting no locator, and its rows are unchanged.
+   */
+  locator?: FragmentLocator | undefined;
+  /** Human label for the fragment a `locator` creates (redacted +
+   *  capped at the write seam). Ignored without a locator. */
+  label?: string | undefined;
 }
 
 export interface ProcessorAdapter {

--- a/test/evidence-locator.unit-spec.ts
+++ b/test/evidence-locator.unit-spec.ts
@@ -2,8 +2,10 @@
  * validateLocator (0109): the kind × modality cross-check matrix, the
  * per-kind shape checks, the image ⇒ page-0 rule, and the unknown-kind
  * hard error (a FLEXIBLE column must never store an unvalidated shape).
+ * Plus locatorDedupKey — the canonical span identity the fragment write
+ * seam hashes into a deterministic record id.
  */
-import { validateLocator } from '../src/evidence/locator';
+import { locatorDedupKey, validateLocator } from '../src/evidence/locator';
 
 const charRange = { kind: 'charRange', start: 0, end: 10 };
 const pageRegion = { kind: 'pageRegion', page: 0, x: 0.1, y: 0.1, w: 0.5, h: 0.5 };
@@ -92,5 +94,26 @@ describe('validateLocator — shapes and edges', () => {
     expect(validateLocator('image', { ...pageRegion, executable: 'nope' })).toMatch(
       /unknown field 'executable'/,
     );
+  });
+});
+
+describe("locatorDedupKey — the fragment write seam's dedup identity", () => {
+  it('is field-order independent (two builders, one span, one key)', () => {
+    const a = { kind: 'pageRegion', page: 2, x: 0.1, y: 0.2, w: 0.3, h: 0.4 };
+    const b = { h: 0.4, w: 0.3, y: 0.2, x: 0.1, page: 2, kind: 'pageRegion' };
+    expect(locatorDedupKey(a)).toBe(locatorDedupKey(b));
+  });
+
+  it('separates different spans, kinds, and pages', () => {
+    const key = locatorDedupKey;
+    expect(key(charRange)).not.toBe(key({ ...charRange, end: 11 }));
+    expect(key(pageRegion)).not.toBe(key({ ...pageRegion, page: 1 }));
+    expect(key(timeRange)).not.toBe(key(frameRange));
+    expect(key(track)).not.toBe(key({ ...track, startMs: 0 }));
+  });
+
+  it('is stable across calls — the key IS the fragment id input', () => {
+    expect(locatorDedupKey(timeRange)).toBe(locatorDedupKey({ ...timeRange }));
+    expect(locatorDedupKey(charRange)).toBe('end=10|kind=charRange|start=0');
   });
 });

--- a/test/evidence-processing.e2e-spec.ts
+++ b/test/evidence-processing.e2e-spec.ts
@@ -21,6 +21,8 @@ import { EvidenceQuarantineService } from '../src/evidence/quarantine.service';
 import { TextExtractionPassthroughAdapter } from '../src/evidence/processing/adapters/text-extraction-passthrough.adapter';
 import type { EvidenceScanHook } from '../src/evidence/processing/scan-hook';
 import { FsEvidenceStorageAdapter } from '../src/evidence/storage/fs-storage.adapter';
+import { FragmentLaneService } from '../src/synthesize/fragment-lane.service';
+import type { ProcessorInput, ProcessorOutput } from '../src/evidence/processing/processor-adapter';
 
 const COMPANY = 'co_evidence_processing_e2e';
 const USER = 'processing_user';
@@ -65,6 +67,7 @@ describe('evidence processing lifecycle (e2e)', () => {
       'EVIDENCE_PROCESSOR_BROKER',
       'EVIDENCE_QUARANTINE',
       'EVIDENCE_DERIVED_MAX_BYTES',
+      'EVIDENCE_FRAGMENT_EMBEDDINGS',
       'EVIDENCE_FS_ROOT',
     ]) {
       saved[k] = process.env[k];
@@ -311,6 +314,133 @@ describe('evidence processing lifecycle (e2e)', () => {
     });
     expect(stale.runs).toHaveLength(0);
     expect(stale.denied[0]!.reason).toContain('modality consent');
+  });
+
+  /**
+   * THE POINT OF THE FRAGMENT-BEARING PASS: a processed asset's output
+   * must be RETURNABLE. The serving lane filters
+   * `subjectKind = 'fragment'`, so an asset-level row — everything the
+   * broker used to write — is invisible to retrieval no matter how good
+   * the adapter is. Here a locator-bearing output is dispatched for
+   * real and then read back through FragmentLaneService itself (the
+   * lane's own fence stack: consent, user, media PII, availability),
+   * with the asset-level generation pinned as still unreachable.
+   */
+  it('a locator-bearing output becomes a fragment the serving lane returns', async () => {
+    const textAdapter = f.app.get(TextExtractionPassthroughAdapter) as {
+      version: string;
+      process: (input: ProcessorInput) => Promise<ProcessorOutput[]>;
+    };
+    const originalVersion = textAdapter.version;
+    const originalProcess = textAdapter.process;
+    const FRAGMENT_TEXT = 'the boiler room key hangs under the third stair';
+    try {
+      textAdapter.version = 'text-locator-v1-test';
+      textAdapter.process = () =>
+        Promise.resolve([
+          {
+            kind: 'text',
+            content: FRAGMENT_TEXT,
+            locator: { kind: 'charRange', start: 0, end: FRAGMENT_TEXT.length },
+            label: 'page 1, line 3',
+          },
+        ]);
+      // Affirmatively-clean asset: the fragment inherits [] and the
+      // lane's fail-closed media fence opens for an unscoped caller.
+      const asset = await registerTextAsset(FRAGMENT_TEXT, { piiClasses: [] });
+      expect(await countRows('evidence_fragment')).toBe(0);
+
+      const run = await broker.dispatchForPack(COMPANY, {
+        packId: 'proc_lifecycle',
+        assetId: asset.assetId,
+      });
+      expect(run.runs[0]).toMatchObject({ status: 'succeeded' });
+      const reprId = run.runs[0]!.representationIds[0]!;
+      const repr = await rawRow(reprId);
+      expect(repr.subjectKind).toBe('fragment');
+      const fragmentId = String(repr.subjectId);
+      expect(fragmentId.startsWith('evidence_fragment:')).toBe(true);
+      const fragment = await rawRow(fragmentId);
+      expect(fragment.piiClasses).toEqual([]);
+      expect(fragment.locator).toMatchObject({ kind: 'charRange', start: 0 });
+      expect(await countRows('evidence_fragment')).toBe(1);
+
+      // Idempotency: a replayed dispatch multiplies nothing.
+      const replay = await broker.dispatchForPack(COMPANY, {
+        packId: 'proc_lifecycle',
+        assetId: asset.assetId,
+      });
+      expect(replay.runs[0]).toMatchObject({ status: 'replayed' });
+      expect(await countRows('evidence_fragment')).toBe(1);
+
+      // THE READ. Dense leg stubbed to fail (no model call in e2e) — the
+      // lane degrades to its BM25 leg over the 0124 index, which is
+      // exactly the shape that could never see a processor output before.
+      const lane = f.app.get(FragmentLaneService);
+      (lane as unknown as { embedder: { embed: () => Promise<number[]> } }).embedder = {
+        embed: () => Promise.reject(new Error('dense leg stubbed off in e2e')),
+      };
+      const served = await lane.fragmentLines({
+        companyId: COMPANY,
+        query: 'boiler room key third stair',
+        callerScopes: ['brain:read'],
+        userId: USER,
+        withIds: true,
+      });
+      expect(served.lines).toHaveLength(1);
+      expect(served.lines[0]).toContain(FRAGMENT_TEXT);
+      expect(served.lines[0]).toContain(`[${fragmentId}]`);
+      expect(served.byId.get(fragmentId)).toMatchObject({ assetId: asset.assetId });
+
+      // CONTROL: the asset-level generation stays unreachable — the
+      // break this pass fixes, pinned from the serving side.
+      const assetLevel = await lane.fragmentLines({
+        companyId: COMPANY,
+        query: 'hello evidence',
+        callerScopes: ['brain:read'],
+        userId: USER,
+        withIds: false,
+      });
+      expect(assetLevel.lines).toEqual([]);
+    } finally {
+      textAdapter.version = originalVersion;
+      textAdapter.process = originalProcess;
+    }
+  });
+
+  /**
+   * The dense leg's missing producer (EVIDENCE_FRAGMENT_EMBEDDINGS):
+   * with the flag on, the vector and its space id land in the columns
+   * 0109 defined WRITE-DEAD. Stubbed embedder — no paid call.
+   */
+  it('stores a representation embedding when the flag is on', async () => {
+    const textAdapter = f.app.get(TextExtractionPassthroughAdapter) as { version: string };
+    const originalVersion = textAdapter.version;
+    const storeWithEmbedder = store as unknown as { embedder?: unknown };
+    const originalEmbedder = storeWithEmbedder.embedder;
+    try {
+      process.env.EVIDENCE_FRAGMENT_EMBEDDINGS = '1';
+      textAdapter.version = 'text-embedding-v1-test';
+      storeWithEmbedder.embedder = {
+        embed: () => Promise.resolve([0.25, -0.5, 0.75]),
+        activeSpaceId: () => 'stub:e2e-embedder:3:l2',
+      };
+      const asset = await registerTextAsset('the fuse box lives behind the pantry door', {
+        piiClasses: [],
+      });
+      const run = await broker.dispatchForPack(COMPANY, {
+        packId: 'proc_lifecycle',
+        assetId: asset.assetId,
+      });
+      expect(run.runs[0]).toMatchObject({ status: 'succeeded' });
+      const repr = await rawRow(run.runs[0]!.representationIds[0]!);
+      expect(repr.embedding).toEqual([0.25, -0.5, 0.75]);
+      expect(repr.embeddingSpaceId).toBe('stub:e2e-embedder:3:l2');
+    } finally {
+      delete process.env.EVIDENCE_FRAGMENT_EMBEDDINGS;
+      textAdapter.version = originalVersion;
+      storeWithEmbedder.embedder = originalEmbedder;
+    }
   });
 
   it('user forget cascades processing runs with the evidence rows and drains the blob outbox', async () => {

--- a/test/processing-run-outputs.unit-spec.ts
+++ b/test/processing-run-outputs.unit-spec.ts
@@ -1,0 +1,393 @@
+/**
+ * Fragment-bearing processor outputs + representation embeddings —
+ * unit coverage of the two seams this PR fixes, over a scripted Surreal
+ * double and the REAL EvidenceStoreService (the write shape is the thing
+ * under test, so stubbing the seam would test nothing).
+ *
+ * THE BREAK. Processor runs wrote every derived_representation with
+ * `subjectKind: 'asset'`, while the only serving lane
+ * (FragmentLaneService) filters `subjectKind = 'fragment'` — so a
+ * perfect OCR adapter produced rows retrieval could never return. And
+ * `derived_representation.embedding` had no producer at all, so the
+ * lane's dense leg was empty by construction.
+ *
+ * Pins here:
+ *   - locator-less output stays asset-level, byte-identical (the row
+ *     written is key-for-key what it was before this PR);
+ *   - locator-bearing output creates the fragment FIRST and attaches the
+ *     representation to it (subjectKind 'fragment');
+ *   - the fragment is deduped by LOCATOR identity: the same span twice
+ *     in one run, and a re-run under a bumped processor version, reuse
+ *     the one deterministic record id;
+ *   - EVIDENCE_FRAGMENT_EMBEDDINGS off ⇒ the embedder is never touched
+ *     (pinned with a throwing stub) and neither vector key is written;
+ *     on ⇒ vector + embeddingSpaceId land; an embed failure is soft (the
+ *     row is written, the run still succeeds);
+ *   - the per-run embed budget caps fan-out.
+ */
+import { StringRecordId } from 'surrealdb';
+import { EvidenceStoreService } from '../src/evidence/evidence-store.service';
+import { ProcessingRunService } from '../src/evidence/processing/processing-run.service';
+import type {
+  ProcessorAdapter,
+  ProcessorOutput,
+} from '../src/evidence/processing/processor-adapter';
+import type { EmbedderService } from '../src/ai/embedder.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { EvidenceStorageRegistry } from '../src/evidence/storage/storage-adapter';
+
+const COMPANY = 'co_proc_unit';
+const ASSET = 'evidence_asset:a1';
+
+interface Call {
+  sql: string;
+  params: Record<string, unknown> | undefined;
+}
+
+/**
+ * Scripted Surreal double: routes by query text, records every call and
+ * every CREATE payload. `insertedFragments` tracks deterministic ids so a
+ * second INSERT IGNORE over the same id reports the collision (empty
+ * result) exactly as SurrealDB would.
+ */
+function surrealOf(opts: { assetPiiClasses?: string[] | undefined } = {}) {
+  const calls: Call[] = [];
+  const creates: Array<{ table: string; content: Record<string, unknown> }> = [];
+  const insertedFragmentIds = new Set<string>();
+  let seq = 0;
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      calls.push({ sql, params });
+      if (sql.includes('INSERT IGNORE INTO processing_run')) return [[{ id: 'processing_run:r' }]];
+      if (sql.includes('INSERT IGNORE INTO evidence_fragment')) {
+        const row = (params?.row ?? {}) as { id: unknown };
+        const id = String(row.id);
+        if (insertedFragmentIds.has(id)) return [[]];
+        insertedFragmentIds.add(id);
+        return [[{ id }]];
+      }
+      if (sql.includes("type::record('evidence_asset'")) {
+        return [
+          [
+            {
+              id: ASSET,
+              modality: 'document',
+              availability: 'hot',
+              ...(opts.assetPiiClasses !== undefined ? { piiClasses: opts.assetPiiClasses } : {}),
+            },
+          ],
+        ];
+      }
+      if (sql.includes("type::record('evidence_fragment'")) {
+        return [[{ id: `evidence_fragment:${String(params?.tail)}`, availability: 'hot' }]];
+      }
+      if (sql.includes('CREATE type::table($t) CONTENT $d')) {
+        const table = String(params?.t);
+        const content = (params?.d ?? {}) as Record<string, unknown>;
+        creates.push({ table, content });
+        seq += 1;
+        return [[{ ...content, id: `${table}:c${seq}` }]];
+      }
+      return [[]];
+    },
+  };
+  const surreal = {
+    withCompany: async (_companyId: string, fn: (d: typeof db) => Promise<unknown>) => fn(db),
+  } as unknown as SurrealService;
+  return { surreal, calls, creates, insertedFragmentIds };
+}
+
+const adapterOf = (outputs: ProcessorOutput[], version = 'proc-v1'): ProcessorAdapter => ({
+  capability: 'text',
+  version,
+  configParts: () => [],
+  accepts: () => true,
+  process: () => Promise.resolve(outputs),
+});
+
+const embedderThrowing = {
+  embed: () => {
+    throw new Error('the embedder must not be called');
+  },
+  activeSpaceId: () => {
+    throw new Error('the embedder must not be called');
+  },
+} as unknown as EmbedderService;
+
+const embedderOk = {
+  embed: async (text: string) => [text.length, 0.5],
+  activeSpaceId: () => 'openai:text-embedding-3-small:1536:l2',
+} as unknown as EmbedderService;
+
+const embedderBroken = {
+  embed: async () => {
+    throw new Error('model 503');
+  },
+  activeSpaceId: () => 'openai:text-embedding-3-small:1536:l2',
+} as unknown as EmbedderService;
+
+function runnerOf(
+  surreal: SurrealService,
+  embedder: EmbedderService | undefined,
+): ProcessingRunService {
+  const registry = new Map() as unknown as EvidenceStorageRegistry;
+  const store = new EvidenceStoreService(surreal, registry, embedder);
+  return new ProcessingRunService(surreal, store, registry);
+}
+
+const CHAR_SPAN = { kind: 'charRange', start: 0, end: 11 } as const;
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeAll(() => {
+  for (const k of ['EVIDENCE_SUBSTRATE_ENABLED', 'EVIDENCE_FRAGMENT_EMBEDDINGS']) {
+    savedEnv[k] = process.env[k];
+  }
+  process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+  delete process.env.EVIDENCE_FRAGMENT_EMBEDDINGS;
+});
+
+afterAll(() => {
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+afterEach(() => {
+  delete process.env.EVIDENCE_FRAGMENT_EMBEDDINGS;
+});
+
+const execute = (runs: ProcessingRunService, adapter: ProcessorAdapter) =>
+  runs.execute(COMPANY, {
+    assetRecordId: ASSET,
+    packId: 'pack_a',
+    adapter,
+    input: { asset: {} as never, openStream: null },
+  });
+
+describe('processor outputs — locator-less rows stay asset-level (byte-identity pin)', () => {
+  it('writes exactly the pre-PR row and never touches evidence_fragment', async () => {
+    const { surreal, calls, creates } = surrealOf();
+    const runs = runnerOf(surreal, embedderThrowing);
+
+    const res = await execute(runs, adapterOf([{ kind: 'text', content: 'hello evidence' }]));
+
+    expect(res.status).toBe('succeeded');
+    expect(calls.some((c) => c.sql.includes('evidence_fragment'))).toBe(false);
+    const repr = creates.find((c) => c.table === 'derived_representation');
+    expect(repr).toBeDefined();
+    // Key-for-key: the shape written before this PR, no vector keys.
+    expect(Object.keys(repr!.content).sort()).toEqual([
+      'confidence',
+      'content',
+      'kind',
+      'lang',
+      'model',
+      'modelVersion',
+      'producedByRun',
+      'producerVersion',
+      'promptVersion',
+      'subjectId',
+      'subjectKind',
+    ]);
+    expect(repr!.content).toMatchObject({
+      subjectId: ASSET,
+      subjectKind: 'asset',
+      kind: 'text',
+      content: 'hello evidence',
+      producerVersion: 'proc-v1',
+    });
+    expect(repr!.content.producedByRun).toBeInstanceOf(StringRecordId);
+  });
+});
+
+describe('processor outputs — a locator makes the output fragment-bearing', () => {
+  it('creates the fragment first and attaches the representation to it', async () => {
+    const { surreal, calls, creates } = surrealOf({ assetPiiClasses: [] });
+    const runs = runnerOf(surreal, embedderThrowing);
+
+    const res = await execute(
+      runs,
+      adapterOf([{ kind: 'text', content: 'hello world', locator: CHAR_SPAN, label: 'line 1' }]),
+    );
+
+    expect(res.status).toBe('succeeded');
+    const insert = calls.find((c) => c.sql.includes('INSERT IGNORE INTO evidence_fragment'));
+    expect(insert).toBeDefined();
+    const row = insert!.params!.row as Record<string, unknown>;
+    expect(String(row.id)).toMatch(/^evidence_fragment:[0-9a-f]{32}$/);
+    expect(row.locator).toEqual(CHAR_SPAN);
+    expect(row.label).toBe('line 1');
+    // Media classification is inherited from the asset: a processor is
+    // not a PII classifier, and the lane's fence reads the FRAGMENT.
+    expect(row.piiClasses).toEqual([]);
+
+    const repr = creates.find((c) => c.table === 'derived_representation');
+    expect(repr!.content).toMatchObject({ subjectKind: 'fragment' });
+    expect(String(repr!.content.subjectId)).toBe(String(row.id));
+  });
+
+  it('an unclassified asset yields an unclassified (fail-closed) fragment', async () => {
+    const { surreal, calls } = surrealOf({ assetPiiClasses: undefined });
+    const runs = runnerOf(surreal, embedderThrowing);
+
+    await execute(runs, adapterOf([{ kind: 'text', content: 'hello world', locator: CHAR_SPAN }]));
+
+    const insert = calls.find((c) => c.sql.includes('INSERT IGNORE INTO evidence_fragment'));
+    const row = insert!.params!.row as Record<string, unknown>;
+    expect('piiClasses' in row).toBe(false);
+  });
+});
+
+describe('processor outputs — fragment dedup is by locator identity', () => {
+  it('two outputs over the same span in one run share one fragment', async () => {
+    const { surreal, calls, insertedFragmentIds } = surrealOf({ assetPiiClasses: [] });
+    const runs = runnerOf(surreal, embedderThrowing);
+
+    await execute(
+      runs,
+      adapterOf([
+        { kind: 'text', content: 'first read', locator: CHAR_SPAN },
+        { kind: 'text', content: 'second read', locator: { ...CHAR_SPAN } },
+      ]),
+    );
+
+    const inserts = calls.filter((c) => c.sql.includes('INSERT IGNORE INTO evidence_fragment'));
+    expect(inserts).toHaveLength(2);
+    // Same deterministic id both times — the second INSERT IGNORE no-ops.
+    expect(insertedFragmentIds.size).toBe(1);
+  });
+
+  it('a re-run under a bumped version reuses the SAME fragment id', async () => {
+    const { surreal, calls, insertedFragmentIds } = surrealOf({ assetPiiClasses: [] });
+    const runs = runnerOf(surreal, embedderThrowing);
+    const output: ProcessorOutput = { kind: 'text', content: 'hello world', locator: CHAR_SPAN };
+
+    const first = await execute(runs, adapterOf([output], 'proc-v1'));
+    const second = await execute(runs, adapterOf([output], 'proc-v2'));
+
+    expect(first.runId).not.toBe(second.runId);
+    const ids = calls
+      .filter((c) => c.sql.includes('INSERT IGNORE INTO evidence_fragment'))
+      .map((c) => String((c.params!.row as { id: unknown }).id));
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(1);
+    expect(insertedFragmentIds.size).toBe(1);
+  });
+
+  it('supersedes over the fragment subject, not just the asset', async () => {
+    const { surreal, calls } = surrealOf({ assetPiiClasses: [] });
+    const runs = runnerOf(surreal, embedderThrowing);
+
+    await execute(runs, adapterOf([{ kind: 'text', content: 'hello world', locator: CHAR_SPAN }]));
+
+    const supersede = calls.find(
+      (c) =>
+        c.sql.includes('FROM derived_representation') && c.sql.includes('supersededBy IS NONE'),
+    );
+    expect(supersede).toBeDefined();
+    expect(supersede!.sql).toContain('subjectId INSIDE $subjects');
+    const subjects = supersede!.params!.subjects as unknown[];
+    // The asset is always in scope; the run's fragment joins it.
+    expect(subjects.map(String)).toEqual([ASSET, expect.stringMatching(/^evidence_fragment:/)]);
+  });
+});
+
+describe('representation embeddings — EVIDENCE_FRAGMENT_EMBEDDINGS', () => {
+  it('off (default): the embedder is never called and no vector key is written', async () => {
+    const { surreal, creates } = surrealOf({ assetPiiClasses: [] });
+    const runs = runnerOf(surreal, embedderThrowing);
+
+    const res = await execute(
+      runs,
+      adapterOf([{ kind: 'text', content: 'hello world', locator: CHAR_SPAN }]),
+    );
+
+    expect(res.status).toBe('succeeded');
+    const repr = creates.find((c) => c.table === 'derived_representation')!;
+    expect('embedding' in repr.content).toBe(false);
+    expect('embeddingSpaceId' in repr.content).toBe(false);
+  });
+
+  it('on: the vector and its space id are stored together', async () => {
+    process.env.EVIDENCE_FRAGMENT_EMBEDDINGS = '1';
+    const { surreal, creates } = surrealOf({ assetPiiClasses: [] });
+    const runs = runnerOf(surreal, embedderOk);
+
+    await execute(runs, adapterOf([{ kind: 'text', content: 'hello world', locator: CHAR_SPAN }]));
+
+    const repr = creates.find((c) => c.table === 'derived_representation')!;
+    expect(repr.content.embedding).toEqual(['hello world'.length, 0.5]);
+    expect(repr.content.embeddingSpaceId).toBe('openai:text-embedding-3-small:1536:l2');
+  });
+
+  it('on with no content: no call, no keys (blank text is not embeddable)', async () => {
+    process.env.EVIDENCE_FRAGMENT_EMBEDDINGS = '1';
+    const { surreal, creates } = surrealOf({ assetPiiClasses: [] });
+    const runs = runnerOf(surreal, embedderThrowing);
+
+    const res = await execute(runs, adapterOf([{ kind: 'text', content: '   ' }]));
+
+    expect(res.status).toBe('succeeded');
+    const repr = creates.find((c) => c.table === 'derived_representation')!;
+    expect('embedding' in repr.content).toBe(false);
+  });
+
+  it('on with no embedder wired: the row still lands without a vector', async () => {
+    process.env.EVIDENCE_FRAGMENT_EMBEDDINGS = '1';
+    const { surreal, creates } = surrealOf({ assetPiiClasses: [] });
+    const runs = runnerOf(surreal, undefined);
+
+    const res = await execute(runs, adapterOf([{ kind: 'text', content: 'hello world' }]));
+
+    expect(res.status).toBe('succeeded');
+    expect('embedding' in creates.find((c) => c.table === 'derived_representation')!.content).toBe(
+      false,
+    );
+  });
+
+  it('an embedding failure is soft: the row is written and the run succeeds', async () => {
+    process.env.EVIDENCE_FRAGMENT_EMBEDDINGS = '1';
+    const { surreal, creates } = surrealOf({ assetPiiClasses: [] });
+    const runs = runnerOf(surreal, embedderBroken);
+
+    const res = await execute(
+      runs,
+      adapterOf([{ kind: 'text', content: 'hello world', locator: CHAR_SPAN }]),
+    );
+
+    expect(res.status).toBe('succeeded');
+    expect(res.representationIds).toHaveLength(1);
+    const repr = creates.find((c) => c.table === 'derived_representation')!;
+    expect(repr.content.content).toBe('hello world');
+    expect('embedding' in repr.content).toBe(false);
+  });
+
+  it('caps embed calls per run — a many-output run cannot fan out unbounded', async () => {
+    process.env.EVIDENCE_FRAGMENT_EMBEDDINGS = '1';
+    let embedCalls = 0;
+    const counting = {
+      embed: async () => {
+        embedCalls += 1;
+        return [0.1];
+      },
+      activeSpaceId: () => 'space',
+    } as unknown as EmbedderService;
+    const { surreal, creates } = surrealOf({ assetPiiClasses: [] });
+    const runs = runnerOf(surreal, counting);
+    const outputs: ProcessorOutput[] = Array.from({ length: 40 }, (_, i) => ({
+      kind: 'text' as const,
+      content: `chunk ${i}`,
+      locator: { kind: 'charRange' as const, start: i, end: i + 1 },
+    }));
+
+    const res = await execute(runs, adapterOf(outputs));
+
+    expect(res.status).toBe('succeeded');
+    expect(embedCalls).toBe(32);
+    const reprs = creates.filter((c) => c.table === 'derived_representation');
+    expect(reprs).toHaveLength(40);
+    expect(reprs.filter((r) => 'embedding' in r.content)).toHaveLength(32);
+  });
+});


### PR DESCRIPTION
## The break

Processor runs wrote **every** `derived_representation` with `subjectKind: 'asset'` (`processing-run.service.ts` `writeOutputs`), while the **only** serving surface — `FragmentLaneService` — filters `subjectKind = 'fragment'` (`fragment-lane.service.ts:132`, again at `:261`). A perfect OCR/vision adapter therefore produced rows retrieval could never return: the difference between *processors exist* and *processors matter*.

Related: `derived_representation.embedding` has been WRITE-DEAD since 0109 (no producer), so the lane's dense leg degraded to empty by construction (`fragment-lane.service.ts:63-66`) and the lane was BM25-only.

Both audited claims verified against the code before building.

## (1) Fragment-bearing processor outputs

`ProcessorOutput` gains an **optional** `locator` (the 0109 `FragmentLocator` union — page/bbox/time/char span) and a `label` for the fragment it creates.

- **With a locator** — `writeOutputs` creates-or-reuses the `evidence_fragment` for that span **first**, then attaches the representation to it (`subjectKind: 'fragment'`, subject = fragment id). That is the only shape the lane can return.
- **Without one** — today's asset-level row, written key-for-key unchanged. An adapter that genuinely describes the whole asset says so by emitting no locator, and both shipped adapters do. Pinned by a byte-identity test asserting the exact key set of the written row.

**Dedup / idempotency.** The fragment takes a *deterministic* record id — `sha256(assetTail | locatorDedupKey)` — written with `INSERT IGNORE`: the #92 `processing_run` idiom, primary-key-addressed, no compound index (0109's header is explicit that `locator` is FLEXIBLE, the table sits on two delete paths, and dedup therefore belongs to the write seam, not the planner's key comparison). The key is the **locator's** identity, not the processor's — the same region re-detected by a bumped adapter version attaches to the **same** citation target, so both generations hang off one fragment and the supersede pass pairs them. Stronger than the brief asked for (which only required same-version re-runs not to multiply fragments).

**PII.** Processor-created fragments inherit the parent asset's `piiClasses` via an explicit opt-in (`inheritAssetPii`) — a processor is not a PII classifier, and a derived span is never cleaner than the asset it came from. Conservative in every state: unclassified asset ⇒ unclassified (fail-closed, unservable) fragment; classified ⇒ classes propagate; only an affirmatively-clean `[]` asset yields a fragment the lane's media fence opens. Existing `addFragment` callers are untouched (the flag is opt-in, `piiClasses` still wins when given).

**Supersede scope** widens from `subjectId = $asset` to `subjectId INSIDE $subjects` (the asset plus every fragment the run attached to — the `purgeRepresentationBatches` shape). A locator-less run has the asset alone and behaves exactly as before; a fragment-bearing one retires both the asset-level generation it replaces and the prior generation on each span it re-detected. Documented residual: a span the new generation no longer finds keeps its old representation — there is no replacement to point it at, and inventing one would attach another span's text to it.

### Design note (alternative considered)

The brief's preferred design held up against the code and is what shipped. One deviation worth flagging: the **embedding leg lives at the write seam, not in the run service**. `ProcessingRunService` is already at the `max-params` 3 ceiling (its own header comments say so), and `EvidenceStoreService.addRepresentation` is the codebase's declared "ONE write seam" for representations — putting the vector in the *same* `dbCreate` avoids a follow-up `UPDATE`, cannot leave a half-written row, and keeps the off-state row byte-identical by key omission. The **budget** stays in the run service (the run is the unit that can fan out); the seam owns the flag and the mechanism.

## (2) A producer for `derived_representation.embedding`

New default-off flag **`EVIDENCE_FRAGMENT_EMBEDDINGS`**. When on, `addRepresentation` embeds a row's TEXT content with the existing `EmbedderService` and stores `embedding` + `embeddingSpaceId` together (the 0101 idiom — a vector whose space is unknown compares to nothing). `@Optional` injection, so positionally-constructed fixtures stay valid and the path degrades to vector-less rows when no embedder is wired.

- **Cap:** `EMBED_OUTPUTS_PER_RUN_MAX = 32` embedded outputs per run — a region-wise OCR pass over a 400-page PDF legitimately emits thousands of outputs, and without a cap one dispatch would fan out thousands of model calls. Uncapped outputs still land as text-only rows the BM25 leg serves. Each embedded text is capped at 8000 chars (a representation may be a megabyte of extracted document text).
- **Soft-fail:** an embedder error costs the vector — never the row, never the run.
- **Off (default):** the embedder is not so much as touched (flag checked first) and neither key is written — byte-identical rows.

## Migration / flag budget

**No migration.** 0124's tables carry all of it: `evidence_fragment.locator` is `FLEXIBLE`, and `embedding` / `embeddingSpaceId` have existed on `derived_representation` since 0109 (defined then precisely as "the column existing now means no second migration then").

**Flag budget untouched, deliberately.** `flag-budget.unit-spec.ts`'s `ENGINE_PREFIX` is `SEARCH|SYNTHESIZE|MULTI_HOP|EXTRACTOR|EXTRACTION|INGEST|EPISODE|EPISODES|DERIVER|AGENT_QA` — `EVIDENCE_` sits outside it by design (substrate builder, not an engine fork), as `evidence-flags.ts` documents. So no golden bump was needed and none was made. Catalog entry + `KNOWN_BOOLEAN_FLAGS` added; `config-catalog-truth.unit-spec.ts` passes.

SurrealDB 3.2.4 discipline held throughout: primary-key-addressed `INSERT IGNORE` for the fragment, two-step `SELECT VALUE id → UPDATE $ids` for supersede, no `DELETE`/`UPDATE WHERE` over an indexed field.

## Tests

**Unit** — new `test/processing-run-outputs.unit-spec.ts` (12 cases over a scripted Surreal double and the *real* store, since the write shape is what's under test): byte-identity pin on the locator-less row; fragment created first and representation attached to it; PII inheritance in both polarities; same span twice in one run ⇒ one fragment; re-run under a bumped version ⇒ same fragment id; widened supersede scope; **flag off ⇒ embedder never called** (pinned with a throwing stub); vector + space id stored when on; blank content and missing embedder ⇒ no keys; **embed failure ⇒ run still succeeds**; the 32-call cap over a 40-output run. Plus `locatorDedupKey` coverage (field-order independence, span/kind separation) in `evidence-locator.unit-spec.ts`.

**E2E** — two legs in `test/evidence-processing.e2e-spec.ts`:
1. **The whole point of the PR:** a dispatched locator-bearing output is read back through `FragmentLaneService` itself — its own fence stack (consent, user, media PII, availability) — and renders, with the citation header resolving; the asset-level generation is pinned as **still unreachable** by the same lane, so the break is proven from the serving side.
2. The embedding columns proven to land against real SurrealDB 3.2.4 with a stubbed embedder (no paid calls anywhere).

## Gates

`pnpm typecheck` ✅ · `pnpm test:unit` ✅ 365 suites / 4136 tests · `pnpm lint:ci` ✅ · `pnpm format:check` ✅ · e2e ✅ `evidence-processing` (8/8) plus the neighbouring `evidence-substrate` / `evidence-grant` / `evidence-raw-gateway` / `evidence-ingest` / `fragment-lane` / `fragment-zoom` / `scene-evidence-links` suites (53/53) for regressions on the touched write seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
