### PR TITLE
feat(evidence): grant and revoke HTTP surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -738,6 +738,10 @@ PRIVACY_COMPOSER_USER_SCOPE=1
 #EVIDENCE_RAW_READ_ENABLED=0
 #EVIDENCE_SIGNED_URL_SECRET=
 #EVIDENCE_SIGNED_URL_TTL_SECONDS=300
+# Sharing surface (0122): grant / list / revoke ownership of an asset.
+# Off = a bare 404 from a guard (no route-revealing 400 on a bad body);
+# needs EVIDENCE_SUBSTRATE_ENABLED or the double gate keeps it dark.
+#EVIDENCE_GRANTS_API_ENABLED=0
 
 # ── Multilingual (Tier 1, migration 0100) ────────────────────────────────
 # Confidence-aware attribution: the detector returns `und` (not `en`) for

--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -1095,6 +1095,57 @@
           }
         ]
       },
+      "EvidenceGrantRow": {
+        "additionalProperties": false,
+        "properties": {
+          "grantId": {
+            "type": "string"
+          },
+          "grantedAt": {
+            "type": "string"
+          },
+          "ownerId": {
+            "type": "string"
+          },
+          "ownerKind": {
+            "enum": [
+              "user",
+              "pack",
+              "system"
+            ],
+            "type": "string"
+          },
+          "purpose": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "grantId",
+          "ownerKind",
+          "ownerId",
+          "grantedAt"
+        ],
+        "type": "object"
+      },
+      "EvidenceGrantsListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "assetId": {
+            "type": "string"
+          },
+          "grants": {
+            "items": {
+              "$ref": "#/components/schemas/EvidenceGrantRow"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "assetId",
+          "grants"
+        ],
+        "type": "object"
+      },
       "EvidenceRawUrlResponse": {
         "additionalProperties": false,
         "properties": {
@@ -1396,6 +1447,59 @@
         "required": [
           "packId",
           "featured"
+        ],
+        "type": "object"
+      },
+      "GrantEvidenceAccessRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "ownerId": {
+            "maxLength": 200,
+            "minLength": 1,
+            "type": "string"
+          },
+          "ownerKind": {
+            "enum": [
+              "user",
+              "pack"
+            ],
+            "type": "string"
+          },
+          "purpose": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "ownerKind",
+          "ownerId"
+        ],
+        "type": "object"
+      },
+      "GrantEvidenceAccessResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "assetId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "boolean"
+          },
+          "grantId": {
+            "type": "string"
+          },
+          "retainUntil": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "grantId",
+          "created",
+          "assetId",
+          "retainUntil"
         ],
         "type": "object"
       },
@@ -2939,6 +3043,23 @@
           "packId",
           "latestVersion",
           "versions"
+        ],
+        "type": "object"
+      },
+      "RevokeEvidenceGrantResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "grantId": {
+            "type": "string"
+          },
+          "revoked": {
+            "const": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "grantId",
+          "revoked"
         ],
         "type": "object"
       },
@@ -4906,6 +5027,48 @@
         ]
       }
     },
+    "/v1/evidence/grants/{grantId}": {
+      "delete": {
+        "description": "Stamps `revokedAt` and KEEPS the row for audit (GDPR erasure hard-deletes instead — a revoked grant still names its owner). IDEMPOTENT: an already-revoked grant answers exactly like a freshly revoked one, keeping its original timestamp, so a retry is indistinguishable from the first call. Ownership is co-equal (0122): any owner of the grant’s asset may revoke any grant on it, including the last one — which is how an asset is administratively killed (the raw-read gateway then denies every read, minted URLs included). Revocation only ever removes access. Acting requires the caller to pass the raw-read gateway’s own fences over the asset: tenant (the lookup runs inside the authenticated tenant), liveness (not tombstoned, quarantine clean-or-absent, retention horizon not already past), OWNERSHIP (at least one live grant exists, and a user-bound key must hold the end user’s own live user grant), and the media-PII polarity (unclassified blocked, `[]` open, classified needs `brain:read_media`) — nobody shares what they cannot read. The byte-delivery steps are deliberately NOT applied (no bytes move here), so a metadata-only `external` asset is shareable; every serve still re-runs the full gateway ladder against the grantee. Any denial is the same bare 404 — unknown, foreign and forbidden are indistinguishable. 404 until `EVIDENCE_GRANTS_API_ENABLED=1` AND `EVIDENCE_SUBSTRATE_ENABLED=1` (raised in a guard, before body validation could reveal the route). Source: src/evidence/evidence-grants.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "revokeEvidenceGrant",
+        "parameters": [
+          {
+            "description": "evidence_grant record id.",
+            "in": "path",
+            "name": "grantId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevokeEvidenceGrantResponse"
+                }
+              }
+            },
+            "description": "The revoked grant."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Revoke an evidence grant",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
     "/v1/evidence/redeem/{token}": {
       "get": {
         "description": "Unauthenticated by design — the token IS the capability. No ABAC/consent/PII re-run; fail-closed re-checks only: signature, expiry, the token’s own tenant, availability still 'hot', and at least one live grant (revocation backstop). Bad, expired and revoked tokens all answer the same bare 404. 404 until EVIDENCE_RAW_READ_ENABLED=1.",
@@ -4938,6 +5101,101 @@
           }
         },
         "summary": "Redeem a signed raw-evidence URL (no auth)",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/evidence/{assetId}/grants": {
+      "get": {
+        "description": "The asset’s LIVE (unrevoked) ownership rows. Revoked rows are audit, not a directory, and stay off the wire. Grantee handles are ownership facts about other principals, so they reach a caller that passed the ownership fence and nobody else — a non-owner gets the same bare 404 as for an asset that does not exist. Acting requires the caller to pass the raw-read gateway’s own fences over the asset: tenant (the lookup runs inside the authenticated tenant), liveness (not tombstoned, quarantine clean-or-absent, retention horizon not already past), OWNERSHIP (at least one live grant exists, and a user-bound key must hold the end user’s own live user grant), and the media-PII polarity (unclassified blocked, `[]` open, classified needs `brain:read_media`) — nobody shares what they cannot read. The byte-delivery steps are deliberately NOT applied (no bytes move here), so a metadata-only `external` asset is shareable; every serve still re-runs the full gateway ladder against the grantee. Any denial is the same bare 404 — unknown, foreign and forbidden are indistinguishable. 404 until `EVIDENCE_GRANTS_API_ENABLED=1` AND `EVIDENCE_SUBSTRATE_ENABLED=1` (raised in a guard, before body validation could reveal the route). Source: src/evidence/evidence-grants.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "listEvidenceGrants",
+        "parameters": [
+          {
+            "description": "evidence_asset record id.",
+            "in": "path",
+            "name": "assetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvidenceGrantsListResponse"
+                }
+              }
+            },
+            "description": "The asset's live grants."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "List an evidence asset’s live owners",
+        "tags": [
+          "Evidence"
+        ]
+      },
+      "post": {
+        "description": "Adds one ownership row (migration 0122) for a `user` handle or an installed `pack`. Idempotent over the live (asset, ownerKind, ownerId) triple: a repeat returns the standing grant with `created: false`. `ownerKind: \"system\"` is REFUSED (400) — a system grant never dies with a user, so a client could pin content past GDPR erasure with it; system ownership stays a write-seam property of registration. The grantee handle is never checked for existence (a grant to an unknown handle is inert), so this is no user-enumeration oracle. There is no grant expiry: 0122 has no such column, an `expiresAt` field is rejected rather than silently ignored, and the asset’s own `retainUntil` — echoed here — is the horizon, since retention purges asset and grants together. Acting requires the caller to pass the raw-read gateway’s own fences over the asset: tenant (the lookup runs inside the authenticated tenant), liveness (not tombstoned, quarantine clean-or-absent, retention horizon not already past), OWNERSHIP (at least one live grant exists, and a user-bound key must hold the end user’s own live user grant), and the media-PII polarity (unclassified blocked, `[]` open, classified needs `brain:read_media`) — nobody shares what they cannot read. The byte-delivery steps are deliberately NOT applied (no bytes move here), so a metadata-only `external` asset is shareable; every serve still re-runs the full gateway ladder against the grantee. Any denial is the same bare 404 — unknown, foreign and forbidden are indistinguishable. 404 until `EVIDENCE_GRANTS_API_ENABLED=1` AND `EVIDENCE_SUBSTRATE_ENABLED=1` (raised in a guard, before body validation could reveal the route). Source: src/evidence/evidence-grants.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "grantEvidenceAccess",
+        "parameters": [
+          {
+            "description": "evidence_asset record id.",
+            "in": "path",
+            "name": "assetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GrantEvidenceAccessRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GrantEvidenceAccessResponse"
+                }
+              }
+            },
+            "description": "The live grant (created now, or the standing one)."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Grant a principal access to an evidence asset",
         "tags": [
           "Evidence"
         ]
@@ -6161,7 +6419,7 @@
       "name": "Beliefs"
     },
     {
-      "description": "The multimodal evidence substrate, both directions. IN: the metadata-only ingest surface — register asset headers + citation-target fragments (originUri required, storageRef rejected, no bytes — the MM-6 boundary); flags EVIDENCE_INGEST_ENABLED (off → 404) and EVIDENCE_SUBSTRATE_ENABLED (off → 503). OUT: the raw-evidence read gateway — original observation bytes back out via direct stream, signed short-lived URLs, fragment twins — behind the full deny-overrides gate ladder (scope, ABAC, tenant/availability/quarantine, ownership grants, pack modality consent, media-PII polarity), every attempt audited content-free; flag EVIDENCE_RAW_READ_ENABLED (off → 404).",
+      "description": "The multimodal evidence substrate, both directions. IN: the metadata-only ingest surface — register asset headers + citation-target fragments (originUri required, storageRef rejected, no bytes — the MM-6 boundary); flags EVIDENCE_INGEST_ENABLED (off → 404) and EVIDENCE_SUBSTRATE_ENABLED (off → 503). OUT: the raw-evidence read gateway — original observation bytes back out via direct stream, signed short-lived URLs, fragment twins — behind the full deny-overrides gate ladder (scope, ABAC, tenant/availability/quarantine, ownership grants, pack modality consent, media-PII polarity), every attempt audited content-free; flag EVIDENCE_RAW_READ_ENABLED (off → 404). ACCESS: the sharing surface — grant, list and revoke the ownership rows (migration 0122) the read side spends, behind the same ownership + media-PII fences and the same uniform 404 (no existence oracle; assets are named by record id, never by content hash); flag EVIDENCE_GRANTS_API_ENABLED (off → 404).",
       "name": "Evidence"
     },
     {

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,6 +124,38 @@ media-PII (`brain:read_media`) → blob head.
 | `GET /v1/evidence/fragments/:fragmentId/raw-url` | Signed-URL twin for fragments. |
 | `GET /v1/evidence/redeem/:token` | Redeem a signed URL — unauthenticated by design; the token IS the capability. Fail-closed re-checks only: signature (timing-safe, before any DB touch), expiry, tenant pin, availability, ≥1 live grant (revocation backstop). Bad/expired/revoked all answer the same bare 404. |
 
+## Evidence sharing surface
+
+The ownership counterpart of the read gateway (Brain v2.1 MM-4,
+migration 0122): the `evidence_grant` rows the ladder above spends, over
+HTTP. All routes answer a bare 404 while `EVIDENCE_GRANTS_API_ENABLED`
+or `EVIDENCE_SUBSTRATE_ENABLED` is off — raised in a **guard**, so even a
+malformed body cannot turn the dark route into a route-revealing 400.
+
+Acting requires the caller to pass the read side's own fences over the
+asset: tenant → liveness (not tombstoned, quarantine clean-or-absent,
+retention horizon not past) → **ownership** (≥1 live grant, and a
+user-bound key must hold the end user's own) → media-PII
+(`brain:read_media`). Nobody shares what they cannot read. The
+byte-delivery steps (`availability='hot'`, blob head) and pack modality
+consent are deliberately NOT applied — no bytes move here, so a
+metadata-only `external` asset is shareable, and every serve still
+re-runs the full gateway ladder against the grantee.
+
+**No existence oracle.** Assets are named by RECORD ID only — no route,
+body field or query parameter accepts a `byteHash` (registration's bare
+409 closes the other half of the dedup-probe leak). Unknown asset,
+foreign tenant, dead asset, non-owner, PII-blocked and malformed id all
+answer the SAME bare 404, over the same two DB round-trips; the grantee
+handle is never checked for existence, so sharing is not a
+user-enumeration oracle either.
+
+| Endpoint | Notes |
+|---|---|
+| `POST /v1/evidence/:assetId/grants` | Share with a `user` handle or an installed `pack` (`brain:write`, ABAC `rest.evidence.grant`). Idempotent over the live (asset, ownerKind, ownerId) triple → `created: false` on a repeat. `ownerKind: "system"` is refused (400): a system grant survives every user's GDPR erasure, so it stays a write-seam property of registration. No expiry field exists (0122 has no column) — `expiresAt` is rejected rather than silently ignored; the asset's `retainUntil`, echoed in the response, is the horizon. |
+| `GET /v1/evidence/:assetId/grants` | The asset's LIVE owners (`brain:read`, ABAC `rest.evidence.grants`). Revoked rows are audit, not a directory, and stay off the wire; a non-owner gets the uniform 404, never a handle. |
+| `DELETE /v1/evidence/grants/:grantId` | Revoke (`brain:write`, ABAC `rest.evidence.revoke`). Idempotent — an already-revoked grant answers identically and keeps its original `revokedAt`. Ownership is co-equal: any owner may revoke any grant on the asset, **including the last one**, which administratively kills it for everyone (minted signed URLs included). Revocation only ever removes access; the row survives as the audit trail. |
+
 ## Mutation (audited)
 
 | Endpoint | Notes |

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1095,6 +1095,57 @@
           }
         ]
       },
