### PR TITLE
feat(evidence): blob upload surface with scan and broker dispatch

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -41,6 +41,16 @@
         },
         "description": "State conflict — e.g. a lost/mismatched claim token, an already claimed work item, or an immutable-version republish."
       },
+      "EvidenceRejected": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "The uploaded evidence was rejected by the scan hook. The asset row survives as a tombstone (availability `gone`, quarantineStatus `rejected`) and the bytes are deleted; the message is deliberately content-free."
+      },
       "FeatureDisabled": {
         "content": {
           "application/json": {
@@ -70,6 +80,16 @@
           }
         },
         "description": "No such resource in this tenant."
+      },
+      "PayloadTooLarge": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "The uploaded part exceeds the effective transfer cap — min(EVIDENCE_MAX_BYTES, the 64 MiB memory-storage ceiling)."
       },
       "SubstrateDisabled": {
         "content": {
@@ -3331,6 +3351,63 @@
         ],
         "type": "object"
       },
+      "UploadEvidenceBlobResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "assetId": {
+            "type": "string"
+          },
+          "availability": {
+            "enum": [
+              "hot",
+              "cold",
+              "external",
+              "gone"
+            ],
+            "type": "string"
+          },
+          "byteHash": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "byteLength": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "deduped": {
+            "type": "boolean"
+          },
+          "dispatched": {
+            "type": "boolean"
+          },
+          "mediaType": {
+            "type": "string"
+          },
+          "quarantineStatus": {
+            "enum": [
+              "clean",
+              "scanning"
+            ],
+            "type": "string"
+          },
+          "storageRef": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "assetId",
+          "availability",
+          "deduped",
+          "byteHash",
+          "byteLength",
+          "storageRef",
+          "mediaType",
+          "quarantineStatus",
+          "dispatched"
+        ],
+        "type": "object"
+      },
       "UpsertPublisherProfileRequest": {
         "additionalProperties": false,
         "properties": {
@@ -5400,6 +5477,142 @@
           }
         },
         "summary": "Register a multimodal evidence asset (metadata-only)",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/ingest/evidence-blob": {
+      "post": {
+        "description": "Takes BYTES into custody: `multipart/form-data` with the content in the `file` part and the asset metadata as text parts. The server owns identity here — `byteHash` (sha256 of what it received), `byteLength` and `storageRef` are computed, never asserted — so the registered asset is blob-backed with availability derived as `hot`. Media types are an explicit conservative allowlist checked AGAINST the declared modality (application/json, application/pdf, audio/aac, audio/flac, audio/mp4, audio/mpeg, audio/ogg, audio/wav, image/avif, image/gif, image/jpeg, image/png, image/webp, text/csv, text/markdown, text/plain, video/mp4, video/quicktime, video/webm); anything else, including SVG, HTML, archives and `application/octet-stream`, is a 400. Transfer is capped at `min(EVIDENCE_MAX_BYTES, 64 MiB)` — an over-cap part is refused mid-upload with 413. Uploaded bytes are EXTERNAL INGEST by definition, so the asset registers with origin `external_ingest` and is SCANNED before it becomes dispatchable: a clean verdict answers 201, a rejection answers 422 with the row tombstoned and the bytes deleted, and a scan hook that cannot decide answers 201 with `quarantineStatus: \"scanning\"` (still dispatch-denied — the surface never fails open). An optional `packId` starts a FIRE-AND-FORGET processor dispatch that can never fail the upload. Same-user re-upload of identical bytes dedupes; a different principal gets a bare 409. Answers a bare 404 until `EVIDENCE_BLOB_UPLOAD_ENABLED=1` (raised before the body is parsed); answers 503 while `EVIDENCE_SUBSTRATE_ENABLED` or `EVIDENCE_QUARANTINE` is off, or when no storage adapter is configured. Source: src/evidence/evidence-ingest.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "uploadEvidenceBlob",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "durationMs": {
+                    "description": "Duration in milliseconds, when known.",
+                    "pattern": "^[0-9]+$",
+                    "type": "string"
+                  },
+                  "file": {
+                    "description": "The evidence bytes. Its Content-Type is the media type unless `mediaType` overrides it.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "height": {
+                    "description": "Pixel height, when known.",
+                    "pattern": "^[0-9]+$",
+                    "type": "string"
+                  },
+                  "mediaType": {
+                    "description": "Overrides the file part’s own Content-Type.",
+                    "type": "string"
+                  },
+                  "modality": {
+                    "description": "Drives pack consent, the dispatch gate and the fragment-locator matrix — the media type must be allowlisted FOR this modality: image → image/jpeg | image/png | image/gif | image/webp | image/avif; audio → audio/mpeg | audio/mp4 | audio/aac | audio/ogg | audio/wav | audio/flac; video → video/mp4 | video/webm | video/quicktime; document → application/pdf | text/plain | text/markdown | text/csv; sensor → application/json | text/csv.",
+                    "enum": [
+                      "image",
+                      "audio",
+                      "video",
+                      "document",
+                      "sensor"
+                    ],
+                    "type": "string"
+                  },
+                  "occurredAt": {
+                    "description": "When the observation happened (ISO-8601).",
+                    "type": "string"
+                  },
+                  "packId": {
+                    "description": "Installed pack to dispatch processors for, fire-and-forget, once the asset scans clean. Requires EVIDENCE_PROCESSOR_BROKER.",
+                    "type": "string"
+                  },
+                  "pageCount": {
+                    "description": "Page count, when known.",
+                    "pattern": "^[0-9]+$",
+                    "type": "string"
+                  },
+                  "piiClasses": {
+                    "description": "Comma-separated media PII classes (face, voice, biometric, id_document, sensitive). Fail-closed polarity: omit the field for “unclassified” (blocked); send it EMPTY for “a classifier looked and found nothing” (open).",
+                    "type": "string"
+                  },
+                  "recorder": {
+                    "description": "Free-text recorder identity.",
+                    "type": "string"
+                  },
+                  "retainUntil": {
+                    "description": "Retention horizon (ISO-8601).",
+                    "type": "string"
+                  },
+                  "scope": {
+                    "description": "Comma-separated scope tags (0093).",
+                    "type": "string"
+                  },
+                  "userId": {
+                    "description": "Per-user scope owner (0055): fail-closed reads for others.",
+                    "type": "string"
+                  },
+                  "vertical": {
+                    "description": "Tenant vertical the asset belongs to.",
+                    "type": "string"
+                  },
+                  "width": {
+                    "description": "Pixel width, when known.",
+                    "pattern": "^[0-9]+$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file",
+                  "modality",
+                  "occurredAt",
+                  "vertical"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadEvidenceBlobResponse"
+                }
+              }
+            },
+            "description": "Stored, registered and scanned asset."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "413": {
+            "$ref": "#/components/responses/PayloadTooLarge"
+          },
+          "422": {
+            "$ref": "#/components/responses/EvidenceRejected"
+          },
+          "503": {
+            "$ref": "#/components/responses/SubstrateDisabled"
+          }
+        },
+        "summary": "Upload an evidence blob (bytes)",
         "tags": [
           "Evidence"
         ]

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -41,6 +41,16 @@
         },
         "description": "State conflict — e.g. a lost/mismatched claim token, an already claimed work item, or an immutable-version republish."
       },
+      "EvidenceRejected": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "The uploaded evidence was rejected by the scan hook. The asset row survives as a tombstone (availability `gone`, quarantineStatus `rejected`) and the bytes are deleted; the message is deliberately content-free."
+      },
       "FeatureDisabled": {
         "content": {
           "application/json": {
@@ -70,6 +80,16 @@
           }
         },
         "description": "No such resource in this tenant."
+      },
+      "PayloadTooLarge": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        },
+        "description": "The uploaded part exceeds the effective transfer cap — min(EVIDENCE_MAX_BYTES, the 64 MiB memory-storage ceiling)."
       },
       "SubstrateDisabled": {
         "content": {
@@ -3331,6 +3351,63 @@
         ],
         "type": "object"
       },
+      "UploadEvidenceBlobResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "assetId": {
+            "type": "string"
+          },
+          "availability": {
+            "enum": [
+              "hot",
+              "cold",
+              "external",
+              "gone"
+            ],
+            "type": "string"
+          },
+          "byteHash": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "byteLength": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "deduped": {
+            "type": "boolean"
+          },
+          "dispatched": {
+            "type": "boolean"
+          },
+          "mediaType": {
+            "type": "string"
+          },
+          "quarantineStatus": {
+            "enum": [
+              "clean",
+              "scanning"
+            ],
+            "type": "string"
+          },
+          "storageRef": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "assetId",
+          "availability",
+          "deduped",
+          "byteHash",
+          "byteLength",
+          "storageRef",
+          "mediaType",
+          "quarantineStatus",
+          "dispatched"
+        ],
+        "type": "object"
+      },
       "UpsertPublisherProfileRequest": {
         "additionalProperties": false,
         "properties": {
@@ -5400,6 +5477,142 @@
           }
         },
         "summary": "Register a multimodal evidence asset (metadata-only)",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/ingest/evidence-blob": {
+      "post": {
+        "description": "Takes BYTES into custody: `multipart/form-data` with the content in the `file` part and the asset metadata as text parts. The server owns identity here — `byteHash` (sha256 of what it received), `byteLength` and `storageRef` are computed, never asserted — so the registered asset is blob-backed with availability derived as `hot`. Media types are an explicit conservative allowlist checked AGAINST the declared modality (application/json, application/pdf, audio/aac, audio/flac, audio/mp4, audio/mpeg, audio/ogg, audio/wav, image/avif, image/gif, image/jpeg, image/png, image/webp, text/csv, text/markdown, text/plain, video/mp4, video/quicktime, video/webm); anything else, including SVG, HTML, archives and `application/octet-stream`, is a 400. Transfer is capped at `min(EVIDENCE_MAX_BYTES, 64 MiB)` — an over-cap part is refused mid-upload with 413. Uploaded bytes are EXTERNAL INGEST by definition, so the asset registers with origin `external_ingest` and is SCANNED before it becomes dispatchable: a clean verdict answers 201, a rejection answers 422 with the row tombstoned and the bytes deleted, and a scan hook that cannot decide answers 201 with `quarantineStatus: \"scanning\"` (still dispatch-denied — the surface never fails open). An optional `packId` starts a FIRE-AND-FORGET processor dispatch that can never fail the upload. Same-user re-upload of identical bytes dedupes; a different principal gets a bare 409. Answers a bare 404 until `EVIDENCE_BLOB_UPLOAD_ENABLED=1` (raised before the body is parsed); answers 503 while `EVIDENCE_SUBSTRATE_ENABLED` or `EVIDENCE_QUARANTINE` is off, or when no storage adapter is configured. Source: src/evidence/evidence-ingest.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "uploadEvidenceBlob",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "durationMs": {
+                    "description": "Duration in milliseconds, when known.",
+                    "pattern": "^[0-9]+$",
+                    "type": "string"
+                  },
+                  "file": {
+                    "description": "The evidence bytes. Its Content-Type is the media type unless `mediaType` overrides it.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "height": {
+                    "description": "Pixel height, when known.",
+                    "pattern": "^[0-9]+$",
+                    "type": "string"
+                  },
+                  "mediaType": {
+                    "description": "Overrides the file part’s own Content-Type.",
+                    "type": "string"
+                  },
+                  "modality": {
+                    "description": "Drives pack consent, the dispatch gate and the fragment-locator matrix — the media type must be allowlisted FOR this modality: image → image/jpeg | image/png | image/gif | image/webp | image/avif; audio → audio/mpeg | audio/mp4 | audio/aac | audio/ogg | audio/wav | audio/flac; video → video/mp4 | video/webm | video/quicktime; document → application/pdf | text/plain | text/markdown | text/csv; sensor → application/json | text/csv.",
+                    "enum": [
+                      "image",
+                      "audio",
+                      "video",
+                      "document",
+                      "sensor"
+                    ],
+                    "type": "string"
+                  },
+                  "occurredAt": {
+                    "description": "When the observation happened (ISO-8601).",
+                    "type": "string"
+                  },
+                  "packId": {
+                    "description": "Installed pack to dispatch processors for, fire-and-forget, once the asset scans clean. Requires EVIDENCE_PROCESSOR_BROKER.",
+                    "type": "string"
+                  },
+                  "pageCount": {
+                    "description": "Page count, when known.",
+                    "pattern": "^[0-9]+$",
+                    "type": "string"
+                  },
+                  "piiClasses": {
+                    "description": "Comma-separated media PII classes (face, voice, biometric, id_document, sensitive). Fail-closed polarity: omit the field for “unclassified” (blocked); send it EMPTY for “a classifier looked and found nothing” (open).",
+                    "type": "string"
+                  },
+                  "recorder": {
+                    "description": "Free-text recorder identity.",
+                    "type": "string"
+                  },
+                  "retainUntil": {
+                    "description": "Retention horizon (ISO-8601).",
+                    "type": "string"
+                  },
+                  "scope": {
+                    "description": "Comma-separated scope tags (0093).",
+                    "type": "string"
+                  },
+                  "userId": {
+                    "description": "Per-user scope owner (0055): fail-closed reads for others.",
+                    "type": "string"
+                  },
+                  "vertical": {
+                    "description": "Tenant vertical the asset belongs to.",
+                    "type": "string"
+                  },
+                  "width": {
+                    "description": "Pixel width, when known.",
+                    "pattern": "^[0-9]+$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file",
+                  "modality",
+                  "occurredAt",
+                  "vertical"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadEvidenceBlobResponse"
+                }
+              }
+            },
+            "description": "Stored, registered and scanned asset."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "413": {
+            "$ref": "#/components/responses/PayloadTooLarge"
+          },
+          "422": {
+            "$ref": "#/components/responses/EvidenceRejected"
+          },
+          "503": {
+            "$ref": "#/components/responses/SubstrateDisabled"
+          }
+        },
+        "summary": "Upload an evidence blob (bytes)",
         "tags": [
           "Evidence"
         ]

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -125,7 +125,8 @@ overview — one line per flag, plus the orderings that matter.
 |---|---|---|
 | `EVIDENCE_SUBSTRATE_ENABLED` | `0` | Master switch for the multimodal evidence substrate writers (evidence_asset / evidence_fragment / derived_representation, 0109); off = every write 503s. GDPR cascade + retention run regardless. |
 | `EVIDENCE_FS_ROOT` | unset | Directory root for the `fs://` storage adapter; unset = the adapter throws a clear unconfigured error. |
-| `EVIDENCE_MAX_BYTES` | 1 GiB | Sanity cap on a registered asset's DECLARED byteLength (a claim bound — no upload endpoint ships). |
+| `EVIDENCE_MAX_BYTES` | 1 GiB | Sanity cap on a registered asset's DECLARED byteLength, and the transfer bound of the blob upload surface — applied there as `min(this, 64 MiB)`, so raising it past that memory-storage ceiling raises nothing. |
+| `EVIDENCE_BLOB_UPLOAD_ENABLED` | `0` | The byte surface: `POST /v1/ingest/evidence-blob` (multipart) — bytes into the content-addressed storage adapter, server-computed `byteHash`/`byteLength`/`storageRef`, asset registered `hot` and SCANNED before it is dispatchable. Media types are a conservative allowlist checked against the declared modality (no SVG/HTML/archives/octet-stream). Off = a bare 404 raised BEFORE the body is parsed. Requires `EVIDENCE_FS_ROOT`, the substrate flag, and `EVIDENCE_QUARANTINE` (uploaded bytes are external ingest — see the quarantine order below). |
 | `EVIDENCE_PROCESSOR_BROKER` | `0` | Trusted platform-owned processor adapters over registered assets, each run an idempotent `processing_run` row (0121). Requires the substrate flag. |
 | `EVIDENCE_QUARANTINE` | `0` | External-ingest quarantine seam (0121): assets get `quarantineStatus` (`clean` internal / `quarantined` external_ingest); the broker refuses non-clean assets. **Off = `origin:'external_ingest'` is rejected 503 outright (fail closed)** — enable BEFORE accepting any externally-sourced media. |
 | `EVIDENCE_DERIVED_MAX_BYTES` | 1 MiB | Cap on what an adapter may read from a blob and on any single derived output (reject, never truncate). |
