### PR TITLE
feat(scenes): gist embeddings and resolved entity links

### DIFF
--- a/src/admin/admin-scenes.controller.ts
+++ b/src/admin/admin-scenes.controller.ts
@@ -17,6 +17,7 @@ import {
   sceneBeliefPromotionEnabled,
   sceneEvidenceLinksEnabled,
   sceneFactBacklinkEnabled,
+  sceneGistEmbeddingEnabled,
   sceneLlmEnrichmentEnabled,
   sceneSegmentationEnabled,
 } from '../common/scene-flags';
@@ -28,6 +29,7 @@ import {
   SceneEvidenceLinkerService,
   SceneEvidenceLinkResult,
 } from './scene-evidence-linker.service';
+import { SceneGistEmbeddingService, SceneGistEmbedResult } from './scene-gist-embedding.service';
 
 /** Purge param belt: DB stamps are short version slugs, not free text. */
 // 128 (was 64): pack scene worlds (0110) are versioned
@@ -50,6 +52,17 @@ const SEGMENTER_VERSION_MAX_CHARS = 128;
  *    Idempotent (0118): scenes already at the current enrichmentVersion
  *    composite (prompt|scorer|model) are SKIPPED — a re-run with an
  *    unchanged configuration makes zero paid calls.
+ *  - POST /scenes/embed-gists — standalone gist encoder pass (PR3): ONE
+ *    bounded embedMany batch over the scenes of the current effective
+ *    world that carry NO `gistEmbedding` yet, writing the vector (plus
+ *    the `embeddingSpaceId` stamp under EMBEDDING_SPACE_TRACKING) by
+ *    primary-key UPDATE. 404 unless BOTH the master flag and
+ *    SCENES_GIST_EMBEDDING are on. Idempotent by construction (a scene
+ *    with a vector is never selected) and bounded per run, so a
+ *    first-time backfill of a large world drains across invocations —
+ *    this is also the BACKFILL verb for a world composed before the flag
+ *    was turned on. Re-embedding EXISTING vectors into a new embedding
+ *    space stays the reindex sweep's job, not this one's.
  *  - POST /scenes/backlink — standalone fact backlink (PR2): idempotent
  *    source.memoryEpisodeIds stamps. 404 unless BOTH the master flag and
  *    SCENES_FACT_BACKLINK are on.
@@ -85,6 +98,7 @@ export class AdminScenesController {
     private readonly backlinker: SceneBacklinkService,
     private readonly beliefs: BeliefPromotionService,
     private readonly evidenceLinker: SceneEvidenceLinkerService,
+    private readonly gistEncoder: SceneGistEmbeddingService,
     private readonly apiKeys: ApiKeyService,
   ) {}
 
@@ -113,6 +127,24 @@ export class AdminScenesController {
     }
     const tenant = this.resolveTenant(req, body.tenant);
     return this.enricher.enrich(
+      tenant,
+      body.conversationId !== undefined ? { conversationId: body.conversationId } : {},
+    );
+  }
+
+  @Post('maintenance/scenes/embed-gists')
+  @RequireScopes('brain:admin')
+  async embedGists(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { tenant?: string; conversationId?: string } = {},
+  ): Promise<SceneGistEmbedResult> {
+    // Double-gate idiom: controller 404 here + the service's defensive
+    // early return (off = zero queries, no embed call, byte-identical).
+    if (!sceneSegmentationEnabled() || !sceneGistEmbeddingEnabled()) {
+      throw new NotFoundException();
+    }
+    const tenant = this.resolveTenant(req, body.tenant);
+    return this.gistEncoder.run(
       tenant,
       body.conversationId !== undefined ? { conversationId: body.conversationId } : {},
     );

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -52,6 +52,7 @@ import { SceneBacklinkService } from './scene-backlink.service';
 import { BeliefPromotionService } from './belief-promotion.service';
 import { SceneEvidenceLinkerService } from './scene-evidence-linker.service';
 import { SceneVersionService } from './scene-version';
+import { SceneGistEmbeddingService } from './scene-gist-embedding.service';
 import { HnswMaintenanceService } from './hnsw-maintenance.service';
 import { CodeMemoryModule } from '../code-memory/code-memory.module';
 import { RegistryModule } from '../registry/registry.module';
@@ -136,6 +137,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     BeliefPromotionService,
     SceneEvidenceLinkerService,
     SceneVersionService,
+    SceneGistEmbeddingService,
     AdminInfraService,
     HealthComponentsService,
     LiveSnapshotService,

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -731,6 +731,31 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Scenes fact backlink (Brain v2 PR2): stamp knowledge_fact rows whose source.episodeIds intersect a scene’s membership with source.memoryEpisodeIds (idempotent array::union) + source.sceneLinkVersion — facts become pointers into the episodic plane. FLEXIBLE source ride, no migration; nothing on the serving path reads the keys (additively visible where `source` is already returned). Off = no fact row is ever touched, backlink route 404s.',
   },
   {
+    key: 'SCENES_GIST_EMBEDDING',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneGistEmbeddingEnabled) by the
+    // admin 404 guard, the encoder pass's defensive early return and the
+    // composer's post-swap hook — never captured in a constructor — so a
+    // flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Scene gist embeddings (Brain v2 PR3): the producer the 0106 `gistEmbedding` column never had. After the composer swap (and via POST /v1/admin/maintenance/scenes/embed-gists) an encoder pass embeds the CANONICAL `gist` text of scenes in the current effective world that carry no vector yet — ONE bounded embedMany batch per run, capped at 200 scenes — and writes the vector by primary-key-addressed UPDATE, plus the `embeddingSpaceId` stamp when EMBEDDING_SPACE_TRACKING is on (exactly the fact-side reindex convention, so space migration treats scenes like every other embedded surface). `gist` and NOT `enrichedGist`: it is the one canonical, post-compose-immutable gist column, the one the 0106 BM25 index covers, the one the scene lane renders and the one the reindex engine already declares as this table’s embed source — so the single seam covers deterministic AND LLM-enriched worlds. Unblocks the scene lane’s dense leg (RETRIEVAL_SCENE_LANE), which is BM25-only while no vector exists. Off = the embedder is never called, no scene row is touched, the route 404s and the composer hook is skipped — byte-identical prod. An embed failure is soft: the run reports it and never fails the compose that spawned it.',
+  },
+  {
+    key: 'SCENES_ENTITY_LINKS',
+    category: 'scenes',
+    // Read at call time (scene-flags.sceneEntityLinksEnabled) by the
+    // enricher, ONCE per run (the Drift-3 contract) — never captured in a
+    // constructor — so a flip takes effect without restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Scene entity links (Brain v2 PR3): the enrichment pass RESOLVES the LLM’s free-text `entityMentions` (parsed since PR2 and deliberately discarded — the 0106 column promises knowledge_entity RECORD refs) into real records through the platform’s own deterministic resolution — exact canonicalName/alias match, plus the INGEST_ARTICLE_NORMALIZATION leading-article variants and the INGEST_CODE_ALIAS_RESOLUTION path↔symbol convention when those flags are on — and persists them in `entityIds`. RESOLVE-ONLY: a scene NEVER mints an entity, never stamps an alias, never writes a merge-log row, and an unresolved mention is dropped — a scene is a reconstruction, not a source of truth. Fenced by the #387 single-user rule: a single-user scene may link its own user’s entities plus tenant-global ones, and a mixed-user / tenant-global / legacy scene links tenant-global entities ONLY, so a foreign user’s entity can never land on a scene; merged-away entities are excluded. At most 12 mentions are attempted per scene (so at most 12 links), and the resolved set fully REPLACES the column, so re-enrichment is idempotent. `relationIds` stays unwritten — the pipeline has no knowledge_edge producer and inventing edges from a mention list would assert evidence the scene never gave. Requires SCENES_LLM_ENRICHMENT. Off = zero resolution queries, a byte-identical scene SELECT projection and UPDATE statement, and no entityIds write.',
+  },
+  {
     key: 'SCENES_VERSION_FINGERPRINT',
     category: 'scenes',
     // Read at call time (scene-flags.sceneVersionFingerprintEnabled) once

--- a/src/admin/scene-composer.service.ts
+++ b/src/admin/scene-composer.service.ts
@@ -11,6 +11,7 @@ import { segmentSessions } from '../episodes/session-window';
 import {
   sceneEvidenceLinksEnabled,
   sceneFactBacklinkEnabled,
+  sceneGistEmbeddingEnabled,
   sceneLlmEnrichmentEnabled,
   sceneSegmentationEnabled,
 } from '../common/scene-flags';
@@ -31,6 +32,7 @@ import { SceneVersionService } from './scene-version';
 import { SceneEnricherService } from './scene-enricher.service';
 import { SceneBacklinkService } from './scene-backlink.service';
 import { SceneEvidenceLinkerService } from './scene-evidence-linker.service';
+import { SceneGistEmbeddingService } from './scene-gist-embedding.service';
 
 /**
  * Scene composer (Brain v2 PR1): batch-derives the SHADOW memory_episode
@@ -78,6 +80,15 @@ export interface SceneRunResult {
    * the composer into the enricher.
    */
   enriched?: number;
+  /**
+   * Scenes the post-swap gist-encoder pass gave a vector (PR3, the
+   * SCENES_GIST_EMBEDDING leg). ABSENT unless the flag is on and the pass
+   * ran to completion — an additive field, so a flag-off response is
+   * unchanged. Surfaced for the same reason as `enriched`: the vector
+   * count IS the run's embedding bill, and the scheduled pass must be able
+   * to meter it without reaching past the composer into the encoder.
+   */
+  gistEmbedded?: number;
 }
 
 /**
@@ -122,6 +133,7 @@ export class SceneComposerService {
     private readonly backlinker: SceneBacklinkService,
     private readonly evidenceLinker: SceneEvidenceLinkerService,
     private readonly versions: SceneVersionService,
+    private readonly gistEncoder: SceneGistEmbeddingService,
   ) {}
 
   async run(companyId: string, opts: SceneRunOptions = {}): Promise<SceneRunResult> {
@@ -219,6 +231,27 @@ export class SceneComposerService {
     // scenes this run actually changed, not by the size of the world.
     const passOpts =
       opts.conversationId !== undefined ? { conversationId: opts.conversationId } : {};
+    // PR3 encoder pass: the producer of the 0106 `gistEmbedding` column
+    // (SceneGistEmbeddingService). It runs FIRST of the post-swap chain
+    // because it encodes the swap's own output — the canonical `gist` text
+    // — and because it is the cheapest leg: ONE embedMany batch over the
+    // vector-less scenes of this world, bounded per run and idempotent.
+    // Order against the enricher is immaterial by construction: the
+    // enricher writes the `enrichedGist` REVISION sibling and never
+    // touches `gist`, so the vector can never go stale relative to the
+    // text it encodes.
+    if (sceneGistEmbeddingEnabled()) {
+      try {
+        const encoded = await this.gistEncoder.run(companyId, passOpts);
+        result.gistEmbedded = encoded.embedded;
+        this.logger.log(
+          `scene gist encoder pass: ${encoded.embedded}/${encoded.scenes} embedded, ` +
+            `${encoded.skipped} unusable, ${encoded.failed} failed`,
+        );
+      } catch (e) {
+        this.logger.warn(`scene gist encoder pass failed: ${(e as Error).message}`);
+      }
+    }
     if (sceneLlmEnrichmentEnabled()) {
       try {
         const enrich = await this.enricher.enrich(companyId, passOpts);
@@ -333,9 +366,13 @@ export class SceneComposerService {
 
     // Build scene + member rows. Scene record ids are deterministic over
     // (conversation, segmenterVersion, index) so a rebuild replaces the
-    // same identities. gistEmbedding is deliberately NOT written in v1 —
-    // it is the gist TEXT's vector, not the member-turn centroid we
-    // compute for novelty; the PR2 encoder pass backfills it.
+    // same identities. gistEmbedding is NOT written HERE — it is the gist
+    // TEXT's vector, not the member-turn centroid we compute for novelty,
+    // and the two must not be conflated. Its producer is the post-swap
+    // encoder pass (SceneGistEmbeddingService, SCENES_GIST_EMBEDDING),
+    // which embeds the `gist` this loop renders once the swap has landed:
+    // the paid step stays OUT of the pre-delete critical section, and a
+    // vector-less world is a graceful state the lane degrades through.
     const priorCentroids: number[][] = [];
     const sceneRows: Array<Record<string, unknown>> = [];
     const memberRows: Array<Record<string, unknown>> = [];

--- a/src/admin/scene-enricher.service.ts
+++ b/src/admin/scene-enricher.service.ts
@@ -1,12 +1,19 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { StringRecordId, type Surreal } from 'surrealdb';
 import type OpenAI from 'openai';
 import { SurrealService } from '../db/surreal.service';
 import { EpisodeReadStoreService, type EpisodeDb } from '../episodes/episode-read-store.service';
+import { EntityUpsertService } from '../ingest/entity-upsert.service';
 import { chatCallParams, createOpenAiClient } from '../ai/openai-client';
-import { sceneLlmEnrichmentEnabled, scenePredictionBaselineEnabled } from '../common/scene-flags';
+import {
+  sceneEntityLinksEnabled,
+  sceneLlmEnrichmentEnabled,
+  scenePredictionBaselineEnabled,
+} from '../common/scene-flags';
 import { type SceneTurnRow } from './scene-segmentation';
 import { sceneSingleUser } from './belief-promotion.service';
+import { selectSceneMentions, stableEntityIds } from './scene-entity-links';
 import {
   baselineRefPayload,
   loadActiveBeliefBaseline,
@@ -77,11 +84,52 @@ import { SceneVersionService } from './scene-version';
  * re-enrichment restores it. Namespacing the two writers under distinct
  * keys is the obvious follow-up and belongs in the promotion service.
  *
- * entityMentions is parsed and validated but deliberately NOT persisted:
- * the 0106 column for entity links is entityIds — RECORD refs to
- * knowledge_entity — and resolving free-text mentions into records is a
- * separate (PR3) pass; storing raw strings where records are promised
- * would poison that column's contract.
+ * ENTITY LINKS (SCENES_ENTITY_LINKS, default off) — PR3, the pass PR2
+ * deferred. Until now `entityMentions` was parsed, validated and THROWN
+ * AWAY: the 0106 column for entity links is `entityIds` — RECORD refs to
+ * knowledge_entity — and storing raw strings where records are promised
+ * would poison that column's contract. With the flag on, each scene's
+ * mentions are RESOLVED against the graph through the platform's own
+ * deterministic resolution (EntityUpsertService.resolveExistingByName:
+ * exact canonicalName/alias, then the INGEST_ARTICLE_NORMALIZATION
+ * variants and the INGEST_CODE_ALIAS_RESOLUTION path↔symbol convention
+ * when those are on) and the resolved refs land in `entityIds`.
+ *
+ *  - RESOLVE-ONLY, NEVER MINT. A scene is a RECONSTRUCTION of turns that
+ *    were already ingested, not a source of truth: every entity it can
+ *    legitimately name already exists, so a mention that resolves to
+ *    nothing is DROPPED. No knowledge_entity row is created, no alias is
+ *    stamped on the entity the link points at, no merge-log row is
+ *    written — and the probabilistic embedding+judge resolver is not in
+ *    the ladder at all (a low-confidence fuse is the wrong trade for an
+ *    unasked-for backlink). Ambiguity — two entities carrying the name —
+ *    also links NOTHING.
+ *  - SCOPE. The #387 single-user fence decides what the scene may see: a
+ *    single-user scene resolves against tenant-global entities PLUS its
+ *    own user's; a mixed-user, tenant-global or legacy (pre-0117) scene
+ *    resolves against tenant-global entities ONLY. A foreign user's
+ *    entity can therefore never appear on a scene. The 0093 scope-tag
+ *    fence ANDs alongside.
+ *  - BOUNDED. At most SCENE_ENTITY_LINKS_MAX mentions are attempted per
+ *    scene, so the resolution cost stays an order of magnitude under the
+ *    one LLM call that produced them.
+ *  - IDEMPOTENT. The resolved set (de-duplicated and SORTED) fully
+ *    REPLACES the column, so a re-enrichment over an unchanged corpus
+ *    writes a byte-identical value; an empty result writes `[]` — "we
+ *    looked and found nothing" is a fact worth recording, and it is
+ *    stable across re-runs in a way an absent column is not.
+ *  - DEGRADE. A resolution failure warns and drops that mention; the
+ *    enrichment write still lands.
+ *
+ * `relationIds` — the sibling 0106 column — stays UNWRITTEN, deliberately.
+ * Nothing in the scene pipeline produces knowledge_edge relations: the
+ * enrichment schema returns MENTIONS and stateDeltas, neither of which is
+ * a typed entity→entity edge, and taking the cross-product of the resolved
+ * entities to look up edges that already exist would assert "this scene is
+ * evidence for that relation" on evidence the scene never gave. A column
+ * left NONE says "no producer"; a column filled by inference says
+ * something false. The honest producer is a relation-extraction pass that
+ * does not exist yet.
  */
 
 /** Stamp on enrichedMemoryValue written by this enricher (scorerVersion). */