+      "EvidenceGrantRow": {
+        "additionalProperties": false,
+        "properties": {
+          "grantId": {
+            "type": "string"
+          },
+          "grantedAt": {
+            "type": "string"
+          },
+          "ownerId": {
+            "type": "string"
+          },
+          "ownerKind": {
+            "enum": [
+              "user",
+              "pack",
+              "system"
+            ],
+            "type": "string"
+          },
+          "purpose": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "grantId",
+          "ownerKind",
+          "ownerId",
+          "grantedAt"
+        ],
+        "type": "object"
+      },
+      "EvidenceGrantsListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "assetId": {
+            "type": "string"
+          },
+          "grants": {
+            "items": {
+              "$ref": "#/components/schemas/EvidenceGrantRow"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "assetId",
+          "grants"
+        ],
+        "type": "object"
+      },
       "EvidenceRawUrlResponse": {
         "additionalProperties": false,
         "properties": {
@@ -1396,6 +1447,59 @@
         "required": [
           "packId",
           "featured"
+        ],
+        "type": "object"
+      },
+      "GrantEvidenceAccessRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "ownerId": {
+            "maxLength": 200,
+            "minLength": 1,
+            "type": "string"
+          },
+          "ownerKind": {
+            "enum": [
+              "user",
+              "pack"
+            ],
+            "type": "string"
+          },
+          "purpose": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "ownerKind",
+          "ownerId"
+        ],
+        "type": "object"
+      },
+      "GrantEvidenceAccessResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "assetId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "boolean"
+          },
+          "grantId": {
+            "type": "string"
+          },
+          "retainUntil": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "grantId",
+          "created",
+          "assetId",
+          "retainUntil"
         ],
         "type": "object"
       },
@@ -2939,6 +3043,23 @@
           "packId",
           "latestVersion",
           "versions"
+        ],
+        "type": "object"
+      },
+      "RevokeEvidenceGrantResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "grantId": {
+            "type": "string"
+          },
+          "revoked": {
+            "const": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "grantId",
+          "revoked"
         ],
         "type": "object"
       },
@@ -4906,6 +5027,48 @@
         ]
       }
     },
+    "/v1/evidence/grants/{grantId}": {
+      "delete": {
+        "description": "Stamps `revokedAt` and KEEPS the row for audit (GDPR erasure hard-deletes instead — a revoked grant still names its owner). IDEMPOTENT: an already-revoked grant answers exactly like a freshly revoked one, keeping its original timestamp, so a retry is indistinguishable from the first call. Ownership is co-equal (0122): any owner of the grant’s asset may revoke any grant on it, including the last one — which is how an asset is administratively killed (the raw-read gateway then denies every read, minted URLs included). Revocation only ever removes access. Acting requires the caller to pass the raw-read gateway’s own fences over the asset: tenant (the lookup runs inside the authenticated tenant), liveness (not tombstoned, quarantine clean-or-absent, retention horizon not already past), OWNERSHIP (at least one live grant exists, and a user-bound key must hold the end user’s own live user grant), and the media-PII polarity (unclassified blocked, `[]` open, classified needs `brain:read_media`) — nobody shares what they cannot read. The byte-delivery steps are deliberately NOT applied (no bytes move here), so a metadata-only `external` asset is shareable; every serve still re-runs the full gateway ladder against the grantee. Any denial is the same bare 404 — unknown, foreign and forbidden are indistinguishable. 404 until `EVIDENCE_GRANTS_API_ENABLED=1` AND `EVIDENCE_SUBSTRATE_ENABLED=1` (raised in a guard, before body validation could reveal the route). Source: src/evidence/evidence-grants.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "revokeEvidenceGrant",
+        "parameters": [
+          {
+            "description": "evidence_grant record id.",
+            "in": "path",
+            "name": "grantId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevokeEvidenceGrantResponse"
+                }
+              }
+            },
+            "description": "The revoked grant."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Revoke an evidence grant",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
     "/v1/evidence/redeem/{token}": {
       "get": {
         "description": "Unauthenticated by design — the token IS the capability. No ABAC/consent/PII re-run; fail-closed re-checks only: signature, expiry, the token’s own tenant, availability still 'hot', and at least one live grant (revocation backstop). Bad, expired and revoked tokens all answer the same bare 404. 404 until EVIDENCE_RAW_READ_ENABLED=1.",
@@ -4938,6 +5101,101 @@
           }
         },
         "summary": "Redeem a signed raw-evidence URL (no auth)",
+        "tags": [
+          "Evidence"
+        ]
+      }
+    },
+    "/v1/evidence/{assetId}/grants": {
+      "get": {
+        "description": "The asset’s LIVE (unrevoked) ownership rows. Revoked rows are audit, not a directory, and stay off the wire. Grantee handles are ownership facts about other principals, so they reach a caller that passed the ownership fence and nobody else — a non-owner gets the same bare 404 as for an asset that does not exist. Acting requires the caller to pass the raw-read gateway’s own fences over the asset: tenant (the lookup runs inside the authenticated tenant), liveness (not tombstoned, quarantine clean-or-absent, retention horizon not already past), OWNERSHIP (at least one live grant exists, and a user-bound key must hold the end user’s own live user grant), and the media-PII polarity (unclassified blocked, `[]` open, classified needs `brain:read_media`) — nobody shares what they cannot read. The byte-delivery steps are deliberately NOT applied (no bytes move here), so a metadata-only `external` asset is shareable; every serve still re-runs the full gateway ladder against the grantee. Any denial is the same bare 404 — unknown, foreign and forbidden are indistinguishable. 404 until `EVIDENCE_GRANTS_API_ENABLED=1` AND `EVIDENCE_SUBSTRATE_ENABLED=1` (raised in a guard, before body validation could reveal the route). Source: src/evidence/evidence-grants.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "listEvidenceGrants",
+        "parameters": [
+          {
+            "description": "evidence_asset record id.",
+            "in": "path",
+            "name": "assetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvidenceGrantsListResponse"
+                }
+              }
+            },
+            "description": "The asset's live grants."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "List an evidence asset’s live owners",
+        "tags": [
+          "Evidence"
+        ]
+      },
+      "post": {
+        "description": "Adds one ownership row (migration 0122) for a `user` handle or an installed `pack`. Idempotent over the live (asset, ownerKind, ownerId) triple: a repeat returns the standing grant with `created: false`. `ownerKind: \"system\"` is REFUSED (400) — a system grant never dies with a user, so a client could pin content past GDPR erasure with it; system ownership stays a write-seam property of registration. The grantee handle is never checked for existence (a grant to an unknown handle is inert), so this is no user-enumeration oracle. There is no grant expiry: 0122 has no such column, an `expiresAt` field is rejected rather than silently ignored, and the asset’s own `retainUntil` — echoed here — is the horizon, since retention purges asset and grants together. Acting requires the caller to pass the raw-read gateway’s own fences over the asset: tenant (the lookup runs inside the authenticated tenant), liveness (not tombstoned, quarantine clean-or-absent, retention horizon not already past), OWNERSHIP (at least one live grant exists, and a user-bound key must hold the end user’s own live user grant), and the media-PII polarity (unclassified blocked, `[]` open, classified needs `brain:read_media`) — nobody shares what they cannot read. The byte-delivery steps are deliberately NOT applied (no bytes move here), so a metadata-only `external` asset is shareable; every serve still re-runs the full gateway ladder against the grantee. Any denial is the same bare 404 — unknown, foreign and forbidden are indistinguishable. 404 until `EVIDENCE_GRANTS_API_ENABLED=1` AND `EVIDENCE_SUBSTRATE_ENABLED=1` (raised in a guard, before body validation could reveal the route). Source: src/evidence/evidence-grants.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "grantEvidenceAccess",
+        "parameters": [
+          {
+            "description": "evidence_asset record id.",
+            "in": "path",
+            "name": "assetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GrantEvidenceAccessRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GrantEvidenceAccessResponse"
+                }
+              }
+            },
+            "description": "The live grant (created now, or the standing one)."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Grant a principal access to an evidence asset",
         "tags": [
           "Evidence"
         ]
