### PR TITLE
feat(packs): media contracts — modalities, processors and raw-evidence policy for all packs

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -54,11 +54,15 @@ BRAIN_API_KEY=... pnpm pack:publish -- --brain-url https://brain.inite.ai \
   --file my_pack.pack.json --keywords my,keywords --verify
 
 # 6. Install into a tenant (key needs brain:admin) — from the registry…
+#    Add --accept-modalities when the manifest declares a media section
+#    (non-text modalities / processors / rawEvidence); without it the
+#    server refuses with a 400 naming what you would be accepting. EVERY
+#    first-party pack declares one as of the 0.3.0 line.
 BRAIN_API_KEY=... pnpm pack:install -- --brain-url https://brain.inite.ai \
-  --registry my_pack
+  --registry my_pack [--accept-modalities]
 #    …or straight from the reviewed local file, checksum-pinned
 BRAIN_API_KEY=... pnpm pack:install -- --brain-url https://brain.inite.ai \
-  --file my_pack.pack.json --verify
+  --file my_pack.pack.json --verify [--accept-modalities]
 
 # 7. Score the LIVE extractor against the pack's own evalFixtures
 curl -X POST -H "Authorization: Bearer $BRAIN_API_KEY" \
@@ -307,7 +311,11 @@ to look, never WHAT is true. The contract is validated, stored, cached,
 exposed read-only on the admin surface, and read by five live core
 consumers (listed below). The builtin `code_memory` pack declares one as
 of 0.4.0 (the reference declaration), and every first-party industry
-pack in `packs/` declares one as of 0.2.0 (see the library table below).
+pack in `packs/` declares one as of 0.2.0. As of the 0.3.0 line (builtin
+`code_memory` 0.5.0) **every** first-party pack also declares the
+Evidence-Plane half of the contract — `modalities`, `processors` and a
+raw-evidence policy — so the media consumers stop denying by default
+(see the library table below).
 
 The semantic plane has five optional arrays. The Evidence Plane adds
 three declarative capabilities. A present section must declare at least
@@ -352,6 +360,40 @@ output remains a recomputable `derived_representation` with provenance.
 The whole section rides the signed/checksummed manifest; an upgrade that
 changes it flips `memoryModelChanged` and invalidates the
 `MemoryModelReaderService` cache.
+
+#### Operator requirement: `acceptModalities`
+
+**Installing any first-party pack now requires explicit media consent.**
+Every pack in the library declares a media section as of the 0.3.0 line,
+so an install without the flag is refused with a `400` that names exactly
+what would be accepted:
+
+```bash
+# REST — both install routes take the flag
+POST /v1/admin/packs                { "manifest": …, "acceptModalities": true }
+POST /v1/admin/packs/from-registry  { "packId": "medical", "acceptModalities": true }
+
+# CLI (scripts/install-pack.ts)
+BRAIN_API_KEY=... pnpm pack:install -- --brain-url $URL \
+  --file packs/medical.pack.json --verify --accept-modalities
+```
+
+What the operator is consenting to, precisely: the tenant's substrate may
+CLASSIFY and PROCESS the declared non-text modalities through core-owned
+processors, and — only for a pack that declares `rawEvidence` — may serve
+raw bytes back after every per-call gate. Consent is checksummed over the
+media section alone: a byte-identical section carries prior consent
+across an upgrade; any change to it (a new modality, a new processor, a
+newly declared or withdrawn `rawEvidence`) re-requires the flag. Until
+consent is current, `gateProcessorDispatch` and `gateRawEvidence` deny —
+the declaration alone activates nothing.
+
+One caveat for the BUILTIN `code_memory` pack: builtins never pass through
+`DomainPackInstallService` (it rejects their ids), so no `domain_pack`
+consent row exists for them. `MemoryModelReaderService` surfaces the
+builtin declaration through its builtin-union path, but both media gates
+still deny at their consent clause. `code_memory`'s media section is a
+published contract, not an activation.
 
 ### Live consumers
 
@@ -428,7 +470,8 @@ pnpm pack:publish  -- --brain-url $URL --file packs/real-estate.pack.json \
                       --keywords real-estate,property   # needs registry:publish
 pnpm pack:search   -- --brain-url $URL --q real          # browse (brain:read)
 pnpm pack:search   -- --brain-url $URL --versions real_estate