@@ -333,12 +381,17 @@ export class SceneEnricherService {
 
   // Fourth dep is the run-scoped version resolver (Drift-3): the enricher
   // must select scenes by the SAME effective version the composer stamps.
+  // Fifth is the platform's entity resolution, @Optional (the module-doc
+  // idiom): positionally-constructed unit fixtures stay valid and the
+  // SCENES_ENTITY_LINKS leg degrades to "resolve nothing" when it is not
+  // wired, exactly as it does when a mention matches nothing.
   // eslint-disable-next-line max-params
   constructor(
     private readonly surreal: SurrealService,
     configService: ConfigService,
     private readonly episodes: EpisodeReadStoreService,
     private readonly versions: SceneVersionService,
+    @Optional() private readonly entities?: EntityUpsertService,
   ) {
     this.openai = createOpenAiClient(configService);
     this.model = configService.get<string>(
@@ -371,12 +424,18 @@ export class SceneEnricherService {
     // mix prompt versions inside one enriched world.
     const { version } = this.versions.resolve();
     const predictionOn = scenePredictionBaselineEnabled();
+    // Resolved ONCE per run for the same Drift-3 reason: a mid-run flip
+    // must not leave half the world linked and half not.
+    const entityLinksOn = sceneEntityLinksEnabled();
     const enrichmentVersion = sceneEnrichmentVersion(this.model, predictionOn);
     await this.surreal.withCompany(companyId, async (db) => {
-      // The scope columns are projected ONLY with the baseline on — flag
-      // off keeps the SELECT byte-identical (pinned by unit test).
+      // The scope columns are projected ONLY when a leg actually needs
+      // them — the prediction baseline's #387 fence, or the entity-link
+      // fence, which reads the same single-user stamp. With BOTH off the
+      // SELECT is byte-identical (pinned by unit test).
+      const needsScope = predictionOn || entityLinksOn;
       const [scenes] = await db.query<[SceneHead[]]>(
-        `SELECT id, conversationIds, enrichmentVersion${predictionOn ? ', userId, userIds' : ''} FROM memory_episode
+        `SELECT id, conversationIds, enrichmentVersion${needsScope ? ', userId, userIds' : ''} FROM memory_episode
           WHERE segmenterVersion = $v` +
           (opts.conversationId !== undefined ? ` AND conversationIds CONTAINS $conv` : ''),
         {
@@ -414,6 +473,7 @@ export class SceneEnricherService {
             turnCache,
             enrichmentVersion,
             predictionOn,
+            entityLinksOn,
             beliefsByUser,
           });
           if (ok) result.enriched += 1;
@@ -451,6 +511,7 @@ export class SceneEnricherService {
     turnCache,
     enrichmentVersion,
     predictionOn,
+    entityLinksOn,
     beliefsByUser,
   }: {
     db: EpisodeDb;
@@ -458,6 +519,7 @@ export class SceneEnricherService {
     turnCache: Map<string, Map<string, SceneTurnRow>>;
     enrichmentVersion: string;
     predictionOn: boolean;
+    entityLinksOn: boolean;
     beliefsByUser: ReadonlyMap<string, BaselineBelief[]>;
   }): Promise<boolean> {
     if (scene.conversationIds.length === 0) return false;
@@ -535,14 +597,22 @@ export class SceneEnricherService {
             selfSubjects: prediction.selfSubjects,
           });
 
+    // The 0106 semantic backlinks (SCENES_ENTITY_LINKS): free-text
+    // mentions → knowledge_entity RECORD refs, resolve-only. null with the
+    // flag off, and the SET clause below is then byte-identical.
+    const entityIds = entityLinksOn
+      ? await this.resolveEntityLinks(db, scene, enrichment.entityMentions)
+      : null;
+
     // Single-record UPDATE by bound id — primary-key addressed, immune to
     // the 3.2.4 secondary-index planner bug by construction. Writes ONLY
     // the enrichment-revision siblings + stamps (0118) — plus, with the
-    // baseline on, the 0106 FLEXIBLE `baselineRef` snapshot: the
-    // composer's deterministic gist / memoryValue stay immutable
-    // post-compose, and gistPromptVersion is legacy-dead (superseded by
-    // enrichmentVersion). The baselineRef clause is APPENDED so the
-    // flag-off statement stays byte-identical (pinned by unit test).
+    // baseline on, the 0106 FLEXIBLE `baselineRef` snapshot, and with
+    // entity links on the 0106 `entityIds` refs: the composer's
+    // deterministic gist / memoryValue stay immutable post-compose, and
+    // gistPromptVersion is legacy-dead (superseded by enrichmentVersion).
+    // Both optional clauses are APPENDED, in flag order, so each off-state
+    // statement stays byte-identical (pinned by unit test).
     await db.query(
       `UPDATE $scene SET
          enrichedGist = $gist,
@@ -552,7 +622,8 @@ export class SceneEnricherService {
          enrichmentModel = $model,
          enrichmentVersion = $enrichmentVersion,
          enrichedAt = time::now()` +
-        (prediction === null ? '' : `,\n         baselineRef = $baselineRef`),
+        (prediction === null ? '' : `,\n         baselineRef = $baselineRef`) +
+        (entityIds === null ? '' : `,\n         entityIds = $entityIds`),
       {
         scene: scene.id,
         gist: enrichment.gist,
@@ -568,9 +639,57 @@ export class SceneEnricherService {
         model: this.model,
         enrichmentVersion,
         ...(prediction === null ? {} : { baselineRef: baselineRefPayload(prediction.beliefs) }),
+        ...(entityIds === null ? {} : { entityIds }),
       },
     );
     return true;
+  }
+
+  /**
+   * Resolve one scene's free-text mentions into knowledge_entity RECORD
+   * refs (SCENES_ENTITY_LINKS). Returns the refs to write — possibly an
+   * EMPTY array, which is a real answer ("we looked, nothing resolved")
+   * and keeps the column stable across re-runs.
+   *
+   * RESOLVE-ONLY. Every lookup goes through
+   * EntityUpsertService.resolveExistingByName, which never mints, never
+   * stamps an alias and refuses ambiguous names — so an unresolvable
+   * mention simply drops out. No resolver wired ⇒ nothing resolves, which
+   * is the same graceful state.
+   *
+   * SCOPE — the #387 fence, reused verbatim. `sceneSingleUser` returns the
+   * user only for a scene that is unambiguously ONE user's; a mixed-user,
+   * tenant-global or legacy (pre-0117 userIds) scene yields null and then
+   * resolves against TENANT-GLOBAL entities only. So a user-scoped scene
+   * can reach its own user's entities and nobody else's, and a shared
+   * scene can never carry a personal one.
+   *
+   * DEGRADE. One mention's failure warns and drops that mention; the
+   * enrichment write it belongs to still lands.
+   */
+  private async resolveEntityLinks(
+    db: EpisodeDb,
+    scene: SceneHead,
+    mentions: readonly string[],
+  ): Promise<StringRecordId[]> {
+    if (!this.entities) return [];
+    const userId = sceneSingleUser(scene);
+    const resolved: string[] = [];
+    for (const name of selectSceneMentions(mentions)) {
+      try {
+        const entityId = await this.entities.resolveExistingByName(
+          db as unknown as Surreal,
+          { name },
+          { userId: userId ?? undefined },
+        );
+        if (entityId !== null) resolved.push(entityId);
+      } catch (e) {
+        this.logger.warn(
+          `scene entity link skipped for "${name}" on ${String(scene.id)}: ${(e as Error).message}`,
+        );
+      }
+    }
+    return stableEntityIds(resolved).map((id) => new StringRecordId(id));
   }
 
   /**

--- a/src/admin/scene-entity-links.ts
+++ b/src/admin/scene-entity-links.ts
@@ -1,0 +1,72 @@
+/**
+ * Scene entity links (Brain v2 PR3, SCENES_ENTITY_LINKS) — the pure half.
+ *
+ * The LLM enricher returns `entityMentions`: free-text names of the
+ * people, places and things a scene names. The 0106 column that holds
+ * them, `entityIds`, is typed `option<array<record<knowledge_entity>>>` —
+ * RECORD REFS, not strings — which is exactly why PR2 parsed the mentions
+ * and threw them away rather than poisoning the column's contract.
+ *
+ * This module owns the two decisions that need no I/O: WHICH mentions are
+ * worth a lookup, and HOW the resolved ids become a stable column value.
+ * The lookup itself is EntityUpsertService.resolveExistingByName (the
+ * platform's own deterministic resolution, resolve-only), and the fence
+ * lives with the enricher that knows the scene's scope.
+ */
+
+/**
+ * Mentions attempted per scene, and therefore the cap on links a single
+ * scene can carry (design constant, the SCENE_LANE_TOP_K idiom —
+ * deliberately NOT an env knob until the pass is measured).
+ *
+ * WHY A CAP AT ALL. The parser already bounds the reply at MENTIONS_MAX =
+ * 50, but each surviving mention costs one indexed lookup (up to three
+ * under the article/code-alias flags), so an off-rubric model listing
+ * every noun in a 40-turn scene would turn ONE enrichment into ~150
+ * queries. Twelve is generous for "who and what this scene is about" and
+ * keeps the resolution cost per scene an order of magnitude below the LLM
+ * call that produced the mentions.
+ *
+ * WHY THE FIRST TWELVE and not a ranked twelve: the model emits mentions
+ * in the order it found them salient, and any re-ranking we invented here
+ * (length, frequency in the transcript) would be a guess dressed as a
+ * signal. Truncation of a list the model itself ordered is the honest cut.
+ */
+export const SCENE_ENTITY_LINKS_MAX = 12;
+
+/**
+ * Pure: the mentions this scene will actually try to resolve.
+ *
+ * Trims, drops blanks, and de-duplicates CASE-INSENSITIVELY while keeping
+ * the FIRST spelling seen — "Lisbon" and "lisbon" are one lookup, and the
+ * surviving spelling is the one the model wrote first, since the exact
+ * match tries `aliases CONTAINS <raw>` where case matters. Order is the
+ * model's, and the list is truncated to SCENE_ENTITY_LINKS_MAX.
+ */
+export function selectSceneMentions(mentions: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const mention of mentions) {
+    if (out.length >= SCENE_ENTITY_LINKS_MAX) break;
+    const name = mention.trim();
+    if (name === '') continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(name);
+  }
+  return out;
+}
+
+/**
+ * Pure: the stable column value for a set of resolved entity ids.
+ *
+ * De-duplicated (two mentions of one entity — "Mika" and "mika savchenko"
+ * — must not double-link it) and SORTED, so the written value is a
+ * function of the resolved SET alone and not of the order the model
+ * happened to list the mentions in. That is what makes a re-enrichment
+ * over an unchanged corpus write a byte-identical column.
+ */
+export function stableEntityIds(resolved: readonly string[]): string[] {
+  return [...new Set(resolved.filter((id) => id !== ''))].sort();
+}

--- a/src/admin/scene-gist-embedding.service.ts
+++ b/src/admin/scene-gist-embedding.service.ts
@@ -1,0 +1,223 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { FactEmbeddingService } from '../ingest/fact-embedding.service';
+import { EMBEDDING_SPACE_FIELD } from '../ai/embedder/embedding-space';
+import { envFlagEnabled } from '../common/env-validation';
+import { sceneGistEmbeddingEnabled } from '../common/scene-flags';
+import { SceneVersionService } from './scene-version';
+
+/**
+ * Scene gist encoder pass (Brain v2 PR3, SCENES_GIST_EMBEDDING — default
+ * off): the PRODUCER the 0106 `gistEmbedding` column never had.
+ *
+ * THE HOLE THIS FILLS. 0106 defined the column, the composer's header
+ * promised "the PR2 encoder pass backfills it", and PR2 shipped without
+ * one. Both downstream consumers were then built around the absence:
+ *   - the reindex engine registers memory_episode/gistEmbedding but its
+ *     sweep runs `WHERE gistEmbedding != NONE` — it MOVES vectors between
+ *     embedding spaces, it never creates them, so it was a documented
+ *     no-op for scenes ("unpopulated derived state");
+ *   - the scene serving lane (RETRIEVAL_SCENE_LANE) shipped BM25-only
+ *     because "a dense leg would be write-dead for the default world".
+ * This pass is the missing write side; the lane's dense leg is the read
+ * side it unblocks.
+ *
+ * WHICH TEXT — `gist`, NOT `enrichedGist`. There is exactly ONE canonical
+ * gist TEXT column on a scene and the composer is its only writer: `gist`
+ * is immutable post-compose (Drift-3b), the LLM enricher writes its
+ * abstractive revision to the SIBLING `enrichedGist` and never touches
+ * `gist`. `gist` is also the column the 0106 `scene_gist_search` FULLTEXT
+ * index covers, the column the lane renders, and the column the reindex
+ * engine already declares as this table's embed source
+ * (ADDITIONAL_TABLE_SPECS). Embedding anything else would put the vector
+ * out of step with the BM25 leg AND have it silently replaced by the first
+ * space-migration sweep. So this ONE seam covers BOTH gist kinds — the
+ * deterministic world and the LLM-enriched world alike — which is exactly
+ * why the pass lives here (post-swap, composer-side) rather than inside
+ * the enricher's UPDATE, which would cover neither.
+ *
+ * SPACE STAMP — the fact-side convention, verbatim. `embeddingSpaceId` is
+ * written ONLY under EMBEDDING_SPACE_TRACKING and always TOGETHER with the
+ * vector (the reindex engine's `spaceStampId` / `writeVector` idiom): a
+ * NONE column means "the current provider's space" (embedding-space.ts),
+ * so with tracking off the row is exactly what a knowledge_fact row looks
+ * like, and with it on the reindex/space-migration machinery treats scenes
+ * like every other embedded surface.
+ *
+ * IDEMPOTENT + BOUNDED. Only scenes of the CURRENT effective segmenter
+ * world (SceneVersionService, resolved ONCE per run — the Drift-3
+ * contract) that carry NO vector are selected, at most
+ * SCENE_EMBED_MAX_PER_RUN of them, embedded in ONE batch. A re-run after a
+ * complete pass selects nothing and spends nothing; a partial run drains
+ * over successive runs (the nightly-maintenance idiom). Re-embedding rows
+ * that ALREADY carry a vector is deliberately NOT this pass's job — that
+ * is the reindex sweep's, which owns space migration.
+ *
+ * DEGRADE, NEVER FAIL. The pass runs AFTER the composer's atomic swap, so
+ * it must never retract a landed result: an embed batch failure logs a
+ * warning and reports `failed`, a per-row write failure is counted and
+ * skipped, and the caller's compose still succeeds.
+ *
+ * WRITE SURFACE: `gistEmbedding` (+ the space stamp) on memory_episode,
+ * by BOUND-ID UPDATE — primary-key addressed, immune by construction to
+ * the SurrealDB 3.2.4 secondary-index planner bug the 0093 header
+ * documents (a WHERE over an indexed field can silently match nothing on
+ * a DELETE/UPDATE).
+ */
+
+/**
+ * Scenes embedded per run (design constant, the SCENE_LANE_TOP_K idiom —
+ * deliberately NOT an env knob until the pass is measured). The bound that
+ * matters: ONE embedMany batch per run, so a first-time backfill of a
+ * large tenant costs a bounded number of vectors per invocation and drains
+ * across runs instead of fanning out unboundedly inside one compose.
+ */
+export const SCENE_EMBED_MAX_PER_RUN = 200;
+
+/** Embedded gist text cap — a belt against a runaway gist, not a budget. */
+const GIST_EMBED_MAX_CHARS = 4000;
+
+export interface SceneGistEmbedResult {
+  /** Vector-less scenes of the current world this run selected. */
+  scenes: number;
+  /** Scenes whose vector actually landed. */
+  embedded: number;
+  /** Selected but unusable (blank gist) — never embedded, never written. */
+  skipped: number;
+  /** Embed-batch or row-write failures (soft: the run still succeeds). */
+  failed: number;
+}
+
+/** Head row of a scene awaiting its gist vector. */
+interface SceneGistRow {
+  id: unknown;
+  gist?: unknown;
+}
+
+@Injectable()
+export class SceneGistEmbeddingService {
+  private readonly logger = new Logger(SceneGistEmbeddingService.name);
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly embedding: FactEmbeddingService,
+    private readonly versions: SceneVersionService,
+  ) {}
+
+  /**
+   * Embed the gists of vector-less scenes in the current effective world
+   * (optionally one conversation's). Never throws.
+   */
+  async run(
+    companyId: string,
+    opts: { conversationId?: string } = {},
+  ): Promise<SceneGistEmbedResult> {
+    const result: SceneGistEmbedResult = { scenes: 0, embedded: 0, skipped: 0, failed: 0 };
+    // Defense in depth: the controller already 404s with the flag off; a
+    // programmatic caller must not spend embedding calls past a disabled
+    // flag. Checked FIRST — off means the embedder is not so much as
+    // touched and no query is issued.
+    if (!sceneGistEmbeddingEnabled()) return result;
+    const { version } = this.versions.resolve();
+    // The space stamp is resolved ONCE per run, before any write, exactly
+    // like the reindex engine resolves it once per tenant.
+    const spaceId = this.spaceStampId();
+    await this.surreal.withCompany(companyId, async (db) => {
+      // Plain WHERE SELECT over indexed fields — safe on 3.2.4 (only
+      // DELETE/UPDATE trip the planner bug; see the composer's swap note).
+      const convClause =
+        opts.conversationId !== undefined ? ' AND conversationIds CONTAINS $conv' : '';
+      const [rows] = await db.query<[SceneGistRow[]]>(
+        `SELECT id, gist FROM memory_episode
+            WHERE segmenterVersion = $v AND gistEmbedding IS NONE${convClause}
+            ORDER BY id
+            LIMIT $cap`,
+        {
+          v: version,
+          cap: SCENE_EMBED_MAX_PER_RUN,
+          ...(opts.conversationId !== undefined ? { conv: opts.conversationId } : {}),
+        },
+      );
+      const page = rows ?? [];
+      result.scenes = page.length;
+      if (page.length === 0) return;
+
+      // A blank gist has nothing to encode — never embed it, so a zero
+      // vector can never enter the space (the reindex sweep's rule).
+      const kept: Array<{ id: unknown; text: string }> = [];
+      for (const row of page) {
+        const text = typeof row.gist === 'string' ? row.gist.trim() : '';
+        if (text === '') {
+          result.skipped += 1;
+          continue;
+        }
+        kept.push({ id: row.id, text: text.slice(0, GIST_EMBED_MAX_CHARS) });
+      }
+      if (kept.length === 0) return;
+
+      // ONE batch for the whole run — the paid step, bounded by the cap.
+      let vectors: number[][];
+      try {
+        vectors = await this.embedding.embedMany(kept.map((k) => k.text));
+      } catch (e) {
+        result.failed += kept.length;
+        this.logger.warn(
+          `scene gist embed batch failed (companyId=${companyId}, scenes=${kept.length}): ` +
+            `${(e as Error).message} — scenes keep no vector`,
+        );
+        return;
+      }
+      for (const [i, entry] of kept.entries()) {
+        const vector = vectors[i];
+        if (!Array.isArray(vector) || vector.length === 0) {
+          result.failed += 1;
+          continue;
+        }
+        try {
+          await this.writeVector(db, { id: entry.id, embedding: vector, spaceId });
+          result.embedded += 1;
+        } catch (e) {
+          result.failed += 1;
+          this.logger.warn(
+            `scene gist vector write failed for ${String(entry.id)}: ${(e as Error).message}`,
+          );
+        }
+      }
+    });
+    return result;
+  }
+
+  /**
+   * Whether to stamp `embeddingSpaceId` alongside the vector — the reindex
+   * engine's rule, read per-call so an operator flip takes effect without a
+   * restart. Off (default) ⇒ the UPDATE is exactly
+   * `SET gistEmbedding = $embedding`, and the NONE space column means "the
+   * current provider's space" (the legacy/implicit space).
+   */
+  private spaceStampId(): string | null {
+    if (!envFlagEnabled(process.env.EMBEDDING_SPACE_TRACKING)) return null;
+    return this.embedding.activeSpaceId();
+  }
+
+  /**
+   * One scene's vector, by BOUND ID — primary-key addressed, so the 3.2.4
+   * secondary-index planner bug cannot silently no-op it. Vector and space
+   * id are written TOGETHER or not at all (the 0101 idiom: a vector whose
+   * space is unknown cannot be compared to anything).
+   */
+  private async writeVector(
+    db: { query: <T>(sql: string, params?: Record<string, unknown>) => Promise<T> },
+    entry: { id: unknown; embedding: number[]; spaceId: string | null },
+  ): Promise<void> {
+    const { id, embedding, spaceId } = entry;
+    if (spaceId === null) {
+      await db.query(`UPDATE $id SET gistEmbedding = $embedding`, { id, embedding });
+      return;
+    }
+    await db.query(`UPDATE $id SET gistEmbedding = $embedding, ${EMBEDDING_SPACE_FIELD} = $space`, {
+      id,
+      embedding,
+      space: spaceId,
+    });
+  }
+}

--- a/src/ai/embedder/reindex-engine.service.ts
+++ b/src/ai/embedder/reindex-engine.service.ts
@@ -35,9 +35,12 @@ interface ReindexTableSpec {
  *                          yet backfilled; the != NONE guard makes this a
  *                          safe no-op until they are)
  *   - episode_segment    — segment-composer stores the exact embedded `text`
- *   - memory_episode     — scene gist (0106; gistEmbedding is unpopulated
- *                          derived state today — the != NONE guard makes
- *                          this a safe no-op until a scorer fills it)
+ *   - memory_episode     — scene gist (0106; the encoder pass
+ *                          SceneGistEmbeddingService, SCENES_GIST_EMBEDDING,
+ *                          embeds `gist` verbatim, so the projection here
+ *                          matches its write path exactly; the != NONE
+ *                          guard keeps a world built before that flag was
+ *                          on a safe no-op)
  *   - strategy_memory    — `<title>\n<situation>` (strategy-memory.service)
  *
  * community_node (summaryEmbedding) and procedural_memory (triggerEmbedding)
@@ -78,10 +81,12 @@ const ADDITIONAL_TABLE_SPECS: ReindexTableSpec[] = [
     text: (r) => asStr(r.text),
   },
   {
-    // Scenes (0106): the deterministic gist IS the embedded text (the
-    // composer embeds `gist` verbatim when it fills gistEmbedding). The
-    // `!= NONE` guard makes this a safe no-op while gist vectors remain
-    // unpopulated derived state.
+    // Scenes (0106): the canonical `gist` IS the embedded text — the
+    // post-swap encoder pass (SceneGistEmbeddingService) embeds it
+    // verbatim, so this re-embed reproduces the write path's vector. The
+    // `!= NONE` guard keeps the sweep a MOVE between spaces, never a
+    // create: a world composed before SCENES_GIST_EMBEDDING was on stays
+    // a safe no-op here and is filled by the encoder pass instead.
     table: 'memory_episode',
     vectorField: 'gistEmbedding',
     select: 'id, gist, gistEmbedding',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1096,6 +1096,30 @@ const KNOWN_BOOLEAN_FLAGS = [
   // verbatim (facts read/provenance API) — additive. Default off ⇒ no
   // fact row is ever touched and the backlink admin route 404s.
   'SCENES_FACT_BACKLINK',
+  // Scene gist embeddings (Brain v2 PR3): the producer the 0106
+  // `gistEmbedding` column never had. A post-swap encoder pass (+ POST
+  // /v1/admin/maintenance/scenes/embed-gists) embeds the CANONICAL `gist`
+  // text of vector-less scenes in the current world, one bounded batch per
+  // run, writing the vector by primary-key UPDATE plus the fact-side
+  // `embeddingSpaceId` stamp under EMBEDDING_SPACE_TRACKING. Unblocks both
+  // waiting consumers: the reindex sweep (which only MOVES existing
+  // vectors between spaces) and the scene lane's dense leg. Default off ⇒
+  // the embedder is never called, no scene row is touched and the route
+  // 404s — byte-identical prod. An embed failure is soft.
+  'SCENES_GIST_EMBEDDING',
+  // Scene entity links (Brain v2 PR3): resolve the enricher's free-text
+  // `entityMentions` into knowledge_entity RECORD refs and persist them in
+  // the 0106 `entityIds` column, through the platform's own deterministic
+  // resolution (exact canonicalName/alias, INGEST_ARTICLE_NORMALIZATION
+  // variants, INGEST_CODE_ALIAS_RESOLUTION path↔symbol). RESOLVE-ONLY: a
+  // scene never MINTS an entity, never stamps an alias, and an unresolved
+  // mention is dropped — a scene is a reconstruction, not a source of
+  // truth. Fenced by #387 (a user-scoped scene links its own user's plus
+  // tenant-global entities; every other scene links tenant-global only),
+  // capped per scene and idempotent. `relationIds` stays unwritten — no
+  // producer exists. Requires SCENES_LLM_ENRICHMENT. Default off ⇒ zero
+  // resolution queries and a byte-identical SELECT/UPDATE.
+  'SCENES_ENTITY_LINKS',
   // Scenes version fingerprint (Drift-3): when on, the EFFECTIVE segmenter
   // version becomes 'scene-segmenter-v1+<8-hex sha256 over the resolved
   // segmenter config>' (impl, scorer, maxTurns, topicBoundary, and — only

--- a/src/common/scene-flags.ts
+++ b/src/common/scene-flags.ts
@@ -72,6 +72,84 @@ export function sceneLlmEnrichmentEnabled(): boolean {
 }
 
 /**
+ * Scene gist embeddings — SCENES_GIST_EMBEDDING (Brain v2 PR3).
+ *
+ * The 0106 `gistEmbedding` column had NO producer. The composer's own
+ * header said so ("deliberately NOT written in v1 … the PR2 encoder pass
+ * backfills it"), PR2 shipped without it, and both downstream consumers
+ * were built around the hole: the reindex sweep registers memory_episode
+ * but no-ops on it (`WHERE gistEmbedding != NONE` — the sweep MOVES
+ * vectors between spaces, it never creates them), and the scene serving
+ * lane (RETRIEVAL_SCENE_LANE) is BM25-only with no dense leg.
+ *
+ * When on, a post-swap encoder pass (SceneGistEmbeddingService, also
+ * triggerable standalone via POST /v1/admin/maintenance/scenes/embed-gists)
+ * embeds the CANONICAL gist TEXT of scenes in the current effective
+ * segmenter world that carry no vector yet, in ONE bounded batch per run,
+ * and writes `gistEmbedding` by primary-key-addressed UPDATE — plus, when
+ * EMBEDDING_SPACE_TRACKING is on, the `embeddingSpaceId` stamp, exactly
+ * the fact-side convention (the reindex engine's spaceStampId).
+ *
+ * WHY `gist` AND NOT `enrichedGist`: `gist` is the ONE canonical gist text
+ * column — immutable post-compose, the column the 0106 BM25 FULLTEXT index
+ * covers, the column the scene lane renders, and the column the reindex
+ * engine already declares as memory_episode's embed source. A vector of
+ * any other text would be silently replaced by the first space-migration
+ * sweep. So this single seam covers BOTH gist kinds: the enricher writes
+ * a REVISION sibling (`enrichedGist`) and never touches `gist`.
+ *
+ * The env read lives here in the common layer, NOT inside the engine dirs
+ * (engine-gates S5.2). Read at call time so a flip is runtime-mutable.
+ * Default off ⇒ the embedder is NEVER called, no scene row is touched, the
+ * admin route 404s and the composer's post-swap hook is skipped —
+ * byte-identical prod. An embed failure is SOFT: the run reports it and the
+ * scenes keep no vector, never failing the composer run that spawned it.
+ */
+export function sceneGistEmbeddingEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_GIST_EMBEDDING);
+}
+
+/**
+ * Scene entity links — SCENES_ENTITY_LINKS (Brain v2 PR3).
+ *
+ * The LLM enricher has parsed `entityMentions` since PR2 and DELIBERATELY
+ * thrown them away: the 0106 column for entity links is `entityIds` —
+ * RECORD refs to knowledge_entity — and storing raw strings where records
+ * are promised would poison that column's contract.
+ *
+ * When on, the enrichment pass RESOLVES those free-text mentions against
+ * the platform's existing deterministic entity resolution
+ * (EntityUpsertService.resolveExistingByName — the same exact
+ * canonicalName/alias match, INGEST_ARTICLE_NORMALIZATION variants and
+ * INGEST_CODE_ALIAS_RESOLUTION path/symbol convention the ingest naming
+ * path uses) and persists the resolved record refs on the scene.
+ *
+ * RESOLVE-ONLY, NEVER MINT. A scene is a RECONSTRUCTION of turns already
+ * ingested, not a source of truth: a mention that resolves to nothing is
+ * DROPPED, no knowledge_entity row is ever created, no alias is stamped
+ * and no merge-log row is written. Scoped by the #387 single-user fence —
+ * a user-scoped scene may link its own user's entities plus tenant-global
+ * ones; a mixed-user / tenant-global / legacy scene links tenant-global
+ * entities ONLY, so a foreign user's entity can never appear on a scene.
+ * Capped per scene, and idempotent: the resolved set fully replaces the
+ * column, so a re-enrichment with the same corpus writes the same value.
+ *
+ * `relationIds` (the sibling 0106 column) stays UNWRITTEN: nothing in the
+ * scene pipeline produces knowledge_edge relations — the enricher's schema
+ * returns mentions, not typed relations — and cross-producting resolved
+ * entities into existing edges would assert evidence the scene never gave.
+ *
+ * The env read lives here in the common layer, NOT inside the engine dirs
+ * (engine-gates S5.2). Read ONCE per enrichment run (the Drift-3 contract).
+ * Default off ⇒ ZERO resolution queries, the byte-identical scene SELECT
+ * projection and UPDATE statement, and no entityIds write. Requires
+ * SCENES_LLM_ENRICHMENT — the mentions are an output of the enrichment call.
+ */
+export function sceneEntityLinksEnabled(): boolean {
+  return envFlagEnabled(process.env.SCENES_ENTITY_LINKS);
+}
+
+/**
  * Scenes fact-backlink flag — SCENES_FACT_BACKLINK (Brain v2 PR2).
  *
  * When on, a batch pass (end of the composer run + standalone POST

--- a/src/ingest/entity-upsert.service.ts
+++ b/src/ingest/entity-upsert.service.ts
@@ -12,6 +12,7 @@ import { EntityRef, IngestFactDto } from './dto/ingest-fact.dto';
 import { externalRefKey, idTailOf } from './ingest-utils';
 import { isCodeSymbolShaped, pathNeedlesForSymbol, symbolAliasForPath } from './code-alias';
 import { scopeForUser } from '../auth/scope-tags';
+import { scopeFenceSql } from '../auth/scope-visibility';
 import { envFlagEnabled } from '../common/env-validation';
 import { analyzeConfusables } from '../common/text-sanitizer';
 
@@ -57,6 +58,13 @@ export function articleNameVariants(nameLc: string): string[] {
  *
  * Shared by all three ingest paths: typed fact (resolveOrCreateEntity),
  * mention (resolveOrCreateNamedEntity), and link (resolveOrCreateBareRef).
+ *
+ * Plus ONE non-minting reader — `resolveExistingByName` — for DERIVED
+ * surfaces that must point at entities the graph already knows without
+ * ever creating one (the scene plane's 0106 `entityIds` backlinks). It
+ * shares this service precisely so there is one place where the corpus's
+ * naming conventions (exact canonical/alias, leading articles, code
+ * path↔symbol) are interpreted, instead of a second, drifting copy.
  */
 @Injectable()
 export class EntityUpsertService {
@@ -273,6 +281,177 @@ export class EntityUpsertService {
       externalRefs: {},
     });
     return String(created?.id);
+  }
+
+  /**
+   * RESOLVE-ONLY name lookup: the deterministic half of
+   * `resolveOrCreateNamedEntity` with the minting, the alias stamping, the
+   * merge-log audit and the probabilistic LLM judge all removed. Returns
+   * an existing knowledge_entity id or null — it NEVER creates a row and
+   * NEVER writes anything at all.
+   *
+   * WHO NEEDS THIS. A RECONSTRUCTION surface — the scene plane's
+   * `entityIds` backlinks (0106, SCENES_ENTITY_LINKS) is the first — wants
+   * to point at entities the graph already knows, and must not be able to
+   * mint them: a scene is derived from turns that were already ingested,
+   * so any entity it legitimately names was already created by the ingest
+   * path. Letting a derived pass mint would make a summary a source of
+   * truth and would let an LLM's paraphrase of a name ("the Lisbon trip")
+   * become a permanent node nothing else references.
+   *
+   * MATCH LADDER — the same three deterministic steps the naming path
+   * uses, in the same order, riding the SAME env flags so the corpus's
+   * naming conventions are read identically wherever they are read:
+   *   1. exact `canonicalNameLc` / `aliases` match;
+   *   2. leading-article variants (INGEST_ARTICLE_NORMALIZATION);
+   *   3. code path↔symbol convention (INGEST_CODE_ALIAS_RESOLUTION).
+   * The probabilistic step 3 of the naming path (the embedding + LLM judge
+   * resolver) is deliberately EXCLUDED: it exists to avoid minting a
+   * duplicate at ingest time, and a low-confidence fuse is the wrong
+   * trade-off for a backlink nobody asked for.
+   *
+   * UNIQUE MATCHES ONLY, at every step — including step 1, where the
+   * minting path takes `LIMIT 1` because it must produce SOME id. Here two
+   * same-named candidates mean the identity is ambiguous, and the honest
+   * answer for a backlink is no link at all. `mergedInto IS NONE` excludes
+   * entities already folded into another identity.
+   *
+   * SCOPE (0055 + 0093). `userId` is the scope key of the asking surface
+   * when it has exactly ONE; undefined means it has none (or more than
+   * one), and then ONLY tenant-global entities are visible — mirroring the
+   * `userId IS NONE` pin the naming path uses, so a personal entity can
+   * never be linked from a shared row. A scoped caller additionally sees
+   * its OWN entities and nobody else's; the 0093 scope-tag fence ANDs
+   * alongside (inert while SCOPE_TAGS_ENABLED is off, and it can only ever
+   * narrow).
+   *
+   * NEVER THROWS: any failure returns null. A backlink is an enrichment,
+   * never a reason to fail the pass that asked for it.
+   */
+  async resolveExistingByName(
+    db: Surreal,
+    e: { name: string },
+    opts: { userId?: string | undefined } = {},
+  ): Promise<string | null> {
+    const raw = e.name.trim();
+    if (raw === '') return null;
+    const target = raw.toLowerCase();
+    const fence = this.readFence(opts.userId);
+    try {
+      // 1. Exact canonical-name / alias match.
+      const exact = await this.uniqueEntity(
+        db,
+        `SELECT id FROM knowledge_entity
+          WHERE (canonicalNameLc = $name OR aliases CONTAINS $rawName)
+            AND mergedInto IS NONE
+            ${fence.clause}
+          LIMIT 2`,
+        { name: target, rawName: raw, ...fence.params },
+      );
+      if (exact) return exact;
+
+      // 2. Leading-article variants (INGEST_ARTICLE_NORMALIZATION).
+      if (envFlagEnabled(process.env.INGEST_ARTICLE_NORMALIZATION)) {
+        const variants = articleNameVariants(target);
+        if (variants.length > 0) {
+          const viaArticle = await this.uniqueEntity(
+            db,
+            `SELECT id FROM knowledge_entity
+              WHERE canonicalNameLc IN $variants
+                AND mergedInto IS NONE
+                ${fence.clause}
+              LIMIT 2`,
+            { variants, ...fence.params },
+          );
+          if (viaArticle) return viaArticle;
+        }
+      }
+
+      // 3. Code path↔symbol convention (INGEST_CODE_ALIAS_RESOLUTION).
+      return await this.resolveExistingByCodeAlias(db, raw, fence);
+    } catch (err) {
+      this.logger.warn(
+        `[entity.resolve_only] lookup failed for "${raw}": ${(err as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * The read fence for a resolve-only lookup: the 0055 userId rule plus
+   * the 0093 scope-tag fence. No scope key ⇒ tenant-global rows only (the
+   * naming path's `userId IS NONE` pin, verbatim); a scope key ⇒ its own
+   * rows too, and never a third party's.
+   */
+  private readFence(userId: string | undefined): {
+    clause: string;
+    params: Record<string, unknown>;
+  } {
+    const scope = scopeFenceSql(userId, 'entityScopeTag');
+    if (userId === undefined) {
+      return { clause: `AND userId IS NONE ${scope.clause}`, params: { ...scope.params } };
+    }
+    return {
+      clause: `AND (userId IS NONE OR userId = $scopeUserId) ${scope.clause}`,
+      params: { scopeUserId: userId, ...scope.params },
+    };
+  }
+
+  /** Run a 2-row probe and return the id only when it is UNAMBIGUOUS. */
+  private async uniqueEntity(
+    db: Surreal,
+    sql: string,
+    params: Record<string, unknown>,
+  ): Promise<string | null> {
+    const rows = await queryRows<{ id: unknown }>(db, sql, params);
+    const ids = [...new Set(rows.map((r) => String(r.id)))];
+    return ids.length === 1 ? ids[0]! : null;
+  }
+
+  /**
+   * Read-only twin of `resolveByCodeAlias`: the same deterministic
+   * path↔symbol convention, both directions, unique matches only — but it
+   * never stamps the new surface into the reused entity's aliases. A
+   * derived backlink must not mutate the entity it points at; the alias
+   * seeding is the ingest path's job, where the surface was actually
+   * observed as a name.
+   */
+  private async resolveExistingByCodeAlias(
+    db: Surreal,
+    name: string,
+    fence: { clause: string; params: Record<string, unknown> },
+  ): Promise<string | null> {
+    if (!envFlagEnabled(process.env.INGEST_CODE_ALIAS_RESOLUTION)) return null;
+    const symbol = symbolAliasForPath(name);
+    if (symbol !== null) {
+      return this.uniqueEntity(
+        db,
+        `SELECT id FROM knowledge_entity
+          WHERE (canonicalNameLc = $sym OR aliases CONTAINS $symRaw)
+            AND mergedInto IS NONE
+            ${fence.clause}
+          LIMIT 2`,
+        { sym: symbol.toLowerCase(), symRaw: symbol, ...fence.params },
+      );
+    }
+    if (!isCodeSymbolShaped(name)) return null;
+    const matched = new Set<string>();
+    for (const needle of pathNeedlesForSymbol(name)) {
+      const rows = await queryRows<{ id: unknown; canonicalName: string }>(
+        db,
+        `SELECT id, canonicalName FROM knowledge_entity
+          WHERE string::contains(canonicalNameLc, $needle)
+            AND mergedInto IS NONE
+            ${fence.clause}
+          LIMIT $k`,
+        { needle, k: 16, ...fence.params },
+      );
+      for (const r of rows) {
+        if (symbolAliasForPath(String(r.canonicalName)) === name) matched.add(String(r.id));
+      }
+      if (matched.size > 1) break; // already ambiguous — stop scanning
+    }
+    return matched.size === 1 ? [...matched][0]! : null;
   }
 
   async resolveOrCreateBareRef(db: Surreal, ref: EntityRef): Promise<string> {

--- a/src/synthesize/scene-lane.service.ts
+++ b/src/synthesize/scene-lane.service.ts
@@ -1,8 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { SurrealService } from '../db/surreal.service';
+import { EmbedderService } from '../ai/embedder.service';
 import { sceneUserGate, sceneVisibleToUser } from '../auth/segment-scope';
 import { scopeFenceSql } from '../auth/scope-visibility';
 import { buildLexMatchLeg } from './lex-leg';
+import { rrfFuse } from './segment-lane.service';
 import type { CitableScene } from './scene-citations';
 
 /**
@@ -81,18 +83,34 @@ const EMPTY_RESULT: SceneLaneResult = { lines: [], byId: new Map() };
  * writing it (scene-enricher.service.ts:362); this lane is its first
  * consumer, rendered as the line's "notable details" clause.
  *
- * RETRIEVAL. BM25 only, over the 0106 `scene_gist_search` FULLTEXT
- * index on `gist` — no dense leg. Two reasons, both deliberate:
- * `gistEmbedding` is populated ONLY when SCENES_TOPIC_BOUNDARY is on
- * (the composer's single paid step), so a dense leg would be write-dead
- * for the default world and silently useless; and a lane that needs no
- * embedder cannot fail on one. The leg is the V11 A2 `or_terms`
- * disjunction (buildLexMatchLeg), NOT a phrase-shaped `@1@ $query`: the
- * matches operator is AND-semantics over analyzed tokens, so a phrase
- * leg would require the WHOLE question to appear in the gist and leave
- * the lane empty for every natural question. Summed BM25 over the
- * bounded per-term disjunction ranks a gist covering more query words
- * higher.
+ * RETRIEVAL — dense + BM25, fused by reciprocal rank (the segment /
+ * fragment lane shape).
+ *
+ * The LEXICAL leg is the V11 A2 `or_terms` disjunction (buildLexMatchLeg)
+ * over the 0106 `scene_gist_search` FULLTEXT index, NOT a phrase-shaped
+ * `@1@ $query`: the matches operator is AND-semantics over analyzed
+ * tokens, so a phrase leg would require the WHOLE question to appear in
+ * the gist and leave the lane empty for every natural question. Summed
+ * BM25 over the bounded per-term disjunction ranks a gist covering more
+ * query words higher.
+ *
+ * The DENSE leg is a brute cosine over `gistEmbedding`. It did not exist
+ * when this lane shipped, for a good reason that has since been fixed:
+ * the column had NO producer at all (0106 defined it; the composer's
+ * header deferred it to "the PR2 encoder pass" which never landed), so a
+ * dense leg would have been write-dead. SceneGistEmbeddingService
+ * (SCENES_GIST_EMBEDDING) is that producer, and this is the read side.
+ *
+ * DEGRADATION IS THE DEFAULT, not a fallback. The dense query filters
+ * `gistEmbedding != NONE`, so a world whose scenes were composed before
+ * that flag was on returns an EMPTY dense list, and RRF over
+ * [[], bm25] reproduces the BM25 ordering exactly — byte-identical lines
+ * to the pre-dense lane. The same holds when no embedder is wired
+ * (@Optional) or when embedding the query fails: the dense leg is
+ * skipped, never the lane. That is why the dense leg needs no switch of
+ * its own — it is strictly an internal recall improvement inside a lane
+ * that is ALREADY gated by profile.sceneLane (RETRIEVAL_SCENE_LANE), and
+ * a world with no vectors cannot tell the difference.
  *
  * WORLD SELECTION — the registry IS the activation record. Scenes are
  * VERSIONED (segmenterVersion; competing segmenters coexist by design,
@@ -144,7 +162,13 @@ const EMPTY_RESULT: SceneLaneResult = { lines: [], byId: new Map() };
 export class SceneLaneService {
   private readonly logger = new Logger(SceneLaneService.name);
 
-  constructor(private readonly surreal: SurrealService) {}
+  /** @Optional embedder (the fragment-lane / evidence-store idiom):
+   *  positionally-constructed unit fixtures stay valid and the lane
+   *  degrades to its pre-dense, BM25-only behavior when none is wired. */
+  constructor(
+    private readonly surreal: SurrealService,
+    @Optional() private readonly embedder?: EmbedderService,
+  ) {}
 
   async sceneLines(opts: {
     companyId: string;
@@ -176,6 +200,38 @@ export class SceneLaneService {
         );
         const world = (worlds ?? [])[0];
         if (typeof world !== 'string' || world === '') return [];
+        // Fences 2/3/4/5, identical for BOTH legs — the dense leg must
+        // never be a way around a gate the lexical leg applies.
+        const fences = `AND segmenterVersion = $world
+                ${piiGate} ${gate.clause} ${scope.clause}`;
+        const select = `id, userId, userIds, sceneLabel, gist, unexpectedDetails,
+                    occurredFrom, occurredTo`;
+        // The dense leg's query vector — resolved AFTER the world check so
+        // a fail-closed read still issues nothing at all, and with its own
+        // degrade: an embedder failure must not kill the lexical leg.
+        let queryVector: number[] | null = null;
+        if (this.embedder) {
+          try {
+            queryVector = await this.embedder.embed(opts.query);
+          } catch (e) {
+            this.logger.warn(`scene lane dense leg unavailable: ${(e as Error).message}`);
+          }
+        }
+        // Dense leg over the 0106 gist vectors. `gistEmbedding != NONE`
+        // makes a vector-less world return [] — the degrade path, not an
+        // error path.
+        const [dense] = queryVector
+          ? await db.query<[SceneLaneRow[]]>(
+              `SELECT ${select},
+                      vector::similarity::cosine(gistEmbedding, $q) AS score
+                 FROM memory_episode
+                WHERE gistEmbedding != NONE
+                  ${fences}
+                ORDER BY score DESC
+                LIMIT $k`,
+              { ...gate.params, ...scope.params, q: queryVector, world, k: fetchK },
+            )
+          : [[] as SceneLaneRow[]];
         // The or_terms disjunctive BM25 leg (see the class doc) —
         // composed per request over the caller's query text.
         const lex = buildLexMatchLeg({
@@ -184,17 +240,17 @@ export class SceneLaneService {
           mode: 'or_terms',
         });
         const [hits] = await db.query<[SceneLaneRow[]]>(
-          `SELECT id, userId, userIds, sceneLabel, gist, unexpectedDetails,
-                    occurredFrom, occurredTo, ${lex.score} AS score
+          `SELECT ${select}, ${lex.score} AS score
                FROM memory_episode
               WHERE ${lex.where}
-                AND segmenterVersion = $world
-                ${piiGate} ${gate.clause} ${scope.clause}
+                ${fences}
               ORDER BY score DESC
               LIMIT $k`,
           { ...lex.params, ...gate.params, ...scope.params, world, k: fetchK },
         );
-        return hits ?? [];
+        // RRF (the house fusion): with an empty dense list this is the
+        // BM25 ordering, unchanged.
+        return rrfFuse([dense ?? [], hits ?? []]);
       });
       if (rows.length === 0) return EMPTY_RESULT;
       return this.render(rows, userId);

--- a/test/scene-enrichment.e2e-spec.ts
+++ b/test/scene-enrichment.e2e-spec.ts
@@ -21,6 +21,10 @@ const USER = 'scene2_user';
 interface SceneRow {
   id: unknown;
   gist: string;
+  gistEmbedding?: number[];
+  embeddingSpaceId?: string;
+  entityIds?: unknown[];
+  relationIds?: unknown[];
   gistPromptVersion?: string;
   memoryValue?: Record<string, unknown>;
   stateDeltas?: Array<Record<string, unknown>>;
@@ -62,7 +66,14 @@ describe('scene enrichment + fact backlink + version purge (e2e)', () => {
     // proves its own 404 gate before flipping its flag on.
     saved.SCENES_SEGMENTATION_ENABLED = process.env.SCENES_SEGMENTATION_ENABLED;
     process.env.SCENES_SEGMENTATION_ENABLED = '1';
-    for (const k of ['SCENES_LLM_ENRICHMENT', 'SCENES_FACT_BACKLINK']) {
+    for (const k of [
+      'SCENES_LLM_ENRICHMENT',
+      'SCENES_FACT_BACKLINK',
+      // PR3 legs, both start OFF so each `it` proves its own gate first.
+      'SCENES_GIST_EMBEDDING',
+      'SCENES_ENTITY_LINKS',
+      'EMBEDDING_SPACE_TRACKING',
+    ]) {
       saved[k] = process.env[k];
       delete process.env[k];
     }
@@ -267,6 +278,112 @@ describe('scene enrichment + fact backlink + version purge (e2e)', () => {
         'Mika planned the Lisbon trip: compared flights and booked the morning one.',
       );
     }
+  });
+
+  /**
+   * PR3 leg 1 — the producer the 0106 `gistEmbedding` column never had.
+   * The stub embedder is deterministic (test-doubles.StubEmbedder), so no
+   * paid call is made anywhere in this suite.
+   */
+  it('embeds the CANONICAL gist of every vector-less scene, idempotently', async () => {
+    const gated = await f.http
+      .post('/v1/admin/maintenance/scenes/embed-gists')
+      .set(auth())
+      .send({});
+    expect(gated.status).toBe(404);
+
+    const before = await scenesInDb();
+    expect(before).toHaveLength(2);
+    for (const scene of before) expect(scene.gistEmbedding).toBeUndefined();
+
+    process.env.SCENES_GIST_EMBEDDING = '1';
+    const res = await f.http.post('/v1/admin/maintenance/scenes/embed-gists').set(auth()).send({});
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ scenes: 2, embedded: 2, skipped: 0, failed: 0 });
+
+    const after = await scenesInDb();
+    for (const scene of after) {
+      expect(Array.isArray(scene.gistEmbedding)).toBe(true);
+      expect(scene.gistEmbedding!.length).toBeGreaterThan(0);
+      // The vector is of the CANONICAL, post-compose-immutable gist —
+      // the same text the 0106 BM25 index covers and the reindex sweep
+      // re-embeds — not the enricher's `enrichedGist` revision sibling,
+      // which these rows also carry from the earlier `it`s.
+      expect(scene.enrichedGist).toBeDefined();
+      expect(scene.gist).toContain('opens:');
+      // EMBEDDING_SPACE_TRACKING is off: no stamp, exactly like a
+      // knowledge_fact row on the fact-side write path.
+      expect(scene.embeddingSpaceId).toBeUndefined();
+    }
+
+    // Idempotent: every scene now carries a vector, so the second run
+    // selects nothing and spends nothing.
+    const rerun = await f.http
+      .post('/v1/admin/maintenance/scenes/embed-gists')
+      .set(auth())
+      .send({});
+    expect(rerun.status).toBe(201);
+    expect(rerun.body).toMatchObject({ scenes: 0, embedded: 0 });
+  });
+
+  /**
+   * PR3 leg 2 — free-text `entityMentions` (parsed since PR2 and thrown
+   * away) become real knowledge_entity RECORD refs. RESOLVE-ONLY: the
+   * unresolvable mention is dropped and nothing is ever minted.
+   */
+  it('resolves entity mentions into record refs — never minting, never crossing users', async () => {
+    // A same-named entity owned by ANOTHER user: the #387 fence must keep
+    // it out of this (single-user) scene's links.
+    const surreal = f.app.get(SurrealService);
+    const entityCountBefore = await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `CREATE knowledge_entity:se_foreign CONTENT {
+           type: 'other', canonicalName: 'Lisbon', userId: 'some_other_user', externalRefs: {}
+         }`,
+      );
+      const [rows] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM knowledge_entity GROUP ALL`,
+      );
+      return (rows ?? [])[0]?.n ?? 0;
+    });
+
+    // Re-enrich with the links flag on: a changed flag does NOT change the
+    // enrichmentVersion composite, so force a fresh world first.
+    process.env.SCENES_ENTITY_LINKS = '1';
+    delete process.env.SCENES_LLM_ENRICHMENT;
+    const recompose = await f.http.post('/v1/admin/maintenance/scenes').set(auth()).send({});
+    expect(recompose.status).toBe(201);
+
+    process.env.SCENES_LLM_ENRICHMENT = '1';
+    const mock = mockSceneEnricherOpenAi(f.app, [ENRICHMENT_REPLY]);
+    const res = await f.http.post('/v1/admin/maintenance/scenes/enrich').set(auth()).send({});
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ scenes: 2, enriched: 2 });
+    expect(mock.calls).toHaveLength(2);
+
+    for (const scene of await scenesInDb()) {
+      // 'Mika' resolves to the tenant-global seeded entity; 'Lisbon'
+      // resolves to NOTHING for this user — the foreign-owned row is
+      // invisible behind the fence — and is therefore dropped.
+      expect((scene.entityIds ?? []).map(String)).toEqual(['knowledge_entity:se_subj']);
+      // relationIds has no producer and must stay unwritten.
+      expect(scene.relationIds).toBeUndefined();
+    }
+
+    // NEVER MINT: not one knowledge_entity row was created by the scene.
+    const entityCountAfter = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM knowledge_entity GROUP ALL`,
+      );
+      return (rows ?? [])[0]?.n ?? 0;
+    });
+    expect(entityCountAfter).toBe(entityCountBefore);
+
+    // Restore the world the later `it`s expect (vector-less fresh rows
+    // were swapped in above; re-embed so the purge count stays honest).
+    process.env.SCENES_GIST_EMBEDDING = '1';
+    await f.http.post('/v1/admin/maintenance/scenes/embed-gists').set(auth()).send({});
+    delete process.env.SCENES_ENTITY_LINKS;
   });
 
   it('backlinks facts idempotently: pointer stamped once, control fact untouched', async () => {

--- a/test/scene-entity-links.unit-spec.ts
+++ b/test/scene-entity-links.unit-spec.ts
@@ -1,0 +1,482 @@
+/**
+ * Scene entity links (Brain v2 PR3, SCENES_ENTITY_LINKS) — the resolution
+ * matrix, over scripted doubles. No network, no Nest, no paid calls.
+ *
+ * Three layers, each pinned where it lives:
+ *
+ *  1. PURE selection (scene-entity-links.ts): which mentions are attempted
+ *     (dedupe, cap, model order) and how resolved ids become a stable
+ *     column value (dedupe + sort ⇒ idempotent re-runs).
+ *
+ *  2. THE RESOLVER (EntityUpsertService.resolveExistingByName): the
+ *     resolve-only ladder — exact hit links, no hit drops, an AMBIGUOUS
+ *     name links nothing, a merged-away entity is excluded, and the scope
+ *     fence means a CROSS-USER candidate is never even a candidate. The
+ *     load-bearing negative: the lookup issues no CREATE/UPDATE at all —
+ *     a scene must never mint or mutate an entity.
+ *
+ *  3. THE ENRICHER LEG: flag off is byte-identical (the resolver is a
+ *     THROWING stub and the SELECT / UPDATE are unchanged); flag on writes
+ *     `entityIds` as record refs, drops what does not resolve, honours the
+ *     cap, passes the #387 single-user scope through, and is idempotent
+ *     across a re-run.
+ */
+import type { ConfigService } from '@nestjs/config';
+import type { Surreal } from 'surrealdb';
+import { StringRecordId } from 'surrealdb';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { EpisodeReadStoreService } from '../src/episodes/episode-read-store.service';
+import type { SceneVersionService } from '../src/admin/scene-version';
+import { EntityUpsertService } from '../src/ingest/entity-upsert.service';
+import { SceneEnricherService } from '../src/admin/scene-enricher.service';
+import {
+  SCENE_ENTITY_LINKS_MAX,
+  selectSceneMentions,
+  stableEntityIds,
+} from '../src/admin/scene-entity-links';
+import { SEGMENTER_VERSION } from '../src/admin/scene-segmentation';
+
+// ── 1. the pure half ────────────────────────────────────────────────────
+
+describe('selectSceneMentions', () => {
+  it('trims, drops blanks and de-duplicates case-insensitively, first spelling wins', () => {
+    expect(selectSceneMentions(['  Lisbon ', 'lisbon', '', '   ', 'Mika', 'LISBON'])).toEqual([
+      'Lisbon',
+      'Mika',
+    ]);
+  });
+
+  it('keeps the model’s own order and truncates at the cap', () => {
+    const many = Array.from({ length: SCENE_ENTITY_LINKS_MAX + 5 }, (_v, i) => `e${i}`);
+    const picked = selectSceneMentions(many);
+    expect(picked).toHaveLength(SCENE_ENTITY_LINKS_MAX);
+    expect(picked[0]).toBe('e0');
+    expect(picked).not.toContain(`e${SCENE_ENTITY_LINKS_MAX}`);
+  });
+});
+
+describe('stableEntityIds', () => {
+  it('is a function of the resolved SET, not of mention order', () => {
+    const a = stableEntityIds(['knowledge_entity:z', 'knowledge_entity:a', 'knowledge_entity:z']);
+    const b = stableEntityIds(['knowledge_entity:a', 'knowledge_entity:z']);
+    expect(a).toEqual(['knowledge_entity:a', 'knowledge_entity:z']);
+    expect(a).toEqual(b);
+  });
+});
+
+// ── 2. the resolve-only ladder ──────────────────────────────────────────
+
+interface ResolverCapture {
+  queries: Array<{ sql: string; params: Record<string, unknown> | undefined }>;
+}
+
+/** Scripted Surreal double: `rows` answers every knowledge_entity probe. */
+function resolverDb(rows: Array<{ id: string; canonicalName?: string }>): {
+  db: Surreal;
+  captured: ResolverCapture;
+} {
+  const captured: ResolverCapture = { queries: [] };
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      captured.queries.push({ sql, params });
+      if (/^\s*(CREATE|UPDATE|INSERT|DELETE|RELATE)/i.test(sql.trim())) {
+        throw new Error(`a resolve-only lookup must never write: ${sql}`);
+      }
+      return [rows];
+    },
+  } as unknown as Surreal;
+  return { db, captured };
+}
+
+describe('EntityUpsertService.resolveExistingByName — resolve-only, never mint', () => {
+  const svc = () => new EntityUpsertService();
+  const SAVED = {
+    article: process.env.INGEST_ARTICLE_NORMALIZATION,
+    codeAlias: process.env.INGEST_CODE_ALIAS_RESOLUTION,
+    scopeTags: process.env.SCOPE_TAGS_ENABLED,
+  };
+  afterEach(() => {
+    for (const [k, v] of [
+      ['INGEST_ARTICLE_NORMALIZATION', SAVED.article],
+      ['INGEST_CODE_ALIAS_RESOLUTION', SAVED.codeAlias],
+      ['SCOPE_TAGS_ENABLED', SAVED.scopeTags],
+    ] as const) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('an EXACT canonical/alias hit resolves, and the probe writes nothing', async () => {
+    const { db, captured } = resolverDb([{ id: 'knowledge_entity:lisbon' }]);
+    await expect(svc().resolveExistingByName(db, { name: 'Lisbon' })).resolves.toBe(
+      'knowledge_entity:lisbon',
+    );
+    const probe = captured.queries[0]!;
+    expect(probe.sql).toContain('canonicalNameLc = $name OR aliases CONTAINS $rawName');
+    expect(probe.sql).toContain('mergedInto IS NONE');
+    expect(probe.params).toMatchObject({ name: 'lisbon', rawName: 'Lisbon' });
+    // Exactly one probe: the ladder stops at the first hit.
+    expect(captured.queries).toHaveLength(1);
+  });
+
+  it('NO hit ⇒ null (the mention is dropped, never minted)', async () => {
+    const { db } = resolverDb([]);
+    await expect(svc().resolveExistingByName(db, { name: 'Nobody' })).resolves.toBeNull();
+  });
+
+  it('an AMBIGUOUS name links NOTHING (two candidates = no answer)', async () => {
+    const { db } = resolverDb([{ id: 'knowledge_entity:a' }, { id: 'knowledge_entity:b' }]);
+    await expect(svc().resolveExistingByName(db, { name: 'John Smith' })).resolves.toBeNull();
+  });
+
+  it('a blank mention never reaches the database', async () => {
+    const { db, captured } = resolverDb([{ id: 'knowledge_entity:x' }]);
+    await expect(svc().resolveExistingByName(db, { name: '   ' })).resolves.toBeNull();
+    expect(captured.queries).toEqual([]);
+  });
+
+  it('UNSCOPED lookups see tenant-global entities ONLY (a personal one can never link)', async () => {
+    const { db, captured } = resolverDb([]);
+    await svc().resolveExistingByName(db, { name: 'Lisbon' });
+    expect(captured.queries[0]!.sql).toContain('AND userId IS NONE');
+    expect(captured.queries[0]!.params).not.toHaveProperty('scopeUserId');
+  });
+
+  it('a SCOPED lookup adds its OWN user and nobody else’s', async () => {
+    const { db, captured } = resolverDb([]);
+    await svc().resolveExistingByName(db, { name: 'Lisbon' }, { userId: 'u1' });
+    const sql = captured.queries[0]!.sql;
+    expect(sql).toContain('AND (userId IS NONE OR userId = $scopeUserId)');
+    // A third user's rows are excluded by the SAME clause — the fence is
+    // an equality on the caller's key, never an "any user" opening.
+    expect(sql).not.toContain('userId != NONE');
+    expect(captured.queries[0]!.params).toMatchObject({ scopeUserId: 'u1' });
+  });
+
+  it('the 0093 scope-tag fence ANDs alongside when SCOPE_TAGS_ENABLED is on', async () => {
+    process.env.SCOPE_TAGS_ENABLED = '1';
+    const { db, captured } = resolverDb([]);
+    await svc().resolveExistingByName(db, { name: 'Lisbon' }, { userId: 'u1' });
+    expect(captured.queries[0]!.sql).toContain('$entityScopeTag');
+    expect(captured.queries[0]!.params).toHaveProperty('entityScopeTag');
+  });
+
+  it('falls through to the article variants only under INGEST_ARTICLE_NORMALIZATION', async () => {
+    const { db, captured } = resolverDb([]);
+    await svc().resolveExistingByName(db, { name: 'the office lease' });
+    expect(captured.queries).toHaveLength(1); // flag off ⇒ no second probe
+
+    process.env.INGEST_ARTICLE_NORMALIZATION = '1';
+    const withFlag = resolverDb([]);
+    await svc().resolveExistingByName(withFlag.db, { name: 'the office lease' });
+    expect(withFlag.captured.queries).toHaveLength(2);
+    expect(withFlag.captured.queries[1]!.sql).toContain('canonicalNameLc IN $variants');
+    expect(withFlag.captured.queries[1]!.params!.variants).toContain('office lease');
+  });
+
+  it('falls through to the code path↔symbol convention only under its own flag', async () => {
+    // The exact probe must MISS for the ladder to reach step 3, so the
+    // double answers miss-then-hit.
+    const pages: Array<Array<{ id: string }>> = [[], [{ id: 'knowledge_entity:dispatcher' }]];
+    const captured: ResolverCapture = { queries: [] };
+    let call = 0;
+    const scripted = {
+      query: async (sql: string, params?: Record<string, unknown>) => {
+        captured.queries.push({ sql, params });
+        return [pages[call++] ?? []];
+      },
+    } as unknown as Surreal;
+
+    // Flag off: the ladder stops after the exact miss.
+    delete process.env.INGEST_CODE_ALIAS_RESOLUTION;
+    await expect(
+      svc().resolveExistingByName(scripted, { name: 'src/gateway/webhook-dispatcher.ts' }),
+    ).resolves.toBeNull();
+    expect(captured.queries).toHaveLength(1);
+
+    process.env.INGEST_CODE_ALIAS_RESOLUTION = '1';
+    call = 0;
+    captured.queries.length = 0;
+    await expect(
+      svc().resolveExistingByName(scripted, { name: 'src/gateway/webhook-dispatcher.ts' }),
+    ).resolves.toBe('knowledge_entity:dispatcher');
+    const last = captured.queries[captured.queries.length - 1]!;
+    expect(last.params).toMatchObject({ sym: 'webhookdispatcher' });
+    // Still read-only: the ingest path stamps the new surface into the
+    // reused entity's aliases; a derived backlink must not mutate it.
+    expect(captured.queries.every((q) => /^\s*SELECT/i.test(q.sql))).toBe(true);
+  });
+
+  it('never throws — a lookup failure degrades to null', async () => {
+    const db = {
+      query: async () => {
+        throw new Error('db down');
+      },
+    } as unknown as Surreal;
+    const service = svc();
+    jest
+      .spyOn((service as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn')
+      .mockImplementation(() => undefined);
+    await expect(service.resolveExistingByName(db, { name: 'Lisbon' })).resolves.toBeNull();
+  });
+});
+
+// ── 3. the enricher leg ─────────────────────────────────────────────────
+
+const WELL_FORMED = {
+  gist: 'Mika planned the Lisbon trip and booked the morning flight.',
+  memoryValue: {
+    novelty: 0.8,
+    contradiction: 0,
+    stateChange: 0.6,
+    identity: 0.2,
+    explicitness: 0.9,
+    estimatedUtility: 0.7,
+  },
+  stateDeltas: [{ subject: 'mika', field: 'trip.flight', from: '', to: 'booked' }],
+  unexpectedDetails: [],
+  entityMentions: ['Mika', 'Lisbon', 'Unknown Place'],
+};
+
+interface EnricherCapture {
+  updates: Array<{ sql: string; params: Record<string, unknown> }>;
+  queries: string[];
+  resolved: Array<{ name: string; userId: string | undefined }>;
+}
+
+function buildEnricher(opts: {
+  /** mention (lowercased) → entity id, or absent for "no hit". */
+  hits?: Record<string, string>;
+  /** Scope stamps on the single fake scene (default: single-user u1). */
+  scope?: Record<string, unknown>;
+  /** Reply override (defaults to WELL_FORMED). */
+  mentions?: string[];
+  /** Wire NO resolver at all (the partial-wiring degrade). */
+  unwired?: boolean;
+  /** The resolver must never be touched (the flag-off pin). */
+  throwing?: boolean;
+}): { svc: SceneEnricherService; captured: EnricherCapture } {
+  const captured: EnricherCapture = { updates: [], queries: [], resolved: [] };
+  const fakeDb = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      captured.queries.push(sql);
+      if (sql.includes('UPDATE $scene')) {
+        captured.updates.push({ sql, params: params ?? {} });
+        return [[]];
+      }
+      if (sql.includes('FROM memory_episode_member')) return [[{ out: 'episode:e1', ord: 0 }]];
+      if (sql.includes('FROM memory_episode')) {
+        return [
+          [
+            {
+              id: 'memory_episode:s1',
+              conversationIds: ['conv'],
+              ...(opts.scope ?? { userId: 'u1', userIds: ['u1'] }),
+            },
+          ],
+        ];
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    },
+  };
+  const entities = opts.throwing
+    ? ({
+        resolveExistingByName: async () => {
+          throw new Error('entity resolution must not run with SCENES_ENTITY_LINKS off');
+        },
+      } as unknown as EntityUpsertService)
+    : ({
+        resolveExistingByName: async (
+          _db: Surreal,
+          e: { name: string },
+          o: { userId?: string | undefined } = {},
+        ) => {
+          captured.resolved.push({ name: e.name, userId: o.userId });
+          return opts.hits?.[e.name.toLowerCase()] ?? null;
+        },
+      } as unknown as EntityUpsertService);
+  const svc = new SceneEnricherService(
+    {
+      withCompany: (_c: string, fn: (db: unknown) => Promise<unknown>) => fn(fakeDb),
+    } as unknown as SurrealService,
+    { get: (_k: string, d?: unknown) => d } as unknown as ConfigService,
+    {
+      conversationTurnsRaw: async () => [
+        {
+          id: 'episode:e1',
+          speaker: 'mika',
+          text: 'I booked the morning flight to Lisbon.',
+          occurredAt: '2026-02-01T10:00:00.000Z',
+        },
+      ],
+    } as unknown as EpisodeReadStoreService,
+    {
+      resolve: () => ({
+        version: SEGMENTER_VERSION,
+        cfg: { topicBoundary: false, minCosine: 0.55, maxTurns: 40, embeddingSpaceId: null },
+      }),
+    } as unknown as SceneVersionService,
+    ...(opts.unwired ? [] : [entities]),
+  );
+  (svc as unknown as { openai: unknown }).openai = {
+    chat: {
+      completions: {
+        create: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  ...WELL_FORMED,
+                  ...(opts.mentions ? { entityMentions: opts.mentions } : {}),
+                }),
+              },
+            },
+          ],
+        }),
+      },
+    },
+  };
+  return { svc, captured };
+}
+
+const linkIds = (c: EnricherCapture): string[] =>
+  ((c.updates[0]!.params.entityIds as StringRecordId[] | undefined) ?? []).map((r) => String(r));
+
+describe('SceneEnricherService — entity links OFF (the byte-identical pin)', () => {
+  const saved = {
+    enrich: process.env.SCENES_LLM_ENRICHMENT,
+    links: process.env.SCENES_ENTITY_LINKS,
+  };
+  beforeAll(() => {
+    process.env.SCENES_LLM_ENRICHMENT = '1';
+    delete process.env.SCENES_ENTITY_LINKS;
+  });
+  afterAll(() => {
+    for (const [k, v] of [
+      ['SCENES_LLM_ENRICHMENT', saved.enrich],
+      ['SCENES_ENTITY_LINKS', saved.links],
+    ] as const) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('the resolver is NEVER called and no entityIds clause is emitted', async () => {
+    const { svc, captured } = buildEnricher({ throwing: true });
+    const result = await svc.enrich('co_test');
+    expect(result).toEqual({ scenes: 1, enriched: 1, failed: 0, skipped: 0 });
+    const { sql, params } = captured.updates[0]!;
+    expect(sql).not.toContain('entityIds');
+    expect(params.entityIds).toBeUndefined();
+    // The scene SELECT projection is byte-identical too (no scope columns
+    // are needed when neither the baseline nor the links leg is on).
+    const select = captured.queries.find((q) => q.includes('FROM memory_episode\n'))!;
+    expect(select).toBe(
+      `SELECT id, conversationIds, enrichmentVersion FROM memory_episode\n` +
+        `          WHERE segmenterVersion = $v`,
+    );
+  });
+});
+
+describe('SceneEnricherService — entity links ON (the resolution matrix)', () => {
+  const saved = {
+    enrich: process.env.SCENES_LLM_ENRICHMENT,
+    links: process.env.SCENES_ENTITY_LINKS,
+  };
+  beforeAll(() => {
+    process.env.SCENES_LLM_ENRICHMENT = '1';
+    process.env.SCENES_ENTITY_LINKS = '1';
+  });
+  afterAll(() => {
+    for (const [k, v] of [
+      ['SCENES_LLM_ENRICHMENT', saved.enrich],
+      ['SCENES_ENTITY_LINKS', saved.links],
+    ] as const) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  const HITS = { mika: 'knowledge_entity:mika', lisbon: 'knowledge_entity:lisbon' };
+
+  it('resolved mentions become RECORD refs; unresolved ones are dropped', async () => {
+    const { svc, captured } = buildEnricher({ hits: HITS });
+    await svc.enrich('co_test');
+    const { sql, params } = captured.updates[0]!;
+    expect(sql).toContain('entityIds = $entityIds');
+    // Sorted set — never the model's mention order.
+    expect(linkIds(captured)).toEqual(['knowledge_entity:lisbon', 'knowledge_entity:mika']);
+    // Record refs, not strings — the whole point of the 0106 contract.
+    for (const ref of params.entityIds as StringRecordId[]) {
+      expect(ref).toBeInstanceOf(StringRecordId);
+    }
+    // "Unknown Place" was attempted and simply did not resolve.
+    expect(captured.resolved.map((r) => r.name)).toEqual(['Mika', 'Lisbon', 'Unknown Place']);
+  });
+
+  it('nothing resolves ⇒ an explicit empty set, still written (stable across re-runs)', async () => {
+    const { svc, captured } = buildEnricher({ hits: {} });
+    await svc.enrich('co_test');
+    expect(captured.updates[0]!.sql).toContain('entityIds = $entityIds');
+    expect(linkIds(captured)).toEqual([]);
+  });
+
+  it('is IDEMPOTENT: a second run over the same corpus writes the identical value', async () => {
+    const first = buildEnricher({ hits: HITS });
+    await first.svc.enrich('co_test');
+    const second = buildEnricher({ hits: HITS, mentions: ['Lisbon', 'Mika', 'lisbon'] });
+    await second.svc.enrich('co_test');
+    expect(linkIds(second.captured)).toEqual(linkIds(first.captured));
+  });
+
+  it('honours the per-scene cap — at most SCENE_ENTITY_LINKS_MAX lookups', async () => {
+    const mentions = Array.from({ length: SCENE_ENTITY_LINKS_MAX + 8 }, (_v, i) => `Thing ${i}`);
+    const { svc, captured } = buildEnricher({ hits: {}, mentions });
+    await svc.enrich('co_test');
+    expect(captured.resolved).toHaveLength(SCENE_ENTITY_LINKS_MAX);
+  });
+
+  it('a SINGLE-USER scene resolves under its own scope key (#387)', async () => {
+    const { svc, captured } = buildEnricher({ hits: HITS });
+    await svc.enrich('co_test');
+    expect(captured.resolved.every((r) => r.userId === 'u1')).toBe(true);
+  });
+
+  it.each([
+    ['mixed-user', { userId: 'u1', userIds: ['u1', 'u2'] }],
+    ['tenant-global', { userIds: [] }],
+    ['legacy (no userIds)', { userId: 'u1' }],
+  ])(
+    'a %s scene resolves TENANT-GLOBAL only — a foreign user’s entity can never link',
+    async (_label, scope) => {
+      const { svc, captured } = buildEnricher({ hits: HITS, scope });
+      await svc.enrich('co_test');
+      // undefined scope key ⇒ the resolver's `userId IS NONE` branch.
+      expect(captured.resolved.every((r) => r.userId === undefined)).toBe(true);
+    },
+  );
+
+  it('projects the scope columns the fence needs', async () => {
+    const { svc, captured } = buildEnricher({ hits: HITS });
+    await svc.enrich('co_test');
+    const select = captured.queries.find((q) => q.includes('FROM memory_episode\n'))!;
+    expect(select).toContain('userId, userIds');
+  });
+
+  it('no resolver wired ⇒ an empty link set, and the enrichment still lands', async () => {
+    const { svc, captured } = buildEnricher({ unwired: true });
+    const result = await svc.enrich('co_test');
+    expect(result.enriched).toBe(1);
+    expect(linkIds(captured)).toEqual([]);
+  });
+
+  it('a resolver failure drops that mention and the write still lands', async () => {
+    const { svc, captured } = buildEnricher({ throwing: true });
+    jest
+      .spyOn((svc as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn')
+      .mockImplementation(() => undefined);
+    const result = await svc.enrich('co_test');
+    expect(result.enriched).toBe(1);
+    expect(linkIds(captured)).toEqual([]);
+  });
+});

--- a/test/scene-gist-embedding.unit-spec.ts
+++ b/test/scene-gist-embedding.unit-spec.ts
@@ -1,0 +1,379 @@
+/**
+ * Scene gist encoder pass (Brain v2 PR3, SCENES_GIST_EMBEDDING) — the
+ * producer the 0106 `gistEmbedding` column never had, over a scripted
+ * Surreal/embedder double. No network, no Nest, no paid calls.
+ *
+ * Pins:
+ *   - FLAG OFF is byte-identical: zero queries, zero embed calls (both
+ *     doubles THROW if touched) and an all-zero result;
+ *   - selection: only scenes of the CURRENT effective world that carry NO
+ *     vector, bounded by SCENE_EMBED_MAX_PER_RUN, ordered for determinism;
+ *   - BOTH GIST KINDS: the pass embeds the canonical `gist`, never the
+ *     enricher's `enrichedGist` revision sibling — one seam covering the
+ *     deterministic AND the LLM-enriched world, and the same text the
+ *     reindex sweep re-embeds;
+ *   - ONE embedMany batch per run (never one call per scene);
+ *   - the write is a BOUND-ID UPDATE (never a WHERE over an indexed
+ *     field — the 3.2.4 planner bug);
+ *   - space stamp = the fact-side convention: written ONLY under
+ *     EMBEDDING_SPACE_TRACKING, and always together with the vector;
+ *   - a blank gist is never embedded (no zero vector enters the space);
+ *   - an embed failure SOFT-fails the run: warn, count, no write, no throw;
+ *   - the composer's post-swap hook is skipped with the flag off (pinned
+ *     with a throwing encoder stub).
+ */
+import type { SurrealService } from '../src/db/surreal.service';
+import type { FactEmbeddingService } from '../src/ingest/fact-embedding.service';
+import type { SceneVersionService } from '../src/admin/scene-version';
+import type { EpisodeReadStoreService } from '../src/episodes/episode-read-store.service';
+import type { ProjectionRegistryService } from '../src/episodes/projection-registry.service';
+import type { SceneEnricherService } from '../src/admin/scene-enricher.service';
+import type { SceneBacklinkService } from '../src/admin/scene-backlink.service';
+import type { SceneEvidenceLinkerService } from '../src/admin/scene-evidence-linker.service';
+import {
+  SceneGistEmbeddingService,
+  SCENE_EMBED_MAX_PER_RUN,
+} from '../src/admin/scene-gist-embedding.service';
+import { SceneComposerService } from '../src/admin/scene-composer.service';
+import { SEGMENTER_VERSION } from '../src/admin/scene-segmentation';
+
+const SAVED = {
+  gistEmbedding: process.env.SCENES_GIST_EMBEDDING,
+  spaceTracking: process.env.EMBEDDING_SPACE_TRACKING,
+  segmentation: process.env.SCENES_SEGMENTATION_ENABLED,
+};
+const restore = () => {
+  for (const [k, v] of [
+    ['SCENES_GIST_EMBEDDING', SAVED.gistEmbedding],
+    ['EMBEDDING_SPACE_TRACKING', SAVED.spaceTracking],
+    ['SCENES_SEGMENTATION_ENABLED', SAVED.segmentation],
+  ] as const) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+};
+
+const SPACE_ID = 'openai:text-embedding-3-small:1536:l2';
+
+interface Captured {
+  queries: Array<{ sql: string; params: Record<string, unknown> | undefined }>;
+  batches: string[][];
+}
+
+interface BuildOpts {
+  /** Rows the selection SELECT returns. */
+  rows?: Array<Record<string, unknown>>;
+  /** Throw from embedMany (the soft-fail path). */
+  failEmbed?: boolean;
+  /** Throw from the per-row UPDATE (the per-row degrade). */
+  failWrite?: boolean;
+}
+
+function build(opts: BuildOpts = {}): { svc: SceneGistEmbeddingService; captured: Captured } {
+  const captured: Captured = { queries: [], batches: [] };
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      captured.queries.push({ sql, params });
+      if (sql.includes('UPDATE $id')) {
+        if (opts.failWrite) throw new Error('write boom');
+        return [[]];
+      }
+      if (sql.includes('FROM memory_episode')) return [opts.rows ?? []];
+      throw new Error(`unexpected query: ${sql}`);
+    },
+  };
+  const surreal = {
+    withCompany: async (_c: string, fn: (d: typeof db) => Promise<unknown>) => fn(db),
+  } as unknown as SurrealService;
+  const embedding = {
+    embedMany: async (texts: string[]) => {
+      captured.batches.push(texts);
+      if (opts.failEmbed) throw new Error('embedder down');
+      return texts.map((_t, i) => [i + 1, 0, 0]);
+    },
+    activeSpaceId: () => SPACE_ID,
+  } as unknown as FactEmbeddingService;
+  const versions = {
+    resolve: () => ({
+      version: SEGMENTER_VERSION,
+      cfg: { topicBoundary: false, minCosine: 0.55, maxTurns: 40, embeddingSpaceId: null },
+    }),
+  } as unknown as SceneVersionService;
+  return { svc: new SceneGistEmbeddingService(surreal, embedding, versions), captured };
+}
+
+/** The double every OFF-path test uses: any touch at all is a failure. */
+function throwingDoubles(): {
+  surreal: SurrealService;
+  embedding: FactEmbeddingService;
+  versions: SceneVersionService;
+} {
+  return {
+    surreal: {
+      withCompany: async () => {
+        throw new Error('no query may be issued with SCENES_GIST_EMBEDDING off');
+      },
+    } as unknown as SurrealService,
+    embedding: {
+      embedMany: async () => {
+        throw new Error('the embedder must not be called with SCENES_GIST_EMBEDDING off');
+      },
+      activeSpaceId: () => {
+        throw new Error('the space must not be resolved with SCENES_GIST_EMBEDDING off');
+      },
+    } as unknown as FactEmbeddingService,
+    versions: {
+      resolve: () => {
+        throw new Error('no version may be resolved with SCENES_GIST_EMBEDDING off');
+      },
+    } as unknown as SceneVersionService,
+  };
+}
+
+const scene = (id: string, over: Record<string, unknown> = {}) => ({
+  id,
+  gist: `2026-07-01 10:00 · 2 turns — opens: "${id}"`,
+  ...over,
+});
+
+const updates = (c: Captured) => c.queries.filter((q) => q.sql.includes('UPDATE $id'));
+const selects = (c: Captured) => c.queries.filter((q) => q.sql.startsWith('SELECT'));
+
+describe('SceneGistEmbeddingService — the flag-off pin', () => {
+  afterAll(restore);
+
+  it('flag off ⇒ NO query, NO embed call, NO version resolve, all-zero result', async () => {
+    delete process.env.SCENES_GIST_EMBEDDING;
+    const d = throwingDoubles();
+    const svc = new SceneGistEmbeddingService(d.surreal, d.embedding, d.versions);
+    await expect(svc.run('co_test')).resolves.toEqual({
+      scenes: 0,
+      embedded: 0,
+      skipped: 0,
+      failed: 0,
+    });
+  });
+});
+
+describe('SceneGistEmbeddingService — selection, batching and the write', () => {
+  beforeAll(() => {
+    process.env.SCENES_GIST_EMBEDDING = '1';
+    delete process.env.EMBEDDING_SPACE_TRACKING;
+  });
+  afterAll(restore);
+
+  it('selects only vector-less scenes of the current world, bounded and ordered', async () => {
+    const { svc, captured } = build({ rows: [scene('memory_episode:s1')] });
+    await svc.run('co_test');
+    const select = selects(captured)[0]!;
+    expect(select.sql).toContain('FROM memory_episode');
+    expect(select.sql).toContain('segmenterVersion = $v');
+    // The idempotency fence: a scene that already carries a vector is
+    // never re-embedded here (moving vectors between spaces is the
+    // reindex sweep's job, not this pass's).
+    expect(select.sql).toContain('gistEmbedding IS NONE');
+    expect(select.sql).toContain('ORDER BY id');
+    expect(select.sql).toContain('LIMIT $cap');
+    // No conversation narrowing unless the caller asked for one.
+    expect(select.sql).not.toContain('conversationIds');
+    expect(select.params).toEqual({ v: SEGMENTER_VERSION, cap: SCENE_EMBED_MAX_PER_RUN });
+  });
+
+  it('narrows to one conversation when asked', async () => {
+    const { svc, captured } = build({ rows: [] });
+    await svc.run('co_test', { conversationId: 'proj:c1' });
+    const select = selects(captured)[0]!;
+    expect(select.sql).toContain('AND conversationIds CONTAINS $conv');
+    expect(select.params).toMatchObject({ conv: 'proj:c1' });
+  });
+
+  it('embeds the CANONICAL gist — never the enricher’s enrichedGist sibling', async () => {
+    // BOTH GIST KINDS through one seam: an ENRICHED scene still has its
+    // immutable `gist` encoded, which is exactly the text the 0106 BM25
+    // index covers and the text the reindex sweep re-embeds.
+    const { svc, captured } = build({
+      rows: [
+        scene('memory_episode:plain'),
+        {
+          id: 'memory_episode:enriched',
+          gist: 'deterministic render',
+          enrichedGist: 'an abstractive summary the model wrote',
+        },
+      ],
+    });
+    const result = await svc.run('co_test');
+    expect(result).toEqual({ scenes: 2, embedded: 2, skipped: 0, failed: 0 });
+    // ONE batch for the whole run, not one call per scene.
+    expect(captured.batches).toHaveLength(1);
+    expect(captured.batches[0]).toEqual([
+      '2026-07-01 10:00 · 2 turns — opens: "memory_episode:plain"',
+      'deterministic render',
+    ]);
+    expect(captured.batches[0]!.join(' ')).not.toContain('abstractive');
+  });
+
+  it('writes each vector by BOUND ID, with no space column while tracking is off', async () => {
+    const { svc, captured } = build({ rows: [scene('memory_episode:s1')] });
+    await svc.run('co_test');
+    const [update] = updates(captured);
+    expect(update!.sql).toBe('UPDATE $id SET gistEmbedding = $embedding');
+    // Primary-key addressed — never a WHERE over an indexed field.
+    expect(update!.sql).not.toContain('WHERE');
+    expect(update!.params).toEqual({ id: 'memory_episode:s1', embedding: [1, 0, 0] });
+    expect(update!.params).not.toHaveProperty('space');
+  });
+
+  it('a blank gist is skipped — never embedded, never written', async () => {
+    const { svc, captured } = build({
+      rows: [scene('memory_episode:ok'), { id: 'memory_episode:blank', gist: '   ' }],
+    });
+    const result = await svc.run('co_test');
+    expect(result).toEqual({ scenes: 2, embedded: 1, skipped: 1, failed: 0 });
+    expect(captured.batches[0]).toHaveLength(1);
+    expect(updates(captured)).toHaveLength(1);
+  });
+
+  it('nothing to do ⇒ no batch and no write', async () => {
+    const { svc, captured } = build({ rows: [] });
+    const result = await svc.run('co_test');
+    expect(result).toEqual({ scenes: 0, embedded: 0, skipped: 0, failed: 0 });
+    expect(captured.batches).toEqual([]);
+    expect(updates(captured)).toEqual([]);
+  });
+});
+
+describe('SceneGistEmbeddingService — the space stamp (the fact-side convention)', () => {
+  afterAll(restore);
+
+  it('EMBEDDING_SPACE_TRACKING on ⇒ vector and space id are written TOGETHER', async () => {
+    process.env.SCENES_GIST_EMBEDDING = '1';
+    process.env.EMBEDDING_SPACE_TRACKING = '1';
+    const { svc, captured } = build({ rows: [scene('memory_episode:s1')] });
+    await svc.run('co_test');
+    const [update] = updates(captured);
+    // Verbatim the reindex engine's writeVector clause, with this table's
+    // vector column — so a space migration treats scenes like every other
+    // embedded surface.
+    expect(update!.sql).toBe(
+      'UPDATE $id SET gistEmbedding = $embedding, embeddingSpaceId = $space',
+    );
+    expect(update!.params).toMatchObject({ space: SPACE_ID });
+  });
+
+  it('tracking off ⇒ the space is never even resolved', async () => {
+    process.env.SCENES_GIST_EMBEDDING = '1';
+    delete process.env.EMBEDDING_SPACE_TRACKING;
+    const { captured } = build({ rows: [scene('memory_episode:s1')] });
+    const surreal = {
+      withCompany: async (_c: string, fn: (d: unknown) => Promise<unknown>) =>
+        fn({
+          query: async (sql: string, params?: Record<string, unknown>) => {
+            captured.queries.push({ sql, params });
+            return [sql.includes('UPDATE') ? [] : [scene('memory_episode:s1')]];
+          },
+        }),
+    } as unknown as SurrealService;
+    const embedding = {
+      embedMany: async (t: string[]) => t.map(() => [1, 0, 0]),
+      activeSpaceId: () => {
+        throw new Error('activeSpaceId must not be called with tracking off');
+      },
+    } as unknown as FactEmbeddingService;
+    const versions = {
+      resolve: () => ({
+        version: SEGMENTER_VERSION,
+        cfg: { topicBoundary: false, minCosine: 0.55, maxTurns: 40, embeddingSpaceId: null },
+      }),
+    } as unknown as SceneVersionService;
+    await expect(
+      new SceneGistEmbeddingService(surreal, embedding, versions).run('co_test'),
+    ).resolves.toMatchObject({ embedded: 1 });
+  });
+});
+
+describe('SceneGistEmbeddingService — degrade, never fail', () => {
+  beforeAll(() => {
+    process.env.SCENES_GIST_EMBEDDING = '1';
+    delete process.env.EMBEDDING_SPACE_TRACKING;
+  });
+  afterAll(restore);
+
+  it('an embed-batch failure soft-fails the run: warn, count, no write, no throw', async () => {
+    const { svc, captured } = build({
+      rows: [scene('memory_episode:a'), scene('memory_episode:b')],
+      failEmbed: true,
+    });
+    const warn = jest
+      .spyOn((svc as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn')
+      .mockImplementation(() => undefined);
+    const result = await svc.run('co_test');
+    expect(result).toEqual({ scenes: 2, embedded: 0, skipped: 0, failed: 2 });
+    expect(updates(captured)).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('embed batch failed'));
+  });
+
+  it('a per-row write failure is counted, not thrown', async () => {
+    const { svc, captured } = build({ rows: [scene('memory_episode:a')], failWrite: true });
+    jest
+      .spyOn((svc as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn')
+      .mockImplementation(() => undefined);
+    const result = await svc.run('co_test');
+    expect(result).toEqual({ scenes: 1, embedded: 0, skipped: 0, failed: 1 });
+    expect(updates(captured)).toHaveLength(1);
+  });
+});
+
+describe('SceneComposerService — the post-swap encoder hook', () => {
+  afterAll(restore);
+
+  /** Composer wired against no-op collaborators; only the hook matters. */
+  function composerWith(encoder: SceneGistEmbeddingService): SceneComposerService {
+    const surreal = {
+      withCompany: async (_c: string, fn: (d: unknown) => Promise<unknown>) =>
+        fn({ query: async () => [[]] }),
+    } as unknown as SurrealService;
+    return new SceneComposerService(
+      surreal,
+      { embedMany: async () => [] } as unknown as FactEmbeddingService,
+      { conversationCounts: async () => [] } as unknown as EpisodeReadStoreService,
+      {
+        begin: async () => undefined,
+        complete: async () => undefined,
+        fail: async () => undefined,
+        markResidual: async () => undefined,
+      } as unknown as ProjectionRegistryService,
+      {} as unknown as SceneEnricherService,
+      {} as unknown as SceneBacklinkService,
+      {} as unknown as SceneEvidenceLinkerService,
+      {
+        resolve: () => ({
+          version: SEGMENTER_VERSION,
+          cfg: { topicBoundary: false, minCosine: 0.55, maxTurns: 40, embeddingSpaceId: null },
+        }),
+      } as unknown as SceneVersionService,
+      encoder,
+    );
+  }
+
+  it('SCENES_GIST_EMBEDDING off ⇒ the encoder is NEVER called and no field is added', async () => {
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    delete process.env.SCENES_GIST_EMBEDDING;
+    const throwing = {
+      run: async () => {
+        throw new Error('the encoder must not run with SCENES_GIST_EMBEDDING off');
+      },
+    } as unknown as SceneGistEmbeddingService;
+    const result = await composerWith(throwing).run('co_test');
+    expect(result.gistEmbedded).toBeUndefined();
+  });
+
+  it('flag on ⇒ the encoder runs after the swap and its count is surfaced', async () => {
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    process.env.SCENES_GIST_EMBEDDING = '1';
+    const encoder = {
+      run: async () => ({ scenes: 3, embedded: 3, skipped: 0, failed: 0 }),
+    } as unknown as SceneGistEmbeddingService;
+    const result = await composerWith(encoder).run('co_test');
+    expect(result.gistEmbedded).toBe(3);
+  });
+});

--- a/test/scene-lane.unit-spec.ts
+++ b/test/scene-lane.unit-spec.ts
@@ -17,9 +17,13 @@
  *    notable-details clause from unexpectedDetails, occurredFrom
  *    ascending, 600-char gist cap, TOP_K = 2, byId = the rendered set;
  *  - degrade: a query failure degrades the lane to empty, never a throw;
+ *  - the DENSE leg (PR3): fuses with BM25 by RRF when the 0106 gist
+ *    vectors exist, and degrades to today's BM25-only ordering when they
+ *    do not — both pinned;
  *  - collector gating: profile.sceneLane off ⇒ the lane is NEVER called
  *    (pinned with a throwing stub) and the prompt is byte-identical.
  */
+import type { EmbedderService } from '../src/ai/embedder.service';
 import { SceneLaneService } from '../src/synthesize/scene-lane.service';
 import { EvidenceCollectorService } from '../src/synthesize/evidence-collector.service';
 import { buildGeneratorUserMessage } from '../src/synthesize/generator-prompt';
@@ -304,6 +308,117 @@ describe('SceneLaneService — render + degrade', () => {
     const out = await new SceneLaneService(surreal).sceneLines(baseOpts);
     expect(out.lines).toEqual([]);
     expect(out.byId.size).toBe(0);
+  });
+});
+
+/**
+ * The dense leg (Brain v2 PR3) — the read side of the 0106
+ * `gistEmbedding` column, whose producer (SCENES_GIST_EMBEDDING) landed
+ * with it. The leg needs NO switch of its own: it is an internal recall
+ * improvement inside a lane already gated by profile.sceneLane, and a
+ * world without vectors cannot tell the difference.
+ */
+describe('SceneLaneService — the dense leg (0106 gistEmbedding)', () => {
+  /**
+   * Surreal double that answers the dense probe and the BM25 probe
+   * SEPARATELY, so the fusion can actually be observed.
+   */
+  function twoLegSurreal(opts: { dense?: SceneRowFixture[]; bm25?: SceneRowFixture[] }) {
+    const calls: RecordedCall[] = [];
+    const db = {
+      query: async (sql: string, params?: Record<string, unknown>) => {
+        calls.push({ sql, params });
+        if (sql.includes('FROM projection')) return [[WORLD]];
+        if (sql.includes('gistEmbedding != NONE')) return [opts.dense ?? []];
+        if (sql.includes('FROM memory_episode')) return [opts.bm25 ?? []];
+        return [[]];
+      },
+    };
+    const surreal = {
+      withCompany: async (_companyId: string, fn: (d: typeof db) => Promise<unknown>) => fn(db),
+    } as unknown as SurrealService;
+    return { surreal, calls };
+  }
+
+  const embedder = (over: Partial<{ fail: boolean }> = {}) =>
+    ({
+      embed: async () => {
+        if (over.fail) throw new Error('embedder down');
+        return [0.1, 0.2, 0.3];
+      },
+    }) as unknown as EmbedderService;
+
+  const denseQueries = (calls: RecordedCall[]) =>
+    calls.filter((c) => c.sql.includes('gistEmbedding != NONE'));
+
+  it('fuses the dense leg with BM25 when vectors exist', async () => {
+    // BM25 only finds `b`; the dense leg surfaces `a`, which no query
+    // term matches lexically. Fusion must render BOTH.
+    const { surreal, calls } = twoLegSurreal({
+      dense: [row({ id: 'memory_episode:a', occurredFrom: '2026-07-01T10:00:00.000Z' })],
+      bm25: [row({ id: 'memory_episode:b', occurredFrom: '2026-07-02T10:00:00.000Z' })],
+    });
+    const out = await new SceneLaneService(surreal, embedder()).sceneLines(baseOpts);
+    expect(denseQueries(calls)).toHaveLength(1);
+    expect(out.lines).toHaveLength(2);
+    expect([...out.byId.keys()].sort()).toEqual(['memory_episode:a', 'memory_episode:b']);
+  });
+
+  it('the dense leg carries the SAME fence stack as the lexical one', async () => {
+    const { surreal, calls } = twoLegSurreal({ dense: [row({})] });
+    await new SceneLaneService(surreal, embedder()).sceneLines(baseOpts);
+    const dense = denseQueries(calls)[0]!;
+    // A dense leg must never be a way around a gate the BM25 leg applies.
+    expect(dense.sql).toContain('segmenterVersion = $world');
+    expect(dense.sql).toContain('AND piiClass IS NONE');
+    expect(dense.sql).toContain('userId = $scopeUserId');
+    expect(dense.sql).toContain('userIds IS NOT NONE');
+    expect(dense.sql).toContain('vector::similarity::cosine(gistEmbedding, $q)');
+    expect(dense.params).toMatchObject({ scopeUserId: 'u1', world: WORLD });
+  });
+
+  it('a VECTOR-LESS world degrades to exactly today’s BM25 ordering', async () => {
+    const bm25 = [
+      row({ id: 'memory_episode:c', occurredFrom: '2026-07-03T10:00:00.000Z', score: 3 }),
+      row({ id: 'memory_episode:a', occurredFrom: '2026-07-01T10:00:00.000Z', score: 2 }),
+      row({ id: 'memory_episode:b', occurredFrom: '2026-07-02T10:00:00.000Z', score: 1 }),
+    ];
+    // With vectors: none (the composer never wrote any — the default
+    // world). The dense probe returns [], so RRF is a no-op over BM25.
+    const withEmbedder = twoLegSurreal({ dense: [], bm25 });
+    const fused = await new SceneLaneService(withEmbedder.surreal, embedder()).sceneLines(baseOpts);
+    // No embedder wired at all — the pre-PR3 lane, byte for byte.
+    const noEmbedder = twoLegSurreal({ bm25 });
+    const lexOnly = await new SceneLaneService(noEmbedder.surreal).sceneLines(baseOpts);
+    expect(fused.lines).toEqual(lexOnly.lines);
+    // And it IS the BM25 top-2 (c, a), rendered oldest-first.
+    expect(fused.lines).toHaveLength(2);
+    expect(fused.lines[0]).toContain('[memory_episode:a]');
+    expect(fused.lines[1]).toContain('[memory_episode:c]');
+    // Unwired ⇒ the dense probe is never issued at all.
+    expect(denseQueries(noEmbedder.calls)).toEqual([]);
+  });
+
+  it('an embedder failure kills the dense leg, never the lane', async () => {
+    const { surreal, calls } = twoLegSurreal({ bm25: [row({})] });
+    const lane = new SceneLaneService(surreal, embedder({ fail: true }));
+    jest
+      .spyOn((lane as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn')
+      .mockImplementation(() => undefined);
+    const out = await lane.sceneLines(baseOpts);
+    expect(denseQueries(calls)).toEqual([]);
+    expect(out.lines).toHaveLength(1);
+  });
+
+  it('NO live world ⇒ not even the query embedding is computed', async () => {
+    const { surreal } = surrealOf({ rows: [row({})], live: [] });
+    const throwingEmbedder = {
+      embed: async () => {
+        throw new Error('the query must not be embedded without a live scene world');
+      },
+    } as unknown as EmbedderService;
+    const out = await new SceneLaneService(surreal, throwingEmbedder).sceneLines(baseOpts);
+    expect(out.lines).toEqual([]);
   });
 });
 

--- a/test/scene-serving.e2e-spec.ts
+++ b/test/scene-serving.e2e-spec.ts
@@ -80,6 +80,10 @@ describe('Scene serving lane e2e (the episodic plane’s first read)', () => {
       'INGEST_EPISODE_ONLY',
       'SCENES_SEGMENTATION_ENABLED',
       'SCENES_TOPIC_BOUNDARY',
+      // PR3: the dense leg's producer. Starts OFF, so every `it` above
+      // this one serves the BM25-ONLY world — which is exactly the
+      // degradation contract the dense leg must preserve.
+      'SCENES_GIST_EMBEDDING',
       'RETRIEVAL_ABSTENTION_CALIBRATION',
     ]) {
       saved[k] = process.env[k];
@@ -269,6 +273,59 @@ describe('Scene serving lane e2e (the episodic plane’s first read)', () => {
     expect(state.calls[0]!.user).not.toContain('Episodic record');
     expect(state.calls[0]!.user).not.toContain('[memory_episode:');
     delete process.env.RETRIEVAL_SCENE_LANE;
+  });
+
+  /**
+   * PR3 — the DENSE leg. Every `it` above served this world BM25-only,
+   * because `gistEmbedding` had no producer and the dense probe's
+   * `!= NONE` filter returned nothing: that IS the degradation contract.
+   * Here the producer fills the column and the fused lane must still
+   * return the scene, now on two legs.
+   */
+  it('dense leg: with gist vectors present the lane still serves the scene (RRF fusion)', async () => {
+    const vectorless = await db(async (d) => {
+      const [rows] = await d.query<[Array<{ gistEmbedding?: number[] }>]>(
+        `SELECT gistEmbedding FROM memory_episode`,
+      );
+      return rows ?? [];
+    });
+    // The world every earlier assertion in this suite ran against.
+    expect(vectorless.every((r) => r.gistEmbedding === undefined)).toBe(true);
+
+    process.env.SCENES_GIST_EMBEDDING = '1';
+    const embed = await f.http
+      .post('/v1/admin/maintenance/scenes/embed-gists')
+      .set(auth())
+      .send({});
+    expect(embed.status).toBe(201);
+    expect(embed.body).toMatchObject({ embedded: 1, failed: 0 });
+    const vectored = await db(async (d) => {
+      const [rows] = await d.query<[Array<{ gistEmbedding?: number[] }>]>(
+        `SELECT gistEmbedding FROM memory_episode`,
+      );
+      return rows ?? [];
+    });
+    expect(vectored[0]!.gistEmbedding!.length).toBeGreaterThan(0);
+
+    process.env.RETRIEVAL_SCENE_LANE = '1';
+    const state = mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({
+        answer: `The signed lease scan arrived and was filed [${factId}] [${sceneId}].`,
+        citedFactIds: [factId],
+        citedSceneIds: [sceneId],
+      }),
+      VERIFY_SUPPORTED,
+    ]);
+    const res = await synth({ query: QUERY, userId: USER });
+    expect(res.status).toBe(201);
+    // Same line, same citation — the dense leg widened recall without
+    // changing the render contract, and every fence still holds.
+    expect(state.calls[0]!.user).toContain(`[${sceneId}]`);
+    expect(state.calls[0]!.user).toContain(sceneGist);
+    expect(res.body.evidenceCitations).toHaveLength(1);
+    expect(res.body.evidenceCitations[0]).toMatchObject({ sceneId, excerpt: sceneGist });
+    delete process.env.RETRIEVAL_SCENE_LANE;
+    delete process.env.SCENES_GIST_EMBEDDING;
   });
 
   it('an UNPROMOTED world does not serve — demote the registry row and the lane goes empty', async () => {

--- a/test/segment-user-fence.unit-spec.ts
+++ b/test/segment-user-fence.unit-spec.ts
@@ -13,6 +13,7 @@ import type { ProjectionRegistryService } from '../src/episodes/projection-regis
 import type { SceneEnricherService } from '../src/admin/scene-enricher.service';
 import type { SceneBacklinkService } from '../src/admin/scene-backlink.service';
 import type { SceneEvidenceLinkerService } from '../src/admin/scene-evidence-linker.service';
+import type { SceneGistEmbeddingService } from '../src/admin/scene-gist-embedding.service';
 import type { SceneVersionService } from '../src/admin/scene-version';
 
 /**
@@ -338,6 +339,13 @@ describe('scene composer persists fold.userIds (0117 write side)', () => {
           cfg: { topicBoundary: false, minCosine: 0.55, maxTurns: 40, embeddingSpaceId: null },
         }),
       } as unknown as SceneVersionService,
+      // SCENES_GIST_EMBEDDING is off in this spec, so the post-swap
+      // encoder pass must never be reached — pin it with a thrower.
+      {
+        run: async () => {
+          throw new Error('the gist encoder must not run with SCENES_GIST_EMBEDDING off');
+        },
+      } as unknown as SceneGistEmbeddingService,
     );
     await svc.run('co_x');
     const swap = queries.find((q) => q.sql.includes('INSERT INTO memory_episode'));


### PR DESCRIPTION
Fills the two never-written columns of the 0106 scene plane. Both legs are default-off and byte-identical when off; no migration (0106 declares both columns).

## 1. `gistEmbedding` — the producer that never landed

0106 defined the column, `scene-composer.service.ts` promised "the PR2 encoder pass backfills it", and PR2 shipped without one. Both downstream consumers were built around the hole: the reindex sweep registers `memory_episode`/`gistEmbedding` but runs `WHERE gistEmbedding != NONE` (it *moves* vectors between spaces, it never creates them), and the scene serving lane shipped BM25-only because "a dense leg would be write-dead for the default world".

**`SceneGistEmbeddingService`** (`SCENES_GIST_EMBEDDING`, default off) is that producer:

- runs as the **first post-swap pass** in the composer chain, and standalone via `POST /v1/admin/maintenance/scenes/embed-gists` (the backfill verb for worlds composed before the flag was on);
- selects only scenes of the **current effective world** carrying **no vector**, capped at 200 per run, **one `embedMany` batch**. Idempotent by construction: a re-run after a complete pass selects nothing. Re-embedding *existing* vectors into a new space stays the reindex sweep's job;
- writes by **primary-key-addressed UPDATE** (immune to the 3.2.4 secondary-index planner bug by construction), plus `embeddingSpaceId` **only under `EMBEDDING_SPACE_TRACKING`** — verbatim the fact-side `ReindexEngineService.spaceStampId`/`writeVector` convention, so space migration treats scenes like every other embedded surface;
- **soft-fails**: an embed-batch or row-write failure warns and counts, and never retracts the swap that spawned it.

### Which seam, and why it covers both gist kinds

The PR brief offered the enricher's UPDATE or a composer-side pass. Reading the code settles it: **the enricher never touches `gist`.** It writes the abstractive revision to the sibling `enrichedGist` (Drift-3b — `gist` is immutable post-compose), and `enrichedGist` has **no readers at all** today. So `gist` is the one canonical gist TEXT column — the column the 0106 `scene_gist_search` BM25 index covers, the column the lane renders, and the column `ReindexEngineService.ADDITIONAL_TABLE_SPECS` **already declares** as this table's embed source.

Embedding anything else would put the dense leg out of step with the lexical one *and* be silently overwritten by the first space-migration sweep. So the composer-side pass covers deterministic **and** LLM-enriched worlds through one seam; the enricher's UPDATE would cover **neither**.

### The lane's dense leg

`SceneLaneService` gains a cosine leg over `gistEmbedding`, fused with the existing `or_terms` BM25 leg by `rrfFuse` (the house fusion), under the **same fence stack** — a dense leg must never be a way around a gate the lexical leg applies.

**Flag decision: reuse `RETRIEVAL_SCENE_LANE` / `profile.sceneLane`, no new read flag.** The dense query filters `gistEmbedding != NONE`, so a vector-less world returns an empty dense list and `rrfFuse([[], bm25])` reproduces the BM25 ordering *exactly*. Same when no embedder is wired (`@Optional`) or the query embed fails. Degradation is the default path, not a fallback, so the leg is strictly an internal recall improvement inside a lane that is already default-off — pinned by a test asserting the fused lines equal the unwired lane's lines. The query is embedded **after** the live-world check, so a fail-closed read still issues nothing at all.

## 2. `entityIds` — resolve-only, never mint

The enricher has parsed `entityMentions` since PR2 and thrown them away on purpose: the column promises `record<knowledge_entity>` refs, and raw strings would poison that contract.

**`SCENES_ENTITY_LINKS`** (default off) resolves them through the platform's own machinery. New **resolve-only reader** `EntityUpsertService.resolveExistingByName` runs the same ladder as the naming path — exact `canonicalNameLc`/`aliases`, then `INGEST_ARTICLE_NORMALIZATION` variants, then the `INGEST_CODE_ALIAS_RESOLUTION` path↔symbol convention (riding those same flags) — with **minting, alias stamping, merge-log audit and the probabilistic embedding+judge resolver all removed**. It lives on `EntityUpsertService` so the corpus's naming conventions have exactly one interpreter; the existing minting path is untouched (byte-identical ingest).

Rules, as required:

- **never mint.** A scene is a reconstruction of already-ingested turns, so any entity it legitimately names already exists. Unresolved → dropped. **Ambiguous → dropped too** (unique matches only at *every* step, including the exact one where the minting path takes `LIMIT 1` because it must return *some* id). `mergedInto IS NONE` excludes merged-away identities. No alias is stamped on the entity a backlink points at.
- **fences.** The #387 single-user rule decides scope: a single-user scene resolves against tenant-global entities **plus its own user's**; a mixed-user / tenant-global / legacy (pre-0117) scene resolves against **tenant-global only**. The 0093 `scopeFenceSql` ANDs alongside. A foreign user's entity can never land on a scene.
- **capped** at 12 mentions per scene (`SCENE_ENTITY_LINKS_MAX`), so resolution cost stays an order of magnitude under the one LLM call that produced the mentions.
- **idempotent.** The de-duplicated, **sorted** set fully replaces the column, so a re-run over an unchanged corpus writes a byte-identical value. An empty result writes `[]` — "we looked and found nothing" is stable in a way an absent column is not.
- **degrades**: one mention's failure warns and drops that mention; the enrichment write still lands.

### `relationIds` got NO producer — deliberately

There is none to write honestly. The enrichment schema returns **mentions and stateDeltas**, neither of which is a typed entity→entity edge, and nothing else in the scene pipeline produces `knowledge_edge` rows. Cross-producting the resolved entities into edges that already exist would assert *"this scene is evidence for that relation"* on evidence the scene never gave. A column left NONE says "no producer"; a column filled by inference says something false. The honest producer is a relation-extraction pass that does not exist yet. The column is left alone and the reasoning is recorded in the enricher header, the flag doc and the config catalogue.

## Default-off discipline

Both flags off ⇒ **no embed call, no resolution query, identical rows and identical SQL**. Pinned, not asserted:

- the encoder's off-path uses **throwing** Surreal/embedder/version doubles — any touch fails the test;
- the composer's post-swap hook is pinned with a **throwing encoder stub**;
- the enricher's off-path uses a **throwing resolver stub**, and the byte-identical scene `SELECT` projection and `UPDATE` statement are asserted verbatim (both optional clauses are *appended*, in flag order).

## Tests

- `test/scene-gist-embedding.unit-spec.ts` (13) — flag-off pin; selection/idempotency fence; conversation narrowing; **both gist kinds** (an enriched scene still embeds `gist`, never `enrichedGist`); one batch per run; bound-id UPDATE with no `WHERE`; the space stamp under `EMBEDDING_SPACE_TRACKING` and never resolved when off; blank gist skipped; embed-batch and per-row soft-fail; the composer hook both ways.
- `test/scene-entity-links.unit-spec.ts` (25) — pure selection/stability; the full resolver matrix (exact hit, no hit, **ambiguity links nothing**, blank never queries, unscoped = tenant-global only, scoped adds its own user, 0093 fence, article and code-alias legs only under their flags, **never writes**, never throws); and the enricher leg (flag-off byte-identical, record refs written, unresolved dropped, empty set still written, idempotent re-run, cap honoured, the #387 scope matrix, unwired/failing resolver degrade).
- `test/scene-lane.unit-spec.ts` — dense leg fuses when vectors exist; **degrades to exactly the unwired lane's lines** when they do not; same fence stack on both legs; embedder failure kills the leg not the lane; no live world ⇒ the query is not even embedded.
- E2E — `scene-enrichment.e2e-spec.ts` gains the 404 gate, vector-on-both-gist-kinds, idempotent re-run, and the entity matrix including a **foreign-user `Lisbon` that must not link** plus a `knowledge_entity` count proving nothing was minted; `scene-serving.e2e-spec.ts` gains a dense-leg pin (every earlier `it` in that file already runs the BM25-only world).

## Gates

`pnpm typecheck` ✅ · unit suite **377 suites / 4467 tests** ✅ · `pnpm lint:ci` ✅ · `pnpm format:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