@@ -6161,7 +6419,7 @@
       "name": "Beliefs"
     },
     {
-      "description": "The multimodal evidence substrate, both directions. IN: the metadata-only ingest surface — register asset headers + citation-target fragments (originUri required, storageRef rejected, no bytes — the MM-6 boundary); flags EVIDENCE_INGEST_ENABLED (off → 404) and EVIDENCE_SUBSTRATE_ENABLED (off → 503). OUT: the raw-evidence read gateway — original observation bytes back out via direct stream, signed short-lived URLs, fragment twins — behind the full deny-overrides gate ladder (scope, ABAC, tenant/availability/quarantine, ownership grants, pack modality consent, media-PII polarity), every attempt audited content-free; flag EVIDENCE_RAW_READ_ENABLED (off → 404).",
+      "description": "The multimodal evidence substrate, both directions. IN: the metadata-only ingest surface — register asset headers + citation-target fragments (originUri required, storageRef rejected, no bytes — the MM-6 boundary); flags EVIDENCE_INGEST_ENABLED (off → 404) and EVIDENCE_SUBSTRATE_ENABLED (off → 503). OUT: the raw-evidence read gateway — original observation bytes back out via direct stream, signed short-lived URLs, fragment twins — behind the full deny-overrides gate ladder (scope, ABAC, tenant/availability/quarantine, ownership grants, pack modality consent, media-PII polarity), every attempt audited content-free; flag EVIDENCE_RAW_READ_ENABLED (off → 404). ACCESS: the sharing surface — grant, list and revoke the ownership rows (migration 0122) the read side spends, behind the same ownership + media-PII fences and the same uniform 404 (no existence oracle; assets are named by record id, never by content hash); flag EVIDENCE_GRANTS_API_ENABLED (off → 404).",
       "name": "Evidence"
     },
     {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -138,6 +138,7 @@ overview — one line per flag, plus the orderings that matter.
 | `EVIDENCE_RAW_READ_ENABLED` | `0` | The raw-read gateway (`/v1/evidence/*` — see [api.md](api.md#evidence-raw-read-gateway)); off = bare 404s. |
 | `EVIDENCE_SIGNED_URL_SECRET` | unset | HMAC secret for signed raw URLs; boot hard-errors when shorter than 32 chars while the gateway is on. No default on purpose. |
 | `EVIDENCE_SIGNED_URL_TTL_SECONDS` | `300` | Signed-URL lifetime — deliberately short; expiry + the live-grant re-check at redeem are the only revocation levers. |
+| `EVIDENCE_GRANTS_API_ENABLED` | `0` | The sharing surface (`/v1/evidence/*/grants` — see [api.md](api.md#evidence-sharing-surface)): grant, list and revoke the ownership rows (0122) the read side spends. Requires the substrate flag (boot warns on the pair); off = bare 404s raised in a guard, so not even a malformed body reveals the route. |
 
 **Grounding order:** stamp before you gate. Enable
 `EVIDENCE_GROUNDING_STAMP` first and let writes accrue stamps; only
@@ -151,7 +152,12 @@ external ingest by definition, so with the seam off every upload answers
 503 (boot warns on the pair). Note the scan hook shipped today is the
 ALLOW-ALL stub — it exercises the quarantined → scanning → clean
 lifecycle but passes everything; install a real scanner before trusting
-uploads from untrusted callers.
+uploads from untrusted callers. **Sharing order:** the sharing surface
+hands out the very grants the raw-read gateway spends, so turn
+`EVIDENCE_GRANTS_API_ENABLED` on only once you are satisfied with who
+holds `brain:write` — a caller who can already read an asset can hand it
+to anyone, and revoking the LAST grant kills the asset for everyone
+(minted signed URLs included, by design).
 
 ### `TOOL_OBSERVATION*` — MCP tool-call observations (0111)
 

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -126,6 +126,13 @@ import {
 } from '../src/contracts/users/user-profile.schema';
 import { EvidenceRawUrlResponseSchema } from '../src/contracts/evidence/raw.schema';
 import {
+  EvidenceGrantRowSchema,
+  EvidenceGrantsListResponseSchema,
+  GrantEvidenceAccessRequestSchema,
+  GrantEvidenceAccessResponseSchema,
+  RevokeEvidenceGrantResponseSchema,
+} from '../src/contracts/evidence/grants.schema';
+import {
   EvidenceFragmentLocatorSchema,
   IngestEvidenceAssetRequestSchema,
   IngestEvidenceAssetResponseSchema,
@@ -240,6 +247,12 @@ const ZOD_COMPONENTS: Record<string, z.ZodType> = {
   UserProfileResponse: UserProfileResponseSchema,
   // --- raw-evidence read gateway (src/contracts/evidence/raw.schema.ts)
   EvidenceRawUrlResponse: EvidenceRawUrlResponseSchema,
+  // --- evidence sharing (src/contracts/evidence/grants.schema.ts)
+  GrantEvidenceAccessRequest: GrantEvidenceAccessRequestSchema,
+  GrantEvidenceAccessResponse: GrantEvidenceAccessResponseSchema,
+  EvidenceGrantRow: EvidenceGrantRowSchema,
+  EvidenceGrantsListResponse: EvidenceGrantsListResponseSchema,
+  RevokeEvidenceGrantResponse: RevokeEvidenceGrantResponseSchema,
   // --- evidence ingest (src/contracts/evidence/evidence-ingest.schema.ts)
   EvidenceFragmentLocator: EvidenceFragmentLocatorSchema,
   IngestEvidenceFragment: IngestEvidenceFragmentSchema,
@@ -1345,6 +1358,116 @@ function evidencePaths(): Json {
   };
 }
 
+/**
+ * Evidence sharing surface (Brain v2.1 MM-4, migration 0122). The same
+ * no-existence-oracle contract as the read gateway, for the same reason:
+ * a sharing route is where a probing client would look for one. Assets
+ * are addressed by RECORD ID only — no route, body field or query
+ * parameter accepts a byteHash — and every denial (unknown asset,
+ * foreign tenant, dead/quarantined/past-retention asset, non-owner,
+ * media-PII-blocked, malformed id) is the SAME bare 404, over the same
+ * DB round-trips.
+ */
+function evidenceGrantPaths(): Json {
+  const ladder =
+    'Acting requires the caller to pass the raw-read gateway’s own ' +
+    'fences over the asset: tenant (the lookup runs inside the ' +
+    'authenticated tenant), liveness (not tombstoned, quarantine ' +
+    'clean-or-absent, retention horizon not already past), OWNERSHIP ' +
+    '(at least one live grant exists, and a user-bound key must hold ' +
+    'the end user’s own live user grant), and the media-PII polarity ' +
+    '(unclassified blocked, `[]` open, classified needs ' +
+    '`brain:read_media`) — nobody shares what they cannot read. The ' +
+    'byte-delivery steps are deliberately NOT applied (no bytes move ' +
+    'here), so a metadata-only `external` asset is shareable; every ' +
+    'serve still re-runs the full gateway ladder against the grantee. ' +
+    'Any denial is the same bare 404 — unknown, foreign and forbidden ' +
+    'are indistinguishable. 404 until `EVIDENCE_GRANTS_API_ENABLED=1` ' +
+    'AND `EVIDENCE_SUBSTRATE_ENABLED=1` (raised in a guard, before body ' +
+    'validation could reveal the route). Source: ' +
+    'src/evidence/evidence-grants.controller.ts.';
+  return {
+    '/v1/evidence/{assetId}/grants': {
+      post: operation({
+        operationId: 'grantEvidenceAccess',
+        tag: 'Evidence',
+        summary: 'Grant a principal access to an evidence asset',
+        description:
+          'Adds one ownership row (migration 0122) for a `user` handle ' +
+          'or an installed `pack`. Idempotent over the live (asset, ' +
+          'ownerKind, ownerId) triple: a repeat returns the standing ' +
+          'grant with `created: false`. `ownerKind: "system"` is ' +
+          'REFUSED (400) — a system grant never dies with a user, so a ' +
+          'client could pin content past GDPR erasure with it; system ' +
+          'ownership stays a write-seam property of registration. The ' +
+          'grantee handle is never checked for existence (a grant to an ' +
+          'unknown handle is inert), so this is no user-enumeration ' +
+          'oracle. There is no grant expiry: 0122 has no such column, ' +
+          'an `expiresAt` field is rejected rather than silently ' +
+          'ignored, and the asset’s own `retainUntil` — echoed here — ' +
+          'is the horizon, since retention purges asset and grants ' +
+          'together. ' +
+          ladder,
+        scope: 'brain:write',
+        parameters: [pathParam('assetId', 'evidence_asset record id.')],
+        requestBody: jsonBody(ref('GrantEvidenceAccessRequest')),
+        responses: {
+          '201': jsonResponse(
+            'The live grant (created now, or the standing one).',
+            ref('GrantEvidenceAccessResponse'),
+          ),
+          '400': errorRef('BadRequest'),
+          ...DRIVER_404,
+        },
+      }),
+      get: operation({
+        operationId: 'listEvidenceGrants',
+        tag: 'Evidence',
+        summary: 'List an evidence asset’s live owners',
+        description:
+          'The asset’s LIVE (unrevoked) ownership rows. Revoked rows are ' +
+          'audit, not a directory, and stay off the wire. Grantee ' +
+          'handles are ownership facts about other principals, so they ' +
+          'reach a caller that passed the ownership fence and nobody ' +
+          'else — a non-owner gets the same bare 404 as for an asset ' +
+          'that does not exist. ' +
+          ladder,
+        scope: 'brain:read',
+        parameters: [pathParam('assetId', 'evidence_asset record id.')],
+        responses: {
+          '200': jsonResponse("The asset's live grants.", ref('EvidenceGrantsListResponse')),
+          ...DRIVER_404,
+        },
+      }),
+    },
+    '/v1/evidence/grants/{grantId}': {
+      delete: operation({
+        operationId: 'revokeEvidenceGrant',
+        tag: 'Evidence',
+        summary: 'Revoke an evidence grant',
+        description:
+          'Stamps `revokedAt` and KEEPS the row for audit (GDPR erasure ' +
+          'hard-deletes instead — a revoked grant still names its ' +
+          'owner). IDEMPOTENT: an already-revoked grant answers exactly ' +
+          'like a freshly revoked one, keeping its original timestamp, ' +
+          'so a retry is indistinguishable from the first call. ' +
+          'Ownership is co-equal (0122): any owner of the grant’s asset ' +
+          'may revoke any grant on it, including the last one — which ' +
+          'is how an asset is administratively killed (the raw-read ' +
+          'gateway then denies every read, minted URLs included). ' +
+          'Revocation only ever removes access. ' +
+          ladder,
+        scope: 'brain:write',
+        parameters: [pathParam('grantId', 'evidence_grant record id.')],
+        responses: {
+          '200': jsonResponse('The revoked grant.', ref('RevokeEvidenceGrantResponse')),
+          ...DRIVER_404,
+        },
+      }),
+    },
+  };
+}
+
 function indexerWorkPaths(): Json {
   return {
     '/v1/indexer/work': {
@@ -1794,7 +1917,13 @@ export function buildOpenApiDocument(): Json {
           'full deny-overrides gate ladder (scope, ABAC, tenant/' +
           'availability/quarantine, ownership grants, pack modality ' +
           'consent, media-PII polarity), every attempt audited ' +
-          'content-free; flag EVIDENCE_RAW_READ_ENABLED (off → 404).',
+          'content-free; flag EVIDENCE_RAW_READ_ENABLED (off → 404). ' +
+          'ACCESS: the sharing surface — grant, list and revoke the ' +
+          'ownership rows (migration 0122) the read side spends, behind ' +
+          'the same ownership + media-PII fences and the same uniform ' +
+          '404 (no existence oracle; assets are named by record id, ' +
+          'never by content hash); flag EVIDENCE_GRANTS_API_ENABLED ' +
+          '(off → 404).',
       },
       {
         name: 'Users',
@@ -1814,6 +1943,7 @@ export function buildOpenApiDocument(): Json {
       ...driverPaths(),
       ...memoryReadPaths(),
       ...evidencePaths(),
+      ...evidenceGrantPaths(),
       ...evidenceIngestPaths(),
     },
     webhooks: {

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1521,6 +1521,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Raw-read gateway (MM-3, migration 0125): the ONE surface serving original evidence bytes — GET /v1/evidence/{assetId}/raw(-url), the fragment twins (whole parent-asset bytes under the STRICTEST fragment+asset piiClasses union), and the unauthenticated signed-URL redeem. Full deny-overrides gate ladder (scope → tenant/availability/quarantine → live grants → ABAC rest.evidence.raw → modality consent via a direct fail-closed domain_pack read → media-PII polarity → blob head), every attempt recorded content-free in evidence_access. Off (default) = every route answers a bare 404, indistinguishable from absent routes — byte-identical.',
   },
   {
+    key: 'EVIDENCE_GRANTS_API_ENABLED',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      "Sharing surface (MM-4, migration 0122): the three ownership verbs over an existing asset — POST /v1/evidence/{assetId}/grants (share with a user or a pack), GET /v1/evidence/{assetId}/grants (live owners) and DELETE /v1/evidence/grants/{grantId} (revoke, idempotent). Assets are addressed by RECORD ID only, never by byteHash — the surface is deliberately no existence oracle: unknown asset, foreign tenant, dead/quarantined asset, non-owner and media-PII-blocked all answer ONE bare 404 with the same body and the same two DB round-trips. Acting requires the caller to pass the raw-read gateway's own ownership fence (a user-bound key needs its OWN live user grant; an M2M key needs the asset to hold at least one live grant) plus the media-PII polarity (unclassified blocked, `[]` open, classified needs brain:read_media), so nobody can share what they cannot read. ownerKind 'system' is refused (400): system ownership would pin content past every user's GDPR erasure and belongs to the write seam, not to a client. Requires EVIDENCE_SUBSTRATE_ENABLED. Off (default) = every route answers a bare 404 raised in a guard, BEFORE the global ValidationPipe could turn a malformed body into a route-revealing 400 — byte-identical prod.",
+  },
+  {
     key: 'EVIDENCE_SIGNED_URL_SECRET',
     category: 'pipeline',
     defaultValue: '',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -266,6 +266,7 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // ── Evidence plane: claim grounding (Drift-1, migration 0115) ──────
   validateEvidenceGroundingEnv(env, warnings);
   validateEvidenceIngestEnv(env, warnings);
+  validateEvidenceGrantsApiEnv(env, warnings);
   validateEvidenceUploadEnv(env, warnings);
 
   // ── Evidence plane: processing lifecycle (migration 0121) ──────────
@@ -529,6 +530,28 @@ function validateEvidenceIngestEnv(env: NodeJS.ProcessEnv, warnings: string[]): 
         'the ingest surface is exposed but the evidence write seam refuses every ' +
         'call; every POST /v1/ingest/evidence-asset will be rejected (503) until ' +
         'EVIDENCE_SUBSTRATE_ENABLED is turned on.',
+    );
+  }
+}
+
+/**
+ * Cross-flag consistency for the sharing surface (Brain v2.1 MM-4): a
+ * WARNING, not an error — the same shape as the ingest pair. With
+ * EVIDENCE_GRANTS_API_ENABLED but no EVIDENCE_SUBSTRATE_ENABLED the
+ * controller's double gate answers a bare 404 for every call (the write
+ * seam would refuse anyway), so the surface looks absent while the
+ * operator believes it is on. Nothing fails open — the pair is simply
+ * inert, and the operator should know before the first caller bounces.
+ */
+function validateEvidenceGrantsApiEnv(env: NodeJS.ProcessEnv, warnings: string[]): void {
+  if (
+    envFlagEnabled(env.EVIDENCE_GRANTS_API_ENABLED) &&
+    !envFlagEnabled(env.EVIDENCE_SUBSTRATE_ENABLED)
+  ) {
+    warnings.push(
+      'EVIDENCE_GRANTS_API_ENABLED is set while EVIDENCE_SUBSTRATE_ENABLED is not — ' +
+        'the sharing surface stays dark (its double gate answers a bare 404 for ' +
+        'every grant/list/revoke) until EVIDENCE_SUBSTRATE_ENABLED is turned on.',
     );
   }
 }
@@ -1254,6 +1277,15 @@ const KNOWN_BOOLEAN_FLAGS = [
   // (validateEvidenceRawReadEnv). EVIDENCE_ family sits off the ENGINE
   // flag budget by design (see above).
   'EVIDENCE_RAW_READ_ENABLED',
+  // Sharing surface (MM-4, migration 0122): the three ownership verbs
+  // over an existing asset (share / list live owners / revoke). Default
+  // off = every route answers a bare 404 raised in a GUARD, before the
+  // global ValidationPipe could turn a malformed body into a
+  // route-revealing 400 — byte-identical prod. Needs
+  // EVIDENCE_SUBSTRATE_ENABLED to write (validateEvidenceGrantsApiEnv
+  // warns on the inconsistent pair). EVIDENCE_ family sits off the
+  // ENGINE flag budget by design (see above).
+  'EVIDENCE_GRANTS_API_ENABLED',
   // Outcome telemetry master (0107): writers append memory_outcome rows
   // + fold memory_outcome_stat counters; the nightly raw-log prune runs.
   // Default off = byte-identical (every writer is a guarded no-op).

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -73,6 +73,39 @@ export function evidenceBlobUploadEnabled(): boolean {
 }
 
 /**
+ * Sharing surface (Brain v2.1 MM-4, migration 0122) —
+ * EVIDENCE_GRANTS_API_ENABLED.
+ *
+ * When on, EvidenceGrantsController exposes the three ownership verbs
+ * over an existing asset: POST /v1/evidence/{assetId}/grants (share),
+ * GET /v1/evidence/{assetId}/grants (list live owners) and DELETE
+ * /v1/evidence/grants/{grantId} (revoke). Off (default) ⇒ every route
+ * answers a bare 404 — raised in a GUARD, so it precedes the global
+ * ValidationPipe and a malformed body cannot turn the dark route into a
+ * route-revealing 400 (the EVIDENCE_BLOB_UPLOAD_ENABLED interceptor
+ * lesson, applied to a JSON body).
+ *
+ * The surface is the reason 0122's write seam was held back
+ * service-only: a sharing route is exactly where a hash-probing client
+ * would look for an existence oracle. It therefore addresses assets ONLY
+ * by record id (never by byteHash), requires the caller to pass the same
+ * ownership + media-PII fences the raw-read gateway applies before it
+ * will act, and answers ONE bare 404 for every negative outcome —
+ * unknown asset, foreign tenant, dead asset, non-owner and PII-blocked
+ * are indistinguishable in status, body and DB round-trips.
+ *
+ * Needs EVIDENCE_SUBSTRATE_ENABLED to write (the store's own 503 gate;
+ * the controller double-gates to a 404 so a dark substrate advertises no
+ * sharing surface at all) — env-validation warns at boot on the
+ * inconsistent pair. Read at call time (runtime-mutable); the env read
+ * lives here in the common layer, NOT in the controller (engine-gates
+ * S5.2). EVIDENCE_ family sits off the ENGINE flag budget by design.
+ */
+export function evidenceGrantsApiEnabled(): boolean {
+  return envFlagEnabled(process.env.EVIDENCE_GRANTS_API_ENABLED);
+}
+
+/**
  * Filesystem storage-adapter root — EVIDENCE_FS_ROOT (non-boolean).
  *
  * The directory the fs:// adapter stores content-addressed blobs under

--- a/src/contracts/evidence/grants.schema.ts
+++ b/src/contracts/evidence/grants.schema.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+
+/**
+ * Wire contracts for the evidence sharing surface (Brain v2.1 MM-4,
+ * migration 0122 — EVIDENCE_GRANTS_API_ENABLED, default off → 404).
+ *
+ * A grant is an OWNERSHIP row, not a capability token: it says WHO may
+ * hold an observation, while every serve of the bytes re-runs the
+ * raw-read gateway's own ladder (0125). So these shapes carry no secret,
+ * no URL and no expiry — 0122 defines exactly four grant fields
+ * (assetId, ownerKind, ownerId, purpose) plus the timestamps, and the
+ * only horizon a grant has is the ASSET's retention (`retainUntil`,
+ * echoed on the grant response): retention tombstones the asset and
+ * purges every grant row with it, so no grant can outlive its content.
+ *
+ * Runtime truth lives at the write seam (evidence-store.service.ts
+ * addGrant / revokeGrant / liveGrants) and in the authorization ladder
+ * (evidence-grant.service.ts); these schemas document the wire.
+ */
+
+/** Grantee kinds a CLIENT may name. 0122's column also allows 'system',
+ *  which this surface refuses: a system grant is live forever and would
+ *  pin content past every user's GDPR erasure, so system ownership stays
+ *  a property the write seam stamps at registration. */
+export const EVIDENCE_GRANTEE_KINDS = ['user', 'pack'] as const;
+
+export const GrantEvidenceAccessRequestSchema = z.object({
+  /** 'user' = an end-user handle (the 0055 per-user fence the raw-read
+   *  gateway enforces); 'pack' = an installed domain pack's id. */
+  ownerKind: z.enum(EVIDENCE_GRANTEE_KINDS),
+  /** Opaque owner handle — never content, never validated for existence
+   *  (a grant to an unknown handle is inert, and probing for one must
+   *  not become a user-enumeration oracle). */
+  ownerId: z.string().min(1).max(200),
+  /** Short machine tag ('share', 'processor'…) — open vocabulary. */
+  purpose: z.string().max(64).optional(),
+});
+export type GrantEvidenceAccessRequest = z.infer<typeof GrantEvidenceAccessRequestSchema>;
+
+/** One LIVE (unrevoked) ownership row. Revoked rows are audit, not wire. */
+export const EvidenceGrantRowSchema = z.object({
+  grantId: z.string(),
+  ownerKind: z.enum(['user', 'pack', 'system']),
+  ownerId: z.string(),
+  purpose: z.string().optional(),
+  /** ISO instant the ownership started. */
+  grantedAt: z.string(),
+});
+export type EvidenceGrantRow = z.infer<typeof EvidenceGrantRowSchema>;
+
+export const GrantEvidenceAccessResponseSchema = z.object({
+  grantId: z.string(),
+  /** False when an identical LIVE grant already existed (idempotent
+   *  re-share returns the standing row instead of a duplicate). */
+  created: z.boolean(),
+  assetId: z.string(),
+  /** The asset's retention horizon (ISO) or null when it has none — the
+   *  effective end of this grant: retention purges asset and grants
+   *  together, and a grant over an asset already past it is refused. */
+  retainUntil: z.string().nullable(),
+});
+export type GrantEvidenceAccessResponse = z.infer<typeof GrantEvidenceAccessResponseSchema>;
+
+export const RevokeEvidenceGrantResponseSchema = z.object({
+  grantId: z.string(),
+  /** Always true — revocation is idempotent, and an already-revoked
+   *  grant answers exactly like a freshly revoked one (its original
+   *  revokedAt timestamp is kept for audit). */
+  revoked: z.literal(true),
+});
+export type RevokeEvidenceGrantResponse = z.infer<typeof RevokeEvidenceGrantResponseSchema>;
+
+export const EvidenceGrantsListResponseSchema = z.object({
+  assetId: z.string(),
+  /** Live owners only, and only for a caller that passed the ownership
+   *  fence — grantee handles never reach a non-owner. */
+  grants: z.array(EvidenceGrantRowSchema),
+});
+export type EvidenceGrantsListResponse = z.infer<typeof EvidenceGrantsListResponseSchema>;

--- a/src/evidence/dto/grant-evidence-access.dto.ts
+++ b/src/evidence/dto/grant-evidence-access.dto.ts
@@ -1,0 +1,43 @@
+import { IsIn, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  EVIDENCE_GRANTEE_KINDS,
+  type GrantEvidenceAccessRequest,
+} from '../../contracts/evidence/grants.schema';
+
+/**
+ * Wire shape of POST /v1/evidence/{assetId}/grants
+ * (EVIDENCE_GRANTS_API_ENABLED, default off → 404).
+ *
+ * Deliberately TINY, and the omissions are the contract:
+ *
+ *  - no `assetId` in the body — the asset is the path, so a request
+ *    cannot name one subject and act on another;
+ *  - no `byteHash` — the surface never resolves content identity to a
+ *    row, which is what closes the dedup-probe leak 0122's write seam
+ *    already refuses to open (registerAsset's bare 409);
+ *  - no `ownerKind: 'system'` — a system grant never dies with a user,
+ *    so a client could pin content past GDPR erasure with it; system
+ *    ownership stays a write-seam property of registration;
+ *  - no expiry field — 0122 has no grant-expiry column, and the global
+ *    `forbidNonWhitelisted` pipe therefore rejects `expiresAt` with a
+ *    400 rather than accepting a horizon nothing would enforce. The
+ *    asset's own `retainUntil` IS the horizon (echoed on the response).
+ */
+export class GrantEvidenceAccessDto implements GrantEvidenceAccessRequest {
+  @IsIn(EVIDENCE_GRANTEE_KINDS)
+  ownerKind!: (typeof EVIDENCE_GRANTEE_KINDS)[number];
+
+  /** Opaque grantee handle. Never checked for existence: a grant to an
+   *  unknown user is inert, and answering differently would turn the
+   *  route into a user-enumeration oracle. */
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  ownerId!: string;
+
+  /** Short machine tag; the write seam caps it at 64 chars too. */
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  purpose?: string | undefined;
+}

--- a/src/evidence/evidence-grant.service.ts
+++ b/src/evidence/evidence-grant.service.ts
@@ -1,0 +1,304 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import type { Surreal } from 'surrealdb';
+import { mediaPiiAllowed } from '../common/media-pii';
+import { SurrealService, queryFirst, queryRows } from '../db/surreal.service';
+import { idTailOf } from '../ingest/ingest-utils';
+import type {
+  EvidenceGrantRow,
+  GrantEvidenceAccessRequest,
+} from '../contracts/evidence/grants.schema';
+import { EvidenceStoreService } from './evidence-store.service';
+
+/** Bound on a caller-supplied record id before it reaches the DB. Over
+ *  the cap is NOT a distinguishable error — the id is simply replaced by
+ *  the sentinel below, so a malformed probe walks the same path as a
+ *  well-formed miss. */
+const RECORD_ID_MAX = 256;
+
+/** Tail used when a caller's id is malformed, or when a grant lookup
+ *  found nothing and the ladder must still run: `type::record()` over it
+ *  is a syntactically valid record id that no writer can ever mint (every
+ *  id in these tables is a ULID or a 32-hex digest), so the ladder issues
+ *  the SAME queries against the SAME indexes and finds nothing. */
+const ABSENT_TAIL = '__absent__';
+
+/** Who is asking — the authenticated slice the ladder fences on. */
+export interface GrantCaller {
+  scopes: readonly string[];
+  /** End-user of a user-bound token; absent for M2M credentials. */
+  userId?: string | undefined;
+}
+
+interface AssetLadderRow {
+  id: unknown;
+  availability?: string | undefined;
+  quarantineStatus?: string | null | undefined;
+  piiClasses?: string[] | null | undefined;
+  retainUntil?: string | Date | null | undefined;
+}
+
+/** What the ladder resolved — enough to act, and nothing about bytes. */
+interface GrantSubject {
+  assetIdStr: string;
+  retainUntil: string | null;
+}
+
+/**
+ * EvidenceGrantService — the authorization half of the sharing surface
+ * (Brain v2.1 MM-4, migration 0122). The controller keeps transport; the
+ * write seam (EvidenceStoreService.addGrant / revokeGrant / liveGrants)
+ * keeps persistence; this service owns the ONE question both of them
+ * refuse to answer on their own: may THIS caller act on THIS asset?
+ *
+ * WHY THE SURFACE WAS WITHHELD. 0122 shipped the grant machinery
+ * service-only with an explicit note — "callers are authorized code
+ * paths, never a hash-probing client". A sharing route is the natural
+ * home of an existence oracle: hand it an id (or, worse, a content hash)
+ * and let the status code say whether those bytes exist in this tenant.
+ * registerAsset already closes the hash half by answering a bare 409
+ * without the stored row's metadata; this ladder closes the id half.
+ *
+ * THE LADDER (deny-overrides, evaluated over rows already fetched):
+ *   (1) tenant fence — every lookup runs inside withCompany(companyId),
+ *       so a foreign asset is simply not found;
+ *   (2) liveness — availability != 'gone', quarantineStatus clean or
+ *       absent (0121: nothing writes a status while the seam is off),
+ *       and retainUntil not already past (an asset the sweeper owes a
+ *       tombstone must not be re-shared: a grant may not outlive the
+ *       asset's own retention policy);
+ *   (3) ownership — the raw-read gateway's own fence, verbatim: at least
+ *       one live grant must exist, and a USER-BOUND key must hold the
+ *       end user's own live user grant (0055/0093). Nobody grants what
+ *       they do not hold;
+ *   (4) media PII — the polarity gate of src/common/media-pii.ts over
+ *       the asset's classes: unclassified blocked, `[]` open, classified
+ *       needs brain:read_media. Nobody shares what they cannot see.
+ * Every failure is the SAME bare 404 — the caller cannot tell "no such
+ * asset" from "not yours" from "PII-blocked".
+ *
+ * WHAT THE LADDER DELIBERATELY OMITS vs the raw-read ladder: the
+ * byte-delivery steps (availability='hot' and the blob head) and the
+ * pack modality-consent fold. Those govern whether ORIGINAL BYTES may
+ * leave the service, and no byte moves here — an ownership row over an
+ * `external` (metadata-only) or not-yet-hot asset is legitimate and
+ * grants strictly nothing extra, because every serve re-runs the full
+ * gateway ladder (consent included) against the grantee. Consent is a
+ * tenant-level serving switch, not an ownership fact: folding it in
+ * would make sharing impossible for tenants whose packs declare no raw
+ * evidence, while granting no additional safety — the bytes stay shut
+ * either way.
+ *
+ * TIMING. The two round-trips (asset row, live grants) are issued
+ * UNCONDITIONALLY, in the same order, against the same indexes, for
+ * every outcome — a missing asset probes the grant index with a record
+ * id that matches nothing rather than short-circuiting. So the deny
+ * classes are not separable by query count or query shape. This is a
+ * structural equalization, not a constant-time guarantee: a statistical
+ * attacker with enough samples can still see row-count differences.
+ */
+@Injectable()
+export class EvidenceGrantService {
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly store: EvidenceStoreService,
+  ) {}
+
+  /**
+   * Share an asset with one more owner. Idempotent over the live
+   * (asset, ownerKind, ownerId) triple — the write seam's own dedup, so
+   * a retry returns the standing row with `created: false`.
+   */
+  async grant(
+    companyId: string,
+    caller: GrantCaller,
+    input: GrantEvidenceAccessRequest & { assetId: string },
+  ): Promise<{ grantId: string; created: boolean; assetId: string; retainUntil: string | null }> {
+    const subject = await this.resolveAsset(companyId, caller, input.assetId);
+    const written = await this.uniform(
+      this.store.addGrant(companyId, {
+        assetId: subject.assetIdStr,
+        ownerKind: input.ownerKind,
+        ownerId: input.ownerId,
+        // 'share' is what this surface does; the seam keeps the tag open
+        // vocabulary, so an explicit purpose always wins.
+        purpose: input.purpose ?? 'share',
+      }),
+    );
+    return { ...written, assetId: subject.assetIdStr, retainUntil: subject.retainUntil };
+  }
+
+  /**
+   * Take an ownership row back. Idempotent: an already-revoked grant
+   * answers exactly like a freshly revoked one (the seam keeps the
+   * original revokedAt for audit), so a retry is indistinguishable from
+   * the first call — and so is a probe for a revoked grant's id.
+   *
+   * Co-equal ownership (the 0122 model): the ladder runs over the
+   * grant's OWN asset, so any owner may revoke any grant on it —
+   * including the last one, which is how an asset is administratively
+   * killed. Revocation only ever REMOVES access, and the row survives
+   * with its timestamp as the audit trail of who lost what.
+   */
+  async revoke(
+    companyId: string,
+    caller: GrantCaller,
+    grantId: string,
+  ): Promise<{ grantId: string; revoked: true }> {
+    const resolved = await this.surreal.withCompany(companyId, async (db) => {
+      const grant = await queryFirst<{ id: unknown; assetId: unknown }>(
+        db,
+        `SELECT id, assetId FROM type::record('evidence_grant', $tail) LIMIT 1`,
+        { tail: tailOf(grantId, 'evidence_grant') },
+      );
+      // The ladder runs either way — an unknown grant id costs the same
+      // two round-trips as one that exists but is not the caller's.
+      const subject = await this.ladder(
+        db,
+        grant ? tailOf(String(grant.assetId), 'evidence_asset') : ABSENT_TAIL,
+        caller,
+      );
+      return grant && subject ? String(grant.id) : null;
+    });
+    if (resolved === null) throw new NotFoundException();
+    await this.uniform(this.store.revokeGrant(companyId, resolved));
+    return { grantId: resolved, revoked: true };
+  }
+
+  /**
+   * The asset's LIVE owners. Grantee handles are ownership facts about
+   * other principals, so they reach only a caller the ladder recognized
+   * as an owner; everyone else gets the same bare 404 as for an asset
+   * that does not exist. Revoked rows stay off the wire — they are audit
+   * (a revoked grant still names its owner), not a directory.
+   */
+  async list(
+    companyId: string,
+    caller: GrantCaller,
+    assetId: string,
+  ): Promise<{ assetId: string; grants: EvidenceGrantRow[] }> {
+    const subject = await this.resolveAsset(companyId, caller, assetId);
+    const rows = await this.store.liveGrants(companyId, subject.assetIdStr);
+    return {
+      assetId: subject.assetIdStr,
+      grants: rows.map((r) => ({
+        grantId: r.grantId,
+        ownerKind: asOwnerKind(r.ownerKind),
+        ownerId: r.ownerId,
+        ...(r.purpose !== undefined ? { purpose: r.purpose } : {}),
+        grantedAt: isoOf(r.grantedAt) ?? new Date(0).toISOString(),
+      })),
+    };
+  }
+
+  /** Ladder over a caller-named asset id; the uniform 404 on any deny. */
+  private async resolveAsset(
+    companyId: string,
+    caller: GrantCaller,
+    assetId: string,
+  ): Promise<GrantSubject> {
+    const subject = await this.surreal.withCompany(companyId, (db) =>
+      this.ladder(db, tailOf(assetId, 'evidence_asset'), caller),
+    );
+    if (!subject) throw new NotFoundException();
+    return subject;
+  }
+
+  /** The four steps (see the class doc). Both queries always run. */
+  private async ladder(
+    db: Surreal,
+    assetTail: string,
+    caller: GrantCaller,
+  ): Promise<GrantSubject | null> {
+    const row = await queryFirst<AssetLadderRow>(
+      db,
+      `SELECT id, availability, quarantineStatus, piiClasses, retainUntil
+         FROM type::record('evidence_asset', $tail) LIMIT 1`,
+      { tail: assetTail },
+    );
+    const live = await queryRows<{ ownerKind: string; ownerId: string }>(
+      db,
+      `SELECT ownerKind, ownerId FROM evidence_grant
+        WHERE assetId = type::record('evidence_asset', $tail) AND revokedAt = NONE`,
+      { tail: assetTail },
+    );
+    // Pure decisions over rows already in hand — no branch below issues
+    // I/O, so the deny classes stay indistinguishable (class doc).
+    if (!row) return null;
+    if (!aliveForSharing(row)) return null;
+    if (!ownedByCaller(live, caller.userId)) return null;
+    if (!mediaPiiAllowed(row.piiClasses, caller.scopes)) return null;
+    return { assetIdStr: String(row.id), retainUntil: isoOf(row.retainUntil) };
+  }
+
+  /**
+   * Seam errors that would otherwise DESCRIBE the subject are flattened
+   * into the same bare 404 the ladder throws: a NotFound (the row died
+   * between the ladder and the write) or a Conflict (it was tombstoned
+   * in the same window) both carry a message naming the asset, which is
+   * exactly the oracle this surface exists to withhold. Everything else
+   * — the store's 503 write gate above all — passes through untouched.
+   */
+  private async uniform<T>(work: Promise<T>): Promise<T> {
+    try {
+      return await work;
+    } catch (e) {
+      if (e instanceof NotFoundException || e instanceof ConflictException) {
+        throw new NotFoundException();
+      }
+      throw e;
+    }
+  }
+}
+
+/**
+ * Step 2 currency. NOT the raw gateway's `availability === 'hot'`: bytes
+ * are not moving, so a metadata-only ('external') or cold observation is
+ * shareable — only a tombstoned one is not. Quarantine keeps the read
+ * path's polarity exactly (clean or absent), because an unscanned or
+ * rejected asset must not spread to new owners. `retainUntil` in the
+ * past means the retention sweep owes this asset a tombstone: refuse
+ * rather than let a grant outlive the asset's own policy.
+ */
+function aliveForSharing(row: AssetLadderRow): boolean {
+  if (row.availability === 'gone') return false;
+  const q = row.quarantineStatus;
+  if (!(q === undefined || q === null || q === 'clean')) return false;
+  const until = row.retainUntil == null ? null : new Date(row.retainUntil).getTime();
+  return until === null || Number.isNaN(until) || until > Date.now();
+}
+
+/** Step 3 currency — EvidenceReadService.grantOk, verbatim: an asset with
+ *  no live grant is administratively dead for everyone, and a user-bound
+ *  key must additionally hold its own user grant (0055). */
+function ownedByCaller(
+  live: ReadonlyArray<{ ownerKind: string; ownerId: string }>,
+  userId: string | undefined,
+): boolean {
+  if (live.length === 0) return false;
+  if (userId === undefined) return true;
+  return live.some((g) => g.ownerKind === 'user' && g.ownerId === userId);
+}
+
+/** Caller-supplied record id → its tail, or the never-matching sentinel
+ *  when the id is not a well-formed reference to `table`. A malformed id
+ *  is answered by the ladder's uniform 404, never by a distinguishable
+ *  400 — the shape of an id space is not a thing this surface teaches. */
+function tailOf(recordId: string, table: string): string {
+  if (recordId.length > RECORD_ID_MAX || !recordId.startsWith(`${table}:`)) return ABSENT_TAIL;
+  const tail = idTailOf(recordId);
+  return tail === '' ? ABSENT_TAIL : tail;
+}
+
+/** Datetime column → ISO string; absent/unparsable → null. */
+function isoOf(value: string | Date | null | undefined): string | null {
+  if (value == null) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+/** The stored ownerKind narrowed to the wire union; 0122's ASSERT keeps
+ *  the column inside it, so anything else is a corrupted row and reads
+ *  as the most restrictive kind rather than widening the contract. */
+function asOwnerKind(kind: string): 'user' | 'pack' | 'system' {
+  return kind === 'user' || kind === 'pack' ? kind : 'system';
+}

--- a/src/evidence/evidence-grants.controller.ts
+++ b/src/evidence/evidence-grants.controller.ts
@@ -1,0 +1,105 @@
+import { Body, Controller, Delete, Get, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import type {
+  EvidenceGrantsListResponse,
+  GrantEvidenceAccessResponse,
+  RevokeEvidenceGrantResponse,
+} from '../contracts/evidence/grants.schema';
+import { PolicyAction } from '../policy/action-registry';
+import { GrantEvidenceAccessDto } from './dto/grant-evidence-access.dto';
+import { EvidenceGrantService, type GrantCaller } from './evidence-grant.service';
+import { EvidenceGrantsEnabledGuard } from './evidence-grants.guard';
+
+/**
+ * EvidenceGrantsController (Brain v2.1 MM-4, migration 0122) — the
+ * sharing surface the grant machinery has been waiting for: who may hold
+ * an observation, expressed over HTTP.
+ *
+ * Routes (all a bare 404 while EVIDENCE_GRANTS_API_ENABLED or
+ * EVIDENCE_SUBSTRATE_ENABLED is off — the EPISODES_API_ENABLED idiom,
+ * indistinguishable from absent routes):
+ *   POST   /v1/evidence/{assetId}/grants   — share with a user or pack
+ *   GET    /v1/evidence/{assetId}/grants   — the asset's live owners
+ *   DELETE /v1/evidence/grants/{grantId}   — revoke (idempotent)
+ * That 404 comes from EvidenceGrantsEnabledGuard, which Nest runs BEFORE
+ * the global ValidationPipe — so while the surface is off, a malformed
+ * body cannot answer 400 and advertise the route (see the guard's doc).
+ *
+ * Transport only. The authorization ladder (tenant fence → liveness +
+ * retention → ownership → media PII) lives in EvidenceGrantService, and
+ * persistence stays in the ONE write seam (EvidenceStoreService) — layer
+ * purity: controllers never import src/db.
+ *
+ * NO EXISTENCE ORACLE, which is the whole point of the PR. 0122 held
+ * this surface back because a sharing route is where a hash-probing
+ * client would look for one, so:
+ *   - assets are addressed by RECORD ID only. No route, body field or
+ *     query parameter takes a byteHash — content identity never resolves
+ *     to a row here (registerAsset's bare 409 closes the other half);
+ *   - unknown asset, foreign tenant, tombstoned/quarantined/past-
+ *     retention asset, non-owner, media-PII-blocked and malformed id all
+ *     answer the SAME bare 404, over the same two DB round-trips;
+ *   - the grantee handle is never checked for existence, so the share
+ *     verb is not a user-enumeration oracle either;
+ *   - the owner list reaches owners only.
+ * The one thing a caller CAN learn is what they were already entitled
+ * to: whether an asset they own holds a given live grant.
+ *
+ * Scopes and ABAC: `brain:write` + `rest.evidence.grant` to share,
+ * `brain:write` + `rest.evidence.revoke` to take back, `brain:read` +
+ * `rest.evidence.grants` to list. ABAC opens the VERB; the ladder still
+ * decides the ASSET, so a policy can never hand out an asset the caller
+ * does not hold.
+ */
+@Controller('v1/evidence')
+@UseGuards(EvidenceGrantsEnabledGuard, ApiKeyGuard)
+export class EvidenceGrantsController {
+  constructor(private readonly grants: EvidenceGrantService) {}
+
+  @Post(':assetId/grants')
+  @RequireScopes('brain:write')
+  @PolicyAction('rest.evidence.grant')
+  async grant(
+    @Req() req: AuthenticatedRequest,
+    @Param('assetId') assetId: string,
+    @Body() body: GrantEvidenceAccessDto,
+  ): Promise<GrantEvidenceAccessResponse> {
+    return this.grants.grant(req.brainAuth.companyId, callerOf(req), {
+      assetId,
+      ownerKind: body.ownerKind,
+      ownerId: body.ownerId,
+      purpose: body.purpose,
+    });
+  }
+
+  @Get(':assetId/grants')
+  @RequireScopes('brain:read')
+  @PolicyAction('rest.evidence.grants')
+  async list(
+    @Req() req: AuthenticatedRequest,
+    @Param('assetId') assetId: string,
+  ): Promise<EvidenceGrantsListResponse> {
+    return this.grants.list(req.brainAuth.companyId, callerOf(req), assetId);
+  }
+
+  /** Declared under a LITERAL prefix ('grants/…') so it can never be
+   *  read as an asset id, and DELETE-only so it shares no pattern with
+   *  the raw-read gateway's GET routes on the same controller prefix. */
+  @Delete('grants/:grantId')
+  @RequireScopes('brain:write')
+  @PolicyAction('rest.evidence.revoke')
+  async revoke(
+    @Req() req: AuthenticatedRequest,
+    @Param('grantId') grantId: string,
+  ): Promise<RevokeEvidenceGrantResponse> {
+    return this.grants.revoke(req.brainAuth.companyId, callerOf(req), grantId);
+  }
+}
+
+/** The brainAuth slice the ladder fences on — one spreadable object so
+ *  the handlers stay within the max-params discipline. */
+function callerOf(req: AuthenticatedRequest): GrantCaller {
+  const { scopes, userId } = req.brainAuth;
+  return { scopes, userId };
+}

--- a/src/evidence/evidence-grants.guard.ts
+++ b/src/evidence/evidence-grants.guard.ts
@@ -1,0 +1,24 @@
+import { CanActivate, Injectable, NotFoundException } from '@nestjs/common';
+import { evidenceGrantsApiEnabled, evidenceSubstrateEnabled } from '../common/evidence-flags';
+
+/**
+ * Flag gate for the sharing surface as a GUARD, not a handler line — the
+ * EvidenceBlobUploadInterceptor lesson applied to a JSON body.
+ *
+ * Nest runs guards BEFORE parameter pipes, so while the surface is off a
+ * malformed POST body answers the bare 404 of an absent route instead of
+ * the global ValidationPipe's 400, which would advertise that the route
+ * (and the shape of its DTO) exist. Double-gated on the substrate for
+ * the same reason the admin dispatch verb is: a dark write seam must not
+ * advertise a sharing surface it would 503 anyway.
+ *
+ * Both flags are read at call time (runtime-mutable) through the common
+ * layer — never captured in a constructor.
+ */
+@Injectable()
+export class EvidenceGrantsEnabledGuard implements CanActivate {
+  canActivate(): boolean {
+    if (!evidenceGrantsApiEnabled() || !evidenceSubstrateEnabled()) throw new NotFoundException();
+    return true;
+  }
+}

--- a/src/evidence/evidence-store.service.ts
+++ b/src/evidence/evidence-store.service.ts
@@ -309,9 +309,15 @@ export class EvidenceStoreService {
   }
 
   /**
-   * Grant an owner access to an existing asset (0122). Service-only —
-   * this PR ships NO HTTP sharing surface; callers are authorized code
-   * paths (and future PRs), never a hash-probing client.
+   * Grant an owner access to an existing asset (0122).
+   *
+   * Persistence only, by design: this seam authorizes NOTHING. It was
+   * held service-only until a caller existed that could not be a
+   * hash-probing client — that caller is now EvidenceGrantService (MM-4,
+   * EVIDENCE_GRANTS_API_ENABLED), which runs the ownership + media-PII
+   * ladder and answers one uniform 404 before it ever reaches here. Any
+   * other call site inherits the same obligation: check first, write
+   * here.
    */
   async addGrant(
     companyId: string,

--- a/src/evidence/evidence.module.ts
+++ b/src/evidence/evidence.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
 import { EvidenceBlobUploadInterceptor } from './blob-upload.interceptor';
 import { EvidenceAdminController } from './evidence-admin.controller';
+import { EvidenceGrantService } from './evidence-grant.service';
+import { EvidenceGrantsController } from './evidence-grants.controller';
+import { EvidenceGrantsEnabledGuard } from './evidence-grants.guard';
 import { EvidenceIngestController } from './evidence-ingest.controller';
 import { EvidenceReadController } from './evidence-read.controller';
 import { EvidenceReadService } from './evidence-read.service';
@@ -66,10 +69,27 @@ import {
  * ladder, default-off (EVIDENCE_RAW_READ_ENABLED → every route 404s).
  * Guard dependencies (ApiKeyGuard / policy gate) resolve from the
  * @Global auth/policy modules.
+ *
+ * Sharing surface (MM-4, migration 0122): EvidenceGrantsController is
+ * the ownership counterpart of the read gateway — grant, list and revoke
+ * over an asset, default-off (EVIDENCE_GRANTS_API_ENABLED, double-gated
+ * on the substrate → every route 404s from EvidenceGrantsEnabledGuard,
+ * before the ValidationPipe can advertise the route with a 400).
+ * EvidenceGrantService owns its authorization ladder (the raw gateway's
+ * ownership + media-PII fences, minus the byte-delivery steps) and
+ * delegates every write to the ONE seam above. The guard is listed as a
+ * provider so Nest resolves it by class in @UseGuards.
  */
 @Module({
-  controllers: [EvidenceIngestController, EvidenceReadController, EvidenceAdminController],
+  controllers: [
+    EvidenceIngestController,
+    EvidenceReadController,
+    EvidenceGrantsController,
+    EvidenceAdminController,
+  ],
   providers: [
+    EvidenceGrantsEnabledGuard,
+    EvidenceGrantService,
     FsEvidenceStorageAdapter,
     {
       provide: EVIDENCE_STORAGE_ADAPTERS,
@@ -100,6 +120,7 @@ import {
   ],
   exports: [
     EvidenceStoreService,
+    EvidenceGrantService,
     ProcessingRunService,
     EvidenceProcessorBrokerService,
     EvidenceQuarantineService,

--- a/src/policy/action-registry.ts
+++ b/src/policy/action-registry.ts
@@ -164,6 +164,17 @@ export const ACTIONS: Record<string, ActionSpec> = {
   // URL to them; redeem is unauthenticated by design and gated by the
   // token itself, so it carries no action.
   'rest.evidence.raw': { kind: 'read', family: 'rest', title: 'Read raw evidence bytes' },
+  // Sharing surface (MM-4, EVIDENCE_GRANTS_API_ENABLED). THREE actions,
+  // not one: handing an asset to another principal, seeing who already
+  // holds it, and taking access back are separable authorities — a
+  // policy may keep revoke open as a safety valve while sharing is
+  // closed, or open the owner list to an auditor who may not re-share.
+  // All three additionally require the caller to pass the raw-read
+  // gateway's own ownership + media-PII fences: ABAC opens the verb,
+  // never the asset.
+  'rest.evidence.grant': { kind: 'write', family: 'rest', title: 'Grant evidence access' },
+  'rest.evidence.revoke': { kind: 'write', family: 'rest', title: 'Revoke an evidence grant' },
+  'rest.evidence.grants': { kind: 'read', family: 'rest', title: 'List evidence grants' },
   // Rolling user profile v1 (USER_PROFILE_API_ENABLED). MCP-tool-style
   // name (the get_entity_profile precedent) so a future MCP surface
   // shares the action; REST-only today.

--- a/test/evidence-grant.e2e-spec.ts
+++ b/test/evidence-grant.e2e-spec.ts
@@ -5,8 +5,11 @@
  * addGrant/revokeGrant/liveGrants seam behavior, the grant-aware GDPR
  * user-forget (shared assets survive minus the erased owner; sole-owned
  * die rows+blob), the pre-backfill legacy leg, and 0122 backfill
- * idempotence. Service-level like evidence-substrate.e2e-spec — this PR
- * ships no HTTP grant surface.
+ * idempotence. Service-level like evidence-substrate.e2e-spec: the seam
+ * itself, with no HTTP in the way. The sharing SURFACE built on top of
+ * it — its authorization ladder, its uniform 404 and the
+ * grant → read → revoke → denied_grant round trip — lives in the
+ * sibling test/evidence-grants-api.e2e-spec.ts (MM-4).
  */
 import { createHash, randomBytes } from 'node:crypto';
 import { readFileSync } from 'node:fs';

--- a/test/evidence-grants-api.e2e-spec.ts
+++ b/test/evidence-grants-api.e2e-spec.ts
@@ -1,0 +1,309 @@
+/**
+ * Evidence sharing surface e2e (MM-4, migration 0122) against a real
+ * SurrealDB — the HTTP half of test/evidence-grant.e2e-spec.ts, which
+ * covers the same seam at service level.
+ *
+ * The spine is the round trip the surface exists for: an owner GRANTS,
+ * the grantee's raw read starts succeeding, the owner REVOKES, and the
+ * same read goes back to a bare 404 recorded as `denied_grant` in the
+ * content-free evidence_access trail. Around it sit the pins that make
+ * the surface safe to ship: the flag-off 404 (raised in a guard, so even
+ * a malformed body cannot reveal the route), the identical answers for
+ * unknown / foreign / unauthorized subjects, revoke idempotence, and the
+ * refusals that keep a client from writing ownership it should not
+ * (system grants, unenforceable expiries).
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { EvidenceStoreService } from '../src/evidence/evidence-store.service';
+import { FsEvidenceStorageAdapter } from '../src/evidence/storage/fs-storage.adapter';
+
+const COMPANY = 'co_evidence_grants_api_e2e';
+const OTHER_COMPANY = 'co_evidence_grants_api_other';
+const sha256 = (b: Buffer) => createHash('sha256').update(b).digest('hex');
+
+const PREDICATE = {
+  localId: 'grant_note',
+  displayLabel: 'grant note',
+  description: 'TYPE subject is a person; value is a note about shared evidence',
+  datatype: 'string',
+  semantics: 'append_only',
+  decayHalfLifeDays: null,
+  piiClass: 'none',
+  status: 'active',
+};
+
+/** Consent for raw serving — the grantee's READ has to be able to
+ *  succeed, or "the grant worked" would be unobservable. */
+const RAW_PACK = {
+  id: 'grants_api_pack',
+  version: '1.0.0',
+  description: 'Evidence sharing surface e2e pack.',
+  predicates: [PREDICATE],
+  memoryModel: { modalities: ['image'], rawEvidence: { serve: true } },
+};
+
+describe('evidence sharing surface (e2e)', () => {
+  let f: AppFixture;
+  let store: EvidenceStoreService;
+  let adapter: FsEvidenceStorageAdapter;
+  let surreal: SurrealService;
+  let fsRoot: string;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const u1Auth = () => ({ Authorization: `Bearer ${f.extraApiKeys[0]!}` });
+  const u2Auth = () => ({ Authorization: `Bearer ${f.extraApiKeys[1]!}` });
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    fsRoot = await mkdtemp(join(tmpdir(), 'evidence-grants-api-e2e-'));
+    for (const k of [
+      'EVIDENCE_SUBSTRATE_ENABLED',
+      'EVIDENCE_GRANTS_API_ENABLED',
+      'EVIDENCE_RAW_READ_ENABLED',
+      'EVIDENCE_FS_ROOT',
+    ]) {
+      saved[k] = process.env[k];
+    }
+    process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    process.env.EVIDENCE_RAW_READ_ENABLED = '1';
+    process.env.EVIDENCE_FS_ROOT = fsRoot;
+    // The sharing flag stays OFF until the 404 pin below runs.
+    delete process.env.EVIDENCE_GRANTS_API_ENABLED;
+    f = await createApp({
+      companyId: COMPANY,
+      extraKeys: [
+        { scopes: ['brain:read', 'brain:write'], userId: 'g_u1' },
+        { scopes: ['brain:read', 'brain:write'], userId: 'g_u2' },
+      ],
+    });
+    store = f.app.get(EvidenceStoreService);
+    adapter = f.app.get(FsEvidenceStorageAdapter);
+    surreal = f.app.get(SurrealService);
+    const install = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: RAW_PACK, acceptModalities: true });
+    expect([200, 201]).toContain(install.status);
+  });
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await rm(fsRoot, { recursive: true, force: true });
+    if (f) await f.close();
+  });
+
+  const query = async <T>(sql: string, params?: Record<string, unknown>): Promise<T> =>
+    surreal.withCompany(COMPANY, async (db) => {
+      const [rows] = await db.query<[T]>(sql, params);
+      return rows;
+    });
+
+  const outcomesFor = (assetId: string) =>
+    query<Array<{ verb: string; outcome: string }>>(
+      `SELECT verb, outcome FROM evidence_access WHERE assetId = $a`,
+      { a: assetId },
+    );
+
+  const registerFsAsset = async (
+    data: Buffer,
+    extra: Partial<Parameters<EvidenceStoreService['registerAsset']>[1]> = {},
+    company = COMPANY,
+  ) => {
+    const byteHash = sha256(data);
+    const { storageRef } = await adapter.put(company, byteHash, data);
+    return store.registerAsset(company, {
+      modality: 'image',
+      mediaType: 'image/jpeg',
+      byteHash,
+      byteLength: data.byteLength,
+      occurredAt: new Date('2026-03-01T10:00:00.000Z'),
+      storageRef,
+      vertical: 'proj',
+      piiClasses: [],
+      userId: 'g_u1',
+      ...extra,
+    });
+  };
+
+  it('flag off: every route answers a bare 404 — a malformed body included', async () => {
+    const created = await registerFsAsset(randomBytes(64));
+    const post = await f.http
+      .post(`/v1/evidence/${created.assetId}/grants`)
+      .set(u1Auth())
+      .send({ ownerKind: 'user', ownerId: 'g_u2' });
+    expect(post.status).toBe(404);
+    // The guard fires BEFORE the global ValidationPipe: a body that
+    // would be a 400 while the surface is on must not advertise it.
+    const bad = await f.http
+      .post(`/v1/evidence/${created.assetId}/grants`)
+      .set(u1Auth())
+      .send({ nonsense: true });
+    expect(bad.status).toBe(404);
+    expect(bad.body).toEqual(post.body);
+    expect((await f.http.get(`/v1/evidence/${created.assetId}/grants`).set(u1Auth())).status).toBe(
+      404,
+    );
+    expect((await f.http.delete('/v1/evidence/grants/evidence_grant:x').set(u1Auth())).status).toBe(
+      404,
+    );
+  });
+
+  it('grant → the grantee reads → revoke → the read is denied_grant', async () => {
+    process.env.EVIDENCE_GRANTS_API_ENABLED = '1'; // stays on from here
+    const data = randomBytes(1024);
+    const created = await registerFsAsset(data);
+    const raw = `/v1/evidence/${created.assetId}/raw`;
+    // Before the share: only the owner reads.
+    expect((await f.http.get(raw).set(u1Auth())).status).toBe(200);
+    expect((await f.http.get(raw).set(u2Auth())).status).toBe(404);
+
+    const granted = await f.http
+      .post(`/v1/evidence/${created.assetId}/grants`)
+      .set(u1Auth())
+      .send({ ownerKind: 'user', ownerId: 'g_u2', purpose: 'share' });
+    expect(granted.status).toBe(201);
+    expect(granted.body).toMatchObject({
+      created: true,
+      assetId: created.assetId,
+      retainUntil: null,
+    });
+    const grantId = (granted.body as { grantId: string }).grantId;
+
+    // The grant is what the read gateway spends.
+    const read = await f.http.get(raw).set(u2Auth());
+    expect(read.status).toBe(200);
+    expect(Buffer.from(read.body as Buffer).equals(data)).toBe(true);
+
+    // Idempotent re-share: the standing row, not a duplicate.
+    const again = await f.http
+      .post(`/v1/evidence/${created.assetId}/grants`)
+      .set(u1Auth())
+      .send({ ownerKind: 'user', ownerId: 'g_u2' });
+    expect(again.status).toBe(201);
+    expect(again.body).toMatchObject({ grantId, created: false });
+
+    const revoked = await f.http.delete(`/v1/evidence/grants/${grantId}`).set(u1Auth());
+    expect(revoked.status).toBe(200);
+    expect(revoked.body).toEqual({ grantId, revoked: true });
+    // Revoke is idempotent — byte-identical answer on the retry.
+    const twice = await f.http.delete(`/v1/evidence/grants/${grantId}`).set(u1Auth());
+    expect(twice.status).toBe(200);
+    expect(twice.body).toEqual(revoked.body);
+
+    expect((await f.http.get(raw).set(u2Auth())).status).toBe(404);
+    // The owner is untouched; the grantee's denial is audited as such.
+    expect((await f.http.get(raw).set(u1Auth())).status).toBe(200);
+    const outcomes = (await outcomesFor(created.assetId)).map((r) => r.outcome);
+    expect(outcomes).toEqual(expect.arrayContaining(['ok', 'denied_grant']));
+  });
+
+  it('unknown, cross-tenant and unauthorized subjects answer IDENTICALLY', async () => {
+    const mine = await registerFsAsset(randomBytes(96));
+    const foreign = await registerFsAsset(randomBytes(97), { userId: 'other_u' }, OTHER_COMPANY);
+    const body = { ownerKind: 'user', ownerId: 'g_u9' };
+    // u2 holds no grant on `mine`; the other two subjects do not exist
+    // in this tenant at all. All three must be one answer.
+    const answers = [
+      await f.http.post(`/v1/evidence/${mine.assetId}/grants`).set(u2Auth()).send(body),
+      await f.http.post('/v1/evidence/evidence_asset:nope/grants').set(u2Auth()).send(body),
+      await f.http.post(`/v1/evidence/${foreign.assetId}/grants`).set(u2Auth()).send(body),
+      await f.http.post('/v1/evidence/not-a-record-id/grants').set(u2Auth()).send(body),
+    ];
+    for (const res of answers) {
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual(answers[0]!.body);
+    }
+    // ...and the refused share wrote nothing.
+    expect(await store.liveGrants(COMPANY, mine.assetId)).toHaveLength(1);
+    // The list and revoke verbs are no better a probe.
+    const listDeny = await f.http.get(`/v1/evidence/${mine.assetId}/grants`).set(u2Auth());
+    expect(listDeny.status).toBe(404);
+    expect(listDeny.body).toEqual(answers[0]!.body);
+    const own = await store.liveGrants(COMPANY, mine.assetId);
+    const revokeDeny = await f.http.delete(`/v1/evidence/grants/${own[0]!.grantId}`).set(u2Auth());
+    expect(revokeDeny.status).toBe(404);
+    expect(revokeDeny.body).toEqual(answers[0]!.body);
+    const unknownGrant = await f.http
+      .delete('/v1/evidence/grants/evidence_grant:nope')
+      .set(u2Auth());
+    expect(unknownGrant.body).toEqual(answers[0]!.body);
+  });
+
+  it('the owner lists live grants; a non-owner never sees a grantee handle', async () => {
+    const created = await registerFsAsset(randomBytes(128));
+    await f.http
+      .post(`/v1/evidence/${created.assetId}/grants`)
+      .set(u1Auth())
+      .send({ ownerKind: 'pack', ownerId: 'pack_alpha', purpose: 'processor' });
+    const listed = await f.http.get(`/v1/evidence/${created.assetId}/grants`).set(u1Auth());
+    expect(listed.status).toBe(200);
+    const grants = (listed.body as { grants: Array<{ ownerId: string; ownerKind: string }> })
+      .grants;
+    expect(grants).toHaveLength(2);
+    expect(grants.map((g) => `${g.ownerKind}:${g.ownerId}`).sort()).toEqual([
+      'pack:pack_alpha',
+      'user:g_u1',
+    ]);
+    const denied = await f.http.get(`/v1/evidence/${created.assetId}/grants`).set(u2Auth());
+    expect(denied.status).toBe(404);
+    expect(JSON.stringify(denied.body)).not.toContain('pack_alpha');
+  });
+
+  it('refuses ownership a client must not write: system grants and fake expiries', async () => {
+    const created = await registerFsAsset(randomBytes(64));
+    const system = await f.http
+      .post(`/v1/evidence/${created.assetId}/grants`)
+      .set(u1Auth())
+      .send({ ownerKind: 'system', ownerId: 'system' });
+    // A system grant outlives every user's erasure — write-seam only.
+    expect(system.status).toBe(400);
+    const expiring = await f.http
+      .post(`/v1/evidence/${created.assetId}/grants`)
+      .set(u1Auth())
+      .send({ ownerKind: 'user', ownerId: 'g_u2', expiresAt: '2030-01-01T00:00:00Z' });
+    // 0122 has no grant-expiry column: refuse rather than accept a
+    // horizon nothing would enforce.
+    expect(expiring.status).toBe(400);
+    expect(await store.liveGrants(COMPANY, created.assetId)).toHaveLength(1);
+  });
+
+  it('a media-classified asset cannot be shared without brain:read_media', async () => {
+    const created = await registerFsAsset(randomBytes(72), { piiClasses: ['face'] });
+    const denied = await f.http
+      .post(`/v1/evidence/${created.assetId}/grants`)
+      .set(u1Auth())
+      .send({ ownerKind: 'user', ownerId: 'g_u2' });
+    expect(denied.status).toBe(404);
+    expect(await store.liveGrants(COMPANY, created.assetId)).toHaveLength(1);
+  });
+
+  it('a tombstoned asset is unshareable (and says nothing about being one)', async () => {
+    const created = await registerFsAsset(randomBytes(80));
+    await query(`UPDATE type::record('evidence_asset', $tail) SET availability = 'gone'`, {
+      tail: created.assetId.slice(created.assetId.indexOf(':') + 1),
+    });
+    const denied = await f.http
+      .post(`/v1/evidence/${created.assetId}/grants`)
+      .set(u1Auth())
+      .send({ ownerKind: 'user', ownerId: 'g_u2' });
+    expect(denied.status).toBe(404);
+    expect(denied.body).toMatchObject({ statusCode: 404 });
+    expect(JSON.stringify(denied.body)).not.toContain(created.assetId);
+  });
+
+  it('unauthenticated and unscoped callers never reach the ladder', async () => {
+    const created = await registerFsAsset(randomBytes(66));
+    const anon = await f.http
+      .post(`/v1/evidence/${created.assetId}/grants`)
+      .send({ ownerKind: 'user', ownerId: 'g_u2' });
+    expect(anon.status).toBe(401);
+  });
+});

--- a/test/evidence-grants-api.unit-spec.ts
+++ b/test/evidence-grants-api.unit-spec.ts
@@ -1,0 +1,408 @@
+/**
+ * Evidence sharing surface (MM-4, migration 0122) — the authorization
+ * matrix and the anti-probing invariants, without a database.
+ *
+ * The point of the PR is that the surface is NOT an existence oracle,
+ * so the sharpest assertions here are the INDISTINGUISHABILITY ones: an
+ * unknown asset and an asset the caller may not touch must produce the
+ * same exception shape AND the same sequence of DB queries. A future
+ * "helpful" 403/404-with-message, or an early return that skips the
+ * grant probe for a missing asset, fails here rather than in a probing
+ * client's log.
+ */
+import { ConflictException, NotFoundException, ServiceUnavailableException } from '@nestjs/common';
+import { EvidenceGrantService, type GrantCaller } from '../src/evidence/evidence-grant.service';
+import { EvidenceGrantsController } from '../src/evidence/evidence-grants.controller';
+import { EvidenceGrantsEnabledGuard } from '../src/evidence/evidence-grants.guard';
+import type { EvidenceStoreService } from '../src/evidence/evidence-store.service';
+import type { SurrealService } from '../src/db/surreal.service';
+
+type Row = Record<string, unknown>;
+
+interface DbScript {
+  /** evidence_asset row (or null for "no such asset in this tenant"). */
+  asset?: Row | null;
+  /** live evidence_grant rows of that asset. */
+  live?: Row[];
+  /** evidence_grant row a revoke addresses. */
+  grant?: Row | null;
+}
+
+/** A db double that answers by STATEMENT SHAPE and records every call —
+ *  the recording is what the indistinguishability assertions compare. */
+function mkDb(script: DbScript) {
+  const calls: string[] = [];
+  const vars: Array<Record<string, unknown> | undefined> = [];
+  return {
+    calls,
+    vars,
+    db: {
+      query: async (sql: string, params?: Record<string, unknown>) => {
+        calls.push(shapeOf(sql));
+        vars.push(params);
+        if (sql.includes("type::record('evidence_grant'")) {
+          return [script.grant ? [script.grant] : []];
+        }
+        if (sql.includes('FROM evidence_grant')) return [script.live ?? []];
+        if (sql.includes("type::record('evidence_asset'")) {
+          return [script.asset ? [script.asset] : []];
+        }
+        return [[]];
+      },
+    },
+  };
+}
+
+/** Statement shape, stripped of whitespace — two denials must agree on
+ *  this sequence, not merely on the number of round-trips. */
+function shapeOf(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim();
+}
+
+function mkSurreal(db: unknown): SurrealService {
+  return {
+    withCompany: async <T>(_c: string, fn: (d: unknown) => Promise<T>): Promise<T> => fn(db),
+  } as unknown as SurrealService;
+}
+
+function mkStore(overrides: Partial<EvidenceStoreService> = {}): EvidenceStoreService {
+  return {
+    addGrant: jest.fn(async () => ({ grantId: 'evidence_grant:new', created: true })),
+    revokeGrant: jest.fn(async (_c: string, id: string) => ({ grantId: id })),
+    liveGrants: jest.fn(async () => []),
+    ...overrides,
+  } as unknown as EvidenceStoreService;
+}
+
+const ASSET = 'evidence_asset:a1';
+/** A clean, live, user-owned asset — the happy path's subject. */
+const OWNED_ASSET: Row = {
+  id: ASSET,
+  availability: 'hot',
+  quarantineStatus: 'clean',
+  piiClasses: [],
+  retainUntil: null,
+};
+const U1_GRANT: Row = { ownerKind: 'user', ownerId: 'u1' };
+const M2M: GrantCaller = { scopes: ['brain:write'] };
+const U1: GrantCaller = { scopes: ['brain:write'], userId: 'u1' };
+const U2: GrantCaller = { scopes: ['brain:write'], userId: 'u2' };
+
+const share = { ownerKind: 'user' as const, ownerId: 'u9', assetId: ASSET };
+
+describe('evidence grants: the flag guard', () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it('404s while the surface flag is off, even with the substrate on', () => {
+    process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    delete process.env.EVIDENCE_GRANTS_API_ENABLED;
+    expect(() => new EvidenceGrantsEnabledGuard().canActivate()).toThrow(NotFoundException);
+  });
+
+  it('404s while the substrate is off (double gate — a dark seam advertises nothing)', () => {
+    process.env.EVIDENCE_GRANTS_API_ENABLED = '1';
+    delete process.env.EVIDENCE_SUBSTRATE_ENABLED;
+    expect(() => new EvidenceGrantsEnabledGuard().canActivate()).toThrow(NotFoundException);
+  });
+
+  it('passes only with both on', () => {
+    process.env.EVIDENCE_GRANTS_API_ENABLED = '1';
+    process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    expect(new EvidenceGrantsEnabledGuard().canActivate()).toBe(true);
+  });
+});
+
+describe('evidence grants: the authorization ladder', () => {
+  it('an owner may share; the write seam gets the resolved asset id', async () => {
+    const { db } = mkDb({ asset: OWNED_ASSET, live: [U1_GRANT] });
+    const store = mkStore();
+    const svc = new EvidenceGrantService(mkSurreal(db), store);
+    const out = await svc.grant('co', U1, share);
+    expect(out).toEqual({
+      grantId: 'evidence_grant:new',
+      created: true,
+      assetId: ASSET,
+      retainUntil: null,
+    });
+    expect(store.addGrant).toHaveBeenCalledWith('co', {
+      assetId: ASSET,
+      ownerKind: 'user',
+      ownerId: 'u9',
+      // Defaulted by the surface: 'share' is what this route does.
+      purpose: 'share',
+    });
+  });
+
+  it('an M2M key acts with tenant authority when ANY live grant exists', async () => {
+    const { db } = mkDb({ asset: OWNED_ASSET, live: [{ ownerKind: 'system', ownerId: 'system' }] });
+    const svc = new EvidenceGrantService(mkSurreal(db), mkStore());
+    await expect(svc.grant('co', M2M, share)).resolves.toMatchObject({ assetId: ASSET });
+  });
+
+  it('a NON-READER (another tenant user) cannot grant — no escalation', async () => {
+    const { db } = mkDb({ asset: OWNED_ASSET, live: [U1_GRANT] });
+    const store = mkStore();
+    const svc = new EvidenceGrantService(mkSurreal(db), store);
+    await expect(svc.grant('co', U2, share)).rejects.toThrow(NotFoundException);
+    expect(store.addGrant).not.toHaveBeenCalled();
+  });
+
+  it('an administratively dead asset (all grants revoked) grants nothing to anyone', async () => {
+    const { db } = mkDb({ asset: OWNED_ASSET, live: [] });
+    const svc = new EvidenceGrantService(mkSurreal(db), mkStore());
+    await expect(svc.grant('co', M2M, share)).rejects.toThrow(NotFoundException);
+  });
+
+  it('media-PII polarity fences sharing exactly as it fences reading', async () => {
+    const cases: Array<[unknown, string[], boolean]> = [
+      // classes,     caller scopes,                          may share
+      [[], ['brain:write'], true],
+      [undefined, ['brain:write'], false], // unclassified = fail closed
+      [['face'], ['brain:write'], false],
+      [['face'], ['brain:write', 'brain:read_media'], true],
+      [undefined, ['brain:write', 'brain:read_media'], true],
+    ];
+    for (const [piiClasses, scopes, allowed] of cases) {
+      const { db } = mkDb({
+        asset: { ...OWNED_ASSET, piiClasses },
+        live: [U1_GRANT],
+      });
+      const svc = new EvidenceGrantService(mkSurreal(db), mkStore());
+      const call = svc.grant('co', { scopes, userId: 'u1' }, share);
+      if (allowed) await expect(call).resolves.toMatchObject({ assetId: ASSET });
+      else await expect(call).rejects.toThrow(NotFoundException);
+    }
+  });
+
+  it('dead, quarantined and past-retention assets are unshareable', async () => {
+    const unshareable: Row[] = [
+      { ...OWNED_ASSET, availability: 'gone' },
+      { ...OWNED_ASSET, quarantineStatus: 'quarantined' },
+      { ...OWNED_ASSET, quarantineStatus: 'scanning' },
+      // A grant may not outlive the asset's own retention policy: past
+      // the horizon the sweeper merely owes this row a tombstone.
+      { ...OWNED_ASSET, retainUntil: new Date(Date.now() - 60_000).toISOString() },
+    ];
+    for (const asset of unshareable) {
+      const { db } = mkDb({ asset, live: [U1_GRANT] });
+      const svc = new EvidenceGrantService(mkSurreal(db), mkStore());
+      await expect(svc.grant('co', U1, share)).rejects.toThrow(NotFoundException);
+    }
+  });
+
+  it('a metadata-only (external) asset IS shareable — no bytes move here', async () => {
+    const { db } = mkDb({
+      asset: { ...OWNED_ASSET, availability: 'external' },
+      live: [U1_GRANT],
+    });
+    const svc = new EvidenceGrantService(mkSurreal(db), mkStore());
+    await expect(svc.grant('co', U1, share)).resolves.toMatchObject({ assetId: ASSET });
+  });
+
+  it('a future retention horizon rides back as the grant’s effective end', async () => {
+    const retainUntil = new Date(Date.now() + 86_400_000);
+    const { db } = mkDb({
+      asset: { ...OWNED_ASSET, retainUntil },
+      live: [U1_GRANT],
+    });
+    const svc = new EvidenceGrantService(mkSurreal(db), mkStore());
+    await expect(svc.grant('co', U1, share)).resolves.toMatchObject({
+      retainUntil: retainUntil.toISOString(),
+    });
+  });
+});
+
+describe('evidence grants: no existence oracle', () => {
+  /** Run one verb against a scripted db and report what came back and
+   *  which statements ran — the two axes a prober could read. */
+  async function probe(
+    script: DbScript,
+    caller: GrantCaller,
+    verb: 'grant' | 'list' | 'revoke' = 'grant',
+  ): Promise<{ error: unknown; calls: string[] }> {
+    const { db, calls } = mkDb(script);
+    const svc = new EvidenceGrantService(mkSurreal(db), mkStore());
+    try {
+      if (verb === 'grant') await svc.grant('co', caller, share);
+      else if (verb === 'list') await svc.list('co', caller, ASSET);
+      else await svc.revoke('co', caller, 'evidence_grant:g1');
+      return { error: null, calls };
+    } catch (e) {
+      const err = e as NotFoundException;
+      return { error: { name: err.constructor.name, body: err.getResponse() }, calls };
+    }
+  }
+
+  it('unknown asset and unauthorized asset are IDENTICAL (body and query trace)', async () => {
+    const unknown = await probe({ asset: null, live: [] }, U2);
+    const forbidden = await probe({ asset: OWNED_ASSET, live: [U1_GRANT] }, U2);
+    expect(unknown.error).toEqual(forbidden.error);
+    // The bare 404 carries no message that could name the subject.
+    expect(unknown.error).toEqual({
+      name: 'NotFoundException',
+      body: { message: 'Not Found', statusCode: 404 },
+    });
+    // ...and the ladder did not short-circuit: the grant probe runs even
+    // when the asset lookup found nothing, so the two denials cost the
+    // same round-trips against the same indexes.
+    expect(unknown.calls).toEqual(forbidden.calls);
+    expect(unknown.calls).toHaveLength(2);
+  });
+
+  it('a malformed / foreign-shaped id is answered by the same 404, never a 400', async () => {
+    const { db, vars } = mkDb({ asset: null, live: [] });
+    const svc = new EvidenceGrantService(mkSurreal(db), mkStore());
+    for (const bad of ['not-a-record-id', 'knowledge_fact:1', 'evidence_asset:', 'x'.repeat(300)]) {
+      await expect(svc.list('co', M2M, bad)).rejects.toThrow(NotFoundException);
+    }
+    // Every malformed id collapses onto the never-matching sentinel tail
+    // — the id space itself teaches nothing.
+    const tails = new Set(vars.map((v) => String(v?.tail)));
+    expect(tails.size).toBe(1);
+  });
+
+  it('the three verbs deny alike — the cheapest one is no better a probe', async () => {
+    const grantDeny = await probe({ asset: OWNED_ASSET, live: [U1_GRANT] }, U2, 'grant');
+    const listDeny = await probe({ asset: OWNED_ASSET, live: [U1_GRANT] }, U2, 'list');
+    expect(listDeny.error).toEqual(grantDeny.error);
+    const revokeDeny = await probe(
+      { grant: { id: 'evidence_grant:g1', assetId: ASSET }, asset: OWNED_ASSET, live: [U1_GRANT] },
+      U2,
+      'revoke',
+    );
+    expect(revokeDeny.error).toEqual(grantDeny.error);
+  });
+
+  it('an unknown GRANT id costs the same trace as a foreign one', async () => {
+    const unknown = await probe({ grant: null, asset: null, live: [] }, U1, 'revoke');
+    const foreign = await probe(
+      { grant: { id: 'evidence_grant:g1', assetId: ASSET }, asset: OWNED_ASSET, live: [U1_GRANT] },
+      U2,
+      'revoke',
+    );
+    expect(unknown.error).toEqual(foreign.error);
+    expect(unknown.calls).toEqual(foreign.calls);
+    expect(unknown.calls).toHaveLength(3);
+  });
+
+  it('a seam error that would NAME the subject is flattened to the bare 404', async () => {
+    const { db } = mkDb({ asset: OWNED_ASSET, live: [U1_GRANT] });
+    const store = mkStore({
+      addGrant: jest.fn(async () => {
+        throw new ConflictException('asset evidence_asset:a1 is no longer available');
+      }) as unknown as EvidenceStoreService['addGrant'],
+    });
+    const svc = new EvidenceGrantService(mkSurreal(db), store);
+    await expect(svc.grant('co', U1, share)).rejects.toMatchObject({
+      response: { message: 'Not Found', statusCode: 404 },
+    });
+  });
+
+  it('the write gate (503) is NOT flattened — operator state is not a denial', async () => {
+    const { db } = mkDb({ asset: OWNED_ASSET, live: [U1_GRANT] });
+    const store = mkStore({
+      addGrant: jest.fn(async () => {
+        throw new ServiceUnavailableException('EVIDENCE_SUBSTRATE_ENABLED is off');
+      }) as unknown as EvidenceStoreService['addGrant'],
+    });
+    const svc = new EvidenceGrantService(mkSurreal(db), store);
+    await expect(svc.grant('co', U1, share)).rejects.toThrow(ServiceUnavailableException);
+  });
+});
+
+describe('evidence grants: revoke and list', () => {
+  it('revoke is idempotent — an already-revoked grant answers identically', async () => {
+    const script: DbScript = {
+      grant: { id: 'evidence_grant:g1', assetId: ASSET, revokedAt: '2026-01-01T00:00:00Z' },
+      asset: OWNED_ASSET,
+      live: [U1_GRANT],
+    };
+    const first = new EvidenceGrantService(mkSurreal(mkDb(script).db), mkStore());
+    const again = new EvidenceGrantService(mkSurreal(mkDb(script).db), mkStore());
+    const a = await first.revoke('co', U1, 'evidence_grant:g1');
+    const b = await again.revoke('co', U1, 'evidence_grant:g1');
+    expect(a).toEqual({ grantId: 'evidence_grant:g1', revoked: true });
+    expect(b).toEqual(a);
+  });
+
+  it('list returns the live rows the owner is entitled to see', async () => {
+    const { db } = mkDb({ asset: OWNED_ASSET, live: [U1_GRANT] });
+    const grantedAt = new Date('2026-03-01T10:00:00.000Z');
+    const store = mkStore({
+      liveGrants: jest.fn(async () => [
+        { grantId: 'evidence_grant:g1', ownerKind: 'user', ownerId: 'u1', grantedAt },
+        {
+          grantId: 'evidence_grant:g2',
+          ownerKind: 'pack',
+          ownerId: 'pack_alpha',
+          purpose: 'processor',
+          grantedAt,
+        },
+      ]) as unknown as EvidenceStoreService['liveGrants'],
+    });
+    const svc = new EvidenceGrantService(mkSurreal(db), store);
+    await expect(svc.list('co', U1, ASSET)).resolves.toEqual({
+      assetId: ASSET,
+      grants: [
+        {
+          grantId: 'evidence_grant:g1',
+          ownerKind: 'user',
+          ownerId: 'u1',
+          grantedAt: grantedAt.toISOString(),
+        },
+        {
+          grantId: 'evidence_grant:g2',
+          ownerKind: 'pack',
+          ownerId: 'pack_alpha',
+          purpose: 'processor',
+          grantedAt: grantedAt.toISOString(),
+        },
+      ],
+    });
+  });
+
+  it('list never reaches the store for a non-owner (no handle leaves the tenant)', async () => {
+    const { db } = mkDb({ asset: OWNED_ASSET, live: [U1_GRANT] });
+    const store = mkStore();
+    const svc = new EvidenceGrantService(mkSurreal(db), store);
+    await expect(svc.list('co', U2, ASSET)).rejects.toThrow(NotFoundException);
+    expect(store.liveGrants).not.toHaveBeenCalled();
+  });
+});
+
+describe('evidence grants: the controller wiring', () => {
+  const req = {
+    brainAuth: { companyId: 'co', scopes: ['brain:write'], keyHash: 'sha256:k', userId: 'u1' },
+  } as never;
+
+  it('passes tenant + caller from the AUTHENTICATED key, never from the body', async () => {
+    const svc = {
+      grant: jest.fn(async () => ({
+        grantId: 'evidence_grant:g',
+        created: true,
+        assetId: ASSET,
+        retainUntil: null,
+      })),
+      list: jest.fn(async () => ({ assetId: ASSET, grants: [] })),
+      revoke: jest.fn(async () => ({ grantId: 'evidence_grant:g', revoked: true as const })),
+    } as unknown as EvidenceGrantService;
+    const ctrl = new EvidenceGrantsController(svc);
+    await ctrl.grant(req, ASSET, { ownerKind: 'user', ownerId: 'u9', purpose: undefined });
+    expect(svc.grant).toHaveBeenCalledWith(
+      'co',
+      { scopes: ['brain:write'], userId: 'u1' },
+      { assetId: ASSET, ownerKind: 'user', ownerId: 'u9', purpose: undefined },
+    );
+    await ctrl.list(req, ASSET);
+    await ctrl.revoke(req, 'evidence_grant:g');
+    expect(svc.list).toHaveBeenCalledWith('co', { scopes: ['brain:write'], userId: 'u1' }, ASSET);
+    expect(svc.revoke).toHaveBeenCalledWith(
+      'co',
+      { scopes: ['brain:write'], userId: 'u1' },
+      'evidence_grant:g',
+    );
+  });
+});

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -70,6 +70,11 @@ const PLATFORM_OPERATIONS: Array<[string, string]> = [
   ['/v1/evidence/fragments/{fragmentId}/raw', 'get'],
   ['/v1/evidence/fragments/{fragmentId}/raw-url', 'get'],
   ['/v1/evidence/redeem/{token}', 'get'],
+  // Sharing surface (MM-4, EVIDENCE_GRANTS_API_ENABLED — 404 until on,
+  // raised in a guard so a bad body cannot reveal the dark route).
+  ['/v1/evidence/{assetId}/grants', 'post'],
+  ['/v1/evidence/{assetId}/grants', 'get'],
+  ['/v1/evidence/grants/{grantId}', 'delete'],
 ];
 
 describe('docs/openapi.json', () => {


### PR DESCRIPTION
## The gap

Migration 0122's grant machinery is complete and correct in the service layer (`addGrant` / `revokeGrant` / `liveGrants`), and the read side consumes it fully — `EvidenceReadService` denies with `denied_grant`. But the write seam carried an explicit note:

> Service-only — this PR ships NO HTTP sharing surface; callers are authorized code paths (and future PRs), never a hash-probing client.

So an operator or an application could not grant or revoke access to an evidence asset at all. Nothing 501'd; there was simply no controller. This PR ships that surface — with the anti-probing properties the note was withholding it for.

## The surface

Behind `EVIDENCE_GRANTS_API_ENABLED` (default off, double-gated on `EVIDENCE_SUBSTRATE_ENABLED` — every route answers a bare 404 while either is off):

| Endpoint | Scope / ABAC | Notes |
|---|---|---|
| `POST /v1/evidence/:assetId/grants` | `brain:write` / `rest.evidence.grant` | Share with a `user` handle or an installed `pack`. Idempotent over the live (asset, ownerKind, ownerId) triple. |
| `GET /v1/evidence/:assetId/grants` | `brain:read` / `rest.evidence.grants` | The asset's LIVE owners. Revoked rows are audit, not a directory. |
| `DELETE /v1/evidence/grants/:grantId` | `brain:write` / `rest.evidence.revoke` | Revoke; idempotent, keeps the original `revokedAt`. |

Three ABAC actions rather than one: handing an asset over, taking it back, and seeing who holds it are separable authorities (a policy can keep revoke open as a safety valve while sharing is closed). ABAC opens the **verb**; the ladder still decides the **asset**.

## Authorization: no privilege escalation

A new `EvidenceGrantService` runs a ladder that mirrors the raw-read gateway's own fences, deny-overrides:

1. **tenant** — every lookup runs inside `withCompany`, so a foreign asset is simply not found;
2. **liveness** — not tombstoned, `quarantineStatus` clean-or-absent, and `retainUntil` not already past (a grant may not outlive the asset's own retention policy — the sweeper merely owes that row a tombstone);
3. **ownership** — the read path's fence verbatim: ≥1 live grant must exist, and a user-bound key must hold the end user's own live user grant (0055/0093);
4. **media PII** — the polarity gate: unclassified blocked, `[]` open, classified needs `brain:read_media`.

Nobody grants what they cannot read. What the ladder deliberately **omits** vs the read ladder is the byte-delivery half (`availability='hot'`, blob head) and the pack modality-consent fold: no bytes move here, a metadata-only `external` asset is legitimately shareable, and every serve still re-runs the full gateway ladder (consent included) against the grantee — so a grant can never widen what the grantor already had.

## Anti-probing measures

- **No hash addressing.** Assets are named by record id only — no route, body field or query parameter accepts a `byteHash`. Content identity never resolves to a row here (`registerAsset`'s bare 409 closes the other half of the dedup-probe leak).
- **One uniform 404.** Unknown asset, foreign tenant, tombstoned / quarantined / past-retention asset, non-owner, PII-blocked and malformed id are indistinguishable — same status, same body, no message that could name the subject.
- **No early exit.** The ladder issues both queries (asset row, live grants) unconditionally, in the same order, against the same indexes: a missing asset probes the grant index with a record id that matches nothing rather than short-circuiting, so the deny classes are not separable by query count or shape. A malformed id collapses onto a never-matching sentinel tail instead of a distinguishable 400. (Structural equalization, not a constant-time guarantee — stated as such in the class doc.)
- **Seam errors flattened.** A `NotFound` / `Conflict` from the store would carry a message naming the asset; both become the same bare 404. The 503 write gate is *not* flattened — operator state is not a denial.
- **No user enumeration.** The grantee handle is never checked for existence; a grant to an unknown handle is inert and answers like any other.
- **Owner-only listing.** Grantee identifiers reach a caller the ladder recognized as an owner and nobody else; all three verbs deny alike, so the cheapest one is no better a probe.
- **Guard-raised flag gate.** Nest runs guards before parameter pipes, so while the surface is off a malformed body answers 404 instead of a route-revealing 400 (the blob-upload interceptor lesson, applied to JSON).

Two writes a client must not make are refused with 400: `ownerKind: "system"` (a system grant survives every user's GDPR erasure — it would pin content past forget; system ownership stays a write-seam property of registration) and any expiry field (0122 has no grant-expiry column, so an unenforceable horizon is rejected rather than silently ignored — the asset's own `retainUntil` is the horizon and rides back on the response).

## Tests

- **Unit** (`test/evidence-grants-api.unit-spec.ts`, 21 cases): the authorization matrix (owner grants; M2M tenant authority; non-reader cannot; administratively dead asset; media-PII polarity table; dead/quarantined/past-retention refusals; `external` shareable) plus the indistinguishability pins — identical exception body **and** identical query trace for unknown vs unauthorized, across all three verbs and for unknown vs foreign grant ids — revoke idempotence, and the flag guard.
- **E2E** (`test/evidence-grants-api.e2e-spec.ts`, 8 cases): the round trip — grant → the grantee's raw read succeeds → revoke → the read is a bare 404 audited as `denied_grant` — plus the flag-off 404 pin (malformed body included), identical answers for unknown / cross-tenant / unauthorized subjects, owner-only listing, and the system-grant / expiry refusals. `test/evidence-grant.e2e-spec.ts` keeps the service-level coverage and now points at its HTTP sibling.

## Gates

`pnpm typecheck`, full unit suite (376 suites / 4448 tests), `pnpm lint:ci`, `pnpm format:check` — all green. `pnpm openapi:build` regenerated BOTH copies (`docs/openapi.json` and `brain-landing/public/openapi.json`, verified byte-identical). The new evidence e2e spec and the two sibling evidence e2e specs pass against an ephemeral SurrealDB 3.2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