-pnpm pack:install  -- --brain-url $URL --registry real_estate[@0.2.0]  # brain:admin
+pnpm pack:install  -- --brain-url $URL --registry real_estate[@0.3.0] \
+                      --accept-modalities                      # brain:admin
 pnpm registry:seed -- --brain-url $URL                   # publish all packs/*.json
 ```
 
@@ -606,8 +649,8 @@ ABAC deny rule.
 Beyond the builtin `code_memory`, brain ships a library of DISTRIBUTABLE
 industry packs (installed per-tenant, published to the registry via
 `pnpm registry:seed`) — each a complete ontology with predicates +
-`extractionProfile` + `evalFixtures` + `memoryModel` (as of 0.2.0), not
-a stub:
+`extractionProfile` + `evalFixtures` + `memoryModel` (as of 0.2.0) + a
+media contract (as of 0.3.0), not a stub:
 
 | pack | domain | predicates (namespaced `<id>__*`) | memoryModel lifecycles |
 |---|---|---|---|
@@ -618,11 +661,46 @@ a stub:
 | `insurance` | insurance policies | covers, coverage_limit, premium, deductible, excludes | policy, claim |
 | `hr` | HR / recruiting (roles, not PII) | requires_skill, seniority, compensation, employment_type, work_location | position, employee |
 
+### Media contracts (`modalities` / `processors` / `rawEvidence`)
+
+What each pack declares its domain can PERCEIVE, which core-owned
+capabilities it asks for, and whether raw bytes may ever serve. Only two
+processor capabilities are declared anywhere in the library, because only
+two adapters exist: `image → caption` (image metadata) and
+`document → text` (text extraction). OCR, ASR and vision captioning are
+deliberately undeclared — declaring a capability with no adapter arms a
+dispatch that always denies.
+
+| pack | version | modalities | processors | rawEvidence | why |
+|---|---|---|---|---|---|
+| `real_estate` | 0.3.0 | text, image, document | image metadata, document text | **serve** | listing photos and floor plans are published marketing material |
+| `medical` | 0.3.0 | text, image, document | image metadata, document text | deny | scans and X-ray photographs are clinical data — never served raw |
+| `insurance` | 0.3.0 | text, image, document | image metadata, document text | deny | claim photos carry injuries, plates, bystanders |
+| `legal` | 0.3.0 | text, image, document | document text, image metadata | deny | contracts, filings and scanned exhibits carry privilege |
+| `fintech` | 0.3.0 | text, document | document text | deny | statements and KYC files; `image` withheld (biometric-adjacent) |
+| `hr` | 0.3.0 | text, document | document text | deny | CVs and offer letters are personal data; `image` withheld |
+| `code_memory` (builtin) | 0.5.0 | text, image, document | image metadata, document text | deny | failure/dashboard screenshots + log artifacts |
+
+`rawEvidence: deny` is the *absence* of the field — the schema's only
+other value is `{ "serve": true }`, so omission is how a pack refuses.
+`gateRawEvidence` then denies raw bytes and signed URLs for that pack
+unconditionally. A `serve` declaration only OPENS the gate: current
+modality consent and the per-call media-PII gate (unclassified fails
+closed; classified needs `brain:read_media`) still apply to every
+fragment.
+
+Predicates deliberately do NOT yet seed `requiredEvidenceCapability`:
+with zero evidence fragments in a tenant's store, requiring a non-text
+capability makes every answer over those predicates abstain
+(`evidence_capability_unmet`). That seeding follows once fragments
+actually exist.
+
 Sources: `src/ai/domain-packs/*.pack.ts` (the `FIRST_PARTY_PACKS` list) →
 committed JSON in `packs/*.pack.json` (drift-guarded by
 `test/industry-packs.unit-spec.ts`). Install one with
-`pnpm pack:install -- --registry fintech` (after `registry:seed`) or
-`--file packs/fintech.pack.json`.
+`pnpm pack:install -- --registry fintech --accept-modalities` (after
+`registry:seed`) or `--file packs/fintech.pack.json --accept-modalities`
+— the media consent flag is now required for every pack in the library.
 
 ## See also
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,7 +88,9 @@ idempotent.
   `/v1/ingest/document` — [Document pipeline](document-pipeline.md).
 - Install a Domain Pack (needs a `brain:admin`-scoped key):
   `BRAIN_API_KEY=... pnpm pack:install -- --brain-url http://localhost:3000
-  --file packs/fintech.pack.json` extends the ontology at runtime —
+  --file packs/fintech.pack.json --accept-modalities` extends the ontology
+  at runtime. `--accept-modalities` is the operator consent to the pack's
+  declared media section; without it the install is refused —
   [Domain Packs](domain-packs.md).
 - Wire your vertical: [Migration guide](migration-guide.md)
 - Understand the read path: [Architecture](architecture.md)

--- a/packs/fintech.pack.json
+++ b/packs/fintech.pack.json
@@ -1,6 +1,6 @@
 {
   "id": "fintech",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Financial-services regulation ontology — regulators, licenses, compliance standards, capital, and settlement of institutions/products, with a domain extraction profile and memory model.",
   "predicates": [
     {
@@ -307,6 +307,19 @@
       {
         "predicateOrScene": "regulatory_filing",
         "hint": "standard"
+      }
+    ],
+    "modalities": [
+      "text",
+      "document"
+    ],
+    "processors": [
+      {
+        "id": "document_text",
+        "modality": "document",
+        "produces": [
+          "text"
+        ]
       }
     ]
   },

--- a/packs/hr.pack.json
+++ b/packs/hr.pack.json
@@ -1,6 +1,6 @@
 {
   "id": "hr",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "HR / recruiting ontology — required skills, seniority, compensation, employment type, and work location of roles, with a domain extraction profile and memory model.",
   "predicates": [
     {
@@ -299,6 +299,19 @@
       {
         "predicateOrScene": "interview_debrief",
         "hint": "ephemeral"
+      }
+    ],
+    "modalities": [
+      "text",
+      "document"
+    ],
+    "processors": [
+      {
+        "id": "document_text",
+        "modality": "document",
+        "produces": [
+          "text"
+        ]
       }
     ]
   },

--- a/packs/insurance.pack.json
+++ b/packs/insurance.pack.json
@@ -1,6 +1,6 @@
 {
   "id": "insurance",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Insurance ontology — coverage, limits, premiums, deductibles, and exclusions of policies, with a domain extraction profile and memory model.",
   "predicates": [
     {
@@ -288,6 +288,27 @@
       {
         "predicateOrScene": "renewal_review",
         "hint": "standard"
+      }
+    ],
+    "modalities": [
+      "text",
+      "image",
+      "document"
+    ],
+    "processors": [
+      {
+        "id": "image_metadata",
+        "modality": "image",
+        "produces": [
+          "caption"
+        ]
+      },
+      {
+        "id": "document_text",
+        "modality": "document",
+        "produces": [
+          "text"
+        ]
       }
     ]
   },

--- a/packs/legal.pack.json
+++ b/packs/legal.pack.json
@@ -1,6 +1,6 @@
 {
   "id": "legal",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Legal / contracts ontology — governing law, parties, obligations, and term of agreements, with a domain extraction profile and memory model.",
   "predicates": [
     {
@@ -307,6 +307,27 @@
       {
         "predicateOrScene": "negotiation_session",
         "hint": "ephemeral"
+      }
+    ],
+    "modalities": [
+      "text",
+      "image",
+      "document"
+    ],
+    "processors": [
+      {
+        "id": "document_text",
+        "modality": "document",
+        "produces": [
+          "text"
+        ]
+      },
+      {
+        "id": "image_metadata",
+        "modality": "image",
+        "produces": [
+          "caption"
+        ]
       }
     ]
   },

--- a/packs/medical.pack.json
+++ b/packs/medical.pack.json
@@ -1,6 +1,6 @@
 {
   "id": "medical",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Clinical pharmacology ontology — indications, dosing, routes, interactions, and contraindications of drugs/treatments, with a domain extraction profile and memory model.",
   "predicates": [
     {
@@ -280,6 +280,27 @@
       {
         "predicateOrScene": "medication_review",
         "hint": "standard"
+      }
+    ],
+    "modalities": [
+      "text",
+      "image",
+      "document"
+    ],
+    "processors": [
+      {
+        "id": "image_metadata",
+        "modality": "image",
+        "produces": [
+          "caption"
+        ]
+      },
+      {
+        "id": "document_text",
+        "modality": "document",
+        "produces": [
+          "text"
+        ]
       }
     ]
   },

--- a/packs/real-estate.pack.json
+++ b/packs/real-estate.pack.json
@@ -1,6 +1,6 @@
 {
   "id": "real_estate",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Real-estate ontology — zoning, valuation, encumbrances, tenure, and construction of properties/parcels, with a domain extraction profile and memory model.",
   "predicates": [
     {
@@ -319,7 +319,31 @@
         "predicateOrScene": "viewing",
         "hint": "ephemeral"
       }
-    ]
+    ],
+    "modalities": [
+      "text",
+      "image",
+      "document"
+    ],
+    "processors": [
+      {
+        "id": "image_metadata",
+        "modality": "image",
+        "produces": [
+          "caption"
+        ]
+      },
+      {
+        "id": "document_text",
+        "modality": "document",
+        "produces": [
+          "text"
+        ]
+      }
+    ],
+    "rawEvidence": {
+      "serve": true
+    }
   },
   "evalFixtures": [
     {

--- a/scripts/install-pack.ts
+++ b/scripts/install-pack.ts
@@ -9,11 +9,18 @@
  *
  *   # from the registry (latest non-yanked, or a pinned version)
  *   BRAIN_API_KEY=... pnpm pack:install -- \
- *     --brain-url https://brain.inite.ai --registry real_estate[@0.2.0]
+ *     --brain-url https://brain.inite.ai --registry real_estate[@0.3.0]
  *
  * --verify (file mode) recomputes the manifest checksum locally and pins it in
  * the request, so the server rejects if what it receives differs from what you
  * reviewed. Registry installs are always checksum-pinned server-side.
+ *
+ * --accept-modalities is the OPERATOR CONSENT flag for a manifest whose
+ * memoryModel declares non-text modalities, non-text processor needs, or the
+ * raw-evidence capability (every first-party pack does, as of the 0.3.0
+ * line). Without it the server refuses the install with a 400 naming what
+ * would be accepted. Read the manifest's media section first — that is the
+ * point of the flag.
  */
 import { readFileSync } from 'node:fs';
 import { packChecksum } from '../src/ai/domain-packs/checksum';
@@ -50,6 +57,11 @@ async function main(): Promise<void> {
     );
   }
 
