### PR TITLE
feat(scenes): prediction baseline — measured surprise instead of guessed saliency

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -781,6 +781,18 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Belief promotion field fold (#135 seam 2): deterministically fold an enricher-re-coined field name onto an existing one for the same (userId, subject) — token-set subset whose extra tokens are all generic modifiers (ownership/status/state/current/of/the); the EXISTING name wins, and more than one match folds nothing and warns loudly (skip loudly, never flip-flop). NO embeddings, NO LLM. Also absorbs orphans: after each canonical upsert, ACTIVE beliefs of the same (userId, subject) stored under a foldable VARIANT of the canonical field (earlier-batch leftovers the incoming-name fold can never retire) are stamped superseded so they stop serving stale values; the canonical belief keeps its own value, the orphan value backfills priorValue only when the canonical has none, and more than one distinct variant field skips loudly. Off = exact-string (subject, field) grouping and zero extra queries — byte-identical fold output.',
   },
   {
+    key: 'SCENES_PREDICTION_BASELINE',
+    category: 'scenes',
+    // Read at call time (scene-flags.scenePredictionBaselineEnabled) once
+    // per enrichment run — never captured in a constructor — so a flip
+    // takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Scene prediction baseline: makes scene surprise MEASURED instead of guessed. On, the enrichment pass (1) loads the scene user’s ACTIVE semantic_belief rows (0120) for the subjects the scene is about — ONE bounded SELECT per run — and stamps them onto the scene as baselineRef {beliefs, stampedAt, baselineVersion} (0106 FLEXIBLE, no migration); (2) renders that snapshot as an explicit “what the system believed BEFORE this scene” block and changes the instruction so contradiction/unexpectedDetails are reported as DEVIATION from that model rather than free-floating saliency (prompt version scene-gist-v2); (3) runs a deterministic no-model-call scorer (scene-scorer-v1) over the same baseline plus the scene’s stateDeltas and OVERRIDES contradiction / stateChange / identity in enrichedMemoryValue (scorerVersion composite scene-scorer-llm-v1+scene-scorer-v1) — a dimension it cannot measure keeps the model’s guess, since an unknown baseline is not a confident zero. Scenes failing the #387 single-user fence get no baseline — never scored against another user’s beliefs. Requires SCENES_LLM_ENRICHMENT. Off = zero extra queries, the byte-identical scene-gist-v1 prompt and enrichmentVersion composite, no baselineRef write.',
+  },
+  {
     key: 'SCENES_EVIDENCE_LINKS',
     category: 'scenes',
     // Read at call time (scene-flags.sceneEvidenceLinksEnabled) by the

--- a/src/admin/scene-enricher.service.ts
+++ b/src/admin/scene-enricher.service.ts
@@ -4,8 +4,19 @@ import type OpenAI from 'openai';
 import { SurrealService } from '../db/surreal.service';
 import { EpisodeReadStoreService, type EpisodeDb } from '../episodes/episode-read-store.service';
 import { chatCallParams, createOpenAiClient } from '../ai/openai-client';
-import { sceneLlmEnrichmentEnabled } from '../common/scene-flags';
+import { sceneLlmEnrichmentEnabled, scenePredictionBaselineEnabled } from '../common/scene-flags';
 import { type SceneTurnRow } from './scene-segmentation';
+import { sceneSingleUser } from './belief-promotion.service';
+import {
+  baselineRefPayload,
+  loadActiveBeliefBaseline,
+  renderBaselineBlock,
+  sceneBaseline,
+  scorePredictionError,
+  SCENE_PREDICTION_SCORER_VERSION,
+  type BaselineBelief,
+  type ScenePredictionError,
+} from './scene-prediction-baseline';
 import { SceneVersionService } from './scene-version';
 
 /**
@@ -41,6 +52,31 @@ import { SceneVersionService } from './scene-version';
  * a scripted stub exactly like mockSynthesizeOpenAi (test-doubles.ts), so
  * NO paid call ever happens in CI.
  *
+ * PREDICTION BASELINE (SCENES_PREDICTION_BASELINE, default off). With the
+ * flag on the pass stops GUESSING surprise. Before the call it loads the
+ * scene user's ACTIVE semantic_belief rows (ONE bounded SELECT per run,
+ * scene-prediction-baseline.ts), renders them as an explicit "what the
+ * system believed BEFORE this scene" block under the scene-gist-v2 prompt
+ * (contradiction / unexpectedDetails become observed-vs-expected), stamps
+ * the snapshot onto the scene as `baselineRef` (0106 FLEXIBLE — no
+ * migration), and then MEASURES contradiction / stateChange / identity
+ * with a deterministic no-model-call scorer over the same baseline plus
+ * the returned stateDeltas, overriding the model's numbers for exactly
+ * those dimensions (scorerVersion composite `scene-scorer-llm-v1+
+ * scene-scorer-v1` names both producers). A dimension the scorer cannot
+ * measure keeps the model's guess — an unknown baseline is NOT a
+ * confident zero. Flag off ⇒ zero extra queries, the byte-identical
+ * scene-gist-v1 prompt/composite and no baselineRef write.
+ *
+ * NOTE ON `baselineRef` SHARING: belief promotion also writes this column,
+ * but only on a REVISION and only for the scenes carrying the winning
+ * value, with a different shape ({belief, revision, value, stampedAt} — a
+ * backpointer to what was displaced). The two are self-describing (`beliefs`
+ * array + `baselineVersion` here vs a single `belief` there); a promotion
+ * revision run after enrichment replaces the expectation snapshot, and a
+ * re-enrichment restores it. Namespacing the two writers under distinct
+ * keys is the obvious follow-up and belongs in the promotion service.
+ *
  * entityMentions is parsed and validated but deliberately NOT persisted:
  * the 0106 column for entity links is entityIds — RECORD refs to
  * knowledge_entity — and resolving free-text mentions into records is a
@@ -51,19 +87,52 @@ import { SceneVersionService } from './scene-version';
 /** Stamp on enrichedMemoryValue written by this enricher (scorerVersion). */
 export const SCENE_SCORER_LLM_VERSION = 'scene-scorer-llm-v1';
 /**
- * Version of the prompt below. No longer written to the legacy-dead
+ * Version of the v1 prompt below. No longer written to the legacy-dead
  * gistPromptVersion column — it is the first component of the
  * enrichmentVersion composite (sceneEnrichmentVersion).
+ *
+ * FROZEN. A prompt version names a prompt STRING: v1 must never be edited
+ * once rows carry its stamp, or the stamp stops identifying what the
+ * model actually saw. Prompt changes ship as a NEW constant + version.
  */
 export const SCENE_GIST_PROMPT_VERSION = 'scene-gist-v1';
+/** Version of the prediction-baseline prompt (SCENES_PREDICTION_BASELINE). */
+export const SCENE_GIST_PROMPT_VERSION_V2 = 'scene-gist-v2';
+
+/**
+ * Pure: the prompt version this run uses. The baseline flag changes the
+ * SYSTEM PROMPT (deviation-from-model instead of free saliency), so it
+ * must change the prompt identity too — otherwise two different prompts
+ * would share one stamp and the idempotency skip would refuse to
+ * re-enrich after a flip.
+ */
+export function sceneGistPromptVersion(predictionBaseline: boolean): string {
+  return predictionBaseline ? SCENE_GIST_PROMPT_VERSION_V2 : SCENE_GIST_PROMPT_VERSION;
+}
+
+/**
+ * Pure: the scorer identity of the enriched vector. With the prediction
+ * baseline on, contradiction / stateChange / identity come from the
+ * deterministic scorer and the rest from the model — the composite names
+ * BOTH producers so a mixed-scorer world stays auditable (the same reason
+ * the v0 vector stamps its own scorerVersion).
+ */
+export function sceneScorerVersion(predictionBaseline: boolean): string {
+  return predictionBaseline
+    ? `${SCENE_SCORER_LLM_VERSION}+${SCENE_PREDICTION_SCORER_VERSION}`
+    : SCENE_SCORER_LLM_VERSION;
+}
 
 /**
  * Pure: the enrichment revision composite stored in `enrichmentVersion`
  * (0118) — readable, NOT hashed: cardinality is low and the model id must
- * stay recoverable. E.g. `scene-gist-v1|scene-scorer-llm-v1|gpt-4o-mini`.
+ * stay recoverable. E.g. `scene-gist-v1|scene-scorer-llm-v1|gpt-4o-mini`,
+ * or `scene-gist-v2|scene-scorer-llm-v1+scene-scorer-v1|gpt-4o-mini` with
+ * the prediction baseline on — so flipping the flag either way re-enriches
+ * naturally instead of leaving a mixed world behind one stamp.
  */
-export function sceneEnrichmentVersion(model: string): string {
-  return `${SCENE_GIST_PROMPT_VERSION}|${SCENE_SCORER_LLM_VERSION}|${model}`;
+export function sceneEnrichmentVersion(model: string, predictionBaseline = false): string {
+  return `${sceneGistPromptVersion(predictionBaseline)}|${sceneScorerVersion(predictionBaseline)}|${model}`;
 }
 
 export const SCENE_ENRICHMENT_SYSTEM = `You analyze ONE scene — a contiguous span of turns from a conversation — and produce its memory encoding. Output strictly the JSON schema:
@@ -77,6 +146,30 @@ export const SCENE_ENRICHMENT_SYSTEM = `You analyze ONE scene — a contiguous s
   - "estimatedUtility": overall likelihood this scene will be needed to answer a future question.
 - "stateDeltas": durable state transitions the scene states, each {"subject", "field", "from", "to"} — subject is who/what changed, field is the changed attribute, from/to are the values (use "" for an unknown prior value). Empty array when none.
 - "unexpectedDetails": short concrete details that are surprising or memorable but do not fit the gist. Empty array when none.
+- "entityMentions": distinct people, places and things named in the scene. Empty array when none.`;
+
+/**
+ * Prediction-baseline prompt (scene-gist-v2, SCENES_PREDICTION_BASELINE).
+ *
+ * The ONLY substantive difference from v1: the user message carries a
+ * "Current model of the world" block, and `contradiction` /
+ * `unexpectedDetails` are defined as DEVIATION FROM THAT MODEL —
+ * observed-vs-expected — instead of free-floating saliency. Held as its
+ * own frozen literal rather than assembled from v1: a prompt version must
+ * name a fixed string, and sharing fragments would let a later v2 edit
+ * silently rewrite what v1-stamped rows claim the model saw.
+ */
+export const SCENE_ENRICHMENT_SYSTEM_V2 = `You analyze ONE scene — a contiguous span of turns from a conversation — and produce its memory encoding. The user message first states the system's CURRENT MODEL OF THE WORLD (what it believed before this scene) and then the scene transcript. Your job is prediction error: report what the scene changes about that model.
+- "gist": 1-3 sentences, abstractive — what happened in this scene, who did what, with the concrete names, dates, numbers and decisions. State the content itself, never meta-language ("the user discussed" is always wrong).
+- "memoryValue": how much this scene matters for long-term memory; every dimension is a number in [0,1]:
+  - "novelty": how much genuinely new information appears;
+  - "contradiction": how far the scene DEVIATES from the stated model of the world — 0 when it confirms the model or only adds to it, high when it overturns a value the model states. Judge against the stated model, never against your own expectations; when the model states nothing, there is nothing to contradict;
+  - "stateChange": how much durable state changed (decisions made, plans fixed, purchases, moves);
+  - "identity": how identity-central the content is (job, family, health, home, long-term goals);
+  - "explicitness": how explicitly the durable content is stated rather than implied;
+  - "estimatedUtility": overall likelihood this scene will be needed to answer a future question.
+- "stateDeltas": durable state transitions the scene states, each {"subject", "field", "from", "to"} — subject is who/what changed, field is the changed attribute, from/to are the values (use "" for an unknown prior value). When the model of the world already states a value for that subject and attribute, use it as "from". Empty array when none.
+- "unexpectedDetails": concrete details the stated model of the world does NOT predict — a value that differs from what the model holds, or a state it says nothing about that the scene treats as settled. A striking detail the model already predicts is NOT unexpected. Empty array when none.
 - "entityMentions": distinct people, places and things named in the scene. Empty array when none.`;
 
 /** Per-dimension keys of the memoryValue vector (0106 order). */
@@ -176,6 +269,29 @@ export function parseSceneEnrichment(content: string): SceneEnrichment | null {
   };
 }
 
+/**
+ * Pure: MEASURED beats GUESSED. Overwrite exactly the dimensions the
+ * deterministic prediction-error scorer actually measured; every other
+ * dimension keeps the model's number.
+ *
+ * A dimension the scorer left UNDEFINED is not overwritten with 0 — an
+ * unknown baseline is not a confident "no contradiction", and silently
+ * zeroing it would be worse than the guess it replaced. The scene keeps
+ * the guess and the scorerVersion composite says both producers were in
+ * play, so a later reader can tell measured from guessed by re-running
+ * the scorer against the stamped baselineRef.
+ */
+export function mergePredictionError(
+  guessed: SceneMemoryValueLlm,
+  measured: ScenePredictionError,
+): SceneMemoryValueLlm {
+  const merged: SceneMemoryValueLlm = { ...guessed };
+  if (measured.contradiction !== undefined) merged.contradiction = clamp01(measured.contradiction);
+  if (measured.stateChange !== undefined) merged.stateChange = clamp01(measured.stateChange);
+  if (measured.identity !== undefined) merged.identity = clamp01(measured.identity);
+  return merged;
+}
+
 export interface SceneEnrichResult {
   scenes: number;
   enriched: number;
@@ -189,6 +305,15 @@ interface SceneHead {
   conversationIds: string[];
   /** Present when a previous enrichment pass stamped the row (0118). */
   enrichmentVersion?: string;
+  /** Projected ONLY under SCENES_PREDICTION_BASELINE (0055/0117 scope). */
+  userId?: unknown;
+  userIds?: unknown;
+}
+
+/** Per-scene expectation snapshot, or null when the scene has none. */
+interface ScenePrediction {
+  beliefs: BaselineBelief[];
+  selfSubjects: ReadonlySet<string>;
 }
 
 /** The one client surface the enricher uses (mock-swappable in tests). */
@@ -241,12 +366,17 @@ export class SceneEnricherService {
     }
     // Effective version + revision composite, resolved ONCE per run: the
     // scene selection follows the composer's stamps, and the composite is
-    // the idempotency key for the skip below.
+    // the idempotency key for the skip below. The prediction flag is
+    // resolved here too (the Drift-3 contract) so a mid-run flip can never
+    // mix prompt versions inside one enriched world.
     const { version } = this.versions.resolve();
-    const enrichmentVersion = sceneEnrichmentVersion(this.model);
+    const predictionOn = scenePredictionBaselineEnabled();
+    const enrichmentVersion = sceneEnrichmentVersion(this.model, predictionOn);
     await this.surreal.withCompany(companyId, async (db) => {
+      // The scope columns are projected ONLY with the baseline on — flag
+      // off keeps the SELECT byte-identical (pinned by unit test).
       const [scenes] = await db.query<[SceneHead[]]>(
-        `SELECT id, conversationIds, enrichmentVersion FROM memory_episode
+        `SELECT id, conversationIds, enrichmentVersion${predictionOn ? ', userId, userIds' : ''} FROM memory_episode
           WHERE segmenterVersion = $v` +
           (opts.conversationId !== undefined ? ` AND conversationIds CONTAINS $conv` : ''),
         {
@@ -254,21 +384,38 @@ export class SceneEnricherService {
           ...(opts.conversationId !== undefined ? { conv: opts.conversationId } : {}),
         },
       );
-      // One raw-turn read per conversation, shared across its scenes.
-      const turnCache = new Map<string, Map<string, SceneTurnRow>>();
-      for (const scene of scenes ?? []) {
-        result.scenes += 1;
-        // Idempotent skip: this scene already carries the current
-        // prompt|scorer|model revision — zero paid calls on a re-run.
+      const all = scenes ?? [];
+      result.scenes = all.length;
+      // Idempotent skip: a scene already carrying the current
+      // prompt|scorer|model revision needs no call — and, resolved BEFORE
+      // the baseline read, no belief query either.
+      const pending: SceneHead[] = [];
+      for (const scene of all) {
         if (scene.enrichmentVersion === enrichmentVersion) {
           result.skipped += 1;
           this.logger.debug(
             `scene enrichment skipped ${String(scene.id)}: already at ${enrichmentVersion}`,
           );
-          continue;
-        }
+        } else pending.push(scene);
+      }
+      // ONE bounded belief read per run, fenced to the users whose scenes
+      // pass #387. Flag off (or nothing to enrich) ⇒ zero extra queries.
+      const beliefsByUser =
+        predictionOn && pending.length > 0
+          ? await loadActiveBeliefBaseline(db, this.baselineUserIds(pending))
+          : new Map<string, BaselineBelief[]>();
+      // One raw-turn read per conversation, shared across its scenes.
+      const turnCache = new Map<string, Map<string, SceneTurnRow>>();
+      for (const scene of pending) {
         try {
-          const ok = await this.enrichScene({ db, scene, turnCache, enrichmentVersion });
+          const ok = await this.enrichScene({
+            db,
+            scene,
+            turnCache,
+            enrichmentVersion,
+            predictionOn,
+            beliefsByUser,
+          });
           if (ok) result.enriched += 1;
           else result.failed += 1;
         } catch (e) {
@@ -282,17 +429,36 @@ export class SceneEnricherService {
     return result;
   }
 
+  /**
+   * The distinct users whose beliefs this run may read: ONLY scenes that
+   * pass the #387 single-user fence contribute one. A mixed-user,
+   * tenant-global or legacy (pre-0117 userIds) scene contributes nothing
+   * and later gets NO baseline — never a shared or foreign one.
+   */
+  private baselineUserIds(scenes: readonly SceneHead[]): string[] {
+    const users = new Set<string>();
+    for (const scene of scenes) {
+      const userId = sceneSingleUser(scene);
+      if (userId !== null) users.add(userId);
+    }
+    return [...users];
+  }
+
   /** One scene: transcript → ONE structured call → validated UPDATE. */
   private async enrichScene({
     db,
     scene,
     turnCache,
     enrichmentVersion,
+    predictionOn,
+    beliefsByUser,
   }: {
     db: EpisodeDb;
     scene: SceneHead;
     turnCache: Map<string, Map<string, SceneTurnRow>>;
     enrichmentVersion: string;
+    predictionOn: boolean;
+    beliefsByUser: ReadonlyMap<string, BaselineBelief[]>;
   }): Promise<boolean> {
     if (scene.conversationIds.length === 0) return false;
     // Member lookup merged over ALL of the scene's conversations (the
@@ -341,7 +507,14 @@ export class SceneEnricherService {
         return `(${stamp}) ${t.speaker ?? 'unknown'}: ${t.text.slice(0, TURN_TEXT_MAX_CHARS)}`;
       })
       .join('\n');
-    const enrichment = await this.callModel(transcript);
+    // THE EXPECTATION SNAPSHOT — taken BEFORE the scene is scored, so
+    // "surprising" can mean "deviates from what we believed" instead of
+    // "vivid". Null with the flag off, and null for any scene that fails
+    // the #387 single-user fence (never scored against foreign beliefs).
+    const prediction: ScenePrediction | null = predictionOn
+      ? this.sceneExpectation({ scene, memberTurns, transcript, beliefsByUser })
+      : null;
+    const enrichment = await this.callModel(transcript, prediction);
     if (!enrichment) {
       this.logger.warn(
         `scene enrichment reply malformed for ${String(scene.id)} — scene keeps its deterministic gist`,
@@ -349,11 +522,27 @@ export class SceneEnricherService {
       return false;
     }
 
+    // MEASURED over GUESSED: the deterministic scorer (no model call) is
+    // the producer of contradiction / stateChange / identity whenever it
+    // can measure them; the rest of the vector stays the model's.
+    const measured: ScenePredictionError =
+      prediction === null
+        ? {}
+        : scorePredictionError({
+            baseline: prediction.beliefs,
+            stateDeltas: enrichment.stateDeltas,
+            memberTurnCount: memberTurns.length,
+            selfSubjects: prediction.selfSubjects,
+          });
+
     // Single-record UPDATE by bound id — primary-key addressed, immune to
     // the 3.2.4 secondary-index planner bug by construction. Writes ONLY
-    // the enrichment-revision siblings + stamps (0118): the composer's
-    // deterministic gist / memoryValue are immutable post-compose, and
-    // gistPromptVersion is legacy-dead (superseded by enrichmentVersion).
+    // the enrichment-revision siblings + stamps (0118) — plus, with the
+    // baseline on, the 0106 FLEXIBLE `baselineRef` snapshot: the
+    // composer's deterministic gist / memoryValue stay immutable
+    // post-compose, and gistPromptVersion is legacy-dead (superseded by
+    // enrichmentVersion). The baselineRef clause is APPENDED so the
+    // flag-off statement stays byte-identical (pinned by unit test).
     await db.query(
       `UPDATE $scene SET
          enrichedGist = $gist,
@@ -362,32 +551,79 @@ export class SceneEnricherService {
          unexpectedDetails = $unexpectedDetails,
          enrichmentModel = $model,
          enrichmentVersion = $enrichmentVersion,
-         enrichedAt = time::now()`,
+         enrichedAt = time::now()` +
+        (prediction === null ? '' : `,\n         baselineRef = $baselineRef`),
       {
         scene: scene.id,
         gist: enrichment.gist,
         memoryValue: {
-          ...enrichment.memoryValue,
-          scorerVersion: SCENE_SCORER_LLM_VERSION,
+          ...(prediction === null
+            ? enrichment.memoryValue
+            : mergePredictionError(enrichment.memoryValue, measured)),
+          scorerVersion: sceneScorerVersion(prediction !== null),
           scoredAt: new Date(),
         },
         stateDeltas: enrichment.stateDeltas,
         unexpectedDetails: enrichment.unexpectedDetails,
         model: this.model,
         enrichmentVersion,
+        ...(prediction === null ? {} : { baselineRef: baselineRefPayload(prediction.beliefs) }),
       },
     );
     return true;
   }
 
+  /**
+   * The per-scene expectation snapshot. Scenes failing the #387 fence get
+   * an EMPTY baseline (not a foreign one) — they still take the v2 prompt
+   * with an explicit "nothing is known" block, which is the honest thing
+   * to show a model whose world we cannot scope.
+   */
+  private sceneExpectation({
+    scene,
+    memberTurns,
+    transcript,
+    beliefsByUser,
+  }: {
+    scene: SceneHead;
+    memberTurns: SceneTurnRow[];
+    transcript: string;
+    beliefsByUser: ReadonlyMap<string, BaselineBelief[]>;
+  }): ScenePrediction {
+    const { userId, beliefs, selfSubjects } = sceneBaseline({
+      scene,
+      turns: memberTurns,
+      transcript,
+      beliefsByUser,
+    });
+    if (userId === null) {
+      this.logger.debug(
+        `scene prediction baseline empty for ${String(scene.id)}: not single-user — #387 fence`,
+      );
+    }
+    return { beliefs, selfSubjects };
+  }
+
   /** ONE strict-schema chat call (deriver-client idiom); null = degrade. */
-  private async callModel(transcript: string): Promise<SceneEnrichment | null> {
+  private async callModel(
+    transcript: string,
+    prediction: ScenePrediction | null,
+  ): Promise<SceneEnrichment | null> {
     const res = await this.openai!.chat.completions.create({
       model: this.model,
       ...chatCallParams(this.model, { temperature: 0, visibleCap: ENRICH_VISIBLE_CAP }),
       messages: [
-        { role: 'system', content: SCENE_ENRICHMENT_SYSTEM },
-        { role: 'user', content: `Scene transcript:\n${transcript}` },
+        {
+          role: 'system',
+          content: prediction === null ? SCENE_ENRICHMENT_SYSTEM : SCENE_ENRICHMENT_SYSTEM_V2,
+        },
+        {
+          role: 'user',
+          content:
+            prediction === null
+              ? `Scene transcript:\n${transcript}`
+              : `${renderBaselineBlock(prediction.beliefs)}\n\nScene transcript:\n${transcript}`,
+        },
       ],
       response_format: {
         type: 'json_schema',

--- a/src/admin/scene-prediction-baseline.ts
+++ b/src/admin/scene-prediction-baseline.ts
@@ -1,0 +1,413 @@
+import { resolveFieldFold } from './belief-field-fold';
+import { sceneSingleUser, type PromotableSceneHead } from './belief-promotion.service';
+import type { SceneTurnRow } from './scene-segmentation';
+
+/**
+ * Scene PREDICTION BASELINE (SCENES_PREDICTION_BASELINE, default off):
+ * the expectation snapshot the scene plane never had.
+ *
+ * THE GAP THIS CLOSES. `memoryValue.contradiction` and
+ * `unexpectedDetails` were pure LLM saliency guesses — the enricher was
+ * never shown ANY prior state to be surprised AGAINST, so "surprising"
+ * meant "vivid", not "deviant". `baselineRef` (0106) existed but was
+ * written only by belief promotion, only on a revision, AFTER the fact —
+ * a provenance backpointer, not an expectation. The roadmap names the
+ * hole exactly: "The missing edge is PREDICTION as a read-side control
+ * signal (surprise currently exists only at write time)"
+ * (docs/roadmap/memory-research-2026-08.md).
+ *
+ * WHAT A BASELINE IS. The tenant/user's ACTIVE `semantic_belief` rows
+ * (0120) for the subjects THIS scene is about, read BEFORE the scene is
+ * scored — literally "what the system believed before this happened".
+ * It is rendered into the enrichment prompt (so the model reports
+ * observed-vs-expected instead of free-floating saliency), measured
+ * against the scene's stateDeltas by a deterministic scorer that costs
+ * nothing, and stamped onto the scene as `baselineRef` so the
+ * expectation is auditable after the fact.
+ *
+ * NEW FILE BY DESIGN. Belief READING for the scene plane lives here, not
+ * inside belief-promotion.service.ts (the god-file ceiling that already
+ * pushed belief-field-fold.ts out) and not inside the enricher (which
+ * stays a transport/orchestration service). The two helpers imported
+ * from the belief layer — `sceneSingleUser` (the #387 fail-closed
+ * single-user fence) and `resolveFieldFold` (the deterministic lexical
+ * field-name rule) — are IMPORTED, never re-implemented: a duplicated
+ * scope fence is a fence that drifts.
+ *
+ * 3.2.4 DISCIPLINE. Exactly one plain SELECT per run (reads never trip
+ * the compound-index planner class that makes `DELETE ... WHERE` a
+ * silent no-op — see the 0093/0120 headers); no write here at all.
+ *
+ * TENANT / USER FENCE. Every read is inside `withCompany` (tenant) and
+ * filtered to the userIds of scenes that PASSED `sceneSingleUser` — a
+ * mixed-user, tenant-global or legacy (pre-0117 `userIds`) scene gets NO
+ * baseline at all rather than a shared one. A scene is therefore never
+ * scored against another user's beliefs; `assembleSceneBaseline` re-
+ * applies the fence per scene so a wrong bucket cannot leak through the
+ * map lookup either.
+ */
+
+/** Stamp of the deterministic prediction-error scorer defined below. */
+export const SCENE_PREDICTION_SCORER_VERSION = 'scene-scorer-v1';
+
+/** Stamp inside the `baselineRef` snapshot (its own shape version). */
+export const SCENE_BASELINE_VERSION = 'scene-baseline-v1';
+
+/**
+ * BOUNDS (all documented, all deliberately small — a baseline is a
+ * prompt block and a stamped snapshot, not a data dump):
+ *  - QUERY_LIMIT caps the ONE per-run belief read; a tenant with more
+ *    active beliefs than this simply gets a truncated (deterministically
+ *    ordered) world model, never a slow query.
+ *  - MAX_SUBJECTS / MAX_BELIEFS cap what any single scene renders and
+ *    stamps, so prompt size and row size stay bounded regardless of how
+ *    much the tenant believes.
+ *  - VALUE_MAX_CHARS mirrors the enricher's DELTA_FIELD_MAX_CHARS so a
+ *    belief value and a delta value are rendered on the same scale.
+ */
+export const BASELINE_QUERY_LIMIT = 2000;
+export const BASELINE_MAX_SUBJECTS = 20;
+export const BASELINE_MAX_BELIEFS = 40;
+export const BASELINE_VALUE_MAX_CHARS = 200;
+
+/**
+ * `stateChange` saturation: deltas-per-member-turn at which the
+ * dimension reaches 1. One durable transition every two turns is already
+ * a dense state-change scene — above that the dimension saturates rather
+ * than growing without bound.
+ */
+export const STATE_CHANGE_SATURATION_PER_TURN = 0.5;
+
+/**
+ * Self-subject markers for the `identity` dimension — a deliberately
+ * small, documented heuristic (English + Russian), the same spirit as
+ * the v0 scorer's FIRST_PERSON_PATTERNS in scene-segmentation.ts. A
+ * delta whose subject normalizes into this set (or into the scene's own
+ * userId / a non-assistant speaker label) is about the speaker
+ * themselves.
+ */
+const SELF_SUBJECT_MARKERS: ReadonlySet<string> = new Set([
+  'user',
+  'the user',
+  'i',
+  'me',
+  'myself',
+  'speaker',
+  'я',
+  'мне',
+  'пользователь',
+]);
+
+/** One ACTIVE belief as the baseline carries it. */
+export interface BaselineBelief {
+  id: string;
+  subject: string;
+  field: string;
+  value: string;
+  revision: number;
+}
+
+/** The `baselineRef` snapshot payload written onto the scene (0106). */
+export interface SceneBaselineRef {
+  beliefs: BaselineBelief[];
+  stampedAt: string;
+  baselineVersion: string;
+}
+
+/** Prediction-error dimensions — every one OPTIONAL by contract. */
+export interface ScenePredictionError {
+  contradiction?: number;
+  stateChange?: number;
+  identity?: number;
+}
+
+/** One scene stateDelta as the enricher parses it. */
+export interface SceneStateDelta {
+  subject: string;
+  field: string;
+  from: string;
+  to: string;
+}
+
+/** The one db surface this module needs (mock-swappable in tests). */
+export interface BaselineDb {
+  query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T>;
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v.trim() : '');
+
+/**
+ * Pure: the lexical normalization used for every comparison here —
+ * lowercase, punctuation to space, whitespace collapsed. This is exactly
+ * what belief-field-fold.ts applies inside `fieldTokens` (which is not
+ * exported and returns a token Set); kept as one string so subjects and
+ * values compare as whole phrases. NO stemming, NO embeddings, NO fuzzy
+ * distance — the belief layer's own rule, nothing invented.
+ */
+export function normalizeLexical(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .split(/\s+/)
+    .filter((t) => t !== '')
+    .join(' ');
+}
+
+/**
+ * The ONE bounded belief read per enrichment run: every ACTIVE
+ * semantic_belief of the given users, bucketed by userId. Same query
+ * shape as the promotion pass's field-fold candidate read
+ * (belief-promotion.service.ts) — `status = 'active' AND userId INSIDE
+ * $userIds` — deliberately NOT a second idiom. Empty input ⇒ zero
+ * queries.
+ *
+ * Ordering is total and deterministic (subject, field, revision desc,
+ * id) so a truncation at BASELINE_QUERY_LIMIT always keeps the SAME
+ * rows for the same data — a baseline that shifted under LIMIT would
+ * make enrichment non-reproducible.
+ */
+export async function loadActiveBeliefBaseline(
+  db: BaselineDb,
+  userIds: readonly string[],
+): Promise<Map<string, BaselineBelief[]>> {
+  const buckets = new Map<string, BaselineBelief[]>();
+  if (userIds.length === 0) return buckets;
+  const [rows] = await db.query<
+    [
+      Array<{
+        id: unknown;
+        userId: unknown;
+        subject: unknown;
+        field: unknown;
+        value: unknown;
+        revision: unknown;
+      }>,
+    ]
+  >(
+    `SELECT id, userId, subject, field, value, revision FROM semantic_belief
+      WHERE status = 'active' AND userId INSIDE $userIds
+      ORDER BY subject ASC, field ASC, revision DESC, id ASC
+      LIMIT $cap`,
+    { userIds: [...userIds], cap: BASELINE_QUERY_LIMIT },
+  );
+  for (const row of rows ?? []) {
+    const userId = str(row.userId);
+    const subject = str(row.subject);
+    const field = str(row.field);
+    if (userId === '' || subject === '' || field === '') continue;
+    const bucket = buckets.get(userId);
+    const belief: BaselineBelief = {
+      id: String(row.id),
+      subject,
+      field,
+      value: str(row.value).slice(0, BASELINE_VALUE_MAX_CHARS),
+      revision:
+        typeof row.revision === 'number' && Number.isFinite(row.revision) ? row.revision : 0,
+    };
+    if (bucket === undefined) buckets.set(userId, [belief]);
+    else bucket.push(belief);
+  }
+  return buckets;
+}
+
+/**
+ * Pure: the normalized subject labels that mean "the speaker themselves"
+ * for this scene — its single-user id, its non-assistant speaker labels
+ * (the assistant lane never owns identity-central state), and the
+ * documented SELF_SUBJECT_MARKERS.
+ */
+export function sceneSelfSubjects(
+  userId: string | null,
+  turns: readonly SceneTurnRow[],
+): Set<string> {
+  const self = new Set<string>(SELF_SUBJECT_MARKERS);
+  if (userId !== null) {
+    const norm = normalizeLexical(userId);
+    if (norm !== '') self.add(norm);
+  }
+  for (const turn of turns) {
+    const speaker = turn.speaker ?? '';
+    if (speaker.toLowerCase().endsWith('assistant')) continue;
+    const norm = normalizeLexical(speaker);
+    if (norm !== '') self.add(norm);
+  }
+  return self;
+}
+
+/**
+ * Pure: which of the user's ACTIVE beliefs this scene is ABOUT — the
+ * subject candidates come from the scene itself (a belief subject named
+ * in the transcript, or a self-subject), never from the model reply
+ * (which does not exist yet at prompt-build time).
+ *
+ * Bounded twice: at most BASELINE_MAX_SUBJECTS distinct subjects and at
+ * most BASELINE_MAX_BELIEFS rows, cut from a totally ordered list so the
+ * same scene always renders the same block.
+ */
+export function assembleSceneBaseline(
+  beliefs: readonly BaselineBelief[],
+  transcript: string,
+  selfSubjects: ReadonlySet<string>,
+): BaselineBelief[] {
+  if (beliefs.length === 0) return [];
+  // Padded normalized transcript: a whole-phrase containment test that
+  // cannot match across word interiors ('ana' inside 'banana').
+  const haystack = ` ${normalizeLexical(transcript)} `;
+  const relevant = beliefs.filter((b) => {
+    const subject = normalizeLexical(b.subject);
+    if (subject === '') return false;
+    return selfSubjects.has(subject) || haystack.includes(` ${subject} `);
+  });
+  const ordered = [...relevant].sort(
+    (a, b) =>
+      a.subject.localeCompare(b.subject) ||
+      a.field.localeCompare(b.field) ||
+      b.revision - a.revision ||
+      a.id.localeCompare(b.id),
+  );
+  const subjects = new Set<string>();
+  const out: BaselineBelief[] = [];
+  for (const belief of ordered) {
+    if (out.length >= BASELINE_MAX_BELIEFS) break;
+    const subject = normalizeLexical(belief.subject);
+    if (!subjects.has(subject)) {
+      if (subjects.size >= BASELINE_MAX_SUBJECTS) continue;
+      subjects.add(subject);
+    }
+    out.push(belief);
+  }
+  return out;
+}
+
+/**
+ * Pure: the per-scene baseline, fenced. Returns null — NO baseline, no
+ * prompt block, no measured dimensions — for any scene that fails the
+ * #387 single-user fence, so a mixed-user / tenant-global / legacy scene
+ * is never scored against one user's beliefs.
+ */
+export function sceneBaseline({
+  scene,
+  turns,
+  transcript,
+  beliefsByUser,
+}: {
+  scene: PromotableSceneHead;
+  turns: readonly SceneTurnRow[];
+  transcript: string;
+  beliefsByUser: ReadonlyMap<string, BaselineBelief[]>;
+}): { userId: string | null; beliefs: BaselineBelief[]; selfSubjects: Set<string> } {
+  const userId = sceneSingleUser(scene);
+  const selfSubjects = sceneSelfSubjects(userId, turns);
+  if (userId === null) return { userId: null, beliefs: [], selfSubjects };
+  const beliefs = assembleSceneBaseline(beliefsByUser.get(userId) ?? [], transcript, selfSubjects);
+  return { userId, beliefs, selfSubjects };
+}
+
+/** Pure: the `baselineRef` snapshot (0106 FLEXIBLE object). */
+export function baselineRefPayload(beliefs: readonly BaselineBelief[]): SceneBaselineRef {
+  return {
+    beliefs: beliefs.map((b) => ({ ...b })),
+    stampedAt: new Date().toISOString(),
+    baselineVersion: SCENE_BASELINE_VERSION,
+  };
+}
+
+/**
+ * Pure: render the baseline as the prompt's "what the system currently
+ * believes" block. An EMPTY baseline renders an explicit empty marker
+ * rather than nothing — the model must be told it knows nothing (so it
+ * cannot report deviation from an imagined model), not left to infer it
+ * from a missing section.
+ */
+export function renderBaselineBlock(beliefs: readonly BaselineBelief[]): string {
+  const head = 'Current model of the world (what the system believed BEFORE this scene):';
+  if (beliefs.length === 0) {
+    return `${head}\n(nothing is known about this speaker yet — nothing here can be contradicted)`;
+  }
+  const lines = beliefs.map(
+    (b) => `- ${b.subject} | ${b.field} = ${b.value} (revision ${b.revision})`,
+  );
+  return `${head}\n${lines.join('\n')}`;
+}
+
+/** Find the baseline belief a delta is ABOUT, or null. */
+function matchBelief(
+  delta: SceneStateDelta,
+  bySubject: ReadonlyMap<string, BaselineBelief[]>,
+): BaselineBelief | null {
+  const candidates = bySubject.get(normalizeLexical(delta.subject));
+  if (candidates === undefined || candidates.length === 0) return null;
+  // The belief layer's own field rule: exact name short-circuits, EXACTLY
+  // one foldable candidate folds, ambiguity folds nothing (fail-closed —
+  // an ambiguous match is not a measurement).
+  const resolved = resolveFieldFold(
+    delta.field,
+    candidates.map((c) => c.field),
+  );
+  if (resolved.ambiguous) return null;
+  return candidates.find((c) => c.field === resolved.field) ?? null;
+}
+
+/**
+ * Pure, NO model call: the deterministic prediction-error scorer
+ * (SCENE_PREDICTION_SCORER_VERSION). It is the paid scorer the v0
+ * comment in scene-segmentation.ts was waiting for, and it costs
+ * nothing.
+ *
+ *  - `contradiction` = share of MATCHED deltas whose `to` disagrees with
+ *    the matching belief's head value (normalizeLexical compare — the
+ *    belief layer's rule, no fuzzy distance). The denominator is the
+ *    MATCHED deltas, not all of them: a delta with no belief behind it
+ *    is evidence of neither agreement nor disagreement.
+ *  - `stateChange` = durable transitions per member turn, saturating at
+ *    STATE_CHANGE_SATURATION_PER_TURN.
+ *  - `identity` = share of deltas about the speaker themselves.
+ *
+ * UNDEFINED IS NOT ZERO — the whole point. No deltas ⇒ nothing was
+ * measured, so all three stay undefined. No MATCHING belief ⇒
+ * `contradiction` stays undefined: an unknown baseline is not a
+ * confident "no contradiction", and the caller must not turn silence
+ * into a confident 0.
+ */
+export function scorePredictionError({
+  baseline,
+  stateDeltas,
+  memberTurnCount,
+  selfSubjects,
+}: {
+  baseline: readonly BaselineBelief[];
+  stateDeltas: readonly SceneStateDelta[];
+  memberTurnCount: number;
+  selfSubjects: ReadonlySet<string>;
+}): ScenePredictionError {
+  if (stateDeltas.length === 0 || memberTurnCount <= 0) return {};
+
+  const bySubject = new Map<string, BaselineBelief[]>();
+  for (const belief of baseline) {
+    const key = normalizeLexical(belief.subject);
+    const bucket = bySubject.get(key);
+    if (bucket === undefined) bySubject.set(key, [belief]);
+    else bucket.push(belief);
+  }
+
+  let matched = 0;
+  let disagreeing = 0;
+  let selfDeltas = 0;
+  for (const delta of stateDeltas) {
+    if (selfSubjects.has(normalizeLexical(delta.subject))) selfDeltas += 1;
+    const belief = matchBelief(delta, bySubject);
+    if (belief === null) continue;
+    matched += 1;
+    if (normalizeLexical(delta.to) !== normalizeLexical(belief.value)) disagreeing += 1;
+  }
+
+  const error: ScenePredictionError = {
+    stateChange: Math.min(
+      1,
+      stateDeltas.length / memberTurnCount / STATE_CHANGE_SATURATION_PER_TURN,
+    ),
+    identity: selfDeltas / stateDeltas.length,
+  };
+  if (matched > 0) error.contradiction = disagreeing / matched;
+  return error;
+}

--- a/src/admin/scene-segmentation.ts
+++ b/src/admin/scene-segmentation.ts
@@ -188,7 +188,19 @@ const FIRST_PERSON_PATTERNS: readonly RegExp[] = [
  *    no priors the scene is maximally novel (1).
  *  - explicitness: fraction of member turns carrying a first-person
  *    declarative marker (FIRST_PERSON_PATTERNS).
- *  - every other dimension stays undefined until a paid scorer exists.
+ *  - every other dimension stays undefined here.
+ *
+ * THE OTHER DIMENSIONS NOW HAVE A PRODUCER, just not at compose time.
+ * contradiction / stateChange / identity are measured from the scene's
+ * stateDeltas against an expectation snapshot of the user's ACTIVE
+ * beliefs — neither of which exists yet when this runs (stateDeltas are
+ * enrichment-owned, migration 0118, and a scene has not been read here).
+ * That scorer is `scorePredictionError` (scene-prediction-baseline.ts,
+ * SCENE_PREDICTION_SCORER_VERSION 'scene-scorer-v1'); the enricher runs
+ * it and lands the result in `enrichedMemoryValue`, because 0118 makes
+ * this deterministic vector immutable post-compose. It costs nothing —
+ * no model call — it simply cannot run this early.
+ *
  * Stamps scorerVersion + scoredAt so mixed-scorer worlds stay auditable.
  */
 export function scoreSceneDeterministic(

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1091,6 +1091,18 @@ const KNOWN_BOOLEAN_FLAGS = [
   // folds nothing and warns loudly. NO embeddings, NO LLM. Default off
   // ⇒ exact-string grouping, zero extra queries — byte-identical.
   'SCENES_BELIEF_FIELD_FOLD',
+  // Scene prediction baseline: the expectation snapshot the scene plane
+  // never had. On, the enrichment pass loads the scene user's ACTIVE
+  // semantic_belief rows (0120) BEFORE scoring, stamps them as
+  // baselineRef (0106 FLEXIBLE), renders them into the prompt so
+  // contradiction/unexpectedDetails are reported as DEVIATION from that
+  // model (prompt scene-gist-v2), and overrides contradiction /
+  // stateChange / identity in enrichedMemoryValue with a deterministic
+  // no-model-call scorer (scene-scorer-v1). Mixed-user/legacy scenes get
+  // NO baseline (#387 fence). Default off ⇒ zero extra queries, the
+  // byte-identical scene-gist-v1 prompt and composite, no baselineRef
+  // write — byte-identical rows.
+  'SCENES_PREDICTION_BASELINE',
   // Scene evidence links (MM-zoom PR1, migration 0123): typed
   // scene-reconstructed_from->evidence_fragment|evidence_asset edges in
   // memory_support from the union of member episodes' source.evidenceRefs

--- a/src/common/scene-flags.ts
+++ b/src/common/scene-flags.ts
@@ -211,6 +211,52 @@ export function sceneBeliefFieldFoldEnabled(): boolean {
 }
 
 /**
+ * Scenes prediction-baseline flag — SCENES_PREDICTION_BASELINE.
+ *
+ * The scene plane had NO prediction machinery: `memoryValue.contradiction`
+ * and `unexpectedDetails` were LLM saliency guesses made against nothing —
+ * the enricher was never shown any prior state to be surprised AGAINST —
+ * and `baselineRef` (0106) was written only by belief promotion, only on a
+ * revision, AFTER the fact. The roadmap names the hole: "the missing edge
+ * is PREDICTION as a read-side control signal (surprise currently exists
+ * only at write time)".
+ *
+ * When on, the enrichment pass gains ONE coherent behavior in three parts:
+ *  1. EXPECTATION SNAPSHOT — before scoring a scene it loads the scene
+ *     user's ACTIVE semantic_belief rows (0120) for the subjects the scene
+ *     is about (ONE bounded SELECT per run, capped) and stamps them onto
+ *     the scene as `baselineRef` = {beliefs, stampedAt, baselineVersion};
+ *  2. PREDICTION ERROR IN THE PROMPT — that snapshot is rendered as an
+ *     explicit "what the system believed BEFORE this scene" block and the
+ *     instruction changes so `contradiction` / `unexpectedDetails` are
+ *     reported as DEVIATION FROM THAT MODEL, not free-floating saliency
+ *     (fresh prompt version scene-gist-v2);
+ *  3. DETERMINISTIC SCORER — a no-model-call scorer (scene-scorer-v1)
+ *     measures contradiction / stateChange / identity from the SAME
+ *     baseline plus the scene's stateDeltas and OVERRIDES the model's
+ *     guesses for exactly those dimensions in `enrichedMemoryValue`
+ *     (scorerVersion composite scene-scorer-llm-v1+scene-scorer-v1).
+ *     A dimension it cannot measure stays the model's guess — an unknown
+ *     baseline is never turned into a confident zero.
+ *
+ * Scenes that fail the #387 single-user fence (mixed-user, tenant-global,
+ * legacy pre-0117 userIds) get NO baseline at all — a scene is never
+ * scored against another user's beliefs.
+ *
+ * The env read lives here in the common layer, NOT inside the engine dirs
+ * (engine-gates S5.2). Read ONCE per enrichment run (the Drift-3 contract)
+ * so a mid-run flip can never mix prompt versions inside one world.
+ * Default off ⇒ ZERO extra queries, the byte-identical scene-gist-v1
+ * prompt and enrichmentVersion composite, no baselineRef write, and the
+ * model's memoryValue verbatim. Requires SCENES_LLM_ENRICHMENT — the
+ * baseline is an input to the enrichment call. SCENES_ family sits off the
+ * ENGINE flag budget by design.
+ */
+export function scenePredictionBaselineEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_PREDICTION_BASELINE);
+}
+
+/**
  * Belief corroboration floor (SCENES_BELIEF_MIN_SCENES): promote a
  * (subject, field) group only when its winning value is corroborated by
  * scenes from at least this many DISTINCT CONVERSATIONS (the #377

--- a/test/scene-enrichment.unit-spec.ts
+++ b/test/scene-enrichment.unit-spec.ts
@@ -13,11 +13,15 @@ import type { ConfigService } from '@nestjs/config';
 import type { SurrealService } from '../src/db/surreal.service';
 import type { EpisodeReadStoreService } from '../src/episodes/episode-read-store.service';
 import {
+  mergePredictionError,
   parseSceneEnrichment,
   sceneEnrichmentVersion,
   SceneEnricherService,
+  SCENE_ENRICHMENT_SYSTEM,
+  SCENE_ENRICHMENT_SYSTEM_V2,
   SCENE_SCORER_LLM_VERSION,
 } from '../src/admin/scene-enricher.service';
+import { SCENE_BASELINE_VERSION } from '../src/admin/scene-prediction-baseline';
 import { matchFactsToScene } from '../src/admin/scene-backlink.service';
 import { SEGMENTER_VERSION } from '../src/admin/scene-segmentation';
 import type { SceneVersionService } from '../src/admin/scene-version';
@@ -95,6 +99,37 @@ describe('sceneEnrichmentVersion', () => {
       'scene-gist-v1|scene-scorer-llm-v1|gpt-4o-mini',
     );
   });
+
+  it('names the prediction prompt AND both scorers with the baseline on', () => {
+    expect(sceneEnrichmentVersion('gpt-4o-mini', true)).toBe(
+      'scene-gist-v2|scene-scorer-llm-v1+scene-scorer-v1|gpt-4o-mini',
+    );
+    // Flipping the flag either way changes the idempotency key, so a
+    // mixed world can never hide behind one stamp.
+    expect(sceneEnrichmentVersion('m', true)).not.toBe(sceneEnrichmentVersion('m', false));
+  });
+});
+
+describe('mergePredictionError', () => {
+  const guessed = { ...WELL_FORMED.memoryValue };
+
+  it('overwrites only the dimensions actually measured', () => {
+    const merged = mergePredictionError(guessed, { contradiction: 1, identity: 0.5 });
+    expect(merged.contradiction).toBe(1);
+    expect(merged.identity).toBe(0.5);
+    // Untouched: the model still owns these.
+    expect(merged.stateChange).toBe(guessed.stateChange);
+    expect(merged.novelty).toBe(guessed.novelty);
+    expect(merged.estimatedUtility).toBe(guessed.estimatedUtility);
+  });
+
+  it('never turns an UNMEASURED dimension into a confident zero', () => {
+    expect(mergePredictionError({ ...guessed, contradiction: 0.42 }, {}).contradiction).toBe(0.42);
+  });
+
+  it('clamps a measured dimension into [0,1]', () => {
+    expect(mergePredictionError(guessed, { stateChange: 4 }).stateChange).toBe(1);
+  });
 });
 
 describe('matchFactsToScene', () => {
@@ -126,19 +161,33 @@ describe('SceneEnricherService degrade contract (scripted provider)', () => {
 
   interface Captured {
     updates: Array<{ sql: string; params: Record<string, unknown> }>;
+    queries: string[];
+    prompts: Array<{ system: string; user: string }>;
     modelCalls: number;
+  }
+
+  interface BuildOpts {
+    sceneEnrichmentVersion?: string;
+    /** Scope stamps on the single fake scene (default: single-user u1). */
+    scope?: Record<string, unknown>;
+    /** Rows the semantic_belief read returns (default: none). */
+    beliefs?: Array<Record<string, unknown>>;
   }
 
   function build(
     reply: string,
-    opts: { sceneEnrichmentVersion?: string } = {},
+    opts: BuildOpts = {},
   ): { svc: SceneEnricherService; captured: Captured } {
-    const captured: Captured = { updates: [], modelCalls: 0 };
+    const captured: Captured = { updates: [], queries: [], prompts: [], modelCalls: 0 };
     const fakeDb = {
       query: async (sql: string, params?: Record<string, unknown>) => {
+        captured.queries.push(sql);
         if (sql.includes('UPDATE $scene')) {
           captured.updates.push({ sql, params: params ?? {} });
           return [[]];
+        }
+        if (sql.includes('FROM semantic_belief')) {
+          return [opts.beliefs ?? []];
         }
         if (sql.includes('FROM memory_episode_member')) {
           return [[{ out: 'episode:e1', ord: 0 }]];
@@ -149,6 +198,7 @@ describe('SceneEnricherService degrade contract (scripted provider)', () => {
               {
                 id: 'memory_episode:s1',
                 conversationIds: ['conv'],
+                ...(opts.scope ?? { userId: 'u1', userIds: ['u1'] }),
                 ...(opts.sceneEnrichmentVersion !== undefined
                   ? { enrichmentVersion: opts.sceneEnrichmentVersion }
                   : {}),
@@ -183,8 +233,12 @@ describe('SceneEnricherService degrade contract (scripted provider)', () => {
     (svc as unknown as { openai: unknown }).openai = {
       chat: {
         completions: {
-          create: async () => {
+          create: async (req: { messages: Array<{ role: string; content: string }> }) => {
             captured.modelCalls += 1;
+            captured.prompts.push({
+              system: req.messages.find((m) => m.role === 'system')?.content ?? '',
+              user: req.messages.find((m) => m.role === 'user')?.content ?? '',
+            });
             return { choices: [{ message: { content: reply } }] };
           },
         },
@@ -260,5 +314,249 @@ describe('SceneEnricherService degrade contract (scripted provider)', () => {
     } finally {
       process.env.SCENES_LLM_ENRICHMENT = '1';
     }
+  });
+
+  // ── SCENES_PREDICTION_BASELINE OFF: byte-identical pins ──────────────
+  it('with the prediction baseline OFF: no belief query, v1 prompt, no baselineRef', async () => {
+    const { svc, captured } = build(JSON.stringify(WELL_FORMED));
+    await svc.enrich('co_test');
+    // Zero extra queries — the belief substrate is never touched.
+    expect(captured.queries.some((q) => q.includes('semantic_belief'))).toBe(false);
+    // The scene SELECT projection is byte-identical (no scope columns).
+    const select = captured.queries.find((q) => q.includes('FROM memory_episode\n'))!;
+    expect(select).toBe(
+      `SELECT id, conversationIds, enrichmentVersion FROM memory_episode\n` +
+        `          WHERE segmenterVersion = $v`,
+    );
+    // The prompt is byte-identical: v1 system, bare transcript user turn.
+    expect(captured.prompts[0]!.system).toBe(SCENE_ENRICHMENT_SYSTEM);
+    expect(captured.prompts[0]!.user).toBe(
+      'Scene transcript:\n(2026-02-01 10:00) mika: I booked the morning flight to Lisbon.',
+    );
+    // The UPDATE is byte-identical and the row shape unchanged.
+    const { sql, params } = captured.updates[0]!;
+    expect(sql).not.toContain('baselineRef');
+    expect(sql.endsWith('enrichedAt = time::now()')).toBe(true);
+    expect(params.baselineRef).toBeUndefined();
+    expect((params.memoryValue as Record<string, unknown>).scorerVersion).toBe(
+      SCENE_SCORER_LLM_VERSION,
+    );
+    expect(params.enrichmentVersion).toBe('scene-gist-v1|scene-scorer-llm-v1|gpt-4o-mini');
+  });
+});
+
+/**
+ * SCENES_PREDICTION_BASELINE on: the expectation snapshot reaches the
+ * prompt, the deterministic scorer overrides the model's guessed
+ * dimensions, the snapshot is stamped as baselineRef, and no scene is
+ * ever scored against another user's beliefs.
+ */
+describe('SceneEnricherService prediction baseline (scripted provider)', () => {
+  const savedEnrich = process.env.SCENES_LLM_ENRICHMENT;
+  const savedBaseline = process.env.SCENES_PREDICTION_BASELINE;
+  beforeAll(() => {
+    process.env.SCENES_LLM_ENRICHMENT = '1';
+    process.env.SCENES_PREDICTION_BASELINE = '1';
+  });
+  afterAll(() => {
+    for (const [k, v] of [
+      ['SCENES_LLM_ENRICHMENT', savedEnrich],
+      ['SCENES_PREDICTION_BASELINE', savedBaseline],
+    ] as const) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  interface Captured {
+    updates: Array<{ sql: string; params: Record<string, unknown> }>;
+    queries: string[];
+    prompts: Array<{ system: string; user: string }>;
+  }
+
+  const BELIEF_ROW = {
+    id: 'semantic_belief:b1',
+    userId: 'u1',
+    subject: 'mika',
+    field: 'trip.flight',
+    value: 'cancelled',
+    revision: 2,
+  };
+
+  function build(opts: {
+    reply?: string;
+    scope?: Record<string, unknown>;
+    beliefs?: Array<Record<string, unknown>>;
+  }): { svc: SceneEnricherService; captured: Captured } {
+    const captured: Captured = { updates: [], queries: [], prompts: [] };
+    const fakeDb = {
+      query: async (sql: string, params?: Record<string, unknown>) => {
+        captured.queries.push(sql);
+        if (sql.includes('UPDATE $scene')) {
+          captured.updates.push({ sql, params: params ?? {} });
+          return [[]];
+        }
+        if (sql.includes('FROM semantic_belief')) return [opts.beliefs ?? []];
+        if (sql.includes('FROM memory_episode_member')) return [[{ out: 'episode:e1', ord: 0 }]];
+        if (sql.includes('FROM memory_episode')) {
+          return [
+            [
+              {
+                id: 'memory_episode:s1',
+                conversationIds: ['conv'],
+                ...(opts.scope ?? { userId: 'u1', userIds: ['u1'] }),
+              },
+            ],
+          ];
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      },
+    };
+    const svc = new SceneEnricherService(
+      {
+        withCompany: (_c: string, fn: (db: unknown) => Promise<unknown>) => fn(fakeDb),
+      } as unknown as SurrealService,
+      { get: (_k: string, d?: unknown) => d } as unknown as ConfigService,
+      {
+        conversationTurnsRaw: async () => [
+          {
+            id: 'episode:e1',
+            speaker: 'mika',
+            text: 'I booked the morning flight to Lisbon.',
+            occurredAt: '2026-02-01T10:00:00.000Z',
+          },
+        ],
+      } as unknown as EpisodeReadStoreService,
+      {
+        resolve: () => ({
+          version: SEGMENTER_VERSION,
+          cfg: { topicBoundary: false, minCosine: 0.55, maxTurns: 40, embeddingSpaceId: null },
+        }),
+      } as unknown as SceneVersionService,
+    );
+    (svc as unknown as { openai: unknown }).openai = {
+      chat: {
+        completions: {
+          create: async (req: { messages: Array<{ role: string; content: string }> }) => {
+            captured.prompts.push({
+              system: req.messages.find((m) => m.role === 'system')?.content ?? '',
+              user: req.messages.find((m) => m.role === 'user')?.content ?? '',
+            });
+            return {
+              choices: [{ message: { content: opts.reply ?? JSON.stringify(WELL_FORMED) } }],
+            };
+          },
+        },
+      },
+    };
+    return { svc, captured };
+  }
+
+  const memoryValue = (c: Captured): Record<string, unknown> =>
+    c.updates[0]!.params.memoryValue as Record<string, unknown>;
+
+  it('projects the scope columns and renders the baseline into the v2 prompt', async () => {
+    const { svc, captured } = build({ beliefs: [BELIEF_ROW] });
+    await svc.enrich('co_test');
+    const select = captured.queries.find((q) => q.includes('FROM memory_episode\n'))!;
+    expect(select).toContain('userId, userIds');
+    expect(captured.prompts[0]!.system).toBe(SCENE_ENRICHMENT_SYSTEM_V2);
+    expect(captured.prompts[0]!.user).toContain('Current model of the world');
+    expect(captured.prompts[0]!.user).toContain('- mika | trip.flight = cancelled (revision 2)');
+    expect(captured.prompts[0]!.user).toContain('Scene transcript:');
+  });
+
+  it('MEASURES contradiction against the baseline, overriding the model’s guess', async () => {
+    // The model guessed contradiction 0; the belief says the flight was
+    // cancelled and the delta says booked — a measured full deviation.
+    const { svc, captured } = build({ beliefs: [BELIEF_ROW] });
+    await svc.enrich('co_test');
+    const mv = memoryValue(captured);
+    expect(WELL_FORMED.memoryValue.contradiction).toBe(0); // the guess
+    expect(mv.contradiction).toBe(1); // the measurement
+    expect(mv.scorerVersion).toBe('scene-scorer-llm-v1+scene-scorer-v1');
+    // Baseline-free dimensions are measured too; the rest stay the model's.
+    expect(mv.stateChange).toBe(1); // 1 delta / 1 turn, saturated
+    expect(mv.identity).toBe(1); // the delta is about the speaker
+    expect(mv.novelty).toBeCloseTo(WELL_FORMED.memoryValue.novelty);
+    expect(mv.estimatedUtility).toBeCloseTo(WELL_FORMED.memoryValue.estimatedUtility);
+  });
+
+  it('measures NO contradiction when the delta agrees with the belief', async () => {
+    const { svc, captured } = build({ beliefs: [{ ...BELIEF_ROW, value: 'Booked ' }] });
+    await svc.enrich('co_test');
+    expect(memoryValue(captured).contradiction).toBe(0);
+  });
+
+  it('keeps the model’s guess when there is nothing to measure against', async () => {
+    const reply = JSON.stringify({
+      ...WELL_FORMED,
+      memoryValue: { ...WELL_FORMED.memoryValue, contradiction: 0.42 },
+    });
+    const { svc, captured } = build({ reply, beliefs: [] });
+    await svc.enrich('co_test');
+    // An unknown baseline is NOT a confident zero — the guess survives.
+    expect(memoryValue(captured).contradiction).toBeCloseTo(0.42);
+    expect(captured.prompts[0]!.user).toContain('nothing is known');
+  });
+
+  it('stamps the expectation snapshot as baselineRef without touching the originals', async () => {
+    const { svc, captured } = build({ beliefs: [BELIEF_ROW] });
+    await svc.enrich('co_test');
+    const { sql, params } = captured.updates[0]!;
+    // The revision-column contract is unchanged in shape: still only the
+    // enriched* siblings + stamps, plus the appended baselineRef.
+    expect(sql).toContain('enrichedGist = $gist');
+    expect(sql).toContain('enrichedMemoryValue = $memoryValue');
+    expect(sql).toContain('baselineRef = $baselineRef');
+    expect(sql).not.toMatch(/\bgist\s*=/);
+    expect(sql).not.toMatch(/\bmemoryValue\s*=/);
+    expect(sql).not.toContain('gistPromptVersion');
+    expect(params.baselineRef).toMatchObject({
+      baselineVersion: SCENE_BASELINE_VERSION,
+      beliefs: [
+        {
+          id: 'semantic_belief:b1',
+          subject: 'mika',
+          field: 'trip.flight',
+          value: 'cancelled',
+          revision: 2,
+        },
+      ],
+    });
+    expect(typeof (params.baselineRef as Record<string, unknown>).stampedAt).toBe('string');
+    expect(params.enrichmentVersion).toBe(
+      'scene-gist-v2|scene-scorer-llm-v1+scene-scorer-v1|gpt-4o-mini',
+    );
+  });
+
+  it.each([
+    ['mixed-user', { userId: 'u1', userIds: ['u1', 'u2'] }],
+    ['tenant-global', { userIds: [] }],
+    ['legacy (no userIds)', { userId: 'u1' }],
+  ])('never scores a %s scene against anyone’s beliefs (#387 fence)', async (_label, scope) => {
+    const { svc, captured } = build({ scope, beliefs: [BELIEF_ROW] });
+    await svc.enrich('co_test');
+    // The fenced-out scene contributes no userId, so the belief read is
+    // never even issued — zero chance of a foreign baseline.
+    expect(captured.queries.some((q) => q.includes('semantic_belief'))).toBe(false);
+    expect(captured.prompts[0]!.user).toContain('nothing is known');
+    expect(captured.prompts[0]!.user).not.toContain('cancelled');
+    // Nothing measurable ⇒ the model's contradiction guess is untouched.
+    expect(memoryValue(captured).contradiction).toBe(0);
+    expect((captured.updates[0]!.params.baselineRef as { beliefs: unknown[] }).beliefs).toEqual([]);
+  });
+
+  it('does not read beliefs of a DIFFERENT user even when the tenant has them', async () => {
+    // The read is fenced to the scene's own user; a row for another user
+    // that slipped into the result set must not land in the baseline.
+    const { svc, captured } = build({
+      beliefs: [{ ...BELIEF_ROW, userId: 'u2', value: 'other-user-secret' }],
+    });
+    await svc.enrich('co_test');
+    const beliefQuery = captured.queries.find((q) => q.includes('semantic_belief'))!;
+    expect(beliefQuery).toContain('userId INSIDE $userIds');
+    expect(captured.prompts[0]!.user).not.toContain('other-user-secret');
+    expect((captured.updates[0]!.params.baselineRef as { beliefs: unknown[] }).beliefs).toEqual([]);
   });
 });

--- a/test/scene-prediction-baseline.e2e-spec.ts
+++ b/test/scene-prediction-baseline.e2e-spec.ts
@@ -1,0 +1,278 @@
+/**
+ * SCENES_PREDICTION_BASELINE e2e on real SurrealDB (stubbed model — no
+ * paid calls): the controlled experiment the whole PR exists to make
+ * possible. TWO scenes with BYTE-IDENTICAL transcripts and the SAME
+ * stubbed enrichment reply, belonging to two different users whose
+ * seeded beliefs differ in exactly one value — one agrees with the
+ * scene's stateDelta, one contradicts it. Free-floating saliency cannot
+ * tell them apart (same text, same model output); a measured prediction
+ * error must.
+ *
+ * Also pins: the flag-off world (v1 composite, no baselineRef, the
+ * model's guess verbatim), the re-enrichment a flag flip triggers via
+ * the composite, the stamped baselineRef snapshot, and cross-user
+ * isolation — each scene's baseline holds ONLY its own user's belief.
+ *
+ * Beliefs are seeded directly in the DB (the belief-promotion e2e
+ * precedent): the promotion pass has its own suite, and hand-seeded rows
+ * make the expectation deterministic.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSceneEnricherOpenAi } from './test-doubles';
+import { SurrealService } from '../src/db/surreal.service';
+
+const CONV_AGREE = 'proj:pred-agree';
+const CONV_DISAGREE = 'proj:pred-disagree';
+const USER_AGREE = 'pred_agree_user';
+const USER_DISAGREE = 'pred_disagree_user';
+
+/** Identical in both conversations — the only variable is the belief. */
+const TURNS = [
+  { t: '2026-03-01T10:00:00.000Z', text: 'I am moving to Lisbon next month.' },
+  { t: '2026-03-01T10:05:00.000Z', text: 'Signed the lease in Lisbon today.' },
+  { t: '2026-03-01T10:10:00.000Z', text: 'Everything is set now.' },
+];
+
+/**
+ * One stubbed reply for every scene. The model GUESSES contradiction
+ * 0.42 with no idea what was believed before — exactly the saliency
+ * guess this PR replaces.
+ */
+const REPLY = JSON.stringify({
+  gist: 'Mika signed the Lisbon lease and the move is settled.',
+  memoryValue: {
+    novelty: 0.8,
+    contradiction: 0.42,
+    stateChange: 0.1,
+    identity: 0.1,
+    explicitness: 0.9,
+    estimatedUtility: 0.7,
+  },
+  stateDeltas: [{ subject: 'Lisbon', field: 'lease', from: '', to: 'signed' }],
+  unexpectedDetails: ['signed the lease the same week'],
+  entityMentions: ['Lisbon'],
+});
+
+interface SceneRow {
+  id: unknown;
+  userId?: string;
+  conversationIds: string[];
+  memoryValue?: Record<string, unknown>;
+  enrichedMemoryValue?: Record<string, unknown>;
+  enrichmentVersion?: string;
+  enrichmentModel?: string;
+  baselineRef?: { beliefs?: Array<Record<string, unknown>>; baselineVersion?: string };
+}
+
+describe('scene prediction baseline (e2e)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const saved: Record<string, string | undefined> = {};
+  const FLAGS = [
+    'EPISODE_SUBSTRATE_ENABLED',
+    'INGEST_EPISODE_ONLY',
+    'SCENES_SEGMENTATION_ENABLED',
+    'SCENES_LLM_ENRICHMENT',
+    'SCENES_PREDICTION_BASELINE',
+  ];
+
+  const db = <T>(
+    fn: (d: { query: <Q>(sql: string, p?: Record<string, unknown>) => Promise<Q> }) => Promise<T>,
+  ): Promise<T> => f.app.get(SurrealService).withCompany(f.companyId, fn);
+
+  const scenes = (): Promise<SceneRow[]> =>
+    db(async (d) => {
+      const [rows] = await d.query<[SceneRow[]]>(
+        `SELECT * FROM memory_episode ORDER BY userId ASC`,
+      );
+      return rows ?? [];
+    });
+
+  const sceneOf = async (userId: string): Promise<SceneRow> => {
+    const row = (await scenes()).find((s) => s.userId === userId);
+    expect(row).toBeDefined();
+    return row!;
+  };
+
+  const seedBelief = (tail: string, userId: string, value: string): Promise<unknown> =>
+    db(async (d) =>
+      d.query(
+        `CREATE type::record('semantic_belief', $tail) CONTENT {
+           userId: $userId,
+           subject: 'Lisbon',
+           field: 'lease',
+           value: $value,
+           statement: $statement,
+           statementSource: 'template',
+           confidence: 0.8,
+           revision: 1,
+           status: 'active',
+           validFrom: <datetime>'2026-01-01T00:00:00Z',
+           sourceSceneIds: [],
+           conversationIds: [],
+           corroborationCount: 1,
+           conversationCount: 1,
+           promoterVersion: 'test-seed'
+         }`,
+        { tail, userId, value, statement: `Lisbon — lease: ${value}` },
+      ),
+    );
+
+  const enrich = () => f.http.post('/v1/admin/maintenance/scenes/enrich').set(auth()).send({});
+
+  beforeAll(async () => {
+    for (const k of FLAGS) saved[k] = process.env[k];
+    process.env.EPISODE_SUBSTRATE_ENABLED = '1';
+    process.env.INGEST_EPISODE_ONLY = '1';
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    // Both PR flags start OFF — each `it` flips only what it proves.
+    delete process.env.SCENES_LLM_ENRICHMENT;
+    delete process.env.SCENES_PREDICTION_BASELINE;
+    f = await createApp({ companyId: 'co_scene_pred_e2e' });
+
+    for (const [conv, userId] of [
+      [CONV_AGREE, USER_AGREE],
+      [CONV_DISAGREE, USER_DISAGREE],
+    ] as const) {
+      for (const [i, turn] of TURNS.entries()) {
+        const res = await f.http
+          .post('/v1/ingest/mention')
+          .set(auth())
+          .send({
+            text: turn.text,
+            contextRef: { vertical: 'proj', conversationId: conv, messageId: `${userId}${i}` },
+            knownEntities: [{ vertical: 'proj', id: 'mika', role: 'speaker', name: 'mika' }],
+            userId,
+            emittedAt: turn.t,
+          });
+        expect(res.status).toBe(201);
+      }
+    }
+
+    // The world model BEFORE the scenes: the same (subject, field) for
+    // both users, differing in exactly one value.
+    await seedBelief('pred_agree', USER_AGREE, 'signed');
+    await seedBelief('pred_dis', USER_DISAGREE, 'cancelled');
+
+    const composed = await f.http.post('/v1/admin/maintenance/scenes').set(auth()).send({});
+    expect(composed.status).toBe(201);
+    expect(composed.body).toMatchObject({ conversations: 2, scenes: 2 });
+  }, 120000);
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (f) await f.close();
+  });
+
+  it('composes single-user scenes with the deterministic v0 vector', async () => {
+    const rows = await scenes();
+    expect(rows).toHaveLength(2);
+    for (const scene of rows) {
+      expect(scene.memoryValue!.scorerVersion).toBe('scene-scorer-v0');
+      // The v0 scorer leaves the prediction-error dimensions undefined.
+      expect(scene.memoryValue!.contradiction).toBeUndefined();
+      expect(scene.baselineRef).toBeUndefined();
+    }
+    expect(rows.map((s) => s.userId).sort()).toEqual([USER_AGREE, USER_DISAGREE]);
+  });
+
+  it('with the baseline OFF the model’s guess survives verbatim — no baselineRef', async () => {
+    process.env.SCENES_LLM_ENRICHMENT = '1';
+    const mock = mockSceneEnricherOpenAi(f.app, [REPLY]);
+    const res = await enrich();
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ scenes: 2, enriched: 2, failed: 0, skipped: 0 });
+    // No baseline block reached the model.
+    for (const call of mock.calls) {
+      expect(call.user).not.toContain('Current model of the world');
+      expect(call.user.startsWith('Scene transcript:')).toBe(true);
+    }
+    for (const scene of await scenes()) {
+      expect(scene.enrichedMemoryValue!.scorerVersion).toBe('scene-scorer-llm-v1');
+      expect(scene.enrichedMemoryValue!.contradiction).toBeCloseTo(0.42);
+      expect(scene.enrichmentVersion).toBe(
+        `scene-gist-v1|scene-scorer-llm-v1|${scene.enrichmentModel!}`,
+      );
+      expect(scene.baselineRef).toBeUndefined();
+    }
+  });
+
+  it('flipping the baseline ON changes the composite, so the world re-enriches', async () => {
+    process.env.SCENES_PREDICTION_BASELINE = '1';
+    const mock = mockSceneEnricherOpenAi(f.app, [REPLY]);
+    const res = await enrich();
+    expect(res.status).toBe(201);
+    // The stamped v1 composite no longer matches ⇒ nothing is skipped.
+    expect(res.body).toMatchObject({ scenes: 2, enriched: 2, failed: 0, skipped: 0 });
+    expect(mock.calls).toHaveLength(2);
+    // Each scene saw its OWN user's world model, and only that.
+    const blocks = mock.calls.map((c) => c.user);
+    expect(blocks.filter((b) => b.includes('Lisbon | lease = signed'))).toHaveLength(1);
+    expect(blocks.filter((b) => b.includes('Lisbon | lease = cancelled'))).toHaveLength(1);
+    for (const block of blocks) {
+      expect(block).toContain('Current model of the world');
+      // Cross-user isolation: never both values in one prompt.
+      expect(block.includes('signed') && block.includes('cancelled')).toBe(false);
+    }
+  });
+
+  it('MEASURES surprise: the contradicting scene scores far above the agreeing one', async () => {
+    const agree = await sceneOf(USER_AGREE);
+    const disagree = await sceneOf(USER_DISAGREE);
+
+    // Identical transcripts, identical model reply, identical guess —
+    // the ONLY difference is what the system believed beforehand.
+    expect(agree.enrichedMemoryValue!.contradiction).toBe(0);
+    expect(disagree.enrichedMemoryValue!.contradiction).toBe(1);
+    expect(
+      (disagree.enrichedMemoryValue!.contradiction as number) -
+        (agree.enrichedMemoryValue!.contradiction as number),
+    ).toBeGreaterThan(0.5);
+
+    for (const scene of [agree, disagree]) {
+      // Both producers are named on the vector.
+      expect(scene.enrichedMemoryValue!.scorerVersion).toBe('scene-scorer-llm-v1+scene-scorer-v1');
+      expect(scene.enrichmentVersion).toBe(
+        `scene-gist-v2|scene-scorer-llm-v1+scene-scorer-v1|${scene.enrichmentModel!}`,
+      );
+      // Deterministic, baseline-free dimensions: 1 delta over 3 turns.
+      expect(scene.enrichedMemoryValue!.stateChange).toBeCloseTo(2 / 3);
+      // The delta is about a place, not the speaker.
+      expect(scene.enrichedMemoryValue!.identity).toBe(0);
+      // Dimensions the scorer cannot measure stay the model's.
+      expect(scene.enrichedMemoryValue!.novelty).toBeCloseTo(0.8);
+      expect(scene.enrichedMemoryValue!.estimatedUtility).toBeCloseTo(0.7);
+      // The composer's deterministic vector is untouched (0118).
+      expect(scene.memoryValue!.scorerVersion).toBe('scene-scorer-v0');
+      expect(scene.memoryValue!.contradiction).toBeUndefined();
+    }
+  });
+
+  it('stamps the expectation snapshot as baselineRef, per user', async () => {
+    const agree = await sceneOf(USER_AGREE);
+    const disagree = await sceneOf(USER_DISAGREE);
+    expect(agree.baselineRef!.baselineVersion).toBe('scene-baseline-v1');
+    expect(agree.baselineRef!.beliefs).toMatchObject([
+      { subject: 'Lisbon', field: 'lease', value: 'signed', revision: 1 },
+    ]);
+    expect(disagree.baselineRef!.beliefs).toMatchObject([
+      { subject: 'Lisbon', field: 'lease', value: 'cancelled', revision: 1 },
+    ]);
+    // A scene never carries another user's belief id.
+    expect(String(agree.baselineRef!.beliefs![0]!.id)).toContain('pred_agree');
+    expect(String(disagree.baselineRef!.beliefs![0]!.id)).toContain('pred_dis');
+  });
+
+  it('re-enrichment with the baseline on is idempotent — zero paid calls', async () => {
+    const mock = mockSceneEnricherOpenAi(f.app, [REPLY]);
+    const res = await enrich();
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ scenes: 2, enriched: 0, failed: 0, skipped: 2 });
+    expect(mock.calls).toHaveLength(0);
+  });
+});

--- a/test/scene-prediction-baseline.unit-spec.ts
+++ b/test/scene-prediction-baseline.unit-spec.ts
@@ -1,0 +1,415 @@
+/**
+ * Unit tests for the scene PREDICTION BASELINE (SCENES_PREDICTION_BASELINE):
+ * the bounded ACTIVE-belief read, subject extraction and caps, the #387
+ * cross-user fence, the prompt block renderer, and the deterministic
+ * prediction-error scorer matrix — including the load-bearing negative:
+ * an unknown baseline yields UNDEFINED contradiction, never a confident 0.
+ * Pure functions plus one scripted db double. No Nest, no network, no
+ * paid calls.
+ */
+import {
+  assembleSceneBaseline,
+  baselineRefPayload,
+  loadActiveBeliefBaseline,
+  normalizeLexical,
+  renderBaselineBlock,
+  sceneBaseline,
+  sceneSelfSubjects,
+  scorePredictionError,
+  BASELINE_MAX_BELIEFS,
+  BASELINE_MAX_SUBJECTS,
+  BASELINE_QUERY_LIMIT,
+  SCENE_BASELINE_VERSION,
+  SCENE_PREDICTION_SCORER_VERSION,
+  type BaselineBelief,
+  type BaselineDb,
+} from '../src/admin/scene-prediction-baseline';
+import type { SceneTurnRow } from '../src/admin/scene-segmentation';
+
+const belief = (
+  subject: string,
+  field: string,
+  value: string,
+  revision = 1,
+  id = `semantic_belief:${subject}_${field}`.replace(/\s+/g, '_'),
+): BaselineBelief => ({ id, subject, field, value, revision });
+
+const turn = (speaker: string, text: string): SceneTurnRow => ({
+  id: `episode:${speaker}_${text.slice(0, 4)}`,
+  speaker,
+  text,
+  occurredAt: '2026-02-01T10:00:00.000Z',
+});
+
+describe('normalizeLexical', () => {
+  it('lowercases, strips punctuation and collapses whitespace', () => {
+    expect(normalizeLexical('  Car   Ownership! ')).toBe('car ownership');
+    expect(normalizeLexical('Mika’s—Car')).toBe('mika s car');
+    expect(normalizeLexical('!!!')).toBe('');
+  });
+
+  it('keeps non-ASCII letters (the substrate is multilingual)', () => {
+    expect(normalizeLexical('Пользователь')).toBe('пользователь');
+  });
+});
+
+describe('sceneSelfSubjects', () => {
+  it('includes the scene userId and non-assistant speakers, never the assistant', () => {
+    const self = sceneSelfSubjects('Mika', [
+      turn('mika', 'I booked the flight.'),
+      turn('proj__assistant', 'Noted.'),
+    ]);
+    expect(self.has('mika')).toBe(true);
+    expect(self.has('proj assistant')).toBe(false);
+    // Documented markers ride along in both languages.
+    expect(self.has('user')).toBe(true);
+    expect(self.has('я')).toBe(true);
+  });
+
+  it('tolerates a fenced-out (null) userId', () => {
+    const self = sceneSelfSubjects(null, [turn('ana', 'hi')]);
+    expect(self.has('ana')).toBe(true);
+  });
+});
+
+describe('assembleSceneBaseline', () => {
+  const transcript = 'mika: I moved to Lisbon last week and Ana came along.';
+
+  it('keeps beliefs the scene is about and drops the rest', () => {
+    const out = assembleSceneBaseline(
+      [
+        belief('mika', 'city', 'Riga'),
+        belief('ana', 'city', 'Riga'),
+        belief('bob', 'city', 'Riga'),
+      ],
+      transcript,
+      sceneSelfSubjects('mika', []),
+    );
+    expect(out.map((b) => b.subject)).toEqual(['ana', 'mika']);
+  });
+
+  it('matches whole phrases only — never a word interior', () => {
+    const out = assembleSceneBaseline(
+      [belief('ana', 'fruit', 'apple')],
+      'mika: I ate a banana today.',
+      sceneSelfSubjects(null, []),
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('keeps a self-subject belief even when the transcript never names it', () => {
+    const out = assembleSceneBaseline(
+      [belief('mika', 'job', 'baker')],
+      'the weather is fine',
+      sceneSelfSubjects('mika', []),
+    );
+    expect(out).toHaveLength(1);
+  });
+
+  it('caps beliefs and subjects, deterministically and repeatably', () => {
+    const many: BaselineBelief[] = [];
+    for (let i = 0; i < BASELINE_MAX_BELIEFS + 10; i++) {
+      many.push(belief('mika', `field${String(i).padStart(3, '0')}`, `v${i}`));
+    }
+    const out = assembleSceneBaseline(many, 'x', sceneSelfSubjects('mika', []));
+    expect(out).toHaveLength(BASELINE_MAX_BELIEFS);
+    // Total order ⇒ the same slice every time, so enrichment is reproducible.
+    expect(assembleSceneBaseline([...many].reverse(), 'x', sceneSelfSubjects('mika', []))).toEqual(
+      out,
+    );
+  });
+
+  it('caps distinct subjects', () => {
+    const subjects: BaselineBelief[] = [];
+    const names: string[] = [];
+    for (let i = 0; i < BASELINE_MAX_SUBJECTS + 5; i++) {
+      const name = `subj${String(i).padStart(3, '0')}`;
+      names.push(name);
+      subjects.push(belief(name, 'f', 'v'));
+    }
+    const out = assembleSceneBaseline(subjects, names.join(' '), sceneSelfSubjects(null, []));
+    expect(new Set(out.map((b) => b.subject)).size).toBe(BASELINE_MAX_SUBJECTS);
+  });
+});
+
+describe('sceneBaseline (#387 cross-user fence)', () => {
+  const beliefsByUser = new Map<string, BaselineBelief[]>([
+    ['u1', [belief('mika', 'city', 'Riga')]],
+    ['u2', [belief('mika', 'city', 'Berlin')]],
+  ]);
+  const transcript = 'mika: I moved to Lisbon.';
+  const turns = [turn('mika', 'I moved to Lisbon.')];
+
+  it('scores a scene against ITS OWN user only', () => {
+    const out = sceneBaseline({
+      scene: { id: 'memory_episode:s1', userId: 'u1', userIds: ['u1'] },
+      turns,
+      transcript,
+      beliefsByUser,
+    });
+    expect(out.userId).toBe('u1');
+    expect(out.beliefs.map((b) => b.value)).toEqual(['Riga']);
+    // The other tenant-user's belief never appears.
+    expect(out.beliefs.some((b) => b.value === 'Berlin')).toBe(false);
+  });
+
+  it.each([
+    ['mixed-user', { userId: 'u1', userIds: ['u1', 'u2'] }],
+    ['tenant-global', { userId: undefined, userIds: [] }],
+    ['legacy (no userIds)', { userId: 'u1', userIds: undefined }],
+    ['disagreeing stamps', { userId: 'u2', userIds: ['u1'] }],
+  ])('gives %s scenes NO baseline at all', (_label, scope) => {
+    const out = sceneBaseline({
+      scene: { id: 'memory_episode:s1', ...scope },
+      turns,
+      transcript,
+      beliefsByUser,
+    });
+    expect(out.userId).toBeNull();
+    expect(out.beliefs).toEqual([]);
+  });
+});
+
+describe('loadActiveBeliefBaseline', () => {
+  const rows = [
+    {
+      id: 'semantic_belief:a',
+      userId: 'u1',
+      subject: 'mika',
+      field: 'city',
+      value: 'Riga',
+      revision: 2,
+    },
+    {
+      id: 'semantic_belief:b',
+      userId: 'u2',
+      subject: 'ana',
+      field: 'city',
+      value: 'Oslo',
+      revision: 1,
+    },
+    { id: 'semantic_belief:c', userId: '', subject: 'x', field: 'y', value: 'z', revision: 1 },
+    { id: 'semantic_belief:d', userId: 'u1', subject: '  ', field: 'y', value: 'z', revision: 1 },
+  ];
+
+  interface Call {
+    sql: string;
+    params: Record<string, unknown> | undefined;
+  }
+
+  function db(): { db: BaselineDb; calls: Call[] } {
+    const calls: Call[] = [];
+    return {
+      calls,
+      db: {
+        query: (async (sql: string, params?: Record<string, unknown>) => {
+          calls.push({ sql, params });
+          return [rows];
+        }) as BaselineDb['query'],
+      },
+    };
+  }
+
+  it('makes ZERO queries for an empty user set', async () => {
+    const { db: d, calls } = db();
+    expect(await loadActiveBeliefBaseline(d, [])).toEqual(new Map());
+    expect(calls).toHaveLength(0);
+  });
+
+  it('reads only ACTIVE rows of the given users, bounded, and buckets them', async () => {
+    const { db: d, calls } = db();
+    const out = await loadActiveBeliefBaseline(d, ['u1', 'u2']);
+    expect(calls).toHaveLength(1);
+    const { sql, params } = calls[0]!;
+    expect(sql).toContain("status = 'active'");
+    expect(sql).toContain('userId INSIDE $userIds');
+    expect(sql).toContain('LIMIT $cap');
+    // A plain SELECT: reads never trip the 3.2.4 DELETE/UPDATE-WHERE trap.
+    expect(sql.trim().startsWith('SELECT')).toBe(true);
+    expect(params!.userIds).toEqual(['u1', 'u2']);
+    expect(params!.cap).toBe(BASELINE_QUERY_LIMIT);
+    expect(out.get('u1')).toEqual([
+      { id: 'semantic_belief:a', subject: 'mika', field: 'city', value: 'Riga', revision: 2 },
+    ]);
+    expect(out.get('u2')).toHaveLength(1);
+    // Rows with a blank userId or blank key column are dropped, not kept
+    // under an empty key where they could leak into a scene's baseline.
+    expect(out.has('')).toBe(false);
+  });
+});
+
+describe('renderBaselineBlock', () => {
+  it('renders an explicit empty marker rather than nothing', () => {
+    const block = renderBaselineBlock([]);
+    expect(block).toContain('Current model of the world');
+    expect(block).toContain('nothing is known');
+  });
+
+  it('renders one line per belief with its revision', () => {
+    const block = renderBaselineBlock([belief('mika', 'city', 'Riga', 3)]);
+    expect(block).toContain('- mika | city = Riga (revision 3)');
+  });
+});
+
+describe('baselineRefPayload', () => {
+  it('is the {beliefs, stampedAt, baselineVersion} snapshot', () => {
+    const payload = baselineRefPayload([belief('mika', 'city', 'Riga')]);
+    expect(payload.baselineVersion).toBe(SCENE_BASELINE_VERSION);
+    expect(typeof payload.stampedAt).toBe('string');
+    expect(payload.beliefs).toEqual([
+      {
+        id: 'semantic_belief:mika_city',
+        subject: 'mika',
+        field: 'city',
+        value: 'Riga',
+        revision: 1,
+      },
+    ]);
+  });
+});
+
+describe('scorePredictionError (deterministic, no model call)', () => {
+  const selfSubjects = sceneSelfSubjects('mika', []);
+  const delta = (subject: string, field: string, to: string, from = '') => ({
+    subject,
+    field,
+    from,
+    to,
+  });
+
+  it('is stamped by its own scorer version', () => {
+    expect(SCENE_PREDICTION_SCORER_VERSION).toBe('scene-scorer-v1');
+  });
+
+  it('scores an AGREEING delta as no contradiction', () => {
+    const out = scorePredictionError({
+      baseline: [belief('mika', 'city', 'Lisbon')],
+      stateDeltas: [delta('mika', 'city', 'Lisbon')],
+      memberTurnCount: 4,
+      selfSubjects,
+    });
+    expect(out.contradiction).toBe(0);
+  });
+
+  it('scores a DISAGREEING delta as full contradiction', () => {
+    const out = scorePredictionError({
+      baseline: [belief('mika', 'city', 'Riga')],
+      stateDeltas: [delta('mika', 'city', 'Lisbon')],
+      memberTurnCount: 4,
+      selfSubjects,
+    });
+    expect(out.contradiction).toBe(1);
+  });
+
+  it('is the FRACTION of matched deltas that disagree', () => {
+    const out = scorePredictionError({
+      baseline: [belief('mika', 'city', 'Riga'), belief('mika', 'job', 'baker')],
+      stateDeltas: [delta('mika', 'city', 'Lisbon'), delta('mika', 'job', 'baker')],
+      memberTurnCount: 4,
+      selfSubjects,
+    });
+    expect(out.contradiction).toBe(0.5);
+  });
+
+  it('compares values string-NORMALIZED (case and punctuation are not disagreement)', () => {
+    const out = scorePredictionError({
+      baseline: [belief('Mika', 'city', 'Lisbon')],
+      stateDeltas: [delta('mika', 'city', ' lisbon! ')],
+      memberTurnCount: 2,
+      selfSubjects,
+    });
+    expect(out.contradiction).toBe(0);
+  });
+
+  it('matches a re-coined field through the belief layer’s own fold rule', () => {
+    const out = scorePredictionError({
+      baseline: [belief('mika', 'car', 'Volvo')],
+      stateDeltas: [delta('mika', 'car ownership', 'Saab')],
+      memberTurnCount: 2,
+      selfSubjects,
+    });
+    expect(out.contradiction).toBe(1);
+  });
+
+  it('refuses to measure an AMBIGUOUS field match (fail-closed)', () => {
+    // Both stored names fold onto the incoming 'car'; fieldsFold is not
+    // transitive, so measuring against either would be a coin flip.
+    const out = scorePredictionError({
+      baseline: [belief('mika', 'car ownership', 'Volvo'), belief('mika', 'car status', 'sold')],
+      stateDeltas: [delta('mika', 'car', 'Saab')],
+      memberTurnCount: 2,
+      selfSubjects,
+    });
+    expect(out.contradiction).toBeUndefined();
+  });
+
+  it('leaves contradiction UNDEFINED with no beliefs — an unknown baseline is not a confident zero', () => {
+    const out = scorePredictionError({
+      baseline: [],
+      stateDeltas: [delta('mika', 'city', 'Lisbon')],
+      memberTurnCount: 4,
+      selfSubjects,
+    });
+    expect(out.contradiction).toBeUndefined();
+    expect(out).not.toHaveProperty('contradiction');
+    // The baseline-free dimensions are still measured.
+    expect(out.stateChange).toBeGreaterThan(0);
+    expect(out.identity).toBe(1);
+  });
+
+  it('leaves contradiction UNDEFINED when no belief matches the delta subject', () => {
+    const out = scorePredictionError({
+      baseline: [belief('ana', 'city', 'Oslo')],
+      stateDeltas: [delta('mika', 'city', 'Lisbon')],
+      memberTurnCount: 4,
+      selfSubjects,
+    });
+    expect(out.contradiction).toBeUndefined();
+  });
+
+  it('measures NOTHING without deltas or turns', () => {
+    expect(
+      scorePredictionError({
+        baseline: [belief('mika', 'city', 'Riga')],
+        stateDeltas: [],
+        memberTurnCount: 4,
+        selfSubjects,
+      }),
+    ).toEqual({});
+    expect(
+      scorePredictionError({
+        baseline: [],
+        stateDeltas: [delta('mika', 'city', 'Lisbon')],
+        memberTurnCount: 0,
+        selfSubjects,
+      }),
+    ).toEqual({});
+  });
+
+  it('saturates stateChange at one delta per two turns', () => {
+    const dense = scorePredictionError({
+      baseline: [],
+      stateDeltas: [delta('a', 'f', 'v'), delta('b', 'f', 'v'), delta('c', 'f', 'v')],
+      memberTurnCount: 3,
+      selfSubjects,
+    });
+    expect(dense.stateChange).toBe(1);
+    const sparse = scorePredictionError({
+      baseline: [],
+      stateDeltas: [delta('a', 'f', 'v')],
+      memberTurnCount: 8,
+      selfSubjects,
+    });
+    expect(sparse.stateChange).toBeCloseTo(0.25);
+  });
+
+  it('scores identity as the share of deltas about the speaker themselves', () => {
+    const out = scorePredictionError({
+      baseline: [],
+      stateDeltas: [delta('mika', 'city', 'Lisbon'), delta('acme corp', 'ceo', 'ana')],
+      memberTurnCount: 4,
+      selfSubjects,
+    });
+    expect(out.identity).toBe(0.5);
+  });
+});


### PR DESCRIPTION
## The gap

The scene plane has **no prediction machinery**. Audited and verified against `origin/main` before building:

| Claim | Verified |
|---|---|
| `memoryValue.contradiction` / `unexpectedDetails` are pure LLM saliency guesses — the enricher is never shown any prior state | `scene-enricher.service.ts` prompt + member fetch + model call: the only user-message content was `Scene transcript:\n…` |
| `baselineRef` (0106, FLEXIBLE) is written ONLY by belief promotion, only on a revision, AFTER the fact | `belief-promotion.service.ts:902` `UPDATE memory_episode SET baselineRef = …`, revision branch only |
| `baselineRef` has zero readers | repo-wide grep: writers + tests only, no `src/` reader |
| `unexpectedDetails` has zero readers | repo-wide grep: written, parsed, never read |
| The roadmap names this hole | `docs/roadmap/memory-research-2026-08.md`: *"The missing edge is PREDICTION as a read-side control signal (surprise currently exists only at write time)."* |

Surprise was **guessed**. This PR makes it **measured**.

## The design

One new default-off flag, `SCENES_PREDICTION_BASELINE` (SCENES_ family — off the ENGINE flag budget by design, verified against `test/flag-budget.unit-spec.ts`'s `ENGINE_PREFIX`), gating three parts of one coherent behavior.

### 1. Expectation snapshot at scoring time

Before enriching, the pass loads the scene user's ACTIVE `semantic_belief` rows (0120) for the subjects the scene is about, and stamps them onto the scene as `baselineRef = {beliefs:[{id,subject,field,value,revision}], stampedAt, baselineVersion}`.

- **One** bounded SELECT per run, reusing the promotion pass's own query shape (`status = 'active' AND userId INSIDE $userIds`) — not a second idiom.
- Subject candidates come from the **scene itself** (belief subject named in the transcript, or a self-subject: the scene's `userId` / its non-assistant speaker labels) — `entityMentions` cannot be used, it does not exist until after the call.
- **No migration.** 0106's FLEXIBLE `baselineRef` carries it.

### 2. Prediction error in the prompt

The snapshot renders as an explicit *"Current model of the world (what the system believed BEFORE this scene)"* block, and a new frozen system prompt (`scene-gist-v2`) redefines `contradiction` and `unexpectedDetails` as **deviation from that model** rather than free-floating saliency. An empty baseline renders an explicit *"nothing is known"* marker — the model is told it knows nothing rather than left to invent a model to deviate from.

### 3. Deterministic prediction-error scorer (`scene-scorer-v1`) — no model call

From the SAME baseline + the scene's `stateDeltas`:

| Dimension | Rule |
|---|---|
| `contradiction` | share of **matched** deltas whose `to` disagrees with the matching belief head value |
| `stateChange` | deltas per member turn, saturating at 0.5 deltas/turn |
| `identity` | share of deltas whose subject is the scene's own user/speaker subject |

Matching reuses the belief layer's own machinery, imported not re-implemented: `resolveFieldFold` for field names (exact short-circuit, one foldable candidate folds, **ambiguity fails closed**) and the same lowercase / strip-punctuation / collapse-whitespace normalization `fieldTokens` applies. No fuzzy distance, no embeddings, no stemming.

**Undefined is not zero.** No deltas, or no belief behind a delta ⇒ the dimension is left `undefined` and the model's guess survives. An unknown baseline is not a confident "no contradiction" — silently zeroing it would be worse than the guess it replaced.

## Where the measured dimensions land, and why

The task asked for these to go into the deterministic `memoryValue`. They cannot, and the reason is structural rather than stylistic:

- `memoryValue` is written by the **composer**, at a point where `stateDeltas` do not exist (they are enrichment-owned per 0118) and no baseline is meaningful (the scene has not been read).
- Migration 0118 declares the composer's `gist` / `memoryValue` **immutable post-compose**; enrichment writes a revision into the `enriched*` siblings.

So the measured dimensions **override the model's guesses inside `enrichedMemoryValue`**, and the vector's `scorerVersion` becomes the composite `scene-scorer-llm-v1+scene-scorer-v1`, naming both producers exactly as the v0 vector's own stamp does for mixed-scorer worlds. The v0 scorer's *"every other dimension stays undefined until a paid scorer exists"* comment is updated to point at the producer that now exists and costs nothing — its code is byte-identical.

## memoryValue dimensions with deterministic producers

| Dimension | Producer before | Producer now (flag on) |
|---|---|---|
| `novelty` | deterministic v0 (centroid distance), composer | unchanged + LLM in the enriched vector |
| `explicitness` | deterministic v0 (first-person markers), composer | unchanged + LLM in the enriched vector |
| **`contradiction`** | LLM guess only | **deterministic `scene-scorer-v1`** (when a belief matches) |
| **`stateChange`** | LLM guess only | **deterministic `scene-scorer-v1`** |
| **`identity`** | LLM guess only | **deterministic `scene-scorer-v1`** |
| `estimatedUtility` | LLM guess only | LLM guess (nothing to measure it against yet) |

Three dimensions moved from guessed to measured; `estimatedUtility` remains the only purely-guessed one.

## Constraints

**Bounded** — 2000 rows per run (`LIMIT`), 20 subjects and 40 beliefs per scene, 200 chars per value; all documented at the constants. Selection comes off a **total order** (subject, field, revision desc, id) so truncation is reproducible — a baseline that shifted under `LIMIT` would make enrichment non-deterministic.

**Fenced** — belief reads run inside `withCompany` (tenant) and are filtered to userIds of scenes that pass the #387 single-user fence (`sceneSingleUser`, **imported** from the belief layer, never re-implemented: a duplicated fence is a fence that drifts). Mixed-user / tenant-global / legacy (pre-0117 `userIds`) scenes get **no baseline at all** rather than a shared one — and contribute no userId, so for a run of only such scenes the belief query is never even issued. Asserted in unit tests (4 scope shapes) and in e2e against a real DB (two users, two beliefs, neither prompt ever contains the other's value).

**3.2.4 discipline** — exactly one plain SELECT (reads never trip the compound-index planner class that makes `DELETE … WHERE` a silent no-op); the only write is the existing primary-key-addressed `UPDATE $scene`, with the `baselineRef` clause **appended** so the flag-off statement stays byte-identical.

**No new migration** — 0106's FLEXIBLE columns carry all of it.

## Off ⇒ byte-identical, pinned

Unit-pinned with the flag off: zero `semantic_belief` queries; the scene SELECT projection string exactly as before (no `userId, userIds`); `SCENE_ENRICHMENT_SYSTEM` verbatim; the user message exactly `Scene transcript:\n…`; the UPDATE ending at `enrichedAt = time::now()` with no `baselineRef`; `scorerVersion` `scene-scorer-llm-v1`; composite `scene-gist-v1|scene-scorer-llm-v1|<model>`.

Flipping the flag changes the composite either way, so the world **re-enriches naturally** instead of hiding a mixed prompt behind one stamp (asserted in e2e).

## Tests

- **`test/scene-prediction-baseline.unit-spec.ts`** (new, 31 tests) — normalization; self-subject extraction (assistant lane excluded); baseline assembly (whole-phrase matching, self-subject inclusion, both caps, order-independence); the bounded read (zero queries on empty input, query shape, bucketing, malformed-row drops); the #387 fence across 4 scope shapes; prompt block rendering; and the scorer matrix — agreeing ⇒ 0, disagreeing ⇒ 1, mixed ⇒ 0.5, case/punctuation not disagreement, re-coined field folds, **ambiguous fold refuses to measure**, **no beliefs / no match ⇒ `undefined`, not 0**, no deltas ⇒ nothing measured, saturation, identity share.
- **`test/scene-enrichment.unit-spec.ts`** (extended) — the byte-identical-off pins above, `mergePredictionError` (only measured dimensions overwritten, unmeasured never zeroed, clamping), the v2 prompt and baseline block, measured override, `baselineRef` payload, revision-column shape unchanged, and the fence at service level including "never reads a different user's beliefs".
- **`test/scene-prediction-baseline.e2e-spec.ts`** (new, real SurrealDB, stubbed model) — **the controlled experiment**: two scenes with *byte-identical transcripts* and the *same stubbed reply* (which guesses `contradiction: 0.42`), belonging to two users whose seeded beliefs differ in exactly one value. Free-floating saliency cannot tell them apart; measured prediction error scores them **0.0 vs 1.0**. Also pins the flag-off world, the re-enrichment a flip triggers, the stamped snapshot per user, cross-user isolation, and idempotent re-runs with zero calls.

No paid API calls anywhere.

## Gates

| Gate | Result |
|---|---|
| `pnpm typecheck` | pass |
| `pnpm test:unit` | 365 suites / **4166 tests** pass (was 364 / 4121) |
| `pnpm lint:ci` | pass (sonarjs cognitive-complexity + max-params clean) |
| `pnpm format:check` | pass |
| e2e (new spec) | 6/6 pass on real SurrealDB 3.2.4 |
| e2e (neighbours: scene-enrichment, belief-promotion, memory-episode, scene-evidence-links) | 4 suites / 23 tests pass |

## Known follow-up (not fixed here)

`baselineRef` now has **two writers**. Belief promotion writes `{belief, revision, value, stampedAt}` — a backpointer to what was displaced — on a revision, for the scenes carrying the winning value. This PR writes `{beliefs[], stampedAt, baselineVersion}` — the expectation snapshot. The shapes are self-describing (`beliefs` array + `baselineVersion` vs a single `belief`), and a promotion run after enrichment replaces the snapshot until the next re-enrichment restores it. Namespacing the two writers under distinct keys belongs in the promotion service, which another agent is concurrently editing — so it is documented in the enricher header rather than done here.

Merge note: this branch imports `sceneSingleUser` and `resolveFieldFold` from the belief layer (read-only, no edits to those files); all new belief-reading logic lives in the new `src/admin/scene-prediction-baseline.ts` to keep the merge trivial against the concurrent state-delta-unification and scheduler work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
