### PR TITLE
feat(packs): pack-projected state deltas reach belief promotion

### DIFF
--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -324,7 +324,7 @@ one non-empty field; present-but-empty is rejected:
 | Field | What it declares | Caps |
 | --- | --- | --- |
 | `sceneSchemas` | Recurring scene shapes (`id`, `description`, literal `cues`) | ≤ 8 schemas, ≤ 12 cues of 2..64 chars |
-| `stateModels` | Subject-typed lifecycles (`states`, optional `transitions`) | ≤ 8 models, 2..16 states, ≤ 64 transitions |
+| `stateModels` | Subject-typed lifecycles (`states`, optional `transitions`, optional belief-attribute `field`) | ≤ 8 models, 2..16 states, ≤ 64 transitions |
 | `attentionHints` | Literal `cue` → `prefer` (own predicates), `zoom` (own scenes ∪ `episodes`/`facts`/`scenes`), `weight` (0,1] | ≤ 16 hints, ≤ 8 prefer, ≤ 4 zoom |
 | `verificationRules` | Claim classes needing `human_confirmation` \| `corroboration` \| `recency_check` | ≤ 16 rules, `claimPattern` 2..128 chars |
 | `retentionHints` | ADVISORY `ephemeral`/`standard`/`durable` per own predicate/scene | ≤ 32 hints |
@@ -418,6 +418,20 @@ security hole:
   writer (`src/episodes/pack-scene-projection.ts`). A schema that
   declares no `cues` can never fire here — there is nothing literal to
   match — so cues are what makes a pack visible to conversational memory.