+  // Operator consent to the manifest's media section (see the header).
+  const consent = process.argv.includes('--accept-modalities')
+    ? { acceptModalities: true }
+    : {};
+
   if (registry) {
     // <packId> or <packId>@<version>
     const [packId, version] = registry.split('@');
@@ -59,6 +71,7 @@ async function main(): Promise<void> {
     await post(brainUrl, key, '/v1/admin/packs/from-registry', {
       packId,
       ...(version ? { version } : {}),
+      ...consent,
     });
     return;
   }
@@ -69,6 +82,7 @@ async function main(): Promise<void> {
   await post(brainUrl, key, '/v1/admin/packs', {
     manifest,
     ...(process.argv.includes('--verify') ? { expectedChecksum: checksum } : {}),
+    ...consent,
   });
 }
 

--- a/src/ai/domain-packs/code-memory.pack.ts
+++ b/src/ai/domain-packs/code-memory.pack.ts
@@ -7,11 +7,21 @@ import { composePredicateId, type DomainPackManifest } from './manifest';
  * were hardcoded in CORE_PREDICATES (Phase 0 PoC shortcut); they now live here
  * as a versioned, namespaced pack, proving the pack standard end-to-end.
  *
+ * As of 0.5.0 the memoryModel carries a MEDIA CONTRACT: failure/dashboard
+ * screenshots and text-ish artifacts (logs, traces) as input modalities,
+ * the two core capabilities the Evidence Plane can actually run (image
+ * metadata, document text), and NO raw-evidence declaration. NOTE the
+ * builtin caveat: builtins never pass through DomainPackInstallService, so
+ * no `domain_pack` consent row exists for this pack — MemoryModelReader-
+ * Service surfaces the declaration through its builtin union, but both
+ * media gates still deny at their consent clause until a consent path for
+ * builtins lands. The declaration is the contract, not an activation.
+ *
  * Bump `version` to ship an updated code-memory ontology.
  */
 export const CODE_MEMORY_PACK: DomainPackManifest = {
   id: 'code_memory',
-  version: '0.4.3',
+  version: '0.5.0',
   description:
     'Non-derivable engineering "why" of a codebase — decisions, rationale, invariants, gotchas, ownership, flag/config defaults, dependency pins, and decision supersession anchored to code, with a domain extraction profile and memory model.',
   // Retro-declaration, documentation-true: code-memory has ALWAYS been an
@@ -218,7 +228,9 @@ never split its clauses across facts or predicates.`,
   },
   // The domain perception contract (docs/domain-packs.md). Declarative data
   // only; consumable once the memory-model reader unions builtin manifests.
-  // Text-only — no modalities/processors/rawEvidence, so no consent surface.
+  // The media section (modalities/processors/rawEvidence) is the consent
+  // surface everywhere else in the library; for a BUILTIN there is no
+  // install to consent at, so it is a declaration only (see the header).
   memoryModel: {
     sceneSchemas: [
       {
@@ -290,6 +302,25 @@ never split its clauses across facts or predicates.`,
       { predicateOrScene: 'depends_on_version', hint: 'standard' },
       { predicateOrScene: 'change_session', hint: 'standard' },
     ],
+    // ── Media contract (Evidence Plane) ─────────────────────────────────
+    // Modest and honest. Engineering evidence that is not prose is a
+    // SCREENSHOT of a failing run or a dashboard, and text-ish ARTIFACTS
+    // (logs, stack traces, diffs) that arrive as document assets. Only the
+    // two capabilities the trusted core can actually run today are
+    // requested: image metadata (image → caption, which for a screenshot
+    // is dimensions and media type, nothing more) and document text
+    // extraction (document → text). No OCR of screenshots, no vision
+    // captioner, no ASR — no adapter exists, so declaring one would arm a
+    // capability that always denies.
+    modalities: ['text', 'image', 'document'],
+    processors: [
+      { id: 'image_metadata', modality: 'image', produces: ['caption'] },
+      { id: 'document_text', modality: 'document', produces: ['text'] },
+    ],
+    // rawEvidence is DELIBERATELY ABSENT (omission = deny). A builtin is
+    // seeded into EVERY tenant without an install decision, so it is the
+    // last pack that should hold a raw-serving capability; derived
+    // representations answer the engineering question either way.
   },
   // Scored by POST /v1/admin/packs/code_memory/eval (resolves the builtin
   // manifest in-process) — one fixture per new predicate + the classic

--- a/src/ai/domain-packs/fintech.pack.ts
+++ b/src/ai/domain-packs/fintech.pack.ts
@@ -8,11 +8,18 @@ import type { DomainPackManifest } from './manifest';
  * tenants. Ships an extractionProfile + eval fixtures + memoryModel (license /
  * certification / enforcement lifecycles, attention + retention hints, recency
  * rules for license and settlement claims) so it's a complete, self-verifying