@@ -144,7 +145,13 @@ then consider `EVIDENCE_UNGROUNDED_EXCLUDE` / `_SERVING_GATE` (both
 treat legacy unstamped rows leniently, but a gate enabled on a corpus
 with zero stamps protects nothing). **Quarantine order:** enable
 `EVIDENCE_QUARANTINE` before any external media ingest — while it is
-off, external-origin registration is refused entirely.
+off, external-origin registration is refused entirely. That is also why
+`EVIDENCE_BLOB_UPLOAD_ENABLED` needs it: bytes arriving over HTTP are
+external ingest by definition, so with the seam off every upload answers
+503 (boot warns on the pair). Note the scan hook shipped today is the
+ALLOW-ALL stub — it exercises the quarantined → scanning → clean
+lifecycle but passes everything; install a real scanner before trusting
+uploads from untrusted callers.
 
 ### `TOOL_OBSERVATION*` — MCP tool-call observations (0111)
 

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -131,7 +131,14 @@ import {
   IngestEvidenceAssetResponseSchema,
   IngestEvidenceFragmentResultSchema,
   IngestEvidenceFragmentSchema,
+  UploadEvidenceBlobResponseSchema,
 } from '../src/contracts/evidence/evidence-ingest.schema';
+import {
+  EVIDENCE_UPLOAD_MEDIA_TYPES,
+  EVIDENCE_UPLOAD_MEDIA_TYPES_FLAT,
+} from '../src/evidence/upload-media-types';
+import { EVIDENCE_MODALITIES } from '../src/common/evidence-taxonomy';
+import { MEDIA_PII_CLASSES } from '../src/common/media-pii';
 
 type Json = Record<string, unknown>;
 
@@ -239,6 +246,7 @@ const ZOD_COMPONENTS: Record<string, z.ZodType> = {
   IngestEvidenceAssetRequest: IngestEvidenceAssetRequestSchema,
   IngestEvidenceFragmentResult: IngestEvidenceFragmentResultSchema,
   IngestEvidenceAssetResponse: IngestEvidenceAssetResponseSchema,
+  UploadEvidenceBlobResponse: UploadEvidenceBlobResponseSchema,
 };
 
 function generateComponentSchemas(): Json {
@@ -1497,6 +1505,125 @@ function evidenceIngestPaths(): Json {
         },
       }),
     },
+    '/v1/ingest/evidence-blob': {
+      post: operation({
+        operationId: 'uploadEvidenceBlob',
+        tag: 'Evidence',
+        summary: 'Upload an evidence blob (bytes)',
+        description:
+          'Takes BYTES into custody: `multipart/form-data` with the ' +
+          'content in the `file` part and the asset metadata as text ' +
+          'parts. The server owns identity here — `byteHash` (sha256 of ' +
+          'what it received), `byteLength` and `storageRef` are computed, ' +
+          'never asserted — so the registered asset is blob-backed with ' +
+          'availability derived as `hot`. Media types are an explicit ' +
+          'conservative allowlist checked AGAINST the declared modality ' +
+          `(${EVIDENCE_UPLOAD_MEDIA_TYPES_FLAT.join(', ')}); anything ` +
+          'else, including SVG, HTML, archives and ' +
+          '`application/octet-stream`, is a 400. Transfer is capped at ' +
+          '`min(EVIDENCE_MAX_BYTES, 64 MiB)` — an over-cap part is ' +
+          'refused mid-upload with 413. Uploaded bytes are EXTERNAL ' +
+          'INGEST by definition, so the asset registers with origin ' +
+          '`external_ingest` and is SCANNED before it becomes ' +
+          'dispatchable: a clean verdict answers 201, a rejection answers ' +
+          '422 with the row tombstoned and the bytes deleted, and a scan ' +
+          'hook that cannot decide answers 201 with `quarantineStatus: ' +
+          '"scanning"` (still dispatch-denied — the surface never fails ' +
+          'open). An optional `packId` starts a FIRE-AND-FORGET processor ' +
+          'dispatch that can never fail the upload. Same-user re-upload ' +
+          'of identical bytes dedupes; a different principal gets a bare ' +
+          '409. Answers a bare 404 until `EVIDENCE_BLOB_UPLOAD_ENABLED=1` ' +
+          '(raised before the body is parsed); answers 503 while ' +
+          '`EVIDENCE_SUBSTRATE_ENABLED` or `EVIDENCE_QUARANTINE` is off, ' +
+          'or when no storage adapter is configured. ' +
+          'Source: src/evidence/evidence-ingest.controller.ts.',
+        scope: 'brain:write',
+        requestBody: uploadEvidenceBlobBody(),
+        responses: {
+          '201': jsonResponse(
+            'Stored, registered and scanned asset.',
+            ref('UploadEvidenceBlobResponse'),
+          ),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+          '409': errorRef('Conflict'),
+          '413': errorRef('PayloadTooLarge'),
+          '422': errorRef('EvidenceRejected'),
+          '503': errorRef('SubstrateDisabled'),
+        },
+      }),
+    },
+  };
+}
+
+/**
+ * The multipart request body of the blob upload — written by hand rather
+ * than generated from a zod object because every metadata part arrives as
+ * a STRING on the wire (multipart has no numbers, no arrays and no null),
+ * and a generated schema would promise types the transport cannot carry.
+ */
+function uploadEvidenceBlobBody(): Json {
+  const text = (description: string): Json => ({ type: 'string', description });
+  const intText = (description: string): Json => ({
+    type: 'string',
+    pattern: '^[0-9]+$',
+    description,
+  });
+  return {
+    required: true,
+    content: {
+      'multipart/form-data': {
+        schema: {
+          type: 'object',
+          required: ['file', 'modality', 'occurredAt', 'vertical'],
+          properties: {
+            file: {
+              type: 'string',
+              format: 'binary',
+              description:
+                'The evidence bytes. Its Content-Type is the media type ' +
+                'unless `mediaType` overrides it.',
+            },
+            modality: {
+              type: 'string',
+              enum: [...EVIDENCE_MODALITIES],
+              description:
+                'Drives pack consent, the dispatch gate and the ' +
+                'fragment-locator matrix — the media type must be ' +
+                'allowlisted FOR this modality: ' +
+                EVIDENCE_MODALITIES.map(
+                  (m) => `${m} → ${EVIDENCE_UPLOAD_MEDIA_TYPES[m].join(' | ')}`,
+                ).join('; ') +
+                '.',
+            },
+            mediaType: text('Overrides the file part’s own Content-Type.'),
+            occurredAt: text('When the observation happened (ISO-8601).'),
+            vertical: text('Tenant vertical the asset belongs to.'),
+            userId: text('Per-user scope owner (0055): fail-closed reads for others.'),
+            scope: text('Comma-separated scope tags (0093).'),
+            piiClasses: {
+              type: 'string',
+              description:
+                'Comma-separated media PII classes ' +
+                `(${MEDIA_PII_CLASSES.join(', ')}). Fail-closed polarity: ` +
+                'omit the field for “unclassified” (blocked); send it EMPTY ' +
+                'for “a classifier looked and found nothing” (open).',
+            },
+            recorder: text('Free-text recorder identity.'),
+            retainUntil: text('Retention horizon (ISO-8601).'),
+            width: intText('Pixel width, when known.'),
+            height: intText('Pixel height, when known.'),
+            durationMs: intText('Duration in milliseconds, when known.'),
+            pageCount: intText('Page count, when known.'),
+            packId: text(
+              'Installed pack to dispatch processors for, fire-and-forget, ' +
+                'once the asset scans clean. Requires EVIDENCE_PROCESSOR_BROKER.',
+            ),
+          },
+        },
+      },
+    },
   };
 }
 
@@ -1512,6 +1639,16 @@ function errorResponses(): Json {
         'claimed work item, or an immutable-version republish.',
     ),
     TooManyRequests: err('Per-credential throttle exceeded.'),
+    PayloadTooLarge: err(
+      'The uploaded part exceeds the effective transfer cap — ' +
+        'min(EVIDENCE_MAX_BYTES, the 64 MiB memory-storage ceiling).',
+    ),
+    EvidenceRejected: err(
+      'The uploaded evidence was rejected by the scan hook. The asset ' +
+        'row survives as a tombstone (availability `gone`, ' +
+        'quarantineStatus `rejected`) and the bytes are deleted; the ' +
+        'message is deliberately content-free.',
+    ),
     FeatureDisabled: jsonResponse(
       'The document pipeline is dark (DOCUMENT_INGEST_ENABLED off).',
       ref('FeatureDisabledResponse'),

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1321,6 +1321,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Evidence ingest surface (Brain v2.1 M3): POST /v1/ingest/evidence-asset. Off (default) = the route answers a bare 404 (scenes-surface precedent), byte-identical prod. Metadata-only by design (MM-6 boundary): originUri required, storageRef rejected, no bytes accepted. Requires EVIDENCE_SUBSTRATE_ENABLED — ingest-on/substrate-off answers 503 from the write seam and env-validation warns at boot.',
   },
   {
+    key: 'EVIDENCE_BLOB_UPLOAD_ENABLED',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Evidence blob upload surface (Brain v2.1 MM-7): POST /v1/ingest/evidence-blob (multipart/form-data) — the ONE route that takes bytes into custody. Bytes land in the content-addressed storage adapter (needs EVIDENCE_FS_ROOT), the server computes byteHash/byteLength itself, and the asset registers blob-backed with availability derived as 'hot'. Registers with origin 'external_ingest', so it ALSO requires EVIDENCE_QUARANTINE (503 otherwise — bytes over HTTP are external ingest; no external bytes without the scan seam) plus EVIDENCE_SUBSTRATE_ENABLED. The upload is scanned before it becomes dispatchable (clean → 201, rejected → 422 with the row tombstoned and the blob deleted, hook failure → 201 with the asset left quarantined and dispatch-denied). An optional packId fires a FIRE-AND-FORGET broker dispatch when EVIDENCE_PROCESSOR_BROKER is on. Media types are an explicit conservative allowlist checked against the declared modality (no SVG, no HTML, no archives, no octet-stream); transfer is capped at min(EVIDENCE_MAX_BYTES, a 64 MiB memory-storage ceiling). Off (default) = the route answers a bare 404 BEFORE the multipart body is parsed — byte-identical prod, and no caller bytes are ever buffered.",
+  },
+  {
     key: 'EVIDENCE_FS_ROOT',
     category: 'pipeline',
     defaultValue: '',
@@ -1336,7 +1345,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: true,
     isBooleanFlag: false,
     description:
-      'Sanity cap on the DECLARED byteLength of a registered evidence asset (default 1 GiB). A claim bound, not a transfer limit — this release ships no upload endpoint.',
+      'Sanity cap on the DECLARED byteLength of a registered evidence asset (default 1 GiB). It is also the transfer bound of the blob upload surface (EVIDENCE_BLOB_UPLOAD_ENABLED), applied there as min(this, a 64 MiB memory-storage ceiling) — raising it past that ceiling raises nothing.',
   },
   {
     key: 'EVIDENCE_PROCESSOR_BROKER',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -261,6 +261,7 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // ── Evidence plane: claim grounding (Drift-1, migration 0115) ──────
   validateEvidenceGroundingEnv(env, warnings);
   validateEvidenceIngestEnv(env, warnings);
+  validateEvidenceUploadEnv(env, warnings);
 
   // ── Evidence plane: processing lifecycle (migration 0121) ──────────
   validateEvidenceProcessingEnv(env, warnings);
@@ -523,6 +524,39 @@ function validateEvidenceIngestEnv(env: NodeJS.ProcessEnv, warnings: string[]): 
         'the ingest surface is exposed but the evidence write seam refuses every ' +
         'call; every POST /v1/ingest/evidence-asset will be rejected (503) until ' +
         'EVIDENCE_SUBSTRATE_ENABLED is turned on.',
+    );
+  }
+}
+
+/**
+ * Cross-flag consistency for the blob upload surface (Brain v2.1 MM-7).
+ * Two WARNINGS, not errors — nothing here is a fail-open; both pairs
+ * simply mean every upload bounces:
+ *
+ *  - without EVIDENCE_SUBSTRATE_ENABLED the write seam refuses;
+ *  - without EVIDENCE_QUARANTINE the store refuses origin
+ *    'external_ingest', which is the ONLY origin an upload can honestly
+ *    claim (bytes crossing an HTTP boundary are external ingest). That
+ *    refusal is the MM-6 fail-closed rule working as designed, so the
+ *    fix is to turn the scan seam on, never to relabel the bytes.
+ */
+function validateEvidenceUploadEnv(env: NodeJS.ProcessEnv, warnings: string[]): void {
+  if (!envFlagEnabled(env.EVIDENCE_BLOB_UPLOAD_ENABLED)) return;
+  if (!envFlagEnabled(env.EVIDENCE_SUBSTRATE_ENABLED)) {
+    warnings.push(
+      'EVIDENCE_BLOB_UPLOAD_ENABLED is set while EVIDENCE_SUBSTRATE_ENABLED is not — ' +
+        'the upload surface is exposed but the evidence write seam refuses every ' +
+        'call; every POST /v1/ingest/evidence-blob will be rejected (503) until ' +
+        'EVIDENCE_SUBSTRATE_ENABLED is turned on.',
+    );
+  }
+  if (!envFlagEnabled(env.EVIDENCE_QUARANTINE)) {
+    warnings.push(
+      'EVIDENCE_BLOB_UPLOAD_ENABLED is set while EVIDENCE_QUARANTINE is not — ' +
+        'uploaded bytes register as external ingest, which the store refuses ' +
+        'without the quarantine seam (fail closed); every POST ' +
+        '/v1/ingest/evidence-blob will be rejected (503) until ' +
+        'EVIDENCE_QUARANTINE is turned on.',
     );
   }
 }
