### PR TITLE
feat(scenes): scheduled maintenance, dirty-conversation trigger and scene metrics

### DIFF
--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -46,6 +46,7 @@ import { SegmentComposerService } from './segment-composer.service';
 import { SegmentBackfillService } from './segment-backfill.service';
 import { AdminScenesController } from './admin-scenes.controller';
 import { SceneComposerService } from './scene-composer.service';
+import { SceneMaintenanceService } from './scene-maintenance.service';
 import { SceneEnricherService } from './scene-enricher.service';
 import { SceneBacklinkService } from './scene-backlink.service';
 import { BeliefPromotionService } from './belief-promotion.service';
@@ -129,6 +130,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     SegmentComposerService,
     SegmentBackfillService,
     SceneComposerService,
+    SceneMaintenanceService,
     SceneEnricherService,
     SceneBacklinkService,
     BeliefPromotionService,

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -669,6 +669,42 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Scenes: force a scene boundary once a scene reaches this many turns, regardless of topic continuity. Positive integer; default 40.',
   },
   {
+    key: 'SCENES_SCHEDULED_MAINTENANCE',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneScheduledMaintenanceEnabled) by
+    // the cron entry point and by the ingest dirty-mark seam — never
+    // captured in a constructor — so a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Scheduled scene maintenance (migration 0130): a nightly 04:20 UTC pass runs the scene chain (compose → enrich → backlink → evidence links → beliefs) per tenant over DIRTY conversations only — the ingest seam marks a conversation when turns land, the pass clears the mark after a successful swap, so the run is proportional to what moved instead of the O(all conversations) full rebuild. Bounded by SCENES_MAINTENANCE_MAX_CONVERSATIONS per tenant per run and SCENES_MAINTENANCE_TIME_BUDGET_MS overall, distributed-lease guarded (one pod, never overlapping itself), per-tenant error isolated. Off = the cron returns before a single query, no dirty mark is ever written, the admin routes stay the only trigger — byte-identical prod.',
+  },
+  {
+    key: 'SCENES_MAINTENANCE_MAX_CONVERSATIONS',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneMaintenanceMaxConversations)
+    // once per nightly run — never captured in a constructor —
+    // runtime-mutable.
+    defaultValue: '200',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Scheduled scene maintenance: max DIRTY conversations composed per tenant per nightly run, oldest mark first. The cost fence — the post-swap chain spends ~1 LLM call per NEW scene (SCENES_LLM_ENRICHMENT) and 1 embedding batch per composed conversation (SCENES_TOPIC_BOUNDARY). Unconsumed marks survive to the next run, so a backlog drains across nights. Positive integer; default 200.',
+  },
+  {
+    key: 'SCENES_MAINTENANCE_TIME_BUDGET_MS',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneMaintenanceTimeBudgetMs) once
+    // per nightly run — never captured in a constructor —
+    // runtime-mutable.
+    defaultValue: '1800000',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Scheduled scene maintenance: whole-run wall-clock budget in ms. Once elapsed the pass stops starting NEW tenants (the tenant in flight always finishes — no compose is aborted mid-swap) and the roster resumes next night with the marks intact. Guarantees the pass cannot still be running when the next night’s crons fire. Positive integer; default 1800000 (30 min).',
+  },
+  {
     key: 'SCENES_LLM_ENRICHMENT',
     category: 'scenes',
     // Read at call time (scene-flags.sceneLlmEnrichmentEnabled) by the

--- a/src/admin/scene-composer.service.ts
+++ b/src/admin/scene-composer.service.ts
@@ -15,12 +15,14 @@ import {
 } from '../common/scene-flags';
 import {
   SEGMENTER_VERSION,
-  detectSceneBoundaries,
+  deriveSceneConfidence,
+  detectSceneSegments,
   foldSceneScope,
   meanVector,
   renderSceneGist,
   renderSceneLabel,
   scoreSceneDeterministic,
+  type SceneSegment,
   type SceneSegmenterConfig,
   type SceneTurnRow,
 } from './scene-segmentation';
@@ -59,6 +61,39 @@ export interface SceneRunResult {
   conversations: number;
   scenes: number;
   skipped: Array<{ conversationId: string; reason: string }>;
+  /**
+   * Scenes the post-swap enrichment pass actually re-wrote (the paid leg).
+   * ABSENT unless SCENES_LLM_ENRICHMENT is on and the pass ran to
+   * completion — an additive field, so a flag-off response is unchanged.
+   * Surfaced because the enrichment call count IS the run's model bill and
+   * the scheduled pass has to be able to meter it without reaching past
+   * the composer into the enricher.
+   */
+  enriched?: number;
+}
+
+/**
+ * Which conversations a run covers.
+ *
+ *  - neither key  — the admin full rebuild: enumerate every conversation
+ *    that has episodes (the O(all turns) GROUP BY) and recompose all of
+ *    them. Unchanged since PR1; this is what the operator button does.
+ *  - `conversationId` — the admin targeted rebuild. Also unchanged: the
+ *    same enumeration, filtered down to one id (so a conversation with no
+ *    episodes is genuinely absent from the result rather than counted).
+ *  - `conversationIds` — the SCHEDULED path (SCENES_SCHEDULED_MAINTENANCE):
+ *    the caller has already resolved the exact working set from the dirty
+ *    marks (migration 0130), so the enumeration is SKIPPED entirely and
+ *    these ids are composed directly. This is the whole point of the dirty
+ *    trigger — a nightly pass must be proportional to what moved, not to
+ *    what exists. An EMPTY array composes nothing: the key is present, so
+ *    the working set is known, and it is empty. It deliberately does not
+ *    fall back to the full enumeration — a caller that lost its working set
+ *    must do nothing, not spend a corpus-wide paid rebuild.
+ */
+export interface SceneRunOptions {
+  conversationId?: string;
+  conversationIds?: string[];
 }
 
 @Injectable()
@@ -81,7 +116,7 @@ export class SceneComposerService {
     private readonly versions: SceneVersionService,
   ) {}
 
-  async run(companyId: string, opts: { conversationId?: string } = {}): Promise<SceneRunResult> {
+  async run(companyId: string, opts: SceneRunOptions = {}): Promise<SceneRunResult> {
     const result: SceneRunResult = { conversations: 0, scenes: 0, skipped: [] };
     // Defense in depth: the controller already 404s with the flag off; a
     // programmatic caller must not write shadow rows past a disabled flag.
@@ -102,7 +137,13 @@ export class SceneComposerService {
     });
     try {
       await this.surreal.withCompany(companyId, async (db) => {
-        const convs = await this.episodes.conversationCounts(db);
+        // Scheduled path: the working set arrived already resolved from the
+        // dirty marks, so the O(all turns) enumeration is skipped whole.
+        // Admin paths keep it (and keep filtering it) byte-identically.
+        const convs: Array<{ conversationId: string }> =
+          opts.conversationIds !== undefined
+            ? opts.conversationIds.map((conversationId) => ({ conversationId }))
+            : await this.episodes.conversationCounts(db);
         for (const conv of convs) {
           const conversationId = conv.conversationId;
           // Targeted rebuild: one conversation should not force a full
@@ -145,9 +186,20 @@ export class SceneComposerService {
     // degrade-never-fail: the swap has landed and its result must not be
     // retracted by an optional pass. The enricher/backlinker re-check
     // their own flags too — these outer guards just skip the no-op calls.
+    //
+    // The three passes take a SINGLE optional conversationId, so the
+    // scheduled multi-conversation working set narrows to nothing here and
+    // they run over the whole current scene world. That is correct AND
+    // cheap: all three are idempotent (the enricher skips scenes already at
+    // the current enrichmentVersion composite, the backlinker unions, the
+    // linker INSERT-RELATION-IGNOREs), so the paid work is bounded by the
+    // scenes this run actually changed, not by the size of the world.
+    const passOpts =
+      opts.conversationId !== undefined ? { conversationId: opts.conversationId } : {};
     if (sceneLlmEnrichmentEnabled()) {
       try {
-        const enrich = await this.enricher.enrich(companyId, opts);
+        const enrich = await this.enricher.enrich(companyId, passOpts);
+        result.enriched = enrich.enriched;
         this.logger.log(
           `scene enrichment pass: ${enrich.enriched}/${enrich.scenes} enriched, ` +
             `${enrich.failed} degraded, ${enrich.skipped} already current`,
@@ -158,14 +210,14 @@ export class SceneComposerService {
     }
     if (sceneFactBacklinkEnabled()) {
       try {
-        await this.backlinker.run(companyId, opts);
+        await this.backlinker.run(companyId, passOpts);
       } catch (e) {
         this.logger.warn(`scene backlink pass failed: ${(e as Error).message}`);
       }
     }
     if (sceneEvidenceLinksEnabled()) {
       try {
-        await this.evidenceLinker.run(companyId, opts);
+        await this.evidenceLinker.run(companyId, passOpts);
       } catch (e) {
         this.logger.warn(`scene evidence links pass failed: ${(e as Error).message}`);
       }
@@ -245,14 +297,16 @@ export class SceneComposerService {
     // within-session detector. Sessions partition `turns` in order, so a
     // running offset maps each session onto its embedding slice.
     const boundaryOpts = { minCosine: cfg.minCosine, maxTurns: cfg.maxTurns };
-    const scenes: SceneTurnRow[][] = [];
+    // Segments, not bare turn arrays: each one remembers which rule made
+    // its two edges, which is the input to the confidence derivation below.
+    const segments: Array<SceneSegment<SceneTurnRow>> = [];
     let offset = 0;
     for (const session of segmentSessions(turns) as SceneTurnRow[][]) {
       const sessionVecs = vectors?.slice(offset, offset + session.length);
       offset += session.length;
-      scenes.push(...detectSceneBoundaries(session, sessionVecs, boundaryOpts));
+      segments.push(...detectSceneSegments(session, sessionVecs, boundaryOpts));
     }
-    if (scenes.length === 0) return;
+    if (segments.length === 0) return;
 
     // Build scene + member rows. Scene record ids are deterministic over
     // (conversation, segmenterVersion, index) so a rebuild replaces the
@@ -263,7 +317,8 @@ export class SceneComposerService {
     const sceneRows: Array<Record<string, unknown>> = [];
     const memberRows: Array<Record<string, unknown>> = [];
     let sceneOffset = 0;
-    for (const [index, scene] of scenes.entries()) {
+    for (const [index, segment] of segments.entries()) {
+      const scene = segment.turns;
       const sceneVecs = (vectors?.slice(sceneOffset, sceneOffset + scene.length) ?? []).filter(
         (v): v is number[] => Array.isArray(v),
       );
@@ -295,10 +350,17 @@ export class SceneComposerService {
         occurredTo: new Date(last.occurredAt as string),
         gist: renderSceneGist(scene),
         memoryValue,
-        // The deterministic segmenter is exact about its own rule — the
-        // knob for "how sure was the boundary model" arrives with a
-        // learned segmenter.
-        confidence: 1,
+        // Derived from the two edges that delimit this scene (see
+        // deriveSceneConfidence): an EXACT rule — the 60-minute session
+        // gap or the SCENES_MAX_TURNS cap — is certain and stays 1;
+        // a topic-cosine edge scores by how far the cosine fell below
+        // the floor, so a barely-cleared split stops claiming certainty.
+        // With SCENES_TOPIC_BOUNDARY off no cosine edge can exist, so
+        // every scene is 1 — byte-identical to the constant it replaces.
+        confidence: deriveSceneConfidence(segment, {
+          minCosine: cfg.minCosine,
+          topicBoundary: cfg.topicBoundary,
+        }),
         segmenterVersion: version,
         generation,
         source: { recorder: SCENE_RECORDER },

--- a/src/admin/scene-maintenance.service.ts
+++ b/src/admin/scene-maintenance.service.ts
@@ -1,0 +1,343 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ApiKeyService } from '../auth/api-key.service';
+import { SurrealService } from '../db/surreal.service';
+import { MetricsService } from '../metrics/metrics.service';
+import { DistributedLeaseGuard } from '../common/distributed-lease.guard';
+import { InFlightGuard } from '../common/in-flight-guard';
+import {
+  clearDirtyConversations,
+  selectDirtyConversations,
+  type DirtyConversationRow,
+} from '../common/scene-dirty';
+import {
+  sceneBeliefPromotionEnabled,
+  sceneMaintenanceMaxConversations,
+  sceneMaintenanceTimeBudgetMs,
+  sceneScheduledMaintenanceEnabled,
+  sceneSegmentationEnabled,
+} from '../common/scene-flags';
+import { SceneComposerService } from './scene-composer.service';
+import { BeliefPromotionService } from './belief-promotion.service';
+
+/** One tenant's slice of a nightly run. */
+export interface SceneMaintenanceTenantResult {
+  companyId: string;
+  /** Dirty conversations the budget admitted (0 ⇒ nothing had moved). */
+  dirty: number;
+  conversations: number;
+  scenes: number;
+  /** Scenes the LLM enrichment leg re-wrote — the run's paid work. */
+  enriched: number;
+  /** semantic_belief upserts (created + revised + corroborated). */
+  beliefs: number;
+  /** Marks retired; < dirty when turns landed DURING the pass. */
+  cleared: number;
+  durationSeconds: number;
+  error?: string;
+}
+
+/** Whole-roster summary — the cron's return value and the log line. */
+export interface SceneMaintenanceRunResult {
+  tenants: SceneMaintenanceTenantResult[];
+  /** True when the wall-clock budget stopped the roster walk early. */
+  budgetExhausted: boolean;
+  /** Tenants never started because the budget ran out. */
+  skippedForBudget: number;
+}
+
+/** Lock key for both the local and the distributed guard. */
+const LOCK_KEY = 'scene_maintenance_all';
+
+/**
+ * Lease TTL for the distributed guard. Matches the DEFAULT whole-run
+ * wall-clock budget (30 min) rather than the guard's own 5-minute default:
+ * a lease shorter than the body it protects expires mid-run and lets a
+ * second pod start a parallel pass over the same dirty rows — two composers
+ * swapping the same (conversation × segmenterVersion) id-space, plus double
+ * enrichment spend. Deliberately NOT derived from
+ * SCENES_MAINTENANCE_TIME_BUDGET_MS: an operator who raises that knob past
+ * this TTL should see the overlap warning and raise the deployment's pod
+ * count expectations consciously, not have a lease silently follow a knob.
+ */
+const LEASE_TTL_SECONDS = 30 * 60;
+
+const EMPTY_RUN: SceneMaintenanceRunResult = {
+  tenants: [],
+  budgetExhausted: false,
+  skippedForBudget: 0,
+};
+
+/**
+ * SceneMaintenanceService — the missing SCHEDULER for the scene plane.
+ *
+ * THE HOLE THIS CLOSES. Every other nightly derivation owns a cron:
+ * recompose 03:05, compaction 03:17, memory quality 03:35, outcome prune
+ * 03:41, calibration refit 03:42/03:51, candidate sweeper 03:45, strategy
+ * distill 03:52, dreams 04:00. Scenes owned none. `SceneComposerService.run`
+ * had exactly one caller — the admin controller — so with all eight SCENES_*
+ * flags on in production, scenes (and therefore the BELIEFS promoted out of
+ * them, which the serving lane reads) existed only for conversations a human
+ * had curled. This service runs the chain on a schedule, per tenant:
+ *
+ *     dirty page → compose → [enrich → backlink → evidence links, inside the
+ *     composer's post-swap chain] → belief promotion → clear the marks
+ *
+ * CRON SLOT — 04:20 UTC. Every :0x–:5x minute of the 03:00 hour is spoken
+ * for (see the list above), and 04:00 is dreams. 04:20 is the first free
+ * slot AFTER dreams has had its full worker lease (dreams enqueues per-tenant
+ * jobs with ttlSeconds 1200 = 20 min), which matters for more than tidiness:
+ * dreams and scene enrichment are the two LLM-heavy nightly passes, and
+ * overlapping them would have them bid against each other for the same
+ * rate limit on the same key. It is also clear of the hourly registry mirror
+ * (:26). The pass reads a substrate that compaction and dreams have already
+ * settled — the same reasoning that put dreams 43 minutes after compaction.
+ *
+ * BUDGETS ARE NOT OPTIONAL. Composing a conversation costs one embedding
+ * batch when SCENES_TOPIC_BOUNDARY is on, and the post-swap enrichment
+ * spends ONE structured LLM call per NEW scene. An unbounded roster walk
+ * therefore has an unbounded model bill and an unbounded runtime, and one
+ * large tenant could consume the entire night. Two fences:
+ *   * SCENES_MAINTENANCE_MAX_CONVERSATIONS (default 200) caps the dirty
+ *     page per tenant per run, oldest mark first, so a backlog drains in
+ *     arrival order across nights instead of starving old conversations;
+ *   * SCENES_MAINTENANCE_TIME_BUDGET_MS (default 30 min) stops the roster
+ *     from STARTING new tenants once elapsed. It never aborts a tenant
+ *     mid-flight: interrupting a compose between the paid step and the swap
+ *     is exactly the failure mode the composer's ordering exists to avoid.
+ * Nothing is lost when a budget bites — unconsumed marks are still there
+ * tomorrow, and the tenants that were skipped are counted, not forgotten.
+ *
+ * ISOLATION. One tenant's failure is caught, counted and logged; the roster
+ * continues (the dreams fan-out rule). One tenant's marks are cleared only
+ * for conversations whose swap did NOT report a skip, so a partial failure
+ * re-composes exactly the failed conversations next night.
+ *
+ * OVERLAP. Guarded by the distributed lease (one pod runs it, and never
+ * concurrently with itself) with a local InFlightGuard as the fallback when
+ * JobsModule is not wired — a 30-minute pass and a daily cron leave plenty
+ * of room for a slow night to still be running at the next firing.
+ *
+ * Default off (SCENES_SCHEDULED_MAINTENANCE): the cron returns before a
+ * single query and no mark is ever written — byte-identical prod.
+ */
+@Injectable()
+export class SceneMaintenanceService {
+  private readonly logger = new Logger(SceneMaintenanceService.name);
+  /**
+   * Fallback reentrancy guard for the no-DI paths (positional unit tests,
+   * a deployment without JobsModule). DistributedLeaseGuard carries its own
+   * local guard, so exactly one of the two is ever consulted.
+   */
+  private readonly local = new InFlightGuard();
+
+  // eslint-disable-next-line max-params
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly apiKeys: ApiKeyService,
+    private readonly composer: SceneComposerService,
+    private readonly beliefs: BeliefPromotionService,
+    // @Optional throughout for the positional unit tests (no DI). In
+    // production MetricsModule and JobsModule are both @Global.
+    @Optional() private readonly metrics?: MetricsService,
+    @Optional() private readonly guard?: DistributedLeaseGuard,
+  ) {}
+
+  /**
+   * Cron entry — daily at 04:20 UTC (slot rationale in the class docblock).
+   *
+   * Returns the run summary so a caller (tests, a future admin trigger) can
+   * see what happened; the @nestjs/schedule loop ignores it.
+   */
+  @Cron('20 4 * * *', { timeZone: 'UTC' })
+  async runNightly(): Promise<SceneMaintenanceRunResult> {
+    // Double gate: the master flag decides whether scenes exist at all, the
+    // maintenance flag whether they are built on a schedule. Read at call
+    // time so both are runtime-mutable, and checked BEFORE the guard so a
+    // disabled pass never even touches the lease table.
+    if (!sceneSegmentationEnabled() || !sceneScheduledMaintenanceEnabled()) return EMPTY_RUN;
+    const run = this.guard
+      ? await this.guard.run(LOCK_KEY, () => this.runAll(), LEASE_TTL_SECONDS)
+      : await this.local.run(LOCK_KEY, () => this.runAll());
+    if (run === null) {
+      // The guard's null is "someone else has it" — either the previous
+      // night's pass is still going on this pod or another pod holds the
+      // lease. Never an error: skipping is the correct outcome.
+      this.logger.warn('scene maintenance skipped — a previous run is still in flight');
+      return EMPTY_RUN;
+    }
+    return run;
+  }
+
+  /**
+   * Walk the tenant roster under the wall-clock budget. Public so tests and
+   * future manual triggers can invoke the body without the guard; the flag
+   * check lives in the cron entry, and the composer/promotion services both
+   * re-check their own flags, so an unguarded call cannot write past a
+   * disabled surface.
+   */
+  async runAll(): Promise<SceneMaintenanceRunResult> {
+    const startedAt = Date.now();
+    const deadline = startedAt + sceneMaintenanceTimeBudgetMs();
+    const maxConversations = sceneMaintenanceMaxConversations();
+    const roster = this.apiKeys.knownCompanyIds();
+    const result: SceneMaintenanceRunResult = {
+      tenants: [],
+      budgetExhausted: false,
+      skippedForBudget: 0,
+    };
+    for (const companyId of roster) {
+      if (Date.now() >= deadline) {
+        // Budget bite: count what we did not start rather than silently
+        // dropping it. The marks survive; tomorrow's run picks them up.
+        result.budgetExhausted = true;
+        result.skippedForBudget += 1;
+        this.metrics?.countSceneMaintenance('skipped_budget');
+        continue;
+      }
+      const tenantStart = Date.now();
+      try {
+        const tenant = await this.runTenant(companyId, maxConversations);
+        result.tenants.push(tenant);
+      } catch (e) {
+        // Per-tenant isolation (the dreams fan-out rule): a Surreal hiccup
+        // or a composer throw on tenant N must not cost tenant N+1 its
+        // night. The tenant keeps its marks and retries tomorrow.
+        const message = (e as Error).message;
+        this.logger.warn(`scene maintenance failed for ${companyId}: ${message}`);
+        this.metrics?.countSceneMaintenance('failed');
+        this.metrics?.observeSceneMaintenanceDuration((Date.now() - tenantStart) / 1000);
+        result.tenants.push({
+          companyId,
+          dirty: 0,
+          conversations: 0,
+          scenes: 0,
+          enriched: 0,
+          beliefs: 0,
+          cleared: 0,
+          durationSeconds: (Date.now() - tenantStart) / 1000,
+          error: message,
+        });
+      }
+    }
+    const scenes = result.tenants.reduce((n, t) => n + t.scenes, 0);
+    this.logger.log(
+      `scene maintenance: ${result.tenants.length}/${roster.length} tenant(s), ` +
+        `${scenes} scene(s), ${result.skippedForBudget} skipped for budget, ` +
+        `${((Date.now() - startedAt) / 1000).toFixed(1)}s`,
+    );
+    return result;
+  }
+
+  /**
+   * One tenant: read the dirty page, compose exactly it, promote beliefs,
+   * clear the marks it consumed.
+   *
+   * `readAt` is captured BEFORE the dirty read on purpose — it is the race
+   * fence handed to `clearDirtyConversations`. A turn arriving during the
+   * (long, paid) compose bumps its mark past this instant, the mark survives
+   * the clear, and that conversation recomposes tomorrow. Never the reverse.
+   */
+  async runTenant(
+    companyId: string,
+    maxConversations: number,
+  ): Promise<SceneMaintenanceTenantResult> {
+    const startedAt = Date.now();
+    const readAt = new Date();
+    const dirty = await this.surreal.withCompany(companyId, (db) =>
+      selectDirtyConversations(db, maxConversations),
+    );
+    if (dirty.length === 0) {
+      // The steady state on a quiet tenant, and the series that proves the
+      // trigger works end to end: marks are being written AND cleared.
+      this.metrics?.countSceneMaintenance('skipped_no_dirty');
+      this.metrics?.observeSceneMaintenanceDuration((Date.now() - startedAt) / 1000);
+      return {
+        companyId,
+        dirty: 0,
+        conversations: 0,
+        scenes: 0,
+        enriched: 0,
+        beliefs: 0,
+        cleared: 0,
+        durationSeconds: (Date.now() - startedAt) / 1000,
+      };
+    }
+
+    // ONE composer call for the whole page — the composer's conversationIds
+    // path skips its O(all turns) enumeration entirely, and the post-swap
+    // enrich/backlink/evidence-link chain runs once instead of per
+    // conversation. Calling it per conversation would re-run that chain N
+    // times for no extra output.
+    const composed = await this.composer.run(companyId, {
+      conversationIds: dirty.map((d) => d.conversationId),
+    });
+
+    // Beliefs are the reason any of this is user-visible (the serving lane
+    // reads semantic_belief), so the promotion leg runs every pass — but it
+    // degrades, never fails: the scene swap has already landed and must not
+    // be retracted by a failing optional pass. Same doctrine as the
+    // composer's own post-swap chain.
+    let beliefs = 0;
+    if (sceneBeliefPromotionEnabled()) {
+      try {
+        const promoted = await this.beliefs.run(companyId, {});
+        beliefs = promoted.beliefsCreated + promoted.beliefsRevised + promoted.beliefsCorroborated;
+      } catch (e) {
+        this.logger.warn(`belief promotion failed for ${companyId}: ${(e as Error).message}`);
+      }
+    }
+
+    const cleared = await this.clearConsumed({
+      companyId,
+      dirty,
+      skipped: composed.skipped,
+      readAt,
+    });
+    const durationSeconds = (Date.now() - startedAt) / 1000;
+    const enriched = composed.enriched ?? 0;
+    this.metrics?.countSceneMaintenance('ok');
+    this.metrics?.observeSceneMaintenanceDuration(durationSeconds);
+    this.metrics?.countSceneMaintenanceEmitted('conversation', composed.conversations);
+    this.metrics?.countSceneMaintenanceEmitted('scene', composed.scenes);
+    this.metrics?.countSceneMaintenanceEmitted('enriched', enriched);
+    this.metrics?.countSceneMaintenanceEmitted('belief', beliefs);
+    this.metrics?.countSceneMaintenanceEmitted('dirty_cleared', cleared);
+    this.logger.log(
+      `scene maintenance ${companyId}: ${dirty.length} dirty, ` +
+        `${composed.conversations} composed, ${composed.scenes} scene(s), ` +
+        `${enriched} enriched, ${beliefs} belief(s), ${cleared} mark(s) cleared, ` +
+        `${durationSeconds.toFixed(1)}s`,
+    );
+    return {
+      companyId,
+      dirty: dirty.length,
+      conversations: composed.conversations,
+      scenes: composed.scenes,
+      enriched,
+      beliefs,
+      cleared,
+      durationSeconds,
+    };
+  }
+
+  /**
+   * Retire the marks for conversations whose swap did NOT report a skip. A
+   * conversation the composer skipped keeps its mark and is retried on the
+   * next pass — the composer's per-conversation try/catch already isolates
+   * it, so the ONLY thing that would make the failure permanent is clearing
+   * its mark here.
+   */
+  private async clearConsumed(args: {
+    companyId: string;
+    dirty: DirtyConversationRow[];
+    skipped: Array<{ conversationId: string }>;
+    readAt: Date;
+  }): Promise<number> {
+    const { companyId, dirty, skipped, readAt } = args;
+    const failed = new Set(skipped.map((s) => s.conversationId));
+    const ids = dirty.filter((d) => !failed.has(d.conversationId)).map((d) => d.id);
+    if (ids.length === 0) return 0;
+    return this.surreal.withCompany(companyId, (db) => clearDirtyConversations(db, ids, readAt));
+  }
+}

--- a/src/admin/scene-segmentation.ts
+++ b/src/admin/scene-segmentation.ts
@@ -55,7 +55,42 @@ export function meanVector(vectors: number[][]): number[] {
 }
 
 /**
- * Pure: split ONE session's time-ordered turns into scenes.
+ * How ONE scene edge came to be. Two families, and the distinction is the
+ * whole point of the confidence derivation below:
+ *
+ *  - 'session'   — the session gap (or the conversation's own start/end).
+ *                  Sessions are pre-split upstream by segmentSessions, so
+ *                  every scene at a session edge inherits that exact rule.
+ *  - 'max-turns' — the SCENES_MAX_TURNS cap fired. Also an exact rule: the
+ *                  scene reached N turns, which is not a judgement call.
+ *  - 'topic-cosine' — the embedding-based within-session split fired, i.e.
+ *                  cosine(mean of the trailing turns, next turn) fell below
+ *                  the floor. The ONLY inexact edge the segmenter can make,
+ *                  and it carries the cosine that fired it.
+ */
+export type SceneBoundaryKind = 'session' | 'max-turns' | 'topic-cosine';
+
+export interface SceneBoundary {
+  kind: SceneBoundaryKind;
+  /** The cosine that fired a 'topic-cosine' split; absent for exact rules. */
+  cosine?: number;
+}
+
+/** One scene plus the two edges that delimit it. */
+export interface SceneSegment<T extends SceneTurnRow> {
+  turns: T[];
+  startBoundary: SceneBoundary;
+  endBoundary: SceneBoundary;
+}
+
+const SESSION_BOUNDARY: SceneBoundary = { kind: 'session' };
+
+/**
+ * Pure: split ONE session's time-ordered turns into scenes, KEEPING the
+ * rule that made each edge (the confidence input — see
+ * `deriveSceneConfidence`). `detectSceneBoundaries` is the turns-only
+ * projection of this function and stays the shape every existing caller
+ * uses; the segmentation itself is byte-identical between the two.
  *
  *  - Without embeddings: a single scene, force-split at maxTurns — the
  *    session gap (handled upstream by segmentSessions) is the only
@@ -66,20 +101,22 @@ export function meanVector(vectors: number[][]): number[] {
  *    never leaving a scene shorter than MIN_SCENE_TURNS.
  *  - Always force-split at maxTurns, embeddings or not.
  */
-export function detectSceneBoundaries<T extends SceneTurnRow>(
+export function detectSceneSegments<T extends SceneTurnRow>(
   sessionTurns: T[],
   embeddings: Array<number[] | undefined> | undefined,
   opts: SceneBoundaryOpts,
-): T[][] {
+): Array<SceneSegment<T>> {
   if (sessionTurns.length === 0) return [];
   const maxTurns = Math.max(1, Math.floor(opts.maxTurns));
-  const scenes: T[][] = [];
+  const segments: Array<SceneSegment<T>> = [];
   let current: T[] = [sessionTurns[0]!];
   let currentStart = 0;
+  // The first scene of a session begins at the session edge by construction.
+  let startBoundary: SceneBoundary = SESSION_BOUNDARY;
   for (let i = 1; i < sessionTurns.length; i++) {
-    let boundary = false;
+    let boundary: SceneBoundary | undefined;
     if (current.length >= maxTurns) {
-      boundary = true;
+      boundary = { kind: 'max-turns' };
     } else if (embeddings && current.length >= MIN_SCENE_TURNS) {
       const tailFrom = Math.max(currentStart, i - TOPIC_TAIL_TURNS);
       const tail: number[][] = [];
@@ -89,18 +126,85 @@ export function detectSceneBoundaries<T extends SceneTurnRow>(
       }
       const next = embeddings[i];
       if (tail.length > 0 && next) {
-        boundary = cosineSimilarity(meanVector(tail), next) < opts.minCosine;
+        const cosine = cosineSimilarity(meanVector(tail), next);
+        if (cosine < opts.minCosine) boundary = { kind: 'topic-cosine', cosine };
       }
     }
     if (boundary) {
-      scenes.push(current);
+      // One edge, two scenes: it ends the current scene and starts the next.
+      segments.push({ turns: current, startBoundary, endBoundary: boundary });
+      startBoundary = boundary;
       current = [];
       currentStart = i;
     }
     current.push(sessionTurns[i]!);
   }
-  scenes.push(current);
-  return scenes;
+  segments.push({ turns: current, startBoundary, endBoundary: SESSION_BOUNDARY });
+  return segments;
+}
+
+/** Pure: `detectSceneSegments` without the edge provenance. */
+export function detectSceneBoundaries<T extends SceneTurnRow>(
+  sessionTurns: T[],
+  embeddings: Array<number[] | undefined> | undefined,
+  opts: SceneBoundaryOpts,
+): T[][] {
+  return detectSceneSegments(sessionTurns, embeddings, opts).map((s) => s.turns);
+}
+
+/**
+ * Pure: how sure the segmenter is about ONE edge, in [0.5, 1].
+ *
+ * CASE 1 — an EXACT rule made it ('session', 'max-turns'): confidence 1.
+ * This is not optimism, it is arithmetic. "The gap between these turns
+ * exceeded 60 minutes" and "this scene reached SCENES_MAX_TURNS turns" are
+ * propositions the segmenter evaluates with certainty; there is no model in
+ * the loop to be unsure about. A number below 1 there would be a made-up
+ * discount on a decision that cannot be wrong on its own terms.
+ *
+ * CASE 2 — the topic-cosine split made it: the edge exists because the
+ * cosine fell BELOW the floor, so how far below is exactly how strong the
+ * evidence was. The margin is `minCosine - cosine`, and the widest margin
+ * the test can ever produce is `minCosine - (-1)`; the ratio is mapped onto
+ * [0.5, 1]:
+ *
+ *     confidence = 0.5 + 0.5 · (minCosine − cosine) / (minCosine + 1)
+ *
+ * A split that barely cleared the floor lands at ~0.5 — the boundary is a
+ * coin-flip and the row now says so. A split between genuinely opposed
+ * turns approaches 1. The floor of 0.5 is deliberate: the rule DID fire, so
+ * the edge is never evidence AGAINST itself.
+ */
+export function boundaryConfidence(boundary: SceneBoundary, minCosine: number): number {
+  if (boundary.kind !== 'topic-cosine' || boundary.cosine === undefined) return 1;
+  const span = minCosine + 1;
+  // Unreachable in practice (cosine ≥ -1 can never fall below a -1 floor),
+  // but a zero-width span must not produce a division by zero.
+  if (span <= 0) return 1;
+  const derived = 0.5 + (0.5 * (minCosine - boundary.cosine)) / span;
+  return Math.min(1, Math.max(0.5, derived));
+}
+
+/**
+ * Pure: the scene's own confidence — the WEAKER of its two edges, because a
+ * scene is only as well-delimited as its shakiest boundary.
+ *
+ * With SCENES_TOPIC_BOUNDARY off no cosine edge can exist (no embedding is
+ * ever taken), so every scene is delimited by session gaps and the turn cap
+ * alone and this returns exactly 1 for all of them — byte-identical to the
+ * hardcoded `confidence: 1` the composer wrote before the derivation
+ * existed. With the boundary on, only scenes that an actual cosine split
+ * touched move off 1.
+ */
+export function deriveSceneConfidence<T extends SceneTurnRow>(
+  segment: SceneSegment<T>,
+  opts: { minCosine: number; topicBoundary: boolean },
+): number {
+  if (!opts.topicBoundary) return 1;
+  return Math.min(
+    boundaryConfidence(segment.startBoundary, opts.minCosine),
+    boundaryConfidence(segment.endBoundary, opts.minCosine),
+  );
 }
 
 /**

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -247,6 +247,11 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   floatInRange(env, 'SCENES_TOPIC_MIN_COSINE', -1, 1, errors);
   // Belief promotion floor (Belief-A, migration 0120): 0 = off.
   nonNegativeInt(env, 'SCENES_BELIEF_MIN_SCENES', errors);
+  // Scheduled maintenance budgets (migration 0130): the nightly pass
+  // clamps bad values to defaults at read time; boot validation catches
+  // the typo before an unbounded-looking knob silently reads as 200/30min.
+  positiveInt(env, 'SCENES_MAINTENANCE_MAX_CONVERSATIONS', errors);
+  positiveInt(env, 'SCENES_MAINTENANCE_TIME_BUDGET_MS', errors);
 
   // ── Evidence substrate (Brain v2.1 M1, migration 0109) ─────────────
   // The write seam clamps bad values to the default at read time; boot
@@ -1025,6 +1030,16 @@ const KNOWN_BOOLEAN_FLAGS = [
   // segmenter is session-gap + max-turns only (embedder-free). The
   // cosine floor (SCENES_TOPIC_MIN_COSINE) is a float, not a boolean.
   'SCENES_TOPIC_BOUNDARY',
+  // Scheduled scene maintenance (migration 0130): the nightly 04:20 UTC
+  // cron that runs the scene chain (compose → enrich → backlink →
+  // evidence links → beliefs) over the DIRTY conversations of every
+  // tenant, plus the ingest-side dirty mark that feeds it. Default off ⇒
+  // the cron returns before a single query and NO scene_dirty_conversation
+  // row is ever written — byte-identical prod; the admin routes are the
+  // only trigger, exactly as before. The budgets
+  // (SCENES_MAINTENANCE_MAX_CONVERSATIONS, _TIME_BUDGET_MS) are ints, not
+  // booleans.
+  'SCENES_SCHEDULED_MAINTENANCE',
   // Scenes LLM enrichment (Brain v2 PR2): the optional post-swap pass —
   // ONE structured LLM call per scene replacing the deterministic gist
   // with an abstractive one and filling the full memoryValue vector +

--- a/src/common/scene-dirty.ts
+++ b/src/common/scene-dirty.ts
@@ -1,0 +1,106 @@
+/**
+ * Dirty-conversation trigger for the scheduled scene-maintenance pass
+ * (migration 0130, SCENES_SCHEDULED_MAINTENANCE).
+ *
+ * Three plain SQL verbs over `scene_dirty_conversation`, deliberately NOT a
+ * Nest provider: the MARK side lives in the ingest hot path
+ * (EpisodeStoreService, src/ingest) and the READ/CLEAR side in the admin
+ * scheduler (src/admin) — a shared injectable would force one of those two
+ * module trees to import the other. This module has no DI, no env reads and
+ * no logging; it takes an already-scoped connection (the caller is inside
+ * `surreal.withCompany`, so the tenant fence is the caller's) and returns
+ * plain values. Flag gating is the CALLER's job too — see the docblocks.
+ *
+ * SurrealDB 3.2.4 discipline: every statement here addresses rows by
+ * PRIMARY KEY — the mark is an UPSERT on the array-literal record id, the
+ * clear is a SELECT-ids → DELETE-by-id-list pair. No UPDATE or DELETE in
+ * this file filters on a secondary or compound index, which is the shape
+ * that silently matches nothing on the pinned server (0093 header /
+ * scene-composer swap comment).
+ */
+
+/** The one connection surface these verbs need (mock-swappable in tests). */
+export interface SceneDirtyDb {
+  query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T>;
+}
+
+/** One pending conversation as read back by the scheduled pass. */
+export interface DirtyConversationRow {
+  /** Record id — passed straight back to the clear, never parsed. */
+  id: unknown;
+  conversationId: string;
+  /** Bump instant; the clear's race fence compares against it server-side. */
+  markedAt?: unknown;
+}
+
+/**
+ * Mark ONE conversation as needing a scene rebuild. Called from the ingest
+ * seam for every captured turn, so it must stay a single round trip with no
+ * read-modify-write: UPSERT on the array-literal primary key collapses a
+ * burst of turns on one conversation onto one row, and `createdAt` keeps
+ * its DEFAULT (first-marked instant) because the SET never restates it.
+ *
+ * The CALLER decides whether marking happens at all — this function does no
+ * flag check. With SCENES_SCHEDULED_MAINTENANCE (or the scenes master flag)
+ * off, the seam must not call it, and no row is ever written.
+ */
+export async function markConversationDirty(
+  db: SceneDirtyDb,
+  conversationId: string,
+): Promise<void> {
+  await db.query(
+    `UPSERT scene_dirty_conversation:[$conv]
+       SET conversationId = $conv, markedAt = time::now()`,
+    { conv: conversationId },
+  );
+}
+
+/**
+ * Read a BOUNDED page of pending conversations, oldest mark first — the
+ * budget fence of the nightly pass. Oldest-first matters: a tenant whose
+ * backlog exceeds the per-run cap drains in arrival order across successive
+ * nights instead of starving its oldest conversations behind a busy one.
+ */
+export async function selectDirtyConversations(
+  db: SceneDirtyDb,
+  limit: number,
+): Promise<DirtyConversationRow[]> {
+  if (limit <= 0) return [];
+  const [rows] = await db.query<[DirtyConversationRow[]]>(
+    `SELECT id, conversationId, markedAt FROM scene_dirty_conversation
+      ORDER BY markedAt ASC LIMIT $limit`,
+    { limit: Math.floor(limit) },
+  );
+  return (rows ?? []).filter((r) => typeof r.conversationId === 'string');
+}
+
+/**
+ * Clear the marks the pass actually consumed, and ONLY those.
+ *
+ * `readAt` must be an instant captured BEFORE the dirty page was selected.
+ * A turn that lands while the (potentially long, LLM-spending) compose runs
+ * bumps `markedAt` past that instant, so its row fails the fence, survives
+ * the delete, and the conversation is recomposed on the next pass. The
+ * asymmetry is deliberate: a redundant recompose is cheap and idempotent, a
+ * dropped turn would be invisible until someone diffed the scene world.
+ *
+ * Two steps rather than one `DELETE … WHERE`: the id list is resolved by a
+ * SELECT and the delete then addresses primary keys only (the LET-select-ids
+ * idiom). Returns how many marks were actually cleared.
+ */
+export async function clearDirtyConversations(
+  db: SceneDirtyDb,
+  ids: readonly unknown[],
+  readAt: Date,
+): Promise<number> {
+  if (ids.length === 0) return 0;
+  const [stale] = await db.query<[unknown[]]>(
+    `SELECT VALUE id FROM scene_dirty_conversation
+      WHERE id INSIDE $ids AND markedAt <= $readAt`,
+    { ids: [...ids], readAt },
+  );
+  const doomed = stale ?? [];
+  if (doomed.length === 0) return 0;
+  await db.query(`DELETE scene_dirty_conversation WHERE id INSIDE $doomed`, { doomed });
+  return doomed.length;
+}

--- a/src/common/scene-flags.ts
+++ b/src/common/scene-flags.ts
@@ -228,6 +228,74 @@ export function sceneBeliefMinScenes(): number {
   return Number.isInteger(v) && v >= 0 ? v : 0;
 }
 
+/**
+ * Scheduled scene-maintenance flag — SCENES_SCHEDULED_MAINTENANCE.
+ *
+ * The scene chain (compose → enrich → backlink → evidence links →
+ * beliefs) had NO scheduled runner: every SCENES_* flag could be on in
+ * prod and the whole episodic/semantic plane would still only exist for
+ * conversations an operator had curled by hand. When this flag is on,
+ * SceneMaintenanceService's nightly cron (04:20 UTC) walks the tenant
+ * roster and runs that chain over the DIRTY conversations only, and the
+ * ingest seam (EpisodeStoreService.captureTurn) starts marking
+ * conversations dirty (migration 0130) as turns land.
+ *
+ * The env read lives here in the common layer, NOT inside the engine dirs
+ * (engine-gates S5.2). Read at call time so a flip is runtime-mutable.
+ * Default off ⇒ the cron returns before a single query, NO dirty mark is
+ * ever written and the admin routes behave exactly as before —
+ * byte-identical prod. Requires SCENES_SEGMENTATION_ENABLED to do
+ * anything: both the cron and the mark seam check the master flag too, so
+ * marks cannot pile up for a composer that is switched off.
+ */
+export function sceneScheduledMaintenanceEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_SCHEDULED_MAINTENANCE);
+}
+
+/** Default per-tenant, per-run conversation budget for the nightly pass. */
+const DEFAULT_MAINTENANCE_MAX_CONVERSATIONS = 200;
+
+/**
+ * Per-tenant conversation budget (SCENES_MAINTENANCE_MAX_CONVERSATIONS):
+ * the nightly pass composes at most this many DIRTY conversations for one
+ * tenant per run, oldest mark first. NOT optional — the post-swap chain
+ * spends one LLM call per new scene and one embedding batch per composed
+ * conversation, so an unbounded run lets one large tenant's backlog
+ * monopolize both the night and the token budget. Unconsumed marks survive
+ * to the next run, so a backlog drains over successive nights instead of
+ * being dropped. A non-boolean knob resolved here in the common layer
+ * (engine-gates S5.2); read at call time so a change is runtime-mutable.
+ * Must be a positive integer; unset, blank, or invalid → 200.
+ */
+export function sceneMaintenanceMaxConversations(): number {
+  const raw = process.env.SCENES_MAINTENANCE_MAX_CONVERSATIONS;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_MAINTENANCE_MAX_CONVERSATIONS;
+  const v = Number(raw);
+  return Number.isInteger(v) && v > 0 ? v : DEFAULT_MAINTENANCE_MAX_CONVERSATIONS;
+}
+
+/** Default wall-clock budget for ONE nightly maintenance run (30 min). */
+const DEFAULT_MAINTENANCE_TIME_BUDGET_MS = 30 * 60 * 1000;
+
+/**
+ * Whole-run wall-clock budget (SCENES_MAINTENANCE_TIME_BUDGET_MS): the
+ * nightly pass stops starting new tenants once this much time has elapsed
+ * since the run began (the tenant already in flight always finishes — the
+ * budget bounds the roster walk, it does not abort a compose mid-swap).
+ * The roster resumes from the top next night and the unconsumed dirty
+ * marks are still there, so nothing is lost; the cap only guarantees the
+ * pass cannot still be running when the next night's crons fire. A
+ * non-boolean knob resolved here in the common layer (engine-gates S5.2);
+ * read at call time so a change is runtime-mutable. Must be a positive
+ * integer number of milliseconds; unset, blank, or invalid → 1_800_000.
+ */
+export function sceneMaintenanceTimeBudgetMs(): number {
+  const raw = process.env.SCENES_MAINTENANCE_TIME_BUDGET_MS;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_MAINTENANCE_TIME_BUDGET_MS;
+  const v = Number(raw);
+  return Number.isInteger(v) && v > 0 ? v : DEFAULT_MAINTENANCE_TIME_BUDGET_MS;
+}
+
 /** Default hard cap on turns per scene (Brain v2 PR1). */
 const DEFAULT_MAX_TURNS = 40;
 

--- a/src/db/migrations/0130_scene_dirty_conversation.surql
+++ b/src/db/migrations/0130_scene_dirty_conversation.surql
@@ -1,0 +1,88 @@
+-- 0130: scene_dirty_conversation — the incremental trigger for the
+-- scheduled scene-maintenance pass (SCENES_SCHEDULED_MAINTENANCE).
+--
+-- WHY. The scene composer (0106) had exactly one entry point — the admin
+-- route — and it rebuilt EVERY conversation of the tenant from scratch on
+-- every call: `SELECT conversationId, count() FROM episode GROUP BY
+-- conversationId` (episode-read-store.conversationCounts) is O(all turns
+-- ever ingested), and the composer then re-derived scenes for every one of
+-- them whether or not a single new turn had landed. That is affordable for
+-- an operator pressing a button and unaffordable for a nightly cron: the
+-- post-swap chain spends ONE LLM call per NEW scene (SCENES_LLM_ENRICHMENT)
+-- and one embedding batch per composed conversation (SCENES_TOPIC_BOUNDARY),
+-- so a full nightly rebuild would re-walk the entire corpus to discover the
+-- handful of conversations that actually moved.
+--
+-- WHAT. One tiny row per conversation that has received turns since the
+-- last successful scene swap. The ingest seam (EpisodeStoreService
+-- .captureTurn — the one place that already knows "this conversation just
+-- got a turn") UPSERTs the row; the scheduled pass reads a BOUNDED page of
+-- it, composes exactly those conversations, and deletes the rows it
+-- consumed. Steady state is therefore proportional to conversations that
+-- MOVED, not to conversations that exist.
+--
+-- ALTERNATIVES CONSIDERED.
+--  * A column on an existing table: there is no per-conversation row
+--    anywhere in the schema to hang it on. `episode` is per-TURN (a mark
+--    smeared over every turn needs an O(turns) clear, and the clear is a
+--    WHERE over the indexed conversationId — the 3.2.4 planner hazard);
+--    `conversation_digest` (0086) is the window-deriver's own derived world
+--    keyed (conversationId, derivedVersion) and hijacking it would put two
+--    unrelated lifecycles on one row; `projection` (raw-substrate driver
+--    surface 3) is the per-WORLD lifecycle ledger, and per-conversation
+--    rows in it would give `status` two meanings in one subsystem — exactly
+--    the trap 0106's NAMING NOTES call out. Hence a table of its own: the
+--    minimal additive structure, not a preference for new tables.
+--  * A derived watermark (compare max(episode.recordedAt) per conversation
+--    against the scene world's per-conversation composed-at): needs no
+--    write at ingest, but the comparison itself is the O(all conversations)
+--    GROUP BY this migration exists to remove.
+--  * A changefeed on `episode`: rejected in 0073 on GDPR grounds (a 30-day
+--    INCLUDE ORIGINAL feed keeps forgotten turns readable) and that
+--    reasoning is unchanged.
+--
+-- IDENTITY. Record id `scene_dirty_conversation:[<conversationId>]` — the
+-- array-literal id idiom (projection:[name, version]): UPSERT-idempotent by
+-- PRIMARY KEY, so a burst of turns on one conversation collapses onto one
+-- row with no read-modify-write, and the scheduled pass clears by explicit
+-- id list. Both the mark and the clear therefore address rows by primary
+-- key; no writer in this table's lifecycle issues an UPDATE/DELETE whose
+-- WHERE filters a secondary or compound index (the 3.2.4 silent-no-op
+-- planner bug documented in 0093 / scene-composer's swap comment).
+--
+-- RACE CONTRACT. `markedAt` is bumped on every turn. The pass captures a
+-- `readAt` instant BEFORE selecting the dirty page and clears only rows
+-- still satisfying `markedAt <= readAt` — a turn that lands DURING a long
+-- compose bumps markedAt past readAt, the row survives the clear, and the
+-- conversation is recomposed on the next pass. Losing a turn is impossible;
+-- the worst case is one redundant recompose.
+--
+-- NO CHANGEFEED (0073/0106 reasoning) and no full-text/vector index: the
+-- row carries no content.
+--
+-- GDPR. Deliberately NOT wired into either forget cascade. The row holds a
+-- conversation IDENTIFIER and two timestamps — no turn text, no userId, no
+-- derived content — and it is self-clearing: the next successful pass
+-- deletes it, and a conversation whose turns were erased simply composes to
+-- zero scenes and drops its mark. Nothing here survives that the `episode`
+-- rows themselves do not.
+--
+-- Derived/transient state: dropping the table costs at most one full
+-- rebuild via the admin route, which is the pre-0130 behaviour.
+
+DEFINE TABLE IF NOT EXISTS scene_dirty_conversation SCHEMAFULL;
+
+-- Mirrored out of the record id so reads and logs never have to parse it.
+DEFINE FIELD IF NOT EXISTS conversationId ON scene_dirty_conversation TYPE string;
+-- Bumped on EVERY marking turn — the race fence described above.
+DEFINE FIELD IF NOT EXISTS markedAt ON scene_dirty_conversation TYPE datetime;
+-- Set once, on create (UPSERT ... SET never restates it): how long this
+-- conversation has been waiting for a pass. Pure observability.
+DEFINE FIELD IF NOT EXISTS createdAt ON scene_dirty_conversation TYPE datetime
+  DEFAULT time::now();
+
+-- Oldest-first page selection for the bounded nightly budget: a big tenant
+-- whose backlog exceeds SCENES_MAINTENANCE_MAX_CONVERSATIONS drains in
+-- arrival order instead of starving its oldest conversations forever.
+DEFINE INDEX IF NOT EXISTS scene_dirty_marked_idx ON scene_dirty_conversation
+  FIELDS markedAt;

--- a/src/ingest/episode-store.service.ts
+++ b/src/ingest/episode-store.service.ts
@@ -6,6 +6,8 @@ import { detectLanguage } from '../ai/locale/language-detector';
 import { redactPiiWithReport } from './ingest-utils';
 import { scopeForUser } from '../auth/scope-tags';
 import { sanitizeIngestText } from '../common/text-sanitizer';
+import { markConversationDirty, type SceneDirtyDb } from '../common/scene-dirty';
+import { sceneScheduledMaintenanceEnabled, sceneSegmentationEnabled } from '../common/scene-flags';
 import type { IngestMentionDto, KnownEntity } from './dto/ingest-mention.dto';
 
 /**
@@ -20,6 +22,11 @@ import type { IngestMentionDto, KnownEntity } from './dto/ingest-mention.dto';
  *    messageId) index — retries and replays are safe);
  *  - non-fatal (any failure is a warn; the fact pipeline must not depend on
  *    the substrate while it is flag-gated).
+ *
+ * Also the scene staleness seam (migration 0130, SCENES_SCHEDULED_MAINTENANCE,
+ * default off): the same call marks the turn's conversation dirty so the
+ * nightly scene pass recomposes what MOVED instead of enumerating every
+ * conversation that exists. Own try/catch, own flag pair — see markSceneDirty.
  */
 @Injectable()
 export class EpisodeStoreService {
@@ -98,6 +105,20 @@ export class EpisodeStoreService {
             row,
           },
         );
+        // Scene staleness trigger (migration 0130): this is the one place
+        // that already knows "conversation X just received a turn", which
+        // is exactly the predicate the nightly scene pass needs so it can
+        // recompose what moved instead of the whole corpus. One UPSERT on a
+        // primary key, and only when BOTH the scenes master flag and
+        // SCENES_SCHEDULED_MAINTENANCE are on — marks must never accumulate
+        // for a composer that is switched off, and with either flag off no
+        // scene_dirty_conversation row is ever written.
+        //
+        // Marked on the duplicate path too, deliberately: an INSERT IGNORE
+        // that matched an existing turn tells us nothing about whether the
+        // SCENE world already covers it (a replay after a failed compose is
+        // the normal case), and a redundant recompose is idempotent.
+        await this.markSceneDirty(db, row.conversationId);
         const created = rows?.[0]?.id;
         if (created !== undefined && created !== null) return String(created);
         // Duplicate (INSERT IGNORE returned no row): recover the existing
@@ -122,6 +143,29 @@ export class EpisodeStoreService {
     } catch (e) {
       this.logger.warn(`episode capture failed (companyId=${companyId}): ${(e as Error).message}`);
       return null;
+    }
+  }
+
+  /**
+   * Mark the conversation for the nightly scene pass. Its own try/catch,
+   * NOT the caller's: capture already succeeded at this point, and a mark
+   * failure must not turn a stored turn into a `null` return — that return
+   * is what the EVIDENCE_FAIL_CLOSED_CAPTURE path reads to reject the whole
+   * mention. Worst case of a swallowed failure is a conversation whose
+   * scenes are one pass stale; the operator's full rebuild still fixes it.
+   *
+   * A turn with no conversationId (the field is optional) has nothing to
+   * mark — scenes are keyed by conversation.
+   */
+  private async markSceneDirty(db: SceneDirtyDb, conversationId?: string): Promise<void> {
+    if (conversationId === undefined) return;
+    if (!sceneSegmentationEnabled() || !sceneScheduledMaintenanceEnabled()) return;
+    try {
+      await markConversationDirty(db, conversationId);
+    } catch (e) {
+      this.logger.warn(
+        `scene dirty mark failed (conversationId=${conversationId}): ${(e as Error).message}`,
+      );
     }
   }
 

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -46,6 +46,9 @@ export interface MemoryQualitySnapshot {
  *   - multi_hop_total{outcome}                — ok|single_hop|chain_empty|no_results|planner_error|hop_error
  *   - dreams_total{outcome}                   — ok|failed
  *   - dreams_emitted_total{kind}              — identity_link|resolution|summary
+ *   - scene_maintenance_total{outcome}        — ok|failed|skipped_no_dirty|skipped_budget
+ *   - scene_maintenance_emitted_total{kind}   — conversation|scene|enriched|belief|dirty_cleared
+ *   - scene_maintenance_duration_seconds      — histogram, per-tenant pass
  *   - retract_total / forget_total            — counters
  *   - compaction_facts_total                  — counter, summed across tenants
  *   - openai_tokens_total{kind, type}         — embed|chat × prompt|completion
@@ -154,6 +157,57 @@ export class MetricsService implements OnModuleInit {
     name: 'brain_multi_hop_total',
     help: 'Multi-hop search invocations by outcome',
     labelNames: ['outcome'] as const,
+    registers: [this.registry],
+  });
+
+  // Scheduled scene maintenance (SCENES_SCHEDULED_MAINTENANCE, migration
+  // 0130). Until this pass existed the whole episodic/semantic plane was
+  // unobservable: scenes only appeared when an operator curled the admin
+  // route, so there was nothing periodic to alert on. Per-TENANT outcomes:
+  //   ok               — the tenant pass composed its dirty page
+  //   skipped_no_dirty — no conversation had moved since the last pass
+  //                      (the steady state on a quiet tenant, and the
+  //                      series that proves the dirty trigger works: if
+  //                      this never fires, the marks are not being cleared)
+  //   skipped_budget   — the run's wall-clock budget expired before this
+  //                      tenant started; its marks wait for tomorrow
+  //   failed           — the tenant threw; the roster continued
+  // No companyId label (unbounded cardinality — the same rule as every
+  // other domain counter here); per-tenant detail is cut from log lines.
+  readonly sceneMaintenanceCount = new Counter({
+    name: 'brain_scene_maintenance_total',
+    help: 'Scheduled scene-maintenance tenant passes by outcome',
+    labelNames: ['outcome'] as const,
+    registers: [this.registry],
+  });
+
+  // What the pass actually produced, by kind:
+  //   conversation — dirty conversations composed
+  //   scene        — scenes written by the swap
+  //   enriched     — scenes the LLM enrichment pass re-wrote (the paid leg;
+  //                  watch this against `scene` to see the idempotent skip
+  //                  working — a steady enriched≈scene ratio on unchanged
+  //                  input means the enrichmentVersion composite moved)
+  //   belief       — semantic_belief upserts (created + revised +
+  //                  corroborated) the promotion leg landed
+  //   dirty_cleared— marks retired after a successful swap. dirty_cleared
+  //                  lagging `conversation` means turns kept landing during
+  //                  the pass (the race fence), not that marks are leaking.
+  readonly sceneMaintenanceEmitted = new Counter({
+    name: 'brain_scene_maintenance_emitted_total',
+    help: 'Scheduled scene-maintenance artefacts by kind',
+    labelNames: ['kind'] as const,
+    registers: [this.registry],
+  });
+
+  // Per-TENANT pass latency. Buckets run to 30 min because the pass is
+  // budgeted in that unit (SCENES_MAINTENANCE_TIME_BUDGET_MS defaults to
+  // 30 min for the whole roster) — a single tenant approaching the top
+  // bucket is the signal that its per-run conversation cap is too high.
+  readonly sceneMaintenanceDuration = new Histogram({
+    name: 'brain_scene_maintenance_duration_seconds',
+    help: 'Scheduled scene-maintenance per-tenant pass latency in seconds',
+    buckets: [0.5, 2, 10, 30, 120, 300, 900, 1800],
     registers: [this.registry],
   });
 
@@ -937,6 +991,23 @@ export class MetricsService implements OnModuleInit {
 
   countCommitMemory(outcome: 'ok' | 'noop' | 'failed'): void {
     this.commitMemoryCount.inc({ outcome } as LabelValues<'outcome'>);
+  }
+
+  countSceneMaintenance(outcome: 'ok' | 'failed' | 'skipped_no_dirty' | 'skipped_budget'): void {
+    this.sceneMaintenanceCount.inc({ outcome } as LabelValues<'outcome'>);
+  }
+
+  countSceneMaintenanceEmitted(
+    kind: 'conversation' | 'scene' | 'enriched' | 'belief' | 'dirty_cleared',
+    n = 1,
+  ): void {
+    if (n > 0) {
+      this.sceneMaintenanceEmitted.inc({ kind } as LabelValues<'kind'>, n);
+    }
+  }
+
+  observeSceneMaintenanceDuration(seconds: number): void {
+    this.sceneMaintenanceDuration.observe(seconds);
   }
 
   /**

--- a/test/scene-dirty-trigger.unit-spec.ts
+++ b/test/scene-dirty-trigger.unit-spec.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit coverage for the dirty-conversation trigger (migration 0130):
+ * the three SQL verbs in src/common/scene-dirty.ts (mark by primary key,
+ * bounded oldest-first page, two-step race-fenced clear) and the ingest
+ * seam that writes the mark (EpisodeStoreService.captureTurn) — including
+ * the default-off pin: with either scene flag off, capture issues exactly
+ * the queries it issued before this feature existed.
+ */
+import {
+  clearDirtyConversations,
+  markConversationDirty,
+  selectDirtyConversations,
+  type SceneDirtyDb,
+} from '../src/common/scene-dirty';
+import { EpisodeStoreService } from '../src/ingest/episode-store.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { IngestMentionDto } from '../src/ingest/dto/ingest-mention.dto';
+
+interface Seen {
+  sql: string;
+  params: Record<string, unknown> | undefined;
+}
+
+function fakeDb(reply: (sql: string) => unknown): { db: SceneDirtyDb; seen: Seen[] } {
+  const seen: Seen[] = [];
+  const db: SceneDirtyDb = {
+    query: async <T>(sql: string, params?: Record<string, unknown>): Promise<T> => {
+      seen.push({ sql, params });
+      return reply(sql) as T;
+    },
+  };
+  return { db, seen };
+}
+
+describe('scene-dirty — mark', () => {
+  it('UPSERTs by PRIMARY KEY (no read-modify-write, burst-collapsing)', async () => {
+    const { db, seen } = fakeDb(() => [[]]);
+    await markConversationDirty(db, 'proj:alpha');
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.sql).toContain('UPSERT scene_dirty_conversation:[$conv]');
+    expect(seen[0]!.sql).toContain('markedAt = time::now()');
+    // createdAt is deliberately NOT restated — its DEFAULT records the
+    // first-marked instant across a burst of turns.
+    expect(seen[0]!.sql).not.toContain('createdAt');
+    expect(seen[0]!.params).toEqual({ conv: 'proj:alpha' });
+  });
+
+  it('never issues an UPDATE/DELETE over a secondary index (3.2.4 discipline)', async () => {
+    const { db, seen } = fakeDb(() => [[]]);
+    await markConversationDirty(db, 'c1');
+    expect(seen[0]!.sql).not.toMatch(/UPDATE scene_dirty_conversation\s+SET/);
+    expect(seen[0]!.sql).not.toContain('WHERE conversationId');
+  });
+});
+
+describe('scene-dirty — select', () => {
+  it('reads a bounded page, oldest mark first', async () => {
+    const rows = [
+      { id: `scene_dirty_conversation:['a']`, conversationId: 'a' },
+      { id: `scene_dirty_conversation:['b']`, conversationId: 'b' },
+    ];
+    const { db, seen } = fakeDb(() => [rows]);
+    await expect(selectDirtyConversations(db, 25)).resolves.toEqual(rows);
+    expect(seen[0]!.sql).toContain('ORDER BY markedAt ASC LIMIT $limit');
+    expect(seen[0]!.params).toEqual({ limit: 25 });
+  });
+
+  it('floors a fractional limit and refuses a non-positive one without a query', async () => {
+    const { db, seen } = fakeDb(() => [[]]);
+    await selectDirtyConversations(db, 7.9);
+    expect(seen[0]!.params).toEqual({ limit: 7 });
+    await expect(selectDirtyConversations(db, 0)).resolves.toEqual([]);
+    await expect(selectDirtyConversations(db, -1)).resolves.toEqual([]);
+    expect(seen).toHaveLength(1);
+  });
+
+  it('drops malformed rows rather than composing an undefined conversation', async () => {
+    const { db } = fakeDb(() => [[{ id: 'x' }, { id: 'y', conversationId: 'ok' }]]);
+    await expect(selectDirtyConversations(db, 10)).resolves.toEqual([
+      { id: 'y', conversationId: 'ok' },
+    ]);
+  });
+});
+
+describe('scene-dirty — clear', () => {
+  it('resolves ids first, then deletes BY ID (LET-select-ids idiom)', async () => {
+    const ids = ['scene_dirty_conversation:[a]', 'scene_dirty_conversation:[b]'];
+    const readAt = new Date('2026-03-01T04:20:00.000Z');
+    const { db, seen } = fakeDb((sql) => (sql.includes('SELECT VALUE id') ? [ids] : [[]]));
+    await expect(clearDirtyConversations(db, ids, readAt)).resolves.toBe(2);
+    expect(seen).toHaveLength(2);
+    // Step 1 carries the race fence: only marks that predate the read.
+    expect(seen[0]!.sql).toContain('SELECT VALUE id FROM scene_dirty_conversation');
+    expect(seen[0]!.sql).toContain('markedAt <= $readAt');
+    expect(seen[0]!.params).toEqual({ ids, readAt });
+    // Step 2 addresses primary keys only.
+    expect(seen[1]!.sql).toBe('DELETE scene_dirty_conversation WHERE id INSIDE $doomed');
+    expect(seen[1]!.params).toEqual({ doomed: ids });
+  });
+
+  it('a mark re-bumped DURING the pass survives — nothing is deleted', async () => {
+    // The fence matched nothing: every candidate was re-marked after readAt.
+    const { db, seen } = fakeDb((sql) => (sql.includes('SELECT VALUE id') ? [[]] : [[]]));
+    await expect(clearDirtyConversations(db, ['x'], new Date())).resolves.toBe(0);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.sql).toContain('SELECT VALUE id');
+  });
+
+  it('an empty id list issues no query at all', async () => {
+    const { db, seen } = fakeDb(() => [[]]);
+    await expect(clearDirtyConversations(db, [], new Date())).resolves.toBe(0);
+    expect(seen).toHaveLength(0);
+  });
+});
+
+// ── the ingest seam ─────────────────────────────────────────────────────
+
+function dto(partial: Partial<IngestMentionDto> = {}): IngestMentionDto {
+  return {
+    text: 'I booked the Lisbon flight',
+    contextRef: { vertical: 'proj', conversationId: 'proj:alpha', messageId: 'm-1' },
+    knownEntities: [{ vertical: 'proj', id: 'mika', role: 'speaker', name: 'mika' }],
+    emittedAt: '2026-03-01T12:00:00.000Z',
+    ...partial,
+  } as IngestMentionDto;
+}
+
+function makeStore(opts: { markThrows?: boolean } = {}): {
+  svc: EpisodeStoreService;
+  queries: string[];
+} {
+  const queries: string[] = [];
+  const surreal = {
+    withCompany: async (_co: string, fn: (db: unknown) => Promise<unknown>) =>
+      fn({
+        query: async (sql: string) => {
+          queries.push(sql);
+          if (sql.startsWith('INSERT IGNORE')) return [[{ id: 'episode:e1' }]];
+          if (sql.startsWith('UPSERT scene_dirty_conversation')) {
+            if (opts.markThrows) throw new Error('mark blew up');
+            return [[]];
+          }
+          return [[]];
+        },
+      }),
+  } as unknown as SurrealService;
+  return { svc: new EpisodeStoreService(surreal), queries };
+}
+
+const ENV = [
+  'EPISODE_SUBSTRATE_ENABLED',
+  'SCENES_SEGMENTATION_ENABLED',
+  'SCENES_SCHEDULED_MAINTENANCE',
+] as const;
+
+describe('EpisodeStoreService — the dirty-mark seam', () => {
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const k of ENV) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.EPISODE_SUBSTRATE_ENABLED = '1';
+  });
+  afterEach(() => {
+    for (const k of ENV) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  const marks = (queries: string[]) =>
+    queries.filter((q) => q.startsWith('UPSERT scene_dirty_conversation'));
+
+  it('PIN: both scene flags off ⇒ capture issues ONLY the INSERT', async () => {
+    const { svc, queries } = makeStore();
+    expect(await svc.captureTurn('co_x', dto())).toBe('episode:e1');
+    expect(queries).toEqual(['INSERT IGNORE INTO episode $row']);
+  });
+
+  it('PIN: the master flag alone does not mark (marks must not outlive a disabled composer)', async () => {
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    const { svc, queries } = makeStore();
+    await svc.captureTurn('co_x', dto());
+    expect(marks(queries)).toHaveLength(0);
+  });
+
+  it('PIN: the maintenance flag alone does not mark either', async () => {
+    process.env.SCENES_SCHEDULED_MAINTENANCE = '1';
+    const { svc, queries } = makeStore();
+    await svc.captureTurn('co_x', dto());
+    expect(marks(queries)).toHaveLength(0);
+  });
+
+  it('marks the conversation when BOTH flags are on', async () => {
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    process.env.SCENES_SCHEDULED_MAINTENANCE = '1';
+    const { svc, queries } = makeStore();
+    expect(await svc.captureTurn('co_x', dto())).toBe('episode:e1');
+    expect(marks(queries)).toHaveLength(1);
+  });
+
+  it('a turn without a conversationId has nothing to mark', async () => {
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    process.env.SCENES_SCHEDULED_MAINTENANCE = '1';
+    const { svc, queries } = makeStore();
+    await svc.captureTurn('co_x', dto({ contextRef: { vertical: 'proj', messageId: 'm-9' } }));
+    expect(marks(queries)).toHaveLength(0);
+  });
+
+  it('a failing mark never costs the captured episode its id', async () => {
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    process.env.SCENES_SCHEDULED_MAINTENANCE = '1';
+    const { svc } = makeStore({ markThrows: true });
+    // The fail-closed capture path reads this return value — a swallowed
+    // mark failure must not turn a stored turn into a rejected mention.
+    expect(await svc.captureTurn('co_x', dto())).toBe('episode:e1');
+  });
+
+  it('marks on the DUPLICATE path too (a replay after a failed compose)', async () => {
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    process.env.SCENES_SCHEDULED_MAINTENANCE = '1';
+    const queries: string[] = [];
+    const surreal = {
+      withCompany: async (_co: string, fn: (db: unknown) => Promise<unknown>) =>
+        fn({
+          query: async (sql: string) => {
+            queries.push(sql);
+            // INSERT IGNORE swallowed the duplicate: no row returned.
+            if (sql.startsWith('INSERT IGNORE')) return [[]];
+            if (sql.startsWith('SELECT VALUE id')) return [['episode:existing']];
+            return [[]];
+          },
+        }),
+    } as unknown as SurrealService;
+    const svc = new EpisodeStoreService(surreal);
+    expect(await svc.captureTurn('co_x', dto())).toBe('episode:existing');
+    expect(marks(queries)).toHaveLength(1);
+  });
+});

--- a/test/scene-maintenance.e2e-spec.ts
+++ b/test/scene-maintenance.e2e-spec.ts
@@ -1,0 +1,206 @@
+/**
+ * Scheduled scene maintenance e2e (SCENES_SCHEDULED_MAINTENANCE, migration
+ * 0130) — the loop the scene plane had no runner for, end to end against a
+ * real SurrealDB 3.2.4:
+ *
+ *   ingest turns → a dirty mark appears → the nightly pass composes exactly
+ *   the dirty conversations → scenes exist → the mark is cleared → a second
+ *   pass finds nothing to do (and composes nothing) → new turns re-dirty the
+ *   same conversation → the pass picks it up again.
+ *
+ * Plus the two pins: with the flag off no mark is ever written, and the
+ * admin route still performs the FULL rebuild it always did (a conversation
+ * that was never marked still gets scenes from the operator button).
+ *
+ * Embedder-free (SCENES_TOPIC_BOUNDARY stays off) and enrichment-free
+ * (SCENES_LLM_ENRICHMENT stays off) — no paid call anywhere.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { SceneMaintenanceService } from '../src/admin/scene-maintenance.service';
+
+const CONV = 'proj:maintenance';
+const QUIET_CONV = 'proj:never-marked';
+const USER = 'maintenance_user';
+
+interface DirtyRow {
+  id: unknown;
+  conversationId: string;
+  markedAt: string;
+}
+
+const ENV = [
+  'EPISODE_SUBSTRATE_ENABLED',
+  'INGEST_EPISODE_ONLY',
+  'SCENES_SEGMENTATION_ENABLED',
+  'SCENES_SCHEDULED_MAINTENANCE',
+  'SCENES_TOPIC_BOUNDARY',
+  'SCENES_LLM_ENRICHMENT',
+  'SCENES_BELIEF_PROMOTION',
+  'SCENES_MAINTENANCE_MAX_CONVERSATIONS',
+] as const;
+
+describe('scheduled scene maintenance (e2e)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    for (const k of ENV) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.EPISODE_SUBSTRATE_ENABLED = '1';
+    process.env.INGEST_EPISODE_ONLY = '1';
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    process.env.SCENES_SCHEDULED_MAINTENANCE = '1';
+    f = await createApp({ companyId: 'co_scene_maint_e2e' });
+  });
+
+  afterAll(async () => {
+    for (const k of ENV) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    if (f) await f.close();
+  });
+
+  const ingest = async (conversationId: string, i: number, iso: string, text: string) => {
+    const res = await f.http
+      .post('/v1/ingest/mention')
+      .set(auth())
+      .send({
+        text,
+        contextRef: { vertical: 'proj', conversationId, messageId: `${conversationId}#${i}` },
+        knownEntities: [{ vertical: 'proj', id: 'mika', role: 'speaker', name: 'mika' }],
+        userId: USER,
+        emittedAt: iso,
+      });
+    expect(res.status).toBe(201);
+  };
+
+  const dirtyRows = async (): Promise<DirtyRow[]> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[DirtyRow[]]>(
+        `SELECT id, conversationId, markedAt FROM scene_dirty_conversation
+          ORDER BY markedAt ASC`,
+      );
+      return rows ?? [];
+    });
+  };
+
+  const scenesOf = async (
+    conversationId: string,
+  ): Promise<Array<{ gist: string; confidence: number }>> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      // occurredFrom must be SELECTed to be orderable (3.2.4 parse rule).
+      const [rows] = await db.query<[Array<{ gist: string; confidence: number }>]>(
+        `SELECT gist, confidence, occurredFrom FROM memory_episode
+          WHERE conversationIds CONTAINS $conv ORDER BY occurredFrom ASC`,
+        { conv: conversationId },
+      );
+      return rows ?? [];
+    });
+  };
+
+  const maintenance = () => f.app.get(SceneMaintenanceService);
+
+  it('ingest marks the conversation dirty', async () => {
+    // One conversation, two sessions (a >60-min gap) ⇒ two scenes later.
+    await ingest(CONV, 0, '2026-04-01T10:00:00.000Z', 'I started planning the Porto trip.');
+    await ingest(CONV, 1, '2026-04-01T10:05:00.000Z', 'Comparing trains for next month.');
+    await ingest(CONV, 2, '2026-04-01T12:00:00.000Z', 'Back to it — now the hotel.');
+
+    const rows = await dirtyRows();
+    expect(rows.map((r) => r.conversationId)).toEqual([CONV]);
+    expect(rows[0]!.markedAt).toBeTruthy();
+    // Three turns collapsed onto ONE row (UPSERT by primary key).
+    expect(rows).toHaveLength(1);
+    // Nothing has composed yet — the mark is the only artefact.
+    expect(await scenesOf(CONV)).toHaveLength(0);
+  });
+
+  it('the nightly pass composes the dirty conversation and clears its mark', async () => {
+    const run = await maintenance().runNightly();
+    expect(run.budgetExhausted).toBe(false);
+    expect(run.tenants).toHaveLength(1);
+    expect(run.tenants[0]).toMatchObject({
+      companyId: f.companyId,
+      dirty: 1,
+      conversations: 1,
+      cleared: 1,
+    });
+    expect(run.tenants[0]!.error).toBeUndefined();
+
+    const scenes = await scenesOf(CONV);
+    expect(scenes).toHaveLength(2);
+    // Embedder-free run: both edges are exact rules, so confidence is 1.
+    expect(scenes.map((s) => s.confidence)).toEqual([1, 1]);
+    expect(await dirtyRows()).toHaveLength(0);
+  });
+
+  it('a second pass finds nothing dirty and composes nothing', async () => {
+    const run = await maintenance().runNightly();
+    expect(run.tenants[0]).toMatchObject({ dirty: 0, conversations: 0, scenes: 0, cleared: 0 });
+    // The scene world is untouched — no rebuild happened.
+    expect(await scenesOf(CONV)).toHaveLength(2);
+  });
+
+  it('new turns re-dirty the same conversation and the next pass picks it up', async () => {
+    await ingest(CONV, 3, '2026-04-01T12:05:00.000Z', 'Found a place near the river.');
+    expect((await dirtyRows()).map((r) => r.conversationId)).toEqual([CONV]);
+
+    const run = await maintenance().runNightly();
+    expect(run.tenants[0]).toMatchObject({ dirty: 1, conversations: 1, cleared: 1 });
+    expect(await dirtyRows()).toHaveLength(0);
+    // Still two sessions, now 2 + 2 turns.
+    expect(await scenesOf(CONV)).toHaveLength(2);
+  });
+
+  it('PIN: with SCENES_SCHEDULED_MAINTENANCE off, ingest marks nothing', async () => {
+    delete process.env.SCENES_SCHEDULED_MAINTENANCE;
+    try {
+      await ingest(QUIET_CONV, 0, '2026-04-02T09:00:00.000Z', 'A conversation nobody scheduled.');
+      await ingest(QUIET_CONV, 1, '2026-04-02T09:05:00.000Z', 'Still nothing marked.');
+      expect(await dirtyRows()).toHaveLength(0);
+      // …and the cron itself is inert.
+      const run = await maintenance().runNightly();
+      expect(run.tenants).toHaveLength(0);
+      expect(await scenesOf(QUIET_CONV)).toHaveLength(0);
+    } finally {
+      process.env.SCENES_SCHEDULED_MAINTENANCE = '1';
+    }
+  });
+
+  it('the admin route still does the FULL rebuild, marks or no marks', async () => {
+    // QUIET_CONV was never marked; the operator button must still cover it.
+    const res = await f.http.post('/v1/admin/maintenance/scenes').set(auth()).send({});
+    expect(res.status).toBe(201);
+    expect(res.body.conversations).toBeGreaterThanOrEqual(2);
+    expect(await scenesOf(QUIET_CONV)).toHaveLength(1);
+    expect(await scenesOf(CONV)).toHaveLength(2);
+  });
+
+  it('the per-tenant conversation budget caps one run and the rest drains next', async () => {
+    process.env.SCENES_MAINTENANCE_MAX_CONVERSATIONS = '1';
+    try {
+      await ingest(CONV, 4, '2026-04-01T12:10:00.000Z', 'One more on the river place.');
+      await ingest(QUIET_CONV, 2, '2026-04-02T09:10:00.000Z', 'And one here too.');
+      expect(await dirtyRows()).toHaveLength(2);
+
+      const first = await maintenance().runNightly();
+      expect(first.tenants[0]).toMatchObject({ dirty: 1, cleared: 1 });
+      // Exactly one mark consumed; the other waits for the next run.
+      expect(await dirtyRows()).toHaveLength(1);
+
+      const second = await maintenance().runNightly();
+      expect(second.tenants[0]).toMatchObject({ dirty: 1, cleared: 1 });
+      expect(await dirtyRows()).toHaveLength(0);
+    } finally {
+      delete process.env.SCENES_MAINTENANCE_MAX_CONVERSATIONS;
+    }
+  });
+});

--- a/test/scene-maintenance.e2e-spec.ts
+++ b/test/scene-maintenance.e2e-spec.ts
@@ -126,14 +126,18 @@ describe('scheduled scene maintenance (e2e)', () => {
   it('the nightly pass composes the dirty conversation and clears its mark', async () => {
     const run = await maintenance().runNightly();
     expect(run.budgetExhausted).toBe(false);
-    expect(run.tenants).toHaveLength(1);
-    expect(run.tenants[0]).toMatchObject({
+    // The roster is every tenant the shared in-process database holds — the
+    // sibling e2e suites' fixtures included — so this asserts OUR tenant's
+    // row, never the roster's length. Every other tenant contributes a
+    // zero-work row, which the "no dirty work" case below pins.
+    const mine = run.tenants.find((t) => t.companyId === f.companyId);
+    expect(mine).toMatchObject({
       companyId: f.companyId,
       dirty: 1,
       conversations: 1,
       cleared: 1,
     });
-    expect(run.tenants[0]!.error).toBeUndefined();
+    expect(mine!.error).toBeUndefined();
 
     const scenes = await scenesOf(CONV);
     expect(scenes).toHaveLength(2);
@@ -144,7 +148,12 @@ describe('scheduled scene maintenance (e2e)', () => {
 
   it('a second pass finds nothing dirty and composes nothing', async () => {
     const run = await maintenance().runNightly();
-    expect(run.tenants[0]).toMatchObject({ dirty: 0, conversations: 0, scenes: 0, cleared: 0 });
+    expect(run.tenants.find((t) => t.companyId === f.companyId)).toMatchObject({
+      dirty: 0,
+      conversations: 0,
+      scenes: 0,
+      cleared: 0,
+    });
     // The scene world is untouched — no rebuild happened.
     expect(await scenesOf(CONV)).toHaveLength(2);
   });
@@ -154,7 +163,11 @@ describe('scheduled scene maintenance (e2e)', () => {
     expect((await dirtyRows()).map((r) => r.conversationId)).toEqual([CONV]);
 
     const run = await maintenance().runNightly();
-    expect(run.tenants[0]).toMatchObject({ dirty: 1, conversations: 1, cleared: 1 });
+    expect(run.tenants.find((t) => t.companyId === f.companyId)).toMatchObject({
+      dirty: 1,
+      conversations: 1,
+      cleared: 1,
+    });
     expect(await dirtyRows()).toHaveLength(0);
     // Still two sessions, now 2 + 2 turns.
     expect(await scenesOf(CONV)).toHaveLength(2);

--- a/test/scene-maintenance.unit-spec.ts
+++ b/test/scene-maintenance.unit-spec.ts
@@ -1,0 +1,475 @@
+/**
+ * Unit coverage for the scheduled scene-maintenance pass
+ * (src/admin/scene-maintenance.service.ts, SCENES_SCHEDULED_MAINTENANCE):
+ * the default-off pin (no roster read, no query, no mark), the reentrancy
+ * guard (a slow night never overlaps the next firing), per-tenant error
+ * isolation across the roster, both budget fences (per-tenant conversation
+ * cap + whole-run wall clock), and the dirty-mark clear contract (cleared
+ * for conversations that swapped, KEPT for the ones the composer skipped).
+ *
+ * Collaborators are stubbed positionally — no Nest DI, no Surreal, and no
+ * paid call anywhere: the composer and the belief promoter are plain fakes.
+ */
+import { SceneMaintenanceService } from '../src/admin/scene-maintenance.service';
+import type { ApiKeyService } from '../src/auth/api-key.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { SceneComposerService, SceneRunResult } from '../src/admin/scene-composer.service';
+import type {
+  BeliefPromotionService,
+  BeliefPromotionResult,
+} from '../src/admin/belief-promotion.service';
+import type { MetricsService } from '../src/metrics/metrics.service';
+
+const FLAGS = [
+  'SCENES_SEGMENTATION_ENABLED',
+  'SCENES_SCHEDULED_MAINTENANCE',
+  'SCENES_BELIEF_PROMOTION',
+  'SCENES_MAINTENANCE_MAX_CONVERSATIONS',
+  'SCENES_MAINTENANCE_TIME_BUDGET_MS',
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+beforeEach(() => {
+  for (const k of FLAGS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.SCENES_SEGMENTATION_ENABLED = '1';
+  process.env.SCENES_SCHEDULED_MAINTENANCE = '1';
+});
+afterEach(() => {
+  for (const k of FLAGS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+/** One tenant's fake dirty table, addressed the way the real one is. */
+interface FakeTenant {
+  dirty: string[];
+  /** Cleared ids, in clear order — the assertion surface for the marks. */
+  cleared: string[];
+  /** Selection limits the pass asked for, one per read. */
+  limits: number[];
+  throws?: string;
+}
+
+function makeSurreal(tenants: Record<string, FakeTenant>): {
+  surreal: SurrealService;
+  companies: string[];
+} {
+  const companies: string[] = [];
+  const surreal = {
+    withCompany: async <T>(companyId: string, fn: (db: unknown) => Promise<T>) => {
+      companies.push(companyId);
+      const t = tenants[companyId];
+      if (!t) throw new Error(`no fake tenant ${companyId}`);
+      if (t.throws) throw new Error(t.throws);
+      const db = {
+        query: async <R>(sql: string, params?: Record<string, unknown>): Promise<R> => {
+          if (sql.includes('SELECT id, conversationId')) {
+            const limit = Number(params?.limit ?? 0);
+            t.limits.push(limit);
+            const page = t.dirty.slice(0, limit).map((conversationId) => ({
+              id: `scene_dirty_conversation:['${conversationId}']`,
+              conversationId,
+              markedAt: '2026-03-01T00:00:00.000Z',
+            }));
+            return [page] as unknown as R;
+          }
+          if (sql.includes('SELECT VALUE id FROM scene_dirty_conversation')) {
+            // The race fence resolves to "everything asked for" here; the
+            // fence itself is exercised in the e2e against a real server.
+            return [params?.ids ?? []] as unknown as R;
+          }
+          if (sql.includes('DELETE scene_dirty_conversation')) {
+            t.cleared.push(...((params?.doomed as string[]) ?? []));
+            return [[]] as unknown as R;
+          }
+          throw new Error(`unexpected sql: ${sql}`);
+        },
+      };
+      return fn(db);
+    },
+  } as unknown as SurrealService;
+  return { surreal, companies };
+}
+
+function makeApiKeys(ids: string[]): ApiKeyService {
+  return { knownCompanyIds: () => ids } as unknown as ApiKeyService;
+}
+
+function makeComposer(
+  impl: (companyId: string, opts: { conversationIds?: string[] }) => Promise<SceneRunResult>,
+): { composer: SceneComposerService; calls: Array<{ companyId: string; ids?: string[] }> } {
+  const calls: Array<{ companyId: string; ids?: string[] }> = [];
+  const composer = {
+    run: async (companyId: string, opts: { conversationIds?: string[] } = {}) => {
+      calls.push({ companyId, ...(opts.conversationIds ? { ids: opts.conversationIds } : {}) });
+      return impl(companyId, opts);
+    },
+  } as unknown as SceneComposerService;
+  return { composer, calls };
+}
+
+const composed = (over: Partial<SceneRunResult> = {}): SceneRunResult => ({
+  conversations: 0,
+  scenes: 0,
+  skipped: [],
+  ...over,
+});
+
+function makeBeliefs(result?: Partial<BeliefPromotionResult>, throws?: string) {
+  const calls: string[] = [];
+  const beliefs = {
+    run: async (companyId: string) => {
+      calls.push(companyId);
+      if (throws) throw new Error(throws);
+      return {
+        scenes: 0,
+        eligibleScenes: 0,
+        skippedMixedUser: 0,
+        skippedConflict: 0,
+        fieldFolds: 0,
+        fieldFoldAmbiguous: 0,
+        fieldOrphansAbsorbed: 0,
+        fieldOrphanAmbiguous: 0,
+        skippedFloor: 0,
+        skippedStale: 0,
+        beliefsCreated: 0,
+        beliefsCorroborated: 0,
+        beliefsRevised: 0,
+        supportEdges: 0,
+        ...result,
+      } as BeliefPromotionResult;
+    },
+  } as unknown as BeliefPromotionService;
+  return { beliefs, calls };
+}
+
+function makeMetrics() {
+  const metrics = {
+    countSceneMaintenance: jest.fn(),
+    countSceneMaintenanceEmitted: jest.fn(),
+    observeSceneMaintenanceDuration: jest.fn(),
+  };
+  return { metrics: metrics as unknown as MetricsService, spy: metrics };
+}
+
+describe('SceneMaintenanceService — flag gate', () => {
+  it('PIN: with SCENES_SCHEDULED_MAINTENANCE off the cron does nothing at all', async () => {
+    delete process.env.SCENES_SCHEDULED_MAINTENANCE;
+    const roster = jest.fn(() => ['co_a']);
+    const { composer, calls } = makeComposer(async () => composed());
+    const svc = new SceneMaintenanceService(
+      makeSurreal({}).surreal,
+      { knownCompanyIds: roster } as unknown as ApiKeyService,
+      composer,
+      makeBeliefs().beliefs,
+    );
+    await expect(svc.runNightly()).resolves.toEqual({
+      tenants: [],
+      budgetExhausted: false,
+      skippedForBudget: 0,
+    });
+    expect(roster).not.toHaveBeenCalled();
+    expect(calls).toHaveLength(0);
+  });
+
+  it('PIN: the scenes MASTER flag off also stops the pass (no orphan marks)', async () => {
+    delete process.env.SCENES_SEGMENTATION_ENABLED;
+    const roster = jest.fn(() => ['co_a']);
+    const svc = new SceneMaintenanceService(
+      makeSurreal({}).surreal,
+      { knownCompanyIds: roster } as unknown as ApiKeyService,
+      makeComposer(async () => composed()).composer,
+      makeBeliefs().beliefs,
+    );
+    await svc.runNightly();
+    expect(roster).not.toHaveBeenCalled();
+  });
+});
+
+describe('SceneMaintenanceService — reentrancy guard', () => {
+  it('a second firing while the first is in flight is a no-op', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const tenants = { co_a: { dirty: ['c1'], cleared: [], limits: [] } };
+    const { composer, calls } = makeComposer(async () => {
+      await gate;
+      return composed({ conversations: 1, scenes: 2 });
+    });
+    const svc = new SceneMaintenanceService(
+      makeSurreal(tenants).surreal,
+      makeApiKeys(['co_a']),
+      composer,
+      makeBeliefs().beliefs,
+    );
+    const first = svc.runNightly();
+    const second = await svc.runNightly();
+    // The overlapping tick returns the empty summary, not a partial run.
+    expect(second.tenants).toHaveLength(0);
+    release();
+    const done = await first;
+    expect(done.tenants).toHaveLength(1);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('the guard releases: the NEXT night runs normally', async () => {
+    const tenants = { co_a: { dirty: ['c1'], cleared: [], limits: [] } };
+    const { composer, calls } = makeComposer(async () => composed({ conversations: 1, scenes: 1 }));
+    const svc = new SceneMaintenanceService(
+      makeSurreal(tenants).surreal,
+      makeApiKeys(['co_a']),
+      composer,
+      makeBeliefs().beliefs,
+    );
+    await svc.runNightly();
+    await svc.runNightly();
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe('SceneMaintenanceService — roster isolation', () => {
+  it('one failing tenant does not abort the roster', async () => {
+    const tenants: Record<string, FakeTenant> = {
+      co_a: { dirty: ['a1'], cleared: [], limits: [] },
+      co_b: { dirty: [], cleared: [], limits: [], throws: 'surreal down' },
+      co_c: { dirty: ['c1'], cleared: [], limits: [] },
+    };
+    const { composer, calls } = makeComposer(async () => composed({ conversations: 1, scenes: 3 }));
+    const { metrics, spy } = makeMetrics();
+    const svc = new SceneMaintenanceService(
+      makeSurreal(tenants).surreal,
+      makeApiKeys(['co_a', 'co_b', 'co_c']),
+      composer,
+      makeBeliefs().beliefs,
+      metrics,
+    );
+    const run = await svc.runAll();
+    expect(run.tenants.map((t) => t.companyId)).toEqual(['co_a', 'co_b', 'co_c']);
+    expect(run.tenants[1]!.error).toBe('surreal down');
+    expect(run.tenants[1]!.scenes).toBe(0);
+    // The tenants either side of the failure both ran to completion.
+    expect(calls.map((c) => c.companyId)).toEqual(['co_a', 'co_c']);
+    expect(run.tenants[0]!.scenes).toBe(3);
+    expect(run.tenants[2]!.scenes).toBe(3);
+    expect(spy.countSceneMaintenance).toHaveBeenCalledWith('failed');
+    expect(spy.countSceneMaintenance).toHaveBeenCalledWith('ok');
+    // The failing tenant keeps every mark it had.
+    expect(tenants.co_b!.cleared).toEqual([]);
+  });
+
+  it('a tenant with nothing dirty is skipped without composing', async () => {
+    const tenants: Record<string, FakeTenant> = {
+      co_quiet: { dirty: [], cleared: [], limits: [] },
+    };
+    const { composer, calls } = makeComposer(async () => composed());
+    const { metrics, spy } = makeMetrics();
+    const svc = new SceneMaintenanceService(
+      makeSurreal(tenants).surreal,
+      makeApiKeys(['co_quiet']),
+      composer,
+      makeBeliefs().beliefs,
+      metrics,
+    );
+    const run = await svc.runAll();
+    expect(calls).toHaveLength(0);
+    expect(run.tenants[0]).toMatchObject({ dirty: 0, conversations: 0, scenes: 0, cleared: 0 });
+    expect(spy.countSceneMaintenance).toHaveBeenCalledWith('skipped_no_dirty');
+  });
+});
+
+describe('SceneMaintenanceService — budgets', () => {
+  it('caps the dirty page at SCENES_MAINTENANCE_MAX_CONVERSATIONS', async () => {
+    process.env.SCENES_MAINTENANCE_MAX_CONVERSATIONS = '2';
+    const tenants: Record<string, FakeTenant> = {
+      co_big: { dirty: ['c1', 'c2', 'c3', 'c4', 'c5'], cleared: [], limits: [] },
+    };
+    const { composer, calls } = makeComposer(async (_c, opts) =>
+      composed({ conversations: opts.conversationIds?.length ?? 0, scenes: 4 }),
+    );
+    const svc = new SceneMaintenanceService(
+      makeSurreal(tenants).surreal,
+      makeApiKeys(['co_big']),
+      composer,
+      makeBeliefs().beliefs,
+    );
+    const run = await svc.runAll();
+    expect(tenants.co_big!.limits).toEqual([2]);
+    expect(calls[0]!.ids).toEqual(['c1', 'c2']);
+    expect(run.tenants[0]!.dirty).toBe(2);
+    // The rest of the backlog is still marked — it drains tomorrow.
+    expect(tenants.co_big!.cleared).toEqual([
+      "scene_dirty_conversation:['c1']",
+      "scene_dirty_conversation:['c2']",
+    ]);
+  });
+
+  it('the default cap applies when the knob is unset or nonsense', async () => {
+    for (const raw of [undefined, '', 'lots', '0', '-3']) {
+      const tenants: Record<string, FakeTenant> = {
+        co_a: { dirty: [], cleared: [], limits: [] },
+      };
+      if (raw === undefined) delete process.env.SCENES_MAINTENANCE_MAX_CONVERSATIONS;
+      else process.env.SCENES_MAINTENANCE_MAX_CONVERSATIONS = raw;
+      const svc = new SceneMaintenanceService(
+        makeSurreal(tenants).surreal,
+        makeApiKeys(['co_a']),
+        makeComposer(async () => composed()).composer,
+        makeBeliefs().beliefs,
+      );
+      await svc.runAll();
+      expect(tenants.co_a!.limits).toEqual([200]);
+    }
+  });
+
+  it('the wall-clock budget stops the roster from starting new tenants', async () => {
+    // A budget already spent by the time the first tenant would start.
+    process.env.SCENES_MAINTENANCE_TIME_BUDGET_MS = '1';
+    const tenants: Record<string, FakeTenant> = {
+      co_a: { dirty: ['a1'], cleared: [], limits: [] },
+      co_b: { dirty: ['b1'], cleared: [], limits: [] },
+    };
+    const { composer, calls } = makeComposer(async () => composed({ conversations: 1 }));
+    const { metrics, spy } = makeMetrics();
+    const svc = new SceneMaintenanceService(
+      makeSurreal(tenants).surreal,
+      makeApiKeys(['co_a', 'co_b']),
+      composer,
+      makeBeliefs().beliefs,
+      metrics,
+    );
+    const now = jest.spyOn(Date, 'now');
+    // startedAt, then a deadline check per tenant — both already past.
+    now.mockReturnValueOnce(1_000).mockReturnValue(1_000_000);
+    const run = await svc.runAll();
+    now.mockRestore();
+    expect(calls).toHaveLength(0);
+    expect(run.budgetExhausted).toBe(true);
+    expect(run.skippedForBudget).toBe(2);
+    expect(spy.countSceneMaintenance).toHaveBeenCalledWith('skipped_budget');
+    // Nothing composed ⇒ nothing cleared: the marks all survive.
+    expect(tenants.co_a!.cleared).toEqual([]);
+    expect(tenants.co_b!.cleared).toEqual([]);
+  });
+});
+
+describe('SceneMaintenanceService — dirty-mark lifecycle', () => {
+  it('clears the marks that swapped and KEEPS the ones the composer skipped', async () => {
+    const tenants: Record<string, FakeTenant> = {
+      co_a: { dirty: ['ok1', 'bad', 'ok2'], cleared: [], limits: [] },
+    };
+    const { composer } = makeComposer(async () =>
+      composed({
+        conversations: 2,
+        scenes: 5,
+        skipped: [{ conversationId: 'bad', reason: 'turn read failed' }],
+      }),
+    );
+    const svc = new SceneMaintenanceService(
+      makeSurreal(tenants).surreal,
+      makeApiKeys(['co_a']),
+      composer,
+      makeBeliefs().beliefs,
+    );
+    const run = await svc.runAll();
+    expect(tenants.co_a!.cleared).toEqual([
+      "scene_dirty_conversation:['ok1']",
+      "scene_dirty_conversation:['ok2']",
+    ]);
+    expect(run.tenants[0]!.cleared).toBe(2);
+    expect(run.tenants[0]!.dirty).toBe(3);
+  });
+
+  it('a compose that skipped EVERYTHING clears nothing', async () => {
+    const tenants: Record<string, FakeTenant> = {
+      co_a: { dirty: ['x'], cleared: [], limits: [] },
+    };
+    const { composer } = makeComposer(async () =>
+      composed({ skipped: [{ conversationId: 'x', reason: 'boom' }] }),
+    );
+    const svc = new SceneMaintenanceService(
+      makeSurreal(tenants).surreal,
+      makeApiKeys(['co_a']),
+      composer,
+      makeBeliefs().beliefs,
+    );
+    const run = await svc.runAll();
+    expect(tenants.co_a!.cleared).toEqual([]);
+    expect(run.tenants[0]!.cleared).toBe(0);
+  });
+});
+
+describe('SceneMaintenanceService — belief promotion leg', () => {
+  it('runs only when SCENES_BELIEF_PROMOTION is on, and counts the upserts', async () => {
+    const tenants: Record<string, FakeTenant> = {
+      co_a: { dirty: ['c1'], cleared: [], limits: [] },
+    };
+    const off = makeBeliefs();
+    const svcOff = new SceneMaintenanceService(
+      makeSurreal(tenants).surreal,
+      makeApiKeys(['co_a']),
+      makeComposer(async () => composed({ conversations: 1 })).composer,
+      off.beliefs,
+    );
+    await svcOff.runAll();
+    expect(off.calls).toHaveLength(0);
+
+    process.env.SCENES_BELIEF_PROMOTION = '1';
+    const on = makeBeliefs({ beliefsCreated: 2, beliefsRevised: 1, beliefsCorroborated: 4 });
+    const tenants2: Record<string, FakeTenant> = {
+      co_a: { dirty: ['c1'], cleared: [], limits: [] },
+    };
+    const svcOn = new SceneMaintenanceService(
+      makeSurreal(tenants2).surreal,
+      makeApiKeys(['co_a']),
+      makeComposer(async () => composed({ conversations: 1 })).composer,
+      on.beliefs,
+    );
+    const run = await svcOn.runAll();
+    expect(on.calls).toEqual(['co_a']);
+    expect(run.tenants[0]!.beliefs).toBe(7);
+  });
+
+  it('a failing promotion degrades — the swap still counts and the marks clear', async () => {
+    process.env.SCENES_BELIEF_PROMOTION = '1';
+    const tenants: Record<string, FakeTenant> = {
+      co_a: { dirty: ['c1'], cleared: [], limits: [] },
+    };
+    const { beliefs } = makeBeliefs(undefined, 'promotion exploded');
+    const svc = new SceneMaintenanceService(
+      makeSurreal(tenants).surreal,
+      makeApiKeys(['co_a']),
+      makeComposer(async () => composed({ conversations: 1, scenes: 2 })).composer,
+      beliefs,
+    );
+    const run = await svc.runAll();
+    expect(run.tenants[0]!.error).toBeUndefined();
+    expect(run.tenants[0]!.scenes).toBe(2);
+    expect(run.tenants[0]!.beliefs).toBe(0);
+    expect(tenants.co_a!.cleared).toHaveLength(1);
+  });
+});
+
+describe('SceneMaintenanceService — metrics', () => {
+  it('emits the artefact counters and the per-tenant duration', async () => {
+    const tenants: Record<string, FakeTenant> = {
+      co_a: { dirty: ['c1', 'c2'], cleared: [], limits: [] },
+    };
+    const { metrics, spy } = makeMetrics();
+    const svc = new SceneMaintenanceService(
+      makeSurreal(tenants).surreal,
+      makeApiKeys(['co_a']),
+      makeComposer(async () => composed({ conversations: 2, scenes: 6, enriched: 5 })).composer,
+      makeBeliefs().beliefs,
+      metrics,
+    );
+    await svc.runAll();
+    expect(spy.countSceneMaintenanceEmitted).toHaveBeenCalledWith('conversation', 2);
+    expect(spy.countSceneMaintenanceEmitted).toHaveBeenCalledWith('scene', 6);
+    expect(spy.countSceneMaintenanceEmitted).toHaveBeenCalledWith('enriched', 5);
+    expect(spy.countSceneMaintenanceEmitted).toHaveBeenCalledWith('dirty_cleared', 2);
+    expect(spy.observeSceneMaintenanceDuration).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/scene-segmentation.unit-spec.ts
+++ b/test/scene-segmentation.unit-spec.ts
@@ -7,7 +7,10 @@
  * (segment-composer :147-160 rule).
  */
 import {
+  boundaryConfidence,
+  deriveSceneConfidence,
   detectSceneBoundaries,
+  detectSceneSegments,
   effectiveSegmenterVersion,
   foldSceneScope,
   meanVector,
@@ -16,6 +19,8 @@ import {
   sceneConfigFingerprint,
   scoreSceneDeterministic,
   SCENE_SCORER_VERSION,
+  type SceneBoundary,
+  type SceneSegment,
   type SceneSegmenterConfig,
   type SceneTurnRow,
 } from '../src/admin/scene-segmentation';
@@ -107,6 +112,113 @@ describe('detectSceneBoundaries', () => {
     const a = detectSceneBoundaries(session, embeddings, OPTS);
     const b = detectSceneBoundaries(session, embeddings, OPTS);
     expect(a).toEqual(b);
+  });
+});
+
+describe('detectSceneSegments — edge provenance', () => {
+  it('is the same segmentation as detectSceneBoundaries, plus the edges', () => {
+    const session = Array.from({ length: 7 }, (_, i) => at(`2026-01-01T10:0${i}:00.000Z`, `t${i}`));
+    const embeddings = session.map((_, i) => (i < 4 ? [1, 0] : [0, 1]));
+    const segments = detectSceneSegments(session, embeddings, OPTS);
+    expect(segments.map((s) => s.turns)).toEqual(detectSceneBoundaries(session, embeddings, OPTS));
+  });
+
+  it('names the rule that made each edge; outer edges are the session', () => {
+    const session = Array.from({ length: 6 }, (_, i) => at(`2026-01-01T10:0${i}:00.000Z`, `t${i}`));
+    const embeddings = session.map((_, i) => (i < 3 ? [1, 0] : [0, 1]));
+    const segments = detectSceneSegments(session, embeddings, OPTS);
+    expect(segments).toHaveLength(2);
+    expect(segments[0]!.startBoundary).toEqual({ kind: 'session' });
+    // The SAME edge ends the first scene and starts the second.
+    expect(segments[0]!.endBoundary.kind).toBe('topic-cosine');
+    expect(segments[0]!.endBoundary.cosine).toBeCloseTo(0, 10);
+    expect(segments[1]!.startBoundary).toEqual(segments[0]!.endBoundary);
+    expect(segments[1]!.endBoundary).toEqual({ kind: 'session' });
+  });
+
+  it('the max-turns cap is named as its own (exact) rule', () => {
+    const session = Array.from({ length: 5 }, (_, i) => at(`2026-01-01T10:0${i}:00.000Z`, `t${i}`));
+    const segments = detectSceneSegments(session, undefined, { minCosine: 0.55, maxTurns: 2 });
+    expect(segments.map((s) => s.endBoundary.kind)).toEqual(['max-turns', 'max-turns', 'session']);
+    expect(segments.every((s) => s.endBoundary.cosine === undefined)).toBe(true);
+  });
+});
+
+describe('scene confidence derivation', () => {
+  const segment = (start: SceneBoundary, end: SceneBoundary): SceneSegment<SceneTurnRow> => ({
+    turns: [],
+    startBoundary: start,
+    endBoundary: end,
+  });
+  const SESSION: SceneBoundary = { kind: 'session' };
+  const CAP: SceneBoundary = { kind: 'max-turns' };
+  const ON = { minCosine: 0.55, topicBoundary: true };
+
+  it('an EXACT rule is certain: session gap and turn cap both score 1', () => {
+    expect(boundaryConfidence(SESSION, 0.55)).toBe(1);
+    expect(boundaryConfidence(CAP, 0.55)).toBe(1);
+    expect(deriveSceneConfidence(segment(SESSION, SESSION), ON)).toBe(1);
+    expect(deriveSceneConfidence(segment(SESSION, CAP), ON)).toBe(1);
+  });
+
+  it('a cosine edge scores by its margin below the floor', () => {
+    // 0.5 + 0.5·(0.55 − 0)/1.55
+    expect(boundaryConfidence({ kind: 'topic-cosine', cosine: 0 }, 0.55)).toBeCloseTo(0.677419, 6);
+    // Maximally opposed turns: the full span, hence 1.
+    expect(boundaryConfidence({ kind: 'topic-cosine', cosine: -1 }, 0.55)).toBeCloseTo(1, 10);
+    // Barely below the floor: a coin-flip boundary, and the row says so.
+    expect(boundaryConfidence({ kind: 'topic-cosine', cosine: 0.5499 }, 0.55)).toBeCloseTo(0.5, 4);
+  });
+
+  it('stays inside [0.5, 1] for every reachable input', () => {
+    for (const cosine of [-1, -0.9, -0.5, 0, 0.2, 0.4, 0.5499]) {
+      const c = boundaryConfidence({ kind: 'topic-cosine', cosine }, 0.55);
+      expect(c).toBeGreaterThanOrEqual(0.5);
+      expect(c).toBeLessThanOrEqual(1);
+    }
+    // Degenerate floor: no cosine can fall below -1, so the edge cannot
+    // exist — the guard must not divide by a zero-width span.
+    expect(boundaryConfidence({ kind: 'topic-cosine', cosine: -1 }, -1)).toBe(1);
+  });
+
+  it('a scene is only as sure as its WEAKER edge', () => {
+    const strong: SceneBoundary = { kind: 'topic-cosine', cosine: -1 };
+    const weak: SceneBoundary = { kind: 'topic-cosine', cosine: 0.5 };
+    const both = deriveSceneConfidence(segment(strong, weak), ON);
+    expect(both).toBeCloseTo(boundaryConfidence(weak, 0.55), 10);
+    expect(both).toBeLessThan(boundaryConfidence(strong, 0.55));
+    // A single soft edge is enough to pull a session-delimited scene down.
+    expect(deriveSceneConfidence(segment(SESSION, weak), ON)).toBeCloseTo(both, 10);
+  });
+
+  it('PIN: with the topic boundary OFF every scene is exactly 1', () => {
+    const off = { minCosine: 0.55, topicBoundary: false };
+    const edges: SceneBoundary[] = [
+      SESSION,
+      CAP,
+      { kind: 'topic-cosine', cosine: 0 },
+      { kind: 'topic-cosine', cosine: 0.5499 },
+    ];
+    for (const start of edges) {
+      for (const end of edges) {
+        expect(deriveSceneConfidence(segment(start, end), off)).toBe(1);
+      }
+    }
+  });
+
+  it('end to end: a real cosine split lands a sub-1 confidence on both halves', () => {
+    const session = Array.from({ length: 6 }, (_, i) => at(`2026-01-01T10:0${i}:00.000Z`, `t${i}`));
+    const embeddings = session.map((_, i) => (i < 3 ? [1, 0] : [0, 1]));
+    const segments = detectSceneSegments(session, embeddings, OPTS);
+    const derived = segments.map((s) => deriveSceneConfidence(s, ON));
+    expect(derived).toHaveLength(2);
+    for (const c of derived) expect(c).toBeCloseTo(0.677419, 6);
+    // The same segments under an embedder-free run are certain.
+    expect(
+      detectSceneSegments(session, undefined, OPTS).map((s) =>
+        deriveSceneConfidence(s, { minCosine: 0.55, topicBoundary: false }),
+      ),
+    ).toEqual([1]);
   });
 });
 


### PR DESCRIPTION
## The hole

Eight `SCENES_*` flags are ON in production (`deploy-brain.yml:234-241`) — segmentation, topic boundary, LLM enrichment, fact backlink, version fingerprint, belief promotion, belief LLM synthesis, evidence links — but **nothing ever ran the composer**. `SceneComposerService.run` had exactly one caller: `admin-scenes.controller.ts:91`. No `@Cron` touched scenes, while every other nightly derivation owns one:

| 03:05 | 03:17 | 03:35 | 03:41 | 03:42 | 03:45 | 03:51 | 03:52 | 04:00 |
|---|---|---|---|---|---|---|---|---|
| recompose | compaction | memory quality | outcome prune | calibration | candidate sweeper | calibration | strategy distill | dreams |

So in prod, scenes — and therefore the **beliefs promoted out of them, which the serving lane reads** — existed only for conversations someone had curled by hand.

Two more, found on the way: the composer full-scanned `conversationCounts` (O(all turns)) and rebuilt *every* conversation on *every* run, and `confidence: 1` was hardcoded on every scene row.

## 1 — Scheduled scene maintenance

New `SceneMaintenanceService` (`src/admin/scene-maintenance.service.ts`). Per tenant:

```
dirty page → compose → [enrich → backlink → evidence links] → belief promotion → clear marks
                        (inside the composer's post-swap chain)
```

**Cron slot: `20 4 * * *` (04:20 UTC).** Every minute of the 03:00 hour is spoken for, and 04:00 is dreams. 04:20 is the first free slot *after* dreams has had its full worker lease (dreams enqueues per-tenant jobs with `ttlSeconds: 1200` = 20 min). That gap is load-bearing, not tidiness: dreams and scene enrichment are the two LLM-heavy nightly passes, and overlapping them has them bid against each other for the same rate limit on the same key. It is also clear of the hourly registry mirror (`:26`), and it reads a substrate compaction and dreams have already settled — the same reasoning that put dreams 43 minutes after compaction.

**House pattern, followed:** tenant roster from `ApiKeyService.knownCompanyIds()` (candidate-sweeper / dreams idiom); per-tenant `try/catch` so one tenant's failure never costs the next its night; `DistributedLeaseGuard` for overlap (one pod, never concurrent with itself), with a local `InFlightGuard` fallback for the no-DI paths.

**Budgets — not optional.** Composing costs one embedding batch per conversation when `SCENES_TOPIC_BOUNDARY` is on, and the post-swap enrichment spends **one structured LLM call per new scene**:

- `SCENES_MAINTENANCE_MAX_CONVERSATIONS` (default **200**) caps the dirty page per tenant per run, **oldest mark first** so a backlog drains in arrival order across nights instead of starving old conversations.
- `SCENES_MAINTENANCE_TIME_BUDGET_MS` (default **1800000** = 30 min) stops the roster from *starting* new tenants. It never aborts a tenant mid-flight — interrupting a compose between the paid step and the swap is exactly the failure mode the composer's ordering exists to avoid.

Nothing is lost when a budget bites: unconsumed marks are still there tomorrow, and skipped tenants are counted (`skippedForBudget`), not forgotten.

### Cost shape (stated plainly)

Per **night**, per tenant, with the prod flag set:

| Leg | Calls | Bound |
|---|---|---|
| Embedding (`SCENES_TOPIC_BOUNDARY`) | 1 batch per **composed conversation** | ≤ `MAX_CONVERSATIONS` = **200 batches** |
| Enrichment (`SCENES_LLM_ENRICHMENT`) | 1 chat call per **NEW or changed scene** | scenes produced by those ≤200 conversations |
| Belief synthesis (`SCENES_BELIEF_LLM_SYNTHESIS`) | 1 chat call per belief **create/revise** (never per corroboration) | beliefs the new scenes move |

The enricher is idempotent (scenes already at the current `enrichmentVersion` composite are skipped), so a night where nothing moved costs **zero** paid calls — that is what the `skipped_no_dirty` series measures. Steady state on a tenant averaging ~5 scenes per active conversation with 20 conversations moving a day: **~20 embedding batches + ~100 chat calls/night**. The worst case is the first night after enabling the flag on a large corpus: **200 conversations × their scenes**, then it drops to the delta. Raising `MAX_CONVERSATIONS` raises the bill linearly; the knob is the throttle.

## 2 — Dirty-conversation trigger (migration 0130)

`EpisodeStoreService.captureTurn` — the one seam that already knows "conversation X just received a turn" — now `UPSERT`s a `scene_dirty_conversation` row **by primary key** (array-literal id, so a burst of turns collapses onto one row with no read-modify-write). The scheduled pass reads a bounded oldest-first page and composes exactly those, clearing by explicit id list after a successful swap.

**Why a table and not a column.** There is no per-conversation row anywhere in the schema to hang a mark on. `episode` is per-**turn** (a smeared mark needs an O(turns) clear whose `WHERE` filters the indexed `conversationId` — the 3.2.4 planner hazard); `conversation_digest` (0086) is the window deriver's own derived world keyed `(conversationId, derivedVersion)`; `projection` is the per-**world** lifecycle ledger, and per-conversation rows there would give `status` two meanings in one subsystem — exactly the trap 0106's NAMING NOTES call out. Also considered and rejected: a derived `max(episode.recordedAt)` watermark (the comparison *is* the O(all conversations) GROUP BY this exists to remove) and a changefeed on `episode` (rejected in 0073 on GDPR grounds). All of this is in the migration header.

**3.2.4 discipline.** Every statement addresses rows by primary key: mark = `UPSERT scene_dirty_conversation:[$conv]`, clear = `SELECT VALUE id … → DELETE … WHERE id INSIDE $doomed`. No `UPDATE`/`DELETE … WHERE` over a secondary or compound index anywhere in this table's lifecycle.

**Race fence.** `readAt` is captured *before* the dirty read; the clear only retires rows still satisfying `markedAt <= readAt`. A turn landing during a long paid compose bumps `markedAt` past that instant, survives the clear, and recomposes next pass. A redundant recompose is cheap and idempotent; a dropped turn would be invisible.

**Composer change is minimal.** `SceneRunOptions` gains `conversationIds`, which skips the `conversationCounts` enumeration whole. The admin full rebuild and the admin targeted rebuild keep their exact previous code path — and the e2e pins that the operator button still covers a conversation that was never marked. With `SCENES_SCHEDULED_MAINTENANCE` off, nothing marks anything.

## 3 — Observability

```
brain_scene_maintenance_total{outcome}          ok | failed | skipped_no_dirty | skipped_budget
brain_scene_maintenance_emitted_total{kind}     conversation | scene | enriched | belief | dirty_cleared
brain_scene_maintenance_duration_seconds        histogram, per-tenant pass, buckets to 30 min
```

No `companyId` label (unbounded cardinality — the house rule). `skipped_no_dirty` is the series that proves the trigger works end to end: if it never fires, marks are not being cleared. `dirty_cleared` lagging `conversation` means turns kept landing during the pass (the race fence), not that marks are leaking.

**Derived confidence.** `confidence: 1` on `memory_episode` is now derived from the two edges that delimit the scene:

- An **exact rule** — the 60-minute session gap or the `SCENES_MAX_TURNS` cap — stays **1**. That is arithmetic, not optimism: "the gap exceeded 60 minutes" is a proposition evaluated with certainty, with no model in the loop to be unsure about. A discount there would be invented.
- A **topic-cosine edge** exists *because* the cosine fell below the floor, so how far below is how strong the evidence was: `0.5 + 0.5·(minCosine − cosine)/(minCosine + 1)`. A split that barely cleared the floor lands at ~0.5 and the row now says so; genuinely opposed turns approach 1. The 0.5 floor is deliberate — the rule *did* fire, so the edge is never evidence against itself.
- A scene takes the **weaker** of its two edges: it is only as well-delimited as its shakiest boundary.

With `SCENES_TOPIC_BOUNDARY` off no cosine edge can exist, so every scene is exactly 1 — byte-identical to the constant it replaces (pinned by a test).

## Default-off contract

`SCENES_SCHEDULED_MAINTENANCE` (scene-flags family + config catalog + `KNOWN_BOOLEAN_FLAGS`, both int knobs boot-validated). Off ⇒ the cron returns before a single query, no `scene_dirty_conversation` row is ever written, the admin routes stay the only trigger. The master flag off stops it too, so marks can never pile up for a composer that is switched off.

## Tests

**Unit (21 new).** Flag-off pins on both the cron and the mark seam (including each flag alone); reentrancy guard (overlapping tick is a no-op, and the guard releases); roster iteration with a failing middle tenant (neighbours complete, the failing tenant keeps every mark); both budgets (page cap + wall clock, with the default-clamp matrix); mark set / cleared / **kept when the composer skipped that conversation**; the three SQL verbs' exact shape (primary-key idioms, the race fence, no query on an empty list); the full confidence matrix.

**E2E (`test/scene-maintenance.e2e-spec.ts`, 7 cases, real SurrealDB 3.2.4).** Ingest → the mark exists (three turns collapsed onto one row) → the pass composes and clears → scenes exist with `confidence: 1` → a second pass finds nothing dirty and composes nothing → new turns re-dirty and the next pass picks them up → the flag-off pin → the admin full-rebuild pin → the per-tenant cap draining across two runs.

Embedder-free and enrichment-free throughout — **no paid API call in any test**.

Gates: `pnpm typecheck`, `pnpm test:unit` (366 suites / 4159 tests), `pnpm lint:ci`, `pnpm format:check` all green, plus the seven scene/belief/episode e2e suites (38 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