- * ontology, not a stub. Bump `version` to ship an update.
+ * ontology, not a stub.
+ *
+ * As of 0.3.0 the memoryModel also carries a MEDIA CONTRACT: statements,
+ * filings, and KYC paperwork as documents; document text extraction as the
+ * single core capability requested; NO image modality (KYC identity
+ * photography is biometric-adjacent) and NO raw-evidence declaration.
+ *
+ * Bump `version` to ship an update.
  */
 export const FINTECH_PACK: DomainPackManifest = {
   id: 'fintech',
-  version: '0.2.0',
+  version: '0.3.0',
   description:
     'Financial-services regulation ontology — regulators, licenses, compliance standards, capital, and settlement of institutions/products, with a domain extraction profile and memory model.',
   predicates: [
@@ -110,7 +117,8 @@ named entity, ALSO emit an edge (Institution —regulated_by→ Authority).`,
   },
   // The domain perception contract (docs/domain-packs.md). Declarative data
   // only — consumed by MemoryModelReaderService for installed tenants.
-  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  // The media section (modalities/processors/rawEvidence) is the consent
+  // surface: installing this pack requires `acceptModalities: true`.
   memoryModel: {
     sceneSchemas: [
       {
@@ -193,6 +201,20 @@ named entity, ALSO emit an edge (Institution —regulated_by→ Authority).`,
       { predicateOrScene: 'audit_review', hint: 'durable' },
       { predicateOrScene: 'regulatory_filing', hint: 'standard' },
     ],
+    // ── Media contract (Evidence Plane) ─────────────────────────────────
+    // Financial evidence is DOCUMENTARY: statements, regulatory filings,
+    // licence certificates, KYC paperwork. Document text extraction
+    // (document → text) is the only core capability requested, and it is
+    // the only one an installed adapter can run. `image` is deliberately
+    // NOT declared: KYC identity photography is biometric-adjacent, and a
+    // pack should not widen a tenant's media consent for evidence this
+    // ontology (institutions and products, not people) never reasons over.
+    modalities: ['text', 'document'],
+    processors: [{ id: 'document_text', modality: 'document', produces: ['text'] }],
+    // rawEvidence is DELIBERATELY ABSENT (omission = deny). Statements and
+    // KYC files are the most re-identifiable artifacts in the library;
+    // derived text is enough to answer a compliance question, so
+    // gateRawEvidence refuses raw bytes and signed URLs for this pack.
   },
   evalFixtures: [
     {

--- a/src/ai/domain-packs/hr.pack.ts
+++ b/src/ai/domain-packs/hr.pack.ts
@@ -6,11 +6,18 @@ import type { DomainPackManifest } from './manifest';
  * required skills, seniority, compensation, employment type, location policy.
  * Scoped to ROLES/REQUISITIONS, not individual PII — the memoryModel's
  * position / employee lifecycles are generic vocabulary about subjects of
- * those types, never person records. Bump `version` to update.
+ * those types, never person records.
+ *
+ * As of 0.3.0 the memoryModel also carries a MEDIA CONTRACT: CVs and offer
+ * letters as documents; document text extraction as the single core
+ * capability requested; NO image modality (candidate photography is not
+ * this ontology's business) and NO raw-evidence declaration.
+ *
+ * Bump `version` to update.
  */
 export const HR_PACK: DomainPackManifest = {
   id: 'hr',
-  version: '0.2.0',
+  version: '0.3.0',
   description:
     'HR / recruiting ontology — required skills, seniority, compensation, employment type, and work location of roles, with a domain extraction profile and memory model.',
   predicates: [
@@ -99,7 +106,8 @@ the SUBJECT entity. Prefer the hr__* predicates for required skills
   },
   // The domain perception contract (docs/domain-packs.md). Declarative data
   // only — consumed by MemoryModelReaderService for installed tenants.
-  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  // The media section (modalities/processors/rawEvidence) is the consent
+  // surface: installing this pack requires `acceptModalities: true`.
   memoryModel: {
     sceneSchemas: [
       {
@@ -171,6 +179,18 @@ the SUBJECT entity. Prefer the hr__* predicates for required skills
       { predicateOrScene: 'offer_stage', hint: 'standard' },
       { predicateOrScene: 'interview_debrief', hint: 'ephemeral' },
     ],
+    // ── Media contract (Evidence Plane) ─────────────────────────────────
+    // Recruiting evidence is DOCUMENTARY: CVs, offer letters, job
+    // descriptions, requisition paperwork. Document text extraction
+    // (document → text) is the only core capability requested, and it is
+    // the only one an installed adapter can run. `image` is deliberately
+    // NOT declared — candidate photography is not this ontology's business
+    // and would widen the tenant's media consent for nothing.
+    modalities: ['text', 'document'],
+    processors: [{ id: 'document_text', modality: 'document', produces: ['text'] }],
+    // rawEvidence is DELIBERATELY ABSENT (omission = deny). A CV is a
+    // person's personal data; the pack reasons over ROLES, so derived text
+    // is sufficient and gateRawEvidence refuses raw bytes and signed URLs.
   },
   evalFixtures: [
     {

--- a/src/ai/domain-packs/insurance.pack.ts
+++ b/src/ai/domain-packs/insurance.pack.ts
@@ -5,12 +5,19 @@ import type { DomainPackManifest } from './manifest';
  * `packs/insurance.pack.json`, NOT in BUILTIN_PACKS). Captures policy ontology —
  * coverage, limits, premiums, deductibles, exclusions — with an extractionProfile
  * + eval fixtures + memoryModel (policy / claim lifecycles, attention +
- * retention hints, recency rules for premium and coverage claims). Bump
- * `version` to ship an update.
+ * retention hints, recency rules for premium and coverage claims).
+ *
+ * As of 0.3.0 the memoryModel also carries a MEDIA CONTRACT: claim
+ * photographs and policy documents as input modalities, the two core
+ * capabilities the Evidence Plane can actually run (image metadata,
+ * document text), and NO raw-evidence declaration — a claim photo
+ * routinely carries third-party personal data.
+ *
+ * Bump `version` to ship an update.
  */
 export const INSURANCE_PACK: DomainPackManifest = {
   id: 'insurance',
-  version: '0.2.0',
+  version: '0.3.0',
   description:
     'Insurance ontology — coverage, limits, premiums, deductibles, and exclusions of policies, with a domain extraction profile and memory model.',
   predicates: [
@@ -101,7 +108,8 @@ what it EXCLUDES.`,
   },
   // The domain perception contract (docs/domain-packs.md). Declarative data
   // only — consumed by MemoryModelReaderService for installed tenants.
-  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  // The media section (modalities/processors/rawEvidence) is the consent
+  // surface: installing this pack requires `acceptModalities: true`.
   memoryModel: {
     sceneSchemas: [
       {
@@ -176,6 +184,22 @@ what it EXCLUDES.`,
       { predicateOrScene: 'claim_intake', hint: 'durable' },
       { predicateOrScene: 'renewal_review', hint: 'standard' },
     ],
+    // ── Media contract (Evidence Plane) ─────────────────────────────────
+    // A claim arrives as PHOTOGRAPHS of the loss and as POLICY DOCUMENTS
+    // (schedules, wordings, adjuster reports). Only the two capabilities
+    // the trusted core can actually run today are requested: image
+    // metadata (image → caption) and document text extraction
+    // (document → text). OCR / ASR / vision-caption are deliberately NOT
+    // declared — no adapter is installed for them.
+    modalities: ['text', 'image', 'document'],
+    processors: [
+      { id: 'image_metadata', modality: 'image', produces: ['caption'] },
+      { id: 'document_text', modality: 'document', produces: ['text'] },
+    ],
+    // rawEvidence is DELIBERATELY ABSENT (omission = deny). Claim
+    // photography routinely captures injuries, plates, and bystanders —
+    // third-party personal data the pack has no standing to hand back —
+    // so gateRawEvidence refuses raw bytes and signed URLs for this pack.
   },
   evalFixtures: [
     {

--- a/src/ai/domain-packs/legal.pack.ts
+++ b/src/ai/domain-packs/legal.pack.ts
@@ -6,11 +6,19 @@ import type { DomainPackManifest } from './manifest';
  * ontology of agreements — governing law, parties, obligations, and term — with
  * an extractionProfile + eval fixtures + memoryModel (matter / agreement /
  * obligation lifecycles, attention + retention hints, recency rules for
- * termination and effective-date claims). Bump `version` to ship an update.
+ * termination and effective-date claims).
+ *
+ * As of 0.3.0 the memoryModel also carries a MEDIA CONTRACT: contracts and
+ * filings as documents, scanned exhibits as images, the two core
+ * capabilities the Evidence Plane can actually run (document text, image
+ * metadata), and NO raw-evidence declaration — an exhibit's bytes carry
+ * privilege.
+ *
+ * Bump `version` to ship an update.
  */
 export const LEGAL_PACK: DomainPackManifest = {
   id: 'legal',
-  version: '0.2.0',
+  version: '0.3.0',
   description:
     'Legal / contracts ontology — governing law, parties, obligations, and term of agreements, with a domain extraction profile and memory model.',
   predicates: [
@@ -106,7 +114,8 @@ an agreement, emit an edge between them in addition to the party facts.`,
   },
   // The domain perception contract (docs/domain-packs.md). Declarative data
   // only — consumed by MemoryModelReaderService for installed tenants.
-  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  // The media section (modalities/processors/rawEvidence) is the consent
+  // surface: installing this pack requires `acceptModalities: true`.
   memoryModel: {
     sceneSchemas: [
       {
@@ -189,6 +198,24 @@ an agreement, emit an edge between them in addition to the party facts.`,
       { predicateOrScene: 'execution', hint: 'durable' },
       { predicateOrScene: 'negotiation_session', hint: 'ephemeral' },
     ],
+    // ── Media contract (Evidence Plane) ─────────────────────────────────
+    // The domain's evidence is DOCUMENTARY first — contracts, filings,
+    // schedules — with SCANNED EXHIBITS arriving as images. Only the two
+    // capabilities the trusted core can actually run today are requested:
+    // document text extraction (document → text) and image metadata
+    // (image → caption). OCR is deliberately NOT declared even though a
+    // scanned exhibit is exactly what would want it: no OCR adapter is
+    // installed, so the declaration would arm a capability that always
+    // denies. Add it in the same PR that ships the adapter.
+    modalities: ['text', 'image', 'document'],
+    processors: [
+      { id: 'document_text', modality: 'document', produces: ['text'] },
+      { id: 'image_metadata', modality: 'image', produces: ['caption'] },
+    ],
+    // rawEvidence is DELIBERATELY ABSENT (omission = deny). Exhibits and
+    // executed agreements carry privilege and counterparty personal data;
+    // handing their bytes back is a document-management decision, not a
+    // memory-recall one, so gateRawEvidence refuses for this pack.
   },
   evalFixtures: [
     {

--- a/src/ai/domain-packs/medical.pack.ts
+++ b/src/ai/domain-packs/medical.pack.ts
@@ -8,11 +8,17 @@ import type { DomainPackManifest } from './manifest';
  * 'none'. Ships an extractionProfile + eval fixtures + memoryModel
  * (prescription / approval lifecycles, attention + retention hints, a recency
  * rule for dosage claims and a corroboration rule for contraindications).
+ *
+ * As of 0.3.0 the memoryModel also carries a MEDIA CONTRACT: imaging and
+ * document scans as input modalities, the two core capabilities the
+ * Evidence Plane can actually run (image metadata, document text), and NO
+ * raw-evidence declaration — clinical images never serve raw.
+ *
  * Bump `version` to update.
  */
 export const MEDICAL_PACK: DomainPackManifest = {
   id: 'medical',
-  version: '0.2.0',
+  version: '0.3.0',
   description:
     'Clinical pharmacology ontology — indications, dosing, routes, interactions, and contraindications of drugs/treatments, with a domain extraction profile and memory model.',
   predicates: [
@@ -108,7 +114,8 @@ pack captures drug ontology, not clinical records.`,
   },
   // The domain perception contract (docs/domain-packs.md). Declarative data
   // only — consumed by MemoryModelReaderService for installed tenants.
-  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  // The media section (modalities/processors/rawEvidence) is the consent
+  // surface: installing this pack requires `acceptModalities: true`.
   memoryModel: {
     sceneSchemas: [
       {
@@ -181,6 +188,25 @@ pack captures drug ontology, not clinical records.`,
       { predicateOrScene: 'adverse_event', hint: 'durable' },
       { predicateOrScene: 'medication_review', hint: 'standard' },
     ],
+    // ── Media contract (Evidence Plane) ─────────────────────────────────
+    // Clinical evidence arrives as IMAGING (scan / X-ray photographs) and
+    // as DOCUMENT scans of reports, alongside plain text. Only the two
+    // capabilities the trusted core can actually run today are requested:
+    // image metadata (image → caption) and document text extraction
+    // (document → text). OCR / ASR / vision-caption are deliberately NOT
+    // declared — no adapter is installed for them, so declaring one would
+    // arm a capability that always denies at dispatch.
+    modalities: ['text', 'image', 'document'],
+    processors: [
+      { id: 'image_metadata', modality: 'image', produces: ['caption'] },
+      { id: 'document_text', modality: 'document', produces: ['text'] },
+    ],
+    // rawEvidence is DELIBERATELY ABSENT — the most conservative setting
+    // the schema offers (the only other legal value is `{ serve: true }`;
+    // omission is what denies). Clinical images are sensitive, so
+    // gateRawEvidence (src/mcp/raw-evidence-gate.ts) refuses raw bytes and
+    // signed URLs for this pack unconditionally: only recomputable derived
+    // representations, never the original pixels, leave the plane.
   },
   evalFixtures: [
     {

--- a/src/ai/domain-packs/real-estate.pack.ts
+++ b/src/ai/domain-packs/real-estate.pack.ts
@@ -19,11 +19,17 @@ import type { DomainPackManifest } from './manifest';
  * appraisal claims) — the domain perception contract consumed by
  * MemoryModelReaderService for installed tenants.
  *
+ * As of 0.3.0 the memoryModel also carries a MEDIA CONTRACT: listing
+ * photography and floor-plan documents as input modalities, the two core
+ * capabilities the Evidence Plane can actually run (image metadata,
+ * document text), and `rawEvidence: { serve: true }` — listing media is
+ * published marketing material whose whole purpose is to be looked at.
+ *
  * Bump `version` to ship an updated real-estate ontology / profile.
  */
 export const REAL_ESTATE_PACK: DomainPackManifest = {
   id: 'real_estate',
-  version: '0.2.0',
+  version: '0.3.0',
   description:
     'Real-estate ontology — zoning, valuation, encumbrances, tenure, and construction of properties/parcels, with a domain extraction profile and memory model.',
   predicates: [
@@ -134,7 +140,8 @@ encumbrance, ALSO emit an edge to that party (e.g. Property —held_by→ Bank).
   },
   // The domain perception contract (docs/domain-packs.md). Declarative data
   // only — consumed by MemoryModelReaderService for installed tenants.
-  // Text-only: no modalities/processors/rawEvidence, so no consent surface.
+  // The media section (modalities/processors/rawEvidence) is the consent
+  // surface: installing this pack requires `acceptModalities: true`.
   memoryModel: {
     sceneSchemas: [
       {
@@ -210,6 +217,26 @@ encumbrance, ALSO emit an edge to that party (e.g. Property —held_by→ Bank).
       { predicateOrScene: 'closing', hint: 'durable' },
       { predicateOrScene: 'viewing', hint: 'ephemeral' },
     ],
+    // ── Media contract (Evidence Plane) ─────────────────────────────────
+    // Property evidence is photographic (listing photos, viewing snaps)
+    // and documentary (floor plans, EPCs, permit paperwork). Only the two
+    // capabilities the trusted core can actually run today are requested:
+    // image metadata (image → caption) and document text extraction
+    // (document → text). OCR / ASR / vision-caption are deliberately NOT
+    // declared — no adapter is installed for them.
+    modalities: ['text', 'image', 'document'],
+    processors: [
+      { id: 'image_metadata', modality: 'image', produces: ['caption'] },
+      { id: 'document_text', modality: 'document', produces: ['text'] },
+    ],
+    // The one first-party pack that declares raw serving: a listing photo
+    // or floor plan is published marketing material, and an agent asking
+    // "show me the kitchen" needs the artifact itself, not a caption of
+    // it. Declaring it only OPENS the gate — gateRawEvidence still
+    // requires current modality consent AND passes every fragment through
+    // the media-PII gate (unclassified fails closed; classified needs
+    // brain:read_media).
+    rawEvidence: { serve: true },
   },
   evalFixtures: [
     {

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -5,17 +5,25 @@
 import {
   assembleSeed,
   composePredicateId,
+  declaredModalitySection,
   diffPackUpgrade,
+  modalitiesChecksum,
+  modalityConsentRequired,
   packChecksum,
   validatePack,
   DomainPackError,
+  FIRST_PARTY_PACKS,
   SEED_DOC_MAX_CHARS,
   SEED_MAX_DOCS,
   SEED_TOTAL_MAX_CHARS,
   type DomainPackManifest,
+  type PackMemoryModality,
   type PackPredicate,
   type PackSeedDocument,
 } from '../src/ai/domain-packs';
+import type { EvidenceModality } from '../src/common/evidence-taxonomy';
+import { gateProcessorDispatch } from '../src/evidence/processing/dispatch-gate';
+import { gateRawEvidence } from '../src/mcp/raw-evidence-gate';
 import { computeHash } from '../src/ai/predicate-registry-internals/db-mapping';
 import {
   CODE_MEMORY_PACK,
@@ -489,10 +497,6 @@ describe('code-memory pack', () => {
     expect(mm?.attentionHints?.length ?? 0).toBeGreaterThanOrEqual(5);
     expect(mm?.verificationRules).toEqual([{ claimPattern: 'default', requires: 'recency_check' }]);
     expect(mm?.retentionHints?.some((h) => h.predicateOrScene === 'gotcha')).toBe(true);
-    // Text-only: no consent-tier declarations.
-    expect(mm?.modalities).toBeUndefined();
-    expect(mm?.processors).toBeUndefined();
-    expect(mm?.rawEvidence).toBeUndefined();
   });
 
   it('eval fixtures cover every 0.4.0 predicate and resolve against declared localIds', () => {
@@ -509,5 +513,262 @@ describe('code-memory pack', () => {
     for (const local of ['owns', 'default_value', 'depends_on_version', 'superseded_by']) {
       expect(asserted.has(local)).toBe(true);
     }
+  });
+});
+
+// ── Media contract: modalities / processors / rawEvidence ────────────────
+//
+// Before these declarations every first-party pack was text-only, which
+// meant FOUR consumers denied unconditionally: gateProcessorDispatch, the
+// processor broker behind it, gateRawEvidence, and the raw-read gateway +
+// signed-URL mint that call it. The pins below are the contract each pack
+// now offers; the gate block after them proves the consumers came alive.
+
+/** The two capabilities an installed adapter can actually run today. */
+const IMAGE_METADATA = { id: 'image_metadata', modality: 'image', produces: ['caption'] };
+const DOCUMENT_TEXT = { id: 'document_text', modality: 'document', produces: ['text'] };
+
+interface MediaExpectation {
+  pack: DomainPackManifest;
+  version: string;
+  modalities: PackMemoryModality[];
+  processors: Array<{ id: string; modality: string; produces: string[] }>;
+  /** undefined = raw serving DENIED (the schema's conservative setting). */
+  rawEvidence: { serve: true } | undefined;
+}
+
+const MEDIA_CONTRACT: MediaExpectation[] = [
+  {
+    pack: packById('real_estate'),
+    version: '0.3.0',
+    modalities: ['text', 'image', 'document'],
+    processors: [IMAGE_METADATA, DOCUMENT_TEXT],
+    // Listing media is published marketing material — the one pack that serves raw.
+    rawEvidence: { serve: true },
+  },
+  {
+    pack: packById('medical'),
+    version: '0.3.0',
+    modalities: ['text', 'image', 'document'],
+    processors: [IMAGE_METADATA, DOCUMENT_TEXT],
+    rawEvidence: undefined, // clinical imaging never serves raw
+  },
+  {
+    pack: packById('insurance'),
+    version: '0.3.0',
+    modalities: ['text', 'image', 'document'],
+    processors: [IMAGE_METADATA, DOCUMENT_TEXT],
+    rawEvidence: undefined, // claim photos carry third-party personal data
+  },
+  {
+    pack: packById('legal'),
+    version: '0.3.0',
+    modalities: ['text', 'image', 'document'],
+    processors: [DOCUMENT_TEXT, IMAGE_METADATA],
+    rawEvidence: undefined, // exhibits carry privilege
+  },
+  {
+    pack: packById('fintech'),
+    version: '0.3.0',
+    modalities: ['text', 'document'],
+    processors: [DOCUMENT_TEXT],
+    rawEvidence: undefined, // statements / KYC files
+  },
+  {
+    pack: packById('hr'),
+    version: '0.3.0',
+    modalities: ['text', 'document'],
+    processors: [DOCUMENT_TEXT],
+    rawEvidence: undefined, // CVs are personal data
+  },
+  {
+    pack: CODE_MEMORY_PACK,
+    version: '0.5.0',
+    modalities: ['text', 'image', 'document'],
+    processors: [IMAGE_METADATA, DOCUMENT_TEXT],
+    rawEvidence: undefined, // a builtin seeds into every tenant unasked
+  },
+];
+
+function packById(id: string): DomainPackManifest {
+  const found = FIRST_PARTY_PACKS.find((p) => p.id === id);
+  if (!found) throw new Error(`no first-party pack "${id}"`);
+  return found;
+}
+
+describe.each(MEDIA_CONTRACT.map((e) => [e.pack.id, e] as const))(
+  'media contract: %s',
+  (_id, expected) => {
+    const mm = expected.pack.memoryModel;
+
+    it('is at the media-contract minor version', () => {
+      expect(expected.pack.version).toBe(expected.version);
+    });
+
+    it('declares the pinned modalities / processors / rawEvidence', () => {
+      expect(mm?.modalities).toEqual(expected.modalities);
+      expect(mm?.processors).toEqual(expected.processors);
+      expect(mm?.rawEvidence).toEqual(expected.rawEvidence);
+    });
+
+    it('requests ONLY capabilities an installed adapter can run', () => {
+      // ImageMetadataStubAdapter (image→caption) and
+      // TextExtractionPassthroughAdapter (document→text) are the whole
+      // installed set. Declaring ocr/asr/vision-caption would arm a
+      // capability that always denies at dispatch.
+      for (const processor of mm?.processors ?? []) {
+        expect(['image', 'document']).toContain(processor.modality);
+        for (const kind of processor.produces) {
+          expect(['caption', 'text']).toContain(kind);
+        }
+      }
+      const kinds = (mm?.processors ?? []).flatMap((p) => p.produces);
+      for (const unbuilt of ['ocr', 'asr', 'object_track', 'scene_graph', 'embedding']) {
+        expect(kinds).not.toContain(unbuilt);
+      }
+    });
+
+    it('never requests a processor for an undeclared input modality', () => {
+      for (const processor of mm?.processors ?? []) {
+        expect(mm?.modalities).toContain(processor.modality);
+      }
+    });
+
+    it('is a CONSENT SURFACE — install requires acceptModalities: true', () => {
+      // Non-text declarations make declaredModalitySection non-null, which
+      // is exactly what modalityConsentRequired keys off.
+      const section = declaredModalitySection(expected.pack);
+      expect(section).not.toBeNull();
+      expect(section?.modalities).not.toContain('text');
+      expect(
+        modalityConsentRequired({
+          packId: expected.pack.id,
+          version: expected.pack.version,
+          declared: section,
+          accepted: undefined,
+          priorAccepted: false,
+          priorChecksum: null,
+        }),
+      ).toContain('acceptModalities: true');
+      expect(modalitiesChecksum(section)).toEqual(expect.any(String));
+    });
+  },
+);
+
+describe('the media gates came alive (they denied every pack before)', () => {
+  const REAL_ESTATE = packById('real_estate');
+  const MEDICAL = packById('medical');
+  const FINTECH = packById('fintech');
+
+  /** A tenant that installed the pack with acceptModalities: true. */
+  const consent = (manifest: DomainPackManifest) => ({
+    manifest,
+    acceptedModalities: true,
+    acceptedModalitiesChecksum: modalitiesChecksum(declaredModalitySection(manifest)),
+  });
+  const asset = (modality: EvidenceModality) => ({ modality, availability: 'hot' });
+
+  describe('gateProcessorDispatch', () => {
+    it('ADMITS image→caption for a pack that declares the image processor', () => {
+      expect(
+        gateProcessorDispatch({
+          ...consent(REAL_ESTATE),
+          capability: 'caption',
+          asset: asset('image'),
+        }),
+      ).toEqual({ allowed: true });
+    });
+
+    it('ADMITS document→text for a document-only pack', () => {
+      expect(
+        gateProcessorDispatch({
+          ...consent(FINTECH),
+          capability: 'text',
+          asset: asset('document'),
+        }),
+      ).toEqual({ allowed: true });
+    });
+
+    it('DENIES image→caption for a pack that declares no image modality', () => {
+      const d = gateProcessorDispatch({
+        ...consent(FINTECH),
+        capability: 'caption',
+        asset: asset('image'),
+      });
+      expect(d.allowed).toBe(false);
+      if (!d.allowed) expect(d.reason).toContain('does not declare');
+    });
+
+    it('DENIES an unbuilt capability (ocr) on a declared modality', () => {
+      const d = gateProcessorDispatch({
+        ...consent(MEDICAL),
+        capability: 'ocr',
+        asset: asset('document'),
+      });
+      expect(d.allowed).toBe(false);
+      if (!d.allowed) expect(d.reason).toContain('does not declare');
+    });
+
+    it('DENIES without the operator consent flag, however good the declaration', () => {
+      const d = gateProcessorDispatch({
+        manifest: REAL_ESTATE,
+        acceptedModalities: false,
+        acceptedModalitiesChecksum: null,
+        capability: 'caption',
+        asset: asset('image'),
+      });
+      expect(d.allowed).toBe(false);
+      if (!d.allowed) expect(d.reason).toContain('acceptModalities: true');
+    });
+  });
+
+  describe('gateRawEvidence', () => {
+    it('ADMITS an affirmatively-clean fragment for the one pack that serves raw', () => {
+      expect(
+        gateRawEvidence({
+          ...consent(REAL_ESTATE),
+          callerScopes: ['brain:read'],
+          fragmentPiiClasses: [],
+        }),
+      ).toEqual({ allowed: true });
+    });
+
+    it('DENIES every pack that omits rawEvidence (omission = deny)', () => {
+      for (const expected of MEDIA_CONTRACT.filter((e) => e.rawEvidence === undefined)) {
+        const d = gateRawEvidence({
+          ...consent(expected.pack),
+          callerScopes: ['brain:read', 'brain:read_media'],
+          fragmentPiiClasses: [],
+        });
+        expect(d.allowed).toBe(false);
+        if (!d.allowed) expect(d.reason).toContain('does not declare the raw-evidence capability');
+      }
+    });
+
+    it('still fails closed on an unclassified fragment for the serving pack', () => {
+      const d = gateRawEvidence({
+        ...consent(REAL_ESTATE),
+        callerScopes: ['brain:read'],
+        fragmentPiiClasses: null,
+      });
+      expect(d.allowed).toBe(false);
+      if (!d.allowed) expect(d.reason).toContain('unclassified');
+    });
+
+    it('still needs brain:read_media for a classified fragment', () => {
+      const d = gateRawEvidence({
+        ...consent(REAL_ESTATE),
+        callerScopes: ['brain:read'],
+        fragmentPiiClasses: ['face'],
+      });
+      expect(d.allowed).toBe(false);
+      expect(
+        gateRawEvidence({
+          ...consent(REAL_ESTATE),
+          callerScopes: ['brain:read', 'brain:read_media'],
+          fragmentPiiClasses: ['face'],
+        }),
+      ).toEqual({ allowed: true });
+    });
   });
 });

--- a/test/eval/domain-packs/runner.ts
+++ b/test/eval/domain-packs/runner.ts
@@ -287,10 +287,15 @@ const seedInstruction = (cfg: Config): string =>
   ].join('\n');
 
 async function installOnePack(cfg: Config, pack: DomainPackManifest): Promise<string> {
+  // Every first-party pack declares a media section (modalities /
+  // processors / rawEvidence) as of the 0.3.0 line, so install is refused
+  // with a 400 unless the operator consents. The battery IS the operator
+  // here: it installs manifests it ships itself, having read them.
   const fromRegistry = (): Promise<RestResult<InstallOut>> =>
     restRaw<InstallOut>(cfg, 'POST', '/v1/admin/packs/from-registry', {
       packId: pack.id,
       version: pack.version,
+      acceptModalities: true,
     });
   let res = await fromRegistry();
   let republished = false;

--- a/test/industry-packs.e2e-spec.ts
+++ b/test/industry-packs.e2e-spec.ts
@@ -18,7 +18,12 @@ describe('industry domain packs (e2e)', () => {
       scopes: ['brain:read', 'brain:write', 'brain:admin'],
     });
     for (const pack of [FINTECH_PACK, MEDICAL_PACK, LEGAL_PACK]) {
-      await f.http.post('/v1/admin/packs').set(auth()).send({ manifest: pack });
+      // Every first-party pack declares a media section as of the 0.3.0
+      // line, so install without acceptModalities is a 400 by design.
+      await f.http
+        .post('/v1/admin/packs')
+        .set(auth())
+        .send({ manifest: pack, acceptModalities: true });
     }
   });
   afterAll(async () => {

--- a/test/marketplace.e2e-spec.ts
+++ b/test/marketplace.e2e-spec.ts
@@ -228,7 +228,7 @@ describe('registry marketplace (e2e)', () => {
       const r = await owner.http
         .post('/v1/admin/packs/from-registry')
         .set(auth(owner))
-        .send({ packId: PAID_ID });
+        .send({ packId: PAID_ID, acceptModalities: true });
       expect(r.status).toBe(402);
       expect(r.body).toMatchObject({
         statusCode: 402,
@@ -280,7 +280,7 @@ describe('registry marketplace (e2e)', () => {
       const r = await owner.http
         .post('/v1/admin/packs/from-registry')
         .set(auth(owner))
-        .send({ packId: PAID_ID });
+        .send({ packId: PAID_ID, acceptModalities: true });
       expect([200, 201]).toContain(r.status);
       expect(r.body.packId).toBe(PAID_ID);
       // Exactly the ONE successful install counted — not the earlier 402.
@@ -291,7 +291,7 @@ describe('registry marketplace (e2e)', () => {
       const r = await rival.http
         .post('/v1/admin/packs/from-registry')
         .set(auth(rival))
-        .send({ packId: PAID_ID });
+        .send({ packId: PAID_ID, acceptModalities: true });
       expect(r.status).toBe(402);
     });
   });
@@ -306,13 +306,13 @@ describe('registry marketplace (e2e)', () => {
       const paid = await rival.http
         .post('/v1/admin/packs/from-registry')
         .set(auth(rival))
-        .send({ packId: PAID_ID });
+        .send({ packId: PAID_ID, acceptModalities: true });
       expect(paid.status).toBe(503);
 
       const free = await owner.http
         .post('/v1/admin/packs/from-registry')
         .set(auth(owner))
-        .send({ packId: FREE_ID });
+        .send({ packId: FREE_ID, acceptModalities: true });
       expect([200, 201]).toContain(free.status);
     });
   });
@@ -334,7 +334,7 @@ describe('registry marketplace (e2e)', () => {
       const r = await rival.http
         .post('/v1/admin/packs/from-registry')
         .set(auth(rival))
-        .send({ packId: PAID_ID });
+        .send({ packId: PAID_ID, acceptModalities: true });
       expect([200, 201]).toContain(r.status);
     });
   });

--- a/test/pack-eval.e2e-spec.ts
+++ b/test/pack-eval.e2e-spec.ts
@@ -17,7 +17,11 @@ describe('/v1/admin/packs/:id/eval — pack eval fixtures (e2e)', () => {
       companyId: 'co_pack_eval_e2e',
       scopes: ['brain:read', 'brain:write', 'brain:admin'],
     });
-    await f.http.post('/v1/admin/packs').set(auth()).send({ manifest: REAL_ESTATE_PACK });
+    // real_estate declares a media section (0.3.0) — install needs consent.
+    await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: REAL_ESTATE_PACK, acceptModalities: true });
   });
   afterAll(async () => {
     if (f) await f.close();

--- a/test/pack-registry.e2e-spec.ts
+++ b/test/pack-registry.e2e-spec.ts
@@ -18,6 +18,10 @@ import { createApp } from './app-fixture';
 
 // A distinct pack id per run guards against catalogue rows lingering in the
 // shared system DB across spec files in one jest process.
+// It inherits real_estate's media section (modalities / processors /
+// rawEvidence, 0.3.0), so every install here passes acceptModalities: true —
+// the operator consent gate. pack-modality-consent.e2e-spec.ts owns the
+// refusal path; this file is about registry mechanics.
 const PACK = {
   ...REAL_ESTATE_PACK,
   id: 'realty_reg_e2e',
@@ -123,7 +127,7 @@ describe('/v1/registry — global pack registry (e2e)', () => {
     const r = await pub.http
       .post('/v1/admin/packs/from-registry')
       .set(auth(pub))
-      .send({ packId: PACK.id });
+      .send({ packId: PACK.id, acceptModalities: true });
     expect([200, 201]).toContain(r.status);
     expect(r.body.packId).toBe(PACK.id);
     expect(r.body.predicatesSeeded).toBe(PACK.predicates.length);
@@ -156,7 +160,7 @@ describe('/v1/registry — global pack registry (e2e)', () => {
     const pinned = await pub.http
       .post('/v1/admin/packs/from-registry')
       .set(auth(pub))
-      .send({ packId: PACK.id, version: '0.2.0' });
+      .send({ packId: PACK.id, version: '0.2.0', acceptModalities: true });
     expect(pinned.status).toBe(400);
 
     // Unyank restores it as latest.
@@ -172,7 +176,7 @@ describe('/v1/registry — global pack registry (e2e)', () => {
     const r = await pub.http
       .post('/v1/admin/packs/from-registry')
       .set(auth(pub))
-      .send({ packId: 'no_such_pack_xyz' });
+      .send({ packId: 'no_such_pack_xyz', acceptModalities: true });
     expect(r.status).toBe(404);
   });
 
@@ -220,7 +224,7 @@ describe('/v1/registry — global pack registry (e2e)', () => {
       const r = await pub.http
         .post('/v1/admin/packs/from-registry')
         .set(auth(pub))
-        .send({ packId: id });
+        .send({ packId: id, acceptModalities: true });
       expect([200, 201]).toContain(r.status);
     }
     versions = await reader.http.get(`/v1/registry/packs/${id}`).set(auth(reader));
@@ -236,7 +240,7 @@ describe('/v1/registry — global pack registry (e2e)', () => {
     const r = await pub.http
       .post('/v1/admin/packs/from-registry')
       .set(auth(pub))
-      .send({ packId: id, version: '0.2.0' });
+      .send({ packId: id, version: '0.2.0', acceptModalities: true });
     expect([200, 201]).toContain(r.status);
 
     const list = await reader.http.get('/v1/registry/packs?q=dl_count').set(auth(reader));
@@ -267,7 +271,7 @@ describe('/v1/registry — global pack registry (e2e)', () => {
     const refused = await pub.http
       .post('/v1/admin/packs/from-registry')
       .set(auth(pub))
-      .send({ packId: id, version: '0.3.0' });
+      .send({ packId: id, version: '0.3.0', acceptModalities: true });
     expect(refused.status).toBe(400);
 
     const versions = await reader.http.get(`/v1/registry/packs/${id}`).set(auth(reader));

--- a/test/real-estate-pack.e2e-spec.ts
+++ b/test/real-estate-pack.e2e-spec.ts
@@ -56,7 +56,11 @@ describe('real_estate pack — extractionProfile consumption (e2e)', () => {
   });
 
   it('installs the real_estate pack and surfaces its profile on the snapshot', async () => {
-    const r = await f.http.post('/v1/admin/packs').set(auth()).send({ manifest: REAL_ESTATE_PACK });
+    // real_estate declares a media section (0.3.0) — install needs consent.
+    const r = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: REAL_ESTATE_PACK, acceptModalities: true });
     expect([200, 201]).toContain(r.status);
     expect(r.body.packId).toBe('real_estate');
     expect(r.body.predicatesSeeded).toBe(REAL_ESTATE_PACK.predicates.length);

--- a/test/registry-ui.e2e-spec.ts
+++ b/test/registry-ui.e2e-spec.ts
@@ -32,8 +32,13 @@ describe('GET /registry/ui — public catalogue (e2e)', () => {
       privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
     );
     await f.http.post('/v1/admin/registry/packs').set(auth).send({ manifest });
-    // One install-from-registry → download counter at 1.
-    await f.http.post('/v1/admin/packs/from-registry').set(auth).send({ packId: 'realty_ui_e2e' });
+    // One install-from-registry → download counter at 1. The fixture
+    // inherits real_estate's media section (0.3.0), so the install needs
+    // the operator consent flag.
+    await f.http
+      .post('/v1/admin/packs/from-registry')
+      .set(auth)
+      .send({ packId: 'realty_ui_e2e', acceptModalities: true });
   });
   afterAll(async () => {
     delete process.env.DOMAIN_PACK_TRUSTED_KEYS;


### PR DESCRIPTION
## The gap

No domain pack declared `modalities`, `processors` or `rawEvidence` — all seven manifests said so verbatim. The consequence was four consumers that could only ever deny:

- `gateProcessorDispatch` (`src/evidence/processing/dispatch-gate.ts`) — clause (b), "pack does not declare a `<modality>→<capability>` processor need";
- the processor broker behind it;
- `gateRawEvidence` (`src/mcp/raw-evidence-gate.ts`) — clause (a), "pack does not declare the raw-evidence capability";
- through the latter, the whole raw-read gateway (`src/evidence/evidence-read.service.ts`) and the signed-URL mint path.

Every pack now declares the Evidence-Plane half of its `memoryModel`, domain-appropriately. Minor bump on each pack touched.

## What each pack declares

| pack | version | modalities | processors | rawEvidence | why |
|---|---|---|---|---|---|
| `real_estate` | 0.2.0 → **0.3.0** | text, image, document | image metadata, document text | **serve** | listing photos and floor plans are published marketing material |
| `medical` | 0.2.0 → **0.3.0** | text, image, document | image metadata, document text | deny | scans and X-ray photographs are clinical data |
| `insurance` | 0.2.0 → **0.3.0** | text, image, document | image metadata, document text | deny | claim photos carry injuries, plates, bystanders |
| `legal` | 0.2.0 → **0.3.0** | text, image, document | document text, image metadata | deny | contracts, filings and scanned exhibits carry privilege |
| `fintech` | 0.2.0 → **0.3.0** | text, document | document text | deny | statements / KYC files; `image` withheld (biometric-adjacent) |
| `hr` | 0.2.0 → **0.3.0** | text, document | document text | deny | CVs and offer letters are personal data; `image` withheld |
| `code_memory` (builtin) | 0.4.3 → **0.5.0** | text, image, document | image metadata, document text | deny | failure/dashboard screenshots + log artifacts |

**"deny" is the absence of the field.** The schema's only other value is `{ "serve": true }`, so omitting `rawEvidence` *is* the most conservative setting it offers — that is what medical got, and `gateRawEvidence` then refuses raw bytes and signed URLs for the pack unconditionally. `real_estate` is the single pack that declares `serve`, and declaring it only OPENS the gate: current modality consent plus the per-call media-PII gate (unclassified fails closed; classified needs `brain:read_media`) still apply per fragment.

**Only capabilities that can actually run.** Two processor entries appear anywhere in the library, because two adapters exist: `image → caption` (`ImageMetadataStubAdapter`) and `document → text` (`TextExtractionPassthroughAdapter`). No OCR, ASR or vision-caption processor is declared — with no adapter installed, such a declaration would arm a capability that always denies at dispatch. A unit test pins this: no `ocr` / `asr` / `object_track` / `scene_graph` / `embedding` anywhere in the library.

## Operator requirement: `acceptModalities`

Installing **any** first-party pack now requires explicit media consent. Without it the install is refused with a `400` naming what would be accepted:

```bash
POST /v1/admin/packs                { "manifest": …, "acceptModalities": true }
POST /v1/admin/packs/from-registry  { "packId": "medical", "acceptModalities": true }

BRAIN_API_KEY=... pnpm pack:install -- --brain-url $URL \
  --file packs/medical.pack.json --verify --accept-modalities
```

`scripts/install-pack.ts` grew the `--accept-modalities` flag (the documented CLI path had no way to pass the consent, so every first-party install would have 400'd). Consent is checksummed over the media section alone: a byte-identical section carries prior consent across an upgrade; any change to it re-requires the flag. Until consent is current both gates still deny — the declaration alone activates nothing.

**Builtin caveat, documented rather than papered over.** `code_memory` is a builtin, and builtins never pass through `DomainPackInstallService` (it rejects their ids), so no `domain_pack` consent row can exist for them. `MemoryModelReaderService` surfaces the declaration through its builtin-union path, but both media gates still deny at their consent clause. `code_memory`'s media section is a published contract, not an activation — which is also why it declares no `rawEvidence`: a pack seeded into every tenant without an install decision is the last one that should hold a raw-serving capability.

## Deliberately NOT in this PR: `requiredEvidenceCapability` seeding

No predicate gets `requiredEvidenceCapability` here, and that ordering is intentional. With zero evidence fragments in a tenant's store, seeding a non-text capability makes every answer over those predicates abstain unconditionally — `answer-integrity.ts` → `verdict.ts`, `reason: 'evidence_capability_unmet'`. Declaring perception is safe; requiring evidence that cannot exist yet is not. **Seed `requiredEvidenceCapability` only after fragments actually exist** — after ingest is producing assets and the two adapters are running against them. Noted in `docs/domain-packs.md` so the follow-up is not lost.

## Tests

`test/domain-pack.unit-spec.ts` gains, per pack: the pinned media version, the exact `modalities` / `processors` / `rawEvidence`, "only capabilities an installed adapter can run", "no processor for an undeclared input modality", and "this is a consent surface" (`declaredModalitySection` non-null, `modalityConsentRequired` demanding the flag).

Then the point of the whole change — the gates came alive:

- `gateProcessorDispatch` **ADMITS** `image→caption` for `real_estate` and `document→text` for `fintech`;
- **DENIES** `image→caption` for `fintech` (no image modality), `ocr` on a declared modality (unbuilt), and anything without the consent flag;
- `gateRawEvidence` **ADMITS** an affirmatively-clean fragment for `real_estate`;
- **DENIES** every pack that omits `rawEvidence` — even with `brain:read_media` — and still fails closed on an unclassified fragment, and still requires `brain:read_media` for a classified one.

Every existing predicate and eval predicate is untouched. The domain-packs eval battery and the e2e specs that install first-party manifests now pass `acceptModalities: true` (they are the operator in those runs). `packs/*.pack.json` regenerated from the TS source of truth; the drift guards in `industry-packs.unit-spec.ts` / `real-estate-pack.unit-spec.ts` are green.

## Gates

`pnpm typecheck`, `pnpm lint:ci`, `pnpm format:check`, `pnpm build` clean. Full `pnpm test:unit`: **364 suites / 4165 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