@@ -1129,6 +1163,15 @@ const KNOWN_BOOLEAN_FLAGS = [
   // actually accept writes — validateEvidenceIngestEnv warns on the
   // inconsistent pair (ingest-on/substrate-off ⇒ every call 503s).
   'EVIDENCE_INGEST_ENABLED',
+  // Evidence blob upload surface (Brain v2.1 MM-7): POST
+  // /v1/ingest/evidence-blob — multipart bytes → content-addressed
+  // storage adapter → registerAsset(storageRef) → scan → fire-and-forget
+  // broker dispatch. Default off ⇒ a bare 404 raised BEFORE the body is
+  // parsed (no caller bytes buffered), byte-identical prod. Needs
+  // EVIDENCE_SUBSTRATE_ENABLED and — because bytes over HTTP are
+  // external ingest — EVIDENCE_QUARANTINE; validateEvidenceUploadEnv
+  // warns on either inconsistent pair.
+  'EVIDENCE_BLOB_UPLOAD_ENABLED',
   // Claim grounding (Drift-1, migration 0115): write-side post-resolve
   // stamp of knowledge_fact.groundingStatus; fail-closed mention capture
   // (requires EPISODE_SUBSTRATE_ENABLED — validateEvidenceGroundingEnv

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -45,6 +45,34 @@ export function evidenceIngestEnabled(): boolean {
 }
 
 /**
+ * Blob upload surface (Brain v2.1 MM-7) — EVIDENCE_BLOB_UPLOAD_ENABLED.
+ *
+ * When on, POST /v1/ingest/evidence-blob exists: the ONE surface that
+ * takes BYTES into custody (multipart/form-data), stores them through the
+ * content-addressed storage adapter, and registers the resulting asset
+ * blob-backed (availability 'hot'). Off (default) ⇒ the route answers a
+ * bare 404 BEFORE the multipart body is parsed (the interceptor gate — an
+ * off surface must not buffer a caller's bytes) and prod stays
+ * byte-identical.
+ *
+ * Sits ON TOP of the sibling flags rather than replacing them: the write
+ * seam still needs EVIDENCE_SUBSTRATE_ENABLED (503 off), and — because
+ * bytes arriving over HTTP ARE external ingest — the upload registers with
+ * origin 'external_ingest', which the store REFUSES (503) unless
+ * EVIDENCE_QUARANTINE is on. That is the MM-6 doctrine held verbatim, not
+ * a new rule: no external bytes may enter without the scan seam.
+ * EVIDENCE_INGEST_ENABLED governs only the metadata-only sibling route
+ * and is deliberately NOT consulted here — a deployment may take bytes
+ * without opening caller-asserted metadata registration, or the reverse.
+ *
+ * Read at call time (runtime-mutable). Env read lives here in the common
+ * layer, NOT inside the controller (engine-gates S5.2).
+ */
+export function evidenceBlobUploadEnabled(): boolean {
+  return envFlagEnabled(process.env.EVIDENCE_BLOB_UPLOAD_ENABLED);
+}
+
+/**
  * Filesystem storage-adapter root — EVIDENCE_FS_ROOT (non-boolean).
  *
  * The directory the fs:// adapter stores content-addressed blobs under
@@ -69,11 +97,14 @@ const DEFAULT_MAX_BYTES = 1073741824;
  * Declared-size sanity cap — EVIDENCE_MAX_BYTES (non-boolean).
  *
  * registerAsset rejects a declared byteLength above this cap — a bound on
- * what a caller may claim an observation weighs, NOT a transfer limit
- * (this PR ships no upload endpoint). A non-boolean knob resolved here in
- * the common layer so the write seam takes a resolved number (engine-
- * gates S5.2); read at call time so a change is runtime-mutable. Must be
- * a positive integer; unset, blank, or invalid → the 1 GiB default.
+ * what a caller may claim an observation weighs. It is ALSO the transfer
+ * bound of the blob upload surface (EVIDENCE_BLOB_UPLOAD_ENABLED), where
+ * it is applied as `min(cap, the upload interceptor's memory-storage
+ * ceiling)` — deny-overrides, so raising this knob past that ceiling
+ * raises nothing. A non-boolean knob resolved here in the common layer so
+ * the write seam takes a resolved number (engine-gates S5.2); read at
+ * call time so a change is runtime-mutable. Must be a positive integer;
+ * unset, blank, or invalid → the 1 GiB default.
  */
 export function evidenceMaxBytes(): number {
   const raw = process.env.EVIDENCE_MAX_BYTES;

--- a/src/contracts/evidence/evidence-ingest.schema.ts
+++ b/src/contracts/evidence/evidence-ingest.schema.ts
@@ -113,6 +113,47 @@ export const IngestEvidenceFragmentResultSchema = z.object({
   representationId: z.string().optional(),
 });
 
+/**
+ * Response of the BYTE surface (POST /v1/ingest/evidence-blob —
+ * EVIDENCE_BLOB_UPLOAD_ENABLED, default off → 404). The request is
+ * `multipart/form-data`, so its shape is documented inline on the path
+ * rather than as a zod object: the bytes ride the `file` part and every
+ * metadata field arrives as a text part.
+ *
+ * Identity fields are echoed because the SERVER produced them — byteHash
+ * is sha256 over the bytes actually received (not a caller assertion, as
+ * on the metadata surface), byteLength is measured, storageRef is minted
+ * by the storage adapter, and mediaType is the canonical (parameter-free,
+ * lowercased) form that the row stores.
+ */
+export const UploadEvidenceBlobResponseSchema = z.object({
+  assetId: z.string(),
+  /** 'hot' for a fresh upload; a same-user dedup echoes the stored state. */
+  availability: z.enum(['hot', 'cold', 'external', 'gone']),
+  /** True when these exact bytes were already this user's asset. */
+  deduped: z.boolean(),
+  byteHash: z.string().regex(/^[0-9a-f]{64}$/),
+  byteLength: z.number().int().positive(),
+  storageRef: z.string(),
+  mediaType: z.string(),
+  /**
+   * Post-scan state. 'clean' = scanned and dispatchable. 'scanning' =
+   * the scan hook could not render a verdict, so the asset stays
+   * quarantined and dispatch-denied (fail closed) and is re-scannable —
+   * the upload is NOT silently treated as clean. A 'rejected' verdict
+   * never appears here: it answers 422 with the row tombstoned and the
+   * bytes deleted.
+   */
+  quarantineStatus: z.enum(['clean', 'scanning']),
+  /**
+   * Whether a processor dispatch was STARTED for the requested packId —
+   * never whether it succeeded. Dispatch is fire-and-forget by design: a
+   * failing adapter must not fail an ingestion whose bytes are already
+   * stored, registered and scanned.
+   */
+  dispatched: z.boolean(),
+});
+
 export const IngestEvidenceAssetResponseSchema = z.object({
   assetId: z.string(),
   /**

--- a/src/evidence/blob-upload.interceptor.ts
+++ b/src/evidence/blob-upload.interceptor.ts
@@ -1,0 +1,95 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+  NotFoundException,
+  Type,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import type { Observable } from 'rxjs';
+import { evidenceBlobUploadEnabled, evidenceMaxBytes } from '../common/evidence-flags';
+
+/** The multipart part name carrying the bytes. */
+export const EVIDENCE_BLOB_FIELD = 'file';
+
+/**
+ * Memory-storage ceiling, 64 MiB. Multer's default storage is in-memory,
+ * so an accepted part is a resident Buffer for the life of the request —
+ * EVIDENCE_MAX_BYTES defaults to 1 GiB, which is a fine bound on what a
+ * caller may CLAIM an observation weighs and a terrible bound on what one
+ * request may pin in the heap. The effective transfer cap is therefore
+ * `min(EVIDENCE_MAX_BYTES, this)`: raising the env knob past the ceiling
+ * raises nothing (deny-overrides), lowering it below takes effect at
+ * once. A streaming/disk-backed adapter is the follow-up that lifts this.
+ */
+const TRANSFER_CEILING_BYTES = 67_108_864;
+
+/**
+ * The multipart part as multer's memory storage hands it over. Declared
+ * locally rather than imported from `@types/multer`: the type is four
+ * fields we actually read, and the alternative is a new devDependency on
+ * a supply-chain-gated tree for an interface we can spell ourselves.
+ * (`@nestjs/platform-express` already depends on multer at runtime — no
+ * new runtime dependency is introduced by this surface.)
+ */
+export interface UploadedEvidenceBlob {
+  /** Original client-side filename — never used as a path. */
+  originalname: string;
+  /** The part's declared Content-Type; checked against the allowlist. */
+  mimetype: string;
+  size: number;
+  buffer: Buffer;
+}
+
+/**
+ * Blob-upload multipart gate (Brain v2.1 MM-7).
+ *
+ * Two jobs the stock `FileInterceptor(...)` decorator cannot do, both
+ * because a decorator argument is evaluated ONCE at module load:
+ *
+ *  1. Flag gate BEFORE parsing. `EVIDENCE_BLOB_UPLOAD_ENABLED` off must
+ *     answer a bare 404 without buffering the caller's bytes — and it
+ *     must be thrown HERE, not in the handler: parameter pipes run after
+ *     interceptors, so an unparsed multipart body would fail DTO
+ *     validation with a 400 and thereby advertise that the dark route
+ *     exists. Throwing from the interceptor keeps the off-state answer
+ *     byte-identical to every other gated route.
+ *  2. Runtime-mutable size cap. `limits.fileSize` is fixed at decorator
+ *     evaluation; resolving it per call keeps EVIDENCE_MAX_BYTES the
+ *     live knob the catalogue promises. Delegates are memoised per cap,
+ *     so a stable configuration builds exactly one multer instance.
+ *
+ * An over-cap part fails inside multer, which Nest maps to 413 — the
+ * connection is aborted mid-upload rather than after a full buffer.
+ */
+@Injectable()
+export class EvidenceBlobUploadInterceptor implements NestInterceptor {
+  private readonly delegates = new Map<number, NestInterceptor>();
+
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<unknown> | Promise<Observable<unknown>> {
+    if (!evidenceBlobUploadEnabled()) throw new NotFoundException();
+    return this.delegateFor(Math.min(evidenceMaxBytes(), TRANSFER_CEILING_BYTES)).intercept(
+      context,
+      next,
+    );
+  }
+
+  /** One memoised multer-backed interceptor per effective byte cap. */
+  private delegateFor(cap: number): NestInterceptor {
+    const cached = this.delegates.get(cap);
+    if (cached) return cached;
+    const Mixin: Type<NestInterceptor> = FileInterceptor(EVIDENCE_BLOB_FIELD, {
+      // files: 1 — a registration is one observation, not a batch.
+      // fields/parts bound the metadata side so a multipart body cannot
+      // become an unbounded field storm.
+      limits: { fileSize: cap, files: 1, fields: 32, parts: 40 },
+    });
+    const made = new Mixin();
+    this.delegates.set(cap, made);
+    return made;
+  }
+}

--- a/src/evidence/dto/upload-evidence-blob.dto.ts
+++ b/src/evidence/dto/upload-evidence-blob.dto.ts
@@ -1,0 +1,158 @@
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsIn,
+  IsISO8601,
+  IsInt,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { EVIDENCE_MODALITIES, type EvidenceModality } from '../../common/evidence-taxonomy';
+import { MEDIA_PII_CLASSES, type MediaPiiClass } from '../../common/media-pii';
+
+/**
+ * Wire shape of the metadata half of POST /v1/ingest/evidence-blob
+ * (`multipart/form-data`; the bytes ride the `file` part).
+ * EVIDENCE_BLOB_UPLOAD_ENABLED, default off → 404.
+ *
+ * SERVER-OWNED, therefore absent here on purpose:
+ *
+ *   - `byteHash` — sha256 of the bytes the server actually received. On
+ *     the metadata-only sibling route the hash is a caller assertion
+ *     because the caller keeps the bytes; here the server takes custody,
+ *     so it computes the 0109 identity itself. A caller-supplied hash
+ *     could only ever disagree with the bytes, and a disagreement has no
+ *     honest resolution.
+ *   - `byteLength` — likewise measured, not declared.
+ *   - `storageRef` — minted by the storage adapter.
+ *   - `origin` — always 'external_ingest': bytes crossing an HTTP
+ *     boundary ARE external ingest (the MM-6 doctrine), which is why the
+ *     surface needs EVIDENCE_QUARANTINE.
+ *
+ * Every field below arrives as a multipart TEXT part, i.e. a string.
+ * Numbers are converted with @Type (a non-numeric value becomes NaN and
+ * fails @IsInt — a clean 400, never a silent 0), and the two list fields
+ * are comma-separated because a repeated multipart field name would make
+ * "one value" and "a list of one" indistinguishable.
+ */
+
+/** Max entries in a comma-separated `scope` list — mirrors the JSON DTO. */
+const SCOPE_MAX = 32;
+
+/**
+ * Split a comma-separated multipart field into a trimmed list. The EMPTY
+ * STRING maps to `[]`, which is load-bearing for `piiClasses`: under the
+ * media fail-closed polarity (src/common/media-pii.ts) an absent field
+ * means "unclassified ⇒ blocked" while `[]` means "a classifier looked
+ * and found nothing ⇒ open". Multipart has no null, so the empty string
+ * is the only way to say the second thing — and dropping empty segments
+ * makes `a,,b` mean `[a, b]` rather than smuggling a blank class in.
+ */
+function splitList(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  return value
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part !== '');
+}
+
+export class UploadEvidenceBlobDto {
+  @IsIn(EVIDENCE_MODALITIES)
+  modality!: EvidenceModality;
+
+  /**
+   * Overrides the uploaded part's own Content-Type. Optional: the part
+   * usually declares it. Either way the effective value is checked
+   * against the upload allowlist AND against `modality` — see
+   * src/evidence/upload-media-types.ts.
+   */
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  mediaType?: string | undefined;
+
+  /** When the observation happened (ISO-8601). */
+  @IsISO8601()
+  occurredAt!: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  vertical!: string;
+
+  /** Per-user scope (0055 discipline): fail-closed reads for others. */
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  userId?: string | undefined;
+
+  /** Comma-separated scope tags (0093). */
+  @IsOptional()
+  @Transform(({ value }) => splitList(value))
+  @IsArray()
+  @IsString({ each: true })
+  @MaxLength(200, { each: true })
+  @ArrayMaxSize(SCOPE_MAX)
+  scope?: string[] | undefined;
+
+  /**
+   * Comma-separated media PII classes. Fail-closed polarity: field absent
+   * = unclassified = blocked; empty string = affirmatively clean.
+   */
+  @IsOptional()
+  @Transform(({ value }) => splitList(value))
+  @IsArray()
+  @IsIn(MEDIA_PII_CLASSES, { each: true })
+  piiClasses?: MediaPiiClass[] | undefined;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  recorder?: string | undefined;
+
+  /** Retention horizon; past it the sweeper tombstones the asset. */
+  @IsOptional()
+  @IsISO8601()
+  retainUntil?: string | undefined;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  width?: number | undefined;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  height?: number | undefined;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  durationMs?: number | undefined;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  pageCount?: number | undefined;
+
+  /**
+   * Installed pack to dispatch processors for once the asset is
+   * registered and scanned clean. Optional, and FIRE-AND-FORGET: an
+   * unknown pack, a pack without modality consent, or a failing adapter
+   * is logged and never touches the upload's response (respects
+   * EVIDENCE_PROCESSOR_BROKER — off ⇒ nothing is dispatched at all). The
+   * admin maintenance sweep is the way to (re)dispatch after the fact.
+   */
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  packId?: string | undefined;
+}

--- a/src/evidence/evidence-admin.controller.ts
+++ b/src/evidence/evidence-admin.controller.ts
@@ -1,0 +1,96 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  NotFoundException,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { ApiKeyService } from '../auth/api-key.service';
+import { resolvePlatformTenant } from '../auth/tenant-scope';
+import { evidenceSubstrateEnabled, processorBrokerEnabled } from '../common/evidence-flags';
+import {
+  EvidenceProcessorBrokerService,
+  type DispatchSweepResult,
+} from './processor-broker.service';
+
+/** Param belt: a pack id is a short slug, not free text. */
+const PACK_ID_MAX_CHARS = 200;
+/** Param belt: an asset id is a `evidence_asset:<tail>` record id. */
+const ASSET_ID_MAX_CHARS = 256;
+
+interface DispatchBody {
+  tenant?: string;
+  packId?: string;
+  assetId?: string;
+  limit?: number;
+}
+
+/**
+ * POST /v1/admin/maintenance/evidence/dispatch — the operator's handle on
+ * the trusted processor broker (Brain v2.1 MM-7).
+ *
+ * The upload path dispatches for at most the pack a caller names, at the
+ * moment bytes land. That leaves the two cases an operator actually has:
+ * a pack installed AFTER assets were registered, and a processor adapter
+ * added to the platform after a pack was installed. This verb sweeps the
+ * existing corpus for both — bounded per call, replay-idempotent (the
+ * broker's deterministic run ids + INSERT IGNORE), and per-asset
+ * fault-tolerant.
+ *
+ * Follows the admin-scenes idiom exactly: `brain:admin`, the shared
+ * resolvePlatformTenant seam (an admin key reaches only its OWN tenant
+ * unless it carries `brain:platform_admin` AND the override gate is on),
+ * and a bare 404 while the feature is off — the double gate, so a dark
+ * broker never advertises a maintenance surface. Deliberately NOT a cron:
+ * v1 ships no scheduler (processing-run.service.ts claimRun), and a sweep
+ * that runs itself would need its own flag, its own claim, and its own
+ * backpressure story.
+ */
+@Controller('v1/admin')
+@UseGuards(ApiKeyGuard)
+export class EvidenceAdminController {
+  constructor(
+    private readonly broker: EvidenceProcessorBrokerService,
+    private readonly apiKeys: ApiKeyService,
+  ) {}
+
+  @Post('maintenance/evidence/dispatch')
+  @RequireScopes('brain:admin')
+  async dispatch(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: DispatchBody = {},
+  ): Promise<DispatchSweepResult> {
+    // Double-gate idiom: 404 here + the service's own 503 gate (off =
+    // zero queries, byte-identical prod).
+    if (!processorBrokerEnabled() || !evidenceSubstrateEnabled()) throw new NotFoundException();
+    const packId = (body.packId ?? '').trim();
+    if (packId === '' || packId.length > PACK_ID_MAX_CHARS) {
+      throw new BadRequestException(
+        `packId is required and must be at most ${PACK_ID_MAX_CHARS} characters`,
+      );
+    }
+    const assetId = this.assetId(body.assetId);
+    const tenant = resolvePlatformTenant(req, body.tenant, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
+    return this.broker.dispatchSweep(tenant, {
+      packId,
+      assetId,
+      limit: body.limit,
+    });
+  }
+
+  /** Optional single-asset target; the broker clamps the sweep bound. */
+  private assetId(raw: string | undefined): string | undefined {
+    if (raw === undefined) return undefined;
+    const assetId = raw.trim();
+    if (!assetId.startsWith('evidence_asset:') || assetId.length > ASSET_ID_MAX_CHARS) {
+      throw new BadRequestException('assetId must be an evidence_asset record id');
+    }
+    return assetId;
+  }
+}

--- a/src/evidence/evidence-ingest.controller.ts
+++ b/src/evidence/evidence-ingest.controller.ts
@@ -5,15 +5,24 @@ import {
   NotFoundException,
   Post,
   Req,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import type { AuthenticatedRequest } from '../auth/api-key.types';
 import { PolicyAction } from '../policy/action-registry';
-import { evidenceIngestEnabled } from '../common/evidence-flags';
+import { evidenceBlobUploadEnabled, evidenceIngestEnabled } from '../common/evidence-flags';
+import {
+  EVIDENCE_BLOB_FIELD,
+  EvidenceBlobUploadInterceptor,
+  type UploadedEvidenceBlob,
+} from './blob-upload.interceptor';
 import { EvidenceStoreService } from './evidence-store.service';
+import { EvidenceUploadService, type UploadEvidenceBlobResult } from './evidence-upload.service';
 import { validateLocator } from './locator';
 import { IngestEvidenceAssetDto, IngestEvidenceFragmentDto } from './dto/ingest-evidence-asset.dto';
+import { UploadEvidenceBlobDto } from './dto/upload-evidence-blob.dto';
 
 /**
  * Producer stamp for caller-asserted fragment excerpts: the "producer"
@@ -36,21 +45,33 @@ export interface IngestEvidenceAssetResult {
 }
 
 /**
- * POST /v1/ingest/evidence-asset — the HTTP surface of the evidence
- * substrate (Brain v2.1 M3), METADATA-ONLY by design (the MM-6
- * quarantine boundary): the caller registers what an observation IS
- * (modality, mediaType, byteHash identity, dimensions) and WHERE it
- * lives (`originUri`, never fetched) — no bytes cross this surface and
- * `storageRef` is rejected by the forbidNonWhitelisted pipe, so a fresh
- * registration is always availability='external'. Blob-backed
- * registration stays service-level until the upload/quarantine design
- * lands.
+ * The evidence substrate's two write-side HTTP surfaces, each behind its
+ * own flag and each honest about whether bytes change hands.
  *
- * Dark behind EVIDENCE_INGEST_ENABLED (default off → bare 404, the
- * scenes-surface precedent; byte-identical prod). The write seam
- * additionally requires EVIDENCE_SUBSTRATE_ENABLED (off → 503;
- * env-validation warns at boot on the inconsistent pair). All flags read
- * at call time (runtime-mutable).
+ * POST /v1/ingest/evidence-asset (Brain v2.1 M3) is METADATA-ONLY by
+ * design (the MM-6 quarantine boundary): the caller registers what an
+ * observation IS (modality, mediaType, byteHash identity, dimensions) and
+ * WHERE it lives (`originUri`, never fetched) — no bytes cross it and
+ * `storageRef` is rejected by the forbidNonWhitelisted pipe, so a fresh
+ * registration is always availability='external'.
+ *
+ * POST /v1/ingest/evidence-blob (Brain v2.1 MM-7) is the byte surface:
+ * `multipart/form-data`, the bytes stored content-addressed through the
+ * storage adapter, availability DERIVED as 'hot', and the asset scanned
+ * before it is dispatchable. Because bytes arriving over HTTP are
+ * external ingest by definition, it registers with origin
+ * 'external_ingest' and therefore inherits the MM-6 fence: without
+ * EVIDENCE_QUARANTINE the store refuses (503) and nothing is written.
+ * The server owns byteHash / byteLength / storageRef there — a caller
+ * that hands over the bytes cannot also assert what they are.
+ *
+ * Both routes are dark by default (EVIDENCE_INGEST_ENABLED and
+ * EVIDENCE_BLOB_UPLOAD_ENABLED, independently — a deployment may take
+ * bytes without opening caller-asserted registration, or the reverse) and
+ * answer a bare 404 when off, the scenes-surface precedent; prod stays
+ * byte-identical. Both additionally need EVIDENCE_SUBSTRATE_ENABLED at
+ * the write seam (off → 503; env-validation warns at boot on the
+ * inconsistent pair). All flags read at call time (runtime-mutable).
  *
  * Semantics inherited from the ONE write seam (EvidenceStoreService):
  * same-user re-registration of a known byteHash dedupes
@@ -64,7 +85,10 @@ export interface IngestEvidenceAssetResult {
 @Controller('v1/ingest')
 @UseGuards(ApiKeyGuard)
 export class EvidenceIngestController {
-  constructor(private readonly store: EvidenceStoreService) {}
+  constructor(
+    private readonly store: EvidenceStoreService,
+    private readonly uploads: EvidenceUploadService,
+  ) {}
 
   @Post('evidence-asset')
   @RequireScopes('brain:write')
@@ -115,6 +139,48 @@ export class EvidenceIngestController {
       deduped: asset.deduped,
       fragments,
     };
+  }
+
+  /**
+   * The byte surface. Same guard, same `brain:write` scope and same
+   * tenant fence as its metadata sibling — `companyId` comes from the
+   * authenticated key, never from the multipart body, so a caller cannot
+   * name a tenant. Its own ABAC action (`rest.ingest.evidence_blob`) so a
+   * policy can open metadata registration without also opening byte
+   * custody.
+   *
+   * The flag is checked TWICE on purpose: the interceptor throws first
+   * (before multer buffers anything, and before parameter pipes could
+   * turn an unparsed body into a route-revealing 400), and this line is
+   * the seam a unit test can pin without a multipart fixture.
+   */
+  @Post('evidence-blob')
+  @RequireScopes('brain:write')
+  @PolicyAction('rest.ingest.evidence_blob')
+  @UseInterceptors(EvidenceBlobUploadInterceptor)
+  async uploadEvidenceBlob(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: UploadEvidenceBlobDto,
+    @UploadedFile() file?: UploadedEvidenceBlob,
+  ): Promise<UploadEvidenceBlobResult> {
+    if (!evidenceBlobUploadEnabled()) throw new NotFoundException();
+    if (!file) throw new BadRequestException(`a '${EVIDENCE_BLOB_FIELD}' file part is required`);
+    return this.uploads.upload(req.brainAuth.companyId, file, {
+      modality: body.modality,
+      mediaType: body.mediaType,
+      occurredAt: new Date(body.occurredAt),
+      vertical: body.vertical,
+      userId: body.userId,
+      scope: body.scope,
+      piiClasses: body.piiClasses,
+      recorder: body.recorder,
+      retainUntil: body.retainUntil !== undefined ? new Date(body.retainUntil) : undefined,
+      width: body.width,
+      height: body.height,
+      durationMs: body.durationMs,
+      pageCount: body.pageCount,
+      packId: body.packId,
+    });
   }
 
   /**

--- a/src/evidence/evidence-upload.service.ts
+++ b/src/evidence/evidence-upload.service.ts
@@ -1,0 +1,283 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  Logger,
+  PayloadTooLargeException,
+  ServiceUnavailableException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import { evidenceMaxBytes, processorBrokerEnabled } from '../common/evidence-flags';
+import type { EvidenceModality } from '../common/evidence-taxonomy';
+import type { MediaPiiClass } from '../common/media-pii';
+import type { UploadedEvidenceBlob } from './blob-upload.interceptor';
+import { EvidenceStoreService } from './evidence-store.service';
+import { EvidenceProcessorBrokerService } from './processor-broker.service';
+import { EvidenceQuarantineService } from './quarantine.service';
+import {
+  EVIDENCE_STORAGE_ADAPTERS,
+  type EvidenceStorageAdapter,
+  type EvidenceStorageRegistry,
+} from './storage/storage-adapter';
+import { normalizeUploadMediaType, uploadMediaTypeError } from './upload-media-types';
+
+/**
+ * The scheme uploads are stored under. v1 registers exactly one adapter
+ * (fs://); resolving by SCHEME rather than by concrete class keeps the
+ * seam the rest of the substrate uses — an s3-class adapter is a registry
+ * entry plus this constant, never a rewrite of the upload path.
+ */
+export const EVIDENCE_UPLOAD_SCHEME = 'fs';
+
+export interface UploadEvidenceBlobInput {
+  modality: EvidenceModality;
+  /** Overrides the multipart part's own Content-Type when present. */
+  mediaType?: string | undefined;
+  occurredAt: Date;
+  vertical: string;
+  userId?: string | undefined;
+  scope?: string[] | undefined;
+  piiClasses?: MediaPiiClass[] | undefined;
+  recorder?: string | undefined;
+  retainUntil?: Date | undefined;
+  width?: number | undefined;
+  height?: number | undefined;
+  durationMs?: number | undefined;
+  pageCount?: number | undefined;
+  /** Optional fire-and-forget processor dispatch target. */
+  packId?: string | undefined;
+}
+
+export interface UploadEvidenceBlobResult {
+  assetId: string;
+  /** 'hot' for a fresh upload; a dedup returns the existing row's state. */
+  availability: string;
+  deduped: boolean;
+  /** sha256 computed over the RECEIVED bytes — the 0109 asset identity. */
+  byteHash: string;
+  byteLength: number;
+  storageRef: string;
+  mediaType: string;
+  /**
+   * Post-scan state. 'clean' = the scan hook passed and the asset is
+   * dispatchable; 'scanning' = the hook could not render a verdict, so
+   * the asset stays quarantined-closed (the quarantine service's own
+   * behaviour on a throwing hook) and is re-scannable. 'rejected' never
+   * appears here — it answers 422.
+   */
+  quarantineStatus: 'clean' | 'scanning';
+  /** Whether a broker dispatch was STARTED (never whether it succeeded). */
+  dispatched: boolean;
+}
+
+/**
+ * EvidenceUploadService (Brain v2.1 MM-7) — the byte-ingest pipeline
+ * behind POST /v1/ingest/evidence-blob, composed entirely out of seams
+ * that already existed and had no production caller:
+ *
+ *   bytes → storage adapter put() → registerAsset(storageRef) → runScan()
+ *         → (fire-and-forget) dispatchForPack()
+ *
+ * Each step keeps its own gate; this service invents no new ones:
+ *
+ *  - registerAsset passes `origin: 'external_ingest'`, so the store's own
+ *    MM-6 fence applies — EVIDENCE_QUARANTINE off ⇒ 503 and NOTHING is
+ *    registered. Bytes that arrive over HTTP are external ingest by
+ *    definition; there is no honest way to call them internal.
+ *  - availability is DERIVED, not asserted: the store re-heads the blob
+ *    through the adapter registry and compares byte lengths, so a fresh
+ *    upload lands 'hot' only because the bytes are genuinely there.
+ *  - the scan is synchronous and BLOCKING (v1 has no scheduler): an
+ *    upload's asset is never dispatchable before a verdict, and a
+ *    'rejected' verdict has already tombstoned the row and deleted the
+ *    blob by the time this service raises 422.
+ *  - the broker dispatch is the ONLY step that may fail silently, and it
+ *    is deliberately never awaited (see dispatch()).
+ *
+ * ORPHAN BLOBS. put() is content-addressed and idempotent, which means a
+ * blob is SHARED by construction: the same bytes from a second caller
+ * land on the same ref. So when registerAsset throws (409 on another
+ * principal's hash, or any transient failure) this service does NOT
+ * delete what it just wrote — the bytes may already be another row's.
+ * An unreferenced blob is inert (no row ⇒ not servable, not enumerable,
+ * not dispatchable) and is reused verbatim by the next successful
+ * registration of the same content. The ONE case where deletion is
+ * provably safe is a 'rejected' verdict: a rejected asset never keeps a
+ * storageRef, so nothing can reference those bytes.
+ */
+@Injectable()
+export class EvidenceUploadService {
+  private readonly logger = new Logger(EvidenceUploadService.name);
+
+  // Four collaborators because the pipeline IS the composition of four
+  // seams (store / blob storage / quarantine / broker); splitting it
+  // would only move the wiring somewhere less obvious.
+  // eslint-disable-next-line max-params
+  constructor(
+    private readonly store: EvidenceStoreService,
+    @Inject(EVIDENCE_STORAGE_ADAPTERS)
+    private readonly adapters: EvidenceStorageRegistry,
+    private readonly quarantine: EvidenceQuarantineService,
+    private readonly broker: EvidenceProcessorBrokerService,
+  ) {}
+
+  async upload(
+    companyId: string,
+    blob: UploadedEvidenceBlob,
+    input: UploadEvidenceBlobInput,
+  ): Promise<UploadEvidenceBlobResult> {
+    const mediaType = this.checkShape(blob, input);
+    const adapter = this.adapter();
+    const byteHash = createHash('sha256').update(blob.buffer).digest('hex');
+    const { storageRef } = await this.put(adapter, { companyId, byteHash, data: blob.buffer });
+    const asset = await this.store.registerAsset(companyId, {
+      modality: input.modality,
+      mediaType,
+      byteHash,
+      byteLength: blob.buffer.byteLength,
+      occurredAt: input.occurredAt,
+      // The bytes ARE in our custody now — storageRef, never originUri.
+      storageRef,
+      origin: 'external_ingest',
+      vertical: input.vertical,
+      userId: input.userId,
+      scope: input.scope,
+      piiClasses: input.piiClasses,
+      recorder: input.recorder,
+      retainUntil: input.retainUntil,
+      width: input.width,
+      height: input.height,
+      durationMs: input.durationMs,
+      pageCount: input.pageCount,
+    });
+    const quarantineStatus = await this.scan(adapter, {
+      companyId,
+      assetId: asset.assetId,
+      storageRef,
+    });
+    return {
+      assetId: asset.assetId,
+      availability: asset.availability,
+      deduped: asset.deduped,
+      byteHash,
+      byteLength: blob.buffer.byteLength,
+      storageRef,
+      mediaType,
+      quarantineStatus,
+      dispatched:
+        quarantineStatus === 'clean' && this.dispatch(companyId, asset.assetId, input.packId),
+    };
+  }
+
+  /** Size + media-type admission. Returns the effective media type. */
+  private checkShape(blob: UploadedEvidenceBlob, input: UploadEvidenceBlobInput): string {
+    const bytes = blob.buffer.byteLength;
+    if (bytes === 0) throw new BadRequestException('the uploaded file part is empty');
+    const cap = evidenceMaxBytes();
+    // Belt to the interceptor's braces: multer already refuses an
+    // over-cap part mid-stream, but the cap is runtime-mutable and this
+    // is the check the write seam would otherwise fail on with a
+    // confusing "declared byteLength" message.
+    if (bytes > cap) {
+      throw new PayloadTooLargeException(`uploaded bytes (${bytes}) exceed the cap of ${cap}`);
+    }
+    const mediaType = input.mediaType ?? blob.mimetype;
+    const err = uploadMediaTypeError(input.modality, mediaType);
+    if (err) throw new BadRequestException(err);
+    // The CANONICAL form is what the row stores: an accepted part sent as
+    // `text/plain; charset=utf-8` must not produce a different asset row
+    // than the same bytes sent as `text/plain`.
+    return normalizeUploadMediaType(mediaType);
+  }
+
+  /** The upload-scheme adapter, or a loud retryable operator error. */
+  private adapter(): EvidenceStorageAdapter {
+    const adapter = this.adapters.get(EVIDENCE_UPLOAD_SCHEME);
+    if (!adapter) {
+      throw new ServiceUnavailableException(
+        `no '${EVIDENCE_UPLOAD_SCHEME}' storage adapter is registered — ` +
+          'the blob upload surface has nowhere to put bytes',
+      );
+    }
+    return adapter;
+  }
+
+  /**
+   * Store the bytes. An adapter failure (EVIDENCE_FS_ROOT unset, a full
+   * disk, a permission problem) is OPERATOR state, not caller error —
+   * 503, and the message stays the adapter's own so the operator can act
+   * on it. Nothing has been written to the DB at this point.
+   */
+  private async put(
+    adapter: EvidenceStorageAdapter,
+    blob: { companyId: string; byteHash: string; data: Buffer },
+  ): Promise<{ storageRef: string }> {
+    try {
+      return await adapter.put(blob.companyId, blob.byteHash, blob.data);
+    } catch (e) {
+      const message = (e as Error).message;
+      this.logger.error(`evidence blob put failed for ${blob.companyId}: ${message}`);
+      throw new ServiceUnavailableException(`evidence blob storage is unavailable: ${message}`);
+    }
+  }
+
+  /**
+   * Scan-before-serve. The quarantine service owns every state
+   * transition; this only maps its three outcomes onto the HTTP surface:
+   *
+   *   clean     → the asset is dispatchable, 201;
+   *   rejected  → the row is already a tombstone and the bytes are gone,
+   *               422 with a content-free message (a scan verdict must
+   *               not describe what it matched on);
+   *   throw     → the service left the asset 'scanning', which the
+   *               dispatch gate denies. Fail CLOSED and say so in the
+   *               response rather than pretending the scan passed.
+   */
+  private async scan(
+    adapter: EvidenceStorageAdapter,
+    asset: { companyId: string; assetId: string; storageRef: string },
+  ): Promise<'clean' | 'scanning'> {
+    let verdict: 'clean' | 'rejected' | null = null;
+    try {
+      verdict = (await this.quarantine.runScan(asset.companyId, asset.assetId)).quarantineStatus;
+    } catch (e) {
+      this.logger.warn(
+        `evidence scan for ${asset.assetId} did not complete (${(e as Error).message}) — ` +
+          'the asset stays quarantined and dispatch-denied',
+      );
+    }
+    if (verdict !== 'rejected') return verdict === 'clean' ? 'clean' : 'scanning';
+    // The reject leg already tombstoned + deleted. The TERMINAL no-op
+    // (bytes rejected on an earlier upload, re-uploaded now) did not —
+    // and a rejected asset never keeps a storageRef, so removing what we
+    // just re-materialised cannot strand another row's bytes.
+    await adapter.delete(asset.storageRef).catch(() => false);
+    throw new UnprocessableEntityException('the uploaded evidence was rejected by the scan hook');
+  }
+
+  /**
+   * Fire-and-forget processor dispatch. NEVER awaited and never able to
+   * fail the upload: the bytes are already stored, registered and
+   * scanned, so an unknown pack or a broken adapter must not turn a
+   * successful ingestion into an error. Returns whether a dispatch was
+   * started, not whether it will succeed. Off (EVIDENCE_PROCESSOR_BROKER)
+   * or with no packId ⇒ nothing is scheduled at all.
+   */
+  private dispatch(companyId: string, assetId: string, packId: string | undefined): boolean {
+    if (packId === undefined || packId.trim() === '' || !processorBrokerEnabled()) return false;
+    void this.broker
+      .dispatchForPack(companyId, { packId, assetId })
+      .then((res) => {
+        for (const denial of res.denied) {
+          this.logger.debug(`dispatch ${assetId}/${denial.capability} denied: ${denial.reason}`);
+        }
+      })
+      .catch((e: unknown) => {
+        this.logger.warn(
+          `post-upload dispatch for ${assetId} (pack ${packId}) failed: ${(e as Error).message}`,
+        );
+      });
+    return true;
+  }
+}

--- a/src/evidence/evidence.module.ts
+++ b/src/evidence/evidence.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { EvidenceBlobUploadInterceptor } from './blob-upload.interceptor';
+import { EvidenceAdminController } from './evidence-admin.controller';
 import { EvidenceIngestController } from './evidence-ingest.controller';
 import { EvidenceReadController } from './evidence-read.controller';
 import { EvidenceReadService } from './evidence-read.service';
 import { EvidenceStoreService } from './evidence-store.service';
+import { EvidenceUploadService } from './evidence-upload.service';
 import { EvidenceProcessorBrokerService } from './processor-broker.service';
 import { EvidenceQuarantineService } from './quarantine.service';
 import { ImageMetadataStubAdapter } from './processing/adapters/image-metadata-stub.adapter';
@@ -26,10 +29,13 @@ import {
  * write seam (EvidenceStoreService) + the blob storage-adapter registry.
  * v1 registers ONE adapter (fs://); an s3-class adapter is a new
  * provider + one more Map entry — consumers resolve by storageRef
- * scheme, never by concrete class. The metadata-only ingest controller
- * (POST /v1/ingest/evidence-asset, dark behind EVIDENCE_INGEST_ENABLED
- * → bare 404) is the ONE write-side HTTP surface; the read gateway
- * below is its bytes-out counterpart. Injections into the GDPR /
+ * scheme, never by concrete class. EvidenceIngestController owns both
+ * write-side HTTP surfaces — the metadata-only registration (POST
+ * /v1/ingest/evidence-asset, EVIDENCE_INGEST_ENABLED) and the MM-7 byte
+ * upload (POST /v1/ingest/evidence-blob, EVIDENCE_BLOB_UPLOAD_ENABLED:
+ * multipart → storage adapter → registerAsset → scan → fire-and-forget
+ * dispatch), both dark by default → bare 404; the read gateway
+ * below is their bytes-out counterpart. Injections into the GDPR /
  * sweeper paths are @Optional so positionally-constructed unit
  * fixtures stay valid. SurrealService comes from the @Global db module.
  *
@@ -39,8 +45,11 @@ import {
  * scan-hook STUB. Adapters are PLATFORM code registered HERE — a pack
  * can only declare needs, never supply processors (anti-DSL doctrine).
  * All of it default-off behind EVIDENCE_PROCESSOR_BROKER /
- * EVIDENCE_QUARANTINE; exports exist for tests and future PR-C
- * consumers.
+ * EVIDENCE_QUARANTINE; exports exist for tests and cross-module
+ * consumers. EvidenceAdminController (MM-7) is the operator's entry into
+ * the broker — POST /v1/admin/maintenance/evidence/dispatch, 404 while
+ * the broker is dark, sweeping already-registered assets that no upload
+ * dispatch covered.
  *
  * Raw-read gateway (MM-3, migration 0125): EvidenceReadController is
  * the ONE surface that serves original bytes back out — stream, signed-
@@ -50,7 +59,7 @@ import {
  * @Global auth/policy modules.
  */
 @Module({
-  controllers: [EvidenceIngestController, EvidenceReadController],
+  controllers: [EvidenceIngestController, EvidenceReadController, EvidenceAdminController],
   providers: [
     FsEvidenceStorageAdapter,
     {
@@ -75,12 +84,15 @@ import {
     EvidenceProcessorBrokerService,
     { provide: EVIDENCE_SCAN_HOOK, useClass: AllowAllScanHook },
     EvidenceQuarantineService,
+    EvidenceBlobUploadInterceptor,
+    EvidenceUploadService,
   ],
   exports: [
     EvidenceStoreService,
     ProcessingRunService,
     EvidenceProcessorBrokerService,
     EvidenceQuarantineService,
+    EvidenceUploadService,
   ],
 })
 export class EvidenceModule {}

--- a/src/evidence/processor-broker.service.ts
+++ b/src/evidence/processor-broker.service.ts
@@ -1,8 +1,14 @@
-import { Inject, Injectable, NotFoundException, ServiceUnavailableException } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import type { DomainPackManifest } from '../ai/domain-packs';
 import { evidenceSubstrateEnabled, processorBrokerEnabled } from '../common/evidence-flags';
 import type { DerivedRepresentationKind, EvidenceModality } from '../common/evidence-taxonomy';
-import { SurrealService, queryFirst } from '../db/surreal.service';
+import { SurrealService, queryFirst, queryRows } from '../db/surreal.service';
 import { idTailOf } from '../ingest/ingest-utils';
 import { gateProcessorDispatch } from './processing/dispatch-gate';
 import {
@@ -42,13 +48,37 @@ export interface DispatchResult {
   denied: Array<{ capability: string; reason: string }>;
 }
 
+export interface DispatchSweepResult {
+  /** Assets considered (1 for a targeted sweep). */
+  assets: number;
+  /** Assets whose dispatch completed without throwing. */
+  dispatched: number;
+  /** Total processing runs produced (created OR replayed). */
+  runs: number;
+  /** Total per-capability denials across the swept assets. */
+  denied: number;
+  /** Assets whose dispatch threw — logged, never fatal to the sweep. */
+  failed: number;
+}
+
+/** Default per-call sweep bound; a maintenance verb, not a migration. */
+const SWEEP_DEFAULT_LIMIT = 100;
+/** Hard bound: one operator call must stay a bounded unit of work. */
+const SWEEP_MAX_LIMIT = 1000;
+
 /**
  * EvidenceProcessorBrokerService (0121 MM-1) — the trusted processor
  * broker: matches a pack's DECLARED `memoryModel.processors` needs
  * against the platform's installed adapters and executes them as
- * idempotent processing runs. Service-level only — no HTTP controller,
- * no scheduler, no ingest surface (sibling PR-C doctrine from 0109:
- * tests and future PRs call the service directly).
+ * idempotent processing runs.
+ *
+ * Two production callers reach it (MM-7 — before that it was
+ * service-level only, exercised solely by tests): the blob upload path
+ * fires dispatchForPack FIRE-AND-FORGET after an asset registers and
+ * scans clean, and the admin maintenance verb calls dispatchSweep to
+ * apply a pack over the EXISTING corpus. There is still NO scheduler:
+ * both entry points are explicit (see processing-run.service.ts claimRun
+ * on why v1 has none).
  *
  * ANTI-DSL: the pack contributes ONLY (modality, produces[]) needs; no
  * pack-supplied endpoint, model, prompt, or code is ever consulted
@@ -59,6 +89,8 @@ export interface DispatchResult {
  */
 @Injectable()
 export class EvidenceProcessorBrokerService {
+  private readonly logger = new Logger(EvidenceProcessorBrokerService.name);
+
   constructor(
     private readonly surreal: SurrealService,
     @Inject(EVIDENCE_PROCESSOR_ADAPTERS)
@@ -113,6 +145,71 @@ export class EvidenceProcessorBrokerService {
       result.runs.push(run);
     }
     return result;
+  }
+
+  /**
+   * Operator sweep over already-registered assets (the admin maintenance
+   * verb). v1 has no scheduler (processing-run.service.ts claimRun), so
+   * this is how a pack installed AFTER an asset landed — or a newly
+   * installed processor adapter — gets applied to the existing corpus.
+   *
+   * Bounded and idempotent by construction: each asset goes through the
+   * SAME dispatchForPack path, whose runs are keyed deterministically and
+   * INSERT IGNORE'd, so re-running the sweep replays instead of
+   * duplicating. Per-asset failures are counted, never fatal — one bad
+   * blob must not abort an operator's sweep.
+   *
+   * Candidate selection is a bounded READ (`SELECT VALUE id … LIMIT`) —
+   * no DELETE/UPDATE-over-WHERE anywhere near the 3.2.4 planner rule. The
+   * per-asset gate ladder (consent, quarantine, tombstone) stays exactly
+   * where it is, in gateProcessorDispatch: this method filters nothing
+   * itself, it only chooses which ids to hand over.
+   */
+  async dispatchSweep(
+    companyId: string,
+    req: { packId: string; assetId?: string | undefined; limit?: number | undefined },
+  ): Promise<DispatchSweepResult> {
+    if (!processorBrokerEnabled() || !evidenceSubstrateEnabled()) {
+      throw new ServiceUnavailableException(
+        'EVIDENCE_PROCESSOR_BROKER (with EVIDENCE_SUBSTRATE_ENABLED) is off',
+      );
+    }
+    const assetIds = req.assetId
+      ? [req.assetId]
+      : await this.sweepCandidates(companyId, req.limit ?? SWEEP_DEFAULT_LIMIT);
+    const out: DispatchSweepResult = {
+      assets: assetIds.length,
+      dispatched: 0,
+      runs: 0,
+      denied: 0,
+      failed: 0,
+    };
+    for (const assetId of assetIds) {
+      try {
+        const res = await this.dispatchForPack(companyId, { packId: req.packId, assetId });
+        out.dispatched++;
+        out.runs += res.runs.length;
+        out.denied += res.denied.length;
+      } catch (e) {
+        out.failed++;
+        this.logger.warn(`sweep dispatch failed for ${assetId}: ${(e as Error).message}`);
+      }
+    }
+    return out;
+  }
+
+  /** Bounded id read of live (non-tombstoned) assets, oldest ids first. */
+  private async sweepCandidates(companyId: string, requested: number): Promise<string[]> {
+    const limit = Math.min(Math.max(1, Math.trunc(requested)), SWEEP_MAX_LIMIT);
+    const ids = await this.surreal.withCompany(companyId, (db) =>
+      queryRows<unknown>(
+        db,
+        `SELECT VALUE id FROM evidence_asset WHERE availability != 'gone'
+          ORDER BY id ASC LIMIT $limit`,
+        { limit },
+      ),
+    );
+    return ids.map((id) => String(id));
   }
 
   private async loadRows(

--- a/src/evidence/upload-media-types.ts
+++ b/src/evidence/upload-media-types.ts
@@ -1,0 +1,74 @@
+import { EVIDENCE_MODALITIES, type EvidenceModality } from '../common/evidence-taxonomy';
+
+/**
+ * Upload media-type allowlist (Brain v2.1 MM-7) — the ONE place that says
+ * which bytes the blob upload surface will take into custody, and under
+ * which modality.
+ *
+ * ALLOWLIST, not a denylist, and deliberately narrow: the metadata-only
+ * sibling route accepts any IANA-shaped `mediaType` because it never
+ * holds the bytes, but this surface stores them and later hands them to
+ * processor adapters and the raw-read gateway. Everything not named here
+ * is refused, including — on purpose:
+ *
+ *   - `image/svg+xml`: an SVG is an active document (script, external
+ *     refs); serving one back from the raw gateway would be stored XSS;
+ *   - `application/octet-stream` and other opaque types: an unclassified
+ *     blob cannot be modality-checked, so it can never be honestly
+ *     described to a pack's perception contract;
+ *   - archives (zip/tar/gz) and macro-capable office formats: a container
+ *     is a delivery vehicle, and nothing in v1 unpacks or scans inside
+ *     one (the scan hook is a metadata-only stub);
+ *   - `text/html`: same active-content reasoning as SVG.
+ *
+ * The pairing matters as much as the membership: a `image/png` part may
+ * not be registered as modality `document`, because modality drives pack
+ * consent (0112), the dispatch gate, and the fragment-locator matrix. A
+ * mismatched pair is a 400, never a silent re-classification.
+ *
+ * Extending this list is a deliberate decision — a new entry means the
+ * raw-read gateway may hand those bytes back to a browser.
+ */
+export const EVIDENCE_UPLOAD_MEDIA_TYPES: Readonly<Record<EvidenceModality, readonly string[]>> = {
+  image: ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif'],
+  audio: ['audio/mpeg', 'audio/mp4', 'audio/aac', 'audio/ogg', 'audio/wav', 'audio/flac'],
+  video: ['video/mp4', 'video/webm', 'video/quicktime'],
+  document: ['application/pdf', 'text/plain', 'text/markdown', 'text/csv'],
+  sensor: ['application/json', 'text/csv'],
+};
+
+/** Flat union of every accepted type — for docs and error messages. */
+export const EVIDENCE_UPLOAD_MEDIA_TYPES_FLAT: readonly string[] = [
+  ...new Set(EVIDENCE_MODALITIES.flatMap((m) => EVIDENCE_UPLOAD_MEDIA_TYPES[m])),
+].sort();
+
+/**
+ * Canonical form of a wire media type: lowercased, parameters dropped
+ * (`text/plain; charset=utf-8` → `text/plain`), surrounding space
+ * trimmed. Parameters are dropped rather than rejected — a charset says
+ * nothing about what the bytes ARE, and the allowlist keys on the
+ * type/subtype only.
+ */
+export function normalizeUploadMediaType(raw: string): string {
+  const semi = raw.indexOf(';');
+  return (semi === -1 ? raw : raw.slice(0, semi)).trim().toLowerCase();
+}
+
+/**
+ * Pure allowlist check. Returns null when the (modality, mediaType) pair
+ * is accepted, else a caller-safe reason string. Kept pure so the unit
+ * suite can pin every pair without booting a Nest app.
+ */
+export function uploadMediaTypeError(modality: EvidenceModality, mediaType: string): string | null {
+  const normalized = normalizeUploadMediaType(mediaType);
+  if (normalized === '') return 'a media type is required for an uploaded blob';
+  const allowed = EVIDENCE_UPLOAD_MEDIA_TYPES[modality];
+  if (allowed.includes(normalized)) return null;
+  if (EVIDENCE_UPLOAD_MEDIA_TYPES_FLAT.includes(normalized)) {
+    return (
+      `mediaType '${normalized}' is not accepted for modality '${modality}' ` +
+      `(accepted: ${allowed.join(', ')})`
+    );
+  }
+  return `mediaType '${normalized}' is not accepted by the evidence blob upload surface`;
+}

--- a/src/policy/action-registry.ts
+++ b/src/policy/action-registry.ts
@@ -88,6 +88,16 @@ export const ACTIONS: Record<string, ActionSpec> = {
     family: 'rest',
     title: 'Ingest evidence asset (metadata-only)',
   },
+  // Byte custody is a STRICTER capability than metadata registration
+  // (MM-7): the uploaded blob is what the raw-read gateway later serves
+  // and what processor adapters read, so it gets its own action rather
+  // than riding the metadata one — a policy may open registration
+  // without opening upload.
+  'rest.ingest.evidence_blob': {
+    kind: 'write',
+    family: 'rest',
+    title: 'Upload evidence blob (bytes)',
+  },
   'rest.documents.get': { kind: 'read', family: 'rest', title: 'Get document' },
   'rest.documents.candidates': { kind: 'read', family: 'rest', title: 'List candidates' },
   'rest.documents.commit': { kind: 'write', family: 'rest', title: 'Commit candidates' },

--- a/test/evidence-blob-upload.e2e-spec.ts
+++ b/test/evidence-blob-upload.e2e-spec.ts
@@ -1,0 +1,386 @@
+/**
+ * Evidence blob upload e2e (Brain v2.1 MM-7) — the first surface that
+ * takes BYTES into custody, end to end over HTTP:
+ *
+ *  - default-off pin: bare 404 while EVIDENCE_BLOB_UPLOAD_ENABLED is off,
+ *    even with the substrate, quarantine and the sibling metadata route
+ *    all on — and the 404 is raised BEFORE the multipart body is parsed;
+ *  - fail-closed pin: upload-on with EVIDENCE_QUARANTINE off answers 503
+ *    (bytes over HTTP are external ingest; no external bytes without the
+ *    scan seam) and writes nothing;
+ *  - the happy path: a tiny in-test buffer lands as a `hot` asset with a
+ *    real fs:// storageRef, a server-computed sha256 identity, the
+ *    per-user 0055/0093 stamps, and quarantineStatus 'clean' — i.e. it
+ *    was actually scanned, not merely admitted;
+ *  - the allowlist and the size cap over the wire (400 / 413);
+ *  - a rejecting scan hook: 422, a content-free message, the row a
+ *    tombstone and the bytes gone — including on a re-upload of
+ *    already-rejected content;
+ *  - dispatch: fire-and-forget from the upload path produces a real
+ *    processing_run + derived text, and the admin maintenance sweep
+ *    reaches an asset no upload dispatch covered (404 while dark);
+ *  - the raw bytes really are retrievable through the storage adapter.
+ */
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { EvidenceQuarantineService } from '../src/evidence/quarantine.service';
+import type { EvidenceScanHook } from '../src/evidence/processing/scan-hook';
+import { FsEvidenceStorageAdapter } from '../src/evidence/storage/fs-storage.adapter';
+
+const COMPANY = 'co_evidence_blob_upload_e2e';
+const USER = 'blob_upload_user';
+const PACK = 'blob_upload_pack';
+
+const NOTE = 'the quick brown fox jumps over the lazy dog';
+const NOTE_BYTES = Buffer.from(NOTE, 'utf8');
+const NOTE_HASH = createHash('sha256').update(NOTE_BYTES).digest('hex');
+
+const PREDICATE = {
+  localId: 'blob_note',
+  displayLabel: 'blob note',
+  description: 'TYPE subject is a person; value is a note about an uploaded blob',
+  datatype: 'string',
+  semantics: 'append_only',
+  decayHalfLifeDays: null,
+  piiClass: 'none',
+  status: 'active',
+};
+
+const packManifest = {
+  id: PACK,
+  version: '1.0.0',
+  description: 'Blob upload e2e pack.',
+  predicates: [PREDICATE],
+  memoryModel: {
+    modalities: ['document'],
+    processors: [{ id: 'doc_text', modality: 'document', produces: ['text'] }],
+  },
+};
+
+describe('evidence blob upload surface (e2e)', () => {
+  let f: AppFixture;
+  let readOnlyKey: string;
+  let fsRoot: string;
+  const auth = (key?: string) => ({ Authorization: `Bearer ${key ?? f.apiKey}` });
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    fsRoot = await mkdtemp(join(tmpdir(), 'evidence-blob-upload-e2e-'));
+    for (const k of [
+      'EVIDENCE_SUBSTRATE_ENABLED',
+      'EVIDENCE_BLOB_UPLOAD_ENABLED',
+      'EVIDENCE_QUARANTINE',
+      'EVIDENCE_PROCESSOR_BROKER',
+      'EVIDENCE_MAX_BYTES',
+      'EVIDENCE_FS_ROOT',
+    ]) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.EVIDENCE_FS_ROOT = fsRoot;
+    process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    f = await createApp({
+      companyId: COMPANY,
+      scopes: ['brain:read', 'brain:write', 'brain:admin'],
+      extraKeys: [{ scopes: ['brain:read'] }],
+    });
+    readOnlyKey = f.extraApiKeys[0]!;
+  }, 120_000);
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await rm(fsRoot, { recursive: true, force: true });
+    if (f) await f.close();
+  });
+
+  const countRows = async (table: string): Promise<number> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(COMPANY, async (db) => {
+      const [rows] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM ${table} GROUP ALL`,
+      );
+      return (rows as Array<{ n: number }>)?.[0]?.n ?? 0;
+    });
+  };
+
+  const rawRow = async (recordId: string): Promise<Record<string, unknown>> => {
+    const surreal = f.app.get(SurrealService);
+    const table = recordId.slice(0, recordId.indexOf(':'));
+    const tail = recordId.slice(recordId.indexOf(':') + 1);
+    return surreal.withCompany(COMPANY, async (db) => {
+      const [rows] = await db.query<[Array<Record<string, unknown>>]>(
+        `SELECT * FROM type::record($t, $tail)`,
+        { t: table, tail },
+      );
+      return (rows as Array<Record<string, unknown>>)[0]!;
+    });
+  };
+
+  /** Wait for a fire-and-forget effect without asserting on a race. */
+  const eventually = async (probe: () => Promise<boolean>): Promise<boolean> => {
+    for (let i = 0; i < 100; i++) {
+      if (await probe()) return true;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    return false;
+  };
+
+  interface UploadOpts {
+    bytes?: Buffer;
+    filename?: string;
+    contentType?: string;
+    fields?: Record<string, string>;
+    key?: string;
+  }
+
+  const upload = (opts: UploadOpts = {}) => {
+    let req = f.http.post('/v1/ingest/evidence-blob').set(auth(opts.key));
+    const fields = {
+      modality: 'document',
+      occurredAt: '2026-05-01T10:00:00.000Z',
+      vertical: 'proj',
+      userId: USER,
+      ...opts.fields,
+    };
+    for (const [k, v] of Object.entries(fields)) req = req.field(k, v);
+    return req.attach('file', opts.bytes ?? NOTE_BYTES, {
+      filename: opts.filename ?? 'note.txt',
+      contentType: opts.contentType ?? 'text/plain',
+    });
+  };
+
+  let assetId = '';
+  let sweepAssetId = '';
+
+  it('answers a bare 404 while EVIDENCE_BLOB_UPLOAD_ENABLED is off', async () => {
+    process.env.EVIDENCE_QUARANTINE = '1';
+    const res = await upload().expect(404);
+    // Bare: the off-state answer must not describe the route it hides.
+    expect(JSON.stringify(res.body)).not.toContain('evidence-blob');
+    expect(await countRows('evidence_asset')).toBe(0);
+    delete process.env.EVIDENCE_QUARANTINE;
+  });
+
+  it('fails closed with 503 when the quarantine seam is off — bytes are external ingest', async () => {
+    process.env.EVIDENCE_BLOB_UPLOAD_ENABLED = '1';
+    const res = await upload().expect(503);
+    expect(JSON.stringify(res.body)).toContain('EVIDENCE_QUARANTINE');
+    expect(await countRows('evidence_asset')).toBe(0);
+  });
+
+  it('requires brain:write (403 for a read-only key)', async () => {
+    process.env.EVIDENCE_QUARANTINE = '1';
+    await upload({ key: readOnlyKey }).expect(403);
+    expect(await countRows('evidence_asset')).toBe(0);
+  });
+
+  it('stores the bytes, registers a hot asset, and scans it before serving', async () => {
+    const res = await upload({
+      fields: { scope: 'team:alpha,team:beta', piiClasses: '', pageCount: '1' },
+    }).expect(201);
+
+    expect(res.body).toMatchObject({
+      availability: 'hot',
+      deduped: false,
+      byteHash: NOTE_HASH,
+      byteLength: NOTE_BYTES.byteLength,
+      mediaType: 'text/plain',
+      // Actually scanned — not merely admitted.
+      quarantineStatus: 'clean',
+      // No packId was sent, so nothing was dispatched.
+      dispatched: false,
+    });
+    expect(res.body.storageRef).toBe(`fs://${COMPANY}/${NOTE_HASH}`);
+    assetId = String(res.body.assetId);
+
+    const row = await rawRow(assetId);
+    expect(row).toMatchObject({
+      availability: 'hot',
+      quarantineStatus: 'clean',
+      mediaType: 'text/plain',
+      modality: 'document',
+      userId: USER,
+      byteHash: NOTE_HASH,
+      pageCount: 1,
+    });
+    // 0055 userId + 0093 scope tags stamped exactly as registerAsset does
+    // for every other writer; piiClasses [] is the affirmative-clean
+    // polarity, distinct from the field being absent.
+    expect(row.scope).toEqual(['team:alpha', 'team:beta']);
+    expect(row.piiClasses).toEqual([]);
+
+    // The bytes are genuinely on disk under the ref the row carries.
+    const adapter = f.app.get(FsEvidenceStorageAdapter);
+    expect(await adapter.head(String(row.storageRef))).toEqual({
+      byteLength: NOTE_BYTES.byteLength,
+    });
+    const stream = await adapter.get(String(row.storageRef));
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(Buffer.from(chunk as Buffer));
+    expect(Buffer.concat(chunks).toString('utf8')).toBe(NOTE);
+  });
+
+  it('dedupes a same-user re-upload of identical bytes', async () => {
+    const res = await upload().expect(201);
+    expect(res.body).toMatchObject({ assetId, deduped: true, availability: 'hot' });
+    expect(await countRows('evidence_asset')).toBe(1);
+  });
+
+  it('refuses media types outside the allowlist and mismatched modality pairs', async () => {
+    // Deliberate exclusion: an SVG is an active document.
+    await upload({
+      contentType: 'image/svg+xml',
+      filename: 'x.svg',
+      fields: { modality: 'image' },
+    }).expect(400);
+    // Allowlisted overall, wrong modality for these bytes.
+    await upload({ contentType: 'application/pdf', fields: { modality: 'image' } }).expect(400);
+    // Opaque bytes cannot be modality-checked.
+    await upload({ contentType: 'application/octet-stream' }).expect(400);
+    expect(await countRows('evidence_asset')).toBe(1);
+  });
+
+  it('enforces the runtime-mutable size cap (413) and rejects an unknown field (400)', async () => {
+    process.env.EVIDENCE_MAX_BYTES = '8';
+    await upload({ bytes: Buffer.from('this is definitely more than eight bytes') }).expect(413);
+    delete process.env.EVIDENCE_MAX_BYTES;
+    // forbidNonWhitelisted still governs the metadata half.
+    await upload({ fields: { storageRef: `fs://${COMPANY}/${NOTE_HASH}` } }).expect(400);
+    expect(await countRows('evidence_asset')).toBe(1);
+  });
+
+  it('dispatches fire-and-forget from the upload path: a real processing run lands', async () => {
+    const install = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: packManifest, acceptModalities: true });
+    expect([200, 201]).toContain(install.status);
+    process.env.EVIDENCE_PROCESSOR_BROKER = '1';
+
+    const second = 'a second observation, uploaded and processed';
+    const res = await upload({
+      bytes: Buffer.from(second, 'utf8'),
+      fields: { packId: PACK },
+    }).expect(201);
+    // The response never waits on the broker — it only reports that a
+    // dispatch was STARTED.
+    expect(res.body).toMatchObject({ quarantineStatus: 'clean', dispatched: true });
+
+    expect(await eventually(async () => (await countRows('processing_run')) >= 1)).toBe(true);
+    const surreal = f.app.get(SurrealService);
+    const repr = await surreal.withCompany(COMPANY, async (db) => {
+      const [rows] = await db.query<[Array<Record<string, unknown>>]>(
+        `SELECT kind, content, producerVersion FROM derived_representation LIMIT 1`,
+      );
+      return (rows as Array<Record<string, unknown>>)[0];
+    });
+    expect(repr).toMatchObject({
+      kind: 'text',
+      content: second,
+      producerVersion: 'text-extraction-passthrough-v1',
+    });
+  });
+
+  it('a failing dispatch target never fails the upload', async () => {
+    const res = await upload({
+      bytes: Buffer.from('uploaded against a pack that is not installed', 'utf8'),
+      fields: { packId: 'no_such_pack_installed' },
+    }).expect(201);
+    expect(res.body).toMatchObject({ availability: 'hot', quarantineStatus: 'clean' });
+    sweepAssetId = String(res.body.assetId);
+  });
+
+  it('a rejecting scan hook answers 422, tombstones the row and deletes the bytes', async () => {
+    const quarantine = f.app.get(EvidenceQuarantineService) as unknown as {
+      hook: EvidenceScanHook;
+    };
+    const original = quarantine.hook;
+    const rejected = 'bytes a real scanner would refuse';
+    const rejectedHash = createHash('sha256').update(Buffer.from(rejected, 'utf8')).digest('hex');
+    try {
+      quarantine.hook = { name: 'reject-all-test', scan: () => Promise.resolve('rejected') };
+      const res = await upload({ bytes: Buffer.from(rejected, 'utf8') }).expect(422);
+      // Content-free: a scan verdict must not describe what it matched.
+      expect(JSON.stringify(res.body)).not.toContain(rejected);
+
+      const adapter = f.app.get(FsEvidenceStorageAdapter);
+      expect(await adapter.exists(`fs://${COMPANY}/${rejectedHash}`)).toBe(false);
+      const surreal = f.app.get(SurrealService);
+      const tomb = await surreal.withCompany(COMPANY, async (db) => {
+        const [rows] = await db.query<[Array<Record<string, unknown>>]>(
+          `SELECT availability, quarantineStatus, storageRef FROM evidence_asset
+            WHERE byteHash = $h LIMIT 1`,
+          { h: rejectedHash },
+        );
+        return (rows as Array<Record<string, unknown>>)[0]!;
+      });
+      expect(tomb).toMatchObject({ availability: 'gone', quarantineStatus: 'rejected' });
+      expect(tomb.storageRef ?? null).toBeNull();
+
+      // Re-uploading known-rejected bytes stays rejected AND does not
+      // leave the re-materialised blob behind.
+      await upload({ bytes: Buffer.from(rejected, 'utf8') }).expect(422);
+      expect(await adapter.exists(`fs://${COMPANY}/${rejectedHash}`)).toBe(false);
+    } finally {
+      quarantine.hook = original;
+    }
+  });
+
+  it('the admin sweep reaches an asset no upload dispatch covered', async () => {
+    const sweep = await f.http
+      .post('/v1/admin/maintenance/evidence/dispatch')
+      .set(auth())
+      .send({ packId: PACK, assetId: sweepAssetId })
+      .expect(201);
+    expect(sweep.body).toMatchObject({ assets: 1, dispatched: 1, runs: 1, failed: 0 });
+
+    // Untargeted, it sweeps every live asset — including the one
+    // registered before the broker was even on. Running it TWICE is the
+    // replay-idempotence pin: the second pass touches the same assets and
+    // produces the same runs, writing no new row.
+    const wide = await f.http
+      .post('/v1/admin/maintenance/evidence/dispatch')
+      .set(auth())
+      .send({ packId: PACK })
+      .expect(201);
+    expect(wide.body.assets).toBeGreaterThan(1);
+    expect(wide.body.dispatched).toBe(wide.body.assets);
+    const runsAfterWide = await countRows('processing_run');
+    const again = await f.http
+      .post('/v1/admin/maintenance/evidence/dispatch')
+      .set(auth())
+      .send({ packId: PACK })
+      .expect(201);
+    expect(again.body).toMatchObject({ assets: wide.body.assets, runs: wide.body.runs, failed: 0 });
+    expect(await countRows('processing_run')).toBe(runsAfterWide);
+  });
+
+  it('the admin sweep validates its params and 404s while the broker is dark', async () => {
+    await f.http.post('/v1/admin/maintenance/evidence/dispatch').set(auth()).send({}).expect(400);
+    await f.http
+      .post('/v1/admin/maintenance/evidence/dispatch')
+      .set(auth())
+      .send({ packId: PACK, assetId: 'not_a_record_id' })
+      .expect(400);
+    delete process.env.EVIDENCE_PROCESSOR_BROKER;
+    await f.http
+      .post('/v1/admin/maintenance/evidence/dispatch')
+      .set(auth())
+      .send({ packId: PACK })
+      .expect(404);
+  });
+
+  it('flag flip back off returns the surface to a bare 404 (runtime-mutable)', async () => {
+    delete process.env.EVIDENCE_BLOB_UPLOAD_ENABLED;
+    await upload({ bytes: Buffer.from('after the flip', 'utf8') }).expect(404);
+    delete process.env.EVIDENCE_QUARANTINE;
+  });
+});

--- a/test/evidence-blob-upload.unit-spec.ts
+++ b/test/evidence-blob-upload.unit-spec.ts
@@ -1,0 +1,344 @@
+/**
+ * Evidence blob upload unit pins (Brain v2.1 MM-7) — the pure decision
+ * seams of the byte surface, no Nest app and no database:
+ *
+ *  - the media-type allowlist: membership, modality PAIRING, parameter
+ *    normalisation, and the explicit exclusions (SVG, HTML, archives,
+ *    octet-stream);
+ *  - the flag gate: interceptor 404 before any multipart parsing, and
+ *    the handler's second 404 — both while EVIDENCE_BLOB_UPLOAD_ENABLED
+ *    is off;
+ *  - the size cap and the empty-part rejection;
+ *  - userId / scope stamping reaching registerAsset verbatim, together
+ *    with the server-owned identity fields (byteHash over the RECEIVED
+ *    bytes, measured byteLength, adapter-minted storageRef, origin
+ *    'external_ingest');
+ *  - scan-before-serve: clean, rejected (422 + blob removal), and a
+ *    throwing hook leaving 'scanning' rather than failing open;
+ *  - dispatch fire-and-forget: a rejecting broker never fails the upload.
+ */
+import { NotFoundException } from '@nestjs/common';
+import type { CallHandler, ExecutionContext } from '@nestjs/common';
+import { EvidenceBlobUploadInterceptor } from '../src/evidence/blob-upload.interceptor';
+import { EvidenceIngestController } from '../src/evidence/evidence-ingest.controller';
+import {
+  EVIDENCE_UPLOAD_SCHEME,
+  EvidenceUploadService,
+  type UploadEvidenceBlobInput,
+} from '../src/evidence/evidence-upload.service';
+import type { UploadedEvidenceBlob } from '../src/evidence/blob-upload.interceptor';
+import {
+  EVIDENCE_UPLOAD_MEDIA_TYPES,
+  normalizeUploadMediaType,
+  uploadMediaTypeError,
+} from '../src/evidence/upload-media-types';
+import type {
+  EvidenceStoreService,
+  RegisterAssetInput,
+} from '../src/evidence/evidence-store.service';
+import type { EvidenceProcessorBrokerService } from '../src/evidence/processor-broker.service';
+import type { EvidenceQuarantineService } from '../src/evidence/quarantine.service';
+import type { EvidenceStorageAdapter } from '../src/evidence/storage/storage-adapter';
+
+const COMPANY = 'co_blob_unit';
+const BYTES = Buffer.from('hello upload', 'utf8');
+// sha256('hello upload') — pinned so a change to what the server hashes
+// (the received bytes, never a caller assertion) fails loudly here.
+const BYTES_HASH = '2d119f1cd272958a492a144af600b9dc36531f73027b34073967345b027021b1';
+
+function blob(over: Partial<UploadedEvidenceBlob> = {}): UploadedEvidenceBlob {
+  return {
+    originalname: 'note.txt',
+    mimetype: 'text/plain',
+    size: BYTES.byteLength,
+    buffer: BYTES,
+    ...over,
+  };
+}
+
+function input(over: Partial<UploadEvidenceBlobInput> = {}): UploadEvidenceBlobInput {
+  return {
+    modality: 'document',
+    occurredAt: new Date('2026-05-01T10:00:00.000Z'),
+    vertical: 'proj',
+    ...over,
+  };
+}
+
+interface Harness {
+  service: EvidenceUploadService;
+  registered: RegisterAssetInput[];
+  deleted: string[];
+  dispatches: Array<{ packId: string; assetId: string }>;
+  adapter: EvidenceStorageAdapter;
+}
+
+function harness(
+  opts: {
+    scan?: () => Promise<{ assetId: string; quarantineStatus: 'clean' | 'rejected' }>;
+    dispatch?: () => Promise<never>;
+    availability?: string;
+    deduped?: boolean;
+    registerThrows?: Error;
+    adapters?: Map<string, EvidenceStorageAdapter>;
+  } = {},
+): Harness {
+  const registered: RegisterAssetInput[] = [];
+  const deleted: string[] = [];
+  const dispatches: Array<{ packId: string; assetId: string }> = [];
+  const stored = new Map<string, Buffer>();
+  const adapter = {
+    scheme: EVIDENCE_UPLOAD_SCHEME,
+    put: (companyId: string, byteHash: string, data: Buffer) => {
+      const storageRef = `${EVIDENCE_UPLOAD_SCHEME}://${companyId}/${byteHash}`;
+      stored.set(storageRef, data);
+      return Promise.resolve({ storageRef, byteLength: data.byteLength });
+    },
+    belongsToTenant: () => true,
+    get: () => Promise.reject(new Error('unused')),
+    head: (ref: string) => {
+      const found = stored.get(ref);
+      return Promise.resolve(found ? { byteLength: found.byteLength } : null);
+    },
+    exists: (ref: string) => Promise.resolve(stored.has(ref)),
+    delete: (ref: string) => {
+      deleted.push(ref);
+      return Promise.resolve(stored.delete(ref));
+    },
+  } as unknown as EvidenceStorageAdapter;
+  const store = {
+    registerAsset: (_companyId: string, spec: RegisterAssetInput) => {
+      if (opts.registerThrows) return Promise.reject(opts.registerThrows);
+      registered.push(spec);
+      return Promise.resolve({
+        assetId: 'evidence_asset:up1',
+        availability: opts.availability ?? 'hot',
+        deduped: opts.deduped ?? false,
+      });
+    },
+  } as unknown as EvidenceStoreService;
+  const quarantine = {
+    runScan: opts.scan ?? (() => Promise.resolve({ assetId: 'x', quarantineStatus: 'clean' })),
+  } as unknown as EvidenceQuarantineService;
+  const broker = {
+    dispatchForPack: (_c: string, req: { packId: string; assetId: string }) => {
+      dispatches.push(req);
+      return opts.dispatch ? opts.dispatch() : Promise.resolve({ runs: [], denied: [] });
+    },
+  } as unknown as EvidenceProcessorBrokerService;
+  const adapters = opts.adapters ?? new Map([[EVIDENCE_UPLOAD_SCHEME, adapter]]);
+  return {
+    service: new EvidenceUploadService(store, adapters, quarantine, broker),
+    registered,
+    deleted,
+    dispatches,
+    adapter,
+  };
+}
+
+describe('upload media-type allowlist', () => {
+  it('accepts only the declared pairs and rejects the cross-modality ones', () => {
+    expect(uploadMediaTypeError('document', 'application/pdf')).toBeNull();
+    expect(uploadMediaTypeError('image', 'image/png')).toBeNull();
+    // text/csv is allowlisted for BOTH document and sensor — deliberate.
+    expect(uploadMediaTypeError('document', 'text/csv')).toBeNull();
+    expect(uploadMediaTypeError('sensor', 'text/csv')).toBeNull();
+    // Allowlisted overall, wrong modality: named as a pairing failure.
+    const paired = uploadMediaTypeError('document', 'image/png');
+    expect(paired).toContain("not accepted for modality 'document'");
+  });
+
+  it('refuses the deliberate exclusions', () => {
+    for (const [modality, type] of [
+      ['image', 'image/svg+xml'],
+      ['document', 'text/html'],
+      ['document', 'application/octet-stream'],
+      ['document', 'application/zip'],
+      ['document', 'application/vnd.ms-excel'],
+    ] as const) {
+      expect(uploadMediaTypeError(modality, type)).toContain('not accepted');
+    }
+  });
+
+  it('normalises parameters and case before matching', () => {
+    expect(normalizeUploadMediaType(' TEXT/Plain; charset=utf-8 ')).toBe('text/plain');
+    expect(uploadMediaTypeError('document', 'Text/Plain; charset=UTF-8')).toBeNull();
+    expect(uploadMediaTypeError('document', '   ')).toContain('media type is required');
+  });
+
+  it('every allowlist entry is a bare lowercase type/subtype', () => {
+    for (const types of Object.values(EVIDENCE_UPLOAD_MEDIA_TYPES)) {
+      for (const t of types) expect(t).toBe(normalizeUploadMediaType(t));
+    }
+  });
+});
+
+describe('blob upload flag gate', () => {
+  const saved = process.env.EVIDENCE_BLOB_UPLOAD_ENABLED;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.EVIDENCE_BLOB_UPLOAD_ENABLED;
+    else process.env.EVIDENCE_BLOB_UPLOAD_ENABLED = saved;
+  });
+
+  it('the interceptor 404s BEFORE the multipart body is parsed', () => {
+    delete process.env.EVIDENCE_BLOB_UPLOAD_ENABLED;
+    const interceptor = new EvidenceBlobUploadInterceptor();
+    const next = { handle: jest.fn() } as unknown as CallHandler;
+    expect(() => interceptor.intercept({} as ExecutionContext, next)).toThrow(NotFoundException);
+    // The proof that nothing was parsed: the handler chain was never
+    // entered, so no multer instance ever saw the request.
+    expect((next.handle as jest.Mock).mock.calls).toHaveLength(0);
+  });
+
+  it('the handler keeps its own 404 (defence in depth)', async () => {
+    delete process.env.EVIDENCE_BLOB_UPLOAD_ENABLED;
+    const h = harness();
+    const controller = new EvidenceIngestController(
+      {} as unknown as EvidenceStoreService,
+      h.service,
+    );
+    const req = { brainAuth: { companyId: COMPANY } } as never;
+    await expect(
+      controller.uploadEvidenceBlob(req, { modality: 'document' } as never, blob()),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('with the flag on, a missing file part is a 400 (not a 500)', async () => {
+    process.env.EVIDENCE_BLOB_UPLOAD_ENABLED = '1';
+    const h = harness();
+    const controller = new EvidenceIngestController(
+      {} as unknown as EvidenceStoreService,
+      h.service,
+    );
+    const req = { brainAuth: { companyId: COMPANY } } as never;
+    await expect(
+      controller.uploadEvidenceBlob(req, { modality: 'document' } as never, undefined),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe('blob upload pipeline', () => {
+  const savedCap = process.env.EVIDENCE_MAX_BYTES;
+  afterEach(() => {
+    if (savedCap === undefined) delete process.env.EVIDENCE_MAX_BYTES;
+    else process.env.EVIDENCE_MAX_BYTES = savedCap;
+  });
+
+  it('stamps userId + scope and owns byteHash / byteLength / storageRef / origin', async () => {
+    const h = harness();
+    const res = await h.service.upload(
+      COMPANY,
+      blob(),
+      input({ userId: 'u1', scope: ['team:a', 'team:b'], piiClasses: [] }),
+    );
+    const spec = h.registered[0]!;
+    expect(spec.userId).toBe('u1');
+    expect(spec.scope).toEqual(['team:a', 'team:b']);
+    expect(spec.piiClasses).toEqual([]);
+    // Server-owned identity, not caller-asserted.
+    expect(spec.byteHash).toBe(BYTES_HASH);
+    expect(spec.byteLength).toBe(BYTES.byteLength);
+    expect(spec.storageRef).toBe(`${EVIDENCE_UPLOAD_SCHEME}://${COMPANY}/${BYTES_HASH}`);
+    expect(spec.originUri).toBeUndefined();
+    // Bytes over HTTP are external ingest — the MM-6 fence must apply.
+    expect(spec.origin).toBe('external_ingest');
+    expect(res).toMatchObject({
+      availability: 'hot',
+      byteHash: BYTES_HASH,
+      quarantineStatus: 'clean',
+      dispatched: false,
+      mediaType: 'text/plain',
+    });
+  });
+
+  it('canonicalises a parameterised part media type onto the row', async () => {
+    const h = harness();
+    const res = await h.service.upload(
+      COMPANY,
+      blob({ mimetype: 'text/plain; charset=utf-8' }),
+      input(),
+    );
+    expect(res.mediaType).toBe('text/plain');
+    expect(h.registered[0]!.mediaType).toBe('text/plain');
+  });
+
+  it('rejects an over-cap upload with 413 and an empty part with 400', async () => {
+    process.env.EVIDENCE_MAX_BYTES = '4';
+    const h = harness();
+    await expect(h.service.upload(COMPANY, blob(), input())).rejects.toMatchObject({ status: 413 });
+    delete process.env.EVIDENCE_MAX_BYTES;
+    await expect(
+      h.service.upload(COMPANY, blob({ buffer: Buffer.alloc(0) }), input()),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(h.registered).toHaveLength(0);
+  });
+
+  it('rejects a disallowed media type before anything is stored', async () => {
+    const h = harness();
+    await expect(
+      h.service.upload(COMPANY, blob({ mimetype: 'image/svg+xml' }), input({ modality: 'image' })),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(h.registered).toHaveLength(0);
+    expect(await h.adapter.exists(`${EVIDENCE_UPLOAD_SCHEME}://${COMPANY}/${BYTES_HASH}`)).toBe(
+      false,
+    );
+  });
+
+  it('503s when no adapter owns the upload scheme', async () => {
+    const h = harness({ adapters: new Map() });
+    await expect(h.service.upload(COMPANY, blob(), input())).rejects.toMatchObject({ status: 503 });
+  });
+});
+
+describe('scan before serve', () => {
+  it('a rejected verdict answers 422 and removes the re-materialised blob', async () => {
+    const h = harness({
+      scan: () => Promise.resolve({ assetId: 'evidence_asset:up1', quarantineStatus: 'rejected' }),
+    });
+    await expect(h.service.upload(COMPANY, blob(), input())).rejects.toMatchObject({ status: 422 });
+    expect(h.deleted).toEqual([`${EVIDENCE_UPLOAD_SCHEME}://${COMPANY}/${BYTES_HASH}`]);
+  });
+
+  it('a throwing scan hook leaves the asset scanning — it never fails open', async () => {
+    const h = harness({ scan: () => Promise.reject(new Error('scanner down')) });
+    const res = await h.service.upload(COMPANY, blob(), input({ packId: 'p1' }));
+    expect(res.quarantineStatus).toBe('scanning');
+    // Not clean ⇒ no dispatch is even attempted (the gate would deny it
+    // anyway, but the upload path must not ask).
+    expect(res.dispatched).toBe(false);
+    expect(h.dispatches).toHaveLength(0);
+  });
+});
+
+describe('dispatch is fire-and-forget', () => {
+  const saved = process.env.EVIDENCE_PROCESSOR_BROKER;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.EVIDENCE_PROCESSOR_BROKER;
+    else process.env.EVIDENCE_PROCESSOR_BROKER = saved;
+  });
+
+  it('a failing dispatch does not fail the upload', async () => {
+    process.env.EVIDENCE_PROCESSOR_BROKER = '1';
+    const h = harness({ dispatch: () => Promise.reject(new Error('broker exploded')) });
+    const res = await h.service.upload(COMPANY, blob(), input({ packId: 'p1' }));
+    expect(res.dispatched).toBe(true);
+    expect(res.assetId).toBe('evidence_asset:up1');
+    expect(h.dispatches).toEqual([{ packId: 'p1', assetId: 'evidence_asset:up1' }]);
+    // Let the rejected promise settle so the handled .catch() runs.
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+
+  it('dispatches nothing while the broker flag is off, or with no packId', async () => {
+    delete process.env.EVIDENCE_PROCESSOR_BROKER;
+    const off = harness();
+    expect((await off.service.upload(COMPANY, blob(), input({ packId: 'p1' }))).dispatched).toBe(
+      false,
+    );
+    expect(off.dispatches).toHaveLength(0);
+
+    process.env.EVIDENCE_PROCESSOR_BROKER = '1';
+    const noPack = harness();
+    expect((await noPack.service.upload(COMPANY, blob(), input())).dispatched).toBe(false);
+    expect(noPack.dispatches).toHaveLength(0);
+  });
+});

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -43,6 +43,8 @@ const PLATFORM_OPERATIONS: Array<[string, string]> = [
   ['/v1/users/{userId}/profile', 'get'],
   ['/v1/ingest/document', 'post'],
   ['/v1/ingest/evidence-asset', 'post'],
+  // Byte custody (MM-7, EVIDENCE_BLOB_UPLOAD_ENABLED — 404 until on).
+  ['/v1/ingest/evidence-blob', 'post'],
   ['/v1/documents/{id}', 'get'],
   ['/v1/documents/{id}/candidates', 'get'],
   ['/v1/documents/{id}/candidates', 'post'],


### PR DESCRIPTION
## The gap

The multimodal plane could store, quarantine, process and serve evidence bytes — but no caller could ever put bytes in.

- `evidence-ingest.controller.ts:94` — "METADATA-ONLY: originUri, never storageRef". No `FileInterceptor`, no `@UploadedFile`, no multipart anywhere in `src/`.
- `FsEvidenceStorageAdapter.put()` — zero production callers (one test).
- `EvidenceProcessorBrokerService.dispatchForPack()` — zero production callers; the authors' own note read *"no HTTP controller, no scheduler, no ingest surface"*.
- `EvidenceQuarantineService.runScan()` — zero production callers; `AllowAllScanHook` warned at boot that everything scans clean, and nothing ever called it.

This PR wires the missing ingest half, using seams that already existed rather than inventing new ones.

## What lands

### 1. `POST /v1/ingest/evidence-blob` — the byte surface

`multipart/form-data` beside the metadata sibling. Bytes go through the content-addressed storage adapter, then `registerAsset` with the resulting `storageRef`, so the **existing** availability derivation (`evidence-store.service.ts:386-403`: scheme → adapter → `head()` → byteLength equality) lands the asset `hot` on its own terms — nothing asserts `hot`, it is derived because the bytes are genuinely there.

The server owns identity: `byteHash` is sha256 over what it *received*, `byteLength` is measured, `storageRef` is minted. A caller who hands over the bytes cannot also assert what they are. Per-user stamping (0055 `userId`, 0093 `scope` tags) and the media-PII fail-closed polarity ride `registerAsset`'s existing handling — and because multipart has no null, an **absent** `piiClasses` field means unclassified/blocked while an **empty** one means affirmatively clean.

Enforced:
- **Size** — `evidenceMaxBytes()` applied as `min(cap, 64 MiB memory-storage ceiling)`, **resolved per call**. `limits.fileSize` on a stock `FileInterceptor(...)` is frozen at decorator evaluation; a small custom interceptor memoises one multer delegate per effective cap so the catalogued knob stays genuinely runtime-mutable, and an over-cap part is refused mid-upload (413) rather than after a full buffer.
- **Media type** — an explicit conservative allowlist checked *against the declared modality* (`image/png` may not register as `document`). Deliberate exclusions, documented in the module: SVG and HTML (active content the raw-read gateway would later serve back), `application/octet-stream` (unclassifiable, so it can never be honestly described to a pack's perception contract), archives and macro-capable office formats (nothing in v1 unpacks or scans inside a container).
- **Auth** — same guard, same `brain:write`, same tenant fence as the metadata route (`companyId` from the key, never the body), plus its own ABAC action `rest.ingest.evidence_blob` so a policy can open registration without opening byte custody.

Gated behind a new default-off **`EVIDENCE_BLOB_UPLOAD_ENABLED`**. The 404 is thrown from the **interceptor**, not the handler — parameter pipes run *after* interceptors, so a handler-only gate would let an unparsed multipart body fail DTO validation with a 400 and thereby advertise the dark route. Off ⇒ bare 404, and no caller bytes are ever buffered.

### 2. Scan before serve

Uploaded bytes are external ingest by definition, so registration passes `origin: 'external_ingest'` and inherits the MM-6 fence **verbatim**: with `EVIDENCE_QUARANTINE` off the store refuses (503) and nothing is written. No new quarantine semantics — the existing rule is simply now reachable.

With the seam on, the scan is synchronous and blocking (v1 has no scheduler), mapping the quarantine service's three existing outcomes onto HTTP:

| verdict | answer |
|---|---|
| `clean` | 201, asset dispatchable |
| `rejected` | 422, content-free message — the reject leg already tombstoned the row and deleted the bytes |
| hook throws | 201 with `quarantineStatus: 'scanning'` — still dispatch-denied. Fail **closed** and say so, never pretend the scan passed |

`AllowAllScanHook` stays the default implementation (a real scanner is infra); only the seam is live.

### 3. Broker invocation

- **Upload path** — fire-and-forget `dispatchForPack` after a clean scan when the caller names a `packId`. Never awaited; a failing adapter cannot turn an ingestion whose bytes are already stored, registered and scanned into an error. The response reports whether a dispatch was *started*, never whether it succeeded.
- **`POST /v1/admin/maintenance/evidence/dispatch`** — the operator's handle, following `admin-scenes.controller.ts` exactly (`brain:admin`, `resolvePlatformTenant`, 404 while dark). Sweeps already-registered assets for a pack: bounded read (`SELECT VALUE id … LIMIT`), per-asset fault-tolerant, replay-idempotent through the broker's own deterministic run ids. This covers the two cases the upload path cannot: a pack installed *after* assets landed, and a processor adapter added after a pack was installed.

**No cron.** `claimRun`'s "v1 has no scheduler" still holds.

## Notes on the constraints

- **No new dependency.** `@nestjs/platform-express` is already in `dependencies` and already depends on multer (pinned `^2.2.0` in the pnpm overrides). The only thing `@types/multer` would have given us is a four-field interface, spelled locally instead — nothing new reaches the supply-chain gate.
- **No migration.** The tables exist; `0129` stays the last one.
- **Orphan blobs are left alone, on purpose.** `put()` is content-addressed, so a blob is *shared* by construction — deleting on a failed registration could destroy bytes another row already owns. An unreferenced blob is inert and is reused verbatim by the next successful registration of the same content. The one case where deletion is provably safe is a `rejected` verdict (a rejected asset never keeps a `storageRef`), and that case is handled.
- **Files avoided** — `processing-run.service.ts`, `processor-adapter.ts` and `fragment-lane.service.ts` are untouched. `evidence.module.ts` gains one controller, two providers and one export.

## Tests

**Unit (16)** — allowlist membership, modality pairing and the exclusions; flag-off 404 at both layers (with a pin that the handler chain was never entered); size cap and empty-part rejection; `userId`/`scope`/`piiClasses` reaching `registerAsset` verbatim alongside the server-owned identity fields; scan outcomes including the throwing hook; dispatch fire-and-forget (a rejecting broker does not fail the upload).

**E2E (13)** — default-off bare 404; quarantine-off 503 with zero rows; a tiny in-test buffer landing `hot` with a real `fs://` ref, `quarantineStatus: 'clean'`, and bytes actually retrievable back through the adapter; dedup; allowlist and 413 over the wire; the rejection path (422, tombstone, bytes gone, and a re-upload of already-rejected content still rejected without leaving the re-materialised blob); a real `processing_run` + derived text produced by the upload path's dispatch; the admin sweep reaching an asset no upload covered, plus its double-run idempotence and 404-while-dark.

## Gates

`pnpm typecheck` ✅ · `pnpm test:unit` ✅ 365 suites / 4138 tests · `pnpm lint:ci` ✅ · `pnpm format:check` ✅ · evidence e2e ✅ 8 suites / 65 tests (plus the 13 new)

## Operator note

The scan hook shipped today is the **allow-all stub**. It exercises the `quarantined → scanning → clean` lifecycle end to end, but it passes everything — install a real scanner before trusting uploads from untrusted callers. Documented in `docs/operations.md` next to the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