+- **Belief promotion of pack deltas**
+  (`src/episodes/pack-scene-projection.ts` →
+  `src/admin/belief-promotion.service.ts`) — a projected `state_delta`,
+  from EITHER producer, carries `field` =
+  `<packId>__<stateModel.field ?? stateModel.id>` alongside its
+  `stateModelId`, and under `SCENES_PACK_DELTA_PROMOTION` the belief pass
+  folds those deltas into `semantic_belief`. The mapping lives in the
+  shared writer precisely so a belief never depends on whether the domain
+  arrived as a document or as a conversation turn. The `field` is
+  pack-NAMESPACED for the same reason predicates and MCP tools are: two
+  packs whose lifecycles resolve to the same local attribute (`status`,
+  `stage`) must stay in SEPARATE belief groups, not silently overwrite
+  each other. `field` is optional — omit it and the stateModel's own `id`
+  is the attribute name.
 - **L3 attention boost** (`src/synthesize/l3-escalation.service.ts`) —
   under `FOVEA_ATTENTION_HINTS`, installed packs' `attentionHints` bias
   which memories the L3 escalation pass prefers and how deep it zooms.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -183,10 +183,20 @@ below (the beliefs READ API is also its own flag,
 | `SCENES_BELIEF_LLM_SYNTHESIS` | `0` | ONE LLM call per belief create/revise to phrase the statement; any failure degrades to the deterministic template. |
 | `SCENES_BELIEF_NEGATION_DELTAS` | `0` | Fold state REMOVALS (sold / quit / ended): a stateDelta with empty `to` + non-empty `from` becomes a belief contribution with the sentinel value `none` (`priorValue` = the removed state). Both-ends-empty deltas stay dropped. |
 | `SCENES_BELIEF_FIELD_FOLD` | `0` | Deterministic field-name folding: an enricher-re-coined field name folds onto an existing `(userId, subject)` field when its extra tokens are all generic modifiers; the EXISTING name wins; more than one match folds nothing and warns loudly. No embeddings, no LLM. |
+| `SCENES_PACK_DELTA_PROMOTION` | `0` | Also promote the PACK-PROJECTION scene worlds (`pack:<packId>+<fp>`, written by BOTH 0110 projectors — the document scene-candidate writer and the capture-path mention producer — under `PACK_MEMORY_PROJECTIONS_ENABLED`). Their deltas carry `field` = `<packId>__<stateModel.field ?? stateModelId>`, so a document ingested — or a turn captured — for a tenant with an installed pack finally reaches the belief plane; the pack namespace keeps two packs that share a local attribute name in SEPARATE belief groups. Pack scenes have no `enrichmentVersion` (their deltas come from the pack's own reading, not the enricher), so that requirement is dropped for `pack:` worlds only. The `#387` single-user fence is unchanged — a TENANT-GLOBAL document's scenes carry no `userIds` and promote for no one. |
 
 Order: master flag → compose → (`SCENES_LLM_ENRICHMENT` → enrich) →
 (`SCENES_BELIEF_PROMOTION` → beliefs). Enrichment is a prerequisite for
 promotion — the belief fold reads enriched fields only.
+
+Exception: `SCENES_PACK_DELTA_PROMOTION` admits pack-projected scenes
+WITHOUT enrichment (the pack indexer already read them). Two operator
+notes for that lane: the pack world must exist first
+(`PACK_MEMORY_PROJECTIONS_ENABLED` + an installed pack whose manifest
+declares `memoryModel.stateModels`), and `SCENES_BELIEF_MIN_SCENES` is a
+distinct-CONVERSATION floor — DOCUMENT scenes carry no conversation, so
+any non-zero floor excludes document-projected beliefs entirely (a
+capture-origin scene carries its turn's conversation and is unaffected).
 
 ### `BELIEFS_*` — belief serving lane (0126)
 

--- a/src/admin/belief-promotion.service.ts
+++ b/src/admin/belief-promotion.service.ts
@@ -11,15 +11,31 @@ import {
   sceneBeliefMinScenes,
   sceneBeliefNegationDeltasEnabled,
   sceneBeliefPromotionEnabled,
+  scenePackDeltaPromotionEnabled,
 } from '../common/scene-flags';
 import { supportEdgesEnabled } from '../common/provenance-flags';
 import { buildSupportEdgeBatches } from '../common/support-edges';
 import { absorbFoldableOrphans, resolveFieldFold } from './belief-field-fold';
+import {
+  beliefPromoterVersion,
+  buildPromotableScenesQuery,
+  promoterVersionFor,
+} from './belief-scene-selection';
 import { SceneVersionService } from './scene-version';
 
-// The lexical fold rule lives in belief-field-fold.ts (god-file split);
-// re-exported here so the historical import surface is unchanged.
+// The lexical fold rule lives in belief-field-fold.ts and the scene
+// selection / world stamping in belief-scene-selection.ts (god-file
+// split); both are re-exported here so the historical import surface is
+// unchanged.
 export { FIELD_FOLD_GENERIC_TOKENS, fieldsFold, resolveFieldFold } from './belief-field-fold';
+export {
+  BELIEF_PROMOTER_VERSION,
+  PACK_SCENE_WORLD_PREFIX,
+  beliefPromoterVersion,
+  buildPromotableScenesQuery,
+  isPackSceneWorld,
+  promoterVersionFor,
+} from './belief-scene-selection';
 
 /**
  * Belief promotion (Belief-A, SCENES_BELIEF_PROMOTION — default off):
@@ -72,6 +88,38 @@ export { FIELD_FOLD_GENERIC_TOKENS, fieldsFold, resolveFieldFold } from './belie
  * priorValue backfill, same-run fence, ambiguity skip, idempotence)
  * lives on absorbFoldableOrphans in belief-field-fold.ts.
  *
+ * PACK DELTAS (SCENES_PACK_DELTA_PROMOTION — default off): the pass
+ * additionally admits scenes of the PACK-PROJECTION worlds
+ * (`segmenterVersion` = `pack:<packId>+<fp>`, written by
+ * SceneCandidateWriterService when a document's external indexer stages
+ * 0110 scene/state_delta candidates). Two fences kept those scenes out
+ * of the belief plane entirely, so `PACK_MEMORY_PROJECTIONS_ENABLED`
+ * (ON in prod) was a write with no reader:
+ *   1. their deltas carried `stateModelId`, never the `field` the fold
+ *      keys on — fixed at PROJECTION time (packDeltaField writes BOTH,
+ *      `<packId>__<stateModel.field ?? stateModelId>`);
+ *   2. the version fence pinned the composer's effective world — widened
+ *      here (buildPromotableScenesQuery), behind this flag.
+ * The pack leg also drops the `enrichmentVersion IS NOT NONE`
+ * requirement, which a pack scene will never satisfy: its deltas come
+ * from the pack indexer's reading, not from the LLM enricher (its
+ * explicitness therefore falls back to DEFAULT_EXPLICITNESS).
+ *
+ * The FENCES that must survive the widening, and do:
+ *  - PER-USER SCOPE: unchanged. A projected scene inherits the
+ *    document's 0128 stamp (userId + 0093 scope + 0117 userIds), so
+ *    sceneSingleUser admits it only for that one user — and a
+ *    TENANT-GLOBAL document's scenes (no userIds) are skipped
+ *    fail-closed like any other, never promoted into someone's beliefs.
+ *  - CROSS-PACK COLLISION: the field is pack-NAMESPACED, so two packs
+ *    whose stateModels resolve to the same local attribute stay in
+ *    separate (userId, subject, field) groups. They are kept distinct,
+ *    deliberately, rather than merged — the predicate/tool namespace
+ *    rule (`<packId>__<name>`) applied to the belief plane.
+ *  - PACK PROVENANCE: a belief folded wholly out of one pack world is
+ *    stamped promoterVersion `belief-promotion-v1|pack:<packId>+<fp>`
+ *    (promoterVersionFor) — an existing column, no migration.
+ *
  * CONFLICT GUARD (built-in, no flag): a group whose latest timestamp is
  * shared by two DIFFERENT values has no deterministic winner — the whole
  * (subject, field) group is SKIPPED LOUDLY with a warn. Same for a
@@ -118,17 +166,6 @@ export { FIELD_FOLD_GENERIC_TOKENS, fieldsFold, resolveFieldFold } from './belie
  * The deterministic template fold works with no client at all.
  */
 
-/** Promoter identity — composed with the effective scene world below. */
-export const BELIEF_PROMOTER_VERSION = 'belief-promotion-v1';
-
-/**
- * Pure: the readable promoter|world composite stamped on belief rows and
- * support edges (the enricher's readable-composite idiom — NOT hashed).
- */
-export function beliefPromoterVersion(sceneVersion: string): string {
-  return `${BELIEF_PROMOTER_VERSION}|${sceneVersion}`;
-}
-
 /** Belts against runaway payloads (the enricher's cap discipline). */
 const STATEMENT_MAX_CHARS = 500;
 const SYNTHESIS_VISIBLE_CAP = 400;
@@ -168,6 +205,12 @@ export interface PromotableSceneHead {
   stateDeltas?: unknown;
   /** enrichedMemoryValue.explicitness projection (confidence signal). */
   explicitness?: unknown;
+  /**
+   * The scene world this row belongs to. Selected ONLY under
+   * SCENES_PACK_DELTA_PROMOTION (the flag-off query is byte-identical),
+   * where it becomes the belief's pack provenance.
+   */
+  segmenterVersion?: unknown;
 }
 
 /**
@@ -194,6 +237,12 @@ export interface BeliefContribution {
   value: string;
   priorValue: string;
   explicitness: number;
+  /**
+   * The contributing scene's world (segmenterVersion). '' unless
+   * SCENES_PACK_DELTA_PROMOTION selected the column — which is exactly
+   * why the flag-off stamps are unchanged.
+   */
+  world: string;
 }
 
 /** One promotable (userId, subject, field) verdict out of the fold. */
@@ -210,6 +259,14 @@ export interface FoldedBelief {
   /** Distinct conversations behind those scenes — the floor unit. */
   conversationIds: string[];
   confidence: number;
+  /**
+   * Distinct scene worlds behind the WINNING value (sorted). Empty
+   * unless SCENES_PACK_DELTA_PROMOTION selected segmenterVersion; a
+   * single `pack:` world becomes the belief's promoterVersion stamp
+   * (promoterVersionFor) — the pack provenance carried onto the row
+   * without a new column.
+   */
+  worlds: string[];
 }
 
 export interface BeliefFold {
@@ -321,6 +378,8 @@ interface SceneFoldContext {
   conversationId: string;
   occurredAt: number;
   explicitness: number;
+  /** segmenterVersion, '' when the column was not selected (flag off). */
+  world: string;
 }
 
 /** Pure: parse one scene's head for the fold; null = unusable (unordered). */
@@ -339,7 +398,7 @@ function sceneFoldContext(scene: PromotableSceneHead): SceneFoldContext | null {
     typeof explicitnessRaw === 'number' && Number.isFinite(explicitnessRaw)
       ? Math.min(1, Math.max(0, explicitnessRaw))
       : DEFAULT_EXPLICITNESS;
-  return { sceneId, conversationId, occurredAt, explicitness };
+  return { sceneId, conversationId, occurredAt, explicitness, world: str(scene.segmenterVersion) };
 }
 
 /**
@@ -388,6 +447,7 @@ function collectSceneDeltas({
       value: admitted.value,
       priorValue: admitted.priorValue,
       explicitness: head.explicitness,
+      world: head.world,
     });
   }
 }
@@ -447,6 +507,9 @@ function foldGroupVerdict(group: {
       sceneIds,
       conversationIds,
       confidence: Math.round(confidence * 10000) / 10000,
+      // Distinct worlds behind the winning value (sorted = deterministic).
+      // Empty with the flag off — the column is not even selected.
+      worlds: [...new Set(corroborating.map((c) => c.world).filter((w) => w !== ''))].sort(),
     },
   };
 }
@@ -637,18 +700,14 @@ export class BeliefPromotionService {
     const edgesOn = supportEdgesEnabled();
     const negationDeltas = sceneBeliefNegationDeltasEnabled();
     const fieldFoldOn = sceneBeliefFieldFoldEnabled();
+    const packDeltas = scenePackDeltaPromotionEnabled();
     await this.surreal.withCompany(companyId, async (db) => {
-      const [scenes] = await db.query<[PromotableSceneHead[]]>(
-        `SELECT id, userId, userIds, conversationIds, occurredTo, stateDeltas,
-                enrichedMemoryValue.explicitness AS explicitness
-           FROM memory_episode
-          WHERE segmenterVersion = $v AND enrichmentVersion IS NOT NONE` +
-          (opts.conversationId !== undefined ? ` AND conversationIds CONTAINS $conv` : ''),
-        {
-          v: version,
-          ...(opts.conversationId !== undefined ? { conv: opts.conversationId } : {}),
-        },
-      );
+      const selection = buildPromotableScenesQuery({
+        version,
+        ...(opts.conversationId !== undefined ? { conversationId: opts.conversationId } : {}),
+        packDeltas,
+      });
+      const [scenes] = await db.query<[PromotableSceneHead[]]>(selection.sql, selection.params);
       const eligible: Array<{ scene: PromotableSceneHead; userId: string }> = [];
       for (const scene of scenes ?? []) {
         result.scenes += 1;
@@ -762,7 +821,7 @@ export class BeliefPromotionService {
   private async upsertBelief({
     db,
     belief,
-    promoterVersion,
+    promoterVersion: runPromoterVersion,
     edgesOn,
     result,
   }: {
@@ -772,6 +831,9 @@ export class BeliefPromotionService {
     edgesOn: boolean;
     result: BeliefPromotionResult;
   }): Promise<void> {
+    // Per-belief stamp: identical to the run stamp unless this belief
+    // came wholly out of ONE pack world (promoterVersionFor).
+    const promoterVersion = promoterVersionFor(belief, runPromoterVersion);
     const [actives] = await db.query<[ActiveBeliefRow[]]>(
       `SELECT id, revision, value, validFrom, sourceSceneIds, conversationIds
          FROM semantic_belief

--- a/src/admin/belief-scene-selection.ts
+++ b/src/admin/belief-scene-selection.ts
@@ -1,0 +1,115 @@
+/**
+ * Which scenes the belief promotion pass reads, and which world stamp a
+ * promoted belief carries (the god-file split off
+ * belief-promotion.service.ts — the belief-field-fold.ts precedent; the
+ * service re-exports every name here, so the historical import surface is
+ * unchanged).
+ *
+ * Two id-spaces feed the belief plane:
+ *  - the COMPOSER's effective segmenter world (`scene-segmenter-v1`,
+ *    optionally fingerprinted under SCENES_VERSION_FINGERPRINT), whose
+ *    scenes are LLM-enriched;
+ *  - the PACK PROJECTION worlds (`pack:<packId>+<fp>`, packSceneVersion
+ *    in episodes/pack-scene-projection.ts), whose stateDeltas come from a
+ *    pack's own reading of a document or of a captured turn — both
+ *    origins write the one shared shape, including the belief `field`.
+ * The prefixes are disjoint by construction, which is what lets one
+ * WHERE serve both without an ambiguity.
+ */
+
+/** Promoter identity — composed with the effective scene world below. */
+export const BELIEF_PROMOTER_VERSION = 'belief-promotion-v1';
+
+/**
+ * Pure: the readable promoter|world composite stamped on belief rows and
+ * support edges (the enricher's readable-composite idiom — NOT hashed).
+ */
+export function beliefPromoterVersion(sceneVersion: string): string {
+  return `${BELIEF_PROMOTER_VERSION}|${sceneVersion}`;
+}
+
+/** Namespace prefix of a pack-projection scene world. */
+export const PACK_SCENE_WORLD_PREFIX = 'pack:';
+
+/** Pure: does this scene world belong to a pack projection? */
+export function isPackSceneWorld(world: string): boolean {
+  return world.startsWith(PACK_SCENE_WORLD_PREFIX);
+}
+
+/**
+ * Pure: the promotion pass's scene selection.
+ *
+ * FLAG OFF (default) the SQL string and the bind map are byte-identical
+ * to the pre-SCENES_PACK_DELTA_PROMOTION pass — pinned by unit test,
+ * because "off is byte-identical" is the whole contract of a shadow
+ * substrate flag.
+ *
+ * FLAG ON a second leg admits the pack-projection worlds. That leg
+ * deliberately does NOT require `enrichmentVersion`: a pack scene's
+ * stateDeltas come from the pack indexer's reading, not from the LLM
+ * enricher, so the enrichment stamp it will never have must not fence it
+ * out. It DOES require a non-empty `stateDeltas` array — a scene with
+ * nothing to promote is not worth loading — and the SELECT gains
+ * `segmenterVersion` so each contribution knows which world it came from
+ * (belief provenance, promoterVersionFor below).
+ *
+ * Both legs are plain reads: the SurrealDB 3.2.4 secondary-index
+ * DELETE/UPDATE-WHERE planner trap applies to writes, not to SELECT.
+ */
+export function buildPromotableScenesQuery(p: {
+  version: string;
+  conversationId?: string | undefined;
+  packDeltas: boolean;
+}): { sql: string; params: Record<string, unknown> } {
+  const conv = p.conversationId !== undefined ? ` AND conversationIds CONTAINS $conv` : '';
+  const params: Record<string, unknown> = {
+    v: p.version,
+    ...(p.conversationId !== undefined ? { conv: p.conversationId } : {}),
+  };
+  if (!p.packDeltas) {
+    return {
+      sql:
+        `SELECT id, userId, userIds, conversationIds, occurredTo, stateDeltas,
+                enrichedMemoryValue.explicitness AS explicitness
+           FROM memory_episode
+          WHERE segmenterVersion = $v AND enrichmentVersion IS NOT NONE` + conv,
+      params,
+    };
+  }
+  return {
+    sql:
+      `SELECT id, userId, userIds, conversationIds, occurredTo, stateDeltas, segmenterVersion,
+              enrichedMemoryValue.explicitness AS explicitness
+         FROM memory_episode
+        WHERE ((segmenterVersion = $v AND enrichmentVersion IS NOT NONE)
+            OR (string::starts_with(segmenterVersion, $packPrefix)
+                AND stateDeltas IS NOT NONE AND array::len(stateDeltas) > 0))` + conv,
+    params: { ...params, packPrefix: PACK_SCENE_WORLD_PREFIX },
+  };
+}
+
+/**
+ * Pure: the promoterVersion stamped on ONE belief.
+ *
+ * Provenance without a new column (0120 is SCHEMAFULL and this ships no
+ * migration): a belief folded entirely out of ONE pack-projection world
+ * is stamped `belief-promotion-v1|pack:<packId>+<fp>` instead of the
+ * run's composer world, so `SELECT promoterVersion FROM semantic_belief`
+ * alone says which pack's perception produced the row — and the
+ * pack-namespaced `field` says it a second time.
+ *
+ * Every other case keeps the run stamp verbatim: no worlds (the flag-off
+ * path never selects the column), a composer world, or a MIXED set (a
+ * belief corroborated by both planes belongs to neither alone). So with
+ * SCENES_PACK_DELTA_PROMOTION off this is the identity function on
+ * runPromoterVersion — byte-identical stamps.
+ */
+export function promoterVersionFor(
+  belief: { worlds: readonly string[] },
+  runPromoterVersion: string,
+): string {
+  const only = belief.worlds.length === 1 ? belief.worlds[0] : undefined;
+  return only !== undefined && isPackSceneWorld(only)
+    ? beliefPromoterVersion(only)
+    : runPromoterVersion;
+}

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -781,6 +781,18 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Belief promotion field fold (#135 seam 2): deterministically fold an enricher-re-coined field name onto an existing one for the same (userId, subject) — token-set subset whose extra tokens are all generic modifiers (ownership/status/state/current/of/the); the EXISTING name wins, and more than one match folds nothing and warns loudly (skip loudly, never flip-flop). NO embeddings, NO LLM. Also absorbs orphans: after each canonical upsert, ACTIVE beliefs of the same (userId, subject) stored under a foldable VARIANT of the canonical field (earlier-batch leftovers the incoming-name fold can never retire) are stamped superseded so they stop serving stale values; the canonical belief keeps its own value, the orphan value backfills priorValue only when the canonical has none, and more than one distinct variant field skips loudly. Off = exact-string (subject, field) grouping and zero extra queries — byte-identical fold output.',
   },
   {
+    key: 'SCENES_PACK_DELTA_PROMOTION',
+    category: 'scenes',
+    // Read at call time (scene-flags.scenePackDeltaPromotionEnabled) ONCE
+    // per promotion run — never captured in a constructor — so a flip
+    // takes effect without restart and can never mix worlds mid-run.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Pack-projected state-delta promotion: the belief pass (SCENES_BELIEF_PROMOTION) additionally admits scenes of the pack-projection worlds (segmenterVersion pack:<packId>+<fp>, written by the 0110 projectors — the document scene-candidate writer and the capture-path mention producer — under PACK_MEMORY_PROJECTIONS_ENABLED). Their stateDeltas carry field = <packId>__<stateModel.field or stateModelId>, so a document ingested — or a turn captured — for a tenant with an installed pack finally reaches the belief plane; the pack namespace keeps two packs sharing a local attribute name in SEPARATE belief groups. Pack scenes carry no enrichmentVersion (their deltas come from the pack’s own reading, not the LLM enricher), so the widened leg drops that requirement for pack: worlds only. Unchanged: the #387 single-user fence (a tenant-global document has no userIds and is skipped fail-closed), the conflict guard, the supersede chain. The belief promoterVersion carries the pack world as provenance. NOTE: document scenes carry no conversationIds, so a non-zero SCENES_BELIEF_MIN_SCENES (a distinct-CONVERSATION floor) excludes document-projected beliefs by construction. Off = the selection query, its parameters and every stamp are byte-identical to the pre-flag pass — no pack scene is ever seen.',
+  },
+  {
     key: 'SCENES_PREDICTION_BASELINE',
     category: 'scenes',
     // Read at call time (scene-flags.scenePredictionBaselineEnabled) once

--- a/src/ai/domain-packs/manifest.ts
+++ b/src/ai/domain-packs/manifest.ts
@@ -293,6 +293,50 @@ export interface PackStateModel {
   states: string[];
   /** ≤ MM_MAX_TRANSITIONS; both ends must be declared states. */
   transitions?: PackStateTransition[];
+  /**
+   * OPTIONAL pack-local ATTRIBUTE name this lifecycle projects onto in the
+   * belief plane (`stateModelFieldLocal`). snake_case, no `__`, ≤64 chars.
+   * Omitted (the state of every shipped pack) ⇒ the stateModel's own `id`
+   * is the attribute name, so a pack that never heard of beliefs still
+   * projects a stable, self-describing one. Declare it only when the
+   * lifecycle id and the attribute read differently ("policy_lifecycle"
+   * the machine vs "policy_status" the attribute).
+   *
+   * NEVER the stored name: the belief field is always NAMESPACED
+   * `<packId>__<local>` (packStateFieldName) — see composePredicateId's
+   * rationale, which this deliberately mirrors.
+   */
+  field?: string;
+}
+
+/**
+ * Pure: the pack-LOCAL belief attribute name a stateModel projects onto —
+ * its declared `field`, else its `id`. The default is what keeps the
+ * manifest addition purely optional: every shipped pack (and every
+ * already-installed third-party manifest) resolves to its stateModel id
+ * without declaring anything.
+ */
+export function stateModelFieldLocal(m: { id: string; field?: string | undefined }): string {
+  const declared = typeof m.field === 'string' ? m.field.trim() : '';
+  return declared === '' ? m.id : declared;
+}
+
+/**
+ * Pure: the STORED belief field name for one pack's stateModel —
+ * `<packId>__<local>`, the predicate/tool namespace discipline applied to
+ * the belief plane.
+ *
+ * WHY NAMESPACED. Two packs may legitimately declare the same local
+ * lifecycle attribute ('status', 'stage'); an unnamespaced field would
+ * silently MERGE their beliefs into one (userId, subject, field) group,
+ * where the fold's latest-value-wins rule would let one domain overwrite
+ * the other's state. Namespacing keeps them distinct by construction —
+ * the same reason `<packId>__<localId>` exists for predicates and MCP
+ * tools — and makes the belief row self-describing about which pack's
+ * perception produced it.
+ */
+export function packStateFieldName(packId: string, local: string): string {
+  return `${packId}${PACK_NAMESPACE_SEP}${local}`;
 }
 
 /** "When you see this, look closer": a literal cue that biases retrieval /

--- a/src/ai/domain-packs/validate-memory-model.ts
+++ b/src/ai/domain-packs/validate-memory-model.ts
@@ -375,6 +375,13 @@ function validateStateModels(packId: string, models: unknown, sceneIds: Set<stri
       min: 1,
       max: 64,
     });
+    // OPTIONAL belief-attribute name (defaults to the id — see
+    // stateModelFieldLocal). Same snake_case/no-`__` charset as the id:
+    // the STORED name is `<packId>__<field>`, so a `__` inside would make
+    // the namespace boundary ambiguous.
+    if (m.field !== undefined) {
+      assertSnakeId(packId, `stateModel "${m.id}" field`, m.field);
+    }
     validateStates(packId, m);
   }
 }

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1137,6 +1137,15 @@ const KNOWN_BOOLEAN_FLAGS = [
   // folds nothing and warns loudly. NO embeddings, NO LLM. Default off
   // ⇒ exact-string grouping, zero extra queries — byte-identical.
   'SCENES_BELIEF_FIELD_FOLD',
+  // Pack-projected state-delta promotion: the belief pass also admits
+  // the `pack:<packId>+<fp>` projection worlds (0110 scene candidates,
+  // both the document and the capture producer), whose deltas carry the
+  // namespaced field `<packId>__<local>` and no enrichmentVersion.
+  // Per-user (#387) scope, cross-pack separation and the conflict guard
+  // are unchanged. Default off ⇒ the selection query, its parameters and
+  // every stamp are byte-identical to the pre-flag pass — no pack scene
+  // is ever seen.
+  'SCENES_PACK_DELTA_PROMOTION',
   // Scene prediction baseline: the expectation snapshot the scene plane
   // never had. On, the enrichment pass loads the scene user's ACTIVE
   // semantic_belief rows (0120) BEFORE scoring, stamps them as

--- a/src/common/scene-flags.ts
+++ b/src/common/scene-flags.ts
@@ -211,6 +211,40 @@ export function sceneBeliefFieldFoldEnabled(): boolean {
 }
 
 /**
+ * Pack-projected state-delta promotion — SCENES_PACK_DELTA_PROMOTION.
+ *
+ * When on, the belief promotion pass ALSO admits scenes of the
+ * pack-projection worlds (`segmenterVersion` LIKE `pack:<packId>+<fp>`,
+ * written by BOTH pack projection producers — SceneCandidateWriterService
+ * on the document path and MentionProjectionService on the capture path —
+ * under PACK_MEMORY_PROJECTIONS_ENABLED), not only the composer's current
+ * effective segmenter version. Pack scenes carry no `enrichmentVersion`
+ * (their stateDeltas come from the pack's own reading, not the LLM
+ * enricher), so the widened leg drops that requirement for `pack:` worlds
+ * ONLY.
+ *
+ * Everything downstream is unchanged: the #387 single-user fence still
+ * applies (a tenant-global document's scenes carry no userIds and are
+ * skipped fail-closed), the field is the pack-namespaced
+ * `<packId>__<local>` (packDeltaField) so packs can never merge, and the
+ * belief's promoterVersion carries the pack world as provenance.
+ *
+ * NOTE: document scenes carry NO conversationIds, so a non-zero
+ * SCENES_BELIEF_MIN_SCENES (a DISTINCT-CONVERSATION floor) excludes
+ * document-projected beliefs by construction; a capture-origin scene does
+ * carry its turn's conversation.
+ *
+ * The env read lives here in the common layer, NOT inside the engine dirs
+ * (engine-gates S5.2). Read ONCE per promotion run so a mid-run flip can
+ * never mix worlds (the Drift-3 contract). Default off ⇒ the promoter's
+ * selection query, parameters and per-belief stamps are byte-identical to
+ * the pre-flag pass — no pack scene is ever seen.
+ */
+export function scenePackDeltaPromotionEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_PACK_DELTA_PROMOTION);
+}
+
+/**
  * Scenes prediction-baseline flag — SCENES_PREDICTION_BASELINE.
  *
  * The scene plane had NO prediction machinery: `memoryValue.contradiction`

--- a/src/documents/scene-candidate-writer.service.ts
+++ b/src/documents/scene-candidate-writer.service.ts
@@ -5,23 +5,28 @@ import { ProjectionRegistryService } from '../episodes/projection-registry.servi
 import {
   PACK_SCENE_PROJECTOR,
   buildPackSceneRow,
+  packDeltaField,
   packSceneIdTail,
   packSceneProjectionName,
   packSceneScopeStamp,
   packSceneVersion,
   packStateDeltaEntry,
+  packStateModelIndex,
   swapPackSceneSlice,
+  type PackStateModelIndex,
 } from '../episodes/pack-scene-projection';
 import { packMemoryProjectionsEnabled } from '../common/pack-projection-flags';
 import { idTailOf } from '../ingest/ingest-utils';
+import { MemoryModelReaderService } from '../ai/memory-model-reader.service';
 import { CandidateStoreService, type CandidateRow } from './candidate-store.service';
 import type { StoredDocument } from './document-store.service';
 
-// The projector stamp, its version mold and the row builder are SHARED
-// with the capture-path producer (MentionProjectionService) — one shape,
-// two origins. Re-exported here for API continuity (the 0110 specs and
-// the e2e import them from this module).
-export { PACK_SCENE_PROJECTOR, packSceneVersion };
+// The projector stamp, its version mold, the row builder and the
+// stateModelId -> belief-field mapping are SHARED with the capture-path
+// producer (MentionProjectionService) — one shape, two origins.
+// Re-exported here for API continuity (the 0110 specs and the e2e import
+// them from this module).
+export { PACK_SCENE_PROJECTOR, packDeltaField, packSceneVersion };
 
 /**
  * Per-user scope stamp for a projected scene row (0128): a user-scoped
@@ -79,6 +84,14 @@ type StatusUpdate = {
  * converges instead of duplicating. Other packs' worlds and the
  * composer's conversation scenes are untouched by construction.
  *
+ * STATE DELTAS carry BOTH `stateModelId` (the pack provenance) and
+ * `field` = `<packId>__<stateModel.field ?? stateModelId>`
+ * (packDeltaField) — the belief plane keys on (userId, subject, field)
+ * and drops fieldless deltas, so without the mapping these projections
+ * were a write with no reader. The pack-namespaced field is also the
+ * cross-pack collision rule: two packs whose lifecycles share a local
+ * attribute name stay in separate belief groups by construction.
+ *
  * Document scenes quote no L0 episode turn, so NO memory_episode_member
  * rows are written; erasure is keyed by source.docId — the entity-forget
  * document cascade owns it (unconditionally — see 0110's header).
@@ -93,10 +106,18 @@ type StatusUpdate = {
 export class SceneCandidateWriterService {
   private readonly logger = new Logger(SceneCandidateWriterService.name);
 
+  // The four collaborators are the four planes this one projection
+  // touches — episode rows (surreal), candidate statuses (candidates),
+  // the projection ledger (registry) and the pack's own declarations
+  // (memoryModels, the stateModelId -> field mapping input). Splitting
+  // would only add a pass-through class (the CandidateCommitService
+  // precedent one file over).
+  // eslint-disable-next-line max-params
   constructor(
     private readonly surreal: SurrealService,
     private readonly candidates: CandidateStoreService,
     private readonly registry: ProjectionRegistryService,
+    private readonly memoryModels: MemoryModelReaderService,
   ) {}
 
   /** rows = the commit's pending candidates of kind scene/state_delta. */
@@ -106,13 +127,23 @@ export class SceneCandidateWriterService {
     rows: CandidateRow[],
   ): Promise<SceneProjectionOutcome[]> {
     if (!packMemoryProjectionsEnabled() || rows.length === 0) return [];
+    // stateModelId -> field mapping input, resolved ONCE per commit (the
+    // reader is LRU+TTL cached and fail-open, so this is at most one
+    // domain_pack read per tenant per 30s).
+    const stateModels = await this.stateModelsByPack(companyId);
     const outcomes: SceneProjectionOutcome[] = [];
     for (const group of groupByRun(rows).values()) {
       const version = packSceneVersion(group.packId, group.packVersion);
       const name = packSceneProjectionName(group.packId);
       await this.registry.begin({ companyId, name, version, builder: PACK_SCENE_PROJECTOR });
       try {
-        const outcome = await this.projectGroup({ companyId, doc, group, version });
+        const outcome = await this.projectGroup({
+          companyId,
+          doc,
+          group,
+          version,
+          models: stateModels.get(group.packId),
+        });
         await this.registry.complete({
           companyId,
           name,
@@ -131,11 +162,27 @@ export class SceneCandidateWriterService {
     return outcomes;
   }
 
+  /**
+   * packId -> (stateModelId -> declaration) for the tenant's installed
+   * packs. Fail-open by contract (MemoryModelReaderService degrades to
+   * builtins-only on a read error): an unresolvable pack falls back to the
+   * stateModelId as the local field name — the projection never fails for
+   * a manifest hiccup.
+   */
+  private async stateModelsByPack(companyId: string): Promise<Map<string, PackStateModelIndex>> {
+    const byPack = new Map<string, PackStateModelIndex>();
+    for (const binding of await this.memoryModels.installedMemoryModels(companyId)) {
+      byPack.set(binding.packId, packStateModelIndex(binding.memoryModel.stateModels));
+    }
+    return byPack;
+  }
+
   private async projectGroup(p: {
     companyId: string;
     doc: StoredDocument;
     group: SceneGroup;
     version: string;
+    models: PackStateModelIndex | undefined;
   }): Promise<SceneProjectionOutcome> {
     const { doc, group, version } = p;
     const generation = new Date().toISOString();
@@ -179,7 +226,12 @@ export class SceneCandidateWriterService {
             schemaId: row.payload.schemaId,
             candidateId: row.id,
           },
-          stateDeltas: deltasForScene(group.deltas, sceneIndex),
+          stateDeltas: projectSceneDeltas({
+            deltas: group.deltas,
+            sceneIndex,
+            packId: group.packId,
+            models: p.models,
+          }),
         }),
       );
       updates.push({ id: row.id, status: 'committed', commitRef: episodeId });
@@ -249,12 +301,33 @@ function groupByRun(rows: CandidateRow[]): Map<string, SceneGroup> {
   return groups;
 }
 
-function deltasForScene(deltas: CandidateRow[], sceneIndex: number): Record<string, unknown>[] {
-  return deltas
-    .filter((d) => Number(d.payload.sceneIndex) === sceneIndex)
+/**
+ * One scene's projected stateDeltas — the SHARED packStateDeltaEntry
+ * shape (the capture path writes the identical entry, modulo the
+ * document-only `candidateId`), narrowed to this scene index.
+ *
+ * `field` (packDeltaField) rides ALONGSIDE `stateModelId`, never instead
+ * of it: `stateModelId` stays the pack provenance (which lifecycle
+ * declaration produced the claim), `field` is the belief plane's key.
+ * Both are additive on a FLEXIBLE column (0106) — existing rows without
+ * `field` stay valid and simply keep being invisible to the promoter.
+ *
+ * Exported pure for the round-trip unit test (projected shape → the
+ * belief fold's collectSceneDeltas).
+ */
+export function projectSceneDeltas(p: {
+  deltas: CandidateRow[];
+  sceneIndex: number;
+  packId: string;
+  models: PackStateModelIndex | undefined;
+}): Record<string, unknown>[] {
+  return p.deltas
+    .filter((d) => Number(d.payload.sceneIndex) === p.sceneIndex)
     .map((d) =>
       packStateDeltaEntry({
+        packId: p.packId,
         stateModelId: d.payload.stateModelId,
+        models: p.models,
         subject: d.payload.subject,
         from: d.payload.from,
         to: d.payload.to,

--- a/src/episodes/pack-scene-projection.ts
+++ b/src/episodes/pack-scene-projection.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { RecordId, type Surreal } from 'surrealdb';
 import { runTransaction } from '../db/surreal.service';
 import { scopeForUser } from '../auth/scope-tags';
+import { packStateFieldName, stateModelFieldLocal } from '../ai/domain-packs/manifest';
 
 /**
  * Pack scene projections — the SHARED write shape (migration 0110,
@@ -19,8 +20,10 @@ import { scopeForUser } from '../auth/scope-tags';
  * Both MUST write the same row: same table, same id mold, same
  * scope/PII/userId stamping (the 0055 per-user fence, the 0093 scope tag,
  * the 0117 userIds membership fold), the same `pack:<packId>+<fp>`
- * segmenterVersion id-space, and the same slice-swap semantics. That is
- * what lives here — one shape, two origins, no drift.
+ * segmenterVersion id-space, the same `stateDeltas` entry shape —
+ * including the pack-namespaced belief `field` the promotion pass keys on
+ * (packDeltaField) — and the same slice-swap semantics. That is what
+ * lives here — one shape, two origins, no drift.
  *
  * Pure module by design (engine-gates S5.2): no env reads, no Nest
  * injection. The flag fence stays with each producer.
@@ -137,9 +140,58 @@ export function buildPackSceneRow(p: PackSceneRowInput): Record<string, unknown>
   };
 }
 
+/**
+ * One pack's declared `stateModels` keyed by id — the field-mapping input
+ * both origins resolve from their own copy of the manifest's memoryModel
+ * (the document path through MemoryModelReaderService at commit time, the
+ * capture path through the binding it already derives the turn against).
+ */
+export type PackStateModelIndex = ReadonlyMap<string, { id: string; field?: string | undefined }>;
+
+/** Pure: index a memoryModel's declared stateModels by id. */
+export function packStateModelIndex(
+  models: readonly { id: string; field?: string | undefined }[] | undefined,
+): PackStateModelIndex {
+  return new Map((models ?? []).map((m) => [m.id, m]));
+}
+
+/**
+ * Pure: the belief-plane attribute name one pack stateModel projects onto.
+ *
+ * `<packId>__<declared field ?? stateModelId>` (packStateFieldName). This
+ * is the ONE mapping the belief layer needs: `collectSceneDeltas` keys
+ * beliefs by (userId, subject, field) and DROPS any delta without a
+ * `field`, so before this the pack-projected deltas — which carried only a
+ * `stateModelId` — were a write with no reader.
+ *
+ * It lives HERE, with the shared row shape, so BOTH origins emit the same
+ * delta: a belief must not depend on whether the domain arrived as a
+ * document or as a conversation turn.
+ *
+ * `models` is the submitting pack's declared stateModels keyed by id (its
+ * manifest memoryModel, resolved per run). A missing pack or an unknown
+ * stateModelId degrades to the id itself: the submit-time declaration
+ * fence already rejected undeclared ids, and a manifest that changed
+ * underneath a staged candidate must still project SOMETHING stable
+ * rather than silently losing the delta again.
+ */
+export function packDeltaField(
+  packId: string,
+  stateModelId: string,
+  models?: PackStateModelIndex,
+): string {
+  const declared = models?.get(stateModelId);
+  const local = declared ? stateModelFieldLocal(declared) : stateModelId;
+  return packStateFieldName(packId, local);
+}
+
 /** One entry of the scene row's `stateDeltas` array (0106 FLEXIBLE). */
 export interface PackStateDeltaInput {
+  /** The projecting pack — `field` is namespaced under it. */
+  packId: string;
   stateModelId: unknown;
+  /** The pack's declared stateModels; absent ⇒ the id is the local name. */
+  models?: PackStateModelIndex | undefined;
   subject: unknown;
   from?: unknown;
   to: unknown;
@@ -148,9 +200,17 @@ export interface PackStateDeltaInput {
   candidateId?: string | undefined;
 }
 
+/**
+ * `field` (packDeltaField) rides ALONGSIDE `stateModelId`, never instead
+ * of it: `stateModelId` stays the pack provenance (which lifecycle
+ * declaration produced the claim), `field` is the belief plane's key.
+ * Both are additive on a FLEXIBLE column (0106) — existing rows without
+ * `field` stay valid and simply keep being invisible to the promoter.
+ */
 export function packStateDeltaEntry(p: PackStateDeltaInput): Record<string, unknown> {
   return {
     stateModelId: p.stateModelId,
+    field: packDeltaField(p.packId, String(p.stateModelId ?? ''), p.models),
     subject: p.subject,
     from: p.from,
     to: p.to,

--- a/src/ingest/mention-projection.service.ts
+++ b/src/ingest/mention-projection.service.ts
@@ -10,6 +10,7 @@ import {
   packSceneProjectionName,
   packSceneVersion,
   packStateDeltaEntry,
+  packStateModelIndex,
   swapPackSceneSlice,
 } from '../episodes/pack-scene-projection';
 import { packMemoryProjectionsEnabled } from '../common/pack-projection-flags';
@@ -43,8 +44,12 @@ export interface TurnProjectionOutcome {
  * SHAPE. Rows are the SHARED buildPackSceneRow shape, in the SHARED
  * `pack:<packId>+<fp>` world, registered in the SAME projection ledger
  * (`scenes:<packId>`) — one shape, two origins (pack-scene-projection.ts).
- * Shadow, exactly like the document origin: nothing on the serving path
- * reads memory_episode.
+ * That includes the stateDeltas: a derived delta carries the same
+ * pack-namespaced `field` (`<packId>__<stateModel.field ?? id>`) the
+ * document origin stamps, so under SCENES_PACK_DELTA_PROMOTION a
+ * conversation turn reaches the belief plane on exactly the same terms as
+ * a document. Shadow, exactly like the document origin: nothing on the
+ * serving path reads memory_episode.
  *
  * COST. Per turn, with the flag on, a tenant WITHOUT packs declaring a
  * memoryModel pays one cached reader call (LRU + 30s TTL) and returns.
@@ -179,12 +184,21 @@ export class MentionProjectionService {
 
     const sceneRows: Record<string, unknown>[] = [];
     const memberRows: Record<string, unknown>[] = [];
+    // The stateModelId -> belief-field mapping input, straight off the
+    // binding this turn was derived against — the capture path's copy of
+    // what the document path resolves through MemoryModelReaderService.
+    // Both origins therefore stamp the same pack-namespaced `field`, so a
+    // belief never depends on whether its domain arrived as a document or
+    // as a conversation turn.
+    const models = packStateModelIndex(binding.memoryModel.stateModels);
     let stateDeltas = 0;
     for (const scene of p.scenes) {
       const idTail = packSceneIdTail(episodeId, version, scene.schemaId);
       const deltas = scene.stateDeltas.map((d) =>
         packStateDeltaEntry({
+          packId: binding.packId,
           stateModelId: d.stateModelId,
+          models,
           subject: d.subject,
           from: d.from,
           to: d.to,

--- a/test/capture-pack-projection.unit-spec.ts
+++ b/test/capture-pack-projection.unit-spec.ts
@@ -22,6 +22,8 @@ import {
   packSceneScopeStamp,
   packSceneVersion,
   packStateDeltaEntry,
+  packDeltaField,
+  packStateModelIndex,
 } from '../src/episodes/pack-scene-projection';
 import { sceneScopeStamp } from '../src/documents/scene-candidate-writer.service';
 import { derivePackScenes } from '../src/ingest/pack-scene-derivation';
@@ -139,13 +141,59 @@ describe('pack scene projection — one shape, two origins', () => {
       buildPackSceneRow({ ...common, idTail: 'x', confidence: Number.NaN, origin: {} }).confidence,
     ).toBe(0.7);
     expect(
-      packStateDeltaEntry({ stateModelId: 'm', subject: 's', to: 'x', confidence: -2 }),
-    ).toEqual({ stateModelId: 'm', subject: 's', from: undefined, to: 'x', confidence: 0 });
+      packStateDeltaEntry({
+        packId: PACK_ID,
+        stateModelId: 'm',
+        subject: 's',
+        to: 'x',
+        confidence: -2,
+      }),
+    ).toEqual({
+      stateModelId: 'm',
+      field: `${PACK_ID}__m`,
+      subject: 's',
+      from: undefined,
+      to: 'x',
+      confidence: 0,
+    });
     // candidateId is document-origin only — never invented for a turn.
     expect(
       'candidateId' in
-        packStateDeltaEntry({ stateModelId: 'm', subject: 's', to: 'x', confidence: 1 }),
+        packStateDeltaEntry({
+          packId: PACK_ID,
+          stateModelId: 'm',
+          subject: 's',
+          to: 'x',
+          confidence: 1,
+        }),
     ).toBe(false);
+  });
+
+  it('stamps the SAME pack-namespaced belief field on both origins', () => {
+    // The `field` the promotion pass keys on is derived in the shared
+    // module, so an origin cannot drift: declared `field` wins, the
+    // stateModel id is the default, and the packId always namespaces.
+    const entry = (stateModelId: string, models?: Parameters<typeof packDeltaField>[2]) =>
+      packStateDeltaEntry({
+        packId: PACK_ID,
+        stateModelId,
+        models,
+        subject: 's',
+        to: 'x',
+        confidence: 1,
+      }).field;
+    expect(entry('listing_lifecycle', packStateModelIndex(MODEL.stateModels))).toBe(
+      `${PACK_ID}__listing_lifecycle`,
+    );
+    expect(
+      entry(
+        'listing_lifecycle',
+        packStateModelIndex([{ id: 'listing_lifecycle', field: 'listing_status' }]),
+      ),
+    ).toBe(`${PACK_ID}__listing_status`);
+    // Unresolvable declarations degrade to the id — never to no field.
+    expect(entry('listing_lifecycle')).toBe(`${PACK_ID}__listing_lifecycle`);
+    expect(packDeltaField(PACK_ID, 'listing_lifecycle')).toBe(entry('listing_lifecycle'));
   });
 
   it('derives a deterministic id per (owner, version, discriminator)', () => {
@@ -414,6 +462,9 @@ describe('MentionProjectionService', () => {
     expect(row.stateDeltas).toEqual([
       {
         stateModelId: 'listing_lifecycle',
+        // The belief key, resolved from the binding's own memoryModel —
+        // the same entry the document origin projects.
+        field: `${PACK_ID}__listing_lifecycle`,
         subject: '12 Elm St',
         from: undefined,
         to: 'under_offer',

--- a/test/pack-delta-promotion.unit-spec.ts
+++ b/test/pack-delta-promotion.unit-spec.ts
@@ -1,0 +1,411 @@
+/**
+ * Pack-projected state deltas → belief promotion
+ * (SCENES_PACK_DELTA_PROMOTION, default off).
+ *
+ * Covers the two independent reasons the pack projections were a write
+ * with no reader, and the fences that must hold now that they are read:
+ *  - the stateModelId → field mapping (packDeltaField), including the
+ *    pack-namespacing rule and a stateModel that DECLARES its own field;
+ *  - the promoter admission matrix (flag off ⇒ the selection query and
+ *    its binds are byte-identical to the pre-flag pass; on ⇒ the pack
+ *    worlds are admitted without an enrichmentVersion);
+ *  - the per-user scope fence over pack scenes (#387 fail-closed);
+ *  - the projected delta shape round-tripping into the fold;
+ *  - the pack provenance stamp (promoterVersionFor) on the belief row.
+ */
+import type { ConfigService } from '@nestjs/config';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { SceneVersionService } from '../src/admin/scene-version';
+import {
+  BELIEF_PROMOTER_VERSION,
+  BeliefPromotionService,
+  buildPromotableScenesQuery,
+  foldBeliefGroups,
+  isPackSceneWorld,
+  promoterVersionFor,
+  sceneSingleUser,
+  type PromotableSceneHead,
+} from '../src/admin/belief-promotion.service';
+import {
+  packDeltaField,
+  packSceneVersion,
+  projectSceneDeltas,
+  sceneScopeStamp,
+} from '../src/documents/scene-candidate-writer.service';
+import type { CandidateRow } from '../src/documents/candidate-store.service';
+import {
+  stateModelFieldLocal,
+  validateMemoryModel,
+  type DomainPackManifest,
+} from '../src/ai/domain-packs';
+import { scenePackDeltaPromotionEnabled } from '../src/common/scene-flags';
+
+const PACK = 'realty_proj';
+const OTHER_PACK = 'insurance_proj';
+
+/** The manifest stateModels map the projector consumes. */
+const models = (entries: Array<{ id: string; field?: string }>) =>
+  new Map(entries.map((m) => [m.id, m]));
+
+describe('packDeltaField (stateModelId → belief field)', () => {
+  it('defaults to the stateModel id, pack-namespaced', () => {
+    expect(packDeltaField(PACK, 'deal', models([{ id: 'deal' }]))).toBe('realty_proj__deal');
+  });
+
+  it('honours an explicitly declared stateModel field', () => {
+    expect(
+      packDeltaField(
+        PACK,
+        'deal_lifecycle',
+        models([{ id: 'deal_lifecycle', field: 'deal_stage' }]),
+      ),
+    ).toBe('realty_proj__deal_stage');
+  });
+
+  it('treats a blank declared field as absent (falls back to the id)', () => {
+    expect(packDeltaField(PACK, 'deal', models([{ id: 'deal', field: '   ' }]))).toBe(
+      'realty_proj__deal',
+    );
+  });
+
+  it.each([
+    ['no manifest resolved (fail-open)', undefined],
+    ['stateModelId absent from the manifest', models([{ id: 'other' }])],
+  ])('degrades to the id for %s', (_name, m) => {
+    expect(packDeltaField(PACK, 'deal', m)).toBe('realty_proj__deal');
+  });
+
+  it('keeps two packs whose stateModels resolve to the SAME local field distinct', () => {
+    const a = packDeltaField(PACK, 'lifecycle', models([{ id: 'lifecycle', field: 'status' }]));
+    const b = packDeltaField(
+      OTHER_PACK,
+      'lifecycle',
+      models([{ id: 'lifecycle', field: 'status' }]),
+    );
+    expect(a).toBe('realty_proj__status');
+    expect(b).toBe('insurance_proj__status');
+    // The whole point of the rule: no silent merge into one belief group.
+    expect(a).not.toBe(b);
+  });
+
+  it('stateModelFieldLocal defaults to the id and never invents a namespace', () => {
+    expect(stateModelFieldLocal({ id: 'listing_lifecycle' })).toBe('listing_lifecycle');
+    expect(stateModelFieldLocal({ id: 'listing_lifecycle', field: 'listing_status' })).toBe(
+      'listing_status',
+    );
+  });
+});
+
+describe('manifest validation of the optional stateModel field', () => {
+  // Deliberately untyped shapes: the point is what a THIRD-PARTY manifest
+  // may carry, which is exactly what the validator exists to reject.
+  const pack = (field: unknown): DomainPackManifest =>
+    ({
+      id: 'p1',
+      version: '1.0.0',
+      description: 'x',
+      predicates: [],
+      memoryModel: {
+        stateModels: [
+          {
+            id: 'deal',
+            subjectType: 'deal',
+            states: ['open', 'closed'],
+            ...(field === undefined ? {} : { field }),
+          },
+        ],
+      },
+    }) as unknown as DomainPackManifest;
+
+  it('accepts a manifest that omits field (every shipped pack)', () => {
+    const p = pack(undefined);
+    expect(() => validateMemoryModel(p, p.memoryModel)).not.toThrow();
+  });
+
+  it('accepts a declared snake_case field', () => {
+    const p = pack('deal_stage');
+    expect(() => validateMemoryModel(p, p.memoryModel)).not.toThrow();
+  });
+
+  it.each([
+    ['a namespace separator', 'deal__stage'],
+    ['upper case', 'DealStage'],
+    ['a non-string', 42],
+  ])('rejects %s', (_name, bad) => {
+    const p = pack(bad);
+    expect(() => validateMemoryModel(p, p.memoryModel)).toThrow(/stateModel "deal" field/);
+  });
+});
+
+describe('buildPromotableScenesQuery (admission matrix)', () => {
+  // The pre-flag query, verbatim. Pinning the STRING is the point: the
+  // default-off promise is "byte-identical", not "equivalent".
+  const HISTORICAL = `SELECT id, userId, userIds, conversationIds, occurredTo, stateDeltas,
+                enrichedMemoryValue.explicitness AS explicitness
+           FROM memory_episode
+          WHERE segmenterVersion = $v AND enrichmentVersion IS NOT NONE`;
+
+  it('flag off ⇒ the historical SQL and binds, byte for byte', () => {
+    expect(
+      buildPromotableScenesQuery({ version: 'scene-segmenter-v1', packDeltas: false }),
+    ).toEqual({ sql: HISTORICAL, params: { v: 'scene-segmenter-v1' } });
+  });
+
+  it('flag off + conversation scope ⇒ the historical conversation clause', () => {
+    const q = buildPromotableScenesQuery({
+      version: 'scene-segmenter-v1',
+      conversationId: 'conv:a',
+      packDeltas: false,
+    });
+    expect(q.sql).toBe(`${HISTORICAL} AND conversationIds CONTAINS $conv`);
+    expect(q.params).toEqual({ v: 'scene-segmenter-v1', conv: 'conv:a' });
+  });
+
+  it('flag off ⇒ no pack leg, no pack bind, no segmenterVersion projection', () => {
+    const q = buildPromotableScenesQuery({ version: 'scene-segmenter-v1', packDeltas: false });
+    expect(q.sql).not.toContain('pack');
+    expect(q.sql).not.toContain('segmenterVersion,');
+    expect(q.params).not.toHaveProperty('packPrefix');
+  });
+
+  it('flag on ⇒ pack worlds admitted WITHOUT an enrichmentVersion, world projected', () => {
+    const q = buildPromotableScenesQuery({ version: 'scene-segmenter-v1', packDeltas: true });
+    // The composer leg is untouched — pack admission is purely additive.
+    expect(q.sql).toContain('segmenterVersion = $v AND enrichmentVersion IS NOT NONE');
+    expect(q.sql).toContain('string::starts_with(segmenterVersion, $packPrefix)');
+    expect(q.sql).toContain('array::len(stateDeltas) > 0');
+    // The world rides back so the belief can carry the pack provenance.
+    expect(q.sql).toContain('stateDeltas, segmenterVersion,');
+    expect(q.params).toEqual({ v: 'scene-segmenter-v1', packPrefix: 'pack:' });
+  });
+
+  it('flag on + conversation scope keeps the conversation clause outside the OR', () => {
+    const q = buildPromotableScenesQuery({
+      version: 'scene-segmenter-v1',
+      conversationId: 'conv:a',
+      packDeltas: true,
+    });
+    expect(q.sql.trimEnd().endsWith('AND conversationIds CONTAINS $conv')).toBe(true);
+  });
+
+  it('the pack world prefix matches what the projector stamps', () => {
+    expect(isPackSceneWorld(packSceneVersion(PACK, '1.0.0'))).toBe(true);
+    expect(isPackSceneWorld('scene-segmenter-v1+abcdef12')).toBe(false);
+  });
+});
+
+describe('SCENES_PACK_DELTA_PROMOTION resolver + service seam', () => {
+  const saved = process.env.SCENES_PACK_DELTA_PROMOTION;
+  const savedPromotion = process.env.SCENES_BELIEF_PROMOTION;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.SCENES_PACK_DELTA_PROMOTION;
+    else process.env.SCENES_PACK_DELTA_PROMOTION = saved;
+    if (savedPromotion === undefined) delete process.env.SCENES_BELIEF_PROMOTION;
+    else process.env.SCENES_BELIEF_PROMOTION = savedPromotion;
+  });
+
+  it('defaults off', () => {
+    delete process.env.SCENES_PACK_DELTA_PROMOTION;
+    expect(scenePackDeltaPromotionEnabled()).toBe(false);
+    process.env.SCENES_PACK_DELTA_PROMOTION = '1';
+    expect(scenePackDeltaPromotionEnabled()).toBe(true);
+  });
+
+  /** A promotion service whose db records every query and returns nothing. */
+  function makeService(): { svc: BeliefPromotionService; sql: string[] } {
+    const sql: string[] = [];
+    const db = {
+      query: (q: string) => {
+        sql.push(q);
+        return Promise.resolve([[]]);
+      },
+    };
+    const surreal = {
+      withCompany: <T>(_c: string, fn: (d: typeof db) => Promise<T>) => fn(db),
+    } as unknown as SurrealService;
+    const versions = {
+      resolve: () => ({ version: 'scene-segmenter-v1' }),
+    } as unknown as SceneVersionService;
+    const config = { get: (_k: string, def?: string) => def } as unknown as ConfigService;
+    return { svc: new BeliefPromotionService(surreal, config, versions), sql };
+  }
+
+  it('flag off ⇒ the pass issues exactly the historical selection', async () => {
+    process.env.SCENES_BELIEF_PROMOTION = '1';
+    delete process.env.SCENES_PACK_DELTA_PROMOTION;
+    const { svc, sql } = makeService();
+    await svc.run('co_test');
+    expect(sql).toHaveLength(1);
+    expect(sql[0]).toBe(
+      buildPromotableScenesQuery({ version: 'scene-segmenter-v1', packDeltas: false }).sql,
+    );
+  });
+
+  it('flag on ⇒ the pass issues the widened selection', async () => {
+    process.env.SCENES_BELIEF_PROMOTION = '1';
+    process.env.SCENES_PACK_DELTA_PROMOTION = '1';
+    const { svc, sql } = makeService();
+    await svc.run('co_test');
+    expect(sql[0]).toBe(
+      buildPromotableScenesQuery({ version: 'scene-segmenter-v1', packDeltas: true }).sql,
+    );
+  });
+});
+
+describe('promoterVersionFor (pack provenance without a new column)', () => {
+  const RUN = `${BELIEF_PROMOTER_VERSION}|scene-segmenter-v1`;
+  const packWorld = packSceneVersion(PACK, '1.0.0');
+
+  it.each([
+    ['no worlds (flag off — the column is not selected)', [] as string[]],
+    ['a composer world', ['scene-segmenter-v1']],
+    ['a MIXED set (belongs to neither plane alone)', ['scene-segmenter-v1', packWorld]],
+  ])('keeps the run stamp for %s', (_name, worlds) => {
+    expect(promoterVersionFor({ worlds }, RUN)).toBe(RUN);
+  });
+
+  it('stamps the pack world when the belief came wholly out of one pack', () => {
+    expect(promoterVersionFor({ worlds: [packWorld] }, RUN)).toBe(
+      `${BELIEF_PROMOTER_VERSION}|${packWorld}`,
+    );
+  });
+});
+
+describe('projected delta shape round-trips into the fold', () => {
+  const deltaRow = (over: Partial<CandidateRow['payload']> = {}): CandidateRow => ({
+    id: 'candidate:d1',
+    runId: 'run1',
+    chunkSeq: 0,
+    kind: 'state_delta',
+    confidence: 0.8,
+    status: 'pending',
+    payload: {
+      sceneIndex: 0,
+      stateModelId: 'deal',
+      subject: 'the Elm St purchase',
+      from: 'open',
+      to: 'under_offer',
+      ...over,
+    },
+  });
+
+  const projected = projectSceneDeltas({
+    deltas: [deltaRow()],
+    sceneIndex: 0,
+    packId: PACK,
+    models: models([{ id: 'deal' }]),
+  });
+
+  it('writes BOTH stateModelId (pack provenance) and field (belief key)', () => {
+    expect(projected).toEqual([
+      {
+        stateModelId: 'deal',
+        field: 'realty_proj__deal',
+        subject: 'the Elm St purchase',
+        from: 'open',
+        to: 'under_offer',
+        confidence: 0.8,
+        candidateId: 'candidate:d1',
+      },
+    ]);
+  });
+
+  it('only projects the deltas of the requested scene index', () => {
+    expect(
+      projectSceneDeltas({
+        deltas: [deltaRow({ sceneIndex: 1 })],
+        sceneIndex: 0,
+        packId: PACK,
+        models: models([{ id: 'deal' }]),
+      }),
+    ).toEqual([]);
+  });
+
+  const packScene = (over: Partial<PromotableSceneHead> = {}): PromotableSceneHead => ({
+    id: 'memory_episode:pack1',
+    ...sceneScopeStamp({ userId: 'u_pack' }),
+    conversationIds: [],
+    occurredTo: '2026-09-01T11:00:00.000Z',
+    segmenterVersion: packSceneVersion(PACK, '1.0.0'),
+    stateDeltas: projected,
+    ...over,
+  });
+
+  it('folds the projected shape into one belief carrying the pack field + world', () => {
+    const { folded, conflicts } = foldBeliefGroups([{ userId: 'u_pack', scene: packScene() }]);
+    expect(conflicts).toEqual([]);
+    expect(folded).toHaveLength(1);
+    expect(folded[0]).toMatchObject({
+      userId: 'u_pack',
+      subject: 'the Elm St purchase',
+      field: 'realty_proj__deal',
+      value: 'under_offer',
+      priorValue: 'open',
+      worlds: [packSceneVersion(PACK, '1.0.0')],
+    });
+    // No conversation backs a document scene — the distinct-CONVERSATION
+    // floor therefore excludes pack beliefs whenever it is non-zero.
+    expect(folded[0]!.conversationIds).toEqual([]);
+  });
+
+  it('a pre-mapping delta (stateModelId only, no field) is still dropped', () => {
+    const legacy = projected.map(({ field: _drop, ...rest }) => rest);
+    const { folded } = foldBeliefGroups([
+      { userId: 'u_pack', scene: packScene({ stateDeltas: legacy }) },
+    ]);
+    expect(folded).toEqual([]);
+  });
+});
+
+describe('per-user scope fence over pack-projected scenes (#387)', () => {
+  const world = packSceneVersion(PACK, '1.0.0');
+  const scene = (over: Partial<PromotableSceneHead>): PromotableSceneHead => ({
+    id: 'memory_episode:pack1',
+    conversationIds: [],
+    occurredTo: '2026-09-01T11:00:00.000Z',
+    segmenterVersion: world,
+    stateDeltas: [{ field: 'realty_proj__deal', subject: 's', from: 'open', to: 'under_offer' }],
+    ...over,
+  });
+
+  it('a user-scoped document projects scenes that admit exactly that user', () => {
+    expect(sceneSingleUser(scene(sceneScopeStamp({ userId: 'u_a' })))).toBe('u_a');
+  });
+
+  it('a TENANT-GLOBAL document projects scenes that promote for NO ONE', () => {
+    // sceneScopeStamp of a doc without a user = { scope: [] } — no
+    // userIds, so the fail-closed fence refuses it.
+    expect(sceneSingleUser(scene(sceneScopeStamp({})))).toBeNull();
+  });
+
+  it.each([
+    ['a mixed member set', { userId: 'u_a', userIds: ['u_a', 'u_b'] }],
+    ['a userId disagreeing with the member set', { userId: 'u_b', userIds: ['u_a'] }],
+    ['legacy rows without userIds', { userId: 'u_a' }],
+  ])('never promotes a pack scene with %s', (_name, over) => {
+    expect(sceneSingleUser(scene(over))).toBeNull();
+  });
+
+  it("a pack scene of user A can never land in user B's beliefs", () => {
+    const { folded } = foldBeliefGroups([
+      {
+        userId: 'u_a',
+        scene: scene({ id: 'memory_episode:a', ...sceneScopeStamp({ userId: 'u_a' }) }),
+      },
+      {
+        userId: 'u_b',
+        scene: scene({
+          id: 'memory_episode:b',
+          ...sceneScopeStamp({ userId: 'u_b' }),
+          stateDeltas: [{ field: 'realty_proj__deal', subject: 's', from: 'open', to: 'closed' }],
+        }),
+      },
+    ]);
+    // Same (subject, field), two users ⇒ two beliefs, never one merged
+    // group and never a conflict between strangers.
+    expect(folded.map((f) => [f.userId, f.value])).toEqual([
+      ['u_a', 'under_offer'],
+      ['u_b', 'closed'],
+    ]);
+  });
+});

--- a/test/pack-memory-projections.e2e-spec.ts
+++ b/test/pack-memory-projections.e2e-spec.ts
@@ -11,10 +11,18 @@
  * view, the CAPTURE-path (mention) origin writing into the same pack
  * world with an L0 membership edge, and the version purge through the
  * existing admin scenes verb.
+ *
+ * Plus the FULL LOOP (SCENES_PACK_DELTA_PROMOTION): document → scenes →
+ * pack-namespaced state deltas → semantic_belief. Before it, prod ran
+ * PACK_MEMORY_PROJECTIONS_ENABLED=1 writing deltas nothing could ever
+ * read — the deltas carried no `field` and the promoter's version fence
+ * excluded the `pack:` worlds. No paid calls: the extractor is stubbed
+ * and belief statements stay on the deterministic template.
  */
 import { AppFixture, createApp } from './app-fixture';
 import { SurrealService } from '../src/db/surreal.service';
 import { packSceneVersion } from '../src/documents/scene-candidate-writer.service';
+import { BELIEF_PROMOTER_VERSION } from '../src/admin/belief-promotion.service';
 
 describe('pack memory projections (e2e)', () => {
   let f: AppFixture;
@@ -89,7 +97,7 @@ describe('pack memory projections (e2e)', () => {
     if (f) await f.close();
   });
 
-  async function createDoc(text: string) {
+  async function createDoc(text: string, userId?: string) {
     // Empty extraction: the document exists purely as a Source for the
     // external indexer to read.
     f.extractor.setScript({ entities: [], facts: [], edges: [] });
@@ -101,6 +109,7 @@ describe('pack memory projections (e2e)', () => {
         text,
         occurredAt: '2026-09-01T10:00:00.000Z',
         contextRef: { vertical: 'proj_e2e' },
+        ...(userId !== undefined ? { userId } : {}),
       });
     expect(r.status).toBe(201);
     return r.body.documentId as string;
@@ -276,6 +285,157 @@ describe('pack memory projections (e2e)', () => {
     expect(piiScene.payload.redacted).toBeUndefined();
   });
 
+  // ORDER MATTERS: this block asserts an EXACT belief set, and BOTH pack
+  // projection origins now stamp the promotable `field` — so it runs
+  // before the capture-path test below, whose user-scoped turn scene would
+  // otherwise promote into a third belief. Keep it above that test.
+  describe('pack deltas reach belief promotion (SCENES_PACK_DELTA_PROMOTION)', () => {
+    const USER_A = 'pack_belief_u1';
+    const USER_B = 'pack_belief_u2';
+    const BELIEF_FLAGS = ['SCENES_SEGMENTATION_ENABLED', 'SCENES_BELIEF_PROMOTION'];
+    const savedFlags: Record<string, string | undefined> = {};
+
+    interface BeliefRow {
+      userId: string;
+      subject: string;
+      field: string;
+      value: string;
+      priorValue?: string;
+      statement: string;
+      statementSource: string;
+      revision: number;
+      status: string;
+      conversationIds?: string[];
+      promoterVersion?: string;
+      sourceSceneIds?: unknown[];
+    }
+
+    const beliefs = (): Promise<BeliefRow[]> =>
+      surreal().withCompany(f.companyId, async (db) => {
+        const [rows] = await db.query<[BeliefRow[]]>(
+          `SELECT * FROM semantic_belief ORDER BY userId ASC, field ASC, revision ASC`,
+        );
+        return rows ?? [];
+      });
+
+    const promote = () => f.http.post('/v1/admin/maintenance/scenes/beliefs').set(auth()).send({});
+
+    beforeAll(async () => {
+      for (const k of BELIEF_FLAGS) {
+        savedFlags[k] = process.env[k];
+        process.env[k] = '1';
+      }
+      delete process.env.SCENES_PACK_DELTA_PROMOTION;
+
+      // Two USER-SCOPED documents (0128) — each projects scenes stamped
+      // with its own user (userId + 0093 scope + 0117 userIds), which is
+      // what makes them promotable at all under the #387 fence.
+      const docA = await createDoc(`${DOC_TEXT} Belief loop, user A.`, USER_A);
+      expect((await submit(docA, submission())).status).toBe(201);
+
+      const docB = await createDoc(`${DOC_TEXT} Belief loop, user B.`, USER_B);
+      expect(
+        (
+          await submit(
+            docB,
+            submission({
+              stateDeltas: [
+                {
+                  sceneIndex: 0,
+                  stateModelId: 'deal',
+                  subject: 'the Elm St purchase',
+                  from: 'open',
+                  to: 'closed',
+                },
+              ],
+            }),
+          )
+        ).status,
+      ).toBe(201);
+    });
+
+    afterAll(() => {
+      for (const k of BELIEF_FLAGS) {
+        if (savedFlags[k] === undefined) delete process.env[k];
+        else process.env[k] = savedFlags[k];
+      }
+      delete process.env.SCENES_PACK_DELTA_PROMOTION;
+    });
+
+    it('projects the pack-namespaced field alongside the stateModelId', async () => {
+      const deltas = await surreal().withCompany(f.companyId, async (db) => {
+        const [rows] = await db.query<[Array<{ stateDeltas: Array<Record<string, unknown>> }>]>(
+          `SELECT stateDeltas FROM memory_episode
+            WHERE segmenterVersion = $v AND userId = $u`,
+          { v: packSceneVersion(PACK_ID, PACK_VERSION), u: USER_A },
+        );
+        return (rows ?? []).flatMap((r) => r.stateDeltas ?? []);
+      });
+      expect(deltas).toHaveLength(1);
+      expect(deltas[0]).toMatchObject({
+        // BOTH: stateModelId is the pack provenance, field is the key the
+        // belief fold reads (and drops the delta without).
+        stateModelId: 'deal',
+        field: `${PACK_ID}__deal`,
+        subject: 'the Elm St purchase',
+        to: 'under_offer',
+      });
+    });
+
+    it('flag off ⇒ the promotion pass never sees a pack scene (byte-identical)', async () => {
+      delete process.env.SCENES_PACK_DELTA_PROMOTION;
+      const r = await promote();
+      expect(r.status).toBe(201);
+      // No composer world exists in this tenant, so the historical
+      // selection matches nothing at all.
+      expect(r.body.scenes).toBe(0);
+      expect(r.body.beliefsCreated).toBe(0);
+      expect(await beliefs()).toEqual([]);
+    });
+
+    it('flag on ⇒ each user-scoped pack scene promotes into that user’s own belief', async () => {
+      process.env.SCENES_PACK_DELTA_PROMOTION = '1';
+      const r = await promote();
+      expect(r.status).toBe(201);
+      expect(r.body.beliefsCreated).toBe(2);
+      // The tenant-global documents projected by the earlier tests are
+      // seen and REFUSED fail-closed — a scene with no userIds belongs to
+      // no one, so it can never feed a belief.
+      expect(r.body.skippedMixedUser).toBeGreaterThanOrEqual(1);
+
+      const rows = await beliefs();
+      expect(rows.map((b) => [b.userId, b.field, b.value])).toEqual([
+        [USER_A, `${PACK_ID}__deal`, 'under_offer'],
+        [USER_B, `${PACK_ID}__deal`, 'closed'],
+      ]);
+      const a = rows[0]!;
+      expect(a.subject).toBe('the Elm St purchase');
+      expect(a.priorValue).toBe('open');
+      expect(a.revision).toBe(1);
+      expect(a.status).toBe('active');
+      // No paid call: the statement is the deterministic template.
+      expect(a.statementSource).toBe('template');
+      expect(a.statement).toBe(`the Elm St purchase — ${PACK_ID}__deal: under_offer (was: open)`);
+      // Pack provenance on the belief row itself — no new column.
+      expect(a.promoterVersion).toBe(
+        `${BELIEF_PROMOTER_VERSION}|${packSceneVersion(PACK_ID, PACK_VERSION)}`,
+      );
+      expect(a.sourceSceneIds).toHaveLength(1);
+      // Document scenes carry no conversation — the distinct-conversation
+      // floor would exclude them, which is why it stays at 0 here.
+      expect(a.conversationIds).toEqual([]);
+    });
+
+    it('is replay-idempotent (a second pass corroborates, never duplicates)', async () => {
+      process.env.SCENES_PACK_DELTA_PROMOTION = '1';
+      const r = await promote();
+      expect(r.status).toBe(201);
+      expect(r.body.beliefsCreated).toBe(0);
+      expect(r.body.beliefsRevised).toBe(0);
+      expect(await beliefs()).toHaveLength(2);
+    });
+  });
+
   it('projects a CAPTURE-path turn into the same pack world, bound to its L0 episode', async () => {
     const version = packSceneVersion(PACK_ID, PACK_VERSION);
     // The subject of a derived state delta = the turn's first extracted
@@ -329,9 +489,12 @@ describe('pack memory projections (e2e)', () => {
     expect(source.docId).toBeUndefined();
     // Only 'under offer' is named in the turn, so the delta carries a
     // destination and no origin state (an absent `from` is not stored).
+    // `field` is the SHARED belief key — a capture-origin delta is the
+    // same entry the document origin writes, minus the candidateId.
     expect(scene.stateDeltas).toEqual([
       {
         stateModelId: 'deal',
+        field: `${PACK_ID}__deal`,
         subject: '12 Elm St',
         to: 'under_offer',
         confidence: 0.5,


### PR DESCRIPTION
## The bug

`PACK_MEMORY_PROJECTIONS_ENABLED=1` is **on in prod**
(`.github/workflows/deploy-brain.yml:242`). The document path writes
pack-projected scenes with state deltas — and nothing could ever read
them, for two independent reasons:

1. **Shape.** The projector wrote deltas as
   `{stateModelId, subject, from, to, confidence, candidateId}`, while the
   only consumer — belief promotion's `collectSceneDeltas` — keys on
   `(userId, subject, field)` and **drops any delta without a `field`**.
2. **Version fence.** The promoter selected scenes whose
   `segmenterVersion` equals the composer's effective version; pack scenes
   are stamped `pack:<packId>+<fp>`, so they were filtered out before the
   shape even mattered.

A third fence surfaced while building: the promoter also required
`enrichmentVersion IS NOT NONE`, which a pack scene never carries — its
deltas come from the pack indexer's reading, not from the LLM enricher.

## The mapping rule

A projected delta now carries **both** keys:

```
stateModelId  — the pack provenance (which lifecycle declaration made the claim)
field         — <packId>__<stateModel.field ?? stateModel.id>
```

`PackStateModel` gains an **optional** `field`. Omitted — the state of all
13 shipped manifests, so **no pack file is touched and no pack version is
bumped** (deliberate: other agents are bumping pack versions in this wave)
— it defaults to the stateModel id, so `deal` under pack `realty_proj`
becomes `realty_proj__deal`.

The name is **pack-namespaced** for the same reason predicates and MCP
tools are `<packId>__<name>`: two packs whose lifecycles resolve to the
same local attribute (`status`, `stage`) must stay in **separate** belief
groups. Merging them would let one domain's latest-value-wins fold
overwrite the other's state. The rule is: **keep them distinct, never
merge** — documented on `packStateFieldName` and pinned by unit test.

The projector resolves declarations through `MemoryModelReaderService`
(LRU+TTL cached, fail-open — an unresolvable pack degrades to the
stateModelId, so a manifest hiccup never loses the delta again).

## Admission — `SCENES_PACK_DELTA_PROMOTION` (default off)

The promoter's selection now goes through `buildPromotableScenesQuery`:

- **flag off** — the SQL string *and* the bind map are byte-identical to
  the pre-flag pass. Pinned by a unit test that asserts the literal string,
  because "off is byte-identical" is the whole contract of a shadow-substrate
  flag; a second test drives the service and asserts the query it issues.
- **flag on** — a second `OR` leg admits `pack:` worlds with a non-empty
  `stateDeltas` array and **without** the enrichment stamp, and the SELECT
  gains `segmenterVersion` so each contribution knows its world.

Both legs are plain reads — the 3.2.4 secondary-index planner trap applies
to `DELETE`/`UPDATE ... WHERE`, not to `SELECT`. **No migration.**

## Fences proved

| Fence | How it holds | Where it's tested |
|---|---|---|
| **Per-user scope** (0055 / 0093 / 0117) | A projected scene inherits the document's 0128 stamp (`userId` + scope tag + `userIds`), so `sceneSingleUser` admits it for exactly one user. A **tenant-global** document's scenes carry no `userIds` → skipped fail-closed, promoted for no one. | unit (`sceneScopeStamp` → `sceneSingleUser` matrix, cross-user fold) + e2e (two user-scoped docs → two beliefs under their own `userId`; `skippedMixedUser ≥ 1` for the tenant-global docs) |
| **Cross-pack collision** | Pack-namespaced field — two packs never share a `(userId, subject, field)` group. | unit |
| **Pack provenance** | A belief folded wholly out of ONE pack world is stamped `promoterVersion = belief-promotion-v1\|pack:<packId>+<fp>` (`promoterVersionFor`) — an **existing 0120 column**, no new column, no migration. Composer or mixed-world beliefs keep the run stamp verbatim. | unit + e2e |

## The loop, end to end

`test/pack-memory-projections.e2e-spec.ts` now runs the whole chain on
real SurrealDB 3.2.4: user-scoped document → external indexer stages
scenes + state deltas → commit projects them → `POST
/v1/admin/maintenance/scenes/beliefs` → `semantic_belief`. It asserts the
projected delta carries both keys, that the flag-off pass sees zero pack
scenes, that the flag-on pass creates one belief per user with the
pack-derived field and the right scope, and that a replay corroborates
rather than duplicating. Model calls are stubbed; statements stay on the
deterministic template — **no paid calls**.

## Notes

- Scene selection + world stamping split into `belief-scene-selection.ts`
  (the `belief-field-fold.ts` god-file precedent) and re-exported, so the
  historical import surface is unchanged.
- `SCENES_BELIEF_MIN_SCENES` is a distinct-**conversation** floor and
  document scenes carry no conversation, so any non-zero floor excludes
  pack-projected beliefs by construction. Documented on the flag, in the
  catalog, and in `docs/operations.md` rather than silently changed.
- Pack edits kept to zero; only `manifest.ts` (+ its validator) gained the
  optional property, per the concurrent-wave coordination note.

## Gates

`pnpm typecheck` ✅ · `pnpm test:unit` ✅ 365 suites / 4156 tests ·
`pnpm lint:ci` ✅ · `pnpm format:check` ✅ ·
`pack-memory-projections` + `belief-promotion` e2e ✅ on real SurrealDB 3.2.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
